### PR TITLE
Add first-class WordPress Plugin Check command

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "core-phpunit-command-smoke": "tsx scripts/core-phpunit-command-smoke.ts",
     "phpunit-diagnostic-artifact-smoke": "tsx scripts/phpunit-diagnostic-artifact-smoke.ts",
+    "plugin-check-normalization-smoke": "tsx scripts/plugin-check-normalization-smoke.ts",
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
     "recipe-browser-smoke": "tsx scripts/recipe-browser-smoke.ts",
     "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",
@@ -55,7 +56,7 @@
     "recipe-staged-files-smoke": "tsx scripts/recipe-staged-files-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -509,6 +509,17 @@ const commandCatalog: CommandMetadata[] = [
     recipe: true,
   },
   {
+    id: "wordpress.plugin-check",
+    description: "Run the official WordPress Plugin Check plugin against a mounted plugin and emit normalized findings.",
+    acceptedArgs: [
+      { name: "plugin-slug", description: "Plugin slug under wp-content/plugins to validate.", required: true, format: "slug" },
+      { name: "checks", description: "Optional comma-separated official Plugin Check slugs to run; omit to run the default suite.", format: "comma-separated check slugs" },
+    ],
+    outputShape: "wp-codebox/plugin-check/v1 JSON with command, target plugin, exit code/status, summary counts, and findings; raw and normalized outputs are captured in artifacts.",
+    policyRequirement: "Runtime policy commands must include wordpress.plugin-check.",
+    recipe: true,
+  },
+  {
     id: "wordpress.core-phpunit",
     description: "Run WordPress core PHPUnit tests with normalized diagnostics and test-result artifact capture.",
     acceptedArgs: [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { createWriteStream } from "node:fs"
 import { createHash } from "node:crypto"
-import { execFile } from "node:child_process"
+import { execFile, spawnSync } from "node:child_process"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
 import { Readable } from "node:stream"
@@ -853,6 +853,11 @@ const secretEnvPolicy: RuntimePolicy = {
 async function main(args: string[]): Promise<number> {
   const command = args.shift()
 
+  const jspiRespawnExitCode = maybeRespawnWithJspi(command, args)
+  if (jspiRespawnExitCode !== undefined) {
+    return jspiRespawnExitCode
+  }
+
   if (!command || command === "help" || command === "--help" || command === "-h") {
     printHelp()
     return command ? 0 : 1
@@ -979,6 +984,57 @@ async function main(args: string[]): Promise<number> {
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
   printJsonFailureDiagnostic(output)
   return output.success ? 0 : 1
+}
+
+function maybeRespawnWithJspi(command: string | undefined, args: string[]): number | undefined {
+  if (!command || !["boot", "run", "recipe-run"].includes(command)) {
+    return undefined
+  }
+
+  if (!shouldRespawnWithJspi()) {
+    return undefined
+  }
+
+  const requiredFlags = ["--experimental-wasm-jspi", "--experimental-wasm-stack-switching"]
+  const missingFlags = requiredFlags.filter((flag) => !process.execArgv.includes(flag))
+  const child = spawnSync(process.execPath, [...missingFlags, ...process.execArgv, ...process.argv.slice(1, 2), command, ...args], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      WP_CODEBOX_JSPI_RESPAWNED: "1",
+    },
+  })
+
+  if (child.error) {
+    return undefined
+  }
+
+  if (child.signal) {
+    process.kill(process.pid, child.signal)
+    return 1
+  }
+
+  return child.status ?? 1
+}
+
+function shouldRespawnWithJspi(): boolean {
+  if (process.env.WP_CODEBOX_JSPI_RESPAWNED || process.env.WP_CODEBOX_NO_JSPI_RESPAWN || process.env.PLAYGROUND_NO_JSPI_RESPAWN) {
+    return false
+  }
+
+  if ("Suspending" in WebAssembly) {
+    return false
+  }
+
+  if (process.versions.bun || "Deno" in globalThis) {
+    return false
+  }
+
+  if (Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10) < 23) {
+    return false
+  }
+
+  return !["--experimental-wasm-jspi", "--experimental-wasm-stack-switching"].every((flag) => process.execArgv.includes(flag))
 }
 
 function parseDiscoveryJsonOption(args: string[]): boolean {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -241,7 +241,7 @@ Options:
   --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
-  --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.
+  --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.plugin-check, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.
   --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
   --blueprint <json|file>
                        WordPress Playground blueprint JSON or path for boot or validate-blueprint.

--- a/packages/runtime-playground/src/blueprint.ts
+++ b/packages/runtime-playground/src/blueprint.ts
@@ -17,7 +17,9 @@ export function normalizeBlueprint(blueprint: unknown): { extraLibraries?: unkno
 }
 
 export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpec["policy"], siteUrl?: string): unknown {
-  if (!siteUrl && !policy.commands.includes("wordpress.wp-cli")) {
+  const needsWpCli = policy.commands.includes("wordpress.wp-cli") || policy.commands.includes("wordpress.plugin-check")
+  const needsPluginCheck = policy.commands.includes("wordpress.plugin-check")
+  if (!siteUrl && !needsWpCli && !needsPluginCheck) {
     return blueprint
   }
 
@@ -27,8 +29,16 @@ export function playgroundBlueprint(blueprint: unknown, policy: RuntimeCreateSpe
 
   return {
     ...base,
-    ...(policy.commands.includes("wordpress.wp-cli") ? { extraLibraries: [...new Set([...extraLibraries, "wp-cli"])] } : {}),
-    ...(siteUrl ? { steps: [{ step: "defineSiteUrl", siteUrl }, ...steps] } : {}),
+    ...(needsWpCli ? { extraLibraries: [...new Set([...extraLibraries, "wp-cli"])] } : {}),
+    steps: [
+      ...(siteUrl ? [{ step: "defineSiteUrl", siteUrl }] : []),
+      ...(needsPluginCheck ? [{
+        step: "installPlugin",
+        pluginData: { resource: "wordpress.org/plugins", slug: "plugin-check" },
+        options: { activate: true },
+      }] : []),
+      ...steps,
+    ],
   }
 }
 

--- a/packages/runtime-playground/src/commands.ts
+++ b/packages/runtime-playground/src/commands.ts
@@ -75,6 +75,207 @@ export interface CorePhpunitRunCodeOptions {
   multisite: boolean
 }
 
+export interface PluginCheckFinding {
+  code?: string
+  type?: string
+  severity?: string
+  message?: string
+  file?: string
+  line?: number
+  column?: number
+  docs?: string
+  raw: Record<string, unknown>
+}
+
+export interface PluginCheckNormalizedOutput {
+  schema: "wp-codebox/plugin-check/v1"
+  command: "wordpress.plugin-check"
+  targetPlugin: string
+  exitCode: number
+  status: "passed" | "failed"
+  summary: {
+    total: number
+    errors: number
+    warnings: number
+    notices: number
+    info: number
+    unknown: number
+  }
+  findings: PluginCheckFinding[]
+  rawFormat: "json" | "text"
+}
+
+export function pluginCheckRunCode(pluginSlug: string, checkSlugs: string[] = []): string {
+  return `if ( ! function_exists( 'activate_plugin' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+
+$plugin_slug = ${JSON.stringify(pluginSlug)};
+$check_slugs = json_decode( ${JSON.stringify(JSON.stringify(checkSlugs))}, true );
+$plugin_check_file = WP_PLUGIN_DIR . '/plugin-check/plugin.php';
+if ( file_exists( $plugin_check_file ) && ! is_plugin_active( 'plugin-check/plugin.php' ) ) {
+    $activation = activate_plugin( 'plugin-check/plugin.php' );
+    if ( is_wp_error( $activation ) ) {
+        throw new RuntimeException( $activation->get_error_message() );
+    }
+}
+
+if ( ! class_exists( '\\WordPress\\Plugin_Check\\Checker\\CLI_Runner' ) ) {
+    throw new RuntimeException( 'The official Plugin Check plugin is not loaded in this Playground runtime.' );
+}
+
+$runner = new \\WordPress\\Plugin_Check\\Checker\\CLI_Runner();
+$runner->set_experimental_flag( false );
+$runner->set_check_slugs( is_array( $check_slugs ) ? $check_slugs : array() );
+$runner->set_categories( array() );
+$runner->set_plugin( $plugin_slug );
+$runner->set_slug( $plugin_slug );
+$runner->set_mode( 'new' );
+$result = $runner->run();
+$errors = $result ? $result->get_errors() : array();
+$warnings = $result ? $result->get_warnings() : array();
+
+echo wp_json_encode( array(
+    'schema' => 'wordpress/plugin-check/raw/v1',
+    'plugin' => $plugin_slug,
+    'errors' => $errors,
+    'warnings' => $warnings,
+), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );`
+}
+
+export function normalizePluginCheckOutput(rawOutput: string, exitCode: number, pluginSlug: string): PluginCheckNormalizedOutput {
+  const parsed = parsePluginCheckJson(rawOutput)
+  const findings = parsed ? collectPluginCheckFindings(parsed) : []
+  const summary = findings.reduce<PluginCheckNormalizedOutput["summary"]>((counts, finding) => {
+    counts.total++
+    const severity = pluginCheckSeverity(finding)
+    counts[severity]++
+    return counts
+  }, { total: 0, errors: 0, warnings: 0, notices: 0, info: 0, unknown: 0 })
+  const effectiveExitCode = exitCode === 0 && summary.errors > 0 ? 1 : exitCode
+
+  return {
+    schema: "wp-codebox/plugin-check/v1",
+    command: "wordpress.plugin-check",
+    targetPlugin: pluginSlug,
+    exitCode: effectiveExitCode,
+    status: effectiveExitCode === 0 && summary.errors === 0 ? "passed" : "failed",
+    summary,
+    findings,
+    rawFormat: parsed ? "json" : "text",
+  }
+}
+
+function parsePluginCheckJson(rawOutput: string): unknown | undefined {
+  const trimmed = rawOutput.trim()
+  if (!trimmed) {
+    return []
+  }
+
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    const firstJson = trimmed.match(/[\[{]/)
+    if (!firstJson) {
+      return undefined
+    }
+
+    try {
+      return JSON.parse(trimmed.slice(firstJson.index))
+    } catch {
+      return undefined
+    }
+  }
+}
+
+function collectPluginCheckFindings(value: unknown, inheritedFile = "", inheritedType = ""): PluginCheckFinding[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectPluginCheckFindings(item, inheritedFile, inheritedType))
+  }
+
+  if (!value || typeof value !== "object") {
+    return []
+  }
+
+  const record = value as Record<string, unknown>
+  if (looksLikePluginCheckFinding(record)) {
+    return [normalizePluginCheckFinding(record, inheritedFile, inheritedType)]
+  }
+
+  return Object.entries(record).flatMap(([key, child]) => collectPluginCheckFindings(
+    child,
+    looksLikePathKey(key) ? key : inheritedFile,
+    pluginCheckTypeKey(key) ?? inheritedType,
+  ))
+}
+
+function looksLikePluginCheckFinding(record: Record<string, unknown>): boolean {
+  return ["message", "code", "type", "severity"].some((key) => typeof record[key] === "string")
+}
+
+function looksLikePathKey(key: string): boolean {
+  return key.includes("/") || key.endsWith(".php") || key.endsWith(".js") || key.endsWith(".css")
+}
+
+function pluginCheckTypeKey(key: string): string | undefined {
+  if (key === "errors" || key === "warnings") {
+    return key.slice(0, -1)
+  }
+  return undefined
+}
+
+function normalizePluginCheckFinding(record: Record<string, unknown>, inheritedFile: string, inheritedType: string): PluginCheckFinding {
+  const file = stringField(record, "file") || stringField(record, "filename") || stringField(record, "path") || inheritedFile || undefined
+  const line = numberField(record, "line") ?? numberField(record, "line_number")
+  const column = numberField(record, "column") ?? numberField(record, "column_number")
+  const type = stringField(record, "type") || inheritedType
+
+  return {
+    ...(stringField(record, "code") ? { code: stringField(record, "code") } : {}),
+    ...(type ? { type } : {}),
+    ...(stringField(record, "severity") ? { severity: stringField(record, "severity") } : {}),
+    ...(stringField(record, "message") ? { message: stringField(record, "message") } : {}),
+    ...(file ? { file } : {}),
+    ...(typeof line === "number" ? { line } : {}),
+    ...(typeof column === "number" ? { column } : {}),
+    ...(stringField(record, "docs") || stringField(record, "documentation") ? { docs: stringField(record, "docs") || stringField(record, "documentation") } : {}),
+    raw: record,
+  }
+}
+
+function pluginCheckSeverity(finding: PluginCheckFinding): "errors" | "warnings" | "notices" | "info" | "unknown" {
+  const value = `${finding.severity ?? finding.type ?? finding.code ?? ""}`.toLowerCase()
+  if (value.includes("error")) {
+    return "errors"
+  }
+  if (value.includes("warning") || value.includes("warn")) {
+    return "warnings"
+  }
+  if (value.includes("notice")) {
+    return "notices"
+  }
+  if (value.includes("info")) {
+    return "info"
+  }
+  return "unknown"
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  return typeof record[key] === "string" && record[key].trim() !== "" ? record[key] : undefined
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key]
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
 export function phpunitRunCode(options: PhpunitRunCodeOptions): string {
   return `error_reporting(E_ALL);
 ini_set('display_errors', '1');

--- a/packages/runtime-playground/src/commands.ts
+++ b/packages/runtime-playground/src/commands.ts
@@ -105,44 +105,6 @@ export interface PluginCheckNormalizedOutput {
   rawFormat: "json" | "text"
 }
 
-export function pluginCheckRunCode(pluginSlug: string, checkSlugs: string[] = []): string {
-  return `if ( ! function_exists( 'activate_plugin' ) ) {
-    require_once ABSPATH . 'wp-admin/includes/plugin.php';
-}
-
-$plugin_slug = ${JSON.stringify(pluginSlug)};
-$check_slugs = json_decode( ${JSON.stringify(JSON.stringify(checkSlugs))}, true );
-$plugin_check_file = WP_PLUGIN_DIR . '/plugin-check/plugin.php';
-if ( file_exists( $plugin_check_file ) && ! is_plugin_active( 'plugin-check/plugin.php' ) ) {
-    $activation = activate_plugin( 'plugin-check/plugin.php' );
-    if ( is_wp_error( $activation ) ) {
-        throw new RuntimeException( $activation->get_error_message() );
-    }
-}
-
-if ( ! class_exists( '\\WordPress\\Plugin_Check\\Checker\\CLI_Runner' ) ) {
-    throw new RuntimeException( 'The official Plugin Check plugin is not loaded in this Playground runtime.' );
-}
-
-$runner = new \\WordPress\\Plugin_Check\\Checker\\CLI_Runner();
-$runner->set_experimental_flag( false );
-$runner->set_check_slugs( is_array( $check_slugs ) ? $check_slugs : array() );
-$runner->set_categories( array() );
-$runner->set_plugin( $plugin_slug );
-$runner->set_slug( $plugin_slug );
-$runner->set_mode( 'new' );
-$result = $runner->run();
-$errors = $result ? $result->get_errors() : array();
-$warnings = $result ? $result->get_warnings() : array();
-
-echo wp_json_encode( array(
-    'schema' => 'wordpress/plugin-check/raw/v1',
-    'plugin' => $plugin_slug,
-    'errors' => $errors,
-    'warnings' => $warnings,
-), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );`
-}
-
 export function normalizePluginCheckOutput(rawOutput: string, exitCode: number, pluginSlug: string): PluginCheckNormalizedOutput {
   const parsed = parsePluginCheckJson(rawOutput)
   const findings = parsed ? collectPluginCheckFindings(parsed) : []

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -26,7 +26,7 @@ import {
   type MountDiffsResult,
 } from "./artifacts.js"
 import { playgroundBlueprint } from "./blueprint.js"
-import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, phpBody, phpunitRunCode, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
+import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, phpBody, phpunitRunCode, pluginCheckRunCode, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
 import type {
   ArtifactBundle,
   ArtifactManifest,
@@ -158,6 +158,22 @@ interface BrowserProbeArtifact {
   }
 }
 
+interface PluginCheckArtifact {
+  targetPlugin: string
+  files: {
+    raw: string
+    normalized: string
+  }
+  summary: {
+    total: number
+    errors: number
+    warnings: number
+    notices: number
+    info: number
+    unknown: number
+  }
+}
+
 interface BrowserProbeErrorRecord {
   type: "pageerror" | "probe-error"
   name: string
@@ -183,6 +199,7 @@ class PlaygroundRuntime implements Runtime {
   private readonly observations: ObservationResult[] = []
   private readonly events: LifecycleEvent[] = []
   private readonly browserProbes: BrowserProbeArtifact[] = []
+  private readonly pluginChecks: PluginCheckArtifact[] = []
   private readonly artifactRoot: string
   private cliServerPromise?: Promise<PlaygroundCliServer>
 
@@ -343,6 +360,7 @@ class PlaygroundRuntime implements Runtime {
     const reviewPath = join(filesDirectory, "review.json")
     const redactor = new ArtifactRedactor(this.spec.secretEnv)
     await this.redactBrowserArtifacts(redactor)
+    await this.redactPluginCheckArtifacts(redactor)
     const preview = await this.previewInfo(createdAt, spec.previewHoldSeconds)
     const browser = this.browserReviewSummary()
 
@@ -400,6 +418,7 @@ class PlaygroundRuntime implements Runtime {
       review: relative(this.artifactRoot, reviewPath),
       mountDiffs: relative(this.artifactRoot, diffsPath),
       ...(browser ? { browser: "files/browser/summary.json" } : {}),
+      ...(this.pluginChecks.length > 0 ? { pluginChecks: this.pluginChecks.map((check) => check.files.normalized) } : {}),
     }
     metadata.artifacts = artifactFiles
     const blueprintAfter = buildBlueprintAfter({
@@ -432,6 +451,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(testResultsPath, "test-results", "application/json"),
       fileEntry(reviewPath, "review", "application/json"),
       ...this.browserManifestFiles(),
+      ...this.pluginCheckManifestFiles(),
       ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
         fileEntry(join(this.artifactRoot, file.artifactPath), "file", file.contentType),
@@ -758,6 +778,10 @@ class PlaygroundRuntime implements Runtime {
       return this.runPhpunit(spec)
     }
 
+    if (spec.command === "wordpress.plugin-check") {
+      return this.runPluginCheck(spec)
+    }
+
     if (spec.command === "wordpress.core-phpunit") {
       return this.runCorePhpunit(spec)
     }
@@ -902,6 +926,62 @@ class PlaygroundRuntime implements Runtime {
     assertPlaygroundResponseOk("wordpress.wp-cli", response)
 
     return cleanWpCliOutput(response.text)
+  }
+
+  private async runPluginCheck(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const args = spec.args ?? []
+    const pluginSlug = argValue(args, "plugin-slug")?.trim()
+    if (!pluginSlug) {
+      throw new Error("wordpress.plugin-check requires plugin-slug=<slug>")
+    }
+
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(pluginSlug)) {
+      throw new Error("wordpress.plugin-check plugin-slug must be a WordPress plugin slug")
+    }
+    const checkSlugs = commaListArg(args, "checks")
+
+    if (!server.playground.writeFile) {
+      throw new Error("wordpress.plugin-check requires a Playground backend with writeFile support")
+    }
+
+    const pluginPath = `/wordpress/wp-content/plugins/${pluginSlug}`
+    const existsResponse = await this.runWpCliCommand(server, ["plugin", "path", pluginSlug])
+    if (existsResponse.exitCode !== 0) {
+      throw new Error(`wordpress.plugin-check target plugin is not installed or mounted at ${pluginPath}`)
+    }
+
+    const rawResponse = await this.runPlaygroundCommand("wordpress.plugin-check", server, { code: this.bootstrapPhpCode(pluginCheckRunCode(pluginSlug, checkSlugs), []) })
+    assertPlaygroundResponseOk("wordpress.plugin-check", rawResponse)
+    const rawOutput = rawResponse.text
+    const normalized = normalizePluginCheckOutput(rawOutput, rawResponse.exitCode ?? 0, pluginSlug)
+    const pluginCheckDirectory = join(this.artifactRoot, "files", "plugin-check")
+    await mkdir(pluginCheckDirectory, { recursive: true })
+    const safeSlug = pluginSlug.replace(/[^a-z0-9_-]/gi, "-")
+    const rawPath = join(pluginCheckDirectory, `${safeSlug}.raw.json`)
+    const normalizedPath = join(pluginCheckDirectory, `${safeSlug}.json`)
+    await writeFile(rawPath, rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`)
+    await writeFile(normalizedPath, `${JSON.stringify(normalized, null, 2)}\n`)
+    this.pluginChecks.push({
+      targetPlugin: pluginSlug,
+      files: {
+        raw: relative(this.artifactRoot, rawPath),
+        normalized: relative(this.artifactRoot, normalizedPath),
+      },
+      summary: normalized.summary,
+    })
+
+    return `${JSON.stringify(normalized, null, 2)}\n`
+  }
+
+  private async runWpCliCommand(server: PlaygroundCliServer, argv: string[]): Promise<PlaygroundRunResponse> {
+    if (!server.playground.writeFile) {
+      throw new Error("WP-CLI commands require a Playground backend with writeFile support")
+    }
+
+    const scriptPath = `/tmp/wp-codebox-wp-cli-${this.commands.length}-${Date.now().toString(36)}.php`
+    await server.playground.writeFile(scriptPath, wpCliPhpScript(argv))
+    return this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
   }
 
   private async runAbility(spec: ExecutionSpec): Promise<string> {
@@ -1203,6 +1283,13 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     return [...files.entries()].map(([path, entry]) => fileEntry(join(this.artifactRoot, path), entry.kind, entry.contentType))
   }
 
+  private pluginCheckManifestFiles(): ArtifactManifestFile[] {
+    return this.pluginChecks.flatMap((check) => [
+      fileEntry(join(this.artifactRoot, check.files.raw), "plugin-check-raw", "application/json"),
+      fileEntry(join(this.artifactRoot, check.files.normalized), "plugin-check", "application/json"),
+    ])
+  }
+
   private async redactBrowserArtifacts(redactor: ArtifactRedactor): Promise<void> {
     for (const probe of this.browserProbes) {
       for (const path of [probe.files.console, probe.files.errors, probe.files.summary]) {
@@ -1215,6 +1302,19 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
           await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
         } catch {
           // Browser capture is best-effort; preserve artifact collection if a file vanished.
+        }
+      }
+    }
+  }
+
+  private async redactPluginCheckArtifacts(redactor: ArtifactRedactor): Promise<void> {
+    for (const check of this.pluginChecks) {
+      for (const path of [check.files.raw, check.files.normalized]) {
+        const absolutePath = join(this.artifactRoot, path)
+        try {
+          await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
+        } catch {
+          // Plugin Check artifacts are generated before bundle collection; tolerate missing files.
         }
       }
     }

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -26,7 +26,7 @@ import {
   type MountDiffsResult,
 } from "./artifacts.js"
 import { playgroundBlueprint } from "./blueprint.js"
-import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, phpBody, phpunitRunCode, pluginCheckRunCode, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
+import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, phpBody, phpunitRunCode, positiveIntegerArg, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
 import type {
   ArtifactBundle,
   ArtifactManifest,
@@ -951,9 +951,16 @@ class PlaygroundRuntime implements Runtime {
       throw new Error(`wordpress.plugin-check target plugin is not installed or mounted at ${pluginPath}`)
     }
 
-    const rawResponse = await this.runPlaygroundCommand("wordpress.plugin-check", server, { code: this.bootstrapPhpCode(pluginCheckRunCode(pluginSlug, checkSlugs), []) })
-    assertPlaygroundResponseOk("wordpress.plugin-check", rawResponse)
-    const rawOutput = rawResponse.text
+    const rawResponse = await this.runWpCliCommand(server, [
+      "plugin",
+      "check",
+      pluginSlug,
+      "--format=strict-json",
+      "--fields=file,line,column,type,code,message,docs",
+      "--mode=new",
+      ...(checkSlugs.length > 0 ? [`--checks=${checkSlugs.join(",")}`] : []),
+    ])
+    const rawOutput = cleanWpCliOutput(rawResponse.text)
     const normalized = normalizePluginCheckOutput(rawOutput, rawResponse.exitCode ?? 0, pluginSlug)
     const pluginCheckDirectory = join(this.artifactRoot, "files", "plugin-check")
     await mkdir(pluginCheckDirectory, { recursive: true })

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -34,6 +34,7 @@ const expectedCommandIds = [
   "wordpress.ability",
   "wordpress.bench",
   "wordpress.phpunit",
+  "wordpress.plugin-check",
   "wordpress.core-phpunit",
   "wordpress.browser-probe",
   "wp-codebox.agent-runtime-probe",
@@ -65,6 +66,9 @@ async function main(): Promise<void> {
 
   const wpCli = catalog.commands.find((command) => command.id === "wordpress.wp-cli")
   assert(wpCli?.acceptedArgs.some((arg) => arg.name === "command" && arg.required), "wordpress.wp-cli must document required command arg")
+
+  const pluginCheck = catalog.commands.find((command) => command.id === "wordpress.plugin-check")
+  assert(pluginCheck?.acceptedArgs.some((arg) => arg.name === "plugin-slug" && arg.required), "wordpress.plugin-check must document required plugin-slug arg")
 
   const schemaOutput = await cliJson<RecipeSchemaOutput>(["schema", "recipe", "--json"])
   assert(schemaOutput.schema === "wp-codebox/json-schema/v1", "Unexpected recipe schema envelope")

--- a/scripts/plugin-check-normalization-smoke.ts
+++ b/scripts/plugin-check-normalization-smoke.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { createRuntime } from "@chubes4/wp-codebox-core"
+import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
+import { normalizePluginCheckOutput } from "../packages/runtime-playground/src/commands.js"
+
+const raw = JSON.stringify({
+  errors: {
+    "simple-plugin/simple-plugin.php": [[{
+      code: "plugin_header_missing",
+      message: "Plugin header is missing.",
+      line: 1,
+      column: 1,
+      docs: "https://developer.wordpress.org/plugins/",
+    }]],
+  },
+  warnings: {
+    "simple-plugin/simple-plugin.php": [[{
+      code: "escaping_missing",
+      message: "Output should be escaped.",
+      line: "12",
+    }]],
+  },
+})
+
+const normalized = normalizePluginCheckOutput(raw, 1, "simple-plugin")
+assert.equal(normalized.schema, "wp-codebox/plugin-check/v1")
+assert.equal(normalized.command, "wordpress.plugin-check")
+assert.equal(normalized.targetPlugin, "simple-plugin")
+assert.equal(normalized.exitCode, 1)
+assert.equal(normalized.status, "failed")
+assert.deepEqual(normalized.summary, { total: 2, errors: 1, warnings: 1, notices: 0, info: 0, unknown: 0 })
+assert.equal(normalized.findings[0].file, "simple-plugin/simple-plugin.php")
+assert.equal(normalized.findings[0].type, "error")
+assert.equal(normalized.findings[0].line, 1)
+assert.equal(normalized.findings[1].type, "warning")
+assert.equal(normalized.findings[1].line, 12)
+
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-plugin-check-"))
+try {
+  const mountDirectory = resolve("examples/simple-plugin")
+  const runtime = await createRuntime(
+    {
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", name: "plugin-check-smoke", version: "7.0", blueprint: { steps: [] } },
+      policy: {
+        network: "deny",
+        filesystem: "readwrite-mounts",
+        commands: ["wordpress.plugin-check"],
+        secrets: "none",
+        approvals: "never",
+      },
+      artifactsDirectory,
+      metadata: { runtime: { version: "0.0.0" }, task: { kind: "plugin-check-smoke" } },
+    },
+    createPlaygroundRuntimeBackend(),
+  )
+
+  await runtime.mount({
+    type: "directory",
+    source: mountDirectory,
+    target: "/wordpress/wp-content/plugins/simple-plugin",
+    mode: "readwrite",
+    metadata: { kind: "component", slug: "simple-plugin" },
+  })
+  await assert.rejects(
+    () => runtime.execute({ command: "wordpress.plugin-check", args: [] }),
+    /requires plugin-slug=<slug>/,
+  )
+  const result = await runtime.execute({ command: "wordpress.plugin-check", args: ["plugin-slug=simple-plugin", "checks=plugin_header_fields"] })
+  const output = JSON.parse(result.stdout)
+  assert.equal(output.schema, "wp-codebox/plugin-check/v1")
+  assert.equal(output.status, "failed")
+  assert.equal(output.summary.errors, 1)
+  assert.equal(output.findings[0].code, "plugin_header_no_license")
+  const artifacts = await runtime.collectArtifacts({ includeLogs: true })
+  const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
+  assert.equal(manifest.files.some((file: { kind: string }) => file.kind === "plugin-check"), true)
+  await runtime.destroy()
+  console.log("Plugin Check normalization smoke passed")
+} finally {
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}

--- a/scripts/plugin-check-normalization-smoke.ts
+++ b/scripts/plugin-check-normalization-smoke.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
 import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
-import { createRuntime } from "@chubes4/wp-codebox-core"
-import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
+import { promisify } from "node:util"
 import { normalizePluginCheckOutput } from "../packages/runtime-playground/src/commands.js"
+
+const execFileAsync = promisify(execFile)
 
 const raw = JSON.stringify({
   errors: {
@@ -40,45 +42,31 @@ assert.equal(normalized.findings[1].line, 12)
 
 const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-plugin-check-"))
 try {
-  const mountDirectory = resolve("examples/simple-plugin")
-  const runtime = await createRuntime(
-    {
-      backend: "wordpress-playground",
-      environment: { kind: "wordpress", name: "plugin-check-smoke", version: "7.0", blueprint: { steps: [] } },
-      policy: {
-        network: "deny",
-        filesystem: "readwrite-mounts",
-        commands: ["wordpress.plugin-check"],
-        secrets: "none",
-        approvals: "never",
-      },
-      artifactsDirectory,
-      metadata: { runtime: { version: "0.0.0" }, task: { kind: "plugin-check-smoke" } },
-    },
-    createPlaygroundRuntimeBackend(),
-  )
-
-  await runtime.mount({
-    type: "directory",
-    source: mountDirectory,
-    target: "/wordpress/wp-content/plugins/simple-plugin",
-    mode: "readwrite",
-    metadata: { kind: "component", slug: "simple-plugin" },
-  })
-  await assert.rejects(
-    () => runtime.execute({ command: "wordpress.plugin-check", args: [] }),
-    /requires plugin-slug=<slug>/,
-  )
-  const result = await runtime.execute({ command: "wordpress.plugin-check", args: ["plugin-slug=simple-plugin", "checks=plugin_header_fields"] })
-  const output = JSON.parse(result.stdout)
+  const cliPath = resolve("packages/cli/dist/index.js")
+  const { stdout } = await execFileAsync(process.execPath, [
+    cliPath,
+    "run",
+    "--mount",
+    "./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin",
+    "--command",
+    "wordpress.plugin-check",
+    "--arg",
+    "plugin-slug=simple-plugin",
+    "--arg",
+    "checks=plugin_header_fields",
+    "--artifacts",
+    artifactsDirectory,
+    "--json",
+  ], { cwd: resolve("."), maxBuffer: 10 * 1024 * 1024 })
+  const runOutput = JSON.parse(stdout)
+  assert.equal(runOutput.success, true)
+  const output = JSON.parse(runOutput.execution.stdout)
   assert.equal(output.schema, "wp-codebox/plugin-check/v1")
   assert.equal(output.status, "failed")
   assert.equal(output.summary.errors, 1)
   assert.equal(output.findings[0].code, "plugin_header_no_license")
-  const artifacts = await runtime.collectArtifacts({ includeLogs: true })
-  const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
+  const manifest = JSON.parse(await readFile(runOutput.artifacts.manifestPath, "utf8"))
   assert.equal(manifest.files.some((file: { kind: string }) => file.kind === "plugin-check"), true)
-  await runtime.destroy()
   console.log("Plugin Check normalization smoke passed")
 } finally {
   await rm(artifactsDirectory, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Add `wordpress.plugin-check` as a first-class WP Codebox command backed by the official WordPress Plugin Check plugin.
- Run Plugin Check through the official `wp plugin check` WP-CLI command instead of calling Plugin Check internals directly.
- Respawn WP Codebox runtime commands under Node's JSPI flags on Node 23+ so Playground avoids the Asyncify `RuntimeError: unreachable` crash triggered by PHPCS/`proc_open()`.
- Normalize Plugin Check findings and capture raw/normalized Plugin Check artifacts.

Fixes #167.

## Root cause
`wp plugin check` can install and register inside Playground, but the actual check crashes under Playground's Asyncify PHP-WASM build because Plugin Check invokes PHPCS and PHPCS uses `proc_open()`. WP Codebox imports `@wp-playground/cli` programmatically, which bypassed the Playground CLI entrypoint's JSPI respawn behavior.

Relevant upstream trackers:
- https://github.com/WordPress/wordpress-playground/pull/3407
- https://github.com/WordPress/wordpress-playground/issues/1872

## Verification
- `npm run build`
- `npm run discovery-command-smoke`
- `npm run plugin-check-normalization-smoke`
- `npm run check`
- Manual targeted run: `npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.plugin-check --arg plugin-slug=simple-plugin --arg checks=plugin_header_fields --artifacts ./artifacts/plugin-check-command-probe --json`
- Manual full run: `npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.plugin-check --arg plugin-slug=simple-plugin --artifacts ./artifacts/plugin-check-full-command-probe --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the Playground/Plugin Check crash, implemented the JSPI respawn and official WP-CLI Plugin Check path, added smoke coverage, and ran verification. Chris remains responsible for review and merge.
