### PR TITLE
Expose generic run lifecycle cleanup status

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,36 @@ Expected shape:
 
 WP Codebox boots Playground lazily on the first command, captures artifacts after execution, and disposes the runtime when the run completes.
 
+Recipe runs also write a registry entry under the run registry directory
+(`artifacts/runs` by default, or `--run-registry <dir>`). Poll it with
+`wp-codebox runs status --registry <dir> --run-id <id> --json`. The returned
+record keeps the existing flat `status` field and adds `lifecycle`, a concise
+machine contract for orchestrators:
+
+```json
+{
+  "status": "succeeded",
+  "lifecycle": {
+    "schema": "wp-codebox/run-lifecycle/v1",
+    "phase": "terminal",
+    "terminal": true,
+    "cancellable": false,
+    "successful": true,
+    "failed": false,
+    "cancelled": false,
+    "outcome": "succeeded",
+    "cleanup": {
+      "status": "succeeded",
+      "attempts": 1
+    }
+  }
+}
+```
+
+Consumers should use `lifecycle.terminal`, `lifecycle.outcome`, and
+`lifecycle.cleanup.status` instead of scraping human logs. Timeout and signal
+interruptions settle as `timed_out` and `cancelled` outcomes respectively.
+
 ## Runtime Evidence
 
 Recipe runs write runtime evidence under `files/runtime-evidence/`. Every recipe

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ machine contract for orchestrators:
 }
 ```
 
-Consumers should use `lifecycle.terminal`, `lifecycle.outcome`, and
+Orchestrators should use `lifecycle.terminal`, `lifecycle.outcome`, and
 `lifecycle.cleanup.status` instead of scraping human logs. Timeout and signal
 interruptions settle as `timed_out` and `cancelled` outcomes respectively.
 

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -609,7 +609,12 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       Object.assign(evidence, agentEvidence)
     }
     const runtimeInfo = successfulRecipe && options.previewHoldSeconds ? await runtime.info() : undefined
-    await awaitRecipe("runtime.release", releaseRuntime(runtime, successfulRecipe ? options.previewHoldSeconds : 0, () => cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays), interruption))
+    const activeRuntime = runtime
+    await runRecipeCleanup(runRegistry, runRecord, async () => {
+      await awaitRecipe("runtime.release", releaseRuntime(activeRuntime, successfulRecipe ? options.previewHoldSeconds : 0, undefined, interruption))
+      await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays)
+    })
+    runRecord = await runRegistry.read(runRecord.runId)
     interruption?.throwIfInterrupted()
 
     const benchResultsList = executions
@@ -665,12 +670,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     }
   } catch (error) {
     if (runtime) {
-      if (error instanceof RecipeRunTimeoutError) {
-        void runtime.destroy().catch(() => undefined)
-      }
-
+      const activeRuntime = runtime
       artifacts = await collectAndFinalizeFailedRecipeArtifacts({
-        runtime,
+        runtime: activeRuntime,
         existingArtifacts: artifacts,
         recipe,
         workspaceMounts,
@@ -681,18 +683,24 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         interruption,
       })
 
-      if (!(error instanceof RecipeRunTimeoutError)) {
-        try {
-          await bestEffortTimeout(runtime.destroy(), 2_000)
-        } catch {
-          // Preserve the original failure as the CLI result.
-        }
+      if (error instanceof RecipeRunTimeoutError) {
+        void activeRuntime.destroy().catch(() => undefined)
+      } else {
+        await runRecipeCleanup(runRegistry, runRecord, async () => {
+          try {
+            await bestEffortTimeout(activeRuntime.destroy(), 2_000)
+          } catch {
+            // Preserve the original failure as the CLI result.
+          }
+        })
+        runRecord = await runRegistry.read(runRecord.runId)
       }
     }
 
-    await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays)
+    await runRecipeCleanup(runRegistry, runRecord, () => cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays))
+    runRecord = await runRegistry.read(runRecord.runId)
     runRecord = await runRegistry.update(runRecord.runId, {
-      status: interruption?.metadata ? "cancelled" : "failed",
+      status: recipeRunFailureStatus(error, interruption),
       ...(runtime ? { runtime: await runtime.info() } : {}),
       ...(artifacts ? { preview: artifacts.preview, artifactRefs: artifactBundleRunRef(artifacts) } : {}),
       error: serializeRecipeRunError(error),
@@ -711,6 +719,29 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       error: serializeRecipeRunError(error),
     }
   }
+}
+
+async function runRecipeCleanup(runRegistry: RuntimeRunRegistry, runRecord: RuntimeRunRecord, cleanup: () => Promise<void>): Promise<void> {
+  await runRegistry.update(runRecord.runId, { cleanup: { status: "running" } })
+  try {
+    await cleanup()
+    await runRegistry.update(runRecord.runId, { cleanup: { status: "succeeded" } })
+  } catch (error) {
+    await runRegistry.update(runRecord.runId, { cleanup: { status: "failed", error: serializeError(error) } })
+    throw error
+  }
+}
+
+function recipeRunFailureStatus(error: unknown, interruption?: RecipeInterruptionController): RuntimeRunRecord["status"] {
+  if (interruption?.metadata) {
+    return "cancelled"
+  }
+
+  if (error instanceof RecipeRunTimeoutError) {
+    return "timed_out"
+  }
+
+  return "failed"
 }
 
 async function prepareRecipeRuntimeOverlaysForRun(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedRuntimeOverlay[]> {

--- a/packages/cli/src/commands/runs.ts
+++ b/packages/cli/src/commands/runs.ts
@@ -85,6 +85,9 @@ function parseRunLookupOptions(args: string[]): RunLookupOptions {
 function printRunStatusHumanOutput(record: RuntimeRunRecord): void {
   console.log(`WP Codebox run: ${record.runId}`)
   console.log(`Status: ${record.status}`)
+  console.log(`Lifecycle: ${record.lifecycle.phase}${record.lifecycle.terminal ? ` (${record.lifecycle.outcome})` : ""}`)
+  console.log(`Cancellable: ${record.lifecycle.cancellable ? "yes" : "no"}`)
+  console.log(`Cleanup: ${record.lifecycle.cleanup.status} (${record.lifecycle.cleanup.attempts} attempts)`)
   console.log(`Heartbeat: ${record.heartbeatAt}`)
   console.log(`Artifacts: ${record.artifactRefs.length}`)
   if (record.preview?.url) {

--- a/packages/runtime-core/src/run-registry.ts
+++ b/packages/runtime-core/src/run-registry.ts
@@ -8,6 +8,32 @@ import { stripUndefined } from "./object-utils.js"
 
 export type RuntimeRunStatus = "queued" | "booting" | "running" | "collecting_artifacts" | "succeeded" | "failed" | "timed_out" | "cancelled"
 
+export type RuntimeRunLifecyclePhase = "pending" | "active" | "finalizing" | "terminal"
+export type RuntimeRunLifecycleOutcome = "succeeded" | "failed" | "timed_out" | "cancelled"
+export type RuntimeRunCleanupStatus = "not_started" | "running" | "succeeded" | "failed"
+
+export interface RuntimeRunCleanupState {
+  status: RuntimeRunCleanupStatus
+  attempts: number
+  startedAt?: string
+  updatedAt?: string
+  completedAt?: string
+  error?: RuntimeRunRecord["error"]
+}
+
+export interface RuntimeRunLifecycle {
+  schema: "wp-codebox/run-lifecycle/v1"
+  status: RuntimeRunStatus
+  phase: RuntimeRunLifecyclePhase
+  terminal: boolean
+  cancellable: boolean
+  successful: boolean
+  failed: boolean
+  cancelled: boolean
+  outcome?: RuntimeRunLifecycleOutcome
+  cleanup: RuntimeRunCleanupState
+}
+
 export interface RuntimeRunArtifactRef {
   kind: "artifact-bundle" | "command-log" | "transcript" | (string & {})
   path?: string
@@ -36,6 +62,7 @@ export interface RuntimeRunRecord {
   schema: "wp-codebox/run-registry-entry/v1"
   runId: string
   status: RuntimeRunStatus
+  lifecycle: RuntimeRunLifecycle
   createdAt: string
   updatedAt: string
   heartbeatAt: string
@@ -73,8 +100,14 @@ export interface RuntimeRunRegistryUpdate {
   replay?: RuntimeRunReplay
   artifactRefs?: RuntimeRunArtifactRef[]
   error?: RuntimeRunRecord["error"]
+  cleanup?: RuntimeRunCleanupUpdate
   heartbeat?: boolean
   now?: Date
+}
+
+export interface RuntimeRunCleanupUpdate {
+  status: RuntimeRunCleanupStatus
+  error?: RuntimeRunRecord["error"]
 }
 
 export class RuntimeRunRegistry {
@@ -90,6 +123,7 @@ export class RuntimeRunRegistry {
       schema: "wp-codebox/run-registry-entry/v1",
       runId: options.runId ?? createRuntimeRunId(),
       status: options.status ?? "queued",
+      lifecycle: buildRuntimeRunLifecycle(options.status ?? "queued", initialRuntimeRunCleanup()),
       createdAt: now,
       updatedAt: now,
       heartbeatAt: now,
@@ -113,9 +147,12 @@ export class RuntimeRunRegistry {
   async update(runId: string, update: RuntimeRunRegistryUpdate): Promise<RuntimeRunRecord> {
     const current = await this.read(runId)
     const now = (update.now ?? new Date()).toISOString()
+    const status = update.status ?? current.status
+    const cleanup = update.cleanup ? updateRuntimeRunCleanup(current.lifecycle?.cleanup, update.cleanup, now) : current.lifecycle?.cleanup ?? initialRuntimeRunCleanup()
     const next: RuntimeRunRecord = {
       ...current,
-      status: update.status ?? current.status,
+      status,
+      lifecycle: buildRuntimeRunLifecycle(status, cleanup),
       ...(update.runtime ? { runtime: update.runtime } : {}),
       ...(update.preview ? { preview: update.preview } : {}),
       ...(update.metadata ? { metadata: sanitizeRunMetadata({ ...(current.metadata ?? {}), ...update.metadata }) } : {}),
@@ -146,6 +183,63 @@ export class RuntimeRunRegistry {
     await writeFile(temp, `${JSON.stringify(record, null, 2)}\n`)
     await rename(temp, target)
   }
+}
+
+export function buildRuntimeRunLifecycle(status: RuntimeRunStatus, cleanup: RuntimeRunCleanupState = initialRuntimeRunCleanup()): RuntimeRunLifecycle {
+  const terminal = isTerminalRuntimeRunStatus(status)
+  return {
+    schema: "wp-codebox/run-lifecycle/v1",
+    status,
+    phase: runtimeRunLifecyclePhase(status),
+    terminal,
+    cancellable: !terminal,
+    successful: status === "succeeded",
+    failed: status === "failed" || status === "timed_out",
+    cancelled: status === "cancelled",
+    ...(terminal ? { outcome: status as RuntimeRunLifecycleOutcome } : {}),
+    cleanup,
+  }
+}
+
+function initialRuntimeRunCleanup(): RuntimeRunCleanupState {
+  return {
+    status: "not_started",
+    attempts: 0,
+  }
+}
+
+function updateRuntimeRunCleanup(current: RuntimeRunCleanupState | undefined, update: RuntimeRunCleanupUpdate, now: string): RuntimeRunCleanupState {
+  const previous = current ?? initialRuntimeRunCleanup()
+  const attempts = update.status === "running" ? previous.attempts + 1 : previous.attempts
+  return stripUndefined({
+    ...previous,
+    status: update.status,
+    attempts,
+    startedAt: update.status === "running" ? now : previous.startedAt,
+    updatedAt: now,
+    completedAt: update.status === "succeeded" || update.status === "failed" ? now : previous.completedAt,
+    error: update.error,
+  }) as RuntimeRunCleanupState
+}
+
+function runtimeRunLifecyclePhase(status: RuntimeRunStatus): RuntimeRunLifecyclePhase {
+  if (isTerminalRuntimeRunStatus(status)) {
+    return "terminal"
+  }
+
+  if (status === "collecting_artifacts") {
+    return "finalizing"
+  }
+
+  if (status === "queued") {
+    return "pending"
+  }
+
+  return "active"
+}
+
+function isTerminalRuntimeRunStatus(status: RuntimeRunStatus): boolean {
+  return status === "succeeded" || status === "failed" || status === "timed_out" || status === "cancelled"
 }
 
 export function createRuntimeRunId(): string {

--- a/scripts/run-registry-smoke.ts
+++ b/scripts/run-registry-smoke.ts
@@ -27,6 +27,12 @@ try {
 
   assert.equal(run.schema, "wp-codebox/run-registry-entry/v1")
   assert.equal(run.status, "queued")
+  assert.equal(run.lifecycle.schema, "wp-codebox/run-lifecycle/v1")
+  assert.equal(run.lifecycle.phase, "pending")
+  assert.equal(run.lifecycle.cancellable, true)
+  assert.equal(run.lifecycle.terminal, false)
+  assert.equal(run.lifecycle.cleanup.status, "not_started")
+  assert.equal(run.lifecycle.cleanup.attempts, 0)
   assert.equal(run.metadata?.secretEnv, "[redacted]")
   assert.equal((run.metadata?.nested as { token?: string }).token, "[redacted]")
 
@@ -34,8 +40,15 @@ try {
   await mkdir(artifactDirectory, { recursive: true })
   await writeFile(join(artifactDirectory, "manifest.json"), "{}\n")
 
+  await registry.update(run.runId, {
+    status: "collecting_artifacts",
+    cleanup: { status: "running" },
+    now: new Date("2026-01-01T00:00:00.500Z"),
+  })
+
   const updated = await registry.update(run.runId, {
     status: "succeeded",
+    cleanup: { status: "succeeded" },
     artifactRefs: artifactBundleRunRef({
       id: "artifact-smoke",
       directory: artifactDirectory,
@@ -45,6 +58,12 @@ try {
     now: new Date("2026-01-01T00:00:01.000Z"),
   })
   assert.equal(updated.status, "succeeded")
+  assert.equal(updated.lifecycle.phase, "terminal")
+  assert.equal(updated.lifecycle.outcome, "succeeded")
+  assert.equal(updated.lifecycle.successful, true)
+  assert.equal(updated.lifecycle.cancellable, false)
+  assert.equal(updated.lifecycle.cleanup.status, "succeeded")
+  assert.equal(updated.lifecycle.cleanup.attempts, 1)
   assert.equal(updated.artifactRefs[0]?.kind, "artifact-bundle")
   assert.equal(updated.artifactRefs[0]?.digest?.value, "a".repeat(64))
   assert.equal(updated.heartbeatAt, "2026-01-01T00:00:01.000Z")
@@ -56,6 +75,12 @@ try {
   const status = JSON.parse(statusStdout)
   assert.equal(status.runId, run.runId)
   assert.equal(status.status, "succeeded")
+  assert.equal(status.lifecycle.cleanup.status, "succeeded")
+
+  const timedOut = await registry.create({ runId: "run_timeout", status: "timed_out" })
+  assert.equal(timedOut.lifecycle.failed, true)
+  assert.equal(timedOut.lifecycle.outcome, "timed_out")
+  assert.equal(timedOut.lifecycle.cancellable, false)
 
   const { stdout: artifactsStdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "runs", "artifacts", "--registry", registryDirectory, "--run-id", run.runId, "--json"], { cwd: root })
   const artifacts = JSON.parse(artifactsStdout)


### PR DESCRIPTION
## Summary
- Add a structured `lifecycle` object to run registry records while preserving the existing flat `status` field.
- Track cleanup attempts/status around recipe runtime teardown and prepared-source cleanup so orchestrators can poll terminal outcomes and cleanup completion.
- Document the `wp-codebox runs status --json` lifecycle contract for generic worker/run consumers.

Fixes https://github.com/Automattic/wp-codebox/issues/530

## Verification
- `npm run build`
- `npm run run-registry-smoke`
- `npm run recipe-run-timeout-smoke`
- `npm run recipe-interruption-artifacts-smoke`
- `npm run recipe-runtime-evidence-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the lifecycle/cleanup contract implementation, docs, and smoke coverage; Chris remains responsible for review and merge.