### PR TITLE
Add site seed importer registry

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -244,6 +244,7 @@ interface RecipeDryRunSiteSeed {
   name: string
   source?: string
   format?: WorkspaceRecipeSiteSeed["format"]
+  importer?: string
   scopes: WorkspaceRecipeSiteSeed["scopes"]
   bounded: boolean
   dryRunOnly: boolean
@@ -259,6 +260,8 @@ interface RecipeRunSiteSeed extends Omit<RecipeDryRunSiteSeed, "dryRunOnly"> {
   action: "imported" | "skipped"
   reason?: string
   counts?: Record<string, number>
+  warnings?: string[]
+  provenance?: Record<string, unknown>
 }
 
 interface RecipeDryRunStep {
@@ -655,7 +658,7 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
         type: { enum: ["fixture", "parent_site"] },
         name: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*$" },
         source: { type: "string", description: "Fixture file path. Not allowed for parent_site dry-run declarations." },
-        format: { enum: ["json", "wxr", "playground-blueprint"] },
+        format: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*$" },
         scopes: {
           type: "object",
           additionalProperties: false,
@@ -1154,12 +1157,12 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       })
     }
 
-    const siteSeeds = await importRecipeSiteSeeds(recipe, recipeDirectory, runtime, executions)
-
     const pluginActivationCode = activateExtraPluginsCode(extraPlugins)
     if (pluginActivationCode) {
       executions.push(await runtime.execute({ command: "wordpress.run-php", args: [`code=${pluginActivationCode}`] }))
     }
+
+    const siteSeeds = await importRecipeSiteSeeds(recipe, recipeDirectory, runtime, executions)
 
     for (const step of recipe.workflow.steps) {
       executions.push(await runtime.execute(await recipeExecutionSpec(step, recipeDirectory)))
@@ -2805,12 +2808,13 @@ function recipeDryRunSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string)
     name: siteSeed.name,
     ...(siteSeed.source ? { source: resolve(recipeDirectory, siteSeed.source) } : {}),
     ...(siteSeed.format ? { format: siteSeed.format } : {}),
+    ...(siteSeed.type === "fixture" ? { importer: siteSeed.format ?? "json" } : {}),
     scopes: siteSeed.scopes,
     bounded: siteSeedScopesAreBounded(siteSeed),
-    dryRunOnly: siteSeed.type !== "fixture" || (siteSeed.format !== undefined && siteSeed.format !== "json"),
+    dryRunOnly: siteSeed.type !== "fixture",
     privacy: {
       exportsParentSiteData: false,
-      importsIntoSandbox: siteSeed.type === "fixture" && (siteSeed.format === undefined || siteSeed.format === "json"),
+      importsIntoSandbox: siteSeed.type === "fixture",
       includesRecordData: siteSeed.type === "fixture",
       secrets: "excluded-by-default",
     },
@@ -2832,25 +2836,49 @@ async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: s
     }
 
     const format = siteSeed.format ?? "json"
-    if (format !== "json") {
-      throw new Error(`Recipe fixture siteSeed ${siteSeed.name} uses unsupported executable format: ${format}`)
+    const source = resolve(recipeDirectory, siteSeed.source ?? "")
+    if (format === "json") {
+      const rawSeed = JSON.parse(await readFile(source, "utf8"))
+      const bounded = boundedFixtureSeed(rawSeed, siteSeed.scopes)
+      const execution = await runtime.execute({
+        command: "wordpress.run-php",
+        args: [`code=${siteSeedJsonImportCode(siteSeed.name, bounded.seed)}`],
+      })
+      executions.push(execution)
+      const imported = parseSiteSeedImportResult(execution.stdout)
+      results.push({
+        ...base,
+        action: "imported",
+        counts: {
+          ...bounded.counts,
+          ...imported.counts,
+        },
+        ...(imported.warnings.length > 0 ? { warnings: imported.warnings } : {}),
+        provenance: {
+          importer: "json",
+          source,
+          ...(imported.provenance ?? {}),
+        },
+      })
+      continue
     }
 
-    const source = resolve(recipeDirectory, siteSeed.source ?? "")
-    const rawSeed = JSON.parse(await readFile(source, "utf8"))
-    const bounded = boundedFixtureSeed(rawSeed, siteSeed.scopes)
+    const sourceContents = await readFile(source, "utf8")
     const execution = await runtime.execute({
       command: "wordpress.run-php",
-      args: [`code=${siteSeedJsonImportCode(siteSeed.name, bounded.seed)}`],
+      args: [`code=${siteSeedRegistryImportCode(siteSeed, format, source, sourceContents)}`],
     })
     executions.push(execution)
-    const counts = parseSiteSeedImportCounts(execution.stdout)
+    const imported = parseSiteSeedImportResult(execution.stdout)
     results.push({
       ...base,
       action: "imported",
-      counts: {
-        ...bounded.counts,
-        ...counts,
+      counts: imported.counts,
+      ...(imported.warnings.length > 0 ? { warnings: imported.warnings } : {}),
+      provenance: {
+        importer: format,
+        source,
+        ...(imported.provenance ?? {}),
       },
     })
   }
@@ -2865,26 +2893,32 @@ function recipeSiteSeedRunBase(siteSeed: WorkspaceRecipeSiteSeed, recipeDirector
     name: siteSeed.name,
     ...(siteSeed.source ? { source: resolve(recipeDirectory, siteSeed.source) } : {}),
     ...(siteSeed.format ? { format: siteSeed.format } : {}),
+    ...(siteSeed.type === "fixture" ? { importer: siteSeed.format ?? "json" } : {}),
     scopes: siteSeed.scopes,
     bounded: siteSeedScopesAreBounded(siteSeed),
     privacy: {
       exportsParentSiteData: false,
-      importsIntoSandbox: siteSeed.type === "fixture" && (siteSeed.format === undefined || siteSeed.format === "json"),
+      importsIntoSandbox: siteSeed.type === "fixture",
       includesRecordData: siteSeed.type === "fixture",
       secrets: "excluded-by-default",
     },
   }
 }
 
-function parseSiteSeedImportCounts(stdout: string): Record<string, number> {
-  const parsed = JSON.parse(stdout.trim() || "{}") as { counts?: Record<string, unknown> }
+function parseSiteSeedImportResult(stdout: string): { counts: Record<string, number>; warnings: string[]; provenance?: Record<string, unknown> } {
+  const parsed = JSON.parse(stdout.trim() || "{}") as { counts?: Record<string, unknown>; warnings?: unknown[]; provenance?: unknown }
   const counts: Record<string, number> = {}
   for (const [key, value] of Object.entries(parsed.counts ?? {})) {
     if (typeof value === "number") {
       counts[key] = value
     }
   }
-  return counts
+  const warnings = (parsed.warnings ?? []).filter((warning): warning is string => typeof warning === "string")
+  return {
+    counts,
+    warnings,
+    ...(parsed.provenance && typeof parsed.provenance === "object" && !Array.isArray(parsed.provenance) ? { provenance: parsed.provenance as Record<string, unknown> } : {}),
+  }
 }
 
 function siteSeedJsonImportCode(seedName: string, seed: unknown): string {
@@ -2988,6 +3022,80 @@ if (is_string($active_theme) && '' !== $active_theme) {
 }
 
 echo wp_json_encode(array('schema' => 'wp-codebox/site-seed-import/v1', 'name' => $seed_name, 'counts' => $counts));
+`}
+
+function siteSeedRegistryImportCode(siteSeed: WorkspaceRecipeSiteSeed, format: string, source: string, sourceContents: string): string {
+  const encodedName = JSON.stringify(siteSeed.name)
+  const encodedFormat = JSON.stringify(format)
+  const encodedSource = JSON.stringify(source)
+  const encodedSourceBasename = JSON.stringify(basename(source))
+  const encodedSourceContents = JSON.stringify(sourceContents)
+  const encodedScopes = JSON.stringify(JSON.stringify(siteSeed.scopes))
+  return `
+$seed_name = ${encodedName};
+$format = ${encodedFormat};
+$source = ${encodedSource};
+$source_basename = ${encodedSourceBasename};
+$source_contents = ${encodedSourceContents};
+$scopes = json_decode(${encodedScopes}, true);
+if (!is_array($scopes)) {
+    throw new RuntimeException('Site seed scopes must decode to an object.');
+}
+
+$importers = apply_filters('wp_codebox_site_seed_importers', array());
+if (!is_array($importers) || !array_key_exists($format, $importers)) {
+    throw new RuntimeException('No WP Codebox site seed importer registered for format: ' . $format);
+}
+
+$importer = $importers[$format];
+$callback = is_array($importer) && array_key_exists('callback', $importer) ? $importer['callback'] : $importer;
+if (!is_callable($callback)) {
+    throw new RuntimeException('WP Codebox site seed importer is not callable for format: ' . $format);
+}
+
+$result = call_user_func($callback, array(
+    'schema' => 'wp-codebox/site-seed-import-request/v1',
+    'name' => $seed_name,
+    'format' => $format,
+    'source' => $source,
+    'source_basename' => $source_basename,
+    'source_contents' => $source_contents,
+    'scopes' => $scopes,
+    'metadata' => array(
+        'source_size' => strlen($source_contents),
+    ),
+));
+
+if (!is_array($result)) {
+    throw new RuntimeException('WP Codebox site seed importer must return an array for format: ' . $format);
+}
+
+$counts = array();
+foreach (($result['counts'] ?? array()) as $key => $value) {
+    if (is_int($value) || is_float($value)) {
+        $counts[(string) $key] = $value;
+    }
+}
+
+$warnings = array();
+foreach (($result['warnings'] ?? array()) as $warning) {
+    if (is_string($warning)) {
+        $warnings[] = $warning;
+    }
+}
+
+$provenance = isset($result['provenance']) && is_array($result['provenance']) ? $result['provenance'] : array();
+$provenance['importer'] = $format;
+$provenance['source'] = $source;
+
+echo wp_json_encode(array(
+    'schema' => 'wp-codebox/site-seed-import/v1',
+    'name' => $seed_name,
+    'importer' => $format,
+    'counts' => $counts,
+    'warnings' => $warnings,
+    'provenance' => $provenance,
+));
 `}
 
 function boundedFixtureSeed(rawSeed: unknown, scopes: WorkspaceRecipeSiteSeed["scopes"]): { seed: Record<string, unknown>; counts: Record<string, number> } {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -167,7 +167,7 @@ export interface WorkspaceRecipeExtraPlugin {
 }
 
 export type WorkspaceRecipeSiteSeedType = "fixture" | "parent_site"
-export type WorkspaceRecipeSiteSeedFormat = "json" | "wxr" | "playground-blueprint"
+export type WorkspaceRecipeSiteSeedFormat = "json" | (string & {})
 
 export interface WorkspaceRecipeSiteSeedScopeSelector {
   ids?: number[]

--- a/scripts/recipe-site-seed-smoke.ts
+++ b/scripts/recipe-site-seed-smoke.ts
@@ -9,8 +9,13 @@ const cli = resolve(root, "packages/cli/dist/index.js")
 const workspace = resolve(root, "artifacts/recipe-site-seed-smoke")
 const recipePath = resolve(workspace, "recipe.json")
 const fixtureSeedPath = resolve(workspace, "fixture-seed.json")
+const customSeedPath = resolve(workspace, "custom-seed.fixture")
+const importerPluginDir = resolve(workspace, "test-seed-importer")
+const importerPluginPath = resolve(importerPluginDir, "test-seed-importer.php")
+const unknownFormatRecipePath = resolve(workspace, "unknown-format-recipe.json")
 
 mkdirSync(workspace, { recursive: true })
+mkdirSync(importerPluginDir, { recursive: true })
 writeFileSync(fixtureSeedPath, `${JSON.stringify({
   posts: [
     {
@@ -41,6 +46,45 @@ writeFileSync(fixtureSeedPath, `${JSON.stringify({
     },
   ],
 }, null, 2)}\n`)
+writeFileSync(customSeedPath, "site-seed-smoke-registry-page\n")
+writeFileSync(importerPluginPath, `<?php
+/**
+ * Plugin Name: WP Codebox Test Site Seed Importer
+ */
+
+add_filter('wp_codebox_site_seed_importers', function (array $importers): array {
+    $importers['test-fixture'] = array(
+        'label' => 'WP Codebox test fixture importer',
+        'callback' => function (array $request): array {
+            $slug = trim((string) ($request['source_contents'] ?? ''));
+            if ('' === $slug) {
+                throw new RuntimeException('Test fixture source was empty.');
+            }
+
+            $post_id = wp_insert_post(array(
+                'post_type' => 'page',
+                'post_status' => 'publish',
+                'post_name' => $slug,
+                'post_title' => 'Registry Site Seed Smoke Page',
+                'post_content' => 'Seeded by a registered WP Codebox site seed importer.',
+            ), true);
+            if (is_wp_error($post_id)) {
+                throw new RuntimeException($post_id->get_error_message());
+            }
+
+            return array(
+                'counts' => array('posts' => 1, 'scopedPostTypes' => count($request['scopes']['posts']['postTypes'] ?? array())),
+                'warnings' => array('registry importer smoke warning'),
+                'provenance' => array(
+                    'requestName' => $request['name'] ?? '',
+                    'sourceBasename' => $request['source_basename'] ?? '',
+                ),
+            );
+        },
+    );
+    return $importers;
+});
+`)
 
 writeFileSync(recipePath, `${JSON.stringify({
   schema: "wp-codebox/workspace-recipe/v1",
@@ -58,6 +102,13 @@ writeFileSync(recipePath, `${JSON.stringify({
         mode: "readonly",
       },
     ],
+    extraPlugins: [
+      {
+        source: "./test-seed-importer",
+        slug: "test-seed-importer",
+        pluginFile: "test-seed-importer/test-seed-importer.php",
+      },
+    ],
     siteSeeds: [
       {
         type: "fixture",
@@ -70,6 +121,15 @@ writeFileSync(recipePath, `${JSON.stringify({
           terms: { taxonomies: ["category"], slugs: ["site-seed-smoke-category"], maxRecords: 1 },
           activePlugins: true,
           activeTheme: true,
+        },
+      },
+      {
+        type: "fixture",
+        name: "site-seed-registry-fixture",
+        source: "./custom-seed.fixture",
+        format: "test-fixture",
+        scopes: {
+          posts: { postTypes: ["page"], slugs: ["site-seed-smoke-registry-page"], maxRecords: 1 },
         },
       },
       {
@@ -87,8 +147,39 @@ writeFileSync(recipePath, `${JSON.stringify({
       {
         command: "wordpress.run-php",
         args: [
-          "code=$page = get_page_by_path('site-seed-smoke-page', OBJECT, 'page'); if (!$page) { throw new RuntimeException('seeded page missing'); } if (get_page_by_path('site-seed-smoke-excluded-page', OBJECT, 'page')) { throw new RuntimeException('unscoped page imported'); } if (get_option('blogname') !== 'WP Codebox Seeded Sandbox') { throw new RuntimeException('seeded option missing'); } if (!term_exists('site-seed-smoke-category', 'category')) { throw new RuntimeException('seeded term missing'); } if (!is_plugin_active('simple-plugin/simple-plugin.php')) { throw new RuntimeException('seeded plugin not active'); } if (get_stylesheet() !== 'twentytwentyfive') { throw new RuntimeException('seeded theme not active: ' . get_stylesheet()); } echo wp_json_encode(array('page' => $page->post_name, 'blogname' => get_option('blogname'), 'pluginActive' => is_plugin_active('simple-plugin/simple-plugin.php'), 'stylesheet' => get_stylesheet()));",
+          "code=$page = get_page_by_path('site-seed-smoke-page', OBJECT, 'page'); if (!$page) { throw new RuntimeException('seeded page missing'); } $registry_page = get_page_by_path('site-seed-smoke-registry-page', OBJECT, 'page'); if (!$registry_page) { throw new RuntimeException('registry seeded page missing'); } if (get_page_by_path('site-seed-smoke-excluded-page', OBJECT, 'page')) { throw new RuntimeException('unscoped page imported'); } if (get_option('blogname') !== 'WP Codebox Seeded Sandbox') { throw new RuntimeException('seeded option missing'); } if (!term_exists('site-seed-smoke-category', 'category')) { throw new RuntimeException('seeded term missing'); } if (!is_plugin_active('simple-plugin/simple-plugin.php')) { throw new RuntimeException('seeded plugin not active'); } if (!is_plugin_active('test-seed-importer/test-seed-importer.php')) { throw new RuntimeException('importer plugin not active'); } if (get_stylesheet() !== 'twentytwentyfive') { throw new RuntimeException('seeded theme not active: ' . get_stylesheet()); } echo wp_json_encode(array('page' => $page->post_name, 'registryPage' => $registry_page->post_name, 'blogname' => get_option('blogname'), 'pluginActive' => is_plugin_active('simple-plugin/simple-plugin.php'), 'stylesheet' => get_stylesheet()));",
         ],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+writeFileSync(unknownFormatRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: {
+    backend: "wordpress-playground",
+    name: "recipe-site-seed-unknown-format-smoke",
+    wp: "7.0",
+    blueprint: { steps: [] },
+  },
+  inputs: {
+    siteSeeds: [
+      {
+        type: "fixture",
+        name: "unknown-format-fixture",
+        source: "./custom-seed.fixture",
+        format: "missing-importer",
+        scopes: {
+          posts: { postTypes: ["page"], maxRecords: 1 },
+        },
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: ["code=echo 'should not run';"],
       },
     ],
   },
@@ -107,7 +198,7 @@ const result = spawnSync(process.execPath, [
 assert.equal(result.status, 0, result.stderr || result.stdout)
 const output = JSON.parse(result.stdout)
 assert.equal(output.success, true)
-assert.equal(output.siteSeeds.length, 2)
+assert.equal(output.siteSeeds.length, 3)
 assert.equal(output.siteSeeds[0].action, "imported")
 assert.equal(output.siteSeeds[0].privacy.importsIntoSandbox, true)
 assert.equal(output.siteSeeds[0].counts.posts, 1)
@@ -118,15 +209,40 @@ assert.equal(output.siteSeeds[0].counts.activeTheme, 1)
 assert.equal(output.siteSeeds[0].counts.fixturePostsExcluded, 1)
 assert.equal(output.siteSeeds[0].counts.fixtureActivePluginsIncluded, 1)
 assert.equal(output.siteSeeds[0].counts.fixtureActiveThemeIncluded, 1)
-assert.equal(output.siteSeeds[1].action, "skipped")
-assert.equal(output.siteSeeds[1].bounded, true)
-assert.equal(output.siteSeeds[1].privacy.exportsParentSiteData, false)
-assert.equal(output.executions.length, 2)
+assert.equal(output.siteSeeds[0].provenance.importer, "json")
+assert.equal(output.siteSeeds[1].action, "imported")
+assert.equal(output.siteSeeds[1].importer, "test-fixture")
+assert.equal(output.siteSeeds[1].counts.posts, 1)
+assert.equal(output.siteSeeds[1].counts.scopedPostTypes, 1)
+assert.equal(output.siteSeeds[1].warnings[0], "registry importer smoke warning")
+assert.equal(output.siteSeeds[1].provenance.importer, "test-fixture")
+assert.equal(output.siteSeeds[1].provenance.requestName, "site-seed-registry-fixture")
+assert.equal(output.siteSeeds[1].provenance.sourceBasename, "custom-seed.fixture")
+assert.equal(output.siteSeeds[2].action, "skipped")
+assert.equal(output.siteSeeds[2].bounded, true)
+assert.equal(output.siteSeeds[2].privacy.exportsParentSiteData, false)
+assert.equal(output.executions.length, 4)
 
-const workflowResult = JSON.parse(output.executions[1].stdout)
+const workflowResult = JSON.parse(output.executions[3].stdout)
 assert.equal(workflowResult.page, "site-seed-smoke-page")
+assert.equal(workflowResult.registryPage, "site-seed-smoke-registry-page")
 assert.equal(workflowResult.blogname, "WP Codebox Seeded Sandbox")
 assert.equal(workflowResult.pluginActive, true)
 assert.equal(workflowResult.stylesheet, "twentytwentyfive")
+
+const unknownFormatResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  unknownFormatRecipePath,
+  "--artifacts",
+  resolve(workspace, "unknown-format-artifacts"),
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(unknownFormatResult.status, 1, unknownFormatResult.stderr || unknownFormatResult.stdout)
+const unknownFormatOutput = JSON.parse(unknownFormatResult.stdout)
+assert.equal(unknownFormatOutput.success, false)
+assert.match(unknownFormatOutput.error.message, /No WP Codebox site seed importer registered for format: missing-importer/)
 
 console.log("recipe site seed smoke passed")


### PR DESCRIPTION
## Summary
- add a generic `wp_codebox_site_seed_importers` sandbox registry for non-JSON fixture site seed formats
- invoke registered importers with source, scopes, seed name, and safe metadata, then normalize counts/warnings/provenance
- keep built-in JSON fixture imports working and fail closed for unknown formats
- extend site seed smoke coverage for registered importer execution, counts, provenance, and unknown-format failure

Fixes #161

## Verification
- `npm run build && npm run recipe-site-seed-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and merge.
