### PR TITLE
Add package distribution smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Parent app, CI job, or WordPress control plane
 
 ## Repo Components
 
-These are local workspace components in this repo, not published packages yet:
+These are local workspace components in this repo. The CLI and WordPress plugin
+now have package artifact validation, but publication and release automation are
+still explicit release-manager steps.
 
 - `packages/runtime-core`: backend-agnostic runtime interfaces and shared types.
 - `packages/runtime-playground`: WordPress Playground backend adapter.
@@ -41,6 +43,38 @@ npm run check
 ```
 
 `npm run check` runs the TypeScript build, policy validation smoke test, WordPress plugin smoke test, and a real Playground-backed CLI smoke test.
+
+## Distribution Artifacts
+
+The CLI package is prepared as `@chubes4/wp-codebox-cli` and exposes the
+`wp-codebox` binary from `packages/cli/dist/index.js`.
+
+```bash
+npm run build
+npm pack --workspace @chubes4/wp-codebox-cli --dry-run --json
+```
+
+The WordPress plugin zip is built from `packages/wordpress-plugin` with only the
+installable plugin files under a top-level `wp-codebox/` directory.
+
+```bash
+npm run package:wordpress-plugin
+unzip -Z1 packages/wordpress-plugin/dist/wp-codebox.zip
+```
+
+`npm run package-distribution-smoke` validates both artifact shapes. It checks
+that the CLI pack includes `package.json`, `README.md`, and compiled `dist/`
+files without TypeScript source, then builds the WordPress plugin zip and checks
+that it contains the plugin bootstrap, README, and PHP sources without package
+metadata or generated artifacts.
+
+Release checklist:
+
+1. Run `npm run check` from a clean checkout.
+2. Review `npm pack --workspace @chubes4/wp-codebox-cli --dry-run --json` before publishing the CLI package.
+3. Build `packages/wordpress-plugin/dist/wp-codebox.zip` with `npm run package:wordpress-plugin` and inspect `unzip -Z1 packages/wordpress-plugin/dist/wp-codebox.zip`.
+4. Install the CLI in the target environment and configure the WordPress plugin `wp_codebox_bin` option or filter to the resolved `wp-codebox` binary path.
+5. Install the plugin zip on the parent site and run the WordPress plugin smoke or equivalent ability registration check in that environment.
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3427,6 +3427,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wp-codebox-wordpress-plugin": {
+      "resolved": "packages/wordpress-plugin",
+      "link": true
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -3566,6 +3570,9 @@
         "@chubes4/wp-codebox-core": "file:../runtime-core",
         "@wp-playground/cli": "3.1.30"
       }
+    },
+    "packages/wordpress-plugin": {
+      "name": "wp-codebox-wordpress-plugin"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b packages/runtime-core packages/runtime-playground packages/cli",
+    "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
+    "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run artifact-contract-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,26 @@
+# WP Codebox CLI
+
+CLI entrypoint for running disposable WP Codebox sandboxes and collecting
+reviewable artifact bundles.
+
+## Install
+
+```bash
+npm install -g @chubes4/wp-codebox-cli
+wp-codebox --help
+```
+
+The package exposes the `wp-codebox` binary and includes the compiled
+`dist/` entrypoint only. Build from source with `npm run build` before running
+local package validation.
+
+## Smoke
+
+```bash
+npm run build
+npm run package-distribution-smoke
+```
+
+The distribution smoke runs `npm pack --dry-run --json` and verifies the package
+contains `package.json`, `README.md`, and the compiled CLI entrypoint used by the
+published binary.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsc -b"

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -69,6 +69,25 @@ Expected component keys:
 The CLI binary can be supplied by ability input, the `wp_codebox_bin` option,
 or the `wp_codebox_bin` filter.
 
+## Package Artifact
+
+Build the installable plugin zip from the repository root:
+
+```bash
+npm run package:wordpress-plugin
+```
+
+The generated artifact is `packages/wordpress-plugin/dist/wp-codebox.zip`. It
+contains a single top-level `wp-codebox/` directory with `wp-codebox.php`, this
+README, and the `src/` PHP files. Generated build outputs and package metadata
+are intentionally excluded from the plugin zip.
+
+Validate the artifact shape with:
+
+```bash
+npm run package-distribution-smoke
+```
+
 ## Boundary
 
 Data Machine Code is the mounted coding-tools component for file-editing agent

--- a/packages/wordpress-plugin/package.json
+++ b/packages/wordpress-plugin/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wp-codebox-wordpress-plugin",
+  "private": true,
+  "description": "WordPress plugin package artifact for WP Codebox parent-site abilities.",
+  "scripts": {
+    "zip": "tsx ../../scripts/build-wordpress-plugin-zip.ts"
+  }
+}

--- a/scripts/build-wordpress-plugin-zip.ts
+++ b/scripts/build-wordpress-plugin-zip.ts
@@ -1,0 +1,26 @@
+import { execFile } from "node:child_process"
+import { cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "..")
+const pluginSource = join(repoRoot, "packages", "wordpress-plugin")
+const outputDirectory = join(pluginSource, "dist")
+const outputZip = join(outputDirectory, "wp-codebox.zip")
+const stagingRoot = await mkdtemp(join(tmpdir(), "wp-codebox-plugin-"))
+const stagingPlugin = join(stagingRoot, "wp-codebox")
+
+try {
+  await mkdir(outputDirectory, { recursive: true })
+  await mkdir(stagingPlugin, { recursive: true })
+  await cp(join(pluginSource, "wp-codebox.php"), join(stagingPlugin, "wp-codebox.php"))
+  await cp(join(pluginSource, "README.md"), join(stagingPlugin, "README.md"))
+  await cp(join(pluginSource, "src"), join(stagingPlugin, "src"), { recursive: true })
+  await rm(outputZip, { force: true })
+  await execFileAsync("zip", ["-qr", outputZip, "wp-codebox"], { cwd: stagingRoot })
+  console.log(`Built ${outputZip}`)
+} finally {
+  await rm(stagingRoot, { recursive: true, force: true })
+}

--- a/scripts/package-distribution-smoke.ts
+++ b/scripts/package-distribution-smoke.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { access } from "node:fs/promises"
+import { resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "..")
+
+const { stdout: packStdout } = await execFileAsync(
+  "npm",
+  ["pack", "--workspace", "@chubes4/wp-codebox-cli", "--dry-run", "--json"],
+  { cwd: repoRoot, maxBuffer: 1024 * 1024 * 10 },
+)
+const [pack] = JSON.parse(packStdout) as Array<{ files: Array<{ path: string }>; entryCount: number }>
+const packedFiles = new Set(pack.files.map((file) => file.path))
+
+assert.ok(packedFiles.has("package.json"), "CLI package should include package.json")
+assert.ok(packedFiles.has("README.md"), "CLI package should include README.md")
+assert.ok(packedFiles.has("dist/index.js"), "CLI package should include compiled binary entrypoint")
+assert.ok(packedFiles.has("dist/index.d.ts"), "CLI package should include generated types")
+assert.equal(packedFiles.has("src/index.ts"), false, "CLI package should not ship TypeScript source")
+assert.ok(pack.entryCount >= 4, "CLI package should contain expected publish files")
+
+await execFileAsync("npm", ["run", "package:wordpress-plugin"], { cwd: repoRoot, maxBuffer: 1024 * 1024 * 10 })
+const pluginZip = resolve(repoRoot, "packages", "wordpress-plugin", "dist", "wp-codebox.zip")
+await access(pluginZip)
+
+const { stdout: zipStdout } = await execFileAsync("unzip", ["-Z1", pluginZip], { cwd: repoRoot })
+const zipEntries = new Set(zipStdout.trim().split("\n").filter(Boolean))
+
+assert.ok(zipEntries.has("wp-codebox/wp-codebox.php"), "Plugin zip should include the main plugin file")
+assert.ok(zipEntries.has("wp-codebox/README.md"), "Plugin zip should include README.md")
+assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-abilities.php"), "Plugin zip should include ability surface")
+assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-agent-sandbox-runner.php"), "Plugin zip should include sandbox runner")
+assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-artifacts.php"), "Plugin zip should include artifact helpers")
+assert.equal(zipEntries.has("wp-codebox/package.json"), false, "Plugin zip should not include package metadata")
+assert.equal(zipEntries.has("wp-codebox/dist/wp-codebox.zip"), false, "Plugin zip should not include generated artifacts")
+
+console.log("Package distribution smoke passed")


### PR DESCRIPTION
## Summary
- Adds a WordPress plugin zip builder that packages only installable plugin files under `wp-codebox/`.
- Adds a package distribution smoke that validates the CLI npm pack file list and WordPress plugin zip contents.
- Documents CLI/plugin artifact commands and a release checklist for issue #34 packaging work.

## Tests
- `npm run check`

## Issue
- Part of #34

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the package validation scripts, docs, and PR preparation; Chris remains responsible for review and merge.