### PR TITLE
Document portable sandbox architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ WordPress has historically lacked a clean scratch space for code execution. Mode
 
 WP Codebox is the runtime boundary for agent-built or workflow-built outputs. It is not the agent framework, the review UI, the deploy system, or the production site mutator. The WordPress plugin in this repo is one optional host adapter (useful when the host *is* a WordPress site); the core CLI/runtime works anywhere `node` can run.
 
+For the durable architecture boundary, see [`docs/architecture.md`](./docs/architecture.md).
+
 ```text
 Any host: CLI, CI, mobile, Node service, WP plugin, GitHub Action, ...
   -> WP Codebox

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,79 @@
+# Architecture Vision
+
+WP Codebox is the portable sandbox boundary for WordPress coding-agent work. It
+lets a parent product start a disposable WordPress Playground runtime, mount the
+target code and agent stack, collect reviewable artifacts, then apply or discard
+those artifacts outside the sandbox.
+
+```text
+Parent control plane
+  owns users, auth, durable jobs, review UX, and apply-back policy
+    -> WP Codebox
+      owns sandbox lifecycle, mounts, execution policy, and artifact capture
+        -> disposable WordPress Playground runtime
+          may mount Agents API, Data Machine, Data Machine Code, providers
+          runs controlled commands or sandboxed agent tasks
+        <- artifact bundle: patch, changed files, tests, preview, provenance
+    <- reviewed apply, export, replay, or discard
+```
+
+## Product Shape
+
+The core use case is safe code generation for WordPress products without giving
+the agent production access. A site owner, Studio user, CI job, eval runner, or
+chat surface can ask for a change; WP Codebox runs the work in Playground and
+returns evidence that the parent product can review.
+
+Example control planes include WordPress.com, Studio, self-hosted WordPress,
+Frontend Agent Chat, Homeboy Extensions, wp-gym, GitHub Actions, and other host
+applications. They consume WP Codebox; they do not change the sandbox contract.
+
+## Landed Contracts
+
+- **Sandbox session contract:** parent control planes pass caller-owned
+  `sandbox_session_id` and optional `orchestrator` metadata to correlate runs.
+  WP Codebox echoes a `wp-codebox/sandbox-session/v1` envelope and artifact refs,
+  but durable queued/running/cancelled/expired lifecycle remains external. See
+  [`sandbox-session-contract.md`](./sandbox-session-contract.md).
+- **Apply-back contract:** sandbox execution returns artifacts only. Reviewed
+  apply validates `artifact_id`, `approved_files[]`, the canonical changed-file
+  manifest, and the artifact content digest before delegating to the
+  `wp_codebox_apply_approved_artifact` adapter. PR creation, bot identity,
+  deployment, and package export stay in parent adapters. See
+  [`external-apply-adapter-contract.md`](./external-apply-adapter-contract.md).
+- **Batch/fan-out primitive:** `wp-codebox/run-agent-task-batch` launches one
+  isolated sandbox per task with bounded concurrency. Homeboy audit fan-out and
+  similar orchestrators should track their own parent jobs, pass correlation
+  metadata into each sandbox run, and store the returned artifact ids as audit
+  evidence.
+
+## Ownership Boundaries
+
+WP Codebox owns:
+
+- Disposable Playground lifecycle.
+- Mount normalization and sandbox workspace layout.
+- Controlled command and agent-task execution.
+- Artifact bundles, provenance, previews, patch surfaces, and replay metadata.
+- WordPress plugin abilities that expose those sandbox operations to a host site.
+
+Parent control planes own:
+
+- Users, permissions, quotas, billing, durable jobs, retries, cancellation, and
+  retention.
+- Human review UX, approval records, and apply-back policy.
+- Branch pushes, pull requests, deploys, package export, or direct apply.
+- Bot identities and credentials used outside the sandbox.
+
+In-sandbox Data Machine and Data Machine Code own only the tools mounted into a
+disposable run. DMC may expose sandbox-scoped read/write/diff helpers for the
+mounted workspace; parent-only operations such as worktree lifecycle, pushes,
+GitSync, PR mutation, comments, deploys, and cleanup remain outside the sandbox.
+
+## Design Rule
+
+Keep the seams small and consumer-agnostic: session correlation, sandbox
+lifecycle, command execution, artifact capture, and reviewed apply-back are
+separate contracts. Integrations can add product policy around those seams
+without making WP Codebox depend on a specific queue, review UI, deploy system,
+or agent framework.


### PR DESCRIPTION
## Summary
- Add a concise architecture vision doc for WP Codebox as the portable WordPress Playground coding-agent sandbox boundary.
- Tie the vision to the landed sandbox session contract, reviewed apply-back contract, batch/fan-out primitive, and ownership boundaries for parent control planes and in-sandbox Data Machine/DMC.
- Link the new architecture doc from the README.

Closes #35.

## Testing
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small architecture documentation update and ran repository validation; Chris remains responsible for review and merge.