### PR TITLE
Add recipe artifact metadata and workspace diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,13 @@ Current bundles include:
 - `logs/runtime.log`, `logs/commands.log`: human-readable logs.
 - `files/mounts.json`: mounted input list.
 - `files/mounted-files.json`: captured readwrite mount files with size, SHA-256, target path, and replayability metadata.
+- `files/diffs.json`: diff index for readwrite mounts that declare a baseline, such as seeded workspaces.
+- `files/diffs/<mount>.patch`: unified text diff from the workspace seed to the cooked output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
 For text files from readwrite mounts, `blueprint.after.json` includes `writeFile` steps so the files can be replayed into a fresh WordPress Playground runtime. Binary files and oversized files are copied into the artifact bundle but are not embedded in the blueprint yet. Database exports, option diffs, uploads, active theme/plugin state, and screenshots are planned capture targets.
+
+Recipe runs also embed a `context.recipe` summary in `metadata.json` so artifacts remain self-describing after the sandbox is destroyed. Seeded workspaces include baseline metadata and emit patch files that show what changed from the scaffold or copied directory seed.
 
 `blueprint.after.json` is backend-specific. It matters when the output should replay in WordPress Playground. Non-WordPress outputs still use the generic artifact contract: manifest, metadata, copied files, hashes, event streams, command logs, observations, patches, and future generic replay recipes.
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,14 @@ interface PreparedWorkspaceMount {
   source: string
   target: string
   mode: "readonly" | "readwrite"
+  cleanupPaths: string[]
+  metadata: Record<string, unknown>
+}
+
+interface PreparedWorkspaceSource {
+  source: string
+  baselineSource: string
+  cleanupPaths: string[]
 }
 
 interface AgentRuntimeProbeOptions {
@@ -277,6 +285,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         policy: Object.keys(secretEnv).length > 0 ? { ...policy, secrets: "connector-scoped" } : policy,
         secretEnv,
         artifactsDirectory: options.artifactsDirectory ?? recipe.artifacts?.directory,
+        metadata: recipeRunMetadata(recipe, recipePath, workspaceMounts),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -287,6 +296,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         source: workspace.source,
         target: workspace.target,
         mode: workspace.mode,
+        metadata: workspace.metadata,
       })
     }
 
@@ -878,16 +888,50 @@ function runPolicy(command: string): RuntimePolicy {
   }
 }
 
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[]): Record<string, unknown> {
+  return {
+    recipe: {
+      path: recipePath,
+      schema: recipe.schema,
+      runtime: recipe.runtime ?? {},
+      artifacts: recipe.artifacts ?? {},
+      workflow: {
+        steps: recipe.workflow.steps.map((step) => ({ command: step.command, args: step.args ?? [] })),
+      },
+      inputs: {
+        workspaces: recipe.inputs?.workspaces ?? [],
+        mounts: recipe.inputs?.mounts ?? [],
+        extra_plugins: recipeExtraPlugins(recipe),
+        secretEnv: recipe.inputs?.secretEnv ?? [],
+      },
+    },
+    preparedWorkspaces: workspaceMounts.map((workspace) => ({
+      target: workspace.target,
+      mode: workspace.mode,
+      metadata: workspace.metadata,
+    })),
+  }
+}
+
 async function prepareRecipeWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedWorkspaceMount[]> {
   const workspaces = recipe.inputs?.workspaces ?? []
   const mounts: PreparedWorkspaceMount[] = []
   for (const [index, workspace] of workspaces.entries()) {
     const slug = workspace.seed.slug ?? basename(resolve(recipeDirectory, workspace.seed.source ?? `workspace-${index}`))
-    const source = await prepareRecipeWorkspace(workspace, recipeDirectory, slug)
+    const prepared = await prepareRecipeWorkspace(workspace, recipeDirectory, slug)
+    const target = workspace.target ?? defaultWorkspaceTarget(workspace, slug)
     mounts.push({
-      source,
-      target: workspace.target ?? defaultWorkspaceTarget(workspace, slug),
+      source: prepared.source,
+      target,
       mode: workspace.mode ?? "readwrite",
+      cleanupPaths: prepared.cleanupPaths,
+      metadata: {
+        kind: "recipe-workspace",
+        index,
+        seed: workspace.seed,
+        baselineSource: prepared.baselineSource,
+        target,
+      },
     })
   }
 
@@ -895,23 +939,28 @@ async function prepareRecipeWorkspaces(recipe: WorkspaceRecipe, recipeDirectory:
 }
 
 async function cleanupRecipeWorkspaces(workspaces: PreparedWorkspaceMount[]): Promise<void> {
-  await Promise.all(workspaces.map((workspace) => rm(workspace.source, { recursive: true, force: true })))
+  await Promise.all(workspaces.flatMap((workspace) => workspace.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })))
 }
 
-async function prepareRecipeWorkspace(workspace: WorkspaceRecipeWorkspace, recipeDirectory: string, slug: string): Promise<string> {
+async function prepareRecipeWorkspace(workspace: WorkspaceRecipeWorkspace, recipeDirectory: string, slug: string): Promise<PreparedWorkspaceSource> {
   const directory = await mkdtemp(join(tmpdir(), `wp-codebox-${slug}-`))
+  const baselineDirectory = await mkdtemp(join(tmpdir(), `wp-codebox-${slug}-baseline-`))
   if (workspace.seed.type === "directory") {
-    await cp(resolve(recipeDirectory, workspace.seed.source ?? ""), directory, { recursive: true })
-    return directory
+    const source = resolve(recipeDirectory, workspace.seed.source ?? "")
+    await cp(source, directory, { recursive: true })
+    await cp(source, baselineDirectory, { recursive: true })
+    return { source: directory, baselineSource: baselineDirectory, cleanupPaths: [directory, baselineDirectory] }
   }
 
   if (workspace.seed.type === "theme_scaffold") {
     await writeThemeScaffold(directory, slug, workspace.seed.name ?? titleFromSlug(slug))
-    return directory
+    await writeThemeScaffold(baselineDirectory, slug, workspace.seed.name ?? titleFromSlug(slug))
+    return { source: directory, baselineSource: baselineDirectory, cleanupPaths: [directory, baselineDirectory] }
   }
 
   await writePluginScaffold(directory, slug, workspace.seed.name ?? titleFromSlug(slug))
-  return directory
+  await writePluginScaffold(baselineDirectory, slug, workspace.seed.name ?? titleFromSlug(slug))
+  return { source: directory, baselineSource: baselineDirectory, cleanupPaths: [directory, baselineDirectory] }
 }
 
 function defaultWorkspaceTarget(workspace: WorkspaceRecipeWorkspace, slug: string): string {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -48,6 +48,7 @@ export interface RuntimeCreateSpec {
   policy: RuntimePolicy
   artifactsDirectory?: string
   secretEnv?: Record<string, string>
+  metadata?: Record<string, unknown>
 }
 
 export interface WorkspaceRecipeMount {
@@ -119,6 +120,7 @@ export interface MountSpec {
   source: string
   target: string
   mode: "readonly" | "readwrite"
+  metadata?: Record<string, unknown>
 }
 
 export interface ExecutionSpec {
@@ -207,6 +209,7 @@ export interface ArtifactBundle {
   commandsLogPath: string
   mountsPath: string
   capturedMountsPath: string
+  diffsPath: string
   createdAt: string
 }
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -85,6 +85,15 @@ interface CapturedMountFiles {
   }
 }
 
+interface MountDiff {
+  mountIndex: number
+  source: string
+  target: string
+  baselineSource: string
+  artifactPath: string
+  changed: boolean
+}
+
 const MAX_CAPTURED_MOUNT_FILES = 200
 const MAX_CAPTURED_MOUNT_FILE_BYTES = 1024 * 1024
 const SKIPPED_CAPTURE_DIRECTORIES = new Set([".git", "node_modules"])
@@ -234,6 +243,7 @@ class PlaygroundRuntime implements Runtime {
     const commandsLogPath = join(logsDirectory, "commands.log")
     const mountsPath = join(filesDirectory, "mounts.json")
     const capturedMountsPath = join(filesDirectory, "mounted-files.json")
+    const diffsPath = join(filesDirectory, "diffs.json")
 
     this.recordEvent("runtime.artifacts.collected", {
       id: bundleId,
@@ -249,9 +259,11 @@ class PlaygroundRuntime implements Runtime {
       runtime,
       mounts: this.mounts,
       policy: this.spec.policy,
+      context: this.spec.metadata ?? {},
       spec,
     }
     const capturedMounts = await this.captureMountedFiles(filesDirectory)
+    const mountDiffs = await this.captureMountDiffs(filesDirectory)
     const blueprintAfter = this.buildBlueprintAfter(capturedMounts)
     const blueprintAfterNotes = this.buildBlueprintAfterNotes(createdAt, capturedMounts)
 
@@ -267,6 +279,8 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(commandsLogPath, "log", "text/plain"),
       fileEntry(mountsPath, "mounts", "application/json"),
       fileEntry(capturedMountsPath, "mounted-files", "application/json"),
+      fileEntry(diffsPath, "mount-diffs", "application/json"),
+      ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
         fileEntry(join(this.artifactRoot, file.artifactPath), "file", file.contentType),
       ),
@@ -296,6 +310,7 @@ class PlaygroundRuntime implements Runtime {
     await writeFile(commandsLogPath, this.formatCommandsLog())
     await writeFile(mountsPath, `${JSON.stringify(this.mounts, null, 2)}\n`)
     await writeFile(capturedMountsPath, `${JSON.stringify(serializeCapturedMountFiles(capturedMounts), null, 2)}\n`)
+    await writeFile(diffsPath, `${JSON.stringify(mountDiffs, null, 2)}\n`)
 
     return {
       id: bundleId,
@@ -311,6 +326,7 @@ class PlaygroundRuntime implements Runtime {
       commandsLogPath,
       mountsPath,
       capturedMountsPath,
+      diffsPath,
       createdAt,
     }
   }
@@ -392,6 +408,33 @@ class PlaygroundRuntime implements Runtime {
     }
 
     return captured
+  }
+
+  private async captureMountDiffs(filesDirectory: string): Promise<MountDiff[]> {
+    const diffsDirectory = join(filesDirectory, "diffs")
+    await mkdir(diffsDirectory, { recursive: true })
+    const diffs: MountDiff[] = []
+
+    for (const [mountIndex, mount] of this.mounts.entries()) {
+      const baselineSource = typeof mount.metadata?.baselineSource === "string" ? mount.metadata.baselineSource : ""
+      if (mount.mode !== "readwrite" || !baselineSource) {
+        continue
+      }
+
+      const patch = await directoryDiff(baselineSource, mount.source, mount.target)
+      const artifactPath = `files/diffs/mount-${mountIndex}.patch`
+      await writeFile(join(this.artifactRoot, artifactPath), patch)
+      diffs.push({
+        mountIndex,
+        source: mount.source,
+        target: mount.target,
+        baselineSource,
+        artifactPath,
+        changed: patch.trim().length > 0,
+      })
+    }
+
+    return diffs
   }
 
   private async captureMountedDirectory(
@@ -801,6 +844,82 @@ function serializeCapturedMountFiles(captured: CapturedMountFiles): CapturedMoun
 
 async function writeJsonLines(path: string, records: unknown[]): Promise<void> {
   await writeFile(path, records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : "")
+}
+
+async function directoryDiff(baselineDirectory: string, currentDirectory: string, targetPrefix: string): Promise<string> {
+  const [baselineFiles, currentFiles] = await Promise.all([
+    listTextFiles(baselineDirectory),
+    listTextFiles(currentDirectory),
+  ])
+  const paths = [...new Set([...baselineFiles.keys(), ...currentFiles.keys()])].sort()
+  const patches: string[] = []
+
+  for (const relativePath of paths) {
+    const before = baselineFiles.get(relativePath)
+    const after = currentFiles.get(relativePath)
+    if (before === after) {
+      continue
+    }
+
+    patches.push(fileDiff(`${targetPrefix}/${relativePath}`, before ?? "", after ?? "", before === undefined, after === undefined))
+  }
+
+  return patches.join("\n")
+}
+
+async function listTextFiles(directory: string, prefix = ""): Promise<Map<string, string>> {
+  const files = new Map<string, string>()
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (SKIPPED_CAPTURE_DIRECTORIES.has(entry.name)) {
+      continue
+    }
+
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
+    const fullPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      for (const [path, contents] of await listTextFiles(fullPath, relativePath)) {
+        files.set(path, contents)
+      }
+      continue
+    }
+
+    if (!entry.isFile()) {
+      continue
+    }
+
+    const buffer = await readFile(fullPath)
+    const text = buffer.toString("utf8")
+    if (isReplayableText(buffer, text)) {
+      files.set(relativePath, text)
+    }
+  }
+
+  return files
+}
+
+function fileDiff(path: string, before: string, after: string, isAdded: boolean, isDeleted: boolean): string {
+  const beforeLines = splitLines(before)
+  const afterLines = splitLines(after)
+  const oldPath = isAdded ? "/dev/null" : `a${path}`
+  const newPath = isDeleted ? "/dev/null" : `b${path}`
+  const lines = [
+    `diff --git ${oldPath} ${newPath}`,
+    `--- ${oldPath}`,
+    `+++ ${newPath}`,
+    `@@ -1,${beforeLines.length} +1,${afterLines.length} @@`,
+    ...beforeLines.map((line) => `-${line}`),
+    ...afterLines.map((line) => `+${line}`),
+  ]
+
+  return `${lines.join("\n")}\n`
+}
+
+function splitLines(text: string): string[] {
+  if (text.length === 0) {
+    return []
+  }
+
+  return text.replace(/\n$/, "").split("\n")
 }
 
 function argValue(args: string[], name: string): string | undefined {


### PR DESCRIPTION
## Summary
- Embed recipe context in artifact `metadata.json` so bundles remain self-describing after sandbox teardown.
- Carry seeded workspace baseline metadata through mounts and emit `files/diffs.json` plus per-mount patch files for review.
- Document diff artifacts in the artifact bundle contract.

## Verification
- `npm run build`
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/seeded-plugin-workspace.json --json`
- Confirmed seeded artifact includes `files/diffs.json` and `files/diffs/mount-0.patch` showing `generated.txt` added.
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/wp-cli.json --json`
- `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/datamachine-agent-bundle.json --json`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted artifact metadata plumbing, seeded workspace diff generation, docs, and verification commands for Chris to review.