### PR TITLE
Bundle Node runtime for plugin CLI runs

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -122,6 +122,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return new WP_Error( 'wp_codebox_bin_invalid', 'wp_codebox_bin must be a command name or path without shell metacharacters.', array( 'status' => 400 ) );
 		}
 
+		$command_prefix = $this->command_prefix( $bin );
+		if ( is_wp_error( $command_prefix ) ) {
+			return $command_prefix;
+		}
+
 		$preview_args = $this->preview_args( $input );
 		if ( is_wp_error( $preview_args ) ) {
 			return $preview_args;
@@ -135,7 +140,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		$command = sprintf(
 			'%s recipe-run --recipe %s --artifacts %s --json',
-			$this->command_prefix( $bin ),
+			$command_prefix,
 			escapeshellarg( $recipe_file ),
 			escapeshellarg( $artifacts )
 		);
@@ -1426,12 +1431,89 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return $normalized;
 	}
 
-	private function command_prefix( string $bin ): string {
+	private function command_prefix( string $bin ): string|WP_Error {
 		if ( str_ends_with( $bin, '.js' ) && is_file( $bin ) ) {
-			return 'node ' . escapeshellarg( $bin );
+			$node = $this->node_binary();
+			if ( is_wp_error( $node ) ) {
+				return $node;
+			}
+
+			return escapeshellarg( $node ) . ' ' . escapeshellarg( $bin );
+		}
+
+		if ( $this->is_bundled_cli_wrapper( $bin ) ) {
+			$node = $this->node_binary();
+			if ( is_wp_error( $node ) ) {
+				return $node;
+			}
 		}
 
 		return escapeshellarg( $bin );
+	}
+
+	private function node_binary(): string|WP_Error {
+		$configured = trim( (string) ( getenv( 'WP_CODEBOX_NODE_BIN' ) ?: '' ) );
+		if ( '' !== $configured ) {
+			if ( is_file( $configured ) && is_executable( $configured ) ) {
+				return $configured;
+			}
+
+			return new WP_Error( 'wp_codebox_node_runtime_unavailable', 'WP_CODEBOX_NODE_BIN is configured but is not an executable file.', array( 'status' => 500, 'path' => $configured ) );
+		}
+
+		$bundled = $this->bundled_node_binary();
+		if ( '' !== $bundled ) {
+			return $bundled;
+		}
+
+		foreach ( array( 'node', 'nodejs' ) as $command ) {
+			$resolved = $this->resolve_command( $command );
+			if ( '' !== $resolved ) {
+				return $resolved;
+			}
+		}
+
+		return new WP_Error(
+			'wp_codebox_node_runtime_unavailable',
+			'WP Codebox could not find an executable Node.js runtime. Use the packaged plugin with vendor/wp-codebox-cli/vendor/node/bin/node, set WP_CODEBOX_NODE_BIN, or install node on PATH.',
+			array( 'status' => 500 )
+		);
+	}
+
+	private function bundled_node_binary(): string {
+		if ( ! defined( 'WP_CODEBOX_PLUGIN_PATH' ) ) {
+			return '';
+		}
+
+		$path = WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/vendor/node/bin/node';
+		return is_file( $path ) && is_executable( $path ) ? $path : '';
+	}
+
+	private function is_bundled_cli_wrapper( string $bin ): bool {
+		if ( ! defined( 'WP_CODEBOX_PLUGIN_PATH' ) ) {
+			return false;
+		}
+
+		return $bin === WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/bin/wp-codebox';
+	}
+
+	private function resolve_command( string $command ): string {
+		if ( isset( $this->callbacks['command_resolver'] ) ) {
+			$resolved = ( $this->callbacks['command_resolver'] )( $command );
+			return is_string( $resolved ) ? $resolved : '';
+		}
+
+		if ( ! function_exists( 'exec' ) ) {
+			return '';
+		}
+
+		$output = array();
+		$exit   = 1;
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Used for executable preflight only.
+		exec( 'command -v ' . escapeshellarg( $command ) . ' 2>/dev/null', $output, $exit );
+		$resolved = 0 === $exit && ! empty( $output[0] ) ? (string) $output[0] : '';
+
+		return '' !== $resolved && is_executable( $resolved ) ? $resolved : '';
 	}
 
 	/**

--- a/scripts/package-distribution-smoke.ts
+++ b/scripts/package-distribution-smoke.ts
@@ -48,6 +48,12 @@ assert.ok(zipEntries.has("wp-codebox/README.md"), "Plugin zip should include REA
 assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-abilities.php"), "Plugin zip should include ability surface")
 assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-agent-sandbox-runner.php"), "Plugin zip should include sandbox runner")
 assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-artifacts.php"), "Plugin zip should include artifact helpers")
+assert.ok(zipEntries.has("wp-codebox/vendor/wp-codebox-cli/bin/wp-codebox"), "Plugin zip should include packaged CLI wrapper")
+assert.ok(
+  zipEntries.has("wp-codebox/vendor/wp-codebox-cli/vendor/node/bin/node"),
+  "Plugin zip should include packaged Node runtime for the plugin CLI path",
+)
+assert.ok(zipEntries.has("wp-codebox/vendor/wp-codebox-cli/packages/cli/dist/index.js"), "Plugin zip should include compiled CLI runtime")
 assert.equal(zipEntries.has("wp-codebox/package.json"), false, "Plugin zip should not include package metadata")
 assert.equal(zipEntries.has("wp-codebox/dist/wp-codebox.zip"), false, "Plugin zip should not include generated artifacts")
 

--- a/scripts/package-release-artifact.ts
+++ b/scripts/package-release-artifact.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process"
-import { chmod, cp, mkdir, rm, writeFile } from "node:fs/promises"
+import { chmod, cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { arch, platform } from "node:os"
+import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 
@@ -10,6 +11,7 @@ const releaseRoot = resolve(repoRoot, "dist", "release")
 const packageRoot = join(releaseRoot, "wp-codebox-cli")
 const platformName = process.env.WP_CODEBOX_RELEASE_PLATFORM ?? normalizePlatform(platform())
 const archName = process.env.WP_CODEBOX_RELEASE_ARCH ?? normalizeArch(arch())
+const nodeRuntimeVersion = process.env.WP_CODEBOX_NODE_RUNTIME_VERSION ?? "24.16.0"
 const artifactName = `wp-codebox-cli-${platformName}-${archName}.tar.gz`
 const artifactPath = resolve(repoRoot, "dist", artifactName)
 
@@ -35,11 +37,29 @@ await execFileAsync("npm", ["install", "--omit=dev", "--omit=optional", "--ignor
   cwd: packageRoot,
   maxBuffer: 1024 * 1024 * 20,
 })
+await bundleNodeRuntime(packageRoot, platformName, archName)
 
 const binDir = join(packageRoot, "bin")
 await mkdir(binDir, { recursive: true })
 const binPath = join(binDir, "wp-codebox")
-await writeFile(binPath, "#!/usr/bin/env bash\nset -euo pipefail\nSCRIPT_DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\nexec node \"${SCRIPT_DIR}/../packages/cli/dist/index.js\" \"$@\"\n")
+await writeFile(binPath, `#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+NODE_BIN="\${WP_CODEBOX_NODE_BIN:-}"
+if [ -z "\${NODE_BIN}" ]; then
+	if [ -x "\${SCRIPT_DIR}/../vendor/node/bin/node" ]; then
+		NODE_BIN="\${SCRIPT_DIR}/../vendor/node/bin/node"
+	elif command -v node >/dev/null 2>&1; then
+		NODE_BIN="$(command -v node)"
+	elif command -v nodejs >/dev/null 2>&1; then
+		NODE_BIN="$(command -v nodejs)"
+	else
+		echo "WP Codebox could not find a Node.js runtime. Bundle vendor/node/bin/node, set WP_CODEBOX_NODE_BIN, or install node on PATH." >&2
+		exit 127
+	fi
+fi
+exec "\${NODE_BIN}" "\${SCRIPT_DIR}/../packages/cli/dist/index.js" "$@"
+`)
 await chmod(binPath, 0o755)
 
 await execFileAsync("tar", ["-czf", artifactPath, "-C", releaseRoot, "wp-codebox-cli"], {
@@ -57,6 +77,50 @@ async function copyIfPresent(relativePath: string): Promise<void> {
       throw error
     }
   }
+}
+
+async function bundleNodeRuntime(root: string, platformName: string, archName: string): Promise<void> {
+  const nodePackageName = nodeRuntimePackageName(platformName, archName)
+  const runtimeRoot = join(root, "vendor", "node")
+  await rm(runtimeRoot, { recursive: true, force: true })
+  await mkdir(join(runtimeRoot, "bin"), { recursive: true })
+
+  if (nodePackageName) {
+    const tempRoot = await mkdtemp(join(tmpdir(), "wp-codebox-node-runtime-"))
+    try {
+      const { stdout } = await execFileAsync(
+        "npm",
+        ["pack", `${nodePackageName}@${nodeRuntimeVersion}`, "--pack-destination", tempRoot, "--json"],
+        { cwd: repoRoot, maxBuffer: 1024 * 1024 * 20 },
+      )
+      const [packed] = JSON.parse(stdout) as Array<{ filename: string }>
+      const tarball = join(tempRoot, packed.filename)
+      await execFileAsync("tar", ["-xzf", tarball, "-C", tempRoot, "package/bin/node"], {
+        cwd: repoRoot,
+        maxBuffer: 1024 * 1024 * 10,
+      })
+      await cp(join(tempRoot, "package", "bin", "node"), join(runtimeRoot, "bin", "node"))
+      await chmod(join(runtimeRoot, "bin", "node"), 0o755)
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  } else if (platformName === normalizePlatform(platform()) && archName === normalizeArch(arch())) {
+    await cp(process.execPath, join(runtimeRoot, "bin", "node"))
+    await chmod(join(runtimeRoot, "bin", "node"), 0o755)
+  } else {
+    await writeFile(
+      join(runtimeRoot, "README.md"),
+      `No bundled Node.js runtime is available for ${platformName}-${archName}. Set WP_CODEBOX_NODE_BIN or install node on PATH.\n`,
+    )
+  }
+}
+
+function nodeRuntimePackageName(platformName: string, archName: string): string | null {
+  if (platformName === "linux" && (archName === "x64" || archName === "arm64")) {
+    return `node-linux-${archName}`
+  }
+
+  return null
 }
 
 function normalizePlatform(value: NodeJS.Platform): string {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -11,6 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', sys_get_temp_dir() . '/wp-codebox-wordpress-plugin/' );
 }
 
+$plugin_bundle_root = sys_get_temp_dir() . '/wp-codebox-wordpress-plugin-bundle-' . getmypid();
+if ( ! defined( 'WP_CODEBOX_PLUGIN_PATH' ) ) {
+	define( 'WP_CODEBOX_PLUGIN_PATH', $plugin_bundle_root . '/wp-codebox/' );
+}
+
 if ( ! class_exists( 'WP_Ability' ) ) {
 	class WP_Ability {}
 }
@@ -100,6 +105,12 @@ foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'plugin-root
 	mkdir( $root . '/' . $dir, 0777, true );
 }
 file_put_contents( $root . '/wp-codebox.js', "#!/usr/bin/env node\n" );
+mkdir( WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/bin', 0777, true );
+mkdir( WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/vendor/node/bin', 0777, true );
+file_put_contents( WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/bin/wp-codebox', "#!/usr/bin/env bash\n" );
+file_put_contents( WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/vendor/node/bin/node', "#!/usr/bin/env bash\n" );
+chmod( WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/bin/wp-codebox', 0755 );
+chmod( WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/vendor/node/bin/node', 0755 );
 if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', $root . '/plugin-root' );
 }
@@ -362,7 +373,7 @@ $assert( 'runner returns orchestrator correlation and artifact refs', ! is_wp_er
 $assert( 'runner returns public preview URL in session artifact metadata', ! is_wp_error( $result ) && 'https://preview.example.test/session-123/' === ( $result['session']['artifacts']['preview_url'] ?? '' ) && 'https://preview.example.test/session-123/' === ( $result['run']['artifacts']['preview']['url'] ?? '' ) );
 $assert( 'runner returns normalized task input for legacy task', ! is_wp_error( $result ) && 'wp-codebox/task-input/v1' === ( $result['task_input']['schema'] ?? '' ) && 'Run a chat-requested sandbox task.' === ( $result['task_input']['goal'] ?? '' ) );
 $assert( 'runner invokes recipe-run', str_contains( $captured_command, 'recipe-run' ) );
-$assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node ' ) );
+$assert( 'runner uses node for JS CLI', str_contains( $captured_command, 'node' ) && str_contains( $captured_command, 'wp-codebox.js' ) );
 $assert( 'runner passes preview hold to CLI', str_contains( $captured_command, '--preview-hold' ) && str_contains( $captured_command, "'30'" ) );
 $assert( 'runner passes preview configuration to CLI', str_contains( $captured_command, '--preview-port' ) && str_contains( $captured_command, "'45678'" ) && str_contains( $captured_command, '--preview-bind' ) && str_contains( $captured_command, "'127.0.0.1'" ) && str_contains( $captured_command, '--preview-public-url' ) && str_contains( $captured_command, "'https://preview.example.test/session-123/'" ) );
 $assert( 'runner recipe uses agent step', str_contains( $captured_recipe, 'wp-codebox.agent-sandbox-run' ) );
@@ -390,6 +401,18 @@ $plugin_native_plugins = array_map(
 );
 $assert( 'runner defaults Agents API path from WP_PLUGIN_DIR', ! is_wp_error( $plugin_native_result ) && in_array( 'agents-api', $plugin_native_plugins, true ) );
 $assert( 'runner does not require Data Machine component paths', ! is_wp_error( $plugin_native_result ) && ! in_array( 'data-machine', $plugin_native_plugins, true ) && ! in_array( 'data-machine-code', $plugin_native_plugins, true ) );
+
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_bin'] );
+$bundled_runtime_result = $runner->run(
+	array(
+		'goal'           => 'Run with the packaged WP Codebox CLI runtime.',
+		'artifacts_path' => $root . '/artifacts',
+	)
+);
+$assert( 'runner defaults to packaged CLI wrapper when present', ! is_wp_error( $bundled_runtime_result ) && str_contains( $captured_command, WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/bin/wp-codebox' ) );
+$assert( 'runner preflights packaged Node runtime', ! is_wp_error( $bundled_runtime_result ) && ! str_contains( $captured_command, 'node: not found' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_bin'] = $root . '/wp-codebox.js';
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] = array(
 	'agents_api'        => $root . '/agents-api',


### PR DESCRIPTION
## Summary
- Bundle a Linux Node runtime into the packaged WP Codebox CLI release artifact used by the WordPress plugin zip.
- Make the CLI wrapper prefer `WP_CODEBOX_NODE_BIN`, then bundled `vendor/node/bin/node`, then host `node`/`nodejs`, with an actionable error when none is available.
- Add plugin/package smoke coverage proving the packaged plugin includes the CLI, bundled runtime, and runner preflight path.

Fixes #207.

## Testing
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run package-distribution-smoke`
- `git diff --check origin/main...HEAD`
- `npm run check` was started and passed through build, discovery, theme/plugin/package/artifact/runtime smokes until `recipe-bench-smoke`; it was interrupted by a controller nudge to finish the PR.

## Follow-up Notes
- This ships the first self-contained runtime slice for Linux package builds, which covers the WP Cloud-style plugin runtime target. Non-Linux package targets still keep the explicit `WP_CODEBOX_NODE_BIN`/host PATH fallback until platform-specific runtime packages are chosen.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bundled runtime packaging/resolution slice, smoke coverage, and PR description; Chris remains responsible for review and merge.