### PR TITLE
Fix browser PHP request handler usage

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -368,8 +368,21 @@ try {
 }
 `;
 
+	const playgroundRequestHandler = ( client ) => {
+		if ( client?.requestHandler && typeof client.requestHandler.request === 'function' ) {
+			return client.requestHandler;
+		}
+
+		if ( client && typeof client.request === 'function' ) {
+			return client;
+		}
+
+		return null;
+	};
+
 	const runPhpRequest = async ( client, options = {} ) => {
-		if ( ! client || typeof client.request !== 'function' ) {
+		const requestHandler = playgroundRequestHandler( client );
+		if ( ! requestHandler ) {
 			throw new Error( 'Playground request handler is unavailable.' );
 		}
 
@@ -394,7 +407,7 @@ try {
 		}
 		await client.writeFile( scriptPath, code );
 
-		const response = await client.request( {
+		const response = await requestHandler.request( {
 			method: 'GET',
 			url: requestUrl,
 		} );

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -71,6 +71,13 @@ assert.match(successClient.files[0]?.contents ?? "", /wp-load\.php/)
 assert.match(successClient.files[0]?.contents ?? "", /case 'ensureDirectory':/)
 assert.match(successClient.requests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/codebox-ensuredirectory-/)
 
+const handlerClient = createClient("prefix {\"success\":true,\"data\":{\"runner\":\"handler\"},\"error\":null} suffix", false, true)
+const handlerResult = await runtime.runPhpRequest(handlerClient, { code: "<?php echo 'ok';", expectJson: true })
+assert.deepEqual(sameRealm(handlerResult), { success: true, data: { runner: "handler" }, error: null })
+assert.equal(handlerClient.handlerRequests.length, 1)
+assert.equal(handlerClient.requests.length, 0)
+assert.match(handlerClient.handlerRequests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/task-/)
+
 const writeClient = createClient("{\"success\":true,\"data\":{\"path\":\"/wordpress/wp-content/example.txt\",\"bytes\":11},\"error\":null}")
 const writeResult = await runtime.writeFile(writeClient, { path: "/wordpress/wp-content/example.txt", content: "hello world" })
 assert.deepEqual(sameRealm(writeResult), {
@@ -298,13 +305,15 @@ function sameRealm<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
 
-function createClient(response: unknown, supportsRun = false) {
+function createClient(response: unknown, supportsRun = false, supportsRequestHandler = false) {
   const client = {
     mkdirs: [] as string[],
     files: [] as Array<{ path: string; contents: string }>,
     requests: [] as Array<{ method: string; url: string }>,
+    handlerRequests: [] as Array<{ method: string; url: string }>,
     runs: [] as Array<{ code: string }>,
     runResponse: undefined as unknown,
+    requestHandler: undefined as undefined | { request: (request: { method: string; url: string }) => Promise<unknown> },
     async mkdir(path: string) {
       this.mkdirs.push(path)
     },
@@ -323,6 +332,15 @@ function createClient(response: unknown, supportsRun = false) {
 
   if (!supportsRun) {
     delete (client as { run?: unknown }).run
+  }
+
+  if (supportsRequestHandler) {
+    client.requestHandler = {
+      request: async (request: { method: string; url: string }) => {
+        client.handlerRequests.push(request)
+        return response
+      },
+    }
   }
 
   return client


### PR DESCRIPTION
## Summary
- Prefer the Playground PHP request handler when running browser-side PHP requests.
- Keep the legacy client request path as a fallback for older clients.
- Add browser runtime smoke coverage proving the request handler path does not call the deprecated client request method.

## Testing
- npm run browser-runtime-operation-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the browser runtime fix, added smoke coverage, and ran targeted verification; Chris requested the change and merge.