### PR TITLE
Add browser Playground session ability

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -62,6 +62,7 @@ final class WP_Codebox_Abilities {
 			$mount_schema      = self::mount_schema();
 			$inherit_schema    = self::inherit_schema();
 			$session_schema    = self::sandbox_session_schema();
+			$browser_session_schema = self::browser_playground_session_schema();
 			$session_input     = self::sandbox_session_input_schema();
 			$preview_schema    = self::preview_input_schema();
 			$artifact_id_schema = array(
@@ -267,6 +268,62 @@ final class WP_Codebox_Abilities {
 						),
 					),
 					'execute_callback'    => array( self::class, 'run_agent_task_batch' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/create-browser-playground-session',
+				array(
+					'label'               => 'Create Browser Playground Session',
+					'description'         => 'Prepare a WP Codebox browser-executed WordPress Playground session without requiring the host to run the WP Codebox CLI or Node.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'anyOf'      => array(
+							array( 'required' => array( 'goal' ) ),
+							array( 'required' => array( 'task' ) ),
+						),
+						'properties' => array(
+							'goal'               => $task_input_schema['properties']['goal'],
+							'task'               => array(
+								'type'        => 'string',
+								'description' => 'Legacy task description. Prefer goal for new product callers.',
+							),
+							'target'             => $task_input_schema['properties']['target'],
+							'allowed_tools'      => $task_input_schema['properties']['allowed_tools'],
+							'expected_artifacts' => $task_input_schema['properties']['expected_artifacts'],
+							'policy'             => $task_input_schema['properties']['policy'],
+							'context'            => $task_input_schema['properties']['context'],
+							'sandbox_session_id' => $session_input['sandbox_session_id'],
+							'orchestrator'       => $session_input['orchestrator'],
+							'playground'         => array(
+								'type'        => 'object',
+								'description' => 'Optional browser Playground client configuration overrides.',
+							),
+							'blueprint'          => array(
+								'type'        => 'object',
+								'description' => 'Optional WordPress Playground blueprint for the browser to compile and run.',
+							),
+							'artifact_files'     => array(
+								'type'        => 'array',
+								'description' => 'Optional text artifact files the browser should write into Playground.',
+								'items'       => array(
+									'type'       => 'object',
+									'required'   => array( 'path', 'content' ),
+									'properties' => array(
+										'path'        => array( 'type' => 'string' ),
+										'content'     => array( 'type' => 'string' ),
+										'kind'        => array( 'type' => 'string' ),
+										'description' => array( 'type' => 'string' ),
+									),
+								),
+							),
+						),
+					),
+					'output_schema'       => $browser_session_schema,
+					'execute_callback'    => array( self::class, 'create_browser_playground_session' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
@@ -573,6 +630,26 @@ final class WP_Codebox_Abilities {
 	}
 
 	/** @return array<string,mixed> */
+	private static function browser_playground_session_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'    => array( 'type' => 'boolean' ),
+				'schema'     => array( 'type' => 'string' ),
+				'execution'  => array(
+					'type'        => 'string',
+					'enum'        => array( 'browser-playground' ),
+					'description' => 'The caller browser executes WordPress Playground; the host site does not run the WP Codebox CLI.',
+				),
+				'session'    => array( 'type' => 'object' ),
+				'task_input' => self::task_input_schema(),
+				'playground' => array( 'type' => 'object' ),
+				'artifacts'  => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
 	private static function task_input_schema(): array {
 		return array(
 			'type'       => 'object',
@@ -629,6 +706,57 @@ final class WP_Codebox_Abilities {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function create_browser_playground_session( array $input ): array|WP_Error {
+		$task_input = self::normalize_task_input( $input );
+		if ( is_wp_error( $task_input ) ) {
+			return $task_input;
+		}
+
+		$session_id = trim( (string) ( $input['sandbox_session_id'] ?? $input['session_id'] ?? '' ) );
+		if ( '' === $session_id ) {
+			$session_id = self::generate_id();
+		}
+
+		$playground = is_array( $input['playground'] ?? null ) ? $input['playground'] : array();
+		$blueprint  = is_array( $input['blueprint'] ?? null ) ? $input['blueprint'] : array();
+		$artifacts  = self::browser_artifact_files( $input );
+		if ( is_wp_error( $artifacts ) ) {
+			return $artifacts;
+		}
+
+		return array(
+			'success'    => true,
+			'schema'     => 'wp-codebox/browser-playground-session/v1',
+			'execution'  => 'browser-playground',
+			'session'    => array(
+				'schema'       => 'wp-codebox/browser-playground-session/v1',
+				'id'           => $session_id,
+				'status'       => 'ready',
+				'persistence'  => 'external-orchestrator',
+				'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
+			),
+			'task_input' => $task_input,
+			'playground' => array(
+				'client_module_url' => (string) ( $playground['client_module_url'] ?? 'https://playground.automattic.ai/client/index.js' ),
+				'remote_url'        => (string) ( $playground['remote_url'] ?? 'https://playground.automattic.ai/remote.html' ),
+				'scope'             => (string) ( $playground['scope'] ?? $session_id ),
+				'blueprint'         => self::browser_playground_blueprint( $blueprint, $playground ),
+				'capabilities'      => array(
+					'compile_blueprint' => true,
+					'run_blueprint'     => true,
+					'write_file'        => true,
+					'run_php'           => true,
+				),
+			),
+			'artifacts'  => array(
+				'schema'             => 'wp-codebox/browser-artifacts/v1',
+				'files'              => $artifacts,
+				'expected_artifacts' => $task_input['expected_artifacts'],
+			),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function list_artifacts( array $input = array() ): array|WP_Error {
 		return ( new WP_Codebox_Artifacts() )->list( $input );
 	}
@@ -657,5 +785,91 @@ final class WP_Codebox_Abilities {
 		$allowed = current_user_can( 'manage_options' );
 
 		return (bool) apply_filters( 'wp_codebox_can_run_agent_task', $allowed );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private static function normalize_task_input( array $input ): array|WP_Error {
+		$goal = trim( (string) ( $input['goal'] ?? $input['task'] ?? '' ) );
+		if ( '' === $goal ) {
+			return new WP_Error( 'wp_codebox_task_missing', 'goal or task is required.', array( 'status' => 400 ) );
+		}
+
+		return array(
+			'schema'             => 'wp-codebox/task-input/v1',
+			'goal'               => $goal,
+			'target'             => is_array( $input['target'] ?? null ) ? $input['target'] : array(),
+			'allowed_tools'      => self::string_list( $input['allowed_tools'] ?? array() ),
+			'expected_artifacts' => self::string_list( $input['expected_artifacts'] ?? array() ),
+			'policy'             => is_array( $input['policy'] ?? null ) ? $input['policy'] : array(),
+			'context'            => is_array( $input['context'] ?? null ) ? $input['context'] : array(),
+		);
+	}
+
+	/** @return string[] */
+	private static function string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item && ! in_array( $item, $items, true ) ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,string>>|WP_Error */
+	private static function browser_artifact_files( array $input ): array|WP_Error {
+		$files = is_array( $input['artifact_files'] ?? null ) ? $input['artifact_files'] : array();
+		$normalized = array();
+		foreach ( $files as $index => $file ) {
+			if ( ! is_array( $file ) ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_file_invalid', 'Each browser artifact file must be an object.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			$path = trim( (string) ( $file['path'] ?? '' ) );
+			if ( '' === $path || str_contains( $path, '..' ) || str_starts_with( $path, '/' ) || ! preg_match( '#^[A-Za-z0-9_./-]+$#', $path ) ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must be safe relative paths.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			$normalized[] = array(
+				'path'        => $path,
+				'content'     => (string) ( $file['content'] ?? '' ),
+				'kind'        => (string) ( $file['kind'] ?? 'text' ),
+				'description' => (string) ( $file['description'] ?? '' ),
+			);
+		}
+
+		return $normalized;
+	}
+
+	/** @param array<string,mixed> $blueprint Blueprint override. @param array<string,mixed> $playground Playground config. @return array<string,mixed> */
+	private static function browser_playground_blueprint( array $blueprint, array $playground ): array {
+		if ( ! empty( $blueprint ) ) {
+			return $blueprint;
+		}
+
+		return array(
+			'preferredVersions' => array(
+				'wp'  => (string) ( $playground['wp'] ?? '6.9' ),
+				'php' => (string) ( $playground['php'] ?? '8.2' ),
+			),
+			'features'          => array(
+				'networking' => true,
+			),
+			'steps'             => array(),
+		);
+	}
+
+	private static function generate_id(): string {
+		if ( function_exists( 'wp_generate_uuid4' ) ) {
+			return wp_generate_uuid4();
+		}
+
+		return bin2hex( random_bytes( 16 ) );
 	}
 }

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -156,6 +156,13 @@ $assert( 'batch ability exposes preview configuration schema', 'integer' === ( $
 $assert( 'batch ability contract does not expose unimplemented concurrency', ! isset( $batch_ability['input_schema']['properties']['concurrency'] ) && ! isset( $batch_ability['output_schema']['properties']['concurrency'] ) );
 $assert( 'batch ability exposes per-task run outputs', isset( $batch_ability['output_schema']['properties']['runs']['items']['properties']['artifact_id'] ) && isset( $batch_ability['output_schema']['properties']['runs']['items']['properties']['preview_url'] ) && isset( $batch_ability['output_schema']['properties']['runs']['items']['properties']['error'] ) );
 
+$browser_session_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/create-browser-playground-session'] ?? null;
+$assert( 'browser Playground session ability registered', is_array( $browser_session_ability ) );
+$assert( 'browser Playground session ability is REST visible', true === ( $browser_session_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'browser Playground session accepts goal or legacy task', array( 'goal' ) === ( $browser_session_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_session_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
+$assert( 'browser Playground session exposes artifact file schema', 'array' === ( $browser_session_ability['input_schema']['properties']['artifact_files']['type'] ?? '' ) );
+$assert( 'browser Playground session output declares browser execution', array( 'browser-playground' ) === ( $browser_session_ability['output_schema']['properties']['execution']['enum'] ?? array() ) );
+
 $artifact_abilities = array(
 	'wp-codebox/list-artifacts',
 	'wp-codebox/get-artifact',
@@ -180,6 +187,46 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_default_agent'] = 'site-coder';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model'] = 'gpt-5.5';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_secret_env'] = array( 'OPENAI_API_KEY' );
+
+$browser_session = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'               => 'Prepare a Studio Web browser preview.',
+		'sandbox_session_id' => 'browser-session-123',
+		'target'             => array( 'kind' => 'static-site' ),
+		'allowed_tools'      => array( 'filesystem-write', 'filesystem-write', '' ),
+		'expected_artifacts' => array( 'static-site' ),
+		'orchestrator'       => array( 'id' => 'studio-web' ),
+		'artifact_files'     => array(
+			array(
+				'path'    => 'static-site/index.html',
+				'content' => '<main>Preview</main>',
+				'kind'    => 'static-html',
+			),
+		),
+	)
+);
+$assert( 'browser Playground session returns without shelling out', ! is_wp_error( $browser_session ) && true === ( $browser_session['success'] ?? false ) );
+$assert( 'browser Playground session schema is stable', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-playground-session/v1' === ( $browser_session['schema'] ?? '' ) );
+$assert( 'browser Playground session pins browser execution', ! is_wp_error( $browser_session ) && 'browser-playground' === ( $browser_session['execution'] ?? '' ) );
+$assert( 'browser Playground session includes Playground client URLs', ! is_wp_error( $browser_session ) && str_contains( $browser_session['playground']['client_module_url'] ?? '', 'playground.automattic.ai' ) && str_contains( $browser_session['playground']['remote_url'] ?? '', 'playground.automattic.ai' ) );
+$assert( 'browser Playground session includes default blueprint', ! is_wp_error( $browser_session ) && true === ( $browser_session['playground']['blueprint']['features']['networking'] ?? false ) && is_array( $browser_session['playground']['blueprint']['steps'] ?? null ) );
+$assert( 'browser Playground session preserves safe artifact files', ! is_wp_error( $browser_session ) && 'static-site/index.html' === ( $browser_session['artifacts']['files'][0]['path'] ?? '' ) );
+$assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
+
+$invalid_browser_file = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'           => 'Prepare an unsafe browser preview.',
+		'artifact_files' => array(
+			array(
+				'path'    => '../secret.txt',
+				'content' => 'nope',
+			),
+		),
+	)
+);
+$assert( 'browser Playground session rejects unsafe artifact paths', is_wp_error( $invalid_browser_file ) && 'wp_codebox_browser_artifact_path_invalid' === $invalid_browser_file->get_error_code() );
 
 $captured_command  = '';
 $captured_commands = array();


### PR DESCRIPTION
## Summary
- adds wp-codebox/create-browser-playground-session for browser-executed WordPress Playground previews
- returns stable session, task, artifact, Playground client URL, remote URL, capability, and blueprint data without shelling out
- validates browser artifact file paths and keeps task normalization consistent with the existing WP Codebox contract

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php
- php -l tests/smoke-wordpress-plugin.php
- php tests/smoke-wordpress-plugin.php
- git diff --check

## Notes
This introduces the WP Cloud-compatible execution surface needed by Studio Web: the WordPress host can prepare the session contract while the browser runs WordPress Playground. It does not replace the existing CLI-backed sandbox abilities.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the browser Playground session ability, schema, and smoke coverage from the Studio Web runtime requirements; Chris remains responsible for review and testing.