### PR TITLE
Add artifact apply-back contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ The WordPress plugin registers parent-site abilities:
 
 - `wp-codebox/run-agent-task`
 - `wp-codebox/run-agent-task-batch`
+- `wp-codebox/list-artifacts`
+- `wp-codebox/get-artifact`
+- `wp-codebox/discard-artifact`
+- `wp-codebox/apply-approved-artifact`
 
 These abilities shell out to the local `wp-codebox` CLI, boot disposable Playground sandboxes, mount the configured agent stack, invoke the sandbox agent through `agents/chat`, and return artifact metadata.
 
@@ -249,7 +253,7 @@ The CLI binary can come from ability input, the `wp_codebox_bin` option, or the 
 
 Data Machine Code is a mounted coding-tools component inside the sandbox. It provides workspace/file/GitHub tools to the sandboxed agent. WP Codebox owns the parent-site ability surface, sandbox lifecycle, and artifact capture boundary.
 
-Apply-back is intentionally not part of `run-agent-task`. Sandbox execution returns proposed outputs and evidence. Applying those outputs to a real site, opening a PR, exporting a package, approving files, or discarding artifacts should use separate reviewed abilities and policy.
+Apply-back is intentionally not part of `run-agent-task`. Sandbox execution returns proposed outputs and evidence. `list-artifacts`, `get-artifact`, and `discard-artifact` manage captured artifact bundles under the configured artifact root. `apply-approved-artifact` validates `artifact_id` plus an explicit `approved_files[]` list against canonical `changed-files.json`, reads the exact `patch.diff` the reviewer approved, and delegates to the `wp_codebox_apply_approved_artifact` filter. PR creation, direct deploy, package export, and bot identity policy live in adapters behind that reviewed boundary.
 
 ## Runtime Policy
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -26,6 +26,17 @@ final class WP_Codebox_Abilities {
 
 	private function register(): void {
 		$register_callback = function (): void {
+			$artifact_id_schema = array(
+				'artifact_id'    => array(
+					'type'        => 'string',
+					'description' => 'Artifact bundle id from manifest.json.',
+				),
+				'artifacts_path' => array(
+					'type'        => 'string',
+					'description' => 'Root directory containing WP Codebox artifact bundles.',
+				),
+			);
+
 			wp_register_ability(
 				'wp-codebox/run-agent-task',
 				array(
@@ -168,6 +179,92 @@ final class WP_Codebox_Abilities {
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
+
+			wp_register_ability(
+				'wp-codebox/list-artifacts',
+				array(
+					'label'               => 'List WP Codebox Artifacts',
+					'description'         => 'List artifact bundles under the configured WP Codebox artifact root.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'artifacts_path' => $artifact_id_schema['artifacts_path'],
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'list_artifacts' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/get-artifact',
+				array(
+					'label'               => 'Get WP Codebox Artifact',
+					'description'         => 'Read one WP Codebox artifact bundle by id.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'artifact_id' ),
+						'properties' => $artifact_id_schema,
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'get_artifact' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/discard-artifact',
+				array(
+					'label'               => 'Discard WP Codebox Artifact',
+					'description'         => 'Delete one WP Codebox artifact bundle from the configured artifact root.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'artifact_id' ),
+						'properties' => $artifact_id_schema,
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'discard_artifact' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/apply-approved-artifact',
+				array(
+					'label'               => 'Apply Approved WP Codebox Artifact',
+					'description'         => 'Validate an approved canonical artifact patch and hand it to the configured apply-back adapter.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'artifact_id', 'approved_files' ),
+						'properties' => array_merge(
+							$artifact_id_schema,
+							array(
+								'approved_files' => array(
+									'type'        => 'array',
+									'description' => 'Explicit sandbox file paths approved by the parent-site reviewer.',
+									'items'       => array( 'type' => 'string' ),
+								),
+								'approver'       => array(
+									'type'        => 'string',
+									'description' => 'Parent-site approver principal for audit records.',
+								),
+							)
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'apply_approved_artifact' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
 		};
 
 		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
@@ -186,6 +283,26 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function run_agent_task_batch( array $input ): array|WP_Error {
 		return ( new WP_Codebox_Agent_Sandbox_Runner() )->run_batch( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function list_artifacts( array $input = array() ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->list( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function get_artifact( array $input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->get( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function discard_artifact( array $input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->discard( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function apply_approved_artifact( array $input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->apply_approved( $input );
 	}
 
 	public static function can_run_agent_task(): bool {

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Parent-site WP Codebox artifact store and apply contract.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Artifacts {
+
+	private const LIST_SCHEMA  = 'wp-codebox/artifact-list/v1';
+	private const GET_SCHEMA   = 'wp-codebox/artifact/v1';
+	private const APPLY_SCHEMA = 'wp-codebox/artifact-apply/v1';
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function list( array $input = array() ): array|WP_Error {
+		$root = $this->artifact_root( $input );
+		if ( is_wp_error( $root ) ) {
+			return $root;
+		}
+
+		$bundles = array();
+		foreach ( $this->find_manifest_paths( $root ) as $manifest_path ) {
+			$bundle = $this->read_bundle_at_manifest( $manifest_path, false );
+			if ( ! is_wp_error( $bundle ) ) {
+				$bundles[] = $bundle;
+			}
+		}
+
+		usort(
+			$bundles,
+			static fn( array $a, array $b ): int => strcmp( (string) ( $b['created_at'] ?? '' ), (string) ( $a['created_at'] ?? '' ) )
+		);
+
+		return array(
+			'success'   => true,
+			'schema'    => self::LIST_SCHEMA,
+			'root'      => $root,
+			'artifacts' => $bundles,
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function get( array $input ): array|WP_Error {
+		$bundle = $this->resolve_bundle( $input );
+		if ( is_wp_error( $bundle ) ) {
+			return $bundle;
+		}
+
+		return array(
+			'success'  => true,
+			'schema'   => self::GET_SCHEMA,
+			'artifact' => $bundle,
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function discard( array $input ): array|WP_Error {
+		$bundle = $this->resolve_bundle( $input );
+		if ( is_wp_error( $bundle ) ) {
+			return $bundle;
+		}
+
+		$directory = (string) $bundle['directory'];
+		$root      = $this->artifact_root( $input );
+		if ( is_wp_error( $root ) ) {
+			return $root;
+		}
+
+		if ( ! $this->path_is_inside( $directory, $root ) ) {
+			return new WP_Error( 'wp_codebox_artifact_outside_root', 'Artifact directory is outside the configured artifact root.', array( 'status' => 400 ) );
+		}
+
+		$this->remove_directory( $directory );
+
+		return array(
+			'success'     => true,
+			'schema'      => self::GET_SCHEMA,
+			'artifact_id' => (string) $bundle['id'],
+			'discarded'   => true,
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function apply_approved( array $input ): array|WP_Error {
+		$bundle = $this->resolve_bundle( $input );
+		if ( is_wp_error( $bundle ) ) {
+			return $bundle;
+		}
+
+		$approved_files = $this->approved_files( $input );
+		if ( empty( $approved_files ) ) {
+			return new WP_Error( 'wp_codebox_approved_files_missing', 'approved_files must include at least one sandbox path.', array( 'status' => 400 ) );
+		}
+
+		$changed_files = $bundle['changed_files']['files'] ?? array();
+		if ( ! is_array( $changed_files ) ) {
+			return new WP_Error( 'wp_codebox_changed_files_invalid', 'Artifact changed-files payload is invalid.', array( 'status' => 400 ) );
+		}
+
+		$changed_paths = array_values(
+			array_filter(
+				array_map(
+					static fn( $file ): string => is_array( $file ) ? (string) ( $file['path'] ?? '' ) : '',
+					$changed_files
+				)
+			)
+		);
+
+		$unknown_files = array_values( array_diff( $approved_files, $changed_paths ) );
+		if ( ! empty( $unknown_files ) ) {
+			return new WP_Error(
+				'wp_codebox_approved_files_invalid',
+				'approved_files contains paths that are not present in changed-files.json.',
+				array(
+					'status' => 400,
+					'files'  => $unknown_files,
+				)
+			);
+		}
+
+		$patch_path = (string) ( $bundle['paths']['patch'] ?? '' );
+		$patch      = '' !== $patch_path && is_file( $patch_path ) ? file_get_contents( $patch_path ) : false;
+		if ( false === $patch || '' === trim( $patch ) ) {
+			return new WP_Error( 'wp_codebox_patch_missing', 'Artifact patch.diff is missing or empty.', array( 'status' => 400 ) );
+		}
+
+		$payload = array(
+			'artifact_id'    => (string) $bundle['id'],
+			'artifact'       => $bundle,
+			'approved_files' => $approved_files,
+			'approver'       => $input['approver'] ?? null,
+			'patch'          => $patch,
+			'patch_sha256'   => hash( 'sha256', $patch ),
+		);
+
+		$result = apply_filters( 'wp_codebox_apply_approved_artifact', null, $payload );
+		if ( null === $result ) {
+			return new WP_Error( 'wp_codebox_apply_adapter_missing', 'No apply-back adapter handled this approved artifact.', array( 'status' => 501 ) );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success'        => true,
+			'schema'         => self::APPLY_SCHEMA,
+			'artifact_id'    => (string) $bundle['id'],
+			'approved_files' => $approved_files,
+			'patch_sha256'   => $payload['patch_sha256'],
+			'result'         => $result,
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private function resolve_bundle( array $input ): array|WP_Error {
+		$artifact_id = trim( (string) ( $input['artifact_id'] ?? '' ) );
+		if ( '' === $artifact_id ) {
+			return new WP_Error( 'wp_codebox_artifact_id_missing', 'artifact_id is required.', array( 'status' => 400 ) );
+		}
+
+		$root = $this->artifact_root( $input );
+		if ( is_wp_error( $root ) ) {
+			return $root;
+		}
+
+		foreach ( $this->find_manifest_paths( $root ) as $manifest_path ) {
+			$bundle = $this->read_bundle_at_manifest( $manifest_path, true );
+			if ( ! is_wp_error( $bundle ) && $artifact_id === (string) $bundle['id'] ) {
+				return $bundle;
+			}
+		}
+
+		return new WP_Error( 'wp_codebox_artifact_not_found', 'Artifact bundle was not found under the configured artifact root.', array( 'status' => 404 ) );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return string|WP_Error */
+	private function artifact_root( array $input ): string|WP_Error {
+		$root = trim( (string) ( $input['artifacts_path'] ?? '' ) );
+		if ( '' === $root ) {
+			$base = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array( 'basedir' => sys_get_temp_dir() );
+			$root = is_array( $base ) && ! empty( $base['basedir'] ) ? (string) $base['basedir'] : sys_get_temp_dir();
+			$root = rtrim( $root, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . 'wp-codebox';
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$root = (string) apply_filters( 'wp_codebox_artifacts_root', $root, $input );
+		}
+
+		$real = realpath( $root );
+		if ( false === $real || ! is_dir( $real ) ) {
+			return new WP_Error( 'wp_codebox_artifacts_root_missing', 'Artifact root is missing or not a directory.', array( 'status' => 400 ) );
+		}
+
+		return rtrim( $real, DIRECTORY_SEPARATOR );
+	}
+
+	/** @return string[] */
+	private function find_manifest_paths( string $root ): array {
+		$paths = glob( $root . DIRECTORY_SEPARATOR . 'manifest.json' ) ?: array();
+		foreach ( glob( $root . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR . 'manifest.json' ) ?: array() as $path ) {
+			$paths[] = $path;
+		}
+		foreach ( glob( $root . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR . 'manifest.json' ) ?: array() as $path ) {
+			$paths[] = $path;
+		}
+
+		return array_values(
+			array_filter(
+				array_unique( $paths ),
+				fn( string $path ): bool => $this->path_is_inside( $path, $root )
+			)
+		);
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private function read_bundle_at_manifest( string $manifest_path, bool $include_contents ): array|WP_Error {
+		$directory = dirname( $manifest_path );
+		$manifest  = $this->read_json_file( $manifest_path );
+		if ( is_wp_error( $manifest ) ) {
+			return $manifest;
+		}
+
+		$id = trim( (string) ( $manifest['id'] ?? '' ) );
+		if ( '' === $id ) {
+			return new WP_Error( 'wp_codebox_manifest_invalid', 'Artifact manifest is missing an id.', array( 'status' => 400 ) );
+		}
+
+		$paths = array(
+			'manifest'      => $manifest_path,
+			'metadata'      => $this->resolve_artifact_file( $directory, 'metadata.json' ),
+			'changed_files' => $this->resolve_artifact_file( $directory, 'files/changed-files.json' ),
+			'patch'         => $this->resolve_artifact_file( $directory, 'files/patch.diff' ),
+		);
+
+		$bundle = array(
+			'id'                => $id,
+			'created_at'        => (string) ( $manifest['createdAt'] ?? '' ),
+			'directory'         => $directory,
+			'paths'             => $paths,
+			'has_patch'         => is_file( $paths['patch'] ),
+			'has_changed_files' => is_file( $paths['changed_files'] ),
+		);
+
+		if ( ! $include_contents ) {
+			return $bundle;
+		}
+
+		$metadata      = is_file( $paths['metadata'] ) ? $this->read_json_file( $paths['metadata'] ) : array();
+		$changed_files = is_file( $paths['changed_files'] ) ? $this->read_json_file( $paths['changed_files'] ) : array();
+		if ( is_wp_error( $metadata ) ) {
+			return $metadata;
+		}
+		if ( is_wp_error( $changed_files ) ) {
+			return $changed_files;
+		}
+
+		$bundle['manifest']      = $manifest;
+		$bundle['metadata']      = $metadata;
+		$bundle['changed_files'] = $changed_files;
+
+		return $bundle;
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private function read_json_file( string $path ): array|WP_Error {
+		$contents = is_file( $path ) ? file_get_contents( $path ) : false;
+		if ( false === $contents ) {
+			return new WP_Error( 'wp_codebox_artifact_file_missing', 'Artifact file is missing.', array( 'status' => 400, 'path' => $path ) );
+		}
+
+		$decoded = json_decode( $contents, true );
+		if ( ! is_array( $decoded ) ) {
+			return new WP_Error( 'wp_codebox_artifact_json_invalid', 'Artifact JSON could not be decoded.', array( 'status' => 400, 'path' => $path ) );
+		}
+
+		return $decoded;
+	}
+
+	private function resolve_artifact_file( string $directory, string $relative_path ): string {
+		$path = $directory . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $relative_path );
+		$real = realpath( $path );
+
+		return false !== $real ? $real : $path;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return string[] */
+	private function approved_files( array $input ): array {
+		$files = is_array( $input['approved_files'] ?? null ) ? $input['approved_files'] : array();
+
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map( static fn( $path ): string => trim( (string) $path ), $files ),
+					static fn( string $path ): bool => '' !== $path
+				)
+			)
+		);
+	}
+
+	private function path_is_inside( string $path, string $root ): bool {
+		$real_path = realpath( $path );
+		$real_root = realpath( $root );
+		if ( false === $real_path || false === $real_root ) {
+			return false;
+		}
+
+		return str_starts_with( $real_path . DIRECTORY_SEPARATOR, rtrim( $real_root, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR );
+	}
+
+	private function remove_directory( string $directory ): void {
+		foreach ( scandir( $directory ) ?: array() as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$path = $directory . DIRECTORY_SEPARATOR . $entry;
+			if ( is_dir( $path ) && ! is_link( $path ) ) {
+				$this->remove_directory( $path );
+				continue;
+			}
+
+			unlink( $path );
+		}
+
+		rmdir( $directory );
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -19,6 +19,7 @@ define( 'WP_CODEBOX_PLUGIN_VERSION', '0.1.0' );
 define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
+require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 
 add_action( 'plugins_loaded', static function (): void {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -38,10 +38,22 @@ function wp_register_ability( string $name, array $definition ): void {
 function doing_action( string $hook ): bool { return 'wp_abilities_api_init' === $hook; }
 function add_action( string $hook, callable $callback, int $priority = 10 ): void {}
 function current_user_can( string $capability ): bool { return 'manage_options' === $capability; }
-function apply_filters( string $hook, mixed $value ): mixed { return $GLOBALS['wp_codebox_filters'][ $hook ] ?? $value; }
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	if ( ! array_key_exists( $hook, $GLOBALS['wp_codebox_filters'] ) ) {
+		return $value;
+	}
+
+	$filter = $GLOBALS['wp_codebox_filters'][ $hook ];
+	if ( is_callable( $filter ) ) {
+		return $filter( $value, ...$args );
+	}
+
+	return $filter;
+}
 function get_option( string $name, mixed $default = null ): mixed { return $default; }
 
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
+require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
 
 $root = sys_get_temp_dir() . '/wp-codebox-wordpress-plugin-' . getmypid();
@@ -78,6 +90,18 @@ $batch_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-age
 $assert( 'run-agent-task-batch ability registered', is_array( $batch_ability ) );
 $assert( 'batch ability is REST visible', true === ( $batch_ability['meta']['show_in_rest'] ?? false ) );
 $assert( 'batch ability requires tasks', array( 'tasks' ) === ( $batch_ability['input_schema']['required'] ?? array() ) );
+
+$artifact_abilities = array(
+	'wp-codebox/list-artifacts',
+	'wp-codebox/get-artifact',
+	'wp-codebox/discard-artifact',
+	'wp-codebox/apply-approved-artifact',
+);
+foreach ( $artifact_abilities as $artifact_ability_name ) {
+	$artifact_ability = $GLOBALS['wp_codebox_registered_abilities'][ $artifact_ability_name ] ?? null;
+	$assert( $artifact_ability_name . ' ability registered', is_array( $artifact_ability ) );
+	$assert( $artifact_ability_name . ' is REST visible', true === ( $artifact_ability['meta']['show_in_rest'] ?? false ) );
+}
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] = array(
 	'agents_api'        => $root . '/agents-api',
@@ -171,6 +195,100 @@ $assert( 'missing task fails closed', is_wp_error( $missing_task ) && 'wp_codebo
 
 $missing_tasks = $runner->run_batch( array( 'artifacts_path' => $root . '/artifacts' ) );
 $assert( 'missing batch tasks fails closed', is_wp_error( $missing_tasks ) && 'wp_codebox_tasks_missing' === $missing_tasks->get_error_code() );
+
+$artifact_root = $root . '/artifact-store';
+$bundle_dir    = $artifact_root . '/runtime-test';
+mkdir( $bundle_dir . '/files', 0777, true );
+file_put_contents(
+	$bundle_dir . '/manifest.json',
+	json_encode(
+		array(
+			'id'        => 'artifact-bundle-test',
+			'createdAt' => '2026-05-19T00:00:00Z',
+			'files'     => array(
+				array(
+					'path'        => 'files/changed-files.json',
+					'kind'        => 'changed-files',
+					'contentType' => 'application/json',
+				),
+				array(
+					'path'        => 'files/patch.diff',
+					'kind'        => 'patch',
+					'contentType' => 'text/x-diff',
+				),
+			),
+		),
+		JSON_PRETTY_PRINT
+	) . "\n"
+);
+file_put_contents( $bundle_dir . '/metadata.json', json_encode( array( 'artifacts' => array( 'patch' => 'files/patch.diff' ) ), JSON_PRETTY_PRINT ) . "\n" );
+file_put_contents(
+	$bundle_dir . '/files/changed-files.json',
+	json_encode(
+		array(
+			'schema' => 'wp-codebox/changed-files/v1',
+			'files'  => array(
+				array(
+					'path'         => '/wordpress/wp-content/plugins/example/generated.txt',
+					'status'       => 'added',
+					'mountIndex'   => 0,
+					'mountTarget'  => '/wordpress/wp-content/plugins/example',
+					'relativePath' => 'generated.txt',
+					'patchPath'    => 'files/diffs/mount-0.patch',
+				),
+			),
+		),
+		JSON_PRETTY_PRINT
+	) . "\n"
+);
+file_put_contents( $bundle_dir . '/files/patch.diff', "diff --git a/generated.txt b/generated.txt\n+cooked\n" );
+
+$artifacts = new WP_Codebox_Artifacts();
+$listed    = $artifacts->list( array( 'artifacts_path' => $artifact_root ) );
+$assert( 'artifact listing succeeds', ! is_wp_error( $listed ) && 1 === count( $listed['artifacts'] ?? array() ) );
+
+$read_artifact = $artifacts->get(
+	array(
+		'artifacts_path' => $artifact_root,
+		'artifact_id'    => 'artifact-bundle-test',
+	)
+);
+$assert( 'artifact get returns canonical changed files', ! is_wp_error( $read_artifact ) && 'wp-codebox/changed-files/v1' === ( $read_artifact['artifact']['changed_files']['schema'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function ( mixed $value, array $payload ): array {
+	return array(
+		'adapter'       => 'test-adapter',
+		'artifact_id'   => $payload['artifact_id'],
+		'patch_sha256'  => $payload['patch_sha256'],
+		'patch_contains' => str_contains( $payload['patch'], 'cooked' ),
+	);
+};
+$applied = $artifacts->apply_approved(
+	array(
+		'artifacts_path'  => $artifact_root,
+		'artifact_id'     => 'artifact-bundle-test',
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt' ),
+		'approver'        => 'site-user:1',
+	)
+);
+$assert( 'approved artifact apply delegates exact patch', ! is_wp_error( $applied ) && true === ( $applied['result']['patch_contains'] ?? false ) && hash( 'sha256', "diff --git a/generated.txt b/generated.txt\n+cooked\n" ) === ( $applied['patch_sha256'] ?? '' ) );
+
+$unknown_apply = $artifacts->apply_approved(
+	array(
+		'artifacts_path' => $artifact_root,
+		'artifact_id'    => 'artifact-bundle-test',
+		'approved_files' => array( '/wordpress/wp-content/plugins/example/unknown.txt' ),
+	)
+);
+$assert( 'approved artifact rejects unknown files', is_wp_error( $unknown_apply ) && 'wp_codebox_approved_files_invalid' === $unknown_apply->get_error_code() );
+
+$discarded = $artifacts->discard(
+	array(
+		'artifacts_path' => $artifact_root,
+		'artifact_id'    => 'artifact-bundle-test',
+	)
+);
+$assert( 'artifact discard removes bundle inside root', ! is_wp_error( $discarded ) && ! is_dir( $bundle_dir ) );
 
 if ( ! empty( $failures ) ) {
 	echo "\nFAIL: " . count( $failures ) . " assertion(s) failed out of {$total}\n";


### PR DESCRIPTION
## Summary
- Add parent-site artifact abilities for listing, reading, discarding, and applying approved artifact bundles.
- Validate `apply-approved-artifact` against canonical `changed-files.json`, require explicit `approved_files[]`, and pass the exact approved `patch.diff` plus SHA-256 to an adapter filter.
- Document the reviewed apply-back boundary and cover the ability contract in the WordPress plugin smoke test.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the PHP artifact store/ability contract, smoke coverage, README updates, and local verification steps for Chris to review.