### PR TITLE
Clarify agent task execution paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,13 @@ The WordPress plugin registers parent-site abilities:
 - `wp-codebox/apply-approved-artifact`
 - `wp-codebox/stage-artifact-apply`
 
-These abilities shell out to the local `wp-codebox` CLI, boot disposable Playground sandboxes, mount the configured agent stack, invoke the sandbox agent through `agents/chat`, and return artifact metadata.
+Canonical agent-task execution paths are intentionally split by caller runtime:
+
+- Server/host execution uses `wp-codebox/run-agent-task` or `wp-codebox/run-agent-task-batch`. These abilities shell out to local `wp-codebox recipe-run`, boot disposable Playground sandboxes, mount the configured agent stack, invoke the sandbox agent through `agents/chat`, and return artifact metadata.
+- Portable CLI execution uses `wp-codebox recipe-run --recipe <path>`. Recipes use the `wp-codebox.agent-sandbox-run` helper step when they need the agent-task bridge; direct `agent-sandbox-run` remains an operator/debug command, not the product API for frontend callers.
+- No-Node/browser execution uses `wp-codebox/create-browser-playground-session`. The host prepares a browser-executable Playground recipe and runner payload; the browser executes `wordpress.run-php` inside Playground instead of requiring host shell or Node access.
+
+All three paths use the same `wp-codebox/task-input/v1` task input contract. Host and browser paths also emit the same `wp-codebox/sandbox-session/v1` session envelope so product callers can correlate prepared browser sessions and completed host runs without transport-specific metadata drift.
 
 `wp-codebox/run-agent-task-batch` runs one isolated sandbox per task sequentially and returns per-task status, artifact id, preview URL, and error fields. Parent orchestrators own any parallel fan-out above this ability.
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -703,8 +703,8 @@ final class WP_Codebox_Abilities {
 				),
 				'status'           => array(
 					'type'        => 'string',
-					'enum'        => array( 'completed' ),
-					'description' => 'Synchronous WP Codebox run status. Durable queued/running/cancelled/expired state belongs to the external orchestrator.',
+					'enum'        => array( 'ready', 'completed' ),
+					'description' => 'Synchronous WP Codebox preparation/run status. Durable queued/running/cancelled/expired state belongs to the external orchestrator.',
 				),
 				'persistence'      => array(
 					'type'        => 'string',
@@ -809,15 +809,8 @@ final class WP_Codebox_Abilities {
 			'execution'        => 'browser-playground',
 			'execution_scope'  => 'disposable-playground',
 			'permission_model' => 'sandbox-bypass',
-			'session'          => array(
-				'schema'       => 'wp-codebox/browser-playground-session/v1',
-				'id'           => $session_id,
-				'status'       => 'ready',
-				'persistence'  => 'external-orchestrator',
-				'execution_scope'  => 'disposable-playground',
-				'permission_model' => 'sandbox-bypass',
-				'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
-			),
+			'session'          => self::browser_session_envelope( $session_id, 'ready', $input ),
+			'task'             => (string) $task_input['goal'],
 			'task_input' => $task_input,
 			'agent'      => (string) ( $input['agent'] ?? 'wp-codebox-sandbox' ),
 			'plugins'    => $browser_plugins,
@@ -873,15 +866,8 @@ final class WP_Codebox_Abilities {
 				'message' => 'Browser Playground sandbox is missing required coding prerequisites.',
 				'missing' => $ready_to_code['missing'] ?? array(),
 			),
-			'session'          => array(
-				'schema'           => 'wp-codebox/browser-playground-session/v1',
-				'id'               => $session_id,
-				'status'           => 'blocked',
-				'persistence'      => 'external-orchestrator',
-				'execution_scope'  => 'disposable-playground',
-				'permission_model' => 'sandbox-bypass',
-				'orchestrator'     => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
-			),
+			'session'          => self::browser_session_envelope( $session_id, 'blocked', $input ),
+			'task'             => (string) $task_input['goal'],
 			'task_input' => $task_input,
 			'agent'      => (string) ( $input['agent'] ?? 'wp-codebox-sandbox' ),
 			'plugins'    => $browser_plugins,
@@ -911,6 +897,15 @@ final class WP_Codebox_Abilities {
 				'expected_artifacts' => $task_input['expected_artifacts'],
 			),
 		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function browser_session_envelope( string $session_id, string $status, array $input ): array {
+		$session = WP_Codebox_Agent_Task::session( $session_id, $status, $input );
+		$session['execution_scope']  = 'disposable-playground';
+		$session['permission_model'] = 'sandbox-bypass';
+
+		return $session;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
@@ -1013,34 +1008,12 @@ final class WP_Codebox_Abilities {
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	private static function normalize_task_input( array $input ): array|WP_Error {
-		$task_input = WP_Codebox_Task_Input_Contract::normalize( $input );
-		if ( is_wp_error( $task_input ) ) {
-			return $task_input;
-		}
-
-		$tool_error = ( new WP_Codebox_Agent_Sandbox_Runner() )->validate_allowed_tools( $task_input['allowed_tools'] );
-		if ( is_wp_error( $tool_error ) ) {
-			return $tool_error;
-		}
-
-		return $task_input;
+		return WP_Codebox_Agent_Task::normalize_input( $input, fn( array $tools ): WP_Error|null => ( new WP_Codebox_Agent_Sandbox_Runner() )->validate_allowed_tools( $tools ), true );
 	}
 
 	/** @return string[] */
 	private static function string_list( mixed $value ): array {
-		if ( ! is_array( $value ) ) {
-			return array();
-		}
-
-		$items = array();
-		foreach ( $value as $item ) {
-			$item = trim( (string) $item );
-			if ( '' !== $item && ! in_array( $item, $items, true ) ) {
-				$items[] = $item;
-			}
-		}
-
-		return $items;
+		return WP_Codebox_Agent_Task::string_list( $value );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,string>>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -780,7 +780,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	private function task_input( array $input ): array|WP_Error {
-		return WP_Codebox_Agent_Task::normalize_input( $input, fn( array $tools ): WP_Error|null => $this->allowed_tools_error( $tools ) );
+		return WP_Codebox_Agent_Task::normalize_input( $input, fn( array $tools ): WP_Error|null => $this->validate_allowed_tools( $tools ) );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -11,8 +11,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	private const SCHEMA = 'wp-codebox/agent-task-run/v1';
 	private const BATCH_SCHEMA = 'wp-codebox/agent-task-batch/v1';
-	private const SESSION_SCHEMA = 'wp-codebox/sandbox-session/v1';
-	private const TASK_INPUT_SCHEMA = WP_Codebox_Task_Input_Contract::SCHEMA;
+	private const SESSION_SCHEMA = WP_Codebox_Agent_Task::SESSION_SCHEMA;
+	private const TASK_INPUT_SCHEMA = WP_Codebox_Agent_Task::INPUT_SCHEMA;
 	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
 	private const REMEDIATION_OUTCOME_SCHEMA = 'wp-codebox/agent-sandbox-remediation-outcome/v1';
 	private const SANDBOX_TOOL_POLICY_FILE = __DIR__ . '/generated-sandbox-datamachine-tool-policy.php';
@@ -780,17 +780,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	private function task_input( array $input ): array|WP_Error {
-		$task_input = WP_Codebox_Task_Input_Contract::normalize( $input );
-		if ( is_wp_error( $task_input ) ) {
-			return $task_input;
-		}
-
-		$tool_error = $this->validate_allowed_tools( $task_input['allowed_tools'] );
-		if ( is_wp_error( $tool_error ) ) {
-			return $tool_error;
-		}
-
-		return $task_input;
+		return WP_Codebox_Agent_Task::normalize_input( $input, fn( array $tools ): WP_Error|null => $this->allowed_tools_error( $tools ) );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
@@ -812,9 +802,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $task_input Normalized task input. */
 	private function task_input_prompt( array $task_input ): string {
-		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $task_input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $task_input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-
-		return is_string( $encoded ) ? $encoded : '';
+		return WP_Codebox_Agent_Task::prompt( $task_input );
 	}
 
 	/** @return string[] */
@@ -1844,37 +1832,19 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $run Decoded CLI run output. */
 	private function sandbox_session( string $session_id, string $status, array $input, array $run, string $artifacts ): array {
-		$session = array(
-			'schema'      => self::SESSION_SCHEMA,
-			'id'          => $session_id,
-			'status'      => $status,
-			'persistence' => 'external-orchestrator',
-			'artifacts'   => array_filter(
+		return WP_Codebox_Agent_Task::session(
+			$session_id,
+			$status,
+			$input,
+			array_filter(
 				array(
-					'path'       => $artifacts,
-					'bundle_id'  => is_array( $run['artifacts'] ?? null ) ? (string) ( $run['artifacts']['id'] ?? '' ) : '',
+					'path'        => $artifacts,
+					'bundle_id'   => is_array( $run['artifacts'] ?? null ) ? (string) ( $run['artifacts']['id'] ?? '' ) : '',
 					'preview_url' => is_array( $run['artifacts']['preview'] ?? null ) ? (string) ( $run['artifacts']['preview']['url'] ?? '' ) : '',
 				),
 				static fn( mixed $value ): bool => '' !== $value
-			),
+			)
 		);
-
-		if ( ! empty( $input['session_id'] ) ) {
-			$session['agent_session_id'] = (string) $input['session_id'];
-		}
-
-		if ( isset( $input['orchestrator'] ) && is_array( $input['orchestrator'] ) ) {
-			$session['orchestrator'] = array_filter(
-				array(
-					'id'     => isset( $input['orchestrator']['id'] ) ? (string) $input['orchestrator']['id'] : '',
-					'type'   => isset( $input['orchestrator']['type'] ) ? (string) $input['orchestrator']['type'] : '',
-					'job_id' => isset( $input['orchestrator']['job_id'] ) ? (string) $input['orchestrator']['job_id'] : '',
-				),
-				static fn( mixed $value ): bool => '' !== $value
-			);
-		}
-
-		return $session;
 	}
 
 	private function error_payload( WP_Error $error ): array {

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Shared WP Codebox agent task helpers.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Agent_Task {
+
+	public const INPUT_SCHEMA = WP_Codebox_Task_Input_Contract::SCHEMA;
+	public const SESSION_SCHEMA = 'wp-codebox/sandbox-session/v1';
+
+	/**
+	 * Normalize the caller-facing task input used by host and browser transports.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @param callable|null       $allowed_tools_validator Optional validator for host-only tool policy.
+	 * @param bool                $keep_empty Whether to keep empty optional fields for preparation payloads.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function normalize_input( array $input, ?callable $allowed_tools_validator = null, bool $keep_empty = false ): array|WP_Error {
+		unset( $keep_empty );
+
+		$task_input = WP_Codebox_Task_Input_Contract::normalize( $input );
+		if ( is_wp_error( $task_input ) ) {
+			return $task_input;
+		}
+
+		if ( ! empty( $task_input['allowed_tools'] ) && null !== $allowed_tools_validator ) {
+			$error = $allowed_tools_validator( $task_input['allowed_tools'] );
+			if ( is_wp_error( $error ) ) {
+				return $error;
+			}
+		}
+
+		return $task_input;
+	}
+
+	/** @param array<string,mixed> $task_input Normalized task input. */
+	public static function prompt( array $task_input ): string {
+		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $task_input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $task_input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		return is_string( $encoded ) ? $encoded : '';
+	}
+
+	/**
+	 * Build the common sandbox session envelope emitted by host and browser paths.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @param array<string,mixed> $artifacts Artifact refs.
+	 * @return array<string,mixed>
+	 */
+	public static function session( string $session_id, string $status, array $input, array $artifacts = array() ): array {
+		$session = array(
+			'schema'      => self::SESSION_SCHEMA,
+			'id'          => $session_id,
+			'status'      => $status,
+			'persistence' => 'external-orchestrator',
+		);
+
+		if ( ! empty( $artifacts ) ) {
+			$session['artifacts'] = $artifacts;
+		}
+
+		if ( ! empty( $input['session_id'] ) ) {
+			$session['agent_session_id'] = (string) $input['session_id'];
+		}
+
+		if ( isset( $input['orchestrator'] ) && is_array( $input['orchestrator'] ) ) {
+			$session['orchestrator'] = array_filter(
+				array(
+					'id'     => isset( $input['orchestrator']['id'] ) ? (string) $input['orchestrator']['id'] : '',
+					'type'   => isset( $input['orchestrator']['type'] ) ? (string) $input['orchestrator']['type'] : '',
+					'job_id' => isset( $input['orchestrator']['job_id'] ) ? (string) $input['orchestrator']['job_id'] : '',
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			);
+		}
+
+		return $session;
+	}
+
+	/** @return string[] */
+	public static function string_list( mixed $values ): array {
+		if ( ! is_array( $values ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map(
+						static fn( $value ): string => trim( (string) $value ),
+						$values
+					),
+					static fn( string $value ): bool => '' !== $value
+				)
+			)
+		);
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -20,6 +20,7 @@ define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-data-machine-pending-actions.php';

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -142,6 +142,7 @@ function get_terms( array $args ): array { return array( new WP_Term( 3, 'catego
 function get_users( array $args ): array { return array( new WP_User( 11, 'Private User', array( 'editor' ) ) ); }
 
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php';
@@ -308,7 +309,7 @@ $assert( 'ability exposes inheritance request schema', 'object' === ( $ability['
 $assert( 'ability exposes connector credential envelope schema', 'object' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['type'] ?? '' ) && 'array' === ( $ability['input_schema']['properties']['inherit']['properties']['credentials']['properties']['secrets']['type'] ?? '' ) );
 $assert( 'ability exposes external sandbox session schema', 'string' === ( $ability['input_schema']['properties']['sandbox_session_id']['type'] ?? '' ) && 'object' === ( $ability['input_schema']['properties']['orchestrator']['type'] ?? '' ) && 'object' === ( $ability['output_schema']['properties']['session']['type'] ?? '' ) );
 $assert( 'session schema pins external orchestrator persistence', array( 'external-orchestrator' ) === ( $ability['output_schema']['properties']['session']['properties']['persistence']['enum'] ?? array() ) && str_contains( $ability['output_schema']['properties']['session']['properties']['persistence']['description'] ?? '', 'does not persist' ) );
-$assert( 'session schema keeps durable lifecycle external', array( 'completed' ) === ( $ability['output_schema']['properties']['session']['properties']['status']['enum'] ?? array() ) && str_contains( $ability['output_schema']['properties']['session']['properties']['status']['description'] ?? '', 'external orchestrator' ) );
+$assert( 'session schema keeps durable lifecycle external', array( 'ready', 'completed' ) === ( $ability['output_schema']['properties']['session']['properties']['status']['enum'] ?? array() ) && str_contains( $ability['output_schema']['properties']['session']['properties']['status']['description'] ?? '', 'external orchestrator' ) );
 $assert( 'ability exposes preview configuration schema', 'integer' === ( $ability['input_schema']['properties']['preview_port']['type'] ?? '' ) && 'string' === ( $ability['input_schema']['properties']['preview_bind']['type'] ?? '' ) && 'string' === ( $ability['input_schema']['properties']['preview_public_url']['type'] ?? '' ) );
 $assert( 'ability exposes strict remediation outcome schema', isset( $ability['output_schema']['properties']['outcome']['properties']['kind']['enum'] ) && in_array( 'provider_error', $ability['output_schema']['properties']['outcome']['properties']['kind']['enum'], true ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
@@ -390,6 +391,7 @@ $assert( 'browser Playground session schema is stable', ! is_wp_error( $browser_
 $assert( 'browser Playground session pins browser execution', ! is_wp_error( $browser_session ) && 'browser-playground' === ( $browser_session['execution'] ?? '' ) );
 $assert( 'browser Playground session identifies disposable execution scope', ! is_wp_error( $browser_session ) && 'disposable-playground' === ( $browser_session['execution_scope'] ?? '' ) && 'disposable-playground' === ( $browser_session['session']['execution_scope'] ?? '' ) );
 $assert( 'browser Playground session identifies sandbox permission model', ! is_wp_error( $browser_session ) && 'sandbox-bypass' === ( $browser_session['permission_model'] ?? '' ) && 'sandbox-bypass' === ( $browser_session['session']['permission_model'] ?? '' ) );
+$assert( 'browser Playground session emits canonical sandbox session envelope', ! is_wp_error( $browser_session ) && 'wp-codebox/sandbox-session/v1' === ( $browser_session['session']['schema'] ?? '' ) && 'browser-session-123' === ( $browser_session['session']['id'] ?? '' ) && 'ready' === ( $browser_session['session']['status'] ?? '' ) && 'external-orchestrator' === ( $browser_session['session']['persistence'] ?? '' ) );
 $assert( 'browser Playground session includes Playground client URLs', ! is_wp_error( $browser_session ) && str_contains( $browser_session['playground']['client_module_url'] ?? '', 'playground.automattic.ai' ) && str_contains( $browser_session['playground']['remote_url'] ?? '', 'playground.automattic.ai' ) );
 $assert( 'browser Playground session includes default blueprint', ! is_wp_error( $browser_session ) && true === ( $browser_session['playground']['blueprint']['features']['networking'] ?? false ) && is_array( $browser_session['playground']['blueprint']['steps'] ?? null ) );
 $assert( 'browser Playground session defaults to latest WordPress and PHP', ! is_wp_error( $browser_session ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['wp'] ?? '' ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['php'] ?? '' ) );
@@ -407,6 +409,7 @@ $assert( 'browser Playground session exposes artifact URL paths', ! is_wp_error(
 $assert( 'browser Playground session exposes preview URL', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['playground']['preview_url'] ?? '' ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['preview_url'] ?? '' ) );
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
 $assert( 'browser Playground session returns canonical task input metadata', ! is_wp_error( $browser_session ) && 'wp-codebox/task-input/v1' === ( $browser_session['task_input']['schema'] ?? '' ) && 1 === ( $browser_session['task_input']['version'] ?? 0 ) );
+$assert( 'browser Playground session exposes canonical task string', ! is_wp_error( $browser_session ) && 'Prepare a Studio Web browser preview.' === ( $browser_session['task'] ?? '' ) );
 
 $browser_parent_only_tool = call_user_func(
 	$browser_session_ability['execute_callback'],
@@ -926,6 +929,15 @@ $assert( 'runner normalizes task input lists', ! is_wp_error( $structured_result
 $assert( 'runner returns canonical structured task input shape', ! is_wp_error( $structured_result ) && array_key_exists( 'context', $structured_result['task_input'] ?? array() ) && 1 === ( $structured_result['task_input']['version'] ?? 0 ) );
 $assert( 'runner passes structured task contract to recipe', str_contains( $captured_recipe, 'wp-codebox/task-input/v1' ) && str_contains( $captured_recipe, 'allowed_tools' ) );
 $assert( 'runner leaves preview config unset by default', ! str_contains( $captured_command, '--preview-port' ) && ! str_contains( $captured_command, '--preview-bind' ) && ! str_contains( $captured_command, '--preview-public-url' ) );
+
+$host_browser_equivalent_input = array(
+	'goal'               => 'Prepare a Studio Web browser preview.',
+	'target'             => array( 'kind' => 'static-site' ),
+	'allowed_tools'      => array( 'filesystem-write', 'filesystem-write', '' ),
+	'expected_artifacts' => array( 'static-site' ),
+);
+$host_browser_equivalent_task = WP_Codebox_Agent_Task::normalize_input( $host_browser_equivalent_input );
+$assert( 'host and browser preparation share task input normalization', ! is_wp_error( $host_browser_equivalent_task ) && array_intersect_key( $browser_session['task_input'] ?? array(), $host_browser_equivalent_task ) === $host_browser_equivalent_task );
 
 $remediation_artifact_run = function ( string $name, array $files ): array {
 	$directory = sys_get_temp_dir() . '/wp-codebox-remediation-artifact-' . $name . '-' . uniqid( '', true );


### PR DESCRIPTION
## Summary
- Adds a shared WordPress plugin helper for canonical agent task input and sandbox session metadata.
- Aligns host and browser task preparation around `wp-codebox/task-input/v1` and `wp-codebox/sandbox-session/v1`.
- Documents the canonical host, portable CLI, and browser execution paths.

Fixes #229.

## Verification
- `npm run build` - passed after rebase
- `npm run wordpress-plugin-smoke` - passed after rebase, OK (214 assertions)
- `git diff --check origin/main...HEAD` - passed after rebase
- Earlier branch verification before the rebase included `npm run package-distribution-smoke`, `npm run plugin-check-normalization-smoke`, and `npm run runtime-episode-smoke` on rerun after an initial transient local Playground port collision.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting the shared helper, focused docs/tests updates, verification triage, rebase conflict resolution, and PR preparation; Chris remains responsible for review and merge.