### PR TITLE
Expose artifact apply preflight contract

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -696,6 +696,41 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/apply-artifact-preflight',
+				array(
+					'label'               => 'Preflight WP Codebox Artifact Apply',
+					'description'         => 'Validate a canonical artifact bundle and return the apply adapter payload without mutating parent-side git, pull requests, or deployments.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'artifact_id', 'approved_files' ),
+						'properties' => array_merge(
+							$artifact_id_schema,
+							array(
+								'approved_files' => array(
+									'type'        => 'array',
+									'description' => 'Explicit sandbox file paths approved by the parent-site reviewer. Preflight requires every changed file to be approved.',
+									'items'       => array( 'type' => 'string' ),
+								),
+								'approver'       => array(
+									'type'        => 'string',
+									'description' => 'Parent-site approver principal preserved in the returned payload.',
+								),
+								'apply_target'   => array(
+									'type'        => 'object',
+									'description' => 'Optional parent-control-plane target metadata preserved in the returned payload.',
+								),
+							)
+						),
+					),
+					'output_schema'       => array( 'type' => 'object' ),
+					'execute_callback'    => array( self::class, 'apply_artifact_preflight' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/apply-approved-artifact',
 				array(
 					'label'               => 'Apply Approved WP Codebox Artifact',
@@ -1399,6 +1434,11 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public static function review_artifact( array $input ): array|WP_Error {
 		return ( new WP_Codebox_Artifacts() )->review_artifact( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function apply_artifact_preflight( array $input ): array|WP_Error {
+		return ( new WP_Codebox_Artifacts() )->apply_preflight( $input );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -11,6 +11,7 @@ final class WP_Codebox_Artifacts {
 
 	private const LIST_SCHEMA  = 'wp-codebox/artifact-list/v1';
 	private const GET_SCHEMA   = 'wp-codebox/artifact/v1';
+	private const APPLY_PREFLIGHT_SCHEMA = 'wp-codebox/artifact-apply-preflight/v1';
 	private const APPLY_SCHEMA = 'wp-codebox/artifact-apply/v1';
 	private const APPLY_RESULT_SCHEMA = 'wp-codebox/apply-result/v1';
 	private const APPLY_AUDIT_SCHEMA = 'wp-codebox/apply-audit/v1';
@@ -421,80 +422,38 @@ final class WP_Codebox_Artifacts {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
-	public function apply_approved( array $input ): array|WP_Error {
-		$bundle = $this->resolve_bundle( $input );
-		if ( is_wp_error( $bundle ) ) {
-			return $bundle;
+	public function apply_preflight( array $input ): array|WP_Error {
+		$preflight = $this->approved_artifact_apply_preflight( $input, true );
+		if ( is_wp_error( $preflight ) ) {
+			return $preflight;
 		}
+
+		return array_merge(
+			array(
+				'success' => true,
+				'schema'  => self::APPLY_PREFLIGHT_SCHEMA,
+			),
+			$preflight
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function apply_approved( array $input ): array|WP_Error {
+		$preflight = $this->approved_artifact_apply_preflight( $input, false );
+		if ( is_wp_error( $preflight ) ) {
+			return $preflight;
+		}
+
+		$bundle         = $preflight['artifact'];
+		$approved_files = $preflight['approved_files'];
+		$payload        = $preflight['payload'];
+		$content_digest = (string) $preflight['content_digest'];
+		$verification   = $preflight['verification'];
 
 		$root = $this->artifact_root( $input );
 		if ( is_wp_error( $root ) ) {
 			return $root;
 		}
-
-		$verification = $this->verify_artifact_bundle( $bundle, $input );
-		if ( is_wp_error( $verification ) ) {
-			return $verification;
-		}
-
-		$approved_files = $this->approved_files( $input );
-		if ( empty( $approved_files ) ) {
-			return new WP_Error( 'wp_codebox_approved_files_missing', 'approved_files must include at least one sandbox path.', array( 'status' => 400 ) );
-		}
-
-		$changed_files = $bundle['changed_files']['files'] ?? array();
-		if ( ! is_array( $changed_files ) ) {
-			return new WP_Error( 'wp_codebox_changed_files_invalid', 'Artifact changed-files payload is invalid.', array( 'status' => 400 ) );
-		}
-
-		$changed_paths = array_values(
-			array_filter(
-				array_map(
-					static fn( $file ): string => is_array( $file ) ? (string) ( $file['path'] ?? '' ) : '',
-					$changed_files
-				)
-			)
-		);
-
-		$unknown_files = array_values( array_diff( $approved_files, $changed_paths ) );
-		if ( ! empty( $unknown_files ) ) {
-			return new WP_Error(
-				'wp_codebox_approved_files_invalid',
-				'approved_files contains paths that are not present in changed-files.json.',
-				array(
-					'status' => 400,
-					'files'  => $unknown_files,
-				)
-			);
-		}
-
-		$patch_path = (string) ( $bundle['paths']['patch'] ?? '' );
-		$patch      = '' !== $patch_path && is_file( $patch_path ) ? file_get_contents( $patch_path ) : false;
-		if ( false === $patch || '' === trim( $patch ) ) {
-			return new WP_Error( 'wp_codebox_patch_missing', 'Artifact patch.diff is missing or empty.', array( 'status' => 400 ) );
-		}
-
-		$patch = $this->filter_patch_to_approved_files( $patch, $changed_files, $approved_files );
-		if ( is_wp_error( $patch ) ) {
-			return $patch;
-		}
-
-		$content_digest = $this->artifact_content_digest( $bundle );
-		if ( is_wp_error( $content_digest ) ) {
-			return $content_digest;
-		}
-
-		$payload = array(
-			'artifact_id'             => (string) $bundle['id'],
-			'artifact'                => $bundle,
-			'approved_files'          => $approved_files,
-			'approver'                => $input['approver'] ?? null,
-			'apply_target'            => is_array( $input['apply_target'] ?? null ) ? $input['apply_target'] : null,
-			'patch'                   => $patch,
-			'patch_sha256'            => hash( 'sha256', $patch ),
-			'artifact_content_digest' => $content_digest,
-			'artifact_verification'   => $verification,
-		);
 
 		$result = apply_filters( 'wp_codebox_apply_approved_artifact', null, $payload );
 		if ( null === $result ) {
@@ -702,6 +661,93 @@ final class WP_Codebox_Artifacts {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private function approved_artifact_apply_preflight( array $input, bool $require_all_changed_files_approved ): array|WP_Error {
+		$bundle = $this->resolve_bundle( $input );
+		if ( is_wp_error( $bundle ) ) {
+			return $bundle;
+		}
+
+		$verification = $this->verify_artifact_bundle( $bundle, $input );
+		if ( is_wp_error( $verification ) ) {
+			return $verification;
+		}
+
+		$approved_files = $this->approved_files( $input );
+		if ( empty( $approved_files ) ) {
+			return new WP_Error( 'wp_codebox_approved_files_missing', 'approved_files must include at least one sandbox path.', array( 'status' => 400 ) );
+		}
+
+		$changed_files = $bundle['changed_files']['files'] ?? array();
+		if ( ! is_array( $changed_files ) ) {
+			return new WP_Error( 'wp_codebox_changed_files_invalid', 'Artifact changed-files payload is invalid.', array( 'status' => 400 ) );
+		}
+
+		$changed_paths = $this->changed_file_paths( $changed_files );
+		$unknown_files = array_values( array_diff( $approved_files, $changed_paths ) );
+		if ( ! empty( $unknown_files ) ) {
+			return new WP_Error(
+				'wp_codebox_approved_files_invalid',
+				'approved_files contains paths that are not present in changed-files.json.',
+				array(
+					'status' => 400,
+					'files'  => $unknown_files,
+				)
+			);
+		}
+
+		$missing_approved_files = $require_all_changed_files_approved ? array_values( array_diff( $changed_paths, $approved_files ) ) : array();
+		if ( ! empty( $missing_approved_files ) ) {
+			return new WP_Error(
+				'wp_codebox_approved_files_incomplete',
+				'approved_files must include every changed file for apply preflight.',
+				array(
+					'status' => 400,
+					'files'  => $missing_approved_files,
+				)
+			);
+		}
+
+		$patch_path = (string) ( $bundle['paths']['patch'] ?? '' );
+		$patch      = '' !== $patch_path && is_file( $patch_path ) ? file_get_contents( $patch_path ) : false;
+		if ( false === $patch || '' === trim( $patch ) ) {
+			return new WP_Error( 'wp_codebox_patch_missing', 'Artifact patch.diff is missing or empty.', array( 'status' => 400 ) );
+		}
+
+		$patch = $this->filter_patch_to_approved_files( $patch, $changed_files, $approved_files );
+		if ( is_wp_error( $patch ) ) {
+			return $patch;
+		}
+
+		$content_digest = $this->artifact_content_digest( $bundle );
+		if ( is_wp_error( $content_digest ) ) {
+			return $content_digest;
+		}
+
+		$payload = array(
+			'artifact_id'             => (string) $bundle['id'],
+			'artifact'                => $bundle,
+			'approved_files'          => $approved_files,
+			'approver'                => $input['approver'] ?? null,
+			'apply_target'            => is_array( $input['apply_target'] ?? null ) ? $input['apply_target'] : null,
+			'patch'                   => $patch,
+			'patch_sha256'            => hash( 'sha256', $patch ),
+			'artifact_content_digest' => $content_digest,
+			'artifact_verification'   => $verification,
+		);
+
+		return array(
+			'artifact_id'    => (string) $bundle['id'],
+			'artifact'       => $bundle,
+			'approved_files' => $approved_files,
+			'changed_files'  => $changed_paths,
+			'patch_sha256'   => $payload['patch_sha256'],
+			'content_digest' => $content_digest,
+			'verification'   => $verification,
+			'payload'        => $payload,
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	private function resolve_bundle( array $input ): array|WP_Error {
 		$artifact_id = trim( (string) ( $input['artifact_id'] ?? '' ) );
 		if ( '' === $artifact_id ) {
@@ -717,6 +763,13 @@ final class WP_Codebox_Artifacts {
 			$bundle = $this->read_bundle_at_manifest( $manifest_path, true );
 			if ( ! is_wp_error( $bundle ) && $artifact_id === (string) $bundle['id'] ) {
 				return $bundle;
+			}
+
+			if ( is_wp_error( $bundle ) ) {
+				$manifest = $this->read_json_file( $manifest_path );
+				if ( ! is_wp_error( $manifest ) && $artifact_id === (string) ( $manifest['id'] ?? '' ) ) {
+					return $bundle;
+				}
 			}
 		}
 
@@ -1263,6 +1316,18 @@ final class WP_Codebox_Artifacts {
 				array_filter(
 					array_map( static fn( $path ): string => trim( (string) $path ), $files ),
 					static fn( string $path ): bool => '' !== $path
+				)
+			)
+		);
+	}
+
+	/** @param array<int,mixed> $changed_files Artifact changed file entries. @return string[] */
+	private function changed_file_paths( array $changed_files ): array {
+		return array_values(
+			array_filter(
+				array_map(
+					static fn( $file ): string => is_array( $file ) ? (string) ( $file['path'] ?? '' ) : '',
+					$changed_files
 				)
 			)
 		);

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -15,6 +15,7 @@ final class WP_Codebox_CLI_Command {
 
 		\WP_CLI::add_command( 'codebox artifacts list', array( $command, 'artifacts_list' ) );
 		\WP_CLI::add_command( 'codebox artifacts get', array( $command, 'artifacts_get' ) );
+		\WP_CLI::add_command( 'codebox artifacts preflight-apply', array( $command, 'artifacts_preflight_apply' ) );
 		\WP_CLI::add_command( 'codebox artifacts stage-apply', array( $command, 'artifacts_stage_apply' ) );
 		\WP_CLI::add_command( 'codebox artifacts apply', array( $command, 'artifacts_apply' ) );
 		\WP_CLI::add_command( 'codebox browser-session create', array( $command, 'browser_session_create' ) );
@@ -40,6 +41,16 @@ final class WP_Codebox_CLI_Command {
 	 */
 	public function artifacts_get( array $args, array $assoc_args ): void {
 		$this->emit( WP_Codebox_Abilities::get_artifact( $this->artifact_input( $args, $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Preflight a reviewed artifact apply without mutating the parent control plane.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function artifacts_preflight_apply( array $args, array $assoc_args ): void {
+		$this->emit( WP_Codebox_Abilities::apply_artifact_preflight( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
 	}
 
 	/**

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -313,6 +313,7 @@ $assert( 'category exposes label and description', isset( $category['label'] ) &
 $cli_commands = $GLOBALS['wp_codebox_cli_commands'];
 $assert( 'wp codebox artifacts list command registered', is_callable( $cli_commands['codebox artifacts list'] ?? null ) );
 $assert( 'wp codebox artifacts get command registered', is_callable( $cli_commands['codebox artifacts get'] ?? null ) );
+$assert( 'wp codebox artifacts preflight-apply command registered', is_callable( $cli_commands['codebox artifacts preflight-apply'] ?? null ) );
 $assert( 'wp codebox artifacts stage-apply command registered', is_callable( $cli_commands['codebox artifacts stage-apply'] ?? null ) );
 $assert( 'wp codebox artifacts apply command registered', is_callable( $cli_commands['codebox artifacts apply'] ?? null ) );
 $assert( 'wp codebox browser-session create command registered', is_callable( $cli_commands['codebox browser-session create'] ?? null ) );
@@ -381,6 +382,7 @@ $artifact_abilities = array(
 	'wp-codebox/discard-artifact',
 	'wp-codebox/persist-browser-artifact',
 	'wp-codebox/review-artifact',
+	'wp-codebox/apply-artifact-preflight',
 	'wp-codebox/apply-approved-artifact',
 	'wp-codebox/stage-artifact-apply',
 );
@@ -2016,6 +2018,37 @@ $assert( 'artifact get verifies content digest', ! is_wp_error( $read_artifact )
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_bin'] = dirname( __DIR__ ) . '/packages/cli/dist/index.js';
 
+$preflight_apply_payloads = array();
+$GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] = function ( mixed $value, array $payload ) use ( &$preflight_apply_payloads ): mixed {
+	$preflight_apply_payloads[] = $payload;
+	return $value;
+};
+$apply_preflight = $artifacts->apply_preflight(
+	array(
+		'artifacts_path'  => $artifact_root,
+		'artifact_id'     => $artifact_id,
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt', '/wordpress/wp-content/plugins/example/unapproved.txt' ),
+		'approver'        => 'site-user:preflight',
+		'apply_target'    => array( 'repo' => 'chubes4/wp-codebox' ),
+	)
+);
+$assert( 'artifact apply preflight returns verified adapter payload without delegation', ! is_wp_error( $apply_preflight ) && 'wp-codebox/artifact-apply-preflight/v1' === ( $apply_preflight['schema'] ?? '' ) && true === ( $apply_preflight['verification']['valid'] ?? false ) && $content_digest === ( $apply_preflight['content_digest'] ?? '' ) && hash( 'sha256', $patch_diff ) === ( $apply_preflight['patch_sha256'] ?? '' ) && array() === $preflight_apply_payloads );
+$assert( 'artifact apply preflight payload preserves apply target and approved files', ! is_wp_error( $apply_preflight ) && array( 'repo' => 'chubes4/wp-codebox' ) === ( $apply_preflight['payload']['apply_target'] ?? array() ) && array( '/wordpress/wp-content/plugins/example/generated.txt', '/wordpress/wp-content/plugins/example/unapproved.txt' ) === ( $apply_preflight['payload']['approved_files'] ?? array() ) && $patch_diff === ( $apply_preflight['payload']['patch'] ?? '' ) );
+
+call_user_func( $GLOBALS['wp_codebox_cli_commands']['codebox artifacts preflight-apply'], array( $artifact_id ), array( 'artifacts-path' => $artifact_root, 'approved-files' => '/wordpress/wp-content/plugins/example/generated.txt,/wordpress/wp-content/plugins/example/unapproved.txt', 'format' => 'json' ) );
+$cli_preflight_output = json_decode( end( $GLOBALS['wp_codebox_cli_lines'] ), true );
+$assert( 'wp codebox artifacts preflight-apply emits JSON service result', is_array( $cli_preflight_output ) && 'wp-codebox/artifact-apply-preflight/v1' === ( $cli_preflight_output['schema'] ?? '' ) && $artifact_id === ( $cli_preflight_output['artifact_id'] ?? '' ) );
+
+$missing_approval_preflight = $artifacts->apply_preflight(
+	array(
+		'artifacts_path'  => $artifact_root,
+		'artifact_id'     => $artifact_id,
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt' ),
+	)
+);
+$assert( 'artifact apply preflight requires every changed file approval', is_wp_error( $missing_approval_preflight ) && 'wp_codebox_approved_files_incomplete' === $missing_approval_preflight->get_error_code() && array( '/wordpress/wp-content/plugins/example/unapproved.txt' ) === ( $missing_approval_preflight->get_error_data()['files'] ?? array() ) );
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_apply_approved_artifact'] );
+
 $malformed_manifest_root = $root . '/artifact-malformed-manifest';
 mkdir( $malformed_manifest_root . '/broken', 0777, true );
 file_put_contents( $malformed_manifest_root . '/broken/manifest.json', "{\n" );
@@ -2024,6 +2057,30 @@ $verify_exit   = 0;
 exec( 'node ' . escapeshellarg( $GLOBALS['wp_codebox_filters']['wp_codebox_bin'] ) . ' artifacts verify --bundle ' . escapeshellarg( $malformed_manifest_root . '/broken' ) . ' --json 2>&1', $verify_output, $verify_exit );
 $verify_result = json_decode( implode( "\n", $verify_output ), true );
 $assert( 'generic verifier reports malformed manifest fixtures', 1 === $verify_exit && false === ( $verify_result['valid'] ?? true ) && 'malformed-manifest' === ( $verify_result['violations'][0]['code'] ?? '' ) );
+
+$digest_fixture_root = $root . '/artifact-digest-fixture';
+$copy_directory( $bundle_dir, $digest_fixture_root . '/runtime-test' );
+file_put_contents( $digest_fixture_root . '/runtime-test/files/patch.diff', $patch_diff . "diff --git a/tampered.txt b/tampered.txt\n+tampered\n" );
+$digest_failure = $artifacts->apply_preflight(
+	array(
+		'artifacts_path'  => $digest_fixture_root,
+		'artifact_id'     => $artifact_id,
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt', '/wordpress/wp-content/plugins/example/unapproved.txt' ),
+	)
+);
+$assert( 'artifact apply preflight rejects digest mismatch before payload creation', is_wp_error( $digest_failure ) && 'wp_codebox_artifact_digest_mismatch' === $digest_failure->get_error_code() );
+
+$missing_patch_fixture_root = $root . '/artifact-missing-patch-fixture';
+$copy_directory( $bundle_dir, $missing_patch_fixture_root . '/runtime-test' );
+unlink( $missing_patch_fixture_root . '/runtime-test/files/patch.diff' );
+$missing_patch_failure = $artifacts->apply_preflight(
+	array(
+		'artifacts_path'  => $missing_patch_fixture_root,
+		'artifact_id'     => $artifact_id,
+		'approved_files'  => array( '/wordpress/wp-content/plugins/example/generated.txt', '/wordpress/wp-content/plugins/example/unapproved.txt' ),
+	)
+);
+$assert( 'artifact apply preflight rejects missing patch before payload creation', is_wp_error( $missing_patch_failure ) && 'wp_codebox_patch_missing' === $missing_patch_failure->get_error_code() );
 
 $hash_fixture_root = $root . '/artifact-hash-fixture';
 $copy_directory( $bundle_dir, $hash_fixture_root . '/runtime-test' );


### PR DESCRIPTION
## Summary
- Adds `wp-codebox/apply-artifact-preflight` and `wp codebox artifacts preflight-apply` so parent control planes can load, verify, approve-check, and receive the apply adapter payload without parent-side git/PR/deploy mutation.
- Reuses the new preflight helper inside `apply_approved()` so validation, patch filtering, digest metadata, and payload construction stay in one WP Codebox-owned path.
- Improves requested corrupt-bundle resolution so digest/missing-patch failures surface as validation errors instead of misleading not-found responses.

## Testing
- `php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-cli-command.php`
- `php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting the upstream preflight contract, targeted smoke coverage, and verification commands; Chris remains responsible for review and merge.