### PR TITLE
Refactor preview server helpers out of runtime index

### DIFF
--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,7 +1,6 @@
 import { createHash, randomBytes } from "node:crypto"
 import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises"
-import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from "node:http"
-import { createServer as createNetServer } from "node:net"
+import { createServer as createHttpServer } from "node:http"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, runtimeEpisodeDigest, type BrowserInteractionStep } from "@chubes4/wp-codebox-core"
 import {
@@ -28,6 +27,7 @@ import { browserProbeBenchMetrics, jsonLines, promoteBrowserMetricsToBenchResult
 import { executePlaygroundCommand, playgroundRuntimeCommandIds } from "./command-router.js"
 export { playgroundRuntimeCommandIds } from "./command-router.js"
 import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, CORE_PHPUNIT_RESULT_FILE, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, normalizeThemeCheckOutput, phpBody, phpunitRunCode, positiveIntegerArg, shellArgv, themeCheckRunCode, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
+import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, closeHttpServer, errorHasCode, listenLocalHttpServer, readBridgeJson, withPreviewProxy, writeBridgeJson, type PlaygroundCliServer } from "./preview-server.js"
 import type {
   ArtifactBundle,
   ArtifactManifestFile,
@@ -442,15 +442,6 @@ class PlaygroundCliExitError extends Error {
   }
 }
 
-class PlaygroundPreviewPortUnavailableError extends Error {
-  readonly code = "wp-codebox-preview-port-in-use"
-
-  constructor(readonly port: number, readonly cause: unknown) {
-    super(`--preview-port ${port} is unavailable: EADDRINUSE. Choose another port or stop the process currently using it.`)
-    this.name = "PlaygroundPreviewPortUnavailableError"
-  }
-}
-
 function assertPlaygroundResponseOk(command: string, response: PlaygroundRunResponse): void {
   if (typeof response.exitCode === "number" && response.exitCode !== 0) {
     throw new PlaygroundCommandError(command, response)
@@ -537,21 +528,6 @@ async function runPlaygroundCliWithoutProcessExit<T>(callback: () => Promise<T>)
   } finally {
     process.exit = exit
   }
-}
-
-interface PlaygroundCliServer {
-  playground: {
-    run(options: { code: string } | { scriptPath: string }): Promise<PlaygroundRunResponse>
-    readFileAsText?(path: string): string | Promise<string>
-    writeFile?(path: string, contents: string): Promise<void>
-  }
-  serverUrl: string
-  [Symbol.asyncDispose](): Promise<void>
-}
-
-interface PlaygroundPreviewProxy {
-  serverUrl: string
-  dispose(): Promise<void>
 }
 
 interface PlaygroundCliModule {
@@ -2622,194 +2598,4 @@ function durationArg(args: string[], name: string, fallbackMs: number): number {
 
   const value = Number.parseFloat(match[1])
   return Math.max(0, Math.round(match[2] === "ms" ? value : value * 1000))
-}
-
-async function withPreviewProxy(server: PlaygroundCliServer, port: number, bind = "127.0.0.1"): Promise<PlaygroundCliServer> {
-  let proxy: PlaygroundPreviewProxy | undefined
-  try {
-    proxy = await startPreviewProxy(server.serverUrl, port, bind)
-  } catch (error) {
-    await server[Symbol.asyncDispose]()
-    throw error
-  }
-
-  return {
-    ...server,
-    serverUrl: proxy.serverUrl,
-    async [Symbol.asyncDispose]() {
-      await proxy.dispose()
-      await server[Symbol.asyncDispose]()
-    },
-  }
-}
-
-async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
-  const target = new URL(targetUrl)
-  const proxy = createHttpServer((incoming, outgoing) => {
-    const targetRequest = httpRequest(
-      {
-        protocol: target.protocol,
-        hostname: target.hostname,
-        port: target.port,
-        method: incoming.method,
-        path: incoming.url ?? "/",
-        headers: proxyRequestHeaders(incoming.headers, target),
-      },
-      (targetResponse) => {
-        outgoing.writeHead(targetResponse.statusCode ?? 502, targetResponse.statusMessage, proxyResponseHeaders(targetResponse.headers))
-        targetResponse.on("error", (error) => outgoing.destroy(error))
-        targetResponse.pipe(outgoing)
-      },
-    )
-
-    targetRequest.on("error", (error) => writeProxyError(outgoing, error))
-    incoming.on("error", () => targetRequest.destroy())
-    incoming.pipe(targetRequest)
-  })
-
-  await new Promise<void>((resolveListen, rejectListen) => {
-    proxy.once("error", rejectListen)
-    proxy.listen(port, bind, () => resolveListen())
-  })
-
-  const address = proxy.address()
-  const resolvedPort = address && typeof address === "object" ? address.port : port
-  const reportedHost = bind === "0.0.0.0" ? "127.0.0.1" : bind
-
-  return {
-    serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
-    async dispose() {
-      if (!proxy.listening) {
-        return
-      }
-
-      await new Promise<void>((resolveClose, rejectClose) => {
-        proxy.close((error) => error ? rejectClose(error) : resolveClose())
-      })
-    },
-  }
-}
-
-function formatPreviewHost(host: string): string {
-  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
-}
-
-function proxyRequestHeaders(headers: IncomingHttpHeaders, target: URL): IncomingHttpHeaders {
-  const forwarded = { ...headers }
-  delete forwarded.connection
-  delete forwarded.host
-  delete forwarded["transfer-encoding"]
-
-  return {
-    ...forwarded,
-    host: target.host,
-  }
-}
-
-function proxyResponseHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
-  const forwarded = { ...headers }
-  delete forwarded.connection
-  delete forwarded["transfer-encoding"]
-
-  return forwarded
-}
-
-function writeProxyError(outgoing: ServerResponse, error: Error): void {
-  if (outgoing.headersSent) {
-    outgoing.destroy(error)
-    return
-  }
-
-  const body = Buffer.from(`Preview proxy failed: ${error.message}\n`, "utf8")
-  outgoing.writeHead(502, {
-    "content-type": "text/plain; charset=utf-8",
-    "content-length": String(body.byteLength),
-  })
-  outgoing.end(body)
-}
-
-function errorHasCode(error: unknown, code: string): boolean {
-  if (!error || typeof error !== "object") {
-    return false
-  }
-
-  if ("code" in error && error.code === code) {
-    return true
-  }
-
-  if ("cause" in error && errorHasCode(error.cause, code)) {
-    return true
-  }
-
-  return error instanceof Error && error.message.includes(code)
-}
-
-async function assertPreviewPortAvailable(port: number): Promise<void> {
-  const server = createNetServer()
-  try {
-    await new Promise<void>((resolveListen, rejectListen) => {
-      server.once("error", rejectListen)
-      server.listen(port, "127.0.0.1", () => resolveListen())
-    })
-  } catch (error) {
-    if (errorHasCode(error, "EADDRINUSE")) {
-      throw new PlaygroundPreviewPortUnavailableError(port, error)
-    }
-
-    throw error
-  } finally {
-    if (server.listening) {
-      await new Promise<void>((resolveClose, rejectClose) => {
-        server.close((error) => error ? rejectClose(error) : resolveClose())
-      })
-    }
-  }
-}
-
-function readBridgeJson(request: IncomingMessage): Promise<Record<string, unknown>> {
-  return new Promise((resolve, reject) => {
-    let body = ""
-    request.on("data", (chunk) => {
-      body += chunk.toString()
-      if (body.length > 1024 * 1024) {
-        reject(new Error("Request body too large"))
-        request.destroy()
-      }
-    })
-    request.on("end", () => {
-      try {
-        const parsed = body ? JSON.parse(body) : {}
-        resolve(parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {})
-      } catch (error) {
-        reject(error)
-      }
-    })
-    request.on("error", reject)
-  })
-}
-
-function writeBridgeJson(response: ServerResponse, statusCode: number, payload: unknown): void {
-  response.writeHead(statusCode, { "content-type": "application/json" })
-  response.end(`${JSON.stringify(payload)}\n`)
-}
-
-function listenLocalHttpServer(server: ReturnType<typeof createHttpServer>): Promise<string> {
-  return new Promise((resolveListen, rejectListen) => {
-    server.once("error", rejectListen)
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", rejectListen)
-      const address = server.address()
-      if (!address || typeof address === "string") {
-        rejectListen(new Error("Runtime WP-CLI bridge did not expose a TCP address"))
-        return
-      }
-      resolveListen(`http://${address.address}:${address.port}`)
-    })
-  })
-}
-
-function closeHttpServer(server: ReturnType<typeof createHttpServer>): Promise<void> {
-  return new Promise((resolveClose, rejectClose) => {
-    server.close((error) => error ? rejectClose(error) : resolveClose())
-  })
 }

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -1,0 +1,222 @@
+import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from "node:http"
+import { createServer as createNetServer } from "node:net"
+
+export interface PlaygroundServerRunResponse {
+  exitCode?: number
+  errors?: string
+  text: string
+}
+
+export interface PlaygroundCliServer {
+  playground: {
+    run(options: { code: string } | { scriptPath: string }): Promise<PlaygroundServerRunResponse>
+    readFileAsText?(path: string): string | Promise<string>
+    writeFile?(path: string, contents: string): Promise<void>
+  }
+  serverUrl: string
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+interface PlaygroundPreviewProxy {
+  serverUrl: string
+  dispose(): Promise<void>
+}
+
+export class PlaygroundPreviewPortUnavailableError extends Error {
+  readonly code = "wp-codebox-preview-port-in-use"
+
+  constructor(readonly port: number, readonly cause: unknown) {
+    super(`--preview-port ${port} is unavailable: EADDRINUSE. Choose another port or stop the process currently using it.`)
+    this.name = "PlaygroundPreviewPortUnavailableError"
+  }
+}
+
+export async function withPreviewProxy(server: PlaygroundCliServer, port: number, bind = "127.0.0.1"): Promise<PlaygroundCliServer> {
+  let proxy: PlaygroundPreviewProxy | undefined
+  try {
+    proxy = await startPreviewProxy(server.serverUrl, port, bind)
+  } catch (error) {
+    await server[Symbol.asyncDispose]()
+    throw error
+  }
+
+  return {
+    ...server,
+    serverUrl: proxy.serverUrl,
+    async [Symbol.asyncDispose]() {
+      await proxy.dispose()
+      await server[Symbol.asyncDispose]()
+    },
+  }
+}
+
+async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
+  const target = new URL(targetUrl)
+  const proxy = createHttpServer((incoming, outgoing) => {
+    const targetRequest = httpRequest(
+      {
+        protocol: target.protocol,
+        hostname: target.hostname,
+        port: target.port,
+        method: incoming.method,
+        path: incoming.url ?? "/",
+        headers: proxyRequestHeaders(incoming.headers, target),
+      },
+      (targetResponse) => {
+        outgoing.writeHead(targetResponse.statusCode ?? 502, targetResponse.statusMessage, proxyResponseHeaders(targetResponse.headers))
+        targetResponse.on("error", (error) => outgoing.destroy(error))
+        targetResponse.pipe(outgoing)
+      },
+    )
+
+    targetRequest.on("error", (error) => writeProxyError(outgoing, error))
+    incoming.on("error", () => targetRequest.destroy())
+    incoming.pipe(targetRequest)
+  })
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    proxy.once("error", rejectListen)
+    proxy.listen(port, bind, () => resolveListen())
+  })
+
+  const address = proxy.address()
+  const resolvedPort = address && typeof address === "object" ? address.port : port
+  const reportedHost = bind === "0.0.0.0" ? "127.0.0.1" : bind
+
+  return {
+    serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
+    async dispose() {
+      if (!proxy.listening) {
+        return
+      }
+
+      await new Promise<void>((resolveClose, rejectClose) => {
+        proxy.close((error) => error ? rejectClose(error) : resolveClose())
+      })
+    },
+  }
+}
+
+function formatPreviewHost(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
+}
+
+function proxyRequestHeaders(headers: IncomingHttpHeaders, target: URL): IncomingHttpHeaders {
+  const forwarded = { ...headers }
+  delete forwarded.connection
+  delete forwarded.host
+  delete forwarded["transfer-encoding"]
+
+  return {
+    ...forwarded,
+    host: target.host,
+  }
+}
+
+function proxyResponseHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+  const forwarded = { ...headers }
+  delete forwarded.connection
+  delete forwarded["transfer-encoding"]
+
+  return forwarded
+}
+
+function writeProxyError(outgoing: ServerResponse, error: Error): void {
+  if (outgoing.headersSent) {
+    outgoing.destroy(error)
+    return
+  }
+
+  const body = Buffer.from(`Preview proxy failed: ${error.message}\n`, "utf8")
+  outgoing.writeHead(502, {
+    "content-type": "text/plain; charset=utf-8",
+    "content-length": String(body.byteLength),
+  })
+  outgoing.end(body)
+}
+
+export function errorHasCode(error: unknown, code: string): boolean {
+  if (!error || typeof error !== "object") {
+    return false
+  }
+
+  if ("code" in error && error.code === code) {
+    return true
+  }
+
+  if ("cause" in error && errorHasCode(error.cause, code)) {
+    return true
+  }
+
+  return error instanceof Error && error.message.includes(code)
+}
+
+export async function assertPreviewPortAvailable(port: number): Promise<void> {
+  const server = createNetServer()
+  try {
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once("error", rejectListen)
+      server.listen(port, "127.0.0.1", () => resolveListen())
+    })
+  } catch (error) {
+    if (errorHasCode(error, "EADDRINUSE")) {
+      throw new PlaygroundPreviewPortUnavailableError(port, error)
+    }
+
+    throw error
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => error ? rejectClose(error) : resolveClose())
+      })
+    }
+  }
+}
+
+export function readBridgeJson(request: IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    let body = ""
+    request.on("data", (chunk) => {
+      body += chunk.toString()
+      if (body.length > 1024 * 1024) {
+        reject(new Error("Request body too large"))
+        request.destroy()
+      }
+    })
+    request.on("end", () => {
+      try {
+        const parsed = body ? JSON.parse(body) : {}
+        resolve(parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {})
+      } catch (error) {
+        reject(error)
+      }
+    })
+    request.on("error", reject)
+  })
+}
+
+export function writeBridgeJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.writeHead(statusCode, { "content-type": "application/json" })
+  response.end(`${JSON.stringify(payload)}\n`)
+}
+
+export function listenLocalHttpServer(server: ReturnType<typeof createHttpServer>): Promise<string> {
+  return new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen)
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectListen)
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        rejectListen(new Error("Runtime WP-CLI bridge did not expose a TCP address"))
+        return
+      }
+      resolveListen(`http://${address.address}:${address.port}`)
+    })
+  })
+}
+
+export function closeHttpServer(server: ReturnType<typeof createHttpServer>): Promise<void> {
+  return new Promise((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose())
+  })
+}


### PR DESCRIPTION
## Summary
- Move preview proxy creation, header forwarding, preview-port availability checks, and local HTTP server helpers into `preview-server.ts`.
- Keep runtime boot and WP-CLI bridge orchestration in `index.ts` while delegating server/proxy plumbing.
- Preserve preview URL behavior, bridge JSON handling, and port-in-use error behavior.

## Testing
- `npm run build`
- `npm run command-registry-smoke`
- `npm run package-distribution-smoke`
- `npm run preview-port-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified and extracted the preview/local-server helper boundary, ran targeted verification, and drafted this PR summary. Chris remains responsible for review and merge.