### PR TITLE
Scope host tools to the Codebox transport boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,19 @@ result outside the sandbox.
 
 ## Host Tool Registry
 
-Host products can register generic tools for sandbox agents without adding
-product-specific logic to WP Codebox core. A tool definition declares a stable
-name, JSON input/output schemas, policy metadata, and a host-side handler. The
+`HostToolRegistry` is a WP Codebox transport adapter, not a generic tool
+contract. Agents API owns canonical tool declarations, tool calls, execution
+results, pending external-tool states, and product-neutral runtime metadata.
+Data Machine or another host owns the concrete tool sources and product policy.
+WP Codebox only exposes caller-provided per-run tool declarations to sandbox
+agents, routes allowed calls across the browser/host boundary, and records
+transport diagnostics.
+
+Host products can register a caller-provided canonical tool declaration plus a
+host-side handler without adding product-specific logic to WP Codebox core. The
 runtime still gates execution through `RuntimePolicy.commands`, so callers must
-explicitly allow each registered tool name before a sandbox can invoke it.
+explicitly allow each registered canonical tool name before a sandbox can invoke
+it.
 
 ```ts
 import { createHostToolRegistry, createRuntime } from "@automattic/wp-codebox-core"
@@ -99,21 +107,28 @@ import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playgroun
 
 const hostTools = createHostToolRegistry([
   {
-    name: "host.echo",
-    description: "Echo a structured payload from the host bridge.",
-    inputSchema: {
-      type: "object",
-      required: ["message"],
-      properties: { message: { type: "string" } },
-      additionalProperties: false,
+    declaration: {
+      name: "client/echo",
+      description: "Echo a structured payload from the host bridge.",
+      parameters: {
+        type: "object",
+        required: ["message"],
+        properties: { message: { type: "string" } },
+        additionalProperties: false,
+      },
+      executor: "client",
+      scope: "run",
+      runtime: { completion_signal: "progress" },
     },
+    name: "client/echo",
+    description: "Echo a structured payload from the host bridge.",
     outputSchema: {
       type: "object",
       required: ["message"],
       properties: { message: { type: "string" } },
       additionalProperties: false,
     },
-    policy: { capability: "host.echo", risk: "read" },
+    policy: { capability: "client/echo", risk: "read" },
     handler: (input) => input,
   },
 ])
@@ -124,7 +139,7 @@ const runtime = await createRuntime({
   policy: {
     network: "deny",
     filesystem: "sandbox",
-    commands: ["host.echo"],
+    commands: ["client/echo"],
     secrets: "none",
     approvals: "never",
   },
@@ -132,18 +147,25 @@ const runtime = await createRuntime({
 }, createPlaygroundRuntimeBackend())
 
 const result = await runtime.execute({
-  command: "host.echo",
+  command: "client/echo",
   args: ['input-json={"message":"hello"}'],
 })
 ```
 
-Host tool output is always a JSON envelope with schema
-`wp-codebox/host-tool-result/v1`. Successful calls return `status: "ok"` and an
-`output` value validated against the tool's output schema. Invalid input,
-invalid output, and handler failures return `status: "error"` with a stable error
-code and message instead of terminal-shaped stderr. Product-specific evidence
-commands should live in product extensions that register tools through this
-surface.
+Host tool output is a Codebox transport diagnostic envelope with schema
+`wp-codebox/host-tool-result/v1`. Successful calls return `status: "ok"`, an
+`output` value validated against the transport output schema, and `toolResult`
+using the canonical Agents API result shape: `success`, `tool_name`, `result`,
+`metadata`, and optional `runtime`. Invalid input, invalid output, malformed
+JSON, and handler failures return `status: "error"` with a stable transport error
+code while `toolResult` maps the same failure to a canonical tool error. The
+`diagnostics` object is the Codebox-owned portion of the envelope and preserves
+the transport, policy command, validation schemas, and resolved policy metadata.
+
+Product-specific tools such as Homeboy evidence commands should live in product
+extensions that provide canonical tool declarations and handlers through this
+transport surface. Codebox should not encode Data Machine policy semantics,
+product tool names, or cross-product tool mediation rules in this layer.
 
 Trusted worker hosts that need repo-local commands can use the playground
 package's `createHostCommandTool()` adapter instead of exposing arbitrary shell.

--- a/packages/runtime-core/src/host-tool-registry.ts
+++ b/packages/runtime-core/src/host-tool-registry.ts
@@ -18,6 +18,18 @@ export interface HostToolPolicyMetadata {
   description?: string
 }
 
+export type HostToolRuntimeMetadata = JsonObject
+
+export interface HostToolCanonicalDeclaration {
+  name: string
+  source?: string
+  description: string
+  parameters?: HostToolJsonSchema
+  executor?: "client"
+  scope?: "run"
+  runtime?: HostToolRuntimeMetadata
+}
+
 export interface HostToolCallContext {
   tool: string
   policyCommand: string
@@ -27,19 +39,46 @@ export interface HostToolCallContext {
 export type HostToolHandler = (input: JsonValue, context: HostToolCallContext) => Promise<JsonValue> | JsonValue
 
 export interface HostToolDefinition {
+  /**
+   * Canonical per-run tool declaration supplied by the caller. Codebox treats
+   * this as transport input; Agents API owns the generic declaration contract.
+   */
+  declaration?: HostToolCanonicalDeclaration
   name: string
   description: string
-  inputSchema: HostToolJsonSchema
+  parameters?: HostToolJsonSchema
+  inputSchema?: HostToolJsonSchema
   outputSchema: HostToolJsonSchema
   policy: HostToolPolicyMetadata
+  runtime?: HostToolRuntimeMetadata
   handler: HostToolHandler
 }
+
+export interface HostToolCanonicalResultOk {
+  success: true
+  tool_name: string
+  result: JsonValue
+  metadata: JsonObject
+  runtime?: HostToolRuntimeMetadata
+}
+
+export interface HostToolCanonicalResultError {
+  success: false
+  tool_name: string
+  error: string
+  metadata: JsonObject
+  runtime?: HostToolRuntimeMetadata
+}
+
+export type HostToolCanonicalResult = HostToolCanonicalResultOk | HostToolCanonicalResultError
 
 export interface HostToolResultOk {
   schema: typeof HOST_TOOL_RESULT_SCHEMA
   tool: string
   status: "ok"
   output: JsonValue
+  toolResult: HostToolCanonicalResultOk
+  diagnostics: HostToolTransportDiagnostics
   startedAt: string
   finishedAt: string
 }
@@ -53,6 +92,8 @@ export interface HostToolResultError {
     message: string
     details?: JsonValue
   }
+  toolResult: HostToolCanonicalResultError
+  diagnostics: HostToolTransportDiagnostics
   startedAt: string
   finishedAt: string
 }
@@ -60,8 +101,20 @@ export interface HostToolResultError {
 export type HostToolResult = HostToolResultOk | HostToolResultError
 
 export interface HostToolCatalogEntry {
+  /** Agents API-shaped declaration exposed to sandbox agents. */
+  declaration: HostToolCanonicalDeclaration
   name: string
   description: string
+  parameters: HostToolJsonSchema
+  inputSchema: HostToolJsonSchema
+  outputSchema: HostToolJsonSchema
+  policy: HostToolPolicyMetadata
+}
+
+export interface HostToolTransportDiagnostics {
+  transport: "wp-codebox-host-tool"
+  resultSchema: typeof HOST_TOOL_RESULT_SCHEMA
+  policyCommand: string
   inputSchema: HostToolJsonSchema
   outputSchema: HostToolJsonSchema
   policy: HostToolPolicyMetadata
@@ -93,13 +146,18 @@ export class HostToolRegistry {
   }
 
   list(): HostToolCatalogEntry[] {
-    return [...this.tools.values()].map(({ name, description, inputSchema, outputSchema, policy }) => ({
-      name,
-      description,
-      inputSchema,
-      outputSchema,
-      policy,
-    }))
+    return [...this.tools.values()].map((definition) => {
+      const declaration = canonicalDeclarationForHostTool(definition)
+      return {
+        declaration,
+        name: declaration.name,
+        description: declaration.description,
+        parameters: declaration.parameters ?? {},
+        inputSchema: inputSchemaForHostTool(definition),
+        outputSchema: definition.outputSchema,
+        policy: definition.policy,
+      }
+    })
   }
 }
 
@@ -109,16 +167,16 @@ export function createHostToolRegistry(definitions: HostToolDefinition[] = []): 
 
 export async function executeHostTool(definition: HostToolDefinition, input: JsonValue, context: HostToolCallContext): Promise<HostToolResult> {
   const startedAt = new Date().toISOString()
-  const inputIssue = validateJsonValueAgainstSchema(input, definition.inputSchema, "input")
+  const inputIssue = validateJsonValueAgainstSchema(input, inputSchemaForHostTool(definition), "input")
   if (inputIssue) {
-    return hostToolError(definition.name, startedAt, "host-tool-invalid-input", inputIssue)
+    return hostToolError(definition, context.policyCommand, startedAt, "host-tool-invalid-input", inputIssue)
   }
 
   try {
     const output = await definition.handler(input, context)
     const outputIssue = validateJsonValueAgainstSchema(output, definition.outputSchema, "output")
     if (outputIssue) {
-      return hostToolError(definition.name, startedAt, "host-tool-invalid-output", outputIssue)
+      return hostToolError(definition, context.policyCommand, startedAt, "host-tool-invalid-output", outputIssue)
     }
 
     return {
@@ -126,15 +184,22 @@ export async function executeHostTool(definition: HostToolDefinition, input: Jso
       tool: definition.name,
       status: "ok",
       output,
+      toolResult: hostToolCanonicalSuccess(definition, output),
+      diagnostics: hostToolDiagnostics(definition, context.policyCommand),
       startedAt,
       finishedAt: new Date().toISOString(),
     }
   } catch (error) {
-    return hostToolError(definition.name, startedAt, "host-tool-handler-error", error instanceof Error ? error.message : String(error))
+    return hostToolError(definition, context.policyCommand, startedAt, "host-tool-handler-error", error instanceof Error ? error.message : String(error))
   }
 }
 
-function hostToolError(tool: string, startedAt: string, code: string, message: string, details?: JsonValue): HostToolResultError {
+export function createHostToolTransportError(definition: HostToolDefinition | string, policyCommand: string, startedAt: string, code: string, message: string, details?: JsonValue): HostToolResultError {
+  return hostToolError(definition, policyCommand, startedAt, code, message, details)
+}
+
+function hostToolError(definition: HostToolDefinition | string, policyCommand: string, startedAt: string, code: string, message: string, details?: JsonValue): HostToolResultError {
+  const tool = typeof definition === "string" ? definition : definition.name
   return {
     schema: HOST_TOOL_RESULT_SCHEMA,
     tool,
@@ -144,21 +209,108 @@ function hostToolError(tool: string, startedAt: string, code: string, message: s
       message,
       ...(details === undefined ? {} : { details }),
     },
+    toolResult: typeof definition === "string"
+      ? hostToolCanonicalError(tool, message)
+      : hostToolCanonicalError(definition, message),
+    diagnostics: typeof definition === "string"
+      ? hostToolDiagnosticsForUnknown(policyCommand)
+      : hostToolDiagnostics(definition, policyCommand),
     startedAt,
     finishedAt: new Date().toISOString(),
   }
 }
 
 function assertValidHostToolDefinition(definition: HostToolDefinition): void {
-  if (!definition.name || !/^[a-z0-9][a-z0-9._-]*$/i.test(definition.name)) {
-    throw new Error("Host tool name must be a stable non-empty tool id")
+  const declaration = canonicalDeclarationForHostTool(definition)
+  if (!declaration.name || !/^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/i.test(declaration.name)) {
+    throw new Error("Host tool name must be a stable canonical tool id such as client/search_docs")
   }
-  if (!definition.description) {
-    throw new Error(`Host tool ${definition.name} is missing a description`)
+  if (declaration.source !== sourceFromToolName(declaration.name)) {
+    throw new Error(`Host tool ${declaration.name} source must match its canonical name prefix`)
+  }
+  if (declaration.executor !== "client") {
+    throw new Error(`Host tool ${declaration.name} executor must be client`)
+  }
+  if (declaration.scope !== "run") {
+    throw new Error(`Host tool ${declaration.name} scope must be run`)
+  }
+  if (!declaration.description) {
+    throw new Error(`Host tool ${declaration.name} is missing a description`)
   }
   if (typeof definition.handler !== "function") {
-    throw new Error(`Host tool ${definition.name} is missing a handler`)
+    throw new Error(`Host tool ${declaration.name} is missing a handler`)
   }
+  definition.name = declaration.name
+  definition.description = declaration.description
+  definition.inputSchema = inputSchemaForHostTool(definition)
+}
+
+function canonicalDeclarationForHostTool(definition: HostToolDefinition): HostToolCanonicalDeclaration {
+  const name = definition.declaration?.name ?? definition.name
+  const parameters = definition.declaration?.parameters ?? definition.parameters ?? definition.inputSchema
+  const runtime = definition.declaration?.runtime ?? definition.runtime
+  return {
+    name,
+    source: definition.declaration?.source ?? sourceFromToolName(name),
+    description: definition.declaration?.description ?? definition.description,
+    parameters,
+    executor: definition.declaration?.executor ?? "client",
+    scope: definition.declaration?.scope ?? "run",
+    ...(runtime ? { runtime } : {}),
+  }
+}
+
+function hostToolCanonicalSuccess(definition: HostToolDefinition, result: JsonValue): HostToolCanonicalResultOk {
+  const runtime = canonicalDeclarationForHostTool(definition).runtime
+  return {
+    success: true,
+    tool_name: definition.name,
+    result,
+    metadata: {},
+    ...(runtime ? { runtime } : {}),
+  }
+}
+
+function hostToolCanonicalError(definition: HostToolDefinition | string, error: string): HostToolCanonicalResultError {
+  const toolName = typeof definition === "string" ? definition : definition.name
+  const runtime = typeof definition === "string" ? undefined : canonicalDeclarationForHostTool(definition).runtime
+  return {
+    success: false,
+    tool_name: toolName,
+    error,
+    metadata: {},
+    ...(runtime ? { runtime } : {}),
+  }
+}
+
+function hostToolDiagnostics(definition: HostToolDefinition, policyCommand: string): HostToolTransportDiagnostics {
+  return {
+    transport: "wp-codebox-host-tool",
+    resultSchema: HOST_TOOL_RESULT_SCHEMA,
+    policyCommand,
+    inputSchema: inputSchemaForHostTool(definition),
+    outputSchema: definition.outputSchema,
+    policy: definition.policy,
+  }
+}
+
+function hostToolDiagnosticsForUnknown(policyCommand: string): HostToolTransportDiagnostics {
+  return {
+    transport: "wp-codebox-host-tool",
+    resultSchema: HOST_TOOL_RESULT_SCHEMA,
+    policyCommand,
+    inputSchema: {},
+    outputSchema: {},
+    policy: {},
+  }
+}
+
+function sourceFromToolName(name: string): string {
+  return name.includes("/") ? name.split("/", 1)[0] : "client"
+}
+
+function inputSchemaForHostTool(definition: HostToolDefinition): HostToolJsonSchema {
+  return definition.declaration?.parameters ?? definition.parameters ?? definition.inputSchema ?? {}
 }
 
 function validateJsonValueAgainstSchema(value: JsonValue, schema: HostToolJsonSchema, path: string): string | undefined {

--- a/packages/runtime-core/src/host-tool-registry.ts
+++ b/packages/runtime-core/src/host-tool-registry.ts
@@ -210,8 +210,8 @@ function hostToolError(definition: HostToolDefinition | string, policyCommand: s
       ...(details === undefined ? {} : { details }),
     },
     toolResult: typeof definition === "string"
-      ? hostToolCanonicalError(tool, message)
-      : hostToolCanonicalError(definition, message),
+      ? hostToolCanonicalError(tool, message, code, details)
+      : hostToolCanonicalError(definition, message, code, details),
     diagnostics: typeof definition === "string"
       ? hostToolDiagnosticsForUnknown(policyCommand)
       : hostToolDiagnostics(definition, policyCommand),
@@ -271,14 +271,17 @@ function hostToolCanonicalSuccess(definition: HostToolDefinition, result: JsonVa
   }
 }
 
-function hostToolCanonicalError(definition: HostToolDefinition | string, error: string): HostToolCanonicalResultError {
+function hostToolCanonicalError(definition: HostToolDefinition | string, error: string, code: string, details?: JsonValue): HostToolCanonicalResultError {
   const toolName = typeof definition === "string" ? definition : definition.name
   const runtime = typeof definition === "string" ? undefined : canonicalDeclarationForHostTool(definition).runtime
   return {
     success: false,
     tool_name: toolName,
     error,
-    metadata: {},
+    metadata: {
+      code,
+      ...(details === undefined ? {} : { details }),
+    },
     ...(runtime ? { runtime } : {}),
   }
 }

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -1,4 +1,4 @@
-import { HOST_TOOL_RESULT_SCHEMA, executeHostTool, getCommandDefinition, type HostToolRegistry, type JsonValue, type PlaygroundRuntimeCommandId } from "@automattic/wp-codebox-core"
+import { createHostToolTransportError, executeHostTool, getCommandDefinition, type HostToolRegistry, type JsonValue, type PlaygroundRuntimeCommandId } from "@automattic/wp-codebox-core"
 import type { ExecutionSpec } from "@automattic/wp-codebox-core"
 
 interface PlaygroundCommandRuntime {
@@ -49,17 +49,7 @@ export async function executePlaygroundCommand(runtime: PlaygroundCommandRuntime
     try {
       input = hostToolInput(spec.args ?? [])
     } catch (error) {
-      return JSON.stringify({
-        schema: HOST_TOOL_RESULT_SCHEMA,
-        tool: hostTool.name,
-        status: "error",
-        error: {
-          code: "host-tool-invalid-input-json",
-          message: error instanceof Error ? error.message : String(error),
-        },
-        startedAt,
-        finishedAt: new Date().toISOString(),
-      })
+      return JSON.stringify(createHostToolTransportError(hostTool, spec.command, startedAt, "host-tool-invalid-input-json", error instanceof Error ? error.message : String(error)))
     }
 
     const result = await executeHostTool(hostTool, input, {

--- a/scripts/host-tool-registry-smoke.ts
+++ b/scripts/host-tool-registry-smoke.ts
@@ -64,6 +64,7 @@ async function main(): Promise<void> {
   assert(invalidBody.status === "error", "invalid host tool input should return a structured error")
   assert(invalidBody.error.code === "host-tool-invalid-input", "invalid input should use the stable input error code")
   assert(invalidBody.toolResult.success === false, "transport errors map to canonical tool errors")
+  assert(invalidBody.toolResult.metadata.code === "host-tool-invalid-input", "canonical tool error metadata preserves transport error classification")
 
   let denied = false
   try {

--- a/scripts/host-tool-registry-smoke.ts
+++ b/scripts/host-tool-registry-smoke.ts
@@ -11,42 +11,59 @@ function assert(condition: unknown, message: string): asserts condition {
 async function main(): Promise<void> {
   const registry = createHostToolRegistry([
     {
-      name: "host.echo",
-      description: "Echo a host-provided payload through the generic host tool bridge.",
-      inputSchema: {
-        type: "object",
-        required: ["message"],
-        properties: { message: { type: "string" } },
-        additionalProperties: false,
+      declaration: {
+        name: "client/echo",
+        description: "Echo a caller-provided payload through the Codebox host transport.",
+        parameters: {
+          type: "object",
+          required: ["message"],
+          properties: { message: { type: "string" } },
+          additionalProperties: false,
+        },
+        executor: "client",
+        scope: "run",
+        runtime: { completion_signal: "progress" },
       },
+      name: "client/echo",
+      description: "Echo a caller-provided payload through the Codebox host transport.",
       outputSchema: {
         type: "object",
         required: ["message"],
         properties: { message: { type: "string" } },
         additionalProperties: false,
       },
-      policy: { capability: "host.echo", risk: "read" },
+      policy: { capability: "client/echo", risk: "read" },
+      runtime: { completion_signal: "progress" },
       handler: (input) => input,
     },
   ])
+  const catalog = registry.list()
+  assert(catalog[0]?.declaration.name === "client/echo", "registry exposes caller-provided canonical tool declaration")
+  assert(catalog[0]?.declaration.executor === "client", "canonical declaration keeps client executor ownership")
+  assert(catalog[0]?.declaration.scope === "run", "canonical declaration stays scoped to one run")
 
   const runtime = await createRuntime({
     backend: "wordpress-playground",
     environment: { kind: "wordpress", version: "latest" },
-    policy: { network: "deny", filesystem: "sandbox", commands: ["host.echo"], secrets: "none", approvals: "never" },
+    policy: { network: "deny", filesystem: "sandbox", commands: ["client/echo"], secrets: "none", approvals: "never" },
     hostTools: registry,
   }, createPlaygroundRuntimeBackend())
 
-  const ok = await runtime.execute({ command: "host.echo", args: ['input-json={"message":"hello"}'] })
+  const ok = await runtime.execute({ command: "client/echo", args: ['input-json={"message":"hello"}'] })
   const okBody = JSON.parse(ok.stdout) as HostToolResult
   assert(okBody.schema === HOST_TOOL_RESULT_SCHEMA, "host tool result must use the stable result schema")
   assert(okBody.status === "ok", "valid host tool call should succeed")
   assert(okBody.output && typeof okBody.output === "object" && !Array.isArray(okBody.output) && okBody.output.message === "hello", "host tool output should be structured")
+  assert(okBody.toolResult.tool_name === "client/echo", "transport envelope includes canonical tool result name")
+  assert(okBody.toolResult.success === true, "successful transport calls map to canonical success")
+  assert(okBody.diagnostics.transport === "wp-codebox-host-tool", "transport diagnostics stay in the Codebox envelope")
+  assert(okBody.diagnostics.policyCommand === "client/echo", "transport diagnostics preserve the policy command")
 
-  const invalid = await runtime.execute({ command: "host.echo", args: ['input-json={"extra":true}'] })
+  const invalid = await runtime.execute({ command: "client/echo", args: ['input-json={"extra":true}'] })
   const invalidBody = JSON.parse(invalid.stdout) as HostToolResult
   assert(invalidBody.status === "error", "invalid host tool input should return a structured error")
   assert(invalidBody.error.code === "host-tool-invalid-input", "invalid input should use the stable input error code")
+  assert(invalidBody.toolResult.success === false, "transport errors map to canonical tool errors")
 
   let denied = false
   try {
@@ -56,7 +73,7 @@ async function main(): Promise<void> {
       policy: { network: "deny", filesystem: "sandbox", commands: [], secrets: "none", approvals: "never" },
       hostTools: registry,
     }, createPlaygroundRuntimeBackend())
-    await deniedRuntime.execute({ command: "host.echo", args: ['input-json={"message":"hello"}'] })
+    await deniedRuntime.execute({ command: "client/echo", args: ['input-json={"message":"hello"}'] })
   } catch {
     denied = true
   }


### PR DESCRIPTION
## Summary
- Clarifies that `HostToolRegistry` is a WP Codebox browser/host transport adapter, while Agents API owns canonical tool declarations and result contracts.
- Adds caller-provided canonical `client/...` declarations to the host tool catalog and maps host tool execution output/errors into an embedded canonical `toolResult` shape.
- Keeps Codebox-specific validation, policy command, and schema details in a transport `diagnostics` envelope, and expands the host-tool smoke to prove canonical catalog pass-through plus policy gating.
- Updates the artifact package provenance fixture from `0.3.1` to `0.4.0`, matching current package metadata so the artifact contract smoke passes.

Fixes #522.

## Verification
- `npm run build` passed.
- `npm run host-tool-registry-smoke` passed.
- `npm run command-registry-smoke` passed.
- `npm run sandbox-tool-policy-smoke` passed.
- `npm run policy-validation-smoke` passed.
- `npm run external-adapter-contract-smoke` passed.
- `npm run runtime-episode-smoke` passed.
- `npm run artifact-contract-smoke` passed after updating the stale package provenance fixture.
- `git diff --check` passed.

## Aggregate check note
- `npm run check` was attempted twice. It exceeded the local tool timeout before completion, first after 30 minutes and then after 60 minutes.
- No assertion failure was reported during the aggregate runs after the package provenance fixture was updated; the directly-run targeted smokes above passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the WP Codebox host-tool runtime boundary, drafted and implemented the transport-scoped contract changes, updated smoke coverage, and ran verification commands for Chris to review.