### PR TITLE
fix: start sandbox chats without transcript session

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -48,13 +48,13 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
   const input: Record<string, unknown> = {
     agent: options.agent,
     message: options.task,
-    session_id: options.sessionId ?? null,
     mode,
     modes: agentModes,
     client_context: {
       source: "bridge",
       client_name: "wp-codebox",
       connector_id: "wp-codebox-cli",
+      codebox_session_id: options.sessionId ?? null,
       mode,
       agent_modes: agentModes,
       workspace_root: SANDBOX_WORKSPACE_ROOT,

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -8,6 +8,7 @@ async function main() {
     mode: "sandbox",
     provider: "opencode",
     model: "opencode-go/kimi-k2.6",
+    sessionId: "codebox-smoke-session",
     agentBundles: [
       { source: "/tmp/site-generator-agent.json", slug: "site-generator" },
       {
@@ -21,6 +22,8 @@ async function main() {
   })
 
   assert.match(code, /\\"modes\\":\[\\"sandbox\\",\\"chat\\"\]/, "sandbox chat input should inherit chat tool surface")
+  assert.doesNotMatch(code, /\\"session_id\\":\\"codebox-smoke-session\\"/, "fresh sandbox chats should not continue a nonexistent transcript session")
+  assert.match(code, /\\"codebox_session_id\\":\\"codebox-smoke-session\\"/, "Codebox session id should remain orchestration metadata")
   assert.match(code, /\\"agent_modes\\":\[\\"sandbox\\",\\"chat\\"\]/, "client context should report additive sandbox modes without pipeline completion semantics")
   assert.doesNotMatch(code, /\\"pipeline\\"/, "sandbox agents should not use pipeline mode because it completes after handler tools")
   assert.match(code, /\\"tool_policy\\":\{\\"mode\\":\\"allow\\",\\"tools\\":\[.*\\"workspace_read\\"/, "sandbox agent should allow workspace tools")


### PR DESCRIPTION
## Summary
- Stops passing the WP Codebox sandbox session id as `agents/chat` `session_id` for fresh sandbox runs.
- Keeps the Codebox session id available as `client_context.codebox_session_id` orchestration metadata.
- Adds smoke coverage proving sandbox chats do not try to continue a nonexistent transcript session.

## Tests
- `npm run agent-sandbox-code-smoke`
- `npm run build`

## Evidence
- Homeboy headless Codebox smoke using the local fixed CLI moved past `session_not_found` and reached the model provider layer.
- Current remaining blocker after this fix: `wp-ai-client provider registry failed: Provider codex is not registered in wp-ai-client`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the sandbox transcript/session contract issue, implemented the minimal WP Codebox fix, ran targeted verification, and drafted this PR description; Chris remains responsible for review and acceptance.