### PR TITLE
Import browser agent bundles with scoped principal

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -989,8 +989,31 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			if ( isset( $bundle['owner_id'] ) && (int) $bundle['owner_id'] > 0 ) {
 				$entry['owner_id'] = (int) $bundle['owner_id'];
 			}
+			if ( is_array( $bundle['import_principal'] ?? null ) ) {
+				$entry['import_principal'] = $this->agent_bundle_import_principal( $bundle['import_principal'] );
+			}
 
 			$normalized[] = $entry;
+		}
+
+		return $normalized;
+	}
+
+	/** @param array<string,mixed> $principal Raw import principal. @return array<string,mixed> */
+	private function agent_bundle_import_principal( array $principal ): array {
+		$normalized = array();
+		foreach ( array( 'agent_id', 'owner_id', 'token_id' ) as $field ) {
+			if ( isset( $principal[ $field ] ) && (int) $principal[ $field ] > 0 ) {
+				$normalized[ $field ] = (int) $principal[ $field ];
+			}
+		}
+
+		$capabilities = $this->string_list( $principal['capabilities'] ?? array() );
+		if ( ! empty( $capabilities ) ) {
+			$normalized['capabilities'] = $capabilities;
+		}
+		if ( is_array( $principal['scope'] ?? null ) ) {
+			$normalized['scope'] = $principal['scope'];
 		}
 
 		return $normalized;

--- a/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
@@ -69,6 +69,7 @@ final class WP_Codebox_Task_Input_Contract {
 							'on_conflict' => array( 'type' => 'string', 'enum' => array( 'error', 'skip', 'upgrade' ) ),
 							'owner_id'    => array( 'type' => 'integer' ),
 							'token_env'   => array( 'type' => 'string' ),
+							'import_principal' => array( 'type' => 'object' ),
 						),
 					),
 				),
@@ -134,10 +135,33 @@ final class WP_Codebox_Task_Input_Contract {
 			if ( isset( $entry['owner_id'] ) && (int) $entry['owner_id'] > 0 ) {
 				$bundle['owner_id'] = (int) $entry['owner_id'];
 			}
+			if ( is_array( $entry['import_principal'] ?? null ) ) {
+				$bundle['import_principal'] = self::import_principal( $entry['import_principal'] );
+			}
 			$bundles[] = $bundle;
 		}
 
 		return $bundles;
+	}
+
+	/** @param array<string,mixed> $principal Raw import principal. @return array<string,mixed> */
+	private static function import_principal( array $principal ): array {
+		$normalized = array();
+		foreach ( array( 'agent_id', 'owner_id', 'token_id' ) as $field ) {
+			if ( isset( $principal[ $field ] ) && (int) $principal[ $field ] > 0 ) {
+				$normalized[ $field ] = (int) $principal[ $field ];
+			}
+		}
+
+		$capabilities = self::string_list( $principal['capabilities'] ?? array() );
+		if ( ! empty( $capabilities ) ) {
+			$normalized['capabilities'] = $capabilities;
+		}
+		if ( is_array( $principal['scope'] ?? null ) ) {
+			$normalized['scope'] = $principal['scope'];
+		}
+
+		return $normalized;
 	}
 
 	/** @return string[] */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -374,6 +374,50 @@ return array_merge(
 );
 }
 
+function wp_codebox_browser_agent_bundle_import_principal( array $spec, array $input ) {
+	$principal = is_array( $spec[\'import_principal\'] ?? null ) ? $spec[\'import_principal\'] : array();
+	if ( empty( $principal ) ) {
+		return null;
+	}
+	if ( ! class_exists( \'\\DataMachine\\Abilities\\PermissionHelper\' ) ) {
+		return new WP_Error( \'wp_codebox_agent_bundle_import_principal_unavailable\', \'Data Machine PermissionHelper is required to apply an agent bundle import principal.\' );
+	}
+
+	$agent_id = (int) ( $principal[\'agent_id\'] ?? 0 );
+	if ( $agent_id <= 0 ) {
+		return new WP_Error( \'wp_codebox_agent_bundle_import_principal_missing_agent\', \'Agent bundle import principals require a positive agent_id.\' );
+	}
+
+	$capabilities = array_values( array_filter( array_map( \'strval\', is_array( $principal[\'capabilities\'] ?? null ) ? $principal[\'capabilities\'] : array() ) ) );
+	if ( empty( $capabilities ) ) {
+		$capabilities = array( \'datamachine_manage_agents\' );
+	}
+
+	$scope = is_array( $principal[\'scope\'] ?? null ) ? $principal[\'scope\'] : array();
+	$scope = array_merge(
+		array(
+			\'scope\'              => \'agent_bundle_import\',
+			\'label\'              => \'Agent bundle import\',
+			\'ability_categories\' => array(),
+			\'ability_allow\'      => array( \'datamachine/import-agent\' ),
+			\'ability_deny\'       => array(),
+			\'capabilities\'       => $capabilities,
+		),
+		$scope
+	);
+	$scope[\'capabilities\'] = array_values( array_filter( array_map( \'strval\', is_array( $scope[\'capabilities\'] ?? null ) ? $scope[\'capabilities\'] : $capabilities ) ) );
+	if ( empty( $scope[\'capabilities\'] ) ) {
+		$scope[\'capabilities\'] = $capabilities;
+	}
+
+	return array(
+		\'agent_id\' => $agent_id,
+		\'owner_id\' => (int) ( $principal[\'owner_id\'] ?? $input[\'owner_id\'] ?? ( get_current_user_id() ?: 1 ) ),
+		\'scope\'    => $scope,
+		\'token_id\' => isset( $principal[\'token_id\'] ) && (int) $principal[\'token_id\'] > 0 ? (int) $principal[\'token_id\'] : null,
+	);
+}
+
 function wp_codebox_browser_import_agent_bundles( array $bundle_specs ): array {
 if ( empty( $bundle_specs ) ) {
 	return array();
@@ -425,11 +469,16 @@ foreach ( $bundle_specs as $index => $spec ) {
 		}
 	}
 	$input[\'owner_id\'] = isset( $spec[\'owner_id\'] ) && (int) $spec[\'owner_id\'] > 0 ? (int) $spec[\'owner_id\'] : ( get_current_user_id() ?: 1 );
-	if ( class_exists( \'\\DataMachine\\Abilities\\PermissionHelper\' ) ) {
-		$result = \\DataMachine\\Abilities\\PermissionHelper::run_as_authenticated(
-			static fn() => $ability->execute( $input ),
-			(int) $input[\'owner_id\']
-		);
+	$principal = wp_codebox_browser_agent_bundle_import_principal( $spec, $input );
+	if ( is_wp_error( $principal ) ) {
+		$result = $principal;
+	} elseif ( is_array( $principal ) ) {
+		\\DataMachine\\Abilities\\PermissionHelper::set_agent_context( (int) $principal[\'agent_id\'], (int) $principal[\'owner_id\'], $principal[\'scope\'], $principal[\'token_id\'] );
+		try {
+			$result = $ability->execute( $input );
+		} finally {
+			\\DataMachine\\Abilities\\PermissionHelper::clear_agent_context();
+		}
 	} else {
 		$result = $ability->execute( $input );
 	}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -185,8 +185,47 @@ private static function normalize_agent_bundles( mixed $bundles ): array {
 		if ( isset( $bundle['owner_id'] ) && (int) $bundle['owner_id'] > 0 ) {
 			$entry['owner_id'] = (int) $bundle['owner_id'];
 		}
+		if ( is_array( $bundle['import_principal'] ?? null ) ) {
+			$entry['import_principal'] = self::normalize_agent_bundle_import_principal( $bundle['import_principal'] );
+		}
 
 		$normalized[] = $entry;
+	}
+
+	return $normalized;
+}
+
+/** @param array<string,mixed> $principal Raw import principal. @return array<string,mixed> */
+private static function normalize_agent_bundle_import_principal( array $principal ): array {
+	$normalized = array();
+	foreach ( array( 'agent_id', 'owner_id', 'token_id' ) as $field ) {
+		if ( isset( $principal[ $field ] ) && (int) $principal[ $field ] > 0 ) {
+			$normalized[ $field ] = (int) $principal[ $field ];
+		}
+	}
+
+	$capabilities = self::string_list( $principal['capabilities'] ?? array() );
+	if ( ! empty( $capabilities ) ) {
+		$normalized['capabilities'] = $capabilities;
+	}
+
+	if ( is_array( $principal['scope'] ?? null ) ) {
+		$scope = array();
+		foreach ( array( 'scope', 'label' ) as $field ) {
+			$value = isset( $principal['scope'][ $field ] ) ? trim( (string) $principal['scope'][ $field ] ) : '';
+			if ( '' !== $value ) {
+				$scope[ $field ] = $value;
+			}
+		}
+		foreach ( array( 'ability_categories', 'ability_allow', 'ability_deny', 'capabilities' ) as $field ) {
+			$values = self::string_list( $principal['scope'][ $field ] ?? array() );
+			if ( ! empty( $values ) ) {
+				$scope[ $field ] = $values;
+			}
+		}
+		if ( ! empty( $scope ) ) {
+			$normalized['scope'] = $scope;
+		}
 	}
 
 	return $normalized;

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -105,6 +105,10 @@ private static function agent_bundle_schema(): array {
 				'on_conflict' => array( 'type' => 'string', 'enum' => array( 'error', 'skip', 'upgrade' ) ),
 				'owner_id'    => array( 'type' => 'integer' ),
 				'token_env'   => array( 'type' => 'string' ),
+				'import_principal' => array(
+					'type'        => 'object',
+					'description' => 'Non-secret Data Machine principal context used only for the datamachine/import-agent call inside the sandbox.',
+				),
 			),
 		),
 	);

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -358,6 +358,7 @@ $assert( 'browser Playground session exposes artifact file schema', 'array' === 
 $assert( 'browser Playground session exposes site blueprint artifact schema', 'object' === ( $browser_session_ability['input_schema']['properties']['site_blueprint_artifact']['type'] ?? '' ) && 'object' === ( $browser_session_ability['input_schema']['properties']['site_blueprint_artifact']['properties']['blueprint']['type'] ?? '' ) );
 $assert( 'browser Playground session declares site blueprint artifact output', 'object' === ( $browser_session_ability['output_schema']['properties']['site_blueprint_artifact']['type'] ?? '' ) );
 $assert( 'browser Playground session exposes explicit trusted orchestrator authorization schema', 'object' === ( $browser_session_ability['input_schema']['properties']['authorization']['type'] ?? '' ) && array( 'browser-session:create' ) === ( $browser_session_ability['input_schema']['properties']['authorization']['properties']['scope']['enum'] ?? array() ) );
+$assert( 'browser Playground session exposes non-secret agent bundle import principal schema', 'object' === ( $browser_session_ability['input_schema']['properties']['agent_bundles']['items']['properties']['import_principal']['type'] ?? '' ) );
 $assert( 'browser Playground session output declares browser execution', array( 'browser-playground' ) === ( $browser_session_ability['output_schema']['properties']['execution']['enum'] ?? array() ) );
 $assert( 'browser Playground session exposes generic sandbox invocation schema', array( 'ability', 'task' ) === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['invocation']['properties']['type']['enum'] ?? array() ) && 'string' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['invocation']['properties']['hook']['type'] ?? '' ) );
 $assert( 'browser Playground session exposes generic capture path schema', 'array' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['capture_paths']['type'] ?? '' ) && 'integer' === ( $browser_session_ability['input_schema']['properties']['browser_runner']['properties']['capture_paths']['items']['properties']['max_bytes']['type'] ?? '' ) && 'object' === ( $browser_session_ability['output_schema']['properties']['materialization']['type'] ?? '' ) );
@@ -968,8 +969,17 @@ $browser_inherited_session = call_user_func(
 		'inherit' => array( 'connectors' => array( 'primary-ai' ) ),
 		'agent_bundles' => array(
 			array(
-				'source' => 'https://example.test/site-generator-agent.json',
-				'slug'   => 'site-generator',
+				'source'           => 'https://example.test/site-generator-agent.json',
+				'slug'             => 'site-generator',
+				'import_principal' => array(
+					'agent_id'     => 123,
+					'owner_id'     => 1,
+					'token_id'     => 456,
+					'capabilities' => array( 'datamachine_manage_agents' ),
+					'scope'        => array(
+						'ability_allow' => array( 'datamachine/import-agent' ),
+					),
+				),
 			),
 			array(
 				'bundle' => array(
@@ -996,7 +1006,8 @@ $assert( 'browser Playground recipe provides bounded user context to agents chat
 $assert( 'browser Playground recipe passes inherited provider and model to agents chat', ! is_wp_error( $browser_inherited_session ) && str_contains( $browser_runner_code, "'provider' => (string) ( \$payload['provider'] ?? '' )" ) && str_contains( $browser_runner_code, "'model' => (string) ( \$payload['model'] ?? '' )" ) );
 $assert( 'browser Playground recipe keeps sandbox id in client context instead of transcript session id', ! is_wp_error( $browser_inherited_session ) && str_contains( $browser_runner_code, "'caller_session_id' => \$session_id" ) && ! str_contains( $browser_runner_code, "'message' => \$message,\n\t'session_id' => \$session_id" ) );
 $assert( 'browser Playground recipe preserves and imports multiple Data Machine agent bundles before agents chat', ! is_wp_error( $browser_inherited_session ) && 2 === count( $browser_inherited_session['recipe']['inputs']['agent_bundles'] ?? array() ) && 2 === count( $browser_inherited_session['task_payload']['agent_bundles'] ?? array() ) && str_contains( $browser_runner_code, 'wp_codebox_browser_import_agent_bundles' ) && str_contains( $browser_runner_code, 'datamachine/import-agent' ) && strpos( $browser_runner_code, 'wp_codebox_browser_import_agent_bundles' ) < strpos( $browser_runner_code, 'wp_get_ability( $ability_name )' ) );
-$assert( 'browser Playground recipe imports Data Machine bundles through scoped pre-authenticated context', ! is_wp_error( $browser_inherited_session ) && str_contains( $browser_runner_code, '\\DataMachine\\Abilities\\PermissionHelper::run_as_authenticated' ) );
+$assert( 'browser Playground recipe preserves non-secret Data Machine import principal', ! is_wp_error( $browser_inherited_session ) && 123 === ( $browser_inherited_session['task_payload']['agent_bundles'][0]['import_principal']['agent_id'] ?? null ) && array( 'datamachine/import-agent' ) === ( $browser_inherited_session['task_payload']['agent_bundles'][0]['import_principal']['scope']['ability_allow'] ?? array() ) );
+$assert( 'browser Playground recipe imports Data Machine bundles through scoped agent context', ! is_wp_error( $browser_inherited_session ) && str_contains( $browser_runner_code, 'wp_codebox_browser_agent_bundle_import_principal' ) && str_contains( $browser_runner_code, '\\DataMachine\\Abilities\\PermissionHelper::set_agent_context' ) && str_contains( $browser_runner_code, '\\DataMachine\\Abilities\\PermissionHelper::clear_agent_context' ) );
 $assert( 'browser Playground recipe stages inline Data Machine bundles as JSON files', ! is_wp_error( $browser_inherited_session ) && str_contains( $browser_runner_code, '$temp_source = $temp_base . \'.json\';' ) );
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_provider'] = 'openai';
 $GLOBALS['wp_codebox_filters']['wp_codebox_default_model']    = 'gpt-5.5';


### PR DESCRIPTION
## Summary
- Adds a non-secret `import_principal` contract for browser Playground agent bundles.
- Uses that principal to set Data Machine agent execution context only around `datamachine/import-agent` calls in the browser runner.
- Preserves the principal through browser session/task payload normalization and updates smoke coverage for the generated runner.

## Testing
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php && php -l packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php && php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`
- `npm run build`
- `git diff --check`

## Notes
- `homeboy lint --path "/Users/chubes/Developer/wp-codebox@fix-browser-agent-bundle-import-principal" --extension nodejs` failed in lab setup before linting the change because the offloaded workspace could not resolve `node_modules/typescript/bin/tsc`. The same `npm run build` command passed locally in this worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the scoped import-principal implementation, updating smoke coverage, running verification, and preparing the PR description for Chris to review.