### PR TITLE
Add configurable preview proxy bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ npm run wp-codebox -- run \
 
 The v1 preview is a held live Playground runtime. When `--preview-hold` is omitted, the preview field still records the URL observed during capture, but the runtime is destroyed on command completion and the URL is marked `expired-on-completion`. Artifact replay from `blueprint.after.json` remains partial and is a separate future preview mode.
 
-For tunnel-first review, reserve the local port in the tunnel command and pass that same port to WP Codebox. `--preview-port <n>` makes Playground use a fixed local port instead of its default random port, and `--preview-public-url <url>` reports the tunnel URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`.
+For tunnel-first review, reserve the local port in the tunnel command and pass that same port to WP Codebox. `--preview-port <n>` makes WP Codebox expose Playground through a fixed local proxy port instead of reporting Playground's default random port, and `--preview-public-url <url>` reports the tunnel URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`.
 
 ```bash
 kimaki tunnel -- sh -c 'npm run wp-codebox -- run \
@@ -251,9 +251,9 @@ kimaki tunnel -- sh -c 'npm run wp-codebox -- run \
   --json'
 ```
 
-When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url` and defines `WP_HOME` / `WP_SITEURL` in the sandbox config, so WordPress-generated links and canonical redirects align with the public preview URL. The local Playground URL remains recorded as `preview.localUrl`. If the fixed port is already occupied, WP Codebox fails clearly with `EADDRINUSE` and the requested `--preview-port` value.
+When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url` and defines `WP_HOME` / `WP_SITEURL` in the sandbox config, so WordPress-generated links and canonical redirects align with the public preview URL. The local proxy URL remains recorded as `preview.localUrl`. If the fixed port is already occupied, WP Codebox fails clearly with `EADDRINUSE` and the requested `--preview-port` value.
 
-Remote preview access still requires an external tunnel or proxy. WP Codebox does not claim true bind-host support: a `--preview-bind` style option depends on upstream WordPress Playground exposing a host/bind API. Track upstream support in https://github.com/WordPress/wordpress-playground/issues/3681.
+Remote-host previews can opt into `--preview-bind <host>` with `--preview-port`. The flag changes the WP Codebox preview proxy bind address only; the upstream Playground server remains loopback-bound because `@wp-playground/cli` does not expose host/bind control yet. The default stays `127.0.0.1`. Use `--preview-bind 0.0.0.0` only behind trusted firewall, tunnel, or reverse-proxy controls because the sandbox preview is reachable for the hold duration. Track the upstream Playground bind-host API gap in https://github.com/WordPress/wordpress-playground/issues/3681.
 
 ## Runtime Episodes
 
@@ -325,6 +325,7 @@ npm run wp-codebox -- run \
   --command <command> \
   --arg <key=value> \
   --preview-port <local-port> \
+  --preview-bind 127.0.0.1 \
   --preview-public-url <public-tunnel-url> \
   --json
 ```
@@ -345,7 +346,7 @@ Supported runtime commands today:
 
 WP Codebox defaults to WordPress `7.0` because the agent and AI plugin stacks need the modern WordPress AI surface. Override with `--wp trunk`, `--wp nightly`, or another supported Playground version.
 
-`--preview-port` fixes the local Playground port for tunnel/proxy wiring. Omit it to keep the current random-port behavior. `--preview-public-url` is metadata and site-url alignment only; it does not make Playground listen on a public interface. Use a tunnel/proxy for remote access.
+`--preview-port` fixes the local WP Codebox proxy port for tunnel/proxy wiring. Omit it to keep the current random-port behavior from upstream Playground. `--preview-bind` changes that fixed-port proxy bind address and requires `--preview-port`; it does not change the upstream Playground server bind. `--preview-public-url` is metadata and site-url alignment only; it does not make a loopback-only preview reachable without a tunnel/proxy or explicit proxy bind.
 
 ### `boot`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,4 +53,4 @@ Parent-site-derived declarations must stay minimized: each scope needs explicit 
 ## Interactive Boot
 
 - `wp-codebox boot [--mount <host>:<vfs>] --hold <duration> [--json]` boots Playground, captures preview/artifact metadata, holds the live preview with the same duration semantics as `run --preview-hold`, then tears down and collects artifacts without creating a workflow command.
-- `boot` accepts the runtime setup options relevant to interactive previews: `--mount`, `--blueprint <json|file>`, `--wp`, `--artifacts`, `--policy <json|file>`, `--preview-port`, and `--preview-public-url`.
+- `boot` accepts the runtime setup options relevant to interactive previews: `--mount`, `--blueprint <json|file>`, `--wp`, `--artifacts`, `--policy <json|file>`, `--preview-port`, `--preview-bind`, and `--preview-public-url`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,7 @@ interface RunOptions {
   previewHoldSeconds?: number
   previewPublicUrl?: string
   previewPort?: number
+  previewBind?: string
   json: boolean
 }
 
@@ -77,6 +78,7 @@ interface BootOptions {
   previewHoldSeconds?: number
   previewPublicUrl?: string
   previewPort?: number
+  previewBind?: string
   json: boolean
 }
 
@@ -98,6 +100,7 @@ interface BlueprintValidateOptions {
   previewHoldSeconds?: number
   previewPublicUrl?: string
   previewPort?: number
+  previewBind?: string
   json: boolean
 }
 
@@ -117,6 +120,7 @@ interface RecipeRunOptions {
   previewHoldSeconds?: number
   previewPublicUrl?: string
   previewPort?: number
+  previewBind?: string
   json: boolean
   dryRun: boolean
 }
@@ -1102,9 +1106,9 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         artifactsDirectory: options.artifactsDirectory ?? recipe.artifacts?.directory,
         metadata: {
           ...runtimeMetadata(options.artifactsDirectory ?? recipe.artifacts?.directory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
-          ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, options.previewPublicUrl, options.previewPort),
+          ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, options.previewPublicUrl, options.previewPort, options.previewBind),
         },
-        preview: previewSpec(options.previewPublicUrl, options.previewPort),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -1352,8 +1356,12 @@ function runtimeMetadata(artifactsDirectory: string | undefined, wpVersion: stri
   }
 }
 
-function previewSpec(publicUrl: string | undefined, port: number | undefined): { publicUrl?: string; siteUrl?: string; port?: number } | undefined {
-  if (!publicUrl && port === undefined) {
+function previewSpec(publicUrl: string | undefined, port: number | undefined, bind: string | undefined): { publicUrl?: string; siteUrl?: string; port?: number; bind?: string } | undefined {
+  if (bind && port === undefined) {
+    throw new Error("--preview-bind requires --preview-port because upstream Playground does not expose bind-host control yet")
+  }
+
+  if (!publicUrl && port === undefined && !bind) {
     return undefined
   }
 
@@ -1361,6 +1369,7 @@ function previewSpec(publicUrl: string | undefined, port: number | undefined): {
     publicUrl,
     siteUrl: publicUrl,
     port,
+    bind,
   })
 }
 
@@ -1374,6 +1383,7 @@ function runMetadata(options: RunOptions): Record<string, unknown> {
       artifactsDirectory: options.artifactsDirectory,
       previewPublicUrl: options.previewPublicUrl,
       previewPort: options.previewPort,
+      previewBind: options.previewBind,
     }),
   }
 }
@@ -1386,6 +1396,7 @@ function bootMetadata(options: BootOptions): Record<string, unknown> {
       artifactsDirectory: options.artifactsDirectory,
       previewPublicUrl: options.previewPublicUrl,
       previewPort: options.previewPort,
+      previewBind: options.previewBind,
     }),
   }
 }
@@ -1399,6 +1410,7 @@ function blueprintValidationMetadata(options: BlueprintValidateOptions): Record<
       artifactsDirectory: options.artifactsDirectory,
       previewPublicUrl: options.previewPublicUrl,
       previewPort: options.previewPort,
+      previewBind: options.previewBind,
     }),
   }
 }
@@ -1692,7 +1704,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
         secretEnv: options.secretEnv,
         artifactsDirectory: options.artifactsDirectory,
         metadata: options.metadata ?? runMetadata(options),
-        preview: previewSpec(options.previewPublicUrl, options.previewPort),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -1756,7 +1768,7 @@ async function boot(options: BootOptions): Promise<BootOutput> {
         policy: options.policy ?? defaultPolicy,
         artifactsDirectory: options.artifactsDirectory,
         metadata: bootMetadata(options),
-        preview: previewSpec(options.previewPublicUrl, options.previewPort),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -1819,7 +1831,7 @@ async function validateBlueprint(options: BlueprintValidateOptions): Promise<Blu
         policy: options.policy ?? defaultPolicy,
         artifactsDirectory: options.artifactsDirectory,
         metadata: blueprintValidationMetadata(options),
-        preview: previewSpec(options.previewPublicUrl, options.previewPort),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -1905,6 +1917,19 @@ function parsePreviewPort(value: string): number {
   return port
 }
 
+function parsePreviewBind(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new Error("--preview-bind must not be empty")
+  }
+
+  if (/[/\\\s]/.test(trimmed)) {
+    throw new Error("--preview-bind must be a hostname or IP address, not a URL")
+  }
+
+  return trimmed
+}
+
 async function parseRunOptions(args: string[]): Promise<RunOptions> {
   const options: RunOptions = {
     mounts: [],
@@ -1952,6 +1977,9 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
         break
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)
+        break
+      case "--preview-bind":
+        options.previewBind = parsePreviewBind(value)
         break
       case "--policy":
         options.policy = await parsePolicy(value)
@@ -2015,6 +2043,9 @@ async function parseBootOptions(args: string[]): Promise<BootOptions> {
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)
         break
+      case "--preview-bind":
+        options.previewBind = parsePreviewBind(value)
+        break
       case "--policy":
         options.policy = await parsePolicy(value)
         break
@@ -2063,6 +2094,9 @@ async function parseBlueprintValidateOptions(args: string[]): Promise<BlueprintV
         break
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)
+        break
+      case "--preview-bind":
+        options.previewBind = parsePreviewBind(value)
         break
       case "--policy":
         options.policy = await parsePolicy(value)
@@ -2117,6 +2151,9 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
         break
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)
+        break
+      case "--preview-bind":
+        options.previewBind = parsePreviewBind(value)
         break
       default:
         throw new Error(`Unknown option: ${name}`)
@@ -2630,7 +2667,7 @@ function runPolicy(command: string): RuntimePolicy {
   }
 }
 
-function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], previewPublicUrl: string | undefined, previewPort: number | undefined): Record<string, unknown> {
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], previewPublicUrl: string | undefined, previewPort: number | undefined, previewBind: string | undefined): Record<string, unknown> {
   const extraPluginMetadata = extraPlugins.map((plugin) => ({
     source: plugin.source,
     slug: plugin.slug,
@@ -2664,6 +2701,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       recipePath,
       previewPublicUrl,
       previewPort,
+      previewBind,
       workflow: {
         steps: recipe.workflow.steps.map((step) => ({ command: step.command, args: step.args ?? [] })),
       },

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -243,9 +243,12 @@ Options:
   --hold <n>           Keep a booted Playground preview available before teardown. Accepts the same values as --preview-hold.
   --preview-hold <n>   Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
   --preview-port <n>   Start Playground on a fixed local port. Defaults to a random available port.
+  --preview-bind <host>
+                       Host/IP for the fixed-port WP Codebox preview proxy. Requires --preview-port.
+                       Defaults to 127.0.0.1; use 0.0.0.0 only behind trusted network controls.
   --preview-public-url <url>
                        Public tunnel/proxy URL to report in preview artifacts and pass to Playground as site-url.
-                       Remote access still requires an external tunnel/proxy; bind-host support depends on upstream Playground.
+                       Upstream Playground remains loopback-bound; this only changes the WP Codebox proxy bind.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --dry-run            Validate recipe-run and emit a resolved JSON plan without booting Playground or writing temp workspaces.
   --json               Emit machine-readable JSON.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -144,6 +144,7 @@ export interface RuntimePreviewSpec {
   publicUrl?: string
   siteUrl?: string
   port?: number
+  bind?: string
 }
 
 export interface WorkspaceRecipeMount {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1138,7 +1138,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
         return server
       }
 
-      return await withPreviewProxy(server, this.spec.preview.port)
+      return await withPreviewProxy(server, this.spec.preview.port, this.spec.preview.bind)
     } catch (error) {
       if (this.spec.preview?.port && errorHasCode(error, "EADDRINUSE")) {
         throw new PlaygroundPreviewPortUnavailableError(this.spec.preview.port, error)
@@ -1294,10 +1294,10 @@ function jsonLines(records: unknown[]): string {
   return records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : ""
 }
 
-async function withPreviewProxy(server: PlaygroundCliServer, port: number): Promise<PlaygroundCliServer> {
+async function withPreviewProxy(server: PlaygroundCliServer, port: number, bind = "127.0.0.1"): Promise<PlaygroundCliServer> {
   let proxy: PlaygroundPreviewProxy | undefined
   try {
-    proxy = await startPreviewProxy(server.serverUrl, port)
+    proxy = await startPreviewProxy(server.serverUrl, port, bind)
   } catch (error) {
     await server[Symbol.asyncDispose]()
     throw error
@@ -1313,7 +1313,7 @@ async function withPreviewProxy(server: PlaygroundCliServer, port: number): Prom
   }
 }
 
-async function startPreviewProxy(targetUrl: string, port: number): Promise<PlaygroundPreviewProxy> {
+async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
   const target = new URL(targetUrl)
   const proxy = createHttpServer((incoming, outgoing) => {
     const targetRequest = httpRequest(
@@ -1343,11 +1343,15 @@ async function startPreviewProxy(targetUrl: string, port: number): Promise<Playg
 
   await new Promise<void>((resolveListen, rejectListen) => {
     proxy.once("error", rejectListen)
-    proxy.listen(port, "127.0.0.1", () => resolveListen())
+    proxy.listen(port, bind, () => resolveListen())
   })
 
+  const address = proxy.address()
+  const resolvedPort = address && typeof address === "object" ? address.port : port
+  const reportedHost = bind === "0.0.0.0" ? "127.0.0.1" : bind
+
   return {
-    serverUrl: `http://127.0.0.1:${port}`,
+    serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
     async dispose() {
       if (!proxy.listening) {
         return
@@ -1358,6 +1362,10 @@ async function startPreviewProxy(targetUrl: string, port: number): Promise<Playg
       })
     },
   }
+}
+
+function formatPreviewHost(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
 }
 
 function proxyRequestHeaders(headers: IncomingHttpHeaders, target: URL): IncomingHttpHeaders {

--- a/scripts/preview-port-smoke.ts
+++ b/scripts/preview-port-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { createServer, type Server } from "node:net"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -24,13 +24,18 @@ try {
     artifactsDirectory,
     "--preview-port",
     String(runPort),
+    "--preview-bind",
+    "0.0.0.0",
     "--preview-public-url",
     "https://run-preview.example.test/",
     "--json",
   ])
   assert.equal(runOutput.success, true)
   assert.equal(new URL(runOutput.artifacts.preview.localUrl).port, String(runPort))
+  assert.equal(new URL(runOutput.artifacts.preview.localUrl).hostname, "127.0.0.1")
   assert.equal(runOutput.artifacts.preview.url, "https://run-preview.example.test/")
+  const runMetadata = JSON.parse(await readFile(runOutput.artifacts.metadataPath, "utf8"))
+  assert.equal(runMetadata.provenance.task.previewBind, "0.0.0.0")
 
   const recipePort = await reserveFreePort()
   const recipeOutput = await runCliJson([
@@ -84,6 +89,24 @@ try {
     (error) => {
       const childError = error as { stdout?: string; stderr?: string }
       assert.match(`${childError.stdout ?? ""}\n${childError.stderr ?? ""}`, /--preview-port must be an integer between 1 and 65535/)
+      return true
+    },
+  )
+
+  await assert.rejects(
+    () => runCliJson([
+      "run",
+      "--mount",
+      "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+      "--command",
+      "wordpress.run-php",
+      "--preview-bind",
+      "0.0.0.0",
+      "--json",
+    ]),
+    (error) => {
+      const childError = error as { stdout?: string; stderr?: string }
+      assert.match(`${childError.stdout ?? ""}\n${childError.stderr ?? ""}`, /--preview-bind requires --preview-port/)
       return true
     },
   )

--- a/scripts/preview-response-body-smoke.ts
+++ b/scripts/preview-response-body-smoke.ts
@@ -26,7 +26,7 @@ try {
         runtime: { version: "0.0.0" },
         task: { kind: "preview-response-body-smoke" },
       },
-      preview: { port: previewPort },
+      preview: { port: previewPort, bind: "0.0.0.0" },
     },
     createPlaygroundRuntimeBackend(),
   )


### PR DESCRIPTION
## Summary
- Adds `--preview-bind <host>` for the fixed-port WP Codebox preview proxy while keeping the default loopback-only behavior.
- Requires `--preview-port` for bind overrides because upstream `@wp-playground/cli` still does not expose host/bind control for its own server.
- Documents the security implications of `0.0.0.0` and links the upstream Playground bind-host tracker.

Fixes #100.

## Upstream context
- Current `@wp-playground/cli` `server` behavior still binds/reports `127.0.0.1` internally; WP Codebox can safely expose only its own fixed-port proxy without replacing Playground internals.
- Upstream tracker: https://github.com/WordPress/wordpress-playground/issues/3681

## Verification
- `npm run build`
- `npm run preview-port-smoke`
- `npm run preview-response-body-smoke`
- `npm run preview-public-url-canonical-smoke`
- `npm run boot-preview-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the preview proxy bind option, docs, and smoke coverage; Chris remains responsible for review and merge decisions.