### PR TITLE
Add browser Playground PHP runner

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -1,0 +1,94 @@
+( () => {
+	const defaultRunnerDir = '/wordpress/wp-content/uploads/wp-codebox/runner';
+	const defaultRunnerUrlBase = '/wp-content/uploads/wp-codebox/runner';
+
+	const safeName = ( name ) => String( name || 'task' ).replace( /[^a-z0-9_-]/gi, '-' ).toLowerCase();
+
+	const responseText = ( response ) => {
+		if ( typeof response === 'string' ) {
+			return response;
+		}
+
+		return typeof response?.text === 'string' ? response.text : '';
+	};
+
+	const parseJsonResponse = ( response ) => {
+		const text = responseText( response );
+		const start = text.indexOf( '{' );
+		const end = text.lastIndexOf( '}' );
+		if ( start === -1 || end === -1 || end < start ) {
+			throw new Error( 'WP Codebox browser runner did not return JSON.' );
+		}
+
+		return JSON.parse( text.slice( start, end + 1 ) );
+	};
+
+	const runPhpRequest = async ( client, options = {} ) => {
+		if ( ! client || typeof client.request !== 'function' ) {
+			throw new Error( 'Playground request handler is unavailable.' );
+		}
+
+		const code = String( options.code || '' );
+		if ( ! code ) {
+			throw new Error( 'PHP code is required.' );
+		}
+
+		const runnerDir = String( options.runnerDir || defaultRunnerDir );
+		const runnerUrlBase = String( options.runnerUrlBase || defaultRunnerUrlBase );
+		const filename = `${ safeName( options.name ) }-${ Date.now() }-${ Math.random().toString( 36 ).slice( 2, 8 ) }.php`;
+		const scriptPath = `${ runnerDir }/${ filename }`;
+		const requestUrl = `${ runnerUrlBase }/${ filename }`;
+
+		if ( typeof client.mkdir === 'function' ) {
+			await client.mkdir( runnerDir );
+		}
+		await client.writeFile( scriptPath, code );
+
+		const response = await client.request( {
+			method: 'GET',
+			url: requestUrl,
+		} );
+
+		return options.expectJson ? parseJsonResponse( response ) : response;
+	};
+
+	const runRecipe = async ( client, recipe, taskPayload, options = {} ) => {
+		const taskPath = recipe?.browser?.task_path;
+		const steps = Array.isArray( recipe?.workflow?.steps ) ? recipe.workflow.steps : [];
+		if ( ! taskPath || steps.length === 0 ) {
+			throw new Error( 'WP Codebox browser recipe missing.' );
+		}
+
+		await client.writeFile( taskPath, JSON.stringify( taskPayload ) );
+
+		let lastResult = null;
+		for ( const step of steps ) {
+			if ( step?.command !== 'wordpress.run-php' ) {
+				throw new Error( `Unsupported browser recipe step: ${ step?.command || 'unknown' }` );
+			}
+
+			const codeArg = ( step.args || [] ).find( ( arg ) => typeof arg === 'string' && arg.startsWith( 'code=' ) );
+			if ( ! codeArg ) {
+				throw new Error( 'Browser recipe PHP step missing code argument.' );
+			}
+
+			lastResult = await runPhpRequest( client, {
+				...options,
+				code: codeArg.slice( 5 ),
+				name: options.name || 'codebox-recipe',
+				expectJson: true,
+			} );
+			if ( ! lastResult.success ) {
+				throw new Error( lastResult?.error?.message || 'WP Codebox browser recipe step failed.' );
+			}
+		}
+
+		return lastResult;
+	};
+
+	window.wpCodeboxBrowser = {
+		parseJsonResponse,
+		runPhpRequest,
+		runRecipe,
+	};
+} )();

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -17,6 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 define( 'WP_CODEBOX_PLUGIN_VERSION', '0.1.0' );
 define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
@@ -28,3 +29,21 @@ new WP_Codebox_Abilities();
 add_action( 'plugins_loaded', static function (): void {
 	new WP_Codebox_Data_Machine_Pending_Actions();
 }, 20 );
+
+add_action(
+	'wp_enqueue_scripts',
+	static function (): void {
+		$script = WP_CODEBOX_PLUGIN_PATH . 'assets/browser-runtime.js';
+		if ( ! file_exists( $script ) ) {
+			return;
+		}
+
+		wp_register_script(
+			'wp-codebox-browser-runtime',
+			WP_CODEBOX_PLUGIN_URL . 'assets/browser-runtime.js',
+			array(),
+			(string) filemtime( $script ),
+			array( 'in_footer' => true )
+		);
+	}
+);


### PR DESCRIPTION
## Summary
- Add a registered `wp-codebox-browser-runtime` frontend script that exposes `window.wpCodeboxBrowser`.
- Provide generic `runPhpRequest()` and `runRecipe()` helpers that execute browser Playground PHP through `client.request()` instead of downstream `client.run({ code })` calls.
- Keep runner files in the Playground filesystem and leave payload staging to recipe inputs.

## Testing
- `node --check packages/wordpress-plugin/assets/browser-runtime.js`
- `php -l packages/wordpress-plugin/wp-codebox.php`
- `npm run wordpress-plugin-smoke`

## Issue
- Closes #227

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the browser runtime helper, smoke-tested the change, and prepared this PR. Chris remains responsible for review and merge.