### PR TITLE
Expose runtime replay index in review evidence

### DIFF
--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -283,6 +283,7 @@ export function buildArtifactReview({
       changedFiles: "files/changed-files.json",
       testResults: "files/test-results.json",
       runtimeReferenceManifest: "files/runtime-reference-manifest.json",
+      runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
     },
     ...(browser ? { browser } : {}),
     riskFlags: [],


### PR DESCRIPTION
## Summary
- Add `runtimeReplayReferenceIndex` to the artifact review evidence map so review consumers can find `files/runtime-replay-index.json` directly.
- Complements the runtime replay/reference index work already merged in #277 for issue #262.

## Verification
- `npm run build`
- `npm run runtime-episode-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `npm run artifact-contract-smoke` attempted locally, but hung past the 25 minute tool timeout after starting; leaving CI to cover the long-running artifact contract path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the review evidence pointer, rebased around upstream issue #262/#277 changes, and ran local verification.