### PR TITLE
Emit terminal sandbox no-op outcomes

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -606,17 +606,17 @@ final class WP_Codebox_Abilities {
 	private static function remediation_outcome_schema(): array {
 		return array(
 			'type'        => 'object',
-			'description' => 'Strict audit-remediation terminal outcome. Successful sandbox outcomes require a reviewed fix or false-positive artifact; parent orchestrators apply artifacts and open PRs outside the sandbox.',
+			'description' => 'Strict audit-remediation terminal outcome. Sandbox runs return reviewed artifacts when they can remediate, or an explicit terminal no-op/failure outcome when they cannot. Parent orchestrators apply artifacts and open PRs outside the sandbox.',
 			'properties'  => array(
 				'schema'                => array( 'type' => 'string' ),
 				'success'               => array( 'type' => 'boolean' ),
 				'kind'                  => array(
 					'type' => 'string',
-					'enum' => array( 'fix_artifact', 'false_positive_artifact', 'fix_pr', 'false_positive_pr', 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
+					'enum' => array( 'fix_artifact', 'false_positive_artifact', 'noop_artifact', 'unable_to_remediate', 'fix_pr', 'false_positive_pr', 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
 				),
 				'failure'               => array(
 					'type' => 'string',
-					'enum' => array( 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
+					'enum' => array( 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded', '' ),
 				),
 				'pr_url'                => array( 'type' => 'string' ),
 				'false_positive_pr_url' => array( 'type' => 'string' ),

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -910,9 +910,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		$outcome = array(
 			'schema'      => self::REMEDIATION_OUTCOME_SCHEMA,
-			'success'     => false,
-			'kind'        => 'agent_no_pr_outcome',
-			'failure'     => 'agent_no_pr_outcome',
+			'success'     => true,
+			'kind'        => 'unable_to_remediate',
+			'failure'     => '',
 			'exit_code'   => $exit_code,
 			'retryable'   => false,
 			'diagnostics' => array_filter(
@@ -968,6 +968,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		if ( $max_turns_reached ) {
+			$outcome['success'] = false;
 			$outcome['kind'] = 'max_turns_exceeded';
 			$outcome['failure'] = 'max_turns_exceeded';
 			$outcome['retryable'] = true;
@@ -975,10 +976,17 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		if ( 0 !== $exit_code || ! empty( $provider_error ) ) {
+			$outcome['success'] = false;
 			$outcome['kind'] = 'provider_error';
 			$outcome['failure'] = 'provider_error';
 			$outcome['provider_error'] = $provider_error;
 			$outcome['retryable'] = (bool) ( $provider_error['retryable'] ?? true );
+			return $outcome;
+		}
+
+		if ( $false_positive ) {
+			$outcome['kind'] = 'noop_artifact';
+			$outcome['false_positive'] = true;
 		}
 
 		return $outcome;
@@ -988,6 +996,12 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private function remediation_false_positive( array $run ): bool {
 		foreach ( array_merge( array( $run ), $this->agent_payloads( $run ) ) as $payload ) {
 			if ( $this->recursive_truthy_key( $payload, 'false_positive' ) || $this->recursive_truthy_key( $payload, 'falsePositive' ) ) {
+				return true;
+			}
+
+			$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ) : json_encode( $payload, JSON_UNESCAPED_SLASHES );
+			$text    = strtolower( is_string( $encoded ) ? $encoded : '' );
+			if ( str_contains( $text, 'false positive' ) || str_contains( $text, 'false_positive' ) ) {
 				return true;
 			}
 		}

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -627,7 +627,7 @@ $text_false_positive_result = $remediation_run(
 		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
 	)
 );
-$assert( 'strict remediation outcome rejects text-only false-positive conclusions without artifact', ! is_wp_error( $text_false_positive_result ) && false === ( $text_false_positive_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $text_false_positive_result['outcome']['kind'] ?? '' ) );
+$assert( 'strict remediation outcome returns noop artifact for text-only false-positive conclusions without artifact', ! is_wp_error( $text_false_positive_result ) && true === ( $text_false_positive_result['success'] ?? false ) && 'noop_artifact' === ( $text_false_positive_result['outcome']['kind'] ?? '' ) && true === ( $text_false_positive_result['outcome']['false_positive'] ?? false ) );
 
 $normal_no_pr_result = $remediation_run(
 	array(
@@ -635,7 +635,7 @@ $normal_no_pr_result = $remediation_run(
 		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
 	)
 );
-$assert( 'strict remediation outcome rejects normal answers without artifact', ! is_wp_error( $normal_no_pr_result ) && false === ( $normal_no_pr_result['success'] ?? true ) && 'agent_no_pr_outcome' === ( $normal_no_pr_result['outcome']['failure'] ?? '' ) );
+$assert( 'strict remediation outcome returns unable-to-remediate terminal outcome without artifact', ! is_wp_error( $normal_no_pr_result ) && true === ( $normal_no_pr_result['success'] ?? false ) && 'unable_to_remediate' === ( $normal_no_pr_result['outcome']['kind'] ?? '' ) );
 
 $fix_artifact_result = $remediation_run(
 	array(


### PR DESCRIPTION
## Summary
- Return explicit terminal outcomes for strict audit-remediation sandbox runs that do not produce changed artifacts.
- Add `noop_artifact` and `unable_to_remediate` to the remediation outcome schema.
- Detect text-only false-positive conclusions as terminal no-op outcomes.

## Tests
- npm run wordpress-plugin-smoke
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the terminal no-op outcome contract update and smoke test coverage; Chris directed the contract and reviewed results.