### PR TITLE
Preserve recipe mount metadata for sandbox repo mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,24 @@ npm run wp-codebox -- recipe-run \
 
 Recipes are JSON declarations for a sandbox setup plus workflow steps. They can mount existing directories, create disposable plugin/theme workspaces, activate extra plugins, allow-list selected secret environment variable names, and capture the output as artifacts.
 
+Mount entries may include opaque `metadata` that is preserved in runtime observations, artifact provenance, and captured mount files. Product-specific callers can use this to map sandbox paths back to source repositories without WP Codebox knowing about the caller's deployment environment:
+
+```json
+{
+  "source": "/srv/site/wp-content/plugins/example",
+  "target": "/wordpress/wp-content/plugins/example",
+  "mode": "readwrite",
+  "metadata": {
+    "kind": "component",
+    "slug": "example-plugin",
+    "repo": "org/example-plugin",
+    "default_branch": "main",
+    "repo_root_relative_to_mount": ".",
+    "editable": true
+  }
+}
+```
+
 Example recipes:
 
 - `examples/recipes/simple-plugin.json`: mount and probe the fixture plugin.
@@ -241,7 +259,7 @@ npm run wp-codebox -- agent-sandbox-run \
 Useful options:
 
 - `--provider-plugin <path>`: mount an AI provider plugin. Repeatable.
-- `--secret-env <NAME>`: expose a parent process environment variable by name. Repeatable. Values are read from the process environment and are not accepted in JSON payloads.
+- `--secret-env <NAME>`: expose a parent process environment variable by name, such as `--secret-env GITHUB_TOKEN`. Repeatable. Values are read from the process environment and are not accepted in JSON payloads.
 - `--mount <host:vfs[:mode]>`: mount extra task inputs.
 - `--session-id <id>`: continue an existing sandbox conversation session.
 - `--max-turns <n>`: bound the agent loop.

--- a/examples/recipes/simple-plugin.json
+++ b/examples/recipes/simple-plugin.json
@@ -10,7 +10,15 @@
       {
         "source": "../simple-plugin",
         "target": "/wordpress/wp-content/plugins/simple-plugin",
-        "mode": "readwrite"
+        "mode": "readwrite",
+        "metadata": {
+          "kind": "component",
+          "slug": "simple-plugin",
+          "repo": "example/simple-plugin",
+          "default_branch": "main",
+          "repo_root_relative_to_mount": ".",
+          "editable": true
+        }
       }
     ]
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -281,6 +281,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         source: resolve(recipeDirectory, mount.source),
         target: mount.target,
         mode: mount.mode ?? "readwrite",
+        metadata: mount.metadata,
       })
     }
 
@@ -996,6 +997,10 @@ function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe 
 
     if (mount.mode && mount.mode !== "readonly" && mount.mode !== "readwrite") {
       throw new Error(`Recipe mount mode must be readonly or readwrite: ${recipePath}`)
+    }
+
+    if (mount.metadata !== undefined && (!mount.metadata || typeof mount.metadata !== "object" || Array.isArray(mount.metadata))) {
+      throw new Error(`Recipe mount metadata must be an object when provided: ${recipePath}`)
     }
   }
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -81,6 +81,7 @@ export interface WorkspaceRecipeMount {
   source: string
   target: string
   mode?: "readonly" | "readwrite"
+  metadata?: Record<string, unknown>
 }
 
 export interface WorkspaceRecipeStep {

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -51,7 +51,16 @@ mounts and activates them without knowing provider-specific behavior. Provider
 credentials continue to resolve through the provider's normal scoped mechanism.
 Pass `secret_env` as a list of environment variable names to expose selected
 parent process credentials inside the sandbox; values are read from the process
-environment and are not accepted in the ability payload.
+environment and are not accepted in the ability payload. For example, pass
+`"secret_env": ["GITHUB_TOKEN"]` after the host process has `GITHUB_TOKEN` in
+its environment; do not pass token values through ability input.
+
+Product callers may pass `mounts` to add editable or readonly host directories
+to the generated recipe. Each mount may include opaque `metadata` such as
+`repo`, `default_branch`, `repo_root_relative_to_mount`, and `editable` so tools
+inside the sandbox can map changed sandbox paths back to source repositories.
+WP Codebox preserves the metadata but does not interpret product-specific repo
+topology.
 
 Returned artifact metadata includes the runtime manifest, replay blueprint,
 after-state notes, captured readwrite mount index, event streams, and logs. WP
@@ -82,7 +91,8 @@ approval surface.
 
 Component paths can be supplied by ability input, the
 `wp_codebox_component_paths` option, or the `wp_codebox_component_paths`
-filter.
+filter. On multisite, WP Codebox reads `wp_codebox_component_paths` from network
+options because component paths are host-level configuration.
 
 Expected component keys:
 
@@ -92,7 +102,13 @@ Expected component keys:
 - `provider_plugins` (optional list)
 
 The CLI binary can be supplied by ability input, the `wp_codebox_bin` option,
-or the `wp_codebox_bin` filter.
+or the `wp_codebox_bin` filter. On multisite, WP Codebox reads `wp_codebox_bin`
+from network options because the binary path is host-level configuration.
+
+The artifact root can be supplied per request with `artifacts_path`, by the
+`wp_codebox_artifacts_root` option, or by the `wp_codebox_artifacts_root`
+filter. On multisite, WP Codebox reads `wp_codebox_artifacts_root` from network
+options.
 
 ## Package Artifact
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -27,6 +27,7 @@ final class WP_Codebox_Abilities {
 	private function register(): void {
 		$register_callback = function (): void {
 			$task_input_schema  = self::task_input_schema();
+			$mount_schema      = self::mount_schema();
 			$artifact_id_schema = array(
 				'artifact_id'    => array(
 					'type'        => 'string',
@@ -82,9 +83,10 @@ final class WP_Codebox_Abilities {
 								'description' => 'AI provider plugin directories to mount and activate inside the sandbox.',
 								'items'       => array( 'type' => 'string' ),
 							),
+							'mounts'                 => $mount_schema,
 							'secret_env'             => array(
 								'type'        => 'array',
-								'description' => 'Parent environment variable names to expose inside the sandbox. Values are read from the parent process, not from this payload.',
+								'description' => 'Parent environment variable names to expose inside the sandbox. Pass names such as GITHUB_TOKEN; values are read from the parent process and are not accepted in this payload.',
 								'items'       => array( 'type' => 'string' ),
 							),
 							'session_id'             => array(
@@ -164,6 +166,7 @@ final class WP_Codebox_Abilities {
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
 							),
+							'mounts'                 => $mount_schema,
 							'secret_env'             => array(
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
@@ -335,6 +338,36 @@ final class WP_Codebox_Abilities {
 		}
 
 		add_action( 'wp_abilities_api_init', $register_callback );
+	}
+
+	/** @return array<string,mixed> */
+	private static function mount_schema(): array {
+		return array(
+			'type'        => 'array',
+			'description' => 'Additional host directories to mount into the sandbox. Callers may attach repo metadata for downstream tools that need to map sandbox paths back to source repositories.',
+			'items'       => array(
+				'type'       => 'object',
+				'required'   => array( 'source', 'target' ),
+				'properties' => array(
+					'source'   => array(
+						'type'        => 'string',
+						'description' => 'Host directory path to mount.',
+					),
+					'target'   => array(
+						'type'        => 'string',
+						'description' => 'Absolute sandbox path, such as /wordpress/wp-content/plugins/example.',
+					),
+					'mode'     => array(
+						'type' => 'string',
+						'enum' => array( 'readonly', 'readwrite' ),
+					),
+					'metadata' => array(
+						'type'        => 'object',
+						'description' => 'Opaque caller metadata, for example repo, default_branch, repo_root_relative_to_mount, and editable flags.',
+					),
+				),
+			),
+		);
 	}
 
 	/** @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -235,14 +235,12 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return $paths;
 	}
 
-	/** @return array<string,string> */
+	/** @return array<string,mixed> */
 	private function configured_paths(): array {
-		$paths = array();
-		if ( function_exists( 'get_option' ) ) {
-			$option = get_option( 'wp_codebox_component_paths', array() );
-			if ( is_array( $option ) ) {
-				$paths = $option;
-			}
+		$paths  = array();
+		$option = $this->config_option( 'wp_codebox_component_paths', array() );
+		if ( is_array( $option ) ) {
+			$paths = $option;
 		}
 
 		if ( function_exists( 'apply_filters' ) ) {
@@ -456,6 +454,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	private function default_artifacts_path(): string {
+		$configured = $this->clean_path( (string) $this->config_option( 'wp_codebox_artifacts_root', '' ) );
+		if ( '' !== $configured ) {
+			return $configured . DIRECTORY_SEPARATOR . $this->generate_run_id();
+		}
+
 		$base = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array( 'basedir' => sys_get_temp_dir() );
 		$root = is_array( $base ) && ! empty( $base['basedir'] ) ? (string) $base['basedir'] : sys_get_temp_dir();
 
@@ -463,10 +466,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	private function default_bin(): string {
-		$bin = 'wp-codebox';
-		if ( function_exists( 'get_option' ) ) {
-			$bin = (string) get_option( 'wp_codebox_bin', $bin );
-		}
+		$bin = (string) $this->config_option( 'wp_codebox_bin', 'wp-codebox' );
 
 		if ( function_exists( 'apply_filters' ) ) {
 			$bin = (string) apply_filters( 'wp_codebox_bin', $bin );
@@ -477,6 +477,63 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	private function clean_path( string $path ): string {
 		return rtrim( trim( $path ), DIRECTORY_SEPARATOR );
+	}
+
+	private function config_option( string $name, mixed $default ): mixed {
+		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
+			return get_site_option( $name, $default );
+		}
+
+		if ( function_exists( 'get_option' ) ) {
+			return get_option( $name, $default );
+		}
+
+		return $default;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
+	private function recipe_mounts( array $input ): array|WP_Error {
+		$mounts = is_array( $input['mounts'] ?? null ) ? $input['mounts'] : array();
+		$normalized = array();
+
+		foreach ( $mounts as $index => $mount ) {
+			if ( ! is_array( $mount ) ) {
+				return new WP_Error( 'wp_codebox_mount_invalid', 'Each WP Codebox mount must be an object.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			$source = $this->clean_path( (string) ( $mount['source'] ?? '' ) );
+			$target = trim( (string) ( $mount['target'] ?? '' ) );
+			if ( '' === $source || ! is_dir( $source ) ) {
+				return new WP_Error( 'wp_codebox_mount_source_invalid', 'WP Codebox mount source must be an existing directory.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			if ( '' === $target || ! str_starts_with( $target, '/' ) ) {
+				return new WP_Error( 'wp_codebox_mount_target_invalid', 'WP Codebox mount target must be an absolute sandbox path.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			$mode = (string) ( $mount['mode'] ?? 'readwrite' );
+			if ( 'readonly' !== $mode && 'readwrite' !== $mode ) {
+				return new WP_Error( 'wp_codebox_mount_mode_invalid', 'WP Codebox mount mode must be readonly or readwrite.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			$entry = array(
+				'source' => $source,
+				'target' => $target,
+				'mode'   => $mode,
+			);
+
+			if ( isset( $mount['metadata'] ) && ! is_array( $mount['metadata'] ) ) {
+				return new WP_Error( 'wp_codebox_mount_metadata_invalid', 'WP Codebox mount metadata must be an object.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			if ( isset( $mount['metadata'] ) ) {
+				$entry['metadata'] = $mount['metadata'];
+			}
+
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
 	}
 
 	private function command_prefix( string $bin ): string {
@@ -526,6 +583,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			);
 		}
 
+		$mounts = $this->recipe_mounts( $input );
+		if ( is_wp_error( $mounts ) ) {
+			return $mounts;
+		}
+
 		$recipe = array(
 			'schema'   => 'wp-codebox/workspace-recipe/v1',
 			'runtime'  => array(
@@ -533,6 +595,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'blueprint' => array( 'steps' => array() ),
 			),
 			'inputs'   => array(
+				'mounts'       => $mounts,
 				'extraPlugins' => array_merge(
 					array(
 						array( 'source' => $paths['agents_api'], 'slug' => 'agents-api', 'activate' => false ),

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -199,9 +199,12 @@ final class WP_Codebox_Artifacts {
 	private function artifact_root( array $input ): string|WP_Error {
 		$root = trim( (string) ( $input['artifacts_path'] ?? '' ) );
 		if ( '' === $root ) {
-			$base = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array( 'basedir' => sys_get_temp_dir() );
-			$root = is_array( $base ) && ! empty( $base['basedir'] ) ? (string) $base['basedir'] : sys_get_temp_dir();
-			$root = rtrim( $root, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . 'wp-codebox';
+			$root = trim( (string) $this->config_option( 'wp_codebox_artifacts_root', '' ) );
+			if ( '' === $root ) {
+				$base = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array( 'basedir' => sys_get_temp_dir() );
+				$root = is_array( $base ) && ! empty( $base['basedir'] ) ? (string) $base['basedir'] : sys_get_temp_dir();
+				$root = rtrim( $root, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . 'wp-codebox';
+			}
 		}
 
 		if ( function_exists( 'apply_filters' ) ) {
@@ -214,6 +217,18 @@ final class WP_Codebox_Artifacts {
 		}
 
 		return rtrim( $real, DIRECTORY_SEPARATOR );
+	}
+
+	private function config_option( string $name, mixed $default ): mixed {
+		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
+			return get_site_option( $name, $default );
+		}
+
+		if ( function_exists( 'get_option' ) ) {
+			return get_option( $name, $default );
+		}
+
+		return $default;
 	}
 
 	/** @return string[] */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -30,6 +30,8 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 
 $GLOBALS['wp_codebox_registered_abilities'] = array();
 $GLOBALS['wp_codebox_filters']              = array();
+$GLOBALS['wp_codebox_options']              = array();
+$GLOBALS['wp_codebox_site_options']         = array();
 
 function wp_register_ability( string $name, array $definition ): void {
 	$GLOBALS['wp_codebox_registered_abilities'][ $name ] = $definition;
@@ -51,7 +53,9 @@ function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 
 	return $filter;
 }
-function get_option( string $name, mixed $default = null ): mixed { return $default; }
+function is_multisite(): bool { return (bool) ( $GLOBALS['wp_codebox_is_multisite'] ?? false ); }
+function get_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_options'][ $name ] ?? $default; }
+function get_site_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_site_options'][ $name ] ?? $default; }
 
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
@@ -59,7 +63,7 @@ require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machi
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
 
 $root = sys_get_temp_dir() . '/wp-codebox-wordpress-plugin-' . getmypid();
-foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'ai-provider-test', 'artifacts' ) as $dir ) {
+foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'ai-provider-test', 'editable-plugin', 'artifacts', 'artifact-network-root' ) as $dir ) {
 	mkdir( $root . '/' . $dir, 0777, true );
 }
 file_put_contents( $root . '/wp-codebox.js', "#!/usr/bin/env node\n" );
@@ -90,6 +94,7 @@ $assert( 'ability exposes task target schema', isset( $ability['input_schema']['
 $assert( 'ability exposes allowed tools schema', 'array' === ( $ability['input_schema']['properties']['allowed_tools']['type'] ?? '' ) );
 $assert( 'ability exposes expected artifacts schema', 'array' === ( $ability['input_schema']['properties']['expected_artifacts']['type'] ?? '' ) );
 $assert( 'ability exposes policy and context schema', 'object' === ( $ability['input_schema']['properties']['policy']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['context']['type'] ?? '' ) );
+$assert( 'ability exposes generic mounts schema', 'array' === ( $ability['input_schema']['properties']['mounts']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['mounts']['items']['properties']['metadata']['type'] ?? '' ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
@@ -150,6 +155,22 @@ $result = $runner->run(
 	array(
 		'task'           => 'Run a chat-requested sandbox task.',
 		'artifacts_path' => $root . '/artifacts',
+		'secret_env'     => array( 'GITHUB_TOKEN' ),
+		'mounts'         => array(
+			array(
+				'source'   => $root . '/editable-plugin',
+				'target'   => '/wordpress/wp-content/plugins/editable-plugin',
+				'mode'     => 'readwrite',
+				'metadata' => array(
+					'kind'                        => 'component',
+					'slug'                        => 'editable-plugin',
+					'repo'                        => 'example/editable-plugin',
+					'default_branch'              => 'main',
+					'repo_root_relative_to_mount' => '.',
+					'editable'                    => true,
+				),
+			),
+		),
 	)
 );
 
@@ -165,7 +186,8 @@ $assert( 'runner recipe passes sandbox mode', str_contains( $captured_recipe, 's
 $assert( 'runner recipe passes default provider', str_contains( $captured_recipe, 'openai' ) );
 $assert( 'runner recipe passes default model', str_contains( $captured_recipe, 'gpt-5.5' ) );
 $assert( 'runner recipe passes provider plugin path', str_contains( $captured_recipe, 'ai-provider-test' ) );
-$assert( 'runner recipe passes secret env name only', str_contains( $captured_recipe, 'OPENAI_API_KEY' ) );
+$assert( 'runner recipe passes generic mount metadata', str_contains( $captured_recipe, 'example/editable-plugin' ) && str_contains( $captured_recipe, 'repo_root_relative_to_mount' ) );
+$assert( 'runner recipe passes secret env name only', str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
 $assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
 
 $raw_code = $runner->run(
@@ -185,6 +207,20 @@ $raw_code_file = $runner->run(
 	)
 );
 $assert( 'raw code file input fails closed', is_wp_error( $raw_code_file ) && 'wp_codebox_raw_code_forbidden' === $raw_code_file->get_error_code() );
+
+$invalid_mount = $runner->run(
+	array(
+		'task'           => 'Run a chat-requested sandbox task.',
+		'artifacts_path' => $root . '/artifacts',
+		'mounts'         => array(
+			array(
+				'source' => $root . '/missing-plugin',
+				'target' => '/wordpress/wp-content/plugins/missing-plugin',
+			),
+		),
+	)
+);
+$assert( 'invalid mount input fails closed', is_wp_error( $invalid_mount ) && 'wp_codebox_mount_source_invalid' === $invalid_mount->get_error_code() );
 
 $structured_result = $runner->run(
 	array(
@@ -224,6 +260,44 @@ $assert( 'batch runner recipe passes default provider', str_contains( $captured_
 $assert( 'batch runner recipe passes default model', str_contains( $captured_recipe, 'gpt-5.5' ) );
 $assert( 'batch runner recipe passes provider plugin path', str_contains( $captured_recipe, 'ai-provider-test' ) );
 $assert( 'batch runner recipe passes secret env name only', str_contains( $captured_recipe, 'OPENAI_API_KEY' ) );
+
+$pending_action_handlers_filter     = $GLOBALS['wp_codebox_filters']['datamachine_pending_action_handlers'] ?? null;
+$GLOBALS['wp_codebox_is_multisite'] = true;
+$GLOBALS['wp_codebox_filters']      = array_filter(
+	array( 'datamachine_pending_action_handlers' => $pending_action_handlers_filter ),
+	static fn( mixed $filter ): bool => null !== $filter
+);
+$GLOBALS['wp_codebox_site_options'] = array(
+	'wp_codebox_component_paths' => array(
+		'agents_api'        => $root . '/agents-api',
+		'data_machine'      => $root . '/data-machine',
+		'data_machine_code' => $root . '/data-machine-code',
+		'provider_plugins'  => array( $root . '/ai-provider-test' ),
+	),
+	'wp_codebox_bin'             => $root . '/wp-codebox.js',
+	'wp_codebox_artifacts_root'  => $root . '/artifact-network-root',
+);
+
+$network_result = $runner->run( array( 'task' => 'Use network-level WP Codebox configuration.' ) );
+$assert( 'multisite runner reads network-level options', ! is_wp_error( $network_result ) && str_starts_with( (string) ( $network_result['artifacts'] ?? '' ), $root . '/artifact-network-root' ) );
+
+$GLOBALS['wp_codebox_is_multisite'] = false;
+$GLOBALS['wp_codebox_filters']      = array_filter(
+	array(
+		'wp_codebox_component_paths'            => array(
+			'agents_api'        => $root . '/agents-api',
+			'data_machine'      => $root . '/data-machine',
+			'data_machine_code' => $root . '/data-machine-code',
+		),
+		'wp_codebox_bin'                        => $root . '/wp-codebox.js',
+		'wp_codebox_default_agent'              => 'site-coder',
+		'wp_codebox_default_provider'           => 'openai',
+		'wp_codebox_default_model'              => 'gpt-5.5',
+		'wp_codebox_default_secret_env'         => array( 'OPENAI_API_KEY' ),
+		'datamachine_pending_action_handlers'   => $pending_action_handlers_filter,
+	),
+	static fn( mixed $filter ): bool => null !== $filter
+);
 
 $missing_task = $runner->run( array( 'artifacts_path' => $root . '/artifacts' ) );
 $assert( 'missing task fails closed', is_wp_error( $missing_task ) && 'wp_codebox_task_missing' === $missing_task->get_error_code() );


### PR DESCRIPTION
## Summary
- Preserve recipe mount metadata from workspace recipes through runtime mounts and artifact observations.
- Add generic host ability `mounts` input so any WordPress environment can supply editable/readonly mounts with repo mapping metadata.
- Read WP Codebox binary, component paths, and artifact root from network options on multisite, while keeping filters and per-request overrides available.

## Notes
- This keeps WP Codebox deployment-neutral. Extra Chill, WordPress.com, or any other caller owns its own site inventory and repo map generation.
- `secret_env` continues to pass environment variable names only, e.g. `GITHUB_TOKEN`; token values are read from the host process environment and are not accepted in ability input.

Refs #79

## Tests
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic mount metadata plumbing, multisite configuration scope updates, docs, and smoke coverage; Chris reviewed requirements and clarified deployment-neutral scope.