### PR TITLE
Harden wordpress.bench dependency loading

### DIFF
--- a/examples/bench-dependency/dependency-main.php
+++ b/examples/bench-dependency/dependency-main.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Bench Dependency
+ * Description: Fixture dependency for WP Codebox bench command smoke tests.
+ * Version: 0.1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$GLOBALS['wp_codebox_bench_dependency_boot'] = array(
+	'plugins_loaded_callbacks' => 0,
+	'init_callbacks'           => 0,
+);
+
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		$GLOBALS['wp_codebox_bench_dependency_boot']['plugins_loaded_callbacks']++;
+	}
+);
+
+add_action(
+	'init',
+	static function (): void {
+		$GLOBALS['wp_codebox_bench_dependency_boot']['init_callbacks']++;
+	}
+);
+
+function wp_codebox_bench_dependency_value(): int {
+	return 11;
+}

--- a/examples/bench-plugin/tests/bench/noop.php
+++ b/examples/bench-plugin/tests/bench/noop.php
@@ -7,6 +7,10 @@ return static function (): array {
 	return array(
 		'metrics'  => array(
 			'fixture_value'                 => wp_codebox_bench_plugin_value(),
+			'dependency_value'              => wp_codebox_bench_dependency_value(),
+			'dependency_active'             => is_plugin_active( 'bench-dependency/dependency-main.php' ) ? 1 : 0,
+			'dependency_plugins_loaded_callback_count' => (int) $GLOBALS['wp_codebox_bench_dependency_boot']['plugins_loaded_callbacks'],
+			'dependency_init_callback_count'           => (int) $GLOBALS['wp_codebox_bench_dependency_boot']['init_callbacks'],
 			'rest_route_visible'            => isset( $data['value'] ) && 7 === (int) $data['value'] ? 1 : 0,
 			'included_before_plugins_loaded' => 0 === (int) $GLOBALS['wp_codebox_bench_plugin_boot']['plugins_loaded_at_include'] ? 1 : 0,
 			'included_before_init'           => 0 === (int) $GLOBALS['wp_codebox_bench_plugin_boot']['init_at_include'] ? 1 : 0,

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -136,18 +136,166 @@ function wp_codebox_bench_run_wp_cli_step(array $step) {
     return $stdout;
 }
 
+function wp_codebox_bench_snapshot_wordpress_hook_callbacks(string $hook_name): array {
+    global $wp_filter;
+    $snapshot = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $snapshot;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach (array_keys($callbacks) as $callback_id) {
+            $snapshot[$priority . ':' . $callback_id] = true;
+        }
+    }
+    return $snapshot;
+}
+
+function wp_codebox_bench_defer_new_wordpress_hook_callbacks(string $hook_name, array $before): array {
+    global $wp_filter;
+    $deferred = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $deferred;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach ($callbacks as $callback_id => $callback) {
+            if (isset($before[$priority . ':' . $callback_id])) {
+                continue;
+            }
+            $deferred[] = array('priority' => (int) $priority, 'callback' => $callback);
+            unset($wp_filter[$hook_name]->callbacks[$priority][$callback_id]);
+        }
+        if (empty($wp_filter[$hook_name]->callbacks[$priority])) {
+            unset($wp_filter[$hook_name]->callbacks[$priority]);
+        }
+    }
+    usort($deferred, static function (array $left, array $right): int {
+        return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10);
+    });
+    return $deferred;
+}
+
+function wp_codebox_bench_run_deferred_wordpress_hook_callbacks(array $deferred, array $args = array(), ?string $hook_name = null): void {
+    global $wp_current_filter;
+    $pushed_hook = false;
+    if (is_string($hook_name) && $hook_name !== '') {
+        if (!is_array($wp_current_filter)) {
+            $wp_current_filter = array();
+        }
+        $wp_current_filter[] = $hook_name;
+        $pushed_hook = true;
+    }
+    try {
+        foreach ($deferred as $entry) {
+            $callback = $entry['callback'] ?? null;
+            if (!is_array($callback) || !isset($callback['function'])) {
+                continue;
+            }
+            $accepted_args = isset($callback['accepted_args']) ? (int) $callback['accepted_args'] : count($args);
+            call_user_func_array($callback['function'], array_slice($args, 0, $accepted_args));
+        }
+    } finally {
+        if ($pushed_hook) {
+            array_pop($wp_current_filter);
+        }
+    }
+}
+
+function wp_codebox_bench_plugin_file_for_slug(string $plugin_slug, string $role): string {
+    $plugin_slug = sanitize_key($plugin_slug);
+    if ($plugin_slug === '') {
+        throw new RuntimeException('wordpress.bench received an empty ' . $role . ' plugin slug.');
+    }
+
+    $plugin_dir = WP_PLUGIN_DIR . '/' . $plugin_slug;
+    if (!is_dir($plugin_dir)) {
+        throw new RuntimeException('wordpress.bench could not find ' . $role . ' plugin directory for slug "' . $plugin_slug . '" at ' . $plugin_dir . '. WP_PLUGIN_DIR=' . WP_PLUGIN_DIR);
+    }
+
+    $candidate_files = array($plugin_dir . '/' . $plugin_slug . '.php');
+    foreach (glob($plugin_dir . '/*.php') ?: array() as $candidate_file) {
+        if (basename($candidate_file) !== 'db.php' && !in_array($candidate_file, $candidate_files, true)) {
+            $candidate_files[] = $candidate_file;
+        }
+    }
+
+    $checked_files = array();
+    foreach ($candidate_files as $candidate_file) {
+        $checked_files[] = $candidate_file;
+        if (!is_file($candidate_file) || !is_readable($candidate_file)) {
+            continue;
+        }
+        $contents = file_get_contents($candidate_file, false, null, 0, 8192);
+        if (is_string($contents) && strpos($contents, 'Plugin Name:') !== false) {
+            return $plugin_slug . '/' . basename($candidate_file);
+        }
+    }
+
+    throw new RuntimeException('wordpress.bench could not locate a readable plugin header for ' . $role . ' slug "' . $plugin_slug . '". Checked: ' . implode(', ', $checked_files));
+}
+
+function wp_codebox_bench_mark_plugin_active(string $plugin_basename): void {
+    $active_plugins = (array) get_option('active_plugins', array());
+    if (!in_array($plugin_basename, $active_plugins, true)) {
+        $active_plugins[] = $plugin_basename;
+        sort($active_plugins);
+        update_option('active_plugins', array_values($active_plugins));
+    }
+}
+
+function wp_codebox_bench_include_plugin_file(string $plugin_basename): void {
+    $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_basename;
+    if (!is_file($absolute_plugin_file) || !is_readable($absolute_plugin_file)) {
+        throw new RuntimeException('wordpress.bench cannot include plugin file "' . $plugin_basename . '" at ' . $absolute_plugin_file . '.');
+    }
+
+    wp_codebox_bench_assert_plugin_autoload_ready($plugin_basename);
+
+    try {
+        require_once $absolute_plugin_file;
+        wp_codebox_bench_mark_plugin_active($plugin_basename);
+    } catch (Throwable $e) {
+        throw new RuntimeException('wordpress.bench failed to include plugin "' . $plugin_basename . '" at ' . $absolute_plugin_file . ': ' . $e->getMessage(), 0, $e);
+    }
+}
+
+function wp_codebox_bench_assert_plugin_autoload_ready(string $plugin_basename): void {
+    $plugin_slug = dirname($plugin_basename);
+    if ($plugin_slug === '.' || $plugin_slug === '') {
+        return;
+    }
+
+    $plugin_dir = WP_PLUGIN_DIR . '/' . $plugin_slug;
+    $autoload_markers = array(
+        $plugin_dir . '/vendor/autoload.php',
+        $plugin_dir . '/vendor/autoload_packages.php',
+    );
+    foreach ($autoload_markers as $autoload_marker) {
+        if (is_file($autoload_marker) && is_readable($autoload_marker)) {
+            return;
+        }
+    }
+
+    $source_autoloader = $plugin_dir . '/src/Autoloader.php';
+    if (!is_file($source_autoloader) || !is_readable($source_autoloader)) {
+        return;
+    }
+
+    $source = file_get_contents($source_autoloader, false, null, 0, 4096);
+    if (is_string($source) && (strpos($source, 'vendor/autoload.php') !== false || strpos($source, 'vendor/autoload_packages.php') !== false)) {
+        throw new RuntimeException('wordpress.bench cannot fully bootstrap plugin "' . $plugin_basename . '" because its source autoloader requires a missing vendor autoload file. Checked: ' . implode(', ', $autoload_markers) . '. Provide a built dependency/plugin with Composer package autoload files before running heavyweight benchmark workloads.');
+    }
+}
+
 $plugins_to_activate = array();
 $activated_plugins = array();
 foreach (is_array($dependency_slugs) ? $dependency_slugs : array() as $dependency_slug) {
-    $dependency_slug = sanitize_key((string) $dependency_slug);
-    $dependency_file = WP_PLUGIN_DIR . '/' . $dependency_slug . '/' . $dependency_slug . '.php';
-    if (file_exists($dependency_file)) {
-        $plugins_to_activate[] = $dependency_slug . '/' . $dependency_slug . '.php';
-    }
+    $plugins_to_activate[] = wp_codebox_bench_plugin_file_for_slug((string) $dependency_slug, 'dependency');
 }
-$plugin_file = $plugin_path . '/' . $plugin_slug . '.php';
-if (file_exists($plugin_file)) {
-    $plugins_to_activate[] = $plugin_slug . '/' . $plugin_slug . '.php';
+$plugin_file = wp_codebox_bench_plugin_file_for_slug($plugin_slug, 'component');
+$plugins_to_activate[] = $plugin_file;
+$plugins_to_activate = array_values(array_unique($plugins_to_activate));
+foreach ($plugins_to_activate as $plugin_to_activate) {
+    wp_codebox_bench_assert_plugin_autoload_ready($plugin_to_activate);
 }
 foreach ($plugins_to_activate as $plugin_to_activate) {
     if (is_plugin_active($plugin_to_activate)) {
@@ -158,6 +306,12 @@ foreach ($plugins_to_activate as $plugin_to_activate) {
         throw new RuntimeException($activation->get_error_message());
     }
     $activated_plugins[] = $plugin_to_activate;
+}
+
+$pre_plugins_loaded_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('plugins_loaded');
+$pre_init_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('init');
+foreach ($plugins_to_activate as $plugin_to_activate) {
+    wp_codebox_bench_include_plugin_file($plugin_to_activate);
 }
 $loaded_bootstrap_file = '';
 foreach (is_array($bootstrap_files) ? $bootstrap_files : array() as $bootstrap_file) {
@@ -174,10 +328,16 @@ foreach (is_array($bootstrap_files) ? $bootstrap_files : array() as $bootstrap_f
 if (is_array($bootstrap_files) && count($bootstrap_files) > 0 && $loaded_bootstrap_file === '') {
     throw new RuntimeException('No configured wordpress.bench bootstrap files were found.');
 }
-if (!empty($activated_plugins)) {
-    do_action('plugins_loaded');
-    do_action('init');
-}
+
+$deferred_plugins_loaded_callbacks = wp_codebox_bench_defer_new_wordpress_hook_callbacks('plugins_loaded', $pre_plugins_loaded_callbacks);
+$pre_replayed_plugins_loaded_init_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('init');
+wp_codebox_bench_run_deferred_wordpress_hook_callbacks($deferred_plugins_loaded_callbacks, array(), 'plugins_loaded');
+$deferred_init_callbacks = wp_codebox_bench_defer_new_wordpress_hook_callbacks('init', $pre_init_callbacks);
+$deferred_init_callbacks = array_merge($deferred_init_callbacks, wp_codebox_bench_defer_new_wordpress_hook_callbacks('init', $pre_replayed_plugins_loaded_init_callbacks));
+usort($deferred_init_callbacks, static function (array $left, array $right): int {
+    return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10);
+});
+wp_codebox_bench_run_deferred_wordpress_hook_callbacks($deferred_init_callbacks, array(), 'init');
 if (did_action('rest_api_init')) {
     $GLOBALS['wp_rest_server'] = null;
     do_action('rest_api_init', rest_get_server());

--- a/scripts/bench-bootstrap-files-smoke.ts
+++ b/scripts/bench-bootstrap-files-smoke.ts
@@ -18,9 +18,10 @@ assert.match(code, /lib\/compat\/old\.php/)
 assert.match(code, /foreach \(is_array\(\$bootstrap_files\)/)
 assert.match(code, /require_once \$bootstrap_path/)
 assert.match(code, /break;/)
-assert.match(code, /do_action\('plugins_loaded'\)/)
+assert.match(code, /wp_codebox_bench_run_deferred_wordpress_hook_callbacks\(\$deferred_plugins_loaded_callbacks, array\(\), 'plugins_loaded'\)/)
+assert.match(code, /wp_codebox_bench_run_deferred_wordpress_hook_callbacks\(\$deferred_init_callbacks, array\(\), 'init'\)/)
 assert.ok(
-  code.indexOf("require_once $bootstrap_path") < code.indexOf("do_action('plugins_loaded')"),
+  code.indexOf("require_once $bootstrap_path") < code.indexOf("wp_codebox_bench_run_deferred_wordpress_hook_callbacks($deferred_plugins_loaded_callbacks"),
   "bootstrap files should load before synthetic plugins_loaded/init hooks"
 )
 

--- a/scripts/recipe-bench-smoke.ts
+++ b/scripts/recipe-bench-smoke.ts
@@ -7,6 +7,7 @@ import { dirname, resolve } from "node:path"
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const cli = resolve(root, "packages/cli/dist/index.js")
 const component = resolve(root, "examples/bench-plugin")
+const dependency = resolve(root, "examples/bench-dependency")
 const artifacts = resolve(root, "artifacts/recipe-bench-smoke")
 const recipePath = resolve(artifacts, "recipe.json")
 
@@ -30,6 +31,11 @@ writeFileSync(recipePath, `${JSON.stringify({
         source: component,
         slug: "bench-plugin",
       },
+      {
+        source: dependency,
+        slug: "bench-dependency",
+        pluginFile: "bench-dependency/dependency-main.php",
+      },
     ],
   },
   workflow: {
@@ -39,6 +45,7 @@ writeFileSync(recipePath, `${JSON.stringify({
         args: [
           "component-id=bench-plugin",
           "plugin-slug=bench-plugin",
+          "dependency-slugs=bench-dependency",
           "iterations=2",
           "warmup=0",
           `env-json=${JSON.stringify({ BENCH_FIXTURE_ENV: "13" })}`,
@@ -92,6 +99,10 @@ assert.equal(scenario.metrics.included_before_plugins_loaded_mean, 1)
 assert.equal(scenario.metrics.included_before_init_mean, 1)
 assert.equal(scenario.metrics.plugins_loaded_callback_count_mean, 1)
 assert.equal(scenario.metrics.init_callback_count_mean, 1)
+assert.equal(scenario.metrics.dependency_value_mean, 11)
+assert.equal(scenario.metrics.dependency_active_mean, 1)
+assert.equal(scenario.metrics.dependency_plugins_loaded_callback_count_mean, 1)
+assert.equal(scenario.metrics.dependency_init_callback_count_mean, 1)
 assert.equal(scenario.metadata.fixture, "bench-plugin")
 const configured = output.benchResults.scenarios[1]
 assert.equal(configured.id, "configured-env")


### PR DESCRIPTION
## Summary
- Load `wordpress.bench` dependency/component plugins by plugin header discovery instead of assuming `slug/slug.php`.
- Replay callbacks registered by late-loaded plugins/bootstrap files for `plugins_loaded` and `init` before workloads run.
- Fail fast when a heavyweight plugin source declares a Composer package autoloader but the mounted dependency lacks vendor autoload files, preventing partial bootstrap workloads.

## Verification
- `npm run build`
- `npm run bench-bootstrap-files-smoke`
- `npm run recipe-bench-smoke`
- Homeboy WooCommerce/Stripe rig now fails before workload execution with a clear missing vendor autoload diagnostic for the unbuilt WooCommerce dependency mount.

## Notes
- Follow-up remains in the Homeboy/dependency-prep layer: the WooCommerce dependency mount must be built or replaced with a built artifact before the Stripe rig can run the heavyweight workload.
- Addresses dependency-loading hardening for #570.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bench loading hardening, fixture coverage, and local/Homeboy verification; Chris directed the scope and reviewed the runtime behavior.