### PR TITLE
Fail closed browser Playground sessions

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -829,6 +829,9 @@ final class WP_Codebox_Abilities {
 			return $artifacts;
 		}
 		$ready_to_code = self::browser_ready_to_code_signal( $input );
+		if ( false === ( $ready_to_code['emitted'] ?? false ) ) {
+			return self::blocked_browser_playground_session( $session_id, $input, $task_input, $ready_to_code, $browser_plugins, $artifacts, $playground, $blueprint );
+		}
 
 		$recipe = self::browser_agent_recipe( $task_input, $session_id, $browser_runner, $blueprint, $playground );
 		if ( is_wp_error( $recipe ) ) {
@@ -865,6 +868,64 @@ final class WP_Codebox_Abilities {
 				),
 			),
 			'recipe'     => $recipe,
+			'signals'    => array(
+				'ready_to_code' => $ready_to_code,
+			),
+			'artifacts'  => array(
+				'schema'             => 'wp-codebox/browser-artifacts/v1',
+				'files'              => $artifacts,
+				'preview_url'        => self::browser_preview_url( $artifacts, $playground ),
+				'expected_artifacts' => $task_input['expected_artifacts'],
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input Ability input.
+	 * @param array<string,mixed> $task_input Normalized task input.
+	 * @param array<string,mixed> $ready_to_code Readiness signal.
+	 * @param array<int,array<string,string>> $browser_plugins Browser plugin specs.
+	 * @param array<int,array<string,string>> $artifacts Browser artifact specs.
+	 * @param array<string,mixed> $playground Playground input.
+	 * @param array<string,mixed> $blueprint Playground blueprint.
+	 * @return array<string,mixed>
+	 */
+	private static function blocked_browser_playground_session( string $session_id, array $input, array $task_input, array $ready_to_code, array $browser_plugins, array $artifacts, array $playground, array $blueprint ): array {
+		return array(
+			'success'    => false,
+			'schema'     => 'wp-codebox/browser-playground-session/v1',
+			'execution'  => 'browser-playground',
+			'status'     => 'blocked',
+			'error'      => array(
+				'code'    => 'wp_codebox_browser_prerequisites_missing',
+				'message' => 'Browser Playground sandbox is missing required coding prerequisites.',
+				'missing' => $ready_to_code['missing'] ?? array(),
+			),
+			'session'    => array(
+				'schema'       => 'wp-codebox/browser-playground-session/v1',
+				'id'           => $session_id,
+				'status'       => 'blocked',
+				'persistence'  => 'external-orchestrator',
+				'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
+			),
+			'task_input' => $task_input,
+			'agent'      => (string) ( $input['agent'] ?? 'wp-codebox-sandbox' ),
+			'plugins'    => $browser_plugins,
+			'playground' => array(
+				'client_module_url'  => (string) ( $playground['client_module_url'] ?? 'https://playground.automattic.ai/client/index.js' ),
+				'remote_url'         => (string) ( $playground['remote_url'] ?? 'https://playground.automattic.ai/remote.html' ),
+				'scope'              => (string) ( $playground['scope'] ?? $session_id ),
+				'artifact_base_path' => self::browser_artifact_base_path( $playground ),
+				'artifact_base_url'  => self::browser_artifact_base_url( $playground ),
+				'preview_url'        => self::browser_preview_url( $artifacts, $playground ),
+				'blueprint'          => self::browser_playground_blueprint( $blueprint, $playground ),
+				'capabilities'       => array(
+					'compile_blueprint' => true,
+					'run_blueprint'     => true,
+					'write_file'        => true,
+					'run_php'           => true,
+				),
+			),
 			'signals'    => array(
 				'ready_to_code' => $ready_to_code,
 			),
@@ -982,7 +1043,7 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_task_missing', 'goal or task is required.', array( 'status' => 400 ) );
 		}
 
-		return array(
+		$task_input = array(
 			'schema'             => 'wp-codebox/task-input/v1',
 			'goal'               => $goal,
 			'target'             => is_array( $input['target'] ?? null ) ? $input['target'] : array(),
@@ -991,6 +1052,13 @@ final class WP_Codebox_Abilities {
 			'policy'             => is_array( $input['policy'] ?? null ) ? $input['policy'] : array(),
 			'context'            => is_array( $input['context'] ?? null ) ? $input['context'] : array(),
 		);
+
+		$tool_error = ( new WP_Codebox_Agent_Sandbox_Runner() )->validate_allowed_tools( $task_input['allowed_tools'] );
+		if ( is_wp_error( $tool_error ) ) {
+			return $tool_error;
+		}
+
+		return $task_input;
 	}
 
 	/** @return string[] */

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -855,7 +855,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$values = $this->string_list( $input[ $field ] ?? array() );
 			if ( ! empty( $values ) ) {
 				if ( 'allowed_tools' === $field ) {
-					$tool_error = $this->allowed_tools_error( $values );
+					$tool_error = $this->validate_allowed_tools( $values );
 					if ( is_wp_error( $tool_error ) ) {
 						return $tool_error;
 					}
@@ -911,7 +911,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	/** @param string[] $tools */
-	private function allowed_tools_error( array $tools ): WP_Error|null {
+	public function validate_allowed_tools( array $tools ): WP_Error|null {
 		$allowed = $this->sandbox_tool_allowlist();
 		$denied  = array();
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -304,13 +304,71 @@ $assert( 'browser Playground session exposes artifact URL paths', ! is_wp_error(
 $assert( 'browser Playground session exposes preview URL', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['playground']['preview_url'] ?? '' ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['preview_url'] ?? '' ) );
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
 
+$browser_parent_only_tool = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'                  => 'Prepare a browser preview with a parent-only tool.',
+		'allowed_tools'         => array( 'datamachine/workspace-git-push' ),
+		'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+		'inherit'               => array( 'connectors' => array( 'openai' ) ),
+	)
+);
+$assert( 'browser Playground session rejects parent-only Data Machine tools before recipe emission', is_wp_error( $browser_parent_only_tool ) && 'wp_codebox_tool_not_allowed' === $browser_parent_only_tool->get_error_code() );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_allowed_sandbox_tools'] = array( 'datamachine/workspace-read' );
+$browser_not_allowlisted_tool = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'                  => 'Prepare a browser preview with an unconfigured tool.',
+		'allowed_tools'         => array( 'datamachine/workspace-write' ),
+		'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+		'inherit'               => array( 'connectors' => array( 'openai' ) ),
+	)
+);
+$assert( 'browser Playground session rejects tools outside configured allow-list before recipe emission', is_wp_error( $browser_not_allowlisted_tool ) && 'wp_codebox_tool_not_allowed' === $browser_not_allowlisted_tool->get_error_code() && 'not-allowlisted' === ( $browser_not_allowlisted_tool->get_error_data()['denied_tools'][0]['reason'] ?? '' ) );
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_allowed_sandbox_tools'] );
+
 $browser_session_missing_prereqs = call_user_func(
 	$browser_session_ability['execute_callback'],
 	array(
 		'goal' => 'Prepare a browser preview without coding prerequisites.',
 	)
 );
-$assert( 'browser Playground session with missing prerequisites does not emit ready-to-code', ! is_wp_error( $browser_session_missing_prereqs ) && false === ( $browser_session_missing_prereqs['signals']['ready_to_code']['emitted'] ?? true ) && in_array( 'provider_plugin', $browser_session_missing_prereqs['signals']['ready_to_code']['missing'] ?? array(), true ) && in_array( 'provider_secret', $browser_session_missing_prereqs['signals']['ready_to_code']['missing'] ?? array(), true ) );
+$assert( 'browser Playground session with missing prerequisites returns blocked state', ! is_wp_error( $browser_session_missing_prereqs ) && false === ( $browser_session_missing_prereqs['success'] ?? true ) && 'blocked' === ( $browser_session_missing_prereqs['status'] ?? '' ) && 'blocked' === ( $browser_session_missing_prereqs['session']['status'] ?? '' ) );
+$assert( 'browser Playground session with missing prerequisites does not emit ready-to-code or recipe', ! is_wp_error( $browser_session_missing_prereqs ) && false === ( $browser_session_missing_prereqs['signals']['ready_to_code']['emitted'] ?? true ) && ! array_key_exists( 'recipe', $browser_session_missing_prereqs ) && in_array( 'provider_plugin', $browser_session_missing_prereqs['signals']['ready_to_code']['missing'] ?? array(), true ) && in_array( 'provider_secret', $browser_session_missing_prereqs['signals']['ready_to_code']['missing'] ?? array(), true ) );
+
+unset( $GLOBALS['wp_codebox_mock_abilities']['agents/chat'] );
+$browser_session_missing_agents_api = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'                  => 'Prepare a browser preview without Agents API.',
+		'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+		'inherit'               => array( 'connectors' => array( 'openai' ) ),
+	)
+);
+$assert( 'browser Playground session blocks when Agents API prerequisite is missing', ! is_wp_error( $browser_session_missing_agents_api ) && false === ( $browser_session_missing_agents_api['success'] ?? true ) && in_array( 'agents_api', $browser_session_missing_agents_api['signals']['ready_to_code']['missing'] ?? array(), true ) && ! array_key_exists( 'recipe', $browser_session_missing_agents_api ) );
+$GLOBALS['wp_codebox_mock_abilities']['agents/chat'] = new WP_Ability();
+
+rmdir( $root . '/plugin-root/data-machine' );
+$browser_session_missing_data_machine = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'                  => 'Prepare a browser preview without Data Machine.',
+		'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+		'inherit'               => array( 'connectors' => array( 'openai' ) ),
+	)
+);
+$assert( 'browser Playground session blocks when Data Machine prerequisite is missing', ! is_wp_error( $browser_session_missing_data_machine ) && false === ( $browser_session_missing_data_machine['success'] ?? true ) && in_array( 'data_machine', $browser_session_missing_data_machine['signals']['ready_to_code']['missing'] ?? array(), true ) && ! array_key_exists( 'recipe', $browser_session_missing_data_machine ) );
+mkdir( $root . '/plugin-root/data-machine', 0777, true );
+
+$browser_session_missing_secret = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'                  => 'Prepare a browser preview without provider secret.',
+		'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+	)
+);
+$assert( 'browser Playground session blocks when provider secret prerequisite is missing', ! is_wp_error( $browser_session_missing_secret ) && false === ( $browser_session_missing_secret['success'] ?? true ) && in_array( 'provider_secret', $browser_session_missing_secret['signals']['ready_to_code']['missing'] ?? array(), true ) && ! array_key_exists( 'recipe', $browser_session_missing_secret ) );
 rmdir( $root . '/plugin-root/data-machine-code' );
 rmdir( $root . '/plugin-root/data-machine' );
 


### PR DESCRIPTION
## Summary
- Return an explicit blocked browser Playground session when required coding prerequisites are missing, without emitting a runnable recipe.
- Reuse the host sandbox Data Machine tool allowlist validator for browser session `allowed_tools` before recipe generation.
- Expand WordPress plugin smoke coverage for missing prerequisites and denied browser tools.

Closes #233

## Verification
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l tests/smoke-wordpress-plugin.php`
- `npm run check` ran until the 20-minute tool timeout during `artifact-contract-smoke`; completed scripts up to that point passed, including `build` and `wordpress-plugin-smoke`.
- `npm run artifact-contract-smoke`
- Remaining `npm run check` tail from `external-adapter-contract-smoke` through the final `wp-codebox run` command.
- Post-rebase: `php tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke tests; Chris remains responsible for review and merge.