### PR TITLE
Set current user for browser runner abilities

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -196,6 +196,10 @@ private static function browser_agent_runner_php( array $task_input, string $ses
 $_GET[\'rest_route\'] = \'/wp-codebox/browser-runner\';
 require_once \'/wordpress/wp-load.php\';
 
+if ( function_exists( \'get_current_user_id\' ) && function_exists( \'wp_set_current_user\' ) && get_current_user_id() <= 0 ) {
+	wp_set_current_user( 1 );
+}
+
 $task_path = ' . var_export( $task_path, true ) . ';
 $result_path = ' . var_export( $result_path, true ) . ';
 $payload = ' . var_export( $default_payload, true ) . ';


### PR DESCRIPTION
## Summary
- Set a default current user inside the disposable browser Playground PHP runner when no user is present.
- Keeps browser-session `agents/chat` invocations aligned with the runner's existing bounded `user_id` input so generic runtime handlers have a safe WordPress user context.

## Verification
- `php tests/smoke-wordpress-plugin.php`
- `npm run build`
- Studio Web live eval using this branch moved past the prior `No user context available` browser generation failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Debugging the browser runner context failure, drafting the minimal runner fix, and running local verification. Chris remains responsible for review and merge.