### PR TITLE
Add richer task input contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,28 @@ The WordPress plugin registers parent-site abilities:
 
 These abilities shell out to the local `wp-codebox` CLI, boot disposable Playground sandboxes, mount the configured agent stack, invoke the sandbox agent through `agents/chat`, and return artifact metadata.
 
-`wp-codebox/run-agent-task` accepts task-shaped inputs only. It rejects raw `code` and `code_file` fields so frontend/chat callers cannot pass arbitrary PHP through the product ability path. Operators can still use CLI debug commands directly when they need raw PHP probes.
+`wp-codebox/run-agent-task` accepts the stable task input contract below. Existing callers that still send `task` as a string are normalized to the same shape with `goal` populated from `task`. It rejects raw `code` and `code_file` fields so frontend/chat callers cannot pass arbitrary PHP through the product ability path. Operators can still use CLI debug commands directly when they need raw PHP probes.
+
+```json
+{
+  "schema": "wp-codebox/task-input/v1",
+  "goal": "Add a focused product feature and return a reviewable patch.",
+  "target": {
+    "kind": "plugin",
+    "path": "wp-content/plugins/example"
+  },
+  "allowed_tools": ["workspace.read", "workspace.write", "tests.run"],
+  "expected_artifacts": ["patch", "tests", "review"],
+  "policy": {
+    "applyBack": "reviewed"
+  },
+  "context": {
+    "issue": "https://github.com/chubes4/wp-codebox/issues/29"
+  }
+}
+```
+
+`target.kind` is caller-defined but should use `repo`, `site`, `plugin`, or `theme` when possible. `allowed_tools` and `expected_artifacts` are advisory contract fields for the product caller and sandboxed agent loop; the host runner still decides the private CLI invocation and returns the normalized `task_input` alongside the string `task` it passed into the current CLI bridge.
 
 Component paths can come from ability input, the `wp_codebox_component_paths` option, or the `wp_codebox_component_paths` filter.
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -15,6 +15,32 @@ export interface RuntimePolicy {
   approvals: "never" | "on-write" | "on-command"
 }
 
+export type TaskTargetKind = "repo" | "site" | "plugin" | "theme" | (string & {})
+
+export interface TaskTarget {
+  kind: TaskTargetKind
+  ref?: string
+  path?: string
+  url?: string
+}
+
+export interface TaskInputPolicy {
+  approvals?: "never" | "on-write" | "on-command"
+  applyBack?: "disabled" | "reviewed"
+  sandbox?: "required" | "preferred"
+  [key: string]: unknown
+}
+
+export interface TaskInput {
+  schema?: "wp-codebox/task-input/v1"
+  goal: string
+  target?: TaskTarget
+  allowed_tools?: string[]
+  expected_artifacts?: string[]
+  policy?: TaskInputPolicy
+  context?: Record<string, unknown>
+}
+
 export type RuntimePolicyField = keyof RuntimePolicy
 
 export type RuntimePolicyValidationIssueCode =

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -15,10 +15,29 @@ WordPress Playground runtime, mounts the agent stack components, invokes the
 configured sandbox agent through the canonical `agents/chat` ability, and returns
 artifact metadata.
 
-The batch ability runs `wp-codebox agent-sandbox-batch`, accepts a list of
-task descriptions, and launches one isolated sandbox per task with bounded
-concurrency. This is the parent-site primitive for fan-out workflows such as
-assigning several GitHub issues to separate sandbox coding agents.
+The task ability accepts `wp-codebox/task-input/v1` fields: `goal`, `target`,
+`allowed_tools`, `expected_artifacts`, `policy`, and `context`. Legacy callers
+may still pass `task` as a string; the runner normalizes it into `goal` and
+returns the normalized `task_input` in the ability response. Raw PHP `code` and
+`code_file` fields remain rejected on this product ability path.
+
+```json
+{
+  "schema": "wp-codebox/task-input/v1",
+  "goal": "Fix the failing settings save flow.",
+  "target": { "kind": "plugin", "path": "wp-content/plugins/example" },
+  "allowed_tools": ["workspace.read", "workspace.write", "tests.run"],
+  "expected_artifacts": ["patch", "tests", "review"],
+  "policy": { "applyBack": "reviewed" },
+  "context": { "issue": "https://github.com/chubes4/wp-codebox/issues/29" }
+}
+```
+
+The batch ability runs `wp-codebox agent-sandbox-batch`, accepts a list of task
+descriptions or structured task inputs, and launches one isolated sandbox per
+task with bounded concurrency. This is the parent-site primitive for fan-out
+workflows such as assigning several GitHub issues to separate sandbox coding
+agents.
 
 Both abilities accept optional `provider` and `model` fields. These seed the
 disposable sandbox's Data Machine agent configuration for the selected execution

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -26,6 +26,7 @@ final class WP_Codebox_Abilities {
 
 	private function register(): void {
 		$register_callback = function (): void {
+			$task_input_schema  = self::task_input_schema();
 			$artifact_id_schema = array(
 				'artifact_id'    => array(
 					'type'        => 'string',
@@ -45,12 +46,21 @@ final class WP_Codebox_Abilities {
 					'category'            => 'wp-codebox',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'task' ),
+						'anyOf'      => array(
+							array( 'required' => array( 'goal' ) ),
+							array( 'required' => array( 'task' ) ),
+						),
 						'properties' => array(
+							'goal'                   => $task_input_schema['properties']['goal'],
 							'task'                   => array(
 								'type'        => 'string',
-								'description' => 'Task description to run inside the isolated sandbox.',
+								'description' => 'Legacy task description. Prefer goal for new product callers.',
 							),
+							'target'                 => $task_input_schema['properties']['target'],
+							'allowed_tools'          => $task_input_schema['properties']['allowed_tools'],
+							'expected_artifacts'     => $task_input_schema['properties']['expected_artifacts'],
+							'policy'                 => $task_input_schema['properties']['policy'],
+							'context'                => $task_input_schema['properties']['context'],
 							'agent'                  => array(
 								'type'        => 'string',
 								'description' => 'Sandbox agent slug to invoke through agents/chat. Defaults through wp_codebox_default_agent.',
@@ -108,6 +118,7 @@ final class WP_Codebox_Abilities {
 							'success'   => array( 'type' => 'boolean' ),
 							'schema'    => array( 'type' => 'string' ),
 							'task'      => array( 'type' => 'string' ),
+							'task_input' => $task_input_schema,
 							'wp'        => array( 'type' => 'string' ),
 							'paths'     => array( 'type' => 'object' ),
 							'artifacts' => array( 'type' => 'string' ),
@@ -133,8 +144,13 @@ final class WP_Codebox_Abilities {
 						'properties' => array(
 							'tasks'                  => array(
 								'type'        => 'array',
-								'description' => 'Task descriptions. Each task runs in its own isolated sandbox.',
-								'items'       => array( 'type' => 'string' ),
+								'description' => 'Task descriptions or structured task inputs. Each task runs in its own isolated sandbox.',
+								'items'       => array(
+									'anyOf' => array(
+										array( 'type' => 'string' ),
+										$task_input_schema,
+									),
+								),
 							),
 							'concurrency'            => array(
 								'type'        => 'integer',
@@ -167,6 +183,10 @@ final class WP_Codebox_Abilities {
 							'success'     => array( 'type' => 'boolean' ),
 							'schema'      => array( 'type' => 'string' ),
 							'tasks'       => array( 'type' => 'array' ),
+							'task_inputs' => array(
+								'type'  => 'array',
+								'items' => $task_input_schema,
+							),
 							'concurrency' => array( 'type' => 'integer' ),
 							'paths'       => array( 'type' => 'object' ),
 							'artifacts'   => array( 'type' => 'string' ),
@@ -273,6 +293,52 @@ final class WP_Codebox_Abilities {
 		}
 
 		add_action( 'wp_abilities_api_init', $register_callback );
+	}
+
+	/** @return array<string,mixed> */
+	private static function task_input_schema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'goal' ),
+			'properties' => array(
+				'schema'             => array(
+					'type'        => 'string',
+					'description' => 'Task input contract version. Use wp-codebox/task-input/v1.',
+				),
+				'goal'               => array(
+					'type'        => 'string',
+					'description' => 'User-facing outcome the sandboxed coding agent should accomplish.',
+				),
+				'target'             => array(
+					'type'        => 'object',
+					'description' => 'Bounded target for the task, such as a repo, site, plugin, or theme.',
+					'properties'  => array(
+						'kind' => array( 'type' => 'string' ),
+						'ref'  => array( 'type' => 'string' ),
+						'path' => array( 'type' => 'string' ),
+						'url'  => array( 'type' => 'string' ),
+					),
+				),
+				'allowed_tools'      => array(
+					'type'        => 'array',
+					'description' => 'Tool names the product caller expects the sandboxed agent to stay within.',
+					'items'       => array( 'type' => 'string' ),
+				),
+				'expected_artifacts' => array(
+					'type'        => 'array',
+					'description' => 'Artifact kinds the caller wants back, such as patch, review, tests, preview, or package.',
+					'items'       => array( 'type' => 'string' ),
+				),
+				'policy'             => array(
+					'type'        => 'object',
+					'description' => 'Caller policy hints for approvals, apply-back, sandboxing, and risk controls.',
+				),
+				'context'            => array(
+					'type'        => 'object',
+					'description' => 'Additional non-secret caller context for the sandboxed task.',
+				),
+			),
+		);
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -11,6 +11,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	private const SCHEMA = 'wp-codebox/agent-task-run/v1';
 	private const BATCH_SCHEMA = 'wp-codebox/agent-task-batch/v1';
+	private const TASK_INPUT_SCHEMA = 'wp-codebox/task-input/v1';
 
 	/** @var array<string, callable> */
 	private array $callbacks;
@@ -33,10 +34,12 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return new WP_Error( 'wp_codebox_shell_unavailable', 'Shell execution is not available for WP Codebox.', array( 'status' => 500 ) );
 		}
 
-		$task = trim( (string) ( $input['task'] ?? '' ) );
-		if ( '' === $task ) {
-			return new WP_Error( 'wp_codebox_task_missing', 'task is required.', array( 'status' => 400 ) );
+		$task_input = $this->task_input( $input );
+		if ( is_wp_error( $task_input ) ) {
+			return $task_input;
 		}
+		$task        = (string) $task_input['goal'];
+		$task_prompt = $this->task_input_prompt( $task_input );
 
 		$raw_code_input = $this->reject_raw_code_input( $input );
 		if ( is_wp_error( $raw_code_input ) ) {
@@ -65,7 +68,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			escapeshellarg( $paths['agents_api'] ),
 			escapeshellarg( $paths['data_machine'] ),
 			escapeshellarg( $paths['data_machine_code'] ),
-			escapeshellarg( $task ),
+			escapeshellarg( $task_prompt ),
 			escapeshellarg( $this->agent_slug( $input ) ),
 			escapeshellarg( $this->mode( $input ) ),
 			escapeshellarg( $this->provider( $input ) ),
@@ -124,6 +127,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'success'   => true,
 			'schema'    => self::SCHEMA,
 			'task'      => $task,
+			'task_input' => $task_input,
 			'wp'        => $wp_version,
 			'paths'     => $paths,
 			'artifacts' => $artifacts,
@@ -143,10 +147,16 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return new WP_Error( 'wp_codebox_shell_unavailable', 'Shell execution is not available for WP Codebox.', array( 'status' => 500 ) );
 		}
 
-		$tasks = $this->tasks( $input );
-		if ( empty( $tasks ) ) {
+		$task_inputs = $this->task_inputs( $input );
+		if ( is_wp_error( $task_inputs ) ) {
+			return $task_inputs;
+		}
+
+		if ( empty( $task_inputs ) ) {
 			return new WP_Error( 'wp_codebox_tasks_missing', 'tasks must include at least one task.', array( 'status' => 400 ) );
 		}
+		$tasks        = array_map( static fn( array $task_input ): string => (string) $task_input['goal'], $task_inputs );
+		$task_prompts = array_map( array( $this, 'task_input_prompt' ), $task_inputs );
 
 		$paths = $this->resolve_component_paths( $input );
 		if ( is_wp_error( $paths ) ) {
@@ -192,8 +202,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$command .= ' --secret-env ' . escapeshellarg( $secret_env );
 		}
 
-		foreach ( $tasks as $task ) {
-			$command .= ' --task ' . escapeshellarg( $task );
+		foreach ( $task_prompts as $task_prompt ) {
+			$command .= ' --task ' . escapeshellarg( $task_prompt );
 		}
 
 		$result    = $this->run_command( $command );
@@ -230,6 +240,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'success'     => true,
 			'schema'      => self::BATCH_SCHEMA,
 			'tasks'       => $tasks,
+			'task_inputs' => $task_inputs,
 			'concurrency' => $concurrency,
 			'wp'          => $wp_version,
 			'paths'       => $paths,
@@ -401,15 +412,81 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */
 	private function tasks( array $input ): array {
+		$task_inputs = $this->task_inputs( $input );
+		if ( is_wp_error( $task_inputs ) ) {
+			return array();
+		}
+
+		return array_map( static fn( array $task_input ): string => (string) $task_input['goal'], $task_inputs );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private function task_input( array $input ): array|WP_Error {
+		$goal = trim( (string) ( $input['goal'] ?? $input['task'] ?? '' ) );
+		if ( '' === $goal ) {
+			return new WP_Error( 'wp_codebox_task_missing', 'goal is required.', array( 'status' => 400 ) );
+		}
+
+		$task_input = array(
+			'schema' => self::TASK_INPUT_SCHEMA,
+			'goal'   => $goal,
+		);
+
+		foreach ( array( 'target', 'policy', 'context' ) as $field ) {
+			if ( isset( $input[ $field ] ) && is_array( $input[ $field ] ) ) {
+				$task_input[ $field ] = $input[ $field ];
+			}
+		}
+
+		foreach ( array( 'allowed_tools', 'expected_artifacts' ) as $field ) {
+			$values = $this->string_list( $input[ $field ] ?? array() );
+			if ( ! empty( $values ) ) {
+				$task_input[ $field ] = $values;
+			}
+		}
+
+		return $task_input;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
+	private function task_inputs( array $input ): array|WP_Error {
 		$tasks = is_array( $input['tasks'] ?? null ) ? $input['tasks'] : array();
 
+		$task_inputs = array();
+		foreach ( $tasks as $task ) {
+			$normalized = is_array( $task ) ? $this->task_input( $task ) : $this->task_input( array( 'task' => $task ) );
+			if ( is_wp_error( $normalized ) ) {
+				continue;
+			}
+
+			$task_inputs[] = $normalized;
+		}
+
+		return $task_inputs;
+	}
+
+	/** @param array<string,mixed> $task_input Normalized task input. */
+	private function task_input_prompt( array $task_input ): string {
+		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $task_input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $task_input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		return is_string( $encoded ) ? $encoded : '';
+	}
+
+	/** @return string[] */
+	private function string_list( mixed $values ): array {
+		if ( ! is_array( $values ) ) {
+			return array();
+		}
+
 		return array_values(
-			array_filter(
-				array_map(
-					static fn( $task ): string => trim( (string) $task ),
-					$tasks
-				),
-				static fn( string $task ): bool => '' !== $task
+			array_unique(
+				array_filter(
+					array_map(
+						static fn( $value ): string => trim( (string) $value ),
+						$values
+					),
+					static fn( string $value ): bool => '' !== $value
+				)
 			)
 		);
 	}

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -82,7 +82,11 @@ new WP_Codebox_Abilities();
 $ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-agent-task'] ?? null;
 $assert( 'run-agent-task ability registered', is_array( $ability ) );
 $assert( 'ability is REST visible', true === ( $ability['meta']['show_in_rest'] ?? false ) );
-$assert( 'ability requires task only', array( 'task' ) === ( $ability['input_schema']['required'] ?? array() ) );
+$assert( 'ability accepts goal or legacy task', array( 'goal' ) === ( $ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
+$assert( 'ability exposes task target schema', isset( $ability['input_schema']['properties']['target']['properties']['kind'] ) );
+$assert( 'ability exposes allowed tools schema', 'array' === ( $ability['input_schema']['properties']['allowed_tools']['type'] ?? '' ) );
+$assert( 'ability exposes expected artifacts schema', 'array' === ( $ability['input_schema']['properties']['expected_artifacts']['type'] ?? '' ) );
+$assert( 'ability exposes policy and context schema', 'object' === ( $ability['input_schema']['properties']['policy']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['context']['type'] ?? '' ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
@@ -143,6 +147,7 @@ $result = $runner->run(
 
 $assert( 'runner succeeds with filter-provided component paths', ! is_wp_error( $result ) && true === ( $result['success'] ?? false ) );
 $assert( 'runner schema is stable', ! is_wp_error( $result ) && 'wp-codebox/agent-task-run/v1' === ( $result['schema'] ?? '' ) );
+$assert( 'runner returns normalized task input for legacy task', ! is_wp_error( $result ) && 'wp-codebox/task-input/v1' === ( $result['task_input']['schema'] ?? '' ) && 'Run a chat-requested sandbox task.' === ( $result['task_input']['goal'] ?? '' ) );
 $assert( 'runner invokes agent-sandbox-run', str_contains( $captured_command, 'agent-sandbox-run' ) );
 $assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node ' ) );
 $assert( 'runner passes task', str_contains( $captured_command, '--task' ) );
@@ -172,6 +177,26 @@ $raw_code_file = $runner->run(
 );
 $assert( 'raw code file input fails closed', is_wp_error( $raw_code_file ) && 'wp_codebox_raw_code_forbidden' === $raw_code_file->get_error_code() );
 
+$structured_result = $runner->run(
+	array(
+		'goal'               => 'Add a focused product feature.',
+		'target'             => array(
+			'kind' => 'plugin',
+			'path' => 'wp-content/plugins/simple-plugin',
+		),
+		'allowed_tools'      => array( 'workspace.read', 'workspace.write', '' ),
+		'expected_artifacts' => array( 'patch', 'tests', 'patch' ),
+		'policy'             => array( 'applyBack' => 'reviewed' ),
+		'context'            => array( 'issue' => 'https://github.com/chubes4/wp-codebox/issues/29' ),
+		'artifacts_path'     => $root . '/artifacts',
+	)
+);
+
+$assert( 'runner accepts structured task input', ! is_wp_error( $structured_result ) && 'Add a focused product feature.' === ( $structured_result['task_input']['goal'] ?? '' ) );
+$assert( 'runner preserves structured target', ! is_wp_error( $structured_result ) && 'plugin' === ( $structured_result['task_input']['target']['kind'] ?? '' ) );
+$assert( 'runner normalizes task input lists', ! is_wp_error( $structured_result ) && array( 'workspace.read', 'workspace.write' ) === ( $structured_result['task_input']['allowed_tools'] ?? array() ) && array( 'patch', 'tests' ) === ( $structured_result['task_input']['expected_artifacts'] ?? array() ) );
+$assert( 'runner passes structured task contract to CLI', str_contains( $captured_command, 'wp-codebox/task-input/v1' ) && str_contains( $captured_command, 'allowed_tools' ) );
+
 $batch_result = $runner->run_batch(
 	array(
 		'tasks'          => array( 'Fix issue one.', 'Fix issue two.' ),
@@ -182,6 +207,7 @@ $batch_result = $runner->run_batch(
 
 $assert( 'batch runner succeeds with filter-provided component paths', ! is_wp_error( $batch_result ) && true === ( $batch_result['success'] ?? false ) );
 $assert( 'batch runner schema is stable', ! is_wp_error( $batch_result ) && 'wp-codebox/agent-task-batch/v1' === ( $batch_result['schema'] ?? '' ) );
+$assert( 'batch runner returns normalized task inputs', ! is_wp_error( $batch_result ) && 2 === count( $batch_result['task_inputs'] ?? array() ) && 'Fix issue one.' === ( $batch_result['task_inputs'][0]['goal'] ?? '' ) );
 $assert( 'batch runner invokes agent-sandbox-batch', str_contains( $captured_command, 'agent-sandbox-batch' ) );
 $assert( 'batch runner passes repeated tasks', 2 === substr_count( $captured_command, '--task' ) );
 $assert( 'batch runner passes concurrency', str_contains( $captured_command, '--concurrency' ) && str_contains( $captured_command, '2' ) );


### PR DESCRIPTION
## Summary
- Adds a `wp-codebox/task-input/v1` contract for `goal`, `target`, `allowed_tools`, `expected_artifacts`, `policy`, and `context`.
- Normalizes legacy `task` strings into the structured task input while keeping raw `code` and `code_file` rejected on the product ability path.
- Documents the contract and expands WordPress plugin smoke coverage for structured and legacy task inputs.

Closes #29.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused schema/types implementation, docs, and smoke coverage; Chris remains responsible for review and testing.