### PR TITLE
Harden browser Playground request transport

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -131,13 +131,38 @@
 		data: error?.data ?? null,
 	} );
 
+	const normalizePlaygroundAttempt = ( attempt, index, method ) => {
+		if ( typeof attempt === 'function' ) {
+			return {
+				label: `${ method }-${ index + 1 }`,
+				run: attempt,
+			};
+		}
+
+		return {
+			label: String( attempt?.label || `${ method }-${ index + 1 }` ),
+			run: attempt?.run,
+			shape: attempt?.shape || null,
+		};
+	};
+
 	const invokePlaygroundMethod = async ( phase, method, attempts ) => {
 		let lastError = null;
-		for ( const attempt of attempts ) {
+		const failedAttempts = [];
+		for ( const [ index, rawAttempt ] of attempts.entries() ) {
+			const attempt = normalizePlaygroundAttempt( rawAttempt, index, method );
 			try {
-				return await attempt();
+				if ( typeof attempt.run !== 'function' ) {
+					throw runtimeError( phase, `playground_${ method }_attempt_invalid`, `Playground ${ method } attempt is not callable.` );
+				}
+				return await attempt.run();
 			} catch ( error ) {
 				lastError = error;
+				failedAttempts.push( {
+					label: attempt.label,
+					shape: attempt.shape,
+					error: errorDetails( error ),
+				} );
 			}
 		}
 
@@ -145,7 +170,10 @@
 			phase,
 			`playground_${ method }_failed`,
 			`Playground ${ method } failed during ${ phase }.`,
-			lastError ? errorDetails( lastError ) : null
+			{
+				last_error: lastError ? errorDetails( lastError ) : null,
+				attempts: failedAttempts,
+			}
 		);
 	};
 
@@ -691,19 +719,19 @@ try {
 `;
 
 	const playgroundRequestTarget = ( client ) => {
-		if ( client?.requestHandler && typeof client.requestHandler.request === 'function' ) {
-			return {
-				target: client.requestHandler,
-				method: client.requestHandler.request,
-				shape: 'request-handler',
-			};
-		}
-
 		if ( client && typeof client.request === 'function' ) {
 			return {
 				target: client,
 				method: client.request,
 				shape: 'client',
+			};
+		}
+
+		if ( client?.requestHandler && typeof client.requestHandler.request === 'function' ) {
+			return {
+				target: client.requestHandler,
+				method: client.requestHandler.request,
+				shape: 'request-handler',
 			};
 		}
 
@@ -742,8 +770,14 @@ try {
 
 		const invoke = ( body ) => requestTarget.method.call( requestTarget.target, body );
 		const attempts = requestTarget.shape === 'request-handler'
-			? [ () => invoke( { request } ), () => invoke( request ) ]
-			: [ () => invoke( request ), () => invoke( { request } ) ];
+			? [
+				{ label: 'request-handler-envelope', shape: 'request-handler', run: () => invoke( { request } ) },
+				{ label: 'request-handler-plain', shape: 'request-handler', run: () => invoke( request ) },
+			]
+			: [
+				{ label: 'client-plain', shape: 'client', run: () => invoke( request ) },
+				{ label: 'client-envelope', shape: 'client', run: () => invoke( { request } ) },
+			];
 
 		return await invokePlaygroundMethod( 'request', 'request', attempts );
 	};

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -85,7 +85,15 @@ assert.match(successClient.files[0]?.contents ?? "", /wp-load\.php/)
 assert.match(successClient.files[0]?.contents ?? "", /case 'ensureDirectory':/)
 assert.match(successClient.requests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/codebox-ensuredirectory-/)
 
+const dualTransportClient = createClient("prefix {\"success\":true,\"data\":{\"runner\":\"client\"},\"error\":null} suffix", false, true)
+const dualTransportResult = await runtime.runPhpRequest(dualTransportClient, { code: "<?php echo 'ok';", expectJson: true })
+assert.deepEqual(sameRealm(dualTransportResult), { success: true, data: { runner: "client" }, error: null })
+assert.equal(dualTransportClient.requests.length, 1)
+assert.equal(dualTransportClient.handlerRequests.length, 0)
+assert.match(dualTransportClient.requests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/task-/)
+
 const handlerClient = createClient("prefix {\"success\":true,\"data\":{\"runner\":\"handler\"},\"error\":null} suffix", false, true)
+delete (handlerClient as { request?: unknown }).request
 const handlerResult = await runtime.runPhpRequest(handlerClient, { code: "<?php echo 'ok';", expectJson: true })
 assert.deepEqual(sameRealm(handlerResult), { success: true, data: { runner: "handler" }, error: null })
 assert.equal(handlerClient.handlerRequests.length, 1)
@@ -93,6 +101,7 @@ assert.equal(handlerClient.requests.length, 0)
 assert.match(handlerClient.handlerRequests[0]?.url ?? "", /\/wp-content\/uploads\/wp-codebox\/runner\/task-/)
 
 const workerEndpointClient = createClient("prefix {\"success\":true,\"data\":{\"runner\":\"worker-endpoint\"},\"error\":null} suffix", false, true)
+delete (workerEndpointClient as { request?: unknown }).request
 workerEndpointClient.requestHandler = {
   request: async (body: { request?: { method: string; url: string } }) => {
     if (!body.request) {
@@ -105,6 +114,36 @@ workerEndpointClient.requestHandler = {
 const workerEndpointResult = await runtime.runPhpRequest(workerEndpointClient, { code: "<?php echo 'ok';", expectJson: true })
 assert.deepEqual(sameRealm(workerEndpointResult), { success: true, data: { runner: "worker-endpoint" }, error: null })
 assert.equal(workerEndpointClient.handlerRequests.length, 1)
+
+const failingRequestClient = createClient("", false, true)
+delete (failingRequestClient as { request?: unknown }).request
+failingRequestClient.requestHandler = {
+  request: async () => {
+    throw new Error("Playground worker rejected request")
+  },
+}
+const failedRequestError = await runtime.runPhpRequest(failingRequestClient, { code: "<?php echo 'ok';", expectJson: true }).catch((error: unknown) => error)
+assert.equal(failedRequestError.code, "playground_request_failed")
+assert.equal(failedRequestError.phase, "request")
+assert.deepEqual(
+  sameRealm(failedRequestError.data?.attempts?.map((attempt: { label?: string; shape?: string; error?: { message?: string } }) => ({
+    label: attempt.label,
+    shape: attempt.shape,
+    message: attempt.error?.message,
+  }))),
+  [
+    {
+      label: "request-handler-envelope",
+      shape: "request-handler",
+      message: "Playground worker rejected request",
+    },
+    {
+      label: "request-handler-plain",
+      shape: "request-handler",
+      message: "Playground worker rejected request",
+    },
+  ]
+)
 
 const objectShapeFileClient = createClient("prefix {\"success\":true,\"data\":{\"runner\":\"object-file\"},\"error\":null} suffix")
 objectShapeFileClient.writeFile = async function writeFile(body: string | { path?: string; data?: string }) {


### PR DESCRIPTION
## Summary
- Prefer the browser Playground client-level `request()` transport before falling back to `requestHandler.request()`.
- Preserve structured per-attempt diagnostics when Playground method transports fail.
- Extend the browser runtime smoke test to cover dual-transport priority, handler fallback, and failed request diagnostics.

Fixes #580.

## Testing
- `node --check packages/wordpress-plugin/assets/browser-runtime.js`
- `npm run browser-runtime-operation-smoke`
- `php tests/smoke-wordpress-plugin.php`
- Studio Web live eval against this WP Codebox worktree with `--plugin-source wp-codebox=/Users/chubes/Developer/wp-codebox@fix-browser-request-failure-diagnostics/packages/wordpress-plugin` wrote `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/wp-codebox-580-live-eval/evidence.json`. It no longer showed `playground_request_failed`; the run failed earlier at `codebox_session_ready` because Studio Web reported the prepared preview target was not browser-ready.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the browser runtime request transport hardening, adjusted smoke coverage, ran verification, and drafted this PR description for Chris to review.