### PR TITLE
Add artifact reference normalization helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "artifact-bundle-verifier-smoke": "tsx scripts/artifact-bundle-verifier-smoke.ts",
     "artifact-redaction-smoke": "tsx scripts/artifact-redaction-smoke.ts",
     "artifact-patch-git-apply-smoke": "tsx scripts/artifact-patch-git-apply-smoke.ts",
+    "artifact-reference-normalization-smoke": "tsx scripts/artifact-reference-normalization-smoke.ts",
     "mounted-workspace-diff-smoke": "tsx scripts/mounted-workspace-diff-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",

--- a/packages/runtime-core/src/artifact-references.ts
+++ b/packages/runtime-core/src/artifact-references.ts
@@ -1,0 +1,189 @@
+import type { ArtifactBundle, RuntimeEpisodeContentDigest, RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
+import type { ArtifactFileDigest, ArtifactManifestFile } from "./artifact-manifest.js"
+import type { RuntimeReferenceManifestArtifactBundleRef, RuntimeReferenceManifestFileRef } from "./runtime-reference.js"
+
+export const RUNTIME_EPISODE_TRACE_ARTIFACT_PATH = "files/runtime-episode-trace.json" as const
+export const RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH = "files/runtime-episode.jsonl" as const
+export const RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH = "files/runtime-reference-manifest.json" as const
+export const RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH = "files/runtime-replay-index.json" as const
+export const ARTIFACT_MANIFEST_PATH = "manifest.json" as const
+
+export interface ArtifactReferenceDigestInput {
+  algorithm?: string
+  value?: string
+  sha256?: string | ArtifactReferenceDigestInput
+  digest?: string | ArtifactReferenceDigestInput
+  contentDigest?: string | ArtifactReferenceDigestInput
+}
+
+export interface ArtifactReferenceFileInput {
+  path?: string
+  kind?: string
+  contentType?: string
+  mime?: string
+  mimeType?: string
+  sha256?: string | ArtifactReferenceDigestInput
+  digest?: string | ArtifactReferenceDigestInput
+}
+
+export interface ArtifactReferenceTraceInput extends ArtifactReferenceFileInput {
+  id?: string
+  artifactId?: string
+}
+
+export interface NormalizeRuntimeEpisodeTraceRefDefaults {
+  kind?: RuntimeEpisodeTraceRef["kind"]
+  id?: string
+  artifactId?: string
+  path?: string
+  digest?: string | ArtifactReferenceDigestInput
+}
+
+export interface BrowserArtifactSummaryRef {
+  probeIndex: number
+  field: string
+  kind: string
+  path: string
+  contentType?: string
+}
+
+type BrowserArtifactProbeSummary = Record<string, unknown>
+
+const BROWSER_ARTIFACT_SUMMARY_FIELDS: Record<string, { kind: string; contentType?: string }> = {
+  actions: { kind: "browser-actions", contentType: "application/x-ndjson" },
+  checkpoints: { kind: "browser-checkpoints", contentType: "application/x-ndjson" },
+  console: { kind: "browser-console", contentType: "application/x-ndjson" },
+  errorsFile: { kind: "browser-errors", contentType: "application/x-ndjson" },
+  html: { kind: "browser-html-snapshot", contentType: "text/html; charset=utf-8" },
+  memory: { kind: "browser-memory", contentType: "application/json" },
+  network: { kind: "browser-network", contentType: "application/x-ndjson" },
+  performance: { kind: "browser-performance", contentType: "application/json" },
+  screenshot: { kind: "browser-screenshot", contentType: "image/png" },
+  steps: { kind: "browser-steps", contentType: "application/x-ndjson" },
+  summaryFile: { kind: "browser-summary", contentType: "application/json" },
+}
+
+export function normalizeArtifactDigest(input: string | ArtifactReferenceDigestInput | undefined): RuntimeEpisodeContentDigest | undefined {
+  if (typeof input === "string" && input.length > 0) {
+    return { algorithm: "sha256", value: input }
+  }
+
+  if (!input || typeof input !== "object") {
+    return undefined
+  }
+
+  if (input.algorithm === "sha256" && typeof input.value === "string" && input.value.length > 0) {
+    return { algorithm: "sha256", value: input.value }
+  }
+
+  return normalizeArtifactDigest(input.sha256)
+    ?? normalizeArtifactDigest(input.digest)
+    ?? normalizeArtifactDigest(input.contentDigest)
+}
+
+export function normalizeArtifactFileDigest(input: string | ArtifactReferenceDigestInput | undefined): ArtifactFileDigest | undefined {
+  return normalizeArtifactDigest(input)
+}
+
+export function normalizeArtifactContentType(input: ArtifactReferenceFileInput | undefined, fallback = "application/octet-stream"): string {
+  const contentType = input?.contentType ?? input?.mimeType ?? input?.mime
+  return typeof contentType === "string" && contentType.trim().length > 0 ? contentType : fallback
+}
+
+export function normalizeRuntimeReferenceManifestFileRef(input: ArtifactReferenceFileInput | ArtifactManifestFile): RuntimeReferenceManifestFileRef | undefined {
+  if (!input.path || !input.kind) {
+    return undefined
+  }
+
+  const sha256 = normalizeArtifactFileDigest(input.sha256 ?? ("digest" in input ? input.digest : undefined))
+  if (!sha256) {
+    return undefined
+  }
+
+  return {
+    path: input.path,
+    kind: input.kind,
+    contentType: normalizeArtifactContentType(input),
+    sha256,
+  }
+}
+
+export function normalizeRuntimeReferenceManifestFileRefs(inputs: Array<ArtifactReferenceFileInput | ArtifactManifestFile>): RuntimeReferenceManifestFileRef[] {
+  return inputs
+    .map((input) => normalizeRuntimeReferenceManifestFileRef(input))
+    .filter((ref): ref is RuntimeReferenceManifestFileRef => ref !== undefined)
+}
+
+export function normalizeRuntimeEpisodeTraceRef(input: ArtifactReferenceTraceInput, defaults: NormalizeRuntimeEpisodeTraceRefDefaults = {}): RuntimeEpisodeTraceRef | undefined {
+  const kind = input.kind ?? defaults.kind
+  const id = input.id ?? defaults.id ?? input.artifactId ?? defaults.artifactId ?? input.path ?? defaults.path
+  if (!kind || !id) {
+    return undefined
+  }
+
+  const digest = normalizeArtifactDigest(input.digest ?? input.sha256 ?? defaults.digest)
+  return stripUndefined({
+    kind,
+    id,
+    artifactId: input.artifactId ?? defaults.artifactId,
+    path: input.path ?? defaults.path,
+    digest,
+  })
+}
+
+export function normalizeRuntimeEpisodeTraceRefs(inputs: ArtifactReferenceTraceInput[], defaults: NormalizeRuntimeEpisodeTraceRefDefaults = {}): RuntimeEpisodeTraceRef[] {
+  return inputs
+    .map((input) => normalizeRuntimeEpisodeTraceRef(input, defaults))
+    .filter((ref): ref is RuntimeEpisodeTraceRef => ref !== undefined)
+}
+
+export function normalizeObservationArtifactRefs(input: { artifactRefs?: ArtifactReferenceTraceInput[] } | ArtifactReferenceTraceInput[] | undefined): RuntimeEpisodeTraceRef[] {
+  const refs = Array.isArray(input) ? input : input?.artifactRefs
+  return normalizeRuntimeEpisodeTraceRefs(refs ?? [])
+}
+
+export function normalizeArtifactBundleTraceRef(bundle: Pick<ArtifactBundle, "id" | "directory" | "contentDigest"> | undefined): RuntimeEpisodeTraceRef | undefined {
+  if (!bundle) {
+    return undefined
+  }
+
+  return normalizeRuntimeEpisodeTraceRef({
+    kind: "artifact-bundle",
+    id: bundle.id,
+    artifactId: bundle.id,
+    path: bundle.directory,
+    digest: bundle.contentDigest,
+  })
+}
+
+export function normalizeRuntimeReferenceArtifactBundleRef(input: { id?: string; digest?: string | ArtifactReferenceDigestInput; contentDigest?: string | ArtifactReferenceDigestInput } | Pick<ArtifactBundle, "id" | "contentDigest">): RuntimeReferenceManifestArtifactBundleRef | undefined {
+  if (!input.id) {
+    return undefined
+  }
+
+  const digest = normalizeArtifactFileDigest("contentDigest" in input ? input.contentDigest : input.digest)
+  if (!digest) {
+    return undefined
+  }
+
+  return { kind: "artifact-bundle", id: input.id, digest }
+}
+
+export function normalizeBrowserArtifactSummaryRefs(summary: { probes?: BrowserArtifactProbeSummary[] } | undefined): BrowserArtifactSummaryRef[] {
+  const probes = Array.isArray(summary?.probes) ? summary.probes : []
+  const refs: BrowserArtifactSummaryRef[] = []
+  for (const [probeIndex, probe] of probes.entries()) {
+    for (const [field, metadata] of Object.entries(BROWSER_ARTIFACT_SUMMARY_FIELDS)) {
+      const path = probe[field]
+      if (typeof path === "string" && path.length > 0) {
+        refs.push(stripUndefined({ probeIndex, field, path, kind: metadata.kind, contentType: metadata.contentType }))
+      }
+    }
+  }
+
+  return refs
+}
+
+function stripUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T
+}

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,6 +1,7 @@
 import type { ArtifactPreview, ArtifactProvenance } from "./runtime-contracts.js"
 
 export * from "./artifact-manifest.js"
+export * from "./artifact-references.js"
 export * from "./runtime-contracts.js"
 export * from "./runtime-policy.js"
 export * from "./workspace-policy.js"

--- a/packages/runtime-core/src/run-registry.ts
+++ b/packages/runtime-core/src/run-registry.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import type { ArtifactBundle, ArtifactPreview, RuntimeInfo } from "./runtime-contracts.js"
+import { normalizeArtifactDigest } from "./artifact-references.js"
 import { stripUndefined } from "./object-utils.js"
 
 export type RuntimeRunStatus = "queued" | "booting" | "running" | "collecting_artifacts" | "succeeded" | "failed" | "timed_out" | "cancelled"
@@ -161,7 +162,7 @@ export function artifactBundleRunRef(bundle: ArtifactBundle | undefined): Runtim
       kind: "artifact-bundle" as const,
       directory: bundle.directory,
       id: bundle.id,
-      digest: bundle.contentDigest ? { algorithm: "sha256" as const, value: bundle.contentDigest } : undefined,
+      digest: normalizeArtifactDigest(bundle.contentDigest),
     }),
   ]
 }

--- a/packages/runtime-core/src/runtime-episode.ts
+++ b/packages/runtime-core/src/runtime-episode.ts
@@ -4,6 +4,14 @@ import { join } from "node:path"
 
 import { artifactFileDigest, artifactManifestFile, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles } from "./artifact-manifest.js"
 import type { ArtifactManifest, ArtifactSpec } from "./artifact-manifest.js"
+import {
+  RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH,
+  RUNTIME_EPISODE_TRACE_ARTIFACT_PATH,
+  RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
+  normalizeArtifactBundleTraceRef,
+  normalizeRuntimeReferenceArtifactBundleRef,
+  normalizeRuntimeReferenceManifestFileRefs,
+} from "./artifact-references.js"
 import { isPlainObject as isRecord } from "./object-utils.js"
 import {
   RUNTIME_EPISODE_ACTION_SCHEMA,
@@ -244,9 +252,9 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     const artifacts = await this.assertRuntime().collectArtifacts(spec)
     this.artifacts = {
       ...artifacts,
-      runtimeEpisodeTracePath: join(artifacts.directory, "files/runtime-episode-trace.json"),
-      runtimeEpisodeEventsPath: join(artifacts.directory, "files/runtime-episode.jsonl"),
-      runtimeReplayReferenceIndexPath: join(artifacts.directory, "files/runtime-replay-index.json"),
+      runtimeEpisodeTracePath: join(artifacts.directory, RUNTIME_EPISODE_TRACE_ARTIFACT_PATH),
+      runtimeEpisodeEventsPath: join(artifacts.directory, RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH),
+      runtimeReplayReferenceIndexPath: join(artifacts.directory, RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH),
     }
     if (spec.includeRuntimeSnapshotBundles) {
       await this.persistRuntimeSnapshotBundles()
@@ -265,7 +273,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     await mkdir(snapshotDirectory, { recursive: true })
     const baseRefs = manifest.files
       .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
-      .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
+    const snapshotRefs = normalizeRuntimeReferenceManifestFileRefs(baseRefs)
 
     for (const [index, snapshot] of this.snapshots.entries()) {
       const semantics = snapshot.semantics === "replayable-runtime-state" || snapshot.semantics === "runtime-state-artifact"
@@ -295,7 +303,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
             "Use files/runtime-episode-trace.json and files/runtime-episode.jsonl to inspect actions, observations, and snapshot refs after the episode trace is persisted.",
           ],
         },
-        refs: baseRefs,
+        refs: snapshotRefs,
       }
       await writeFile(join(this.artifacts.directory, relativePath), `${JSON.stringify(bundle, null, 2)}\n`)
       const digest = artifactFileDigest(await readFile(join(this.artifacts.directory, relativePath)))
@@ -326,8 +334,8 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     }
 
     const trace = await this.trace()
-    const traceRelativePath = "files/runtime-episode-trace.json"
-    const eventsRelativePath = "files/runtime-episode.jsonl"
+    const traceRelativePath = RUNTIME_EPISODE_TRACE_ARTIFACT_PATH
+    const eventsRelativePath = RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH
     await writeFile(this.artifacts.runtimeEpisodeTracePath, `${JSON.stringify(trace, null, 2)}\n`)
     await writeFile(this.artifacts.runtimeEpisodeEventsPath, `${runtimeEpisodeJsonLines(trace)}`)
     await this.updateArtifactMetadataForRuntimeEpisodeTrace(traceRelativePath, eventsRelativePath)
@@ -345,18 +353,18 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
     const fileRefs = manifest.files
       .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
-      .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
-    const traceRef = fileRefs.find((file) => file.path === traceRelativePath)
-    const eventsRef = fileRefs.find((file) => file.path === eventsRelativePath)
+    const referenceFiles = normalizeRuntimeReferenceManifestFileRefs(fileRefs)
+    const traceRef = referenceFiles.find((file) => file.path === traceRelativePath)
+    const eventsRef = referenceFiles.find((file) => file.path === eventsRelativePath)
+    const artifactBundle = normalizeRuntimeReferenceArtifactBundleRef(manifest)
+    if (!artifactBundle) {
+      return
+    }
     const referenceManifest = buildRuntimeReferenceManifest({
       createdAt: this.artifacts.createdAt,
       runtime: manifest.runtime,
-      artifactBundle: {
-        kind: "artifact-bundle",
-        id: manifest.id,
-        digest: { algorithm: "sha256", value: manifest.contentDigest.value },
-      },
-      files: fileRefs,
+      artifactBundle,
+      files: referenceFiles,
       ...(traceRef ? { trace: traceRef } : {}),
       ...(eventsRef ? { events: eventsRef } : {}),
       snapshots: this.snapshots,
@@ -374,19 +382,19 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
     const fileRefs = manifest.files
       .filter((file) => file.path !== "manifest.json")
-      .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
-    const traceRef = fileRefs.find((file) => file.path === traceRelativePath)
-    const eventsRef = fileRefs.find((file) => file.path === eventsRelativePath)
-    const runtimeReferenceManifestRef = fileRefs.find((file) => file.path === "files/runtime-reference-manifest.json")
+    const referenceFiles = normalizeRuntimeReferenceManifestFileRefs(fileRefs)
+    const traceRef = referenceFiles.find((file) => file.path === traceRelativePath)
+    const eventsRef = referenceFiles.find((file) => file.path === eventsRelativePath)
+    const runtimeReferenceManifestRef = referenceFiles.find((file) => file.path === "files/runtime-reference-manifest.json")
+    const artifactBundle = normalizeRuntimeReferenceArtifactBundleRef(manifest)
+    if (!artifactBundle) {
+      return
+    }
     const replayIndex = buildRuntimeReplayReferenceIndex({
       createdAt: this.artifacts.createdAt,
       runtime: manifest.runtime,
-      artifactBundle: {
-        kind: "artifact-bundle",
-        id: manifest.id,
-        digest: { algorithm: "sha256", value: manifest.contentDigest.value },
-      },
-      files: fileRefs,
+      artifactBundle,
+      files: referenceFiles,
       ...(traceRef ? { trace: traceRef } : {}),
       ...(eventsRef ? { events: eventsRef } : {}),
       ...(runtimeReferenceManifestRef ? { runtimeReferenceManifest: runtimeReferenceManifestRef } : {}),
@@ -407,7 +415,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     upsertArtifactManifestFiles(manifest, [
       artifactManifestFile(traceRelativePath, "runtime-episode-trace", "application/json"),
       artifactManifestFile(eventsRelativePath, "runtime-episode-events", "application/x-ndjson"),
-      artifactManifestFile("files/runtime-replay-index.json", "runtime-replay-index", "application/json"),
+      artifactManifestFile(RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH, "runtime-replay-index", "application/json"),
     ])
     await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
     await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
@@ -423,7 +431,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       ...(isRecord(metadata.artifacts) ? metadata.artifacts : {}),
       runtimeEpisodeTrace: traceRelativePath,
       runtimeEpisodeEvents: eventsRelativePath,
-      runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
+      runtimeReplayReferenceIndex: RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
     }
     await writeFile(this.artifacts.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`)
   }
@@ -435,7 +443,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
 
     const review = JSON.parse(await readFile(this.artifacts.reviewPath, "utf8")) as ArtifactReview
     review.evidence.runtimeEpisodeTrace = traceRelativePath
-    review.evidence.runtimeReplayReferenceIndex = "files/runtime-replay-index.json"
+    review.evidence.runtimeReplayReferenceIndex = RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH
     if (!review.progress.some((event) => event.type === "artifact" && event.component === "runtime-episode")) {
       review.progress.push({
         type: "artifact",
@@ -455,15 +463,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       observations: [],
       observationRefs: [],
     }
-    const artifactRef = this.artifacts
-      ? {
-          kind: "artifact-bundle" as const,
-          id: this.artifacts.id,
-          artifactId: this.artifacts.id,
-          path: this.artifacts.directory,
-          digest: { algorithm: "sha256" as const, value: this.artifacts.contentDigest },
-        }
-      : undefined
+    const artifactRef = normalizeArtifactBundleTraceRef(this.artifacts)
 
     return {
       schema: RUNTIME_EPISODE_TRACE_SCHEMA,

--- a/packages/runtime-core/src/runtime-reference.ts
+++ b/packages/runtime-core/src/runtime-reference.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 
 import type { ArtifactFileDigest } from "./artifact-manifest.js"
+import { normalizeObservationArtifactRefs, normalizeRuntimeReferenceManifestFileRef } from "./artifact-references.js"
 import { stableJson } from "./object-utils.js"
 import type {
   ObservationResult,
@@ -242,7 +243,7 @@ function runtimeReplayObservationRefs(trace: RuntimeEpisodeTrace | undefined): R
     id: observation.id ?? `observation:${index}`,
     type: observation.type,
     ref: observationRef(observation, observation.id ?? `observation:${index}`),
-    artifactRefs: [...(observation.artifactRefs ?? [])],
+    artifactRefs: normalizeObservationArtifactRefs(observation),
   }))
 }
 
@@ -290,12 +291,7 @@ function runtimeReferenceManifestDigestPayload(manifest: RuntimeReferenceManifes
 }
 
 function runtimeReferenceManifestFileRef(file: RuntimeReferenceManifestFileRef): RuntimeReferenceManifestFileRef {
-  return {
-    path: file.path,
-    kind: file.kind,
-    contentType: file.contentType,
-    sha256: file.sha256,
-  }
+  return normalizeRuntimeReferenceManifestFileRef(file) ?? file
 }
 
 function runtimeReferenceManifestSnapshotRef(snapshot: Snapshot): RuntimeReferenceManifestSnapshotRef {
@@ -306,7 +302,7 @@ function runtimeReferenceManifestSnapshotRef(snapshot: Snapshot): RuntimeReferen
     semantics,
     digest: snapshot.digest ?? runtimeEpisodeDigest(runtimeEpisodeSnapshotDigestPayload({ ...snapshot, semantics })),
     replay: runtimeSnapshotReplaySemantics(semantics),
-    artifactRefs: [...(snapshot.artifactRefs ?? [])],
+    artifactRefs: normalizeObservationArtifactRefs(snapshot),
   }
 }
 

--- a/scripts/artifact-reference-normalization-smoke.ts
+++ b/scripts/artifact-reference-normalization-smoke.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict"
+import {
+  RUNTIME_EPISODE_TRACE_ARTIFACT_PATH,
+  normalizeArtifactBundleTraceRef,
+  normalizeArtifactContentType,
+  normalizeArtifactDigest,
+  normalizeBrowserArtifactSummaryRefs,
+  normalizeObservationArtifactRefs,
+  normalizeRuntimeEpisodeTraceRef,
+  normalizeRuntimeReferenceArtifactBundleRef,
+  normalizeRuntimeReferenceManifestFileRef,
+} from "@chubes4/wp-codebox-core"
+
+assert.deepEqual(normalizeArtifactDigest("a".repeat(64)), { algorithm: "sha256", value: "a".repeat(64) })
+assert.deepEqual(normalizeArtifactDigest({ sha256: "b".repeat(64) }), { algorithm: "sha256", value: "b".repeat(64) })
+assert.deepEqual(normalizeArtifactDigest({ digest: { algorithm: "sha256", value: "c".repeat(64) } }), { algorithm: "sha256", value: "c".repeat(64) })
+
+assert.equal(normalizeArtifactContentType({ mime: "text/plain" }), "text/plain")
+assert.equal(normalizeArtifactContentType({ mimeType: "application/json" }), "application/json")
+assert.equal(normalizeArtifactContentType(undefined), "application/octet-stream")
+
+assert.deepEqual(normalizeRuntimeReferenceManifestFileRef({
+  path: RUNTIME_EPISODE_TRACE_ARTIFACT_PATH,
+  kind: "runtime-episode-trace",
+  mime: "application/json",
+  sha256: "d".repeat(64),
+}), {
+  path: RUNTIME_EPISODE_TRACE_ARTIFACT_PATH,
+  kind: "runtime-episode-trace",
+  contentType: "application/json",
+  sha256: { algorithm: "sha256", value: "d".repeat(64) },
+})
+
+assert.deepEqual(normalizeRuntimeEpisodeTraceRef({
+  kind: "observation-artifact",
+  path: "files/observations/body.txt",
+  sha256: "e".repeat(64),
+}), {
+  kind: "observation-artifact",
+  id: "files/observations/body.txt",
+  path: "files/observations/body.txt",
+  digest: { algorithm: "sha256", value: "e".repeat(64) },
+})
+
+assert.deepEqual(normalizeObservationArtifactRefs({
+  artifactRefs: [{ kind: "wordpress-state-section", id: "posts", path: "files/observations/posts.json", digest: { value: "f".repeat(64), algorithm: "sha256" } }],
+}), [
+  { kind: "wordpress-state-section", id: "posts", path: "files/observations/posts.json", digest: { algorithm: "sha256", value: "f".repeat(64) } },
+])
+
+assert.deepEqual(normalizeArtifactBundleTraceRef({ id: "artifact-bundle-sha256-test", directory: "/tmp/artifacts", contentDigest: "1".repeat(64) }), {
+  kind: "artifact-bundle",
+  id: "artifact-bundle-sha256-test",
+  artifactId: "artifact-bundle-sha256-test",
+  path: "/tmp/artifacts",
+  digest: { algorithm: "sha256", value: "1".repeat(64) },
+})
+
+assert.deepEqual(normalizeRuntimeReferenceArtifactBundleRef({ id: "artifact-bundle-sha256-test", contentDigest: { algorithm: "sha256", value: "2".repeat(64) } }), {
+  kind: "artifact-bundle",
+  id: "artifact-bundle-sha256-test",
+  digest: { algorithm: "sha256", value: "2".repeat(64) },
+})
+
+assert.deepEqual(normalizeBrowserArtifactSummaryRefs({
+  probes: [
+    {
+      html: "files/browser/probe-0.html",
+      screenshot: "files/browser/probe-0.png",
+      steps: "files/browser/probe-0.steps.ndjson",
+      summaryFile: "files/browser/probe-0.summary.json",
+    },
+  ],
+}), [
+  { probeIndex: 0, field: "html", kind: "browser-html-snapshot", path: "files/browser/probe-0.html", contentType: "text/html; charset=utf-8" },
+  { probeIndex: 0, field: "screenshot", kind: "browser-screenshot", path: "files/browser/probe-0.png", contentType: "image/png" },
+  { probeIndex: 0, field: "steps", kind: "browser-steps", path: "files/browser/probe-0.steps.ndjson", contentType: "application/x-ndjson" },
+  { probeIndex: 0, field: "summaryFile", kind: "browser-summary", path: "files/browser/probe-0.summary.json", contentType: "application/json" },
+])
+
+console.log("Artifact reference normalization smoke passed")


### PR DESCRIPTION
## Summary
- Adds runtime-core helpers for canonical artifact reference paths, digest normalization, content type/mime normalization, manifest file refs, trace refs, artifact bundle refs, observation refs, and browser artifact summary refs.
- Reuses those helpers in runtime episode/reference/run registry code paths so consumers do not need to hard-code the same shapes.
- Adds a focused smoke fixture for the new normalization API.

## Verification
- `npm run build`
- `npm run artifact-reference-normalization-smoke`
- `npm run artifact-contract-smoke`
- `npm run runtime-episode-smoke`
- `npm run run-registry-smoke`

## Notes
- Refs https://github.com/chubes4/wp-codebox/issues/460
- Related to https://github.com/chubes4/wp-codebox/issues/453, but this PR stays limited to generic artifact/ref normalization helpers rather than caller-owned bundle validation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runtime-core helper implementation, smoke coverage, and focused rewiring; Chris remains responsible for review and testing.