### PR TITLE
Add apply audit records

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -473,7 +473,7 @@ final class WP_Codebox_Artifacts {
 		$redacted = array();
 		foreach ( $value as $key => $item ) {
 			$normalized_key = strtolower( (string) $key );
-			if ( in_array( $normalized_key, array( 'patch', 'patch_body', 'patch_diff', 'diff', 'body', 'content', 'contents' ), true ) ) {
+			if ( $this->is_sensitive_audit_key( $normalized_key ) ) {
 				$redacted[ $key ] = '[redacted]';
 				continue;
 			}
@@ -482,6 +482,20 @@ final class WP_Codebox_Artifacts {
 		}
 
 		return $redacted;
+	}
+
+	private function is_sensitive_audit_key( string $key ): bool {
+		if ( in_array( $key, array( 'patch', 'patch_body', 'patch_diff', 'diff', 'body', 'content', 'contents' ), true ) ) {
+			return true;
+		}
+
+		foreach ( array( 'secret', 'token', 'password', 'credential', 'authorization', 'private_key', 'api_key' ) as $needle ) {
+			if ( str_contains( $key, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/** @param array<string,mixed> $record Audit record. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -12,6 +12,7 @@ final class WP_Codebox_Artifacts {
 	private const LIST_SCHEMA  = 'wp-codebox/artifact-list/v1';
 	private const GET_SCHEMA   = 'wp-codebox/artifact/v1';
 	private const APPLY_SCHEMA = 'wp-codebox/artifact-apply/v1';
+	private const APPLY_AUDIT_SCHEMA = 'wp-codebox/apply-audit/v1';
 	private const CONTENT_DIGEST_PREFIX = "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n";
 	private const CONTENT_DIGEST_SEPARATOR = "\nfiles/patch.diff\n";
 
@@ -91,6 +92,11 @@ final class WP_Codebox_Artifacts {
 			return $bundle;
 		}
 
+		$root = $this->artifact_root( $input );
+		if ( is_wp_error( $root ) ) {
+			return $root;
+		}
+
 		$approved_files = $this->approved_files( $input );
 		if ( empty( $approved_files ) ) {
 			return new WP_Error( 'wp_codebox_approved_files_missing', 'approved_files must include at least one sandbox path.', array( 'status' => 400 ) );
@@ -145,12 +151,16 @@ final class WP_Codebox_Artifacts {
 
 		$result = apply_filters( 'wp_codebox_apply_approved_artifact', null, $payload );
 		if ( null === $result ) {
+			$this->record_apply_audit( $root, $bundle, $approved_files, $payload, null, new WP_Error( 'wp_codebox_apply_adapter_missing', 'No apply-back adapter handled this approved artifact.', array( 'status' => 501 ) ) );
 			return new WP_Error( 'wp_codebox_apply_adapter_missing', 'No apply-back adapter handled this approved artifact.', array( 'status' => 501 ) );
 		}
 
 		if ( is_wp_error( $result ) ) {
+			$this->record_apply_audit( $root, $bundle, $approved_files, $payload, null, $result );
 			return $result;
 		}
+
+		$this->record_apply_audit( $root, $bundle, $approved_files, $payload, $result, null );
 
 		return array(
 			'success'        => true,
@@ -359,6 +369,124 @@ final class WP_Codebox_Artifacts {
 				)
 			)
 		);
+	}
+
+	/**
+	 * @param array<string,mixed> $bundle Artifact bundle.
+	 * @param string[]            $approved_files Approved sandbox paths.
+	 * @param array<string,mixed> $payload Apply adapter payload.
+	 * @param mixed               $result Apply adapter result.
+	 */
+	private function record_apply_audit( string $root, array $bundle, array $approved_files, array $payload, mixed $result, ?WP_Error $error ): void {
+		$record = array(
+			'schema'         => self::APPLY_AUDIT_SCHEMA,
+			'timestamp'      => gmdate( 'c' ),
+			'artifact_id'    => (string) $bundle['id'],
+			'content_digest' => (string) ( $payload['artifact_content_digest'] ?? $bundle['content_digest'] ?? '' ),
+			'patch_sha256'   => (string) ( $payload['patch_sha256'] ?? '' ),
+			'requester'      => $this->requester_principal( $bundle ),
+			'approver'       => $this->approver_principal( $payload['approver'] ?? null ),
+			'approved_files' => $approved_files,
+			'adapter'        => is_array( $result ) ? ( $result['adapter'] ?? null ) : $this->adapter_from_error( $error ),
+			'status'         => null === $error ? 'success' : 'failure',
+		);
+
+		if ( is_array( $result ) ) {
+			$record['result'] = $this->redact_audit_metadata( $result );
+		}
+
+		if ( null !== $error ) {
+			$record['error'] = array(
+				'code'    => $error->get_error_code(),
+				'message' => $error->get_error_message(),
+				'data'    => $this->redact_audit_metadata( $error->get_error_data() ),
+			);
+		}
+
+		$record = $this->strip_null_values( $record );
+		$line   = function_exists( 'wp_json_encode' ) ? wp_json_encode( $record, JSON_UNESCAPED_SLASHES ) : json_encode( $record, JSON_UNESCAPED_SLASHES );
+		if ( false === $line ) {
+			return;
+		}
+
+		file_put_contents( $this->apply_audit_path( $root ), $line . "\n", FILE_APPEND | LOCK_EX );
+	}
+
+	private function apply_audit_path( string $root ): string {
+		$path = $root . DIRECTORY_SEPARATOR . 'apply-audit.jsonl';
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$path = (string) apply_filters( 'wp_codebox_apply_audit_path', $path, $root );
+		}
+
+		return $path;
+	}
+
+	/** @param array<string,mixed> $bundle Artifact bundle. */
+	private function requester_principal( array $bundle ): mixed {
+		foreach ( array( 'metadata', 'review' ) as $section ) {
+			$provenance = is_array( $bundle[ $section ]['provenance'] ?? null ) ? $bundle[ $section ]['provenance'] : array();
+			$task       = is_array( $provenance['task'] ?? null ) ? $provenance['task'] : array();
+
+			foreach ( array( 'requester', 'requested_by', 'principal', 'user' ) as $key ) {
+				if ( ! empty( $task[ $key ] ) ) {
+					return $task[ $key ];
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private function approver_principal( mixed $input_approver ): mixed {
+		if ( null !== $input_approver && '' !== $input_approver ) {
+			return $input_approver;
+		}
+
+		if ( function_exists( 'wp_get_current_user' ) ) {
+			$user = wp_get_current_user();
+			if ( is_object( $user ) && ! empty( $user->ID ) ) {
+				return array(
+					'id'    => (int) $user->ID,
+					'login' => (string) ( $user->user_login ?? '' ),
+				);
+			}
+		}
+
+		return null;
+	}
+
+	private function adapter_from_error( ?WP_Error $error ): mixed {
+		if ( null === $error ) {
+			return null;
+		}
+
+		$data = $error->get_error_data();
+		return is_array( $data ) ? ( $data['adapter'] ?? null ) : null;
+	}
+
+	private function redact_audit_metadata( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$redacted = array();
+		foreach ( $value as $key => $item ) {
+			$normalized_key = strtolower( (string) $key );
+			if ( in_array( $normalized_key, array( 'patch', 'patch_body', 'patch_diff', 'diff', 'body', 'content', 'contents' ), true ) ) {
+				$redacted[ $key ] = '[redacted]';
+				continue;
+			}
+
+			$redacted[ $key ] = $this->redact_audit_metadata( $item );
+		}
+
+		return $redacted;
+	}
+
+	/** @param array<string,mixed> $record Audit record. @return array<string,mixed> */
+	private function strip_null_values( array $record ): array {
+		return array_filter( $record, static fn( mixed $value ): bool => null !== $value );
 	}
 
 	private function path_is_inside( string $path, string $root ): bool {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -364,6 +364,7 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function 
 		'artifact_content_digest' => $payload['artifact_content_digest'],
 		'patch_contains'          => str_contains( $payload['patch'], 'cooked' ),
 		'patch'                   => $payload['patch'],
+		'access_token'            => 'secret-token-value',
 		'pr_url'                  => 'https://github.com/chubes4/wp-codebox/pull/999',
 	);
 };
@@ -384,10 +385,10 @@ $success_encoded = isset( $audit_lines[0] ) ? $audit_lines[0] : '';
 $assert( 'approved artifact apply writes success audit record', is_array( $success_audit ) && 'wp-codebox/apply-audit/v1' === ( $success_audit['schema'] ?? '' ) && 'success' === ( $success_audit['status'] ?? '' ) );
 $assert( 'success audit records reviewed principals and files', 'chat:user-7' === ( $success_audit['requester'] ?? '' ) && 'site-user:1' === ( $success_audit['approver'] ?? '' ) && array( '/wordpress/wp-content/plugins/example/generated.txt' ) === ( $success_audit['approved_files'] ?? array() ) );
 $assert( 'success audit records digest and adapter metadata', $artifact_id === ( $success_audit['artifact_id'] ?? '' ) && $content_digest === ( $success_audit['content_digest'] ?? '' ) && 'test-adapter' === ( $success_audit['adapter'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/999' === ( $success_audit['result']['pr_url'] ?? '' ) );
-$assert( 'success audit excludes raw patch body', ! str_contains( $success_encoded, 'diff --git' ) && '[redacted]' === ( $success_audit['result']['patch'] ?? '' ) );
+$assert( 'success audit excludes raw patch body and secrets', ! str_contains( $success_encoded, 'diff --git' ) && ! str_contains( $success_encoded, 'secret-token-value' ) && '[redacted]' === ( $success_audit['result']['patch'] ?? '' ) && '[redacted]' === ( $success_audit['result']['access_token'] ?? '' ) );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function (): WP_Error {
-	return new WP_Error( 'wp_codebox_adapter_failed', 'Adapter failed to apply artifact.', array( 'status' => 502, 'adapter' => 'test-adapter', 'patch' => 'diff --git should not persist' ) );
+	return new WP_Error( 'wp_codebox_adapter_failed', 'Adapter failed to apply artifact.', array( 'status' => 502, 'adapter' => 'test-adapter', 'patch' => 'diff --git should not persist', 'password' => 'secret-password-value' ) );
 };
 $failed_apply = $artifacts->apply_approved(
 	array(
@@ -401,7 +402,7 @@ $audit_lines   = is_file( $audit_path ) ? array_values( array_filter( explode( "
 $failure_audit = isset( $audit_lines[1] ) ? json_decode( $audit_lines[1], true ) : array();
 $failure_encoded = isset( $audit_lines[1] ) ? $audit_lines[1] : '';
 $assert( 'approved artifact apply writes adapter failure audit record', is_wp_error( $failed_apply ) && is_array( $failure_audit ) && 'failure' === ( $failure_audit['status'] ?? '' ) && 'test-adapter' === ( $failure_audit['adapter'] ?? '' ) && 'wp_codebox_adapter_failed' === ( $failure_audit['error']['code'] ?? '' ) );
-$assert( 'failure audit records approver and excludes raw patch body', 'site-user:2' === ( $failure_audit['approver'] ?? '' ) && ! str_contains( $failure_encoded, 'diff --git' ) && '[redacted]' === ( $failure_audit['error']['data']['patch'] ?? '' ) );
+$assert( 'failure audit records approver and excludes raw patch body and secrets', 'site-user:2' === ( $failure_audit['approver'] ?? '' ) && ! str_contains( $failure_encoded, 'diff --git' ) && ! str_contains( $failure_encoded, 'secret-password-value' ) && '[redacted]' === ( $failure_audit['error']['data']['patch'] ?? '' ) && '[redacted]' === ( $failure_audit['error']['data']['password'] ?? '' ) );
 
 $unknown_apply = $artifacts->apply_approved(
 	array(

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -281,7 +281,20 @@ file_put_contents(
 		JSON_PRETTY_PRINT
 	) . "\n"
 );
-file_put_contents( $bundle_dir . '/metadata.json', json_encode( array( 'artifacts' => array( 'patch' => 'files/patch.diff' ) ), JSON_PRETTY_PRINT ) . "\n" );
+file_put_contents(
+	$bundle_dir . '/metadata.json',
+	json_encode(
+		array(
+			'artifacts'  => array( 'patch' => 'files/patch.diff' ),
+			'provenance' => array(
+				'task' => array(
+					'requester' => 'chat:user-7',
+				),
+			),
+		),
+		JSON_PRETTY_PRINT
+	) . "\n"
+);
 file_put_contents( $bundle_dir . '/files/changed-files.json', $changed_files_json );
 file_put_contents( $bundle_dir . '/files/patch.diff', $patch_diff );
 file_put_contents(
@@ -350,6 +363,8 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function 
 		'patch_sha256'            => $payload['patch_sha256'],
 		'artifact_content_digest' => $payload['artifact_content_digest'],
 		'patch_contains'          => str_contains( $payload['patch'], 'cooked' ),
+		'patch'                   => $payload['patch'],
+		'pr_url'                  => 'https://github.com/chubes4/wp-codebox/pull/999',
 	);
 };
 $applied = $artifacts->apply_approved(
@@ -361,6 +376,32 @@ $applied = $artifacts->apply_approved(
 	)
 );
 $assert( 'approved artifact apply delegates exact patch', ! is_wp_error( $applied ) && true === ( $applied['result']['patch_contains'] ?? false ) && hash( 'sha256', $patch_diff ) === ( $applied['patch_sha256'] ?? '' ) && $content_digest === ( $applied['content_digest'] ?? '' ) );
+
+$audit_path      = $artifact_root . '/apply-audit.jsonl';
+$audit_lines     = is_file( $audit_path ) ? array_values( array_filter( explode( "\n", trim( (string) file_get_contents( $audit_path ) ) ) ) ) : array();
+$success_audit   = isset( $audit_lines[0] ) ? json_decode( $audit_lines[0], true ) : array();
+$success_encoded = isset( $audit_lines[0] ) ? $audit_lines[0] : '';
+$assert( 'approved artifact apply writes success audit record', is_array( $success_audit ) && 'wp-codebox/apply-audit/v1' === ( $success_audit['schema'] ?? '' ) && 'success' === ( $success_audit['status'] ?? '' ) );
+$assert( 'success audit records reviewed principals and files', 'chat:user-7' === ( $success_audit['requester'] ?? '' ) && 'site-user:1' === ( $success_audit['approver'] ?? '' ) && array( '/wordpress/wp-content/plugins/example/generated.txt' ) === ( $success_audit['approved_files'] ?? array() ) );
+$assert( 'success audit records digest and adapter metadata', $artifact_id === ( $success_audit['artifact_id'] ?? '' ) && $content_digest === ( $success_audit['content_digest'] ?? '' ) && 'test-adapter' === ( $success_audit['adapter'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/999' === ( $success_audit['result']['pr_url'] ?? '' ) );
+$assert( 'success audit excludes raw patch body', ! str_contains( $success_encoded, 'diff --git' ) && '[redacted]' === ( $success_audit['result']['patch'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function (): WP_Error {
+	return new WP_Error( 'wp_codebox_adapter_failed', 'Adapter failed to apply artifact.', array( 'status' => 502, 'adapter' => 'test-adapter', 'patch' => 'diff --git should not persist' ) );
+};
+$failed_apply = $artifacts->apply_approved(
+	array(
+		'artifacts_path'  => $artifact_root,
+		'artifact_id'     => $artifact_id,
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt' ),
+		'approver'        => 'site-user:2',
+	)
+);
+$audit_lines   = is_file( $audit_path ) ? array_values( array_filter( explode( "\n", trim( (string) file_get_contents( $audit_path ) ) ) ) ) : array();
+$failure_audit = isset( $audit_lines[1] ) ? json_decode( $audit_lines[1], true ) : array();
+$failure_encoded = isset( $audit_lines[1] ) ? $audit_lines[1] : '';
+$assert( 'approved artifact apply writes adapter failure audit record', is_wp_error( $failed_apply ) && is_array( $failure_audit ) && 'failure' === ( $failure_audit['status'] ?? '' ) && 'test-adapter' === ( $failure_audit['adapter'] ?? '' ) && 'wp_codebox_adapter_failed' === ( $failure_audit['error']['code'] ?? '' ) );
+$assert( 'failure audit records approver and excludes raw patch body', 'site-user:2' === ( $failure_audit['approver'] ?? '' ) && ! str_contains( $failure_encoded, 'diff --git' ) && '[redacted]' === ( $failure_audit['error']['data']['patch'] ?? '' ) );
 
 $unknown_apply = $artifacts->apply_approved(
 	array(


### PR DESCRIPTION
## Summary
- Persist apply-approved-artifact audit records as JSONL at the artifact root for successful and adapter-failed apply attempts.
- Record artifact id, content/patch digests, requester/approver principals when available, approved files, adapter/result metadata, errors, and timestamps.
- Redact raw patch/diff/body/content fields from persisted audit metadata while keeping hashes and digest identifiers.

## Testing
- npm run check

Closes #65

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the audit record slice and smoke coverage; Chris remains responsible for review and final validation.