### PR TITLE
Expose editor-open through runtime action adapter

### DIFF
--- a/packages/runtime-core/src/runtime-action-adapter.ts
+++ b/packages/runtime-core/src/runtime-action-adapter.ts
@@ -8,7 +8,7 @@ export const RUNTIME_ACTION_OBSERVATION_SCHEMA = "wp-codebox/runtime-action-obse
 
 export const SANDBOX_WORKSPACE_ROOT = "/workspace"
 
-export type RuntimeAction = RuntimeWpCliAction | RuntimeRestRequestAction | RuntimeFilesystemAction | RuntimeBrowserAction
+export type RuntimeAction = RuntimeWpCliAction | RuntimeRestRequestAction | RuntimeFilesystemAction | RuntimeBrowserAction | RuntimeEditorOpenAction
 
 export interface RuntimeWpCliAction {
   type: "wp_cli"
@@ -44,6 +44,17 @@ export interface RuntimeBrowserAction {
   key?: string
   wait_for?: string
   duration?: string
+  capture?: string[]
+  timeout_ms?: number
+}
+
+export interface RuntimeEditorOpenAction {
+  type: "editor_open"
+  target?: "post-new" | "site"
+  post_id?: number
+  post_type?: string
+  url?: string
+  wait_selector?: string
   capture?: string[]
   timeout_ms?: number
 }
@@ -91,6 +102,10 @@ export async function runRuntimeAction(
 
   if (action.type === "browser") {
     return runRuntimeBrowserAction(episode, action)
+  }
+
+  if (action.type === "editor_open") {
+    return runRuntimeEditorOpenAction(episode, action)
   }
 
   return runRuntimeFilesystemAction(episode, action, policy)
@@ -323,6 +338,82 @@ function runtimeBrowserCommandAction(action: RuntimeBrowserAction): Record<strin
     commandAction.capture = action.capture
   }
   return commandAction
+}
+
+async function runRuntimeEditorOpenAction(episode: RuntimeEpisode, action: RuntimeEditorOpenAction): Promise<RuntimeActionObservation> {
+  const args = runtimeEditorOpenArgs(action)
+  const step = await episode.step(
+    {
+      kind: "browser",
+      command: "wordpress.editor-open",
+      args,
+      ...(action.timeout_ms !== undefined ? { timeoutMs: action.timeout_ms } : {}),
+      ...(action.url ? { url: action.url } : {}),
+      ...(action.target ? { target: action.target } : {}),
+      operation: "editor_open",
+    },
+    { type: "browser-result" },
+  )
+
+  let stdout: unknown = step.execution.stdout
+  try {
+    stdout = JSON.parse(step.execution.stdout)
+  } catch {
+    // Keep raw stdout when a backend returns non-JSON diagnostics.
+  }
+  const summary = recordValue(stdout)
+
+  return runtimeActionObservation({
+    type: action.type,
+    action,
+    step,
+    data: {
+      mappedCommand: step.execution.command,
+      args: step.execution.args,
+      exitCode: step.execution.exitCode,
+      stdout,
+      stderr: step.execution.stderr,
+      executionId: step.execution.id,
+      stepId: step.id,
+      diagnostics: {
+        exitCode: step.execution.exitCode,
+        stderr: step.execution.stderr,
+      },
+      ...(summary?.target ? { target: summary.target } : {}),
+      ...(summary?.finalUrl ? { finalUrl: summary.finalUrl } : {}),
+      ...(summary?.files ? { files: summary.files } : {}),
+      ...(summary?.summary ? { summary: summary.summary } : {}),
+      ...(summary?.steps ? { steps: summary.steps } : {}),
+      artifactRefs: step.observation?.artifactRefs ?? [],
+    },
+    artifactRefs: step.observation?.artifactRefs,
+  })
+}
+
+function runtimeEditorOpenArgs(action: RuntimeEditorOpenAction): string[] {
+  const args: string[] = []
+  if (action.target) {
+    args.push(`target=${action.target}`)
+  }
+  if (action.post_id !== undefined) {
+    args.push(`post-id=${action.post_id}`)
+  }
+  if (action.post_type) {
+    args.push(`post-type=${action.post_type}`)
+  }
+  if (action.url) {
+    args.push(`url=${action.url}`)
+  }
+  if (action.wait_selector) {
+    args.push(`wait-selector=${action.wait_selector}`)
+  }
+  if (action.timeout_ms !== undefined) {
+    args.push(`wait-timeout=${action.timeout_ms}ms`)
+  }
+  if (action.capture && action.capture.length > 0) {
+    args.push(`capture=${action.capture.join(",")}`)
+  }
+  return args
 }
 
 function normalizeWpCliRuntimeActionCommand(command: string): string {

--- a/scripts/runtime-action-adapter-smoke.ts
+++ b/scripts/runtime-action-adapter-smoke.ts
@@ -28,7 +28,7 @@ try {
         policy: {
           network: "deny",
           filesystem: "readwrite-mounts",
-          commands: ["wordpress.wp-cli", "wordpress.browser-actions", "inspect-mounted-inputs"],
+          commands: ["wordpress.wp-cli", "wordpress.browser-actions", "wordpress.editor-open", "inspect-mounted-inputs"],
           secrets: "none",
           approvals: "never",
         },
@@ -82,6 +82,29 @@ try {
       "capture=actions,errors",
     ])
 
+    const editorOpen = await runRuntimeAction(
+      episode,
+      { type: "editor_open", target: "post-new", post_type: "post", capture: ["steps", "editor-state"], timeout_ms: 30_000 },
+      policy,
+    )
+    assert.equal(editorOpen.schema, RUNTIME_ACTION_OBSERVATION_SCHEMA)
+    assert.equal(editorOpen.type, "editor_open")
+    assert.equal(editorOpen.step?.action.kind, "browser")
+    assert.equal(editorOpen.step?.execution.command, "wordpress.editor-open")
+    assert.deepEqual(editorOpen.step?.execution.args, [
+      "target=post-new",
+      "post-type=post",
+      "wait-timeout=30000ms",
+      "capture=steps,editor-state",
+    ])
+    assert.equal(editorOpen.data.exitCode, 0)
+    assert.equal((editorOpen.data.target as { kind?: string; postType?: string }).kind, "post-new")
+    assert.equal((editorOpen.data.target as { kind?: string; postType?: string }).postType, "post")
+    assert.equal((editorOpen.data.files as { editorState?: string }).editorState, "files/browser/editor-state.json")
+    assert.equal((editorOpen.data.summary as { editor?: { storesAvailable?: boolean; postType?: string } }).editor?.storesAvailable, true)
+    assert.equal((editorOpen.data.summary as { editor?: { storesAvailable?: boolean; postType?: string } }).editor?.postType, "post")
+    assert.ok(Array.isArray(editorOpen.data.artifactRefs), "editor open should expose artifact refs")
+
     const deleteResult = await runRuntimeAction(episode, { type: "filesystem", operation: "delete", path: "/workspace/notes/hello.txt" }, policy)
     assert.equal(deleteResult.data.deleted, true)
 
@@ -95,9 +118,9 @@ try {
     )
 
     const trace = await episode.trace()
-    assert.equal(trace.steps.length, 6)
+    assert.equal(trace.steps.length, 7)
     assert.equal(trace.steps.filter((step) => step.action.kind === "filesystem").length, 4)
-    assert.equal(trace.steps.filter((step) => step.action.kind === "browser").length, 1)
+    assert.equal(trace.steps.filter((step) => step.action.kind === "browser").length, 2)
     assert.equal(validateRuntimeEpisodeTrace(trace).valid, true)
   } finally {
     await episode.close()


### PR DESCRIPTION
## Summary
- Adds a generic `editor_open` runtime action adapter type that maps to `wordpress.editor-open`.
- Normalizes editor-open command output into action observation data, including parsed target/files/summary/steps, diagnostics, step id, and artifact refs.
- Extends runtime action adapter smoke coverage to prove adapter-driven editor state capture.

## Tests
- `npm run build`
- `npm run editor-open-artifact-smoke`
- `npm run discovery-command-smoke`
- `npm run runtime-action-adapter-smoke` (passed when rerun serially after a transient parallel Playground CLI `EADDRINUSE 127.0.0.1:62936` collision)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic runtime action adapter mapping and focused smoke coverage; Chris remains responsible for review and testing.

Fixes #507