### PR TITLE
Centralize runtime command registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
     "external-adapter-contract-smoke": "tsx scripts/external-adapter-contract-smoke.ts",
+    "command-registry-smoke": "tsx scripts/command-registry-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "core-phpunit-command-smoke": "tsx scripts/core-phpunit-command-smoke.ts",
     "theme-check-normalization-smoke": "tsx scripts/theme-check-normalization-smoke.ts",
@@ -63,7 +64,7 @@
     "recipe-runtime-evidence-smoke": "tsx scripts/recipe-runtime-evidence-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wordpress-plugin-smoke": "php tests/smoke-wordpress-plugin.php",
-    "check": "npm run build && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run workspace-policy-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-bundle-verifier-smoke && npm run artifact-patch-git-apply-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run recipe-workspace-seed-excludes-smoke && npm run recipe-runtime-evidence-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
+    "check": "npm run build && npm run command-registry-smoke && npm run discovery-command-smoke && npm run theme-check-normalization-smoke && npm run agent-sandbox-code-smoke && npm run policy-validation-smoke && npm run workspace-policy-smoke && npm run wordpress-plugin-smoke && npm run package-distribution-smoke && npm run artifact-bundle-verifier-smoke && npm run artifact-patch-git-apply-smoke && npm run artifact-contract-smoke && npm run external-adapter-contract-smoke && npm run runtime-episode-smoke && npm run core-phpunit-command-smoke && npm run plugin-check-normalization-smoke && npm run recipe-bench-smoke && npm run recipe-dry-run-smoke && npm run recipe-workflow-phases-smoke && npm run recipe-site-seed-smoke && npm run recipe-staged-files-smoke && npm run recipe-workspace-seed-excludes-smoke && npm run recipe-runtime-evidence-smoke && npm run preview-port-smoke && npm run preview-public-url-canonical-smoke && npm run preview-response-body-smoke && npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,29 +9,14 @@ import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, calculateArtifactManifestFileSha256, checkWorkspacePolicy, createRuntime, validateRuntimePolicy, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
+import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, calculateArtifactManifestFileSha256, checkWorkspacePolicy, commandRegistry, createRuntime, recipeCommandDefinitions, validateRuntimePolicy, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type CommandDefinition, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
 import { captureStdout, printArtifactVerifyHumanOutput, printBatchHumanOutput, printBlueprintValidateHumanOutput, printBootHumanOutput, printCommandCatalogHumanOutput, printHelp, printHumanOutput, printRecipeHumanOutput, printRecipeSchemaHumanOutput, printRecipeValidateHumanOutput, serializeError } from "./output.js"
 
-interface CommandMetadata {
-  id: string
-  description: string
-  acceptedArgs: Array<{
-    name: string
-    description: string
-    required?: boolean
-    repeatable?: boolean
-    format?: string
-  }>
-  outputShape: string
-  policyRequirement: string
-  recipe: boolean
-}
-
 interface CommandCatalogOutput {
   schema: "wp-codebox/command-catalog/v1"
-  commands: CommandMetadata[]
+  commands: Array<Omit<CommandDefinition, "handler">>
 }
 
 interface RecipeSchemaOutput {
@@ -643,167 +628,7 @@ async function copyWorkspaceSeedDirectory(source: string, target: string, exclud
 }
 const moduleDirectory = dirname(fileURLToPath(import.meta.url))
 const workspaceRoot = resolve(moduleDirectory, "..", "..", "..")
-const commandCatalog: CommandMetadata[] = [
-  {
-    id: "inspect-mounted-inputs",
-    description: "List mounted input entries visible inside the Playground runtime.",
-    acceptedArgs: [],
-    outputShape: "JSON array of mounted input descriptors.",
-    policyRequirement: "Runtime policy commands must include inspect-mounted-inputs.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.run-php",
-    description: "Run PHP against WordPress, bootstrapping wp-load.php unless bootstrap=none is supplied.",
-    acceptedArgs: [
-      { name: "code", description: "Inline PHP code to run.", format: "PHP string" },
-      { name: "code-file", description: "Path to a PHP file whose contents should run.", format: "path" },
-      { name: "bootstrap", description: "Use bootstrap=none to skip wp-load.php.", format: "wordpress|none" },
-    ],
-    outputShape: "Raw command stdout from the PHP snippet.",
-    policyRequirement: "Runtime policy commands must include wordpress.run-php.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.wp-cli",
-    description: "Run a WP-CLI command inside the same disposable WordPress runtime.",
-    acceptedArgs: [
-      { name: "command", description: "WP-CLI command line, with or without the leading wp token.", required: true, format: "string" },
-    ],
-    outputShape: "Raw WP-CLI stdout.",
-    policyRequirement: "Runtime policy commands must include wordpress.wp-cli.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.ability",
-    description: "Execute a registered WordPress Ability in the sandbox.",
-    acceptedArgs: [
-      { name: "name", description: "Ability name to execute.", required: true, format: "string" },
-      { name: "input", description: "Ability input payload.", format: "JSON object" },
-    ],
-    outputShape: "JSON object with command, name, input, and result fields.",
-    policyRequirement: "Runtime policy commands must include wordpress.ability.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.bench",
-    description: "Run plugin benchmark workloads and emit a Homeboy-compatible BenchResults envelope.",
-    acceptedArgs: [
-      { name: "component-id", description: "Component id for the BenchResults envelope.", format: "string" },
-      { name: "plugin-slug", description: "Plugin slug containing tests/bench workloads.", required: true, format: "slug" },
-      { name: "iterations", description: "Measured iterations per workload.", format: "positive integer" },
-      { name: "warmup", description: "Warmup iterations before measurement.", format: "non-negative integer" },
-      { name: "dependency-slugs", description: "Comma-separated plugin dependency slugs to load.", format: "comma-separated slugs" },
-      { name: "env-json", description: "Benchmark environment object.", format: "JSON object" },
-      { name: "workloads-json", description: "Explicit workload list.", format: "JSON array" },
-    ],
-    outputShape: "BenchResults JSON envelope with component_id, iterations, and scenarios.",
-    policyRequirement: "Runtime policy commands must include wordpress.bench.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.phpunit",
-    description: "Run plugin PHPUnit tests with normalized diagnostics and test-result artifact capture.",
-    acceptedArgs: [
-      { name: "plugin-slug", description: "Plugin slug under wp-content/plugins.", format: "slug" },
-      { name: "code", description: "Inline override PHP runner code.", format: "PHP string" },
-      { name: "code-file", description: "Path to override PHP runner code.", format: "path" },
-      { name: "autoload-file", description: "PHPUnit/vendor autoload path inside the sandbox.", format: "sandbox path" },
-      { name: "tests-dir", description: "WP PHPUnit tests directory inside the sandbox.", format: "sandbox path" },
-      { name: "phpunit-xml", description: "phpunit.xml path inside the plugin.", format: "path" },
-      { name: "test-file", description: "Single test file to run.", format: "path" },
-      { name: "changed-tests-json", description: "Changed test files for diagnostics.", format: "JSON array" },
-      { name: "env-json", description: "PHPUnit environment values.", format: "JSON object" },
-      { name: "wp-config-defines-json", description: "wp-config.php constants for the run.", format: "JSON object" },
-      { name: "dependency-mounts", description: "Comma-separated mounted dependency paths.", format: "comma-separated sandbox paths" },
-      { name: "multisite", description: "Run as multisite.", format: "boolean" },
-    ],
-    outputShape: "Raw PHPUnit runner JSON/log output plus normalized test-results artifact when artifacts are collected.",
-    policyRequirement: "Runtime policy commands must include wordpress.phpunit.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.plugin-check",
-    description: "Run the official WordPress Plugin Check plugin against a mounted plugin and emit normalized findings.",
-    acceptedArgs: [
-      { name: "plugin-slug", description: "Plugin slug under wp-content/plugins to validate.", required: true, format: "slug" },
-      { name: "checks", description: "Optional comma-separated official Plugin Check slugs to run; omit to run the default suite.", format: "comma-separated check slugs" },
-    ],
-    outputShape: "wp-codebox/plugin-check/v1 JSON with command, target plugin, exit code/status, summary counts, and findings; raw and normalized outputs are captured in artifacts.",
-    policyRequirement: "Runtime policy commands must include wordpress.plugin-check.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.core-phpunit",
-    description: "Run WordPress core PHPUnit tests with normalized diagnostics and test-result artifact capture.",
-    acceptedArgs: [
-      { name: "core-root", description: "WordPress develop checkout root inside the sandbox.", format: "sandbox path" },
-      { name: "tests-dir", description: "Core tests directory inside the sandbox.", format: "sandbox path" },
-      { name: "phpunit-xml", description: "phpunit.xml path.", format: "path" },
-      { name: "test-file", description: "Single test file to run.", format: "path" },
-      { name: "changed-tests-json", description: "Changed test files for diagnostics.", format: "JSON array" },
-      { name: "autoload-file", description: "Autoload path inside the sandbox.", format: "sandbox path" },
-      { name: "wp-config-defines-json", description: "wp-config.php constants for the run.", format: "JSON object" },
-      { name: "multisite", description: "Run as multisite.", format: "boolean" },
-    ],
-    outputShape: "Raw PHPUnit runner JSON/log output plus normalized test-results artifact when artifacts are collected.",
-    policyRequirement: "Runtime policy commands must include wordpress.core-phpunit.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.theme-check",
-    description: "Run Theme Check against a mounted WordPress theme inside the disposable Playground runtime.",
-    acceptedArgs: [
-      { name: "theme", description: "Theme slug under wp-content/themes.", required: true, format: "slug" },
-    ],
-    outputShape: "Normalized Theme Check JSON plus files/theme-check raw and normalized artifacts.",
-    policyRequirement: "Runtime policy commands must include wordpress.theme-check.",
-    recipe: true,
-  },
-  {
-    id: "wordpress.browser-probe",
-    description: "Open the live Playground preview in Playwright and capture generic browser replay/audit evidence artifacts.",
-    acceptedArgs: [
-      { name: "url", description: "Preview path or absolute URL to visit.", required: true, format: "path or URL" },
-      { name: "wait-for", description: "Navigation wait condition.", format: "domcontentloaded|load|networkidle|selector:<selector>|duration" },
-      { name: "duration", description: "Extra capture duration, or wait time when wait-for=duration.", format: "duration, e.g. 2s or 500ms" },
-      { name: "capture", description: "Comma-separated artifacts to capture.", format: "console,errors,html,network,screenshot" },
-    ],
-    outputShape: "JSON summary plus files/browser/console.jsonl, errors.jsonl, network.jsonl, snapshot.html, summary.json, and screenshot.png when captured.",
-    policyRequirement: "Runtime policy commands must include wordpress.browser-probe.",
-    recipe: true,
-  },
-  {
-    id: "wp-codebox.agent-runtime-probe",
-    description: "Recipe-only probe that boots Agents API, Data Machine, and Data Machine Code and verifies the stack loads.",
-    acceptedArgs: [
-      { name: "provider-plugin-slugs", description: "Comma-separated provider plugin slugs already mounted by recipe inputs.", format: "comma-separated slugs" },
-    ],
-    outputShape: "JSON probe result emitted by the sandbox PHP runner.",
-    policyRequirement: "Recipe policy maps this helper to wordpress.run-php.",
-    recipe: true,
-  },
-  {
-    id: "wp-codebox.agent-sandbox-run",
-    description: "Recipe-only helper that runs one natural-language task through the sandboxed agent stack.",
-    acceptedArgs: [
-      { name: "task", description: "Task prompt for the sandbox agent.", required: true, format: "string" },
-      { name: "agent", description: "Agent slug.", format: "string" },
-      { name: "mode", description: "Agent mode.", format: "string" },
-      { name: "provider", description: "AI provider id.", format: "string" },
-      { name: "model", description: "Model id.", format: "string" },
-      { name: "session-id", description: "Conversation session id.", format: "string" },
-      { name: "max-turns", description: "Maximum agent loop turns.", format: "positive integer" },
-      { name: "provider-plugin-slugs", description: "Comma-separated provider plugin slugs already mounted by recipe inputs.", format: "comma-separated slugs" },
-      { name: "code", description: "Inline PHP runner override for operator/debug use.", format: "PHP string" },
-      { name: "code-file", description: "Path to PHP runner override for operator/debug use.", format: "path" },
-    ],
-    outputShape: "JSON agent run result emitted by the sandbox PHP runner.",
-    policyRequirement: "Recipe policy maps this helper to wordpress.run-php.",
-    recipe: true,
-  },
-]
-const supportedRecipeCommands = new Set(commandCatalog.filter((command) => command.recipe).map((command) => command.id))
+const supportedRecipeCommands = new Set(recipeCommandDefinitions().map((command) => command.id))
 const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
   $id: "wp-codebox/workspace-recipe/v1",
@@ -1027,7 +852,7 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
       additionalProperties: false,
       required: ["command"],
       properties: {
-        command: { enum: commandCatalog.filter((command) => command.recipe).map((command) => command.id) },
+        command: { enum: recipeCommandDefinitions().map((command) => command.id) },
         args: {
           type: "array",
           items: { type: "string" },
@@ -1421,7 +1246,7 @@ function printWorkspacePolicyHumanOutput(output: WorkspacePolicyResult): void {
 function commandCatalogOutput(): CommandCatalogOutput {
   return {
     schema: "wp-codebox/command-catalog/v1",
-    commands: commandCatalog,
+    commands: commandRegistry.map(({ handler, ...metadata }) => metadata),
   }
 }
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -12,6 +12,215 @@ export const RUNTIME_EPISODE_OBSERVATION_SCHEMA = "wp-codebox/runtime-episode-ob
 export const RUNTIME_EPISODE_SNAPSHOT_SCHEMA = "wp-codebox/runtime-episode-snapshot/v1" as const
 export const RUNTIME_REFERENCE_MANIFEST_SCHEMA = "wp-codebox/runtime-reference-manifest/v1" as const
 
+export type CommandHandlerBinding =
+  | { kind: "playground"; method: string }
+  | { kind: "recipe-alias"; command: string }
+
+export interface CommandDefinition {
+  id: string
+  description: string
+  acceptedArgs: Array<{
+    name: string
+    description: string
+    required?: boolean
+    repeatable?: boolean
+    format?: string
+  }>
+  outputShape: string
+  policyRequirement: string
+  recipe: boolean
+  handler: CommandHandlerBinding
+}
+
+export const commandRegistry = [
+  {
+    id: "inspect-mounted-inputs",
+    description: "List mounted input entries visible inside the Playground runtime.",
+    acceptedArgs: [],
+    outputShape: "JSON array of mounted input descriptors.",
+    policyRequirement: "Runtime policy commands must include inspect-mounted-inputs.",
+    recipe: true,
+    handler: { kind: "playground", method: "inspectMountedInputs" },
+  },
+  {
+    id: "wordpress.run-php",
+    description: "Run PHP against WordPress, bootstrapping wp-load.php unless bootstrap=none is supplied.",
+    acceptedArgs: [
+      { name: "code", description: "Inline PHP code to run.", format: "PHP string" },
+      { name: "code-file", description: "Path to a PHP file whose contents should run.", format: "path" },
+      { name: "bootstrap", description: "Use bootstrap=none to skip wp-load.php.", format: "wordpress|none" },
+    ],
+    outputShape: "Raw command stdout from the PHP snippet.",
+    policyRequirement: "Runtime policy commands must include wordpress.run-php.",
+    recipe: true,
+    handler: { kind: "playground", method: "runPhp" },
+  },
+  {
+    id: "wordpress.wp-cli",
+    description: "Run a WP-CLI command inside the same disposable WordPress runtime.",
+    acceptedArgs: [
+      { name: "command", description: "WP-CLI command line, with or without the leading wp token.", required: true, format: "string" },
+    ],
+    outputShape: "Raw WP-CLI stdout.",
+    policyRequirement: "Runtime policy commands must include wordpress.wp-cli.",
+    recipe: true,
+    handler: { kind: "playground", method: "runWpCli" },
+  },
+  {
+    id: "wordpress.ability",
+    description: "Execute a registered WordPress Ability in the sandbox.",
+    acceptedArgs: [
+      { name: "name", description: "Ability name to execute.", required: true, format: "string" },
+      { name: "input", description: "Ability input payload.", format: "JSON object" },
+    ],
+    outputShape: "JSON object with command, name, input, and result fields.",
+    policyRequirement: "Runtime policy commands must include wordpress.ability.",
+    recipe: true,
+    handler: { kind: "playground", method: "runAbility" },
+  },
+  {
+    id: "wordpress.bench",
+    description: "Run plugin benchmark workloads and emit a Homeboy-compatible BenchResults envelope.",
+    acceptedArgs: [
+      { name: "component-id", description: "Component id for the BenchResults envelope.", format: "string" },
+      { name: "plugin-slug", description: "Plugin slug containing tests/bench workloads.", required: true, format: "slug" },
+      { name: "iterations", description: "Measured iterations per workload.", format: "positive integer" },
+      { name: "warmup", description: "Warmup iterations before measurement.", format: "non-negative integer" },
+      { name: "dependency-slugs", description: "Comma-separated plugin dependency slugs to load.", format: "comma-separated slugs" },
+      { name: "env-json", description: "Benchmark environment object.", format: "JSON object" },
+      { name: "workloads-json", description: "Explicit workload list.", format: "JSON array" },
+    ],
+    outputShape: "BenchResults JSON envelope with component_id, iterations, and scenarios.",
+    policyRequirement: "Runtime policy commands must include wordpress.bench.",
+    recipe: true,
+    handler: { kind: "playground", method: "runBench" },
+  },
+  {
+    id: "wordpress.phpunit",
+    description: "Run plugin PHPUnit tests with normalized diagnostics and test-result artifact capture.",
+    acceptedArgs: [
+      { name: "plugin-slug", description: "Plugin slug under wp-content/plugins.", format: "slug" },
+      { name: "code", description: "Inline override PHP runner code.", format: "PHP string" },
+      { name: "code-file", description: "Path to override PHP runner code.", format: "path" },
+      { name: "autoload-file", description: "PHPUnit/vendor autoload path inside the sandbox.", format: "sandbox path" },
+      { name: "tests-dir", description: "WP PHPUnit tests directory inside the sandbox.", format: "sandbox path" },
+      { name: "phpunit-xml", description: "phpunit.xml path inside the plugin.", format: "path" },
+      { name: "test-file", description: "Single test file to run.", format: "path" },
+      { name: "changed-tests-json", description: "Changed test files for diagnostics.", format: "JSON array" },
+      { name: "env-json", description: "PHPUnit environment values.", format: "JSON object" },
+      { name: "wp-config-defines-json", description: "wp-config.php constants for the run.", format: "JSON object" },
+      { name: "dependency-mounts", description: "Comma-separated mounted dependency paths.", format: "comma-separated sandbox paths" },
+      { name: "multisite", description: "Run as multisite.", format: "boolean" },
+    ],
+    outputShape: "Raw PHPUnit runner JSON/log output plus normalized test-results artifact when artifacts are collected.",
+    policyRequirement: "Runtime policy commands must include wordpress.phpunit.",
+    recipe: true,
+    handler: { kind: "playground", method: "runPhpunit" },
+  },
+  {
+    id: "wordpress.plugin-check",
+    description: "Run the official WordPress Plugin Check plugin against a mounted plugin and emit normalized findings.",
+    acceptedArgs: [
+      { name: "plugin-slug", description: "Plugin slug under wp-content/plugins to validate.", required: true, format: "slug" },
+      { name: "checks", description: "Optional comma-separated official Plugin Check slugs to run; omit to run the default suite.", format: "comma-separated check slugs" },
+    ],
+    outputShape: "wp-codebox/plugin-check/v1 JSON with command, target plugin, exit code/status, summary counts, and findings; raw and normalized outputs are captured in artifacts.",
+    policyRequirement: "Runtime policy commands must include wordpress.plugin-check.",
+    recipe: true,
+    handler: { kind: "playground", method: "runPluginCheck" },
+  },
+  {
+    id: "wordpress.core-phpunit",
+    description: "Run WordPress core PHPUnit tests with normalized diagnostics and test-result artifact capture.",
+    acceptedArgs: [
+      { name: "core-root", description: "WordPress develop checkout root inside the sandbox.", format: "sandbox path" },
+      { name: "tests-dir", description: "Core tests directory inside the sandbox.", format: "sandbox path" },
+      { name: "phpunit-xml", description: "phpunit.xml path.", format: "path" },
+      { name: "test-file", description: "Single test file to run.", format: "path" },
+      { name: "changed-tests-json", description: "Changed test files for diagnostics.", format: "JSON array" },
+      { name: "autoload-file", description: "Autoload path inside the sandbox.", format: "sandbox path" },
+      { name: "wp-config-defines-json", description: "wp-config.php constants for the run.", format: "JSON object" },
+      { name: "multisite", description: "Run as multisite.", format: "boolean" },
+    ],
+    outputShape: "Raw PHPUnit runner JSON/log output plus normalized test-results artifact when artifacts are collected.",
+    policyRequirement: "Runtime policy commands must include wordpress.core-phpunit.",
+    recipe: true,
+    handler: { kind: "playground", method: "runCorePhpunit" },
+  },
+  {
+    id: "wordpress.theme-check",
+    description: "Run Theme Check against a mounted WordPress theme inside the disposable Playground runtime.",
+    acceptedArgs: [
+      { name: "theme", description: "Theme slug under wp-content/themes.", required: true, format: "slug" },
+    ],
+    outputShape: "Normalized Theme Check JSON plus files/theme-check raw and normalized artifacts.",
+    policyRequirement: "Runtime policy commands must include wordpress.theme-check.",
+    recipe: true,
+    handler: { kind: "playground", method: "runThemeCheck" },
+  },
+  {
+    id: "wordpress.browser-probe",
+    description: "Open the live Playground preview in Playwright and capture generic browser replay/audit evidence artifacts.",
+    acceptedArgs: [
+      { name: "url", description: "Preview path or absolute URL to visit.", required: true, format: "path or URL" },
+      { name: "wait-for", description: "Navigation wait condition.", format: "domcontentloaded|load|networkidle|selector:<selector>|duration" },
+      { name: "duration", description: "Extra capture duration, or wait time when wait-for=duration.", format: "duration, e.g. 2s or 500ms" },
+      { name: "capture", description: "Comma-separated artifacts to capture.", format: "console,errors,html,network,screenshot" },
+    ],
+    outputShape: "JSON summary plus files/browser/console.jsonl, errors.jsonl, network.jsonl, snapshot.html, summary.json, and screenshot.png when captured.",
+    policyRequirement: "Runtime policy commands must include wordpress.browser-probe.",
+    recipe: true,
+    handler: { kind: "playground", method: "runBrowserProbe" },
+  },
+  {
+    id: "wp-codebox.agent-runtime-probe",
+    description: "Recipe-only probe that boots Agents API, Data Machine, and Data Machine Code and verifies the stack loads.",
+    acceptedArgs: [
+      { name: "provider-plugin-slugs", description: "Comma-separated provider plugin slugs already mounted by recipe inputs.", format: "comma-separated slugs" },
+    ],
+    outputShape: "JSON probe result emitted by the sandbox PHP runner.",
+    policyRequirement: "Recipe policy maps this helper to wordpress.run-php.",
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "wordpress.run-php" },
+  },
+  {
+    id: "wp-codebox.agent-sandbox-run",
+    description: "Recipe-only helper that runs one natural-language task through the sandboxed agent stack.",
+    acceptedArgs: [
+      { name: "task", description: "Task prompt for the sandbox agent.", required: true, format: "string" },
+      { name: "agent", description: "Agent slug.", format: "string" },
+      { name: "mode", description: "Agent mode.", format: "string" },
+      { name: "provider", description: "AI provider id.", format: "string" },
+      { name: "model", description: "Model id.", format: "string" },
+      { name: "session-id", description: "Conversation session id.", format: "string" },
+      { name: "max-turns", description: "Maximum agent loop turns.", format: "positive integer" },
+      { name: "provider-plugin-slugs", description: "Comma-separated provider plugin slugs already mounted by recipe inputs.", format: "comma-separated slugs" },
+      { name: "code", description: "Inline PHP runner override for operator/debug use.", format: "PHP string" },
+      { name: "code-file", description: "Path to PHP runner override for operator/debug use.", format: "path" },
+    ],
+    outputShape: "JSON agent run result emitted by the sandbox PHP runner.",
+    policyRequirement: "Recipe policy maps this helper to wordpress.run-php.",
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "wordpress.run-php" },
+  },
+] as const satisfies readonly CommandDefinition[]
+
+export type CommandId = typeof commandRegistry[number]["id"]
+export type PlaygroundRuntimeCommandDefinition = Extract<typeof commandRegistry[number], { handler: { kind: "playground" } }>
+export type PlaygroundRuntimeCommandId = PlaygroundRuntimeCommandDefinition["id"]
+
+export function getCommandDefinition(command: string): CommandDefinition | undefined {
+  return commandRegistry.find((definition) => definition.id === command)
+}
+
+export function runtimeCommandDefinitions(): CommandDefinition[] {
+  return commandRegistry.filter((definition) => definition.handler.kind === "playground")
+}
+
+export function recipeCommandDefinitions(): CommandDefinition[] {
+  return commandRegistry.filter((definition) => definition.recipe)
+}
+
 export const RUNTIME_EPISODE_TRACE_JSON_SCHEMA = {
   $id: RUNTIME_EPISODE_TRACE_SCHEMA,
   type: "object",

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -3,7 +3,7 @@ import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "n
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
 import { basename, dirname, join, relative, resolve } from "node:path"
-import { RUNTIME_EPISODE_OBSERVATION_SCHEMA, assertRuntimeCommandAllowed, buildRuntimeReferenceManifest, calculateArtifactManifestFileSha256, runtimeEpisodeDigest } from "@chubes4/wp-codebox-core"
+import { RUNTIME_EPISODE_OBSERVATION_SCHEMA, assertRuntimeCommandAllowed, buildRuntimeReferenceManifest, calculateArtifactManifestFileSha256, getCommandDefinition, runtimeEpisodeDigest, type PlaygroundRuntimeCommandId } from "@chubes4/wp-codebox-core"
 import {
   MAX_CAPTURED_MOUNT_FILE_BYTES,
   MAX_CAPTURED_MOUNT_FILES,
@@ -257,7 +257,24 @@ export class PlaygroundRuntimeBackend implements RuntimeBackend {
   }
 }
 
+export function playgroundRuntimeCommandIds(): string[] {
+  return Object.keys(PlaygroundRuntime.commandHandlers)
+}
+
 class PlaygroundRuntime implements Runtime {
+  static readonly commandHandlers = {
+    "inspect-mounted-inputs": (runtime) => runtime.inspectMountedInputs(),
+    "wordpress.run-php": (runtime, spec) => runtime.runPhp(spec),
+    "wordpress.wp-cli": (runtime, spec) => runtime.runWpCli(spec),
+    "wordpress.ability": (runtime, spec) => runtime.runAbility(spec),
+    "wordpress.bench": (runtime, spec) => runtime.runBench(spec),
+    "wordpress.phpunit": (runtime, spec) => runtime.runPhpunit(spec),
+    "wordpress.plugin-check": (runtime, spec) => runtime.runPluginCheck(spec),
+    "wordpress.core-phpunit": (runtime, spec) => runtime.runCorePhpunit(spec),
+    "wordpress.theme-check": (runtime, spec) => runtime.runThemeCheck(spec),
+    "wordpress.browser-probe": (runtime, spec) => runtime.runBrowserProbe(spec),
+  } satisfies Record<PlaygroundRuntimeCommandId, (runtime: PlaygroundRuntime, spec: ExecutionSpec) => Promise<string> | string>
+
   private status: RuntimeInfo["status"] = "created"
   private readonly runtimeId = id("runtime")
   private readonly createdAt = now()
@@ -887,44 +904,13 @@ class PlaygroundRuntime implements Runtime {
   }
 
   private async executePlaygroundCommand(spec: ExecutionSpec): Promise<string> {
-    if (spec.command === "inspect-mounted-inputs") {
-      return this.inspectMountedInputs()
-    }
-
-    if (spec.command === "wordpress.run-php") {
-      return this.runPhp(spec)
-    }
-
-    if (spec.command === "wordpress.wp-cli") {
-      return this.runWpCli(spec)
-    }
-
-    if (spec.command === "wordpress.ability") {
-      return this.runAbility(spec)
-    }
-
-    if (spec.command === "wordpress.bench") {
-      return this.runBench(spec)
-    }
-
-    if (spec.command === "wordpress.phpunit") {
-      return this.runPhpunit(spec)
-    }
-
-    if (spec.command === "wordpress.plugin-check") {
-      return this.runPluginCheck(spec)
-    }
-
-    if (spec.command === "wordpress.core-phpunit") {
-      return this.runCorePhpunit(spec)
-    }
-
-    if (spec.command === "wordpress.theme-check") {
-      return this.runThemeCheck(spec)
-    }
-
-    if (spec.command === "wordpress.browser-probe") {
-      return this.runBrowserProbe(spec)
+    const definition = getCommandDefinition(spec.command)
+    if (definition?.handler.kind === "playground") {
+      const handler = PlaygroundRuntime.commandHandlers[definition.id as PlaygroundRuntimeCommandId]
+      if (!handler) {
+        throw new Error(`No Playground command handler is registered for: ${spec.command}`)
+      }
+      return handler(this, spec)
     }
 
     throw new Error(`No Playground command handler is registered for: ${spec.command}`)

--- a/scripts/command-registry-smoke.ts
+++ b/scripts/command-registry-smoke.ts
@@ -1,0 +1,40 @@
+import { commandRegistry, runtimeCommandDefinitions } from "@chubes4/wp-codebox-core"
+import { playgroundRuntimeCommandIds } from "@chubes4/wp-codebox-playground"
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function sorted(values: Iterable<string>): string[] {
+  return [...values].sort((left, right) => left.localeCompare(right))
+}
+
+function main(): void {
+  const registryIds = commandRegistry.map((command) => command.id)
+  assert(new Set(registryIds).size === registryIds.length, "Command registry ids must be unique")
+
+  for (const command of commandRegistry) {
+    assert(command.id.length > 0, "Command id must be non-empty")
+    assert(command.description.length > 0, `${command.id} is missing description`)
+    assert(command.outputShape.length > 0, `${command.id} is missing outputShape`)
+    assert(command.policyRequirement.length > 0, `${command.id} is missing policyRequirement`)
+    assert(Array.isArray(command.acceptedArgs), `${command.id} acceptedArgs must be an array`)
+  }
+
+  const metadataRuntimeIds = new Set(runtimeCommandDefinitions().map((command) => command.id))
+  const handlerRuntimeIds = new Set(playgroundRuntimeCommandIds())
+  const metadataWithoutHandler = sorted([...metadataRuntimeIds].filter((id) => !handlerRuntimeIds.has(id)))
+  const handlerWithoutMetadata = sorted([...handlerRuntimeIds].filter((id) => !metadataRuntimeIds.has(id)))
+
+  assert(metadataWithoutHandler.length === 0, `Command metadata has no Playground handler: ${metadataWithoutHandler.join(", ")}`)
+  assert(handlerWithoutMetadata.length === 0, `Playground handler has no command metadata: ${handlerWithoutMetadata.join(", ")}`)
+
+  for (const command of runtimeCommandDefinitions()) {
+    assert(command.handler.kind === "playground", `${command.id} must bind to a Playground handler`)
+    assert(command.handler.method.length > 0, `${command.id} must name its Playground handler method`)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- Move runtime command metadata into a shared core command registry that records ids, args, recipe support, policy requirements, output shapes, and handler bindings.
- Render CLI command discovery and recipe schema command enums from the shared registry while preserving the public command catalog output shape.
- Dispatch Playground runtime commands through registry-backed handler bindings and add a smoke test that fails on metadata/handler drift.

Closes #235.

## Verification
- `npm run build`
- `npm run command-registry-smoke`
- `npm run discovery-command-smoke`
- `npm run check` was attempted, but the local OpenCode server is already listening on `127.0.0.1:53001`; `@wp-playground/cli` also tried to bind that port during `artifact-contract-smoke`, causing `EADDRINUSE` and the shell timed out.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and applied the registry refactor, drift smoke test, and verification notes for Chris to review.