### PR TITLE
Add Theme Check sandbox command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "external-adapter-contract-smoke": "tsx scripts/external-adapter-contract-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "core-phpunit-command-smoke": "tsx scripts/core-phpunit-command-smoke.ts",
+    "theme-check-normalization-smoke": "tsx scripts/theme-check-normalization-smoke.ts",
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
     "plugin-check-normalization-smoke": "tsx scripts/plugin-check-normalization-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
@@ -56,7 +57,7 @@
     "recipe-staged-files-smoke": "tsx scripts/recipe-staged-files-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -537,6 +537,16 @@ const commandCatalog: CommandMetadata[] = [
     recipe: true,
   },
   {
+    id: "wordpress.theme-check",
+    description: "Run Theme Check against a mounted WordPress theme inside the disposable Playground runtime.",
+    acceptedArgs: [
+      { name: "theme", description: "Theme slug under wp-content/themes.", required: true, format: "slug" },
+    ],
+    outputShape: "Normalized Theme Check JSON plus files/theme-check raw and normalized artifacts.",
+    policyRequirement: "Runtime policy commands must include wordpress.theme-check.",
+    recipe: true,
+  },
+  {
     id: "wordpress.browser-probe",
     description: "Open the live Playground preview in Playwright and capture browser console, page errors, and screenshot artifacts.",
     acceptedArgs: [

--- a/packages/runtime-playground/src/blueprint.ts
+++ b/packages/runtime-playground/src/blueprint.ts
@@ -17,8 +17,9 @@ export function normalizeBlueprint(blueprint: unknown): { extraLibraries?: unkno
 }
 
 export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpec["policy"], siteUrl?: string): unknown {
-  const needsWpCli = policy.commands.includes("wordpress.wp-cli") || policy.commands.includes("wordpress.plugin-check")
+  const needsWpCli = policy.commands.includes("wordpress.wp-cli") || policy.commands.includes("wordpress.plugin-check") || policy.commands.includes("wordpress.theme-check")
   const needsPluginCheck = policy.commands.includes("wordpress.plugin-check")
+  const needsThemeCheck = policy.commands.includes("wordpress.theme-check")
   if (!siteUrl && !needsWpCli && !needsPluginCheck) {
     return blueprint
   }
@@ -35,6 +36,11 @@ export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpe
       ...(needsPluginCheck ? [{
         step: "installPlugin",
         pluginData: { resource: "wordpress.org/plugins", slug: "plugin-check" },
+        options: { activate: true },
+      }] : []),
+      ...(needsThemeCheck ? [{
+        step: "installPlugin",
+        pluginData: { resource: "wordpress.org/plugins", slug: "theme-check" },
         options: { activate: true },
       }] : []),
       ...steps,

--- a/packages/runtime-playground/src/commands.ts
+++ b/packages/runtime-playground/src/commands.ts
@@ -238,6 +238,194 @@ function numberField(record: Record<string, unknown>, key: string): number | und
   return undefined
 }
 
+export interface ThemeCheckFinding {
+  type: string
+  severity: "error" | "warning" | "required" | "recommended" | "info" | "unknown"
+  message: string
+}
+
+export interface ThemeCheckNormalizedOutput {
+  schema: "wp-codebox/theme-check/v1"
+  command: "wordpress.theme-check"
+  targetTheme: string
+  status: "passed" | "failed" | "error"
+  exitCode: number
+  summary: {
+    total: number
+    errors: number
+    warnings: number
+    required: number
+    recommended: number
+    info: number
+    unknown: number
+  }
+  findings: ThemeCheckFinding[]
+  raw: {
+    format: "json" | "text"
+    parseError?: string
+  }
+}
+
+export function themeCheckRunCode(theme: string): string {
+  return `$theme_slug = ${JSON.stringify(theme)};
+$plugin_dir = WP_PLUGIN_DIR . '/theme-check';
+if (!file_exists($plugin_dir . '/theme-check.php')) {
+    throw new RuntimeException('Theme Check plugin is not installed in the sandbox.');
+}
+
+require_once $plugin_dir . '/checkbase.php';
+require_once $plugin_dir . '/main.php';
+
+$theme = wp_get_theme($theme_slug);
+if (!$theme->exists()) {
+    throw new RuntimeException("Theme '{$theme_slug}' not found.");
+}
+
+$success = run_themechecks_against_theme($theme, $theme_slug);
+$messages = array();
+global $themechecks;
+foreach ($themechecks as $check) {
+    if ($check instanceof themecheck) {
+        $error = (array) $check->getError();
+        if (!empty($error)) {
+            $messages = array_merge($messages, $error);
+        }
+    }
+}
+
+$processed = array_map(function ($message) {
+    if (preg_match('/<span[^>]*>(.*?)<\/span>(.*)/', $message, $matches)) {
+        $key = $matches[1];
+        $value = $matches[2];
+    } else {
+        $key = '';
+        $value = $message;
+    }
+
+    $key = wp_strip_all_tags($key);
+    $key = html_entity_decode($key, ENT_QUOTES, 'UTF-8');
+    $key = rtrim($key, ':');
+
+    $value = wp_strip_all_tags($value);
+    $value = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+    $value = ltrim($value, ': ');
+
+    return array(
+        'type' => trim($key),
+        'value' => trim($value),
+    );
+}, $messages);
+
+echo wp_json_encode(array(
+    'exitCode' => $success ? 0 : 1,
+    'findings' => $processed,
+), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
+}
+
+export function normalizeThemeCheckOutput(rawOutput: string, exitCode: number, targetTheme: string): ThemeCheckNormalizedOutput {
+  const trimmed = cleanWpCliOutput(rawOutput).trim()
+  const findings: ThemeCheckFinding[] = []
+  let format: ThemeCheckNormalizedOutput["raw"]["format"] = "json"
+  let parseError: string | undefined
+  let effectiveExitCode = exitCode
+
+  try {
+    const parsed = trimmed ? JSON.parse(extractJsonPayload(trimmed)) : []
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && typeof parsed.exitCode === "number") {
+      effectiveExitCode = parsed.exitCode
+    }
+    const rows = Array.isArray(parsed) ? parsed : Array.isArray(parsed?.findings) ? parsed.findings : undefined
+    if (!rows) {
+      throw new Error("Theme Check JSON output must be an array or an object with findings")
+    }
+
+    for (const item of rows) {
+      if (!item || typeof item !== "object") {
+        continue
+      }
+
+      const record = item as Record<string, unknown>
+      const rawType = typeof record.type === "string" ? record.type.trim() : ""
+      const rawMessage = typeof record.value === "string" ? record.value.trim() : ""
+      const prefixed = !rawType ? rawMessage.match(/^(ERROR|WARNING|REQUIRED|RECOMMENDED|INFO)\s*:?\s*(.*)$/i) : null
+      const type = prefixed?.[1] ?? rawType
+      const message = prefixed?.[2]?.trim() || rawMessage
+      if (!type && !message) {
+        continue
+      }
+
+      findings.push({
+        type,
+        severity: themeCheckSeverity(type),
+        message,
+      })
+    }
+  } catch (error) {
+    format = "text"
+    parseError = error instanceof Error ? error.message : String(error)
+    if (trimmed) {
+      findings.push({ type: "raw", severity: "unknown", message: trimmed })
+    }
+  }
+
+  const summary = {
+    total: findings.length,
+    errors: findings.filter((finding) => finding.severity === "error").length,
+    warnings: findings.filter((finding) => finding.severity === "warning").length,
+    required: findings.filter((finding) => finding.severity === "required").length,
+    recommended: findings.filter((finding) => finding.severity === "recommended").length,
+    info: findings.filter((finding) => finding.severity === "info").length,
+    unknown: findings.filter((finding) => finding.severity === "unknown").length,
+  }
+
+  return {
+    schema: "wp-codebox/theme-check/v1",
+    command: "wordpress.theme-check",
+    targetTheme,
+    status: format === "text" && effectiveExitCode !== 0 ? "error" : effectiveExitCode === 0 ? "passed" : "failed",
+    exitCode: effectiveExitCode,
+    summary,
+    findings,
+    raw: {
+      format,
+      ...(parseError ? { parseError } : {}),
+    },
+  }
+}
+
+function extractJsonPayload(output: string): string {
+  const firstObject = output.indexOf("{")
+  const firstArray = output.indexOf("[")
+  const starts = [firstObject, firstArray].filter((index) => index >= 0)
+  if (starts.length === 0) {
+    return output
+  }
+
+  const start = Math.min(...starts)
+  const end = output[start] === "[" ? output.lastIndexOf("]") : output.lastIndexOf("}")
+  return end > start ? output.slice(start, end + 1) : output.slice(start)
+}
+
+function themeCheckSeverity(type: string): ThemeCheckFinding["severity"] {
+  const normalized = type.trim().toLowerCase()
+  if (["error", "errors"].includes(normalized)) {
+    return "error"
+  }
+  if (["warning", "warnings"].includes(normalized)) {
+    return "warning"
+  }
+  if (["required", "requirement"].includes(normalized)) {
+    return "required"
+  }
+  if (["recommended", "recommendation"].includes(normalized)) {
+    return "recommended"
+  }
+  if (["info", "information", "notice"].includes(normalized)) {
+    return "info"
+  }
+
+  return "unknown"
+}
 export function phpunitRunCode(options: PhpunitRunCodeOptions): string {
   return `error_reporting(E_ALL);
 ini_set('display_errors', '1');

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -26,7 +26,7 @@ import {
   type MountDiffsResult,
 } from "./artifacts.js"
 import { playgroundBlueprint } from "./blueprint.js"
-import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, phpBody, phpunitRunCode, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
+import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, normalizeThemeCheckOutput, phpBody, phpunitRunCode, positiveIntegerArg, shellArgv, themeCheckRunCode, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
 import type {
   ArtifactBundle,
   ArtifactManifest,
@@ -182,6 +182,17 @@ interface BrowserProbeErrorRecord {
   timestamp: string
 }
 
+interface ThemeCheckArtifact {
+  theme: string
+  files: {
+    raw: string
+    normalized: string
+  }
+  summary: ReturnType<typeof normalizeThemeCheckOutput>["summary"]
+  status: ReturnType<typeof normalizeThemeCheckOutput>["status"]
+  exitCode: number
+}
+
 export class PlaygroundRuntimeBackend implements RuntimeBackend {
   readonly kind = "wordpress-playground" as const
 
@@ -200,6 +211,7 @@ class PlaygroundRuntime implements Runtime {
   private readonly events: LifecycleEvent[] = []
   private readonly browserProbes: BrowserProbeArtifact[] = []
   private readonly pluginChecks: PluginCheckArtifact[] = []
+  private readonly themeChecks: ThemeCheckArtifact[] = []
   private readonly artifactRoot: string
   private cliServerPromise?: Promise<PlaygroundCliServer>
 
@@ -361,6 +373,7 @@ class PlaygroundRuntime implements Runtime {
     const redactor = new ArtifactRedactor(this.spec.secretEnv)
     await this.redactBrowserArtifacts(redactor)
     await this.redactPluginCheckArtifacts(redactor)
+    await this.redactThemeCheckArtifacts(redactor)
     const preview = await this.previewInfo(createdAt, spec.previewHoldSeconds)
     const browser = this.browserReviewSummary()
 
@@ -419,6 +432,7 @@ class PlaygroundRuntime implements Runtime {
       mountDiffs: relative(this.artifactRoot, diffsPath),
       ...(browser ? { browser: "files/browser/summary.json" } : {}),
       ...(this.pluginChecks.length > 0 ? { pluginChecks: this.pluginChecks.map((check) => check.files.normalized) } : {}),
+      ...(this.themeChecks.length > 0 ? { themeChecks: this.themeChecks.map((check) => check.files.normalized) } : {}),
     }
     metadata.artifacts = artifactFiles
     const blueprintAfter = buildBlueprintAfter({
@@ -452,6 +466,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(reviewPath, "review", "application/json"),
       ...this.browserManifestFiles(),
       ...this.pluginCheckManifestFiles(),
+      ...this.themeCheckManifestFiles(),
       ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
         fileEntry(join(this.artifactRoot, file.artifactPath), "file", file.contentType),
@@ -786,6 +801,10 @@ class PlaygroundRuntime implements Runtime {
       return this.runCorePhpunit(spec)
     }
 
+    if (spec.command === "wordpress.theme-check") {
+      return this.runThemeCheck(spec)
+    }
+
     if (spec.command === "wordpress.browser-probe") {
       return this.runBrowserProbe(spec)
     }
@@ -981,6 +1000,32 @@ class PlaygroundRuntime implements Runtime {
     return `${JSON.stringify(normalized, null, 2)}\n`
   }
 
+  private async runThemeCheck(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const args = spec.args ?? []
+    const theme = argValue(args, "theme")?.trim()
+    if (!theme) {
+      throw new Error("wordpress.theme-check requires theme=<slug>")
+    }
+
+    if (!server.playground.writeFile) {
+      throw new Error("wordpress.theme-check requires a Playground backend with writeFile support")
+    }
+
+    if (!await this.themeCheckPluginInstalled(server)) {
+      const install = await this.runWpCliArgv(server, ["plugin", "install", "theme-check"])
+      assertPlaygroundResponseOk("wordpress.theme-check", install)
+    }
+
+    const response = await this.runPlaygroundCommand("wordpress.theme-check", server, { code: this.bootstrapPhpCode(themeCheckRunCode(theme), []) })
+    assertPlaygroundResponseOk("wordpress.theme-check", response)
+    const raw = cleanWpCliOutput(response.text)
+    const normalized = normalizeThemeCheckOutput(raw, response.exitCode ?? 0, theme)
+    await this.writeThemeCheckArtifacts(theme, raw, normalized)
+
+    return `${JSON.stringify(normalized, null, 2)}\n`
+  }
+
   private async runWpCliCommand(server: PlaygroundCliServer, argv: string[]): Promise<PlaygroundRunResponse> {
     if (!server.playground.writeFile) {
       throw new Error("WP-CLI commands require a Playground backend with writeFile support")
@@ -1091,6 +1136,44 @@ class PlaygroundRuntime implements Runtime {
     } catch {
       // The structured result is best-effort; preserve the command failure if copying fails.
     }
+  }
+
+  private async runWpCliArgv(server: PlaygroundCliServer, argv: string[]): Promise<PlaygroundRunResponse> {
+    if (!server.playground.writeFile) {
+      throw new Error("WP-CLI commands require a Playground backend with writeFile support")
+    }
+
+    const scriptPath = `/tmp/wp-codebox-wp-cli-${this.commands.length}-${Date.now().toString(36)}.php`
+    await server.playground.writeFile(scriptPath, wpCliPhpScript(argv))
+    return this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
+  }
+
+  private async themeCheckPluginInstalled(server: PlaygroundCliServer): Promise<boolean> {
+    const response = await this.runPlaygroundCommand("wordpress.theme-check", server, {
+      code: "<?php echo file_exists('/wordpress/wp-content/plugins/theme-check/theme-check.php') ? 'yes' : 'no';",
+    })
+
+    return response.text.trim() === "yes"
+  }
+
+  private async writeThemeCheckArtifacts(theme: string, raw: string, normalized: ReturnType<typeof normalizeThemeCheckOutput>): Promise<void> {
+    const safeTheme = theme.replace(/[^a-z0-9_-]/gi, "-") || "theme"
+    const directory = join(this.artifactRoot, "files", "theme-check")
+    await mkdir(directory, { recursive: true })
+    const rawPath = join(directory, `${safeTheme}.raw.txt`)
+    const normalizedPath = join(directory, `${safeTheme}.normalized.json`)
+    await writeFile(rawPath, raw.endsWith("\n") ? raw : `${raw}\n`)
+    await writeFile(normalizedPath, `${JSON.stringify(normalized, null, 2)}\n`)
+    this.themeChecks.push({
+      theme,
+      files: {
+        raw: relative(this.artifactRoot, rawPath),
+        normalized: relative(this.artifactRoot, normalizedPath),
+      },
+      summary: normalized.summary,
+      status: normalized.status,
+      exitCode: normalized.exitCode,
+    })
   }
 
   private hostPathForVfsPath(vfsPath: string): string | undefined {
@@ -1322,6 +1405,33 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
           await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
         } catch {
           // Plugin Check artifacts are generated before bundle collection; tolerate missing files.
+        }
+      }
+    }
+  }
+
+  private themeCheckManifestFiles(): ArtifactManifestFile[] {
+    if (this.themeChecks.length === 0) {
+      return []
+    }
+
+    const files = new Map<string, { kind: string; contentType: string }>()
+    for (const check of this.themeChecks) {
+      files.set(check.files.raw, { kind: "theme-check-raw", contentType: "text/plain" })
+      files.set(check.files.normalized, { kind: "theme-check-normalized", contentType: "application/json" })
+    }
+
+    return [...files.entries()].map(([path, entry]) => fileEntry(join(this.artifactRoot, path), entry.kind, entry.contentType))
+  }
+
+  private async redactThemeCheckArtifacts(redactor: ArtifactRedactor): Promise<void> {
+    for (const check of this.themeChecks) {
+      for (const path of [check.files.raw, check.files.normalized]) {
+        const absolutePath = join(this.artifactRoot, path)
+        try {
+          await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
+        } catch {
+          // Theme Check capture is best-effort; preserve artifact collection if a file vanished.
         }
       }
     }

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -36,6 +36,7 @@ const expectedCommandIds = [
   "wordpress.phpunit",
   "wordpress.plugin-check",
   "wordpress.core-phpunit",
+  "wordpress.theme-check",
   "wordpress.browser-probe",
   "wp-codebox.agent-runtime-probe",
   "wp-codebox.agent-sandbox-run",
@@ -66,6 +67,8 @@ async function main(): Promise<void> {
 
   const wpCli = catalog.commands.find((command) => command.id === "wordpress.wp-cli")
   assert(wpCli?.acceptedArgs.some((arg) => arg.name === "command" && arg.required), "wordpress.wp-cli must document required command arg")
+  const themeCheck = catalog.commands.find((command) => command.id === "wordpress.theme-check")
+  assert(themeCheck?.acceptedArgs.some((arg) => arg.name === "theme" && arg.required), "wordpress.theme-check must document required theme arg")
 
   const pluginCheck = catalog.commands.find((command) => command.id === "wordpress.plugin-check")
   assert(pluginCheck?.acceptedArgs.some((arg) => arg.name === "plugin-slug" && arg.required), "wordpress.plugin-check must document required plugin-slug arg")

--- a/scripts/theme-check-normalization-smoke.ts
+++ b/scripts/theme-check-normalization-smoke.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import { normalizeThemeCheckOutput } from "../packages/runtime-playground/src/commands.js"
+
+const raw = JSON.stringify([
+  { type: "REQUIRED", value: "Missing license." },
+  { type: "WARNING", value: "Found deprecated function." },
+  { type: "INFO", value: "This is informational." },
+])
+
+const normalized = normalizeThemeCheckOutput(raw, 1, "sample-theme")
+assert.equal(normalized.schema, "wp-codebox/theme-check/v1")
+assert.equal(normalized.command, "wordpress.theme-check")
+assert.equal(normalized.targetTheme, "sample-theme")
+assert.equal(normalized.status, "failed")
+assert.equal(normalized.exitCode, 1)
+assert.equal(normalized.summary.total, 3)
+assert.equal(normalized.summary.required, 1)
+assert.equal(normalized.summary.warnings, 1)
+assert.equal(normalized.summary.info, 1)
+assert.deepEqual(normalized.findings.map((finding) => finding.severity), ["required", "warning", "info"])
+
+const malformed = normalizeThemeCheckOutput("not json", 1, "broken-theme")
+assert.equal(malformed.status, "error")
+assert.equal(malformed.raw.format, "text")
+assert.equal(malformed.summary.unknown, 1)
+
+console.log("theme check normalization smoke passed")


### PR DESCRIPTION
## Summary
- Register `wordpress.theme-check` in the command catalog and recipe discovery path.
- Run Theme Check inside WordPress Playground against a mounted theme, normalizing results into `wp-codebox/theme-check/v1`.
- Capture raw and normalized Theme Check outputs in the artifact bundle manifest.
- Add targeted discovery and normalization smoke coverage.

Fixes #168.

## Testing
- `npm run build`
- `npm run discovery-command-smoke`
- `npm run theme-check-normalization-smoke`
- `npm run wp-codebox -- run --mount ./examples/recipes/cookbook/theme-block-editor-theme:/wordpress/wp-content/themes/theme-block-editor-theme --command wordpress.theme-check --arg theme=theme-block-editor-theme --artifacts ./artifacts/theme-check-smoke --json`
- `npm run check` progressed through `recipe-site-seed-smoke` before the local tool timeout; the remaining tail was rerun directly with a longer timeout:
- `npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, smoke coverage, validation commands, and PR description. Chris remains responsible for review and merge.