### PR TITLE
fix: refresh bench REST routes after activation

### DIFF
--- a/examples/bench-plugin/bench-plugin.php
+++ b/examples/bench-plugin/bench-plugin.php
@@ -10,3 +10,18 @@ defined( 'ABSPATH' ) || exit;
 function wp_codebox_bench_plugin_value(): int {
 	return 7;
 }
+
+add_action(
+	'rest_api_init',
+	static function (): void {
+		register_rest_route(
+			'wp-codebox-bench/v1',
+			'/value',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static fn (): array => array( 'value' => wp_codebox_bench_plugin_value() ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+);

--- a/examples/bench-plugin/tests/bench/noop.php
+++ b/examples/bench-plugin/tests/bench/noop.php
@@ -1,9 +1,13 @@
 <?php
 
 return static function (): array {
+	$response = rest_do_request( new WP_REST_Request( 'GET', '/wp-codebox-bench/v1/value' ) );
+	$data     = rest_get_server()->response_to_data( $response, false );
+
 	return array(
 		'metrics'  => array(
-			'fixture_value' => wp_codebox_bench_plugin_value(),
+			'fixture_value'      => wp_codebox_bench_plugin_value(),
+			'rest_route_visible' => isset( $data['value'] ) && 7 === (int) $data['value'] ? 1 : 0,
 		),
 		'metadata' => array(
 			'fixture' => 'bench-plugin',

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -155,6 +155,10 @@ foreach ($plugins_to_activate as $plugin_to_activate) {
         throw new RuntimeException($activation->get_error_message());
     }
 }
+if (!empty($plugins_to_activate)) {
+    do_action('plugins_loaded');
+    do_action('init');
+}
 if (did_action('rest_api_init')) {
     $GLOBALS['wp_rest_server'] = null;
     do_action('rest_api_init', rest_get_server());

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -155,6 +155,10 @@ foreach ($plugins_to_activate as $plugin_to_activate) {
         throw new RuntimeException($activation->get_error_message());
     }
 }
+if (did_action('rest_api_init')) {
+    $GLOBALS['wp_rest_server'] = null;
+    do_action('rest_api_init', rest_get_server());
+}
 
 function wp_codebox_bench_run_configured_workload(array $workload, string $plugin_path) {
     $steps = isset($workload['run']) && is_array($workload['run']) ? $workload['run'] : array($workload);

--- a/scripts/recipe-bench-smoke.ts
+++ b/scripts/recipe-bench-smoke.ts
@@ -87,6 +87,7 @@ assert.equal(scenario.id, "noop")
 assert.equal(scenario.file, "tests/bench/noop.php")
 assert.equal(scenario.iterations, 2)
 assert.equal(scenario.metrics.fixture_value_mean, 7)
+assert.equal(scenario.metrics.rest_route_visible_mean, 1)
 assert.equal(scenario.metadata.fixture, "bench-plugin")
 const configured = output.benchResults.scenarios[1]
 assert.equal(configured.id, "configured-env")


### PR DESCRIPTION
## Summary
- Refresh the REST server after `wordpress.bench` activates mounted plugins late in a runtime.
- Covers plugins that register routes on `rest_api_init`, matching normal WordPress activation/load behavior more closely.
- Extends the bench fixture smoke to assert a plugin REST route is visible to bench workloads.

## Testing
- `npm run build`
- `npm run recipe-bench-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the late plugin activation REST route gap, drafted the route refresh fix, and added smoke coverage. Chris remains responsible for review and merge.