### PR TITLE
Harden artifact and workspace evidence verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ their result artifacts are recorded as advisory/declarative evidence. Secret
 values are never written to the attestation; it records only names, counts,
 availability, and the redaction mode.
 
+Workspace policy evidence rejects symlinks, special files, nested `.git`
+metadata, hidden-policy paths, paths outside writable roots, gitlinks,
+unmerged-index entries, ignored files in git-backed mode, and regular files with
+more than one hard link. The hard-link check uses the host platform's
+`lstat().nlink` value and fails closed if the link count cannot be determined,
+because a hard-linked file under an allowed root is not independent evidence.
+
 For interactive review, pass `--preview-hold <duration>` to keep the live Playground server available briefly after artifact capture. The command emits `artifacts.preview.url` and `files/review.json` includes a matching top-level `preview` object with lifecycle and expiry details.
 
 ```bash
@@ -684,6 +691,13 @@ Current bundles include:
 Artifact bundle ids are content-addressed for the apply-back contract. The runtime writes `manifest.id` as `artifact-bundle-sha256-<digest>`, where `<digest>` is SHA-256 over the exact bytes of `files/changed-files.json` and `files/patch.diff` with the `wp-codebox/artifact-content/v1` domain separator. The same value is exposed as `manifest.contentDigest.value`, `metadata.contentDigest.value`, the CLI `artifacts.contentDigest` field, and `files/review.json` evidence. Approval and apply-back consumers must recompute it before trusting an approved artifact.
 
 Every `manifest.files[]` entry also carries `sha256: { "algorithm": "sha256", "value": "..." }`. For regular files, `value` is the SHA-256 of that artifact file's bytes. For `manifest.json`, `value` is a canonical self-hash over the parsed manifest with the manifest entry's own hash replaced by 64 zeroes, using the `wp-codebox/artifact-manifest-self/v1` domain separator. `wp-codebox artifacts verify` rejects missing hashes and mismatched hashes for any declared file, so tampering with replay-critical or supporting artifacts is detected even when the top-level content digest inputs are unchanged.
+
+`wp-codebox artifacts verify` also fails closed on unsafe bundle topology: all
+declared file paths must be bundle-relative, non-duplicated, traversal-free,
+listed in `manifest.files[]` when used as digest inputs or evidence refs, and
+present as regular files under the bundle directory. Symlinks, special files, and
+regular files with multiple hard links are rejected so downstream consumers do
+not trust artifact evidence that may alias protected content outside the bundle.
 
 ### `files/review.json`
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto"
-import { readdir, readFile, stat, writeFile } from "node:fs/promises"
-import { isAbsolute, join, normalize, sep } from "node:path"
+import { lstat, readdir, readFile, realpath, writeFile } from "node:fs/promises"
+import { isAbsolute, join, normalize, relative, sep } from "node:path"
 
 export * from "./workspace-policy.js"
 
@@ -859,12 +859,15 @@ export type ArtifactBundleVerificationViolationCode =
   | "bundle-id-mismatch"
   | "malformed-reference"
   | "review-evidence-mismatch"
+  | "unsafe-file"
+  | "hardlink"
 
 export interface ArtifactBundleVerificationViolation {
   code: ArtifactBundleVerificationViolationCode
   path: string
   message: string
   file?: string
+  details?: Record<string, unknown>
 }
 
 export interface ArtifactBundleVerificationResult {
@@ -916,12 +919,12 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
       continue
     }
 
+    if (manifestFiles.has(file.path)) {
+      violations.push({ code: "invalid-manifest-shape", path: fieldPath, file: file.path, message: `Manifest file path is duplicated: ${file.path}` })
+    }
     manifestFiles.add(file.path)
     try {
-      const fileStat = await stat(join(bundleDirectory, file.path))
-      if (!fileStat.isFile()) {
-        violations.push({ code: "missing-file", path: fieldPath, file: file.path, message: `Manifest path is not a file: ${file.path}` })
-      }
+      await verifyBundleFileTopology(bundleDirectory, file.path, fieldPath, violations)
     } catch {
       violations.push({ code: "missing-file", path: fieldPath, file: file.path, message: `Manifest file is missing: ${file.path}` })
     }
@@ -945,7 +948,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   }
 
   await verifyManifestFileHashes(bundleDirectory, manifest, manifestFileName, violations)
-  await verifyContentDigest(bundleDirectory, manifest, violations)
+  await verifyContentDigest(bundleDirectory, manifest, manifestFiles, violations)
   verifyBundleId(manifest, violations)
   await verifyMetadataReferences(bundleDirectory, manifestFiles, violations)
   await verifyReviewEvidence(bundleDirectory, manifest, manifestFiles, violations)
@@ -974,6 +977,31 @@ export async function calculateArtifactManifestFileSha256(directory: string, man
   }
 
   return createHash("sha256").update(await readFile(join(directory, file.path))).digest("hex")
+}
+
+async function verifyBundleFileTopology(directory: string, path: string, fieldPath: string, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  const absolutePath = join(directory, path)
+  const fileStat = await lstat(absolutePath)
+  if (!fileStat.isFile()) {
+    violations.push({ code: "missing-file", path: fieldPath, file: path, message: `Manifest path is not a regular file: ${path}` })
+    return
+  }
+
+  if (typeof fileStat.nlink !== "number" || !Number.isFinite(fileStat.nlink)) {
+    violations.push({ code: "hardlink", path: fieldPath, file: path, message: `Unable to determine artifact file link count: ${path}`, details: { linkCountAvailable: false } })
+  } else if (fileStat.nlink > 1) {
+    violations.push({ code: "hardlink", path: fieldPath, file: path, message: `Artifact file must not be hard linked: ${path}`, details: { links: fileStat.nlink } })
+  }
+
+  try {
+    const [bundleRealpath, fileRealpath] = await Promise.all([realpath(directory), realpath(absolutePath)])
+    const realRelative = relative(bundleRealpath, fileRealpath)
+    if (realRelative === ".." || realRelative.startsWith(`..${sep}`) || isAbsolute(realRelative)) {
+      violations.push({ code: "unsafe-file", path: fieldPath, file: path, message: `Artifact file resolves outside the bundle directory: ${path}` })
+    }
+  } catch (error) {
+    violations.push({ code: "unsafe-file", path: fieldPath, file: path, message: `Unable to prove artifact file stays inside the bundle directory: ${errorMessage(error)}` })
+  }
 }
 
 export function calculateArtifactManifestSelfSha256(manifest: ArtifactManifest, manifestFileName = "manifest.json"): string {
@@ -1121,11 +1149,15 @@ function artifactPathViolation(path: string, fieldPath: string): ArtifactBundleV
   return undefined
 }
 
-async function verifyContentDigest(directory: string, manifest: ArtifactManifest, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+async function verifyContentDigest(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
   for (const [index, input] of manifest.contentDigest.inputs.entries()) {
     const pathViolation = artifactPathViolation(input, `manifest.contentDigest.inputs[${index}]`)
     if (pathViolation) {
       violations.push(pathViolation)
+      return
+    }
+    if (!manifestFiles.has(input)) {
+      violations.push({ code: "malformed-reference", path: `manifest.contentDigest.inputs[${index}]`, file: input, message: `contentDigest input is not listed in manifest.json: ${input}` })
       return
     }
   }
@@ -1375,7 +1407,7 @@ async function listBundleFiles(directory: string, prefix = ""): Promise<string[]
     const path = prefix ? `${prefix}/${entry.name}` : entry.name
     if (entry.isDirectory()) {
       files.push(...await listBundleFiles(directory, path))
-    } else if (entry.isFile()) {
+    } else {
       files.push(path)
     }
   }

--- a/packages/runtime-core/src/workspace-policy.ts
+++ b/packages/runtime-core/src/workspace-policy.ts
@@ -78,6 +78,10 @@ export async function checkWorkspacePolicy(options: WorkspacePolicyCheckOptions)
   }
 
   const paths = new Set<string>()
+  for (const path of await listWorkspacePaths(workspaceRoot, { skipRootGitMetadata: policy.gitBacked })) {
+    paths.add(path)
+  }
+
   if (policy.gitBacked) {
     const gitEntries = await readGitStatusEntries(workspaceRoot)
     for (const entry of gitEntries) {
@@ -96,10 +100,6 @@ export async function checkWorkspacePolicy(options: WorkspacePolicyCheckOptions)
     for (const path of await readUnmergedIndexPaths(workspaceRoot)) {
       paths.add(path)
       violations.push({ code: "unmerged-index", path, message: `Unmerged index entry: ${path}` })
-    }
-  } else {
-    for (const path of await listWorkspacePaths(workspaceRoot)) {
-      paths.add(path)
     }
   }
 
@@ -159,8 +159,12 @@ async function checkWorkspacePath(policy: NormalizedWorkspacePolicy, path: strin
     return violations
   }
 
-  if (stat.isFile() && stat.nlink > 1) {
-    violations.push({ code: "hardlink", path: normalizedPath, message: `Hardlink is not allowed: ${normalizedPath}`, details: { links: stat.nlink } })
+  if (stat.isFile()) {
+    if (typeof stat.nlink !== "number" || !Number.isFinite(stat.nlink)) {
+      violations.push({ code: "hardlink", path: normalizedPath, message: `Unable to determine link count for regular file: ${normalizedPath}`, details: { linkCountAvailable: false } })
+    } else if (stat.nlink > 1) {
+      violations.push({ code: "hardlink", path: normalizedPath, message: `Hardlink is not allowed: ${normalizedPath}`, details: { links: stat.nlink } })
+    }
   }
 
   if (!stat.isFile() && !stat.isDirectory()) {
@@ -183,7 +187,7 @@ async function checkWorkspacePath(policy: NormalizedWorkspacePolicy, path: strin
   return violations
 }
 
-async function listWorkspacePaths(workspaceRoot: string): Promise<string[]> {
+async function listWorkspacePaths(workspaceRoot: string, options: { skipRootGitMetadata?: boolean } = {}): Promise<string[]> {
   const paths: string[] = []
   const queue = [""]
   while (queue.length > 0) {
@@ -192,6 +196,9 @@ async function listWorkspacePaths(workspaceRoot: string): Promise<string[]> {
     const entries = await readdir(absolute, { withFileTypes: true })
     for (const entry of entries) {
       const relativePath = normalizePolicyPath(current ? `${current}/${entry.name}` : entry.name)
+      if (options.skipRootGitMetadata && (relativePath === ".git" || relativePath.startsWith(".git/"))) {
+        continue
+      }
       paths.push(relativePath)
       if (entry.isDirectory() && !entry.isSymbolicLink()) {
         queue.push(relativePath)

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
-import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { cp, link, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
@@ -54,6 +54,30 @@ try {
   delete (missingHashManifest.files[2] as Partial<(typeof missingHashManifest.files)[number]>).sha256
   await writeJson(join(missingFileHash, "manifest.json"), missingHashManifest)
   assertViolation(await verifyArtifactBundle(missingFileHash), "missing-file-hash")
+
+  const unlistedDigestInput = await copyBundle(validBundle, join(workspace, "unlisted-digest-input"))
+  const unlistedDigestManifest = manifestFixture(await calculateArtifactContentDigest(unlistedDigestInput, ["files/changed-files.json", "files/patch.diff"]))
+  unlistedDigestManifest.contentDigest.inputs = ["files/unlisted.txt"]
+  await writeFile(join(unlistedDigestInput, "files/unlisted.txt"), "not listed\n")
+  unlistedDigestManifest.contentDigest.value = await calculateArtifactContentDigest(unlistedDigestInput, unlistedDigestManifest.contentDigest.inputs)
+  await attachManifestFileHashes(unlistedDigestInput, unlistedDigestManifest)
+  await writeJson(join(unlistedDigestInput, "manifest.json"), unlistedDigestManifest)
+  assertViolation(await verifyArtifactBundle(unlistedDigestInput), "malformed-reference")
+
+  const duplicateManifestPath = await copyBundle(validBundle, join(workspace, "duplicate-manifest-path"))
+  const duplicateManifest = manifestFixture(await calculateArtifactContentDigest(duplicateManifestPath, ["files/changed-files.json", "files/patch.diff"]))
+  duplicateManifest.files.push(fileFixture("files/patch.diff", "patch-copy", "text/x-diff"))
+  await attachManifestFileHashes(duplicateManifestPath, duplicateManifest)
+  await writeJson(join(duplicateManifestPath, "manifest.json"), duplicateManifest)
+  assertViolation(await verifyArtifactBundle(duplicateManifestPath), "invalid-manifest-shape")
+
+  const hardlinkedFile = await copyBundle(validBundle, join(workspace, "hardlinked-file"))
+  await link(join(hardlinkedFile, "files/patch.diff"), join(hardlinkedFile, "files/patch-copy.diff"))
+  assertViolation(await verifyArtifactBundle(hardlinkedFile), "hardlink")
+
+  const orphanedSymlink = await copyBundle(validBundle, join(workspace, "orphaned-symlink"))
+  await symlink("patch.diff", join(orphanedSymlink, "files/patch-link.diff"))
+  assertViolation(await verifyArtifactBundle(orphanedSymlink), "orphaned-file")
 
   const malformedManifest = join(workspace, "malformed-manifest")
   await mkdir(malformedManifest, { recursive: true })

--- a/scripts/workspace-policy-smoke.ts
+++ b/scripts/workspace-policy-smoke.ts
@@ -60,6 +60,10 @@ assert.ok(invalidPolicy.violations.some((violation) => violation.code === "inval
 const gitRoot = await mkdtemp(join(tmpdir(), "wp-codebox-workspace-policy-git-"))
 await execFileAsync("git", ["init"], { cwd: gitRoot })
 await mkdir(join(gitRoot, "src"), { recursive: true })
+await writeFile(join(gitRoot, "src", "tracked-hardlink-source.txt"), "tracked-linked\n")
+await link(join(gitRoot, "src", "tracked-hardlink-source.txt"), join(gitRoot, "src", "tracked-hardlink-copy.txt"))
+await execFileAsync("git", ["add", "src/tracked-hardlink-source.txt", "src/tracked-hardlink-copy.txt"], { cwd: gitRoot })
+await execFileAsync("git", ["-c", "user.email=wp-codebox@example.test", "-c", "user.name=WP Codebox Smoke", "commit", "-m", "Add tracked hardlink fixture"], { cwd: gitRoot })
 await writeFile(join(gitRoot, ".gitignore"), "src/ignored.txt\n")
 await writeFile(join(gitRoot, "src", "ignored.txt"), "ignored\n")
 await execFileAsync("git", ["update-index", "--add", "--cacheinfo", "160000", "0123456789012345678901234567890123456789", "src/submodule"], { cwd: gitRoot })
@@ -81,6 +85,7 @@ const gitBacked = await checkWorkspacePolicy({
 })
 assert.equal(gitBacked.passed, false)
 assert.ok(gitBacked.violations.some((violation) => violation.code === "ignored-path" && violation.path === "src/ignored.txt"))
+assert.ok(gitBacked.violations.some((violation) => violation.code === "hardlink" && violation.path === "src/tracked-hardlink-copy.txt"))
 assert.ok(gitBacked.violations.some((violation) => violation.code === "gitlink" && violation.path === "src/submodule"))
 assert.ok(gitBacked.violations.some((violation) => violation.code === "unmerged-index" && violation.path === "src/conflict.txt"))
 


### PR DESCRIPTION
## Summary
- Tighten artifact bundle verification so unsafe file topology fails closed: duplicate manifest paths, unlisted digest inputs, symlink/special-file orphans, and hard-linked artifact files are reported as structured violations.
- Strengthen workspace policy evidence so git-backed workspaces also inspect regular filesystem entries while excluding only the repository's own root `.git` internals.
- Document the generic verifier/workspace-policy contract and add regression smoke coverage for hard links and verifier edge cases.

Closes #176.
Closes #196.

## Tests
- `npm run build`
- `npm run artifact-bundle-verifier-smoke`
- `npm run workspace-policy-smoke`
- `npm run recipe-runtime-evidence-smoke`
- `git diff --check`
- `npm run check` progressed through `recipe-runtime-evidence-smoke`; the command was manually interrupted at `preview-port-smoke` after the earlier regression was fixed.
- Remaining `npm run check` tail passed separately: `npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the artifact verifier and workspace policy hardening, added smoke coverage/docs, diagnosed and fixed the git-backed workspace policy regression, and ran local verification. Chris remains responsible for review and merge.