### PR TITLE
Add browser provider adapter hook

### DIFF
--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -52,6 +52,56 @@ adds any permission bypass. If the runner is copied into a normal host WordPress
 install, it fails with `wp_codebox_browser_runner_not_playground` instead of
 executing the requested sandbox invocation.
 
+## Browser Provider Adapter Contract
+
+Browser Playground provider calls that need parent-side connector authorization
+use the generic `wp-codebox/execute-browser-provider-request` ability. WP Codebox
+resolves connector inheritance on the parent site, strips raw credential values,
+and dispatches the request through the `wp_codebox_browser_provider_request`
+filter.
+
+```text
+Browser connector bridge
+  -> wp-codebox/execute-browser-provider-request
+    -> parent-side connector inheritance resolution
+      -> wp_codebox_browser_provider_request filter
+        -> provider adapter owned by the host/control plane
+```
+
+The adapter filter receives a redacted request envelope:
+
+```json
+{
+  "schema": "wp-codebox/browser-provider-adapter-request/v1",
+  "operation": "chat.completions",
+  "provider": "openai",
+  "model": "gpt-5.5",
+  "connector": {
+    "name": "primary-ai",
+    "status": "resolved",
+    "provider": "openai",
+    "model": "gpt-5.5"
+  },
+  "context": {
+    "session_id": "browser-session-123",
+    "caller": "trusted-orchestrator",
+    "authorization_scope": "browser-session:create"
+  },
+  "request": {}
+}
+```
+
+Adapters return an array response envelope or `WP_Error`. If no adapter handles
+the request, WP Codebox fails closed with
+`wp_codebox_browser_provider_adapter_missing`. Returned success and error data is
+redacted before WP Codebox exposes the normalized
+`wp-codebox/browser-provider-adapter-response/v1` response.
+
+WP Codebox core does not implement provider-specific execution here. Adapters
+must resolve provider credentials server-side from their trusted connector
+configuration. Raw provider keys must not be returned to browser JavaScript,
+browser Playground PHP, artifacts, diagnostics, or audit metadata.
+
 ## Request Fields
 
 `wp-codebox/run-agent-task` and `wp-codebox/run-agent-task-batch` accept these

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/trait-wp-codebox-abilities-schemas.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-execution.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-permissions.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-inheritance.php';
+require_once __DIR__ . '/trait-wp-codebox-abilities-provider-adapter.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-artifacts.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-runtime.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-blueprint.php';
@@ -32,6 +33,7 @@ final class WP_Codebox_Abilities {
 	use WP_Codebox_Abilities_Execution;
 	use WP_Codebox_Abilities_Permissions;
 	use WP_Codebox_Abilities_Inheritance;
+	use WP_Codebox_Abilities_Provider_Adapter;
 	use WP_Codebox_Abilities_Browser_Artifacts;
 	use WP_Codebox_Abilities_Browser_Runtime;
 	use WP_Codebox_Abilities_Browser_Blueprint;
@@ -639,6 +641,58 @@ final class WP_Codebox_Abilities {
 					'output_schema'       => self::browser_connector_response_schema(),
 					'execute_callback'    => array( self::class, 'browser_connector_request' ),
 					'permission_callback' => array( self::class, 'can_request_browser_connector' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/execute-browser-provider-request',
+				array(
+					'label'               => 'Execute Browser Provider Request',
+					'description'         => 'Dispatch a connector-scoped browser provider request through the generic parent-side provider adapter hook without exposing raw provider credentials to the browser Playground.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'operation', 'request', 'inherit' ),
+						'properties' => array(
+							'operation' => array(
+								'type'        => 'string',
+								'description' => 'Generic provider operation id, for example chat.completions. WP Codebox treats this as opaque adapter input.',
+							),
+							'provider'  => array( 'type' => 'string' ),
+							'model'     => array( 'type' => 'string' ),
+							'connector' => array(
+								'type'        => 'string',
+								'description' => 'Optional connector name to select from the resolved inheritance connector set. Defaults to the first resolved connector.',
+							),
+							'inherit'   => $inherit_schema,
+							'request'   => array(
+								'type'        => 'object',
+								'description' => 'Generic provider request payload. Secret-like fields are redacted before adapter/audit envelopes are returned.',
+							),
+							'sandbox_session_id' => $session_input['sandbox_session_id'],
+							'session_id'         => array( 'type' => 'string' ),
+							'caller_session_id'  => array( 'type' => 'string' ),
+							'job_id'             => array( 'type' => 'string' ),
+							'orchestrator'       => $session_input['orchestrator'],
+							'authorization'      => self::browser_session_authorization_schema(),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'   => array( 'type' => 'boolean' ),
+							'schema'    => array( 'type' => 'string', 'const' => 'wp-codebox/browser-provider-adapter-response/v1' ),
+							'operation' => array( 'type' => 'string' ),
+							'provider'  => array( 'type' => 'string' ),
+							'model'     => array( 'type' => 'string' ),
+							'connector' => array( 'type' => 'object' ),
+							'response'  => array( 'type' => 'object' ),
+							'audit'     => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'execute_browser_provider_request' ),
+					'permission_callback' => array( self::class, 'can_create_browser_playground_session' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-provider-adapter.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-provider-adapter.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * WP_Codebox_Abilities_Provider_Adapter implementation.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+trait WP_Codebox_Abilities_Provider_Adapter {
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function execute_browser_provider_request( array $input ): array|WP_Error {
+		$operation = trim( (string) ( $input['operation'] ?? '' ) );
+		if ( '' === $operation ) {
+			return new WP_Error( 'wp_codebox_browser_provider_operation_required', 'Browser provider requests must include an operation.', array( 'status' => 400, 'schema' => 'wp-codebox/browser-provider-error/v1' ) );
+		}
+
+		$request_payload = is_array( $input['request'] ?? null ) ? $input['request'] : array();
+		if ( empty( $request_payload ) ) {
+			return new WP_Error( 'wp_codebox_browser_provider_request_required', 'Browser provider requests must include a generic request object.', array( 'status' => 400, 'schema' => 'wp-codebox/browser-provider-error/v1' ) );
+		}
+
+		$inheritance_payload = self::browser_inheritance_resolution_payload( $input );
+		if ( is_wp_error( $inheritance_payload ) ) {
+			return $inheritance_payload;
+		}
+
+		$inheritance = $inheritance_payload['inheritance'];
+		$connector   = self::browser_provider_request_connector( $input, $inheritance );
+		if ( empty( $connector ) ) {
+			return new WP_Error( 'wp_codebox_browser_provider_connector_required', 'Browser provider requests require a resolved connector scope.', array( 'status' => 403, 'schema' => 'wp-codebox/browser-provider-error/v1' ) );
+		}
+
+		$adapter_request = array(
+			'schema'    => 'wp-codebox/browser-provider-adapter-request/v1',
+			'operation' => $operation,
+			'provider'  => self::browser_provider( $input, $inheritance ),
+			'model'     => self::browser_model( $input, $inheritance ),
+			'connector' => $connector,
+			'context'   => self::browser_provider_request_context( $input ),
+			'request'   => self::redact_provider_metadata( $request_payload ),
+		);
+
+		/**
+		 * Executes a connector-scoped browser provider request on the parent site.
+		 *
+		 * Adapters must resolve credentials server-side from the connector/context they
+		 * trust. WP Codebox passes only redacted connector provenance and request data;
+		 * raw provider credentials must not be returned in the response envelope.
+		 *
+		 * @param mixed               $response        Adapter response, or null when unhandled.
+		 * @param array<string,mixed> $adapter_request Generic redacted provider request.
+		 * @param array<string,mixed> $input           Original ability input.
+		 */
+		$response = apply_filters( 'wp_codebox_browser_provider_request', null, $adapter_request, $input );
+
+		if ( null === $response ) {
+			return new WP_Error( 'wp_codebox_browser_provider_adapter_missing', 'No browser provider adapter handled this connector-scoped request.', array( 'status' => 501, 'schema' => 'wp-codebox/browser-provider-error/v1', 'operation' => $operation, 'provider' => $adapter_request['provider'], 'model' => $adapter_request['model'], 'connector' => $connector ) );
+		}
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( $response->get_error_code(), $response->get_error_message(), self::redact_provider_metadata( array_merge( array( 'schema' => 'wp-codebox/browser-provider-error/v1' ), is_array( $response->get_error_data() ) ? $response->get_error_data() : array() ) ) );
+		}
+
+		if ( ! is_array( $response ) ) {
+			return new WP_Error( 'wp_codebox_browser_provider_adapter_invalid_response', 'Browser provider adapters must return an array response envelope or WP_Error.', array( 'status' => 502, 'schema' => 'wp-codebox/browser-provider-error/v1' ) );
+		}
+
+		return self::normalize_browser_provider_response( $response, $adapter_request );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed> */
+	private static function browser_provider_request_connector( array $input, array $inheritance ): array {
+		$requested_name = trim( (string) ( $input['connector'] ?? '' ) );
+		foreach ( $inheritance['connectors'] as $connector ) {
+			$name = trim( (string) ( $connector['name'] ?? '' ) );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			if ( '' !== $requested_name && $name !== $requested_name ) {
+				continue;
+			}
+
+			return self::redact_provider_metadata( $connector );
+		}
+
+		return array();
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private static function browser_provider_request_context( array $input ): array {
+		$authorization = self::browser_session_authorization( $input );
+		$context       = array_filter(
+			array(
+				'session_id'         => trim( (string) ( $input['sandbox_session_id'] ?? $input['session_id'] ?? '' ) ),
+				'caller_session_id'  => trim( (string) ( $input['caller_session_id'] ?? '' ) ),
+				'job_id'             => trim( (string) ( $input['job_id'] ?? '' ) ),
+				'caller'             => (string) ( $authorization['caller'] ?? '' ),
+				'authorization_scope' => (string) ( $authorization['scope'] ?? '' ),
+				'orchestrator'       => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+
+		return self::redact_provider_metadata( $context );
+	}
+
+	/** @param array<string,mixed> $response Adapter response. @param array<string,mixed> $adapter_request Adapter request. @return array<string,mixed> */
+	private static function normalize_browser_provider_response( array $response, array $adapter_request ): array {
+		$redacted_response = self::redact_provider_metadata( $response );
+
+		return array_filter(
+			array(
+				'success'   => true,
+				'schema'    => 'wp-codebox/browser-provider-adapter-response/v1',
+				'operation' => $adapter_request['operation'],
+				'provider'  => $adapter_request['provider'],
+				'model'     => $adapter_request['model'],
+				'connector' => is_array( $adapter_request['connector'] ?? null ) ? $adapter_request['connector'] : array(),
+				'response'  => is_array( $redacted_response['response'] ?? null ) ? $redacted_response['response'] : $redacted_response,
+				'audit'     => array(
+					'schema'    => 'wp-codebox/browser-provider-audit/v1',
+					'operation' => $adapter_request['operation'],
+					'provider'  => $adapter_request['provider'],
+					'model'     => $adapter_request['model'],
+					'connector' => is_array( $adapter_request['connector'] ?? null ) ? $adapter_request['connector'] : array(),
+					'request'   => is_array( $adapter_request['request'] ?? null ) ? $adapter_request['request'] : array(),
+					'response'  => $redacted_response,
+				),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	private static function redact_provider_metadata( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$redacted = array();
+		foreach ( $value as $key => $item ) {
+			$normalized_key = strtolower( (string) $key );
+			if ( self::is_sensitive_provider_metadata_key( $normalized_key ) ) {
+				$redacted[ $key ] = '[redacted]';
+				continue;
+			}
+
+			$redacted[ $key ] = self::redact_provider_metadata( $item );
+		}
+
+		return $redacted;
+	}
+
+	private static function is_sensitive_provider_metadata_key( string $key ): bool {
+		if ( in_array( $key, array( 'authorization', 'key', 'value' ), true ) ) {
+			return true;
+		}
+
+		foreach ( array( 'secret', 'token', 'password', 'credential', 'private_key', 'api_key' ) as $needle ) {
+			if ( str_contains( $key, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -403,6 +403,12 @@ $assert( 'browser connector request ability is REST visible', true === ( $browse
 $assert( 'browser connector request uses canonical schemas', 'wp-codebox/browser-connector-request/v1' === ( $browser_connector_ability['input_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/browser-connector-response/v1' === ( $browser_connector_ability['output_schema']['properties']['schema']['const'] ?? '' ) );
 $assert( 'browser connector request uses connector-specific authorization scope', array( 'browser-connector:request' ) === ( $browser_connector_ability['input_schema']['properties']['authorization']['properties']['scope']['enum'] ?? array() ) );
 
+$browser_provider_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/execute-browser-provider-request'] ?? null;
+$assert( 'browser provider request ability registered', is_array( $browser_provider_ability ) );
+$assert( 'browser provider request ability is REST visible', true === ( $browser_provider_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'browser provider request requires connector-scoped input', array( 'operation', 'request', 'inherit' ) === ( $browser_provider_ability['input_schema']['required'] ?? array() ) && 'object' === ( $browser_provider_ability['input_schema']['properties']['inherit']['type'] ?? '' ) );
+$assert( 'browser provider request exposes redacted response envelope schema', 'wp-codebox/browser-provider-adapter-response/v1' === ( $browser_provider_ability['output_schema']['properties']['schema']['const'] ?? '' ) && 'object' === ( $browser_provider_ability['output_schema']['properties']['audit']['type'] ?? '' ) );
+
 $trusted_browser_authorization = array(
 	'authorization' => array(
 		'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
@@ -418,7 +424,79 @@ $assert( 'browser Playground session denies untrusted orchestrator caller', fals
 $assert( 'browser Playground session denies trusted caller without browser-session scope', false === call_user_func( $browser_session_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
 $assert( 'browser materializer contract reuses trusted browser-session authorization', true === call_user_func( $browser_materializer_ability['permission_callback'], $trusted_browser_authorization ) && false === call_user_func( $browser_materializer_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
 $assert( 'browser task contract reuses trusted browser-session authorization', true === call_user_func( $browser_task_contract_ability['permission_callback'], $trusted_browser_authorization ) && false === call_user_func( $browser_task_contract_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
+$assert( 'browser provider request reuses trusted browser-session authorization', true === call_user_func( $browser_provider_ability['permission_callback'], $trusted_browser_authorization ) && false === call_user_func( $browser_provider_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
 $GLOBALS['wp_codebox_current_user_can_manage_options'] = true;
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ): array {
+	$resolution['connectors'] = array(
+		array(
+			'name'       => $request['connectors'][0] ?? 'primary-ai',
+			'status'     => 'resolved',
+			'provider'   => 'openai',
+			'model'      => 'gpt-5.5',
+			'secret_env_values' => array( 'OPENAI_API_KEY' => 'sk-browser-provider-secret' ),
+			'credentials' => array(
+				'schema'    => 'wp-codebox/connector-credentials/v1',
+				'connector' => $request['connectors'][0] ?? 'primary-ai',
+				'scope'     => 'connector',
+				'status'    => 'available',
+				'secrets'   => array(
+					array(
+						'name'   => 'OPENAI_API_KEY',
+						'status' => 'available',
+						'value'  => 'sk-browser-provider-secret',
+					),
+				),
+			),
+		),
+	);
+
+	return $resolution;
+};
+
+$provider_missing_adapter = call_user_func(
+	$browser_provider_ability['execute_callback'],
+	array(
+		'operation' => 'chat.completions',
+		'inherit'   => array( 'connectors' => array( 'primary-ai' ) ),
+		'request'   => array( 'messages' => array( array( 'role' => 'user', 'content' => 'Hello' ) ) ),
+	)
+);
+$assert( 'browser provider request fails closed without adapter', is_wp_error( $provider_missing_adapter ) && 'wp_codebox_browser_provider_adapter_missing' === $provider_missing_adapter->get_error_code() );
+$assert( 'browser provider missing-adapter error is redacted', is_wp_error( $provider_missing_adapter ) && ! str_contains( json_encode( $provider_missing_adapter->get_error_data() ), 'sk-browser-provider-secret' ) );
+
+$captured_provider_adapter_request = array();
+$GLOBALS['wp_codebox_filters']['wp_codebox_browser_provider_request'] = function ( mixed $response, array $adapter_request ) use ( &$captured_provider_adapter_request ): array {
+	$captured_provider_adapter_request = $adapter_request;
+	return array(
+		'response' => array(
+			'id'      => 'provider-response-1',
+			'text'    => 'Adapter handled the request.',
+			'api_key' => 'sk-browser-provider-secret',
+		),
+		'audit' => array(
+			'token' => 'sk-browser-provider-secret',
+		),
+	);
+};
+$provider_adapter_response = call_user_func(
+	$browser_provider_ability['execute_callback'],
+	array(
+		'operation'          => 'chat.completions',
+		'inherit'            => array( 'connectors' => array( 'primary-ai' ) ),
+		'connector'          => 'primary-ai',
+		'sandbox_session_id' => 'browser-session-123',
+		'request'            => array(
+			'messages' => array( array( 'role' => 'user', 'content' => 'Hello' ) ),
+			'api_key'  => 'sk-browser-provider-secret',
+		),
+	)
+);
+$provider_adapter_encoded = json_encode( $provider_adapter_response );
+$assert( 'browser provider adapter receives generic redacted connector context', ! is_wp_error( $provider_adapter_response ) && 'wp-codebox/browser-provider-adapter-request/v1' === ( $captured_provider_adapter_request['schema'] ?? '' ) && 'openai' === ( $captured_provider_adapter_request['provider'] ?? '' ) && 'gpt-5.5' === ( $captured_provider_adapter_request['model'] ?? '' ) && 'primary-ai' === ( $captured_provider_adapter_request['connector']['name'] ?? '' ) && 'browser-session-123' === ( $captured_provider_adapter_request['context']['session_id'] ?? '' ) );
+$assert( 'browser provider adapter request excludes raw provider secrets', ! str_contains( json_encode( $captured_provider_adapter_request ), 'sk-browser-provider-secret' ) && '[redacted]' === ( $captured_provider_adapter_request['request']['api_key'] ?? '' ) );
+$assert( 'browser provider response envelope redacts adapter secrets', ! is_wp_error( $provider_adapter_response ) && 'wp-codebox/browser-provider-adapter-response/v1' === ( $provider_adapter_response['schema'] ?? '' ) && ! str_contains( $provider_adapter_encoded, 'sk-browser-provider-secret' ) && '[redacted]' === ( $provider_adapter_response['response']['api_key'] ?? '' ) );
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'], $GLOBALS['wp_codebox_filters']['wp_codebox_browser_provider_request'] );
 
 $artifact_abilities = array(
 	'wp-codebox/list-artifacts',


### PR DESCRIPTION
## Summary
- Adds `wp-codebox/execute-browser-provider-request` as the generic parent-side provider adapter ability for browser connector requests.
- Dispatches connector-scoped requests through `wp_codebox_browser_provider_request`, with fail-closed missing/invalid adapter behavior and redacted request/response/audit envelopes.
- Documents the contract and adds smoke coverage for permissions, adapter dispatch, fail-closed behavior, and secret redaction.

Closes #545.

## Testing
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-provider-adapter.php && php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the browser connector/provider boundary, drafted the generic adapter contract and tests, and prepared this PR for Chris to review.