### PR TITLE
Add Data Machine bundle recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Recipe shape:
     "wp": "latest"
   },
   "inputs": {
+    "extra_plugins": [
+      {
+        "source": "../../../woocommerce",
+        "slug": "woocommerce",
+        "pluginFile": "woocommerce/woocommerce.php"
+      }
+    ],
     "mounts": [
       {
         "source": "../simple-plugin",
@@ -118,7 +125,44 @@ Recipe shape:
 }
 ```
 
-The first recipe schema intentionally maps to existing runtime primitives: WordPress version, mounted inputs, allow-listed environment variable names, workflow steps, and artifact directory. Relative mount paths resolve from the recipe file location. Workflow commands are used as the runtime command allow-list for that run.
+The first recipe schema intentionally maps to existing runtime primitives: WordPress version, mounted inputs, extra WordPress plugins, allow-listed environment variable names, workflow steps, and artifact directory. Relative mount paths and `extra_plugins` sources resolve from the recipe file location. Workflow commands are used as the runtime command allow-list for that run.
+
+`extra_plugins` mounts local plugin checkouts into `/wordpress/wp-content/plugins/<slug>` and activates them before the workflow steps run. This lets recipes add WooCommerce, Data Machine, provider plugins, test helpers, or experimental runtime extensions without adding product-specific code to WP Codebox. `pluginFile` defaults to `<slug>/<slug>.php`; set it when the plugin entrypoint differs.
+
+The Data Machine bundle example installs sibling `agents-api` and `data-machine` checkouts through `extra_plugins`, then mounts a small bundle directory that follows the same `manifest.json`, `memory/agent`, `pipelines`, and `flows` layout used by World of WordPress and WP Site Generator bundles:
+
+```bash
+npm run wp-codebox -- recipe-run \
+  --recipe ./examples/recipes/datamachine-agent-bundle.json \
+  --json
+```
+
+That recipe imports `examples/datamachine-bundle/world-creator-lite` inside the disposable Playground runtime through Data Machine's `datamachine/import-agent` ability. It proves the bundle shape without Homeboy in the path; Homeboy, Data Machine Code, wp-gym, or another controller can all consume the resulting WP Codebox artifact bundle.
+
+To run a different Data Machine-compatible bundle, change the bundle mount source while keeping the target path stable:
+
+```json
+{
+  "source": "../../../world-of-wordpress/bundles/world-creator",
+  "target": "/wordpress/wp-content/wp-codebox-inputs/datamachine-bundle",
+  "mode": "readwrite"
+}
+```
+
+Agent runtime awareness remains a bundle concern. A `wordpress_native_agent` can keep Data Machine's default context/directive behavior and know it is operating inside WordPress. A `blind_agent` can use Data Machine's `agent_config.directive_policy` to suppress runtime context before prompts are assembled, for example:
+
+```json
+{
+  "agent_config": {
+    "directive_policy": {
+      "mode": "allow_only",
+      "allow_only": []
+    }
+  }
+}
+```
+
+That keeps WP Codebox generic: the recipe defines the runtime ingredients, while the imported agent bundle decides whether the model should see WordPress/Data Machine context.
 
 ## Artifact Bundles
 

--- a/examples/datamachine-bundle/world-creator-lite/flows/world-creator-lite-cycle-flow.json
+++ b/examples/datamachine-bundle/world-creator-lite/flows/world-creator-lite-cycle-flow.json
@@ -1,0 +1,27 @@
+{
+  "max_items": [],
+  "name": "World Creator Lite Cycle",
+  "pipeline_slug": "world-creator-lite-pipeline",
+  "schedule": "manual",
+  "schema_version": 1,
+  "slug": "world-creator-lite-cycle-flow",
+  "steps": [
+    {
+      "agent_modes": ["pipeline", "world"],
+      "enabled_tools": ["agent_memory", "agent_daily_memory"],
+      "handler_configs": {},
+      "completion_assertions": {
+        "required_tool_names": ["agent_memory"]
+      },
+      "prompt_queue": [
+        {
+          "added_at": "2026-05-19T00:00:00Z",
+          "prompt": "Inspect your memory and describe one small next step for the sandbox world."
+        }
+      ],
+      "queue_mode": "static",
+      "step_position": 0,
+      "step_type": "ai"
+    }
+  ]
+}

--- a/examples/datamachine-bundle/world-creator-lite/manifest.json
+++ b/examples/datamachine-bundle/world-creator-lite/manifest.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "bundle_slug": "world-creator-lite",
+  "bundle_version": "0.1.0",
+  "source_ref": "chubes4/wp-codebox/examples/datamachine-bundle/world-creator-lite",
+  "source_revision": "example",
+  "exported_at": "2026-05-19T00:00:00Z",
+  "exported_by": "WP Codebox",
+  "agent": {
+    "slug": "world-creator-lite",
+    "label": "World Creator Lite",
+    "description": "Small Data Machine agent bundle fixture based on the World of WordPress bundle directory shape.",
+    "agent_config": {
+      "default_provider": "openai",
+      "default_model": "gpt-5.5",
+      "max_turns": 3,
+      "daily_memory": {
+        "enabled": true,
+        "recent_days": 7
+      }
+    }
+  },
+  "run_artifacts": {
+    "daily_memory": {
+      "egress": ["bundle-file"],
+      "bundle_relative_path": "memory/agent/daily/{yyyy}/{mm}/{dd}.md"
+    },
+    "transcript_summary": {
+      "egress": ["artifact"]
+    }
+  },
+  "included": {
+    "memory": ["MEMORY.md", "SOUL.md"],
+    "pipelines": ["world-creator-lite-pipeline"],
+    "flows": ["world-creator-lite-cycle-flow"],
+    "prompts": [],
+    "rubrics": [],
+    "tool_policies": [],
+    "auth_refs": [],
+    "seed_queues": [],
+    "handler_auth": "refs"
+  }
+}

--- a/examples/datamachine-bundle/world-creator-lite/memory/agent/MEMORY.md
+++ b/examples/datamachine-bundle/world-creator-lite/memory/agent/MEMORY.md
@@ -1,0 +1,3 @@
+# Agent Memory - World Creator Lite
+
+This fixture keeps memory intentionally small so WP Codebox recipe runs can prove Data Machine bundle import mechanics without invoking a model.

--- a/examples/datamachine-bundle/world-creator-lite/memory/agent/SOUL.md
+++ b/examples/datamachine-bundle/world-creator-lite/memory/agent/SOUL.md
@@ -1,0 +1,3 @@
+# Agent Soul - World Creator Lite
+
+You are a tiny sandbox-safe world creator used to verify Data Machine bundle imports in WP Codebox.

--- a/examples/datamachine-bundle/world-creator-lite/pipelines/world-creator-lite-pipeline.json
+++ b/examples/datamachine-bundle/world-creator-lite/pipelines/world-creator-lite-pipeline.json
@@ -1,0 +1,18 @@
+{
+  "name": "World Creator Lite Pipeline",
+  "schema_version": 1,
+  "slug": "world-creator-lite-pipeline",
+  "steps": [
+    {
+      "step_config": {
+        "agent_modes": ["pipeline", "world"],
+        "execution_order": 0,
+        "label": "Run World Creator Lite",
+        "step_type": "ai",
+        "system_prompt": "Use the injected memory to summarize what the sandbox world needs next. Keep the response brief."
+      },
+      "step_position": 0,
+      "step_type": "ai"
+    }
+  ]
+}

--- a/examples/datamachine/import-agent-bundle.php
+++ b/examples/datamachine/import-agent-bundle.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Import a mounted Data Machine agent bundle inside a WP Codebox sandbox.
+ */
+
+$bundle_path = getenv( 'WP_CODEBOX_DATAMACHINE_BUNDLE' ) ?: '/wordpress/wp-content/wp-codebox-inputs/datamachine-bundle';
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+add_filter( 'datamachine_should_load_full_runtime', '__return_true' );
+
+foreach ( array( 'agents-api/agents-api.php', 'data-machine/data-machine.php' ) as $plugin ) {
+	$plugin_file = WP_PLUGIN_DIR . '/' . $plugin;
+	if ( ! file_exists( $plugin_file ) ) {
+		throw new RuntimeException( sprintf( 'Required plugin is not mounted: %s', $plugin ) );
+	}
+
+	if ( ! is_plugin_active( $plugin ) ) {
+		$result = activate_plugin( $plugin );
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException( $result->get_error_message() );
+		}
+	}
+}
+
+if ( function_exists( 'datamachine_run_datamachine_plugin' ) ) {
+	datamachine_run_datamachine_plugin();
+}
+
+wp_set_current_user( 1 );
+
+if ( ! function_exists( 'wp_get_ability' ) ) {
+	throw new RuntimeException( 'The WordPress Abilities API is not available in this runtime.' );
+}
+
+$ability = wp_get_ability( 'datamachine/import-agent' );
+if ( ! $ability ) {
+	throw new RuntimeException( 'The datamachine/import-agent ability is not registered.' );
+}
+
+$result = $ability->execute(
+	array(
+		'source'      => $bundle_path,
+		'on_conflict' => 'upgrade',
+		'owner_id'    => 1,
+	)
+);
+
+if ( is_wp_error( $result ) ) {
+	throw new RuntimeException( $result->get_error_message() );
+}
+
+echo wp_json_encode(
+	array(
+		'command'     => 'import-datamachine-agent-bundle',
+		'bundle_path' => $bundle_path,
+		'result'      => $result,
+	),
+	JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+);

--- a/examples/recipes/datamachine-agent-bundle.json
+++ b/examples/recipes/datamachine-agent-bundle.json
@@ -1,0 +1,42 @@
+{
+  "schema": "wp-codebox/workspace-recipe/v1",
+  "runtime": {
+    "backend": "wordpress-playground",
+    "name": "datamachine-agent-bundle-lab",
+    "wp": "trunk"
+  },
+  "inputs": {
+    "extra_plugins": [
+      {
+        "source": "../../../agents-api",
+        "slug": "agents-api",
+        "pluginFile": "agents-api/agents-api.php"
+      },
+      {
+        "source": "../../../data-machine",
+        "slug": "data-machine",
+        "pluginFile": "data-machine/data-machine.php"
+      }
+    ],
+    "mounts": [
+      {
+        "source": "../datamachine-bundle/world-creator-lite",
+        "target": "/wordpress/wp-content/wp-codebox-inputs/datamachine-bundle",
+        "mode": "readwrite"
+      }
+    ]
+  },
+  "workflow": {
+    "steps": [
+      {
+        "command": "wordpress.run-php",
+        "args": [
+          "code-file=./examples/datamachine/import-agent-bundle.php"
+        ]
+      }
+    ]
+  },
+  "artifacts": {
+    "directory": "./artifacts"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises"
 import { basename, dirname, resolve } from "node:path"
-import { createRuntime, type ArtifactBundle, type ExecutionResult, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe } from "@chubes4/wp-codebox-core"
+import { createRuntime, type ArtifactBundle, type ExecutionResult, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 interface RunOptions {
@@ -271,6 +271,16 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       createPlaygroundRuntimeBackend(),
     )
 
+    for (const plugin of recipeExtraPlugins(recipe)) {
+      const slug = recipeExtraPluginSlug(plugin)
+      await runtime.mount({
+        type: "directory",
+        source: resolve(recipeDirectory, plugin.source),
+        target: `/wordpress/wp-content/plugins/${slug}`,
+        mode: "readonly",
+      })
+    }
+
     for (const mount of recipe.inputs?.mounts ?? []) {
       await runtime.mount({
         type: "directory",
@@ -278,6 +288,11 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         target: mount.target,
         mode: mount.mode ?? "readwrite",
       })
+    }
+
+    const pluginActivationCode = activateExtraPluginsCode(recipe)
+    if (pluginActivationCode) {
+      executions.push(await runtime.execute({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }))
     }
 
     for (const step of recipe.workflow.steps) {
@@ -777,14 +792,75 @@ function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe 
     }
   }
 
+  const rawExtraPlugins = recipe.inputs?.extra_plugins ?? recipe.inputs?.extraPlugins
+  if (rawExtraPlugins && !Array.isArray(rawExtraPlugins)) {
+    throw new Error(`Recipe extra_plugins must be an array: ${recipePath}`)
+  }
+
+  for (const plugin of recipeExtraPlugins(recipe)) {
+    if (!plugin.source) {
+      throw new Error(`Recipe extra_plugins entries must include source: ${recipePath}`)
+    }
+
+    if (plugin.slug && !/^[a-z0-9][a-z0-9-_]*$/i.test(plugin.slug)) {
+      throw new Error(`Recipe extra_plugins slug must be a plugin-directory slug: ${recipePath}`)
+    }
+  }
+
   return recipe
 }
 
 function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
+  const commands = recipe.workflow.steps.map((step) => step.command)
+  if (recipeExtraPlugins(recipe).some((plugin) => plugin.activate !== false)) {
+    commands.unshift("wordpress.run-php")
+  }
+
   return {
     ...defaultPolicy,
-    commands: [...new Set(recipe.workflow.steps.map((step) => step.command))],
+    commands: [...new Set(commands)],
   }
+}
+
+function recipeExtraPlugins(recipe: WorkspaceRecipe): WorkspaceRecipeExtraPlugin[] {
+  return recipe.inputs?.extra_plugins ?? recipe.inputs?.extraPlugins ?? []
+}
+
+function recipeExtraPluginSlug(plugin: WorkspaceRecipeExtraPlugin): string {
+  return plugin.slug ?? basename(resolve(plugin.source))
+}
+
+function recipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin): string {
+  const slug = recipeExtraPluginSlug(plugin)
+  return plugin.pluginFile ?? `${slug}/${slug}.php`
+}
+
+function activateExtraPluginsCode(recipe: WorkspaceRecipe): string | null {
+  const pluginFiles = recipeExtraPlugins(recipe)
+    .filter((plugin) => plugin.activate !== false)
+    .map(recipeExtraPluginFile)
+
+  if (pluginFiles.length === 0) {
+    return null
+  }
+
+  return `require_once ABSPATH . 'wp-admin/includes/plugin.php';
+$plugins = ${JSON.stringify(pluginFiles)};
+$activated = array();
+foreach ($plugins as $plugin) {
+    $plugin_file = WP_PLUGIN_DIR . '/' . $plugin;
+    if (! file_exists($plugin_file)) {
+        throw new RuntimeException(sprintf('Recipe extra plugin is not mounted: %s', $plugin));
+    }
+    if (! is_plugin_active($plugin)) {
+        $result = activate_plugin($plugin);
+        if (is_wp_error($result)) {
+            throw new RuntimeException($result->get_error_message());
+        }
+    }
+    $activated[] = $plugin;
+}
+echo wp_json_encode(array('command' => 'activate-extra-plugins', 'plugins' => $activated), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
 }
 
 function parseMount(value: string): RunOptions["mounts"][number] {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -61,6 +61,13 @@ export interface WorkspaceRecipeStep {
   args?: string[]
 }
 
+export interface WorkspaceRecipeExtraPlugin {
+  source: string
+  slug?: string
+  pluginFile?: string
+  activate?: boolean
+}
+
 export interface WorkspaceRecipe {
   schema: "wp-codebox/workspace-recipe/v1"
   runtime?: {
@@ -71,6 +78,8 @@ export interface WorkspaceRecipe {
   }
   inputs?: {
     mounts?: WorkspaceRecipeMount[]
+    extra_plugins?: WorkspaceRecipeExtraPlugin[]
+    extraPlugins?: WorkspaceRecipeExtraPlugin[]
     secretEnv?: string[]
   }
   workflow: {


### PR DESCRIPTION
## Summary
- Add recipe-level `extra_plugins` support so WP Codebox recipes can mount and activate arbitrary WordPress plugin checkouts before workflow execution.
- Add a generic Data Machine agent bundle recipe that imports any mounted Data Machine-compatible bundle through `datamachine/import-agent`.
- Document bundle runtime-awareness choices, including Data Machine `directive_policy` for blind agents versus WordPress-native agents.

## Verification
- `npm run check`
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/datamachine-agent-bundle.json --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the recipe contract update, example bundle fixture, docs, and verification commands for Chris to review.