### PR TITLE
fix: bundle CLI with WordPress plugin

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,6 +1,9 @@
 {
   "id": "wp-codebox",
-  "build_artifact": "dist/wp-codebox-cli-linux-x64.tar.gz",
+  "extensions": {
+    "nodejs": {}
+  },
+  "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
   "version_targets": [
     {
       "file": "package.json",

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1254,7 +1254,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	private function default_bin(): string {
-		$bin = (string) $this->config_option( 'wp_codebox_bin', 'wp-codebox' );
+		$bundled = defined( 'WP_CODEBOX_PLUGIN_PATH' ) ? WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/bin/wp-codebox' : '';
+		$default = is_string( $bundled ) && is_file( $bundled ) ? $bundled : 'wp-codebox';
+		$bin     = (string) $this->config_option( 'wp_codebox_bin', $default );
 
 		if ( function_exists( 'apply_filters' ) ) {
 			$bin = (string) apply_filters( 'wp_codebox_bin', $bin );

--- a/scripts/build-wordpress-plugin-zip.ts
+++ b/scripts/build-wordpress-plugin-zip.ts
@@ -11,14 +11,25 @@ const outputDirectory = join(pluginSource, "dist")
 const outputZip = join(outputDirectory, "wp-codebox.zip")
 const stagingRoot = await mkdtemp(join(tmpdir(), "wp-codebox-plugin-"))
 const stagingPlugin = join(stagingRoot, "wp-codebox")
+const cliPackageRoot = join(repoRoot, "dist", "release", "wp-codebox-cli")
 
 try {
-  await mkdir(outputDirectory, { recursive: true })
-  await mkdir(stagingPlugin, { recursive: true })
-  await cp(join(pluginSource, "wp-codebox.php"), join(stagingPlugin, "wp-codebox.php"))
-  await cp(join(pluginSource, "README.md"), join(stagingPlugin, "README.md"))
-  await cp(join(pluginSource, "src"), join(stagingPlugin, "src"), { recursive: true })
-  await rm(outputZip, { force: true })
+	await execFileAsync("npm", ["run", "release:package"], {
+		cwd: repoRoot,
+		env: {
+			...process.env,
+			WP_CODEBOX_RELEASE_PLATFORM: process.env.WP_CODEBOX_RELEASE_PLATFORM ?? "linux",
+			WP_CODEBOX_RELEASE_ARCH: process.env.WP_CODEBOX_RELEASE_ARCH ?? "x64",
+		},
+		maxBuffer: 1024 * 1024 * 20,
+	})
+	await mkdir(outputDirectory, { recursive: true })
+	await mkdir(stagingPlugin, { recursive: true })
+	await cp(join(pluginSource, "wp-codebox.php"), join(stagingPlugin, "wp-codebox.php"))
+	await cp(join(pluginSource, "README.md"), join(stagingPlugin, "README.md"))
+	await cp(join(pluginSource, "src"), join(stagingPlugin, "src"), { recursive: true })
+	await cp(cliPackageRoot, join(stagingPlugin, "vendor", "wp-codebox-cli"), { recursive: true })
+	await rm(outputZip, { force: true })
   await execFileAsync("zip", ["-qr", outputZip, "wp-codebox"], { cwd: stagingRoot })
   console.log(`Built ${outputZip}`)
 } finally {

--- a/scripts/package-release-artifact.ts
+++ b/scripts/package-release-artifact.ts
@@ -8,8 +8,8 @@ const execFileAsync = promisify(execFile)
 const repoRoot = resolve(import.meta.dirname, "..")
 const releaseRoot = resolve(repoRoot, "dist", "release")
 const packageRoot = join(releaseRoot, "wp-codebox-cli")
-const platformName = normalizePlatform(platform())
-const archName = normalizeArch(arch())
+const platformName = process.env.WP_CODEBOX_RELEASE_PLATFORM ?? normalizePlatform(platform())
+const archName = process.env.WP_CODEBOX_RELEASE_ARCH ?? normalizeArch(arch())
 const artifactName = `wp-codebox-cli-${platformName}-${archName}.tar.gz`
 const artifactPath = resolve(repoRoot, "dist", artifactName)
 


### PR DESCRIPTION
## Summary
- Add the Node.js Homeboy extension and point deploys at the WordPress plugin zip artifact.
- Build the WP Codebox CLI release package into the WordPress plugin zip under `vendor/wp-codebox-cli`.
- Prefer the bundled CLI wrapper as the plugin default so `wp-codebox/run-agent-task` does not require a global `wp-codebox` command.
- Allow the release package script to target Linux x64 from non-Linux build hosts.

## Testing
- `npm run package:wordpress-plugin`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php`
- Verified the zip contains `wp-codebox/vendor/wp-codebox-cli/bin/wp-codebox`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing runtime CLI executable, drafted plugin packaging and default-binary changes, and ran verification commands for Chris to review/test.
