### PR TITLE
Refactor browser probe helpers out of runtime index

### DIFF
--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -1,0 +1,266 @@
+import type { Page } from "playwright"
+import type {
+  BrowserProbeCheckpointRecord,
+  BrowserProbeMemoryArtifact,
+  BrowserProbeMetricsSnapshot,
+  BrowserProbePerformanceArtifact,
+  BrowserProbeReplayability,
+  BrowserProbeViewport,
+} from "./browser-artifacts.js"
+import { browserProbeMemorySummary, browserProbePerformanceSummary, cdpDomCounters, cdpHeapUsage, cdpPerformanceMetrics } from "./browser-metrics.js"
+
+export const BROWSER_PROBE_CAPTURE_VALUES = ["console", "errors", "html", "network", "performance", "memory", "screenshot"] as const
+
+export const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
+(() => {
+  const state = globalThis.__wpCodeboxBrowserProbe = globalThis.__wpCodeboxBrowserProbe || { checkpoints: [], longTasks: [] };
+  state.checkpoints = state.checkpoints || [];
+  globalThis.__wpCodeboxProbeCheckpoint = (name, metadata = {}) => {
+    state.checkpoints.push({
+      name: String(name || ''),
+      metadata,
+      timestamp: new Date().toISOString(),
+    });
+  };
+  if (state.longTaskObserverInstalled || typeof PerformanceObserver === 'undefined') {
+    return;
+  }
+  try {
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        state.longTasks.push({
+          name: entry.name,
+          startTime: entry.startTime,
+          duration: entry.duration,
+        });
+      }
+    });
+    observer.observe({ type: 'longtask', buffered: true });
+    state.longTaskObserverInstalled = true;
+  } catch {
+    state.longTaskObserverInstalled = false;
+  }
+})();
+`
+
+function now(): string {
+  return new Date().toISOString()
+}
+
+export async function navigateBrowserProbe(page: Page, url: string, waitFor: string, durationMs: number): Promise<void> {
+  if (["domcontentloaded", "load", "networkidle"].includes(waitFor)) {
+    await page.goto(url, { waitUntil: waitFor as "domcontentloaded" | "load" | "networkidle", timeout: 30_000 })
+    return
+  }
+
+  if (waitFor.startsWith("selector:")) {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
+    const selector = waitFor.slice("selector:".length).trim()
+    if (!selector) {
+      throw new Error("wordpress.browser-probe wait-for=selector:<selector> requires a selector")
+    }
+    await page.locator(selector).first().waitFor({ timeout: 30_000 })
+    return
+  }
+
+  if (waitFor === "duration") {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
+    await page.waitForTimeout(durationMs > 0 ? durationMs : 1000)
+    return
+  }
+
+  throw new Error(`wordpress.browser-probe wait-for supports domcontentloaded, load, networkidle, selector:<selector>, duration: ${waitFor}`)
+}
+
+export async function browserProbeViewport(page: Page): Promise<BrowserProbeViewport> {
+  const viewport = page.viewportSize()
+  const device = await page.evaluate(() => ({
+    deviceScaleFactor: window.devicePixelRatio,
+    hasTouch: navigator.maxTouchPoints > 0,
+    userAgent: navigator.userAgent,
+  }))
+
+  return {
+    width: viewport?.width ?? 0,
+    height: viewport?.height ?? 0,
+    deviceScaleFactor: device.deviceScaleFactor,
+    isMobile: /Mobile|Android|iPhone|iPad/i.test(device.userAgent),
+    hasTouch: device.hasTouch,
+    userAgent: device.userAgent,
+  }
+}
+
+export function browserProbeReplayability(capture: Set<string>): BrowserProbeReplayability {
+  if (capture.has("html") && capture.has("screenshot")) {
+    return "artifact-backed"
+  }
+
+  if (capture.has("html") || capture.has("screenshot") || capture.has("network")) {
+    return "partial"
+  }
+
+  return "diagnostic-only"
+}
+
+export async function browserProbePendingCheckpoints(page: Page): Promise<BrowserProbeCheckpointRecord[]> {
+  const pending = await page.evaluate(() => {
+    const state = (globalThis as typeof globalThis & { __wpCodeboxBrowserProbe?: { checkpoints?: Array<{ name?: unknown; metadata?: unknown; timestamp?: unknown }> } }).__wpCodeboxBrowserProbe
+    const checkpoints = Array.isArray(state?.checkpoints) ? state.checkpoints.splice(0) : []
+    return checkpoints.map((checkpoint) => ({
+      name: typeof checkpoint.name === "string" ? checkpoint.name : "checkpoint",
+      metadata: checkpoint.metadata,
+      timestamp: typeof checkpoint.timestamp === "string" ? checkpoint.timestamp : undefined,
+    }))
+  })
+
+  const records: BrowserProbeCheckpointRecord[] = []
+  for (const checkpoint of pending) {
+    records.push(await browserProbeCheckpoint(page, checkpoint.name, checkpoint.metadata, checkpoint.timestamp))
+  }
+  return records
+}
+
+export async function browserProbeCheckpoint(page: Page, name: string, metadata?: unknown, timestamp?: string): Promise<BrowserProbeCheckpointRecord> {
+  return {
+    schema: "wp-codebox/browser-checkpoint/v1",
+    name,
+    ...(typeof metadata !== "undefined" ? { metadata } : {}),
+    timestamp: timestamp ?? now(),
+    metrics: await browserProbeMetricsSnapshot(page),
+  }
+}
+
+async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetricsSnapshot> {
+  const [pageMetrics, cdpMetrics] = await Promise.all([
+    page.evaluate(() => {
+      const memory = (performance as Performance & { memory?: { usedJSHeapSize?: number; totalJSHeapSize?: number; jsHeapSizeLimit?: number } }).memory
+      const resources = performance.getEntriesByType("resource") as PerformanceResourceTiming[]
+      const longTasks = ((globalThis as typeof globalThis & { __wpCodeboxBrowserProbe?: { longTasks?: Array<{ duration?: number }> } }).__wpCodeboxBrowserProbe?.longTasks ?? [])
+        .map((entry) => Number(entry.duration ?? 0))
+        .filter((duration) => Number.isFinite(duration) && duration >= 0)
+
+      return {
+        performanceMemory: {
+          usedJSHeapSize: finiteNumberOrNull(memory?.usedJSHeapSize),
+          totalJSHeapSize: finiteNumberOrNull(memory?.totalJSHeapSize),
+          jsHeapSizeLimit: finiteNumberOrNull(memory?.jsHeapSizeLimit),
+        },
+        dom: {
+          nodes: document.querySelectorAll("*").length,
+          documents: 1,
+          iframes: document.querySelectorAll("iframe").length,
+        },
+        resources: {
+          count: resources.length,
+          transferSizeBytes: resourceTotal(resources, "transferSize"),
+          encodedBodySizeBytes: resourceTotal(resources, "encodedBodySize"),
+          decodedBodySizeBytes: resourceTotal(resources, "decodedBodySize"),
+        },
+        longTasks: {
+          count: longTasks.length,
+          totalDurationMs: longTasks.reduce((total, duration) => total + duration, 0),
+          maxDurationMs: longTasks.reduce((max, duration) => Math.max(max, duration), 0),
+        },
+      }
+
+      function finiteNumberOrNull(value: unknown): number | null {
+        return typeof value === "number" && Number.isFinite(value) ? value : null
+      }
+
+      function resourceTotal(resources: PerformanceResourceTiming[], field: "transferSize" | "encodedBodySize" | "decodedBodySize"): number {
+        return resources.reduce((total, resource) => {
+          const value = resource[field]
+          return total + (Number.isFinite(value) && value > 0 ? value : 0)
+        }, 0)
+      }
+    }),
+    browserProbeCdpMetrics(page),
+  ])
+
+  return {
+    timestamp: now(),
+    memory: {
+      performanceMemory: pageMetrics.performanceMemory,
+      cdpHeap: cdpMetrics.heap,
+      domCounters: cdpMetrics.domCounters,
+    },
+    performance: {
+      cdpMetrics: cdpMetrics.performance,
+      dom: {
+        nodes: cdpMetrics.domCounters.nodes ?? pageMetrics.dom.nodes,
+        documents: cdpMetrics.domCounters.documents ?? pageMetrics.dom.documents,
+        iframes: pageMetrics.dom.iframes,
+      },
+      resources: pageMetrics.resources,
+      longTasks: pageMetrics.longTasks,
+    },
+  }
+}
+
+async function browserProbeCdpMetrics(page: Page): Promise<{
+  performance: Record<string, number>
+  domCounters: { documents: number | null; nodes: number | null; jsEventListeners: number | null }
+  heap: { usedSize: number | null; totalSize: number | null }
+}> {
+  const fallback = {
+    performance: {},
+    domCounters: { documents: null, nodes: null, jsEventListeners: null },
+    heap: { usedSize: null, totalSize: null },
+  }
+
+  try {
+    const session = await page.context().newCDPSession(page)
+    try {
+      await session.send("Performance.enable").catch(() => undefined)
+      const [performanceResult, domCountersResult, heapResult] = await Promise.all([
+        session.send("Performance.getMetrics").catch(() => undefined),
+        session.send("Memory.getDOMCounters").catch(() => undefined),
+        session.send("Runtime.getHeapUsage").catch(() => undefined),
+      ])
+      return {
+        performance: cdpPerformanceMetrics(performanceResult),
+        domCounters: cdpDomCounters(domCountersResult),
+        heap: cdpHeapUsage(heapResult),
+      }
+    } finally {
+      await session.detach().catch(() => undefined)
+    }
+  } catch {
+    return fallback
+  }
+}
+
+export function browserProbeMemoryArtifact(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbeMemoryArtifact {
+  const final = checkpoints.at(-1)?.metrics.memory ?? {
+    performanceMemory: { usedJSHeapSize: null, totalJSHeapSize: null, jsHeapSizeLimit: null },
+    cdpHeap: { usedSize: null, totalSize: null },
+    domCounters: { documents: null, nodes: null, jsEventListeners: null },
+  }
+
+  return {
+    schema: "wp-codebox/browser-memory/v1",
+    version: 1,
+    capturedAt: now(),
+    final,
+    peak: browserProbeMemorySummary(checkpoints),
+    checkpoints,
+  }
+}
+
+export function browserProbePerformanceArtifact(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbePerformanceArtifact {
+  const final = checkpoints.at(-1)?.metrics.performance ?? {
+    cdpMetrics: {},
+    dom: { nodes: 0, documents: 0, iframes: 0 },
+    resources: { count: 0, transferSizeBytes: 0, encodedBodySizeBytes: 0, decodedBodySizeBytes: 0 },
+    longTasks: { count: 0, totalDurationMs: 0, maxDurationMs: 0 },
+  }
+
+  return {
+    schema: "wp-codebox/browser-performance/v1",
+    version: 1,
+    capturedAt: now(),
+    final,
+    peak: browserProbePerformanceSummary(checkpoints),
+    checkpoints,
+  }
+}

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -21,9 +21,10 @@ import {
 import { ArtifactBundleBuilder } from "./artifact-bundle-builder.js"
 import { playgroundBlueprint } from "./blueprint.js"
 import { browserInteractionStepsFromArgs } from "./browser-actions.js"
-import { browserManifestFiles as browserArtifactManifestFiles, browserRedactionPaths, browserReviewSummary as browserArtifactReviewSummary, type BrowserAssertionsSummary, type BrowserProbeArtifact, type BrowserProbeCheckpointRecord, type BrowserProbeErrorRecord, type BrowserProbeMemoryArtifact, type BrowserProbeMemorySummary, type BrowserProbeMetricDigest, type BrowserProbeMetricsSnapshot, type BrowserProbeNetworkRecord, type BrowserProbeNetworkSizes, type BrowserProbePerformanceArtifact, type BrowserProbePerformanceSummary, type BrowserProbeReplayability, type BrowserProbeViewport, type BrowserStepAssertion, type BrowserStepRecord } from "./browser-artifacts.js"
+import { browserManifestFiles as browserArtifactManifestFiles, browserRedactionPaths, browserReviewSummary as browserArtifactReviewSummary, type BrowserProbeArtifact, type BrowserProbeCheckpointRecord, type BrowserProbeErrorRecord, type BrowserProbeMemoryArtifact, type BrowserProbeNetworkRecord, type BrowserProbePerformanceArtifact, type BrowserProbeViewport, type BrowserStepRecord } from "./browser-artifacts.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
-import { browserProbeBenchMetrics, browserProbeMemorySummary, browserProbePerformanceSummary, cdpDomCounters, cdpHeapUsage, cdpPerformanceMetrics, jsonLines, promoteBrowserMetricsToBenchResults, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
+import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, navigateBrowserProbe } from "./browser-probe.js"
+import { browserProbeBenchMetrics, jsonLines, promoteBrowserMetricsToBenchResults, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import { executePlaygroundCommand, playgroundRuntimeCommandIds } from "./command-router.js"
 export { playgroundRuntimeCommandIds } from "./command-router.js"
 import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, CORE_PHPUNIT_RESULT_FILE, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, normalizeThemeCheckOutput, phpBody, phpunitRunCode, positiveIntegerArg, shellArgv, themeCheckRunCode, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
@@ -48,40 +49,8 @@ import type {
 } from "@chubes4/wp-codebox-core"
 import type { Page } from "playwright"
 
-const BROWSER_PROBE_CAPTURE_VALUES = ["console", "errors", "html", "network", "performance", "memory", "screenshot"] as const
 const BROWSER_STEP_DEFAULT_TIMEOUT_MS = 15_000
 const BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS = 120_000
-const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
-(() => {
-  const state = globalThis.__wpCodeboxBrowserProbe = globalThis.__wpCodeboxBrowserProbe || { checkpoints: [], longTasks: [] };
-  state.checkpoints = state.checkpoints || [];
-  globalThis.__wpCodeboxProbeCheckpoint = (name, metadata = {}) => {
-    state.checkpoints.push({
-      name: String(name || ''),
-      metadata,
-      timestamp: new Date().toISOString(),
-    });
-  };
-  if (state.longTaskObserverInstalled || typeof PerformanceObserver === 'undefined') {
-    return;
-  }
-  try {
-    const observer = new PerformanceObserver((list) => {
-      for (const entry of list.getEntries()) {
-        state.longTasks.push({
-          name: entry.name,
-          startTime: entry.startTime,
-          duration: entry.duration,
-        });
-      }
-    });
-    observer.observe({ type: 'longtask', buffered: true });
-    state.longTaskObserverInstalled = true;
-  } catch {
-    state.longTaskObserverInstalled = false;
-  }
-})();
-`
 
 function now(): string {
   return new Date().toISOString()
@@ -2624,229 +2593,11 @@ function summarizeWordPressStateSection(section: string, contents: unknown): unk
   return { count: contents == null ? 0 : 1 }
 }
 
-async function navigateBrowserProbe(page: Page, url: string, waitFor: string, durationMs: number): Promise<void> {
-  if (["domcontentloaded", "load", "networkidle"].includes(waitFor)) {
-    await page.goto(url, { waitUntil: waitFor as "domcontentloaded" | "load" | "networkidle", timeout: 30_000 })
-    return
-  }
-
-  if (waitFor.startsWith("selector:")) {
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
-    const selector = waitFor.slice("selector:".length).trim()
-    if (!selector) {
-      throw new Error("wordpress.browser-probe wait-for=selector:<selector> requires a selector")
-    }
-    await page.locator(selector).first().waitFor({ timeout: 30_000 })
-    return
-  }
-
-  if (waitFor === "duration") {
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
-    await page.waitForTimeout(durationMs > 0 ? durationMs : 1000)
-    return
-  }
-
-  throw new Error(`wordpress.browser-probe wait-for supports domcontentloaded, load, networkidle, selector:<selector>, duration: ${waitFor}`)
-}
-
 function resolveBrowserProbeUrl(pathOrUrl: string, baseUrl: string): string {
   try {
     return new URL(pathOrUrl).toString()
   } catch {
     return new URL(pathOrUrl, baseUrl).toString()
-  }
-}
-
-async function browserProbeViewport(page: Page): Promise<BrowserProbeViewport> {
-  const viewport = page.viewportSize()
-  const device = await page.evaluate(() => ({
-    deviceScaleFactor: window.devicePixelRatio,
-    hasTouch: navigator.maxTouchPoints > 0,
-    userAgent: navigator.userAgent,
-  }))
-
-  return {
-    width: viewport?.width ?? 0,
-    height: viewport?.height ?? 0,
-    deviceScaleFactor: device.deviceScaleFactor,
-    isMobile: /Mobile|Android|iPhone|iPad/i.test(device.userAgent),
-    hasTouch: device.hasTouch,
-    userAgent: device.userAgent,
-  }
-}
-
-function browserProbeReplayability(capture: Set<string>): BrowserProbeReplayability {
-  if (capture.has("html") && capture.has("screenshot")) {
-    return "artifact-backed"
-  }
-
-  if (capture.has("html") || capture.has("screenshot") || capture.has("network")) {
-    return "partial"
-  }
-
-  return "diagnostic-only"
-}
-
-async function browserProbePendingCheckpoints(page: Page): Promise<BrowserProbeCheckpointRecord[]> {
-  const pending = await page.evaluate(() => {
-    const state = (globalThis as typeof globalThis & { __wpCodeboxBrowserProbe?: { checkpoints?: Array<{ name?: unknown; metadata?: unknown; timestamp?: unknown }> } }).__wpCodeboxBrowserProbe
-    const checkpoints = Array.isArray(state?.checkpoints) ? state.checkpoints.splice(0) : []
-    return checkpoints.map((checkpoint) => ({
-      name: typeof checkpoint.name === "string" ? checkpoint.name : "checkpoint",
-      metadata: checkpoint.metadata,
-      timestamp: typeof checkpoint.timestamp === "string" ? checkpoint.timestamp : undefined,
-    }))
-  })
-
-  const records: BrowserProbeCheckpointRecord[] = []
-  for (const checkpoint of pending) {
-    records.push(await browserProbeCheckpoint(page, checkpoint.name, checkpoint.metadata, checkpoint.timestamp))
-  }
-  return records
-}
-
-async function browserProbeCheckpoint(page: Page, name: string, metadata?: unknown, timestamp?: string): Promise<BrowserProbeCheckpointRecord> {
-  return {
-    schema: "wp-codebox/browser-checkpoint/v1",
-    name,
-    ...(typeof metadata !== "undefined" ? { metadata } : {}),
-    timestamp: timestamp ?? now(),
-    metrics: await browserProbeMetricsSnapshot(page),
-  }
-}
-
-async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetricsSnapshot> {
-  const [pageMetrics, cdpMetrics] = await Promise.all([
-    page.evaluate(() => {
-      const memory = (performance as Performance & { memory?: { usedJSHeapSize?: number; totalJSHeapSize?: number; jsHeapSizeLimit?: number } }).memory
-      const resources = performance.getEntriesByType("resource") as PerformanceResourceTiming[]
-      const longTasks = ((globalThis as typeof globalThis & { __wpCodeboxBrowserProbe?: { longTasks?: Array<{ duration?: number }> } }).__wpCodeboxBrowserProbe?.longTasks ?? [])
-        .map((entry) => Number(entry.duration ?? 0))
-        .filter((duration) => Number.isFinite(duration) && duration >= 0)
-
-      return {
-        performanceMemory: {
-          usedJSHeapSize: finiteNumberOrNull(memory?.usedJSHeapSize),
-          totalJSHeapSize: finiteNumberOrNull(memory?.totalJSHeapSize),
-          jsHeapSizeLimit: finiteNumberOrNull(memory?.jsHeapSizeLimit),
-        },
-        dom: {
-          nodes: document.querySelectorAll("*").length,
-          documents: 1,
-          iframes: document.querySelectorAll("iframe").length,
-        },
-        resources: {
-          count: resources.length,
-          transferSizeBytes: resourceTotal(resources, "transferSize"),
-          encodedBodySizeBytes: resourceTotal(resources, "encodedBodySize"),
-          decodedBodySizeBytes: resourceTotal(resources, "decodedBodySize"),
-        },
-        longTasks: {
-          count: longTasks.length,
-          totalDurationMs: longTasks.reduce((total, duration) => total + duration, 0),
-          maxDurationMs: longTasks.reduce((max, duration) => Math.max(max, duration), 0),
-        },
-      }
-
-      function finiteNumberOrNull(value: unknown): number | null {
-        return typeof value === "number" && Number.isFinite(value) ? value : null
-      }
-
-      function resourceTotal(resources: PerformanceResourceTiming[], field: "transferSize" | "encodedBodySize" | "decodedBodySize"): number {
-        return resources.reduce((total, resource) => {
-          const value = resource[field]
-          return total + (Number.isFinite(value) && value > 0 ? value : 0)
-        }, 0)
-      }
-    }),
-    browserProbeCdpMetrics(page),
-  ])
-
-  return {
-    timestamp: now(),
-    memory: {
-      performanceMemory: pageMetrics.performanceMemory,
-      cdpHeap: cdpMetrics.heap,
-      domCounters: cdpMetrics.domCounters,
-    },
-    performance: {
-      cdpMetrics: cdpMetrics.performance,
-      dom: {
-        nodes: cdpMetrics.domCounters.nodes ?? pageMetrics.dom.nodes,
-        documents: cdpMetrics.domCounters.documents ?? pageMetrics.dom.documents,
-        iframes: pageMetrics.dom.iframes,
-      },
-      resources: pageMetrics.resources,
-      longTasks: pageMetrics.longTasks,
-    },
-  }
-}
-
-async function browserProbeCdpMetrics(page: Page): Promise<{
-  performance: Record<string, number>
-  domCounters: { documents: number | null; nodes: number | null; jsEventListeners: number | null }
-  heap: { usedSize: number | null; totalSize: number | null }
-}> {
-  const fallback = {
-    performance: {},
-    domCounters: { documents: null, nodes: null, jsEventListeners: null },
-    heap: { usedSize: null, totalSize: null },
-  }
-
-  try {
-    const session = await page.context().newCDPSession(page)
-    try {
-      await session.send("Performance.enable").catch(() => undefined)
-      const [performanceResult, domCountersResult, heapResult] = await Promise.all([
-        session.send("Performance.getMetrics").catch(() => undefined),
-        session.send("Memory.getDOMCounters").catch(() => undefined),
-        session.send("Runtime.getHeapUsage").catch(() => undefined),
-      ])
-      return {
-        performance: cdpPerformanceMetrics(performanceResult),
-        domCounters: cdpDomCounters(domCountersResult),
-        heap: cdpHeapUsage(heapResult),
-      }
-    } finally {
-      await session.detach().catch(() => undefined)
-    }
-  } catch {
-    return fallback
-  }
-}
-
-function browserProbeMemoryArtifact(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbeMemoryArtifact {
-  const final = checkpoints.at(-1)?.metrics.memory ?? {
-    performanceMemory: { usedJSHeapSize: null, totalJSHeapSize: null, jsHeapSizeLimit: null },
-    cdpHeap: { usedSize: null, totalSize: null },
-    domCounters: { documents: null, nodes: null, jsEventListeners: null },
-  }
-
-  return {
-    schema: "wp-codebox/browser-memory/v1",
-    version: 1,
-    capturedAt: now(),
-    final,
-    peak: browserProbeMemorySummary(checkpoints),
-    checkpoints,
-  }
-}
-
-function browserProbePerformanceArtifact(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbePerformanceArtifact {
-  const final = checkpoints.at(-1)?.metrics.performance ?? {
-    cdpMetrics: {},
-    dom: { nodes: 0, documents: 0, iframes: 0 },
-    resources: { count: 0, transferSizeBytes: 0, encodedBodySizeBytes: 0, decodedBodySizeBytes: 0 },
-    longTasks: { count: 0, totalDurationMs: 0, maxDurationMs: 0 },
-  }
-
-  return {
-    schema: "wp-codebox/browser-performance/v1",
-    version: 1,
-    capturedAt: now(),
-    final,
-    peak: browserProbePerformanceSummary(checkpoints),
-    checkpoints,
   }
 }
 


### PR DESCRIPTION
## Summary
- Move browser-probe navigation, viewport capture, replayability classification, checkpoint collection, and probe memory/performance artifact helpers into `browser-probe.ts`.
- Keep `runBrowserProbe()` as the orchestration and artifact-writing boundary while delegating probe-specific helper behavior.
- Preserve existing browser probe artifact output shapes and metric collection behavior.

## Testing
- `npm run build`
- `npm run command-registry-smoke`
- `npm run package-distribution-smoke`
- `npm run browser-actions-artifact-smoke`
- `npm run browser-probe-artifact-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified and extracted the browser probe helper boundary, ran targeted verification, and drafted this PR summary. Chris remains responsible for review and merge.