### PR TITLE
Filter artifact patches by approved files

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -134,6 +134,11 @@ final class WP_Codebox_Artifacts {
 			return new WP_Error( 'wp_codebox_patch_missing', 'Artifact patch.diff is missing or empty.', array( 'status' => 400 ) );
 		}
 
+		$patch = $this->filter_patch_to_approved_files( $patch, $changed_files, $approved_files );
+		if ( is_wp_error( $patch ) ) {
+			return $patch;
+		}
+
 		$content_digest = $this->artifact_content_digest( $bundle );
 		if ( is_wp_error( $content_digest ) ) {
 			return $content_digest;
@@ -384,6 +389,134 @@ final class WP_Codebox_Artifacts {
 				)
 			)
 		);
+	}
+
+	/**
+	 * @param array<int,mixed> $changed_files Artifact changed file entries.
+	 * @param string[]         $approved_files Approved sandbox paths.
+	 */
+	private function filter_patch_to_approved_files( string $patch, array $changed_files, array $approved_files ): string|WP_Error {
+		$approved_lookup             = array_fill_keys( $approved_files, true );
+		$approved_patch_path_sets    = array();
+		$approved_patch_paths_lookup = array();
+
+		foreach ( $changed_files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = trim( (string) ( $file['path'] ?? '' ) );
+			if ( '' === $path || ! isset( $approved_lookup[ $path ] ) ) {
+				continue;
+			}
+
+			foreach ( array( $path, (string) ( $file['relativePath'] ?? '' ) ) as $patch_path ) {
+				$normalized = $this->normalize_patch_path( $patch_path );
+				if ( '' !== $normalized ) {
+					$approved_patch_path_sets[ $path ][ $normalized ] = true;
+					$approved_patch_paths_lookup[ $normalized ] = true;
+				}
+			}
+		}
+
+		if ( empty( $approved_patch_paths_lookup ) ) {
+			return new WP_Error( 'wp_codebox_approved_patch_paths_missing', 'Approved files could not be mapped to patch paths.', array( 'status' => 400 ) );
+		}
+
+		$blocks = $this->split_git_patch_blocks( $patch );
+		if ( empty( $blocks ) ) {
+			return new WP_Error( 'wp_codebox_patch_unfilterable', 'Artifact patch.diff could not be split into file patches.', array( 'status' => 400 ) );
+		}
+
+		$matched_approved_files = array();
+		$filtered_blocks = array();
+		foreach ( $blocks as $block ) {
+			$block_paths = $this->git_patch_block_paths( $block );
+			$matches     = array_intersect_key( $block_paths, $approved_patch_paths_lookup );
+			if ( empty( $matches ) ) {
+				continue;
+			}
+
+			foreach ( $approved_patch_path_sets as $approved_file => $candidate_paths ) {
+				if ( ! empty( array_intersect_key( $matches, $candidate_paths ) ) ) {
+					$matched_approved_files[ $approved_file ] = true;
+				}
+			}
+
+			$filtered_blocks[] = $block;
+		}
+
+		$missing_files = array_values( array_diff( $approved_files, array_keys( $matched_approved_files ) ) );
+		if ( ! empty( $missing_files ) ) {
+			return new WP_Error(
+				'wp_codebox_approved_patch_missing',
+				'Artifact patch.diff does not contain every approved file, so the partial approval cannot be applied safely.',
+				array(
+					'status' => 400,
+					'files'  => $missing_files,
+				)
+			);
+		}
+
+		$filtered_patch = implode( '', $filtered_blocks );
+		if ( '' === trim( $filtered_patch ) ) {
+			return new WP_Error( 'wp_codebox_approved_patch_empty', 'Approved files produced an empty patch.', array( 'status' => 400 ) );
+		}
+
+		return $filtered_patch;
+	}
+
+	/** @return string[] */
+	private function split_git_patch_blocks( string $patch ): array {
+		$lines = preg_split( "/(?<=\n)(?=diff --git )/", $patch );
+		if ( false === $lines ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$lines,
+				static fn( string $block ): bool => str_starts_with( $block, 'diff --git ' )
+			)
+		);
+	}
+
+	/** @return array<string,bool> */
+	private function git_patch_block_paths( string $block ): array {
+		$paths = array();
+		if ( preg_match( '/^diff --git\s+a\/(.+?)\s+b\/(.+)$/m', $block, $matches ) ) {
+			foreach ( array( $matches[1], $matches[2] ) as $path ) {
+				$normalized = $this->normalize_patch_path( $path );
+				if ( '' !== $normalized ) {
+					$paths[ $normalized ] = true;
+				}
+			}
+		}
+
+		foreach ( array( '---', '+++' ) as $prefix ) {
+			if ( preg_match( '/^' . preg_quote( $prefix, '/' ) . '\s+(.+)$/m', $block, $matches ) ) {
+				$normalized = $this->normalize_patch_path( $matches[1] );
+				if ( '' !== $normalized ) {
+					$paths[ $normalized ] = true;
+				}
+			}
+		}
+
+		return $paths;
+	}
+
+	private function normalize_patch_path( string $path ): string {
+		$path = trim( $path );
+		if ( '' === $path || '/dev/null' === $path ) {
+			return '';
+		}
+
+		$path = preg_replace( '/\s+.*$/', '', $path ) ?? $path;
+		$path = str_replace( '\\', '/', $path );
+		$path = preg_replace( '#^(?:a|b)/#', '', $path ) ?? $path;
+		$path = ltrim( $path, '/' );
+
+		return $path;
 	}
 
 	/**

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -496,11 +496,20 @@ $changed_files_json = json_encode(
 				'relativePath' => 'generated.txt',
 				'patchPath'    => 'files/diffs/mount-0.patch',
 			),
+			array(
+				'path'         => '/wordpress/wp-content/plugins/example/unapproved.txt',
+				'status'       => 'added',
+				'mountIndex'   => 0,
+				'mountTarget'  => '/wordpress/wp-content/plugins/example',
+				'relativePath' => 'unapproved.txt',
+				'patchPath'    => 'files/diffs/mount-0.patch',
+			),
 		),
 	),
 	JSON_PRETTY_PRINT
 ) . "\n";
-$patch_diff          = "diff --git a/generated.txt b/generated.txt\n+cooked\n";
+$approved_patch_diff = "diff --git a/generated.txt b/generated.txt\n+cooked\n";
+$patch_diff          = $approved_patch_diff . "diff --git a/unapproved.txt b/unapproved.txt\n+unsafe\n";
 $content_digest      = hash( 'sha256', "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n" . $changed_files_json . "\nfiles/patch.diff\n" . $patch_diff );
 $artifact_id         = 'artifact-bundle-sha256-' . $content_digest;
 file_put_contents(
@@ -622,6 +631,7 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function 
 		'patch_sha256'            => $payload['patch_sha256'],
 		'artifact_content_digest' => $payload['artifact_content_digest'],
 		'patch_contains'          => str_contains( $payload['patch'], 'cooked' ),
+		'patch_contains_unsafe'   => str_contains( $payload['patch'], 'unsafe' ),
 		'patch'                   => $payload['patch'],
 		'access_token'            => 'secret-token-value',
 		'pr_url'                  => 'https://github.com/chubes4/wp-codebox/pull/999',
@@ -635,7 +645,7 @@ $applied = $artifacts->apply_approved(
 		'approver'        => 'site-user:1',
 	)
 );
-$assert( 'approved artifact apply delegates exact patch', ! is_wp_error( $applied ) && true === ( $applied['result']['patch_contains'] ?? false ) && hash( 'sha256', $patch_diff ) === ( $applied['patch_sha256'] ?? '' ) && $content_digest === ( $applied['content_digest'] ?? '' ) );
+$assert( 'approved artifact apply delegates filtered patch', ! is_wp_error( $applied ) && true === ( $applied['result']['patch_contains'] ?? false ) && false === ( $applied['result']['patch_contains_unsafe'] ?? true ) && hash( 'sha256', $approved_patch_diff ) === ( $applied['patch_sha256'] ?? '' ) && $content_digest === ( $applied['content_digest'] ?? '' ) );
 
 $captured_stage_args = array();
 $GLOBALS['wp_codebox_filters']['wp_codebox_stage_pending_apply_artifact'] = function ( mixed $value, array $stage_args ) use ( &$captured_stage_args ): array {
@@ -685,7 +695,7 @@ $success_audit   = isset( $audit_lines[0] ) ? json_decode( $audit_lines[0], true
 $success_encoded = isset( $audit_lines[0] ) ? $audit_lines[0] : '';
 $assert( 'approved artifact apply writes success audit record', is_array( $success_audit ) && 'wp-codebox/apply-audit/v1' === ( $success_audit['schema'] ?? '' ) && 'success' === ( $success_audit['status'] ?? '' ) );
 $assert( 'success audit records reviewed principals and files', 'chat:user-7' === ( $success_audit['requester'] ?? '' ) && 'site-user:1' === ( $success_audit['approver'] ?? '' ) && array( '/wordpress/wp-content/plugins/example/generated.txt' ) === ( $success_audit['approved_files'] ?? array() ) );
-$assert( 'success audit records digest and adapter metadata', $artifact_id === ( $success_audit['artifact_id'] ?? '' ) && $content_digest === ( $success_audit['content_digest'] ?? '' ) && 'test-adapter' === ( $success_audit['adapter'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/999' === ( $success_audit['result']['pr_url'] ?? '' ) );
+$assert( 'success audit records applied patch digest and adapter metadata', $artifact_id === ( $success_audit['artifact_id'] ?? '' ) && $content_digest === ( $success_audit['content_digest'] ?? '' ) && hash( 'sha256', $approved_patch_diff ) === ( $success_audit['patch_sha256'] ?? '' ) && 'test-adapter' === ( $success_audit['adapter'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/999' === ( $success_audit['result']['pr_url'] ?? '' ) );
 $assert( 'success audit excludes raw patch body and secrets', ! str_contains( $success_encoded, 'diff --git' ) && ! str_contains( $success_encoded, 'secret-token-value' ) && '[redacted]' === ( $success_audit['result']['patch'] ?? '' ) && '[redacted]' === ( $success_audit['result']['access_token'] ?? '' ) );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function (): WP_Error {


### PR DESCRIPTION
## Summary
- Filter artifact `patch.diff` down to the approved changed-file subset before invoking the apply adapter.
- Fail closed when an approved file cannot be mapped to a diff block, rather than sending an unsafe full patch.
- Update the WordPress plugin smoke fixture to prove a multi-file artifact only sends the approved file patch and audits that applied patch SHA.

Closes #148

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php`
- `npm run wordpress-plugin-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the patch-filtering implementation, regression smoke coverage, and PR description; Chris remains responsible for review and merge.