### PR TITLE
Support recipe file mounts

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,7 +24,7 @@ interface RecipeSchemaOutput {
 }
 
 interface RunOptions {
-  mounts: Array<{ source: string; target: string; mode: "readonly" | "readwrite"; metadata?: Record<string, unknown> }>
+  mounts: Array<{ type?: MountSpec["type"]; source: string; target: string; mode: "readonly" | "readwrite"; metadata?: Record<string, unknown> }>
   command: string
   args: string[]
   wpVersion?: string
@@ -1159,6 +1159,17 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
   const siteSeeds = recipeDryRunSiteSeeds(recipe, recipeDirectory)
   const stagedFiles = await recipeDryRunStagedFiles(recipe, recipeDirectory)
   const workflowSteps = await recipeDryRunSteps(recipe, recipeDirectory, policy)
+  const recipeMounts = await Promise.all((recipe.inputs?.mounts ?? []).map(async (mount) => {
+    const source = resolve(recipeDirectory, mount.source)
+    return {
+      type: await recipeMountType(source, mount.type),
+      source,
+      target: mount.target,
+      mode: mount.mode ?? "readwrite" as const,
+      ...(mount.metadata ? { metadata: mount.metadata } : {}),
+      planned: "existing" as const,
+    }
+  }))
   const mounts: RecipeDryRunMount[] = [
     ...workspaces.map((workspace) => ({
       type: "directory" as const,
@@ -1180,14 +1191,7 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
       },
       planned: "existing" as const,
     })),
-    ...(recipe.inputs?.mounts ?? []).map((mount) => ({
-      type: "directory" as const,
-      source: resolve(recipeDirectory, mount.source),
-      target: mount.target,
-      mode: mount.mode ?? "readwrite" as const,
-      ...(mount.metadata ? { metadata: mount.metadata } : {}),
-      planned: "existing" as const,
-    })),
+    ...recipeMounts,
     ...stagedFiles.map((stagedFile) => ({
       type: stagedFile.type,
       source: stagedFile.source,
@@ -1444,9 +1448,10 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     }
 
     for (const mount of recipe.inputs?.mounts ?? []) {
+      const source = resolve(recipeDirectory, mount.source)
       await awaitRecipe(runtime.mount({
-        type: "directory",
-        source: resolve(recipeDirectory, mount.source),
+        type: await recipeMountType(source, mount.type),
+        source,
         target: mount.target,
         mode: mount.mode ?? "readwrite",
         metadata: mount.metadata,
@@ -2733,7 +2738,7 @@ async function run(options: RunOptions): Promise<RunOutput> {
     )
 
     for (const mount of options.mounts) {
-      await runtime.mount({ type: "directory", source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
+      await runtime.mount({ type: await recipeMountType(mount.source, mount.type), source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
     }
 
     execution = await runtime.execute({ command: options.command, args: options.args })
@@ -2797,7 +2802,7 @@ async function boot(options: BootOptions): Promise<BootOutput> {
     )
 
     for (const mount of options.mounts) {
-      await runtime.mount({ type: "directory", source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
+      await runtime.mount({ type: await recipeMountType(mount.source, mount.type), source: mount.source, target: mount.target, mode: mount.mode, metadata: mount.metadata })
     }
 
     await runtime.observe({ type: "runtime-info" })
@@ -3252,6 +3257,10 @@ function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe 
       throw new Error(`Recipe mounts must include source and target: ${recipePath}`)
     }
 
+    if (mount.type && mount.type !== "directory" && mount.type !== "file") {
+      throw new Error(`Recipe mount type must be directory or file: ${recipePath}`)
+    }
+
     if (mount.mode && mount.mode !== "readonly" && mount.mode !== "readwrite") {
       throw new Error(`Recipe mount mode must be readonly or readwrite: ${recipePath}`)
     }
@@ -3393,7 +3402,7 @@ async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: stri
 
   for (const [index, mount] of (recipe.inputs?.mounts ?? []).entries()) {
     const path = `$.inputs.mounts[${index}]`
-    await validateExistingDirectory(resolve(recipeDirectory, mount.source), `${path}.source`, addIssue)
+    await validateExistingMountSource(resolve(recipeDirectory, mount.source), mount.type, `${path}.source`, addIssue)
     validateAbsoluteSandboxPath(mount.target, `${path}.target`, addIssue)
   }
 
@@ -3736,6 +3745,20 @@ async function validateExistingFileOrDirectory(path: string, issuePath: string, 
   } catch {
     addIssue("missing-path", issuePath, `File or directory does not exist: ${path}`)
   }
+}
+
+async function validateExistingMountSource(path: string, type: MountSpec["type"] | undefined, issuePath: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
+  if (type === "directory") {
+    await validateExistingDirectory(path, issuePath, addIssue)
+    return
+  }
+
+  if (type === "file") {
+    await validateExistingFile(path, issuePath, addIssue)
+    return
+  }
+
+  await validateExistingFileOrDirectory(path, issuePath, addIssue)
 }
 
 function validateAbsoluteSandboxPath(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): void {
@@ -4846,6 +4869,14 @@ async function prepareRecipeStagedFiles(recipe: WorkspaceRecipe, recipeDirectory
 }
 
 async function stagedFileMountType(source: string): Promise<MountSpec["type"]> {
+  return recipeMountType(source)
+}
+
+async function recipeMountType(source: string, explicitType?: MountSpec["type"]): Promise<MountSpec["type"]> {
+  if (explicitType === "directory" || explicitType === "file") {
+    return explicitType
+  }
+
   const result = await stat(source)
   if (result.isDirectory()) {
     return "directory"
@@ -4854,7 +4885,7 @@ async function stagedFileMountType(source: string): Promise<MountSpec["type"]> {
     return "file"
   }
 
-  throw new Error(`Recipe stagedFiles source must be a file or directory: ${source}`)
+  throw new Error(`Recipe mount source must be a file or directory: ${source}`)
 }
 
 function stagedFileProvenance(stagedFile: WorkspaceRecipeStagedFile, recipeDirectory: string): RecipeStagedFileProvenance {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -502,6 +502,7 @@ export interface RuntimePreviewSpec {
 }
 
 export interface WorkspaceRecipeMount {
+  type?: "directory" | "file"
   source: string
   target: string
   mode?: "readonly" | "readwrite"
@@ -848,6 +849,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
         additionalProperties: false,
         required: ["source", "target"],
         properties: {
+          type: { enum: ["directory", "file"] },
           source: { type: "string" },
           target: { type: "string", pattern: "^/" },
           mode: { enum: ["readonly", "readwrite"] },

--- a/scripts/recipe-dry-run-smoke.ts
+++ b/scripts/recipe-dry-run-smoke.ts
@@ -15,11 +15,15 @@ const externalUntrustedHostRecipePath = resolve(workspace, "external-untrusted-h
 const externalStrictDigestRecipePath = resolve(workspace, "external-strict-digest-recipe.json")
 const invalidSiteSeedRecipePath = resolve(workspace, "invalid-site-seed-recipe.json")
 const fixtureSeedPath = resolve(workspace, "fixture-seed.json")
+const fixtureMountPath = resolve(workspace, "fixture-mount.json")
+const fixtureMountDir = resolve(workspace, "fixture-mount-dir")
 const dryRunArtifacts = resolve(workspace, "dry-run-artifacts")
 const multisiteCookbookRecipePath = resolve(root, "examples/recipes/cookbook/multisite-network.json")
 
 mkdirSync(workspace, { recursive: true })
+mkdirSync(fixtureMountDir, { recursive: true })
 writeFileSync(fixtureSeedPath, `${JSON.stringify({ posts: [{ slug: "fixture-page" }] }, null, 2)}\n`)
+writeFileSync(fixtureMountPath, `${JSON.stringify({ ok: true }, null, 2)}\n`)
 writeFileSync(recipePath, `${JSON.stringify({
   schema: "wp-codebox/workspace-recipe/v1",
   runtime: {
@@ -73,6 +77,18 @@ writeFileSync(recipePath, `${JSON.stringify({
           activePlugins: true,
           activeTheme: true,
         },
+      },
+    ],
+    mounts: [
+      {
+        type: "file",
+        source: "./fixture-mount.json",
+        target: "/wordpress/wp-content/plugins/example/fixture-mount.json",
+        mode: "readonly",
+      },
+      {
+        source: "./fixture-mount-dir",
+        target: "/wordpress/wp-content/plugins/example/fixture-mount-dir",
       },
     ],
   },
@@ -223,6 +239,8 @@ assert.equal(output.plan.siteSeeds[1].bounded, true)
 assert.equal(output.plan.siteSeeds[1].dryRunOnly, true)
 assert.equal(output.plan.siteSeeds[1].privacy.exportsParentSiteData, false)
 assert.equal(output.plan.siteSeeds[1].privacy.importsIntoSandbox, false)
+assert.equal(output.plan.mounts.some((mount: { type: string; source?: string; target: string; mode: string }) => mount.type === "file" && mount.source === fixtureMountPath && mount.target === "/wordpress/wp-content/plugins/example/fixture-mount.json" && mount.mode === "readonly"), true)
+assert.equal(output.plan.mounts.some((mount: { type: string; source?: string; target: string; mode: string }) => mount.type === "directory" && mount.source === fixtureMountDir && mount.target === "/wordpress/wp-content/plugins/example/fixture-mount-dir" && mount.mode === "readwrite"), true)
 assert.equal(output.plan.secretEnv[0].name, "DRY_RUN_TOKEN")
 assert.equal(Object.prototype.hasOwnProperty.call(output.plan.secretEnv[0], "value"), false)
 assert.equal(output.plan.secretEnv[0].available, true)


### PR DESCRIPTION
## Summary
- Add explicit `file` / `directory` typing for workspace recipe mounts.
- Preserve mount type through recipe validation, dry-run planning, and runtime mounting so file mounts are no longer rejected as non-directories.
- Cover typed file mounts in the recipe dry-run smoke test.

## Verification
- `npm run build`
- `npm run recipe-dry-run-smoke`
- `git diff --check`
- `node packages/cli/dist/index.js run --mount ./artifacts/recipe-dry-run-smoke/fixture-mount.json:/tmp/fixture-mount.json:readonly --command wordpress.run-php --arg "code=echo file_exists('/tmp/fixture-mount.json') ? 'mounted' : 'missing';" --artifacts ./artifacts/file-mount-smoke --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the Homeboy/WP Codebox file-mount validation failure, drafted the CLI/schema/runtime plumbing change, and ran local verification. Chris remains responsible for review and merge.