### PR TITLE
Fix browser session task payload default

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -614,7 +614,7 @@ try {
 
 	const runBrowserSessionRecipe = async ( client, session, taskPayload, options = {} ) => {
 		const recipe = browserSessionRecipe( session );
-		const payload = taskPayload === undefined ? ( session.task_input ?? {} ) : taskPayload;
+		const payload = taskPayload === undefined ? ( session.task_payload ?? session.task_input ?? {} ) : taskPayload;
 		return runRecipe( client, recipe, payload, {
 			...options,
 			name: options.name || 'codebox-browser-session',

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -264,6 +264,16 @@ const sessionOutput = {
   success: true,
   session: { id: "browser-session-smoke", status: "ready" },
   task_input: { goal: "Run session smoke", expected_artifacts: ["summary"] },
+  task_payload: {
+    schema: "wp-codebox/browser-agent-task-payload/v1",
+    goal: "Run session smoke from task payload",
+    provider: "openai",
+    model: "gpt-5.5",
+    inherited: {
+      provider_plugin_paths: ["/wordpress/wp-content/plugins/ai-provider-for-openai"],
+      env_names: ["AI_PROVIDER_OPENAI_CODEX_REFRESH_TOKEN"],
+    },
+  },
   recipe: {
     schema: "wp-codebox/workspace-recipe/v1",
     browser: {
@@ -287,11 +297,22 @@ assert.deepEqual(extractBrowserOperation(sessionClient.files[0]?.contents ?? "")
   type: "writeFile",
   args: {
     path: "/tmp/wp-codebox-agent-task.json",
-    content: JSON.stringify({ goal: "Run session smoke", expected_artifacts: ["summary"] }),
+    content: JSON.stringify(sessionOutput.task_payload),
   },
 })
 assert.match(sessionClient.files[1]?.path ?? "", /\/wordpress\/wp-content\/uploads\/wp-codebox\/runner\/codebox-browser-session-/)
 assert.match(sessionClient.requests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/codebox-browser-session-/)
+
+const overridePayload = { goal: "Explicit payload override", provider: "test-provider", model: "override-model" }
+const overrideSessionClient = createClient("prefix {\"success\":true,\"data\":{\"summary\":\"override runner\"},\"error\":null} suffix")
+await runtime.runBrowserSessionRecipe(overrideSessionClient, sessionOutput, overridePayload)
+assert.deepEqual(extractBrowserOperation(overrideSessionClient.files[0]?.contents ?? ""), {
+  type: "writeFile",
+  args: {
+    path: "/tmp/wp-codebox-agent-task.json",
+    content: JSON.stringify(overridePayload),
+  },
+})
 
 assert.equal(runtime.browserSessionRecipe(sessionOutput), sessionOutput.recipe)
 await assert.rejects(


### PR DESCRIPTION
## Summary
- Default `runBrowserSessionRecipe()` to `session.task_payload` before falling back to legacy `task_input`.
- Extend the browser runtime smoke to prove provider/model/inheritance metadata reaches `runRecipe()` by default.
- Keep explicit `taskPayload` overrides taking precedence.

## Tests
- `npm run browser-runtime-operation-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the minimal runtime fix, smoke coverage, and verification commands for Chris to review.

Closes #544