### PR TITLE
Expand browser probe evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,13 +403,13 @@ Supported runtime commands today:
 - `wordpress.run-php`: run PHP; accepts `code=<php>` or `code-file=<path>`.
 - `wordpress.wp-cli`: run WP-CLI; accepts `command='wp option get home'` or plain args.
 - `wordpress.ability`: execute a registered WordPress Ability; accepts `name=<ability>` and optional JSON `input=<object>`.
-- `wordpress.browser-probe`: boot the live preview, visit `url=<path-or-url>` with Playwright, and capture browser console, page errors, and screenshot artifacts under `files/browser/`.
+- `wordpress.browser-probe`: boot the live preview, visit `url=<path-or-url>` with Playwright, and capture generic browser replay/audit evidence under `files/browser/`.
 
 `wordpress.run-php` loads `/wordpress/wp-load.php` by default. Use `--arg bootstrap=none` for raw PHP.
 
 `wordpress.wp-cli` automatically enables Playground's `wp-cli` extra library when the command is allowed by runtime policy.
 
-`wordpress.browser-probe` accepts `wait-for=domcontentloaded|load|networkidle|selector:<selector>|duration`, `duration=<n>s`, and `capture=console,errors,screenshot`. It records `files/browser/console.jsonl`, `files/browser/errors.jsonl`, `files/browser/screenshot.png`, and `files/browser/summary.json` when those captures are enabled, and the artifact review includes a concise browser summary with counts.
+`wordpress.browser-probe` accepts `wait-for=domcontentloaded|load|networkidle|selector:<selector>|duration`, `duration=<n>s`, and `capture=console,errors,html,network,screenshot`. It records machine-readable evidence refs such as `files/browser/console.jsonl`, `files/browser/errors.jsonl`, `files/browser/network.jsonl`, `files/browser/snapshot.html`, `files/browser/screenshot.png`, and `files/browser/summary.json` when those captures are enabled. The summary includes requested/final URLs, viewport/device metadata, HTML and screenshot hashes, network event counts, and a generic `artifact-backed|partial|diagnostic-only` replayability classification. WP Codebox intentionally keeps these browser evidence fields generic; consumers such as eval harnesses may interpret them without WP Codebox adding scoring, grading, or benchmark semantics.
 
 WP Codebox defaults to WordPress `7.0` because the agent and AI plugin stacks need the modern WordPress AI surface. Override with `--wp trunk`, `--wp nightly`, or another supported Playground version.
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -672,14 +672,14 @@ const commandCatalog: CommandMetadata[] = [
   },
   {
     id: "wordpress.browser-probe",
-    description: "Open the live Playground preview in Playwright and capture browser console, page errors, and screenshot artifacts.",
+    description: "Open the live Playground preview in Playwright and capture generic browser replay/audit evidence artifacts.",
     acceptedArgs: [
       { name: "url", description: "Preview path or absolute URL to visit.", required: true, format: "path or URL" },
       { name: "wait-for", description: "Navigation wait condition.", format: "domcontentloaded|load|networkidle|selector:<selector>|duration" },
       { name: "duration", description: "Extra capture duration, or wait time when wait-for=duration.", format: "duration, e.g. 2s or 500ms" },
-      { name: "capture", description: "Comma-separated artifacts to capture.", format: "console,errors,screenshot" },
+      { name: "capture", description: "Comma-separated artifacts to capture.", format: "console,errors,html,network,screenshot" },
     ],
-    outputShape: "JSON summary plus files/browser/console.jsonl, errors.jsonl, summary.json, and screenshot.png when captured.",
+    outputShape: "JSON summary plus files/browser/console.jsonl, errors.jsonl, network.jsonl, snapshot.html, summary.json, and screenshot.png when captured.",
     policyRequirement: "Runtime policy commands must include wordpress.browser-probe.",
     recipe: true,
   },
@@ -3484,7 +3484,7 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
     const capture = recipeStepArgValue(step.args ?? [], "capture")
     if (capture) {
       for (const item of capture.split(",").map((value) => value.trim()).filter(Boolean)) {
-        if (!["console", "errors", "screenshot"].includes(item)) {
+        if (!["console", "errors", "html", "network", "screenshot"].includes(item)) {
           addIssue("invalid-capture", `${path}.args`, `wordpress.browser-probe capture does not support: ${item}`)
         }
       }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -641,8 +641,22 @@ export interface ArtifactReviewBrowserSummary {
   summary: string
   probes: Array<{
     url: string
+    requestedUrl?: string
+    finalUrl?: string
+    viewport?: {
+      width: number
+      height: number
+      deviceScaleFactor: number
+      isMobile: boolean
+      hasTouch: boolean
+      userAgent: string
+    } | null
+    replayability?: "artifact-backed" | "partial" | "diagnostic-only"
     consoleMessages: number
     errors: number
+    html?: string
+    network?: string
+    networkEvents?: number
     screenshot?: string
     console?: string
     errorsFile?: string

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -46,7 +46,7 @@ import type {
   RuntimeInfo,
   Snapshot,
 } from "@chubes4/wp-codebox-core"
-import type { ConsoleMessage, Page } from "playwright"
+import type { ConsoleMessage, Page, Request, Response } from "playwright"
 
 function now(): string {
   return new Date().toISOString()
@@ -167,19 +167,38 @@ interface PlaygroundCliModule {
 }
 
 interface BrowserProbeArtifact {
+  requestedUrl: string
   url: string
   files: {
     console?: string
     errors?: string
+    html?: string
+    network?: string
     screenshot?: string
     summary: string
   }
   summary: {
     consoleMessages: number
     errors: number
+    finalUrl: string
+    htmlSnapshot: boolean
+    networkEvents: number
+    replayability: BrowserProbeReplayability
     screenshot: boolean
+    viewport: BrowserProbeViewport | null
   }
 }
+
+interface BrowserProbeViewport {
+  width: number
+  height: number
+  deviceScaleFactor: number
+  isMobile: boolean
+  hasTouch: boolean
+  userAgent: string
+}
+
+type BrowserProbeReplayability = "artifact-backed" | "partial" | "diagnostic-only"
 
 interface PluginCheckArtifact {
   targetPlugin: string
@@ -203,6 +222,19 @@ interface BrowserProbeErrorRecord {
   message: string
   stack?: string
   timestamp: string
+}
+
+interface BrowserProbeNetworkRecord {
+  type: "response" | "requestfailed"
+  url: string
+  method: string
+  resourceType: string
+  timestamp: string
+  status?: number
+  statusText?: string
+  ok?: boolean
+  contentType?: string | null
+  failure?: ReturnType<Request["failure"]>
 }
 
 interface ThemeCheckArtifact {
@@ -864,12 +896,14 @@ class PlaygroundRuntime implements Runtime {
     if (capture.size === 0) {
       capture.add("console")
       capture.add("errors")
+      capture.add("html")
+      capture.add("network")
       capture.add("screenshot")
     }
 
     for (const item of capture) {
-      if (!["console", "errors", "screenshot"].includes(item)) {
-        throw new Error(`wordpress.browser-probe capture supports console, errors, screenshot: ${item}`)
+      if (!["console", "errors", "html", "network", "screenshot"].includes(item)) {
+        throw new Error(`wordpress.browser-probe capture supports console, errors, html, network, screenshot: ${item}`)
       }
     }
 
@@ -881,30 +915,50 @@ class PlaygroundRuntime implements Runtime {
 
     const consoleMessages: Record<string, unknown>[] = []
     const errors: BrowserProbeErrorRecord[] = []
+    const network: BrowserProbeNetworkRecord[] = []
     const consolePath = join(browserDirectory, "console.jsonl")
     const errorsPath = join(browserDirectory, "errors.jsonl")
+    const htmlPath = join(browserDirectory, "snapshot.html")
+    const networkPath = join(browserDirectory, "network.jsonl")
     const screenshotPath = join(browserDirectory, "screenshot.png")
     const summaryPath = join(browserDirectory, "summary.json")
     const startedAt = now()
     const { chromium } = await import("playwright")
     const browser = await chromium.launch()
+    let finalUrl = targetUrl
+    let htmlSha256: string | undefined
+    let screenshotSha256: string | undefined
+    let viewport: BrowserProbeViewport | null = null
 
     try {
       const page = await browser.newPage()
+      viewport = await browserProbeViewport(page)
       if (capture.has("console")) {
         page.on("console", (message) => consoleMessages.push(serializeBrowserConsoleMessage(message)))
       }
       if (capture.has("errors")) {
         page.on("pageerror", (error) => errors.push(serializeBrowserError("pageerror", error)))
       }
+      if (capture.has("network")) {
+        page.on("response", (response) => network.push(serializeBrowserResponse(response)))
+        page.on("requestfailed", (request) => network.push(serializeBrowserRequestFailure(request)))
+      }
 
       await navigateBrowserProbe(page, targetUrl, waitFor, durationMs)
       if (durationMs > 0 && waitFor !== "duration") {
         await page.waitForTimeout(durationMs)
       }
+      finalUrl = page.url()
+
+      if (capture.has("html")) {
+        const html = await page.content()
+        await writeFile(htmlPath, html)
+        htmlSha256 = sha256(Buffer.from(html, "utf8"))
+      }
 
       if (capture.has("screenshot")) {
         await page.screenshot({ path: screenshotPath, fullPage: true })
+        screenshotSha256 = await fileSha256(screenshotPath)
       }
     } catch (error) {
       errors.push(serializeBrowserError("probe-error", error))
@@ -917,38 +971,56 @@ class PlaygroundRuntime implements Runtime {
       if (capture.has("errors")) {
         await writeFile(errorsPath, jsonLines(errors))
       }
+      if (capture.has("network")) {
+        await writeFile(networkPath, jsonLines(network))
+      }
 
       const artifact: BrowserProbeArtifact = {
+        requestedUrl: targetUrl,
         url: targetUrl,
         files: {
           ...(capture.has("console") ? { console: "files/browser/console.jsonl" } : {}),
           ...(capture.has("errors") ? { errors: "files/browser/errors.jsonl" } : {}),
+          ...(capture.has("html") ? { html: "files/browser/snapshot.html" } : {}),
+          ...(capture.has("network") ? { network: "files/browser/network.jsonl" } : {}),
           ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
           summary: "files/browser/summary.json",
         },
         summary: {
           consoleMessages: consoleMessages.length,
           errors: errors.length,
+          finalUrl,
+          htmlSnapshot: capture.has("html"),
+          networkEvents: network.length,
+          replayability: browserProbeReplayability(capture),
           screenshot: capture.has("screenshot"),
+          viewport,
         },
       }
       this.browserProbes.push(artifact)
       await writeFile(summaryPath, `${JSON.stringify({
         schema: "wp-codebox/browser-probe/v1",
-        url: targetUrl,
+        requestedUrl: targetUrl,
+        finalUrl,
         waitFor,
         durationMs,
         capture: [...capture].sort(),
         startedAt,
         finishedAt: now(),
         files: artifact.files,
+        hashes: {
+          ...(htmlSha256 ? { html: { algorithm: "sha256", value: htmlSha256 } } : {}),
+          ...(screenshotSha256 ? { screenshot: { algorithm: "sha256", value: screenshotSha256 } } : {}),
+        },
+        viewport,
         summary: artifact.summary,
       }, null, 2)}\n`)
     }
 
     return `${JSON.stringify({
       command: "wordpress.browser-probe",
-      url: targetUrl,
+      requestedUrl: targetUrl,
+      finalUrl: this.browserProbes.at(-1)?.summary.finalUrl ?? targetUrl,
       files: this.browserProbes.at(-1)?.files,
       summary: this.browserProbes.at(-1)?.summary,
     }, null, 2)}\n`
@@ -1382,8 +1454,15 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
       summary: `Browser probe captured ${consoleMessages} console message${consoleMessages === 1 ? "" : "s"}, ${errors} error${errors === 1 ? "" : "s"}, and ${screenshots} screenshot${screenshots === 1 ? "" : "s"}.`,
       probes: this.browserProbes.map((probe) => ({
         url: probe.url,
+        requestedUrl: probe.requestedUrl,
+        finalUrl: probe.summary.finalUrl,
+        viewport: probe.summary.viewport,
+        replayability: probe.summary.replayability,
         consoleMessages: probe.summary.consoleMessages,
         errors: probe.summary.errors,
+        html: probe.files.html,
+        network: probe.files.network,
+        networkEvents: probe.summary.networkEvents,
         screenshot: probe.files.screenshot,
         console: probe.files.console,
         errorsFile: probe.files.errors,
@@ -1404,6 +1483,12 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
       if (probe.files.errors) {
         files.set(probe.files.errors, { kind: "browser-errors", contentType: "application/x-ndjson" })
       }
+      if (probe.files.html) {
+        files.set(probe.files.html, { kind: "browser-html-snapshot", contentType: "text/html; charset=utf-8" })
+      }
+      if (probe.files.network) {
+        files.set(probe.files.network, { kind: "browser-network", contentType: "application/x-ndjson" })
+      }
       if (probe.files.screenshot) {
         files.set(probe.files.screenshot, { kind: "browser-screenshot", contentType: "image/png" })
       }
@@ -1422,7 +1507,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
 
   private async redactBrowserArtifacts(redactor: ArtifactRedactor): Promise<void> {
     for (const probe of this.browserProbes) {
-      for (const path of [probe.files.console, probe.files.errors, probe.files.summary]) {
+      for (const path of [probe.files.console, probe.files.errors, probe.files.html, probe.files.network, probe.files.summary]) {
         if (!path) {
           continue
         }
@@ -1513,6 +1598,70 @@ function resolveBrowserProbeUrl(pathOrUrl: string, baseUrl: string): string {
   } catch {
     return new URL(pathOrUrl, baseUrl).toString()
   }
+}
+
+async function browserProbeViewport(page: Page): Promise<BrowserProbeViewport> {
+  const viewport = page.viewportSize()
+  const device = await page.evaluate(() => ({
+    deviceScaleFactor: window.devicePixelRatio,
+    hasTouch: navigator.maxTouchPoints > 0,
+    userAgent: navigator.userAgent,
+  }))
+
+  return {
+    width: viewport?.width ?? 0,
+    height: viewport?.height ?? 0,
+    deviceScaleFactor: device.deviceScaleFactor,
+    isMobile: /Mobile|Android|iPhone|iPad/i.test(device.userAgent),
+    hasTouch: device.hasTouch,
+    userAgent: device.userAgent,
+  }
+}
+
+function browserProbeReplayability(capture: Set<string>): BrowserProbeReplayability {
+  if (capture.has("html") && capture.has("screenshot")) {
+    return "artifact-backed"
+  }
+
+  if (capture.has("html") || capture.has("screenshot") || capture.has("network")) {
+    return "partial"
+  }
+
+  return "diagnostic-only"
+}
+
+function serializeBrowserResponse(response: Response): BrowserProbeNetworkRecord {
+  const request = response.request()
+  return {
+    type: "response",
+    url: response.url(),
+    method: request.method(),
+    resourceType: request.resourceType(),
+    status: response.status(),
+    statusText: response.statusText(),
+    ok: response.ok(),
+    contentType: response.headers()["content-type"] ?? null,
+    timestamp: now(),
+  }
+}
+
+function serializeBrowserRequestFailure(request: Request): BrowserProbeNetworkRecord {
+  return {
+    type: "requestfailed",
+    url: request.url(),
+    method: request.method(),
+    resourceType: request.resourceType(),
+    failure: request.failure(),
+    timestamp: now(),
+  }
+}
+
+async function fileSha256(path: string): Promise<string> {
+  return sha256(await readFile(path))
+}
+
+function sha256(contents: Buffer): string {
+  return createHash("sha256").update(contents).digest("hex")
 }
 
 function durationArg(args: string[], name: string, fallbackMs: number): number {

--- a/scripts/browser-probe-artifact-smoke.ts
+++ b/scripts/browser-probe-artifact-smoke.ts
@@ -37,7 +37,7 @@ await writeFile(recipePath, `${JSON.stringify({
     steps: [
       {
         command: "wordpress.browser-probe",
-        args: ["url=/", "wait-for=load", "duration=1s", "capture=console,errors,screenshot"],
+        args: ["url=/", "wait-for=load", "duration=1s", "capture=console,errors,html,network,screenshot"],
       },
     ],
   },
@@ -60,6 +60,8 @@ assert.ok(output.artifacts?.directory, "recipe-run should return an artifact dir
 const artifactDirectory = output.artifacts.directory
 const consolePath = join(artifactDirectory, "files", "browser", "console.jsonl")
 const errorsPath = join(artifactDirectory, "files", "browser", "errors.jsonl")
+const htmlPath = join(artifactDirectory, "files", "browser", "snapshot.html")
+const networkPath = join(artifactDirectory, "files", "browser", "network.jsonl")
 const screenshotPath = join(artifactDirectory, "files", "browser", "screenshot.png")
 const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
 const manifestPath = join(artifactDirectory, "manifest.json")
@@ -67,23 +69,56 @@ const reviewPath = join(artifactDirectory, "files", "review.json")
 
 assert.equal(existsSync(consolePath), true, "console.jsonl should be captured")
 assert.equal(existsSync(errorsPath), true, "errors.jsonl should be captured")
+assert.equal(existsSync(htmlPath), true, "snapshot.html should be captured")
+assert.equal(existsSync(networkPath), true, "network.jsonl should be captured")
 assert.equal(existsSync(screenshotPath), true, "screenshot.png should be captured")
 assert.equal(existsSync(summaryPath), true, "summary.json should be captured")
 
 const consoleLog = await readFile(consolePath, "utf8")
 const errorLog = await readFile(errorsPath, "utf8")
+const htmlSnapshot = await readFile(htmlPath, "utf8")
+const networkLog = await readFile(networkPath, "utf8")
 assert.match(consoleLog, /wp-codebox fixture console error/)
 assert.match(errorLog, /wp-codebox fixture browser error/)
+assert.match(htmlSnapshot, /Browser Error Fixture|wp-codebox fixture console error/)
+assert.match(networkLog, /"type":"response"/)
+
+const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
+  requestedUrl: string
+  finalUrl: string
+  files: { html?: string; network?: string; screenshot?: string }
+  hashes: { html?: { value: string }; screenshot?: { value: string } }
+  viewport: { width: number; height: number; userAgent: string }
+  summary: { replayability: string; networkEvents: number; htmlSnapshot: boolean }
+}
+assert.equal(summary.requestedUrl.endsWith("/"), true, "summary should include requested URL")
+assert.equal(summary.finalUrl.endsWith("/"), true, "summary should include final URL")
+assert.equal(summary.files.html, "files/browser/snapshot.html")
+assert.equal(summary.files.network, "files/browser/network.jsonl")
+assert.match(summary.hashes.html?.value ?? "", /^[a-f0-9]{64}$/)
+assert.match(summary.hashes.screenshot?.value ?? "", /^[a-f0-9]{64}$/)
+assert.equal(summary.summary.replayability, "artifact-backed")
+assert.equal(summary.summary.htmlSnapshot, true)
+assert.ok(summary.summary.networkEvents >= 1, "summary should count network events")
+assert.ok(summary.viewport.width > 0, "summary should include viewport width")
+assert.ok(summary.viewport.height > 0, "summary should include viewport height")
+assert.ok(summary.viewport.userAgent.length > 0, "summary should include user agent")
 
 const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
 assert.ok(manifest.files.some((file) => file.path === "files/browser/console.jsonl" && file.kind === "browser-console"))
 assert.ok(manifest.files.some((file) => file.path === "files/browser/errors.jsonl" && file.kind === "browser-errors"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/snapshot.html" && file.kind === "browser-html-snapshot"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/network.jsonl" && file.kind === "browser-network"))
 assert.ok(manifest.files.some((file) => file.path === "files/browser/screenshot.png" && file.kind === "browser-screenshot"))
 
-const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ consoleMessages: number; errors: number }> } }
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ consoleMessages: number; errors: number; html?: string; network?: string; finalUrl?: string; replayability?: string }> } }
 assert.ok(review.browser?.probes?.[0], "review should include browser probe summary")
 assert.ok(review.browser.probes[0].consoleMessages >= 1, "review should count console messages")
 assert.ok(review.browser.probes[0].errors >= 1, "review should count browser errors")
+assert.equal(review.browser.probes[0].html, "files/browser/snapshot.html")
+assert.equal(review.browser.probes[0].network, "files/browser/network.jsonl")
+assert.equal(review.browser.probes[0].replayability, "artifact-backed")
+assert.equal(review.browser.probes[0].finalUrl?.endsWith("/"), true, "review should include final URL")
 
 console.log(`Browser probe artifact smoke passed: ${artifactDirectory}`)
 


### PR DESCRIPTION
## Summary
- Expand `wordpress.browser-probe` with generic replay/audit evidence refs for HTML snapshots, network summaries, final URLs, viewport/device metadata, hashes, and replayability classification.
- Surface the new browser evidence refs in artifact manifests and artifact reviews while preserving existing console/error/screenshot outputs.
- Update the browser probe smoke and README contract for machine-readable evidence consumers.

## Tests
- `npm run build`
- `npm run browser-probe-artifact-smoke`
- `npm run discovery-command-smoke`
- `npm run check` partially ran until the bash tool timeout; completed through `artifact-contract-smoke` entry after earlier steps passed.
- Direct follow-up smokes using this worktree's `./node_modules/.bin/tsx`: `scripts/artifact-contract-smoke.ts`, `scripts/preview-port-smoke.ts`, `scripts/preview-public-url-canonical-smoke.ts`, `scripts/preview-response-body-smoke.ts`, `scripts/boot-preview-smoke.ts`, `scripts/blueprint-validation-smoke.ts`, `scripts/browser-probe-artifact-smoke.ts`.
- Direct CLI smoke: `node packages/cli/dist/index.js run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`.

## Notes
- `npm run check` could not complete as one command in this local session because the shell timed out and stale sibling-worktree WP Codebox smoke processes were present. The affected smokes passed when run directly from this issue worktree.

Closes #221.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the browser evidence implementation, smoke coverage, documentation update, and local verification. Chris remains responsible for review and merge.