### PR TITLE
Preserve caller browser artifact schemas

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -3911,38 +3911,55 @@ function wp_codebox_browser_safe_artifact_path( $path, $root ) {
 	return str_starts_with( $normalized, $root ) ? $normalized : \'\';
 }
 
+function wp_codebox_browser_safe_playground_read_path( $path ) {
+	$path = str_replace( chr( 92 ), "/", (string) $path );
+	$root = defined( \'ABSPATH\' ) ? wp_normalize_path( ABSPATH ) : \'/wordpress/\';
+	$root = rtrim( str_replace( chr( 92 ), "/", $root ), "/" ) . "/";
+	if ( \'\' === $path || str_contains( $path, \'..\' ) || ! str_starts_with( $path, $root ) || ! is_readable( $path ) ) {
+		return \'\';
+	}
+
+	return $path;
+}
+
 function wp_codebox_browser_capture_artifact_bundle( array $payload ) {
 	$contract = is_array( $payload[\'artifacts\'] ?? null ) ? $payload[\'artifacts\'] : array();
-	if ( \'studio-web/website-artifact-bundle/v1\' !== (string) ( $contract[\'schema\'] ?? \'\' ) ) {
+	$schema = trim( (string) ( $contract[\'schema\'] ?? \'\' ) );
+	if ( \'\' === $schema ) {
 		return array();
 	}
 
-	$root = (string) ( $contract[\'root\'] ?? \'website/\' );
+	$root = (string) ( $contract[\'root\'] ?? \'\' );
 	$root = rtrim( ltrim( str_replace( chr( 92 ), "/", $root ), "/" ), "/" ) . "/";
+	if ( \'/\' === $root ) {
+		return array();
+	}
 	$entrypoint = wp_codebox_browser_safe_artifact_path( (string) ( $contract[\'entrypoint\'] ?? $root . \'index.html\' ), $root );
+	if ( \'\' === $entrypoint ) {
+		return array();
+	}
+
 	$files = array();
 	foreach ( is_array( $contract[\'files\'] ?? null ) ? $contract[\'files\'] : array() as $file ) {
 		if ( ! is_array( $file ) ) {
 			continue;
 		}
 		$path = wp_codebox_browser_safe_artifact_path( $file[\'path\'] ?? \'\', $root );
-		$playground_path = (string) ( $file[\'playground_path\'] ?? \'\' );
-		if ( \'\' === $path || \'\' === $playground_path || str_contains( $playground_path, \'..\' ) || ! str_starts_with( $playground_path, \'/wordpress/\' ) || ! is_readable( $playground_path ) ) {
+		$playground_path = wp_codebox_browser_safe_playground_read_path( $file[\'playground_path\'] ?? \'\' );
+		if ( \'\' === $path || \'\' === $playground_path ) {
 			continue;
 		}
 		$contents = file_get_contents( $playground_path );
 		if ( ! is_string( $contents ) ) {
 			continue;
 		}
-		$is_text = preg_match( \'#^[\\x09\\x0A\\x0D\\x20-\\x7E]*$#\', $contents );
-		$record = array(
-			\'path\' => $path,
-			\'role\' => $path === $entrypoint ? \'entrypoint\' : ( (bool) preg_match( \'/\\.(md|markdown|mdx)$/i\', $path ) ? \'source-document\' : \'asset\' ),
-			\'kind\' => (string) ( $file[\'kind\'] ?? ( $path === $entrypoint ? \'html\' : \'\' ) ),
-			\'mime_type\' => (string) ( $file[\'mime_type\'] ?? \'\' ),
-			\'url_path\' => (string) ( $file[\'url_path\'] ?? \'\' ),
-			\'sha256\' => hash( \'sha256\', $contents ),
-		);
+		$is_text = 1 === preg_match( \'#^[\\x09\\x0A\\x0D\\x20-\\x7E]*$#\', $contents );
+		$record = array_diff_key( $file, array( \'playground_path\' => true, \'content\' => true, \'content_base64\' => true, \'encoding\' => true, \'sha256\' => true ) );
+		$record[\'path\'] = $path;
+		$record[\'kind\'] = (string) ( $file[\'kind\'] ?? \'\' );
+		$record[\'mime_type\'] = (string) ( $file[\'mime_type\'] ?? \'\' );
+		$record[\'url_path\'] = (string) ( $file[\'url_path\'] ?? \'\' );
+		$record[\'sha256\'] = hash( \'sha256\', $contents );
 		if ( $is_text ) {
 			$record[\'content\'] = $contents;
 			$record[\'encoding\'] = \'utf-8\';
@@ -3953,15 +3970,19 @@ function wp_codebox_browser_capture_artifact_bundle( array $payload ) {
 		$files[] = array_filter( $record, static fn( $value ) => \'\' !== $value );
 	}
 
-	if ( empty( $files ) || \'\' === $entrypoint ) {
+	$entrypoint_captured = in_array( $entrypoint, array_column( $files, \'path\' ), true );
+	if ( empty( $files ) || ! $entrypoint_captured ) {
 		return array();
 	}
 
-	return array(
-		\'schema\' => \'studio-web/website-artifact-bundle/v1\',
-		\'root\' => $root,
-		\'entrypoint\' => $entrypoint,
-		\'files\' => $files,
+	return array_merge(
+		array_diff_key( $contract, array( \'files\' => true ) ),
+		array(
+			\'schema\' => $schema,
+			\'root\' => $root,
+			\'entrypoint\' => $entrypoint,
+			\'files\' => $files,
+		)
 	);
 }
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -688,6 +688,61 @@ $runner_php = preg_replace( '/^<\?php\s*/', '', $runner_php ) ?? $runner_php;
 $runner_php = str_replace( "require_once '/wordpress/wp-load.php';", '', $runner_php );
 $runner_php = str_replace( '/wordpress/wp-content/uploads/wp-codebox/artifacts/materialization/report.json', $runner_report_path, $runner_php );
 $runner_php = preg_replace( '/\$wp_codebox_is_playground = .*?;\n/', '$wp_codebox_is_playground = true;' . "\n", $runner_php ) ?? $runner_php;
+$runner_artifact_root = rtrim( ABSPATH, '/' ) . '/wp-content/uploads/wp-codebox/artifacts/generic-output';
+if ( ! is_dir( $runner_artifact_root . '/assets' ) ) {
+	mkdir( $runner_artifact_root . '/assets', 0777, true );
+}
+file_put_contents( $runner_artifact_root . '/index.html', '<main>Generic caller artifact</main>' );
+file_put_contents( $runner_artifact_root . '/assets/logo.png', "\x89PNG\r\n\x1a\ngeneric" );
+$runner_task_payload = $browser_session['recipe']['browser']['task_payload'] ?? array();
+$runner_task_payload['artifacts'] = array(
+	'schema'     => 'caller/generic-browser-artifact-bundle/v1',
+	'root'       => 'generic-output',
+	'entrypoint' => 'generic-output/index.html',
+	'roles'      => array(
+		'preview' => 'generic-output/index.html',
+	),
+	'metadata'   => array(
+		'caller' => 'wordpress-plugin-smoke',
+		'labels' => array( 'non-studio-web' ),
+	),
+	'files'      => array(
+		array(
+			'path'            => 'generic-output/index.html',
+			'playground_path' => $runner_artifact_root . '/index.html',
+			'url_path'        => '/wp-content/uploads/wp-codebox/artifacts/generic-output/index.html',
+			'kind'            => 'html',
+			'mime_type'       => 'text/html',
+			'roles'           => array( 'preview' ),
+			'metadata'        => array( 'opaque' => 'entrypoint' ),
+		),
+		array(
+			'path'            => 'generic-output/assets/logo.png',
+			'playground_path' => $runner_artifact_root . '/assets/logo.png',
+			'url_path'        => '/wp-content/uploads/wp-codebox/artifacts/generic-output/assets/logo.png',
+			'kind'            => 'image',
+			'mime_type'       => 'image/png',
+			'metadata'        => array( 'opaque' => 'binary' ),
+		),
+		array(
+			'path'            => '../escape.html',
+			'playground_path' => $runner_artifact_root . '/index.html',
+			'kind'            => 'html',
+		),
+		array(
+			'path'            => 'generic-output/missing.txt',
+			'playground_path' => $runner_artifact_root . '/missing.txt',
+			'kind'            => 'text',
+		),
+	),
+);
+$runner_task_path = (string) ( $browser_session['recipe']['browser']['task_path'] ?? '' );
+if ( '' !== $runner_task_path ) {
+	if ( ! is_dir( dirname( $runner_task_path ) ) ) {
+		mkdir( dirname( $runner_task_path ), 0777, true );
+	}
+	file_put_contents( $runner_task_path, wp_json_encode( $runner_task_payload ) );
+}
 ob_start();
 eval( $runner_php );
 $runner_output = ob_get_clean();
@@ -698,6 +753,11 @@ $assert( 'browser Playground generated runner invokes caller task hook', is_arra
 $assert( 'browser Playground generated runner captures normalized materialization evidence', is_array( $runner_result ) && 'wp-codebox/browser-materialization/v1' === ( $runner_result['schema'] ?? '' ) && 'wp-codebox/browser-capture/v1' === ( $runner_result['captures'][0]['schema'] ?? '' ) && true === ( $runner_result['captures'][0]['exists'] ?? false ) && 'caller/materialization-report/v1' === ( $runner_result['captures'][0]['json']['schema'] ?? '' ) );
 $assert( 'browser Playground generated runner writes result evidence file', is_array( $runner_result_file ) && $runner_result === $runner_result_file );
 $assert( 'browser Playground generated runner records diagnostics and provenance', is_array( $runner_result ) && 1 === ( $runner_result['diagnostics']['capture_count'] ?? 0 ) && array() === ( $runner_result['errors'] ?? null ) && 'wp-codebox/browser-runner' === ( $runner_result['provenance']['generated_by'] ?? '' ) && '/tmp/wp-codebox-agent-result.json' === ( $runner_result['provenance']['result_path'] ?? '' ) );
+$assert( 'browser Playground generated runner captures caller-owned artifact schema', is_array( $runner_result ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['artifact_bundle']['schema'] ?? '' ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['response']['artifact_bundle']['schema'] ?? '' ) );
+$assert( 'browser Playground generated runner preserves caller artifact metadata and roles', is_array( $runner_result ) && array( 'non-studio-web' ) === ( $runner_result['artifact_bundle']['metadata']['labels'] ?? array() ) && array( 'preview' => 'generic-output/index.html' ) === ( $runner_result['artifact_bundle']['roles'] ?? array() ) && array( 'preview' ) === ( $runner_result['artifact_bundle']['files'][0]['roles'] ?? array() ) && 'entrypoint' === ( $runner_result['artifact_bundle']['files'][0]['metadata']['opaque'] ?? '' ) );
+$assert( 'browser Playground generated runner captures text and base64 artifact files', is_array( $runner_result ) && 2 === count( $runner_result['artifact_bundle']['files'] ?? array() ) && '<main>Generic caller artifact</main>' === ( $runner_result['artifact_bundle']['files'][0]['content'] ?? '' ) && 'utf-8' === ( $runner_result['artifact_bundle']['files'][0]['encoding'] ?? '' ) && 'base64' === ( $runner_result['artifact_bundle']['files'][1]['encoding'] ?? '' ) && hash( 'sha256', "\x89PNG\r\n\x1a\ngeneric" ) === ( $runner_result['artifact_bundle']['files'][1]['sha256'] ?? '' ) );
+$runner_missing_entrypoint = function_exists( 'wp_codebox_browser_capture_artifact_bundle' ) ? wp_codebox_browser_capture_artifact_bundle( array( 'artifacts' => array_merge( $runner_task_payload['artifacts'], array( 'entrypoint' => 'generic-output/missing.html' ) ) ) ) : array( 'missing_function' => true );
+$assert( 'browser Playground generated runner skips missing artifact entrypoints safely', array() === $runner_missing_entrypoint );
 $assert( 'browser Playground session emits ready-to-code signal only when blueprint prerequisites are present', ! is_wp_error( $browser_session ) && true === ( $browser_session['signals']['ready_to_code']['emitted'] ?? false ) && 'ready_to_code' === ( $browser_session['signals']['ready_to_code']['name'] ?? '' ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['agents_api'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['data_machine'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['data_machine_code'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['provider_secret'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['runtime_dependencies'] ?? false ) );
 $assert( 'browser Playground session exposes runtime dependency readiness metadata', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-runtime-readiness/v1' === ( $browser_session['signals']['ready_to_code']['requirement_metadata']['runtime_dependencies']['schema'] ?? '' ) && 'caller-runtime' === ( $browser_session['signals']['ready_to_code']['requirement_metadata']['runtime_dependencies']['mu_plugins'][0]['slug'] ?? '' ) && 'example-starter' === ( $browser_session['signals']['ready_to_code']['requirement_metadata']['runtime_dependencies']['themes'][0]['slug'] ?? '' ) );
 $assert( 'browser Playground session preserves safe artifact files', ! is_wp_error( $browser_session ) && 'repair-output/index.html' === ( $browser_session['artifacts']['files'][0]['path'] ?? '' ) );


### PR DESCRIPTION
## Summary
- Removes the Studio Web-specific browser artifact bundle schema gate from generated runner capture.
- Captures any non-empty caller-provided artifact schema while preserving opaque caller roles and metadata.
- Extends the WordPress plugin smoke test with a non-Studio caller schema, invalid path skip, unreadable file skip, and missing-entrypoint coverage.

## Tests
- `php tests/smoke-wordpress-plugin.php`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the code change and smoke coverage; Chris remains responsible for review and testing.