### PR TITLE
Add browser task contract ability

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -559,6 +559,74 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/create-browser-task-contract',
+				array(
+					'label'               => 'Create Browser Task Contract',
+					'description'         => 'Prepare a product-facing multi-phase browser Playground task contract with a primary session and optional materializer phases.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'anyOf'      => array(
+							array( 'type' => 'object', 'required' => array( 'goal' ) ),
+							array( 'type' => 'object', 'required' => array( 'task' ) ),
+						),
+						'properties' => array(
+							'goal'               => $task_input_schema['properties']['goal'],
+							'task'               => array(
+								'type'        => 'string',
+								'description' => 'Legacy task description. Prefer goal for new product callers.',
+							),
+							'target'             => $task_input_schema['properties']['target'],
+							'allowed_tools'      => $task_input_schema['properties']['allowed_tools'],
+							'sandbox_tool_policy' => $task_input_schema['properties']['sandbox_tool_policy'],
+							'expected_artifacts' => $task_input_schema['properties']['expected_artifacts'],
+							'policy'             => $task_input_schema['properties']['policy'],
+							'context'            => $task_input_schema['properties']['context'],
+							'agent'              => array( 'type' => 'string' ),
+							'provider'           => array( 'type' => 'string' ),
+							'model'              => array( 'type' => 'string' ),
+							'mode'               => array( 'type' => 'string' ),
+							'provider_plugin_paths' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							'agent_bundles'      => self::agent_bundle_schema(),
+							'inherit'            => $inherit_schema,
+							'secret_env'         => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+							'sandbox_session_id' => $session_input['sandbox_session_id'],
+							'orchestrator'       => $session_input['orchestrator'],
+							'authorization'      => self::browser_session_authorization_schema(),
+							'playground'         => array( 'type' => 'object' ),
+							'browser_runner'     => array( 'type' => 'object' ),
+							'browser_plugins'    => array( 'type' => 'array' ),
+							'runtime'            => array( 'type' => 'object' ),
+							'blueprint'          => array( 'type' => 'object' ),
+							'site_blueprint_artifact' => array( 'type' => 'object' ),
+							'artifact_files'     => array( 'type' => 'array' ),
+							'phases'             => array(
+								'type'        => 'array',
+								'description' => 'Optional named browser task phases. Each materializer phase may override any primary session input through input.',
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'name'  => array( 'type' => 'string' ),
+										'kind'  => array( 'type' => 'string', 'enum' => array( 'materializer' ) ),
+										'input' => array( 'type' => 'object' ),
+									),
+								),
+							),
+							'materializers'      => array(
+								'type'        => 'array',
+								'description' => 'Convenience list of materializer input overrides. Prefer phases for named multi-phase contracts.',
+								'items'       => array( 'type' => 'object' ),
+							),
+						),
+					),
+					'output_schema'       => self::browser_task_contract_schema(),
+					'execute_callback'    => array( self::class, 'create_browser_task_contract' ),
+					'permission_callback' => array( self::class, 'can_create_browser_playground_session' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/list-artifacts',
 				array(
 					'label'               => 'List WP Codebox Artifacts',

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -172,6 +172,101 @@ public static function create_browser_materializer_contract( array $input ): arr
 	);
 }
 
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+public static function create_browser_task_contract( array $input ): array|WP_Error {
+	$primary = self::create_browser_playground_session( $input );
+	if ( is_wp_error( $primary ) ) {
+		return $primary;
+	}
+
+	$session_envelope = is_array( $primary['session'] ?? null ) ? $primary['session'] : array();
+	if ( true !== ( $primary['success'] ?? false ) ) {
+		return array_filter(
+			array(
+				'success'          => false,
+				'schema'           => 'wp-codebox/browser-task-contract/v1',
+				'execution'        => 'browser-playground',
+				'execution_scope'  => 'disposable-playground',
+				'permission_model' => 'sandbox-bypass',
+				'status'           => (string) ( $primary['status'] ?? 'blocked' ),
+				'error'            => is_array( $primary['error'] ?? null ) ? $primary['error'] : array(),
+				'session'          => $session_envelope,
+				'primary'          => $primary,
+				'phases'           => array(),
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+
+	$phases = self::browser_task_contract_phases( $input, $session_envelope );
+	if ( is_wp_error( $phases ) ) {
+		return $phases;
+	}
+
+	return array(
+		'success'          => true,
+		'schema'           => 'wp-codebox/browser-task-contract/v1',
+		'execution'        => 'browser-playground',
+		'execution_scope'  => 'disposable-playground',
+		'permission_model' => 'sandbox-bypass',
+		'session'          => $session_envelope,
+		'primary'          => $primary,
+		'phases'           => $phases,
+		'provenance'       => array(
+			'generated_by' => 'wp-codebox/browser-task-contract',
+			'source'       => 'wp-codebox/create-browser-playground-session',
+		),
+	);
+}
+
+/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $session_envelope Primary browser session envelope. @return array<int,array<string,mixed>>|WP_Error */
+private static function browser_task_contract_phases( array $input, array $session_envelope ): array|WP_Error {
+	$phase_specs = is_array( $input['phases'] ?? null ) ? $input['phases'] : array();
+	if ( empty( $phase_specs ) && is_array( $input['materializers'] ?? null ) ) {
+		$phase_specs = array_map(
+			static fn( mixed $materializer ): array => array(
+				'kind'  => 'materializer',
+				'input' => is_array( $materializer ) ? $materializer : array(),
+			),
+			$input['materializers']
+		);
+	}
+
+	$phases = array();
+	foreach ( $phase_specs as $index => $phase ) {
+		if ( ! is_array( $phase ) ) {
+			return new WP_Error( 'wp_codebox_browser_phase_invalid', 'Each browser task phase must be an object.', array( 'status' => 400, 'index' => $index ) );
+		}
+
+		$kind = self::safe_key( (string) ( $phase['kind'] ?? 'materializer' ) );
+		if ( 'materializer' !== $kind ) {
+			return new WP_Error( 'wp_codebox_browser_phase_kind_invalid', 'Browser task phases currently support materializer phases only.', array( 'status' => 400, 'index' => $index, 'kind' => $kind ) );
+		}
+
+		$phase_input = is_array( $phase['input'] ?? null ) ? $phase['input'] : array();
+		$phase_input = array_replace_recursive( $input, $phase_input );
+		unset( $phase_input['phases'], $phase_input['materializers'] );
+
+		if ( empty( $phase_input['sandbox_session_id'] ) && '' !== (string) ( $session_envelope['id'] ?? '' ) ) {
+			$phase_input['sandbox_session_id'] = (string) $session_envelope['id'];
+		}
+
+		$contract = self::create_browser_materializer_contract( $phase_input );
+		if ( is_wp_error( $contract ) ) {
+			return $contract;
+		}
+
+		$phases[] = array(
+			'name'     => self::safe_key( (string) ( $phase['name'] ?? $kind . '-' . ( $index + 1 ) ) ),
+			'kind'     => $kind,
+			'index'    => $index,
+			'contract' => $contract,
+		);
+	}
+
+	return $phases;
+}
+
 /**
  * @param array<string,mixed> $input Ability input.
  * @param array<string,mixed> $task_input Normalized task input.

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -353,6 +353,37 @@ private static function browser_materializer_contract_schema(): array {
 }
 
 /** @return array<string,mixed> */
+private static function browser_task_contract_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'success'          => array( 'type' => 'boolean' ),
+			'schema'           => array( 'type' => 'string' ),
+			'execution'        => array(
+				'type' => 'string',
+				'enum' => array( 'browser-playground' ),
+			),
+			'execution_scope'  => array(
+				'type' => 'string',
+				'enum' => array( 'disposable-playground' ),
+			),
+			'permission_model' => array(
+				'type' => 'string',
+				'enum' => array( 'sandbox-bypass' ),
+			),
+			'session'          => array( 'type' => 'object' ),
+			'primary'          => self::browser_playground_session_schema(),
+			'phases'           => array(
+				'type'        => 'array',
+				'description' => 'Named browser task phases. The first supported kind is materializer, which returns a browser-materializer-contract envelope.',
+				'items'       => array( 'type' => 'object' ),
+			),
+			'provenance'       => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
 private static function browser_session_authorization_schema(): array {
 	return self::trusted_orchestrator_authorization_schema( self::BROWSER_SESSION_CREATE_SCOPE, 'Explicit trusted orchestrator authorization for browser session creation. Callers must provide a caller id and the browser-session:create scope; sites grant trust through wp_codebox_trusted_browser_session_callers.' );
 }

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -391,6 +391,12 @@ $assert( 'browser materializer contract ability is REST visible', true === ( $br
 $assert( 'browser materializer contract accepts goal or legacy task', array( 'goal' ) === ( $browser_materializer_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_materializer_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
 $assert( 'browser materializer contract exposes recipe materialization and authorization output', 'object' === ( $browser_materializer_ability['output_schema']['properties']['recipe']['type'] ?? '' ) && 'object' === ( $browser_materializer_ability['output_schema']['properties']['materialization']['type'] ?? '' ) && 'object' === ( $browser_materializer_ability['output_schema']['properties']['authorization']['type'] ?? '' ) );
 
+$browser_task_contract_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/create-browser-task-contract'] ?? null;
+$assert( 'browser task contract ability registered', is_array( $browser_task_contract_ability ) );
+$assert( 'browser task contract ability is REST visible', true === ( $browser_task_contract_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'browser task contract accepts goal or legacy task', array( 'goal' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
+$assert( 'browser task contract exposes phase schema', 'array' === ( $browser_task_contract_ability['input_schema']['properties']['phases']['type'] ?? '' ) && array( 'materializer' ) === ( $browser_task_contract_ability['input_schema']['properties']['phases']['items']['properties']['kind']['enum'] ?? array() ) && 'array' === ( $browser_task_contract_ability['output_schema']['properties']['phases']['type'] ?? '' ) );
+
 $trusted_browser_authorization = array(
 	'authorization' => array(
 		'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
@@ -405,6 +411,7 @@ $assert( 'browser Playground session allows trusted orchestrator caller with bro
 $assert( 'browser Playground session denies untrusted orchestrator caller', false === call_user_func( $browser_session_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'unknown-product', 'scope' => 'browser-session:create' ) ) ) );
 $assert( 'browser Playground session denies trusted caller without browser-session scope', false === call_user_func( $browser_session_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
 $assert( 'browser materializer contract reuses trusted browser-session authorization', true === call_user_func( $browser_materializer_ability['permission_callback'], $trusted_browser_authorization ) && false === call_user_func( $browser_materializer_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
+$assert( 'browser task contract reuses trusted browser-session authorization', true === call_user_func( $browser_task_contract_ability['permission_callback'], $trusted_browser_authorization ) && false === call_user_func( $browser_task_contract_ability['permission_callback'], array( 'authorization' => array( 'caller' => 'studio-web', 'scope' => 'artifact:write' ) ) ) );
 $GLOBALS['wp_codebox_current_user_can_manage_options'] = true;
 
 $artifact_abilities = array(
@@ -684,6 +691,61 @@ $assert( 'browser materializer contract preserves trusted authorization shape', 
 $assert( 'browser materializer contract returns same runnable recipe as duplicate session', ! is_wp_error( $browser_materializer_contract ) && ( $browser_session['recipe'] ?? array() ) === ( $browser_materializer_contract['recipe'] ?? array() ) );
 $assert( 'browser materializer contract returns same materialization descriptor as duplicate session', ! is_wp_error( $browser_materializer_contract ) && ( $browser_session['materialization'] ?? array() ) === ( $browser_materializer_contract['materialization'] ?? array() ) );
 $assert( 'browser materializer contract preserves runnable context for existing browser session', ! is_wp_error( $browser_materializer_contract ) && ( $browser_session['task_payload'] ?? array() ) === ( $browser_materializer_contract['task_payload'] ?? array() ) && ( $browser_session['playground'] ?? array() ) === ( $browser_materializer_contract['playground'] ?? array() ) && ( $browser_session['artifacts'] ?? array() ) === ( $browser_materializer_contract['artifacts'] ?? array() ) );
+
+$browser_task_contract_input = array_replace_recursive(
+	$browser_session_input,
+	array(
+		'phases' => array(
+			array(
+				'name'  => 'static-site-materializer',
+				'kind'  => 'materializer',
+				'input' => array(
+					'goal'           => 'Materialize generated browser artifacts.',
+					'browser_runner' => array(
+						'task_path'     => '/tmp/materializer-task.json',
+						'result_path'   => '/tmp/materializer-result.json',
+						'invocation'    => array(
+							'type' => 'task',
+							'hook' => 'caller_runtime_task',
+						),
+						'capture_paths' => array(
+							array(
+								'path'      => '/wordpress/wp-content/uploads/wp-codebox/artifacts/materializer/report.json',
+								'name'      => 'phase-report',
+								'kind'      => 'report',
+								'mime_type' => 'application/json',
+								'max_bytes' => 2048,
+							),
+						),
+					),
+				),
+			),
+		),
+	)
+);
+$browser_task_contract = call_user_func(
+	$browser_task_contract_ability['execute_callback'],
+	$browser_task_contract_input
+);
+$assert( 'browser task contract returns primary session and phases', ! is_wp_error( $browser_task_contract ) && true === ( $browser_task_contract['success'] ?? false ) && 'wp-codebox/browser-task-contract/v1' === ( $browser_task_contract['schema'] ?? '' ) && 'wp-codebox/browser-playground-session/v1' === ( $browser_task_contract['primary']['schema'] ?? '' ) && 1 === count( $browser_task_contract['phases'] ?? array() ) );
+$assert( 'browser task contract preserves primary browser session envelope', ! is_wp_error( $browser_task_contract ) && ( $browser_task_contract['primary']['session'] ?? array() ) === ( $browser_task_contract['session'] ?? array() ) && 'browser-session-123' === ( $browser_task_contract['session']['id'] ?? '' ) );
+$assert( 'browser task contract composes named materializer phase contract', ! is_wp_error( $browser_task_contract ) && 'static-site-materializer' === ( $browser_task_contract['phases'][0]['name'] ?? '' ) && 'materializer' === ( $browser_task_contract['phases'][0]['kind'] ?? '' ) && 'wp-codebox/browser-materializer-contract/v1' === ( $browser_task_contract['phases'][0]['contract']['schema'] ?? '' ) );
+$assert( 'browser task contract shares parent session id with materializer by default', ! is_wp_error( $browser_task_contract ) && 'browser-session-123' === ( $browser_task_contract['phases'][0]['contract']['session_id'] ?? '' ) && '/tmp/materializer-result.json' === ( $browser_task_contract['phases'][0]['contract']['materialization']['result_path'] ?? '' ) );
+
+$invalid_browser_task_contract = call_user_func(
+	$browser_task_contract_ability['execute_callback'],
+	array_replace_recursive(
+		$browser_session_input,
+		array(
+			'phases' => array(
+				array(
+					'kind' => 'host-task',
+				),
+			),
+		)
+	)
+);
+$assert( 'browser task contract rejects unsupported phase kinds', is_wp_error( $invalid_browser_task_contract ) && 'wp_codebox_browser_phase_kind_invalid' === $invalid_browser_task_contract->get_error_code() );
 
 $runner_report_path = $root . '/browser-materialization-report.json';
 add_filter(


### PR DESCRIPTION
## Summary
- Adds `wp-codebox/create-browser-task-contract` as a product-facing browser Playground contract that composes a primary browser session plus optional named phases.
- Supports generic `materializer` phases by reusing the existing browser materializer contract, sharing the parent session id by default, and preserving the disposable Playground/sandbox-bypass boundary.
- Extends plugin smoke coverage for registration, authorization, phase composition, session sharing, and unsupported phase rejection.

Refs #546.

## Proposed API shape
```json
{
  "goal": "Generate or transform a browser Playground artifact.",
  "authorization": {
    "schema": "wp-codebox/trusted-orchestrator-authorization/v1",
    "caller": "product-id",
    "scope": "browser-session:create"
  },
  "sandbox_session_id": "product-session-id",
  "runtime": {},
  "browser_runner": {},
  "phases": [
    {
      "name": "static-site-materializer",
      "kind": "materializer",
      "input": {
        "goal": "Materialize the generated artifact bundle.",
        "runtime": {},
        "browser_runner": {}
      }
    }
  ]
}
```

Returns `wp-codebox/browser-task-contract/v1`:
- `primary`: the normal `wp-codebox/browser-playground-session/v1` response.
- `phases[]`: named phase envelopes; materializer phases contain the existing `wp-codebox/browser-materializer-contract/v1` under `contract`.
- `session`: the primary session envelope for external orchestrator correlation.

## Verification
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `npm run build`
- `npm run wordpress-plugin-smoke` (`OK (369 assertions)`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the browser task contract ability, schema, smoke coverage, and verification steps for Chris to review.