### PR TITLE
fix: register abilities before init hooks

### DIFF
--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -23,7 +23,8 @@ require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-data-machine-pending-actions.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 
+new WP_Codebox_Abilities();
+
 add_action( 'plugins_loaded', static function (): void {
 	new WP_Codebox_Data_Machine_Pending_Actions();
-	new WP_Codebox_Abilities();
 }, 20 );


### PR DESCRIPTION
## Summary
- Instantiate the WP Codebox ability registrar at plugin load instead of waiting for `plugins_loaded`.
- Keeps ability callbacks attached before the Abilities API category/ability init hooks fire.
- Leaves Data Machine pending-action integration on `plugins_loaded`.

## Testing
- `php tests/smoke-wordpress-plugin.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed and fixed late WP Codebox ability registration observed during Studio Web runtime verification.
