### PR TITLE
Strengthen apply-back evidence fixture

### DIFF
--- a/docs/external-apply-adapter-contract.md
+++ b/docs/external-apply-adapter-contract.md
@@ -65,6 +65,10 @@ plane adapter, and persists this external record shape:
     "patch_sha256": "...",
     "approved_files": ["/wordpress/wp-content/plugins/example/generated.txt"]
   },
+  "approval": {
+    "approver": "site-user:1",
+    "approved_at": "2026-05-25T00:00:00.000Z"
+  },
   "target": {
     "repo": "example/example-plugin",
     "branch": "codebox/apply-generated-file",
@@ -73,10 +77,12 @@ plane adapter, and persists this external record shape:
   },
   "result": {
     "status": "pr-opened",
-    "pr_url": "https://github.com/example/example-plugin/pull/123"
+    "pr_url": "https://github.com/example/example-plugin/pull/123",
+    "author": "wp-codebox-bot"
   }
 }
 ```
 
-The smoke asserts that the external record includes adapter metadata, PR URL,
-branch, commit, and artifact digest while excluding the raw patch body.
+The smoke asserts that the external record includes adapter metadata, explicit
+owner approval metadata, bot-authored PR metadata, branch, commit, and artifact
+digest while excluding the raw patch body.

--- a/scripts/external-adapter-contract-smoke.ts
+++ b/scripts/external-adapter-contract-smoke.ts
@@ -52,6 +52,10 @@ interface ExternalApplyRecord {
     patch_sha256: string
     approved_files: string[]
   }
+  approval: {
+    approver: string
+    approved_at: string
+  }
   target: {
     repo: string
     branch: string
@@ -61,6 +65,7 @@ interface ExternalApplyRecord {
   result: {
     status: "pr-opened"
     pr_url: string
+    author: string
   }
 }
 
@@ -109,6 +114,10 @@ function externalParentControlPlaneApply(payload: ArtifactBundlePayload): Extern
       patch_sha256: payload.patch_sha256,
       approved_files: payload.approved_files,
     },
+    approval: {
+      approver: "site-user:1",
+      approved_at: "2026-05-25T00:00:00.000Z",
+    },
     target: {
       repo,
       branch,
@@ -118,6 +127,7 @@ function externalParentControlPlaneApply(payload: ArtifactBundlePayload): Extern
     result: {
       status: "pr-opened",
       pr_url: "https://github.com/example/example-plugin/pull/123",
+      author: "wp-codebox-bot",
     },
   }
 }
@@ -185,7 +195,9 @@ try {
 
   const persisted = JSON.parse(await readFile(recordPath, "utf8")) as ExternalApplyRecord
   assert.equal(persisted.adapter.name, "fixture-parent-control-plane")
+  assert.equal(persisted.approval.approver, "site-user:1")
   assert.equal(persisted.result.pr_url, "https://github.com/example/example-plugin/pull/123")
+  assert.equal(persisted.result.author, "wp-codebox-bot")
   assert.equal(persisted.target.branch, "codebox/apply-generated-file")
   assert.equal(persisted.target.commit, "abc1234")
   assert.equal(persisted.artifact.content_digest, digest)

--- a/scripts/preview-public-url-canonical-smoke.ts
+++ b/scripts/preview-public-url-canonical-smoke.ts
@@ -6,6 +6,7 @@ import { resolve } from "node:path"
 const repoRoot = resolve(import.meta.dirname, "..")
 const port = await reserveFreePort()
 const publicUrl = "https://preview-public.example.test"
+const previewReadyTimeoutMs = 75000
 const child = spawn(process.execPath, [
   "packages/cli/dist/index.js",
   "run",
@@ -46,7 +47,7 @@ const exitCode = await exitPromise
 assert.ok(exitCode === 0 || exitCode === null, `wp-codebox exited with ${exitCode}\nstdout: ${stdout}\nstderr: ${stderr}`)
 
 async function waitForCanonicalRedirect(listenPort: number): Promise<string> {
-  const deadline = Date.now() + 18000
+  const deadline = Date.now() + previewReadyTimeoutMs
   let lastError: unknown
   while (Date.now() < deadline) {
     try {


### PR DESCRIPTION
## Summary
- Extends the external apply adapter fixture to persist explicit owner approval metadata.
- Records bot-authored PR metadata in the external adapter record so the dogfood evidence matches the reviewed apply-back acceptance path.
- Gives the public-preview canonical smoke enough startup budget for current Playground boot times.

Refs #71

## Testing
- `npm run external-adapter-contract-smoke`
- `npm run build`
- `npm run preview-public-url-canonical-smoke`
- `npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`

Note: `npm run check` was started and progressed through the updated external adapter smoke, runtime/core/recipe smokes, and into preview checks, but was manually aborted during `preview-port-smoke` before completion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the fixture/doc updates, isolated the preview smoke timing issue, and prepared this PR; Chris remains responsible for review and merge.