### PR TITLE
Preserve failed command diagnostics in artifacts

### DIFF
--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -197,26 +197,49 @@ class PlaygroundRuntime implements Runtime {
       cwd: spec.cwd ?? null,
       timeoutMs: spec.timeoutMs ?? null,
     })
-    const result: ExecutionResult = {
-      id: commandId,
-      command: spec.command,
-      args: spec.args ?? [],
-      exitCode: 0,
-      stdout: await this.executePlaygroundCommand(spec),
-      stderr: "",
-      startedAt,
-      finishedAt: now(),
-    }
+    try {
+      const result: ExecutionResult = {
+        id: commandId,
+        command: spec.command,
+        args: spec.args ?? [],
+        exitCode: 0,
+        stdout: await this.executePlaygroundCommand(spec),
+        stderr: "",
+        startedAt,
+        finishedAt: now(),
+      }
 
-    this.commands.push(result)
-    this.recordEvent("runtime.command.finished", {
-      id: result.id,
-      command: result.command,
-      exitCode: result.exitCode,
-      startedAt: result.startedAt,
-      finishedAt: result.finishedAt,
-    })
-    return result
+      this.commands.push(result)
+      this.recordEvent("runtime.command.finished", {
+        id: result.id,
+        command: result.command,
+        exitCode: result.exitCode,
+        startedAt: result.startedAt,
+        finishedAt: result.finishedAt,
+      })
+      return result
+    } catch (error) {
+      const result: ExecutionResult = {
+        id: commandId,
+        command: spec.command,
+        args: spec.args ?? [],
+        exitCode: 1,
+        stdout: "",
+        stderr: errorMessage(error),
+        startedAt,
+        finishedAt: now(),
+      }
+
+      this.commands.push(result)
+      this.recordEvent("runtime.command.finished", {
+        id: result.id,
+        command: result.command,
+        exitCode: result.exitCode,
+        startedAt: result.startedAt,
+        finishedAt: result.finishedAt,
+      })
+      throw error
+    }
   }
 
   async observe(spec: ObservationSpec): Promise<ObservationResult> {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -184,6 +185,8 @@ try {
       const childError = error as { stdout?: string; stderr?: string }
       assert.match(childError.stdout ?? "", /wp-codebox-canary-cli-fatal/)
       assert.match(childError.stderr ?? "", /wp-codebox-canary-cli-fatal/)
+      const output = JSON.parse(childError.stdout ?? "{}")
+      assert.match(readFileSync(output.artifacts.commandsLogPath, "utf8"), /wp-codebox-canary-cli-fatal/)
       return true
     },
   )


### PR DESCRIPTION
## Summary
- Record failed Playground command executions before rethrowing so artifact command logs include the captured bootstrap/runtime diagnostic.
- Extend the issue #84 canary smoke to assert the literal failure message is present in the generated artifact log, not only CLI stdout/stderr.

Refs #84

## Tests
- npm run build && npm run artifact-contract-smoke
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected issue #84 and recent fixes, implemented the remaining failed-command artifact diagnostic path, added canary smoke coverage, and ran verification. Chris remains responsible for review and merge.