### PR TITLE
Refactor shared artifact helpers

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { calculateArtifactManifestFileSha256, checkWorkspacePolicy, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspacePolicyResult, type WorkspaceRecipe } from "@chubes4/wp-codebox-core"
+import { checkWorkspacePolicy, isPlainObject as isRecord, refreshArtifactManifestFileSha256s, sha256StableJson, upsertArtifactManifestFiles, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ArtifactManifestFile, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspacePolicyResult, type WorkspaceRecipe } from "@chubes4/wp-codebox-core"
 
 export interface RecipeArtifactEvidenceFile {
   path: string
@@ -644,17 +644,7 @@ async function readGitCommit(cwd: string): Promise<string | undefined> {
 }
 
 function sha256Json(value: unknown): string {
-  return createHash("sha256").update(`${stableJson(value)}\n`).digest("hex")
-}
-
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJson).join(",")}]`
-  }
-  if (isRecord(value)) {
-    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`
-  }
-  return JSON.stringify(value)
+  return sha256StableJson(value, true)
 }
 
 export function recipeArtifactEvidenceFailure(evidence: RecipeArtifactEvidenceResult): { name: string; code: string; message: string } | undefined {
@@ -793,16 +783,7 @@ async function writeRecipeEvidenceJson(artifactRoot: string, path: string, value
 
 async function updateRecipeArtifactEvidenceReferences(artifacts: ArtifactBundle, evidenceFiles: RecipeArtifactEvidenceFile[]): Promise<void> {
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as ArtifactManifest
-  manifest.files = Array.isArray(manifest.files) ? manifest.files : []
-  for (const file of evidenceFiles) {
-    const existing = manifest.files.find((entry) => entry.path === file.path)
-    const manifestFile = { path: file.path, kind: file.kind, contentType: file.contentType, sha256: { algorithm: "sha256" as const, value: file.sha256 } }
-    if (existing) {
-      Object.assign(existing, manifestFile)
-    } else {
-      manifest.files.push(manifestFile)
-    }
-  }
+  upsertArtifactManifestFiles(manifest, evidenceFiles.map(evidenceFileToManifestFile))
 
   const evidence = Object.fromEntries(evidenceFiles.map((file) => [file.kind, { path: file.path, sha256: file.sha256 }]))
   const metadata = JSON.parse(await readFile(artifacts.metadataPath, "utf8")) as Record<string, unknown>
@@ -817,17 +798,12 @@ async function updateRecipeArtifactEvidenceReferences(artifacts: ArtifactBundle,
   review.evidence = { ...reviewEvidence, runtimeEvidence: { ...(isRecord(reviewEvidence.runtimeEvidence) ? reviewEvidence.runtimeEvidence : {}), ...evidence } }
   await writeFile(artifacts.reviewPath, `${JSON.stringify(review, null, 2)}\n`)
 
-  for (const file of manifest.files) {
-    if (file.path !== "manifest.json") {
-      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(artifacts.directory, manifest, file) }
-    }
-  }
-  for (const file of manifest.files) {
-    if (file.path === "manifest.json") {
-      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(artifacts.directory, manifest, file) }
-    }
-  }
+  await refreshArtifactManifestFileSha256s(artifacts.directory, manifest)
   await writeFile(artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+function evidenceFileToManifestFile(file: RecipeArtifactEvidenceFile): ArtifactManifestFile {
+  return { path: file.path, kind: file.kind, contentType: file.contentType, sha256: { algorithm: "sha256", value: file.sha256 } }
 }
 
 function markRecipeArtifactsFinalized(interruption: RecipeArtifactsFinalizationController | undefined, artifactsFinalized: boolean): void {
@@ -836,10 +812,6 @@ function markRecipeArtifactsFinalized(interruption: RecipeArtifactsFinalizationC
   }
 
   ;(interruption.metadata as { artifactsFinalized: boolean }).artifactsFinalized = artifactsFinalized
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
 }
 
 function stripUndefined<T extends Record<string, unknown>>(record: T): T {

--- a/packages/runtime-core/src/artifact-manifest.ts
+++ b/packages/runtime-core/src/artifact-manifest.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import type { RuntimeInfo } from "./index.js"
+import { stableJson } from "./object-utils.js"
 
 export interface ArtifactSpec {
   includeFiles?: boolean
@@ -78,6 +79,31 @@ export function calculateArtifactManifestSelfSha256(manifest: ArtifactManifest, 
     .digest("hex")
 }
 
+export function upsertArtifactManifestFiles(manifest: ArtifactManifest, files: ArtifactManifestFile[]): void {
+  manifest.files = Array.isArray(manifest.files) ? manifest.files : []
+  for (const file of files) {
+    const existing = manifest.files.find((entry) => entry.path === file.path)
+    if (existing) {
+      Object.assign(existing, file)
+    } else {
+      manifest.files.push(file)
+    }
+  }
+}
+
+export async function refreshArtifactManifestFileSha256s(directory: string, manifest: ArtifactManifest, manifestFileName = "manifest.json"): Promise<void> {
+  for (const file of manifest.files) {
+    if (file.path !== manifestFileName) {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file, manifestFileName) }
+    }
+  }
+  for (const file of manifest.files) {
+    if (file.path === manifestFileName) {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file, manifestFileName) }
+    }
+  }
+}
+
 function manifestWithPlaceholderSelfHash(manifest: ArtifactManifest, manifestFileName: string): ArtifactManifest {
   return {
     ...manifest,
@@ -85,19 +111,4 @@ function manifestWithPlaceholderSelfHash(manifest: ArtifactManifest, manifestFil
       ? { ...file, sha256: { algorithm: "sha256", value: "0".repeat(64) } }
       : file),
   }
-}
-
-function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJson(item)).join(",")}]`
-  }
-
-  return `{${Object.keys(value as Record<string, unknown>)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
-    .join(",")}}`
 }

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -19,7 +19,6 @@ export * from "./browser-interaction.js"
 export * from "./recipe-schema.js"
 export * from "./runtime-reference.js"
 export * from "./object-utils.js"
-export * from "./runtime-reference.js"
 
 export type RuntimeBackendKind = "wordpress-playground" | (string & {})
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto"
 import { lstat, mkdir, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path"
-import { calculateArtifactContentDigest, calculateArtifactManifestFileSha256 } from "./artifact-manifest.js"
+import { calculateArtifactContentDigest, calculateArtifactManifestFileSha256, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles } from "./artifact-manifest.js"
 import type { ArtifactFileDigest, ArtifactManifest, ArtifactManifestFile, ArtifactSpec } from "./artifact-manifest.js"
 import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA, buildRuntimeReferenceManifest, buildRuntimeReplayReferenceIndex, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest } from "./runtime-reference.js"
 import type { RuntimeReferenceManifest, RuntimeReferenceManifestArtifactBundleRef, RuntimeReferenceManifestFileRef, RuntimeReferenceManifestSnapshotRef, RuntimeReplayReferenceIndex, RuntimeReplayReferenceIndexActionRef, RuntimeReplayReferenceIndexObservationRef } from "./runtime-reference.js"
+import { isPlainObject as isRecord, stableJson } from "./object-utils.js"
 import { assertRuntimePolicy } from "./runtime-policy.js"
 import type { RuntimePolicy } from "./runtime-policy.js"
 
@@ -16,6 +17,8 @@ export * from "./command-registry.js"
 export * from "./task-input.js"
 export * from "./browser-interaction.js"
 export * from "./recipe-schema.js"
+export * from "./runtime-reference.js"
+export * from "./object-utils.js"
 export * from "./runtime-reference.js"
 
 export type RuntimeBackendKind = "wordpress-playground" | (string & {})
@@ -1398,10 +1401,6 @@ async function listBundleFiles(directory: string, prefix = ""): Promise<string[]
   return files.sort()
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
@@ -1900,21 +1899,6 @@ function nonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0
 }
 
-function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJson(item)).join(",")}]`
-  }
-
-  return `{${Object.keys(value)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
-    .join(",")}}`
-}
-
 function observationRef(observation: ObservationResult, fallbackId: string): RuntimeEpisodeTraceRef {
   return { kind: "observation", id: observation.id || fallbackId, digest: observation.digest ?? runtimeEpisodeDigest(runtimeEpisodeObservationDigestPayload(observation)) }
 }
@@ -2010,31 +1994,8 @@ function runtimeEpisodeJsonLines(trace: RuntimeEpisodeTrace): string {
   return `${records.map((record) => JSON.stringify(record)).join("\n")}\n`
 }
 
-function upsertManifestFile(manifest: ArtifactManifest, file: ArtifactManifestFile): void {
-  const index = manifest.files.findIndex((candidate) => candidate.path === file.path)
-  if (index === -1) {
-    manifest.files.push(file)
-    return
-  }
-
-  manifest.files[index] = file
-}
-
 function artifactManifestFile(path: string, kind: string, contentType: string): ArtifactManifestFile {
   return { path, kind, contentType, sha256: { algorithm: "sha256", value: "0".repeat(64) } }
-}
-
-async function refreshArtifactManifestFileHashes(directory: string, manifest: ArtifactManifest): Promise<void> {
-  for (const file of manifest.files) {
-    if (file.path !== "manifest.json") {
-      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
-    }
-  }
-  for (const file of manifest.files) {
-    if (file.path === "manifest.json") {
-      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
-    }
-  }
 }
 
 export async function createRuntime(spec: RuntimeCreateSpec, backend: RuntimeBackend): Promise<Runtime> {
@@ -2535,10 +2496,10 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
           artifactRef,
         ],
       })
-      upsertManifestFile(manifest, artifactManifestFile(relativePath, "runtime-snapshot-bundle", "application/json"))
+      upsertArtifactManifestFiles(manifest, [artifactManifestFile(relativePath, "runtime-snapshot-bundle", "application/json")])
     }
 
-    await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
+    await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
     await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
 
@@ -2584,7 +2545,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       snapshots: this.snapshots,
     })
     await writeFile(this.artifacts.runtimeReferenceManifestPath, `${JSON.stringify(referenceManifest, null, 2)}\n`)
-    await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
+    await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
     await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
 
@@ -2616,7 +2577,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       episodeTrace: trace,
     })
     await writeFile(this.artifacts.runtimeReplayReferenceIndexPath, `${JSON.stringify(replayIndex, null, 2)}\n`)
-    await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
+    await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
     await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
 
@@ -2626,10 +2587,12 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     }
 
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
-    upsertManifestFile(manifest, artifactManifestFile(traceRelativePath, "runtime-episode-trace", "application/json"))
-    upsertManifestFile(manifest, artifactManifestFile(eventsRelativePath, "runtime-episode-events", "application/x-ndjson"))
-    upsertManifestFile(manifest, artifactManifestFile("files/runtime-replay-index.json", "runtime-replay-index", "application/json"))
-    await refreshArtifactManifestFileHashes(this.artifacts.directory, manifest)
+    upsertArtifactManifestFiles(manifest, [
+      artifactManifestFile(traceRelativePath, "runtime-episode-trace", "application/json"),
+      artifactManifestFile(eventsRelativePath, "runtime-episode-events", "application/x-ndjson"),
+      artifactManifestFile("files/runtime-replay-index.json", "runtime-replay-index", "application/json"),
+    ])
+    await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
     await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   }
 

--- a/packages/runtime-core/src/object-utils.ts
+++ b/packages/runtime-core/src/object-utils.ts
@@ -1,5 +1,26 @@
+import { createHash } from "node:crypto"
+
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value)
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`
+  }
+
+  return `{${Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+    .join(",")}}`
+}
+
+export function sha256StableJson(value: unknown, trailingNewline = false): string {
+  return createHash("sha256").update(`${stableJson(value)}${trailingNewline ? "\n" : ""}`).digest("hex")
 }
 
 export function stringList(value: unknown): string[] {

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -4,6 +4,7 @@ import {
   buildRuntimeReferenceManifest,
   buildRuntimeReplayReferenceIndex,
   calculateArtifactManifestFileSha256,
+  refreshArtifactManifestFileSha256s,
   type ArtifactBundle,
   type ArtifactManifest,
   type ArtifactManifestFile,
@@ -250,20 +251,7 @@ export class ArtifactBundleBuilder {
         path: relative(source.artifactRoot, file.path),
       })),
     }
-    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "manifest.json" ? file : ({
-      ...file,
-      sha256: {
-        algorithm: "sha256" as const,
-        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, file),
-      },
-    })))
-    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path !== "manifest.json" ? file : ({
-      ...file,
-      sha256: {
-        algorithm: "sha256" as const,
-        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, file),
-      },
-    })))
+    await refreshArtifactManifestFileSha256s(source.artifactRoot, manifest)
     const runtimeReferenceIndex = await buildRuntimeReferenceIndex({
       artifactRoot: source.artifactRoot,
       createdAt,
@@ -272,13 +260,7 @@ export class ArtifactBundleBuilder {
       browserProbes: source.browserArtifacts(),
     })
     await writeFile(runtimeReferenceIndexPath, `${JSON.stringify(runtimeReferenceIndex, null, 2)}\n`)
-    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "files/runtime-reference-index.json" ? ({
-      ...file,
-      sha256: {
-        algorithm: "sha256" as const,
-        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, file),
-      },
-    }) : file))
+    await refreshArtifactManifestFileSha256s(source.artifactRoot, manifest)
     const runtimeReferenceManifest = buildRuntimeReferenceManifest({
       createdAt,
       runtime,
@@ -317,27 +299,7 @@ export class ArtifactBundleBuilder {
       snapshots: runtimeSnapshots,
     })
     await writeFile(runtimeReplayReferenceIndexPath, `${JSON.stringify(runtimeReplayReferenceIndex, null, 2)}\n`)
-    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "files/runtime-reference-manifest.json" ? ({
-      ...file,
-      sha256: {
-        algorithm: "sha256" as const,
-        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, file),
-      },
-    }) : file))
-    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path === "files/runtime-replay-index.json" ? ({
-      ...file,
-      sha256: {
-        algorithm: "sha256" as const,
-        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, file),
-      },
-    }) : file))
-    manifest.files = await Promise.all(manifest.files.map(async (file) => file.path !== "manifest.json" ? file : ({
-      ...file,
-      sha256: {
-        algorithm: "sha256" as const,
-        value: await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, file),
-      },
-    })))
+    await refreshArtifactManifestFileSha256s(source.artifactRoot, manifest)
     await writeRedactedArtifact(redactor, manifestPath, source.artifactRoot, `${JSON.stringify(manifest, null, 2)}\n`)
 
     return {

--- a/packages/runtime-playground/src/runtime-snapshot.ts
+++ b/packages/runtime-playground/src/runtime-snapshot.ts
@@ -1,6 +1,5 @@
-import { createHash } from "node:crypto"
 import { readFile } from "node:fs/promises"
-import { RUNTIME_EPISODE_SNAPSHOT_SCHEMA, runtimeEpisodeDigest, type MountSpec, type RuntimeCreateSpec, type RuntimeInfo, type Snapshot } from "@chubes4/wp-codebox-core"
+import { isPlainObject as isRecord, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, runtimeEpisodeDigest, sha256StableJson, type MountSpec, type RuntimeCreateSpec, type RuntimeInfo, type Snapshot } from "@chubes4/wp-codebox-core"
 import { playgroundRuntimeCommandIds } from "./command-router.js"
 
 export interface RuntimeSnapshotArtifact {
@@ -52,7 +51,7 @@ export class PlaygroundSnapshotRestoreError extends Error {
 }
 
 export function contentDigest(value: unknown): { algorithm: "sha256"; value: string } {
-  return { algorithm: "sha256", value: createHash("sha256").update(stableJson(value)).digest("hex") }
+  return { algorithm: "sha256", value: sha256StableJson(value) }
 }
 
 export function snapshotDigest(snapshot: Snapshot): { algorithm: "sha256"; value: string } {
@@ -262,21 +261,6 @@ echo wp_json_encode( array(
 `}`
 }
 
-function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJson(item)).join(",")}]`
-  }
-
-  return `{${Object.keys(value)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
-    .join(",")}}`
-}
-
 function isRuntimeInfo(value: unknown): value is RuntimeInfo {
   return isRecord(value)
     && value.backend === "wordpress-playground"
@@ -299,8 +283,4 @@ function isRuntimeSnapshotArtifact(value: unknown): value is RuntimeSnapshotArti
     && isRecord(value.database)
     && Array.isArray(value.database.tables)
     && Array.isArray(value.files)
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }


### PR DESCRIPTION
## Summary
- Centralize stable JSON and SHA-256 JSON helpers in runtime-core object utilities.
- Add generic artifact manifest file upsert and hash-refresh helpers in runtime-core.
- Reuse the shared helpers from CLI evidence, runtime episode artifact updates, playground artifact bundle building, and snapshot content digest paths without adding product-specific semantics.

Closes #344.

## Verification
- `npm run build`
- `npm run artifact-bundle-verifier-smoke`
- `npm run recipe-runtime-evidence-smoke`
- `npm run runtime-episode-smoke`
- `npm run artifact-contract-smoke` passed before rebase; after rebase, rerun exceeded the local tool timeout without failure output amid concurrent Playground processes.
- `npm run runtime-snapshot-restore-smoke` was attempted but blocked locally by Playground `EADDRINUSE` port collisions from concurrent worktree processes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the shared substrate helper refactor, resolved the rebase conflict, and ran verification commands. Chris remains responsible for review and merge.