### PR TITLE
Add bench run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,20 @@ Supported workspace seeds:
 - `theme_scaffold`: creates `style.css`, `index.php`, and `README.md`, mounted by default at `/wordpress/wp-content/themes/<slug>`.
 - `directory`: copies `seed.source` into a disposable workspace and requires an explicit sandbox `target`.
 
+### `bench-run`
+
+Run plugin `tests/bench/*.php` workloads in a disposable WP Codebox runtime and emit the Homeboy-compatible `BenchResults` envelope.
+
+```bash
+npm run wp-codebox -- bench-run \
+  --component ./examples/bench-plugin \
+  --component-id bench-plugin \
+  --iterations 3 \
+  --json
+```
+
+Each workload file returns a callable. The callable may return numeric metrics directly or a payload with `metrics` and `metadata` keys. The command reports duration percentiles, custom metric aggregates, peak memory, runtime artifacts, and the parsed `benchResults` object in JSON output.
+
 ### `agent-runtime-probe`
 
 Boot a sandbox with Agents API, Data Machine, and Data Machine Code mounted, then verify the stack loads.

--- a/examples/bench-plugin/bench-plugin.php
+++ b/examples/bench-plugin/bench-plugin.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: Bench Plugin
+ * Description: Fixture plugin for WP Codebox bench command smoke tests.
+ * Version: 0.1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+function wp_codebox_bench_plugin_value(): int {
+	return 7;
+}

--- a/examples/bench-plugin/tests/bench/noop.php
+++ b/examples/bench-plugin/tests/bench/noop.php
@@ -1,0 +1,12 @@
+<?php
+
+return static function (): array {
+	return array(
+		'metrics'  => array(
+			'fixture_value' => wp_codebox_bench_plugin_value(),
+		),
+		'metadata' => array(
+			'fixture' => 'bench-plugin',
+		),
+	);
+};

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
+    "bench-command-smoke": "tsx scripts/bench-command-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run bench-command-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -133,6 +133,28 @@ interface AgentSandboxBatchOutput {
   runs: Array<RunOutput & { index: number; task: string }>
 }
 
+interface BenchRunOptions {
+  componentPath: string
+  componentId?: string
+  pluginSlug?: string
+  iterations?: string
+  warmupIterations?: string
+  wpVersion?: string
+  artifactsDirectory?: string
+  json: boolean
+}
+
+interface BenchResults {
+  component_id: string
+  iterations: number
+  scenarios: Array<Record<string, unknown>>
+}
+
+interface BenchRunOutput extends RunOutput {
+  schema: "wp-codebox/bench-run/v1"
+  benchResults?: BenchResults
+}
+
 const defaultPolicy: RuntimePolicy = {
   network: "deny",
   filesystem: "readwrite-mounts",
@@ -143,7 +165,7 @@ const defaultPolicy: RuntimePolicy = {
 
 const WP_CODEBOX_RUNTIME_VERSION = "0.0.0"
 const DEFAULT_WORDPRESS_VERSION = "7.0"
-const supportedRecipeCommands = new Set(["inspect-mounted-inputs", "wordpress.run-php", "wordpress.wp-cli", "wordpress.ability"])
+const supportedRecipeCommands = new Set(["inspect-mounted-inputs", "wordpress.run-php", "wordpress.wp-cli", "wordpress.ability", "wordpress.bench"])
 
 const secretEnvPolicy: RuntimePolicy = {
   ...defaultPolicy,
@@ -243,6 +265,25 @@ async function main(args: string[]): Promise<number> {
     return output.success ? 0 : 1
   }
 
+  if (command === "bench-run") {
+    const options = parseBenchRunOptions(args)
+    const execute = () => runBench(options)
+
+    if (!options.json) {
+      const output = await execute()
+      printHumanOutput(output)
+      if (output.benchResults) {
+        console.log(`Bench scenarios: ${output.benchResults.scenarios.length}`)
+      }
+      return output.success ? 0 : 1
+    }
+
+    const { result, logs } = await captureStdout(execute)
+    const output = logs.length > 0 ? { ...result, logs } : result
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    return output.success ? 0 : 1
+  }
+
   if (command !== "run") {
     console.error(`Unknown command: ${command}`)
     printHelp()
@@ -310,6 +351,46 @@ async function runAgentSandboxBatch(options: AgentSandboxBatchOptions): Promise<
     completed: runs.length - failed,
     failed,
     runs,
+  }
+}
+
+async function runBench(options: BenchRunOptions): Promise<BenchRunOutput> {
+  const componentPath = resolve(options.componentPath)
+  const pluginSlug = options.pluginSlug ?? basename(componentPath)
+  const componentId = options.componentId ?? pluginSlug
+  const output = await run({
+    mounts: [componentMount(componentPath, `/wordpress/wp-content/plugins/${pluginSlug}`, pluginSlug)],
+    command: "wordpress.bench",
+    args: [
+      `component-id=${componentId}`,
+      `plugin-slug=${pluginSlug}`,
+      `iterations=${positiveInteger(options.iterations, 3)}`,
+      `warmup=${positiveInteger(options.warmupIterations, 1)}`,
+    ],
+    wpVersion: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
+    artifactsDirectory: options.artifactsDirectory,
+    metadata: {
+      ...runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION),
+      task: stripUndefined({
+        kind: "bench-run",
+        componentId,
+        pluginSlug,
+        componentPath,
+        iterations: positiveInteger(options.iterations, 3),
+        warmupIterations: positiveInteger(options.warmupIterations, 1),
+      }),
+    },
+    json: options.json,
+  })
+
+  if (!output.success) {
+    return { ...output, schema: "wp-codebox/bench-run/v1" }
+  }
+
+  return {
+    ...output,
+    schema: "wp-codebox/bench-run/v1",
+    benchResults: parseBenchResults(output.execution?.stdout ?? ""),
   }
 }
 
@@ -688,6 +769,67 @@ function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
   }
 
   return options as AgentSandboxRunOptions
+}
+
+function parseBenchRunOptions(args: string[]): BenchRunOptions {
+  const options: Partial<BenchRunOptions> = { json: false }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--component":
+        options.componentPath = value
+        break
+      case "--component-id":
+        options.componentId = value
+        break
+      case "--plugin-slug":
+        options.pluginSlug = value
+        break
+      case "--iterations":
+        options.iterations = value
+        break
+      case "--warmup":
+        options.warmupIterations = value
+        break
+      case "--wp":
+        options.wpVersion = value
+        break
+      case "--artifacts":
+        options.artifactsDirectory = value
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (!options.componentPath) {
+    throw new Error("Missing required option: --component")
+  }
+
+  return options as BenchRunOptions
+}
+
+function parseBenchResults(raw: string): BenchResults {
+  const parsed = JSON.parse(raw) as BenchResults
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.scenarios)) {
+    throw new Error("Bench command did not emit a BenchResults envelope")
+  }
+
+  return parsed
 }
 
 async function parseAgentSandboxBatchOptions(args: string[]): Promise<AgentSandboxBatchOptions> {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -128,6 +128,7 @@ export function printHelp(): void {
   wp-codebox recipe validate --recipe <path> [--json]
   wp-codebox recipe-run --recipe <path> [options]
   wp-codebox run --mount <host>:<vfs> --command <id> [options]
+  wp-codebox bench-run --component <path> [options]
   wp-codebox agent-runtime-probe --agents-api <path> --data-machine <path> --data-machine-code <path> [options]
   wp-codebox agent-sandbox-run --agents-api <path> --data-machine <path> --data-machine-code <path> --task <text> [options]
   wp-codebox agent-sandbox-batch --agents-api <path> --data-machine <path> --data-machine-code <path> --task <text> [--task <text> ...] [options]
@@ -141,6 +142,13 @@ Options:
   --artifacts <dir>    Artifact root directory.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --json               Emit machine-readable JSON.
+
+Bench run options:
+  --component <path>       Local plugin component path containing tests/bench/*.php workloads.
+  --component-id <id>      Component id for the BenchResults envelope. Defaults to component basename.
+  --plugin-slug <slug>     Plugin directory slug inside WordPress. Defaults to component basename.
+  --iterations <n>         Measured iterations per workload. Defaults to 3.
+  --warmup <n>             Warmup iterations per workload. Defaults to 1.
 
 Agent runtime probe options:
   --agents-api <path>         Local Agents API plugin checkout.

--- a/packages/runtime-playground/src/commands.ts
+++ b/packages/runtime-playground/src/commands.ts
@@ -41,6 +41,148 @@ echo wp_json_encode( array(
 ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );`
 }
 
+export interface BenchRunCodeOptions {
+  componentId: string
+  pluginSlug: string
+  iterations: number
+  warmupIterations: number
+}
+
+export function benchRunCode(options: BenchRunCodeOptions): string {
+  return `require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+$component_id = ${JSON.stringify(options.componentId)};
+$plugin_slug = ${JSON.stringify(options.pluginSlug)};
+$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_slug;
+$iterations = max(1, (int) ${JSON.stringify(String(options.iterations))});
+$warmup_iterations = max(0, (int) ${JSON.stringify(String(options.warmupIterations))});
+
+function wp_codebox_bench_percentile(array $samples, float $percentile): float {
+    if (empty($samples)) {
+        return 0.0;
+    }
+
+    sort($samples, SORT_NUMERIC);
+    $index = (int) ceil($percentile * count($samples)) - 1;
+    $index = max(0, min(count($samples) - 1, $index));
+    return (float) $samples[$index];
+}
+
+function wp_codebox_bench_aggregate(array $samples, string $prefix = '', string $suffix = ''): array {
+    sort($samples, SORT_NUMERIC);
+    $count = count($samples);
+    $sum = array_sum($samples);
+    $key_prefix = $prefix === '' ? '' : $prefix . '_';
+
+    return array(
+        $key_prefix . 'mean' . $suffix => $count > 0 ? $sum / $count : 0.0,
+        $key_prefix . 'p50' . $suffix => wp_codebox_bench_percentile($samples, 0.50),
+        $key_prefix . 'p95' . $suffix => wp_codebox_bench_percentile($samples, 0.95),
+        $key_prefix . 'p99' . $suffix => wp_codebox_bench_percentile($samples, 0.99),
+        $key_prefix . 'min' . $suffix => $count > 0 ? (float) $samples[0] : 0.0,
+        $key_prefix . 'max' . $suffix => $count > 0 ? (float) $samples[$count - 1] : 0.0,
+    );
+}
+
+function wp_codebox_bench_record_payload($payload, array &$metric_samples, ?array &$metadata): void {
+    if (!is_array($payload)) {
+        return;
+    }
+
+    if (isset($payload['metadata']) && is_array($payload['metadata'])) {
+        $metadata = $payload['metadata'];
+    }
+
+    $metrics = array();
+    if (isset($payload['metrics']) && is_array($payload['metrics'])) {
+        $metrics = $payload['metrics'];
+    } else {
+        $metrics = $payload;
+        unset($metrics['metadata'], $metrics['artifacts']);
+    }
+
+    foreach ($metrics as $name => $value) {
+        if (!is_string($name) || $name === '' || !is_numeric($value)) {
+            continue;
+        }
+
+        $sample = (float) $value;
+        if (is_finite($sample)) {
+            $metric_samples[$name][] = $sample;
+        }
+    }
+}
+
+$plugin_file = $plugin_path . '/' . $plugin_slug . '.php';
+if (file_exists($plugin_file) && !is_plugin_active($plugin_slug . '/' . $plugin_slug . '.php')) {
+    $activation = activate_plugin($plugin_slug . '/' . $plugin_slug . '.php');
+    if (is_wp_error($activation)) {
+        throw new RuntimeException($activation->get_error_message());
+    }
+}
+
+$bench_dir = $plugin_path . '/tests/bench';
+$workload_files = is_dir($bench_dir) ? glob($bench_dir . '/*.php') : array();
+sort($workload_files, SORT_STRING);
+
+$scenarios = array();
+foreach ($workload_files as $workload_file) {
+    $callable = require $workload_file;
+    if (!is_callable($callable)) {
+        continue;
+    }
+
+    $timings = array();
+    $metric_samples = array();
+    $metadata = null;
+
+    if (function_exists('memory_reset_peak_usage')) {
+        memory_reset_peak_usage();
+    }
+
+    $total_iterations = $iterations + $warmup_iterations;
+    for ($i = 0; $i < $total_iterations; $i++) {
+        $is_warmup = $i < $warmup_iterations;
+        $started = hrtime(true);
+        $payload = $callable();
+        $elapsed_ms = (hrtime(true) - $started) / 1000000;
+
+        if (!$is_warmup) {
+            $timings[] = $elapsed_ms;
+            wp_codebox_bench_record_payload($payload, $metric_samples, $metadata);
+        }
+    }
+
+    $metrics = wp_codebox_bench_aggregate($timings, '', '_ms');
+    ksort($metric_samples);
+    foreach ($metric_samples as $metric => $samples) {
+        $metrics += wp_codebox_bench_aggregate($samples, $metric);
+    }
+
+    $relative_file = substr($workload_file, strlen($plugin_path) + 1);
+    $scenario = array(
+        'id' => preg_replace('/\\.php$/', '', basename($workload_file)),
+        'source' => 'in_tree',
+        'file' => $relative_file,
+        'iterations' => $iterations,
+        'metrics' => $metrics,
+        'memory' => array('peak_bytes' => memory_get_peak_usage(true)),
+    );
+
+    if (is_array($metadata) && !empty($metadata)) {
+        $scenario['metadata'] = $metadata;
+    }
+
+    $scenarios[] = $scenario;
+}
+
+echo wp_json_encode(array(
+    'component_id' => $component_id,
+    'iterations' => $iterations,
+    'scenarios' => $scenarios,
+), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
+}
+
 export function shellArgv(command: string): string[] {
   const args: string[] = []
   let current = ""
@@ -105,6 +247,16 @@ export function argValue(args: string[], name: string): string | undefined {
   const prefix = `${name}=`
   const match = args.find((arg) => arg.startsWith(prefix))
   return match?.slice(prefix.length)
+}
+
+export function positiveIntegerArg(args: string[], name: string, fallback: number): number {
+  const raw = argValue(args, name)
+  if (!raw) {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
 export function isSafeEnvName(name: string): boolean {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -24,7 +24,7 @@ import {
   type MountDiffsResult,
 } from "./artifacts.js"
 import { playgroundBlueprint } from "./blueprint.js"
-import { abilityInputFromArgs, abilityPhpCode, argValue, cleanWpCliOutput, isSafeEnvName, normalizePhpCode, phpBody, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
+import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, cleanWpCliOutput, isSafeEnvName, normalizePhpCode, phpBody, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
 import type {
   ArtifactBundle,
   ArtifactManifest,
@@ -594,6 +594,10 @@ class PlaygroundRuntime implements Runtime {
       return this.runAbility(spec)
     }
 
+    if (spec.command === "wordpress.bench") {
+      return this.runBench(spec)
+    }
+
     throw new Error(`No Playground command handler is registered for: ${spec.command}`)
   }
 
@@ -640,6 +644,24 @@ class PlaygroundRuntime implements Runtime {
 
     const input = abilityInputFromArgs(spec.args ?? [])
     const response = await server.playground.run({ code: this.bootstrapAbilityPhpCode(abilityPhpCode(name, input)) })
+    return response.text
+  }
+
+  private async runBench(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const args = spec.args ?? []
+    const pluginSlug = argValue(args, "plugin-slug")?.trim()
+    if (!pluginSlug) {
+      throw new Error("wordpress.bench requires plugin-slug=<slug>")
+    }
+
+    const componentId = argValue(args, "component-id")?.trim() || pluginSlug
+    const iterations = positiveIntegerArg(args, "iterations", 3)
+    const warmupIterations = positiveIntegerArg(args, "warmup", 1)
+    const response = await server.playground.run({
+      code: this.bootstrapPhpCode(benchRunCode({ componentId, pluginSlug, iterations, warmupIterations }), []),
+    })
+
     return response.text
   }
 

--- a/scripts/bench-command-smoke.ts
+++ b/scripts/bench-command-smoke.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { dirname, resolve } from "node:path"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const component = resolve(root, "examples/bench-plugin")
+const artifacts = resolve(root, "artifacts/bench-command-smoke")
+
+const result = spawnSync(process.execPath, [
+  cli,
+  "bench-run",
+  "--component",
+  component,
+  "--component-id",
+  "bench-plugin",
+  "--iterations",
+  "2",
+  "--warmup",
+  "1",
+  "--artifacts",
+  artifacts,
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(result.status, 0, result.stderr || result.stdout)
+
+const output = JSON.parse(result.stdout)
+assert.equal(output.success, true)
+assert.equal(output.schema, "wp-codebox/bench-run/v1")
+assert.equal(output.execution.command, "wordpress.bench")
+assert.equal(output.benchResults.component_id, "bench-plugin")
+assert.equal(output.benchResults.iterations, 2)
+assert.equal(output.benchResults.scenarios.length, 1)
+
+const scenario = output.benchResults.scenarios[0]
+assert.equal(scenario.id, "noop")
+assert.equal(scenario.file, "tests/bench/noop.php")
+assert.equal(scenario.iterations, 2)
+assert.equal(scenario.metrics.fixture_value_mean, 7)
+assert.equal(scenario.metadata.fixture, "bench-plugin")
+assert.ok(output.artifacts?.directory)
+
+console.log("bench command smoke passed")


### PR DESCRIPTION
## Summary
- Add `wp-codebox bench-run` for plugin `tests/bench/*.php` workloads.
- Emit the Homeboy-compatible `BenchResults` envelope alongside normal WP Codebox runtime/artifact metadata.
- Add a bench fixture plugin and smoke coverage, then include it in `npm run check`.

## Verification
- `npm run build`
- `npm run bench-command-smoke`
- `npm run check`

## Related
- Unblocks the first upstream slice for Extra-Chill/homeboy-extensions#698.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the CLI command, PHP bench wrapper, smoke fixture, and documentation; Chris remains responsible for review and testing.