### PR TITLE
Add browser connector request bridge

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/trait-wp-codebox-abilities-browser-artifacts.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-runtime.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-blueprint.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-runner.php';
+require_once __DIR__ . '/trait-wp-codebox-abilities-browser-connectors.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-utils.php';
 
 final class WP_Codebox_Abilities {
@@ -22,6 +23,7 @@ final class WP_Codebox_Abilities {
 	private const BROWSER_ARTIFACT_MAX_BYTES = 5242880;
 	private const BROWSER_CAPTURE_MAX_BYTES  = 262144;
 	private const BROWSER_SESSION_CREATE_SCOPE = 'browser-session:create';
+	private const BROWSER_CONNECTOR_REQUEST_SCOPE = 'browser-connector:request';
 	private const BROWSER_ARTIFACT_WRITE_SCOPE = 'artifact:write';
 
 	private static bool $registered = false;
@@ -34,6 +36,7 @@ final class WP_Codebox_Abilities {
 	use WP_Codebox_Abilities_Browser_Runtime;
 	use WP_Codebox_Abilities_Browser_Blueprint;
 	use WP_Codebox_Abilities_Browser_Runner;
+	use WP_Codebox_Abilities_Browser_Connectors;
 	use WP_Codebox_Abilities_Utils;
 
 	public function __construct() {
@@ -554,6 +557,20 @@ final class WP_Codebox_Abilities {
 					'output_schema'       => self::browser_materializer_contract_schema(),
 					'execute_callback'    => array( self::class, 'create_browser_materializer_contract' ),
 					'permission_callback' => array( self::class, 'can_create_browser_playground_session' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/browser-connector-request',
+				array(
+					'label'               => 'Run Browser Connector Request',
+					'description'         => 'Resolve connector credentials server-side and dispatch a generic browser connector request without exposing raw secrets to the browser sandbox.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::browser_connector_request_schema(),
+					'output_schema'       => self::browser_connector_response_schema(),
+					'execute_callback'    => array( self::class, 'browser_connector_request' ),
+					'permission_callback' => array( self::class, 'can_request_browser_connector' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-connectors.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-connectors.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * WP_Codebox_Abilities_Browser_Connectors implementation.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+trait WP_Codebox_Abilities_Browser_Connectors {
+	/** @return array<string,mixed> */
+	private static function browser_connector_request_schema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'connector', 'operation' ),
+			'properties' => array(
+				'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/browser-connector-request/v1' ),
+				'connector'    => array( 'type' => 'string' ),
+				'provider'     => array( 'type' => 'string' ),
+				'model'        => array( 'type' => 'string' ),
+				'operation'    => array( 'type' => 'string' ),
+				'payload'      => array( 'type' => 'object' ),
+				'session'      => array( 'type' => 'object' ),
+				'context'      => array( 'type' => 'object' ),
+				'authorization' => self::trusted_orchestrator_authorization_schema( self::BROWSER_CONNECTOR_REQUEST_SCOPE, 'Explicit trusted orchestrator authorization for browser connector requests. Callers must provide a caller id and the browser-connector:request scope; sites grant trust through wp_codebox_trusted_browser_session_callers.' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function browser_connector_response_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'     => array( 'type' => 'boolean' ),
+				'schema'      => array( 'type' => 'string', 'const' => 'wp-codebox/browser-connector-response/v1' ),
+				'status'      => array( 'type' => 'string' ),
+				'connector'   => array( 'type' => 'string' ),
+				'provider'    => array( 'type' => 'string' ),
+				'model'       => array( 'type' => 'string' ),
+				'operation'   => array( 'type' => 'string' ),
+				'response'    => array( 'type' => 'object' ),
+				'error'       => array( 'type' => 'object' ),
+				'credentials' => array( 'type' => 'object' ),
+				'audit'       => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function browser_connector_request( array $input ): array|WP_Error {
+		$connector_name = trim( (string) ( $input['connector'] ?? '' ) );
+		$operation      = trim( (string) ( $input['operation'] ?? '' ) );
+		if ( '' === $connector_name || '' === $operation ) {
+			return new WP_Error( 'wp_codebox_browser_connector_request_invalid', 'Browser connector requests require connector and operation.', array( 'status' => 400, 'schema' => 'wp-codebox/browser-connector-response/v1' ) );
+		}
+
+		$raw_resolution = self::browser_connector_raw_resolution( $connector_name, $input );
+		$inheritance_payload = self::browser_inheritance_resolution_payload( array( 'inherit' => array( 'connectors' => array( $connector_name ) ) ) );
+		if ( is_wp_error( $inheritance_payload ) ) {
+			$error_data       = $inheritance_payload->get_error_data();
+			$error_connectors = is_array( $error_data['connectors'] ?? null ) ? $error_data['connectors'] : array();
+			$error_connector  = is_array( $error_connectors[0] ?? null ) ? $error_connectors[0] : array();
+			return self::browser_connector_error_response( $input, $connector_name, $operation, $inheritance_payload, $error_connector );
+		}
+
+		$connector = self::browser_resolved_connector( $inheritance_payload['inheritance']['connectors'] ?? array(), $connector_name );
+		if ( empty( $connector ) || 'resolved' !== (string) ( $connector['status'] ?? '' ) ) {
+			return self::browser_connector_error_response( $input, $connector_name, $operation, new WP_Error( 'wp_codebox_browser_connector_unresolved', 'Requested browser connector is not available for this scope.', array( 'status' => 403 ) ) );
+		}
+
+		$provider = trim( (string) ( $input['provider'] ?? $connector['provider'] ?? '' ) );
+		$model    = trim( (string) ( $input['model'] ?? $connector['model'] ?? '' ) );
+		if ( '' !== trim( (string) ( $connector['provider'] ?? '' ) ) && '' !== $provider && $provider !== (string) $connector['provider'] ) {
+			return self::browser_connector_error_response( $input, $connector_name, $operation, new WP_Error( 'wp_codebox_browser_connector_provider_mismatch', 'Browser connector request provider does not match the resolved connector provider.', array( 'status' => 403 ) ) );
+		}
+		if ( '' !== trim( (string) ( $connector['model'] ?? '' ) ) && '' !== $model && $model !== (string) $connector['model'] ) {
+			return self::browser_connector_error_response( $input, $connector_name, $operation, new WP_Error( 'wp_codebox_browser_connector_model_mismatch', 'Browser connector request model does not match the resolved connector model.', array( 'status' => 403 ) ) );
+		}
+
+		$credential_values = self::browser_connector_secret_values( $connector, $raw_resolution );
+		if ( empty( $credential_values ) ) {
+			return self::browser_connector_error_response( $input, $connector_name, $operation, new WP_Error( 'wp_codebox_browser_connector_credentials_unavailable', 'Requested browser connector credentials are unavailable for this scope.', array( 'status' => 403 ) ) );
+		}
+
+		$request = array(
+			'schema'      => 'wp-codebox/browser-connector-request/v1',
+			'connector'   => $connector_name,
+			'provider'    => $provider,
+			'model'       => $model,
+			'operation'   => $operation,
+			'payload'     => is_array( $input['payload'] ?? null ) ? $input['payload'] : array(),
+			'session'     => is_array( $input['session'] ?? null ) ? $input['session'] : array(),
+			'context'     => is_array( $input['context'] ?? null ) ? $input['context'] : array(),
+			'credentials' => $credential_values,
+			'audit'       => self::browser_connector_audit( $input, $connector, $operation ),
+		);
+
+		$response = apply_filters( 'wp_codebox_browser_connector_request', null, $request, $input );
+		if ( null === $response ) {
+			return self::browser_connector_error_response( $input, $connector_name, $operation, new WP_Error( 'wp_codebox_browser_connector_handler_missing', 'No browser connector request handler is registered.', array( 'status' => 501 ) ), $connector );
+		}
+
+		return self::sanitize_browser_connector_response( $response, $connector, $operation, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>> */
+	private static function browser_connector_raw_resolution( string $connector_name, array $input ): array {
+		$resolution = array(
+			'connectors' => array(
+				array(
+					'name'   => $connector_name,
+					'status' => 'unresolved',
+				),
+			),
+			'settings'   => array(),
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'wp_codebox_resolve_inheritance', $resolution, array( 'connectors' => array( $connector_name ), 'settings' => array() ), $input );
+			if ( is_array( $filtered ) ) {
+				$resolution = $filtered;
+			}
+		}
+
+		return array_values( array_filter( is_array( $resolution['connectors'] ?? null ) ? $resolution['connectors'] : array(), 'is_array' ) );
+	}
+
+	/** @param array<int,array<string,mixed>> $connectors Resolved connectors. @return array<string,mixed> */
+	private static function browser_resolved_connector( array $connectors, string $connector_name ): array {
+		foreach ( $connectors as $connector ) {
+			if ( $connector_name === (string) ( $connector['name'] ?? '' ) ) {
+				return $connector;
+			}
+		}
+
+		return array();
+	}
+
+	/** @param array<string,mixed> $connector Resolved connector. @return array<string,string> */
+	private static function browser_connector_secret_values( array $connector, array $raw_connectors ): array {
+		$values = array();
+		foreach ( $raw_connectors as $raw_connector ) {
+			if ( (string) ( $connector['name'] ?? '' ) === (string) ( $raw_connector['name'] ?? '' ) ) {
+				$values = is_array( $raw_connector['secret_env_values'] ?? null ) ? $raw_connector['secret_env_values'] : ( is_array( $raw_connector['secretEnvValues'] ?? null ) ? $raw_connector['secretEnvValues'] : array() );
+				break;
+			}
+		}
+		$allowed = self::browser_inheritance_secret_env_names( array( 'connectors' => array( $connector ), 'settings' => array() ) );
+		$secrets = array();
+		foreach ( $allowed as $name ) {
+			if ( isset( $values[ $name ] ) && '' !== (string) $values[ $name ] ) {
+				$secrets[ $name ] = (string) $values[ $name ];
+			}
+		}
+
+		return $secrets;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $connector Resolved connector. @return array<string,mixed> */
+	private static function browser_connector_audit( array $input, array $connector, string $operation ): array {
+		$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
+		return array(
+			'schema'              => 'wp-codebox/browser-connector-audit/v1',
+			'operation'           => $operation,
+			'credential_status'   => (string) ( $credentials['status'] ?? 'missing' ),
+			'credential_names'    => self::browser_inheritance_secret_env_names( array( 'connectors' => array( $connector ), 'settings' => array() ) ),
+			'authorization'       => self::trusted_orchestrator_authorization( $input, self::BROWSER_CONNECTOR_REQUEST_SCOPE ),
+			'secrets_redacted'    => true,
+			'generated_by'        => 'wp-codebox/browser-connector-request',
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $connector Resolved connector. @return array<string,mixed> */
+	private static function browser_connector_error_response( array $input, string $connector_name, string $operation, WP_Error $error, array $connector = array() ): array {
+		return array(
+			'success'     => false,
+			'schema'      => 'wp-codebox/browser-connector-response/v1',
+			'status'      => 'failed-closed',
+			'connector'   => $connector_name,
+			'provider'    => (string) ( $input['provider'] ?? $connector['provider'] ?? '' ),
+			'model'       => (string) ( $input['model'] ?? $connector['model'] ?? '' ),
+			'operation'   => $operation,
+			'credentials' => is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array(),
+			'error'       => array(
+				'code'    => $error->get_error_code(),
+				'message' => $error->get_error_message(),
+			),
+			'audit'       => self::browser_connector_audit( $input, $connector, $operation ),
+		);
+	}
+
+	/** @param mixed $response Filter response. @param array<string,mixed> $connector Resolved connector. @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private static function sanitize_browser_connector_response( mixed $response, array $connector, string $operation, array $input ): array {
+		$response = is_array( $response ) ? $response : array( 'value' => $response );
+		unset( $response['credentials'], $response['secret_env_values'], $response['_secretEnvValues'] );
+
+		return array_filter(
+			array(
+				'success'     => true,
+				'schema'      => 'wp-codebox/browser-connector-response/v1',
+				'status'      => 'completed',
+				'connector'   => (string) ( $connector['name'] ?? '' ),
+				'provider'    => (string) ( $input['provider'] ?? $connector['provider'] ?? '' ),
+				'model'       => (string) ( $input['model'] ?? $connector['model'] ?? '' ),
+				'operation'   => $operation,
+				'response'    => $response,
+				'credentials' => is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array(),
+				'audit'       => self::browser_connector_audit( $input, $connector, $operation ),
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-permissions.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-permissions.php
@@ -52,6 +52,22 @@ public static function can_persist_browser_artifact( mixed $input = null ): bool
 	return true === ( $authorization['authorized'] ?? false );
 }
 
+/** @param mixed $input Ability input or request-like object. */
+public static function can_request_browser_connector( mixed $input = null ): bool {
+	if ( current_user_can( 'manage_options' ) ) {
+		return true;
+	}
+
+	$input = self::permission_input_array( $input );
+	if ( empty( $input ) ) {
+		return false;
+	}
+
+	$authorization = self::trusted_orchestrator_authorization( $input, self::BROWSER_CONNECTOR_REQUEST_SCOPE );
+
+	return true === ( $authorization['authorized'] ?? false );
+}
+
 /** @param mixed $input Ability input or request-like object. @return array<string,mixed> */
 private static function permission_input_array( mixed $input ): array {
 	if ( is_array( $input ) ) {

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -391,6 +391,12 @@ $assert( 'browser materializer contract ability is REST visible', true === ( $br
 $assert( 'browser materializer contract accepts goal or legacy task', array( 'goal' ) === ( $browser_materializer_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_materializer_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
 $assert( 'browser materializer contract exposes recipe materialization and authorization output', 'object' === ( $browser_materializer_ability['output_schema']['properties']['recipe']['type'] ?? '' ) && 'object' === ( $browser_materializer_ability['output_schema']['properties']['materialization']['type'] ?? '' ) && 'object' === ( $browser_materializer_ability['output_schema']['properties']['authorization']['type'] ?? '' ) );
 
+$browser_connector_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/browser-connector-request'] ?? null;
+$assert( 'browser connector request ability registered', is_array( $browser_connector_ability ) );
+$assert( 'browser connector request ability is REST visible', true === ( $browser_connector_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'browser connector request uses canonical schemas', 'wp-codebox/browser-connector-request/v1' === ( $browser_connector_ability['input_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/browser-connector-response/v1' === ( $browser_connector_ability['output_schema']['properties']['schema']['const'] ?? '' ) );
+$assert( 'browser connector request uses connector-specific authorization scope', array( 'browser-connector:request' ) === ( $browser_connector_ability['input_schema']['properties']['authorization']['properties']['scope']['enum'] ?? array() ) );
+
 $trusted_browser_authorization = array(
 	'authorization' => array(
 		'schema' => 'wp-codebox/trusted-orchestrator-authorization/v1',
@@ -1025,6 +1031,81 @@ $assert( 'browser Playground session resolves inherited provider and model', ! i
 $assert( 'browser Playground session packages inherited provider plugin path', ! is_wp_error( $browser_inherited_session ) && 1 === count( array_filter( $browser_inherited_session['plugins'] ?? array(), static fn( array $plugin ): bool => 'ai-provider-inherited' === ( $plugin['slug'] ?? '' ) ) ) );
 $assert( 'browser Playground session embeds first-class browser task payload', ! is_wp_error( $browser_inherited_session ) && 'wp-codebox/browser-agent-task-payload/v1' === ( $browser_inherited_session['task_payload']['schema'] ?? '' ) && 'openai' === ( $browser_inherited_session['recipe']['browser']['task_payload']['provider'] ?? '' ) && 'gpt-5.5' === ( $browser_inherited_session['recipe']['browser']['task_payload']['model'] ?? '' ) );
 $assert( 'browser Playground session records inherited connector credential provenance without values', ! is_wp_error( $browser_inherited_session ) && 'wp-codebox/connector-credentials/v1' === ( $browser_inherited_session['inheritance']['connectors'][0]['credentials']['schema'] ?? '' ) && 'available' === ( $browser_inherited_session['task_payload']['inheritance']['connectors'][0]['credentials']['secrets'][0]['status'] ?? '' ) && str_contains( $browser_inherited_encoded, 'OPENAI_API_KEY' ) && ! str_contains( $browser_inherited_encoded, 'sk-browser-secret-value' ) && ! str_contains( $browser_inherited_encoded, 'secret_env_values' ) );
+$browser_connector_handler_saw_secret = false;
+$GLOBALS['wp_codebox_filters']['wp_codebox_browser_connector_request'] = function ( mixed $response, array $request ) use ( &$browser_connector_handler_saw_secret ): array {
+	$browser_connector_handler_saw_secret = 'sk-browser-secret-value' === ( $request['credentials']['OPENAI_API_KEY'] ?? '' );
+	return array(
+		'schema'            => 'caller/provider-response/v1',
+		'ok'                => true,
+		'credentials'       => $request['credentials'],
+		'secret_env_values' => $request['credentials'],
+	);
+};
+$browser_connector_response = is_array( $browser_connector_ability ) ? call_user_func(
+	$browser_connector_ability['execute_callback'],
+	array(
+		'schema'    => 'wp-codebox/browser-connector-request/v1',
+		'connector' => 'primary-ai',
+		'provider'  => 'openai',
+		'model'     => 'gpt-5.5',
+		'operation' => 'chat.completions.create',
+		'payload'   => array( 'messages' => array( array( 'role' => 'user', 'content' => 'hello' ) ) ),
+	)
+) : null;
+$browser_connector_response_encoded = ! is_wp_error( $browser_connector_response ) ? json_encode( $browser_connector_response, JSON_UNESCAPED_SLASHES ) : '';
+$assert( 'browser connector bridge dispatches available credential values only to server-side handler', ! is_wp_error( $browser_connector_response ) && true === ( $browser_connector_response['success'] ?? false ) && true === $browser_connector_handler_saw_secret );
+$assert( 'browser connector bridge response redacts credential values', ! is_wp_error( $browser_connector_response ) && 'wp-codebox/browser-connector-response/v1' === ( $browser_connector_response['schema'] ?? '' ) && 'available' === ( $browser_connector_response['credentials']['status'] ?? '' ) && str_contains( $browser_connector_response_encoded, 'OPENAI_API_KEY' ) && ! str_contains( $browser_connector_response_encoded, 'sk-browser-secret-value' ) && ! str_contains( $browser_connector_response_encoded, 'secret_env_values' ) );
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_browser_connector_request'] );
+$browser_connector_no_handler = is_array( $browser_connector_ability ) ? call_user_func(
+	$browser_connector_ability['execute_callback'],
+	array(
+		'connector' => 'primary-ai',
+		'provider'  => 'openai',
+		'model'     => 'gpt-5.5',
+		'operation' => 'chat.completions.create',
+	)
+) : null;
+$assert( 'browser connector bridge fails closed without handler', ! is_wp_error( $browser_connector_no_handler ) && false === ( $browser_connector_no_handler['success'] ?? true ) && 'failed-closed' === ( $browser_connector_no_handler['status'] ?? '' ) && 'wp_codebox_browser_connector_handler_missing' === ( $browser_connector_no_handler['error']['code'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ): array {
+	$resolution['connectors'] = array(
+		array(
+			'name'        => $request['connectors'][0] ?? 'primary-ai',
+			'status'      => 'resolved',
+			'provider'    => 'openai',
+			'model'       => 'gpt-5.5',
+			'credentials' => array(
+				'schema'  => 'wp-codebox/connector-credentials/v1',
+				'status'  => 'missing',
+				'secrets' => array( array( 'name' => 'OPENAI_API_KEY', 'status' => 'missing', 'reason' => 'not configured' ) ),
+			),
+		),
+	);
+	return $resolution;
+};
+$browser_connector_missing = is_array( $browser_connector_ability ) ? call_user_func( $browser_connector_ability['execute_callback'], array( 'connector' => 'primary-ai', 'operation' => 'chat.completions.create' ) ) : null;
+$assert( 'browser connector bridge fails closed for missing credentials', ! is_wp_error( $browser_connector_missing ) && false === ( $browser_connector_missing['success'] ?? true ) && 'failed-closed' === ( $browser_connector_missing['status'] ?? '' ) && 'wp_codebox_connector_credentials_unavailable' === ( $browser_connector_missing['error']['code'] ?? '' ) && 'missing' === ( $browser_connector_missing['credentials']['status'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_resolve_inheritance'] = function ( array $resolution, array $request ): array {
+	$resolution['connectors'] = array(
+		array(
+			'name'        => $request['connectors'][0] ?? 'primary-ai',
+			'status'      => 'resolved',
+			'provider'    => 'openai',
+			'model'       => 'gpt-5.5',
+			'secret_env_values' => array( 'OPENAI_API_KEY' => 'sk-denied-secret-value' ),
+			'credentials' => array(
+				'schema'  => 'wp-codebox/connector-credentials/v1',
+				'status'  => 'denied',
+				'secrets' => array( array( 'name' => 'OPENAI_API_KEY', 'status' => 'denied', 'reason' => 'scope denied' ) ),
+			),
+		),
+	);
+	return $resolution;
+};
+$browser_connector_denied = is_array( $browser_connector_ability ) ? call_user_func( $browser_connector_ability['execute_callback'], array( 'connector' => 'primary-ai', 'operation' => 'chat.completions.create' ) ) : null;
+$browser_connector_denied_encoded = ! is_wp_error( $browser_connector_denied ) ? json_encode( $browser_connector_denied, JSON_UNESCAPED_SLASHES ) : '';
+$assert( 'browser connector bridge fails closed for denied credentials without leaking values', ! is_wp_error( $browser_connector_denied ) && false === ( $browser_connector_denied['success'] ?? true ) && 'denied' === ( $browser_connector_denied['credentials']['status'] ?? '' ) && ! str_contains( $browser_connector_denied_encoded, 'sk-denied-secret-value' ) );
 $assert( 'browser Playground recipe defaults to agents chat invocation with embedded payload', ! is_wp_error( $browser_inherited_session ) && 'ability' === ( $browser_inherited_session['recipe']['browser']['invocation']['type'] ?? '' ) && 'agents/chat' === ( $browser_inherited_session['recipe']['browser']['invocation']['name'] ?? '' ) && str_contains( (string) ( $browser_inherited_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' ), 'wp_get_ability( $ability_name )' ) );
 $browser_runner_code = (string) ( $browser_inherited_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' );
 $assert( 'browser Playground recipe bypasses agents chat transcript permissions only inside sandbox', ! is_wp_error( $browser_inherited_session ) && str_contains( $browser_runner_code, 'agents_chat_permission' ) && str_contains( $browser_runner_code, 'agents_conversation_sessions_permission' ) && str_contains( $browser_runner_code, '$wp_codebox_is_playground' ) );


### PR DESCRIPTION
## Summary
- Adds a generic `wp-codebox/browser-connector-request` ability with `wp-codebox/browser-connector-request/v1` and `wp-codebox/browser-connector-response/v1` contracts.
- Re-resolves connector scope server-side, validates provider/model context, fails closed for missing/denied credentials or absent execution handlers, and dispatches provider work through the generic `wp_codebox_browser_connector_request` filter.
- Keeps raw connector secret values out of browser session payloads and bridge responses while smoke tests prove server-side handler access and response redaction.

## Follow-up
- Actual provider adapter execution remains connector-handler work for #545; this PR only adds the generic fail-closed bridge surface.

## Tests
- `php tests/smoke-wordpress-plugin.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the generic bridge implementation, smoke tests, and PR summary; Chris remains responsible for review and validation.