### PR TITLE
Add browser artifact bundle normalization

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -503,6 +503,66 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/normalize-browser-artifact-bundle',
+				array(
+					'label'               => 'Normalize Browser Artifact Bundle',
+					'description'         => 'Normalize and verify a caller-owned browser artifact bundle without interpreting product-specific roles or metadata.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'schema_id', 'entrypoint', 'files' ),
+						'properties' => array(
+							'schema_id'  => array(
+								'type'        => 'string',
+								'description' => 'Caller-owned schema id for the product artifact contract being normalized.',
+							),
+							'root'       => array(
+								'type'        => 'string',
+								'description' => 'Optional safe relative artifact root applied to entrypoint and file paths.',
+							),
+							'entrypoint' => array(
+								'type'        => 'string',
+								'description' => 'Safe relative entrypoint path that must exist in the normalized files.',
+							),
+							'roles'      => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller role metadata preserved without product-specific interpretation.',
+							),
+							'provenance' => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller provenance preserved on the normalized bundle.',
+							),
+							'metadata'   => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller metadata preserved on the normalized bundle.',
+							),
+							'files'      => array(
+								'type'        => 'array',
+								'description' => 'Browser-produced artifact files to normalize.',
+								'items'       => array(
+									'type'       => 'object',
+									'required'   => array( 'path' ),
+									'properties' => array(
+										'path'           => array( 'type' => 'string' ),
+										'content'        => array( 'type' => 'string' ),
+										'content_base64' => array( 'type' => 'string' ),
+										'encoding'       => array( 'type' => 'string', 'enum' => array( 'utf-8', 'base64' ) ),
+										'mime_type'      => array( 'type' => 'string' ),
+										'kind'           => array( 'type' => 'string' ),
+										'roles'          => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+									),
+								),
+							),
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'normalize_browser_artifact_bundle' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/persist-browser-artifact',
 				array(
 					'label'               => 'Persist Browser Artifact',
@@ -1196,6 +1256,11 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function discard_artifact( array $input ): array|WP_Error {
 		return ( new WP_Codebox_Artifacts() )->discard( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function normalize_browser_artifact_bundle( array $input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->normalize_browser_bundle( $input );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -15,6 +15,7 @@ final class WP_Codebox_Artifacts {
 	private const APPLY_RESULT_SCHEMA = 'wp-codebox/apply-result/v1';
 	private const APPLY_AUDIT_SCHEMA = 'wp-codebox/apply-audit/v1';
 	private const VERIFICATION_SCHEMA = 'wp-codebox/artifact-bundle-verification/v1';
+	private const BROWSER_NORMALIZATION_SCHEMA = 'wp-codebox/browser-artifact-bundle-normalization/v1';
 	private const BROWSER_PERSIST_SCHEMA = 'wp-codebox/browser-artifact-persistence/v1';
 	private const GENERIC_VERIFIER_ISSUE_URL = 'https://github.com/chubes4/wp-codebox/issues/176';
 	private const CONTENT_DIGEST_PREFIX = "wp-codebox/artifact-content/v1\nfiles/changed-files.json\n";
@@ -91,20 +92,104 @@ final class WP_Codebox_Artifacts {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function normalize_browser_bundle( array $input, bool $include_bytes = false ): array|WP_Error {
+		$schema_id = trim( (string) ( $input['schema_id'] ?? $input['caller_schema'] ?? $input['callerSchema'] ?? '' ) );
+		if ( '' === $schema_id ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_schema_missing', 'schema_id is required for browser artifact bundle normalization.', array( 'status' => 400 ) );
+		}
+
+		$root = $this->normalize_browser_bundle_root( (string) ( $input['root'] ?? '' ) );
+		if ( is_wp_error( $root ) ) {
+			return $root;
+		}
+
+		$entrypoint = $this->normalize_browser_bundle_scoped_path( (string) ( $input['entrypoint'] ?? '' ), $root, -1, 'entrypoint' );
+		if ( is_wp_error( $entrypoint ) ) {
+			return $entrypoint;
+		}
+
+		$files = $this->browser_bundle_files( $input, $root );
+		if ( is_wp_error( $files ) ) {
+			return $files;
+		}
+		if ( empty( $files ) ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_files_missing', 'files must include at least one browser-produced artifact file.', array( 'status' => 400 ) );
+		}
+
+		$persistence_files = $files;
+		usort( $files, static fn( array $a, array $b ): int => strcmp( (string) $a['path'], (string) $b['path'] ) );
+		$entrypoint_found = false;
+		$output_files      = array();
+		foreach ( $files as $file ) {
+			if ( $entrypoint === $file['path'] ) {
+				$entrypoint_found = true;
+			}
+
+			$output_file = array(
+				'path'      => $file['path'],
+				'encoding'  => $file['encoding'],
+				'mime_type' => $file['mime_type'],
+				'size'      => strlen( $file['bytes'] ),
+				'sha256'    => hash( 'sha256', $file['bytes'] ),
+				'kind'      => $file['kind'],
+			);
+			if ( ! empty( $file['roles'] ) ) {
+				$output_file['roles'] = $file['roles'];
+			}
+			if ( 'base64' === $file['encoding'] ) {
+				$output_file['content_base64'] = base64_encode( $file['bytes'] );
+			} else {
+				$output_file['content'] = $file['bytes'];
+			}
+
+			$output_files[] = $output_file;
+		}
+
+		if ( ! $entrypoint_found ) {
+			return new WP_Error( 'wp_codebox_browser_artifact_entrypoint_missing', 'Browser artifact bundle entrypoint must match one normalized file path.', array( 'status' => 400, 'entrypoint' => $entrypoint ) );
+		}
+
+		$bundle = array(
+			'success'       => true,
+			'schema'        => self::BROWSER_NORMALIZATION_SCHEMA,
+			'caller_schema' => $schema_id,
+			'root'          => $root,
+			'entrypoint'    => $entrypoint,
+			'files'         => $output_files,
+			'roles'         => is_array( $input['roles'] ?? null ) ? $this->stable_assoc_array( $input['roles'] ) : array(),
+			'provenance'    => is_array( $input['provenance'] ?? null ) ? $this->stable_assoc_array( $input['provenance'] ) : array(),
+			'metadata'      => is_array( $input['metadata'] ?? null ) ? $this->stable_assoc_array( $input['metadata'] ) : array(),
+		);
+		$bundle['content_digest'] = hash( 'sha256', "wp-codebox/browser-artifact-bundle/v1\n" . $this->stable_json( $bundle ) );
+
+		if ( $include_bytes ) {
+			$bundle['_files'] = $persistence_files;
+		}
+
+		return $bundle;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public function persist_browser_bundle( array $input ): array|WP_Error {
 		$root = $this->artifact_root( $input, true );
 		if ( is_wp_error( $root ) ) {
 			return $root;
 		}
 
-		$files = $this->browser_bundle_files( $input );
-		if ( is_wp_error( $files ) ) {
-			return $files;
+		$normalization = $this->normalize_browser_bundle(
+			array_merge(
+				array(
+					'schema_id'  => self::BROWSER_PERSIST_SCHEMA,
+					'entrypoint' => (string) ( $input['entrypoint'] ?? ( is_array( $input['files'] ?? null ) && is_array( $input['files'][0] ?? null ) ? (string) ( $input['files'][0]['path'] ?? '' ) : '' ) ),
+				),
+				$input
+			),
+			true
+		);
+		if ( is_wp_error( $normalization ) ) {
+			return $normalization;
 		}
-
-		if ( empty( $files ) ) {
-			return new WP_Error( 'wp_codebox_browser_artifact_files_missing', 'files must include at least one browser-produced artifact file.', array( 'status' => 400 ) );
-		}
+		$files = is_array( $normalization['_files'] ?? null ) ? $normalization['_files'] : array();
 
 		$created_at = gmdate( 'c' );
 		$tmp        = $root . DIRECTORY_SEPARATOR . '.browser-artifact-' . bin2hex( random_bytes( 8 ) );
@@ -492,7 +577,7 @@ final class WP_Codebox_Artifacts {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
-	private function browser_bundle_files( array $input ): array|WP_Error {
+	private function browser_bundle_files( array $input, string $root = '' ): array|WP_Error {
 		$files      = is_array( $input['files'] ?? null ) ? $input['files'] : array();
 		$normalized = array();
 		$seen       = array();
@@ -502,7 +587,7 @@ final class WP_Codebox_Artifacts {
 				return new WP_Error( 'wp_codebox_browser_artifact_file_invalid', 'Each browser artifact file must be an object.', array( 'status' => 400, 'index' => $index ) );
 			}
 
-			$path = $this->validate_browser_bundle_file_path( trim( (string) ( $file['path'] ?? '' ) ), (int) $index );
+			$path = $this->normalize_browser_bundle_scoped_path( (string) ( $file['path'] ?? '' ), $root, (int) $index, 'file' );
 			if ( is_wp_error( $path ) ) {
 				return $path;
 			}
@@ -544,10 +629,39 @@ final class WP_Codebox_Artifacts {
 				'encoding'  => $encoding,
 				'mime_type' => $mime_type,
 				'kind'      => trim( (string) ( $file['kind'] ?? 'browser-artifact' ) ),
+				'roles'     => array_values( array_filter( array_map( 'strval', is_array( $file['roles'] ?? null ) ? $file['roles'] : array() ), static fn( string $role ): bool => '' !== trim( $role ) ) ),
 			);
 		}
 
 		return $normalized;
+	}
+
+	private function normalize_browser_bundle_root( string $root ): string|WP_Error {
+		$root = rtrim( trim( str_replace( '\\', '/', $root ) ), '/' );
+		if ( '' === $root ) {
+			return '';
+		}
+
+		return $this->validate_browser_bundle_file_path( $root, -1 );
+	}
+
+	private function normalize_browser_bundle_scoped_path( string $path, string $root, int $index, string $field ): string|WP_Error {
+		$path = trim( str_replace( '\\', '/', $path ) );
+		$path = $this->validate_browser_bundle_file_path( $path, $index );
+		if ( is_wp_error( $path ) ) {
+			return $path;
+		}
+
+		if ( '' === $root || $root === $path || str_starts_with( $path, $root . '/' ) ) {
+			return $path;
+		}
+
+		$scoped = $this->validate_browser_bundle_file_path( $root . '/' . $path, $index );
+		if ( is_wp_error( $scoped ) ) {
+			return new WP_Error( $scoped->get_error_code(), $scoped->get_error_message(), array_merge( (array) $scoped->get_error_data(), array( 'field' => $field ) ) );
+		}
+
+		return $scoped;
 	}
 
 	private function validate_browser_bundle_file_path( string $path, int $index ): string|WP_Error {
@@ -635,6 +749,22 @@ final class WP_Codebox_Artifacts {
 		}
 
 		return '{' . implode( ',', $parts ) . '}';
+	}
+
+	/** @param array<mixed> $value Input array. @return array<mixed> */
+	private function stable_assoc_array( array $value ): array {
+		if ( array_is_list( $value ) ) {
+			return array_map( fn( mixed $item ): mixed => is_array( $item ) ? $this->stable_assoc_array( $item ) : $item, $value );
+		}
+
+		ksort( $value, SORT_STRING );
+		foreach ( $value as $key => $item ) {
+			if ( is_array( $item ) ) {
+				$value[ $key ] = $this->stable_assoc_array( $item );
+			}
+		}
+
+		return $value;
 	}
 
 	private function json_encode_pretty( mixed $value ): string {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -597,6 +597,56 @@ $assert( 'browser Playground session normalizes task input lists', ! is_wp_error
 $assert( 'browser Playground session returns canonical task input metadata', ! is_wp_error( $browser_session ) && 'wp-codebox/task-input/v1' === ( $browser_session['task_input']['schema'] ?? '' ) && 1 === ( $browser_session['task_input']['version'] ?? 0 ) );
 $assert( 'browser Playground session exposes canonical task string', ! is_wp_error( $browser_session ) && 'Prepare a browser Playground preview.' === ( $browser_session['task'] ?? '' ) );
 
+$normalize_browser_bundle_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/normalize-browser-artifact-bundle'] ?? null;
+$browser_bundle_input            = array(
+	'schema_id'  => 'caller/browser-bundle/v1',
+	'root'       => 'site',
+	'entrypoint' => 'index.html',
+	'roles'      => array(
+		'preview' => 'index.html',
+		'assets'  => array( 'assets/logo.png' ),
+	),
+	'provenance' => array(
+		'caller' => 'wordpress-plugin-smoke',
+	),
+	'metadata'   => array(
+		'opaque' => array( 'product' => 'fixture' ),
+	),
+	'files'      => array(
+		array(
+			'path'    => 'assets/app.css',
+			'content' => 'body{color:#111}',
+			'kind'    => 'stylesheet',
+			'roles'   => array( 'style' ),
+		),
+		array(
+			'path'           => 'assets/logo.png',
+			'content_base64' => base64_encode( "\x89PNG\r\n\x1a\nbundle" ),
+			'encoding'       => 'base64',
+			'kind'           => 'image',
+		),
+		array(
+			'path'      => 'index.html',
+			'content'   => '<main>Normalized</main>',
+			'mime_type' => 'text/html',
+			'kind'      => 'html',
+		),
+	),
+);
+$normalized_browser_bundle       = is_array( $normalize_browser_bundle_ability ) ? call_user_func( $normalize_browser_bundle_ability['execute_callback'], $browser_bundle_input ) : new WP_Error( 'missing_ability', 'normalize-browser-artifact-bundle missing.' );
+$normalized_browser_bundle_again = is_array( $normalize_browser_bundle_ability ) ? call_user_func( $normalize_browser_bundle_ability['execute_callback'], $browser_bundle_input ) : null;
+$assert( 'normalize-browser-artifact-bundle returns caller-owned schema envelope', ! is_wp_error( $normalized_browser_bundle ) && true === ( $normalized_browser_bundle['success'] ?? false ) && 'wp-codebox/browser-artifact-bundle-normalization/v1' === ( $normalized_browser_bundle['schema'] ?? '' ) && 'caller/browser-bundle/v1' === ( $normalized_browser_bundle['caller_schema'] ?? '' ) );
+$assert( 'normalize-browser-artifact-bundle scopes root and entrypoint', ! is_wp_error( $normalized_browser_bundle ) && 'site' === ( $normalized_browser_bundle['root'] ?? '' ) && 'site/index.html' === ( $normalized_browser_bundle['entrypoint'] ?? '' ) );
+$assert( 'normalize-browser-artifact-bundle supports mixed text and base64 files', ! is_wp_error( $normalized_browser_bundle ) && 'site/assets/logo.png' === ( $normalized_browser_bundle['files'][1]['path'] ?? '' ) && 'base64' === ( $normalized_browser_bundle['files'][1]['encoding'] ?? '' ) && hash( 'sha256', "\x89PNG\r\n\x1a\nbundle" ) === ( $normalized_browser_bundle['files'][1]['sha256'] ?? '' ) && 'site/index.html' === ( $normalized_browser_bundle['files'][2]['path'] ?? '' ) && '<main>Normalized</main>' === ( $normalized_browser_bundle['files'][2]['content'] ?? '' ) );
+$assert( 'normalize-browser-artifact-bundle preserves opaque roles', ! is_wp_error( $normalized_browser_bundle ) && array( 'assets' => array( 'assets/logo.png' ), 'preview' => 'index.html' ) === ( $normalized_browser_bundle['roles'] ?? array() ) && array( 'style' ) === ( $normalized_browser_bundle['files'][0]['roles'] ?? array() ) );
+$assert( 'normalize-browser-artifact-bundle output is stable', ! is_wp_error( $normalized_browser_bundle ) && $normalized_browser_bundle === $normalized_browser_bundle_again );
+$normalized_browser_invalid_path = is_array( $normalize_browser_bundle_ability ) ? call_user_func( $normalize_browser_bundle_ability['execute_callback'], array_merge( $browser_bundle_input, array( 'files' => array( array( 'path' => '/escape.html', 'content' => 'nope' ) ) ) ) ) : null;
+$assert( 'normalize-browser-artifact-bundle rejects invalid paths', is_wp_error( $normalized_browser_invalid_path ) && 'wp_codebox_browser_artifact_path_invalid' === $normalized_browser_invalid_path->get_error_code() );
+$normalized_browser_missing_entrypoint = is_array( $normalize_browser_bundle_ability ) ? call_user_func( $normalize_browser_bundle_ability['execute_callback'], array_merge( $browser_bundle_input, array( 'entrypoint' => 'missing.html' ) ) ) : null;
+$assert( 'normalize-browser-artifact-bundle rejects missing entrypoint', is_wp_error( $normalized_browser_missing_entrypoint ) && 'wp_codebox_browser_artifact_entrypoint_missing' === $normalized_browser_missing_entrypoint->get_error_code() );
+$normalized_browser_duplicate = is_array( $normalize_browser_bundle_ability ) ? call_user_func( $normalize_browser_bundle_ability['execute_callback'], array_merge( $browser_bundle_input, array( 'files' => array( array( 'path' => 'index.html', 'content' => 'one' ), array( 'path' => 'site/index.html', 'content' => 'two' ) ) ) ) ) : null;
+$assert( 'normalize-browser-artifact-bundle rejects duplicate files', is_wp_error( $normalized_browser_duplicate ) && 'wp_codebox_browser_artifact_path_duplicate' === $normalized_browser_duplicate->get_error_code() );
+
 $persist_browser_artifact_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/persist-browser-artifact'] ?? null;
 $persisted_browser_artifact       = is_array( $persist_browser_artifact_ability ) ? call_user_func(
 	$persist_browser_artifact_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Adds a caller-owned browser artifact bundle normalization ability for schema/root/entrypoint/files/roles/provenance.
- Reuses the normalized bundle primitive in browser artifact persistence while preserving persisted file order.
- Covers invalid paths, missing entrypoints, duplicate files, mixed text/base64 content, role passthrough, and stable output in the WordPress plugin smoke test.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementation and tests for the browser artifact bundle normalization primitive; Chris remains responsible for review and acceptance.

Closes #453.