### PR TITLE
Add browser probe page scripting

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -168,6 +168,7 @@ export const commandRegistry = [
       { name: "url", description: "Preview path or absolute URL to visit.", required: true, format: "path or URL" },
       { name: "wait-for", description: "Navigation wait condition.", format: "domcontentloaded|load|networkidle|selector:<selector>|duration" },
       { name: "duration", description: "Extra capture duration, or wait time when wait-for=duration.", format: "duration, e.g. 2s or 500ms" },
+      { name: "script", description: "Optional page-side JavaScript to evaluate after navigation and before final capture.", format: "JavaScript function body" },
       { name: "capture", description: "Comma-separated artifacts to capture.", format: "console,errors,html,network,screenshot" },
     ],
     outputShape: "JSON summary plus files/browser/console.jsonl, errors.jsonl, network.jsonl, snapshot.html, summary.json, and screenshot.png when captured.",

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -541,6 +541,7 @@ interface BrowserProbeArtifact {
     networkEvents: number
     replayability: BrowserProbeReplayability
     screenshot: boolean
+    scriptResult?: unknown
     viewport: BrowserProbeViewport | null
   }
 }
@@ -1211,6 +1212,7 @@ class PlaygroundRuntime implements Runtime {
 
     const waitFor = argValue(args, "wait-for")?.trim() || "domcontentloaded"
     const durationMs = durationArg(args, "duration", 0)
+    const script = argValue(args, "script")
     const targetUrl = resolveBrowserProbeUrl(urlArg, server.serverUrl)
     const browserDirectory = join(this.artifactRoot, "files", "browser")
     await mkdir(browserDirectory, { recursive: true })
@@ -1231,6 +1233,7 @@ class PlaygroundRuntime implements Runtime {
     let htmlSha256: string | undefined
     let screenshotSha256: string | undefined
     let viewport: BrowserProbeViewport | null = null
+    let scriptResult: unknown
 
     try {
       const page = await browser.newPage()
@@ -1247,6 +1250,12 @@ class PlaygroundRuntime implements Runtime {
       }
 
       await navigateBrowserProbe(page, targetUrl, waitFor, durationMs)
+      if (script) {
+        scriptResult = await page.evaluate(async (source) => {
+          const run = new Function(`return (async () => {\n${source}\n})()`)
+          return run()
+        }, script)
+      }
       if (durationMs > 0 && waitFor !== "duration") {
         await page.waitForTimeout(durationMs)
       }
@@ -1296,6 +1305,7 @@ class PlaygroundRuntime implements Runtime {
           networkEvents: network.length,
           replayability: browserProbeReplayability(capture),
           screenshot: capture.has("screenshot"),
+          ...(typeof scriptResult !== "undefined" ? { scriptResult } : {}),
           viewport,
         },
       }

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -1820,15 +1820,15 @@ final class WP_Codebox_Abilities {
 		}
 
 		$scheme     = strtolower( (string) $parts['scheme'] );
-		$allow_http = (bool) apply_filters( 'wp_codebox_browser_plugin_allow_http', false, $url, $index );
+		$host       = strtolower( (string) $parts['host'] );
+		$allow_http = self::is_loopback_host( $host ) || (bool) apply_filters( 'wp_codebox_browser_plugin_allow_http', false, $url, $index );
 		if ( 'https' !== $scheme && ! ( $allow_http && 'http' === $scheme ) ) {
 			return new WP_Error( 'wp_codebox_browser_plugin_url_insecure', 'Browser plugin URL must use https://.', array( 'status' => 400, 'index' => $index ) );
 		}
 
 		$origin        = self::url_origin( $parts );
-		$default_hosts = array( 'downloads.wordpress.org' );
+		$default_hosts = self::is_loopback_host( $host ) ? array( 'downloads.wordpress.org', $host ) : array( 'downloads.wordpress.org' );
 		$allowed_hosts = array_map( 'strtolower', self::string_list( apply_filters( 'wp_codebox_browser_plugin_allowed_hosts', $default_hosts, $url, $index ) ) );
-		$host          = strtolower( (string) $parts['host'] );
 		if ( ! in_array( $host, $allowed_hosts, true ) ) {
 			return new WP_Error( 'wp_codebox_browser_plugin_host_not_allowed', 'Browser plugin URL host is not allowed.', array( 'status' => 400, 'index' => $index, 'host' => $host ) );
 		}
@@ -1843,15 +1843,16 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_browser_theme_url_invalid', 'Browser theme URL must be absolute.', array( 'status' => 400, 'index' => $index ) );
 		}
 
-		$scheme = strtolower( (string) $parts['scheme'] );
-		if ( 'https' !== $scheme ) {
+		$scheme     = strtolower( (string) $parts['scheme'] );
+		$host       = strtolower( (string) $parts['host'] );
+		$allow_http = self::is_loopback_host( $host );
+		if ( 'https' !== $scheme && ! ( $allow_http && 'http' === $scheme ) ) {
 			return new WP_Error( 'wp_codebox_browser_theme_url_insecure', 'Browser theme URL must use https://.', array( 'status' => 400, 'index' => $index ) );
 		}
 
 		$origin        = self::url_origin( $parts );
-		$default_hosts = array( 'downloads.wordpress.org' );
+		$default_hosts = self::is_loopback_host( $host ) ? array( 'downloads.wordpress.org', $host ) : array( 'downloads.wordpress.org' );
 		$allowed_hosts = array_map( 'strtolower', self::string_list( apply_filters( 'wp_codebox_browser_theme_allowed_hosts', $default_hosts, $url, $index ) ) );
-		$host          = strtolower( (string) $parts['host'] );
 		if ( ! in_array( $host, $allowed_hosts, true ) ) {
 			return new WP_Error( 'wp_codebox_browser_theme_host_not_allowed', 'Browser theme URL host is not allowed.', array( 'status' => 400, 'index' => $index, 'host' => $host ) );
 		}
@@ -1865,6 +1866,11 @@ final class WP_Codebox_Abilities {
 		$host   = strtolower( (string) ( $parts['host'] ?? '' ) );
 		$port   = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
 		return $scheme . '://' . $host . $port;
+	}
+
+	private static function is_loopback_host( string $host ): bool {
+		$host = strtolower( trim( $host, '[]' ) );
+		return 'localhost' === $host || '127.0.0.1' === $host || '::1' === $host;
 	}
 
 	/** @return string[] */

--- a/scripts/browser-probe-artifact-smoke.ts
+++ b/scripts/browser-probe-artifact-smoke.ts
@@ -37,7 +37,13 @@ await writeFile(recipePath, `${JSON.stringify({
     steps: [
       {
         command: "wordpress.browser-probe",
-        args: ["url=/", "wait-for=load", "duration=1s", "capture=console,errors,html,network,screenshot"],
+        args: [
+          "url=/",
+          "wait-for=load",
+          "duration=1s",
+          "capture=console,errors,html,network,screenshot",
+          "script=console.info('wp-codebox fixture browser script'); return { title: document.title, hasBody: !!document.body };",
+        ],
       },
     ],
   },
@@ -79,6 +85,7 @@ const errorLog = await readFile(errorsPath, "utf8")
 const htmlSnapshot = await readFile(htmlPath, "utf8")
 const networkLog = await readFile(networkPath, "utf8")
 assert.match(consoleLog, /wp-codebox fixture console error/)
+assert.match(consoleLog, /wp-codebox fixture browser script/)
 assert.match(errorLog, /wp-codebox fixture browser error/)
 assert.match(htmlSnapshot, /Browser Error Fixture|wp-codebox fixture console error/)
 assert.match(networkLog, /"type":"response"/)
@@ -89,7 +96,7 @@ const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
   files: { html?: string; network?: string; screenshot?: string }
   hashes: { html?: { value: string }; screenshot?: { value: string } }
   viewport: { width: number; height: number; userAgent: string }
-  summary: { replayability: string; networkEvents: number; htmlSnapshot: boolean }
+  summary: { replayability: string; networkEvents: number; htmlSnapshot: boolean; scriptResult?: { title?: string; hasBody?: boolean } }
 }
 assert.equal(summary.requestedUrl.endsWith("/"), true, "summary should include requested URL")
 assert.equal(summary.finalUrl.endsWith("/"), true, "summary should include final URL")
@@ -99,6 +106,8 @@ assert.match(summary.hashes.html?.value ?? "", /^[a-f0-9]{64}$/)
 assert.match(summary.hashes.screenshot?.value ?? "", /^[a-f0-9]{64}$/)
 assert.equal(summary.summary.replayability, "artifact-backed")
 assert.equal(summary.summary.htmlSnapshot, true)
+assert.equal(summary.summary.scriptResult?.title, "My WordPress Website")
+assert.equal(summary.summary.scriptResult?.hasBody, true)
 assert.ok(summary.summary.networkEvents >= 1, "summary should count network events")
 assert.ok(summary.viewport.width > 0, "summary should include viewport width")
 assert.ok(summary.viewport.height > 0, "summary should include viewport height")

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -566,6 +566,20 @@ $browser_insecure_plugin_url = call_user_func(
 );
 $assert( 'browser Playground session rejects insecure browser plugin URLs', is_wp_error( $browser_insecure_plugin_url ) && 'wp_codebox_browser_plugin_url_insecure' === $browser_insecure_plugin_url->get_error_code() );
 
+$browser_plugin_allowed_hosts_filter = $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] ?? null;
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] );
+$browser_loopback_plugin_url = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'            => 'Prepare a browser preview with a loopback plugin URL.',
+		'browser_plugins' => array( array( 'url' => 'http://127.0.0.1:8888/plugin.zip' ) ),
+	)
+);
+if ( null !== $browser_plugin_allowed_hosts_filter ) {
+	$GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] = $browser_plugin_allowed_hosts_filter;
+}
+$assert( 'browser Playground session accepts loopback browser plugin URLs', ! is_wp_error( $browser_loopback_plugin_url ) );
+
 $browser_untrusted_plugin_host = call_user_func(
 	$browser_session_ability['execute_callback'],
 	array(


### PR DESCRIPTION
## Summary
- Adds an optional `script=` argument to `wordpress.browser-probe` so headless probes can exercise page-side flows before artifact capture.
- Records script return values in the browser probe summary and covers the behavior in the browser artifact smoke test.
- Allows loopback HTTP plugin/theme URLs for browser Playground sessions while keeping non-local HTTP rejected.

## Testing
- `npm run build && npm run browser-probe-artifact-smoke && npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris reviewed direction and requested the PR.