### PR TITLE
Bound agent sandbox task runtime

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -10,6 +10,7 @@ export interface AgentSandboxCodeOptions {
   model?: string
   sessionId?: string
   maxTurns?: string
+  timeoutSeconds?: string
   code?: string
   codeFile?: string
 }
@@ -55,9 +56,16 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
     input.max_turns = Number.parseInt(options.maxTurns, 10)
   }
 
+  const timeoutSeconds = Number.parseInt(options.timeoutSeconds ?? '', 10)
+  const timeoutLimit = Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 0
+
   return `
 if (function_exists('wp_set_current_user')) {
     wp_set_current_user(1);
+}
+
+if (${timeoutLimit} > 0 && function_exists('set_time_limit')) {
+    set_time_limit(${timeoutLimit});
 }
 
 if (!defined('DATAMACHINE_WORKSPACE_PATH')) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -575,6 +575,7 @@ interface AgentSandboxRunOptions extends AgentRuntimeProbeOptions {
   model?: string
   sessionId?: string
   maxTurns?: string
+  timeoutSeconds?: string
   code?: string
   codeFile?: string
 }
@@ -2278,6 +2279,7 @@ async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["steps"][nu
       model: argValue(args, "model"),
       sessionId: argValue(args, "session-id"),
       maxTurns: argValue(args, "max-turns"),
+      timeoutSeconds: argValue(args, "timeout-seconds"),
     }))
 
     return {
@@ -2398,6 +2400,7 @@ function agentSandboxRunMetadata(options: AgentSandboxRunOptions): Record<string
       input: options.task,
       sessionId: options.sessionId,
       maxTurns: options.maxTurns,
+      timeoutSeconds: options.timeoutSeconds,
       hasCodeOverride: Boolean(options.code || options.codeFile),
       secretEnv: options.secretEnvNames ?? [],
     }),
@@ -2478,7 +2481,7 @@ function parseAgentRuntimeProbeOptions(args: string[], extraOptions: string[] = 
 }
 
 function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
-  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--code", "--code-file", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
+  const options = parseAgentRuntimeProbeOptions(args, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--timeout-seconds", "--code", "--code-file", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -2506,6 +2509,9 @@ function parseAgentSandboxRunOptions(args: string[]): AgentSandboxRunOptions {
         break
       case "--max-turns":
         options.maxTurns = value
+        break
+      case "--timeout-seconds":
+        options.timeoutSeconds = value
         break
       case "--code":
         options.code = value

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -197,6 +197,7 @@ export const commandRegistry = [
       { name: "model", description: "Model id.", format: "string" },
       { name: "session-id", description: "Conversation session id.", format: "string" },
       { name: "max-turns", description: "Maximum agent loop turns.", format: "positive integer" },
+      { name: "timeout-seconds", description: "Maximum wall-clock seconds for the sandbox agent PHP task.", format: "positive integer" },
       { name: "provider-plugin-slugs", description: "Comma-separated provider plugin slugs already mounted by recipe inputs.", format: "comma-separated slugs" },
       { name: "code", description: "Inline PHP runner override for operator/debug use.", format: "PHP string" },
       { name: "code-file", description: "Path to PHP runner override for operator/debug use.", format: "path" },

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -140,6 +140,10 @@ final class WP_Codebox_Abilities {
 								'type'        => 'integer',
 								'description' => 'Maximum agent loop turns for this sandbox task.',
 							),
+							'task_timeout_seconds'   => array(
+								'type'        => 'integer',
+								'description' => 'Maximum wall-clock seconds for this sandbox task. Zero or omitted disables the host-side timeout.',
+							),
 							'preview_hold_seconds'   => $preview_schema['preview_hold_seconds'],
 							'preview_port'           => $preview_schema['preview_port'],
 							'preview_bind'           => $preview_schema['preview_bind'],

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -92,7 +92,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		);
 		$command .= $preview_args;
 
-		$result    = $this->run_command( $command, $inheritance_payload['secret_env'] );
+		$result    = $this->run_command( $command, $inheritance_payload['secret_env'], $this->task_timeout_seconds( $input ) );
 		@unlink( $recipe_file );
 		foreach ( $recipe_payload['cleanup_paths'] as $cleanup_path ) {
 			@unlink( (string) $cleanup_path );
@@ -1450,6 +1450,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			if ( ! empty( $input['max_turns'] ) ) {
 				$args[] = 'max-turns=' . (string) max( 1, (int) $input['max_turns'] );
 			}
+			if ( ! empty( $input['task_timeout_seconds'] ) ) {
+				$args[] = 'timeout-seconds=' . (string) $this->task_timeout_seconds( $input );
+			}
 
 			$steps[] = array(
 				'command' => 'wp-codebox.agent-sandbox-run',
@@ -1881,20 +1884,26 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return new WP_Error( 'json_decode_failed', json_last_error_msg() );
 	}
 
-	/** @param array<string,string> $secret_env Secret env values for the child process. @return array{exit_code:int,output:string} */
-	private function run_command( string $command, array $secret_env = array() ): array {
+	/** @param array<string,mixed> $input Ability input. */
+	private function task_timeout_seconds( array $input ): int {
+		$timeout = (int) ( $input['task_timeout_seconds'] ?? 0 );
+		return max( 0, $timeout );
+	}
+
+	/** @param array<string,string> $secret_env Secret env values for the child process. @return array{exit_code:int,output:string,timed_out?:bool,timeout_seconds?:int} */
+	private function run_command( string $command, array $secret_env = array(), int $timeout_seconds = 0 ): array {
 		if ( isset( $this->callbacks['command_runner'] ) ) {
-			return ( $this->callbacks['command_runner'] )( $command, $secret_env );
+			return ( $this->callbacks['command_runner'] )( $command, $secret_env, $timeout_seconds );
 		}
 
-		if ( ! empty( $secret_env ) && ! function_exists( 'proc_open' ) ) {
+		if ( ( ! empty( $secret_env ) || $timeout_seconds > 0 ) && ! function_exists( 'proc_open' ) ) {
 			return array(
 				'exit_code' => 1,
-				'output'    => 'WP Codebox inherited secret environment requires proc_open support.',
+				'output'    => 'WP Codebox inherited secret environment or timeout requires proc_open support.',
 			);
 		}
 
-		if ( ! empty( $secret_env ) ) {
+		if ( ! empty( $secret_env ) || $timeout_seconds > 0 ) {
 			$descriptor_spec = array(
 				1 => array( 'pipe', 'w' ),
 				2 => array( 'pipe', 'w' ),
@@ -1902,13 +1911,45 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$current_env = getenv();
 			$process     = proc_open( $command, $descriptor_spec, $pipes, null, array_merge( is_array( $current_env ) ? $current_env : array(), $_ENV, $secret_env ) );
 			if ( is_resource( $process ) ) {
-				$output = stream_get_contents( $pipes[1] );
-				$error  = stream_get_contents( $pipes[2] );
+				stream_set_blocking( $pipes[1], false );
+				stream_set_blocking( $pipes[2], false );
+				$output    = '';
+				$error     = '';
+				$started   = time();
+				$timed_out = false;
+
+				while ( true ) {
+					$output .= (string) stream_get_contents( $pipes[1] );
+					$error  .= (string) stream_get_contents( $pipes[2] );
+					$status = proc_get_status( $process );
+					if ( ! (bool) ( $status['running'] ?? false ) ) {
+						break;
+					}
+					if ( $timeout_seconds > 0 && time() - $started >= $timeout_seconds ) {
+						$timed_out = true;
+						proc_terminate( $process );
+						break;
+					}
+					usleep( 100000 );
+				}
+
+				$output .= (string) stream_get_contents( $pipes[1] );
+				$error  .= (string) stream_get_contents( $pipes[2] );
 				fclose( $pipes[1] );
 				fclose( $pipes[2] );
+				$exit_code = proc_close( $process );
+
+				if ( $timed_out ) {
+					return array(
+						'exit_code'       => 124,
+						'output'          => trim( (string) $output . "\n" . (string) $error . "\nWP Codebox task timed out after {$timeout_seconds} seconds." ),
+						'timed_out'       => true,
+						'timeout_seconds' => $timeout_seconds,
+					);
+				}
 
 				return array(
-					'exit_code' => proc_close( $process ),
+					'exit_code' => $exit_code,
 					'output'    => trim( (string) $output . "\n" . (string) $error ),
 				);
 			}

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -146,7 +146,7 @@ final class WP_Codebox_CLI_Command {
 			return $this->json_or_list( (string) $value, $field );
 		}
 
-		if ( in_array( $field, array( 'max_turns', 'preview_hold_seconds', 'preview_port', 'agent_id', 'user_id' ), true ) ) {
+		if ( in_array( $field, array( 'max_turns', 'task_timeout_seconds', 'preview_hold_seconds', 'preview_port', 'agent_id', 'user_id' ), true ) ) {
 			return (int) $value;
 		}
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -630,15 +630,17 @@ $captured_commands = array();
 $captured_recipe   = '';
 $captured_recipes  = array();
 $captured_secret_env = array();
+$captured_timeout  = null;
 $command_count     = 0;
 $runner           = new WP_Codebox_Agent_Sandbox_Runner(
 	array(
 		'shell_available' => fn() => true,
-		'command_runner'  => function ( string $command, array $secret_env = array() ) use ( &$captured_command, &$captured_commands, &$captured_recipe, &$captured_recipes, &$captured_secret_env, &$command_count ): array {
+		'command_runner'  => function ( string $command, array $secret_env = array(), int $timeout_seconds = 0 ) use ( &$captured_command, &$captured_commands, &$captured_recipe, &$captured_recipes, &$captured_secret_env, &$captured_timeout, &$command_count ): array {
 			++$command_count;
 			$captured_command    = $command;
 			$captured_commands[] = $command;
 			$captured_secret_env = $secret_env;
+			$captured_timeout    = $timeout_seconds;
 			if ( preg_match( "/--recipe '([^']+)'/", $command, $matches ) && is_readable( $matches[1] ) ) {
 				$captured_recipe   = (string) file_get_contents( $matches[1] );
 				$captured_recipes[] = $captured_recipe;
@@ -700,6 +702,7 @@ $result = $runner->run(
 		'preview_port'   => 45678,
 		'preview_bind'   => '127.0.0.1',
 		'preview_public_url' => 'https://preview.example.test/session-123/',
+		'task_timeout_seconds' => 7200,
 		'mounts'         => array(
 			array(
 				'source'   => $root . '/editable-plugin',
@@ -741,6 +744,7 @@ $assert( 'runner recipe passes default model', str_contains( $captured_recipe, '
 $assert( 'runner recipe passes provider plugin path', str_contains( $captured_recipe, 'ai-provider-test' ) );
 $assert( 'runner recipe passes generic mount metadata', str_contains( $captured_recipe, 'example/editable-plugin' ) && str_contains( $captured_recipe, 'repo_root_relative_to_mount' ) );
 $assert( 'runner recipe passes secret env name only', str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
+$assert( 'runner passes timeout to command runner and recipe', 7200 === $captured_timeout && str_contains( $captured_recipe, 'timeout-seconds=7200' ) );
 $assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
 
 $GLOBALS['wp_codebox_options']['blogname'] = 'Parent Seed Site';


### PR DESCRIPTION
## Summary
- Adds a `task_timeout_seconds` host ability input and forwards it into generated WP Codebox agent sandbox recipes as `timeout-seconds`.
- Runs sandbox recipe commands through a bounded `proc_open()` path when a timeout or secret environment is present, returning timeout metadata instead of blocking indefinitely.
- Applies the recipe timeout inside generated sandbox PHP with `set_time_limit()` so long-running agent tasks fail within the intended task budget.

## Verification
- `npm install` (also ran `npm run build` via prepare)
- `npm run command-registry-smoke`
- `npm run agent-sandbox-code-smoke`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l packages/wordpress-plugin/src/class-wp-codebox-cli-command.php`
- `php tests/smoke-wordpress-plugin.php` reaches the new timeout assertions, then fails on 16 existing artifact-apply fixture assertions unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the timeout propagation/runtime changes and ran focused local verification; Chris remains responsible for review and acceptance.