### PR TITLE
fix: expose browser operation success

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -84,11 +84,13 @@
 
 	const siteOperationEnvelope = ( operation, result, meta = {} ) => {
 		const errors = result?.success === false ? [ result.error ].filter( Boolean ) : [];
+		const success = result?.success === true;
 		return {
 			operation,
-			status: result?.success ? 'ok' : 'error',
+			success,
+			status: success ? 'ok' : 'error',
 			...meta,
-			data: result?.success ? result.data ?? null : null,
+			data: success ? result.data ?? null : null,
 			errors,
 		};
 	};

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -610,6 +610,7 @@ $browser_session = call_user_func(
 );
 $assert( 'browser Playground session returns without shelling out', ! is_wp_error( $browser_session ) && true === ( $browser_session['success'] ?? false ) );
 $assert( 'browser runtime admin bar operation does not fall through', str_contains( $browser_runtime_source, "'target' => 'frontendAdminBar'" ) && str_contains( $browser_runtime_source, "\n\t\t\tbreak;\n\n\t\tcase 'writeReviewFile':" ) );
+$assert( 'browser runtime operation envelopes expose success boolean', str_contains( $browser_runtime_source, 'const success = result?.success === true;' ) && str_contains( $browser_runtime_source, "\n\t\t\tsuccess,\n\t\t\tstatus: success ? 'ok' : 'error'," ) );
 $assert( 'browser Playground session schema is stable', ! is_wp_error( $browser_session ) && 'wp-codebox/browser-playground-session/v1' === ( $browser_session['schema'] ?? '' ) );
 $assert( 'browser Playground session pins browser execution', ! is_wp_error( $browser_session ) && 'browser-playground' === ( $browser_session['execution'] ?? '' ) );
 $assert( 'browser Playground session identifies disposable execution scope', ! is_wp_error( $browser_session ) && 'disposable-playground' === ( $browser_session['execution_scope'] ?? '' ) && 'disposable-playground' === ( $browser_session['session']['execution_scope'] ?? '' ) );


### PR DESCRIPTION
## Summary
- Adds a `success` boolean to WP Codebox browser operation envelopes so callers can distinguish successful `status: ok` results from failures.
- Adds smoke coverage for the envelope contract alongside the admin-bar operation regression coverage.

## Testing
- `npm run build`
- `php tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the live Studio Web eval contract failure, drafted the envelope fix, and added smoke coverage for Chris to review/test.