### PR TITLE
Add blueprint validation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ What you can build on top of WP Codebox:
 What WP Codebox provides for product use cases:
 
 - Run a PHP or WP-CLI probe against mounted WordPress code.
+- Validate raw WordPress Playground blueprints through the same runtime and artifact contract.
 - Execute a WordPress Ability inside a disposable Playground runtime.
 - Run repeatable workspace recipes that mount plugins, seed workspaces, and capture outputs.
 - Drive stateful runtime episodes with reset, step, observe, snapshot, artifact, and close operations.
@@ -332,6 +333,20 @@ npm run wp-codebox -- boot \
 `boot` accepts the same mount, WordPress version, policy, artifact, fixed preview port, and public preview URL setup used by the runtime commands. `--blueprint` accepts inline JSON or a path to a Playground blueprint JSON file. `--hold` uses the same duration syntax and 3600-second maximum as `run --preview-hold`.
 
 The JSON output uses `wp-codebox/boot/v1` and includes runtime information plus the collected artifact bundle. The artifact bundle includes preview metadata, mounted-file capture, diffs, review metadata, and lifecycle logs, but no `execution` object and no fake command entry.
+
+### `validate-blueprint`
+
+Validate a raw WordPress Playground blueprint through WP Codebox instead of calling `@wp-playground/cli` directly.
+
+```bash
+npm run wp-codebox -- validate-blueprint \
+  --blueprint ./playground-blueprint.json \
+  --wp 7.0 \
+  --artifacts ./artifacts \
+  --json
+```
+
+`--blueprint` accepts inline JSON or a path to a Playground blueprint JSON file. The command boots Playground with that blueprint, captures the normal artifact bundle, and returns `wp-codebox/blueprint-validation/v1` with runtime and artifact paths. Use it in CI when the desired contract is "this blueprint boots and produces reviewable WP Codebox artifacts" rather than a recipe workflow.
 
 ### `recipe validate`
 

--- a/package.json
+++ b/package.json
@@ -45,11 +45,12 @@
     "preview-public-url-canonical-smoke": "tsx scripts/preview-public-url-canonical-smoke.ts",
     "preview-response-body-smoke": "tsx scripts/preview-response-body-smoke.ts",
     "boot-preview-smoke": "tsx scripts/boot-preview-smoke.ts",
+    "blueprint-validation-smoke": "tsx scripts/blueprint-validation-smoke.ts",
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,6 +41,7 @@ descriptions, accepted args, known output shape, and policy requirements.
 
 ## Recipe Planning
 
+- `wp-codebox validate-blueprint --blueprint <json|file> [--json]` boots a raw WordPress Playground blueprint through WP Codebox and captures the normal artifact bundle.
 - `wp-codebox recipe validate --recipe <path> [--json]` validates recipe shape, paths, commands, and arguments without resolving a full execution plan.
 - `wp-codebox recipe-run --recipe <path> --dry-run --json` validates the recipe and emits the resolved plan without booting Playground, creating temp workspaces, mutating files, or writing artifacts.
 - `wp-codebox recipe-run --recipe <path> [--json]` boots Playground, mounts inputs, executes workflow steps, and captures artifacts.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import { promisify } from "node:util"
 import { createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
-import { captureStdout, printBatchHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
+import { captureStdout, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
 
 interface CommandMetadata {
   id: string
@@ -83,6 +83,28 @@ interface BootOptions {
 interface BootOutput {
   success: boolean
   schema: "wp-codebox/boot/v1"
+  runtime?: RuntimeInfo
+  artifacts?: ArtifactBundle
+  logs?: string[]
+  error?: RunOutput["error"]
+}
+
+interface BlueprintValidateOptions {
+  blueprint: unknown
+  blueprintPath?: string
+  wpVersion?: string
+  artifactsDirectory?: string
+  policy?: RuntimePolicy
+  previewHoldSeconds?: number
+  previewPublicUrl?: string
+  previewPort?: number
+  json: boolean
+}
+
+interface BlueprintValidateOutput {
+  success: boolean
+  schema: "wp-codebox/blueprint-validation/v1"
+  blueprintPath?: string
   runtime?: RuntimeInfo
   artifacts?: ArtifactBundle
   logs?: string[]
@@ -662,6 +684,23 @@ async function main(args: string[]): Promise<number> {
     if (!options.json) {
       const output = await execute()
       printBootHumanOutput(output)
+      return output.success ? 0 : 1
+    }
+
+    const { result, logs } = await captureStdout(execute)
+    const output = logs.length > 0 ? { ...result, logs } : result
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    printJsonFailureDiagnostic(output)
+    return output.success ? 0 : 1
+  }
+
+  if (command === "validate-blueprint") {
+    const options = await parseBlueprintValidateOptions(args)
+    const execute = () => validateBlueprint(options)
+
+    if (!options.json) {
+      const output = await execute()
+      printBlueprintValidateHumanOutput(output)
       return output.success ? 0 : 1
     }
 
@@ -1258,6 +1297,19 @@ function bootMetadata(options: BootOptions): Record<string, unknown> {
   }
 }
 
+function blueprintValidationMetadata(options: BlueprintValidateOptions): Record<string, unknown> {
+  return {
+    ...runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION),
+    task: stripUndefined({
+      kind: "blueprint-validation",
+      blueprintPath: options.blueprintPath,
+      artifactsDirectory: options.artifactsDirectory,
+      previewPublicUrl: options.previewPublicUrl,
+      previewPort: options.previewPort,
+    }),
+  }
+}
+
 function agentRuntimeMetadata(options: AgentRuntimeProbeOptions): Record<string, unknown> {
   const base = runtimeMetadata(options.artifactsDirectory, options.wpVersion ?? DEFAULT_WORDPRESS_VERSION)
 
@@ -1657,6 +1709,67 @@ async function boot(options: BootOptions): Promise<BootOutput> {
   }
 }
 
+async function validateBlueprint(options: BlueprintValidateOptions): Promise<BlueprintValidateOutput> {
+  let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
+  let artifacts: ArtifactBundle | undefined
+
+  try {
+    runtime = await createRuntime(
+      {
+        backend: "wordpress-playground",
+        environment: {
+          kind: "wordpress",
+          name: "wp-codebox-blueprint-validation",
+          version: options.wpVersion ?? DEFAULT_WORDPRESS_VERSION,
+          blueprint: options.blueprint,
+        },
+        policy: options.policy ?? defaultPolicy,
+        artifactsDirectory: options.artifactsDirectory,
+        metadata: blueprintValidationMetadata(options),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort),
+      },
+      createPlaygroundRuntimeBackend(),
+    )
+
+    await runtime.observe({ type: "runtime-info" })
+    await runtime.observe({ type: "mounts" })
+    artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
+    const runtimeInfo = options.previewHoldSeconds ? await runtime.info() : undefined
+    await releaseRuntime(runtime, options.previewHoldSeconds)
+
+    return {
+      success: true,
+      schema: "wp-codebox/blueprint-validation/v1",
+      ...(options.blueprintPath ? { blueprintPath: options.blueprintPath } : {}),
+      runtime: runtimeInfo ?? await runtime.info(),
+      artifacts,
+    }
+  } catch (error) {
+    if (runtime) {
+      try {
+        artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true })
+      } catch {
+        // Preserve the original failure as the CLI result.
+      }
+
+      try {
+        await runtime.destroy()
+      } catch {
+        // Preserve the original failure as the CLI result.
+      }
+    }
+
+    return {
+      success: false,
+      schema: "wp-codebox/blueprint-validation/v1",
+      ...(options.blueprintPath ? { blueprintPath: options.blueprintPath } : {}),
+      ...(runtime ? { runtime: await runtime.info() } : {}),
+      ...(artifacts ? { artifacts } : {}),
+      error: serializeError(error),
+    }
+  }
+}
+
 async function releaseRuntime(runtime: Runtime, previewHoldSeconds = 0, afterDestroy?: () => Promise<void>): Promise<void> {
   const holdSeconds = Math.max(0, Math.floor(previewHoldSeconds))
   if (holdSeconds === 0) {
@@ -1818,6 +1931,59 @@ async function parseBootOptions(args: string[]): Promise<BootOptions> {
   }
 
   return options
+}
+
+async function parseBlueprintValidateOptions(args: string[]): Promise<BlueprintValidateOptions> {
+  const options: Partial<BlueprintValidateOptions> = { json: false }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--blueprint":
+        options.blueprint = await parseJsonOption(value)
+        options.blueprintPath = jsonOptionPath(value)
+        break
+      case "--wp":
+        options.wpVersion = value
+        break
+      case "--artifacts":
+        options.artifactsDirectory = value
+        break
+      case "--preview-hold":
+        options.previewHoldSeconds = parsePreviewHoldSeconds(value)
+        break
+      case "--preview-public-url":
+        options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
+      case "--preview-port":
+        options.previewPort = parsePreviewPort(value)
+        break
+      case "--policy":
+        options.policy = await parsePolicy(value)
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (options.blueprint === undefined) {
+    throw new Error("Missing required option: --blueprint")
+  }
+
+  return options as BlueprintValidateOptions
 }
 
 function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
@@ -2708,6 +2874,11 @@ async function parseJsonOption(value: string): Promise<unknown> {
 async function readJsonOption(value: string): Promise<string> {
   const trimmed = value.trim()
   return trimmed.startsWith("{") || trimmed.startsWith("[") ? value : await readFile(resolve(value), "utf8")
+}
+
+function jsonOptionPath(value: string): string | undefined {
+  const trimmed = value.trim()
+  return trimmed.startsWith("{") || trimmed.startsWith("[") ? undefined : resolve(value)
 }
 
 function stripUndefined<T extends Record<string, unknown>>(record: T): T {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -40,6 +40,10 @@ interface RecipeValidateOutputLike {
   }
 }
 
+interface BlueprintValidateOutputLike extends RunOutputLike {
+  blueprintPath?: string
+}
+
 interface BatchOutputLike {
   concurrency: number
   total: number
@@ -118,6 +122,21 @@ export function printBootHumanOutput(output: RunOutputLike): void {
   }
 
   console.log("WP Codebox boot")
+  console.log(`Runtime: ${output.runtime?.backend ?? "unknown"}`)
+  console.log(`Artifacts: ${output.artifacts?.directory ?? "none"}`)
+  if (output.artifacts?.preview?.url) {
+    console.log(`Preview: ${output.artifacts.preview.url} (${output.artifacts.preview.status})`)
+  }
+}
+
+export function printBlueprintValidateHumanOutput(output: BlueprintValidateOutputLike): void {
+  if (!output.success) {
+    console.error(output.error?.message ?? "WP Codebox blueprint validation failed")
+    return
+  }
+
+  console.log("WP Codebox blueprint validation")
+  console.log(`Blueprint: ${output.blueprintPath ?? "inline"}`)
   console.log(`Runtime: ${output.runtime?.backend ?? "unknown"}`)
   console.log(`Artifacts: ${output.artifacts?.directory ?? "none"}`)
   if (output.artifacts?.preview?.url) {
@@ -205,6 +224,7 @@ export function printHelp(): void {
   wp-codebox commands [--json]
   wp-codebox schema recipe [--json]
   wp-codebox recipe validate --recipe <path> [--json]
+  wp-codebox validate-blueprint --blueprint <json|file> [options]
   wp-codebox recipe-run --recipe <path> [options]
   wp-codebox boot [--mount <host>:<vfs>] [options]
   wp-codebox run --mount <host>:<vfs> --command <id> [options]
@@ -216,7 +236,7 @@ Options:
   --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --blueprint <json|file>
-                       WordPress Playground blueprint JSON or path for boot.
+                       WordPress Playground blueprint JSON or path for boot or validate-blueprint.
   --artifacts <dir>    Artifact root directory.
   --hold <n>           Keep a booted Playground preview available before teardown. Accepts the same values as --preview-hold.
   --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.

--- a/scripts/blueprint-validation-smoke.ts
+++ b/scripts/blueprint-validation-smoke.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "..")
+const tempDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-blueprint-validation-"))
+const artifactsDirectory = join(tempDirectory, "artifacts")
+const blueprintPath = join(tempDirectory, "blueprint.json")
+
+try {
+  await writeFile(blueprintPath, `${JSON.stringify({ steps: [] }, null, 2)}\n`)
+
+  const output = await runCliJson([
+    "validate-blueprint",
+    "--blueprint",
+    blueprintPath,
+    "--artifacts",
+    artifactsDirectory,
+    "--json",
+  ])
+
+  assert.equal(output.success, true)
+  assert.equal(output.schema, "wp-codebox/blueprint-validation/v1")
+  assert.equal(output.blueprintPath, blueprintPath)
+  assert.equal(output.execution, undefined)
+  assert.equal(output.runtime.backend, "wordpress-playground")
+  assert.equal(output.runtime.status, "destroyed")
+  assert.equal(output.artifacts.preview.status, "expired-on-completion")
+  assert.equal(output.artifacts.preview.lifecycle, "destroyed-on-completion")
+
+  const commands = await readFile(output.artifacts.commandsPath, "utf8")
+  assert.equal(commands.trim(), "", "blueprint validation should not create a fake workflow command")
+
+  const metadata = JSON.parse(await readFile(output.artifacts.metadataPath, "utf8"))
+  assert.equal(metadata.context.task.kind, "blueprint-validation")
+  assert.equal(metadata.context.task.blueprintPath, blueprintPath)
+} finally {
+  await rm(tempDirectory, { recursive: true, force: true })
+}
+
+async function runCliJson(args: string[]): Promise<any> {
+  const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", ...args], {
+    cwd: repoRoot,
+    maxBuffer: 1024 * 1024 * 10,
+  })
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- Add `wp-codebox validate-blueprint` for raw Playground blueprint validation through the WP Codebox runtime contract.
- Return a `wp-codebox/blueprint-validation/v1` JSON envelope with normal runtime/artifact bundle paths.
- Document the command and add a focused smoke test to the full check pipeline.

Closes #113.

## Testing
- `npm run blueprint-validation-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the CLI command, docs, and smoke test; Chris remains responsible for review and merge.