### PR TITLE
Add generic benchmark comparison helpers

### DIFF
--- a/docs/benchmark-contract.md
+++ b/docs/benchmark-contract.md
@@ -22,6 +22,7 @@ caller benchmark suite
 - Capture runtime artifacts, command logs, browser evidence, and provenance.
 - Emit `benchResults` and `benchResultsList` in `wp-codebox/recipe-run/v1` JSON output when `wordpress.bench` steps succeed.
 - Provide CLI helpers that extract benchmark envelopes from saved `recipe-run` output or artifact bundles.
+- Provide CLI/API helpers that compare compatible baseline/candidate benchmark envelopes and emit generic deltas plus diagnostics.
 - Keep helper output stable, JSON-friendly, and free of product-specific scoring fields.
 
 ## Caller Responsibilities
@@ -135,6 +136,36 @@ envelopes plus a flattened scenario summary for automation:
 
 Omit `--json` for a compact human-readable table. The human form is for quick
 inspection; automation should consume the JSON envelope.
+
+## Comparing Results
+
+Compare two saved `recipe-run` JSON outputs:
+
+```bash
+npm run wp-codebox -- bench compare \
+  --baseline-input ./artifacts/baseline/recipe-run.json \
+  --candidate-input ./artifacts/candidate/recipe-run.json \
+  --json
+```
+
+Compare two artifact bundles by reading each bundle's command log:
+
+```bash
+npm run wp-codebox -- artifacts bench-compare \
+  --baseline-bundle ./artifacts/baseline \
+  --candidate-bundle ./artifacts/candidate \
+  --json
+```
+
+Both commands emit `wp-codebox/benchmark-comparison/v1`. The comparison surface
+is mechanical: it matches scenario ids and metric ids, compares numeric values or
+`samples.mean` from metric records, emits absolute and percent deltas, carries
+sample counts and stability metadata, and reports missing scenarios or metrics as
+diagnostics. It does not decide whether a delta is a regression, improvement,
+pass, or failure.
+
+When a source contains multiple benchmark envelopes, select an envelope with
+`--baseline-index` or `--candidate-index`.
 
 ## Non-Responsibilities
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
     "run-registry-smoke": "tsx scripts/run-registry-smoke.ts",
     "benchmark-substrate-smoke": "tsx scripts/benchmark-substrate-smoke.ts",
+    "benchmark-comparison-smoke": "tsx scripts/benchmark-comparison-smoke.ts",
     "runtime-episode-smoke": "tsx scripts/runtime-episode-smoke.ts",
     "wordpress-state-contract-smoke": "tsx scripts/wordpress-state-contract-smoke.ts",
     "runtime-snapshot-restore-smoke": "tsx scripts/runtime-snapshot-restore-smoke.ts",

--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -1,7 +1,7 @@
 import { routeCliCommand } from "./command-router.js"
 import { runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
 import { runAgentTaskRunCommand } from "./commands/agent-task-run.js"
-import { runArtifactsBenchResultsCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
+import { runArtifactsBenchCompareCommand, runArtifactsBenchResultsCommand, runBenchCompareCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
 import { runCommandsCommand, runRecipeSchemaCommand } from "./commands/discovery.js"
 import { runCleanupCommand, runDoctorCommand } from "./commands/doctor.js"
 import { runRecipeBuildCommand } from "./commands/recipe-build.js"
@@ -25,7 +25,9 @@ export async function runCli(args: string[]): Promise<number> {
     artifactsBrowserMetrics: runArtifactsBrowserMetricsCommand,
     artifactsBenchmark: runArtifactsBenchmarkCommand,
     artifactsBenchResults: runArtifactsBenchResultsCommand,
+    artifactsBenchCompare: runArtifactsBenchCompareCommand,
     benchSummarize: runBenchSummarizeCommand,
+    benchCompare: runBenchCompareCommand,
     runsStatus: runRunsStatusCommand,
     runsArtifacts: runRunsArtifactsCommand,
     commands: runCommandsCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -15,7 +15,9 @@ interface CliCommandRouter {
   artifactsBrowserMetrics: CliCommandHandler
   artifactsBenchmark: CliCommandHandler
   artifactsBenchResults: CliCommandHandler
+  artifactsBenchCompare: CliCommandHandler
   benchSummarize: CliCommandHandler
+  benchCompare: CliCommandHandler
   runsStatus: CliCommandHandler
   runsArtifacts: CliCommandHandler
   commands: CliCommandHandler
@@ -85,6 +87,9 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
       if (subcommand === "bench-results") {
         return router.artifactsBenchResults(args)
       }
+      if (subcommand === "bench-compare") {
+        return router.artifactsBenchCompare(args)
+      }
       console.error(`Unknown artifacts command: ${subcommand ?? ""}`)
       router.printHelp()
       return 1
@@ -93,6 +98,9 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
       const subcommand = args.shift()
       if (subcommand === "summarize") {
         return router.benchSummarize(args)
+      }
+      if (subcommand === "compare") {
+        return router.benchCompare(args)
       }
       console.error(`Unknown bench command: ${subcommand ?? ""}`)
       router.printHelp()

--- a/packages/cli/src/commands/benchmark.ts
+++ b/packages/cli/src/commands/benchmark.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
+import { compareBenchmarkResults, type BenchmarkComparison, type BenchmarkResultEnvelope, type BenchmarkRunRef, type BenchmarkScenarioResult } from "@automattic/wp-codebox-core"
 
 interface BenchmarkSummaryOptions {
   inputPath?: string
@@ -7,12 +8,35 @@ interface BenchmarkSummaryOptions {
   json: boolean
 }
 
-interface BenchResults {
+interface BenchmarkCompareOptions {
+  baselineInputPath?: string
+  candidateInputPath?: string
+  baselineBundleDirectory?: string
+  candidateBundleDirectory?: string
+  baselineIndex?: number
+  candidateIndex?: number
+  json: boolean
+}
+
+interface BenchResults extends BenchmarkResultEnvelope {
   component_id?: string
   iterations?: number
   warmup_iterations?: number
-  scenarios?: unknown[]
+  scenarios?: BenchmarkScenarioResult[]
   [key: string]: unknown
+}
+
+interface BenchmarkSourceRef {
+  type: "recipe-run-output" | "artifact-bundle"
+  path: string
+  benchmarkIndex: number
+}
+
+interface BenchmarkCompareOutput extends BenchmarkComparison {
+  source: {
+    baseline: BenchmarkSourceRef
+    candidate: BenchmarkSourceRef
+  }
 }
 
 interface BenchmarkScenarioSummary {
@@ -62,6 +86,30 @@ export async function runArtifactsBenchResultsCommand(args: string[]): Promise<n
   return 0
 }
 
+export async function runBenchCompareCommand(args: string[]): Promise<number> {
+  const options = parseBenchmarkCompareOptions(args)
+  const output = await compareBenchmarks(options)
+  if (!options.json) {
+    printBenchmarkCompareHumanOutput(output)
+    return 0
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return 0
+}
+
+export async function runArtifactsBenchCompareCommand(args: string[]): Promise<number> {
+  const options = parseBenchmarkCompareOptions(args, { requireBundles: true })
+  const output = await compareBenchmarks(options)
+  if (!options.json) {
+    printBenchmarkCompareHumanOutput(output)
+    return 0
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return 0
+}
+
 async function summarizeBenchmarks(options: BenchmarkSummaryOptions): Promise<BenchmarkSummaryOutput> {
   if (options.inputPath) {
     const inputPath = resolve(options.inputPath)
@@ -71,16 +119,75 @@ async function summarizeBenchmarks(options: BenchmarkSummaryOptions): Promise<Be
 
   if (options.bundleDirectory) {
     const bundleDirectory = resolve(options.bundleDirectory)
-    const commandsLog = await readFile(join(bundleDirectory, "logs", "commands.log"), "utf8").catch((error: unknown) => {
-      if (isRecord(error) && error.code === "ENOENT") {
-        return ""
-      }
-      throw error
-    })
+    const commandsLog = await readArtifactBundleCommandsLog(bundleDirectory)
     return benchmarkSummaryOutput({ type: "artifact-bundle", path: bundleDirectory }, extractBenchResultsFromText(commandsLog))
   }
 
   throw new Error("Missing required option: --input or --bundle")
+}
+
+async function compareBenchmarks(options: BenchmarkCompareOptions): Promise<BenchmarkCompareOutput> {
+  const baseline = await loadBenchmarkForComparison("baseline", options)
+  const candidate = await loadBenchmarkForComparison("candidate", options)
+  return {
+    ...compareBenchmarkResults(baseline.benchmark, candidate.benchmark, {
+      baseline: benchmarkRunRef(baseline.source),
+      candidate: benchmarkRunRef(candidate.source),
+    }),
+    source: {
+      baseline: baseline.source,
+      candidate: candidate.source,
+    },
+  }
+}
+
+async function loadBenchmarkForComparison(kind: "baseline" | "candidate", options: BenchmarkCompareOptions): Promise<{ source: BenchmarkSourceRef; benchmark: BenchResults }> {
+  const inputPath = kind === "baseline" ? options.baselineInputPath : options.candidateInputPath
+  const bundleDirectory = kind === "baseline" ? options.baselineBundleDirectory : options.candidateBundleDirectory
+  const benchmarkIndex = kind === "baseline" ? options.baselineIndex ?? 0 : options.candidateIndex ?? 0
+
+  if (inputPath) {
+    const resolvedPath = resolve(inputPath)
+    const parsed = JSON.parse(await readFile(resolvedPath, "utf8")) as unknown
+    return selectBenchmark(kind, { type: "recipe-run-output", path: resolvedPath, benchmarkIndex }, extractBenchResultsFromRecipeRun(parsed))
+  }
+
+  if (bundleDirectory) {
+    const resolvedDirectory = resolve(bundleDirectory)
+    const commandsLog = await readArtifactBundleCommandsLog(resolvedDirectory)
+    return selectBenchmark(kind, { type: "artifact-bundle", path: resolvedDirectory, benchmarkIndex }, extractBenchResultsFromText(commandsLog))
+  }
+
+  throw new Error(`Missing required ${kind} source: use --${kind}-input or --${kind}-bundle`)
+}
+
+function selectBenchmark(kind: "baseline" | "candidate", source: BenchmarkSourceRef, benchmarks: BenchResults[]): { source: BenchmarkSourceRef; benchmark: BenchResults } {
+  const benchmark = benchmarks[source.benchmarkIndex]
+  if (!benchmark) {
+    throw new Error(`No ${kind} benchResults envelope found at index ${source.benchmarkIndex} in ${source.path}.`)
+  }
+  return { source, benchmark }
+}
+
+function benchmarkRunRef(source: BenchmarkSourceRef): BenchmarkRunRef {
+  return {
+    label: source.type,
+    artifactRef: source.path,
+    provenance: {
+      sourceType: source.type,
+      path: source.path,
+      benchmarkIndex: source.benchmarkIndex,
+    },
+  }
+}
+
+async function readArtifactBundleCommandsLog(bundleDirectory: string): Promise<string> {
+  return readFile(join(bundleDirectory, "logs", "commands.log"), "utf8").catch((error: unknown) => {
+    if (isRecord(error) && error.code === "ENOENT") {
+      return ""
+    }
+    throw error
+  })
 }
 
 function benchmarkSummaryOutput(source: BenchmarkSummaryOutput["source"], benchmarks: BenchResults[]): BenchmarkSummaryOutput {
@@ -201,9 +308,20 @@ function numericRecord(value: unknown): Record<string, number> {
 
   return Object.fromEntries(
     Object.entries(value)
-      .filter((entry): entry is [string, number] => typeof entry[1] === "number" && Number.isFinite(entry[1]))
+      .map(([key, metric]) => [key, numericMetricValue(metric)] as const)
+      .filter((entry): entry is readonly [string, number] => typeof entry[1] === "number" && Number.isFinite(entry[1]))
       .sort(([left], [right]) => left.localeCompare(right)),
   )
+}
+
+function numericMetricValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+  if (isRecord(value) && isRecord(value.samples) && typeof value.samples.mean === "number" && Number.isFinite(value.samples.mean)) {
+    return value.samples.mean
+  }
+  return undefined
 }
 
 function printBenchmarkSummaryHumanOutput(output: BenchmarkSummaryOutput): void {
@@ -220,6 +338,92 @@ function printBenchmarkSummaryHumanOutput(output: BenchmarkSummaryOutput): void 
   for (const scenario of output.scenarios) {
     console.log(`  ${scenario.componentId}/${scenario.id}: ${scenario.metricCount} metrics`)
   }
+}
+
+function printBenchmarkCompareHumanOutput(output: BenchmarkCompareOutput): void {
+  console.log("WP Codebox benchmark comparison")
+  console.log(`Baseline: ${output.source.baseline.path}`)
+  console.log(`Candidate: ${output.source.candidate.path}`)
+  console.log(`Scenarios compared: ${output.pairs.length}`)
+  console.log(`Diagnostics: ${output.diagnostics.length}`)
+
+  for (const pair of output.pairs) {
+    console.log(`  ${pair.scenarioId}: ${pair.metrics.length} metric delta${pair.metrics.length === 1 ? "" : "s"}`)
+    for (const metric of pair.metrics) {
+      const percent = metric.percentDelta === undefined ? "n/a" : `${metric.percentDelta.toFixed(2)}%`
+      console.log(`    ${metric.metricId}: ${metric.baseline} -> ${metric.candidate} (${metric.absoluteDelta >= 0 ? "+" : ""}${metric.absoluteDelta}, ${percent})`)
+    }
+  }
+}
+
+function parseBenchmarkCompareOptions(args: string[], config: { requireBundles?: boolean } = {}): BenchmarkCompareOptions {
+  const options: Partial<BenchmarkCompareOptions> = { json: false }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--baseline":
+      case "--baseline-input":
+        options.baselineInputPath = value
+        break
+      case "--candidate":
+      case "--candidate-input":
+        options.candidateInputPath = value
+        break
+      case "--baseline-bundle":
+      case "--baseline-artifacts":
+        options.baselineBundleDirectory = value
+        break
+      case "--candidate-bundle":
+      case "--candidate-artifacts":
+        options.candidateBundleDirectory = value
+        break
+      case "--baseline-index":
+        options.baselineIndex = parseBenchmarkIndex(value, name)
+        break
+      case "--candidate-index":
+        options.candidateIndex = parseBenchmarkIndex(value, name)
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (config.requireBundles && (options.baselineInputPath || options.candidateInputPath)) {
+    throw new Error("Use --baseline-bundle and --candidate-bundle with artifacts bench-compare")
+  }
+  if (config.requireBundles && (!options.baselineBundleDirectory || !options.candidateBundleDirectory)) {
+    throw new Error("Missing required options: --baseline-bundle and --candidate-bundle")
+  }
+  if (!config.requireBundles && !options.baselineInputPath && !options.baselineBundleDirectory) {
+    throw new Error("Missing required option: --baseline-input or --baseline-bundle")
+  }
+  if (!config.requireBundles && !options.candidateInputPath && !options.candidateBundleDirectory) {
+    throw new Error("Missing required option: --candidate-input or --candidate-bundle")
+  }
+
+  return options as BenchmarkCompareOptions
+}
+
+function parseBenchmarkIndex(value: string, name: string): number {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`)
+  }
+  return parsed
 }
 
 function parseBenchmarkSummaryOptions(args: string[], config: { requireBundle?: boolean } = {}): BenchmarkSummaryOptions {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -253,10 +253,12 @@ export function printHelp(): void {
   wp-codebox recipe build phpunit --options <path> [--output <path>]
   wp-codebox recipe validate --recipe <path> [--json]
   wp-codebox bench summarize (--input <recipe-run.json>|--bundle <dir>) [--json]
+  wp-codebox bench compare --baseline-input <recipe-run.json> --candidate-input <recipe-run.json> [--json]
   wp-codebox artifacts verify --bundle <dir> [--json]
   wp-codebox artifacts browser-metrics --bundle <dir> [--json]
   wp-codebox artifacts benchmark --bundle <dir> [--scenario-id <id>] [--extract-to <dir>] [--json]
   wp-codebox artifacts bench-results --bundle <dir> [--json]
+  wp-codebox artifacts bench-compare --baseline-bundle <dir> --candidate-bundle <dir> [--json]
   wp-codebox runs status --registry <dir> --run-id <id> [--json]
   wp-codebox runs artifacts --registry <dir> --run-id <id> [--json]
   wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
@@ -278,6 +280,18 @@ Options:
   --scenario-id <id>  Filter benchmark artifact refs to one scenario.
   --extract-to <dir>  Copy listed benchmark artifact refs to a directory.
   --input <path>      Saved recipe-run JSON output for benchmark summarization.
+  --baseline-input <path>
+                       Saved baseline recipe-run JSON for benchmark comparison.
+  --candidate-input <path>
+                       Saved candidate recipe-run JSON for benchmark comparison.
+  --baseline-bundle <dir>
+                       Baseline artifact bundle directory for benchmark comparison.
+  --candidate-bundle <dir>
+                       Candidate artifact bundle directory for benchmark comparison.
+  --baseline-index <n>
+                       Benchmark envelope index to compare when a source has multiple results.
+  --candidate-index <n>
+                       Benchmark envelope index to compare when a source has multiple results.
   --artifacts <dir>   Artifact root directory. Also accepted by artifacts verify.
   --run-registry <dir>
                        Durable run registry directory for recipe-run.

--- a/packages/runtime-core/src/benchmark-substrate.ts
+++ b/packages/runtime-core/src/benchmark-substrate.ts
@@ -75,10 +75,25 @@ export interface BenchmarkMatrixCellResult {
 export interface BenchmarkComparisonMetricDelta {
   scenarioId: string
   metricId: string
+  unit?: string
+  statistic?: "mean" | "value" | (string & {})
   baseline: number
   candidate: number
   absoluteDelta: number
   percentDelta?: number
+  baselineSamples?: BenchmarkComparisonSampleMetadata
+  candidateSamples?: BenchmarkComparisonSampleMetadata
+}
+
+export interface BenchmarkComparisonSampleMetadata {
+  count?: number
+  standardDeviation?: number
+  relativeStandardDeviation?: number
+  min?: number
+  max?: number
+  p50?: number
+  p95?: number
+  p99?: number
 }
 
 export interface BenchmarkComparisonScenarioPair {
@@ -197,14 +212,14 @@ export function compareBenchmarkResults(baseline: BenchmarkResultEnvelope, candi
       continue
     }
 
-    const baselineMetrics = numericMetricMap(baselineScenario.metrics)
-    const candidateMetrics = numericMetricMap(candidateScenario.metrics)
+    const baselineMetrics = comparableMetricMap(baselineScenario.metrics)
+    const candidateMetrics = comparableMetricMap(candidateScenario.metrics)
     const metricIds = sortedUnion(Object.keys(baselineMetrics), Object.keys(candidateMetrics))
     const metrics: BenchmarkComparisonMetricDelta[] = []
     for (const metricId of metricIds) {
-      const baselineValue = baselineMetrics[metricId]
-      const candidateValue = candidateMetrics[metricId]
-      if (baselineValue === undefined) {
+      const baselineMetric = baselineMetrics[metricId]
+      const candidateMetric = candidateMetrics[metricId]
+      if (!baselineMetric) {
         diagnostics.push({
           type: "missing-baseline-metric",
           severity: "warning",
@@ -214,7 +229,7 @@ export function compareBenchmarkResults(baseline: BenchmarkResultEnvelope, candi
         })
         continue
       }
-      if (candidateValue === undefined) {
+      if (!candidateMetric) {
         diagnostics.push({
           type: "missing-candidate-metric",
           severity: "warning",
@@ -225,14 +240,18 @@ export function compareBenchmarkResults(baseline: BenchmarkResultEnvelope, candi
         continue
       }
 
-      const absoluteDelta = candidateValue - baselineValue
+      const absoluteDelta = candidateMetric.value - baselineMetric.value
       metrics.push({
         scenarioId,
         metricId,
-        baseline: baselineValue,
-        candidate: candidateValue,
+        ...(baselineMetric.unit === candidateMetric.unit && baselineMetric.unit ? { unit: baselineMetric.unit } : {}),
+        ...comparisonStatistic(baselineMetric, candidateMetric),
+        baseline: baselineMetric.value,
+        candidate: candidateMetric.value,
         absoluteDelta,
-        ...(baselineValue !== 0 ? { percentDelta: (absoluteDelta / baselineValue) * 100 } : {}),
+        ...(baselineMetric.value !== 0 ? { percentDelta: (absoluteDelta / baselineMetric.value) * 100 } : {}),
+        ...(baselineMetric.samples ? { baselineSamples: baselineMetric.samples } : {}),
+        ...(candidateMetric.samples ? { candidateSamples: candidateMetric.samples } : {}),
       })
     }
 
@@ -301,14 +320,72 @@ function scenarioMap(results: BenchmarkResultEnvelope): Record<string, Benchmark
   return scenarios
 }
 
-function numericMetricMap(metrics: Record<string, unknown> | undefined): Record<string, number> {
-  const numericMetrics: Record<string, number> = {}
+interface ComparableBenchmarkMetric {
+  value: number
+  unit?: string
+  statistic: "mean" | "value" | (string & {})
+  samples?: BenchmarkComparisonSampleMetadata
+}
+
+function comparableMetricMap(metrics: Record<string, unknown> | undefined): Record<string, ComparableBenchmarkMetric> {
+  const comparableMetrics: Record<string, ComparableBenchmarkMetric> = {}
   for (const [key, value] of Object.entries(metrics ?? {})) {
     if (typeof value === "number" && Number.isFinite(value)) {
-      numericMetrics[key] = value
+      comparableMetrics[key] = { value, statistic: "value" }
+      continue
+    }
+
+    const samples = metricSamplesSummary(value)
+    if (samples && Number.isFinite(samples.mean)) {
+      comparableMetrics[key] = {
+        value: samples.mean,
+        statistic: "mean",
+        ...metricUnit(value),
+        samples: comparisonSampleMetadata(samples),
+      }
     }
   }
-  return numericMetrics
+  return comparableMetrics
+}
+
+function metricSamplesSummary(value: unknown): { count?: unknown; mean: number; standard_deviation?: unknown; relative_standard_deviation?: unknown; min?: unknown; max?: unknown; p50?: unknown; p95?: unknown; p99?: unknown } | undefined {
+  if (!isRecord(value) || !isRecord(value.samples) || typeof value.samples.mean !== "number") {
+    return undefined
+  }
+  return value.samples as { count?: unknown; mean: number; standard_deviation?: unknown; relative_standard_deviation?: unknown; min?: unknown; max?: unknown; p50?: unknown; p95?: unknown; p99?: unknown }
+}
+
+function metricUnit(value: unknown): { unit?: string } {
+  if (!isRecord(value) || typeof value.unit !== "string" || !value.unit.trim()) {
+    return {}
+  }
+  return { unit: value.unit }
+}
+
+function comparisonSampleMetadata(samples: { count?: unknown; standard_deviation?: unknown; relative_standard_deviation?: unknown; min?: unknown; max?: unknown; p50?: unknown; p95?: unknown; p99?: unknown }): BenchmarkComparisonSampleMetadata {
+  return {
+    ...finiteNumberProperty("count", samples.count),
+    ...finiteNumberProperty("standardDeviation", samples.standard_deviation),
+    ...finiteNumberProperty("relativeStandardDeviation", samples.relative_standard_deviation),
+    ...finiteNumberProperty("min", samples.min),
+    ...finiteNumberProperty("max", samples.max),
+    ...finiteNumberProperty("p50", samples.p50),
+    ...finiteNumberProperty("p95", samples.p95),
+    ...finiteNumberProperty("p99", samples.p99),
+  }
+}
+
+function finiteNumberProperty(name: keyof BenchmarkComparisonSampleMetadata, value: unknown): Partial<BenchmarkComparisonSampleMetadata> {
+  return typeof value === "number" && Number.isFinite(value) ? { [name]: value } : {}
+}
+
+function comparisonStatistic(baselineMetric: ComparableBenchmarkMetric, candidateMetric: ComparableBenchmarkMetric): { statistic?: "mean" | "value" | (string & {}) } {
+  const statistic = baselineMetric.statistic === candidateMetric.statistic ? baselineMetric.statistic : "value"
+  return statistic === "value" ? {} : { statistic }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function sortedUnion(left: string[], right: string[]): string[] {

--- a/scripts/benchmark-comparison-smoke.ts
+++ b/scripts/benchmark-comparison-smoke.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const workspace = resolve(root, "artifacts/benchmark-comparison-smoke")
+const baselineRecipeRun = resolve(workspace, "baseline-recipe-run.json")
+const candidateRecipeRun = resolve(workspace, "candidate-recipe-run.json")
+const baselineBundle = resolve(workspace, "baseline-bundle")
+const candidateBundle = resolve(workspace, "candidate-bundle")
+
+rmSync(workspace, { recursive: true, force: true })
+mkdirSync(resolve(baselineBundle, "logs"), { recursive: true })
+mkdirSync(resolve(candidateBundle, "logs"), { recursive: true })
+
+const baselineBenchResults = {
+  schema: "wp-codebox/bench-results/v1",
+  component_id: "bench-plugin",
+  iterations: 4,
+  warmup_iterations: 1,
+  scenarios: [
+    {
+      id: "load",
+      source: "file",
+      iterations: 4,
+      metrics: {
+        duration: {
+          unit: "ms",
+          samples: {
+            count: 4,
+            mean: 100,
+            p50: 99,
+            p95: 120,
+            p99: 130,
+            min: 90,
+            max: 125,
+            standard_deviation: 5,
+            relative_standard_deviation: 0.05,
+          },
+        },
+        peak_memory: {
+          unit: "bytes",
+          samples: { count: 4, mean: 1000, p50: 1000, p95: 1100, p99: 1200, min: 900, max: 1100 },
+        },
+        baseline_only: {
+          unit: "count",
+          samples: { count: 4, mean: 1, p50: 1, p95: 1, p99: 1, min: 1, max: 1 },
+        },
+      },
+      diagnostics: [],
+    },
+    { id: "baseline-only", source: "file", iterations: 4, metrics: { duration: { unit: "ms", samples: { count: 4, mean: 9, p50: 9, p95: 9, p99: 9, min: 9, max: 9 } } }, diagnostics: [] },
+  ],
+  diagnostics: [],
+  provenance: { command: "wordpress.bench", component: { id: "bench-plugin" } },
+}
+
+const candidateBenchResults = {
+  schema: "wp-codebox/bench-results/v1",
+  component_id: "bench-plugin",
+  iterations: 6,
+  warmup_iterations: 1,
+  scenarios: [
+    {
+      id: "load",
+      source: "file",
+      iterations: 6,
+      metrics: {
+        duration: {
+          unit: "ms",
+          samples: {
+            count: 6,
+            mean: 125,
+            p50: 124,
+            p95: 150,
+            p99: 160,
+            min: 110,
+            max: 155,
+            standard_deviation: 9,
+            relative_standard_deviation: 0.072,
+          },
+        },
+        peak_memory: {
+          unit: "bytes",
+          samples: { count: 6, mean: 900, p50: 900, p95: 950, p99: 990, min: 850, max: 975 },
+        },
+        candidate_only: {
+          unit: "count",
+          samples: { count: 6, mean: 2, p50: 2, p95: 2, p99: 2, min: 2, max: 2 },
+        },
+      },
+      diagnostics: [],
+    },
+    { id: "candidate-only", source: "file", iterations: 6, metrics: { duration: { unit: "ms", samples: { count: 6, mean: 8, p50: 8, p95: 8, p99: 8, min: 8, max: 8 } } }, diagnostics: [] },
+  ],
+  diagnostics: [],
+  provenance: { command: "wordpress.bench", component: { id: "bench-plugin" } },
+}
+
+writeFileSync(baselineRecipeRun, `${JSON.stringify({ schema: "wp-codebox/recipe-run/v1", success: true, benchResults: baselineBenchResults }, null, 2)}\n`)
+writeFileSync(candidateRecipeRun, `${JSON.stringify({ schema: "wp-codebox/recipe-run/v1", success: true, benchResults: candidateBenchResults }, null, 2)}\n`)
+writeFileSync(resolve(baselineBundle, "logs", "commands.log"), `[2026-06-04T00:00:00.000Z] wordpress.bench\n${JSON.stringify(baselineBenchResults, null, 2)}\n`)
+writeFileSync(resolve(candidateBundle, "logs", "commands.log"), `[2026-06-04T00:00:00.000Z] wordpress.bench\n${JSON.stringify(candidateBenchResults, null, 2)}\n`)
+
+const recipeComparison = runJson("bench", "compare", "--baseline-input", baselineRecipeRun, "--candidate-input", candidateRecipeRun, "--json")
+assertComparison(recipeComparison, "recipe-run-output")
+
+const bundleComparison = runJson("artifacts", "bench-compare", "--baseline-bundle", baselineBundle, "--candidate-bundle", candidateBundle, "--json")
+assertComparison(bundleComparison, "artifact-bundle")
+
+const human = spawnSync(process.execPath, [cli, "bench", "compare", "--baseline-input", baselineRecipeRun, "--candidate-input", candidateRecipeRun], { cwd: root, encoding: "utf8" })
+assert.equal(human.status, 0, human.stderr || human.stdout)
+assert.match(human.stdout, /WP Codebox benchmark comparison/)
+assert.match(human.stdout, /duration: 100 -> 125/)
+
+console.log("benchmark comparison smoke passed")
+
+function assertComparison(output: any, sourceType: string): void {
+  assert.equal(output.schema, "wp-codebox/benchmark-comparison/v1")
+  assert.equal(output.source.baseline.type, sourceType)
+  assert.equal(output.source.candidate.type, sourceType)
+  assert.equal(output.provenance.baselineComponentId, "bench-plugin")
+  assert.equal(output.provenance.candidateComponentId, "bench-plugin")
+  assert.equal(output.provenance.baselineIterations, 4)
+  assert.equal(output.provenance.candidateIterations, 6)
+
+  const load = output.pairs.find((pair: any) => pair.scenarioId === "load")
+  assert.ok(load)
+  assert.equal(load.baselineIterations, 4)
+  assert.equal(load.candidateIterations, 6)
+
+  const duration = load.metrics.find((metric: any) => metric.metricId === "duration")
+  assert.deepEqual(duration, {
+    scenarioId: "load",
+    metricId: "duration",
+    unit: "ms",
+    statistic: "mean",
+    baseline: 100,
+    candidate: 125,
+    absoluteDelta: 25,
+    percentDelta: 25,
+    baselineSamples: { count: 4, standardDeviation: 5, relativeStandardDeviation: 0.05, min: 90, max: 125, p50: 99, p95: 120, p99: 130 },
+    candidateSamples: { count: 6, standardDeviation: 9, relativeStandardDeviation: 0.072, min: 110, max: 155, p50: 124, p95: 150, p99: 160 },
+  })
+
+  const memory = load.metrics.find((metric: any) => metric.metricId === "peak_memory")
+  assert.equal(memory.absoluteDelta, -100)
+  assert.equal(memory.percentDelta, -10)
+  assert.equal(output.diagnostics.some((diagnostic: any) => diagnostic.type === "missing-candidate-metric" && diagnostic.scenarioId === "load" && diagnostic.metricId === "baseline_only"), true)
+  assert.equal(output.diagnostics.some((diagnostic: any) => diagnostic.type === "missing-baseline-metric" && diagnostic.scenarioId === "load" && diagnostic.metricId === "candidate_only"), true)
+  assert.equal(output.diagnostics.some((diagnostic: any) => diagnostic.type === "missing-candidate-scenario" && diagnostic.scenarioId === "baseline-only"), true)
+  assert.equal(output.diagnostics.some((diagnostic: any) => diagnostic.type === "missing-baseline-scenario" && diagnostic.scenarioId === "candidate-only"), true)
+}
+
+function runJson(...args: string[]): any {
+  const result = spawnSync(process.execPath, [cli, ...args], { cwd: root, encoding: "utf8" })
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+  return JSON.parse(result.stdout)
+}

--- a/scripts/benchmark-substrate-smoke.ts
+++ b/scripts/benchmark-substrate-smoke.ts
@@ -89,4 +89,28 @@ assert.equal(comparison.diagnostics.some((diagnostic) => diagnostic.type === "mi
 assert.equal(comparison.diagnostics.some((diagnostic) => diagnostic.type === "missing-candidate-scenario" && diagnostic.scenarioId === "baseline-only"), true)
 assert.equal(comparison.diagnostics.some((diagnostic) => diagnostic.type === "missing-baseline-scenario" && diagnostic.scenarioId === "candidate-only"), true)
 
+const sampleComparison = compareBenchmarkResults(
+  {
+    component_id: "demo",
+    scenarios: [{ id: "load", metrics: { duration: { unit: "ms", samples: { count: 2, mean: 10, p50: 10, p95: 11, p99: 11, min: 9, max: 11, standard_deviation: 1, relative_standard_deviation: 0.1 } } } }],
+  },
+  {
+    component_id: "demo",
+    scenarios: [{ id: "load", metrics: { duration: { unit: "ms", samples: { count: 4, mean: 12, p50: 12, p95: 13, p99: 13, min: 11, max: 13, standard_deviation: 2, relative_standard_deviation: 0.16 } } } }],
+  },
+)
+const sampleDelta = sampleComparison.pairs[0]?.metrics[0]
+assert.deepEqual(sampleDelta, {
+  scenarioId: "load",
+  metricId: "duration",
+  unit: "ms",
+  statistic: "mean",
+  baseline: 10,
+  candidate: 12,
+  absoluteDelta: 2,
+  percentDelta: 20,
+  baselineSamples: { count: 2, standardDeviation: 1, relativeStandardDeviation: 0.1, min: 9, max: 11, p50: 10, p95: 11, p99: 11 },
+  candidateSamples: { count: 4, standardDeviation: 2, relativeStandardDeviation: 0.16, min: 11, max: 13, p50: 12, p95: 13, p99: 13 },
+})
+
 console.log("benchmark substrate smoke passed")


### PR DESCRIPTION
## Summary
- Extends the generic benchmark comparison substrate to compare current `benchResults` metric records via `samples.mean` while preserving units, sample counts, and stability metadata.
- Adds `bench compare` and `artifacts bench-compare` CLI helpers for comparing baseline/candidate recipe-run JSON or artifact bundles.
- Documents the comparison contract and adds focused smoke coverage for deltas and missing scenario/metric diagnostics.

Fixes #578.

## Testing
- `npm run build`
- `npm run benchmark-substrate-smoke`
- `npm run benchmark-summary-smoke`
- `npm run benchmark-comparison-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic comparison helper extensions, CLI wiring, docs, and focused smoke coverage; Chris remains responsible for review and testing.