### PR TITLE
Refactor runtime WP-CLI bridge helpers

### DIFF
--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,6 +1,5 @@
-import { createHash, randomBytes } from "node:crypto"
+import { createHash } from "node:crypto"
 import { copyFile, mkdir, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises"
-import { createServer as createHttpServer } from "node:http"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, runtimeEpisodeDigest, type BrowserInteractionStep } from "@chubes4/wp-codebox-core"
 import {
@@ -27,7 +26,8 @@ import { browserProbeBenchMetrics, jsonLines, promoteBrowserMetricsToBenchResult
 import { executePlaygroundCommand, playgroundRuntimeCommandIds } from "./command-router.js"
 export { playgroundRuntimeCommandIds } from "./command-router.js"
 import { abilityInputFromArgs, abilityPhpCode, argValue, benchRunCode, booleanArg, cleanWpCliOutput, commaListArg, CORE_PHPUNIT_RESULT_FILE, corePhpunitRunCode, isSafeEnvName, jsonArrayArg, jsonObjectArg, nonNegativeIntegerArg, normalizePhpCode, normalizePluginCheckOutput, normalizeThemeCheckOutput, phpBody, phpunitRunCode, positiveIntegerArg, shellArgv, themeCheckRunCode, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
-import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, closeHttpServer, errorHasCode, listenLocalHttpServer, readBridgeJson, withPreviewProxy, writeBridgeJson, type PlaygroundCliServer } from "./preview-server.js"
+import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
+import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
 import type {
   ArtifactBundle,
   ArtifactManifestFile,
@@ -366,53 +366,6 @@ interface PlaygroundRunResponse {
   exitCode?: number
   errors?: string
   text: string
-}
-
-interface RuntimeWpCliBridge {
-  url: string
-  token: string
-  close: () => Promise<void>
-}
-
-interface RuntimeWpCliCommandResult {
-  exitCode: number
-  stdout: string
-  stderr: string
-}
-
-function runtimeWpCliCommandArgv(command: string): string[][] {
-  const tokens = shellArgv(command)
-  const commands: string[][] = []
-  let current: string[] = []
-
-  for (const token of tokens) {
-    if (token === "&&" || token === ";" || token === "||") {
-      if (current.length > 0) {
-        commands.push(runtimeWpCliNormalizeArgv(current))
-        current = []
-      }
-      if (token === "||") {
-        break
-      }
-      continue
-    }
-
-    if (token === "|") {
-      break
-    }
-
-    current.push(token)
-  }
-
-  if (current.length > 0) {
-    commands.push(runtimeWpCliNormalizeArgv(current))
-  }
-
-  return commands.filter((argv) => argv.length > 0)
-}
-
-function runtimeWpCliNormalizeArgv(argv: string[]): string[] {
-  return argv[0] === "wp" ? argv.slice(1) : argv
 }
 
 class PlaygroundCommandError extends Error {
@@ -1659,75 +1612,8 @@ class PlaygroundRuntime implements Runtime {
     return this.runPlaygroundCommand("wordpress.wp-cli", server, { scriptPath })
   }
 
-  private async runRuntimeWpCliBridgeCommand(server: PlaygroundCliServer, command: string): Promise<RuntimeWpCliCommandResult> {
-    const commands = runtimeWpCliCommandArgv(command)
-    if (commands.length === 0) {
-      throw new Error("wp_cli command is required")
-    }
-
-    let stdout = ""
-    let stderr = ""
-    let exitCode = 0
-    for (const argv of commands) {
-      const result = await this.runWpCliCommand(server, argv)
-      exitCode = result.exitCode ?? 0
-      stdout += cleanWpCliOutput(result.text)
-      stderr += result.errors ?? ""
-      if (exitCode !== 0) {
-        break
-      }
-    }
-
-    return { exitCode, stdout, stderr }
-  }
-
   private async createRuntimeWpCliBridge(server: PlaygroundCliServer): Promise<RuntimeWpCliBridge> {
-    const token = randomBytes(24).toString("base64url")
-    const bridge = createHttpServer(async (request, response) => {
-      try {
-        if (request.method !== "POST" || request.url !== "/execute") {
-          writeBridgeJson(response, 404, { success: false, error: "not_found" })
-          return
-        }
-
-        if (request.headers.authorization !== `Bearer ${token}`) {
-          writeBridgeJson(response, 403, { success: false, error: "forbidden" })
-          return
-        }
-
-        const action = await readBridgeJson(request)
-        const type = typeof action.type === "string" ? action.type.trim() : ""
-        const command = typeof action.command === "string" ? action.command.trim() : ""
-        if (type !== "wp_cli" || command === "") {
-          writeBridgeJson(response, 400, { success: false, error: "wp_cli command is required" })
-          return
-        }
-
-        const started = Date.now()
-        const result = await this.runRuntimeWpCliBridgeCommand(server, command)
-        const exitCode = result.exitCode
-        writeBridgeJson(response, 200, {
-          type,
-          command: command.startsWith("wp ") ? command : `wp ${command}`,
-          exitCode,
-          stdout: result.stdout,
-          stderr: result.stderr,
-          success: exitCode === 0,
-          timedOut: false,
-          durationMs: Date.now() - started,
-          error: exitCode === 0 ? "" : (result.stderr.trim() || result.stdout.trim() || "WP-CLI command failed"),
-        })
-      } catch (error) {
-        writeBridgeJson(response, 500, { success: false, error: errorMessage(error) })
-      }
-    })
-
-    const url = await listenLocalHttpServer(bridge)
-    return {
-      url,
-      token,
-      close: () => closeHttpServer(bridge),
-    }
+    return createRuntimeWpCliBridge((argv) => this.runWpCliCommand(server, argv))
   }
 
   async runAbility(spec: ExecutionSpec): Promise<string> {

--- a/packages/runtime-playground/src/runtime-wp-cli-bridge.ts
+++ b/packages/runtime-playground/src/runtime-wp-cli-bridge.ts
@@ -1,0 +1,128 @@
+import { randomBytes } from "node:crypto"
+import { createServer as createHttpServer } from "node:http"
+import { cleanWpCliOutput, shellArgv } from "./commands.js"
+import { closeHttpServer, listenLocalHttpServer, readBridgeJson, writeBridgeJson, type PlaygroundServerRunResponse } from "./preview-server.js"
+
+export interface RuntimeWpCliBridge {
+  url: string
+  token: string
+  close: () => Promise<void>
+}
+
+interface RuntimeWpCliCommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+type RuntimeWpCliRunner = (argv: string[]) => Promise<PlaygroundServerRunResponse>
+
+export async function createRuntimeWpCliBridge(runWpCliCommand: RuntimeWpCliRunner): Promise<RuntimeWpCliBridge> {
+  const token = randomBytes(24).toString("base64url")
+  const bridge = createHttpServer(async (request, response) => {
+    try {
+      if (request.method !== "POST" || request.url !== "/execute") {
+        writeBridgeJson(response, 404, { success: false, error: "not_found" })
+        return
+      }
+
+      if (request.headers.authorization !== `Bearer ${token}`) {
+        writeBridgeJson(response, 403, { success: false, error: "forbidden" })
+        return
+      }
+
+      const action = await readBridgeJson(request)
+      const type = typeof action.type === "string" ? action.type.trim() : ""
+      const command = typeof action.command === "string" ? action.command.trim() : ""
+      if (type !== "wp_cli" || command === "") {
+        writeBridgeJson(response, 400, { success: false, error: "wp_cli command is required" })
+        return
+      }
+
+      const started = Date.now()
+      const result = await runRuntimeWpCliBridgeCommand(runWpCliCommand, command)
+      const exitCode = result.exitCode
+      writeBridgeJson(response, 200, {
+        type,
+        command: command.startsWith("wp ") ? command : `wp ${command}`,
+        exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        success: exitCode === 0,
+        timedOut: false,
+        durationMs: Date.now() - started,
+        error: exitCode === 0 ? "" : (result.stderr.trim() || result.stdout.trim() || "WP-CLI command failed"),
+      })
+    } catch (error) {
+      writeBridgeJson(response, 500, { success: false, error: errorMessage(error) })
+    }
+  })
+
+  const url = await listenLocalHttpServer(bridge)
+  return {
+    url,
+    token,
+    close: () => closeHttpServer(bridge),
+  }
+}
+
+async function runRuntimeWpCliBridgeCommand(runWpCliCommand: RuntimeWpCliRunner, command: string): Promise<RuntimeWpCliCommandResult> {
+  const commands = runtimeWpCliCommandArgv(command)
+  if (commands.length === 0) {
+    throw new Error("wp_cli command is required")
+  }
+
+  let stdout = ""
+  let stderr = ""
+  let exitCode = 0
+  for (const argv of commands) {
+    const result = await runWpCliCommand(argv)
+    exitCode = result.exitCode ?? 0
+    stdout += cleanWpCliOutput(result.text)
+    stderr += result.errors ?? ""
+    if (exitCode !== 0) {
+      break
+    }
+  }
+
+  return { exitCode, stdout, stderr }
+}
+
+function runtimeWpCliCommandArgv(command: string): string[][] {
+  const tokens = shellArgv(command)
+  const commands: string[][] = []
+  let current: string[] = []
+
+  for (const token of tokens) {
+    if (token === "&&" || token === ";" || token === "||") {
+      if (current.length > 0) {
+        commands.push(runtimeWpCliNormalizeArgv(current))
+        current = []
+      }
+      if (token === "||") {
+        break
+      }
+      continue
+    }
+
+    if (token === "|") {
+      break
+    }
+
+    current.push(token)
+  }
+
+  if (current.length > 0) {
+    commands.push(runtimeWpCliNormalizeArgv(current))
+  }
+
+  return commands.filter((argv) => argv.length > 0)
+}
+
+function runtimeWpCliNormalizeArgv(argv: string[]): string[] {
+  return argv[0] === "wp" ? argv.slice(1) : argv
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}


### PR DESCRIPTION
## Summary
- Extract runtime WP-CLI bridge request handling and command splitting into `runtime-wp-cli-bridge.ts`.
- Keep `PlaygroundRuntime` responsible for the existing VFS-backed WP-CLI command runner while delegating bridge transport details.

## Testing
- `npm install` (fresh worktree dependency install; prepare build passed)
- `npm run build`
- `npm run command-registry-smoke`
- `npm run package-distribution-smoke`
- `npm run runtime-action-adapter-smoke`
- `npm run runtime-episode-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused extraction and ran verification; Chris remains responsible for review and merge.