### PR TITLE
Add policy validation smoke coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc -b packages/runtime-core packages/runtime-playground",
     "hello-runtime": "tsx scripts/hello-runtime.ts",
-    "check": "npm run build && npm run hello-runtime -- ./examples/simple-plugin"
+    "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
+    "check": "npm run build && npm run policy-validation-smoke && npm run hello-runtime -- ./examples/simple-plugin"
   },
   "workspaces": [
     "packages/*"

--- a/scripts/policy-validation-smoke.ts
+++ b/scripts/policy-validation-smoke.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict"
+import {
+  RuntimeCommandPolicyViolationError,
+  RuntimePolicyValidationError,
+  assertRuntimeCommandAllowed,
+  assertRuntimePolicy,
+  validateRuntimePolicy,
+  type RuntimePolicy,
+} from "@chubes4/sandbox-runtime-core"
+
+const policy: RuntimePolicy = {
+  network: "deny",
+  filesystem: "readwrite-mounts",
+  commands: ["inspect-mounted-inputs"],
+  secrets: "none",
+  approvals: "never",
+}
+
+assert.deepEqual(validateRuntimePolicy(policy), { valid: true, issues: [] })
+assert.doesNotThrow(() => assertRuntimePolicy(policy))
+assert.doesNotThrow(() => assertRuntimeCommandAllowed("inspect-mounted-inputs", policy))
+
+assert.throws(
+  () => assertRuntimePolicy({ ...policy, commands: [""] }),
+  (error) => {
+    assert.ok(error instanceof RuntimePolicyValidationError)
+    assert.equal(error.code, "runtime-policy-invalid")
+    assert.deepEqual(error.toJSON(), {
+      code: "runtime-policy-invalid",
+      issues: [
+        {
+          code: "invalid-command",
+          field: "commands",
+          message: "commands must be a list of non-empty command names",
+        },
+      ],
+      message: "Runtime policy is invalid: commands must be a list of non-empty command names",
+      name: "RuntimePolicyValidationError",
+    })
+    return true
+  },
+)
+
+assert.throws(
+  () => assertRuntimeCommandAllowed("write-production", policy),
+  (error) => {
+    assert.ok(error instanceof RuntimeCommandPolicyViolationError)
+    assert.deepEqual(error.toJSON(), {
+      code: "runtime-command-disallowed",
+      command: "write-production",
+      allowedCommands: ["inspect-mounted-inputs"],
+      policy,
+      message: "Command is not allowed by runtime policy: write-production",
+      name: "RuntimeCommandPolicyViolationError",
+    })
+    return true
+  },
+)
+
+console.log("Policy validation smoke passed")


### PR DESCRIPTION
## Summary
- Adds a policy validation smoke script that verifies valid v0 policy handling, invalid policy validation errors, and disallowed command error serialization.
- Wires the smoke script into `npm run check` so structured policy error payloads stay artifact-friendly.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the smoke coverage, ran validation, and opened the PR; Chris remains responsible for review and merge.