### PR TITLE
Use mounted workspace backend in sandbox runs

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -64,6 +64,8 @@ if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
     define('DATAMACHINE_WORKSPACE_PATH', ${JSON.stringify(SANDBOX_WORKSPACE_ROOT)});
 }
 
+add_filter('datamachine_code_remote_workspace_backend_should_handle', '__return_false', 100);
+
 $sandbox_workspace_adoptions = array();
 if (function_exists('wp_get_ability')) {
     $sandbox_adopt_callback = static function () use (&$sandbox_workspace_adoptions): void {
@@ -256,6 +258,8 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
     define('DATAMACHINE_WORKSPACE_PATH', ${JSON.stringify(SANDBOX_WORKSPACE_ROOT)});
 }
+
+add_filter('datamachine_code_remote_workspace_backend_should_handle', '__return_false', 100);
 
 add_filter('datamachine_should_load_full_runtime', '__return_true', 1);
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -80,6 +80,15 @@ class PlaygroundCommandCrashError extends Error {
   }
 }
 
+class PlaygroundCliExitError extends Error {
+  readonly code = "wp-codebox-playground-cli-exited"
+
+  constructor(readonly exitCode: number) {
+    super(`WordPress Playground CLI exited while booting the runtime with exit code ${exitCode}.`)
+    this.name = "PlaygroundCliExitError"
+  }
+}
+
 class PlaygroundPreviewPortUnavailableError extends Error {
   readonly code = "wp-codebox-preview-port-in-use"
 
@@ -113,6 +122,20 @@ function playgroundFailureMessage(command: string, response: PlaygroundRunRespon
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+async function runPlaygroundCliWithoutProcessExit<T>(callback: () => Promise<T>): Promise<T> {
+  const exit = process.exit
+  process.exit = ((code?: string | number | null | undefined): never => {
+    const exitCode = typeof code === "number" ? code : 1
+    throw new PlaygroundCliExitError(exitCode)
+  }) as typeof process.exit
+
+  try {
+    return await callback()
+  } finally {
+    process.exit = exit
+  }
 }
 
 interface PlaygroundCliServer {
@@ -1290,7 +1313,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     }
 
     try {
-      const server = await runCLI({
+      const server = await runPlaygroundCliWithoutProcessExit(() => runCLI({
         command: "server",
         port: 0,
         quiet: true,
@@ -1302,7 +1325,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
         wp: this.spec.environment.version,
         "site-url": this.spec.preview?.siteUrl,
         blueprint: playgroundBlueprint(this.spec.environment.blueprint, this.spec.policy, this.spec.preview?.siteUrl),
-      })
+      }))
 
       if (!this.spec.preview?.port) {
         return server

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -14,6 +14,7 @@ async function main() {
   assert.match(code, /\\"agent_modes\\":\[\\"sandbox\\",\\"pipeline\\"\]/, "client context should report additive sandbox modes")
   assert.match(code, /\\"tool_policy\\":\{\\"mode\\":\\"allow\\",\\"tools\\":\[.*\\"workspace_read\\"/, "sandbox agent should allow workspace tools")
   assert.match(code, /datamachine_agent_mode_sandbox/, "sandbox mode should inject tool guidance")
+  assert.match(code, /datamachine_code_remote_workspace_backend_should_handle/, "sandbox mode should use the mounted workspace backend")
   assert.match(code, /Do not invent alternate tool names such as read_file/, "sandbox guidance should prevent pseudo-tool aliases")
   assert.match(code, /workspace_apply_patch/, "sandbox tool policy should include patch application")
 }


### PR DESCRIPTION
## Summary
- Force Data Machine Code sandbox runs to use the mounted `/workspace` backend instead of the remote GitHub backend.
- Keep the existing sandbox workspace root and adoption flow.
- Preserve WP Codebox recipe-run diagnostics when `@wp-playground/cli` calls `process.exit()` during runtime boot.
- Cover the emitted backend filter in the agent sandbox code smoke.

## Tests
- `npm run build`
- `npm run agent-sandbox-code-smoke`
- Homeboy Lab targeted probe verified `workspace_read` and `workspace_write` with a non-empty patch artifact.

Depends on https://github.com/Extra-Chill/data-machine-code/pull/459
Also depends on https://github.com/Extra-Chill/data-machine/pull/2321 for opt-in allow-policy tools.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced WP Codebox sandbox workspace failures through Data Machine/Data Machine Code policy and backend selection, drafted the sandbox backend and diagnostics fixes, rebuilt the CLI, and ran focused Homeboy Lab verification.