### PR TITLE
Verify artifact bundle file hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,8 @@ Current bundles include:
 
 Artifact bundle ids are content-addressed for the apply-back contract. The runtime writes `manifest.id` as `artifact-bundle-sha256-<digest>`, where `<digest>` is SHA-256 over the exact bytes of `files/changed-files.json` and `files/patch.diff` with the `wp-codebox/artifact-content/v1` domain separator. The same value is exposed as `manifest.contentDigest.value`, `metadata.contentDigest.value`, the CLI `artifacts.contentDigest` field, and `files/review.json` evidence. Approval and apply-back consumers must recompute it before trusting an approved artifact.
 
+Every `manifest.files[]` entry also carries `sha256: { "algorithm": "sha256", "value": "..." }`. For regular files, `value` is the SHA-256 of that artifact file's bytes. For `manifest.json`, `value` is a canonical self-hash over the parsed manifest with the manifest entry's own hash replaced by 64 zeroes, using the `wp-codebox/artifact-manifest-self/v1` domain separator. `wp-codebox artifacts verify` rejects missing hashes and mismatched hashes for any declared file, so tampering with replay-critical or supporting artifacts is detected even when the top-level content digest inputs are unchanged.
+
 ### `files/review.json`
 
 `files/review.json` is the frontend contract for chat and owner review flows. It is derived from canonical artifacts and should be safe for a generic frontend to render without parsing unified diffs.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ import { basename, dirname, join, relative, resolve } from "node:path"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import { promisify } from "node:util"
-import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, checkWorkspacePolicy, createRuntime, validateRuntimePolicy, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, calculateArtifactManifestFileSha256, checkWorkspacePolicy, createRuntime, validateRuntimePolicy, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
 import { captureStdout, printArtifactVerifyHumanOutput, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
@@ -1790,18 +1790,17 @@ async function writeRecipeEvidenceJson(artifactRoot: string, path: string, value
 }
 
 async function updateRecipeArtifactEvidenceReferences(artifacts: ArtifactBundle, evidenceFiles: RecipeArtifactEvidenceFile[]): Promise<void> {
-  const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as { files?: Array<Record<string, unknown>> }
+  const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as ArtifactManifest
   manifest.files = Array.isArray(manifest.files) ? manifest.files : []
   for (const file of evidenceFiles) {
     const existing = manifest.files.find((entry) => entry.path === file.path)
-    const manifestFile = { path: file.path, kind: file.kind, contentType: file.contentType }
+    const manifestFile = { path: file.path, kind: file.kind, contentType: file.contentType, sha256: { algorithm: "sha256" as const, value: file.sha256 } }
     if (existing) {
       Object.assign(existing, manifestFile)
     } else {
       manifest.files.push(manifestFile)
     }
   }
-  await writeFile(artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
 
   const evidence = Object.fromEntries(evidenceFiles.map((file) => [file.kind, { path: file.path, sha256: file.sha256 }]))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8")) as Record<string, unknown>
@@ -1812,6 +1811,18 @@ async function updateRecipeArtifactEvidenceReferences(artifacts: ArtifactBundle,
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8")) as Record<string, unknown>
   review.evidence = { ...(isRecord(review.evidence) ? review.evidence : {}), runtimeEvidence: evidence }
   await writeFile(artifacts.reviewPath, `${JSON.stringify(review, null, 2)}\n`)
+
+  for (const file of manifest.files) {
+    if (file.path !== "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(artifacts.directory, manifest, file) }
+    }
+  }
+  for (const file of manifest.files) {
+    if (file.path === "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(artifacts.directory, manifest, file) }
+    }
+  }
+  await writeFile(artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -532,6 +532,12 @@ export interface ArtifactManifestFile {
     | "test-results"
     | (string & {})
   contentType: string
+  sha256: ArtifactFileDigest
+}
+
+export interface ArtifactFileDigest {
+  algorithm: "sha256"
+  value: string
 }
 
 export interface ArtifactManifest {
@@ -730,6 +736,8 @@ export type ArtifactBundleVerificationViolationCode =
   | "missing-file"
   | "orphaned-file"
   | "digest-mismatch"
+  | "missing-file-hash"
+  | "file-hash-mismatch"
   | "bundle-id-mismatch"
   | "malformed-reference"
   | "review-evidence-mismatch"
@@ -818,6 +826,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
     }
   }
 
+  await verifyManifestFileHashes(bundleDirectory, manifest, manifestFileName, violations)
   await verifyContentDigest(bundleDirectory, manifest, violations)
   verifyBundleId(manifest, violations)
   await verifyMetadataReferences(bundleDirectory, manifestFiles, violations)
@@ -837,6 +846,53 @@ export async function calculateArtifactContentDigest(directory: string, inputs: 
   }
 
   return hash.digest("hex")
+}
+
+export async function calculateArtifactManifestFileSha256(directory: string, manifest: ArtifactManifest, file: ArtifactManifestFile, manifestFileName = "manifest.json"): Promise<string> {
+  if (file.path === manifestFileName) {
+    return calculateArtifactManifestSelfSha256(manifest, manifestFileName)
+  }
+
+  return createHash("sha256").update(await readFile(join(directory, file.path))).digest("hex")
+}
+
+export function calculateArtifactManifestSelfSha256(manifest: ArtifactManifest, manifestFileName = "manifest.json"): string {
+  return createHash("sha256")
+    .update("wp-codebox/artifact-manifest-self/v1\n")
+    .update(stableJson(manifestWithPlaceholderSelfHash(manifest, manifestFileName)))
+    .digest("hex")
+}
+
+function manifestWithPlaceholderSelfHash(manifest: ArtifactManifest, manifestFileName: string): ArtifactManifest {
+  return {
+    ...manifest,
+    files: manifest.files.map((file) => file.path === manifestFileName
+      ? { ...file, sha256: { algorithm: "sha256", value: "0".repeat(64) } }
+      : file),
+  }
+}
+
+async function verifyManifestFileHashes(directory: string, manifest: ArtifactManifest, manifestFileName: string, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  for (const [index, file] of manifest.files.entries()) {
+    if (artifactPathViolation(file.path, `manifest.files[${index}].path`)) {
+      continue
+    }
+
+    const fieldPath = `manifest.files[${index}].sha256`
+    if (!isArtifactFileDigestShape(file.sha256)) {
+      violations.push({ code: "missing-file-hash", path: fieldPath, file: file.path, message: `Manifest file entry must include a lowercase SHA-256 digest: ${file.path}` })
+      continue
+    }
+
+    try {
+      const value = await calculateArtifactManifestFileSha256(directory, manifest, file, manifestFileName)
+      if (value !== file.sha256.value) {
+        violations.push({ code: "file-hash-mismatch", path: fieldPath, file: file.path, message: `Manifest file hash does not match ${file.path}: expected ${value}, got ${file.sha256.value}` })
+      }
+    } catch (error) {
+      violations.push({ code: "file-hash-mismatch", path: fieldPath, file: file.path, message: `Unable to hash manifest file entry ${file.path}: ${errorMessage(error)}` })
+    }
+  }
 }
 
 function artifactBundleVerificationResult(bundleDirectory: string, violations: ArtifactBundleVerificationViolation[], manifest?: ArtifactManifest): ArtifactBundleVerificationResult {
@@ -872,6 +928,13 @@ function isArtifactManifestFileShape(value: unknown): value is ArtifactManifestF
     && typeof value.path === "string"
     && typeof value.kind === "string"
     && typeof value.contentType === "string"
+}
+
+function isArtifactFileDigestShape(value: unknown): value is ArtifactFileDigest {
+  return isRecord(value)
+    && value.algorithm === "sha256"
+    && typeof value.value === "string"
+    && /^[a-f0-9]{64}$/.test(value.value)
 }
 
 function artifactPathViolation(path: string, fieldPath: string): ArtifactBundleVerificationViolation | undefined {

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -409,7 +409,7 @@ export function buildBlueprintAfterNotes({
 }
 
 export function fileEntry(path: string, kind: ArtifactManifestFile["kind"], contentType: string): ArtifactManifestFile {
-  return { path, kind, contentType }
+  return { path, kind, contentType, sha256: { algorithm: "sha256", value: "0".repeat(64) } }
 }
 
 export function mountTargetPath(mount: MountSpec, relativePath: string): string {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -3,7 +3,7 @@ import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "n
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
 import { basename, dirname, join, relative, resolve } from "node:path"
-import { assertRuntimeCommandAllowed } from "@chubes4/wp-codebox-core"
+import { assertRuntimeCommandAllowed, calculateArtifactManifestFileSha256 } from "@chubes4/wp-codebox-core"
 import {
   MAX_CAPTURED_MOUNT_FILE_BYTES,
   MAX_CAPTURED_MOUNT_FILES,
@@ -498,23 +498,8 @@ class PlaygroundRuntime implements Runtime {
       ),
     ]
 
-    const manifest: ArtifactManifest = {
-      id: bundleId,
-      contentDigest: {
-        algorithm: "sha256",
-        inputs: ["files/changed-files.json", "files/patch.diff"],
-        value: contentDigest,
-      },
-      createdAt,
-      runtime,
-      files: manifestFiles.map((file) => ({
-        ...file,
-        path: relative(this.artifactRoot, file.path),
-      })),
-    }
     metadata.preview = preview
 
-    await writeRedactedArtifact(redactor, manifestPath, this.artifactRoot, `${JSON.stringify(manifest, null, 2)}\n`)
     await writeRedactedArtifact(redactor, blueprintAfterPath, this.artifactRoot, `${JSON.stringify(blueprintAfter, null, 2)}\n`)
     await writeRedactedArtifact(redactor, blueprintAfterNotesPath, this.artifactRoot, `${JSON.stringify(blueprintAfterNotes, null, 2)}\n`)
     await writeJsonLines(eventsPath, this.events, redactor, this.artifactRoot)
@@ -536,6 +521,36 @@ class PlaygroundRuntime implements Runtime {
     await writeRedactedArtifact(redactor, reviewPath, this.artifactRoot, `${JSON.stringify(review, null, 2)}\n`)
     metadata.redaction = redactor.summary()
     await writeRedactedArtifact(redactor, metadataPath, this.artifactRoot, `${JSON.stringify(metadata, null, 2)}\n`)
+
+    const manifest: ArtifactManifest = {
+      id: bundleId,
+      contentDigest: {
+        algorithm: "sha256",
+        inputs: ["files/changed-files.json", "files/patch.diff"],
+        value: contentDigest,
+      },
+      createdAt,
+      runtime,
+      files: manifestFiles.map((file) => ({
+        ...file,
+        path: relative(this.artifactRoot, file.path),
+      })),
+    }
+    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "manifest.json" ? file : ({
+      ...file,
+      sha256: {
+        algorithm: "sha256" as const,
+        value: await calculateArtifactManifestFileSha256(this.artifactRoot, manifest, file),
+      },
+    })))
+    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path !== "manifest.json" ? file : ({
+      ...file,
+      sha256: {
+        algorithm: "sha256" as const,
+        value: await calculateArtifactManifestFileSha256(this.artifactRoot, manifest, file),
+      },
+    })))
+    await writeRedactedArtifact(redactor, manifestPath, this.artifactRoot, `${JSON.stringify(manifest, null, 2)}\n`)
 
     return {
       id: bundleId,

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -5,7 +5,8 @@ import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { calculateArtifactContentDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
+import { calculateArtifactContentDigest, calculateArtifactManifestFileSha256, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
+import type { ArtifactManifest } from "@chubes4/wp-codebox-core"
 
 const execFileAsync = promisify(execFile)
 const root = resolve(import.meta.dirname, "..")
@@ -32,13 +33,24 @@ try {
 
   const traversalPath = await copyBundle(validBundle, join(workspace, "traversal-path"))
   const traversalManifest = manifestFixture(await calculateArtifactContentDigest(traversalPath, ["files/changed-files.json", "files/patch.diff"]))
-  traversalManifest.files.push({ path: "../escape.txt", kind: "file", contentType: "text/plain" })
+  traversalManifest.files.push(fileFixture("../escape.txt", "file", "text/plain"))
   await writeJson(join(traversalPath, "manifest.json"), traversalManifest)
   assertViolation(await verifyArtifactBundle(traversalPath), "invalid-path")
 
   const digestMismatch = await copyBundle(validBundle, join(workspace, "digest-mismatch"))
   await writeFile(join(digestMismatch, "files/patch.diff"), "diff --git a/file.txt b/file.txt\n+tampered\n")
   assertViolation(await verifyArtifactBundle(digestMismatch), "digest-mismatch")
+
+  const fileHashMismatch = await copyBundle(validBundle, join(workspace, "file-hash-mismatch"))
+  await writeFile(join(fileHashMismatch, "files/test-results.json"), "{\"tampered\":true}\n")
+  assertViolation(await verifyArtifactBundle(fileHashMismatch), "file-hash-mismatch")
+
+  const missingFileHash = await copyBundle(validBundle, join(workspace, "missing-file-hash"))
+  const missingHashManifest = manifestFixture(await calculateArtifactContentDigest(missingFileHash, ["files/changed-files.json", "files/patch.diff"]))
+  await attachManifestFileHashes(missingFileHash, missingHashManifest)
+  delete (missingHashManifest.files[2] as Partial<(typeof missingHashManifest.files)[number]>).sha256
+  await writeJson(join(missingFileHash, "manifest.json"), missingHashManifest)
+  assertViolation(await verifyArtifactBundle(missingFileHash), "missing-file-hash")
 
   const malformedManifest = join(workspace, "malformed-manifest")
   await mkdir(malformedManifest, { recursive: true })
@@ -75,10 +87,12 @@ async function writeValidBundle(directory: string): Promise<void> {
       testResults: "files/test-results.json",
     },
   })
-  await writeJson(join(directory, "manifest.json"), manifestFixture(digest))
+  const manifest = manifestFixture(digest)
+  await attachManifestFileHashes(directory, manifest)
+  await writeJson(join(directory, "manifest.json"), manifest)
 }
 
-function manifestFixture(digest: string) {
+function manifestFixture(digest: string): ArtifactManifest {
   return {
     id: `artifact-bundle-sha256-${digest}`,
     contentDigest: {
@@ -95,13 +109,30 @@ function manifestFixture(digest: string) {
       createdAt: "2026-05-27T00:00:00.000Z",
     },
     files: [
-      { path: "manifest.json", kind: "manifest", contentType: "application/json" },
-      { path: "metadata.json", kind: "metadata", contentType: "application/json" },
-      { path: "files/changed-files.json", kind: "changed-files", contentType: "application/json" },
-      { path: "files/patch.diff", kind: "patch", contentType: "text/x-diff" },
-      { path: "files/review.json", kind: "review", contentType: "application/json" },
-      { path: "files/test-results.json", kind: "test-results", contentType: "application/json" },
+      fileFixture("manifest.json", "manifest", "application/json"),
+      fileFixture("metadata.json", "metadata", "application/json"),
+      fileFixture("files/changed-files.json", "changed-files", "application/json"),
+      fileFixture("files/patch.diff", "patch", "text/x-diff"),
+      fileFixture("files/review.json", "review", "application/json"),
+      fileFixture("files/test-results.json", "test-results", "application/json"),
     ],
+  }
+}
+
+function fileFixture(path: string, kind: string, contentType: string): ArtifactManifest["files"][number] {
+  return { path, kind, contentType, sha256: { algorithm: "sha256", value: "0".repeat(64) } }
+}
+
+async function attachManifestFileHashes(directory: string, manifest: ArtifactManifest): Promise<void> {
+  for (const file of manifest.files) {
+    if (file.path !== "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
+    }
+  }
+  for (const file of manifest.files) {
+    if (file.path === "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add per-file SHA-256 digests to artifact manifest entries
- verify every declared file hash, including an explicit canonical self-hash for manifest.json
- refresh hashes when runtime evidence files update manifest, metadata, and review artifacts
- extend artifact verifier smoke coverage for valid, missing hash, mismatched hash, and tampered artifact cases

Fixes #190.

## Checks run
- npm run build
- npm run artifact-bundle-verifier-smoke
- git diff --check

## Blocked / not run
- npm run artifact-contract-smoke hit local port conflict: 127.0.0.1:60060 is already owned by .opencode
- npm run recipe-runtime-evidence-smoke timed out locally while booting/tearing down Playground

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented per-file artifact hash writing and verification, updated smoke coverage and docs; Chris remains responsible for review and merge.