### PR TITLE
Add workspace policy checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
+    "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
     "external-adapter-contract-smoke": "tsx scripts/external-adapter-contract-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
@@ -57,7 +58,7 @@
     "recipe-staged-files-smoke": "tsx scripts/recipe-staged-files-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run workspace-policy-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ import { basename, dirname, join, resolve } from "node:path"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import { promisify } from "node:util"
-import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, checkWorkspacePolicy, createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
 import { captureStdout, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
@@ -127,6 +127,14 @@ interface RecipeRunOptions {
 
 interface RecipeValidateOptions {
   recipePath: string
+  json: boolean
+}
+
+interface WorkspacePolicyOptions {
+  workspaceRoot: string
+  writableRoots: string[]
+  hiddenPaths: string[]
+  gitBacked: boolean
   json: boolean
 }
 
@@ -943,6 +951,30 @@ async function main(args: string[]): Promise<number> {
     return output.success ? 0 : 1
   }
 
+  if (command === "workspace-policy") {
+    const subcommand = args.shift()
+    if (subcommand !== "check") {
+      console.error(`Unknown workspace-policy command: ${subcommand ?? ""}`)
+      printHelp()
+      return 1
+    }
+
+    const options = parseWorkspacePolicyOptions(args)
+    const output = await checkWorkspacePolicy({
+      workspaceRoot: options.workspaceRoot,
+      writableRoots: options.writableRoots,
+      hiddenPaths: options.hiddenPaths,
+      gitBacked: options.gitBacked,
+    })
+    if (!options.json) {
+      printWorkspacePolicyHumanOutput(output)
+      return output.passed ? 0 : 1
+    }
+
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    return output.passed ? 0 : 1
+  }
+
   if (command === "commands") {
     const json = parseDiscoveryJsonOption(args)
     const output = commandCatalogOutput()
@@ -1059,6 +1091,74 @@ function parseDiscoveryJsonOption(args: string[]): boolean {
   }
 
   return json
+}
+
+function parseWorkspacePolicyOptions(args: string[]): WorkspacePolicyOptions {
+  const options: WorkspacePolicyOptions = {
+    workspaceRoot: process.cwd(),
+    writableRoots: [],
+    hiddenPaths: [],
+    gitBacked: false,
+    json: false,
+  }
+
+  while (args.length > 0) {
+    const arg = args.shift()
+    if (!arg) {
+      continue
+    }
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+    if (arg === "--git") {
+      options.gitBacked = true
+      continue
+    }
+
+    const value = args.shift()
+    if (!value) {
+      throw new Error(`Missing value for ${arg}`)
+    }
+
+    switch (arg) {
+      case "--workspace":
+      case "--workspace-root":
+        options.workspaceRoot = resolve(value)
+        break
+      case "--writable-root":
+      case "--writable":
+        options.writableRoots.push(value)
+        break
+      case "--hidden-path":
+      case "--hidden":
+        options.hiddenPaths.push(value)
+        break
+      default:
+        throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+
+  if (options.writableRoots.length === 0) {
+    throw new Error("At least one --writable-root is required")
+  }
+
+  return options
+}
+
+function printWorkspacePolicyHumanOutput(output: WorkspacePolicyResult): void {
+  console.log(output.passed ? "Workspace policy passed" : "Workspace policy failed")
+  console.log(`Policy: ${output.policy_sha256}`)
+  if (output.violations.length === 0) {
+    return
+  }
+
+  console.log("Violations:")
+  for (const violation of output.violations) {
+    console.log(`- ${violation.code}: ${violation.path}`)
+    console.log(`  ${violation.message}`)
+  }
 }
 
 function commandCatalogOutput(): CommandCatalogOutput {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -231,6 +231,7 @@ export function printHelp(): void {
   console.log(`Usage:
   wp-codebox commands [--json]
   wp-codebox schema recipe [--json]
+  wp-codebox workspace-policy check --workspace-root <path> --writable-root <path> [options]
   wp-codebox recipe validate --recipe <path> [--json]
   wp-codebox validate-blueprint --blueprint <json|file> [options]
   wp-codebox recipe-run --recipe <path> [options]
@@ -258,6 +259,14 @@ Options:
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --dry-run            Validate recipe-run and emit a resolved JSON plan without booting Playground or writing temp workspaces.
   --json               Emit machine-readable JSON.
+
+Workspace policy:
+  --workspace-root <dir>
+                       Workspace root to inspect. Defaults to the current directory.
+  --writable-root <path>
+                       Relative path that may be changed. Repeatable.
+  --hidden-path <path> Relative path that must not be changed or exposed. Repeatable.
+  --git                Use git status metadata, including ignored and unmerged entries.
 
 Discovery:
   commands             Print supported runtime and recipe command metadata.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./workspace-policy.js"
+
 export type RuntimeBackendKind = "wordpress-playground" | (string & {})
 
 export const SANDBOX_WORKSPACE_ROOT = "/workspace"

--- a/packages/runtime-core/src/workspace-policy.ts
+++ b/packages/runtime-core/src/workspace-policy.ts
@@ -1,0 +1,285 @@
+import { createHash } from "node:crypto"
+import { execFile } from "node:child_process"
+import { lstat, readdir, realpath } from "node:fs/promises"
+import { isAbsolute, normalize, relative, resolve, sep } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+export type WorkspacePolicyViolationCode =
+  | "invalid-policy-path"
+  | "path-outside-workspace"
+  | "path-outside-writable-roots"
+  | "hidden-path"
+  | "symlink"
+  | "hardlink"
+  | "gitlink"
+  | "nested-git-metadata"
+  | "ignored-path"
+  | "special-file"
+  | "unmerged-index"
+
+export interface WorkspacePolicyViolation {
+  code: WorkspacePolicyViolationCode
+  path: string
+  message: string
+  details?: Record<string, unknown>
+}
+
+export interface WorkspacePolicyCheckOptions {
+  workspaceRoot: string
+  writableRoots: string[]
+  hiddenPaths?: string[]
+  gitBacked?: boolean
+}
+
+export interface WorkspacePolicyResult {
+  schema: "wp-codebox/workspace-policy-result/v1"
+  passed: boolean
+  policy_sha256: string
+  violations: WorkspacePolicyViolation[]
+}
+
+interface NormalizedWorkspacePolicy {
+  workspaceRoot: string
+  writableRoots: string[]
+  hiddenPaths: string[]
+  gitBacked: boolean
+}
+
+interface GitStatusEntry {
+  status: string
+  path: string
+}
+
+export async function checkWorkspacePolicy(options: WorkspacePolicyCheckOptions): Promise<WorkspacePolicyResult> {
+  const workspaceRoot = resolve(options.workspaceRoot)
+  const policy: NormalizedWorkspacePolicy = {
+    workspaceRoot,
+    writableRoots: options.writableRoots.map(normalizePolicyPath),
+    hiddenPaths: (options.hiddenPaths ?? []).map(normalizePolicyPath),
+    gitBacked: options.gitBacked ?? false,
+  }
+  const violations: WorkspacePolicyViolation[] = []
+
+  for (const [kind, paths] of [
+    ["writable root", policy.writableRoots],
+    ["hidden path", policy.hiddenPaths],
+  ] as const) {
+    for (const path of paths) {
+      if (!path || path === "." || isAbsolute(path) || path === ".." || path.startsWith(`..${sep}`)) {
+        violations.push({
+          code: "invalid-policy-path",
+          path,
+          message: `Invalid ${kind}: ${path || "<empty>"}`,
+        })
+      }
+    }
+  }
+
+  const paths = new Set<string>()
+  if (policy.gitBacked) {
+    const gitEntries = await readGitStatusEntries(workspaceRoot)
+    for (const entry of gitEntries) {
+      paths.add(entry.path)
+      if (entry.status === "!!") {
+        violations.push({ code: "ignored-path", path: entry.path, message: `Ignored path is present in git-backed workspace: ${entry.path}` })
+      }
+      if (isUnmergedStatus(entry.status)) {
+        violations.push({ code: "unmerged-index", path: entry.path, message: `Unmerged index entry: ${entry.path}`, details: { status: entry.status } })
+      }
+    }
+    for (const path of await readGitlinkPaths(workspaceRoot)) {
+      paths.add(path)
+      violations.push({ code: "gitlink", path, message: `Gitlink/submodule entry is not allowed: ${path}` })
+    }
+    for (const path of await readUnmergedIndexPaths(workspaceRoot)) {
+      paths.add(path)
+      violations.push({ code: "unmerged-index", path, message: `Unmerged index entry: ${path}` })
+    }
+  } else {
+    for (const path of await listWorkspacePaths(workspaceRoot)) {
+      paths.add(path)
+    }
+  }
+
+  for (const path of paths) {
+    violations.push(...(await checkWorkspacePath(policy, path)))
+  }
+
+  return {
+    schema: "wp-codebox/workspace-policy-result/v1",
+    passed: violations.length === 0,
+    policy_sha256: workspacePolicySha256(policy),
+    violations: sortViolations(dedupeViolations(violations)),
+  }
+}
+
+export function workspacePolicySha256(policy: WorkspacePolicyCheckOptions | NormalizedWorkspacePolicy): string {
+  const normalized = {
+    workspaceRoot: resolve(policy.workspaceRoot),
+    writableRoots: [...policy.writableRoots].map(normalizePolicyPath).sort(),
+    hiddenPaths: [...(policy.hiddenPaths ?? [])].map(normalizePolicyPath).sort(),
+    gitBacked: policy.gitBacked ?? false,
+  }
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex")
+}
+
+async function checkWorkspacePath(policy: NormalizedWorkspacePolicy, path: string): Promise<WorkspacePolicyViolation[]> {
+  const violations: WorkspacePolicyViolation[] = []
+  const normalizedPath = normalizePolicyPath(path)
+  const absolutePath = resolve(policy.workspaceRoot, normalizedPath)
+  const relativePath = relative(policy.workspaceRoot, absolutePath)
+
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    return [{ code: "path-outside-workspace", path, message: `Path escapes workspace root: ${path}` }]
+  }
+
+  if (!isPathUnderAny(normalizedPath, policy.writableRoots)) {
+    violations.push({ code: "path-outside-writable-roots", path: normalizedPath, message: `Path is outside writable roots: ${normalizedPath}` })
+  }
+
+  if (isPathUnderAny(normalizedPath, policy.hiddenPaths)) {
+    violations.push({ code: "hidden-path", path: normalizedPath, message: `Path is under a hidden policy path: ${normalizedPath}` })
+  }
+
+  if (hasNestedGitMetadata(normalizedPath)) {
+    violations.push({ code: "nested-git-metadata", path: normalizedPath, message: `Nested .git metadata is not allowed: ${normalizedPath}` })
+  }
+
+  let stat
+  try {
+    stat = await lstat(absolutePath)
+  } catch {
+    return violations
+  }
+
+  if (stat.isSymbolicLink()) {
+    violations.push({ code: "symlink", path: normalizedPath, message: `Symlink is not allowed: ${normalizedPath}` })
+    return violations
+  }
+
+  if (stat.isFile() && stat.nlink > 1) {
+    violations.push({ code: "hardlink", path: normalizedPath, message: `Hardlink is not allowed: ${normalizedPath}`, details: { links: stat.nlink } })
+  }
+
+  if (!stat.isFile() && !stat.isDirectory()) {
+    violations.push({ code: "special-file", path: normalizedPath, message: `Special file is not allowed: ${normalizedPath}` })
+  }
+
+  if (stat.isDirectory()) {
+    try {
+      const entryRealpath = await realpath(absolutePath)
+      const rootRealpath = await realpath(policy.workspaceRoot)
+      const realRelative = relative(rootRealpath, entryRealpath)
+      if (realRelative === ".." || realRelative.startsWith(`..${sep}`) || isAbsolute(realRelative)) {
+        violations.push({ code: "path-outside-workspace", path: normalizedPath, message: `Path resolves outside workspace root: ${normalizedPath}` })
+      }
+    } catch {
+      // lstat already proved the entry exists; realpath can fail on broken trees.
+    }
+  }
+
+  return violations
+}
+
+async function listWorkspacePaths(workspaceRoot: string): Promise<string[]> {
+  const paths: string[] = []
+  const queue = [""]
+  while (queue.length > 0) {
+    const current = queue.shift() ?? ""
+    const absolute = current ? resolve(workspaceRoot, current) : workspaceRoot
+    const entries = await readdir(absolute, { withFileTypes: true })
+    for (const entry of entries) {
+      const relativePath = normalizePolicyPath(current ? `${current}/${entry.name}` : entry.name)
+      paths.push(relativePath)
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        queue.push(relativePath)
+      }
+    }
+  }
+  return paths
+}
+
+async function readGitStatusEntries(workspaceRoot: string): Promise<GitStatusEntry[]> {
+  const { stdout } = await execFileAsync("git", ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored"], {
+    cwd: workspaceRoot,
+    encoding: "buffer",
+    maxBuffer: 1024 * 1024 * 20,
+  })
+  const tokens = stdout.toString("utf8").split("\0").filter(Boolean)
+  const entries: GitStatusEntry[] = []
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]
+    const status = token.slice(0, 2)
+    const path = normalizePolicyPath(token.slice(3))
+    entries.push({ status, path })
+    if (status.includes("R") || status.includes("C")) {
+      index++
+      if (tokens[index]) {
+        entries.push({ status, path: normalizePolicyPath(tokens[index]) })
+      }
+    }
+  }
+  return entries
+}
+
+async function readGitlinkPaths(workspaceRoot: string): Promise<string[]> {
+  const { stdout } = await execFileAsync("git", ["ls-files", "-s", "-z"], {
+    cwd: workspaceRoot,
+    encoding: "buffer",
+    maxBuffer: 1024 * 1024 * 20,
+  })
+  return stdout
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .filter((entry) => entry.startsWith("160000 "))
+    .map((entry) => normalizePolicyPath(entry.slice(entry.indexOf("\t") + 1)))
+}
+
+async function readUnmergedIndexPaths(workspaceRoot: string): Promise<string[]> {
+  const { stdout } = await execFileAsync("git", ["ls-files", "-u", "-z"], {
+    cwd: workspaceRoot,
+    encoding: "buffer",
+    maxBuffer: 1024 * 1024 * 20,
+  })
+  return stdout
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .map((entry) => normalizePolicyPath(entry.slice(entry.indexOf("\t") + 1)))
+}
+
+function normalizePolicyPath(path: string): string {
+  return normalize(path.replaceAll("\\", "/")).replaceAll("\\", "/").replace(/^\.\//, "")
+}
+
+function isPathUnderAny(path: string, roots: string[]): boolean {
+  return roots.some((root) => path === root || path.startsWith(`${root}/`))
+}
+
+function hasNestedGitMetadata(path: string): boolean {
+  const parts = path.split("/")
+  return parts.includes(".git")
+}
+
+function isUnmergedStatus(status: string): boolean {
+  return ["DD", "AU", "UD", "UA", "DU", "AA", "UU"].includes(status)
+}
+
+function dedupeViolations(violations: WorkspacePolicyViolation[]): WorkspacePolicyViolation[] {
+  const seen = new Set<string>()
+  return violations.filter((violation) => {
+    const key = `${violation.code}\0${violation.path}\0${violation.message}`
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+}
+
+function sortViolations(violations: WorkspacePolicyViolation[]): WorkspacePolicyViolation[] {
+  return violations.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code))
+}

--- a/scripts/workspace-policy-smoke.ts
+++ b/scripts/workspace-policy-smoke.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict"
+import { execFile, spawnSync } from "node:child_process"
+import { link, mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+import { checkWorkspacePolicy } from "@chubes4/wp-codebox-core"
+
+const execFileAsync = promisify(execFile)
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-workspace-policy-"))
+await mkdir(join(root, "src"), { recursive: true })
+await writeFile(join(root, "src", "index.js"), "export const ok = true\n")
+
+const passing = await checkWorkspacePolicy({
+  workspaceRoot: root,
+  writableRoots: ["src/../src"],
+  hiddenPaths: ["private"],
+})
+assert.equal(passing.passed, true)
+assert.equal(passing.schema, "wp-codebox/workspace-policy-result/v1")
+assert.match(passing.policy_sha256, /^[a-f0-9]{64}$/)
+
+await mkdir(join(root, "private"), { recursive: true })
+await writeFile(join(root, "private", "secret.txt"), "secret\n")
+await symlink("../private/secret.txt", join(root, "src", "secret-link"))
+await writeFile(join(root, "src", "hardlink-source.txt"), "linked\n")
+await link(join(root, "src", "hardlink-source.txt"), join(root, "src", "hardlink-copy.txt"))
+await mkdir(join(root, "src", "nested", ".git"), { recursive: true })
+await writeFile(join(root, "src", "nested", ".git", "config"), "[core]\n")
+await execFileAsync("mkfifo", [join(root, "src", "pipe")])
+
+const failing = await checkWorkspacePolicy({
+  workspaceRoot: root,
+  writableRoots: ["src"],
+  hiddenPaths: ["private"],
+})
+const violationCodes = new Set(failing.violations.map((violation) => violation.code))
+assert.equal(failing.passed, false)
+assert.ok(violationCodes.has("path-outside-writable-roots"))
+assert.ok(violationCodes.has("hidden-path"))
+assert.ok(violationCodes.has("symlink"))
+assert.ok(violationCodes.has("hardlink"))
+assert.ok(violationCodes.has("nested-git-metadata"))
+assert.ok(violationCodes.has("special-file"))
+
+const invalidPolicy = await checkWorkspacePolicy({
+  workspaceRoot: root,
+  writableRoots: ["../outside"],
+})
+assert.equal(invalidPolicy.passed, false)
+assert.ok(invalidPolicy.violations.some((violation) => violation.code === "invalid-policy-path"))
+
+const gitRoot = await mkdtemp(join(tmpdir(), "wp-codebox-workspace-policy-git-"))
+await execFileAsync("git", ["init"], { cwd: gitRoot })
+await mkdir(join(gitRoot, "src"), { recursive: true })
+await writeFile(join(gitRoot, ".gitignore"), "src/ignored.txt\n")
+await writeFile(join(gitRoot, "src", "ignored.txt"), "ignored\n")
+await execFileAsync("git", ["update-index", "--add", "--cacheinfo", "160000", "0123456789012345678901234567890123456789", "src/submodule"], { cwd: gitRoot })
+await writeFile(join(gitRoot, "base.txt"), "base\n")
+await writeFile(join(gitRoot, "ours.txt"), "ours\n")
+await writeFile(join(gitRoot, "theirs.txt"), "theirs\n")
+const baseHash = (await execFileAsync("git", ["hash-object", "-w", "base.txt"], { cwd: gitRoot })).stdout.trim()
+const oursHash = (await execFileAsync("git", ["hash-object", "-w", "ours.txt"], { cwd: gitRoot })).stdout.trim()
+const theirsHash = (await execFileAsync("git", ["hash-object", "-w", "theirs.txt"], { cwd: gitRoot })).stdout.trim()
+const unmerged = spawnSync("git", ["update-index", "--index-info"], {
+  cwd: gitRoot,
+  input: `100644 ${baseHash} 1\tsrc/conflict.txt\n100644 ${oursHash} 2\tsrc/conflict.txt\n100644 ${theirsHash} 3\tsrc/conflict.txt\n`,
+})
+assert.equal(unmerged.status, 0, unmerged.stderr.toString())
+const gitBacked = await checkWorkspacePolicy({
+  workspaceRoot: gitRoot,
+  writableRoots: ["src"],
+  gitBacked: true,
+})
+assert.equal(gitBacked.passed, false)
+assert.ok(gitBacked.violations.some((violation) => violation.code === "ignored-path" && violation.path === "src/ignored.txt"))
+assert.ok(gitBacked.violations.some((violation) => violation.code === "gitlink" && violation.path === "src/submodule"))
+assert.ok(gitBacked.violations.some((violation) => violation.code === "unmerged-index" && violation.path === "src/conflict.txt"))
+
+const cli = await execFileAsync(process.execPath, [
+  "packages/cli/dist/index.js",
+  "workspace-policy",
+  "check",
+  "--workspace-root",
+  root,
+  "--writable-root",
+  "src",
+  "--hidden-path",
+  "private",
+  "--json",
+], { cwd: process.cwd(), encoding: "utf8" }).catch((error: unknown) => {
+  const failed = error as { stdout?: string }
+  return { stdout: failed.stdout ?? "" }
+})
+const cliOutput = JSON.parse(cli.stdout) as Awaited<ReturnType<typeof checkWorkspacePolicy>>
+assert.equal(cliOutput.schema, "wp-codebox/workspace-policy-result/v1")
+assert.equal(cliOutput.passed, false)
+
+console.log("Workspace policy smoke passed")


### PR DESCRIPTION
## Summary
- Add a reusable generic workspace policy checker API in @chubes4/wp-codebox-core.
- Add `wp-codebox workspace-policy check` CLI output in human and JSON modes.
- Cover writable roots, hidden paths, symlink, hardlink, gitlink, nested .git metadata, ignored git paths, unmerged index entries, special files, non-writable paths, and path normalization in smoke tests.

Fixes #177.

## Testing
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the workspace policy checker implementation, CLI wiring, and smoke coverage; Chris remains responsible for review and validation.