### PR TITLE
Add generic runtime evidence envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ those files with `runtime-episode-trace` and `runtime-episode-events` kinds,
 checks the advertised trace file exists and validates against
 `wp-codebox/runtime-episode-trace/v1`.
 
-Products such as eval harnesses can project this generic episode trace into their
-own action, observation, reward, and report schemas outside WP Codebox.
+Products can project this generic episode trace into their own domain schemas
+outside WP Codebox.
 
 The episode trace is a versioned machine-verifiable contract with schema
 `wp-codebox/runtime-episode-trace/v1`. `@chubes4/wp-codebox-core` exports
@@ -334,12 +334,20 @@ the trace into their own schemas.
 Episode steps include stable ids and refs for the step, requested action,
 runtime execution, optional observation, and collected artifact bundle. Actions
 use the generic `wp-codebox/runtime-episode-action/v1` envelope with
-`kind: "command"`, a command name, string args, optional `cwd`, optional
-`timeoutMs`, and a SHA-256 digest over that replay payload. Observations use
-the generic `wp-codebox/runtime-episode-observation/v1` envelope with id, type,
-data, timestamp, and digest. Refs carry matching digests so callers can compare
-action args, observations, executions, snapshots, and artifacts without parsing
-presentation logs.
+`kind: "command" | "filesystem" | "http" | "browser"`, the underlying command
+execution name, string args, optional replay intent fields such as `method`,
+`url`, `path`, `operation`, `selector`, and a SHA-256 digest over that canonical
+payload. Non-command action kinds preserve higher-level runtime intent while the
+command execution remains the compatibility primitive.
+
+Observations use the generic `wp-codebox/runtime-episode-observation/v1`
+envelope with id, type, data, timestamp, optional artifact refs, and digest. The
+Playground backend provides structured observation types for `runtime-info`,
+`mounts`, `command-result`, `wordpress-state`, `http-response`,
+`browser-result`, `runtime-events`, and `runtime-logs`. Large observation
+payloads can be stored as bundle-relative artifacts and referenced by digest.
+Refs carry matching digests so callers can compare action args, observations,
+executions, snapshots, and artifacts without parsing presentation logs.
 
 Replay is bounded to the generic runtime contract. A consumer can replay a step
 by creating a compatible backend runtime, applying the same mounts/artifact

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -34,11 +34,18 @@ export const RUNTIME_EPISODE_TRACE_JSON_SCHEMA = {
             properties: {
               schema: { const: RUNTIME_EPISODE_ACTION_SCHEMA },
               id: { type: "string", minLength: 1 },
-              kind: { const: "command" },
+              kind: { enum: ["command", "filesystem", "http", "browser"] },
               command: { type: "string", minLength: 1 },
               args: { type: "array", items: { type: "string" } },
               cwd: { type: "string" },
               timeoutMs: { type: "number", minimum: 0 },
+              method: { type: "string", minLength: 1 },
+              url: { type: "string", minLength: 1 },
+              path: { type: "string", minLength: 1 },
+              operation: { type: "string", minLength: 1 },
+              selector: { type: "string", minLength: 1 },
+              description: { type: "string", minLength: 1 },
+              metadata: { type: "object" },
               digest: {
                 type: "object",
                 required: ["algorithm", "value"],
@@ -437,6 +444,19 @@ export interface ExecutionSpec {
   timeoutMs?: number
 }
 
+export type RuntimeEpisodeActionKind = "command" | "filesystem" | "http" | "browser"
+
+export interface RuntimeEpisodeActionSpec extends ExecutionSpec {
+  kind?: RuntimeEpisodeActionKind
+  method?: string
+  url?: string
+  path?: string
+  operation?: string
+  selector?: string
+  description?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface RuntimeEpisodeContentDigest {
   algorithm: "sha256"
   value: string
@@ -453,11 +473,18 @@ export interface RuntimeEpisodeTraceRef {
 export interface RuntimeEpisodeActionRecord {
   schema: typeof RUNTIME_EPISODE_ACTION_SCHEMA
   id: string
-  kind: "command"
+  kind: RuntimeEpisodeActionKind
   command: string
   args: string[]
   cwd?: string
   timeoutMs?: number
+  method?: string
+  url?: string
+  path?: string
+  operation?: string
+  selector?: string
+  description?: string
+  metadata?: Record<string, unknown>
   digest: RuntimeEpisodeContentDigest
 }
 
@@ -473,8 +500,24 @@ export interface ExecutionResult {
 }
 
 export interface ObservationSpec {
-  type: "runtime-info" | "mounts" | "files" | (string & {})
+  type:
+    | "runtime-info"
+    | "mounts"
+    | "files"
+    | "command-result"
+    | "wordpress-state"
+    | "http-response"
+    | "browser-result"
+    | "runtime-events"
+    | "runtime-logs"
+    | (string & {})
   path?: string
+  commandId?: string
+  url?: string
+  method?: string
+  headers?: Record<string, string>
+  body?: string
+  includeBody?: boolean
 }
 
 export interface ObservationResult {
@@ -483,6 +526,7 @@ export interface ObservationResult {
   type: string
   data: unknown
   observedAt: string
+  artifactRefs?: RuntimeEpisodeTraceRef[]
   digest?: RuntimeEpisodeContentDigest
 }
 
@@ -1219,7 +1263,7 @@ export interface RuntimeEpisodeTraceValidationResult {
 
 export interface RuntimeEpisode {
   reset(): Promise<RuntimeEpisodeResetResult>
-  step(action: ExecutionSpec, observation?: ObservationSpec | false): Promise<RuntimeEpisodeStepResult>
+  step(action: RuntimeEpisodeActionSpec, observation?: ObservationSpec | false): Promise<RuntimeEpisodeStepResult>
   observe(spec: ObservationSpec): Promise<ObservationResult>
   snapshot(): Promise<Snapshot>
   collectArtifacts(spec?: ArtifactSpec): Promise<ArtifactBundle>
@@ -1364,19 +1408,24 @@ export function runtimeEpisodeDigest(value: unknown): RuntimeEpisodeContentDiges
   }
 }
 
-function runtimeEpisodeActionDigestPayload(action: RuntimeEpisodeActionRecord | ExecutionSpec): Record<string, unknown> {
+function runtimeEpisodeActionDigestPayload(action: RuntimeEpisodeActionRecord | RuntimeEpisodeActionSpec): Record<string, unknown> {
   const payload: Record<string, unknown> = {
     schema: RUNTIME_EPISODE_ACTION_SCHEMA,
-    kind: "command",
+    kind: action.kind ?? "command",
     command: action.command,
     args: Array.isArray(action.args) ? action.args : [],
   }
 
-  if (typeof action.cwd === "string") {
-    payload.cwd = action.cwd
+  for (const key of ["cwd", "method", "url", "path", "operation", "selector", "description"] as const) {
+    if (typeof action[key] === "string") {
+      payload[key] = action[key]
+    }
   }
   if (typeof action.timeoutMs === "number") {
     payload.timeoutMs = action.timeoutMs
+  }
+  if (isRecord(action.metadata)) {
+    payload.metadata = action.metadata
   }
 
   return payload
@@ -1388,6 +1437,7 @@ function runtimeEpisodeObservationDigestPayload(observation: ObservationResult):
     type: observation.type,
     data: observation.data,
     observedAt: observation.observedAt,
+    artifactRefs: observation.artifactRefs ?? [],
   }
 }
 
@@ -1520,8 +1570,8 @@ function validateRuntimeEpisodeAction(
   if (action.schema !== RUNTIME_EPISODE_ACTION_SCHEMA) {
     issues.push({ path: `${path}.schema`, message: `action schema must be ${RUNTIME_EPISODE_ACTION_SCHEMA}` })
   }
-  if (action.kind !== "command") {
-    issues.push({ path: `${path}.kind`, message: "action kind must be command" })
+  if (!["command", "filesystem", "http", "browser"].includes(`${action.kind}`)) {
+    issues.push({ path: `${path}.kind`, message: "action kind must be command, filesystem, http, or browser" })
   }
   if (!nonEmptyString(action.command)) {
     issues.push({ path: `${path}.command`, message: "action command is required" })
@@ -1531,6 +1581,14 @@ function validateRuntimeEpisodeAction(
   }
   if (action.cwd !== undefined && typeof action.cwd !== "string") {
     issues.push({ path: `${path}.cwd`, message: "action cwd must be a string when present" })
+  }
+  for (const key of ["method", "url", "path", "operation", "selector", "description"] as const) {
+    if (action[key] !== undefined && !nonEmptyString(action[key])) {
+      issues.push({ path: `${path}.${key}`, message: `action ${key} must be a non-empty string when present` })
+    }
+  }
+  if (action.metadata !== undefined && !isRecord(action.metadata)) {
+    issues.push({ path: `${path}.metadata`, message: "action metadata must be an object when present" })
   }
   const timeoutMs = action.timeoutMs
   if (timeoutMs !== undefined && (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs < 0)) {
@@ -1575,6 +1633,14 @@ function validateRuntimeEpisodeObservation(
   if (!validDigest(observation.digest)) {
     issues.push({ path: `${path}.digest`, message: "observation digest must be a sha256 digest" })
     return
+  }
+
+  if (observation.artifactRefs !== undefined) {
+    if (!Array.isArray(observation.artifactRefs)) {
+      issues.push({ path: `${path}.artifactRefs`, message: "observation artifactRefs must be an array when present" })
+    } else {
+      observation.artifactRefs.forEach((ref, index) => validateRuntimeEpisodeTraceRef(ref, `${path}.artifactRefs[${index}]`, undefined, issues))
+    }
   }
 
   const expected = runtimeEpisodeDigest(runtimeEpisodeObservationDigestPayload(observation as unknown as ObservationResult))
@@ -1860,7 +1926,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     return this.resetResult
   }
 
-  async step(action: ExecutionSpec, observation: ObservationSpec | false = this.spec.stepObservation ?? false): Promise<RuntimeEpisodeStepResult> {
+  async step(action: RuntimeEpisodeActionSpec, observation: ObservationSpec | false = this.spec.stepObservation ?? false): Promise<RuntimeEpisodeStepResult> {
     const runtime = this.assertRuntime()
     const execution = await runtime.execute(action)
     const index = this.steps.length
@@ -1868,11 +1934,18 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     const actionRecord = {
       schema: RUNTIME_EPISODE_ACTION_SCHEMA,
       id: `${stepId}:action`,
-      kind: "command" as const,
+      kind: action.kind ?? "command",
       command: action.command,
       args: action.args ?? [],
       ...(action.cwd ? { cwd: action.cwd } : {}),
       ...(action.timeoutMs !== undefined ? { timeoutMs: action.timeoutMs } : {}),
+      ...(action.method ? { method: action.method } : {}),
+      ...(action.url ? { url: action.url } : {}),
+      ...(action.path ? { path: action.path } : {}),
+      ...(action.operation ? { operation: action.operation } : {}),
+      ...(action.selector ? { selector: action.selector } : {}),
+      ...(action.description ? { description: action.description } : {}),
+      ...(action.metadata ? { metadata: action.metadata } : {}),
       digest: runtimeEpisodeDigest(runtimeEpisodeActionDigestPayload(action)),
     }
     const stepObservation = observation ? observationWithId(await runtime.observe(observation), `${stepId}:observation`) : undefined

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -3,7 +3,7 @@ import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "n
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
 import { basename, dirname, join, relative, resolve } from "node:path"
-import { assertRuntimeCommandAllowed, calculateArtifactManifestFileSha256 } from "@chubes4/wp-codebox-core"
+import { RUNTIME_EPISODE_OBSERVATION_SCHEMA, assertRuntimeCommandAllowed, calculateArtifactManifestFileSha256, runtimeEpisodeDigest } from "@chubes4/wp-codebox-core"
 import {
   MAX_CAPTURED_MOUNT_FILE_BYTES,
   MAX_CAPTURED_MOUNT_FILES,
@@ -43,6 +43,7 @@ import type {
   Runtime,
   RuntimeBackend,
   RuntimeCreateSpec,
+  RuntimeEpisodeTraceRef,
   RuntimeInfo,
   Snapshot,
 } from "@chubes4/wp-codebox-core"
@@ -337,12 +338,24 @@ class PlaygroundRuntime implements Runtime {
   }
 
   async observe(spec: ObservationSpec): Promise<ObservationResult> {
+    const observationId = id("observation")
+    const observedAt = now()
+    const observed = await this.observeData(spec, observationId)
     const observation: ObservationResult = {
-      id: id("observation"),
+      schema: RUNTIME_EPISODE_OBSERVATION_SCHEMA,
+      id: observationId,
       type: spec.type,
-      data: await this.observeStub(spec),
-      observedAt: now(),
+      data: observed.data,
+      observedAt,
+      ...(observed.artifactRefs.length > 0 ? { artifactRefs: observed.artifactRefs } : {}),
     }
+    observation.digest = runtimeEpisodeDigest({
+      schema: RUNTIME_EPISODE_OBSERVATION_SCHEMA,
+      type: observation.type,
+      data: observation.data,
+      observedAt: observation.observedAt,
+      artifactRefs: observation.artifactRefs ?? [],
+    })
 
     this.observations.push(observation)
     this.recordEvent("runtime.observed", {
@@ -490,6 +503,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(testResultsPath, "test-results", "application/json"),
       fileEntry(reviewPath, "review", "application/json"),
       ...this.browserManifestFiles(),
+      ...this.observationManifestFiles(),
       ...this.pluginCheckManifestFiles(),
       ...this.themeCheckManifestFiles(),
       ...mountDiffs.map((diff) => fileEntry(join(this.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
@@ -1358,6 +1372,47 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     }
   }
 
+  private async observeData(spec: ObservationSpec, observationId: string): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {
+    const artifactRefs: RuntimeEpisodeTraceRef[] = []
+
+    if (spec.type === "command-result") {
+      const command = spec.commandId ? this.commands.find((candidate) => candidate.id === spec.commandId) : this.commands.at(-1)
+      return {
+        data: command
+          ? {
+              id: command.id,
+              command: command.command,
+              args: command.args,
+              exitCode: command.exitCode,
+              stdout: command.stdout,
+              stderr: command.stderr,
+              startedAt: command.startedAt,
+              finishedAt: command.finishedAt,
+            }
+          : { commandId: spec.commandId ?? null, found: false },
+        artifactRefs,
+      }
+    }
+
+    if (spec.type === "wordpress-state") {
+      return { data: await this.observeWordPressState(), artifactRefs }
+    }
+
+    if (spec.type === "http-response") {
+      return this.observeHttpResponse(spec, observationId)
+    }
+
+    if (spec.type === "browser-result") {
+      return { data: this.browserReviewSummary() ?? { probes: [] }, artifactRefs }
+    }
+
+    if (spec.type === "runtime-events" || spec.type === "runtime-logs") {
+      return { data: this.events, artifactRefs }
+    }
+
+    return { data: await this.observeStub(spec), artifactRefs }
+  }
+
   private async observeStub(spec: ObservationSpec): Promise<unknown> {
     if (spec.type === "runtime-info") {
       return this.info()
@@ -1368,6 +1423,78 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     }
 
     return { type: spec.type, path: spec.path ?? null }
+  }
+
+  private async observeWordPressState(): Promise<unknown> {
+    const cliServer = await this.bootPlayground()
+    const response = await cliServer.playground.run({ code: this.bootstrapPhpCode(`
+$post_counts = array();
+foreach ( get_post_types( array(), 'names' ) as $post_type ) {
+    $counts = wp_count_posts( $post_type );
+    $post_counts[ $post_type ] = array();
+    foreach ( get_object_vars( $counts ) as $status => $count ) {
+        $post_counts[ $post_type ][ $status ] = (int) $count;
+    }
+}
+
+echo wp_json_encode( array(
+    'siteUrl' => get_site_url(),
+    'homeUrl' => get_home_url(),
+    'wordpressVersion' => get_bloginfo( 'version' ),
+    'activeTheme' => wp_get_theme()->get_stylesheet(),
+    'activePlugins' => array_values( (array) get_option( 'active_plugins', array() ) ),
+    'postCounts' => $post_counts,
+), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+`, []) })
+    assertPlaygroundResponseOk("observe.wordpress-state", response)
+    return JSON.parse(response.text || "{}")
+  }
+
+  private async observeHttpResponse(spec: ObservationSpec, observationId: string): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {
+    const url = await this.resolveObservationUrl(spec.url ?? spec.path ?? "/")
+    const response = await fetch(url, {
+      method: spec.method ?? "GET",
+      headers: spec.headers,
+      body: spec.body,
+    })
+    const body = await response.text()
+    const bodyDigest = createHash("sha256").update(body).digest("hex")
+    const artifactRefs: RuntimeEpisodeTraceRef[] = []
+    const data: Record<string, unknown> = {
+      url,
+      method: spec.method ?? "GET",
+      status: response.status,
+      statusText: response.statusText,
+      headers: Object.fromEntries(response.headers.entries()),
+      bodySha256: bodyDigest,
+      bodyBytes: Buffer.byteLength(body),
+    }
+
+    if (spec.includeBody === true && body.length <= 4096) {
+      data.body = body
+    } else if (body.length > 0) {
+      const relativePath = `files/observations/${observationId}-body.txt`
+      await mkdir(dirname(join(this.artifactRoot, relativePath)), { recursive: true })
+      await writeFile(join(this.artifactRoot, relativePath), body)
+      artifactRefs.push({
+        kind: "observation-artifact",
+        id: `${observationId}:body`,
+        path: relativePath,
+        digest: { algorithm: "sha256", value: bodyDigest },
+      })
+    }
+
+    return { data, artifactRefs }
+  }
+
+  private async resolveObservationUrl(url: string): Promise<string> {
+    if (/^https?:\/\//.test(url)) {
+      return url
+    }
+
+    const previewUrl = await this.currentPreviewUrl()
+    const baseUrl = previewUrl ?? (await this.bootPlayground()).serverUrl
+    return new URL(url, baseUrl).toString()
   }
 
   private browserReviewSummary(): ArtifactReviewBrowserSummary | undefined {
@@ -1411,6 +1538,14 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     }
 
     return [...files.entries()].map(([path, entry]) => fileEntry(join(this.artifactRoot, path), entry.kind, entry.contentType))
+  }
+
+  private observationManifestFiles(): ArtifactManifestFile[] {
+    return this.observations.flatMap((observation) =>
+      (observation.artifactRefs ?? [])
+        .filter((ref): ref is RuntimeEpisodeTraceRef & { path: string } => typeof ref.path === "string" && ref.path.length > 0)
+        .map((ref) => fileEntry(join(this.artifactRoot, ref.path), "observation-artifact", "text/plain")),
+    )
   }
 
   private pluginCheckManifestFiles(): ArtifactManifestFile[] {

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -76,6 +76,34 @@ try {
     assert.equal(queryPost.index, 1)
     assert.equal(queryPost.execution.stdout.trim(), "Episode Smoke")
 
+    const semanticHttpAction = await episode.step({
+      kind: "http",
+      method: "GET",
+      url: "/?p=1",
+      command: "wordpress.run-php",
+      args: ["code=echo get_bloginfo('name');"],
+      metadata: { source: "runtime-episode-smoke" },
+    }, { type: "wordpress-state" })
+    assert.equal(semanticHttpAction.index, 2)
+    assert.equal(semanticHttpAction.action.kind, "http")
+    assert.equal(semanticHttpAction.action.command, "wordpress.run-php")
+    assert.equal(semanticHttpAction.action.method, "GET")
+    assert.equal(semanticHttpAction.action.url, "/?p=1")
+    assert.equal(semanticHttpAction.actionRef.digest?.value, semanticHttpAction.action.digest.value)
+    assert.equal(semanticHttpAction.executionRef.id, semanticHttpAction.execution.id)
+    assert.equal(semanticHttpAction.observation?.type, "wordpress-state")
+    assert.equal(typeof (semanticHttpAction.observation?.data as { wordpressVersion?: unknown }).wordpressVersion, "string")
+    assert.equal(semanticHttpAction.observationRef?.digest?.value, semanticHttpAction.observation?.digest?.value)
+
+    const httpObservation = await episode.observe({ type: "http-response", url: "/" })
+    assert.equal(httpObservation.type, "http-response")
+    assert.equal(httpObservation.digest?.algorithm, "sha256")
+    assert.equal((httpObservation.data as { status?: number }).status, 200)
+    assert.match((httpObservation.data as { bodySha256?: string }).bodySha256 ?? "", /^[a-f0-9]{64}$/)
+    assert.equal(httpObservation.artifactRefs?.[0].kind, "observation-artifact")
+    assert.match(httpObservation.artifactRefs?.[0].path ?? "", /^files\/observations\/observation-.+-body\.txt$/)
+    assert.equal(httpObservation.artifactRefs?.[0].digest?.value, (httpObservation.data as { bodySha256?: string }).bodySha256)
+
     const snapshot = await episode.snapshot()
     assert.match(snapshot.id, /^snapshot-/)
     assert.equal(snapshot.schema, RUNTIME_EPISODE_SNAPSHOT_SCHEMA)
@@ -94,6 +122,7 @@ try {
     const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode-trace.json" && file.kind === "runtime-episode-trace"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode.jsonl" && file.kind === "runtime-episode-events"))
+    assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === httpObservation.artifactRefs?.[0].path && file.kind === "observation-artifact"))
 
     const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
     assert.equal(review.evidence.runtimeEpisodeTrace, "files/runtime-episode-trace.json")
@@ -112,7 +141,7 @@ try {
     assert.equal(trace.schema, RUNTIME_EPISODE_TRACE_SCHEMA)
     assert.equal(trace.version, 1)
     assert.match(trace.id, /^trace-runtime-/)
-    assert.equal(trace.steps.length, 2)
+    assert.equal(trace.steps.length, 3)
     assert.equal(trace.snapshots.length, 1)
     assert.equal(trace.snapshots[0].schema, RUNTIME_EPISODE_SNAPSHOT_SCHEMA)
     assert.equal(trace.snapshots[0].digest?.value, snapshot.digest?.value)
@@ -129,6 +158,22 @@ try {
       validateRuntimeEpisodeTrace({ ...trace, reward: 1 }).valid,
       false,
       "trace validator must reject eval-specific fields",
+    )
+
+    const evalSemanticAction = structuredClone(trace)
+    ;(evalSemanticAction.steps[2].action as unknown as { grader: string }).grader = "not-generic"
+    assert.equal(
+      validateRuntimeEpisodeTrace(evalSemanticAction).valid,
+      false,
+      "trace validator must reject eval-specific fields inside semantic action envelopes",
+    )
+
+    const malformedActionKind = structuredClone(trace)
+    ;(malformedActionKind.steps[2].action as unknown as { kind: string }).kind = "grader"
+    assert.equal(
+      validateRuntimeEpisodeTrace(malformedActionKind).valid,
+      false,
+      "trace validator must reject non-generic action kinds",
     )
 
     const missingActionSchema = structuredClone(trace)


### PR DESCRIPTION
## Summary
- Adds generic runtime action envelopes for `command`, `filesystem`, `http`, and `browser` intents while preserving command execution as the compatibility primitive.
- Adds structured Playground observation providers for runtime, command, WordPress state, HTTP response, browser, and runtime event/log evidence with canonical digests and artifact refs.
- Extends runtime episode smoke/docs to prove semantic actions, WordPress observations, HTTP body artifact refs, digest validation, and fail-closed rejection of non-generic fields.

Closes #218.
Closes #219.

## Tests
- `npm run build`
- `npm run runtime-episode-smoke`
- `npm run check` (exceeded the 60-minute tool timeout after earlier commands passed; no failure observed before timeout)
- `npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run recipe-runtime-evidence-smoke`
- `npm run preview-port-smoke`
- `npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the TypeScript runtime contract/provider changes, updated smoke coverage/docs, ran local verification, and prepared this PR. Chris remains responsible for review and merge.