### PR TITLE
Persist runtime episode trace artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ const trace = await episode.trace()
 await episode.close()
 ```
 
+When `collectArtifacts()` runs for an episode, WP Codebox persists the trace into
+the artifact bundle at `files/runtime-episode-trace.json` and writes a compact
+stream form to `files/runtime-episode.jsonl`. The bundle manifest advertises
+those files with `runtime-episode-trace` and `runtime-episode-events` kinds,
+`metadata.json` lists them under `artifacts.runtimeEpisodeTrace` and
+`artifacts.runtimeEpisodeEvents`, and `files/review.json` includes
+`evidence.runtimeEpisodeTrace` for review tooling. `verifyArtifactBundle()`
+checks the advertised trace file exists and validates against
+`wp-codebox/runtime-episode-trace/v1`.
+
 Products such as eval harnesses can project this generic episode trace into their
 own action, observation, reward, and report schemas outside WP Codebox.
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { readdir, readFile, stat } from "node:fs/promises"
+import { readdir, readFile, stat, writeFile } from "node:fs/promises"
 import { isAbsolute, join, normalize, sep } from "node:path"
 
 export * from "./workspace-policy.js"
@@ -621,6 +621,7 @@ export interface ArtifactReview {
     artifactContentDigest: string
     changedFiles: string
     testResults?: string
+    runtimeEpisodeTrace?: string
   }
   browser?: ArtifactReviewBrowserSummary
   redaction?: ArtifactRedactionSummary
@@ -715,6 +716,8 @@ export interface ArtifactBundle {
   patchPath: string
   testResultsPath: string
   reviewPath: string
+  runtimeEpisodeTracePath?: string
+  runtimeEpisodeEventsPath?: string
   artifactVerificationPath?: string
   workspacePolicyPath?: string
   preview?: ArtifactPreview
@@ -822,6 +825,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   verifyBundleId(manifest, violations)
   await verifyMetadataReferences(bundleDirectory, manifestFiles, violations)
   await verifyReviewEvidence(bundleDirectory, manifest, manifestFiles, violations)
+  await verifyRuntimeEpisodeTraceArtifacts(bundleDirectory, manifest, violations)
 
   return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
 }
@@ -985,6 +989,38 @@ async function verifyReviewEvidence(directory: string, manifest: ArtifactManifes
   if (typeof evidence.changedFiles === "string") {
     validateArtifactReference(evidence.changedFiles, "files/review.json:evidence.changedFiles", manifestFiles, violations)
     await verifyChangedFileEvidence(directory, evidence.changedFiles, review, violations)
+  }
+
+  if (typeof evidence.runtimeEpisodeTrace === "string") {
+    validateArtifactReference(evidence.runtimeEpisodeTrace, "files/review.json:evidence.runtimeEpisodeTrace", manifestFiles, violations)
+  }
+}
+
+async function verifyRuntimeEpisodeTraceArtifacts(directory: string, manifest: ArtifactManifest, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  for (const file of manifest.files) {
+    if (file.kind !== "runtime-episode-trace") {
+      continue
+    }
+
+    try {
+      const trace = JSON.parse(await readFile(join(directory, file.path), "utf8"))
+      const validation = validateRuntimeEpisodeTrace(trace)
+      if (!validation.valid) {
+        violations.push({
+          code: "malformed-reference",
+          path: file.path,
+          file: file.path,
+          message: `Runtime episode trace is invalid: ${validation.issues.map((issue) => `${issue.path} ${issue.message}`).join("; ")}`,
+        })
+      }
+    } catch (error) {
+      violations.push({
+        code: "malformed-reference",
+        path: file.path,
+        file: file.path,
+        message: `Runtime episode trace is not valid JSON: ${errorMessage(error)}`,
+      })
+    }
   }
 }
 
@@ -1576,6 +1612,52 @@ function snapshotWithSemantics(snapshot: Snapshot): Snapshot {
   return { semantics: "metadata-only", ...snapshot }
 }
 
+function runtimeEpisodeJsonLines(trace: RuntimeEpisodeTrace): string {
+  const records: Array<Record<string, unknown>> = [
+    {
+      type: "episode.reset",
+      id: trace.reset.id,
+      runtime: trace.reset.runtime,
+      observations: trace.reset.observationRefs,
+    },
+    ...trace.steps.map((step) => ({
+      type: "episode.step",
+      id: step.id,
+      index: step.index,
+      actionRef: step.actionRef,
+      executionRef: step.executionRef,
+      ...(step.observationRef ? { observationRef: step.observationRef } : {}),
+    })),
+    ...trace.snapshots.map((snapshot) => ({
+      type: "episode.snapshot",
+      id: snapshot.id,
+      createdAt: snapshot.createdAt,
+      semantics: snapshot.semantics,
+      artifactRefs: snapshot.artifactRefs ?? [],
+    })),
+  ]
+
+  if (trace.artifactRef) {
+    records.push({
+      type: "episode.artifacts",
+      id: trace.artifactRef.id,
+      artifactRef: trace.artifactRef,
+    })
+  }
+
+  return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`
+}
+
+function upsertManifestFile(manifest: ArtifactManifest, file: ArtifactManifestFile): void {
+  const index = manifest.files.findIndex((candidate) => candidate.path === file.path)
+  if (index === -1) {
+    manifest.files.push(file)
+    return
+  }
+
+  manifest.files[index] = file
+}
+
 export async function createRuntime(spec: RuntimeCreateSpec, backend: RuntimeBackend): Promise<Runtime> {
   assertRuntimePolicy(spec.policy)
 
@@ -1597,6 +1679,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
   private readonly steps: RuntimeEpisodeStepResult[] = []
   private readonly snapshots: Snapshot[] = []
   private artifacts?: ArtifactBundle
+  private traceCreatedAt?: string
 
   private constructor(
     private readonly spec: RuntimeEpisodeSpec,
@@ -1615,6 +1698,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     this.steps.length = 0
     this.snapshots.length = 0
     this.artifacts = undefined
+    this.traceCreatedAt = undefined
 
     for (const mount of this.spec.mounts ?? []) {
       await this.runtime.mount(mount)
@@ -1679,8 +1763,72 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
   }
 
   async collectArtifacts(spec: ArtifactSpec = this.spec.artifactSpec ?? {}): Promise<ArtifactBundle> {
-    this.artifacts = await this.assertRuntime().collectArtifacts(spec)
+    const artifacts = await this.assertRuntime().collectArtifacts(spec)
+    this.artifacts = {
+      ...artifacts,
+      runtimeEpisodeTracePath: join(artifacts.directory, "files/runtime-episode-trace.json"),
+      runtimeEpisodeEventsPath: join(artifacts.directory, "files/runtime-episode.jsonl"),
+    }
+    await this.persistRuntimeEpisodeTraceArtifacts()
     return this.artifacts
+  }
+
+  private async persistRuntimeEpisodeTraceArtifacts(): Promise<void> {
+    if (!this.artifacts?.runtimeEpisodeTracePath || !this.artifacts.runtimeEpisodeEventsPath) {
+      return
+    }
+
+    const trace = await this.trace()
+    const traceRelativePath = "files/runtime-episode-trace.json"
+    const eventsRelativePath = "files/runtime-episode.jsonl"
+    await writeFile(this.artifacts.runtimeEpisodeTracePath, `${JSON.stringify(trace, null, 2)}\n`)
+    await writeFile(this.artifacts.runtimeEpisodeEventsPath, `${runtimeEpisodeJsonLines(trace)}`)
+    await this.updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
+    await this.updateArtifactMetadataForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
+    await this.updateArtifactReviewForRuntimeEpisodeTrace(traceRelativePath)
+  }
+
+  private async updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
+    if (!this.artifacts) {
+      return
+    }
+
+    const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
+    upsertManifestFile(manifest, { path: traceRelativePath, kind: "runtime-episode-trace", contentType: "application/json" })
+    upsertManifestFile(manifest, { path: eventsRelativePath, kind: "runtime-episode-events", contentType: "application/x-ndjson" })
+    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  }
+
+  private async updateArtifactMetadataForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
+    if (!this.artifacts) {
+      return
+    }
+
+    const metadata = JSON.parse(await readFile(this.artifacts.metadataPath, "utf8")) as Record<string, unknown>
+    metadata.artifacts = {
+      ...(isRecord(metadata.artifacts) ? metadata.artifacts : {}),
+      runtimeEpisodeTrace: traceRelativePath,
+      runtimeEpisodeEvents: eventsRelativePath,
+    }
+    await writeFile(this.artifacts.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`)
+  }
+
+  private async updateArtifactReviewForRuntimeEpisodeTrace(traceRelativePath: string): Promise<void> {
+    if (!this.artifacts) {
+      return
+    }
+
+    const review = JSON.parse(await readFile(this.artifacts.reviewPath, "utf8")) as ArtifactReview
+    review.evidence.runtimeEpisodeTrace = traceRelativePath
+    if (!review.progress.some((event) => event.type === "artifact" && event.component === "runtime-episode")) {
+      review.progress.push({
+        type: "artifact",
+        component: "runtime-episode",
+        label: "Runtime episode trace persisted",
+        timestamp: new Date().toISOString(),
+      })
+    }
+    await writeFile(this.artifacts.reviewPath, `${JSON.stringify(review, null, 2)}\n`)
   }
 
   async trace(): Promise<RuntimeEpisodeTrace> {
@@ -1705,7 +1853,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       schema: RUNTIME_EPISODE_TRACE_SCHEMA,
       version: 1,
       id: `trace-${reset.runtime.id}`,
-      createdAt: new Date().toISOString(),
+      createdAt: this.traceCreatedAt ??= new Date().toISOString(),
       runtime: await runtime.info(),
       reset,
       steps: [...this.steps],

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -50,6 +50,10 @@ try {
   await writeJson(join(reviewMismatch, "files/review.json"), review)
   assertViolation(await verifyArtifactBundle(reviewMismatch), "review-evidence-mismatch")
 
+  const invalidTrace = await copyBundle(validBundle, join(workspace, "invalid-runtime-episode-trace"))
+  await writeJson(join(invalidTrace, "files/runtime-episode-trace.json"), { schema: "wrong" })
+  assertViolation(await verifyArtifactBundle(invalidTrace), "malformed-reference")
+
   console.log("Artifact bundle verifier smoke passed")
 } finally {
   await rm(workspace, { recursive: true, force: true })
@@ -65,6 +69,8 @@ async function writeValidBundle(directory: string): Promise<void> {
   await writeFile(join(directory, "files/test-results.json"), "{}\n")
 
   const digest = await calculateArtifactContentDigest(directory, ["files/changed-files.json", "files/patch.diff"])
+  await writeJson(join(directory, "files/runtime-episode-trace.json"), runtimeEpisodeTraceFixture(digest))
+  await writeFile(join(directory, "files/runtime-episode.jsonl"), `${JSON.stringify({ type: "episode.artifacts", id: `artifact-bundle-sha256-${digest}` })}\n`)
   await writeJson(join(directory, "files/review.json"), reviewFixture(digest))
   await writeJson(join(directory, "metadata.json"), {
     id: `artifact-bundle-sha256-${digest}`,
@@ -73,6 +79,8 @@ async function writeValidBundle(directory: string): Promise<void> {
       patch: "files/patch.diff",
       review: "files/review.json",
       testResults: "files/test-results.json",
+      runtimeEpisodeTrace: "files/runtime-episode-trace.json",
+      runtimeEpisodeEvents: "files/runtime-episode.jsonl",
     },
   })
   await writeJson(join(directory, "manifest.json"), manifestFixture(digest))
@@ -101,7 +109,42 @@ function manifestFixture(digest: string) {
       { path: "files/patch.diff", kind: "patch", contentType: "text/x-diff" },
       { path: "files/review.json", kind: "review", contentType: "application/json" },
       { path: "files/test-results.json", kind: "test-results", contentType: "application/json" },
+      { path: "files/runtime-episode-trace.json", kind: "runtime-episode-trace", contentType: "application/json" },
+      { path: "files/runtime-episode.jsonl", kind: "runtime-episode-events", contentType: "application/x-ndjson" },
     ],
+  }
+}
+
+function runtimeEpisodeTraceFixture(digest: string) {
+  const runtime = {
+    id: "runtime-fixture",
+    backend: "wordpress-playground",
+    status: "destroyed",
+    environment: { kind: "wordpress", version: "latest" },
+    createdAt: "2026-05-27T00:00:00.000Z",
+  }
+
+  return {
+    schema: "wp-codebox/runtime-episode-trace/v1",
+    version: 1,
+    id: "trace-runtime-fixture",
+    createdAt: "2026-05-27T00:00:00.000Z",
+    runtime,
+    reset: {
+      id: "runtime-fixture:reset:0",
+      runtime,
+      observations: [],
+      observationRefs: [],
+    },
+    steps: [],
+    snapshots: [],
+    artifactRef: {
+      kind: "artifact-bundle",
+      id: `artifact-bundle-sha256-${digest}`,
+      artifactId: `artifact-bundle-sha256-${digest}`,
+      path: "/tmp/wp-codebox-artifact-verifier/valid",
+      digest: { algorithm: "sha256", value: digest },
+    },
   }
 }
 
@@ -116,6 +159,7 @@ function reviewFixture(digest: string) {
       artifactContentDigest: digest,
       changedFiles: "files/changed-files.json",
       testResults: "files/test-results.json",
+      runtimeEpisodeTrace: "files/runtime-episode-trace.json",
     },
     changedFiles: [{ path: "/wordpress/wp-content/plugins/example/file.txt", status: "added" }],
   }

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -10,6 +10,7 @@ import {
   RUNTIME_EPISODE_OBSERVATION_SCHEMA,
   createRuntimeEpisode,
   validateRuntimeEpisodeTrace,
+  verifyArtifactBundle,
 } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
@@ -81,8 +82,26 @@ try {
     const artifacts = await episode.collectArtifacts()
     const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8"))
     assert.equal(metadata.provenance.task.kind, "runtime-episode-smoke")
+    assert.ok(artifacts.runtimeEpisodeTracePath, "artifact bundle should expose runtimeEpisodeTracePath")
+    assert.ok(artifacts.runtimeEpisodeEventsPath, "artifact bundle should expose runtimeEpisodeEventsPath")
+    assert.equal(metadata.artifacts.runtimeEpisodeTrace, "files/runtime-episode-trace.json")
+    assert.equal(metadata.artifacts.runtimeEpisodeEvents, "files/runtime-episode.jsonl")
+
+    const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
+    assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode-trace.json" && file.kind === "runtime-episode-trace"))
+    assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode.jsonl" && file.kind === "runtime-episode-events"))
+
+    const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
+    assert.equal(review.evidence.runtimeEpisodeTrace, "files/runtime-episode-trace.json")
+    assert.ok(review.progress.some((event: { component?: string; label?: string }) => event.component === "runtime-episode" && event.label === "Runtime episode trace persisted"))
 
     const trace = await episode.trace()
+    const persistedTrace = JSON.parse(await readFile(artifacts.runtimeEpisodeTracePath, "utf8"))
+    assert.deepEqual(persistedTrace, trace)
+    const persistedEvents = (await readFile(artifacts.runtimeEpisodeEventsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line))
+    assert.equal(persistedEvents.some((event: { type: string }) => event.type === "episode.step"), true)
+    assert.equal(persistedEvents.some((event: { type: string }) => event.type === "episode.artifacts"), true)
+
     assert.equal(RUNTIME_EPISODE_TRACE_JSON_SCHEMA.$id, RUNTIME_EPISODE_TRACE_SCHEMA)
     const validateJsonSchema = new Ajv({ strict: false }).compile(RUNTIME_EPISODE_TRACE_JSON_SCHEMA)
     assert.equal(validateJsonSchema(trace), true, JSON.stringify(validateJsonSchema.errors, null, 2))
@@ -98,6 +117,8 @@ try {
     assert.equal(trace.artifactRef?.digest?.value, artifacts.contentDigest)
     const validation = validateRuntimeEpisodeTrace(trace)
     assert.equal(validation.valid, true, JSON.stringify(validation.issues, null, 2))
+    const artifactVerification = await verifyArtifactBundle(artifacts.directory)
+    assert.equal(artifactVerification.valid, true, JSON.stringify(artifactVerification.violations, null, 2))
     assert.equal(
       validateRuntimeEpisodeTrace({ ...trace, reward: 1 }).valid,
       false,


### PR DESCRIPTION
## Summary
- Persist runtime episode traces into artifact bundles as `files/runtime-episode-trace.json` plus compact `files/runtime-episode.jsonl` event streams.
- Advertise trace artifacts through `manifest.json`, `metadata.json`, and `files/review.json` evidence.
- Extend artifact verification to validate advertised runtime episode trace files against the generic `wp-codebox/runtime-episode-trace/v1` contract.
- Document where orchestration/eval consumers can find the trace while keeping WP Codebox free of reward/grader semantics.

Fixes #189.

## Checks run
- `npm run build`
- `npm run runtime-episode-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `npm run build && npm run runtime-episode-smoke && npm run artifact-bundle-verifier-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the runtime episode trace artifact persistence implementation, smoke coverage updates, and documentation. Chris remains responsible for review and testing.