### PR TITLE
Expose browser Playground CORS proxy

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -323,6 +323,11 @@ final class WP_Codebox_Abilities {
 							'playground'         => array(
 								'type'        => 'object',
 								'description' => 'Optional browser Playground client and artifact preview configuration overrides.',
+								'properties'  => array(
+									'client_module_url' => array( 'type' => 'string' ),
+									'remote_url'        => array( 'type' => 'string' ),
+									'cors_proxy_url'    => array( 'type' => 'string' ),
+								),
 							),
 							'browser_runner'     => array(
 								'type'        => 'object',
@@ -877,6 +882,7 @@ final class WP_Codebox_Abilities {
 			'playground' => array(
 				'client_module_url'  => $playground['client_module_url'],
 				'remote_url'         => $playground['remote_url'],
+				'cors_proxy_url'    => $playground['cors_proxy_url'],
 				'scope'              => (string) ( $playground['scope'] ?? $session_id ),
 				'artifact_base_path' => self::browser_artifact_base_path( $playground ),
 				'artifact_base_url'  => self::browser_artifact_base_url( $playground ),
@@ -938,6 +944,7 @@ final class WP_Codebox_Abilities {
 			'playground' => array(
 				'client_module_url'  => $playground['client_module_url'],
 				'remote_url'         => $playground['remote_url'],
+				'cors_proxy_url'    => $playground['cors_proxy_url'],
 				'scope'              => (string) ( $playground['scope'] ?? $session_id ),
 				'artifact_base_path' => self::browser_artifact_base_path( $playground ),
 				'artifact_base_url'  => self::browser_artifact_base_url( $playground ),
@@ -1407,12 +1414,29 @@ final class WP_Codebox_Abilities {
 			return $remote;
 		}
 
+		$default_cors_proxy_url = (string) apply_filters( 'wp_codebox_browser_playground_default_cors_proxy_url', 'https://wordpress-playground-cors-proxy.net/?', $playground );
+		$cors_proxy_url         = (string) ( $playground['cors_proxy_url'] ?? $playground['corsProxy'] ?? $default_cors_proxy_url );
+		$cors_proxy             = array( 'url' => '', 'origin' => '', 'host' => '' );
+		if ( '' !== trim( $cors_proxy_url ) ) {
+			$cors_proxy = self::browser_trusted_url(
+				$cors_proxy_url,
+				'cors_proxy_url',
+				'wp_codebox_browser_playground_cors_proxy_allowed_origins',
+				array( 'https://wordpress-playground-cors-proxy.net', 'https://playground.wordpress.net', 'https://playground.automattic.ai' )
+			);
+			if ( is_wp_error( $cors_proxy ) ) {
+				return $cors_proxy;
+			}
+		}
+
 		$playground['client_module_url'] = $client['url'];
 		$playground['remote_url']        = $remote['url'];
+		$playground['cors_proxy_url']    = $cors_proxy['url'];
 		$playground['provenance']        = array(
 			'schema'            => 'wp-codebox/browser-playground-provenance/v1',
 			'client_module_url' => $client,
 			'remote_url'        => $remote,
+			'cors_proxy_url'    => $cors_proxy,
 		);
 
 		return $playground;

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -526,6 +526,7 @@ $assert( 'browser Playground session identifies disposable execution scope', ! i
 $assert( 'browser Playground session identifies sandbox permission model', ! is_wp_error( $browser_session ) && 'sandbox-bypass' === ( $browser_session['permission_model'] ?? '' ) && 'sandbox-bypass' === ( $browser_session['session']['permission_model'] ?? '' ) );
 $assert( 'browser Playground session emits canonical sandbox session envelope', ! is_wp_error( $browser_session ) && 'wp-codebox/sandbox-session/v1' === ( $browser_session['session']['schema'] ?? '' ) && 'browser-session-123' === ( $browser_session['session']['id'] ?? '' ) && 'ready' === ( $browser_session['session']['status'] ?? '' ) && 'external-orchestrator' === ( $browser_session['session']['persistence'] ?? '' ) );
 $assert( 'browser Playground session includes Playground client URLs', ! is_wp_error( $browser_session ) && str_contains( $browser_session['playground']['client_module_url'] ?? '', 'playground.automattic.ai' ) && str_contains( $browser_session['playground']['remote_url'] ?? '', 'playground.automattic.ai' ) );
+$assert( 'browser Playground session includes Playground CORS proxy URL', ! is_wp_error( $browser_session ) && 'https://wordpress-playground-cors-proxy.net/?' === ( $browser_session['playground']['cors_proxy_url'] ?? '' ) && 'https://wordpress-playground-cors-proxy.net' === ( $browser_session['playground']['provenance']['cors_proxy_url']['origin'] ?? '' ) );
 $assert( 'browser Playground session includes default blueprint', ! is_wp_error( $browser_session ) && true === ( $browser_session['playground']['blueprint']['features']['networking'] ?? false ) && is_array( $browser_session['playground']['blueprint']['steps'] ?? null ) );
 $assert( 'browser Playground session defaults to latest WordPress and PHP', ! is_wp_error( $browser_session ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['wp'] ?? '' ) && 'latest' === ( $browser_session['playground']['blueprint']['preferredVersions']['php'] ?? '' ) );
 $assert( 'browser Playground session logs in before admin workflows', ! is_wp_error( $browser_session ) && 'login' === ( $browser_session['playground']['blueprint']['steps'][0]['step'] ?? '' ) && 'admin' === ( $browser_session['playground']['blueprint']['steps'][0]['username'] ?? '' ) );
@@ -725,6 +726,15 @@ $browser_untrusted_playground_origin = call_user_func(
 	)
 );
 $assert( 'browser Playground session rejects untrusted Playground origins', is_wp_error( $browser_untrusted_playground_origin ) && 'wp_codebox_browser_origin_not_allowed' === $browser_untrusted_playground_origin->get_error_code() );
+
+$browser_untrusted_cors_proxy = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'       => 'Prepare a browser preview with an untrusted Playground CORS proxy.',
+		'playground' => array( 'cors_proxy_url' => 'https://evil.example/cors-proxy?' ),
+	)
+);
+$assert( 'browser Playground session rejects untrusted CORS proxy origins', is_wp_error( $browser_untrusted_cors_proxy ) && 'wp_codebox_browser_origin_not_allowed' === $browser_untrusted_cors_proxy->get_error_code() && 'cors_proxy_url' === ( $browser_untrusted_cors_proxy->get_error_data()['field'] ?? '' ) );
 
 $component_paths_filter = $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] ?? null;
 unset( $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] );


### PR DESCRIPTION
## Summary
- Adds a browser Playground `cors_proxy_url` session contract so consumers can pass WP Codebox-provided proxy configuration into `startPlaygroundWeb({ corsProxy })`.
- Defaults to the public Playground CORS proxy and validates proxy origins through a dedicated allow-list filter.
- Covers the emitted proxy metadata and untrusted proxy rejection in the WordPress plugin smoke test.

## Testing
- `npm install`
- `npm run build`
- `npm run wordpress-plugin-smoke`

## Notes
- Stacked on #417 (`fix/issue-416-runtime-component-registry`).
- This does not reintroduce local component-path packaging; registry resources remain the runtime dependency source.
- Studio Web still needs to consume `playground.cors_proxy_url` and pass it as `corsProxy` to Playground before the live eval can prove the browser CORS fix end-to-end.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the Playground CORS proxy contract, drafted the WP Codebox session contract update, and ran targeted verification; Chris directed the architecture and reviewed the local-dependency concern.