### PR TITLE
Content-address artifact bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Expected shape:
     "exitCode": 0
   },
   "artifacts": {
+    "id": "artifact-bundle-sha256-...",
+    "contentDigest": "...",
     "directory": "./artifacts/runtime-...",
     "manifestPath": "./artifacts/runtime-.../manifest.json",
     "blueprintAfterPath": "./artifacts/runtime-.../blueprint.after.json",
@@ -207,7 +209,7 @@ Artifact capture is owned by WP Codebox because WP Codebox knows what was mounte
 
 Current bundles include:
 
-- `manifest.json`: artifact index with content types.
+- `manifest.json`: artifact index with content types and the content digest used for the bundle id.
 - `metadata.json`: runtime, policy, mounts, and caller metadata.
 - `blueprint.after.json`: partial WordPress Playground replay blueprint for captured text files.
 - `blueprint.after-notes.json`: replay limitations and next capture targets.
@@ -223,6 +225,8 @@ Current bundles include:
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
 `metadata.json` points to the canonical changed-files, patch, review, and mount-diff artifact paths under `artifacts`. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
+
+Artifact bundle ids are content-addressed for the apply-back contract. The runtime writes `manifest.id` as `artifact-bundle-sha256-<digest>`, where `<digest>` is SHA-256 over the exact bytes of `files/changed-files.json` and `files/patch.diff` with the `wp-codebox/artifact-content/v1` domain separator. The same value is exposed as `manifest.contentDigest.value`, `metadata.contentDigest.value`, the CLI `artifacts.contentDigest` field, and `files/review.json` evidence. Approval and apply-back consumers must recompute it before trusting an approved artifact.
 
 ### `files/review.json`
 
@@ -257,6 +261,7 @@ Current bundles include:
   "evidence": {
     "patch": "files/patch.diff",
     "patchSha256": "...",
+    "artifactContentDigest": "...",
     "changedFiles": "files/changed-files.json"
   },
   "riskFlags": []
@@ -265,7 +270,7 @@ Current bundles include:
 
 Review actions are declarative. Frontends call `wp-codebox/apply-approved-artifact` with `artifact_id` and an explicit `approved_files[]` list for approve actions, call `wp-codebox/discard-artifact` for discard, and start a new sandbox task for iterate/request-changes flows.
 
-Binary files and oversized files are copied when allowed by capture limits but are not embedded into `blueprint.after.json`. Database exports, option diffs, uploaded media, active plugin/theme state, screenshots, normalized test results, content-addressed artifact IDs, and redaction guarantees are still future artifact targets.
+Binary files and oversized files are copied when allowed by capture limits but are not embedded into `blueprint.after.json`. Database exports, option diffs, uploaded media, active plugin/theme state, screenshots, normalized test results, and redaction guarantees are still future artifact targets.
 
 ## WordPress Plugin
 
@@ -295,7 +300,7 @@ The CLI binary can come from ability input, the `wp_codebox_bin` option, or the 
 
 Data Machine Code is a mounted coding-tools component inside the sandbox. It provides workspace/file/GitHub tools to the sandboxed agent. WP Codebox owns the parent-site ability surface, sandbox lifecycle, and artifact capture boundary.
 
-Apply-back is intentionally not part of `run-agent-task`. Sandbox execution returns proposed outputs and evidence. `list-artifacts`, `get-artifact`, and `discard-artifact` manage captured artifact bundles under the configured artifact root. `apply-approved-artifact` validates `artifact_id` plus an explicit `approved_files[]` list against canonical `changed-files.json`, reads the exact `patch.diff` the reviewer approved, and delegates to the `wp_codebox_apply_approved_artifact` filter. PR creation, direct deploy, package export, and bot identity policy live in adapters behind that reviewed boundary.
+Apply-back is intentionally not part of `run-agent-task`. Sandbox execution returns proposed outputs and evidence. `list-artifacts`, `get-artifact`, and `discard-artifact` manage captured artifact bundles under the configured artifact root. `apply-approved-artifact` validates `artifact_id` plus an explicit `approved_files[]` list against canonical `changed-files.json`, recomputes the artifact content digest from `changed-files.json` and the exact `patch.diff` the reviewer approved, and delegates to the `wp_codebox_apply_approved_artifact` filter. PR creation, direct deploy, package export, and bot identity policy live in adapters behind that reviewed boundary.
 
 ## Runtime Policy
 
@@ -341,7 +346,7 @@ WP Codebox does not own:
 
 ## Near-Term Gaps
 
-- Define content-addressed artifact IDs and redaction guarantees.
+- Define redaction guarantees.
 - Define multi-user sandbox session lifecycle, retention, quotas, cancellation, and audit records.
 - Define reviewed apply-back adapters for bot-authored PRs, direct apply, and package export.
 - Add visual previews, normalized test results, and richer risk flags to frontend review payloads.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -190,9 +190,16 @@ export interface ArtifactManifestFile {
 
 export interface ArtifactManifest {
   id: string
+  contentDigest: ArtifactContentDigest
   createdAt: string
   runtime: RuntimeInfo
   files: ArtifactManifestFile[]
+}
+
+export interface ArtifactContentDigest {
+  algorithm: "sha256"
+  inputs: string[]
+  value: string
 }
 
 export type ArtifactReviewProgressEventType =
@@ -245,6 +252,7 @@ export interface ArtifactReview {
   evidence: {
     patch: string
     patchSha256: string
+    artifactContentDigest: string
     changedFiles: string
   }
   riskFlags: string[]
@@ -268,6 +276,7 @@ export interface ArtifactBundle {
   changedFilesPath: string
   patchPath: string
   reviewPath: string
+  contentDigest: string
   createdAt: string
 }
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -31,6 +31,16 @@ function id(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
 
+function artifactContentDigest(changedFilesJson: string, patch: string): string {
+  return createHash("sha256")
+    .update("wp-codebox/artifact-content/v1\n")
+    .update("files/changed-files.json\n")
+    .update(changedFilesJson)
+    .update("\nfiles/patch.diff\n")
+    .update(patch)
+    .digest("hex")
+}
+
 interface PlaygroundRunResponse {
   exitCode?: number
   errors?: string
@@ -258,7 +268,6 @@ class PlaygroundRuntime implements Runtime {
     await mkdir(logsDirectory, { recursive: true })
     await mkdir(filesDirectory, { recursive: true })
 
-    const bundleId = id("artifact-bundle")
     const createdAt = now()
     const manifestPath = join(this.artifactRoot, "manifest.json")
     const metadataPath = join(this.artifactRoot, "metadata.json")
@@ -276,16 +285,20 @@ class PlaygroundRuntime implements Runtime {
     const patchPath = join(filesDirectory, "patch.diff")
     const reviewPath = join(filesDirectory, "review.json")
 
-    this.recordEvent("runtime.artifacts.collected", {
-      id: bundleId,
-      directory: this.artifactRoot,
-      createdAt,
-      spec,
-    })
-
     const runtime = await this.info()
+    const capturedMounts = await this.captureMountedFiles(filesDirectory)
+    const { mountDiffs, changedFiles, patch } = await this.captureMountDiffs(filesDirectory)
+    const changedFilesJson = `${JSON.stringify(changedFiles, null, 2)}\n`
+    const contentDigest = artifactContentDigest(changedFilesJson, patch)
+    const bundleId = `artifact-bundle-sha256-${contentDigest}`
+    const contentDigestMetadata = {
+      algorithm: "sha256",
+      inputs: ["files/changed-files.json", "files/patch.diff"],
+      value: contentDigest,
+    }
     const metadata: Record<string, unknown> = {
       id: bundleId,
+      contentDigest: contentDigestMetadata,
       createdAt,
       runtime,
       mounts: this.mounts,
@@ -293,9 +306,15 @@ class PlaygroundRuntime implements Runtime {
       context: this.spec.metadata ?? {},
       spec,
     }
-    const capturedMounts = await this.captureMountedFiles(filesDirectory)
-    const { mountDiffs, changedFiles, patch } = await this.captureMountDiffs(filesDirectory)
-    const review = this.buildArtifactReview(bundleId, createdAt, changedFiles, patch)
+
+    this.recordEvent("runtime.artifacts.collected", {
+      id: bundleId,
+      directory: this.artifactRoot,
+      createdAt,
+      spec,
+    })
+    const review = this.buildArtifactReview(bundleId, createdAt, changedFiles, patch, contentDigest)
+    const reviewJson = `${JSON.stringify(review, null, 2)}\n`
     const artifactFiles = {
       changedFiles: relative(this.artifactRoot, changedFilesPath),
       patch: relative(this.artifactRoot, patchPath),
@@ -330,6 +349,11 @@ class PlaygroundRuntime implements Runtime {
 
     const manifest: ArtifactManifest = {
       id: bundleId,
+      contentDigest: {
+        algorithm: "sha256",
+        inputs: ["files/changed-files.json", "files/patch.diff"],
+        value: contentDigest,
+      },
       createdAt,
       runtime,
       files: manifestFiles.map((file) => ({
@@ -353,9 +377,9 @@ class PlaygroundRuntime implements Runtime {
     await writeFile(mountsPath, `${JSON.stringify(this.mounts, null, 2)}\n`)
     await writeFile(capturedMountsPath, `${JSON.stringify(serializeCapturedMountFiles(capturedMounts), null, 2)}\n`)
     await writeFile(diffsPath, `${JSON.stringify(mountDiffs, null, 2)}\n`)
-    await writeFile(changedFilesPath, `${JSON.stringify(changedFiles, null, 2)}\n`)
+    await writeFile(changedFilesPath, changedFilesJson)
     await writeFile(patchPath, patch)
-    await writeFile(reviewPath, `${JSON.stringify(review, null, 2)}\n`)
+    await writeFile(reviewPath, reviewJson)
 
     return {
       id: bundleId,
@@ -375,6 +399,7 @@ class PlaygroundRuntime implements Runtime {
       changedFilesPath,
       patchPath,
       reviewPath,
+      contentDigest,
       createdAt,
     }
   }
@@ -384,6 +409,7 @@ class PlaygroundRuntime implements Runtime {
     createdAt: string,
     changedFiles: CanonicalChangedFiles,
     patch: string,
+    contentDigest: string,
   ): ArtifactReview {
     const stats = {
       added: changedFiles.files.filter((file) => file.status === "added").length,
@@ -456,6 +482,7 @@ class PlaygroundRuntime implements Runtime {
       evidence: {
         patch: "files/patch.diff",
         patchSha256: createHash("sha256").update(patch).digest("hex"),
+        artifactContentDigest: contentDigest,
         changedFiles: "files/changed-files.json",
       },
       riskFlags: [],

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -12,6 +12,8 @@ final class WP_Codebox_Artifacts {
 	private const LIST_SCHEMA  = 'wp-codebox/artifact-list/v1';
 	private const GET_SCHEMA   = 'wp-codebox/artifact/v1';
 	private const APPLY_SCHEMA = 'wp-codebox/artifact-apply/v1';
+	private const CONTENT_DIGEST_PREFIX = "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n";
+	private const CONTENT_DIGEST_SEPARATOR = "\nfiles/patch.diff\n";
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public function list( array $input = array() ): array|WP_Error {
@@ -126,13 +128,19 @@ final class WP_Codebox_Artifacts {
 			return new WP_Error( 'wp_codebox_patch_missing', 'Artifact patch.diff is missing or empty.', array( 'status' => 400 ) );
 		}
 
+		$content_digest = $this->artifact_content_digest( $bundle );
+		if ( is_wp_error( $content_digest ) ) {
+			return $content_digest;
+		}
+
 		$payload = array(
-			'artifact_id'    => (string) $bundle['id'],
-			'artifact'       => $bundle,
-			'approved_files' => $approved_files,
-			'approver'       => $input['approver'] ?? null,
-			'patch'          => $patch,
-			'patch_sha256'   => hash( 'sha256', $patch ),
+			'artifact_id'             => (string) $bundle['id'],
+			'artifact'                => $bundle,
+			'approved_files'          => $approved_files,
+			'approver'                => $input['approver'] ?? null,
+			'patch'                   => $patch,
+			'patch_sha256'            => hash( 'sha256', $patch ),
+			'artifact_content_digest' => $content_digest,
 		);
 
 		$result = apply_filters( 'wp_codebox_apply_approved_artifact', null, $payload );
@@ -150,6 +158,7 @@ final class WP_Codebox_Artifacts {
 			'artifact_id'    => (string) $bundle['id'],
 			'approved_files' => $approved_files,
 			'patch_sha256'   => $payload['patch_sha256'],
+			'content_digest' => $content_digest,
 			'result'         => $result,
 		);
 	}
@@ -238,6 +247,7 @@ final class WP_Codebox_Artifacts {
 
 		$bundle = array(
 			'id'                => $id,
+			'content_digest'    => is_array( $manifest['contentDigest'] ?? null ) ? (string) ( $manifest['contentDigest']['value'] ?? '' ) : '',
 			'created_at'        => (string) ( $manifest['createdAt'] ?? '' ),
 			'directory'         => $directory,
 			'paths'             => $paths,
@@ -263,6 +273,25 @@ final class WP_Codebox_Artifacts {
 			return $review;
 		}
 
+		$content_digest = $this->artifact_content_digest( $bundle );
+		if ( is_wp_error( $content_digest ) ) {
+			return $content_digest;
+		}
+
+		$declared_digest = (string) ( $bundle['content_digest'] ?? '' );
+		if ( '' === $declared_digest ) {
+			return new WP_Error( 'wp_codebox_artifact_digest_missing', 'Artifact manifest is missing contentDigest.value.', array( 'status' => 400 ) );
+		}
+
+		if ( ! hash_equals( $declared_digest, $content_digest ) ) {
+			return new WP_Error( 'wp_codebox_artifact_digest_mismatch', 'Artifact content digest does not match changed-files.json and patch.diff.', array( 'status' => 400 ) );
+		}
+
+		$expected_id = 'artifact-bundle-sha256-' . $content_digest;
+		if ( $expected_id !== $id ) {
+			return new WP_Error( 'wp_codebox_artifact_id_mismatch', 'Artifact id does not match the content digest.', array( 'status' => 400 ) );
+		}
+
 		$bundle['manifest']      = $manifest;
 		$bundle['metadata']      = $metadata;
 		$bundle['changed_files'] = $changed_files;
@@ -284,6 +313,24 @@ final class WP_Codebox_Artifacts {
 		}
 
 		return $decoded;
+	}
+
+	/** @param array<string,mixed> $bundle Artifact bundle. */
+	private function artifact_content_digest( array $bundle ): string|WP_Error {
+		$changed_files_path = (string) ( $bundle['paths']['changed_files'] ?? '' );
+		$patch_path         = (string) ( $bundle['paths']['patch'] ?? '' );
+		$changed_files      = '' !== $changed_files_path && is_file( $changed_files_path ) ? file_get_contents( $changed_files_path ) : false;
+		$patch              = '' !== $patch_path && is_file( $patch_path ) ? file_get_contents( $patch_path ) : false;
+
+		if ( false === $changed_files ) {
+			return new WP_Error( 'wp_codebox_changed_files_missing', 'Artifact changed-files.json is missing.', array( 'status' => 400 ) );
+		}
+
+		if ( false === $patch ) {
+			return new WP_Error( 'wp_codebox_patch_missing', 'Artifact patch.diff is missing.', array( 'status' => 400 ) );
+		}
+
+		return hash( 'sha256', self::CONTENT_DIGEST_PREFIX . $changed_files . self::CONTENT_DIGEST_SEPARATOR . $patch );
 	}
 
 	private function resolve_artifact_file( string $directory, string $relative_path ): string {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
+import { createHash } from "node:crypto"
 import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -36,9 +37,26 @@ try {
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8"))
   const changedFiles = JSON.parse(await readFile(artifacts.changedFilesPath, "utf8"))
+  const changedFilesJson = await readFile(artifacts.changedFilesPath, "utf8")
   const patch = await readFile(artifacts.patchPath, "utf8")
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
+  const contentDigest = createHash("sha256")
+    .update("wp-codebox/artifact-content/v1\n")
+    .update("files/changed-files.json\n")
+    .update(changedFilesJson)
+    .update("\nfiles/patch.diff\n")
+    .update(patch)
+    .digest("hex")
 
+  assert.equal(artifacts.id, `artifact-bundle-sha256-${contentDigest}`)
+  assert.equal(artifacts.contentDigest, contentDigest)
+  assert.equal(manifest.id, artifacts.id)
+  assert.deepEqual(manifest.contentDigest, {
+    algorithm: "sha256",
+    inputs: ["files/changed-files.json", "files/patch.diff"],
+    value: contentDigest,
+  })
+  assert.deepEqual(metadata.contentDigest, manifest.contentDigest)
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/changed-files.json" && file.kind === "changed-files"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/patch.diff" && file.kind === "patch"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/review.json" && file.kind === "review"))
@@ -57,7 +75,9 @@ try {
   assert.match(patch, /generated\.txt/)
   assert.match(patch, /\+cooked/)
   assert.equal(review.schema, "wp-codebox/artifact-review/v1")
+  assert.equal(review.artifactId, artifacts.id)
   assert.equal(review.evidence.patch, "files/patch.diff")
+  assert.equal(review.evidence.artifactContentDigest, contentDigest)
   assert.equal(review.evidence.changedFiles, "files/changed-files.json")
   assert.ok(review.changedFiles.some((file: { path: string; status: string }) =>
     file.path === "/wordpress/wp-content/plugins/seeded-helper/generated.txt" && file.status === "added",

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -199,13 +199,37 @@ $assert( 'missing batch tasks fails closed', is_wp_error( $missing_tasks ) && 'w
 $artifact_root = $root . '/artifact-store';
 $bundle_dir    = $artifact_root . '/runtime-test';
 mkdir( $bundle_dir . '/files', 0777, true );
+$changed_files_json = json_encode(
+	array(
+		'schema' => 'wp-codebox/changed-files/v1',
+		'files'  => array(
+			array(
+				'path'         => '/wordpress/wp-content/plugins/example/generated.txt',
+				'status'       => 'added',
+				'mountIndex'   => 0,
+				'mountTarget'  => '/wordpress/wp-content/plugins/example',
+				'relativePath' => 'generated.txt',
+				'patchPath'    => 'files/diffs/mount-0.patch',
+			),
+		),
+	),
+	JSON_PRETTY_PRINT
+) . "\n";
+$patch_diff          = "diff --git a/generated.txt b/generated.txt\n+cooked\n";
+$content_digest      = hash( 'sha256', "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n" . $changed_files_json . "\nfiles/patch.diff\n" . $patch_diff );
+$artifact_id         = 'artifact-bundle-sha256-' . $content_digest;
 file_put_contents(
 	$bundle_dir . '/manifest.json',
 	json_encode(
 		array(
-			'id'        => 'artifact-bundle-test',
-			'createdAt' => '2026-05-19T00:00:00Z',
-			'files'     => array(
+			'id'            => $artifact_id,
+			'contentDigest' => array(
+				'algorithm' => 'sha256',
+				'inputs'    => array( 'files/changed-files.json', 'files/patch.diff' ),
+				'value'     => $content_digest,
+			),
+			'createdAt'     => '2026-05-19T00:00:00Z',
+			'files'         => array(
 				array(
 					'path'        => 'files/changed-files.json',
 					'kind'        => 'changed-files',
@@ -227,33 +251,16 @@ file_put_contents(
 	) . "\n"
 );
 file_put_contents( $bundle_dir . '/metadata.json', json_encode( array( 'artifacts' => array( 'patch' => 'files/patch.diff' ) ), JSON_PRETTY_PRINT ) . "\n" );
-file_put_contents(
-	$bundle_dir . '/files/changed-files.json',
-	json_encode(
-		array(
-			'schema' => 'wp-codebox/changed-files/v1',
-			'files'  => array(
-				array(
-					'path'         => '/wordpress/wp-content/plugins/example/generated.txt',
-					'status'       => 'added',
-					'mountIndex'   => 0,
-					'mountTarget'  => '/wordpress/wp-content/plugins/example',
-					'relativePath' => 'generated.txt',
-					'patchPath'    => 'files/diffs/mount-0.patch',
-				),
-			),
-		),
-		JSON_PRETTY_PRINT
-	) . "\n"
-);
-file_put_contents( $bundle_dir . '/files/patch.diff', "diff --git a/generated.txt b/generated.txt\n+cooked\n" );
+file_put_contents( $bundle_dir . '/files/changed-files.json', $changed_files_json );
+file_put_contents( $bundle_dir . '/files/patch.diff', $patch_diff );
 file_put_contents(
 	$bundle_dir . '/files/review.json',
 	json_encode(
 		array(
-			'schema'  => 'wp-codebox/artifact-review/v1',
-			'summary' => 'Sandbox produced changes in 1 file.',
-			'actions' => array(
+			'schema'     => 'wp-codebox/artifact-review/v1',
+			'artifactId' => $artifact_id,
+			'summary'    => 'Sandbox produced changes in 1 file.',
+			'actions'    => array(
 				array(
 					'kind'                  => 'approve',
 					'label'                 => 'Approve all changes',
@@ -272,34 +279,36 @@ $assert( 'artifact listing succeeds', ! is_wp_error( $listed ) && 1 === count( $
 $read_artifact = $artifacts->get(
 	array(
 		'artifacts_path' => $artifact_root,
-		'artifact_id'    => 'artifact-bundle-test',
+		'artifact_id'    => $artifact_id,
 	)
 );
 $assert( 'artifact get returns canonical changed files', ! is_wp_error( $read_artifact ) && 'wp-codebox/changed-files/v1' === ( $read_artifact['artifact']['changed_files']['schema'] ?? '' ) );
 $assert( 'artifact get returns review payload', ! is_wp_error( $read_artifact ) && 'wp-codebox/artifact-review/v1' === ( $read_artifact['artifact']['review']['schema'] ?? '' ) );
+$assert( 'artifact get verifies content digest', ! is_wp_error( $read_artifact ) && $content_digest === ( $read_artifact['artifact']['content_digest'] ?? '' ) );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function ( mixed $value, array $payload ): array {
 	return array(
-		'adapter'       => 'test-adapter',
-		'artifact_id'   => $payload['artifact_id'],
-		'patch_sha256'  => $payload['patch_sha256'],
-		'patch_contains' => str_contains( $payload['patch'], 'cooked' ),
+		'adapter'                 => 'test-adapter',
+		'artifact_id'             => $payload['artifact_id'],
+		'patch_sha256'            => $payload['patch_sha256'],
+		'artifact_content_digest' => $payload['artifact_content_digest'],
+		'patch_contains'          => str_contains( $payload['patch'], 'cooked' ),
 	);
 };
 $applied = $artifacts->apply_approved(
 	array(
 		'artifacts_path'  => $artifact_root,
-		'artifact_id'     => 'artifact-bundle-test',
+		'artifact_id'     => $artifact_id,
 		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt' ),
 		'approver'        => 'site-user:1',
 	)
 );
-$assert( 'approved artifact apply delegates exact patch', ! is_wp_error( $applied ) && true === ( $applied['result']['patch_contains'] ?? false ) && hash( 'sha256', "diff --git a/generated.txt b/generated.txt\n+cooked\n" ) === ( $applied['patch_sha256'] ?? '' ) );
+$assert( 'approved artifact apply delegates exact patch', ! is_wp_error( $applied ) && true === ( $applied['result']['patch_contains'] ?? false ) && hash( 'sha256', $patch_diff ) === ( $applied['patch_sha256'] ?? '' ) && $content_digest === ( $applied['content_digest'] ?? '' ) );
 
 $unknown_apply = $artifacts->apply_approved(
 	array(
 		'artifacts_path' => $artifact_root,
-		'artifact_id'    => 'artifact-bundle-test',
+		'artifact_id'    => $artifact_id,
 		'approved_files' => array( '/wordpress/wp-content/plugins/example/unknown.txt' ),
 	)
 );
@@ -308,7 +317,7 @@ $assert( 'approved artifact rejects unknown files', is_wp_error( $unknown_apply 
 $discarded = $artifacts->discard(
 	array(
 		'artifacts_path' => $artifact_root,
-		'artifact_id'    => 'artifact-bundle-test',
+		'artifact_id'    => $artifact_id,
 	)
 );
 $assert( 'artifact discard removes bundle inside root', ! is_wp_error( $discarded ) && ! is_dir( $bundle_dir ) );


### PR DESCRIPTION
## Summary
- Derive artifact bundle IDs from a SHA-256 digest of the exact canonical apply inputs: `files/changed-files.json` and `files/patch.diff`.
- Expose the digest in manifest, metadata, CLI bundle output, and review evidence so approval/apply consumers can verify patch identity.
- Recompute and validate the digest in the WordPress artifact apply path before delegating to apply-back adapters.

## Tests
- `npm run check`

Refs #26

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the focused content-addressed artifact ID implementation, smoke coverage updates, and README contract documentation for Chris to review.