### PR TITLE
Enforce sandbox Data Machine tool allowlist

### DIFF
--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -26,6 +26,14 @@ may still pass `task` as a string; the runner normalizes it into `goal` and
 returns the normalized `task_input` in the ability response. Raw PHP `code` and
 `code_file` fields remain rejected on this product ability path.
 
+When `allowed_tools` includes Data Machine ability names, the parent-side runner
+enforces the sandbox allow-list before launching the CLI. Parent-only abilities
+such as workspace worktree, Git push, GitSync, GitHub mutation, and code-task
+creation fail closed with `wp_codebox_tool_not_allowed`; hosts can narrow the
+safe Data Machine tool set with the `wp_codebox_allowed_sandbox_tools` option or
+filter. Non-Data-Machine labels remain descriptive task hints for the sandbox
+agent.
+
 ```json
 {
   "schema": "wp-codebox/task-input/v1",
@@ -204,6 +212,12 @@ Those abilities must not be exposed through the sandbox agent bundle. The sandbo
 produces artifact metadata, changed files, patches, and review evidence; the
 parent control plane performs reviewed apply-back, branch pushes, deploys, and PR
 creation.
+
+The WordPress runner validates any requested `datamachine/*` entries in
+`allowed_tools` against that boundary before the sandbox process starts. The
+default list matches the sandbox-safe DMC abilities above; installations can
+narrow it with `wp_codebox_allowed_sandbox_tools` while parent-only abilities are
+always removed from the effective allow-list.
 
 Data Machine, Data Machine Code, Homeboy Extensions, wp-gym, and other systems
 are consumers or mounted tools. They do not own WP Codebox's artifact contract.

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -13,6 +13,63 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const BATCH_SCHEMA = 'wp-codebox/agent-task-batch/v1';
 	private const SESSION_SCHEMA = 'wp-codebox/sandbox-session/v1';
 	private const TASK_INPUT_SCHEMA = 'wp-codebox/task-input/v1';
+	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
+	private const DEFAULT_SANDBOX_TOOLS = array(
+		'datamachine/workspace-read',
+		'datamachine/workspace-ls',
+		'datamachine/workspace-grep',
+		'datamachine/workspace-write',
+		'datamachine/workspace-edit',
+		'datamachine/workspace-apply-patch',
+		'datamachine/workspace-git-status',
+		'datamachine/workspace-git-log',
+		'datamachine/workspace-git-diff',
+		'datamachine/list-github-issues',
+		'datamachine/get-github-issue',
+		'datamachine/list-github-pulls',
+		'datamachine/get-github-pull',
+		'datamachine/list-github-pull-files',
+		'datamachine/get-github-check-runs',
+		'datamachine/get-github-commit-statuses',
+		'datamachine/list-github-tree',
+		'datamachine/get-github-file',
+		'datamachine/list-github-repos',
+	);
+	private const PARENT_ONLY_SANDBOX_TOOLS = array(
+		'datamachine/workspace-clone',
+		'datamachine/workspace-adopt',
+		'datamachine/workspace-remove',
+		'datamachine/workspace-delete',
+		'datamachine/workspace-git-pull',
+		'datamachine/workspace-git-add',
+		'datamachine/workspace-git-commit',
+		'datamachine/workspace-git-push',
+		'datamachine/workspace-git-rebase',
+		'datamachine/workspace-git-reset',
+		'datamachine/workspace-pr-rebase',
+		'datamachine/workspace-worktree-add',
+		'datamachine/workspace-worktree-finalize',
+		'datamachine/workspace-worktree-remove',
+		'datamachine/workspace-worktree-prune',
+		'datamachine/workspace-worktree-cleanup',
+		'datamachine/workspace-cleanup-apply',
+		'datamachine/create-github-issue',
+		'datamachine/update-github-issue',
+		'datamachine/create-github-pull-request',
+		'datamachine/comment-github-issue',
+		'datamachine/comment-github-pull-request',
+		'datamachine/upsert-github-pull-review-comment',
+		'datamachine/merge-github-pull-request',
+		'datamachine/cleanup-github-pull-request',
+		'datamachine/create-or-update-github-file',
+		'datamachine/create-code-task',
+		'datamachine/gitsync-bind',
+		'datamachine/gitsync-unbind',
+		'datamachine/gitsync-pull',
+		'datamachine/gitsync-submit',
+		'datamachine/gitsync-push',
+		'datamachine/gitsync-policy-update',
+	);
 
 	/** @var array<string, callable> */
 	private array $callbacks;
@@ -678,6 +735,12 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		foreach ( array( 'allowed_tools', 'expected_artifacts' ) as $field ) {
 			$values = $this->string_list( $input[ $field ] ?? array() );
 			if ( ! empty( $values ) ) {
+				if ( 'allowed_tools' === $field ) {
+					$tool_error = $this->allowed_tools_error( $values );
+					if ( is_wp_error( $tool_error ) ) {
+						return $tool_error;
+					}
+				}
 				$task_input[ $field ] = $values;
 			}
 		}
@@ -723,6 +786,65 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 						$values
 					),
 					static fn( string $value ): bool => '' !== $value
+				)
+			)
+		);
+	}
+
+	/** @param string[] $tools */
+	private function allowed_tools_error( array $tools ): WP_Error|null {
+		$allowed = $this->sandbox_tool_allowlist();
+		$denied  = array();
+
+		foreach ( $tools as $tool ) {
+			if ( ! str_starts_with( $tool, 'datamachine/' ) ) {
+				continue;
+			}
+
+			$reason = in_array( $tool, self::PARENT_ONLY_SANDBOX_TOOLS, true ) ? 'parent-only' : 'not-allowlisted';
+			if ( 'parent-only' === $reason || ! in_array( $tool, $allowed, true ) ) {
+				$denied[] = array(
+					'tool'   => $tool,
+					'reason' => $reason,
+				);
+			}
+		}
+
+		if ( empty( $denied ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'wp_codebox_tool_not_allowed',
+			'One or more requested Data Machine tools are not allowed in the sandbox scope.',
+			array(
+				'status'        => 403,
+				'schema'        => self::TOOL_DENIAL_SCHEMA,
+				'denied_tools'  => $denied,
+				'allowed_tools' => $allowed,
+			)
+		);
+	}
+
+	/** @return string[] */
+	private function sandbox_tool_allowlist(): array {
+		$tools = $this->config_option( 'wp_codebox_allowed_sandbox_tools', self::DEFAULT_SANDBOX_TOOLS );
+		if ( function_exists( 'apply_filters' ) ) {
+			$tools = apply_filters( 'wp_codebox_allowed_sandbox_tools', $tools );
+		}
+
+		if ( ! is_array( $tools ) ) {
+			$tools = array();
+		}
+
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map(
+						static fn( $tool ): string => trim( (string) $tool ),
+						$tools
+					),
+					static fn( string $tool ): bool => str_starts_with( $tool, 'datamachine/' ) && ! in_array( $tool, self::PARENT_ONLY_SANDBOX_TOOLS, true )
 				)
 			)
 		);

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -383,7 +383,7 @@ $structured_result = $runner->run(
 			'kind' => 'plugin',
 			'path' => 'wp-content/plugins/simple-plugin',
 		),
-		'allowed_tools'      => array( 'workspace.read', 'workspace.write', '' ),
+		'allowed_tools'      => array( 'workspace.read', 'workspace.write', 'datamachine/workspace-read', '' ),
 		'expected_artifacts' => array( 'patch', 'tests', 'patch' ),
 		'policy'             => array( 'applyBack' => 'reviewed' ),
 		'context'            => array( 'issue' => 'https://github.com/chubes4/wp-codebox/issues/29' ),
@@ -393,8 +393,30 @@ $structured_result = $runner->run(
 
 $assert( 'runner accepts structured task input', ! is_wp_error( $structured_result ) && 'Add a focused product feature.' === ( $structured_result['task_input']['goal'] ?? '' ) );
 $assert( 'runner preserves structured target', ! is_wp_error( $structured_result ) && 'plugin' === ( $structured_result['task_input']['target']['kind'] ?? '' ) );
-$assert( 'runner normalizes task input lists', ! is_wp_error( $structured_result ) && array( 'workspace.read', 'workspace.write' ) === ( $structured_result['task_input']['allowed_tools'] ?? array() ) && array( 'patch', 'tests' ) === ( $structured_result['task_input']['expected_artifacts'] ?? array() ) );
+$assert( 'runner normalizes task input lists', ! is_wp_error( $structured_result ) && array( 'workspace.read', 'workspace.write', 'datamachine/workspace-read' ) === ( $structured_result['task_input']['allowed_tools'] ?? array() ) && array( 'patch', 'tests' ) === ( $structured_result['task_input']['expected_artifacts'] ?? array() ) );
 $assert( 'runner passes structured task contract to recipe', str_contains( $captured_recipe, 'wp-codebox/task-input/v1' ) && str_contains( $captured_recipe, 'allowed_tools' ) );
+
+$parent_only_tool = $runner->run(
+	array(
+		'goal'           => 'Try a parent-only workspace mutation.',
+		'allowed_tools'  => array( 'datamachine/workspace-git-push' ),
+		'artifacts_path' => $root . '/artifacts',
+	)
+);
+$assert( 'parent-only Data Machine tool request fails closed', is_wp_error( $parent_only_tool ) && 'wp_codebox_tool_not_allowed' === $parent_only_tool->get_error_code() );
+$assert( 'tool denial includes structured redacted details', is_wp_error( $parent_only_tool ) && 'wp-codebox/tool-allowlist-denial/v1' === ( $parent_only_tool->get_error_data()['schema'] ?? '' ) && 'parent-only' === ( $parent_only_tool->get_error_data()['denied_tools'][0]['reason'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_allowed_sandbox_tools'] = array( 'datamachine/workspace-read' );
+$not_allowlisted_tool = $runner->run(
+	array(
+		'goal'           => 'Try an unconfigured sandbox tool.',
+		'allowed_tools'  => array( 'datamachine/workspace-write' ),
+		'artifacts_path' => $root . '/artifacts',
+	)
+);
+$assert( 'configured Data Machine tool allow-list fails closed', is_wp_error( $not_allowlisted_tool ) && 'wp_codebox_tool_not_allowed' === $not_allowlisted_tool->get_error_code() );
+$assert( 'configured allow-list denial reports allowed tools', is_wp_error( $not_allowlisted_tool ) && array( 'datamachine/workspace-read' ) === ( $not_allowlisted_tool->get_error_data()['allowed_tools'] ?? array() ) && 'not-allowlisted' === ( $not_allowlisted_tool->get_error_data()['denied_tools'][0]['reason'] ?? '' ) );
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_allowed_sandbox_tools'] );
 
 $batch_result = $runner->run_batch(
 	array(


### PR DESCRIPTION
## Summary
- Enforce the parent-side sandbox allow-list when `allowed_tools` contains Data Machine ability names.
- Fail closed with structured `wp-codebox/tool-allowlist-denial/v1` errors for parent-only or unconfigured `datamachine/*` tools before launching the CLI.
- Document the `wp_codebox_allowed_sandbox_tools` option/filter and cover default/custom allow-list denials in the WordPress plugin smoke test.

Fixes #28.

## Testing
- `npm run wordpress-plugin-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused sandbox allow-list enforcement slice, tests, docs, and local verification; Chris remains responsible for review and merge.