### PR TITLE
Package remote browser plugins server-side

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -1347,7 +1347,35 @@ final class WP_Codebox_Abilities {
 			}
 
 			$resource = (string) ( $plugin['resource'] ?? 'url' );
-			$path     = 'git:directory' === $resource ? '' : self::browser_clean_path( (string) ( $plugin['path'] ?? '' ) );
+			if ( 'server' === (string) ( $plugin['package'] ?? '' ) ) {
+				$slug = self::safe_key( (string) ( $plugin['slug'] ?? '' ) );
+				if ( '' === $slug ) {
+					return new WP_Error( 'wp_codebox_browser_plugin_slug_missing', 'Server-packaged browser plugin specs require a slug.', array( 'status' => 400, 'field' => 'runtime.plugins', 'index' => $index ) );
+				}
+
+				$package = self::browser_package_remote_plugin( $slug, (string) ( $plugin['url'] ?? '' ), $index, (string) ( $plugin['sha256'] ?? '' ) );
+				if ( is_wp_error( $package ) ) {
+					return $package;
+				}
+
+				$resolved[] = array_merge(
+					$plugin,
+					array(
+						'slug'          => $slug,
+						'url'           => $package['url'],
+						'sha256'        => $package['sha256'],
+						'local_package' => true,
+						'provenance'    => array(
+							'schema' => 'wp-codebox/browser-plugin-provenance/v1',
+							'source' => 'runtime-plugin-remote-package',
+							'url'    => (string) ( $plugin['url'] ?? '' ),
+						),
+					)
+				);
+				continue;
+			}
+
+			$path = 'git:directory' === $resource ? '' : self::browser_clean_path( (string) ( $plugin['path'] ?? '' ) );
 			if ( '' === $path ) {
 				$resolved[] = $plugin;
 				continue;
@@ -1545,6 +1573,94 @@ final class WP_Codebox_Abilities {
 			'path'   => $zip_path,
 			'sha256' => $sha256,
 		);
+	}
+
+	/** @return array{url:string,path:string,sha256:string}|WP_Error */
+	private static function browser_package_remote_plugin( string $slug, string $url, int $index, string $expected_sha256 = '' ): array|WP_Error {
+		$source = self::browser_plugin_url( $url, $index );
+		if ( is_wp_error( $source ) ) {
+			return $source;
+		}
+
+		$expected_sha256 = strtolower( trim( $expected_sha256 ) );
+		if ( '' !== $expected_sha256 && ! preg_match( '/^[a-f0-9]{64}$/', $expected_sha256 ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_sha256_invalid', 'Browser plugin sha256 must be a 64-character hex digest.', array( 'status' => 400, 'index' => $index ) );
+		}
+
+		$upload = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array( 'basedir' => sys_get_temp_dir(), 'baseurl' => '' );
+		if ( ! is_array( $upload ) || empty( $upload['basedir'] ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_upload_dir_missing', 'Browser runtime plugin packaging requires an upload directory.', array( 'status' => 500, 'slug' => $slug ) );
+		}
+
+		$base_dir = rtrim( (string) $upload['basedir'], '/\\' ) . DIRECTORY_SEPARATOR . 'wp-codebox' . DIRECTORY_SEPARATOR . 'browser-runtime-plugins';
+		if ( ! is_dir( $base_dir ) && ! mkdir( $base_dir, 0777, true ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_package_dir_failed', 'Could not create browser runtime plugin package directory.', array( 'status' => 500, 'slug' => $slug ) );
+		}
+
+		$package_id = substr( hash( 'sha256', $slug . "\n" . $source['url'] . "\n" . $expected_sha256 ), 0, 16 );
+		$zip_path   = $base_dir . DIRECTORY_SEPARATOR . $slug . '-' . $package_id . '.zip';
+		if ( ! is_file( $zip_path ) ) {
+			$downloaded = self::browser_download_remote_plugin( $source['url'], $zip_path, $slug );
+			if ( is_wp_error( $downloaded ) ) {
+				return $downloaded;
+			}
+		}
+
+		$sha256 = hash_file( 'sha256', $zip_path );
+		if ( ! is_string( $sha256 ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_package_hash_failed', 'Could not hash browser runtime plugin package.', array( 'status' => 500, 'slug' => $slug ) );
+		}
+
+		if ( '' !== $expected_sha256 && ! hash_equals( $expected_sha256, $sha256 ) ) {
+			@unlink( $zip_path );
+			return new WP_Error( 'wp_codebox_browser_plugin_package_hash_mismatch', 'Downloaded browser runtime plugin package does not match the expected sha256.', array( 'status' => 500, 'slug' => $slug ) );
+		}
+
+		$base_url = is_array( $upload ) && ! empty( $upload['baseurl'] ) ? rtrim( (string) $upload['baseurl'], '/' ) : '';
+		$url      = '' !== $base_url ? $base_url . '/wp-codebox/browser-runtime-plugins/' . rawurlencode( basename( $zip_path ) ) : '';
+		if ( '' === $url ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_package_url_missing', 'Browser runtime plugin package URL is missing.', array( 'status' => 500, 'slug' => $slug ) );
+		}
+
+		return array(
+			'url'    => $url,
+			'path'   => $zip_path,
+			'sha256' => $sha256,
+		);
+	}
+
+	private static function browser_download_remote_plugin( string $url, string $zip_path, string $slug ): true|WP_Error {
+		$request = function_exists( 'wp_safe_remote_get' ) ? 'wp_safe_remote_get' : ( function_exists( 'wp_remote_get' ) ? 'wp_remote_get' : null );
+		if ( null === $request ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_http_missing', 'Browser runtime plugin remote packaging requires the WordPress HTTP API.', array( 'status' => 500, 'slug' => $slug ) );
+		}
+
+		$response = $request(
+			$url,
+			array(
+				'timeout'     => 60,
+				'redirection' => 5,
+			)
+		);
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = function_exists( 'wp_remote_retrieve_response_code' ) ? (int) wp_remote_retrieve_response_code( $response ) : (int) ( $response['response']['code'] ?? 0 );
+		if ( $code < 200 || $code >= 300 ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_download_failed', 'Could not download browser runtime plugin package.', array( 'status' => 502, 'slug' => $slug, 'http_status' => $code ) );
+		}
+
+		$body = function_exists( 'wp_remote_retrieve_body' ) ? (string) wp_remote_retrieve_body( $response ) : (string) ( $response['body'] ?? '' );
+		if ( '' === $body ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_download_empty', 'Downloaded browser runtime plugin package is empty.', array( 'status' => 502, 'slug' => $slug ) );
+		}
+
+		if ( false === file_put_contents( $zip_path, $body ) ) {
+			return new WP_Error( 'wp_codebox_browser_plugin_package_write_failed', 'Could not write browser runtime plugin package.', array( 'status' => 500, 'slug' => $slug ) );
+		}
+
+		return true;
 	}
 
 	private static function browser_component_source_fingerprint( string $source_path ): string {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -122,6 +122,12 @@ function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 	return $filter;
 }
 function wp_parse_url( string $url ): array|false { return parse_url( $url ); }
+function wp_safe_remote_get( string $url, array $args = array() ): array|WP_Error {
+	$GLOBALS['wp_codebox_remote_gets'][] = array( 'url' => $url, 'args' => $args );
+	return $GLOBALS['wp_codebox_remote_responses'][ $url ] ?? new WP_Error( 'not_found', 'Remote URL not mocked.' );
+}
+function wp_remote_retrieve_response_code( array $response ): int { return (int) ( $response['response']['code'] ?? 0 ); }
+function wp_remote_retrieve_body( array $response ): string { return (string) ( $response['body'] ?? '' ); }
 function is_multisite(): bool { return (bool) ( $GLOBALS['wp_codebox_is_multisite'] ?? false ); }
 function get_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_options'][ $name ] ?? $default; }
 function get_site_option( string $name, mixed $default = null ): mixed { return $GLOBALS['wp_codebox_site_options'][ $name ] ?? $default; }
@@ -368,6 +374,10 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_default_secret_env'] = array( 'OPENAI
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org', 'github.com' );
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_theme_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org' );
 $GLOBALS['wp_codebox_mock_abilities']['agents/chat'] = new WP_Ability();
+$GLOBALS['wp_codebox_remote_responses']['https://github.com/example/static-site-importer/releases/download/v1.0.0/static-site-importer.zip'] = array(
+	'response' => array( 'code' => 200 ),
+	'body'     => "PK\x03\x04server-packaged-plugin",
+);
 mkdir( $root . '/plugin-root/data-machine', 0777, true );
 mkdir( $root . '/plugin-root/data-machine-code', 0777, true );
 mkdir( $root . '/plugin-root/studio-web', 0777, true );
@@ -395,7 +405,8 @@ $browser_session = call_user_func(
 			'plugins'    => array(
 				array(
 					'slug'     => 'static-site-importer',
-					'url'      => 'https://example.test/static-site-importer.zip',
+					'url'      => 'https://github.com/example/static-site-importer/releases/download/v1.0.0/static-site-importer.zip',
+					'package'  => 'server',
 					'activate' => false,
 				),
 				array(
@@ -463,7 +474,7 @@ $assert( 'browser Playground session logs in before admin workflows', ! is_wp_er
 $assert( 'browser Playground session installs caller browser plugins without duplicating packaged components', ! is_wp_error( $browser_session ) && 'installPlugin' === ( $browser_session['playground']['blueprint']['steps'][1]['step'] ?? '' ) && 'https://example.test/agents-api.zip' === ( $browser_session['playground']['blueprint']['steps'][1]['pluginData']['url'] ?? '' ) && 1 === count( array_filter( $browser_session['plugins'], static fn( array $plugin ): bool => 'agents-api' === ( $plugin['slug'] ?? '' ) ) ) );
 $assert( 'browser Playground session packages required host runtime plugins', ! is_wp_error( $browser_session ) && str_starts_with( (string) ( $browser_session['plugins'][1]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/data-machine-' ) && str_starts_with( (string) ( $browser_session['plugins'][2]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/data-machine-code-' ) && 64 === strlen( (string) ( $browser_session['plugins'][1]['provenance']['sha256'] ?? '' ) ) );
 $assert( 'browser Playground session accepts structured runtime dependencies', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-runtime-dependencies/v1' === ( $browser_session['runtime']['schema'] ?? '' ) && 6 === ( $browser_session['runtime']['summary']['plugins'] ?? 0 ) && 2 === ( $browser_session['runtime']['component_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['mu_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['themes'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['bootstrap'] ?? 0 ) );
-$assert( 'browser Playground session compiles structured runtime plugins after required components', ! is_wp_error( $browser_session ) && 'installPlugin' === ( $browser_session['playground']['blueprint']['steps'][4]['step'] ?? '' ) && 'https://example.test/static-site-importer.zip' === ( $browser_session['playground']['blueprint']['steps'][4]['pluginData']['url'] ?? '' ) && false === ( $browser_session['playground']['blueprint']['steps'][4]['options']['activate'] ?? true ) );
+$assert( 'browser Playground session server-packages remote runtime plugins after required components', ! is_wp_error( $browser_session ) && 'installPlugin' === ( $browser_session['playground']['blueprint']['steps'][4]['step'] ?? '' ) && str_starts_with( (string) ( $browser_session['playground']['blueprint']['steps'][4]['pluginData']['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/static-site-importer-' ) && false === ( $browser_session['playground']['blueprint']['steps'][4]['options']['activate'] ?? true ) && 'runtime-plugin-remote-package' === ( $browser_session['plugins'][3]['provenance']['source'] ?? '' ) );
 $assert( 'browser Playground session packages declarative runtime plugin paths', ! is_wp_error( $browser_session ) && str_starts_with( (string) ( $browser_session['plugins'][4]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/studio-web-' ) && 64 === strlen( (string) ( $browser_session['plugins'][4]['provenance']['sha256'] ?? '' ) ) );
 $assert( 'browser Playground session compiles git directory runtime plugins', ! is_wp_error( $browser_session ) && 'git:directory' === ( $browser_session['playground']['blueprint']['steps'][6]['pluginData']['resource'] ?? '' ) && 'plugins/example-git-plugin' === ( $browser_session['playground']['blueprint']['steps'][6]['pluginData']['path'] ?? '' ) && 'example-git-plugin' === ( $browser_session['playground']['blueprint']['steps'][6]['options']['targetFolderName'] ?? '' ) );
 $assert( 'browser Playground session compiles mu-plugin runtime dependency', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][7]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][7]['code'] ?? '' ), '/wordpress/wp-content/mu-plugins/example-review.php' ) );


### PR DESCRIPTION
## Summary
- Add a server-packaged runtime plugin mode so Codebox downloads remote plugin zips through WordPress and exposes same-origin upload URLs to Playground.
- Validate optional SHA256 pins before returning packaged plugin specs, avoiding browser CORS on GitHub release asset redirects.
- Cover the flow in the WordPress plugin smoke test.

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php
- php tests/smoke-wordpress-plugin.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and validating the server-packaged runtime plugin implementation and smoke coverage; Chris reviewed direction and release intent.