### PR TITLE
Import active extension site seeds

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2897,7 +2897,7 @@ if (!is_array($seed)) {
     throw new RuntimeException('Site seed fixture must decode to a JSON object.');
 }
 
-$counts = array('posts' => 0, 'options' => 0, 'terms' => 0);
+$counts = array('posts' => 0, 'options' => 0, 'terms' => 0, 'activePlugins' => 0, 'activeTheme' => 0);
 
 foreach (($seed['posts'] ?? array()) as $post) {
     if (!is_array($post)) {
@@ -2951,6 +2951,42 @@ foreach (($seed['terms'] ?? array()) as $term) {
     $counts['terms']++;
 }
 
+$active_plugins = $seed['activePlugins'] ?? array();
+if (is_array($active_plugins) && count($active_plugins) > 0) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    foreach ($active_plugins as $plugin) {
+        $plugin_file = is_array($plugin) ? ($plugin['pluginFile'] ?? ($plugin['file'] ?? '')) : $plugin;
+        $plugin_file = is_string($plugin_file) ? $plugin_file : '';
+        if ('' === $plugin_file || str_starts_with($plugin_file, '/') || str_contains($plugin_file, '..') || !str_ends_with($plugin_file, '.php')) {
+            throw new RuntimeException('Unsafe site seed active plugin entry from ' . $seed_name . '.');
+        }
+        if (!file_exists(WP_PLUGIN_DIR . '/' . $plugin_file)) {
+            throw new RuntimeException('Site seed active plugin is not installed in sandbox: ' . $plugin_file);
+        }
+        $result = activate_plugin($plugin_file, '', false, true);
+        if (is_wp_error($result)) {
+            throw new RuntimeException('Failed to activate site seed plugin from ' . $seed_name . ': ' . $result->get_error_message());
+        }
+        $counts['activePlugins']++;
+    }
+}
+
+$active_theme = $seed['activeTheme'] ?? null;
+if (is_array($active_theme)) {
+    $active_theme = $active_theme['stylesheet'] ?? ($active_theme['slug'] ?? null);
+}
+if (is_string($active_theme) && '' !== $active_theme) {
+    if (!preg_match('/^[A-Za-z0-9_-]+$/', $active_theme)) {
+        throw new RuntimeException('Unsafe site seed active theme entry from ' . $seed_name . '.');
+    }
+    $theme = wp_get_theme($active_theme);
+    if (!$theme->exists()) {
+        throw new RuntimeException('Site seed active theme is not installed in sandbox: ' . $active_theme);
+    }
+    switch_theme($active_theme);
+    $counts['activeTheme']++;
+}
+
 echo wp_json_encode(array('schema' => 'wp-codebox/site-seed-import/v1', 'name' => $seed_name, 'counts' => $counts));
 `}
 
@@ -2963,9 +2999,11 @@ function boundedFixtureSeed(rawSeed: unknown, scopes: WorkspaceRecipeSiteSeed["s
   const posts = boundedRecords(arrayRecords(seed.posts), scopes.posts, (record, scope) => matchesPostScope(record, scope))
   const options = boundedOptions(seed.options, scopes.options)
   const terms = boundedRecords(arrayRecords(seed.terms), scopes.terms, (record, scope) => matchesTermScope(record, scope))
+  const activePlugins = boundedActivePlugins(seed.activePlugins, scopes.activePlugins)
+  const activeTheme = boundedActiveTheme(seed.activeTheme, scopes.activeTheme)
 
   return {
-    seed: stripUndefined({ posts: posts.records, options: options.records, terms: terms.records }),
+    seed: stripUndefined({ posts: posts.records, options: options.records, terms: terms.records, activePlugins: activePlugins.records, activeTheme: activeTheme.record }),
     counts: {
       fixturePostsIncluded: posts.records.length,
       fixturePostsExcluded: posts.excluded,
@@ -2973,8 +3011,37 @@ function boundedFixtureSeed(rawSeed: unknown, scopes: WorkspaceRecipeSiteSeed["s
       fixtureOptionsExcluded: options.excluded,
       fixtureTermsIncluded: terms.records.length,
       fixtureTermsExcluded: terms.excluded,
+      fixtureActivePluginsIncluded: activePlugins.records.length,
+      fixtureActivePluginsExcluded: activePlugins.excluded,
+      fixtureActiveThemeIncluded: activeTheme.record === undefined ? 0 : 1,
+      fixtureActiveThemeExcluded: activeTheme.excluded,
     },
   }
+}
+
+function boundedActivePlugins(activePlugins: unknown, scope: boolean | undefined): { records: Array<string | Record<string, unknown>>; excluded: number } {
+  const records = Array.isArray(activePlugins)
+    ? activePlugins.filter((plugin): plugin is string | Record<string, unknown> => typeof plugin === "string" || (Boolean(plugin) && typeof plugin === "object" && !Array.isArray(plugin)))
+    : []
+
+  if (scope !== true) {
+    return { records: [], excluded: records.length }
+  }
+
+  const included = records.slice(0, 100)
+  return { records: included, excluded: records.length - included.length }
+}
+
+function boundedActiveTheme(activeTheme: unknown, scope: boolean | undefined): { record: unknown; excluded: number } {
+  if (activeTheme === undefined || activeTheme === null) {
+    return { record: undefined, excluded: 0 }
+  }
+
+  if (scope !== true) {
+    return { record: undefined, excluded: 1 }
+  }
+
+  return { record: activeTheme, excluded: 0 }
 }
 
 function arrayRecords(value: unknown): Array<Record<string, unknown>> {

--- a/scripts/recipe-site-seed-smoke.ts
+++ b/scripts/recipe-site-seed-smoke.ts
@@ -31,6 +31,8 @@ writeFileSync(fixtureSeedPath, `${JSON.stringify({
     blogname: "WP Codebox Seeded Sandbox",
     admin_email: "private@example.test",
   },
+  activePlugins: ["simple-plugin/simple-plugin.php"],
+  activeTheme: "twentytwentyfive",
   terms: [
     {
       taxonomy: "category",
@@ -49,6 +51,13 @@ writeFileSync(recipePath, `${JSON.stringify({
     blueprint: { steps: [] },
   },
   inputs: {
+    mounts: [
+      {
+        source: "../../examples/simple-plugin",
+        target: "/wordpress/wp-content/plugins/simple-plugin",
+        mode: "readonly",
+      },
+    ],
     siteSeeds: [
       {
         type: "fixture",
@@ -59,6 +68,8 @@ writeFileSync(recipePath, `${JSON.stringify({
           posts: { postTypes: ["page"], slugs: ["site-seed-smoke-page"], maxRecords: 1 },
           options: { names: ["blogname"], maxRecords: 1 },
           terms: { taxonomies: ["category"], slugs: ["site-seed-smoke-category"], maxRecords: 1 },
+          activePlugins: true,
+          activeTheme: true,
         },
       },
       {
@@ -76,7 +87,7 @@ writeFileSync(recipePath, `${JSON.stringify({
       {
         command: "wordpress.run-php",
         args: [
-          "code=$page = get_page_by_path('site-seed-smoke-page', OBJECT, 'page'); if (!$page) { throw new RuntimeException('seeded page missing'); } if (get_page_by_path('site-seed-smoke-excluded-page', OBJECT, 'page')) { throw new RuntimeException('unscoped page imported'); } if (get_option('blogname') !== 'WP Codebox Seeded Sandbox') { throw new RuntimeException('seeded option missing'); } if (!term_exists('site-seed-smoke-category', 'category')) { throw new RuntimeException('seeded term missing'); } echo wp_json_encode(array('page' => $page->post_name, 'blogname' => get_option('blogname')));",
+          "code=$page = get_page_by_path('site-seed-smoke-page', OBJECT, 'page'); if (!$page) { throw new RuntimeException('seeded page missing'); } if (get_page_by_path('site-seed-smoke-excluded-page', OBJECT, 'page')) { throw new RuntimeException('unscoped page imported'); } if (get_option('blogname') !== 'WP Codebox Seeded Sandbox') { throw new RuntimeException('seeded option missing'); } if (!term_exists('site-seed-smoke-category', 'category')) { throw new RuntimeException('seeded term missing'); } if (!is_plugin_active('simple-plugin/simple-plugin.php')) { throw new RuntimeException('seeded plugin not active'); } if (get_stylesheet() !== 'twentytwentyfive') { throw new RuntimeException('seeded theme not active: ' . get_stylesheet()); } echo wp_json_encode(array('page' => $page->post_name, 'blogname' => get_option('blogname'), 'pluginActive' => is_plugin_active('simple-plugin/simple-plugin.php'), 'stylesheet' => get_stylesheet()));",
         ],
       },
     ],
@@ -102,7 +113,11 @@ assert.equal(output.siteSeeds[0].privacy.importsIntoSandbox, true)
 assert.equal(output.siteSeeds[0].counts.posts, 1)
 assert.equal(output.siteSeeds[0].counts.options, 1)
 assert.equal(output.siteSeeds[0].counts.terms, 1)
+assert.equal(output.siteSeeds[0].counts.activePlugins, 1)
+assert.equal(output.siteSeeds[0].counts.activeTheme, 1)
 assert.equal(output.siteSeeds[0].counts.fixturePostsExcluded, 1)
+assert.equal(output.siteSeeds[0].counts.fixtureActivePluginsIncluded, 1)
+assert.equal(output.siteSeeds[0].counts.fixtureActiveThemeIncluded, 1)
 assert.equal(output.siteSeeds[1].action, "skipped")
 assert.equal(output.siteSeeds[1].bounded, true)
 assert.equal(output.siteSeeds[1].privacy.exportsParentSiteData, false)
@@ -111,5 +126,7 @@ assert.equal(output.executions.length, 2)
 const workflowResult = JSON.parse(output.executions[1].stdout)
 assert.equal(workflowResult.page, "site-seed-smoke-page")
 assert.equal(workflowResult.blogname, "WP Codebox Seeded Sandbox")
+assert.equal(workflowResult.pluginActive, true)
+assert.equal(workflowResult.stylesheet, "twentytwentyfive")
 
 console.log("recipe site seed smoke passed")


### PR DESCRIPTION
## Summary
- Adds executable JSON fixture support for `activePlugins` and `activeTheme` site seed scopes.
- Keeps parent-site seeds dry-run-only while allowing fixtures to activate already-installed sandbox plugins and switch to already-installed sandbox themes.
- Extends the site seed smoke to prove the seeded plugin/theme state is visible to workflow steps.

Refs #147.

## Verification
- `npm run build`
- `npm run recipe-site-seed-smoke`
- `npm run check`

## Remaining scope for #147
- Parent-site export/import remains intentionally unimplemented.
- WXR fixtures, Playground blueprint fixtures, users, and media files remain follow-up slices.
- Active plugin/theme fixture import requires the plugin/theme to already be installed or mounted in the sandbox.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused active plugin/theme fixture importer, updated smoke coverage, ran verification, and prepared this PR description for Chris to review.