### PR TITLE
Add artifact review workflow

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -551,6 +551,55 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/review-artifact',
+				array(
+					'label'               => 'Review WP Codebox Artifact',
+					'description'         => 'Normalize an artifact review decision from a browser or parent product, then delegate only approval consequences through product-owned adapters.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'artifact_id', 'action' ),
+						'properties' => array_merge(
+							$artifact_id_schema,
+							array(
+								'action'         => array(
+									'type'        => 'string',
+									'description' => 'Review decision action.',
+									'enum'        => array( 'approve', 'reject', 'request-changes' ),
+								),
+								'approved_files' => array(
+									'type'        => 'array',
+									'description' => 'Explicit sandbox file paths approved by the reviewer. Required for approve decisions.',
+									'items'       => array( 'type' => 'string' ),
+								),
+								'approver'       => array(
+									'type'        => 'string',
+									'description' => 'Parent-site reviewer principal for decision and audit records.',
+								),
+								'reason'         => array(
+									'type'        => 'string',
+									'description' => 'Optional reviewer note for reject or request-changes decisions.',
+								),
+								'decided_at'     => array( 'type' => 'string' ),
+								'apply_target'   => array(
+									'type'        => 'object',
+									'description' => 'Optional parent-control-plane target metadata passed through to approval adapters.',
+								),
+								'context'        => array(
+									'type'        => 'object',
+									'description' => 'Opaque caller-owned context preserved on the normalized decision.',
+								),
+							)
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'review_artifact' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/apply-approved-artifact',
 				array(
 					'label'               => 'Apply Approved WP Codebox Artifact',
@@ -1201,6 +1250,11 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function persist_browser_artifact( array $input ): array|WP_Error {
 		return ( new WP_Codebox_Artifacts() )->persist_browser_bundle( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function review_artifact( array $input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->review_artifact( $input );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -14,6 +14,10 @@ final class WP_Codebox_Artifacts {
 	private const APPLY_SCHEMA = 'wp-codebox/artifact-apply/v1';
 	private const APPLY_RESULT_SCHEMA = 'wp-codebox/apply-result/v1';
 	private const APPLY_AUDIT_SCHEMA = 'wp-codebox/apply-audit/v1';
+	private const REVIEW_DECISION_SCHEMA = 'wp-codebox/artifact-review-decision/v1';
+	private const REVIEW_DECISION_MESSAGE_TYPE = 'wp-codebox:artifact-review-decision';
+	private const REVIEW_DECISION_RESULT_SCHEMA = 'wp-codebox/artifact-review-result/v1';
+	private const REVIEW_AUDIT_SCHEMA = 'wp-codebox/artifact-review-audit/v1';
 	private const VERIFICATION_SCHEMA = 'wp-codebox/artifact-bundle-verification/v1';
 	private const BROWSER_PERSIST_SCHEMA = 'wp-codebox/browser-artifact-persistence/v1';
 	private const GENERIC_VERIFIER_ISSUE_URL = 'https://github.com/chubes4/wp-codebox/issues/176';
@@ -244,6 +248,91 @@ final class WP_Codebox_Artifacts {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function review_artifact( array $input ): array|WP_Error {
+		$bundle = $this->resolve_bundle( $input );
+		if ( is_wp_error( $bundle ) ) {
+			return $bundle;
+		}
+
+		$root = $this->artifact_root( $input );
+		if ( is_wp_error( $root ) ) {
+			return $root;
+		}
+
+		$action = $this->review_action( $input );
+		if ( is_wp_error( $action ) ) {
+			return $action;
+		}
+
+		$verification = $this->verify_artifact_bundle( $bundle, $input );
+		if ( is_wp_error( $verification ) ) {
+			return $verification;
+		}
+
+		$approved_files = $this->approved_files( $input );
+		if ( 'approve' === $action && empty( $approved_files ) ) {
+			return new WP_Error( 'wp_codebox_approved_files_missing', 'approved_files must include at least one sandbox path for approve decisions.', array( 'status' => 400 ) );
+		}
+
+		$content_digest = $this->artifact_content_digest( $bundle );
+		if ( is_wp_error( $content_digest ) ) {
+			return $content_digest;
+		}
+
+		$decision = $this->review_decision_payload( $bundle, $input, $action, $approved_files, $content_digest );
+		$message  = array(
+			'type'    => self::REVIEW_DECISION_MESSAGE_TYPE,
+			'payload' => $decision,
+		);
+		$adapter_payload = array(
+			'decision'              => $decision,
+			'message'               => $message,
+			'artifact'              => $bundle,
+			'artifact_verification' => $verification,
+		);
+
+		$result = apply_filters( 'wp_codebox_review_artifact_decision', null, $adapter_payload );
+		if ( null === $result && 'approve' === $action ) {
+			$apply_input = array(
+				'artifacts_path'  => $root,
+				'artifact_id'     => (string) $bundle['id'],
+				'approved_files'  => $approved_files,
+				'approver'        => $decision['approver'] ?? null,
+				'apply_target'    => $decision['apply_target'] ?? null,
+			);
+			$result = $this->apply_approved( $apply_input );
+		}
+
+		$error = null;
+		if ( is_wp_error( $result ) ) {
+			$error = $result;
+			$this->record_review_audit( $root, $bundle, $decision, null, $error );
+			return $result;
+		}
+
+		$normalized_result = null === $result ? $this->default_review_result( $decision ) : $this->normalize_review_result( $result );
+		if ( is_wp_error( $normalized_result ) ) {
+			$this->record_review_audit( $root, $bundle, $decision, null, $normalized_result );
+			return $normalized_result;
+		}
+
+		$this->record_review_audit( $root, $bundle, $decision, $normalized_result, null );
+
+		return array(
+			'success'        => true,
+			'schema'         => self::REVIEW_DECISION_RESULT_SCHEMA,
+			'artifact_id'    => (string) $bundle['id'],
+			'action'         => $action,
+			'approved_files' => $approved_files,
+			'content_digest' => $content_digest,
+			'verification'   => $verification,
+			'decision'       => $decision,
+			'message'        => $message,
+			'result'         => $normalized_result,
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public function apply_approved( array $input ): array|WP_Error {
 		$bundle = $this->resolve_bundle( $input );
 		if ( is_wp_error( $bundle ) ) {
@@ -348,6 +437,101 @@ final class WP_Codebox_Artifacts {
 			'verification'   => $verification,
 			'result'         => $result,
 		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. */
+	private function review_action( array $input ): string|WP_Error {
+		$action = trim( (string) ( $input['action'] ?? $input['decision'] ?? '' ) );
+		if ( '' === $action ) {
+			return new WP_Error( 'wp_codebox_review_action_missing', 'Review action is required.', array( 'status' => 400 ) );
+		}
+
+		if ( ! in_array( $action, array( 'approve', 'reject', 'request-changes' ), true ) ) {
+			return new WP_Error( 'wp_codebox_review_action_invalid', 'Review action must be approve, reject, or request-changes.', array( 'status' => 400, 'action' => $action ) );
+		}
+
+		return $action;
+	}
+
+	/** @param array<string,mixed> $bundle Artifact bundle. @param array<string,mixed> $input Ability input. @param string[] $approved_files Approved sandbox paths. @return array<string,mixed> */
+	private function review_decision_payload( array $bundle, array $input, string $action, array $approved_files, string $content_digest ): array {
+		$context      = is_array( $input['context'] ?? null ) ? $input['context'] : array();
+		$apply_target = is_array( $input['apply_target'] ?? null ) ? $input['apply_target'] : null;
+		$provenance   = array(
+			'artifact' => is_array( $bundle['metadata']['provenance'] ?? null ) ? $bundle['metadata']['provenance'] : array(),
+			'review'   => is_array( $bundle['review']['provenance'] ?? null ) ? $bundle['review']['provenance'] : array(),
+		);
+
+		$decision = array(
+			'schema'         => self::REVIEW_DECISION_SCHEMA,
+			'action'         => $action,
+			'artifact_id'    => (string) $bundle['id'],
+			'approved_files' => $approved_files,
+			'approver'       => $this->approver_principal( $input['approver'] ?? null ),
+			'reason'         => $this->optional_string( $input['reason'] ?? null ),
+			'decided_at'     => $this->optional_string( $input['decided_at'] ?? null ) ?? gmdate( 'c' ),
+			'source'         => 'wp-codebox/wordpress-plugin',
+			'provenance'     => $provenance,
+			'content_digest' => $content_digest,
+			'apply_target'   => $apply_target,
+			'requester'      => $this->requester_principal( $bundle ),
+			'context'        => empty( $context ) ? null : $context,
+		);
+
+		return $this->strip_null_values( $decision );
+	}
+
+	/** @param array<string,mixed> $decision Normalized decision. @return array<string,mixed> */
+	private function default_review_result( array $decision ): array {
+		return array(
+			'schema'          => self::REVIEW_DECISION_RESULT_SCHEMA,
+			'adapter'         => 'wp-codebox/default-review-decision',
+			'status'          => (string) $decision['action'],
+			'audit_reference' => (string) $decision['artifact_id'] . '#' . (string) $decision['decided_at'],
+		);
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private function normalize_review_result( mixed $result ): array|WP_Error {
+		if ( ! is_array( $result ) ) {
+			return new WP_Error( 'wp_codebox_review_result_invalid', 'Review decision adapter returned an invalid result: result must be an object.', array( 'status' => 502 ) );
+		}
+
+		if ( isset( $result['schema'] ) && self::REVIEW_DECISION_RESULT_SCHEMA !== $result['schema'] && self::APPLY_SCHEMA !== $result['schema'] ) {
+			return new WP_Error( 'wp_codebox_review_result_invalid', 'Review decision adapter returned an invalid result: schema is not supported.', array( 'status' => 502 ) );
+		}
+
+		if ( self::APPLY_SCHEMA === ( $result['schema'] ?? null ) ) {
+			return $result;
+		}
+
+		$adapter = trim( (string) ( $result['adapter'] ?? '' ) );
+		if ( '' === $adapter ) {
+			return new WP_Error( 'wp_codebox_review_result_invalid', 'Review decision adapter returned an invalid result: result.adapter is required.', array( 'status' => 502 ) );
+		}
+
+		$status = trim( (string) ( $result['status'] ?? '' ) );
+		if ( '' === $status ) {
+			return new WP_Error( 'wp_codebox_review_result_invalid', 'Review decision adapter returned an invalid result: result.status is required.', array( 'status' => 502, 'adapter' => $adapter ) );
+		}
+
+		$normalized = array(
+			'schema'  => self::REVIEW_DECISION_RESULT_SCHEMA,
+			'adapter' => $adapter,
+			'status'  => $status,
+		);
+
+		foreach ( array( 'audit_reference', 'url', 'pr_url', 'comment_url' ) as $key ) {
+			if ( isset( $result[ $key ] ) && '' !== trim( (string) $result[ $key ] ) ) {
+				$normalized[ $key ] = (string) $result[ $key ];
+			}
+		}
+
+		if ( isset( $result['target'] ) && is_array( $result['target'] ) ) {
+			$normalized['target'] = $result['target'];
+		}
+
+		return $normalized;
 	}
 
 	/** @return array<string,mixed>|WP_Error */
@@ -1081,11 +1265,58 @@ final class WP_Codebox_Artifacts {
 		file_put_contents( $this->apply_audit_path( $root ), $line . "\n", FILE_APPEND | LOCK_EX );
 	}
 
+	/** @param array<string,mixed> $bundle Artifact bundle. @param array<string,mixed> $decision Normalized decision. @param mixed $result Review adapter result. */
+	private function record_review_audit( string $root, array $bundle, array $decision, mixed $result, ?WP_Error $error ): void {
+		$record = array(
+			'schema'         => self::REVIEW_AUDIT_SCHEMA,
+			'timestamp'      => gmdate( 'c' ),
+			'artifact_id'    => (string) $bundle['id'],
+			'action'         => (string) ( $decision['action'] ?? '' ),
+			'content_digest' => (string) ( $decision['content_digest'] ?? $bundle['content_digest'] ?? '' ),
+			'requester'      => $decision['requester'] ?? $this->requester_principal( $bundle ),
+			'approver'       => $decision['approver'] ?? null,
+			'approved_files' => is_array( $decision['approved_files'] ?? null ) ? $decision['approved_files'] : array(),
+			'adapter'        => is_array( $result ) ? ( $result['adapter'] ?? null ) : $this->adapter_from_error( $error ),
+			'status'         => null === $error ? 'success' : 'failure',
+			'decision'       => $this->redact_audit_metadata( $decision ),
+		);
+
+		if ( is_array( $result ) ) {
+			$record['result'] = $this->redact_audit_metadata( $result );
+		}
+
+		if ( null !== $error ) {
+			$record['error'] = array(
+				'code'    => $error->get_error_code(),
+				'message' => $error->get_error_message(),
+				'data'    => $this->redact_audit_metadata( $error->get_error_data() ),
+			);
+		}
+
+		$record = $this->strip_null_values( $record );
+		$line   = function_exists( 'wp_json_encode' ) ? wp_json_encode( $record, JSON_UNESCAPED_SLASHES ) : json_encode( $record, JSON_UNESCAPED_SLASHES );
+		if ( false === $line ) {
+			return;
+		}
+
+		file_put_contents( $this->review_audit_path( $root ), $line . "\n", FILE_APPEND | LOCK_EX );
+	}
+
 	private function apply_audit_path( string $root ): string {
 		$path = $root . DIRECTORY_SEPARATOR . 'apply-audit.jsonl';
 
 		if ( function_exists( 'apply_filters' ) ) {
 			$path = (string) apply_filters( 'wp_codebox_apply_audit_path', $path, $root );
+		}
+
+		return $path;
+	}
+
+	private function review_audit_path( string $root ): string {
+		$path = $root . DIRECTORY_SEPARATOR . 'review-audit.jsonl';
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$path = (string) apply_filters( 'wp_codebox_review_audit_path', $path, $root );
 		}
 
 		return $path;
@@ -1123,6 +1354,12 @@ final class WP_Codebox_Artifacts {
 		}
 
 		return null;
+	}
+
+	private function optional_string( mixed $value ): ?string {
+		$trimmed = trim( (string) $value );
+
+		return '' === $trimmed ? null : $trimmed;
 	}
 
 	private function adapter_from_error( ?WP_Error $error ): mixed {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -358,6 +358,7 @@ $artifact_abilities = array(
 	'wp-codebox/get-artifact',
 	'wp-codebox/discard-artifact',
 	'wp-codebox/persist-browser-artifact',
+	'wp-codebox/review-artifact',
 	'wp-codebox/apply-approved-artifact',
 	'wp-codebox/stage-artifact-apply',
 );
@@ -1851,6 +1852,75 @@ $reference_failure = WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifa
 	)
 );
 $assert( 'pending artifact apply rejects malformed references before staging', is_wp_error( $reference_failure ) && 'wp_codebox_artifact_verification_failed' === $reference_failure->get_error_code() && in_array( 'malformed-reference', $violation_codes( $reference_failure ), true ) && 'https://github.com/chubes4/wp-codebox/issues/176' === ( $reference_failure->get_error_data()['issue_url'] ?? '' ) );
+
+$review_fixture_root = $root . '/artifact-review-fixture';
+$copy_directory( $bundle_dir, $review_fixture_root . '/runtime-test' );
+$review_apply_payloads = array();
+$GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function ( mixed $value, array $payload ) use ( &$review_apply_payloads ): array {
+	$review_apply_payloads[] = $payload;
+	return array(
+		'schema'          => 'wp-codebox/apply-result/v1',
+		'adapter'         => 'review-approve-adapter',
+		'status'          => 'queued',
+		'target'          => is_array( $payload['apply_target'] ?? null ) ? $payload['apply_target'] : array(),
+		'applied_files'   => $payload['approved_files'] ?? array(),
+		'audit_reference' => 'review-approve:test',
+	);
+};
+$approved_review = $artifacts->review_artifact(
+	array(
+		'artifacts_path'  => $review_fixture_root,
+		'artifact_id'     => $artifact_id,
+		'action'          => 'approve',
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt', '' ),
+		'approver'        => 'site-user:reviewer',
+		'reason'          => 'Ship the generated fix.',
+		'decided_at'      => '2026-05-20T00:00:00Z',
+		'apply_target'    => array( 'repo' => 'chubes4/wp-codebox' ),
+		'context'         => array( 'product' => 'studio-web' ),
+	)
+);
+$assert( 'artifact review approve returns generic decision result', ! is_wp_error( $approved_review ) && 'wp-codebox/artifact-review-result/v1' === ( $approved_review['schema'] ?? '' ) && 'approve' === ( $approved_review['action'] ?? '' ) && 'wp-codebox/artifact-apply/v1' === ( $approved_review['result']['schema'] ?? '' ) );
+$assert( 'artifact review approve preserves approved files and provenance', ! is_wp_error( $approved_review ) && array( '/wordpress/wp-content/plugins/example/generated.txt' ) === ( $approved_review['decision']['approved_files'] ?? array() ) && 'chat:user-7' === ( $approved_review['decision']['requester'] ?? '' ) && 'chat:user-7' === ( $approved_review['decision']['provenance']['artifact']['task']['requester'] ?? '' ) );
+$assert( 'artifact review approve returns browser decision message shape', ! is_wp_error( $approved_review ) && 'wp-codebox:artifact-review-decision' === ( $approved_review['message']['type'] ?? '' ) && 'wp-codebox/artifact-review-decision/v1' === ( $approved_review['message']['payload']['schema'] ?? '' ) && 'wp-codebox/wordpress-plugin' === ( $approved_review['message']['payload']['source'] ?? '' ) );
+$assert( 'artifact review approve delegates approval consequence to adapter', 1 === count( $review_apply_payloads ) && array( 'repo' => 'chubes4/wp-codebox' ) === ( $review_apply_payloads[0]['apply_target'] ?? array() ) );
+
+$captured_review_decisions = array();
+$GLOBALS['wp_codebox_filters']['wp_codebox_review_artifact_decision'] = function ( mixed $value, array $payload ) use ( &$captured_review_decisions ): array {
+	$captured_review_decisions[] = $payload['decision'];
+	return array(
+		'schema'          => 'wp-codebox/artifact-review-result/v1',
+		'adapter'         => 'review-state-adapter',
+		'status'          => $payload['decision']['action'],
+		'audit_reference' => 'review-state:' . $payload['decision']['action'],
+	);
+};
+$rejected_review = $artifacts->review_artifact(
+	array(
+		'artifacts_path' => $review_fixture_root,
+		'artifact_id'    => $artifact_id,
+		'action'         => 'reject',
+		'approver'       => 'site-user:reviewer',
+		'reason'         => 'Wrong target.',
+	)
+);
+$changes_review = $artifacts->review_artifact(
+	array(
+		'artifacts_path' => $review_fixture_root,
+		'artifact_id'    => $artifact_id,
+		'action'         => 'request-changes',
+		'approver'       => 'site-user:reviewer',
+		'reason'         => 'Limit the patch to generated.txt.',
+	)
+);
+$assert( 'artifact review reject normalizes decision without approved files', ! is_wp_error( $rejected_review ) && 'reject' === ( $rejected_review['decision']['action'] ?? '' ) && array() === ( $rejected_review['decision']['approved_files'] ?? array() ) && 'Wrong target.' === ( $rejected_review['decision']['reason'] ?? '' ) );
+$assert( 'artifact review request-changes normalizes decision message', ! is_wp_error( $changes_review ) && 'request-changes' === ( $changes_review['message']['payload']['action'] ?? '' ) && 'review-state-adapter' === ( $changes_review['result']['adapter'] ?? '' ) );
+$assert( 'artifact review hook receives reject and request-changes decisions', array( 'reject', 'request-changes' ) === array_map( static fn( array $decision ): string => (string) $decision['action'], $captured_review_decisions ) );
+$review_audit_path = $review_fixture_root . '/review-audit.jsonl';
+$review_audit_lines = is_file( $review_audit_path ) ? array_values( array_filter( explode( "\n", trim( (string) file_get_contents( $review_audit_path ) ) ) ) ) : array();
+$review_audit_first = isset( $review_audit_lines[0] ) ? json_decode( $review_audit_lines[0], true ) : array();
+$assert( 'artifact review audit records decisions separately from apply consequences', 3 === count( $review_audit_lines ) && 'wp-codebox/artifact-review-audit/v1' === ( $review_audit_first['schema'] ?? '' ) && 'approve' === ( $review_audit_first['action'] ?? '' ) );
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_review_artifact_decision'] );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function ( mixed $value, array $payload ): array {
 	return array(


### PR DESCRIPTION
## Summary
- Adds a plugin-level `wp-codebox/review-artifact` ability for normalized artifact review decisions.
- Preserves generic approve/reject/request-changes decision payloads, provenance, message shape, and separate review audit records.
- Keeps product-specific consequences behind adapters: approvals fall through to the existing approved-artifact apply adapter, while non-approval decisions use the generic review decision hook/result path.

## Tests
- `npm run wordpress-plugin-smoke`
- `npm run browser-review-bridge-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementation and tests for the plugin-level artifact review workflow; Chris remains responsible for review and merge decisions.