### PR TITLE
Add canonical artifact outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Expected shape:
     "manifestPath": "./artifacts/runtime-.../manifest.json",
     "blueprintAfterPath": "./artifacts/runtime-.../blueprint.after.json",
     "capturedMountsPath": "./artifacts/runtime-.../files/mounted-files.json",
-    "diffsPath": "./artifacts/runtime-.../files/diffs.json"
+    "diffsPath": "./artifacts/runtime-.../files/diffs.json",
+    "changedFilesPath": "./artifacts/runtime-.../files/changed-files.json",
+    "patchPath": "./artifacts/runtime-.../files/patch.diff"
   }
 }
 ```
@@ -213,11 +215,15 @@ Current bundles include:
 - `logs/runtime.log`, `logs/commands.log`: human-readable logs.
 - `files/mounts.json`: mounted input list.
 - `files/mounted-files.json`: captured readwrite mount files with size, SHA-256, target path, and replayability metadata.
+- `files/changed-files.json`: canonical changed-files manifest for review and apply-back consumers.
+- `files/patch.diff`: canonical combined text patch for changed readwrite mounts that declare a baseline.
 - `files/diffs.json`: diff index for readwrite mounts that declare a baseline.
 - `files/diffs/<mount>.patch`: unified text diff from a seeded baseline to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
-Binary files and oversized files are copied when allowed by capture limits but are not embedded into `blueprint.after.json`. Database exports, option diffs, uploaded media, active plugin/theme state, screenshots, normalized test results, and canonical apply-back patch metadata are still future artifact targets.
+`metadata.json` points to the canonical changed-files, patch, and mount-diff artifact paths under `artifacts`. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
+
+Binary files and oversized files are copied when allowed by capture limits but are not embedded into `blueprint.after.json`. Database exports, option diffs, uploaded media, active plugin/theme state, screenshots, normalized test results, content-addressed artifact IDs, and redaction guarantees are still future artifact targets.
 
 ## WordPress Plugin
 
@@ -289,7 +295,7 @@ WP Codebox does not own:
 
 ## Near-Term Gaps
 
-- Define canonical `patch.diff`, `changed-files.json`, content-addressed artifact IDs, and redaction guarantees.
+- Define content-addressed artifact IDs and redaction guarantees.
 - Add list/get/discard/apply-approved artifact abilities to the WordPress plugin.
 - Define multi-user sandbox session lifecycle, retention, quotas, cancellation, and audit records.
 - Define reviewed apply-back adapters for bot-authored PRs, direct apply, and package export.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "build": "tsc -b packages/runtime-core packages/runtime-playground packages/cli",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
+    "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run artifact-contract-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -210,6 +210,8 @@ export interface ArtifactBundle {
   mountsPath: string
   capturedMountsPath: string
   diffsPath: string
+  changedFilesPath: string
+  patchPath: string
   createdAt: string
 }
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -96,6 +96,31 @@ interface MountDiff {
   changed: boolean
 }
 
+interface ChangedFile {
+  path: string
+  status: "added" | "modified" | "deleted"
+  mountIndex: number
+  mountTarget: string
+  relativePath: string
+  patchPath: string
+}
+
+interface CanonicalChangedFiles {
+  schema: "wp-codebox/changed-files/v1"
+  files: ChangedFile[]
+}
+
+interface DirectoryDiffResult {
+  patch: string
+  files: Omit<ChangedFile, "mountIndex" | "mountTarget" | "patchPath">[]
+}
+
+interface MountDiffsResult {
+  mountDiffs: MountDiff[]
+  changedFiles: CanonicalChangedFiles
+  patch: string
+}
+
 const MAX_CAPTURED_MOUNT_FILES = 200
 const MAX_CAPTURED_MOUNT_FILE_BYTES = 1024 * 1024
 const SKIPPED_CAPTURE_DIRECTORIES = new Set([".git", "node_modules"])
@@ -246,6 +271,8 @@ class PlaygroundRuntime implements Runtime {
     const mountsPath = join(filesDirectory, "mounts.json")
     const capturedMountsPath = join(filesDirectory, "mounted-files.json")
     const diffsPath = join(filesDirectory, "diffs.json")
+    const changedFilesPath = join(filesDirectory, "changed-files.json")
+    const patchPath = join(filesDirectory, "patch.diff")
 
     this.recordEvent("runtime.artifacts.collected", {
       id: bundleId,
@@ -255,7 +282,7 @@ class PlaygroundRuntime implements Runtime {
     })
 
     const runtime = await this.info()
-    const metadata = {
+    const metadata: Record<string, unknown> = {
       id: bundleId,
       createdAt,
       runtime,
@@ -265,7 +292,13 @@ class PlaygroundRuntime implements Runtime {
       spec,
     }
     const capturedMounts = await this.captureMountedFiles(filesDirectory)
-    const mountDiffs = await this.captureMountDiffs(filesDirectory)
+    const { mountDiffs, changedFiles, patch } = await this.captureMountDiffs(filesDirectory)
+    const artifactFiles = {
+      changedFiles: relative(this.artifactRoot, changedFilesPath),
+      patch: relative(this.artifactRoot, patchPath),
+      mountDiffs: relative(this.artifactRoot, diffsPath),
+    }
+    metadata.artifacts = artifactFiles
     const blueprintAfter = this.buildBlueprintAfter(capturedMounts)
     const blueprintAfterNotes = this.buildBlueprintAfterNotes(createdAt, capturedMounts)
 
@@ -282,6 +315,8 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(mountsPath, "mounts", "application/json"),
       fileEntry(capturedMountsPath, "mounted-files", "application/json"),
       fileEntry(diffsPath, "mount-diffs", "application/json"),
+      fileEntry(changedFilesPath, "changed-files", "application/json"),
+      fileEntry(patchPath, "patch", "text/x-diff"),
       ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
         fileEntry(join(this.artifactRoot, file.artifactPath), "file", file.contentType),
@@ -313,6 +348,8 @@ class PlaygroundRuntime implements Runtime {
     await writeFile(mountsPath, `${JSON.stringify(this.mounts, null, 2)}\n`)
     await writeFile(capturedMountsPath, `${JSON.stringify(serializeCapturedMountFiles(capturedMounts), null, 2)}\n`)
     await writeFile(diffsPath, `${JSON.stringify(mountDiffs, null, 2)}\n`)
+    await writeFile(changedFilesPath, `${JSON.stringify(changedFiles, null, 2)}\n`)
+    await writeFile(patchPath, patch)
 
     return {
       id: bundleId,
@@ -329,6 +366,8 @@ class PlaygroundRuntime implements Runtime {
       mountsPath,
       capturedMountsPath,
       diffsPath,
+      changedFilesPath,
+      patchPath,
       createdAt,
     }
   }
@@ -412,10 +451,12 @@ class PlaygroundRuntime implements Runtime {
     return captured
   }
 
-  private async captureMountDiffs(filesDirectory: string): Promise<MountDiff[]> {
+  private async captureMountDiffs(filesDirectory: string): Promise<MountDiffsResult> {
     const diffsDirectory = join(filesDirectory, "diffs")
     await mkdir(diffsDirectory, { recursive: true })
     const diffs: MountDiff[] = []
+    const changedFiles: ChangedFile[] = []
+    const patches: string[] = []
 
     for (const [mountIndex, mount] of this.mounts.entries()) {
       const baselineSource = typeof mount.metadata?.baselineSource === "string" ? mount.metadata.baselineSource : ""
@@ -423,20 +464,36 @@ class PlaygroundRuntime implements Runtime {
         continue
       }
 
-      const patch = await directoryDiff(baselineSource, mount.source, mount.target)
+      const diff = await directoryDiff(baselineSource, mount.source, mount.target)
       const artifactPath = `files/diffs/mount-${mountIndex}.patch`
-      await writeFile(join(this.artifactRoot, artifactPath), patch)
+      await writeFile(join(this.artifactRoot, artifactPath), diff.patch)
       diffs.push({
         mountIndex,
         source: mount.source,
         target: mount.target,
         baselineSource,
         artifactPath,
-        changed: patch.trim().length > 0,
+        changed: diff.patch.trim().length > 0,
       })
+      patches.push(diff.patch)
+      changedFiles.push(
+        ...diff.files.map((file) => ({
+          ...file,
+          mountIndex,
+          mountTarget: mount.target,
+          patchPath: artifactPath,
+        })),
+      )
     }
 
-    return diffs
+    return {
+      mountDiffs: diffs,
+      changedFiles: {
+        schema: "wp-codebox/changed-files/v1",
+        files: changedFiles,
+      },
+      patch: patches.filter((patch) => patch.length > 0).join("\n"),
+    }
   }
 
   private async captureMountedDirectory(
@@ -758,13 +815,14 @@ async function writeJsonLines(path: string, records: unknown[]): Promise<void> {
   await writeFile(path, records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : "")
 }
 
-async function directoryDiff(baselineDirectory: string, currentDirectory: string, targetPrefix: string): Promise<string> {
+async function directoryDiff(baselineDirectory: string, currentDirectory: string, targetPrefix: string): Promise<DirectoryDiffResult> {
   const [baselineFiles, currentFiles] = await Promise.all([
     listTextFiles(baselineDirectory),
     listTextFiles(currentDirectory),
   ])
   const paths = [...new Set([...baselineFiles.keys(), ...currentFiles.keys()])].sort()
   const patches: string[] = []
+  const files: DirectoryDiffResult["files"] = []
 
   for (const relativePath of paths) {
     const before = baselineFiles.get(relativePath)
@@ -773,10 +831,19 @@ async function directoryDiff(baselineDirectory: string, currentDirectory: string
       continue
     }
 
-    patches.push(fileDiff(`${targetPrefix}/${relativePath}`, before ?? "", after ?? "", before === undefined, after === undefined))
+    const path = `${targetPrefix}/${relativePath}`
+    patches.push(fileDiff(path, before ?? "", after ?? "", before === undefined, after === undefined))
+    files.push({
+      path,
+      relativePath,
+      status: before === undefined ? "added" : after === undefined ? "deleted" : "modified",
+    })
   }
 
-  return patches.join("\n")
+  return {
+    patch: patches.join("\n"),
+    files,
+  }
 }
 
 async function listTextFiles(directory: string, prefix = ""): Promise<Map<string, string>> {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-artifacts-"))
+
+try {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "packages/cli/dist/index.js",
+      "recipe-run",
+      "--recipe",
+      "./examples/recipes/seeded-plugin-workspace.json",
+      "--artifacts",
+      artifactsDirectory,
+      "--json",
+    ],
+    {
+      cwd: resolve(import.meta.dirname, ".."),
+      maxBuffer: 1024 * 1024 * 10,
+    },
+  )
+  const output = JSON.parse(stdout)
+  assert.equal(output.success, true)
+
+  const artifacts = output.artifacts
+  assert.ok(artifacts.changedFilesPath, "artifact bundle should expose changedFilesPath")
+  assert.ok(artifacts.patchPath, "artifact bundle should expose patchPath")
+
+  const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
+  const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8"))
+  const changedFiles = JSON.parse(await readFile(artifacts.changedFilesPath, "utf8"))
+  const patch = await readFile(artifacts.patchPath, "utf8")
+
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/changed-files.json" && file.kind === "changed-files"))
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/patch.diff" && file.kind === "patch"))
+  assert.deepEqual(metadata.artifacts, {
+    changedFiles: "files/changed-files.json",
+    patch: "files/patch.diff",
+    mountDiffs: "files/diffs.json",
+  })
+  assert.equal(changedFiles.schema, "wp-codebox/changed-files/v1")
+  assert.ok(
+    changedFiles.files.some((file: { path: string; status: string }) =>
+      file.path === "/wordpress/wp-content/plugins/seeded-helper/generated.txt" && file.status === "added",
+    ),
+  )
+  assert.match(patch, /generated\.txt/)
+  assert.match(patch, /\+cooked/)
+
+  console.log("Artifact contract smoke passed")
+} finally {
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Add canonical `files/changed-files.json` and `files/patch.diff` outputs to artifact bundles.
- Expose the new artifact paths through `ArtifactBundle`, manifest entries, and metadata.
- Add a smoke test that runs the seeded plugin recipe and verifies the artifact contract.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the TypeScript implementation, smoke coverage, README updates, and local verification steps for Chris to review.