### PR TITLE
Support fixed preview ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,21 @@ npm run wp-codebox -- run \
 
 The v1 preview is a held live Playground runtime. When `--preview-hold` is omitted, the preview field still records the URL observed during capture, but the runtime is destroyed on command completion and the URL is marked `expired-on-completion`. Artifact replay from `blueprint.after.json` remains partial and is a separate future preview mode.
 
-When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url`, so WordPress-generated links can align with the public preview where Playground supports that option. The local Playground URL remains recorded as `preview.localUrl`.
+For tunnel-first review, reserve the local port in the tunnel command and pass that same port to WP Codebox. `--preview-port <n>` makes Playground use a fixed local port instead of its default random port, and `--preview-public-url <url>` reports the tunnel URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`.
+
+```bash
+kimaki tunnel -- sh -c 'npm run wp-codebox -- run \
+  --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin \
+  --command wordpress.run-php \
+  --arg code-file=./examples/simple-plugin/probe.php \
+  --artifacts ./artifacts \
+  --preview-hold 15m \
+  --preview-port 4173 \
+  --preview-public-url "$TRAFORO_URL" \
+  --json'
+```
+
+When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url`, so WordPress-generated links can align with the public preview where Playground supports that option. The local Playground URL remains recorded as `preview.localUrl`. If the fixed port is already occupied, WP Codebox fails clearly with `EADDRINUSE` and the requested `--preview-port` value.
 
 Remote preview access still requires an external tunnel or proxy. WP Codebox does not claim true bind-host support: a `--preview-bind` style option depends on upstream WordPress Playground exposing a host/bind API. Track upstream support in https://github.com/WordPress/wordpress-playground/issues/3681.
 
@@ -243,6 +257,7 @@ npm run wp-codebox -- run \
   --mount <host-path>:<sandbox-path>[:readonly|readwrite] \
   --command <command> \
   --arg <key=value> \
+  --preview-port <local-port> \
   --preview-public-url <public-tunnel-url> \
   --json
 ```
@@ -260,7 +275,7 @@ Supported runtime commands today:
 
 WP Codebox defaults to WordPress `7.0` because the agent and AI plugin stacks need the modern WordPress AI surface. Override with `--wp trunk`, `--wp nightly`, or another supported Playground version.
 
-`--preview-public-url` is metadata and site-url alignment only; it does not make Playground listen on a public interface. Use a tunnel/proxy for remote access.
+`--preview-port` fixes the local Playground port for tunnel/proxy wiring. Omit it to keep the current random-port behavior. `--preview-public-url` is metadata and site-url alignment only; it does not make Playground listen on a public interface. Use a tunnel/proxy for remote access.
 
 ### `recipe validate`
 
@@ -284,6 +299,7 @@ Run a repeatable recipe.
 npm run wp-codebox -- recipe-run \
   --recipe ./examples/recipes/simple-plugin.json \
   --preview-hold 15m \
+  --preview-port 4173 \
   --preview-public-url https://example-tunnel.test/ \
   --json
 ```

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
     "core-phpunit-command-smoke": "tsx scripts/core-phpunit-command-smoke.ts",
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
+    "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ interface RunOptions {
   blueprint?: unknown
   previewHoldSeconds?: number
   previewPublicUrl?: string
+  previewPort?: number
   json: boolean
 }
 
@@ -66,6 +67,7 @@ interface RecipeRunOptions {
   artifactsDirectory?: string
   previewHoldSeconds?: number
   previewPublicUrl?: string
+  previewPort?: number
   json: boolean
   dryRun: boolean
 }
@@ -852,9 +854,9 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         artifactsDirectory: options.artifactsDirectory ?? recipe.artifacts?.directory,
         metadata: {
           ...runtimeMetadata(options.artifactsDirectory ?? recipe.artifacts?.directory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
-          ...recipeRunMetadata(recipe, recipePath, workspaceMounts, options.previewPublicUrl),
+          ...recipeRunMetadata(recipe, recipePath, workspaceMounts, options.previewPublicUrl, options.previewPort),
         },
-        preview: previewSpec(options.previewPublicUrl),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -1097,8 +1099,16 @@ function runtimeMetadata(artifactsDirectory: string | undefined, wpVersion: stri
   }
 }
 
-function previewSpec(publicUrl: string | undefined): { publicUrl: string; siteUrl: string } | undefined {
-  return publicUrl ? { publicUrl, siteUrl: publicUrl } : undefined
+function previewSpec(publicUrl: string | undefined, port: number | undefined): { publicUrl?: string; siteUrl?: string; port?: number } | undefined {
+  if (!publicUrl && port === undefined) {
+    return undefined
+  }
+
+  return stripUndefined({
+    publicUrl,
+    siteUrl: publicUrl,
+    port,
+  })
 }
 
 function runMetadata(options: RunOptions): Record<string, unknown> {
@@ -1110,6 +1120,7 @@ function runMetadata(options: RunOptions): Record<string, unknown> {
       args: options.args,
       artifactsDirectory: options.artifactsDirectory,
       previewPublicUrl: options.previewPublicUrl,
+      previewPort: options.previewPort,
     }),
   }
 }
@@ -1403,7 +1414,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
         secretEnv: options.secretEnv,
         artifactsDirectory: options.artifactsDirectory,
         metadata: options.metadata ?? runMetadata(options),
-        preview: previewSpec(options.previewPublicUrl),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -1479,6 +1490,20 @@ function parsePreviewHoldSeconds(value: string): number {
   return seconds
 }
 
+function parsePreviewPort(value: string): number {
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`Invalid --preview-port value: ${value}`)
+  }
+
+  const port = Number.parseInt(trimmed, 10)
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error("--preview-port must be an integer between 1 and 65535")
+  }
+
+  return port
+}
+
 async function parseRunOptions(args: string[]): Promise<RunOptions> {
   const options: RunOptions = {
     mounts: [],
@@ -1523,6 +1548,9 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
         break
       case "--preview-public-url":
         options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
+      case "--preview-port":
+        options.previewPort = parsePreviewPort(value)
         break
       case "--policy":
         options.policy = await parsePolicy(value)
@@ -1578,6 +1606,9 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
         break
       case "--preview-public-url":
         options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
+      case "--preview-port":
+        options.previewPort = parsePreviewPort(value)
         break
       default:
         throw new Error(`Unknown option: ${name}`)
@@ -1941,7 +1972,7 @@ function runPolicy(command: string): RuntimePolicy {
   }
 }
 
-function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], previewPublicUrl: string | undefined): Record<string, unknown> {
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], previewPublicUrl: string | undefined, previewPort: number | undefined): Record<string, unknown> {
   return {
     recipe: {
       path: recipePath,
@@ -1964,6 +1995,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       kind: "recipe-run",
       recipePath,
       previewPublicUrl,
+      previewPort,
       workflow: {
         steps: recipe.workflow.steps.map((step) => ({ command: step.command, args: step.args ?? [] })),
       },

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -202,6 +202,7 @@ Options:
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --artifacts <dir>    Artifact root directory.
   --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
+  --preview-port <n>   Start Playground on a fixed local port. Defaults to a random available port.
   --preview-public-url <url>
                        Public tunnel/proxy URL to report in preview artifacts and pass to Playground as site-url.
                        Remote access still requires an external tunnel/proxy; bind-host support depends on upstream Playground.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -81,6 +81,7 @@ export interface RuntimeCreateSpec {
 export interface RuntimePreviewSpec {
   publicUrl?: string
   siteUrl?: string
+  port?: number
 }
 
 export interface WorkspaceRecipeMount {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto"
 import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises"
+import { createServer } from "node:net"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { assertRuntimeCommandAllowed } from "@chubes4/wp-codebox-core"
 import {
@@ -73,6 +74,15 @@ class PlaygroundCommandCrashError extends Error {
   constructor(readonly command: string, readonly cause: unknown) {
     super(`${command} crashed before producing a structured response\n\n${errorMessage(cause)}`)
     this.name = "PlaygroundCommandCrashError"
+  }
+}
+
+class PlaygroundPreviewPortUnavailableError extends Error {
+  readonly code = "wp-codebox-preview-port-in-use"
+
+  constructor(readonly port: number, readonly cause: unknown) {
+    super(`--preview-port ${port} is unavailable: EADDRINUSE. Choose another port or stop the process currently using it.`)
+    this.name = "PlaygroundPreviewPortUnavailableError"
   }
 }
 
@@ -939,20 +949,31 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
 
   private async startPlayground(): Promise<PlaygroundCliServer> {
     const { runCLI } = (await import("@wp-playground/cli")) as unknown as PlaygroundCliModule
+    if (this.spec.preview?.port) {
+      await assertPreviewPortAvailable(this.spec.preview.port)
+    }
 
-    return runCLI({
-      command: "server",
-      port: 0,
-      quiet: true,
-      skipBrowser: true,
-      mount: this.mounts.map((mount) => ({
-        hostPath: mount.source,
-        vfsPath: mount.target,
-      })),
-      wp: this.spec.environment.version,
-      "site-url": this.spec.preview?.siteUrl,
-      blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy),
-    })
+    try {
+      return await runCLI({
+        command: "server",
+        port: this.spec.preview?.port ?? 0,
+        quiet: true,
+        skipBrowser: true,
+        mount: this.mounts.map((mount) => ({
+          hostPath: mount.source,
+          vfsPath: mount.target,
+        })),
+        wp: this.spec.environment.version,
+        "site-url": this.spec.preview?.siteUrl,
+        blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy),
+      })
+    } catch (error) {
+      if (this.spec.preview?.port && errorHasCode(error, "EADDRINUSE")) {
+        throw new PlaygroundPreviewPortUnavailableError(this.spec.preview.port, error)
+      }
+
+      throw error
+    }
   }
 
   private async observeStub(spec: ObservationSpec): Promise<unknown> {
@@ -970,6 +991,44 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
 
 export function createPlaygroundRuntimeBackend(): RuntimeBackend {
   return new PlaygroundRuntimeBackend()
+}
+
+function errorHasCode(error: unknown, code: string): boolean {
+  if (!error || typeof error !== "object") {
+    return false
+  }
+
+  if ("code" in error && error.code === code) {
+    return true
+  }
+
+  if ("cause" in error && errorHasCode(error.cause, code)) {
+    return true
+  }
+
+  return error instanceof Error && error.message.includes(code)
+}
+
+async function assertPreviewPortAvailable(port: number): Promise<void> {
+  const server = createServer()
+  try {
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once("error", rejectListen)
+      server.listen(port, "127.0.0.1", () => resolveListen())
+    })
+  } catch (error) {
+    if (errorHasCode(error, "EADDRINUSE")) {
+      throw new PlaygroundPreviewPortUnavailableError(port, error)
+    }
+
+    throw error
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => error ? rejectClose(error) : resolveClose())
+      })
+    }
+  }
 }
 
 async function writeJsonLines(path: string, records: unknown[], redactor: ArtifactRedactor, artifactRoot: string): Promise<void> {

--- a/scripts/preview-port-smoke.ts
+++ b/scripts/preview-port-smoke.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, rm } from "node:fs/promises"
+import { createServer, type Server } from "node:net"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "..")
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-preview-port-"))
+
+try {
+  const runPort = await reserveFreePort()
+  const runOutput = await runCliJson([
+    "run",
+    "--mount",
+    "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+    "--command",
+    "wordpress.run-php",
+    "--arg",
+    "code-file=./examples/simple-plugin/probe.php",
+    "--artifacts",
+    artifactsDirectory,
+    "--preview-port",
+    String(runPort),
+    "--preview-public-url",
+    "https://run-preview.example.test/",
+    "--json",
+  ])
+  assert.equal(runOutput.success, true)
+  assert.equal(new URL(runOutput.artifacts.preview.localUrl).port, String(runPort))
+  assert.equal(runOutput.artifacts.preview.url, "https://run-preview.example.test/")
+
+  const recipePort = await reserveFreePort()
+  const recipeOutput = await runCliJson([
+    "recipe-run",
+    "--recipe",
+    "./examples/recipes/seeded-plugin-workspace.json",
+    "--artifacts",
+    artifactsDirectory,
+    "--preview-port",
+    String(recipePort),
+    "--json",
+  ])
+  assert.equal(recipeOutput.success, true)
+  assert.equal(new URL(recipeOutput.artifacts.preview.url).port, String(recipePort))
+  assert.equal(recipeOutput.artifacts.preview.status, "expired-on-completion")
+
+  await assert.rejects(
+    () => runCliJson([
+      "run",
+      "--mount",
+      "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+      "--command",
+      "wordpress.run-php",
+      "--arg",
+      "code-file=./examples/simple-plugin/probe.php",
+      "--artifacts",
+      artifactsDirectory,
+      "--preview-port",
+      String(recipePort),
+      "--json",
+    ], recipePort),
+    (error) => {
+      const childError = error as { stdout?: string; stderr?: string }
+      assert.match(`${childError.stdout ?? ""}\n${childError.stderr ?? ""}`, /EADDRINUSE/)
+      assert.match(`${childError.stdout ?? ""}\n${childError.stderr ?? ""}`, new RegExp(`--preview-port ${recipePort}`))
+      return true
+    },
+  )
+
+  await assert.rejects(
+    () => runCliJson([
+      "run",
+      "--mount",
+      "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+      "--command",
+      "wordpress.run-php",
+      "--preview-port",
+      "0",
+      "--json",
+    ]),
+    (error) => {
+      const childError = error as { stdout?: string; stderr?: string }
+      assert.match(`${childError.stdout ?? ""}\n${childError.stderr ?? ""}`, /--preview-port must be an integer between 1 and 65535/)
+      return true
+    },
+  )
+} finally {
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}
+
+async function runCliJson(args: string[], heldPort?: number): Promise<any> {
+  let server: Server | undefined
+  if (heldPort !== undefined) {
+    server = await listenOnPort(heldPort)
+  }
+
+  try {
+    const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", ...args], {
+      cwd: repoRoot,
+      maxBuffer: 1024 * 1024 * 10,
+    })
+    return JSON.parse(stdout)
+  } finally {
+    await closeServer(server)
+  }
+}
+
+async function reserveFreePort(): Promise<number> {
+  const server = await listenOnPort(0)
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const port = address.port
+  await closeServer(server)
+  return port
+}
+
+async function listenOnPort(port: number): Promise<Server> {
+  const server = createServer()
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen)
+    server.listen(port, "127.0.0.1", () => resolveListen())
+  })
+  return server
+}
+
+async function closeServer(server: Server | undefined): Promise<void> {
+  if (!server?.listening) {
+    return
+  }
+
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose())
+  })
+}


### PR DESCRIPTION
## Summary
- Add `--preview-port <n>` to `wp-codebox run` and `recipe-run` so callers can bind Playground to a known local port for tunnel/proxy wiring.
- Preserve random-port behavior when unset, pass the configured port into the Playground CLI server, and surface fixed-port `EADDRINUSE` failures with the requested port.
- Document the tunnel-first pattern with `--preview-port` plus `--preview-public-url`, and add a preview-port smoke test for run, recipe-run, invalid ports, and occupied ports.

Fixes https://github.com/chubes4/wp-codebox/issues/109

## Tests
- `npm run build`
- `npm run preview-port-smoke`
- `npm run artifact-contract-smoke`
- `npm run runtime-episode-smoke`
- `npm run core-phpunit-command-smoke`
- `npm run recipe-bench-smoke`
- `npm run recipe-dry-run-smoke`
- `npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`
- `npm run check` was started and passed through build, discovery, policy validation, WordPress plugin smoke, package distribution smoke, then was manually aborted during `artifact-contract-smoke`; the remaining checks were rerun individually above.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the CLI/runtime preview-port option, docs, focused smoke coverage, and local verification under Chris's requested issue scope.