### PR TITLE
Expose parent agent task runner contract

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -128,7 +128,26 @@ final class WP_Codebox_Abilities {
 								'description' => 'AI provider plugin directories to mount and activate inside the sandbox.',
 								'items'       => array( 'type' => 'string' ),
 							),
+							'parent_request'         => array(
+								'type'        => 'object',
+								'description' => 'External orchestrator task request, such as homeboy/wp-codebox-task-request/v1, normalized into the WP Codebox runner contract.',
+							),
 							'mounts'                 => $mount_schema,
+							'workspaces'             => array(
+								'type'        => 'array',
+								'description' => 'Recipe workspace entries to seed as policy-checked writable repositories.',
+								'items'       => array( 'type' => 'object' ),
+							),
+							'runtime_stack_mounts'   => array(
+								'type'        => 'array',
+								'description' => 'Runtime stack mounts to pass through to recipe.runtime.stack.mounts.',
+								'items'       => array( 'type' => 'object' ),
+							),
+							'runtime_overlays'       => array(
+								'type'        => 'array',
+								'description' => 'Runtime overlays to pass through to recipe.runtime.overlays.',
+								'items'       => array( 'type' => 'object' ),
+							),
 							'site_seeds'             => $site_seed_schema,
 							'inherit'                => $inherit_schema,
 							'sandbox_session_id'     => $session_input['sandbox_session_id'],
@@ -222,7 +241,20 @@ final class WP_Codebox_Abilities {
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
 							),
+							'parent_request'         => array( 'type' => 'object' ),
 							'mounts'                 => $mount_schema,
+							'workspaces'             => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
+							'runtime_stack_mounts'   => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
+							'runtime_overlays'       => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'object' ),
+							),
 							'inherit'                => $inherit_schema,
 							'sandbox_session_id'     => $session_input['sandbox_session_id'],
 							'orchestrator'           => $session_input['orchestrator'],

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -39,6 +39,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return new WP_Error( 'wp_codebox_shell_unavailable', 'Shell execution is not available for WP Codebox.', array( 'status' => 500 ) );
 		}
 
+		$input = $this->normalize_parent_task_request( $input );
+		if ( is_wp_error( $input ) ) {
+			return $input;
+		}
+
 		$task_input = $this->task_input( $input );
 		if ( is_wp_error( $task_input ) ) {
 			return $task_input;
@@ -161,6 +166,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	public function run_batch( array $input ): array|WP_Error {
 		if ( ! $this->shell_available() ) {
 			return new WP_Error( 'wp_codebox_shell_unavailable', 'Shell execution is not available for WP Codebox.', array( 'status' => 500 ) );
+		}
+
+		$input = $this->normalize_parent_task_request( $input );
+		if ( is_wp_error( $input ) ) {
+			return $input;
 		}
 
 		$task_inputs = $this->task_inputs( $input );
@@ -353,6 +363,80 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return true;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private function normalize_parent_task_request( array $input ): array|WP_Error {
+		$request = is_array( $input['parent_request'] ?? null ) ? $input['parent_request'] : $input;
+		$schema  = (string) ( $request['schema'] ?? '' );
+		if ( 'homeboy/wp-codebox-task-request/v1' !== $schema ) {
+			return $input;
+		}
+
+		$task = is_array( $request['task'] ?? null ) ? $request['task'] : array();
+		$goal = trim( (string) ( $task['goal'] ?? $task['prompt'] ?? $request['goal'] ?? $request['task_prompt'] ?? '' ) );
+		if ( '' === $goal ) {
+			return new WP_Error( 'wp_codebox_parent_task_missing', 'parent_request.task.prompt or parent_request.task.goal is required.', array( 'status' => 400 ) );
+		}
+
+		$workspace_paths = array_filter(
+			array(
+				(string) ( $input['agents_api_path'] ?? $request['agents_api'] ?? '' ),
+				(string) ( $request['homeboy'] ?? '' ),
+				(string) ( $request['homeboy_extensions'] ?? '' ),
+			),
+			static fn( string $path ): bool => '' !== trim( $path )
+		);
+		$workspaces      = $this->workspace_entries_for_paths( $workspace_paths );
+		$workspace_slugs = array_map( static fn( array $workspace ): string => (string) ( $workspace['seed']['slug'] ?? '' ), $workspaces );
+		$workspace_slugs = array_values( array_filter( $workspace_slugs, static fn( string $slug ): bool => '' !== $slug ) );
+
+		if ( ! empty( $workspace_slugs ) ) {
+			$goal .= "\n\nUse Data Machine Code workspace repos " . implode( ', ', array_map( static fn( string $slug ): string => '`' . $slug . '`', $workspace_slugs ) ) . ' for workspace_* tool calls.';
+		}
+
+		$context = is_array( $task['context'] ?? null ) ? $task['context'] : array();
+		foreach ( array( 'sandbox_session_id', 'group_key', 'audit_findings', 'orchestrator' ) as $context_key ) {
+			if ( array_key_exists( $context_key, $request ) ) {
+				$context[ $context_key ] = $request[ $context_key ];
+			}
+		}
+
+		$normalized = array_merge(
+			$input,
+			array_filter(
+				array(
+					'goal'                   => $goal,
+					'target'                 => is_array( $task['target'] ?? null ) ? $task['target'] : array(),
+					'allowed_tools'          => is_array( $task['allowed_tools'] ?? null ) ? $task['allowed_tools'] : array(),
+					'expected_artifacts'     => is_array( $task['expected_artifacts'] ?? null ) ? $task['expected_artifacts'] : array(),
+					'policy'                 => is_array( $task['policy'] ?? null ) ? $task['policy'] : array(),
+					'context'                => $context,
+					'provider'               => (string) ( $input['provider'] ?? $request['provider'] ?? '' ),
+					'model'                  => (string) ( $input['model'] ?? $request['model'] ?? '' ),
+					'provider_plugin_paths'  => $this->merge_string_lists( $input['provider_plugin_paths'] ?? array(), $request['provider_plugin_paths'] ?? array() ),
+					'secret_env'             => $this->merge_string_lists( $input['secret_env'] ?? array(), $request['secret_env'] ?? array() ),
+					'mounts'                 => $this->merge_array_lists( $input['mounts'] ?? array(), $request['mounts'] ?? array() ),
+					'workspaces'             => $this->merge_array_lists( $input['workspaces'] ?? array(), $workspaces ),
+					'runtime_stack_mounts'   => $this->merge_array_lists( $input['runtime_stack_mounts'] ?? array(), $request['runtime_stack_mounts'] ?? array() ),
+					'runtime_overlays'       => $this->merge_array_lists( $input['runtime_overlays'] ?? array(), $request['runtime_overlays'] ?? array() ),
+					'task_timeout_seconds'   => (int) ( $input['task_timeout_seconds'] ?? $request['task_timeout_seconds'] ?? $request['taskTimeoutSeconds'] ?? 0 ),
+					'max_turns'              => (int) ( $input['max_turns'] ?? $request['max_turns'] ?? $request['maxTurns'] ?? 0 ),
+					'sandbox_session_id'     => (string) ( $input['sandbox_session_id'] ?? $request['sandbox_session_id'] ?? '' ),
+					'orchestrator'           => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : ( is_array( $request['orchestrator'] ?? null ) ? $request['orchestrator'] : array() ),
+					'artifacts_path'         => (string) ( $input['artifacts_path'] ?? $request['artifacts'] ?? '' ),
+					'wp_codebox_bin'         => (string) ( $input['wp_codebox_bin'] ?? $request['wp_codebox_bin'] ?? '' ),
+					'agents_api_path'        => (string) ( $input['agents_api_path'] ?? $request['agents_api'] ?? '' ),
+					'data_machine_path'      => (string) ( $input['data_machine_path'] ?? $request['data_machine'] ?? '' ),
+					'data_machine_code_path' => (string) ( $input['data_machine_code_path'] ?? $request['data_machine_code'] ?? '' ),
+				),
+				static fn( mixed $value ): bool => '' !== $value && array() !== $value && 0 !== $value
+			)
+		);
+
+		unset( $normalized['parent_request'] );
+
+		return $normalized;
 	}
 
 	private function agent_slug( array $input ): string {
@@ -849,6 +933,61 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				)
 			)
 		);
+	}
+
+	/** @return string[] */
+	private function merge_string_lists( mixed ...$lists ): array {
+		$merged = array();
+		foreach ( $lists as $list ) {
+			$merged = array_merge( $merged, $this->string_list( $list ) );
+		}
+
+		return array_values( array_unique( $merged ) );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private function merge_array_lists( mixed ...$lists ): array {
+		$merged = array();
+		foreach ( $lists as $list ) {
+			foreach ( is_array( $list ) ? $list : array() as $entry ) {
+				if ( is_array( $entry ) ) {
+					$merged[] = $entry;
+				}
+			}
+		}
+
+		return $merged;
+	}
+
+	/** @param string[] $paths @return array<int,array<string,mixed>> */
+	private function workspace_entries_for_paths( array $paths ): array {
+		$workspaces = array();
+		foreach ( $paths as $path ) {
+			$path = $this->clean_path( $path );
+			if ( '' === $path || ! is_dir( $path ) ) {
+				continue;
+			}
+
+			$slug = preg_replace( '/[^A-Za-z0-9_-]/', '-', explode( '@', basename( $path ) )[0] );
+			$slug = is_string( $slug ) ? trim( $slug, '-' ) : '';
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$workspaces[] = array(
+				'seed'       => array(
+					'type'         => 'directory',
+					'source'       => $path,
+					'slug'         => $slug,
+					'excludePaths' => array( '.git', '.homeboy', '.homeboy-bin', '.homeboy-build', '.datamachine', '.DS_Store', '._*', '.env*', 'node_modules', 'target', 'vendor' ),
+				),
+				'target'     => '/workspace/' . $slug,
+				'mode'       => 'readwrite',
+				'sourceMode' => 'repo-backed',
+			);
+		}
+
+		return $workspaces;
 	}
 
 	/** @param string[] $tools */
@@ -1364,6 +1503,41 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return $normalized;
 	}
 
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
+	private function recipe_workspaces( array $input ): array|WP_Error {
+		$workspaces = is_array( $input['workspaces'] ?? null ) ? $input['workspaces'] : array();
+		foreach ( $workspaces as $index => $workspace ) {
+			if ( ! is_array( $workspace ) || ! is_array( $workspace['seed'] ?? null ) ) {
+				return new WP_Error( 'wp_codebox_workspace_invalid', 'Each WP Codebox workspace must include a seed object.', array( 'status' => 400, 'index' => $index ) );
+			}
+			if ( 'directory' === (string) ( $workspace['seed']['type'] ?? '' ) && empty( $workspace['seed']['source'] ) ) {
+				return new WP_Error( 'wp_codebox_workspace_source_missing', 'Directory workspaces require seed.source.', array( 'status' => 400, 'index' => $index ) );
+			}
+		}
+
+		return $workspaces;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	private function recipe_runtime( array $input, string $wp_version ): array|WP_Error {
+		$runtime = array(
+			'wp'        => $wp_version,
+			'blueprint' => array( 'steps' => array() ),
+		);
+
+		$stack_mounts = $this->merge_array_lists( $input['runtime_stack_mounts'] ?? array() );
+		if ( ! empty( $stack_mounts ) ) {
+			$runtime['stack'] = array( 'mounts' => $stack_mounts );
+		}
+
+		$overlays = $this->merge_array_lists( $input['runtime_overlays'] ?? array() );
+		if ( ! empty( $overlays ) ) {
+			$runtime['overlays'] = $overlays;
+		}
+
+		return $runtime;
+	}
+
 	private function command_prefix( string $bin ): string|WP_Error {
 		if ( str_ends_with( $bin, '.js' ) && is_file( $bin ) ) {
 			$node = $this->node_binary();
@@ -1501,6 +1675,14 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		if ( is_wp_error( $mounts ) ) {
 			return $mounts;
 		}
+		$workspaces = $this->recipe_workspaces( $input );
+		if ( is_wp_error( $workspaces ) ) {
+			return $workspaces;
+		}
+		$runtime = $this->recipe_runtime( $input, $wp_version );
+		if ( is_wp_error( $runtime ) ) {
+			return $runtime;
+		}
 
 		$site_seed_payload = $this->parent_site_seed_recipe_entries( $input );
 		if ( is_wp_error( $site_seed_payload ) ) {
@@ -1509,6 +1691,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		$recipe_inputs = array(
 			'mounts'       => $mounts,
+			'workspaces'   => $workspaces,
 			'inherit'      => $this->inheritance_request( $input ),
 			'inheritance'  => $inheritance,
 			'extraPlugins' => array_merge( $this->component_plugins( $paths ), $provider_plugins ),
@@ -1520,10 +1703,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		$recipe = array(
 			'schema'   => 'wp-codebox/workspace-recipe/v1',
-			'runtime'  => array(
-				'wp'        => $wp_version,
-				'blueprint' => array( 'steps' => array() ),
-			),
+			'runtime'  => $runtime,
 			'inputs'   => $recipe_inputs,
 			'workflow' => array( 'steps' => $steps ),
 		);

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
@@ -71,9 +71,10 @@ final class WP_Codebox_Agent_Task {
 		if ( isset( $input['orchestrator'] ) && is_array( $input['orchestrator'] ) ) {
 			$session['orchestrator'] = array_filter(
 				array(
-					'id'     => isset( $input['orchestrator']['id'] ) ? (string) $input['orchestrator']['id'] : '',
-					'type'   => isset( $input['orchestrator']['type'] ) ? (string) $input['orchestrator']['type'] : '',
-					'job_id' => isset( $input['orchestrator']['job_id'] ) ? (string) $input['orchestrator']['job_id'] : '',
+					'id'            => isset( $input['orchestrator']['id'] ) ? (string) $input['orchestrator']['id'] : '',
+					'type'          => isset( $input['orchestrator']['type'] ) ? (string) $input['orchestrator']['type'] : '',
+					'job_id'        => isset( $input['orchestrator']['job_id'] ) ? (string) $input['orchestrator']['job_id'] : '',
+					'agent_task_id' => isset( $input['orchestrator']['agent_task_id'] ) ? (string) $input['orchestrator']['agent_task_id'] : '',
 				),
 				static fn( mixed $value ): bool => '' !== $value
 			);

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -138,11 +138,11 @@ final class WP_Codebox_CLI_Command {
 	}
 
 	private function normalize_value( string $field, mixed $value ): mixed {
-		if ( in_array( $field, array( 'target', 'policy', 'context', 'inherit', 'orchestrator', 'playground', 'browser_runner', 'runtime', 'blueprint', 'apply_target' ), true ) ) {
+		if ( in_array( $field, array( 'target', 'policy', 'context', 'inherit', 'orchestrator', 'parent_request', 'playground', 'browser_runner', 'runtime', 'blueprint', 'apply_target' ), true ) ) {
 			return $this->json_object( (string) $value, $field );
 		}
 
-		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'provider_plugin_paths', 'secret_env', 'browser_plugins', 'artifact_files', 'approved_files' ), true ) ) {
+		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'provider_plugin_paths', 'secret_env', 'mounts', 'workspaces', 'runtime_stack_mounts', 'runtime_overlays', 'browser_plugins', 'artifact_files', 'approved_files' ), true ) ) {
 			return $this->json_or_list( (string) $value, $field );
 		}
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -1356,6 +1356,71 @@ $assert( 'runner recipe passes secret env name only', str_contains( $captured_re
 $assert( 'runner passes timeout to command runner and recipe', 7200 === $captured_timeout && str_contains( $captured_recipe, 'timeout-seconds=7200' ) );
 $assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
 
+$homeboy_result = $runner->run(
+	array(
+		'parent_request' => array(
+			'schema'               => 'homeboy/wp-codebox-task-request/v1',
+			'provider'             => 'openai',
+			'model'                => 'gpt-5.5',
+			'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+			'secret_env'           => array( 'GITHUB_TOKEN' ),
+			'mounts'               => array(
+				array(
+					'source'   => $root . '/editable-plugin',
+					'target'   => '/workspace/editable-plugin',
+					'mode'     => 'readwrite',
+					'metadata' => array( 'kind' => 'homeboy-audit-fanout' ),
+				),
+			),
+			'runtime_stack_mounts' => array(
+				array(
+					'source' => $root . '/agents-api',
+					'target' => '/runtime/agents-api',
+					'mode'   => 'readonly',
+				),
+			),
+			'runtime_overlays'     => array(
+				array(
+					'id'     => 'homeboy-runtime-overlay',
+					'source' => $root . '/data-machine-code',
+				),
+			),
+			'task_timeout_seconds' => 3600,
+			'max_turns'            => 8,
+			'sandbox_session_id'   => 'homeboy-sandbox-session-123',
+			'group_key'            => 'homeboy-group-key',
+			'audit_findings'       => array( array( 'id' => 'finding-1', 'summary' => 'Finding one' ) ),
+			'artifacts'            => $root . '/artifacts/homeboy',
+			'orchestrator'         => array(
+				'type'          => 'homeboy',
+				'id'            => 'homeboy-agent-task',
+				'job_id'        => 'homeboy-job-123',
+				'agent_task_id' => 'agent-task-123',
+			),
+			'agents_api'           => $root . '/agents-api',
+			'data_machine'         => $root . '/data-machine',
+			'data_machine_code'    => $root . '/data-machine-code',
+			'homeboy'              => $root . '/editable-plugin',
+			'homeboy_extensions'   => $root . '/plugin-root/agents-api',
+			'task'                 => array(
+				'prompt'             => 'Run the Homeboy-shaped Codebox task.',
+				'expected_artifacts' => array( 'patch' ),
+				'policy'             => array( 'kind' => 'audit-remediation' ),
+				'context'            => array( 'group_key' => 'smoke' ),
+			),
+		),
+	)
+);
+$homeboy_recipe = json_decode( $captured_recipe, true );
+$homeboy_step_args = $homeboy_recipe['workflow']['steps'][0]['args'] ?? array();
+$assert( 'runner accepts Homeboy-shaped parent request', ! is_wp_error( $homeboy_result ) && true === ( $homeboy_result['success'] ?? false ) && 'homeboy-sandbox-session-123' === ( $homeboy_result['session']['id'] ?? '' ) );
+$assert( 'runner maps Homeboy artifacts and orchestrator metadata', ! is_wp_error( $homeboy_result ) && $root . '/artifacts/homeboy' === ( $homeboy_result['artifacts'] ?? '' ) && 'homeboy-job-123' === ( $homeboy_result['session']['orchestrator']['job_id'] ?? '' ) && 'agent-task-123' === ( $homeboy_result['session']['orchestrator']['agent_task_id'] ?? '' ) );
+$assert( 'runner maps Homeboy provider plugins and secrets', in_array( 'provider-plugin-slugs=ai-provider-test', $homeboy_step_args, true ) && str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
+$assert( 'runner maps Homeboy timeout and max turns', 3600 === $captured_timeout && in_array( 'timeout-seconds=3600', $homeboy_step_args, true ) && in_array( 'max-turns=8', $homeboy_step_args, true ) );
+$assert( 'runner maps Homeboy runtime stack mounts and overlays', '/runtime/agents-api' === ( $homeboy_recipe['runtime']['stack']['mounts'][0]['target'] ?? '' ) && 'homeboy-runtime-overlay' === ( $homeboy_recipe['runtime']['overlays'][0]['id'] ?? '' ) );
+$assert( 'runner maps Homeboy workspaces without downstream recipe generation', 3 === count( $homeboy_recipe['inputs']['workspaces'] ?? array() ) && str_contains( $captured_recipe, 'Use Data Machine Code workspace repos' ) && str_contains( $captured_recipe, '`agents-api`' ) );
+$assert( 'runner passes Homeboy task context to sandbox agent', str_contains( $captured_recipe, 'homeboy-group-key' ) && str_contains( $captured_recipe, 'finding-1' ) && str_contains( $captured_recipe, 'agent-task-123' ) );
+
 $GLOBALS['wp_codebox_options']['blogname'] = 'Parent Seed Site';
 $GLOBALS['wp_codebox_options']['active_plugins'] = array( 'agents-api/agents-api.php' );
 $seed_result = $runner->run(


### PR DESCRIPTION
## Summary
- Adds a `parent_request` adapter for `homeboy/wp-codebox-task-request/v1` so external executors can call `wp-codebox/run-agent-task` without synthesizing full WP Codebox recipes.
- Passes provider plugin paths, secret env names, mounts, runtime stack mounts/overlays, workspaces, timeouts, max turns, sandbox session IDs, artifacts paths, and orchestrator/task context through the existing sandbox runner.
- Extends WordPress plugin smoke coverage for Homeboy-shaped input through the upstream runner contract.

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-task.php`
- `php -l tests/smoke-wordpress-plugin.php`
- `npm run build`
- `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the parent task runner adapter, CLI/schema updates, smoke coverage, and verification under Chris's requested issue scope.