### PR TITLE
fix: stream preview proxy responses

### DIFF
--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1326,13 +1326,9 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
         headers: proxyRequestHeaders(incoming.headers, target),
       },
       (targetResponse) => {
-        const chunks: Buffer[] = []
-        targetResponse.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
-        targetResponse.on("end", () => {
-          const body = Buffer.concat(chunks)
-          outgoing.writeHead(targetResponse.statusCode ?? 502, targetResponse.statusMessage, proxyResponseHeaders(targetResponse.headers, body.byteLength))
-          outgoing.end(body)
-        })
+        outgoing.writeHead(targetResponse.statusCode ?? 502, targetResponse.statusMessage, proxyResponseHeaders(targetResponse.headers))
+        targetResponse.on("error", (error) => outgoing.destroy(error))
+        targetResponse.pipe(outgoing)
       },
     )
 
@@ -1380,16 +1376,12 @@ function proxyRequestHeaders(headers: IncomingHttpHeaders, target: URL): Incomin
   }
 }
 
-function proxyResponseHeaders(headers: IncomingHttpHeaders, bodyLength: number): IncomingHttpHeaders {
+function proxyResponseHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
   const forwarded = { ...headers }
   delete forwarded.connection
-  delete forwarded["content-length"]
   delete forwarded["transfer-encoding"]
 
-  return {
-    ...forwarded,
-    "content-length": String(bodyLength),
-  }
+  return forwarded
 }
 
 function writeProxyError(outgoing: ServerResponse, error: Error): void {

--- a/scripts/preview-response-body-smoke.ts
+++ b/scripts/preview-response-body-smoke.ts
@@ -17,7 +17,7 @@ try {
       policy: {
         network: "deny",
         filesystem: "readwrite-mounts",
-        commands: ["wordpress.wp-cli"],
+        commands: ["wordpress.wp-cli", "wordpress.run-php"],
         secrets: "none",
         approvals: "never",
       },
@@ -51,6 +51,26 @@ try {
     assert.match(body, /Preview Body Smoke/)
     assert.match(body, /Tunnel-visible response body/)
     assertExplicitResponseFraming(response, body)
+
+    const largePost = await runtime.execute({
+      command: "wordpress.run-php",
+      args: [
+        "code=$post_id = wp_insert_post(array('post_type' => 'page', 'post_status' => 'publish', 'post_title' => 'Large Preview Body Smoke', 'post_content' => str_repeat('streaming-preview-body ', 70000)), true); if (is_wp_error($post_id)) { throw new Error($post_id->get_error_message()); } echo $post_id;",
+      ],
+    })
+    assert.equal(largePost.exitCode, 0)
+
+    const largePostId = largePost.stdout.trim()
+    assert.match(largePostId, /^\d+$/)
+
+    const largeResponse = await fetch(`${previewUrl}/?p=${largePostId}`)
+    const largeBody = await largeResponse.text()
+
+    assert.equal(largeResponse.status, 200)
+    assert.match(largeBody, /Large Preview Body Smoke/)
+    assert.match(largeBody, /streaming-preview-body/)
+    assert.ok(Buffer.byteLength(largeBody) > 1024 * 1024, `expected large preview response; got ${Buffer.byteLength(largeBody)} bytes`)
+    assertStreamingResponseFraming(largeResponse)
   } finally {
     await runtime.destroy()
   }
@@ -96,4 +116,12 @@ function assertExplicitResponseFraming(response: Response, body: string): void {
     contentLength === String(Buffer.byteLength(body)) || transferEncoding === "chunked",
     `expected content-length=${Buffer.byteLength(body)} or transfer-encoding=chunked; got content-length=${contentLength}, transfer-encoding=${transferEncoding}`,
   )
+}
+
+function assertStreamingResponseFraming(response: Response): void {
+  const contentLength = response.headers.get("content-length")
+  const transferEncoding = response.headers.get("transfer-encoding")
+
+  assert.equal(contentLength, null, `preview proxy should not synthesize content-length for streamed responses; got ${contentLength}`)
+  assert.equal(transferEncoding, "chunked")
 }


### PR DESCRIPTION
## Summary
- Stream preview proxy upstream responses directly to the downstream client instead of buffering the full body in memory.
- Preserve upstream status/status text and sanitized response headers, while letting Node handle streamed transfer framing.
- Extend the preview response body smoke with a large page assertion that catches synthetic buffered `content-length` behavior.

Closes #149.

## Verification
- `npm run build`
- `npm run preview-response-body-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the preview proxy streaming change, updated smoke coverage, and ran verification commands for Chris to review.