### PR TITLE
Add browser session recipe runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,8 @@ Browser Playground callers can provide sandbox-owned MU plugin source through `r
 
 `browser_runner.invocation.type` supports `ability` for a `namespace/name` WordPress Ability and `task` for a caller-owned WordPress hook. WP Codebox validates the invocation shape, runs it inside the disposable Playground only, and returns normal artifact metadata without encoding product-specific repair semantics.
 
+The packaged browser runtime exposes `window.wpCodeboxBrowser.runBrowserSessionRecipe( client, sessionOutput, taskPayload?, options? )` for executing the `wp-codebox/create-browser-playground-session` response. Pass the full ability output as `sessionOutput`; WP Codebox resolves `sessionOutput.recipe`, stages `taskPayload` or `sessionOutput.task_input` at the recipe's browser task path, runs the generated PHP request step through Playground, and returns the parsed runner result. Product callers should use this helper instead of reading `recipe.workflow.steps` or extracting `code=` arguments themselves.
+
 External sources are explicit and CI-safe. WP Codebox validates URL-shaped sources before Playground boots, but it downloads them only when `WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS=1` is set. Supported first-slice forms are WordPress.org plugin zip URLs and generic HTTPS `.zip` URLs:
 
 ```json

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -345,6 +345,27 @@ try {
 		return `<?php\n${ marker }\n?>\n${ source }`;
 	};
 
+	const browserSessionRecipe = ( session ) => {
+		if ( ! session || typeof session !== 'object' ) {
+			throw new Error( 'WP Codebox browser session output is required.' );
+		}
+
+		if ( session.schema && session.schema !== 'wp-codebox/browser-playground-session/v1' ) {
+			throw new Error( `Unsupported WP Codebox browser session schema: ${ session.schema }` );
+		}
+
+		if ( session.success === false || session.status === 'blocked' ) {
+			throw new Error( session?.error?.message || 'WP Codebox browser session is not ready.' );
+		}
+
+		const recipe = session.recipe && typeof session.recipe === 'object' ? session.recipe : null;
+		if ( ! recipe ) {
+			throw new Error( 'WP Codebox browser session is missing a recipe.' );
+		}
+
+		return recipe;
+	};
+
 	const runRecipe = async ( client, recipe, taskPayload, options = {} ) => {
 		const taskPath = recipe?.browser?.task_path;
 		const steps = Array.isArray( recipe?.workflow?.steps ) ? recipe.workflow.steps : [];
@@ -379,12 +400,23 @@ try {
 		return lastResult;
 	};
 
+	const runBrowserSessionRecipe = async ( client, session, taskPayload, options = {} ) => {
+		const recipe = browserSessionRecipe( session );
+		const payload = taskPayload === undefined ? ( session.task_input ?? {} ) : taskPayload;
+		return runRecipe( client, recipe, payload, {
+			...options,
+			name: options.name || 'codebox-browser-session',
+		} );
+	};
+
 	window.wpCodeboxBrowser = {
 		activateTheme,
+		browserSessionRecipe,
 		ensureDirectory,
 		installTheme,
 		normalizeOperationResult,
 		parseJsonResponse,
+		runBrowserSessionRecipe,
 		runPhpRequest,
 		runRecipe,
 		runWordPressOperation,

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -20,6 +20,8 @@ const runtime = context.window.wpCodeboxBrowser
 assert.ok(runtime, "browser runtime should attach window.wpCodeboxBrowser")
 assert.equal(typeof runtime.runPhpRequest, "function")
 assert.equal(typeof runtime.runRecipe, "function")
+assert.equal(typeof runtime.runBrowserSessionRecipe, "function")
+assert.equal(typeof runtime.browserSessionRecipe, "function")
 assert.equal(typeof runtime.runWordPressOperation, "function")
 assert.equal(typeof runtime.ensureDirectory, "function")
 assert.equal(typeof runtime.writeFile, "function")
@@ -130,6 +132,41 @@ assert.equal(recipeResult.success, true)
 assert.equal(recipeClient.files[0]?.path, "/tmp/wp-codebox-agent-task.json")
 assert.match(recipeClient.files[1]?.contents ?? "", /WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER/)
 assert.match(recipeClient.files[1]?.contents ?? "", /<\?php\ndefine\( 'WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER', true \);/)
+
+const sessionClient = createClient("prefix {\"success\":true,\"data\":{\"summary\":\"session runner\"},\"error\":null} suffix")
+const sessionOutput = {
+  schema: "wp-codebox/browser-playground-session/v1",
+  success: true,
+  session: { id: "browser-session-smoke", status: "ready" },
+  task_input: { goal: "Run session smoke", expected_artifacts: ["summary"] },
+  recipe: {
+    schema: "wp-codebox/workspace-recipe/v1",
+    browser: {
+      task_path: "/tmp/wp-codebox-agent-task.json",
+      result_path: "/tmp/wp-codebox-agent-result.json",
+    },
+    workflow: {
+      steps: [
+        {
+          command: "wordpress.run-php",
+          args: ["code=<?php echo wp_json_encode(array('success' => true, 'data' => array('summary' => 'session runner'), 'error' => null));"],
+        },
+      ],
+    },
+  },
+}
+const sessionResult = await runtime.runBrowserSessionRecipe(sessionClient, sessionOutput)
+assert.deepEqual(sameRealm(sessionResult), { success: true, data: { summary: "session runner" }, error: null })
+assert.equal(sessionClient.files[0]?.path, "/tmp/wp-codebox-agent-task.json")
+assert.equal(JSON.parse(sessionClient.files[0]?.contents).goal, "Run session smoke")
+assert.match(sessionClient.files[1]?.path ?? "", /\/wordpress\/wp-content\/uploads\/wp-codebox\/runner\/codebox-browser-session-/)
+assert.match(sessionClient.requests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/codebox-browser-session-/)
+
+assert.equal(runtime.browserSessionRecipe(sessionOutput), sessionOutput.recipe)
+await assert.rejects(
+  () => runtime.runBrowserSessionRecipe(createClient("{}"), { ...sessionOutput, success: false, error: { message: "not ready" } }),
+  /not ready/
+)
 
 await assert.rejects(
   () => runtime.runWordPressOperation(createClient("{}"), { args: {} }),


### PR DESCRIPTION
## Summary
- Add `window.wpCodeboxBrowser.runBrowserSessionRecipe()` so browser callers can pass the full `wp-codebox/create-browser-playground-session` output instead of parsing recipe steps or `code=` args themselves.
- Preserve the raw `runRecipe()` helper while validating browser session readiness and defaulting the task payload from `sessionOutput.task_input`.
- Document the generic browser-session runner contract and cover it in the browser runtime smoke test.

Closes #437.

## Testing
- `npm run build`
- `npm run browser-runtime-operation-smoke`
- `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic browser session recipe runner helper, updated smoke coverage and docs, and ran verification; Chris remains responsible for review and merge.