### PR TITLE
Fix sandbox agent bundle imports before chat

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -2,6 +2,15 @@ import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT } from "@chubes4/wp-codebox-core"
 
+export interface AgentBundleSpec {
+  source?: string
+  bundle?: Record<string, unknown>
+  slug?: string
+  on_conflict?: "error" | "skip" | "upgrade"
+  owner_id?: number
+  token_env?: string
+}
+
 export interface AgentSandboxCodeOptions {
   task: string
   agent?: string
@@ -11,6 +20,7 @@ export interface AgentSandboxCodeOptions {
   sessionId?: string
   maxTurns?: string
   timeoutSeconds?: string
+  agentBundles?: AgentBundleSpec[]
   code?: string
   codeFile?: string
 }
@@ -58,6 +68,7 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
 
   const timeoutSeconds = Number.parseInt(options.timeoutSeconds ?? '', 10)
   const timeoutLimit = Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 0
+  const agentBundles = normalizeAgentBundleSpecs(options.agentBundles ?? [])
 
   return `
 if (function_exists('wp_set_current_user')) {
@@ -100,7 +111,12 @@ if (function_exists('wp_get_ability')) {
 }
 $sandbox_stack['workspace_adoptions'] = $sandbox_workspace_adoptions;
 
-if (class_exists('DataMachine\\Core\\Database\\Agents\\Agents')) {
+$sandbox_agent_bundles = json_decode(${JSON.stringify(JSON.stringify(agentBundles))}, true);
+$sandbox_agent_bundle_imports = wp_codebox_import_sandbox_agent_bundles(is_array($sandbox_agent_bundles) ? $sandbox_agent_bundles : array());
+$sandbox_stack['agent_bundle_imports'] = $sandbox_agent_bundle_imports;
+$sandbox_agent_bundle_import_failures = array_filter($sandbox_agent_bundle_imports, static fn($import) => is_array($import) && empty($import['success']));
+
+if (empty($sandbox_agent_bundle_imports) && class_exists('DataMachine\\Core\\Database\\Agents\\Agents')) {
     $sandbox_agent_slug = sanitize_title((string) (${JSON.stringify(input.agent)}));
     if ('' !== $sandbox_agent_slug) {
         $sandbox_agents = new DataMachine\\Core\\Database\\Agents\\Agents();
@@ -147,6 +163,78 @@ add_filter('datamachine_agent_mode_sandbox', static function (string $content): 
     $guidance = ${JSON.stringify(sandboxModeGuidance())};
     return trim($content) === '' ? $guidance : trim($content) . "\n\n" . $guidance;
 }, 100, 1);
+
+function wp_codebox_import_sandbox_agent_bundles(array $bundle_specs): array {
+    if (empty($bundle_specs)) {
+        return array();
+    }
+
+    $ability = function_exists('wp_get_ability') ? wp_get_ability('datamachine/import-agent') : null;
+    if (!$ability || !method_exists($ability, 'execute')) {
+        return array(array(
+            'success' => false,
+            'error' => array(
+                'code' => 'datamachine_import_agent_unavailable',
+                'message' => 'The canonical datamachine/import-agent ability is not available inside the sandbox.',
+            ),
+        ));
+    }
+
+    $imports = array();
+    foreach ($bundle_specs as $index => $spec) {
+        if (!is_array($spec)) {
+            $imports[] = array('success' => false, 'index' => $index, 'error' => array('code' => 'agent_bundle_spec_invalid', 'message' => 'Agent bundle spec must be an object.'));
+            continue;
+        }
+
+        $source = isset($spec['source']) ? trim((string) $spec['source']) : '';
+        $temp_source = '';
+        if ('' === $source && isset($spec['bundle']) && is_array($spec['bundle'])) {
+            $temp_source = tempnam(sys_get_temp_dir(), 'wp-codebox-agent-bundle-');
+            if (false === $temp_source) {
+                $imports[] = array('success' => false, 'index' => $index, 'error' => array('code' => 'agent_bundle_temp_failed', 'message' => 'Could not create a temporary agent bundle JSON file.'));
+                continue;
+            }
+            $json_source = wp_json_encode($spec['bundle'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            if (!is_string($json_source) || false === file_put_contents($temp_source, $json_source)) {
+                @unlink($temp_source);
+                $imports[] = array('success' => false, 'index' => $index, 'error' => array('code' => 'agent_bundle_write_failed', 'message' => 'Could not stage inline agent bundle JSON.'));
+                continue;
+            }
+            $source = $temp_source;
+        }
+
+        if ('' === $source) {
+            $imports[] = array('success' => false, 'index' => $index, 'error' => array('code' => 'agent_bundle_source_missing', 'message' => 'Agent bundle spec requires source or bundle.'));
+            continue;
+        }
+
+        $input = array('source' => $source, 'on_conflict' => (string) ($spec['on_conflict'] ?? 'upgrade'));
+        foreach (array('slug', 'token_env') as $field) {
+            if (isset($spec[$field]) && '' !== trim((string) $spec[$field])) {
+                $input[$field] = trim((string) $spec[$field]);
+            }
+        }
+        if (isset($spec['owner_id']) && (int) $spec['owner_id'] > 0) {
+            $input['owner_id'] = (int) $spec['owner_id'];
+        } else {
+            $input['owner_id'] = get_current_user_id() ?: 1;
+        }
+
+        $execute = static fn() => $ability->execute($input);
+        $result = class_exists('DataMachine\\Abilities\\PermissionHelper')
+            ? DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($execute, (int) $input['owner_id'])
+            : $execute();
+        if ('' !== $temp_source) {
+            @unlink($temp_source);
+        }
+        $imports[] = is_wp_error($result)
+            ? array('success' => false, 'index' => $index, 'source' => isset($spec['source']) ? $source : 'inline', 'error' => array('code' => $result->get_error_code(), 'message' => $result->get_error_message(), 'data' => $result->get_error_data()))
+            : array_merge(array('index' => $index, 'source' => isset($spec['source']) ? $source : 'inline'), is_array($result) ? $result : array('result' => $result));
+    }
+
+    return $imports;
+}
 
 if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') && !class_exists('WP_Codebox_Sandbox_Perception_Directive')) {
     final class WP_Codebox_Sandbox_Perception_Directive implements DataMachine\\Engine\\AI\\Directives\\DirectiveInterface {
@@ -285,8 +373,19 @@ add_filter('datamachine_directives', static function (array $directives): array 
     return $directives;
 });
 
-$ability = function_exists('wp_get_ability') ? wp_get_ability('agents/chat') : null;
-if (!$ability || !method_exists($ability, 'execute')) {
+$ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability('agents/chat') : null;
+if (!empty($sandbox_agent_bundle_import_failures)) {
+    $sandbox_agent_runtime = array(
+        'agent_runtime' => array(
+            'success' => false,
+            'error' => array(
+                'code' => 'agent_bundle_import_failed',
+                'message' => 'One or more Data Machine agent bundles failed to import before sandbox invocation.',
+                'data' => array('agent_bundle_imports' => array_values($sandbox_agent_bundle_import_failures)),
+            ),
+        ),
+    );
+} elseif (!$ability || !method_exists($ability, 'execute')) {
     $sandbox_agent_runtime = array(
         'agent_runtime' => array(
             'success' => false,
@@ -342,6 +441,24 @@ function sandboxToolNames(): string[] {
 
 function sandboxAgentModes(mode: string): string[] {
   return Array.from(new Set([mode, "chat"].filter(Boolean)))
+}
+
+function normalizeAgentBundleSpecs(specs: AgentBundleSpec[]): AgentBundleSpec[] {
+  return specs.flatMap((spec) => {
+    if (!spec || typeof spec !== "object") return []
+    const source = typeof spec.source === "string" ? spec.source.trim() : ""
+    const bundle = spec.bundle && typeof spec.bundle === "object" && !Array.isArray(spec.bundle) ? spec.bundle : undefined
+    if (!source && !bundle) return []
+
+    const normalized: AgentBundleSpec = {}
+    if (source) normalized.source = source
+    if (bundle) normalized.bundle = bundle
+    if (typeof spec.slug === "string" && spec.slug.trim()) normalized.slug = spec.slug.trim()
+    normalized.on_conflict = spec.on_conflict && ["error", "skip", "upgrade"].includes(spec.on_conflict) ? spec.on_conflict : "upgrade"
+    if (Number.isSafeInteger(spec.owner_id) && Number(spec.owner_id) > 0) normalized.owner_id = Number(spec.owner_id)
+    if (typeof spec.token_env === "string" && spec.token_env.trim()) normalized.token_env = spec.token_env.trim()
+    return [normalized]
+  })
 }
 
 function sandboxModeGuidance(): string {

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises"
 import { basename, resolve } from "node:path"
 import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, stripUndefined, type MountSpec, type RuntimePolicy, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type WorkspaceRecipe } from "@chubes4/wp-codebox-core"
 import { agentRuntimeProbeCode, agentSandboxRunCode, resolveSandboxTaskCode } from "./agent-code.js"
+import type { AgentBundleSpec } from "./agent-code.js"
 import type { PreparedWorkspaceMount } from "./recipe-sources.js"
 import { defaultPolicy } from "./recipe-validation.js"
 
@@ -26,6 +27,7 @@ export interface AgentSandboxRunOptions extends AgentRuntimeProbeOptions {
   sessionId?: string
   maxTurns?: string
   timeoutSeconds?: string
+  agentBundles?: AgentBundleSpec[]
   code?: string
   codeFile?: string
 }
@@ -110,6 +112,7 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
       sessionId: argValue(args, "session-id"),
       maxTurns: argValue(args, "max-turns"),
       timeoutSeconds: argValue(args, "timeout-seconds"),
+      agentBundles: parseAgentBundles(args),
     }))
 
     return {
@@ -226,7 +229,7 @@ export function parseAgentRuntimeProbeOptions(args: string[], parseMount: (value
 }
 
 export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: string) => AgentRuntimeMount): AgentSandboxRunOptions {
-  const options = parseAgentRuntimeProbeOptions(args, parseMount, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--timeout-seconds", "--code", "--code-file", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
+  const options = parseAgentRuntimeProbeOptions(args, parseMount, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--timeout-seconds", "--agent-bundles-json", "--code", "--code-file", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -264,6 +267,9 @@ export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: 
       case "--code-file":
         options.codeFile = value
         break
+      case "--agent-bundles-json":
+        options.agentBundles = parseAgentBundleList(value)
+        break
     }
   }
 
@@ -276,6 +282,19 @@ export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: 
   }
 
   return options as AgentSandboxRunOptions
+}
+
+function parseAgentBundles(args: string[]): AgentBundleSpec[] {
+  return parseAgentBundleList(argValue(args, "agent-bundles-json") ?? "[]")
+}
+
+function parseAgentBundleList(value: string): AgentBundleSpec[] {
+  if (!value.trim()) return []
+  const parsed = JSON.parse(value)
+  if (!Array.isArray(parsed)) {
+    throw new Error("agent-bundles-json must be an array")
+  }
+  return parsed.filter((entry): entry is AgentBundleSpec => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry))
 }
 
 export async function parseAgentSandboxBatchOptions(args: string[], parseMount: (value: string) => AgentRuntimeMount): Promise<AgentSandboxBatchOptions> {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -69,6 +69,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             description: "Local recipe-owned files or directories copied into absolute sandbox paths before workflow steps execute.",
             items: { $ref: "#/$defs/stagedFile" },
           },
+          agent_bundles: {
+            type: "array",
+            description: "Data Machine agent bundles to import into the sandbox before invoking the selected runtime agent.",
+            items: { $ref: "#/$defs/agentBundle" },
+          },
           inherit: { $ref: "#/$defs/inheritanceRequest" },
           inheritance: { $ref: "#/$defs/inheritanceResolution" },
         },
@@ -238,6 +243,31 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           healthProbes: {
             type: "array",
             items: { $ref: "#/$defs/pluginRuntimeHealthProbe" },
+          },
+        },
+      },
+      agentBundle: {
+        type: "object",
+        additionalProperties: false,
+        anyOf: [
+          { required: ["source"] },
+          { required: ["bundle"] },
+        ],
+        properties: {
+          source: {
+            type: "string",
+            description: "Bundle source accepted by datamachine/import-agent: local directory, .zip, .json, or remote URL.",
+          },
+          bundle: {
+            type: "object",
+            description: "Inline Data Machine agent bundle JSON staged into the sandbox and imported through datamachine/import-agent.",
+          },
+          slug: { type: "string" },
+          on_conflict: { enum: ["error", "skip", "upgrade"] },
+          owner_id: { type: "integer", minimum: 1 },
+          token_env: {
+            type: "string",
+            description: "Environment variable or PHP constant name used by datamachine/import-agent for private source resolution.",
           },
         },
       },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -121,6 +121,15 @@ export interface WorkspaceRecipePluginRuntime {
   healthProbes?: WorkspaceRecipePluginRuntimeHealthProbe[]
 }
 
+export interface WorkspaceRecipeAgentBundle {
+  source?: string
+  bundle?: Record<string, unknown>
+  slug?: string
+  on_conflict?: "error" | "skip" | "upgrade"
+  owner_id?: number
+  token_env?: string
+}
+
 export interface WorkspaceRecipeExtraPlugin {
   source: string
   slug?: string
@@ -222,6 +231,7 @@ export interface WorkspaceRecipe {
     pluginRuntime?: WorkspaceRecipePluginRuntime
     siteSeeds?: WorkspaceRecipeSiteSeed[]
     stagedFiles?: WorkspaceRecipeStagedFile[]
+    agent_bundles?: WorkspaceRecipeAgentBundle[]
     inherit?: WorkspaceRecipeInheritanceRequest
     inheritance?: WorkspaceRecipeInheritanceResolution
   }

--- a/packages/runtime-core/src/task-input.ts
+++ b/packages/runtime-core/src/task-input.ts
@@ -19,6 +19,15 @@ export interface TaskInputPolicy {
   [key: string]: unknown
 }
 
+export interface TaskInputAgentBundle {
+  source?: string
+  bundle?: Record<string, unknown>
+  slug?: string
+  on_conflict?: "error" | "skip" | "upgrade"
+  owner_id?: number
+  token_env?: string
+}
+
 export interface TaskInput {
   schema: typeof TASK_INPUT_SCHEMA
   version: typeof TASK_INPUT_VERSION
@@ -26,6 +35,7 @@ export interface TaskInput {
   target: Partial<TaskTarget>
   allowed_tools: string[]
   expected_artifacts: string[]
+  agent_bundles: TaskInputAgentBundle[]
   policy: TaskInputPolicy
   context: Record<string, unknown>
 }
@@ -38,7 +48,7 @@ export type TaskInputRequest = Partial<Omit<TaskInput, "schema" | "version" | "g
 export const TASK_INPUT_JSON_SCHEMA = {
   $id: TASK_INPUT_SCHEMA,
   type: "object",
-  required: ["schema", "version", "goal", "target", "allowed_tools", "expected_artifacts", "policy", "context"],
+  required: ["schema", "version", "goal", "target", "allowed_tools", "expected_artifacts", "agent_bundles", "policy", "context"],
   properties: {
     schema: { const: TASK_INPUT_SCHEMA, description: "Task input contract schema id." },
     version: { const: TASK_INPUT_VERSION, description: "Task input contract version." },
@@ -63,6 +73,22 @@ export const TASK_INPUT_JSON_SCHEMA = {
       description: "Artifact kinds the caller wants back, such as patch, review, tests, preview, or package.",
       items: { type: "string" },
     },
+    agent_bundles: {
+      type: "array",
+      description: "Data Machine agent bundles to import into the disposable sandbox before invoking the selected runtime agent.",
+      items: {
+        type: "object",
+        anyOf: [{ required: ["source"] }, { required: ["bundle"] }],
+        properties: {
+          source: { type: "string" },
+          bundle: { type: "object" },
+          slug: { type: "string" },
+          on_conflict: { enum: ["error", "skip", "upgrade"] },
+          owner_id: { type: "integer", minimum: 1 },
+          token_env: { type: "string" },
+        },
+      },
+    },
     policy: {
       type: "object",
       description: "Caller policy hints for approvals, apply-back, sandboxing, and risk controls.",
@@ -85,7 +111,28 @@ export function normalizeTaskInput(input: TaskInputRequest): TaskInput {
     target: isPlainObject(input.target) ? input.target : {},
     allowed_tools: stringList(input.allowed_tools),
     expected_artifacts: stringList(input.expected_artifacts),
+    agent_bundles: normalizeAgentBundles((input as Record<string, unknown>).agent_bundles ?? (input as Record<string, unknown>).agentBundles),
     policy: isPlainObject(input.policy) ? input.policy : {},
     context: isPlainObject(input.context) ? input.context : {},
   }
+}
+
+function normalizeAgentBundles(value: unknown): TaskInputAgentBundle[] {
+  if (!Array.isArray(value)) return []
+
+  return value.flatMap((entry): TaskInputAgentBundle[] => {
+    if (!isPlainObject(entry)) return []
+    const source = typeof entry.source === "string" ? entry.source.trim() : ""
+    const bundle = isPlainObject(entry.bundle) ? entry.bundle : undefined
+    if (!source && !bundle) return []
+
+    const normalized: TaskInputAgentBundle = {}
+    if (source) normalized.source = source
+    if (bundle) normalized.bundle = bundle
+    if (typeof entry.slug === "string" && entry.slug.trim()) normalized.slug = entry.slug.trim()
+    normalized.on_conflict = ["error", "skip", "upgrade"].includes(String(entry.on_conflict)) ? entry.on_conflict as TaskInputAgentBundle["on_conflict"] : "upgrade"
+    if (Number.isSafeInteger(entry.owner_id) && Number(entry.owner_id) > 0) normalized.owner_id = Number(entry.owner_id)
+    if (typeof entry.token_env === "string" && entry.token_env.trim()) normalized.token_env = entry.token_env.trim()
+    return [normalized]
+  })
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -128,6 +128,7 @@ final class WP_Codebox_Abilities {
 								'description' => 'AI provider plugin directories to mount and activate inside the sandbox.',
 								'items'       => array( 'type' => 'string' ),
 							),
+							'agent_bundles'          => self::agent_bundle_schema(),
 							'parent_request'         => array(
 								'type'        => 'object',
 								'description' => 'External orchestrator task request, such as homeboy/wp-codebox-task-request/v1, normalized into the WP Codebox runner contract.',
@@ -241,6 +242,7 @@ final class WP_Codebox_Abilities {
 								'type'  => 'array',
 								'items' => array( 'type' => 'string' ),
 							),
+							'agent_bundles'          => self::agent_bundle_schema(),
 							'parent_request'         => array( 'type' => 'object' ),
 							'mounts'                 => $mount_schema,
 							'workspaces'             => array(
@@ -366,6 +368,7 @@ final class WP_Codebox_Abilities {
 								'description' => 'AI provider plugin directories the browser sandbox should have available before code execution.',
 								'items'       => array( 'type' => 'string' ),
 							),
+							'agent_bundles'      => self::agent_bundle_schema(),
 							'inherit'            => $inherit_schema,
 							'secret_env'         => array(
 								'type'        => 'array',
@@ -917,6 +920,35 @@ final class WP_Codebox_Abilities {
 							'activeTheme'   => array( 'type' => 'boolean' ),
 						),
 					),
+				),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function agent_bundle_schema(): array {
+		return array(
+			'type'        => 'array',
+			'description' => 'Data Machine agent bundles to import into the disposable sandbox before invoking the selected runtime agent.',
+			'items'       => array(
+				'type'       => 'object',
+				'anyOf'      => array(
+					array( 'required' => array( 'source' ) ),
+					array( 'required' => array( 'bundle' ) ),
+				),
+				'properties' => array(
+					'source'      => array(
+						'type'        => 'string',
+						'description' => 'Bundle source accepted by datamachine/import-agent: local directory, .zip, .json, or remote URL.',
+					),
+					'bundle'      => array(
+						'type'        => 'object',
+						'description' => 'Inline Data Machine agent bundle JSON staged in the sandbox and imported through datamachine/import-agent.',
+					),
+					'slug'        => array( 'type' => 'string' ),
+					'on_conflict' => array( 'type' => 'string', 'enum' => array( 'error', 'skip', 'upgrade' ) ),
+					'owner_id'    => array( 'type' => 'integer' ),
+					'token_env'   => array( 'type' => 'string' ),
 				),
 			),
 		);
@@ -1697,6 +1729,7 @@ final class WP_Codebox_Abilities {
 				'message'     => (string) $task_input['goal'],
 				'session_id'  => $session_id,
 				'task_input'  => $task_input,
+				'agent_bundles' => self::normalize_agent_bundles( $input['agent_bundles'] ?? $input['agentBundles'] ?? array() ),
 				'inheritance' => $inheritance,
 				'secret_env'  => self::browser_secret_env_names( $input ),
 				'artifacts'   => array(
@@ -1766,6 +1799,44 @@ final class WP_Codebox_Abilities {
 	/** @param array<string,mixed> $input Ability input. @return string[] */
 	private static function browser_secret_env_names( array $input ): array {
 		return array_values( array_unique( array_filter( self::string_list( $input['secret_env'] ?? array() ), static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) ) );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function normalize_agent_bundles( mixed $bundles ): array {
+		$normalized = array();
+		foreach ( is_array( $bundles ) ? $bundles : array() as $bundle ) {
+			if ( ! is_array( $bundle ) ) {
+				continue;
+			}
+			$source = isset( $bundle['source'] ) ? trim( (string) $bundle['source'] ) : '';
+			$inline = is_array( $bundle['bundle'] ?? null ) ? $bundle['bundle'] : null;
+			if ( '' === $source && null === $inline ) {
+				continue;
+			}
+
+			$entry = array();
+			if ( '' !== $source ) {
+				$entry['source'] = $source;
+			}
+			if ( null !== $inline ) {
+				$entry['bundle'] = $inline;
+			}
+			foreach ( array( 'slug', 'token_env' ) as $field ) {
+				$value = isset( $bundle[ $field ] ) ? trim( (string) $bundle[ $field ] ) : '';
+				if ( '' !== $value ) {
+					$entry[ $field ] = $value;
+				}
+			}
+			$on_conflict = (string) ( $bundle['on_conflict'] ?? 'upgrade' );
+			$entry['on_conflict'] = in_array( $on_conflict, array( 'error', 'skip', 'upgrade' ), true ) ? $on_conflict : 'upgrade';
+			if ( isset( $bundle['owner_id'] ) && (int) $bundle['owner_id'] > 0 ) {
+				$entry['owner_id'] = (int) $bundle['owner_id'];
+			}
+
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
 	}
 
 	/** @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return string[] */
@@ -3493,6 +3564,7 @@ flush_rewrite_rules();
 						'target' => $task_path,
 					),
 				),
+				'agent_bundles' => is_array( $task_payload['agent_bundles'] ?? null ) ? $task_payload['agent_bundles'] : array(),
 			),
 			'workflow' => array(
 				'steps' => array(
@@ -3694,6 +3766,67 @@ function wp_codebox_browser_capture_file( array $capture ) {
 	return array_filter( $record, static fn( $value ) => \'\' !== $value );
 }
 
+function wp_codebox_browser_import_agent_bundles( array $bundle_specs ): array {
+	if ( empty( $bundle_specs ) ) {
+		return array();
+	}
+	$ability = function_exists( \'wp_get_ability\' ) ? wp_get_ability( \'datamachine/import-agent\' ) : null;
+	if ( ! $ability instanceof WP_Ability ) {
+		return array( array(
+			\'success\' => false,
+			\'error\' => array(
+				\'code\' => \'datamachine_import_agent_unavailable\',
+				\'message\' => \'The canonical datamachine/import-agent ability is not available inside the Playground site.\',
+			),
+		) );
+	}
+
+	$imports = array();
+	foreach ( $bundle_specs as $index => $spec ) {
+		if ( ! is_array( $spec ) ) {
+			$imports[] = array( \'success\' => false, \'index\' => $index, \'error\' => array( \'code\' => \'agent_bundle_spec_invalid\', \'message\' => \'Agent bundle spec must be an object.\' ) );
+			continue;
+		}
+		$source = isset( $spec[\'source\'] ) ? trim( (string) $spec[\'source\'] ) : \'\';
+		$temp_source = \'\';
+		if ( \'\' === $source && isset( $spec[\'bundle\'] ) && is_array( $spec[\'bundle\'] ) ) {
+			$temp_source = tempnam( sys_get_temp_dir(), \'wp-codebox-agent-bundle-\' );
+			if ( false === $temp_source ) {
+				$imports[] = array( \'success\' => false, \'index\' => $index, \'error\' => array( \'code\' => \'agent_bundle_temp_failed\', \'message\' => \'Could not create a temporary agent bundle JSON file.\' ) );
+				continue;
+			}
+			$json_source = wp_json_encode( $spec[\'bundle\'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			if ( ! is_string( $json_source ) || false === file_put_contents( $temp_source, $json_source ) ) {
+				@unlink( $temp_source );
+				$imports[] = array( \'success\' => false, \'index\' => $index, \'error\' => array( \'code\' => \'agent_bundle_write_failed\', \'message\' => \'Could not stage inline agent bundle JSON.\' ) );
+				continue;
+			}
+			$source = $temp_source;
+		}
+		if ( \'\' === $source ) {
+			$imports[] = array( \'success\' => false, \'index\' => $index, \'error\' => array( \'code\' => \'agent_bundle_source_missing\', \'message\' => \'Agent bundle spec requires source or bundle.\' ) );
+			continue;
+		}
+
+		$input = array( \'source\' => $source, \'on_conflict\' => (string) ( $spec[\'on_conflict\'] ?? \'upgrade\' ) );
+		foreach ( array( \'slug\', \'token_env\' ) as $field ) {
+			if ( isset( $spec[ $field ] ) && \'\' !== trim( (string) $spec[ $field ] ) ) {
+				$input[ $field ] = trim( (string) $spec[ $field ] );
+			}
+		}
+		$input[\'owner_id\'] = isset( $spec[\'owner_id\'] ) && (int) $spec[\'owner_id\'] > 0 ? (int) $spec[\'owner_id\'] : ( get_current_user_id() ?: 1 );
+		$result = $ability->execute( $input );
+		if ( \'\' !== $temp_source ) {
+			@unlink( $temp_source );
+		}
+		$imports[] = is_wp_error( $result )
+			? array( \'success\' => false, \'index\' => $index, \'source\' => isset( $spec[\'source\'] ) ? $source : \'inline\', \'error\' => array( \'code\' => $result->get_error_code(), \'message\' => $result->get_error_message(), \'data\' => $result->get_error_data() ) )
+			: array_merge( array( \'index\' => $index, \'source\' => isset( $spec[\'source\'] ) ? $source : \'inline\' ), is_array( $result ) ? $result : array( \'result\' => $result ) );
+	}
+
+	return $imports;
+}
+
 $wp_codebox_playground_root = defined( \'ABSPATH\' ) ? wp_normalize_path( ABSPATH ) : \'\';
 $wp_codebox_is_playground = \'/wordpress/\' === $wp_codebox_playground_root && ( \'Emscripten\' === PHP_OS_FAMILY || ( defined( \'WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER\' ) && WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER ) );
 
@@ -3716,6 +3849,7 @@ if ( is_readable( $task_path ) ) {
 $agent = sanitize_key( (string) ( $payload[\'agent\'] ?? \'wp-codebox-sandbox\' ) );
 $message = (string) ( $payload[\'message\'] ?? ( $payload[\'task_input\'][\'goal\'] ?? \'\' ) );
 $session_id = (string) ( $payload[\'session_id\'] ?? ' . var_export( $session_id, true ) . ' );
+$agent_bundle_imports = array();
 $base_input = array(
 	\'agent\' => $agent,
 	\'message\' => $message,
@@ -3748,12 +3882,16 @@ if ( ! $wp_codebox_is_playground ) {
 		)
 	);
 } else {
+	$agent_bundle_imports = wp_codebox_browser_import_agent_bundles( is_array( $payload[\'agent_bundles\'] ?? null ) ? $payload[\'agent_bundles\'] : array() );
 	if ( \'\' !== $permission_filter ) {
 		add_filter( $permission_filter, \'__return_true\', 999 );
 	}
 
 	try {
-		if ( \'task\' === $invocation_type ) {
+		$failed_imports = array_filter( $agent_bundle_imports, static fn( $import ) => is_array( $import ) && empty( $import[\'success\'] ) );
+		if ( ! empty( $failed_imports ) ) {
+			$response = new WP_Error( \'wp_codebox_agent_bundle_import_failed\', \'One or more Data Machine agent bundles failed to import before sandbox invocation.\', array( \'agent_bundle_imports\' => array_values( $failed_imports ) ) );
+		} elseif ( \'task\' === $invocation_type ) {
 			$hook = (string) ( $invocation[\'hook\'] ?? $invocation[\'name\'] ?? \'\' );
 			if ( \'\' === $hook || ! has_filter( $hook ) ) {
 				$response = new WP_Error( \'wp_codebox_browser_task_unavailable\', \'The requested sandbox task hook is not registered inside the Playground site.\', array( \'hook\' => $hook ) );
@@ -3796,6 +3934,7 @@ $invocation_metadata = array_filter(
 $diagnostics = array(
 	\'capture_count\' => count( $captures ),
 	\'captured_paths\' => array_values( array_map( static fn( $capture ) => (string) ( $capture[\'path\'] ?? \'\' ), $captures ) ),
+	\'agent_bundle_imports\' => $agent_bundle_imports,
 );
 $provenance = array(
 	\'generated_by\' => \'wp-codebox/browser-runner\',

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -415,6 +415,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 					'provider'               => (string) ( $input['provider'] ?? $request['provider'] ?? '' ),
 					'model'                  => (string) ( $input['model'] ?? $request['model'] ?? '' ),
 					'provider_plugin_paths'  => $this->merge_string_lists( $input['provider_plugin_paths'] ?? array(), $request['provider_plugin_paths'] ?? array() ),
+					'agent_bundles'          => $this->agent_bundles( $input, $request ),
 					'secret_env'             => $this->merge_string_lists( $input['secret_env'] ?? array(), $request['secret_env'] ?? array() ),
 					'mounts'                 => $this->merge_array_lists( $input['mounts'] ?? array(), $request['mounts'] ?? array() ),
 					'workspaces'             => $this->merge_array_lists( $input['workspaces'] ?? array(), $workspaces ),
@@ -957,6 +958,47 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return $merged;
+	}
+
+	/** @param array<string,mixed> $input Direct ability input. @param array<string,mixed> $request Parent request input. @return array<int,array<string,mixed>> */
+	private function agent_bundles( array $input, array $request = array() ): array {
+		$bundles = $this->merge_array_lists( $input['agent_bundles'] ?? $input['agentBundles'] ?? array(), $request['agent_bundles'] ?? $request['agentBundles'] ?? array() );
+		$normalized = array();
+		foreach ( $bundles as $bundle ) {
+			$source = isset( $bundle['source'] ) ? trim( (string) $bundle['source'] ) : '';
+			$inline = is_array( $bundle['bundle'] ?? null ) ? $bundle['bundle'] : null;
+			if ( '' === $source && null === $inline ) {
+				continue;
+			}
+
+			$entry = array();
+			if ( '' !== $source ) {
+				$entry['source'] = $source;
+			}
+			if ( null !== $inline ) {
+				$entry['bundle'] = $inline;
+			}
+			foreach ( array( 'slug', 'token_env' ) as $field ) {
+				$value = isset( $bundle[ $field ] ) ? trim( (string) $bundle[ $field ] ) : '';
+				if ( '' !== $value ) {
+					$entry[ $field ] = $value;
+				}
+			}
+			$on_conflict = (string) ( $bundle['on_conflict'] ?? 'upgrade' );
+			$entry['on_conflict'] = in_array( $on_conflict, array( 'error', 'skip', 'upgrade' ), true ) ? $on_conflict : 'upgrade';
+			if ( isset( $bundle['owner_id'] ) && (int) $bundle['owner_id'] > 0 ) {
+				$entry['owner_id'] = (int) $bundle['owner_id'];
+			}
+
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
+	}
+
+	private function json_encode( mixed $value ): string {
+		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		return is_string( $encoded ) ? $encoded : '[]';
 	}
 
 	/** @param string[] $paths @return array<int,array<string,mixed>> */
@@ -1645,6 +1687,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		);
 
 		$provider_slugs = array_map( static fn( array $plugin ): string => (string) $plugin['slug'], $provider_plugins );
+		$agent_bundles  = $this->agent_bundles( $input );
 		$steps          = array();
 		foreach ( $task_prompts as $task_prompt ) {
 			$args = array(
@@ -1655,6 +1698,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'model=' . $this->model( $input, $inheritance ),
 				'provider-plugin-slugs=' . implode( ',', $provider_slugs ),
 			);
+			if ( ! empty( $agent_bundles ) ) {
+				$args[] = 'agent-bundles-json=' . $this->json_encode( $agent_bundles );
+			}
 			if ( ! empty( $input['session_id'] ) ) {
 				$args[] = 'session-id=' . (string) $input['session_id'];
 			}
@@ -1697,6 +1743,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'extraPlugins' => array_merge( $this->component_plugins( $paths ), $provider_plugins ),
 			'secretEnv'    => $this->secret_env_names( $input, $inheritance ),
 		);
+		if ( ! empty( $agent_bundles ) ) {
+			$recipe_inputs['agent_bundles'] = $agent_bundles;
+		}
 		if ( ! empty( $site_seed_payload['siteSeeds'] ) ) {
 			$recipe_inputs['siteSeeds'] = $site_seed_payload['siteSeeds'];
 		}

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -153,7 +153,7 @@ final class WP_Codebox_CLI_Command {
 			return $this->json_object( (string) $value, $field );
 		}
 
-		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'provider_plugin_paths', 'secret_env', 'mounts', 'workspaces', 'runtime_stack_mounts', 'runtime_overlays', 'browser_plugins', 'artifact_files', 'approved_files' ), true ) ) {
+		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'agent_bundles', 'provider_plugin_paths', 'secret_env', 'mounts', 'workspaces', 'runtime_stack_mounts', 'runtime_overlays', 'browser_plugins', 'artifact_files', 'approved_files' ), true ) ) {
 			return $this->json_or_list( (string) $value, $field );
 		}
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
@@ -17,7 +17,7 @@ final class WP_Codebox_Task_Input_Contract {
 		return array(
 			'$id'        => self::SCHEMA,
 			'type'       => 'object',
-			'required'   => array( 'schema', 'version', 'goal', 'target', 'allowed_tools', 'expected_artifacts', 'policy', 'context' ),
+			'required'   => array( 'schema', 'version', 'goal', 'target', 'allowed_tools', 'expected_artifacts', 'agent_bundles', 'policy', 'context' ),
 			'properties' => array(
 				'schema'             => array(
 					'type'        => 'string',
@@ -53,6 +53,25 @@ final class WP_Codebox_Task_Input_Contract {
 					'description' => 'Artifact kinds the caller wants back, such as patch, review, tests, preview, or package.',
 					'items'       => array( 'type' => 'string' ),
 				),
+				'agent_bundles'      => array(
+					'type'        => 'array',
+					'description' => 'Data Machine agent bundles to import into the disposable sandbox before invoking the selected runtime agent.',
+					'items'       => array(
+						'type'       => 'object',
+						'anyOf'      => array(
+							array( 'required' => array( 'source' ) ),
+							array( 'required' => array( 'bundle' ) ),
+						),
+						'properties' => array(
+							'source'      => array( 'type' => 'string' ),
+							'bundle'      => array( 'type' => 'object' ),
+							'slug'        => array( 'type' => 'string' ),
+							'on_conflict' => array( 'type' => 'string', 'enum' => array( 'error', 'skip', 'upgrade' ) ),
+							'owner_id'    => array( 'type' => 'integer' ),
+							'token_env'   => array( 'type' => 'string' ),
+						),
+					),
+				),
 				'policy'             => array(
 					'type'        => 'object',
 					'description' => 'Caller policy hints for approvals, apply-back, sandboxing, and risk controls.',
@@ -79,9 +98,46 @@ final class WP_Codebox_Task_Input_Contract {
 			'target'             => is_array( $input['target'] ?? null ) ? $input['target'] : array(),
 			'allowed_tools'      => self::string_list( $input['allowed_tools'] ?? array() ),
 			'expected_artifacts' => self::string_list( $input['expected_artifacts'] ?? array() ),
+			'agent_bundles'      => self::agent_bundles( $input['agent_bundles'] ?? $input['agentBundles'] ?? array() ),
 			'policy'             => is_array( $input['policy'] ?? null ) ? $input['policy'] : array(),
 			'context'            => is_array( $input['context'] ?? null ) ? $input['context'] : array(),
 		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function agent_bundles( mixed $value ): array {
+		$bundles = array();
+		foreach ( is_array( $value ) ? $value : array() as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$source = isset( $entry['source'] ) ? trim( (string) $entry['source'] ) : '';
+			$inline = is_array( $entry['bundle'] ?? null ) ? $entry['bundle'] : null;
+			if ( '' === $source && null === $inline ) {
+				continue;
+			}
+			$bundle = array();
+			if ( '' !== $source ) {
+				$bundle['source'] = $source;
+			}
+			if ( null !== $inline ) {
+				$bundle['bundle'] = $inline;
+			}
+			foreach ( array( 'slug', 'token_env' ) as $field ) {
+				$value = isset( $entry[ $field ] ) ? trim( (string) $entry[ $field ] ) : '';
+				if ( '' !== $value ) {
+					$bundle[ $field ] = $value;
+				}
+			}
+			$on_conflict = (string) ( $entry['on_conflict'] ?? 'upgrade' );
+			$bundle['on_conflict'] = in_array( $on_conflict, array( 'error', 'skip', 'upgrade' ), true ) ? $on_conflict : 'upgrade';
+			if ( isset( $entry['owner_id'] ) && (int) $entry['owner_id'] > 0 ) {
+				$bundle['owner_id'] = (int) $entry['owner_id'];
+			}
+			$bundles[] = $bundle;
+		}
+
+		return $bundles;
 	}
 
 	/** @return string[] */

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -8,6 +8,16 @@ async function main() {
     mode: "sandbox",
     provider: "opencode",
     model: "opencode-go/kimi-k2.6",
+    agentBundles: [
+      { source: "/tmp/site-generator-agent.json", slug: "site-generator" },
+      {
+        bundle: {
+          bundle_version: "1.0.0",
+          agent: { agent_slug: "repair-agent", agent_name: "Repair Agent", agent_config: {} },
+        },
+        slug: "repair-agent",
+      },
+    ],
   })
 
   assert.match(code, /\\"modes\\":\[\\"sandbox\\",\\"chat\\"\]/, "sandbox chat input should inherit chat tool surface")
@@ -24,6 +34,15 @@ async function main() {
   assert.doesNotMatch(code, /workspace_git_log/, "sandbox tool policy should not advertise unbridged git log")
   assert.doesNotMatch(code, /workspace_git_diff/, "sandbox tool policy should not advertise unbridged git diff")
   assert.match(code, /For changes use workspace_write or workspace_edit/, "sandbox guidance should steer changes to tools that work without git")
+  assert.match(code, /wp_codebox_import_sandbox_agent_bundles/, "sandbox setup should import declared Data Machine agent bundles")
+  assert.match(code, /wp_get_ability\('datamachine\/import-agent'\)/, "sandbox setup should use the canonical Data Machine import ability")
+  assert.match(code, /agent_bundle_imports/, "sandbox setup should report agent bundle import results")
+  assert.match(code, /agent_bundle_import_failed/, "sandbox setup should fail before chat when bundle imports fail")
+  assert.ok(code.indexOf("wp_codebox_import_sandbox_agent_bundles") < code.indexOf("wp_get_ability('agents/chat')"), "agent bundles should import before agents/chat is resolved")
+  const fallbackGateIndex = code.indexOf("if (empty($sandbox_agent_bundle_imports) && class_exists")
+  const createIfMissingIndex = code.indexOf("create_if_missing")
+  assert.ok(fallbackGateIndex > code.indexOf("wp_codebox_import_sandbox_agent_bundles") && createIfMissingIndex > fallbackGateIndex, "legacy create_if_missing should be gated behind the no-bundle fallback")
+  assert.match(code, /repair-agent/, "inline bundle specs should be embedded in sandbox setup")
 
   const runCode = agentSandboxRunCode(
     '{"prompt":"Do not interpolate $buckets, $meta, or $state_store."}',

--- a/tests/fixtures/task-input-normalization.json
+++ b/tests/fixtures/task-input-normalization.json
@@ -11,6 +11,7 @@
       "target": {},
       "allowed_tools": [],
       "expected_artifacts": [],
+      "agent_bundles": [],
       "policy": {},
       "context": {}
     }
@@ -25,6 +26,26 @@
       },
       "allowed_tools": ["workspace.read", "workspace.write", "workspace.read", ""],
       "expected_artifacts": ["patch", "tests", "patch"],
+      "agent_bundles": [
+        {
+          "source": "/tmp/site-generator-agent.json",
+          "slug": "site-generator",
+          "on_conflict": "upgrade",
+          "owner_id": 1
+        },
+        {
+          "bundle": {
+            "bundle_version": "1.0.0",
+            "agent": {
+              "agent_slug": "repair-agent",
+              "agent_name": "Repair Agent",
+              "agent_config": {}
+            }
+          },
+          "slug": "repair-agent",
+          "token_env": "AGENT_BUNDLE_TOKEN"
+        }
+      ],
       "policy": {
         "applyBack": "reviewed"
       },
@@ -42,6 +63,27 @@
       },
       "allowed_tools": ["workspace.read", "workspace.write"],
       "expected_artifacts": ["patch", "tests"],
+      "agent_bundles": [
+        {
+          "source": "/tmp/site-generator-agent.json",
+          "slug": "site-generator",
+          "on_conflict": "upgrade",
+          "owner_id": 1
+        },
+        {
+          "bundle": {
+            "bundle_version": "1.0.0",
+            "agent": {
+              "agent_slug": "repair-agent",
+              "agent_name": "Repair Agent",
+              "agent_config": {}
+            }
+          },
+          "slug": "repair-agent",
+          "on_conflict": "upgrade",
+          "token_env": "AGENT_BUNDLE_TOKEN"
+        }
+      ],
       "policy": {
         "applyBack": "reviewed"
       },

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -883,6 +883,23 @@ $browser_inherited_session = call_user_func(
 	array(
 		'goal'    => 'Invoke a browser agent with inherited connector metadata.',
 		'inherit' => array( 'connectors' => array( 'primary-ai' ) ),
+		'agent_bundles' => array(
+			array(
+				'source' => 'https://example.test/site-generator-agent.json',
+				'slug'   => 'site-generator',
+			),
+			array(
+				'bundle' => array(
+					'bundle_version' => '1.0.0',
+					'agent'          => array(
+						'agent_slug'   => 'repair-agent',
+						'agent_name'   => 'Repair Agent',
+						'agent_config' => array(),
+					),
+				),
+				'slug' => 'repair-agent',
+			),
+		),
 	)
 );
 $browser_inherited_encoded = ! is_wp_error( $browser_inherited_session ) ? json_encode( $browser_inherited_session, JSON_UNESCAPED_SLASHES ) : '';
@@ -891,6 +908,8 @@ $assert( 'browser Playground session packages inherited provider plugin path', !
 $assert( 'browser Playground session embeds first-class browser task payload', ! is_wp_error( $browser_inherited_session ) && 'wp-codebox/browser-agent-task-payload/v1' === ( $browser_inherited_session['task_payload']['schema'] ?? '' ) && 'openai' === ( $browser_inherited_session['recipe']['browser']['task_payload']['provider'] ?? '' ) && 'gpt-5.5' === ( $browser_inherited_session['recipe']['browser']['task_payload']['model'] ?? '' ) );
 $assert( 'browser Playground session records inherited connector credential provenance without values', ! is_wp_error( $browser_inherited_session ) && 'wp-codebox/connector-credentials/v1' === ( $browser_inherited_session['inheritance']['connectors'][0]['credentials']['schema'] ?? '' ) && 'available' === ( $browser_inherited_session['task_payload']['inheritance']['connectors'][0]['credentials']['secrets'][0]['status'] ?? '' ) && str_contains( $browser_inherited_encoded, 'OPENAI_API_KEY' ) && ! str_contains( $browser_inherited_encoded, 'sk-browser-secret-value' ) && ! str_contains( $browser_inherited_encoded, 'secret_env_values' ) );
 $assert( 'browser Playground recipe defaults to agents chat invocation with embedded payload', ! is_wp_error( $browser_inherited_session ) && 'ability' === ( $browser_inherited_session['recipe']['browser']['invocation']['type'] ?? '' ) && 'agents/chat' === ( $browser_inherited_session['recipe']['browser']['invocation']['name'] ?? '' ) && str_contains( (string) ( $browser_inherited_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_get_ability( $ability_name )' ) );
+$browser_runner_code = (string) ( $browser_inherited_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' );
+$assert( 'browser Playground recipe preserves and imports multiple Data Machine agent bundles before agents chat', ! is_wp_error( $browser_inherited_session ) && 2 === count( $browser_inherited_session['recipe']['inputs']['agent_bundles'] ?? array() ) && 2 === count( $browser_inherited_session['task_payload']['agent_bundles'] ?? array() ) && str_contains( $browser_runner_code, 'wp_codebox_browser_import_agent_bundles' ) && str_contains( $browser_runner_code, 'datamachine/import-agent' ) && strpos( $browser_runner_code, 'wp_codebox_browser_import_agent_bundles' ) < strpos( $browser_runner_code, 'wp_get_ability( $ability_name )' ) );
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model']    = 'gpt-5.5';
 unset( $GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] );
@@ -1365,6 +1384,24 @@ $homeboy_result = $runner->run(
 			'provider'             => 'openai',
 			'model'                => 'gpt-5.5',
 			'provider_plugin_paths' => array( $root . '/ai-provider-test' ),
+			'agent_bundles'        => array(
+				array(
+					'source'      => $root . '/site-generator-agent.json',
+					'slug'        => 'site-generator',
+					'on_conflict' => 'upgrade',
+				),
+				array(
+					'bundle' => array(
+						'bundle_version' => '1.0.0',
+						'agent'          => array(
+							'agent_slug'   => 'repair-agent',
+							'agent_name'   => 'Repair Agent',
+							'agent_config' => array(),
+						),
+					),
+					'slug'   => 'repair-agent',
+				),
+			),
 			'secret_env'           => array( 'GITHUB_TOKEN' ),
 			'mounts'               => array(
 				array(
@@ -1418,6 +1455,7 @@ $homeboy_step_args = $homeboy_recipe['workflow']['steps'][0]['args'] ?? array();
 $assert( 'runner accepts Homeboy-shaped parent request', ! is_wp_error( $homeboy_result ) && true === ( $homeboy_result['success'] ?? false ) && 'homeboy-sandbox-session-123' === ( $homeboy_result['session']['id'] ?? '' ) );
 $assert( 'runner maps Homeboy artifacts and orchestrator metadata', ! is_wp_error( $homeboy_result ) && $root . '/artifacts/homeboy' === ( $homeboy_result['artifacts'] ?? '' ) && 'homeboy-job-123' === ( $homeboy_result['session']['orchestrator']['job_id'] ?? '' ) && 'agent-task-123' === ( $homeboy_result['session']['orchestrator']['agent_task_id'] ?? '' ) );
 $assert( 'runner maps Homeboy provider plugins and secrets', in_array( 'provider-plugin-slugs=ai-provider-test', $homeboy_step_args, true ) && str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
+$assert( 'runner preserves multiple Data Machine agent bundles in recipe inputs and step args', 2 === count( $homeboy_recipe['inputs']['agent_bundles'] ?? array() ) && str_contains( implode( "\n", $homeboy_step_args ), 'agent-bundles-json=' ) && str_contains( $captured_recipe, 'site-generator-agent.json' ) && str_contains( $captured_recipe, 'repair-agent' ) );
 $assert( 'runner maps Homeboy timeout and max turns', 3600 === $captured_timeout && in_array( 'timeout-seconds=3600', $homeboy_step_args, true ) && in_array( 'max-turns=8', $homeboy_step_args, true ) );
 $assert( 'runner maps Homeboy runtime stack mounts and overlays', '/runtime/agents-api' === ( $homeboy_recipe['runtime']['stack']['mounts'][0]['target'] ?? '' ) && 'homeboy-runtime-overlay' === ( $homeboy_recipe['runtime']['overlays'][0]['id'] ?? '' ) );
 $assert( 'runner maps Homeboy workspaces without downstream recipe generation', 3 === count( $homeboy_recipe['inputs']['workspaces'] ?? array() ) && str_contains( $captured_recipe, 'Use Data Machine Code workspace repos' ) && str_contains( $captured_recipe, '`agents-api`' ) );


### PR DESCRIPTION
## Summary
- Adds a generic `agent_bundles` sandbox contract for multiple Data Machine agent bundle specs, preserving source URL/path specs and inline bundle JSON through task input, recipe, CLI, and browser-session paths.
- Imports declared bundles through the canonical `datamachine/import-agent` ability before invoking `agents/chat`, with the legacy direct `create_if_missing()` row seed retained only as a no-bundle fallback.
- Fails sandbox invocation early when bundle imports fail and records bundle import diagnostics in sandbox/browser results.

## Testing
- `npm run build`
- `npm run task-input-contract-smoke`
- `npm run agent-sandbox-code-smoke`
- `npm run wordpress-recipe-builders-smoke`
- `php tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the sandbox agent bundle import contract and smoke coverage; Chris remains responsible for review and merge.