### PR TITLE
Define connector-scoped credential envelope

### DIFF
--- a/docs/portable-wp-codebox.md
+++ b/docs/portable-wp-codebox.md
@@ -44,7 +44,32 @@ The v0 policy is intentionally small and backend-agnostic. Core validation prove
 | `commands` | Yes. Backends can call `assertRuntimeCommandAllowed()` before execution. Disallowed commands raise `RuntimeCommandPolicyViolationError` with structured `toJSON()` output for artifacts. | The complete command allow-list requested by the control plane. |
 | `network` | Shape only. `allow`, `deny`, and host allow-lists are validated. | The network boundary that a real runtime backend must enforce. |
 | `filesystem` | Shape only. Mount and write behavior still belongs to backend implementations. | The intended filesystem boundary for sandbox-local writes and mounted inputs. |
-| `secrets` | Shape only. No secret injection is implemented in the runtime stub. | Whether future control planes may inject no secrets or connector-scoped secrets. |
+| `secrets` | Connector-scoped names can be declared and redacted from artifacts. Secret values stay in parent environment variables and are not accepted in recipe, args, logs, or artifacts. | Whether a control plane may inject no secrets or connector-scoped secrets. |
 | `approvals` | Shape only. No approval UI is implemented in the runtime stub. | The approval posture expected by a product surface before writes or commands. |
 
 This keeps the v0 contract honest: `commands` are actively denied by the stub, while the remaining fields are explicit declarations that can be carried into artifacts and enforced as backends become real.
+
+## Connector-Scoped Credential Envelope
+
+Parent sites resolve connector credentials through an explicit envelope. The envelope is provenance, not transport: it names the connector scope and sandbox environment variable names, but never includes secret values.
+
+```json
+{
+  "schema": "wp-codebox/connector-credentials/v1",
+  "connector": "primary-ai",
+  "scope": "connector",
+  "status": "available",
+  "secrets": [
+    {
+      "name": "OPENAI_API_KEY",
+      "status": "available",
+      "scope": "primary-ai",
+      "source": "parent-env"
+    }
+  ]
+}
+```
+
+Status values are `available`, `missing`, or `denied`. A parent WordPress runner fails closed before launching the sandbox when any requested connector credential envelope or secret reports `missing` or `denied`, returning `wp-codebox/connector-credential-failure/v1` with the same redacted connector/secret names and reasons.
+
+Successful runs carry the sanitized envelope through `inputs.inheritance.connectors[].credentials` and artifact provenance. Artifact redaction treats configured secret names and values as redactable, so provenance, logs, patches, mounted files, and review metadata expose only names/status/source/scope.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -649,6 +649,32 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
         provider: { type: "string" },
         model: { type: "string" },
         secretEnv: { type: "array", items: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" } },
+        credentials: { $ref: "#/$defs/connectorCredentialEnvelope" },
+      },
+    },
+    connectorCredentialEnvelope: {
+      type: "object",
+      additionalProperties: false,
+      required: ["schema", "connector", "scope", "status", "secrets"],
+      properties: {
+        schema: { const: "wp-codebox/connector-credentials/v1" },
+        connector: { type: "string" },
+        scope: { const: "connector" },
+        status: { enum: ["available", "missing", "denied"] },
+        reason: { type: "string" },
+        secrets: { type: "array", items: { $ref: "#/$defs/connectorCredentialSecret" } },
+      },
+    },
+    connectorCredentialSecret: {
+      type: "object",
+      additionalProperties: false,
+      required: ["name", "status"],
+      properties: {
+        name: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" },
+        status: { enum: ["available", "missing", "denied"] },
+        scope: { type: "string" },
+        source: { type: "string" },
+        reason: { type: "string" },
       },
     },
     inheritanceSetting: {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -154,6 +154,26 @@ export interface WorkspaceRecipeInheritanceConnector {
   provider?: string
   model?: string
   secretEnv?: string[]
+  credentials?: ConnectorCredentialEnvelope
+}
+
+export type ConnectorCredentialStatus = "available" | "missing" | "denied"
+
+export interface ConnectorCredentialSecret {
+  name: string
+  status: ConnectorCredentialStatus
+  scope?: string
+  source?: "parent-env" | "connector" | (string & {})
+  reason?: string
+}
+
+export interface ConnectorCredentialEnvelope {
+  schema: "wp-codebox/connector-credentials/v1"
+  connector: string
+  scope: "connector"
+  status: ConnectorCredentialStatus
+  secrets: ConnectorCredentialSecret[]
+  reason?: string
 }
 
 export interface WorkspaceRecipeInheritanceSetting {

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -88,7 +88,7 @@ final class WP_Codebox_Abilities {
 							'inherit'                => $inherit_schema,
 							'secret_env'             => array(
 								'type'        => 'array',
-								'description' => 'Parent environment variable names to expose inside the sandbox. Pass names such as GITHUB_TOKEN; values are read from the parent process and are not accepted in this payload.',
+								'description' => 'Explicit parent environment variable names to expose inside the sandbox. Prefer connector-scoped inheritance credentials for product flows. Values are read from the parent process and are not accepted in this payload.',
 								'items'       => array( 'type' => 'string' ),
 							),
 							'session_id'             => array(
@@ -380,9 +380,36 @@ final class WP_Codebox_Abilities {
 
 	/** @return array<string,mixed> */
 	private static function inherit_schema(): array {
+		$credential_secret_schema = array(
+			'type'       => 'object',
+			'required'   => array( 'name', 'status' ),
+			'properties' => array(
+				'name'   => array(
+					'type'        => 'string',
+					'description' => 'Sandbox environment variable name. Secret values are never transported.',
+				),
+				'status' => array(
+					'type' => 'string',
+					'enum' => array( 'available', 'missing', 'denied' ),
+				),
+				'scope'  => array(
+					'type'        => 'string',
+					'description' => 'Parent-side connector scope that authorized this secret name.',
+				),
+				'source' => array(
+					'type'        => 'string',
+					'description' => 'Redacted source label, such as parent-env or connector.',
+				),
+				'reason' => array(
+					'type'        => 'string',
+					'description' => 'Redacted missing/denied reason for audit surfaces.',
+				),
+			),
+		);
+
 		return array(
 			'type'        => 'object',
-			'description' => 'Declarative request for parent-environment connector or setting inheritance. Parent filters resolve names into a sanitized sandbox payload; secret values are never accepted here.',
+			'description' => 'Declarative request for parent-environment connector or setting inheritance. Parent filters resolve names into a sanitized sandbox payload with explicit connector-scoped credential envelopes; secret values are never accepted here.',
 			'properties'  => array(
 				'connectors' => array(
 					'type'        => 'array',
@@ -393,6 +420,18 @@ final class WP_Codebox_Abilities {
 					'type'        => 'array',
 					'description' => 'Setting names the parent environment should resolve for artifact/audit metadata. Values are not transported in this slice.',
 					'items'       => array( 'type' => 'string' ),
+				),
+				'credentials' => array(
+					'type'        => 'object',
+					'description' => 'Observable credential envelope shape returned under inheritance.connectors[].credentials by parent filters. Values are not accepted.',
+					'properties'  => array(
+						'schema'    => array( 'type' => 'string' ),
+						'connector' => array( 'type' => 'string' ),
+						'scope'     => array( 'type' => 'string', 'enum' => array( 'connector' ) ),
+						'status'    => array( 'type' => 'string', 'enum' => array( 'available', 'missing', 'denied' ) ),
+						'reason'    => array( 'type' => 'string' ),
+						'secrets'   => array( 'type' => 'array', 'items' => $credential_secret_schema ),
+					),
 				),
 			),
 		);

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -459,10 +459,115 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				$entry['secretEnv'] = array_values( array_unique( $secret_env ) );
 			}
 
+			$credentials = $this->sanitize_connector_credentials( $connector['credentials'] ?? null, $name );
+			if ( ! empty( $credentials ) ) {
+				$entry['credentials'] = $credentials;
+			}
+
 			$sanitized[] = $entry;
 		}
 
 		return $sanitized;
+	}
+
+	/** @return array<string,mixed> */
+	private function sanitize_connector_credentials( mixed $credentials, string $connector_name ): array {
+		if ( ! is_array( $credentials ) ) {
+			return array();
+		}
+
+		$status = $this->credential_status( (string) ( $credentials['status'] ?? 'missing' ) );
+		$entry  = array(
+			'schema'    => 'wp-codebox/connector-credentials/v1',
+			'connector' => $connector_name,
+			'scope'     => 'connector',
+			'status'    => $status,
+			'secrets'   => array(),
+		);
+
+		$reason = $this->redacted_reason( $credentials['reason'] ?? '' );
+		if ( '' !== $reason ) {
+			$entry['reason'] = $reason;
+		}
+
+		foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
+			if ( ! is_array( $secret ) ) {
+				continue;
+			}
+
+			$name = trim( (string) ( $secret['name'] ?? '' ) );
+			if ( 1 !== preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) {
+				continue;
+			}
+
+			$secret_entry = array(
+				'name'   => $name,
+				'status' => $this->credential_status( (string) ( $secret['status'] ?? $status ) ),
+			);
+
+			foreach ( array( 'scope', 'source', 'reason' ) as $field ) {
+				$value = 'reason' === $field ? $this->redacted_reason( $secret[ $field ] ?? '' ) : trim( (string) ( $secret[ $field ] ?? '' ) );
+				if ( '' !== $value ) {
+					$secret_entry[ $field ] = $value;
+				}
+			}
+
+			$entry['secrets'][] = $secret_entry;
+		}
+
+		return $entry;
+	}
+
+	private function credential_status( string $status ): string {
+		return in_array( $status, array( 'available', 'missing', 'denied' ), true ) ? $status : 'missing';
+	}
+
+	private function redacted_reason( mixed $reason ): string {
+		$reason = trim( (string) $reason );
+		if ( '' === $reason ) {
+			return '';
+		}
+
+		return substr( preg_replace( '/[^A-Za-z0-9 .:_-]/', '', $reason ) ?? '', 0, 160 );
+	}
+
+	/** @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
+	private function connector_credentials_error( array $inheritance ): WP_Error|null {
+		$failures = array();
+		foreach ( $inheritance['connectors'] as $connector ) {
+			$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
+			if ( empty( $credentials ) ) {
+				continue;
+			}
+
+			$status = (string) ( $credentials['status'] ?? 'missing' );
+			$secrets = array_filter(
+				is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array(),
+				static fn( mixed $secret ): bool => is_array( $secret ) && in_array( (string) ( $secret['status'] ?? '' ), array( 'missing', 'denied' ), true )
+			);
+
+			if ( in_array( $status, array( 'missing', 'denied' ), true ) || ! empty( $secrets ) ) {
+				$failures[] = array(
+					'name'        => (string) ( $connector['name'] ?? '' ),
+					'status'      => (string) ( $connector['status'] ?? '' ),
+					'credentials' => $credentials,
+				);
+			}
+		}
+
+		if ( empty( $failures ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'wp_codebox_connector_credentials_unavailable',
+			'Requested connector credentials are missing or denied for this sandbox scope.',
+			array(
+				'status'     => 403,
+				'schema'     => 'wp-codebox/connector-credential-failure/v1',
+				'connectors' => $failures,
+			)
+		);
 	}
 
 	/** @param array<int,mixed> $settings Inheritance setting rows. @return array<int,array<string,mixed>> */
@@ -524,6 +629,13 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		foreach ( ( $inheritance ?? $this->inheritance_resolution( $input ) )['connectors'] as $connector ) {
 			if ( is_array( $connector['secretEnv'] ?? null ) ) {
 				$names = array_merge( $names, $connector['secretEnv'] );
+			}
+
+			$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
+			foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
+				if ( is_array( $secret ) && 'available' === ( $secret['status'] ?? '' ) ) {
+					$names[] = (string) ( $secret['name'] ?? '' );
+				}
 			}
 		}
 
@@ -721,6 +833,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	 */
 	private function write_agent_recipe( array $paths, array $input, array $task_prompts, string $wp_version ): string|WP_Error {
 		$inheritance = $this->inheritance_resolution( $input );
+		$credential_error = $this->connector_credentials_error( $inheritance );
+		if ( null !== $credential_error ) {
+			return $credential_error;
+		}
+
 		$provider_plugins = array_map(
 			fn( string $path ): array => array(
 				'source'   => $path,

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -269,7 +269,29 @@ try {
       secretEnv: { [secretName]: secretValue },
       metadata: {
         runtime: { version: "0.0.0" },
-        task: { kind: "agent-sandbox-run", input: `Redact ${secretName}` },
+        task: {
+          kind: "agent-sandbox-run",
+          input: `Redact ${secretName}`,
+          inheritance: {
+            connectors: [
+              {
+                name: "primary-ai",
+                status: "resolved",
+                provider: "openai",
+                model: "gpt-5.5",
+                credentials: {
+                  schema: "wp-codebox/connector-credentials/v1",
+                  connector: "primary-ai",
+                  scope: "connector",
+                  status: "available",
+                  secrets: [
+                    { name: secretName, status: "available", scope: "primary-ai", source: "parent-env" },
+                  ],
+                },
+              },
+            ],
+          },
+        },
       },
     },
     createPlaygroundRuntimeBackend(),
@@ -309,6 +331,8 @@ try {
   assert.equal(redactionReview.redaction.status, "redacted")
   assert.ok(redactionReview.redaction.total >= 3)
   assert.ok(redactionReview.riskFlags.includes("secrets-redacted"))
+  assert.equal(redactionReview.provenance.task.inheritance.connectors[0].credentials.schema, "wp-codebox/connector-credentials/v1")
+  assert.equal(redactionReview.provenance.task.inheritance.connectors[0].credentials.status, "available")
   await redactionRuntime.destroy()
 
   console.log("Artifact contract smoke passed")

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -96,6 +96,7 @@ $assert( 'ability exposes expected artifacts schema', 'array' === ( $ability['in
 $assert( 'ability exposes policy and context schema', 'object' === ( $ability['input_schema']['properties']['policy']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['context']['type'] ?? '' ) );
 $assert( 'ability exposes generic mounts schema', 'array' === ( $ability['input_schema']['properties']['mounts']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['mounts']['items']['properties']['metadata']['type'] ?? '' ) );
 $assert( 'ability exposes inheritance request schema', 'object' === ( $ability['input_schema']['properties']['inherit']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['connectors']['type'] ?? '' ) );
+$assert( 'ability exposes connector credential envelope schema', 'object' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['properties']['secrets']['type'] ?? '' ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
@@ -203,6 +204,20 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( ar
 			'provider'   => 'openai',
 			'model'      => 'gpt-5.5',
 			'secret_env' => array( 'OPENAI_API_KEY' ),
+			'credentials' => array(
+				'schema'    => 'wp-codebox/connector-credentials/v1',
+				'connector' => $request['connectors'][0] ?? 'primary-ai',
+				'scope'     => 'connector',
+				'status'    => 'available',
+				'secrets'   => array(
+					array(
+						'name'   => 'OPENAI_API_KEY',
+						'status' => 'available',
+						'scope'  => 'primary-ai',
+						'source' => 'parent-env',
+					),
+				),
+			),
 			'value'      => 'sk-test-secret-value',
 			'token'      => 'sk-test-secret-value',
 		),
@@ -234,8 +249,79 @@ $inherit_step_args = $inherit_recipe['workflow']['steps'][0]['args'] ?? array();
 $assert( 'runner resolves inherited connector provider', ! is_wp_error( $inherit_result ) && in_array( 'provider=openai', $inherit_step_args, true ) );
 $assert( 'runner resolves inherited connector model', ! is_wp_error( $inherit_result ) && in_array( 'model=gpt-5.5', $inherit_step_args, true ) );
 $assert( 'runner transports inherited secret env name only', ! is_wp_error( $inherit_result ) && in_array( 'OPENAI_API_KEY', $inherit_recipe['inputs']['secretEnv'] ?? array(), true ) && ! str_contains( $captured_recipe, 'OPENAI_API_KEY=' ) );
+$assert( 'runner records connector credential provenance without value', ! is_wp_error( $inherit_result ) && 'wp-codebox/connector-credentials/v1' === ( $inherit_recipe['inputs']['inheritance']['connectors'][0]['credentials']['schema'] ?? '' ) && 'available' === ( $inherit_recipe['inputs']['inheritance']['connectors'][0]['credentials']['secrets'][0]['status'] ?? '' ) );
 $assert( 'runner records sanitized inheritance status', ! is_wp_error( $inherit_result ) && 'primary-ai' === ( $inherit_recipe['inputs']['inheritance']['connectors'][0]['name'] ?? '' ) && 'resolved' === ( $inherit_recipe['inputs']['inheritance']['settings'][0]['status'] ?? '' ) );
 $assert( 'runner drops inherited secret values from recipe', ! str_contains( $captured_recipe, 'sk-test-secret-value' ) && ! str_contains( $captured_recipe, 'token' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ): array {
+	$resolution['connectors'] = array(
+		array(
+			'name'        => $request['connectors'][0] ?? 'primary-ai',
+			'status'      => 'resolved',
+			'provider'    => 'openai',
+			'model'       => 'gpt-5.5',
+			'credentials' => array(
+				'schema'    => 'wp-codebox/connector-credentials/v1',
+				'connector' => $request['connectors'][0] ?? 'primary-ai',
+				'scope'     => 'connector',
+				'status'    => 'denied',
+				'reason'    => 'scope not approved',
+				'secrets'   => array(
+					array(
+						'name'   => 'OPENAI_API_KEY',
+						'status' => 'denied',
+						'scope'  => 'primary-ai',
+						'source' => 'connector',
+						'reason' => 'scope not approved',
+					),
+				),
+			),
+		),
+	);
+
+	return $resolution;
+};
+
+$denied_credentials = $runner->run(
+	array(
+		'goal'           => 'Use denied connector credentials.',
+		'artifacts_path' => $root . '/artifacts',
+		'inherit'        => array( 'connectors' => array( 'primary-ai' ) ),
+	)
+);
+$assert( 'denied connector credential scope fails closed', is_wp_error( $denied_credentials ) && 'wp_codebox_connector_credentials_unavailable' === $denied_credentials->get_error_code() );
+$assert( 'denied connector credential failure is observable and redacted', is_wp_error( $denied_credentials ) && 'wp-codebox/connector-credential-failure/v1' === ( $denied_credentials->get_error_data()['schema'] ?? '' ) && ! str_contains( json_encode( $denied_credentials->get_error_data() ), 'sk-test-secret-value' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ): array {
+	$resolution['connectors'] = array(
+		array(
+			'name'        => $request['connectors'][0] ?? 'primary-ai',
+			'status'      => 'resolved',
+			'provider'    => 'openai',
+			'model'       => 'gpt-5.5',
+			'credentials' => array(
+				'schema'    => 'wp-codebox/connector-credentials/v1',
+				'connector' => $request['connectors'][0] ?? 'primary-ai',
+				'scope'     => 'connector',
+				'status'    => 'missing',
+				'secrets'   => array(
+					array( 'name' => 'OPENAI_API_KEY', 'status' => 'missing', 'scope' => 'primary-ai', 'source' => 'parent-env' ),
+				),
+			),
+		),
+	);
+
+	return $resolution;
+};
+
+$missing_credentials = $runner->run(
+	array(
+		'goal'           => 'Use missing connector credentials.',
+		'artifacts_path' => $root . '/artifacts',
+		'inherit'        => array( 'connectors' => array( 'primary-ai' ) ),
+	)
+);
+$assert( 'missing connector credential scope fails closed', is_wp_error( $missing_credentials ) && 'wp_codebox_connector_credentials_unavailable' === $missing_credentials->get_error_code() );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model']    = 'gpt-5.5';


### PR DESCRIPTION
## Summary
- Defines the `wp-codebox/connector-credentials/v1` envelope for connector-scoped secret provenance without transporting secret values.
- Adds WordPress runner sanitization and fail-closed handling for missing or denied connector credential scopes.
- Documents the contract and covers redacted provenance plus missing/denied credential failures in focused smoke tests.

Fixes #24

## Tests
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run artifact-contract-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the credential envelope contract, runner guardrails, docs, and focused smoke coverage; Chris remains responsible for review and merge.