### PR TITLE
Keep fsevents optional for Linux installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "fresh": "^0.5.2",
         "fs-ext-extra-prebuilt": "^2.2.7",
         "fs-extra": "^11.1.1",
-        "fsevents": "^2.3.3",
         "function-bind": "^1.1.2",
         "get-caller-file": "^2.0.5",
         "get-intrinsic": "^1.3.0",
@@ -2326,8 +2325,10 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "fresh": "^0.5.2",
     "fs-ext-extra-prebuilt": "^2.2.7",
     "fs-extra": "^11.1.1",
-    "fsevents": "^2.3.3",
     "function-bind": "^1.1.2",
     "get-caller-file": "^2.0.5",
     "get-intrinsic": "^1.3.0",


### PR DESCRIPTION
## Summary
- Remove the direct `fsevents` dependency so Linux `npm install` can install WP Codebox.
- Preserve `fsevents` only as an optional transitive dependency in the lockfile.

## Context
- Found while validating Extra-Chill/homeboy-extensions#742: its CI checks out WP Codebox on Linux and failed before tests with `Unsupported platform for fsevents@2.3.3`.

## Testing
- `npm install --package-lock-only --ignore-scripts --os=linux`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Linux install failure and drafted the dependency cleanup; Chris remains responsible for review and merge.