### PR TITLE
Add generic runtime episodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ What WP Codebox provides for product use cases:
 - Run a PHP or WP-CLI probe against mounted WordPress code.
 - Execute a WordPress Ability inside a disposable Playground runtime.
 - Run repeatable workspace recipes that mount plugins, seed workspaces, and capture outputs.
+- Drive stateful runtime episodes with reset, step, observe, snapshot, artifact, and close operations.
 - Launch sandboxed Data Machine / Agents API coding-agent tasks from the CLI or WordPress ability surface.
 - Fan out several task descriptions into separate isolated sandboxes.
 - Produce artifact bundles — patches, diffs, test results, live Playground preview URLs — that a parent product can review, replay, apply, or discard.
@@ -168,6 +169,44 @@ npm run wp-codebox -- run \
 ```
 
 The v1 preview is a held live Playground runtime. When `--preview-hold` is omitted, the preview field still records the URL observed during capture, but the runtime is destroyed on command completion and the URL is marked `expired-on-completion`. Artifact replay from `blueprint.after.json` remains partial and is a separate future preview mode.
+
+## Runtime Episodes
+
+Use `createRuntimeEpisode()` when a caller needs a stateful sandbox loop instead
+of a one-shot command or recipe. The episode wrapper is generic: it records reset
+observations, step executions, optional per-step observations, snapshots, and
+artifact bundles without knowing benchmark, reward, or scenario semantics.
+
+```ts
+import { createRuntimeEpisode } from "@chubes4/wp-codebox-core"
+import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
+
+const episode = await createRuntimeEpisode(
+  {
+    runtime: {
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", version: "7.0", blueprint: { steps: [] } },
+      policy: {
+        network: "deny",
+        filesystem: "readwrite-mounts",
+        commands: ["wordpress.wp-cli", "wordpress.run-php"],
+        secrets: "none",
+        approvals: "never",
+      },
+    },
+    stepObservation: { type: "runtime-info" },
+  },
+  createPlaygroundRuntimeBackend(),
+)
+
+await episode.step({ command: "wordpress.wp-cli", args: ["command=post list"] })
+const artifacts = await episode.collectArtifacts({ includeLogs: true })
+const trace = await episode.trace()
+await episode.close()
+```
+
+Products such as eval harnesses can project this generic episode trace into their
+own action, observation, reward, and report schemas outside WP Codebox.
 
 ## CLI Commands
 

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
+    "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run recipe-bench-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run recipe-bench-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -432,6 +432,45 @@ export interface Runtime {
   destroy(): Promise<void>
 }
 
+export interface RuntimeEpisodeSpec {
+  runtime: RuntimeCreateSpec
+  mounts?: MountSpec[]
+  resetObservations?: ObservationSpec[]
+  stepObservation?: ObservationSpec | false
+  artifactSpec?: ArtifactSpec
+}
+
+export interface RuntimeEpisodeResetResult {
+  runtime: RuntimeInfo
+  observations: ObservationResult[]
+}
+
+export interface RuntimeEpisodeStepResult {
+  index: number
+  action: ExecutionSpec
+  execution: ExecutionResult
+  observation?: ObservationResult
+}
+
+export interface RuntimeEpisodeTrace {
+  schema: "wp-codebox/runtime-episode-trace/v1"
+  runtime: RuntimeInfo
+  reset: RuntimeEpisodeResetResult
+  steps: RuntimeEpisodeStepResult[]
+  snapshots: Snapshot[]
+  artifacts?: ArtifactBundle
+}
+
+export interface RuntimeEpisode {
+  reset(): Promise<RuntimeEpisodeResetResult>
+  step(action: ExecutionSpec, observation?: ObservationSpec | false): Promise<RuntimeEpisodeStepResult>
+  observe(spec: ObservationSpec): Promise<ObservationResult>
+  snapshot(): Promise<Snapshot>
+  collectArtifacts(spec?: ArtifactSpec): Promise<ArtifactBundle>
+  trace(): Promise<RuntimeEpisodeTrace>
+  close(): Promise<void>
+}
+
 export interface RuntimeBackend {
   readonly kind: RuntimeBackendKind
   create(spec: RuntimeCreateSpec): Promise<Runtime>
@@ -570,4 +609,110 @@ export async function createRuntime(spec: RuntimeCreateSpec, backend: RuntimeBac
   }
 
   return backend.create(spec)
+}
+
+export async function createRuntimeEpisode(spec: RuntimeEpisodeSpec, backend: RuntimeBackend): Promise<RuntimeEpisode> {
+  return RuntimeEpisodeRunner.create(spec, backend)
+}
+
+class RuntimeEpisodeRunner implements RuntimeEpisode {
+  private runtime?: Runtime
+  private resetResult?: RuntimeEpisodeResetResult
+  private readonly steps: RuntimeEpisodeStepResult[] = []
+  private readonly snapshots: Snapshot[] = []
+  private artifacts?: ArtifactBundle
+
+  private constructor(
+    private readonly spec: RuntimeEpisodeSpec,
+    private readonly backend: RuntimeBackend,
+  ) {}
+
+  static async create(spec: RuntimeEpisodeSpec, backend: RuntimeBackend): Promise<RuntimeEpisodeRunner> {
+    const episode = new RuntimeEpisodeRunner(spec, backend)
+    await episode.reset()
+    return episode
+  }
+
+  async reset(): Promise<RuntimeEpisodeResetResult> {
+    await this.runtime?.destroy()
+    this.runtime = await createRuntime(this.spec.runtime, this.backend)
+    this.steps.length = 0
+    this.snapshots.length = 0
+    this.artifacts = undefined
+
+    for (const mount of this.spec.mounts ?? []) {
+      await this.runtime.mount(mount)
+    }
+
+    const observations = []
+    for (const observation of this.spec.resetObservations ?? [{ type: "runtime-info" }, { type: "mounts" }]) {
+      observations.push(await this.runtime.observe(observation))
+    }
+
+    this.resetResult = {
+      runtime: await this.runtime.info(),
+      observations,
+    }
+
+    return this.resetResult
+  }
+
+  async step(action: ExecutionSpec, observation: ObservationSpec | false = this.spec.stepObservation ?? false): Promise<RuntimeEpisodeStepResult> {
+    const runtime = this.assertRuntime()
+    const execution = await runtime.execute(action)
+    const result: RuntimeEpisodeStepResult = {
+      index: this.steps.length,
+      action,
+      execution,
+      ...(observation ? { observation: await runtime.observe(observation) } : {}),
+    }
+
+    this.steps.push(result)
+    return result
+  }
+
+  async observe(spec: ObservationSpec): Promise<ObservationResult> {
+    return this.assertRuntime().observe(spec)
+  }
+
+  async snapshot(): Promise<Snapshot> {
+    const snapshot = await this.assertRuntime().snapshot()
+    this.snapshots.push(snapshot)
+    return snapshot
+  }
+
+  async collectArtifacts(spec: ArtifactSpec = this.spec.artifactSpec ?? {}): Promise<ArtifactBundle> {
+    this.artifacts = await this.assertRuntime().collectArtifacts(spec)
+    return this.artifacts
+  }
+
+  async trace(): Promise<RuntimeEpisodeTrace> {
+    const runtime = this.assertRuntime()
+    const reset = this.resetResult ?? {
+      runtime: await runtime.info(),
+      observations: [],
+    }
+
+    return {
+      schema: "wp-codebox/runtime-episode-trace/v1",
+      runtime: await runtime.info(),
+      reset,
+      steps: [...this.steps],
+      snapshots: [...this.snapshots],
+      ...(this.artifacts ? { artifacts: this.artifacts } : {}),
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.runtime?.destroy()
+    this.runtime = undefined
+  }
+
+  private assertRuntime(): Runtime {
+    if (!this.runtime) {
+      throw new Error("Runtime episode is closed")
+    }
+
+    return this.runtime
+  }
 }

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createRuntimeEpisode } from "@chubes4/wp-codebox-core"
+import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
+
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-episode-"))
+
+try {
+  const episode = await createRuntimeEpisode(
+    {
+      runtime: {
+        backend: "wordpress-playground",
+        environment: { kind: "wordpress", name: "episode-smoke", version: "7.0", blueprint: { steps: [] } },
+        policy: {
+          network: "deny",
+          filesystem: "readwrite-mounts",
+          commands: ["wordpress.wp-cli", "wordpress.run-php"],
+          secrets: "none",
+          approvals: "never",
+        },
+        artifactsDirectory,
+        metadata: {
+          runtime: { version: "0.0.0" },
+          task: { kind: "runtime-episode-smoke" },
+        },
+      },
+      resetObservations: [{ type: "runtime-info" }],
+      stepObservation: { type: "runtime-info" },
+      artifactSpec: { includeLogs: true, includeObservations: true },
+    },
+    createPlaygroundRuntimeBackend(),
+  )
+
+  try {
+    const createPost = await episode.step({
+      command: "wordpress.wp-cli",
+      args: ["command=post create --post_type=page --post_status=publish --post_title='Episode Smoke' --porcelain"],
+    })
+    assert.equal(createPost.index, 0)
+    assert.equal(createPost.execution.exitCode, 0)
+    assert.match(createPost.execution.stdout, /\d+/)
+    assert.equal(createPost.observation?.type, "runtime-info")
+
+    const queryPost = await episode.step({
+      command: "wordpress.run-php",
+      args: ["code=$post = get_page_by_title('Episode Smoke'); echo $post ? $post->post_title : '';"],
+    })
+    assert.equal(queryPost.index, 1)
+    assert.equal(queryPost.execution.stdout.trim(), "Episode Smoke")
+
+    const snapshot = await episode.snapshot()
+    assert.match(snapshot.id, /^snapshot-/)
+
+    const artifacts = await episode.collectArtifacts()
+    const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8"))
+    assert.equal(metadata.provenance.task.kind, "runtime-episode-smoke")
+
+    const trace = await episode.trace()
+    assert.equal(trace.schema, "wp-codebox/runtime-episode-trace/v1")
+    assert.equal(trace.steps.length, 2)
+    assert.equal(trace.snapshots.length, 1)
+    assert.equal(trace.reset.observations.length, 1)
+    assert.equal(trace.artifacts?.id, artifacts.id)
+  } finally {
+    await episode.close()
+  }
+
+  console.log("Runtime episode smoke passed")
+} finally {
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Add a backend-agnostic `createRuntimeEpisode()` wrapper with reset, step, observe, snapshot, artifact, trace, and close operations.
- Keep episode traces generic to WP Codebox runtime data, leaving scenario/reward/benchmark semantics to callers.
- Document the stateful episode API and add a WordPress Playground smoke covering multiple steps, artifacts, and trace output.

## Testing
- `npm run check`
- `npm run build && npm run runtime-episode-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic runtime episode API, smoke coverage, and README documentation; Chris reviewed and directed the architecture boundary.