### PR TITLE
Support binary browser artifact files

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -9,6 +9,8 @@ defined( 'ABSPATH' ) || exit;
 
 final class WP_Codebox_Abilities {
 
+	private const BROWSER_ARTIFACT_MAX_BYTES = 5242880;
+
 	private static bool $registered = false;
 
 	public function __construct() {
@@ -365,13 +367,16 @@ final class WP_Codebox_Abilities {
 							),
 							'artifact_files'     => array(
 								'type'        => 'array',
-								'description' => 'Optional text artifact files the browser should write into Playground.',
+								'description' => 'Optional text or base64 artifact files the browser should write into Playground.',
 								'items'       => array(
 									'type'       => 'object',
-									'required'   => array( 'path', 'content' ),
+									'required'   => array( 'path' ),
 									'properties' => array(
 										'path'        => array( 'type' => 'string' ),
 										'content'     => array( 'type' => 'string' ),
+										'content_base64' => array( 'type' => 'string' ),
+										'encoding'    => array( 'type' => 'string' ),
+										'mime_type'   => array( 'type' => 'string' ),
 										'kind'        => array( 'type' => 'string' ),
 										'description' => array( 'type' => 'string' ),
 									),
@@ -1066,7 +1071,7 @@ final class WP_Codebox_Abilities {
 		return WP_Codebox_Agent_Task::string_list( $value );
 	}
 
-	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,string>>|WP_Error */
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
 	private static function browser_artifact_files( array $input ): array|WP_Error {
 		$files      = is_array( $input['artifact_files'] ?? null ) ? $input['artifact_files'] : array();
 		$playground = is_array( $input['playground'] ?? null ) ? $input['playground'] : array();
@@ -1078,22 +1083,100 @@ final class WP_Codebox_Abilities {
 				return new WP_Error( 'wp_codebox_browser_artifact_file_invalid', 'Each browser artifact file must be an object.', array( 'status' => 400, 'index' => $index ) );
 			}
 
-			$path = trim( (string) ( $file['path'] ?? '' ) );
-			if ( '' === $path || str_contains( $path, '..' ) || str_starts_with( $path, '/' ) || ! preg_match( '#^[A-Za-z0-9_./-]+$#', $path ) ) {
-				return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must be safe relative paths.', array( 'status' => 400, 'index' => $index ) );
+			$path_validation = self::validate_browser_artifact_path( trim( (string) ( $file['path'] ?? '' ) ), (int) $index );
+			if ( is_wp_error( $path_validation ) ) {
+				return $path_validation;
+			}
+			$path = $path_validation;
+
+			$encoding = strtolower( trim( (string) ( $file['encoding'] ?? '' ) ) );
+			if ( '' === $encoding ) {
+				$encoding = array_key_exists( 'content_base64', $file ) ? 'base64' : 'utf-8';
 			}
 
-			$normalized[] = array(
+			if ( ! in_array( $encoding, array( 'utf-8', 'base64' ), true ) ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_encoding_invalid', 'Browser artifact file encoding must be utf-8 or base64.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'encoding' => $encoding ) );
+			}
+
+			if ( 'base64' === $encoding ) {
+				$encoded = (string) ( $file['content_base64'] ?? $file['content'] ?? '' );
+				$bytes   = base64_decode( $encoded, true );
+				if ( false === $bytes ) {
+					return new WP_Error( 'wp_codebox_browser_artifact_base64_invalid', 'Browser artifact file content_base64 must be valid base64.', array( 'status' => 400, 'index' => $index, 'path' => $path ) );
+				}
+			} else {
+				$bytes   = (string) ( $file['content'] ?? '' );
+				$encoded = '';
+			}
+
+			$size = strlen( $bytes );
+			if ( $size > self::BROWSER_ARTIFACT_MAX_BYTES ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_file_too_large', 'Browser artifact file exceeds the maximum inline size.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'size' => $size, 'max_size' => self::BROWSER_ARTIFACT_MAX_BYTES ) );
+			}
+
+			$mime_type = trim( (string) ( $file['mime_type'] ?? '' ) );
+			if ( '' === $mime_type ) {
+				$mime_type = self::browser_artifact_mime_type( $path );
+			}
+
+			$artifact = array(
 				'path'            => $path,
 				'playground_path' => self::join_browser_path( $base_path, $path ),
 				'url_path'        => self::join_browser_path( $base_url, $path ),
-				'content'         => (string) ( $file['content'] ?? '' ),
+				'encoding'        => $encoding,
+				'mime_type'       => $mime_type,
+				'size'            => $size,
+				'sha256'          => hash( 'sha256', $bytes ),
 				'kind'            => (string) ( $file['kind'] ?? 'text' ),
 				'description'     => (string) ( $file['description'] ?? '' ),
 			);
+
+			if ( 'base64' === $encoding ) {
+				$artifact['content_base64'] = $encoded;
+			} else {
+				$artifact['content'] = $bytes;
+			}
+
+			$normalized[] = $artifact;
 		}
 
 		return $normalized;
+	}
+
+	private static function validate_browser_artifact_path( string $path, int $index ): string|WP_Error {
+		if ( '' === $path || str_starts_with( $path, '/' ) || ! preg_match( '#^[A-Za-z0-9_./-]+$#', $path ) ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must be safe relative paths.', array( 'status' => 400, 'index' => $index, 'path' => $path ) );
+		}
+
+		$segments = explode( '/', $path );
+		foreach ( $segments as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must not contain empty, current-directory, or parent-directory segments.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'segment' => $segment ) );
+			}
+		}
+
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		if ( in_array( $extension, array( 'php', 'phtml', 'phar', 'cgi', 'pl', 'py', 'rb', 'asp', 'aspx', 'jsp' ), true ) ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_extension_blocked', 'Browser artifact files must not use executable server-side extensions.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'extension' => $extension ) );
+		}
+
+		return $path;
+	}
+
+	private static function browser_artifact_mime_type( string $path ): string {
+		return match ( strtolower( pathinfo( $path, PATHINFO_EXTENSION ) ) ) {
+			'html', 'htm' => 'text/html',
+			'css'        => 'text/css',
+			'js', 'mjs'   => 'text/javascript',
+			'json'       => 'application/json',
+			'svg'        => 'image/svg+xml',
+			'jpg', 'jpeg' => 'image/jpeg',
+			'png'        => 'image/png',
+			'webp'       => 'image/webp',
+			'gif'        => 'image/gif',
+			'txt'        => 'text/plain',
+			default      => 'application/octet-stream',
+		};
 	}
 
 	/** @param array<int,mixed> $mu_plugins Mu-plugin dependency specs. @return array<int,array<string,mixed>>|WP_Error */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -458,6 +458,40 @@ $browser_session = call_user_func(
 				'content' => '<main>Preview</main>',
 				'kind'    => 'static-html',
 			),
+			array(
+				'path'    => 'static-site/assets/app.css',
+				'content' => 'body { color: #111; }',
+				'kind'    => 'stylesheet',
+			),
+			array(
+				'path'    => 'static-site/assets/app.js',
+				'content' => 'console.log( "preview" );',
+				'kind'    => 'script',
+			),
+			array(
+				'path'           => 'static-site/assets/photo.png',
+				'content_base64' => base64_encode( "\x89PNG\r\n\x1a\nfixture" ),
+				'encoding'       => 'base64',
+				'kind'           => 'image',
+			),
+			array(
+				'path'           => 'static-site/assets/photo.jpg',
+				'content_base64' => base64_encode( "\xff\xd8fixture\xff\xd9" ),
+				'encoding'       => 'base64',
+				'kind'           => 'image',
+			),
+			array(
+				'path'           => 'static-site/assets/hero.webp',
+				'content_base64' => base64_encode( 'RIFFfixtureWEBP' ),
+				'encoding'       => 'base64',
+				'kind'           => 'image',
+			),
+			array(
+				'path'      => 'static-site/assets/icon.svg',
+				'content'   => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>',
+				'mime_type' => 'image/svg+xml',
+				'kind'      => 'image',
+			),
 		),
 	)
 );
@@ -491,6 +525,9 @@ $assert( 'browser Playground session exposes runtime dependency readiness metada
 $assert( 'browser Playground session preserves safe artifact files', ! is_wp_error( $browser_session ) && 'static-site/index.html' === ( $browser_session['artifacts']['files'][0]['path'] ?? '' ) );
 $assert( 'browser Playground session exposes artifact write paths', ! is_wp_error( $browser_session ) && '/wordpress/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['files'][0]['playground_path'] ?? '' ) );
 $assert( 'browser Playground session exposes artifact URL paths', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['files'][0]['url_path'] ?? '' ) );
+$assert( 'browser Playground session preserves mixed text and binary artifact trees', ! is_wp_error( $browser_session ) && 'text/css' === ( $browser_session['artifacts']['files'][1]['mime_type'] ?? '' ) && 'text/javascript' === ( $browser_session['artifacts']['files'][2]['mime_type'] ?? '' ) && 'image/png' === ( $browser_session['artifacts']['files'][3]['mime_type'] ?? '' ) && 'image/jpeg' === ( $browser_session['artifacts']['files'][4]['mime_type'] ?? '' ) && 'image/webp' === ( $browser_session['artifacts']['files'][5]['mime_type'] ?? '' ) && 'image/svg+xml' === ( $browser_session['artifacts']['files'][6]['mime_type'] ?? '' ) );
+$assert( 'browser Playground session returns binary artifact metadata', ! is_wp_error( $browser_session ) && 'base64' === ( $browser_session['artifacts']['files'][3]['encoding'] ?? '' ) && strlen( "\x89PNG\r\n\x1a\nfixture" ) === ( $browser_session['artifacts']['files'][3]['size'] ?? 0 ) && hash( 'sha256', "\x89PNG\r\n\x1a\nfixture" ) === ( $browser_session['artifacts']['files'][3]['sha256'] ?? '' ) && isset( $browser_session['artifacts']['files'][3]['content_base64'] ) );
+$assert( 'browser Playground session keeps existing text artifact content', ! is_wp_error( $browser_session ) && 'utf-8' === ( $browser_session['artifacts']['files'][0]['encoding'] ?? '' ) && '<main>Preview</main>' === ( $browser_session['artifacts']['files'][0]['content'] ?? '' ) && hash( 'sha256', '<main>Preview</main>' ) === ( $browser_session['artifacts']['files'][0]['sha256'] ?? '' ) );
 $assert( 'browser Playground session exposes preview URL', ! is_wp_error( $browser_session ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['playground']['preview_url'] ?? '' ) && '/wp-content/uploads/wp-codebox/artifacts/static-site/index.html' === ( $browser_session['artifacts']['preview_url'] ?? '' ) );
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
 $assert( 'browser Playground session returns canonical task input metadata', ! is_wp_error( $browser_session ) && 'wp-codebox/task-input/v1' === ( $browser_session['task_input']['schema'] ?? '' ) && 1 === ( $browser_session['task_input']['version'] ?? 0 ) );
@@ -680,6 +717,34 @@ $invalid_browser_file = call_user_func(
 	)
 );
 $assert( 'browser Playground session rejects unsafe artifact paths', is_wp_error( $invalid_browser_file ) && 'wp_codebox_browser_artifact_path_invalid' === $invalid_browser_file->get_error_code() );
+
+$browser_executable_artifact = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'           => 'Prepare an executable artifact.',
+		'artifact_files' => array(
+			array(
+				'path'    => 'uploads/shell.php',
+				'content' => '<?php echo "nope";',
+			),
+		),
+	)
+);
+$assert( 'browser Playground session rejects server-side executable artifact extensions', is_wp_error( $browser_executable_artifact ) && 'wp_codebox_browser_artifact_extension_blocked' === $browser_executable_artifact->get_error_code() && 'php' === ( $browser_executable_artifact->get_error_data()['extension'] ?? '' ) );
+
+$browser_oversized_artifact = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'           => 'Prepare an oversized artifact.',
+		'artifact_files' => array(
+			array(
+				'path'    => 'assets/large.txt',
+				'content' => str_repeat( 'a', 5242881 ),
+			),
+		),
+	)
+);
+$assert( 'browser Playground session rejects oversized artifact files explicitly', is_wp_error( $browser_oversized_artifact ) && 'wp_codebox_browser_artifact_file_too_large' === $browser_oversized_artifact->get_error_code() && 5242881 === ( $browser_oversized_artifact->get_error_data()['size'] ?? 0 ) && 5242880 === ( $browser_oversized_artifact->get_error_data()['max_size'] ?? 0 ) );
 
 $captured_command  = '';
 $captured_commands = array();


### PR DESCRIPTION
## Summary
- Extend browser Playground artifact files to support UTF-8 text and base64 binary entries in one generic envelope.
- Add per-file `encoding`, `mime_type`, `size`, and `sha256` metadata while preserving existing text content behavior.
- Reject unsafe relative paths, traversal/current-directory segments, server-side executable extensions, invalid base64 encodings, and oversized inline files with explicit errors.

Fixes https://github.com/chubes4/wp-codebox/issues/315

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke-test updates; Chris remains responsible for review and merge.