### PR TITLE
Install workspace runtime aliases for git consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,191 @@
     "": {
       "name": "wp-codebox-workspace",
       "version": "0.0.0",
+      "license": "ISC",
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@chubes4/wp-codebox-cli": "file:packages/cli",
+        "@chubes4/wp-codebox-core": "file:packages/runtime-core",
+        "@chubes4/wp-codebox-playground": "file:packages/runtime-playground",
+        "abort-controller": "^3.0.0",
+        "accepts": "^1.3.8",
+        "aggregate-error": "^3.1.0",
+        "ajv": "^8.12.0",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^4.3.0",
+        "array-flatten": "^1.1.1",
+        "async-lock": "^1.4.1",
+        "available-typed-arrays": "^1.0.7",
+        "base64-js": "^1.5.1",
+        "before-after-hook": "^2.2.3",
+        "body-parser": "^1.20.5",
+        "bottleneck": "^2.19.5",
+        "btoa-lite": "^1.0.0",
+        "buffer": "^6.0.3",
+        "buffer-equal-constant-time": "^1.0.1",
+        "bytes": "^3.1.2",
+        "call-bind": "^1.0.9",
+        "call-bind-apply-helpers": "^1.0.2",
+        "call-bound": "^1.0.4",
+        "clean-git-ref": "^2.0.1",
+        "clean-stack": "^2.2.0",
+        "cliui": "^8.0.1",
+        "color-convert": "^2.0.1",
+        "color-name": "^1.1.4",
+        "content-disposition": "^0.5.4",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.2",
+        "cookie-signature": "^1.0.7",
+        "crc-32": "^1.2.2",
+        "debug": "^2.6.9",
+        "decompress-response": "^6.0.0",
+        "define-data-property": "^1.1.4",
+        "depd": "^2.0.0",
+        "deprecation": "^2.3.1",
+        "destroy": "^1.2.0",
+        "diff3": "^0.0.3",
+        "dunder-proto": "^1.0.1",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "ee-first": "^1.1.1",
+        "emoji-regex": "^8.0.0",
+        "encodeurl": "^2.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "esbuild": "^0.28.0",
+        "escalade": "^3.2.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "event-target-shim": "^5.0.1",
+        "events": "^3.3.0",
+        "express": "^4.22.0",
+        "fast-deep-equal": "^3.1.3",
+        "fast-xml-builder": "^1.2.0",
+        "fast-xml-parser": "^5.8.0",
+        "finalhandler": "^1.3.2",
+        "for-each": "^0.3.5",
+        "forwarded": "^0.2.0",
+        "fresh": "^0.5.2",
+        "fs-ext-extra-prebuilt": "^2.2.7",
+        "fs-extra": "^11.1.1",
+        "fsevents": "^2.3.3",
+        "function-bind": "^1.1.2",
+        "get-caller-file": "^2.0.5",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "graceful-fs": "^4.2.11",
+        "has-property-descriptors": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.4.24",
+        "ieee754": "^1.2.1",
+        "ignore": "^5.3.2",
+        "indent-string": "^4.0.0",
+        "inherits": "^2.0.4",
+        "ini": "^4.1.2",
+        "ipaddr.js": "^1.9.1",
+        "is-callable": "^1.2.7",
+        "is-fullwidth-code-point": "^3.0.0",
+        "is-typed-array": "^1.1.15",
+        "isarray": "^2.0.5",
+        "isomorphic-git": "^1.37.6",
+        "json-schema-traverse": "^1.0.0",
+        "jsonc-parser": "^3.3.1",
+        "jsonfile": "^6.2.1",
+        "jsonwebtoken": "^9.0.3",
+        "jwa": "^2.0.1",
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.1.1",
+        "lru-cache": "^11.0.2-patch.1",
+        "math-intrinsics": "^1.1.0",
+        "media-typer": "^0.3.0",
+        "merge-descriptors": "^1.0.3",
+        "methods": "^1.1.2",
+        "mime": "^1.6.0",
+        "mime-db": "^1.52.0",
+        "mime-types": "^2.1.35",
+        "mimic-response": "^3.1.0",
+        "minimist": "^1.2.8",
+        "minimisted": "^2.0.1",
+        "ms": "^2.0.0",
+        "nan": "^2.27.0",
+        "negotiator": "^0.6.3",
+        "object-inspect": "^1.13.4",
+        "octokit": "^3.1.2",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "pako": "^1.0.11",
+        "parseurl": "^1.3.3",
+        "path-expression-matcher": "^1.5.0",
+        "path-to-regexp": "^0.1.13",
+        "pify": "^4.0.1",
+        "possible-typed-array-names": "^1.1.0",
+        "process": "^0.11.10",
+        "proxy-addr": "^2.0.7",
+        "punycode": "^2.3.1",
+        "qs": "^6.14.2",
+        "range-parser": "^1.2.1",
+        "raw-body": "^2.5.3",
+        "readable-stream": "^4.7.0",
+        "require-directory": "^2.1.1",
+        "require-from-string": "^2.0.2",
+        "safe-buffer": "^5.2.1",
+        "safer-buffer": "^2.1.2",
+        "sax": "^1.6.0",
+        "semver": "^7.8.0",
+        "send": "^0.19.2",
+        "serve-static": "^1.16.3",
+        "set-function-length": "^1.2.2",
+        "setprototypeof": "^1.2.0",
+        "sha.js": "^2.4.12",
+        "side-channel": "^1.1.0",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2",
+        "simple-concat": "^1.0.1",
+        "simple-get": "^4.0.1",
+        "statuses": "^2.0.2",
+        "string_decoder": "^1.3.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "strnum": "^2.3.0",
+        "tmp": "^0.2.5",
+        "tmp-promise": "^3.0.3",
+        "to-buffer": "^1.2.2",
+        "toidentifier": "^1.0.1",
+        "type-is": "^1.6.18",
+        "typed-array-buffer": "^1.0.3",
+        "undici-types": "^7.16.0",
+        "universal-github-app-jwt": "^1.2.0",
+        "universal-user-agent": "^6.0.1",
+        "universalify": "^2.0.1",
+        "unpipe": "^1.0.0",
+        "uri-js": "^4.4.1",
+        "utils-merge": "^1.0.1",
+        "vary": "^1.1.2",
+        "wasm-feature-detect": "^1.8.0",
+        "which-typed-array": "^1.1.20",
+        "wrap-ansi": "^7.0.0",
+        "wrappy": "^1.0.2",
+        "ws": "^8.18.0",
+        "xml-naming": "^0.1.0",
+        "xml2js": "^0.6.2",
+        "xmlbuilder": "^11.0.1",
+        "y18n": "^5.0.8",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "tsx": "^4.20.0",
@@ -35,7 +217,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -52,7 +233,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -69,7 +249,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -86,7 +265,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -103,7 +281,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -120,7 +297,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -137,7 +313,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -154,7 +329,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -171,7 +345,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -188,7 +361,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -205,7 +377,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -222,7 +393,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -239,7 +409,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -256,7 +425,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -273,7 +441,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -290,7 +457,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -307,7 +473,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -324,7 +489,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -341,7 +505,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -358,7 +521,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,7 +537,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -392,7 +553,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -409,7 +569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -426,7 +585,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -443,7 +601,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -460,7 +617,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1919,7 +2075,6 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2171,10 +2326,8 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "test": "tests"
   },
   "dependencies": {
+    "@chubes4/wp-codebox-cli": "file:packages/cli",
+    "@chubes4/wp-codebox-core": "file:packages/runtime-core",
+    "@chubes4/wp-codebox-playground": "file:packages/runtime-playground",
     "abort-controller": "^3.0.0",
     "accepts": "^1.3.8",
     "aggregate-error": "^3.1.0",


### PR DESCRIPTION
## Summary
- Add root package dependencies for the workspace runtime packages so git-installed consumers can resolve internal imports such as `@chubes4/wp-codebox-core`.
- Refresh the lockfile so the root workspace package installs its core, playground, and CLI package aliases consistently.

## Testing
- temp consumer install/import smoke for `wp-codebox-workspace/core` and `wp-codebox-workspace/playground`
- `npm run build && npm run runtime-episode-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed downstream root-package internal import failure and drafted the workspace dependency fix.