### PR TITLE
Emit runtime replay reference index

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -13,6 +13,7 @@ export const RUNTIME_EPISODE_OBSERVATION_SCHEMA = "wp-codebox/runtime-episode-ob
 export const RUNTIME_EPISODE_SNAPSHOT_SCHEMA = "wp-codebox/runtime-episode-snapshot/v1" as const
 export const RUNTIME_REFERENCE_MANIFEST_SCHEMA = "wp-codebox/runtime-reference-manifest/v1" as const
 export const RUNTIME_ACTION_OBSERVATION_SCHEMA = "wp-codebox/runtime-action-observation/v1" as const
+export const RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA = "wp-codebox/runtime-replay-reference-index/v1" as const
 
 export type CommandHandlerBinding =
   | { kind: "playground"; method: string }
@@ -1188,6 +1189,54 @@ export interface RuntimeReferenceManifest {
   snapshots: RuntimeReferenceManifestSnapshotRef[]
 }
 
+export interface RuntimeReplayReferenceIndexActionRef {
+  index: number
+  id: string
+  actionRef: RuntimeEpisodeTraceRef
+  executionRef: RuntimeEpisodeTraceRef
+  observationRef?: RuntimeEpisodeTraceRef
+}
+
+export interface RuntimeReplayReferenceIndexObservationRef {
+  id: string
+  type: string
+  ref: RuntimeEpisodeTraceRef
+  artifactRefs: RuntimeEpisodeTraceRef[]
+}
+
+export interface RuntimeReplayReferenceIndex {
+  schema: typeof RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA
+  version: 1
+  id: string
+  createdAt: string
+  digest: RuntimeEpisodeContentDigest
+  runtime: RuntimeInfo
+  artifactBundle: RuntimeReferenceManifestArtifactBundleRef
+  references: {
+    trace?: RuntimeReferenceManifestFileRef
+    events?: RuntimeReferenceManifestFileRef
+    runtimeReferenceManifest?: RuntimeReferenceManifestFileRef
+    observations?: RuntimeReferenceManifestFileRef
+    commands?: RuntimeReferenceManifestFileRef
+    runtimeEvents?: RuntimeReferenceManifestFileRef
+    blueprintAfter?: RuntimeReferenceManifestFileRef
+    blueprintAfterNotes?: RuntimeReferenceManifestFileRef
+    mountedFiles?: RuntimeReferenceManifestFileRef
+    mountDiffs?: RuntimeReferenceManifestFileRef
+    changedFiles?: RuntimeReferenceManifestFileRef
+    patch?: RuntimeReferenceManifestFileRef
+    testResults?: RuntimeReferenceManifestFileRef
+  }
+  actions: RuntimeReplayReferenceIndexActionRef[]
+  observations: RuntimeReplayReferenceIndexObservationRef[]
+  snapshots: RuntimeReferenceManifestSnapshotRef[]
+  replay: {
+    status: "partial" | RuntimeSnapshotReplayStatus
+    instructions: string[]
+    limitations: string[]
+  }
+}
+
 export interface BuildRuntimeReferenceManifestInput {
   createdAt: string
   runtime: RuntimeInfo
@@ -1196,6 +1245,18 @@ export interface BuildRuntimeReferenceManifestInput {
   trace?: RuntimeReferenceManifestFileRef
   events?: RuntimeReferenceManifestFileRef
   snapshots?: Snapshot[]
+}
+
+export interface BuildRuntimeReplayReferenceIndexInput {
+  createdAt: string
+  runtime: RuntimeInfo
+  artifactBundle: RuntimeReferenceManifestArtifactBundleRef
+  files: RuntimeReferenceManifestFileRef[]
+  trace?: RuntimeReferenceManifestFileRef
+  events?: RuntimeReferenceManifestFileRef
+  runtimeReferenceManifest?: RuntimeReferenceManifestFileRef
+  snapshots?: Snapshot[]
+  episodeTrace?: RuntimeEpisodeTrace
 }
 
 export interface ArtifactProvenance {
@@ -1273,6 +1334,7 @@ export interface ArtifactReview {
     testResults?: string
     runtimeEpisodeTrace?: string
     runtimeReferenceManifest?: string
+    runtimeReplayReferenceIndex?: string
     agentResult?: string
     transcript?: string
   }
@@ -1389,6 +1451,7 @@ export interface ArtifactBundle {
   artifactVerificationPath?: string
   workspacePolicyPath?: string
   runtimeReferenceManifestPath?: string
+  runtimeReplayReferenceIndexPath?: string
   preview?: ArtifactPreview
   contentDigest: string
   createdAt: string
@@ -1502,6 +1565,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   await verifyReviewEvidence(bundleDirectory, manifest, manifestFiles, violations)
   await verifyRuntimeEpisodeTraceArtifacts(bundleDirectory, manifest, violations)
   await verifyRuntimeReferenceManifestArtifacts(bundleDirectory, manifest, manifestFiles, violations)
+  await verifyRuntimeReplayReferenceIndexArtifacts(bundleDirectory, manifest, manifestFiles, violations)
 
   return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
 }
@@ -1674,6 +1738,68 @@ function isRuntimeReferenceManifestSnapshotRefShape(value: unknown): value is Ru
     && value.artifactRefs.every((ref) => isRecord(ref) && typeof ref.kind === "string" && typeof ref.id === "string" && validDigest(ref.digest))
 }
 
+function isRuntimeReplayReferenceIndexShape(value: unknown): value is RuntimeReplayReferenceIndex {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return value.schema === RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA
+    && value.version === 1
+    && typeof value.id === "string"
+    && typeof value.createdAt === "string"
+    && isArtifactFileDigestShape(value.digest)
+    && isRecord(value.runtime)
+    && isRuntimeReferenceManifestArtifactBundleRefShape(value.artifactBundle)
+    && isRuntimeReplayReferenceIndexReferencesShape(value.references)
+    && Array.isArray(value.actions)
+    && value.actions.every(isRuntimeReplayReferenceIndexActionRefShape)
+    && Array.isArray(value.observations)
+    && value.observations.every(isRuntimeReplayReferenceIndexObservationRefShape)
+    && Array.isArray(value.snapshots)
+    && value.snapshots.every(isRuntimeReferenceManifestSnapshotRefShape)
+    && isRecord(value.replay)
+    && typeof value.replay.status === "string"
+    && Array.isArray(value.replay.instructions)
+    && value.replay.instructions.every((instruction) => typeof instruction === "string")
+    && Array.isArray(value.replay.limitations)
+    && value.replay.limitations.every((limitation) => typeof limitation === "string")
+}
+
+function isRuntimeReplayReferenceIndexReferencesShape(value: unknown): value is RuntimeReplayReferenceIndex["references"] {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return Object.values(value).every((reference) => reference === undefined || isRuntimeReferenceManifestFileRefShape(reference))
+}
+
+function isRuntimeReplayReferenceIndexActionRefShape(value: unknown): value is RuntimeReplayReferenceIndexActionRef {
+  return isRecord(value)
+    && typeof value.index === "number"
+    && typeof value.id === "string"
+    && isRuntimeEpisodeTraceRefShape(value.actionRef)
+    && isRuntimeEpisodeTraceRefShape(value.executionRef)
+    && (value.observationRef === undefined || isRuntimeEpisodeTraceRefShape(value.observationRef))
+}
+
+function isRuntimeReplayReferenceIndexObservationRefShape(value: unknown): value is RuntimeReplayReferenceIndexObservationRef {
+  return isRecord(value)
+    && typeof value.id === "string"
+    && typeof value.type === "string"
+    && isRuntimeEpisodeTraceRefShape(value.ref)
+    && Array.isArray(value.artifactRefs)
+    && value.artifactRefs.every(isRuntimeEpisodeTraceRefShape)
+}
+
+function isRuntimeEpisodeTraceRefShape(value: unknown): value is RuntimeEpisodeTraceRef {
+  return isRecord(value)
+    && typeof value.kind === "string"
+    && typeof value.id === "string"
+    && (value.digest === undefined || validDigest(value.digest))
+    && (value.artifactId === undefined || typeof value.artifactId === "string")
+    && (value.path === undefined || typeof value.path === "string")
+}
+
 function isArtifactFileDigestShape(value: unknown): value is ArtifactFileDigest {
   return isRecord(value)
     && value.algorithm === "sha256"
@@ -1805,6 +1931,10 @@ async function verifyReviewEvidence(directory: string, manifest: ArtifactManifes
   if (typeof evidence.runtimeReferenceManifest === "string") {
     validateArtifactReference(evidence.runtimeReferenceManifest, "files/review.json:evidence.runtimeReferenceManifest", manifestFiles, violations)
   }
+
+  if (typeof evidence.runtimeReplayReferenceIndex === "string") {
+    validateArtifactReference(evidence.runtimeReplayReferenceIndex, "files/review.json:evidence.runtimeReplayReferenceIndex", manifestFiles, violations)
+  }
 }
 
 async function verifyRuntimeEpisodeTraceArtifacts(directory: string, manifest: ArtifactManifest, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
@@ -1889,6 +2019,74 @@ async function verifyRuntimeReferenceManifestArtifacts(directory: string, manife
     }
 
     for (const [snapshotIndex, snapshot] of referenceManifest.snapshots.entries()) {
+      for (const [refIndex, ref] of snapshot.artifactRefs.entries()) {
+        if (typeof ref.path !== "string") {
+          continue
+        }
+        validateArtifactReference(ref.path, `${file.path}:snapshots[${snapshotIndex}].artifactRefs[${refIndex}].path`, manifestFiles, violations)
+        await verifyRuntimeEpisodeTraceRefFileDigest(directory, ref, `${file.path}:snapshots[${snapshotIndex}].artifactRefs[${refIndex}].digest`, violations)
+      }
+    }
+  }
+}
+
+async function verifyRuntimeReplayReferenceIndexArtifacts(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  for (const file of manifest.files) {
+    if (file.kind !== "runtime-replay-index") {
+      continue
+    }
+
+    let index: unknown
+    try {
+      index = JSON.parse(await readFile(join(directory, file.path), "utf8"))
+    } catch (error) {
+      violations.push({
+        code: "malformed-reference",
+        path: file.path,
+        file: file.path,
+        message: `Runtime replay reference index is not valid JSON: ${errorMessage(error)}`,
+      })
+      continue
+    }
+
+    if (!isRuntimeReplayReferenceIndexShape(index)) {
+      violations.push({ code: "malformed-reference", path: file.path, file: file.path, message: "Runtime replay reference index does not match wp-codebox/runtime-replay-reference-index/v1." })
+      continue
+    }
+
+    const expectedDigest = runtimeReplayReferenceIndexDigest(index)
+    if (index.digest.value !== expectedDigest.value) {
+      violations.push({ code: "digest-mismatch", path: `${file.path}:digest`, file: file.path, message: `Runtime replay reference index digest does not match declared refs: expected ${expectedDigest.value}, got ${index.digest.value}` })
+    }
+
+    const expectedId = `runtime-replay-reference-index-sha256-${index.digest.value}`
+    if (index.id !== expectedId) {
+      violations.push({ code: "bundle-id-mismatch", path: `${file.path}:id`, file: file.path, message: `Runtime replay reference index id must match its digest: expected ${expectedId}, got ${index.id}` })
+    }
+
+    if (index.artifactBundle.id !== manifest.id || index.artifactBundle.digest.value !== manifest.contentDigest.value) {
+      violations.push({ code: "review-evidence-mismatch", path: `${file.path}:artifactBundle`, file: file.path, message: "Runtime replay reference index artifactBundle ref must match manifest id and contentDigest." })
+    }
+
+    for (const [key, referencedFile] of Object.entries(index.references)) {
+      if (!referencedFile) {
+        continue
+      }
+      validateArtifactReference(referencedFile.path, `${file.path}:references.${key}.path`, manifestFiles, violations)
+      await verifyReferencedFileDigest(directory, referencedFile, `${file.path}:references.${key}.sha256`, violations)
+    }
+
+    for (const [observationIndex, observation] of index.observations.entries()) {
+      for (const [refIndex, ref] of observation.artifactRefs.entries()) {
+        if (typeof ref.path !== "string") {
+          continue
+        }
+        validateArtifactReference(ref.path, `${file.path}:observations[${observationIndex}].artifactRefs[${refIndex}].path`, manifestFiles, violations)
+        await verifyRuntimeEpisodeTraceRefFileDigest(directory, ref, `${file.path}:observations[${observationIndex}].artifactRefs[${refIndex}].digest`, violations)
+      }
+    }
+
+    for (const [snapshotIndex, snapshot] of index.snapshots.entries()) {
       for (const [refIndex, ref] of snapshot.artifactRefs.entries()) {
         if (typeof ref.path !== "string") {
           continue
@@ -2283,6 +2481,128 @@ export function runtimeReferenceManifestDigest(manifest: RuntimeReferenceManifes
       .update(stableJson(runtimeReferenceManifestDigestPayload(manifest)))
       .digest("hex"),
   }
+}
+
+export function buildRuntimeReplayReferenceIndex(input: BuildRuntimeReplayReferenceIndexInput): RuntimeReplayReferenceIndex {
+  const filesByPath = new Map(input.files.map((file) => [file.path, runtimeReferenceManifestFileRef(file)]))
+  const references: RuntimeReplayReferenceIndex["references"] = stripUndefined({
+    trace: input.trace ? runtimeReferenceManifestFileRef(input.trace) : filesByPath.get("files/runtime-episode-trace.json"),
+    events: input.events ? runtimeReferenceManifestFileRef(input.events) : filesByPath.get("files/runtime-episode.jsonl"),
+    runtimeReferenceManifest: input.runtimeReferenceManifest ? runtimeReferenceManifestFileRef(input.runtimeReferenceManifest) : filesByPath.get("files/runtime-reference-manifest.json"),
+    observations: filesByPath.get("observations.jsonl"),
+    commands: filesByPath.get("commands.jsonl"),
+    runtimeEvents: filesByPath.get("events.jsonl"),
+    blueprintAfter: filesByPath.get("blueprint.after.json"),
+    blueprintAfterNotes: filesByPath.get("blueprint.after-notes.json"),
+    mountedFiles: filesByPath.get("files/mounted-files.json"),
+    mountDiffs: filesByPath.get("files/diffs.json"),
+    changedFiles: filesByPath.get("files/changed-files.json"),
+    patch: filesByPath.get("files/patch.diff"),
+    testResults: filesByPath.get("files/test-results.json"),
+  })
+  const snapshots = (input.snapshots ?? []).map(runtimeReferenceManifestSnapshotRef)
+  const replay = runtimeReplayInstructions(references, snapshots)
+  const index = {
+    schema: RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA,
+    version: 1 as const,
+    id: "runtime-replay-reference-index-pending",
+    createdAt: input.createdAt,
+    digest: { algorithm: "sha256" as const, value: "0".repeat(64) },
+    runtime: input.runtime,
+    artifactBundle: input.artifactBundle,
+    references,
+    actions: runtimeReplayActionRefs(input.episodeTrace),
+    observations: runtimeReplayObservationRefs(input.episodeTrace),
+    snapshots,
+    replay,
+  }
+  const digest = runtimeReplayReferenceIndexDigest(index)
+
+  return {
+    ...index,
+    id: `runtime-replay-reference-index-sha256-${digest.value}`,
+    digest,
+  }
+}
+
+export function runtimeReplayReferenceIndexDigest(index: RuntimeReplayReferenceIndex): RuntimeEpisodeContentDigest {
+  return {
+    algorithm: "sha256",
+    value: createHash("sha256")
+      .update("wp-codebox/runtime-replay-reference-index/v1\n")
+      .update(stableJson(runtimeReplayReferenceIndexDigestPayload(index)))
+      .digest("hex"),
+  }
+}
+
+function runtimeReplayReferenceIndexDigestPayload(index: RuntimeReplayReferenceIndex): Record<string, unknown> {
+  return {
+    schema: index.schema,
+    version: index.version,
+    runtime: index.runtime,
+    artifactBundle: index.artifactBundle,
+    references: index.references,
+    actions: index.actions,
+    observations: index.observations,
+    snapshots: index.snapshots,
+    replay: index.replay,
+  }
+}
+
+function runtimeReplayActionRefs(trace: RuntimeEpisodeTrace | undefined): RuntimeReplayReferenceIndexActionRef[] {
+  return (trace?.steps ?? []).map((step) => stripUndefined({
+    index: step.index,
+    id: step.id,
+    actionRef: step.actionRef,
+    executionRef: step.executionRef,
+    observationRef: step.observationRef,
+  }))
+}
+
+function runtimeReplayObservationRefs(trace: RuntimeEpisodeTrace | undefined): RuntimeReplayReferenceIndexObservationRef[] {
+  const observations = [
+    ...(trace?.reset.observations ?? []),
+    ...(trace?.steps.flatMap((step) => step.observation ? [step.observation] : []) ?? []),
+  ]
+
+  return observations.map((observation, index) => ({
+    id: observation.id ?? `observation:${index}`,
+    type: observation.type,
+    ref: observationRef(observation, observation.id ?? `observation:${index}`),
+    artifactRefs: [...(observation.artifactRefs ?? [])],
+  }))
+}
+
+function runtimeReplayInstructions(
+  references: RuntimeReplayReferenceIndex["references"],
+  snapshots: RuntimeReferenceManifestSnapshotRef[],
+): RuntimeReplayReferenceIndex["replay"] {
+  const limitations = [...new Set(snapshots.flatMap((snapshot) => snapshot.replay.limitations))]
+  const status = snapshots.some((snapshot) => snapshot.replay.status === "runtime-state-artifact" || snapshot.replay.status === "replayable-runtime-state")
+    ? snapshots.find((snapshot) => snapshot.replay.status === "runtime-state-artifact" || snapshot.replay.status === "replayable-runtime-state")?.replay.status ?? "runtime-state-artifact"
+    : snapshots.some((snapshot) => snapshot.replay.status === "partial-replay")
+      ? "partial-replay"
+      : snapshots.length > 0
+        ? "metadata-only"
+        : "partial"
+
+  return {
+    status,
+    instructions: [
+      ...(references.trace ? ["Use references.trace for ordered runtime actions, observations, snapshots, and artifact bundle refs."] : []),
+      ...(references.events ? ["Use references.events for replay-oriented JSONL lifecycle records derived from the runtime trace."] : []),
+      ...(references.runtimeReferenceManifest ? ["Use references.runtimeReferenceManifest for compatible snapshot metadata, limitations, and hashed runtime files."] : []),
+      ...(references.mountedFiles || references.changedFiles || references.patch ? ["Use references.mountedFiles, references.changedFiles, and references.patch for filesystem and mount-state evidence."] : []),
+      ...(references.blueprintAfter ? ["Use references.blueprintAfter and references.blueprintAfterNotes when available for generated Playground replay guidance."] : []),
+    ],
+    limitations: limitations.length > 0 ? limitations : [
+      "This index points to replay evidence; it is not a complete WordPress database or filesystem checkpoint.",
+    ],
+  }
+}
+
+function stripUndefined<T extends Record<string, unknown>>(record: T): T {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined)) as T
 }
 
 function runtimeReferenceManifestDigestPayload(manifest: RuntimeReferenceManifest): Record<string, unknown> {
@@ -3166,6 +3486,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       ...artifacts,
       runtimeEpisodeTracePath: join(artifacts.directory, "files/runtime-episode-trace.json"),
       runtimeEpisodeEventsPath: join(artifacts.directory, "files/runtime-episode.jsonl"),
+      runtimeReplayReferenceIndexPath: join(artifacts.directory, "files/runtime-replay-index.json"),
     }
     if (spec.includeRuntimeSnapshotBundles) {
       await this.persistRuntimeSnapshotBundles()
@@ -3183,7 +3504,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     const snapshotDirectory = join(this.artifacts.directory, "files/runtime-snapshots")
     await mkdir(snapshotDirectory, { recursive: true })
     const baseRefs = manifest.files
-      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json"].includes(file.path))
+      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
       .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
 
     for (const [index, snapshot] of this.snapshots.entries()) {
@@ -3240,7 +3561,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
   }
 
   private async persistRuntimeEpisodeTraceArtifacts(): Promise<void> {
-    if (!this.artifacts?.runtimeEpisodeTracePath || !this.artifacts.runtimeEpisodeEventsPath || !this.artifacts.runtimeReferenceManifestPath) {
+    if (!this.artifacts?.runtimeEpisodeTracePath || !this.artifacts.runtimeEpisodeEventsPath || !this.artifacts.runtimeReferenceManifestPath || !this.artifacts.runtimeReplayReferenceIndexPath) {
       return
     }
 
@@ -3253,6 +3574,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     await this.updateArtifactReviewForRuntimeEpisodeTrace(traceRelativePath)
     await this.updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
     await this.updateRuntimeReferenceManifestForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
+    await this.updateRuntimeReplayReferenceIndexForRuntimeEpisodeTrace(trace, traceRelativePath, eventsRelativePath)
   }
 
   private async updateRuntimeReferenceManifestForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
@@ -3262,7 +3584,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
 
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
     const fileRefs = manifest.files
-      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json"].includes(file.path))
+      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
       .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
     const traceRef = fileRefs.find((file) => file.path === traceRelativePath)
     const eventsRef = fileRefs.find((file) => file.path === eventsRelativePath)
@@ -3284,6 +3606,38 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
 
+  private async updateRuntimeReplayReferenceIndexForRuntimeEpisodeTrace(trace: RuntimeEpisodeTrace, traceRelativePath: string, eventsRelativePath: string): Promise<void> {
+    if (!this.artifacts?.runtimeReplayReferenceIndexPath) {
+      return
+    }
+
+    const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
+    const fileRefs = manifest.files
+      .filter((file) => !["manifest.json", "files/runtime-replay-index.json"].includes(file.path))
+      .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
+    const traceRef = fileRefs.find((file) => file.path === traceRelativePath)
+    const eventsRef = fileRefs.find((file) => file.path === eventsRelativePath)
+    const runtimeReferenceManifestRef = fileRefs.find((file) => file.path === "files/runtime-reference-manifest.json")
+    const replayIndex = buildRuntimeReplayReferenceIndex({
+      createdAt: this.artifacts.createdAt,
+      runtime: manifest.runtime,
+      artifactBundle: {
+        kind: "artifact-bundle",
+        id: manifest.id,
+        digest: { algorithm: "sha256", value: manifest.contentDigest.value },
+      },
+      files: fileRefs,
+      ...(traceRef ? { trace: traceRef } : {}),
+      ...(eventsRef ? { events: eventsRef } : {}),
+      ...(runtimeReferenceManifestRef ? { runtimeReferenceManifest: runtimeReferenceManifestRef } : {}),
+      snapshots: this.snapshots,
+      episodeTrace: trace,
+    })
+    await writeFile(this.artifacts.runtimeReplayReferenceIndexPath, `${JSON.stringify(replayIndex, null, 2)}\n`)
+    await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
+    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  }
+
   private async updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
     if (!this.artifacts) {
       return
@@ -3292,6 +3646,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
     upsertManifestFile(manifest, artifactManifestFile(traceRelativePath, "runtime-episode-trace", "application/json"))
     upsertManifestFile(manifest, artifactManifestFile(eventsRelativePath, "runtime-episode-events", "application/x-ndjson"))
+    upsertManifestFile(manifest, artifactManifestFile("files/runtime-replay-index.json", "runtime-replay-index", "application/json"))
     await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
     await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
@@ -3306,6 +3661,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       ...(isRecord(metadata.artifacts) ? metadata.artifacts : {}),
       runtimeEpisodeTrace: traceRelativePath,
       runtimeEpisodeEvents: eventsRelativePath,
+      runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
     }
     await writeFile(this.artifacts.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`)
   }
@@ -3317,6 +3673,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
 
     const review = JSON.parse(await readFile(this.artifacts.reviewPath, "utf8")) as ArtifactReview
     review.evidence.runtimeEpisodeTrace = traceRelativePath
+    review.evidence.runtimeReplayReferenceIndex = "files/runtime-replay-index.json"
     if (!review.progress.some((event) => event.type === "artifact" && event.component === "runtime-episode")) {
       review.progress.push({
         type: "artifact",

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
 import {
   buildRuntimeReferenceManifest,
+  buildRuntimeReplayReferenceIndex,
   calculateArtifactManifestFileSha256,
   type ArtifactBundle,
   type ArtifactManifest,
@@ -87,6 +88,7 @@ export class ArtifactBundleBuilder {
     const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
     const runtimeReferenceManifestPath = join(filesDirectory, "runtime-reference-manifest.json")
+    const runtimeReplayReferenceIndexPath = join(filesDirectory, "runtime-replay-index.json")
     const redactor = new ArtifactRedactor(source.spec.secretEnv)
 
     await source.redactBrowserArtifacts(redactor)
@@ -143,6 +145,7 @@ export class ArtifactBundleBuilder {
       testResults: relative(source.artifactRoot, testResultsPath),
       review: relative(source.artifactRoot, reviewPath),
       runtimeReferenceManifest: relative(source.artifactRoot, runtimeReferenceManifestPath),
+      runtimeReplayReferenceIndex: relative(source.artifactRoot, runtimeReplayReferenceIndexPath),
       mountDiffs: relative(source.artifactRoot, diffsPath),
       ...(browser ? { browser: "files/browser/summary.json" } : {}),
       ...(source.pluginCheckArtifactPaths().length > 0 ? { pluginChecks: source.pluginCheckArtifactPaths() } : {}),
@@ -179,6 +182,7 @@ export class ArtifactBundleBuilder {
       fileEntry(testResultsPath, "test-results", "application/json"),
       fileEntry(reviewPath, "review", "application/json"),
       fileEntry(runtimeReferenceManifestPath, "runtime-reference-manifest", "application/json"),
+      fileEntry(runtimeReplayReferenceIndexPath, "runtime-replay-index", "application/json"),
       ...source.browserManifestFiles(),
       ...source.observationManifestFiles(),
       ...source.pluginCheckManifestFiles(),
@@ -211,6 +215,7 @@ export class ArtifactBundleBuilder {
     }
     await writeRedactedArtifact(redactor, reviewPath, source.artifactRoot, `${JSON.stringify(review, null, 2)}\n`)
     await writeFile(runtimeReferenceManifestPath, "{}\n")
+    await writeFile(runtimeReplayReferenceIndexPath, "{}\n")
     metadata.redaction = redactor.summary()
     await writeRedactedArtifact(redactor, metadataPath, source.artifactRoot, `${JSON.stringify(metadata, null, 2)}\n`)
 
@@ -251,11 +256,41 @@ export class ArtifactBundleBuilder {
         digest: { algorithm: "sha256", value: contentDigest },
       },
       files: manifest.files
-        .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json"].includes(file.path))
+        .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
         .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 })),
     })
     await writeFile(runtimeReferenceManifestPath, `${JSON.stringify(runtimeReferenceManifest, null, 2)}\n`)
+    const runtimeReferenceManifestRef = {
+      path: "files/runtime-reference-manifest.json",
+      kind: "runtime-reference-manifest",
+      contentType: "application/json",
+      sha256: {
+        algorithm: "sha256" as const,
+        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, { path: "files/runtime-reference-manifest.json", kind: "runtime-reference-manifest", contentType: "application/json", sha256: { algorithm: "sha256", value: "0".repeat(64) } }),
+      },
+    }
+    const runtimeReplayReferenceIndex = buildRuntimeReplayReferenceIndex({
+      createdAt,
+      runtime,
+      artifactBundle: {
+        kind: "artifact-bundle",
+        id: bundleId,
+        digest: { algorithm: "sha256", value: contentDigest },
+      },
+      files: manifest.files
+        .filter((file) => !["manifest.json", "files/runtime-replay-index.json"].includes(file.path))
+        .map((file) => file.path === "files/runtime-reference-manifest.json" ? runtimeReferenceManifestRef : ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 })),
+      runtimeReferenceManifest: runtimeReferenceManifestRef,
+    })
+    await writeFile(runtimeReplayReferenceIndexPath, `${JSON.stringify(runtimeReplayReferenceIndex, null, 2)}\n`)
     manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "files/runtime-reference-manifest.json" ? ({
+      ...file,
+      sha256: {
+        algorithm: "sha256" as const,
+        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, file),
+      },
+    }) : file))
+    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "files/runtime-replay-index.json" ? ({
       ...file,
       sha256: {
         algorithm: "sha256" as const,
@@ -291,6 +326,7 @@ export class ArtifactBundleBuilder {
       testResultsPath,
       reviewPath,
       runtimeReferenceManifestPath,
+      runtimeReplayReferenceIndexPath,
       ...(preview ? { preview } : {}),
       contentDigest,
       createdAt,

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -283,6 +283,7 @@ export function buildArtifactReview({
       changedFiles: "files/changed-files.json",
       testResults: "files/test-results.json",
       runtimeReferenceManifest: "files/runtime-reference-manifest.json",
+      runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
     },
     ...(browser ? { browser } : {}),
     riskFlags: [],

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -6,7 +6,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, createRuntime, runtimeReferenceManifestDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
+import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA, createRuntime, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 const execFileAsync = promisify(execFile)
@@ -62,6 +62,7 @@ try {
   const testResults = JSON.parse(await readFile(artifacts.testResultsPath, "utf8"))
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
   const runtimeReferenceManifest = JSON.parse(await readFile(artifacts.runtimeReferenceManifestPath, "utf8"))
+  const runtimeReplayReferenceIndex = JSON.parse(await readFile(artifacts.runtimeReplayReferenceIndexPath, "utf8"))
   const contentDigest = createHash("sha256")
     .update("wp-codebox/artifact-content/v1\n")
     .update("files/changed-files.json\n")
@@ -85,6 +86,7 @@ try {
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/test-results.json" && file.kind === "test-results"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/review.json" && file.kind === "review"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-replay-index.json" && file.kind === "runtime-replay-index"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-evidence/run-attestation.json" && file.kind === "run-attestation"))
   const runtimeEvidence = metadata.artifacts.runtimeEvidence
   assert.match(runtimeEvidence["run-attestation"].sha256, /^[a-f0-9]{64}$/)
@@ -94,6 +96,7 @@ try {
     testResults: "files/test-results.json",
     review: "files/review.json",
     runtimeReferenceManifest: "files/runtime-reference-manifest.json",
+    runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
     mountDiffs: "files/diffs.json",
     runtimeEvidence,
   })
@@ -141,6 +144,7 @@ try {
   assert.equal(review.evidence.changedFiles, "files/changed-files.json")
   assert.equal(review.evidence.testResults, "files/test-results.json")
   assert.equal(review.evidence.runtimeReferenceManifest, "files/runtime-reference-manifest.json")
+  assert.equal(review.evidence.runtimeReplayReferenceIndex, "files/runtime-replay-index.json")
   assert.equal(runtimeReferenceManifest.schema, RUNTIME_REFERENCE_MANIFEST_SCHEMA)
   assert.equal(runtimeReferenceManifest.artifactBundle.id, artifacts.id)
   assert.equal(runtimeReferenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
@@ -148,6 +152,17 @@ try {
   assert.equal(runtimeReferenceManifest.id, `runtime-reference-manifest-sha256-${runtimeReferenceManifest.digest.value}`)
   assert.equal(runtimeReferenceManifest.snapshots.length, 0)
   assert.ok(runtimeReferenceManifest.files.some((file: { path: string }) => file.path === "files/changed-files.json"))
+  assert.equal(runtimeReplayReferenceIndex.schema, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA)
+  assert.equal(runtimeReplayReferenceIndex.artifactBundle.id, artifacts.id)
+  assert.equal(runtimeReplayReferenceIndex.artifactBundle.digest.value, artifacts.contentDigest)
+  assert.equal(runtimeReplayReferenceIndex.references.runtimeReferenceManifest.path, "files/runtime-reference-manifest.json")
+  assert.equal(runtimeReplayReferenceIndex.references.changedFiles.path, "files/changed-files.json")
+  assert.equal(runtimeReplayReferenceIndex.references.patch.path, "files/patch.diff")
+  assert.equal(runtimeReplayReferenceIndex.references.mountedFiles.path, "files/mounted-files.json")
+  assert.equal(runtimeReplayReferenceIndex.replay.status, "partial")
+  assert.ok(runtimeReplayReferenceIndex.replay.instructions.some((instruction: string) => instruction.includes("references.mountedFiles")))
+  assert.equal(runtimeReplayReferenceIndex.digest.value, runtimeReplayReferenceIndexDigest(runtimeReplayReferenceIndex).value)
+  assert.equal(runtimeReplayReferenceIndex.id, `runtime-replay-reference-index-sha256-${runtimeReplayReferenceIndex.digest.value}`)
   assert.ok(review.changedFiles.some((file: { path: string; status: string }) =>
     file.path === "/wordpress/wp-content/plugins/seeded-helper/generated.txt" && file.status === "added",
   ))

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -10,7 +10,9 @@ import {
   RUNTIME_EPISODE_OBSERVATION_SCHEMA,
   RUNTIME_EPISODE_SNAPSHOT_SCHEMA,
   RUNTIME_REFERENCE_MANIFEST_SCHEMA,
+  RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA,
   runtimeReferenceManifestDigest,
+  runtimeReplayReferenceIndexDigest,
   createRuntimeEpisode,
   validateRuntimeEpisodeTrace,
   verifyArtifactBundle,
@@ -118,20 +120,24 @@ try {
     assert.equal(metadata.provenance.task.kind, "runtime-episode-smoke")
     assert.ok(artifacts.runtimeEpisodeTracePath, "artifact bundle should expose runtimeEpisodeTracePath")
     assert.ok(artifacts.runtimeEpisodeEventsPath, "artifact bundle should expose runtimeEpisodeEventsPath")
+    assert.ok(artifacts.runtimeReplayReferenceIndexPath, "artifact bundle should expose runtimeReplayReferenceIndexPath")
     assert.equal(metadata.artifacts.runtimeEpisodeTrace, "files/runtime-episode-trace.json")
     assert.equal(metadata.artifacts.runtimeEpisodeEvents, "files/runtime-episode.jsonl")
+    assert.equal(metadata.artifacts.runtimeReplayReferenceIndex, "files/runtime-replay-index.json")
 
     const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode-trace.json" && file.kind === "runtime-episode-trace"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode.jsonl" && file.kind === "runtime-episode-events"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === httpObservation.artifactRefs?.[0].path && file.kind === "observation-artifact"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
+    assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-replay-index.json" && file.kind === "runtime-replay-index"))
     const snapshotBundleEntry = manifest.files.find((file: { path: string; kind: string }) => file.path.startsWith("files/runtime-snapshots/") && file.kind === "runtime-snapshot-bundle")
     assert.ok(snapshotBundleEntry, "runtime snapshot bundle should be listed in manifest")
 
     const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
     assert.equal(review.evidence.runtimeEpisodeTrace, "files/runtime-episode-trace.json")
     assert.equal(review.evidence.runtimeReferenceManifest, "files/runtime-reference-manifest.json")
+    assert.equal(review.evidence.runtimeReplayReferenceIndex, "files/runtime-replay-index.json")
     assert.ok(review.progress.some((event: { component?: string; label?: string }) => event.component === "runtime-episode" && event.label === "Runtime episode trace persisted"))
 
     const referenceManifest = JSON.parse(await readFile(artifacts.runtimeReferenceManifestPath ?? "", "utf8"))
@@ -155,6 +161,27 @@ try {
     assert.equal(snapshotBundle.snapshot.originalSemantics, "metadata-only")
     assert.equal(snapshotBundle.replay.status, "partial-replay")
     assert.ok(snapshotBundle.refs.some((ref: { path: string }) => ref.path === "blueprint.after.json"))
+
+    const replayIndex = JSON.parse(await readFile(artifacts.runtimeReplayReferenceIndexPath ?? "", "utf8"))
+    assert.equal(replayIndex.schema, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA)
+    assert.equal(replayIndex.artifactBundle.id, artifacts.id)
+    assert.equal(replayIndex.artifactBundle.digest.value, artifacts.contentDigest)
+    assert.equal(replayIndex.references.trace.path, "files/runtime-episode-trace.json")
+    assert.equal(replayIndex.references.events.path, "files/runtime-episode.jsonl")
+    assert.equal(replayIndex.references.runtimeReferenceManifest.path, "files/runtime-reference-manifest.json")
+    assert.equal(replayIndex.references.observations.path, "observations.jsonl")
+    assert.equal(replayIndex.references.blueprintAfter.path, "blueprint.after.json")
+    assert.equal(replayIndex.references.mountedFiles.path, "files/mounted-files.json")
+    assert.equal(replayIndex.actions.length, 3)
+    assert.equal(replayIndex.actions[0].executionRef.id, createPost.executionRef.id)
+    assert.ok(replayIndex.observations.some((observation: { id: string }) => observation.id === createPost.observationRef?.id))
+    assert.equal(replayIndex.snapshots[0].id, snapshot.id)
+    assert.equal(replayIndex.snapshots[0].artifactRefs[0].path, snapshotBundleEntry.path)
+    assert.equal(replayIndex.replay.status, "partial-replay")
+    assert.ok(replayIndex.replay.instructions.some((instruction: string) => instruction.includes("references.trace")))
+    assert.ok(replayIndex.replay.limitations.some((limitation: string) => limitation.includes("not a complete WordPress database checkpoint")))
+    assert.equal(replayIndex.digest.value, runtimeReplayReferenceIndexDigest(replayIndex).value)
+    assert.equal(replayIndex.id, `runtime-replay-reference-index-sha256-${replayIndex.digest.value}`)
 
     const trace = await episode.trace()
     const persistedTrace = JSON.parse(await readFile(artifacts.runtimeEpisodeTracePath, "utf8"))


### PR DESCRIPTION
## Summary
- Adds a typed `wp-codebox/runtime-replay-reference-index/v1` artifact at `files/runtime-replay-index.json` so consumers can find replay inputs without filename alias scanning.
- Indexes trace/events, runtime reference manifest, observation logs, replay guidance, snapshot refs, mount/filesystem evidence, and stable hashes.
- Extends artifact bundle verification and smoke coverage to validate the index, referenced files, digests, and runtime episode replay discovery.

Fixes #262.

## Verification
- `npm run build`
- `npm run runtime-episode-smoke`
- `npm run artifact-contract-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `git diff --check origin/main...HEAD`

Full `npm run check` was started earlier but was abandoned after stale local Playground/check processes hung. After clearing those local processes, the targeted replay-index checks above passed cleanly on the rebased branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the runtime replay reference index implementation, resolved rebase conflicts, and prepared the PR; Chris remains responsible for review and merge.