### PR TITLE
Let browser runtimes declare plugin sources

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -1288,7 +1288,12 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @param array<int,array<string,mixed>> $legacy_plugins Legacy browser_plugins specs. @return array<string,mixed>|WP_Error */
 	private static function browser_runtime_dependencies( array $input, array $legacy_plugins ): array|WP_Error {
 		$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
-		$runtime_plugins = self::normalize_browser_plugins( is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array(), 'runtime.plugins' );
+		$runtime_plugin_specs = self::browser_runtime_plugin_specs( is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array() );
+		if ( is_wp_error( $runtime_plugin_specs ) ) {
+			return $runtime_plugin_specs;
+		}
+
+		$runtime_plugins = self::normalize_browser_plugins( $runtime_plugin_specs, 'runtime.plugins' );
 		if ( is_wp_error( $runtime_plugins ) ) {
 			return $runtime_plugins;
 		}
@@ -1330,6 +1335,55 @@ final class WP_Codebox_Abilities {
 				'bootstrap'  => count( $bootstrap ),
 			),
 		);
+	}
+
+	/** @param array<int,mixed> $plugins Runtime plugin specs. @return array<int,array<string,mixed>>|WP_Error */
+	private static function browser_runtime_plugin_specs( array $plugins ): array|WP_Error {
+		$resolved = array();
+
+		foreach ( $plugins as $index => $plugin ) {
+			if ( ! is_array( $plugin ) ) {
+				return new WP_Error( 'wp_codebox_browser_plugin_invalid', 'Each browser plugin must be an object.', array( 'status' => 400, 'field' => 'runtime.plugins', 'index' => $index ) );
+			}
+
+			$resource = (string) ( $plugin['resource'] ?? 'url' );
+			$path     = 'git:directory' === $resource ? '' : self::browser_clean_path( (string) ( $plugin['path'] ?? '' ) );
+			if ( '' === $path ) {
+				$resolved[] = $plugin;
+				continue;
+			}
+
+			$slug = self::safe_key( (string) ( $plugin['slug'] ?? basename( $path ) ) );
+			if ( '' === $slug ) {
+				return new WP_Error( 'wp_codebox_browser_plugin_slug_missing', 'Browser plugin path specs require a slug.', array( 'status' => 400, 'field' => 'runtime.plugins', 'index' => $index ) );
+			}
+
+			if ( ! is_dir( $path ) ) {
+				return new WP_Error( 'wp_codebox_browser_plugin_path_missing', 'Browser plugin path does not exist.', array( 'status' => 400, 'field' => 'runtime.plugins', 'index' => $index, 'slug' => $slug ) );
+			}
+
+			$package = self::browser_package_component_plugin( $slug, $path );
+			if ( is_wp_error( $package ) ) {
+				return $package;
+			}
+
+			$resolved[] = array_merge(
+				$plugin,
+				array(
+					'slug'          => $slug,
+					'url'           => $package['url'],
+					'sha256'        => $package['sha256'],
+					'local_package' => true,
+					'provenance'    => array(
+						'schema' => 'wp-codebox/browser-plugin-provenance/v1',
+						'source' => 'runtime-plugin-path',
+						'path'   => $path,
+					),
+				)
+			);
+		}
+
+		return $resolved;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @param array<int,array<string,mixed>> $declared_plugins Caller/runtime plugin specs. @return array<int,array<string,mixed>>|WP_Error */
@@ -1584,9 +1638,14 @@ final class WP_Codebox_Abilities {
 				return new WP_Error( 'wp_codebox_browser_plugin_invalid', 'Each browser plugin must be an object.', array( 'status' => 400, 'field' => $field, 'index' => $index ) );
 			}
 
-			$url = trim( (string) ( $plugin['url'] ?? '' ) );
-			$slug = self::safe_key( (string) ( $plugin['slug'] ?? '' ) );
-			$source = self::browser_plugin_url( $url, $index );
+			$url      = trim( (string) ( $plugin['url'] ?? '' ) );
+			$slug     = self::safe_key( (string) ( $plugin['slug'] ?? '' ) );
+			$resource = (string) ( $plugin['resource'] ?? 'url' );
+			if ( ! in_array( $resource, array( 'url', 'git:directory' ), true ) ) {
+				return new WP_Error( 'wp_codebox_browser_plugin_resource_invalid', 'Browser plugin resource is not supported.', array( 'status' => 400, 'index' => $index, 'resource' => $resource ) );
+			}
+
+			$source = ! empty( $plugin['local_package'] ) ? self::browser_local_plugin_url( $url, $index ) : self::browser_plugin_url( $url, $index );
 			if ( is_wp_error( $source ) ) {
 				return $source;
 			}
@@ -1596,16 +1655,24 @@ final class WP_Codebox_Abilities {
 				return new WP_Error( 'wp_codebox_browser_plugin_sha256_invalid', 'Browser plugin sha256 must be a 64-character hex digest.', array( 'status' => 400, 'index' => $index ) );
 			}
 
+			$provenance = is_array( $plugin['provenance'] ?? null ) ? $plugin['provenance'] : array();
+
 			$normalized[] = array(
-				'url'      => $source['url'],
-				'slug'     => $slug,
-				'activate' => ! array_key_exists( 'activate', $plugin ) || (bool) $plugin['activate'],
-				'provenance' => array_filter(
+				'url'              => $source['url'],
+				'slug'             => $slug,
+				'resource'         => $resource,
+				'activate'         => ! array_key_exists( 'activate', $plugin ) || (bool) $plugin['activate'],
+				'ref'              => sanitize_text_field( (string) ( $plugin['ref'] ?? '' ) ),
+				'refType'          => sanitize_key( (string) ( $plugin['refType'] ?? '' ) ),
+				'path'             => 'git:directory' === $resource ? ltrim( str_replace( '\\', '/', (string) ( $plugin['path'] ?? '' ) ), '/' ) : '',
+				'targetFolderName' => sanitize_key( (string) ( $plugin['targetFolderName'] ?? '' ) ),
+				'provenance'       => array_filter(
 					array(
 						'schema' => 'wp-codebox/browser-plugin-provenance/v1',
 						'url'    => $source['url'],
 						'origin' => $source['origin'],
 						'host'   => $source['host'],
+						'source' => is_string( $provenance['source'] ?? null ) ? $provenance['source'] : '',
 						'sha256' => $sha256,
 					)
 				),
@@ -1613,6 +1680,20 @@ final class WP_Codebox_Abilities {
 		}
 
 		return $normalized;
+	}
+
+	/** @return array{url:string,origin:string,host:string}|WP_Error */
+	private static function browser_local_plugin_url( string $url, int $index ): array|WP_Error {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_url_invalid', 'Browser plugin URL must be absolute.', array( 'status' => 400, 'index' => $index ) );
+		}
+
+		return array(
+			'url'    => $url,
+			'origin' => self::url_origin( $parts ),
+			'host'   => strtolower( (string) $parts['host'] ),
+		);
 	}
 
 	/** @return array{url:string,origin:string,host:string}|WP_Error */
@@ -1744,15 +1825,30 @@ final class WP_Codebox_Abilities {
 		}
 
 		foreach ( $runtime['plugins'] as $plugin ) {
+			$plugin_data = array(
+				'resource' => (string) ( $plugin['resource'] ?? 'url' ),
+				'url'      => $plugin['url'],
+			);
+
+			if ( 'git:directory' === $plugin_data['resource'] ) {
+				$plugin_data['ref']     = (string) ( $plugin['ref'] ?? 'main' );
+				$plugin_data['refType'] = (string) ( $plugin['refType'] ?? 'branch' );
+				if ( '' !== (string) ( $plugin['path'] ?? '' ) ) {
+					$plugin_data['path'] = (string) $plugin['path'];
+				}
+			}
+
+			$options = array(
+				'activate' => (bool) $plugin['activate'],
+			);
+			if ( '' !== (string) ( $plugin['targetFolderName'] ?? '' ) ) {
+				$options['targetFolderName'] = (string) $plugin['targetFolderName'];
+			}
+
 			$steps[] = array(
 				'step'       => 'installPlugin',
-				'pluginData' => array(
-					'resource' => 'url',
-					'url'      => $plugin['url'],
-				),
-				'options'    => array(
-					'activate' => (bool) $plugin['activate'],
-				),
+				'pluginData' => $plugin_data,
+				'options'    => $options,
 			);
 		}
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -365,11 +365,13 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_default_agent'] = 'site-coder';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model'] = 'gpt-5.5';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_secret_env'] = array( 'OPENAI_API_KEY' );
-$GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org' );
+$GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org', 'github.com' );
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_theme_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org' );
 $GLOBALS['wp_codebox_mock_abilities']['agents/chat'] = new WP_Ability();
 mkdir( $root . '/plugin-root/data-machine', 0777, true );
 mkdir( $root . '/plugin-root/data-machine-code', 0777, true );
+mkdir( $root . '/plugin-root/studio-web', 0777, true );
+file_put_contents( $root . '/plugin-root/studio-web/studio-web.php', '<?php /* Plugin Name: Studio Web */' );
 
 $browser_session = call_user_func(
 	$browser_session_ability['execute_callback'],
@@ -395,6 +397,19 @@ $browser_session = call_user_func(
 					'slug'     => 'static-site-importer',
 					'url'      => 'https://example.test/static-site-importer.zip',
 					'activate' => false,
+				),
+				array(
+					'slug' => 'studio-web',
+					'path' => $root . '/plugin-root/studio-web',
+				),
+				array(
+					'slug'             => 'example-git-plugin',
+					'resource'         => 'git:directory',
+					'url'              => 'https://github.com/example/example-git-plugin',
+					'ref'              => 'main',
+					'refType'          => 'branch',
+					'path'             => 'plugins/example-git-plugin',
+					'targetFolderName' => 'example-git-plugin',
 				),
 			),
 			'mu_plugins' => array(
@@ -447,11 +462,13 @@ $assert( 'browser Playground session defaults to latest WordPress and PHP', ! is
 $assert( 'browser Playground session logs in before admin workflows', ! is_wp_error( $browser_session ) && 'login' === ( $browser_session['playground']['blueprint']['steps'][0]['step'] ?? '' ) && 'admin' === ( $browser_session['playground']['blueprint']['steps'][0]['username'] ?? '' ) );
 $assert( 'browser Playground session installs caller browser plugins without duplicating packaged components', ! is_wp_error( $browser_session ) && 'installPlugin' === ( $browser_session['playground']['blueprint']['steps'][1]['step'] ?? '' ) && 'https://example.test/agents-api.zip' === ( $browser_session['playground']['blueprint']['steps'][1]['pluginData']['url'] ?? '' ) && 1 === count( array_filter( $browser_session['plugins'], static fn( array $plugin ): bool => 'agents-api' === ( $plugin['slug'] ?? '' ) ) ) );
 $assert( 'browser Playground session packages required host runtime plugins', ! is_wp_error( $browser_session ) && str_starts_with( (string) ( $browser_session['plugins'][1]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/data-machine-' ) && str_starts_with( (string) ( $browser_session['plugins'][2]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/data-machine-code-' ) && 64 === strlen( (string) ( $browser_session['plugins'][1]['provenance']['sha256'] ?? '' ) ) );
-$assert( 'browser Playground session accepts structured runtime dependencies', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-runtime-dependencies/v1' === ( $browser_session['runtime']['schema'] ?? '' ) && 4 === ( $browser_session['runtime']['summary']['plugins'] ?? 0 ) && 2 === ( $browser_session['runtime']['component_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['mu_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['themes'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['bootstrap'] ?? 0 ) );
+$assert( 'browser Playground session accepts structured runtime dependencies', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-runtime-dependencies/v1' === ( $browser_session['runtime']['schema'] ?? '' ) && 6 === ( $browser_session['runtime']['summary']['plugins'] ?? 0 ) && 2 === ( $browser_session['runtime']['component_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['mu_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['themes'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['bootstrap'] ?? 0 ) );
 $assert( 'browser Playground session compiles structured runtime plugins after required components', ! is_wp_error( $browser_session ) && 'installPlugin' === ( $browser_session['playground']['blueprint']['steps'][4]['step'] ?? '' ) && 'https://example.test/static-site-importer.zip' === ( $browser_session['playground']['blueprint']['steps'][4]['pluginData']['url'] ?? '' ) && false === ( $browser_session['playground']['blueprint']['steps'][4]['options']['activate'] ?? true ) );
-$assert( 'browser Playground session compiles mu-plugin runtime dependency', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][5]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][5]['code'] ?? '' ), '/wordpress/wp-content/mu-plugins/example-review.php' ) );
-$assert( 'browser Playground session compiles theme runtime dependency', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][6]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][6]['code'] ?? '' ), '/wordpress/wp-content/themes/example-starter/style.css' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][6]['code'] ?? '' ), "require_once '/wordpress/wp-load.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][6]['code'] ?? '' ), "require_once ABSPATH . WPINC . '/theme.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][6]['code'] ?? '' ), "switch_theme( 'example-starter' )" ) );
-$assert( 'browser Playground session compiles named bootstrap runtime operation', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][7]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][7]['code'] ?? '' ), "require_once '/wordpress/wp-load.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][7]['code'] ?? '' ), "update_option( 'blogname', 'Browser Preview' )" ) );
+$assert( 'browser Playground session packages declarative runtime plugin paths', ! is_wp_error( $browser_session ) && str_starts_with( (string) ( $browser_session['plugins'][4]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/studio-web-' ) && 64 === strlen( (string) ( $browser_session['plugins'][4]['provenance']['sha256'] ?? '' ) ) );
+$assert( 'browser Playground session compiles git directory runtime plugins', ! is_wp_error( $browser_session ) && 'git:directory' === ( $browser_session['playground']['blueprint']['steps'][6]['pluginData']['resource'] ?? '' ) && 'plugins/example-git-plugin' === ( $browser_session['playground']['blueprint']['steps'][6]['pluginData']['path'] ?? '' ) && 'example-git-plugin' === ( $browser_session['playground']['blueprint']['steps'][6]['options']['targetFolderName'] ?? '' ) );
+$assert( 'browser Playground session compiles mu-plugin runtime dependency', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][7]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][7]['code'] ?? '' ), '/wordpress/wp-content/mu-plugins/example-review.php' ) );
+$assert( 'browser Playground session compiles theme runtime dependency', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][8]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), '/wordpress/wp-content/themes/example-starter/style.css' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), "require_once '/wordpress/wp-load.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), "require_once ABSPATH . WPINC . '/theme.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), "switch_theme( 'example-starter' )" ) );
+$assert( 'browser Playground session compiles named bootstrap runtime operation', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][9]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][9]['code'] ?? '' ), "require_once '/wordpress/wp-load.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][9]['code'] ?? '' ), "update_option( 'blogname', 'Browser Preview' )" ) );
 $assert( 'browser Playground session records trusted origins', ! is_wp_error( $browser_session ) && 'https://playground.automattic.ai' === ( $browser_session['playground']['provenance']['client_module_url']['origin'] ?? '' ) );
 $assert( 'browser Playground session records browser plugin provenance', ! is_wp_error( $browser_session ) && 'example.test' === ( $browser_session['plugins'][0]['provenance']['host'] ?? '' ) && str_repeat( 'a', 64 ) === ( $browser_session['plugins'][0]['provenance']['sha256'] ?? '' ) );
 $assert( 'browser Playground session includes recipe', ! is_wp_error( $browser_session ) && 'wp-codebox/workspace-recipe/v1' === ( $browser_session['recipe']['schema'] ?? '' ) );
@@ -601,6 +618,8 @@ $browser_session_missing_secret = call_user_func(
 $assert( 'browser Playground session blocks when provider secret prerequisite is missing', ! is_wp_error( $browser_session_missing_secret ) && false === ( $browser_session_missing_secret['success'] ?? true ) && in_array( 'provider_secret', $browser_session_missing_secret['signals']['ready_to_code']['missing'] ?? array(), true ) && ! array_key_exists( 'recipe', $browser_session_missing_secret ) );
 rmdir( $root . '/plugin-root/data-machine-code' );
 rmdir( $root . '/plugin-root/data-machine' );
+unlink( $root . '/plugin-root/studio-web/studio-web.php' );
+rmdir( $root . '/plugin-root/studio-web' );
 
 $custom_browser_session = call_user_func(
 	$browser_session_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Add support for `runtime.plugins` entries that Codebox packages from local plugin paths.
- Preserve `git:directory` plugin metadata so browser Playground sessions can install repo subdirectories directly.
- Cover local path packaging and git-directory plugin compilation in the WordPress plugin smoke test.

## Tests
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the runtime plugin source handling and smoke coverage; Chris reviewed direction and requested PR/merge/deploy.