### PR TITLE
Bootstrap WordPress for run-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Expected output:
 
 The Playground backend mounts the local plugin directory into WordPress Playground and boots lazily on the first `execute()` call. The CLI command runs PHP from `--arg code-file=...` through `server.playground.run()`, collects artifacts, and disposes the Playground server when the runtime is destroyed. Machine-readable JSON gives consumers such as Data Machine Code, Homeboy Extensions, Studio, and CI runners a stable integration seam.
 
-`wordpress.run-php` accepts either `--arg code-file=<path>` or `--arg code=<php>`.
+`wordpress.run-php` accepts either `--arg code-file=<path>` or `--arg code=<php>`. It loads `/wordpress/wp-load.php` before running the supplied PHP so WordPress functions are available by default. Use `--arg bootstrap=none` for raw PHP execution without WordPress bootstrap.
 
 The fixture plugin is documented in [`examples/simple-plugin/README.md`](examples/simple-plugin/README.md).
 

--- a/examples/simple-plugin/probe.php
+++ b/examples/simple-plugin/probe.php
@@ -2,6 +2,8 @@
 echo json_encode(
     array(
         'command' => 'wordpress.run-php',
+        'wp_loaded' => function_exists('wp_insert_post'),
+        'home_url' => function_exists('home_url') ? home_url() : null,
         'plugin_file_exists' => file_exists('/wordpress/wp-content/plugins/simple-plugin/simple-plugin.php'),
         'plugin_readme_exists' => file_exists('/wordpress/wp-content/plugins/simple-plugin/README.md'),
     ),

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -307,9 +307,19 @@ class PlaygroundRuntime implements Runtime {
   private async runPhp(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
     const code = await this.phpCodeFromArgs(spec.args ?? [])
-    const response = await server.playground.run({ code })
+    const response = await server.playground.run({ code: this.bootstrapPhpCode(code, spec.args ?? []) })
 
     return response.text
+  }
+
+  private bootstrapPhpCode(code: string, args: string[]): string {
+    if (argValue(args, "bootstrap") === "none") {
+      return code
+    }
+
+    return `<?php
+require_once '/wordpress/wp-load.php';
+${phpBody(code)}`
   }
 
   private async phpCodeFromArgs(args: string[]): Promise<string> {
@@ -408,4 +418,8 @@ function argValue(args: string[], name: string): string | undefined {
 
 function normalizePhpCode(code: string): string {
   return code.trimStart().startsWith("<?php") ? code : `<?php\n${code}`
+}
+
+function phpBody(code: string): string {
+  return code.trimStart().replace(/^<\?php\s*/, "")
 }


### PR DESCRIPTION
## Summary
- Makes `wordpress.run-php` load `/wordpress/wp-load.php` before running supplied PHP by default.
- Adds `--arg bootstrap=none` as an escape hatch for raw PHP execution.
- Updates the fixture probe to verify WordPress functions and mounted plugin files are available.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Probed the runtime behavior, fixed the WordPress bootstrap path, updated fixture/docs, ran validation, and opened the PR; Chris remains responsible for review and merge.