### PR TITLE
Fix browser runtime component delivery

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -1661,6 +1661,18 @@ final class WP_Codebox_Abilities {
 			}
 
 			$component['slug'] = $slug;
+			if ( 'url' === (string) ( $component['resource'] ?? 'url' ) && 'browser' !== (string) ( $component['package'] ?? '' ) ) {
+				$package = self::browser_package_remote_plugin( $slug, (string) ( $component['url'] ?? '' ), count( $plugins ), (string) ( $component['sha256'] ?? '' ) );
+				if ( is_wp_error( $package ) ) {
+					return $package;
+				}
+
+				$component['url']                     = $package['url'];
+				$component['local_package']           = true;
+				$component['local_package_fetch_url'] = $package['fetch_url'];
+				$component['sha256']                  = $package['sha256'];
+			}
+
 			$normalized = self::normalize_browser_plugins( array( $component ), 'runtime.components' );
 			if ( is_wp_error( $normalized ) ) {
 				return $normalized;
@@ -1697,10 +1709,8 @@ final class WP_Codebox_Abilities {
 	private static function browser_runtime_component_registry(): array {
 		$registry = array(
 			'agents-api'        => array(
-				'resource'         => 'git:directory',
-				'url'              => 'https://github.com/Automattic/agents-api',
-				'ref'              => 'main',
-				'refType'          => 'branch',
+				'resource'         => 'url',
+				'url'              => 'https://github.com/Automattic/agents-api/releases/latest/download/agents-api.zip',
 				'targetFolderName' => 'agents-api',
 				'activate'         => true,
 				'provenance'       => array( 'source' => 'runtime-component-registry' ),
@@ -1821,14 +1831,15 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_browser_plugin_package_hash_failed', 'Could not hash browser runtime plugin package.', array( 'status' => 500, 'slug' => $slug ) );
 		}
 
-		$delivery_url = self::browser_plugin_delivery_url( $zip_path, self::browser_safe_local_package_url( $url ), $slug );
+		$safe_url     = self::browser_safe_local_package_url( $url );
+		$delivery_url = self::browser_plugin_delivery_url( $zip_path, $safe_url, $slug );
 		if ( is_wp_error( $delivery_url ) ) {
 			return $delivery_url;
 		}
 
 		return array(
 			'url'       => $delivery_url,
-			'fetch_url' => $url,
+			'fetch_url' => $safe_url,
 			'path'      => $zip_path,
 			'sha256'    => $sha256,
 		);
@@ -1881,14 +1892,15 @@ final class WP_Codebox_Abilities {
 			return new WP_Error( 'wp_codebox_browser_plugin_package_url_missing', 'Browser runtime plugin package URL is missing.', array( 'status' => 500, 'slug' => $slug ) );
 		}
 
-		$delivery_url = self::browser_plugin_delivery_url( $zip_path, self::browser_safe_local_package_url( $url ), $slug );
+		$safe_url     = self::browser_safe_local_package_url( $url );
+		$delivery_url = self::browser_plugin_delivery_url( $zip_path, $safe_url, $slug );
 		if ( is_wp_error( $delivery_url ) ) {
 			return $delivery_url;
 		}
 
 		return array(
 			'url'       => $delivery_url,
-			'fetch_url' => $url,
+			'fetch_url' => $safe_url,
 			'path'      => $zip_path,
 			'sha256'    => $sha256,
 		);
@@ -1897,7 +1909,7 @@ final class WP_Codebox_Abilities {
 	private static function browser_plugin_delivery_url( string $zip_path, string $public_url, string $slug ): string|WP_Error {
 		$max_bytes = (int) apply_filters( 'wp_codebox_browser_plugin_data_url_max_bytes', 16 * 1024 * 1024, $zip_path, $slug );
 		$size      = filesize( $zip_path );
-		if ( is_int( $size ) && $size > $max_bytes ) {
+		if ( is_int( $size ) && $size > $max_bytes && ! self::browser_plugin_uses_loopback_url( $public_url ) ) {
 			return $public_url;
 		}
 
@@ -1911,12 +1923,13 @@ final class WP_Codebox_Abilities {
 
 	private static function browser_safe_local_package_url( string $url ): string {
 		$parts = wp_parse_url( $url );
-		if ( ! is_array( $parts ) || 'http' !== strtolower( (string) ( $parts['scheme'] ?? '' ) ) || ! self::is_loopback_host( (string) ( $parts['host'] ?? '' ) ) ) {
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
+		if ( ! is_array( $parts ) || ! in_array( $scheme, array( 'http', 'https' ), true ) || ! self::is_loopback_host( (string) ( $parts['host'] ?? '' ) ) ) {
 			return $url;
 		}
 
 		$host = strtolower( trim( (string) $parts['host'], '[]' ) );
-		if ( 'localhost' === $host ) {
+		if ( 'localhost' === $host && 'http' === $scheme ) {
 			return $url;
 		}
 
@@ -1930,7 +1943,8 @@ final class WP_Codebox_Abilities {
 
 	private static function browser_plugin_uses_loopback_url( string $url ): bool {
 		$parts = wp_parse_url( $url );
-		return is_array( $parts ) && 'http' === strtolower( (string) ( $parts['scheme'] ?? '' ) ) && self::is_loopback_host( (string) ( $parts['host'] ?? '' ) );
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
+		return is_array( $parts ) && in_array( $scheme, array( 'http', 'https' ), true ) && self::is_loopback_host( (string) ( $parts['host'] ?? '' ) );
 	}
 
 	private static function browser_download_remote_plugin( string $url, string $zip_path, string $slug ): true|WP_Error {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -387,6 +387,18 @@ $GLOBALS['wp_codebox_remote_responses']['https://github.com/example/generic-mu-r
 	'response' => array( 'code' => 200 ),
 	'body'     => "PK\x03\x04generic-mu-runtime",
 );
+$GLOBALS['wp_codebox_remote_responses']['https://github.com/Automattic/agents-api/releases/latest/download/agents-api.zip'] = array(
+	'response' => array( 'code' => 200 ),
+	'body'     => "PK\x03\x04agents-api",
+);
+$GLOBALS['wp_codebox_remote_responses']['https://github.com/Extra-Chill/data-machine/releases/latest/download/data-machine.zip'] = array(
+	'response' => array( 'code' => 200 ),
+	'body'     => "PK\x03\x04data-machine",
+);
+$GLOBALS['wp_codebox_remote_responses']['https://github.com/Extra-Chill/data-machine-code/releases/latest/download/data-machine-code.zip'] = array(
+	'response' => array( 'code' => 200 ),
+	'body'     => "PK\x03\x04data-machine-code",
+);
 mkdir( $root . '/plugin-root/data-machine', 0777, true );
 mkdir( $root . '/plugin-root/data-machine-code', 0777, true );
 mkdir( $root . '/plugin-root/generic-caller-plugin', 0777, true );
@@ -623,7 +635,7 @@ $browser_local_url_package_session = call_user_func(
 );
 $GLOBALS['wp_codebox_upload_dir'] = $previous_upload_dir;
 unset( $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] );
-$assert( 'browser Playground session installs loopback package URLs through PHP instead of URL resources', ! is_wp_error( $browser_local_url_package_session ) && str_starts_with( (string) ( $browser_local_url_package_session['plugins'][0]['url'] ?? '' ), 'http://localhost:63498/uploads/wp-codebox/browser-runtime-plugins/generic-caller-plugin-' ) && 'http://127.0.0.1:63498/uploads/wp-codebox/browser-runtime-plugins/' === substr( (string) ( $browser_local_url_package_session['plugins'][0]['local_package_fetch_url'] ?? '' ), 0, 66 ) && ! str_starts_with( (string) ( $browser_local_url_package_session['plugins'][0]['url'] ?? '' ), 'data:application/zip;base64,' ) && 'runPHP' === ( $browser_local_url_package_session['playground']['blueprint']['steps'][1]['step'] ?? '' ) && str_contains( (string) ( $browser_local_url_package_session['playground']['blueprint']['steps'][1]['code'] ?? '' ), 'http://127.0.0.1:63498/uploads/wp-codebox/browser-runtime-plugins/generic-caller-plugin-' ) && ! str_contains( (string) ( $browser_local_url_package_session['playground']['blueprint']['steps'][1]['code'] ?? '' ), 'http://localhost:63498/uploads/wp-codebox/browser-runtime-plugins/generic-caller-plugin-' ) && ! isset( $browser_local_url_package_session['playground']['blueprint']['steps'][1]['pluginData'] ) );
+$assert( 'browser Playground session inlines loopback package URLs instead of emitting broken URL resources', ! is_wp_error( $browser_local_url_package_session ) && str_starts_with( (string) ( $browser_local_url_package_session['plugins'][0]['url'] ?? '' ), 'data:application/zip;base64,' ) && 'http://localhost:63498/uploads/wp-codebox/browser-runtime-plugins/' === substr( (string) ( $browser_local_url_package_session['plugins'][0]['local_package_fetch_url'] ?? '' ), 0, 66 ) && 'installPlugin' === ( $browser_local_url_package_session['playground']['blueprint']['steps'][1]['step'] ?? '' ) && str_starts_with( (string) ( $browser_local_url_package_session['playground']['blueprint']['steps'][1]['pluginData']['url'] ?? '' ), 'data:application/zip;base64,' ) && ! str_contains( (string) json_encode( $browser_local_url_package_session['playground']['blueprint']['steps'][1] ), 'http://127.0.0.1:63498/uploads/wp-codebox/browser-runtime-plugins/generic-caller-plugin-' ) );
 
 $browser_site_blueprint_session = call_user_func(
 	$browser_session_ability['execute_callback'],
@@ -751,8 +763,9 @@ if ( null !== $component_paths_filter ) {
 	$GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] = $component_paths_filter;
 }
 $canonical_component_urls = ! is_wp_error( $browser_canonical_component_session ) ? array_values( array_map( static fn( array $plugin ): string => (string) ( $plugin['url'] ?? '' ), $browser_canonical_component_session['plugins'] ?? array() ) ) : array();
-$assert( 'browser Playground session uses canonical registry components without path packaging by default', ! is_wp_error( $browser_canonical_component_session ) && true === ( $browser_canonical_component_session['success'] ?? false ) && in_array( 'https://github.com/Automattic/agents-api', $canonical_component_urls, true ) && in_array( 'https://github.com/Extra-Chill/data-machine/releases/latest/download/data-machine.zip', $canonical_component_urls, true ) && in_array( 'https://github.com/Extra-Chill/data-machine-code/releases/latest/download/data-machine-code.zip', $canonical_component_urls, true ) && 3 === count( array_filter( $browser_canonical_component_session['plugins'] ?? array(), static fn( array $plugin ): bool => 'runtime-component-registry' === ( $plugin['provenance']['source'] ?? '' ) && empty( $plugin['local_package'] ) ) ) );
-$assert( 'browser Playground canonical registry components do not emit localhost package URLs', ! is_wp_error( $browser_canonical_component_session ) && ! str_contains( implode( "\n", $canonical_component_urls ), 'localhost' ) && ! str_contains( implode( "\n", $canonical_component_urls ), '127.0.0.1' ) && ! str_contains( implode( "\n", $canonical_component_urls ), 'data:application/zip;base64,' ) );
+$canonical_component_remote_get_urls = array_values( array_map( static fn( array $request ): string => (string) ( $request['url'] ?? '' ), $GLOBALS['wp_codebox_remote_gets'] ?? array() ) );
+$assert( 'browser Playground session uses canonical registry components without path packaging by default', ! is_wp_error( $browser_canonical_component_session ) && true === ( $browser_canonical_component_session['success'] ?? false ) && in_array( 'https://github.com/Automattic/agents-api/releases/latest/download/agents-api.zip', $canonical_component_remote_get_urls, true ) && in_array( 'https://github.com/Extra-Chill/data-machine/releases/latest/download/data-machine.zip', $canonical_component_remote_get_urls, true ) && in_array( 'https://github.com/Extra-Chill/data-machine-code/releases/latest/download/data-machine-code.zip', $canonical_component_remote_get_urls, true ) && 3 === count( array_filter( $browser_canonical_component_session['plugins'] ?? array(), static fn( array $plugin ): bool => 'runtime-component-registry' === ( $plugin['provenance']['source'] ?? '' ) && ! empty( $plugin['local_package'] ) ) ) );
+$assert( 'browser Playground canonical registry components avoid direct GitHub and localhost browser fetches', ! is_wp_error( $browser_canonical_component_session ) && ! str_contains( implode( "\n", $canonical_component_urls ), 'github.com/' ) && ! str_contains( implode( "\n", $canonical_component_urls ), 'localhost' ) && ! str_contains( implode( "\n", $canonical_component_urls ), '127.0.0.1' ) );
 
 $browser_session_missing_prereqs = call_user_func(
 	$browser_session_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Server-package canonical browser runtime registry components so browser Playgrounds do not fetch GitHub release assets directly.
- Switch Agents API to its release ZIP registry source, preserving the generic runtime component contract.
- Keep loopback package delivery inline and normalize loopback fetch URLs so the visible Playground avoids broken localhost URL resources.

## Verification
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run blueprint-validation-smoke`
- Downstream Studio Web live website generation eval passed locally, run id `live-2026-06-01T21-05-25-537Z`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed browser-runtime dependency delivery failures, drafted the packaging fix and smoke coverage, and ran verification; Chris remains responsible for review and merge.