### PR TITLE
Add inheritance transport for sandbox runs

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1284,6 +1284,8 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: recipeExtraPlugins(recipe),
         secretEnv: recipe.inputs?.secretEnv ?? [],
+        inherit: recipe.inputs?.inherit ?? {},
+        inheritance: recipe.inputs?.inheritance ?? {},
       },
     },
     task: {
@@ -1297,6 +1299,8 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: recipeExtraPlugins(recipe),
         secretEnv: recipe.inputs?.secretEnv ?? [],
+        inherit: recipe.inputs?.inherit ?? {},
+        inheritance: recipe.inputs?.inheritance ?? {},
       },
     },
     preparedWorkspaces: workspaceMounts.map((workspace) => ({

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -125,6 +125,8 @@ export interface WorkspaceRecipe {
     extra_plugins?: WorkspaceRecipeExtraPlugin[]
     extraPlugins?: WorkspaceRecipeExtraPlugin[]
     secretEnv?: string[]
+    inherit?: WorkspaceRecipeInheritanceRequest
+    inheritance?: WorkspaceRecipeInheritanceResolution
   }
   workflow: {
     steps: WorkspaceRecipeStep[]
@@ -132,6 +134,30 @@ export interface WorkspaceRecipe {
   artifacts?: {
     directory?: string
   }
+}
+
+export interface WorkspaceRecipeInheritanceRequest {
+  connectors?: string[]
+  settings?: string[]
+}
+
+export interface WorkspaceRecipeInheritanceConnector {
+  name: string
+  status: "resolved" | "unresolved" | "skipped" | (string & {})
+  provider?: string
+  model?: string
+  secretEnv?: string[]
+}
+
+export interface WorkspaceRecipeInheritanceSetting {
+  name: string
+  status: "resolved" | "unresolved" | "skipped" | (string & {})
+  scope?: string
+}
+
+export interface WorkspaceRecipeInheritanceResolution {
+  connectors?: WorkspaceRecipeInheritanceConnector[]
+  settings?: WorkspaceRecipeInheritanceSetting[]
 }
 
 export interface RuntimeInfo {

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -55,6 +55,26 @@ environment and are not accepted in the ability payload. For example, pass
 `"secret_env": ["GITHUB_TOKEN"]` after the host process has `GITHUB_TOKEN` in
 its environment; do not pass token values through ability input.
 
+Callers may also pass an `inherit` declaration to request parent-environment
+connectors or settings by name:
+
+```json
+{
+  "inherit": {
+    "connectors": ["primary-ai"],
+    "settings": ["mode_models"]
+  }
+}
+```
+
+The parent site resolves that declaration through the
+`wp_codebox_resolve_inheritance` filter. The resolver may return connector
+status, `provider`, `model`, and `secret_env` names. WP Codebox records the
+requested names and sanitized resolution status in the generated recipe/artifact
+metadata and merges inherited `secret_env` names into the sandbox secret-env
+allowlist. Secret values and setting values are not serialized into recipe JSON,
+artifact metadata, logs, or patches by this transport slice.
+
 Product callers may pass `mounts` to add editable or readonly host directories
 to the generated recipe. Each mount may include opaque `metadata` such as
 `repo`, `default_branch`, `repo_root_relative_to_mount`, and `editable` so tools

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -28,6 +28,7 @@ final class WP_Codebox_Abilities {
 		$register_callback = function (): void {
 			$task_input_schema  = self::task_input_schema();
 			$mount_schema      = self::mount_schema();
+			$inherit_schema    = self::inherit_schema();
 			$artifact_id_schema = array(
 				'artifact_id'    => array(
 					'type'        => 'string',
@@ -84,6 +85,7 @@ final class WP_Codebox_Abilities {
 								'items'       => array( 'type' => 'string' ),
 							),
 							'mounts'                 => $mount_schema,
+							'inherit'                => $inherit_schema,
 							'secret_env'             => array(
 								'type'        => 'array',
 								'description' => 'Parent environment variable names to expose inside the sandbox. Pass names such as GITHUB_TOKEN; values are read from the parent process and are not accepted in this payload.',
@@ -171,6 +173,7 @@ final class WP_Codebox_Abilities {
 								'items' => array( 'type' => 'string' ),
 							),
 							'mounts'                 => $mount_schema,
+							'inherit'                => $inherit_schema,
 							'secret_env'             => array(
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
@@ -370,6 +373,26 @@ final class WP_Codebox_Abilities {
 						'type'        => 'object',
 						'description' => 'Opaque caller metadata, for example repo, default_branch, repo_root_relative_to_mount, and editable flags.',
 					),
+				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function inherit_schema(): array {
+		return array(
+			'type'        => 'object',
+			'description' => 'Declarative request for parent-environment connector or setting inheritance. Parent filters resolve names into a sanitized sandbox payload; secret values are never accepted here.',
+			'properties'  => array(
+				'connectors' => array(
+					'type'        => 'array',
+					'description' => 'Connector names the parent environment should resolve for this sandbox run.',
+					'items'       => array( 'type' => 'string' ),
+				),
+				'settings'   => array(
+					'type'        => 'array',
+					'description' => 'Setting names the parent environment should resolve for artifact/audit metadata. Values are not transported in this slice.',
+					'items'       => array( 'type' => 'string' ),
 				),
 			),
 		);

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -304,10 +304,15 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return '' !== $mode ? $mode : 'sandbox';
 	}
 
-	private function provider( array $input ): string {
+	private function provider( array $input, ?array $inheritance = null ): string {
 		$provider = trim( (string) ( $input['provider'] ?? '' ) );
 		if ( '' !== $provider ) {
 			return $provider;
+		}
+
+		$inheritance_provider = $this->inheritance_provider( $input, $inheritance );
+		if ( '' !== $inheritance_provider ) {
+			return $inheritance_provider;
 		}
 
 		if ( function_exists( 'apply_filters' ) ) {
@@ -317,10 +322,15 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return trim( $provider );
 	}
 
-	private function model( array $input ): string {
+	private function model( array $input, ?array $inheritance = null ): string {
 		$model = trim( (string) ( $input['model'] ?? '' ) );
 		if ( '' !== $model ) {
 			return $model;
+		}
+
+		$inheritance_model = $this->inheritance_model( $input, $inheritance );
+		if ( '' !== $inheritance_model ) {
+			return $inheritance_model;
 		}
 
 		if ( function_exists( 'apply_filters' ) ) {
@@ -351,8 +361,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */
-	private function secret_env_names( array $input ): array {
+	private function secret_env_names( array $input, ?array $inheritance = null ): array {
 		$names = is_array( $input['secret_env'] ?? null ) ? $input['secret_env'] : array();
+		$names = array_merge( $names, $this->inheritance_secret_env_names( $input, $inheritance ) );
 		if ( empty( $names ) && function_exists( 'apply_filters' ) ) {
 			$names = apply_filters( 'wp_codebox_default_secret_env', array() );
 		}
@@ -372,6 +383,151 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				)
 			)
 		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array{connectors:string[],settings:string[]} */
+	private function inheritance_request( array $input ): array {
+		$inherit = is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array();
+
+		return array(
+			'connectors' => $this->string_list( $inherit['connectors'] ?? array() ),
+			'settings'   => $this->string_list( $inherit['settings'] ?? array() ),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} */
+	private function inheritance_resolution( array $input ): array {
+		$request    = $this->inheritance_request( $input );
+		$resolution = array(
+			'connectors' => array_map(
+				static fn( string $name ): array => array(
+					'name'   => $name,
+					'status' => 'unresolved',
+				),
+				$request['connectors']
+			),
+			'settings'   => array_map(
+				static fn( string $name ): array => array(
+					'name'   => $name,
+					'status' => 'unresolved',
+				),
+				$request['settings']
+			),
+		);
+
+		if ( function_exists( 'apply_filters' ) && ( ! empty( $request['connectors'] ) || ! empty( $request['settings'] ) ) ) {
+			$filtered = apply_filters( 'wp_codebox_resolve_inheritance', $resolution, $request, $input );
+			if ( is_array( $filtered ) ) {
+				$resolution = $filtered;
+			}
+		}
+
+		return array(
+			'connectors' => $this->sanitize_inheritance_connectors( $resolution['connectors'] ?? array() ),
+			'settings'   => $this->sanitize_inheritance_settings( $resolution['settings'] ?? array() ),
+		);
+	}
+
+	/** @param array<int,mixed> $connectors Inheritance connector rows. @return array<int,array<string,mixed>> */
+	private function sanitize_inheritance_connectors( array $connectors ): array {
+		$sanitized = array();
+		foreach ( $connectors as $connector ) {
+			if ( ! is_array( $connector ) ) {
+				continue;
+			}
+
+			$name = trim( (string) ( $connector['name'] ?? '' ) );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$entry = array(
+				'name'   => $name,
+				'status' => trim( (string) ( $connector['status'] ?? 'resolved' ) ),
+			);
+
+			foreach ( array( 'provider', 'model' ) as $field ) {
+				$value = trim( (string) ( $connector[ $field ] ?? '' ) );
+				if ( '' !== $value ) {
+					$entry[ $field ] = $value;
+				}
+			}
+
+			$secret_env = $this->string_list( $connector['secret_env'] ?? $connector['secretEnv'] ?? array() );
+			$secret_env = array_values( array_filter( $secret_env, static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) );
+			if ( ! empty( $secret_env ) ) {
+				$entry['secretEnv'] = array_values( array_unique( $secret_env ) );
+			}
+
+			$sanitized[] = $entry;
+		}
+
+		return $sanitized;
+	}
+
+	/** @param array<int,mixed> $settings Inheritance setting rows. @return array<int,array<string,mixed>> */
+	private function sanitize_inheritance_settings( array $settings ): array {
+		$sanitized = array();
+		foreach ( $settings as $setting ) {
+			if ( ! is_array( $setting ) ) {
+				continue;
+			}
+
+			$name = trim( (string) ( $setting['name'] ?? '' ) );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$entry = array(
+				'name'   => $name,
+				'status' => trim( (string) ( $setting['status'] ?? 'resolved' ) ),
+			);
+
+			$scope = trim( (string) ( $setting['scope'] ?? '' ) );
+			if ( '' !== $scope ) {
+				$entry['scope'] = $scope;
+			}
+
+			$sanitized[] = $entry;
+		}
+
+		return $sanitized;
+	}
+
+	/** @param array<string,mixed> $input Ability input. */
+	private function inheritance_provider( array $input, ?array $inheritance = null ): string {
+		foreach ( ( $inheritance ?? $this->inheritance_resolution( $input ) )['connectors'] as $connector ) {
+			$provider = trim( (string) ( $connector['provider'] ?? '' ) );
+			if ( '' !== $provider ) {
+				return $provider;
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $input Ability input. */
+	private function inheritance_model( array $input, ?array $inheritance = null ): string {
+		foreach ( ( $inheritance ?? $this->inheritance_resolution( $input ) )['connectors'] as $connector ) {
+			$model = trim( (string) ( $connector['model'] ?? '' ) );
+			if ( '' !== $model ) {
+				return $model;
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return string[] */
+	private function inheritance_secret_env_names( array $input, ?array $inheritance = null ): array {
+		$names = array();
+		foreach ( ( $inheritance ?? $this->inheritance_resolution( $input ) )['connectors'] as $connector ) {
+			if ( is_array( $connector['secretEnv'] ?? null ) ) {
+				$names = array_merge( $names, $connector['secretEnv'] );
+			}
+		}
+
+		return $names;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */
@@ -564,6 +720,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	 * @param string[] $task_prompts Encoded task prompts.
 	 */
 	private function write_agent_recipe( array $paths, array $input, array $task_prompts, string $wp_version ): string|WP_Error {
+		$inheritance = $this->inheritance_resolution( $input );
 		$provider_plugins = array_map(
 			fn( string $path ): array => array(
 				'source'   => $path,
@@ -580,8 +737,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'task=' . $task_prompt,
 				'agent=' . $this->agent_slug( $input ),
 				'mode=' . $this->mode( $input ),
-				'provider=' . $this->provider( $input ),
-				'model=' . $this->model( $input ),
+				'provider=' . $this->provider( $input, $inheritance ),
+				'model=' . $this->model( $input, $inheritance ),
 				'provider-plugin-slugs=' . implode( ',', $provider_slugs ),
 			);
 			if ( ! empty( $input['session_id'] ) ) {
@@ -610,6 +767,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			),
 			'inputs'   => array(
 				'mounts'       => $mounts,
+				'inherit'      => $this->inheritance_request( $input ),
+				'inheritance'  => $inheritance,
 				'extraPlugins' => array_merge(
 					array(
 						array( 'source' => $paths['agents_api'], 'slug' => 'agents-api', 'activate' => false ),
@@ -618,7 +777,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 					),
 					$provider_plugins
 				),
-				'secretEnv'    => $this->secret_env_names( $input ),
+				'secretEnv'    => $this->secret_env_names( $input, $inheritance ),
 			),
 			'workflow' => array( 'steps' => $steps ),
 		);

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -95,6 +95,7 @@ $assert( 'ability exposes allowed tools schema', 'array' === ( $ability['input_s
 $assert( 'ability exposes expected artifacts schema', 'array' === ( $ability['input_schema']['properties']['expected_artifacts']['type'] ?? '' ) );
 $assert( 'ability exposes policy and context schema', 'object' === ( $ability['input_schema']['properties']['policy']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['context']['type'] ?? '' ) );
 $assert( 'ability exposes generic mounts schema', 'array' === ( $ability['input_schema']['properties']['mounts']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['mounts']['items']['properties']['metadata']['type'] ?? '' ) );
+$assert( 'ability exposes inheritance request schema', 'object' === ( $ability['input_schema']['properties']['inherit']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['connectors']['type'] ?? '' ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
@@ -191,6 +192,54 @@ $assert( 'runner recipe passes provider plugin path', str_contains( $captured_re
 $assert( 'runner recipe passes generic mount metadata', str_contains( $captured_recipe, 'example/editable-plugin' ) && str_contains( $captured_recipe, 'repo_root_relative_to_mount' ) );
 $assert( 'runner recipe passes secret env name only', str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
 $assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = '';
+$GLOBALS['wp_codebox_filters']['wp_codebox_default_model']    = '';
+$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ): array {
+	$resolution['connectors'] = array(
+		array(
+			'name'       => $request['connectors'][0] ?? 'primary-ai',
+			'status'     => 'resolved',
+			'provider'   => 'openai',
+			'model'      => 'gpt-5.5',
+			'secret_env' => array( 'OPENAI_API_KEY' ),
+			'value'      => 'sk-test-secret-value',
+			'token'      => 'sk-test-secret-value',
+		),
+	);
+	$resolution['settings']   = array(
+		array(
+			'name'   => $request['settings'][0] ?? 'mode_models',
+			'status' => 'resolved',
+			'scope'  => 'site',
+			'value'  => 'sk-test-secret-value',
+		),
+	);
+
+	return $resolution;
+};
+
+$inherit_result = $runner->run(
+	array(
+		'goal'           => 'Use inherited connector configuration.',
+		'artifacts_path' => $root . '/artifacts',
+		'inherit'        => array(
+			'connectors' => array( 'primary-ai' ),
+			'settings'   => array( 'mode_models' ),
+		),
+	)
+);
+$inherit_recipe    = json_decode( $captured_recipe, true );
+$inherit_step_args = $inherit_recipe['workflow']['steps'][0]['args'] ?? array();
+$assert( 'runner resolves inherited connector provider', ! is_wp_error( $inherit_result ) && in_array( 'provider=openai', $inherit_step_args, true ) );
+$assert( 'runner resolves inherited connector model', ! is_wp_error( $inherit_result ) && in_array( 'model=gpt-5.5', $inherit_step_args, true ) );
+$assert( 'runner transports inherited secret env name only', ! is_wp_error( $inherit_result ) && in_array( 'OPENAI_API_KEY', $inherit_recipe['inputs']['secretEnv'] ?? array(), true ) && ! str_contains( $captured_recipe, 'OPENAI_API_KEY=' ) );
+$assert( 'runner records sanitized inheritance status', ! is_wp_error( $inherit_result ) && 'primary-ai' === ( $inherit_recipe['inputs']['inheritance']['connectors'][0]['name'] ?? '' ) && 'resolved' === ( $inherit_recipe['inputs']['inheritance']['settings'][0]['status'] ?? '' ) );
+$assert( 'runner drops inherited secret values from recipe', ! str_contains( $captured_recipe, 'sk-test-secret-value' ) && ! str_contains( $captured_recipe, 'token' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
+$GLOBALS['wp_codebox_filters']['wp_codebox_default_model']    = 'gpt-5.5';
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] );
 
 $raw_code = $runner->run(
 	array(


### PR DESCRIPTION
## Summary
- Adds an `inherit` declaration to the WordPress sandbox ability and workspace recipe contract for connector/settings names.
- Resolves declarations through a host-side `wp_codebox_resolve_inheritance` filter and stores only sanitized status/provider/model/env-name metadata.
- Merges inherited secret environment variable names into sandbox runs while dropping returned secret/setting values from generated recipes.

## Scope
- This is the transport/resolution foundation for #88, not the full feature.
- Remaining #88 work includes agent identity inheritance and any explicit pre-`plugins_loaded` hydration mechanism needed by real callers.

## Tests
- `npm run check`

Refs #88.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused inheritance transport implementation, tests, and documentation; Chris remains responsible for review and merge.