### PR TITLE
Add benchmark matrix execution

### DIFF
--- a/docs/benchmark-contract.md
+++ b/docs/benchmark-contract.md
@@ -136,6 +136,67 @@ envelopes plus a flattened scenario summary for automation:
 Omit `--json` for a compact human-readable table. The human form is for quick
 inspection; automation should consume the JSON envelope.
 
+## Matrix Execution
+
+`bench matrix` runs the same benchmark recipe across an opaque cartesian product
+of mechanical dimensions. Dimensions are generic; callers decide whether they
+represent WordPress versions, environment maps, blueprint fragments, seeds,
+mounts, viewport settings, cache modes, or other runtime knobs.
+
+```bash
+npm run wp-codebox -- bench matrix \
+  --matrix ./benchmarks/matrix.json \
+  --json > ./artifacts/benchmark-matrix.json
+```
+
+Matrix definitions point at a base recipe and declare dimension values. When a
+value includes `value.recipe`, WP Codebox deep-merges that partial recipe into
+the base recipe for the generated cell recipe. Arrays are replaced, not merged.
+
+```json
+{
+  "schema": "wp-codebox/benchmark-recipe-matrix/v1",
+  "recipe": "./bench-plugin.recipe.json",
+  "artifacts": { "directory": "./artifacts/bench-plugin-matrix" },
+  "dimensions": [
+    {
+      "id": "wp",
+      "values": [
+        { "id": "6.9", "value": { "recipe": { "runtime": { "wp": "6.9" } } } },
+        { "id": "7.0", "value": { "recipe": { "runtime": { "wp": "7.0" } } } }
+      ]
+    },
+    {
+      "id": "cache",
+      "values": [
+        { "id": "cold", "provenance": { "cache": "cold" } },
+        { "id": "warm", "provenance": { "cache": "warm" } }
+      ]
+    }
+  ]
+}
+```
+
+Each cell gets its own generated recipe, `recipe-run.json`, and artifact bundle
+directory. The JSON output uses `wp-codebox/benchmark-matrix-run/v1` and groups
+benchmark envelopes by cell:
+
+```json
+{
+  "schema": "wp-codebox/benchmark-matrix-run/v1",
+  "matrix": { "schema": "wp-codebox/benchmark-matrix/v1", "cells": [], "diagnostics": [] },
+  "cells": [],
+  "benchResults": [
+    { "cellId": "wp:6.9__cache:cold", "cell": {}, "results": [] }
+  ],
+  "diagnostics": []
+}
+```
+
+Failed cells remain isolated as `cell-failed` diagnostics. A failed cell does not
+prevent later cells from running, and WP Codebox still does not score, grade,
+rank, retry, or publish benchmark results.
+
 ## Non-Responsibilities
 
 WP Codebox benchmark helpers do not define or store:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
     "run-registry-smoke": "tsx scripts/run-registry-smoke.ts",
     "benchmark-substrate-smoke": "tsx scripts/benchmark-substrate-smoke.ts",
+    "benchmark-matrix-cli-smoke": "tsx scripts/benchmark-matrix-cli-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "wordpress-state-contract-smoke": "tsx scripts/wordpress-state-contract-smoke.ts",
     "runtime-snapshot-restore-smoke": "tsx scripts/runtime-snapshot-restore-smoke.ts",

--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -1,7 +1,7 @@
 import { routeCliCommand } from "./command-router.js"
 import { runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
 import { runAgentTaskRunCommand } from "./commands/agent-task-run.js"
-import { runArtifactsBenchResultsCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
+import { runArtifactsBenchResultsCommand, runBenchMatrixCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
 import { runCommandsCommand, runRecipeSchemaCommand } from "./commands/discovery.js"
 import { runCleanupCommand, runDoctorCommand } from "./commands/doctor.js"
 import { runRecipeBuildCommand } from "./commands/recipe-build.js"
@@ -25,6 +25,7 @@ export async function runCli(args: string[]): Promise<number> {
     artifactsBrowserMetrics: runArtifactsBrowserMetricsCommand,
     artifactsBenchmark: runArtifactsBenchmarkCommand,
     artifactsBenchResults: runArtifactsBenchResultsCommand,
+    benchMatrix: runBenchMatrixCommand,
     benchSummarize: runBenchSummarizeCommand,
     runsStatus: runRunsStatusCommand,
     runsArtifacts: runRunsArtifactsCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -15,6 +15,7 @@ interface CliCommandRouter {
   artifactsBrowserMetrics: CliCommandHandler
   artifactsBenchmark: CliCommandHandler
   artifactsBenchResults: CliCommandHandler
+  benchMatrix: CliCommandHandler
   benchSummarize: CliCommandHandler
   runsStatus: CliCommandHandler
   runsArtifacts: CliCommandHandler
@@ -93,6 +94,9 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
       const subcommand = args.shift()
       if (subcommand === "summarize") {
         return router.benchSummarize(args)
+      }
+      if (subcommand === "matrix") {
+        return router.benchMatrix(args)
       }
       console.error(`Unknown bench command: ${subcommand ?? ""}`)
       router.printHelp()

--- a/packages/cli/src/commands/benchmark.ts
+++ b/packages/cli/src/commands/benchmark.ts
@@ -1,9 +1,20 @@
-import { readFile } from "node:fs/promises"
-import { join, resolve } from "node:path"
+import { spawn } from "node:child_process"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+import { expandBenchmarkMatrix, createBenchmarkMatrixCellFailure, createBenchmarkMatrixCellResults, type BenchmarkMatrixCell, type BenchmarkMatrixCellResult, type BenchmarkMatrixDimension, type BenchmarkResultEnvelope } from "@automattic/wp-codebox-core"
 
 interface BenchmarkSummaryOptions {
   inputPath?: string
   bundleDirectory?: string
+  json: boolean
+}
+
+interface BenchmarkMatrixOptions {
+  matrixPath: string
+  recipePath?: string
+  artifactsDirectory?: string
+  runRegistryDirectory?: string
+  timeout?: string
   json: boolean
 }
 
@@ -38,6 +49,33 @@ interface BenchmarkSummaryOutput {
   scenarios: BenchmarkScenarioSummary[]
 }
 
+interface BenchmarkRecipeMatrixDefinition {
+  schema?: "wp-codebox/benchmark-recipe-matrix/v1" | (string & {})
+  recipe?: string
+  dimensions?: BenchmarkMatrixDimension[]
+  artifacts?: string | { directory?: string }
+  runRegistry?: string
+  timeout?: string
+  metadata?: Record<string, unknown>
+}
+
+interface BenchmarkMatrixRunOutput {
+  schema: "wp-codebox/benchmark-matrix-run/v1"
+  source: {
+    matrixPath: string
+    recipePath: string
+  }
+  matrix: ReturnType<typeof expandBenchmarkMatrix>
+  cells: BenchmarkMatrixCellResult[]
+  benchResults: Array<{
+    cellId: string
+    cell: BenchmarkMatrixCell
+    results: BenchResults[]
+  }>
+  diagnostics: BenchmarkMatrixCellResult["diagnostics"]
+  provenance: Record<string, unknown>
+}
+
 export async function runBenchSummarizeCommand(args: string[]): Promise<number> {
   const options = parseBenchmarkSummaryOptions(args)
   const output = await summarizeBenchmarks(options)
@@ -48,6 +86,18 @@ export async function runBenchSummarizeCommand(args: string[]): Promise<number> 
 
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
   return 0
+}
+
+export async function runBenchMatrixCommand(args: string[]): Promise<number> {
+  const options = parseBenchmarkMatrixOptions(args)
+  const output = await runBenchmarkRecipeMatrix(options)
+  if (!options.json) {
+    printBenchmarkMatrixHumanOutput(output)
+    return output.diagnostics.length === 0 ? 0 : 1
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return output.diagnostics.length === 0 ? 0 : 1
 }
 
 export async function runArtifactsBenchResultsCommand(args: string[]): Promise<number> {
@@ -81,6 +131,95 @@ async function summarizeBenchmarks(options: BenchmarkSummaryOptions): Promise<Be
   }
 
   throw new Error("Missing required option: --input or --bundle")
+}
+
+async function runBenchmarkRecipeMatrix(options: BenchmarkMatrixOptions): Promise<BenchmarkMatrixRunOutput> {
+  const matrixPath = resolve(options.matrixPath)
+  const matrixDirectory = dirname(matrixPath)
+  const definition = JSON.parse(await readFile(matrixPath, "utf8")) as BenchmarkRecipeMatrixDefinition
+  const configuredRecipePath = options.recipePath ?? definition.recipe
+  if (!configuredRecipePath) {
+    throw new Error("Benchmark matrix requires --recipe or recipe in the matrix definition")
+  }
+  const recipePath = resolve(matrixDirectory, configuredRecipePath)
+
+  const baseRecipe = JSON.parse(await readFile(recipePath, "utf8")) as Record<string, unknown>
+  const dimensions = Array.isArray(definition.dimensions) ? definition.dimensions : []
+  const matrix = expandBenchmarkMatrix(dimensions)
+  const artifactsDirectory = resolve(matrixDirectory, options.artifactsDirectory ?? artifactsDirectoryFromDefinition(definition) ?? "artifacts/benchmark-matrix")
+  const cells: BenchmarkMatrixCellResult[] = []
+  if (matrix.diagnostics.length > 0) {
+    return {
+      schema: "wp-codebox/benchmark-matrix-run/v1",
+      source: { matrixPath, recipePath },
+      matrix,
+      cells,
+      benchResults: [],
+      diagnostics: matrix.diagnostics.map((diagnostic) => ({
+        type: "cell-failed",
+        severity: diagnostic.severity,
+        cellId: "matrix-expansion",
+        code: diagnostic.type,
+        message: diagnostic.message,
+      })),
+      provenance: {
+        generated_at: new Date().toISOString(),
+        command: "bench matrix",
+        ...(definition.metadata ? { definition: { metadata: definition.metadata } } : {}),
+      },
+    }
+  }
+
+  for (const cell of matrix.cells) {
+    const cellDirectory = join(artifactsDirectory, safeCellDirectoryName(cell.id))
+    const cellArtifactsDirectory = join(cellDirectory, "artifacts")
+    const cellRecipePath = join(cellDirectory, "recipe.json")
+    const recipe = applyCellRecipePatches(baseRecipe, cell)
+    await mkdir(cellArtifactsDirectory, { recursive: true })
+    await writeFile(cellRecipePath, `${JSON.stringify(recipe, null, 2)}\n`)
+
+    const recipeRun = await runRecipeRunForMatrixCell({
+      recipePath: cellRecipePath,
+      artifactsDirectory: cellArtifactsDirectory,
+      runRegistryDirectory: options.runRegistryDirectory ?? definition.runRegistry,
+      timeout: options.timeout ?? definition.timeout,
+    })
+    await writeFile(join(cellDirectory, "recipe-run.json"), `${recipeRun.stdout}\n`)
+
+    if (recipeRun.status === 0 && isRecord(recipeRun.output) && recipeRun.output.success === true) {
+      const benchResultsList = extractBenchResultsFromRecipeRun(recipeRun.output)
+      cells.push({
+        ...createBenchmarkMatrixCellResults(cell, benchResultsList as BenchmarkResultEnvelope[]),
+        diagnostics: benchResultsList.length > 0 ? [] : [{
+          type: "cell-failed",
+          severity: "error",
+          cellId: cell.id,
+          code: "missing-bench-results",
+          message: `Benchmark matrix cell "${cell.id}" completed without benchResults.`,
+        }],
+        ...(benchResultsList.length === 0 ? { status: "failed" as const } : {}),
+      })
+      continue
+    }
+
+    cells.push(createBenchmarkMatrixCellFailure(cell, recipeRunFailure(recipeRun)))
+  }
+
+  return {
+    schema: "wp-codebox/benchmark-matrix-run/v1",
+    source: { matrixPath, recipePath },
+    matrix,
+    cells,
+    benchResults: cells
+      .filter((cell): cell is BenchmarkMatrixCellResult & { benchResultsList: BenchResults[] } => cell.status === "succeeded" && Array.isArray(cell.benchResultsList))
+      .map((cell) => ({ cellId: cell.cell.id, cell: cell.cell, results: cell.benchResultsList })),
+    diagnostics: cells.flatMap((cell) => cell.diagnostics),
+    provenance: {
+      generated_at: new Date().toISOString(),
+      command: "bench matrix",
+      ...(definition.metadata ? { definition: { metadata: definition.metadata } } : {}),
+    },
+  }
 }
 
 function benchmarkSummaryOutput(source: BenchmarkSummaryOutput["source"], benchmarks: BenchResults[]): BenchmarkSummaryOutput {
@@ -222,6 +361,14 @@ function printBenchmarkSummaryHumanOutput(output: BenchmarkSummaryOutput): void 
   }
 }
 
+function printBenchmarkMatrixHumanOutput(output: BenchmarkMatrixRunOutput): void {
+  console.log("WP Codebox benchmark matrix")
+  console.log(`Recipe: ${output.source.recipePath}`)
+  console.log(`Cells: ${output.cells.length}`)
+  console.log(`Succeeded: ${output.cells.filter((cell) => cell.status === "succeeded").length}`)
+  console.log(`Failed: ${output.cells.filter((cell) => cell.status === "failed").length}`)
+}
+
 function parseBenchmarkSummaryOptions(args: string[], config: { requireBundle?: boolean } = {}): BenchmarkSummaryOptions {
   const options: Partial<BenchmarkSummaryOptions> = { json: false }
 
@@ -266,6 +413,114 @@ function parseBenchmarkSummaryOptions(args: string[], config: { requireBundle?: 
   }
 
   return options as BenchmarkSummaryOptions
+}
+
+function parseBenchmarkMatrixOptions(args: string[]): BenchmarkMatrixOptions {
+  const options: Partial<BenchmarkMatrixOptions> = { json: false }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--matrix":
+        options.matrixPath = value
+        break
+      case "--recipe":
+        options.recipePath = value
+        break
+      case "--artifacts":
+        options.artifactsDirectory = value
+        break
+      case "--run-registry":
+        options.runRegistryDirectory = value
+        break
+      case "--timeout":
+        options.timeout = value
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (!options.matrixPath) {
+    throw new Error("bench matrix requires --matrix <path>")
+  }
+
+  return options as BenchmarkMatrixOptions
+}
+
+async function runRecipeRunForMatrixCell(options: { recipePath: string; artifactsDirectory: string; runRegistryDirectory?: string; timeout?: string }): Promise<{ status: number; stdout: string; stderr: string; output: unknown }> {
+  const args = [process.argv[1] ?? "", "recipe-run", "--recipe", options.recipePath, "--artifacts", options.artifactsDirectory, "--json"]
+  if (options.runRegistryDirectory) {
+    args.push("--run-registry", options.runRegistryDirectory)
+  }
+  if (options.timeout) {
+    args.push("--timeout", options.timeout)
+  }
+
+  const result = await new Promise<{ status: number; stdout: string; stderr: string }>((resolveResult, reject) => {
+    const child = spawn(process.execPath, args)
+    let stdout = ""
+    let stderr = ""
+    child.stdout?.setEncoding("utf8")
+    child.stderr?.setEncoding("utf8")
+    child.stdout?.on("data", (chunk: string) => { stdout += chunk })
+    child.stderr?.on("data", (chunk: string) => { stderr += chunk })
+    child.once("error", reject)
+    child.once("close", (status) => resolveResult({ status: status ?? 1, stdout, stderr }))
+  })
+
+  return { ...result, output: parseJsonObject(result.stdout) }
+}
+
+function applyCellRecipePatches(baseRecipe: Record<string, unknown>, cell: BenchmarkMatrixCell): Record<string, unknown> {
+  return Object.values(cell.dimensions).reduce((recipe, dimensionValue) => {
+    const patch = isRecord(dimensionValue.value) && isRecord(dimensionValue.value.recipe) ? dimensionValue.value.recipe : undefined
+    return patch ? deepMerge(recipe, patch) : recipe
+  }, deepClone(baseRecipe) as Record<string, unknown>)
+}
+
+function deepMerge(left: Record<string, unknown>, right: Record<string, unknown>): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...left }
+  for (const [key, value] of Object.entries(right)) {
+    merged[key] = isRecord(value) && isRecord(merged[key]) ? deepMerge(merged[key], value) : value
+  }
+  return merged
+}
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function artifactsDirectoryFromDefinition(definition: BenchmarkRecipeMatrixDefinition): string | undefined {
+  return typeof definition.artifacts === "string" ? definition.artifacts : definition.artifacts?.directory
+}
+
+function safeCellDirectoryName(cellId: string): string {
+  return cellId.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") || "cell"
+}
+
+function recipeRunFailure(recipeRun: { status: number; stderr: string; output: unknown }): Error & { code?: string } {
+  const error = new Error(recipeRunErrorMessage(recipeRun)) as Error & { code?: string }
+  error.code = isRecord(recipeRun.output) && isRecord(recipeRun.output.error) && typeof recipeRun.output.error.code === "string" ? recipeRun.output.error.code : `recipe-run-exit-${recipeRun.status}`
+  return error
+}
+
+function recipeRunErrorMessage(recipeRun: { status: number; stderr: string; output: unknown }): string {
+  if (isRecord(recipeRun.output) && isRecord(recipeRun.output.error) && typeof recipeRun.output.error.message === "string") {
+    return recipeRun.output.error.message
+  }
+  return recipeRun.stderr.trim() || `recipe-run exited with status ${recipeRun.status}`
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -252,6 +252,7 @@ export function printHelp(): void {
   wp-codebox workspace-policy check --workspace-root <path> --writable-root <path> [options]
   wp-codebox recipe build phpunit --options <path> [--output <path>]
   wp-codebox recipe validate --recipe <path> [--json]
+  wp-codebox bench matrix --matrix <path> [--recipe <path>] [--artifacts <dir>] [--json]
   wp-codebox bench summarize (--input <recipe-run.json>|--bundle <dir>) [--json]
   wp-codebox artifacts verify --bundle <dir> [--json]
   wp-codebox artifacts browser-metrics --bundle <dir> [--json]
@@ -278,6 +279,7 @@ Options:
   --scenario-id <id>  Filter benchmark artifact refs to one scenario.
   --extract-to <dir>  Copy listed benchmark artifact refs to a directory.
   --input <path>      Saved recipe-run JSON output for benchmark summarization.
+  --matrix <path>     Benchmark recipe matrix JSON file for bench matrix.
   --artifacts <dir>   Artifact root directory. Also accepted by artifacts verify.
   --run-registry <dir>
                        Durable run registry directory for recipe-run.

--- a/packages/runtime-core/src/benchmark-substrate.ts
+++ b/packages/runtime-core/src/benchmark-substrate.ts
@@ -69,8 +69,31 @@ export interface BenchmarkMatrixCellResult {
   cell: BenchmarkMatrixCell
   status: "succeeded" | "failed"
   benchResults?: BenchmarkResultEnvelope
+  benchResultsList?: BenchmarkResultEnvelope[]
   diagnostics: BenchmarkMatrixCellDiagnostic[]
 }
+
+export interface BenchmarkMatrixGroupedBenchResults {
+  cellId: string
+  cell: BenchmarkMatrixCell
+  results: BenchmarkResultEnvelope[]
+}
+
+export interface BenchmarkMatrixRun {
+  schema: "wp-codebox/benchmark-matrix-run/v1"
+  matrix: BenchmarkMatrixExpansion
+  cells: BenchmarkMatrixCellResult[]
+  benchResults: BenchmarkMatrixGroupedBenchResults[]
+  diagnostics: BenchmarkMatrixCellDiagnostic[]
+  provenance: Record<string, unknown>
+}
+
+export interface ExecuteBenchmarkMatrixOptions {
+  generatedAt?: string
+  provenance?: Record<string, unknown>
+}
+
+export type BenchmarkMatrixCellRunner = (cell: BenchmarkMatrixCell) => Promise<BenchmarkResultEnvelope | BenchmarkResultEnvelope[]>
 
 export interface BenchmarkComparisonMetricDelta {
   scenarioId: string
@@ -152,6 +175,17 @@ export function createBenchmarkMatrixCellResult(cell: BenchmarkMatrixCell, bench
   }
 }
 
+export function createBenchmarkMatrixCellResults(cell: BenchmarkMatrixCell, benchResultsList: BenchmarkResultEnvelope[]): BenchmarkMatrixCellResult {
+  return {
+    schema: "wp-codebox/benchmark-matrix-cell-result/v1",
+    cell,
+    status: "succeeded",
+    ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
+    benchResultsList,
+    diagnostics: [],
+  }
+}
+
 export function createBenchmarkMatrixCellFailure(cell: BenchmarkMatrixCell, error: unknown): BenchmarkMatrixCellResult {
   const normalized = normalizeError(error)
   return {
@@ -165,6 +199,48 @@ export function createBenchmarkMatrixCellFailure(cell: BenchmarkMatrixCell, erro
       message: normalized.message,
       ...(normalized.code ? { code: normalized.code } : {}),
     }],
+  }
+}
+
+export async function executeBenchmarkMatrix(dimensions: readonly BenchmarkMatrixDimension[], runCell: BenchmarkMatrixCellRunner, options: ExecuteBenchmarkMatrixOptions = {}): Promise<BenchmarkMatrixRun> {
+  const matrix = expandBenchmarkMatrix(dimensions)
+  const cells: BenchmarkMatrixCellResult[] = []
+
+  if (matrix.diagnostics.length > 0) {
+    return {
+      schema: "wp-codebox/benchmark-matrix-run/v1",
+      matrix,
+      cells,
+      benchResults: [],
+      diagnostics: matrix.diagnostics.map((diagnostic) => ({
+        type: "cell-failed",
+        severity: diagnostic.severity,
+        cellId: "matrix-expansion",
+        message: diagnostic.message,
+        code: diagnostic.type,
+      })),
+      provenance: matrixRunProvenance(options),
+    }
+  }
+
+  for (const cell of matrix.cells) {
+    try {
+      const result = await runCell(cell)
+      cells.push(createBenchmarkMatrixCellResults(cell, Array.isArray(result) ? result : [result]))
+    } catch (error) {
+      cells.push(createBenchmarkMatrixCellFailure(cell, error))
+    }
+  }
+
+  return {
+    schema: "wp-codebox/benchmark-matrix-run/v1",
+    matrix,
+    cells,
+    benchResults: cells
+      .filter((cell): cell is BenchmarkMatrixCellResult & { benchResultsList: BenchmarkResultEnvelope[] } => cell.status === "succeeded" && Array.isArray(cell.benchResultsList))
+      .map((cell) => ({ cellId: cell.cell.id, cell: cell.cell, results: cell.benchResultsList })),
+    diagnostics: cells.flatMap((cell) => cell.diagnostics),
+    provenance: matrixRunProvenance(options),
   }
 }
 
@@ -341,4 +417,11 @@ function normalizeError(error: unknown): { message: string; code?: string } {
     return { message: error.message, ...(code ? { code } : {}) }
   }
   return { message: typeof error === "string" ? error : "Benchmark matrix cell failed." }
+}
+
+function matrixRunProvenance(options: ExecuteBenchmarkMatrixOptions): Record<string, unknown> {
+  return {
+    generated_at: options.generatedAt ?? new Date().toISOString(),
+    ...(options.provenance ?? {}),
+  }
 }

--- a/scripts/benchmark-matrix-cli-smoke.ts
+++ b/scripts/benchmark-matrix-cli-smoke.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const workspace = resolve(root, "artifacts/benchmark-matrix-cli-smoke")
+const recipePath = resolve(workspace, "recipe.json")
+const matrixPath = resolve(workspace, "matrix.json")
+
+rmSync(workspace, { recursive: true, force: true })
+mkdirSync(workspace, { recursive: true })
+
+writeFileSync(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: { steps: [{ command: "wordpress.bench", args: [] }] },
+}, null, 2)}\n`)
+
+writeFileSync(matrixPath, `${JSON.stringify({
+  schema: "wp-codebox/benchmark-recipe-matrix/v1",
+  recipe: "./recipe.json",
+  dimensions: [
+    { id: "wp", values: [{ id: "7.0", value: { recipe: { runtime: { wp: "7.0" } } } }] },
+    { id: "cache", values: [] },
+  ],
+}, null, 2)}\n`)
+
+const result = spawnSync(process.execPath, [cli, "bench", "matrix", "--matrix", matrixPath, "--json"], { cwd: root, encoding: "utf8" })
+assert.equal(result.status, 1, result.stderr || result.stdout)
+
+const output = JSON.parse(result.stdout)
+assert.equal(output.schema, "wp-codebox/benchmark-matrix-run/v1")
+assert.equal(output.matrix.schema, "wp-codebox/benchmark-matrix/v1")
+assert.equal(output.matrix.cells.length, 0)
+assert.equal(output.diagnostics.length, 1)
+assert.equal(output.diagnostics[0].cellId, "matrix-expansion")
+assert.equal(output.diagnostics[0].code, "empty-dimension")
+
+console.log("benchmark matrix cli smoke passed")

--- a/scripts/benchmark-substrate-smoke.ts
+++ b/scripts/benchmark-substrate-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { compareBenchmarkResults, createBenchmarkMatrixCellFailure, createBenchmarkMatrixCellResult, expandBenchmarkMatrix } from "@automattic/wp-codebox-core"
+import { compareBenchmarkResults, createBenchmarkMatrixCellFailure, createBenchmarkMatrixCellResult, executeBenchmarkMatrix, expandBenchmarkMatrix } from "@automattic/wp-codebox-core"
 
 const matrix = expandBenchmarkMatrix([
   {
@@ -38,6 +38,42 @@ const failure = createBenchmarkMatrixCellFailure(cell, Object.assign(new Error("
 assert.equal(failure.status, "failed")
 assert.equal(failure.diagnostics[0]?.type, "cell-failed")
 assert.equal(failure.diagnostics[0]?.code, "boot-failed")
+
+const matrixRun = await executeBenchmarkMatrix([
+  {
+    id: "wp",
+    values: [
+      { id: "6.9", value: { recipe: { runtime: { wp: "6.9" } } } },
+      { id: "7.0", value: { recipe: { runtime: { wp: "7.0" } } } },
+    ],
+  },
+  {
+    id: "cache",
+    values: [
+      { id: "cold", value: { recipe: { workflow: { steps: [{ command: "wordpress.bench", args: ["cache=cold"] }] } } } },
+      { id: "warm", value: { recipe: { workflow: { steps: [{ command: "wordpress.bench", args: ["cache=warm"] }] } } } },
+    ],
+  },
+], async (matrixCell) => {
+  if (matrixCell.id === "wp:7.0__cache:warm") {
+    throw Object.assign(new Error("simulated cell failure"), { code: "simulated-failure" })
+  }
+
+  return {
+    component_id: "demo",
+    iterations: 1,
+    scenarios: [{ id: matrixCell.id, iterations: 1, metrics: { duration_ms_mean: 1 } }],
+  }
+}, { generatedAt: "2026-06-04T00:00:00.000Z" })
+
+assert.equal(matrixRun.schema, "wp-codebox/benchmark-matrix-run/v1")
+assert.equal(matrixRun.matrix.cells.length, 4)
+assert.equal(matrixRun.cells.length, 4)
+assert.equal(matrixRun.benchResults.length, 3)
+assert.equal(matrixRun.diagnostics.length, 1)
+assert.equal(matrixRun.diagnostics[0]?.cellId, "wp:7.0__cache:warm")
+assert.equal(matrixRun.diagnostics[0]?.code, "simulated-failure")
+assert.equal(matrixRun.cells.find((matrixCell) => matrixCell.cell.id === "wp:7.0__cache:warm")?.status, "failed")
 
 const comparison = compareBenchmarkResults(
   {


### PR DESCRIPTION
## Summary
- Adds a generic benchmark matrix run envelope that executes expanded cells and groups `benchResults` by cell.
- Adds `wp-codebox bench matrix` to generate per-cell recipes, run `recipe-run`, isolate failed cells, and preserve structured diagnostics.
- Documents the opaque `value.recipe` patch contract for mechanical recipe dimensions.

Refs #573.

## Verification
- `npm run build`
- `npm run benchmark-substrate-smoke`
- `npm run benchmark-summary-smoke`
- `npm run benchmark-matrix-cli-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic matrix execution layer, CLI helper, docs, and smoke coverage; Chris remains responsible for review and testing.