### PR TITLE
Authorize browser artifact persistence callers

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -12,6 +12,7 @@ final class WP_Codebox_Abilities {
 	private const BROWSER_ARTIFACT_MAX_BYTES = 5242880;
 	private const BROWSER_CAPTURE_MAX_BYTES  = 262144;
 	private const BROWSER_SESSION_CREATE_SCOPE = 'browser-session:create';
+	private const BROWSER_ARTIFACT_WRITE_SCOPE = 'artifact:write';
 
 	private static bool $registered = false;
 
@@ -575,6 +576,7 @@ final class WP_Codebox_Abilities {
 						'required'   => array( 'files' ),
 						'properties' => array(
 							'artifacts_path' => $artifact_id_schema['artifacts_path'],
+							'authorization'  => self::trusted_orchestrator_authorization_schema( self::BROWSER_ARTIFACT_WRITE_SCOPE, 'Explicit trusted orchestrator authorization for browser artifact persistence. Callers must provide a caller id and the artifact:write scope; sites grant trust through wp_codebox_trusted_browser_session_callers.' ),
 							'session_id'     => array(
 								'type'        => 'string',
 								'description' => 'Optional browser Playground session id that produced the artifact files.',
@@ -639,7 +641,7 @@ final class WP_Codebox_Abilities {
 					),
 					'output_schema'       => array( 'type' => 'object' ),
 					'execute_callback'    => array( self::class, 'persist_browser_artifact' ),
-					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'permission_callback' => array( self::class, 'can_persist_browser_artifact' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -1061,9 +1063,14 @@ final class WP_Codebox_Abilities {
 
 	/** @return array<string,mixed> */
 	private static function browser_session_authorization_schema(): array {
+		return self::trusted_orchestrator_authorization_schema( self::BROWSER_SESSION_CREATE_SCOPE, 'Explicit trusted orchestrator authorization for browser session creation. Callers must provide a caller id and the browser-session:create scope; sites grant trust through wp_codebox_trusted_browser_session_callers.' );
+	}
+
+	/** @return array<string,mixed> */
+	private static function trusted_orchestrator_authorization_schema( string $scope, string $description ): array {
 		return array(
 			'type'        => 'object',
-			'description' => 'Explicit trusted orchestrator authorization for browser session creation. Callers must provide a caller id and the browser-session:create scope; sites grant trust through wp_codebox_trusted_browser_session_callers.',
+			'description' => $description,
 			'properties'  => array(
 				'schema' => array(
 					'type'        => 'string',
@@ -1075,8 +1082,8 @@ final class WP_Codebox_Abilities {
 				),
 				'scope'  => array(
 					'type'        => 'string',
-					'enum'        => array( self::BROWSER_SESSION_CREATE_SCOPE ),
-					'description' => 'Required capability scope for creating a browser Playground session.',
+					'enum'        => array( $scope ),
+					'description' => 'Required trusted-orchestrator capability scope.',
 				),
 			),
 		);
@@ -1376,7 +1383,17 @@ final class WP_Codebox_Abilities {
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function persist_browser_artifact( array $input ): array|WP_Error {
-		return ( new WP_Codebox_Artifacts() )->persist_browser_bundle( $input );
+		$result = ( new WP_Codebox_Artifacts() )->persist_browser_bundle( $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$authorization = self::trusted_orchestrator_authorization( $input, self::BROWSER_ARTIFACT_WRITE_SCOPE );
+		if ( ! empty( $authorization['caller'] ) || ! empty( $authorization['scope'] ) ) {
+			$result['authorization'] = $authorization;
+		}
+
+		return $result;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
@@ -1417,7 +1434,23 @@ final class WP_Codebox_Abilities {
 			return false;
 		}
 
-		$authorization = self::browser_session_authorization( $input );
+		$authorization = self::trusted_orchestrator_authorization( $input, self::BROWSER_SESSION_CREATE_SCOPE );
+
+		return true === ( $authorization['authorized'] ?? false );
+	}
+
+	/** @param mixed $input Ability input or request-like object. */
+	public static function can_persist_browser_artifact( mixed $input = null ): bool {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		$input = self::permission_input_array( $input );
+		if ( empty( $input ) ) {
+			return false;
+		}
+
+		$authorization = self::trusted_orchestrator_authorization( $input, self::BROWSER_ARTIFACT_WRITE_SCOPE );
 
 		return true === ( $authorization['authorized'] ?? false );
 	}
@@ -1443,6 +1476,11 @@ final class WP_Codebox_Abilities {
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
 	private static function browser_session_authorization( array $input ): array {
+		return self::trusted_orchestrator_authorization( $input, self::BROWSER_SESSION_CREATE_SCOPE );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private static function trusted_orchestrator_authorization( array $input, string $required_scope ): array {
 		$authorization = is_array( $input['authorization'] ?? null ) ? $input['authorization'] : array();
 		$caller        = trim( (string) ( $authorization['caller'] ?? '' ) );
 		$scope         = trim( (string) ( $authorization['scope'] ?? '' ) );
@@ -1462,7 +1500,7 @@ final class WP_Codebox_Abilities {
 			return $result;
 		}
 
-		if ( self::BROWSER_SESSION_CREATE_SCOPE !== $scope ) {
+		if ( $required_scope !== $scope ) {
 			$result['reason'] = 'missing-scope';
 			return $result;
 		}

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -367,7 +367,7 @@ $trusted_browser_authorization = array(
 		'scope'  => 'browser-session:create',
 	),
 );
-$GLOBALS['wp_codebox_filters']['wp_codebox_trusted_browser_session_callers'] = array( 'studio-web' => array( 'browser-session:create' ) );
+$GLOBALS['wp_codebox_filters']['wp_codebox_trusted_browser_session_callers'] = array( 'studio-web' => array( 'browser-session:create', 'artifact:write' ) );
 $GLOBALS['wp_codebox_current_user_can_manage_options'] = false;
 $assert( 'browser Playground session keeps default protection for untrusted users', false === call_user_func( $browser_session_ability['permission_callback'], array( 'goal' => 'Denied without trusted caller.' ) ) );
 $assert( 'browser Playground session allows trusted orchestrator caller with browser-session scope', true === call_user_func( $browser_session_ability['permission_callback'], $trusted_browser_authorization ) );
@@ -389,6 +389,24 @@ foreach ( $artifact_abilities as $artifact_ability_name ) {
 	$assert( $artifact_ability_name . ' ability registered', is_array( $artifact_ability ) );
 	$assert( $artifact_ability_name . ' is REST visible', true === ( $artifact_ability['meta']['show_in_rest'] ?? false ) );
 }
+$persist_browser_artifact_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/persist-browser-artifact'] ?? null;
+$assert( 'persist-browser-artifact exposes explicit trusted orchestrator authorization schema', is_array( $persist_browser_artifact_ability ) && 'object' === ( $persist_browser_artifact_ability['input_schema']['properties']['authorization']['type'] ?? '' ) && array( 'artifact:write' ) === ( $persist_browser_artifact_ability['input_schema']['properties']['authorization']['properties']['scope']['enum'] ?? array() ) );
+$trusted_artifact_authorization = array(
+	'authorization' => array(
+		'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
+		'caller' => 'studio-web',
+		'scope'  => 'artifact:write',
+	),
+);
+$GLOBALS['wp_codebox_current_user_can_manage_options'] = false;
+$assert( 'persist-browser-artifact keeps default protection for untrusted users', false === call_user_func( $persist_browser_artifact_ability['permission_callback'], array( 'files' => array() ) ) );
+$GLOBALS['wp_codebox_filters']['wp_codebox_can_run_agent_task'] = true;
+$assert( 'persist-browser-artifact ignores global agent-task bypass without artifact authorization', false === call_user_func( $persist_browser_artifact_ability['permission_callback'], array( 'files' => array() ) ) );
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_can_run_agent_task'] );
+$assert( 'persist-browser-artifact allows trusted orchestrator caller with artifact write scope', true === call_user_func( $persist_browser_artifact_ability['permission_callback'], $trusted_artifact_authorization ) );
+$assert( 'persist-browser-artifact denies untrusted orchestrator caller', false === call_user_func( $persist_browser_artifact_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'unknown-product', 'scope' => 'artifact:write' ) ) ) );
+$assert( 'persist-browser-artifact denies trusted caller without artifact write scope', false === call_user_func( $persist_browser_artifact_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'browser-session:create' ) ) ) );
+$GLOBALS['wp_codebox_current_user_can_manage_options'] = true;
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_component_paths'] = array(
 	'agents_api'        => $root . '/agents-api',
@@ -719,11 +737,15 @@ $assert( 'normalize-browser-artifact-bundle rejects missing entrypoint', is_wp_e
 $normalized_browser_duplicate = is_array( $normalize_browser_bundle_ability ) ? call_user_func( $normalize_browser_bundle_ability['execute_callback'], array_merge( $browser_bundle_input, array( 'files' => array( array( 'path' => 'index.html', 'content' => 'one' ), array( 'path' => 'site/index.html', 'content' => 'two' ) ) ) ) ) : null;
 $assert( 'normalize-browser-artifact-bundle rejects duplicate files', is_wp_error( $normalized_browser_duplicate ) && 'wp_codebox_browser_artifact_path_duplicate' === $normalized_browser_duplicate->get_error_code() );
 
-$persist_browser_artifact_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/persist-browser-artifact'] ?? null;
 $persisted_browser_artifact       = is_array( $persist_browser_artifact_ability ) ? call_user_func(
 	$persist_browser_artifact_ability['execute_callback'],
 	array(
 		'artifacts_path' => $root . '/artifacts',
+		'authorization'  => array(
+			'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
+			'caller' => 'studio-web',
+			'scope'  => 'artifact:write',
+		),
 		'session_id'     => 'browser-session-123',
 		'session'        => array(
 			'id'              => 'browser-session-123',
@@ -782,6 +804,7 @@ $assert( 'persist-browser-artifact preserves caller schema metadata', ! is_wp_er
 $assert( 'persist-browser-artifact preserves provenance and review hints', ! is_wp_error( $persisted_browser_artifact ) && 'wordpress-plugin-smoke' === ( $persisted_browser_artifact['artifact']['metadata']['provenance']['task']['source'] ?? '' ) && 'wordpress-plugin-smoke' === ( $persisted_browser_artifact['artifact']['review']['provenance']['task']['source'] ?? '' ) && 'low' === ( $persisted_browser_artifact['artifact']['review']['reviewHints']['severity'] ?? '' ) );
 $assert( 'persist-browser-artifact preserves materialization and session metadata', ! is_wp_error( $persisted_browser_artifact ) && 'ready' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['materialization']['status'] ?? '' ) && 'project-artifact' === ( $persisted_browser_artifact['artifact']['metadata']['caller']['applyTarget']['type'] ?? '' ) && 'tab-abc' === ( $persisted_browser_artifact['artifact']['metadata']['runtime']['metadata']['tab_id'] ?? '' ) && 'materialization-run-123' === ( $persisted_browser_artifact['artifact']['metadata']['runtime']['materialization']['run_id'] ?? '' ) );
 $assert( 'persist-browser-artifact preserves text and binary files', ! is_wp_error( $persisted_browser_artifact ) && 'utf-8' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][0]['encoding'] ?? '' ) && 'base64' === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['encoding'] ?? '' ) && strlen( '<main>Persisted</main>' ) === ( $persisted_browser_artifact['artifact']['changed_files']['files'][0]['size'] ?? 0 ) && strlen( "\x89PNG\r\n\x1a\nparent-persisted" ) === ( $persisted_browser_artifact['artifact']['changed_files']['files'][1]['size'] ?? 0 ) );
+$assert( 'persist-browser-artifact returns trusted authorization provenance', ! is_wp_error( $persisted_browser_artifact ) && 'studio-web' === ( $persisted_browser_artifact['authorization']['caller'] ?? '' ) && 'artifact:write' === ( $persisted_browser_artifact['authorization']['scope'] ?? '' ) && true === ( $persisted_browser_artifact['authorization']['authorized'] ?? false ) && 'trusted-caller-grant' === ( $persisted_browser_artifact['authorization']['reason'] ?? '' ) );
 $assert( 'persist-browser-artifact lists persisted bundle', ! is_wp_error( $persisted_browser_artifact ) && ! is_wp_error( call_user_func( $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/list-artifacts']['execute_callback'], array( 'artifacts_path' => $root . '/artifacts' ) ) ) );
 $persisted_browser_duplicate = is_array( $persist_browser_artifact_ability ) ? call_user_func(
 	$persist_browser_artifact_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Adds explicit trusted-orchestrator authorization for `wp-codebox/persist-browser-artifact` using the existing trusted browser-session authorization envelope and grant filter.
- Requires `artifact:write` for trusted non-admin callers and does not honor the global `wp_codebox_can_run_agent_task` bypass for artifact persistence.
- Returns authorization provenance from successful browser artifact persistence calls.

Fixes #476

## Tests
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the authorization helper reuse, permission tests, and smoke verification; Chris remains responsible for review and merge.