### PR TITLE
Fix artifact patches for added and deleted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "artifact-bundle-verifier-smoke": "tsx scripts/artifact-bundle-verifier-smoke.ts",
+    "artifact-patch-git-apply-smoke": "tsx scripts/artifact-patch-git-apply-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
@@ -60,7 +61,7 @@
     "recipe-runtime-evidence-smoke": "tsx scripts/recipe-runtime-evidence-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run workspace-policy-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-bundle-verifier-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run recipe-runtime-evidence-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run workspace-policy-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-bundle-verifier-smoke && npm run artifact-patch-git-apply-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run recipe-runtime-evidence-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -526,13 +526,19 @@ function stripUndefined<T extends Record<string, unknown>>(record: T): T {
 function fileDiff(path: string, before: string, after: string, isAdded: boolean, isDeleted: boolean): string {
   const beforeLines = splitLines(before)
   const afterLines = splitLines(after)
-  const oldPath = isAdded ? "/dev/null" : `a${path}`
-  const newPath = isDeleted ? "/dev/null" : `b${path}`
+  const gitOldPath = `a${path}`
+  const gitNewPath = `b${path}`
+  const oldPath = isAdded ? "/dev/null" : gitOldPath
+  const newPath = isDeleted ? "/dev/null" : gitNewPath
+  const oldStart = isAdded ? 0 : 1
+  const newStart = isDeleted ? 0 : 1
   const lines = [
-    `diff --git ${oldPath} ${newPath}`,
+    `diff --git ${gitOldPath} ${gitNewPath}`,
+    ...(isAdded ? ["new file mode 100644"] : []),
+    ...(isDeleted ? ["deleted file mode 100644"] : []),
     `--- ${oldPath}`,
     `+++ ${newPath}`,
-    `@@ -1,${beforeLines.length} +1,${afterLines.length} @@`,
+    `@@ -${oldStart},${beforeLines.length} +${newStart},${afterLines.length} @@`,
     ...beforeLines.map((line) => `-${line}`),
     ...afterLines.map((line) => `+${line}`),
   ]

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -77,7 +77,7 @@ try {
 async function writeValidBundle(directory: string): Promise<void> {
   await mkdir(join(directory, "files"), { recursive: true })
   const changedFiles = `${JSON.stringify({ schema: "wp-codebox/changed-files/v1", files: [{ path: "/wordpress/wp-content/plugins/example/file.txt", status: "added", mountIndex: 0, mountTarget: "/wordpress/wp-content/plugins/example", relativePath: "file.txt", patchPath: "files/diffs/0-file.txt.diff" }] }, null, 2)}\n`
-  const patch = "diff --git /dev/null b/wordpress/wp-content/plugins/example/file.txt\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
+  const patch = "diff --git a/wordpress/wp-content/plugins/example/file.txt b/wordpress/wp-content/plugins/example/file.txt\nnew file mode 100644\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
   await writeFile(join(directory, "files/changed-files.json"), changedFiles)
   await writeFile(join(directory, "files/patch.diff"), patch)
   await writeFile(join(directory, "metadata.json"), "{}\n")
@@ -183,7 +183,7 @@ async function attachManifestFileHashes(directory: string, manifest: ArtifactMan
 }
 
 function reviewFixture(digest: string) {
-  const patch = "diff --git /dev/null b/wordpress/wp-content/plugins/example/file.txt\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
+  const patch = "diff --git a/wordpress/wp-content/plugins/example/file.txt b/wordpress/wp-content/plugins/example/file.txt\nnew file mode 100644\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
   return {
     schema: "wp-codebox/artifact-review/v1",
     artifactId: `artifact-bundle-sha256-${digest}`,

--- a/scripts/artifact-patch-git-apply-smoke.ts
+++ b/scripts/artifact-patch-git-apply-smoke.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { promisify } from "node:util"
+import { directoryDiff } from "../packages/runtime-playground/src/artifacts.js"
+
+const execFileAsync = promisify(execFile)
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-patch-"))
+
+try {
+  const addedBaseline = join(workspace, "added-baseline")
+  const addedCurrent = join(workspace, "added-current")
+  await mkdir(addedBaseline, { recursive: true })
+  await mkdir(addedCurrent, { recursive: true })
+  await writeFile(join(addedCurrent, "added.txt"), "added\n")
+
+  const added = await directoryDiff(addedBaseline, addedCurrent, "/workspace/plugin")
+  assert.match(added.patch, /^diff --git a\/workspace\/plugin\/added\.txt b\/workspace\/plugin\/added\.txt/m)
+  assert.match(added.patch, /^--- \/dev\/null$/m)
+  assert.match(added.patch, /^\+\+\+ b\/workspace\/plugin\/added\.txt$/m)
+  await assertPatchApplies(join(workspace, "added-apply"), added.patch)
+
+  const deletedBaseline = join(workspace, "deleted-baseline")
+  const deletedCurrent = join(workspace, "deleted-current")
+  await mkdir(deletedBaseline, { recursive: true })
+  await mkdir(deletedCurrent, { recursive: true })
+  await writeFile(join(deletedBaseline, "deleted.txt"), "deleted\n")
+
+  const deleted = await directoryDiff(deletedBaseline, deletedCurrent, "/workspace/plugin")
+  assert.match(deleted.patch, /^diff --git a\/workspace\/plugin\/deleted\.txt b\/workspace\/plugin\/deleted\.txt/m)
+  assert.match(deleted.patch, /^--- a\/workspace\/plugin\/deleted\.txt$/m)
+  assert.match(deleted.patch, /^\+\+\+ \/dev\/null$/m)
+  await assertPatchApplies(join(workspace, "deleted-apply"), deleted.patch, { "workspace/plugin/deleted.txt": "deleted\n" })
+
+  console.log("Artifact patch git apply smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function assertPatchApplies(directory: string, patch: string, files: Record<string, string> = {}): Promise<void> {
+  await mkdir(directory, { recursive: true })
+  await execFileAsync("git", ["init"], { cwd: directory })
+  for (const [path, contents] of Object.entries(files)) {
+    const fullPath = join(directory, path)
+    await mkdir(dirname(fullPath), { recursive: true })
+    await writeFile(fullPath, contents)
+  }
+
+  const patchPath = join(directory, "patch.diff")
+  await writeFile(patchPath, patch)
+  await execFileAsync("git", ["apply", "--check", patchPath], { cwd: directory })
+}


### PR DESCRIPTION
## Summary
- Keep real `a/...` and `b/...` paths in `diff --git` headers while limiting `/dev/null` to the `---`/`+++` file markers.
- Emit standard new/deleted file mode lines and zero-side hunk ranges so generated artifact patches pass `git apply --check`.
- Add a focused smoke covering added and deleted file patch generation against `git apply --check`.

## Testing
- `npm run build`
- `npm run artifact-patch-git-apply-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `npm run artifact-contract-smoke`
- `npm run check` reached `preview-port-smoke` after passing the artifact checks, then was manually aborted by the controller.
- Remaining post-abort checks run individually: `npm run preview-port-smoke`, `npm run preview-public-url-canonical-smoke`, `npm run preview-response-body-smoke`, `npm run boot-preview-smoke`, `npm run blueprint-validation-smoke`, `npm run browser-probe-artifact-smoke`, and `npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed and patched artifact diff generation, added the focused smoke test, and ran local verification. Chris remains responsible for review and merge.