### PR TITLE
Expose mounted workspace context to sandbox agents

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
-import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT } from "@automattic/wp-codebox-core"
+import { SANDBOX_DMC_PARENT_ONLY_ABILITIES, SANDBOX_DMC_SAFE_ABILITIES, SANDBOX_WORKSPACE_ROOT, type SandboxWorkspaceContract } from "@automattic/wp-codebox-core"
 
 export interface AgentBundleSpec {
   source?: string
@@ -23,6 +23,7 @@ export interface AgentSandboxCodeOptions {
   agentBundles?: AgentBundleSpec[]
   code?: string
   codeFile?: string
+  sandboxWorkspace?: SandboxWorkspaceContract
 }
 
 export async function resolveSandboxTaskCode(options: AgentSandboxCodeOptions): Promise<string> {
@@ -58,6 +59,8 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
       mode,
       agent_modes: agentModes,
       workspace_root: SANDBOX_WORKSPACE_ROOT,
+      sandbox_workspace: options.sandboxWorkspace ?? null,
+      default_workspace: defaultSandboxWorkspace(options.sandboxWorkspace),
       tool_contract: sandboxToolContract(),
     },
   }
@@ -248,6 +251,7 @@ function wp_codebox_import_sandbox_agent_bundles(array $bundle_specs): array {
 if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') && !class_exists('WP_Codebox_Sandbox_Perception_Directive')) {
     final class WP_Codebox_Sandbox_Perception_Directive implements DataMachine\\Engine\\AI\\Directives\\DirectiveInterface {
         private const TREE_MAX_DEPTH = 2;
+        private const TREE_MAX_ENTRIES = 80;
 
         public static function get_outputs(string $provider_name, array $tools, ?string $step_id = null, array $payload = array()): array {
             unset($provider_name, $step_id);
@@ -255,6 +259,7 @@ if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') 
             $sections = array(
                 self::section_header(),
                 self::section_workspace((string) $workspace_root),
+                self::section_mounted_workspaces($workspace_root, is_array($payload['client_context']['sandbox_workspace'] ?? null) ? $payload['client_context']['sandbox_workspace'] : array(), is_array($payload['client_context']['default_workspace'] ?? null) ? $payload['client_context']['default_workspace'] : array()),
                 self::section_runtime(),
                 self::section_tools($tools, is_array($payload['client_context']['tool_contract'] ?? null) ? $payload['client_context']['tool_contract'] : array()),
                 self::section_outcome(),
@@ -271,6 +276,7 @@ if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') 
                 '# WP Codebox Sandbox Perception',
                 '',
                 'Live snapshot of the disposable WP Codebox sandbox at the start of this run. Use it as your starting awareness; workspace tools remain available for targeted inspection and edits.',
+                'Prefer this mounted-workspace map before broad reconnaissance. Inspect only the specific files or directories needed for the task.',
             ));
         }
 
@@ -278,13 +284,14 @@ if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') 
             if ('' === $workspace_root || !is_dir($workspace_root)) {
                 return '';
             }
-            $entries = self::scan_tree($workspace_root, $workspace_root, 0);
+            $entries = self::scan_tree($workspace_root, $workspace_root, 0, self::TREE_MAX_ENTRIES);
             sort($entries, SORT_STRING);
             $lines = array(
                 '## Workspace',
                 '',
                 sprintf('- Root: %s', $workspace_root),
                 sprintf('- Tree depth: %d', self::TREE_MAX_DEPTH),
+                sprintf('- Tree max entries: %d', self::TREE_MAX_ENTRIES),
                 '',
                 'Tree:',
             );
@@ -294,8 +301,60 @@ if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') 
             return implode("\n", $lines);
         }
 
-        private static function scan_tree(string $base, string $current, int $depth): array {
-            if ($depth > self::TREE_MAX_DEPTH) {
+        private static function section_mounted_workspaces(string $workspace_root, array $workspace_contract, array $default_workspace): string {
+            $mounts = is_array($workspace_contract['mounts'] ?? null) ? $workspace_contract['mounts'] : array();
+            if (empty($mounts)) {
+                return '';
+            }
+
+            $lines = array(
+                '## Mounted Workspaces',
+                '',
+            );
+            if (!empty($default_workspace)) {
+                $lines[] = sprintf('- Default workspace: %s at %s', (string) ($default_workspace['workspaceRef'] ?? $default_workspace['component'] ?? 'mounted workspace'), (string) ($default_workspace['target'] ?? $workspace_root));
+                $lines[] = '';
+            }
+            foreach ($mounts as $mount) {
+                if (!is_array($mount)) {
+                    continue;
+                }
+                $target = (string) ($mount['target'] ?? '');
+                if ('' === $target) {
+                    continue;
+                }
+                $label = (string) ($mount['workspaceRef'] ?? $mount['component'] ?? basename($target));
+                $lines[] = sprintf('### %s', $label);
+                $lines[] = sprintf('- Path: %s', $target);
+                $lines[] = sprintf('- Mode: %s', (string) ($mount['mode'] ?? 'readwrite'));
+                if (!empty($mount['repo'])) {
+                    $lines[] = sprintf('- Repo: %s', (string) $mount['repo']);
+                }
+                if (!empty($mount['sourceMode'])) {
+                    $lines[] = sprintf('- Source mode: %s', (string) $mount['sourceMode']);
+                }
+                if (!empty($mount['mountRole'])) {
+                    $lines[] = sprintf('- Role: %s', (string) $mount['mountRole']);
+                }
+                $mount_path = str_starts_with($target, '/') ? $target : rtrim($workspace_root, '/') . '/' . ltrim($target, '/');
+                if (is_dir($mount_path)) {
+                    $tree = self::scan_tree($mount_path, $mount_path, 0, 30);
+                    sort($tree, SORT_STRING);
+                    if (!empty($tree)) {
+                        $lines[] = '- Bounded tree:';
+                        foreach ($tree as $entry) {
+                            $lines[] = sprintf('  - %s', $entry);
+                        }
+                    }
+                }
+                $lines[] = '';
+            }
+
+            return trim(implode("\n", $lines));
+        }
+
+        private static function scan_tree(string $base, string $current, int $depth, int $remaining): array {
+            if ($depth > self::TREE_MAX_DEPTH || $remaining <= 0) {
                 return array();
             }
             $ignored = array('.git', 'node_modules', 'vendor', 'dist', 'build');
@@ -312,10 +371,19 @@ if (interface_exists('DataMachine\\Engine\\AI\\Directives\\DirectiveInterface') 
                 $relative = ltrim(substr($path, strlen($base)), '/');
                 if (is_dir($path)) {
                     $results[] = $relative . '/';
-                    $results = array_merge($results, self::scan_tree($base, $path, $depth + 1));
+                    if (count($results) >= $remaining) {
+                        break;
+                    }
+                    $results = array_merge($results, self::scan_tree($base, $path, $depth + 1, $remaining - count($results)));
+                    if (count($results) >= $remaining) {
+                        break;
+                    }
                     continue;
                 }
                 $results[] = $relative;
+                if (count($results) >= $remaining) {
+                    break;
+                }
             }
             return $results;
         }
@@ -450,6 +518,12 @@ function sandboxToolNames(): string[] {
 
 function sandboxAgentModes(mode: string): string[] {
   return Array.from(new Set([mode, "chat"].filter(Boolean)))
+}
+
+function defaultSandboxWorkspace(workspace: SandboxWorkspaceContract | undefined): Record<string, unknown> | null {
+  if (!workspace?.mounts.length) return null
+  const mount = workspace.mounts.find((entry) => entry.mode === "readwrite" && entry.target.startsWith(SANDBOX_WORKSPACE_ROOT)) ?? workspace.mounts[0]
+  return mount ? { ...mount } : null
 }
 
 function normalizeAgentBundleSpecs(specs: AgentBundleSpec[]): AgentBundleSpec[] {

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -30,6 +30,7 @@ export interface AgentSandboxRunOptions extends AgentRuntimeProbeOptions {
   agentBundles?: AgentBundleSpec[]
   code?: string
   codeFile?: string
+  sandboxWorkspace?: SandboxWorkspaceContract
 }
 
 export interface AgentSandboxBatchOptions extends AgentRuntimeProbeOptions {
@@ -83,7 +84,7 @@ export function agentRuntimeMounts(options: AgentRuntimeProbeOptions): AgentRunt
   ]
 }
 
-export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string): Promise<{ command: string; args: string[] }> {
+export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string, sandboxWorkspace?: SandboxWorkspaceContract): Promise<{ command: string; args: string[] }> {
   if (step.command === "wp-codebox.agent-runtime-probe") {
     return {
       command: "wordpress.run-php",
@@ -113,6 +114,7 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
       maxTurns: argValue(args, "max-turns"),
       timeoutSeconds: argValue(args, "timeout-seconds"),
       agentBundles: parseAgentBundles(args),
+      sandboxWorkspace: parseSandboxWorkspace(args) ?? sandboxWorkspace,
     }))
 
     return {
@@ -229,7 +231,7 @@ export function parseAgentRuntimeProbeOptions(args: string[], parseMount: (value
 }
 
 export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: string) => AgentRuntimeMount): AgentSandboxRunOptions {
-  const options = parseAgentRuntimeProbeOptions(args, parseMount, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--timeout-seconds", "--agent-bundles-json", "--code", "--code-file", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
+  const options = parseAgentRuntimeProbeOptions(args, parseMount, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--timeout-seconds", "--agent-bundles-json", "--code", "--code-file", "--workspace-context-json", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -270,6 +272,9 @@ export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: 
       case "--agent-bundles-json":
         options.agentBundles = parseAgentBundleList(value)
         break
+      case "--workspace-context-json":
+        options.sandboxWorkspace = parseSandboxWorkspaceValue(value)
+        break
     }
   }
 
@@ -286,6 +291,20 @@ export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: 
 
 function parseAgentBundles(args: string[]): AgentBundleSpec[] {
   return parseAgentBundleList(argValue(args, "agent-bundles-json") ?? "[]")
+}
+
+function parseSandboxWorkspace(args: string[]): SandboxWorkspaceContract | undefined {
+  const value = argValue(args, "workspace-context-json")
+  return value ? parseSandboxWorkspaceValue(value) : undefined
+}
+
+function parseSandboxWorkspaceValue(value: string): SandboxWorkspaceContract | undefined {
+  if (!value.trim()) return undefined
+  const parsed = JSON.parse(value)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || parsed.schema !== "wp-codebox/sandbox-workspace/v1") {
+    throw new Error("workspace-context-json must be a wp-codebox/sandbox-workspace/v1 object")
+  }
+  return parsed as SandboxWorkspaceContract
 }
 
 function parseAgentBundleList(value: string): AgentBundleSpec[] {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -586,8 +586,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const siteSeeds = await awaitRecipe("site-seeds.import", importRecipeSiteSeeds(recipe, recipeDirectory, runtime, executions))
     interruption?.throwIfInterrupted()
 
+    const sandboxWorkspace = sandboxWorkspaceContract(workspaceMounts, recipe.inputs?.mounts ?? [])
     for (const workflowStep of recipeWorkflowSteps(recipe)) {
-      executions.push(await awaitRecipe(`workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`, executeRecipeWorkflowStep(runtime, workflowStep, recipeDirectory)))
+      executions.push(await awaitRecipe(`workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`, executeRecipeWorkflowStep(runtime, workflowStep, recipeDirectory, sandboxWorkspace)))
       interruption?.throwIfInterrupted()
     }
 
@@ -908,9 +909,9 @@ function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: Recip
   }
 }
 
-async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string): Promise<RecipeExecutionResult> {
+async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>): Promise<RecipeExecutionResult> {
   try {
-    const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory))
+    const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory, sandboxWorkspace))
     return withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, workflowStep.step.command)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -1,7 +1,27 @@
 import assert from "node:assert/strict"
+import { recipeExecutionSpec } from "../packages/cli/src/agent-sandbox.ts"
 import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.ts"
 
 async function main() {
+  const sandboxWorkspace = {
+    schema: "wp-codebox/sandbox-workspace/v1" as const,
+    root: "/workspace",
+    defaultMode: "repo-backed" as const,
+    mounts: [
+      {
+        target: "/workspace/wp-codebox",
+        mode: "readwrite" as const,
+        sourceMode: "repo-backed" as const,
+        workspaceRef: "wp-codebox@fix-issue-533-mounted-workspace-perception",
+        repo: "Automattic/wp-codebox",
+        mountRole: "recipe-workspace",
+      },
+    ],
+    dmc: {
+      safeAbilities: ["datamachine/workspace-read"],
+      parentOnlyAbilities: [],
+    },
+  }
   const code = await resolveSandboxTaskCode({
     task: "Fix duplicate code",
     agent: "sandbox-agent",
@@ -9,6 +29,7 @@ async function main() {
     provider: "opencode",
     model: "opencode-go/kimi-k2.6",
     sessionId: "codebox-smoke-session",
+    sandboxWorkspace,
     agentBundles: [
       { source: "/tmp/site-generator-agent.json", slug: "site-generator" },
       {
@@ -30,6 +51,17 @@ async function main() {
   assert.match(code, /datamachine_agent_mode_sandbox/, "sandbox mode should inject tool guidance")
   assert.match(code, /WP_Codebox_Sandbox_Perception_Directive/, "sandbox mode should inject a WP Codebox perception directive")
   assert.match(code, /WP Codebox Sandbox Perception/, "sandbox perception should expose workspace context by default")
+  assert.match(code, /sandbox_workspace/, "sandbox request should include mounted workspace context")
+  assert.match(code, /default_workspace/, "sandbox request should include a default mounted workspace")
+  assert.match(code, /wp-codebox@fix-issue-533-mounted-workspace-perception/, "sandbox context should include mounted workspace handle")
+  assert.match(code, /\/workspace\/wp-codebox/, "sandbox context should include mounted workspace path")
+  assert.match(code, /Automattic\/wp-codebox/, "sandbox context should include mounted workspace repo")
+  assert.match(code, /\\"mode\\":\\"readwrite\\"/, "sandbox context should include mounted workspace mode")
+  assert.match(code, /Mounted Workspaces/, "sandbox perception should render a mounted workspace section")
+  assert.match(code, /Bounded tree/, "sandbox perception should render bounded mounted workspace trees")
+  assert.match(code, /TREE_MAX_ENTRIES = 80/, "sandbox perception should bound the root tree")
+  assert.match(code, /scan_tree\(\$mount_path, \$mount_path, 0, 30\)/, "sandbox perception should bound each mounted workspace tree")
+  assert.match(code, /Prefer this mounted-workspace map before broad reconnaissance/, "sandbox guidance should discourage repeated reconnaissance")
   assert.match(code, /datamachine_code_remote_workspace_backend_should_handle/, "sandbox mode should use the mounted workspace backend")
   assert.match(code, /is_file\(\$sandbox_workspace_dir \. '\/.git'\)/, "sandbox setup should detect linked worktree mounts")
   assert.match(code, /linked_worktree_mount/, "sandbox setup should report linked worktree mounts as non-fatal diagnostics")
@@ -49,6 +81,20 @@ async function main() {
   const createIfMissingIndex = code.indexOf("create_if_missing")
   assert.ok(fallbackGateIndex > code.indexOf("wp_codebox_import_sandbox_agent_bundles") && createIfMissingIndex > fallbackGateIndex, "legacy create_if_missing should be gated behind the no-bundle fallback")
   assert.match(code, /repair-agent/, "inline bundle specs should be embedded in sandbox setup")
+
+  const recipeSpec = await recipeExecutionSpec(
+    {
+      command: "wp-codebox.agent-sandbox-run",
+      args: ["task=Inspect the mounted repo", "agent=sandbox-agent"],
+    },
+    process.cwd(),
+    sandboxWorkspace,
+  )
+  const recipeCodeArg = recipeSpec.args.find((arg) => arg.startsWith("code=")) ?? ""
+  assert.match(recipeCodeArg, /wp-codebox@fix-issue-533-mounted-workspace-perception/, "recipe-generated sandbox code should include mounted workspace handle")
+  assert.match(recipeCodeArg, /\/workspace\/wp-codebox/, "recipe-generated sandbox code should include mounted workspace path")
+  assert.match(recipeCodeArg, /Automattic\/wp-codebox/, "recipe-generated sandbox code should include mounted workspace repo")
+  assert.match(recipeCodeArg, /\\"mode\\":\\"readwrite\\"/, "recipe-generated sandbox code should include mounted workspace mode")
 
   const runCode = agentSandboxRunCode(
     '{"prompt":"Do not interpolate $buckets, $meta, or $state_store."}',


### PR DESCRIPTION
## Summary
- Pass the recipe sandbox workspace contract into generated `wp-codebox.agent-sandbox-run` chat requests.
- Add mounted workspace perception that reports default workspace, handle/path/repo/mode/source mode/role, and bounded trees to avoid repeated broad reconnaissance.
- Extend `agent-sandbox-code-smoke` to cover generated sandbox code and recipe-lowered sandbox code for mounted workspace context.

Fixes https://github.com/Automattic/wp-codebox/issues/533
Parent tracker: https://github.com/Extra-Chill/homeboy/issues/3378

## Verification
- `npm run build`
- `npm run agent-sandbox-code-smoke`
- `npm run sandbox-tool-policy-smoke`
- `npm run recipe-dry-run-smoke`
- `npm run agent-runtime-failure-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation and smoke coverage; Chris remains responsible for review and testing.