### PR TITLE
Classify agent sandbox remediation outcomes

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -65,6 +65,7 @@ final class WP_Codebox_Abilities {
 			$browser_session_schema = self::browser_playground_session_schema();
 			$session_input     = self::sandbox_session_input_schema();
 			$preview_schema    = self::preview_input_schema();
+			$outcome_schema    = self::remediation_outcome_schema();
 			$artifact_id_schema = array(
 				'artifact_id'    => array(
 					'type'        => 'string',
@@ -170,6 +171,7 @@ final class WP_Codebox_Abilities {
 							'paths'     => array( 'type' => 'object' ),
 							'artifacts' => array( 'type' => 'string' ),
 							'exit_code' => array( 'type' => 'integer' ),
+							'outcome'   => $outcome_schema,
 							'run'       => array( 'type' => 'object' ),
 						),
 					),
@@ -260,6 +262,7 @@ final class WP_Codebox_Abilities {
 										'artifact_id' => array( 'type' => 'string' ),
 										'preview_url' => array( 'type' => 'string' ),
 										'artifacts'   => array( 'type' => 'object' ),
+										'outcome'     => $outcome_schema,
 										'run'         => array( 'type' => 'object' ),
 										'error'       => array( 'type' => 'object' ),
 									),
@@ -595,6 +598,33 @@ final class WP_Codebox_Abilities {
 					'type'   => array( 'type' => 'string' ),
 					'job_id' => array( 'type' => 'string' ),
 				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function remediation_outcome_schema(): array {
+		return array(
+			'type'        => 'object',
+			'description' => 'Strict audit-remediation terminal outcome. Successful outcomes require a fix PR or false-positive PR URL; failure outcomes are machine-classified.',
+			'properties'  => array(
+				'schema'                => array( 'type' => 'string' ),
+				'success'               => array( 'type' => 'boolean' ),
+				'kind'                  => array(
+					'type' => 'string',
+					'enum' => array( 'fix_pr', 'false_positive_pr', 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
+				),
+				'failure'               => array(
+					'type' => 'string',
+					'enum' => array( 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
+				),
+				'pr_url'                => array( 'type' => 'string' ),
+				'false_positive_pr_url' => array( 'type' => 'string' ),
+				'exit_code'             => array( 'type' => 'integer' ),
+				'retryable'             => array( 'type' => 'boolean' ),
+				'provider_error'        => array( 'type' => 'object' ),
+				'metadata'              => array( 'type' => 'object' ),
+				'diagnostics'           => array( 'type' => 'object' ),
 			),
 		);
 	}

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -14,6 +14,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const SESSION_SCHEMA = 'wp-codebox/sandbox-session/v1';
 	private const TASK_INPUT_SCHEMA = 'wp-codebox/task-input/v1';
 	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
+	private const REMEDIATION_OUTCOME_SCHEMA = 'wp-codebox/agent-sandbox-remediation-outcome/v1';
 	private const DEFAULT_SANDBOX_TOOLS = array(
 		'datamachine/workspace-read',
 		'datamachine/workspace-ls',
@@ -157,7 +158,10 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			);
 		}
 
-		if ( 0 !== $exit_code ) {
+		$strict_remediation_outcome = $this->strict_remediation_outcome( $task_input );
+		$outcome                    = $strict_remediation_outcome ? $this->remediation_outcome( $decoded, $exit_code, $output ) : null;
+
+		if ( 0 !== $exit_code && ! $strict_remediation_outcome ) {
 			return new WP_Error(
 				'wp_codebox_run_failed',
 				'WP Codebox agent sandbox run failed.',
@@ -170,8 +174,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			);
 		}
 
-		return array(
-			'success'   => true,
+		$response = array(
+			'success'   => $strict_remediation_outcome ? (bool) ( $outcome['success'] ?? false ) : true,
 			'schema'    => self::SCHEMA,
 			'session'   => $this->sandbox_session( $session_id, 'completed', $input, $decoded, $artifacts ),
 			'task'      => $task,
@@ -182,6 +186,12 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'exit_code' => $exit_code,
 			'run'       => $decoded,
 		);
+
+		if ( null !== $outcome ) {
+			$response['outcome'] = $outcome;
+		}
+
+		return $response;
 	}
 
 	/**
@@ -861,6 +871,217 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'denied_tools'  => $denied,
 				'allowed_tools' => $allowed,
 			)
+		);
+	}
+
+	/** @param array<string,mixed> $task_input Normalized task input. */
+	private function strict_remediation_outcome( array $task_input ): bool {
+		$target = is_array( $task_input['target'] ?? null ) ? $task_input['target'] : array();
+		$policy = is_array( $task_input['policy'] ?? null ) ? $task_input['policy'] : array();
+		$expected_artifacts = is_array( $task_input['expected_artifacts'] ?? null ) ? $task_input['expected_artifacts'] : array();
+
+		foreach ( array( $target['kind'] ?? '', $policy['kind'] ?? '', $policy['outcome_contract'] ?? '', $policy['outcomeContract'] ?? '' ) as $value ) {
+			$value = strtolower( str_replace( '_', '-', trim( (string) $value ) ) );
+			if ( in_array( $value, array( 'audit-remediation', 'agent-sandbox-remediation', 'remediation-outcome' ), true ) ) {
+				return true;
+			}
+		}
+
+		foreach ( $expected_artifacts as $artifact ) {
+			$artifact = strtolower( str_replace( '_', '-', trim( (string) $artifact ) ) );
+			if ( in_array( $artifact, array( 'fix-pr', 'false-positive-pr', 'remediation-pr' ), true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
+	private function remediation_outcome( array $run, int $exit_code, string $output ): array {
+		$datamachine = $this->first_datamachine_metadata( $run );
+		$max_turns_reached = $this->recursive_truthy_key( $run, 'max_turns_reached' ) || true === ( $datamachine['max_turns_reached'] ?? false );
+		$provider_error = $this->provider_error_details( $run, $output );
+		$pr_url = $this->first_url_for_keys( $run, array( 'pr_url', 'pull_request_url', 'pullRequestUrl' ) );
+		$false_positive_pr_url = $this->first_url_for_keys( $run, array( 'false_positive_pr_url', 'falsePositivePrUrl' ) );
+
+		$outcome = array(
+			'schema'      => self::REMEDIATION_OUTCOME_SCHEMA,
+			'success'     => false,
+			'kind'        => 'agent_no_pr_outcome',
+			'failure'     => 'agent_no_pr_outcome',
+			'exit_code'   => $exit_code,
+			'retryable'   => false,
+			'diagnostics' => array_filter(
+				array(
+					'datamachine_completed' => array_key_exists( 'completed', $datamachine ) ? (bool) $datamachine['completed'] : null,
+					'max_turns_reached'     => $max_turns_reached,
+				),
+				static fn( mixed $value ): bool => null !== $value
+			),
+		);
+
+		if ( ! empty( $datamachine ) ) {
+			$outcome['metadata'] = array( 'datamachine' => $datamachine );
+		}
+
+		if ( '' !== $false_positive_pr_url ) {
+			$outcome['success'] = true;
+			$outcome['kind'] = 'false_positive_pr';
+			$outcome['false_positive_pr_url'] = $false_positive_pr_url;
+			unset( $outcome['failure'] );
+			return $outcome;
+		}
+
+		if ( '' !== $pr_url ) {
+			$outcome['success'] = true;
+			$outcome['kind'] = 'fix_pr';
+			$outcome['pr_url'] = $pr_url;
+			unset( $outcome['failure'] );
+			return $outcome;
+		}
+
+		if ( $max_turns_reached ) {
+			$outcome['kind'] = 'max_turns_exceeded';
+			$outcome['failure'] = 'max_turns_exceeded';
+			$outcome['retryable'] = true;
+			return $outcome;
+		}
+
+		if ( 0 !== $exit_code || ! empty( $provider_error ) ) {
+			$outcome['kind'] = 'provider_error';
+			$outcome['failure'] = 'provider_error';
+			$outcome['provider_error'] = $provider_error;
+			$outcome['retryable'] = (bool) ( $provider_error['retryable'] ?? true );
+		}
+
+		return $outcome;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
+	private function first_datamachine_metadata( array $run ): array {
+		$payloads = array_merge( array( $run ), $this->agent_payloads( $run ) );
+		foreach ( $payloads as $payload ) {
+			$metadata = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
+			$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
+			if ( ! empty( $datamachine ) ) {
+				return $datamachine;
+			}
+		}
+
+		return array();
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @return array<int,array<string,mixed>> */
+	private function agent_payloads( array $run ): array {
+		$payloads = array();
+		foreach ( is_array( $run['executions'] ?? null ) ? $run['executions'] : array() as $execution ) {
+			if ( ! is_array( $execution ) ) {
+				continue;
+			}
+
+			foreach ( array( 'stdout', 'stderr' ) as $stream ) {
+				$decoded = $this->decode_json_fragment( (string) ( $execution[ $stream ] ?? '' ) );
+				if ( is_array( $decoded ) ) {
+					$payloads[] = is_array( $decoded['result'] ?? null ) ? $decoded['result'] : $decoded;
+				}
+			}
+		}
+
+		return $payloads;
+	}
+
+	/** @return array<string,mixed>|null */
+	private function decode_json_fragment( string $text ): ?array {
+		$text = trim( $text );
+		if ( '' === $text ) {
+			return null;
+		}
+
+		$decoded = json_decode( $text, true );
+		if ( is_array( $decoded ) ) {
+			return $decoded;
+		}
+
+		$start = strpos( $text, '{' );
+		$end   = strrpos( $text, '}' );
+		if ( false === $start || false === $end || $end <= $start ) {
+			return null;
+		}
+
+		$decoded = json_decode( substr( $text, $start, $end - $start + 1 ), true );
+
+		return is_array( $decoded ) ? $decoded : null;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @param string[] $keys */
+	private function first_url_for_keys( array $run, array $keys ): string {
+		foreach ( array_merge( array( $run ), $this->agent_payloads( $run ) ) as $payload ) {
+			$url = $this->recursive_first_string_key( $payload, $keys );
+			if ( '' !== $url && preg_match( '#^https://github\.com/[^/\s]+/[^/\s]+/pull/\d+#', $url ) ) {
+				return $url;
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $payload @param string[] $keys */
+	private function recursive_first_string_key( array $payload, array $keys ): string {
+		foreach ( $payload as $key => $value ) {
+			if ( in_array( (string) $key, $keys, true ) && ! is_array( $value ) && '' !== trim( (string) $value ) ) {
+				return trim( (string) $value );
+			}
+
+			if ( is_array( $value ) ) {
+				$nested = $this->recursive_first_string_key( $value, $keys );
+				if ( '' !== $nested ) {
+					return $nested;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $payload */
+	private function recursive_truthy_key( array $payload, string $needle ): bool {
+		foreach ( $payload as $key => $value ) {
+			if ( $needle === (string) $key && true === (bool) $value ) {
+				return true;
+			}
+
+			if ( is_array( $value ) && $this->recursive_truthy_key( $value, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
+	private function provider_error_details( array $run, string $output ): array {
+		$payloads = array_merge( array( $run ), $this->agent_payloads( $run ) );
+		$json     = function_exists( 'wp_json_encode' ) ? wp_json_encode( $payloads, JSON_UNESCAPED_SLASHES ) : json_encode( $payloads, JSON_UNESCAPED_SLASHES );
+		$encoded  = strtolower( is_string( $json ) ? $json : '' );
+		$output_l = strtolower( $output );
+		$haystack = $encoded . "\n" . $output_l;
+
+		if ( ! preg_match( '/provider|timeout|timed out|429|rate limit|too many requests|openai|anthropic/', $haystack ) ) {
+			return array();
+		}
+
+		$message = $this->recursive_first_string_key( $run, array( 'message', 'error', 'error_message', 'errorMessage', 'details' ) );
+		if ( '' === $message ) {
+			$message = $this->bound_output( $output );
+		}
+
+		return array_filter(
+			array(
+				'message'   => $this->bound_output( $message ),
+				'retryable' => (bool) preg_match( '/timeout|timed out|429|rate limit|too many requests/', $haystack ),
+			),
+			static fn( mixed $value ): bool => null !== $value && '' !== $value
 		);
 	}
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -145,6 +145,7 @@ $assert( 'ability exposes external sandbox session schema', 'string' === ( $abil
 $assert( 'session schema pins external orchestrator persistence', array( 'external-orchestrator' ) === ( $ability['output_schema']['properties']['session']['properties']['persistence']['enum'] ?? array() ) && str_contains( $ability['output_schema']['properties']['session']['properties']['persistence']['description'] ?? '', 'does not persist' ) );
 $assert( 'session schema keeps durable lifecycle external', array( 'completed' ) === ( $ability['output_schema']['properties']['session']['properties']['status']['enum'] ?? array() ) && str_contains( $ability['output_schema']['properties']['session']['properties']['status']['description'] ?? '', 'external orchestrator' ) );
 $assert( 'ability exposes preview configuration schema', 'integer' === ( $ability['input_schema']['properties']['preview_port']['type'] ?? '' ) && 'string' === ( $ability['input_schema']['properties']['preview_bind']['type'] ?? '' ) && 'string' === ( $ability['input_schema']['properties']['preview_public_url']['type'] ?? '' ) );
+$assert( 'ability exposes strict remediation outcome schema', isset( $ability['output_schema']['properties']['outcome']['properties']['kind']['enum'] ) && in_array( 'provider_error', $ability['output_schema']['properties']['outcome']['properties']['kind']['enum'], true ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
@@ -546,6 +547,103 @@ $assert( 'runner preserves structured target', ! is_wp_error( $structured_result
 $assert( 'runner normalizes task input lists', ! is_wp_error( $structured_result ) && array( 'workspace.read', 'workspace.write', 'datamachine/workspace-read' ) === ( $structured_result['task_input']['allowed_tools'] ?? array() ) && array( 'patch', 'tests' ) === ( $structured_result['task_input']['expected_artifacts'] ?? array() ) );
 $assert( 'runner passes structured task contract to recipe', str_contains( $captured_recipe, 'wp-codebox/task-input/v1' ) && str_contains( $captured_recipe, 'allowed_tools' ) );
 $assert( 'runner leaves preview config unset by default', ! str_contains( $captured_command, '--preview-port' ) && ! str_contains( $captured_command, '--preview-bind' ) && ! str_contains( $captured_command, '--preview-public-url' ) );
+
+$remediation_run = function ( array $agent_payload, int $exit_code = 0, array $run_overrides = array() ) use ( $root ): array|WP_Error {
+	$strict_runner = new WP_Codebox_Agent_Sandbox_Runner(
+		array(
+			'shell_available' => fn() => true,
+			'command_runner'  => function () use ( $agent_payload, $exit_code, $run_overrides ): array {
+				$run = array_merge(
+					array(
+						'success'    => 0 === $exit_code,
+						'schema'     => 'wp-codebox/recipe-run/v1',
+						'executions' => array(
+							array(
+								'command'  => 'wp-codebox.agent-sandbox-run',
+								'exitCode' => $exit_code,
+								'stdout'   => json_encode( array( 'result' => $agent_payload ) ),
+								'stderr'   => '',
+							),
+						),
+					),
+					$run_overrides
+				);
+
+				return array(
+					'exit_code' => $exit_code,
+					'output'    => json_encode( $run ),
+				);
+			},
+		)
+	);
+
+	return $strict_runner->run(
+		array(
+			'goal'               => 'Remediate audit finding.',
+			'target'             => array( 'kind' => 'audit-remediation' ),
+			'expected_artifacts' => array( 'fix_pr', 'false_positive_pr' ),
+			'artifacts_path'     => $root . '/artifacts',
+		)
+	);
+};
+
+$provider_error_result = $remediation_run(
+	array(
+		'error'    => array(
+			'message' => 'Provider timeout after OpenAI 429 Too Many Requests.',
+			'code'    => 'provider_rate_limited',
+		),
+		'metadata' => array(
+			'datamachine' => array(
+				'completed'         => false,
+				'max_turns_reached' => false,
+			),
+		),
+	),
+	1
+);
+$assert( 'strict remediation outcome classifies provider timeout and 429', ! is_wp_error( $provider_error_result ) && false === ( $provider_error_result['success'] ?? true ) && 'provider_error' === ( $provider_error_result['outcome']['kind'] ?? '' ) && true === ( $provider_error_result['outcome']['retryable'] ?? false ) );
+$assert( 'strict remediation outcome preserves provider and Data Machine diagnostics', ! is_wp_error( $provider_error_result ) && str_contains( $provider_error_result['outcome']['provider_error']['message'] ?? '', 'Provider timeout' ) && false === ( $provider_error_result['outcome']['metadata']['datamachine']['completed'] ?? true ) );
+
+$text_false_positive_result = $remediation_run(
+	array(
+		'answer'   => 'This looks like a false positive; no code changes are needed.',
+		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
+	)
+);
+$assert( 'strict remediation outcome rejects text-only false-positive conclusions without PR', ! is_wp_error( $text_false_positive_result ) && false === ( $text_false_positive_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $text_false_positive_result['outcome']['kind'] ?? '' ) );
+
+$normal_no_pr_result = $remediation_run(
+	array(
+		'answer'   => 'Done.',
+		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
+	)
+);
+$assert( 'strict remediation outcome rejects normal answers without PR', ! is_wp_error( $normal_no_pr_result ) && false === ( $normal_no_pr_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $normal_no_pr_result['outcome']['failure'] ?? '' ) );
+
+$fix_pr_result = $remediation_run(
+	array(
+		'pr_url'   => 'https://github.com/chubes4/wp-codebox/pull/2020',
+		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
+	)
+);
+$assert( 'strict remediation outcome accepts valid fix PR URL', ! is_wp_error( $fix_pr_result ) && true === ( $fix_pr_result['success'] ?? false ) && 'fix_pr' === ( $fix_pr_result['outcome']['kind'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/2020' === ( $fix_pr_result['outcome']['pr_url'] ?? '' ) );
+
+$false_positive_pr_result = $remediation_run(
+	array(
+		'false_positive_pr_url' => 'https://github.com/chubes4/wp-codebox/pull/2021',
+		'metadata'              => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
+	)
+);
+$assert( 'strict remediation outcome accepts valid false-positive PR URL', ! is_wp_error( $false_positive_pr_result ) && true === ( $false_positive_pr_result['success'] ?? false ) && 'false_positive_pr' === ( $false_positive_pr_result['outcome']['kind'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/2021' === ( $false_positive_pr_result['outcome']['false_positive_pr_url'] ?? '' ) );
+
+$max_turns_result = $remediation_run(
+	array(
+		'answer'   => 'Still working.',
+		'metadata' => array( 'datamachine' => array( 'completed' => false, 'max_turns_reached' => true ) ),
+	)
+);
+$assert( 'strict remediation outcome preserves max turns exhaustion', ! is_wp_error( $max_turns_result ) && false === ( $max_turns_result['success'] ?? true ) && 'max_turns_exceeded' === ( $max_turns_result['outcome']['kind'] ?? '' ) && true === ( $max_turns_result['outcome']['diagnostics']['max_turns_reached'] ?? false ) );
 
 $parent_only_tool = $runner->run(
 	array(


### PR DESCRIPTION
## Summary
- add a strict audit-remediation outcome envelope for agent sandbox runs
- classify fix PR, false-positive PR, provider errors, no-PR completions, and max-turn exhaustion
- expose the outcome schema through the WordPress ability contract and cover required cases in the smoke test

## Verification
- `npm run check`
- `php tests/smoke-wordpress-plugin.php`
- `npm run build`

Closes #202

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the remediation outcome classification implementation and smoke coverage; Chris remains responsible for review and merge.