### PR TITLE
Add bounded parent-site seed imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,12 @@ External sources are explicit and CI-safe. WP Codebox validates URL-shaped sourc
 
 WordPress.org plugin zip URLs infer the plugin slug from the zip filename. Generic HTTPS zip sources require `slug` so the sandbox mount target is deterministic. Dry-run plans and artifact provenance record the original source reference, resolved URL, source kind, and SHA-256 digest when a download occurs; temporary download paths are reported by category rather than as durable host paths.
 
+`inputs.siteSeeds` supports bounded sandbox setup data before workflow steps run. Local `fixture` seeds import JSON objects with scoped `posts`, `terms`, `options`, anonymized `users`, media metadata, `activePlugins`, and `activeTheme`. Every record scope must be explicit through selectors and/or `maxRecords`; option scopes require a `names` allow-list; parent-site users are anonymized; media file bytes are not replayed.
+
+The WordPress host ability also accepts `site_seeds` entries with `type: "parent_site"`. That path is opt-in: the host exports only the requested current-site scopes into a temporary JSON fixture, invokes `recipe-run`, then deletes the fixture. This is a bounded seed substrate, not a full migration engine. It does not replay full database state, comments, revisions, arbitrary meta, uploads, secrets, or source-site filesystem state.
+
+Reprint remains a future backend candidate for full/essential parent-site snapshots. WP Codebox does not vendor or shell out to Reprint for bounded `siteSeeds` yet because Reprint is a site-scale migration engine, while this contract needs explicit per-scope limits and privacy defaults.
+
 Mount entries may include opaque `metadata` that is preserved in runtime observations, artifact provenance, and captured mount files. Product-specific callers can use this to map sandbox paths back to source repositories without WP Codebox knowing about the caller's deployment environment:
 
 ```json

--- a/docs/reprint-parent-site-snapshots.md
+++ b/docs/reprint-parent-site-snapshots.md
@@ -1,0 +1,36 @@
+# Reprint Parent-Site Snapshot Evaluation
+
+Issue #162 evaluated Reprint as a parent-site snapshot backend for WP Codebox.
+
+## Recommendation
+
+Use Reprint later as a full/essential-site snapshot backend under a WP Codebox-owned policy layer. Do not use Reprint for the first bounded `siteSeeds` implementation.
+
+## Why
+
+Reprint already owns the hard migration mechanics: authenticated source-site export, resumable streaming, database import, URL rewriting, status/state/audit files, and Playground-oriented runtime output.
+
+WP Codebox issue #147 needs a different public contract first: explicit scopes, record caps, option allow-lists, anonymized users, media-file exclusion by default, and artifact provenance that says what was included or excluded. Reprint does not currently expose those WP Codebox-specific selectors as a small Node/CLI API.
+
+## Current Slice
+
+The current implementation keeps bounded seeds inside WP Codebox:
+
+- Local `fixture` seeds import scoped JSON into the sandbox before workflow steps run.
+- The WordPress host ability can export explicit `parent_site` scopes to a temporary JSON fixture and pass it to `recipe-run`.
+- Users are anonymized and media file bytes are not exported.
+- Full database state, comments, revisions, arbitrary meta, uploads, secrets, and filesystem state are intentionally out of scope.
+
+## Future Reprint Shape
+
+A future Reprint integration should be explicit and separate from bounded seeds:
+
+- Add a recipe field for full/essential parent-site snapshots, not overload bounded fixture seeds.
+- Shell out to a user-installed or managed `reprint.phar` instead of vendoring Reprint internals.
+- Start with `preflight` and state/status/audit artifact capture.
+- Keep `essential-files` and no upload replay as the default policy.
+- Record Reprint version, command phases, exit codes, status files, audit files, source URL origin, URL rewrite settings, and runtime output paths in artifact provenance.
+
+## Close Or Keep Open
+
+Issue #162 should remain open as a future-backend tracker unless maintainers decide this evaluation is enough and open a narrower implementation issue for the eventual Reprint adapter.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3966,7 +3966,7 @@ if (!is_array($seed)) {
     throw new RuntimeException('Site seed fixture must decode to a JSON object.');
 }
 
-$counts = array('posts' => 0, 'options' => 0, 'terms' => 0, 'activePlugins' => 0, 'activeTheme' => 0);
+$counts = array('posts' => 0, 'options' => 0, 'terms' => 0, 'users' => 0, 'media' => 0, 'activePlugins' => 0, 'activeTheme' => 0);
 
 foreach (($seed['posts'] ?? array()) as $post) {
     if (!is_array($post)) {
@@ -4018,6 +4018,59 @@ foreach (($seed['terms'] ?? array()) as $term) {
         throw new RuntimeException('Failed to import site seed term from ' . $seed_name . ': ' . $result->get_error_message());
     }
     $counts['terms']++;
+}
+
+foreach (($seed['users'] ?? array()) as $user) {
+    if (!is_array($user)) {
+        continue;
+    }
+    $login = isset($user['user_login']) ? (string) $user['user_login'] : (isset($user['login']) ? (string) $user['login'] : '');
+    if ('' === $login || !preg_match('/^[A-Za-z0-9_.@-]+$/', $login)) {
+        throw new RuntimeException('Unsafe site seed user login from ' . $seed_name . '.');
+    }
+    if (username_exists($login)) {
+        $counts['users']++;
+        continue;
+    }
+    $email = isset($user['user_email']) ? (string) $user['user_email'] : (isset($user['email']) ? (string) $user['email'] : $login . '@example.invalid');
+    if (!is_email($email)) {
+        $email = $login . '@example.invalid';
+    }
+    $user_id = wp_insert_user(array(
+        'user_login' => $login,
+        'user_pass' => wp_generate_password(24, true, true),
+        'user_email' => $email,
+        'display_name' => isset($user['display_name']) ? (string) $user['display_name'] : $login,
+        'role' => isset($user['role']) ? (string) $user['role'] : (is_array($user['roles'] ?? null) && count($user['roles']) > 0 ? (string) reset($user['roles']) : 'subscriber'),
+    ));
+    if (is_wp_error($user_id)) {
+        throw new RuntimeException('Failed to import site seed user from ' . $seed_name . ': ' . $user_id->get_error_message());
+    }
+    $counts['users']++;
+}
+
+foreach (($seed['media'] ?? array()) as $media) {
+    if (!is_array($media)) {
+        continue;
+    }
+    $attachment = array(
+        'post_type' => 'attachment',
+        'post_status' => isset($media['post_status']) ? (string) $media['post_status'] : 'inherit',
+        'post_title' => isset($media['post_title']) ? (string) $media['post_title'] : (isset($media['title']) ? (string) $media['title'] : 'Seeded media'),
+        'post_content' => isset($media['post_content']) ? (string) $media['post_content'] : '',
+        'post_excerpt' => isset($media['post_excerpt']) ? (string) $media['post_excerpt'] : '',
+        'post_mime_type' => isset($media['post_mime_type']) ? (string) $media['post_mime_type'] : (isset($media['mime_type']) ? (string) $media['mime_type'] : ''),
+    );
+    if (isset($media['slug'])) {
+        $attachment['post_name'] = (string) $media['slug'];
+    } elseif (isset($media['post_name'])) {
+        $attachment['post_name'] = (string) $media['post_name'];
+    }
+    $attachment_id = wp_insert_post($attachment, true);
+    if (is_wp_error($attachment_id)) {
+        throw new RuntimeException('Failed to import site seed media from ' . $seed_name . ': ' . $attachment_id->get_error_message());
+    }
+    $counts['media']++;
 }
 
 $active_plugins = $seed['activePlugins'] ?? array();
@@ -4142,11 +4195,13 @@ function boundedFixtureSeed(rawSeed: unknown, scopes: WorkspaceRecipeSiteSeed["s
   const posts = boundedRecords(arrayRecords(seed.posts), scopes.posts, (record, scope) => matchesPostScope(record, scope))
   const options = boundedOptions(seed.options, scopes.options)
   const terms = boundedRecords(arrayRecords(seed.terms), scopes.terms, (record, scope) => matchesTermScope(record, scope))
+  const users = boundedRecords(arrayRecords(seed.users), scopes.users, (record, scope) => matchesUserScope(record, scope))
+  const media = boundedRecords(arrayRecords(seed.media), scopes.media, (record, scope) => matchesMediaScope(record, scope))
   const activePlugins = boundedActivePlugins(seed.activePlugins, scopes.activePlugins)
   const activeTheme = boundedActiveTheme(seed.activeTheme, scopes.activeTheme)
 
   return {
-    seed: stripUndefined({ posts: posts.records, options: options.records, terms: terms.records, activePlugins: activePlugins.records, activeTheme: activeTheme.record }),
+    seed: stripUndefined({ posts: posts.records, options: options.records, terms: terms.records, users: users.records, media: media.records, activePlugins: activePlugins.records, activeTheme: activeTheme.record }),
     counts: {
       fixturePostsIncluded: posts.records.length,
       fixturePostsExcluded: posts.excluded,
@@ -4154,6 +4209,10 @@ function boundedFixtureSeed(rawSeed: unknown, scopes: WorkspaceRecipeSiteSeed["s
       fixtureOptionsExcluded: options.excluded,
       fixtureTermsIncluded: terms.records.length,
       fixtureTermsExcluded: terms.excluded,
+      fixtureUsersIncluded: users.records.length,
+      fixtureUsersExcluded: users.excluded,
+      fixtureMediaIncluded: media.records.length,
+      fixtureMediaExcluded: media.excluded,
       fixtureActivePluginsIncluded: activePlugins.records.length,
       fixtureActivePluginsExcluded: activePlugins.excluded,
       fixtureActiveThemeIncluded: activeTheme.record === undefined ? 0 : 1,
@@ -4239,11 +4298,32 @@ function matchesTermScope(record: Record<string, unknown>, scope: NonNullable<Wo
     matchesStringSelector(record, scope.taxonomies, ["taxonomy"])
 }
 
+function matchesUserScope(record: Record<string, unknown>, scope: NonNullable<WorkspaceRecipeSiteSeed["scopes"]["users"]>): boolean {
+  return matchesNumberSelector(record, scope.ids, ["id", "ID"]) &&
+    matchesStringSelector(record, scope.names, ["user_login", "login", "display_name", "name"]) &&
+    matchesArrayStringSelector(record, scope.roles, ["roles"])
+}
+
+function matchesMediaScope(record: Record<string, unknown>, scope: NonNullable<WorkspaceRecipeSiteSeed["scopes"]["media"]>): boolean {
+  return matchesNumberSelector(record, scope.ids, ["id", "ID"]) &&
+    matchesStringSelector(record, scope.slugs, ["slug", "post_name"]) &&
+    matchesStringSelector(record, scope.names, ["post_title", "title", "name"]) &&
+    matchesStringSelector(record, scope.statuses, ["post_status", "status"])
+}
+
 function matchesStringSelector(record: Record<string, unknown>, allowed: string[] | undefined, keys: string[]): boolean {
   if (!allowed || allowed.length === 0) {
     return true
   }
   const values = keys.map((key) => record[key]).filter((value): value is string => typeof value === "string")
+  return values.some((value) => allowed.includes(value))
+}
+
+function matchesArrayStringSelector(record: Record<string, unknown>, allowed: string[] | undefined, keys: string[]): boolean {
+  if (!allowed || allowed.length === 0) {
+    return true
+  }
+  const values = keys.flatMap((key) => Array.isArray(record[key]) ? record[key] : []).filter((value): value is string => typeof value === "string")
   return values.some((value) => allowed.includes(value))
 }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -60,6 +60,7 @@ final class WP_Codebox_Abilities {
 		$register_callback = function (): void {
 			$task_input_schema  = self::task_input_schema();
 			$mount_schema      = self::mount_schema();
+			$site_seed_schema  = self::site_seed_schema();
 			$inherit_schema    = self::inherit_schema();
 			$session_schema    = self::sandbox_session_schema();
 			$browser_session_schema = self::browser_playground_session_schema();
@@ -122,6 +123,7 @@ final class WP_Codebox_Abilities {
 								'items'       => array( 'type' => 'string' ),
 							),
 							'mounts'                 => $mount_schema,
+							'site_seeds'             => $site_seed_schema,
 							'inherit'                => $inherit_schema,
 							'sandbox_session_id'     => $session_input['sandbox_session_id'],
 							'orchestrator'           => $session_input['orchestrator'],
@@ -513,6 +515,50 @@ final class WP_Codebox_Abilities {
 					'metadata' => array(
 						'type'        => 'object',
 						'description' => 'Opaque caller metadata, for example repo, default_branch, repo_root_relative_to_mount, and editable flags.',
+					),
+				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function site_seed_schema(): array {
+		$scope_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'ids'          => array( 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+				'slugs'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				'names'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				'postTypes'    => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				'taxonomies'   => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				'roles'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				'statuses'     => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				'includeFiles' => array( 'type' => 'boolean' ),
+				'anonymize'    => array( 'type' => 'boolean' ),
+				'maxRecords'   => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100 ),
+			),
+		);
+
+		return array(
+			'type'        => 'array',
+			'description' => 'Explicit opt-in bounded parent-site seed exports for existing-site sandboxes. Exported data is written to a temporary JSON fixture and imported into the sandbox before the task runs.',
+			'items'       => array(
+				'type'       => 'object',
+				'required'   => array( 'type', 'name', 'scopes' ),
+				'properties' => array(
+					'type'   => array( 'type' => 'string', 'enum' => array( 'parent_site' ) ),
+					'name'   => array( 'type' => 'string' ),
+					'scopes' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'posts'         => $scope_schema,
+							'terms'         => $scope_schema,
+							'options'       => $scope_schema,
+							'users'         => $scope_schema,
+							'media'         => $scope_schema,
+							'activePlugins' => array( 'type' => 'boolean' ),
+							'activeTheme'   => array( 'type' => 'boolean' ),
+						),
 					),
 				),
 			),

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -128,10 +128,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		$inheritance_payload = $this->inheritance_resolution_payload( $input );
-		$recipe_file         = $this->write_agent_recipe( $paths, $input, array( $task_prompt ), $wp_version, $inheritance_payload['inheritance'] );
-		if ( is_wp_error( $recipe_file ) ) {
-			return $recipe_file;
+		$recipe_payload      = $this->write_agent_recipe( $paths, $input, array( $task_prompt ), $wp_version, $inheritance_payload['inheritance'] );
+		if ( is_wp_error( $recipe_payload ) ) {
+			return $recipe_payload;
 		}
+		$recipe_file = (string) $recipe_payload['path'];
 
 		$command = sprintf(
 			'%s recipe-run --recipe %s --artifacts %s --json',
@@ -143,6 +144,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		$result    = $this->run_command( $command, $inheritance_payload['secret_env'] );
 		@unlink( $recipe_file );
+		foreach ( $recipe_payload['cleanup_paths'] as $cleanup_path ) {
+			@unlink( (string) $cleanup_path );
+		}
 		$exit_code = (int) ( $result['exit_code'] ?? 1 );
 		$output    = (string) ( $result['output'] ?? '' );
 		$decoded   = $this->decode_json_output( $output );
@@ -1439,7 +1443,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	 * @param array<string,mixed> $input Ability input.
 	 * @param string[] $task_prompts Encoded task prompts.
 	 */
-	private function write_agent_recipe( array $paths, array $input, array $task_prompts, string $wp_version, ?array $inheritance = null ): string|WP_Error {
+	private function write_agent_recipe( array $paths, array $input, array $task_prompts, string $wp_version, ?array $inheritance = null ): array|WP_Error {
 		$inheritance = $inheritance ?? $this->inheritance_resolution( $input );
 		$credential_error = $this->connector_credentials_error( $inheritance );
 		if ( null !== $credential_error ) {
@@ -1484,19 +1488,29 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return $mounts;
 		}
 
+		$site_seed_payload = $this->parent_site_seed_recipe_entries( $input );
+		if ( is_wp_error( $site_seed_payload ) ) {
+			return $site_seed_payload;
+		}
+
+		$recipe_inputs = array(
+			'mounts'       => $mounts,
+			'inherit'      => $this->inheritance_request( $input ),
+			'inheritance'  => $inheritance,
+			'extraPlugins' => array_merge( $this->component_plugins( $paths ), $provider_plugins ),
+			'secretEnv'    => $this->secret_env_names( $input, $inheritance ),
+		);
+		if ( ! empty( $site_seed_payload['siteSeeds'] ) ) {
+			$recipe_inputs['siteSeeds'] = $site_seed_payload['siteSeeds'];
+		}
+
 		$recipe = array(
 			'schema'   => 'wp-codebox/workspace-recipe/v1',
 			'runtime'  => array(
 				'wp'        => $wp_version,
 				'blueprint' => array( 'steps' => array() ),
 			),
-			'inputs'   => array(
-				'mounts'       => $mounts,
-				'inherit'      => $this->inheritance_request( $input ),
-				'inheritance'  => $inheritance,
-				'extraPlugins' => array_merge( $this->component_plugins( $paths ), $provider_plugins ),
-				'secretEnv'    => $this->secret_env_names( $input, $inheritance ),
-			),
+			'inputs'   => $recipe_inputs,
 			'workflow' => array( 'steps' => $steps ),
 		);
 
@@ -1508,10 +1522,293 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $recipe, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $recipe, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 		if ( ! is_string( $encoded ) || false === file_put_contents( $file, $encoded ) ) {
 			@unlink( $file );
+			foreach ( $site_seed_payload['cleanup_paths'] as $cleanup_path ) {
+				@unlink( (string) $cleanup_path );
+			}
 			return new WP_Error( 'wp_codebox_recipe_write_failed', 'Could not write the temporary WP Codebox recipe.', array( 'status' => 500 ) );
 		}
 
-		return $file;
+		return array(
+			'path'          => $file,
+			'cleanup_paths' => $site_seed_payload['cleanup_paths'],
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array{siteSeeds:array<int,array<string,mixed>>,cleanup_paths:array<int,string>}|WP_Error
+	 */
+	private function parent_site_seed_recipe_entries( array $input ): array|WP_Error {
+		$declarations = is_array( $input['site_seeds'] ?? null ) ? $input['site_seeds'] : array();
+		if ( empty( $declarations ) ) {
+			return array( 'siteSeeds' => array(), 'cleanup_paths' => array() );
+		}
+
+		$site_seeds    = array();
+		$cleanup_paths = array();
+		foreach ( $declarations as $index => $declaration ) {
+			if ( ! is_array( $declaration ) ) {
+				return new WP_Error( 'wp_codebox_site_seed_invalid', 'Each site_seeds entry must be an object.', array( 'status' => 400, 'index' => $index ) );
+			}
+			if ( 'parent_site' !== (string) ( $declaration['type'] ?? '' ) ) {
+				return new WP_Error( 'wp_codebox_site_seed_type_invalid', 'Only parent_site site_seeds are accepted by the WordPress host exporter.', array( 'status' => 400, 'index' => $index ) );
+			}
+			$name = (string) ( $declaration['name'] ?? 'parent-site' );
+			if ( ! preg_match( '/^[A-Za-z0-9][A-Za-z0-9_.-]*$/', $name ) ) {
+				return new WP_Error( 'wp_codebox_site_seed_name_invalid', 'site_seeds entries require a stable name.', array( 'status' => 400, 'index' => $index ) );
+			}
+			$scopes = is_array( $declaration['scopes'] ?? null ) ? $declaration['scopes'] : array();
+			$validation = $this->validate_parent_site_seed_scopes( $scopes );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+
+			$seed = $this->export_parent_site_seed( $name, $scopes );
+			if ( is_wp_error( $seed ) ) {
+				return $seed;
+			}
+
+			$file = tempnam( sys_get_temp_dir(), 'wp-codebox-site-seed-' );
+			if ( false === $file ) {
+				return new WP_Error( 'wp_codebox_site_seed_temp_failed', 'Could not create a temporary WP Codebox site seed fixture.', array( 'status' => 500 ) );
+			}
+
+			$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $seed, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $seed, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			if ( ! is_string( $encoded ) || false === file_put_contents( $file, $encoded ) ) {
+				@unlink( $file );
+				return new WP_Error( 'wp_codebox_site_seed_write_failed', 'Could not write a temporary WP Codebox site seed fixture.', array( 'status' => 500 ) );
+			}
+
+			$cleanup_paths[] = $file;
+			$site_seeds[] = array(
+				'type'   => 'fixture',
+				'name'   => $name,
+				'source' => $file,
+				'format' => 'json',
+				'scopes' => $scopes,
+			);
+		}
+
+		return array( 'siteSeeds' => $site_seeds, 'cleanup_paths' => $cleanup_paths );
+	}
+
+	/** @param array<string,mixed> $scopes Parent-site seed scopes. */
+	private function validate_parent_site_seed_scopes( array $scopes ): true|WP_Error {
+		if ( empty( $scopes ) ) {
+			return new WP_Error( 'wp_codebox_site_seed_scopes_missing', 'parent_site site_seeds require explicit scopes.', array( 'status' => 400 ) );
+		}
+
+		foreach ( array( 'posts', 'terms', 'options', 'users', 'media' ) as $scope_name ) {
+			$scope = $scopes[ $scope_name ] ?? null;
+			if ( null === $scope ) {
+				continue;
+			}
+			if ( ! is_array( $scope ) ) {
+				return new WP_Error( 'wp_codebox_site_seed_scope_invalid', 'Record site seed scopes must be objects.', array( 'status' => 400, 'scope' => $scope_name ) );
+			}
+			$max = isset( $scope['maxRecords'] ) ? (int) $scope['maxRecords'] : 0;
+			if ( $max < 1 || $max > 100 ) {
+				return new WP_Error( 'wp_codebox_site_seed_scope_unbounded', 'Parent-site record scopes require maxRecords between 1 and 100.', array( 'status' => 400, 'scope' => $scope_name ) );
+			}
+		}
+
+		if ( isset( $scopes['options'] ) && empty( $scopes['options']['names'] ) ) {
+			return new WP_Error( 'wp_codebox_site_seed_options_unbounded', 'Parent-site option seeds require an explicit names allow-list.', array( 'status' => 400 ) );
+		}
+		if ( isset( $scopes['users'] ) && false === ( $scopes['users']['anonymize'] ?? true ) ) {
+			return new WP_Error( 'wp_codebox_site_seed_users_unsafe', 'Parent-site user seeds must be anonymized.', array( 'status' => 400 ) );
+		}
+		if ( isset( $scopes['media'] ) && true === ( $scopes['media']['includeFiles'] ?? false ) ) {
+			return new WP_Error( 'wp_codebox_site_seed_media_files_unsupported', 'Parent-site media seed export includes metadata only; file export is not supported.', array( 'status' => 400 ) );
+		}
+
+		return true;
+	}
+
+	/** @param array<string,mixed> $scopes Parent-site seed scopes. @return array<string,mixed>|WP_Error */
+	private function export_parent_site_seed( string $name, array $scopes ): array|WP_Error {
+		$seed = array(
+			'schema'     => 'wp-codebox/site-seed-fixture/v1',
+			'name'       => $name,
+			'provenance' => array(
+				'source'      => 'parent_site',
+				'source_url'  => function_exists( 'home_url' ) ? home_url( '/' ) : '',
+				'exported_at' => gmdate( 'c' ),
+				'limitations' => array(
+					'media file bytes are not exported',
+					'user credentials and raw user emails are not exported',
+					'full database state, revisions, comments, post meta, term meta, and arbitrary options are not replayed',
+				),
+			),
+		);
+
+		if ( isset( $scopes['posts'] ) ) {
+			$seed['posts'] = $this->export_parent_site_posts( $scopes['posts'] );
+		}
+		if ( isset( $scopes['terms'] ) ) {
+			$seed['terms'] = $this->export_parent_site_terms( $scopes['terms'] );
+		}
+		if ( isset( $scopes['options'] ) ) {
+			$seed['options'] = $this->export_parent_site_options( $scopes['options'] );
+		}
+		if ( isset( $scopes['users'] ) ) {
+			$seed['users'] = $this->export_parent_site_users( $scopes['users'] );
+		}
+		if ( isset( $scopes['media'] ) ) {
+			$seed['media'] = $this->export_parent_site_media( $scopes['media'] );
+		}
+		if ( true === ( $scopes['activePlugins'] ?? false ) ) {
+			$seed['activePlugins'] = array_slice( array_values( (array) get_option( 'active_plugins', array() ) ), 0, 100 );
+		}
+		if ( true === ( $scopes['activeTheme'] ?? false ) && function_exists( 'get_stylesheet' ) ) {
+			$seed['activeTheme'] = get_stylesheet();
+		}
+
+		return $seed;
+	}
+
+	/** @param array<string,mixed> $scope Parent-site posts scope. @return array<int,array<string,mixed>> */
+	private function export_parent_site_posts( array $scope ): array {
+		$query = array(
+			'post_type'      => ! empty( $scope['postTypes'] ) && is_array( $scope['postTypes'] ) ? array_map( 'sanitize_key', $scope['postTypes'] ) : array( 'post', 'page' ),
+			'post_status'    => ! empty( $scope['statuses'] ) && is_array( $scope['statuses'] ) ? array_map( 'sanitize_key', $scope['statuses'] ) : array( 'publish' ),
+			'posts_per_page' => min( 100, max( 1, (int) $scope['maxRecords'] ) ),
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+			'no_found_rows'  => true,
+		);
+		if ( ! empty( $scope['ids'] ) && is_array( $scope['ids'] ) ) {
+			$query['post__in'] = array_map( 'absint', $scope['ids'] );
+			$query['orderby']  = 'post__in';
+		}
+		if ( ! empty( $scope['slugs'] ) && is_array( $scope['slugs'] ) ) {
+			$query['post_name__in'] = array_map( 'sanitize_title', $scope['slugs'] );
+		}
+
+		$posts = function_exists( 'get_posts' ) ? get_posts( $query ) : array();
+		return array_map(
+			static fn( WP_Post $post ): array => array(
+				'id'           => (int) $post->ID,
+				'post_type'    => $post->post_type,
+				'post_status'  => $post->post_status,
+				'post_name'    => $post->post_name,
+				'post_title'   => $post->post_title,
+				'post_content' => $post->post_content,
+				'post_excerpt' => $post->post_excerpt,
+			),
+			$posts
+		);
+	}
+
+	/** @param array<string,mixed> $scope Parent-site terms scope. @return array<int,array<string,mixed>> */
+	private function export_parent_site_terms( array $scope ): array {
+		$args = array(
+			'taxonomy'   => ! empty( $scope['taxonomies'] ) && is_array( $scope['taxonomies'] ) ? array_map( 'sanitize_key', $scope['taxonomies'] ) : array( 'category', 'post_tag' ),
+			'number'     => min( 100, max( 1, (int) $scope['maxRecords'] ) ),
+			'hide_empty' => false,
+			'orderby'    => 'term_id',
+			'order'      => 'ASC',
+		);
+		if ( ! empty( $scope['ids'] ) && is_array( $scope['ids'] ) ) {
+			$args['include'] = array_map( 'absint', $scope['ids'] );
+		}
+		if ( ! empty( $scope['slugs'] ) && is_array( $scope['slugs'] ) ) {
+			$args['slug'] = array_map( 'sanitize_title', $scope['slugs'] );
+		}
+		if ( ! empty( $scope['names'] ) && is_array( $scope['names'] ) ) {
+			$args['name'] = array_values( array_map( 'sanitize_text_field', $scope['names'] ) );
+		}
+
+		$terms = function_exists( 'get_terms' ) ? get_terms( $args ) : array();
+		if ( is_wp_error( $terms ) || ! is_array( $terms ) ) {
+			return array();
+		}
+
+		return array_map(
+			static fn( WP_Term $term ): array => array(
+				'id'          => (int) $term->term_id,
+				'taxonomy'    => $term->taxonomy,
+				'slug'        => $term->slug,
+				'name'        => $term->name,
+				'description' => $term->description,
+			),
+			array_slice( $terms, 0, min( 100, max( 1, (int) $scope['maxRecords'] ) ) )
+		);
+	}
+
+	/** @param array<string,mixed> $scope Parent-site options scope. @return array<string,mixed> */
+	private function export_parent_site_options( array $scope ): array {
+		$options = array();
+		$names   = ! empty( $scope['names'] ) && is_array( $scope['names'] ) ? array_slice( $scope['names'], 0, min( 100, max( 1, (int) $scope['maxRecords'] ) ) ) : array();
+		foreach ( $names as $name ) {
+			$name = sanitize_key( (string) $name );
+			if ( '' === $name ) {
+				continue;
+			}
+			$options[ $name ] = get_option( $name );
+		}
+
+		return $options;
+	}
+
+	/** @param array<string,mixed> $scope Parent-site users scope. @return array<int,array<string,mixed>> */
+	private function export_parent_site_users( array $scope ): array {
+		$args = array(
+			'number'  => min( 100, max( 1, (int) $scope['maxRecords'] ) ),
+			'orderby' => 'ID',
+			'order'   => 'ASC',
+			'fields'  => array( 'ID', 'display_name', 'roles' ),
+		);
+		if ( ! empty( $scope['ids'] ) && is_array( $scope['ids'] ) ) {
+			$args['include'] = array_map( 'absint', $scope['ids'] );
+		}
+		if ( ! empty( $scope['roles'] ) && is_array( $scope['roles'] ) ) {
+			$args['role__in'] = array_map( 'sanitize_key', $scope['roles'] );
+		}
+
+		$users = function_exists( 'get_users' ) ? get_users( $args ) : array();
+		return array_map(
+			static fn( WP_User $user ): array => array(
+				'id'           => (int) $user->ID,
+				'user_login'   => 'seed-user-' . (int) $user->ID,
+				'user_email'   => 'seed-user-' . (int) $user->ID . '@example.invalid',
+				'display_name' => 'Seed user ' . (int) $user->ID,
+				'roles'        => array_values( array_map( 'sanitize_key', (array) $user->roles ) ),
+			),
+			$users
+		);
+	}
+
+	/** @param array<string,mixed> $scope Parent-site media scope. @return array<int,array<string,mixed>> */
+	private function export_parent_site_media( array $scope ): array {
+		$query = array(
+			'post_type'      => 'attachment',
+			'post_status'    => ! empty( $scope['statuses'] ) && is_array( $scope['statuses'] ) ? array_map( 'sanitize_key', $scope['statuses'] ) : array( 'inherit' ),
+			'posts_per_page' => min( 100, max( 1, (int) $scope['maxRecords'] ) ),
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+			'no_found_rows'  => true,
+		);
+		if ( ! empty( $scope['ids'] ) && is_array( $scope['ids'] ) ) {
+			$query['post__in'] = array_map( 'absint', $scope['ids'] );
+			$query['orderby']  = 'post__in';
+		}
+		if ( ! empty( $scope['slugs'] ) && is_array( $scope['slugs'] ) ) {
+			$query['post_name__in'] = array_map( 'sanitize_title', $scope['slugs'] );
+		}
+
+		$attachments = function_exists( 'get_posts' ) ? get_posts( $query ) : array();
+		return array_map(
+			static fn( WP_Post $post ): array => array(
+				'id'             => (int) $post->ID,
+				'post_name'      => $post->post_name,
+				'post_title'     => $post->post_title,
+				'post_excerpt'   => $post->post_excerpt,
+				'post_mime_type' => $post->post_mime_type,
+				'post_status'    => $post->post_status,
+			),
+			$attachments
+		);
 	}
 
 	/**

--- a/scripts/recipe-site-seed-smoke.ts
+++ b/scripts/recipe-site-seed-smoke.ts
@@ -45,6 +45,21 @@ writeFileSync(fixtureSeedPath, `${JSON.stringify({
       name: "Site Seed Smoke Category",
     },
   ],
+  users: [
+    {
+      user_login: "site-seed-smoke-user",
+      user_email: "site-seed-smoke-user@example.invalid",
+      display_name: "Site Seed Smoke User",
+      roles: ["editor"],
+    },
+  ],
+  media: [
+    {
+      post_name: "site-seed-smoke-media",
+      post_title: "Site Seed Smoke Media",
+      post_mime_type: "image/png",
+    },
+  ],
 }, null, 2)}\n`)
 writeFileSync(customSeedPath, "site-seed-smoke-registry-page\n")
 writeFileSync(importerPluginPath, `<?php
@@ -119,6 +134,8 @@ writeFileSync(recipePath, `${JSON.stringify({
           posts: { postTypes: ["page"], slugs: ["site-seed-smoke-page"], maxRecords: 1 },
           options: { names: ["blogname"], maxRecords: 1 },
           terms: { taxonomies: ["category"], slugs: ["site-seed-smoke-category"], maxRecords: 1 },
+          users: { names: ["site-seed-smoke-user"], anonymize: true, maxRecords: 1 },
+          media: { slugs: ["site-seed-smoke-media"], maxRecords: 1 },
           activePlugins: true,
           activeTheme: true,
         },
@@ -147,7 +164,7 @@ writeFileSync(recipePath, `${JSON.stringify({
       {
         command: "wordpress.run-php",
         args: [
-          "code=$page = get_page_by_path('site-seed-smoke-page', OBJECT, 'page'); if (!$page) { throw new RuntimeException('seeded page missing'); } $registry_page = get_page_by_path('site-seed-smoke-registry-page', OBJECT, 'page'); if (!$registry_page) { throw new RuntimeException('registry seeded page missing'); } if (get_page_by_path('site-seed-smoke-excluded-page', OBJECT, 'page')) { throw new RuntimeException('unscoped page imported'); } if (get_option('blogname') !== 'WP Codebox Seeded Sandbox') { throw new RuntimeException('seeded option missing'); } if (!term_exists('site-seed-smoke-category', 'category')) { throw new RuntimeException('seeded term missing'); } if (!is_plugin_active('simple-plugin/simple-plugin.php')) { throw new RuntimeException('seeded plugin not active'); } if (!is_plugin_active('test-seed-importer/test-seed-importer.php')) { throw new RuntimeException('importer plugin not active'); } if (get_stylesheet() !== 'twentytwentyfive') { throw new RuntimeException('seeded theme not active: ' . get_stylesheet()); } echo wp_json_encode(array('page' => $page->post_name, 'registryPage' => $registry_page->post_name, 'blogname' => get_option('blogname'), 'pluginActive' => is_plugin_active('simple-plugin/simple-plugin.php'), 'stylesheet' => get_stylesheet()));",
+          "code=$page = get_page_by_path('site-seed-smoke-page', OBJECT, 'page'); if (!$page) { throw new RuntimeException('seeded page missing'); } $registry_page = get_page_by_path('site-seed-smoke-registry-page', OBJECT, 'page'); if (!$registry_page) { throw new RuntimeException('registry seeded page missing'); } if (get_page_by_path('site-seed-smoke-excluded-page', OBJECT, 'page')) { throw new RuntimeException('unscoped page imported'); } if (get_option('blogname') !== 'WP Codebox Seeded Sandbox') { throw new RuntimeException('seeded option missing'); } if (!term_exists('site-seed-smoke-category', 'category')) { throw new RuntimeException('seeded term missing'); } if (!username_exists('site-seed-smoke-user')) { throw new RuntimeException('seeded user missing'); } $media = get_page_by_path('site-seed-smoke-media', OBJECT, 'attachment'); if (!$media) { throw new RuntimeException('seeded media missing'); } if (!is_plugin_active('simple-plugin/simple-plugin.php')) { throw new RuntimeException('seeded plugin not active'); } if (!is_plugin_active('test-seed-importer/test-seed-importer.php')) { throw new RuntimeException('importer plugin not active'); } if (get_stylesheet() !== 'twentytwentyfive') { throw new RuntimeException('seeded theme not active: ' . get_stylesheet()); } echo wp_json_encode(array('page' => $page->post_name, 'registryPage' => $registry_page->post_name, 'blogname' => get_option('blogname'), 'user' => username_exists('site-seed-smoke-user'), 'media' => $media->post_name, 'pluginActive' => is_plugin_active('simple-plugin/simple-plugin.php'), 'stylesheet' => get_stylesheet()));",
         ],
       },
     ],
@@ -204,6 +221,8 @@ assert.equal(output.siteSeeds[0].privacy.importsIntoSandbox, true)
 assert.equal(output.siteSeeds[0].counts.posts, 1)
 assert.equal(output.siteSeeds[0].counts.options, 1)
 assert.equal(output.siteSeeds[0].counts.terms, 1)
+assert.equal(output.siteSeeds[0].counts.users, 1)
+assert.equal(output.siteSeeds[0].counts.media, 1)
 assert.equal(output.siteSeeds[0].counts.activePlugins, 1)
 assert.equal(output.siteSeeds[0].counts.activeTheme, 1)
 assert.equal(output.siteSeeds[0].counts.fixturePostsExcluded, 1)
@@ -227,6 +246,8 @@ const workflowResult = JSON.parse(output.executions[3].stdout)
 assert.equal(workflowResult.page, "site-seed-smoke-page")
 assert.equal(workflowResult.registryPage, "site-seed-smoke-registry-page")
 assert.equal(workflowResult.blogname, "WP Codebox Seeded Sandbox")
+assert.equal(typeof workflowResult.user, "number")
+assert.equal(workflowResult.media, "site-seed-smoke-media")
 assert.equal(workflowResult.pluginActive, true)
 assert.equal(workflowResult.stylesheet, "twentytwentyfive")
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -24,6 +24,24 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+		public function __construct( public int $ID, public string $post_type, public string $post_status, public string $post_name, public string $post_title, public string $post_content = '', public string $post_excerpt = '', public string $post_mime_type = '' ) {}
+	}
+}
+
+if ( ! class_exists( 'WP_Term' ) ) {
+	class WP_Term {
+		public function __construct( public int $term_id, public string $taxonomy, public string $slug, public string $name, public string $description = '' ) {}
+	}
+}
+
+if ( ! class_exists( 'WP_User' ) ) {
+	class WP_User {
+		public function __construct( public int $ID, public string $display_name, public array $roles ) {}
+	}
+}
+
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $thing ): bool { return $thing instanceof WP_Error; }
 }
@@ -89,6 +107,21 @@ function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 function is_multisite(): bool { return (bool) ( $GLOBALS['wp_codebox_is_multisite'] ?? false ); }
 function get_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_options'][ $name ] ?? $default; }
 function get_site_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_site_options'][ $name ] ?? $default; }
+function home_url( string $path = '' ): string { return 'https://parent.example.test' . $path; }
+function sanitize_key( string $key ): string { return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key ) ?? '' ); }
+function sanitize_title( string $title ): string { return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '-', $title ) ?? '' ); }
+function sanitize_text_field( string $text ): string { return trim( preg_replace( '/[\r\n\t]+/', ' ', $text ) ?? '' ); }
+function absint( mixed $value ): int { return abs( (int) $value ); }
+function get_stylesheet(): string { return 'twentytwentyfive'; }
+function get_posts( array $args ): array {
+	if ( 'attachment' === ( $args['post_type'] ?? '' ) ) {
+		return array( new WP_Post( 5, 'attachment', 'inherit', 'seed-image', 'Seed Image', '', '', 'image/png' ) );
+	}
+
+	return array( new WP_Post( 7, 'page', 'publish', 'seed-page', 'Seed Page', '<!-- wp:paragraph --><p>Seeded</p><!-- /wp:paragraph -->' ) );
+}
+function get_terms( array $args ): array { return array( new WP_Term( 3, 'category', 'seed-category', 'Seed Category' ) ); }
+function get_users( array $args ): array { return array( new WP_User( 11, 'Private User', array( 'editor' ) ) ); }
 
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
@@ -141,6 +174,7 @@ $assert( 'ability exposes allowed tools schema', 'array' === ( $ability['input_s
 $assert( 'ability exposes expected artifacts schema', 'array' === ( $ability['input_schema']['properties']['expected_artifacts']['type'] ?? '' ) );
 $assert( 'ability exposes policy and context schema', 'object' === ( $ability['input_schema']['properties']['policy']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['context']['type'] ?? '' ) );
 $assert( 'ability exposes generic mounts schema', 'array' === ( $ability['input_schema']['properties']['mounts']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['mounts']['items']['properties']['metadata']['type'] ?? '' ) );
+$assert( 'ability exposes bounded parent-site seed schema', 'array' === ( $ability['input_schema']['properties']['site_seeds']['type'] ?? '' ) && array( 'parent_site' ) === ( $ability['input_schema']['properties']['site_seeds']['items']['properties']['type']['enum'] ?? array() ) );
 $assert( 'ability exposes inheritance request schema', 'object' === ( $ability['input_schema']['properties']['inherit']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['connectors']['type'] ?? '' ) );
 $assert( 'ability exposes connector credential envelope schema', 'object' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['properties']['secrets']['type'] ?? '' ) );
 $assert( 'ability exposes external sandbox session schema', 'string' === ( $ability['input_schema']['properties']['sandbox_session_id']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['orchestrator']['type'] ?? '' ) && 'object' === ( $ability['output_schema']['properties']['session']['type'] ?? '' ) );
@@ -375,6 +409,35 @@ $assert( 'runner recipe passes provider plugin path', str_contains( $captured_re
 $assert( 'runner recipe passes generic mount metadata', str_contains( $captured_recipe, 'example/editable-plugin' ) && str_contains( $captured_recipe, 'repo_root_relative_to_mount' ) );
 $assert( 'runner recipe passes secret env name only', str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
 $assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
+
+$GLOBALS['wp_codebox_options']['blogname'] = 'Parent Seed Site';
+$GLOBALS['wp_codebox_options']['active_plugins'] = array( 'agents-api/agents-api.php' );
+$seed_result = $runner->run(
+	array(
+		'goal'           => 'Run with a bounded parent-site seed.',
+		'artifacts_path' => $root . '/artifacts',
+		'site_seeds'    => array(
+			array(
+				'type'   => 'parent_site',
+				'name'   => 'parent-site-smoke',
+				'scopes' => array(
+					'posts'         => array( 'postTypes' => array( 'page' ), 'maxRecords' => 1 ),
+					'terms'         => array( 'taxonomies' => array( 'category' ), 'maxRecords' => 1 ),
+					'options'       => array( 'names' => array( 'blogname' ), 'maxRecords' => 1 ),
+					'users'         => array( 'roles' => array( 'editor' ), 'anonymize' => true, 'maxRecords' => 1 ),
+					'media'         => array( 'maxRecords' => 1 ),
+					'activePlugins' => true,
+					'activeTheme'   => true,
+				),
+			),
+		),
+	)
+);
+$seed_recipe = json_decode( $captured_recipe, true );
+$seed_path   = (string) ( $seed_recipe['inputs']['siteSeeds'][0]['source'] ?? '' );
+$assert( 'runner exports bounded parent-site seed as fixture', ! is_wp_error( $seed_result ) && 'fixture' === ( $seed_recipe['inputs']['siteSeeds'][0]['type'] ?? '' ) && 'json' === ( $seed_recipe['inputs']['siteSeeds'][0]['format'] ?? '' ) );
+$assert( 'runner cleans temporary parent-site seed fixture after run', ! is_wp_error( $seed_result ) && '' !== $seed_path && ! file_exists( $seed_path ) );
+$assert( 'runner preserves parent-site seed scope in recipe', ! is_wp_error( $seed_result ) && 1 === ( $seed_recipe['inputs']['siteSeeds'][0]['scopes']['posts']['maxRecords'] ?? 0 ) && true === ( $seed_recipe['inputs']['siteSeeds'][0]['scopes']['users']['anonymize'] ?? false ) );
 
 unset( $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] );
 $plugin_native_result = $runner->run(


### PR DESCRIPTION
## Summary
- Adds bounded parent-site seed export from the WordPress host ability into temporary JSON fixtures consumed by existing recipe `siteSeeds` import.
- Extends fixture import to cover anonymized users and media metadata alongside posts, terms, options, active plugins, and active theme.
- Documents Reprint as a future full/essential-site snapshot backend rather than a dependency for bounded seeds.

Fixes #147.
Refs #162.

## Testing
- `npm run build`
- `git diff --check HEAD~1..HEAD`
- `npm run recipe-site-seed-smoke`
- `npm run wordpress-plugin-smoke`
- `npm run check` was started and progressed through `artifact-contract-smoke`, but was manually aborted by controller nudge before completion; no failure was observed before abort.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bounded seed export/import slice, tests, and documentation for Chris to review.