### PR TITLE
Add artifact provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Current bundles include:
 - `files/diffs/<mount>.patch`: unified text diff from a seeded baseline to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
-`metadata.json` points to the canonical changed-files, patch, test-results, review, and mount-diff artifact paths under `artifacts`. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
+`metadata.json` points to the canonical changed-files, patch, test-results, review, and mount-diff artifact paths under `artifacts`. It also includes `provenance` derived from data WP Codebox already has: task input/context where available, WP Codebox runtime version, WordPress version, mounted component/mount metadata, and agent/provider/model fields passed to the sandbox runner. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
 
 ### `files/test-results.json`
 
@@ -255,6 +255,24 @@ Artifact bundle ids are content-addressed for the apply-back contract. The runti
 {
   "schema": "wp-codebox/artifact-review/v1",
   "artifactId": "artifact-bundle-...",
+  "provenance": {
+    "task": { "kind": "agent-sandbox-run", "input": "Add a Dry Rub filter..." },
+    "runtime": {
+      "backend": "wordpress-playground",
+      "version": "0.0.0",
+      "wordpressVersion": "7.0"
+    },
+    "agent": { "agent": "sandbox-agent", "provider": "openai", "model": "gpt-5.5" },
+    "mounts": [
+      {
+        "type": "directory",
+        "source": "/path/to/data-machine-code",
+        "target": "/wordpress/wp-content/plugins/data-machine-code",
+        "mode": "readonly",
+        "metadata": { "kind": "component", "slug": "data-machine-code" }
+      }
+    ]
+  },
   "summary": "Sandbox produced changes in 1 file.",
   "stats": { "added": 1, "modified": 0, "deleted": 0, "total": 1 },
   "changedFiles": [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,13 +8,14 @@ import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } fr
 import { captureStdout, printBatchHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
 
 interface RunOptions {
-  mounts: Array<{ source: string; target: string; mode: "readonly" | "readwrite" }>
+  mounts: Array<{ source: string; target: string; mode: "readonly" | "readwrite"; metadata?: Record<string, unknown> }>
   command: string
   args: string[]
   wpVersion?: string
   artifactsDirectory?: string
   policy?: RuntimePolicy
   secretEnv?: Record<string, string>
+  metadata?: Record<string, unknown>
   json: boolean
 }
 
@@ -140,6 +141,7 @@ const defaultPolicy: RuntimePolicy = {
   approvals: "never",
 }
 
+const WP_CODEBOX_RUNTIME_VERSION = "0.0.0"
 const DEFAULT_WORDPRESS_VERSION = "7.0"
 const supportedRecipeCommands = new Set(["inspect-mounted-inputs", "wordpress.run-php", "wordpress.wp-cli", "wordpress.ability"])
 
@@ -269,6 +271,7 @@ async function agentRuntimeProbeRunOptions(options: AgentRuntimeProbeOptions): P
     args: [`code=${agentRuntimeProbeCode(providerPluginMounts(options))}`],
     wpVersion: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
     artifactsDirectory: options.artifactsDirectory,
+    metadata: agentRuntimeMetadata(options),
     ...await runSecretEnvOptions(options),
     json: options.json,
   }
@@ -281,6 +284,7 @@ async function agentSandboxRunOptions(options: AgentSandboxRunOptions): Promise<
     args: [`code=${agentSandboxRunCode(options.task, await resolveSandboxTaskCode(options), providerPluginMounts(options))}`],
     wpVersion: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
     artifactsDirectory: options.artifactsDirectory,
+    metadata: agentSandboxRunMetadata(options),
     ...await runSecretEnvOptions(options),
     json: options.json,
   }
@@ -333,7 +337,10 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         policy: Object.keys(secretEnv).length > 0 ? { ...policy, secrets: "connector-scoped" } : policy,
         secretEnv,
         artifactsDirectory: options.artifactsDirectory ?? recipe.artifacts?.directory,
-        metadata: recipeRunMetadata(recipe, recipePath, workspaceMounts),
+        metadata: {
+          ...runtimeMetadata(options.artifactsDirectory ?? recipe.artifacts?.directory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
+          ...recipeRunMetadata(recipe, recipePath, workspaceMounts),
+        },
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -474,16 +481,32 @@ async function mapWithConcurrency<T, R>(items: T[], concurrency: number, callbac
 
 function agentRuntimeMounts(options: AgentRuntimeProbeOptions): RunOptions["mounts"] {
   return [
-    { source: resolve(options.agentsApiPath), target: "/wordpress/wp-content/plugins/agents-api", mode: "readonly" },
-    { source: resolve(options.dataMachinePath), target: "/wordpress/wp-content/plugins/data-machine", mode: "readonly" },
-    { source: resolve(options.dataMachineCodePath), target: "/wordpress/wp-content/plugins/data-machine-code", mode: "readonly" },
+    componentMount(options.agentsApiPath, "/wordpress/wp-content/plugins/agents-api", "agents-api"),
+    componentMount(options.dataMachinePath, "/wordpress/wp-content/plugins/data-machine", "data-machine"),
+    componentMount(options.dataMachineCodePath, "/wordpress/wp-content/plugins/data-machine-code", "data-machine-code"),
     ...providerPluginMounts(options).map((plugin) => ({
       source: plugin.source,
       target: `/wordpress/wp-content/plugins/${plugin.slug}`,
       mode: "readonly" as const,
+      metadata: {
+        kind: "provider-plugin",
+        slug: plugin.slug,
+      },
     })),
     ...options.mounts,
   ]
+}
+
+function componentMount(source: string, target: string, slug: string): RunOptions["mounts"][number] {
+  return {
+    source: resolve(source),
+    target,
+    mode: "readonly",
+    metadata: {
+      kind: "component",
+      slug,
+    },
+  }
 }
 
 function providerPluginMounts(options: AgentRuntimeProbeOptions): Array<{ source: string; slug: string }> {
@@ -491,6 +514,63 @@ function providerPluginMounts(options: AgentRuntimeProbeOptions): Array<{ source
     const source = resolve(pluginPath)
     return { source, slug: basename(source) }
   })
+}
+
+function runtimeMetadata(artifactsDirectory: string | undefined, wpVersion: string): Record<string, unknown> {
+  return {
+    runtime: {
+      version: WP_CODEBOX_RUNTIME_VERSION,
+      wordpressVersion: wpVersion,
+    },
+    task: {
+      artifactsDirectory,
+    },
+  }
+}
+
+function runMetadata(options: RunOptions): Record<string, unknown> {
+  return {
+    ...runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION),
+    task: stripUndefined({
+      kind: "cli-run",
+      command: options.command,
+      args: options.args,
+      artifactsDirectory: options.artifactsDirectory,
+    }),
+  }
+}
+
+function agentRuntimeMetadata(options: AgentRuntimeProbeOptions): Record<string, unknown> {
+  const base = runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION)
+
+  return {
+    ...base,
+    task: {
+      ...(base.task as Record<string, unknown>),
+      kind: "agent-runtime-probe",
+      secretEnv: options.secretEnvNames ?? [],
+    },
+  }
+}
+
+function agentSandboxRunMetadata(options: AgentSandboxRunOptions): Record<string, unknown> {
+  return {
+    ...runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION),
+    task: stripUndefined({
+      kind: "agent-sandbox-run",
+      input: options.task,
+      sessionId: options.sessionId,
+      maxTurns: options.maxTurns,
+      hasCodeOverride: Boolean(options.code || options.codeFile),
+      secretEnv: options.secretEnvNames ?? [],
+    }),
+    agent: stripUndefined({
+      agent: options.agent,
+      mode: options.mode,
+      provider: options.provider,
+      model: options.model,
+    }),
+  }
 }
 
 function parseAgentRuntimeProbeOptions(args: string[], extraOptions: string[] = []): AgentRuntimeProbeOptions {
@@ -739,12 +819,13 @@ async function run(options: RunOptions): Promise<RunOutput> {
         policy: options.policy ?? runPolicy(options.command),
         secretEnv: options.secretEnv,
         artifactsDirectory: options.artifactsDirectory,
+        metadata: options.metadata ?? runMetadata(options),
       },
       createPlaygroundRuntimeBackend(),
     )
 
     for (const mount of options.mounts) {
-      await runtime.mount({ type: "directory", source: mount.source, target: mount.target, mode: mount.mode })
+      await runtime.mount({ type: "directory", source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
     }
 
     execution = await runtime.execute({ command: options.command, args: options.args })
@@ -1168,6 +1249,19 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         secretEnv: recipe.inputs?.secretEnv ?? [],
       },
     },
+    task: {
+      kind: "recipe-run",
+      recipePath,
+      workflow: {
+        steps: recipe.workflow.steps.map((step) => ({ command: step.command, args: step.args ?? [] })),
+      },
+      inputs: {
+        workspaces: recipe.inputs?.workspaces ?? [],
+        mounts: recipe.inputs?.mounts ?? [],
+        extra_plugins: recipeExtraPlugins(recipe),
+        secretEnv: recipe.inputs?.secretEnv ?? [],
+      },
+    },
     preparedWorkspaces: workspaceMounts.map((workspace) => ({
       target: workspace.target,
       mode: workspace.mode,
@@ -1336,12 +1430,23 @@ function parseMount(value: string): RunOptions["mounts"][number] {
     throw new Error(`Invalid mount mode, expected readonly or readwrite: ${mode}`)
   }
 
-  return { source: resolve(source), target, mode }
+  return {
+    source: resolve(source),
+    target,
+    mode,
+    metadata: {
+      kind: "cli-mount",
+    },
+  }
 }
 
 async function parsePolicy(value: string): Promise<RuntimePolicy> {
   const raw = value.trim().startsWith("{") ? value : await readFile(resolve(value), "utf8")
   return JSON.parse(raw) as RuntimePolicy
+}
+
+function stripUndefined<T extends Record<string, unknown>>(record: T): T {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined)) as T
 }
 
 main(process.argv.slice(2)).then(

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -238,6 +238,23 @@ export interface ArtifactContentDigest {
   value: string
 }
 
+export interface ArtifactProvenance {
+  task?: Record<string, unknown>
+  runtime: {
+    backend: RuntimeBackendKind
+    version?: string
+    wordpressVersion?: string
+  }
+  agent?: Record<string, unknown>
+  mounts: Array<{
+    type: MountSpec["type"]
+    source: string
+    target: string
+    mode: MountSpec["mode"]
+    metadata?: Record<string, unknown>
+  }>
+}
+
 export type ArtifactReviewProgressEventType =
   | "boot"
   | "mount"
@@ -275,6 +292,7 @@ export interface ArtifactReview {
   schema: "wp-codebox/artifact-review/v1"
   artifactId: string
   createdAt: string
+  provenance: ArtifactProvenance
   summary: string
   stats: {
     added: number

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -8,6 +8,7 @@ import type {
   ArtifactBundle,
   ArtifactManifest,
   ArtifactManifestFile,
+  ArtifactProvenance,
   ArtifactReview,
   ArtifactSpec,
   ArtifactTestResults,
@@ -298,11 +299,13 @@ class PlaygroundRuntime implements Runtime {
       inputs: ["files/changed-files.json", "files/patch.diff"],
       value: contentDigest,
     }
+    const provenance = this.buildArtifactProvenance(runtime)
     const metadata: Record<string, unknown> = {
       id: bundleId,
       contentDigest: contentDigestMetadata,
       createdAt,
       runtime,
+      provenance,
       mounts: this.mounts,
       policy: this.spec.policy,
       context: this.spec.metadata ?? {},
@@ -315,7 +318,7 @@ class PlaygroundRuntime implements Runtime {
       spec,
     })
     const testResults = this.buildTestResults()
-    const review = this.buildArtifactReview(bundleId, createdAt, changedFiles, patch, contentDigest)
+    const review = this.buildArtifactReview(bundleId, createdAt, provenance, changedFiles, patch, contentDigest)
     const reviewJson = `${JSON.stringify(review, null, 2)}\n`
     const artifactFiles = {
       changedFiles: relative(this.artifactRoot, changedFilesPath),
@@ -413,6 +416,7 @@ class PlaygroundRuntime implements Runtime {
   private buildArtifactReview(
     artifactId: string,
     createdAt: string,
+    provenance: ArtifactProvenance,
     changedFiles: CanonicalChangedFiles,
     patch: string,
     contentDigest: string,
@@ -430,6 +434,7 @@ class PlaygroundRuntime implements Runtime {
       schema: "wp-codebox/artifact-review/v1",
       artifactId,
       createdAt,
+      provenance,
       summary,
       stats,
       changedFiles: changedFiles.files.map((file) => ({
@@ -519,6 +524,26 @@ class PlaygroundRuntime implements Runtime {
         },
       ],
     }
+  }
+
+  private buildArtifactProvenance(runtime: RuntimeInfo): ArtifactProvenance {
+    const context = this.spec.metadata ?? {}
+    return stripUndefined({
+      task: provenanceContext(context, "task"),
+      runtime: stripUndefined({
+        backend: runtime.backend,
+        version: provenanceString(provenanceContext(context, "runtime"), "version"),
+        wordpressVersion: runtime.environment.version,
+      }),
+      agent: provenanceContext(context, "agent"),
+      mounts: this.mounts.map((mount) => stripUndefined({
+        type: mount.type,
+        source: mount.source,
+        target: mount.target,
+        mode: mount.mode,
+        metadata: mount.metadata,
+      })),
+    })
   }
 
   private buildBlueprintAfter(capturedMounts: CapturedMountFiles): Record<string, unknown> {
@@ -958,6 +983,28 @@ function serializeCapturedMountFiles(captured: CapturedMountFiles): CapturedMoun
     ...captured,
     files: captured.files.map(({ replayContents, ...file }) => file),
   }
+}
+
+function provenanceContext(context: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = context[key]
+  if (!isRecord(value) || Object.keys(value).length === 0) {
+    return undefined
+  }
+
+  return value
+}
+
+function provenanceString(context: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = context?.[key]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function stripUndefined<T extends Record<string, unknown>>(record: T): T {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined)) as T
 }
 
 async function writeJsonLines(path: string, records: unknown[]): Promise<void> {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
+import { createRuntime } from "@chubes4/wp-codebox-core"
+import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 const execFileAsync = promisify(execFile)
 const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-artifacts-"))
@@ -70,6 +72,15 @@ try {
     review: "files/review.json",
     mountDiffs: "files/diffs.json",
   })
+  assert.equal(metadata.provenance.runtime.backend, "wordpress-playground")
+  assert.equal(metadata.provenance.runtime.version, "0.0.0")
+  assert.equal(metadata.provenance.runtime.wordpressVersion, "latest")
+  assert.equal(metadata.provenance.task.kind, "recipe-run")
+  assert.equal(metadata.provenance.task.recipePath.endsWith("examples/recipes/seeded-plugin-workspace.json"), true)
+  assert.ok(metadata.provenance.task.inputs.workspaces.length > 0)
+  assert.ok(metadata.provenance.mounts.some((mount: { target: string; mode: string; metadata?: { kind?: string } }) =>
+    mount.target === "/wordpress/wp-content/plugins/seeded-helper" && mount.mode === "readwrite" && mount.metadata?.kind === "recipe-workspace",
+  ))
   assert.equal(changedFiles.schema, "wp-codebox/changed-files/v1")
   assert.ok(
     changedFiles.files.some((file: { path: string; status: string }) =>
@@ -85,6 +96,8 @@ try {
   assert.ok(testResults.rawLogReferences.some((log: { path: string }) => log.path === "logs/commands.log"))
   assert.equal(review.schema, "wp-codebox/artifact-review/v1")
   assert.equal(review.artifactId, artifacts.id)
+  assert.equal(review.provenance.task.kind, "recipe-run")
+  assert.equal(review.provenance.runtime.wordpressVersion, "latest")
   assert.equal(review.evidence.patch, "files/patch.diff")
   assert.equal(review.evidence.artifactContentDigest, contentDigest)
   assert.equal(review.evidence.changedFiles, "files/changed-files.json")
@@ -95,6 +108,47 @@ try {
   assert.ok(review.actions.some((action: { kind: string; requiresApprovedFiles?: boolean }) => action.kind === "approve" && action.requiresApprovedFiles === true))
   assert.ok(review.actions.some((action: { kind: string }) => action.kind === "discard"))
   assert.ok(review.progress.some((event: { type: string; label: string }) => event.type === "complete" && event.label === "Ready for your review."))
+
+  const agentMount = join(artifactsDirectory, "agent-mounted-component")
+  await mkdir(agentMount, { recursive: true })
+  await writeFile(join(agentMount, "component.php"), "<?php // fixture\n")
+  const runtime = await createRuntime(
+    {
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", name: "provenance-smoke", version: "7.0", blueprint: { steps: [] } },
+      policy: {
+        network: "deny",
+        filesystem: "readwrite-mounts",
+        commands: ["wordpress.run-php"],
+        secrets: "none",
+        approvals: "never",
+      },
+      artifactsDirectory,
+      metadata: {
+        runtime: { version: "0.0.0" },
+        task: { kind: "agent-sandbox-run", input: "Cook provenance smoke" },
+        agent: { agent: "sandbox-agent", provider: "openai", model: "gpt-5.5" },
+      },
+    },
+    createPlaygroundRuntimeBackend(),
+  )
+  await runtime.mount({
+    type: "directory",
+    source: agentMount,
+    target: "/wordpress/wp-content/plugins/provenance-smoke",
+    mode: "readonly",
+    metadata: { kind: "component", slug: "provenance-smoke" },
+  })
+  const agentArtifacts = await runtime.collectArtifacts({ includeLogs: true })
+  const agentMetadata = JSON.parse(await readFile(agentArtifacts.metadataPath, "utf8"))
+  const agentReview = JSON.parse(await readFile(agentArtifacts.reviewPath, "utf8"))
+  assert.equal(agentMetadata.provenance.task.input, "Cook provenance smoke")
+  assert.deepEqual(agentMetadata.provenance.agent, { agent: "sandbox-agent", provider: "openai", model: "gpt-5.5" })
+  assert.equal(agentReview.provenance.agent.model, "gpt-5.5")
+  assert.ok(agentReview.provenance.mounts.some((mount: { target: string; metadata?: { slug?: string } }) =>
+    mount.target === "/wordpress/wp-content/plugins/provenance-smoke" && mount.metadata?.slug === "provenance-smoke",
+  ))
+  await runtime.destroy()
 
   console.log("Artifact contract smoke passed")
 } finally {


### PR DESCRIPTION
## Summary
- Add a shared artifact provenance block to `metadata.json` and `files/review.json` using runtime, task, agent, and mount data WP Codebox already has.
- Thread provenance metadata through CLI runs, recipe runs, and agent sandbox/probe runners without discovering or inventing unsupported fields.
- Document the provenance contract and extend artifact smoke coverage for recipe and agent/provider/model provenance.

## Tests
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the focused provenance metadata implementation, documentation, and smoke coverage for Chris to review.

Refs #26