### PR TITLE
Add agent runtime stack probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Sandbox Runtime mounts the local plugin directory into WordPress Playground and 
 
 `wordpress.run-php` accepts either `--arg code-file=<path>` or `--arg code=<php>`. It loads `/wordpress/wp-load.php` before running the supplied PHP so WordPress functions are available by default. Use `--arg bootstrap=none` for raw PHP execution without WordPress bootstrap.
 
+Use `--wp trunk`, `--wp nightly`, or a numeric WordPress version when a mounted plugin stack requires a version other than Playground's default.
+
 The fixture plugin is documented in [`examples/simple-plugin/README.md`](examples/simple-plugin/README.md).
 
 ## v0 Runtime Policy

--- a/examples/agent-runtime/README.md
+++ b/examples/agent-runtime/README.md
@@ -1,0 +1,24 @@
+# Agent Runtime Stack Probe
+
+This example proves the intended guest application surface: a WordPress Playground sandbox with the agent runtime stack mounted and activated.
+
+Set local checkout paths, then run:
+
+```bash
+AGENTS_API_PATH=/path/to/agents-api \
+DATA_MACHINE_PATH=/path/to/data-machine \
+DATA_MACHINE_CODE_PATH=/path/to/data-machine-code \
+OPENAI_PROVIDER_PATH=/path/to/ai-provider-for-openai \
+npm run sandbox-runtime -- run \
+  --wp trunk \
+  --mount "$AGENTS_API_PATH:/wordpress/wp-content/plugins/agents-api" \
+  --mount "$DATA_MACHINE_PATH:/wordpress/wp-content/plugins/data-machine" \
+  --mount "$DATA_MACHINE_CODE_PATH:/wordpress/wp-content/plugins/data-machine-code" \
+  --mount "$OPENAI_PROVIDER_PATH:/wordpress/wp-content/plugins/ai-provider-for-openai" \
+  --command wordpress.run-php \
+  --arg code-file=./examples/agent-runtime/probe.php \
+  --artifacts ./artifacts \
+  --json
+```
+
+The probe activates the mounted plugins in dependency order and returns a JSON readiness packet. It intentionally does not require provider credentials or model calls.

--- a/examples/agent-runtime/probe.php
+++ b/examples/agent-runtime/probe.php
@@ -1,0 +1,42 @@
+<?php
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+$plugins = array(
+    'agents-api/agents-api.php',
+    'data-machine/data-machine.php',
+    'data-machine-code/data-machine-code.php',
+    'ai-provider-for-openai/plugin.php',
+);
+
+$activation_results = array();
+
+foreach ($plugins as $plugin) {
+    $result = activate_plugin($plugin);
+    $activation_results[$plugin] = array(
+        'active' => is_plugin_active($plugin),
+        'error' => is_wp_error($result) ? $result->get_error_message() : null,
+    );
+}
+
+do_action('plugins_loaded');
+do_action('init');
+do_action('wp_abilities_api_categories_init');
+do_action('wp_abilities_api_init');
+
+echo json_encode(
+    array(
+        'command' => 'agent-runtime.probe',
+        'wp_loaded' => function_exists('wp_insert_post'),
+        'plugins' => $activation_results,
+        'signals' => array(
+            'agents_api_loaded' => defined('AGENTS_API_LOADED'),
+            'agents_registry_class' => class_exists('WP_Agents_Registry'),
+            'data_machine_version' => defined('DATAMACHINE_VERSION') ? DATAMACHINE_VERSION : null,
+            'data_machine_permission_helper' => class_exists('DataMachine\\Abilities\\PermissionHelper'),
+            'data_machine_code_version' => defined('DATAMACHINE_CODE_VERSION') ? DATAMACHINE_CODE_VERSION : null,
+            'data_machine_code_workspace' => class_exists('DataMachineCode\\Workspace\\Workspace'),
+            'openai_provider_plugin_loaded' => function_exists('WordPress\\OpenAiAiProvider\\register_provider'),
+        ),
+    ),
+    JSON_PRETTY_PRINT
+);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ interface RunOptions {
   mounts: Array<{ source: string; target: string; mode: "readonly" | "readwrite" }>
   command: string
   args: string[]
+  wpVersion?: string
   artifactsDirectory?: string
   policy?: RuntimePolicy
   json: boolean
@@ -75,7 +76,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
         environment: {
           kind: "wordpress",
           name: "sandbox-runtime-cli",
-          version: "latest",
+          version: options.wpVersion ?? "latest",
           blueprint: { steps: [] },
         },
         policy: options.policy ?? defaultPolicy,
@@ -157,6 +158,9 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
         break
       case "--arg":
         options.args.push(value)
+        break
+      case "--wp":
+        options.wpVersion = value
         break
       case "--artifacts":
         options.artifactsDirectory = value
@@ -253,6 +257,7 @@ Options:
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
   --arg <key=value>    Command argument. Repeatable.
+  --wp <version>       WordPress version for Playground, e.g. latest, trunk, nightly, 6.9.
   --artifacts <dir>    Artifact root directory.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --json               Emit machine-readable JSON.

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -46,6 +46,7 @@ interface PlaygroundCliModule {
     skipBrowser: boolean
     mount: Array<{ hostPath: string; vfsPath: string }>
     blueprint?: unknown
+    wp?: string
   }): Promise<PlaygroundCliServer>
 }
 
@@ -381,6 +382,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
         hostPath: mount.source,
         vfsPath: mount.target,
       })),
+      wp: this.spec.environment.version,
       blueprint: this.spec.environment.blueprint,
     })
   }


### PR DESCRIPTION
## Summary
- Adds `--wp <version>` support so runtime consumers can request Playground `trunk`, `nightly`, or numeric WordPress versions.
- Threads the selected WordPress version into the Playground backend.
- Adds an `examples/agent-runtime` probe that mounts and activates Agents API, Data Machine, Data Machine Code, and AI Provider for OpenAI inside the sandbox.

## Testing
- `npm run check`
- Local stack probe with `--wp trunk` and mounted local checkouts for `agents-api`, `data-machine`, `data-machine-code`, and `ai-provider-for-openai` returned all plugins active and runtime signals present.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Probed the agent-runtime stack, found the WordPress version blocker, implemented `--wp`, added the stack probe example, ran validation, and opened the PR; Chris remains responsible for review and merge.