### PR TITLE
Allow plugin-native agent sandbox paths

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -284,7 +284,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	 * @return array{agents_api:string,data_machine:string,data_machine_code:string}|WP_Error
 	 */
 	private function resolve_component_paths( array $input ): array|WP_Error {
-		$configured = $this->configured_paths();
+		$configured = array_merge( $this->default_component_paths(), $this->configured_paths() );
 		$paths      = array(
 			'agents_api'        => $this->clean_path( (string) ( $input['agents_api_path'] ?? $configured['agents_api'] ?? '' ) ),
 			'data_machine'      => $this->clean_path( (string) ( $input['data_machine_path'] ?? $configured['data_machine'] ?? '' ) ),
@@ -292,8 +292,45 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		);
 
 		foreach ( $paths as $key => $path ) {
-			if ( '' === $path || ! is_dir( $path ) ) {
+			if ( '' === $path ) {
+				if ( 'agents_api' !== $key ) {
+					continue;
+				}
+
 				return new WP_Error( 'wp_codebox_component_path_missing', sprintf( 'WP Codebox component path %s is missing or not a directory.', $key ), array( 'status' => 400 ) );
+			}
+
+			if ( ! is_dir( $path ) ) {
+				return new WP_Error( 'wp_codebox_component_path_missing', sprintf( 'WP Codebox component path %s is missing or not a directory.', $key ), array( 'status' => 400 ) );
+			}
+		}
+
+		return $paths;
+	}
+
+	/** @return array{agents_api:string,data_machine:string,data_machine_code:string} */
+	private function default_component_paths(): array {
+		$paths = array(
+			'agents_api'        => '',
+			'data_machine'      => '',
+			'data_machine_code' => '',
+		);
+
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			return $paths;
+		}
+
+		$plugin_dir = $this->clean_path( (string) WP_PLUGIN_DIR );
+		foreach (
+			array(
+				'agents_api'        => 'agents-api',
+				'data_machine'      => 'data-machine',
+				'data_machine_code' => 'data-machine-code',
+			) as $key => $slug
+		) {
+			$path = $plugin_dir . DIRECTORY_SEPARATOR . $slug;
+			if ( is_dir( $path ) ) {
+				$paths[ $key ] = $path;
 			}
 		}
 
@@ -1088,14 +1125,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'mounts'       => $mounts,
 				'inherit'      => $this->inheritance_request( $input ),
 				'inheritance'  => $inheritance,
-				'extraPlugins' => array_merge(
-					array(
-						array( 'source' => $paths['agents_api'], 'slug' => 'agents-api', 'activate' => false ),
-						array( 'source' => $paths['data_machine'], 'slug' => 'data-machine', 'activate' => false ),
-						array( 'source' => $paths['data_machine_code'], 'slug' => 'data-machine-code', 'activate' => false ),
-					),
-					$provider_plugins
-				),
+				'extraPlugins' => array_merge( $this->component_plugins( $paths ), $provider_plugins ),
 				'secretEnv'    => $this->secret_env_names( $input, $inheritance ),
 			),
 			'workflow' => array( 'steps' => $steps ),
@@ -1113,6 +1143,33 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return $file;
+	}
+
+	/**
+	 * @param array{agents_api:string,data_machine:string,data_machine_code:string} $paths Component paths.
+	 * @return array<int,array{source:string,slug:string,activate:bool}>
+	 */
+	private function component_plugins( array $paths ): array {
+		$plugins = array();
+		foreach (
+			array(
+				'agents_api'        => 'agents-api',
+				'data_machine'      => 'data-machine',
+				'data_machine_code' => 'data-machine-code',
+			) as $key => $slug
+		) {
+			if ( '' === $paths[ $key ] ) {
+				continue;
+			}
+
+			$plugins[] = array(
+				'source'   => $paths[ $key ],
+				'slug'     => $slug,
+				'activate' => false,
+			);
+		}
+
+		return $plugins;
 	}
 
 	private function generate_run_id(): string {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -94,10 +94,13 @@ require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machi
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
 
 $root = sys_get_temp_dir() . '/wp-codebox-wordpress-plugin-' . getmypid();
-foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'ai-provider-test', 'editable-plugin', 'artifacts', 'artifact-network-root' ) as $dir ) {
+foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'plugin-root/agents-api', 'ai-provider-test', 'editable-plugin', 'artifacts', 'artifact-network-root' ) as $dir ) {
 	mkdir( $root . '/' . $dir, 0777, true );
 }
 file_put_contents( $root . '/wp-codebox.js', "#!/usr/bin/env node\n" );
+if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+	define( 'WP_PLUGIN_DIR', $root . '/plugin-root' );
+}
 
 $failures = array();
 $total    = 0;
@@ -270,6 +273,28 @@ $assert( 'runner recipe passes provider plugin path', str_contains( $captured_re
 $assert( 'runner recipe passes generic mount metadata', str_contains( $captured_recipe, 'example/editable-plugin' ) && str_contains( $captured_recipe, 'repo_root_relative_to_mount' ) );
 $assert( 'runner recipe passes secret env name only', str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
 $assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
+
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] );
+$plugin_native_result = $runner->run(
+	array(
+		'goal'           => 'Run with the host-installed Agents API plugin only.',
+		'artifacts_path' => $root . '/artifacts',
+	)
+);
+$plugin_native_recipe  = json_decode( $captured_recipe, true );
+$plugin_native_plugins = array_map(
+	static fn( array $plugin ): string => (string) ( $plugin['slug'] ?? '' ),
+	$plugin_native_recipe['inputs']['extraPlugins'] ?? array()
+);
+$assert( 'runner defaults Agents API path from WP_PLUGIN_DIR', ! is_wp_error( $plugin_native_result ) && in_array( 'agents-api', $plugin_native_plugins, true ) );
+$assert( 'runner does not require Data Machine component paths', ! is_wp_error( $plugin_native_result ) && ! in_array( 'data-machine', $plugin_native_plugins, true ) && ! in_array( 'data-machine-code', $plugin_native_plugins, true ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] = array(
+	'agents_api'        => $root . '/agents-api',
+	'data_machine'      => $root . '/data-machine',
+	'data_machine_code' => $root . '/data-machine-code',
+	'provider_plugins'  => array( $root . '/ai-provider-test' ),
+);
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = '';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model']    = '';


### PR DESCRIPTION
## Summary
- default WP Codebox agent sandbox component paths from installed plugins under WP_PLUGIN_DIR
- require Agents API for agent sandbox runs while treating Data Machine and Data Machine Code mounts as optional
- omit missing optional components from generated recipes instead of failing before the run starts

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
- php -l tests/smoke-wordpress-plugin.php
- php tests/smoke-wordpress-plugin.php
- git diff --check

## Notes
This unblocks the first runtime failure seen from Studio Web: wp_codebox_component_path_missing for agents_api/data_machine/data_machine_code when WP Codebox is installed as a WordPress plugin rather than pointed at local component checkouts.

The WP Cloud runtime still lacks a Node executable, so this PR intentionally exposes the next real runtime issue instead of hiding it behind component path validation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Studio Web runtime failure and drafted the WP Codebox plugin-native path resolution fix and smoke coverage; Chris remains responsible for review and testing.