### PR TITLE
Verify artifact bundles before PHP apply flows

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -13,6 +13,8 @@ final class WP_Codebox_Artifacts {
 	private const GET_SCHEMA   = 'wp-codebox/artifact/v1';
 	private const APPLY_SCHEMA = 'wp-codebox/artifact-apply/v1';
 	private const APPLY_AUDIT_SCHEMA = 'wp-codebox/apply-audit/v1';
+	private const VERIFICATION_SCHEMA = 'wp-codebox/artifact-bundle-verification/v1';
+	private const GENERIC_VERIFIER_ISSUE_URL = 'https://github.com/chubes4/wp-codebox/issues/176';
 	private const CONTENT_DIGEST_PREFIX = "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n";
 	private const CONTENT_DIGEST_SEPARATOR = "\nfiles/patch.diff\n";
 
@@ -97,6 +99,11 @@ final class WP_Codebox_Artifacts {
 			return $root;
 		}
 
+		$verification = $this->verify_artifact_bundle( $bundle, $input );
+		if ( is_wp_error( $verification ) ) {
+			return $verification;
+		}
+
 		$approved_files = $this->approved_files( $input );
 		if ( empty( $approved_files ) ) {
 			return new WP_Error( 'wp_codebox_approved_files_missing', 'approved_files must include at least one sandbox path.', array( 'status' => 400 ) );
@@ -152,6 +159,7 @@ final class WP_Codebox_Artifacts {
 			'patch'                   => $patch,
 			'patch_sha256'            => hash( 'sha256', $patch ),
 			'artifact_content_digest' => $content_digest,
+			'artifact_verification'   => $verification,
 		);
 
 		$result = apply_filters( 'wp_codebox_apply_approved_artifact', null, $payload );
@@ -174,8 +182,19 @@ final class WP_Codebox_Artifacts {
 			'approved_files' => $approved_files,
 			'patch_sha256'   => $payload['patch_sha256'],
 			'content_digest' => $content_digest,
+			'verification'   => $verification,
 			'result'         => $result,
 		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function verify_resolved_bundle( array $input ): array|WP_Error {
+		$bundle = $this->resolve_bundle( $input );
+		if ( is_wp_error( $bundle ) ) {
+			return $bundle;
+		}
+
+		return $this->verify_artifact_bundle( $bundle, $input );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
@@ -368,6 +387,108 @@ final class WP_Codebox_Artifacts {
 		}
 
 		return hash( 'sha256', self::CONTENT_DIGEST_PREFIX . $changed_files . self::CONTENT_DIGEST_SEPARATOR . $patch );
+	}
+
+	/** @param array<string,mixed> $bundle Artifact bundle. @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private function verify_artifact_bundle( array $bundle, array $input ): array|WP_Error {
+		$directory = realpath( (string) ( $bundle['directory'] ?? '' ) );
+		if ( false === $directory || ! is_dir( $directory ) ) {
+			return new WP_Error( 'wp_codebox_artifact_directory_missing', 'Artifact bundle directory is missing.', array( 'status' => 400 ) );
+		}
+
+		if ( ! function_exists( 'exec' ) ) {
+			return $this->artifact_verifier_unavailable( 'Shell execution is not available for WP Codebox artifact verification.' );
+		}
+
+		$bin = trim( (string) ( $input['wp_codebox_bin'] ?? $this->default_bin() ) );
+		if ( '' === $bin || ! preg_match( '#^[A-Za-z0-9_./:@+-]+$#', $bin ) ) {
+			return new WP_Error( 'wp_codebox_bin_invalid', 'wp_codebox_bin must be a command name or path without shell metacharacters.', array( 'status' => 400 ) );
+		}
+
+		$command = sprintf(
+			'%s artifacts verify --bundle %s --json',
+			$this->command_prefix( $bin ),
+			escapeshellarg( $directory )
+		);
+
+		$output = array();
+		$exit   = 0;
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Required to delegate to the packaged generic artifact verifier.
+		exec( $command . ' 2>&1', $output, $exit );
+		$raw     = implode( "\n", $output );
+		$decoded = json_decode( $raw, true );
+
+		if ( ! is_array( $decoded ) ) {
+			return $this->artifact_verifier_unavailable( 'WP Codebox artifact verifier did not return valid JSON.', array( 'exit_code' => $exit, 'output' => $this->bound_output( $raw ) ) );
+		}
+
+		if ( self::VERIFICATION_SCHEMA !== ( $decoded['schema'] ?? '' ) || ! array_key_exists( 'valid', $decoded ) || ! is_array( $decoded['violations'] ?? null ) ) {
+			return $this->artifact_verifier_unavailable( 'WP Codebox artifact verifier returned an unexpected payload.', array( 'exit_code' => $exit, 'output' => $decoded ) );
+		}
+
+		if ( true !== (bool) $decoded['valid'] ) {
+			return new WP_Error(
+				'wp_codebox_artifact_verification_failed',
+				'Artifact bundle verification failed.',
+				array(
+					'status'       => 400,
+					'schema'       => self::VERIFICATION_SCHEMA,
+					'valid'        => false,
+					'violations'   => $decoded['violations'],
+					'verification' => $decoded,
+					'issue_url'    => self::GENERIC_VERIFIER_ISSUE_URL,
+				)
+			);
+		}
+
+		if ( 0 !== $exit ) {
+			return $this->artifact_verifier_unavailable( 'WP Codebox artifact verifier exited unsuccessfully.', array( 'exit_code' => $exit, 'output' => $decoded ) );
+		}
+
+		return $decoded;
+	}
+
+	/** @param array<string,mixed> $extra_data Additional WP_Error data. */
+	private function artifact_verifier_unavailable( string $message, array $extra_data = array() ): WP_Error {
+		return new WP_Error(
+			'wp_codebox_artifact_verifier_unavailable',
+			$message,
+			array_merge(
+				array(
+					'status'    => 500,
+					'issue_url' => self::GENERIC_VERIFIER_ISSUE_URL,
+				),
+				$extra_data
+			)
+		);
+	}
+
+	private function default_bin(): string {
+		$bundled = defined( 'WP_CODEBOX_PLUGIN_PATH' ) ? WP_CODEBOX_PLUGIN_PATH . 'vendor/wp-codebox-cli/bin/wp-codebox' : '';
+		$default = is_string( $bundled ) && is_file( $bundled ) ? $bundled : 'wp-codebox';
+		$bin     = (string) $this->config_option( 'wp_codebox_bin', $default );
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$bin = (string) apply_filters( 'wp_codebox_bin', $bin );
+		}
+
+		return $bin;
+	}
+
+	private function command_prefix( string $bin ): string {
+		if ( str_ends_with( $bin, '.js' ) && is_file( $bin ) ) {
+			return 'node ' . escapeshellarg( $bin );
+		}
+
+		return escapeshellarg( $bin );
+	}
+
+	private function bound_output( string $output ): string {
+		if ( strlen( $output ) <= 4000 ) {
+			return $output;
+		}
+
+		return substr( $output, 0, 4000 );
 	}
 
 	private function resolve_artifact_file( string $directory, string $relative_path ): string {

--- a/packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php
@@ -32,9 +32,15 @@ final class WP_Codebox_Data_Machine_Pending_Actions {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public static function stage_apply_artifact( array $input ): array|WP_Error {
-		$bundle_result = ( new WP_Codebox_Artifacts() )->get( $input );
+		$artifacts     = new WP_Codebox_Artifacts();
+		$bundle_result = $artifacts->get( $input );
 		if ( is_wp_error( $bundle_result ) ) {
 			return $bundle_result;
+		}
+
+		$verification = $artifacts->verify_resolved_bundle( $input );
+		if ( is_wp_error( $verification ) ) {
+			return $verification;
 		}
 
 		$apply_input = self::apply_input( $input );
@@ -53,7 +59,7 @@ final class WP_Codebox_Data_Machine_Pending_Actions {
 			'kind'         => self::KIND,
 			'summary'      => $summary,
 			'apply_input'  => $apply_input,
-			'preview_data' => self::preview_data( $bundle, $apply_input ),
+			'preview_data' => self::preview_data( $bundle, $apply_input, $verification ),
 			'agent_id'     => isset( $input['agent_id'] ) ? (int) $input['agent_id'] : 0,
 			'user_id'      => isset( $input['user_id'] ) ? (int) $input['user_id'] : 0,
 			'context'      => isset( $input['context'] ) && is_array( $input['context'] ) ? $input['context'] : array(),
@@ -127,12 +133,13 @@ final class WP_Codebox_Data_Machine_Pending_Actions {
 	}
 
 	/** @param array<string,mixed> $bundle Artifact bundle. @param array<string,mixed> $apply_input Stored apply input. */
-	private static function preview_data( array $bundle, array $apply_input ): array {
+	private static function preview_data( array $bundle, array $apply_input, array $verification ): array {
 		return array(
 			'schema'         => 'wp-codebox/pending-apply-preview/v1',
 			'artifact_id'    => (string) ( $bundle['id'] ?? $apply_input['artifact_id'] ?? '' ),
 			'content_digest' => (string) ( $bundle['content_digest'] ?? '' ),
 			'created_at'     => (string) ( $bundle['created_at'] ?? '' ),
+			'verification'   => $verification,
 			'approved_files' => $apply_input['approved_files'] ?? array(),
 			'changed_files'  => is_array( $bundle['changed_files'] ?? null ) ? $bundle['changed_files'] : array(),
 			'test_results'   => is_array( $bundle['test_results'] ?? null ) ? $bundle['test_results'] : array(),

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -174,6 +174,78 @@ $assert   = function ( string $label, bool $condition ) use ( &$failures, &$tota
 	echo "  fail {$label}\n";
 };
 
+$stable_json = function ( mixed $value ) use ( &$stable_json ): string {
+	if ( ! is_array( $value ) ) {
+		return json_encode( $value, JSON_UNESCAPED_SLASHES );
+	}
+
+	if ( array_is_list( $value ) ) {
+		return '[' . implode( ',', array_map( $stable_json, $value ) ) . ']';
+	}
+
+	ksort( $value, SORT_STRING );
+	$parts = array();
+	foreach ( $value as $key => $item ) {
+		$parts[] = json_encode( (string) $key, JSON_UNESCAPED_SLASHES ) . ':' . $stable_json( $item );
+	}
+
+	return '{' . implode( ',', $parts ) . '}';
+};
+
+$manifest_self_hash = function ( array $manifest ) use ( $stable_json ): string {
+	foreach ( $manifest['files'] as &$file ) {
+		if ( 'manifest.json' === ( $file['path'] ?? '' ) ) {
+			$file['sha256'] = array( 'algorithm' => 'sha256', 'value' => str_repeat( '0', 64 ) );
+		}
+	}
+	unset( $file );
+
+	return hash( 'sha256', "wp-codebox/artifact-manifest-self/v1\n" . $stable_json( $manifest ) );
+};
+
+$copy_directory = function ( string $source, string $destination ) use ( &$copy_directory ): void {
+	mkdir( $destination, 0777, true );
+	foreach ( scandir( $source ) ?: array() as $entry ) {
+		if ( '.' === $entry || '..' === $entry ) {
+			continue;
+		}
+
+		$source_path      = $source . '/' . $entry;
+		$destination_path = $destination . '/' . $entry;
+		if ( is_dir( $source_path ) ) {
+			$copy_directory( $source_path, $destination_path );
+			continue;
+		}
+
+		copy( $source_path, $destination_path );
+	}
+};
+
+$refresh_manifest_hashes = function ( string $bundle_path ) use ( $manifest_self_hash ): void {
+	$manifest_path = $bundle_path . '/manifest.json';
+	$manifest      = json_decode( (string) file_get_contents( $manifest_path ), true );
+	foreach ( $manifest['files'] as &$manifest_file ) {
+		if ( 'manifest.json' !== $manifest_file['path'] ) {
+			$manifest_file['sha256'] = array( 'algorithm' => 'sha256', 'value' => hash_file( 'sha256', $bundle_path . '/' . $manifest_file['path'] ) );
+		}
+	}
+	unset( $manifest_file );
+	foreach ( $manifest['files'] as &$manifest_file ) {
+		if ( 'manifest.json' === $manifest_file['path'] ) {
+			$manifest_file['sha256'] = array( 'algorithm' => 'sha256', 'value' => $manifest_self_hash( $manifest ) );
+		}
+	}
+	unset( $manifest_file );
+	file_put_contents( $manifest_path, json_encode( $manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+};
+
+$violation_codes = static function ( WP_Error $error ): array {
+	$data       = $error->get_error_data();
+	$violations = is_array( $data['violations'] ?? null ) ? $data['violations'] : array();
+
+	return array_values( array_filter( array_map( static fn( mixed $violation ): string => is_array( $violation ) ? (string) ( $violation['code'] ?? '' ) : '', $violations ) ) );
+};
+
 echo "WP Codebox WordPress plugin - smoke\n";
 
 new WP_Codebox_Data_Machine_Pending_Actions();
@@ -1013,101 +1085,82 @@ $approved_patch_diff = "diff --git a/generated.txt b/generated.txt\n+cooked\n";
 $patch_diff          = $approved_patch_diff . "diff --git a/unapproved.txt b/unapproved.txt\n+unsafe\n";
 $content_digest      = hash( 'sha256', "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n" . $changed_files_json . "\nfiles/patch.diff\n" . $patch_diff );
 $artifact_id         = 'artifact-bundle-sha256-' . $content_digest;
-file_put_contents(
-	$bundle_dir . '/manifest.json',
-	json_encode(
-		array(
-			'id'            => $artifact_id,
-			'contentDigest' => array(
-				'algorithm' => 'sha256',
-				'inputs'    => array( 'files/changed-files.json', 'files/patch.diff' ),
-				'value'     => $content_digest,
-			),
-			'createdAt'     => '2026-05-19T00:00:00Z',
-			'files'         => array(
-				array(
-					'path'        => 'files/changed-files.json',
-					'kind'        => 'changed-files',
-					'contentType' => 'application/json',
-				),
-				array(
-					'path'        => 'files/patch.diff',
-					'kind'        => 'patch',
-					'contentType' => 'text/x-diff',
-				),
-				array(
-					'path'        => 'files/test-results.json',
-					'kind'        => 'test-results',
-					'contentType' => 'application/json',
-				),
-				array(
-					'path'        => 'files/review.json',
-					'kind'        => 'review',
-					'contentType' => 'application/json',
-				),
-			),
+$metadata = array(
+	'artifacts'  => array( 'patch' => 'files/patch.diff' ),
+	'provenance' => array(
+		'task' => array(
+			'requester' => 'chat:user-7',
 		),
-		JSON_PRETTY_PRINT
-	) . "\n"
+	),
 );
-file_put_contents(
-	$bundle_dir . '/metadata.json',
-	json_encode(
+$test_results = array(
+	'schema'           => 'wp-codebox/test-results/v1',
+	'status'           => 'unknown',
+	'summary'          => array(
+		'total'   => 0,
+		'passed'  => 0,
+		'failed'  => 0,
+		'skipped' => 0,
+		'unknown' => 0,
+	),
+	'suites'           => array(),
+	'rawLogReferences' => array(),
+);
+$review = array(
+	'schema'       => 'wp-codebox/artifact-review/v1',
+	'artifactId'   => $artifact_id,
+	'summary'      => 'Sandbox produced changes in 1 file.',
+	'actions'      => array(
 		array(
-			'artifacts'  => array( 'patch' => 'files/patch.diff' ),
-			'provenance' => array(
-				'task' => array(
-					'requester' => 'chat:user-7',
-				),
-			),
+			'kind'                  => 'approve',
+			'label'                 => 'Approve all changes',
+			'requiresApprovedFiles' => true,
 		),
-		JSON_PRETTY_PRINT
-	) . "\n"
+	),
+	'evidence'     => array(
+		'artifactContentDigest' => $content_digest,
+		'changedFiles'          => 'files/changed-files.json',
+		'patch'                 => 'files/patch.diff',
+		'patchSha256'           => hash( 'sha256', $patch_diff ),
+	),
+	'changedFiles' => array(
+		array(
+			'path'   => '/wordpress/wp-content/plugins/example/generated.txt',
+			'status' => 'added',
+		),
+	),
 );
+file_put_contents( $bundle_dir . '/metadata.json', json_encode( $metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
 file_put_contents( $bundle_dir . '/files/changed-files.json', $changed_files_json );
 file_put_contents( $bundle_dir . '/files/patch.diff', $patch_diff );
-file_put_contents(
-	$bundle_dir . '/files/test-results.json',
-	json_encode(
-		array(
-			'schema'           => 'wp-codebox/test-results/v1',
-			'status'           => 'unknown',
-			'summary'          => array(
-				'total'   => 0,
-				'passed'  => 0,
-				'failed'  => 0,
-				'skipped' => 0,
-				'unknown' => 0,
-			),
-			'suites'           => array(),
-			'rawLogReferences' => array(
-				array(
-					'path' => 'logs/commands.log',
-					'kind' => 'commands-log',
-				),
-			),
-		),
-		JSON_PRETTY_PRINT
-	) . "\n"
+file_put_contents( $bundle_dir . '/files/test-results.json', json_encode( $test_results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+file_put_contents( $bundle_dir . '/files/review.json', json_encode( $review, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+$manifest = array(
+	'id'            => $artifact_id,
+	'contentDigest' => array(
+		'algorithm' => 'sha256',
+		'inputs'    => array( 'files/changed-files.json', 'files/patch.diff' ),
+		'value'     => $content_digest,
+	),
+	'createdAt'     => '2026-05-19T00:00:00Z',
+	'runtime'       => array( 'type' => 'php-smoke-fixture' ),
+	'files'         => array(
+		array( 'path' => 'manifest.json', 'kind' => 'manifest', 'contentType' => 'application/json' ),
+		array( 'path' => 'metadata.json', 'kind' => 'metadata', 'contentType' => 'application/json' ),
+		array( 'path' => 'files/changed-files.json', 'kind' => 'changed-files', 'contentType' => 'application/json' ),
+		array( 'path' => 'files/patch.diff', 'kind' => 'patch', 'contentType' => 'text/x-diff' ),
+		array( 'path' => 'files/test-results.json', 'kind' => 'test-results', 'contentType' => 'application/json' ),
+		array( 'path' => 'files/review.json', 'kind' => 'review', 'contentType' => 'application/json' ),
+	),
 );
-file_put_contents(
-	$bundle_dir . '/files/review.json',
-	json_encode(
-		array(
-			'schema'     => 'wp-codebox/artifact-review/v1',
-			'artifactId' => $artifact_id,
-			'summary'    => 'Sandbox produced changes in 1 file.',
-			'actions'    => array(
-				array(
-					'kind'                  => 'approve',
-					'label'                 => 'Approve all changes',
-					'requiresApprovedFiles' => true,
-				),
-			),
-		),
-		JSON_PRETTY_PRINT
-	) . "\n"
-);
+foreach ( $manifest['files'] as &$manifest_file ) {
+	if ( 'manifest.json' !== $manifest_file['path'] ) {
+		$manifest_file['sha256'] = array( 'algorithm' => 'sha256', 'value' => hash_file( 'sha256', $bundle_dir . '/' . $manifest_file['path'] ) );
+	}
+}
+unset( $manifest_file );
+$manifest['files'][0]['sha256'] = array( 'algorithm' => 'sha256', 'value' => $manifest_self_hash( $manifest ) );
+file_put_contents( $bundle_dir . '/manifest.json', json_encode( $manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
 
 $artifacts = new WP_Codebox_Artifacts();
 $listed    = $artifacts->list( array( 'artifacts_path' => $artifact_root ) );
@@ -1128,6 +1181,44 @@ $assert( 'artifact get returns canonical changed files', ! is_wp_error( $read_ar
 $assert( 'artifact get returns test results', ! is_wp_error( $read_artifact ) && 'wp-codebox/test-results/v1' === ( $read_artifact['artifact']['test_results']['schema'] ?? '' ) );
 $assert( 'artifact get returns review payload', ! is_wp_error( $read_artifact ) && 'wp-codebox/artifact-review/v1' === ( $read_artifact['artifact']['review']['schema'] ?? '' ) );
 $assert( 'artifact get verifies content digest', ! is_wp_error( $read_artifact ) && $content_digest === ( $read_artifact['artifact']['content_digest'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_bin'] = dirname( __DIR__ ) . '/packages/cli/dist/index.js';
+
+$malformed_manifest_root = $root . '/artifact-malformed-manifest';
+mkdir( $malformed_manifest_root . '/broken', 0777, true );
+file_put_contents( $malformed_manifest_root . '/broken/manifest.json', "{\n" );
+$verify_output = array();
+$verify_exit   = 0;
+exec( 'node ' . escapeshellarg( $GLOBALS['wp_codebox_filters']['wp_codebox_bin'] ) . ' artifacts verify --bundle ' . escapeshellarg( $malformed_manifest_root . '/broken' ) . ' --json 2>&1', $verify_output, $verify_exit );
+$verify_result = json_decode( implode( "\n", $verify_output ), true );
+$assert( 'generic verifier reports malformed manifest fixtures', 1 === $verify_exit && false === ( $verify_result['valid'] ?? true ) && 'malformed-manifest' === ( $verify_result['violations'][0]['code'] ?? '' ) );
+
+$hash_fixture_root = $root . '/artifact-hash-fixture';
+$copy_directory( $bundle_dir, $hash_fixture_root . '/runtime-test' );
+file_put_contents( $hash_fixture_root . '/runtime-test/metadata.json', "{}\n" );
+$hash_failure = $artifacts->apply_approved(
+	array(
+		'artifacts_path' => $hash_fixture_root,
+		'artifact_id'    => $artifact_id,
+		'approved_files' => array( '/wordpress/wp-content/plugins/example/generated.txt' ),
+	)
+);
+$assert( 'approved artifact apply rejects hash mismatch fixtures before delegation', is_wp_error( $hash_failure ) && 'wp_codebox_artifact_verification_failed' === $hash_failure->get_error_code() && in_array( 'file-hash-mismatch', $violation_codes( $hash_failure ), true ) );
+
+$reference_fixture_root = $root . '/artifact-reference-fixture';
+$copy_directory( $bundle_dir, $reference_fixture_root . '/runtime-test' );
+$reference_metadata = $metadata;
+$reference_metadata['artifacts']['patch'] = 'files/missing.diff';
+file_put_contents( $reference_fixture_root . '/runtime-test/metadata.json', json_encode( $reference_metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
+$refresh_manifest_hashes( $reference_fixture_root . '/runtime-test' );
+$reference_failure = WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact(
+	array(
+		'artifacts_path' => $reference_fixture_root,
+		'artifact_id'    => $artifact_id,
+		'approved_files' => array( '/wordpress/wp-content/plugins/example/generated.txt' ),
+	)
+);
+$assert( 'pending artifact apply rejects malformed references before staging', is_wp_error( $reference_failure ) && 'wp_codebox_artifact_verification_failed' === $reference_failure->get_error_code() && in_array( 'malformed-reference', $violation_codes( $reference_failure ), true ) && 'https://github.com/chubes4/wp-codebox/issues/176' === ( $reference_failure->get_error_data()['issue_url'] ?? '' ) );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function ( mixed $value, array $payload ): array {
 	return array(
@@ -1180,6 +1271,7 @@ $staged = WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact(
 $assert( 'pending artifact apply can be staged', ! is_wp_error( $staged ) && true === ( $staged['staged'] ?? false ) && WP_Codebox_Data_Machine_Pending_Actions::KIND === ( $captured_stage_args['kind'] ?? '' ) );
 $assert( 'pending artifact apply stores exact apply input', $artifact_id === ( $captured_stage_args['apply_input']['artifact_id'] ?? '' ) && array( '/wordpress/wp-content/plugins/example/generated.txt' ) === ( $captured_stage_args['apply_input']['approved_files'] ?? array() ) && array( 'repo' => 'chubes4/wp-codebox' ) === ( $captured_stage_args['apply_input']['apply_target'] ?? array() ) );
 $assert( 'pending artifact apply preview includes review and changed files', 'wp-codebox/pending-apply-preview/v1' === ( $captured_stage_args['preview_data']['schema'] ?? '' ) && 'wp-codebox/artifact-review/v1' === ( $captured_stage_args['preview_data']['review']['schema'] ?? '' ) && 'wp-codebox/changed-files/v1' === ( $captured_stage_args['preview_data']['changed_files']['schema'] ?? '' ) );
+$assert( 'pending artifact apply preview includes successful bundle verification', true === ( $captured_stage_args['preview_data']['verification']['valid'] ?? false ) && 'wp-codebox/artifact-bundle-verification/v1' === ( $captured_stage_args['preview_data']['verification']['schema'] ?? '' ) );
 
 $handlers = apply_filters( 'datamachine_pending_action_handlers', array() );
 $assert( 'pending artifact apply handler registers with Data Machine', isset( $handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'] ) && is_callable( $handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'] ) );


### PR DESCRIPTION
## Summary
- Verify the full artifact bundle with the packaged generic verifier before `apply-approved-artifact` delegates to apply-back adapters.
- Verify the same bundle before `stage-artifact-apply` creates Data Machine pending actions, and include the successful verification payload in pending previews.
- Return stable machine-readable verification failures with violation details and link them to the generic verifier work in #176.

Fixes #232
Refs #176

## Verification
- `npm run check`
- `npm run wordpress-plugin-smoke && npm run artifact-bundle-verifier-smoke && php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php && php -l packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php && php -l tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the PHP verifier delegation, pending-action integration, and smoke fixture coverage; Chris remains responsible for review and merge.