### PR TITLE
docs: add codex agent recipe example

### DIFF
--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -25,6 +25,44 @@ out of recipe files and dry-run evidence.
 
 ## Available recipes
 
+### `codex-agent-smoke.json`
+
+Runs a headless Data Machine agent inside a disposable WordPress Playground
+sandbox using the Codex provider. This is the smallest end-to-end recipe for
+proving that WP Codebox can mount the agent runtime stack, overlay a
+`php-ai-client` branch with provider-supplied request auth, activate a Codex
+provider plugin branch, and execute `agents/chat` through `wp-codebox.agent-sandbox-run`.
+
+**Replace** these recipe paths before running:
+
+- `/path/to/agents-api`
+- `/path/to/data-machine`
+- `/path/to/data-machine-code`
+- `/path/to/php-ai-client-pr-238-or-newer`
+- `/path/to/ai-provider-for-openai-pr-28-or-newer`
+
+Export Codex OAuth credentials in the shell that runs WP Codebox. Keep token
+values out of recipe files and artifacts:
+
+```bash
+export AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN="..."
+export AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN="..."
+export AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT="..."
+export AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID="..."
+export AI_PROVIDER_OPENAI_CODEX_FEDRAMP="false"
+
+npm run wp-codebox -- recipe-run \
+  --recipe ./examples/recipes/cookbook/codex-agent-smoke.json \
+  --json
+```
+
+The expected successful response is a JSON recipe run whose agent runtime
+reports the Playground site title and active theme. Fleet runners such as
+Homeboy should generate one recipe/run per task and own queueing,
+concurrency, retry policy, durable run records, and PR/comment workflows above
+WP Codebox. WP Codebox owns the sandbox, mounts, overlays, agent invocation,
+and artifact bundle.
+
 ### `multisite-network.json`
 
 Converts the Playground install to multisite with WP-CLI, mounts your plugin

--- a/examples/recipes/cookbook/codex-agent-smoke.json
+++ b/examples/recipes/cookbook/codex-agent-smoke.json
@@ -1,0 +1,78 @@
+{
+  "schema": "wp-codebox/workspace-recipe/v1",
+  "runtime": {
+    "backend": "wordpress-playground",
+    "name": "codex-agent-smoke",
+    "wp": "trunk",
+    "blueprint": {
+      "steps": []
+    },
+    "overlays": [
+      {
+        "kind": "bundled-library",
+        "library": "php-ai-client",
+        "source": "/path/to/php-ai-client-pr-238-or-newer",
+        "target": "/wordpress/wp-includes/php-ai-client",
+        "strategy": "wordpress-scoped-bundle",
+        "metadata": {
+          "component": "php-ai-client",
+          "purpose": "provider-supplied request authentication"
+        }
+      }
+    ]
+  },
+  "inputs": {
+    "extraPlugins": [
+      {
+        "source": "/path/to/agents-api",
+        "slug": "agents-api",
+        "activate": true
+      },
+      {
+        "source": "/path/to/data-machine",
+        "slug": "data-machine",
+        "activate": true
+      },
+      {
+        "source": "/path/to/data-machine-code",
+        "slug": "data-machine-code",
+        "activate": true
+      },
+      {
+        "source": "/path/to/ai-provider-for-openai-pr-28-or-newer",
+        "slug": "ai-provider-for-openai",
+        "activate": false
+      }
+    ],
+    "secretEnv": [
+      "AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN",
+      "AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN",
+      "AI_PROVIDER_OPENAI_CODEX_EXPIRES_AT",
+      "AI_PROVIDER_OPENAI_CODEX_ACCOUNT_ID",
+      "AI_PROVIDER_OPENAI_CODEX_FEDRAMP"
+    ]
+  },
+  "workflow": {
+    "steps": [
+      {
+        "command": "wp-codebox.agent-sandbox-run",
+        "args": [
+          "task=Run a minimal headless WP Codebox smoke. Inspect the WordPress runtime, report the site title and active theme, and do not modify files.",
+          "agent=wp-codebox-sandbox",
+          "mode=default",
+          "provider=codex",
+          "model=gpt-5.5",
+          "provider-plugin-slugs=ai-provider-for-openai",
+          "max-turns=1",
+          "timeout-seconds=300"
+        ]
+      }
+    ]
+  },
+  "artifacts": {
+    "directory": "./artifacts/codex-agent-smoke",
+    "verify": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a cookbook recipe showing the minimal WP Codebox shape for a Codex-backed headless agent run.
- Documents the required runtime ingredients: Agents API, Data Machine, Data Machine Code, a `php-ai-client` provider-auth overlay, a Codex-enabled OpenAI provider plugin, and `AI_PROVIDER_OPENAI_CODEX_*` env vars.
- Clarifies the boundary: WP Codebox owns sandbox/recipe/artifact execution; fleet runners such as Homeboy own queueing, concurrency, retries, durable run records, and PR/comment workflows above it.

## Tests
- `node -e 'JSON.parse(require("fs").readFileSync("examples/recipes/cookbook/codex-agent-smoke.json", "utf8")); console.log("codex-agent-smoke.json valid")'`

## Evidence
- A local Homeboy `agent-task run-plan` smoke using WP Codebox, `php-ai-client#238` as a runtime overlay, `ai-provider-for-openai#28` as the provider plugin, and OpenCode OAuth mapped into `AI_PROVIDER_OPENAI_CODEX_*` succeeded.
- The Codex-backed sandbox agent responded with the Playground site title and active theme.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the Codex recipe example and README guidance from the successful local Homeboy/WP Codebox smoke; Chris remains responsible for review and acceptance.