### PR TITLE
Surface agent sandbox transcript summaries

### DIFF
--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -68,12 +68,47 @@ The ability response includes a `wp-codebox/sandbox-session/v1` envelope:
       "bundle_id": "artifact-bundle-sha256-...",
       "preview_url": "https://preview.example.test/abc"
     }
+  },
+  "agent_result": {
+    "schema": "wp-codebox/agent-result/v1",
+    "status": "completed",
+    "actionable": true,
+    "summary": "Agent sandbox produced 2 changed files and a 1842-byte patch.",
+    "changedFiles": {
+      "count": 2,
+      "paths": ["plugin.php", "tests/plugin-test.php"],
+      "artifact": "files/changed-files.json"
+    },
+    "patch": {
+      "bytes": 1842,
+      "artifact": "files/patch.diff"
+    },
+    "transcript": {
+      "artifact": "files/transcript.json",
+      "executionCount": 1
+    }
   }
 }
 ```
 
 The `status` field describes the synchronous WP Codebox call result. Durable
 queued/running/cancelled/expired transitions belong to the external orchestrator.
+
+## Agent Result Evidence
+
+Agent sandbox recipe runs also write these additive artifact files:
+
+- `files/agent-result.json` uses `wp-codebox/agent-result/v1` and summarizes
+  actionability, changed-file count, patch bytes, transcript location, failures,
+  no-op reason, and workspace-tool diagnostics.
+- `files/transcript.json` uses `wp-codebox/agent-transcript/v1` and captures the
+  bounded stdout/stderr plus parsed JSON for each `wp-codebox.agent-sandbox-run`
+  workflow step.
+
+The recipe-run JSON exposes the same compact `agentResult` object, and the host
+WordPress ability mirrors it as `agent_result`. Empty patches and empty
+`changed-files.json` are explicit non-actionable no-op results even when the
+process exits successfully.
 
 ## External Orchestrator Responsibilities
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -145,6 +145,61 @@ interface RecipeArtifactEvidenceResult {
     artifact: RecipeArtifactEvidenceFile
     strict: boolean
   }
+  agentResult?: AgentSandboxResultSummary & {
+    artifact: RecipeArtifactEvidenceFile
+  }
+  transcript?: AgentSandboxTranscript & {
+    artifact: RecipeArtifactEvidenceFile
+  }
+}
+
+interface AgentSandboxResultSummary {
+  schema: "wp-codebox/agent-result/v1"
+  status: "completed" | "failed" | "unknown"
+  actionable: boolean
+  summary: string
+  changedFiles: {
+    count: number
+    paths: string[]
+    statuses: Record<string, number>
+    artifact: string
+  }
+  patch: {
+    bytes: number
+    sha256: string
+    artifact: string
+  }
+  transcript: {
+    artifact: string
+    executionCount: number
+  }
+  artifacts: {
+    directory: string
+    review: string
+    manifest: string
+  }
+  failures: Array<{ executionIndex: number; command: string; exitCode: number; message: string }>
+  noOpReason?: string
+  workspaceTools?: {
+    diagnostics: string[]
+  }
+}
+
+interface AgentSandboxTranscript {
+  schema: "wp-codebox/agent-transcript/v1"
+  executions: AgentSandboxTranscriptExecution[]
+}
+
+interface AgentSandboxTranscriptExecution {
+  executionIndex: number
+  command: string
+  exitCode: number
+  recipePhase?: string
+  recipeStepIndex?: number
+  recipeCommand?: string
+  stdout: string
+  stderr: string
+  parsed?: unknown
 }
 
 interface RecipeRunAttestation {
@@ -339,6 +394,7 @@ type RecipeWorkflowPhase = "setup" | "before" | "steps" | "after"
 type RecipeExecutionResult = ExecutionResult & {
   recipePhase?: RecipeWorkflowPhase
   recipeStepIndex?: number
+  recipeCommand?: string
 }
 
 interface RecipeDryRunMount {
@@ -1610,6 +1666,8 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
     await runtime.observe({ type: "mounts" })
     artifacts = await runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds })
     const evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)
+    const agentEvidence = await finalizeAgentSandboxEvidence(artifacts, executions)
+    Object.assign(evidence, agentEvidence)
     const strictFailure = recipeArtifactEvidenceFailure(evidence)
     const runtimeInfo = options.previewHoldSeconds ? await runtime.info() : undefined
     await releaseRuntime(runtime, options.previewHoldSeconds, () => cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles))
@@ -1629,6 +1687,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
         siteSeeds,
         ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
         ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
+        ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
         artifacts,
         error: strictFailure,
       }
@@ -1644,6 +1703,7 @@ async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunOutput> {
       siteSeeds,
       ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
       ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
+      ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
       artifacts,
     }
   } catch (error) {
@@ -1750,6 +1810,188 @@ async function finalizeRecipeArtifactEvidence(
 
   await updateRecipeArtifactEvidenceReferences(artifacts, evidenceFiles)
   return result
+}
+
+async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, executions: RecipeExecutionResult[]): Promise<Pick<RecipeArtifactEvidenceResult, "agentResult" | "transcript">> {
+  const transcript = buildAgentSandboxTranscript(executions)
+  if (transcript.executions.length === 0) {
+    return {}
+  }
+
+  const transcriptPath = join(dirname(artifacts.reviewPath), "transcript.json")
+  const agentResultPath = join(dirname(artifacts.reviewPath), "agent-result.json")
+  const transcriptFile = await writeRecipeEvidenceJson(artifacts.directory, transcriptPath, transcript, "agent-transcript")
+  const agentResult = await buildAgentSandboxResultSummary(artifacts, transcript, transcriptFile.path)
+  const agentResultFile = await writeRecipeEvidenceJson(artifacts.directory, agentResultPath, agentResult, "agent-result")
+  await updateRecipeArtifactEvidenceReferences(artifacts, [agentResultFile, transcriptFile])
+
+  return {
+    agentResult: { ...agentResult, artifact: agentResultFile },
+    transcript: { ...transcript, artifact: transcriptFile },
+  }
+}
+
+function buildAgentSandboxTranscript(executions: RecipeExecutionResult[]): AgentSandboxTranscript {
+  return {
+    schema: "wp-codebox/agent-transcript/v1",
+    executions: executions
+      .map((execution, index) => ({ execution, index }))
+      .filter(({ execution }) => isAgentSandboxExecution(execution))
+      .map(({ execution, index }) => ({
+        executionIndex: index,
+        command: execution.command,
+        exitCode: execution.exitCode,
+        recipePhase: execution.recipePhase,
+        recipeStepIndex: execution.recipeStepIndex,
+        recipeCommand: execution.recipeCommand,
+        stdout: boundTranscriptText(execution.stdout),
+        stderr: boundTranscriptText(execution.stderr),
+        ...(decodeJsonFragment(execution.stdout) ?? decodeJsonFragment(execution.stderr) ? { parsed: decodeJsonFragment(execution.stdout) ?? decodeJsonFragment(execution.stderr) } : {}),
+      })),
+  }
+}
+
+function isAgentSandboxExecution(execution: RecipeExecutionResult): boolean {
+  return execution.recipeCommand === "wp-codebox.agent-sandbox-run"
+}
+
+async function buildAgentSandboxResultSummary(artifacts: ArtifactBundle, transcript: AgentSandboxTranscript, transcriptPath: string): Promise<AgentSandboxResultSummary> {
+  const changedFiles = await readChangedFileSummary(artifacts.changedFilesPath)
+  const patch = await readPatchSummary(artifacts.patchPath)
+  const failures = transcript.executions
+    .filter((execution) => execution.exitCode !== 0)
+    .map((execution) => ({
+      executionIndex: execution.executionIndex,
+      command: execution.command,
+      exitCode: execution.exitCode,
+      message: firstTranscriptMessage(execution) || `Command exited with ${execution.exitCode}`,
+    }))
+  const status: AgentSandboxResultSummary["status"] = failures.length > 0 ? "failed" : transcript.executions.length > 0 ? "completed" : "unknown"
+  const actionable = status === "completed" && (changedFiles.count > 0 || patch.bytes > 0)
+  const noOpReason = actionable ? undefined : status === "failed" ? "execution_failed" : "no_file_changes"
+
+  return stripUndefined({
+    schema: "wp-codebox/agent-result/v1" as const,
+    status,
+    actionable,
+    summary: actionable
+      ? `Agent sandbox produced ${changedFiles.count === 1 ? "1 changed file" : `${changedFiles.count} changed files`} and a ${patch.bytes}-byte patch.`
+      : status === "failed"
+        ? "Agent sandbox failed before producing actionable file changes."
+        : "Agent sandbox completed without actionable file changes.",
+    changedFiles,
+    patch,
+    transcript: {
+      artifact: transcriptPath,
+      executionCount: transcript.executions.length,
+    },
+    artifacts: {
+      directory: artifacts.directory,
+      review: relative(artifacts.directory, artifacts.reviewPath),
+      manifest: relative(artifacts.directory, artifacts.manifestPath),
+    },
+    failures,
+    noOpReason,
+    workspaceTools: workspaceToolDiagnostics(transcript),
+  })
+}
+
+async function readChangedFileSummary(path: string): Promise<AgentSandboxResultSummary["changedFiles"]> {
+  try {
+    const decoded = JSON.parse(await readFile(path, "utf8"))
+    const files: Record<string, unknown>[] = Array.isArray(decoded?.files) ? decoded.files.filter(isRecord) : []
+    const statuses: Record<string, number> = {}
+    for (const file of files) {
+      const status = typeof file.status === "string" && file.status.length > 0 ? file.status : "unknown"
+      statuses[status] = (statuses[status] ?? 0) + 1
+    }
+
+    return {
+      count: files.length,
+      paths: files.map((file) => String(file.relativePath ?? file.relative_path ?? file.path ?? "")).filter(Boolean),
+      statuses,
+      artifact: "files/changed-files.json",
+    }
+  } catch {
+    return { count: 0, paths: [], statuses: {}, artifact: "files/changed-files.json" }
+  }
+}
+
+async function readPatchSummary(path: string): Promise<AgentSandboxResultSummary["patch"]> {
+  try {
+    const patch = await readFile(path, "utf8")
+    return {
+      bytes: Buffer.byteLength(patch),
+      sha256: createHash("sha256").update(patch).digest("hex"),
+      artifact: "files/patch.diff",
+    }
+  } catch {
+    return { bytes: 0, sha256: createHash("sha256").update("").digest("hex"), artifact: "files/patch.diff" }
+  }
+}
+
+function firstTranscriptMessage(execution: AgentSandboxTranscriptExecution): string {
+  const parsed = isRecord(execution.parsed) ? execution.parsed : undefined
+  const result = isRecord(parsed?.result) ? parsed.result : parsed
+  for (const key of ["message", "error", "error_message", "errorMessage", "answer"]) {
+    const value = result?.[key]
+    if (typeof value === "string" && value.trim()) {
+      return boundTranscriptText(value.trim(), 500)
+    }
+  }
+
+  return boundTranscriptText(execution.stderr || execution.stdout, 500)
+}
+
+function workspaceToolDiagnostics(transcript: AgentSandboxTranscript): AgentSandboxResultSummary["workspaceTools"] | undefined {
+  const diagnostics = new Set<string>()
+  const text = transcript.executions.map((execution) => `${execution.stdout}\n${execution.stderr}`).join("\n").toLowerCase()
+  if (text.includes("workspace") && /not found|unknown tool|tool_not_found|tool not found|not available/.test(text)) {
+    diagnostics.add("workspace-tool-unavailable")
+  }
+  if (/permission denied|not allowlisted|not allowed|forbidden/.test(text)) {
+    diagnostics.add("workspace-tool-denied")
+  }
+  if (text.includes("workspace_apply_patch") || text.includes("workspace-edit") || text.includes("workspace_write")) {
+    diagnostics.add("workspace-tool-surface-observed")
+  }
+
+  return diagnostics.size > 0 ? { diagnostics: [...diagnostics].sort() } : undefined
+}
+
+function recipeAgentResultOutput(agentResult: RecipeArtifactEvidenceResult["agentResult"]): AgentSandboxResultSummary | undefined {
+  if (!agentResult) {
+    return undefined
+  }
+
+  const { artifact: _artifact, ...result } = agentResult
+  return result
+}
+
+function decodeJsonFragment(text: string): unknown {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    const start = trimmed.indexOf("{")
+    const end = trimmed.lastIndexOf("}")
+    if (start === -1 || end <= start) {
+      return undefined
+    }
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1))
+    } catch {
+      return undefined
+    }
+  }
+}
+
+function boundTranscriptText(text: string, maxLength = 12000): string {
+  return text.length > maxLength ? `${text.slice(0, maxLength)}\n[truncated ${text.length - maxLength} bytes]` : text
 }
 
 async function buildRecipeRunAttestation(args: {
@@ -2071,12 +2313,15 @@ async function updateRecipeArtifactEvidenceReferences(artifacts: ArtifactBundle,
 
   const evidence = Object.fromEntries(evidenceFiles.map((file) => [file.kind, { path: file.path, sha256: file.sha256 }]))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8")) as Record<string, unknown>
-  metadata.artifacts = { ...(isRecord(metadata.artifacts) ? metadata.artifacts : {}), runtimeEvidence: evidence }
-  metadata.evidence = { ...(isRecord(metadata.evidence) ? metadata.evidence : {}), runtimeEvidence: evidence }
+  const metadataArtifacts = isRecord(metadata.artifacts) ? metadata.artifacts : {}
+  const metadataEvidence = isRecord(metadata.evidence) ? metadata.evidence : {}
+  metadata.artifacts = { ...metadataArtifacts, runtimeEvidence: { ...(isRecord(metadataArtifacts.runtimeEvidence) ? metadataArtifacts.runtimeEvidence : {}), ...evidence } }
+  metadata.evidence = { ...metadataEvidence, runtimeEvidence: { ...(isRecord(metadataEvidence.runtimeEvidence) ? metadataEvidence.runtimeEvidence : {}), ...evidence } }
   await writeFile(artifacts.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`)
 
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8")) as Record<string, unknown>
-  review.evidence = { ...(isRecord(review.evidence) ? review.evidence : {}), runtimeEvidence: evidence }
+  const reviewEvidence = isRecord(review.evidence) ? review.evidence : {}
+  review.evidence = { ...reviewEvidence, runtimeEvidence: { ...(isRecord(reviewEvidence.runtimeEvidence) ? reviewEvidence.runtimeEvidence : {}), ...evidence } }
   await writeFile(artifacts.reviewPath, `${JSON.stringify(review, null, 2)}\n`)
 
   for (const file of manifest.files) {
@@ -3578,18 +3823,19 @@ function recipeWorkflowSteps(recipe: WorkspaceRecipe): Array<{ phase: Exclude<Re
   ]
 }
 
-function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number): RecipeExecutionResult {
+function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number, recipeCommand?: string): RecipeExecutionResult {
   return {
     ...execution,
     recipePhase,
     recipeStepIndex,
+    recipeCommand,
   }
 }
 
 async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string): Promise<RecipeExecutionResult> {
   try {
     const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory))
-    return withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index)
+    return withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, workflowStep.step.command)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Recipe workflow ${workflowStep.phase}[${workflowStep.index}] failed: ${message}`, { cause: error })

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -727,6 +727,8 @@ export interface ArtifactReview {
     testResults?: string
     runtimeEpisodeTrace?: string
     runtimeReferenceManifest?: string
+    agentResult?: string
+    transcript?: string
   }
   browser?: ArtifactReviewBrowserSummary
   redaction?: ArtifactRedactionSummary

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -182,10 +182,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'task'      => $task,
 			'task_input' => $task_input,
 			'wp'        => $wp_version,
-			'paths'     => $paths,
-			'artifacts' => $artifacts,
-			'exit_code' => $exit_code,
-			'run'       => $decoded,
+			'paths'        => $paths,
+			'artifacts'    => $artifacts,
+			'exit_code'    => $exit_code,
+			'agent_result' => is_array( $decoded['agentResult'] ?? null ) ? $decoded['agentResult'] : array(),
+			'run'          => $decoded,
 		);
 
 		if ( null !== $outcome ) {
@@ -265,8 +266,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'session'     => $task_result['session'] ?? array(),
 				'artifact_id' => (string) ( $task_result['session']['artifacts']['bundle_id'] ?? '' ),
 				'preview_url' => (string) ( $task_result['session']['artifacts']['preview_url'] ?? '' ),
-				'artifacts'   => $task_result['session']['artifacts'] ?? array(),
-				'run'         => $task_result['run'] ?? array(),
+				'artifacts'    => $task_result['session']['artifacts'] ?? array(),
+				'agent_result' => $task_result['agent_result'] ?? array(),
+				'run'          => $task_result['run'] ?? array(),
 			);
 		}
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -313,6 +313,26 @@ $runner           = new WP_Codebox_Agent_Sandbox_Runner(
 								'localUrl' => 'http://127.0.0.1:' . ( 12344 + $command_count ),
 							),
 						),
+						'agentResult' => array(
+							'schema'       => 'wp-codebox/agent-result/v1',
+							'status'       => 'completed',
+							'actionable'   => false,
+							'summary'      => 'Agent sandbox completed without actionable file changes.',
+							'noOpReason'   => 'no_file_changes',
+							'changedFiles' => array(
+								'count'    => 0,
+								'paths'    => array(),
+								'artifact' => 'files/changed-files.json',
+							),
+							'patch'        => array(
+								'bytes'    => 0,
+								'artifact' => 'files/patch.diff',
+							),
+							'transcript'   => array(
+								'artifact'       => 'files/transcript.json',
+								'executionCount' => 1,
+							),
+						),
 					)
 				),
 			);
@@ -360,6 +380,7 @@ $assert( 'runner returns caller-owned sandbox session envelope', ! is_wp_error( 
 $assert( 'runner keeps agent session separate from sandbox session', ! is_wp_error( $result ) && 'agent-chat-session-456' === ( $result['session']['agent_session_id'] ?? '' ) && str_contains( $captured_recipe, 'session-id=agent-chat-session-456' ) );
 $assert( 'runner returns orchestrator correlation and artifact refs', ! is_wp_error( $result ) && 'job-123' === ( $result['session']['orchestrator']['job_id'] ?? '' ) && 'artifact-bundle-sha256-fixture' === ( $result['session']['artifacts']['bundle_id'] ?? '' ) );
 $assert( 'runner returns public preview URL in session artifact metadata', ! is_wp_error( $result ) && 'https://preview.example.test/session-123/' === ( $result['session']['artifacts']['preview_url'] ?? '' ) && 'https://preview.example.test/session-123/' === ( $result['run']['artifacts']['preview']['url'] ?? '' ) );
+$assert( 'runner surfaces normalized agent result summary', ! is_wp_error( $result ) && 'wp-codebox/agent-result/v1' === ( $result['agent_result']['schema'] ?? '' ) && false === ( $result['agent_result']['actionable'] ?? true ) && 'no_file_changes' === ( $result['agent_result']['noOpReason'] ?? '' ) && 'files/transcript.json' === ( $result['agent_result']['transcript']['artifact'] ?? '' ) );
 $assert( 'runner returns normalized task input for legacy task', ! is_wp_error( $result ) && 'wp-codebox/task-input/v1' === ( $result['task_input']['schema'] ?? '' ) && 'Run a chat-requested sandbox task.' === ( $result['task_input']['goal'] ?? '' ) );
 $assert( 'runner invokes recipe-run', str_contains( $captured_command, 'recipe-run' ) );
 $assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node ' ) );
@@ -762,6 +783,7 @@ $assert( 'batch runner invokes recipe-run once per task', 2 === count( $batch_re
 $assert( 'batch runner emits one agent step per isolated recipe', 1 === substr_count( $batch_recipes[0] ?? '', 'wp-codebox.agent-sandbox-run' ) && 1 === substr_count( $batch_recipes[1] ?? '', 'wp-codebox.agent-sandbox-run' ) );
 $assert( 'batch runner returns sequential isolation contract', 'sequential-isolated-sandboxes' === ( $batch_result['execution'] ?? '' ) && ! array_key_exists( 'concurrency', $batch_result ) );
 $assert( 'batch runner returns per-task artifact refs', ! is_wp_error( $batch_result ) && '' !== ( $batch_result['runs'][0]['artifact_id'] ?? '' ) && '' !== ( $batch_result['runs'][1]['artifact_id'] ?? '' ) && ( $batch_result['runs'][0]['artifact_id'] ?? '' ) !== ( $batch_result['runs'][1]['artifact_id'] ?? '' ) );
+$assert( 'batch runner returns per-task agent result summaries', ! is_wp_error( $batch_result ) && 'wp-codebox/agent-result/v1' === ( $batch_result['runs'][0]['agent_result']['schema'] ?? '' ) && 'files/transcript.json' === ( $batch_result['runs'][1]['agent_result']['transcript']['artifact'] ?? '' ) );
 $assert( 'batch runner returns per-task preview URLs', ! is_wp_error( $batch_result ) && 'https://preview.example.test/batch/' === ( $batch_result['runs'][0]['preview_url'] ?? '' ) && 'https://preview.example.test/batch/' === ( $batch_result['runs'][1]['preview_url'] ?? '' ) );
 $assert( 'batch runner assigns per-task sandbox session ids', ! is_wp_error( $batch_result ) && 'parent-batch-789:1' === ( $batch_result['runs'][0]['session']['id'] ?? '' ) && 'parent-batch-789:2' === ( $batch_result['runs'][1]['session']['id'] ?? '' ) );
 $assert( 'batch runner reports per-task counts', ! is_wp_error( $batch_result ) && 2 === ( $batch_result['total'] ?? 0 ) && 2 === ( $batch_result['completed'] ?? 0 ) && 0 === ( $batch_result['failed'] ?? -1 ) );


### PR DESCRIPTION
## Summary
- Add a compact `agentResult` summary to recipe-run output and mirror it from the WordPress runner as `agent_result`.
- Write additive `files/agent-result.json` and `files/transcript.json` artifacts for agent sandbox workflow steps.
- Preserve existing artifact evidence while documenting no-op/actionability semantics for downstream orchestrators.

Closes #172.

## Testing
- `npm run build`
- `npm run agent-sandbox-code-smoke`
- `npm run wordpress-plugin-smoke`
- `git diff --check`
- `npm run check` was started and passed through the focused and early full-suite smokes, then was aborted by controller during `recipe-staged-files-smoke` to finish the PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the additive agent sandbox summary/artifact contract, updated smoke coverage/docs, and ran verification commands. Chris remains responsible for review and merge.