### PR TITLE
Invoke sandbox agents through agents/chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The WordPress plugin in `packages/wordpress-plugin` registers:
 
 - `sandbox-runtime/run-agent-task`
 
-This is the parent-site control-plane surface for frontend/chat integrations. A chat agent can be granted this ability without receiving raw shell or parent-site filesystem access. The ability launches `sandbox-runtime agent-sandbox-run`, which boots a disposable WordPress Playground runtime, mounts the configured agent stack, executes the task, and returns artifact metadata.
+This is the parent-site control-plane surface for frontend/chat integrations. A chat agent can be granted this ability without receiving raw shell or parent-site filesystem access. The ability launches `sandbox-runtime agent-sandbox-run`, which boots a disposable WordPress Playground runtime, mounts the configured agent stack, invokes the sandbox agent through `agents/chat`, and returns artifact metadata.
 
 Component paths come from ability input, the `sandbox_runtime_component_paths` option, or the `sandbox_runtime_component_paths` filter. Data Machine Code is the mounted coding-tools component for file-editing agent sandboxes; it provides the workspace/file/GitHub tools inside the sandbox, while Sandbox Runtime owns the parent-site control plane and sandbox lifecycle.
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,6 +39,10 @@ interface AgentRuntimeProbeOptions {
 
 interface AgentSandboxRunOptions extends AgentRuntimeProbeOptions {
   task: string
+  agent?: string
+  mode?: string
+  sessionId?: string
+  maxTurns?: string
   code?: string
   codeFile?: string
 }
@@ -205,7 +209,7 @@ function parseAgentRuntimeProbeOptions(args: string[], extraOptions: string[] = 
 }
 
 function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
-  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--code", "--code-file"]) as Partial<AgentSandboxRunOptions>
+  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--agent", "--mode", "--session-id", "--max-turns", "--code", "--code-file"]) as Partial<AgentSandboxRunOptions>
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -215,6 +219,18 @@ function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
     switch (name) {
       case "--task":
         options.task = value
+        break
+      case "--agent":
+        options.agent = value
+        break
+      case "--mode":
+        options.mode = value
+        break
+      case "--session-id":
+        options.sessionId = value
+        break
+      case "--max-turns":
+        options.maxTurns = value
         break
       case "--code":
         options.code = value
@@ -444,6 +460,10 @@ Agent runtime probe options:
 
 Agent sandbox run options:
   --task <text>               Task description recorded in the sandbox run.
+  --agent <slug>              Agent slug to invoke through the canonical agents/chat ability.
+  --mode <slug>               Agent execution mode. Defaults to sandbox.
+  --session-id <id>           Existing sandbox conversation session id.
+  --max-turns <n>             Maximum agent loop turns for the sandbox task.
   --code <php>                Optional PHP body to run after the agent stack boots.
   --code-file <path>          Optional PHP file to run after the agent stack boots.
 
@@ -452,6 +472,10 @@ Example:
 }
 
 async function resolveSandboxTaskCode(options: AgentSandboxRunOptions): Promise<string> {
+  if (options.agent) {
+    return agentChatTaskCode(options)
+  }
+
   if (options.code) {
     return options.code
   }
@@ -463,9 +487,92 @@ async function resolveSandboxTaskCode(options: AgentSandboxRunOptions): Promise<
   return `echo json_encode(array('task_received' => true), JSON_PRETTY_PRINT);`
 }
 
+function agentChatTaskCode(options: AgentSandboxRunOptions): string {
+  const input: Record<string, unknown> = {
+    agent: options.agent,
+    message: options.task,
+    session_id: options.sessionId ?? null,
+    mode: options.mode ?? "sandbox",
+    client_context: {
+      source: "bridge",
+      client_name: "sandbox-runtime",
+      connector_id: "sandbox-runtime-cli",
+      mode: options.mode ?? "sandbox",
+      agent_modes: [options.mode ?? "sandbox"],
+    },
+  }
+
+  if (options.maxTurns) {
+    input.max_turns = Number.parseInt(options.maxTurns, 10)
+  }
+
+  return `
+if (function_exists('wp_set_current_user')) {
+    wp_set_current_user(1);
+}
+
+if (class_exists('DataMachine\\Core\\Database\\Agents\\Agents')) {
+    $sandbox_agent_slug = sanitize_title((string) (${JSON.stringify(input.agent)}));
+    if ('' !== $sandbox_agent_slug) {
+        (new DataMachine\\Core\\Database\\Agents\\Agents())->create_if_missing(
+            $sandbox_agent_slug,
+            'Sandbox Agent',
+            1,
+            array()
+        );
+    }
+}
+
+add_filter('agents_chat_permission', static function () {
+    return true;
+}, 100, 2);
+
+$ability = function_exists('wp_get_ability') ? wp_get_ability('agents/chat') : null;
+if (!$ability || !method_exists($ability, 'execute')) {
+    $sandbox_agent_runtime = array(
+        'agent_runtime' => array(
+            'success' => false,
+            'error' => array(
+                'code' => 'agents_chat_unavailable',
+                'message' => 'The canonical agents/chat ability is not available inside the sandbox.',
+            ),
+        ),
+    );
+} else {
+    $agent_input = ${JSON.stringify(JSON.stringify(input))};
+    $agent_result = $ability->execute(json_decode($agent_input, true));
+    if (is_wp_error($agent_result)) {
+        $sandbox_agent_runtime = array(
+            'agent_runtime' => array(
+                'success' => false,
+                'input' => json_decode($agent_input, true),
+                'error' => array(
+                    'code' => $agent_result->get_error_code(),
+                    'message' => $agent_result->get_error_message(),
+                    'data' => $agent_result->get_error_data(),
+                ),
+            ),
+        );
+    } else {
+        $sandbox_agent_runtime = array(
+            'agent_runtime' => array(
+                'success' => true,
+                'input' => json_decode($agent_input, true),
+                'result' => $agent_result,
+            ),
+        );
+    }
+}
+
+echo json_encode($sandbox_agent_runtime, JSON_PRETTY_PRINT);
+`
+}
+
 function agentSandboxRunCode(task: string, code: string): string {
   return `<?php
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+add_filter('datamachine_should_load_full_runtime', '__return_true', 1);
 
 $plugins = array(
     'agents-api/agents-api.php',
@@ -527,6 +634,8 @@ function phpBody(code: string): string {
 function agentRuntimeProbeCode(): string {
   return `<?php
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+add_filter('datamachine_should_load_full_runtime', '__return_true', 1);
 
 $plugins = array(
     'agents-api/agents-api.php',

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -8,8 +8,9 @@ agent sandboxes from a parent site.
 - `sandbox-runtime/run-agent-task`
 
 The ability runs `sandbox-runtime agent-sandbox-run`, which boots a disposable
-WordPress Playground runtime, mounts the agent stack components, executes the
-task, and returns artifact metadata.
+WordPress Playground runtime, mounts the agent stack components, invokes the
+configured sandbox agent through the canonical `agents/chat` ability, and returns
+artifact metadata.
 
 ## Configuration
 

--- a/packages/wordpress-plugin/src/class-sandbox-runtime-abilities.php
+++ b/packages/wordpress-plugin/src/class-sandbox-runtime-abilities.php
@@ -40,6 +40,22 @@ final class Sandbox_Runtime_Abilities {
 								'type'        => 'string',
 								'description' => 'Task description to run inside the isolated sandbox.',
 							),
+							'agent'                  => array(
+								'type'        => 'string',
+								'description' => 'Sandbox agent slug to invoke through agents/chat. Defaults through sandbox_runtime_default_agent.',
+							),
+							'mode'                   => array(
+								'type'        => 'string',
+								'description' => 'Agent execution mode. Defaults to sandbox.',
+							),
+							'session_id'             => array(
+								'type'        => 'string',
+								'description' => 'Existing sandbox conversation session id.',
+							),
+							'max_turns'              => array(
+								'type'        => 'integer',
+								'description' => 'Maximum agent loop turns for this sandbox task.',
+							),
 							'code'                   => array(
 								'type'        => 'string',
 								'description' => 'Optional PHP code body to execute after the sandbox agent stack boots.',

--- a/packages/wordpress-plugin/src/class-sandbox-runtime-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-sandbox-runtime-agent-sandbox-runner.php
@@ -60,16 +60,26 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 		}
 
 		$command = sprintf(
-			'%s agent-sandbox-run --agents-api %s --data-machine %s --data-machine-code %s --openai-provider %s --task %s --wp %s --artifacts %s --json',
+			'%s agent-sandbox-run --agents-api %s --data-machine %s --data-machine-code %s --openai-provider %s --task %s --agent %s --mode %s --wp %s --artifacts %s --json',
 			$this->command_prefix( $bin ),
 			escapeshellarg( $paths['agents_api'] ),
 			escapeshellarg( $paths['data_machine'] ),
 			escapeshellarg( $paths['data_machine_code'] ),
 			escapeshellarg( $paths['openai_provider'] ),
 			escapeshellarg( $task ),
+			escapeshellarg( $this->agent_slug( $input ) ),
+			escapeshellarg( $this->mode( $input ) ),
 			escapeshellarg( $wp_version ),
 			escapeshellarg( $artifacts )
 		);
+
+		if ( ! empty( $input['session_id'] ) ) {
+			$command .= ' --session-id ' . escapeshellarg( (string) $input['session_id'] );
+		}
+
+		if ( ! empty( $input['max_turns'] ) ) {
+			$command .= ' --max-turns ' . escapeshellarg( (string) max( 1, (int) $input['max_turns'] ) );
+		}
 
 		if ( '' !== $code ) {
 			$command .= ' --code ' . escapeshellarg( $code );
@@ -166,6 +176,25 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 		}
 
 		return function_exists( 'exec' ) && function_exists( 'shell_exec' );
+	}
+
+	private function agent_slug( array $input ): string {
+		$agent = trim( (string) ( $input['agent'] ?? '' ) );
+		if ( '' !== $agent ) {
+			return $agent;
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$agent = (string) apply_filters( 'sandbox_runtime_default_agent', '' );
+		}
+
+		return '' !== trim( $agent ) ? trim( $agent ) : 'sandbox-agent';
+	}
+
+	private function mode( array $input ): string {
+		$mode = trim( (string) ( $input['mode'] ?? '' ) );
+
+		return '' !== $mode ? $mode : 'sandbox';
 	}
 
 	private function default_artifacts_path(): string {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -80,6 +80,7 @@ $GLOBALS['sandbox_runtime_filters']['sandbox_runtime_component_paths'] = array(
 	'openai_provider'   => $root . '/ai-provider-for-openai',
 );
 $GLOBALS['sandbox_runtime_filters']['sandbox_runtime_bin'] = $root . '/sandbox-runtime.js';
+$GLOBALS['sandbox_runtime_filters']['sandbox_runtime_default_agent'] = 'site-coder';
 
 $captured_command = '';
 $runner           = new Sandbox_Runtime_Agent_Sandbox_Runner(
@@ -112,6 +113,8 @@ $assert( 'runner schema is stable', ! is_wp_error( $result ) && 'sandbox-runtime
 $assert( 'runner invokes agent-sandbox-run', str_contains( $captured_command, 'agent-sandbox-run' ) );
 $assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node ' ) );
 $assert( 'runner passes task', str_contains( $captured_command, '--task' ) );
+$assert( 'runner passes default agent', str_contains( $captured_command, '--agent' ) && str_contains( $captured_command, 'site-coder' ) );
+$assert( 'runner passes sandbox mode', str_contains( $captured_command, '--mode' ) && str_contains( $captured_command, 'sandbox' ) );
 
 $missing_task = $runner->run( array( 'artifacts_path' => $root . '/artifacts' ) );
 $assert( 'missing task fails closed', is_wp_error( $missing_task ) && 'sandbox_runtime_task_missing' === $missing_task->get_error_code() );


### PR DESCRIPTION
## Summary
- Route `agent-sandbox-run --agent` through the canonical `agents/chat` ability inside the disposable Playground runtime.
- Opt the sandbox bootstrap into Data Machine's full runtime, seed the requested disposable agent slug, and return structured agent runtime output.
- Add `agent-sandbox-batch` plus `sandbox-runtime/run-agent-task-batch` so a parent control plane can fan out multiple goals/issues into separate isolated sandbox runs with bounded concurrency.
- Seed scoped provider/model config into the disposable sandbox agent and Data Machine settings so `agents/chat` can reach wp-ai-client dispatch instead of stopping at `provider_required`.
- Pass agent/mode/provider/model/session/max-turns from the WordPress plugin ability into the CLI and document the updated control-plane behavior.

Closes #23.

## Verification
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run check`
- `node packages/cli/dist/index.js agent-sandbox-batch --agents-api "/Users/chubes/Developer/agents-api" --data-machine "/Users/chubes/Developer/data-machine" --data-machine-code "/Users/chubes/Developer/data-machine-code" --openai-provider "/Users/chubes/Developer/ai-provider-for-openai" --task "Batch smoke task one" --task "Batch smoke task two" --concurrency 2 --wp trunk --artifacts "/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/sandbox-runtime-batch-smoke" --json`
- `node packages/cli/dist/index.js agent-sandbox-run --agents-api "/Users/chubes/Developer/agents-api" --data-machine "/Users/chubes/Developer/data-machine" --data-machine-code "/Users/chubes/Developer/data-machine-code" --openai-provider "/Users/chubes/Developer/ai-provider-for-openai" --task "Say sandbox provider model injection worked in one short sentence." --agent sandbox-agent --mode sandbox --provider openai --model gpt-5.5 --max-turns 1 --wp trunk --artifacts "/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/sandbox-runtime-provider-model-smoke" --json`

## Follow-up
- Provider/model injection now gets the sandbox past `provider_required`; the real smoke reaches wp-ai-client dispatch and fails at request authentication because the sandbox process has no provider API key configured.
- Raw secret transport remains a separate scoped credential contract: credentials should resolve through provider-normal mechanisms such as `OPENAI_API_KEY`, not task payloads.
- PR-opening semantics remain the responsibility of the in-sandbox coding agent/DMC contract; this PR adds the coordinator fan-out primitive.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the Sandbox Runtime CLI/plugin changes; Chris reviewed direction and requested the PR.