### PR TITLE
Remove backend CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ For WordPress, this means a control plane such as Studio, Data Machine, or WordP
 npm install
 npm run build
 npm run sandbox-runtime -- run \
-  --backend wordpress-playground \
   --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin \
   --command wordpress.run-php \
   --arg code-file=./examples/simple-plugin/probe.php \
@@ -61,7 +60,7 @@ Expected output:
 }
 ```
 
-The Playground backend mounts the local plugin directory into WordPress Playground and boots lazily on the first `execute()` call. The CLI command runs PHP from `--arg code-file=...` through `server.playground.run()`, collects artifacts, and disposes the Playground server when the runtime is destroyed. Machine-readable JSON gives consumers such as Data Machine Code, Homeboy Extensions, Studio, and CI runners a stable integration seam.
+Sandbox Runtime mounts the local plugin directory into WordPress Playground and boots lazily on the first `execute()` call. The CLI command runs PHP from `--arg code-file=...` through `server.playground.run()`, collects artifacts, and disposes the Playground server when the runtime is destroyed. Machine-readable JSON gives consumers such as Data Machine Code, Homeboy Extensions, Studio, and CI runners a stable integration seam.
 
 `wordpress.run-php` accepts either `--arg code-file=<path>` or `--arg code=<php>`. It loads `/wordpress/wp-load.php` before running the supplied PHP so WordPress functions are available by default. Use `--arg bootstrap=none` for raw PHP execution without WordPress bootstrap.
 

--- a/examples/simple-plugin/README.md
+++ b/examples/simple-plugin/README.md
@@ -12,7 +12,6 @@ Use it to verify the v0 runtime contract:
 
 ```bash
 npm run sandbox-runtime -- run \
-  --backend wordpress-playground \
   --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin \
   --command wordpress.run-php \
   --arg code-file=./examples/simple-plugin/probe.php \

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -b packages/runtime-core packages/runtime-playground packages/cli",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "sandbox-runtime": "node packages/cli/dist/index.js",
-    "check": "npm run build && npm run policy-validation-smoke && npm run sandbox-runtime -- run --backend wordpress-playground --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run policy-validation-smoke && npm run sandbox-runtime -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,6 @@ import { createRuntime, type ArtifactBundle, type ExecutionResult, type RuntimeI
 import { createPlaygroundRuntimeBackend } from "@chubes4/sandbox-runtime-playground"
 
 interface RunOptions {
-  backend: "wordpress-playground"
   mounts: Array<{ source: string; target: string; mode: "readonly" | "readwrite" }>
   command: string
   args: string[]
@@ -72,7 +71,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
   try {
     runtime = await createRuntime(
       {
-        backend: options.backend,
+        backend: "wordpress-playground",
         environment: {
           kind: "wordpress",
           name: "sandbox-runtime-cli",
@@ -128,7 +127,6 @@ async function run(options: RunOptions): Promise<RunOutput> {
 
 async function parseRunOptions(args: string[]): Promise<RunOptions> {
   const options: RunOptions = {
-    backend: "wordpress-playground",
     mounts: [],
     command: "",
     args: [],
@@ -151,12 +149,6 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
     }
 
     switch (name) {
-      case "--backend":
-        if (value !== "wordpress-playground") {
-          throw new Error(`Unsupported backend: ${value}`)
-        }
-        options.backend = value
-        break
       case "--mount":
         options.mounts.push(parseMount(value))
         break
@@ -258,7 +250,6 @@ function printHelp(): void {
   sandbox-runtime run --mount <host>:<vfs> --command <id> [options]
 
 Options:
-  --backend <name>     Runtime backend. Currently: wordpress-playground
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
   --arg <key=value>    Command argument. Repeatable.
@@ -267,7 +258,7 @@ Options:
   --json               Emit machine-readable JSON.
 
 Example:
-  sandbox-runtime run --backend wordpress-playground --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`)
+  sandbox-runtime run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`)
 }
 
 main(process.argv.slice(2)).then(


### PR DESCRIPTION
## Summary
- Removes the public `--backend` option from `sandbox-runtime run`.
- Keeps WordPress Playground as the internal runtime while preserving backend metadata in artifacts.
- Updates docs and `npm run check` to use the shorter command shape.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Removed the premature backend selector, updated docs/checks, ran validation, and opened the PR; Chris remains responsible for review and merge.