### PR TITLE
Add canonical browser artifact persistence

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -471,6 +471,54 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/persist-browser-artifact',
+				array(
+					'label'               => 'Persist Browser Artifact',
+					'description'         => 'Persist browser-produced files from a disposable Playground session as a canonical WP Codebox artifact bundle.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'files' ),
+						'properties' => array(
+							'artifacts_path' => $artifact_id_schema['artifacts_path'],
+							'session_id'     => array(
+								'type'        => 'string',
+								'description' => 'Optional browser Playground session id that produced the artifact files.',
+							),
+							'session'        => array(
+								'type'        => 'object',
+								'description' => 'Optional browser session metadata to preserve in artifact runtime provenance.',
+							),
+							'provenance'     => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller provenance describing who requested the browser run and what produced these files.',
+							),
+							'files'          => array(
+								'type'        => 'array',
+								'description' => 'Browser-produced artifact files to store under files/browser/ in a canonical WP Codebox artifact bundle.',
+								'items'       => array(
+									'type'       => 'object',
+									'required'   => array( 'path' ),
+									'properties' => array(
+										'path'           => array( 'type' => 'string' ),
+										'content'        => array( 'type' => 'string' ),
+										'content_base64' => array( 'type' => 'string' ),
+										'encoding'       => array( 'type' => 'string', 'enum' => array( 'utf-8', 'base64' ) ),
+										'mime_type'      => array( 'type' => 'string' ),
+										'kind'           => array( 'type' => 'string' ),
+									),
+								),
+							),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'persist_browser_artifact' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/apply-approved-artifact',
 				array(
 					'label'               => 'Apply Approved WP Codebox Artifact',
@@ -1094,6 +1142,11 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function discard_artifact( array $input ): array|WP_Error {
 		return ( new WP_Codebox_Artifacts() )->discard( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function persist_browser_artifact( array $input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->persist_browser_bundle( $input );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -15,9 +15,11 @@ final class WP_Codebox_Artifacts {
 	private const APPLY_RESULT_SCHEMA = 'wp-codebox/apply-result/v1';
 	private const APPLY_AUDIT_SCHEMA = 'wp-codebox/apply-audit/v1';
 	private const VERIFICATION_SCHEMA = 'wp-codebox/artifact-bundle-verification/v1';
+	private const BROWSER_PERSIST_SCHEMA = 'wp-codebox/browser-artifact-persistence/v1';
 	private const GENERIC_VERIFIER_ISSUE_URL = 'https://github.com/chubes4/wp-codebox/issues/176';
 	private const CONTENT_DIGEST_PREFIX = "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n";
 	private const CONTENT_DIGEST_SEPARATOR = "\nfiles/patch.diff\n";
+	private const BROWSER_ARTIFACT_MAX_BYTES = 5242880;
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public function list( array $input = array() ): array|WP_Error {
@@ -85,6 +87,159 @@ final class WP_Codebox_Artifacts {
 			'schema'      => self::GET_SCHEMA,
 			'artifact_id' => (string) $bundle['id'],
 			'discarded'   => true,
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function persist_browser_bundle( array $input ): array|WP_Error {
+		$root = $this->artifact_root( $input, true );
+		if ( is_wp_error( $root ) ) {
+			return $root;
+		}
+
+		$files = $this->browser_bundle_files( $input );
+		if ( is_wp_error( $files ) ) {
+			return $files;
+		}
+
+		if ( empty( $files ) ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_files_missing', 'files must include at least one browser-produced artifact file.', array( 'status' => 400 ) );
+		}
+
+		$created_at = gmdate( 'c' );
+		$tmp        = $root . DIRECTORY_SEPARATOR . '.browser-artifact-' . bin2hex( random_bytes( 8 ) );
+		if ( ! $this->mkdir_p( $tmp . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'browser' ) ) {
+			return new WP_Error( 'wp_codebox_artifact_directory_unwritable', 'Unable to create artifact bundle directory.', array( 'status' => 500 ) );
+		}
+
+		$changed_files = array(
+			'schema' => 'wp-codebox/changed-files/v1',
+			'files'  => array(),
+		);
+		$manifest_files = array();
+
+		foreach ( $files as $file ) {
+			$artifact_path = 'files/browser/' . $file['path'];
+			$target_path   = $tmp . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $artifact_path );
+			$target_dir    = dirname( $target_path );
+			if ( ! is_dir( $target_dir ) && ! $this->mkdir_p( $target_dir ) ) {
+				$this->remove_directory( $tmp );
+				return new WP_Error( 'wp_codebox_artifact_directory_unwritable', 'Unable to create artifact file directory.', array( 'status' => 500, 'path' => $artifact_path ) );
+			}
+
+			if ( false === file_put_contents( $target_path, $file['bytes'] ) ) {
+				$this->remove_directory( $tmp );
+				return new WP_Error( 'wp_codebox_artifact_file_unwritable', 'Unable to write artifact file.', array( 'status' => 500, 'path' => $artifact_path ) );
+			}
+
+			$file_sha256 = hash( 'sha256', $file['bytes'] );
+			$changed_files['files'][] = array(
+				'path'         => $file['path'],
+				'artifactPath' => $artifact_path,
+				'status'       => 'created',
+				'encoding'     => $file['encoding'],
+				'mimeType'     => $file['mime_type'],
+				'size'         => strlen( $file['bytes'] ),
+				'sha256'       => array( 'algorithm' => 'sha256', 'value' => $file_sha256 ),
+				'kind'         => $file['kind'],
+			);
+			$manifest_files[] = $this->manifest_file( $artifact_path, 'browser-artifact', $file['mime_type'], $file_sha256 );
+		}
+
+		$changed_files_json = $this->json_encode_pretty( $changed_files );
+		$patch              = '';
+		file_put_contents( $tmp . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'changed-files.json', $changed_files_json );
+		file_put_contents( $tmp . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'patch.diff', $patch );
+
+		$content_digest = hash( 'sha256', self::CONTENT_DIGEST_PREFIX . $changed_files_json . self::CONTENT_DIGEST_SEPARATOR . $patch );
+		$bundle_id      = 'artifact-bundle-sha256-' . $content_digest;
+		$destination    = $root . DIRECTORY_SEPARATOR . $bundle_id;
+		if ( file_exists( $destination ) ) {
+			$this->remove_directory( $tmp );
+			return new WP_Error( 'wp_codebox_artifact_already_exists', 'Artifact bundle already exists for this browser artifact content digest.', array( 'status' => 409, 'artifact_id' => $bundle_id ) );
+		}
+
+		$provenance = is_array( $input['provenance'] ?? null ) ? $input['provenance'] : array();
+		$metadata   = array(
+			'id'            => $bundle_id,
+			'contentDigest' => array(
+				'algorithm' => 'sha256',
+				'inputs'    => array( 'files/changed-files.json', 'files/patch.diff' ),
+				'value'     => $content_digest,
+			),
+			'createdAt'     => $created_at,
+			'runtime'       => $this->browser_runtime_metadata( $input ),
+			'provenance'    => $provenance,
+			'artifacts'     => array(
+				'browser'      => 'files/browser',
+				'changedFiles' => 'files/changed-files.json',
+				'patch'        => 'files/patch.diff',
+				'review'       => 'files/review.json',
+				'testResults'  => 'files/test-results.json',
+			),
+		);
+		$review     = array(
+			'schema'       => 'wp-codebox/artifact-review/v1',
+			'artifactId'   => $bundle_id,
+			'createdAt'    => $created_at,
+			'summary'      => 'Browser-produced artifact files persisted as a canonical WP Codebox artifact bundle.',
+			'provenance'   => $provenance,
+			'changedFiles' => $changed_files['files'],
+			'evidence'     => array(
+				'artifactContentDigest' => $content_digest,
+				'changedFiles'          => 'files/changed-files.json',
+				'patch'                 => 'files/patch.diff',
+				'patchSha256'           => hash( 'sha256', $patch ),
+			),
+			'riskFlags'    => array(),
+		);
+		$test_results = array(
+			'schema' => 'wp-codebox/test-results/v1',
+			'status' => 'not-run',
+			'tests'  => array(),
+		);
+
+		file_put_contents( $tmp . DIRECTORY_SEPARATOR . 'metadata.json', $this->json_encode_pretty( $metadata ) );
+		file_put_contents( $tmp . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'review.json', $this->json_encode_pretty( $review ) );
+		file_put_contents( $tmp . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'test-results.json', $this->json_encode_pretty( $test_results ) );
+
+		$manifest = array(
+			'id'            => $bundle_id,
+			'contentDigest' => $metadata['contentDigest'],
+			'createdAt'     => $created_at,
+			'runtime'       => $metadata['runtime'],
+			'files'         => array_merge(
+				array(
+					$this->manifest_file( 'manifest.json', 'manifest', 'application/json', str_repeat( '0', 64 ) ),
+					$this->manifest_file( 'metadata.json', 'metadata', 'application/json', hash_file( 'sha256', $tmp . DIRECTORY_SEPARATOR . 'metadata.json' ) ),
+					$this->manifest_file( 'files/changed-files.json', 'changed-files', 'application/json', hash( 'sha256', $changed_files_json ) ),
+					$this->manifest_file( 'files/patch.diff', 'patch', 'text/x-diff', hash( 'sha256', $patch ) ),
+					$this->manifest_file( 'files/review.json', 'review', 'application/json', hash_file( 'sha256', $tmp . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'review.json' ) ),
+					$this->manifest_file( 'files/test-results.json', 'test-results', 'application/json', hash_file( 'sha256', $tmp . DIRECTORY_SEPARATOR . 'files' . DIRECTORY_SEPARATOR . 'test-results.json' ) ),
+				),
+				$manifest_files
+			),
+		);
+		$manifest['files'][0]['sha256']['value'] = $this->manifest_self_hash( $manifest );
+		file_put_contents( $tmp . DIRECTORY_SEPARATOR . 'manifest.json', $this->json_encode_pretty( $manifest ) );
+
+		if ( ! rename( $tmp, $destination ) ) {
+			$this->remove_directory( $tmp );
+			return new WP_Error( 'wp_codebox_artifact_persist_failed', 'Unable to finalize artifact bundle directory.', array( 'status' => 500 ) );
+		}
+
+		$bundle = $this->read_bundle_at_manifest( $destination . DIRECTORY_SEPARATOR . 'manifest.json', true );
+		if ( is_wp_error( $bundle ) ) {
+			return $bundle;
+		}
+
+		return array(
+			'success'        => true,
+			'schema'         => self::BROWSER_PERSIST_SCHEMA,
+			'artifact_id'    => $bundle_id,
+			'content_digest' => $content_digest,
+			'directory'      => $destination,
+			'artifact'       => $bundle,
 		);
 	}
 
@@ -297,7 +452,7 @@ final class WP_Codebox_Artifacts {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return string|WP_Error */
-	private function artifact_root( array $input ): string|WP_Error {
+	private function artifact_root( array $input, bool $create = false ): string|WP_Error {
 		$root = trim( (string) ( $input['artifacts_path'] ?? '' ) );
 		if ( '' === $root ) {
 			$root = trim( (string) $this->config_option( 'wp_codebox_artifacts_root', '' ) );
@@ -310,6 +465,10 @@ final class WP_Codebox_Artifacts {
 
 		if ( function_exists( 'apply_filters' ) ) {
 			$root = (string) apply_filters( 'wp_codebox_artifacts_root', $root, $input );
+		}
+
+		if ( $create && ! is_dir( $root ) && ! $this->mkdir_p( $root ) ) {
+			return new WP_Error( 'wp_codebox_artifacts_root_unwritable', 'Artifact root could not be created.', array( 'status' => 500 ) );
 		}
 
 		$real = realpath( $root );
@@ -330,6 +489,170 @@ final class WP_Codebox_Artifacts {
 		}
 
 		return $default;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
+	private function browser_bundle_files( array $input ): array|WP_Error {
+		$files      = is_array( $input['files'] ?? null ) ? $input['files'] : array();
+		$normalized = array();
+		$seen       = array();
+
+		foreach ( $files as $index => $file ) {
+			if ( ! is_array( $file ) ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_file_invalid', 'Each browser artifact file must be an object.', array( 'status' => 400, 'index' => $index ) );
+			}
+
+			$path = $this->validate_browser_bundle_file_path( trim( (string) ( $file['path'] ?? '' ) ), (int) $index );
+			if ( is_wp_error( $path ) ) {
+				return $path;
+			}
+			if ( isset( $seen[ $path ] ) ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_path_duplicate', 'Browser artifact file paths must be unique.', array( 'status' => 400, 'index' => $index, 'path' => $path ) );
+			}
+			$seen[ $path ] = true;
+
+			$encoding = strtolower( trim( (string) ( $file['encoding'] ?? '' ) ) );
+			if ( '' === $encoding ) {
+				$encoding = array_key_exists( 'content_base64', $file ) ? 'base64' : 'utf-8';
+			}
+			if ( ! in_array( $encoding, array( 'utf-8', 'base64' ), true ) ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_encoding_invalid', 'Browser artifact file encoding must be utf-8 or base64.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'encoding' => $encoding ) );
+			}
+
+			if ( 'base64' === $encoding ) {
+				$bytes = base64_decode( (string) ( $file['content_base64'] ?? $file['content'] ?? '' ), true );
+				if ( false === $bytes ) {
+					return new WP_Error( 'wp_codebox_browser_artifact_base64_invalid', 'Browser artifact file content_base64 must be valid base64.', array( 'status' => 400, 'index' => $index, 'path' => $path ) );
+				}
+			} else {
+				$bytes = (string) ( $file['content'] ?? '' );
+			}
+
+			$size = strlen( $bytes );
+			if ( $size > self::BROWSER_ARTIFACT_MAX_BYTES ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_file_too_large', 'Browser artifact file exceeds the maximum inline size.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'size' => $size, 'max_size' => self::BROWSER_ARTIFACT_MAX_BYTES ) );
+			}
+
+			$mime_type = trim( (string) ( $file['mime_type'] ?? '' ) );
+			if ( '' === $mime_type ) {
+				$mime_type = $this->browser_bundle_mime_type( $path );
+			}
+
+			$normalized[] = array(
+				'path'      => $path,
+				'bytes'     => $bytes,
+				'encoding'  => $encoding,
+				'mime_type' => $mime_type,
+				'kind'      => trim( (string) ( $file['kind'] ?? 'browser-artifact' ) ),
+			);
+		}
+
+		return $normalized;
+	}
+
+	private function validate_browser_bundle_file_path( string $path, int $index ): string|WP_Error {
+		if ( '' === $path || str_starts_with( $path, '/' ) || ! preg_match( '#^[A-Za-z0-9_./-]+$#', $path ) ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must be safe relative paths.', array( 'status' => 400, 'index' => $index, 'path' => $path ) );
+		}
+
+		foreach ( explode( '/', $path ) as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must not contain empty, current-directory, or parent-directory segments.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'segment' => $segment ) );
+			}
+		}
+
+		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		if ( in_array( $extension, array( 'php', 'phtml', 'phar', 'cgi', 'pl', 'py', 'rb', 'asp', 'aspx', 'jsp' ), true ) ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_extension_blocked', 'Browser artifact files must not use executable server-side extensions.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'extension' => $extension ) );
+		}
+
+		return $path;
+	}
+
+	private function browser_bundle_mime_type( string $path ): string {
+		return match ( strtolower( pathinfo( $path, PATHINFO_EXTENSION ) ) ) {
+			'html', 'htm' => 'text/html',
+			'css'        => 'text/css',
+			'js', 'mjs'  => 'text/javascript',
+			'json'       => 'application/json',
+			'svg'        => 'image/svg+xml',
+			'jpg', 'jpeg' => 'image/jpeg',
+			'png'        => 'image/png',
+			'webp'       => 'image/webp',
+			'gif'        => 'image/gif',
+			'txt'        => 'text/plain',
+			default      => 'application/octet-stream',
+		};
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private function browser_runtime_metadata( array $input ): array {
+		$session = is_array( $input['session'] ?? null ) ? $input['session'] : array();
+
+		return array(
+			'id'          => (string) ( $session['id'] ?? $input['session_id'] ?? 'browser-playground' ),
+			'kind'        => 'browser-playground',
+			'execution'   => 'browser-playground',
+			'createdAt'   => (string) ( $session['created_at'] ?? $session['createdAt'] ?? '' ),
+			'provenance'  => is_array( $session['provenance'] ?? null ) ? $session['provenance'] : array(),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function manifest_file( string $path, string $kind, string $content_type, string $sha256 ): array {
+		return array(
+			'path'        => $path,
+			'kind'        => $kind,
+			'contentType' => $content_type,
+			'sha256'      => array( 'algorithm' => 'sha256', 'value' => $sha256 ),
+		);
+	}
+
+	private function manifest_self_hash( array $manifest ): string {
+		foreach ( $manifest['files'] as &$file ) {
+			if ( 'manifest.json' === ( $file['path'] ?? '' ) ) {
+				$file['sha256'] = array( 'algorithm' => 'sha256', 'value' => str_repeat( '0', 64 ) );
+			}
+		}
+		unset( $file );
+
+		return hash( 'sha256', "wp-codebox/artifact-manifest-self/v1\n" . $this->stable_json( $manifest ) );
+	}
+
+	private function stable_json( mixed $value ): string {
+		if ( ! is_array( $value ) ) {
+			return (string) json_encode( $value, JSON_UNESCAPED_SLASHES );
+		}
+
+		if ( array_is_list( $value ) ) {
+			return '[' . implode( ',', array_map( fn( mixed $item ): string => $this->stable_json( $item ), $value ) ) . ']';
+		}
+
+		ksort( $value, SORT_STRING );
+		$parts = array();
+		foreach ( $value as $key => $item ) {
+			$parts[] = json_encode( (string) $key, JSON_UNESCAPED_SLASHES ) . ':' . $this->stable_json( $item );
+		}
+
+		return '{' . implode( ',', $parts ) . '}';
+	}
+
+	private function json_encode_pretty( mixed $value ): string {
+		$json = json_encode( $value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+
+		return false === $json ? "{}\n" : $json . "\n";
+	}
+
+	private function mkdir_p( string $path ): bool {
+		if ( is_dir( $path ) ) {
+			return true;
+		}
+
+		if ( function_exists( 'wp_mkdir_p' ) ) {
+			return (bool) wp_mkdir_p( $path );
+		}
+
+		return mkdir( $path, 0777, true );
 	}
 
 	/** @return string[] */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -353,6 +353,7 @@ $artifact_abilities = array(
 	'wp-codebox/list-artifacts',
 	'wp-codebox/get-artifact',
 	'wp-codebox/discard-artifact',
+	'wp-codebox/persist-browser-artifact',
 	'wp-codebox/apply-approved-artifact',
 	'wp-codebox/stage-artifact-apply',
 );
@@ -575,6 +576,55 @@ $assert( 'browser Playground session exposes preview URL', ! is_wp_error( $brows
 $assert( 'browser Playground session normalizes task input lists', ! is_wp_error( $browser_session ) && array( 'filesystem-write' ) === ( $browser_session['task_input']['allowed_tools'] ?? array() ) );
 $assert( 'browser Playground session returns canonical task input metadata', ! is_wp_error( $browser_session ) && 'wp-codebox/task-input/v1' === ( $browser_session['task_input']['schema'] ?? '' ) && 1 === ( $browser_session['task_input']['version'] ?? 0 ) );
 $assert( 'browser Playground session exposes canonical task string', ! is_wp_error( $browser_session ) && 'Prepare a browser Playground preview.' === ( $browser_session['task'] ?? '' ) );
+
+$persist_browser_artifact_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/persist-browser-artifact'] ?? null;
+$persisted_browser_artifact       = is_array( $persist_browser_artifact_ability ) ? call_user_func(
+	$persist_browser_artifact_ability['execute_callback'],
+	array(
+		'artifacts_path' => $root . '/artifacts',
+		'session_id'     => 'browser-session-123',
+		'provenance'     => array(
+			'task' => array(
+				'id'     => 'issue-437-smoke',
+				'source' => 'wordpress-plugin-smoke',
+			),
+		),
+		'files'          => array(
+			array(
+				'path'      => 'site/index.html',
+				'content'   => '<main>Persisted</main>',
+				'mime_type' => 'text/html',
+				'kind'      => 'html',
+			),
+			array(
+				'path'           => 'site/assets/photo.png',
+				'content_base64' => base64_encode( "\x89PNG\r\n\x1a\nparent-persisted" ),
+				'encoding'       => 'base64',
+				'kind'           => 'image',
+			),
+		),
+	)
+) : new WP_Error( 'missing_ability', 'persist-browser-artifact missing.' );
+$assert( 'persist-browser-artifact stores canonical artifact bundle', ! is_wp_error( $persisted_browser_artifact ) && true === ( $persisted_browser_artifact['success'] ?? false ) && 'wp-codebox/browser-artifact-persistence/v1' === ( $persisted_browser_artifact['schema'] ?? '' ) && str_starts_with( (string) ( $persisted_browser_artifact['artifact_id'] ?? '' ), 'artifact-bundle-sha256-' ) );
+$assert( 'persist-browser-artifact writes manifest and metadata', ! is_wp_error( $persisted_browser_artifact ) && is_file( (string) ( $persisted_browser_artifact['artifact']['paths']['manifest'] ?? '' ) ) && is_file( (string) ( $persisted_browser_artifact['artifact']['paths']['metadata'] ?? '' ) ) );
+$assert( 'persist-browser-artifact records browser file metadata', ! is_wp_error( $persisted_browser_artifact ) && 'site/assets/photo.png' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['path'] ?? '' ) && 'files/browser/site/assets/photo.png' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['artifactPath'] ?? '' ) && 'image/png' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['mimeType'] ?? '' ) && hash( 'sha256', "\x89PNG\r\n\x1a\nparent-persisted" ) === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['sha256']['value'] ?? '' ) );
+$assert( 'persist-browser-artifact lists persisted bundle', ! is_wp_error( $persisted_browser_artifact ) && ! is_wp_error( call_user_func( $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/list-artifacts']['execute_callback'], array( 'artifacts_path' => $root . '/artifacts' ) ) ) );
+$persisted_browser_traversal = is_array( $persist_browser_artifact_ability ) ? call_user_func(
+	$persist_browser_artifact_ability['execute_callback'],
+	array(
+		'artifacts_path' => $root . '/artifacts',
+		'files'          => array( array( 'path' => '../escape.html', 'content' => 'nope' ) ),
+	)
+) : null;
+$assert( 'persist-browser-artifact rejects traversal paths', is_wp_error( $persisted_browser_traversal ) && 'wp_codebox_browser_artifact_path_invalid' === $persisted_browser_traversal->get_error_code() );
+$persisted_browser_php = is_array( $persist_browser_artifact_ability ) ? call_user_func(
+	$persist_browser_artifact_ability['execute_callback'],
+	array(
+		'artifacts_path' => $root . '/artifacts',
+		'files'          => array( array( 'path' => 'site/shell.php', 'content' => '<?php echo "nope";' ) ),
+	)
+) : null;
+$assert( 'persist-browser-artifact rejects server executable extensions', is_wp_error( $persisted_browser_php ) && 'wp_codebox_browser_artifact_extension_blocked' === $persisted_browser_php->get_error_code() );
 
 $browser_packaged_mu_session = call_user_func(
 	$browser_session_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Adds `wp-codebox/persist-browser-artifact` as a REST-visible ability for parent sites to receive browser-produced files and persist a canonical WP Codebox artifact bundle.
- Stores mixed text/binary browser artifacts under `files/browser/` with manifest entries, SHA-256 digests, changed-file metadata, review evidence, test-result placeholder, runtime metadata, and caller provenance.
- Reuses the existing artifact store/list/get bundle shape and validation rules, including safe relative paths, duplicate rejection, encoding validation, size limits, MIME type inference, and blocked server-executable extensions.

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`
- `npm run build`

## Issues
- Closes #436
- Refs #315
- Refs #437 / #446 for the separate browser recipe runner work

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the parent-side browser artifact persistence ability, canonical artifact bundle writer, and smoke coverage; Chris remains responsible for review and merge.