### PR TITLE
Keep agent stack mounts readonly

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -228,13 +228,13 @@ async function mapWithConcurrency<T, R>(items: T[], concurrency: number, callbac
 
 function agentRuntimeMounts(options: AgentRuntimeProbeOptions): RunOptions["mounts"] {
   return [
-    { source: resolve(options.agentsApiPath), target: "/wordpress/wp-content/plugins/agents-api", mode: "readwrite" },
-    { source: resolve(options.dataMachinePath), target: "/wordpress/wp-content/plugins/data-machine", mode: "readwrite" },
-    { source: resolve(options.dataMachineCodePath), target: "/wordpress/wp-content/plugins/data-machine-code", mode: "readwrite" },
+    { source: resolve(options.agentsApiPath), target: "/wordpress/wp-content/plugins/agents-api", mode: "readonly" },
+    { source: resolve(options.dataMachinePath), target: "/wordpress/wp-content/plugins/data-machine", mode: "readonly" },
+    { source: resolve(options.dataMachineCodePath), target: "/wordpress/wp-content/plugins/data-machine-code", mode: "readonly" },
     ...providerPluginMounts(options).map((plugin) => ({
       source: plugin.source,
       target: `/wordpress/wp-content/plugins/${plugin.slug}`,
-      mode: "readwrite" as const,
+      mode: "readonly" as const,
     })),
     ...options.mounts,
   ]


### PR DESCRIPTION
## Summary
- Mount built-in agent stack components as readonly in agent runtime commands.
- Keep explicit extra `--mount` values as the way to opt into readwrite task/output capture.
- Avoid artifact bundles filling with framework source files from Agents API, Data Machine, Data Machine Code, and provider plugins.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed artifact noise from a Homeboy adapter proof run, drafted the mount-mode fix, and ran local smoke verification for Chris to review.