### PR TITLE
Define generic sandbox session contract

### DIFF
--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -1,0 +1,87 @@
+# Sandbox Session Contract
+
+WP Codebox keeps sandbox execution generic and host-storage agnostic. It does not
+create host-site database tables or own a queue. Parent control planes that need
+durable sessions should create their own job/session record, then call WP Codebox
+with a caller-owned `sandbox_session_id`.
+
+## Boundary
+
+```text
+Parent control plane
+  owns users, queues, jobs, retries, cancellation, retention, and UI history
+    -> calls wp-codebox/run-agent-task with sandbox_session_id
+      -> WP Codebox shells out to the CLI and captures artifacts
+    <- returns wp-codebox/sandbox-session/v1 for correlation
+
+Disposable Playground sandbox
+  may mount Agents API, Data Machine, Data Machine Code, and provider plugins
+  owns in-sandbox agent behavior only
+```
+
+The host WP Codebox plugin should not depend on a specific parent job system.
+Data Machine, Homeboy, DMC, Studio, or a custom host app can all be external
+orchestrators that consume the same abilities and artifact contracts.
+
+## Request Fields
+
+`wp-codebox/run-agent-task` and `wp-codebox/run-agent-task-batch` accept these
+optional correlation fields:
+
+```json
+{
+  "sandbox_session_id": "external-job-123",
+  "session_id": "sandbox-agent-conversation-456",
+  "orchestrator": {
+    "type": "data-machine-job",
+    "id": "parent-site-control-plane",
+    "job_id": "123"
+  }
+}
+```
+
+- `sandbox_session_id` is caller-owned. WP Codebox echoes it in the response and
+  does not persist it.
+- `session_id` remains the in-sandbox agent conversation/session id passed to the
+  mounted agent runtime.
+- `orchestrator` is opaque correlation metadata for external job systems.
+
+## Response Shape
+
+The ability response includes a `wp-codebox/sandbox-session/v1` envelope:
+
+```json
+{
+  "session": {
+    "schema": "wp-codebox/sandbox-session/v1",
+    "id": "external-job-123",
+    "status": "completed",
+    "persistence": "external-orchestrator",
+    "agent_session_id": "sandbox-agent-conversation-456",
+    "orchestrator": {
+      "type": "data-machine-job",
+      "id": "parent-site-control-plane",
+      "job_id": "123"
+    },
+    "artifacts": {
+      "path": "/srv/artifacts/run-123",
+      "bundle_id": "artifact-bundle-sha256-...",
+      "preview_url": "https://preview.example.test/abc"
+    }
+  }
+}
+```
+
+The `status` field describes the synchronous WP Codebox call result. Durable
+queued/running/cancelled/expired transitions belong to the external orchestrator.
+
+## External Orchestrator Responsibilities
+
+- Store durable job/session state and user ownership.
+- Enforce quotas, cancellation, concurrency, and retention.
+- Decide whether to retry failed runs.
+- Store links to returned artifact ids and preview URLs.
+- Call WP Codebox artifact abilities for review, discard, or approved apply-back.
+
+WP Codebox owns the sandbox run and artifact contract. It intentionally does not
+own the parent site's job tables or product lifecycle UI.

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -44,6 +44,13 @@ task with bounded concurrency. This is the parent-site primitive for fan-out
 workflows such as assigning several GitHub issues to separate sandbox coding
 agents.
 
+Parent control planes that need durable job/session state should own that state
+outside WP Codebox and pass a caller-owned `sandbox_session_id`. WP Codebox
+returns a `wp-codebox/sandbox-session/v1` envelope with that id, optional
+`orchestrator` correlation metadata, and artifact references, but it does not
+create host-site job tables or depend on a specific queue. See
+`docs/sandbox-session-contract.md`.
+
 Both abilities accept optional `provider` and `model` fields. These seed the
 disposable sandbox's Data Machine agent configuration for the selected execution
 mode. Provider plugins are supplied with `provider_plugin_paths`; WP Codebox

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -29,6 +29,8 @@ final class WP_Codebox_Abilities {
 			$task_input_schema  = self::task_input_schema();
 			$mount_schema      = self::mount_schema();
 			$inherit_schema    = self::inherit_schema();
+			$session_schema    = self::sandbox_session_schema();
+			$session_input     = self::sandbox_session_input_schema();
 			$artifact_id_schema = array(
 				'artifact_id'    => array(
 					'type'        => 'string',
@@ -86,6 +88,8 @@ final class WP_Codebox_Abilities {
 							),
 							'mounts'                 => $mount_schema,
 							'inherit'                => $inherit_schema,
+							'sandbox_session_id'     => $session_input['sandbox_session_id'],
+							'orchestrator'           => $session_input['orchestrator'],
 							'secret_env'             => array(
 								'type'        => 'array',
 								'description' => 'Explicit parent environment variable names to expose inside the sandbox. Prefer connector-scoped inheritance credentials for product flows. Values are read from the parent process and are not accepted in this payload.',
@@ -125,6 +129,7 @@ final class WP_Codebox_Abilities {
 						'properties' => array(
 							'success'   => array( 'type' => 'boolean' ),
 							'schema'    => array( 'type' => 'string' ),
+							'session'   => $session_schema,
 							'task'      => array( 'type' => 'string' ),
 							'task_input' => $task_input_schema,
 							'wp'        => array( 'type' => 'string' ),
@@ -174,6 +179,8 @@ final class WP_Codebox_Abilities {
 							),
 							'mounts'                 => $mount_schema,
 							'inherit'                => $inherit_schema,
+							'sandbox_session_id'     => $session_input['sandbox_session_id'],
+							'orchestrator'           => $session_input['orchestrator'],
 							'secret_env'             => array(
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
@@ -193,6 +200,7 @@ final class WP_Codebox_Abilities {
 						'properties' => array(
 							'success'     => array( 'type' => 'boolean' ),
 							'schema'      => array( 'type' => 'string' ),
+							'session'     => $session_schema,
 							'tasks'       => array( 'type' => 'array' ),
 							'task_inputs' => array(
 								'type'  => 'array',
@@ -433,6 +441,41 @@ final class WP_Codebox_Abilities {
 						'secrets'   => array( 'type' => 'array', 'items' => $credential_secret_schema ),
 					),
 				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function sandbox_session_input_schema(): array {
+		return array(
+			'sandbox_session_id' => array(
+				'type'        => 'string',
+				'description' => 'Caller-owned sandbox session id for external job/session systems. WP Codebox returns it in the response but does not persist sessions itself.',
+			),
+			'orchestrator'       => array(
+				'type'        => 'object',
+				'description' => 'Optional caller-owned job/session metadata, such as external job system, job id, or control-plane id. Values are copied into the response session envelope for correlation only.',
+				'properties'  => array(
+					'id'     => array( 'type' => 'string' ),
+					'type'   => array( 'type' => 'string' ),
+					'job_id' => array( 'type' => 'string' ),
+				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function sandbox_session_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'schema'           => array( 'type' => 'string' ),
+				'id'               => array( 'type' => 'string' ),
+				'status'           => array( 'type' => 'string' ),
+				'persistence'      => array( 'type' => 'string' ),
+				'agent_session_id' => array( 'type' => 'string' ),
+				'orchestrator'     => array( 'type' => 'object' ),
+				'artifacts'        => array( 'type' => 'object' ),
 			),
 		);
 	}

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -11,6 +11,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	private const SCHEMA = 'wp-codebox/agent-task-run/v1';
 	private const BATCH_SCHEMA = 'wp-codebox/agent-task-batch/v1';
+	private const SESSION_SCHEMA = 'wp-codebox/sandbox-session/v1';
 	private const TASK_INPUT_SCHEMA = 'wp-codebox/task-input/v1';
 
 	/** @var array<string, callable> */
@@ -40,6 +41,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 		$task        = (string) $task_input['goal'];
 		$task_prompt = $this->task_input_prompt( $task_input );
+		$session_id  = $this->sandbox_session_id( $input );
 
 		$raw_code_input = $this->reject_raw_code_input( $input );
 		if ( is_wp_error( $raw_code_input ) ) {
@@ -109,6 +111,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return array(
 			'success'   => true,
 			'schema'    => self::SCHEMA,
+			'session'   => $this->sandbox_session( $session_id, 'completed', $input, $decoded, $artifacts ),
 			'task'      => $task,
 			'task_input' => $task_input,
 			'wp'        => $wp_version,
@@ -140,6 +143,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 		$tasks        = array_map( static fn( array $task_input ): string => (string) $task_input['goal'], $task_inputs );
 		$task_prompts = array_map( array( $this, 'task_input_prompt' ), $task_inputs );
+		$session_id   = $this->sandbox_session_id( $input );
 
 		$paths = $this->resolve_component_paths( $input );
 		if ( is_wp_error( $paths ) ) {
@@ -205,6 +209,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return array(
 			'success'     => true,
 			'schema'      => self::BATCH_SCHEMA,
+			'session'     => $this->sandbox_session( $session_id, 'completed', $input, $decoded, $artifacts ),
 			'tasks'       => $tasks,
 			'task_inputs' => $task_inputs,
 			'concurrency' => $concurrency,
@@ -919,6 +924,51 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return bin2hex( random_bytes( 16 ) );
+	}
+
+	private function sandbox_session_id( array $input ): string {
+		$id = trim( (string) ( $input['sandbox_session_id'] ?? '' ) );
+		if ( '' !== $id ) {
+			return $id;
+		}
+
+		$id = trim( (string) ( $input['session_id'] ?? '' ) );
+		return '' !== $id ? $id : $this->generate_run_id();
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $run Decoded CLI run output. */
+	private function sandbox_session( string $session_id, string $status, array $input, array $run, string $artifacts ): array {
+		$session = array(
+			'schema'      => self::SESSION_SCHEMA,
+			'id'          => $session_id,
+			'status'      => $status,
+			'persistence' => 'external-orchestrator',
+			'artifacts'   => array_filter(
+				array(
+					'path'       => $artifacts,
+					'bundle_id'  => is_array( $run['artifacts'] ?? null ) ? (string) ( $run['artifacts']['id'] ?? '' ) : '',
+					'preview_url' => is_array( $run['artifacts']['preview'] ?? null ) ? (string) ( $run['artifacts']['preview']['url'] ?? '' ) : '',
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			),
+		);
+
+		if ( ! empty( $input['session_id'] ) ) {
+			$session['agent_session_id'] = (string) $input['session_id'];
+		}
+
+		if ( isset( $input['orchestrator'] ) && is_array( $input['orchestrator'] ) ) {
+			$session['orchestrator'] = array_filter(
+				array(
+					'id'     => isset( $input['orchestrator']['id'] ) ? (string) $input['orchestrator']['id'] : '',
+					'type'   => isset( $input['orchestrator']['type'] ) ? (string) $input['orchestrator']['type'] : '',
+					'job_id' => isset( $input['orchestrator']['job_id'] ) ? (string) $input['orchestrator']['job_id'] : '',
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			);
+		}
+
+		return $session;
 	}
 
 	/** @return array<string,mixed>|WP_Error */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -97,6 +97,7 @@ $assert( 'ability exposes policy and context schema', 'object' === ( $ability['i
 $assert( 'ability exposes generic mounts schema', 'array' === ( $ability['input_schema']['properties']['mounts']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['mounts']['items']['properties']['metadata']['type'] ?? '' ) );
 $assert( 'ability exposes inheritance request schema', 'object' === ( $ability['input_schema']['properties']['inherit']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['connectors']['type'] ?? '' ) );
 $assert( 'ability exposes connector credential envelope schema', 'object' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['properties']['secrets']['type'] ?? '' ) );
+$assert( 'ability exposes external sandbox session schema', 'string' === ( $ability['input_schema']['properties']['sandbox_session_id']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['orchestrator']['type'] ?? '' ) && 'object' === ( $ability['output_schema']['properties']['session']['type'] ?? '' ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
@@ -144,8 +145,12 @@ $runner           = new WP_Codebox_Agent_Sandbox_Runner(
 				'exit_code' => 0,
 				'output'    => json_encode(
 					array(
-						'success' => true,
-						'runtime' => array( 'backend' => 'wordpress-playground' ),
+						'success'   => true,
+						'runtime'   => array( 'backend' => 'wordpress-playground' ),
+						'artifacts' => array(
+							'id'      => 'artifact-bundle-sha256-fixture',
+							'preview' => array( 'url' => 'http://127.0.0.1:12345' ),
+						),
 					)
 				),
 			);
@@ -156,6 +161,13 @@ $runner           = new WP_Codebox_Agent_Sandbox_Runner(
 $result = $runner->run(
 	array(
 		'task'           => 'Run a chat-requested sandbox task.',
+		'sandbox_session_id' => 'parent-job-123',
+		'session_id'     => 'agent-chat-session-456',
+		'orchestrator'   => array(
+			'type'   => 'external-job-system',
+			'id'     => 'parent-control-plane',
+			'job_id' => 'job-123',
+		),
 		'artifacts_path' => $root . '/artifacts',
 		'secret_env'     => array( 'GITHUB_TOKEN' ),
 		'preview_hold_seconds' => 30,
@@ -179,6 +191,9 @@ $result = $runner->run(
 
 $assert( 'runner succeeds with filter-provided component paths', ! is_wp_error( $result ) && true === ( $result['success'] ?? false ) );
 $assert( 'runner schema is stable', ! is_wp_error( $result ) && 'wp-codebox/agent-task-run/v1' === ( $result['schema'] ?? '' ) );
+$assert( 'runner returns caller-owned sandbox session envelope', ! is_wp_error( $result ) && 'wp-codebox/sandbox-session/v1' === ( $result['session']['schema'] ?? '' ) && 'parent-job-123' === ( $result['session']['id'] ?? '' ) && 'external-orchestrator' === ( $result['session']['persistence'] ?? '' ) );
+$assert( 'runner keeps agent session separate from sandbox session', ! is_wp_error( $result ) && 'agent-chat-session-456' === ( $result['session']['agent_session_id'] ?? '' ) && str_contains( $captured_recipe, 'session-id=agent-chat-session-456' ) );
+$assert( 'runner returns orchestrator correlation and artifact refs', ! is_wp_error( $result ) && 'job-123' === ( $result['session']['orchestrator']['job_id'] ?? '' ) && 'artifact-bundle-sha256-fixture' === ( $result['session']['artifacts']['bundle_id'] ?? '' ) );
 $assert( 'runner returns normalized task input for legacy task', ! is_wp_error( $result ) && 'wp-codebox/task-input/v1' === ( $result['task_input']['schema'] ?? '' ) && 'Run a chat-requested sandbox task.' === ( $result['task_input']['goal'] ?? '' ) );
 $assert( 'runner invokes recipe-run', str_contains( $captured_command, 'recipe-run' ) );
 $assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node ' ) );


### PR DESCRIPTION
## Summary
- Defines the host-agnostic `wp-codebox/sandbox-session/v1` envelope for external orchestrators.
- Adds `sandbox_session_id` and opaque `orchestrator` correlation fields to the WordPress plugin abilities without adding host DB/job ownership.
- Documents the parent control-plane boundary and verifies the schema through the WordPress plugin smoke test.

Refs #31

## Testing
- `npm run build`
- `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the session contract implementation, docs, tests, and PR description; Chris remains responsible for review and merge.