### PR TITLE
Add browser probe artifact capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,10 +302,13 @@ Supported runtime commands today:
 - `wordpress.run-php`: run PHP; accepts `code=<php>` or `code-file=<path>`.
 - `wordpress.wp-cli`: run WP-CLI; accepts `command='wp option get home'` or plain args.
 - `wordpress.ability`: execute a registered WordPress Ability; accepts `name=<ability>` and optional JSON `input=<object>`.
+- `wordpress.browser-probe`: boot the live preview, visit `url=<path-or-url>` with Playwright, and capture browser console, page errors, and screenshot artifacts under `files/browser/`.
 
 `wordpress.run-php` loads `/wordpress/wp-load.php` by default. Use `--arg bootstrap=none` for raw PHP.
 
 `wordpress.wp-cli` automatically enables Playground's `wp-cli` extra library when the command is allowed by runtime policy.
+
+`wordpress.browser-probe` accepts `wait-for=domcontentloaded|load|networkidle|selector:<selector>|duration`, `duration=<n>s`, and `capture=console,errors,screenshot`. It records `files/browser/console.jsonl`, `files/browser/errors.jsonl`, `files/browser/screenshot.png`, and `files/browser/summary.json` when those captures are enabled, and the artifact review includes a concise browser summary with counts.
 
 WP Codebox defaults to WordPress `7.0` because the agent and AI plugin stacks need the modern WordPress AI surface. Override with `--wp trunk`, `--wp nightly`, or another supported Playground version.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2970,7 +2970,6 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -2989,7 +2988,6 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -3002,7 +3000,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3770,7 +3767,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@chubes4/wp-codebox-core": "file:../runtime-core",
-        "@wp-playground/cli": "3.1.30"
+        "@wp-playground/cli": "3.1.30",
+        "playwright": "^1.60.0"
       }
     },
     "packages/wordpress-plugin": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
     "recipe-browser-smoke": "tsx scripts/recipe-browser-smoke.ts",
+    "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",
     "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",
     "preview-public-url-canonical-smoke": "tsx scripts/preview-public-url-canonical-smoke.ts",
     "preview-response-body-smoke": "tsx scripts/preview-response-body-smoke.ts",
@@ -47,7 +48,7 @@
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -407,6 +407,19 @@ const commandCatalog: CommandMetadata[] = [
     recipe: true,
   },
   {
+    id: "wordpress.browser-probe",
+    description: "Open the live Playground preview in Playwright and capture browser console, page errors, and screenshot artifacts.",
+    acceptedArgs: [
+      { name: "url", description: "Preview path or absolute URL to visit.", required: true, format: "path or URL" },
+      { name: "wait-for", description: "Navigation wait condition.", format: "domcontentloaded|load|networkidle|selector:<selector>|duration" },
+      { name: "duration", description: "Extra capture duration, or wait time when wait-for=duration.", format: "duration, e.g. 2s or 500ms" },
+      { name: "capture", description: "Comma-separated artifacts to capture.", format: "console,errors,screenshot" },
+    ],
+    outputShape: "JSON summary plus files/browser/console.jsonl, errors.jsonl, summary.json, and screenshot.png when captured.",
+    policyRequirement: "Runtime policy commands must include wordpress.browser-probe.",
+    recipe: true,
+  },
+  {
     id: "wp-codebox.agent-runtime-probe",
     description: "Recipe-only probe that boots Agents API, Data Machine, and Data Machine Code and verifies the stack loads.",
     acceptedArgs: [
@@ -1934,6 +1947,32 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
 
   if (step.command === "wordpress.wp-cli" && recipeWpCliCommandFromArgs(step.args ?? []).length === 0) {
     addIssue("missing-command", `${path}.args`, "wordpress.wp-cli requires a non-empty command.")
+    return
+  }
+
+  if (step.command === "wordpress.browser-probe") {
+    if (!recipeStepArgValue(step.args ?? [], "url")?.trim()) {
+      addIssue("missing-url", `${path}.args`, "wordpress.browser-probe requires url=<path-or-url>.")
+    }
+
+    const waitFor = recipeStepArgValue(step.args ?? [], "wait-for")
+    if (waitFor && !["domcontentloaded", "load", "networkidle", "duration"].includes(waitFor) && !waitFor.startsWith("selector:")) {
+      addIssue("invalid-wait-for", `${path}.args`, "wordpress.browser-probe wait-for must be domcontentloaded, load, networkidle, selector:<selector>, or duration.")
+    }
+
+    const duration = recipeStepArgValue(step.args ?? [], "duration")
+    if (duration && !/^(\d+(?:\.\d+)?)(ms|s)$/.test(duration)) {
+      addIssue("invalid-duration", `${path}.args`, "wordpress.browser-probe duration must look like 500ms or 2s.")
+    }
+
+    const capture = recipeStepArgValue(step.args ?? [], "capture")
+    if (capture) {
+      for (const item of capture.split(",").map((value) => value.trim()).filter(Boolean)) {
+        if (!["console", "errors", "screenshot"].includes(item)) {
+          addIssue("invalid-capture", `${path}.args`, `wordpress.browser-probe capture does not support: ${item}`)
+        }
+      }
+    }
     return
   }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -198,7 +198,7 @@ Options:
   --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
-  --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.wp-cli, wordpress.ability, and wordpress.bench.
+  --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --artifacts <dir>    Artifact root directory.
   --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -347,8 +347,21 @@ export interface ArtifactReview {
     changedFiles: string
     testResults?: string
   }
+  browser?: ArtifactReviewBrowserSummary
   redaction?: ArtifactRedactionSummary
   riskFlags: string[]
+}
+
+export interface ArtifactReviewBrowserSummary {
+  summary: string
+  probes: Array<{
+    url: string
+    consoleMessages: number
+    errors: number
+    screenshot?: string
+    console?: string
+    errorsFile?: string
+  }>
 }
 
 export interface ArtifactPreview {

--- a/packages/runtime-playground/package.json
+++ b/packages/runtime-playground/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@chubes4/wp-codebox-core": "file:../runtime-core",
-    "@wp-playground/cli": "3.1.30"
+    "@wp-playground/cli": "3.1.30",
+    "playwright": "^1.60.0"
   }
 }

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -8,6 +8,7 @@ import type {
   ArtifactProvenance,
   ArtifactRedactionSummary,
   ArtifactReview,
+  ArtifactReviewBrowserSummary,
   ArtifactTestResults,
   MountSpec,
   RuntimeCreateSpec,
@@ -191,6 +192,7 @@ export function buildArtifactReview({
   runtimeCreatedAt,
   mounts,
   preview,
+  browser,
 }: {
   artifactId: string
   createdAt: string
@@ -201,6 +203,7 @@ export function buildArtifactReview({
   runtimeCreatedAt: string
   mounts: MountSpec[]
   preview?: ArtifactPreview
+  browser?: ArtifactReviewBrowserSummary
 }): ArtifactReview {
   const stats = {
     added: changedFiles.files.filter((file) => file.status === "added").length,
@@ -279,6 +282,7 @@ export function buildArtifactReview({
       changedFiles: "files/changed-files.json",
       testResults: "files/test-results.json",
     },
+    ...(browser ? { browser } : {}),
     riskFlags: [],
   }
 }

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -32,6 +32,7 @@ import type {
   ArtifactManifest,
   ArtifactManifestFile,
   ArtifactPreview,
+  ArtifactReviewBrowserSummary,
   ArtifactSpec,
   ExecutionResult,
   ExecutionSpec,
@@ -45,6 +46,7 @@ import type {
   RuntimeInfo,
   Snapshot,
 } from "@chubes4/wp-codebox-core"
+import type { ConsoleMessage, Page } from "playwright"
 
 function now(): string {
   return new Date().toISOString()
@@ -141,6 +143,29 @@ interface PlaygroundCliModule {
   }): Promise<PlaygroundCliServer>
 }
 
+interface BrowserProbeArtifact {
+  url: string
+  files: {
+    console?: string
+    errors?: string
+    screenshot?: string
+    summary: string
+  }
+  summary: {
+    consoleMessages: number
+    errors: number
+    screenshot: boolean
+  }
+}
+
+interface BrowserProbeErrorRecord {
+  type: "pageerror" | "probe-error"
+  name: string
+  message: string
+  stack?: string
+  timestamp: string
+}
+
 export class PlaygroundRuntimeBackend implements RuntimeBackend {
   readonly kind = "wordpress-playground" as const
 
@@ -157,6 +182,7 @@ class PlaygroundRuntime implements Runtime {
   private readonly commands: ExecutionResult[] = []
   private readonly observations: ObservationResult[] = []
   private readonly events: LifecycleEvent[] = []
+  private readonly browserProbes: BrowserProbeArtifact[] = []
   private readonly artifactRoot: string
   private cliServerPromise?: Promise<PlaygroundCliServer>
 
@@ -316,7 +342,9 @@ class PlaygroundRuntime implements Runtime {
     const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
     const redactor = new ArtifactRedactor(this.spec.secretEnv)
+    await this.redactBrowserArtifacts(redactor)
     const preview = await this.previewInfo(createdAt, spec.previewHoldSeconds)
+    const browser = this.browserReviewSummary()
 
     const runtime = await this.info()
     const capturedMounts = await this.captureMountedFiles(filesDirectory, redactor)
@@ -363,6 +391,7 @@ class PlaygroundRuntime implements Runtime {
       runtimeCreatedAt: this.createdAt,
       mounts: this.mounts,
       preview,
+      browser,
     })
     const artifactFiles = {
       changedFiles: relative(this.artifactRoot, changedFilesPath),
@@ -370,6 +399,7 @@ class PlaygroundRuntime implements Runtime {
       testResults: relative(this.artifactRoot, testResultsPath),
       review: relative(this.artifactRoot, reviewPath),
       mountDiffs: relative(this.artifactRoot, diffsPath),
+      ...(browser ? { browser: "files/browser/summary.json" } : {}),
     }
     metadata.artifacts = artifactFiles
     const blueprintAfter = buildBlueprintAfter({
@@ -401,6 +431,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(patchPath, "patch", "text/x-diff"),
       fileEntry(testResultsPath, "test-results", "application/json"),
       fileEntry(reviewPath, "review", "application/json"),
+      ...this.browserManifestFiles(),
       ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
         fileEntry(join(this.artifactRoot, file.artifactPath), "file", file.contentType),
@@ -731,7 +762,113 @@ class PlaygroundRuntime implements Runtime {
       return this.runCorePhpunit(spec)
     }
 
+    if (spec.command === "wordpress.browser-probe") {
+      return this.runBrowserProbe(spec)
+    }
+
     throw new Error(`No Playground command handler is registered for: ${spec.command}`)
+  }
+
+  private async runBrowserProbe(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const args = spec.args ?? []
+    const urlArg = argValue(args, "url")?.trim()
+    if (!urlArg) {
+      throw new Error("wordpress.browser-probe requires url=<path-or-url>")
+    }
+
+    const capture = new Set(commaListArg(args, "capture"))
+    if (capture.size === 0) {
+      capture.add("console")
+      capture.add("errors")
+      capture.add("screenshot")
+    }
+
+    for (const item of capture) {
+      if (!["console", "errors", "screenshot"].includes(item)) {
+        throw new Error(`wordpress.browser-probe capture supports console, errors, screenshot: ${item}`)
+      }
+    }
+
+    const waitFor = argValue(args, "wait-for")?.trim() || "domcontentloaded"
+    const durationMs = durationArg(args, "duration", 0)
+    const targetUrl = resolveBrowserProbeUrl(urlArg, server.serverUrl)
+    const browserDirectory = join(this.artifactRoot, "files", "browser")
+    await mkdir(browserDirectory, { recursive: true })
+
+    const consoleMessages: Record<string, unknown>[] = []
+    const errors: BrowserProbeErrorRecord[] = []
+    const consolePath = join(browserDirectory, "console.jsonl")
+    const errorsPath = join(browserDirectory, "errors.jsonl")
+    const screenshotPath = join(browserDirectory, "screenshot.png")
+    const summaryPath = join(browserDirectory, "summary.json")
+    const startedAt = now()
+    const { chromium } = await import("playwright")
+    const browser = await chromium.launch()
+
+    try {
+      const page = await browser.newPage()
+      if (capture.has("console")) {
+        page.on("console", (message) => consoleMessages.push(serializeBrowserConsoleMessage(message)))
+      }
+      if (capture.has("errors")) {
+        page.on("pageerror", (error) => errors.push(serializeBrowserError("pageerror", error)))
+      }
+
+      await navigateBrowserProbe(page, targetUrl, waitFor, durationMs)
+      if (durationMs > 0 && waitFor !== "duration") {
+        await page.waitForTimeout(durationMs)
+      }
+
+      if (capture.has("screenshot")) {
+        await page.screenshot({ path: screenshotPath, fullPage: true })
+      }
+    } catch (error) {
+      errors.push(serializeBrowserError("probe-error", error))
+      throw error
+    } finally {
+      await browser.close()
+      if (capture.has("console")) {
+        await writeFile(consolePath, jsonLines(consoleMessages))
+      }
+      if (capture.has("errors")) {
+        await writeFile(errorsPath, jsonLines(errors))
+      }
+
+      const artifact: BrowserProbeArtifact = {
+        url: targetUrl,
+        files: {
+          ...(capture.has("console") ? { console: "files/browser/console.jsonl" } : {}),
+          ...(capture.has("errors") ? { errors: "files/browser/errors.jsonl" } : {}),
+          ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
+          summary: "files/browser/summary.json",
+        },
+        summary: {
+          consoleMessages: consoleMessages.length,
+          errors: errors.length,
+          screenshot: capture.has("screenshot"),
+        },
+      }
+      this.browserProbes.push(artifact)
+      await writeFile(summaryPath, `${JSON.stringify({
+        schema: "wp-codebox/browser-probe/v1",
+        url: targetUrl,
+        waitFor,
+        durationMs,
+        capture: [...capture].sort(),
+        startedAt,
+        finishedAt: now(),
+        files: artifact.files,
+        summary: artifact.summary,
+      }, null, 2)}\n`)
+    }
+
+    return `${JSON.stringify({
+      command: "wordpress.browser-probe",
+      url: targetUrl,
+      files: this.browserProbes.at(-1)?.files,
+      summary: this.browserProbes.at(-1)?.summary,
+    }, null, 2)}\n`
   }
 
   private async runPhp(spec: ExecutionSpec): Promise<string> {
@@ -1022,10 +1159,139 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
 
     return { type: spec.type, path: spec.path ?? null }
   }
+
+  private browserReviewSummary(): ArtifactReviewBrowserSummary | undefined {
+    if (this.browserProbes.length === 0) {
+      return undefined
+    }
+
+    const consoleMessages = this.browserProbes.reduce((total, probe) => total + probe.summary.consoleMessages, 0)
+    const errors = this.browserProbes.reduce((total, probe) => total + probe.summary.errors, 0)
+    const screenshots = this.browserProbes.filter((probe) => probe.summary.screenshot).length
+    return {
+      summary: `Browser probe captured ${consoleMessages} console message${consoleMessages === 1 ? "" : "s"}, ${errors} error${errors === 1 ? "" : "s"}, and ${screenshots} screenshot${screenshots === 1 ? "" : "s"}.`,
+      probes: this.browserProbes.map((probe) => ({
+        url: probe.url,
+        consoleMessages: probe.summary.consoleMessages,
+        errors: probe.summary.errors,
+        screenshot: probe.files.screenshot,
+        console: probe.files.console,
+        errorsFile: probe.files.errors,
+      })),
+    }
+  }
+
+  private browserManifestFiles(): ArtifactManifestFile[] {
+    if (this.browserProbes.length === 0) {
+      return []
+    }
+
+    const files = new Map<string, { kind: string; contentType: string }>()
+    for (const probe of this.browserProbes) {
+      if (probe.files.console) {
+        files.set(probe.files.console, { kind: "browser-console", contentType: "application/x-ndjson" })
+      }
+      if (probe.files.errors) {
+        files.set(probe.files.errors, { kind: "browser-errors", contentType: "application/x-ndjson" })
+      }
+      if (probe.files.screenshot) {
+        files.set(probe.files.screenshot, { kind: "browser-screenshot", contentType: "image/png" })
+      }
+      files.set(probe.files.summary, { kind: "browser-summary", contentType: "application/json" })
+    }
+
+    return [...files.entries()].map(([path, entry]) => fileEntry(join(this.artifactRoot, path), entry.kind, entry.contentType))
+  }
+
+  private async redactBrowserArtifacts(redactor: ArtifactRedactor): Promise<void> {
+    for (const probe of this.browserProbes) {
+      for (const path of [probe.files.console, probe.files.errors, probe.files.summary]) {
+        if (!path) {
+          continue
+        }
+
+        const absolutePath = join(this.artifactRoot, path)
+        try {
+          await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
+        } catch {
+          // Browser capture is best-effort; preserve artifact collection if a file vanished.
+        }
+      }
+    }
+  }
 }
 
 export function createPlaygroundRuntimeBackend(): RuntimeBackend {
   return new PlaygroundRuntimeBackend()
+}
+
+async function navigateBrowserProbe(page: Page, url: string, waitFor: string, durationMs: number): Promise<void> {
+  if (["domcontentloaded", "load", "networkidle"].includes(waitFor)) {
+    await page.goto(url, { waitUntil: waitFor as "domcontentloaded" | "load" | "networkidle", timeout: 30_000 })
+    return
+  }
+
+  if (waitFor.startsWith("selector:")) {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
+    const selector = waitFor.slice("selector:".length).trim()
+    if (!selector) {
+      throw new Error("wordpress.browser-probe wait-for=selector:<selector> requires a selector")
+    }
+    await page.locator(selector).first().waitFor({ timeout: 30_000 })
+    return
+  }
+
+  if (waitFor === "duration") {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
+    await page.waitForTimeout(durationMs > 0 ? durationMs : 1000)
+    return
+  }
+
+  throw new Error(`wordpress.browser-probe wait-for supports domcontentloaded, load, networkidle, selector:<selector>, duration: ${waitFor}`)
+}
+
+function resolveBrowserProbeUrl(pathOrUrl: string, baseUrl: string): string {
+  try {
+    return new URL(pathOrUrl).toString()
+  } catch {
+    return new URL(pathOrUrl, baseUrl).toString()
+  }
+}
+
+function durationArg(args: string[], name: string, fallbackMs: number): number {
+  const raw = argValue(args, name)?.trim()
+  if (!raw) {
+    return fallbackMs
+  }
+
+  const match = raw.match(/^(\d+(?:\.\d+)?)(ms|s)$/)
+  if (!match) {
+    throw new Error(`${name} must be a duration like 500ms or 2s`)
+  }
+
+  const value = Number.parseFloat(match[1])
+  return Math.max(0, Math.round(match[2] === "ms" ? value : value * 1000))
+}
+
+function serializeBrowserConsoleMessage(message: ConsoleMessage): Record<string, unknown> {
+  return {
+    type: message.type(),
+    text: message.text(),
+    location: message.location(),
+    timestamp: now(),
+  }
+}
+
+function serializeBrowserError(type: BrowserProbeErrorRecord["type"], error: unknown): BrowserProbeErrorRecord {
+  if (error instanceof Error) {
+    return { type, name: error.name, message: error.message, stack: error.stack, timestamp: now() }
+  }
+
+  return { type, name: "Error", message: String(error), timestamp: now() }
+}
+
+function jsonLines(records: unknown[]): string {
+  return records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : ""
 }
 
 async function withPreviewProxy(server: PlaygroundCliServer, port: number): Promise<PlaygroundCliServer> {

--- a/scripts/browser-probe-artifact-smoke.ts
+++ b/scripts/browser-probe-artifact-smoke.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "browser-probe-artifact-smoke")
+const pluginDir = join(workspace, "browser-error-fixture")
+const recipePath = join(workspace, "recipe.json")
+const artifactsRoot = join(workspace, "artifacts")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(pluginDir, { recursive: true })
+
+await writeFile(join(pluginDir, "browser-error-fixture.php"), `<?php
+/**
+ * Plugin Name: Browser Error Fixture
+ */
+add_action('wp_footer', function () {
+    echo '<script>console.error("wp-codebox fixture console error"); setTimeout(function () { throw new Error("wp-codebox fixture browser error"); }, 0);</script>';
+});
+`)
+
+await writeFile(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extraPlugins: [
+      {
+        source: "./browser-error-fixture",
+        pluginFile: "browser-error-fixture/browser-error-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.browser-probe",
+        args: ["url=/", "wait-for=load", "duration=1s", "capture=console,errors,screenshot"],
+      },
+    ],
+  },
+  artifacts: {
+    directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const output = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--json",
+])
+
+assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
+assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+
+const artifactDirectory = output.artifacts.directory
+const consolePath = join(artifactDirectory, "files", "browser", "console.jsonl")
+const errorsPath = join(artifactDirectory, "files", "browser", "errors.jsonl")
+const screenshotPath = join(artifactDirectory, "files", "browser", "screenshot.png")
+const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
+const manifestPath = join(artifactDirectory, "manifest.json")
+const reviewPath = join(artifactDirectory, "files", "review.json")
+
+assert.equal(existsSync(consolePath), true, "console.jsonl should be captured")
+assert.equal(existsSync(errorsPath), true, "errors.jsonl should be captured")
+assert.equal(existsSync(screenshotPath), true, "screenshot.png should be captured")
+assert.equal(existsSync(summaryPath), true, "summary.json should be captured")
+
+const consoleLog = await readFile(consolePath, "utf8")
+const errorLog = await readFile(errorsPath, "utf8")
+assert.match(consoleLog, /wp-codebox fixture console error/)
+assert.match(errorLog, /wp-codebox fixture browser error/)
+
+const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
+assert.ok(manifest.files.some((file) => file.path === "files/browser/console.jsonl" && file.kind === "browser-console"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/errors.jsonl" && file.kind === "browser-errors"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/screenshot.png" && file.kind === "browser-screenshot"))
+
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ consoleMessages: number; errors: number }> } }
+assert.ok(review.browser?.probes?.[0], "review should include browser probe summary")
+assert.ok(review.browser.probes[0].consoleMessages >= 1, "review should count console messages")
+assert.ok(review.browser.probes[0].errors >= 1, "review should count browser errors")
+
+console.log(`Browser probe artifact smoke passed: ${artifactDirectory}`)
+
+async function runCli(args: string[]): Promise<any> {
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const exitCode = await new Promise<number | null>((resolveExit) => child.once("exit", (code) => resolveExit(code)))
+  assert.equal(exitCode, 0, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  return JSON.parse(stdout)
+}

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -35,6 +35,7 @@ const expectedCommandIds = [
   "wordpress.bench",
   "wordpress.phpunit",
   "wordpress.core-phpunit",
+  "wordpress.browser-probe",
   "wp-codebox.agent-runtime-probe",
   "wp-codebox.agent-sandbox-run",
 ]


### PR DESCRIPTION
## Summary
- Add `wordpress.browser-probe` for recipe/runtime runs to open a live Playground preview with Playwright and capture browser console messages, page errors, and screenshots.
- Persist browser artifacts under `files/browser/` with manifest entries and a review summary containing console/error/screenshot counts.
- Update command discovery/schema/help/README and add a smoke fixture that throws a browser error to prove artifact capture.

Fixes https://github.com/chubes4/wp-codebox/issues/122

## Tests
- `npm run check`

## Deferred
- HAR/network capture, DOM snapshots, and login automation are intentionally left for follow-up slices.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the first-slice runtime command, artifact wiring, docs, and smoke coverage; Chris remains responsible for review and merge.