### PR TITLE
Validate browser sandbox readiness before ready signal

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -299,6 +299,17 @@ final class WP_Codebox_Abilities {
 							'expected_artifacts' => $task_input_schema['properties']['expected_artifacts'],
 							'policy'             => $task_input_schema['properties']['policy'],
 							'context'            => $task_input_schema['properties']['context'],
+							'provider_plugin_paths' => array(
+								'type'        => 'array',
+								'description' => 'AI provider plugin directories the browser sandbox should have available before code execution.',
+								'items'       => array( 'type' => 'string' ),
+							),
+							'inherit'            => $inherit_schema,
+							'secret_env'         => array(
+								'type'        => 'array',
+								'description' => 'Parent environment variable names expected to be available to the browser sandbox. Values are never accepted in this payload.',
+								'items'       => array( 'type' => 'string' ),
+							),
 							'sandbox_session_id' => $session_input['sandbox_session_id'],
 							'orchestrator'       => $session_input['orchestrator'],
 							'playground'         => array(
@@ -755,6 +766,7 @@ final class WP_Codebox_Abilities {
 		if ( is_wp_error( $artifacts ) ) {
 			return $artifacts;
 		}
+		$ready_to_code = self::browser_ready_to_code_signal( $input );
 
 		return array(
 			'success'    => true,
@@ -784,12 +796,7 @@ final class WP_Codebox_Abilities {
 				),
 			),
 			'signals'    => array(
-				'ready_to_code' => array(
-					'schema'  => 'wp-codebox/signal/v1',
-					'name'    => 'ready_to_code',
-					'emitted' => true,
-					'message' => 'Browser Playground sandbox is ready to code.',
-				),
+				'ready_to_code' => $ready_to_code,
 			),
 			'artifacts'  => array(
 				'schema'             => 'wp-codebox/browser-artifacts/v1',
@@ -798,6 +805,73 @@ final class WP_Codebox_Abilities {
 				'expected_artifacts' => $task_input['expected_artifacts'],
 			),
 		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private static function browser_ready_to_code_signal( array $input ): array {
+		$provider_plugin_paths = array_values(
+			array_filter(
+				array_map( 'strval', is_array( $input['provider_plugin_paths'] ?? null ) ? $input['provider_plugin_paths'] : array() ),
+				static fn( string $path ): bool => '' !== trim( $path )
+			)
+		);
+		$inherit      = is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array();
+		$connectors   = array_values( array_filter( array_map( 'strval', is_array( $inherit['connectors'] ?? null ) ? $inherit['connectors'] : array() ) ) );
+		$secret_env   = array_values( array_filter( array_map( 'strval', is_array( $input['secret_env'] ?? null ) ? $input['secret_env'] : array() ) ) );
+		$requirements = array(
+			'agents_api'        => self::agents_api_ready(),
+			'data_machine'      => self::plugin_path_ready( 'data-machine' ),
+			'data_machine_code' => self::plugin_path_ready( 'data-machine-code' ),
+			'provider_plugin'   => ! empty( $provider_plugin_paths ) && self::all_paths_ready( $provider_plugin_paths ),
+			'provider_secret'   => ! empty( $connectors ) || ! empty( $secret_env ),
+		);
+
+		/**
+		 * Filters browser sandbox readiness requirements before the signal is emitted.
+		 *
+		 * @param array<string,bool>  $requirements Named readiness checks.
+		 * @param array<string,mixed> $input        Ability input.
+		 */
+		$requirements = apply_filters( 'wp_codebox_browser_ready_to_code_requirements', $requirements, $input );
+		$requirements = is_array( $requirements ) ? array_map( 'boolval', $requirements ) : array();
+		$missing      = array_keys( array_filter( $requirements, static fn( bool $ready ): bool => ! $ready ) );
+		$emitted      = empty( $missing );
+
+		return array(
+			'schema'       => 'wp-codebox/signal/v1',
+			'name'         => 'ready_to_code',
+			'emitted'      => $emitted,
+			'message'      => $emitted ? 'Browser Playground sandbox is ready to code.' : 'Browser Playground sandbox is not ready to code.',
+			'requirements' => $requirements,
+			'missing'      => $missing,
+		);
+	}
+
+	private static function agents_api_ready(): bool {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return false;
+		}
+
+		return (bool) wp_get_ability( 'agents/chat' );
+	}
+
+	private static function plugin_path_ready( string $plugin_slug ): bool {
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			return false;
+		}
+
+		return is_dir( rtrim( WP_PLUGIN_DIR, '/\\' ) . '/' . $plugin_slug );
+	}
+
+	/** @param array<int,string> $paths Paths to verify. */
+	private static function all_paths_ready( array $paths ): bool {
+		foreach ( $paths as $path ) {
+			if ( ! is_dir( $path ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -33,6 +33,7 @@ $GLOBALS['wp_codebox_registered_ability_categories'] = array();
 $GLOBALS['wp_codebox_actions']                      = array();
 $GLOBALS['wp_codebox_current_action']              = null;
 $GLOBALS['wp_codebox_filters']                      = array();
+$GLOBALS['wp_codebox_mock_abilities']              = array();
 $GLOBALS['wp_codebox_options']                      = array();
 $GLOBALS['wp_codebox_site_options']                 = array();
 
@@ -51,6 +52,7 @@ function wp_register_ability_category( string $slug, array $args ): void {
 
 	$GLOBALS['wp_codebox_registered_ability_categories'][ $slug ] = $args;
 }
+function wp_get_ability( string $name ): mixed { return $GLOBALS['wp_codebox_mock_abilities'][ $name ] ?? null; }
 
 function doing_action( string $hook ): bool {
 	return $hook === $GLOBALS['wp_codebox_current_action'];
@@ -188,17 +190,22 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_default_agent'] = 'site-coder';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model'] = 'gpt-5.5';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_secret_env'] = array( 'OPENAI_API_KEY' );
+$GLOBALS['wp_codebox_mock_abilities']['agents/chat'] = new WP_Ability();
+mkdir( $root . '/plugin-root/data-machine', 0777, true );
+mkdir( $root . '/plugin-root/data-machine-code', 0777, true );
 
 $browser_session = call_user_func(
 	$browser_session_ability['execute_callback'],
 	array(
-		'goal'               => 'Prepare a Studio Web browser preview.',
-		'sandbox_session_id' => 'browser-session-123',
-		'target'             => array( 'kind' => 'static-site' ),
-		'allowed_tools'      => array( 'filesystem-write', 'filesystem-write', '' ),
-		'expected_artifacts' => array( 'static-site' ),
-		'orchestrator'       => array( 'id' => 'studio-web' ),
-		'artifact_files'     => array(
+		'goal'                  => 'Prepare a Studio Web browser preview.',
+		'sandbox_session_id'    => 'browser-session-123',
+		'target'                => array( 'kind' => 'static-site' ),
+		'allowed_tools'         => array( 'filesystem-write', 'filesystem-write', '' ),
+		'expected_artifacts'    => array( 'static-site' ),
+		'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+		'inherit'               => array( 'connectors' => array( 'openai' ) ),
+		'orchestrator'          => array( 'id' => 'studio-web' ),
+		'artifact_files'        => array(
 			array(
 				'path'    => 'static-site/index.html',
 				'content' => '<main>Preview</main>',
@@ -213,12 +220,22 @@ $assert( 'browser Playground session pins browser execution', ! is_wp_error( $br
 $assert( 'browser Playground session includes Playground client URLs', ! is_wp_error( $browser_session ) && str_contains( $browser_session['playground']['client_module_url'] ?? '', 'playground.automattic.ai' ) && str_contains( $browser_session['playground']['remote_url'] ?? '', 'playground.automattic.ai' ) );
 $assert( 'browser Playground session includes default blueprint', ! is_wp_error( $browser_session ) && true === ( $browser_session['playground']['blueprint']['features']['networking'] ?? false ) && is_array( $browser_session['playground']['blueprint']['steps'] ?? null ) );
 $assert( 'browser Playground session defaults to latest WordPress and PHP', ! is_wp_error( $browser_session ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['wp'] ?? '' ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['php'] ?? '' ) );
-$assert( 'browser Playground session emits ready-to-code signal', ! is_wp_error( $browser_session ) && true === ( $browser_session['signals']['ready_to_code']['emitted'] ?? false ) && 'ready_to_code' === ( $browser_session['signals']['ready_to_code']['name'] ?? '' ) );
+$assert( 'browser Playground session emits ready-to-code signal only when prerequisites are present', ! is_wp_error( $browser_session ) && true === ( $browser_session['signals']['ready_to_code']['emitted'] ?? false ) && 'ready_to_code' === ( $browser_session['signals']['ready_to_code']['name'] ?? '' ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['agents_api'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['provider_secret'] ?? false ) );
 $assert( 'browser Playground session preserves safe artifact files', ! is_wp_error( $browser_session ) && 'static-site/index.html' === ( $browser_session['artifacts']['files'][0]['path'] ?? '' ) );
 $assert( 'browser Playground session exposes artifact write paths', ! is_wp_error( $browser_session ) && '/wordpress/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['files'][0]['playground_path'] ?? '' ) );
 $assert( 'browser Playground session exposes artifact URL paths', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['files'][0]['url_path'] ?? '' ) );
 $assert( 'browser Playground session exposes preview URL', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['playground']['preview_url'] ?? '' ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['preview_url'] ?? '' ) );
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
+
+$browser_session_missing_prereqs = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal' => 'Prepare a browser preview without coding prerequisites.',
+	)
+);
+$assert( 'browser Playground session with missing prerequisites does not emit ready-to-code', ! is_wp_error( $browser_session_missing_prereqs ) && false === ( $browser_session_missing_prereqs['signals']['ready_to_code']['emitted'] ?? true ) && in_array( 'provider_plugin', $browser_session_missing_prereqs['signals']['ready_to_code']['missing'] ?? array(), true ) && in_array( 'provider_secret', $browser_session_missing_prereqs['signals']['ready_to_code']['missing'] ?? array(), true ) );
+rmdir( $root . '/plugin-root/data-machine-code' );
+rmdir( $root . '/plugin-root/data-machine' );
 
 $custom_browser_session = call_user_func(
 	$browser_session_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- make `signals.ready_to_code.emitted` depend on actual coding prerequisites
- check Agents API chat availability, Data Machine/Data Machine Code plugin paths, provider plugin paths, and provider credential handoff
- expose requirement details and missing keys when the sandbox is not ready
- add smoke coverage for both ready and missing-prerequisite sessions

## Testing
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `npm run wordpress-plugin-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Tightening the browser sandbox readiness contract and adding smoke coverage. Chris remains responsible for review and merge.