### PR TITLE
Fix mounted workspace patch churn

### DIFF
--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -319,7 +319,7 @@ export function buildArtifactReview({
       runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
     },
     ...(browser ? { browser } : {}),
-    riskFlags: [],
+    riskFlags: suspiciousFullFileRewriteRiskFlags(patch),
   }
 }
 
@@ -652,8 +652,8 @@ export async function directoryDiff(baselineDirectory: string, currentDirectory:
   const files: DirectoryDiffResult["files"] = []
 
   for (const relativePath of paths) {
-    const before = baselineFiles.get(relativePath)
-    const after = currentFiles.get(relativePath)
+    const before = normalizePatchText(baselineFiles.get(relativePath))
+    const after = normalizePatchText(currentFiles.get(relativePath))
     if (before === after) {
       continue
     }
@@ -737,20 +737,76 @@ function fileDiff(path: string, before: string, after: string, isAdded: boolean,
   const gitNewPath = `b${path}`
   const oldPath = isAdded ? "/dev/null" : gitOldPath
   const newPath = isDeleted ? "/dev/null" : gitNewPath
-  const oldStart = isAdded ? 0 : 1
-  const newStart = isDeleted ? 0 : 1
   const lines = [
     `diff --git ${gitOldPath} ${gitNewPath}`,
     ...(isAdded ? ["new file mode 100644"] : []),
     ...(isDeleted ? ["deleted file mode 100644"] : []),
     `--- ${oldPath}`,
     `+++ ${newPath}`,
+    ...(isAdded || isDeleted ? fullFileHunk(beforeLines, afterLines, isAdded, isDeleted) : localizedFileHunk(beforeLines, afterLines)),
+  ]
+
+  return `${lines.join("\n")}\n`
+}
+
+function normalizePatchText(text: string | undefined): string | undefined {
+  return text?.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+}
+
+function fullFileHunk(beforeLines: string[], afterLines: string[], isAdded: boolean, isDeleted: boolean): string[] {
+  const oldStart = isAdded ? 0 : 1
+  const newStart = isDeleted ? 0 : 1
+  return [
     `@@ -${oldStart},${beforeLines.length} +${newStart},${afterLines.length} @@`,
     ...beforeLines.map((line) => `-${line}`),
     ...afterLines.map((line) => `+${line}`),
   ]
+}
 
-  return `${lines.join("\n")}\n`
+function localizedFileHunk(beforeLines: string[], afterLines: string[]): string[] {
+  const context = 3
+  let prefix = 0
+  while (prefix < beforeLines.length && prefix < afterLines.length && beforeLines[prefix] === afterLines[prefix]) {
+    prefix++
+  }
+
+  let suffix = 0
+  while (
+    suffix < beforeLines.length - prefix &&
+    suffix < afterLines.length - prefix &&
+    beforeLines[beforeLines.length - suffix - 1] === afterLines[afterLines.length - suffix - 1]
+  ) {
+    suffix++
+  }
+
+  const beforeChangeEnd = beforeLines.length - suffix
+  const afterChangeEnd = afterLines.length - suffix
+  const beforeHunkStart = Math.max(0, prefix - context)
+  const afterHunkStart = Math.max(0, prefix - context)
+  const beforeHunkEnd = Math.min(beforeLines.length, beforeChangeEnd + context)
+  const afterHunkEnd = Math.min(afterLines.length, afterChangeEnd + context)
+  const beforeHunkLength = beforeHunkEnd - beforeHunkStart
+  const afterHunkLength = afterHunkEnd - afterHunkStart
+  const lines = [`@@ -${hunkStartLine(beforeHunkStart, beforeHunkLength)},${beforeHunkLength} +${hunkStartLine(afterHunkStart, afterHunkLength)},${afterHunkLength} @@`]
+
+  for (let index = beforeHunkStart; index < prefix; index++) {
+    lines.push(` ${beforeLines[index]}`)
+  }
+  for (let index = prefix; index < beforeChangeEnd; index++) {
+    lines.push(`-${beforeLines[index]}`)
+  }
+  for (let index = prefix; index < afterChangeEnd; index++) {
+    lines.push(`+${afterLines[index]}`)
+  }
+  for (let index = afterChangeEnd; index < afterHunkEnd; index++) {
+    lines.push(` ${afterLines[index]}`)
+  }
+
+  return lines
+}
+
+function hunkStartLine(startIndex: number, lineCount: number): number {
+  return lineCount === 0 ? 0 : startIndex + 1
 }
 
 function splitLines(text: string): string[] {
@@ -759,4 +815,48 @@ function splitLines(text: string): string[] {
   }
 
   return text.replace(/\n$/, "").split("\n")
+}
+
+function suspiciousFullFileRewriteRiskFlags(patch: string): string[] {
+  const flags = new Set<string>()
+  let currentPath = ""
+  let currentHunkLines = { old: 0, new: 0, added: 0, removed: 0 }
+
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      recordSuspiciousRewrite(flags, currentPath, currentHunkLines)
+      currentPath = line.replace(/^diff --git a/, "").replace(/ b.*$/, "")
+      currentHunkLines = { old: 0, new: 0, added: 0, removed: 0 }
+      continue
+    }
+
+    const hunk = line.match(/^@@ -(?:\d+),(\d+) \+(?:\d+),(\d+) @@/)
+    if (hunk) {
+      recordSuspiciousRewrite(flags, currentPath, currentHunkLines)
+      currentHunkLines = { old: Number(hunk[1]), new: Number(hunk[2]), added: 0, removed: 0 }
+      continue
+    }
+
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      currentHunkLines.added++
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      currentHunkLines.removed++
+    }
+  }
+
+  recordSuspiciousRewrite(flags, currentPath, currentHunkLines)
+  return [...flags].sort()
+}
+
+function recordSuspiciousRewrite(flags: Set<string>, path: string, hunkLines: { old: number; new: number; added: number; removed: number }): void {
+  const fileLines = Math.max(hunkLines.old, hunkLines.new)
+  const touchedLines = hunkLines.added + hunkLines.removed
+  const hunkLinesTotal = hunkLines.old + hunkLines.new
+  if (!path || fileLines < 50 || hunkLinesTotal === 0) {
+    return
+  }
+
+  if (touchedLines / hunkLinesTotal >= 0.8) {
+    flags.add(`suspicious-full-file-rewrite:${path}`)
+  }
 }

--- a/scripts/mounted-workspace-diff-smoke.ts
+++ b/scripts/mounted-workspace-diff-smoke.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { MountSpec } from "@chubes4/wp-codebox-core"
-import { ArtifactRedactor } from "../packages/runtime-playground/src/artifacts.js"
+import { ArtifactRedactor, buildArtifactReview } from "../packages/runtime-playground/src/artifacts.js"
 import { captureMountDiffs } from "../packages/runtime-playground/src/mounted-artifact-capture.js"
 
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-mounted-diff-smoke-"))
@@ -19,9 +19,13 @@ try {
 
   await writeFile(join(baseline, "plugin.php"), "<?php\n// before\n")
   await writeFile(join(baseline, "delete-me.txt"), "remove me\n")
+  await writeFile(join(baseline, "script.sh"), numberedLines("before", 120).join("\r\n") + "\r\n")
 
   // Simulates workspace_edit mutations against the mounted workspace copy.
   await writeFile(join(workspace, "plugin.php"), "<?php\n// after\n")
+  const scriptLines = numberedLines("before", 120)
+  scriptLines[41] = "line 042 after"
+  await writeFile(join(workspace, "script.sh"), scriptLines.join("\n") + "\n")
 
   // Simulates workspace_write creating a new file in the mounted workspace copy.
   await writeFile(join(workspace, "generated.txt"), "cooked\n")
@@ -50,11 +54,18 @@ try {
   assert.equal(result.mountDiffs[0].changed, true)
   assert.equal(changed.get("generated.txt")?.status, "added")
   assert.equal(changed.get("plugin.php")?.status, "modified")
+  assert.equal(changed.get("script.sh")?.status, "modified")
   assert.equal(changed.get("delete-me.txt")?.status, "deleted")
   assert.match(result.patch, /diff --git a\/workspace\/plugin\/generated\.txt b\/workspace\/plugin\/generated\.txt/)
   assert.match(result.patch, /\+cooked/)
   assert.match(result.patch, /diff --git a\/workspace\/plugin\/plugin\.php b\/workspace\/plugin\/plugin\.php/)
   assert.match(result.patch, /\+\/\/ after/)
+  assert.match(result.patch, /diff --git a\/workspace\/plugin\/script\.sh b\/workspace\/plugin\/script\.sh/)
+  assert.match(result.patch, /@@ -39,7 \+39,7 @@/)
+  assert.match(result.patch, /-line 042 before/)
+  assert.match(result.patch, /\+line 042 after/)
+  assert.doesNotMatch(result.patch, /@@ -1,120 \+1,120 @@/)
+  assert.doesNotMatch(result.patch, /-line 001 before[\s\S]*-line 120 before/)
   assert.match(result.patch, /deleted file mode 100644/)
 
   const mountPatch = await readFile(join(artifactRoot, result.mountDiffs[0].artifactPath), "utf8")
@@ -73,6 +84,37 @@ try {
   assert.equal(missingBaselineResult.changedFiles.files.length, 0)
   assert.equal(missingBaselineResult.mountDiffs[0].status, "skipped")
   assert.equal(missingBaselineResult.mountDiffs[0].reason, "missing-baseline-source")
+
+  const fullRewritePatch = [
+    "diff --git a/workspace/plugin/script.sh b/workspace/plugin/script.sh",
+    "--- a/workspace/plugin/script.sh",
+    "+++ b/workspace/plugin/script.sh",
+    "@@ -1,60 +1,60 @@",
+    ...numberedLines("before", 60).map((line) => `-${line}`),
+    ...numberedLines("after", 60).map((line) => `+${line}`),
+    "",
+  ].join("\n")
+  const review = buildArtifactReview({
+    artifactId: "artifact-bundle-test",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    provenance: {
+      runtime: { backend: "wordpress-playground" },
+      mounts: [{ type: "directory", source: workspace, target: "/workspace/plugin", mode: "readwrite" }],
+    },
+    changedFiles: {
+      schema: "wp-codebox/changed-files/v1",
+      files: [{ path: "/workspace/plugin/script.sh", relativePath: "script.sh", status: "modified", mountIndex: 0, mountTarget: "/workspace/plugin", patchPath: "files/patch.diff" }],
+    },
+    patch: fullRewritePatch,
+    contentDigest: "sha256-test",
+    runtimeCreatedAt: "2026-06-01T00:00:00.000Z",
+    mounts,
+  })
+  assert.deepEqual(review.riskFlags, ["suspicious-full-file-rewrite:/workspace/plugin/script.sh"])
 } finally {
   await rm(root, { recursive: true, force: true })
+}
+
+function numberedLines(label: string, count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `line ${String(index + 1).padStart(3, "0")} ${label}`)
 }


### PR DESCRIPTION
## Summary
- Normalize mounted text-file line endings before comparing baseline and sandbox copies so CRLF/LF churn does not create false file rewrites.
- Emit localized unified hunks for modified mounted files while preserving full-file hunks for added and deleted files.
- Flag suspicious high-ratio full-file rewrites in artifact review `riskFlags`.

Fixes #488.

## Verification
- `npm run mounted-workspace-diff-smoke` passed
- `npm run build` passed
- `npm run artifact-patch-git-apply-smoke` passed
- `npm run artifact-bundle-verifier-smoke` passed
- `npm run artifact-contract-smoke` passed
- `npm run check` did not complete: persistent unrelated `recipe-site-seed-smoke` assertion failure, `4 !== 3` at `scripts/recipe-site-seed-smoke.ts:243`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WP Codebox mounted workspace diff normalization change, regression smoke coverage, verification commands, commit, and PR description for Chris to review.