### PR TITLE
Generalize browser runner artifact paths

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -406,8 +406,79 @@ foreach ( $candidates as $candidate ) {
 return array();
 }
 
-function wp_codebox_browser_discover_artifact_files( array $contract, string $root ): array {
-$base = \'/wordpress/wp-content/uploads/studio-web/\' . $root;
+function wp_codebox_browser_normalize_artifact_root( $root ): string {
+$root = rtrim( ltrim( str_replace( chr( 92 ), "/", (string) $root ), "/" ), "/" );
+if ( \'\' === $root || str_contains( $root, \'..\' ) ) {
+	return \'\';
+}
+
+return $root . \'/\';
+}
+
+function wp_codebox_browser_artifact_root( array $contract ): string {
+$root = wp_codebox_browser_normalize_artifact_root( $contract[\'root\'] ?? \'\' );
+return \'\' !== $root ? $root : \'wp-codebox-output/\';
+}
+
+function wp_codebox_browser_artifact_base_path( array $payload, array $contract, string $root ): string {
+$candidates = array(
+	$contract[\'artifact_base_path\'] ?? null,
+	$contract[\'base_path\'] ?? null,
+	$payload[\'task_input\'][\'context\'][\'output\'][\'artifact_base_path\'] ?? null,
+	$payload[\'task_input\'][\'context\'][\'output\'][\'base_path\'] ?? null,
+	$payload[\'playground\'][\'artifact_base_path\'] ?? null,
+);
+$bundle_root = (string) ( $payload[\'task_input\'][\'context\'][\'output\'][\'bundle_root\'] ?? \'\' );
+if ( \'\' !== $bundle_root ) {
+	$candidates[] = preg_replace( \'#/?\' . preg_quote( rtrim( $root, \'/\' ), \'#\' ) . \'/?$#\', \'\', $bundle_root );
+}
+
+foreach ( $candidates as $candidate ) {
+	$base = rtrim( str_replace( chr( 92 ), \'/\', (string) $candidate ), \'/\' );
+	if ( \'\' !== $base && str_starts_with( $base, \'/\' ) && ! str_contains( $base, \'..\' ) && preg_match( \'#^[A-Za-z0-9_./-]+$#\', $base ) ) {
+		return $base;
+	}
+}
+
+return \'/wordpress/wp-content/uploads/wp-codebox/artifacts\';
+}
+
+function wp_codebox_browser_artifact_base_url( array $payload, array $contract ): string {
+$candidates = array(
+	$contract[\'artifact_base_url\'] ?? null,
+	$contract[\'base_url\'] ?? null,
+	$payload[\'task_input\'][\'context\'][\'output\'][\'artifact_base_url\'] ?? null,
+	$payload[\'task_input\'][\'context\'][\'output\'][\'base_url\'] ?? null,
+	$payload[\'playground\'][\'artifact_base_url\'] ?? null,
+);
+foreach ( $candidates as $candidate ) {
+	$base = rtrim( str_replace( chr( 92 ), \'/\', (string) $candidate ), \'/\' );
+	if ( \'\' !== $base && str_starts_with( $base, \'/\' ) && ! str_contains( $base, \'..\' ) ) {
+		return $base;
+	}
+}
+
+return \'/wp-content/uploads/wp-codebox/artifacts\';
+}
+
+function wp_codebox_browser_artifact_environment( array $payload ): array {
+$contract = wp_codebox_browser_artifact_contract( $payload );
+$root = wp_codebox_browser_artifact_root( $contract );
+$base_path = wp_codebox_browser_artifact_base_path( $payload, $contract, $root );
+$base_url = wp_codebox_browser_artifact_base_url( $payload, $contract );
+$entrypoint = wp_codebox_browser_safe_artifact_path( (string) ( $contract[\'entrypoint\'] ?? $root . \'index.html\' ), $root );
+
+return array(
+	\'contract\' => $contract,
+	\'root\' => $root,
+	\'base_path\' => $base_path,
+	\'base_url\' => $base_url,
+	\'entrypoint\' => $entrypoint,
+);
+}
+
+function wp_codebox_browser_discover_artifact_files( array $contract, string $root, string $base_path, string $base_url ): array {
+$base = rtrim( $base_path, \'/\' ) . \'/\' . $root;
 if ( ! is_dir( $base ) ) {
 	return array();
 }
@@ -423,6 +494,7 @@ foreach ( $iterator as $file ) {
 	$files[] = array(
 		\'path\'            => $relative,
 		\'playground_path\' => $absolute,
+		\'url_path\'        => rtrim( $base_url, \'/\' ) . \'/\' . $relative,
 	);
 }
 
@@ -430,24 +502,21 @@ return $files;
 }
 
 function wp_codebox_browser_capture_artifact_bundle( array $payload ) {
-$contract = wp_codebox_browser_artifact_contract( $payload );
+$environment = wp_codebox_browser_artifact_environment( $payload );
+$contract = $environment[\'contract\'];
 $schema = trim( (string) ( $contract[\'schema\'] ?? \'\' ) );
 if ( \'\' === $schema ) {
 	return array();
 }
 
-$root = (string) ( $contract[\'root\'] ?? \'\' );
-$root = rtrim( ltrim( str_replace( chr( 92 ), "/", $root ), "/" ), "/" ) . "/";
-if ( \'/\' === $root ) {
-	return array();
-}
-$entrypoint = wp_codebox_browser_safe_artifact_path( (string) ( $contract[\'entrypoint\'] ?? $root . \'index.html\' ), $root );
+$root = $environment[\'root\'];
+$entrypoint = $environment[\'entrypoint\'];
 if ( \'\' === $entrypoint ) {
 	return array();
 }
 $contract_files = is_array( $contract[\'files\'] ?? null ) ? $contract[\'files\'] : array();
 if ( empty( $contract_files ) ) {
-	$contract_files = wp_codebox_browser_discover_artifact_files( $contract, $root );
+	$contract_files = wp_codebox_browser_discover_artifact_files( $contract, $root, $environment[\'base_path\'], $environment[\'base_url\'] );
 }
 
 $files = array();
@@ -498,19 +567,20 @@ return array_merge(
 }
 
 function wp_codebox_browser_artifact_capture_diagnostics( array $payload, array $artifact_bundle ) {
-$contract = wp_codebox_browser_artifact_contract( $payload );
-$root = (string) ( $contract[\'root\'] ?? \'\' );
-$root = rtrim( ltrim( str_replace( chr( 92 ), "/", $root ), "/" ), "/" ) . "/";
-$base = \'/wordpress/wp-content/uploads/studio-web/\' . $root;
-$entrypoint = wp_codebox_browser_safe_artifact_path( (string) ( $contract[\'entrypoint\'] ?? $root . \'index.html\' ), $root );
+$environment = wp_codebox_browser_artifact_environment( $payload );
+$contract = $environment[\'contract\'];
+$root = $environment[\'root\'];
+$base = rtrim( $environment[\'base_path\'], \'/\' ) . \'/\' . $root;
+$entrypoint = $environment[\'entrypoint\'];
 $contract_files = is_array( $contract[\'files\'] ?? null ) ? $contract[\'files\'] : array();
 
 return array_filter( array(
 	\'contract_schema\' => (string) ( $contract[\'schema\'] ?? \'\' ),
-	\'root\' => \'/\' === $root ? \'\' : $root,
-	\'base_exists\' => \'/\' !== $root && is_dir( $base ),
+	\'root\' => $root,
+	\'base_path\' => $environment[\'base_path\'],
+	\'base_exists\' => is_dir( $base ),
 	\'entrypoint\' => $entrypoint,
-	\'entrypoint_exists\' => \'\' !== $entrypoint && is_readable( \'/wordpress/wp-content/uploads/studio-web/\' . $entrypoint ),
+	\'entrypoint_exists\' => \'\' !== $entrypoint && is_readable( rtrim( $environment[\'base_path\'], \'/\' ) . \'/\' . $entrypoint ),
 	\'contract_file_count\' => count( $contract_files ),
 	\'captured_file_count\' => is_array( $artifact_bundle[\'files\'] ?? null ) ? count( $artifact_bundle[\'files\'] ) : 0,
 	\'captured\' => ! empty( $artifact_bundle ),
@@ -602,10 +672,14 @@ return $imports;
 
 class WP_Codebox_Browser_Filesystem_Write_Tool {
 	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		global $wp_codebox_browser_artifact_environment;
+		$environment = is_array( $wp_codebox_browser_artifact_environment ?? null ) ? $wp_codebox_browser_artifact_environment : array();
+		$root = (string) ( $environment[\'root\'] ?? \'wp-codebox-output/\' );
+		$base_path = rtrim( (string) ( $environment[\'base_path\'] ?? \'/wordpress/wp-content/uploads/wp-codebox/artifacts\' ), \'/\' );
 		$path = str_replace( chr( 92 ), \'/\', (string) ( $parameters[\'path\'] ?? \'\' ) );
 		$path = ltrim( preg_replace( \'#/+#\', \'/\', $path ), \'/\' );
-		if ( \'\' === $path || str_contains( $path, \'..\' ) || ! str_starts_with( $path, \'website/\' ) ) {
-			return array( \'success\' => false, \'error\' => \'Path must stay inside the website artifact bundle root.\' );
+		if ( \'\' === $path || str_contains( $path, \'..\' ) || ! str_starts_with( $path, $root ) ) {
+			return array( \'success\' => false, \'error\' => \'Path must stay inside the configured artifact bundle root.\', \'root\' => $root );
 		}
 
 		$content = (string) ( $parameters[\'content\'] ?? \'\' );
@@ -617,7 +691,7 @@ class WP_Codebox_Browser_Filesystem_Write_Tool {
 			$content = $decoded;
 		}
 
-		$absolute = \'/wordpress/wp-content/uploads/studio-web/\' . $path;
+		$absolute = $base_path . \'/\' . $path;
 		$directory = dirname( $absolute );
 		if ( ! is_dir( $directory ) && ! mkdir( $directory, 0777, true ) ) {
 			return array( \'success\' => false, \'error\' => \'Could not create artifact directory.\', \'path\' => $path );
@@ -635,6 +709,31 @@ class WP_Codebox_Browser_Filesystem_Write_Tool {
 		);
 	}
 }
+
+add_filter( \'wp_agent_runtime_resolved_tools\', function ( array $tools, $mode, array $args ) {
+	global $wp_codebox_browser_artifact_environment;
+	$environment = is_array( $wp_codebox_browser_artifact_environment ?? null ) ? $wp_codebox_browser_artifact_environment : array();
+	$root = (string) ( $environment[\'root\'] ?? \'wp-codebox-output/\' );
+	$base_path = rtrim( (string) ( $environment[\'base_path\'] ?? \'/wordpress/wp-content/uploads/wp-codebox/artifacts\' ), \'/\' );
+	$tools[\'filesystem-write\'] = array(
+		\'name\'        => \'filesystem-write\',
+		\'description\' => sprintf( \'Write one generated artifact file inside %s/%s. Call this once per file required by the caller artifact contract.\', $base_path, $root ),
+		\'class\'       => \'WP_Codebox_Browser_Filesystem_Write_Tool\',
+		\'method\'      => \'handle_tool_call\',
+		\'parameters\'  => array(
+			\'type\'       => \'object\',
+			\'required\'   => array( \'path\', \'content\' ),
+			\'properties\' => array(
+				\'path\'     => array( \'type\' => \'string\', \'description\' => sprintf( \'Relative artifact path under %s, for example %sindex.html.\', $root, $root ) ),
+				\'content\'  => array( \'type\' => \'string\', \'description\' => \'Full file contents. Use UTF-8 text unless encoding is base64.\' ),
+				\'encoding\' => array( \'type\' => \'string\', \'enum\' => array( \'utf-8\', \'base64\' ) ),
+			),
+		),
+		\'access_level\' => \'public\',
+		\'modes\'        => is_array( $mode ) ? $mode : array( (string) $mode ),
+	);
+	return $tools;
+}, 20, 3 );
 
 $wp_codebox_playground_root = defined( \'ABSPATH\' ) ? wp_normalize_path( ABSPATH ) : \'\';
 $wp_codebox_is_playground = \'/wordpress/\' === $wp_codebox_playground_root && ( \'Emscripten\' === PHP_OS_FAMILY || ( defined( \'WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER\' ) && WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER ) );
@@ -655,6 +754,7 @@ if ( is_array( $raw_payload ) ) {
 }
 }
 
+$wp_codebox_browser_artifact_environment = wp_codebox_browser_artifact_environment( $payload );
 wp_codebox_browser_install_provider_proxy( $payload );
 
 $agent = sanitize_key( (string) ( $payload[\'agent\'] ?? \'wp-codebox-sandbox\' ) );

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -865,6 +865,8 @@ add_filter(
 	10
 );
 $runner_php = (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' );
+$assert( 'browser Playground generated runner has no Studio Web-specific artifact paths', ! str_contains( $runner_php, '/wordpress/wp-content/uploads/studio-web' ) && ! str_contains( $runner_php, 'studio-web/website' ) );
+$assert( 'browser Playground generated runner defaults to generic Codebox artifacts path', str_contains( $runner_php, '/wordpress/wp-content/uploads/wp-codebox/artifacts' ) && str_contains( $runner_php, 'wp-codebox-output/' ) );
 $runner_php = preg_replace( '/^code=/', '', $runner_php ) ?? $runner_php;
 $runner_php = preg_replace( '/^<\?php\s*/', '', $runner_php ) ?? $runner_php;
 $runner_php = str_replace( "require_once '/wordpress/wp-load.php';", '', $runner_php );
@@ -938,6 +940,22 @@ $assert( 'browser Playground generated runner records diagnostics and provenance
 $assert( 'browser Playground generated runner captures caller-owned artifact schema', is_array( $runner_result ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['artifact_bundle']['schema'] ?? '' ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['response']['artifact_bundle']['schema'] ?? '' ) );
 $assert( 'browser Playground generated runner preserves caller artifact metadata and roles', is_array( $runner_result ) && array( 'non-studio-web' ) === ( $runner_result['artifact_bundle']['metadata']['labels'] ?? array() ) && array( 'preview' => 'generic-output/index.html' ) === ( $runner_result['artifact_bundle']['roles'] ?? array() ) && array( 'preview' ) === ( $runner_result['artifact_bundle']['files'][0]['roles'] ?? array() ) && 'entrypoint' === ( $runner_result['artifact_bundle']['files'][0]['metadata']['opaque'] ?? '' ) );
 $assert( 'browser Playground generated runner captures text and base64 artifact files', is_array( $runner_result ) && 2 === count( $runner_result['artifact_bundle']['files'] ?? array() ) && '<main>Generic caller artifact</main>' === ( $runner_result['artifact_bundle']['files'][0]['content'] ?? '' ) && 'utf-8' === ( $runner_result['artifact_bundle']['files'][0]['encoding'] ?? '' ) && 'base64' === ( $runner_result['artifact_bundle']['files'][1]['encoding'] ?? '' ) && hash( 'sha256', "\x89PNG\r\n\x1a\ngeneric" ) === ( $runner_result['artifact_bundle']['files'][1]['sha256'] ?? '' ) );
+$tool_artifact_base = rtrim( ABSPATH, '/' ) . '/wp-content/uploads/wp-codebox/artifacts';
+$tool_task_payload  = array(
+	'artifacts' => array(
+		'schema'     => 'caller/tool-written-browser-artifact-bundle/v1',
+		'root'       => 'tool-output',
+		'entrypoint' => 'tool-output/index.html',
+		'base_path'  => $tool_artifact_base,
+		'base_url'   => '/wp-content/uploads/wp-codebox/artifacts',
+	),
+);
+$GLOBALS['wp_codebox_browser_artifact_environment'] = function_exists( 'wp_codebox_browser_artifact_environment' ) ? wp_codebox_browser_artifact_environment( $tool_task_payload ) : array();
+$filesystem_write_tool = class_exists( 'WP_Codebox_Browser_Filesystem_Write_Tool' ) ? new WP_Codebox_Browser_Filesystem_Write_Tool() : null;
+$tool_write_result = $filesystem_write_tool ? $filesystem_write_tool->handle_tool_call( array( 'path' => 'tool-output/index.html', 'content' => '<main>Tool Output</main>' ) ) : array();
+$tool_capture = function_exists( 'wp_codebox_browser_capture_artifact_bundle' ) ? wp_codebox_browser_capture_artifact_bundle( $tool_task_payload ) : array();
+$assert( 'browser Playground filesystem-write uses caller artifact base and root', true === ( $tool_write_result['success'] ?? false ) && $tool_artifact_base . '/tool-output/index.html' === ( $tool_write_result['playground_path'] ?? '' ) );
+$assert( 'browser Playground artifact capture discovers caller-rooted files', 'caller/tool-written-browser-artifact-bundle/v1' === ( $tool_capture['schema'] ?? '' ) && 'tool-output/index.html' === ( $tool_capture['files'][0]['path'] ?? '' ) && '<main>Tool Output</main>' === ( $tool_capture['files'][0]['content'] ?? '' ) );
 $runner_missing_entrypoint = function_exists( 'wp_codebox_browser_capture_artifact_bundle' ) ? wp_codebox_browser_capture_artifact_bundle( array( 'artifacts' => array_merge( $runner_task_payload['artifacts'], array( 'entrypoint' => 'generic-output/missing.html' ) ) ) ) : array( 'missing_function' => true );
 $assert( 'browser Playground generated runner skips missing artifact entrypoints safely', array() === $runner_missing_entrypoint );
 $assert( 'browser Playground session emits ready-to-code signal only when blueprint prerequisites are present', ! is_wp_error( $browser_session ) && true === ( $browser_session['signals']['ready_to_code']['emitted'] ?? false ) && 'ready_to_code' === ( $browser_session['signals']['ready_to_code']['name'] ?? '' ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['agents_api'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['data_machine'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['data_machine_code'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['provider_secret'] ?? false ) && true === ( $browser_session['signals']['ready_to_code']['requirements']['runtime_dependencies'] ?? false ) );


### PR DESCRIPTION
## Summary
- Generalizes browser runner artifact capture and filesystem-write paths away from Studio Web-specific `/wp-content/uploads/studio-web` and `website/` assumptions.
- Resolves artifact base path, base URL, root, and entrypoint from the caller artifact contract, with generic WP Codebox defaults.
- Extends WordPress plugin smoke coverage to prove the generated runner has no Studio Web-specific artifact paths and can write/capture caller-rooted artifacts.

## Scope
This is the independently mergeable upstream artifact-path portion of #546. It intentionally leaves the compact product-facing task DTO and sandbox tool policy resolver/helper as follow-up API work so Studio Web can migrate in a separate downstream PR.

## Tests
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run sandbox-tool-policy-smoke`
- `npm run task-input-contract-smoke`
- `git diff --check HEAD~1..HEAD`

## Additional verification
- A long `npm run check` attempt progressed through build, command/host/tool/task/WordPress/plugin/package/runtime/recipe smokes, but the tool timed out during browser smoke sections.
- Continued tail checks passed through the final CLI probe.
- `npm run browser-actions-artifact-smoke` hangs independently for 15 minutes on this machine, so it was not completed.

## Remaining follow-up
- Add a compact/product response mode for `wp-codebox/create-browser-task-contract` so Studio Web does not need local REST payload compaction.
- Add a Codebox-owned sandbox tool policy resolver/helper so Studio Web can pass product-level allowed-tool intent instead of constructing `wp-codebox/sandbox-tool-policy/v1` directly.
- Migrate Studio Web #360 to consume the task contract/product DTO once those API pieces land.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the browser runner artifact path generalization and smoke coverage; Chris remains responsible for review and merge.