### PR TITLE
Expose live Playground preview artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ Expected shape:
 
 WP Codebox boots Playground lazily on the first command, captures artifacts after execution, and disposes the runtime when the run completes.
 
+For interactive review, pass `--preview-hold <duration>` to keep the live Playground server available briefly after artifact capture. The command emits `artifacts.preview.url` and `files/review.json` includes a matching top-level `preview` object with lifecycle and expiry details.
+
+```bash
+npm run wp-codebox -- run \
+  --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin \
+  --command wordpress.run-php \
+  --arg code-file=./examples/simple-plugin/probe.php \
+  --artifacts ./artifacts \
+  --preview-hold 15m \
+  --json
+```
+
+The v1 preview is a held live Playground runtime. When `--preview-hold` is omitted, the preview field still records the URL observed during capture, but the runtime is destroyed on command completion and the URL is marked `expired-on-completion`. Artifact replay from `blueprint.after.json` remains partial and is a separate future preview mode.
+
 ## CLI Commands
 
 ### `run`
@@ -180,6 +194,7 @@ Run a repeatable recipe.
 ```bash
 npm run wp-codebox -- recipe-run \
   --recipe ./examples/recipes/simple-plugin.json \
+  --preview-hold 15m \
   --json
 ```
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
-import { createRuntime, type ArtifactBundle, type ExecutionResult, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { createRuntime, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
 import { captureStdout, printBatchHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
@@ -17,6 +17,7 @@ interface RunOptions {
   secretEnv?: Record<string, string>
   metadata?: Record<string, unknown>
   blueprint?: unknown
+  previewHoldSeconds?: number
   json: boolean
 }
 
@@ -36,6 +37,7 @@ interface RunOutput {
 interface RecipeRunOptions {
   recipePath: string
   artifactsDirectory?: string
+  previewHoldSeconds?: number
   json: boolean
 }
 
@@ -296,9 +298,8 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
 
     await runtime.observe({ type: "runtime-info" })
     await runtime.observe({ type: "mounts" })
-    artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true })
-    await runtime.destroy()
-    await cleanupRecipeWorkspaces(workspaceMounts)
+    artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
+    await releaseRuntime(runtime, options.previewHoldSeconds, () => cleanupRecipeWorkspaces(workspaceMounts))
 
     const benchResultsList = executions
       .filter((execution) => execution.command === "wordpress.bench" && execution.exitCode === 0)
@@ -806,8 +807,8 @@ async function run(options: RunOptions): Promise<RunOutput> {
     execution = await runtime.execute({ command: options.command, args: options.args })
     await runtime.observe({ type: "runtime-info" })
     await runtime.observe({ type: "mounts" })
-    artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true })
-    await runtime.destroy()
+    artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
+    await releaseRuntime(runtime, options.previewHoldSeconds)
 
     return {
       success: true,
@@ -838,6 +839,36 @@ async function run(options: RunOptions): Promise<RunOutput> {
       error: serializeError(error),
     }
   }
+}
+
+async function releaseRuntime(runtime: Runtime, previewHoldSeconds = 0, afterDestroy?: () => Promise<void>): Promise<void> {
+  const holdSeconds = Math.max(0, Math.floor(previewHoldSeconds))
+  if (holdSeconds === 0) {
+    await runtime.destroy()
+    await afterDestroy?.()
+    return
+  }
+
+  setTimeout(() => {
+    void runtime.destroy().finally(() => {
+      void afterDestroy?.()
+    })
+  }, holdSeconds * 1000)
+}
+
+function parsePreviewHoldSeconds(value: string): number {
+  const match = value.trim().match(/^(\d+)(s|m)?$/)
+  if (!match) {
+    throw new Error(`Invalid --preview-hold value: ${value}`)
+  }
+
+  const amount = Number.parseInt(match[1], 10)
+  const seconds = match[2] === "m" ? amount * 60 : amount
+  if (!Number.isFinite(seconds) || seconds < 0 || seconds > 3600) {
+    throw new Error("--preview-hold must be between 0s and 3600s")
+  }
+
+  return seconds
 }
 
 async function parseRunOptions(args: string[]): Promise<RunOptions> {
@@ -878,6 +909,9 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
         break
       case "--artifacts":
         options.artifactsDirectory = value
+        break
+      case "--preview-hold":
+        options.previewHoldSeconds = parsePreviewHoldSeconds(value)
         break
       case "--policy":
         options.policy = await parsePolicy(value)
@@ -922,6 +956,9 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
         break
       case "--artifacts":
         options.artifactsDirectory = value
+        break
+      case "--preview-hold":
+        options.previewHoldSeconds = parsePreviewHoldSeconds(value)
         break
       default:
         throw new Error(`Unknown option: ${name}`)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -81,6 +81,9 @@ export function printHumanOutput(output: RunOutputLike): void {
   console.log(`Runtime: ${output.runtime?.backend ?? "unknown"}`)
   console.log(`Executed: ${output.execution?.command ?? "unknown"}`)
   console.log(`Artifacts: ${output.artifacts?.directory ?? "none"}`)
+  if (output.artifacts?.preview?.url) {
+    console.log(`Preview: ${output.artifacts.preview.url} (${output.artifacts.preview.status})`)
+  }
 }
 
 export function printRecipeHumanOutput(output: RecipeRunOutputLike): void {
@@ -93,6 +96,9 @@ export function printRecipeHumanOutput(output: RecipeRunOutputLike): void {
   console.log(`Runtime: ${output.runtime?.backend ?? "unknown"}`)
   console.log(`Steps: ${output.executions.length}`)
   console.log(`Artifacts: ${output.artifacts?.directory ?? "none"}`)
+  if (output.artifacts?.preview?.url) {
+    console.log(`Preview: ${output.artifacts.preview.url} (${output.artifacts.preview.status})`)
+  }
 }
 
 export function printRecipeValidateHumanOutput(output: RecipeValidateOutputLike): void {
@@ -136,6 +142,7 @@ Options:
   --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.wp-cli, wordpress.ability, and wordpress.bench.
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --artifacts <dir>    Artifact root directory.
+  --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --json               Emit machine-readable JSON.
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -140,6 +140,7 @@ export interface RuntimeInfo {
   environment: EnvironmentSpec
   createdAt: string
   status: "created" | "destroyed"
+  previewUrl?: string
 }
 
 export interface MountSpec {
@@ -207,6 +208,7 @@ export interface ArtifactSpec {
   includePatch?: boolean
   includeScreenshots?: boolean
   includeObservations?: boolean
+  previewHoldSeconds?: number
 }
 
 export interface ArtifactManifestFile {
@@ -302,6 +304,7 @@ export interface ArtifactReview {
     total: number
   }
   changedFiles: ArtifactReviewChangedFile[]
+  preview?: ArtifactPreview
   progress: ArtifactReviewProgressEvent[]
   actions: ArtifactReviewAction[]
   evidence: {
@@ -313,6 +316,16 @@ export interface ArtifactReview {
   }
   redaction?: ArtifactRedactionSummary
   riskFlags: string[]
+}
+
+export interface ArtifactPreview {
+  url: string
+  status: "available" | "expired-on-completion"
+  lifecycle: "held-after-run" | "destroyed-on-completion"
+  source: "live-playground"
+  createdAt: string
+  expiresAt?: string
+  holdSeconds?: number
 }
 
 export interface ArtifactRedactionArtifactSummary {
@@ -378,6 +391,7 @@ export interface ArtifactBundle {
   patchPath: string
   testResultsPath: string
   reviewPath: string
+  preview?: ArtifactPreview
   contentDigest: string
   createdAt: string
 }

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -4,6 +4,7 @@ import { basename, join } from "node:path"
 import { normalizeBlueprint, preferredVersionsForEnvironment } from "./blueprint.js"
 import type {
   ArtifactManifestFile,
+  ArtifactPreview,
   ArtifactProvenance,
   ArtifactRedactionSummary,
   ArtifactReview,
@@ -189,6 +190,7 @@ export function buildArtifactReview({
   contentDigest,
   runtimeCreatedAt,
   mounts,
+  preview,
 }: {
   artifactId: string
   createdAt: string
@@ -198,6 +200,7 @@ export function buildArtifactReview({
   contentDigest: string
   runtimeCreatedAt: string
   mounts: MountSpec[]
+  preview?: ArtifactPreview
 }): ArtifactReview {
   const stats = {
     added: changedFiles.files.filter((file) => file.status === "added").length,
@@ -222,6 +225,7 @@ export function buildArtifactReview({
       mountTarget: file.mountTarget,
       relativePath: file.relativePath,
     })),
+    ...(preview ? { preview } : {}),
     progress: [
       {
         type: "boot",

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -29,6 +29,7 @@ import type {
   ArtifactBundle,
   ArtifactManifest,
   ArtifactManifestFile,
+  ArtifactPreview,
   ArtifactSpec,
   ExecutionResult,
   ExecutionSpec,
@@ -62,6 +63,7 @@ interface PlaygroundCliServer {
     run(options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse>
     writeFile?(path: string, contents: string): Promise<void>
   }
+  serverUrl: string
   [Symbol.asyncDispose](): Promise<void>
 }
 
@@ -112,12 +114,14 @@ class PlaygroundRuntime implements Runtime {
   }
 
   async info(): Promise<RuntimeInfo> {
+    const previewUrl = await this.currentPreviewUrl()
     return {
       id: this.runtimeId,
       backend: "wordpress-playground",
       environment: this.spec.environment,
       createdAt: this.createdAt,
       status: this.status,
+      ...(previewUrl ? { previewUrl } : {}),
     }
   }
 
@@ -227,6 +231,7 @@ class PlaygroundRuntime implements Runtime {
     const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
     const redactor = new ArtifactRedactor(this.spec.secretEnv)
+    const preview = await this.previewInfo(createdAt, spec.previewHoldSeconds)
 
     const runtime = await this.info()
     const capturedMounts = await this.captureMountedFiles(filesDirectory, redactor)
@@ -272,6 +277,7 @@ class PlaygroundRuntime implements Runtime {
       contentDigest,
       runtimeCreatedAt: this.createdAt,
       mounts: this.mounts,
+      preview,
     })
     const artifactFiles = {
       changedFiles: relative(this.artifactRoot, changedFilesPath),
@@ -330,6 +336,7 @@ class PlaygroundRuntime implements Runtime {
         path: relative(this.artifactRoot, file.path),
       })),
     }
+    metadata.preview = preview
 
     await writeRedactedArtifact(redactor, manifestPath, this.artifactRoot, `${JSON.stringify(manifest, null, 2)}\n`)
     await writeRedactedArtifact(redactor, blueprintAfterPath, this.artifactRoot, `${JSON.stringify(blueprintAfter, null, 2)}\n`)
@@ -373,6 +380,7 @@ class PlaygroundRuntime implements Runtime {
       patchPath,
       testResultsPath,
       reviewPath,
+      ...(preview ? { preview } : {}),
       contentDigest,
       createdAt,
     }
@@ -547,6 +555,34 @@ class PlaygroundRuntime implements Runtime {
     await cliServer?.[Symbol.asyncDispose]()
     this.status = "destroyed"
     this.recordEvent("runtime.destroyed", { runtimeId: this.runtimeId })
+  }
+
+  private async currentPreviewUrl(): Promise<string | undefined> {
+    if (this.status === "destroyed") {
+      return undefined
+    }
+
+    if (!this.cliServerPromise) {
+      return undefined
+    }
+
+    const server = await this.cliServerPromise
+    return server.serverUrl
+  }
+
+  private async previewInfo(createdAt: string, holdSeconds = 0): Promise<ArtifactPreview> {
+    const server = await this.bootPlayground()
+    const normalizedHoldSeconds = Math.max(0, Math.floor(holdSeconds))
+    const expiresAt = normalizedHoldSeconds > 0 ? new Date(Date.now() + normalizedHoldSeconds * 1000).toISOString() : undefined
+
+    return {
+      url: server.serverUrl,
+      status: normalizedHoldSeconds > 0 ? "available" : "expired-on-completion",
+      lifecycle: normalizedHoldSeconds > 0 ? "held-after-run" : "destroyed-on-completion",
+      source: "live-playground",
+      createdAt,
+      ...(expiresAt ? { expiresAt, holdSeconds: normalizedHoldSeconds } : {}),
+    }
   }
 
   private recordEvent(type: LifecycleEvent["type"], data?: Record<string, unknown>): LifecycleEvent {

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -62,6 +62,13 @@ inside the sandbox can map changed sandbox paths back to source repositories.
 WP Codebox preserves the metadata but does not interpret product-specific repo
 topology.
 
+For browser review, callers may pass `preview_hold_seconds` to keep the live
+Playground runtime available after artifact capture. The ability response's
+`run.artifacts.preview.url` and the artifact's `files/review.json` `preview`
+field point at the same live URL until the hold window expires. Without a hold
+window, the preview field is still recorded as evidence but marked
+`expired-on-completion` because the sandbox is destroyed when the command exits.
+
 Returned artifact metadata includes the runtime manifest, replay blueprint,
 after-state notes, captured readwrite mount index, event streams, and logs. WP
 Codebox owns this capture boundary so the parent site can discard the disposable

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -97,6 +97,10 @@ final class WP_Codebox_Abilities {
 								'type'        => 'integer',
 								'description' => 'Maximum agent loop turns for this sandbox task.',
 							),
+							'preview_hold_seconds'   => array(
+								'type'        => 'integer',
+								'description' => 'Seconds to keep the live Playground preview URL available after capture. Max 3600.',
+							),
 							'wp'                     => array(
 								'type'        => 'string',
 								'description' => 'WordPress version passed to Playground. Defaults to trunk.',
@@ -172,6 +176,7 @@ final class WP_Codebox_Abilities {
 								'items' => array( 'type' => 'string' ),
 							),
 							'max_turns'              => array( 'type' => 'integer' ),
+							'preview_hold_seconds'   => array( 'type' => 'integer' ),
 							'wp'                     => array( 'type' => 'string' ),
 							'artifacts_path'         => array( 'type' => 'string' ),
 							'wp_codebox_bin'    => array( 'type' => 'string' ),

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -73,6 +73,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			escapeshellarg( $recipe_file ),
 			escapeshellarg( $artifacts )
 		);
+		$command .= $this->preview_hold_arg( $input );
 
 		$result    = $this->run_command( $command );
 		@unlink( $recipe_file );
@@ -168,6 +169,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			escapeshellarg( $recipe_file ),
 			escapeshellarg( $artifacts )
 		);
+		$command .= $this->preview_hold_arg( $input );
 
 		$result    = $this->run_command( $command );
 		@unlink( $recipe_file );
@@ -477,6 +479,18 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	private function clean_path( string $path ): string {
 		return rtrim( trim( $path ), DIRECTORY_SEPARATOR );
+	}
+
+	private function preview_hold_seconds( array $input ): int {
+		$seconds = (int) ( $input['preview_hold_seconds'] ?? $input['preview_hold'] ?? 0 );
+
+		return max( 0, min( 3600, $seconds ) );
+	}
+
+	private function preview_hold_arg( array $input ): string {
+		$seconds = $this->preview_hold_seconds( $input );
+
+		return $seconds > 0 ? ' --preview-hold ' . escapeshellarg( (string) $seconds ) : '';
 	}
 
 	private function config_option( string $name, mixed $default ): mixed {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -21,6 +21,8 @@ try {
       "./examples/recipes/seeded-plugin-workspace.json",
       "--artifacts",
       artifactsDirectory,
+      "--preview-hold",
+      "1s",
       "--json",
     ],
     {
@@ -30,12 +32,18 @@ try {
   )
   const output = JSON.parse(stdout)
   assert.equal(output.success, true)
+  assert.equal(output.runtime.status, "created")
+  assert.match(output.runtime.previewUrl, /^http:\/\/127\.0\.0\.1:/)
 
   const artifacts = output.artifacts
   assert.ok(artifacts.changedFilesPath, "artifact bundle should expose changedFilesPath")
   assert.ok(artifacts.patchPath, "artifact bundle should expose patchPath")
   assert.ok(artifacts.testResultsPath, "artifact bundle should expose testResultsPath")
   assert.ok(artifacts.reviewPath, "artifact bundle should expose reviewPath")
+  assert.equal(artifacts.preview.status, "available")
+  assert.equal(artifacts.preview.lifecycle, "held-after-run")
+  assert.equal(artifacts.preview.holdSeconds, 1)
+  assert.match(artifacts.preview.url, /^http:\/\/127\.0\.0\.1:/)
 
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8"))
@@ -61,6 +69,7 @@ try {
     value: contentDigest,
   })
   assert.deepEqual(metadata.contentDigest, manifest.contentDigest)
+  assert.deepEqual(metadata.preview, artifacts.preview)
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/changed-files.json" && file.kind === "changed-files"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/patch.diff" && file.kind === "patch"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/test-results.json" && file.kind === "test-results"))
@@ -96,6 +105,7 @@ try {
   assert.ok(testResults.rawLogReferences.some((log: { path: string }) => log.path === "logs/commands.log"))
   assert.equal(review.schema, "wp-codebox/artifact-review/v1")
   assert.equal(review.artifactId, artifacts.id)
+  assert.deepEqual(review.preview, artifacts.preview)
   assert.equal(review.provenance.task.kind, "recipe-run")
   assert.equal(review.provenance.runtime.wordpressVersion, "latest")
   assert.equal(review.evidence.patch, "files/patch.diff")
@@ -142,6 +152,9 @@ try {
   const agentArtifacts = await runtime.collectArtifacts({ includeLogs: true })
   const agentMetadata = JSON.parse(await readFile(agentArtifacts.metadataPath, "utf8"))
   const agentReview = JSON.parse(await readFile(agentArtifacts.reviewPath, "utf8"))
+  assert.equal(agentArtifacts.preview?.status, "expired-on-completion")
+  assert.equal(agentReview.preview.status, "expired-on-completion")
+  assert.equal(agentReview.preview.lifecycle, "destroyed-on-completion")
   assert.equal(agentMetadata.provenance.task.input, "Cook provenance smoke")
   assert.deepEqual(agentMetadata.provenance.agent, { agent: "sandbox-agent", provider: "openai", model: "gpt-5.5" })
   assert.equal(agentReview.provenance.agent.model, "gpt-5.5")

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -156,6 +156,7 @@ $result = $runner->run(
 		'task'           => 'Run a chat-requested sandbox task.',
 		'artifacts_path' => $root . '/artifacts',
 		'secret_env'     => array( 'GITHUB_TOKEN' ),
+		'preview_hold_seconds' => 30,
 		'mounts'         => array(
 			array(
 				'source'   => $root . '/editable-plugin',
@@ -179,6 +180,7 @@ $assert( 'runner schema is stable', ! is_wp_error( $result ) && 'wp-codebox/agen
 $assert( 'runner returns normalized task input for legacy task', ! is_wp_error( $result ) && 'wp-codebox/task-input/v1' === ( $result['task_input']['schema'] ?? '' ) && 'Run a chat-requested sandbox task.' === ( $result['task_input']['goal'] ?? '' ) );
 $assert( 'runner invokes recipe-run', str_contains( $captured_command, 'recipe-run' ) );
 $assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node ' ) );
+$assert( 'runner passes preview hold to CLI', str_contains( $captured_command, '--preview-hold' ) && str_contains( $captured_command, "'30'" ) );
 $assert( 'runner recipe uses agent step', str_contains( $captured_recipe, 'wp-codebox.agent-sandbox-run' ) );
 $assert( 'runner recipe passes task', str_contains( $captured_recipe, 'Run a chat-requested sandbox task.' ) );
 $assert( 'runner recipe passes default agent', str_contains( $captured_recipe, 'site-coder' ) );


### PR DESCRIPTION
## Summary
- Add a first-class live Playground preview object to artifact bundles, metadata, and `files/review.json`.
- Add `--preview-hold <duration>` for CLI runs and recipe runs so callers can keep the live preview URL available briefly after artifact capture.
- Allow the WordPress ability surface to request the same hold window with `preview_hold_seconds`.

## Notes
- This intentionally ships Option A from #80 as the v1: a held live Playground runtime with explicit expiry metadata.
- Artifact replay from `blueprint.after.json` remains a future mode because replay capture is still partial for DB/options/uploads/active plugin-theme state.

Refs #80

## Tests
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented preview artifact plumbing, hold-window CLI/ability options, docs, and smoke coverage; Chris directed the issue sequence and reviewed product intent.