### PR TITLE
Define WordPress state artifact contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,36 @@ needed. Options require `optionNames`; users are redacted by default, expose onl
 allowed role/capability fields, and include identity fields only with
 `redaction: "none"` plus an explicit `userFields` allowlist.
 
+The canonical replayable WordPress state artifact contracts are:
+
+- `wp-codebox/wordpress-state-export/v1`: the inline observation data. It is an
+  object with `schema`, `version: 1`, `generatedAt`, the normalized request
+  `config`, compact `sections` summaries, and an `artifacts` map keyed by section
+  name. Each artifact entry contains `artifact`, `sha256`, and `bytes`.
+- `wp-codebox/wordpress-state-section/v1`: the artifact-backed full section. It
+  is an object with `schema`, `version: 1`, `section`, and `data`. The `section`
+  value matches the key in the export `artifacts` map and the artifact filename.
+
+Stable `wordpress-state-section/v1` section fields are intentionally generic
+WordPress state, not replay/grader semantics:
+
+| Section | Stable fields |
+| --- | --- |
+| `summary` | `siteUrl`, `homeUrl`, `wordpressVersion`, `activeTheme`, `activePlugins`, `postCounts` keyed by post type and status. |
+| `posts` | Array of public post types ordered by ascending `ID`. Entries include `id`, `type`, `slug`, `status`, `title`, `contentHash`, `modifiedGmt`, and `content` when `includeContent: true`. This covers posts, pages, and public custom post types. |
+| `templates` | `theme`, `templates`, `templateParts`, and `globalStyles`. Template entries include `id`, `slug`, `theme`, `type`, `source`, and `contentHash`; template part entries include `id`, `slug`, `theme`, `area`, `source`, and `contentHash`; global styles expose `stylesheetHash` when available. |
+| `options` | Object keyed by explicitly requested `optionNames`; no options are exported implicitly. |
+| `terms` | Array of terms with `id`, `taxonomy`, `slug`, `name`, `parent`, and `count`. |
+| `menus` | Array of menus with `id`, `slug`, `name`, and `items`; menu items include `id`, `title`, `url`, `parentId`, `object`, and `type`. |
+| `media` | Array of attachments ordered by ascending `ID`. Entries include `id`, `slug`, `title`, `status`, `mimeType`, `sourceUrl`, `altText`, and `metadataHash`. |
+| `users` | Array ordered by ascending `ID`. Entries always include `id` and `redacted`; `roles` and `caps` are allowed safe fields. Identity fields such as `user_login` and `display_name` are emitted only when requested and `redaction: "none"`. |
+
+Redaction is part of the contract. The default `redaction: "safe"` avoids user
+identity fields and requires explicit allowlists for options and users.
+`redaction: "none"` is an opt-in export mode for trusted callers that need identity fields.
+Consumers should verify artifact SHA-256 values before replay and should branch
+on `schema` and `version` instead of projecting per-consumer legacy state shapes.
+
 Replay is bounded to the generic runtime contract. A consumer can replay a step
 by creating a compatible backend runtime, applying the same mounts/artifact
 inputs, and executing the action envelope in order. WP Codebox intentionally

--- a/fixtures/wordpress-state/wordpress-state-export-v1.json
+++ b/fixtures/wordpress-state/wordpress-state-export-v1.json
@@ -1,0 +1,81 @@
+{
+  "schema": "wp-codebox/wordpress-state-export/v1",
+  "version": 1,
+  "generatedAt": "2026-01-01T00:00:00+00:00",
+  "config": {
+    "sections": [
+      "summary",
+      "posts",
+      "terms",
+      "menus",
+      "templates",
+      "media",
+      "options",
+      "users"
+    ],
+    "redaction": "safe",
+    "includeContent": true,
+    "optionNames": [
+      "blogname"
+    ],
+    "userFields": [
+      "roles"
+    ]
+  },
+  "sections": {
+    "summary": {
+      "siteUrl": "https://example.test",
+      "homeUrl": "https://example.test",
+      "wordpressVersion": "6.8.0",
+      "activeTheme": "twentytwentyfive",
+      "activePlugins": [
+        "hello.php"
+      ],
+      "postCounts": {
+        "post": {
+          "publish": 1
+        },
+        "page": {
+          "publish": 1
+        }
+      }
+    },
+    "posts": {
+      "count": 2
+    },
+    "terms": {
+      "count": 1
+    },
+    "menus": {
+      "count": 1
+    },
+    "templates": {
+      "count": 4,
+      "keys": [
+        "theme",
+        "templates",
+        "templateParts",
+        "globalStyles"
+      ]
+    },
+    "media": {
+      "count": 1
+    },
+    "options": {
+      "count": 1,
+      "keys": [
+        "blogname"
+      ]
+    },
+    "users": {
+      "count": 1
+    }
+  },
+  "artifacts": {
+    "posts": {
+      "artifact": "files/observations/observation-1-wordpress-state-posts.json",
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "bytes": 512
+    }
+  }
+}

--- a/fixtures/wordpress-state/wordpress-state-section-v1.json
+++ b/fixtures/wordpress-state/wordpress-state-section-v1.json
@@ -1,0 +1,27 @@
+{
+  "schema": "wp-codebox/wordpress-state-section/v1",
+  "version": 1,
+  "section": "posts",
+  "data": [
+    {
+      "id": 42,
+      "type": "page",
+      "slug": "sample-page",
+      "status": "publish",
+      "title": "Sample Page",
+      "contentHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "content": "<!-- wp:paragraph --><p>Hello from Codebox.</p><!-- /wp:paragraph -->",
+      "modifiedGmt": "2026-01-01 00:00:00"
+    },
+    {
+      "id": 43,
+      "type": "book",
+      "slug": "custom-post-type-entry",
+      "status": "draft",
+      "title": "Custom Post Type Entry",
+      "contentHash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+      "content": "Custom post body",
+      "modifiedGmt": "2026-01-02 00:00:00"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
     "run-registry-smoke": "tsx scripts/run-registry-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
+    "wordpress-state-contract-smoke": "tsx scripts/wordpress-state-contract-smoke.ts",
     "runtime-snapshot-restore-smoke": "tsx scripts/runtime-snapshot-restore-smoke.ts",
     "runtime-action-adapter-smoke": "tsx scripts/runtime-action-adapter-smoke.ts",
     "rest-request-runtime-smoke": "tsx scripts/rest-request-runtime-smoke.ts",

--- a/packages/runtime-playground/src/observation-artifacts.ts
+++ b/packages/runtime-playground/src/observation-artifacts.ts
@@ -40,7 +40,7 @@ export async function observeWordPressState({
   const sections = stateExport.sections ?? {}
 
   for (const [section, contents] of Object.entries(sections)) {
-    const serialized = `${JSON.stringify({ schema: "wp-codebox/wordpress-state-section/v1", section, data: contents }, null, 2)}\n`
+    const serialized = `${JSON.stringify({ schema: "wp-codebox/wordpress-state-section/v1", version: 1, section, data: contents }, null, 2)}\n`
     const digest = createHash("sha256").update(serialized).digest("hex")
     const relativePath = `files/observations/${observationId}-wordpress-state-${safeArtifactSegment(section)}.json`
     await mkdir(dirname(join(artifactRoot, relativePath)), { recursive: true })
@@ -247,13 +247,17 @@ if ( in_array( 'media', $sections, true ) ) {
         'orderby'        => 'ID',
         'order'          => 'ASC',
     ) );
-    $exports['media'] = array_map( function ( $attachment ) {
+    $exports['media'] = array_map( function ( $attachment ) use ( $hash_value ) {
+        $metadata = wp_get_attachment_metadata( $attachment->ID );
         return array(
-            'id'       => (int) $attachment->ID,
-            'slug'     => $attachment->post_name,
-            'title'    => get_the_title( $attachment ),
-            'mimeType' => $attachment->post_mime_type,
-            'metadata' => wp_get_attachment_metadata( $attachment->ID ),
+            'id'           => (int) $attachment->ID,
+            'slug'         => $attachment->post_name,
+            'title'        => get_the_title( $attachment ),
+            'status'       => $attachment->post_status,
+            'mimeType'     => $attachment->post_mime_type,
+            'sourceUrl'    => wp_get_attachment_url( $attachment->ID ) ?: '',
+            'altText'      => (string) get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
+            'metadataHash' => $hash_value( $metadata ),
         );
     }, $attachments );
 }

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -103,7 +103,7 @@ try {
 
     const fullStateObservation = await episode.observe({
       type: "wordpress-state",
-      sections: ["summary", "posts", "terms", "options", "users", "rest-routes", "abilities"],
+      sections: ["summary", "posts", "terms", "menus", "templates", "media", "options", "users", "rest-routes", "abilities"],
       optionNames: ["blogname"],
       userFields: ["user_login", "roles"],
     })
@@ -112,7 +112,7 @@ try {
       sections?: { posts?: { count?: number }; users?: { count?: number }; options?: { keys?: string[] } }
       artifacts?: Record<string, { artifact?: string; sha256?: string; bytes?: number }>
     }
-    assert.deepEqual(fullStateData.config?.sections, ["summary", "posts", "terms", "options", "users", "rest-routes", "abilities"])
+    assert.deepEqual(fullStateData.config?.sections, ["summary", "posts", "terms", "menus", "templates", "media", "options", "users", "rest-routes", "abilities"])
     assert.ok((fullStateData.sections?.posts?.count ?? 0) >= 2)
     assert.equal(fullStateData.sections?.users?.count, 1)
     assert.deepEqual(fullStateData.sections?.options?.keys, ["blogname"])
@@ -159,7 +159,10 @@ try {
     const snapshotBundleEntry = manifest.files.find((file: { path: string; kind: string }) => file.path.startsWith("files/runtime-snapshots/") && file.kind === "runtime-snapshot-bundle")
     assert.ok(snapshotBundleEntry, "runtime snapshot bundle should be listed in manifest")
 
-    const usersArtifact = JSON.parse(await readFile(join(artifacts.directory, usersArtifactPath), "utf8")) as { data?: Array<Record<string, unknown>> }
+    const usersArtifact = JSON.parse(await readFile(join(artifacts.directory, usersArtifactPath), "utf8")) as { schema?: string; version?: number; section?: string; data?: Array<Record<string, unknown>> }
+    assert.equal(usersArtifact.schema, "wp-codebox/wordpress-state-section/v1")
+    assert.equal(usersArtifact.version, 1)
+    assert.equal(usersArtifact.section, "users")
     assert.equal(usersArtifact.data?.[0]?.redacted, true)
     assert.equal(Object.hasOwn(usersArtifact.data?.[0] ?? {}, "user_login"), false)
     assert.deepEqual(usersArtifact.data?.[0]?.roles, ["administrator"])

--- a/scripts/wordpress-state-contract-smoke.ts
+++ b/scripts/wordpress-state-contract-smoke.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+type JsonObject = Record<string, unknown>
+
+const sectionFixture = JSON.parse(await readFile("fixtures/wordpress-state/wordpress-state-section-v1.json", "utf8")) as JsonObject
+const exportFixture = JSON.parse(await readFile("fixtures/wordpress-state/wordpress-state-export-v1.json", "utf8")) as JsonObject
+
+assert.equal(sectionFixture.schema, "wp-codebox/wordpress-state-section/v1")
+assert.equal(sectionFixture.version, 1)
+assert.equal(sectionFixture.section, "posts")
+assert.ok(Array.isArray(sectionFixture.data))
+
+const posts = sectionFixture.data as JsonObject[]
+for (const post of posts) {
+  assert.equal(typeof post.id, "number")
+  assert.equal(typeof post.type, "string")
+  assert.equal(typeof post.slug, "string")
+  assert.equal(typeof post.status, "string")
+  assert.equal(typeof post.title, "string")
+  assert.match(String(post.contentHash), /^[a-f0-9]{64}$/)
+  assert.equal(typeof post.modifiedGmt, "string")
+  if (Object.hasOwn(post, "content")) {
+    assert.equal(typeof post.content, "string")
+  }
+}
+
+assert.equal(exportFixture.schema, "wp-codebox/wordpress-state-export/v1")
+assert.equal(exportFixture.version, 1)
+assert.equal(typeof exportFixture.generatedAt, "string")
+assert.ok(exportFixture.config && typeof exportFixture.config === "object")
+assert.ok(exportFixture.sections && typeof exportFixture.sections === "object")
+assert.ok(exportFixture.artifacts && typeof exportFixture.artifacts === "object")
+
+const config = exportFixture.config as JsonObject
+assert.deepEqual(config.sections, ["summary", "posts", "terms", "menus", "templates", "media", "options", "users"])
+assert.equal(config.redaction, "safe")
+assert.equal(config.includeContent, true)
+assert.deepEqual(config.optionNames, ["blogname"])
+assert.deepEqual(config.userFields, ["roles"])
+
+const sections = exportFixture.sections as Record<string, JsonObject>
+assert.equal(typeof sections.summary?.siteUrl, "string")
+assert.equal(typeof sections.summary?.homeUrl, "string")
+assert.equal(typeof sections.summary?.wordpressVersion, "string")
+assert.equal(typeof sections.summary?.activeTheme, "string")
+assert.ok(Array.isArray(sections.summary?.activePlugins))
+assert.ok(sections.summary?.postCounts && typeof sections.summary.postCounts === "object")
+
+for (const section of ["posts", "terms", "menus", "media", "users"]) {
+  assert.equal(typeof sections[section]?.count, "number")
+}
+
+assert.deepEqual(sections.options?.keys, ["blogname"])
+assert.deepEqual(sections.templates?.keys, ["theme", "templates", "templateParts", "globalStyles"])
+
+const artifacts = exportFixture.artifacts as Record<string, JsonObject>
+assert.equal(typeof artifacts.posts?.artifact, "string")
+assert.match(String(artifacts.posts?.sha256), /^[a-f0-9]{64}$/)
+assert.equal(typeof artifacts.posts?.bytes, "number")
+
+console.log("WordPress state contract fixtures passed")


### PR DESCRIPTION
## Summary
- Documents the canonical `wp-codebox/wordpress-state-export/v1` and `wp-codebox/wordpress-state-section/v1` contracts for replayable generic WordPress state.
- Adds fixture smoke coverage for the export and section artifact shapes.
- Stabilizes section artifact versioning and media export fields so consumers can rely on portable state fields without per-consumer projection shims.

Closes #462.
Related context: #444.

## Verification
- `npm run wordpress-state-contract-smoke`
- `npm run build`
- `npm run runtime-episode-smoke` passed once against WordPress Playground. A later rerun hit an environment port collision with an already-running Playground listener on `127.0.0.1:51723`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the contract documentation, fixture smoke coverage, and focused runtime artifact contract updates; Chris remains responsible for review and merge.