### PR TITLE
Extend bench run inputs

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ interface RunOptions {
   policy?: RuntimePolicy
   secretEnv?: Record<string, string>
   metadata?: Record<string, unknown>
+  blueprint?: unknown
   json: boolean
 }
 
@@ -137,6 +138,11 @@ interface BenchRunOptions {
   componentPath: string
   componentId?: string
   pluginSlug?: string
+  dependencies: Array<{ source: string; slug: string }>
+  mounts: RunOptions["mounts"]
+  envJson?: string
+  wpConfigDefinesJson?: string
+  workloadsJson?: string
   iterations?: string
   warmupIterations?: string
   wpVersion?: string
@@ -358,17 +364,28 @@ async function runBench(options: BenchRunOptions): Promise<BenchRunOutput> {
   const componentPath = resolve(options.componentPath)
   const pluginSlug = options.pluginSlug ?? basename(componentPath)
   const componentId = options.componentId ?? pluginSlug
+  const env = parseJsonRecord(options.envJson, "--env-json")
+  const wpConfigDefines = parseJsonRecord(options.wpConfigDefinesJson, "--wp-config-defines-json")
+  const workloads = parseJsonArray(options.workloadsJson, "--workloads-json")
   const output = await run({
-    mounts: [componentMount(componentPath, `/wordpress/wp-content/plugins/${pluginSlug}`, pluginSlug)],
+    mounts: [
+      componentMount(componentPath, `/wordpress/wp-content/plugins/${pluginSlug}`, pluginSlug),
+      ...options.dependencies.map((dependency) => componentMount(dependency.source, `/wordpress/wp-content/plugins/${dependency.slug}`, dependency.slug)),
+      ...options.mounts,
+    ],
     command: "wordpress.bench",
     args: [
       `component-id=${componentId}`,
       `plugin-slug=${pluginSlug}`,
       `iterations=${positiveInteger(options.iterations, 3)}`,
-      `warmup=${positiveInteger(options.warmupIterations, 1)}`,
+      `warmup=${nonNegativeInteger(options.warmupIterations, 1)}`,
+      `dependency-slugs=${options.dependencies.map((dependency) => dependency.slug).join(",")}`,
+      `env-json=${JSON.stringify(env)}`,
+      `workloads-json=${JSON.stringify(workloads)}`,
     ],
     wpVersion: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
     artifactsDirectory: options.artifactsDirectory,
+    blueprint: Object.keys(wpConfigDefines).length > 0 ? wpConfigDefinesBlueprint(wpConfigDefines) : undefined,
     metadata: {
       ...runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION),
       task: stripUndefined({
@@ -376,8 +393,13 @@ async function runBench(options: BenchRunOptions): Promise<BenchRunOutput> {
         componentId,
         pluginSlug,
         componentPath,
+        dependencies: options.dependencies,
+        mounts: options.mounts,
+        env,
+        wpConfigDefines,
+        workloads,
         iterations: positiveInteger(options.iterations, 3),
-        warmupIterations: positiveInteger(options.warmupIterations, 1),
+        warmupIterations: nonNegativeInteger(options.warmupIterations, 1),
       }),
     },
     json: options.json,
@@ -772,7 +794,7 @@ function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
 }
 
 function parseBenchRunOptions(args: string[]): BenchRunOptions {
-  const options: Partial<BenchRunOptions> = { json: false }
+  const options: Partial<BenchRunOptions> = { json: false, dependencies: [], mounts: [] }
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -799,6 +821,21 @@ function parseBenchRunOptions(args: string[]): BenchRunOptions {
       case "--plugin-slug":
         options.pluginSlug = value
         break
+      case "--dependency":
+        options.dependencies = [...(options.dependencies ?? []), parseDependency(value)]
+        break
+      case "--mount":
+        options.mounts = [...(options.mounts ?? []), parseMount(value)]
+        break
+      case "--env-json":
+        options.envJson = value
+        break
+      case "--wp-config-defines-json":
+        options.wpConfigDefinesJson = value
+        break
+      case "--workloads-json":
+        options.workloadsJson = value
+        break
       case "--iterations":
         options.iterations = value
         break
@@ -821,6 +858,52 @@ function parseBenchRunOptions(args: string[]): BenchRunOptions {
   }
 
   return options as BenchRunOptions
+}
+
+function parseDependency(value: string): { source: string; slug: string } {
+  const [source, slug = basename(resolve(value))] = value.split(":")
+  if (!source || !slug) {
+    throw new Error(`Invalid dependency, expected path[:slug]: ${value}`)
+  }
+
+  return { source: resolve(source), slug }
+}
+
+function parseJsonRecord(raw: string | undefined, label: string): Record<string, unknown> {
+  if (!raw) {
+    return {}
+  }
+
+  const parsed = JSON.parse(raw)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object`)
+  }
+
+  return parsed as Record<string, unknown>
+}
+
+function parseJsonArray(raw: string | undefined, label: string): unknown[] {
+  if (!raw) {
+    return []
+  }
+
+  const parsed = JSON.parse(raw)
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON array`)
+  }
+
+  return parsed
+}
+
+function wpConfigDefinesBlueprint(defines: Record<string, unknown>): unknown {
+  return {
+    steps: [
+      {
+        step: "defineWpConfigConsts",
+        consts: defines,
+      },
+    ],
+  }
 }
 
 function parseBenchResults(raw: string): BenchResults {
@@ -914,6 +997,15 @@ function positiveInteger(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
+function nonNegativeInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
 function resolveSecretEnv(names: string[]): Record<string, string> {
   const secretEnv: Record<string, string> = {}
   for (const name of names) {
@@ -956,7 +1048,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
           kind: "wordpress",
           name: "wp-codebox-cli",
           version: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
-          blueprint: { steps: [] },
+          blueprint: options.blueprint ?? { steps: [] },
         },
         policy: options.policy ?? runPolicy(options.command),
         secretEnv: options.secretEnv,

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -147,6 +147,11 @@ Bench run options:
   --component <path>       Local plugin component path containing tests/bench/*.php workloads.
   --component-id <id>      Component id for the BenchResults envelope. Defaults to component basename.
   --plugin-slug <slug>     Plugin directory slug inside WordPress. Defaults to component basename.
+  --dependency <path:slug> Extra plugin dependency to mount and activate. Repeatable.
+  --mount <host:vfs>       Extra host path to mount into the runtime. Repeatable.
+  --env-json <json>        Bench environment object exposed through getenv() and $_ENV.
+  --wp-config-defines-json <json> wp-config constant object applied before WordPress boots.
+  --workloads-json <json>  Configured workload array for PHP/ability/wp-cli steps.
   --iterations <n>         Measured iterations per workload. Defaults to 3.
   --warmup <n>             Warmup iterations per workload. Defaults to 1.
 

--- a/packages/runtime-playground/src/commands.ts
+++ b/packages/runtime-playground/src/commands.ts
@@ -46,6 +46,9 @@ export interface BenchRunCodeOptions {
   pluginSlug: string
   iterations: number
   warmupIterations: number
+  dependencySlugs: string[]
+  env: Record<string, unknown>
+  workloads: unknown[]
 }
 
 export function benchRunCode(options: BenchRunCodeOptions): string {
@@ -56,6 +59,19 @@ $plugin_slug = ${JSON.stringify(options.pluginSlug)};
 $plugin_path = WP_PLUGIN_DIR . '/' . $plugin_slug;
 $iterations = max(1, (int) ${JSON.stringify(String(options.iterations))});
 $warmup_iterations = max(0, (int) ${JSON.stringify(String(options.warmupIterations))});
+$dependency_slugs = json_decode(${JSON.stringify(JSON.stringify(options.dependencySlugs))}, true);
+$bench_env = json_decode(${JSON.stringify(JSON.stringify(options.env))}, true);
+$configured_workloads = json_decode(${JSON.stringify(JSON.stringify(options.workloads))}, true);
+
+if (is_array($bench_env)) {
+    foreach ($bench_env as $name => $value) {
+        if (is_string($name) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+            $string_value = is_scalar($value) ? (string) $value : wp_json_encode($value);
+            putenv($name . '=' . $string_value);
+            $_ENV[$name] = $string_value;
+        }
+    }
+}
 
 function wp_codebox_bench_percentile(array $samples, float $percentile): float {
     if (empty($samples)) {
@@ -84,13 +100,17 @@ function wp_codebox_bench_aggregate(array $samples, string $prefix = '', string 
     );
 }
 
-function wp_codebox_bench_record_payload($payload, array &$metric_samples, ?array &$metadata): void {
+function wp_codebox_bench_record_payload($payload, array &$metric_samples, ?array &$metadata, ?array &$artifacts = null): void {
     if (!is_array($payload)) {
         return;
     }
 
     if (isset($payload['metadata']) && is_array($payload['metadata'])) {
         $metadata = $payload['metadata'];
+    }
+
+    if (isset($payload['artifacts']) && is_array($payload['artifacts'])) {
+        $artifacts = $payload['artifacts'];
     }
 
     $metrics = array();
@@ -113,12 +133,92 @@ function wp_codebox_bench_record_payload($payload, array &$metric_samples, ?arra
     }
 }
 
+$plugins_to_activate = array();
+foreach (is_array($dependency_slugs) ? $dependency_slugs : array() as $dependency_slug) {
+    $dependency_slug = sanitize_key((string) $dependency_slug);
+    $dependency_file = WP_PLUGIN_DIR . '/' . $dependency_slug . '/' . $dependency_slug . '.php';
+    if (file_exists($dependency_file)) {
+        $plugins_to_activate[] = $dependency_slug . '/' . $dependency_slug . '.php';
+    }
+}
 $plugin_file = $plugin_path . '/' . $plugin_slug . '.php';
-if (file_exists($plugin_file) && !is_plugin_active($plugin_slug . '/' . $plugin_slug . '.php')) {
-    $activation = activate_plugin($plugin_slug . '/' . $plugin_slug . '.php');
+if (file_exists($plugin_file)) {
+    $plugins_to_activate[] = $plugin_slug . '/' . $plugin_slug . '.php';
+}
+foreach ($plugins_to_activate as $plugin_to_activate) {
+    if (is_plugin_active($plugin_to_activate)) {
+        continue;
+    }
+    $activation = activate_plugin($plugin_to_activate);
     if (is_wp_error($activation)) {
         throw new RuntimeException($activation->get_error_message());
     }
+}
+
+function wp_codebox_bench_run_configured_workload(array $workload, string $plugin_path) {
+    $steps = isset($workload['run']) && is_array($workload['run']) ? $workload['run'] : array($workload);
+    $payload = array('metrics' => array(), 'metadata' => array(), 'artifacts' => array());
+    if (isset($workload['metadata']) && is_array($workload['metadata'])) {
+        $payload['metadata'] = array_merge($payload['metadata'], $workload['metadata']);
+    }
+    if (isset($workload['artifacts']) && is_array($workload['artifacts'])) {
+        $payload['artifacts'] = array_merge($payload['artifacts'], $workload['artifacts']);
+    }
+    foreach ($steps as $step) {
+        if (!is_array($step)) {
+            continue;
+        }
+        $type = isset($step['type']) ? (string) $step['type'] : 'php';
+        if ($type === 'php') {
+            if (isset($step['file']) && is_string($step['file'])) {
+                $file = $plugin_path . '/' . ltrim($step['file'], '/');
+                $callable = require $file;
+                $result = is_callable($callable) ? $callable() : $callable;
+            } else {
+                $result = null;
+                $code = isset($step['code']) && is_string($step['code']) ? $step['code'] : '';
+                if ($code !== '') {
+                    $runner = static function () use ($code, &$result): void {
+                        $result = eval($code);
+                    };
+                    $runner();
+                }
+            }
+        } elseif ($type === 'ability') {
+            if (!function_exists('wp_get_ability')) {
+                throw new RuntimeException('The WordPress Abilities API is not available in this runtime.');
+            }
+            $ability_name = isset($step['name']) ? (string) $step['name'] : (isset($step['ability']) ? (string) $step['ability'] : '');
+            $ability = wp_get_ability($ability_name);
+            if (!$ability) {
+                throw new RuntimeException('Ability is not registered: ' . $ability_name);
+            }
+            $result = $ability->execute(isset($step['input']) && is_array($step['input']) ? $step['input'] : array());
+            if (is_wp_error($result)) {
+                throw new RuntimeException($result->get_error_message());
+            }
+        } elseif ($type === 'wp-cli') {
+            if (!class_exists('WP_CLI')) {
+                throw new RuntimeException('WP-CLI is not loaded inside wordpress.bench yet.');
+            }
+            $command = isset($step['command']) ? (string) $step['command'] : '';
+            $result = WP_CLI::runcommand($command, array('return' => true, 'launch' => false, 'parse' => 'json'));
+        } else {
+            throw new RuntimeException('Unsupported bench workload step type: ' . $type);
+        }
+        if (is_array($result)) {
+            if (isset($result['metrics']) && is_array($result['metrics'])) {
+                $payload['metrics'] = array_merge($payload['metrics'], $result['metrics']);
+            }
+            if (isset($result['metadata']) && is_array($result['metadata'])) {
+                $payload['metadata'] = array_merge($payload['metadata'], $result['metadata']);
+            }
+            if (isset($result['artifacts']) && is_array($result['artifacts'])) {
+                $payload['artifacts'] = array_merge($payload['artifacts'], $result['artifacts']);
+            }
+        }
+    }
+    return $payload;
 }
 
 $bench_dir = $plugin_path . '/tests/bench';
@@ -135,6 +235,8 @@ foreach ($workload_files as $workload_file) {
     $timings = array();
     $metric_samples = array();
     $metadata = null;
+    $artifacts = null;
+    $artifacts = null;
 
     if (function_exists('memory_reset_peak_usage')) {
         memory_reset_peak_usage();
@@ -149,7 +251,7 @@ foreach ($workload_files as $workload_file) {
 
         if (!$is_warmup) {
             $timings[] = $elapsed_ms;
-            wp_codebox_bench_record_payload($payload, $metric_samples, $metadata);
+            wp_codebox_bench_record_payload($payload, $metric_samples, $metadata, $artifacts);
         }
     }
 
@@ -176,9 +278,50 @@ foreach ($workload_files as $workload_file) {
     $scenarios[] = $scenario;
 }
 
+foreach (is_array($configured_workloads) ? $configured_workloads : array() as $index => $workload) {
+    if (!is_array($workload)) {
+        continue;
+    }
+    $scenario_id = isset($workload['id']) && is_string($workload['id']) ? $workload['id'] : 'configured-' . $index;
+    $timings = array();
+    $metric_samples = array();
+    $metadata = null;
+    $total_iterations = $iterations + $warmup_iterations;
+    for ($i = 0; $i < $total_iterations; $i++) {
+        $is_warmup = $i < $warmup_iterations;
+        $started = hrtime(true);
+        $payload = wp_codebox_bench_run_configured_workload($workload, $plugin_path);
+        $elapsed_ms = (hrtime(true) - $started) / 1000000;
+        if (!$is_warmup) {
+            $timings[] = $elapsed_ms;
+            wp_codebox_bench_record_payload($payload, $metric_samples, $metadata, $artifacts);
+        }
+    }
+    $metrics = wp_codebox_bench_aggregate($timings, '', '_ms');
+    ksort($metric_samples);
+    foreach ($metric_samples as $metric => $samples) {
+        $metrics += wp_codebox_bench_aggregate($samples, $metric);
+    }
+    $scenario = array(
+        'id' => $scenario_id,
+        'source' => 'config',
+        'iterations' => $iterations,
+        'metrics' => $metrics,
+        'memory' => array('peak_bytes' => memory_get_peak_usage(true)),
+    );
+    if (is_array($metadata) && !empty($metadata)) {
+        $scenario['metadata'] = $metadata;
+    }
+    if (is_array($artifacts) && !empty($artifacts)) {
+        $scenario['artifacts'] = $artifacts;
+    }
+    $scenarios[] = $scenario;
+}
+
 echo wp_json_encode(array(
     'component_id' => $component_id,
     'iterations' => $iterations,
+    'warmup_iterations' => $warmup_iterations,
     'scenarios' => $scenarios,
 ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
 }
@@ -257,6 +400,48 @@ export function positiveIntegerArg(args: string[], name: string, fallback: numbe
 
   const parsed = Number.parseInt(raw, 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export function nonNegativeIntegerArg(args: string[], name: string, fallback: number): number {
+  const raw = argValue(args, name)
+  if (!raw) {
+    return fallback
+  }
+
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+export function commaListArg(args: string[], name: string): string[] {
+  return (argValue(args, name) ?? "").split(",").map((item) => item.trim()).filter(Boolean)
+}
+
+export function jsonObjectArg(args: string[], name: string): Record<string, unknown> {
+  const raw = argValue(args, name)
+  if (!raw) {
+    return {}
+  }
+
+  const parsed = JSON.parse(raw)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${name} must be a JSON object`)
+  }
+
+  return parsed as Record<string, unknown>
+}
+
+export function jsonArrayArg(args: string[], name: string): unknown[] {
+  const raw = argValue(args, name)
+  if (!raw) {
+    return []
+  }
+
+  const parsed = JSON.parse(raw)
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${name} must be a JSON array`)
+  }
+
+  return parsed
 }
 
 export function isSafeEnvName(name: string): boolean {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -24,7 +24,7 @@ import {
   type MountDiffsResult,
 } from "./artifacts.js"
 import { playgroundBlueprint } from "./blueprint.js"
-import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, cleanWpCliOutput, isSafeEnvName, normalizePhpCode, phpBody, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
+import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, cleanWpCliOutput, commaListArg, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, phpBody, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
 import type {
   ArtifactBundle,
   ArtifactManifest,
@@ -657,9 +657,12 @@ class PlaygroundRuntime implements Runtime {
 
     const componentId = argValue(args, "component-id")?.trim() || pluginSlug
     const iterations = positiveIntegerArg(args, "iterations", 3)
-    const warmupIterations = positiveIntegerArg(args, "warmup", 1)
+    const warmupIterations = nonNegativeIntegerArg(args, "warmup", 1)
+    const dependencySlugs = commaListArg(args, "dependency-slugs")
+    const env = jsonObjectArg(args, "env-json")
+    const workloads = jsonArrayArg(args, "workloads-json")
     const response = await server.playground.run({
-      code: this.bootstrapPhpCode(benchRunCode({ componentId, pluginSlug, iterations, warmupIterations }), []),
+      code: this.bootstrapPhpCode(benchRunCode({ componentId, pluginSlug, iterations, warmupIterations, dependencySlugs, env, workloads }), []),
     })
 
     return response.text

--- a/scripts/bench-command-smoke.ts
+++ b/scripts/bench-command-smoke.ts
@@ -18,7 +18,20 @@ const result = spawnSync(process.execPath, [
   "--iterations",
   "2",
   "--warmup",
-  "1",
+  "0",
+  "--env-json",
+  JSON.stringify({ BENCH_FIXTURE_ENV: "13" }),
+  "--wp-config-defines-json",
+  JSON.stringify({ BENCH_FIXTURE_DEFINE: "defined-value" }),
+  "--workloads-json",
+  JSON.stringify([
+    {
+      id: "configured-env",
+      type: "php",
+      artifacts: { report: { path: "workloads/report.json", kind: "json" } },
+      code: "return array('metrics' => array('env_value' => (int) getenv('BENCH_FIXTURE_ENV'), 'define_visible' => defined('BENCH_FIXTURE_DEFINE') && BENCH_FIXTURE_DEFINE === 'defined-value' ? 1 : 0), 'metadata' => array('kind' => 'configured'));",
+    },
+  ]),
   "--artifacts",
   artifacts,
   "--json",
@@ -32,7 +45,8 @@ assert.equal(output.schema, "wp-codebox/bench-run/v1")
 assert.equal(output.execution.command, "wordpress.bench")
 assert.equal(output.benchResults.component_id, "bench-plugin")
 assert.equal(output.benchResults.iterations, 2)
-assert.equal(output.benchResults.scenarios.length, 1)
+assert.equal(output.benchResults.warmup_iterations, 0)
+assert.equal(output.benchResults.scenarios.length, 2)
 
 const scenario = output.benchResults.scenarios[0]
 assert.equal(scenario.id, "noop")
@@ -40,6 +54,13 @@ assert.equal(scenario.file, "tests/bench/noop.php")
 assert.equal(scenario.iterations, 2)
 assert.equal(scenario.metrics.fixture_value_mean, 7)
 assert.equal(scenario.metadata.fixture, "bench-plugin")
+const configured = output.benchResults.scenarios[1]
+assert.equal(configured.id, "configured-env")
+assert.equal(configured.source, "config")
+assert.equal(configured.metrics.env_value_mean, 13)
+assert.equal(configured.metrics.define_visible_mean, 1)
+assert.equal(configured.metadata.kind, "configured")
+assert.equal(configured.artifacts.report.path, "workloads/report.json")
 assert.ok(output.artifacts?.directory)
 
 console.log("bench command smoke passed")


### PR DESCRIPTION
## Summary
- Add `bench-run` inputs for dependency plugin mounts, extra mounts, env vars, wp-config defines, and configured workloads.
- Preserve zero warmup iterations for side-effectful configured workloads and include `warmup_iterations` in the bench envelope.
- Extend the bench smoke to prove env forwarding, wp-config defines, configured workloads, and zero warmup handling.

## Verification
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and verification loop for the bench input expansion.