### PR TITLE
Add runtime reference manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,15 @@ those files with `runtime-episode-trace` and `runtime-episode-events` kinds,
 checks the advertised trace file exists and validates against
 `wp-codebox/runtime-episode-trace/v1`.
 
+Artifact bundles also include `files/runtime-reference-manifest.json` using
+schema `wp-codebox/runtime-reference-manifest/v1`. This manifest is a stable,
+hashable index of runtime-related refs: the artifact-bundle id/digest,
+bundle-relative artifact file refs with SHA-256 values, optional trace/events
+refs, and snapshot refs. Its id is `runtime-reference-manifest-sha256-<digest>`,
+where the digest is computed from the declared refs rather than presentation
+fields such as `createdAt`. `verifyArtifactBundle()` validates the manifest
+shape, referenced file hashes, artifact-bundle digest, and id/digest pairing.
+
 Products such as eval harnesses can project this generic episode trace into their
 own action, observation, reward, and report schemas outside WP Codebox.
 
@@ -359,6 +368,12 @@ logs, observations, and artifact bundle refs. Future backends may emit stronger
 snapshot semantics such as runtime-state artifacts, but replay consumers should
 branch on the snapshot `semantics` field instead of assuming a portable restore
 point.
+
+The runtime reference manifest repeats each snapshot's `semantics` and adds an
+explicit `replay.status`. For current Playground snapshots that status is
+`metadata-only` with limitations explaining that replay must come from trace
+actions and artifact files. This keeps full WordPress replay as an incremental
+backend capability while giving consumers a concrete contract today.
 
 ## CLI Commands
 
@@ -634,6 +649,7 @@ Current bundles include:
 - `files/patch.diff`: canonical combined text patch for changed readwrite mounts that declare a baseline.
 - `files/test-results.json`: normalized test-results artifact with schema, summary counts, suites, and raw log references. When WP Codebox has not run test-aware commands, the artifact is present with `status: "unknown"`, zero counts, an empty `suites` array, and pointers to raw command logs instead of inferred pass/fail data.
 - `files/review.json`: frontend-oriented review payload with summary, progress labels, changed file labels, evidence links, and approval actions.
+- `files/runtime-reference-manifest.json`: stable runtime ref index with artifact-bundle, file, trace/events, and snapshot refs plus SHA-256 digests.
 - `files/diffs.json`: diff index for readwrite mounts that declare a baseline.
 - `files/diffs/<mount>.patch`: unified text diff from a seeded baseline to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -10,6 +10,7 @@ export const RUNTIME_EPISODE_TRACE_SCHEMA = "wp-codebox/runtime-episode-trace/v1
 export const RUNTIME_EPISODE_ACTION_SCHEMA = "wp-codebox/runtime-episode-action/v1" as const
 export const RUNTIME_EPISODE_OBSERVATION_SCHEMA = "wp-codebox/runtime-episode-observation/v1" as const
 export const RUNTIME_EPISODE_SNAPSHOT_SCHEMA = "wp-codebox/runtime-episode-snapshot/v1" as const
+export const RUNTIME_REFERENCE_MANIFEST_SCHEMA = "wp-codebox/runtime-reference-manifest/v1" as const
 
 export const RUNTIME_EPISODE_TRACE_JSON_SCHEMA = {
   $id: RUNTIME_EPISODE_TRACE_SCHEMA,
@@ -557,6 +558,56 @@ export interface ArtifactContentDigest {
   value: string
 }
 
+export type RuntimeSnapshotReplayStatus = "metadata-only" | "runtime-state-artifact" | "not-replayable" | (string & {})
+
+export interface RuntimeReferenceManifestFileRef {
+  path: string
+  kind: string
+  contentType: string
+  sha256: ArtifactFileDigest
+}
+
+export interface RuntimeReferenceManifestArtifactBundleRef {
+  kind: "artifact-bundle"
+  id: string
+  digest: ArtifactFileDigest
+}
+
+export interface RuntimeReferenceManifestSnapshotRef {
+  id: string
+  semantics: string
+  digest: RuntimeEpisodeContentDigest
+  replay: {
+    status: RuntimeSnapshotReplayStatus
+    limitations: string[]
+  }
+  artifactRefs: RuntimeEpisodeTraceRef[]
+}
+
+export interface RuntimeReferenceManifest {
+  schema: typeof RUNTIME_REFERENCE_MANIFEST_SCHEMA
+  version: 1
+  id: string
+  createdAt: string
+  digest: RuntimeEpisodeContentDigest
+  runtime: RuntimeInfo
+  artifactBundle: RuntimeReferenceManifestArtifactBundleRef
+  files: RuntimeReferenceManifestFileRef[]
+  trace?: RuntimeReferenceManifestFileRef
+  events?: RuntimeReferenceManifestFileRef
+  snapshots: RuntimeReferenceManifestSnapshotRef[]
+}
+
+export interface BuildRuntimeReferenceManifestInput {
+  createdAt: string
+  runtime: RuntimeInfo
+  artifactBundle: RuntimeReferenceManifestArtifactBundleRef
+  files: RuntimeReferenceManifestFileRef[]
+  trace?: RuntimeReferenceManifestFileRef
+  events?: RuntimeReferenceManifestFileRef
+  snapshots?: Snapshot[]
+}
+
 export interface ArtifactProvenance {
   task?: Record<string, unknown>
   workspace?: SandboxWorkspaceContract
@@ -631,6 +682,7 @@ export interface ArtifactReview {
     changedFiles: string
     testResults?: string
     runtimeEpisodeTrace?: string
+    runtimeReferenceManifest?: string
   }
   browser?: ArtifactReviewBrowserSummary
   redaction?: ArtifactRedactionSummary
@@ -730,6 +782,7 @@ export interface ArtifactBundle {
   runtimeEpisodeEventsPath?: string
   artifactVerificationPath?: string
   workspacePolicyPath?: string
+  runtimeReferenceManifestPath?: string
   preview?: ArtifactPreview
   contentDigest: string
   createdAt: string
@@ -839,6 +892,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   await verifyMetadataReferences(bundleDirectory, manifestFiles, violations)
   await verifyReviewEvidence(bundleDirectory, manifest, manifestFiles, violations)
   await verifyRuntimeEpisodeTraceArtifacts(bundleDirectory, manifest, violations)
+  await verifyRuntimeReferenceManifestArtifacts(bundleDirectory, manifest, manifestFiles, violations)
 
   return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
 }
@@ -936,6 +990,53 @@ function isArtifactManifestFileShape(value: unknown): value is ArtifactManifestF
     && typeof value.path === "string"
     && typeof value.kind === "string"
     && typeof value.contentType === "string"
+}
+
+function isRuntimeReferenceManifestShape(value: unknown): value is RuntimeReferenceManifest {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return value.schema === RUNTIME_REFERENCE_MANIFEST_SCHEMA
+    && value.version === 1
+    && typeof value.id === "string"
+    && typeof value.createdAt === "string"
+    && isArtifactFileDigestShape(value.digest)
+    && isRecord(value.runtime)
+    && isRuntimeReferenceManifestArtifactBundleRefShape(value.artifactBundle)
+    && Array.isArray(value.files)
+    && value.files.every(isRuntimeReferenceManifestFileRefShape)
+    && (value.trace === undefined || isRuntimeReferenceManifestFileRefShape(value.trace))
+    && (value.events === undefined || isRuntimeReferenceManifestFileRefShape(value.events))
+    && Array.isArray(value.snapshots)
+    && value.snapshots.every(isRuntimeReferenceManifestSnapshotRefShape)
+}
+
+function isRuntimeReferenceManifestArtifactBundleRefShape(value: unknown): value is RuntimeReferenceManifestArtifactBundleRef {
+  return isRecord(value)
+    && value.kind === "artifact-bundle"
+    && typeof value.id === "string"
+    && isArtifactFileDigestShape(value.digest)
+}
+
+function isRuntimeReferenceManifestFileRefShape(value: unknown): value is RuntimeReferenceManifestFileRef {
+  return isRecord(value)
+    && typeof value.path === "string"
+    && typeof value.kind === "string"
+    && typeof value.contentType === "string"
+    && isArtifactFileDigestShape(value.sha256)
+}
+
+function isRuntimeReferenceManifestSnapshotRefShape(value: unknown): value is RuntimeReferenceManifestSnapshotRef {
+  return isRecord(value)
+    && typeof value.id === "string"
+    && typeof value.semantics === "string"
+    && validDigest(value.digest)
+    && isRecord(value.replay)
+    && typeof value.replay.status === "string"
+    && Array.isArray(value.replay.limitations)
+    && value.replay.limitations.every((limitation) => typeof limitation === "string")
+    && Array.isArray(value.artifactRefs)
 }
 
 function isArtifactFileDigestShape(value: unknown): value is ArtifactFileDigest {
@@ -1061,6 +1162,10 @@ async function verifyReviewEvidence(directory: string, manifest: ArtifactManifes
   if (typeof evidence.runtimeEpisodeTrace === "string") {
     validateArtifactReference(evidence.runtimeEpisodeTrace, "files/review.json:evidence.runtimeEpisodeTrace", manifestFiles, violations)
   }
+
+  if (typeof evidence.runtimeReferenceManifest === "string") {
+    validateArtifactReference(evidence.runtimeReferenceManifest, "files/review.json:evidence.runtimeReferenceManifest", manifestFiles, violations)
+  }
 }
 
 async function verifyRuntimeEpisodeTraceArtifacts(directory: string, manifest: ArtifactManifest, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
@@ -1088,6 +1193,77 @@ async function verifyRuntimeEpisodeTraceArtifacts(directory: string, manifest: A
         message: `Runtime episode trace is not valid JSON: ${errorMessage(error)}`,
       })
     }
+  }
+}
+
+async function verifyRuntimeReferenceManifestArtifacts(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  for (const file of manifest.files) {
+    if (file.kind !== "runtime-reference-manifest") {
+      continue
+    }
+
+    let referenceManifest: unknown
+    try {
+      referenceManifest = JSON.parse(await readFile(join(directory, file.path), "utf8"))
+    } catch (error) {
+      violations.push({
+        code: "malformed-reference",
+        path: file.path,
+        file: file.path,
+        message: `Runtime reference manifest is not valid JSON: ${errorMessage(error)}`,
+      })
+      continue
+    }
+
+    if (!isRuntimeReferenceManifestShape(referenceManifest)) {
+      violations.push({ code: "malformed-reference", path: file.path, file: file.path, message: "Runtime reference manifest does not match wp-codebox/runtime-reference-manifest/v1." })
+      continue
+    }
+
+    const expectedDigest = runtimeReferenceManifestDigest(referenceManifest)
+    if (referenceManifest.digest.value !== expectedDigest.value) {
+      violations.push({ code: "digest-mismatch", path: `${file.path}:digest`, file: file.path, message: `Runtime reference manifest digest does not match declared refs: expected ${expectedDigest.value}, got ${referenceManifest.digest.value}` })
+    }
+
+    const expectedId = `runtime-reference-manifest-sha256-${referenceManifest.digest.value}`
+    if (referenceManifest.id !== expectedId) {
+      violations.push({ code: "bundle-id-mismatch", path: `${file.path}:id`, file: file.path, message: `Runtime reference manifest id must match its digest: expected ${expectedId}, got ${referenceManifest.id}` })
+    }
+
+    if (referenceManifest.artifactBundle.id !== manifest.id || referenceManifest.artifactBundle.digest.value !== manifest.contentDigest.value) {
+      violations.push({ code: "review-evidence-mismatch", path: `${file.path}:artifactBundle`, file: file.path, message: "Runtime reference manifest artifactBundle ref must match manifest id and contentDigest." })
+    }
+
+    for (const [index, referencedFile] of referenceManifest.files.entries()) {
+      validateArtifactReference(referencedFile.path, `${file.path}:files[${index}].path`, manifestFiles, violations)
+      await verifyReferencedFileDigest(directory, referencedFile, `${file.path}:files[${index}].sha256`, violations)
+    }
+
+    if (referenceManifest.trace) {
+      validateArtifactReference(referenceManifest.trace.path, `${file.path}:trace.path`, manifestFiles, violations)
+      await verifyReferencedFileDigest(directory, referenceManifest.trace, `${file.path}:trace.sha256`, violations)
+    }
+
+    if (referenceManifest.events) {
+      validateArtifactReference(referenceManifest.events.path, `${file.path}:events.path`, manifestFiles, violations)
+      await verifyReferencedFileDigest(directory, referenceManifest.events, `${file.path}:events.sha256`, violations)
+    }
+  }
+}
+
+async function verifyReferencedFileDigest(directory: string, file: RuntimeReferenceManifestFileRef, path: string, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  if (!isArtifactFileDigestShape(file.sha256)) {
+    violations.push({ code: "missing-file-hash", path, file: file.path, message: `Runtime reference manifest file ref must include a lowercase SHA-256 digest: ${file.path}` })
+    return
+  }
+
+  try {
+    const value = createHash("sha256").update(await readFile(join(directory, file.path))).digest("hex")
+    if (value !== file.sha256.value) {
+      violations.push({ code: "file-hash-mismatch", path, file: file.path, message: `Runtime reference manifest file ref hash does not match ${file.path}: expected ${value}, got ${file.sha256.value}` })
+    }
+  } catch (error) {
+    violations.push({ code: "file-hash-mismatch", path, file: file.path, message: `Unable to hash runtime reference file ${file.path}: ${errorMessage(error)}` })
   }
 }
 
@@ -1361,6 +1537,94 @@ export function runtimeEpisodeDigest(value: unknown): RuntimeEpisodeContentDiges
   return {
     algorithm: "sha256",
     value: createHash("sha256").update("wp-codebox/runtime-episode-trace/v1\n").update(stableJson(value)).digest("hex"),
+  }
+}
+
+export function buildRuntimeReferenceManifest(input: BuildRuntimeReferenceManifestInput): RuntimeReferenceManifest {
+  const manifest = {
+    schema: RUNTIME_REFERENCE_MANIFEST_SCHEMA,
+    version: 1 as const,
+    id: "runtime-reference-manifest-pending",
+    createdAt: input.createdAt,
+    digest: { algorithm: "sha256" as const, value: "0".repeat(64) },
+    runtime: input.runtime,
+    artifactBundle: input.artifactBundle,
+    files: input.files.map(runtimeReferenceManifestFileRef).sort((left, right) => left.path.localeCompare(right.path)),
+    ...(input.trace ? { trace: runtimeReferenceManifestFileRef(input.trace) } : {}),
+    ...(input.events ? { events: runtimeReferenceManifestFileRef(input.events) } : {}),
+    snapshots: (input.snapshots ?? []).map(runtimeReferenceManifestSnapshotRef),
+  }
+  const digest = runtimeReferenceManifestDigest(manifest)
+
+  return {
+    ...manifest,
+    id: `runtime-reference-manifest-sha256-${digest.value}`,
+    digest,
+  }
+}
+
+export function runtimeReferenceManifestDigest(manifest: RuntimeReferenceManifest): RuntimeEpisodeContentDigest {
+  return {
+    algorithm: "sha256",
+    value: createHash("sha256")
+      .update("wp-codebox/runtime-reference-manifest/v1\n")
+      .update(stableJson(runtimeReferenceManifestDigestPayload(manifest)))
+      .digest("hex"),
+  }
+}
+
+function runtimeReferenceManifestDigestPayload(manifest: RuntimeReferenceManifest): Record<string, unknown> {
+  return {
+    schema: manifest.schema,
+    version: manifest.version,
+    runtime: manifest.runtime,
+    artifactBundle: manifest.artifactBundle,
+    files: manifest.files,
+    ...(manifest.trace ? { trace: manifest.trace } : {}),
+    ...(manifest.events ? { events: manifest.events } : {}),
+    snapshots: manifest.snapshots,
+  }
+}
+
+function runtimeReferenceManifestFileRef(file: RuntimeReferenceManifestFileRef): RuntimeReferenceManifestFileRef {
+  return {
+    path: file.path,
+    kind: file.kind,
+    contentType: file.contentType,
+    sha256: file.sha256,
+  }
+}
+
+function runtimeReferenceManifestSnapshotRef(snapshot: Snapshot): RuntimeReferenceManifestSnapshotRef {
+  const semantics = snapshot.semantics ?? "metadata-only"
+
+  return {
+    id: snapshot.id,
+    semantics,
+    digest: snapshot.digest ?? runtimeEpisodeDigest(runtimeEpisodeSnapshotDigestPayload({ ...snapshot, semantics })),
+    replay: runtimeSnapshotReplaySemantics(semantics),
+    artifactRefs: [...(snapshot.artifactRefs ?? [])],
+  }
+}
+
+function runtimeSnapshotReplaySemantics(semantics: string): RuntimeReferenceManifestSnapshotRef["replay"] {
+  if (semantics === "runtime-state-artifact") {
+    return { status: "runtime-state-artifact", limitations: [] }
+  }
+
+  if (semantics === "metadata-only") {
+    return {
+      status: "metadata-only",
+      limitations: [
+        "Snapshot records runtime metadata only; it is not a WordPress database or filesystem checkpoint.",
+        "Replay consumers must use trace actions and artifact bundle files to reconstruct supported state.",
+      ],
+    }
+  }
+
+  return {
+    status: "not-replayable",
+    limitations: [`Snapshot semantics are not recognized by this WP Codebox version: ${semantics}`],
   }
 }
 
@@ -1914,7 +2178,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
   }
 
   private async persistRuntimeEpisodeTraceArtifacts(): Promise<void> {
-    if (!this.artifacts?.runtimeEpisodeTracePath || !this.artifacts.runtimeEpisodeEventsPath) {
+    if (!this.artifacts?.runtimeEpisodeTracePath || !this.artifacts.runtimeEpisodeEventsPath || !this.artifacts.runtimeReferenceManifestPath) {
       return
     }
 
@@ -1926,6 +2190,36 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     await this.updateArtifactMetadataForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
     await this.updateArtifactReviewForRuntimeEpisodeTrace(traceRelativePath)
     await this.updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
+    await this.updateRuntimeReferenceManifestForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
+  }
+
+  private async updateRuntimeReferenceManifestForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
+    if (!this.artifacts?.runtimeReferenceManifestPath) {
+      return
+    }
+
+    const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
+    const fileRefs = manifest.files
+      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json"].includes(file.path))
+      .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
+    const traceRef = fileRefs.find((file) => file.path === traceRelativePath)
+    const eventsRef = fileRefs.find((file) => file.path === eventsRelativePath)
+    const referenceManifest = buildRuntimeReferenceManifest({
+      createdAt: this.artifacts.createdAt,
+      runtime: manifest.runtime,
+      artifactBundle: {
+        kind: "artifact-bundle",
+        id: manifest.id,
+        digest: { algorithm: "sha256", value: manifest.contentDigest.value },
+      },
+      files: fileRefs,
+      ...(traceRef ? { trace: traceRef } : {}),
+      ...(eventsRef ? { events: eventsRef } : {}),
+      snapshots: this.snapshots,
+    })
+    await writeFile(this.artifacts.runtimeReferenceManifestPath, `${JSON.stringify(referenceManifest, null, 2)}\n`)
+    await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
+    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
 
   private async updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -282,6 +282,7 @@ export function buildArtifactReview({
       artifactContentDigest: contentDigest,
       changedFiles: "files/changed-files.json",
       testResults: "files/test-results.json",
+      runtimeReferenceManifest: "files/runtime-reference-manifest.json",
     },
     ...(browser ? { browser } : {}),
     riskFlags: [],

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -3,7 +3,7 @@ import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "n
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
 import { basename, dirname, join, relative, resolve } from "node:path"
-import { assertRuntimeCommandAllowed, calculateArtifactManifestFileSha256 } from "@chubes4/wp-codebox-core"
+import { assertRuntimeCommandAllowed, buildRuntimeReferenceManifest, calculateArtifactManifestFileSha256 } from "@chubes4/wp-codebox-core"
 import {
   MAX_CAPTURED_MOUNT_FILE_BYTES,
   MAX_CAPTURED_MOUNT_FILES,
@@ -395,6 +395,7 @@ class PlaygroundRuntime implements Runtime {
     const patchPath = join(filesDirectory, "patch.diff")
     const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
+    const runtimeReferenceManifestPath = join(filesDirectory, "runtime-reference-manifest.json")
     const redactor = new ArtifactRedactor(this.spec.secretEnv)
     await this.redactBrowserArtifacts(redactor)
     await this.redactPluginCheckArtifacts(redactor)
@@ -454,6 +455,7 @@ class PlaygroundRuntime implements Runtime {
       patch: relative(this.artifactRoot, patchPath),
       testResults: relative(this.artifactRoot, testResultsPath),
       review: relative(this.artifactRoot, reviewPath),
+      runtimeReferenceManifest: relative(this.artifactRoot, runtimeReferenceManifestPath),
       mountDiffs: relative(this.artifactRoot, diffsPath),
       ...(browser ? { browser: "files/browser/summary.json" } : {}),
       ...(this.pluginChecks.length > 0 ? { pluginChecks: this.pluginChecks.map((check) => check.files.normalized) } : {}),
@@ -489,6 +491,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(patchPath, "patch", "text/x-diff"),
       fileEntry(testResultsPath, "test-results", "application/json"),
       fileEntry(reviewPath, "review", "application/json"),
+      fileEntry(runtimeReferenceManifestPath, "runtime-reference-manifest", "application/json"),
       ...this.browserManifestFiles(),
       ...this.pluginCheckManifestFiles(),
       ...this.themeCheckManifestFiles(),
@@ -519,6 +522,7 @@ class PlaygroundRuntime implements Runtime {
       review.riskFlags.push("secrets-redacted")
     }
     await writeRedactedArtifact(redactor, reviewPath, this.artifactRoot, `${JSON.stringify(review, null, 2)}\n`)
+    await writeFile(runtimeReferenceManifestPath, "{}\n")
     metadata.redaction = redactor.summary()
     await writeRedactedArtifact(redactor, metadataPath, this.artifactRoot, `${JSON.stringify(metadata, null, 2)}\n`)
 
@@ -550,6 +554,33 @@ class PlaygroundRuntime implements Runtime {
         value: await calculateArtifactManifestFileSha256(this.artifactRoot, manifest, file),
       },
     })))
+    const runtimeReferenceManifest = buildRuntimeReferenceManifest({
+      createdAt,
+      runtime,
+      artifactBundle: {
+        kind: "artifact-bundle",
+        id: bundleId,
+        digest: { algorithm: "sha256", value: contentDigest },
+      },
+      files: manifest.files
+        .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json"].includes(file.path))
+        .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 })),
+    })
+    await writeFile(runtimeReferenceManifestPath, `${JSON.stringify(runtimeReferenceManifest, null, 2)}\n`)
+    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "files/runtime-reference-manifest.json" ? ({
+      ...file,
+      sha256: {
+        algorithm: "sha256" as const,
+        value: await calculateArtifactManifestFileSha256(this.artifactRoot, manifest, file),
+      },
+    }) : file))
+    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path !== "manifest.json" ? file : ({
+      ...file,
+      sha256: {
+        algorithm: "sha256" as const,
+        value: await calculateArtifactManifestFileSha256(this.artifactRoot, manifest, file),
+      },
+    })))
     await writeRedactedArtifact(redactor, manifestPath, this.artifactRoot, `${JSON.stringify(manifest, null, 2)}\n`)
 
     return {
@@ -571,6 +602,7 @@ class PlaygroundRuntime implements Runtime {
       patchPath,
       testResultsPath,
       reviewPath,
+      runtimeReferenceManifestPath,
       ...(preview ? { preview } : {}),
       contentDigest,
       createdAt,

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -6,7 +6,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { createRuntime, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
+import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, createRuntime, runtimeReferenceManifestDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 const execFileAsync = promisify(execFile)
@@ -61,6 +61,7 @@ try {
   const patch = await readFile(artifacts.patchPath, "utf8")
   const testResults = JSON.parse(await readFile(artifacts.testResultsPath, "utf8"))
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
+  const runtimeReferenceManifest = JSON.parse(await readFile(artifacts.runtimeReferenceManifestPath, "utf8"))
   const contentDigest = createHash("sha256")
     .update("wp-codebox/artifact-content/v1\n")
     .update("files/changed-files.json\n")
@@ -83,6 +84,7 @@ try {
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/patch.diff" && file.kind === "patch"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/test-results.json" && file.kind === "test-results"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/review.json" && file.kind === "review"))
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-evidence/run-attestation.json" && file.kind === "run-attestation"))
   const runtimeEvidence = metadata.artifacts.runtimeEvidence
   assert.match(runtimeEvidence["run-attestation"].sha256, /^[a-f0-9]{64}$/)
@@ -91,6 +93,7 @@ try {
     patch: "files/patch.diff",
     testResults: "files/test-results.json",
     review: "files/review.json",
+    runtimeReferenceManifest: "files/runtime-reference-manifest.json",
     mountDiffs: "files/diffs.json",
     runtimeEvidence,
   })
@@ -137,6 +140,14 @@ try {
   assert.equal(review.evidence.artifactContentDigest, contentDigest)
   assert.equal(review.evidence.changedFiles, "files/changed-files.json")
   assert.equal(review.evidence.testResults, "files/test-results.json")
+  assert.equal(review.evidence.runtimeReferenceManifest, "files/runtime-reference-manifest.json")
+  assert.equal(runtimeReferenceManifest.schema, RUNTIME_REFERENCE_MANIFEST_SCHEMA)
+  assert.equal(runtimeReferenceManifest.artifactBundle.id, artifacts.id)
+  assert.equal(runtimeReferenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
+  assert.equal(runtimeReferenceManifest.digest.value, runtimeReferenceManifestDigest(runtimeReferenceManifest).value)
+  assert.equal(runtimeReferenceManifest.id, `runtime-reference-manifest-sha256-${runtimeReferenceManifest.digest.value}`)
+  assert.equal(runtimeReferenceManifest.snapshots.length, 0)
+  assert.ok(runtimeReferenceManifest.files.some((file: { path: string }) => file.path === "files/changed-files.json"))
   assert.ok(review.changedFiles.some((file: { path: string; status: string }) =>
     file.path === "/wordpress/wp-content/plugins/seeded-helper/generated.txt" && file.status === "added",
   ))

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -9,6 +9,8 @@ import {
   RUNTIME_EPISODE_ACTION_SCHEMA,
   RUNTIME_EPISODE_OBSERVATION_SCHEMA,
   RUNTIME_EPISODE_SNAPSHOT_SCHEMA,
+  RUNTIME_REFERENCE_MANIFEST_SCHEMA,
+  runtimeReferenceManifestDigest,
   createRuntimeEpisode,
   validateRuntimeEpisodeTrace,
   verifyArtifactBundle,
@@ -94,10 +96,26 @@ try {
     const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode-trace.json" && file.kind === "runtime-episode-trace"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode.jsonl" && file.kind === "runtime-episode-events"))
+    assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
 
     const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
     assert.equal(review.evidence.runtimeEpisodeTrace, "files/runtime-episode-trace.json")
+    assert.equal(review.evidence.runtimeReferenceManifest, "files/runtime-reference-manifest.json")
     assert.ok(review.progress.some((event: { component?: string; label?: string }) => event.component === "runtime-episode" && event.label === "Runtime episode trace persisted"))
+
+    const referenceManifest = JSON.parse(await readFile(artifacts.runtimeReferenceManifestPath ?? "", "utf8"))
+    assert.equal(referenceManifest.schema, RUNTIME_REFERENCE_MANIFEST_SCHEMA)
+    assert.equal(referenceManifest.artifactBundle.id, artifacts.id)
+    assert.equal(referenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
+    assert.equal(referenceManifest.trace.path, "files/runtime-episode-trace.json")
+    assert.equal(referenceManifest.events.path, "files/runtime-episode.jsonl")
+    assert.equal(referenceManifest.snapshots.length, 1)
+    assert.equal(referenceManifest.snapshots[0].id, snapshot.id)
+    assert.equal(referenceManifest.snapshots[0].semantics, "metadata-only")
+    assert.equal(referenceManifest.snapshots[0].replay.status, "metadata-only")
+    assert.ok(referenceManifest.snapshots[0].replay.limitations.some((limitation: string) => limitation.includes("not a WordPress database or filesystem checkpoint")))
+    assert.equal(referenceManifest.digest.value, runtimeReferenceManifestDigest(referenceManifest).value)
+    assert.equal(referenceManifest.id, `runtime-reference-manifest-sha256-${referenceManifest.digest.value}`)
 
     const trace = await episode.trace()
     const persistedTrace = JSON.parse(await readFile(artifacts.runtimeEpisodeTracePath, "utf8"))


### PR DESCRIPTION
## Summary
- Adds a generic `wp-codebox/runtime-reference-manifest/v1` contract for artifact bundles with stable, hashable runtime refs.
- Writes `files/runtime-reference-manifest.json` into Playground artifact bundles and updates episode bundles with trace/events and explicit snapshot replay semantics.
- Extends verification, smokes, and README docs so manifest refs are checked and metadata-only snapshots are clearly not full WordPress checkpoints.

## Scope
- Closes #222.
- Lays the foundation for #220 by making snapshot semantics explicit and replay inputs discoverable through a stable manifest.
- Full replayable WordPress state capture remains scoped follow-up work: database export/import, uploads/media capture, active theme/plugin state, and binary-file replay.

## Tests
- `npm run build`
- `npm run runtime-episode-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `npm run artifact-contract-smoke`
- `npm run check` passed through `preview-response-body-smoke`, then timed out during `boot-preview-smoke` after 40 minutes.
- Tail commands rerun individually: `npm run boot-preview-smoke`, `npm run blueprint-validation-smoke`, `npm run browser-probe-artifact-smoke`, `npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the runtime reference manifest substrate, updated artifact verification/tests/docs, and ran local verification; Chris remains responsible for review and merge.