### PR TITLE
Harden external browser and recipe sources

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
-import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
-import { createWriteStream } from "node:fs"
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises"
 import { createHash } from "node:crypto"
 import { execFile, spawnSync } from "node:child_process"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, relative, resolve } from "node:path"
-import { Readable } from "node:stream"
-import { pipeline } from "node:stream/promises"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, calculateArtifactManifestFileSha256, checkWorkspacePolicy, commandRegistry, createRuntime, recipeCommandDefinitions, validateRuntimePolicy, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type CommandDefinition, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspacePolicyResult, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@chubes4/wp-codebox-core"
@@ -493,6 +490,15 @@ interface RecipeSourceProvenance {
   resolvedUrl?: string
   digest?: {
     sha256: string
+    expected?: string
+    verified?: boolean
+  }
+  policy?: {
+    host: string
+    maxDownloadBytes: number
+    maxExtractedBytes: number
+    maxExtractedFiles: number
+    sha256Required: boolean
   }
   localPathCategory?: "recipe-relative" | "temporary-download"
 }
@@ -591,7 +597,48 @@ const defaultPolicy: RuntimePolicy = {
 const WP_CODEBOX_RUNTIME_VERSION = "0.0.0"
 const DEFAULT_WORDPRESS_VERSION = "7.0"
 const ALLOW_NETWORK_DOWNLOADS_ENV = "WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS"
+const ALLOWED_DOWNLOAD_HOSTS_ENV = "WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS"
+const REQUIRE_SOURCE_SHA256_ENV = "WP_CODEBOX_REQUIRE_SOURCE_SHA256"
+const MAX_DOWNLOAD_BYTES_ENV = "WP_CODEBOX_MAX_DOWNLOAD_BYTES"
+const MAX_EXTRACTED_BYTES_ENV = "WP_CODEBOX_MAX_EXTRACTED_BYTES"
+const MAX_EXTRACTED_FILES_ENV = "WP_CODEBOX_MAX_EXTRACTED_FILES"
+const DEFAULT_ALLOWED_DOWNLOAD_HOSTS = ["downloads.wordpress.org"]
+const DEFAULT_MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
+const DEFAULT_MAX_EXTRACTED_BYTES = 100 * 1024 * 1024
+const DEFAULT_MAX_EXTRACTED_FILES = 2000
 const execFileAsync = promisify(execFile)
+
+function isSha256(value: string): boolean {
+  return /^[a-f0-9]{64}$/i.test(value)
+}
+
+function sourceSha256Required(): boolean {
+  return process.env[REQUIRE_SOURCE_SHA256_ENV] === "1"
+}
+
+function allowedDownloadHosts(): string[] {
+  const configured = process.env[ALLOWED_DOWNLOAD_HOSTS_ENV]
+  return (configured ? configured.split(",") : DEFAULT_ALLOWED_DOWNLOAD_HOSTS)
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+function envPositiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name] ?? "")
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback
+}
+
+function maxDownloadBytes(): number {
+  return envPositiveInteger(MAX_DOWNLOAD_BYTES_ENV, DEFAULT_MAX_DOWNLOAD_BYTES)
+}
+
+function maxExtractedBytes(): number {
+  return envPositiveInteger(MAX_EXTRACTED_BYTES_ENV, DEFAULT_MAX_EXTRACTED_BYTES)
+}
+
+function maxExtractedFiles(): number {
+  return envPositiveInteger(MAX_EXTRACTED_FILES_ENV, DEFAULT_MAX_EXTRACTED_FILES)
+}
 
 function normalizedWorkspaceSeedExcludePath(value: string): string {
   return value.replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "").replace(/\/+$/, "")
@@ -796,6 +843,7 @@ const workspaceRecipeJsonSchema: RecipeSchemaOutput["jsonSchema"] = {
         slug: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
         pluginFile: { type: "string" },
         activate: { type: "boolean" },
+        sha256: { type: "string", pattern: "^[a-fA-F0-9]{64}$" },
       },
     },
     siteSeed: {
@@ -3438,7 +3486,7 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
     const path = `$.inputs.extra_plugins[${index}]`
     let source: ReturnType<typeof recipeSource>
     try {
-      source = recipeSource(plugin.source)
+      source = recipeSource(plugin.source, plugin.sha256)
     } catch (error) {
       addIssue("invalid-source", `${path}.source`, error instanceof Error ? error.message : String(error))
       continue
@@ -3453,7 +3501,7 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
     }
     const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
 
-    validateRecipeSource(source, `${path}.source`, addIssue)
+    validateRecipeSource(source, `${path}.source`, addIssue, plugin.sha256)
     if (pluginSource) {
       await validateExistingDirectory(pluginSource, `${path}.source`, addIssue)
     }
@@ -3652,7 +3700,7 @@ function validateAbsoluteSandboxPath(path: string, issuePath: string, addIssue: 
   }
 }
 
-function validateRecipeSource(source: ReturnType<typeof recipeSource>, issuePath: string, addIssue: (code: string, path: string, message: string) => void): void {
+function validateRecipeSource(source: ReturnType<typeof recipeSource>, issuePath: string, addIssue: (code: string, path: string, message: string) => void, expectedSha256?: string): void {
   if (source.type === "local") {
     return
   }
@@ -3663,6 +3711,18 @@ function validateRecipeSource(source: ReturnType<typeof recipeSource>, issuePath
       issuePath,
       `External recipe sources require ${ALLOW_NETWORK_DOWNLOADS_ENV}=1 before WP Codebox downloads anything.`,
     )
+  }
+
+  if (!allowedDownloadHosts().includes(source.host)) {
+    addIssue("download-host-not-allowed", issuePath, `External recipe source host is not allowed: ${source.host}`)
+  }
+
+  if (expectedSha256 !== undefined && !isSha256(expectedSha256)) {
+    addIssue("invalid-source-sha256", issuePath, "External recipe source sha256 must be a 64-character hex digest.")
+  }
+
+  if (sourceSha256Required() && !expectedSha256) {
+    addIssue("missing-source-sha256", issuePath, `External recipe sources require sha256 when ${REQUIRE_SOURCE_SHA256_ENV}=1.`)
   }
 }
 
@@ -3725,7 +3785,7 @@ async function recipeDryRunSteps(recipe: WorkspaceRecipe, recipeDirectory: strin
       pluginFile: await resolveRecipeExtraPluginFile(plugin, recipeDirectory),
       activate: plugin.activate !== false,
       cleanupPaths: [],
-      provenance: recipeSourceProvenance(recipeSource(plugin.source), recipeDirectory),
+      provenance: recipeSourceProvenance(recipeSource(plugin.source, plugin.sha256), recipeDirectory),
     }
   }))
   const pluginActivationCode = activateExtraPluginsCode(dryRunExtraPlugins)
@@ -3900,7 +3960,7 @@ function recipeDryRunWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string
 function recipeDryRunExtraPlugins(recipe: WorkspaceRecipe, recipeDirectory: string): RecipeDryRunExtraPlugin[] {
   return recipeExtraPlugins(recipe).map((plugin) => {
     const slug = recipeExtraPluginSlug(plugin)
-    const source = recipeSource(plugin.source)
+    const source = recipeSource(plugin.source, plugin.sha256)
     const provenance = recipeSourceProvenance(source, recipeDirectory)
     return {
       source: source.type === "local" ? resolve(recipeDirectory, plugin.source) : source.resolvedUrl,
@@ -4510,7 +4570,7 @@ async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeDirector
   const plugins: PreparedExtraPlugin[] = []
   for (const plugin of recipeExtraPlugins(recipe)) {
     const slug = recipeExtraPluginSlug(plugin)
-    const resolved = await prepareRecipeSource(plugin.source, recipeDirectory, slug)
+    const resolved = await prepareRecipeSource(plugin.source, recipeDirectory, slug, plugin.sha256)
     const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
     await assertPreparedPluginFileExists(resolved.source, pluginFile.slice(slug.length + 1), plugin.source)
     plugins.push({
@@ -4588,8 +4648,8 @@ async function assertPreparedPluginFileExists(sourceDirectory: string, pluginFil
   throw new Error(`Recipe extra plugin source did not contain expected plugin file ${pluginFileRelativeToSource}: ${sourceRef}`)
 }
 
-async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, slug: string): Promise<PreparedExternalSource> {
-  const source = recipeSource(sourceRef)
+async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, slug: string, expectedSha256?: string): Promise<PreparedExternalSource> {
+  const source = recipeSource(sourceRef, expectedSha256)
   if (source.type === "local") {
     return {
       source: resolve(recipeDirectory, sourceRef),
@@ -4602,33 +4662,103 @@ async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, s
     throw new Error(`External recipe sources require ${ALLOW_NETWORK_DOWNLOADS_ENV}=1 before WP Codebox downloads anything.`)
   }
 
+  if (!allowedDownloadHosts().includes(source.host)) {
+    throw new Error(`External recipe source host is not allowed: ${source.host}`)
+  }
+
   const directory = await mkdtemp(join(tmpdir(), `wp-codebox-source-${slug}-`))
   const zipPath = join(directory, "source.zip")
   const extractDirectory = join(directory, "extracted")
   await mkdir(extractDirectory, { recursive: true })
-  const digest = await downloadRecipeSourceZip(source.resolvedUrl, zipPath)
+  const digest = await downloadRecipeSourceZip(source.resolvedUrl, zipPath, source.expectedSha256)
+  await assertSafeZipEntries(zipPath)
   await execFileAsync("unzip", ["-q", zipPath, "-d", extractDirectory])
+  await assertExtractedSourceBounds(extractDirectory)
 
   return {
     source: await extractedPluginSourceDirectory(extractDirectory, slug),
     cleanupPaths: [directory],
     provenance: {
       ...recipeSourceProvenance(source, recipeDirectory),
-      digest: { sha256: digest },
+      digest: { sha256: digest, ...(source.expectedSha256 ? { expected: source.expectedSha256, verified: true } : {}) },
+      policy: {
+        host: source.host,
+        maxDownloadBytes: maxDownloadBytes(),
+        maxExtractedBytes: maxExtractedBytes(),
+        maxExtractedFiles: maxExtractedFiles(),
+        sha256Required: sourceSha256Required(),
+      },
       localPathCategory: "temporary-download",
     },
   }
 }
 
-async function downloadRecipeSourceZip(url: string, targetPath: string): Promise<string> {
+async function downloadRecipeSourceZip(url: string, targetPath: string, expectedSha256?: string): Promise<string> {
   const response = await fetch(url)
   if (!response.ok || !response.body) {
     throw new Error(`Failed to download recipe source ${url}: HTTP ${response.status}`)
   }
 
-  await pipeline(Readable.fromWeb(response.body as never), createWriteStream(targetPath))
-  const buffer = await readFile(targetPath)
-  return createHash("sha256").update(buffer).digest("hex")
+  const contentLength = Number(response.headers.get("content-length") ?? "0")
+  if (contentLength > maxDownloadBytes()) {
+    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${url}`)
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer())
+  if (buffer.byteLength > maxDownloadBytes()) {
+    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${url}`)
+  }
+
+  const digest = createHash("sha256").update(buffer).digest("hex")
+  if (expectedSha256 && digest !== expectedSha256.toLowerCase()) {
+    throw new Error(`Recipe source sha256 mismatch for ${url}: expected ${expectedSha256.toLowerCase()}, got ${digest}`)
+  }
+
+  await writeFile(targetPath, buffer)
+  return digest
+}
+
+async function assertSafeZipEntries(zipPath: string): Promise<void> {
+  const { stdout } = await execFileAsync("unzip", ["-Z1", zipPath])
+  const entries = stdout.split(/\r?\n/).filter(Boolean)
+  if (entries.length > maxExtractedFiles()) {
+    throw new Error(`Recipe source zip contains too many entries: ${entries.length}`)
+  }
+
+  for (const entry of entries) {
+    const normalized = entry.replace(/\\/g, "/")
+    if (normalized.startsWith("/") || normalized.split("/").includes("..")) {
+      throw new Error(`Recipe source zip contains an unsafe path: ${entry}`)
+    }
+  }
+}
+
+async function assertExtractedSourceBounds(directory: string): Promise<void> {
+  const totals = await directoryTotals(directory)
+  if (totals.files > maxExtractedFiles()) {
+    throw new Error(`Recipe source extraction contains too many files: ${totals.files}`)
+  }
+  if (totals.bytes > maxExtractedBytes()) {
+    throw new Error(`Recipe source extraction exceeds ${maxExtractedBytes()} bytes: ${totals.bytes}`)
+  }
+}
+
+async function directoryTotals(directory: string): Promise<{ files: number; bytes: number }> {
+  let files = 0
+  let bytes = 0
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      const child = await directoryTotals(path)
+      files += child.files
+      bytes += child.bytes
+    } else if (entry.isFile()) {
+      const result = await stat(path)
+      files += 1
+      bytes += result.size
+    }
+  }
+  return { files, bytes }
 }
 
 async function extractedPluginSourceDirectory(extractDirectory: string, slug: string): Promise<string> {
@@ -4780,12 +4910,12 @@ function recipeExtraPlugins(recipe: WorkspaceRecipe): WorkspaceRecipeExtraPlugin
   return recipe.inputs?.extra_plugins ?? recipe.inputs?.extraPlugins ?? []
 }
 
-function recipeSource(sourceRef: string): { type: RecipeSourceType; resolvedUrl: string; wporgSlug?: string } {
+function recipeSource(sourceRef: string, expectedSha256?: string): { type: RecipeSourceType; resolvedUrl: string; host: string; expectedSha256?: string; wporgSlug?: string } {
   let url: URL
   try {
     url = new URL(sourceRef)
   } catch {
-    return { type: "local", resolvedUrl: sourceRef }
+    return { type: "local", resolvedUrl: sourceRef, host: "" }
   }
 
   if (url.protocol !== "https:") {
@@ -4799,10 +4929,10 @@ function recipeSource(sourceRef: string): { type: RecipeSourceType; resolvedUrl:
   if (url.hostname === "downloads.wordpress.org" && url.pathname.startsWith("/plugin/")) {
     const filename = basename(url.pathname)
     const match = filename.match(/^([A-Za-z0-9_-]+)\./)
-    return { type: "wporg_plugin_zip", resolvedUrl: url.toString(), ...(match ? { wporgSlug: match[1] } : {}) }
+    return { type: "wporg_plugin_zip", resolvedUrl: url.toString(), host: url.hostname, ...(expectedSha256 ? { expectedSha256: expectedSha256.toLowerCase() } : {}), ...(match ? { wporgSlug: match[1] } : {}) }
   }
 
-  return { type: "https_zip", resolvedUrl: url.toString() }
+  return { type: "https_zip", resolvedUrl: url.toString(), host: url.hostname, ...(expectedSha256 ? { expectedSha256: expectedSha256.toLowerCase() } : {}) }
 }
 
 function recipeSourceProvenance(source: ReturnType<typeof recipeSource>, recipeDirectory: string): RecipeSourceProvenance {
@@ -4818,6 +4948,14 @@ function recipeSourceProvenance(source: ReturnType<typeof recipeSource>, recipeD
     kind: source.type,
     original: source.resolvedUrl,
     resolvedUrl: source.resolvedUrl,
+    ...(source.expectedSha256 ? { digest: { sha256: source.expectedSha256, expected: source.expectedSha256, verified: false } } : {}),
+    policy: {
+      host: source.host,
+      maxDownloadBytes: maxDownloadBytes(),
+      maxExtractedBytes: maxExtractedBytes(),
+      maxExtractedFiles: maxExtractedFiles(),
+      sha256Required: sourceSha256Required(),
+    },
   }
 }
 
@@ -4826,7 +4964,7 @@ function recipeExtraPluginSlug(plugin: WorkspaceRecipeExtraPlugin): string {
     return plugin.slug
   }
 
-  const source = recipeSource(plugin.source)
+  const source = recipeSource(plugin.source, plugin.sha256)
   if (source.wporgSlug) {
     return source.wporgSlug
   }
@@ -4849,7 +4987,7 @@ async function resolveRecipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin, 
     return plugin.pluginFile
   }
 
-  const source = recipeSource(plugin.source)
+  const source = recipeSource(plugin.source, plugin.sha256)
   if (source.type === "local") {
     const pluginSource = resolve(recipeDirectory, plugin.source)
     for (const candidate of [`${slug}/${slug}.php`, `${slug}/plugin.php`]) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4699,6 +4699,18 @@ async function downloadRecipeSourceZip(url: string, targetPath: string, expected
     throw new Error(`Failed to download recipe source ${url}: HTTP ${response.status}`)
   }
 
+  const finalUrl = response.url || url
+  let finalSource: ReturnType<typeof recipeSource>
+  try {
+    finalSource = recipeSource(finalUrl, expectedSha256)
+  } catch (error) {
+    throw new Error(`Recipe source redirected to an invalid URL: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  if (finalSource.type === "local" || !allowedDownloadHosts().includes(finalSource.host)) {
+    throw new Error(`Recipe source redirected to a host that is not allowed: ${finalSource.host || finalUrl}`)
+  }
+
   const contentLength = Number(response.headers.get("content-length") ?? "0")
   if (contentLength > maxDownloadBytes()) {
     throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${url}`)

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -411,6 +411,7 @@ export interface WorkspaceRecipeExtraPlugin {
   slug?: string
   pluginFile?: string
   activate?: boolean
+  sha256?: string
 }
 
 export type WorkspaceRecipeSiteSeedType = "fixture" | "parent_site"

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -325,7 +325,15 @@ final class WP_Codebox_Abilities {
 							'browser_plugins'    => array(
 								'type'        => 'array',
 								'description' => 'Optional plugin zip URLs the browser Playground should install and activate before running the recipe.',
-								'items'       => array( 'type' => 'object' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'slug'     => array( 'type' => 'string' ),
+										'url'      => array( 'type' => 'string' ),
+										'activate' => array( 'type' => 'boolean' ),
+										'sha256'   => array( 'type' => 'string' ),
+									),
+								),
 							),
 							'blueprint'          => array(
 								'type'        => 'object',
@@ -830,7 +838,11 @@ final class WP_Codebox_Abilities {
 			$session_id = self::generate_id();
 		}
 
-		$playground     = is_array( $input['playground'] ?? null ) ? $input['playground'] : array();
+		$playground = self::browser_playground( $input );
+		if ( is_wp_error( $playground ) ) {
+			return $playground;
+		}
+
 		$browser_runner = is_array( $input['browser_runner'] ?? null ) ? $input['browser_runner'] : array();
 		$browser_plugins = self::browser_plugins( $input );
 		if ( is_wp_error( $browser_plugins ) ) {
@@ -871,8 +883,8 @@ final class WP_Codebox_Abilities {
 			'agent'      => (string) ( $input['agent'] ?? 'wp-codebox-sandbox' ),
 			'plugins'    => $browser_plugins,
 			'playground' => array(
-				'client_module_url'  => (string) ( $playground['client_module_url'] ?? 'https://playground.automattic.ai/client/index.js' ),
-				'remote_url'         => (string) ( $playground['remote_url'] ?? 'https://playground.automattic.ai/remote.html' ),
+				'client_module_url'  => $playground['client_module_url'],
+				'remote_url'         => $playground['remote_url'],
 				'scope'              => (string) ( $playground['scope'] ?? $session_id ),
 				'artifact_base_path' => self::browser_artifact_base_path( $playground ),
 				'artifact_base_url'  => self::browser_artifact_base_url( $playground ),
@@ -884,6 +896,7 @@ final class WP_Codebox_Abilities {
 					'write_file'        => true,
 					'run_php'           => true,
 				),
+				'provenance'         => $playground['provenance'],
 			),
 			'recipe'     => $recipe,
 			'signals'    => array(
@@ -934,8 +947,8 @@ final class WP_Codebox_Abilities {
 			'agent'      => (string) ( $input['agent'] ?? 'wp-codebox-sandbox' ),
 			'plugins'    => $browser_plugins,
 			'playground' => array(
-				'client_module_url'  => (string) ( $playground['client_module_url'] ?? 'https://playground.automattic.ai/client/index.js' ),
-				'remote_url'         => (string) ( $playground['remote_url'] ?? 'https://playground.automattic.ai/remote.html' ),
+				'client_module_url'  => $playground['client_module_url'],
+				'remote_url'         => $playground['remote_url'],
 				'scope'              => (string) ( $playground['scope'] ?? $session_id ),
 				'artifact_base_path' => self::browser_artifact_base_path( $playground ),
 				'artifact_base_url'  => self::browser_artifact_base_url( $playground ),
@@ -947,6 +960,7 @@ final class WP_Codebox_Abilities {
 					'write_file'        => true,
 					'run_php'           => true,
 				),
+				'provenance'         => $playground['provenance'],
 			),
 			'signals'    => array(
 				'ready_to_code' => $ready_to_code,
@@ -1130,6 +1144,65 @@ final class WP_Codebox_Abilities {
 		return $normalized;
 	}
 
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private static function browser_playground( array $input ): array|WP_Error {
+		$playground = is_array( $input['playground'] ?? null ) ? $input['playground'] : array();
+		$client     = self::browser_trusted_url(
+			(string) ( $playground['client_module_url'] ?? 'https://playground.automattic.ai/client/index.js' ),
+			'client_module_url',
+			'wp_codebox_browser_playground_allowed_origins',
+			array( 'https://playground.automattic.ai' )
+		);
+		if ( is_wp_error( $client ) ) {
+			return $client;
+		}
+
+		$remote = self::browser_trusted_url(
+			(string) ( $playground['remote_url'] ?? 'https://playground.automattic.ai/remote.html' ),
+			'remote_url',
+			'wp_codebox_browser_playground_allowed_origins',
+			array( 'https://playground.automattic.ai' )
+		);
+		if ( is_wp_error( $remote ) ) {
+			return $remote;
+		}
+
+		$playground['client_module_url'] = $client['url'];
+		$playground['remote_url']        = $remote['url'];
+		$playground['provenance']        = array(
+			'schema'            => 'wp-codebox/browser-playground-provenance/v1',
+			'client_module_url' => $client,
+			'remote_url'        => $remote,
+		);
+
+		return $playground;
+	}
+
+	/** @return array{url:string,origin:string,host:string} | WP_Error */
+	private static function browser_trusted_url( string $url, string $field, string $filter, array $default_allowed_origins ): array|WP_Error {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return new WP_Error( 'wp_codebox_browser_url_invalid', 'Browser Playground URL must be absolute.', array( 'status' => 400, 'field' => $field ) );
+		}
+
+		$scheme = strtolower( (string) $parts['scheme'] );
+		if ( 'https' !== $scheme ) {
+			return new WP_Error( 'wp_codebox_browser_url_insecure', 'Browser Playground URL must use https://.', array( 'status' => 400, 'field' => $field ) );
+		}
+
+		$origin  = self::url_origin( $parts );
+		$allowed = self::normalized_origins( apply_filters( $filter, $default_allowed_origins, $field, $url ) );
+		if ( ! in_array( $origin, $allowed, true ) ) {
+			return new WP_Error( 'wp_codebox_browser_origin_not_allowed', 'Browser Playground URL origin is not allowed.', array( 'status' => 400, 'field' => $field, 'origin' => $origin ) );
+		}
+
+		return array(
+			'url'    => $url,
+			'origin' => $origin,
+			'host'   => strtolower( (string) $parts['host'] ),
+		);
+	}
+
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
 	private static function browser_plugins( array $input ): array|WP_Error {
 		$plugins = is_array( $input['browser_plugins'] ?? null ) ? $input['browser_plugins'] : array();
@@ -1142,18 +1215,77 @@ final class WP_Codebox_Abilities {
 
 			$url = trim( (string) ( $plugin['url'] ?? '' ) );
 			$slug = self::safe_key( (string) ( $plugin['slug'] ?? '' ) );
-			if ( '' === $url || ! preg_match( '#^https?://#i', $url ) ) {
-				return new WP_Error( 'wp_codebox_browser_plugin_url_invalid', 'Browser plugin URL must be an http or https URL.', array( 'status' => 400, 'index' => $index ) );
+			$source = self::browser_plugin_url( $url, $index );
+			if ( is_wp_error( $source ) ) {
+				return $source;
+			}
+
+			$sha256 = strtolower( trim( (string) ( $plugin['sha256'] ?? '' ) ) );
+			if ( '' !== $sha256 && ! preg_match( '/^[a-f0-9]{64}$/', $sha256 ) ) {
+				return new WP_Error( 'wp_codebox_browser_plugin_sha256_invalid', 'Browser plugin sha256 must be a 64-character hex digest.', array( 'status' => 400, 'index' => $index ) );
 			}
 
 			$normalized[] = array(
-				'url'      => $url,
+				'url'      => $source['url'],
 				'slug'     => $slug,
 				'activate' => ! array_key_exists( 'activate', $plugin ) || (bool) $plugin['activate'],
+				'provenance' => array_filter(
+					array(
+						'schema' => 'wp-codebox/browser-plugin-provenance/v1',
+						'url'    => $source['url'],
+						'origin' => $source['origin'],
+						'host'   => $source['host'],
+						'sha256' => $sha256,
+					)
+				),
 			);
 		}
 
 		return $normalized;
+	}
+
+	/** @return array{url:string,origin:string,host:string}|WP_Error */
+	private static function browser_plugin_url( string $url, int $index ): array|WP_Error {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_url_invalid', 'Browser plugin URL must be absolute.', array( 'status' => 400, 'index' => $index ) );
+		}
+
+		$scheme     = strtolower( (string) $parts['scheme'] );
+		$allow_http = (bool) apply_filters( 'wp_codebox_browser_plugin_allow_http', false, $url, $index );
+		if ( 'https' !== $scheme && ! ( $allow_http && 'http' === $scheme ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_url_insecure', 'Browser plugin URL must use https://.', array( 'status' => 400, 'index' => $index ) );
+		}
+
+		$origin        = self::url_origin( $parts );
+		$default_hosts = array( 'downloads.wordpress.org' );
+		$allowed_hosts = array_map( 'strtolower', self::string_list( apply_filters( 'wp_codebox_browser_plugin_allowed_hosts', $default_hosts, $url, $index ) ) );
+		$host          = strtolower( (string) $parts['host'] );
+		if ( ! in_array( $host, $allowed_hosts, true ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_host_not_allowed', 'Browser plugin URL host is not allowed.', array( 'status' => 400, 'index' => $index, 'host' => $host ) );
+		}
+
+		return array( 'url' => $url, 'origin' => $origin, 'host' => $host );
+	}
+
+	/** @param array<string,string|int> $parts URL parts. */
+	private static function url_origin( array $parts ): string {
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
+		$host   = strtolower( (string) ( $parts['host'] ?? '' ) );
+		$port   = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
+		return $scheme . '://' . $host . $port;
+	}
+
+	/** @return string[] */
+	private static function normalized_origins( mixed $origins ): array {
+		$normalized = array();
+		foreach ( self::string_list( $origins ) as $origin ) {
+			$parts = wp_parse_url( $origin );
+			if ( is_array( $parts ) && ! empty( $parts['scheme'] ) && ! empty( $parts['host'] ) ) {
+				$normalized[] = self::url_origin( $parts );
+			}
+		}
+		return array_values( array_unique( $normalized ) );
 	}
 
 	private static function safe_key( string $value ): string {

--- a/scripts/recipe-dry-run-smoke.ts
+++ b/scripts/recipe-dry-run-smoke.ts
@@ -11,6 +11,8 @@ const recipePath = resolve(workspace, "recipe.json")
 const invalidRecipePath = resolve(workspace, "invalid-recipe.json")
 const externalRecipePath = resolve(workspace, "external-recipe.json")
 const externalDisabledRecipePath = resolve(workspace, "external-disabled-recipe.json")
+const externalUntrustedHostRecipePath = resolve(workspace, "external-untrusted-host-recipe.json")
+const externalStrictDigestRecipePath = resolve(workspace, "external-strict-digest-recipe.json")
 const invalidSiteSeedRecipePath = resolve(workspace, "invalid-site-seed-recipe.json")
 const fixtureSeedPath = resolve(workspace, "fixture-seed.json")
 const dryRunArtifacts = resolve(workspace, "dry-run-artifacts")
@@ -150,6 +152,29 @@ const externalRecipe = {
 
 writeFileSync(externalRecipePath, `${JSON.stringify(externalRecipe, null, 2)}\n`)
 writeFileSync(externalDisabledRecipePath, `${JSON.stringify(externalRecipe, null, 2)}\n`)
+writeFileSync(externalUntrustedHostRecipePath, `${JSON.stringify({
+  ...externalRecipe,
+  inputs: {
+    extraPlugins: [
+      {
+        source: "https://evil.example/plugin.zip",
+        slug: "evil-plugin",
+        pluginFile: "evil-plugin/evil-plugin.php",
+      },
+    ],
+  },
+}, null, 2)}\n`)
+writeFileSync(externalStrictDigestRecipePath, `${JSON.stringify({
+  ...externalRecipe,
+  inputs: {
+    extraPlugins: [
+      {
+        source: "https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
+        pluginFile: "bbpress/bbpress.php",
+      },
+    ],
+  },
+}, null, 2)}\n`)
 
 const result = spawnSync(process.execPath, [
   cli,
@@ -238,7 +263,7 @@ const externalResult = spawnSync(process.execPath, [
   externalRecipePath,
   "--dry-run",
   "--json",
-], { cwd: root, encoding: "utf8", env: { ...process.env, WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS: "1" } })
+], { cwd: root, encoding: "utf8", env: { ...process.env, WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS: "1", WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS: "downloads.wordpress.org,example.com" } })
 
 assert.equal(externalResult.status, 0, externalResult.stderr || externalResult.stdout)
 const externalOutput = JSON.parse(externalResult.stdout)
@@ -248,6 +273,35 @@ assert.equal(externalOutput.plan.extra_plugins[0].sourceType, "wporg_plugin_zip"
 assert.equal(externalOutput.plan.extra_plugins[0].provenance.resolvedUrl, "https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip")
 assert.equal(externalOutput.plan.extra_plugins[1].sourceType, "https_zip")
 assert.equal(externalOutput.plan.extra_plugins[1].provenance.kind, "https_zip")
+assert.equal(externalOutput.plan.extra_plugins[1].provenance.policy.host, "example.com")
+
+const externalUntrustedHostResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  externalUntrustedHostRecipePath,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8", env: { ...process.env, WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS: "1" } })
+
+assert.equal(externalUntrustedHostResult.status, 1, externalUntrustedHostResult.stderr || externalUntrustedHostResult.stdout)
+const externalUntrustedHostOutput = JSON.parse(externalUntrustedHostResult.stdout)
+assert.equal(externalUntrustedHostOutput.success, false)
+assert.equal(externalUntrustedHostOutput.validation.issues[0].code, "download-host-not-allowed")
+
+const externalStrictDigestResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  externalStrictDigestRecipePath,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8", env: { ...process.env, WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS: "1", WP_CODEBOX_REQUIRE_SOURCE_SHA256: "1" } })
+
+assert.equal(externalStrictDigestResult.status, 1, externalStrictDigestResult.stderr || externalStrictDigestResult.stdout)
+const externalStrictDigestOutput = JSON.parse(externalStrictDigestResult.stdout)
+assert.equal(externalStrictDigestOutput.success, false)
+assert.equal(externalStrictDigestOutput.validation.issues[0].code, "missing-source-sha256")
 
 const externalDisabledResult = spawnSync(process.execPath, [
   cli,

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -121,6 +121,7 @@ function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 
 	return $filter;
 }
+function wp_parse_url( string $url ): array|false { return parse_url( $url ); }
 function is_multisite(): bool { return (bool) ( $GLOBALS['wp_codebox_is_multisite'] ?? false ); }
 function get_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_options'][ $name ] ?? $default; }
 function get_site_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_site_options'][ $name ] ?? $default; }
@@ -329,6 +330,7 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_default_agent'] = 'site-coder';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model'] = 'gpt-5.5';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_secret_env'] = array( 'OPENAI_API_KEY' );
+$GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org' );
 $GLOBALS['wp_codebox_mock_abilities']['agents/chat'] = new WP_Ability();
 mkdir( $root . '/plugin-root/data-machine', 0777, true );
 mkdir( $root . '/plugin-root/data-machine-code', 0777, true );
@@ -346,8 +348,9 @@ $browser_session = call_user_func(
 		'orchestrator'          => array( 'id' => 'studio-web' ),
 		'browser_plugins'       => array(
 			array(
-				'slug' => 'agents-api',
-				'url'  => 'https://example.test/agents-api.zip',
+				'slug'   => 'agents-api',
+				'url'    => 'https://example.test/agents-api.zip',
+				'sha256' => str_repeat( 'a', 64 ),
 			),
 		),
 		'artifact_files'        => array(
@@ -369,6 +372,8 @@ $assert( 'browser Playground session includes default blueprint', ! is_wp_error(
 $assert( 'browser Playground session defaults to latest WordPress and PHP', ! is_wp_error( $browser_session ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['wp'] ?? '' ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['php'] ?? '' ) );
 $assert( 'browser Playground session logs in before admin workflows', ! is_wp_error( $browser_session ) && 'login' === ( $browser_session['playground']['blueprint']['steps'][0]['step'] ?? '' ) && 'admin' === ( $browser_session['playground']['blueprint']['steps'][0]['username'] ?? '' ) );
 $assert( 'browser Playground session installs browser plugins', ! is_wp_error( $browser_session ) && 'installPlugin' === ( $browser_session['playground']['blueprint']['steps'][1]['step'] ?? '' ) && 'https://example.test/agents-api.zip' === ( $browser_session['playground']['blueprint']['steps'][1]['pluginData']['url'] ?? '' ) );
+$assert( 'browser Playground session records trusted origins', ! is_wp_error( $browser_session ) && 'https://playground.automattic.ai' === ( $browser_session['playground']['provenance']['client_module_url']['origin'] ?? '' ) );
+$assert( 'browser Playground session records browser plugin provenance', ! is_wp_error( $browser_session ) && 'example.test' === ( $browser_session['plugins'][0]['provenance']['host'] ?? '' ) && str_repeat( 'a', 64 ) === ( $browser_session['plugins'][0]['provenance']['sha256'] ?? '' ) );
 $assert( 'browser Playground session includes recipe', ! is_wp_error( $browser_session ) && 'wp-codebox/workspace-recipe/v1' === ( $browser_session['recipe']['schema'] ?? '' ) );
 $assert( 'browser Playground recipe calls agents/chat inside site', ! is_wp_error( $browser_session ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), "wp_get_ability( 'agents/chat' )" ) );
 $assert( 'browser Playground recipe guards permission bypass to Playground', ! is_wp_error( $browser_session ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), "'Emscripten' === PHP_OS_FAMILY" ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_codebox_browser_runner_not_playground' ) );
@@ -402,6 +407,33 @@ $browser_not_allowlisted_tool = call_user_func(
 );
 $assert( 'browser Playground session rejects tools outside configured allow-list before recipe emission', is_wp_error( $browser_not_allowlisted_tool ) && 'wp_codebox_tool_not_allowed' === $browser_not_allowlisted_tool->get_error_code() && 'not-allowlisted' === ( $browser_not_allowlisted_tool->get_error_data()['denied_tools'][0]['reason'] ?? '' ) );
 unset( $GLOBALS['wp_codebox_filters']['wp_codebox_allowed_sandbox_tools'] );
+
+$browser_insecure_plugin_url = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'            => 'Prepare a browser preview with an insecure plugin URL.',
+		'browser_plugins' => array( array( 'url' => 'http://example.test/plugin.zip' ) ),
+	)
+);
+$assert( 'browser Playground session rejects insecure browser plugin URLs', is_wp_error( $browser_insecure_plugin_url ) && 'wp_codebox_browser_plugin_url_insecure' === $browser_insecure_plugin_url->get_error_code() );
+
+$browser_untrusted_plugin_host = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'            => 'Prepare a browser preview with an untrusted plugin host.',
+		'browser_plugins' => array( array( 'url' => 'https://evil.example/plugin.zip' ) ),
+	)
+);
+$assert( 'browser Playground session rejects untrusted browser plugin hosts', is_wp_error( $browser_untrusted_plugin_host ) && 'wp_codebox_browser_plugin_host_not_allowed' === $browser_untrusted_plugin_host->get_error_code() );
+
+$browser_untrusted_playground_origin = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'       => 'Prepare a browser preview with an untrusted Playground client.',
+		'playground' => array( 'client_module_url' => 'https://evil.example/client.js' ),
+	)
+);
+$assert( 'browser Playground session rejects untrusted Playground origins', is_wp_error( $browser_untrusted_playground_origin ) && 'wp_codebox_browser_origin_not_allowed' === $browser_untrusted_playground_origin->get_error_code() );
 
 $browser_session_missing_prereqs = call_user_func(
 	$browser_session_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Harden browser Playground client/remote URLs and plugin zip URLs with HTTPS and trusted origin/host policy checks.
- Add external recipe download host policy, post-redirect host validation, optional/strict SHA-256 support, size caps, zip traversal checks, extraction bounds, and provenance metadata.
- Cover rejected schemes, untrusted hosts, strict digest requirements, and provenance in smoke tests.

Closes #234.

## Verification
- `npm run check`
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run recipe-dry-run-smoke`
- Controller rerun after redirected-host validation: `npm run build`, `npm run wordpress-plugin-smoke`, `npm run recipe-dry-run-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused hardening implementation, tests, and verification steps for Chris to review.