### PR TITLE
Support preview public URL overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ npm run wp-codebox -- run \
 
 The v1 preview is a held live Playground runtime. When `--preview-hold` is omitted, the preview field still records the URL observed during capture, but the runtime is destroyed on command completion and the URL is marked `expired-on-completion`. Artifact replay from `blueprint.after.json` remains partial and is a separate future preview mode.
 
+When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url`, so WordPress-generated links can align with the public preview where Playground supports that option. The local Playground URL remains recorded as `preview.localUrl`.
+
+Remote preview access still requires an external tunnel or proxy. WP Codebox does not claim true bind-host support: a `--preview-bind` style option depends on upstream WordPress Playground exposing a host/bind API. Track upstream support in https://github.com/WordPress/wordpress-playground/issues/3681.
+
 ## Runtime Episodes
 
 Use `createRuntimeEpisode()` when a caller needs a stateful sandbox loop instead
@@ -219,6 +223,7 @@ npm run wp-codebox -- run \
   --mount <host-path>:<sandbox-path>[:readonly|readwrite] \
   --command <command> \
   --arg <key=value> \
+  --preview-public-url <public-tunnel-url> \
   --json
 ```
 
@@ -234,6 +239,8 @@ Supported runtime commands today:
 `wordpress.wp-cli` automatically enables Playground's `wp-cli` extra library when the command is allowed by runtime policy.
 
 WP Codebox defaults to WordPress `7.0` because the agent and AI plugin stacks need the modern WordPress AI surface. Override with `--wp trunk`, `--wp nightly`, or another supported Playground version.
+
+`--preview-public-url` is metadata and site-url alignment only; it does not make Playground listen on a public interface. Use a tunnel/proxy for remote access.
 
 ### `recipe validate`
 
@@ -255,6 +262,7 @@ Run a repeatable recipe.
 npm run wp-codebox -- recipe-run \
   --recipe ./examples/recipes/simple-plugin.json \
   --preview-hold 15m \
+  --preview-public-url https://example-tunnel.test/ \
   --json
 ```
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ interface RunOptions {
   metadata?: Record<string, unknown>
   blueprint?: unknown
   previewHoldSeconds?: number
+  previewPublicUrl?: string
   json: boolean
 }
 
@@ -38,6 +39,7 @@ interface RecipeRunOptions {
   recipePath: string
   artifactsDirectory?: string
   previewHoldSeconds?: number
+  previewPublicUrl?: string
   json: boolean
 }
 
@@ -271,8 +273,9 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         artifactsDirectory: options.artifactsDirectory ?? recipe.artifacts?.directory,
         metadata: {
           ...runtimeMetadata(options.artifactsDirectory ?? recipe.artifacts?.directory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
-          ...recipeRunMetadata(recipe, recipePath, workspaceMounts),
+          ...recipeRunMetadata(recipe, recipePath, workspaceMounts, options.previewPublicUrl),
         },
+        preview: previewSpec(options.previewPublicUrl),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -515,6 +518,10 @@ function runtimeMetadata(artifactsDirectory: string | undefined, wpVersion: stri
   }
 }
 
+function previewSpec(publicUrl: string | undefined): { publicUrl: string; siteUrl: string } | undefined {
+  return publicUrl ? { publicUrl, siteUrl: publicUrl } : undefined
+}
+
 function runMetadata(options: RunOptions): Record<string, unknown> {
   return {
     ...runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION),
@@ -523,6 +530,7 @@ function runMetadata(options: RunOptions): Record<string, unknown> {
       command: options.command,
       args: options.args,
       artifactsDirectory: options.artifactsDirectory,
+      previewPublicUrl: options.previewPublicUrl,
     }),
   }
 }
@@ -816,6 +824,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
         secretEnv: options.secretEnv,
         artifactsDirectory: options.artifactsDirectory,
         metadata: options.metadata ?? runMetadata(options),
+        preview: previewSpec(options.previewPublicUrl),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -933,6 +942,9 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
       case "--preview-hold":
         options.previewHoldSeconds = parsePreviewHoldSeconds(value)
         break
+      case "--preview-public-url":
+        options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
       case "--policy":
         options.policy = await parsePolicy(value)
         break
@@ -980,6 +992,9 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
       case "--preview-hold":
         options.previewHoldSeconds = parsePreviewHoldSeconds(value)
         break
+      case "--preview-public-url":
+        options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
       default:
         throw new Error(`Unknown option: ${name}`)
     }
@@ -990,6 +1005,25 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
   }
 
   return options as RecipeRunOptions
+}
+
+function parsePreviewPublicUrl(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`Invalid --preview-public-url value: ${value}`)
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("--preview-public-url must be an http or https URL")
+  }
+
+  if (!url.hostname) {
+    throw new Error("--preview-public-url must include a hostname")
+  }
+
+  return url.toString()
 }
 
 function parseRecipeValidateOptions(args: string[]): RecipeValidateOptions {
@@ -1272,7 +1306,7 @@ function runPolicy(command: string): RuntimePolicy {
   }
 }
 
-function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[]): Record<string, unknown> {
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], previewPublicUrl: string | undefined): Record<string, unknown> {
   return {
     recipe: {
       path: recipePath,
@@ -1294,6 +1328,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
     task: {
       kind: "recipe-run",
       recipePath,
+      previewPublicUrl,
       workflow: {
         steps: recipe.workflow.steps.map((step) => ({ command: step.command, args: step.args ?? [] })),
       },

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -143,6 +143,9 @@ Options:
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --artifacts <dir>    Artifact root directory.
   --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
+  --preview-public-url <url>
+                       Public tunnel/proxy URL to report in preview artifacts and pass to Playground as site-url.
+                       Remote access still requires an external tunnel/proxy; bind-host support depends on upstream Playground.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --json               Emit machine-readable JSON.
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -75,6 +75,12 @@ export interface RuntimeCreateSpec {
   artifactsDirectory?: string
   secretEnv?: Record<string, string>
   metadata?: Record<string, unknown>
+  preview?: RuntimePreviewSpec
+}
+
+export interface RuntimePreviewSpec {
+  publicUrl?: string
+  siteUrl?: string
 }
 
 export interface WorkspaceRecipeMount {
@@ -346,9 +352,12 @@ export interface ArtifactReview {
 
 export interface ArtifactPreview {
   url: string
+  localUrl?: string
+  publicUrl?: string
+  siteUrl?: string
   status: "available" | "expired-on-completion"
   lifecycle: "held-after-run" | "destroyed-on-completion"
-  source: "live-playground"
+  source: "live-playground" | "public-url-override"
   createdAt: string
   expiresAt?: string
   holdSeconds?: number

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -121,6 +121,7 @@ interface PlaygroundCliModule {
     mount: Array<{ hostPath: string; vfsPath: string }>
     blueprint?: unknown
     wp?: string
+    "site-url"?: string
   }): Promise<PlaygroundCliServer>
 }
 
@@ -612,19 +613,23 @@ class PlaygroundRuntime implements Runtime {
     }
 
     const server = await this.cliServerPromise
-    return server.serverUrl
+    return this.spec.preview?.publicUrl ?? server.serverUrl
   }
 
   private async previewInfo(createdAt: string, holdSeconds = 0): Promise<ArtifactPreview> {
     const server = await this.bootPlayground()
     const normalizedHoldSeconds = Math.max(0, Math.floor(holdSeconds))
     const expiresAt = normalizedHoldSeconds > 0 ? new Date(Date.now() + normalizedHoldSeconds * 1000).toISOString() : undefined
+    const publicUrl = this.spec.preview?.publicUrl
+    const siteUrl = this.spec.preview?.siteUrl
 
     return {
-      url: server.serverUrl,
+      url: publicUrl ?? server.serverUrl,
+      ...(publicUrl ? { publicUrl, localUrl: server.serverUrl } : {}),
+      ...(siteUrl ? { siteUrl } : {}),
       status: normalizedHoldSeconds > 0 ? "available" : "expired-on-completion",
       lifecycle: normalizedHoldSeconds > 0 ? "held-after-run" : "destroyed-on-completion",
-      source: "live-playground",
+      source: publicUrl ? "public-url-override" : "live-playground",
       createdAt,
       ...(expiresAt ? { expiresAt, holdSeconds: normalizedHoldSeconds } : {}),
     }
@@ -945,6 +950,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
         vfsPath: mount.target,
       })),
       wp: this.spec.environment.version,
+      "site-url": this.spec.preview?.siteUrl,
       blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy),
     })
   }

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -23,6 +23,8 @@ try {
       artifactsDirectory,
       "--preview-hold",
       "1s",
+      "--preview-public-url",
+      "https://preview.example.test/codebox/",
       "--json",
     ],
     {
@@ -33,7 +35,7 @@ try {
   const output = JSON.parse(stdout)
   assert.equal(output.success, true)
   assert.equal(output.runtime.status, "created")
-  assert.match(output.runtime.previewUrl, /^http:\/\/127\.0\.0\.1:/)
+  assert.equal(output.runtime.previewUrl, "https://preview.example.test/codebox/")
 
   const artifacts = output.artifacts
   assert.ok(artifacts.changedFilesPath, "artifact bundle should expose changedFilesPath")
@@ -43,7 +45,11 @@ try {
   assert.equal(artifacts.preview.status, "available")
   assert.equal(artifacts.preview.lifecycle, "held-after-run")
   assert.equal(artifacts.preview.holdSeconds, 1)
-  assert.match(artifacts.preview.url, /^http:\/\/127\.0\.0\.1:/)
+  assert.equal(artifacts.preview.url, "https://preview.example.test/codebox/")
+  assert.equal(artifacts.preview.publicUrl, "https://preview.example.test/codebox/")
+  assert.equal(artifacts.preview.siteUrl, "https://preview.example.test/codebox/")
+  assert.match(artifacts.preview.localUrl, /^http:\/\/127\.0\.0\.1:/)
+  assert.equal(artifacts.preview.source, "public-url-override")
 
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8"))
@@ -86,6 +92,7 @@ try {
   assert.equal(metadata.provenance.runtime.wordpressVersion, "latest")
   assert.equal(metadata.provenance.task.kind, "recipe-run")
   assert.equal(metadata.provenance.task.recipePath.endsWith("examples/recipes/seeded-plugin-workspace.json"), true)
+  assert.equal(metadata.provenance.task.previewPublicUrl, "https://preview.example.test/codebox/")
   assert.ok(metadata.provenance.task.inputs.workspaces.length > 0)
   assert.ok(metadata.provenance.mounts.some((mount: { target: string; mode: string; metadata?: { kind?: string } }) =>
     mount.target === "/wordpress/wp-content/plugins/seeded-helper" && mount.mode === "readwrite" && mount.metadata?.kind === "recipe-workspace",
@@ -118,6 +125,35 @@ try {
   assert.ok(review.actions.some((action: { kind: string; requiresApprovedFiles?: boolean }) => action.kind === "approve" && action.requiresApprovedFiles === true))
   assert.ok(review.actions.some((action: { kind: string }) => action.kind === "discard"))
   assert.ok(review.progress.some((event: { type: string; label: string }) => event.type === "complete" && event.label === "Ready for your review."))
+
+  const { stdout: runStdout } = await execFileAsync(
+    process.execPath,
+    [
+      "packages/cli/dist/index.js",
+      "run",
+      "--mount",
+      "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+      "--command",
+      "wordpress.run-php",
+      "--arg",
+      "code-file=./examples/simple-plugin/probe.php",
+      "--artifacts",
+      artifactsDirectory,
+      "--preview-public-url",
+      "https://run-preview.example.test/",
+      "--json",
+    ],
+    {
+      cwd: resolve(import.meta.dirname, ".."),
+      maxBuffer: 1024 * 1024 * 10,
+    },
+  )
+  const runOutput = JSON.parse(runStdout)
+  assert.equal(runOutput.success, true)
+  assert.equal(runOutput.runtime.status, "destroyed")
+  assert.equal(runOutput.artifacts.preview.url, "https://run-preview.example.test/")
+  assert.equal(runOutput.artifacts.preview.publicUrl, "https://run-preview.example.test/")
+  assert.match(runOutput.artifacts.preview.localUrl, /^http:\/\/127\.0\.0\.1:/)
 
   const agentMount = join(artifactsDirectory, "agent-mounted-component")
   await mkdir(agentMount, { recursive: true })


### PR DESCRIPTION
## Summary
- Adds `--preview-public-url` to `run` and `recipe-run` so callers can report a tunnel/proxy URL in artifact preview metadata and `files/review.json`.
- Preserves the local Playground URL as `preview.localUrl` while using the public URL for `runtime.previewUrl` and `preview.url`.
- Passes the public URL through to Playground as `site-url` so WordPress-generated links can align when supported, while documenting that remote preview still requires an external tunnel/proxy and true bind-host support depends on upstream Playground.

Refs https://github.com/chubes4/wp-codebox/issues/100
Upstream: https://github.com/WordPress/wordpress-playground/issues/3681

## Testing
- `npm run build`
- `npm run artifact-contract-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the CLI/runtime/docs/test changes; Chris remains responsible for review and merge.