### PR TITLE
Add bench recipe build CLI support

### DIFF
--- a/packages/cli/src/commands/recipe-build.ts
+++ b/packages/cli/src/commands/recipe-build.ts
@@ -1,13 +1,14 @@
 import { readFile, writeFile } from "node:fs/promises"
-import { buildWordPressPhpunitRecipe, type WorkspaceRecipe, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
+import { buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
 
 interface RecipeBuildOptions {
-  recipeType: "phpunit"
+  recipeType: "phpunit" | "bench"
   optionsPath: string
   outputPath?: string
 }
 
 interface WordPressPhpunitBuilderOptions {
+  blueprint?: unknown
   wordpressVersion?: string
   mounts?: WorkspaceRecipeMount[]
   pluginSlug: string
@@ -21,9 +22,25 @@ interface WordPressPhpunitBuilderOptions {
   multisite?: boolean
 }
 
+interface WordPressBenchBuilderOptions {
+  blueprint?: unknown
+  wordpressVersion?: string
+  mounts?: WorkspaceRecipeMount[]
+  extraPlugins?: WorkspaceRecipeExtraPlugin[]
+  componentId?: string
+  pluginSlug: string
+  iterations?: number
+  warmupIterations?: number
+  dependencySlugs?: string[]
+  env?: Record<string, unknown>
+  wpConfigDefines?: Record<string, unknown>
+  bootstrapFiles?: string[]
+  workloads?: unknown[]
+}
+
 export async function runRecipeBuildCommand(args: string[]): Promise<number> {
   const options = parseRecipeBuildOptions(args)
-  const builderOptions = JSON.parse(await readFile(options.optionsPath, "utf8")) as WordPressPhpunitBuilderOptions
+  const builderOptions = JSON.parse(await readFile(options.optionsPath, "utf8")) as WordPressPhpunitBuilderOptions | WordPressBenchBuilderOptions
   const recipe = buildRecipe(options.recipeType, builderOptions)
   const json = `${JSON.stringify(recipe, null, 2)}\n`
 
@@ -36,28 +53,45 @@ export async function runRecipeBuildCommand(args: string[]): Promise<number> {
   return 0
 }
 
-function buildRecipe(recipeType: RecipeBuildOptions["recipeType"], options: WordPressPhpunitBuilderOptions): WorkspaceRecipe {
+function buildRecipe(recipeType: RecipeBuildOptions["recipeType"], options: WordPressPhpunitBuilderOptions | WordPressBenchBuilderOptions): WorkspaceRecipe {
   switch (recipeType) {
     case "phpunit":
       return buildWordPressPhpunitRecipe({
+        blueprint: options.blueprint,
         wordpressVersion: stringOrUndefined(options.wordpressVersion),
         mounts: Array.isArray(options.mounts) ? options.mounts : [],
         pluginSlug: requiredString(options.pluginSlug, "pluginSlug"),
-        selectedTestFile: stringOrUndefined(options.selectedTestFile),
-        changedTestFiles: Array.isArray(options.changedTestFiles) ? options.changedTestFiles : [],
+        selectedTestFile: stringOrUndefined((options as WordPressPhpunitBuilderOptions).selectedTestFile),
+        changedTestFiles: Array.isArray((options as WordPressPhpunitBuilderOptions).changedTestFiles) ? (options as WordPressPhpunitBuilderOptions).changedTestFiles : [],
         env: plainObject(options.env),
         wpConfigDefines: plainObject(options.wpConfigDefines),
-        autoloadFile: stringOrUndefined(options.autoloadFile),
-        testsDir: stringOrUndefined(options.testsDir),
-        dependencyMounts: Array.isArray(options.dependencyMounts) ? options.dependencyMounts : [],
-        multisite: Boolean(options.multisite),
+        autoloadFile: stringOrUndefined((options as WordPressPhpunitBuilderOptions).autoloadFile),
+        testsDir: stringOrUndefined((options as WordPressPhpunitBuilderOptions).testsDir),
+        dependencyMounts: Array.isArray((options as WordPressPhpunitBuilderOptions).dependencyMounts) ? (options as WordPressPhpunitBuilderOptions).dependencyMounts : [],
+        multisite: Boolean((options as WordPressPhpunitBuilderOptions).multisite),
+      })
+    case "bench":
+      return buildWordPressBenchRecipe({
+        blueprint: options.blueprint,
+        wordpressVersion: stringOrUndefined(options.wordpressVersion),
+        mounts: Array.isArray(options.mounts) ? options.mounts : [],
+        extraPlugins: Array.isArray((options as WordPressBenchBuilderOptions).extraPlugins) ? (options as WordPressBenchBuilderOptions).extraPlugins : [],
+        componentId: stringOrUndefined((options as WordPressBenchBuilderOptions).componentId),
+        pluginSlug: requiredString(options.pluginSlug, "pluginSlug"),
+        iterations: integerOrUndefined((options as WordPressBenchBuilderOptions).iterations),
+        warmupIterations: integerOrUndefined((options as WordPressBenchBuilderOptions).warmupIterations),
+        dependencySlugs: Array.isArray((options as WordPressBenchBuilderOptions).dependencySlugs) ? (options as WordPressBenchBuilderOptions).dependencySlugs : [],
+        env: plainObject(options.env),
+        wpConfigDefines: plainObject(options.wpConfigDefines),
+        bootstrapFiles: Array.isArray((options as WordPressBenchBuilderOptions).bootstrapFiles) ? (options as WordPressBenchBuilderOptions).bootstrapFiles : [],
+        workloads: Array.isArray((options as WordPressBenchBuilderOptions).workloads) ? (options as WordPressBenchBuilderOptions).workloads : [],
       })
   }
 }
 
 function parseRecipeBuildOptions(args: string[]): RecipeBuildOptions {
   const recipeType = args.shift()
-  if (recipeType !== "phpunit") {
+  if (recipeType !== "phpunit" && recipeType !== "bench") {
     throw new Error(`Unknown recipe build type: ${recipeType ?? ""}`)
   }
 
@@ -78,7 +112,7 @@ function parseRecipeBuildOptions(args: string[]): RecipeBuildOptions {
   }
 
   if (!optionsPath) {
-    throw new Error("recipe build phpunit requires --options <path>")
+    throw new Error(`recipe build ${recipeType} requires --options <path>`)
   }
 
   return { recipeType, optionsPath, outputPath }
@@ -93,6 +127,10 @@ function requiredString(value: unknown, name: string): string {
 
 function stringOrUndefined(value: unknown): string | undefined {
   return typeof value === "string" && value !== "" ? value : undefined
+}
+
+function integerOrUndefined(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) ? value as number : undefined
 }
 
 function plainObject(value: unknown): Record<string, unknown> {

--- a/scripts/recipe-build-cli-smoke.ts
+++ b/scripts/recipe-build-cli-smoke.ts
@@ -7,6 +7,8 @@ import { runCli } from "../packages/cli/src/cli-entry.js"
 const directory = await mkdtemp(join(tmpdir(), "wp-codebox-recipe-build-cli-"))
 const optionsPath = join(directory, "phpunit-options.json")
 const outputPath = join(directory, "phpunit-recipe.json")
+const benchOptionsPath = join(directory, "bench-options.json")
+const benchOutputPath = join(directory, "bench-recipe.json")
 
 await writeFile(optionsPath, JSON.stringify({
   wordpressVersion: "6.10",
@@ -40,6 +42,48 @@ assert.deepEqual(recipe.workflow.steps[0].args, [
   "tests-dir=/wp-codebox-vendor/wp-phpunit/wp-phpunit",
   "dependency-mounts=/wordpress/wp-content/plugins/dep",
   "multisite=1",
+])
+
+await writeFile(benchOptionsPath, JSON.stringify({
+  wordpressVersion: "6.10",
+  blueprint: { steps: [{ step: "login", username: "admin", password: "password" }] },
+  mounts: [{ source: "/repo/db.php", target: "/wordpress/wp-content/db.php", type: "file" }],
+  extraPlugins: [{ source: "/repo/plugin", slug: "demo", pluginFile: "demo/demo.php", activate: true }],
+  componentId: "demo-component",
+  pluginSlug: "demo",
+  iterations: 7,
+  warmupIterations: 2,
+  dependencySlugs: ["dependency-plugin"],
+  env: { BENCH_FLAG: "yes" },
+  wpConfigDefines: { SAVEQUERIES: true },
+  bootstrapFiles: ["bench/bootstrap.php"],
+  workloads: [{ id: "homepage", path: "/" }],
+}, null, 2))
+
+const benchExitCode = await runCli(["recipe", "build", "bench", "--options", benchOptionsPath, "--output", benchOutputPath])
+assert.equal(benchExitCode, 0)
+
+const benchRecipe = JSON.parse(await readFile(benchOutputPath, "utf8"))
+assert.equal(benchRecipe.schema, "wp-codebox/workspace-recipe/v1")
+assert.equal(benchRecipe.runtime.wp, "6.10")
+assert.deepEqual(benchRecipe.runtime.blueprint, {
+  steps: [
+    { step: "login", username: "admin", password: "password" },
+    { step: "defineWpConfigConsts", consts: { SAVEQUERIES: true } },
+  ],
+})
+assert.equal(benchRecipe.workflow.steps[0].command, "wordpress.bench")
+assert.deepEqual(benchRecipe.inputs.mounts, [{ source: "/repo/db.php", target: "/wordpress/wp-content/db.php", mode: "readonly", type: "file" }])
+assert.deepEqual(benchRecipe.inputs.extraPlugins, [{ source: "/repo/plugin", slug: "demo", pluginFile: "demo/demo.php", activate: true }])
+assert.deepEqual(benchRecipe.workflow.steps[0].args, [
+  "component-id=demo-component",
+  "plugin-slug=demo",
+  "iterations=7",
+  "warmup=2",
+  "dependency-slugs=dependency-plugin",
+  'env-json={"BENCH_FLAG":"yes"}',
+  'bootstrap-files-json=["bench/bootstrap.php"]',
+  'workloads-json=[{"id":"homepage","path":"/"}]',
 ])
 
 console.log("recipe build cli smoke passed")


### PR DESCRIPTION
## Summary
- Extends `recipe build` so callers can emit bench recipes from JSON options, matching the existing PHPUnit builder CLI path.
- Wires bench options through the reusable runtime-core builder for mounts, extra plugins, dependencies, env, bootstrap files, workloads, blueprint fragments, and wp-config defines.
- Expands the recipe build CLI smoke test to cover bench recipe generation with a drop-in mount and dependency plugin metadata.

## Verification
- `npm run build`
- `npm run recipe-build-cli-smoke`
- `npm run wordpress-recipe-builders-smoke`
- `git diff --check`

Closes #482.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the TypeScript CLI extension, smoke coverage, verification runs, and PR description. Chris remains responsible for review and merge.