### PR TITLE
Consume Agents API run outcomes in sandbox remediation

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -16,6 +16,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
 	private const REMEDIATION_OUTCOME_SCHEMA = 'wp-codebox/agent-sandbox-remediation-outcome/v1';
 	private const COMPLETION_OUTCOME_SCHEMA = 'wp-codebox/sandbox-completion-outcome/v1';
+	private const AGENTS_API_RUN_OUTCOME_SCHEMA = 'agents-api.run-outcome';
 	private const SANDBOX_TOOL_POLICY_SCHEMA = 'wp-codebox/sandbox-tool-policy/v1';
 	private const AGENTS_API_RUNTIME_ENVIRONMENT = 'environment';
 	private const AGENTS_API_RUNTIME_CAPABILITY_SCOPE = 'capability_scope';
@@ -1141,9 +1142,14 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
 	private function remediation_outcome( array $run, int $exit_code, string $output ): array {
-		$datamachine = $this->first_datamachine_metadata( $run );
-		$max_turns_reached = $this->recursive_truthy_key( $run, 'max_turns_reached' ) || true === ( $datamachine['max_turns_reached'] ?? false );
-		$provider_error = $this->provider_error_details( $run, $output );
+		$run_outcome = $this->agents_api_run_outcome( $run );
+		$has_run_outcome = ! empty( $run_outcome );
+		$datamachine = $has_run_outcome ? array() : $this->first_datamachine_metadata( $run );
+		$run_status = (string) ( $run_outcome['status'] ?? '' );
+		$stop_reason = (string) ( $run_outcome['stop_reason'] ?? '' );
+		$max_turns_reached = $has_run_outcome ? 'max_turns' === $stop_reason : ( $this->recursive_truthy_key( $run, 'max_turns_reached' ) || true === ( $datamachine['max_turns_reached'] ?? false ) );
+		$pending_runtime_tool = $has_run_outcome && ( 'runtime_tool_pending' === $run_status || 'runtime_tool_pending' === $stop_reason );
+		$provider_error = $has_run_outcome ? $this->agents_api_provider_error_details( $run_outcome ) : $this->provider_error_details( $run, $output );
 		$pr_url = $this->first_url_for_keys( $run, array( 'pr_url', 'pull_request_url', 'pullRequestUrl' ) );
 		$false_positive_pr_url = $this->first_url_for_keys( $run, array( 'false_positive_pr_url', 'falsePositivePrUrl' ) );
 		$artifact = $this->remediation_artifact_details( $run );
@@ -1159,6 +1165,10 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'retryable'   => false,
 			'diagnostics' => array_filter(
 				array(
+					'agents_api_status'      => $has_run_outcome ? $run_status : null,
+					'agents_api_stop_reason' => $has_run_outcome ? $stop_reason : null,
+					'agents_api_completed'   => $has_run_outcome && array_key_exists( 'completed', $run_outcome ) ? (bool) $run_outcome['completed'] : null,
+					'pending_runtime_tool'   => $has_run_outcome ? $pending_runtime_tool : null,
 					'datamachine_completed' => array_key_exists( 'completed', $datamachine ) ? (bool) $datamachine['completed'] : null,
 					'max_turns_reached'     => $max_turns_reached,
 				),
@@ -1166,7 +1176,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			),
 		);
 
-		if ( ! empty( $datamachine ) ) {
+		if ( $has_run_outcome ) {
+			$outcome['metadata'] = array( 'agents_api' => array( 'run_outcome' => $run_outcome ) );
+		} elseif ( ! empty( $datamachine ) ) {
 			$outcome['metadata'] = array( 'datamachine' => $datamachine );
 		}
 
@@ -1209,20 +1221,28 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return $outcome;
 		}
 
+		if ( $pending_runtime_tool ) {
+			$outcome['success'] = false;
+			$outcome['kind'] = 'runtime_tool_pending';
+			$outcome['failure'] = 'runtime_tool_pending';
+			$outcome['retryable'] = (bool) ( $run_outcome['retryable'] ?? false );
+			return $outcome;
+		}
+
 		if ( $max_turns_reached ) {
 			$outcome['success'] = false;
 			$outcome['kind'] = 'max_turns_exceeded';
 			$outcome['failure'] = 'max_turns_exceeded';
-			$outcome['retryable'] = true;
+			$outcome['retryable'] = $has_run_outcome ? (bool) ( $run_outcome['retryable'] ?? true ) : true;
 			return $outcome;
 		}
 
-		if ( 0 !== $exit_code || ! empty( $provider_error ) ) {
+		if ( ( $has_run_outcome && 'failed' === $run_status ) || 0 !== $exit_code || ! empty( $provider_error ) ) {
 			$outcome['success'] = false;
 			$outcome['kind'] = 'provider_error';
 			$outcome['failure'] = 'provider_error';
 			$outcome['provider_error'] = $provider_error;
-			$outcome['retryable'] = (bool) ( $provider_error['retryable'] ?? true );
+			$outcome['retryable'] = $has_run_outcome ? (bool) ( $run_outcome['retryable'] ?? true ) : (bool) ( $provider_error['retryable'] ?? true );
 			return $outcome;
 		}
 
@@ -1232,6 +1252,33 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return $outcome;
+	}
+
+	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
+	private function agents_api_run_outcome( array $run ): array {
+		foreach ( array_merge( array( $run ), $this->agent_payloads( $run ) ) as $payload ) {
+			$outcome = is_array( $payload['run_outcome'] ?? null ) ? $payload['run_outcome'] : array();
+			if ( self::AGENTS_API_RUN_OUTCOME_SCHEMA === ( $outcome['schema'] ?? '' ) ) {
+				return $outcome;
+			}
+		}
+
+		return array();
+	}
+
+	/** @param array<string,mixed> $run_outcome Stable Agents API run outcome. @return array<string,mixed> */
+	private function agents_api_provider_error_details( array $run_outcome ): array {
+		$provider_error = is_array( $run_outcome['provider_error'] ?? null ) ? $run_outcome['provider_error'] : array();
+		if ( empty( $provider_error ) && is_array( $run_outcome['failure'] ?? null ) ) {
+			$provider_error = $run_outcome['failure'];
+		}
+
+		if ( empty( $provider_error ) ) {
+			return array();
+		}
+
+		$provider_error['retryable'] = (bool) ( $run_outcome['retryable'] ?? ( $provider_error['retryable'] ?? true ) );
+		return $provider_error;
 	}
 
 	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -207,11 +207,11 @@ private static function remediation_outcome_schema(): array {
 			'success'               => array( 'type' => 'boolean' ),
 			'kind'                  => array(
 				'type' => 'string',
-				'enum' => array( 'fix_artifact', 'false_positive_artifact', 'noop_artifact', 'unable_to_remediate', 'fix_pr', 'false_positive_pr', 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded' ),
+				'enum' => array( 'fix_artifact', 'false_positive_artifact', 'noop_artifact', 'unable_to_remediate', 'fix_pr', 'false_positive_pr', 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded', 'runtime_tool_pending' ),
 			),
 			'failure'               => array(
 				'type' => 'string',
-				'enum' => array( 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded', '' ),
+				'enum' => array( 'provider_error', 'agent_no_pr_outcome', 'max_turns_exceeded', 'runtime_tool_pending', '' ),
 			),
 			'pr_url'                => array( 'type' => 'string' ),
 			'false_positive_pr_url' => array( 'type' => 'string' ),

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -2181,21 +2181,37 @@ $remediation_run = function ( array $agent_payload, int $exit_code = 0, array $r
 
 $provider_error_result = $remediation_run(
 	array(
-		'error'    => array(
-			'message' => 'Provider timeout after OpenAI 429 Too Many Requests.',
-			'code'    => 'provider_rate_limited',
-		),
-		'metadata' => array(
-			'datamachine' => array(
-				'completed'         => false,
-				'max_turns_reached' => false,
+		'run_outcome' => array(
+			'schema'         => 'agents-api.run-outcome',
+			'version'        => 1,
+			'status'         => 'failed',
+			'completed'      => false,
+			'stop_reason'    => 'provider_error',
+			'retryable'      => true,
+			'provider_error' => array(
+				'message' => 'Provider timeout after OpenAI 429 Too Many Requests.',
+				'type'    => 'provider_rate_limited',
 			),
 		),
 	),
 	1
 );
 $assert( 'strict remediation outcome classifies provider timeout and 429', ! is_wp_error( $provider_error_result ) && false === ( $provider_error_result['success'] ?? true ) && 'provider_error' === ( $provider_error_result['outcome']['kind'] ?? '' ) && true === ( $provider_error_result['outcome']['retryable'] ?? false ) );
-$assert( 'strict remediation outcome preserves provider and Data Machine diagnostics', ! is_wp_error( $provider_error_result ) && str_contains( $provider_error_result['outcome']['provider_error']['message'] ?? '', 'Provider timeout' ) && false === ( $provider_error_result['outcome']['metadata']['datamachine']['completed'] ?? true ) );
+$assert( 'strict remediation outcome preserves provider and Agents API diagnostics', ! is_wp_error( $provider_error_result ) && str_contains( $provider_error_result['outcome']['provider_error']['message'] ?? '', 'Provider timeout' ) && false === ( $provider_error_result['outcome']['metadata']['agents_api']['run_outcome']['completed'] ?? true ) && 'provider_error' === ( $provider_error_result['outcome']['diagnostics']['agents_api_stop_reason'] ?? '' ) );
+
+$pending_runtime_tool_result = $remediation_run(
+	array(
+		'run_outcome' => array(
+			'schema'      => 'agents-api.run-outcome',
+			'version'     => 1,
+			'status'      => 'runtime_tool_pending',
+			'completed'   => false,
+			'stop_reason' => 'runtime_tool_pending',
+			'retryable'   => false,
+		),
+	)
+);
+$assert( 'strict remediation outcome preserves pending runtime tools', ! is_wp_error( $pending_runtime_tool_result ) && false === ( $pending_runtime_tool_result['success'] ?? true ) && 'runtime_tool_pending' === ( $pending_runtime_tool_result['outcome']['kind'] ?? '' ) && false === ( $pending_runtime_tool_result['outcome']['retryable'] ?? true ) && true === ( $pending_runtime_tool_result['outcome']['diagnostics']['pending_runtime_tool'] ?? false ) );
 
 $text_false_positive_result = $remediation_run(
 	array(
@@ -2212,6 +2228,21 @@ $normal_no_pr_result = $remediation_run(
 	)
 );
 $assert( 'strict remediation outcome returns unable-to-remediate terminal outcome without artifact', ! is_wp_error( $normal_no_pr_result ) && true === ( $normal_no_pr_result['success'] ?? false ) && 'unable_to_remediate' === ( $normal_no_pr_result['outcome']['kind'] ?? '' ) );
+
+$completed_run_outcome_result = $remediation_run(
+	array(
+		'answer'      => 'Done.',
+		'run_outcome' => array(
+			'schema'      => 'agents-api.run-outcome',
+			'version'     => 1,
+			'status'      => 'completed',
+			'completed'   => true,
+			'stop_reason' => 'natural',
+			'retryable'   => false,
+		),
+	)
+);
+$assert( 'strict remediation outcome preserves completed Agents API outcome', ! is_wp_error( $completed_run_outcome_result ) && true === ( $completed_run_outcome_result['success'] ?? false ) && 'unable_to_remediate' === ( $completed_run_outcome_result['outcome']['kind'] ?? '' ) && true === ( $completed_run_outcome_result['outcome']['diagnostics']['agents_api_completed'] ?? false ) && 'natural' === ( $completed_run_outcome_result['outcome']['diagnostics']['agents_api_stop_reason'] ?? '' ) );
 
 $fix_artifact_result = $remediation_run(
 	array(
@@ -2234,11 +2265,18 @@ $assert( 'strict remediation outcome accepts changed false-positive artifact', !
 
 $max_turns_result = $remediation_run(
 	array(
-		'answer'   => 'Still working.',
-		'metadata' => array( 'datamachine' => array( 'completed' => false, 'max_turns_reached' => true ) ),
+		'answer'      => 'Still working.',
+		'run_outcome' => array(
+			'schema'      => 'agents-api.run-outcome',
+			'version'     => 1,
+			'status'      => 'incomplete',
+			'completed'   => false,
+			'stop_reason' => 'max_turns',
+			'retryable'   => true,
+		),
 	)
 );
-$assert( 'strict remediation outcome preserves max turns exhaustion', ! is_wp_error( $max_turns_result ) && false === ( $max_turns_result['success'] ?? true ) && 'max_turns_exceeded' === ( $max_turns_result['outcome']['kind'] ?? '' ) && true === ( $max_turns_result['outcome']['diagnostics']['max_turns_reached'] ?? false ) );
+$assert( 'strict remediation outcome preserves max turns exhaustion from Agents API outcome', ! is_wp_error( $max_turns_result ) && false === ( $max_turns_result['success'] ?? true ) && 'max_turns_exceeded' === ( $max_turns_result['outcome']['kind'] ?? '' ) && true === ( $max_turns_result['outcome']['diagnostics']['max_turns_reached'] ?? false ) && 'max_turns' === ( $max_turns_result['outcome']['diagnostics']['agents_api_stop_reason'] ?? '' ) );
 
 $parent_only_tool = $runner->run(
 	array(


### PR DESCRIPTION
## Summary
- Prefer stable Agents API `run_outcome` envelopes when deriving strict sandbox remediation outcomes.
- Preserve completed, pending runtime tool, max-turn, provider-error, and retryability state without parsing Data Machine metadata when `run_outcome` is present.
- Extend the remediation outcome schema with `runtime_tool_pending` and add smoke coverage for the stable outcome path.

Addresses #547.

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php && php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Audited the Agents API/WP Codebox contract boundary, drafted the Codebox consumption change and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.