### PR TITLE
Make recipe startup prefer cached WordPress assets

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat } from "node:fs/promises"
 import { basename, dirname, resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
-import { RuntimeRunRegistry, artifactBundleRunRef, createBenchResultsJsonSchema, createRuntimeRunId, defaultRunRegistryDirectory, createRuntime, stripUndefined, type ArtifactBundle, type BenchResults, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimeRunRecord, type WorkspaceRecipe, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { RuntimeRunRegistry, artifactBundleRunRef, createBenchResultsJsonSchema, createRuntimeRunId, defaultRunRegistryDirectory, createRuntime, stripUndefined, type ArtifactBundle, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimeInfo, type RuntimeRunRecord, type WorkspaceRecipe, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -442,6 +442,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       name: recipe.runtime?.name ?? "wp-codebox-recipe",
       version: recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION,
       blueprint: recipeBlueprintWithBootActivePlugins(recipe.runtime?.blueprint, extraPlugins),
+      assets: resolveRecipeRuntimeAssets(recipe, recipeDirectory),
     }
     const runtimeCreateSpec = {
       backend: recipe.runtime?.backend ?? "wordpress-playground",
@@ -725,6 +726,22 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       error: serializedError,
     }
   }
+}
+
+function resolveRecipeRuntimeAssets(recipe: WorkspaceRecipe, recipeDirectory: string): RuntimeAssetSpec | undefined {
+  const assets = recipe.runtime?.assets
+  if (!assets?.wordpressZip) {
+    return undefined
+  }
+
+  return {
+    ...assets,
+    wordpressZip: isUrl(assets.wordpressZip) ? assets.wordpressZip : resolve(recipeDirectory, assets.wordpressZip),
+  }
+}
+
+function isUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value)
 }
 
 interface RunResourceCleanupEvidence {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,6 @@
 import { stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { ALLOW_NETWORK_DOWNLOADS_ENV, REQUIRE_SOURCE_SHA256_ENV, allowedDownloadHosts, isSha256, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile, sourceSha256Required } from "./recipe-sources.js"
 
 export interface RecipeValidationIssue {
@@ -50,6 +50,7 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
 
   validateRecipeMounts(recipe.runtime?.stack?.mounts, "runtime stack", recipePath)
   validateRecipeRuntimeOverlays(recipe.runtime?.overlays, recipePath)
+  validateRecipeRuntimeAssets(recipe.runtime?.assets, recipePath)
   validateRecipeMounts(recipe.inputs?.mounts, "mounts", recipePath)
 
   const workspaces = recipe.inputs?.workspaces ?? []
@@ -159,6 +160,20 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   }
 
   return recipe
+}
+
+function validateRecipeRuntimeAssets(assets: RuntimeAssetSpec | undefined, recipePath: string): void {
+  if (assets === undefined) {
+    return
+  }
+
+  if (!assets || typeof assets !== "object" || Array.isArray(assets)) {
+    throw new Error(`Recipe runtime assets must be an object: ${recipePath}`)
+  }
+
+  if (assets.wordpressZip !== undefined && typeof assets.wordpressZip !== "string") {
+    throw new Error(`Recipe runtime assets wordpressZip must be a string: ${recipePath}`)
+  }
 }
 
 function validateRecipeMounts(mounts: WorkspaceRecipeMount[] | undefined, label: string, recipePath: string): void {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -26,6 +26,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           name: { type: "string" },
           wp: { type: "string" },
           blueprint: { type: "object" },
+          assets: { $ref: "#/$defs/runtimeAssets" },
           stack: { $ref: "#/$defs/runtimeStack" },
           overlays: {
             type: "array",
@@ -141,6 +142,17 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
       metadata: {
         type: "object",
         additionalProperties: true,
+      },
+      runtimeAssets: {
+        type: "object",
+        additionalProperties: false,
+        description: "Pre-resolved runtime assets. Use local paths or URLs to make recipe startup deterministic without live release metadata lookups.",
+        properties: {
+          wordpressZip: {
+            type: "string",
+            description: "Local path or HTTP(S) URL for a WordPress release zip used to boot the Playground runtime.",
+          },
+        },
       },
       mount: {
         type: "object",

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -19,6 +19,11 @@ export interface EnvironmentSpec {
   name?: string
   blueprint?: unknown
   version?: string
+  assets?: RuntimeAssetSpec
+}
+
+export interface RuntimeAssetSpec {
+  wordpressZip?: string
 }
 
 export interface RuntimeCreateSpec {
@@ -216,6 +221,7 @@ export interface WorkspaceRecipe {
     name?: string
     wp?: string
     blueprint?: unknown
+    assets?: RuntimeAssetSpec
     stack?: WorkspaceRecipeRuntimeStack
     overlays?: WorkspaceRecipeRuntimeOverlay[]
   }

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -4,9 +4,10 @@ import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, erro
 import type { BrowserStartupProgressEvent, BrowserStartupProgressPhase, BrowserStartupProgressStatus, MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { randomInt } from "node:crypto"
 import { existsSync } from "node:fs"
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http"
 import { readFile, stat, unlink } from "node:fs/promises"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { basename, join } from "node:path"
 import { createServer as createNetServer } from "node:net"
 import { resolveWordPressRelease } from "@wp-playground/wordpress"
 
@@ -56,7 +57,9 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
     emitProgress("preview:loading-wordpress", "running", "Loading your site", {
       wordpressVersion: spec.environment.version,
     })
-    const cacheValidation = await validatePlaygroundWordPressArchiveCache(spec.environment.version)
+    const wordpressStartupAsset = await resolvePlaygroundWordPressStartupAsset(spec.environment.version, spec.environment.assets?.wordpressZip)
+    const cacheValidation = wordpressStartupAsset.cacheValidation
+    const localAssetServer = wordpressStartupAsset.localPath ? await serveLocalStartupAsset(wordpressStartupAsset.localPath) : undefined
     const port = spec.preview?.port ? 0 : await availablePlaygroundPortRange()
     const blueprintSummary = summarizeBlueprint(spec.environment.blueprint)
     if (blueprintSummary.steps > 0) {
@@ -69,20 +72,26 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       emitProgress("preview:activating-dependencies", "running", "Activating site features", blueprintSummary)
     }
 
-    const server = await runPlaygroundCliWithoutProcessExit(() => runCLI({
-      command: "server",
-      port,
-      quiet: true,
-      verbosity: "quiet",
-      skipBrowser: true,
-      mount: mounts.map((mount) => ({
-        hostPath: mount.source,
-        vfsPath: mount.target,
-      })),
-      wp: spec.environment.version,
-      "site-url": spec.preview?.siteUrl,
-      blueprint: playgroundBlueprint(spec.environment.blueprint, spec.policy, spec.preview?.siteUrl),
-    }))
+    const server = await runPlaygroundCliWithoutProcessExit(async () => {
+      try {
+        return await runCLI({
+          command: "server",
+          port,
+          quiet: true,
+          verbosity: "quiet",
+          skipBrowser: true,
+          mount: mounts.map((mount) => ({
+            hostPath: mount.source,
+            vfsPath: mount.target,
+          })),
+          wp: localAssetServer?.url ?? wordpressStartupAsset.wp,
+          "site-url": spec.preview?.siteUrl,
+          blueprint: playgroundBlueprint(spec.environment.blueprint, spec.policy, spec.preview?.siteUrl),
+        })
+      } finally {
+        await localAssetServer?.close()
+      }
+    })
 
     emitProgress("preview:connecting-client", "running", "Connecting preview", {
       localUrl: server.serverUrl,
@@ -166,6 +175,7 @@ function errorDetail(error: unknown): Record<string, unknown> {
 export interface PlaygroundWordPressArchiveCacheValidation {
   version: string
   sourceUrl: string
+  source: "pre-resolved" | "cache" | "inferred" | "api"
   invalidArchives: Array<{
     path: string
     size: number
@@ -179,9 +189,9 @@ export interface PlaygroundWordPressArchiveCacheValidationOptions {
 }
 
 export async function validatePlaygroundWordPressArchiveCache(versionQuery: string | undefined, cacheDirectory = join(homedir(), ".wordpress-playground"), options: PlaygroundWordPressArchiveCacheValidationOptions = { deleteInvalid: true }): Promise<PlaygroundWordPressArchiveCacheValidation> {
-  const release = await resolveWordPressRelease(versionQuery)
-  const version = String(release.version)
-  const sourceUrl = String(release.releaseUrl)
+  const release = await resolveWordPressReleaseForStartup(versionQuery)
+  const version = release.version
+  const sourceUrl = release.releaseUrl
   const archivePaths = [
     join(cacheDirectory, `${version}.zip`),
     join(cacheDirectory, `prebuilt-wp-content-for-wp-${version}.zip`),
@@ -213,7 +223,169 @@ export async function validatePlaygroundWordPressArchiveCache(versionQuery: stri
     }
   }
 
-  return { version, sourceUrl, invalidArchives }
+  return { version, sourceUrl, source: release.source, invalidArchives }
+}
+
+interface PlaygroundWordPressStartupAsset {
+  wp: string | undefined
+  localPath?: string
+  cacheValidation: PlaygroundWordPressArchiveCacheValidation
+}
+
+interface ResolvedWordPressReleaseForStartup {
+  version: string
+  releaseUrl: string
+  source: PlaygroundWordPressArchiveCacheValidation["source"]
+}
+
+export async function resolvePlaygroundWordPressStartupAsset(versionQuery: string | undefined, wordpressZip?: string, cacheDirectory = join(homedir(), ".wordpress-playground")): Promise<PlaygroundWordPressStartupAsset> {
+  if (wordpressZip) {
+    const version = startupAssetVersion(versionQuery, wordpressZip)
+    const cacheValidation = await validateWordPressArchivePaths(version, wordpressZip, isHttpUrl(wordpressZip) ? [] : [wordpressZip], { deleteInvalid: false })
+    return { wp: isHttpUrl(wordpressZip) ? wordpressZip : undefined, localPath: isHttpUrl(wordpressZip) ? undefined : wordpressZip, cacheValidation: { ...cacheValidation, sourceUrl: wordpressZip, source: "pre-resolved" } }
+  }
+
+  const cachedVersion = exactWordPressVersion(versionQuery)
+  if (cachedVersion) {
+    const cachedArchivePath = join(cacheDirectory, `${cachedVersion}.zip`)
+    if (existsSync(cachedArchivePath)) {
+      const cacheValidation = await validateWordPressArchivePaths(cachedVersion, `cache:${cachedArchivePath}`, [cachedArchivePath, join(cacheDirectory, `prebuilt-wp-content-for-wp-${cachedVersion}.zip`)], { deleteInvalid: true })
+      if (existsSync(cachedArchivePath)) {
+        return { wp: undefined, localPath: cachedArchivePath, cacheValidation: { ...cacheValidation, source: "cache" } }
+      }
+    }
+  }
+
+  const cacheValidation = await validatePlaygroundWordPressArchiveCache(versionQuery, cacheDirectory)
+  return { wp: cacheValidation.sourceUrl, cacheValidation }
+}
+
+async function resolveWordPressReleaseForStartup(versionQuery: string | undefined): Promise<ResolvedWordPressReleaseForStartup> {
+  const exactVersion = exactWordPressVersion(versionQuery)
+  if (exactVersion) {
+    return {
+      version: exactVersion,
+      releaseUrl: `https://wordpress.org/wordpress-${exactVersion}.zip`,
+      source: "inferred",
+    }
+  }
+
+  try {
+    const release = await resolveWordPressRelease(versionQuery)
+    return {
+      version: String(release.version),
+      releaseUrl: String(release.releaseUrl),
+      source: release.source === "api" ? "api" : "inferred",
+    }
+  } catch (error) {
+    throw new PlaygroundStartupAssetError("wordpress-release-metadata", "https://api.wordpress.org/core/version-check/1.7/?channel=beta", versionQuery ?? "latest", error)
+  }
+}
+
+async function validateWordPressArchivePaths(version: string, sourceUrl: string, archivePaths: string[], options: PlaygroundWordPressArchiveCacheValidationOptions): Promise<PlaygroundWordPressArchiveCacheValidation> {
+  const invalidArchives: PlaygroundWordPressArchiveCacheValidation["invalidArchives"] = []
+
+  for (const archivePath of archivePaths) {
+    if (!existsSync(archivePath)) {
+      continue
+    }
+
+    const archiveStat = await stat(archivePath)
+    const reason = await invalidZipReason(archivePath, archiveStat.size)
+    if (!reason) {
+      continue
+    }
+
+    if (!options.deleteInvalid) {
+      invalidArchives.push({ path: archivePath, size: archiveStat.size, reason, deleted: false })
+      continue
+    }
+
+    try {
+      await unlink(archivePath)
+      invalidArchives.push({ path: archivePath, size: archiveStat.size, reason, deleted: true })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Corrupt cached WordPress archive could not be removed: ${archivePath} (size: ${archiveStat.size} bytes, requested WordPress version: ${version}, resolved WordPress version: ${version}, source URL: ${sourceUrl}, validation: ${reason}, unlink error: ${message})`)
+    }
+  }
+
+  return { version, sourceUrl, source: "inferred", invalidArchives }
+}
+
+class PlaygroundStartupAssetError extends Error {
+  readonly code = "wp-codebox-playground-startup-asset-unavailable"
+  readonly phase = "preview:loading-wordpress"
+  readonly asset: string
+  readonly sourceUrl: string
+  readonly requestedVersion: string
+
+  constructor(asset: string, sourceUrl: string, requestedVersion: string, cause: unknown) {
+    const message = cause instanceof Error ? cause.message : String(cause)
+    super(`Unable to resolve Playground startup asset ${asset} for WordPress ${requestedVersion} from ${sourceUrl}: ${message}`, { cause })
+    this.name = "PlaygroundStartupAssetError"
+    this.asset = asset
+    this.sourceUrl = sourceUrl
+    this.requestedVersion = requestedVersion
+  }
+}
+
+async function serveLocalStartupAsset(assetPath: string): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createHttpServer(async (_request, response) => {
+    try {
+      const contents = await readFile(assetPath)
+      response.writeHead(200, {
+        "content-type": "application/zip",
+        "content-length": String(contents.byteLength),
+      })
+      response.end(contents)
+    } catch (error) {
+      response.writeHead(500, { "content-type": "text/plain" })
+      response.end(error instanceof Error ? error.message : String(error))
+    }
+  })
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen)
+    server.listen(0, "127.0.0.1", () => resolveListen())
+  })
+
+  const address = server.address()
+  if (!address || typeof address !== "object") {
+    await closeHttpServer(server)
+    throw new Error(`Unable to serve local Playground startup asset: ${assetPath}`)
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/${encodeURIComponent(basename(assetPath))}`,
+    close: () => closeHttpServer(server),
+  }
+}
+
+async function closeHttpServer(server: HttpServer): Promise<void> {
+  if (!server.listening) {
+    return
+  }
+
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose())
+  })
+}
+
+function startupAssetVersion(versionQuery: string | undefined, wordpressZip: string): string {
+  return exactWordPressVersion(versionQuery) ?? `pre-resolved-${basename(wordpressZip).replace(/[^A-Za-z0-9_.-]+/g, "-")}`
+}
+
+function exactWordPressVersion(versionQuery: string | undefined): string | undefined {
+  if (!versionQuery || !/^\d+\.\d+(?:\.\d+)?$/.test(versionQuery)) {
+    return undefined
+  }
+
+  return versionQuery.endsWith(".0") ? versionQuery.split(".").slice(0, 2).join(".") : versionQuery
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value)
 }
 
 async function invalidZipReason(archivePath: string, size: number): Promise<string | undefined> {

--- a/scripts/playground-archive-cache-validation-smoke.ts
+++ b/scripts/playground-archive-cache-validation-smoke.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { validatePlaygroundWordPressArchiveCache } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import { resolvePlaygroundWordPressStartupAsset, validatePlaygroundWordPressArchiveCache } from "../packages/runtime-playground/src/playground-cli-runner.js"
 
 const cacheDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-playground-cache-"))
 
@@ -15,13 +15,40 @@ try {
 
   assert.equal(result.version, "7.1")
   assert.match(result.sourceUrl, /wordpress/i)
+  assert.equal(result.source, "inferred")
   assert.equal(result.invalidArchives.length, 2)
   assert.equal(result.invalidArchives.every((archive) => archive.deleted), true)
   assert.equal(existsSync(join(cacheDirectory, "7.1.zip")), false)
   assert.equal(existsSync(join(cacheDirectory, "prebuilt-wp-content-for-wp-7.1.zip")), false)
   assert.match(result.invalidArchives[0]?.reason ?? "", /too small|unexpected zip header/)
 
+  await writeFile(join(cacheDirectory, "7.2.zip"), minimalZipArchive())
+  const cachedStartupAsset = await resolvePlaygroundWordPressStartupAsset("7.2", undefined, cacheDirectory)
+  assert.equal(cachedStartupAsset.wp, undefined)
+  assert.equal(cachedStartupAsset.localPath, join(cacheDirectory, "7.2.zip"))
+  assert.equal(cachedStartupAsset.cacheValidation.source, "cache")
+  assert.equal(cachedStartupAsset.cacheValidation.sourceUrl, `cache:${join(cacheDirectory, "7.2.zip")}`)
+
+  const inferredStartupAsset = await resolvePlaygroundWordPressStartupAsset("7.3", undefined, cacheDirectory)
+  assert.equal(inferredStartupAsset.wp, "https://wordpress.org/wordpress-7.3.zip")
+  assert.equal(inferredStartupAsset.cacheValidation.source, "inferred")
+  assert.equal(inferredStartupAsset.cacheValidation.sourceUrl, "https://wordpress.org/wordpress-7.3.zip")
+
+  const preResolvedStartupAsset = await resolvePlaygroundWordPressStartupAsset("7.4", join(cacheDirectory, "7.2.zip"), cacheDirectory)
+  assert.equal(preResolvedStartupAsset.wp, undefined)
+  assert.equal(preResolvedStartupAsset.localPath, join(cacheDirectory, "7.2.zip"))
+  assert.equal(preResolvedStartupAsset.cacheValidation.source, "pre-resolved")
+
   console.log("Playground archive cache validation smoke passed")
 } finally {
   await rm(cacheDirectory, { recursive: true, force: true })
+}
+
+function minimalZipArchive(): Uint8Array {
+  const archive = new Uint8Array(22)
+  archive[0] = 0x50
+  archive[1] = 0x4b
+  archive[2] = 0x05
+  archive[3] = 0x06
+  return archive
 }


### PR DESCRIPTION
## Summary
- Add generic `runtime.assets.wordpressZip` support so recipes can provide a pre-resolved local or HTTP(S) WordPress zip for deterministic Playground startup.
- Prefer warm local WordPress archives for exact-version recipe runs and pass them to Playground through a loopback URL, avoiding live `api.wordpress.org` release metadata during startup.
- Preserve fallback behavior for unresolved aliases while surfacing the exact startup asset and source URL when release metadata cannot be resolved.

Closes #585.

## Testing
- `npm run build`
- `npm run playground-archive-cache-validation-smoke`
- `npm run recipe-build-cli-smoke`
- `npm run wordpress-recipe-builders-smoke`
- `npm run recipe-playground-boot-failure-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the deterministic startup/cache path, added focused smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.