### PR TITLE
Add generic recipe file staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,10 @@
     "agent-sandbox-code-smoke": "tsx scripts/agent-sandbox-code-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "recipe-site-seed-smoke": "tsx scripts/recipe-site-seed-smoke.ts",
+    "recipe-staged-files-smoke": "tsx scripts/recipe-staged-files-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-site-seed-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ import { basename, dirname, join, resolve } from "node:path"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import { promisify } from "node:util"
-import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
 import { captureStdout, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
@@ -147,6 +147,7 @@ interface RecipeValidateOutput {
     mounts: number
     workspaces: number
     extraPlugins: number
+    stagedFiles: number
   }
   error?: RunOutput["error"]
 }
@@ -157,6 +158,7 @@ interface RecipeRunOutput {
   recipePath?: string
   runtime?: RuntimeInfo
   executions: ExecutionResult[]
+  stagedFiles?: RecipeRunStagedFile[]
   siteSeeds?: RecipeRunSiteSeed[]
   validation?: {
     issues: RecipeValidationIssue[]
@@ -197,6 +199,7 @@ interface RecipeDryRunPlan {
   workspaces: RecipeDryRunWorkspace[]
   extra_plugins: RecipeDryRunExtraPlugin[]
   siteSeeds: RecipeDryRunSiteSeed[]
+  stagedFiles: RecipeDryRunStagedFile[]
   secretEnv: Array<{ name: string; available: boolean }>
   policy: RuntimePolicy & {
     valid: boolean
@@ -208,7 +211,7 @@ interface RecipeDryRunPlan {
 }
 
 interface RecipeDryRunMount {
-  type: "directory"
+  type: MountSpec["type"]
   source?: string
   target: string
   mode: "readonly" | "readwrite"
@@ -259,6 +262,19 @@ interface RecipeRunSiteSeed extends Omit<RecipeDryRunSiteSeed, "dryRunOnly"> {
   action: "imported" | "skipped"
   reason?: string
   counts?: Record<string, number>
+}
+
+interface RecipeDryRunStagedFile {
+  index: number
+  source: string
+  sourceRef: string
+  target: string
+  type: MountSpec["type"]
+  provenance: RecipeStagedFileProvenance
+}
+
+interface RecipeRunStagedFile extends RecipeDryRunStagedFile {
+  action: "staged"
 }
 
 interface RecipeDryRunStep {
@@ -319,6 +335,23 @@ interface PreparedExtraPlugin {
   activate: boolean
   cleanupPaths: string[]
   provenance: RecipeSourceProvenance
+}
+
+interface RecipeStagedFileProvenance {
+  kind: "local"
+  original: string
+  localPathCategory?: "recipe-relative"
+}
+
+interface PreparedStagedFile {
+  source: string
+  originalSource: string
+  sourceRef: string
+  target: string
+  type: MountSpec["type"]
+  cleanupPaths: string[]
+  provenance: RecipeStagedFileProvenance
+  metadata: Record<string, unknown>
 }
 
 interface AgentRuntimeProbeOptions {
@@ -571,6 +604,11 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
           description: "Explicit site/content seed declarations. Local JSON fixture seeds are imported into the sandbox before workflow steps. Parent-site declarations remain bounded, auditable metadata until export support lands.",
           items: { $ref: "#/$defs/siteSeed" },
         },
+        stagedFiles: {
+          type: "array",
+          description: "Local recipe-owned files or directories copied into absolute sandbox paths before workflow steps execute.",
+          items: { $ref: "#/$defs/stagedFile" },
+        },
         inherit: { $ref: "#/$defs/inheritanceRequest" },
         inheritance: { $ref: "#/$defs/inheritanceResolution" },
       },
@@ -685,6 +723,15 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
         includeFiles: { type: "boolean" },
         anonymize: { type: "boolean" },
         maxRecords: { type: "integer", minimum: 1, maximum: 100 },
+      },
+    },
+    stagedFile: {
+      type: "object",
+      additionalProperties: false,
+      required: ["source", "target"],
+      properties: {
+        source: { type: "string" },
+        target: { type: "string", pattern: "^/" },
       },
     },
     step: {
@@ -990,6 +1037,7 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
   const workspaces = recipeDryRunWorkspaces(recipe, recipeDirectory)
   const extraPlugins = recipeDryRunExtraPlugins(recipe, recipeDirectory)
   const siteSeeds = recipeDryRunSiteSeeds(recipe, recipeDirectory)
+  const stagedFiles = await recipeDryRunStagedFiles(recipe, recipeDirectory)
   const mounts: RecipeDryRunMount[] = [
     ...workspaces.map((workspace) => ({
       type: "directory" as const,
@@ -1019,6 +1067,18 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
       ...(mount.metadata ? { metadata: mount.metadata } : {}),
       planned: "existing" as const,
     })),
+    ...stagedFiles.map((stagedFile) => ({
+      type: stagedFile.type,
+      source: stagedFile.source,
+      target: stagedFile.target,
+      mode: "readwrite" as const,
+      metadata: {
+        kind: "staged-file",
+        index: stagedFile.index,
+        source: stagedFile.provenance,
+      },
+      planned: "generated" as const,
+    })),
   ]
 
   return {
@@ -1035,6 +1095,7 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
     workspaces,
     extra_plugins: extraPlugins,
     siteSeeds,
+    stagedFiles,
     secretEnv: (recipe.inputs?.secretEnv ?? []).map((name) => ({
       name,
       available: process.env[name] !== undefined,
@@ -1091,6 +1152,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
   const secretEnv = resolveSecretEnv(recipe.inputs?.secretEnv ?? [])
   let workspaceMounts: PreparedWorkspaceMount[] = []
   let extraPlugins: PreparedExtraPlugin[] = []
+  let stagedFiles: PreparedStagedFile[] = []
   let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
   const executions: ExecutionResult[] = []
   let artifacts: ArtifactBundle | undefined
@@ -1098,6 +1160,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
   try {
     workspaceMounts = await prepareRecipeWorkspaces(recipe, recipeDirectory)
     extraPlugins = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
+    stagedFiles = await prepareRecipeStagedFiles(recipe, recipeDirectory)
 
     runtime = await createRuntime(
       {
@@ -1113,7 +1176,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         artifactsDirectory: options.artifactsDirectory ?? recipe.artifacts?.directory,
         metadata: {
           ...runtimeMetadata(options.artifactsDirectory ?? recipe.artifacts?.directory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
-          ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, options.previewPublicUrl, options.previewPort, options.previewBind),
+          ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, stagedFiles, options.previewPublicUrl, options.previewPort, options.previewBind),
         },
         preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
       },
@@ -1154,6 +1217,16 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       })
     }
 
+    for (const stagedFile of stagedFiles) {
+      await runtime.mount({
+        type: stagedFile.type,
+        source: stagedFile.source,
+        target: stagedFile.target,
+        mode: "readwrite",
+        metadata: stagedFile.metadata,
+      })
+    }
+
     const siteSeeds = await importRecipeSiteSeeds(recipe, recipeDirectory, runtime, executions)
 
     const pluginActivationCode = activateExtraPluginsCode(extraPlugins)
@@ -1169,7 +1242,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
     await runtime.observe({ type: "mounts" })
     artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
     const runtimeInfo = options.previewHoldSeconds ? await runtime.info() : undefined
-    await releaseRuntime(runtime, options.previewHoldSeconds, () => cleanupRecipePreparedSources(workspaceMounts, extraPlugins))
+      await releaseRuntime(runtime, options.previewHoldSeconds, () => cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles))
 
     const benchResultsList = executions
       .filter((execution) => execution.command === "wordpress.bench" && execution.exitCode === 0)
@@ -1181,6 +1254,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       recipePath,
       runtime: runtimeInfo ?? await runtime.info(),
       executions,
+      stagedFiles: stagedFiles.map(recipeRunStagedFile),
       siteSeeds,
       ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
       ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
@@ -1201,7 +1275,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       }
     }
 
-    await cleanupRecipePreparedSources(workspaceMounts, extraPlugins)
+    await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles)
 
     return {
       success: false,
@@ -1233,6 +1307,7 @@ async function validateRecipe(options: RecipeValidateOptions): Promise<RecipeVal
         mounts: recipe.inputs?.mounts?.length ?? 0,
         workspaces: recipe.inputs?.workspaces?.length ?? 0,
         extraPlugins: recipeExtraPlugins(recipe).length,
+        stagedFiles: recipe.inputs?.stagedFiles?.length ?? 0,
       },
     }
   } catch (error) {
@@ -2338,6 +2413,25 @@ function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe 
     }
   }
 
+  const stagedFiles = recipe.inputs?.stagedFiles ?? []
+  if (!Array.isArray(stagedFiles)) {
+    throw new Error(`Recipe stagedFiles must be an array: ${recipePath}`)
+  }
+
+  for (const stagedFile of stagedFiles) {
+    if (!stagedFile || typeof stagedFile !== "object") {
+      throw new Error(`Recipe stagedFiles entries must be objects: ${recipePath}`)
+    }
+
+    if (!stagedFile.source || typeof stagedFile.source !== "string") {
+      throw new Error(`Recipe stagedFiles entries must include source: ${recipePath}`)
+    }
+
+    if (!stagedFile.target || typeof stagedFile.target !== "string") {
+      throw new Error(`Recipe stagedFiles entries must include target: ${recipePath}`)
+    }
+  }
+
   return recipe
 }
 
@@ -2425,6 +2519,12 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
 
   for (const [index, siteSeed] of (recipe.inputs?.siteSeeds ?? []).entries()) {
     await validateRecipeSiteSeed(siteSeed, recipeDirectory, `$.inputs.siteSeeds[${index}]`, addIssue)
+  }
+
+  for (const [index, stagedFile] of (recipe.inputs?.stagedFiles ?? []).entries()) {
+    const path = `$.inputs.stagedFiles[${index}]`
+    await validateExistingFileOrDirectory(resolve(recipeDirectory, stagedFile.source), `${path}.source`, addIssue)
+    validateAbsoluteSandboxPath(stagedFile.target, `${path}.target`, addIssue)
   }
 
   return issues
@@ -2578,6 +2678,17 @@ async function validateExistingFile(path: string, issuePath: string, addIssue: (
   }
 }
 
+async function validateExistingFileOrDirectory(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
+  try {
+    const result = await stat(path)
+    if (!result.isFile() && !result.isDirectory()) {
+      addIssue("unsupported-path", issuePath, `Expected file or directory: ${path}`)
+    }
+  } catch {
+    addIssue("missing-path", issuePath, `File or directory does not exist: ${path}`)
+  }
+}
+
 function validateAbsoluteSandboxPath(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): void {
   if (!path.startsWith("/")) {
     addIssue("invalid-sandbox-path", issuePath, `Sandbox paths must be absolute: ${path}`)
@@ -2692,7 +2803,7 @@ function runPolicy(command: string): RuntimePolicy {
   }
 }
 
-function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], previewPublicUrl: string | undefined, previewPort: number | undefined, previewBind: string | undefined): Record<string, unknown> {
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[], previewPublicUrl: string | undefined, previewPort: number | undefined, previewBind: string | undefined): Record<string, unknown> {
   const extraPluginMetadata = extraPlugins.map((plugin) => ({
     source: plugin.source,
     slug: plugin.slug,
@@ -2701,6 +2812,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
     provenance: plugin.provenance,
   }))
   const siteSeedProvenance = recipeDryRunSiteSeeds(recipe, dirname(recipePath))
+  const stagedFileProvenance = stagedFiles.map(recipeRunStagedFile)
 
   return {
     recipe: {
@@ -2717,6 +2829,8 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         extra_plugins: extraPluginMetadata,
         siteSeeds: recipe.inputs?.siteSeeds ?? [],
         siteSeedProvenance,
+        stagedFiles: recipe.inputs?.stagedFiles ?? [],
+        stagedFileProvenance,
         secretEnv: recipe.inputs?.secretEnv ?? [],
         inherit: recipe.inputs?.inherit ?? {},
         inheritance: recipe.inputs?.inheritance ?? {},
@@ -2738,6 +2852,8 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         extra_plugins: extraPluginMetadata,
         siteSeeds: recipe.inputs?.siteSeeds ?? [],
         siteSeedProvenance,
+        stagedFiles: recipe.inputs?.stagedFiles ?? [],
+        stagedFileProvenance,
         secretEnv: recipe.inputs?.secretEnv ?? [],
         inherit: recipe.inputs?.inherit ?? {},
         inheritance: recipe.inputs?.inheritance ?? {},
@@ -2747,6 +2863,13 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       target: workspace.target,
       mode: workspace.mode,
       metadata: workspace.metadata,
+    })),
+    preparedStagedFiles: stagedFiles.map((stagedFile) => ({
+      sourceRef: stagedFile.sourceRef,
+      target: stagedFile.target,
+      type: stagedFile.type,
+      provenance: stagedFile.provenance,
+      metadata: stagedFile.metadata,
     })),
   }
 }
@@ -2815,6 +2938,33 @@ function recipeDryRunSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string)
       secrets: "excluded-by-default",
     },
   }))
+}
+
+async function recipeDryRunStagedFiles(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<RecipeDryRunStagedFile[]> {
+  return Promise.all((recipe.inputs?.stagedFiles ?? []).map(async (stagedFile, index) => {
+    const source = resolve(recipeDirectory, stagedFile.source)
+    return {
+      index,
+      source,
+      sourceRef: stagedFile.source,
+      target: stagedFile.target,
+      type: await stagedFileMountType(source),
+      provenance: stagedFileProvenance(stagedFile, recipeDirectory),
+    }
+  }))
+}
+
+function recipeRunStagedFile(stagedFile: PreparedStagedFile): RecipeRunStagedFile {
+  const index = typeof stagedFile.metadata.index === "number" ? stagedFile.metadata.index : 0
+  return {
+    index,
+    source: stagedFile.originalSource,
+    sourceRef: stagedFile.sourceRef,
+    target: stagedFile.target,
+    type: stagedFile.type,
+    provenance: stagedFile.provenance,
+    action: "staged",
+  }
 }
 
 async function importRecipeSiteSeeds(recipe: WorkspaceRecipe, recipeDirectory: string, runtime: Runtime, executions: ExecutionResult[]): Promise<RecipeRunSiteSeed[]> {
@@ -3169,10 +3319,11 @@ async function cleanupRecipeWorkspaces(workspaces: PreparedWorkspaceMount[]): Pr
   await Promise.all(workspaces.flatMap((workspace) => workspace.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })))
 }
 
-async function cleanupRecipePreparedSources(workspaces: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[]): Promise<void> {
+async function cleanupRecipePreparedSources(workspaces: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[] = []): Promise<void> {
   await Promise.all([
     cleanupRecipeWorkspaces(workspaces),
     ...extraPlugins.flatMap((plugin) => plugin.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
+    ...stagedFiles.flatMap((stagedFile) => stagedFile.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
   ])
 }
 
@@ -3195,6 +3346,54 @@ async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeDirector
   }
 
   return plugins
+}
+
+async function prepareRecipeStagedFiles(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedStagedFile[]> {
+  const stagedFiles: PreparedStagedFile[] = []
+  for (const [index, stagedFile] of (recipe.inputs?.stagedFiles ?? []).entries()) {
+    const originalSource = resolve(recipeDirectory, stagedFile.source)
+    const type = await stagedFileMountType(originalSource)
+    const stagingRoot = await mkdtemp(join(tmpdir(), "wp-codebox-staged-file-"))
+    const stagedSource = join(stagingRoot, basename(originalSource))
+    await cp(originalSource, stagedSource, { recursive: type === "directory" })
+    const provenance = stagedFileProvenance(stagedFile, recipeDirectory)
+    stagedFiles.push({
+      source: stagedSource,
+      originalSource,
+      sourceRef: stagedFile.source,
+      target: stagedFile.target,
+      type,
+      cleanupPaths: [stagingRoot],
+      provenance,
+      metadata: {
+        kind: "staged-file",
+        index,
+        source: provenance,
+      },
+    })
+  }
+
+  return stagedFiles
+}
+
+async function stagedFileMountType(source: string): Promise<MountSpec["type"]> {
+  const result = await stat(source)
+  if (result.isDirectory()) {
+    return "directory"
+  }
+  if (result.isFile()) {
+    return "file"
+  }
+
+  throw new Error(`Recipe stagedFiles source must be a file or directory: ${source}`)
+}
+
+function stagedFileProvenance(stagedFile: WorkspaceRecipeStagedFile, recipeDirectory: string): RecipeStagedFileProvenance {
+  return {
+    kind: "local",
+    original: stagedFile.source,
+    localPathCategory: resolve(recipeDirectory, stagedFile.source).startsWith(recipeDirectory) ? "recipe-relative" : undefined,
+  }
 }
 
 async function assertPreparedPluginFileExists(sourceDirectory: string, pluginFileRelativeToSource: string, sourceRef: string): Promise<void> {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -23,6 +23,7 @@ interface RecipeRunOutputLike extends RunOutputLike {
     workspaces?: unknown[]
     extra_plugins?: unknown[]
     siteSeeds?: unknown[]
+    stagedFiles?: unknown[]
   }
   validation?: {
     issues?: Array<{ code: string; path: string; message: string }>
@@ -38,6 +39,7 @@ interface RecipeValidateOutputLike {
     mounts: number
     workspaces: number
     extraPlugins: number
+    stagedFiles?: number
   }
 }
 
@@ -161,6 +163,7 @@ export function printRecipeHumanOutput(output: RecipeRunOutputLike): void {
     console.log(`Workspaces: ${output.plan?.workspaces?.length ?? 0}`)
     console.log(`Extra plugins: ${output.plan?.extra_plugins?.length ?? 0}`)
     console.log(`Site seeds: ${output.plan?.siteSeeds?.length ?? 0}`)
+    console.log(`Staged files: ${output.plan?.stagedFiles?.length ?? 0}`)
     return
   }
 
@@ -182,6 +185,9 @@ export function printRecipeValidateHumanOutput(output: RecipeValidateOutputLike)
     console.log(`Mounts: ${output.summary.mounts}`)
     console.log(`Workspaces: ${output.summary.workspaces}`)
     console.log(`Extra plugins: ${output.summary.extraPlugins}`)
+    if (output.summary.stagedFiles !== undefined) {
+      console.log(`Staged files: ${output.summary.stagedFiles}`)
+    }
   }
 
   for (const issue of output.issues) {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -154,6 +154,11 @@ export interface WorkspaceRecipeMount {
   metadata?: Record<string, unknown>
 }
 
+export interface WorkspaceRecipeStagedFile {
+  source: string
+  target: string
+}
+
 export interface WorkspaceRecipeStep {
   command: string
   args?: string[]
@@ -253,6 +258,7 @@ export interface WorkspaceRecipe {
     extraPlugins?: WorkspaceRecipeExtraPlugin[]
     secretEnv?: string[]
     siteSeeds?: WorkspaceRecipeSiteSeed[]
+    stagedFiles?: WorkspaceRecipeStagedFile[]
     inherit?: WorkspaceRecipeInheritanceRequest
     inheritance?: WorkspaceRecipeInheritanceResolution
   }

--- a/scripts/recipe-staged-files-smoke.ts
+++ b/scripts/recipe-staged-files-smoke.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const workspace = resolve(root, "artifacts/recipe-staged-files-smoke")
+const recipePath = resolve(workspace, "recipe.json")
+const dryRunArtifacts = resolve(workspace, "dry-run-artifacts")
+const stagedFileSource = resolve(workspace, "source-file.txt")
+const stagedDirectorySource = resolve(workspace, "source-directory")
+
+mkdirSync(stagedDirectorySource, { recursive: true })
+writeFileSync(stagedFileSource, "staged file content\n")
+writeFileSync(resolve(stagedDirectorySource, "nested.txt"), "staged directory content\n")
+
+writeFileSync(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: {
+    backend: "wordpress-playground",
+    name: "recipe-staged-files-smoke",
+    wp: "7.0",
+    blueprint: { steps: [] },
+  },
+  inputs: {
+    stagedFiles: [
+      {
+        source: "./source-file.txt",
+        target: "/wordpress/wp-content/uploads/staged-file.txt",
+      },
+      {
+        source: "./source-directory",
+        target: "/wordpress/wp-content/uploads/staged-directory",
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: [
+          "code=$file = file_get_contents('/wordpress/wp-content/uploads/staged-file.txt'); $dir = file_get_contents('/wordpress/wp-content/uploads/staged-directory/nested.txt'); if ($file !== \"staged file content\\n\") { throw new RuntimeException('staged file missing'); } if ($dir !== \"staged directory content\\n\") { throw new RuntimeException('staged directory missing'); } echo wp_json_encode(array('file' => $file, 'directory' => $dir));",
+        ],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+const beforeDryRunFileContent = readFileSync(stagedFileSource, "utf8")
+const beforeDryRunDirectoryContent = readFileSync(resolve(stagedDirectorySource, "nested.txt"), "utf8")
+const dryRunResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--artifacts",
+  dryRunArtifacts,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(dryRunResult.status, 0, dryRunResult.stderr || dryRunResult.stdout)
+assert.equal(existsSync(dryRunArtifacts), false, "dry-run must not create artifact directories")
+assert.equal(readFileSync(stagedFileSource, "utf8"), beforeDryRunFileContent, "dry-run must not mutate staged file sources")
+assert.equal(readFileSync(resolve(stagedDirectorySource, "nested.txt"), "utf8"), beforeDryRunDirectoryContent, "dry-run must not mutate staged directory sources")
+
+const dryRunOutput = JSON.parse(dryRunResult.stdout)
+assert.equal(dryRunOutput.success, true)
+assert.equal(dryRunOutput.plan.stagedFiles.length, 2)
+assert.equal(dryRunOutput.plan.stagedFiles[0].source, stagedFileSource)
+assert.equal(dryRunOutput.plan.stagedFiles[0].target, "/wordpress/wp-content/uploads/staged-file.txt")
+assert.equal(dryRunOutput.plan.stagedFiles[0].type, "file")
+assert.equal(dryRunOutput.plan.stagedFiles[0].provenance.kind, "local")
+assert.equal(dryRunOutput.plan.stagedFiles[1].source, stagedDirectorySource)
+assert.equal(dryRunOutput.plan.stagedFiles[1].target, "/wordpress/wp-content/uploads/staged-directory")
+assert.equal(dryRunOutput.plan.stagedFiles[1].type, "directory")
+assert.equal(dryRunOutput.plan.mounts.some((mount: { target: string; planned: string }) => mount.target === "/wordpress/wp-content/uploads/staged-file.txt" && mount.planned === "generated"), true)
+
+const runResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--artifacts",
+  resolve(workspace, "artifacts"),
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(runResult.status, 0, runResult.stderr || runResult.stdout)
+const runOutput = JSON.parse(runResult.stdout)
+assert.equal(runOutput.success, true)
+assert.equal(runOutput.stagedFiles.length, 2)
+assert.equal(runOutput.stagedFiles[0].action, "staged")
+assert.equal(runOutput.stagedFiles[0].source, stagedFileSource)
+assert.equal(runOutput.stagedFiles[1].source, stagedDirectorySource)
+const workflowResult = JSON.parse(runOutput.executions[0].stdout)
+assert.equal(workflowResult.file, "staged file content\n")
+assert.equal(workflowResult.directory, "staged directory content\n")
+
+const metadata = JSON.parse(readFileSync(runOutput.artifacts.metadataPath, "utf8"))
+assert.equal(metadata.context.recipe.inputs.stagedFiles.length, 2)
+assert.equal(metadata.context.recipe.inputs.stagedFileProvenance[0].target, "/wordpress/wp-content/uploads/staged-file.txt")
+assert.equal(metadata.context.recipe.inputs.stagedFileProvenance[1].target, "/wordpress/wp-content/uploads/staged-directory")
+assert.equal(metadata.context.preparedStagedFiles[0].target, "/wordpress/wp-content/uploads/staged-file.txt")
+assert.equal(metadata.provenance.mounts.some((mount: { target: string; metadata?: { kind?: string } }) => mount.target === "/wordpress/wp-content/uploads/staged-file.txt" && mount.metadata?.kind === "staged-file"), true)
+
+console.log("recipe staged files smoke passed")


### PR DESCRIPTION
## Summary
- Add generic `inputs.stagedFiles` recipe declarations for local files/directories copied into absolute sandbox paths before workflow steps run.
- Report staged file provenance in dry-run plans and runtime artifact metadata.
- Add smoke coverage for staged file/directory visibility and dry-run non-mutation.

## Verification
- `npm run build`
- `npm run recipe-staged-files-smoke`
- `npm run recipe-dry-run-smoke`
- `npm run recipe-workflow-phases-smoke`
- `npm run recipe-site-seed-smoke`
- `npm run preview-port-smoke`
- `npm run preview-public-url-canonical-smoke`
- `npm run preview-response-body-smoke`
- `npm run boot-preview-smoke`
- `npm run blueprint-validation-smoke`
- `npm run browser-probe-artifact-smoke`
- `npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`

`npm run check` was attempted twice. It progressed through the recipe smoke section but exceeded the local tool timeout before completing, so the remaining checks were run individually.

Closes #159.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the staged-files recipe slice, smoke coverage, verification runs, and PR drafting for Chris to review.