### PR TITLE
Add Data Machine bundle task execution

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -22,6 +22,7 @@ export interface AgentSandboxCodeOptions {
   maxTurns?: string
   timeoutSeconds?: string
   agentBundles?: AgentBundleSpec[]
+  datamachineBundle?: Record<string, unknown>
   sandboxToolPolicy?: SandboxToolPolicySnapshot
   code?: string
   codeFile?: string
@@ -90,6 +91,7 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
   const timeoutSeconds = Number.parseInt(options.timeoutSeconds ?? '', 10)
   const timeoutLimit = Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 0
   const agentBundles = normalizeAgentBundleSpecs(options.agentBundles ?? [])
+  const datamachineBundle = normalizeDatamachineBundleRunInput(options.datamachineBundle, input)
 
   return `
 if (function_exists('wp_set_current_user')) {
@@ -145,6 +147,8 @@ $sandbox_agent_bundles = json_decode(${JSON.stringify(JSON.stringify(agentBundle
 $sandbox_agent_bundle_imports = wp_codebox_import_sandbox_agent_bundles(is_array($sandbox_agent_bundles) ? $sandbox_agent_bundles : array());
 $sandbox_stack['agent_bundle_imports'] = $sandbox_agent_bundle_imports;
 $sandbox_agent_bundle_import_failures = array_filter($sandbox_agent_bundle_imports, static fn($import) => is_array($import) && empty($import['success']));
+$sandbox_datamachine_bundle = json_decode(${JSON.stringify(JSON.stringify(datamachineBundle))}, true);
+$sandbox_stack['datamachine_bundle'] = is_array($sandbox_datamachine_bundle) ? $sandbox_datamachine_bundle : null;
 
 add_filter('agents_chat_runtime_principal_permission', static function (bool $allowed, $principal, array $input): bool {
     if (!$principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal) {
@@ -213,7 +217,9 @@ function wp_codebox_import_sandbox_agent_bundles(array $bundle_specs): array {
     return $imports;
 }
 
-$ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability('agents/chat') : null;
+$datamachine_bundle_run = is_array($sandbox_datamachine_bundle) && !empty($sandbox_datamachine_bundle);
+$ability_name = $datamachine_bundle_run ? 'datamachine/run-agent-bundle' : 'agents/chat';
+$ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability($ability_name) : null;
 if (!empty($sandbox_agent_bundle_import_failures)) {
     $sandbox_agent_runtime = array(
         'agent_runtime' => array(
@@ -230,14 +236,14 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
         'agent_runtime' => array(
             'success' => false,
             'error' => array(
-                'code' => 'agents_chat_unavailable',
-                'message' => 'The canonical agents/chat ability is not available inside the sandbox.',
+                'code' => $datamachine_bundle_run ? 'datamachine_agent_bundle_runner_unavailable' : 'agents_chat_unavailable',
+                'message' => $datamachine_bundle_run ? 'The datamachine/run-agent-bundle ability is not available inside the sandbox.' : 'The canonical agents/chat ability is not available inside the sandbox.',
             ),
         ),
     );
 } else {
     $agent_input = ${JSON.stringify(JSON.stringify(input))};
-    $agent_result = $ability->execute(json_decode($agent_input, true));
+    $agent_result = $ability->execute($datamachine_bundle_run ? $sandbox_datamachine_bundle : json_decode($agent_input, true));
     if (is_wp_error($agent_result)) {
         $sandbox_agent_runtime = array(
             'agent_runtime' => array(
@@ -326,6 +332,47 @@ function normalizeAgentBundleSpecs(specs: AgentBundleSpec[]): AgentBundleSpec[] 
     if (spec.import_principal && typeof spec.import_principal === "object" && !Array.isArray(spec.import_principal)) normalized.import_principal = spec.import_principal
     return [normalized]
   })
+}
+
+function normalizeDatamachineBundleRunInput(config: Record<string, unknown> | undefined, agentInput: Record<string, unknown>): Record<string, unknown> | null {
+  if (!config || typeof config !== "object" || Array.isArray(config)) return null
+
+  const source = stringFromKeys(config, ["source", "bundle_path", "bundle_host_path"])
+  if (!source) return null
+
+  const runInput: Record<string, unknown> = {
+    source,
+    initial_data: {
+      ...(recordValue(config.initial_data) ?? {}),
+      task_input: agentInput,
+      datamachine_bundle: config,
+    },
+    job_source: "wp_codebox_agent_task",
+  }
+
+  const flow = stringFromKeys(config, ["flow", "flow_slug"])
+  if (flow) {
+    runInput.flow = flow
+  }
+
+  for (const key of ["token_env", "job_label"] as const) {
+    const value = typeof config[key] === "string" ? config[key].trim() : ""
+    if (value) runInput[key] = value
+  }
+
+  return runInput
+}
+
+function stringFromKeys(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = typeof record[key] === "string" ? record[key].trim() : ""
+    if (value) return value
+  }
+  return ""
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined
 }
 
 export function agentSandboxRunCode(task: string, code: string, providerPlugins: Array<{ slug: string }>): string {

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -28,6 +28,7 @@ export interface AgentSandboxRunOptions extends AgentRuntimeProbeOptions {
   maxTurns?: string
   timeoutSeconds?: string
   agentBundles?: AgentBundleSpec[]
+  datamachineBundle?: Record<string, unknown>
   sandboxToolPolicy?: SandboxToolPolicySnapshot
   code?: string
   codeFile?: string
@@ -115,6 +116,7 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
       maxTurns: argValue(args, "max-turns"),
       timeoutSeconds: argValue(args, "timeout-seconds"),
       agentBundles: parseAgentBundles(args),
+      datamachineBundle: parseDatamachineBundle(args),
       sandboxWorkspace: parseSandboxWorkspace(args) ?? sandboxWorkspace,
       sandboxToolPolicy: parseSandboxToolPolicy(args),
     }))
@@ -233,7 +235,7 @@ export function parseAgentRuntimeProbeOptions(args: string[], parseMount: (value
 }
 
 export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: string) => AgentRuntimeMount): AgentSandboxRunOptions {
-  const options = parseAgentRuntimeProbeOptions(args, parseMount, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--timeout-seconds", "--agent-bundles-json", "--sandbox-tool-policy-json", "--code", "--code-file", "--workspace-context-json", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
+  const options = parseAgentRuntimeProbeOptions(args, parseMount, ["--task", "--agent", "--mode", "--provider", "--model", "--session-id", "--max-turns", "--timeout-seconds", "--agent-bundles-json", "--datamachine-bundle-json", "--sandbox-tool-policy-json", "--code", "--code-file", "--workspace-context-json", "--secret-env", "--mount"]) as Partial<AgentSandboxRunOptions>
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -274,6 +276,9 @@ export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: 
       case "--agent-bundles-json":
         options.agentBundles = parseAgentBundleList(value)
         break
+      case "--datamachine-bundle-json":
+        options.datamachineBundle = parseDatamachineBundleValue(value)
+        break
       case "--sandbox-tool-policy-json":
         options.sandboxToolPolicy = normalizeSandboxToolPolicySnapshot(JSON.parse(value))
         break
@@ -296,6 +301,20 @@ export function parseAgentSandboxRunOptions(args: string[], parseMount: (value: 
 
 function parseAgentBundles(args: string[]): AgentBundleSpec[] {
   return parseAgentBundleList(argValue(args, "agent-bundles-json") ?? "[]")
+}
+
+function parseDatamachineBundle(args: string[]): Record<string, unknown> | undefined {
+  const value = argValue(args, "datamachine-bundle-json")
+  return value ? parseDatamachineBundleValue(value) : undefined
+}
+
+function parseDatamachineBundleValue(value: string): Record<string, unknown> | undefined {
+  if (!value.trim()) return undefined
+  const parsed = JSON.parse(value)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("datamachine-bundle-json must be an object")
+  }
+  return parsed as Record<string, unknown>
 }
 
 function parseSandboxWorkspace(args: string[]): SandboxWorkspaceContract | undefined {

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -27,6 +27,7 @@ interface AgentTaskRunInput {
   runtime_stack_mounts?: Array<Record<string, unknown>>
   runtime_overlays?: Array<Record<string, unknown>>
   agent_bundles?: Array<Record<string, unknown>>
+  datamachine_bundle?: Record<string, unknown>
   sandbox_tool_policy?: SandboxToolPolicySnapshot
   max_turns?: number | string
   task_timeout_seconds?: number | string
@@ -150,6 +151,9 @@ function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: ReturnType<ty
   }
   if (Array.isArray(input.agent_bundles) && input.agent_bundles.length > 0) {
     workflowArgs.push(`agent-bundles-json=${JSON.stringify(input.agent_bundles)}`)
+  }
+  if (input.datamachine_bundle && typeof input.datamachine_bundle === "object" && !Array.isArray(input.datamachine_bundle)) {
+    workflowArgs.push(`datamachine-bundle-json=${JSON.stringify(input.datamachine_bundle)}`)
   }
 
   return stripUndefined({

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -178,6 +178,10 @@ final class WP_Codebox_Abilities {
 								'items'       => array( 'type' => 'string' ),
 							),
 							'agent_bundles'          => self::agent_bundle_schema(),
+							'datamachine_bundle'     => array(
+								'type'        => 'object',
+								'description' => 'Data Machine agent bundle run request. WP Codebox forwards this to datamachine/run-agent-bundle inside the sandbox.',
+							),
 							'parent_request'         => array(
 								'type'        => 'object',
 								'description' => 'External orchestrator task request, such as homeboy/wp-codebox-task-request/v1, normalized into the WP Codebox runner contract.',
@@ -296,6 +300,7 @@ final class WP_Codebox_Abilities {
 								'items' => array( 'type' => 'string' ),
 							),
 							'agent_bundles'          => self::agent_bundle_schema(),
+							'datamachine_bundle'     => array( 'type' => 'object' ),
 							'parent_request'         => array( 'type' => 'object' ),
 							'mounts'                 => $mount_schema,
 							'workspaces'             => array(

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -427,6 +427,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 					'model'                  => (string) ( $input['model'] ?? $request['model'] ?? '' ),
 					'provider_plugin_paths'  => $this->merge_string_lists( $input['provider_plugin_paths'] ?? array(), $request['provider_plugin_paths'] ?? array() ),
 					'agent_bundles'          => $this->agent_bundles( $input, $request ),
+					'datamachine_bundle'     => $this->datamachine_bundle( $input, $request ),
 					'secret_env'             => $this->merge_string_lists( $input['secret_env'] ?? array(), $request['secret_env'] ?? array() ),
 					'mounts'                 => $this->merge_array_lists( $input['mounts'] ?? array(), $request['mounts'] ?? array() ),
 					'workspaces'             => $this->merge_array_lists( $input['workspaces'] ?? array(), $workspaces ),
@@ -1020,6 +1021,26 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return $normalized;
+	}
+
+	/**
+	 * @param array<string,mixed> $input Ability input.
+	 * @param array<string,mixed> $request Parent request input.
+	 * @return array<string,mixed>
+	 */
+	private function datamachine_bundle( array $input, array $request = array() ): array {
+		$candidates = array(
+			$input['datamachine_bundle'] ?? $input['datamachineBundle'] ?? null,
+			$request['datamachine_bundle'] ?? $request['datamachineBundle'] ?? null,
+		);
+
+		foreach ( $candidates as $bundle ) {
+			if ( is_array( $bundle ) ) {
+				return $bundle;
+			}
+		}
+
+		return array();
 	}
 
 	/** @param array<string,mixed> $principal Raw import principal. @return array<string,mixed> */
@@ -1860,9 +1881,10 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$this->provider_plugin_paths( $input, $inheritance )
 		);
 
-		$provider_slugs = array_map( static fn( array $plugin ): string => (string) $plugin['slug'], $provider_plugins );
-		$agent_bundles  = $this->agent_bundles( $input );
-		$steps          = array();
+		$provider_slugs     = array_map( static fn( array $plugin ): string => (string) $plugin['slug'], $provider_plugins );
+		$agent_bundles      = $this->agent_bundles( $input );
+		$datamachine_bundle = $this->datamachine_bundle( $input );
+		$steps              = array();
 		foreach ( $task_prompts as $task_prompt ) {
 			$task_input = $this->task_input( array_merge( $input, array( 'goal' => $task_prompt ) ) );
 			if ( is_wp_error( $task_input ) ) {
@@ -1880,6 +1902,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			);
 			if ( ! empty( $agent_bundles ) ) {
 				$args[] = 'agent-bundles-json=' . $this->json_encode( $agent_bundles );
+			}
+			if ( ! empty( $datamachine_bundle ) ) {
+				$args[] = 'datamachine-bundle-json=' . $this->json_encode( $datamachine_bundle );
 			}
 			if ( ! empty( $input['session_id'] ) ) {
 				$args[] = 'session-id=' . (string) $input['session_id'];

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -153,7 +153,7 @@ final class WP_Codebox_CLI_Command {
 			return $this->json_object( (string) $value, $field );
 		}
 
-		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'agent_bundles', 'provider_plugin_paths', 'secret_env', 'mounts', 'workspaces', 'runtime_stack_mounts', 'runtime_overlays', 'browser_plugins', 'artifact_files', 'approved_files' ), true ) ) {
+		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'agent_bundles', 'datamachine_bundle', 'provider_plugin_paths', 'secret_env', 'mounts', 'workspaces', 'runtime_stack_mounts', 'runtime_overlays', 'browser_plugins', 'artifact_files', 'approved_files' ), true ) ) {
 			return $this->json_or_list( (string) $value, $field );
 		}
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -552,9 +552,10 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_default_secret_env'] = array( 'OPENAI
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org', 'github.com' );
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_theme_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org' );
 $recipe_run_source = file_get_contents( $source_root . '/packages/cli/src/commands/recipe-run.ts' );
-$assert( 'recipe extra plugin activation exposes lifecycle hook', false !== $recipe_run_source && str_contains( $recipe_run_source, "do_action('wp_codebox_runtime_plugins_activated', $" . "activated)" ) );
+$assert( 'recipe extra plugin activation exposes lifecycle hook', false !== $recipe_run_source && str_contains( $recipe_run_source, "do_action('wp_codebox_runtime_plugin_activated', $" . "plugin_file)" ) );
 $agent_code_source = file_get_contents( $source_root . '/packages/cli/src/agent-code.ts' );
 $assert( 'CLI sandbox delegates runtime bundle imports through generic helper', false !== $agent_code_source && str_contains( $agent_code_source, "wp_agent_import_runtime_bundles" ) && str_contains( $agent_code_source, "apply_filters('wp_agent_runtime_import_bundle'" ) && ! str_contains( $agent_code_source, "wp_get_ability('datamachine/import-agent')" ) && ! str_contains( $agent_code_source, 'DataMachine\\Core\\Database\\Agents\\Agents' ) );
+$assert( 'CLI sandbox runs Data Machine bundles through canonical ability', false !== $agent_code_source && str_contains( $agent_code_source, "'datamachine/run-agent-bundle'" ) && str_contains( $agent_code_source, 'normalizeDatamachineBundleRunInput' ) && ! str_contains( $agent_code_source, 'ExecuteWorkflowAbility' ) );
 $assert( 'CLI sandbox preserves runtime bundle import principal without Data Machine permission helper', false !== $agent_code_source && str_contains( $agent_code_source, "'import_principal'" ) && ! str_contains( $agent_code_source, 'DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($execute' ) );
 $assert( 'CLI sandbox uses Agents API runtime-principal authorization instead of Data Machine chat mode glue', false !== $agent_code_source && str_contains( $agent_code_source, "agents_chat_runtime_principal_permission" ) && ! str_contains( $agent_code_source, 'datamachine_settings' ) && ! str_contains( $agent_code_source, 'datamachine_agent_modes' ) && ! str_contains( $agent_code_source, 'datamachine_agent_mode_sandbox' ) && ! str_contains( $agent_code_source, 'datamachine_directives' ) && ! str_contains( $agent_code_source, 'WP_Codebox_Sandbox_Perception_Directive' ) );
 $GLOBALS['wp_codebox_mock_abilities']['agents/chat'] = new WP_Ability();
@@ -1775,6 +1776,10 @@ $assert( 'runner does not pass raw code options', ! str_contains( $captured_comm
 
 $homeboy_result = $runner->run(
 	array(
+		'datamachine_bundle' => array(
+			'bundle_path' => $root . '/site-generator-agent.json',
+			'flow_slug'   => 'static-site-manual-flow',
+		),
 		'parent_request' => array(
 			'schema'               => 'homeboy/wp-codebox-task-request/v1',
 			'provider'             => 'openai',
@@ -1853,6 +1858,7 @@ $assert( 'runner maps Homeboy artifacts and orchestrator metadata', ! is_wp_erro
 $assert( 'runner returns stable Homeboy status diagnostics evidence and metadata refs', ! is_wp_error( $homeboy_result ) && in_array( (string) ( $homeboy_result['status'] ?? '' ), array( 'completed', 'failed' ), true ) && 'wp-codebox/agent-task-diagnostics/v1' === ( $homeboy_result['diagnostics']['schema'] ?? '' ) && 'wp-codebox/agent-task-evidence-refs/v1' === ( $homeboy_result['evidence_refs']['schema'] ?? '' ) && 'artifact-bundle-sha256-fixture-2' === ( $homeboy_result['evidence_refs']['artifact_bundle_id'] ?? '' ) && 'files/transcript.json' === ( $homeboy_result['evidence_refs']['transcript'] ?? '' ) && 'wp-codebox/agent-task-run-metadata/v1' === ( $homeboy_result['run_metadata']['schema'] ?? '' ) && 'homeboy-sandbox-session-123' === ( $homeboy_result['run_metadata']['sandbox_session_id'] ?? '' ) );
 $assert( 'runner maps Homeboy provider plugins and secrets', in_array( 'provider-plugin-slugs=ai-provider-test', $homeboy_step_args, true ) && str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
 $assert( 'runner preserves multiple runtime agent bundles in recipe inputs and step args', 2 === count( $homeboy_recipe['inputs']['agent_bundles'] ?? array() ) && str_contains( implode( "\n", $homeboy_step_args ), 'agent-bundles-json=' ) && str_contains( $captured_recipe, 'site-generator-agent.json' ) && str_contains( $captured_recipe, 'repair-agent' ) );
+$assert( 'runner passes Data Machine bundle execution request to sandbox step', str_contains( implode( "\n", $homeboy_step_args ), 'datamachine-bundle-json=' ) && str_contains( $captured_recipe, 'static-site-manual-flow' ) );
 $assert( 'runner maps Homeboy timeout and max turns', 3600 === $captured_timeout && in_array( 'timeout-seconds=3600', $homeboy_step_args, true ) && in_array( 'max-turns=8', $homeboy_step_args, true ) );
 $assert( 'runner maps Homeboy runtime stack mounts and overlays', '/runtime/agents-api' === ( $homeboy_recipe['runtime']['stack']['mounts'][0]['target'] ?? '' ) && 'homeboy-runtime-overlay' === ( $homeboy_recipe['runtime']['overlays'][0]['id'] ?? '' ) );
 $assert( 'runner maps Homeboy workspaces without downstream recipe generation', 3 === count( $homeboy_recipe['inputs']['workspaces'] ?? array() ) && str_contains( $captured_recipe, 'Use mounted workspace repos' ) && ! str_contains( $captured_recipe, 'Use Data Machine Code workspace repos' ) && str_contains( $captured_recipe, '`agents-api`' ) );


### PR DESCRIPTION
## Summary
- Forward `datamachine_bundle` through `wp-codebox agent-task-run` into sandbox recipe steps.
- Execute bundle tasks inside the sandbox through the canonical `datamachine/run-agent-bundle` ability when a bundle run request is present.
- Update WordPress plugin smoke coverage for the new contract and the current runtime plugin activation hook.

## Testing
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the WP Codebox sandbox integration and focused smoke coverage; Chris remains responsible for review and merge.