### PR TITLE
Inherit connector provider plugin paths

### DIFF
--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -309,6 +309,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           status: { type: "string" },
           provider: { type: "string" },
           model: { type: "string" },
+          providerPluginPaths: { type: "array", items: { type: "string" } },
           secretEnv: { type: "array", items: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" } },
           credentials: { $ref: "#/$defs/connectorCredentialEnvelope" },
         },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -215,6 +215,7 @@ export interface WorkspaceRecipeInheritanceConnector {
   status: "resolved" | "unresolved" | "skipped" | (string & {})
   provider?: string
   model?: string
+  providerPluginPaths?: string[]
   secretEnv?: string[]
   credentials?: ConnectorCredentialEnvelope
 }

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -85,11 +85,13 @@ connectors or settings by name:
 
 The parent site resolves that declaration through the
 `wp_codebox_resolve_inheritance` filter. The resolver may return connector
-status, `provider`, `model`, and `secret_env` names. WP Codebox records the
-requested names and sanitized resolution status in the generated recipe/artifact
-metadata and merges inherited `secret_env` names into the sandbox secret-env
-allowlist. Secret values and setting values are not serialized into recipe JSON,
-artifact metadata, logs, or patches by this transport slice.
+status, `provider`, `model`, `provider_plugin_paths`, and `secret_env` names. WP
+Codebox records the requested names and sanitized resolution status in the
+generated recipe/artifact metadata, mounts inherited provider plugins, and merges
+inherited `secret_env` names into the sandbox secret-env allowlist. Connector
+secret values are passed to the sandbox process environment only; secret values
+and setting values are not serialized into recipe JSON, artifact metadata, logs,
+or patches by this transport slice.
 
 Product callers may pass `mounts` to add editable or readonly host directories
 to the generated recipe. Each mount may include opaque `metadata` such as

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -408,21 +408,24 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */
-	private function provider_plugin_paths( array $input ): array {
+	private function provider_plugin_paths( array $input, ?array $inheritance = null ): array {
 		$configured = $this->configured_paths();
 		$paths      = is_array( $input['provider_plugin_paths'] ?? null ) ? $input['provider_plugin_paths'] : ( $configured['provider_plugins'] ?? array() );
+		$paths      = array_merge( is_array( $paths ) ? $paths : array(), $this->inheritance_provider_plugin_paths( $input, $inheritance ) );
 
 		if ( ! is_array( $paths ) ) {
 			return array();
 		}
 
 		return array_values(
-			array_filter(
-				array_map(
-					fn( $path ): string => $this->clean_path( (string) $path ),
-					$paths
-				),
-				static fn( string $path ): bool => '' !== $path && is_dir( $path )
+			array_unique(
+				array_filter(
+					array_map(
+						fn( $path ): string => $this->clean_path( (string) $path ),
+						$paths
+					),
+					static fn( string $path ): bool => '' !== $path && is_dir( $path )
+				)
 			)
 		);
 	}
@@ -577,6 +580,17 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				if ( '' !== $value ) {
 					$entry[ $field ] = $value;
 				}
+			}
+
+			$provider_plugin_paths = $this->string_list( $connector['provider_plugin_paths'] ?? $connector['providerPluginPaths'] ?? array() );
+			$provider_plugin_paths = array_values(
+				array_filter(
+					array_map( fn( string $path ): string => $this->clean_path( $path ), $provider_plugin_paths ),
+					static fn( string $path ): bool => '' !== $path && is_dir( $path )
+				)
+			);
+			if ( ! empty( $provider_plugin_paths ) ) {
+				$entry['providerPluginPaths'] = array_values( array_unique( $provider_plugin_paths ) );
 			}
 
 			$secret_env = $this->string_list( $connector['secret_env'] ?? $connector['secretEnv'] ?? array() );
@@ -747,6 +761,16 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return '';
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return string[] */
+	private function inheritance_provider_plugin_paths( array $input, ?array $inheritance = null ): array {
+		$paths = array();
+		foreach ( ( $inheritance ?? $this->inheritance_resolution( $input ) )['connectors'] as $connector ) {
+			$paths = array_merge( $paths, $this->string_list( $connector['providerPluginPaths'] ?? array() ) );
+		}
+
+		return $paths;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */
@@ -1430,7 +1454,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'slug'     => basename( $path ),
 				'activate' => false,
 			),
-			$this->provider_plugin_paths( $input )
+			$this->provider_plugin_paths( $input, $inheritance )
 		);
 
 		$provider_slugs = array_map( static fn( array $plugin ): string => (string) $plugin['slug'], $provider_plugins );

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -76,7 +76,7 @@ const representativeRecipes = [
       secretEnv: ["OPENAI_API_KEY"],
       inherit: { connectors: ["primary-ai"], settings: ["site-defaults"] },
       inheritance: {
-        connectors: [{ name: "primary-ai", status: "resolved", provider: "openai", model: "gpt-5.5", secretEnv: ["OPENAI_API_KEY"] }],
+        connectors: [{ name: "primary-ai", status: "resolved", provider: "openai", model: "gpt-5.5", providerPluginPaths: ["/tmp/ai-provider-test"], secretEnv: ["OPENAI_API_KEY"] }],
         settings: [{ name: "site-defaults", status: "resolved", scope: "site" }],
       },
     },

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -158,7 +158,7 @@ require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-cli-command.php';
 
 $root = sys_get_temp_dir() . '/wp-codebox-wordpress-plugin-' . getmypid();
-foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'plugin-root/agents-api', 'ai-provider-test', 'editable-plugin', 'artifacts', 'artifact-network-root' ) as $dir ) {
+foreach ( array( 'agents-api', 'data-machine', 'data-machine-code', 'plugin-root/agents-api', 'ai-provider-test', 'ai-provider-inherited', 'editable-plugin', 'artifacts', 'artifact-network-root' ) as $dir ) {
 	mkdir( $root . '/' . $dir, 0777, true );
 }
 $GLOBALS['wp_codebox_upload_dir'] = array(
@@ -947,13 +947,14 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] = array(
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = '';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model']    = '';
-$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ): array {
+$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ) use ( $root ): array {
 	$resolution['connectors'] = array(
 		array(
 			'name'       => $request['connectors'][0] ?? 'primary-ai',
 			'status'     => 'resolved',
 			'provider'   => 'openai',
 			'model'      => 'gpt-5.5',
+			'provider_plugin_paths' => array( $root . '/ai-provider-inherited' ),
 			'secret_env' => array( 'OPENAI_API_KEY' ),
 			'secret_env_values' => array( 'OPENAI_API_KEY' => 'sk-test-secret-value' ),
 			'credentials' => array(
@@ -1000,6 +1001,7 @@ $inherit_recipe    = json_decode( $captured_recipe, true );
 $inherit_step_args = $inherit_recipe['workflow']['steps'][0]['args'] ?? array();
 $assert( 'runner resolves inherited connector provider', ! is_wp_error( $inherit_result ) && in_array( 'provider=openai', $inherit_step_args, true ) );
 $assert( 'runner resolves inherited connector model', ! is_wp_error( $inherit_result ) && in_array( 'model=gpt-5.5', $inherit_step_args, true ) );
+$assert( 'runner mounts inherited provider plugin path', ! is_wp_error( $inherit_result ) && str_contains( $captured_recipe, 'ai-provider-inherited' ) && in_array( 'provider-plugin-slugs=ai-provider-test,ai-provider-inherited', $inherit_step_args, true ) );
 $assert( 'runner transports inherited secret env name only', ! is_wp_error( $inherit_result ) && in_array( 'OPENAI_API_KEY', $inherit_recipe['inputs']['secretEnv'] ?? array(), true ) && ! str_contains( $captured_recipe, 'OPENAI_API_KEY=' ) );
 $assert( 'runner passes inherited secret env value to command runner', ! is_wp_error( $inherit_result ) && 'sk-test-secret-value' === ( $captured_secret_env['OPENAI_API_KEY'] ?? '' ) );
 $assert( 'runner records connector credential provenance without value', ! is_wp_error( $inherit_result ) && 'wp-codebox/connector-credentials/v1' === ( $inherit_recipe['inputs']['inheritance']['connectors'][0]['credentials']['schema'] ?? '' ) && 'available' === ( $inherit_recipe['inputs']['inheritance']['connectors'][0]['credentials']['secrets'][0]['status'] ?? '' ) );


### PR DESCRIPTION
## Summary
- Carries inherited connector `provider_plugin_paths` through sanitized recipe inheritance as `providerPluginPaths`.
- Merges inherited provider plugin paths into the generated sandbox recipe so the agent step receives the inherited provider plugin slugs.
- Extends generic smoke coverage for provider/model/provider plugin path/secret env name/secret env value inheritance while asserting secret values stay out of recipe JSON.

## Tests
- `npm run build`
- `npm run discovery-command-smoke`
- `npm run wordpress-plugin-smoke`
- `git diff --check`

Closes #394.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic connector inheritance path, added regression coverage, ran focused verification, and prepared the PR summary. Chris remains responsible for review and merge.