### PR TITLE
fix: register wp-codebox ability category before registering abilities

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -20,8 +20,40 @@ final class WP_Codebox_Abilities {
 			return;
 		}
 
+		$this->register_category();
 		$this->register();
 		self::$registered = true;
+	}
+
+	/**
+	 * Register the `wp-codebox` ability category.
+	 *
+	 * As of WordPress 6.9 the Abilities API requires the category to be
+	 * registered before any ability that declares it; unregistered categories
+	 * cause `wp_register_ability()` to return `null` and silently drop the
+	 * ability. Categories must be registered on `wp_abilities_api_categories_init`.
+	 */
+	private function register_category(): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+
+		$register_category = static function (): void {
+			wp_register_ability_category(
+				'wp-codebox',
+				array(
+					'label'       => 'WP Codebox',
+					'description' => 'Disposable WordPress Playground sandbox runs, artifact capture, and reviewed apply-back.',
+				)
+			);
+		};
+
+		if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_categories_init' ) ) {
+			$register_category();
+			return;
+		}
+
+		add_action( 'wp_abilities_api_categories_init', $register_category );
 	}
 
 	private function register(): void {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -28,16 +28,23 @@ if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $thing ): bool { return $thing instanceof WP_Error; }
 }
 
-$GLOBALS['wp_codebox_registered_abilities'] = array();
-$GLOBALS['wp_codebox_filters']              = array();
-$GLOBALS['wp_codebox_options']              = array();
-$GLOBALS['wp_codebox_site_options']         = array();
+$GLOBALS['wp_codebox_registered_abilities']         = array();
+$GLOBALS['wp_codebox_registered_ability_categories'] = array();
+$GLOBALS['wp_codebox_filters']                      = array();
+$GLOBALS['wp_codebox_options']                      = array();
+$GLOBALS['wp_codebox_site_options']                 = array();
 
 function wp_register_ability( string $name, array $definition ): void {
 	$GLOBALS['wp_codebox_registered_abilities'][ $name ] = $definition;
 }
 
-function doing_action( string $hook ): bool { return 'wp_abilities_api_init' === $hook; }
+function wp_register_ability_category( string $slug, array $args ): void {
+	$GLOBALS['wp_codebox_registered_ability_categories'][ $slug ] = $args;
+}
+
+function doing_action( string $hook ): bool {
+	return in_array( $hook, array( 'wp_abilities_api_init', 'wp_abilities_api_categories_init' ), true );
+}
 function add_action( string $hook, callable $callback, int $priority = 10 ): void {}
 function add_filter( string $hook, callable $callback, int $priority = 10 ): void { $GLOBALS['wp_codebox_filters'][ $hook ] = $callback; }
 function current_user_can( string $capability ): bool { return 'manage_options' === $capability; }
@@ -85,6 +92,10 @@ echo "WP Codebox WordPress plugin - smoke\n";
 
 new WP_Codebox_Data_Machine_Pending_Actions();
 new WP_Codebox_Abilities();
+
+$category = $GLOBALS['wp_codebox_registered_ability_categories']['wp-codebox'] ?? null;
+$assert( 'wp-codebox ability category registered', is_array( $category ) );
+$assert( 'category exposes label and description', isset( $category['label'] ) && isset( $category['description'] ) );
 
 $ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-agent-task'] ?? null;
 $assert( 'run-agent-task ability registered', is_array( $ability ) );


### PR DESCRIPTION
Fixes #155.

## Problem

WordPress 6.9 made `WP_Abilities_Registry::register()` strictly validate the `'category'` argument. From `wp-includes/abilities-api/class-wp-abilities-registry.php`:

```php
if ( isset( $args['category'] ) ) {
    if ( ! wp_has_ability_category( $args['category'] ) ) {
        _doing_it_wrong( __METHOD__, sprintf( __( 'Ability category "%1$s" is not registered...' ), ... ), '6.9.0' );
        return null;   // <-- the ability is silently dropped
    }
}
```

`packages/wordpress-plugin/src/class-wp-codebox-abilities.php` registers all 7 parent-site abilities under `'category' => 'wp-codebox'`, but never registers that category. On any WP 6.9+ install the result is:

- 7 `_doing_it_wrong` notices on every request that hits abilities init.
- `wp_get_ability( 'wp-codebox/run-agent-task' )` returns `null`.
- Every consumer (REST `/wp-abilities/v1/abilities/<name>/run`, host product chat tools, etc.) sees an empty plugin.

This was discovered while installing wp-codebox on a live WP 7.0 multisite to support [Extra-Chill/extrachill-roadie#13](https://github.com/Extra-Chill/extrachill-roadie/pull/13), which depends on `wp-codebox/run-agent-task` being callable through the abilities API.

## Fix

Register the `wp-codebox` ability category on `wp_abilities_api_categories_init` before the existing ability-registration callback fires on `wp_abilities_api_init`. Both hooks run during the abilities API bootstrap on `plugins_loaded`, so the category exists by the time any ability is registered.

`class-wp-codebox-abilities.php`:

```php
private function register_category(): void {
    if ( ! function_exists( 'wp_register_ability_category' ) ) {
        return;
    }

    $register_category = static function (): void {
        wp_register_ability_category(
            'wp-codebox',
            array(
                'label'       => 'WP Codebox',
                'description' => 'Disposable WordPress Playground sandbox runs, artifact capture, and reviewed apply-back.',
            )
        );
    };

    if ( function_exists( 'doing_action' ) && doing_action( 'wp_abilities_api_categories_init' ) ) {
        $register_category();
        return;
    }

    add_action( 'wp_abilities_api_categories_init', $register_category );
}
```

The constructor now calls `register_category()` before `register()`. Both follow the existing "fire immediately if we're already inside the matching hook, otherwise defer" pattern.

Smoke test (`tests/smoke-wordpress-plugin.php`) is updated to:

- Stub `wp_register_ability_category()` and accept `wp_abilities_api_categories_init` in the `doing_action()` stub.
- Assert that the `wp-codebox` category was registered with both `label` and `description`.

## Verification

**Live WP 7.0 multisite, plugin built from this branch:**

```
$ wp eval '
foreach (["wp-codebox/run-agent-task","wp-codebox/run-agent-task-batch","wp-codebox/list-artifacts","wp-codebox/get-artifact","wp-codebox/discard-artifact","wp-codebox/apply-approved-artifact","wp-codebox/stage-artifact-apply"] as $n) {
    $a = wp_get_ability( $n );
    echo $n . " => " . ( $a === null ? "NULL" : "OK" ) . PHP_EOL;
}
echo wp_get_ability_category("wp-codebox")->get_label();
'
```

Before this fix:

```
wp-codebox/run-agent-task => NULL
wp-codebox/run-agent-task-batch => NULL
wp-codebox/list-artifacts => NULL
wp-codebox/get-artifact => NULL
wp-codebox/discard-artifact => NULL
wp-codebox/apply-approved-artifact => NULL
wp-codebox/stage-artifact-apply => NULL
```

(plus 7 `_doing_it_wrong` notices)

After this fix:

```
wp-codebox/run-agent-task => OK
wp-codebox/run-agent-task-batch => OK
wp-codebox/list-artifacts => OK
wp-codebox/get-artifact => OK
wp-codebox/discard-artifact => OK
wp-codebox/apply-approved-artifact => OK
wp-codebox/stage-artifact-apply => OK
wp-codebox category => WP Codebox
```

(no notices)

**Local checks:**

- `php tests/smoke-wordpress-plugin.php` → `OK (118 assertions)` (was 116; 2 new assertions for the category).
- `npm run check` runs the full 19-step smoke chain. Steps 1-18 pass on this branch, including `wordpress-plugin-smoke`. Step 19 (`browser-probe-artifact-smoke`, added in #123) fails on this host with `browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1223/...` — a Playwright Chromium binary missing from my dev environment, **unrelated to this change**. If you have Playwright Chromium installed locally, `npm run check` should pass end-to-end.

## Notes

- The category label/description don't use `__()` because the rest of the plugin (all 7 existing `wp_register_ability()` calls in this same file) uses bare strings. Happy to wrap them if you'd rather move the plugin to `__()` everywhere in a follow-up.
- No version bump or CHANGELOG edit — leaving that to the maintainer per the repo's release workflow.