### PR TITLE
Add browser runtime contract probe

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -915,6 +915,213 @@ try {
 		} );
 	};
 
+	const browserRuntimeContractPhase = async ( phases, name, callback ) => {
+		const startedAt = Date.now();
+		try {
+			const data = await callback();
+			const phase = {
+				name,
+				status: 'passed',
+				duration_ms: Date.now() - startedAt,
+				...( data && typeof data === 'object' ? { data } : {} ),
+			};
+			phases.push( phase );
+			return phase;
+		} catch ( error ) {
+			const phase = {
+				name,
+				status: 'failed',
+				duration_ms: Date.now() - startedAt,
+				error: {
+					code: error?.code || 'phase_failed',
+					message: error?.message || String( error ),
+				},
+			};
+			phases.push( phase );
+			return phase;
+		}
+	};
+
+	const requireProbeSuccess = ( result, message ) => {
+		if ( ! result?.success ) {
+			throw new Error( result?.error?.message || message );
+		}
+
+		return result.data ?? null;
+	};
+
+	const withEchoBrowserProviderBridge = async ( callback ) => {
+		const previousWp = window.wp;
+		const previousApiFetch = window.wp?.apiFetch;
+		window.wp = window.wp && typeof window.wp === 'object' ? window.wp : {};
+		window.wp.apiFetch = async ( request ) => ( {
+			success: true,
+			response: {
+				schema: 'wp-codebox/browser-provider-adapter-response/v1',
+				http: {
+					status: 200,
+					body: JSON.stringify( {
+						id: 'wp-codebox-contract-probe-response',
+						status: 'completed',
+						output: [
+							{
+								type: 'message',
+								role: 'assistant',
+								content: [ { type: 'output_text', text: 'echo' } ],
+							},
+						],
+					} ),
+				},
+			},
+			audit: {
+				schema: 'wp-codebox/browser-provider-audit/v1',
+				operation: request?.data?.operation || 'responses.create',
+			},
+		} );
+
+		try {
+			return await callback();
+		} finally {
+			if ( previousWp === undefined ) {
+				delete window.wp;
+			} else {
+				window.wp = previousWp;
+				if ( previousApiFetch === undefined && window.wp && typeof window.wp === 'object' ) {
+					delete window.wp.apiFetch;
+				} else if ( window.wp && typeof window.wp === 'object' ) {
+					window.wp.apiFetch = previousApiFetch;
+				}
+			}
+		}
+	};
+
+	const runBrowserRuntimeContractProbe = async ( client, options = {} ) => {
+		const phases = [];
+		const artifactRoot = String( options.artifactRoot || '/wordpress/wp-content/uploads/wp-codebox/artifacts/contract-probe' );
+		const artifactFile = `${ artifactRoot.replace( /\/$/, '' ) }/tool-output.txt`;
+		const probeText = 'wp-codebox-browser-runtime-contract-probe';
+
+		await browserRuntimeContractPhase( phases, 'runtime-bootstrap', async () => {
+			const functions = [ 'runPhpRequest', 'runRecipe', 'runBrowserSessionRecipe', 'runWordPressOperation', 'writeFile' ];
+			const missing = functions.filter( ( name ) => typeof window.wpCodeboxBrowser?.[ name ] !== 'function' );
+			if ( missing.length > 0 ) {
+				throw new Error( `Missing browser runtime functions: ${ missing.join( ', ' ) }` );
+			}
+
+			return { schema: 'wp-codebox/browser-runtime-contract-phase/v1', functions };
+		} );
+
+		await browserRuntimeContractPhase( phases, 'php-execution', async () => {
+			const result = await runPhpRequest( client, {
+				code: "<?php echo wp_json_encode( array( 'success' => true, 'data' => array( 'phase' => 'php-execution' ), 'error' => null ) );",
+				expectJson: true,
+				name: 'codebox-contract-php-execution',
+			} );
+			if ( true !== result?.success ) {
+				throw new Error( 'PHP execution did not return success.' );
+			}
+
+			return { phase: result.data?.phase || '' };
+		} );
+
+		await browserRuntimeContractPhase( phases, 'playground-request-handler', async () => {
+			const result = await runPhpRequest( client, {
+				code: "<?php echo wp_json_encode( array( 'success' => true, 'data' => array( 'phase' => 'playground-request-handler' ), 'error' => null ) );",
+				expectJson: true,
+				forceRequest: true,
+				name: 'codebox-contract-request-handler',
+			} );
+			if ( true !== result?.success ) {
+				throw new Error( 'Playground request handler did not return success.' );
+			}
+
+			return { phase: result.data?.phase || '' };
+		} );
+
+		await browserRuntimeContractPhase( phases, 'runner-file-write-read', async () => {
+			const path = '/tmp/wp-codebox-contract-probe.txt';
+			requireProbeSuccess( await writeFile( client, { path, content: probeText }, { name: 'codebox-contract-file-write' } ), 'Runner file write failed.' );
+			const result = await runPhpRequest( client, {
+				code: `<?php $path = ${ JSON.stringify( path ) }; echo wp_json_encode( array( 'success' => is_readable( $path ), 'data' => array( 'path' => $path, 'sha256' => is_readable( $path ) ? hash( 'sha256', file_get_contents( $path ) ) : '' ), 'error' => null ) );`,
+				expectJson: true,
+				forceRequest: true,
+				name: 'codebox-contract-file-read',
+			} );
+			if ( true !== result?.success ) {
+				throw new Error( 'Runner file read failed.' );
+			}
+
+			return { path, sha256: result.data?.sha256 || '' };
+		} );
+
+		await browserRuntimeContractPhase( phases, 'provider-bridge-echo', async () => withEchoBrowserProviderBridge( async () => {
+			const result = await executeBrowserProviderProxyRequest( {
+				schema: browserProviderProxySchema,
+				id: 'wp-codebox-contract-probe-provider-request',
+				operation: 'responses.create',
+				provider: 'echo',
+				model: 'echo-probe',
+				connector: 'contract-probe',
+				request: {
+					method: 'POST',
+					uri: '/v1/responses',
+					body: JSON.stringify( { model: 'echo-probe', input: [ { role: 'user', content: 'echo' } ], tools: [] } ),
+				},
+			} );
+			if ( true !== result?.success ) {
+				throw new Error( result?.error?.message || 'Echo browser provider bridge failed.' );
+			}
+
+			const diagnostics = browserProviderDiagnostics();
+			return {
+				provider: 'echo',
+				status: result.response?.http?.status ?? null,
+				diagnostic_count: diagnostics.requests.length,
+			};
+		} ) );
+
+		await browserRuntimeContractPhase( phases, 'runtime-tool-artifact-write', async () => {
+			const data = requireProbeSuccess( await writeFile( client, { path: artifactFile, content: probeText }, { name: 'codebox-contract-artifact-write' } ), 'Artifact write failed.' );
+			return { path: data?.path || artifactFile, bytes: data?.bytes ?? null };
+		} );
+
+		await browserRuntimeContractPhase( phases, 'artifact-capture', async () => {
+			const result = await runPhpRequest( client, {
+				code: `<?php $path = ${ JSON.stringify( artifactFile ) }; $exists = is_readable( $path ); echo wp_json_encode( array( 'success' => $exists, 'data' => array( 'schema' => 'wp-codebox/browser-runtime-contract-artifact-capture/v1', 'files' => $exists ? array( array( 'path' => basename( $path ), 'sha256' => hash( 'sha256', file_get_contents( $path ) ), 'size' => filesize( $path ) ) ) : array() ), 'error' => $exists ? null : array( 'code' => 'artifact_missing', 'message' => 'Probe artifact was not readable.' ) ) );`,
+				expectJson: true,
+				forceRequest: true,
+				name: 'codebox-contract-artifact-capture',
+			} );
+			if ( true !== result?.success ) {
+				throw new Error( result?.error?.message || 'Artifact capture failed.' );
+			}
+
+			return result.data;
+		} );
+
+		await browserRuntimeContractPhase( phases, 'event-diagnostics', async () => {
+			const diagnostics = browserProviderDiagnostics();
+			return {
+				schema: diagnostics.schema,
+				provider_requests: diagnostics.requests.length,
+				bounded: diagnostics.requests.length <= 20,
+				failed_phases: phases.filter( ( phase ) => phase.status !== 'passed' ).map( ( phase ) => phase.name ),
+			};
+		} );
+
+		const failed = phases.filter( ( phase ) => phase.status !== 'passed' );
+		return {
+			schema: 'wp-codebox/browser-runtime-contract-probe/v1',
+			success: failed.length === 0,
+			status: failed.length === 0 ? 'passed' : 'failed',
+			phases,
+			errors: failed.map( ( phase ) => ( {
+				phase: phase.name,
+				...( phase.error || {} ),
+			} ) ),
+		};
+	};
+
 	window.wpCodeboxBrowser = {
 		activateTheme,
 		browserSessionRecipe,
@@ -922,6 +1129,7 @@ try {
 		installTheme,
 		normalizeOperationResult,
 		parseJsonResponse,
+		runBrowserRuntimeContractProbe,
 		runBrowserSessionRecipe,
 		runPhpRequest,
 		runRecipe,

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -1099,6 +1099,62 @@ try {
 			return result.data;
 		} );
 
+		await browserRuntimeContractPhase( phases, 'generated-runner-artifact-capture', async () => {
+			const recipeTaskPath = '/tmp/wp-codebox-contract-recipe-task.json';
+			const result = await runRecipe( client, {
+				browser: {
+					task_path: recipeTaskPath,
+				},
+				workflow: {
+					steps: [
+						{
+							command: 'wordpress.run-php',
+							args: [ `code=<?php
+$payload = array();
+if ( is_readable( '${ recipeTaskPath }' ) ) {
+	$raw_payload = json_decode( (string) file_get_contents( '${ recipeTaskPath }' ), true );
+	if ( is_array( $raw_payload ) ) {
+		$payload = $raw_payload;
+	}
+}
+$environment = wp_codebox_browser_artifact_environment( $payload );
+$artifact_bundle = wp_codebox_browser_capture_artifact_bundle( $payload );
+echo wp_json_encode( array(
+	'success' => ! empty( $environment ) && ! empty( $artifact_bundle ),
+	'data' => array(
+		'schema' => 'wp-codebox/browser-runtime-contract-generated-runner/v1',
+		'root' => $environment['root'] ?? '',
+		'artifact_schema' => $artifact_bundle['schema'] ?? '',
+		'file_count' => is_array( $artifact_bundle['files'] ?? null ) ? count( $artifact_bundle['files'] ) : 0,
+	),
+	'error' => null,
+) );` ],
+						},
+					],
+				},
+			}, {
+				artifacts: {
+					schema: 'wp-codebox/browser-runtime-contract-generated-artifact/v1',
+					root: 'contract-generated',
+					entrypoint: 'contract-generated/index.html',
+					files: [
+						{
+							path: 'contract-generated/index.html',
+							playground_path: '/wordpress/wp-content/uploads/wp-codebox/artifacts/contract-generated/index.html',
+							kind: 'html',
+							mime_type: 'text/html',
+						},
+					],
+				},
+			}, { name: 'codebox-contract-generated-runner' } );
+
+			if ( true !== result?.success ) {
+				throw new Error( result?.error?.message || 'Generated browser runner artifact capture failed.' );
+			}
+
+			return result.data;
+		} );
+
 		await browserRuntimeContractPhase( phases, 'event-diagnostics', async () => {
 			const diagnostics = browserProviderDiagnostics();
 			return {

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -12,8 +12,17 @@ const context = {
 	TextEncoder,
 	TextDecoder,
   window: {} as { wpCodeboxBrowser?: any },
+  CustomEvent: class CustomEvent {
+    type: string
+    detail: unknown
+    constructor(type: string, init: { detail?: unknown } = {}) {
+      this.type = type
+      this.detail = init.detail
+    }
+  },
   btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
 }
+context.window.dispatchEvent = () => true
 
 vm.runInNewContext(runtimeSource, context)
 
@@ -22,6 +31,7 @@ assert.ok(runtime, "browser runtime should attach window.wpCodeboxBrowser")
 assert.equal(typeof runtime.runPhpRequest, "function")
 assert.equal(typeof runtime.runRecipe, "function")
 assert.equal(typeof runtime.runBrowserSessionRecipe, "function")
+assert.equal(typeof runtime.runBrowserRuntimeContractProbe, "function")
 assert.equal(typeof runtime.browserSessionRecipe, "function")
 assert.equal(typeof runtime.runWordPressOperation, "function")
 assert.equal(typeof runtime.ensureDirectory, "function")
@@ -349,6 +359,27 @@ await assert.rejects(
   /WordPress browser operation must include a type/
 )
 
+const probeClient = createContractProbeClient()
+const probeResult = await runtime.runBrowserRuntimeContractProbe(probeClient)
+assert.equal(probeResult.schema, "wp-codebox/browser-runtime-contract-probe/v1")
+assert.equal(probeResult.success, true)
+assert.deepEqual(sameRealm(probeResult.phases.map((phase: { name: string }) => phase.name)), [
+  "runtime-bootstrap",
+  "php-execution",
+  "playground-request-handler",
+  "runner-file-write-read",
+  "provider-bridge-echo",
+  "runtime-tool-artifact-write",
+  "artifact-capture",
+  "event-diagnostics",
+])
+assert.equal(probeResult.phases.every((phase: { status: string }) => phase.status === "passed"), true)
+assert.equal(probeResult.phases.find((phase: { name: string }) => phase.name === "provider-bridge-echo")?.data.provider, "echo")
+assert.equal(probeResult.phases.find((phase: { name: string }) => phase.name === "event-diagnostics")?.data.bounded, true)
+assert.equal(probeClient.requests.length > 0, true)
+assert.equal(probeClient.targetWrites.includes("/tmp/wp-codebox-contract-probe.txt"), true)
+assert.equal(probeClient.targetWrites.some((path: string) => path.endsWith("/tool-output.txt")), true)
+
 console.log("Browser runtime operation smoke passed")
 
 function sameRealm<T>(value: T): T {
@@ -400,4 +431,77 @@ function createClient(response: unknown, supportsRun = false, supportsRequestHan
   }
 
   return client
+}
+
+function createContractProbeClient() {
+  const storedFiles = new Map<string, string>()
+  const targetWrites: string[] = []
+  const client = {
+    mkdirs: [] as string[],
+    files: [] as Array<{ path: string; contents: string }>,
+    targetWrites,
+    requests: [] as Array<{ method: string; url: string }>,
+    runs: [] as Array<{ code: string }>,
+    async mkdir(path: string) {
+      this.mkdirs.push(path)
+    },
+    async writeFile(path: string, contents: string) {
+      this.files.push({ path, contents })
+      storedFiles.set(path, contents)
+    },
+    async request(request: { method: string; url: string }) {
+      this.requests.push(request)
+      const script = this.files.find((file) => request.url.endsWith(file.path.split("/").pop() ?? ""))?.contents ?? ""
+      return probePhpResponse(script, storedFiles, targetWrites)
+    },
+    async run(options: { code: string }) {
+      this.runs.push(options)
+      return probePhpResponse(options.code, storedFiles, targetWrites)
+    },
+  }
+
+  return client
+}
+
+function probePhpResponse(script: string, storedFiles: Map<string, string>, targetWrites: string[]) {
+  if (script.includes("'phase' => 'php-execution'")) {
+    return JSON.stringify({ success: true, data: { phase: "php-execution" }, error: null })
+  }
+
+  if (script.includes("'phase' => 'playground-request-handler'")) {
+    return JSON.stringify({ success: true, data: { phase: "playground-request-handler" }, error: null })
+  }
+
+  if (script.includes("/tmp/wp-codebox-contract-probe.txt")) {
+    const content = storedFiles.get("/tmp/wp-codebox-contract-probe.txt") ?? ""
+    return JSON.stringify({ success: content.length > 0, data: { path: "/tmp/wp-codebox-contract-probe.txt", sha256: sha256(content) }, error: null })
+  }
+
+  if (script.includes("wp-codebox/browser-runtime-contract-artifact-capture/v1")) {
+    const path = "/wordpress/wp-content/uploads/wp-codebox/artifacts/contract-probe/tool-output.txt"
+    const content = storedFiles.get(path) ?? ""
+    return JSON.stringify({
+      success: content.length > 0,
+      data: {
+        schema: "wp-codebox/browser-runtime-contract-artifact-capture/v1",
+        files: content.length > 0 ? [{ path: "tool-output.txt", sha256: sha256(content), size: content.length }] : [],
+      },
+      error: content.length > 0 ? null : { code: "artifact_missing", message: "Probe artifact was not readable." },
+    })
+  }
+
+  const operation = extractBrowserOperation(script) as { type?: string; args?: Record<string, unknown> }
+  if (operation.type === "writeFile") {
+    const path = String(operation.args?.path ?? "")
+    const content = String(operation.args?.content ?? "")
+    storedFiles.set(path, content)
+    targetWrites.push(path)
+    return JSON.stringify({ success: true, data: { path, bytes: content.length }, error: null })
+  }
+
+  return JSON.stringify({ success: true, data: {}, error: null })
+}
+
+function sha256(value: string) {
+  return Buffer.from(value).toString("hex")
 }

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -371,14 +371,22 @@ assert.deepEqual(sameRealm(probeResult.phases.map((phase: { name: string }) => p
   "provider-bridge-echo",
   "runtime-tool-artifact-write",
   "artifact-capture",
+  "generated-runner-artifact-capture",
   "event-diagnostics",
 ])
 assert.equal(probeResult.phases.every((phase: { status: string }) => phase.status === "passed"), true)
 assert.equal(probeResult.phases.find((phase: { name: string }) => phase.name === "provider-bridge-echo")?.data.provider, "echo")
+assert.deepEqual(sameRealm(probeResult.phases.find((phase: { name: string }) => phase.name === "generated-runner-artifact-capture")?.data), {
+  schema: "wp-codebox/browser-runtime-contract-generated-runner/v1",
+  root: "contract-generated/",
+  artifact_schema: "wp-codebox/browser-runtime-contract-generated-artifact/v1",
+  file_count: 1,
+})
 assert.equal(probeResult.phases.find((phase: { name: string }) => phase.name === "event-diagnostics")?.data.bounded, true)
 assert.equal(probeClient.requests.length > 0, true)
 assert.equal(probeClient.targetWrites.includes("/tmp/wp-codebox-contract-probe.txt"), true)
 assert.equal(probeClient.targetWrites.some((path: string) => path.endsWith("/tool-output.txt")), true)
+assert.equal(probeClient.targetWrites.includes("/tmp/wp-codebox-contract-recipe-task.json"), true)
 
 console.log("Browser runtime operation smoke passed")
 
@@ -487,6 +495,25 @@ function probePhpResponse(script: string, storedFiles: Map<string, string>, targ
         files: content.length > 0 ? [{ path: "tool-output.txt", sha256: sha256(content), size: content.length }] : [],
       },
       error: content.length > 0 ? null : { code: "artifact_missing", message: "Probe artifact was not readable." },
+    })
+  }
+
+  if (script.includes("wp-codebox/browser-runtime-contract-generated-runner/v1")) {
+    assert.match(script, /WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER/)
+    assert.match(script, /wp_codebox_browser_artifact_environment\( \$payload \)/)
+    assert.match(script, /wp_codebox_browser_capture_artifact_bundle\( \$payload \)/)
+    const payload = JSON.parse(storedFiles.get("/tmp/wp-codebox-contract-recipe-task.json") ?? "{}")
+    const artifact = payload.artifacts ?? {}
+    const fileCount = Array.isArray(artifact.files) ? artifact.files.length : 0
+    return JSON.stringify({
+      success: Boolean(artifact.schema && artifact.root && fileCount > 0),
+      data: {
+        schema: "wp-codebox/browser-runtime-contract-generated-runner/v1",
+        root: `${String(artifact.root ?? "").replace(/\/$/, "")}/`,
+        artifact_schema: artifact.schema ?? "",
+        file_count: fileCount,
+      },
+      error: artifact.schema ? null : { code: "artifact_contract_missing", message: "Generated runner artifact contract was not available." },
     })
   }
 


### PR DESCRIPTION
## Summary
- Add a deterministic `runBrowserRuntimeContractProbe()` browser-runtime export with stable phase diagnostics for bootstrap, PHP execution, request-handler execution, file write/read, echo provider bridge, artifact write/capture, and event diagnostics.
- Extend the browser runtime smoke script with a mock Playground client so the probe runs without live provider credentials.

Fixes #566.

## Tests
- `node --check packages/wordpress-plugin/assets/browser-runtime.js`
- `npm run browser-runtime-operation-smoke`
- `php tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the browser-runtime contract probe, deterministic smoke coverage, and local verification; Chris remains responsible for review and final acceptance.