### PR TITLE
Export configurable WordPress state artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,30 @@ payloads can be stored as bundle-relative artifacts and referenced by digest.
 Refs carry matching digests so callers can compare action args, observations,
 executions, snapshots, and artifacts without parsing presentation logs.
 
+`wordpress-state` is a generic WordPress runtime state export with schema
+`wp-codebox/wordpress-state-export/v1`. The default request remains small and
+safe: `{ type: "wordpress-state" }` exports the summary section only, including
+site/home URLs, WordPress version, active theme/plugins, and post counts. Callers
+that need richer evidence can pass a section allowlist:
+
+```ts
+await episode.observe({
+  type: "wordpress-state",
+  sections: ["summary", "posts", "terms", "menus", "templates", "media", "options", "users", "rest-routes", "abilities"],
+  optionNames: ["blogname", "permalink_structure"],
+  userFields: ["roles"],
+})
+```
+
+Each exported section is written as a bundle-relative artifact under
+`files/observations/`, with a SHA-256 digest in both the observation data and the
+observation `artifactRefs`. The inline observation data summarizes non-summary
+sections by count/key metadata so traces stay compact. Posts include content
+hashes by default; pass `includeContent: true` only when full post content is
+needed. Options require `optionNames`; users are redacted by default, expose only
+allowed role/capability fields, and include identity fields only with
+`redaction: "none"` plus an explicit `userFields` allowlist.
+
 Replay is bounded to the generic runtime contract. A consumer can replay a step
 by creating a compatible backend runtime, applying the same mounts/artifact
 inputs, and executing the action envelope in order. WP Codebox intentionally

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1067,6 +1067,11 @@ export interface ObservationSpec {
   headers?: Record<string, string>
   body?: string
   includeBody?: boolean
+  sections?: string[]
+  redaction?: "safe" | "none" | (string & {})
+  includeContent?: boolean
+  optionNames?: string[]
+  userFields?: string[]
 }
 
 export interface ObservationResult {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1404,7 +1404,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     }
 
     if (spec.type === "wordpress-state") {
-      return { data: await this.observeWordPressState(), artifactRefs }
+      return this.observeWordPressState(spec, observationId)
     }
 
     if (spec.type === "http-response") {
@@ -1434,9 +1434,32 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     return { type: spec.type, path: spec.path ?? null }
   }
 
-  private async observeWordPressState(): Promise<unknown> {
+  private async observeWordPressState(spec: ObservationSpec, observationId: string): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {
     const cliServer = await this.bootPlayground()
+    const config = {
+      sections: spec.sections,
+      redaction: spec.redaction ?? "safe",
+      includeContent: spec.includeContent === true,
+      optionNames: spec.optionNames,
+      userFields: spec.userFields,
+    }
     const response = await cliServer.playground.run({ code: this.bootstrapPhpCode(`
+$config = json_decode( ${JSON.stringify(JSON.stringify(config))}, true );
+$requested_sections = isset( $config['sections'] ) && is_array( $config['sections'] ) ? array_values( array_unique( array_map( 'strval', $config['sections'] ) ) ) : array( 'summary' );
+$redaction = isset( $config['redaction'] ) ? (string) $config['redaction'] : 'safe';
+$include_content = ! empty( $config['includeContent'] );
+$option_names = isset( $config['optionNames'] ) && is_array( $config['optionNames'] ) ? array_values( array_unique( array_map( 'strval', $config['optionNames'] ) ) ) : array();
+$user_fields = isset( $config['userFields'] ) && is_array( $config['userFields'] ) ? array_values( array_unique( array_map( 'strval', $config['userFields'] ) ) ) : array();
+$allowed_sections = array( 'summary', 'posts', 'terms', 'menus', 'templates', 'media', 'options', 'users', 'rest-routes', 'abilities' );
+$sections = array_values( array_intersect( $requested_sections, $allowed_sections ) );
+if ( empty( $sections ) ) {
+    $sections = array( 'summary' );
+}
+
+$hash_value = function ( $value ) {
+    return hash( 'sha256', wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+};
+
 $post_counts = array();
 foreach ( get_post_types( array(), 'names' ) as $post_type ) {
     $counts = wp_count_posts( $post_type );
@@ -1446,17 +1469,237 @@ foreach ( get_post_types( array(), 'names' ) as $post_type ) {
     }
 }
 
+$exports = array();
+$exports['summary'] = array(
+    'siteUrl'           => get_site_url(),
+    'homeUrl'           => get_home_url(),
+    'wordpressVersion'  => get_bloginfo( 'version' ),
+    'activeTheme'       => wp_get_theme()->get_stylesheet(),
+    'activePlugins'     => array_values( (array) get_option( 'active_plugins', array() ) ),
+    'postCounts'        => $post_counts,
+);
+
+if ( in_array( 'posts', $sections, true ) ) {
+    $post_types = get_post_types( array( 'public' => true ), 'names' );
+    $posts = get_posts( array(
+        'post_type'      => array_values( $post_types ),
+        'post_status'    => 'any',
+        'posts_per_page' => 200,
+        'orderby'        => 'ID',
+        'order'          => 'ASC',
+    ) );
+    $exports['posts'] = array_map( function ( $post ) use ( $include_content, $hash_value ) {
+        $entry = array(
+            'id'          => (int) $post->ID,
+            'type'        => $post->post_type,
+            'slug'        => $post->post_name,
+            'status'      => $post->post_status,
+            'title'       => get_the_title( $post ),
+            'contentHash' => $hash_value( (string) $post->post_content ),
+            'modifiedGmt' => $post->post_modified_gmt,
+        );
+        if ( $include_content ) {
+            $entry['content'] = (string) $post->post_content;
+        }
+        return $entry;
+    }, $posts );
+}
+
+if ( in_array( 'terms', $sections, true ) ) {
+    $terms = get_terms( array( 'hide_empty' => false ) );
+    $exports['terms'] = is_wp_error( $terms ) ? array() : array_map( function ( $term ) {
+        return array(
+            'id'       => (int) $term->term_id,
+            'taxonomy' => $term->taxonomy,
+            'slug'     => $term->slug,
+            'name'     => $term->name,
+            'parent'   => (int) $term->parent,
+            'count'    => (int) $term->count,
+        );
+    }, $terms );
+}
+
+if ( in_array( 'menus', $sections, true ) ) {
+    $menus = wp_get_nav_menus();
+    $exports['menus'] = array_map( function ( $menu ) {
+        $items = wp_get_nav_menu_items( $menu->term_id );
+        return array(
+            'id'    => (int) $menu->term_id,
+            'slug'  => $menu->slug,
+            'name'  => $menu->name,
+            'items' => is_array( $items ) ? array_map( function ( $item ) {
+                return array(
+                    'id'       => (int) $item->ID,
+                    'title'    => $item->title,
+                    'url'      => $item->url,
+                    'parentId' => (int) $item->menu_item_parent,
+                    'object'   => $item->object,
+                    'type'     => $item->type,
+                );
+            }, $items ) : array(),
+        );
+    }, $menus );
+}
+
+if ( in_array( 'templates', $sections, true ) ) {
+    $exports['templates'] = array(
+        'theme'         => wp_get_theme()->get_stylesheet(),
+        'templates'     => function_exists( 'get_block_templates' ) ? array_map( function ( $template ) use ( $hash_value ) {
+            return array(
+                'id'          => $template->id ?? '',
+                'slug'        => $template->slug ?? '',
+                'theme'       => $template->theme ?? '',
+                'type'        => $template->type ?? '',
+                'source'      => $template->source ?? '',
+                'contentHash' => $hash_value( (string) ( $template->content ?? '' ) ),
+            );
+        }, get_block_templates( array(), 'wp_template' ) ) : array(),
+        'templateParts' => function_exists( 'get_block_templates' ) ? array_map( function ( $template ) use ( $hash_value ) {
+            return array(
+                'id'          => $template->id ?? '',
+                'slug'        => $template->slug ?? '',
+                'theme'       => $template->theme ?? '',
+                'area'        => $template->area ?? '',
+                'source'      => $template->source ?? '',
+                'contentHash' => $hash_value( (string) ( $template->content ?? '' ) ),
+            );
+        }, get_block_templates( array(), 'wp_template_part' ) ) : array(),
+        'globalStyles'  => function_exists( 'wp_get_global_stylesheet' ) ? array( 'stylesheetHash' => $hash_value( wp_get_global_stylesheet() ) ) : null,
+    );
+}
+
+if ( in_array( 'media', $sections, true ) ) {
+    $attachments = get_posts( array(
+        'post_type'      => 'attachment',
+        'post_status'    => 'any',
+        'posts_per_page' => 200,
+        'orderby'        => 'ID',
+        'order'          => 'ASC',
+    ) );
+    $exports['media'] = array_map( function ( $attachment ) {
+        return array(
+            'id'       => (int) $attachment->ID,
+            'slug'     => $attachment->post_name,
+            'title'    => get_the_title( $attachment ),
+            'mimeType' => $attachment->post_mime_type,
+            'metadata' => wp_get_attachment_metadata( $attachment->ID ),
+        );
+    }, $attachments );
+}
+
+if ( in_array( 'options', $sections, true ) ) {
+    $exports['options'] = array();
+    foreach ( $option_names as $option_name ) {
+        $exports['options'][ $option_name ] = get_option( $option_name, null );
+    }
+}
+
+if ( in_array( 'users', $sections, true ) ) {
+    $allowed_user_fields = array_intersect( $user_fields, array( 'ID', 'user_login', 'display_name', 'roles', 'caps' ) );
+    $users = get_users( array( 'orderby' => 'ID', 'order' => 'ASC' ) );
+    $exports['users'] = array_map( function ( $user ) use ( $allowed_user_fields, $redaction ) {
+        $entry = array( 'id' => (int) $user->ID, 'redacted' => 'none' !== $redaction );
+        foreach ( $allowed_user_fields as $field ) {
+            if ( 'ID' === $field ) {
+                $entry['ID'] = (int) $user->ID;
+            } elseif ( 'roles' === $field ) {
+                $entry['roles'] = array_values( (array) $user->roles );
+            } elseif ( 'caps' === $field ) {
+                $entry['caps'] = array_keys( array_filter( (array) $user->allcaps ) );
+            } elseif ( 'none' === $redaction ) {
+                $entry[ $field ] = (string) $user->{$field};
+            }
+        }
+        return $entry;
+    }, $users );
+}
+
+if ( in_array( 'rest-routes', $sections, true ) ) {
+    $routes = rest_get_server()->get_routes();
+    $exports['rest-routes'] = array_map( function ( $route, $handlers ) {
+        return array(
+            'route'   => $route,
+            'methods' => array_values( array_unique( array_reduce( $handlers, function ( $methods, $handler ) {
+                foreach ( (array) ( $handler['methods'] ?? array() ) as $method => $enabled ) {
+                    if ( $enabled ) {
+                        $methods[] = is_string( $method ) ? $method : (string) $enabled;
+                    }
+                }
+                return $methods;
+            }, array() ) ) ),
+        );
+    }, array_keys( $routes ), $routes );
+}
+
+if ( in_array( 'abilities', $sections, true ) ) {
+    $abilities = array();
+    if ( function_exists( 'wp_get_abilities' ) ) {
+        $registered = wp_get_abilities();
+        if ( is_array( $registered ) ) {
+            foreach ( $registered as $name => $ability ) {
+                $abilities[] = array(
+                    'name'        => (string) $name,
+                    'description' => is_array( $ability ) ? (string) ( $ability['description'] ?? '' ) : '',
+                    'category'    => is_array( $ability ) ? (string) ( $ability['category'] ?? '' ) : '',
+                );
+            }
+        }
+    }
+    $exports['abilities'] = $abilities;
+}
+
 echo wp_json_encode( array(
-    'siteUrl' => get_site_url(),
-    'homeUrl' => get_home_url(),
-    'wordpressVersion' => get_bloginfo( 'version' ),
-    'activeTheme' => wp_get_theme()->get_stylesheet(),
-    'activePlugins' => array_values( (array) get_option( 'active_plugins', array() ) ),
-    'postCounts' => $post_counts,
+    'schema'    => 'wp-codebox/wordpress-state-export/v1',
+    'version'   => 1,
+    'generatedAt' => gmdate( 'c' ),
+    'config'    => array(
+        'sections'       => $sections,
+        'redaction'      => $redaction,
+        'includeContent' => $include_content,
+        'optionNames'    => $option_names,
+        'userFields'     => $user_fields,
+    ),
+    'sections'  => $exports,
 ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 `, []) })
     assertPlaygroundResponseOk("observe.wordpress-state", response)
-    return JSON.parse(response.text || "{}")
+    const stateExport = JSON.parse(response.text || "{}") as {
+      schema?: string
+      version?: number
+      generatedAt?: string
+      config?: Record<string, unknown>
+      sections?: Record<string, unknown>
+    }
+    const sectionArtifacts: Record<string, { artifact: string; sha256: string; bytes: number }> = {}
+    const artifactRefs: RuntimeEpisodeTraceRef[] = []
+    const sections = stateExport.sections ?? {}
+
+    for (const [section, contents] of Object.entries(sections)) {
+      const serialized = `${JSON.stringify({ schema: "wp-codebox/wordpress-state-section/v1", section, data: contents }, null, 2)}\n`
+      const digest = createHash("sha256").update(serialized).digest("hex")
+      const relativePath = `files/observations/${observationId}-wordpress-state-${safeArtifactSegment(section)}.json`
+      await mkdir(dirname(join(this.artifactRoot, relativePath)), { recursive: true })
+      await writeFile(join(this.artifactRoot, relativePath), serialized)
+      sectionArtifacts[section] = { artifact: relativePath, sha256: digest, bytes: Buffer.byteLength(serialized) }
+      artifactRefs.push({
+        kind: "wordpress-state-section",
+        id: `${observationId}:${section}`,
+        path: relativePath,
+        digest: { algorithm: "sha256", value: digest },
+      })
+    }
+
+    return {
+      data: {
+        schema: stateExport.schema ?? "wp-codebox/wordpress-state-export/v1",
+        version: stateExport.version ?? 1,
+        generatedAt: stateExport.generatedAt,
+        config: stateExport.config,
+        sections: Object.fromEntries(Object.entries(sections).map(([section, contents]) => [section, summarizeWordPressStateSection(section, contents)])),
+        artifacts: sectionArtifacts,
+      },
+      artifactRefs,
+    }
   }
 
   private async observeHttpResponse(spec: ObservationSpec, observationId: string): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {
@@ -1566,7 +1809,7 @@ echo wp_json_encode( array(
     return this.observations.flatMap((observation) =>
       (observation.artifactRefs ?? [])
         .filter((ref): ref is RuntimeEpisodeTraceRef & { path: string } => typeof ref.path === "string" && ref.path.length > 0)
-        .map((ref) => fileEntry(join(this.artifactRoot, ref.path), "observation-artifact", "text/plain")),
+        .map((ref) => fileEntry(join(this.artifactRoot, ref.path), ref.kind, ref.path.endsWith(".json") ? "application/json" : "text/plain")),
     )
   }
 
@@ -1637,6 +1880,30 @@ echo wp_json_encode( array(
 
 export function createPlaygroundRuntimeBackend(): RuntimeBackend {
   return new PlaygroundRuntimeBackend()
+}
+
+function safeArtifactSegment(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "section"
+}
+
+function summarizeWordPressStateSection(section: string, contents: unknown): unknown {
+  if (section === "summary") {
+    return contents
+  }
+
+  if (Array.isArray(contents)) {
+    return { count: contents.length }
+  }
+
+  if (contents && typeof contents === "object") {
+    const entries = Object.entries(contents as Record<string, unknown>)
+    return {
+      count: entries.length,
+      keys: entries.map(([key]) => key),
+    }
+  }
+
+  return { count: contents == null ? 0 : 1 }
 }
 
 async function navigateBrowserProbe(page: Page, url: string, waitFor: string, durationMs: number): Promise<void> {

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -96,8 +96,32 @@ try {
     assert.equal(semanticHttpAction.actionRef.digest?.value, semanticHttpAction.action.digest.value)
     assert.equal(semanticHttpAction.executionRef.id, semanticHttpAction.execution.id)
     assert.equal(semanticHttpAction.observation?.type, "wordpress-state")
-    assert.equal(typeof (semanticHttpAction.observation?.data as { wordpressVersion?: unknown }).wordpressVersion, "string")
+    assert.equal((semanticHttpAction.observation?.data as { schema?: string }).schema, "wp-codebox/wordpress-state-export/v1")
+    assert.equal(typeof (((semanticHttpAction.observation?.data as { sections?: { summary?: { wordpressVersion?: unknown } } }).sections?.summary?.wordpressVersion)), "string")
+    assert.equal(semanticHttpAction.observation?.artifactRefs?.[0].kind, "wordpress-state-section")
     assert.equal(semanticHttpAction.observationRef?.digest?.value, semanticHttpAction.observation?.digest?.value)
+
+    const fullStateObservation = await episode.observe({
+      type: "wordpress-state",
+      sections: ["summary", "posts", "terms", "options", "users", "rest-routes", "abilities"],
+      optionNames: ["blogname"],
+      userFields: ["user_login", "roles"],
+    })
+    const fullStateData = fullStateObservation.data as {
+      config?: { sections?: string[] }
+      sections?: { posts?: { count?: number }; users?: { count?: number }; options?: { keys?: string[] } }
+      artifacts?: Record<string, { artifact?: string; sha256?: string; bytes?: number }>
+    }
+    assert.deepEqual(fullStateData.config?.sections, ["summary", "posts", "terms", "options", "users", "rest-routes", "abilities"])
+    assert.ok((fullStateData.sections?.posts?.count ?? 0) >= 2)
+    assert.equal(fullStateData.sections?.users?.count, 1)
+    assert.deepEqual(fullStateData.sections?.options?.keys, ["blogname"])
+    assert.match(fullStateData.artifacts?.posts?.sha256 ?? "", /^[a-f0-9]{64}$/)
+    assert.equal(fullStateObservation.artifactRefs?.some((ref) => ref.kind === "wordpress-state-section" && ref.path?.endsWith("wordpress-state-users.json")), true)
+
+    const usersArtifactRef = fullStateObservation.artifactRefs?.find((ref) => ref.path?.endsWith("wordpress-state-users.json"))
+    assert.ok(usersArtifactRef?.path, "users state export should be artifact-backed")
+    const usersArtifactPath = usersArtifactRef.path
 
     const httpObservation = await episode.observe({ type: "http-response", url: "/" })
     assert.equal(httpObservation.type, "http-response")
@@ -129,10 +153,16 @@ try {
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode-trace.json" && file.kind === "runtime-episode-trace"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-episode.jsonl" && file.kind === "runtime-episode-events"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === httpObservation.artifactRefs?.[0].path && file.kind === "observation-artifact"))
+    assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === usersArtifactPath && file.kind === "wordpress-state-section"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-replay-index.json" && file.kind === "runtime-replay-index"))
     const snapshotBundleEntry = manifest.files.find((file: { path: string; kind: string }) => file.path.startsWith("files/runtime-snapshots/") && file.kind === "runtime-snapshot-bundle")
     assert.ok(snapshotBundleEntry, "runtime snapshot bundle should be listed in manifest")
+
+    const usersArtifact = JSON.parse(await readFile(join(artifacts.directory, usersArtifactPath), "utf8")) as { data?: Array<Record<string, unknown>> }
+    assert.equal(usersArtifact.data?.[0]?.redacted, true)
+    assert.equal(Object.hasOwn(usersArtifact.data?.[0] ?? {}, "user_login"), false)
+    assert.deepEqual(usersArtifact.data?.[0]?.roles, ["administrator"])
 
     const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
     assert.equal(review.evidence.runtimeEpisodeTrace, "files/runtime-episode-trace.json")


### PR DESCRIPTION
## Summary
- Adds configurable `wordpress-state` observation sections for generic WordPress state: summary, posts, terms, menus, templates, media, options, users, REST routes, and abilities.
- Emits `wp-codebox/wordpress-state-export/v1` inline summaries plus per-section artifact files with SHA-256 hashes and observation artifact refs.
- Keeps defaults small/safe and documents option/user allowlists plus user redaction behavior.

Closes #287.

## Verification
- `npm run build` passed.
- `npm run runtime-episode-smoke` passed.
- `npm run check` progressed through the impacted runtime/artifact suites, then hit a local Playground `EADDRINUSE` preview-port collision at `preview-response-body-smoke`.
- `npm run preview-response-body-smoke` passed when rerun in isolation.
- Remaining tail commands from `check` passed: `npm run boot-preview-smoke && npm run blueprint-validation-smoke && npm run browser-probe-artifact-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, docs, and verification loop; Chris remains responsible for review and merge.