### PR TITLE
Fall back from cloned browser runner requests

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -177,6 +177,32 @@
 		);
 	};
 
+	const isPlaygroundStructuredCloneError = ( error ) => {
+		const message = String( error?.message || '' );
+		if ( error?.code === 25 || message.includes( 'could not be cloned' ) || message.includes( 'DataCloneError' ) ) {
+			return true;
+		}
+
+		const details = error?.data;
+		if ( details?.last_error && isPlaygroundStructuredCloneError( details.last_error ) ) {
+			return true;
+		}
+
+		return Array.isArray( details?.attempts ) && details.attempts.some( ( attempt ) => isPlaygroundStructuredCloneError( attempt?.error ) );
+	};
+
+	const runPhpDirect = async ( client, code, options = {} ) => {
+		if ( typeof client?.run !== 'function' ) {
+			throw runtimeError( 'run_php', 'playground_run_unavailable', 'Playground run is unavailable.' );
+		}
+
+		const response = await invokePlaygroundMethod( 'run_php', 'run', [
+			() => client.run( { code } ),
+			() => client.run( code ),
+		] );
+		return options.expectJson ? await parseJsonResponse( response ) : response;
+	};
+
 	const redactBrowserProviderProxyData = ( value ) => {
 		if ( ! value || typeof value !== 'object' ) {
 			return value;
@@ -789,11 +815,7 @@ try {
 		}
 
 		if ( ! options.forceRequest && typeof client.run === 'function' ) {
-			const response = await invokePlaygroundMethod( 'run_php', 'run', [
-				() => client.run( { code } ),
-				() => client.run( code ),
-			] );
-			return options.expectJson ? await parseJsonResponse( response ) : response;
+			return await runPhpDirect( client, code, options );
 		}
 
 		const runnerDir = String( options.runnerDir || defaultRunnerDir );
@@ -808,7 +830,16 @@ try {
 			method: 'GET',
 			url: requestUrl,
 		};
-		const response = await playgroundRequest( client, request );
+		let response;
+		try {
+			response = await playgroundRequest( client, request );
+		} catch ( error ) {
+			if ( options.forceRequest && typeof client.run === 'function' && isPlaygroundStructuredCloneError( error ) ) {
+				return await runPhpDirect( client, code, options );
+			}
+
+			throw error;
+		}
 
 		return options.expectJson ? await parseJsonResponse( response ) : response;
 	};

--- a/scripts/browser-runtime-operation-smoke.ts
+++ b/scripts/browser-runtime-operation-smoke.ts
@@ -332,6 +332,44 @@ assert.deepEqual(extractBrowserOperation(recipeClient.files[0]?.contents ?? ""),
 assert.match(recipeClient.files[1]?.contents ?? "", /WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER/)
 assert.match(recipeClient.files[1]?.contents ?? "", /<\?php\ndefine\( 'WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER', true \);/)
 
+const cloneSafeRecipeClient = createClient("unused", true)
+cloneSafeRecipeClient.runResponse = '{"success":true,"schema":"wp-codebox/browser-agent-run/v1","data":{"runner":"direct-fallback"}}'
+let providerProxyInstalled = false
+;(cloneSafeRecipeClient as typeof cloneSafeRecipeClient & { onMessage: (callback: (data: unknown) => unknown) => Promise<() => void> }).onMessage = async () => {
+  providerProxyInstalled = true
+  return () => {
+    providerProxyInstalled = false
+  }
+}
+cloneSafeRecipeClient.request = async function request(request: { method: string; url: string }) {
+  this.requests.push(request)
+  if (providerProxyInstalled) {
+    const error = new Error("Failed to execute 'postMessage' on 'Worker': function(){} could not be cloned.") as Error & { code?: number }
+    error.code = 25
+    throw error
+  }
+  return "unused"
+}
+const cloneSafeRecipeResult = await runtime.runRecipe(cloneSafeRecipeClient, {
+  browser: { task_path: "/tmp/wp-codebox-agent-task.json" },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: ["code=<?php echo wp_json_encode( array( 'success' => true, 'data' => array( 'runner' => 'direct-fallback' ) ) );"],
+      },
+    ],
+  },
+}, { goal: "Smoke test clone-safe browser execution." })
+assert.deepEqual(sameRealm(cloneSafeRecipeResult), {
+  success: true,
+  schema: "wp-codebox/browser-agent-run/v1",
+  data: { runner: "direct-fallback" },
+})
+assert.equal(cloneSafeRecipeClient.requests.length, 2)
+assert.equal(cloneSafeRecipeClient.runs.length, 2)
+assert.equal(providerProxyInstalled, false)
+
 const sessionClient = createClient("prefix {\"success\":true,\"data\":{\"summary\":\"session runner\"},\"error\":null} suffix")
 const sessionOutput = {
   schema: "wp-codebox/browser-playground-session/v1",


### PR DESCRIPTION
## Summary
- Detect Playground worker structured-clone failures in both direct and wrapped browser request diagnostics.
- Keep the HTTP PHP runner request path as the default for forced runner execution, but fall back to direct `client.run()` when the request transport rejects the call because an installed browser provider proxy callback cannot be cloned across the worker boundary.
- Add browser runtime smoke coverage that simulates `client.onMessage()` installing a provider proxy callback, reproduces the cloned-function request failure, and verifies generated recipe execution falls back safely.

Follow-up to #582 for #580.

## Testing
- `node --check packages/wordpress-plugin/assets/browser-runtime.js`
- `npm run browser-runtime-operation-smoke`
- `php tests/smoke-wordpress-plugin.php`
- Studio Web live eval against this WP Codebox branch with `--plugin-source wp-codebox=/Users/chubes/Developer/wp-codebox@eval-main-20260604-580/packages/wordpress-plugin` wrote `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/wp-codebox-580-clone-safe-eval/evidence.json`. It did not show `playground_request_failed` or `could not be cloned`; the run failed earlier at `codebox_session_ready` because Studio Web reported the prepared preview target was not browser-ready.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the follow-up browser Playground transport failure, implemented the clone-safe fallback and smoke coverage, ran verification, and drafted this PR description for Chris to review.