### PR TITLE
Accept artifacts option for bundle verifier

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3136,6 +3136,7 @@ function parseArtifactVerifyOptions(args: string[]): ArtifactVerifyOptions {
 
     switch (name) {
       case "--bundle":
+      case "--artifacts":
         options.bundleDirectory = value
         break
       default:

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -251,6 +251,7 @@ export function printHelp(): void {
 Options:
   --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
   --bundle <dir>      Artifact bundle directory for artifacts verify.
+  --artifacts <dir>   Artifact root directory. Also accepted by artifacts verify.
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
   --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.plugin-check, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -23,6 +23,9 @@ try {
   const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "verify", "--bundle", validBundle, "--json"], { cwd: root })
   assert.equal(JSON.parse(stdout).valid, true)
 
+  const artifactsOption = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "verify", "--artifacts", validBundle, "--json"], { cwd: root })
+  assert.equal(JSON.parse(artifactsOption.stdout).valid, true)
+
   const missingManifest = join(workspace, "missing-manifest")
   await mkdir(missingManifest, { recursive: true })
   assertViolation(await verifyArtifactBundle(missingManifest), "missing-manifest")


### PR DESCRIPTION
## Summary
- accept `--artifacts` as an alias for `--bundle` in `wp-codebox artifacts verify`
- cover the downstream artifact-root invocation in the bundle verifier smoke test

## Testing
- `npm run build`
- `npm run artifact-bundle-verifier-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the downstream Homeboy runner failure and drafted the CLI option alias/test; Chris remains responsible for review and merge.
