### PR TITLE
Fail incomplete sandbox agent runs

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -527,8 +527,14 @@ export function agentSandboxRuntimeFailure(execution: AgentSandboxTranscriptExec
     return directFailure
   }
 
+  const directIncomplete = agentRuntimeIncompleteFromRecord(parsed)
+  if (directIncomplete) {
+    return directIncomplete
+  }
+
   const output = typeof parsed?.output === "string" ? decodeJsonFragment(parsed.output) : undefined
-  return agentRuntimeFailureFromRecord(isRecord(output) ? output : undefined)
+  const outputRecord = isRecord(output) ? output : undefined
+  return agentRuntimeFailureFromRecord(outputRecord) ?? agentRuntimeIncompleteFromRecord(outputRecord)
 }
 
 function agentRuntimeFailureFromRecord(record: Record<string, unknown> | undefined): AgentSandboxRuntimeFailure | undefined {
@@ -547,6 +553,37 @@ function agentRuntimeFailureFromRecord(record: Record<string, unknown> | undefin
     message: boundTranscriptText(message, 500),
     data: error?.data,
   })
+}
+
+function agentRuntimeIncompleteFromRecord(record: Record<string, unknown> | undefined): AgentSandboxRuntimeFailure | undefined {
+  const runtime = isRecord(record?.agent_runtime) ? record.agent_runtime : undefined
+  if (!runtime || runtime.success !== true) {
+    return undefined
+  }
+
+  const result = isRecord(runtime.result) ? runtime.result : undefined
+  if (!result || !isIncompleteAgentResult(result)) {
+    return undefined
+  }
+
+  return {
+    code: "agent_runtime_incomplete",
+    message: "Agent sandbox runtime ended before the nested agent completed pending tool work.",
+    data: stripUndefined({
+      status: typeof result.status === "string" ? result.status : undefined,
+      completed: typeof result.completed === "boolean" ? result.completed : undefined,
+      current_turn: typeof result.current_turn === "number" ? result.current_turn : undefined,
+      has_pending_tools: typeof result.has_pending_tools === "boolean" ? result.has_pending_tools : undefined,
+    }),
+  }
+}
+
+function isIncompleteAgentResult(result: Record<string, unknown>): boolean {
+  const status = typeof result.status === "string" ? result.status.toLowerCase() : ""
+  const completed = typeof result.completed === "boolean" ? result.completed : undefined
+  const hasPendingTools = result.has_pending_tools === true
+
+  return (status === "processing" || completed === false) && hasPendingTools
 }
 
 export function recipeAgentResultFailure(agentResult: RecipeArtifactEvidenceResult["agentResult"]): { name: string; code: string; message: string } | undefined {

--- a/scripts/agent-runtime-failure-smoke.ts
+++ b/scripts/agent-runtime-failure-smoke.ts
@@ -55,4 +55,45 @@ assert.equal(agentFailure?.code, "agent-runtime-failed")
 assert.equal(agentFailure?.message, "Provider codex is not registered in wp-ai-client")
 assert.equal(agentFailure?.name, "AgentRuntimeError")
 
+const pendingToolsFailure = agentSandboxRuntimeFailure({
+  executionIndex: 1,
+  command: "wordpress.run-php",
+  exitCode: 0,
+  recipeCommand: "wp-codebox.agent-sandbox-run",
+  stdout: JSON.stringify({
+    agent_runtime: {
+      success: true,
+      result: {
+        status: "processing",
+        completed: false,
+        current_turn: 20,
+        has_pending_tools: true,
+      },
+    },
+  }),
+  stderr: "",
+  parsed: {
+    agent_runtime: {
+      success: true,
+      result: {
+        status: "processing",
+        completed: false,
+        current_turn: 20,
+        has_pending_tools: true,
+      },
+    },
+  },
+})
+
+assert.deepEqual(pendingToolsFailure, {
+  code: "agent_runtime_incomplete",
+  message: "Agent sandbox runtime ended before the nested agent completed pending tool work.",
+  data: {
+    status: "processing",
+    completed: false,
+    current_turn: 20,
+    has_pending_tools: true,
+  },
+})
+
 console.log("Agent runtime failure smoke passed")


### PR DESCRIPTION
## Summary
- Treat successful WP Codebox sandbox wrappers with nested agent results still `processing` and `has_pending_tools:true` as runtime failures instead of completed no-op runs.
- Preserve the nested status/current-turn diagnostics in the agent-result failure payload.
- Extend the runtime failure smoke with the pending-tool shape observed in the Homeboy fanout blocker.

Fixes https://github.com/Automattic/wp-codebox/issues/534
Parent tracker: https://github.com/Extra-Chill/homeboy/issues/3378

## Verification
- `npm run agent-runtime-failure-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the classifier fix and regression smoke; Chris remains responsible for review and merge.