### PR TITLE
Fix held recipe previews

### DIFF
--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -16,8 +16,8 @@ smoke testing.
 
 Boots a Playground with bbPress installed from `wordpress.org/plugins`, mounts
 your plugin under test, seeds one forum and one topic, and auto-logs in as
-admin. Pair with `--preview-hold` and navigate the preview URL to the topic
-permalink to land on the bbPress reply form.
+admin. Pair with `--preview-hold` and navigate the preview URL from the seed
+output to land on the bbPress reply form.
 
 **Replace** the `inputs.mounts[0].source` value in the recipe with the path
 to the plugin you want to exercise against bbPress. The default points at
@@ -35,8 +35,8 @@ npm run wp-codebox -- recipe-run \
   --json
 ```
 
-The seed step's JSON output includes `topic_permalink` — that's the URL on
-the preview server where the bbPress reply form renders.
+The seed step's JSON output includes the preview URLs for the seeded reply
+form.
 
 #### Why this exists
 

--- a/examples/recipes/cookbook/bbpress-reply-editor-seed.php
+++ b/examples/recipes/cookbook/bbpress-reply-editor-seed.php
@@ -17,9 +17,19 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 // Activate the plugin under test if the recipe mounted one and it isn't
 // already active via blueprint.
-$plugin_under_test = 'plugin-under-test/plugin-under-test.php';
-if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin_under_test ) && ! is_plugin_active( $plugin_under_test ) ) {
-	activate_plugin( $plugin_under_test );
+$plugin_under_test = null;
+foreach ( get_plugins( '/plugin-under-test' ) as $plugin_file => $plugin_data ) {
+	if ( ! empty( $plugin_data['Name'] ) ) {
+		$plugin_under_test = 'plugin-under-test/' . $plugin_file;
+		break;
+	}
+}
+
+if ( $plugin_under_test && ! is_plugin_active( $plugin_under_test ) ) {
+	$activation_result = activate_plugin( $plugin_under_test );
+	if ( is_wp_error( $activation_result ) ) {
+		throw new RuntimeException( $activation_result->get_error_message() );
+	}
 }
 
 // Force bbPress to register its post types so wp_insert_post knows about them.
@@ -57,6 +67,18 @@ if ( is_wp_error( $topic_id ) || ! $topic_id ) {
 update_post_meta( $topic_id, '_bbp_forum_id', $forum_id );
 update_post_meta( $topic_id, '_bbp_topic_id', $topic_id );
 
+$reply_page_id = wp_insert_post( array(
+	'post_title'   => 'Cookbook bbPress Reply Editor',
+	'post_content' => sprintf( '[bbp-single-topic id="%d"]', (int) $topic_id ),
+	'post_status'  => 'publish',
+	'post_type'    => 'page',
+	'post_author'  => 1,
+) );
+
+if ( is_wp_error( $reply_page_id ) || ! $reply_page_id ) {
+	throw new RuntimeException( 'Failed to create reply editor page' );
+}
+
 // Set pretty permalinks so /forums/topic/<slug>/ resolves correctly.
 update_option( 'permalink_structure', '/%postname%/' );
 
@@ -71,10 +93,14 @@ wp_set_auth_cookie( 1, true );
 echo wp_json_encode( array(
 	'forum_id'           => (int) $forum_id,
 	'topic_id'           => (int) $topic_id,
+	'reply_page_id'      => (int) $reply_page_id,
 	'topic_permalink'    => get_permalink( $topic_id ),
+	'reply_page_url'     => get_permalink( $reply_page_id ),
 	'reply_form_anchor'  => get_permalink( $topic_id ) . '#new-post',
+	'reply_page_anchor'  => get_permalink( $reply_page_id ) . '#new-post',
 	'home_url'           => home_url( '/' ),
 	'bbpress_active'     => is_plugin_active( 'bbpress/bbpress.php' ),
-	'plugin_under_test'  => is_plugin_active( $plugin_under_test ),
+	'plugin_under_test'  => $plugin_under_test ? is_plugin_active( $plugin_under_test ) : false,
+	'plugin_file'        => $plugin_under_test,
 ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 echo "\n";

--- a/examples/recipes/cookbook/bbpress-reply-editor.json
+++ b/examples/recipes/cookbook/bbpress-reply-editor.json
@@ -17,6 +17,16 @@
           }
         },
         {
+          "step": "installTheme",
+          "themeData": {
+            "resource": "wordpress.org/themes",
+            "slug": "twentytwentyfive"
+          },
+          "options": {
+            "activate": true
+          }
+        },
+        {
           "step": "login",
           "username": "admin",
           "password": "password"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -901,6 +901,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
     await runtime.observe({ type: "runtime-info" })
     await runtime.observe({ type: "mounts" })
     artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
+    const runtimeInfo = options.previewHoldSeconds ? await runtime.info() : undefined
     await releaseRuntime(runtime, options.previewHoldSeconds, () => cleanupRecipeWorkspaces(workspaceMounts))
 
     const benchResultsList = executions
@@ -911,7 +912,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       success: true,
       schema: "wp-codebox/recipe-run/v1",
       recipePath,
-      runtime: await runtime.info(),
+      runtime: runtimeInfo ?? await runtime.info(),
       executions,
       ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
       ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
@@ -1416,11 +1417,12 @@ async function run(options: RunOptions): Promise<RunOutput> {
     await runtime.observe({ type: "runtime-info" })
     await runtime.observe({ type: "mounts" })
     artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
+    const runtimeInfo = options.previewHoldSeconds ? await runtime.info() : undefined
     await releaseRuntime(runtime, options.previewHoldSeconds)
 
     return {
       success: true,
-      runtime: await runtime.info(),
+      runtime: runtimeInfo ?? await runtime.info(),
       execution,
       artifacts,
     }
@@ -1457,11 +1459,9 @@ async function releaseRuntime(runtime: Runtime, previewHoldSeconds = 0, afterDes
     return
   }
 
-  setTimeout(() => {
-    void runtime.destroy().finally(() => {
-      void afterDestroy?.()
-    })
-  }, holdSeconds * 1000)
+  await new Promise((resolve) => setTimeout(resolve, holdSeconds * 1000))
+  await runtime.destroy()
+  await afterDestroy?.()
 }
 
 function parsePreviewHoldSeconds(value: string): number {


### PR DESCRIPTION
## Summary
- Keep `--preview-hold` recipe/run processes alive until the hold window expires so the reported Playground preview URL is actually reachable.
- Preserve the pre-destroy runtime info for held preview JSON output while keeping no-hold output behavior intact.
- Make the bbPress cookbook activate the mounted plugin by reading its plugin headers and emit the actual plugin file plus seeded reply-form URLs.

## Verification
- `npm run build`
- `npm run recipe-dry-run-smoke`
- `npm run artifact-contract-smoke` was started but aborted externally before completion.
- Manual wp-codebox + Playwright probe confirmed held preview URLs are reachable during the hold window.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the runtime hold fix, cookbook activation cleanup, and local verification commands; Chris reviewed and directed scope.