### PR TITLE
Add WP Codebox WP-CLI wrappers

### DIFF
--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -14,6 +14,7 @@ the parent control plane for review, replay, or apply-back.
 - `wp-codebox/discard-artifact`
 - `wp-codebox/apply-approved-artifact`
 - `wp-codebox/stage-artifact-apply`
+- WP-CLI wrappers under `wp codebox ...`
 
 The ability runs `wp-codebox agent-sandbox-run`, which boots a disposable
 WordPress Playground runtime, mounts the agent stack components, invokes the
@@ -138,6 +139,29 @@ Without Data Machine pending actions, `stage-artifact-apply` fails closed with
 `wp_codebox_datamachine_pending_actions_missing`. Direct reviewed apply remains
 available through `apply-approved-artifact` for hosts that provide their own
 approval surface.
+
+## WP-CLI
+
+The plugin registers focused WP-CLI wrappers for the same PHP service layer used
+by Abilities:
+
+- `wp codebox artifacts list --format=json`
+- `wp codebox artifacts get <artifact_id> --format=json`
+- `wp codebox artifacts stage-apply <artifact_id> --approved-files='/path.php' --format=json`
+- `wp codebox artifacts apply <artifact_id> --approved-files='/path.php' --format=json`
+- `wp codebox browser-session create --goal='Prepare a browser sandbox' --format=json`
+- `wp codebox run-agent-task --goal='Fix the plugin bug' --format=json`
+
+Complex task payloads can be passed with `--input-json='{"goal":"..."}'` or
+`--input-file=/path/to/input.json`; command-line flags override fields from the
+JSON payload. `--approved-files` accepts either a JSON array or a comma-separated
+list. CLI output is JSON-first for automation.
+
+WP-CLI commands run in trusted operator context. They do not call the Ability
+permission callbacks; shell/WP-CLI access is the permission boundary. The command
+methods delegate to the same PHP services as Abilities, so validation, artifact
+digest checks, pending-action staging, apply adapters, and runner errors behave
+the same way.
 
 See [External Apply Adapter Contract](../../docs/external-apply-adapter-contract.md)
 for the parent-control-plane contract. The documented smoke fixture proves that

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * WP-CLI adapter for WP Codebox public API operations.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_CLI_Command {
+
+	/** Register focused `wp codebox ...` commands. */
+	public static function register(): void {
+		$command = new self();
+
+		\WP_CLI::add_command( 'codebox artifacts list', array( $command, 'artifacts_list' ) );
+		\WP_CLI::add_command( 'codebox artifacts get', array( $command, 'artifacts_get' ) );
+		\WP_CLI::add_command( 'codebox artifacts stage-apply', array( $command, 'artifacts_stage_apply' ) );
+		\WP_CLI::add_command( 'codebox artifacts apply', array( $command, 'artifacts_apply' ) );
+		\WP_CLI::add_command( 'codebox browser-session create', array( $command, 'browser_session_create' ) );
+		\WP_CLI::add_command( 'codebox run-agent-task', array( $command, 'run_agent_task' ) );
+	}
+
+	/**
+	 * List artifact bundles.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function artifacts_list( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_Abilities::list_artifacts( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Read one artifact bundle.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function artifacts_get( array $args, array $assoc_args ): void {
+		$this->emit( WP_Codebox_Abilities::get_artifact( $this->artifact_input( $args, $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Stage a reviewed artifact apply through Data Machine pending actions.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function artifacts_stage_apply( array $args, array $assoc_args ): void {
+		$this->emit( WP_Codebox_Abilities::stage_artifact_apply( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Apply a reviewed artifact through the configured apply-back adapter.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function artifacts_apply( array $args, array $assoc_args ): void {
+		$this->emit( WP_Codebox_Abilities::apply_approved_artifact( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Create a browser-executed Playground session payload.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function browser_session_create( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_Abilities::create_browser_playground_session( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Run a bounded task inside an isolated WP Codebox agent sandbox.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function run_agent_task( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_Abilities::run_agent_task( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 * @return array<string,mixed>
+	 */
+	private function artifact_input( array $args, array $assoc_args ): array {
+		$input                = $this->input_from_args( $assoc_args );
+		$input['artifact_id'] = (string) ( $args[0] ?? $input['artifact_id'] ?? '' );
+
+		return $input;
+	}
+
+	/**
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 * @return array<string,mixed>
+	 */
+	private function apply_input( array $args, array $assoc_args ): array {
+		$input = $this->artifact_input( $args, $assoc_args );
+		if ( isset( $assoc_args['approved-files'] ) ) {
+			$input['approved_files'] = $this->string_list( $assoc_args['approved-files'] );
+		}
+
+		return $input;
+	}
+
+	/**
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 * @return array<string,mixed>
+	 */
+	private function input_from_args( array $assoc_args ): array {
+		$input = array();
+
+		if ( isset( $assoc_args['input-file'] ) ) {
+			$input = array_merge( $input, $this->json_file( (string) $assoc_args['input-file'] ) );
+		}
+
+		if ( isset( $assoc_args['input-json'] ) ) {
+			$input = array_merge( $input, $this->json_object( (string) $assoc_args['input-json'], 'input-json' ) );
+		}
+
+		foreach ( $assoc_args as $key => $value ) {
+			if ( in_array( $key, array( 'format', 'input-file', 'input-json' ), true ) ) {
+				continue;
+			}
+
+			$field           = str_replace( '-', '_', (string) $key );
+			$input[ $field ] = $this->normalize_value( $field, $value );
+		}
+
+		return $input;
+	}
+
+	private function normalize_value( string $field, mixed $value ): mixed {
+		if ( in_array( $field, array( 'target', 'policy', 'context', 'inherit', 'orchestrator', 'playground', 'browser_runner', 'blueprint', 'apply_target' ), true ) ) {
+			return $this->json_object( (string) $value, $field );
+		}
+
+		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'provider_plugin_paths', 'secret_env', 'browser_plugins', 'artifact_files', 'approved_files' ), true ) ) {
+			return $this->json_or_list( (string) $value, $field );
+		}
+
+		if ( in_array( $field, array( 'max_turns', 'preview_hold_seconds', 'preview_port', 'agent_id', 'user_id' ), true ) ) {
+			return (int) $value;
+		}
+
+		return $value;
+	}
+
+	/** @return array<string,mixed> */
+	private function json_file( string $path ): array {
+		$contents = is_readable( $path ) ? file_get_contents( $path ) : false;
+		if ( false === $contents ) {
+			\WP_CLI::error( 'Input file is not readable: ' . $path );
+		}
+
+		return $this->json_object( (string) $contents, 'input-file' );
+	}
+
+	/** @return array<string,mixed> */
+	private function json_object( string $json, string $field ): array {
+		$decoded = json_decode( $json, true );
+		if ( ! is_array( $decoded ) || array_is_list( $decoded ) ) {
+			\WP_CLI::error( $field . ' must be a JSON object.' );
+		}
+
+		return $decoded;
+	}
+
+	/** @return array<int,mixed> */
+	private function json_or_list( string $value, string $field ): array {
+		$trimmed = trim( $value );
+		if ( str_starts_with( $trimmed, '[' ) ) {
+			$decoded = json_decode( $trimmed, true );
+			if ( ! is_array( $decoded ) || ! array_is_list( $decoded ) ) {
+				\WP_CLI::error( $field . ' must be a JSON array.' );
+			}
+
+			return $decoded;
+		}
+
+		return $this->string_list( $value );
+	}
+
+	/** @return string[] */
+	private function string_list( mixed $value ): array {
+		$items = is_array( $value ) ? $value : explode( ',', (string) $value );
+
+		return array_values(
+			array_filter(
+				array_map( static fn( mixed $item ): string => trim( (string) $item ), $items ),
+				static fn( string $item ): bool => '' !== $item
+			)
+		);
+	}
+
+	/** @param array<string,mixed>|WP_Error $result Service result. */
+	private function emit( array|WP_Error $result, array $assoc_args ): void {
+		if ( is_wp_error( $result ) ) {
+			\WP_CLI::error( $result->get_error_message() );
+		}
+
+		$format = (string) ( $assoc_args['format'] ?? 'json' );
+		if ( 'json' !== $format ) {
+			\WP_CLI::warning( 'WP Codebox WP-CLI wrappers currently emit JSON; ignoring --format=' . $format . '.' );
+		}
+
+		\WP_CLI::line( $this->json_encode( $result ) );
+	}
+
+	/** @param array<string,mixed> $data Data to encode. */
+	private function json_encode( array $data ): string {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			$encoded = wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		} else {
+			$encoded = json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		}
+
+		return false === $encoded ? '{}' : (string) $encoded;
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -24,7 +24,15 @@ require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-data-machine-pending-actions.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once __DIR__ . '/src/class-wp-codebox-cli-command.php';
+}
+
 new WP_Codebox_Abilities();
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	WP_Codebox_CLI_Command::register();
+}
 
 add_action( 'plugins_loaded', static function (): void {
 	new WP_Codebox_Data_Machine_Pending_Actions();

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -24,6 +24,15 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		public static function add_command( string $name, callable $callable ): void { $GLOBALS['wp_codebox_cli_commands'][ $name ] = $callable; }
+		public static function line( string $message ): void { $GLOBALS['wp_codebox_cli_lines'][] = $message; }
+		public static function warning( string $message ): void { $GLOBALS['wp_codebox_cli_warnings'][] = $message; }
+		public static function error( string $message ): void { throw new RuntimeException( $message ); }
+	}
+}
+
 if ( ! function_exists( 'is_wp_error' ) ) {
 	function is_wp_error( $thing ): bool { return $thing instanceof WP_Error; }
 }
@@ -36,6 +45,9 @@ $GLOBALS['wp_codebox_filters']                      = array();
 $GLOBALS['wp_codebox_mock_abilities']              = array();
 $GLOBALS['wp_codebox_options']                      = array();
 $GLOBALS['wp_codebox_site_options']                 = array();
+$GLOBALS['wp_codebox_cli_commands']                 = array();
+$GLOBALS['wp_codebox_cli_lines']                    = array();
+$GLOBALS['wp_codebox_cli_warnings']                 = array();
 
 function wp_register_ability( string $name, array $definition ): void {
 	if ( isset( $definition['category'] ) && ! isset( $GLOBALS['wp_codebox_registered_ability_categories'][ $definition['category'] ] ) ) {
@@ -94,6 +106,7 @@ require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sand
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
+require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-cli-command.php';
 
 $root = sys_get_temp_dir() . '/wp-codebox-wordpress-plugin-' . getmypid();
 foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'plugin-root/agents-api', 'ai-provider-test', 'editable-plugin', 'artifacts', 'artifact-network-root' ) as $dir ) {
@@ -121,6 +134,7 @@ echo "WP Codebox WordPress plugin - smoke\n";
 
 new WP_Codebox_Data_Machine_Pending_Actions();
 new WP_Codebox_Abilities();
+WP_Codebox_CLI_Command::register();
 
 do_action( 'wp_abilities_api_init' );
 $assert( 'ability registration waits for category registration', ! isset( $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-agent-task'] ) );
@@ -131,6 +145,14 @@ do_action( 'wp_abilities_api_init' );
 $category = $GLOBALS['wp_codebox_registered_ability_categories']['wp-codebox'] ?? null;
 $assert( 'wp-codebox ability category registered', is_array( $category ) );
 $assert( 'category exposes label and description', isset( $category['label'] ) && isset( $category['description'] ) );
+
+$cli_commands = $GLOBALS['wp_codebox_cli_commands'];
+$assert( 'wp codebox artifacts list command registered', is_callable( $cli_commands['codebox artifacts list'] ?? null ) );
+$assert( 'wp codebox artifacts get command registered', is_callable( $cli_commands['codebox artifacts get'] ?? null ) );
+$assert( 'wp codebox artifacts stage-apply command registered', is_callable( $cli_commands['codebox artifacts stage-apply'] ?? null ) );
+$assert( 'wp codebox artifacts apply command registered', is_callable( $cli_commands['codebox artifacts apply'] ?? null ) );
+$assert( 'wp codebox browser-session create command registered', is_callable( $cli_commands['codebox browser-session create'] ?? null ) );
+$assert( 'wp codebox run-agent-task command registered', is_callable( $cli_commands['codebox run-agent-task'] ?? null ) );
 
 $ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-agent-task'] ?? null;
 $assert( 'run-agent-task ability registered', is_array( $ability ) );
@@ -983,6 +1005,10 @@ $artifacts = new WP_Codebox_Artifacts();
 $listed    = $artifacts->list( array( 'artifacts_path' => $artifact_root ) );
 $assert( 'artifact listing succeeds', ! is_wp_error( $listed ) && 1 === count( $listed['artifacts'] ?? array() ) );
 $assert( 'artifact listing detects test results', ! is_wp_error( $listed ) && true === ( $listed['artifacts'][0]['has_test_results'] ?? false ) );
+
+call_user_func( $GLOBALS['wp_codebox_cli_commands']['codebox artifacts list'], array(), array( 'artifacts-path' => $artifact_root, 'format' => 'json' ) );
+$cli_list_output = json_decode( end( $GLOBALS['wp_codebox_cli_lines'] ), true );
+$assert( 'wp codebox artifacts list emits JSON service result', is_array( $cli_list_output ) && 'wp-codebox/artifact-list/v1' === ( $cli_list_output['schema'] ?? '' ) && $artifact_id === ( $cli_list_output['artifacts'][0]['id'] ?? '' ) );
 
 $read_artifact = $artifacts->get(
 	array(


### PR DESCRIPTION
## Summary
- Add focused `wp codebox ...` WP-CLI commands for artifact, browser-session, and agent-task operations.
- Delegate each command to the same PHP service layer used by the Ability callbacks.
- Document CLI permission behavior and add smoke coverage for command registration plus JSON artifact listing output.

Closes #239.

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-cli-command.php && php -l packages/wordpress-plugin/wp-codebox.php && php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`
- `npm run package-distribution-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the WP-CLI adapter, smoke coverage, docs, and verification commands; Chris remains responsible for review and testing.