### PR TITLE
Fix sandbox workspace setup for agent runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,11 @@
     "boot-preview-smoke": "tsx scripts/boot-preview-smoke.ts",
     "blueprint-validation-smoke": "tsx scripts/blueprint-validation-smoke.ts",
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
+    "agent-sandbox-code-smoke": "tsx scripts/agent-sandbox-code-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -32,18 +32,20 @@ export async function resolveSandboxTaskCode(options: AgentSandboxCodeOptions): 
 
 function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
   const mode = options.mode ?? "sandbox"
+  const agentModes = sandboxAgentModes(mode)
   const agentConfig = scopedAgentConfig(mode, options.provider, options.model)
   const input: Record<string, unknown> = {
     agent: options.agent,
     message: options.task,
     session_id: options.sessionId ?? null,
     mode,
+    modes: agentModes,
     client_context: {
       source: "bridge",
       client_name: "wp-codebox",
       connector_id: "wp-codebox-cli",
       mode,
-      agent_modes: [mode],
+      agent_modes: agentModes,
       workspace_root: SANDBOX_WORKSPACE_ROOT,
       tool_contract: sandboxToolContract(),
     },
@@ -58,15 +60,50 @@ if (function_exists('wp_set_current_user')) {
     wp_set_current_user(1);
 }
 
+if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
+    define('DATAMACHINE_WORKSPACE_PATH', ${JSON.stringify(SANDBOX_WORKSPACE_ROOT)});
+}
+
+$sandbox_workspace_adoptions = array();
+if (function_exists('wp_get_ability')) {
+    $sandbox_adopt_callback = static function () use (&$sandbox_workspace_adoptions): void {
+        $sandbox_adopt_ability = wp_get_ability('datamachine/workspace-adopt');
+        if (!$sandbox_adopt_ability || !method_exists($sandbox_adopt_ability, 'execute')) {
+            return;
+        }
+        foreach (glob(rtrim(DATAMACHINE_WORKSPACE_PATH, '/') . '/*', GLOB_ONLYDIR) ?: array() as $sandbox_workspace_dir) {
+            $sandbox_workspace_name = basename($sandbox_workspace_dir);
+            $sandbox_adopt_result = $sandbox_adopt_ability->execute(array(
+                'path' => $sandbox_workspace_dir,
+                'name' => $sandbox_workspace_name,
+            ));
+            $sandbox_workspace_adoptions[$sandbox_workspace_name] = is_wp_error($sandbox_adopt_result)
+                ? array('success' => false, 'error' => $sandbox_adopt_result->get_error_message())
+                : $sandbox_adopt_result;
+        }
+    };
+    if (class_exists('DataMachine\\Abilities\\PermissionHelper')) {
+        DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($sandbox_adopt_callback, 1);
+    } else {
+        $sandbox_adopt_callback();
+    }
+}
+$sandbox_stack['workspace_adoptions'] = $sandbox_workspace_adoptions;
+
 if (class_exists('DataMachine\\Core\\Database\\Agents\\Agents')) {
     $sandbox_agent_slug = sanitize_title((string) (${JSON.stringify(input.agent)}));
     if ('' !== $sandbox_agent_slug) {
-        (new DataMachine\\Core\\Database\\Agents\\Agents())->create_if_missing(
+        $sandbox_agents = new DataMachine\\Core\\Database\\Agents\\Agents();
+        $sandbox_agent_config = json_decode(${JSON.stringify(JSON.stringify(agentConfig))}, true);
+        $sandbox_agent_id = $sandbox_agents->create_if_missing(
             $sandbox_agent_slug,
             'Sandbox Agent',
             1,
-            json_decode(${JSON.stringify(JSON.stringify(agentConfig))}, true)
+            $sandbox_agent_config
         );
+        if ($sandbox_agent_id > 0 && method_exists($sandbox_agents, 'update_agent')) {
+            $sandbox_agents->update_agent($sandbox_agent_id, array('agent_config' => $sandbox_agent_config));
+        }
     }
 }
 
@@ -86,6 +123,20 @@ add_filter('datamachine_code_sandbox_safe_abilities', static function () {
 add_filter('datamachine_code_sandbox_parent_only_abilities', static function () {
     return json_decode(${JSON.stringify(JSON.stringify([...SANDBOX_DMC_PARENT_ONLY_ABILITIES]))}, true);
 }, 100);
+
+add_action('datamachine_agent_modes', static function () {
+    if (class_exists('DataMachine\\Engine\\AI\\AgentModeRegistry')) {
+        DataMachine\\Engine\\AI\\AgentModeRegistry::register('sandbox', 25, array(
+            'label' => 'Sandbox',
+            'description' => 'WP Codebox sandbox execution with reviewed artifact output.',
+        ));
+    }
+}, 100);
+
+add_filter('datamachine_agent_mode_sandbox', static function (string $content): string {
+    $guidance = ${JSON.stringify(sandboxModeGuidance())};
+    return trim($content) === '' ? $guidance : trim($content) . "\n\n" . $guidance;
+}, 100, 1);
 
 $ability = function_exists('wp_get_ability') ? wp_get_ability('agents/chat') : null;
 if (!$ability || !method_exists($ability, 'execute')) {
@@ -131,19 +182,47 @@ echo json_encode($sandbox_agent_runtime, JSON_PRETTY_PRINT);
 function sandboxToolContract(): Record<string, unknown> {
   return {
     schema: "wp-codebox/sandbox-dmc-tools/v1",
+    modes: ["pipeline", "sandbox"],
+    tools: sandboxToolNames(),
     safe_abilities: [...SANDBOX_DMC_SAFE_ABILITIES],
     parent_only_abilities: [...SANDBOX_DMC_PARENT_ONLY_ABILITIES],
   }
 }
 
+function sandboxToolNames(): string[] {
+  return SANDBOX_DMC_SAFE_ABILITIES.map((ability) => ability.replace(/^datamachine\//, "").replaceAll("-", "_"))
+}
+
+function sandboxAgentModes(mode: string): string[] {
+  return Array.from(new Set([mode, "pipeline"].filter(Boolean)))
+}
+
+function sandboxModeGuidance(): string {
+  return `# WP Codebox Sandbox Context
+
+You are running inside a disposable WP Codebox sandbox. The sandbox can produce a reviewed artifact bundle from workspace changes.
+
+Use the available workspace tools by their exact names: ${sandboxToolNames().join(", ")}.
+
+Do not invent alternate tool names such as read_file, read-file, write_file, or edit_file. For file inspection use workspace_read, workspace_ls, and workspace_grep. For changes use workspace_write, workspace_edit, or workspace_apply_patch.
+
+The sandbox workspace root is ${SANDBOX_WORKSPACE_ROOT}. Keep changes focused on the requested task and prefer patchable repository edits over prose-only answers.`
+}
+
 function scopedAgentConfig(mode: string, provider: string | undefined, model: string | undefined): Record<string, unknown> {
+  const toolPolicy = {
+    mode: "allow",
+    tools: sandboxToolNames(),
+  }
+
   if (!provider && !model) {
-    return {}
+    return { tool_policy: toolPolicy }
   }
 
   return {
     ...(provider ? { default_provider: provider } : {}),
     ...(model ? { default_model: model } : {}),
+    tool_policy: toolPolicy,
     mode_models: {
       [mode]: {
         ...(provider ? { provider } : {}),
@@ -173,6 +252,10 @@ function scopedSettings(mode: string, provider: string | undefined, model: strin
 export function agentSandboxRunCode(task: string, code: string, providerPlugins: Array<{ slug: string }>): string {
   return `<?php
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
+    define('DATAMACHINE_WORKSPACE_PATH', ${JSON.stringify(SANDBOX_WORKSPACE_ROOT)});
+}
 
 add_filter('datamachine_should_load_full_runtime', '__return_true', 1);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1147,7 +1147,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       })
     }
 
-    const pluginActivationCode = activateExtraPluginsCode(recipe)
+    const pluginActivationCode = activateExtraPluginsCode(extraPlugins)
     if (pluginActivationCode) {
       executions.push(await runtime.execute({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }))
     }
@@ -2390,7 +2390,7 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
       addIssue("invalid-slug", `${path}.slug`, error instanceof Error ? error.message : String(error))
       continue
     }
-    const pluginFile = recipeExtraPluginFile(plugin)
+    const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
 
     validateRecipeSource(source, `${path}.source`, addIssue)
     if (pluginSource) {
@@ -2599,7 +2599,19 @@ function recipeWpCliCommandFromArgs(args: string[]): string {
 
 async function recipeDryRunSteps(recipe: WorkspaceRecipe, recipeDirectory: string, policy: RuntimePolicy): Promise<RecipeDryRunStep[]> {
   const steps: Array<Promise<RecipeDryRunStep>> = []
-  const pluginActivationCode = activateExtraPluginsCode(recipe)
+  const dryRunExtraPlugins = await Promise.all(recipeExtraPlugins(recipe).map(async (plugin) => {
+    const slug = recipeExtraPluginSlug(plugin)
+    return {
+      source: plugin.source,
+      slug,
+      target: `/wordpress/wp-content/plugins/${slug}`,
+      pluginFile: await resolveRecipeExtraPluginFile(plugin, recipeDirectory),
+      activate: plugin.activate !== false,
+      cleanupPaths: [],
+      provenance: recipeSourceProvenance(recipeSource(plugin.source), recipeDirectory),
+    }
+  }))
+  const pluginActivationCode = activateExtraPluginsCode(dryRunExtraPlugins)
   if (pluginActivationCode) {
     steps.push(recipeDryRunStep({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }, recipeDirectory, policy, -1, "activate-extra-plugins"))
   }
@@ -2858,7 +2870,7 @@ async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeDirector
   for (const plugin of recipeExtraPlugins(recipe)) {
     const slug = recipeExtraPluginSlug(plugin)
     const resolved = await prepareRecipeSource(plugin.source, recipeDirectory, slug)
-    const pluginFile = recipeExtraPluginFile(plugin)
+    const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
     await assertPreparedPluginFileExists(resolved.source, pluginFile.slice(slug.length + 1), plugin.source)
     plugins.push({
       source: resolved.source,
@@ -2951,6 +2963,7 @@ async function prepareRecipeWorkspace(workspace: WorkspaceRecipeWorkspace, recip
     const source = resolve(recipeDirectory, workspace.seed.source ?? "")
     await cp(source, directory, { recursive: true })
     await cp(source, baselineDirectory, { recursive: true })
+    await ensureStandaloneGitPrimary(directory)
     return { source: directory, baselineSource: baselineDirectory, cleanupPaths: [directory, baselineDirectory] }
   }
 
@@ -2963,6 +2976,22 @@ async function prepareRecipeWorkspace(workspace: WorkspaceRecipeWorkspace, recip
   await writePluginScaffold(directory, slug, workspace.seed.name ?? titleFromSlug(slug))
   await writePluginScaffold(baselineDirectory, slug, workspace.seed.name ?? titleFromSlug(slug))
   return { source: directory, baselineSource: baselineDirectory, cleanupPaths: [directory, baselineDirectory] }
+}
+
+async function ensureStandaloneGitPrimary(directory: string): Promise<void> {
+  const gitPath = join(directory, ".git")
+  try {
+    const gitStat = await stat(gitPath)
+    if (gitStat.isDirectory()) {
+      return
+    }
+
+    await rm(gitPath, { force: true })
+  } catch {
+    // No Git metadata was copied; initialize a sandbox-local primary below.
+  }
+
+  await execFileAsync("git", ["init", "--quiet"], { cwd: directory })
 }
 
 function defaultWorkspaceTarget(workspace: WorkspaceRecipeWorkspace, slug: string): string {
@@ -3125,10 +3154,34 @@ function recipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin): string {
   return plugin.pluginFile ?? `${slug}/${slug}.php`
 }
 
-function activateExtraPluginsCode(recipe: WorkspaceRecipe): string | null {
-  const pluginFiles = recipeExtraPlugins(recipe)
+async function resolveRecipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin, recipeDirectory: string): Promise<string> {
+  const slug = recipeExtraPluginSlug(plugin)
+  if (plugin.pluginFile) {
+    return plugin.pluginFile
+  }
+
+  const source = recipeSource(plugin.source)
+  if (source.type === "local") {
+    const pluginSource = resolve(recipeDirectory, plugin.source)
+    for (const candidate of [`${slug}/${slug}.php`, `${slug}/plugin.php`]) {
+      try {
+        const result = await stat(join(pluginSource, candidate.slice(slug.length + 1)))
+        if (result.isFile()) {
+          return candidate
+        }
+      } catch {
+        // Try the next common plugin entrypoint.
+      }
+    }
+  }
+
+  return `${slug}/${slug}.php`
+}
+
+function activateExtraPluginsCode(extraPlugins: PreparedExtraPlugin[]): string | null {
+  const pluginFiles = extraPlugins
     .filter((plugin) => plugin.activate !== false)
-    .map(recipeExtraPluginFile)
+    .map((plugin) => plugin.pluginFile)
 
   if (pluginFiles.length === 0) {
     return null

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.ts"
+
+async function main() {
+  const code = await resolveSandboxTaskCode({
+    task: "Fix duplicate code",
+    agent: "sandbox-agent",
+    mode: "sandbox",
+    provider: "opencode",
+    model: "opencode-go/kimi-k2.6",
+  })
+
+  assert.match(code, /\\"modes\\":\[\\"sandbox\\",\\"pipeline\\"\]/, "sandbox chat input should inherit pipeline tool surface")
+  assert.match(code, /\\"agent_modes\\":\[\\"sandbox\\",\\"pipeline\\"\]/, "client context should report additive sandbox modes")
+  assert.match(code, /\\"tool_policy\\":\{\\"mode\\":\\"allow\\",\\"tools\\":\[.*\\"workspace_read\\"/, "sandbox agent should allow workspace tools")
+  assert.match(code, /datamachine_agent_mode_sandbox/, "sandbox mode should inject tool guidance")
+  assert.match(code, /Do not invent alternate tool names such as read_file/, "sandbox guidance should prevent pseudo-tool aliases")
+  assert.match(code, /workspace_apply_patch/, "sandbox tool policy should include patch application")
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- Configure sandbox agent runs with additive sandbox/pipeline modes, explicit DMC workspace tool policy, and sandbox guidance.
- Define the sandbox workspace path before Data Machine Code loads, adopt mounted workspaces, and upsert sandbox agent config each run.
- Resolve local provider plugin entrypoints and prepare copied worktree sources as sandbox-local primary Git checkouts.

## Verification
- `npm run build`
- `npm run agent-sandbox-code-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the sandbox wiring fix, smoke coverage, and local canary investigation; Chris remains responsible for review and testing.