### PR TITLE
Expose browser metrics from artifact bundles

### DIFF
--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -10,6 +10,7 @@ interface CliCommandRouter {
   recipeRun: CliCommandHandler
   workspacePolicyCheck: CliCommandHandler
   artifactsVerify: CliCommandHandler
+  artifactsBrowserMetrics: CliCommandHandler
   runsStatus: CliCommandHandler
   runsArtifacts: CliCommandHandler
   commands: CliCommandHandler
@@ -58,12 +59,15 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
     }
     case "artifacts": {
       const subcommand = args.shift()
-      if (subcommand !== "verify") {
-        console.error(`Unknown artifacts command: ${subcommand ?? ""}`)
-        router.printHelp()
-        return 1
+      if (subcommand === "verify") {
+        return router.artifactsVerify(args)
       }
-      return router.artifactsVerify(args)
+      if (subcommand === "browser-metrics") {
+        return router.artifactsBrowserMetrics(args)
+      }
+      console.error(`Unknown artifacts command: ${subcommand ?? ""}`)
+      router.printHelp()
+      return 1
     }
     case "runs": {
       const subcommand = args.shift()

--- a/packages/cli/src/commands/artifacts.ts
+++ b/packages/cli/src/commands/artifacts.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path"
 import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@chubes4/wp-codebox-core"
+import { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "@chubes4/wp-codebox-playground"
 import { printArtifactVerifyHumanOutput } from "../output.js"
 
 interface ArtifactVerifyOptions {
@@ -19,8 +20,46 @@ export async function runArtifactsVerifyCommand(args: string[]): Promise<number>
   return output.valid ? 0 : 1
 }
 
+export async function runArtifactsBrowserMetricsCommand(args: string[]): Promise<number> {
+  const options = parseArtifactBrowserMetricsOptions(args)
+  const output = await browserMetrics(options)
+  if (!options.json) {
+    printArtifactBrowserMetricsHumanOutput(output)
+    return 0
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return 0
+}
+
 async function verifyArtifacts(options: ArtifactVerifyOptions): Promise<ArtifactBundleVerificationResult> {
   return verifyArtifactBundle(resolve(options.bundleDirectory))
+}
+
+async function browserMetrics(options: ArtifactVerifyOptions): Promise<BrowserArtifactMetricsResult> {
+  return browserArtifactMetrics(resolve(options.bundleDirectory))
+}
+
+function parseArtifactBrowserMetricsOptions(args: string[]): ArtifactVerifyOptions {
+  return parseArtifactVerifyOptions(args)
+}
+
+function printArtifactBrowserMetricsHumanOutput(output: BrowserArtifactMetricsResult): void {
+  console.log("WP Codebox browser metrics")
+  console.log(`Bundle: ${output.bundleDirectory}`)
+  console.log(`Browser metrics: ${output.hasBrowserMetrics ? "yes" : "no"}`)
+  if (Object.keys(output.metrics).length > 0) {
+    console.log("Metrics:")
+    for (const [name, value] of Object.entries(output.metrics).sort(([left], [right]) => left.localeCompare(right))) {
+      console.log(`  ${name}: ${value}`)
+    }
+  }
+  if (Object.keys(output.artifacts).length > 0) {
+    console.log("Artifacts:")
+    for (const [name, artifact] of Object.entries(output.artifacts).sort(([left], [right]) => left.localeCompare(right))) {
+      console.log(`  ${name}: ${artifact.path}`)
+    }
+  }
 }
 
 function parseArtifactVerifyOptions(args: string[]): ArtifactVerifyOptions {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { routeCliCommand } from "./command-router.js"
-import { runArtifactsVerifyCommand } from "./commands/artifacts.js"
+import { runArtifactsBrowserMetricsCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
 import { runCommandsCommand, runRecipeSchemaCommand } from "./commands/discovery.js"
 import { runRecipeRunCommand, runRecipeValidateCommand } from "./commands/recipe-run.js"
 import { runBootCommand, runRunCommand, runValidateBlueprintCommand } from "./commands/runtime.js"
@@ -17,6 +17,7 @@ async function runCli(args: string[]): Promise<number> {
     recipeValidate: runRecipeValidateCommand,
     workspacePolicyCheck: runWorkspacePolicyCheckCommand,
     artifactsVerify: runArtifactsVerifyCommand,
+    artifactsBrowserMetrics: runArtifactsBrowserMetricsCommand,
     runsStatus: runRunsStatusCommand,
     runsArtifacts: runRunsArtifactsCommand,
     commands: runCommandsCommand,

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -243,6 +243,7 @@ export function printHelp(): void {
   wp-codebox workspace-policy check --workspace-root <path> --writable-root <path> [options]
   wp-codebox recipe validate --recipe <path> [--json]
   wp-codebox artifacts verify --bundle <dir> [--json]
+  wp-codebox artifacts browser-metrics --bundle <dir> [--json]
   wp-codebox runs status --registry <dir> --run-id <id> [--json]
   wp-codebox runs artifacts --registry <dir> --run-id <id> [--json]
   wp-codebox validate-blueprint --blueprint <json|file> [options]

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -1,3 +1,5 @@
+import { access, readFile } from "node:fs/promises"
+import { join } from "node:path"
 import type { ConsoleMessage, Request, Response } from "playwright"
 import type {
   BrowserProbeArtifact,
@@ -11,6 +13,14 @@ import type {
   BrowserProbePerformanceArtifact,
   BrowserProbePerformanceSummary,
 } from "./browser-artifacts.js"
+
+export interface BrowserArtifactMetricsResult {
+  schema: "wp-codebox/browser-metrics/v1"
+  bundleDirectory: string
+  hasBrowserMetrics: boolean
+  metrics: Record<string, number>
+  artifacts: Record<string, { path: string; kind: "json" | "jsonl" }>
+}
 
 function now(): string {
   return new Date().toISOString()
@@ -143,6 +153,61 @@ export function promoteBrowserMetricsToBenchResults(raw: string, probes: Browser
   }
 
   return `${JSON.stringify(parsed, null, 2)}\n`
+}
+
+export async function browserArtifactMetrics(bundleDirectory: string): Promise<BrowserArtifactMetricsResult> {
+  const summaryPath = join(bundleDirectory, "files", "browser", "summary.json")
+  const artifacts: BrowserArtifactMetricsResult["artifacts"] = {}
+
+  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "summary", "summary.json", "json")
+  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "memory", "memory.json", "json")
+  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "performance", "performance.json", "json")
+  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "checkpoints", "checkpoints.jsonl", "jsonl")
+
+  let metrics: Record<string, number> = {}
+  try {
+    const summary = JSON.parse(await readFile(summaryPath, "utf8")) as Record<string, unknown>
+    const browserSummary = isRecord(summary.summary) ? summary.summary : {}
+    metrics = isNumericMetricRecord(browserSummary.metrics) ? browserSummary.metrics : {}
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error
+    }
+  }
+
+  return {
+    schema: "wp-codebox/browser-metrics/v1",
+    bundleDirectory,
+    hasBrowserMetrics: Object.keys(metrics).length > 0,
+    metrics,
+    artifacts,
+  }
+}
+
+async function addBrowserArtifactIfPresent(artifacts: BrowserArtifactMetricsResult["artifacts"], bundleDirectory: string, name: string, file: string, kind: "json" | "jsonl"): Promise<void> {
+  const relativePath = `files/browser/${file}`
+  try {
+    await access(join(bundleDirectory, relativePath))
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return
+    }
+    throw error
+  }
+
+  artifacts[name] = { path: relativePath, kind }
+}
+
+function isNumericMetricRecord(value: unknown): value is Record<string, number> {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return Object.values(value).every((metric) => typeof metric === "number" && Number.isFinite(metric))
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT"
 }
 
 function combinedBrowserBenchMetrics(probes: BrowserProbeArtifact[]): Record<string, number> | undefined {

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,3 +1,4 @@
 export { playgroundRuntimeCommandIds } from "./command-router.js"
 export { buildArtifactDiagnostics } from "./artifacts.js"
+export { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "./browser-metrics.js"
 export { PlaygroundRuntimeBackend, createPlaygroundRuntimeBackend } from "./playground-runtime.js"

--- a/scripts/recipe-browser-bench-metrics-smoke.ts
+++ b/scripts/recipe-browser-bench-metrics-smoke.ts
@@ -8,9 +8,11 @@ const repoRoot = resolve(import.meta.dirname, "..")
 const workspace = resolve(repoRoot, "artifacts", "recipe-browser-bench-metrics-smoke")
 const recipePath = join(workspace, "recipe.json")
 const artifactsRoot = join(workspace, "artifacts")
+const emptyArtifactsRoot = join(workspace, "empty-artifacts")
 
 await rm(workspace, { recursive: true, force: true })
 await mkdir(workspace, { recursive: true })
+await mkdir(emptyArtifactsRoot, { recursive: true })
 
 await writeFile(recipePath, `${JSON.stringify({
   schema: "wp-codebox/workspace-recipe/v1",
@@ -62,6 +64,17 @@ assert.ok(output.benchResults, "recipe-run should expose benchResults")
 assert.equal(output.benchResults.scenarios.length, 1)
 
 const metrics = output.benchResults.scenarios[0].metrics
+const expectedBrowserMetrics = {
+  browser_peak_used_js_heap_bytes: metrics.browser_peak_used_js_heap_bytes,
+  browser_final_used_js_heap_bytes: metrics.browser_final_used_js_heap_bytes,
+  browser_checkpoint_count: metrics.browser_checkpoint_count,
+  browser_dom_node_count: metrics.browser_dom_node_count,
+  browser_iframe_count: metrics.browser_iframe_count,
+  browser_resource_count: metrics.browser_resource_count,
+  browser_transfer_size_bytes: metrics.browser_transfer_size_bytes,
+  browser_long_task_count: metrics.browser_long_task_count,
+  browser_long_task_total_ms: metrics.browser_long_task_total_ms,
+}
 assert.ok(metrics.browser_checkpoint_count >= 3, "browser_checkpoint_count should include probe checkpoints")
 assert.ok(metrics.browser_dom_node_count > 0, "browser_dom_node_count should be numeric")
 assert.equal(metrics.browser_iframe_count, 1)
@@ -82,6 +95,37 @@ const performance = JSON.parse(await readFile(performancePath, "utf8"))
 assert.equal(performance.schema, "wp-codebox/browser-performance/v1")
 assert.ok(performance.checkpoints.length >= 3, "performance artifact should include probe checkpoints")
 assert.match(await readFile(checkpointsPath, "utf8"), /"name":"after-navigation"/)
+
+const browserMetrics = await runCli([
+  "packages/cli/dist/index.js",
+  "artifacts",
+  "browser-metrics",
+  "--bundle",
+  artifactDirectory,
+  "--json",
+])
+
+assert.equal(browserMetrics.schema, "wp-codebox/browser-metrics/v1")
+assert.equal(browserMetrics.hasBrowserMetrics, true)
+assert.deepEqual(browserMetrics.metrics, expectedBrowserMetrics)
+assert.equal(browserMetrics.artifacts.summary.path, "files/browser/summary.json")
+assert.equal(browserMetrics.artifacts.memory.path, "files/browser/memory.json")
+assert.equal(browserMetrics.artifacts.performance.path, "files/browser/performance.json")
+assert.equal(browserMetrics.artifacts.checkpoints.path, "files/browser/checkpoints.jsonl")
+
+const emptyBrowserMetrics = await runCli([
+  "packages/cli/dist/index.js",
+  "artifacts",
+  "browser-metrics",
+  "--bundle",
+  emptyArtifactsRoot,
+  "--json",
+])
+
+assert.equal(emptyBrowserMetrics.schema, "wp-codebox/browser-metrics/v1")
+assert.equal(emptyBrowserMetrics.hasBrowserMetrics, false)
+assert.deepEqual(emptyBrowserMetrics.metrics, {})
+assert.deepEqual(emptyBrowserMetrics.artifacts, {})
 
 console.log(`Recipe browser bench metrics smoke passed: ${artifactDirectory}`)
 


### PR DESCRIPTION
## Summary
- Add `wp-codebox artifacts browser-metrics --bundle <dir> --json` so parent bench consumers can read browser metrics without parsing WP Codebox browser artifact internals.
- Return an explicit no-browser-metrics result for bundles without browser artifacts.
- Extend browser bench metrics smoke coverage for `recipe-run` bench promotion plus artifact-bundle metrics extraction with and without browser artifacts.

## Testing
- `npm run build`
- `npm run recipe-browser-bench-metrics-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the CLI command, shared browser metrics helper, and smoke coverage; Chris remains responsible for review and merge.