### PR TITLE
chore: configure WP Codebox releases

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,5 +1,7 @@
 {
   "id": "wp-codebox",
+  "remote_url": "https://github.com/chubes4/wp-codebox.git",
+  "changelog_target": "CHANGELOG.md",
   "extensions": {
     "nodejs": {}
   },
@@ -21,9 +23,17 @@
     {
       "file": "packages/cli/package.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
+      "file": "packages/wordpress-plugin/wp-codebox.php",
+      "pattern": "Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "packages/wordpress-plugin/wp-codebox.php",
+      "pattern": "WP_CODEBOX_PLUGIN_VERSION',\\s*'([0-9.]+)"
     }
   ],
-  "self_checks": {
+  "scripts": {
     "lint": [
       "npm run build"
     ],


### PR DESCRIPTION
## Summary
- Add Homeboy release metadata for WP Codebox.
- Move release preflight checks from legacy `self_checks` to supported `scripts.lint` / `scripts.test`.
- Include WordPress plugin header/version constant targets in release version bumps.

## Testing
- `homeboy lint wp-codebox --path /Users/chubes/Developer/wp-codebox@release-config --summary`
- `homeboy test wp-codebox --path /Users/chubes/Developer/wp-codebox@release-config --json-summary`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updated Homeboy release configuration and ran targeted release preflight checks. Chris remains responsible for review and merge.