### PR TITLE
fix: build WordPress plugin zip for deploys

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -3,6 +3,7 @@
   "extensions": {
     "nodejs": {}
   },
+  "build_command": "npm run package:wordpress-plugin",
   "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
   "version_targets": [
     {


### PR DESCRIPTION
## Summary
- Configure Homeboy to run `npm run package:wordpress-plugin` for WP Codebox builds.
- Matches the existing `build_artifact` path so deploys produce `packages/wordpress-plugin/dist/wp-codebox.zip` before installation.

## Testing
- `npm run package:wordpress-plugin`
- `test -f packages/wordpress-plugin/dist/wp-codebox.zip`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Fixed the Homeboy build command after deploy exposed that WP Codebox did not create its configured plugin ZIP artifact.
