### PR TITLE
fix: default browser Playground to latest versions

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -886,8 +886,8 @@ final class WP_Codebox_Abilities {
 
 		return array(
 			'preferredVersions' => array(
-				'wp'  => (string) ( $playground['wp'] ?? '6.9' ),
-				'php' => (string) ( $playground['php'] ?? '8.2' ),
+				'wp'  => (string) ( $playground['wp'] ?? 'latest' ),
+				'php' => (string) ( $playground['php'] ?? 'latest' ),
 			),
 			'features'          => array(
 				'networking' => true,

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -212,6 +212,7 @@ $assert( 'browser Playground session schema is stable', ! is_wp_error( $browser_
 $assert( 'browser Playground session pins browser execution', ! is_wp_error( $browser_session ) && 'browser-playground' === ( $browser_session['execution'] ?? '' ) );
 $assert( 'browser Playground session includes Playground client URLs', ! is_wp_error( $browser_session ) && str_contains( $browser_session['playground']['client_module_url'] ?? '', 'playground.automattic.ai' ) && str_contains( $browser_session['playground']['remote_url'] ?? '', 'playground.automattic.ai' ) );
 $assert( 'browser Playground session includes default blueprint', ! is_wp_error( $browser_session ) && true === ( $browser_session['playground']['blueprint']['features']['networking'] ?? false ) && is_array( $browser_session['playground']['blueprint']['steps'] ?? null ) );
+$assert( 'browser Playground session defaults to latest WordPress and PHP', ! is_wp_error( $browser_session ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['wp'] ?? '' ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['php'] ?? '' ) );
 $assert( 'browser Playground session preserves safe artifact files', ! is_wp_error( $browser_session ) && 'static-site/index.html' === ( $browser_session['artifacts']['files'][0]['path'] ?? '' ) );
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
 


### PR DESCRIPTION
## Summary
- Change WP Codebox browser Playground defaults from pinned `wp: 6.9` / `php: 8.2` to `latest` / `latest`.
- Add smoke coverage so the browser session contract keeps advertising latest WordPress and PHP by default.

## Testing
- `php tests/smoke-wordpress-plugin.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated stale browser Playground defaults and smoke coverage after Chris spotted the incorrect advertised versions.
