### PR TITLE
Fix fixed-port preview response framing

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,12 @@
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
     "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",
+    "preview-response-body-smoke": "tsx scripts/preview-response-body-smoke.ts",
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-response-body-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises"
-import { createServer } from "node:net"
+import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type ServerResponse } from "node:http"
+import { createServer as createNetServer } from "node:net"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { assertRuntimeCommandAllowed } from "@chubes4/wp-codebox-core"
 import {
@@ -120,6 +121,11 @@ interface PlaygroundCliServer {
   }
   serverUrl: string
   [Symbol.asyncDispose](): Promise<void>
+}
+
+interface PlaygroundPreviewProxy {
+  serverUrl: string
+  dispose(): Promise<void>
 }
 
 interface PlaygroundCliModule {
@@ -977,9 +983,9 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     }
 
     try {
-      return await runCLI({
+      const server = await runCLI({
         command: "server",
-        port: this.spec.preview?.port ?? 0,
+        port: 0,
         quiet: true,
         skipBrowser: true,
         mount: this.mounts.map((mount) => ({
@@ -990,6 +996,12 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
         "site-url": this.spec.preview?.siteUrl,
         blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy),
       })
+
+      if (!this.spec.preview?.port) {
+        return server
+      }
+
+      return await withPreviewProxy(server, this.spec.preview.port)
     } catch (error) {
       if (this.spec.preview?.port && errorHasCode(error, "EADDRINUSE")) {
         throw new PlaygroundPreviewPortUnavailableError(this.spec.preview.port, error)
@@ -1016,6 +1028,110 @@ export function createPlaygroundRuntimeBackend(): RuntimeBackend {
   return new PlaygroundRuntimeBackend()
 }
 
+async function withPreviewProxy(server: PlaygroundCliServer, port: number): Promise<PlaygroundCliServer> {
+  let proxy: PlaygroundPreviewProxy | undefined
+  try {
+    proxy = await startPreviewProxy(server.serverUrl, port)
+  } catch (error) {
+    await server[Symbol.asyncDispose]()
+    throw error
+  }
+
+  return {
+    ...server,
+    serverUrl: proxy.serverUrl,
+    async [Symbol.asyncDispose]() {
+      await proxy.dispose()
+      await server[Symbol.asyncDispose]()
+    },
+  }
+}
+
+async function startPreviewProxy(targetUrl: string, port: number): Promise<PlaygroundPreviewProxy> {
+  const target = new URL(targetUrl)
+  const proxy = createHttpServer((incoming, outgoing) => {
+    const targetRequest = httpRequest(
+      {
+        protocol: target.protocol,
+        hostname: target.hostname,
+        port: target.port,
+        method: incoming.method,
+        path: incoming.url ?? "/",
+        headers: proxyRequestHeaders(incoming.headers, target),
+      },
+      (targetResponse) => {
+        const chunks: Buffer[] = []
+        targetResponse.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+        targetResponse.on("end", () => {
+          const body = Buffer.concat(chunks)
+          outgoing.writeHead(targetResponse.statusCode ?? 502, targetResponse.statusMessage, proxyResponseHeaders(targetResponse.headers, body.byteLength))
+          outgoing.end(body)
+        })
+      },
+    )
+
+    targetRequest.on("error", (error) => writeProxyError(outgoing, error))
+    incoming.on("error", () => targetRequest.destroy())
+    incoming.pipe(targetRequest)
+  })
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    proxy.once("error", rejectListen)
+    proxy.listen(port, "127.0.0.1", () => resolveListen())
+  })
+
+  return {
+    serverUrl: `http://127.0.0.1:${port}`,
+    async dispose() {
+      if (!proxy.listening) {
+        return
+      }
+
+      await new Promise<void>((resolveClose, rejectClose) => {
+        proxy.close((error) => error ? rejectClose(error) : resolveClose())
+      })
+    },
+  }
+}
+
+function proxyRequestHeaders(headers: IncomingHttpHeaders, target: URL): IncomingHttpHeaders {
+  const forwarded = { ...headers }
+  delete forwarded.connection
+  delete forwarded.host
+  delete forwarded["transfer-encoding"]
+
+  return {
+    ...forwarded,
+    host: target.host,
+  }
+}
+
+function proxyResponseHeaders(headers: IncomingHttpHeaders, bodyLength: number): IncomingHttpHeaders {
+  const forwarded = { ...headers }
+  delete forwarded.connection
+  delete forwarded["content-length"]
+  delete forwarded["transfer-encoding"]
+
+  return {
+    ...forwarded,
+    "content-length": String(bodyLength),
+  }
+}
+
+function writeProxyError(outgoing: ServerResponse, error: Error): void {
+  if (outgoing.headersSent) {
+    outgoing.destroy(error)
+    return
+  }
+
+  const body = Buffer.from(`Preview proxy failed: ${error.message}\n`, "utf8")
+  outgoing.writeHead(502, {
+    "content-type": "text/plain; charset=utf-8",
+    "content-length": String(body.byteLength),
+  })
+  outgoing.end(body)
+}
+
 function errorHasCode(error: unknown, code: string): boolean {
   if (!error || typeof error !== "object") {
     return false
@@ -1033,7 +1149,7 @@ function errorHasCode(error: unknown, code: string): boolean {
 }
 
 async function assertPreviewPortAvailable(port: number): Promise<void> {
-  const server = createServer()
+  const server = createNetServer()
   try {
     await new Promise<void>((resolveListen, rejectListen) => {
       server.once("error", rejectListen)

--- a/scripts/preview-response-body-smoke.ts
+++ b/scripts/preview-response-body-smoke.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { createServer, type Server } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createRuntime } from "@chubes4/wp-codebox-core"
+import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
+
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-preview-body-"))
+
+try {
+  const previewPort = await reserveFreePort()
+  const runtime = await createRuntime(
+    {
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", name: "preview-body-smoke", version: "7.0", blueprint: { steps: [] } },
+      policy: {
+        network: "deny",
+        filesystem: "readwrite-mounts",
+        commands: ["wordpress.wp-cli"],
+        secrets: "none",
+        approvals: "never",
+      },
+      artifactsDirectory,
+      metadata: {
+        runtime: { version: "0.0.0" },
+        task: { kind: "preview-response-body-smoke" },
+      },
+      preview: { port: previewPort },
+    },
+    createPlaygroundRuntimeBackend(),
+  )
+
+  try {
+    const createPost = await runtime.execute({
+      command: "wordpress.wp-cli",
+      args: ["command=post create --post_type=page --post_status=publish --post_title='Preview Body Smoke' --post_content='Tunnel-visible response body' --porcelain"],
+    })
+    assert.equal(createPost.exitCode, 0)
+
+    const postId = createPost.stdout.trim()
+    assert.match(postId, /^\d+$/)
+
+    const previewUrl = (await runtime.info()).previewUrl
+    assert.equal(previewUrl, `http://127.0.0.1:${previewPort}`)
+
+    const response = await fetch(`${previewUrl}/?p=${postId}`)
+    const body = await response.text()
+
+    assert.equal(response.status, 200)
+    assert.match(body, /Preview Body Smoke/)
+    assert.match(body, /Tunnel-visible response body/)
+    assertExplicitResponseFraming(response, body)
+  } finally {
+    await runtime.destroy()
+  }
+
+  console.log("Preview response body smoke passed")
+} finally {
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}
+
+async function reserveFreePort(): Promise<number> {
+  const server = await listenOnPort(0)
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const port = address.port
+  await closeServer(server)
+  return port
+}
+
+async function listenOnPort(port: number): Promise<Server> {
+  const server = createServer()
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen)
+    server.listen(port, "127.0.0.1", () => resolveListen())
+  })
+  return server
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return
+  }
+
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose())
+  })
+}
+
+function assertExplicitResponseFraming(response: Response, body: string): void {
+  const contentLength = response.headers.get("content-length")
+  const transferEncoding = response.headers.get("transfer-encoding")
+
+  assert.ok(
+    contentLength === String(Buffer.byteLength(body)) || transferEncoding === "chunked",
+    `expected content-length=${Buffer.byteLength(body)} or transfer-encoding=chunked; got content-length=${contentLength}, transfer-encoding=${transferEncoding}`,
+  )
+}


### PR DESCRIPTION
## Summary
- Route fixed-port Playground previews through a WP Codebox-owned loopback proxy so tunnel clients get explicitly framed response bodies.
- Preserve existing preview metadata by reporting the requested fixed port while keeping the raw Playground server internal.
- Add a focused smoke test that fetches a published preview page and asserts a non-empty body plus explicit `Content-Length` or `Transfer-Encoding: chunked` framing.

Fixes https://github.com/chubes4/wp-codebox/issues/118

## Tests
- `npm run build`
- `npm run preview-response-body-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox preview response path, drafted the fixed-port preview proxy and smoke coverage, and ran local verification. Chris remains responsible for review and merge.