### PR TITLE
Add recipe workflow before and after phases

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "agent-sandbox-code-smoke": "tsx scripts/agent-sandbox-code-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
+    "recipe-workflow-phases-smoke": "tsx scripts/recipe-workflow-phases-smoke.ts",
     "recipe-site-seed-smoke": "tsx scripts/recipe-site-seed-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-site-seed-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -156,7 +156,7 @@ interface RecipeRunOutput {
   schema: "wp-codebox/recipe-run/v1"
   recipePath?: string
   runtime?: RuntimeInfo
-  executions: ExecutionResult[]
+  executions: RecipeExecutionResult[]
   siteSeeds?: RecipeRunSiteSeed[]
   validation?: {
     issues: RecipeValidationIssue[]
@@ -203,8 +203,17 @@ interface RecipeDryRunPlan {
     issues: ReturnType<typeof validateRuntimePolicy>["issues"]
   }
   workflow: {
+    before?: RecipeDryRunStep[]
     steps: RecipeDryRunStep[]
+    after?: RecipeDryRunStep[]
   }
+}
+
+type RecipeWorkflowPhase = "setup" | "before" | "steps" | "after"
+
+type RecipeExecutionResult = ExecutionResult & {
+  recipePhase?: RecipeWorkflowPhase
+  recipeStepIndex?: number
 }
 
 interface RecipeDryRunMount {
@@ -262,6 +271,7 @@ interface RecipeRunSiteSeed extends Omit<RecipeDryRunSiteSeed, "dryRunOnly"> {
 }
 
 interface RecipeDryRunStep {
+  phase: RecipeWorkflowPhase
   index: number
   command: string
   args: string[]
@@ -580,9 +590,17 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
       additionalProperties: false,
       required: ["steps"],
       properties: {
+        before: {
+          type: "array",
+          items: { $ref: "#/$defs/step" },
+        },
         steps: {
           type: "array",
           minItems: 1,
+          items: { $ref: "#/$defs/step" },
+        },
+        after: {
+          type: "array",
           items: { $ref: "#/$defs/step" },
         },
       },
@@ -990,6 +1008,7 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
   const workspaces = recipeDryRunWorkspaces(recipe, recipeDirectory)
   const extraPlugins = recipeDryRunExtraPlugins(recipe, recipeDirectory)
   const siteSeeds = recipeDryRunSiteSeeds(recipe, recipeDirectory)
+  const workflowSteps = await recipeDryRunSteps(recipe, recipeDirectory, policy)
   const mounts: RecipeDryRunMount[] = [
     ...workspaces.map((workspace) => ({
       type: "directory" as const,
@@ -1045,7 +1064,9 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
       issues: policyValidation.issues,
     },
     workflow: {
-      steps: await recipeDryRunSteps(recipe, recipeDirectory, policy),
+      ...(recipe.workflow.before ? { before: workflowSteps.filter((step) => step.phase === "before") } : {}),
+      steps: workflowSteps,
+      ...(recipe.workflow.after ? { after: workflowSteps.filter((step) => step.phase === "after") } : {}),
     },
   }
 }
@@ -1092,7 +1113,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
   let workspaceMounts: PreparedWorkspaceMount[] = []
   let extraPlugins: PreparedExtraPlugin[] = []
   let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
-  const executions: ExecutionResult[] = []
+  const executions: RecipeExecutionResult[] = []
   let artifacts: ArtifactBundle | undefined
 
   try {
@@ -1158,11 +1179,11 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
 
     const pluginActivationCode = activateExtraPluginsCode(extraPlugins)
     if (pluginActivationCode) {
-      executions.push(await runtime.execute({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }))
+      executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }), "setup", -1))
     }
 
-    for (const step of recipe.workflow.steps) {
-      executions.push(await runtime.execute(await recipeExecutionSpec(step, recipeDirectory)))
+    for (const workflowStep of recipeWorkflowSteps(recipe)) {
+      executions.push(await executeRecipeWorkflowStep(runtime, workflowStep, recipeDirectory))
     }
 
     await runtime.observe({ type: "runtime-info" })
@@ -1229,7 +1250,7 @@ async function validateRecipe(options: RecipeValidateOptions): Promise<RecipeVal
       valid: issues.length === 0,
       issues,
       summary: {
-        steps: recipe.workflow.steps.length,
+        steps: recipeWorkflowSteps(recipe).length,
         mounts: recipe.inputs?.mounts?.length ?? 0,
         workspaces: recipe.inputs?.workspaces?.length ?? 0,
         extraPlugins: recipeExtraPlugins(recipe).length,
@@ -2241,13 +2262,19 @@ function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe 
     throw new Error(`Recipe must include at least one workflow step: ${recipePath}`)
   }
 
-  for (const step of recipe.workflow.steps) {
+  for (const phase of ["before", "after"] as const) {
+    if (recipe.workflow[phase] !== undefined && !Array.isArray(recipe.workflow[phase])) {
+      throw new Error(`Recipe workflow ${phase} must be an array: ${recipePath}`)
+    }
+  }
+
+  for (const { phase, step } of recipeWorkflowSteps(recipe)) {
     if (!step || typeof step.command !== "string" || step.command === "") {
-      throw new Error(`Recipe workflow steps must include a command: ${recipePath}`)
+      throw new Error(`Recipe workflow ${phase} entries must include a command: ${recipePath}`)
     }
 
     if (step.args && !Array.isArray(step.args)) {
-      throw new Error(`Recipe workflow step args must be arrays: ${recipePath}`)
+      throw new Error(`Recipe workflow ${phase} args must be arrays: ${recipePath}`)
     }
   }
 
@@ -2352,8 +2379,8 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
     addIssue("unsupported-backend", "$.runtime.backend", `Unsupported recipe backend: ${recipe.runtime.backend}`)
   }
 
-  for (const [index, step] of recipe.workflow.steps.entries()) {
-    const path = `$.workflow.steps[${index}]`
+  for (const { phase, index, step } of recipeWorkflowSteps(recipe)) {
+    const path = `$.workflow.${phase}[${index}]`
     if (!supportedRecipeCommands.has(step.command)) {
       addIssue("unsupported-command", `${path}.command`, `Unsupported recipe command: ${step.command}`)
       continue
@@ -2607,6 +2634,44 @@ function recipeWpCliCommandFromArgs(args: string[]): string {
   return recipeStepArgValue(args, "command")?.trim() ?? args.join(" ").trim()
 }
 
+function recipeWorkflowSteps(recipe: WorkspaceRecipe): Array<{ phase: Exclude<RecipeWorkflowPhase, "setup">; index: number; step: WorkspaceRecipe["workflow"]["steps"][number] }> {
+  return [
+    ...(recipe.workflow.before ?? []).map((step, index) => ({ phase: "before" as const, index, step })),
+    ...recipe.workflow.steps.map((step, index) => ({ phase: "steps" as const, index, step })),
+    ...(recipe.workflow.after ?? []).map((step, index) => ({ phase: "after" as const, index, step })),
+  ]
+}
+
+function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number): RecipeExecutionResult {
+  return {
+    ...execution,
+    recipePhase,
+    recipeStepIndex,
+  }
+}
+
+async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string): Promise<RecipeExecutionResult> {
+  try {
+    const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory))
+    return withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Recipe workflow ${workflowStep.phase}[${workflowStep.index}] failed: ${message}`, { cause: error })
+  }
+}
+
+function recipeWorkflowMetadata(recipe: WorkspaceRecipe): { before?: Array<{ command: string; args: string[] }>; steps: Array<{ command: string; args: string[] }>; after?: Array<{ command: string; args: string[] }> } {
+  return {
+    ...(recipe.workflow.before ? { before: recipe.workflow.before.map(recipeStepMetadata) } : {}),
+    steps: recipe.workflow.steps.map(recipeStepMetadata),
+    ...(recipe.workflow.after ? { after: recipe.workflow.after.map(recipeStepMetadata) } : {}),
+  }
+}
+
+function recipeStepMetadata(step: WorkspaceRecipe["workflow"]["steps"][number]): { command: string; args: string[] } {
+  return { command: step.command, args: step.args ?? [] }
+}
+
 async function recipeDryRunSteps(recipe: WorkspaceRecipe, recipeDirectory: string, policy: RuntimePolicy): Promise<RecipeDryRunStep[]> {
   const steps: Array<Promise<RecipeDryRunStep>> = []
   const dryRunExtraPlugins = await Promise.all(recipeExtraPlugins(recipe).map(async (plugin) => {
@@ -2623,20 +2688,21 @@ async function recipeDryRunSteps(recipe: WorkspaceRecipe, recipeDirectory: strin
   }))
   const pluginActivationCode = activateExtraPluginsCode(dryRunExtraPlugins)
   if (pluginActivationCode) {
-    steps.push(recipeDryRunStep({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }, recipeDirectory, policy, -1, "activate-extra-plugins"))
+    steps.push(recipeDryRunStep({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }, recipeDirectory, policy, "setup", -1, "activate-extra-plugins"))
   }
 
-  for (const [index, step] of recipe.workflow.steps.entries()) {
-    steps.push(recipeDryRunStep(step, recipeDirectory, policy, index))
+  for (const workflowStep of recipeWorkflowSteps(recipe)) {
+    steps.push(recipeDryRunStep(workflowStep.step, recipeDirectory, policy, workflowStep.phase, workflowStep.index))
   }
 
   return Promise.all(steps)
 }
 
-async function recipeDryRunStep(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string, policy: RuntimePolicy, index: number, label?: string): Promise<RecipeDryRunStep> {
+async function recipeDryRunStep(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string, policy: RuntimePolicy, phase: RecipeWorkflowPhase, index: number, label?: string): Promise<RecipeDryRunStep> {
   const resolved = await recipeExecutionSpec(step, recipeDirectory)
   const allowed = policy.commands.includes(resolved.command)
   return {
+    phase,
     index,
     command: label ?? step.command,
     args: step.args ?? [],
@@ -2671,7 +2737,7 @@ function parseRecipeArgs(args: string[]): Record<string, string | true> {
 }
 
 function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
-  const commands = recipe.workflow.steps.map((step) => step.command.startsWith("wp-codebox.agent-") ? "wordpress.run-php" : step.command)
+  const commands = recipeWorkflowSteps(recipe).map(({ step }) => step.command.startsWith("wp-codebox.agent-") ? "wordpress.run-php" : step.command)
   if (recipeExtraPlugins(recipe).some((plugin) => plugin.activate !== false)) {
     commands.unshift("wordpress.run-php")
   }
@@ -2701,6 +2767,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
     provenance: plugin.provenance,
   }))
   const siteSeedProvenance = recipeDryRunSiteSeeds(recipe, dirname(recipePath))
+  const workflow = recipeWorkflowMetadata(recipe)
 
   return {
     recipe: {
@@ -2708,9 +2775,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       schema: recipe.schema,
       runtime: recipe.runtime ?? {},
       artifacts: recipe.artifacts ?? {},
-      workflow: {
-        steps: recipe.workflow.steps.map((step) => ({ command: step.command, args: step.args ?? [] })),
-      },
+      workflow,
       inputs: {
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
@@ -2729,9 +2794,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       previewPublicUrl,
       previewPort,
       previewBind,
-      workflow: {
-        steps: recipe.workflow.steps.map((step) => ({ command: step.command, args: step.args ?? [] })),
-      },
+      workflow,
       inputs: {
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
@@ -2817,7 +2880,7 @@ function recipeDryRunSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string)
   }))
 }
 
-async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string, runtime: Runtime, executions: ExecutionResult[]): Promise<RecipeRunSiteSeed[]> {
+async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string, runtime: Runtime, executions: RecipeExecutionResult[]): Promise<RecipeRunSiteSeed[]> {
   const results: RecipeRunSiteSeed[] = []
 
   for (const [index, siteSeed] of (recipe.inputs?.siteSeeds ?? []).entries()) {
@@ -2843,7 +2906,7 @@ async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: s
       command: "wordpress.run-php",
       args: [`code=${siteSeedJsonImportCode(siteSeed.name, bounded.seed)}`],
     })
-    executions.push(execution)
+    executions.push(withRecipeExecutionPhase(execution, "setup", index))
     const counts = parseSiteSeedImportCounts(execution.stdout)
     results.push({
       ...base,

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -257,7 +257,9 @@ export interface WorkspaceRecipe {
     inheritance?: WorkspaceRecipeInheritanceResolution
   }
   workflow: {
+    before?: WorkspaceRecipeStep[]
     steps: WorkspaceRecipeStep[]
+    after?: WorkspaceRecipeStep[]
   }
   artifacts?: {
     directory?: string

--- a/scripts/recipe-workflow-phases-smoke.ts
+++ b/scripts/recipe-workflow-phases-smoke.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const workspace = resolve(root, "artifacts/recipe-workflow-phases-smoke")
+const recipePath = resolve(workspace, "recipe.json")
+const failureRecipePath = resolve(workspace, "failure-recipe.json")
+const artifactDirectory = resolve(workspace, "artifacts")
+
+const appendPhaseCode = (phase: string) => `$order = get_option('wp_codebox_workflow_phase_order', array()); $order[] = '${phase}'; update_option('wp_codebox_workflow_phase_order', $order); echo wp_json_encode($order);`
+
+mkdirSync(workspace, { recursive: true })
+writeFileSync(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: {
+    backend: "wordpress-playground",
+    name: "recipe-workflow-phases-smoke",
+    wp: "7.0",
+    blueprint: { steps: [] },
+  },
+  workflow: {
+    before: [
+      {
+        command: "wordpress.run-php",
+        args: [`code=${appendPhaseCode("before")}`],
+      },
+    ],
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: [`code=${appendPhaseCode("steps")}`],
+      },
+    ],
+    after: [
+      {
+        command: "wordpress.run-php",
+        args: [`code=${appendPhaseCode("after")}`],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+writeFileSync(failureRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: {
+    backend: "wordpress-playground",
+    name: "recipe-workflow-phases-failure-smoke",
+    wp: "7.0",
+    blueprint: { steps: [] },
+  },
+  workflow: {
+    before: [
+      {
+        command: "wordpress.run-php",
+        args: [`code=${appendPhaseCode("before")}`],
+      },
+    ],
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: [`code=${appendPhaseCode("steps")}`],
+      },
+    ],
+    after: [
+      {
+        command: "wordpress.run-php",
+        args: ["code=throw new RuntimeException('after phase failed');"],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+const dryRun = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(dryRun.status, 0, dryRun.stderr || dryRun.stdout)
+const dryRunOutput = JSON.parse(dryRun.stdout)
+assert.deepEqual(dryRunOutput.plan.workflow.steps.map((step: { phase: string }) => step.phase), ["before", "steps", "after"])
+assert.equal(dryRunOutput.plan.workflow.before[0].phase, "before")
+assert.equal(dryRunOutput.plan.workflow.after[0].phase, "after")
+
+const result = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--artifacts",
+  artifactDirectory,
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(result.status, 0, result.stderr || result.stdout)
+const output = JSON.parse(result.stdout)
+assert.equal(output.success, true)
+assert.deepEqual(output.executions.map((execution: { recipePhase: string }) => execution.recipePhase), ["before", "steps", "after"])
+assert.deepEqual(JSON.parse(output.executions[2].stdout), ["before", "steps", "after"])
+
+const metadata = JSON.parse(readFileSync(output.artifacts.metadataPath, "utf8"))
+assert.equal(metadata.provenance.task.workflow.before[0].command, "wordpress.run-php")
+assert.equal(metadata.provenance.task.workflow.steps[0].command, "wordpress.run-php")
+assert.equal(metadata.provenance.task.workflow.after[0].command, "wordpress.run-php")
+
+const failureResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  failureRecipePath,
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(failureResult.status, 1, failureResult.stderr || failureResult.stdout)
+const failureOutput = JSON.parse(failureResult.stdout)
+assert.equal(failureOutput.success, false)
+assert.match(failureOutput.error.message, /Recipe workflow after\[0\] failed/)
+assert.deepEqual(failureOutput.executions.map((execution: { recipePhase: string }) => execution.recipePhase), ["before", "steps"])
+
+console.log("recipe workflow phases smoke passed")


### PR DESCRIPTION
## Summary
- Add generic `workflow.before` and `workflow.after` recipe phases around existing `workflow.steps`.
- Preserve phase metadata in dry-run plans, execution output, and artifact provenance.
- Add workflow phase smoke coverage for ordering and after-phase failure behavior.

Fixes #160.

## Verification
- `npm run build`
- `npm run recipe-workflow-phases-smoke`
- `npm run recipe-dry-run-smoke`
- `npm run check`

## Notes
- Installed the local Playwright Chromium browser with `npx playwright install chromium` after the first full check hit a missing browser binary on this machine.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, smoke coverage, verification, commit, and PR body for Chris to review.