### PR TITLE
Add sandbox completion outcome artifacts

### DIFF
--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -95,7 +95,39 @@ The ability response includes a `wp-codebox/sandbox-session/v1` envelope:
     "artifacts": {
       "path": "/srv/artifacts/run-123",
       "bundle_id": "artifact-bundle-sha256-...",
-      "preview_url": "https://preview.example.test/abc"
+      "preview_url": "https://preview.example.test/abc",
+      "completion_outcome": "files/completion-outcome.json"
+    }
+  },
+  "completion_outcome": {
+    "schema": "wp-codebox/sandbox-completion-outcome/v1",
+    "status": "succeeded",
+    "summary": "Agent sandbox produced 2 changed files and a 1842-byte patch.",
+    "changedFiles": {
+      "count": 2,
+      "paths": ["plugin.php", "tests/plugin-test.php"],
+      "artifact": "files/changed-files.json"
+    },
+    "patch": {
+      "bytes": 1842,
+      "artifact": "files/patch.diff"
+    },
+    "verification": {
+      "transcript": {
+        "artifact": "files/transcript.json",
+        "executionCount": 1
+      },
+      "commands": [
+        { "command": "wp-codebox.agent-sandbox-run", "exitCode": 0 }
+      ]
+    },
+    "blockers": [],
+    "riskNotes": [],
+    "confidence": "high",
+    "nextAction": "promote",
+    "provenance": {
+      "artifactBundleId": "artifact-bundle-sha256-...",
+      "artifactDirectory": "/srv/artifacts/run-123"
     }
   },
   "agent_result": {
@@ -127,6 +159,12 @@ queued/running/cancelled/expired transitions belong to the external orchestrator
 
 Agent sandbox recipe runs also write these additive artifact files:
 
+- `files/completion-outcome.json` uses
+  `wp-codebox/sandbox-completion-outcome/v1` and is the generic terminal
+  contract for orchestration. It includes status (`succeeded`, `blocked`,
+  `failed`, or `partial`), changed files, patch refs, verification command
+  results, blockers, confidence/risk notes, next action, and artifact
+  provenance.
 - `files/agent-result.json` uses `wp-codebox/agent-result/v1` and summarizes
   actionability, changed-file count, patch bytes, transcript location, failures,
   no-op reason, and workspace-tool diagnostics.

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -6,7 +6,7 @@ import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded, type RecipeDryRunOutput, type RecipeDryRunSiteSeed, type RecipeDryRunStagedFile } from "../recipe-dry-run.js"
-import { collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeArtifactEvidenceFailure } from "../recipe-evidence.js"
+import { collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput } from "../recipe-evidence.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { parseWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { DEFAULT_WORDPRESS_VERSION, previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
@@ -475,6 +475,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
         ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
         ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
+        ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
         artifacts,
         error: strictFailure ?? agentFailure,
       }
@@ -491,6 +492,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
       ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
       ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
+      ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
       artifacts,
     }
   } catch (error) {

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -28,6 +28,9 @@ export interface RecipeArtifactEvidenceResult {
   agentResult?: AgentSandboxResultSummary & {
     artifact: RecipeArtifactEvidenceFile
   }
+  completionOutcome?: SandboxCompletionOutcome & {
+    artifact: RecipeArtifactEvidenceFile
+  }
   transcript?: AgentSandboxTranscript & {
     artifact: RecipeArtifactEvidenceFile
   }
@@ -62,6 +65,34 @@ export interface AgentSandboxResultSummary {
   noOpReason?: string
   workspaceTools?: {
     diagnostics: string[]
+  }
+}
+
+export interface SandboxCompletionOutcome {
+  schema: "wp-codebox/sandbox-completion-outcome/v1"
+  status: "succeeded" | "blocked" | "failed" | "partial"
+  summary: string
+  changedFiles: AgentSandboxResultSummary["changedFiles"]
+  patch: AgentSandboxResultSummary["patch"]
+  artifacts: AgentSandboxResultSummary["artifacts"]
+  verification: {
+    transcript: AgentSandboxResultSummary["transcript"]
+    commands: Array<{ command: string; exitCode: number }>
+    artifactBundle?: {
+      artifact: string
+      status: "passed" | "failed" | "unknown"
+      strict: boolean
+    }
+  }
+  blockers: Array<{ kind: string; message: string; retryable: boolean }>
+  riskNotes: string[]
+  confidence: "high" | "medium" | "low"
+  nextAction: "promote" | "retry" | "review" | "fix-blocker"
+  provenance: {
+    artifactBundleId: string
+    artifactDirectory: string
+    runtime?: RuntimeInfo
+    task?: Record<string, unknown>
   }
 }
 
@@ -311,7 +342,7 @@ export async function finalizeRecipeArtifactEvidence(
   return result
 }
 
-export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, executions: RecipeEvidenceExecutionResult[]): Promise<Pick<RecipeArtifactEvidenceResult, "agentResult" | "transcript">> {
+export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, executions: RecipeEvidenceExecutionResult[]): Promise<Pick<RecipeArtifactEvidenceResult, "agentResult" | "completionOutcome" | "transcript">> {
   const transcript = buildAgentSandboxTranscript(executions)
   if (transcript.executions.length === 0) {
     return {}
@@ -319,13 +350,17 @@ export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, ex
 
   const transcriptPath = join(dirname(artifacts.reviewPath), "transcript.json")
   const agentResultPath = join(dirname(artifacts.reviewPath), "agent-result.json")
+  const completionOutcomePath = join(dirname(artifacts.reviewPath), "completion-outcome.json")
   const transcriptFile = await writeRecipeEvidenceJson(artifacts.directory, transcriptPath, transcript, "agent-transcript")
   const agentResult = await buildAgentSandboxResultSummary(artifacts, transcript, transcriptFile.path)
   const agentResultFile = await writeRecipeEvidenceJson(artifacts.directory, agentResultPath, agentResult, "agent-result")
-  await updateRecipeArtifactEvidenceReferences(artifacts, [agentResultFile, transcriptFile])
+  const completionOutcome = buildSandboxCompletionOutcome(artifacts, agentResult, transcript)
+  const completionOutcomeFile = await writeRecipeEvidenceJson(artifacts.directory, completionOutcomePath, completionOutcome, "completion-outcome")
+  await updateRecipeArtifactEvidenceReferences(artifacts, [agentResultFile, completionOutcomeFile, transcriptFile])
 
   return {
     agentResult: { ...agentResult, artifact: agentResultFile },
+    completionOutcome: { ...completionOutcome, artifact: completionOutcomeFile },
     transcript: { ...transcript, artifact: transcriptFile },
   }
 }
@@ -393,6 +428,43 @@ async function buildAgentSandboxResultSummary(artifacts: ArtifactBundle, transcr
     failures,
     noOpReason,
     workspaceTools: workspaceToolDiagnostics(transcript),
+  })
+}
+
+function buildSandboxCompletionOutcome(artifacts: ArtifactBundle, agentResult: AgentSandboxResultSummary, transcript: AgentSandboxTranscript): SandboxCompletionOutcome {
+  const blockedDiagnostics = new Set(agentResult.workspaceTools?.diagnostics ?? [])
+  const blockers = agentResult.failures.map((failure) => ({
+    kind: blockedDiagnostics.size > 0 ? "runtime-blocker" : "runtime-failure",
+    message: failure.message,
+    retryable: true,
+  }))
+  const status: SandboxCompletionOutcome["status"] = agentResult.status === "failed"
+    ? blockedDiagnostics.size > 0 ? "blocked" : "failed"
+    : agentResult.status === "completed"
+      ? agentResult.actionable ? "succeeded" : "partial"
+      : "partial"
+  const confidence: SandboxCompletionOutcome["confidence"] = status === "succeeded" ? "high" : blockers.length > 0 ? "low" : "medium"
+  const nextAction: SandboxCompletionOutcome["nextAction"] = status === "succeeded" ? "promote" : status === "blocked" ? "fix-blocker" : status === "failed" ? "retry" : "review"
+
+  return stripUndefined({
+    schema: "wp-codebox/sandbox-completion-outcome/v1" as const,
+    status,
+    summary: agentResult.summary,
+    changedFiles: agentResult.changedFiles,
+    patch: agentResult.patch,
+    artifacts: agentResult.artifacts,
+    verification: {
+      transcript: agentResult.transcript,
+      commands: transcript.executions.map((execution) => ({ command: execution.command, exitCode: execution.exitCode })),
+    },
+    blockers,
+    riskNotes: agentResult.noOpReason ? [agentResult.noOpReason] : [],
+    confidence,
+    nextAction,
+    provenance: {
+      artifactBundleId: artifacts.id,
+      artifactDirectory: artifacts.directory,
+    },
   })
 }
 
@@ -512,6 +584,15 @@ export function recipeAgentResultOutput(agentResult: RecipeArtifactEvidenceResul
   }
 
   const { artifact: _artifact, ...result } = agentResult
+  return result
+}
+
+export function recipeCompletionOutcomeOutput(completionOutcome: RecipeArtifactEvidenceResult["completionOutcome"]): SandboxCompletionOutcome | undefined {
+  if (!completionOutcome) {
+    return undefined
+  }
+
+  const { artifact: _artifact, ...result } = completionOutcome
   return result
 }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -69,6 +69,7 @@ final class WP_Codebox_Abilities {
 			$session_input     = self::sandbox_session_input_schema();
 			$preview_schema    = self::preview_input_schema();
 			$outcome_schema    = self::remediation_outcome_schema();
+			$completion_outcome_schema = self::completion_outcome_schema();
 			$artifact_id_schema = array(
 				'artifact_id'    => array(
 					'type'        => 'string',
@@ -180,6 +181,7 @@ final class WP_Codebox_Abilities {
 							'artifacts' => array( 'type' => 'string' ),
 							'exit_code' => array( 'type' => 'integer' ),
 							'outcome'   => $outcome_schema,
+							'completion_outcome' => $completion_outcome_schema,
 							'run'       => array( 'type' => 'object' ),
 						),
 					),
@@ -271,6 +273,7 @@ final class WP_Codebox_Abilities {
 										'preview_url' => array( 'type' => 'string' ),
 										'artifacts'   => array( 'type' => 'object' ),
 										'outcome'     => $outcome_schema,
+										'completion_outcome' => $completion_outcome_schema,
 										'run'         => array( 'type' => 'object' ),
 										'error'       => array( 'type' => 'object' ),
 									),
@@ -734,6 +737,31 @@ final class WP_Codebox_Abilities {
 				'artifact'              => array( 'type' => 'object' ),
 				'metadata'              => array( 'type' => 'object' ),
 				'diagnostics'           => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function completion_outcome_schema(): array {
+		return array(
+			'type'        => 'object',
+			'description' => 'Generic sandbox completion outcome emitted as files/completion-outcome.json and returned for orchestration without parsing prose.',
+			'properties'  => array(
+				'schema'       => array( 'type' => 'string' ),
+				'status'       => array(
+					'type' => 'string',
+					'enum' => array( 'succeeded', 'blocked', 'failed', 'partial' ),
+				),
+				'summary'      => array( 'type' => 'string' ),
+				'changedFiles' => array( 'type' => 'object' ),
+				'patch'        => array( 'type' => 'object' ),
+				'artifacts'    => array( 'type' => 'object' ),
+				'verification' => array( 'type' => 'object' ),
+				'blockers'     => array( 'type' => 'array' ),
+				'riskNotes'    => array( 'type' => 'array' ),
+				'confidence'   => array( 'type' => 'string' ),
+				'nextAction'   => array( 'type' => 'string' ),
+				'provenance'   => array( 'type' => 'object' ),
 			),
 		);
 	}

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -15,6 +15,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const TASK_INPUT_SCHEMA = WP_Codebox_Agent_Task::INPUT_SCHEMA;
 	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
 	private const REMEDIATION_OUTCOME_SCHEMA = 'wp-codebox/agent-sandbox-remediation-outcome/v1';
+	private const COMPLETION_OUTCOME_SCHEMA = 'wp-codebox/sandbox-completion-outcome/v1';
 	private const SANDBOX_TOOL_POLICY_FILE = __DIR__ . '/generated-sandbox-datamachine-tool-policy.php';
 
 	/** @var array<string, callable> */
@@ -140,6 +141,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'artifacts'    => $artifacts,
 			'exit_code'    => $exit_code,
 			'agent_result' => is_array( $decoded['agentResult'] ?? null ) ? $decoded['agentResult'] : array(),
+			'completion_outcome' => $this->completion_outcome( $decoded ),
 			'run'          => $decoded,
 		);
 
@@ -222,6 +224,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'preview_url' => (string) ( $task_result['session']['artifacts']['preview_url'] ?? '' ),
 				'artifacts'    => $task_result['session']['artifacts'] ?? array(),
 				'agent_result' => $task_result['agent_result'] ?? array(),
+				'completion_outcome' => $task_result['completion_outcome'] ?? array(),
 				'run'          => $task_result['run'] ?? array(),
 			);
 		}
@@ -996,6 +999,16 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		if ( $false_positive ) {
 			$outcome['kind'] = 'noop_artifact';
 			$outcome['false_positive'] = true;
+		}
+
+		return $outcome;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
+	private function completion_outcome( array $run ): array {
+		$outcome = is_array( $run['completionOutcome'] ?? null ) ? $run['completionOutcome'] : array();
+		if ( self::COMPLETION_OUTCOME_SCHEMA !== ( $outcome['schema'] ?? '' ) ) {
+			return array();
 		}
 
 		return $outcome;
@@ -1869,6 +1882,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 					'path'        => $artifacts,
 					'bundle_id'   => is_array( $run['artifacts'] ?? null ) ? (string) ( $run['artifacts']['id'] ?? '' ) : '',
 					'preview_url' => is_array( $run['artifacts']['preview'] ?? null ) ? (string) ( $run['artifacts']['preview']['url'] ?? '' ) : '',
+					'completion_outcome' => is_array( $run['completionOutcome'] ?? null ) ? 'files/completion-outcome.json' : '',
 				),
 				static fn( mixed $value ): bool => '' !== $value
 			)

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -327,6 +327,7 @@ $assert( 'session schema pins external orchestrator persistence', array( 'extern
 $assert( 'session schema keeps durable lifecycle external', array( 'ready', 'completed' ) === ( $ability['output_schema']['properties']['session']['properties']['status']['enum'] ?? array() ) && str_contains( $ability['output_schema']['properties']['session']['properties']['status']['description'] ?? '', 'external orchestrator' ) );
 $assert( 'ability exposes preview configuration schema', 'integer' === ( $ability['input_schema']['properties']['preview_port']['type'] ?? '' ) && 'string' === ( $ability['input_schema']['properties']['preview_bind']['type'] ?? '' ) && 'string' === ( $ability['input_schema']['properties']['preview_public_url']['type'] ?? '' ) );
 $assert( 'ability exposes strict remediation outcome schema', isset( $ability['output_schema']['properties']['outcome']['properties']['kind']['enum'] ) && in_array( 'provider_error', $ability['output_schema']['properties']['outcome']['properties']['kind']['enum'], true ) );
+$assert( 'ability exposes generic completion outcome schema', isset( $ability['output_schema']['properties']['completion_outcome']['properties']['status']['enum'] ) && in_array( 'blocked', $ability['output_schema']['properties']['completion_outcome']['properties']['status']['enum'], true ) );
 $assert( 'ability omits raw code input', ! isset( $ability['input_schema']['properties']['code'] ) && ! isset( $ability['input_schema']['properties']['code_file'] ) );
 $assert( 'permission defaults to manage_options', true === call_user_func( $ability['permission_callback'] ) );
 
@@ -942,6 +943,31 @@ $runner           = new WP_Codebox_Agent_Sandbox_Runner(
 								'executionCount' => 1,
 							),
 						),
+						'completionOutcome' => array(
+							'schema'       => 'wp-codebox/sandbox-completion-outcome/v1',
+							'status'       => 'partial',
+							'summary'      => 'Agent sandbox completed without actionable file changes.',
+							'changedFiles' => array(
+								'count'    => 0,
+								'paths'    => array(),
+								'artifact' => 'files/changed-files.json',
+							),
+							'patch'        => array(
+								'bytes'    => 0,
+								'artifact' => 'files/patch.diff',
+							),
+							'verification' => array(
+								'transcript' => array( 'artifact' => 'files/transcript.json', 'executionCount' => 1 ),
+								'commands'   => array(
+									array( 'command' => 'wp-codebox.agent-sandbox-run', 'exitCode' => 0 ),
+								),
+							),
+							'blockers'     => array(),
+							'provenance'   => array(
+								'artifactBundleId'  => $artifact_id,
+								'artifactDirectory' => 'artifact-directory-fixture',
+							),
+						),
 					)
 				),
 			);
@@ -991,6 +1017,7 @@ $assert( 'runner keeps agent session separate from sandbox session', ! is_wp_err
 $assert( 'runner returns orchestrator correlation and artifact refs', ! is_wp_error( $result ) && 'job-123' === ( $result['session']['orchestrator']['job_id'] ?? '' ) && 'artifact-bundle-sha256-fixture' === ( $result['session']['artifacts']['bundle_id'] ?? '' ) );
 $assert( 'runner returns public preview URL in session artifact metadata', ! is_wp_error( $result ) && 'https://preview.example.test/session-123/' === ( $result['session']['artifacts']['preview_url'] ?? '' ) && 'https://preview.example.test/session-123/' === ( $result['run']['artifacts']['preview']['url'] ?? '' ) );
 $assert( 'runner surfaces normalized agent result summary', ! is_wp_error( $result ) && 'wp-codebox/agent-result/v1' === ( $result['agent_result']['schema'] ?? '' ) && false === ( $result['agent_result']['actionable'] ?? true ) && 'no_file_changes' === ( $result['agent_result']['noOpReason'] ?? '' ) && 'files/transcript.json' === ( $result['agent_result']['transcript']['artifact'] ?? '' ) );
+$assert( 'runner surfaces generic completion outcome', ! is_wp_error( $result ) && 'wp-codebox/sandbox-completion-outcome/v1' === ( $result['completion_outcome']['schema'] ?? '' ) && 'partial' === ( $result['completion_outcome']['status'] ?? '' ) && 'files/completion-outcome.json' === ( $result['session']['artifacts']['completion_outcome'] ?? '' ) );
 $assert( 'runner returns normalized task input for legacy task', ! is_wp_error( $result ) && 'wp-codebox/task-input/v1' === ( $result['task_input']['schema'] ?? '' ) && 'Run a chat-requested sandbox task.' === ( $result['task_input']['goal'] ?? '' ) );
 $legacy_task_fixture = $task_input_fixture_by_name['legacy task maps to canonical goal with empty optionals']['normalized'] ?? array();
 $assert( 'runner legacy task matches shared normalization fixture', ! is_wp_error( $result ) && $legacy_task_fixture === ( $result['task_input'] ?? array() ) );


### PR DESCRIPTION
## Summary
- Add a generic `wp-codebox/sandbox-completion-outcome/v1` artifact at `files/completion-outcome.json` for sandbox agent recipe runs.
- Surface the completion outcome through `recipe-run --json`, `wp-codebox/run-agent-task`, batch run outputs, and session artifact refs.
- Document the generic completion contract and cover the WordPress ability/runner schema in smoke tests.

Fixes #430.

## Tests
- `git diff --check`
- `npm run build`
- `npm run recipe-runtime-evidence-smoke`
- `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic completion outcome contract, tests, docs, and PR preparation for Chris to review.