### PR TITLE
Expose browser artifact preview paths

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -303,7 +303,7 @@ final class WP_Codebox_Abilities {
 							'orchestrator'       => $session_input['orchestrator'],
 							'playground'         => array(
 								'type'        => 'object',
-								'description' => 'Optional browser Playground client configuration overrides.',
+								'description' => 'Optional browser Playground client and artifact preview configuration overrides.',
 							),
 							'blueprint'          => array(
 								'type'        => 'object',
@@ -768,11 +768,14 @@ final class WP_Codebox_Abilities {
 			),
 			'task_input' => $task_input,
 			'playground' => array(
-				'client_module_url' => (string) ( $playground['client_module_url'] ?? 'https://playground.automattic.ai/client/index.js' ),
-				'remote_url'        => (string) ( $playground['remote_url'] ?? 'https://playground.automattic.ai/remote.html' ),
-				'scope'             => (string) ( $playground['scope'] ?? $session_id ),
-				'blueprint'         => self::browser_playground_blueprint( $blueprint, $playground ),
-				'capabilities'      => array(
+				'client_module_url'  => (string) ( $playground['client_module_url'] ?? 'https://playground.automattic.ai/client/index.js' ),
+				'remote_url'         => (string) ( $playground['remote_url'] ?? 'https://playground.automattic.ai/remote.html' ),
+				'scope'              => (string) ( $playground['scope'] ?? $session_id ),
+				'artifact_base_path' => self::browser_artifact_base_path( $playground ),
+				'artifact_base_url'  => self::browser_artifact_base_url( $playground ),
+				'preview_url'        => self::browser_preview_url( $artifacts, $playground ),
+				'blueprint'          => self::browser_playground_blueprint( $blueprint, $playground ),
+				'capabilities'       => array(
 					'compile_blueprint' => true,
 					'run_blueprint'     => true,
 					'write_file'        => true,
@@ -782,6 +785,7 @@ final class WP_Codebox_Abilities {
 			'artifacts'  => array(
 				'schema'             => 'wp-codebox/browser-artifacts/v1',
 				'files'              => $artifacts,
+				'preview_url'        => self::browser_preview_url( $artifacts, $playground ),
 				'expected_artifacts' => $task_input['expected_artifacts'],
 			),
 		);
@@ -855,7 +859,10 @@ final class WP_Codebox_Abilities {
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,string>>|WP_Error */
 	private static function browser_artifact_files( array $input ): array|WP_Error {
-		$files = is_array( $input['artifact_files'] ?? null ) ? $input['artifact_files'] : array();
+		$files      = is_array( $input['artifact_files'] ?? null ) ? $input['artifact_files'] : array();
+		$playground = is_array( $input['playground'] ?? null ) ? $input['playground'] : array();
+		$base_path  = self::browser_artifact_base_path( $playground );
+		$base_url   = self::browser_artifact_base_url( $playground );
 		$normalized = array();
 		foreach ( $files as $index => $file ) {
 			if ( ! is_array( $file ) ) {
@@ -868,14 +875,47 @@ final class WP_Codebox_Abilities {
 			}
 
 			$normalized[] = array(
-				'path'        => $path,
-				'content'     => (string) ( $file['content'] ?? '' ),
-				'kind'        => (string) ( $file['kind'] ?? 'text' ),
-				'description' => (string) ( $file['description'] ?? '' ),
+				'path'            => $path,
+				'playground_path' => self::join_browser_path( $base_path, $path ),
+				'url_path'        => self::join_browser_path( $base_url, $path ),
+				'content'         => (string) ( $file['content'] ?? '' ),
+				'kind'            => (string) ( $file['kind'] ?? 'text' ),
+				'description'     => (string) ( $file['description'] ?? '' ),
 			);
 		}
 
 		return $normalized;
+	}
+
+	/** @param array<string,mixed> $playground Playground config. */
+	private static function browser_artifact_base_path( array $playground ): string {
+		return self::normalize_absolute_browser_path( (string) ( $playground['artifact_base_path'] ?? '/wordpress/wp-content/uploads/wp-codebox/artifacts' ) );
+	}
+
+	/** @param array<string,mixed> $playground Playground config. */
+	private static function browser_artifact_base_url( array $playground ): string {
+		return self::normalize_absolute_browser_path( (string) ( $playground['artifact_base_url'] ?? '/wp-content/uploads/wp-codebox/artifacts' ) );
+	}
+
+	/** @param array<int,array<string,string>> $artifacts Artifact files. @param array<string,mixed> $playground Playground config. */
+	private static function browser_preview_url( array $artifacts, array $playground ): string {
+		$preview_url = trim( (string) ( $playground['preview_url'] ?? '' ) );
+		if ( '' !== $preview_url ) {
+			return self::normalize_absolute_browser_path( $preview_url );
+		}
+
+		$first_file = $artifacts[0]['url_path'] ?? '';
+		return '' !== $first_file ? $first_file : '/';
+	}
+
+	private static function normalize_absolute_browser_path( string $path ): string {
+		$path = '/' . ltrim( trim( $path ), '/' );
+		$path = rtrim( $path, '/' );
+		return '' === $path ? '/' : $path;
+	}
+
+	private static function join_browser_path( string $base, string $path ): string {
+		return rtrim( $base, '/' ) . '/' . ltrim( $path, '/' );
 	}
 
 	/** @param array<string,mixed> $blueprint Blueprint override. @param array<string,mixed> $playground Playground config. @return array<string,mixed> */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -214,7 +214,30 @@ $assert( 'browser Playground session includes Playground client URLs', ! is_wp_e
 $assert( 'browser Playground session includes default blueprint', ! is_wp_error( $browser_session ) && true === ( $browser_session['playground']['blueprint']['features']['networking'] ?? false ) && is_array( $browser_session['playground']['blueprint']['steps'] ?? null ) );
 $assert( 'browser Playground session defaults to latest WordPress and PHP', ! is_wp_error( $browser_session ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['wp'] ?? '' ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['php'] ?? '' ) );
 $assert( 'browser Playground session preserves safe artifact files', ! is_wp_error( $browser_session ) && 'static-site/index.html' === ( $browser_session['artifacts']['files'][0]['path'] ?? '' ) );
+$assert( 'browser Playground session exposes artifact write paths', ! is_wp_error( $browser_session ) && '/wordpress/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['files'][0]['playground_path'] ?? '' ) );
+$assert( 'browser Playground session exposes artifact URL paths', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['files'][0]['url_path'] ?? '' ) );
+$assert( 'browser Playground session exposes preview URL', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['playground']['preview_url'] ?? '' ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['preview_url'] ?? '' ) );
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
+
+$custom_browser_session = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'           => 'Prepare a custom browser preview.',
+		'playground'     => array(
+			'artifact_base_path' => '/wordpress/wp-content/uploads/studio-web',
+			'artifact_base_url'  => '/wp-content/uploads/studio-web',
+			'preview_url'        => '/wp-content/uploads/studio-web/static-site/index.html',
+		),
+		'artifact_files' => array(
+			array(
+				'path'    => 'static-site/index.html',
+				'content' => '<main>Custom</main>',
+			),
+		),
+	)
+);
+$assert( 'browser Playground session honors custom artifact base path', ! is_wp_error( $custom_browser_session ) && '/wordpress/wp-content/uploads/studio-web/static-site/index.html' === ( $custom_browser_session['artifacts']['files'][0]['playground_path'] ?? '' ) );
+$assert( 'browser Playground session honors custom preview URL', ! is_wp_error( $custom_browser_session ) && '/wp-content/uploads/studio-web/static-site/index.html' === ( $custom_browser_session['playground']['preview_url'] ?? '' ) );
 
 $invalid_browser_file = call_user_func(
 	$browser_session_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Extends `wp-codebox/create-browser-playground-session` so browser artifact files include normalized Playground write paths and URL paths.
- Adds artifact base path/base URL/preview URL metadata to the browser Playground session contract.
- Covers default and custom artifact preview paths in the WordPress plugin smoke test.

## Testing
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `php tests/smoke-wordpress-plugin.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the browser artifact preview contract fields and smoke coverage; Chris remains responsible for review and testing.