### PR TITLE
Add sandbox batch fan-out and model config seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ The fixture plugin is documented in [`examples/simple-plugin/README.md`](example
 The WordPress plugin in `packages/wordpress-plugin` registers:
 
 - `sandbox-runtime/run-agent-task`
+- `sandbox-runtime/run-agent-task-batch`
 
 This is the parent-site control-plane surface for frontend/chat integrations. A chat agent can be granted this ability without receiving raw shell or parent-site filesystem access. The ability launches `sandbox-runtime agent-sandbox-run`, which boots a disposable WordPress Playground runtime, mounts the configured agent stack, invokes the sandbox agent through `agents/chat`, and returns artifact metadata.
+
+For parallel cooking, `sandbox-runtime agent-sandbox-batch` and `sandbox-runtime/run-agent-task-batch` accept multiple tasks and run each task in its own isolated Playground sandbox with a bounded concurrency limit. This is the first coordinator primitive for issue fan-out: a parent can turn several GitHub issues into separate sandbox agent runs, and each sandbox agent is responsible for doing its own branch/test/PR work through the mounted coding tools.
 
 Component paths come from ability input, the `sandbox_runtime_component_paths` option, or the `sandbox_runtime_component_paths` filter. Data Machine Code is the mounted coding-tools component for file-editing agent sandboxes; it provides the workspace/file/GitHub tools inside the sandbox, while Sandbox Runtime owns the parent-site control plane and sandbox lifecycle.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ This is the parent-site control-plane surface for frontend/chat integrations. A 
 
 For parallel cooking, `sandbox-runtime agent-sandbox-batch` and `sandbox-runtime/run-agent-task-batch` accept multiple tasks and run each task in its own isolated Playground sandbox with a bounded concurrency limit. This is the first coordinator primitive for issue fan-out: a parent can turn several GitHub issues into separate sandbox agent runs, and each sandbox agent is responsible for doing its own branch/test/PR work through the mounted coding tools.
 
+Parent control planes can pass `provider` and `model` to seed the disposable sandbox's Data Machine agent configuration for the requested execution mode. Provider credentials still resolve through the mounted provider's normal scoped mechanism, such as `OPENAI_API_KEY` for the OpenAI provider, so raw API keys do not need to appear in task payloads.
+
 Component paths come from ability input, the `sandbox_runtime_component_paths` option, or the `sandbox_runtime_component_paths` filter. Data Machine Code is the mounted coding-tools component for file-editing agent sandboxes; it provides the workspace/file/GitHub tools inside the sandbox, while Sandbox Runtime owns the parent-site control plane and sandbox lifecycle.
 
 Apply-back is intentionally separate: sandbox task execution returns artifacts and proposed outputs, while applying changes to the real site should use a distinct reviewed permission path.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,6 +41,8 @@ interface AgentSandboxRunOptions extends AgentRuntimeProbeOptions {
   task: string
   agent?: string
   mode?: string
+  provider?: string
+  model?: string
   sessionId?: string
   maxTurns?: string
   code?: string
@@ -51,6 +53,8 @@ interface AgentSandboxBatchOptions extends AgentRuntimeProbeOptions {
   tasks: string[]
   agent?: string
   mode?: string
+  provider?: string
+  model?: string
   maxTurns?: string
   concurrency?: string
 }
@@ -281,7 +285,7 @@ function parseAgentRuntimeProbeOptions(args: string[], extraOptions: string[] = 
 }
 
 function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
-  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--agent", "--mode", "--session-id", "--max-turns", "--code", "--code-file"]) as Partial<AgentSandboxRunOptions>
+  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--code", "--code-file"]) as Partial<AgentSandboxRunOptions>
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -297,6 +301,12 @@ function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
         break
       case "--mode":
         options.mode = value
+        break
+      case "--provider":
+        options.provider = value
+        break
+      case "--model":
+        options.model = value
         break
       case "--session-id":
         options.sessionId = value
@@ -325,7 +335,7 @@ function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
 }
 
 async function parseAgentSandboxBatchOptions(args: string[]): Promise<AgentSandboxBatchOptions> {
-  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--tasks-json", "--tasks-file", "--agent", "--mode", "--max-turns", "--concurrency"]) as Partial<AgentSandboxBatchOptions>
+  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--tasks-json", "--tasks-file", "--agent", "--mode", "--provider", "--model", "--max-turns", "--concurrency"]) as Partial<AgentSandboxBatchOptions>
   options.tasks = []
 
   for (let index = 0; index < args.length; index++) {
@@ -354,6 +364,12 @@ async function parseAgentSandboxBatchOptions(args: string[]): Promise<AgentSandb
         break
       case "--mode":
         options.mode = value
+        break
+      case "--provider":
+        options.provider = value
+        break
+      case "--model":
+        options.model = value
         break
       case "--max-turns":
         options.maxTurns = value
@@ -623,6 +639,8 @@ Agent sandbox run options:
   --task <text>               Task description recorded in the sandbox run.
   --agent <slug>              Agent slug to invoke through the canonical agents/chat ability.
   --mode <slug>               Agent execution mode. Defaults to sandbox.
+  --provider <id>             AI provider id to seed into the sandbox agent config.
+  --model <id>                AI model id to seed into the sandbox agent config.
   --session-id <id>           Existing sandbox conversation session id.
   --max-turns <n>             Maximum agent loop turns for the sandbox task.
   --code <php>                Optional PHP body to run after the agent stack boots.
@@ -655,17 +673,19 @@ async function resolveSandboxTaskCode(options: AgentSandboxRunOptions): Promise<
 }
 
 function agentChatTaskCode(options: AgentSandboxRunOptions): string {
+  const mode = options.mode ?? "sandbox"
+  const agentConfig = scopedAgentConfig(mode, options.provider, options.model)
   const input: Record<string, unknown> = {
     agent: options.agent,
     message: options.task,
     session_id: options.sessionId ?? null,
-    mode: options.mode ?? "sandbox",
+    mode,
     client_context: {
       source: "bridge",
       client_name: "sandbox-runtime",
       connector_id: "sandbox-runtime-cli",
-      mode: options.mode ?? "sandbox",
-      agent_modes: [options.mode ?? "sandbox"],
+      mode,
+      agent_modes: [mode],
     },
   }
 
@@ -685,9 +705,14 @@ if (class_exists('DataMachine\\Core\\Database\\Agents\\Agents')) {
             $sandbox_agent_slug,
             'Sandbox Agent',
             1,
-            array()
+            json_decode(${JSON.stringify(JSON.stringify(agentConfig))}, true)
         );
     }
+}
+
+$sandbox_model_settings = json_decode(${JSON.stringify(JSON.stringify(scopedSettings(mode, options.provider, options.model)))}, true);
+if (is_array($sandbox_model_settings) && !empty($sandbox_model_settings)) {
+    update_option('datamachine_settings', array_merge(get_option('datamachine_settings', array()), $sandbox_model_settings));
 }
 
 add_filter('agents_chat_permission', static function () {
@@ -733,6 +758,40 @@ if (!$ability || !method_exists($ability, 'execute')) {
 
 echo json_encode($sandbox_agent_runtime, JSON_PRETTY_PRINT);
 `
+}
+
+function scopedAgentConfig(mode: string, provider: string | undefined, model: string | undefined): Record<string, unknown> {
+  if (!provider && !model) {
+    return {}
+  }
+
+  return {
+    ...(provider ? { default_provider: provider } : {}),
+    ...(model ? { default_model: model } : {}),
+    mode_models: {
+      [mode]: {
+        ...(provider ? { provider } : {}),
+        ...(model ? { model } : {}),
+      },
+    },
+  }
+}
+
+function scopedSettings(mode: string, provider: string | undefined, model: string | undefined): Record<string, unknown> {
+  if (!provider && !model) {
+    return {}
+  }
+
+  return {
+    ...(provider ? { default_provider: provider } : {}),
+    ...(model ? { default_model: model } : {}),
+    mode_models: {
+      [mode]: {
+        ...(provider ? { provider } : {}),
+        ...(model ? { model } : {}),
+      },
+    },
+  }
 }
 
 function agentSandboxRunCode(task: string, code: string): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,6 +47,24 @@ interface AgentSandboxRunOptions extends AgentRuntimeProbeOptions {
   codeFile?: string
 }
 
+interface AgentSandboxBatchOptions extends AgentRuntimeProbeOptions {
+  tasks: string[]
+  agent?: string
+  mode?: string
+  maxTurns?: string
+  concurrency?: string
+}
+
+interface AgentSandboxBatchOutput {
+  success: boolean
+  schema: "sandbox-runtime/agent-sandbox-batch/v1"
+  concurrency: number
+  total: number
+  completed: number
+  failed: number
+  runs: Array<RunOutput & { index: number; task: string }>
+}
+
 const defaultPolicy: RuntimePolicy = {
   network: "deny",
   filesystem: "readwrite-mounts",
@@ -97,6 +115,22 @@ async function main(args: string[]): Promise<number> {
     return output.success ? 0 : 1
   }
 
+  if (command === "agent-sandbox-batch") {
+    const options = await parseAgentSandboxBatchOptions(args)
+    const execute = () => runAgentSandboxBatch(options)
+
+    if (!options.json) {
+      const output = await execute()
+      printBatchHumanOutput(output)
+      return output.success ? 0 : 1
+    }
+
+    const { result, logs } = await captureStdout(execute)
+    const output = logs.length > 0 ? { ...result, logs } : result
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    return output.success ? 0 : 1
+  }
+
   if (command !== "run") {
     console.error(`Unknown command: ${command}`)
     printHelp()
@@ -138,6 +172,44 @@ async function agentSandboxRunOptions(options: AgentSandboxRunOptions): Promise<
     artifactsDirectory: options.artifactsDirectory,
     json: options.json,
   }
+}
+
+async function runAgentSandboxBatch(options: AgentSandboxBatchOptions): Promise<AgentSandboxBatchOutput> {
+  const concurrency = positiveInteger(options.concurrency, 2)
+  const runs = await mapWithConcurrency(options.tasks, concurrency, async (task, index) => {
+    const runOptions = await agentSandboxRunOptions({
+      ...options,
+      task,
+    })
+    const output = await run(runOptions)
+    return { ...output, index, task }
+  })
+  const failed = runs.filter((run) => !run.success).length
+
+  return {
+    success: failed === 0,
+    schema: "sandbox-runtime/agent-sandbox-batch/v1",
+    concurrency,
+    total: runs.length,
+    completed: runs.length - failed,
+    failed,
+    runs,
+  }
+}
+
+async function mapWithConcurrency<T, R>(items: T[], concurrency: number, callback: (item: T, index: number) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let nextIndex = 0
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex++
+      results[index] = await callback(items[index], index)
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()))
+  return results
 }
 
 function agentRuntimeMounts(options: AgentRuntimeProbeOptions): RunOptions["mounts"] {
@@ -250,6 +322,82 @@ function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
   }
 
   return options as AgentSandboxRunOptions
+}
+
+async function parseAgentSandboxBatchOptions(args: string[]): Promise<AgentSandboxBatchOptions> {
+  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--tasks-json", "--tasks-file", "--agent", "--mode", "--max-turns", "--concurrency"]) as Partial<AgentSandboxBatchOptions>
+  options.tasks = []
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[index + 1]
+
+    switch (name) {
+      case "--task":
+        if (value) {
+          options.tasks.push(value)
+        }
+        break
+      case "--tasks-json":
+        if (value) {
+          options.tasks.push(...parseTaskList(value))
+        }
+        break
+      case "--tasks-file":
+        if (value) {
+          options.tasks.push(...parseTaskList(await readFile(resolve(value), "utf8")))
+        }
+        break
+      case "--agent":
+        options.agent = value
+        break
+      case "--mode":
+        options.mode = value
+        break
+      case "--max-turns":
+        options.maxTurns = value
+        break
+      case "--concurrency":
+        options.concurrency = value
+        break
+    }
+  }
+
+  options.tasks = options.tasks.map((task) => task.trim()).filter(Boolean)
+  if (options.tasks.length === 0) {
+    throw new Error("Missing required option: --task, --tasks-json, or --tasks-file")
+  }
+
+  return options as AgentSandboxBatchOptions
+}
+
+function parseTaskList(raw: string): string[] {
+  const parsed = JSON.parse(raw)
+  if (!Array.isArray(parsed)) {
+    throw new Error("Task list must be a JSON array")
+  }
+
+  return parsed.map((task) => {
+    if (typeof task === "string") {
+      return task
+    }
+
+    if (task && typeof task === "object" && "task" in task && typeof task.task === "string") {
+      return task.task
+    }
+
+    throw new Error("Task list entries must be strings or objects with a task string")
+  })
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
 async function run(options: RunOptions): Promise<RunOutput> {
@@ -437,11 +585,24 @@ function printHumanOutput(output: RunOutput): void {
   console.log(`Artifacts: ${output.artifacts?.directory ?? "none"}`)
 }
 
+function printBatchHumanOutput(output: AgentSandboxBatchOutput): void {
+  console.log("Sandbox Runtime batch")
+  console.log(`Runs: ${output.completed}/${output.total} completed`)
+  console.log(`Concurrency: ${output.concurrency}`)
+  for (const run of output.runs) {
+    console.log(`${run.success ? "ok" : "fail"} #${run.index + 1}: ${run.task}`)
+    if (run.artifacts?.directory) {
+      console.log(`  Artifacts: ${run.artifacts.directory}`)
+    }
+  }
+}
+
 function printHelp(): void {
   console.log(`Usage:
   sandbox-runtime run --mount <host>:<vfs> --command <id> [options]
   sandbox-runtime agent-runtime-probe --agents-api <path> --data-machine <path> --data-machine-code <path> --openai-provider <path> [options]
   sandbox-runtime agent-sandbox-run --agents-api <path> --data-machine <path> --data-machine-code <path> --openai-provider <path> --task <text> [options]
+  sandbox-runtime agent-sandbox-batch --agents-api <path> --data-machine <path> --data-machine-code <path> --openai-provider <path> --task <text> [--task <text> ...] [options]
 
 Options:
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
@@ -466,6 +627,12 @@ Agent sandbox run options:
   --max-turns <n>             Maximum agent loop turns for the sandbox task.
   --code <php>                Optional PHP body to run after the agent stack boots.
   --code-file <path>          Optional PHP file to run after the agent stack boots.
+
+Agent sandbox batch options:
+  --task <text>               Task to run in its own isolated sandbox. Repeatable.
+  --tasks-json <json>         JSON array of task strings or objects with a task string.
+  --tasks-file <path>         File containing a JSON task array.
+  --concurrency <n>           Maximum concurrent sandboxes. Defaults to 2.
 
 Example:
   sandbox-runtime run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`)

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -6,11 +6,17 @@ agent sandboxes from a parent site.
 ## Ability
 
 - `sandbox-runtime/run-agent-task`
+- `sandbox-runtime/run-agent-task-batch`
 
 The ability runs `sandbox-runtime agent-sandbox-run`, which boots a disposable
 WordPress Playground runtime, mounts the agent stack components, invokes the
 configured sandbox agent through the canonical `agents/chat` ability, and returns
 artifact metadata.
+
+The batch ability runs `sandbox-runtime agent-sandbox-batch`, accepts a list of
+task descriptions, and launches one isolated sandbox per task with bounded
+concurrency. This is the parent-site primitive for fan-out workflows such as
+assigning several GitHub issues to separate sandbox coding agents.
 
 ## Configuration
 

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -18,6 +18,11 @@ task descriptions, and launches one isolated sandbox per task with bounded
 concurrency. This is the parent-site primitive for fan-out workflows such as
 assigning several GitHub issues to separate sandbox coding agents.
 
+Both abilities accept optional `provider` and `model` fields. These seed the
+disposable sandbox's Data Machine agent configuration for the selected execution
+mode. Provider credentials continue to resolve through the provider's normal
+scoped mechanism, such as `OPENAI_API_KEY` for the OpenAI provider.
+
 ## Configuration
 
 Component paths can be supplied by ability input, the

--- a/packages/wordpress-plugin/src/class-sandbox-runtime-abilities.php
+++ b/packages/wordpress-plugin/src/class-sandbox-runtime-abilities.php
@@ -48,6 +48,14 @@ final class Sandbox_Runtime_Abilities {
 								'type'        => 'string',
 								'description' => 'Agent execution mode. Defaults to sandbox.',
 							),
+							'provider'               => array(
+								'type'        => 'string',
+								'description' => 'AI provider id to seed into the sandbox agent config.',
+							),
+							'model'                  => array(
+								'type'        => 'string',
+								'description' => 'AI model id to seed into the sandbox agent config.',
+							),
 							'session_id'             => array(
 								'type'        => 'string',
 								'description' => 'Existing sandbox conversation session id.',
@@ -122,6 +130,8 @@ final class Sandbox_Runtime_Abilities {
 							),
 							'agent'                  => array( 'type' => 'string' ),
 							'mode'                   => array( 'type' => 'string' ),
+							'provider'               => array( 'type' => 'string' ),
+							'model'                  => array( 'type' => 'string' ),
 							'max_turns'              => array( 'type' => 'integer' ),
 							'wp'                     => array( 'type' => 'string' ),
 							'artifacts_path'         => array( 'type' => 'string' ),

--- a/packages/wordpress-plugin/src/class-sandbox-runtime-abilities.php
+++ b/packages/wordpress-plugin/src/class-sandbox-runtime-abilities.php
@@ -100,6 +100,56 @@ final class Sandbox_Runtime_Abilities {
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
+
+			wp_register_ability(
+				'sandbox-runtime/run-agent-task-batch',
+				array(
+					'label'               => 'Run Agent Sandbox Task Batch',
+					'description'         => 'Run multiple tasks in isolated Sandbox Runtime WordPress agent sandboxes and return artifacts for each run.',
+					'category'            => 'sandbox-runtime',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'tasks' ),
+						'properties' => array(
+							'tasks'                  => array(
+								'type'        => 'array',
+								'description' => 'Task descriptions. Each task runs in its own isolated sandbox.',
+								'items'       => array( 'type' => 'string' ),
+							),
+							'concurrency'            => array(
+								'type'        => 'integer',
+								'description' => 'Maximum number of concurrent sandbox runs. Defaults to 2.',
+							),
+							'agent'                  => array( 'type' => 'string' ),
+							'mode'                   => array( 'type' => 'string' ),
+							'max_turns'              => array( 'type' => 'integer' ),
+							'wp'                     => array( 'type' => 'string' ),
+							'artifacts_path'         => array( 'type' => 'string' ),
+							'sandbox_runtime_bin'    => array( 'type' => 'string' ),
+							'agents_api_path'        => array( 'type' => 'string' ),
+							'data_machine_path'      => array( 'type' => 'string' ),
+							'data_machine_code_path' => array( 'type' => 'string' ),
+							'openai_provider_path'   => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'     => array( 'type' => 'boolean' ),
+							'schema'      => array( 'type' => 'string' ),
+							'tasks'       => array( 'type' => 'array' ),
+							'concurrency' => array( 'type' => 'integer' ),
+							'paths'       => array( 'type' => 'object' ),
+							'artifacts'   => array( 'type' => 'string' ),
+							'exit_code'   => array( 'type' => 'integer' ),
+							'run'         => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'run_agent_task_batch' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
 		};
 
 		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
@@ -113,6 +163,11 @@ final class Sandbox_Runtime_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function run_agent_task( array $input ): array|WP_Error {
 		return ( new Sandbox_Runtime_Agent_Sandbox_Runner() )->run( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function run_agent_task_batch( array $input ): array|WP_Error {
+		return ( new Sandbox_Runtime_Agent_Sandbox_Runner() )->run_batch( $input );
 	}
 
 	public static function can_run_agent_task(): bool {

--- a/packages/wordpress-plugin/src/class-sandbox-runtime-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-sandbox-runtime-agent-sandbox-runner.php
@@ -61,7 +61,7 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 		}
 
 		$command = sprintf(
-			'%s agent-sandbox-run --agents-api %s --data-machine %s --data-machine-code %s --openai-provider %s --task %s --agent %s --mode %s --wp %s --artifacts %s --json',
+			'%s agent-sandbox-run --agents-api %s --data-machine %s --data-machine-code %s --openai-provider %s --task %s --agent %s --mode %s --provider %s --model %s --wp %s --artifacts %s --json',
 			$this->command_prefix( $bin ),
 			escapeshellarg( $paths['agents_api'] ),
 			escapeshellarg( $paths['data_machine'] ),
@@ -70,6 +70,8 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 			escapeshellarg( $task ),
 			escapeshellarg( $this->agent_slug( $input ) ),
 			escapeshellarg( $this->mode( $input ) ),
+			escapeshellarg( $this->provider( $input ) ),
+			escapeshellarg( $this->model( $input ) ),
 			escapeshellarg( $wp_version ),
 			escapeshellarg( $artifacts )
 		);
@@ -166,7 +168,7 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 
 		$concurrency = max( 1, (int) ( $input['concurrency'] ?? 2 ) );
 		$command     = sprintf(
-			'%s agent-sandbox-batch --agents-api %s --data-machine %s --data-machine-code %s --openai-provider %s --agent %s --mode %s --concurrency %s --wp %s --artifacts %s --json',
+			'%s agent-sandbox-batch --agents-api %s --data-machine %s --data-machine-code %s --openai-provider %s --agent %s --mode %s --provider %s --model %s --concurrency %s --wp %s --artifacts %s --json',
 			$this->command_prefix( $bin ),
 			escapeshellarg( $paths['agents_api'] ),
 			escapeshellarg( $paths['data_machine'] ),
@@ -174,6 +176,8 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 			escapeshellarg( $paths['openai_provider'] ),
 			escapeshellarg( $this->agent_slug( $input ) ),
 			escapeshellarg( $this->mode( $input ) ),
+			escapeshellarg( $this->provider( $input ) ),
+			escapeshellarg( $this->model( $input ) ),
 			escapeshellarg( (string) $concurrency ),
 			escapeshellarg( $wp_version ),
 			escapeshellarg( $artifacts )
@@ -294,6 +298,32 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 		$mode = trim( (string) ( $input['mode'] ?? '' ) );
 
 		return '' !== $mode ? $mode : 'sandbox';
+	}
+
+	private function provider( array $input ): string {
+		$provider = trim( (string) ( $input['provider'] ?? '' ) );
+		if ( '' !== $provider ) {
+			return $provider;
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$provider = (string) apply_filters( 'sandbox_runtime_default_provider', '' );
+		}
+
+		return trim( $provider );
+	}
+
+	private function model( array $input ): string {
+		$model = trim( (string) ( $input['model'] ?? '' ) );
+		if ( '' !== $model ) {
+			return $model;
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$model = (string) apply_filters( 'sandbox_runtime_default_model', '' );
+		}
+
+		return trim( $model );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */

--- a/packages/wordpress-plugin/src/class-sandbox-runtime-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-sandbox-runtime-agent-sandbox-runner.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit;
 final class Sandbox_Runtime_Agent_Sandbox_Runner {
 
 	private const SCHEMA = 'sandbox-runtime/agent-task-run/v1';
+	private const BATCH_SCHEMA = 'sandbox-runtime/agent-task-batch/v1';
 
 	/** @var array<string, callable> */
 	private array $callbacks;
@@ -132,6 +133,104 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 	}
 
 	/**
+	 * Run multiple tasks, each in its own isolated Sandbox Runtime agent sandbox.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function run_batch( array $input ): array|WP_Error {
+		if ( ! $this->shell_available() ) {
+			return new WP_Error( 'sandbox_runtime_shell_unavailable', 'Shell execution is not available for Sandbox Runtime.', array( 'status' => 500 ) );
+		}
+
+		$tasks = $this->tasks( $input );
+		if ( empty( $tasks ) ) {
+			return new WP_Error( 'sandbox_runtime_tasks_missing', 'tasks must include at least one task.', array( 'status' => 400 ) );
+		}
+
+		$paths = $this->resolve_component_paths( $input );
+		if ( is_wp_error( $paths ) ) {
+			return $paths;
+		}
+
+		$artifacts  = $this->clean_path( (string) ( $input['artifacts_path'] ?? $this->default_artifacts_path() ) );
+		$wp_version = trim( (string) ( $input['wp'] ?? 'trunk' ) );
+		if ( '' === $wp_version ) {
+			$wp_version = 'trunk';
+		}
+
+		$bin = trim( (string) ( $input['sandbox_runtime_bin'] ?? $this->default_bin() ) );
+		if ( '' === $bin || ! preg_match( '#^[A-Za-z0-9_./:@+-]+$#', $bin ) ) {
+			return new WP_Error( 'sandbox_runtime_bin_invalid', 'sandbox_runtime_bin must be a command name or path without shell metacharacters.', array( 'status' => 400 ) );
+		}
+
+		$concurrency = max( 1, (int) ( $input['concurrency'] ?? 2 ) );
+		$command     = sprintf(
+			'%s agent-sandbox-batch --agents-api %s --data-machine %s --data-machine-code %s --openai-provider %s --agent %s --mode %s --concurrency %s --wp %s --artifacts %s --json',
+			$this->command_prefix( $bin ),
+			escapeshellarg( $paths['agents_api'] ),
+			escapeshellarg( $paths['data_machine'] ),
+			escapeshellarg( $paths['data_machine_code'] ),
+			escapeshellarg( $paths['openai_provider'] ),
+			escapeshellarg( $this->agent_slug( $input ) ),
+			escapeshellarg( $this->mode( $input ) ),
+			escapeshellarg( (string) $concurrency ),
+			escapeshellarg( $wp_version ),
+			escapeshellarg( $artifacts )
+		);
+
+		if ( ! empty( $input['max_turns'] ) ) {
+			$command .= ' --max-turns ' . escapeshellarg( (string) max( 1, (int) $input['max_turns'] ) );
+		}
+
+		foreach ( $tasks as $task ) {
+			$command .= ' --task ' . escapeshellarg( $task );
+		}
+
+		$result    = $this->run_command( $command );
+		$exit_code = (int) ( $result['exit_code'] ?? 1 );
+		$output    = (string) ( $result['output'] ?? '' );
+		$decoded   = $this->decode_json_output( $output );
+
+		if ( is_wp_error( $decoded ) ) {
+			return new WP_Error(
+				'sandbox_runtime_json_invalid',
+				'Sandbox Runtime did not return valid JSON: ' . $decoded->get_error_message(),
+				array(
+					'status'    => 500,
+					'exit_code' => $exit_code,
+					'output'    => $this->bound_output( $output ),
+				)
+			);
+		}
+
+		if ( 0 !== $exit_code ) {
+			return new WP_Error(
+				'sandbox_runtime_batch_failed',
+				'Sandbox Runtime agent sandbox batch failed.',
+				array(
+					'status'    => 500,
+					'exit_code' => $exit_code,
+					'output'    => $this->bound_output( $output ),
+					'run'       => $decoded,
+				)
+			);
+		}
+
+		return array(
+			'success'     => true,
+			'schema'      => self::BATCH_SCHEMA,
+			'tasks'       => $tasks,
+			'concurrency' => $concurrency,
+			'wp'          => $wp_version,
+			'paths'       => $paths,
+			'artifacts'   => $artifacts,
+			'exit_code'   => $exit_code,
+			'run'         => $decoded,
+		);
+	}
+
+	/**
 	 * @param array<string,mixed> $input Ability input.
 	 * @return array{agents_api:string,data_machine:string,data_machine_code:string,openai_provider:string}|WP_Error
 	 */
@@ -195,6 +294,21 @@ final class Sandbox_Runtime_Agent_Sandbox_Runner {
 		$mode = trim( (string) ( $input['mode'] ?? '' ) );
 
 		return '' !== $mode ? $mode : 'sandbox';
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return string[] */
+	private function tasks( array $input ): array {
+		$tasks = is_array( $input['tasks'] ?? null ) ? $input['tasks'] : array();
+
+		return array_values(
+			array_filter(
+				array_map(
+					static fn( $task ): string => trim( (string) $task ),
+					$tasks
+				),
+				static fn( string $task ): bool => '' !== $task
+			)
+		);
 	}
 
 	private function default_artifacts_path(): string {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -86,6 +86,8 @@ $GLOBALS['sandbox_runtime_filters']['sandbox_runtime_component_paths'] = array(
 );
 $GLOBALS['sandbox_runtime_filters']['sandbox_runtime_bin'] = $root . '/sandbox-runtime.js';
 $GLOBALS['sandbox_runtime_filters']['sandbox_runtime_default_agent'] = 'site-coder';
+$GLOBALS['sandbox_runtime_filters']['sandbox_runtime_default_provider'] = 'openai';
+$GLOBALS['sandbox_runtime_filters']['sandbox_runtime_default_model'] = 'gpt-5.5';
 
 $captured_command = '';
 $runner           = new Sandbox_Runtime_Agent_Sandbox_Runner(
@@ -120,6 +122,8 @@ $assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node '
 $assert( 'runner passes task', str_contains( $captured_command, '--task' ) );
 $assert( 'runner passes default agent', str_contains( $captured_command, '--agent' ) && str_contains( $captured_command, 'site-coder' ) );
 $assert( 'runner passes sandbox mode', str_contains( $captured_command, '--mode' ) && str_contains( $captured_command, 'sandbox' ) );
+$assert( 'runner passes default provider', str_contains( $captured_command, '--provider' ) && str_contains( $captured_command, 'openai' ) );
+$assert( 'runner passes default model', str_contains( $captured_command, '--model' ) && str_contains( $captured_command, 'gpt-5.5' ) );
 
 $batch_result = $runner->run_batch(
 	array(
@@ -134,6 +138,8 @@ $assert( 'batch runner schema is stable', ! is_wp_error( $batch_result ) && 'san
 $assert( 'batch runner invokes agent-sandbox-batch', str_contains( $captured_command, 'agent-sandbox-batch' ) );
 $assert( 'batch runner passes repeated tasks', 2 === substr_count( $captured_command, '--task' ) );
 $assert( 'batch runner passes concurrency', str_contains( $captured_command, '--concurrency' ) && str_contains( $captured_command, '2' ) );
+$assert( 'batch runner passes default provider', str_contains( $captured_command, '--provider' ) && str_contains( $captured_command, 'openai' ) );
+$assert( 'batch runner passes default model', str_contains( $captured_command, '--model' ) && str_contains( $captured_command, 'gpt-5.5' ) );
 
 $missing_task = $runner->run( array( 'artifacts_path' => $root . '/artifacts' ) );
 $assert( 'missing task fails closed', is_wp_error( $missing_task ) && 'sandbox_runtime_task_missing' === $missing_task->get_error_code() );

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -73,6 +73,11 @@ $assert( 'ability is REST visible', true === ( $ability['meta']['show_in_rest'] 
 $assert( 'ability requires task only', array( 'task' ) === ( $ability['input_schema']['required'] ?? array() ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
+$batch_ability = $GLOBALS['sandbox_runtime_registered_abilities']['sandbox-runtime/run-agent-task-batch'] ?? null;
+$assert( 'run-agent-task-batch ability registered', is_array( $batch_ability ) );
+$assert( 'batch ability is REST visible', true === ( $batch_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'batch ability requires tasks', array( 'tasks' ) === ( $batch_ability['input_schema']['required'] ?? array() ) );
+
 $GLOBALS['sandbox_runtime_filters']['sandbox_runtime_component_paths'] = array(
 	'agents_api'        => $root . '/agents-api',
 	'data_machine'      => $root . '/data-machine',
@@ -116,8 +121,25 @@ $assert( 'runner passes task', str_contains( $captured_command, '--task' ) );
 $assert( 'runner passes default agent', str_contains( $captured_command, '--agent' ) && str_contains( $captured_command, 'site-coder' ) );
 $assert( 'runner passes sandbox mode', str_contains( $captured_command, '--mode' ) && str_contains( $captured_command, 'sandbox' ) );
 
+$batch_result = $runner->run_batch(
+	array(
+		'tasks'          => array( 'Fix issue one.', 'Fix issue two.' ),
+		'concurrency'    => 2,
+		'artifacts_path' => $root . '/artifacts',
+	)
+);
+
+$assert( 'batch runner succeeds with filter-provided component paths', ! is_wp_error( $batch_result ) && true === ( $batch_result['success'] ?? false ) );
+$assert( 'batch runner schema is stable', ! is_wp_error( $batch_result ) && 'sandbox-runtime/agent-task-batch/v1' === ( $batch_result['schema'] ?? '' ) );
+$assert( 'batch runner invokes agent-sandbox-batch', str_contains( $captured_command, 'agent-sandbox-batch' ) );
+$assert( 'batch runner passes repeated tasks', 2 === substr_count( $captured_command, '--task' ) );
+$assert( 'batch runner passes concurrency', str_contains( $captured_command, '--concurrency' ) && str_contains( $captured_command, '2' ) );
+
 $missing_task = $runner->run( array( 'artifacts_path' => $root . '/artifacts' ) );
 $assert( 'missing task fails closed', is_wp_error( $missing_task ) && 'sandbox_runtime_task_missing' === $missing_task->get_error_code() );
+
+$missing_tasks = $runner->run_batch( array( 'artifacts_path' => $root . '/artifacts' ) );
+$assert( 'missing batch tasks fails closed', is_wp_error( $missing_tasks ) && 'sandbox_runtime_tasks_missing' === $missing_tasks->get_error_code() );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";


### PR DESCRIPTION
## Summary
- Add `agent-sandbox-batch` plus `sandbox-runtime/run-agent-task-batch` so parent control planes can fan out multiple goals/issues into separate isolated sandbox runs with bounded concurrency.
- Seed scoped provider/model config into the disposable sandbox agent and Data Machine settings so `agents/chat` reaches wp-ai-client dispatch instead of stopping at `provider_required`.
- Extend the WordPress ability runner, docs, and smoke coverage for batch and provider/model pass-through.

Follow-up to #36. These commits were pushed after #36 had already merged, so this PR carries the slices that did not land in that merge.

## Verification
- `npm run check`
- Previously verified real batch smoke with two concurrent Playground sandboxes.
- Previously verified provider/model smoke reaches wp-ai-client dispatch; it then stops at request authentication because scoped secret transport is intentionally still separate.

## Follow-up
- Raw provider secret transport remains a separate scoped credential contract; provider credentials should resolve through provider-normal mechanisms such as `OPENAI_API_KEY`, not task payloads.
- PR-opening semantics remain the responsibility of the in-sandbox coding agent/DMC contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the Sandbox Runtime CLI/plugin follow-up changes; Chris reviewed direction and requested the PR path.