### PR TITLE
Add seeded recipe workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Recipe shape:
     "wp": "7.0"
   },
   "inputs": {
+    "workspaces": [
+      {
+        "seed": {
+          "type": "plugin_scaffold",
+          "slug": "seeded-helper",
+          "name": "Seeded Helper"
+        }
+      }
+    ],
     "extra_plugins": [
       {
         "source": "../../../woocommerce",
@@ -131,7 +140,23 @@ Recipe shape:
 }
 ```
 
-The first recipe schema intentionally maps to existing runtime primitives: WordPress version, mounted inputs, extra WordPress plugins, allow-listed environment variable names, workflow steps, and artifact directory. Relative mount paths and `extra_plugins` sources resolve from the recipe file location. Workflow commands are used as the runtime command allow-list for that run.
+The first recipe schema intentionally maps to existing runtime primitives: WordPress version, seeded workspaces, mounted inputs, extra WordPress plugins, allow-listed environment variable names, workflow steps, and artifact directory. Relative mount paths, directory workspace seeds, and `extra_plugins` sources resolve from the recipe file location. Workflow commands are used as the runtime command allow-list for that run.
+
+`workspaces` create disposable readwrite directories before Playground boots and mount them into WordPress. Scaffold seeds start from a minimal plugin or theme; directory seeds copy an existing checkout or fixture into the disposable workspace. WP Codebox captures readwrite workspace files into the artifact bundle after workflow steps mutate them.
+
+Supported workspace seeds:
+
+- `plugin_scaffold`: creates `<slug>.php` and `README.md`, mounted by default at `/wordpress/wp-content/plugins/<slug>`.
+- `theme_scaffold`: creates `style.css`, `index.php`, and `README.md`, mounted by default at `/wordpress/wp-content/themes/<slug>`.
+- `directory`: copies `seed.source` into a disposable workspace and requires an explicit `target`.
+
+The seeded plugin example proves a scaffold can be activated, mutated, and captured as an artifact:
+
+```bash
+npm run wp-codebox -- recipe-run \
+  --recipe ./examples/recipes/seeded-plugin-workspace.json \
+  --json
+```
 
 The WP-CLI example proves command steps can mutate the same disposable WordPress runtime observed by later PHP steps:
 

--- a/examples/recipes/seeded-plugin-workspace.json
+++ b/examples/recipes/seeded-plugin-workspace.json
@@ -1,0 +1,38 @@
+{
+  "schema": "wp-codebox/workspace-recipe/v1",
+  "runtime": {
+    "backend": "wordpress-playground",
+    "name": "seeded-plugin-workspace-lab",
+    "wp": "latest"
+  },
+  "inputs": {
+    "workspaces": [
+      {
+        "seed": {
+          "type": "plugin_scaffold",
+          "slug": "seeded-helper",
+          "name": "Seeded Helper"
+        }
+      }
+    ]
+  },
+  "workflow": {
+    "steps": [
+      {
+        "command": "wordpress.wp-cli",
+        "args": [
+          "command=wp plugin activate seeded-helper"
+        ]
+      },
+      {
+        "command": "wordpress.run-php",
+        "args": [
+          "code=require_once ABSPATH . 'wp-admin/includes/plugin.php'; file_put_contents(WP_PLUGIN_DIR . '/seeded-helper/generated.txt', 'cooked'); echo wp_json_encode(array('active' => is_plugin_active('seeded-helper/seeded-helper.php'), 'generated' => file_exists(WP_PLUGIN_DIR . '/seeded-helper/generated.txt')), JSON_PRETTY_PRINT);"
+        ]
+      }
+    ]
+  },
+  "artifacts": {
+    "directory": "./artifacts"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises"
-import { basename, dirname, resolve } from "node:path"
-import { createRuntime, type ArtifactBundle, type ExecutionResult, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin } from "@chubes4/wp-codebox-core"
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { basename, dirname, join, resolve } from "node:path"
+import { createRuntime, type ArtifactBundle, type ExecutionResult, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 interface RunOptions {
@@ -43,6 +44,12 @@ interface RecipeRunOutput {
   artifacts?: ArtifactBundle
   logs?: string[]
   error?: RunOutput["error"]
+}
+
+interface PreparedWorkspaceMount {
+  source: string
+  target: string
+  mode: "readonly" | "readwrite"
 }
 
 interface AgentRuntimeProbeOptions {
@@ -252,6 +259,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
   const recipe = parseWorkspaceRecipe(await readFile(recipePath, "utf8"), recipePath)
   const policy = recipePolicy(recipe)
   const secretEnv = resolveSecretEnv(recipe.inputs?.secretEnv ?? [])
+  const workspaceMounts = await prepareRecipeWorkspaces(recipe, recipeDirectory)
   let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
   const executions: ExecutionResult[] = []
   let artifacts: ArtifactBundle | undefined
@@ -272,6 +280,15 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       },
       createPlaygroundRuntimeBackend(),
     )
+
+    for (const workspace of workspaceMounts) {
+      await runtime.mount({
+        type: "directory",
+        source: workspace.source,
+        target: workspace.target,
+        mode: workspace.mode,
+      })
+    }
 
     for (const plugin of recipeExtraPlugins(recipe)) {
       const slug = recipeExtraPluginSlug(plugin)
@@ -305,6 +322,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
     await runtime.observe({ type: "mounts" })
     artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true })
     await runtime.destroy()
+    await cleanupRecipeWorkspaces(workspaceMounts)
 
     return {
       success: true,
@@ -328,6 +346,8 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         // Preserve the original failure as the CLI result.
       }
     }
+
+    await cleanupRecipeWorkspaces(workspaceMounts)
 
     return {
       success: false,
@@ -794,6 +814,33 @@ function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe 
     }
   }
 
+  const workspaces = recipe.inputs?.workspaces ?? []
+  if (!Array.isArray(workspaces)) {
+    throw new Error(`Recipe workspaces must be an array: ${recipePath}`)
+  }
+
+  for (const workspace of workspaces) {
+    if (!workspace.seed || typeof workspace.seed !== "object") {
+      throw new Error(`Recipe workspaces entries must include a seed object: ${recipePath}`)
+    }
+
+    if (!["plugin_scaffold", "theme_scaffold", "directory"].includes(workspace.seed.type)) {
+      throw new Error(`Recipe workspace seed type is unsupported: ${recipePath}`)
+    }
+
+    if ((workspace.seed.type === "plugin_scaffold" || workspace.seed.type === "theme_scaffold") && !workspace.seed.slug) {
+      throw new Error(`Recipe ${workspace.seed.type} workspace seeds require slug: ${recipePath}`)
+    }
+
+    if (workspace.seed.type === "directory" && !workspace.seed.source) {
+      throw new Error(`Recipe directory workspace seeds require source: ${recipePath}`)
+    }
+
+    if (workspace.mode && workspace.mode !== "readonly" && workspace.mode !== "readwrite") {
+      throw new Error(`Recipe workspace mode must be readonly or readwrite: ${recipePath}`)
+    }
+  }
+
   const rawExtraPlugins = recipe.inputs?.extra_plugins ?? recipe.inputs?.extraPlugins
   if (rawExtraPlugins && !Array.isArray(rawExtraPlugins)) {
     throw new Error(`Recipe extra_plugins must be an array: ${recipePath}`)
@@ -829,6 +876,100 @@ function runPolicy(command: string): RuntimePolicy {
     ...defaultPolicy,
     commands: [...new Set([...defaultPolicy.commands, command])],
   }
+}
+
+async function prepareRecipeWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedWorkspaceMount[]> {
+  const workspaces = recipe.inputs?.workspaces ?? []
+  const mounts: PreparedWorkspaceMount[] = []
+  for (const [index, workspace] of workspaces.entries()) {
+    const slug = workspace.seed.slug ?? basename(resolve(recipeDirectory, workspace.seed.source ?? `workspace-${index}`))
+    const source = await prepareRecipeWorkspace(workspace, recipeDirectory, slug)
+    mounts.push({
+      source,
+      target: workspace.target ?? defaultWorkspaceTarget(workspace, slug),
+      mode: workspace.mode ?? "readwrite",
+    })
+  }
+
+  return mounts
+}
+
+async function cleanupRecipeWorkspaces(workspaces: PreparedWorkspaceMount[]): Promise<void> {
+  await Promise.all(workspaces.map((workspace) => rm(workspace.source, { recursive: true, force: true })))
+}
+
+async function prepareRecipeWorkspace(workspace: WorkspaceRecipeWorkspace, recipeDirectory: string, slug: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), `wp-codebox-${slug}-`))
+  if (workspace.seed.type === "directory") {
+    await cp(resolve(recipeDirectory, workspace.seed.source ?? ""), directory, { recursive: true })
+    return directory
+  }
+
+  if (workspace.seed.type === "theme_scaffold") {
+    await writeThemeScaffold(directory, slug, workspace.seed.name ?? titleFromSlug(slug))
+    return directory
+  }
+
+  await writePluginScaffold(directory, slug, workspace.seed.name ?? titleFromSlug(slug))
+  return directory
+}
+
+function defaultWorkspaceTarget(workspace: WorkspaceRecipeWorkspace, slug: string): string {
+  if (workspace.seed.type === "theme_scaffold") {
+    return `/wordpress/wp-content/themes/${slug}`
+  }
+
+  if (workspace.seed.type === "plugin_scaffold") {
+    return `/wordpress/wp-content/plugins/${slug}`
+  }
+
+  if (workspace.target) {
+    return workspace.target
+  }
+
+  throw new Error("Directory workspace seeds require an explicit target")
+}
+
+async function writePluginScaffold(directory: string, slug: string, name: string): Promise<void> {
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, `${slug}.php`), `<?php
+/**
+ * Plugin Name: ${name}
+ * Description: WP Codebox seeded plugin workspace.
+ * Version: 0.1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'init', static function (): void {
+	do_action( '${slug.replace(/-/g, "_")}_loaded' );
+} );
+`)
+  await writeFile(join(directory, "README.md"), `# ${name}
+
+Seeded by WP Codebox.
+`)
+}
+
+async function writeThemeScaffold(directory: string, slug: string, name: string): Promise<void> {
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, "style.css"), `/*
+Theme Name: ${name}
+Description: WP Codebox seeded theme workspace.
+Version: 0.1.0
+*/
+`)
+  await writeFile(join(directory, "index.php"), `<?php
+?><main id="site-content"><h1><?php bloginfo( 'name' ); ?></h1></main>
+`)
+  await writeFile(join(directory, "README.md"), `# ${name}
+
+Seeded by WP Codebox.
+`)
+}
+
+function titleFromSlug(slug: string): string {
+  return slug.split(/[-_]+/).filter(Boolean).map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`).join(" ")
 }
 
 function recipeExtraPlugins(recipe: WorkspaceRecipe): WorkspaceRecipeExtraPlugin[] {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -68,6 +68,21 @@ export interface WorkspaceRecipeExtraPlugin {
   activate?: boolean
 }
 
+export type WorkspaceRecipeSeedType = "plugin_scaffold" | "theme_scaffold" | "directory"
+
+export interface WorkspaceRecipeWorkspaceSeed {
+  type: WorkspaceRecipeSeedType
+  slug?: string
+  name?: string
+  source?: string
+}
+
+export interface WorkspaceRecipeWorkspace {
+  target?: string
+  mode?: "readonly" | "readwrite"
+  seed: WorkspaceRecipeWorkspaceSeed
+}
+
 export interface WorkspaceRecipe {
   schema: "wp-codebox/workspace-recipe/v1"
   runtime?: {
@@ -77,6 +92,7 @@ export interface WorkspaceRecipe {
     blueprint?: unknown
   }
   inputs?: {
+    workspaces?: WorkspaceRecipeWorkspace[]
     mounts?: WorkspaceRecipeMount[]
     extra_plugins?: WorkspaceRecipeExtraPlugin[]
     extraPlugins?: WorkspaceRecipeExtraPlugin[]


### PR DESCRIPTION
## Summary
- Add recipe-level `inputs.workspaces` for disposable seeded workspaces mounted readwrite into Playground.
- Support `plugin_scaffold`, `theme_scaffold`, and copied `directory` seeds so recipes can start from a scaffold or focused checkout fixture.
- Add a seeded plugin workspace recipe that activates the scaffold, mutates it, and captures the generated file in the artifact bundle.

## Verification
- `npm run build`
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/seeded-plugin-workspace.json --json`
- Confirmed `files/mounted-files.json` captured `generated.txt` from the seeded plugin workspace.
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/wp-cli.json --json`
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/datamachine-agent-bundle.json --json`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted seeded workspace schema, implementation, recipe smoke, docs, and verification commands for Chris to review.