### PR TITLE
Return sandbox remediation artifacts

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -439,7 +439,7 @@ do_action('init');
 do_action('wp_abilities_api_categories_init');
 do_action('wp_abilities_api_init');
 
-$sandbox_task = ${JSON.stringify(task)};
+$sandbox_task = ${phpStringLiteral(task)};
 $sandbox_stack = array(
     'plugins' => $activation_results,
     'signals' => array(
@@ -472,6 +472,11 @@ echo json_encode(
 
 function phpBody(code: string): string {
   return code.trimStart().replace(/^<\?php\s*/, "")
+}
+
+function phpStringLiteral(value: string): string {
+  const marker = `WP_CODEBOX_LITERAL_${Math.random().toString(36).slice(2).toUpperCase()}`
+  return `<<<'${marker}'\n${value}\n${marker}`
 }
 
 export function agentRuntimeProbeCode(providerPlugins: Array<{ slug: string }>): string {

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -606,13 +606,13 @@ final class WP_Codebox_Abilities {
 	private static function remediation_outcome_schema(): array {
 		return array(
 			'type'        => 'object',
-			'description' => 'Strict audit-remediation terminal outcome. Successful outcomes require a fix PR or false-positive PR URL; failure outcomes are machine-classified.',
+			'description' => 'Strict audit-remediation terminal outcome. Successful sandbox outcomes require a reviewed fix or false-positive artifact; parent orchestrators apply artifacts and open PRs outside the sandbox.',
 			'properties'  => array(
 				'schema'                => array( 'type' => 'string' ),
 				'success'               => array( 'type' => 'boolean' ),
 				'kind'                  => array(
 					'type' => 'string',
-					'enum' => array( 'fix_pr', 'false_positive_pr', 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
+					'enum' => array( 'fix_artifact', 'false_positive_artifact', 'fix_pr', 'false_positive_pr', 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
 				),
 				'failure'               => array(
 					'type' => 'string',
@@ -623,6 +623,7 @@ final class WP_Codebox_Abilities {
 				'exit_code'             => array( 'type' => 'integer' ),
 				'retryable'             => array( 'type' => 'boolean' ),
 				'provider_error'        => array( 'type' => 'object' ),
+				'artifact'              => array( 'type' => 'object' ),
 				'metadata'              => array( 'type' => 'object' ),
 				'diagnostics'           => array( 'type' => 'object' ),
 			),

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -889,7 +889,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		foreach ( $expected_artifacts as $artifact ) {
 			$artifact = strtolower( str_replace( '_', '-', trim( (string) $artifact ) ) );
-			if ( in_array( $artifact, array( 'fix-pr', 'false-positive-pr', 'remediation-pr' ), true ) ) {
+			if ( in_array( $artifact, array( 'fix-artifact', 'false-positive-artifact', 'remediation-artifact', 'fix-pr', 'false-positive-pr', 'remediation-pr' ), true ) ) {
 				return true;
 			}
 		}
@@ -904,6 +904,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$provider_error = $this->provider_error_details( $run, $output );
 		$pr_url = $this->first_url_for_keys( $run, array( 'pr_url', 'pull_request_url', 'pullRequestUrl' ) );
 		$false_positive_pr_url = $this->first_url_for_keys( $run, array( 'false_positive_pr_url', 'falsePositivePrUrl' ) );
+		$artifact = $this->remediation_artifact_details( $run );
+		$has_artifact_changes = ! empty( $artifact['changed_files'] );
+		$false_positive = $this->remediation_false_positive( $run );
 
 		$outcome = array(
 			'schema'      => self::REMEDIATION_OUTCOME_SCHEMA,
@@ -923,6 +926,29 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		if ( ! empty( $datamachine ) ) {
 			$outcome['metadata'] = array( 'datamachine' => $datamachine );
+		}
+
+		if ( $has_artifact_changes && $false_positive ) {
+			$outcome['success'] = true;
+			$outcome['kind'] = 'false_positive_artifact';
+			$outcome['artifact'] = $artifact;
+			$outcome['false_positive'] = true;
+			unset( $outcome['failure'] );
+			return $outcome;
+		}
+
+		if ( $has_artifact_changes ) {
+			$outcome['success'] = true;
+			$outcome['kind'] = 'fix_artifact';
+			$outcome['artifact'] = $artifact;
+			unset( $outcome['failure'] );
+			if ( '' !== $pr_url ) {
+				$outcome['pr_url'] = $pr_url;
+			}
+			if ( '' !== $false_positive_pr_url ) {
+				$outcome['false_positive_pr_url'] = $false_positive_pr_url;
+			}
+			return $outcome;
 		}
 
 		if ( '' !== $false_positive_pr_url ) {
@@ -956,6 +982,52 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return $outcome;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. */
+	private function remediation_false_positive( array $run ): bool {
+		foreach ( array_merge( array( $run ), $this->agent_payloads( $run ) ) as $payload ) {
+			if ( $this->recursive_truthy_key( $payload, 'false_positive' ) || $this->recursive_truthy_key( $payload, 'falsePositive' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
+	private function remediation_artifact_details( array $run ): array {
+		$artifacts = is_array( $run['artifacts'] ?? null ) ? $run['artifacts'] : array();
+		$directory = $this->clean_path( (string) ( $artifacts['directory'] ?? $artifacts['path'] ?? '' ) );
+		$changed_files = array();
+
+		if ( '' !== $directory ) {
+			$changed_files_path = $directory . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'changed-files.json';
+			if ( is_readable( $changed_files_path ) ) {
+				$decoded = json_decode( (string) file_get_contents( $changed_files_path ), true );
+				foreach ( is_array( $decoded['files'] ?? null ) ? $decoded['files'] : array() as $file ) {
+					if ( is_array( $file ) ) {
+						$changed_files[] = array_filter(
+							array(
+								'path'          => (string) ( $file['path'] ?? '' ),
+								'relative_path' => (string) ( $file['relativePath'] ?? $file['relative_path'] ?? '' ),
+								'status'        => (string) ( $file['status'] ?? '' ),
+							),
+							static fn( mixed $value ): bool => '' !== $value
+						);
+					}
+				}
+			}
+		}
+
+		return array_filter(
+			array(
+				'id'            => (string) ( $artifacts['id'] ?? '' ),
+				'directory'     => $directory,
+				'changed_files' => $changed_files,
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
 	}
 
 	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.ts"
+import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.ts"
 
 async function main() {
   const code = await resolveSandboxTaskCode({
@@ -20,6 +20,14 @@ async function main() {
   assert.match(code, /datamachine_code_remote_workspace_backend_should_handle/, "sandbox mode should use the mounted workspace backend")
   assert.match(code, /Do not invent alternate tool names such as read_file/, "sandbox guidance should prevent pseudo-tool aliases")
   assert.match(code, /workspace_apply_patch/, "sandbox tool policy should include patch application")
+
+  const runCode = agentSandboxRunCode(
+    '{"prompt":"Do not interpolate $buckets, $meta, or $state_store."}',
+    '<?php echo "ok";',
+    [],
+  )
+  assert.match(runCode, /<<<'WP_CODEBOX_LITERAL_/, "sandbox task JSON should use a single-quoted nowdoc")
+  assert.doesNotMatch(runCode, /\$sandbox_task = "\{/, "sandbox task JSON should not use PHP double-quoted strings")
 }
 
 main().catch((error) => {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -548,6 +548,22 @@ $assert( 'runner normalizes task input lists', ! is_wp_error( $structured_result
 $assert( 'runner passes structured task contract to recipe', str_contains( $captured_recipe, 'wp-codebox/task-input/v1' ) && str_contains( $captured_recipe, 'allowed_tools' ) );
 $assert( 'runner leaves preview config unset by default', ! str_contains( $captured_command, '--preview-port' ) && ! str_contains( $captured_command, '--preview-bind' ) && ! str_contains( $captured_command, '--preview-public-url' ) );
 
+$remediation_artifact_run = function ( string $name, array $files ): array {
+	$directory = sys_get_temp_dir() . '/wp-codebox-remediation-artifact-' . $name . '-' . uniqid( '', true );
+	mkdir( $directory . '/files', 0777, true );
+	file_put_contents(
+		$directory . '/files/changed-files.json',
+		json_encode( array( 'schema' => 'wp-codebox/changed-files/v1', 'files' => $files ), JSON_PRETTY_PRINT )
+	);
+
+	return array(
+		'artifacts' => array(
+			'id'        => 'artifact-' . $name,
+			'directory' => $directory,
+		),
+	);
+};
+
 $remediation_run = function ( array $agent_payload, int $exit_code = 0, array $run_overrides = array() ) use ( $root ): array|WP_Error {
 	$strict_runner = new WP_Codebox_Agent_Sandbox_Runner(
 		array(
@@ -581,7 +597,7 @@ $remediation_run = function ( array $agent_payload, int $exit_code = 0, array $r
 		array(
 			'goal'               => 'Remediate audit finding.',
 			'target'             => array( 'kind' => 'audit-remediation' ),
-			'expected_artifacts' => array( 'fix_pr', 'false_positive_pr' ),
+			'expected_artifacts' => array( 'fix_artifact', 'false_positive_artifact' ),
 			'artifacts_path'     => $root . '/artifacts',
 		)
 	);
@@ -611,7 +627,7 @@ $text_false_positive_result = $remediation_run(
 		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
 	)
 );
-$assert( 'strict remediation outcome rejects text-only false-positive conclusions without PR', ! is_wp_error( $text_false_positive_result ) && false === ( $text_false_positive_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $text_false_positive_result['outcome']['kind'] ?? '' ) );
+$assert( 'strict remediation outcome rejects text-only false-positive conclusions without artifact', ! is_wp_error( $text_false_positive_result ) && false === ( $text_false_positive_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $text_false_positive_result['outcome']['kind'] ?? '' ) );
 
 $normal_no_pr_result = $remediation_run(
 	array(
@@ -619,23 +635,26 @@ $normal_no_pr_result = $remediation_run(
 		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
 	)
 );
-$assert( 'strict remediation outcome rejects normal answers without PR', ! is_wp_error( $normal_no_pr_result ) && false === ( $normal_no_pr_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $normal_no_pr_result['outcome']['failure'] ?? '' ) );
+$assert( 'strict remediation outcome rejects normal answers without artifact', ! is_wp_error( $normal_no_pr_result ) && false === ( $normal_no_pr_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $normal_no_pr_result['outcome']['failure'] ?? '' ) );
 
-$fix_pr_result = $remediation_run(
+$fix_artifact_result = $remediation_run(
 	array(
-		'pr_url'   => 'https://github.com/chubes4/wp-codebox/pull/2020',
 		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
-	)
+	),
+	0,
+	$remediation_artifact_run( 'fix', array( array( 'path' => '/wordpress/wp-content/plugins/example/example.php', 'relativePath' => 'example.php', 'status' => 'modified' ) ) )
 );
-$assert( 'strict remediation outcome accepts valid fix PR URL', ! is_wp_error( $fix_pr_result ) && true === ( $fix_pr_result['success'] ?? false ) && 'fix_pr' === ( $fix_pr_result['outcome']['kind'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/2020' === ( $fix_pr_result['outcome']['pr_url'] ?? '' ) );
+$assert( 'strict remediation outcome accepts changed fix artifact', ! is_wp_error( $fix_artifact_result ) && true === ( $fix_artifact_result['success'] ?? false ) && 'fix_artifact' === ( $fix_artifact_result['outcome']['kind'] ?? '' ) && 'example.php' === ( $fix_artifact_result['outcome']['artifact']['changed_files'][0]['relative_path'] ?? '' ) );
 
-$false_positive_pr_result = $remediation_run(
+$false_positive_artifact_result = $remediation_run(
 	array(
-		'false_positive_pr_url' => 'https://github.com/chubes4/wp-codebox/pull/2021',
-		'metadata'              => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
-	)
+		'false_positive' => true,
+		'metadata'       => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
+	),
+	0,
+	$remediation_artifact_run( 'false-positive', array( array( 'path' => '/wordpress/wp-content/plugins/example/tests/audit.php', 'relativePath' => 'tests/audit.php', 'status' => 'modified' ) ) )
 );
-$assert( 'strict remediation outcome accepts valid false-positive PR URL', ! is_wp_error( $false_positive_pr_result ) && true === ( $false_positive_pr_result['success'] ?? false ) && 'false_positive_pr' === ( $false_positive_pr_result['outcome']['kind'] ?? '' ) && 'https://github.com/chubes4/wp-codebox/pull/2021' === ( $false_positive_pr_result['outcome']['false_positive_pr_url'] ?? '' ) );
+$assert( 'strict remediation outcome accepts changed false-positive artifact', ! is_wp_error( $false_positive_artifact_result ) && true === ( $false_positive_artifact_result['success'] ?? false ) && 'false_positive_artifact' === ( $false_positive_artifact_result['outcome']['kind'] ?? '' ) && true === ( $false_positive_artifact_result['outcome']['false_positive'] ?? false ) );
 
 $max_turns_result = $remediation_run(
 	array(


### PR DESCRIPTION
## Summary
- Treat strict audit-remediation sandbox success as a reviewed artifact, not a PR URL.
- Preserve legacy PR URL outcome parsing as metadata compatibility.
- Emit sandbox task JSON through a PHP nowdoc so prompts containing `$` tokens are not interpolated.

## Tests
- npm run agent-sandbox-code-smoke
- npm run build
- npm run wordpress-plugin-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the sandbox outcome contract update, escaping fix, and smoke test coverage; Chris reviewed direction during implementation.