### PR TITLE
Add permissioned host-tool bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,35 @@ code and message instead of terminal-shaped stderr. Product-specific tools such
 as Homeboy evidence commands should live in product extensions that register
 tools through this surface.
 
+Trusted worker hosts that need repo-local commands can use the playground
+package's `createHostCommandTool()` adapter instead of exposing arbitrary shell.
+Each adapter is still a named host tool such as `host.pnpm-test`,
+`host.cargo-test`, or `host.homeboy-check`; the runtime denies it unless that
+exact name appears in `policy.commands`. The adapter runs one configured
+executable with `child_process.spawn()` and `shell: false`, appends only
+structured string-array arguments from the input, enforces allowed cwd roots,
+uses an explicit timeout, captures bounded stdout/stderr, and passes only
+configured environment variables plus explicitly allowlisted input env keys.
+
+```ts
+import { createHostToolRegistry } from "@automattic/wp-codebox-core"
+import { createHostCommandTool } from "@automattic/wp-codebox-playground"
+
+const hostTools = createHostToolRegistry([
+  createHostCommandTool({
+    name: "host.pnpm-test",
+    description: "Run repo-local tests from a trusted worker host.",
+    command: "pnpm",
+    args: ["test"],
+    cwd: repoRoot,
+    allowedCwdRoots: [repoRoot],
+    timeoutMs: 120_000,
+    maxOutputBytes: 256 * 1024,
+    inheritedEnv: ["CI"],
+  }),
+])
+```
+
 ## In-Sandbox Workspace Contract
 
 WP Codebox reserves `/workspace` as the stable editable workspace root inside a

--- a/README.md
+++ b/README.md
@@ -141,14 +141,14 @@ Host tool output is always a JSON envelope with schema
 `wp-codebox/host-tool-result/v1`. Successful calls return `status: "ok"` and an
 `output` value validated against the tool's output schema. Invalid input,
 invalid output, and handler failures return `status: "error"` with a stable error
-code and message instead of terminal-shaped stderr. Product-specific tools such
-as Homeboy evidence commands should live in product extensions that register
-tools through this surface.
+code and message instead of terminal-shaped stderr. Product-specific evidence
+commands should live in product extensions that register tools through this
+surface.
 
 Trusted worker hosts that need repo-local commands can use the playground
 package's `createHostCommandTool()` adapter instead of exposing arbitrary shell.
 Each adapter is still a named host tool such as `host.pnpm-test`,
-`host.cargo-test`, or `host.homeboy-check`; the runtime denies it unless that
+`host.cargo-test`, or `host.project-check`; the runtime denies it unless that
 exact name appears in `policy.commands`. The adapter runs one configured
 executable with `child_process.spawn()` and `shell: false`, appends only
 structured string-array arguments from the input, enforces allowed cwd roots,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "external-adapter-contract-smoke": "tsx scripts/external-adapter-contract-smoke.ts",
     "command-registry-smoke": "tsx scripts/command-registry-smoke.ts",
     "host-tool-registry-smoke": "tsx scripts/host-tool-registry-smoke.ts",
+    "host-command-tool-smoke": "tsx scripts/host-command-tool-smoke.ts",
     "sandbox-tool-policy-smoke": "tsx scripts/sandbox-tool-policy-smoke.ts",
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
     "run-registry-smoke": "tsx scripts/run-registry-smoke.ts",

--- a/packages/runtime-playground/src/host-command-tool.ts
+++ b/packages/runtime-playground/src/host-command-tool.ts
@@ -1,0 +1,230 @@
+import { spawn } from "node:child_process"
+import { realpath } from "node:fs/promises"
+import { resolve } from "node:path"
+import type { HostToolDefinition, JsonObject, JsonValue } from "@automattic/wp-codebox-core"
+
+export interface HostCommandToolConfig {
+  name: string
+  description: string
+  command: string
+  args?: string[]
+  cwd: string
+  allowedCwdRoots?: string[]
+  timeoutMs?: number
+  maxOutputBytes?: number
+  inheritedEnv?: string[]
+  allowedInputEnv?: string[]
+  env?: Record<string, string>
+}
+
+interface HostCommandInput {
+  args?: string[]
+  cwd?: string
+  timeoutMs?: number
+  env?: Record<string, string>
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000
+const DEFAULT_MAX_OUTPUT_BYTES = 256 * 1024
+
+export function createHostCommandTool(config: HostCommandToolConfig): HostToolDefinition {
+  return {
+    name: config.name,
+    description: config.description,
+    inputSchema: {
+      type: "object",
+      properties: {
+        args: { type: "array", items: { type: "string" } },
+        cwd: { type: "string" },
+        timeoutMs: { type: "integer" },
+        env: { type: "object", additionalProperties: true },
+      },
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      required: ["command", "args", "cwd", "exitCode", "signal", "stdout", "stderr", "durationMs", "timedOut", "outputTruncated"],
+      properties: {
+        command: { type: "string" },
+        args: { type: "array", items: { type: "string" } },
+        cwd: { type: "string" },
+        exitCode: { type: "integer" },
+        signal: { type: "string" },
+        stdout: { type: "string" },
+        stderr: { type: "string" },
+        durationMs: { type: "integer" },
+        timedOut: { type: "boolean" },
+        outputTruncated: { type: "boolean" },
+      },
+      additionalProperties: false,
+    },
+    policy: {
+      capability: config.name,
+      permissions: ["host-command"],
+      risk: "external",
+      description: "Runs one explicitly registered host command without shell expansion.",
+    },
+    handler: (input) => executeHostCommandTool(config, normalizeHostCommandInput(input)),
+  }
+}
+
+async function executeHostCommandTool(config: HostCommandToolConfig, input: HostCommandInput): Promise<JsonObject> {
+  const started = Date.now()
+  const cwd = await resolveAllowedCwd(config, input.cwd)
+  const timeoutMs = boundedPositiveInteger(input.timeoutMs ?? config.timeoutMs ?? DEFAULT_TIMEOUT_MS, "timeoutMs")
+  const maxOutputBytes = boundedPositiveInteger(config.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES, "maxOutputBytes")
+  const args = [...(config.args ?? []), ...(input.args ?? [])]
+  const env = commandEnv(config, input.env ?? {})
+
+  return new Promise<JsonObject>((resolveResult, reject) => {
+    let stdout = ""
+    let stderr = ""
+    let outputTruncated = false
+    let timedOut = false
+    let settled = false
+
+    const child = spawn(config.command, args, {
+      cwd,
+      env,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill("SIGTERM")
+    }, timeoutMs)
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const captured = appendBoundedOutput(stdout, chunk, maxOutputBytes)
+      stdout = captured.output
+      outputTruncated ||= captured.truncated
+    })
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const captured = appendBoundedOutput(stderr, chunk, maxOutputBytes)
+      stderr = captured.output
+      outputTruncated ||= captured.truncated
+    })
+
+    child.on("error", (error) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      reject(error)
+    })
+
+    child.on("close", (exitCode, signal) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolveResult({
+        command: config.command,
+        args,
+        cwd,
+        exitCode: exitCode ?? -1,
+        signal: signal ?? "",
+        stdout,
+        stderr,
+        durationMs: Date.now() - started,
+        timedOut,
+        outputTruncated,
+      })
+    })
+  })
+}
+
+function normalizeHostCommandInput(input: JsonValue): HostCommandInput {
+  if (!isJsonObject(input)) {
+    throw new Error("host command input must be an object")
+  }
+  return {
+    args: input.args === undefined ? undefined : stringArray(input.args, "args"),
+    cwd: input.cwd === undefined ? undefined : stringValue(input.cwd, "cwd"),
+    timeoutMs: input.timeoutMs === undefined ? undefined : boundedPositiveInteger(input.timeoutMs, "timeoutMs"),
+    env: input.env === undefined ? undefined : stringRecord(input.env, "env"),
+  }
+}
+
+async function resolveAllowedCwd(config: HostCommandToolConfig, requestedCwd?: string): Promise<string> {
+  const cwd = await realpath(resolve(requestedCwd ?? config.cwd))
+  const allowedRoots = await Promise.all((config.allowedCwdRoots?.length ? config.allowedCwdRoots : [config.cwd]).map((root) => realpath(resolve(root))))
+  if (!allowedRoots.some((root) => cwd === root || cwd.startsWith(`${root}/`))) {
+    throw new Error(`host command cwd is outside allowed roots: ${cwd}`)
+  }
+  return cwd
+}
+
+function commandEnv(config: HostCommandToolConfig, inputEnv: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? "",
+    ...config.env,
+  }
+  for (const name of config.inheritedEnv ?? []) {
+    if (process.env[name] !== undefined) {
+      env[name] = process.env[name]
+    }
+  }
+  const allowedInputEnv = new Set(config.allowedInputEnv ?? [])
+  for (const [name, value] of Object.entries(inputEnv)) {
+    if (!allowedInputEnv.has(name)) {
+      throw new Error(`host command env is not allowed: ${name}`)
+    }
+    env[name] = value
+  }
+  return env
+}
+
+function appendBoundedOutput(current: string, chunk: Buffer, maxBytes: number): { output: string; truncated: boolean } {
+  if (Buffer.byteLength(current) >= maxBytes) {
+    return { output: current, truncated: true }
+  }
+  const next = current + chunk.toString("utf8")
+  if (Buffer.byteLength(next) <= maxBytes) {
+    return { output: next, truncated: false }
+  }
+  return { output: next.slice(0, maxBytes), truncated: true }
+}
+
+function boundedPositiveInteger(value: JsonValue | number, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive integer`)
+  }
+  return value
+}
+
+function stringValue(value: JsonValue, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string`)
+  }
+  return value
+}
+
+function stringArray(value: JsonValue, field: string): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`${field} must be an array of strings`)
+  }
+  return value
+}
+
+function stringRecord(value: JsonValue, field: string): Record<string, string> {
+  if (!isJsonObject(value)) {
+    throw new Error(`${field} must be an object`)
+  }
+  const record: Record<string, string> = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item !== "string") {
+      throw new Error(`${field}.${key} must be a string`)
+    }
+    record[key] = item
+  }
+  return record
+}
+
+function isJsonObject(value: JsonValue): value is JsonObject {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,4 +1,5 @@
 export { playgroundRuntimeCommandIds } from "./command-router.js"
 export { buildArtifactDiagnostics } from "./artifacts.js"
 export { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "./browser-metrics.js"
+export { createHostCommandTool, type HostCommandToolConfig } from "./host-command-tool.js"
 export { PlaygroundRuntimeBackend, createPlaygroundRuntimeBackend } from "./playground-runtime.js"

--- a/scripts/host-command-tool-smoke.ts
+++ b/scripts/host-command-tool-smoke.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, mkdir, realpath } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createHostToolRegistry, createRuntime, type HostToolResult } from "@automattic/wp-codebox-core"
+import { createHostCommandTool, createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+async function main(): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "wp-codebox-host-command-"))
+  const nested = join(root, "repo")
+  await mkdir(nested)
+  const resolvedNested = await realpath(nested)
+
+  const registry = createHostToolRegistry([
+    createHostCommandTool({
+      name: "host.node-smoke",
+      description: "Runs a bounded Node.js host command for smoke coverage.",
+      command: process.execPath,
+      args: ["-e", "console.log(JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(1), token: process.env.SMOKE_TOKEN || null }))", "--"],
+      cwd: root,
+      allowedCwdRoots: [root],
+      allowedInputEnv: ["SMOKE_TOKEN"],
+      timeoutMs: 5_000,
+      maxOutputBytes: 4_096,
+    }),
+  ])
+
+  const runtime = await createRuntime({
+    backend: "wordpress-playground",
+    environment: { kind: "wordpress", version: "latest" },
+    policy: { network: "deny", filesystem: "sandbox", commands: ["host.node-smoke"], secrets: "none", approvals: "never" },
+    hostTools: registry,
+  }, createPlaygroundRuntimeBackend())
+
+  const ok = await runtime.execute({
+    command: "host.node-smoke",
+    args: [`input-json=${JSON.stringify({ args: ["--flag"], cwd: nested, env: { SMOKE_TOKEN: "allowed" } })}`],
+  })
+  const okBody = JSON.parse(ok.stdout) as HostToolResult
+  assert(okBody.status === "ok", "allowed host command should succeed")
+  assert(typeof okBody.output === "object" && okBody.output !== null && !Array.isArray(okBody.output), "host command output should be an object")
+  assert(okBody.output.cwd === resolvedNested, "host command should run from requested allowed cwd")
+  assert(okBody.output.exitCode === 0, `host command should report exit code: ${JSON.stringify(okBody.output)}`)
+  assert(typeof okBody.output.stdout === "string" && okBody.output.stdout.includes("allowed"), "host command should pass explicitly allowed env")
+
+  const deniedCwd = await runtime.execute({
+    command: "host.node-smoke",
+    args: [`input-json=${JSON.stringify({ cwd: tmpdir() })}`],
+  })
+  const deniedCwdBody = JSON.parse(deniedCwd.stdout) as HostToolResult
+  assert(deniedCwdBody.status === "error", "host command cwd escapes should fail closed")
+  assert(deniedCwdBody.error.message.includes("outside allowed roots"), "host command cwd errors should be explicit")
+
+  const deniedEnv = await runtime.execute({
+    command: "host.node-smoke",
+    args: [`input-json=${JSON.stringify({ env: { SECRET_TOKEN: "blocked" } })}`],
+  })
+  const deniedEnvBody = JSON.parse(deniedEnv.stdout) as HostToolResult
+  assert(deniedEnvBody.status === "error", "host command env escapes should fail closed")
+  assert(deniedEnvBody.error.message.includes("env is not allowed"), "host command env errors should be explicit")
+}
+
+await main()


### PR DESCRIPTION
## Summary
- Adds `createHostCommandTool()` for trusted worker hosts to expose selected host commands as named host-tool capabilities without granting arbitrary shell access.
- Enforces explicit cwd roots, timeout, bounded output capture, inherited/input env allowlists, and `spawn(..., { shell: false })` for repo-local commands such as tests, cargo, pnpm, or other product-owned wrappers.
- Documents the trusted host-command pattern and adds targeted smoke coverage for allowed execution plus cwd/env denial.

## Boundary
- Implements this as a generic WP Codebox trusted-run capability.
- Codebox does not import downstream product concepts, hardcode downstream task semantics, or name product-specific APIs.
- Downstream orchestrators can request/consume named host capabilities through policy, but they own their product-specific command registration and semantics.

Fixes #529.

## Verification
- `npm run build`
- `npm run host-tool-registry-smoke`
- `npm run host-command-tool-smoke`
- `npm run command-registry-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the permissioned host command adapter, smoke coverage, docs, and verification commands for Chris to review.