### PR TITLE
Add normalized test results artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Expected shape:
     "capturedMountsPath": "./artifacts/runtime-.../files/mounted-files.json",
     "diffsPath": "./artifacts/runtime-.../files/diffs.json",
     "changedFilesPath": "./artifacts/runtime-.../files/changed-files.json",
-    "patchPath": "./artifacts/runtime-.../files/patch.diff"
+    "patchPath": "./artifacts/runtime-.../files/patch.diff",
+    "testResultsPath": "./artifacts/runtime-.../files/test-results.json"
   }
 }
 ```
@@ -219,12 +220,30 @@ Current bundles include:
 - `files/mounted-files.json`: captured readwrite mount files with size, SHA-256, target path, and replayability metadata.
 - `files/changed-files.json`: canonical changed-files manifest for review and apply-back consumers.
 - `files/patch.diff`: canonical combined text patch for changed readwrite mounts that declare a baseline.
+- `files/test-results.json`: normalized test-results artifact with schema, summary counts, suites, and raw log references. When WP Codebox has not run test-aware commands, the artifact is present with `status: "unknown"`, zero counts, an empty `suites` array, and pointers to raw command logs instead of inferred pass/fail data.
 - `files/review.json`: frontend-oriented review payload with summary, progress labels, changed file labels, evidence links, and approval actions.
 - `files/diffs.json`: diff index for readwrite mounts that declare a baseline.
 - `files/diffs/<mount>.patch`: unified text diff from a seeded baseline to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
-`metadata.json` points to the canonical changed-files, patch, review, and mount-diff artifact paths under `artifacts`. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
+`metadata.json` points to the canonical changed-files, patch, test-results, review, and mount-diff artifact paths under `artifacts`. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
+
+### `files/test-results.json`
+
+`files/test-results.json` is the normalized contract for future test-aware commands. The artifact exists even when no command produced structured test output, so artifact consumers can read one stable path and treat `status: "unknown"` as "no structured test result was captured."
+
+```json
+{
+  "schema": "wp-codebox/test-results/v1",
+  "status": "unknown",
+  "summary": { "total": 0, "passed": 0, "failed": 0, "skipped": 0, "unknown": 0 },
+  "suites": [],
+  "rawLogReferences": [
+    { "path": "commands.jsonl", "kind": "commands-jsonl" },
+    { "path": "logs/commands.log", "kind": "commands-log" }
+  ]
+}
+```
 
 Artifact bundle ids are content-addressed for the apply-back contract. The runtime writes `manifest.id` as `artifact-bundle-sha256-<digest>`, where `<digest>` is SHA-256 over the exact bytes of `files/changed-files.json` and `files/patch.diff` with the `wp-codebox/artifact-content/v1` domain separator. The same value is exposed as `manifest.contentDigest.value`, `metadata.contentDigest.value`, the CLI `artifacts.contentDigest` field, and `files/review.json` evidence. Approval and apply-back consumers must recompute it before trusting an approved artifact.
 
@@ -262,7 +281,8 @@ Artifact bundle ids are content-addressed for the apply-back contract. The runti
     "patch": "files/patch.diff",
     "patchSha256": "...",
     "artifactContentDigest": "...",
-    "changedFiles": "files/changed-files.json"
+    "changedFiles": "files/changed-files.json",
+    "testResults": "files/test-results.json"
   },
   "riskFlags": []
 }
@@ -270,7 +290,7 @@ Artifact bundle ids are content-addressed for the apply-back contract. The runti
 
 Review actions are declarative. Frontends call `wp-codebox/apply-approved-artifact` with `artifact_id` and an explicit `approved_files[]` list for approve actions, call `wp-codebox/discard-artifact` for discard, and start a new sandbox task for iterate/request-changes flows.
 
-Binary files and oversized files are copied when allowed by capture limits but are not embedded into `blueprint.after.json`. Database exports, option diffs, uploaded media, active plugin/theme state, screenshots, normalized test results, and redaction guarantees are still future artifact targets.
+Binary files and oversized files are copied when allowed by capture limits but are not embedded into `blueprint.after.json`. Database exports, option diffs, uploaded media, active plugin/theme state, screenshots, parsed test command output, and redaction guarantees are still future artifact targets.
 
 ## WordPress Plugin
 
@@ -370,7 +390,7 @@ WP Codebox does not own:
 - Define redaction guarantees.
 - Define multi-user sandbox session lifecycle, retention, quotas, cancellation, and audit records.
 - Define reviewed apply-back adapters for bot-authored PRs, direct apply, and package export.
-- Add visual previews, normalized test results, and richer risk flags to frontend review payloads.
+- Add visual previews, parsed test command output, and richer risk flags to frontend review payloads.
 
 ## Development Notes
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -210,7 +210,17 @@ export interface ArtifactSpec {
 
 export interface ArtifactManifestFile {
   path: string
-  kind: "manifest" | "metadata" | "events" | "commands" | "observations" | "log" | "mounts" | "file" | (string & {})
+  kind:
+    | "manifest"
+    | "metadata"
+    | "events"
+    | "commands"
+    | "observations"
+    | "log"
+    | "mounts"
+    | "file"
+    | "test-results"
+    | (string & {})
   contentType: string
 }
 
@@ -280,8 +290,39 @@ export interface ArtifactReview {
     patchSha256: string
     artifactContentDigest: string
     changedFiles: string
+    testResults?: string
   }
   riskFlags: string[]
+}
+
+export interface ArtifactTestResultsRawLogReference {
+  path: string
+  kind: string
+}
+
+export interface ArtifactTestResultsSuite {
+  name: string
+  status: "passed" | "failed" | "skipped" | "unknown"
+  tests: number
+  passed: number
+  failed: number
+  skipped: number
+  unknown: number
+  rawLogReferences?: ArtifactTestResultsRawLogReference[]
+}
+
+export interface ArtifactTestResults {
+  schema: "wp-codebox/test-results/v1"
+  status: "passed" | "failed" | "skipped" | "unknown"
+  summary: {
+    total: number
+    passed: number
+    failed: number
+    skipped: number
+    unknown: number
+  }
+  suites: ArtifactTestResultsSuite[]
+  rawLogReferences: ArtifactTestResultsRawLogReference[]
 }
 
 export interface ArtifactBundle {
@@ -301,6 +342,7 @@ export interface ArtifactBundle {
   diffsPath: string
   changedFilesPath: string
   patchPath: string
+  testResultsPath: string
   reviewPath: string
   contentDigest: string
   createdAt: string

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -10,6 +10,7 @@ import type {
   ArtifactManifestFile,
   ArtifactReview,
   ArtifactSpec,
+  ArtifactTestResults,
   ExecutionResult,
   ExecutionSpec,
   LifecycleEvent,
@@ -283,6 +284,7 @@ class PlaygroundRuntime implements Runtime {
     const diffsPath = join(filesDirectory, "diffs.json")
     const changedFilesPath = join(filesDirectory, "changed-files.json")
     const patchPath = join(filesDirectory, "patch.diff")
+    const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
 
     const runtime = await this.info()
@@ -306,18 +308,19 @@ class PlaygroundRuntime implements Runtime {
       context: this.spec.metadata ?? {},
       spec,
     }
-
     this.recordEvent("runtime.artifacts.collected", {
       id: bundleId,
       directory: this.artifactRoot,
       createdAt,
       spec,
     })
+    const testResults = this.buildTestResults()
     const review = this.buildArtifactReview(bundleId, createdAt, changedFiles, patch, contentDigest)
     const reviewJson = `${JSON.stringify(review, null, 2)}\n`
     const artifactFiles = {
       changedFiles: relative(this.artifactRoot, changedFilesPath),
       patch: relative(this.artifactRoot, patchPath),
+      testResults: relative(this.artifactRoot, testResultsPath),
       review: relative(this.artifactRoot, reviewPath),
       mountDiffs: relative(this.artifactRoot, diffsPath),
     }
@@ -340,6 +343,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(diffsPath, "mount-diffs", "application/json"),
       fileEntry(changedFilesPath, "changed-files", "application/json"),
       fileEntry(patchPath, "patch", "text/x-diff"),
+      fileEntry(testResultsPath, "test-results", "application/json"),
       fileEntry(reviewPath, "review", "application/json"),
       ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
@@ -379,6 +383,7 @@ class PlaygroundRuntime implements Runtime {
     await writeFile(diffsPath, `${JSON.stringify(mountDiffs, null, 2)}\n`)
     await writeFile(changedFilesPath, changedFilesJson)
     await writeFile(patchPath, patch)
+    await writeFile(testResultsPath, `${JSON.stringify(testResults, null, 2)}\n`)
     await writeFile(reviewPath, reviewJson)
 
     return {
@@ -398,6 +403,7 @@ class PlaygroundRuntime implements Runtime {
       diffsPath,
       changedFilesPath,
       patchPath,
+      testResultsPath,
       reviewPath,
       contentDigest,
       createdAt,
@@ -484,8 +490,34 @@ class PlaygroundRuntime implements Runtime {
         patchSha256: createHash("sha256").update(patch).digest("hex"),
         artifactContentDigest: contentDigest,
         changedFiles: "files/changed-files.json",
+        testResults: "files/test-results.json",
       },
       riskFlags: [],
+    }
+  }
+
+  private buildTestResults(): ArtifactTestResults {
+    return {
+      schema: "wp-codebox/test-results/v1",
+      status: "unknown",
+      summary: {
+        total: 0,
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        unknown: 0,
+      },
+      suites: [],
+      rawLogReferences: [
+        {
+          path: "commands.jsonl",
+          kind: "commands-jsonl",
+        },
+        {
+          path: "logs/commands.log",
+          kind: "commands-log",
+        },
+      ],
     }
   }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -242,6 +242,7 @@ final class WP_Codebox_Artifacts {
 			'metadata'      => $this->resolve_artifact_file( $directory, 'metadata.json' ),
 			'changed_files' => $this->resolve_artifact_file( $directory, 'files/changed-files.json' ),
 			'patch'         => $this->resolve_artifact_file( $directory, 'files/patch.diff' ),
+			'test_results'  => $this->resolve_artifact_file( $directory, 'files/test-results.json' ),
 			'review'        => $this->resolve_artifact_file( $directory, 'files/review.json' ),
 		);
 
@@ -253,6 +254,7 @@ final class WP_Codebox_Artifacts {
 			'paths'             => $paths,
 			'has_patch'         => is_file( $paths['patch'] ),
 			'has_changed_files' => is_file( $paths['changed_files'] ),
+			'has_test_results'  => is_file( $paths['test_results'] ),
 			'has_review'        => is_file( $paths['review'] ),
 		);
 
@@ -262,12 +264,16 @@ final class WP_Codebox_Artifacts {
 
 		$metadata      = is_file( $paths['metadata'] ) ? $this->read_json_file( $paths['metadata'] ) : array();
 		$changed_files = is_file( $paths['changed_files'] ) ? $this->read_json_file( $paths['changed_files'] ) : array();
+		$test_results  = is_file( $paths['test_results'] ) ? $this->read_json_file( $paths['test_results'] ) : array();
 		$review        = is_file( $paths['review'] ) ? $this->read_json_file( $paths['review'] ) : array();
 		if ( is_wp_error( $metadata ) ) {
 			return $metadata;
 		}
 		if ( is_wp_error( $changed_files ) ) {
 			return $changed_files;
+		}
+		if ( is_wp_error( $test_results ) ) {
+			return $test_results;
 		}
 		if ( is_wp_error( $review ) ) {
 			return $review;
@@ -295,6 +301,7 @@ final class WP_Codebox_Artifacts {
 		$bundle['manifest']      = $manifest;
 		$bundle['metadata']      = $metadata;
 		$bundle['changed_files'] = $changed_files;
+		$bundle['test_results']  = $test_results;
 		$bundle['review']        = $review;
 
 		return $bundle;

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -32,6 +32,7 @@ try {
   const artifacts = output.artifacts
   assert.ok(artifacts.changedFilesPath, "artifact bundle should expose changedFilesPath")
   assert.ok(artifacts.patchPath, "artifact bundle should expose patchPath")
+  assert.ok(artifacts.testResultsPath, "artifact bundle should expose testResultsPath")
   assert.ok(artifacts.reviewPath, "artifact bundle should expose reviewPath")
 
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
@@ -39,6 +40,7 @@ try {
   const changedFiles = JSON.parse(await readFile(artifacts.changedFilesPath, "utf8"))
   const changedFilesJson = await readFile(artifacts.changedFilesPath, "utf8")
   const patch = await readFile(artifacts.patchPath, "utf8")
+  const testResults = JSON.parse(await readFile(artifacts.testResultsPath, "utf8"))
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
   const contentDigest = createHash("sha256")
     .update("wp-codebox/artifact-content/v1\n")
@@ -59,10 +61,12 @@ try {
   assert.deepEqual(metadata.contentDigest, manifest.contentDigest)
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/changed-files.json" && file.kind === "changed-files"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/patch.diff" && file.kind === "patch"))
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/test-results.json" && file.kind === "test-results"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/review.json" && file.kind === "review"))
   assert.deepEqual(metadata.artifacts, {
     changedFiles: "files/changed-files.json",
     patch: "files/patch.diff",
+    testResults: "files/test-results.json",
     review: "files/review.json",
     mountDiffs: "files/diffs.json",
   })
@@ -74,11 +78,17 @@ try {
   )
   assert.match(patch, /generated\.txt/)
   assert.match(patch, /\+cooked/)
+  assert.equal(testResults.schema, "wp-codebox/test-results/v1")
+  assert.equal(testResults.status, "unknown")
+  assert.deepEqual(testResults.summary, { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 })
+  assert.deepEqual(testResults.suites, [])
+  assert.ok(testResults.rawLogReferences.some((log: { path: string }) => log.path === "logs/commands.log"))
   assert.equal(review.schema, "wp-codebox/artifact-review/v1")
   assert.equal(review.artifactId, artifacts.id)
   assert.equal(review.evidence.patch, "files/patch.diff")
   assert.equal(review.evidence.artifactContentDigest, contentDigest)
   assert.equal(review.evidence.changedFiles, "files/changed-files.json")
+  assert.equal(review.evidence.testResults, "files/test-results.json")
   assert.ok(review.changedFiles.some((file: { path: string; status: string }) =>
     file.path === "/wordpress/wp-content/plugins/seeded-helper/generated.txt" && file.status === "added",
   ))

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -267,6 +267,11 @@ file_put_contents(
 					'contentType' => 'text/x-diff',
 				),
 				array(
+					'path'        => 'files/test-results.json',
+					'kind'        => 'test-results',
+					'contentType' => 'application/json',
+				),
+				array(
 					'path'        => 'files/review.json',
 					'kind'        => 'review',
 					'contentType' => 'application/json',
@@ -279,6 +284,30 @@ file_put_contents(
 file_put_contents( $bundle_dir . '/metadata.json', json_encode( array( 'artifacts' => array( 'patch' => 'files/patch.diff' ) ), JSON_PRETTY_PRINT ) . "\n" );
 file_put_contents( $bundle_dir . '/files/changed-files.json', $changed_files_json );
 file_put_contents( $bundle_dir . '/files/patch.diff', $patch_diff );
+file_put_contents(
+	$bundle_dir . '/files/test-results.json',
+	json_encode(
+		array(
+			'schema'           => 'wp-codebox/test-results/v1',
+			'status'           => 'unknown',
+			'summary'          => array(
+				'total'   => 0,
+				'passed'  => 0,
+				'failed'  => 0,
+				'skipped' => 0,
+				'unknown' => 0,
+			),
+			'suites'           => array(),
+			'rawLogReferences' => array(
+				array(
+					'path' => 'logs/commands.log',
+					'kind' => 'commands-log',
+				),
+			),
+		),
+		JSON_PRETTY_PRINT
+	) . "\n"
+);
 file_put_contents(
 	$bundle_dir . '/files/review.json',
 	json_encode(
@@ -301,6 +330,7 @@ file_put_contents(
 $artifacts = new WP_Codebox_Artifacts();
 $listed    = $artifacts->list( array( 'artifacts_path' => $artifact_root ) );
 $assert( 'artifact listing succeeds', ! is_wp_error( $listed ) && 1 === count( $listed['artifacts'] ?? array() ) );
+$assert( 'artifact listing detects test results', ! is_wp_error( $listed ) && true === ( $listed['artifacts'][0]['has_test_results'] ?? false ) );
 
 $read_artifact = $artifacts->get(
 	array(
@@ -309,6 +339,7 @@ $read_artifact = $artifacts->get(
 	)
 );
 $assert( 'artifact get returns canonical changed files', ! is_wp_error( $read_artifact ) && 'wp-codebox/changed-files/v1' === ( $read_artifact['artifact']['changed_files']['schema'] ?? '' ) );
+$assert( 'artifact get returns test results', ! is_wp_error( $read_artifact ) && 'wp-codebox/test-results/v1' === ( $read_artifact['artifact']['test_results']['schema'] ?? '' ) );
 $assert( 'artifact get returns review payload', ! is_wp_error( $read_artifact ) && 'wp-codebox/artifact-review/v1' === ( $read_artifact['artifact']['review']['schema'] ?? '' ) );
 $assert( 'artifact get verifies content digest', ! is_wp_error( $read_artifact ) && $content_digest === ( $read_artifact['artifact']['content_digest'] ?? '' ) );
 


### PR DESCRIPTION
## Summary
- Adds `files/test-results.json` as a stable normalized artifact with schema, summary counts, suites, and raw log references.
- Threads the artifact through bundle metadata, manifest entries, review evidence, and the WordPress artifact reader.
- Documents the contract and extends artifact/WordPress smoke coverage without inferring pass/fail data when no structured test command exists.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the focused normalized test-results artifact contract, README updates, and smoke coverage; Chris remains responsible for review and merge.

Refs #26