### PR TITLE
Fix preview public URL canonical redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ kimaki tunnel -- sh -c 'npm run wp-codebox -- run \
   --json'
 ```
 
-When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url`, so WordPress-generated links can align with the public preview where Playground supports that option. The local Playground URL remains recorded as `preview.localUrl`. If the fixed port is already occupied, WP Codebox fails clearly with `EADDRINUSE` and the requested `--preview-port` value.
+When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url` and defines `WP_HOME` / `WP_SITEURL` in the sandbox config, so WordPress-generated links and canonical redirects align with the public preview URL. The local Playground URL remains recorded as `preview.localUrl`. If the fixed port is already occupied, WP Codebox fails clearly with `EADDRINUSE` and the requested `--preview-port` value.
 
 Remote preview access still requires an external tunnel or proxy. WP Codebox does not claim true bind-host support: a `--preview-bind` style option depends on upstream WordPress Playground exposing a host/bind API. Track upstream support in https://github.com/WordPress/wordpress-playground/issues/3681.
 

--- a/package.json
+++ b/package.json
@@ -40,11 +40,12 @@
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
     "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",
+    "preview-public-url-canonical-smoke": "tsx scripts/preview-public-url-canonical-smoke.ts",
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/runtime-playground/src/blueprint.ts
+++ b/packages/runtime-playground/src/blueprint.ts
@@ -16,17 +16,19 @@ export function normalizeBlueprint(blueprint: unknown): { extraLibraries?: unkno
   }
 }
 
-export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpec["policy"]): unknown {
-  if (!policy.commands.includes("wordpress.wp-cli")) {
+export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpec["policy"], siteUrl?: string): unknown {
+  if (!siteUrl && !policy.commands.includes("wordpress.wp-cli")) {
     return blueprint
   }
 
   const base = !blueprint || typeof blueprint !== "object" || Array.isArray(blueprint) ? {} : blueprint as Record<string, unknown>
+  const steps = Array.isArray(base.steps) ? base.steps : []
   const extraLibraries = Array.isArray(base.extraLibraries) ? base.extraLibraries : []
 
   return {
     ...base,
-    extraLibraries: [...new Set([...extraLibraries, "wp-cli"])],
+    ...(policy.commands.includes("wordpress.wp-cli") ? { extraLibraries: [...new Set([...extraLibraries, "wp-cli"])] } : {}),
+    ...(siteUrl ? { steps: [{ step: "defineSiteUrl", siteUrl }, ...steps] } : {}),
   }
 }
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -988,7 +988,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
         })),
         wp: this.spec.environment.version,
         "site-url": this.spec.preview?.siteUrl,
-        blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy),
+        blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy, this.spec.preview?.siteUrl),
       })
     } catch (error) {
       if (this.spec.preview?.port && errorHasCode(error, "EADDRINUSE")) {

--- a/scripts/preview-public-url-canonical-smoke.ts
+++ b/scripts/preview-public-url-canonical-smoke.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { createServer, type Server } from "node:net"
+import { resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const port = await reserveFreePort()
+const publicUrl = "https://preview-public.example.test"
+const child = spawn(process.execPath, [
+  "packages/cli/dist/index.js",
+  "run",
+  "--mount",
+  "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+  "--command",
+  "wordpress.run-php",
+  "--arg",
+  "code=update_option('permalink_structure', '/%postname%/'); flush_rewrite_rules();",
+  "--preview-port",
+  String(port),
+  "--preview-public-url",
+  publicUrl,
+  "--preview-hold",
+  "20s",
+  "--json",
+], { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
+const exitPromise = new Promise<number | null>((resolveExit) => child.once("exit", resolveExit))
+
+let stdout = ""
+let stderr = ""
+child.stdout.setEncoding("utf8")
+child.stderr.setEncoding("utf8")
+child.stdout.on("data", (chunk) => { stdout += chunk })
+child.stderr.on("data", (chunk) => { stderr += chunk })
+
+try {
+  const location = await waitForCanonicalRedirect(port)
+  assert.equal(location, `${publicUrl}/hello-world`)
+  assert.ok(!location.includes("127.0.0.1"), "canonical redirect must not emit loopback host")
+} finally {
+  if (child.exitCode === null) {
+    child.kill("SIGTERM")
+  }
+}
+
+const exitCode = await exitPromise
+assert.ok(exitCode === 0 || exitCode === null, `wp-codebox exited with ${exitCode}\nstdout: ${stdout}\nstderr: ${stderr}`)
+
+async function waitForCanonicalRedirect(listenPort: number): Promise<string> {
+  const deadline = Date.now() + 18000
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${listenPort}/hello-world`, { redirect: "manual" })
+      const location = response.headers.get("location")
+      if (response.status >= 300 && response.status < 400 && location) {
+        return new URL(location, publicUrl).toString()
+      }
+      lastError = new Error(`Unexpected response ${response.status} with location ${location ?? "<none>"}`)
+    } catch (error) {
+      lastError = error
+    }
+
+    await new Promise((resolvePoll) => setTimeout(resolvePoll, 250))
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError))
+}
+
+async function reserveFreePort(): Promise<number> {
+  const server = await listenOnPort(0)
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const reservedPort = address.port
+  await closeServer(server)
+  return reservedPort
+}
+
+async function listenOnPort(listenPort: number): Promise<Server> {
+  const server = createServer()
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen)
+    server.listen(listenPort, "127.0.0.1", () => resolveListen())
+  })
+  return server
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return
+  }
+
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose())
+  })
+}


### PR DESCRIPTION
## Summary
- Defines the preview public URL through Playground's `defineSiteUrl` blueprint step so `WP_HOME` and `WP_SITEURL` are available during request handling.
- Adds a held-preview smoke that requests the loopback port and verifies canonical redirects target the configured public URL instead of `127.0.0.1`.
- Updates preview docs to describe the stronger site URL alignment behavior.

Fixes https://github.com/chubes4/wp-codebox/issues/117

## Testing
- `npm run build && npm run preview-public-url-canonical-smoke`
- `npm run build && npm run preview-public-url-canonical-smoke && npm run preview-port-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WP Codebox preview URL canonical redirect path, drafted the runtime fix, smoke coverage, docs update, and ran local verification. Chris remains responsible for review and merge.