### PR TITLE
Add runtime snapshot bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,10 +330,21 @@ Artifact bundles also include `files/runtime-reference-manifest.json` using
 schema `wp-codebox/runtime-reference-manifest/v1`. This manifest is a stable,
 hashable index of runtime-related refs: the artifact-bundle id/digest,
 bundle-relative artifact file refs with SHA-256 values, optional trace/events
-refs, and snapshot refs. Its id is `runtime-reference-manifest-sha256-<digest>`,
-where the digest is computed from the declared refs rather than presentation
-fields such as `createdAt`. `verifyArtifactBundle()` validates the manifest
-shape, referenced file hashes, artifact-bundle digest, and id/digest pairing.
+refs, a snapshot-bundle ref, and snapshot refs. Its id is
+`runtime-reference-manifest-sha256-<digest>`, where the digest is computed from
+the declared refs rather than presentation fields such as `createdAt`.
+`verifyArtifactBundle()` validates the manifest shape, referenced file hashes,
+artifact-bundle digest, and id/digest pairing.
+
+Artifact bundles also include `files/runtime-snapshot-bundle.json` using schema
+`wp-codebox/runtime-snapshot-bundle/v1`. This is the bounded replay foundation
+for WordPress runtime state. The v1 bundle is explicitly
+`partial-artifact-backed`: it points to replay inputs WP Codebox already knows how
+to verify, including the partial Playground blueprint, mounted-file manifests,
+patch/changed-file artifacts, runtime trace/events when present, and active
+theme/plugin metadata captured from WordPress. It intentionally marks unsupported
+state as limitations: no portable database dump, no VM memory checkpoint, and no
+Media Library/uploads export unless uploads were already part of captured mounts.
 
 Products such as eval harnesses can project this generic episode trace into their
 own action, observation, reward, and report schemas outside WP Codebox.
@@ -389,6 +400,11 @@ explicit `replay.status`. For current Playground snapshots that status is
 `metadata-only` with limitations explaining that replay must come from trace
 actions and artifact files. This keeps full WordPress replay as an incremental
 backend capability while giving consumers a concrete contract today.
+
+For a replay attempt, start from `files/runtime-snapshot-bundle.json` instead of
+assuming a snapshot is a restore point. The bundle's `replay.instructions` define
+the supported sequence, and each component has `captured`, `partial`, or
+`not-captured` status with file refs or limitations.
 
 ## CLI Commands
 
@@ -671,6 +687,7 @@ Current bundles include:
 - `files/test-results.json`: normalized test-results artifact with schema, summary counts, suites, and raw log references. When WP Codebox has not run test-aware commands, the artifact is present with `status: "unknown"`, zero counts, an empty `suites` array, and pointers to raw command logs instead of inferred pass/fail data.
 - `files/review.json`: frontend-oriented review payload with summary, progress labels, changed file labels, evidence links, and approval actions.
 - `files/runtime-reference-manifest.json`: stable runtime ref index with artifact-bundle, file, trace/events, and snapshot refs plus SHA-256 digests.
+- `files/runtime-snapshot-bundle.json`: bounded replay contract for partial WordPress runtime state, with supported refs plus explicit database/uploads limitation markers.
 - `files/diffs.json`: diff index for readwrite mounts that declare a baseline.
 - `files/diffs/<mount>.patch`: unified text diff from a seeded baseline to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -11,6 +11,7 @@ export const RUNTIME_EPISODE_ACTION_SCHEMA = "wp-codebox/runtime-episode-action/
 export const RUNTIME_EPISODE_OBSERVATION_SCHEMA = "wp-codebox/runtime-episode-observation/v1" as const
 export const RUNTIME_EPISODE_SNAPSHOT_SCHEMA = "wp-codebox/runtime-episode-snapshot/v1" as const
 export const RUNTIME_REFERENCE_MANIFEST_SCHEMA = "wp-codebox/runtime-reference-manifest/v1" as const
+export const RUNTIME_SNAPSHOT_BUNDLE_SCHEMA = "wp-codebox/runtime-snapshot-bundle/v1" as const
 
 export const RUNTIME_EPISODE_TRACE_JSON_SCHEMA = {
   $id: RUNTIME_EPISODE_TRACE_SCHEMA,
@@ -628,6 +629,54 @@ export interface RuntimeReferenceManifestSnapshotRef {
   artifactRefs: RuntimeEpisodeTraceRef[]
 }
 
+export type RuntimeSnapshotBundleReplayStatus = "partial-artifact-backed" | "not-replayable" | (string & {})
+
+export interface RuntimeSnapshotBundleComponent {
+  status: "captured" | "partial" | "not-captured" | (string & {})
+  refs?: RuntimeReferenceManifestFileRef[]
+  data?: unknown
+  limitations?: string[]
+}
+
+export interface RuntimeSnapshotBundleReplay {
+  status: RuntimeSnapshotBundleReplayStatus
+  instructions: string[]
+  limitations: string[]
+}
+
+export interface RuntimeSnapshotBundle {
+  schema: typeof RUNTIME_SNAPSHOT_BUNDLE_SCHEMA
+  version: 1
+  id: string
+  createdAt: string
+  digest: RuntimeEpisodeContentDigest
+  runtime: RuntimeInfo
+  replay: RuntimeSnapshotBundleReplay
+  components: {
+    database: RuntimeSnapshotBundleComponent
+    playgroundState: RuntimeSnapshotBundleComponent
+    uploadsMedia: RuntimeSnapshotBundleComponent
+    activeThemePlugins: RuntimeSnapshotBundleComponent
+    mountedFiles: RuntimeSnapshotBundleComponent
+    blueprint: RuntimeSnapshotBundleComponent
+  }
+}
+
+export interface BuildRuntimeSnapshotBundleInput {
+  createdAt: string
+  runtime: RuntimeInfo
+  wordpressState?: unknown
+  refs: {
+    blueprintAfter?: RuntimeReferenceManifestFileRef
+    blueprintAfterNotes?: RuntimeReferenceManifestFileRef
+    mountedFiles?: RuntimeReferenceManifestFileRef
+    changedFiles?: RuntimeReferenceManifestFileRef
+    patch?: RuntimeReferenceManifestFileRef
+    trace?: RuntimeReferenceManifestFileRef
+    events?: RuntimeReferenceManifestFileRef
+  }
+}
+
 export interface RuntimeReferenceManifest {
   schema: typeof RUNTIME_REFERENCE_MANIFEST_SCHEMA
   version: 1
@@ -639,6 +688,7 @@ export interface RuntimeReferenceManifest {
   files: RuntimeReferenceManifestFileRef[]
   trace?: RuntimeReferenceManifestFileRef
   events?: RuntimeReferenceManifestFileRef
+  snapshotBundle?: RuntimeReferenceManifestFileRef
   snapshots: RuntimeReferenceManifestSnapshotRef[]
 }
 
@@ -649,6 +699,7 @@ export interface BuildRuntimeReferenceManifestInput {
   files: RuntimeReferenceManifestFileRef[]
   trace?: RuntimeReferenceManifestFileRef
   events?: RuntimeReferenceManifestFileRef
+  snapshotBundle?: RuntimeReferenceManifestFileRef
   snapshots?: Snapshot[]
 }
 
@@ -729,6 +780,7 @@ export interface ArtifactReview {
     runtimeReferenceManifest?: string
     agentResult?: string
     transcript?: string
+    runtimeSnapshotBundle?: string
   }
   browser?: ArtifactReviewBrowserSummary
   redaction?: ArtifactRedactionSummary
@@ -843,6 +895,7 @@ export interface ArtifactBundle {
   artifactVerificationPath?: string
   workspacePolicyPath?: string
   runtimeReferenceManifestPath?: string
+  runtimeSnapshotBundlePath?: string
   preview?: ArtifactPreview
   contentDigest: string
   createdAt: string
@@ -955,6 +1008,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   await verifyMetadataReferences(bundleDirectory, manifestFiles, violations)
   await verifyReviewEvidence(bundleDirectory, manifest, manifestFiles, violations)
   await verifyRuntimeEpisodeTraceArtifacts(bundleDirectory, manifest, violations)
+  await verifyRuntimeSnapshotBundleArtifacts(bundleDirectory, manifest, manifestFiles, violations)
   await verifyRuntimeReferenceManifestArtifacts(bundleDirectory, manifest, manifestFiles, violations)
 
   return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
@@ -1096,8 +1150,39 @@ function isRuntimeReferenceManifestShape(value: unknown): value is RuntimeRefere
     && value.files.every(isRuntimeReferenceManifestFileRefShape)
     && (value.trace === undefined || isRuntimeReferenceManifestFileRefShape(value.trace))
     && (value.events === undefined || isRuntimeReferenceManifestFileRefShape(value.events))
+    && (value.snapshotBundle === undefined || isRuntimeReferenceManifestFileRefShape(value.snapshotBundle))
     && Array.isArray(value.snapshots)
     && value.snapshots.every(isRuntimeReferenceManifestSnapshotRefShape)
+}
+
+function isRuntimeSnapshotBundleShape(value: unknown): value is RuntimeSnapshotBundle {
+  return isRecord(value)
+    && value.schema === RUNTIME_SNAPSHOT_BUNDLE_SCHEMA
+    && value.version === 1
+    && typeof value.id === "string"
+    && typeof value.createdAt === "string"
+    && validDigest(value.digest)
+    && isRecord(value.runtime)
+    && isRecord(value.replay)
+    && typeof value.replay.status === "string"
+    && Array.isArray(value.replay.instructions)
+    && value.replay.instructions.every((instruction) => typeof instruction === "string")
+    && Array.isArray(value.replay.limitations)
+    && value.replay.limitations.every((limitation) => typeof limitation === "string")
+    && isRecord(value.components)
+    && isRuntimeSnapshotBundleComponentShape(value.components.database)
+    && isRuntimeSnapshotBundleComponentShape(value.components.playgroundState)
+    && isRuntimeSnapshotBundleComponentShape(value.components.uploadsMedia)
+    && isRuntimeSnapshotBundleComponentShape(value.components.activeThemePlugins)
+    && isRuntimeSnapshotBundleComponentShape(value.components.mountedFiles)
+    && isRuntimeSnapshotBundleComponentShape(value.components.blueprint)
+}
+
+function isRuntimeSnapshotBundleComponentShape(value: unknown): value is RuntimeSnapshotBundleComponent {
+  return isRecord(value)
+    && typeof value.status === "string"
+    && (value.refs === undefined || (Array.isArray(value.refs) && value.refs.every(isRuntimeReferenceManifestFileRefShape)))
+    && (value.limitations === undefined || (Array.isArray(value.limitations) && value.limitations.every((limitation) => typeof limitation === "string")))
 }
 
 function isRuntimeReferenceManifestArtifactBundleRefShape(value: unknown): value is RuntimeReferenceManifestArtifactBundleRef {
@@ -1258,6 +1343,10 @@ async function verifyReviewEvidence(directory: string, manifest: ArtifactManifes
   if (typeof evidence.runtimeReferenceManifest === "string") {
     validateArtifactReference(evidence.runtimeReferenceManifest, "files/review.json:evidence.runtimeReferenceManifest", manifestFiles, violations)
   }
+
+  if (typeof evidence.runtimeSnapshotBundle === "string") {
+    validateArtifactReference(evidence.runtimeSnapshotBundle, "files/review.json:evidence.runtimeSnapshotBundle", manifestFiles, violations)
+  }
 }
 
 async function verifyRuntimeEpisodeTraceArtifacts(directory: string, manifest: ArtifactManifest, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
@@ -1339,6 +1428,54 @@ async function verifyRuntimeReferenceManifestArtifacts(directory: string, manife
     if (referenceManifest.events) {
       validateArtifactReference(referenceManifest.events.path, `${file.path}:events.path`, manifestFiles, violations)
       await verifyReferencedFileDigest(directory, referenceManifest.events, `${file.path}:events.sha256`, violations)
+    }
+
+    if (referenceManifest.snapshotBundle) {
+      validateArtifactReference(referenceManifest.snapshotBundle.path, `${file.path}:snapshotBundle.path`, manifestFiles, violations)
+      await verifyReferencedFileDigest(directory, referenceManifest.snapshotBundle, `${file.path}:snapshotBundle.sha256`, violations)
+    }
+  }
+}
+
+async function verifyRuntimeSnapshotBundleArtifacts(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  for (const file of manifest.files) {
+    if (file.kind !== "runtime-snapshot-bundle") {
+      continue
+    }
+
+    let snapshotBundle: unknown
+    try {
+      snapshotBundle = JSON.parse(await readFile(join(directory, file.path), "utf8"))
+    } catch (error) {
+      violations.push({
+        code: "malformed-reference",
+        path: file.path,
+        file: file.path,
+        message: `Runtime snapshot bundle is not valid JSON: ${errorMessage(error)}`,
+      })
+      continue
+    }
+
+    if (!isRuntimeSnapshotBundleShape(snapshotBundle)) {
+      violations.push({ code: "malformed-reference", path: file.path, file: file.path, message: "Runtime snapshot bundle does not match wp-codebox/runtime-snapshot-bundle/v1." })
+      continue
+    }
+
+    const expectedDigest = runtimeSnapshotBundleDigest(snapshotBundle)
+    if (snapshotBundle.digest.value !== expectedDigest.value) {
+      violations.push({ code: "digest-mismatch", path: `${file.path}:digest`, file: file.path, message: `Runtime snapshot bundle digest does not match declared replay refs: expected ${expectedDigest.value}, got ${snapshotBundle.digest.value}` })
+    }
+
+    const expectedId = `runtime-snapshot-bundle-sha256-${snapshotBundle.digest.value}`
+    if (snapshotBundle.id !== expectedId) {
+      violations.push({ code: "bundle-id-mismatch", path: `${file.path}:id`, file: file.path, message: `Runtime snapshot bundle id must match its digest: expected ${expectedId}, got ${snapshotBundle.id}` })
+    }
+
+    for (const [componentName, component] of Object.entries(snapshotBundle.components)) {
+      for (const [index, referencedFile] of (component.refs ?? []).entries()) {
+        validateArtifactReference(referencedFile.path, `${file.path}:components.${componentName}.refs[${index}].path`, manifestFiles, violations)
+        await verifyReferencedFileDigest(directory, referencedFile, `${file.path}:components.${componentName}.refs[${index}].sha256`, violations)
+      }
     }
   }
 }
@@ -1644,6 +1781,7 @@ export function buildRuntimeReferenceManifest(input: BuildRuntimeReferenceManife
     files: input.files.map(runtimeReferenceManifestFileRef).sort((left, right) => left.path.localeCompare(right.path)),
     ...(input.trace ? { trace: runtimeReferenceManifestFileRef(input.trace) } : {}),
     ...(input.events ? { events: runtimeReferenceManifestFileRef(input.events) } : {}),
+    ...(input.snapshotBundle ? { snapshotBundle: runtimeReferenceManifestFileRef(input.snapshotBundle) } : {}),
     snapshots: (input.snapshots ?? []).map(runtimeReferenceManifestSnapshotRef),
   }
   const digest = runtimeReferenceManifestDigest(manifest)
@@ -1674,7 +1812,108 @@ function runtimeReferenceManifestDigestPayload(manifest: RuntimeReferenceManifes
     files: manifest.files,
     ...(manifest.trace ? { trace: manifest.trace } : {}),
     ...(manifest.events ? { events: manifest.events } : {}),
+    ...(manifest.snapshotBundle ? { snapshotBundle: manifest.snapshotBundle } : {}),
     snapshots: manifest.snapshots,
+  }
+}
+
+export function buildRuntimeSnapshotBundle(input: BuildRuntimeSnapshotBundleInput): RuntimeSnapshotBundle {
+  const refs = input.refs
+  const mountedFileRefs = [refs.mountedFiles, refs.changedFiles, refs.patch].filter(isRuntimeReferenceManifestFileRef)
+  const blueprintRefs = [refs.blueprintAfter, refs.blueprintAfterNotes].filter(isRuntimeReferenceManifestFileRef)
+  const playgroundRefs = [refs.trace, refs.events].filter(isRuntimeReferenceManifestFileRef)
+  const bundle = {
+    schema: RUNTIME_SNAPSHOT_BUNDLE_SCHEMA,
+    version: 1 as const,
+    id: "runtime-snapshot-bundle-pending",
+    createdAt: input.createdAt,
+    digest: { algorithm: "sha256" as const, value: "0".repeat(64) },
+    runtime: input.runtime,
+    replay: {
+      status: "partial-artifact-backed" as const,
+      instructions: [
+        "Create a compatible WordPress Playground runtime with the declared runtime environment and policy.",
+        "Apply the partial blueprint.after.json replay file, then restore captured replayable mounted files to their declared targets.",
+        "Replay runtime episode actions from files/runtime-episode-trace.json when action-level reproduction is required.",
+      ],
+      limitations: [
+        "The Playground database is not exported in this v1 bundle.",
+        "Uploads/media files are only represented when they appear in captured readwrite mounts; no Media Library export is captured.",
+        "Binary mounted files are captured for audit but are not embedded in the partial Playground blueprint.",
+      ],
+    },
+    components: {
+      database: {
+        status: "not-captured" as const,
+        limitations: ["No portable database dump is captured by the current Playground backend."],
+      },
+      playgroundState: {
+        status: playgroundRefs.length > 0 ? "partial" as const : "not-captured" as const,
+        ...(playgroundRefs.length > 0 ? { refs: playgroundRefs } : {}),
+        limitations: ["Replay state comes from trace/actions and artifact refs, not a VM memory checkpoint."],
+      },
+      uploadsMedia: {
+        status: "not-captured" as const,
+        limitations: ["Media Library and uploads directory export are not captured unless the caller mounted uploads as a readwrite input."],
+      },
+      activeThemePlugins: {
+        status: input.wordpressState ? "captured" as const : "not-captured" as const,
+        ...(input.wordpressState ? { data: activeThemePluginsSnapshot(input.wordpressState) } : {}),
+      },
+      mountedFiles: {
+        status: mountedFileRefs.length > 0 ? "partial" as const : "not-captured" as const,
+        ...(mountedFileRefs.length > 0 ? { refs: mountedFileRefs } : {}),
+        limitations: ["Captured mounted files are bounded by file-count, file-size, skipped-directory, and text replayability limits."],
+      },
+      blueprint: {
+        status: blueprintRefs.length > 0 ? "partial" as const : "not-captured" as const,
+        ...(blueprintRefs.length > 0 ? { refs: blueprintRefs } : {}),
+        limitations: ["blueprint.after.json restores captured replayable text files only; it is not a complete site image."],
+      },
+    },
+  }
+  const digest = runtimeSnapshotBundleDigest(bundle)
+
+  return {
+    ...bundle,
+    id: `runtime-snapshot-bundle-sha256-${digest.value}`,
+    digest,
+  }
+}
+
+export function runtimeSnapshotBundleDigest(bundle: RuntimeSnapshotBundle): RuntimeEpisodeContentDigest {
+  return {
+    algorithm: "sha256",
+    value: createHash("sha256")
+      .update("wp-codebox/runtime-snapshot-bundle/v1\n")
+      .update(stableJson(runtimeSnapshotBundleDigestPayload(bundle)))
+      .digest("hex"),
+  }
+}
+
+function runtimeSnapshotBundleDigestPayload(bundle: RuntimeSnapshotBundle): Record<string, unknown> {
+  return {
+    schema: bundle.schema,
+    version: bundle.version,
+    runtime: bundle.runtime,
+    replay: bundle.replay,
+    components: bundle.components,
+  }
+}
+
+function isRuntimeReferenceManifestFileRef(value: RuntimeReferenceManifestFileRef | undefined): value is RuntimeReferenceManifestFileRef {
+  return value !== undefined
+}
+
+function activeThemePluginsSnapshot(wordpressState: unknown): unknown {
+  if (!isRecord(wordpressState)) {
+    return wordpressState
+  }
+
+  return {
+    ...(typeof wordpressState.wordpressVersion === "string" ? { wordpressVersion: wordpressState.wordpressVersion } : {}),
+    ...(typeof wordpressState.activeTheme === "string" ? { activeTheme: wordpressState.activeTheme } : {}),
+    ...(Array.isArray(wordpressState.activePlugins) ? { activePlugins: wordpressState.activePlugins.filter((plugin) => typeof plugin === "string") } : {}),
   }
 }
 
@@ -2311,7 +2550,31 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     await this.updateArtifactMetadataForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
     await this.updateArtifactReviewForRuntimeEpisodeTrace(traceRelativePath)
     await this.updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
+    await this.updateRuntimeSnapshotBundleForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
     await this.updateRuntimeReferenceManifestForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
+  }
+
+  private async updateRuntimeSnapshotBundleForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
+    if (!this.artifacts?.runtimeSnapshotBundlePath) {
+      return
+    }
+
+    const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
+    const fileRefs = manifest.files.map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
+    const snapshotBundle = JSON.parse(await readFile(this.artifacts.runtimeSnapshotBundlePath, "utf8")) as RuntimeSnapshotBundle
+    const traceRef = fileRefs.find((file) => file.path === traceRelativePath)
+    const eventsRef = fileRefs.find((file) => file.path === eventsRelativePath)
+
+    snapshotBundle.components.playgroundState = {
+      ...snapshotBundle.components.playgroundState,
+      status: traceRef || eventsRef ? "partial" : snapshotBundle.components.playgroundState.status,
+      refs: [traceRef, eventsRef].filter(isRuntimeReferenceManifestFileRef),
+    }
+    snapshotBundle.digest = runtimeSnapshotBundleDigest(snapshotBundle)
+    snapshotBundle.id = `runtime-snapshot-bundle-sha256-${snapshotBundle.digest.value}`
+    await writeFile(this.artifacts.runtimeSnapshotBundlePath, `${JSON.stringify(snapshotBundle, null, 2)}\n`)
+    await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
+    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
 
   private async updateRuntimeReferenceManifestForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
@@ -2325,6 +2588,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
     const traceRef = fileRefs.find((file) => file.path === traceRelativePath)
     const eventsRef = fileRefs.find((file) => file.path === eventsRelativePath)
+    const snapshotBundleRef = fileRefs.find((file) => file.path === "files/runtime-snapshot-bundle.json")
     const referenceManifest = buildRuntimeReferenceManifest({
       createdAt: this.artifacts.createdAt,
       runtime: manifest.runtime,
@@ -2336,6 +2600,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       files: fileRefs,
       ...(traceRef ? { trace: traceRef } : {}),
       ...(eventsRef ? { events: eventsRef } : {}),
+      ...(snapshotBundleRef ? { snapshotBundle: snapshotBundleRef } : {}),
       snapshots: this.snapshots,
     })
     await writeFile(this.artifacts.runtimeReferenceManifestPath, `${JSON.stringify(referenceManifest, null, 2)}\n`)

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -283,6 +283,7 @@ export function buildArtifactReview({
       changedFiles: "files/changed-files.json",
       testResults: "files/test-results.json",
       runtimeReferenceManifest: "files/runtime-reference-manifest.json",
+      runtimeSnapshotBundle: "files/runtime-snapshot-bundle.json",
     },
     ...(browser ? { browser } : {}),
     riskFlags: [],

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -3,7 +3,7 @@ import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "n
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
 import { basename, dirname, join, relative, resolve } from "node:path"
-import { RUNTIME_EPISODE_OBSERVATION_SCHEMA, assertRuntimeCommandAllowed, buildRuntimeReferenceManifest, calculateArtifactManifestFileSha256, runtimeEpisodeDigest } from "@chubes4/wp-codebox-core"
+import { RUNTIME_EPISODE_OBSERVATION_SCHEMA, assertRuntimeCommandAllowed, buildRuntimeReferenceManifest, buildRuntimeSnapshotBundle, calculateArtifactManifestFileSha256, runtimeEpisodeDigest } from "@chubes4/wp-codebox-core"
 import {
   MAX_CAPTURED_MOUNT_FILE_BYTES,
   MAX_CAPTURED_MOUNT_FILES,
@@ -55,6 +55,23 @@ function now(): string {
 
 function id(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+async function refreshArtifactManifestFileHashes(directory: string, manifest: ArtifactManifest): Promise<void> {
+  manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "manifest.json" ? file : ({
+    ...file,
+    sha256: {
+      algorithm: "sha256" as const,
+      value: await calculateArtifactManifestFileSha256(directory, manifest, file),
+    },
+  })))
+  manifest.files = await Promise.all(manifest.files.map(async (file) => file.path !== "manifest.json" ? file : ({
+    ...file,
+    sha256: {
+      algorithm: "sha256" as const,
+      value: await calculateArtifactManifestFileSha256(directory, manifest, file),
+    },
+  })))
 }
 
 interface PlaygroundRunResponse {
@@ -441,6 +458,7 @@ class PlaygroundRuntime implements Runtime {
     const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
     const runtimeReferenceManifestPath = join(filesDirectory, "runtime-reference-manifest.json")
+    const runtimeSnapshotBundlePath = join(filesDirectory, "runtime-snapshot-bundle.json")
     const redactor = new ArtifactRedactor(this.spec.secretEnv)
     await this.redactBrowserArtifacts(redactor)
     await this.redactPluginCheckArtifacts(redactor)
@@ -449,6 +467,7 @@ class PlaygroundRuntime implements Runtime {
     const browser = this.browserReviewSummary()
 
     const runtime = await this.info()
+    const wordpressState = await this.snapshotWordPressState()
     const capturedMounts = await this.captureMountedFiles(filesDirectory, redactor)
     const { mountDiffs, changedFiles, patch } = await this.captureMountDiffs(filesDirectory, redactor)
     const changedFilesJson = redactor.redact("files/changed-files.json", `${JSON.stringify(changedFiles, null, 2)}\n`)
@@ -501,6 +520,7 @@ class PlaygroundRuntime implements Runtime {
       testResults: relative(this.artifactRoot, testResultsPath),
       review: relative(this.artifactRoot, reviewPath),
       runtimeReferenceManifest: relative(this.artifactRoot, runtimeReferenceManifestPath),
+      runtimeSnapshotBundle: relative(this.artifactRoot, runtimeSnapshotBundlePath),
       mountDiffs: relative(this.artifactRoot, diffsPath),
       ...(browser ? { browser: "files/browser/summary.json" } : {}),
       ...(this.pluginChecks.length > 0 ? { pluginChecks: this.pluginChecks.map((check) => check.files.normalized) } : {}),
@@ -537,6 +557,7 @@ class PlaygroundRuntime implements Runtime {
       fileEntry(testResultsPath, "test-results", "application/json"),
       fileEntry(reviewPath, "review", "application/json"),
       fileEntry(runtimeReferenceManifestPath, "runtime-reference-manifest", "application/json"),
+      fileEntry(runtimeSnapshotBundlePath, "runtime-snapshot-bundle", "application/json"),
       ...this.browserManifestFiles(),
       ...this.observationManifestFiles(),
       ...this.pluginCheckManifestFiles(),
@@ -569,6 +590,7 @@ class PlaygroundRuntime implements Runtime {
     }
     await writeRedactedArtifact(redactor, reviewPath, this.artifactRoot, `${JSON.stringify(review, null, 2)}\n`)
     await writeFile(runtimeReferenceManifestPath, "{}\n")
+    await writeFile(runtimeSnapshotBundlePath, "{}\n")
     metadata.redaction = redactor.summary()
     await writeRedactedArtifact(redactor, metadataPath, this.artifactRoot, `${JSON.stringify(metadata, null, 2)}\n`)
 
@@ -600,6 +622,25 @@ class PlaygroundRuntime implements Runtime {
         value: await calculateArtifactManifestFileSha256(this.artifactRoot, manifest, file),
       },
     })))
+    const snapshotBundleFileRefs = manifest.files.map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
+    const findSnapshotBundleRef = (path: string) => snapshotBundleFileRefs.find((file) => file.path === path)
+    const runtimeSnapshotBundle = buildRuntimeSnapshotBundle({
+      createdAt,
+      runtime,
+      wordpressState,
+      refs: {
+        blueprintAfter: findSnapshotBundleRef("blueprint.after.json"),
+        blueprintAfterNotes: findSnapshotBundleRef("blueprint.after-notes.json"),
+        mountedFiles: findSnapshotBundleRef("files/mounted-files.json"),
+        changedFiles: findSnapshotBundleRef("files/changed-files.json"),
+        patch: findSnapshotBundleRef("files/patch.diff"),
+      },
+    })
+    await writeFile(runtimeSnapshotBundlePath, `${JSON.stringify(runtimeSnapshotBundle, null, 2)}\n`)
+    await refreshArtifactManifestFileHashes(this.artifactRoot, manifest)
+    const runtimeReferenceFileRefs = manifest.files
+      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json"].includes(file.path))
+      .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
     const runtimeReferenceManifest = buildRuntimeReferenceManifest({
       createdAt,
       runtime,
@@ -608,9 +649,8 @@ class PlaygroundRuntime implements Runtime {
         id: bundleId,
         digest: { algorithm: "sha256", value: contentDigest },
       },
-      files: manifest.files
-        .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json"].includes(file.path))
-        .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 })),
+      files: runtimeReferenceFileRefs,
+      snapshotBundle: runtimeReferenceFileRefs.find((file) => file.path === "files/runtime-snapshot-bundle.json"),
     })
     await writeFile(runtimeReferenceManifestPath, `${JSON.stringify(runtimeReferenceManifest, null, 2)}\n`)
     manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "files/runtime-reference-manifest.json" ? ({
@@ -649,6 +689,7 @@ class PlaygroundRuntime implements Runtime {
       testResultsPath,
       reviewPath,
       runtimeReferenceManifestPath,
+      runtimeSnapshotBundlePath,
       ...(preview ? { preview } : {}),
       contentDigest,
       createdAt,
@@ -1553,6 +1594,15 @@ echo wp_json_encode( array(
 `, []) })
     assertPlaygroundResponseOk("observe.wordpress-state", response)
     return JSON.parse(response.text || "{}")
+  }
+
+  private async snapshotWordPressState(): Promise<unknown | undefined> {
+    try {
+      return await this.observeWordPressState()
+    } catch (error) {
+      this.recordEvent("runtime.snapshot.wordpress-state-unavailable", { error: errorMessage(error) })
+      return undefined
+    }
   }
 
   private async observeHttpResponse(spec: ObservationSpec, observationId: string): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -6,7 +6,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, createRuntime, runtimeReferenceManifestDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
+import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, RUNTIME_SNAPSHOT_BUNDLE_SCHEMA, createRuntime, runtimeReferenceManifestDigest, runtimeSnapshotBundleDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 const execFileAsync = promisify(execFile)
@@ -62,6 +62,7 @@ try {
   const testResults = JSON.parse(await readFile(artifacts.testResultsPath, "utf8"))
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
   const runtimeReferenceManifest = JSON.parse(await readFile(artifacts.runtimeReferenceManifestPath, "utf8"))
+  const runtimeSnapshotBundle = JSON.parse(await readFile(artifacts.runtimeSnapshotBundlePath, "utf8"))
   const contentDigest = createHash("sha256")
     .update("wp-codebox/artifact-content/v1\n")
     .update("files/changed-files.json\n")
@@ -85,6 +86,7 @@ try {
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/test-results.json" && file.kind === "test-results"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/review.json" && file.kind === "review"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-snapshot-bundle.json" && file.kind === "runtime-snapshot-bundle"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-evidence/run-attestation.json" && file.kind === "run-attestation"))
   const runtimeEvidence = metadata.artifacts.runtimeEvidence
   assert.match(runtimeEvidence["run-attestation"].sha256, /^[a-f0-9]{64}$/)
@@ -94,6 +96,7 @@ try {
     testResults: "files/test-results.json",
     review: "files/review.json",
     runtimeReferenceManifest: "files/runtime-reference-manifest.json",
+    runtimeSnapshotBundle: "files/runtime-snapshot-bundle.json",
     mountDiffs: "files/diffs.json",
     runtimeEvidence,
   })
@@ -141,13 +144,22 @@ try {
   assert.equal(review.evidence.changedFiles, "files/changed-files.json")
   assert.equal(review.evidence.testResults, "files/test-results.json")
   assert.equal(review.evidence.runtimeReferenceManifest, "files/runtime-reference-manifest.json")
+  assert.equal(review.evidence.runtimeSnapshotBundle, "files/runtime-snapshot-bundle.json")
   assert.equal(runtimeReferenceManifest.schema, RUNTIME_REFERENCE_MANIFEST_SCHEMA)
   assert.equal(runtimeReferenceManifest.artifactBundle.id, artifacts.id)
   assert.equal(runtimeReferenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
   assert.equal(runtimeReferenceManifest.digest.value, runtimeReferenceManifestDigest(runtimeReferenceManifest).value)
   assert.equal(runtimeReferenceManifest.id, `runtime-reference-manifest-sha256-${runtimeReferenceManifest.digest.value}`)
   assert.equal(runtimeReferenceManifest.snapshots.length, 0)
+  assert.equal(runtimeReferenceManifest.snapshotBundle.path, "files/runtime-snapshot-bundle.json")
   assert.ok(runtimeReferenceManifest.files.some((file: { path: string }) => file.path === "files/changed-files.json"))
+  assert.equal(runtimeSnapshotBundle.schema, RUNTIME_SNAPSHOT_BUNDLE_SCHEMA)
+  assert.equal(runtimeSnapshotBundle.replay.status, "partial-artifact-backed")
+  assert.equal(runtimeSnapshotBundle.components.database.status, "not-captured")
+  assert.equal(runtimeSnapshotBundle.components.activeThemePlugins.status, "captured")
+  assert.equal(runtimeSnapshotBundle.components.blueprint.status, "partial")
+  assert.ok(runtimeSnapshotBundle.components.blueprint.refs.some((ref: { path: string }) => ref.path === "blueprint.after.json"))
+  assert.equal(runtimeSnapshotBundle.digest.value, runtimeSnapshotBundleDigest(runtimeSnapshotBundle).value)
   assert.ok(review.changedFiles.some((file: { path: string; status: string }) =>
     file.path === "/wordpress/wp-content/plugins/seeded-helper/generated.txt" && file.status === "added",
   ))

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -10,7 +10,9 @@ import {
   RUNTIME_EPISODE_OBSERVATION_SCHEMA,
   RUNTIME_EPISODE_SNAPSHOT_SCHEMA,
   RUNTIME_REFERENCE_MANIFEST_SCHEMA,
+  RUNTIME_SNAPSHOT_BUNDLE_SCHEMA,
   runtimeReferenceManifestDigest,
+  runtimeSnapshotBundleDigest,
   createRuntimeEpisode,
   validateRuntimeEpisodeTrace,
   verifyArtifactBundle,
@@ -126,10 +128,12 @@ try {
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode.jsonl" && file.kind === "runtime-episode-events"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === httpObservation.artifactRefs?.[0].path && file.kind === "observation-artifact"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
+    assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-snapshot-bundle.json" && file.kind === "runtime-snapshot-bundle"))
 
     const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
     assert.equal(review.evidence.runtimeEpisodeTrace, "files/runtime-episode-trace.json")
     assert.equal(review.evidence.runtimeReferenceManifest, "files/runtime-reference-manifest.json")
+    assert.equal(review.evidence.runtimeSnapshotBundle, "files/runtime-snapshot-bundle.json")
     assert.ok(review.progress.some((event: { component?: string; label?: string }) => event.component === "runtime-episode" && event.label === "Runtime episode trace persisted"))
 
     const referenceManifest = JSON.parse(await readFile(artifacts.runtimeReferenceManifestPath ?? "", "utf8"))
@@ -138,6 +142,7 @@ try {
     assert.equal(referenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
     assert.equal(referenceManifest.trace.path, "files/runtime-episode-trace.json")
     assert.equal(referenceManifest.events.path, "files/runtime-episode.jsonl")
+    assert.equal(referenceManifest.snapshotBundle.path, "files/runtime-snapshot-bundle.json")
     assert.equal(referenceManifest.snapshots.length, 1)
     assert.equal(referenceManifest.snapshots[0].id, snapshot.id)
     assert.equal(referenceManifest.snapshots[0].semantics, "metadata-only")
@@ -145,6 +150,18 @@ try {
     assert.ok(referenceManifest.snapshots[0].replay.limitations.some((limitation: string) => limitation.includes("not a WordPress database or filesystem checkpoint")))
     assert.equal(referenceManifest.digest.value, runtimeReferenceManifestDigest(referenceManifest).value)
     assert.equal(referenceManifest.id, `runtime-reference-manifest-sha256-${referenceManifest.digest.value}`)
+
+    const snapshotBundle = JSON.parse(await readFile(artifacts.runtimeSnapshotBundlePath ?? "", "utf8"))
+    assert.equal(snapshotBundle.schema, RUNTIME_SNAPSHOT_BUNDLE_SCHEMA)
+    assert.equal(snapshotBundle.replay.status, "partial-artifact-backed")
+    assert.equal(snapshotBundle.components.database.status, "not-captured")
+    assert.equal(snapshotBundle.components.activeThemePlugins.status, "captured")
+    assert.equal(typeof snapshotBundle.components.activeThemePlugins.data.wordpressVersion, "string")
+    assert.equal(snapshotBundle.components.playgroundState.status, "partial")
+    assert.ok(snapshotBundle.components.playgroundState.refs.some((ref: { path: string }) => ref.path === "files/runtime-episode-trace.json"))
+    assert.ok(snapshotBundle.components.blueprint.refs.some((ref: { path: string }) => ref.path === "blueprint.after.json"))
+    assert.equal(snapshotBundle.digest.value, runtimeSnapshotBundleDigest(snapshotBundle).value)
+    assert.equal(snapshotBundle.id, `runtime-snapshot-bundle-sha256-${snapshotBundle.digest.value}`)
 
     const trace = await episode.trace()
     const persistedTrace = JSON.parse(await readFile(artifacts.runtimeEpisodeTracePath, "utf8"))


### PR DESCRIPTION
## Summary
- Adds a bounded `wp-codebox/runtime-snapshot-bundle/v1` artifact at `files/runtime-snapshot-bundle.json` with explicit replay instructions, verified refs, and limitation markers for unsupported database/uploads/VM state.
- Wires snapshot bundles into artifact metadata, review evidence, manifest verification, and the runtime reference manifest.
- Extends runtime/artifact smokes and README docs to prove the partial artifact-backed replay contract without adding benchmark/eval semantics.

Closes #220.

## Tests
- `npm run build`
- `npm run runtime-episode-smoke`
- `npm run artifact-contract-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `git diff --check HEAD~1..HEAD`
- `npm run check` was started and passed through `recipe-workflow-phases-smoke`, then the controller/user interrupted it while `recipe-site-seed-smoke` was starting so I could finish the PR. No failure was observed before interruption.

## Follow-up
- Full portable replay remains intentionally limited: no database dump, VM memory checkpoint, or Media Library/uploads export is captured by this slice. Those are explicit component limitations in the v1 bundle.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime snapshot bundle contract, artifact wiring, verifier coverage, tests, docs, and local validation. Chris remains responsible for review and merge.