### PR TITLE
Stage artifact apply approvals through Data Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # WP Codebox
 
-WP Codebox runs disposable WordPress Playground sandboxes, executes bounded work inside them, and saves replayable artifacts before the sandbox is destroyed.
+WP Codebox runs disposable WordPress Playground sandboxes, executes bounded work inside them, and saves replayable artifacts before the sandbox is destroyed. It runs WordPress inside the sandbox, but the host that calls it can be anything: a CLI script, CI job, Node app, WordPress plugin, Data Machine flow, Homeboy workflow, or another control plane.
 
-It is the runtime boundary for agent-built or workflow-built outputs. It is not the agent framework, the review UI, the deploy system, or the production site mutator.
+It is the runtime boundary for agent-built or workflow-built outputs. It is not the agent framework, the review UI, the deploy system, or the production site mutator. The WordPress plugin in this repo is an optional host adapter that exposes WP Codebox through WordPress abilities; the core CLI/runtime works without installing that plugin on a parent site.
 
 ```text
-Parent app, CI job, or WordPress control plane
+Any host: CLI, CI, Node app, WordPress plugin, Data Machine, Homeboy, Studio
   -> WP Codebox
     -> disposable WordPress Playground runtime
       -> mounted inputs, plugins, tools, and optional agent stack
@@ -22,6 +22,21 @@ Parent app, CI job, or WordPress control plane
 - Launch sandboxed Data Machine / Agents API coding-agent tasks from the CLI or WordPress ability surface.
 - Fan out several task descriptions into separate isolated sandboxes.
 - Produce artifact bundles that a parent product can review or consume later.
+
+## Why A WordPress Plugin?
+
+The WordPress plugin is useful when the host experience should live inside a
+WordPress site. It turns WP Codebox into a WordPress-native control plane for
+reviewed coding workflows without asking users to run a terminal.
+
+Good fits include:
+
+- Letting non-technical site owners request, review, and approve bounded coding changes from a WordPress UI or chat surface.
+- Running a managed coding community where users submit tasks and maintainers approve sandboxed artifacts before anything reaches real code.
+- Supporting WordPress contributors with disposable reproduction, patch, review, and test-result artifacts that can be shared before commit or PR creation.
+
+These are host-product use cases. The core runtime still works anywhere the CLI
+can run.
 
 ## Repo Components
 
@@ -354,6 +369,7 @@ The WordPress plugin registers parent-site abilities:
 - `wp-codebox/get-artifact`
 - `wp-codebox/discard-artifact`
 - `wp-codebox/apply-approved-artifact`
+- `wp-codebox/stage-artifact-apply`
 
 These abilities shell out to the local `wp-codebox` CLI, boot disposable Playground sandboxes, mount the configured agent stack, invoke the sandbox agent through `agents/chat`, and return artifact metadata.
 
@@ -394,6 +410,8 @@ The CLI binary can come from ability input, the `wp_codebox_bin` option, or the 
 Data Machine Code is a mounted coding-tools component inside the sandbox. It provides workspace/file/GitHub tools to the sandboxed agent. WP Codebox owns the parent-site ability surface, sandbox lifecycle, and artifact capture boundary.
 
 Apply-back is intentionally not part of `run-agent-task`. Sandbox execution returns proposed outputs and evidence. `list-artifacts`, `get-artifact`, and `discard-artifact` manage captured artifact bundles under the configured artifact root. `apply-approved-artifact` validates `artifact_id` plus an explicit `approved_files[]` list against canonical `changed-files.json`, recomputes the artifact content digest from `changed-files.json` and the exact `patch.diff` the reviewer approved, and delegates to the `wp_codebox_apply_approved_artifact` filter. PR creation, direct deploy, package export, and bot identity policy live in adapters behind that reviewed boundary.
+
+When Data Machine is present, `stage-artifact-apply` stages that same apply input as a Data Machine pending action with kind `wp_codebox_apply_back`. Its preview includes `files/review.json`, canonical changed files, normalized test results, and the explicit approved file list. Accepting the pending action resolves through Data Machine's generic resolver and calls the existing `apply-approved-artifact` path; rejecting it leaves the artifact untouched. This keeps approval lifecycle in Data Machine without making WP Codebox depend on Homeboy or any site-specific apply adapter.
 
 ## Runtime Policy
 

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -9,6 +9,11 @@ the parent control plane for review, replay, or apply-back.
 
 - `wp-codebox/run-agent-task`
 - `wp-codebox/run-agent-task-batch`
+- `wp-codebox/list-artifacts`
+- `wp-codebox/get-artifact`
+- `wp-codebox/discard-artifact`
+- `wp-codebox/apply-approved-artifact`
+- `wp-codebox/stage-artifact-apply`
 
 The ability runs `wp-codebox agent-sandbox-run`, which boots a disposable
 WordPress Playground runtime, mounts the agent stack components, invokes the
@@ -52,6 +57,26 @@ Returned artifact metadata includes the runtime manifest, replay blueprint,
 after-state notes, captured readwrite mount index, event streams, and logs. WP
 Codebox owns this capture boundary so the parent site can discard the disposable
 sandbox while keeping durable evidence and outputs.
+
+## Apply-Back Approval
+
+Apply-back is a reviewed artifact flow, not part of sandbox execution.
+`wp-codebox/apply-approved-artifact` validates the requested `artifact_id`, the
+explicit `approved_files[]` list, and the artifact content digest before handing
+the exact approved `files/patch.diff` to the `wp_codebox_apply_approved_artifact`
+adapter filter.
+
+When Data Machine is installed, `wp-codebox/stage-artifact-apply` stages the same
+apply input as a Data Machine pending action with kind `wp_codebox_apply_back`.
+The pending action preview includes `files/review.json`, canonical changed files,
+normalized test results, and the approved file list. Accepting the pending action
+calls the registered handler, which delegates back to
+`wp-codebox/apply-approved-artifact`; rejecting it leaves the artifact untouched.
+
+Without Data Machine pending actions, `stage-artifact-apply` fails closed with
+`wp_codebox_datamachine_pending_actions_missing`. Direct reviewed apply remains
+available through `apply-approved-artifact` for hosts that provide their own
+approval surface.
 
 ## Configuration
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -285,6 +285,48 @@ final class WP_Codebox_Abilities {
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
+
+			wp_register_ability(
+				'wp-codebox/stage-artifact-apply',
+				array(
+					'label'               => 'Stage WP Codebox Artifact Apply',
+					'description'         => 'Stage a reviewed WP Codebox artifact apply-back request through Data Machine pending actions.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'artifact_id', 'approved_files' ),
+						'properties' => array_merge(
+							$artifact_id_schema,
+							array(
+								'approved_files' => array(
+									'type'        => 'array',
+									'description' => 'Explicit sandbox file paths approved by the parent-site reviewer.',
+									'items'       => array( 'type' => 'string' ),
+								),
+								'approver'       => array(
+									'type'        => 'string',
+									'description' => 'Parent-site approver principal for audit records.',
+								),
+								'apply_target'   => array(
+									'type'        => 'object',
+									'description' => 'Optional parent-control-plane target metadata consumed by the apply adapter.',
+								),
+								'summary'        => array(
+									'type'        => 'string',
+									'description' => 'Optional human-readable pending-action summary.',
+								),
+								'agent_id'       => array( 'type' => 'integer' ),
+								'user_id'        => array( 'type' => 'integer' ),
+								'context'        => array( 'type' => 'object' ),
+							)
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'stage_artifact_apply' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
 		};
 
 		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_init' ) ) {
@@ -369,6 +411,11 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function apply_approved_artifact( array $input ): array|WP_Error {
 		return ( new WP_Codebox_Artifacts() )->apply_approved( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function stage_artifact_apply( array $input ): array|WP_Error {
+		return WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact( $input );
 	}
 
 	public static function can_run_agent_task(): bool {

--- a/packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Optional Data Machine pending-action integration for artifact apply-back.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Data_Machine_Pending_Actions {
+
+	public const KIND = 'wp_codebox_apply_back';
+
+	public function __construct() {
+		add_filter( 'datamachine_pending_action_handlers', array( self::class, 'register_handler' ) );
+	}
+
+	/** @param array<string,mixed> $handlers Current Data Machine pending-action handlers. */
+	public static function register_handler( array $handlers ): array {
+		$handlers[ self::KIND ] = array(
+			'apply'       => array( self::class, 'apply' ),
+			'can_resolve' => array( self::class, 'can_resolve' ),
+		);
+
+		return $handlers;
+	}
+
+	/**
+	 * Stage an artifact apply request through Data Machine pending actions.
+	 *
+	 * @param array<string,mixed> $input Ability/helper input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function stage_apply_artifact( array $input ): array|WP_Error {
+		$bundle_result = ( new WP_Codebox_Artifacts() )->get( $input );
+		if ( is_wp_error( $bundle_result ) ) {
+			return $bundle_result;
+		}
+
+		$apply_input = self::apply_input( $input );
+		if ( is_wp_error( $apply_input ) ) {
+			return $apply_input;
+		}
+
+		$bundle  = is_array( $bundle_result['artifact'] ?? null ) ? $bundle_result['artifact'] : array();
+		$summary = trim( (string) ( $input['summary'] ?? '' ) );
+		if ( '' === $summary ) {
+			$review_summary = is_array( $bundle['review'] ?? null ) ? trim( (string) ( $bundle['review']['summary'] ?? '' ) ) : '';
+			$summary        = '' !== $review_summary ? $review_summary : 'Review and approve WP Codebox artifact apply-back.';
+		}
+
+		$stage_args = array(
+			'kind'         => self::KIND,
+			'summary'      => $summary,
+			'apply_input'  => $apply_input,
+			'preview_data' => self::preview_data( $bundle, $apply_input ),
+			'agent_id'     => isset( $input['agent_id'] ) ? (int) $input['agent_id'] : 0,
+			'user_id'      => isset( $input['user_id'] ) ? (int) $input['user_id'] : 0,
+			'context'      => isset( $input['context'] ) && is_array( $input['context'] ) ? $input['context'] : array(),
+		);
+
+		$filtered = apply_filters( 'wp_codebox_stage_pending_apply_artifact', null, $stage_args, $bundle );
+		if ( null !== $filtered ) {
+			return $filtered;
+		}
+
+		if ( ! class_exists( '\\DataMachine\\Engine\\AI\\Actions\\PendingActionHelper' ) ) {
+			return new WP_Error( 'wp_codebox_datamachine_pending_actions_missing', 'Data Machine pending actions are not available.', array( 'status' => 501 ) );
+		}
+
+		return \DataMachine\Engine\AI\Actions\PendingActionHelper::stage( $stage_args );
+	}
+
+	/** @param array<string,mixed> $apply_input Stored Data Machine apply input. */
+	public static function apply( array $apply_input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->apply_approved( $apply_input );
+	}
+
+	/** @param array<string,mixed> $payload Stored Data Machine pending-action payload. */
+	public static function can_resolve( array $payload, string $decision, int $user_id ): bool|WP_Error {
+		$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : true;
+
+		return (bool) apply_filters( 'wp_codebox_can_resolve_pending_apply_artifact', $allowed, $payload, $decision, $user_id );
+	}
+
+	/**
+	 * @param array<string,mixed> $input Ability/helper input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private static function apply_input( array $input ): array|WP_Error {
+		$artifact_id = trim( (string) ( $input['artifact_id'] ?? '' ) );
+		if ( '' === $artifact_id ) {
+			return new WP_Error( 'wp_codebox_artifact_id_missing', 'artifact_id is required.', array( 'status' => 400 ) );
+		}
+
+		$approved_files = self::approved_files( $input );
+		if ( empty( $approved_files ) ) {
+			return new WP_Error( 'wp_codebox_approved_files_missing', 'approved_files must include at least one sandbox path.', array( 'status' => 400 ) );
+		}
+
+		$apply_input = array(
+			'artifact_id'    => $artifact_id,
+			'approved_files' => $approved_files,
+		);
+
+		foreach ( array( 'artifacts_path', 'approver', 'apply_target' ) as $key ) {
+			if ( array_key_exists( $key, $input ) ) {
+				$apply_input[ $key ] = $input[ $key ];
+			}
+		}
+
+		return $apply_input;
+	}
+
+	/** @param array<string,mixed> $input Ability/helper input. @return string[] */
+	private static function approved_files( array $input ): array {
+		$files = is_array( $input['approved_files'] ?? null ) ? $input['approved_files'] : array();
+
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map( static fn( $path ): string => trim( (string) $path ), $files ),
+					static fn( string $path ): bool => '' !== $path
+				)
+			)
+		);
+	}
+
+	/** @param array<string,mixed> $bundle Artifact bundle. @param array<string,mixed> $apply_input Stored apply input. */
+	private static function preview_data( array $bundle, array $apply_input ): array {
+		return array(
+			'schema'         => 'wp-codebox/pending-apply-preview/v1',
+			'artifact_id'    => (string) ( $bundle['id'] ?? $apply_input['artifact_id'] ?? '' ),
+			'content_digest' => (string) ( $bundle['content_digest'] ?? '' ),
+			'created_at'     => (string) ( $bundle['created_at'] ?? '' ),
+			'approved_files' => $apply_input['approved_files'] ?? array(),
+			'changed_files'  => is_array( $bundle['changed_files'] ?? null ) ? $bundle['changed_files'] : array(),
+			'test_results'   => is_array( $bundle['test_results'] ?? null ) ? $bundle['test_results'] : array(),
+			'review'         => is_array( $bundle['review'] ?? null ) ? $bundle['review'] : array(),
+		);
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -20,8 +20,10 @@ define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
+require_once __DIR__ . '/src/class-wp-codebox-data-machine-pending-actions.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 
 add_action( 'plugins_loaded', static function (): void {
+	new WP_Codebox_Data_Machine_Pending_Actions();
 	new WP_Codebox_Abilities();
 }, 20 );

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -37,6 +37,7 @@ function wp_register_ability( string $name, array $definition ): void {
 
 function doing_action( string $hook ): bool { return 'wp_abilities_api_init' === $hook; }
 function add_action( string $hook, callable $callback, int $priority = 10 ): void {}
+function add_filter( string $hook, callable $callback, int $priority = 10 ): void { $GLOBALS['wp_codebox_filters'][ $hook ] = $callback; }
 function current_user_can( string $capability ): bool { return 'manage_options' === $capability; }
 function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 	if ( ! array_key_exists( $hook, $GLOBALS['wp_codebox_filters'] ) ) {
@@ -54,6 +55,7 @@ function get_option( string $name, mixed $default = null ): mixed { return $defa
 
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
+require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
 
 $root = sys_get_temp_dir() . '/wp-codebox-wordpress-plugin-' . getmypid();
@@ -77,6 +79,7 @@ $assert   = function ( string $label, bool $condition ) use ( &$failures, &$tota
 
 echo "WP Codebox WordPress plugin - smoke\n";
 
+new WP_Codebox_Data_Machine_Pending_Actions();
 new WP_Codebox_Abilities();
 
 $ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-agent-task'] ?? null;
@@ -100,6 +103,7 @@ $artifact_abilities = array(
 	'wp-codebox/get-artifact',
 	'wp-codebox/discard-artifact',
 	'wp-codebox/apply-approved-artifact',
+	'wp-codebox/stage-artifact-apply',
 );
 foreach ( $artifact_abilities as $artifact_ability_name ) {
 	$artifact_ability = $GLOBALS['wp_codebox_registered_abilities'][ $artifact_ability_name ] ?? null;
@@ -378,6 +382,48 @@ $applied = $artifacts->apply_approved(
 );
 $assert( 'approved artifact apply delegates exact patch', ! is_wp_error( $applied ) && true === ( $applied['result']['patch_contains'] ?? false ) && hash( 'sha256', $patch_diff ) === ( $applied['patch_sha256'] ?? '' ) && $content_digest === ( $applied['content_digest'] ?? '' ) );
 
+$captured_stage_args = array();
+$GLOBALS['wp_codebox_filters']['wp_codebox_stage_pending_apply_artifact'] = function ( mixed $value, array $stage_args ) use ( &$captured_stage_args ): array {
+	$captured_stage_args = $stage_args;
+	return array(
+		'staged'    => true,
+		'action_id' => 'act_test',
+		'payload'   => array(
+			'pending_action' => array(
+				'kind'        => $stage_args['kind'],
+				'apply_input' => $stage_args['apply_input'],
+				'preview'     => $stage_args['preview_data'],
+			),
+		),
+	);
+};
+$staged = WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact(
+	array(
+		'artifacts_path'  => $artifact_root,
+		'artifact_id'     => $artifact_id,
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt', '' ),
+		'approver'        => 'site-user:1',
+		'apply_target'    => array( 'repo' => 'chubes4/wp-codebox' ),
+		'context'         => array( 'session_id' => 'chat-123' ),
+	)
+);
+$assert( 'pending artifact apply can be staged', ! is_wp_error( $staged ) && true === ( $staged['staged'] ?? false ) && WP_Codebox_Data_Machine_Pending_Actions::KIND === ( $captured_stage_args['kind'] ?? '' ) );
+$assert( 'pending artifact apply stores exact apply input', $artifact_id === ( $captured_stage_args['apply_input']['artifact_id'] ?? '' ) && array( '/wordpress/wp-content/plugins/example/generated.txt' ) === ( $captured_stage_args['apply_input']['approved_files'] ?? array() ) && array( 'repo' => 'chubes4/wp-codebox' ) === ( $captured_stage_args['apply_input']['apply_target'] ?? array() ) );
+$assert( 'pending artifact apply preview includes review and changed files', 'wp-codebox/pending-apply-preview/v1' === ( $captured_stage_args['preview_data']['schema'] ?? '' ) && 'wp-codebox/artifact-review/v1' === ( $captured_stage_args['preview_data']['review']['schema'] ?? '' ) && 'wp-codebox/changed-files/v1' === ( $captured_stage_args['preview_data']['changed_files']['schema'] ?? '' ) );
+
+$handlers = apply_filters( 'datamachine_pending_action_handlers', array() );
+$assert( 'pending artifact apply handler registers with Data Machine', isset( $handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'] ) && is_callable( $handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'] ) );
+$pending_handler_result = call_user_func(
+	$handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'],
+	array(
+		'artifacts_path'  => $artifact_root,
+		'artifact_id'     => $artifact_id,
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt' ),
+		'approver'        => 'site-user:1',
+	)
+);
+$assert( 'pending artifact apply handler delegates to approved artifact apply', ! is_wp_error( $pending_handler_result ) && true === ( $pending_handler_result['success'] ?? false ) && $artifact_id === ( $pending_handler_result['artifact_id'] ?? '' ) );
+
 $audit_path      = $artifact_root . '/apply-audit.jsonl';
 $audit_lines     = is_file( $audit_path ) ? array_values( array_filter( explode( "\n", trim( (string) file_get_contents( $audit_path ) ) ) ) ) : array();
 $success_audit   = isset( $audit_lines[0] ) ? json_decode( $audit_lines[0], true ) : array();
@@ -399,8 +445,8 @@ $failed_apply = $artifacts->apply_approved(
 	)
 );
 $audit_lines   = is_file( $audit_path ) ? array_values( array_filter( explode( "\n", trim( (string) file_get_contents( $audit_path ) ) ) ) ) : array();
-$failure_audit = isset( $audit_lines[1] ) ? json_decode( $audit_lines[1], true ) : array();
-$failure_encoded = isset( $audit_lines[1] ) ? $audit_lines[1] : '';
+$failure_audit = isset( $audit_lines[2] ) ? json_decode( $audit_lines[2], true ) : array();
+$failure_encoded = isset( $audit_lines[2] ) ? $audit_lines[2] : '';
 $assert( 'approved artifact apply writes adapter failure audit record', is_wp_error( $failed_apply ) && is_array( $failure_audit ) && 'failure' === ( $failure_audit['status'] ?? '' ) && 'test-adapter' === ( $failure_audit['adapter'] ?? '' ) && 'wp_codebox_adapter_failed' === ( $failure_audit['error']['code'] ?? '' ) );
 $assert( 'failure audit records approver and excludes raw patch body and secrets', 'site-user:2' === ( $failure_audit['approver'] ?? '' ) && ! str_contains( $failure_encoded, 'diff --git' ) && ! str_contains( $failure_encoded, 'secret-password-value' ) && '[redacted]' === ( $failure_audit['error']['data']['patch'] ?? '' ) && '[redacted]' === ( $failure_audit['error']['data']['password'] ?? '' ) );
 


### PR DESCRIPTION
## Summary
- Add an optional Data Machine pending-action integration for reviewed WP Codebox artifact apply-back.
- Register `wp-codebox/stage-artifact-apply` and the `wp_codebox_apply_back` pending-action handler that delegates to the existing approved artifact apply path.
- Clarify README positioning: WP Codebox runs WordPress in the sandbox, but the host can be CLI, CI, Node, WordPress, Data Machine, Homeboy, Studio, or another control plane.

## Testing
- `npm run wordpress-plugin-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the optional pending-action integration, smoke coverage, and README updates; Chris reviewed direction interactively.