### PR TITLE
Fix browser evidence capture on partial failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "headless-browser-agent-recipe-smoke": "tsx scripts/headless-browser-agent-recipe-smoke.ts",
     "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",
     "browser-actions-artifact-smoke": "tsx scripts/browser-actions-artifact-smoke.ts",
+    "browser-html-capture-smoke": "tsx scripts/browser-html-capture-smoke.ts",
     "browser-review-bridge-smoke": "tsx scripts/browser-review-bridge-smoke.ts",
     "browser-interaction-script-validation-smoke": "tsx scripts/browser-interaction-script-validation-smoke.ts",
     "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -179,6 +179,21 @@ export const commandRegistry = [
     handler: { kind: "playground", method: "runBrowserProbe" },
   },
   {
+    id: "wordpress.capture-html",
+    description: "Open the live Playground preview in Playwright and capture rendered HTML plus generic browser diagnostics as Codebox artifact refs.",
+    acceptedArgs: [
+      { name: "url", description: "Preview path or absolute URL to visit.", required: true, format: "path or URL" },
+      { name: "wait-for", description: "Navigation wait condition.", format: "domcontentloaded|load|networkidle|selector:<selector>|duration" },
+      { name: "duration", description: "Extra capture duration, or wait time when wait-for=duration.", format: "duration, e.g. 2s or 500ms" },
+      { name: "script", description: "Optional page-side JavaScript to evaluate after navigation and before final capture.", format: "JavaScript function body" },
+      { name: "capture", description: "Comma-separated artifacts to capture; defaults to html,console,errors,network.", format: "console,errors,html,network,performance,memory,screenshot" },
+    ],
+    outputShape: "JSON summary plus files/browser/snapshot.html, console.jsonl, errors.jsonl, network.jsonl, and summary.json by default; optional screenshot/performance/memory artifacts when requested.",
+    policyRequirement: "Runtime policy commands must include wordpress.capture-html.",
+    recipe: true,
+    handler: { kind: "playground", method: "runHtmlCapture" },
+  },
+  {
     id: "wordpress.browser-actions",
     description: "Drive the live Playground preview with an ordered interaction script and capture replay/audit evidence artifacts, including per-step results and machine-readable assertions.",
     acceptedArgs: [

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -13,12 +13,25 @@ import type { PlaygroundCliServer } from "./preview-server.js"
 const BROWSER_STEP_DEFAULT_TIMEOUT_MS = 15_000
 const BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS = 120_000
 
+export class BrowserCommandArtifactError extends Error {
+  constructor(message: string, readonly artifact: BrowserProbeArtifact) {
+    super(message)
+    this.name = "BrowserCommandArtifactError"
+  }
+}
+
+export function isBrowserCommandArtifactError(error: unknown): error is BrowserCommandArtifactError {
+  return error instanceof BrowserCommandArtifactError
+}
+
 export async function runBrowserProbeCommand({
   artifactRoot,
+  command = "wordpress.browser-probe",
   server,
   spec,
 }: {
   artifactRoot: string
+  command?: string
   server: PlaygroundCliServer
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
@@ -138,14 +151,22 @@ export async function runBrowserProbeCommand({
       }
 
       if (capture.has("html")) {
-        const html = await page.content()
-        await writeFile(htmlPath, html)
-        htmlSha256 = sha256(Buffer.from(html, "utf8"))
+        try {
+          const html = await page.content()
+          await writeFile(htmlPath, html)
+          htmlSha256 = sha256(Buffer.from(html, "utf8"))
+        } catch (error) {
+          errors.push(serializeBrowserError("probe-error", error))
+        }
       }
 
       if (capture.has("screenshot")) {
-        await page.screenshot({ path: screenshotPath, fullPage: true })
-        screenshotSha256 = await fileSha256(screenshotPath)
+        try {
+          await page.screenshot({ path: screenshotPath, fullPage: true })
+          screenshotSha256 = await fileSha256(screenshotPath)
+        } catch (error) {
+          errors.push(serializeBrowserError("probe-error", error))
+        }
       }
     }
     if (networkTasks.length > 0) {
@@ -222,13 +243,30 @@ export async function runBrowserProbeCommand({
   return {
     artifact,
     output: `${JSON.stringify({
-      command: "wordpress.browser-probe",
+      command,
       requestedUrl: targetUrl,
       finalUrl: artifact.summary.finalUrl ?? targetUrl,
       files: artifact.files,
       summary: artifact.summary,
     }, null, 2)}\n`,
   }
+}
+
+export async function runHtmlCaptureCommand(input: {
+  artifactRoot: string
+  server: PlaygroundCliServer
+  spec: ExecutionSpec
+}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+  const args = [...(input.spec.args ?? [])]
+  if (!args.some((arg) => arg.startsWith("capture="))) {
+    args.push("capture=html,console,errors,network")
+  }
+
+  return runBrowserProbeCommand({
+    ...input,
+    command: "wordpress.capture-html",
+    spec: { ...input.spec, args },
+  })
 }
 
 export async function runBrowserActionsCommand({
@@ -351,12 +389,13 @@ export async function runBrowserActionsCommand({
         if (outcome.screenshot && capture.has("screenshot") && outcome.screenshotIsDefault) {
           screenshotSha256 = await fileSha256(screenshotPath)
         }
-        stepRecords.push(browserStepRecord(index, step, "ok", recordStartedAt, recordStartedAtMs, finalUrl, outcome))
         // A failed expect/evaluate assertion is a clean step failure: no silent partial success.
         if (outcome.assertion && !outcome.assertion.passed) {
+          stepRecords.push(browserStepRecord(index, step, "failed", recordStartedAt, recordStartedAtMs, finalUrl, outcome))
           pendingError = new Error(`wordpress.browser-actions ${step.kind} assertion failed at step ${index}`)
           break
         }
+        stepRecords.push(browserStepRecord(index, step, "ok", recordStartedAt, recordStartedAtMs, finalUrl, outcome))
       } catch (error) {
         const serialized = serializeBrowserError("probe-error", error)
         errors.push(serialized)
@@ -367,14 +406,30 @@ export async function runBrowserActionsCommand({
     }
 
     if (capture.has("html")) {
-      const html = await page.content()
-      await writeFile(htmlPath, html)
-      htmlSha256 = sha256(Buffer.from(html, "utf8"))
+      try {
+        const html = await page.content()
+        await writeFile(htmlPath, html)
+        htmlSha256 = sha256(Buffer.from(html, "utf8"))
+      } catch (error) {
+        const serialized = serializeBrowserError("probe-error", error)
+        errors.push(serialized)
+        if (!pendingError) {
+          pendingError = error instanceof Error ? error : new Error(String(error))
+        }
+      }
     }
 
     if (capture.has("screenshot")) {
-      await page.screenshot({ path: screenshotPath, fullPage: true })
-      screenshotSha256 = await fileSha256(screenshotPath)
+      try {
+        await page.screenshot({ path: screenshotPath, fullPage: true })
+        screenshotSha256 = await fileSha256(screenshotPath)
+      } catch (error) {
+        const serialized = serializeBrowserError("probe-error", error)
+        errors.push(serialized)
+        if (!pendingError) {
+          pendingError = error instanceof Error ? error : new Error(String(error))
+        }
+      }
     }
   } finally {
     if (networkTasks.length > 0) {
@@ -443,7 +498,7 @@ export async function runBrowserActionsCommand({
   }
 
   if (pendingError) {
-    throw new Error(`wordpress.browser-actions failed after ${stepRecords.length} step(s): ${pendingError.message}`)
+    throw new BrowserCommandArtifactError(`wordpress.browser-actions failed after ${stepRecords.length} step(s): ${pendingError.message}`, artifact)
   }
 
   return {

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -13,6 +13,7 @@ interface PlaygroundCommandRuntime {
   runCorePhpunit(spec: ExecutionSpec): Promise<string>
   runThemeCheck(spec: ExecutionSpec): Promise<string>
   runBrowserProbe(spec: ExecutionSpec): Promise<string>
+  runHtmlCapture(spec: ExecutionSpec): Promise<string>
   runBrowserActions(spec: ExecutionSpec): Promise<string>
 }
 
@@ -28,6 +29,7 @@ const playgroundCommandHandlers = {
   "wordpress.core-phpunit": (runtime, spec) => runtime.runCorePhpunit(spec),
   "wordpress.theme-check": (runtime, spec) => runtime.runThemeCheck(spec),
   "wordpress.browser-probe": (runtime, spec) => runtime.runBrowserProbe(spec),
+  "wordpress.capture-html": (runtime, spec) => runtime.runHtmlCapture(spec),
   "wordpress.browser-actions": (runtime, spec) => runtime.runBrowserActions(spec),
 } satisfies Record<PlaygroundRuntimeCommandId, (runtime: PlaygroundCommandRuntime, spec: ExecutionSpec) => Promise<string>>
 

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -3,7 +3,7 @@ import { mkdir, realpath, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, createHostToolRegistry, runtimeEpisodeDigest } from "@chubes4/wp-codebox-core"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserProbeArtifact } from "./browser-artifacts.js"
-import { runBrowserActionsCommand, runBrowserProbeCommand } from "./browser-command-runners.js"
+import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runHtmlCaptureCommand } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
 import { cleanWpCliOutput, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
@@ -413,9 +413,24 @@ class PlaygroundRuntime implements Runtime {
     return result.output
   }
 
+  async runHtmlCapture(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const result = await runHtmlCaptureCommand({ artifactRoot: this.artifactRoot, server, spec })
+    this.browserProbes.push(result.artifact)
+    return result.output
+  }
+
   async runBrowserActions(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
-    const result = await runBrowserActionsCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, server, spec })
+    let result: Awaited<ReturnType<typeof runBrowserActionsCommand>>
+    try {
+      result = await runBrowserActionsCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, server, spec })
+    } catch (error) {
+      if (isBrowserCommandArtifactError(error)) {
+        this.browserProbes.push(error.artifact)
+      }
+      throw error
+    }
     this.browserProbes.push(result.artifact)
     return result.output
   }

--- a/scripts/browser-actions-artifact-smoke.ts
+++ b/scripts/browser-actions-artifact-smoke.ts
@@ -8,7 +8,9 @@ const repoRoot = resolve(import.meta.dirname, "..")
 const workspace = resolve(repoRoot, "artifacts", "browser-actions-artifact-smoke")
 const pluginDir = join(workspace, "browser-action-fixture")
 const recipePath = join(workspace, "recipe.json")
+const failingRecipePath = join(workspace, "failing-recipe.json")
 const artifactsRoot = join(workspace, "artifacts")
+const failingArtifactsRoot = join(workspace, "failing-artifacts")
 
 await rm(workspace, { recursive: true, force: true })
 await mkdir(pluginDir, { recursive: true })
@@ -69,7 +71,7 @@ const output = await runCli([
   "--recipe",
   recipePath,
   "--json",
-])
+], 0)
 
 assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
 assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
@@ -139,9 +141,92 @@ assert.equal(review.browser?.probes?.[0]?.summaryFile, "files/browser/action-sum
 assert.equal(review.browser?.probes?.[0]?.assertions?.total, 2)
 assert.equal(review.browser?.probes?.[0]?.assertions?.passed, 2)
 
+await writeFile(failingRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extraPlugins: [
+      {
+        source: "./browser-action-fixture",
+        pluginFile: "browser-action-fixture/browser-action-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.browser-actions",
+        args: [
+          "url=/",
+          `steps-json=${JSON.stringify([
+            { kind: "waitFor", selector: "#wp-codebox-button" },
+            { kind: "fill", selector: "#wp-codebox-name", value: "Failure" },
+            { kind: "expect", selector: "#wp-codebox-result", state: "visible" },
+          ])}`,
+          "capture=steps,console,errors,html,network",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: failingArtifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const failing = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  failingRecipePath,
+  "--json",
+], 1)
+
+assert.equal(failing.success, false, "failing browser action recipe should fail")
+assert.match(failing.error?.message ?? "", /wordpress\.browser-actions failed/)
+assert.ok(failing.artifacts?.directory, "failing recipe should still return an artifact directory")
+
+const failingArtifactDirectory = failing.artifacts.directory
+const failingStepsPath = join(failingArtifactDirectory, "files", "browser", "steps.jsonl")
+const failingHtmlPath = join(failingArtifactDirectory, "files", "browser", "snapshot.html")
+const failingErrorsPath = join(failingArtifactDirectory, "files", "browser", "errors.jsonl")
+const failingSummaryPath = join(failingArtifactDirectory, "files", "browser", "action-summary.json")
+const failingManifestPath = join(failingArtifactDirectory, "manifest.json")
+const failingReviewPath = join(failingArtifactDirectory, "files", "review.json")
+
+assert.equal(existsSync(failingStepsPath), true, "failed run should retain steps.jsonl")
+assert.equal(existsSync(failingHtmlPath), true, "failed run should retain snapshot.html")
+assert.equal(existsSync(failingErrorsPath), true, "failed run should retain errors.jsonl")
+assert.equal(existsSync(failingSummaryPath), true, "failed run should retain action-summary.json")
+
+const failingStepsLog = await readFile(failingStepsPath, "utf8")
+const failingHtmlSnapshot = await readFile(failingHtmlPath, "utf8")
+const failingSummary = JSON.parse(await readFile(failingSummaryPath, "utf8")) as {
+  schema: string
+  files: { steps?: string; html?: string; errors?: string; summary: string }
+  assertions?: { total: number; passed: number; failed: number; results: Array<{ kind: string; passed: boolean }> }
+  summary: { steps: number; htmlSnapshot: boolean; assertions?: { total: number; passed: number; failed: number } }
+}
+assert.match(failingStepsLog, /"status":"failed"/)
+assert.match(failingHtmlSnapshot, /wp-codebox-result/)
+assert.equal(failingSummary.schema, "wp-codebox/browser-actions/v1")
+assert.equal(failingSummary.files.steps, "files/browser/steps.jsonl")
+assert.equal(failingSummary.files.html, "files/browser/snapshot.html")
+assert.equal(failingSummary.assertions?.failed, 1)
+assert.equal(failingSummary.summary.htmlSnapshot, true)
+
+const failingManifest = JSON.parse(await readFile(failingManifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
+assert.ok(failingManifest.files.some((file) => file.path === "files/browser/steps.jsonl" && file.kind === "browser-steps"))
+assert.ok(failingManifest.files.some((file) => file.path === "files/browser/snapshot.html" && file.kind === "browser-html-snapshot"))
+
+const failingReview = JSON.parse(await readFile(failingReviewPath, "utf8")) as { browser?: { probes?: Array<{ steps?: string; html?: string; summaryFile?: string; assertions?: { failed: number } }> } }
+assert.equal(failingReview.browser?.probes?.[0]?.steps, "files/browser/steps.jsonl")
+assert.equal(failingReview.browser?.probes?.[0]?.html, "files/browser/snapshot.html")
+assert.equal(failingReview.browser?.probes?.[0]?.summaryFile, "files/browser/action-summary.json")
+assert.equal(failingReview.browser?.probes?.[0]?.assertions?.failed, 1)
+
 console.log(`Browser actions artifact smoke passed: ${artifactDirectory}`)
 
-async function runCli(args: string[]): Promise<any> {
+async function runCli(args: string[], expectedExitCode: number): Promise<any> {
   const child = spawn(process.execPath, args, {
     cwd: repoRoot,
     stdio: ["ignore", "pipe", "pipe"],
@@ -157,6 +242,6 @@ async function runCli(args: string[]): Promise<any> {
   })
 
   const exitCode = await new Promise<number | null>((resolveExit) => child.once("exit", (code) => resolveExit(code)))
-  assert.equal(exitCode, 0, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  assert.equal(exitCode, expectedExitCode, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
   return JSON.parse(stdout)
 }

--- a/scripts/browser-html-capture-smoke.ts
+++ b/scripts/browser-html-capture-smoke.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "browser-html-capture-smoke")
+const pluginDir = join(workspace, "html-capture-fixture")
+const recipePath = join(workspace, "recipe.json")
+const artifactsRoot = join(workspace, "artifacts")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(pluginDir, { recursive: true })
+
+await writeFile(join(pluginDir, "html-capture-fixture.php"), `<?php
+/**
+ * Plugin Name: HTML Capture Fixture
+ */
+add_action('wp_footer', function () {
+    echo '<main id="wp-codebox-html-capture"><h1>Captured by Codebox</h1><script>console.log("wp-codebox html capture ready");</script></main>';
+});
+`)
+
+await writeFile(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extraPlugins: [
+      {
+        source: "./html-capture-fixture",
+        pluginFile: "html-capture-fixture/html-capture-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.capture-html",
+        args: ["url=/"],
+      },
+    ],
+  },
+  artifacts: {
+    directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const output = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--json",
+], 0)
+
+assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
+assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+assert.equal(output.executions?.[0]?.command, "wordpress.capture-html")
+
+const artifactDirectory = output.artifacts.directory
+const htmlPath = join(artifactDirectory, "files", "browser", "snapshot.html")
+const consolePath = join(artifactDirectory, "files", "browser", "console.jsonl")
+const errorsPath = join(artifactDirectory, "files", "browser", "errors.jsonl")
+const networkPath = join(artifactDirectory, "files", "browser", "network.jsonl")
+const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
+const manifestPath = join(artifactDirectory, "manifest.json")
+const reviewPath = join(artifactDirectory, "files", "review.json")
+
+assert.equal(existsSync(htmlPath), true, "snapshot.html should be captured")
+assert.equal(existsSync(consolePath), true, "console.jsonl should be captured")
+assert.equal(existsSync(errorsPath), true, "errors.jsonl should be captured")
+assert.equal(existsSync(networkPath), true, "network.jsonl should be captured")
+assert.equal(existsSync(summaryPath), true, "summary.json should be captured")
+
+const htmlSnapshot = await readFile(htmlPath, "utf8")
+const consoleLog = await readFile(consolePath, "utf8")
+assert.match(htmlSnapshot, /Captured by Codebox/)
+assert.match(consoleLog, /wp-codebox html capture ready/)
+
+const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
+  schema: string
+  files: { html?: string; console?: string; errors?: string; network?: string; summary: string }
+  summary: { replayability: string; htmlSnapshot: boolean; screenshot: boolean }
+}
+assert.equal(summary.schema, "wp-codebox/browser-probe/v1")
+assert.equal(summary.files.html, "files/browser/snapshot.html")
+assert.equal(summary.files.summary, "files/browser/summary.json")
+assert.equal(summary.summary.replayability, "partial")
+assert.equal(summary.summary.htmlSnapshot, true)
+assert.equal(summary.summary.screenshot, false)
+
+const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
+assert.ok(manifest.files.some((file) => file.path === "files/browser/snapshot.html" && file.kind === "browser-html-snapshot"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/summary.json" && file.kind === "browser-summary"))
+
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ html?: string; summaryFile?: string }> } }
+assert.equal(review.browser?.probes?.[0]?.html, "files/browser/snapshot.html")
+assert.equal(review.browser?.probes?.[0]?.summaryFile, "files/browser/summary.json")
+
+console.log(`Browser HTML capture smoke passed: ${artifactDirectory}`)
+
+async function runCli(args: string[], expectedExitCode: number): Promise<any> {
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const exitCode = await new Promise<number | null>((resolveExit) => child.once("exit", (code) => resolveExit(code)))
+  assert.equal(exitCode, expectedExitCode, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- Add a generic `wordpress.capture-html` runtime command that captures rendered HTML through Codebox browser artifact storage instead of caller-created refs.
- Preserve browser-action artifacts when a partial interaction fails, including failed assertion step records, summary files, HTML snapshots, errors, and review/manifest entries.
- Harden final HTML/screenshot capture so capture errors are serialized into browser diagnostics where possible.

Closes #458.

## Verification
- `npm run build`
- `npm run browser-html-capture-smoke`
- `npm run browser-actions-artifact-smoke`
- `npm run command-registry-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the browser capture/runtime command changes and focused smoke coverage; Chris remains responsible for review and merge.