### PR TITLE
Add recipe site seed dry-run planning

### DIFF
--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -10,6 +10,19 @@ mounts a target plugin or theme, seeds a realistic host context via Playground
 blueprint steps, and is intended to be paired with `--preview-hold` for visual
 smoke testing.
 
+## Site seed planning boundary
+
+Recipe authors can use `inputs.siteSeeds` to describe fixture or parent-site
+content shapes for dry-run review, but the current cookbook recipes still seed
+runtime content through explicit fixture scripts. WP Codebox does not snapshot a
+parent site, read private production rows, copy uploads, or import site seed
+records from `inputs.siteSeeds` in this slice.
+
+Treat parent-site seed declarations as a reviewable manifest only: opt in to
+bounded scopes, name exact option keys, keep user data anonymized, and keep
+secrets, credentials, private post bodies, raw option values, and upload files
+out of recipe files and dry-run evidence.
+
 ## Available recipes
 
 ### `multisite-network.json`

--- a/examples/recipes/cookbook/seeded-content.json
+++ b/examples/recipes/cookbook/seeded-content.json
@@ -36,6 +36,33 @@
           "editable": true
         }
       }
+    ],
+    "siteSeeds": [
+      {
+        "type": "parent_site",
+        "name": "bounded-editorial-shape",
+        "scopes": {
+          "posts": {
+            "postTypes": ["page", "post"],
+            "maxRecords": 10
+          },
+          "terms": {
+            "taxonomies": ["category", "post_tag"],
+            "maxRecords": 10
+          },
+          "options": {
+            "names": ["blogname", "show_on_front", "page_on_front", "page_for_posts"],
+            "maxRecords": 4
+          },
+          "users": {
+            "roles": ["administrator", "editor", "author"],
+            "maxRecords": 3,
+            "anonymize": true
+          },
+          "activePlugins": true,
+          "activeTheme": true
+        }
+      }
     ]
   },
   "workflow": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -46,6 +46,10 @@ descriptions, accepted args, known output shape, and policy requirements.
 - `wp-codebox recipe-run --recipe <path> --dry-run --json` validates the recipe and emits the resolved plan without booting Playground, creating temp workspaces, mutating files, or writing artifacts.
 - `wp-codebox recipe-run --recipe <path> [--json]` boots Playground, mounts inputs, executes workflow steps, and captures artifacts.
 
+Recipes may declare `inputs.siteSeeds` for explicit content/site seed planning. This first slice is dry-run-only: WP Codebox validates bounded fixture or parent-site seed declarations and reports them under `plan.siteSeeds`, but it does not export data from a parent WordPress site and does not import seed records into Playground during normal `recipe-run` execution.
+
+Parent-site-derived declarations must stay minimized: each scope needs explicit selectors or `maxRecords`, option scopes must name exact option keys, user scopes must stay anonymized, and parent-site media file copying is rejected. Dry-run output reports only names, selectors, bounds, fixture paths, and privacy flags; it does not include record bodies, option values, user emails, secrets, uploads, or database rows.
+
 ## Interactive Boot
 
 - `wp-codebox boot [--mount <host>:<vfs>] --hold <duration> [--json]` boots Playground, captures preview/artifact metadata, holds the live preview with the same duration semantics as `run --preview-hold`, then tears down and collects artifacts without creating a workflow command.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ import { basename, dirname, join, resolve } from "node:path"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import { promisify } from "node:util"
-import { createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
 import { captureStdout, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
@@ -191,6 +191,7 @@ interface RecipeDryRunPlan {
   mounts: RecipeDryRunMount[]
   workspaces: RecipeDryRunWorkspace[]
   extra_plugins: RecipeDryRunExtraPlugin[]
+  siteSeeds: RecipeDryRunSiteSeed[]
   secretEnv: Array<{ name: string; available: boolean }>
   policy: RuntimePolicy & {
     valid: boolean
@@ -229,6 +230,23 @@ interface RecipeDryRunExtraPlugin {
   pluginFile: string
   activate: boolean
   provenance: RecipeSourceProvenance
+}
+
+interface RecipeDryRunSiteSeed {
+  index: number
+  type: WorkspaceRecipeSiteSeed["type"]
+  name: string
+  source?: string
+  format?: WorkspaceRecipeSiteSeed["format"]
+  scopes: WorkspaceRecipeSiteSeed["scopes"]
+  bounded: boolean
+  dryRunOnly: true
+  privacy: {
+    exportsParentSiteData: false
+    importsIntoSandbox: false
+    includesRecordData: false
+    secrets: "excluded-by-default"
+  }
 }
 
 interface RecipeDryRunStep {
@@ -536,6 +554,11 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
           type: "array",
           items: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" },
         },
+        siteSeeds: {
+          type: "array",
+          description: "Explicit site/content seed declarations. The v1 CLI only validates and reports these in dry-run plans; it does not export parent-site data or import seed data into the sandbox.",
+          items: { $ref: "#/$defs/siteSeed" },
+        },
         inherit: { $ref: "#/$defs/inheritanceRequest" },
         inheritance: { $ref: "#/$defs/inheritanceResolution" },
       },
@@ -609,6 +632,46 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
         slug: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
         pluginFile: { type: "string" },
         activate: { type: "boolean" },
+      },
+    },
+    siteSeed: {
+      type: "object",
+      additionalProperties: false,
+      required: ["type", "name", "scopes"],
+      properties: {
+        type: { enum: ["fixture", "parent_site"] },
+        name: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*$" },
+        source: { type: "string", description: "Fixture file path. Not allowed for parent_site dry-run declarations." },
+        format: { enum: ["json", "wxr", "playground-blueprint"] },
+        scopes: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            posts: { $ref: "#/$defs/siteSeedScope" },
+            terms: { $ref: "#/$defs/siteSeedScope" },
+            options: { $ref: "#/$defs/siteSeedScope" },
+            users: { $ref: "#/$defs/siteSeedScope" },
+            media: { $ref: "#/$defs/siteSeedScope" },
+            activePlugins: { type: "boolean" },
+            activeTheme: { type: "boolean" },
+          },
+        },
+      },
+    },
+    siteSeedScope: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        ids: { type: "array", items: { type: "integer", minimum: 1 }, maxItems: 100 },
+        slugs: { type: "array", items: { type: "string" }, maxItems: 100 },
+        names: { type: "array", items: { type: "string" }, maxItems: 100 },
+        postTypes: { type: "array", items: { type: "string" }, maxItems: 25 },
+        taxonomies: { type: "array", items: { type: "string" }, maxItems: 25 },
+        roles: { type: "array", items: { type: "string" }, maxItems: 25 },
+        statuses: { type: "array", items: { type: "string" }, maxItems: 25 },
+        includeFiles: { type: "boolean" },
+        anonymize: { type: "boolean" },
+        maxRecords: { type: "integer", minimum: 1, maximum: 100 },
       },
     },
     step: {
@@ -887,6 +950,7 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
   const policyValidation = validateRuntimePolicy(policy)
   const workspaces = recipeDryRunWorkspaces(recipe, recipeDirectory)
   const extraPlugins = recipeDryRunExtraPlugins(recipe, recipeDirectory)
+  const siteSeeds = recipeDryRunSiteSeeds(recipe, recipeDirectory)
   const mounts: RecipeDryRunMount[] = [
     ...workspaces.map((workspace) => ({
       type: "directory" as const,
@@ -931,6 +995,7 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
     mounts,
     workspaces,
     extra_plugins: extraPlugins,
+    siteSeeds,
     secretEnv: (recipe.inputs?.secretEnv ?? []).map((name) => ({
       name,
       available: process.env[name] !== undefined,
@@ -2167,6 +2232,33 @@ function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe 
     }
   }
 
+  const siteSeeds = recipe.inputs?.siteSeeds ?? []
+  if (!Array.isArray(siteSeeds)) {
+    throw new Error(`Recipe siteSeeds must be an array: ${recipePath}`)
+  }
+
+  for (const siteSeed of siteSeeds) {
+    if (!siteSeed || typeof siteSeed !== "object") {
+      throw new Error(`Recipe siteSeeds entries must be objects: ${recipePath}`)
+    }
+
+    if (siteSeed.type !== "fixture" && siteSeed.type !== "parent_site") {
+      throw new Error(`Recipe siteSeeds type is unsupported: ${recipePath}`)
+    }
+
+    if (!siteSeed.name || typeof siteSeed.name !== "string") {
+      throw new Error(`Recipe siteSeeds entries must include name: ${recipePath}`)
+    }
+
+    if (siteSeed.type === "fixture" && !siteSeed.source) {
+      throw new Error(`Recipe fixture siteSeeds require source: ${recipePath}`)
+    }
+
+    if (!siteSeed.scopes || typeof siteSeed.scopes !== "object" || Array.isArray(siteSeed.scopes)) {
+      throw new Error(`Recipe siteSeeds entries must include scopes: ${recipePath}`)
+    }
+  }
+
   return recipe
 }
 
@@ -2255,7 +2347,70 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
     }
   }
 
+  for (const [index, siteSeed] of (recipe.inputs?.siteSeeds ?? []).entries()) {
+    await validateRecipeSiteSeed(siteSeed, recipeDirectory, `$.inputs.siteSeeds[${index}]`, addIssue)
+  }
+
   return issues
+}
+
+async function validateRecipeSiteSeed(siteSeed: WorkspaceRecipeSiteSeed, recipeDirectory: string, path: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
+  if (!/^[a-z0-9][a-z0-9_.-]*$/i.test(siteSeed.name)) {
+    addIssue("invalid-site-seed-name", `${path}.name`, `Site seed names must be stable identifiers: ${siteSeed.name}`)
+  }
+
+  if (siteSeed.type === "fixture") {
+    await validateExistingFile(resolve(recipeDirectory, siteSeed.source ?? ""), `${path}.source`, addIssue)
+  }
+
+  if (siteSeed.type === "parent_site" && siteSeed.source) {
+    addIssue("invalid-site-seed-source", `${path}.source`, "Parent-site seed declarations must not name a source file in this dry-run-only slice.")
+  }
+
+  const scopeEntries = Object.entries(siteSeed.scopes).filter(([, value]) => value !== undefined && value !== false)
+  if (scopeEntries.length === 0) {
+    addIssue("missing-site-seed-scopes", `${path}.scopes`, "Site seed declarations must opt in to at least one bounded scope.")
+  }
+
+  for (const [scopeName, scope] of scopeEntries) {
+    if (scope === true) {
+      continue
+    }
+
+    if (!scope || typeof scope !== "object" || Array.isArray(scope)) {
+      addIssue("invalid-site-seed-scope", `${path}.scopes.${scopeName}`, "Site seed scopes must be objects or explicit true flags where supported.")
+      continue
+    }
+
+    validateSiteSeedScopeBounds(scope as NonNullable<WorkspaceRecipeSiteSeed["scopes"]["posts"]>, `${path}.scopes.${scopeName}`, scopeName, siteSeed.type, addIssue)
+  }
+}
+
+function validateSiteSeedScopeBounds(scope: NonNullable<WorkspaceRecipeSiteSeed["scopes"]["posts"]>, path: string, scopeName: string, seedType: WorkspaceRecipeSiteSeed["type"], addIssue: (code: string, path: string, message: string) => void): void {
+  const maxRecords = scope.maxRecords
+  if (maxRecords !== undefined && (!Number.isInteger(maxRecords) || maxRecords < 1 || maxRecords > 100)) {
+    addIssue("invalid-site-seed-bound", `${path}.maxRecords`, "Site seed maxRecords must be an integer from 1 through 100.")
+  }
+
+  if (seedType === "parent_site" && maxRecords === undefined && !hasExplicitSiteSeedSelectors(scope)) {
+    addIssue("unbounded-site-seed-scope", path, "Parent-site scopes require maxRecords or explicit ids/slugs/names selectors before any future export can run.")
+  }
+
+  if (scopeName === "options" && (!scope.names || scope.names.length === 0)) {
+    addIssue("unbounded-site-seed-options", `${path}.names`, "Option seed scopes must name explicit option keys; wildcard option export is not supported.")
+  }
+
+  if (scopeName === "users" && scope.anonymize === false) {
+    addIssue("unsafe-site-seed-users", `${path}.anonymize`, "User seed scopes must keep anonymization enabled unless a future importer explicitly supports reviewed identities.")
+  }
+
+  if (scopeName === "media" && scope.includeFiles === true && seedType === "parent_site") {
+    addIssue("unsafe-site-seed-media-files", `${path}.includeFiles`, "Parent-site media file copying is outside this dry-run-only slice; declare metadata selectors without includeFiles.")
+  }
+}
+
+function hasExplicitSiteSeedSelectors(scope: NonNullable<WorkspaceRecipeSiteSeed["scopes"]["posts"]>): boolean {
+  return [scope.ids, scope.slugs, scope.names].some((values) => Array.isArray(values) && values.length > 0)
 }
 
 async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"][number], path: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
@@ -2468,6 +2623,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: extraPluginMetadata,
+        siteSeeds: recipe.inputs?.siteSeeds ?? [],
         secretEnv: recipe.inputs?.secretEnv ?? [],
         inherit: recipe.inputs?.inherit ?? {},
         inheritance: recipe.inputs?.inheritance ?? {},
@@ -2485,6 +2641,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: extraPluginMetadata,
+        siteSeeds: recipe.inputs?.siteSeeds ?? [],
         secretEnv: recipe.inputs?.secretEnv ?? [],
         inherit: recipe.inputs?.inherit ?? {},
         inheritance: recipe.inputs?.inheritance ?? {},
@@ -2539,6 +2696,51 @@ function recipeDryRunExtraPlugins(recipe: WorkspaceRecipe, recipeDirectory: stri
       provenance,
     }
   })
+}
+
+function recipeDryRunSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string): RecipeDryRunSiteSeed[] {
+  return (recipe.inputs?.siteSeeds ?? []).map((siteSeed, index) => ({
+    index,
+    type: siteSeed.type,
+    name: siteSeed.name,
+    ...(siteSeed.source ? { source: resolve(recipeDirectory, siteSeed.source) } : {}),
+    ...(siteSeed.format ? { format: siteSeed.format } : {}),
+    scopes: siteSeed.scopes,
+    bounded: siteSeedScopesAreBounded(siteSeed),
+    dryRunOnly: true,
+    privacy: {
+      exportsParentSiteData: false,
+      importsIntoSandbox: false,
+      includesRecordData: false,
+      secrets: "excluded-by-default",
+    },
+  }))
+}
+
+function siteSeedScopesAreBounded(siteSeed: WorkspaceRecipeSiteSeed): boolean {
+  for (const [scopeName, scope] of Object.entries(siteSeed.scopes)) {
+    if (!scope || scope === true) {
+      continue
+    }
+
+    if (scopeName === "options" && (!scope.names || scope.names.length === 0)) {
+      return false
+    }
+
+    if (siteSeed.type === "parent_site" && scope.maxRecords === undefined && !hasExplicitSiteSeedSelectors(scope)) {
+      return false
+    }
+
+    if (scopeName === "users" && scope.anonymize === false) {
+      return false
+    }
+
+    if (scopeName === "media" && scope.includeFiles === true && siteSeed.type === "parent_site") {
+      return false
+    }
+  }
+
+  return Object.values(siteSeed.scopes).some((scope) => scope !== undefined && scope !== false)
 }
 
 async function prepareRecipeWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedWorkspaceMount[]> {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -22,6 +22,7 @@ interface RecipeRunOutputLike extends RunOutputLike {
     mounts?: unknown[]
     workspaces?: unknown[]
     extra_plugins?: unknown[]
+    siteSeeds?: unknown[]
   }
   validation?: {
     issues?: Array<{ code: string; path: string; message: string }>
@@ -159,6 +160,7 @@ export function printRecipeHumanOutput(output: RecipeRunOutputLike): void {
     console.log(`Mounts: ${output.plan?.mounts?.length ?? 0}`)
     console.log(`Workspaces: ${output.plan?.workspaces?.length ?? 0}`)
     console.log(`Extra plugins: ${output.plan?.extra_plugins?.length ?? 0}`)
+    console.log(`Site seeds: ${output.plan?.siteSeeds?.length ?? 0}`)
     return
   }
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -103,6 +103,38 @@ export interface WorkspaceRecipeExtraPlugin {
   activate?: boolean
 }
 
+export type WorkspaceRecipeSiteSeedType = "fixture" | "parent_site"
+export type WorkspaceRecipeSiteSeedFormat = "json" | "wxr" | "playground-blueprint"
+
+export interface WorkspaceRecipeSiteSeedScopeSelector {
+  ids?: number[]
+  slugs?: string[]
+  names?: string[]
+  postTypes?: string[]
+  taxonomies?: string[]
+  roles?: string[]
+  statuses?: string[]
+  includeFiles?: boolean
+  anonymize?: boolean
+  maxRecords?: number
+}
+
+export interface WorkspaceRecipeSiteSeed {
+  type: WorkspaceRecipeSiteSeedType
+  name: string
+  source?: string
+  format?: WorkspaceRecipeSiteSeedFormat
+  scopes: {
+    posts?: WorkspaceRecipeSiteSeedScopeSelector
+    terms?: WorkspaceRecipeSiteSeedScopeSelector
+    options?: WorkspaceRecipeSiteSeedScopeSelector
+    users?: WorkspaceRecipeSiteSeedScopeSelector
+    media?: WorkspaceRecipeSiteSeedScopeSelector
+    activePlugins?: boolean
+    activeTheme?: boolean
+  }
+}
+
 export type WorkspaceRecipeSeedType = "plugin_scaffold" | "theme_scaffold" | "directory"
 
 export interface WorkspaceRecipeWorkspaceSeed {
@@ -132,6 +164,7 @@ export interface WorkspaceRecipe {
     extra_plugins?: WorkspaceRecipeExtraPlugin[]
     extraPlugins?: WorkspaceRecipeExtraPlugin[]
     secretEnv?: string[]
+    siteSeeds?: WorkspaceRecipeSiteSeed[]
     inherit?: WorkspaceRecipeInheritanceRequest
     inheritance?: WorkspaceRecipeInheritanceResolution
   }

--- a/scripts/recipe-dry-run-smoke.ts
+++ b/scripts/recipe-dry-run-smoke.ts
@@ -11,10 +11,13 @@ const recipePath = resolve(workspace, "recipe.json")
 const invalidRecipePath = resolve(workspace, "invalid-recipe.json")
 const externalRecipePath = resolve(workspace, "external-recipe.json")
 const externalDisabledRecipePath = resolve(workspace, "external-disabled-recipe.json")
+const invalidSiteSeedRecipePath = resolve(workspace, "invalid-site-seed-recipe.json")
+const fixtureSeedPath = resolve(workspace, "fixture-seed.json")
 const dryRunArtifacts = resolve(workspace, "dry-run-artifacts")
 const multisiteCookbookRecipePath = resolve(root, "examples/recipes/cookbook/multisite-network.json")
 
 mkdirSync(workspace, { recursive: true })
+writeFileSync(fixtureSeedPath, `${JSON.stringify({ posts: [{ slug: "fixture-page" }] }, null, 2)}\n`)
 writeFileSync(recipePath, `${JSON.stringify({
   schema: "wp-codebox/workspace-recipe/v1",
   runtime: {
@@ -40,6 +43,28 @@ writeFileSync(recipePath, `${JSON.stringify({
         pluginFile: "simple-plugin/simple-plugin.php",
       },
     ],
+    siteSeeds: [
+      {
+        type: "fixture",
+        name: "fixture-editorial-shape",
+        source: "./fixture-seed.json",
+        format: "json",
+        scopes: {
+          posts: { slugs: ["fixture-page"], maxRecords: 1 },
+        },
+      },
+      {
+        type: "parent_site",
+        name: "bounded-parent-shape",
+        scopes: {
+          posts: { postTypes: ["page"], slugs: ["sample-page"], maxRecords: 1 },
+          options: { names: ["blogname"], maxRecords: 1 },
+          users: { roles: ["administrator"], maxRecords: 1, anonymize: true },
+          activePlugins: true,
+          activeTheme: true,
+        },
+      },
+    ],
   },
   workflow: {
     steps: [
@@ -62,6 +87,29 @@ writeFileSync(invalidRecipePath, `${JSON.stringify({
       {
         command: "wordpress.run-php",
         args: [],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+writeFileSync(invalidSiteSeedRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    siteSeeds: [
+      {
+        type: "parent_site",
+        name: "unsafe-parent-users",
+        scopes: {
+          users: { roles: ["administrator"], anonymize: false },
+        },
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: ["code=echo 'invalid seed';"],
       },
     ],
   },
@@ -126,6 +174,13 @@ assert.equal(output.plan.workspaces.length, 1)
 assert.equal(output.plan.workspaces[0].generated, true)
 assert.equal(output.plan.workspaces[0].source, undefined)
 assert.equal(output.plan.extra_plugins[0].target, "/wordpress/wp-content/plugins/simple-plugin")
+assert.equal(output.plan.siteSeeds.length, 2)
+assert.equal(output.plan.siteSeeds[0].source, fixtureSeedPath)
+assert.equal(output.plan.siteSeeds[0].privacy.includesRecordData, false)
+assert.equal(output.plan.siteSeeds[1].type, "parent_site")
+assert.equal(output.plan.siteSeeds[1].bounded, true)
+assert.equal(output.plan.siteSeeds[1].privacy.exportsParentSiteData, false)
+assert.equal(output.plan.siteSeeds[1].privacy.importsIntoSandbox, false)
 assert.equal(output.plan.secretEnv[0].name, "DRY_RUN_TOKEN")
 assert.equal(Object.prototype.hasOwnProperty.call(output.plan.secretEnv[0], "value"), false)
 assert.equal(output.plan.secretEnv[0].available, true)
@@ -154,6 +209,20 @@ const invalidOutput = JSON.parse(invalidResult.stdout)
 assert.equal(invalidOutput.success, false)
 assert.equal(invalidOutput.valid, false)
 assert.equal(invalidOutput.validation.issues[0].code, "missing-code")
+
+const invalidSiteSeedResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  invalidSiteSeedRecipePath,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(invalidSiteSeedResult.status, 1, invalidSiteSeedResult.stderr || invalidSiteSeedResult.stdout)
+const invalidSiteSeedOutput = JSON.parse(invalidSiteSeedResult.stdout)
+assert.equal(invalidSiteSeedOutput.success, false)
+assert.equal(invalidSiteSeedOutput.validation.issues.some((issue: { code: string }) => issue.code === "unsafe-site-seed-users"), true)
 
 const externalResult = spawnSync(process.execPath, [
   cli,


### PR DESCRIPTION
## Summary
- Add `inputs.siteSeeds` recipe types/schema for explicit fixture and parent-site seed declarations.
- Validate bounded/minimized seed scopes and surface a dry-run-only `plan.siteSeeds` payload with privacy flags.
- Document that this slice does not export parent-site data or import seed records into Playground.

## Tests
- `npm run build`
- `npm run recipe-dry-run-smoke`
- `npm run discovery-command-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the first-slice schema, dry-run planner, validation, docs, and smoke-test updates; Chris remains responsible for review and acceptance.

Fixes #108 for the first dry-run planning slice.