### PR TITLE
Add artifact review payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,53 @@ Current bundles include:
 - `files/mounted-files.json`: captured readwrite mount files with size, SHA-256, target path, and replayability metadata.
 - `files/changed-files.json`: canonical changed-files manifest for review and apply-back consumers.
 - `files/patch.diff`: canonical combined text patch for changed readwrite mounts that declare a baseline.
+- `files/review.json`: frontend-oriented review payload with summary, progress labels, changed file labels, evidence links, and approval actions.
 - `files/diffs.json`: diff index for readwrite mounts that declare a baseline.
 - `files/diffs/<mount>.patch`: unified text diff from a seeded baseline to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
-`metadata.json` points to the canonical changed-files, patch, and mount-diff artifact paths under `artifacts`. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
+`metadata.json` points to the canonical changed-files, patch, review, and mount-diff artifact paths under `artifacts`. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
+
+### `files/review.json`
+
+`files/review.json` is the frontend contract for chat and owner review flows. It is derived from canonical artifacts and should be safe for a generic frontend to render without parsing unified diffs.
+
+```json
+{
+  "schema": "wp-codebox/artifact-review/v1",
+  "artifactId": "artifact-bundle-...",
+  "summary": "Sandbox produced changes in 1 file.",
+  "stats": { "added": 1, "modified": 0, "deleted": 0, "total": 1 },
+  "changedFiles": [
+    {
+      "path": "/wordpress/wp-content/plugins/example/generated.txt",
+      "status": "added",
+      "label": "added generated.txt",
+      "mountTarget": "/wordpress/wp-content/plugins/example",
+      "relativePath": "generated.txt"
+    }
+  ],
+  "progress": [
+    { "type": "boot", "label": "Spinning up a test copy of your site..." },
+    { "type": "artifact", "label": "Saving the result for review..." },
+    { "type": "complete", "label": "Ready for your review." }
+  ],
+  "actions": [
+    { "kind": "approve", "label": "Approve all changes", "requiresApprovedFiles": true },
+    { "kind": "approve-files", "label": "Approve selected files", "requiresApprovedFiles": true },
+    { "kind": "discard", "label": "Discard changes" },
+    { "kind": "iterate", "label": "Request changes" }
+  ],
+  "evidence": {
+    "patch": "files/patch.diff",
+    "patchSha256": "...",
+    "changedFiles": "files/changed-files.json"
+  },
+  "riskFlags": []
+}
+```
+
+Review actions are declarative. Frontends call `wp-codebox/apply-approved-artifact` with `artifact_id` and an explicit `approved_files[]` list for approve actions, call `wp-codebox/discard-artifact` for discard, and start a new sandbox task for iterate/request-changes flows.
 
 Binary files and oversized files are copied when allowed by capture limits but are not embedded into `blueprint.after.json`. Database exports, option diffs, uploaded media, active plugin/theme state, screenshots, normalized test results, content-addressed artifact IDs, and redaction guarantees are still future artifact targets.
 
@@ -300,10 +342,9 @@ WP Codebox does not own:
 ## Near-Term Gaps
 
 - Define content-addressed artifact IDs and redaction guarantees.
-- Add list/get/discard/apply-approved artifact abilities to the WordPress plugin.
 - Define multi-user sandbox session lifecycle, retention, quotas, cancellation, and audit records.
 - Define reviewed apply-back adapters for bot-authored PRs, direct apply, and package export.
-- Add frontend progress/review payloads for non-technical site owners.
+- Add visual previews, normalized test results, and richer risk flags to frontend review payloads.
 
 ## Development Notes
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -195,6 +195,61 @@ export interface ArtifactManifest {
   files: ArtifactManifestFile[]
 }
 
+export type ArtifactReviewProgressEventType =
+  | "boot"
+  | "mount"
+  | "agent-start"
+  | "tool-activity"
+  | "artifact"
+  | "complete"
+  | (string & {})
+
+export interface ArtifactReviewProgressEvent {
+  type: ArtifactReviewProgressEventType
+  label: string
+  component?: string
+  action?: string
+  timestamp?: string
+}
+
+export type ArtifactReviewActionKind = "approve" | "approve-files" | "discard" | "iterate" | (string & {})
+
+export interface ArtifactReviewAction {
+  kind: ArtifactReviewActionKind
+  label: string
+  requiresApprovedFiles?: boolean
+}
+
+export interface ArtifactReviewChangedFile {
+  path: string
+  status: "added" | "modified" | "deleted"
+  label: string
+  mountTarget: string
+  relativePath: string
+}
+
+export interface ArtifactReview {
+  schema: "wp-codebox/artifact-review/v1"
+  artifactId: string
+  createdAt: string
+  summary: string
+  stats: {
+    added: number
+    modified: number
+    deleted: number
+    total: number
+  }
+  changedFiles: ArtifactReviewChangedFile[]
+  progress: ArtifactReviewProgressEvent[]
+  actions: ArtifactReviewAction[]
+  evidence: {
+    patch: string
+    patchSha256: string
+    changedFiles: string
+  }
+  riskFlags: string[]
+}
+
 export interface ArtifactBundle {
   id: string
   directory: string
@@ -212,6 +267,7 @@ export interface ArtifactBundle {
   diffsPath: string
   changedFilesPath: string
   patchPath: string
+  reviewPath: string
   createdAt: string
 }
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -8,6 +8,7 @@ import type {
   ArtifactBundle,
   ArtifactManifest,
   ArtifactManifestFile,
+  ArtifactReview,
   ArtifactSpec,
   ExecutionResult,
   ExecutionSpec,
@@ -273,6 +274,7 @@ class PlaygroundRuntime implements Runtime {
     const diffsPath = join(filesDirectory, "diffs.json")
     const changedFilesPath = join(filesDirectory, "changed-files.json")
     const patchPath = join(filesDirectory, "patch.diff")
+    const reviewPath = join(filesDirectory, "review.json")
 
     this.recordEvent("runtime.artifacts.collected", {
       id: bundleId,
@@ -293,9 +295,11 @@ class PlaygroundRuntime implements Runtime {
     }
     const capturedMounts = await this.captureMountedFiles(filesDirectory)
     const { mountDiffs, changedFiles, patch } = await this.captureMountDiffs(filesDirectory)
+    const review = this.buildArtifactReview(bundleId, createdAt, changedFiles, patch)
     const artifactFiles = {
       changedFiles: relative(this.artifactRoot, changedFilesPath),
       patch: relative(this.artifactRoot, patchPath),
+      review: relative(this.artifactRoot, reviewPath),
       mountDiffs: relative(this.artifactRoot, diffsPath),
     }
     metadata.artifacts = artifactFiles
@@ -317,6 +321,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(diffsPath, "mount-diffs", "application/json"),
       fileEntry(changedFilesPath, "changed-files", "application/json"),
       fileEntry(patchPath, "patch", "text/x-diff"),
+      fileEntry(reviewPath, "review", "application/json"),
       ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
         fileEntry(join(this.artifactRoot, file.artifactPath), "file", file.contentType),
@@ -350,6 +355,7 @@ class PlaygroundRuntime implements Runtime {
     await writeFile(diffsPath, `${JSON.stringify(mountDiffs, null, 2)}\n`)
     await writeFile(changedFilesPath, `${JSON.stringify(changedFiles, null, 2)}\n`)
     await writeFile(patchPath, patch)
+    await writeFile(reviewPath, `${JSON.stringify(review, null, 2)}\n`)
 
     return {
       id: bundleId,
@@ -368,7 +374,91 @@ class PlaygroundRuntime implements Runtime {
       diffsPath,
       changedFilesPath,
       patchPath,
+      reviewPath,
       createdAt,
+    }
+  }
+
+  private buildArtifactReview(
+    artifactId: string,
+    createdAt: string,
+    changedFiles: CanonicalChangedFiles,
+    patch: string,
+  ): ArtifactReview {
+    const stats = {
+      added: changedFiles.files.filter((file) => file.status === "added").length,
+      modified: changedFiles.files.filter((file) => file.status === "modified").length,
+      deleted: changedFiles.files.filter((file) => file.status === "deleted").length,
+      total: changedFiles.files.length,
+    }
+    const changedFileLabel = stats.total === 1 ? "1 file" : `${stats.total} files`
+    const summary = stats.total > 0 ? `Sandbox produced changes in ${changedFileLabel}.` : "Sandbox produced no file changes."
+
+    return {
+      schema: "wp-codebox/artifact-review/v1",
+      artifactId,
+      createdAt,
+      summary,
+      stats,
+      changedFiles: changedFiles.files.map((file) => ({
+        path: file.path,
+        status: file.status,
+        label: `${file.status} ${file.relativePath}`,
+        mountTarget: file.mountTarget,
+        relativePath: file.relativePath,
+      })),
+      progress: [
+        {
+          type: "boot",
+          label: "Spinning up a test copy of your site...",
+          action: "boot",
+          timestamp: this.createdAt,
+        },
+        ...this.mounts.map((mount) => ({
+          type: "mount" as const,
+          label: `Loading ${basename(mount.target)}...`,
+          component: mount.target,
+          action: "mount",
+        })),
+        {
+          type: "artifact",
+          label: "Saving the result for review...",
+          action: "capture",
+          timestamp: createdAt,
+        },
+        {
+          type: "complete",
+          label: "Ready for your review.",
+          action: "complete",
+          timestamp: createdAt,
+        },
+      ],
+      actions: [
+        {
+          kind: "approve",
+          label: "Approve all changes",
+          requiresApprovedFiles: true,
+        },
+        {
+          kind: "approve-files",
+          label: "Approve selected files",
+          requiresApprovedFiles: true,
+        },
+        {
+          kind: "discard",
+          label: "Discard changes",
+        },
+        {
+          kind: "iterate",
+          label: "Request changes",
+        },
+      ],
+      evidence: {
+        patch: "files/patch.diff",
+        patchSha256: createHash("sha256").update(patch).digest("hex"),
+        changedFiles: "files/changed-files.json",
+      },
+      riskFlags: [],
     }
   }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -233,6 +233,7 @@ final class WP_Codebox_Artifacts {
 			'metadata'      => $this->resolve_artifact_file( $directory, 'metadata.json' ),
 			'changed_files' => $this->resolve_artifact_file( $directory, 'files/changed-files.json' ),
 			'patch'         => $this->resolve_artifact_file( $directory, 'files/patch.diff' ),
+			'review'        => $this->resolve_artifact_file( $directory, 'files/review.json' ),
 		);
 
 		$bundle = array(
@@ -242,6 +243,7 @@ final class WP_Codebox_Artifacts {
 			'paths'             => $paths,
 			'has_patch'         => is_file( $paths['patch'] ),
 			'has_changed_files' => is_file( $paths['changed_files'] ),
+			'has_review'        => is_file( $paths['review'] ),
 		);
 
 		if ( ! $include_contents ) {
@@ -250,16 +252,21 @@ final class WP_Codebox_Artifacts {
 
 		$metadata      = is_file( $paths['metadata'] ) ? $this->read_json_file( $paths['metadata'] ) : array();
 		$changed_files = is_file( $paths['changed_files'] ) ? $this->read_json_file( $paths['changed_files'] ) : array();
+		$review        = is_file( $paths['review'] ) ? $this->read_json_file( $paths['review'] ) : array();
 		if ( is_wp_error( $metadata ) ) {
 			return $metadata;
 		}
 		if ( is_wp_error( $changed_files ) ) {
 			return $changed_files;
 		}
+		if ( is_wp_error( $review ) ) {
+			return $review;
+		}
 
 		$bundle['manifest']      = $manifest;
 		$bundle['metadata']      = $metadata;
 		$bundle['changed_files'] = $changed_files;
+		$bundle['review']        = $review;
 
 		return $bundle;
 	}

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -31,17 +31,21 @@ try {
   const artifacts = output.artifacts
   assert.ok(artifacts.changedFilesPath, "artifact bundle should expose changedFilesPath")
   assert.ok(artifacts.patchPath, "artifact bundle should expose patchPath")
+  assert.ok(artifacts.reviewPath, "artifact bundle should expose reviewPath")
 
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8"))
   const changedFiles = JSON.parse(await readFile(artifacts.changedFilesPath, "utf8"))
   const patch = await readFile(artifacts.patchPath, "utf8")
+  const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
 
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/changed-files.json" && file.kind === "changed-files"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/patch.diff" && file.kind === "patch"))
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/review.json" && file.kind === "review"))
   assert.deepEqual(metadata.artifacts, {
     changedFiles: "files/changed-files.json",
     patch: "files/patch.diff",
+    review: "files/review.json",
     mountDiffs: "files/diffs.json",
   })
   assert.equal(changedFiles.schema, "wp-codebox/changed-files/v1")
@@ -52,6 +56,15 @@ try {
   )
   assert.match(patch, /generated\.txt/)
   assert.match(patch, /\+cooked/)
+  assert.equal(review.schema, "wp-codebox/artifact-review/v1")
+  assert.equal(review.evidence.patch, "files/patch.diff")
+  assert.equal(review.evidence.changedFiles, "files/changed-files.json")
+  assert.ok(review.changedFiles.some((file: { path: string; status: string }) =>
+    file.path === "/wordpress/wp-content/plugins/seeded-helper/generated.txt" && file.status === "added",
+  ))
+  assert.ok(review.actions.some((action: { kind: string; requiresApprovedFiles?: boolean }) => action.kind === "approve" && action.requiresApprovedFiles === true))
+  assert.ok(review.actions.some((action: { kind: string }) => action.kind === "discard"))
+  assert.ok(review.progress.some((event: { type: string; label: string }) => event.type === "complete" && event.label === "Ready for your review."))
 
   console.log("Artifact contract smoke passed")
 } finally {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -216,6 +216,11 @@ file_put_contents(
 					'kind'        => 'patch',
 					'contentType' => 'text/x-diff',
 				),
+				array(
+					'path'        => 'files/review.json',
+					'kind'        => 'review',
+					'contentType' => 'application/json',
+				),
 			),
 		),
 		JSON_PRETTY_PRINT
@@ -242,6 +247,23 @@ file_put_contents(
 	) . "\n"
 );
 file_put_contents( $bundle_dir . '/files/patch.diff', "diff --git a/generated.txt b/generated.txt\n+cooked\n" );
+file_put_contents(
+	$bundle_dir . '/files/review.json',
+	json_encode(
+		array(
+			'schema'  => 'wp-codebox/artifact-review/v1',
+			'summary' => 'Sandbox produced changes in 1 file.',
+			'actions' => array(
+				array(
+					'kind'                  => 'approve',
+					'label'                 => 'Approve all changes',
+					'requiresApprovedFiles' => true,
+				),
+			),
+		),
+		JSON_PRETTY_PRINT
+	) . "\n"
+);
 
 $artifacts = new WP_Codebox_Artifacts();
 $listed    = $artifacts->list( array( 'artifacts_path' => $artifact_root ) );
@@ -254,6 +276,7 @@ $read_artifact = $artifacts->get(
 	)
 );
 $assert( 'artifact get returns canonical changed files', ! is_wp_error( $read_artifact ) && 'wp-codebox/changed-files/v1' === ( $read_artifact['artifact']['changed_files']['schema'] ?? '' ) );
+$assert( 'artifact get returns review payload', ! is_wp_error( $read_artifact ) && 'wp-codebox/artifact-review/v1' === ( $read_artifact['artifact']['review']['schema'] ?? '' ) );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function ( mixed $value, array $payload ): array {
 	return array(


### PR DESCRIPTION
## Summary
- Add a generated `files/review.json` artifact for frontend/chat review flows.
- Export the review contract types, expose `reviewPath` on artifact bundles, and include the review payload in artifact metadata/manifest output.
- Surface review payloads through the WordPress artifact reader and cover the contract in artifact/plugin smoke tests.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the TypeScript/PHP review contract implementation, smoke coverage, README updates, and local verification steps for Chris to review.