### PR TITLE
Keep task ability free of raw code

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Useful options:
 - `--session-id <id>`: continue an existing sandbox conversation session.
 - `--max-turns <n>`: bound the agent loop.
 
-`--code` and `--code-file` still exist for operator/debug use after the agent stack boots. Product-facing task APIs should treat natural-language `--task` as the stable input shape and keep raw code execution gated away from untrusted frontend callers.
+`--code` and `--code-file` still exist on the CLI for operator/debug use after the agent stack boots. They are not accepted by the parent-site `wp-codebox/run-agent-task` ability.
 
 ### `agent-sandbox-batch`
 
@@ -227,6 +227,8 @@ The WordPress plugin registers parent-site abilities:
 - `wp-codebox/run-agent-task-batch`
 
 These abilities shell out to the local `wp-codebox` CLI, boot disposable Playground sandboxes, mount the configured agent stack, invoke the sandbox agent through `agents/chat`, and return artifact metadata.
+
+`wp-codebox/run-agent-task` accepts task-shaped inputs only. It rejects raw `code` and `code_file` fields so frontend/chat callers cannot pass arbitrary PHP through the product ability path. Operators can still use CLI debug commands directly when they need raw PHP probes.
 
 Component paths can come from ability input, the `wp_codebox_component_paths` option, or the `wp_codebox_component_paths` filter.
 
@@ -287,7 +289,6 @@ WP Codebox does not own:
 
 ## Near-Term Gaps
 
-- Split raw operator/debug PHP execution away from product-facing task APIs.
 - Define canonical `patch.diff`, `changed-files.json`, content-addressed artifact IDs, and redaction guarantees.
 - Add list/get/discard/apply-approved artifact abilities to the WordPress plugin.
 - Define multi-user sandbox session lifecycle, retention, quotas, cancellation, and audit records.

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -74,14 +74,6 @@ final class WP_Codebox_Abilities {
 								'type'        => 'integer',
 								'description' => 'Maximum agent loop turns for this sandbox task.',
 							),
-							'code'                   => array(
-								'type'        => 'string',
-								'description' => 'Optional PHP code body to execute after the sandbox agent stack boots.',
-							),
-							'code_file'              => array(
-								'type'        => 'string',
-								'description' => 'Optional PHP file to execute after the sandbox agent stack boots.',
-							),
 							'wp'                     => array(
 								'type'        => 'string',
 								'description' => 'WordPress version passed to Playground. Defaults to trunk.',

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -38,15 +38,14 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return new WP_Error( 'wp_codebox_task_missing', 'task is required.', array( 'status' => 400 ) );
 		}
 
+		$raw_code_input = $this->reject_raw_code_input( $input );
+		if ( is_wp_error( $raw_code_input ) ) {
+			return $raw_code_input;
+		}
+
 		$paths = $this->resolve_component_paths( $input );
 		if ( is_wp_error( $paths ) ) {
 			return $paths;
-		}
-
-		$code      = trim( (string) ( $input['code'] ?? '' ) );
-		$code_file = $this->clean_path( (string) ( $input['code_file'] ?? '' ) );
-		if ( '' !== $code && '' !== $code_file ) {
-			return new WP_Error( 'wp_codebox_code_conflict', 'Use either code or code_file, not both.', array( 'status' => 400 ) );
 		}
 
 		$artifacts = $this->clean_path( (string) ( $input['artifacts_path'] ?? $this->default_artifacts_path() ) );
@@ -85,14 +84,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		if ( ! empty( $input['max_turns'] ) ) {
 			$command .= ' --max-turns ' . escapeshellarg( (string) max( 1, (int) $input['max_turns'] ) );
-		}
-
-		if ( '' !== $code ) {
-			$command .= ' --code ' . escapeshellarg( $code );
-		}
-
-		if ( '' !== $code_file ) {
-			$command .= ' --code-file ' . escapeshellarg( $code_file );
 		}
 
 		foreach ( $this->secret_env_names( $input ) as $secret_env ) {
@@ -292,6 +283,31 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return function_exists( 'exec' ) && function_exists( 'shell_exec' );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return true|WP_Error */
+	private function reject_raw_code_input( array $input ): true|WP_Error {
+		foreach ( array( 'code', 'code_file' ) as $field ) {
+			if ( ! array_key_exists( $field, $input ) ) {
+				continue;
+			}
+
+			$value = $input[ $field ];
+			if ( null === $value || '' === trim( (string) $value ) ) {
+				continue;
+			}
+
+			return new WP_Error(
+				'wp_codebox_raw_code_forbidden',
+				'Raw PHP code inputs are not accepted by wp-codebox/run-agent-task. Use the operator CLI debug path for raw PHP execution.',
+				array(
+					'status' => 400,
+					'field'  => $field,
+				)
+			);
+		}
+
+		return true;
 	}
 
 	private function agent_slug( array $input ): string {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -71,6 +71,7 @@ $ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-agent-tas
 $assert( 'run-agent-task ability registered', is_array( $ability ) );
 $assert( 'ability is REST visible', true === ( $ability['meta']['show_in_rest'] ?? false ) );
 $assert( 'ability requires task only', array( 'task' ) === ( $ability['input_schema']['required'] ?? array() ) );
+$assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
 $batch_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-agent-task-batch'] ?? null;
@@ -127,6 +128,25 @@ $assert( 'runner passes default provider', str_contains( $captured_command, '--p
 $assert( 'runner passes default model', str_contains( $captured_command, '--model' ) && str_contains( $captured_command, 'gpt-5.5' ) );
 $assert( 'runner passes provider plugin path', str_contains( $captured_command, '--provider-plugin' ) && str_contains( $captured_command, 'ai-provider-test' ) );
 $assert( 'runner passes secret env name only', str_contains( $captured_command, '--secret-env' ) && str_contains( $captured_command, 'OPENAI_API_KEY' ) );
+$assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
+
+$raw_code = $runner->run(
+	array(
+		'task'           => 'Run a chat-requested sandbox task.',
+		'artifacts_path' => $root . '/artifacts',
+		'code'           => '<?php echo "raw";',
+	)
+);
+$assert( 'raw code input fails closed', is_wp_error( $raw_code ) && 'wp_codebox_raw_code_forbidden' === $raw_code->get_error_code() );
+
+$raw_code_file = $runner->run(
+	array(
+		'task'           => 'Run a chat-requested sandbox task.',
+		'artifacts_path' => $root . '/artifacts',
+		'code_file'      => '/tmp/raw.php',
+	)
+);
+$assert( 'raw code file input fails closed', is_wp_error( $raw_code_file ) && 'wp_codebox_raw_code_forbidden' === $raw_code_file->get_error_code() );
 
 $batch_result = $runner->run_batch(
 	array(


### PR DESCRIPTION
## Summary
- Remove `code` and `code_file` from the parent-site `wp-codebox/run-agent-task` ability schema.
- Reject raw code fields in the host-side runner so callers cannot bypass schema validation.
- Keep raw PHP probing available through the CLI operator/debug path and document the boundary.

## Testing
- `npm run wordpress-plugin-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Implemented the task API boundary change, added smoke coverage, ran verification, and drafted this PR description for Chris to review.