### PR TITLE
Add WordPress PHPUnit recipe command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -152,7 +152,7 @@ const defaultPolicy: RuntimePolicy = {
 
 const WP_CODEBOX_RUNTIME_VERSION = "0.0.0"
 const DEFAULT_WORDPRESS_VERSION = "7.0"
-const supportedRecipeCommands = new Set(["inspect-mounted-inputs", "wordpress.run-php", "wordpress.wp-cli", "wordpress.ability", "wordpress.bench", "wp-codebox.agent-runtime-probe", "wp-codebox.agent-sandbox-run"])
+const supportedRecipeCommands = new Set(["inspect-mounted-inputs", "wordpress.run-php", "wordpress.wp-cli", "wordpress.ability", "wordpress.bench", "wordpress.phpunit", "wp-codebox.agent-runtime-probe", "wp-codebox.agent-sandbox-run"])
 
 const secretEnvPolicy: RuntimePolicy = {
   ...defaultPolicy,
@@ -1114,14 +1114,14 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
 }
 
 async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"][number], path: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
-  if (step.command === "wordpress.run-php") {
+  if (step.command === "wordpress.run-php" || step.command === "wordpress.phpunit") {
     const code = recipeStepArgValue(step.args ?? [], "code")
     const codeFile = recipeStepArgValue(step.args ?? [], "code-file")
     if (!code && !codeFile) {
-      addIssue("missing-code", `${path}.args`, "wordpress.run-php requires code=<php> or code-file=<path>.")
+      addIssue("missing-code", `${path}.args`, `${step.command} requires code=<php> or code-file=<path>.`)
     }
     if (code && codeFile) {
-      addIssue("ambiguous-code", `${path}.args`, "wordpress.run-php accepts either code=<php> or code-file=<path>, not both.")
+      addIssue("ambiguous-code", `${path}.args`, `${step.command} accepts either code=<php> or code-file=<path>, not both.`)
     }
     if (codeFile) {
       await validateExistingFile(resolve(codeFile), `${path}.args`, addIssue)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -133,7 +133,7 @@ Options:
   --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
-  --arg <key=value>    Command argument. Repeatable.
+  --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.wp-cli, wordpress.ability, and wordpress.bench.
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --artifacts <dir>    Artifact root directory.
   --policy <json|file> Runtime policy JSON or path to a JSON file.

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -598,6 +598,10 @@ class PlaygroundRuntime implements Runtime {
       return this.runBench(spec)
     }
 
+    if (spec.command === "wordpress.phpunit") {
+      return this.runPhpunit(spec)
+    }
+
     throw new Error(`No Playground command handler is registered for: ${spec.command}`)
   }
 
@@ -668,6 +672,14 @@ class PlaygroundRuntime implements Runtime {
     return response.text
   }
 
+  private async runPhpunit(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const code = await this.phpCodeFromArgs(spec.args ?? [], "wordpress.phpunit")
+    const response = await server.playground.run({ code })
+
+    return response.text
+  }
+
   private bootstrapAbilityPhpCode(code: string): string {
     return `<?php
 $_SERVER['REQUEST_URI'] = '/wp-json/wp-codebox/ability';
@@ -698,7 +710,7 @@ ${phpBody(code)}`
       .join("\n")}\n`
   }
 
-  private async phpCodeFromArgs(args: string[]): Promise<string> {
+  private async phpCodeFromArgs(args: string[], command = "wordpress.run-php"): Promise<string> {
     const inlineCode = argValue(args, "code")
     if (inlineCode) {
       return normalizePhpCode(inlineCode)
@@ -709,7 +721,7 @@ ${phpBody(code)}`
       return normalizePhpCode(await readFile(resolve(codeFile), "utf8"))
     }
 
-    throw new Error("wordpress.run-php requires code=<php> or code-file=<path>")
+    throw new Error(`${command} requires code=<php> or code-file=<path>`)
   }
 
   private async inspectMountedInputs(): Promise<string> {


### PR DESCRIPTION
## Summary
- Add `wordpress.phpunit` as a first-class WP Codebox runtime/recipe command.
- Allow recipes to validate `wordpress.phpunit` with the same `code` / `code-file` input contract used by PHP runner commands.
- Keep the command policy-aware so downstream runners can use a PHPUnit-specific recipe step instead of low-level `wordpress.run-php`.

## Verification
- `npm run check`
- `git diff --check`
- Downstream canary with Homeboy branch: `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/sandbox-runtime@recipe-entrypoint/packages/cli/dist/index.js homeboy test --path /Users/chubes/Developer/homeboy-extensions@recipe-bench-runner/wordpress/tests/fixtures/playground-schema-scope --extension wordpress -- --file tests/SchemaScopeRunsTest.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the runtime command seam, updating recipe validation/help, and running verification. Chris remains responsible for review and merge.