### PR TITLE
feat: add sitemap paged-404 core-bug reproduction recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ Example recipes:
 - `examples/recipes/cookbook/theme-block-editor.json`: realistic theme/block-editor smoke surface with a mounted theme, seeded block page, and frontend/editor/admin URLs.
 - `examples/recipes/cookbook/seeded-content.json`: realistic fixture content shape with pages, posts, categories, tags, editor/author users, and preview/admin URLs.
 - `examples/recipes/cookbook/bbpress-reply-editor.json`: realistic bbPress dependency shape with a seeded forum/topic and reply form.
+- `examples/recipes/cookbook/sitemap-paged-404-repro.json`: clean-room reproduction harness for a WordPress core paginated-sitemap 404 (a sitemap sub-page is served 404 once its page number exceeds the blog sitemap page count, despite having valid URLs).
 
 Supported workspace seeds:
 

--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -232,3 +232,47 @@ WooCommerce shape (variable products, coupons, subscriptions, custom gateways,
 tax classes, shipping zones, or more order statuses), edit
 `woocommerce-store-seed.php` to add them before the JSON output line, or fork
 the recipe entirely.
+
+### `sitemap-paged-404-repro.json`
+
+A **bug-reproduction harness** (the "ship a recipe with an issue" use case) for a
+WordPress core defect: a paginated core XML sitemap sub-page
+(`wp-sitemap-posts-<cpt>-N.xml`) is served with **HTTP 404** once `N` exceeds the
+blog (`post`) sitemap page count, even though `WP_Sitemaps` would render a valid
+`<urlset>` for that page. It is the clean-room proof behind
+[Extra-Chill/data-machine-events#334](https://github.com/Extra-Chill/data-machine-events/issues/334):
+the recipe uses a plain public CPT plus a taxonomy shared on both `post` and the
+CPT, with **none** of that plugin's 404-prevention hooks, so the 404 is provably
+core behavior.
+
+```bash
+npm run wp-codebox -- recipe-run \
+  --recipe ./examples/recipes/cookbook/sitemap-paged-404-repro.json \
+  --json
+```
+
+The seed step (`sitemap-paged-404-repro-seed.php`) registers the shared CPT +
+taxonomy, seeds a boundary condition where the blog sitemap has **fewer** pages
+than the CPT/taxonomy sitemap, then drives the real core request lifecycle
+(`WP::query_posts()` → `WP::handle_404()`) for each sitemap sub-page URL and
+emits a JSON verdict. A reproducing run shows `bug_reproduced: true` with the
+beyond-boundary CPT page reporting `status_header: 404` while
+`sitemap_renderer_url_count` is non-zero — core 404s a page it has valid URLs
+for.
+
+#### Why this exists
+
+The root cause is core, not any plugin: `wp-sitemap-posts-<cpt>-N.xml` rewrites
+to `index.php?sitemap=posts&sitemap-subtype=<cpt>&paged=N` with **no** `post_type`
+query var, so the dummy main `WP_Query` defaults to `post` at the site's
+`posts_per_page`. `WP::handle_404()` runs against that main query (on the `wp`
+action) **before** `WP_Sitemaps::render_sitemaps()` runs on `template_redirect`,
+and flags `is_404()` once `paged` exceeds the blog page count. This recipe is the
+durable instrument to attach to a WordPress Trac ticket and to re-verify against
+future core versions with `--wp trunk`.
+
+#### Extending
+
+Adjust `posts_per_page`, the seed counts, or `wp_sitemaps_max_urls` in the seed
+to model other boundary ratios, or change `runtime.wp` to test whether a future
+core release fixes the behavior.

--- a/examples/recipes/cookbook/sitemap-paged-404-repro-seed.php
+++ b/examples/recipes/cookbook/sitemap-paged-404-repro-seed.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Sitemap paged-404 reproduction seed.
+ *
+ * Reproduces the WordPress core bug where a paginated core XML sitemap sub-page
+ * (wp-sitemap-posts-<cpt>-N.xml) is served with HTTP 404 once N exceeds the
+ * blog (`post`) sitemap page count, even though WP_Sitemaps would render valid
+ * XML for that page. Originally surfaced on extrachill.com via the
+ * data-machine-events plugin (Extra-Chill/data-machine-events#334), but this
+ * recipe proves the behavior is CORE: it uses a plain public CPT and a shared
+ * taxonomy with NONE of that plugin's 404-prevention hooks.
+ *
+ * Root cause (WP 7.0):
+ *   wp-sitemap-posts-<cpt>-N.xml rewrites to
+ *     index.php?sitemap=posts&sitemap-subtype=<cpt>&paged=N
+ *   with NO post_type query var. The dummy MAIN WP_Query defaults to the `post`
+ *   post type at the site's posts_per_page. WP::main() (wp-includes/class-wp.php)
+ *   calls handle_404() against that main query on the `wp` action, BEFORE
+ *   WP_Sitemaps::render_sitemaps() runs on template_redirect. Once `paged`
+ *   exceeds the blog post page count, the main query returns zero posts and core
+ *   flags is_404() -> status_header(404), stamping a 404 on a response whose
+ *   body is a valid <urlset>.
+ *
+ * This seed registers the shared CPT + taxonomy, seeds a boundary condition
+ * where the blog sitemap has FEWER pages than the CPT/taxonomy sitemap, then
+ * drives the real core request lifecycle for each sitemap sub-page URL and
+ * reports the resulting HTTP status + is_404 as JSON.
+ *
+ * Run after wp-load.php (the recipe uses wordpress.run-php).
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	fwrite( STDERR, "sitemap-paged-404-repro-seed: no ABSPATH\n" );
+	exit( 1 );
+}
+
+/* 1. Register a public CPT + a taxonomy shared on BOTH `post` and the CPT.
+ *    NO pre_get_posts / wp / pre_handle_404 hooks: pure vanilla behavior. */
+register_post_type( 'repro_event', array(
+	'public'      => true,
+	'label'       => 'Repro Events',
+	'has_archive' => true,
+	'rewrite'     => array( 'slug' => 'repro-event' ),
+	'taxonomies'  => array( 'repro_artist' ),
+) );
+register_taxonomy( 'repro_artist', array( 'post', 'repro_event' ), array(
+	'public'       => true,
+	'label'        => 'Repro Artists',
+	'hierarchical' => false,
+	'rewrite'      => array( 'slug' => 'repro-artist' ),
+) );
+
+/* Shrink sitemap page size so the CPT/taxonomy sitemaps advertise multiple
+ * pages with a modest seed. This does NOT change the mechanism: the 404
+ * boundary is driven by the MAIN query's posts_per_page (blog page count). */
+add_filter( 'wp_sitemaps_max_urls', static function () {
+	return 50;
+} );
+
+/* 2. Pretty permalinks + tiny blog page size, then flush rewrites so sitemap
+ *    routes resolve. */
+update_option( 'permalink_structure', '/%postname%/' );
+update_option( 'posts_per_page', 5 );
+
+global $wp_rewrite;
+$wp_rewrite->init();
+$wp_rewrite->set_permalink_structure( '/%postname%/' );
+$wp_rewrite->flush_rules( false );
+
+/* 3. Seed the boundary condition.
+ *    blog: 6 posts / 5 per page   = 2 main-query pages   -> 404 boundary at page 3
+ *    CPT : 120 posts / 50 max_urls = 3 CPT sitemap pages  (pages 1,2,3)
+ *    So CPT/taxonomy page 3 has paged(3) > blog page count(2): the bug zone. */
+$term    = wp_insert_term( 'Test Artist', 'repro_artist', array( 'slug' => 'test-artist' ) );
+$term_id = is_wp_error( $term )
+	? (int) get_term_by( 'slug', 'test-artist', 'repro_artist' )->term_id
+	: (int) $term['term_id'];
+
+for ( $i = 1; $i <= 6; $i++ ) {
+	wp_insert_post( array(
+		'post_type'   => 'post',
+		'post_status' => 'publish',
+		'post_title'  => "Blog Post $i",
+		'post_name'   => "blog-post-$i",
+	) );
+}
+for ( $i = 1; $i <= 120; $i++ ) {
+	$pid = wp_insert_post( array(
+		'post_type'   => 'repro_event',
+		'post_status' => 'publish',
+		'post_title'  => "Repro Event $i",
+		'post_name'   => "repro-event-$i",
+	) );
+	if ( $pid && ! is_wp_error( $pid ) ) {
+		wp_set_object_terms( $pid, array( $term_id ), 'repro_artist' );
+	}
+}
+
+$blog_posts            = (int) wp_count_posts( 'post' )->publish;
+$cpt_posts             = (int) wp_count_posts( 'repro_event' )->publish;
+$ppp                   = (int) get_option( 'posts_per_page' );
+$blog_main_query_pages = (int) ceil( $blog_posts / $ppp );
+
+/* 4. Read how many pages each subtype advertises in the sitemap index. */
+$sitemaps   = wp_sitemaps_get_server();
+$index_list = $sitemaps->index->get_sitemap_list();
+$cpt_sitemap_pages    = 0;
+$artist_sitemap_pages = 0;
+foreach ( $index_list as $entry ) {
+	$loc = $entry['loc'] ?? '';
+	if ( preg_match( '#wp-sitemap-posts-repro_event-(\d+)\.xml#', $loc, $m ) ) {
+		$cpt_sitemap_pages = max( $cpt_sitemap_pages, (int) $m[1] );
+	}
+	if ( preg_match( '#wp-sitemap-taxonomies-repro_artist-(\d+)\.xml#', $loc, $m ) ) {
+		$artist_sitemap_pages = max( $artist_sitemap_pages, (int) $m[1] );
+	}
+}
+
+/* 5. Drive the REAL core request lifecycle for each sitemap sub-page URL.
+ *    Mirrors WP::main(): query_posts() -> handle_404(). The status decision we
+ *    care about happens in handle_404 BEFORE the renderer would run/exit. */
+$probe = static function ( $query_vars_string ) {
+	global $wp, $wp_query, $wp_the_query;
+
+	$captured = array( 'status' => null );
+	$cb = static function ( $header ) use ( &$captured ) {
+		if ( preg_match( '#\s(\d{3})\s#', ' ' . $header . ' ', $m ) ) {
+			$captured['status'] = (int) $m[1];
+		}
+		return $header;
+	};
+	add_filter( 'status_header', $cb, 10, 1 );
+
+	$wp                  = new WP();
+	$wp_query            = new WP_Query();
+	$wp_the_query        = $wp_query;
+	$GLOBALS['wp_query'] = $wp_query;
+
+	parse_str( $query_vars_string, $qv );
+	$wp->query_vars = $qv;
+	$wp->query_posts();
+	$wp->handle_404();
+
+	$is_404 = $wp_query->is_404();
+
+	// What WP_Sitemaps would actually render for this page (the body it 404s).
+	$server    = wp_sitemaps_get_server();
+	$sitemap   = $qv['sitemap'] ?? '';
+	$subtype   = $qv['sitemap-subtype'] ?? '';
+	$paged     = isset( $qv['paged'] ) ? (int) $qv['paged'] : 1;
+	$url_count = null;
+	if ( $sitemap && 'index' !== $sitemap ) {
+		$provider = $server->registry->get_provider( $sitemap );
+		if ( $provider ) {
+			$url_list  = $provider->get_url_list( $paged ?: 1, $subtype );
+			$url_count = is_array( $url_list ) ? count( $url_list ) : 0;
+		}
+	}
+
+	remove_filter( 'status_header', $cb, 10 );
+
+	return array(
+		'query'                      => $query_vars_string,
+		'paged'                      => $paged,
+		'main_query_post_type'       => $wp_query->get( 'post_type' ),
+		'main_query_posts'           => count( $wp_query->posts ),
+		'main_query_found'           => (int) $wp_query->found_posts,
+		'handle_404_set_is_404'      => $is_404,
+		'status_header'              => $captured['status'],
+		'sitemap_renderer_url_count' => $url_count,
+		'result'                     => $is_404 ? '404 (core handle_404 flagged it)' : '200',
+	);
+};
+
+$probes = array(
+	// Within blog page count -> expected 200.
+	'cpt_page_1'    => $probe( 'sitemap=posts&sitemap-subtype=repro_event&paged=1' ),
+	// Beyond blog page count (3 > 2) -> the bug zone.
+	'cpt_page_3'    => $probe( 'sitemap=posts&sitemap-subtype=repro_event&paged=3' ),
+	'artist_page_1' => $probe( 'sitemap=taxonomies&sitemap-subtype=repro_artist&paged=1' ),
+	'artist_page_3' => $probe( 'sitemap=taxonomies&sitemap-subtype=repro_artist&paged=3' ),
+);
+
+$bug_reproduced = ( true === $probes['cpt_page_3']['handle_404_set_is_404'] )
+	&& ( $probes['cpt_page_3']['sitemap_renderer_url_count'] > 0 );
+
+$result = array(
+	'wp_version'              => get_bloginfo( 'version' ),
+	'core_sitemaps_enabled'   => (bool) ( $sitemaps && $sitemaps->sitemaps_enabled() ),
+	'no_404_prevention_hooks' => true,
+	'config'                  => array(
+		'blog_posts'            => $blog_posts,
+		'cpt_posts'             => $cpt_posts,
+		'posts_per_page'        => $ppp,
+		'sitemap_max_urls'      => 50,
+		'blog_main_query_pages' => $blog_main_query_pages,
+		'cpt_sitemap_pages'     => $cpt_sitemap_pages,
+		'artist_sitemap_pages'  => $artist_sitemap_pages,
+	),
+	'probes'                  => $probes,
+	'bug_reproduced'          => $bug_reproduced,
+	'verdict'                 => $bug_reproduced
+		? 'CORE BUG: vanilla WP 7.0 404s a paginated sitemap page that has valid URLs, with no plugin involved.'
+		: 'Not reproduced in this run.',
+);
+
+echo wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+echo "\n";

--- a/examples/recipes/cookbook/sitemap-paged-404-repro.json
+++ b/examples/recipes/cookbook/sitemap-paged-404-repro.json
@@ -1,0 +1,34 @@
+{
+  "schema": "wp-codebox/workspace-recipe/v1",
+  "runtime": {
+    "backend": "wordpress-playground",
+    "name": "sitemap-paged-404-repro",
+    "wp": "7.0"
+  },
+  "inputs": {
+    "mounts": [
+      {
+        "source": ".",
+        "target": "/tmp/wp-codebox-cookbook",
+        "mode": "readonly",
+        "metadata": {
+          "kind": "recipe-support",
+          "slug": "sitemap-paged-404-repro-seed"
+        }
+      }
+    ]
+  },
+  "workflow": {
+    "steps": [
+      {
+        "command": "wordpress.wp-cli",
+        "args": [
+          "command=wp eval-file /tmp/wp-codebox-cookbook/sitemap-paged-404-repro-seed.php"
+        ]
+      }
+    ]
+  },
+  "artifacts": {
+    "directory": "./artifacts"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a clean-room WP Codebox cookbook recipe that reproduces a **WordPress core** defect: a paginated core XML sitemap sub-page (`wp-sitemap-posts-<cpt>-N.xml`) is served **HTTP 404** once `N` exceeds the blog (`post`) sitemap page count, even though `WP_Sitemaps` would render a valid `<urlset>` for that page.

This is the "ship a recipe with a bug report" use case from the README — the durable reproduction harness behind [Extra-Chill/data-machine-events#334](https://github.com/Extra-Chill/data-machine-events/issues/334). It proves the 404 is core behavior, **not** a plugin trigger.

## Files

- `examples/recipes/cookbook/sitemap-paged-404-repro.json` — the recipe (Playground, `wp: "7.0"`, single `wordpress.wp-cli` `eval-file` step).
- `examples/recipes/cookbook/sitemap-paged-404-repro-seed.php` — registers a public CPT (`repro_event`) and a taxonomy (`repro_artist`) shared on **both** `post` and the CPT, with **none** of the data-machine-events 404-prevention hooks; seeds the boundary condition; drives the real core request lifecycle and emits a JSON verdict.
- Cookbook + top-level README entries.

## Root cause (WP 7.0)

`wp-sitemap-posts-<cpt>-N.xml` rewrites to `index.php?sitemap=posts&sitemap-subtype=<cpt>&paged=N` with **no** `post_type` query var, so the dummy main `WP_Query` defaults to `post` at the site's `posts_per_page`. `WP::handle_404()` (`wp-includes/class-wp.php`) runs against that main query on the `wp` action **before** `WP_Sitemaps::render_sitemaps()` runs on `template_redirect`, and flags `is_404()` once `paged` exceeds the blog page count — stamping a 404 on a body that is a valid `<urlset>`.

## Captured result (WP 7.0, Playground)

`recipe-run` output, `bug_reproduced: true`:

| probe | paged | main_query_post_type | main_query_posts | status_header | sitemap_renderer_url_count |
|---|---|---|---|---|---|
| cpt_page_1 | 1 | `""` (→post) | 5 | **200** | 50 |
| cpt_page_3 | 3 | `""` (→post) | 0 | **404** | **20** |
| artist_page_1 | 1 | `""` (→post) | 5 | **200** | 1 |
| artist_page_3 | 3 | `""` (→post) | 0 | **404** | 0 |

Config: `blog_main_query_pages=2` (7 posts / 5 per page), `cpt_sitemap_pages=3`. The 404 boundary tracks the **blog** page count, exactly as observed in production.

## How to run

```bash
npm run wp-codebox -- recipe-run \
  --recipe ./examples/recipes/cookbook/sitemap-paged-404-repro.json \
  --json
```

Change `runtime.wp` to `trunk` to check whether a future core release fixes the behavior.

## Checks

- `recipe validate` → valid.
- `php -l` on the seed → clean.
- `recipe-run` executed end-to-end in Playground WP 7.0 (numbers above are captured, not theorized).

Do not merge without review.

cc <@532385681268408341>