### PR TITLE
Fix ability output after Playground login blueprints

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "preview-response-body-smoke": "tsx scripts/preview-response-body-smoke.ts",
     "boot-preview-smoke": "tsx scripts/boot-preview-smoke.ts",
     "blueprint-validation-smoke": "tsx scripts/blueprint-validation-smoke.ts",
+    "ability-login-blueprint-smoke": "tsx scripts/ability-login-blueprint-smoke.ts",
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "agent-sandbox-code-smoke": "tsx scripts/agent-sandbox-code-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1366,6 +1366,7 @@ class PlaygroundRuntime implements Runtime {
 
   private bootstrapAbilityPhpCode(code: string): string {
     return `<?php
+define( 'REST_REQUEST', true );
 $_SERVER['REQUEST_URI'] = '/wp-json/wp-codebox/ability';
 require_once '/wordpress/wp-load.php';
 ${this.secretEnvPhp()}

--- a/scripts/ability-login-blueprint-smoke.ts
+++ b/scripts/ability-login-blueprint-smoke.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const workspace = resolve(root, "artifacts/ability-login-blueprint-smoke")
+const artifactDirectory = resolve(workspace, "artifacts")
+const sourceRecipePath = resolve(root, "examples/recipes/datamachine-agent-bundle.json")
+const bundlePath = resolve(root, "examples/datamachine-bundle/world-creator-lite")
+const agentsApiPath = resolve(root, "../agents-api")
+const dataMachinePath = resolve(root, "../data-machine")
+
+for (const requiredPath of [sourceRecipePath, bundlePath, agentsApiPath, dataMachinePath]) {
+  assert(existsSync(requiredPath), `Missing required smoke fixture path: ${requiredPath}`)
+}
+
+mkdirSync(workspace, { recursive: true })
+
+function writeRecipe(name: string, blueprint: Record<string, unknown>): string {
+  const recipe = JSON.parse(readFileSync(sourceRecipePath, "utf8"))
+  recipe.runtime.blueprint = blueprint
+  recipe.inputs.extra_plugins[0].source = agentsApiPath
+  recipe.inputs.extra_plugins[1].source = dataMachinePath
+  recipe.inputs.mounts[0].source = bundlePath
+
+  const path = resolve(workspace, `${name}.json`)
+  writeFileSync(path, `${JSON.stringify(recipe, null, 2)}\n`)
+  return path
+}
+
+function runRecipe(path: string): Record<string, any> {
+  const result = spawnSync(process.execPath, [
+    cli,
+    "recipe-run",
+    "--recipe",
+    path,
+    "--artifacts",
+    artifactDirectory,
+    "--json",
+  ], { cwd: root, encoding: "utf8", maxBuffer: 1024 * 1024 * 20 })
+
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+  return JSON.parse(result.stdout)
+}
+
+function assertAbilityImport(output: Record<string, any>, label: string): void {
+  assert.equal(output.success, true, `${label} recipe should succeed`)
+  const abilityExecution = output.executions.find((execution: { command: string }) => execution.command === "wordpress.ability")
+  assert(abilityExecution, `${label} recipe should execute wordpress.ability`)
+  assert.equal(abilityExecution.exitCode, 0)
+  assert.notEqual(abilityExecution.stdout.trim(), "", `${label} wordpress.ability stdout must not be empty`)
+
+  const abilityOutput = JSON.parse(abilityExecution.stdout)
+  assert.equal(abilityOutput.command, "wordpress.ability")
+  assert.equal(abilityOutput.name, "datamachine/import-agent")
+  assert.equal(abilityOutput.result?.success, true)
+  assert.equal(abilityOutput.result?.summary?.agent_slug, "world-creator-lite")
+}
+
+assertAbilityImport(runRecipe(writeRecipe("without-login", { steps: [] })), "without-login")
+assertAbilityImport(runRecipe(writeRecipe("with-login", {
+  steps: [{
+    step: "login",
+    username: "admin",
+    password: "password",
+  }],
+})), "with-login")


### PR DESCRIPTION
## Summary
- Fix `wordpress.ability` execution after a Playground `login` blueprint step by marking the synthetic ability bootstrap as a REST request before WordPress loads.
- Add a focused regression smoke that runs the Data Machine agent import ability both with and without a login blueprint and asserts stdout plus import result remain present.

Closes #170.

## Reproduction / verification
- Reproduced on current main: adding `{ \"step\": \"login\", \"username\": \"admin\", \"password\": \"password\" }` to the Data Machine agent bundle recipe made `wordpress.ability` exit `0` with empty stdout.
- Root cause: the login blueprint installs Playground auto-login behavior during `init`; the synthetic `/wp-json/...` request was treated as a normal frontend request until `REST_REQUEST` was defined, so bootstrap could terminate before the ability body emitted output.
- Verified fixed by `npm run ability-login-blueprint-smoke`, which imports the same bundle with and without the login blueprint.

## Tests
- `npm run build`
- `npm run ability-login-blueprint-smoke`
- `git diff --check`

## Notes
- `npm run check` was attempted before opening the PR. It reached `artifact-contract-smoke` and then failed because fixed preview ports `127.0.0.1:61212` and `127.0.0.1:61214` were already held by `.opencode` processes in this environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause investigation, fix implementation, regression smoke, and verification command execution. Chris remains responsible for review and merge.