### PR TITLE
Add browser site operation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,39 @@ What WP Codebox provides for product use cases:
 - Fan out several task descriptions into separate isolated sandboxes.
 - Produce artifact bundles — patches, diffs, test results, live Playground preview URLs — that a parent product can review, replay, apply, or discard.
 
+## Browser Site Operations
+
+The WordPress plugin ships a browser runtime helper at
+`window.wpCodeboxBrowser` for product callers that drive a WordPress Playground
+from the browser. Low-level helpers such as `runPhpRequest`,
+`runWordPressOperation`, `ensureDirectory`, and `writeFile` remain available for
+custom workflows. Prefer the typed site-operation helpers for common safe
+actions because they validate input and return a normalized product envelope:
+
+```js
+{
+  operation: "setFrontendAdminBarVisible",
+  status: "ok",
+  target: "frontendAdminBar",
+  key: "show_admin_bar_front",
+  data: { visible: false },
+  errors: [],
+}
+```
+
+Current safe helpers:
+
+- `setFrontendAdminBarVisible(client, { visible, userId? })` toggles the
+  frontend admin bar preference for a Playground user. `visible` must be a
+  boolean, and `userId` must be a positive integer when supplied.
+- `writeReviewFile(client, { path, content, encoding? })` writes review or
+  artifact notes below the Playground uploads `wp-codebox/reviews` directory.
+  `path` must be a relative path without `.` or `..` segments.
+
+These helpers mutate only the disposable Playground runtime. Parent products
+remain responsible for reviewing artifacts and deciding whether to apply any
+result outside the sandbox.
+
 ## Host Tool Registry
 
 Host products can register generic tools for sandbox agents without adding

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -61,6 +61,36 @@
 		};
 	};
 
+	const siteOperationEnvelope = ( operation, result, meta = {} ) => {
+		const errors = result?.success === false ? [ result.error ].filter( Boolean ) : [];
+		return {
+			operation,
+			status: result?.success ? 'ok' : 'error',
+			...meta,
+			data: result?.success ? result.data ?? null : null,
+			errors,
+		};
+	};
+
+	const siteOperationValidationError = ( operation, message, meta = {} ) => siteOperationEnvelope( operation, {
+		success: false,
+		error: {
+			code: 'invalid_args',
+			message,
+			data: null,
+		},
+	}, meta );
+
+	const isSafeRelativePath = ( path ) => {
+		if ( typeof path !== 'string' || '' === path || path.startsWith( '/' ) || path.includes( '\\' ) ) {
+			return false;
+		}
+
+		return path.split( '/' ).every( ( part ) => part && part !== '.' && part !== '..' );
+	};
+
+	const isPlainObject = ( value ) => !! value && typeof value === 'object' && ! Array.isArray( value );
+
 const operationPhp = ( operation ) => `<?php
 header( 'Content-Type: application/json; charset=utf-8' );
 
@@ -159,10 +189,82 @@ function wp_codebox_browser_operation_theme_file_path( $theme_dir, $relative_pat
 	return trailingslashit( $theme_dir ) . implode( '/', $parts );
 }
 
+function wp_codebox_browser_operation_safe_relative_path( $relative_path, $label ) {
+	if ( ! is_string( $relative_path ) || '' === $relative_path || '/' === $relative_path[0] ) {
+		throw new InvalidArgumentException( sprintf( '%s path must be relative.', $label ) );
+	}
+
+	$parts = explode( '/', str_replace( chr( 92 ), '/', $relative_path ) );
+	foreach ( $parts as $part ) {
+		if ( '' === $part || '.' === $part || '..' === $part ) {
+			throw new InvalidArgumentException( sprintf( 'Invalid %s path: %s', $label, $relative_path ) );
+		}
+	}
+
+	return implode( '/', $parts );
+}
+
 try {
 	$type = isset( $operation['type'] ) && is_string( $operation['type'] ) ? $operation['type'] : '';
 
 	switch ( $type ) {
+		case 'setFrontendAdminBarVisible':
+			$visible = wp_codebox_browser_operation_arg( $operation, 'visible' );
+			if ( ! is_bool( $visible ) ) {
+				throw new InvalidArgumentException( 'Admin bar visibility must be a boolean.' );
+			}
+
+			$user_id = (int) wp_codebox_browser_operation_arg( $operation, 'userId', 0 );
+			if ( $user_id <= 0 ) {
+				$users = get_users( array(
+					'role__in' => array( 'administrator' ),
+					'number' => 1,
+					'fields' => 'ID',
+				) );
+				$user_id = isset( $users[0] ) ? (int) $users[0] : 1;
+			}
+
+			$user = get_user_by( 'id', $user_id );
+			if ( ! $user ) {
+				throw new RuntimeException( sprintf( 'User does not exist: %d', $user_id ) );
+			}
+
+			$value = $visible ? 'true' : 'false';
+			update_user_meta( $user_id, 'show_admin_bar_front', $value );
+			wp_codebox_browser_operation_response( true, array(
+				'target' => 'frontendAdminBar',
+				'key' => 'show_admin_bar_front',
+				'userId' => $user_id,
+				'visible' => $visible,
+				'value' => $value,
+			) );
+
+		case 'writeReviewFile':
+			$relative_path = wp_codebox_browser_operation_safe_relative_path( wp_codebox_browser_operation_arg( $operation, 'path' ), 'Review file' );
+			$content = wp_codebox_browser_operation_arg( $operation, 'content', '' );
+			$encoding = wp_codebox_browser_operation_arg( $operation, 'encoding', 'utf8' );
+			$content = wp_codebox_browser_operation_file_content( $content, $encoding );
+
+			$upload_dir = wp_upload_dir();
+			if ( empty( $upload_dir['basedir'] ) ) {
+				throw new RuntimeException( 'Upload directory is unavailable.' );
+			}
+
+			$base_dir = trailingslashit( $upload_dir['basedir'] ) . 'wp-codebox/reviews';
+			$path = trailingslashit( $base_dir ) . $relative_path;
+			wp_codebox_browser_operation_mkdir( dirname( $path ) );
+			$bytes = file_put_contents( $path, $content );
+			if ( false === $bytes ) {
+				throw new RuntimeException( sprintf( 'Unable to write review file: %s', $relative_path ) );
+			}
+
+			wp_codebox_browser_operation_response( true, array(
+				'target' => 'reviewFile',
+				'path' => $path,
+				'relativePath' => $relative_path,
+				'bytes' => $bytes,
+			) );
+
 		case 'ensureDirectory':
 			$path = wp_codebox_browser_operation_path( wp_codebox_browser_operation_arg( $operation, 'path' ) );
 			wp_codebox_browser_operation_mkdir( $path );
@@ -335,6 +437,65 @@ try {
 		args,
 	}, options );
 
+	const setFrontendAdminBarVisible = async ( client, args = {}, options = {} ) => {
+		const operation = 'setFrontendAdminBarVisible';
+		const meta = {
+			target: 'frontendAdminBar',
+			key: 'show_admin_bar_front',
+		};
+		if ( ! isPlainObject( args ) ) {
+			return siteOperationValidationError( operation, 'Admin bar operation args must be an object.', meta );
+		}
+
+		if ( typeof args?.visible !== 'boolean' ) {
+			return siteOperationValidationError( operation, 'Admin bar visibility must be a boolean.', meta );
+		}
+
+		if ( args.userId !== undefined && ( ! Number.isInteger( args.userId ) || args.userId <= 0 ) ) {
+			return siteOperationValidationError( operation, 'Admin bar userId must be a positive integer when provided.', meta );
+		}
+
+		const result = await runWordPressOperation( client, {
+			type: operation,
+			args,
+		}, options );
+
+		return siteOperationEnvelope( operation, result, meta );
+	};
+
+	const writeReviewFile = async ( client, args = {}, options = {} ) => {
+		const operation = 'writeReviewFile';
+		const meta = {
+			target: 'reviewFile',
+			path: args?.path ?? null,
+		};
+		if ( ! isPlainObject( args ) ) {
+			return siteOperationValidationError( operation, 'Review file operation args must be an object.', meta );
+		}
+
+		if ( ! isSafeRelativePath( args?.path ) ) {
+			return siteOperationValidationError( operation, 'Review file path must be a safe relative path.', meta );
+		}
+
+		if ( typeof args?.content !== 'string' ) {
+			return siteOperationValidationError( operation, 'Review file content must be a string.', meta );
+		}
+
+		if ( args.encoding !== undefined && args.encoding !== 'utf8' && args.encoding !== 'utf-8' && args.encoding !== 'base64' ) {
+			return siteOperationValidationError( operation, 'Review file encoding must be utf8 or base64.', meta );
+		}
+
+		const result = await runWordPressOperation( client, {
+			type: operation,
+			args,
+		}, options );
+
+		return siteOperationEnvelope( operation, result, {
+			...meta,
+			path: result?.data?.path ?? args.path,
+		} );
+	};
+
 	const markBrowserPlaygroundRunner = ( code ) => {
 		const marker = "define( 'WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER', true );";
 		const source = String( code || '' );
@@ -425,6 +586,8 @@ try {
 		runPhpRequest,
 		runRecipe,
 		runWordPressOperation,
+		setFrontendAdminBarVisible,
 		writeFile,
+		writeReviewFile,
 	};
 } )();

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -25,6 +25,8 @@ assert.equal(typeof runtime.browserSessionRecipe, "function")
 assert.equal(typeof runtime.runWordPressOperation, "function")
 assert.equal(typeof runtime.ensureDirectory, "function")
 assert.equal(typeof runtime.writeFile, "function")
+assert.equal(typeof runtime.setFrontendAdminBarVisible, "function")
+assert.equal(typeof runtime.writeReviewFile, "function")
 assert.equal(typeof runtime.installTheme, "function")
 assert.equal(typeof runtime.activateTheme, "function")
 
@@ -79,6 +81,105 @@ assert.deepEqual(sameRealm(writeResult), {
   },
 })
 assert.match(writeClient.files[0]?.contents ?? "", /case 'writeFile':/)
+
+const adminBarClient = createClient('{"success":true,"data":{"target":"frontendAdminBar","key":"show_admin_bar_front","userId":1,"visible":false,"value":"false"},"error":null}')
+const adminBarResult = await runtime.setFrontendAdminBarVisible(adminBarClient, { visible: false })
+assert.deepEqual(sameRealm(adminBarResult), {
+  operation: "setFrontendAdminBarVisible",
+  status: "ok",
+  target: "frontendAdminBar",
+  key: "show_admin_bar_front",
+  data: {
+    target: "frontendAdminBar",
+    key: "show_admin_bar_front",
+    userId: 1,
+    visible: false,
+    value: "false",
+  },
+  errors: [],
+})
+assert.match(adminBarClient.files[0]?.contents ?? "", /case 'setFrontendAdminBarVisible':/)
+
+const invalidAdminBarResult = await runtime.setFrontendAdminBarVisible(createClient("{}"), { visible: "false" })
+assert.deepEqual(sameRealm(invalidAdminBarResult), {
+  operation: "setFrontendAdminBarVisible",
+  status: "error",
+  target: "frontendAdminBar",
+  key: "show_admin_bar_front",
+  data: null,
+  errors: [
+    {
+      code: "invalid_args",
+      message: "Admin bar visibility must be a boolean.",
+      data: null,
+    },
+  ],
+})
+
+const invalidAdminBarArgsResult = await runtime.setFrontendAdminBarVisible(createClient("{}"), null)
+assert.deepEqual(sameRealm(invalidAdminBarArgsResult), {
+  operation: "setFrontendAdminBarVisible",
+  status: "error",
+  target: "frontendAdminBar",
+  key: "show_admin_bar_front",
+  data: null,
+  errors: [
+    {
+      code: "invalid_args",
+      message: "Admin bar operation args must be an object.",
+      data: null,
+    },
+  ],
+})
+
+const reviewFileClient = createClient('{"success":true,"data":{"target":"reviewFile","path":"/wordpress/wp-content/uploads/wp-codebox/reviews/artifacts/review.md","relativePath":"artifacts/review.md","bytes":9},"error":null}')
+const reviewFileResult = await runtime.writeReviewFile(reviewFileClient, { path: "artifacts/review.md", content: "looks ok\n" })
+assert.deepEqual(sameRealm(reviewFileResult), {
+  operation: "writeReviewFile",
+  status: "ok",
+  target: "reviewFile",
+  path: "/wordpress/wp-content/uploads/wp-codebox/reviews/artifacts/review.md",
+  data: {
+    target: "reviewFile",
+    path: "/wordpress/wp-content/uploads/wp-codebox/reviews/artifacts/review.md",
+    relativePath: "artifacts/review.md",
+    bytes: 9,
+  },
+  errors: [],
+})
+assert.match(reviewFileClient.files[0]?.contents ?? "", /case 'writeReviewFile':/)
+
+const unsafeReviewFileResult = await runtime.writeReviewFile(createClient("{}"), { path: "../escape.md", content: "nope" })
+assert.deepEqual(sameRealm(unsafeReviewFileResult), {
+  operation: "writeReviewFile",
+  status: "error",
+  target: "reviewFile",
+  path: "../escape.md",
+  data: null,
+  errors: [
+    {
+      code: "invalid_args",
+      message: "Review file path must be a safe relative path.",
+      data: null,
+    },
+  ],
+})
+
+const invalidReviewFileArgsResult = await runtime.writeReviewFile(createClient("{}"), null)
+assert.deepEqual(sameRealm(invalidReviewFileArgsResult), {
+  operation: "writeReviewFile",
+  status: "error",
+  target: "reviewFile",
+  path: null,
+  data: null,
+  errors: [
+    {
+      code: "invalid_args",
+      message: "Review file operation args must be an object.",
+      data: null,
+    },
+  ],
+})
 
 const themeClient = createClient("{\"success\":true,\"data\":{\"slug\":\"codebox-theme\",\"activated\":true,\"files\":[]},\"error\":null}")
 const themeResult = await runtime.installTheme(themeClient, {


### PR DESCRIPTION
## Summary
- Add typed browser runtime site-operation helpers for toggling the frontend admin bar and writing safe review files in disposable Playground runs.
- Return normalized product envelopes with operation, status, target/key/path metadata, data, and errors while keeping low-level runtime helpers available.
- Document the browser site-operation boundary for product callers.

Closes #478.

## Verification
- npm run browser-runtime-operation-smoke
- npm run build
- npm run wordpress-plugin-smoke
- npm run package-distribution-smoke
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the browser runtime helper implementation, smoke coverage, documentation updates, and verification commands for Chris to review/test.