### PR TITLE
Fix browser runner recipe contract

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -948,6 +948,29 @@ try {
 		return `<?php\n${ marker }\n?>\n${ source }`;
 	};
 
+	const normalizePhpPrelude = ( prelude ) => String( prelude || '' )
+		.replace( /^\s*<\?php\s*/i, '' )
+		.replace( /\?>\s*$/i, '' );
+
+	const withBrowserRunnerPrelude = ( code, recipe ) => {
+		const source = String( code || '' );
+		const prelude = recipe?.browser?.runner_contract?.php_prelude;
+		if ( typeof prelude !== 'string' || prelude.trim() === '' || source.includes( 'function wp_codebox_browser_artifact_environment' ) ) {
+			return source;
+		}
+
+		return injectPhpPrelude( source, normalizePhpPrelude( prelude ) );
+	};
+
+	const injectPhpPrelude = ( code, prelude ) => {
+		const source = String( code || '' );
+		if ( source.startsWith( '<?php' ) ) {
+			return source.replace( '<?php', `<?php\n${ prelude }` );
+		}
+
+		return `<?php\n${ prelude }\n?>\n${ source }`;
+	};
+
 	const browserSessionRecipe = ( session ) => {
 		if ( ! session || typeof session !== 'object' ) {
 			throw new Error( 'WP Codebox browser session output is required.' );
@@ -980,6 +1003,9 @@ try {
 		if ( ! payload || typeof payload !== 'object' ) {
 			throw runtimeError( 'recipe_validate', 'browser_recipe_task_payload_missing', 'WP Codebox browser recipe task payload missing.' );
 		}
+		if ( ! recipe?.browser?.runner_contract?.php_prelude && steps.some( ( step ) => ( step?.args || [] ).some( ( arg ) => typeof arg === 'string' && arg.startsWith( 'code=' ) && arg.includes( 'wp_codebox_browser_' ) && ! arg.includes( 'function wp_codebox_browser_artifact_environment' ) ) ) ) {
+			throw runtimeError( 'recipe_validate', 'browser_recipe_runner_contract_missing', 'Browser recipe PHP references WP Codebox runner helpers but does not include a runner contract.' );
+		}
 
 		const writeResult = await writeFile( client, {
 			path: taskPath,
@@ -1006,7 +1032,7 @@ try {
 
 				lastResult = await runPhpRequest( client, {
 					...options,
-					code: markBrowserPlaygroundRunner( codeArg.slice( 5 ) ),
+					code: markBrowserPlaygroundRunner( withBrowserRunnerPrelude( codeArg.slice( 5 ), recipe ) ),
 					name: options.name || 'codebox-recipe',
 					expectJson: true,
 					forceRequest: true,
@@ -1220,6 +1246,18 @@ try {
 			const result = await runRecipe( client, {
 				browser: {
 					task_path: recipeTaskPath,
+					runner_contract: {
+						schema: 'wp-codebox/browser-runner-contract/v1',
+						php_prelude: `<?php
+function wp_codebox_browser_artifact_environment( array $payload ): array {
+$contract = is_array( $payload['artifacts'] ?? null ) ? $payload['artifacts'] : array();
+$root = rtrim( (string) ( $contract['root'] ?? 'wp-codebox-output' ), '/' ) . '/';
+return array( 'contract' => $contract, 'root' => $root );
+}
+function wp_codebox_browser_capture_artifact_bundle( array $payload ): array {
+return is_array( $payload['artifacts'] ?? null ) ? $payload['artifacts'] : array();
+}`,
+					},
 				},
 				workflow: {
 					steps: [

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -38,6 +38,9 @@ trait WP_Codebox_Abilities_Browser_Runner {
 		}
 	}
 
+	$runner_php      = self::browser_agent_runner_php( $task_input, $session_id, $task_path, $result_path, $invocation, $captures );
+	$runner_contract = self::browser_agent_runner_contract( $runner_php );
+
 	return array(
 		'schema'   => 'wp-codebox/workspace-recipe/v1',
 		'runtime'  => array(
@@ -60,7 +63,7 @@ trait WP_Codebox_Abilities_Browser_Runner {
 				array(
 					'command' => 'wordpress.run-php',
 					'args'    => array(
-						'code=' . self::browser_agent_runner_php( $task_input, $session_id, $task_path, $result_path, $invocation, $captures ),
+						'code=' . $runner_php,
 					),
 				),
 			),
@@ -75,6 +78,7 @@ trait WP_Codebox_Abilities_Browser_Runner {
 			'task_payload' => $task_payload,
 			'invocation' => self::browser_runner_invocation_metadata( $invocation ),
 			'captures'   => $captures,
+			'runner_contract' => $runner_contract,
 		),
 	);
 }
@@ -1036,6 +1040,7 @@ if ( interface_exists( "\\DataMachine\\Engine\\AI\\LoopEventSinkInterface" ) && 
 }
 $invocation_type = (string) ( $invocation[\'type\'] ?? \'ability\' );
 
+/* WP_CODEBOX_BROWSER_RUNNER_BODY_START */
 if ( ! $wp_codebox_is_playground ) {
 $response = new WP_Error(
 	\'wp_codebox_browser_runner_not_playground\',
@@ -1098,6 +1103,7 @@ try {
 }
 }
 
+/* WP_CODEBOX_BROWSER_RUNNER_BODY_END */
 $captures = array();
 foreach ( $capture_paths as $capture ) {
 if ( is_array( $capture ) ) {
@@ -1187,6 +1193,26 @@ if ( ! empty( $artifact_bundle ) ) {
 file_put_contents( $result_path, wp_json_encode( $result ) );
 echo wp_json_encode( $result );
 ';
+}
+
+/** @return array<string,string> */
+private static function browser_agent_runner_contract( string $runner_php ): array {
+	$body_start = '/* WP_CODEBOX_BROWSER_RUNNER_BODY_START */';
+	$body_end   = '/* WP_CODEBOX_BROWSER_RUNNER_BODY_END */';
+	$start_pos  = strpos( $runner_php, $body_start );
+	$end_pos    = strpos( $runner_php, $body_end );
+
+	if ( false === $start_pos || false === $end_pos || $end_pos <= $start_pos ) {
+		return array(
+			'schema' => 'wp-codebox/browser-runner-contract/v1',
+		);
+	}
+
+	return array(
+		'schema'      => 'wp-codebox/browser-runner-contract/v1',
+		'php_prelude' => substr( $runner_php, 0, $start_pos ),
+		'php_footer'  => substr( $runner_php, $end_pos + strlen( $body_end ) ),
+	);
 }
 
 /** @param array<string,mixed> $playground Playground config. */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -552,7 +552,7 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_default_secret_env'] = array( 'OPENAI
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org', 'github.com' );
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_theme_allowed_hosts'] = array( 'example.test', 'downloads.wordpress.org' );
 $recipe_run_source = file_get_contents( $source_root . '/packages/cli/src/commands/recipe-run.ts' );
-$assert( 'recipe extra plugin activation exposes lifecycle hook', false !== $recipe_run_source && str_contains( $recipe_run_source, "do_action('wp_codebox_runtime_plugins_activated', $" . "activated)" ) );
+$assert( 'recipe extra plugin activation exposes lifecycle hook', false !== $recipe_run_source && ( str_contains( $recipe_run_source, "do_action('wp_codebox_runtime_plugins_activated', $" . "activated)" ) || str_contains( $recipe_run_source, "do_action('wp_codebox_runtime_plugin_activated', $" . "plugin_file)" ) ) );
 $agent_code_source = file_get_contents( $source_root . '/packages/cli/src/agent-code.ts' );
 $assert( 'CLI sandbox delegates runtime bundle imports through generic helper', false !== $agent_code_source && str_contains( $agent_code_source, "wp_agent_import_runtime_bundles" ) && str_contains( $agent_code_source, "apply_filters('wp_agent_runtime_import_bundle'" ) && ! str_contains( $agent_code_source, "wp_get_ability('datamachine/import-agent')" ) && ! str_contains( $agent_code_source, 'DataMachine\\Core\\Database\\Agents\\Agents' ) );
 $assert( 'CLI sandbox preserves runtime bundle import principal without Data Machine permission helper', false !== $agent_code_source && str_contains( $agent_code_source, "'import_principal'" ) && ! str_contains( $agent_code_source, 'DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($execute' ) );
@@ -875,6 +875,9 @@ add_filter(
 $runner_php = (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' );
 $assert( 'browser Playground generated runner has no Studio Web-specific artifact paths', ! str_contains( $runner_php, '/wordpress/wp-content/uploads/studio-web' ) && ! str_contains( $runner_php, 'studio-web/website' ) );
 $assert( 'browser Playground generated runner defaults to generic Codebox artifacts path', str_contains( $runner_php, '/wordpress/wp-content/uploads/wp-codebox/artifacts' ) && str_contains( $runner_php, 'wp-codebox-output/' ) );
+$runner_contract = $browser_session['recipe']['browser']['runner_contract'] ?? array();
+$assert( 'browser Playground recipe exposes reusable runner PHP contract prelude', is_array( $runner_contract ) && 'wp-codebox/browser-runner-contract/v1' === ( $runner_contract['schema'] ?? '' ) && str_contains( (string) ( $runner_contract['php_prelude'] ?? '' ), 'function wp_codebox_browser_artifact_environment' ) && str_contains( (string) ( $runner_contract['php_prelude'] ?? '' ), '$wp_codebox_is_playground' ) && str_contains( (string) ( $runner_contract['php_prelude'] ?? '' ), '$capture_paths' ) );
+$assert( 'browser Playground recipe exposes reusable runner PHP contract footer', is_array( $runner_contract ) && str_contains( (string) ( $runner_contract['php_footer'] ?? '' ), 'wp_codebox_browser_artifact_capture_diagnostics' ) && str_contains( (string) ( $runner_contract['php_footer'] ?? '' ), 'file_put_contents( $result_path' ) );
 $runner_php = preg_replace( '/^code=/', '', $runner_php ) ?? $runner_php;
 $runner_php = preg_replace( '/^<\?php\s*/', '', $runner_php ) ?? $runner_php;
 $runner_php = str_replace( "require_once '/wordpress/wp-load.php';", '', $runner_php );


### PR DESCRIPTION
## Summary
- Exposes a reusable browser runner PHP contract on generated browser recipes so partial materializer PHP can inherit the canonical WP Codebox runner prelude instead of depending on JS-side helper stubs.
- Updates the browser runtime to wrap helper-dependent recipe PHP with the contract-provided prelude and fail clearly when helper-dependent partial PHP has no runner contract.
- Adds smoke coverage for the generated runner contract and keeps the lifecycle-hook assertion compatible with the current recipe activation hook shape.

Refs #580.

## Verification
- `node --check packages/wordpress-plugin/assets/browser-runtime.js`
- `npm run browser-runtime-operation-smoke`
- `php tests/smoke-wordpress-plugin.php`
- Studio Web live eval run `live-2026-06-04T15-38-38-258Z` wrote `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/studio-web-headless-eval-fast/evidence.json`

## Eval notes
- The eval no longer shows the `/internal/eval.php` missing `wp_codebox_browser_*` helper/global fatal cascade.
- Browser evidence shows 10 successful `/wp-codebox/v1/browser-provider-request` responses, so the run reached live provider execution.
- The remaining failure is later downstream Studio Web materialization metadata: `Website materialization import_result missing canonical theme_slug`; `has_artifact_bundle=false` in the eval evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the browser runner contract refactor, smoke coverage, validation runs, and PR evidence summary; Chris remains responsible for review and merge.