### PR TITLE
Add artifact bundle verifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
     "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
+    "artifact-bundle-verifier-smoke": "tsx scripts/artifact-bundle-verifier-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
@@ -58,7 +59,7 @@
     "recipe-staged-files-smoke": "tsx scripts/recipe-staged-files-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run workspace-policy-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run workspace-policy-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-bundle-verifier-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,10 +8,10 @@ import { basename, dirname, join, resolve } from "node:path"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import { promisify } from "node:util"
-import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, checkWorkspacePolicy, createRuntime, validateRuntimePolicy, type ArtifactBundle, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, checkWorkspacePolicy, createRuntime, validateRuntimePolicy, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
-import { captureStdout, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
+import { captureStdout, printArtifactVerifyHumanOutput, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
 
 interface CommandMetadata {
   id: string
@@ -135,6 +135,11 @@ interface WorkspacePolicyOptions {
   writableRoots: string[]
   hiddenPaths: string[]
   gitBacked: boolean
+  json: boolean
+}
+
+interface ArtifactVerifyOptions {
+  bundleDirectory: string
   json: boolean
 }
 
@@ -975,6 +980,25 @@ async function main(args: string[]): Promise<number> {
     return output.passed ? 0 : 1
   }
 
+  if (command === "artifacts") {
+    const subcommand = args.shift()
+    if (subcommand !== "verify") {
+      console.error(`Unknown artifacts command: ${subcommand ?? ""}`)
+      printHelp()
+      return 1
+    }
+
+    const options = parseArtifactVerifyOptions(args)
+    const output = await verifyArtifacts(options)
+    if (!options.json) {
+      printArtifactVerifyHumanOutput(output)
+      return output.valid ? 0 : 1
+    }
+
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    return output.valid ? 0 : 1
+  }
+
   if (command === "commands") {
     const json = parseDiscoveryJsonOption(args)
     const output = commandCatalogOutput()
@@ -1527,6 +1551,10 @@ async function validateRecipe(options: RecipeValidateOptions): Promise<RecipeVal
       error: serializeError(error),
     }
   }
+}
+
+async function verifyArtifacts(options: ArtifactVerifyOptions): Promise<ArtifactBundleVerificationResult> {
+  return verifyArtifactBundle(resolve(options.bundleDirectory))
 }
 
 async function mapWithConcurrency<T, R>(items: T[], concurrency: number, callback: (item: T, index: number) => Promise<R>): Promise<R[]> {
@@ -2504,6 +2532,40 @@ function parseRecipeValidateOptions(args: string[]): RecipeValidateOptions {
   }
 
   return options as RecipeValidateOptions
+}
+
+function parseArtifactVerifyOptions(args: string[]): ArtifactVerifyOptions {
+  const options: Partial<ArtifactVerifyOptions> = { json: false }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--bundle":
+        options.bundleDirectory = value
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (!options.bundleDirectory) {
+    throw new Error("Missing required option: --bundle")
+  }
+
+  return options as ArtifactVerifyOptions
 }
 
 function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,4 +1,4 @@
-import type { ArtifactBundle, ExecutionResult, RuntimeInfo } from "@chubes4/wp-codebox-core"
+import type { ArtifactBundle, ArtifactBundleVerificationResult, ExecutionResult, RuntimeInfo } from "@chubes4/wp-codebox-core"
 
 interface CliError {
   name: string
@@ -195,6 +195,15 @@ export function printRecipeValidateHumanOutput(output: RecipeValidateOutputLike)
   }
 }
 
+export function printArtifactVerifyHumanOutput(output: ArtifactBundleVerificationResult): void {
+  console.log("WP Codebox artifact bundle verification")
+  console.log(`Bundle: ${output.bundleDirectory}`)
+  console.log(`Valid: ${output.valid ? "yes" : "no"}`)
+  for (const violation of output.violations) {
+    console.log(`- ${violation.code} ${violation.path}: ${violation.message}`)
+  }
+}
+
 export function printBatchHumanOutput(output: BatchOutputLike): void {
   console.log("WP Codebox batch")
   console.log(`Runs: ${output.completed}/${output.total} completed`)
@@ -233,6 +242,7 @@ export function printHelp(): void {
   wp-codebox schema recipe [--json]
   wp-codebox workspace-policy check --workspace-root <path> --writable-root <path> [options]
   wp-codebox recipe validate --recipe <path> [--json]
+  wp-codebox artifacts verify --bundle <dir> [--json]
   wp-codebox validate-blueprint --blueprint <json|file> [options]
   wp-codebox recipe-run --recipe <path> [options]
   wp-codebox boot [--mount <host>:<vfs>] [options]
@@ -240,6 +250,7 @@ export function printHelp(): void {
 
 Options:
   --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
+  --bundle <dir>      Artifact bundle directory for artifacts verify.
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
   --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.plugin-check, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto"
+import { readdir, readFile, stat } from "node:fs/promises"
+import { isAbsolute, join, normalize, sep } from "node:path"
 
 export * from "./workspace-policy.js"
 
@@ -659,6 +661,338 @@ export interface ArtifactBundle {
   preview?: ArtifactPreview
   contentDigest: string
   createdAt: string
+}
+
+export type ArtifactBundleVerificationViolationCode =
+  | "missing-manifest"
+  | "malformed-manifest"
+  | "invalid-manifest-shape"
+  | "invalid-path"
+  | "missing-file"
+  | "orphaned-file"
+  | "digest-mismatch"
+  | "bundle-id-mismatch"
+  | "malformed-reference"
+  | "review-evidence-mismatch"
+
+export interface ArtifactBundleVerificationViolation {
+  code: ArtifactBundleVerificationViolationCode
+  path: string
+  message: string
+  file?: string
+}
+
+export interface ArtifactBundleVerificationResult {
+  schema: "wp-codebox/artifact-bundle-verification/v1"
+  bundleDirectory: string
+  valid: boolean
+  violations: ArtifactBundleVerificationViolation[]
+  manifest?: ArtifactManifest
+}
+
+export interface VerifyArtifactBundleOptions {
+  manifestFileName?: string
+  allowOrphanedFiles?: boolean
+}
+
+export async function verifyArtifactBundle(directory: string, options: VerifyArtifactBundleOptions = {}): Promise<ArtifactBundleVerificationResult> {
+  const bundleDirectory = normalize(directory)
+  const manifestFileName = options.manifestFileName ?? "manifest.json"
+  const manifestPath = join(bundleDirectory, manifestFileName)
+  const violations: ArtifactBundleVerificationViolation[] = []
+  let manifest: ArtifactManifest | undefined
+
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, "utf8")) as ArtifactManifest
+  } catch (error) {
+    violations.push({
+      code: (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing-manifest" : "malformed-manifest",
+      path: manifestFileName,
+      message: (error as NodeJS.ErrnoException).code === "ENOENT" ? "manifest.json is missing." : "manifest.json is not valid JSON.",
+    })
+    return artifactBundleVerificationResult(bundleDirectory, violations)
+  }
+
+  if (!isArtifactManifestShape(manifest)) {
+    violations.push({
+      code: "invalid-manifest-shape",
+      path: manifestFileName,
+      message: "manifest.json does not match the WP Codebox artifact manifest shape.",
+    })
+    return artifactBundleVerificationResult(bundleDirectory, violations)
+  }
+
+  const manifestFiles = new Set<string>()
+  for (const [index, file] of manifest.files.entries()) {
+    const fieldPath = `manifest.files[${index}].path`
+    const pathViolation = artifactPathViolation(file.path, fieldPath)
+    if (pathViolation) {
+      violations.push(pathViolation)
+      continue
+    }
+
+    manifestFiles.add(file.path)
+    try {
+      const fileStat = await stat(join(bundleDirectory, file.path))
+      if (!fileStat.isFile()) {
+        violations.push({ code: "missing-file", path: fieldPath, file: file.path, message: `Manifest path is not a file: ${file.path}` })
+      }
+    } catch {
+      violations.push({ code: "missing-file", path: fieldPath, file: file.path, message: `Manifest file is missing: ${file.path}` })
+    }
+  }
+
+  if (!manifestFiles.has(manifestFileName)) {
+    violations.push({
+      code: "invalid-manifest-shape",
+      path: "manifest.files",
+      file: manifestFileName,
+      message: "manifest.json must list itself in manifest.files.",
+    })
+  }
+
+  if (!options.allowOrphanedFiles) {
+    for (const file of await listBundleFiles(bundleDirectory)) {
+      if (!manifestFiles.has(file)) {
+        violations.push({ code: "orphaned-file", path: file, file, message: `Bundle file is not listed in manifest.json: ${file}` })
+      }
+    }
+  }
+
+  await verifyContentDigest(bundleDirectory, manifest, violations)
+  verifyBundleId(manifest, violations)
+  await verifyMetadataReferences(bundleDirectory, manifestFiles, violations)
+  await verifyReviewEvidence(bundleDirectory, manifest, manifestFiles, violations)
+
+  return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
+}
+
+export async function calculateArtifactContentDigest(directory: string, inputs: string[]): Promise<string> {
+  const hash = createHash("sha256").update("wp-codebox/artifact-content/v1\n")
+  for (const [index, input] of inputs.entries()) {
+    if (index > 0) {
+      hash.update("\n")
+    }
+    hash.update(`${input}\n`)
+    hash.update(await readFile(join(directory, input)))
+  }
+
+  return hash.digest("hex")
+}
+
+function artifactBundleVerificationResult(bundleDirectory: string, violations: ArtifactBundleVerificationViolation[], manifest?: ArtifactManifest): ArtifactBundleVerificationResult {
+  return {
+    schema: "wp-codebox/artifact-bundle-verification/v1",
+    bundleDirectory,
+    valid: violations.length === 0,
+    violations,
+    ...(manifest ? { manifest } : {}),
+  }
+}
+
+function isArtifactManifestShape(value: unknown): value is ArtifactManifest {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  const contentDigest = value.contentDigest
+  return typeof value.id === "string"
+    && typeof value.createdAt === "string"
+    && isRecord(value.runtime)
+    && isRecord(contentDigest)
+    && contentDigest.algorithm === "sha256"
+    && Array.isArray(contentDigest.inputs)
+    && contentDigest.inputs.every((input) => typeof input === "string")
+    && typeof contentDigest.value === "string"
+    && Array.isArray(value.files)
+    && value.files.every(isArtifactManifestFileShape)
+}
+
+function isArtifactManifestFileShape(value: unknown): value is ArtifactManifestFile {
+  return isRecord(value)
+    && typeof value.path === "string"
+    && typeof value.kind === "string"
+    && typeof value.contentType === "string"
+}
+
+function artifactPathViolation(path: string, fieldPath: string): ArtifactBundleVerificationViolation | undefined {
+  if (path.length === 0) {
+    return { code: "invalid-path", path: fieldPath, file: path, message: "Artifact paths must not be empty." }
+  }
+
+  if (path.includes("\\") || isAbsolute(path) || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(path)) {
+    return { code: "invalid-path", path: fieldPath, file: path, message: `Artifact path must be bundle-relative and local: ${path}` }
+  }
+
+  const normalized = normalize(path).split(sep).join("/")
+  if (normalized === ".." || normalized.startsWith("../") || path.split("/").includes("..")) {
+    return { code: "invalid-path", path: fieldPath, file: path, message: `Artifact path must not contain traversal: ${path}` }
+  }
+
+  return undefined
+}
+
+async function verifyContentDigest(directory: string, manifest: ArtifactManifest, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  for (const [index, input] of manifest.contentDigest.inputs.entries()) {
+    const pathViolation = artifactPathViolation(input, `manifest.contentDigest.inputs[${index}]`)
+    if (pathViolation) {
+      violations.push(pathViolation)
+      return
+    }
+  }
+
+  if (!/^[a-f0-9]{64}$/.test(manifest.contentDigest.value)) {
+    violations.push({ code: "invalid-manifest-shape", path: "manifest.contentDigest.value", message: "contentDigest.value must be a lowercase sha256 hex digest." })
+    return
+  }
+
+  try {
+    const value = await calculateArtifactContentDigest(directory, manifest.contentDigest.inputs)
+    if (value !== manifest.contentDigest.value) {
+      violations.push({
+        code: "digest-mismatch",
+        path: "manifest.contentDigest.value",
+        message: `contentDigest.value does not match declared inputs: expected ${value}, got ${manifest.contentDigest.value}`,
+      })
+    }
+  } catch (error) {
+    violations.push({ code: "digest-mismatch", path: "manifest.contentDigest.inputs", message: `Unable to calculate content digest: ${errorMessage(error)}` })
+  }
+}
+
+function verifyBundleId(manifest: ArtifactManifest, violations: ArtifactBundleVerificationViolation[]): void {
+  const prefix = "artifact-bundle-sha256-"
+  if (manifest.id.startsWith(prefix) && manifest.id !== `${prefix}${manifest.contentDigest.value}`) {
+    violations.push({
+      code: "bundle-id-mismatch",
+      path: "manifest.id",
+      message: `Bundle id must match content digest: expected ${prefix}${manifest.contentDigest.value}, got ${manifest.id}`,
+    })
+  }
+}
+
+async function verifyMetadataReferences(directory: string, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  let metadata: unknown
+  try {
+    metadata = JSON.parse(await readFile(join(directory, "metadata.json"), "utf8"))
+  } catch {
+    return
+  }
+
+  const artifacts = isRecord(metadata) ? metadata.artifacts : undefined
+  if (!isRecord(artifacts)) {
+    return
+  }
+
+  for (const [key, value] of Object.entries(artifacts)) {
+    for (const reference of artifactReferenceStrings(value)) {
+      validateArtifactReference(reference, `metadata.artifacts.${key}`, manifestFiles, violations)
+    }
+  }
+}
+
+async function verifyReviewEvidence(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  let review: unknown
+  try {
+    review = JSON.parse(await readFile(join(directory, "files/review.json"), "utf8"))
+  } catch {
+    return
+  }
+
+  if (!isRecord(review) || !isRecord(review.evidence)) {
+    violations.push({ code: "malformed-reference", path: "files/review.json", file: "files/review.json", message: "Review artifact does not include an evidence object." })
+    return
+  }
+
+  const evidence = review.evidence
+  if (typeof evidence.artifactContentDigest === "string" && evidence.artifactContentDigest !== manifest.contentDigest.value) {
+    violations.push({ code: "review-evidence-mismatch", path: "files/review.json:evidence.artifactContentDigest", file: "files/review.json", message: "Review artifact content digest does not match manifest contentDigest.value." })
+  }
+
+  if (typeof evidence.patch === "string") {
+    validateArtifactReference(evidence.patch, "files/review.json:evidence.patch", manifestFiles, violations)
+    if (typeof evidence.patchSha256 === "string") {
+      try {
+        const patchSha256 = createHash("sha256").update(await readFile(join(directory, evidence.patch))).digest("hex")
+        if (patchSha256 !== evidence.patchSha256) {
+          violations.push({ code: "review-evidence-mismatch", path: "files/review.json:evidence.patchSha256", file: "files/review.json", message: "Review patchSha256 does not match the referenced patch file." })
+        }
+      } catch (error) {
+        violations.push({ code: "review-evidence-mismatch", path: "files/review.json:evidence.patchSha256", file: evidence.patch, message: `Unable to hash review patch evidence: ${errorMessage(error)}` })
+      }
+    }
+  }
+
+  if (typeof evidence.changedFiles === "string") {
+    validateArtifactReference(evidence.changedFiles, "files/review.json:evidence.changedFiles", manifestFiles, violations)
+    await verifyChangedFileEvidence(directory, evidence.changedFiles, review, violations)
+  }
+}
+
+async function verifyChangedFileEvidence(directory: string, changedFilesPath: string, review: Record<string, unknown>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  try {
+    const changedFiles = JSON.parse(await readFile(join(directory, changedFilesPath), "utf8"))
+    const changedFileList = isRecord(changedFiles) && Array.isArray(changedFiles.files) ? changedFiles.files : undefined
+    const reviewChangedFiles = Array.isArray(review.changedFiles) ? review.changedFiles : undefined
+    if (!changedFileList || !reviewChangedFiles) {
+      return
+    }
+
+    const changedFileKeys = new Set(changedFileList.filter(isRecord).map((file) => `${file.path}:${file.status}`))
+    for (const file of reviewChangedFiles.filter(isRecord)) {
+      if (!changedFileKeys.has(`${file.path}:${file.status}`)) {
+        violations.push({ code: "review-evidence-mismatch", path: "files/review.json:changedFiles", file: "files/review.json", message: `Review changed-file evidence is not present in ${changedFilesPath}: ${String(file.path)}` })
+      }
+    }
+  } catch (error) {
+    violations.push({ code: "review-evidence-mismatch", path: "files/review.json:evidence.changedFiles", file: changedFilesPath, message: `Unable to read changed-file evidence: ${errorMessage(error)}` })
+  }
+}
+
+function validateArtifactReference(reference: string, fieldPath: string, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): void {
+  const pathViolation = artifactPathViolation(reference, fieldPath)
+  if (pathViolation) {
+    violations.push(pathViolation)
+    return
+  }
+
+  if (!manifestFiles.has(reference)) {
+    violations.push({ code: "malformed-reference", path: fieldPath, file: reference, message: `Artifact reference is not listed in manifest.json: ${reference}` })
+  }
+}
+
+function artifactReferenceStrings(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value]
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string")
+  }
+
+  return []
+}
+
+async function listBundleFiles(directory: string, prefix = ""): Promise<string[]> {
+  const files: string[] = []
+  for (const entry of await readdir(join(directory, prefix), { withFileTypes: true })) {
+    const path = prefix ? `${prefix}/${entry.name}` : entry.name
+    if (entry.isDirectory()) {
+      files.push(...await listBundleFiles(directory, path))
+    } else if (entry.isFile()) {
+      files.push(path)
+    }
+  }
+
+  return files.sort()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 export interface Runtime {

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { createHash } from "node:crypto"
+import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+import { calculateArtifactContentDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
+
+const execFileAsync = promisify(execFile)
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-verifier-"))
+
+try {
+  const validBundle = join(workspace, "valid")
+  await writeValidBundle(validBundle)
+
+  const valid = await verifyArtifactBundle(validBundle)
+  assert.equal(valid.valid, true)
+  assert.deepEqual(valid.violations, [])
+
+  const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "verify", "--bundle", validBundle, "--json"], { cwd: root })
+  assert.equal(JSON.parse(stdout).valid, true)
+
+  const missingManifest = join(workspace, "missing-manifest")
+  await mkdir(missingManifest, { recursive: true })
+  assertViolation(await verifyArtifactBundle(missingManifest), "missing-manifest")
+
+  const missingFile = await copyBundle(validBundle, join(workspace, "missing-file"))
+  await rm(join(missingFile, "files/patch.diff"))
+  assertViolation(await verifyArtifactBundle(missingFile), "missing-file")
+
+  const traversalPath = await copyBundle(validBundle, join(workspace, "traversal-path"))
+  const traversalManifest = manifestFixture(await calculateArtifactContentDigest(traversalPath, ["files/changed-files.json", "files/patch.diff"]))
+  traversalManifest.files.push({ path: "../escape.txt", kind: "file", contentType: "text/plain" })
+  await writeJson(join(traversalPath, "manifest.json"), traversalManifest)
+  assertViolation(await verifyArtifactBundle(traversalPath), "invalid-path")
+
+  const digestMismatch = await copyBundle(validBundle, join(workspace, "digest-mismatch"))
+  await writeFile(join(digestMismatch, "files/patch.diff"), "diff --git a/file.txt b/file.txt\n+tampered\n")
+  assertViolation(await verifyArtifactBundle(digestMismatch), "digest-mismatch")
+
+  const malformedManifest = join(workspace, "malformed-manifest")
+  await mkdir(malformedManifest, { recursive: true })
+  await writeFile(join(malformedManifest, "manifest.json"), "{not-json")
+  assertViolation(await verifyArtifactBundle(malformedManifest), "malformed-manifest")
+
+  const reviewMismatch = await copyBundle(validBundle, join(workspace, "review-mismatch"))
+  const review = reviewFixture("0".repeat(64))
+  await writeJson(join(reviewMismatch, "files/review.json"), review)
+  assertViolation(await verifyArtifactBundle(reviewMismatch), "review-evidence-mismatch")
+
+  console.log("Artifact bundle verifier smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function writeValidBundle(directory: string): Promise<void> {
+  await mkdir(join(directory, "files"), { recursive: true })
+  const changedFiles = `${JSON.stringify({ schema: "wp-codebox/changed-files/v1", files: [{ path: "/wordpress/wp-content/plugins/example/file.txt", status: "added", mountIndex: 0, mountTarget: "/wordpress/wp-content/plugins/example", relativePath: "file.txt", patchPath: "files/diffs/0-file.txt.diff" }] }, null, 2)}\n`
+  const patch = "diff --git /dev/null b/wordpress/wp-content/plugins/example/file.txt\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
+  await writeFile(join(directory, "files/changed-files.json"), changedFiles)
+  await writeFile(join(directory, "files/patch.diff"), patch)
+  await writeFile(join(directory, "metadata.json"), "{}\n")
+  await writeFile(join(directory, "files/test-results.json"), "{}\n")
+
+  const digest = await calculateArtifactContentDigest(directory, ["files/changed-files.json", "files/patch.diff"])
+  await writeJson(join(directory, "files/review.json"), reviewFixture(digest))
+  await writeJson(join(directory, "metadata.json"), {
+    id: `artifact-bundle-sha256-${digest}`,
+    artifacts: {
+      changedFiles: "files/changed-files.json",
+      patch: "files/patch.diff",
+      review: "files/review.json",
+      testResults: "files/test-results.json",
+    },
+  })
+  await writeJson(join(directory, "manifest.json"), manifestFixture(digest))
+}
+
+function manifestFixture(digest: string) {
+  return {
+    id: `artifact-bundle-sha256-${digest}`,
+    contentDigest: {
+      algorithm: "sha256",
+      inputs: ["files/changed-files.json", "files/patch.diff"],
+      value: digest,
+    },
+    createdAt: "2026-05-27T00:00:00.000Z",
+    runtime: {
+      id: "runtime-fixture",
+      backend: "wordpress-playground",
+      status: "destroyed",
+      environment: { kind: "wordpress", version: "latest" },
+      createdAt: "2026-05-27T00:00:00.000Z",
+    },
+    files: [
+      { path: "manifest.json", kind: "manifest", contentType: "application/json" },
+      { path: "metadata.json", kind: "metadata", contentType: "application/json" },
+      { path: "files/changed-files.json", kind: "changed-files", contentType: "application/json" },
+      { path: "files/patch.diff", kind: "patch", contentType: "text/x-diff" },
+      { path: "files/review.json", kind: "review", contentType: "application/json" },
+      { path: "files/test-results.json", kind: "test-results", contentType: "application/json" },
+    ],
+  }
+}
+
+function reviewFixture(digest: string) {
+  const patch = "diff --git /dev/null b/wordpress/wp-content/plugins/example/file.txt\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
+  return {
+    schema: "wp-codebox/artifact-review/v1",
+    artifactId: `artifact-bundle-sha256-${digest}`,
+    evidence: {
+      patch: "files/patch.diff",
+      patchSha256: createHash("sha256").update(patch).digest("hex"),
+      artifactContentDigest: digest,
+      changedFiles: "files/changed-files.json",
+      testResults: "files/test-results.json",
+    },
+    changedFiles: [{ path: "/wordpress/wp-content/plugins/example/file.txt", status: "added" }],
+  }
+}
+
+async function copyBundle(source: string, target: string): Promise<string> {
+  await cp(source, target, { recursive: true })
+  return target
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function assertViolation(result: Awaited<ReturnType<typeof verifyArtifactBundle>>, code: string): void {
+  assert.equal(result.valid, false)
+  assert.ok(result.violations.some((violation) => violation.code === code), `Expected ${code}, got ${result.violations.map((violation) => violation.code).join(", ")}`)
+}

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -6,7 +6,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { createRuntime } from "@chubes4/wp-codebox-core"
+import { createRuntime, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 const execFileAsync = promisify(execFile)
@@ -39,6 +39,8 @@ try {
   assert.equal(output.runtime.previewUrl, "https://preview.example.test/codebox/")
 
   const artifacts = output.artifacts
+  const verification = await verifyArtifactBundle(artifacts.directory)
+  assert.equal(verification.valid, true, JSON.stringify(verification.violations, null, 2))
   assert.ok(artifacts.changedFilesPath, "artifact bundle should expose changedFilesPath")
   assert.ok(artifacts.patchPath, "artifact bundle should expose patchPath")
   assert.ok(artifacts.testResultsPath, "artifact bundle should expose testResultsPath")


### PR DESCRIPTION
## Summary
- add generic artifact bundle verification in wp-codebox core
- expose `wp-codebox artifacts verify --bundle <dir>`
- add smoke coverage for valid bundles, malformed manifests, missing files, traversal paths, digest mismatches, and review evidence mismatches

Supersedes #181 after #179 and #183 landed first.

## Tests
- `npm run build && npm run artifact-bundle-verifier-smoke && npm run artifact-contract-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Rebasing the artifact bundle verifier after dependent wp-codebox PRs landed, resolving CLI/core/package conflicts, and rerunning targeted checks; Chris remains responsible for review and merge.