### PR TITLE
Add editor open evidence primitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",
     "browser-actions-artifact-smoke": "tsx scripts/browser-actions-artifact-smoke.ts",
     "browser-html-capture-smoke": "tsx scripts/browser-html-capture-smoke.ts",
+    "editor-open-artifact-smoke": "tsx scripts/editor-open-artifact-smoke.ts",
     "browser-review-bridge-smoke": "tsx scripts/browser-review-bridge-smoke.ts",
     "browser-interaction-script-validation-smoke": "tsx scripts/browser-interaction-script-validation-smoke.ts",
     "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -210,6 +210,23 @@ export const commandRegistry = [
     handler: { kind: "playground", method: "runBrowserActions" },
   },
   {
+    id: "wordpress.editor-open",
+    description: "Open a generic WordPress block editor target and capture replayable editor evidence artifacts.",
+    acceptedArgs: [
+      { name: "target", description: "Editor target to open; defaults to post-new.", format: "post-new|site" },
+      { name: "post-id", description: "Existing post ID to open in the post editor.", format: "positive integer" },
+      { name: "post-type", description: "Post type for post-new or post-id targets; defaults to post.", format: "post type slug" },
+      { name: "url", description: "Explicit editor path or absolute URL to open instead of resolving a target.", format: "path or URL" },
+      { name: "wait-selector", description: "Selector that marks the editor as ready; defaults to the block editor shell.", format: "CSS selector" },
+      { name: "wait-timeout", description: "Timeout for navigation and editor-ready waits.", format: "duration, e.g. 15s or 500ms" },
+      { name: "capture", description: "Comma-separated artifacts to capture after opening the editor.", format: "steps,console,errors,html,screenshot,editor-state" },
+    ],
+    outputShape: "JSON summary plus files/browser/editor-steps.jsonl, editor-summary.json, editor-state.json, and optional console/errors/html/screenshot artifacts.",
+    policyRequirement: "Runtime policy commands must include wordpress.editor-open.",
+    recipe: true,
+    handler: { kind: "playground", method: "runEditorOpen" },
+  },
+  {
     id: "wordpress.browser-actions.evaluate",
     description: "Policy capability gating arbitrary page-side JavaScript (the evaluate step) inside wordpress.browser-actions. Non-JS interaction steps do not require this capability.",
     acceptedArgs: [],

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -113,6 +113,7 @@ export interface ArtifactReviewBrowserSummary {
     console?: string
     errorsFile?: string
     actions?: string
+    editorState?: string
     actionCount?: number
     steps?: string
     stepCount?: number

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -7,6 +7,7 @@ export interface BrowserProbeArtifact {
   url: string
   files: {
     actions?: string
+    editorState?: string
     steps?: string
     checkpoints?: string
     console?: string
@@ -20,6 +21,14 @@ export interface BrowserProbeArtifact {
   }
   summary: {
     actions?: number
+    editor?: {
+      kind: string
+      postId?: number
+      postType?: string
+      title?: string
+      blockCount?: number
+      storesAvailable: boolean
+    }
     steps?: number
     assertions?: BrowserAssertionsSummary
     consoleMessages: number
@@ -235,6 +244,7 @@ export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactRe
       console: probe.files.console,
       checkpoints: probe.files.checkpoints,
       errorsFile: probe.files.errors,
+      editorState: probe.files.editorState,
       memory: probe.files.memory,
       actions: probe.files.steps ?? probe.files.actions,
       actionCount: probe.summary.steps ?? probe.summary.actions,
@@ -259,6 +269,9 @@ export function browserManifestFiles(artifactRoot: string, probes: BrowserProbeA
     }
     if (probe.files.actions) {
       files.set(probe.files.actions, { kind: "browser-actions", contentType: "application/x-ndjson" })
+    }
+    if (probe.files.editorState) {
+      files.set(probe.files.editorState, { kind: "browser-editor-state", contentType: "application/json" })
     }
     if (probe.files.console) {
       files.set(probe.files.console, { kind: "browser-console", contentType: "application/x-ndjson" })
@@ -291,6 +304,6 @@ export function browserManifestFiles(artifactRoot: string, probes: BrowserProbeA
 }
 
 export function browserRedactionPaths(probe: BrowserProbeArtifact): string[] {
-  return [probe.files.steps, probe.files.actions, probe.files.checkpoints, probe.files.console, probe.files.errors, probe.files.html, probe.files.memory, probe.files.network, probe.files.performance, probe.files.summary]
+  return [probe.files.steps, probe.files.actions, probe.files.editorState, probe.files.checkpoints, probe.files.console, probe.files.errors, probe.files.html, probe.files.memory, probe.files.network, probe.files.performance, probe.files.summary]
     .filter((path): path is string => typeof path === "string" && path.length > 0)
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -7,7 +7,10 @@ import type { BrowserProbeArtifact, BrowserProbeCheckpointRecord, BrowserProbeEr
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, navigateBrowserProbe } from "./browser-probe.js"
-import { argValue, commaListArg } from "./commands.js"
+import { argValue, cleanWpCliOutput, commaListArg } from "./commands.js"
+import { editorOpenTargetFromArgs } from "./editor-actions.js"
+import { bootstrapPhpCode } from "./php-bootstrap.js"
+import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 
 const BROWSER_STEP_DEFAULT_TIMEOUT_MS = 15_000
@@ -512,6 +515,340 @@ export async function runBrowserActionsCommand({
       steps: stepRecords,
     }, null, 2)}\n`,
   }
+}
+
+export async function runEditorOpenCommand({
+  artifactRoot,
+  runPlaygroundCommand,
+  runtimeSpec,
+  server,
+  spec,
+}: {
+  artifactRoot: string
+  runPlaygroundCommand: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
+  runtimeSpec: RuntimeCreateSpec
+  server: PlaygroundCliServer
+  spec: ExecutionSpec
+}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+  const args = spec.args ?? []
+  const target = editorOpenTargetFromArgs(args)
+  const capture = new Set(commaListArg(args, "capture"))
+  if (capture.size === 0) {
+    capture.add("steps")
+    capture.add("console")
+    capture.add("errors")
+    capture.add("html")
+    capture.add("screenshot")
+    capture.add("editor-state")
+  }
+  for (const item of capture) {
+    if (!["steps", "console", "errors", "html", "screenshot", "editor-state"].includes(item)) {
+      throw new Error(`wordpress.editor-open capture supports steps, console, errors, html, screenshot, editor-state: ${item}`)
+    }
+  }
+
+  const waitTimeoutMs = durationArg(args, "wait-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
+  const targetUrl = resolveBrowserProbeUrl(target.url, server.serverUrl)
+  const browserDirectory = join(artifactRoot, "files", "browser")
+  await mkdir(browserDirectory, { recursive: true })
+
+  const stepRecords: BrowserStepRecord[] = []
+  const consoleMessages: Record<string, unknown>[] = []
+  const errors: BrowserProbeErrorRecord[] = []
+  const stepsPath = join(browserDirectory, "editor-steps.jsonl")
+  const consolePath = join(browserDirectory, "editor-console.jsonl")
+  const errorsPath = join(browserDirectory, "editor-errors.jsonl")
+  const htmlPath = join(browserDirectory, "editor-snapshot.html")
+  const screenshotPath = join(browserDirectory, "editor-screenshot.png")
+  const editorStatePath = join(browserDirectory, "editor-state.json")
+  const summaryPath = join(browserDirectory, "editor-summary.json")
+  const startedAt = now()
+  const { chromium } = await import("playwright")
+  const browser = await chromium.launch()
+  let finalUrl = targetUrl
+  let htmlSha256: string | undefined
+  let screenshotSha256: string | undefined
+  let viewport: BrowserProbeViewport | null = null
+  let editorState: EditorStateSnapshot | undefined
+  let pendingError: Error | undefined
+  let artifact: BrowserProbeArtifact | undefined
+
+  try {
+    const page = await browser.newPage()
+    await installEditorAuthCookies({ page, runPlaygroundCommand, runtimeSpec, server })
+    viewport = await browserProbeViewport(page)
+    if (capture.has("console")) {
+      page.on("console", (message) => consoleMessages.push(serializeBrowserConsoleMessage(message)))
+    }
+    if (capture.has("errors")) {
+      page.on("pageerror", (error) => errors.push(serializeBrowserError("pageerror", error)))
+    }
+
+    const navigateStartedAt = now()
+    const navigateStartedAtMs = Date.now()
+    try {
+      await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: waitTimeoutMs })
+      finalUrl = page.url()
+      stepRecords.push(browserStepRecord(0, { kind: "navigate", url: target.url }, "ok", navigateStartedAt, navigateStartedAtMs, finalUrl, {}))
+    } catch (error) {
+      const serialized = serializeBrowserError("probe-error", error)
+      errors.push(serialized)
+      stepRecords.push(browserStepRecord(0, { kind: "navigate", url: target.url }, "failed", navigateStartedAt, navigateStartedAtMs, page.url(), { error: serialized }))
+      pendingError = error instanceof Error ? error : new Error(String(error))
+    }
+
+    if (!pendingError) {
+      const waitStartedAt = now()
+      const waitStartedAtMs = Date.now()
+      try {
+        await waitForAnyVisibleSelector(page, target.waitSelector, waitTimeoutMs)
+        finalUrl = page.url()
+        stepRecords.push(browserStepRecord(1, { kind: "waitFor", selector: target.waitSelector }, "ok", waitStartedAt, waitStartedAtMs, finalUrl, {}))
+      } catch (error) {
+        const serialized = serializeBrowserError("probe-error", error)
+        errors.push(serialized)
+        stepRecords.push(browserStepRecord(1, { kind: "waitFor", selector: target.waitSelector }, "failed", waitStartedAt, waitStartedAtMs, page.url(), { error: serialized }))
+        pendingError = error instanceof Error ? error : new Error(String(error))
+      }
+    }
+
+    if (capture.has("editor-state")) {
+      editorState = await captureEditorState(page, target)
+      await writeFile(editorStatePath, `${JSON.stringify(editorState, null, 2)}\n`)
+    }
+    if (capture.has("html")) {
+      const html = await page.content()
+      await writeFile(htmlPath, html)
+      htmlSha256 = sha256(Buffer.from(html, "utf8"))
+    }
+    if (capture.has("screenshot")) {
+      await page.screenshot({ path: screenshotPath, fullPage: true })
+      screenshotSha256 = await fileSha256(screenshotPath)
+    }
+  } finally {
+    await browser.close()
+    if (capture.has("steps")) {
+      await writeFile(stepsPath, jsonLines(stepRecords))
+    }
+    if (capture.has("console")) {
+      await writeFile(consolePath, jsonLines(consoleMessages))
+    }
+    if (capture.has("errors")) {
+      await writeFile(errorsPath, jsonLines(errors))
+    }
+
+    const editorSummary = editorState ? summarizeEditorState(target, editorState) : undefined
+    artifact = {
+      requestedUrl: targetUrl,
+      url: targetUrl,
+      files: {
+        ...(capture.has("steps") ? { steps: "files/browser/editor-steps.jsonl" } : {}),
+        ...(capture.has("console") ? { console: "files/browser/editor-console.jsonl" } : {}),
+        ...(capture.has("editor-state") ? { editorState: "files/browser/editor-state.json" } : {}),
+        ...(capture.has("errors") ? { errors: "files/browser/editor-errors.jsonl" } : {}),
+        ...(capture.has("html") ? { html: "files/browser/editor-snapshot.html" } : {}),
+        ...(capture.has("screenshot") ? { screenshot: "files/browser/editor-screenshot.png" } : {}),
+        summary: "files/browser/editor-summary.json",
+      },
+      summary: {
+        steps: stepRecords.length,
+        consoleMessages: consoleMessages.length,
+        errors: errors.length,
+        finalUrl,
+        htmlSnapshot: capture.has("html"),
+        networkEvents: 0,
+        replayability: browserProbeReplayability(capture),
+        screenshot: capture.has("screenshot"),
+        ...(editorSummary ? { editor: editorSummary } : {}),
+        viewport,
+      },
+    }
+    await writeFile(summaryPath, `${JSON.stringify({
+      schema: "wp-codebox/editor-open/v1",
+      target,
+      requestedUrl: targetUrl,
+      finalUrl,
+      capture: [...capture].sort(),
+      waitTimeoutMs,
+      steps: stepRecords,
+      startedAt,
+      finishedAt: now(),
+      files: artifact.files,
+      hashes: {
+        ...(htmlSha256 ? { html: { algorithm: "sha256", value: htmlSha256 } } : {}),
+        ...(screenshotSha256 ? { screenshot: { algorithm: "sha256", value: screenshotSha256 } } : {}),
+      },
+      viewport,
+      summary: artifact.summary,
+    }, null, 2)}\n`)
+  }
+
+  if (pendingError) {
+    throw new Error(`wordpress.editor-open failed after ${stepRecords.length} step(s): ${pendingError.message}`)
+  }
+
+  return {
+    artifact,
+    output: `${JSON.stringify({
+      command: "wordpress.editor-open",
+      target,
+      requestedUrl: targetUrl,
+      finalUrl: artifact.summary.finalUrl ?? finalUrl,
+      files: artifact.files,
+      summary: artifact.summary,
+      steps: stepRecords,
+    }, null, 2)}\n`,
+  }
+}
+
+async function waitForAnyVisibleSelector(page: import("playwright").Page, selector: string, timeoutMs: number): Promise<void> {
+  await page.waitForFunction((targetSelector) => {
+    return Array.from(document.querySelectorAll(targetSelector)).some((element) => {
+      const rect = element.getBoundingClientRect()
+      const style = window.getComputedStyle(element)
+      return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none"
+    })
+  }, selector, { timeout: timeoutMs })
+}
+
+interface EditorStateSnapshot {
+  schema: "wp-codebox/editor-state/v1"
+  capturedAt: string
+  target: ReturnType<typeof editorOpenTargetFromArgs>
+  storesAvailable: boolean
+  post?: {
+    id?: number
+    type?: string
+    status?: string
+    title?: string
+  }
+  blocks?: Array<{
+    name: string
+    clientId?: string
+    attributes?: Record<string, unknown>
+  }>
+}
+
+async function captureEditorState(page: import("playwright").Page, target: ReturnType<typeof editorOpenTargetFromArgs>): Promise<EditorStateSnapshot> {
+  const state = await page.evaluate(() => {
+    const wpData = (window as unknown as { wp?: { data?: { select?: (store: string) => Record<string, unknown> } } }).wp?.data
+    const select = wpData?.select
+    if (!select) {
+      return { storesAvailable: false }
+    }
+    const editor = select("core/editor")
+    const blockEditor = select("core/block-editor")
+    const currentPost = typeof editor.getCurrentPost === "function" ? editor.getCurrentPost() as Record<string, unknown> | null : null
+    const blocks = typeof blockEditor.getBlocks === "function" ? blockEditor.getBlocks() as Array<Record<string, unknown>> : []
+    return {
+      storesAvailable: true,
+      post: {
+        id: typeof editor.getCurrentPostId === "function" ? editor.getCurrentPostId() : currentPost?.id,
+        type: typeof editor.getCurrentPostType === "function" ? editor.getCurrentPostType() : currentPost?.type,
+        status: currentPost?.status,
+        title: typeof currentPost?.title === "object" && currentPost.title ? (currentPost.title as Record<string, unknown>).raw ?? (currentPost.title as Record<string, unknown>).rendered : undefined,
+      },
+      blocks: blocks.map((block) => ({
+        name: typeof block.name === "string" ? block.name : "",
+        clientId: typeof block.clientId === "string" ? block.clientId : undefined,
+        attributes: typeof block.attributes === "object" && block.attributes ? block.attributes as Record<string, unknown> : undefined,
+      })),
+    }
+  }) as Omit<EditorStateSnapshot, "schema" | "capturedAt" | "target">
+
+  return {
+    schema: "wp-codebox/editor-state/v1",
+    capturedAt: now(),
+    target,
+    ...state,
+  }
+}
+
+function summarizeEditorState(target: ReturnType<typeof editorOpenTargetFromArgs>, state: EditorStateSnapshot): NonNullable<BrowserProbeArtifact["summary"]["editor"]> {
+  return {
+    kind: target.kind,
+    ...(typeof state.post?.id === "number" ? { postId: state.post.id } : {}),
+    ...(typeof state.post?.type === "string" ? { postType: state.post.type } : target.postType ? { postType: target.postType } : {}),
+    ...(typeof state.post?.title === "string" ? { title: state.post.title } : {}),
+    ...(Array.isArray(state.blocks) ? { blockCount: state.blocks.length } : {}),
+    storesAvailable: state.storesAvailable,
+  }
+}
+
+async function installEditorAuthCookies({
+  page,
+  runPlaygroundCommand,
+  runtimeSpec,
+  server,
+}: {
+  page: import("playwright").Page
+  runPlaygroundCommand: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
+  runtimeSpec: RuntimeCreateSpec
+  server: PlaygroundCliServer
+}): Promise<void> {
+  const response = await runPlaygroundCommand("wordpress.editor-open.auth", server, { code: bootstrapPhpCode(runtimeSpec, editorAuthCookiePhpCode(server.serverUrl), []) })
+  assertPlaygroundResponseOk("wordpress.editor-open.auth", response)
+  const cookies = JSON.parse(cleanWpCliOutput(response.text)) as Array<{ name?: string; value?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: "Lax" }>
+  const cookieDomain = new URL(server.serverUrl).hostname
+  await page.context().addCookies(cookies.map((cookie) => ({
+    name: String(cookie.name ?? ""),
+    value: String(cookie.value ?? ""),
+    domain: cookieDomain,
+    path: typeof cookie.path === "string" && cookie.path.length > 0 ? cookie.path : "/",
+    expires: typeof cookie.expires === "number" ? cookie.expires : Math.floor(Date.now() / 1000) + 3600,
+    httpOnly: cookie.httpOnly !== false,
+    secure: cookie.secure === true,
+    sameSite: cookie.sameSite ?? "Lax",
+  })))
+}
+
+function editorAuthCookiePhpCode(browserUrl: string): string {
+  return `
+$user_id = 1;
+$user = get_user_by( 'id', $user_id );
+if ( ! $user ) {
+    throw new RuntimeException( 'wordpress.editor-open requires admin user ID 1 to exist.' );
+}
+wp_set_current_user( $user_id );
+$expiration = time() + HOUR_IN_SECONDS;
+$browser_url = ${JSON.stringify(browserUrl)};
+$auth_scheme = is_ssl() ? 'secure_auth' : 'auth';
+$cookies = array(
+    array(
+        'name'     => AUTH_COOKIE,
+        'value'    => wp_generate_auth_cookie( $user_id, $expiration, $auth_scheme ),
+        'url'      => $browser_url,
+        'path'     => defined( 'ADMIN_COOKIE_PATH' ) && ADMIN_COOKIE_PATH ? ADMIN_COOKIE_PATH : '/wp-admin',
+        'expires'  => $expiration,
+        'httpOnly' => true,
+        'secure'   => is_ssl(),
+        'sameSite' => 'Lax',
+    ),
+    array(
+        'name'     => LOGGED_IN_COOKIE,
+        'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in' ),
+        'url'      => $browser_url,
+        'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
+        'expires'  => $expiration,
+        'httpOnly' => true,
+        'secure'   => is_ssl(),
+        'sameSite' => 'Lax',
+    ),
+);
+if ( defined( 'SITECOOKIEPATH' ) && SITECOOKIEPATH && SITECOOKIEPATH !== COOKIEPATH ) {
+    $cookies[] = array(
+        'name'     => LOGGED_IN_COOKIE,
+        'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in' ),
+        'url'      => $browser_url,
+        'path'     => SITECOOKIEPATH,
+        'expires'  => $expiration,
+        'httpOnly' => true,
+        'secure'   => is_ssl(),
+        'sameSite' => 'Lax',
+    );
+}
+echo wp_json_encode( $cookies );
+`
 }
 
 function now(): string {

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -15,6 +15,7 @@ interface PlaygroundCommandRuntime {
   runBrowserProbe(spec: ExecutionSpec): Promise<string>
   runHtmlCapture(spec: ExecutionSpec): Promise<string>
   runBrowserActions(spec: ExecutionSpec): Promise<string>
+  runEditorOpen(spec: ExecutionSpec): Promise<string>
 }
 
 const playgroundCommandHandlers = {
@@ -31,6 +32,7 @@ const playgroundCommandHandlers = {
   "wordpress.browser-probe": (runtime, spec) => runtime.runBrowserProbe(spec),
   "wordpress.capture-html": (runtime, spec) => runtime.runHtmlCapture(spec),
   "wordpress.browser-actions": (runtime, spec) => runtime.runBrowserActions(spec),
+  "wordpress.editor-open": (runtime, spec) => runtime.runEditorOpen(spec),
 } satisfies Record<PlaygroundRuntimeCommandId, (runtime: PlaygroundCommandRuntime, spec: ExecutionSpec) => Promise<string>>
 
 export function playgroundRuntimeCommandIds(): string[] {

--- a/packages/runtime-playground/src/editor-actions.ts
+++ b/packages/runtime-playground/src/editor-actions.ts
@@ -1,0 +1,44 @@
+import { argValue } from "./commands.js"
+
+export interface EditorOpenTarget {
+  url: string
+  kind: "post" | "post-new" | "site" | "url"
+  postId?: number
+  postType?: string
+  waitSelector: string
+}
+
+const DEFAULT_EDITOR_WAIT_SELECTOR = ".edit-post-visual-editor, .editor-styles-wrapper, .block-editor, .interface-interface-skeleton"
+
+export function editorOpenTargetFromArgs(args: string[]): EditorOpenTarget {
+  const explicitUrl = argValue(args, "url")?.trim()
+  const waitSelector = argValue(args, "wait-selector")?.trim() || DEFAULT_EDITOR_WAIT_SELECTOR
+  if (explicitUrl) {
+    return { url: explicitUrl, kind: "url", waitSelector }
+  }
+
+  const target = argValue(args, "target")?.trim() || "post-new"
+  if (target === "site") {
+    return { url: "/wp-admin/site-editor.php", kind: "site", waitSelector }
+  }
+
+  const postType = argValue(args, "post-type")?.trim() || "post"
+  if (!/^[a-zA-Z0-9_-]+$/.test(postType)) {
+    throw new Error(`wordpress.editor-open post-type must be a WordPress post type slug: ${postType}`)
+  }
+
+  const postIdRaw = argValue(args, "post-id")?.trim()
+  if (postIdRaw) {
+    const postId = Number.parseInt(postIdRaw, 10)
+    if (!Number.isInteger(postId) || postId <= 0) {
+      throw new Error(`wordpress.editor-open post-id must be a positive integer: ${postIdRaw}`)
+    }
+    return { url: `/wp-admin/post.php?post=${postId}&action=edit`, kind: "post", postId, postType, waitSelector }
+  }
+
+  if (target !== "post-new") {
+    throw new Error(`wordpress.editor-open target supports post-new, site, or url=<path-or-url>: ${target}`)
+  }
+
+  return { url: `/wp-admin/post-new.php?post_type=${encodeURIComponent(postType)}`, kind: "post-new", postType, waitSelector }
+}

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -3,7 +3,7 @@ import { mkdir, realpath, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, createHostToolRegistry, runtimeEpisodeDigest } from "@chubes4/wp-codebox-core"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserProbeArtifact } from "./browser-artifacts.js"
-import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runHtmlCaptureCommand } from "./browser-command-runners.js"
+import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
 import { cleanWpCliOutput, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
@@ -431,6 +431,19 @@ class PlaygroundRuntime implements Runtime {
       }
       throw error
     }
+    this.browserProbes.push(result.artifact)
+    return result.output
+  }
+
+  async runEditorOpen(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const result = await runEditorOpenCommand({
+      artifactRoot: this.artifactRoot,
+      runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options),
+      runtimeSpec: this.spec,
+      server,
+      spec,
+    })
     this.browserProbes.push(result.artifact)
     return result.output
   }

--- a/scripts/editor-open-artifact-smoke.ts
+++ b/scripts/editor-open-artifact-smoke.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "editor-open-artifact-smoke")
+const recipePath = join(workspace, "recipe.json")
+const artifactsRoot = join(workspace, "artifacts")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(workspace, { recursive: true })
+
+await writeFile(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.editor-open",
+        args: [
+          "target=post-new",
+          "post-type=post",
+          "wait-timeout=30s",
+          "capture=steps,console,errors,html,screenshot,editor-state",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const output = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--json",
+])
+
+assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
+assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+
+const artifactDirectory = output.artifacts.directory
+const stepsPath = join(artifactDirectory, "files", "browser", "editor-steps.jsonl")
+const consolePath = join(artifactDirectory, "files", "browser", "editor-console.jsonl")
+const errorsPath = join(artifactDirectory, "files", "browser", "editor-errors.jsonl")
+const htmlPath = join(artifactDirectory, "files", "browser", "editor-snapshot.html")
+const screenshotPath = join(artifactDirectory, "files", "browser", "editor-screenshot.png")
+const editorStatePath = join(artifactDirectory, "files", "browser", "editor-state.json")
+const summaryPath = join(artifactDirectory, "files", "browser", "editor-summary.json")
+const manifestPath = join(artifactDirectory, "manifest.json")
+const reviewPath = join(artifactDirectory, "files", "review.json")
+
+assert.equal(existsSync(stepsPath), true, "editor step trace should be captured")
+assert.equal(existsSync(consolePath), true, "editor console trace should be captured")
+assert.equal(existsSync(errorsPath), true, "editor error trace should be captured")
+assert.equal(existsSync(htmlPath), true, "editor DOM snapshot should be captured")
+assert.equal(existsSync(screenshotPath), true, "editor screenshot should be captured")
+assert.equal(existsSync(editorStatePath), true, "editor store state should be captured")
+assert.equal(existsSync(summaryPath), true, "editor summary should be captured")
+
+const stepsLog = await readFile(stepsPath, "utf8")
+assert.match(stepsLog, /"kind":"navigate"/)
+assert.match(stepsLog, /"kind":"waitFor"/)
+assert.match(stepsLog, /"status":"ok"/)
+
+const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
+  schema: string
+  target: { kind: string; postType?: string }
+  files: { steps?: string; editorState?: string; html?: string; screenshot?: string; summary: string }
+  summary: { steps: number; replayability: string; htmlSnapshot: boolean; editor?: { postType?: string; storesAvailable: boolean } }
+}
+assert.equal(summary.schema, "wp-codebox/editor-open/v1")
+assert.equal(summary.target.kind, "post-new")
+assert.equal(summary.target.postType, "post")
+assert.equal(summary.files.steps, "files/browser/editor-steps.jsonl")
+assert.equal(summary.files.editorState, "files/browser/editor-state.json")
+assert.equal(summary.files.html, "files/browser/editor-snapshot.html")
+assert.equal(summary.files.screenshot, "files/browser/editor-screenshot.png")
+assert.equal(summary.files.summary, "files/browser/editor-summary.json")
+assert.equal(summary.summary.steps, 2)
+assert.equal(summary.summary.replayability, "artifact-backed")
+assert.equal(summary.summary.htmlSnapshot, true)
+assert.equal(summary.summary.editor?.postType, "post")
+assert.equal(summary.summary.editor?.storesAvailable, true)
+
+const editorState = JSON.parse(await readFile(editorStatePath, "utf8")) as {
+  schema: string
+  storesAvailable: boolean
+  post?: { type?: string }
+  blocks?: Array<{ name: string }>
+}
+assert.equal(editorState.schema, "wp-codebox/editor-state/v1")
+assert.equal(editorState.storesAvailable, true)
+assert.equal(editorState.post?.type, "post")
+assert.ok(Array.isArray(editorState.blocks), "editor state should include a blocks array")
+
+const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
+assert.ok(manifest.files.some((file) => file.path === "files/browser/editor-state.json" && file.kind === "browser-editor-state"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/editor-summary.json" && file.kind === "browser-summary"))
+
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ editorState?: string; html?: string; screenshot?: string; summaryFile?: string }> } }
+assert.equal(review.browser?.probes?.[0]?.editorState, "files/browser/editor-state.json")
+assert.equal(review.browser?.probes?.[0]?.html, "files/browser/editor-snapshot.html")
+assert.equal(review.browser?.probes?.[0]?.screenshot, "files/browser/editor-screenshot.png")
+assert.equal(review.browser?.probes?.[0]?.summaryFile, "files/browser/editor-summary.json")
+
+console.log(`Editor open artifact smoke passed: ${artifactDirectory}`)
+
+async function runCli(args: string[]): Promise<any> {
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const exitCode = await new Promise<number | null>((resolveExit) => child.once("exit", (code) => resolveExit(code)))
+  assert.equal(exitCode, 0, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- Add `wordpress.editor-open`, a focused generic block editor primitive that opens post/site/explicit editor targets.
- Capture replayable editor evidence artifacts: step trace, DOM snapshot, screenshot, console/errors, and fixed WordPress editor store state.
- Register editor-state artifacts in manifests/review summaries and add a focused editor-open smoke test.

Refs #459

## Verification
- `npm run build`
- `npm run command-registry-smoke`
- `npm run editor-open-artifact-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic editor-open primitive, evidence artifact plumbing, and smoke coverage; Chris remains responsible for review and merge.