### PR TITLE
Document external apply adapter contract

### DIFF
--- a/docs/external-apply-adapter-contract.md
+++ b/docs/external-apply-adapter-contract.md
@@ -1,0 +1,82 @@
+# External Apply Adapter Contract
+
+WP Codebox owns the sandbox and artifact boundary. A parent control plane owns
+the product-specific apply-back adapter, such as opening a branch and pull
+request in an external system.
+
+## Boundary
+
+```text
+WP Codebox sandbox
+  -> artifact bundle
+  -> parent review approval
+  -> wp-codebox/apply-approved-artifact
+  -> wp_codebox_apply_approved_artifact filter payload
+  -> external adapter records branch, commit, PR URL, and artifact digest
+```
+
+WP Codebox core validates the artifact before delegation:
+
+- `manifest.json` id matches `artifact-bundle-sha256-<contentDigest>`.
+- `contentDigest.value` matches `files/changed-files.json` plus `files/patch.diff`.
+- `approved_files[]` contains only sandbox paths from `changed-files.json`.
+- `patch_sha256` identifies the exact delegated patch body.
+
+The external adapter receives the validated payload through
+`wp_codebox_apply_approved_artifact`. The adapter may use opaque artifact
+metadata such as mount `repo`, `branch`, `commit`, or product routing fields, but
+WP Codebox does not interpret those fields or call the adapter's system directly.
+
+## Adapter Result
+
+An adapter should return product metadata that the parent control plane can audit
+outside WP Codebox:
+
+```json
+{
+  "adapter": "parent-control-plane",
+  "artifact_id": "artifact-bundle-sha256-...",
+  "artifact_content_digest": "...",
+  "patch_sha256": "...",
+  "branch": "codebox/apply-generated-file",
+  "commit": "abc1234",
+  "pr_url": "https://github.com/example/example-plugin/pull/123"
+}
+```
+
+WP Codebox records the adapter result in `apply-audit.jsonl` with sensitive keys
+redacted. The external system remains responsible for durable branch, commit, PR,
+and reviewer workflow records.
+
+## Smoke Fixture
+
+`npm run external-adapter-contract-smoke` demonstrates the contract without
+depending on Homeboy, Data Machine Code, or any other apply-back implementation.
+The fixture builds a verified artifact payload, runs a stand-in parent control
+plane adapter, and persists this external record shape:
+
+```json
+{
+  "schema": "wp-codebox/external-apply-record/v1",
+  "adapter": { "name": "fixture-parent-control-plane", "version": "2026-05-25" },
+  "artifact": {
+    "id": "artifact-bundle-sha256-...",
+    "content_digest": "...",
+    "patch_sha256": "...",
+    "approved_files": ["/wordpress/wp-content/plugins/example/generated.txt"]
+  },
+  "target": {
+    "repo": "example/example-plugin",
+    "branch": "codebox/apply-generated-file",
+    "commit": "abc1234",
+    "files": ["generated.txt"]
+  },
+  "result": {
+    "status": "pr-opened",
+    "pr_url": "https://github.com/example/example-plugin/pull/123"
+  }
+}
+```
+
+The smoke asserts that the external record includes adapter metadata, PR URL,
+branch, commit, and artifact digest while excluding the raw patch body.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "release:package": "tsx scripts/package-release-artifact.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
+    "external-adapter-contract-smoke": "tsx scripts/external-adapter-contract-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "core-phpunit-command-smoke": "tsx scripts/core-phpunit-command-smoke.ts",
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
@@ -50,7 +51,7 @@
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -114,6 +114,12 @@ Without Data Machine pending actions, `stage-artifact-apply` fails closed with
 available through `apply-approved-artifact` for hosts that provide their own
 approval surface.
 
+See [External Apply Adapter Contract](../../docs/external-apply-adapter-contract.md)
+for the parent-control-plane contract. The documented smoke fixture proves that
+an external adapter can consume the verified artifact payload and record adapter
+metadata, PR URL, branch, commit, and artifact digest without WP Codebox calling
+Homeboy, Data Machine Code, or any other product-specific apply-back system.
+
 ## Configuration
 
 Component paths can be supplied by ability input, the

--- a/scripts/external-adapter-contract-smoke.ts
+++ b/scripts/external-adapter-contract-smoke.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+interface ArtifactBundlePayload {
+  artifact_id: string
+  artifact: {
+    id: string
+    content_digest: string
+    changed_files: {
+      schema: "wp-codebox/changed-files/v1"
+      files: Array<{
+        path: string
+        status: string
+        mountTarget: string
+        relativePath: string
+      }>
+    }
+    metadata: {
+      provenance: {
+        mounts: Array<{
+          target: string
+          metadata?: Record<string, unknown>
+        }>
+      }
+    }
+    review: {
+      schema: "wp-codebox/artifact-review/v1"
+      evidence: {
+        artifactContentDigest: string
+        patch: string
+      }
+    }
+  }
+  approved_files: string[]
+  patch: string
+  patch_sha256: string
+  artifact_content_digest: string
+}
+
+interface ExternalApplyRecord {
+  schema: "wp-codebox/external-apply-record/v1"
+  adapter: {
+    name: string
+    version: string
+  }
+  artifact: {
+    id: string
+    content_digest: string
+    patch_sha256: string
+    approved_files: string[]
+  }
+  target: {
+    repo: string
+    branch: string
+    commit: string
+    files: string[]
+  }
+  result: {
+    status: "pr-opened"
+    pr_url: string
+  }
+}
+
+function artifactContentDigest(changedFilesJson: string, patch: string): string {
+  return createHash("sha256")
+    .update("wp-codebox/artifact-content/v1\n")
+    .update("files/changed-files.json\n")
+    .update(changedFilesJson)
+    .update("\nfiles/patch.diff\n")
+    .update(patch)
+    .digest("hex")
+}
+
+function externalParentControlPlaneApply(payload: ArtifactBundlePayload): ExternalApplyRecord {
+  assert.equal(payload.artifact_id, payload.artifact.id)
+  assert.equal(payload.artifact_content_digest, payload.artifact.content_digest)
+  assert.equal(payload.artifact.review.evidence.artifactContentDigest, payload.artifact_content_digest)
+  assert.equal(createHash("sha256").update(payload.patch).digest("hex"), payload.patch_sha256)
+
+  const changedPaths = new Set(payload.artifact.changed_files.files.map((file) => file.path))
+  for (const approvedFile of payload.approved_files) {
+    assert.equal(changedPaths.has(approvedFile), true, `${approvedFile} must be present in changed-files.json`)
+  }
+
+  const editableMount = payload.artifact.metadata.provenance.mounts.find(
+    (mount) => mount.target === "/wordpress/wp-content/plugins/example" && mount.metadata?.editable === true,
+  )
+  assert.ok(editableMount, "artifact provenance must carry opaque mount metadata for the external adapter")
+
+  const repo = editableMount.metadata?.repo
+  const branch = editableMount.metadata?.branch
+  const commit = editableMount.metadata?.commit
+  assert.equal(typeof repo, "string")
+  assert.equal(typeof branch, "string")
+  assert.equal(typeof commit, "string")
+
+  return {
+    schema: "wp-codebox/external-apply-record/v1",
+    adapter: {
+      name: "fixture-parent-control-plane",
+      version: "2026-05-25",
+    },
+    artifact: {
+      id: payload.artifact_id,
+      content_digest: payload.artifact_content_digest,
+      patch_sha256: payload.patch_sha256,
+      approved_files: payload.approved_files,
+    },
+    target: {
+      repo,
+      branch,
+      commit,
+      files: payload.approved_files.map((path) => path.replace("/wordpress/wp-content/plugins/example/", "")),
+    },
+    result: {
+      status: "pr-opened",
+      pr_url: "https://github.com/example/example-plugin/pull/123",
+    },
+  }
+}
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-external-adapter-"))
+
+try {
+  const changedFiles = {
+    schema: "wp-codebox/changed-files/v1" as const,
+    files: [
+      {
+        path: "/wordpress/wp-content/plugins/example/generated.txt",
+        status: "added",
+        mountTarget: "/wordpress/wp-content/plugins/example",
+        relativePath: "generated.txt",
+      },
+    ],
+  }
+  const patch = "diff --git a/generated.txt b/generated.txt\nnew file mode 100644\n--- /dev/null\n+++ b/generated.txt\n@@ -0,0 +1 @@\n+cooked\n"
+  const changedFilesJson = `${JSON.stringify(changedFiles, null, 2)}\n`
+  const digest = artifactContentDigest(changedFilesJson, patch)
+  const artifactId = `artifact-bundle-sha256-${digest}`
+  const patchSha256 = createHash("sha256").update(patch).digest("hex")
+
+  const artifact = {
+    id: artifactId,
+    content_digest: digest,
+    changed_files: changedFiles,
+    metadata: {
+      provenance: {
+        mounts: [
+          {
+            target: "/wordpress/wp-content/plugins/example",
+            metadata: {
+              editable: true,
+              repo: "example/example-plugin",
+              branch: "codebox/apply-generated-file",
+              commit: "abc1234",
+            },
+          },
+        ],
+      },
+    },
+    review: {
+      schema: "wp-codebox/artifact-review/v1" as const,
+      evidence: {
+        artifactContentDigest: digest,
+        patch: "files/patch.diff",
+      },
+    },
+  }
+
+  const payload: ArtifactBundlePayload = {
+    artifact_id: artifactId,
+    artifact,
+    approved_files: ["/wordpress/wp-content/plugins/example/generated.txt"],
+    patch,
+    patch_sha256: patchSha256,
+    artifact_content_digest: digest,
+  }
+
+  const record = externalParentControlPlaneApply(payload)
+  const recordPath = join(root, "external-apply-record.json")
+  await writeFile(recordPath, `${JSON.stringify(record, null, 2)}\n`)
+
+  const persisted = JSON.parse(await readFile(recordPath, "utf8")) as ExternalApplyRecord
+  assert.equal(persisted.adapter.name, "fixture-parent-control-plane")
+  assert.equal(persisted.result.pr_url, "https://github.com/example/example-plugin/pull/123")
+  assert.equal(persisted.target.branch, "codebox/apply-generated-file")
+  assert.equal(persisted.target.commit, "abc1234")
+  assert.equal(persisted.artifact.content_digest, digest)
+  assert.equal(JSON.stringify(persisted).includes(patch), false, "external record must not persist the raw patch body")
+
+  console.log(`OK external adapter contract smoke wrote ${recordPath}`)
+} finally {
+  await rm(root, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Add a focused external adapter contract smoke that verifies a parent control plane can consume a validated artifact payload and persist adapter metadata externally.
- Document the apply-back boundary so WP Codebox delegates through the adapter filter without depending on Homeboy, Data Machine Code, or any product-specific apply system.
- Wire the smoke into `npm run check` so the contract remains covered.

## Tests
- `npm run external-adapter-contract-smoke`
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the documentation and focused smoke fixture; Chris remains responsible for review and merge.