### PR TITLE
fix: use Homeboy build script metadata

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -5,7 +5,6 @@
   "extensions": {
     "nodejs": {}
   },
-  "build_command": "npm run package:wordpress-plugin",
   "build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip",
   "version_targets": [
     {
@@ -34,6 +33,9 @@
     }
   ],
   "scripts": {
+    "build": [
+      "npm run package:wordpress-plugin"
+    ],
     "lint": [
       "npm run build"
     ],


### PR DESCRIPTION
## Summary
- Replace the unsupported Homeboy `build_command` field with the supported `scripts.build` metadata.
- Lets `homeboy build wp-codebox` produce the configured WordPress plugin ZIP artifact used by deploys.

## Testing
- homeboy build wp-codebox --path /Users/chubes/Developer/wp-codebox@fix-homeboy-build-script

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the Homeboy deploy metadata mismatch, updated the component config, and verified the Homeboy build path.