### PR TITLE
Add WP-CLI runtime command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ WP Codebox mounts the local plugin directory into WordPress Playground and boots
 
 `wordpress.run-php` accepts either `--arg code-file=<path>` or `--arg code=<php>`. It loads `/wordpress/wp-load.php` before running the supplied PHP so WordPress functions are available by default. Use `--arg bootstrap=none` for raw PHP execution without WordPress bootstrap.
 
+`wordpress.wp-cli` runs WP-CLI inside the same Playground runtime with `/tmp/wp-cli.phar` and `--path=/wordpress`. WP Codebox automatically enables Playground's `wp-cli` extra library when this command is allowed by the runtime policy. Pass commands with `--arg command='wp option get home'`; the leading `wp` is optional.
+
 WP Codebox defaults Playground to WordPress `7.0` because its agent and AI plugin stacks require the modern WordPress AI surface. Use `--wp trunk`, `--wp nightly`, or another numeric WordPress version when a mounted plugin stack needs a different runtime.
 
 The fixture plugin is documented in [`examples/simple-plugin/README.md`](examples/simple-plugin/README.md).
@@ -116,6 +118,10 @@ Recipe shape:
       {
         "command": "wordpress.run-php",
         "args": ["code-file=./examples/simple-plugin/probe.php"]
+      },
+      {
+        "command": "wordpress.wp-cli",
+        "args": ["command=wp option get home"]
       }
     ]
   },
@@ -126,6 +132,14 @@ Recipe shape:
 ```
 
 The first recipe schema intentionally maps to existing runtime primitives: WordPress version, mounted inputs, extra WordPress plugins, allow-listed environment variable names, workflow steps, and artifact directory. Relative mount paths and `extra_plugins` sources resolve from the recipe file location. Workflow commands are used as the runtime command allow-list for that run.
+
+The WP-CLI example proves command steps can mutate the same disposable WordPress runtime observed by later PHP steps:
+
+```bash
+npm run wp-codebox -- recipe-run \
+  --recipe ./examples/recipes/wp-cli.json \
+  --json
+```
 
 `extra_plugins` mounts local plugin checkouts into `/wordpress/wp-content/plugins/<slug>` and activates them before the workflow steps run. This lets recipes add WooCommerce, Data Machine, provider plugins, test helpers, or experimental runtime extensions without adding product-specific code to WP Codebox. `pluginFile` defaults to `<slug>/<slug>.php`; set it when the plugin entrypoint differs.
 

--- a/examples/recipes/wp-cli.json
+++ b/examples/recipes/wp-cli.json
@@ -1,0 +1,36 @@
+{
+  "schema": "wp-codebox/workspace-recipe/v1",
+  "runtime": {
+    "backend": "wordpress-playground",
+    "name": "wp-cli-lab",
+    "wp": "latest"
+  },
+  "inputs": {
+    "mounts": [
+      {
+        "source": "../simple-plugin",
+        "target": "/wordpress/wp-content/plugins/simple-plugin",
+        "mode": "readwrite"
+      }
+    ]
+  },
+  "workflow": {
+    "steps": [
+      {
+        "command": "wordpress.wp-cli",
+        "args": [
+          "command=wp option update wp_codebox_wp_cli_smoke ok"
+        ]
+      },
+      {
+        "command": "wordpress.run-php",
+        "args": [
+          "code=echo wp_json_encode(array('wp_cli_option' => get_option('wp_codebox_wp_cli_smoke')), JSON_PRETTY_PRINT);"
+        ]
+      }
+    ]
+  },
+  "artifacts": {
+    "directory": "./artifacts"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -620,7 +620,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
           version: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
           blueprint: { steps: [] },
         },
-        policy: options.policy ?? defaultPolicy,
+        policy: options.policy ?? runPolicy(options.command),
         secretEnv: options.secretEnv,
         artifactsDirectory: options.artifactsDirectory,
       },
@@ -821,6 +821,13 @@ function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
   return {
     ...defaultPolicy,
     commands: [...new Set(commands)],
+  }
+}
+
+function runPolicy(command: string): RuntimePolicy {
+  return {
+    ...defaultPolicy,
+    commands: [...new Set([...defaultPolicy.commands, command])],
   }
 }
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -29,12 +29,15 @@ function id(prefix: string): string {
 }
 
 interface PlaygroundRunResponse {
+  exitCode?: number
+  errors?: string
   text: string
 }
 
 interface PlaygroundCliServer {
   playground: {
-    run(options: { code: string }): Promise<PlaygroundRunResponse>
+    run(options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse>
+    writeFile?(path: string, contents: string): Promise<void>
   }
   [Symbol.asyncDispose](): Promise<void>
 }
@@ -329,6 +332,7 @@ class PlaygroundRuntime implements Runtime {
 
     return {
       $schema: "https://playground.wordpress.net/blueprint-schema.json",
+      ...(baseBlueprint.extraLibraries ? { extraLibraries: baseBlueprint.extraLibraries } : {}),
       ...(preferredVersions ? { preferredVersions } : {}),
       landingPage: baseBlueprint.landingPage ?? "/",
       steps: [...baseBlueprint.steps, ...replaySteps],
@@ -514,6 +518,10 @@ class PlaygroundRuntime implements Runtime {
       return this.runPhp(spec)
     }
 
+    if (spec.command === "wordpress.wp-cli") {
+      return this.runWpCli(spec)
+    }
+
     throw new Error(`No Playground command handler is registered for: ${spec.command}`)
   }
 
@@ -523,6 +531,32 @@ class PlaygroundRuntime implements Runtime {
     const response = await server.playground.run({ code: this.bootstrapPhpCode(code, spec.args ?? []) })
 
     return response.text
+  }
+
+  private async runWpCli(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const command = wpCliCommandFromArgs(spec.args ?? [])
+    const argv = shellArgv(command)
+    if (argv[0] === "wp") {
+      argv.shift()
+    }
+
+    if (argv.length === 0) {
+      throw new Error("wordpress.wp-cli requires a non-empty command")
+    }
+
+    if (!server.playground.writeFile) {
+      throw new Error("wordpress.wp-cli requires a Playground backend with writeFile support")
+    }
+
+    const scriptPath = `/tmp/wp-codebox-wp-cli-${this.commands.length}.php`
+    await server.playground.writeFile(scriptPath, wpCliPhpScript(argv))
+    const response = await server.playground.run({ scriptPath })
+    if (typeof response.exitCode === "number" && response.exitCode !== 0) {
+      throw new Error(response.errors || `wordpress.wp-cli failed with exit code ${response.exitCode}`)
+    }
+
+    return cleanWpCliOutput(response.text)
   }
 
   private bootstrapPhpCode(code: string, args: string[]): string {
@@ -607,7 +641,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
         vfsPath: mount.target,
       })),
       wp: this.spec.environment.version,
-      blueprint: this.spec.environment.blueprint,
+      blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy),
     })
   }
 
@@ -632,7 +666,7 @@ function fileEntry(path: string, kind: ArtifactManifestFile["kind"], contentType
   return { path, kind, contentType }
 }
 
-function normalizeBlueprint(blueprint: unknown): { landingPage?: unknown; preferredVersions?: unknown; steps: unknown[] } {
+function normalizeBlueprint(blueprint: unknown): { extraLibraries?: unknown; landingPage?: unknown; preferredVersions?: unknown; steps: unknown[] } {
   if (!blueprint || typeof blueprint !== "object" || Array.isArray(blueprint)) {
     return { steps: [] }
   }
@@ -641,10 +675,94 @@ function normalizeBlueprint(blueprint: unknown): { landingPage?: unknown; prefer
   const steps = Array.isArray(candidate.steps) ? candidate.steps : []
 
   return {
+    extraLibraries: candidate.extraLibraries,
     landingPage: candidate.landingPage,
     preferredVersions: candidate.preferredVersions,
     steps,
   }
+}
+
+function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpec["policy"]): unknown {
+  if (!policy.commands.includes("wordpress.wp-cli")) {
+    return blueprint
+  }
+
+  const base = !blueprint || typeof blueprint !== "object" || Array.isArray(blueprint) ? {} : blueprint as Record<string, unknown>
+  const extraLibraries = Array.isArray(base.extraLibraries) ? base.extraLibraries : []
+
+  return {
+    ...base,
+    extraLibraries: [...new Set([...extraLibraries, "wp-cli"])],
+  }
+}
+
+function wpCliCommandFromArgs(args: string[]): string {
+  const explicit = argValue(args, "command")
+  if (explicit) {
+    return explicit.trim()
+  }
+
+  return args.join(" ").trim()
+}
+
+function shellArgv(command: string): string[] {
+  const args: string[] = []
+  let current = ""
+  let quote = ""
+
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index]
+    if (!quote && /\s/.test(char)) {
+      if (current) {
+        args.push(current)
+        current = ""
+      }
+      continue
+    }
+
+    if ((char === "'" || char === '"') && (!quote || quote === char)) {
+      quote = quote ? "" : char
+      continue
+    }
+
+    if (char === "\\" && index + 1 < command.length) {
+      current += command[++index]
+      continue
+    }
+
+    current += char
+  }
+
+  if (quote) {
+    throw new Error("Unclosed quote in wordpress.wp-cli command")
+  }
+
+  if (current) {
+    args.push(current)
+  }
+
+  return args
+}
+
+function wpCliPhpScript(argv: string[]): string {
+  return `<?php
+putenv('SHELL_PIPE=0');
+$GLOBALS['argv'] = array_merge(array('/tmp/wp-cli.phar', '--path=/wordpress', '--no-color'), json_decode(${JSON.stringify(JSON.stringify(argv))}, true));
+if (!defined('STDIN')) {
+    define('STDIN', fopen('php://stdin', 'rb'));
+}
+if (!defined('STDOUT')) {
+    define('STDOUT', fopen('php://stdout', 'wb'));
+}
+if (!defined('STDERR')) {
+    define('STDERR', fopen('php://stderr', 'wb'));
+}
+require '/tmp/wp-cli.phar';
+`
+}
+
+function cleanWpCliOutput(output: string): string {
+  return output.replace(/^#!\/usr\/bin\/env php\r?\n/, "")
 }
 
 function preferredVersionsForEnvironment(


### PR DESCRIPTION
## Summary
- Add `wordpress.wp-cli` as a first-class WP Codebox Playground command that runs `/tmp/wp-cli.phar` with `--path=/wordpress` inside the sandbox.
- Automatically enables Playground's `wp-cli` extra library when the runtime policy allows `wordpress.wp-cli`.
- Add a WP-CLI recipe proving a CLI step can mutate the same disposable WordPress runtime observed by a later PHP step.

## Verification
- `npm run build`
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/wp-cli.json --json`
- `npm run check`
- `npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.wp-cli --arg 'command=wp option get home' --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WP-CLI runtime command implementation, recipe smoke, docs, and verification commands for Chris to review.