### PR TITLE
Emit artifact diagnostics bundles

### DIFF
--- a/packages/runtime-core/src/artifact-manifest.ts
+++ b/packages/runtime-core/src/artifact-manifest.ts
@@ -26,6 +26,7 @@ export interface ArtifactManifestFile {
     | "log"
     | "mounts"
     | "file"
+    | "diagnostics"
     | "test-results"
     | (string & {})
   contentType: string

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -69,6 +69,7 @@ export interface ArtifactReview {
     patchSha256: string
     artifactContentDigest: string
     changedFiles: string
+    diagnostics?: string
     testResults?: string
     runtimeEpisodeTrace?: string
     runtimeReferenceManifest?: string
@@ -137,6 +138,44 @@ export interface ArtifactRedactionSummary {
 export interface ArtifactTestResultsRawLogReference {
   path: string
   kind: string
+}
+
+export type ArtifactDiagnosticSeverity = "error" | "warning" | "notice" | "info" | (string & {})
+
+export interface ArtifactDiagnosticRef {
+  path?: string
+  kind?: string
+  id?: string
+  url?: string
+}
+
+export interface ArtifactDiagnostic {
+  id: string
+  type: string
+  severity: ArtifactDiagnosticSeverity
+  message: string
+  category?: string
+  source?: string
+  path?: string
+  selector?: string
+  stage?: string
+  code?: string
+  provenance?: Record<string, unknown>
+  refs?: ArtifactDiagnosticRef[]
+  details?: Record<string, unknown>
+}
+
+export interface ArtifactDiagnostics {
+  schema: "wp-codebox/artifact-diagnostics/v1"
+  status: "clean" | "reported"
+  summary: {
+    total: number
+    error: number
+    warning: number
+    notice: number
+    info: number
+  }
+  diagnostics: ArtifactDiagnostic[]
 }
 
 export interface ArtifactTestResultsSuite {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -441,6 +441,7 @@ export interface ArtifactBundle {
   diffsPath: string
   changedFilesPath: string
   patchPath: string
+  diagnosticsPath: string
   testResultsPath: string
   reviewPath: string
   runAttestationPath?: string

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -25,6 +25,7 @@ import type { BrowserProbeArtifact } from "./browser-artifacts.js"
 import {
   ArtifactRedactor,
   artifactContentDigest,
+  buildArtifactDiagnostics,
   buildArtifactProvenance,
   buildArtifactReview,
   buildBlueprintAfter,
@@ -92,6 +93,7 @@ export class ArtifactBundleBuilder {
     const diffsPath = join(filesDirectory, "diffs.json")
     const changedFilesPath = join(filesDirectory, "changed-files.json")
     const patchPath = join(filesDirectory, "patch.diff")
+    const diagnosticsPath = join(filesDirectory, "diagnostics.json")
     const testResultsPath = join(filesDirectory, "test-results.json")
     const reviewPath = join(filesDirectory, "review.json")
     const runtimeReferenceManifestPath = join(filesDirectory, "runtime-reference-manifest.json")
@@ -140,6 +142,7 @@ export class ArtifactBundleBuilder {
       spec,
     }
     source.recordArtifactsCollected(bundleId, createdAt, spec)
+    const diagnostics = buildArtifactDiagnostics(source.observations)
     const testResults = buildTestResults()
     const review = buildArtifactReview({
       artifactId: bundleId,
@@ -152,10 +155,12 @@ export class ArtifactBundleBuilder {
       mounts: source.mounts,
       preview,
       browser,
+      diagnosticsPath: "files/diagnostics.json",
     })
     const artifactFiles = {
       changedFiles: relative(source.artifactRoot, changedFilesPath),
       patch: relative(source.artifactRoot, patchPath),
+      diagnostics: relative(source.artifactRoot, diagnosticsPath),
       testResults: relative(source.artifactRoot, testResultsPath),
       review: relative(source.artifactRoot, reviewPath),
       runtimeReferenceManifest: relative(source.artifactRoot, runtimeReferenceManifestPath),
@@ -195,6 +200,7 @@ export class ArtifactBundleBuilder {
       artifactManifestFile(diffsPath, "mount-diffs", "application/json"),
       artifactManifestFile(changedFilesPath, "changed-files", "application/json"),
       artifactManifestFile(patchPath, "patch", "text/x-diff"),
+      artifactManifestFile(diagnosticsPath, "diagnostics", "application/json"),
       artifactManifestFile(testResultsPath, "test-results", "application/json"),
       artifactManifestFile(reviewPath, "review", "application/json"),
       artifactManifestFile(runtimeReferenceManifestPath, "runtime-reference-manifest", "application/json"),
@@ -225,6 +231,7 @@ export class ArtifactBundleBuilder {
     await writeRedactedArtifact(redactor, diffsPath, source.artifactRoot, `${JSON.stringify(mountDiffs, null, 2)}\n`)
     await writeFile(changedFilesPath, changedFilesJson)
     await writeFile(patchPath, redactedPatch)
+    await writeRedactedArtifact(redactor, diagnosticsPath, source.artifactRoot, `${JSON.stringify(diagnostics, null, 2)}\n`)
     await writeRedactedArtifact(redactor, testResultsPath, source.artifactRoot, `${JSON.stringify(testResults, null, 2)}\n`)
     const redaction = redactor.summary()
     if (redaction.total > 0) {
@@ -317,6 +324,7 @@ export class ArtifactBundleBuilder {
       diffsPath,
       changedFilesPath,
       patchPath,
+      diagnosticsPath,
       testResultsPath,
       reviewPath,
       runtimeReferenceManifestPath,

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -4,6 +4,8 @@ import { basename, join } from "node:path"
 import { normalizeBlueprint, preferredVersionsForEnvironment } from "./blueprint.js"
 import { artifactFileDigest, stripUndefined } from "@chubes4/wp-codebox-core"
 import type {
+  ArtifactDiagnostic,
+  ArtifactDiagnostics,
   ArtifactPreview,
   ArtifactProvenance,
   ArtifactRedactionSummary,
@@ -11,6 +13,7 @@ import type {
   ArtifactReviewBrowserSummary,
   ArtifactTestResults,
   MountSpec,
+  ObservationResult,
   RuntimeCreateSpec,
   RuntimeInfo,
   SandboxWorkspaceContract,
@@ -194,6 +197,7 @@ export function buildArtifactReview({
   mounts,
   preview,
   browser,
+  diagnosticsPath,
 }: {
   artifactId: string
   createdAt: string
@@ -205,6 +209,7 @@ export function buildArtifactReview({
   mounts: MountSpec[]
   preview?: ArtifactPreview
   browser?: ArtifactReviewBrowserSummary
+  diagnosticsPath?: string
 }): ArtifactReview {
   const stats = {
     added: changedFiles.files.filter((file) => file.status === "added").length,
@@ -281,6 +286,7 @@ export function buildArtifactReview({
       patchSha256: artifactFileDigest(patch).value,
       artifactContentDigest: contentDigest,
       changedFiles: "files/changed-files.json",
+      ...(diagnosticsPath ? { diagnostics: diagnosticsPath } : {}),
       testResults: "files/test-results.json",
       runtimeReferenceManifest: "files/runtime-reference-manifest.json",
       runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
@@ -288,6 +294,125 @@ export function buildArtifactReview({
     ...(browser ? { browser } : {}),
     riskFlags: [],
   }
+}
+
+export function buildArtifactDiagnostics(observations: ObservationResult[]): ArtifactDiagnostics {
+  const diagnostics = observations.flatMap((observation, observationIndex) => diagnosticsFromObservation(observation, observationIndex))
+  const summary = {
+    total: diagnostics.length,
+    error: diagnostics.filter((diagnostic) => diagnostic.severity === "error").length,
+    warning: diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length,
+    notice: diagnostics.filter((diagnostic) => diagnostic.severity === "notice").length,
+    info: diagnostics.filter((diagnostic) => diagnostic.severity === "info").length,
+  }
+
+  return {
+    schema: "wp-codebox/artifact-diagnostics/v1",
+    status: diagnostics.length > 0 ? "reported" : "clean",
+    summary,
+    diagnostics,
+  }
+}
+
+function diagnosticsFromObservation(observation: ObservationResult, observationIndex: number): ArtifactDiagnostic[] {
+  const payload = observation.data && typeof observation.data === "object" ? observation.data as Record<string, unknown> : {}
+  const rawDiagnostics = [
+    ...arrayPayload(payload.diagnostics),
+    ...arrayPayload(payload.findings),
+    ...arrayPayload(payload.issues),
+    ...arrayPayload(payload.diagnostic),
+  ]
+
+  return rawDiagnostics
+    .map((raw, diagnosticIndex) => normalizeArtifactDiagnostic(raw, observation, observationIndex, diagnosticIndex))
+    .filter((diagnostic): diagnostic is ArtifactDiagnostic => diagnostic !== null)
+}
+
+function normalizeArtifactDiagnostic(raw: unknown, observation: ObservationResult, observationIndex: number, diagnosticIndex: number): ArtifactDiagnostic | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null
+  }
+
+  const value = raw as Record<string, unknown>
+  const type = stringField(value.type) || stringField(value.kind) || stringField(value.code) || "diagnostic"
+  const message = stringField(value.message) || stringField(value.summary) || stringField(value.reason) || type
+  const details = stripUndefined(Object.fromEntries(Object.entries(value).filter(([key]) => ![
+    "id",
+    "diagnostic_id",
+    "type",
+    "kind",
+    "code",
+    "message",
+    "summary",
+    "reason",
+    "severity",
+    "category",
+    "source",
+    "path",
+    "source_path",
+    "selector",
+    "stage",
+    "refs",
+    "references",
+    "artifactRefs",
+  ].includes(key))))
+
+  return stripUndefined({
+    id: stringField(value.id) || stringField(value.diagnostic_id) || `${observation.id ?? `observation-${observationIndex}`}-diagnostic-${diagnosticIndex + 1}`,
+    type,
+    severity: normalizeSeverity(value.severity),
+    message,
+    category: stringField(value.category),
+    source: stringField(value.source),
+    path: stringField(value.path) || stringField(value.source_path),
+    selector: stringField(value.selector),
+    stage: stringField(value.stage),
+    code: stringField(value.code),
+    provenance: stripUndefined({
+      observationId: observation.id,
+      observationType: observation.type,
+      observedAt: observation.observedAt,
+    }),
+    refs: artifactDiagnosticRefs(value.refs ?? value.references ?? value.artifactRefs),
+    details: Object.keys(details).length > 0 ? details : undefined,
+  }) as ArtifactDiagnostic
+}
+
+function artifactDiagnosticRefs(raw: unknown): ArtifactDiagnostic["refs"] {
+  return arrayPayload(raw)
+    .filter((value) => value && typeof value === "object" && !Array.isArray(value))
+    .map((value) => {
+      const record = value as Record<string, unknown>
+      return stripUndefined({
+        path: stringField(record.path),
+        kind: stringField(record.kind),
+        id: stringField(record.id),
+        url: stringField(record.url),
+      })
+    })
+    .filter((value) => Object.keys(value).length > 0)
+}
+
+function arrayPayload(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value
+  }
+  return value && typeof value === "object" ? [value] : []
+}
+
+function stringField(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim() !== "") {
+    return value
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+  return undefined
+}
+
+function normalizeSeverity(value: unknown): ArtifactDiagnostic["severity"] {
+  const severity = stringField(value)?.toLowerCase()
+  return severity === "error" || severity === "warning" || severity === "notice" || severity === "info" ? severity : "warning"
 }
 
 export function buildTestResults(): ArtifactTestResults {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,2 +1,3 @@
 export { playgroundRuntimeCommandIds } from "./command-router.js"
+export { buildArtifactDiagnostics } from "./artifacts.js"
 export { PlaygroundRuntimeBackend, createPlaygroundRuntimeBackend } from "./playground-runtime.js"

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA, createRuntime, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, verifyArtifactBundle } from "@chubes4/wp-codebox-core"
-import { createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
+import { buildArtifactDiagnostics, createPlaygroundRuntimeBackend } from "@chubes4/wp-codebox-playground"
 
 const execFileAsync = promisify(execFile)
 const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-artifacts-"))
@@ -43,6 +43,7 @@ try {
   assert.equal(verification.valid, true, JSON.stringify(verification.violations, null, 2))
   assert.ok(artifacts.changedFilesPath, "artifact bundle should expose changedFilesPath")
   assert.ok(artifacts.patchPath, "artifact bundle should expose patchPath")
+  assert.ok(artifacts.diagnosticsPath, "artifact bundle should expose diagnosticsPath")
   assert.ok(artifacts.testResultsPath, "artifact bundle should expose testResultsPath")
   assert.ok(artifacts.reviewPath, "artifact bundle should expose reviewPath")
   assert.equal(artifacts.preview.status, "available")
@@ -59,6 +60,7 @@ try {
   const changedFiles = JSON.parse(await readFile(artifacts.changedFilesPath, "utf8"))
   const changedFilesJson = await readFile(artifacts.changedFilesPath, "utf8")
   const patch = await readFile(artifacts.patchPath, "utf8")
+  const diagnostics = JSON.parse(await readFile(artifacts.diagnosticsPath, "utf8"))
   const testResults = JSON.parse(await readFile(artifacts.testResultsPath, "utf8"))
   const review = JSON.parse(await readFile(artifacts.reviewPath, "utf8"))
   const runtimeReferenceManifest = JSON.parse(await readFile(artifacts.runtimeReferenceManifestPath, "utf8"))
@@ -84,6 +86,7 @@ try {
   assert.deepEqual(metadata.preview, artifacts.preview)
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/changed-files.json" && file.kind === "changed-files"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/patch.diff" && file.kind === "patch"))
+  assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/diagnostics.json" && file.kind === "diagnostics"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/test-results.json" && file.kind === "test-results"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/review.json" && file.kind === "review"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
@@ -95,6 +98,7 @@ try {
   assert.deepEqual(metadata.artifacts, {
     changedFiles: "files/changed-files.json",
     patch: "files/patch.diff",
+    diagnostics: "files/diagnostics.json",
     testResults: "files/test-results.json",
     review: "files/review.json",
     runtimeReferenceManifest: "files/runtime-reference-manifest.json",
@@ -132,6 +136,10 @@ try {
   )
   assert.match(patch, /generated\.txt/)
   assert.match(patch, /\+cooked/)
+  assert.equal(diagnostics.schema, "wp-codebox/artifact-diagnostics/v1")
+  assert.equal(diagnostics.status, "clean")
+  assert.deepEqual(diagnostics.summary, { total: 0, error: 0, warning: 0, notice: 0, info: 0 })
+  assert.deepEqual(diagnostics.diagnostics, [])
   assert.equal(testResults.schema, "wp-codebox/test-results/v1")
   assert.equal(testResults.status, "unknown")
   assert.deepEqual(testResults.summary, { total: 0, passed: 0, failed: 0, skipped: 0, unknown: 0 })
@@ -145,6 +153,7 @@ try {
   assert.equal(review.evidence.patch, "files/patch.diff")
   assert.equal(review.evidence.artifactContentDigest, contentDigest)
   assert.equal(review.evidence.changedFiles, "files/changed-files.json")
+  assert.equal(review.evidence.diagnostics, "files/diagnostics.json")
   assert.equal(review.evidence.testResults, "files/test-results.json")
   assert.equal(review.evidence.runtimeReferenceManifest, "files/runtime-reference-manifest.json")
   assert.equal(runtimeReferenceIndex.schema, "wp-codebox/runtime-reference-index/v1")
@@ -175,6 +184,34 @@ try {
   assert.ok(review.actions.some((action: { kind: string; requiresApprovedFiles?: boolean }) => action.kind === "approve" && action.requiresApprovedFiles === true))
   assert.ok(review.actions.some((action: { kind: string }) => action.kind === "discard"))
   assert.ok(review.progress.some((event: { type: string; label: string }) => event.type === "complete" && event.label === "Ready for your review."))
+
+  const reportedDiagnostics = buildArtifactDiagnostics([
+    {
+      id: "observation-fixture",
+      type: "import-report",
+      observedAt: "2026-01-01T00:00:00.000Z",
+      data: {
+        diagnostics: [
+          {
+            diagnostic_id: "layout-gap-1",
+            type: "layout_fidelity_gap",
+            severity: "warning",
+            category: "transformation",
+            message: "Generated artifact lost source grid structure.",
+            path: "index.html",
+            selector: ".hero",
+            refs: [{ path: "files/import-report.json", kind: "import-report" }],
+            source_report: { html: { element_count: 8 }, css: { selector_count: 4 } },
+          },
+        ],
+      },
+    },
+  ])
+  assert.equal(reportedDiagnostics.status, "reported")
+  assert.equal(reportedDiagnostics.summary.warning, 1)
+  assert.equal(reportedDiagnostics.diagnostics[0].id, "layout-gap-1")
+  assert.equal(reportedDiagnostics.diagnostics[0].provenance?.observationType, "import-report")
+  assert.equal(reportedDiagnostics.diagnostics[0].details?.source_report?.html?.element_count, 8)
 
   const { stdout: runStdout } = await execFileAsync(
     process.execPath,


### PR DESCRIPTION
## Summary
- Add a generic `wp-codebox/artifact-diagnostics/v1` contract for normalized runtime/artifact diagnostics.
- Emit `files/diagnostics.json` in every Codebox artifact bundle and reference it from manifest, metadata, review evidence, and returned artifact paths.
- Export `buildArtifactDiagnostics()` so downstream consumers can normalize observation diagnostics without product-specific packet scripts.

## Testing
- `npm run build`
- `node --input-type=module -e 'import assert from \"node:assert/strict\"; import { buildArtifactDiagnostics } from \"./packages/runtime-playground/dist/index.js\"; const diagnostics = buildArtifactDiagnostics([{ id: \"obs-1\", type: \"import-report\", observedAt: \"2026-01-01T00:00:00.000Z\", data: { diagnostics: [{ diagnostic_id: \"layout-gap-1\", type: \"layout_fidelity_gap\", severity: \"warning\", message: \"Grid lost\", path: \"index.html\", selector: \".hero\", refs: [{ path: \"files/import-report.json\", kind: \"import-report\" }], source_report: { html: { element_count: 8 } } }] } }]); assert.equal(diagnostics.schema, \"wp-codebox/artifact-diagnostics/v1\"); assert.equal(diagnostics.status, \"reported\"); assert.equal(diagnostics.summary.warning, 1); assert.equal(diagnostics.diagnostics[0].id, \"layout-gap-1\"); assert.equal(diagnostics.diagnostics[0].details.source_report.html.element_count, 8); console.log(\"artifact diagnostics contract smoke passed\")'`
- `node packages/cli/dist/index.js run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code='echo \"diagnostics smoke\";' --artifacts "$tmpdir" --json` plus assertions for `diagnosticsPath`, `metadata.artifacts.diagnostics`, and `review.evidence.diagnostics`
- `npm run release:package`
- `npm run package-distribution-smoke`

## Notes
- `npm run artifact-contract-smoke` was attempted but did not return within 10 minutes in this environment. The targeted artifact bundle diagnostics smoke passed.
- An initial parallel run of `package-distribution-smoke` and `release:package` conflicted in `dist/release/.../playwright`; rerunning sequentially passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic artifact diagnostics contract, bundle emission, and smoke assertions under Chris's direction on Codebox/Homeboy/SSI ownership boundaries.