### PR TITLE
Validate cached Playground WordPress archives

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "recipe-staged-files-smoke": "tsx scripts/recipe-staged-files-smoke.ts",
     "recipe-workspace-seed-excludes-smoke": "tsx scripts/recipe-workspace-seed-excludes-smoke.ts",
     "recipe-runtime-evidence-smoke": "tsx scripts/recipe-runtime-evidence-smoke.ts",
+    "playground-archive-cache-validation-smoke": "tsx scripts/playground-archive-cache-validation-smoke.ts",
     "recipe-playground-boot-failure-smoke": "tsx scripts/recipe-playground-boot-failure-smoke.ts",
     "runtime-stack-mount-smoke": "tsx scripts/runtime-stack-mount-smoke.ts",
     "runtime-overlay-php-ai-client-smoke": "tsx scripts/runtime-overlay-php-ai-client-smoke.ts",

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -3,7 +3,12 @@ import { PlaygroundCliExitError } from "./playground-command-errors.js"
 import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
 import type { MountSpec, RuntimeCreateSpec } from "@chubes4/wp-codebox-core"
 import { randomInt } from "node:crypto"
+import { existsSync } from "node:fs"
+import { readFile, stat, unlink } from "node:fs/promises"
+import { homedir } from "node:os"
+import { join } from "node:path"
 import { createServer as createNetServer } from "node:net"
+import { resolveWordPressRelease } from "@wp-playground/wordpress"
 
 interface PlaygroundCliModule {
   runCLI(options: {
@@ -23,6 +28,8 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
   if (spec.preview?.port) {
     await assertPreviewPortAvailable(spec.preview.port)
   }
+
+  await validatePlaygroundWordPressArchiveCache(spec.environment.version)
 
   const port = spec.preview?.port ? 0 : await availablePlaygroundPortRange()
 
@@ -53,6 +60,71 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
 
     throw error
   }
+}
+
+export interface PlaygroundWordPressArchiveCacheValidation {
+  version: string
+  sourceUrl: string
+  invalidArchives: Array<{
+    path: string
+    size: number
+    reason: string
+    deleted: boolean
+  }>
+}
+
+export async function validatePlaygroundWordPressArchiveCache(versionQuery: string | undefined, cacheDirectory = join(homedir(), ".wordpress-playground")): Promise<PlaygroundWordPressArchiveCacheValidation> {
+  const release = await resolveWordPressRelease(versionQuery)
+  const version = String(release.version)
+  const sourceUrl = String(release.releaseUrl)
+  const archivePaths = [
+    join(cacheDirectory, `${version}.zip`),
+    join(cacheDirectory, `prebuilt-wp-content-for-wp-${version}.zip`),
+  ]
+  const invalidArchives: PlaygroundWordPressArchiveCacheValidation["invalidArchives"] = []
+
+  for (const archivePath of archivePaths) {
+    if (!existsSync(archivePath)) {
+      continue
+    }
+
+    const archiveStat = await stat(archivePath)
+    const reason = await invalidZipReason(archivePath, archiveStat.size)
+    if (!reason) {
+      continue
+    }
+
+    try {
+      await unlink(archivePath)
+      invalidArchives.push({ path: archivePath, size: archiveStat.size, reason, deleted: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Corrupt cached WordPress archive could not be removed: ${archivePath} (size: ${archiveStat.size} bytes, requested WordPress version: ${versionQuery ?? "latest"}, resolved WordPress version: ${version}, source URL: ${sourceUrl}, validation: ${reason}, unlink error: ${message})`)
+    }
+  }
+
+  return { version, sourceUrl, invalidArchives }
+}
+
+async function invalidZipReason(archivePath: string, size: number): Promise<string | undefined> {
+  if (size < 22) {
+    return "too small to be a zip archive"
+  }
+
+  const header = await readFile(archivePath, { encoding: null, flag: "r" }).then((buffer) => buffer.subarray(0, 4))
+  if (header.length < 4) {
+    return "missing zip header"
+  }
+
+  if (header[0] !== 0x50 || header[1] !== 0x4b) {
+    return `unexpected zip header ${header.toString("hex")}`
+  }
+
+  if (![0x03, 0x05, 0x07].includes(header[2])) {
+    return `unexpected zip header ${header.toString("hex")}`
+  }
+
+  return undefined
 }
 
 async function availablePlaygroundPortRange(): Promise<number> {

--- a/scripts/playground-archive-cache-validation-smoke.ts
+++ b/scripts/playground-archive-cache-validation-smoke.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import { existsSync } from "node:fs"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { validatePlaygroundWordPressArchiveCache } from "../packages/runtime-playground/src/playground-cli-runner.js"
+
+const cacheDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-playground-cache-"))
+
+try {
+  await writeFile(join(cacheDirectory, "7.1.zip"), "not a valid zip yet")
+  await writeFile(join(cacheDirectory, "prebuilt-wp-content-for-wp-7.1.zip"), "nope")
+
+  const result = await validatePlaygroundWordPressArchiveCache("7.1", cacheDirectory)
+
+  assert.equal(result.version, "7.1")
+  assert.match(result.sourceUrl, /wordpress/i)
+  assert.equal(result.invalidArchives.length, 2)
+  assert.equal(result.invalidArchives.every((archive) => archive.deleted), true)
+  assert.equal(existsSync(join(cacheDirectory, "7.1.zip")), false)
+  assert.equal(existsSync(join(cacheDirectory, "prebuilt-wp-content-for-wp-7.1.zip")), false)
+  assert.match(result.invalidArchives[0]?.reason ?? "", /too small|unexpected zip header/)
+
+  console.log("Playground archive cache validation smoke passed")
+} finally {
+  await rm(cacheDirectory, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Validate cached Playground WordPress release archives before booting the runtime.
- Delete corrupt downloaded/prebuilt WordPress archive caches so Playground can refetch or regenerate them instead of failing with a low-level unzip error.
- Add a focused smoke script covering corrupt cached archive cleanup.

Closes https://github.com/chubes4/wp-codebox/issues/418

## Tests
- `npm run build`
- `npm run playground-archive-cache-validation-smoke`
- `npm run recipe-playground-boot-failure-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the archive cache validation fix and smoke coverage; Chris remains responsible for review and merge.