### PR TITLE
Fix sandbox agent mode routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,7 @@
         "toidentifier": "^1.0.1",
         "type-is": "^1.6.18",
         "typed-array-buffer": "^1.0.3",
+        "typescript": "^5.8.0",
         "undici-types": "^7.16.0",
         "universal-github-app-jwt": "^1.2.0",
         "universal-user-agent": "^6.0.1",
@@ -194,8 +195,7 @@
       "devDependencies": {
         "@types/node": "^24.0.0",
         "playwright": "^1.60.0",
-        "tsx": "^4.20.0",
-        "typescript": "^5.8.0"
+        "tsx": "^4.20.0"
       }
     },
     "node_modules/@chubes4/wp-codebox-cli": {
@@ -3522,7 +3522,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "playwright": "^1.60.0",
-    "tsx": "^4.20.0",
-    "typescript": "^5.8.0"
+    "tsx": "^4.20.0"
   },
   "description": "**WP Codebox unlocks secure WordPress code execution from anywhere.** Run agents, accept untrusted patches, evaluate plugins, reproduce bugs, or experiment freely — every sandbox is a disposable WordPress Playground that can't touch its caller. Your host can be a CLI, CI job, mobile app, Node service, WordPress plugin, or anything else that can shell out or hit an API.",
   "main": "index.js",
@@ -237,6 +236,7 @@
     "to-buffer": "^1.2.2",
     "toidentifier": "^1.0.1",
     "type-is": "^1.6.18",
+    "typescript": "^5.8.0",
     "typed-array-buffer": "^1.0.3",
     "undici-types": "^7.16.0",
     "universal-github-app-jwt": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc -b packages/runtime-core packages/runtime-playground packages/cli",
+    "build": "node ./node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli",
     "prepare": "npm run build",
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
     "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",

--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -184,7 +184,7 @@ echo json_encode($sandbox_agent_runtime, JSON_PRETTY_PRINT);
 function sandboxToolContract(): Record<string, unknown> {
   return {
     schema: "wp-codebox/sandbox-dmc-tools/v1",
-    modes: ["pipeline", "sandbox"],
+    modes: ["chat", "sandbox"],
     tools: sandboxToolNames(),
     safe_abilities: [...SANDBOX_DMC_SAFE_ABILITIES],
     parent_only_abilities: [...SANDBOX_DMC_PARENT_ONLY_ABILITIES],
@@ -196,7 +196,7 @@ function sandboxToolNames(): string[] {
 }
 
 function sandboxAgentModes(mode: string): string[] {
-  return Array.from(new Set([mode, "pipeline"].filter(Boolean)))
+  return Array.from(new Set([mode, "chat"].filter(Boolean)))
 }
 
 function sandboxModeGuidance(): string {

--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -140,6 +140,143 @@ add_filter('datamachine_agent_mode_sandbox', static function (string $content): 
     return trim($content) === '' ? $guidance : trim($content) . "\n\n" . $guidance;
 }, 100, 1);
 
+if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') && !class_exists('WP_Codebox_Sandbox_Perception_Directive')) {
+    final class WP_Codebox_Sandbox_Perception_Directive implements DataMachine\\Engine\\AI\\Directives\\DirectiveInterface {
+        private const TREE_MAX_DEPTH = 2;
+
+        public static function get_outputs(string $provider_name, array $tools, ?string $step_id = null, array $payload = array()): array {
+            unset($provider_name, $step_id);
+            $workspace_root = defined('DATAMACHINE_WORKSPACE_PATH') ? DATAMACHINE_WORKSPACE_PATH : (${JSON.stringify(SANDBOX_WORKSPACE_ROOT)});
+            $sections = array(
+                self::section_header(),
+                self::section_workspace((string) $workspace_root),
+                self::section_runtime(),
+                self::section_tools($tools, is_array($payload['client_context']['tool_contract'] ?? null) ? $payload['client_context']['tool_contract'] : array()),
+                self::section_outcome(),
+            );
+            $content = trim(implode("\n\n", array_filter($sections, static fn(string $section): bool => '' !== $section)));
+            if ('' === $content) {
+                return array();
+            }
+            return array(array('type' => 'system_text', 'content' => $content));
+        }
+
+        private static function section_header(): string {
+            return implode("\n", array(
+                '# WP Codebox Sandbox Perception',
+                '',
+                'Live snapshot of the disposable WP Codebox sandbox at the start of this run. Use it as your starting awareness; workspace tools remain available for targeted inspection and edits.',
+            ));
+        }
+
+        private static function section_workspace(string $workspace_root): string {
+            if ('' === $workspace_root || !is_dir($workspace_root)) {
+                return '';
+            }
+            $entries = self::scan_tree($workspace_root, $workspace_root, 0);
+            sort($entries, SORT_STRING);
+            $lines = array(
+                '## Workspace',
+                '',
+                sprintf('- Root: %s', $workspace_root),
+                sprintf('- Tree depth: %d', self::TREE_MAX_DEPTH),
+                '',
+                'Tree:',
+            );
+            foreach ($entries as $entry) {
+                $lines[] = $entry;
+            }
+            return implode("\n", $lines);
+        }
+
+        private static function scan_tree(string $base, string $current, int $depth): array {
+            if ($depth > self::TREE_MAX_DEPTH) {
+                return array();
+            }
+            $ignored = array('.git', 'node_modules', 'vendor', 'dist', 'build', '.homeboy-build');
+            $items = scandir($current);
+            if (false === $items) {
+                return array();
+            }
+            $results = array();
+            foreach ($items as $item) {
+                if ('.' === $item || '..' === $item || in_array($item, $ignored, true)) {
+                    continue;
+                }
+                $path = $current . '/' . $item;
+                $relative = ltrim(substr($path, strlen($base)), '/');
+                if (is_dir($path)) {
+                    $results[] = $relative . '/';
+                    $results = array_merge($results, self::scan_tree($base, $path, $depth + 1));
+                    continue;
+                }
+                $results[] = $relative;
+            }
+            return $results;
+        }
+
+        private static function section_runtime(): string {
+            $plugins = array();
+            foreach ((array) get_option('active_plugins', array()) as $plugin_file) {
+                $plugins[] = '- ' . (string) $plugin_file;
+            }
+            $lines = array(
+                '## Runtime',
+                '',
+                sprintf('- WordPress: %s', get_bloginfo('version')),
+                sprintf('- PHP: %s', PHP_VERSION),
+            );
+            if (!empty($plugins)) {
+                $lines[] = '';
+                $lines[] = 'Active plugins:';
+                $lines = array_merge($lines, $plugins);
+            }
+            return implode("\n", $lines);
+        }
+
+        private static function section_tools(array $tools, array $tool_contract): string {
+            $tool_names = array_keys($tools);
+            sort($tool_names, SORT_STRING);
+            $contract_tools = array_values(array_filter((array) ($tool_contract['tools'] ?? array()), 'is_string'));
+            sort($contract_tools, SORT_STRING);
+            $lines = array('## Tool Surface', '');
+            if (!empty($tool_names)) {
+                $lines[] = 'Resolved tools:';
+                foreach ($tool_names as $tool_name) {
+                    $lines[] = sprintf('- %s', $tool_name);
+                }
+            }
+            if (!empty($contract_tools)) {
+                $lines[] = '';
+                $lines[] = 'Sandbox contract tools:';
+                foreach ($contract_tools as $tool_name) {
+                    $lines[] = sprintf('- %s', $tool_name);
+                }
+            }
+            return implode("\n", $lines);
+        }
+
+        private static function section_outcome(): string {
+            return implode("\n", array(
+                '## Outcome Contract',
+                '',
+                'Make repository changes through workspace tools when the task calls for code changes. The parent WP Codebox run captures sandbox diffs as reviewed artifacts; return a concise final outcome that includes changed files, verification, and any PR or false-positive disposition when available.',
+            ));
+        }
+    }
+}
+
+add_filter('datamachine_directives', static function (array $directives): array {
+    if (class_exists('WP_Codebox_Sandbox_Perception_Directive')) {
+        $directives[] = array(
+            'class' => 'WP_Codebox_Sandbox_Perception_Directive',
+            'priority' => 25,
+            'modes' => array('sandbox'),
+        );
+    }
+    return $directives;
+});
+
 $ability = function_exists('wp_get_ability') ? wp_get_ability('agents/chat') : null;
 if (!$ability || !method_exists($ability, 'execute')) {
     $sandbox_agent_runtime = array(

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -10,8 +10,9 @@ async function main() {
     model: "opencode-go/kimi-k2.6",
   })
 
-  assert.match(code, /\\"modes\\":\[\\"sandbox\\",\\"pipeline\\"\]/, "sandbox chat input should inherit pipeline tool surface")
-  assert.match(code, /\\"agent_modes\\":\[\\"sandbox\\",\\"pipeline\\"\]/, "client context should report additive sandbox modes")
+  assert.match(code, /\\"modes\\":\[\\"sandbox\\",\\"chat\\"\]/, "sandbox chat input should inherit chat tool surface")
+  assert.match(code, /\\"agent_modes\\":\[\\"sandbox\\",\\"chat\\"\]/, "client context should report additive sandbox modes without pipeline completion semantics")
+  assert.doesNotMatch(code, /\\"pipeline\\"/, "sandbox agents should not use pipeline mode because it completes after handler tools")
   assert.match(code, /\\"tool_policy\\":\{\\"mode\\":\\"allow\\",\\"tools\\":\[.*\\"workspace_read\\"/, "sandbox agent should allow workspace tools")
   assert.match(code, /datamachine_agent_mode_sandbox/, "sandbox mode should inject tool guidance")
   assert.match(code, /datamachine_code_remote_workspace_backend_should_handle/, "sandbox mode should use the mounted workspace backend")

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -15,6 +15,8 @@ async function main() {
   assert.doesNotMatch(code, /\\"pipeline\\"/, "sandbox agents should not use pipeline mode because it completes after handler tools")
   assert.match(code, /\\"tool_policy\\":\{\\"mode\\":\\"allow\\",\\"tools\\":\[.*\\"workspace_read\\"/, "sandbox agent should allow workspace tools")
   assert.match(code, /datamachine_agent_mode_sandbox/, "sandbox mode should inject tool guidance")
+  assert.match(code, /WP_Codebox_Sandbox_Perception_Directive/, "sandbox mode should inject a WP Codebox perception directive")
+  assert.match(code, /WP Codebox Sandbox Perception/, "sandbox perception should expose workspace context by default")
   assert.match(code, /datamachine_code_remote_workspace_backend_should_handle/, "sandbox mode should use the mounted workspace backend")
   assert.match(code, /Do not invent alternate tool names such as read_file/, "sandbox guidance should prevent pseudo-tool aliases")
   assert.match(code, /workspace_apply_patch/, "sandbox tool policy should include patch application")


### PR DESCRIPTION
## Summary
- route WP Codebox sandbox agents through the chat tool surface instead of pipeline mode
- register sandbox as a first-class Data Machine agent mode inside WP Codebox sandbox runs
- inject a WP Codebox sandbox perception directive with workspace tree, runtime state, tool surface, and outcome contract
- update smoke coverage to reject pipeline mode and require sandbox perception context
- keep TypeScript available during GitHub branch installs and use an explicit build-tool path

## Testing
- npm run build
- npm run agent-sandbox-code-smoke
- npm run discovery-command-smoke
- npm run wordpress-plugin-smoke
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the lab fanout failure, drafted the sandbox mode/perception and install-prep fixes plus smoke coverage, and ran focused verification; Chris remains responsible for review and merge.