### PR TITLE
Avoid large browser runtime plugin payloads

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -65,7 +65,10 @@ const operationPhp = ( operation ) => `<?php
 header( 'Content-Type: application/json; charset=utf-8' );
 
 if ( ! defined( 'ABSPATH' ) ) {
-	$wp_load = dirname( __DIR__, 4 ) . '/wp-load.php';
+	$wp_load = '/wordpress/wp-load.php';
+	if ( ! file_exists( $wp_load ) ) {
+		$wp_load = dirname( __DIR__, 4 ) . '/wp-load.php';
+	}
 	if ( ! file_exists( $wp_load ) ) {
 		$wp_load = rtrim( $_SERVER['DOCUMENT_ROOT'] ?? '', '/' ) . '/wp-load.php';
 	}
@@ -271,6 +274,11 @@ try {
 		const code = String( options.code || '' );
 		if ( ! code ) {
 			throw new Error( 'PHP code is required.' );
+		}
+
+		if ( typeof client.run === 'function' ) {
+			const response = await client.run( { code } );
+			return options.expectJson ? parseJsonResponse( response ) : response;
 		}
 
 		const runnerDir = String( options.runnerDir || defaultRunnerDir );

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -1445,7 +1445,8 @@ final class WP_Codebox_Abilities {
 			}
 
 			$resource = (string) ( $plugin['resource'] ?? 'url' );
-			if ( 'server' === (string) ( $plugin['package'] ?? '' ) ) {
+			$path     = 'git:directory' === $resource ? '' : self::browser_clean_path( (string) ( $plugin['path'] ?? '' ) );
+			if ( 'server' === (string) ( $plugin['package'] ?? '' ) && '' === $path ) {
 				$slug = self::safe_key( (string) ( $plugin['slug'] ?? '' ) );
 				if ( '' === $slug ) {
 					return new WP_Error( 'wp_codebox_browser_plugin_slug_missing', 'Server-packaged browser plugin specs require a slug.', array( 'status' => 400, 'field' => 'runtime.plugins', 'index' => $index ) );
@@ -1473,7 +1474,6 @@ final class WP_Codebox_Abilities {
 				continue;
 			}
 
-			$path = 'git:directory' === $resource ? '' : self::browser_clean_path( (string) ( $plugin['path'] ?? '' ) );
 			if ( '' === $path ) {
 				$resolved[] = $plugin;
 				continue;
@@ -1514,6 +1514,10 @@ final class WP_Codebox_Abilities {
 
 	/** @param array<string,mixed> $input Ability input. @param array<int,array<string,mixed>> $declared_plugins Caller/runtime plugin specs. @return array<int,array<string,mixed>>|WP_Error */
 	private static function browser_component_plugins( array $input, array $declared_plugins ): array|WP_Error {
+		if ( ! self::browser_component_plugins_required( $input ) ) {
+			return array();
+		}
+
 		$paths = self::browser_component_paths( $input );
 		$declared_slugs = array_values(
 			array_filter(
@@ -1558,15 +1562,29 @@ final class WP_Codebox_Abilities {
 		return $plugins;
 	}
 
+	private static function browser_component_plugins_required( array $input ): bool {
+		$provider_plugin_paths = is_array( $input['provider_plugin_paths'] ?? null ) ? $input['provider_plugin_paths'] : array();
+		$inherit               = is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array();
+		$connectors            = is_array( $inherit['connectors'] ?? null ) ? $inherit['connectors'] : array();
+		$secret_env            = is_array( $input['secret_env'] ?? null ) ? $input['secret_env'] : array();
+
+		return ! empty( $input['browser_runner'] ) || ! empty( $provider_plugin_paths ) || ! empty( $connectors ) || ! empty( $secret_env );
+	}
+
 	/** @param array<string,mixed> $input Ability input. @return array{agents_api:string,data_machine:string,data_machine_code:string} */
 	private static function browser_component_paths( array $input ): array {
 		$configured = array_merge( self::browser_default_component_paths(), self::browser_configured_component_paths() );
 
 		return array(
-			'agents_api'        => self::browser_clean_path( (string) ( $input['agents_api_path'] ?? $configured['agents_api'] ?? '' ) ),
-			'data_machine'      => self::browser_clean_path( (string) ( $input['data_machine_path'] ?? $configured['data_machine'] ?? '' ) ),
-			'data_machine_code' => self::browser_clean_path( (string) ( $input['data_machine_code_path'] ?? $configured['data_machine_code'] ?? '' ) ),
+			'agents_api'        => self::browser_clean_path( self::browser_component_path_value( $input, 'agents_api_path', $configured['agents_api'] ?? '' ) ),
+			'data_machine'      => self::browser_clean_path( self::browser_component_path_value( $input, 'data_machine_path', $configured['data_machine'] ?? '' ) ),
+			'data_machine_code' => self::browser_clean_path( self::browser_component_path_value( $input, 'data_machine_code_path', $configured['data_machine_code'] ?? '' ) ),
 		);
+	}
+
+	private static function browser_component_path_value( array $input, string $key, string $fallback ): string {
+		$value = trim( (string) ( $input[ $key ] ?? '' ) );
+		return '' !== $value ? $value : $fallback;
 	}
 
 	/** @return array{agents_api:string,data_machine:string,data_machine_code:string} */
@@ -1666,13 +1684,13 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_browser_plugin_package_hash_failed', 'Could not hash browser runtime plugin package.', array( 'status' => 500, 'slug' => $slug ) );
 		}
 
-		$data_url = self::browser_plugin_data_url( $zip_path, $slug );
-		if ( is_wp_error( $data_url ) ) {
-			return $data_url;
+		$delivery_url = self::browser_plugin_delivery_url( $zip_path, $url, $slug );
+		if ( is_wp_error( $delivery_url ) ) {
+			return $delivery_url;
 		}
 
 		return array(
-			'url'    => $data_url,
+			'url'    => $delivery_url,
 			'path'   => $zip_path,
 			'sha256' => $sha256,
 		);
@@ -1725,23 +1743,23 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_browser_plugin_package_url_missing', 'Browser runtime plugin package URL is missing.', array( 'status' => 500, 'slug' => $slug ) );
 		}
 
-		$data_url = self::browser_plugin_data_url( $zip_path, $slug );
-		if ( is_wp_error( $data_url ) ) {
-			return $data_url;
+		$delivery_url = self::browser_plugin_delivery_url( $zip_path, $url, $slug );
+		if ( is_wp_error( $delivery_url ) ) {
+			return $delivery_url;
 		}
 
 		return array(
-			'url'    => $data_url,
+			'url'    => $delivery_url,
 			'path'   => $zip_path,
 			'sha256' => $sha256,
 		);
 	}
 
-	private static function browser_plugin_data_url( string $zip_path, string $slug ): string|WP_Error {
-		$max_bytes = (int) apply_filters( 'wp_codebox_browser_plugin_data_url_max_bytes', 24 * 1024 * 1024, $zip_path, $slug );
+	private static function browser_plugin_delivery_url( string $zip_path, string $public_url, string $slug ): string|WP_Error {
+		$max_bytes = (int) apply_filters( 'wp_codebox_browser_plugin_data_url_max_bytes', 512 * 1024, $zip_path, $slug );
 		$size      = filesize( $zip_path );
 		if ( is_int( $size ) && $size > $max_bytes ) {
-			return new WP_Error( 'wp_codebox_browser_plugin_package_too_large', 'Browser runtime plugin package is too large for inline browser delivery.', array( 'status' => 500, 'slug' => $slug, 'bytes' => $size, 'max_bytes' => $max_bytes ) );
+			return $public_url;
 		}
 
 		$contents = file_get_contents( $zip_path );
@@ -2370,7 +2388,7 @@ $payload = ' . var_export( $default_payload, true ) . ';
 $invocation = ' . var_export( $default_invocation, true ) . ';
 
 $wp_codebox_playground_root = defined( \'ABSPATH\' ) ? wp_normalize_path( ABSPATH ) : \'\';
-$wp_codebox_is_playground = \'Emscripten\' === PHP_OS_FAMILY && \'/wordpress/\' === $wp_codebox_playground_root;
+$wp_codebox_is_playground = \'/wordpress/\' === $wp_codebox_playground_root;
 
 if ( is_readable( $task_path ) ) {
 	$raw_payload = json_decode( (string) file_get_contents( $task_path ), true );

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -29,6 +29,14 @@ assert.equal(typeof runtime.activateTheme, "function")
 const parsed = runtime.parseJsonResponse("notice before {\"success\":true,\"data\":{\"ok\":true}} warning after")
 assert.deepEqual(sameRealm(parsed), { success: true, data: { ok: true } })
 
+const runClient = createClient("unused", true)
+runClient.runResponse = { text: "prefix {\"success\":true,\"data\":{\"runner\":\"direct\"},\"error\":null} suffix" }
+const directRunResult = await runtime.runPhpRequest(runClient, { code: "<?php echo 'ok';", expectJson: true })
+assert.deepEqual(sameRealm(directRunResult), { success: true, data: { runner: "direct" }, error: null })
+assert.equal(runClient.runs[0]?.code, "<?php echo 'ok';")
+assert.equal(runClient.files.length, 0)
+assert.equal(runClient.requests.length, 0)
+
 assert.deepEqual(sameRealm(runtime.normalizeOperationResult({ success: true, data: { path: "/tmp/example" } })), {
   success: true,
   data: { path: "/tmp/example" },
@@ -54,6 +62,7 @@ assert.deepEqual(sameRealm(directoryResult), {
 })
 assert.equal(successClient.mkdirs[0], "/wordpress/wp-content/uploads/wp-codebox/runner")
 assert.match(successClient.files[0]?.path ?? "", /\/wordpress\/wp-content\/uploads\/wp-codebox\/runner\/codebox-ensuredirectory-/)
+assert.match(successClient.files[0]?.contents ?? "", /\/wordpress\/wp-load\.php/)
 assert.match(successClient.files[0]?.contents ?? "", /wp-load\.php/)
 assert.match(successClient.files[0]?.contents ?? "", /case 'ensureDirectory':/)
 assert.match(successClient.requests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/codebox-ensuredirectory-/)
@@ -116,11 +125,13 @@ function sameRealm<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
 
-function createClient(response: unknown) {
-  return {
+function createClient(response: unknown, supportsRun = false) {
+  const client = {
     mkdirs: [] as string[],
     files: [] as Array<{ path: string; contents: string }>,
     requests: [] as Array<{ method: string; url: string }>,
+    runs: [] as Array<{ code: string }>,
+    runResponse: undefined as unknown,
     async mkdir(path: string) {
       this.mkdirs.push(path)
     },
@@ -131,5 +142,15 @@ function createClient(response: unknown) {
       this.requests.push(request)
       return response
     },
+    async run(options: { code: string }) {
+      this.runs.push(options)
+      return this.runResponse
+    },
   }
+
+  if (!supportsRun) {
+    delete (client as { run?: unknown }).run
+  }
+
+  return client
 }

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -388,6 +388,9 @@ $browser_session = call_user_func(
 	$browser_session_ability['execute_callback'],
 	array(
 		'goal'                  => 'Prepare a browser Playground preview.',
+		'agents_api_path'       => '',
+		'data_machine_path'     => '',
+		'data_machine_code_path' => '',
 		'sandbox_session_id'    => 'browser-session-123',
 		'target'                => array( 'kind' => 'sandbox-runtime' ),
 		'allowed_tools'         => array( 'filesystem-write', 'filesystem-write', '' ),
@@ -411,8 +414,9 @@ $browser_session = call_user_func(
 					'activate' => false,
 				),
 				array(
-					'slug' => 'generic-caller-plugin',
-					'path' => $root . '/plugin-root/generic-caller-plugin',
+					'slug'    => 'generic-caller-plugin',
+					'package' => 'server',
+					'path'    => $root . '/plugin-root/generic-caller-plugin',
 				),
 				array(
 					'slug'             => 'example-git-plugin',
@@ -519,7 +523,7 @@ $assert( 'browser Playground session installs caller browser plugins without dup
 $assert( 'browser Playground session packages required host runtime plugins', ! is_wp_error( $browser_session ) && str_starts_with( (string) ( $browser_session['plugins'][1]['url'] ?? '' ), 'data:application/zip;base64,' ) && str_starts_with( (string) ( $browser_session['plugins'][2]['url'] ?? '' ), 'data:application/zip;base64,' ) && 64 === strlen( (string) ( $browser_session['plugins'][1]['provenance']['sha256'] ?? '' ) ) );
 $assert( 'browser Playground session accepts structured runtime dependencies', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-runtime-dependencies/v1' === ( $browser_session['runtime']['schema'] ?? '' ) && 6 === ( $browser_session['runtime']['summary']['plugins'] ?? 0 ) && 2 === ( $browser_session['runtime']['component_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['mu_plugins'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['themes'] ?? 0 ) && 1 === ( $browser_session['runtime']['summary']['bootstrap'] ?? 0 ) );
 $assert( 'browser Playground session server-packages remote runtime plugins after required components', ! is_wp_error( $browser_session ) && 'installPlugin' === ( $browser_session['playground']['blueprint']['steps'][4]['step'] ?? '' ) && str_starts_with( (string) ( $browser_session['playground']['blueprint']['steps'][4]['pluginData']['url'] ?? '' ), 'data:application/zip;base64,' ) && false === ( $browser_session['playground']['blueprint']['steps'][4]['options']['activate'] ?? true ) && 'runtime-plugin-remote-package' === ( $browser_session['plugins'][3]['provenance']['source'] ?? '' ) );
-$assert( 'browser Playground session packages declarative runtime plugin paths', ! is_wp_error( $browser_session ) && str_starts_with( (string) ( $browser_session['plugins'][4]['url'] ?? '' ), 'data:application/zip;base64,' ) && 64 === strlen( (string) ( $browser_session['plugins'][4]['provenance']['sha256'] ?? '' ) ) );
+$assert( 'browser Playground session packages server runtime plugin paths', ! is_wp_error( $browser_session ) && str_starts_with( (string) ( $browser_session['plugins'][4]['url'] ?? '' ), 'data:application/zip;base64,' ) && 64 === strlen( (string) ( $browser_session['plugins'][4]['provenance']['sha256'] ?? '' ) ) && 'runtime-plugin-path' === ( $browser_session['plugins'][4]['provenance']['source'] ?? '' ) );
 $assert( 'browser Playground session compiles git directory runtime plugins', ! is_wp_error( $browser_session ) && 'git:directory' === ( $browser_session['playground']['blueprint']['steps'][6]['pluginData']['resource'] ?? '' ) && 'plugins/example-git-plugin' === ( $browser_session['playground']['blueprint']['steps'][6]['pluginData']['path'] ?? '' ) && 'example-git-plugin' === ( $browser_session['playground']['blueprint']['steps'][6]['options']['targetFolderName'] ?? '' ) );
 $assert( 'browser Playground session compiles caller mu-plugin runtime dependency', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][7]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][7]['code'] ?? '' ), '/wordpress/wp-content/mu-plugins/caller-runtime.php' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][7]['code'] ?? '' ), 'caller_runtime_task' ) );
 $assert( 'browser Playground session compiles theme runtime dependency', ! is_wp_error( $browser_session ) && 'runPHP' === ( $browser_session['playground']['blueprint']['steps'][8]['step'] ?? '' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), '/wordpress/wp-content/themes/example-starter/style.css' ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), "require_once '/wordpress/wp-load.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), "require_once ABSPATH . WPINC . '/theme.php'" ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][8]['code'] ?? '' ), "switch_theme( 'example-starter' )" ) );
@@ -532,7 +536,7 @@ $assert( 'browser Playground recipe invokes caller task inside site', ! is_wp_er
 $assert( 'browser Playground recipe keeps ability invocation path generic', ! is_wp_error( $browser_session ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_get_ability( $ability_name )' ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_codebox_browser_ability_unavailable' ) );
 $assert( 'browser Playground recipe installs caller mu-plugin before invocation', ! is_wp_error( $browser_session ) && 7 < count( $browser_session['playground']['blueprint']['steps'] ?? array() ) && str_contains( (string) ( $browser_session['playground']['blueprint']['steps'][7]['code'] ?? '' ), 'caller_runtime_task' ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'caller_runtime_task' ) );
 $assert( 'browser Playground recipe keeps invocation fixed after parent validation', ! is_wp_error( $browser_session ) && ! str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), '$payload[\'invocation\']' ) );
-$assert( 'browser Playground recipe guards permission bypass to Playground', ! is_wp_error( $browser_session ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), "'Emscripten' === PHP_OS_FAMILY" ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_codebox_browser_runner_not_playground' ) );
+$assert( 'browser Playground recipe guards permission bypass to Playground', ! is_wp_error( $browser_session ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), "'/wordpress/' === $" . 'wp_codebox_playground_root' ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_codebox_browser_runner_not_playground' ) );
 $assert( 'browser Playground session emits ready-to-code signal only when blueprint prerequisites are present', ! is_wp_error( $browser_session ) && true === ( $browser_session['signals']['ready_to_code']['emitted'] ?? false ) && 'ready_to_code' === ( $browser_session['signals']['ready_to_code']['name'] ?? '' ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['agents_api'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['data_machine'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['data_machine_code'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['provider_secret'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['runtime_dependencies'] ?? false ) );
 $assert( 'browser Playground session exposes runtime dependency readiness metadata', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-runtime-readiness/v1' === ( $browser_session['signals']['ready_to_code']['requirement_metadata']['runtime_dependencies']['schema'] ?? '' ) && 'caller-runtime' === ( $browser_session['signals']['ready_to_code']['requirement_metadata']['runtime_dependencies']['mu_plugins'][0]['slug'] ?? '' ) && 'example-starter' === ( $browser_session['signals']['ready_to_code']['requirement_metadata']['runtime_dependencies']['themes'][0]['slug'] ?? '' ) );
 $assert( 'browser Playground session preserves safe artifact files', ! is_wp_error( $browser_session ) && 'repair-output/index.html' === ( $browser_session['artifacts']['files'][0]['path'] ?? '' ) );
@@ -545,6 +549,25 @@ $assert( 'browser Playground session exposes preview URL', ! is_wp_error( $brows
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
 $assert( 'browser Playground session returns canonical task input metadata', ! is_wp_error( $browser_session ) && 'wp-codebox/task-input/v1' === ( $browser_session['task_input']['schema'] ?? '' ) && 1 === ( $browser_session['task_input']['version'] ?? 0 ) );
 $assert( 'browser Playground session exposes canonical task string', ! is_wp_error( $browser_session ) && 'Prepare a browser Playground preview.' === ( $browser_session['task'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] = static fn(): int => 1;
+$browser_url_package_session = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'    => 'Prepare browser Playground with URL-delivered packages.',
+		'runtime' => array(
+			'plugins' => array(
+				array(
+					'slug'    => 'generic-caller-plugin',
+					'package' => 'server',
+					'path'    => $root . '/plugin-root/generic-caller-plugin',
+				),
+			),
+		),
+	)
+);
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] );
+$assert( 'browser Playground session uses stable package URLs when inline budget is exceeded', ! is_wp_error( $browser_url_package_session ) && str_starts_with( (string) ( $browser_url_package_session['plugins'][0]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/generic-caller-plugin-' ) && ! str_starts_with( (string) ( $browser_url_package_session['plugins'][0]['url'] ?? '' ), 'data:application/zip;base64,' ) && ( $browser_url_package_session['plugins'][0]['url'] ?? '' ) === ( $browser_url_package_session['playground']['blueprint']['steps'][1]['pluginData']['url'] ?? '' ) && 64 === strlen( (string) ( $browser_url_package_session['plugins'][0]['provenance']['sha256'] ?? '' ) ) );
 
 $browser_site_blueprint_session = call_user_func(
 	$browser_session_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Keep browser runtime/component plugin ZIP payloads small by using stable upload URLs once a package exceeds the inline data URL budget.
- Preserve tiny inline plugin delivery and continue generating Playground-installable `installPlugin` blueprint steps.
- Include the prior browser runtime fixes needed for this path: local `package: server` plugin paths, direct `client.run({ code })`, Playground wp-load bootstrap, `/wordpress/` sandbox guard, blank component path fallbacks, and avoiding unnecessary component packaging for plain starter previews.

Fixes #396.

## Verification
- `php tests/smoke-wordpress-plugin.php` passed: 242 assertions.
- `npm run browser-runtime-operation-smoke` passed.
- Studio Web live eval passed the previous `/studio-web/v1/projects` memory exhaustion and now fails later with `Studio Web preview client unavailable; targets REST returned 200`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing and verifying WP Codebox browser runtime/session payload fixes under Chris's review.