### PR TITLE
Add recipe-run dry-run plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ npm run wp-codebox -- recipe validate \
 
 Validation checks schema, source paths, extra plugin entrypoints, workspace seeds, supported workflow commands, JSON ability inputs, and command arguments.
 
+Use `recipe validate` when you only need a pass/fail contract for authoring or CI. It does not resolve the execution plan beyond validation summaries.
+
 ### `recipe-run`
 
 Run a repeatable recipe.
@@ -259,6 +261,17 @@ npm run wp-codebox -- recipe-run \
 ```
 
 Recipes are JSON declarations for a sandbox setup plus workflow steps. They can mount existing directories, create disposable plugin/theme workspaces, activate extra plugins, allow-list selected secret environment variable names, and capture the output as artifacts.
+
+Pass `--dry-run --json` to validate the same recipe and emit the resolved plan without booting Playground, creating temp workspaces, mounting files, executing commands, or writing artifacts:
+
+```bash
+npm run wp-codebox -- recipe-run \
+  --recipe ./examples/recipes/simple-plugin.json \
+  --dry-run \
+  --json
+```
+
+Dry-run output uses `wp-codebox/recipe-run-dry-run/v1` and includes resolved mounts, planned workspaces, extra plugins, workflow steps with parsed and resolved command args, allowed secret environment variable names without values, and per-step policy status. Use `recipe-run` without `--dry-run` when you want the real Playground-backed execution and artifact bundle.
 
 Mount entries may include opaque `metadata` that is preserved in runtime observations, artifact provenance, and captured mount files. Product-specific callers can use this to map sandbox paths back to source repositories without WP Codebox knowing about the caller's deployment environment:
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "core-phpunit-command-smoke": "tsx scripts/core-phpunit-command-smoke.ts",
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
+    "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,3 +24,9 @@ npm run package-distribution-smoke
 The distribution smoke runs `npm pack --dry-run --json` and verifies the package
 contains `package.json`, `README.md`, and the compiled CLI entrypoint used by the
 published binary.
+
+## Recipe Planning
+
+- `wp-codebox recipe validate --recipe <path> [--json]` validates recipe shape, paths, commands, and arguments without resolving a full execution plan.
+- `wp-codebox recipe-run --recipe <path> --dry-run --json` validates the recipe and emits the resolved plan without booting Playground, creating temp workspaces, mutating files, or writing artifacts.
+- `wp-codebox recipe-run --recipe <path> [--json]` boots Playground, mounts inputs, executes workflow steps, and captures artifacts.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
-import { createRuntime, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
 import { captureStdout, printBatchHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
@@ -39,6 +39,7 @@ interface RecipeRunOptions {
   artifactsDirectory?: string
   previewHoldSeconds?: number
   json: boolean
+  dryRun: boolean
 }
 
 interface RecipeValidateOptions {
@@ -78,6 +79,89 @@ interface RecipeRunOutput {
   artifacts?: ArtifactBundle
   logs?: string[]
   error?: RunOutput["error"]
+}
+
+interface RecipeDryRunOutput {
+  success: boolean
+  schema: "wp-codebox/recipe-run-dry-run/v1"
+  recipePath?: string
+  dryRun: true
+  valid: boolean
+  validation: {
+    issues: RecipeValidationIssue[]
+  }
+  plan?: RecipeDryRunPlan
+  error?: RunOutput["error"]
+}
+
+type RecipeRunCommandOutput = RecipeRunOutput | RecipeDryRunOutput
+
+interface RecipeDryRunPlan {
+  runtime: {
+    backend: string
+    name: string
+    wp: string
+    blueprint: unknown
+  }
+  artifacts: {
+    directory?: string
+  }
+  mounts: RecipeDryRunMount[]
+  workspaces: RecipeDryRunWorkspace[]
+  extra_plugins: RecipeDryRunExtraPlugin[]
+  secretEnv: Array<{ name: string; available: boolean }>
+  policy: RuntimePolicy & {
+    valid: boolean
+    issues: ReturnType<typeof validateRuntimePolicy>["issues"]
+  }
+  workflow: {
+    steps: RecipeDryRunStep[]
+  }
+}
+
+interface RecipeDryRunMount {
+  type: "directory"
+  source?: string
+  target: string
+  mode: "readonly" | "readwrite"
+  metadata?: Record<string, unknown>
+  planned?: "existing" | "generated"
+}
+
+interface RecipeDryRunWorkspace {
+  index: number
+  source?: string
+  target: string
+  mode: "readonly" | "readwrite"
+  seed: WorkspaceRecipeWorkspace["seed"]
+  generated: boolean
+  metadata: Record<string, unknown>
+}
+
+interface RecipeDryRunExtraPlugin {
+  source: string
+  slug: string
+  target: string
+  pluginFile: string
+  activate: boolean
+}
+
+interface RecipeDryRunStep {
+  index: number
+  command: string
+  args: string[]
+  parsedArgs: Record<string, string | true>
+  resolvedCommand: string
+  resolvedArgs: string[]
+  resolvedParsedArgs: Record<string, string | true>
+  policy: {
+    status: "allowed" | "denied"
+    command: string
+    allowedCommands: string[]
+    approvals: RuntimePolicy["approvals"]
+    filesystem: RuntimePolicy["filesystem"]
+    secrets: RuntimePolicy["secrets"]
+  }
 }
 
 interface PreparedWorkspaceMount {
@@ -171,7 +255,7 @@ async function main(args: string[]): Promise<number> {
 
   if (command === "recipe-run") {
     const options = parseRecipeRunOptions(args)
-    const execute = () => runRecipe(options)
+    const execute = (): Promise<RecipeRunCommandOutput> => options.dryRun ? dryRunRecipe(options) : runRecipe(options)
 
     if (!options.json) {
       const output = await execute()
@@ -225,6 +309,122 @@ async function main(args: string[]): Promise<number> {
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
   printJsonFailureDiagnostic(output)
   return output.success ? 0 : 1
+}
+
+async function dryRunRecipe(options: RecipeRunOptions): Promise<RecipeDryRunOutput> {
+  const recipePath = resolve(options.recipePath)
+  try {
+    const recipeDirectory = dirname(recipePath)
+    const raw = await readFile(recipePath, "utf8")
+    const recipe = parseWorkspaceRecipe(raw, recipePath)
+    const issues = await validateWorkspaceRecipe(recipe, recipePath)
+
+    if (issues.length > 0) {
+      return {
+        success: false,
+        schema: "wp-codebox/recipe-run-dry-run/v1",
+        recipePath,
+        dryRun: true,
+        valid: false,
+        validation: { issues },
+        error: {
+          name: "RecipeValidationError",
+          message: `Recipe validation failed with ${issues.length} issue${issues.length === 1 ? "" : "s"}.`,
+        },
+      }
+    }
+
+    return {
+      success: true,
+      schema: "wp-codebox/recipe-run-dry-run/v1",
+      recipePath,
+      dryRun: true,
+      valid: true,
+      validation: { issues },
+      plan: await recipeDryRunPlan(recipe, recipeDirectory, options),
+    }
+  } catch (error) {
+    return {
+      success: false,
+      schema: "wp-codebox/recipe-run-dry-run/v1",
+      recipePath,
+      dryRun: true,
+      valid: false,
+      validation: {
+        issues: [
+          {
+            code: "invalid-recipe",
+            path: "$",
+            message: error instanceof SyntaxError ? `Recipe JSON is invalid: ${error.message}` : error instanceof Error ? error.message : String(error),
+          },
+        ],
+      },
+      error: serializeError(error),
+    }
+  }
+}
+
+async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string, options: RecipeRunOptions): Promise<RecipeDryRunPlan> {
+  const policy = recipePolicy(recipe)
+  const policyValidation = validateRuntimePolicy(policy)
+  const workspaces = recipeDryRunWorkspaces(recipe, recipeDirectory)
+  const extraPlugins = recipeDryRunExtraPlugins(recipe, recipeDirectory)
+  const mounts: RecipeDryRunMount[] = [
+    ...workspaces.map((workspace) => ({
+      type: "directory" as const,
+      ...(workspace.source ? { source: workspace.source } : {}),
+      target: workspace.target,
+      mode: workspace.mode,
+      metadata: workspace.metadata,
+      planned: workspace.generated ? "generated" as const : "existing" as const,
+    })),
+    ...extraPlugins.map((plugin) => ({
+      type: "directory" as const,
+      source: plugin.source,
+      target: plugin.target,
+      mode: "readonly" as const,
+      metadata: {
+        kind: "extra-plugin",
+        slug: plugin.slug,
+      },
+      planned: "existing" as const,
+    })),
+    ...(recipe.inputs?.mounts ?? []).map((mount) => ({
+      type: "directory" as const,
+      source: resolve(recipeDirectory, mount.source),
+      target: mount.target,
+      mode: mount.mode ?? "readwrite" as const,
+      ...(mount.metadata ? { metadata: mount.metadata } : {}),
+      planned: "existing" as const,
+    })),
+  ]
+
+  return {
+    runtime: {
+      backend: recipe.runtime?.backend ?? "wordpress-playground",
+      name: recipe.runtime?.name ?? "wp-codebox-recipe",
+      wp: recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION,
+      blueprint: recipe.runtime?.blueprint ?? { steps: [] },
+    },
+    artifacts: stripUndefined({
+      directory: options.artifactsDirectory ?? recipe.artifacts?.directory,
+    }),
+    mounts,
+    workspaces,
+    extra_plugins: extraPlugins,
+    secretEnv: (recipe.inputs?.secretEnv ?? []).map((name) => ({
+      name,
+      available: process.env[name] !== undefined,
+    })),
+    policy: {
+      ...policy,
+      valid: policyValidation.valid,
+      issues: policyValidation.issues,
+    },
+    workflow: {
+      steps: await recipeDryRunSteps(recipe, recipeDirectory, policy),
+    },
+  }
 }
 
 function printJsonFailureDiagnostic(output: { success: boolean; error?: { message?: string }; logs?: string[] }): void {
@@ -953,13 +1153,18 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
 }
 
 function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
-  const options: Partial<RecipeRunOptions> = { json: false }
+  const options: Partial<RecipeRunOptions> = { json: false, dryRun: false }
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
 
     if (arg === "--json") {
       options.json = true
+      continue
+    }
+
+    if (arg === "--dry-run") {
+      options.dryRun = true
       continue
     }
 
@@ -1253,6 +1458,57 @@ function recipeWpCliCommandFromArgs(args: string[]): string {
   return recipeStepArgValue(args, "command")?.trim() ?? args.join(" ").trim()
 }
 
+async function recipeDryRunSteps(recipe: WorkspaceRecipe, recipeDirectory: string, policy: RuntimePolicy): Promise<RecipeDryRunStep[]> {
+  const steps: Array<Promise<RecipeDryRunStep>> = []
+  const pluginActivationCode = activateExtraPluginsCode(recipe)
+  if (pluginActivationCode) {
+    steps.push(recipeDryRunStep({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }, recipeDirectory, policy, -1, "activate-extra-plugins"))
+  }
+
+  for (const [index, step] of recipe.workflow.steps.entries()) {
+    steps.push(recipeDryRunStep(step, recipeDirectory, policy, index))
+  }
+
+  return Promise.all(steps)
+}
+
+async function recipeDryRunStep(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string, policy: RuntimePolicy, index: number, label?: string): Promise<RecipeDryRunStep> {
+  const resolved = await recipeExecutionSpec(step, recipeDirectory)
+  const allowed = policy.commands.includes(resolved.command)
+  return {
+    index,
+    command: label ?? step.command,
+    args: step.args ?? [],
+    parsedArgs: parseRecipeArgs(step.args ?? []),
+    resolvedCommand: resolved.command,
+    resolvedArgs: resolved.args,
+    resolvedParsedArgs: parseRecipeArgs(resolved.args),
+    policy: {
+      status: allowed ? "allowed" : "denied",
+      command: resolved.command,
+      allowedCommands: policy.commands,
+      approvals: policy.approvals,
+      filesystem: policy.filesystem,
+      secrets: policy.secrets,
+    },
+  }
+}
+
+function parseRecipeArgs(args: string[]): Record<string, string | true> {
+  const parsed: Record<string, string | true> = {}
+  for (const arg of args) {
+    const separator = arg.indexOf("=")
+    if (separator === -1) {
+      parsed[arg] = true
+      continue
+    }
+
+    parsed[arg.slice(0, separator)] = arg.slice(separator + 1)
+  }
+
+  return parsed
+}
+
 function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
   const commands = recipe.workflow.steps.map((step) => step.command.startsWith("wp-codebox.agent-") ? "wordpress.run-php" : step.command)
   if (recipeExtraPlugins(recipe).some((plugin) => plugin.activate !== false)) {
@@ -1312,6 +1568,44 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       metadata: workspace.metadata,
     })),
   }
+}
+
+function recipeDryRunWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string): RecipeDryRunWorkspace[] {
+  return (recipe.inputs?.workspaces ?? []).map((workspace, index) => {
+    const slug = workspace.seed.slug ?? basename(resolve(recipeDirectory, workspace.seed.source ?? `workspace-${index}`))
+    const target = workspace.target ?? defaultWorkspaceTarget(workspace, slug)
+    const generated = workspace.seed.type !== "directory"
+    const metadata = {
+      kind: "recipe-workspace",
+      index,
+      seed: workspace.seed,
+      target,
+      dryRun: true,
+    }
+
+    return {
+      index,
+      ...(generated ? {} : { source: resolve(recipeDirectory, workspace.seed.source ?? "") }),
+      target,
+      mode: workspace.mode ?? "readwrite",
+      seed: workspace.seed,
+      generated,
+      metadata,
+    }
+  })
+}
+
+function recipeDryRunExtraPlugins(recipe: WorkspaceRecipe, recipeDirectory: string): RecipeDryRunExtraPlugin[] {
+  return recipeExtraPlugins(recipe).map((plugin) => {
+    const slug = recipeExtraPluginSlug(plugin)
+    return {
+      source: resolve(recipeDirectory, plugin.source),
+      slug,
+      target: `/wordpress/wp-content/plugins/${slug}`,
+      pluginFile: recipeExtraPluginFile(plugin),
+      activate: plugin.activate !== false,
+    }
+  })
 }
 
 async function prepareRecipeWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedWorkspaceMount[]> {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -15,7 +15,17 @@ interface RunOutputLike {
 }
 
 interface RecipeRunOutputLike extends RunOutputLike {
-  executions: ExecutionResult[]
+  executions?: ExecutionResult[]
+  dryRun?: boolean
+  plan?: {
+    workflow?: { steps?: unknown[] }
+    mounts?: unknown[]
+    workspaces?: unknown[]
+    extra_plugins?: unknown[]
+  }
+  validation?: {
+    issues?: Array<{ code: string; path: string; message: string }>
+  }
 }
 
 interface RecipeValidateOutputLike {
@@ -89,12 +99,24 @@ export function printHumanOutput(output: RunOutputLike): void {
 export function printRecipeHumanOutput(output: RecipeRunOutputLike): void {
   if (!output.success) {
     console.error(output.error?.message ?? "WP Codebox recipe failed")
+    for (const issue of output.validation?.issues ?? []) {
+      console.error(`- ${issue.code} ${issue.path}: ${issue.message}`)
+    }
+    return
+  }
+
+  if (output.dryRun) {
+    console.log("WP Codebox recipe dry-run")
+    console.log(`Steps: ${output.plan?.workflow?.steps?.length ?? 0}`)
+    console.log(`Mounts: ${output.plan?.mounts?.length ?? 0}`)
+    console.log(`Workspaces: ${output.plan?.workspaces?.length ?? 0}`)
+    console.log(`Extra plugins: ${output.plan?.extra_plugins?.length ?? 0}`)
     return
   }
 
   console.log("WP Codebox recipe")
   console.log(`Runtime: ${output.runtime?.backend ?? "unknown"}`)
-  console.log(`Steps: ${output.executions.length}`)
+  console.log(`Steps: ${output.executions?.length ?? 0}`)
   console.log(`Artifacts: ${output.artifacts?.directory ?? "none"}`)
   if (output.artifacts?.preview?.url) {
     console.log(`Preview: ${output.artifacts.preview.url} (${output.artifacts.preview.status})`)
@@ -144,6 +166,7 @@ Options:
   --artifacts <dir>    Artifact root directory.
   --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
+  --dry-run            Validate recipe-run and emit a resolved JSON plan without booting Playground or writing temp workspaces.
   --json               Emit machine-readable JSON.
 
 Example:

--- a/scripts/recipe-dry-run-smoke.ts
+++ b/scripts/recipe-dry-run-smoke.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const workspace = resolve(root, "artifacts/recipe-dry-run-smoke")
+const recipePath = resolve(workspace, "recipe.json")
+const invalidRecipePath = resolve(workspace, "invalid-recipe.json")
+const dryRunArtifacts = resolve(workspace, "dry-run-artifacts")
+
+mkdirSync(workspace, { recursive: true })
+writeFileSync(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: {
+    backend: "wordpress-playground",
+    name: "dry-run-smoke",
+    wp: "7.0",
+    blueprint: { steps: [] },
+  },
+  inputs: {
+    secretEnv: ["DRY_RUN_TOKEN"],
+    workspaces: [
+      {
+        seed: {
+          type: "plugin_scaffold",
+          slug: "dry-run-plugin",
+        },
+      },
+    ],
+    extraPlugins: [
+      {
+        source: "../../examples/simple-plugin",
+        slug: "simple-plugin",
+        pluginFile: "simple-plugin/simple-plugin.php",
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: ["code=echo 'dry run';"],
+      },
+      {
+        command: "wordpress.wp-cli",
+        args: ["command=option get home"],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+writeFileSync(invalidRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: [],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+const result = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--artifacts",
+  dryRunArtifacts,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8", env: { ...process.env, DRY_RUN_TOKEN: "redacted-value" } })
+
+assert.equal(result.status, 0, result.stderr || result.stdout)
+assert.equal(existsSync(dryRunArtifacts), false, "dry-run must not create artifact directories")
+
+const output = JSON.parse(result.stdout)
+assert.equal(output.success, true)
+assert.equal(output.schema, "wp-codebox/recipe-run-dry-run/v1")
+assert.equal(output.dryRun, true)
+assert.equal(output.valid, true)
+assert.equal(output.plan.runtime.backend, "wordpress-playground")
+assert.equal(output.plan.workspaces.length, 1)
+assert.equal(output.plan.workspaces[0].generated, true)
+assert.equal(output.plan.workspaces[0].source, undefined)
+assert.equal(output.plan.extra_plugins[0].target, "/wordpress/wp-content/plugins/simple-plugin")
+assert.equal(output.plan.secretEnv[0].name, "DRY_RUN_TOKEN")
+assert.equal(Object.prototype.hasOwnProperty.call(output.plan.secretEnv[0], "value"), false)
+assert.equal(output.plan.secretEnv[0].available, true)
+assert.equal(output.plan.workflow.steps.length, 3)
+assert.equal(output.plan.workflow.steps[0].command, "activate-extra-plugins")
+assert.equal(output.plan.workflow.steps[0].policy.status, "allowed")
+assert.equal(output.plan.workflow.steps[1].resolvedCommand, "wordpress.run-php")
+assert.equal(output.plan.workflow.steps[1].resolvedParsedArgs.code, "echo 'dry run';")
+assert.equal(output.plan.workflow.steps[2].parsedArgs.command, "option get home")
+assert.equal(output.plan.workflow.steps[2].policy.status, "allowed")
+assert.equal(output.runtime, undefined)
+assert.equal(output.executions, undefined)
+assert.equal(output.artifacts, undefined)
+
+const invalidResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  invalidRecipePath,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(invalidResult.status, 1, invalidResult.stderr || invalidResult.stdout)
+const invalidOutput = JSON.parse(invalidResult.stdout)
+assert.equal(invalidOutput.success, false)
+assert.equal(invalidOutput.valid, false)
+assert.equal(invalidOutput.validation.issues[0].code, "missing-code")
+
+console.log("recipe dry-run smoke passed")


### PR DESCRIPTION
## Summary
- Add `recipe-run --dry-run` for validating recipes and emitting a resolved JSON execution plan without creating temp workspaces or booting Playground.
- Include resolved mounts, planned workspaces, extra plugins, parsed/resolved workflow args, secret environment variable names without values, and per-step policy status.
- Document `recipe validate` vs `recipe-run --dry-run` vs real `recipe-run`, and add a dry-run smoke to the check suite.

Fixes https://github.com/chubes4/wp-codebox/issues/102

## Tests
- `npm run build`
- `npm run recipe-dry-run-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the CLI dry-run implementation, docs updates, and smoke coverage; Chris remains responsible for review and merge.