### PR TITLE
Default Playground sandboxes to WordPress 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ WP Codebox mounts the local plugin directory into WordPress Playground and boots
 
 `wordpress.run-php` accepts either `--arg code-file=<path>` or `--arg code=<php>`. It loads `/wordpress/wp-load.php` before running the supplied PHP so WordPress functions are available by default. Use `--arg bootstrap=none` for raw PHP execution without WordPress bootstrap.
 
-Use `--wp trunk`, `--wp nightly`, or a numeric WordPress version when a mounted plugin stack requires a version other than Playground's default.
+WP Codebox defaults Playground to WordPress `7.0` because its agent and AI plugin stacks require the modern WordPress AI surface. Use `--wp trunk`, `--wp nightly`, or another numeric WordPress version when a mounted plugin stack needs a different runtime.
 
 The fixture plugin is documented in [`examples/simple-plugin/README.md`](examples/simple-plugin/README.md).
 
@@ -92,7 +92,7 @@ Recipe shape:
   "runtime": {
     "backend": "wordpress-playground",
     "name": "simple-plugin-lab",
-    "wp": "latest"
+    "wp": "7.0"
   },
   "inputs": {
     "mounts": [

--- a/examples/agent-runtime/README.md
+++ b/examples/agent-runtime/README.md
@@ -18,4 +18,4 @@ npm run wp-codebox -- agent-runtime-probe \
   --json
 ```
 
-The preset mounts the plugins at their canonical slugs, uses WordPress `trunk` by default, activates the plugins in dependency order, and returns a JSON readiness packet. It intentionally does not require provider credentials or model calls.
+The preset mounts the plugins at their canonical slugs, uses WordPress `7.0` by default, activates the plugins in dependency order, and returns a JSON readiness packet. It intentionally does not require provider credentials or model calls.

--- a/examples/recipes/simple-plugin.json
+++ b/examples/recipes/simple-plugin.json
@@ -3,7 +3,7 @@
   "runtime": {
     "backend": "wordpress-playground",
     "name": "simple-plugin-lab",
-    "wp": "latest"
+    "wp": "7.0"
   },
   "inputs": {
     "mounts": [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,6 +97,8 @@ const defaultPolicy: RuntimePolicy = {
   approvals: "never",
 }
 
+const DEFAULT_WORDPRESS_VERSION = "7.0"
+
 const secretEnvPolicy: RuntimePolicy = {
   ...defaultPolicy,
   secrets: "connector-scoped",
@@ -202,7 +204,7 @@ async function agentRuntimeProbeRunOptions(options: AgentRuntimeProbeOptions): P
     mounts: agentRuntimeMounts(options),
     command: "wordpress.run-php",
     args: [`code=${agentRuntimeProbeCode(providerPluginMounts(options))}`],
-    wpVersion: options.wpVersion ?? "trunk",
+    wpVersion: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
     artifactsDirectory: options.artifactsDirectory,
     ...await runSecretEnvOptions(options),
     json: options.json,
@@ -214,7 +216,7 @@ async function agentSandboxRunOptions(options: AgentSandboxRunOptions): Promise<
     mounts: agentRuntimeMounts(options),
     command: "wordpress.run-php",
     args: [`code=${agentSandboxRunCode(options.task, await resolveSandboxTaskCode(options), providerPluginMounts(options))}`],
-    wpVersion: options.wpVersion ?? "trunk",
+    wpVersion: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
     artifactsDirectory: options.artifactsDirectory,
     ...await runSecretEnvOptions(options),
     json: options.json,
@@ -261,7 +263,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         environment: {
           kind: "wordpress",
           name: recipe.runtime?.name ?? "wp-codebox-recipe",
-          version: recipe.runtime?.wp ?? "latest",
+          version: recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION,
           blueprint: recipe.runtime?.blueprint ?? { steps: [] },
         },
         policy: Object.keys(secretEnv).length > 0 ? { ...policy, secrets: "connector-scoped" } : policy,
@@ -600,7 +602,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
         environment: {
           kind: "wordpress",
           name: "wp-codebox-cli",
-          version: options.wpVersion ?? "latest",
+          version: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
           blueprint: { steps: [] },
         },
         policy: options.policy ?? defaultPolicy,
@@ -889,7 +891,7 @@ Options:
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
   --arg <key=value>    Command argument. Repeatable.
-  --wp <version>       WordPress version for Playground, e.g. latest, trunk, nightly, 6.9.
+  --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --artifacts <dir>    Artifact root directory.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --json               Emit machine-readable JSON.


### PR DESCRIPTION
## Summary
- Default generic wp-codebox Playground runs, recipes, and agent presets to WordPress 7.0.
- Keep explicit \\`--wp\\` and recipe \\`runtime.wp\\` overrides intact for callers that need another runtime.
- Update docs and the sample recipe to describe the 7.0 default.

## Validation
- \\`npm run build\\`
- \\`npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code='<?php echo get_bloginfo(\"version\"); ?>' --json\\` returned \\`7.0-RC4\\` without passing \\`--wp\\`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the runtime default/version flow, drafting the small code/docs change, and running local validation. Chris directed the requirement and remains responsible for review.