### PR TITLE
Keep WP Codebox consumer agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Any host: CLI, CI, mobile, Node service, WP plugin, GitHub Action, ...
 What you can build on top of WP Codebox:
 
 - **Agentic coding against a WordPress site.** Let users describe a change in chat — from any host: a WordPress plugin, a mobile app, a desktop tool, a Slack/Discord bot. Dispatch a sandbox with the target site's stack mounted, capture an artifact with a live Playground preview URL, then let the parent control plane review, apply, and open any PR. The contributor never needs shell access.
-- **Agent training and evaluation.** Run the same WordPress task side by side across multiple models in isolated Playground workspaces. Capture each model's output, grade against hidden quality checks, and produce per-model PRs as review surface. See [wp-gym](https://github.com/Automattic/wp-gym).
+- **Agent training and evaluation.** Run the same WordPress task side by side across multiple models in isolated Playground workspaces. Capture each model's output, grade against hidden quality checks, and produce per-model review artifacts.
 - **Long-running terrariums.** Boot a Playground that an agent evolves over time — software, content, configuration — with day-cycle automation driven from CI. See [world-of-wordpress](https://github.com/chubes4/world-of-wordpress).
 - **Static-site / WordPress-import factories.** Generate raw HTML/CSS sites in CI, validate them via Playground + WordPress import, post Playground preview links as PR evidence. See [wp-site-generator](https://github.com/chubes4/wp-site-generator).
 - **Untrusted patch evaluation.** Plugin and theme authors can accept community-submitted patches, run them in a sandbox, capture artifacts (diffs, test results, screenshots), and review before merging. The reviewing tool can be anything.
@@ -597,7 +597,7 @@ Supported workspace seeds:
 
 ### Bench Recipes
 
-Run `wordpress.bench` from a recipe workflow to execute plugin `tests/bench/*.php` workloads in a disposable WP Codebox runtime and emit the Homeboy-compatible `BenchResults` envelope.
+Run `wordpress.bench` from a recipe workflow to execute plugin `tests/bench/*.php` workloads in a disposable WP Codebox runtime and emit a normalized benchmark results envelope.
 
 ```bash
 npm run wp-codebox -- recipe-run \
@@ -840,7 +840,7 @@ Data Machine Code is a mounted coding-tools component inside the sandbox. It pro
 
 Apply-back is intentionally not part of `run-agent-task`. Sandbox execution returns proposed outputs and evidence. `list-artifacts`, `get-artifact`, and `discard-artifact` manage captured artifact bundles under the configured artifact root. `apply-approved-artifact` is the lower-level adapter/test API: it validates `artifact_id` plus an explicit `approved_files[]` list against canonical `changed-files.json`, recomputes the artifact content digest from `changed-files.json` and the exact `patch.diff` the reviewer approved, delegates to the `wp_codebox_apply_approved_artifact` filter, and requires the adapter to return `wp-codebox/apply-result/v1`. PR creation, direct deploy, package export, and bot identity policy live in adapters behind that reviewed boundary.
 
-When Data Machine is present, prefer `stage-artifact-apply` for user-facing apply flows. It stages that same apply input as a Data Machine pending action with kind `wp_codebox_apply_back`. Its preview includes `files/review.json`, canonical changed files, normalized test results, and the explicit approved file list. Accepting the pending action resolves through Data Machine's generic resolver and calls the existing `apply-approved-artifact` path; rejecting it leaves the artifact untouched. This keeps approval lifecycle in Data Machine without making WP Codebox depend on Homeboy or any site-specific apply adapter.
+When Data Machine is present, prefer `stage-artifact-apply` for user-facing apply flows. It stages that same apply input as a Data Machine pending action with kind `wp_codebox_apply_back`. Its preview includes `files/review.json`, canonical changed files, normalized test results, and the explicit approved file list. Accepting the pending action resolves through Data Machine's generic resolver and calls the existing `apply-approved-artifact` path; rejecting it leaves the artifact untouched. This keeps approval lifecycle in Data Machine without making WP Codebox depend on any site-specific apply adapter.
 
 ## Runtime Policy
 
@@ -881,7 +881,7 @@ WP Codebox does not own:
 - Agent identity, sessions, or model loop internals. Agents API and Data Machine own those.
 - Model provider authentication. Provider plugins and parent control planes own credentials.
 - Production mutation or deploy. Apply-back must be separate and reviewed.
-- CI/eval orchestration. Homeboy, wp-gym, or other consumers can invoke WP Codebox.
+- CI/eval orchestration. Parent control planes and other consumers can invoke WP Codebox.
 - Frontend review UX. WP Codebox should produce renderable artifacts for those UIs.
 
 ## Near-Term Gaps
@@ -893,6 +893,6 @@ WP Codebox does not own:
 
 ## Development Notes
 
-- Keep the runtime contract consumer-agnostic. Data Machine, Homeboy, Studio, wp-gym, and WordPress.com are consumers or mounted tools, not owners of the core artifact contract.
+- Keep the runtime contract consumer-agnostic. Parent control planes and mounted tools consume WP Codebox; they do not own the core artifact contract.
 - Prefer small seams: runtime lifecycle, command handlers, artifact capture, recipes, WordPress integration, and apply-back should stay separate.
 - When adding a new command or artifact type, update this README and `npm run check`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Any host: CLI, CI, mobile, Node service, WP plugin, GitHub Action, ...
 What you can build on top of WP Codebox:
 
 - **Agentic coding against a WordPress site.** Let users describe a change in chat — from any host: a WordPress plugin, a mobile app, a desktop tool, a Slack/Discord bot. Dispatch a sandbox with the target site's stack mounted, capture an artifact with a live Playground preview URL, then let the parent control plane review, apply, and open any PR. The contributor never needs shell access.
-- **Agent training and evaluation.** Run the same WordPress task side by side across multiple models in isolated Playground workspaces. Capture each model's output, grade against hidden quality checks, and produce per-model review artifacts.
+- **Agent training and evaluation.** Run the same WordPress task side by side across multiple models in isolated Playground workspaces. Capture each model's output, grade against hidden quality checks, and produce per-model review artifacts. Example implementation: [wp-gym](https://github.com/Automattic/wp-gym).
 - **Long-running terrariums.** Boot a Playground that an agent evolves over time — software, content, configuration — with day-cycle automation driven from CI. See [world-of-wordpress](https://github.com/chubes4/world-of-wordpress).
 - **Static-site / WordPress-import factories.** Generate raw HTML/CSS sites in CI, validate them via Playground + WordPress import, post Playground preview links as PR evidence. See [wp-site-generator](https://github.com/chubes4/wp-site-generator).
 - **Untrusted patch evaluation.** Plugin and theme authors can accept community-submitted patches, run them in a sandbox, capture artifacts (diffs, test results, screenshots), and review before merging. The reviewing tool can be anything.
@@ -881,7 +881,7 @@ WP Codebox does not own:
 - Agent identity, sessions, or model loop internals. Agents API and Data Machine own those.
 - Model provider authentication. Provider plugins and parent control planes own credentials.
 - Production mutation or deploy. Apply-back must be separate and reviewed.
-- CI/eval orchestration. Parent control planes and other consumers can invoke WP Codebox.
+- CI/eval orchestration. Parent control planes and other consumers can invoke WP Codebox; Homeboy is one example orchestrator.
 - Frontend review UX. WP Codebox should produce renderable artifacts for those UIs.
 
 ## Near-Term Gaps
@@ -893,6 +893,6 @@ WP Codebox does not own:
 
 ## Development Notes
 
-- Keep the runtime contract consumer-agnostic. Parent control planes and mounted tools consume WP Codebox; they do not own the core artifact contract.
+- Keep the runtime contract consumer-agnostic. Parent control planes and mounted tools consume WP Codebox; they do not own the core artifact contract. Examples include Homeboy as an orchestrator and wp-gym as an evaluation implementation.
 - Prefer small seams: runtime lifecycle, command handlers, artifact capture, recipes, WordPress integration, and apply-back should stay separate.
 - When adding a new command or artifact type, update this README and `npm run check`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,9 +24,9 @@ the agent production access. A site owner, Studio user, CI job, eval runner, or
 chat surface can ask for a change; WP Codebox runs the work in Playground and
 returns evidence that the parent product can review.
 
-Example control planes include WordPress.com, Studio, self-hosted WordPress,
-Frontend Agent Chat, Homeboy Extensions, wp-gym, GitHub Actions, and other host
-applications. They consume WP Codebox; they do not change the sandbox contract.
+Example control planes include hosted WordPress products, local development
+tools, chat surfaces, CI jobs, GitHub Actions, and other host applications. They
+consume WP Codebox; they do not change the sandbox contract.
 
 ## Landed Contracts
 
@@ -43,10 +43,9 @@ applications. They consume WP Codebox; they do not change the sandbox contract.
   [`external-apply-adapter-contract.md`](./external-apply-adapter-contract.md).
 - **Batch/fan-out primitive:** `wp-codebox/run-agent-task-batch` launches one
   isolated sandbox per task sequentially and returns per-task artifact ids,
-  preview URLs, statuses, and errors. Homeboy audit fan-out and similar
-  orchestrators should own parent-side parallelism, track their own parent jobs,
-  pass correlation metadata into each sandbox run, and store the returned
-  artifact ids as audit evidence.
+  preview URLs, statuses, and errors. Parent orchestrators own parallelism,
+  track their own jobs, pass correlation metadata into each sandbox run, and
+  store the returned artifact ids as evidence.
 
 ## Ownership Boundaries
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,8 +25,10 @@ chat surface can ask for a change; WP Codebox runs the work in Playground and
 returns evidence that the parent product can review.
 
 Example control planes include hosted WordPress products, local development
-tools, chat surfaces, CI jobs, GitHub Actions, and other host applications. They
-consume WP Codebox; they do not change the sandbox contract.
+tools, chat surfaces, CI jobs, GitHub Actions, Homeboy, and other host
+applications. They consume WP Codebox; they do not change the sandbox contract.
+wp-gym is an example implementation that can build evaluation workflows on top
+of the same generic sandbox contract.
 
 ## Landed Contracts
 
@@ -43,9 +45,9 @@ consume WP Codebox; they do not change the sandbox contract.
   [`external-apply-adapter-contract.md`](./external-apply-adapter-contract.md).
 - **Batch/fan-out primitive:** `wp-codebox/run-agent-task-batch` launches one
   isolated sandbox per task sequentially and returns per-task artifact ids,
-  preview URLs, statuses, and errors. Parent orchestrators own parallelism,
-  track their own jobs, pass correlation metadata into each sandbox run, and
-  store the returned artifact ids as evidence.
+  preview URLs, statuses, and errors. Parent orchestrators such as Homeboy own
+  parallelism, track their own jobs, pass correlation metadata into each sandbox
+  run, and store the returned artifact ids as evidence.
 
 ## Ownership Boundaries
 

--- a/docs/external-apply-adapter-contract.md
+++ b/docs/external-apply-adapter-contract.md
@@ -62,7 +62,7 @@ and reviewer workflow records.
 ## Smoke Fixture
 
 `npm run external-adapter-contract-smoke` demonstrates the contract without
-depending on Homeboy, Data Machine Code, or any other apply-back implementation.
+depending on Data Machine Code or any other apply-back implementation.
 The fixture builds a verified artifact payload, runs a stand-in parent control
 plane adapter, and persists this external record shape:
 

--- a/docs/portable-wp-codebox.md
+++ b/docs/portable-wp-codebox.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Homeboy proves that isolated WordPress environments are powerful for CI, benchmarks, evidence capture, and repeatable investigations. Studio and other real-time applications need the same principle in an embeddable TypeScript shape: start a sandbox now, stream/observe work, collect artifacts, and let the user apply or discard results without waiting for CI.
+Isolated WordPress environments are powerful for CI, benchmarks, evidence capture, and repeatable investigations. Real-time applications need the same principle in an embeddable TypeScript shape: start a sandbox now, stream/observe work, collect artifacts, and let the user apply or discard results without waiting for CI.
 
 ## Proposal
 
@@ -16,7 +16,7 @@ WordPress Playground is the first backend because it provides a cheap, portable,
 
 ## Boundary
 
-- **Homeboy** remains the operator/CI/evidence harness.
+- **Parent control planes** own operator, CI, and evidence workflows.
 - **Agents API** owns agent identity, sessions, tools, and run loops.
 - **WP AI Client** owns model/provider prompt execution.
 - **Connectors API** owns external service auth and credential configuration.

--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -20,8 +20,7 @@ Disposable Playground sandbox
 ```
 
 The host WP Codebox plugin should not depend on a specific parent job system.
-Data Machine, Homeboy, DMC, Studio, or a custom host app can all be external
-orchestrators that consume the same abilities and artifact contracts.
+External orchestrators consume the same abilities and artifact contracts.
 
 ## Browser Playground Permission Model
 

--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -20,7 +20,8 @@ Disposable Playground sandbox
 ```
 
 The host WP Codebox plugin should not depend on a specific parent job system.
-External orchestrators consume the same abilities and artifact contracts.
+External orchestrators, including Homeboy, consume the same abilities and
+artifact contracts.
 
 ## Browser Playground Permission Model
 

--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -193,7 +193,7 @@ if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') 
             if ($depth > self::TREE_MAX_DEPTH) {
                 return array();
             }
-            $ignored = array('.git', 'node_modules', 'vendor', 'dist', 'build', '.homeboy-build');
+            $ignored = array('.git', 'node_modules', 'vendor', 'dist', 'build');
             $items = scandir($current);
             if (false === $items) {
                 return array();

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -83,9 +83,9 @@ export const commandRegistry = [
   },
   {
     id: "wordpress.bench",
-    description: "Run plugin benchmark workloads and emit a Homeboy-compatible BenchResults envelope.",
+    description: "Run plugin benchmark workloads and emit a normalized benchmark results envelope.",
     acceptedArgs: [
-      { name: "component-id", description: "Component id for the BenchResults envelope.", format: "string" },
+      { name: "component-id", description: "Component id for the benchmark results envelope.", format: "string" },
       { name: "plugin-slug", description: "Plugin slug containing tests/bench workloads.", required: true, format: "slug" },
       { name: "iterations", description: "Measured iterations per workload.", format: "positive integer" },
       { name: "warmup", description: "Warmup iterations before measurement.", format: "non-negative integer" },
@@ -93,7 +93,7 @@ export const commandRegistry = [
       { name: "env-json", description: "Benchmark environment object.", format: "JSON object" },
       { name: "workloads-json", description: "Explicit workload list.", format: "JSON array" },
     ],
-    outputShape: "BenchResults JSON envelope with component_id, iterations, and scenarios.",
+    outputShape: "Benchmark results JSON envelope with component_id, iterations, and scenarios.",
     policyRequirement: "Runtime policy commands must include wordpress.bench.",
     recipe: true,
     handler: { kind: "playground", method: "runBench" },

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -167,7 +167,7 @@ See [External Apply Adapter Contract](../../docs/external-apply-adapter-contract
 for the parent-control-plane contract. The documented smoke fixture proves that
 an external adapter can consume the verified artifact payload and record adapter
 metadata, PR URL, branch, commit, and artifact digest without WP Codebox calling
-Homeboy, Data Machine Code, or any other product-specific apply-back system.
+Data Machine Code or any other product-specific apply-back system.
 
 ## Configuration
 
@@ -244,5 +244,5 @@ default list matches the sandbox-safe DMC abilities above; installations can
 narrow it with `wp_codebox_allowed_sandbox_tools` while parent-only abilities are
 always removed from the effective allow-list.
 
-Data Machine, Data Machine Code, Homeboy Extensions, wp-gym, and other systems
-are consumers or mounted tools. They do not own WP Codebox's artifact contract.
+Data Machine, Data Machine Code, and other systems are consumers or mounted
+tools. They do not own WP Codebox's artifact contract.


### PR DESCRIPTION
## Summary
- Remove direct Homeboy/wp-gym references from WP Codebox source and docs.
- Reword benchmark and orchestration language around generic parent control planes and normalized artifacts.
- Stop the sandbox tree scanner from carrying a Homeboy-specific ignored directory.

## Testing
- npm run build
- npm run release:package
- npm run command-registry-smoke
- npm run package-distribution-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the source/docs cleanup, ran verification commands, and prepared the PR summary; Chris reviewed the direction and requested the PR.