### PR TITLE
Add WordPress run-php command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ npm run build
 npm run sandbox-runtime -- run \
   --backend wordpress-playground \
   --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin \
-  --command inspect-mounted-inputs \
+  --command wordpress.run-php \
+  --arg code-file=./examples/simple-plugin/probe.php \
   --artifacts ./artifacts \
   --json
 ```
@@ -47,7 +48,7 @@ Expected output:
     "status": "destroyed"
   },
   "execution": {
-    "command": "inspect-mounted-inputs",
+    "command": "wordpress.run-php",
     "exitCode": 0
   },
   "artifacts": {
@@ -60,7 +61,9 @@ Expected output:
 }
 ```
 
-The Playground backend mounts the local plugin directory into WordPress Playground and boots lazily on the first `execute()` call. The CLI command runs a controlled PHP probe through `server.playground.run()`, collects artifacts, and disposes the Playground server when the runtime is destroyed. Machine-readable JSON gives consumers such as Data Machine Code, Homeboy Extensions, Studio, and CI runners a stable integration seam.
+The Playground backend mounts the local plugin directory into WordPress Playground and boots lazily on the first `execute()` call. The CLI command runs PHP from `--arg code-file=...` through `server.playground.run()`, collects artifacts, and disposes the Playground server when the runtime is destroyed. Machine-readable JSON gives consumers such as Data Machine Code, Homeboy Extensions, Studio, and CI runners a stable integration seam.
+
+`wordpress.run-php` accepts either `--arg code-file=<path>` or `--arg code=<php>`.
 
 The fixture plugin is documented in [`examples/simple-plugin/README.md`](examples/simple-plugin/README.md).
 
@@ -72,7 +75,7 @@ The fixture plugin is documented in [`examples/simple-plugin/README.md`](example
 const result = validateRuntimePolicy({
   network: "deny",
   filesystem: "readwrite-mounts",
-  commands: ["inspect-mounted-inputs"],
+  commands: ["wordpress.run-php"],
   secrets: "none",
   approvals: "never",
 })

--- a/examples/simple-plugin/README.md
+++ b/examples/simple-plugin/README.md
@@ -1,6 +1,6 @@
 # Simple Plugin Fixture
 
-Tiny WordPress plugin fixture for `npm run hello-runtime`.
+Tiny WordPress plugin fixture for `sandbox-runtime run`.
 
 The demo mounts this directory into a disposable WordPress Playground-shaped runtime at:
 
@@ -11,7 +11,13 @@ The demo mounts this directory into a disposable WordPress Playground-shaped run
 Use it to verify the v0 runtime contract:
 
 ```bash
-npm run hello-runtime -- ./examples/simple-plugin
+npm run sandbox-runtime -- run \
+  --backend wordpress-playground \
+  --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin \
+  --command wordpress.run-php \
+  --arg code-file=./examples/simple-plugin/probe.php \
+  --artifacts ./artifacts \
+  --json
 ```
 
-The current backend is a foundation stub. It records mounts, command output, logs, and observations in an artifact bundle so product surfaces can link users to the evidence they would review before applying sandboxed work.
+The current backend records mounts, command output, logs, and observations in an artifact bundle so product surfaces can link users to the evidence they would review before applying sandboxed work.

--- a/examples/simple-plugin/probe.php
+++ b/examples/simple-plugin/probe.php
@@ -1,0 +1,9 @@
+<?php
+echo json_encode(
+    array(
+        'command' => 'wordpress.run-php',
+        'plugin_file_exists' => file_exists('/wordpress/wp-content/plugins/simple-plugin/simple-plugin.php'),
+        'plugin_readme_exists' => file_exists('/wordpress/wp-content/plugins/simple-plugin/README.md'),
+    ),
+    JSON_PRETTY_PRINT
+);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -b packages/runtime-core packages/runtime-playground packages/cli",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "sandbox-runtime": "node packages/cli/dist/index.js",
-    "check": "npm run build && npm run policy-validation-smoke && npm run sandbox-runtime -- run --backend wordpress-playground --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command inspect-mounted-inputs --artifacts ./artifacts --json"
+    "check": "npm run build && npm run policy-validation-smoke && npm run sandbox-runtime -- run --backend wordpress-playground --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises"
-import { basename, resolve } from "node:path"
+import { resolve } from "node:path"
 import { createRuntime, type ArtifactBundle, type ExecutionResult, type RuntimeInfo, type RuntimePolicy } from "@chubes4/sandbox-runtime-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/sandbox-runtime-playground"
 
@@ -8,6 +8,7 @@ interface RunOptions {
   backend: "wordpress-playground"
   mounts: Array<{ source: string; target: string; mode: "readonly" | "readwrite" }>
   command: string
+  args: string[]
   artifactsDirectory?: string
   policy?: RuntimePolicy
   json: boolean
@@ -29,7 +30,7 @@ interface RunOutput {
 const defaultPolicy: RuntimePolicy = {
   network: "deny",
   filesystem: "readwrite-mounts",
-  commands: ["inspect-mounted-inputs"],
+  commands: ["inspect-mounted-inputs", "wordpress.run-php"],
   secrets: "none",
   approvals: "never",
 }
@@ -88,7 +89,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
       await runtime.mount({ type: "directory", source: mount.source, target: mount.target, mode: mount.mode })
     }
 
-    execution = await runtime.execute({ command: options.command })
+    execution = await runtime.execute({ command: options.command, args: options.args })
     await runtime.observe({ type: "runtime-info" })
     await runtime.observe({ type: "mounts" })
     artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true })
@@ -130,6 +131,7 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
     backend: "wordpress-playground",
     mounts: [],
     command: "",
+    args: [],
     json: false,
   }
 
@@ -160,6 +162,9 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
         break
       case "--command":
         options.command = value
+        break
+      case "--arg":
+        options.args.push(value)
         break
       case "--artifacts":
         options.artifactsDirectory = value
@@ -256,12 +261,13 @@ Options:
   --backend <name>     Runtime backend. Currently: wordpress-playground
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
+  --arg <key=value>    Command argument. Repeatable.
   --artifacts <dir>    Artifact root directory.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --json               Emit machine-readable JSON.
 
 Example:
-  sandbox-runtime run --backend wordpress-playground --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command inspect-mounted-inputs --artifacts ./artifacts --json`)
+  sandbox-runtime run --backend wordpress-playground --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`)
 }
 
 main(process.argv.slice(2)).then(

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, realpath, writeFile } from "node:fs/promises"
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
 import { assertRuntimeCommandAllowed } from "@chubes4/sandbox-runtime-core"
 import type {
@@ -297,7 +297,33 @@ class PlaygroundRuntime implements Runtime {
       return this.inspectMountedInputs()
     }
 
+    if (spec.command === "wordpress.run-php") {
+      return this.runPhp(spec)
+    }
+
     throw new Error(`No Playground command handler is registered for: ${spec.command}`)
+  }
+
+  private async runPhp(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const code = await this.phpCodeFromArgs(spec.args ?? [])
+    const response = await server.playground.run({ code })
+
+    return response.text
+  }
+
+  private async phpCodeFromArgs(args: string[]): Promise<string> {
+    const inlineCode = argValue(args, "code")
+    if (inlineCode) {
+      return normalizePhpCode(inlineCode)
+    }
+
+    const codeFile = argValue(args, "code-file")
+    if (codeFile) {
+      return normalizePhpCode(await readFile(resolve(codeFile), "utf8"))
+    }
+
+    throw new Error("wordpress.run-php requires code=<php> or code-file=<path>")
   }
 
   private async inspectMountedInputs(): Promise<string> {
@@ -372,4 +398,14 @@ function fileEntry(path: string, kind: ArtifactManifestFile["kind"], contentType
 
 async function writeJsonLines(path: string, records: unknown[]): Promise<void> {
   await writeFile(path, records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : "")
+}
+
+function argValue(args: string[], name: string): string | undefined {
+  const prefix = `${name}=`
+  const match = args.find((arg) => arg.startsWith(prefix))
+  return match?.slice(prefix.length)
+}
+
+function normalizePhpCode(code: string): string {
+  return code.trimStart().startsWith("<?php") ? code : `<?php\n${code}`
 }


### PR DESCRIPTION
## Summary
- Adds repeatable CLI `--arg key=value` support and forwards args into runtime execution.
- Implements `wordpress.run-php` for the Playground backend with `code-file=<path>` or `code=<php>` inputs.
- Replaces the check/demo path with a mounted plugin PHP probe that runs inside WordPress Playground and emits artifacts.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the command/CLI args, updated docs and fixture coverage, ran validation, and opened the PR; Chris remains responsible for review and merge.