### PR TITLE
fix: include playground runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@chubes4/wp-codebox-cli": "file:packages/cli",
         "@chubes4/wp-codebox-core": "file:packages/runtime-core",
         "@chubes4/wp-codebox-playground": "file:packages/runtime-playground",
+        "@wp-playground/cli": "3.1.30",
         "abort-controller": "^3.0.0",
         "accepts": "^1.3.8",
         "aggregate-error": "^3.1.0",
@@ -135,6 +136,7 @@
         "path-expression-matcher": "^1.5.0",
         "path-to-regexp": "^0.1.13",
         "pify": "^4.0.1",
+        "playwright": "^1.60.0",
         "possible-typed-array-names": "^1.1.0",
         "process": "^0.11.10",
         "proxy-addr": "^2.0.7",
@@ -194,7 +196,6 @@
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
-        "playwright": "^1.60.0",
         "tsx": "^4.20.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   ],
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "playwright": "^1.60.0",
     "tsx": "^4.20.0"
   },
   "description": "**WP Codebox unlocks secure WordPress code execution from anywhere.** Run agents, accept untrusted patches, evaluate plugins, reproduce bugs, or experiment freely — every sandbox is a disposable WordPress Playground that can't touch its caller. Your host can be a CLI, CI job, mobile app, Node service, WordPress plugin, or anything else that can shell out or hit an API.",
@@ -81,6 +80,7 @@
     "@chubes4/wp-codebox-cli": "file:packages/cli",
     "@chubes4/wp-codebox-core": "file:packages/runtime-core",
     "@chubes4/wp-codebox-playground": "file:packages/runtime-playground",
+    "@wp-playground/cli": "3.1.30",
     "abort-controller": "^3.0.0",
     "accepts": "^1.3.8",
     "aggregate-error": "^3.1.0",
@@ -201,6 +201,7 @@
     "path-expression-matcher": "^1.5.0",
     "path-to-regexp": "^0.1.13",
     "pify": "^4.0.1",
+    "playwright": "^1.60.0",
     "possible-typed-array-names": "^1.1.0",
     "process": "^0.11.10",
     "proxy-addr": "^2.0.7",

--- a/scripts/package-distribution-smoke.ts
+++ b/scripts/package-distribution-smoke.ts
@@ -1,11 +1,25 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
-import { access } from "node:fs/promises"
+import { access, readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { promisify } from "node:util"
 
 const execFileAsync = promisify(execFile)
 const repoRoot = resolve(import.meta.dirname, "..")
+
+const rootPackage = JSON.parse(await readFile(resolve(repoRoot, "package.json"), "utf8")) as {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+assert.ok(
+  rootPackage.dependencies?.["@wp-playground/cli"],
+  "Published workspace package should install the Playground CLI runtime dependency",
+)
+assert.ok(
+  rootPackage.dependencies?.playwright,
+  "Published workspace package should install the Playwright runtime dependency",
+)
 
 const { stdout: packStdout } = await execFileAsync(
   "npm",


### PR DESCRIPTION
## Summary
- move Playwright into the published root package dependencies
- declare @wp-playground/cli on the published root package
- extend the package distribution smoke to catch missing runtime dependencies

## Tests
- npm run build
- npm run package-distribution-smoke
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the failed packed WP Codebox install, drafting the dependency fix, and running local smoke validation. Chris remains responsible for review and merge.