### PR TITLE
Fix release packaging workspace isolation

### DIFF
--- a/scripts/package-release-artifact.ts
+++ b/scripts/package-release-artifact.ts
@@ -8,41 +8,42 @@ import { promisify } from "node:util"
 const execFileAsync = promisify(execFile)
 const repoRoot = resolve(import.meta.dirname, "..")
 const releaseRoot = resolve(repoRoot, "dist", "release")
-const packageRoot = join(releaseRoot, "wp-codebox-cli")
+const stagingReleaseRoot = await mkdtemp(join(tmpdir(), "wp-codebox-release-"))
+const packageRoot = join(stagingReleaseRoot, "wp-codebox-cli")
 const platformName = process.env.WP_CODEBOX_RELEASE_PLATFORM ?? normalizePlatform(platform())
 const archName = process.env.WP_CODEBOX_RELEASE_ARCH ?? normalizeArch(arch())
 const nodeRuntimeVersion = process.env.WP_CODEBOX_NODE_RUNTIME_VERSION ?? "24.16.0"
 const artifactName = `wp-codebox-cli-${platformName}-${archName}.tar.gz`
 const artifactPath = resolve(repoRoot, "dist", artifactName)
 
-await execFileAsync("npm", ["run", "build"], { cwd: repoRoot, maxBuffer: 1024 * 1024 * 10 })
+try {
+  await execFileAsync("npm", ["run", "build"], { cwd: repoRoot, maxBuffer: 1024 * 1024 * 10 })
 
-await rm(releaseRoot, { recursive: true, force: true })
-await mkdir(packageRoot, { recursive: true })
+  await mkdir(packageRoot, { recursive: true })
 
-await copyIfPresent("README.md")
-await copyIfPresent("LICENSE")
-await cp(resolve(repoRoot, "package.json"), join(packageRoot, "package.json"))
-await cp(resolve(repoRoot, "package-lock.json"), join(packageRoot, "package-lock.json"))
+  await copyIfPresent("README.md")
+  await copyIfPresent("LICENSE")
+  await cp(resolve(repoRoot, "package.json"), join(packageRoot, "package.json"))
+  await cp(resolve(repoRoot, "package-lock.json"), join(packageRoot, "package-lock.json"))
 
-for (const packageName of ["runtime-core", "runtime-playground", "cli"]) {
-  const sourceRoot = resolve(repoRoot, "packages", packageName)
-  const targetRoot = join(packageRoot, "packages", packageName)
-  await mkdir(targetRoot, { recursive: true })
-  await cp(join(sourceRoot, "package.json"), join(targetRoot, "package.json"))
-  await cp(join(sourceRoot, "dist"), join(targetRoot, "dist"), { recursive: true })
-}
+  for (const packageName of ["runtime-core", "runtime-playground", "cli"]) {
+    const sourceRoot = resolve(repoRoot, "packages", packageName)
+    const targetRoot = join(packageRoot, "packages", packageName)
+    await mkdir(targetRoot, { recursive: true })
+    await cp(join(sourceRoot, "package.json"), join(targetRoot, "package.json"))
+    await cp(join(sourceRoot, "dist"), join(targetRoot, "dist"), { recursive: true })
+  }
 
-await execFileAsync("npm", ["install", "--omit=dev", "--omit=optional", "--ignore-scripts", "--no-fund", "--no-audit"], {
-  cwd: packageRoot,
-  maxBuffer: 1024 * 1024 * 20,
-})
-await bundleNodeRuntime(packageRoot, platformName, archName)
+  await execFileAsync("npm", ["install", "--omit=dev", "--omit=optional", "--ignore-scripts", "--no-fund", "--no-audit"], {
+    cwd: packageRoot,
+    maxBuffer: 1024 * 1024 * 20,
+  })
+  await bundleNodeRuntime(packageRoot, platformName, archName)
 
-const binDir = join(packageRoot, "bin")
-await mkdir(binDir, { recursive: true })
-const binPath = join(binDir, "wp-codebox")
-await writeFile(binPath, `#!/usr/bin/env bash
+  const binDir = join(packageRoot, "bin")
+  await mkdir(binDir, { recursive: true })
+  const binPath = join(binDir, "wp-codebox")
+  await writeFile(binPath, `#!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 NODE_BIN="\${WP_CODEBOX_NODE_BIN:-}"
@@ -60,14 +61,21 @@ if [ -z "\${NODE_BIN}" ]; then
 fi
 exec "\${NODE_BIN}" "\${SCRIPT_DIR}/../packages/cli/dist/index.js" "$@"
 `)
-await chmod(binPath, 0o755)
+  await chmod(binPath, 0o755)
 
-await execFileAsync("tar", ["-czf", artifactPath, "-C", releaseRoot, "wp-codebox-cli"], {
-  cwd: repoRoot,
-  maxBuffer: 1024 * 1024 * 10,
-})
+  await rm(releaseRoot, { recursive: true, force: true })
+  await mkdir(releaseRoot, { recursive: true })
+  await cp(packageRoot, join(releaseRoot, "wp-codebox-cli"), { recursive: true })
 
-process.stdout.write(JSON.stringify([{ path: `dist/${artifactName}`, type: "node-cli-tarball", platform: `${platformName}-${archName}` }]) + "\n")
+  await execFileAsync("tar", ["-czf", artifactPath, "-C", stagingReleaseRoot, "wp-codebox-cli"], {
+    cwd: repoRoot,
+    maxBuffer: 1024 * 1024 * 10,
+  })
+
+  process.stdout.write(JSON.stringify([{ path: `dist/${artifactName}`, type: "node-cli-tarball", platform: `${platformName}-${archName}` }]) + "\n")
+} finally {
+  await rm(stagingReleaseRoot, { recursive: true, force: true })
+}
 
 async function copyIfPresent(relativePath: string): Promise<void> {
   try {


### PR DESCRIPTION
## Summary
- Build the release CLI package in a temporary directory outside the repo so `npm install --omit=dev` cannot mutate the root workspace install.
- Copy the completed package back into `dist/release/wp-codebox-cli` before creating the tarball, preserving the existing distribution layout.

## Context
- Issue #261 was already closed by #274 while this branch was being rebased onto current `main`.
- This packaging fix was found while running the issue #261 verification path: `package-distribution-smoke` removed root `node_modules`, which caused later npm scripts to lose `tsx`.

## Verification
- `npm run build`
- `npm run package-distribution-smoke`
- `npm run runtime-action-adapter-smoke`
- `npm run recipe-bench-smoke`
- `npm run check` reached the known local Playground/OpenCode port failure in `artifact-contract-smoke`: `listen EADDRINUSE: address already in use 127.0.0.1:53436`, then timed out.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigating the runtime action adapter request, resolving the current-main overlap, identifying the packaging verification bug, drafting the fix, and running verification. Chris remains responsible for review and testing.