### PR TITLE
docs: add browser-actions interaction-probe cookbook example

### DIFF
--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -189,6 +189,66 @@ The seed step is intentionally small. If you need additional bbPress shape
 varying content shapes), edit `bbpress-reply-editor-seed.php` to add them
 before the JSON output line, or fork the recipe entirely.
 
+### `browser-actions-demo.json`
+
+The reference example for the **`wordpress.browser-actions` interaction probe**
+(shipped in wp-codebox #311). Where the other cookbook recipes seed a host shape
+and pair with `--preview-hold` for *manual* clicking, this recipe *drives* a
+real React component with an ordered interaction script and asserts that it
+still **works** — not just that the page renders.
+
+It boots WordPress **trunk** (so the editor stack runs on **React 19**), mounts
+a tiny vendor-neutral demo plugin (`browser-actions-demo-plugin/`) that renders
+a real `@wordpress/element` widget — a click counter and a bound range slider —
+into a Tools admin page, then drives it:
+
+- clicks the **Increment** button three times and asserts the counter advanced
+  to `3` and a "threshold reached" message appeared;
+- moves the **slider** to `80` and asserts the bound output value updated.
+
+```bash
+npm run wp-codebox -- recipe-run \
+  --recipe ./examples/recipes/cookbook/browser-actions-demo.json \
+  --json
+```
+
+The demo plugin uses `@wordpress/element` (the React WordPress already ships) so
+the fixture needs **no build step** — the recipe mounts the plugin directory
+as-is.
+
+The recipe's `wordpress.browser-actions` step records its evidence under
+`artifacts/<runtime>/files/browser/`:
+
+- `steps.jsonl` — per-step index/kind/selector/timing/ok-fail
+- `action-summary.json` — the machine-readable `assertions` block
+  (`total`/`passed`/`failed`) plus each `expect`/`evaluate` result
+- `screenshot-*.png` — named captures: `demo-loaded`, `after-increment`,
+  `after-slider`
+
+A green run reports **6/6 assertions passed, 0 failed, 0 page errors**.
+
+#### Why this exists
+
+A render-only smoke test ("the component mounts") would not catch a regression
+where a component renders but its interaction is dead — the exact failure mode
+that bites when a third-party React widget breaks on a major React bump (React
+18 → 19 changed effect timing, `ref` semantics, and Strict Mode
+double-invocation). The interaction probe drives the real component and asserts
+behavior, which is the difference between "it renders" and "it works."
+
+#### Adapting it to your plugin
+
+Swap `inputs.mounts[0].source` to your plugin and rewrite the `steps-json` to
+drive your own UI: `click`/`hover`/`fill`/`type`/`select`/`drag` to interact,
+`expect`/`evaluate` to assert state, and `screenshot` to capture named frames.
+Keep `steps-json` inline (not `@file`) if it contains an `evaluate` step so the
+recipe auto-grants the `wordpress.browser-actions.evaluate` policy capability.
+
+A worked, plugin-specific consumer of this capability — driving the
+[data-machine-socials](https://github.com/Extra-Chill/data-machine-socials)
+`react-easy-crop` modal under React 19 — lives in that plugin's own repository,
+where the recipe sits next to the code it guards.
+
 ### `woocommerce-store.json`
 
 Boots a Playground with WooCommerce installed from `wordpress.org/plugins`,

--- a/examples/recipes/cookbook/browser-actions-demo-plugin/browser-actions-demo.php
+++ b/examples/recipes/cookbook/browser-actions-demo-plugin/browser-actions-demo.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Plugin Name: WP Codebox Browser Actions Demo
+ * Description: Vendor-neutral fixture for the wordpress.browser-actions cookbook
+ *              example. Registers an admin page that renders a small, real
+ *              React (@wordpress/element) interactive widget so the interaction
+ *              probe has genuine behavior to drive and assert — not just static
+ *              markup.
+ * Version: 0.0.1
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Register a Tools submenu page that hosts the interactive demo widget.
+ */
+add_action( 'admin_menu', static function (): void {
+	add_management_page(
+		'Browser Actions Demo',
+		'Browser Actions Demo',
+		'edit_posts',
+		'wp-codebox-browser-actions-demo',
+		static function (): void {
+			// The React app mounts into this root. The probe asserts against the
+			// elements the app renders, proving the component actually works.
+			echo '<div class="wrap"><h1>Browser Actions Demo</h1>';
+			echo '<div id="wpcb-browser-actions-demo-root"></div>';
+			echo '</div>';
+		}
+	);
+} );
+
+/**
+ * Enqueue the inline React widget on our demo page only.
+ *
+ * Uses @wordpress/element (the React WordPress already ships) so this fixture
+ * needs no build step: the recipe can mount the plugin directory as-is.
+ */
+add_action( 'admin_enqueue_scripts', static function ( string $hook ): void {
+	if ( 'tools_page_wp-codebox-browser-actions-demo' !== $hook ) {
+		return;
+	}
+
+	wp_enqueue_script( 'wp-element' );
+
+	$script = <<<'JS'
+( function ( el, render, useState ) {
+	var e = el.createElement;
+
+	function Demo() {
+		var countState = useState( 0 );
+		var count = countState[0];
+		var setCount = countState[1];
+
+		var sliderState = useState( 50 );
+		var slider = sliderState[0];
+		var setSlider = sliderState[1];
+
+		return e(
+			'div',
+			{ className: 'wpcb-demo', style: { maxWidth: 480 } },
+			e( 'p', null, 'A real React component. The interaction probe drives it.' ),
+			e(
+				'div',
+				{ className: 'wpcb-counter' },
+				e(
+					'button',
+					{
+						type: 'button',
+						className: 'button button-primary wpcb-increment',
+						onClick: function () { setCount( count + 1 ); }
+					},
+					'Increment'
+				),
+				e(
+					'span',
+					{ className: 'wpcb-count', 'data-count': String( count ), style: { marginLeft: 12 } },
+					'Count: ' + count
+				)
+			),
+			e(
+				'div',
+				{ className: 'wpcb-slider-row', style: { marginTop: 16 } },
+				e( 'label', { htmlFor: 'wpcb-slider' }, 'Value' ),
+				e( 'input', {
+					id: 'wpcb-slider',
+					className: 'wpcb-slider',
+					type: 'range',
+					min: 0,
+					max: 100,
+					value: slider,
+					onChange: function ( ev ) { setSlider( Number( ev.target.value ) ); }
+				} ),
+				e(
+					'output',
+					{ className: 'wpcb-slider-value', 'data-value': String( slider ) },
+					String( slider )
+				)
+			),
+			count >= 3
+				? e( 'p', { className: 'wpcb-threshold' }, 'Threshold reached: clicked at least 3 times.' )
+				: null
+		);
+	}
+
+	render( e( Demo ), document.getElementById( 'wpcb-browser-actions-demo-root' ) );
+} )( window.wp.element, window.wp.element.render, window.wp.element.useState );
+JS;
+
+	wp_add_inline_script( 'wp-element', $script );
+} );

--- a/examples/recipes/cookbook/browser-actions-demo-seed.php
+++ b/examples/recipes/cookbook/browser-actions-demo-seed.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Browser Actions Demo cookbook seed.
+ *
+ * Activates the mounted vendor-neutral demo plugin and auto-logs in as admin so
+ * the interaction probe can navigate straight to the demo's Tools page and
+ * drive its real React widget.
+ *
+ * Output: JSON with the demo page URL the wordpress.browser-actions step
+ * navigates to.
+ */
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+$demo_plugin = null;
+foreach ( get_plugins( '/browser-actions-demo' ) as $plugin_file => $plugin_data ) {
+	if ( ! empty( $plugin_data['Name'] ) ) {
+		$demo_plugin = 'browser-actions-demo/' . $plugin_file;
+		break;
+	}
+}
+
+if ( $demo_plugin && ! is_plugin_active( $demo_plugin ) ) {
+	$result = activate_plugin( $demo_plugin );
+	if ( is_wp_error( $result ) ) {
+		throw new RuntimeException( $result->get_error_message() );
+	}
+}
+
+// Auto-login admin so the admin demo page is authorized.
+wp_set_auth_cookie( 1, true );
+
+echo wp_json_encode( array(
+	'demo_plugin'        => $demo_plugin,
+	'demo_active'        => $demo_plugin ? is_plugin_active( $demo_plugin ) : false,
+	'demo_url'           => admin_url( 'tools.php?page=wp-codebox-browser-actions-demo' ),
+	'demo_url_relative'  => '/wp-admin/tools.php?page=wp-codebox-browser-actions-demo',
+	'admin_url'          => admin_url(),
+	'home_url'           => home_url( '/' ),
+), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+echo "\n";

--- a/examples/recipes/cookbook/browser-actions-demo.json
+++ b/examples/recipes/cookbook/browser-actions-demo.json
@@ -1,0 +1,63 @@
+{
+  "schema": "wp-codebox/workspace-recipe/v1",
+  "runtime": {
+    "backend": "wordpress-playground",
+    "name": "browser-actions-demo-lab",
+    "wp": "trunk",
+    "blueprint": {
+      "steps": [
+        {
+          "step": "installTheme",
+          "themeData": {
+            "resource": "wordpress.org/themes",
+            "slug": "twentytwentyfive"
+          },
+          "options": {
+            "activate": true
+          }
+        },
+        {
+          "step": "login",
+          "username": "admin",
+          "password": "password"
+        }
+      ]
+    }
+  },
+  "inputs": {
+    "mounts": [
+      {
+        "source": "./browser-actions-demo-plugin",
+        "target": "/wordpress/wp-content/plugins/browser-actions-demo",
+        "mode": "readonly",
+        "metadata": {
+          "kind": "component",
+          "slug": "browser-actions-demo",
+          "editable": false
+        }
+      }
+    ]
+  },
+  "workflow": {
+    "steps": [
+      {
+        "command": "wordpress.run-php",
+        "args": [
+          "code-file=./examples/recipes/cookbook/browser-actions-demo-seed.php"
+        ]
+      },
+      {
+        "command": "wordpress.browser-actions",
+        "args": [
+          "step-timeout=30s",
+          "timeout=120s",
+          "capture=steps,console,errors,network,html,screenshot",
+          "steps-json=[{\"kind\":\"navigate\",\"url\":\"/wp-admin/tools.php?page=wp-codebox-browser-actions-demo\",\"waitFor\":\"load\"},{\"kind\":\"waitFor\",\"selector\":\".wpcb-increment\"},{\"kind\":\"screenshot\",\"name\":\"demo-loaded\"},{\"kind\":\"expect\",\"selector\":\".wpcb-count[data-count=\\\"0\\\"]\",\"state\":\"visible\"},{\"kind\":\"click\",\"selector\":\".wpcb-increment\"},{\"kind\":\"click\",\"selector\":\".wpcb-increment\"},{\"kind\":\"click\",\"selector\":\".wpcb-increment\"},{\"kind\":\"expect\",\"selector\":\".wpcb-count[data-count=\\\"3\\\"]\",\"state\":\"visible\"},{\"kind\":\"expect\",\"selector\":\".wpcb-threshold\",\"state\":\"visible\"},{\"kind\":\"evaluate\",\"expression\":\"document.querySelector('.wpcb-count').getAttribute('data-count')\",\"assert\":\"3\"},{\"kind\":\"screenshot\",\"name\":\"after-increment\"},{\"kind\":\"fill\",\"selector\":\".wpcb-slider\",\"value\":\"80\"},{\"kind\":\"expect\",\"selector\":\".wpcb-slider-value[data-value=\\\"80\\\"]\",\"state\":\"visible\"},{\"kind\":\"evaluate\",\"expression\":\"document.querySelector('.wpcb-slider-value').getAttribute('data-value')\",\"assert\":\"80\"},{\"kind\":\"screenshot\",\"name\":\"after-slider\"}]"
+        ]
+      }
+    ]
+  },
+  "artifacts": {
+    "directory": "./artifacts"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the reference cookbook example for the **`wordpress.browser-actions` interaction probe** shipped in #311. It boots WordPress **trunk** (so the editor stack runs on **React 19**), mounts a tiny **vendor-neutral** `@wordpress/element` demo plugin (no build step), and *drives* it with an ordered interaction script to prove the probe verifies a component **works** — not just that it renders.

This is the difference #311 was built for: a render-only probe ("the component mounts") would miss a regression where a component renders but its interaction is dead after a React major bump.

> **Scope note:** an earlier revision of this PR shipped a plugin-specific recipe driving the data-machine-socials `react-easy-crop` modal. Per the platform's layer-purity convention (generic layers shouldn't hard-code vendor specifics), that worked consumer now lives in **data-machine-socials' own repo**, next to the code it guards. This PR keeps only the generic, swappable example.

## What's added

- `examples/recipes/cookbook/browser-actions-demo.json` — the recipe (WP trunk, mounts the demo plugin, runs the seed, then a `wordpress.browser-actions` step).
- `examples/recipes/cookbook/browser-actions-demo-plugin/browser-actions-demo.php` — a tiny fixture plugin that renders a real `@wordpress/element` widget (click counter + bound range slider) into a Tools admin page. No build step.
- `examples/recipes/cookbook/browser-actions-demo-seed.php` — activates the plugin, logs in admin, emits the demo URL.
- `examples/recipes/cookbook/README.md` — documents the example and how to adapt it.

## The interaction script (`steps-json`)

```jsonc
[
  { "kind": "navigate",   "url": "/wp-admin/tools.php?page=wp-codebox-browser-actions-demo", "waitFor": "load" },
  { "kind": "waitFor",    "selector": ".wpcb-increment" },
  { "kind": "screenshot", "name": "demo-loaded" },
  { "kind": "expect",     "selector": ".wpcb-count[data-count=\"0\"]", "state": "visible" },
  { "kind": "click",      "selector": ".wpcb-increment" },
  { "kind": "click",      "selector": ".wpcb-increment" },
  { "kind": "click",      "selector": ".wpcb-increment" },
  { "kind": "expect",     "selector": ".wpcb-count[data-count=\"3\"]", "state": "visible" },
  { "kind": "expect",     "selector": ".wpcb-threshold", "state": "visible" },
  { "kind": "evaluate",   "expression": "document.querySelector('.wpcb-count').getAttribute('data-count')", "assert": "3" },
  { "kind": "screenshot", "name": "after-increment" },
  { "kind": "fill",       "selector": ".wpcb-slider", "value": "80" },
  { "kind": "expect",     "selector": ".wpcb-slider-value[data-value=\"80\"]", "state": "visible" },
  { "kind": "evaluate",   "expression": "document.querySelector('.wpcb-slider-value').getAttribute('data-value')", "assert": "80" },
  { "kind": "screenshot", "name": "after-slider" }
]
```

## Real run results (`action-summary.json`)

Ran end-to-end with `npm run wp-codebox -- recipe-run --recipe ./examples/recipes/cookbook/browser-actions-demo.json --json` on WordPress **trunk** / React 19:

```
success: true
steps: 15/15 ok
assertions: { "total": 6, "passed": 6, "failed": 0 }
errors: 0
```

| # | kind | target | passed |
|---|------|--------|--------|
| 1 | expect | counter starts at 0 | ✅ |
| 2 | expect | counter == 3 after 3 clicks | ✅ |
| 3 | expect | `.wpcb-threshold` message visible | ✅ |
| 4 | evaluate | `data-count` == "3" | ✅ |
| 5 | expect | slider output == 80 | ✅ |
| 6 | evaluate | `data-value` == "80" | ✅ |

## Adapting it

Swap `inputs.mounts[0].source` to your plugin and rewrite `steps-json` to drive your own UI (`click`/`fill`/`drag` to interact, `expect`/`evaluate` to assert, `screenshot` to capture). Keep `steps-json` inline (not `@file`) if it contains an `evaluate` step so the recipe auto-grants the `wordpress.browser-actions.evaluate` policy capability.

Consumes the capability added in #311.

---

Note: building the original socials-specific version surfaced a real latent bug in data-machine-socials (a double `/wp-json/` prefix in `apiFetch` paths), filed as Extra-Chill/data-machine-socials#145.
