### PR TITLE
fix: preserve phpunit diagnostic artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "core-phpunit-command-smoke": "tsx scripts/core-phpunit-command-smoke.ts",
+    "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -105,6 +105,7 @@ function errorMessage(error: unknown): string {
 interface PlaygroundCliServer {
   playground: {
     run(options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse>
+    readFileAsText?(path: string): string | Promise<string>
     writeFile?(path: string, contents: string): Promise<void>
   }
   serverUrl: string
@@ -778,6 +779,7 @@ class PlaygroundRuntime implements Runtime {
       throw new Error("wordpress.phpunit requires plugin-slug=<slug> when code/code-file is not provided")
     }
     const response = await this.runPlaygroundCommand("wordpress.phpunit", server, { code })
+    await this.persistVfsDiagnosticFile(server, `/wordpress/wp-content/plugins/${pluginSlug}/.pg-test-result.txt`)
     assertPlaygroundResponseOk("wordpress.phpunit", response)
 
     return response.text
@@ -798,9 +800,51 @@ class PlaygroundRuntime implements Runtime {
       multisite: booleanArg(args, "multisite"),
     }))
     const response = await this.runPlaygroundCommand("wordpress.core-phpunit", server, { code })
+    await this.persistVfsDiagnosticFile(server, `${argValue(args, "core-root")?.trim() || "/wordpress"}/.pg-test-result.txt`)
     assertPlaygroundResponseOk("wordpress.core-phpunit", response)
 
     return response.text
+  }
+
+  private async persistVfsDiagnosticFile(server: PlaygroundCliServer, vfsPath: string): Promise<void> {
+    if (!server.playground.readFileAsText) {
+      return
+    }
+
+    const hostPath = this.hostPathForVfsPath(vfsPath)
+    if (!hostPath) {
+      return
+    }
+
+    try {
+      const contents = await server.playground.readFileAsText(vfsPath)
+      await mkdir(dirname(hostPath), { recursive: true })
+      await writeFile(hostPath, contents)
+    } catch {
+      // The structured result is best-effort; preserve the command failure if copying fails.
+    }
+  }
+
+  private hostPathForVfsPath(vfsPath: string): string | undefined {
+    for (const mount of this.mounts) {
+      if (mount.mode !== "readwrite") {
+        continue
+      }
+
+      const target = mount.target.replace(/\/+$/, "")
+      if (vfsPath !== target && !vfsPath.startsWith(`${target}/`)) {
+        continue
+      }
+
+      const relativePath = vfsPath === target ? "" : vfsPath.slice(target.length + 1)
+      if (relativePath.split("/").includes("..")) {
+        continue
+      }
+
+      return join(mount.source, relativePath)
+    }
+
+    return undefined
   }
 
   private async runPlaygroundCommand(command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse> {

--- a/scripts/phpunit-diagnostic-artifact-smoke.ts
+++ b/scripts/phpunit-diagnostic-artifact-smoke.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const fixtureRoot = mkdtempSync(join(tmpdir(), "wp-codebox-phpunit-diagnostic-"))
+const pluginRoot = join(fixtureRoot, "diagnostic-plugin")
+mkdirSync(pluginRoot, { recursive: true })
+writeFileSync(
+  join(pluginRoot, "diagnostic-plugin.php"),
+  `<?php
+/**
+ * Plugin Name: WP Codebox Diagnostic Fixture
+ */
+`,
+)
+
+const run = spawnSync(
+  "node",
+  [
+    "packages/cli/dist/index.js",
+    "run",
+    "--mount",
+    `${pluginRoot}:/wordpress/wp-content/plugins/diagnostic-plugin:readwrite`,
+    "--command",
+    "wordpress.phpunit",
+    "--arg",
+    "plugin-slug=diagnostic-plugin",
+    "--json",
+  ],
+  {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  },
+)
+
+assert.equal(run.status, 1, run.stderr || run.stdout)
+
+const diagnosticPath = join(pluginRoot, ".pg-test-result.txt")
+assert.equal(existsSync(diagnosticPath), true, run.stderr || run.stdout)
+
+const diagnostic = readFileSync(diagnosticPath, "utf8")
+assert.match(diagnostic, /STAGE_BEGIN:boot/)
+assert.match(diagnostic, /STAGE_FAIL:boot|NO_TEST_FILES/)
+
+console.log("PHPUnit diagnostic artifact smoke passed")


### PR DESCRIPTION
## Summary
- Persist PHPUnit `.pg-test-result.txt` diagnostics from the Playground VFS back to the matching readwrite host mount before classifying command failures.
- Cover the regression with a focused smoke test that asserts a failing PHPUnit run leaves the diagnostic artifact on the mounted plugin directory.

Closes https://github.com/chubes4/wp-codebox/issues/97

## Test evidence
- `npm run build`
- `npm run phpunit-diagnostic-artifact-smoke`
- `npm run core-phpunit-command-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause investigation, implementation, focused smoke coverage, and verification. Chris remains responsible for review and merge.