### PR TITLE
Extend browser artifact metadata persistence

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -525,6 +525,38 @@ final class WP_Codebox_Abilities {
 								'type'        => 'object',
 								'description' => 'Opaque caller provenance describing who requested the browser run and what produced these files.',
 							),
+							'caller'         => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller-owned schema and metadata to preserve in the canonical artifact bundle.',
+							),
+							'caller_schema'  => array(
+								'type'        => 'string',
+								'description' => 'Optional caller schema URI or id preserved under metadata.caller.schema.',
+							),
+							'caller_schema_id' => array(
+								'type'        => 'string',
+								'description' => 'Optional caller schema id preserved under metadata.caller.schemaId.',
+							),
+							'caller_kind'    => array(
+								'type'        => 'string',
+								'description' => 'Optional caller artifact kind preserved under metadata.caller.kind.',
+							),
+							'caller_metadata' => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller-owned artifact bundle metadata preserved under metadata.caller.metadata.',
+							),
+							'materialization' => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller materialization metadata preserved under metadata.caller.materialization.',
+							),
+							'review_hints'   => array(
+								'type'        => 'object',
+								'description' => 'Optional caller review hints preserved in bundle metadata and review metadata.',
+							),
+							'apply_target'   => array(
+								'type'        => 'object',
+								'description' => 'Opaque caller apply target metadata preserved under metadata.caller.applyTarget.',
+							),
 							'files'          => array(
 								'type'        => 'array',
 								'description' => 'Browser-produced artifact files to store under files/browser/ in a canonical WP Codebox artifact bundle.',

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -160,6 +160,7 @@ final class WP_Codebox_Artifacts {
 		}
 
 		$provenance = is_array( $input['provenance'] ?? null ) ? $input['provenance'] : array();
+		$caller     = $this->browser_caller_metadata( $input );
 		$metadata   = array(
 			'id'            => $bundle_id,
 			'contentDigest' => array(
@@ -170,6 +171,7 @@ final class WP_Codebox_Artifacts {
 			'createdAt'     => $created_at,
 			'runtime'       => $this->browser_runtime_metadata( $input ),
 			'provenance'    => $provenance,
+			'caller'        => $caller,
 			'artifacts'     => array(
 				'browser'      => 'files/browser',
 				'changedFiles' => 'files/changed-files.json',
@@ -184,6 +186,7 @@ final class WP_Codebox_Artifacts {
 			'createdAt'    => $created_at,
 			'summary'      => 'Browser-produced artifact files persisted as a canonical WP Codebox artifact bundle.',
 			'provenance'   => $provenance,
+			'reviewHints'  => is_array( $caller['reviewHints'] ?? null ) ? $caller['reviewHints'] : array(),
 			'changedFiles' => $changed_files['files'],
 			'evidence'     => array(
 				'artifactContentDigest' => $content_digest,
@@ -589,13 +592,52 @@ final class WP_Codebox_Artifacts {
 	private function browser_runtime_metadata( array $input ): array {
 		$session = is_array( $input['session'] ?? null ) ? $input['session'] : array();
 
-		return array(
+		$runtime = array(
 			'id'          => (string) ( $session['id'] ?? $input['session_id'] ?? 'browser-playground' ),
 			'kind'        => 'browser-playground',
 			'execution'   => 'browser-playground',
 			'createdAt'   => (string) ( $session['created_at'] ?? $session['createdAt'] ?? '' ),
 			'provenance'  => is_array( $session['provenance'] ?? null ) ? $session['provenance'] : array(),
 		);
+
+		foreach ( array( 'metadata', 'materialization' ) as $key ) {
+			if ( is_array( $session[ $key ] ?? null ) ) {
+				$runtime[ $key ] = $session[ $key ];
+			}
+		}
+
+		return $runtime;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private function browser_caller_metadata( array $input ): array {
+		$caller = is_array( $input['caller'] ?? null ) ? $input['caller'] : array();
+
+		$scalar_fields = array(
+			'caller_schema'    => 'schema',
+			'caller_schema_id' => 'schemaId',
+			'caller_kind'      => 'kind',
+		);
+		foreach ( $scalar_fields as $input_key => $caller_key ) {
+			$value = trim( (string) ( $input[ $input_key ] ?? '' ) );
+			if ( '' !== $value ) {
+				$caller[ $caller_key ] = $value;
+			}
+		}
+
+		$array_fields = array(
+			'caller_metadata' => 'metadata',
+			'materialization' => 'materialization',
+			'review_hints'    => 'reviewHints',
+			'apply_target'    => 'applyTarget',
+		);
+		foreach ( $array_fields as $input_key => $caller_key ) {
+			if ( is_array( $input[ $input_key ] ?? null ) ) {
+				$caller[ $caller_key ] = $input[ $input_key ];
+			}
+		}
+
+		return $caller;
 	}
 
 	/** @return array<string,mixed> */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -603,11 +603,39 @@ $persisted_browser_artifact       = is_array( $persist_browser_artifact_ability 
 	array(
 		'artifacts_path' => $root . '/artifacts',
 		'session_id'     => 'browser-session-123',
+		'session'        => array(
+			'id'              => 'browser-session-123',
+			'createdAt'       => '2026-06-02T00:00:00+00:00',
+			'metadata'        => array(
+				'tab_id' => 'tab-abc',
+			),
+			'materialization' => array(
+				'run_id' => 'materialization-run-123',
+			),
+		),
 		'provenance'     => array(
 			'task' => array(
 				'id'     => 'issue-437-smoke',
 				'source' => 'wordpress-plugin-smoke',
 			),
+		),
+		'caller_schema'  => 'example/browser-artifact/v1',
+		'caller_schema_id' => 'example-browser-artifact',
+		'caller_kind'    => 'browser-preview',
+		'caller_metadata' => array(
+			'project_id' => 'project-123',
+			'labels'     => array( 'canonical', 'browser' ),
+		),
+		'materialization' => array(
+			'status' => 'ready',
+			'paths'  => array( 'index' => 'site/index.html' ),
+		),
+		'review_hints'   => array(
+			'severity' => 'low',
+		),
+		'apply_target'   => array(
+			'type' => 'project-artifact',
+			'id'   => 'target-123',
 		),
 		'files'          => array(
 			array(
@@ -628,7 +656,34 @@ $persisted_browser_artifact       = is_array( $persist_browser_artifact_ability 
 $assert( 'persist-browser-artifact stores canonical artifact bundle', ! is_wp_error( $persisted_browser_artifact ) && true === ( $persisted_browser_artifact['success'] ?? false ) && 'wp-codebox/browser-artifact-persistence/v1' === ( $persisted_browser_artifact['schema'] ?? '' ) && str_starts_with( (string) ( $persisted_browser_artifact['artifact_id'] ?? '' ), 'artifact-bundle-sha256-' ) );
 $assert( 'persist-browser-artifact writes manifest and metadata', ! is_wp_error( $persisted_browser_artifact ) && is_file( (string) ( $persisted_browser_artifact['artifact']['paths']['manifest'] ?? '' ) ) && is_file( (string) ( $persisted_browser_artifact['artifact']['paths']['metadata'] ?? '' ) ) );
 $assert( 'persist-browser-artifact records browser file metadata', ! is_wp_error( $persisted_browser_artifact ) && 'site/assets/photo.png' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['path'] ?? '' ) && 'files/browser/site/assets/photo.png' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['artifactPath'] ?? '' ) && 'image/png' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['mimeType'] ?? '' ) && hash( 'sha256', "\x89PNG\r\n\x1a\nparent-persisted" ) === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['sha256']['value'] ?? '' ) );
+$assert( 'persist-browser-artifact preserves caller schema metadata', ! is_wp_error( $persisted_browser_artifact ) && 'example/browser-artifact/v1' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['schema'] ?? '' ) && 'example-browser-artifact' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['schemaId'] ?? '' ) && 'browser-preview' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['kind'] ?? '' ) && 'project-123' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['metadata']['project_id'] ?? '' ) );
+$assert( 'persist-browser-artifact preserves provenance and review hints', ! is_wp_error( $persisted_browser_artifact ) && 'wordpress-plugin-smoke' === ( $persisted_browser_artifact['artifact']['metadata']['provenance']['task']['source'] ?? '' ) && 'wordpress-plugin-smoke' === ( $persisted_browser_artifact['artifact']['review']['provenance']['task']['source'] ?? '' ) && 'low' === ( $persisted_browser_artifact['artifact']['review']['reviewHints']['severity'] ?? '' ) );
+$assert( 'persist-browser-artifact preserves materialization and session metadata', ! is_wp_error( $persisted_browser_artifact ) && 'ready' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['materialization']['status'] ?? '' ) && 'project-artifact' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['applyTarget']['type'] ?? '' ) && 'tab-abc' === ( $persisted_browser_artifact['artifact']['metadata']['runtime']['metadata']['tab_id'] ?? '' ) && 'materialization-run-123' === ( $persisted_browser_artifact['artifact']['metadata']['runtime']['materialization']['run_id'] ?? '' ) );
+$assert( 'persist-browser-artifact preserves text and binary files', ! is_wp_error( $persisted_browser_artifact ) && 'utf-8' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][0]['encoding'] ?? '' ) && 'base64' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['encoding'] ?? '' ) && strlen( '<main>Persisted</main>' ) === ( $persisted_browser_artifact['artifact']['changed_files']['files'][0]['size'] ?? 0 ) && strlen( "\x89PNG\r\n\x1a\nparent-persisted" ) === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['size'] ?? 0 ) );
 $assert( 'persist-browser-artifact lists persisted bundle', ! is_wp_error( $persisted_browser_artifact ) && ! is_wp_error( call_user_func( $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/list-artifacts']['execute_callback'], array( 'artifacts_path' => $root . '/artifacts' ) ) ) );
+$persisted_browser_duplicate = is_array( $persist_browser_artifact_ability ) ? call_user_func(
+	$persist_browser_artifact_ability['execute_callback'],
+	array(
+		'artifacts_path' => $root . '/artifacts',
+		'caller_schema'  => 'example/browser-artifact/v2',
+		'caller_metadata' => array( 'project_id' => 'project-456' ),
+		'files'          => array(
+			array(
+				'path'      => 'site/index.html',
+				'content'   => '<main>Persisted</main>',
+				'mime_type' => 'text/html',
+				'kind'      => 'html',
+			),
+			array(
+				'path'           => 'site/assets/photo.png',
+				'content_base64' => base64_encode( "\x89PNG\r\n\x1a\nparent-persisted" ),
+				'encoding'       => 'base64',
+				'kind'           => 'image',
+			),
+		),
+	)
+) : null;
+$assert( 'persist-browser-artifact rejects duplicate content digest independently of caller metadata', is_wp_error( $persisted_browser_duplicate ) && 'wp_codebox_artifact_already_exists' === $persisted_browser_duplicate->get_error_code() && ( $persisted_browser_artifact['artifact_id'] ?? '' ) === ( $persisted_browser_duplicate->get_error_data()['artifact_id'] ?? null ) );
 $persisted_browser_traversal = is_array( $persist_browser_artifact_ability ) ? call_user_func(
 	$persist_browser_artifact_ability['execute_callback'],
 	array(


### PR DESCRIPTION
## Summary
- Preserve optional caller-owned schema, kind, metadata, materialization, review hints, and apply-target metadata in canonical browser artifact bundles.
- Preserve browser session metadata/materialization under runtime metadata while keeping artifact content digest behavior file-content based.
- Expand smoke coverage for caller metadata, provenance passthrough, materialization/session metadata, text/binary files, and duplicate digests.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php && php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementation and tests for the browser artifact persistence metadata extension; Chris remains responsible for review and merge.