### PR TITLE
Authorize trusted browser session callers

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -11,6 +11,7 @@ final class WP_Codebox_Abilities {
 
 	private const BROWSER_ARTIFACT_MAX_BYTES = 5242880;
 	private const BROWSER_CAPTURE_MAX_BYTES  = 262144;
+	private const BROWSER_SESSION_CREATE_SCOPE = 'browser-session:create';
 
 	private static bool $registered = false;
 
@@ -340,6 +341,7 @@ final class WP_Codebox_Abilities {
 							),
 							'sandbox_session_id' => $session_input['sandbox_session_id'],
 							'orchestrator'       => $session_input['orchestrator'],
+							'authorization'      => self::browser_session_authorization_schema(),
 							'playground'         => array(
 								'type'        => 'object',
 								'description' => 'Optional browser Playground client and artifact preview configuration overrides.',
@@ -442,7 +444,7 @@ final class WP_Codebox_Abilities {
 					),
 					'output_schema'       => $browser_session_schema,
 					'execute_callback'    => array( self::class, 'create_browser_playground_session' ),
-					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'permission_callback' => array( self::class, 'can_create_browser_playground_session' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -980,6 +982,7 @@ final class WP_Codebox_Abilities {
 				),
 				'agent_session_id' => array( 'type' => 'string' ),
 				'orchestrator'     => array( 'type' => 'object' ),
+				'authorization'    => array( 'type' => 'object' ),
 				'artifacts'        => array( 'type' => 'object' ),
 			),
 		);
@@ -1020,6 +1023,29 @@ final class WP_Codebox_Abilities {
 				'recipe'     => array( 'type' => 'object' ),
 				'signals'    => array( 'type' => 'object' ),
 				'artifacts'  => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function browser_session_authorization_schema(): array {
+		return array(
+			'type'        => 'object',
+			'description' => 'Explicit trusted orchestrator authorization for browser session creation. Callers must provide a caller id and the browser-session:create scope; sites grant trust through wp_codebox_trusted_browser_session_callers.',
+			'properties'  => array(
+				'schema' => array(
+					'type'        => 'string',
+					'description' => 'Authorization contract version. Use wp-codebox/trusted-orchestrator-authorization/v1.',
+				),
+				'caller' => array(
+					'type'        => 'string',
+					'description' => 'Stable caller id, for example studio-web.',
+				),
+				'scope'  => array(
+					'type'        => 'string',
+					'enum'        => array( self::BROWSER_SESSION_CREATE_SCOPE ),
+					'description' => 'Required capability scope for creating a browser Playground session.',
+				),
 			),
 		);
 	}
@@ -1214,6 +1240,10 @@ final class WP_Codebox_Abilities {
 		$session = WP_Codebox_Agent_Task::session( $session_id, $status, $input );
 		$session['execution_scope']  = 'disposable-playground';
 		$session['permission_model'] = 'sandbox-bypass';
+		$authorization               = self::browser_session_authorization( $input );
+		if ( ! empty( $authorization['caller'] ) || ! empty( $authorization['scope'] ) ) {
+			$session['authorization'] = $authorization;
+		}
 
 		return $session;
 	}
@@ -1336,6 +1366,119 @@ final class WP_Codebox_Abilities {
 		$allowed = current_user_can( 'manage_options' );
 
 		return (bool) apply_filters( 'wp_codebox_can_run_agent_task', $allowed );
+	}
+
+	/** @param mixed $input Ability input or request-like object. */
+	public static function can_create_browser_playground_session( mixed $input = null ): bool {
+		$allowed          = current_user_can( 'manage_options' );
+		$filtered_allowed = (bool) apply_filters( 'wp_codebox_can_run_agent_task', $allowed );
+		if ( $filtered_allowed ) {
+			return true;
+		}
+
+		if ( $allowed ) {
+			return false;
+		}
+
+		$input = self::permission_input_array( $input );
+		if ( empty( $input ) ) {
+			return false;
+		}
+
+		$authorization = self::browser_session_authorization( $input );
+
+		return true === ( $authorization['authorized'] ?? false );
+	}
+
+	/** @param mixed $input Ability input or request-like object. @return array<string,mixed> */
+	private static function permission_input_array( mixed $input ): array {
+		if ( is_array( $input ) ) {
+			return $input;
+		}
+
+		if ( is_object( $input ) && is_callable( array( $input, 'get_json_params' ) ) ) {
+			$params = $input->get_json_params();
+			return is_array( $params ) ? $params : array();
+		}
+
+		if ( is_object( $input ) && is_callable( array( $input, 'get_params' ) ) ) {
+			$params = $input->get_params();
+			return is_array( $params ) ? $params : array();
+		}
+
+		return array();
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private static function browser_session_authorization( array $input ): array {
+		$authorization = is_array( $input['authorization'] ?? null ) ? $input['authorization'] : array();
+		$caller        = trim( (string) ( $authorization['caller'] ?? '' ) );
+		$scope         = trim( (string) ( $authorization['scope'] ?? '' ) );
+		$result        = array_filter(
+			array(
+				'schema'     => 'wp-codebox/trusted-orchestrator-authorization/v1',
+				'caller'     => $caller,
+				'scope'      => $scope,
+				'authorized' => false,
+				'method'     => 'trusted-orchestrator',
+				'reason'     => 'missing-authorization',
+			),
+			static fn( mixed $value ): bool => '' !== $value
+		);
+
+		if ( '' === $caller ) {
+			return $result;
+		}
+
+		if ( self::BROWSER_SESSION_CREATE_SCOPE !== $scope ) {
+			$result['reason'] = 'missing-scope';
+			return $result;
+		}
+
+		/**
+		 * Filters trusted browser-session callers.
+		 *
+		 * Return either a map of caller ids to scopes, or a list of grant arrays:
+		 * [ 'studio-web' => [ 'browser-session:create' ] ]
+		 * [ [ 'caller' => 'studio-web', 'scopes' => [ 'browser-session:create' ] ] ]
+		 *
+		 * @param array<int|string,mixed> $trusted_callers Trusted caller grants.
+		 * @param array<string,mixed>     $authorization   Explicit caller authorization payload.
+		 * @param array<string,mixed>     $input           Ability input.
+		 */
+		$trusted_callers = apply_filters( 'wp_codebox_trusted_browser_session_callers', array(), $authorization, $input );
+		$trusted_callers = is_array( $trusted_callers ) ? $trusted_callers : array();
+
+		if ( self::trusted_browser_session_caller_has_scope( $trusted_callers, $caller, $scope ) ) {
+			$result['authorized'] = true;
+			$result['reason']     = 'trusted-caller-grant';
+			return $result;
+		}
+
+		$result['reason'] = 'caller-not-trusted';
+
+		return $result;
+	}
+
+	/** @param array<int|string,mixed> $trusted_callers Trusted caller grants. */
+	private static function trusted_browser_session_caller_has_scope( array $trusted_callers, string $caller, string $scope ): bool {
+		foreach ( $trusted_callers as $key => $grant ) {
+			if ( is_string( $key ) && $caller === $key ) {
+				$scopes = is_array( $grant ) ? $grant : array( $grant );
+				return in_array( $scope, array_map( 'strval', $scopes ), true );
+			}
+
+			if ( ! is_array( $grant ) || $caller !== (string) ( $grant['caller'] ?? '' ) ) {
+				continue;
+			}
+
+			$scopes = is_array( $grant['scopes'] ?? null ) ? $grant['scopes'] : array( $grant['scope'] ?? '' );
+			if ( in_array( $scope, array_map( 'strval', $scopes ), true ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -112,7 +112,7 @@ function do_action( string $hook ): void {
 }
 function add_filter( string $hook, callable $callback, int $priority = 10 ): void { $GLOBALS['wp_codebox_filters'][ $hook ] = $callback; }
 function has_filter( string $hook ): bool { return array_key_exists( $hook, $GLOBALS['wp_codebox_filters'] ); }
-function current_user_can( string $capability ): bool { return 'manage_options' === $capability; }
+function current_user_can( string $capability ): bool { return 'manage_options' === $capability && ( $GLOBALS['wp_codebox_current_user_can_manage_options'] ?? true ); }
 function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 	if ( ! array_key_exists( $hook, $GLOBALS['wp_codebox_filters'] ) ) {
 		return $value;
@@ -355,9 +355,25 @@ $assert( 'browser Playground session accepts goal or legacy task', array( 'goal'
 $assert( 'browser Playground session exposes artifact file schema', 'array' === ( $browser_session_ability['input_schema']['properties']['artifact_files']['type'] ?? '' ) );
 $assert( 'browser Playground session exposes site blueprint artifact schema', 'object' === ( $browser_session_ability['input_schema']['properties']['site_blueprint_artifact']['type'] ?? '' ) && 'object' === ( $browser_session_ability['input_schema']['properties']['site_blueprint_artifact']['properties']['blueprint']['type'] ?? '' ) );
 $assert( 'browser Playground session declares site blueprint artifact output', 'object' === ( $browser_session_ability['output_schema']['properties']['site_blueprint_artifact']['type'] ?? '' ) );
+$assert( 'browser Playground session exposes explicit trusted orchestrator authorization schema', 'object' === ( $browser_session_ability['input_schema']['properties']['authorization']['type'] ?? '' ) && array( 'browser-session:create' ) === ( $browser_session_ability['input_schema']['properties']['authorization']['properties']['scope']['enum'] ?? array() ) );
 $assert( 'browser Playground session output declares browser execution', array( 'browser-playground' ) === ( $browser_session_ability['output_schema']['properties']['execution']['enum'] ?? array() ) );
 $assert( 'browser Playground session exposes generic sandbox invocation schema', array( 'ability', 'task' ) === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['invocation']['properties']['type']['enum'] ?? array() ) && 'string' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['invocation']['properties']['hook']['type'] ?? '' ) );
 $assert( 'browser Playground session exposes generic capture path schema', 'array' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['capture_paths']['type'] ?? '' ) && 'integer' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['capture_paths']['items']['properties']['max_bytes']['type'] ?? '' ) && 'object' === ( $browser_session_ability['output_schema']['properties']['materialization']['type'] ?? '' ) );
+
+$trusted_browser_authorization = array(
+	'authorization' => array(
+		'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
+		'caller' => 'studio-web',
+		'scope'  => 'browser-session:create',
+	),
+);
+$GLOBALS['wp_codebox_filters']['wp_codebox_trusted_browser_session_callers'] = array( 'studio-web' => array( 'browser-session:create' ) );
+$GLOBALS['wp_codebox_current_user_can_manage_options'] = false;
+$assert( 'browser Playground session keeps default protection for untrusted users', false === call_user_func( $browser_session_ability['permission_callback'], array( 'goal' => 'Denied without trusted caller.' ) ) );
+$assert( 'browser Playground session allows trusted orchestrator caller with browser-session scope', true === call_user_func( $browser_session_ability['permission_callback'], $trusted_browser_authorization ) );
+$assert( 'browser Playground session denies untrusted orchestrator caller', false === call_user_func( $browser_session_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'unknown-product', 'scope' => 'browser-session:create' ) ) ) );
+$assert( 'browser Playground session denies trusted caller without browser-session scope', false === call_user_func( $browser_session_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
+$GLOBALS['wp_codebox_current_user_can_manage_options'] = true;
 
 $artifact_abilities = array(
 	'wp-codebox/list-artifacts',
@@ -431,6 +447,11 @@ $browser_session = call_user_func(
 		'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
 		'inherit'               => array( 'connectors' => array( 'openai' ) ),
 		'orchestrator'          => array( 'id' => 'example-orchestrator' ),
+		'authorization'         => array(
+			'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
+			'caller' => 'studio-web',
+			'scope'  => 'browser-session:create',
+		),
 		'browser_plugins'       => array(
 			array(
 				'slug'   => 'agents-api',
@@ -559,6 +580,7 @@ $assert( 'browser Playground session pins browser execution', ! is_wp_error( $br
 $assert( 'browser Playground session identifies disposable execution scope', ! is_wp_error( $browser_session ) && 'disposable-playground' === ( $browser_session['execution_scope'] ?? '' ) && 'disposable-playground' === ( $browser_session['session']['execution_scope'] ?? '' ) );
 $assert( 'browser Playground session identifies sandbox permission model', ! is_wp_error( $browser_session ) && 'sandbox-bypass' === ( $browser_session['permission_model'] ?? '' ) && 'sandbox-bypass' === ( $browser_session['session']['permission_model'] ?? '' ) );
 $assert( 'browser Playground session emits canonical sandbox session envelope', ! is_wp_error( $browser_session ) && 'wp-codebox/sandbox-session/v1' === ( $browser_session['session']['schema'] ?? '' ) && 'browser-session-123' === ( $browser_session['session']['id'] ?? '' ) && 'ready' === ( $browser_session['session']['status'] ?? '' ) && 'external-orchestrator' === ( $browser_session['session']['persistence'] ?? '' ) );
+$assert( 'browser Playground session returns trusted authorization provenance in session envelope', ! is_wp_error( $browser_session ) && 'studio-web' === ( $browser_session['session']['authorization']['caller'] ?? '' ) && 'browser-session:create' === ( $browser_session['session']['authorization']['scope'] ?? '' ) && true === ( $browser_session['session']['authorization']['authorized'] ?? false ) && 'trusted-caller-grant' === ( $browser_session['session']['authorization']['reason'] ?? '' ) );
 $assert( 'browser Playground session includes Playground client URLs', ! is_wp_error( $browser_session ) && str_contains( $browser_session['playground']['client_module_url'] ?? '', 'playground.automattic.ai' ) && str_contains( $browser_session['playground']['remote_url'] ?? '', 'playground.automattic.ai' ) );
 $assert( 'browser Playground session includes Playground CORS proxy URL', ! is_wp_error( $browser_session ) && 'https://wordpress-playground-cors-proxy.net/?' === ( $browser_session['playground']['cors_proxy_url'] ?? '' ) && 'https://wordpress-playground-cors-proxy.net' === ( $browser_session['playground']['provenance']['cors_proxy_url']['origin'] ?? '' ) );
 $assert( 'browser Playground session includes default blueprint', ! is_wp_error( $browser_session ) && true === ( $browser_session['playground']['blueprint']['features']['networking'] ?? false ) && is_array( $browser_session['playground']['blueprint']['steps'] ?? null ) );


### PR DESCRIPTION
## Summary
- Add a browser-session-specific authorization contract for trusted orchestrator callers using explicit caller + scope input.
- Keep the existing default `manage_options` / `wp_codebox_can_run_agent_task` protection intact while allowing scoped browser session grants through `wp_codebox_trusted_browser_session_callers`.
- Return authorization provenance in the browser session envelope and cover allowed, denied, missing-scope, default-deny, and provenance behavior in smoke tests.

## Tests
- `npm run build`
- `npm run wordpress-plugin-smoke`

## Issue
Refs https://github.com/chubes4/wp-codebox/issues/456

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementation and tests for the trusted browser session authorization contract; Chris remains responsible for review and merge.