### PR TITLE
Add boot command for held previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,25 @@ WP Codebox defaults to WordPress `7.0` because the agent and AI plugin stacks ne
 
 `--preview-port` fixes the local Playground port for tunnel/proxy wiring. Omit it to keep the current random-port behavior. `--preview-public-url` is metadata and site-url alignment only; it does not make Playground listen on a public interface. Use a tunnel/proxy for remote access.
 
+### `boot`
+
+Boot a disposable Playground runtime for interactive sandbox review without running a workflow step.
+
+```bash
+npm run wp-codebox -- boot \
+  --mount <host-path>:<sandbox-path>[:readonly|readwrite] \
+  --blueprint ./playground-blueprint.json \
+  --artifacts ./artifacts \
+  --hold 15m \
+  --preview-port 4173 \
+  --preview-public-url https://example-tunnel.test/ \
+  --json
+```
+
+`boot` accepts the same mount, WordPress version, policy, artifact, fixed preview port, and public preview URL setup used by the runtime commands. `--blueprint` accepts inline JSON or a path to a Playground blueprint JSON file. `--hold` uses the same duration syntax and 3600-second maximum as `run --preview-hold`.
+
+The JSON output uses `wp-codebox/boot/v1` and includes runtime information plus the collected artifact bundle. The artifact bundle includes preview metadata, mounted-file capture, diffs, review metadata, and lifecycle logs, but no `execution` object and no fake command entry.
+
 ### `recipe validate`
 
 Validate a workspace recipe without launching Playground.

--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
     "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",
     "preview-public-url-canonical-smoke": "tsx scripts/preview-public-url-canonical-smoke.ts",
     "preview-response-body-smoke": "tsx scripts/preview-response-body-smoke.ts",
+    "boot-preview-smoke": "tsx scripts/boot-preview-smoke.ts",
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,3 +44,8 @@ descriptions, accepted args, known output shape, and policy requirements.
 - `wp-codebox recipe validate --recipe <path> [--json]` validates recipe shape, paths, commands, and arguments without resolving a full execution plan.
 - `wp-codebox recipe-run --recipe <path> --dry-run --json` validates the recipe and emits the resolved plan without booting Playground, creating temp workspaces, mutating files, or writing artifacts.
 - `wp-codebox recipe-run --recipe <path> [--json]` boots Playground, mounts inputs, executes workflow steps, and captures artifacts.
+
+## Interactive Boot
+
+- `wp-codebox boot [--mount <host>:<vfs>] --hold <duration> [--json]` boots Playground, captures preview/artifact metadata, holds the live preview with the same duration semantics as `run --preview-hold`, then tears down and collects artifacts without creating a workflow command.
+- `boot` accepts the runtime setup options relevant to interactive previews: `--mount`, `--blueprint <json|file>`, `--wp`, `--artifacts`, `--policy <json|file>`, `--preview-port`, and `--preview-public-url`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import { promisify } from "node:util"
 import { createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
-import { captureStdout, printBatchHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
+import { captureStdout, printBatchHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
 
 interface CommandMetadata {
   id: string
@@ -66,6 +66,27 @@ interface RunOutput {
     message: string
     code?: string
   }
+}
+
+interface BootOptions {
+  mounts: RunOptions["mounts"]
+  wpVersion?: string
+  artifactsDirectory?: string
+  policy?: RuntimePolicy
+  blueprint?: unknown
+  previewHoldSeconds?: number
+  previewPublicUrl?: string
+  previewPort?: number
+  json: boolean
+}
+
+interface BootOutput {
+  success: boolean
+  schema: "wp-codebox/boot/v1"
+  runtime?: RuntimeInfo
+  artifacts?: ArtifactBundle
+  logs?: string[]
+  error?: RunOutput["error"]
 }
 
 interface RecipeRunOptions {
@@ -632,6 +653,23 @@ async function main(args: string[]): Promise<number> {
   if (!command || command === "help" || command === "--help" || command === "-h") {
     printHelp()
     return command ? 0 : 1
+  }
+
+  if (command === "boot") {
+    const options = await parseBootOptions(args)
+    const execute = () => boot(options)
+
+    if (!options.json) {
+      const output = await execute()
+      printBootHumanOutput(output)
+      return output.success ? 0 : 1
+    }
+
+    const { result, logs } = await captureStdout(execute)
+    const output = logs.length > 0 ? { ...result, logs } : result
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    printJsonFailureDiagnostic(output)
+    return output.success ? 0 : 1
   }
 
   if (command === "recipe-run") {
@@ -1208,6 +1246,18 @@ function runMetadata(options: RunOptions): Record<string, unknown> {
   }
 }
 
+function bootMetadata(options: BootOptions): Record<string, unknown> {
+  return {
+    ...runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION),
+    task: stripUndefined({
+      kind: "cli-boot",
+      artifactsDirectory: options.artifactsDirectory,
+      previewPublicUrl: options.previewPublicUrl,
+      previewPort: options.previewPort,
+    }),
+  }
+}
+
 function agentRuntimeMetadata(options: AgentRuntimeProbeOptions): Record<string, unknown> {
   const base = runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION)
 
@@ -1544,6 +1594,69 @@ async function run(options: RunOptions): Promise<RunOutput> {
   }
 }
 
+async function boot(options: BootOptions): Promise<BootOutput> {
+  let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
+  let artifacts: ArtifactBundle | undefined
+
+  try {
+    runtime = await createRuntime(
+      {
+        backend: "wordpress-playground",
+        environment: {
+          kind: "wordpress",
+          name: "wp-codebox-boot",
+          version: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
+          blueprint: options.blueprint ?? { steps: [] },
+        },
+        policy: options.policy ?? defaultPolicy,
+        artifactsDirectory: options.artifactsDirectory,
+        metadata: bootMetadata(options),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort),
+      },
+      createPlaygroundRuntimeBackend(),
+    )
+
+    for (const mount of options.mounts) {
+      await runtime.mount({ type: "directory", source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
+    }
+
+    await runtime.observe({ type: "runtime-info" })
+    await runtime.observe({ type: "mounts" })
+    artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
+    const runtimeInfo = options.previewHoldSeconds ? await runtime.info() : undefined
+    await releaseRuntime(runtime, options.previewHoldSeconds)
+
+    return {
+      success: true,
+      schema: "wp-codebox/boot/v1",
+      runtime: runtimeInfo ?? await runtime.info(),
+      artifacts,
+    }
+  } catch (error) {
+    if (runtime) {
+      try {
+        artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true })
+      } catch {
+        // Preserve the original failure as the CLI result.
+      }
+
+      try {
+        await runtime.destroy()
+      } catch {
+        // Preserve the original failure as the CLI result.
+      }
+    }
+
+    return {
+      success: false,
+      schema: "wp-codebox/boot/v1",
+      ...(runtime ? { runtime: await runtime.info() } : {}),
+      ...(artifacts ? { artifacts } : {}),
+      error: serializeError(error),
+    }
+  }
+}
+
 async function releaseRuntime(runtime: Runtime, previewHoldSeconds = 0, afterDestroy?: () => Promise<void>): Promise<void> {
   const holdSeconds = Math.max(0, Math.floor(previewHoldSeconds))
   if (holdSeconds === 0) {
@@ -1648,6 +1761,60 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
 
   if (options.mounts.length === 0) {
     throw new Error("At least one --mount host:vfs value is required")
+  }
+
+  return options
+}
+
+async function parseBootOptions(args: string[]): Promise<BootOptions> {
+  const options: BootOptions = {
+    mounts: [],
+    json: false,
+  }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--mount":
+        options.mounts.push(parseMount(value))
+        break
+      case "--wp":
+        options.wpVersion = value
+        break
+      case "--blueprint":
+        options.blueprint = await parseJsonOption(value)
+        break
+      case "--artifacts":
+        options.artifactsDirectory = value
+        break
+      case "--hold":
+        options.previewHoldSeconds = parsePreviewHoldSeconds(value)
+        break
+      case "--preview-public-url":
+        options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
+      case "--preview-port":
+        options.previewPort = parsePreviewPort(value)
+        break
+      case "--policy":
+        options.policy = await parsePolicy(value)
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
   }
 
   return options
@@ -2531,8 +2698,16 @@ function parseMount(value: string): RunOptions["mounts"][number] {
 }
 
 async function parsePolicy(value: string): Promise<RuntimePolicy> {
-  const raw = value.trim().startsWith("{") ? value : await readFile(resolve(value), "utf8")
-  return JSON.parse(raw) as RuntimePolicy
+  return JSON.parse(await readJsonOption(value)) as RuntimePolicy
+}
+
+async function parseJsonOption(value: string): Promise<unknown> {
+  return JSON.parse(await readJsonOption(value))
+}
+
+async function readJsonOption(value: string): Promise<string> {
+  const trimmed = value.trim()
+  return trimmed.startsWith("{") || trimmed.startsWith("[") ? value : await readFile(resolve(value), "utf8")
 }
 
 function stripUndefined<T extends Record<string, unknown>>(record: T): T {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -111,6 +111,20 @@ export function printHumanOutput(output: RunOutputLike): void {
   }
 }
 
+export function printBootHumanOutput(output: RunOutputLike): void {
+  if (!output.success) {
+    console.error(output.error?.message ?? "WP Codebox boot failed")
+    return
+  }
+
+  console.log("WP Codebox boot")
+  console.log(`Runtime: ${output.runtime?.backend ?? "unknown"}`)
+  console.log(`Artifacts: ${output.artifacts?.directory ?? "none"}`)
+  if (output.artifacts?.preview?.url) {
+    console.log(`Preview: ${output.artifacts.preview.url} (${output.artifacts.preview.status})`)
+  }
+}
+
 export function printRecipeHumanOutput(output: RecipeRunOutputLike): void {
   if (!output.success) {
     console.error(output.error?.message ?? "WP Codebox recipe failed")
@@ -192,6 +206,7 @@ export function printHelp(): void {
   wp-codebox schema recipe [--json]
   wp-codebox recipe validate --recipe <path> [--json]
   wp-codebox recipe-run --recipe <path> [options]
+  wp-codebox boot [--mount <host>:<vfs>] [options]
   wp-codebox run --mount <host>:<vfs> --command <id> [options]
 
 Options:
@@ -200,7 +215,10 @@ Options:
   --command <id>       Command/action id to execute.
   --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
+  --blueprint <json|file>
+                       WordPress Playground blueprint JSON or path for boot.
   --artifacts <dir>    Artifact root directory.
+  --hold <n>           Keep a booted Playground preview available before teardown. Accepts the same values as --preview-hold.
   --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
   --preview-port <n>   Start Playground on a fixed local port. Defaults to a random available port.
   --preview-public-url <url>

--- a/scripts/boot-preview-smoke.ts
+++ b/scripts/boot-preview-smoke.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "..")
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-boot-preview-"))
+
+try {
+  const output = await runCliJson([
+    "boot",
+    "--mount",
+    "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+    "--artifacts",
+    artifactsDirectory,
+    "--hold",
+    "1s",
+    "--json",
+  ])
+
+  assert.equal(output.success, true)
+  assert.equal(output.schema, "wp-codebox/boot/v1")
+  assert.equal(output.execution, undefined)
+  assert.equal(output.runtime.backend, "wordpress-playground")
+  assert.equal(output.artifacts.preview.status, "available")
+  assert.equal(output.artifacts.preview.holdSeconds, 1)
+  assert.match(output.artifacts.preview.url, /^http:\/\//)
+
+  const commands = await readFile(output.artifacts.commandsPath, "utf8")
+  assert.equal(commands.trim(), "", "boot should not create a fake workflow command")
+
+  const review = JSON.parse(await readFile(output.artifacts.reviewPath, "utf8"))
+  assert.equal(review.preview.status, "available")
+  assert.equal(review.preview.holdSeconds, 1)
+
+  const metadata = JSON.parse(await readFile(output.artifacts.metadataPath, "utf8"))
+  assert.equal(metadata.context.task.kind, "cli-boot")
+} finally {
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}
+
+async function runCliJson(args: string[]): Promise<any> {
+  const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", ...args], {
+    cwd: repoRoot,
+    maxBuffer: 1024 * 1024 * 10,
+  })
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- Add `wp-codebox boot` for workflow-free interactive Playground sessions with mount, blueprint, WordPress version, policy, artifact, preview port, public URL, hold, and JSON options.
- Reuse existing preview hold and artifact collection behavior so boot emits runtime, preview, and artifact metadata without creating a fake workflow command.
- Document the command in CLI help/README surfaces and add a focused smoke covering held preview artifacts.

Fixes https://github.com/chubes4/wp-codebox/issues/110

## Tests
- `npm run build`
- `npm run boot-preview-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the first-slice CLI command, docs, and smoke coverage; Chris remains responsible for review and merge.