### PR TITLE
Add artifact redaction and secret scanning

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -310,7 +310,22 @@ export interface ArtifactReview {
     changedFiles: string
     testResults?: string
   }
+  redaction?: ArtifactRedactionSummary
   riskFlags: string[]
+}
+
+export interface ArtifactRedactionArtifactSummary {
+  path: string
+  count: number
+  kinds: string[]
+}
+
+export interface ArtifactRedactionSummary {
+  schema: "wp-codebox/artifact-redaction/v1"
+  status: "clean" | "redacted"
+  total: number
+  byKind: Record<string, number>
+  artifacts: ArtifactRedactionArtifactSummary[]
 }
 
 export interface ArtifactTestResultsRawLogReference {

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -5,6 +5,7 @@ import { normalizeBlueprint, preferredVersionsForEnvironment } from "./blueprint
 import type {
   ArtifactManifestFile,
   ArtifactProvenance,
+  ArtifactRedactionSummary,
   ArtifactReview,
   ArtifactTestResults,
   MountSpec,
@@ -77,9 +78,97 @@ export interface MountDiffsResult {
   patch: string
 }
 
+interface RedactionResult {
+  contents: string
+  count: number
+  byKind: Map<string, number>
+}
+
 export const MAX_CAPTURED_MOUNT_FILES = 200
 export const MAX_CAPTURED_MOUNT_FILE_BYTES = 1024 * 1024
 export const SKIPPED_CAPTURE_DIRECTORIES = new Set([".git", "node_modules"])
+
+const COMMON_SECRET_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
+  { kind: "openai-api-key", pattern: /sk-[A-Za-z0-9_-]{20,}/g },
+  { kind: "github-token", pattern: /(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}/g },
+  { kind: "github-token", pattern: /github_pat_[A-Za-z0-9_]{20,}/g },
+  { kind: "slack-token", pattern: /xox(?:a|b|p|o|s|r)-[A-Za-z0-9-]{20,}/g },
+  { kind: "jwt", pattern: /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g },
+  { kind: "aws-access-key", pattern: /A(?:KIA|SIA)[A-Z0-9]{16}/g },
+]
+
+export class ArtifactRedactor {
+  private readonly replacements: Array<{ kind: string; pattern: RegExp }> = []
+  private readonly artifactCounts = new Map<string, { count: number; kinds: Set<string> }>()
+  private readonly byKind = new Map<string, number>()
+  private total = 0
+
+  constructor(secretEnv: Record<string, string> = {}) {
+    this.replacements.push(...COMMON_SECRET_PATTERNS)
+
+    for (const [name, value] of Object.entries(secretEnv)) {
+      if (name.length > 0) {
+        this.replacements.push({ kind: "configured-secret-name", pattern: new RegExp(escapeRegExp(name), "g") })
+      }
+
+      if (value.length >= 4) {
+        this.replacements.push({ kind: "configured-secret-value", pattern: new RegExp(escapeRegExp(value), "g") })
+      }
+    }
+  }
+
+  redact(path: string, contents: string): string {
+    const result = this.scan(contents)
+    if (result.count > 0) {
+      this.record(path, result)
+    }
+
+    return result.contents
+  }
+
+  summary(): ArtifactRedactionSummary {
+    return {
+      schema: "wp-codebox/artifact-redaction/v1",
+      status: this.total > 0 ? "redacted" : "clean",
+      total: this.total,
+      byKind: Object.fromEntries([...this.byKind.entries()].sort(([left], [right]) => left.localeCompare(right))),
+      artifacts: [...this.artifactCounts.entries()]
+        .map(([path, artifact]) => ({ path, count: artifact.count, kinds: [...artifact.kinds].sort() }))
+        .sort((left, right) => left.path.localeCompare(right.path)),
+    }
+  }
+
+  private scan(contents: string): RedactionResult {
+    let redacted = contents
+    let count = 0
+    const byKind = new Map<string, number>()
+
+    for (const replacement of this.replacements) {
+      redacted = redacted.replace(replacement.pattern, () => {
+        count++
+        byKind.set(replacement.kind, (byKind.get(replacement.kind) ?? 0) + 1)
+        return `[REDACTED:${replacement.kind}]`
+      })
+    }
+
+    return { contents: redacted, count, byKind }
+  }
+
+  private record(path: string, result: RedactionResult): void {
+    this.total += result.count
+    const artifact = this.artifactCounts.get(path) ?? { count: 0, kinds: new Set<string>() }
+    artifact.count += result.count
+    for (const [kind, count] of result.byKind) {
+      artifact.kinds.add(kind)
+      this.byKind.set(kind, (this.byKind.get(kind) ?? 0) + count)
+    }
+    this.artifactCounts.set(path, artifact)
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
 
 export function artifactContentDigest(changedFilesJson: string, patch: string): string {
   return createHash("sha256")

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -6,6 +6,7 @@ import {
   MAX_CAPTURED_MOUNT_FILE_BYTES,
   MAX_CAPTURED_MOUNT_FILES,
   SKIPPED_CAPTURE_DIRECTORIES,
+  ArtifactRedactor,
   artifactContentDigest,
   buildArtifactProvenance,
   buildArtifactReview,
@@ -225,12 +226,14 @@ class PlaygroundRuntime implements Runtime {
     const patchPath = join(filesDirectory, "patch.diff")
     const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
+    const redactor = new ArtifactRedactor(this.spec.secretEnv)
 
     const runtime = await this.info()
-    const capturedMounts = await this.captureMountedFiles(filesDirectory)
-    const { mountDiffs, changedFiles, patch } = await this.captureMountDiffs(filesDirectory)
-    const changedFilesJson = `${JSON.stringify(changedFiles, null, 2)}\n`
-    const contentDigest = artifactContentDigest(changedFilesJson, patch)
+    const capturedMounts = await this.captureMountedFiles(filesDirectory, redactor)
+    const { mountDiffs, changedFiles, patch } = await this.captureMountDiffs(filesDirectory, redactor)
+    const changedFilesJson = redactor.redact("files/changed-files.json", `${JSON.stringify(changedFiles, null, 2)}\n`)
+    const redactedPatch = redactor.redact("files/patch.diff", patch)
+    const contentDigest = artifactContentDigest(changedFilesJson, redactedPatch)
     const bundleId = `artifact-bundle-sha256-${contentDigest}`
     const contentDigestMetadata = {
       algorithm: "sha256",
@@ -265,12 +268,11 @@ class PlaygroundRuntime implements Runtime {
       createdAt,
       provenance,
       changedFiles,
-      patch,
+      patch: redactedPatch,
       contentDigest,
       runtimeCreatedAt: this.createdAt,
       mounts: this.mounts,
     })
-    const reviewJson = `${JSON.stringify(review, null, 2)}\n`
     const artifactFiles = {
       changedFiles: relative(this.artifactRoot, changedFilesPath),
       patch: relative(this.artifactRoot, patchPath),
@@ -329,25 +331,28 @@ class PlaygroundRuntime implements Runtime {
       })),
     }
 
-    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
-    await writeFile(
-      metadataPath,
-      `${JSON.stringify(metadata, null, 2)}\n`,
-    )
-    await writeFile(blueprintAfterPath, `${JSON.stringify(blueprintAfter, null, 2)}\n`)
-    await writeFile(blueprintAfterNotesPath, `${JSON.stringify(blueprintAfterNotes, null, 2)}\n`)
-    await writeJsonLines(eventsPath, this.events)
-    await writeJsonLines(commandsPath, this.commands)
-    await writeJsonLines(observationsPath, this.observations)
-    await writeFile(runtimeLogPath, this.formatRuntimeLog())
-    await writeFile(commandsLogPath, this.formatCommandsLog())
-    await writeFile(mountsPath, `${JSON.stringify(this.mounts, null, 2)}\n`)
-    await writeFile(capturedMountsPath, `${JSON.stringify(serializeCapturedMountFiles(capturedMounts), null, 2)}\n`)
-    await writeFile(diffsPath, `${JSON.stringify(mountDiffs, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, manifestPath, this.artifactRoot, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, blueprintAfterPath, this.artifactRoot, `${JSON.stringify(blueprintAfter, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, blueprintAfterNotesPath, this.artifactRoot, `${JSON.stringify(blueprintAfterNotes, null, 2)}\n`)
+    await writeJsonLines(eventsPath, this.events, redactor, this.artifactRoot)
+    await writeJsonLines(commandsPath, this.commands, redactor, this.artifactRoot)
+    await writeJsonLines(observationsPath, this.observations, redactor, this.artifactRoot)
+    await writeRedactedArtifact(redactor, runtimeLogPath, this.artifactRoot, this.formatRuntimeLog())
+    await writeRedactedArtifact(redactor, commandsLogPath, this.artifactRoot, this.formatCommandsLog())
+    await writeRedactedArtifact(redactor, mountsPath, this.artifactRoot, `${JSON.stringify(this.mounts, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, capturedMountsPath, this.artifactRoot, `${JSON.stringify(serializeCapturedMountFiles(capturedMounts), null, 2)}\n`)
+    await writeRedactedArtifact(redactor, diffsPath, this.artifactRoot, `${JSON.stringify(mountDiffs, null, 2)}\n`)
     await writeFile(changedFilesPath, changedFilesJson)
-    await writeFile(patchPath, patch)
-    await writeFile(testResultsPath, `${JSON.stringify(testResults, null, 2)}\n`)
-    await writeFile(reviewPath, reviewJson)
+    await writeFile(patchPath, redactedPatch)
+    await writeRedactedArtifact(redactor, testResultsPath, this.artifactRoot, `${JSON.stringify(testResults, null, 2)}\n`)
+    const redaction = redactor.summary()
+    if (redaction.total > 0) {
+      review.redaction = redaction
+      review.riskFlags.push("secrets-redacted")
+    }
+    await writeRedactedArtifact(redactor, reviewPath, this.artifactRoot, `${JSON.stringify(review, null, 2)}\n`)
+    metadata.redaction = redactor.summary()
+    await writeRedactedArtifact(redactor, metadataPath, this.artifactRoot, `${JSON.stringify(metadata, null, 2)}\n`)
 
     return {
       id: bundleId,
@@ -373,7 +378,7 @@ class PlaygroundRuntime implements Runtime {
     }
   }
 
-  private async captureMountedFiles(filesDirectory: string): Promise<CapturedMountFiles> {
+  private async captureMountedFiles(filesDirectory: string, redactor: ArtifactRedactor): Promise<CapturedMountFiles> {
     const captured: CapturedMountFiles = {
       files: [],
       skipped: [],
@@ -391,19 +396,19 @@ class PlaygroundRuntime implements Runtime {
 
       const mountStats = await stat(mount.source)
       if (mountStats.isDirectory()) {
-        await this.captureMountedDirectory(filesDirectory, captured, mount, mountIndex, mount.source, "")
+        await this.captureMountedDirectory(filesDirectory, captured, mount, mountIndex, mount.source, "", redactor)
         continue
       }
 
       if (mountStats.isFile()) {
-        await this.captureMountedFile(filesDirectory, captured, mount, mountIndex, mount.source, basename(mount.source))
+        await this.captureMountedFile(filesDirectory, captured, mount, mountIndex, mount.source, basename(mount.source), redactor)
       }
     }
 
     return captured
   }
 
-  private async captureMountDiffs(filesDirectory: string): Promise<MountDiffsResult> {
+  private async captureMountDiffs(filesDirectory: string, redactor: ArtifactRedactor): Promise<MountDiffsResult> {
     const diffsDirectory = join(filesDirectory, "diffs")
     await mkdir(diffsDirectory, { recursive: true })
     const diffs: MountDiff[] = []
@@ -418,7 +423,7 @@ class PlaygroundRuntime implements Runtime {
 
       const diff = await directoryDiff(baselineSource, mount.source, mount.target)
       const artifactPath = `files/diffs/mount-${mountIndex}.patch`
-      await writeFile(join(this.artifactRoot, artifactPath), diff.patch)
+      await writeFile(join(this.artifactRoot, artifactPath), redactor.redact(artifactPath, diff.patch))
       diffs.push({
         mountIndex,
         source: mount.source,
@@ -455,6 +460,7 @@ class PlaygroundRuntime implements Runtime {
     mountIndex: number,
     directory: string,
     relativeDirectory: string,
+    redactor: ArtifactRedactor,
   ): Promise<void> {
     const entries = await readdir(directory, { withFileTypes: true })
 
@@ -474,12 +480,12 @@ class PlaygroundRuntime implements Runtime {
           continue
         }
 
-        await this.captureMountedDirectory(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath)
+        await this.captureMountedDirectory(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath, redactor)
         continue
       }
 
       if (entry.isFile()) {
-        await this.captureMountedFile(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath)
+        await this.captureMountedFile(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath, redactor)
       }
     }
   }
@@ -491,6 +497,7 @@ class PlaygroundRuntime implements Runtime {
     mountIndex: number,
     sourcePath: string,
     relativePath: string,
+    redactor: ArtifactRedactor,
   ): Promise<void> {
     const target = mount.type === "file" ? mount.target : mountTargetPath(mount, relativePath)
 
@@ -508,23 +515,30 @@ class PlaygroundRuntime implements Runtime {
     const artifactRelativePath = `mounts/${mountIndex}/${relativePath}`
     const artifactPath = join(filesDirectory, artifactRelativePath)
     await mkdir(dirname(artifactPath), { recursive: true })
-    await copyFile(sourcePath, artifactPath)
 
     const buffer = await readFile(sourcePath)
     const text = buffer.toString("utf8")
     const replayable = isReplayableText(buffer, text)
+    const artifactBundlePath = `files/${artifactRelativePath}`
+    const artifactContents = replayable ? redactor.redact(artifactBundlePath, text) : buffer
+    if (typeof artifactContents === "string") {
+      await writeFile(artifactPath, artifactContents)
+    } else {
+      await copyFile(sourcePath, artifactPath)
+    }
+    const artifactBuffer = typeof artifactContents === "string" ? Buffer.from(artifactContents, "utf8") : buffer
 
     captured.files.push({
       mountIndex,
       source: sourcePath,
       target,
       relativePath,
-      artifactPath: `files/${artifactRelativePath}`,
-      size: fileStats.size,
-      sha256: createHash("sha256").update(buffer).digest("hex"),
+      artifactPath: artifactBundlePath,
+      size: artifactBuffer.byteLength,
+      sha256: createHash("sha256").update(artifactBuffer).digest("hex"),
       contentType: replayable ? "text/plain; charset=utf-8" : "application/octet-stream",
       replayable,
-      ...(replayable ? { replayContents: text } : {}),
+      ...(replayable ? { replayContents: artifactContents as string } : {}),
     })
   }
 
@@ -740,6 +754,10 @@ export function createPlaygroundRuntimeBackend(): RuntimeBackend {
   return new PlaygroundRuntimeBackend()
 }
 
-async function writeJsonLines(path: string, records: unknown[]): Promise<void> {
-  await writeFile(path, records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : "")
+async function writeJsonLines(path: string, records: unknown[], redactor: ArtifactRedactor, artifactRoot: string): Promise<void> {
+  await writeRedactedArtifact(redactor, path, artifactRoot, records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : "")
+}
+
+async function writeRedactedArtifact(redactor: ArtifactRedactor, path: string, artifactRoot: string, contents: string): Promise<void> {
+  await writeFile(path, redactor.redact(relative(artifactRoot, path), contents))
 }

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -150,6 +150,71 @@ try {
   ))
   await runtime.destroy()
 
+  const secretName = "WP_CODEBOX_SMOKE_SECRET"
+  const secretValue = "fixture-secret-value-64"
+  const commonToken = "sk-fixtureSecretTokenForRedaction123456"
+  const redactionBaseline = join(artifactsDirectory, "redaction-baseline")
+  const redactionMount = join(artifactsDirectory, "redaction-mounted-component")
+  await mkdir(redactionBaseline, { recursive: true })
+  await mkdir(redactionMount, { recursive: true })
+  await writeFile(join(redactionMount, "component.php"), "<?php // redaction fixture\n")
+  const redactionRuntime = await createRuntime(
+    {
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", name: "redaction-smoke", version: "7.0", blueprint: { steps: [] } },
+      policy: {
+        network: "deny",
+        filesystem: "readwrite-mounts",
+        commands: ["wordpress.run-php"],
+        secrets: "connector-scoped",
+        approvals: "never",
+      },
+      artifactsDirectory,
+      secretEnv: { [secretName]: secretValue },
+      metadata: {
+        runtime: { version: "0.0.0" },
+        task: { kind: "agent-sandbox-run", input: `Redact ${secretName}` },
+      },
+    },
+    createPlaygroundRuntimeBackend(),
+  )
+  await redactionRuntime.mount({
+    type: "directory",
+    source: redactionMount,
+    target: "/wordpress/wp-content/plugins/redaction-smoke",
+    mode: "readwrite",
+    metadata: { kind: "component", slug: "redaction-smoke", baselineSource: redactionBaseline },
+  })
+  await redactionRuntime.execute({
+    command: "wordpress.run-php",
+    args: [
+      `code=file_put_contents('/wordpress/wp-content/plugins/redaction-smoke/leak.txt', getenv('${secretName}') . "\\n${commonToken}\\n"); echo getenv('${secretName}') . " ${commonToken}";`,
+    ],
+  })
+  const redactionArtifacts = await redactionRuntime.collectArtifacts({ includeLogs: true })
+  const redactionMetadataText = await readFile(redactionArtifacts.metadataPath, "utf8")
+  const redactionPatch = await readFile(redactionArtifacts.patchPath, "utf8")
+  const redactionCommandsLog = await readFile(redactionArtifacts.commandsLogPath, "utf8")
+  const redactionReview = JSON.parse(await readFile(redactionArtifacts.reviewPath, "utf8"))
+  const redactionMountedFile = await readFile(join(redactionArtifacts.directory, "files/mounts/0/leak.txt"), "utf8")
+
+  for (const [artifactName, artifactText] of Object.entries({
+    metadata: redactionMetadataText,
+    patch: redactionPatch,
+    commandsLog: redactionCommandsLog,
+    mountedFile: redactionMountedFile,
+  })) {
+    assert.equal(artifactText.includes(secretName), false, `${artifactName} should redact configured secret names`)
+    assert.equal(artifactText.includes(secretValue), false, `${artifactName} should redact configured secret values`)
+    assert.equal(artifactText.includes(commonToken), false, `${artifactName} should redact common token patterns`)
+  }
+  assert.match(redactionPatch, /\[REDACTED:configured-secret-value\]/)
+  assert.match(redactionPatch, /\[REDACTED:openai-api-key\]/)
+  assert.equal(redactionReview.redaction.status, "redacted")
+  assert.ok(redactionReview.redaction.total >= 3)
+  assert.ok(redactionReview.riskFlags.includes("secrets-redacted"))
+  await redactionRuntime.destroy()
+
   console.log("Artifact contract smoke passed")
 } finally {
   await rm(artifactsDirectory, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Redacts configured secret env names/values and common token patterns from review-facing JSON, text, log, diff, and replayable mounted-file artifacts before writing them.
- Records non-sensitive redaction metadata/counts on artifact metadata and review payloads, with a `secrets-redacted` review risk flag when findings are redacted.
- Extends the artifact contract smoke test with a fixture secret value and common token leak across logs, patch, metadata, and mounted-file output.

## Verification
- `npm run check`

Closes #64.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the redaction slice, smoke coverage, verification, and PR preparation for Chris to review.