### PR TITLE
Fix local browser runtime package delivery

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -1750,7 +1750,7 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_browser_plugin_package_hash_failed', 'Could not hash browser runtime plugin package.', array( 'status' => 500, 'slug' => $slug ) );
 		}
 
-		$delivery_url = self::browser_plugin_delivery_url( $zip_path, $url, $slug );
+		$delivery_url = self::browser_plugin_delivery_url( $zip_path, self::browser_safe_local_package_url( $url ), $slug );
 		if ( is_wp_error( $delivery_url ) ) {
 			return $delivery_url;
 		}
@@ -1809,7 +1809,7 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_browser_plugin_package_url_missing', 'Browser runtime plugin package URL is missing.', array( 'status' => 500, 'slug' => $slug ) );
 		}
 
-		$delivery_url = self::browser_plugin_delivery_url( $zip_path, $url, $slug );
+		$delivery_url = self::browser_plugin_delivery_url( $zip_path, self::browser_safe_local_package_url( $url ), $slug );
 		if ( is_wp_error( $delivery_url ) ) {
 			return $delivery_url;
 		}
@@ -1834,6 +1834,25 @@ final class WP_Codebox_Abilities {
 		}
 
 		return 'data:application/zip;base64,' . base64_encode( $contents );
+	}
+
+	private static function browser_safe_local_package_url( string $url ): string {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || 'http' !== strtolower( (string) ( $parts['scheme'] ?? '' ) ) || ! self::is_loopback_host( (string) ( $parts['host'] ?? '' ) ) ) {
+			return $url;
+		}
+
+		$host = strtolower( trim( (string) $parts['host'], '[]' ) );
+		if ( 'localhost' === $host ) {
+			return $url;
+		}
+
+		$port     = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
+		$path     = (string) ( $parts['path'] ?? '' );
+		$query    = isset( $parts['query'] ) ? '?' . (string) $parts['query'] : '';
+		$fragment = isset( $parts['fragment'] ) ? '#' . (string) $parts['fragment'] : '';
+
+		return 'http://localhost' . $port . $path . $query . $fragment;
 	}
 
 	private static function browser_download_remote_plugin( string $url, string $zip_path, string $slug ): true|WP_Error {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -602,6 +602,28 @@ $browser_url_package_session = call_user_func(
 unset( $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] );
 $assert( 'browser Playground session uses stable package URLs when inline budget is exceeded', ! is_wp_error( $browser_url_package_session ) && str_starts_with( (string) ( $browser_url_package_session['plugins'][0]['url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/generic-caller-plugin-' ) && ! str_starts_with( (string) ( $browser_url_package_session['plugins'][0]['url'] ?? '' ), 'data:application/zip;base64,' ) && ( $browser_url_package_session['plugins'][0]['url'] ?? '' ) === ( $browser_url_package_session['playground']['blueprint']['steps'][1]['pluginData']['url'] ?? '' ) && 64 === strlen( (string) ( $browser_url_package_session['plugins'][0]['provenance']['sha256'] ?? '' ) ) );
 
+$GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] = static fn(): int => 1;
+$previous_upload_dir = $GLOBALS['wp_codebox_upload_dir'];
+$GLOBALS['wp_codebox_upload_dir']['baseurl'] = 'http://127.0.0.1:63498/uploads';
+$browser_local_url_package_session = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'    => 'Prepare browser Playground with local URL-delivered packages.',
+		'runtime' => array(
+			'plugins' => array(
+				array(
+					'slug'    => 'generic-caller-plugin',
+					'package' => 'server',
+					'path'    => $root . '/plugin-root/generic-caller-plugin',
+				),
+			),
+		),
+	)
+);
+$GLOBALS['wp_codebox_upload_dir'] = $previous_upload_dir;
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] );
+$assert( 'browser Playground session rewrites loopback package URLs to localhost', ! is_wp_error( $browser_local_url_package_session ) && str_starts_with( (string) ( $browser_local_url_package_session['plugins'][0]['url'] ?? '' ), 'http://localhost:63498/uploads/wp-codebox/browser-runtime-plugins/generic-caller-plugin-' ) && ! str_starts_with( (string) ( $browser_local_url_package_session['plugins'][0]['url'] ?? '' ), 'data:application/zip;base64,' ) && ( $browser_local_url_package_session['plugins'][0]['url'] ?? '' ) === ( $browser_local_url_package_session['playground']['blueprint']['steps'][1]['pluginData']['url'] ?? '' ) );
+
 $browser_site_blueprint_session = call_user_func(
 	$browser_session_ability['execute_callback'],
 	array(


### PR DESCRIPTION
## Summary
- Normalize WP Codebox-generated loopback browser runtime package URLs from `http://127.0.0.1` / `http://[::1]` to `http://localhost` before emitting stable URL delivery.
- Preserve URL delivery for packages above the inline data URL budget so browser session payloads do not embed large ZIP data URLs.
- Add smoke coverage for forced URL delivery from a local upload base URL and assert the emitted blueprint uses the localhost package URL.

Fixes #410.

## Tests
- `npm run wordpress-plugin-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the browser runtime package transport failure, implementing the WP Codebox upstream fix, and adding targeted smoke coverage; Chris remains responsible for review and merge.