### PR TITLE
Surface Playground crash diagnostics

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -182,6 +182,7 @@ async function main(args: string[]): Promise<number> {
     const { result, logs } = await captureStdout(execute)
     const output = logs.length > 0 ? { ...result, logs } : result
     process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    printJsonFailureDiagnostic(output)
     return output.success ? 0 : 1
   }
 
@@ -222,7 +223,26 @@ async function main(args: string[]): Promise<number> {
   const { result, logs } = await captureStdout(execute)
   const output = logs.length > 0 ? { ...result, logs } : result
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  printJsonFailureDiagnostic(output)
   return output.success ? 0 : 1
+}
+
+function printJsonFailureDiagnostic(output: { success: boolean; error?: { message?: string }; logs?: string[] }): void {
+  if (output.success) {
+    return
+  }
+
+  const message = output.error?.message?.trim()
+  if (message) {
+    console.error(message)
+  }
+
+  for (const log of output.logs ?? []) {
+    const trimmed = log.trim()
+    if (trimmed) {
+      console.error(trimmed)
+    }
+  }
 }
 
 async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -58,6 +58,50 @@ interface PlaygroundRunResponse {
   text: string
 }
 
+class PlaygroundCommandError extends Error {
+  readonly code = "wp-codebox-playground-command-failed"
+
+  constructor(readonly command: string, readonly response: PlaygroundRunResponse) {
+    super(playgroundFailureMessage(command, response))
+    this.name = "PlaygroundCommandError"
+  }
+}
+
+class PlaygroundCommandCrashError extends Error {
+  readonly code = "wp-codebox-playground-command-crashed"
+
+  constructor(readonly command: string, readonly cause: unknown) {
+    super(`${command} crashed before producing a structured response\n\n${errorMessage(cause)}`)
+    this.name = "PlaygroundCommandCrashError"
+  }
+}
+
+function assertPlaygroundResponseOk(command: string, response: PlaygroundRunResponse): void {
+  if (typeof response.exitCode === "number" && response.exitCode !== 0) {
+    throw new PlaygroundCommandError(command, response)
+  }
+}
+
+function playgroundFailureMessage(command: string, response: PlaygroundRunResponse): string {
+  const lines = [`${command} failed with exit code ${response.exitCode ?? "unknown"}`]
+  const errors = response.errors?.trim()
+  const text = response.text?.trim()
+
+  if (errors) {
+    lines.push("", "--- Playground errors ---", errors)
+  }
+
+  if (text) {
+    lines.push("", "--- Playground output ---", text)
+  }
+
+  return lines.join("\n")
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 interface PlaygroundCliServer {
   playground: {
     run(options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse>
@@ -644,7 +688,8 @@ class PlaygroundRuntime implements Runtime {
   private async runPhp(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
     const code = await this.phpCodeFromArgs(spec.args ?? [])
-    const response = await server.playground.run({ code: this.bootstrapPhpCode(code, spec.args ?? []) })
+    const response = await this.runPlaygroundCommand("wordpress.run-php", server, { code: this.bootstrapPhpCode(code, spec.args ?? []) })
+    assertPlaygroundResponseOk("wordpress.run-php", response)
 
     return response.text
   }
@@ -667,10 +712,8 @@ class PlaygroundRuntime implements Runtime {
 
     const scriptPath = `/tmp/wp-codebox-wp-cli-${this.commands.length}.php`
     await server.playground.writeFile(scriptPath, wpCliPhpScript(argv))
-    const response = await server.playground.run({ scriptPath })
-    if (typeof response.exitCode === "number" && response.exitCode !== 0) {
-      throw new Error(response.errors || `wordpress.wp-cli failed with exit code ${response.exitCode}`)
-    }
+    const response = await this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
+    assertPlaygroundResponseOk("wordpress.wp-cli", response)
 
     return cleanWpCliOutput(response.text)
   }
@@ -683,7 +726,8 @@ class PlaygroundRuntime implements Runtime {
     }
 
     const input = abilityInputFromArgs(spec.args ?? [])
-    const response = await server.playground.run({ code: this.bootstrapAbilityPhpCode(abilityPhpCode(name, input)) })
+    const response = await this.runPlaygroundCommand("wordpress.ability", server, { code: this.bootstrapAbilityPhpCode(abilityPhpCode(name, input)) })
+    assertPlaygroundResponseOk("wordpress.ability", response)
     return response.text
   }
 
@@ -701,9 +745,10 @@ class PlaygroundRuntime implements Runtime {
     const dependencySlugs = commaListArg(args, "dependency-slugs")
     const env = jsonObjectArg(args, "env-json")
     const workloads = jsonArrayArg(args, "workloads-json")
-    const response = await server.playground.run({
+    const response = await this.runPlaygroundCommand("wordpress.bench", server, {
       code: this.bootstrapPhpCode(benchRunCode({ componentId, pluginSlug, iterations, warmupIterations, dependencySlugs, env, workloads }), []),
     })
+    assertPlaygroundResponseOk("wordpress.bench", response)
 
     return response.text
   }
@@ -725,9 +770,18 @@ class PlaygroundRuntime implements Runtime {
     if (!explicitCode && !argValue(args, "plugin-slug")?.trim()) {
       throw new Error("wordpress.phpunit requires plugin-slug=<slug> when code/code-file is not provided")
     }
-    const response = await server.playground.run({ code })
+    const response = await this.runPlaygroundCommand("wordpress.phpunit", server, { code })
+    assertPlaygroundResponseOk("wordpress.phpunit", response)
 
     return response.text
+  }
+
+  private async runPlaygroundCommand(command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse> {
+    try {
+      return await server.playground.run(options)
+    } catch (error) {
+      throw new PlaygroundCommandCrashError(command, error)
+    }
   }
 
   private bootstrapAbilityPhpCode(code: string): string {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -122,6 +122,36 @@ try {
   const agentMount = join(artifactsDirectory, "agent-mounted-component")
   await mkdir(agentMount, { recursive: true })
   await writeFile(join(agentMount, "component.php"), "<?php // fixture\n")
+
+  await assert.rejects(
+    () => execFileAsync(
+      process.execPath,
+      [
+        "packages/cli/dist/index.js",
+        "run",
+        "--mount",
+        `${agentMount}:/wordpress/wp-content/plugins/provenance-smoke`,
+        "--command",
+        "wordpress.phpunit",
+        "--arg",
+        "code=throw new Error('wp-codebox-canary-cli-fatal');",
+        "--artifacts",
+        artifactsDirectory,
+        "--json",
+      ],
+      {
+        cwd: resolve(import.meta.dirname, ".."),
+        maxBuffer: 1024 * 1024 * 10,
+      },
+    ),
+    (error) => {
+      const childError = error as { stdout?: string; stderr?: string }
+      assert.match(childError.stdout ?? "", /wp-codebox-canary-cli-fatal/)
+      assert.match(childError.stderr ?? "", /wp-codebox-canary-cli-fatal/)
+      return true
+    },
+  )
+
   const runtime = await createRuntime(
     {
       backend: "wordpress-playground",
@@ -129,7 +159,7 @@ try {
       policy: {
         network: "deny",
         filesystem: "readwrite-mounts",
-        commands: ["wordpress.run-php"],
+        commands: ["wordpress.run-php", "wordpress.phpunit"],
         secrets: "none",
         approvals: "never",
       },
@@ -161,6 +191,20 @@ try {
   assert.ok(agentReview.provenance.mounts.some((mount: { target: string; metadata?: { slug?: string } }) =>
     mount.target === "/wordpress/wp-content/plugins/provenance-smoke" && mount.metadata?.slug === "provenance-smoke",
   ))
+
+  await assert.rejects(
+    () => runtime.execute({
+      command: "wordpress.phpunit",
+      args: ["code=throw new Error('wp-codebox-canary-bootstrap-fatal');"],
+    }),
+    (error) => {
+      assert.ok(error instanceof Error)
+      assert.match(error.message, /wordpress\.phpunit (failed with exit code|crashed before producing a structured response)/)
+      assert.match(error.message, /wp-codebox-canary-bootstrap-fatal/)
+      assert.match(error.message, /Playground output|Playground errors|=== Stdout ===|=== Stderr ===/)
+      return true
+    },
+  )
   await runtime.destroy()
 
   const secretName = "WP_CODEBOX_SMOKE_SECRET"


### PR DESCRIPTION
## Summary
- Preserve Playground command `errors` and `text` when WordPress commands return non-zero responses.
- Wrap hard Playground command crashes with the command name and original stdout/stderr-bearing error message.
- Print JSON-mode failure diagnostics to stderr so parent wrappers and CI logs have a useful tail even when they do not parse stdout.

## Tests
- `npm run check`
- Added canaries proving `wp-codebox-canary-cli-fatal` reaches CLI stderr and `wp-codebox-canary-bootstrap-fatal` reaches runtime error messages.

Refs #84

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented failure-path diagnostics and smoke coverage for surfaced Playground/PHP fatal output; Chris identified the real-world opaque failure from CI usage.