### PR TITLE
Expose browser materializer contract

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -486,6 +486,56 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/create-browser-materializer-contract',
+				array(
+					'label'               => 'Create Browser Materializer Contract',
+					'description'         => 'Prepare the browser-executed Playground recipe and materialization contract for an already-created parent browser session.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'anyOf'      => array(
+							array( 'type' => 'object', 'required' => array( 'goal' ) ),
+							array( 'type' => 'object', 'required' => array( 'task' ) ),
+						),
+						'properties' => array(
+							'goal'               => $task_input_schema['properties']['goal'],
+							'task'               => array(
+								'type'        => 'string',
+								'description' => 'Legacy task description. Prefer goal for new product callers.',
+							),
+							'target'             => $task_input_schema['properties']['target'],
+							'allowed_tools'      => $task_input_schema['properties']['allowed_tools'],
+							'expected_artifacts' => $task_input_schema['properties']['expected_artifacts'],
+							'policy'             => $task_input_schema['properties']['policy'],
+							'context'            => $task_input_schema['properties']['context'],
+							'agent'              => array( 'type' => 'string' ),
+							'provider'           => array( 'type' => 'string' ),
+							'model'              => array( 'type' => 'string' ),
+							'mode'               => array( 'type' => 'string' ),
+							'provider_plugin_paths' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							'agent_bundles'      => self::agent_bundle_schema(),
+							'inherit'            => $inherit_schema,
+							'secret_env'         => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							'sandbox_session_id' => $session_input['sandbox_session_id'],
+							'orchestrator'       => $session_input['orchestrator'],
+							'authorization'      => self::browser_session_authorization_schema(),
+							'playground'         => array( 'type' => 'object' ),
+							'browser_runner'     => array( 'type' => 'object' ),
+							'browser_plugins'    => array( 'type' => 'array' ),
+							'runtime'            => array( 'type' => 'object' ),
+							'blueprint'          => array( 'type' => 'object' ),
+							'site_blueprint_artifact' => array( 'type' => 'object' ),
+							'artifact_files'     => array( 'type' => 'array' ),
+						),
+					),
+					'output_schema'       => self::browser_materializer_contract_schema(),
+					'execute_callback'    => array( self::class, 'create_browser_materializer_contract' ),
+					'permission_callback' => array( self::class, 'can_create_browser_playground_session' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/list-artifacts',
 				array(
 					'label'               => 'List WP Codebox Artifacts',
@@ -1161,6 +1211,38 @@ final class WP_Codebox_Abilities {
 	}
 
 	/** @return array<string,mixed> */
+	private static function browser_materializer_contract_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'          => array( 'type' => 'boolean' ),
+				'schema'           => array( 'type' => 'string' ),
+				'execution'        => array(
+					'type' => 'string',
+					'enum' => array( 'browser-playground' ),
+				),
+				'execution_scope'  => array(
+					'type' => 'string',
+					'enum' => array( 'disposable-playground' ),
+				),
+				'permission_model' => array(
+					'type' => 'string',
+					'enum' => array( 'sandbox-bypass' ),
+				),
+				'session_id'       => array( 'type' => 'string' ),
+				'authorization'    => array( 'type' => 'object' ),
+				'task_input'       => self::task_input_schema(),
+				'task_payload'     => array( 'type' => 'object' ),
+				'materialization'  => array( 'type' => 'object' ),
+				'recipe'           => array( 'type' => 'object' ),
+				'playground'       => array( 'type' => 'object' ),
+				'runtime'          => array( 'type' => 'object' ),
+				'artifacts'        => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
 	private static function browser_session_authorization_schema(): array {
 		return self::trusted_orchestrator_authorization_schema( self::BROWSER_SESSION_CREATE_SCOPE, 'Explicit trusted orchestrator authorization for browser session creation. Callers must provide a caller id and the browser-session:create scope; sites grant trust through wp_codebox_trusted_browser_session_callers.' );
 	}
@@ -1303,6 +1385,56 @@ final class WP_Codebox_Abilities {
 				'files'              => $artifacts,
 				'preview_url'        => self::browser_preview_url( $artifacts, $playground ),
 				'expected_artifacts' => $task_input['expected_artifacts'],
+			),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function create_browser_materializer_contract( array $input ): array|WP_Error {
+		$session = self::create_browser_playground_session( $input );
+		if ( is_wp_error( $session ) ) {
+			return $session;
+		}
+
+		if ( true !== ( $session['success'] ?? false ) ) {
+			$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
+			return array_filter(
+				array(
+					'success'          => false,
+					'schema'           => 'wp-codebox/browser-materializer-contract/v1',
+					'execution'        => 'browser-playground',
+					'execution_scope'  => 'disposable-playground',
+					'permission_model' => 'sandbox-bypass',
+					'status'           => (string) ( $session['status'] ?? 'blocked' ),
+					'error'            => is_array( $session['error'] ?? null ) ? $session['error'] : array(),
+					'session_id'       => (string) ( $session_envelope['id'] ?? '' ),
+					'authorization'    => is_array( $session_envelope['authorization'] ?? null ) ? $session_envelope['authorization'] : self::browser_session_authorization( $input ),
+					'signals'          => is_array( $session['signals'] ?? null ) ? $session['signals'] : array(),
+				),
+				static fn( mixed $value ): bool => array() !== $value && '' !== $value
+			);
+		}
+
+		$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
+
+		return array(
+			'success'          => true,
+			'schema'           => 'wp-codebox/browser-materializer-contract/v1',
+			'execution'        => 'browser-playground',
+			'execution_scope'  => 'disposable-playground',
+			'permission_model' => 'sandbox-bypass',
+			'session_id'       => (string) ( $session_envelope['id'] ?? '' ),
+			'authorization'    => is_array( $session_envelope['authorization'] ?? null ) ? $session_envelope['authorization'] : self::browser_session_authorization( $input ),
+			'task_input'       => is_array( $session['task_input'] ?? null ) ? $session['task_input'] : array(),
+			'task_payload'     => is_array( $session['task_payload'] ?? null ) ? $session['task_payload'] : array(),
+			'materialization'  => is_array( $session['materialization'] ?? null ) ? $session['materialization'] : array(),
+			'recipe'           => is_array( $session['recipe'] ?? null ) ? $session['recipe'] : array(),
+			'playground'       => is_array( $session['playground'] ?? null ) ? $session['playground'] : array(),
+			'runtime'          => is_array( $session['runtime'] ?? null ) ? $session['runtime'] : array(),
+			'artifacts'        => is_array( $session['artifacts'] ?? null ) ? $session['artifacts'] : array(),
+			'provenance'       => array(
+				'generated_by' => 'wp-codebox/browser-materializer-contract',
+				'source'       => 'wp-codebox/create-browser-playground-session',
 			),
 		);
 	}

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -361,6 +361,12 @@ $assert( 'browser Playground session output declares browser execution', array( 
 $assert( 'browser Playground session exposes generic sandbox invocation schema', array( 'ability', 'task' ) === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['invocation']['properties']['type']['enum'] ?? array() ) && 'string' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['invocation']['properties']['hook']['type'] ?? '' ) );
 $assert( 'browser Playground session exposes generic capture path schema', 'array' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['capture_paths']['type'] ?? '' ) && 'integer' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['capture_paths']['items']['properties']['max_bytes']['type'] ?? '' ) && 'object' === ( $browser_session_ability['output_schema']['properties']['materialization']['type'] ?? '' ) );
 
+$browser_materializer_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/create-browser-materializer-contract'] ?? null;
+$assert( 'browser materializer contract ability registered', is_array( $browser_materializer_ability ) );
+$assert( 'browser materializer contract ability is REST visible', true === ( $browser_materializer_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'browser materializer contract accepts goal or legacy task', array( 'goal' ) === ( $browser_materializer_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_materializer_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
+$assert( 'browser materializer contract exposes recipe materialization and authorization output', 'object' === ( $browser_materializer_ability['output_schema']['properties']['recipe']['type'] ?? '' ) && 'object' === ( $browser_materializer_ability['output_schema']['properties']['materialization']['type'] ?? '' ) && 'object' === ( $browser_materializer_ability['output_schema']['properties']['authorization']['type'] ?? '' ) );
+
 $trusted_browser_authorization = array(
 	'authorization' => array(
 		'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
@@ -374,6 +380,7 @@ $assert( 'browser Playground session keeps default protection for untrusted user
 $assert( 'browser Playground session allows trusted orchestrator caller with browser-session scope', true === call_user_func( $browser_session_ability['permission_callback'], $trusted_browser_authorization ) );
 $assert( 'browser Playground session denies untrusted orchestrator caller', false === call_user_func( $browser_session_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'unknown-product', 'scope' => 'browser-session:create' ) ) ) );
 $assert( 'browser Playground session denies trusted caller without browser-session scope', false === call_user_func( $browser_session_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
+$assert( 'browser materializer contract reuses trusted browser-session authorization', true === call_user_func( $browser_materializer_ability['permission_callback'], $trusted_browser_authorization ) && false === call_user_func( $browser_materializer_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
 $GLOBALS['wp_codebox_current_user_can_manage_options'] = true;
 
 $artifact_abilities = array(
@@ -453,9 +460,7 @@ mkdir( $root . '/plugin-root/data-machine-code', 0777, true );
 mkdir( $root . '/plugin-root/generic-caller-plugin', 0777, true );
 file_put_contents( $root . '/plugin-root/generic-caller-plugin/generic-caller-plugin.php', '<?php /* Plugin Name: Generic Caller Plugin */' );
 
-$browser_session = call_user_func(
-	$browser_session_ability['execute_callback'],
-	array(
+$browser_session_input = array(
 		'goal'                  => 'Prepare a browser Playground preview.',
 		'agents_api_path'       => '',
 		'data_machine_path'     => '',
@@ -592,7 +597,11 @@ $browser_session = call_user_func(
 				'kind'      => 'image',
 			),
 		),
-	)
+	);
+
+$browser_session = call_user_func(
+	$browser_session_ability['execute_callback'],
+	$browser_session_input
 );
 $assert( 'browser Playground session returns without shelling out', ! is_wp_error( $browser_session ) && true === ( $browser_session['success'] ?? false ) );
 $assert( 'browser Playground session schema is stable', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-playground-session/v1' === ( $browser_session['schema'] ?? '' ) );
@@ -635,6 +644,16 @@ $assert( 'browser Playground recipe initializes abilities before invocation', ! 
 $assert( 'browser Playground recipe installs caller mu-plugin before invocation', ! is_wp_error( $browser_session ) && ! empty( $browser_step_with_code( 'caller_runtime_task' ) ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'caller_runtime_task' ) );
 $assert( 'browser Playground recipe keeps invocation fixed after parent validation', ! is_wp_error( $browser_session ) && ! str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), '$payload[\'invocation\']' ) );
 $assert( 'browser Playground recipe guards permission bypass to Playground', ! is_wp_error( $browser_session ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), "'/wordpress/' === \$wp_codebox_playground_root" ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER' ) && str_contains( (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_codebox_browser_runner_not_playground' ) );
+
+$browser_materializer_contract = call_user_func(
+	$browser_materializer_ability['execute_callback'],
+	$browser_session_input
+);
+$assert( 'browser materializer contract returns recipe-only envelope', ! is_wp_error( $browser_materializer_contract ) && true === ( $browser_materializer_contract['success'] ?? false ) && 'wp-codebox/browser-materializer-contract/v1' === ( $browser_materializer_contract['schema'] ?? '' ) && ! isset( $browser_materializer_contract['session'] ) && 'browser-session-123' === ( $browser_materializer_contract['session_id'] ?? '' ) );
+$assert( 'browser materializer contract preserves trusted authorization shape', ! is_wp_error( $browser_materializer_contract ) && ( $browser_session['session']['authorization'] ?? array() ) === ( $browser_materializer_contract['authorization'] ?? array() ) );
+$assert( 'browser materializer contract returns same runnable recipe as duplicate session', ! is_wp_error( $browser_materializer_contract ) && ( $browser_session['recipe'] ?? array() ) === ( $browser_materializer_contract['recipe'] ?? array() ) );
+$assert( 'browser materializer contract returns same materialization descriptor as duplicate session', ! is_wp_error( $browser_materializer_contract ) && ( $browser_session['materialization'] ?? array() ) === ( $browser_materializer_contract['materialization'] ?? array() ) );
+$assert( 'browser materializer contract preserves runnable context for existing browser session', ! is_wp_error( $browser_materializer_contract ) && ( $browser_session['task_payload'] ?? array() ) === ( $browser_materializer_contract['task_payload'] ?? array() ) && ( $browser_session['playground'] ?? array() ) === ( $browser_materializer_contract['playground'] ?? array() ) && ( $browser_session['artifacts'] ?? array() ) === ( $browser_materializer_contract['artifacts'] ?? array() ) );
 
 $runner_report_path = $root . '/browser-materialization-report.json';
 add_filter(


### PR DESCRIPTION
## Summary
- Adds `wp-codebox/create-browser-materializer-contract` so parent products can request the browser runner recipe/materialization contract without calling the browser session ability a second time.
- Reuses the existing browser Playground session builder to preserve the current recipe, materialization, authorization, and runnable context shape.
- Extends the WordPress plugin smoke to prove the new contract matches the recipe/materialization/authorization shape currently extracted from a duplicate session.

Fixes #500.

## Tests
- `php tests/smoke-wordpress-plugin.php`
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run recipe-browser-smoke`
- `npm run browser-runtime-operation-smoke`
- `npm run command-registry-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the recipe-only browser materializer contract API, updated smoke coverage, and ran verification under Chris's review.