### PR TITLE
Fix run-php recipe plugin loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "recipe-bench-smoke": "tsx scripts/recipe-bench-smoke.ts",
     "recipe-build-cli-smoke": "tsx scripts/recipe-build-cli-smoke.ts",
     "recipe-browser-bench-metrics-smoke": "tsx scripts/recipe-browser-bench-metrics-smoke.ts",
+    "recipe-run-php-plugin-load-smoke": "tsx scripts/recipe-run-php-plugin-load-smoke.ts",
+    "run-php-plugin-diagnostics-smoke": "tsx scripts/run-php-plugin-diagnostics-smoke.ts",
     "recipe-browser-smoke": "tsx scripts/recipe-browser-smoke.ts",
     "headless-browser-agent-recipe-smoke": "tsx scripts/headless-browser-agent-recipe-smoke.ts",
     "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -25,11 +25,106 @@ export function bootstrapPhpCode(spec: RuntimeCreateSpec, code: string, args: st
   return `<?php
 ${pluginRuntimeBootstrapPhp(spec)}
 require_once '/wordpress/wp-load.php';
+${recipeActivePluginBootstrapPhp(spec)}
 ${secretEnvPhp(spec)}
 ${wpCliBridge ? `putenv(${JSON.stringify(`HOMEBOY_TERMINAL_ACTION_URL=${wpCliBridge.url}`)});
 putenv(${JSON.stringify(`HOMEBOY_TERMINAL_ACTION_TOKEN=${wpCliBridge.token}`)});
 ` : ""}
 ${phpBody(code)}`
+}
+
+interface RecipePluginMetadata {
+  slug?: unknown
+  pluginFile?: unknown
+  target?: unknown
+  activate?: unknown
+  loadAs?: unknown
+}
+
+function recipeActivePluginBootstrapPhp(spec: RuntimeCreateSpec): string {
+  const plugins = recipeActivePluginMetadata(spec)
+  if (plugins.length === 0) {
+    return ""
+  }
+
+  return `$wp_codebox_run_php_active_plugins = json_decode(base64_decode('${Buffer.from(JSON.stringify(plugins), "utf8").toString("base64")}'), true);
+function wp_codebox_run_php_plugin_load_diagnostic(array $plugin, string $error = ''): string {
+    $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
+    $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
+    $real_plugin_file = realpath($absolute_plugin_file);
+    $included_files = array_map(static fn($file) => realpath($file) ?: $file, get_included_files());
+    $included = in_array($real_plugin_file ?: $absolute_plugin_file, $included_files, true);
+    return 'diagnostic=' . wp_json_encode(array(
+        'schema' => 'wp-codebox/run-php-plugin-load-diagnostic/v1',
+        'role' => 'active-recipe-plugin',
+        'plugin_slug' => isset($plugin['slug']) ? (string) $plugin['slug'] : dirname($plugin_file),
+        'plugin_file' => $plugin_file,
+        'mounted_path' => isset($plugin['target']) ? (string) $plugin['target'] : WP_PLUGIN_DIR . '/' . dirname($plugin_file),
+        'expected_file_path' => $absolute_plugin_file,
+        'file_exists' => is_file($absolute_plugin_file),
+        'file_readable' => is_readable($absolute_plugin_file),
+        'active' => function_exists('is_plugin_active') ? is_plugin_active($plugin_file) : null,
+        'included' => $included,
+        'wp_plugin_dir' => WP_PLUGIN_DIR,
+        'error' => $error,
+    ), JSON_UNESCAPED_SLASHES);
+}
+function wp_codebox_run_php_include_active_plugin(array $plugin): void {
+    $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
+    if ($plugin_file === '' || str_starts_with($plugin_file, '/') || str_contains($plugin_file, '..') || !str_ends_with($plugin_file, '.php')) {
+        throw new RuntimeException('wordpress.run-php cannot include unsafe recipe plugin file "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, 'unsafe plugin file'));
+    }
+    $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
+    if (!is_file($absolute_plugin_file) || !is_readable($absolute_plugin_file)) {
+        throw new RuntimeException('wordpress.run-php cannot include recipe plugin file "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, 'missing or unreadable plugin file'));
+    }
+    try {
+        require_once $absolute_plugin_file;
+    } catch (Throwable $e) {
+        throw new RuntimeException('wordpress.run-php failed to include recipe plugin "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, $e->getMessage()), 0, $e);
+    }
+    $diagnostic = wp_codebox_run_php_plugin_load_diagnostic($plugin, 'plugin file was not included');
+    if (strpos($diagnostic, '"included":true') === false) {
+        throw new RuntimeException('wordpress.run-php failed to verify included recipe plugin "' . $plugin_file . '". ' . $diagnostic);
+    }
+}
+foreach (is_array($wp_codebox_run_php_active_plugins) ? $wp_codebox_run_php_active_plugins : array() as $wp_codebox_run_php_active_plugin) {
+    if (is_array($wp_codebox_run_php_active_plugin)) {
+        wp_codebox_run_php_include_active_plugin($wp_codebox_run_php_active_plugin);
+    }
+}
+`
+}
+
+function recipeActivePluginMetadata(spec: RuntimeCreateSpec): RecipePluginMetadata[] {
+  const recipe = spec.metadata?.recipe && typeof spec.metadata.recipe === "object" && !Array.isArray(spec.metadata.recipe)
+    ? spec.metadata.recipe as { inputs?: { extra_plugins?: unknown; extraPlugins?: unknown } }
+    : undefined
+  const task = spec.metadata?.task && typeof spec.metadata.task === "object" && !Array.isArray(spec.metadata.task)
+    ? spec.metadata.task as { inputs?: { extra_plugins?: unknown; extraPlugins?: unknown } }
+    : undefined
+  const extraPlugins = Array.isArray(recipe?.inputs?.extra_plugins)
+    ? recipe.inputs.extra_plugins
+    : Array.isArray(recipe?.inputs?.extraPlugins)
+      ? recipe.inputs.extraPlugins
+      : Array.isArray(task?.inputs?.extra_plugins)
+        ? task.inputs.extra_plugins
+        : Array.isArray(task?.inputs?.extraPlugins)
+          ? task.inputs.extraPlugins
+          : []
+
+  const plugins: RecipePluginMetadata[] = extraPlugins
+    .filter((plugin): plugin is RecipePluginMetadata => Boolean(plugin) && typeof plugin === "object" && !Array.isArray(plugin))
+    .filter((plugin) => plugin.loadAs !== "mu-plugin" && plugin.activate !== false)
+    .map((plugin) => ({
+      slug: typeof plugin.slug === "string" ? plugin.slug : undefined,
+      pluginFile: typeof plugin.pluginFile === "string" && /^[^/][^:]*\.php$/.test(plugin.pluginFile) && !plugin.pluginFile.includes("..") ? plugin.pluginFile : undefined,
+      target: typeof plugin.target === "string" ? plugin.target : undefined,
+      activate: plugin.activate,
+      loadAs: plugin.loadAs,
+    }))
+
+  return plugins.filter((plugin) => typeof plugin.pluginFile === "string")
 }
 
 export async function phpCodeFromArgs(args: string[], command = "wordpress.run-php"): Promise<string> {

--- a/scripts/recipe-run-php-plugin-load-smoke.ts
+++ b/scripts/recipe-run-php-plugin-load-smoke.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const component = resolve(root, "examples/bench-plugin")
+const dependency = resolve(root, "examples/bench-dependency")
+const artifacts = resolve(root, "artifacts/recipe-run-php-plugin-load-smoke")
+const recipePath = resolve(artifacts, "recipe.json")
+
+mkdirSync(artifacts, { recursive: true })
+writeFileSync(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: {
+    backend: "wordpress-playground",
+    name: "recipe-run-php-plugin-load-smoke",
+    wp: "7.0",
+    blueprint: { steps: [] },
+  },
+  inputs: {
+    extraPlugins: [
+      {
+        source: component,
+        slug: "bench-plugin",
+        pluginFile: "bench-plugin/bench-plugin.php",
+      },
+      {
+        source: dependency,
+        slug: "bench-dependency",
+        pluginFile: "bench-dependency/dependency-main.php",
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: [
+          "code=if (!function_exists('wp_codebox_bench_plugin_value')) { throw new RuntimeException('component plugin function missing'); } if (!class_exists('WP_Codebox_Bench_Dependency_Fixture')) { throw new RuntimeException('extra plugin class missing'); } if (!function_exists('wp_codebox_bench_dependency_value')) { throw new RuntimeException('extra plugin function missing'); } echo wp_json_encode(array('componentValue' => wp_codebox_bench_plugin_value(), 'dependencyValue' => wp_codebox_bench_dependency_value(), 'componentActive' => is_plugin_active('bench-plugin/bench-plugin.php'), 'dependencyActive' => is_plugin_active('bench-dependency/dependency-main.php'), 'dependencyActiveAtInclude' => $GLOBALS['wp_codebox_bench_dependency_boot']['active_at_include'] ?? 0));",
+        ],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+const result = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--artifacts",
+  artifacts,
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(result.status, 0, result.stderr || result.stdout)
+const output = JSON.parse(result.stdout)
+assert.equal(output.success, true)
+
+const workflowExecution = output.executions.find((execution: { command: string; recipePhase?: string }) => execution.command === "wordpress.run-php" && execution.recipePhase === "steps")
+assert.ok(workflowExecution)
+
+const workflowResult = JSON.parse(workflowExecution.stdout)
+assert.equal(workflowResult.componentValue, 7)
+assert.equal(workflowResult.dependencyValue, 11)
+assert.equal(workflowResult.componentActive, true)
+assert.equal(workflowResult.dependencyActive, true)
+assert.equal(workflowResult.dependencyActiveAtInclude, 1)
+
+console.log("recipe run-php plugin load smoke passed")

--- a/scripts/run-php-plugin-diagnostics-smoke.ts
+++ b/scripts/run-php-plugin-diagnostics-smoke.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
+import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+
+const spec = {
+  backend: "wordpress-playground",
+  environment: { kind: "wordpress" },
+  policy: { network: "none", filesystem: "sandbox", secrets: "none" },
+  metadata: {
+    recipe: {
+      inputs: {
+        extra_plugins: [
+          {
+            slug: "missing-plugin",
+            pluginFile: "missing-plugin/missing-plugin.php",
+            target: "/wordpress/wp-content/plugins/missing-plugin",
+            activate: true,
+            loadAs: "plugin",
+          },
+        ],
+      },
+    },
+  },
+} satisfies RuntimeCreateSpec
+
+const code = bootstrapPhpCode(spec, "echo 'unreachable';", [])
+
+assert.match(code, /wp-codebox\/run-php-plugin-load-diagnostic\/v1/)
+assert.match(code, /wordpress\.run-php cannot include recipe plugin file/)
+assert.match(code, /missing or unreadable plugin file/)
+assert.match(code, /'mounted_path' => isset\(\$plugin\['target'\]\)/)
+assert.match(code, /'active' => function_exists\('is_plugin_active'\) \? is_plugin_active\(\$plugin_file\) : null/)
+assert.match(code, /'included' => \$included/)
+const encodedPluginMetadata = Buffer.from(JSON.stringify([{ slug: "missing-plugin", pluginFile: "missing-plugin/missing-plugin.php", target: "/wordpress/wp-content/plugins/missing-plugin", activate: true, loadAs: "plugin" }]), "utf8").toString("base64")
+assert.match(code, new RegExp(encodedPluginMetadata))
+
+console.log("run-php plugin diagnostics smoke passed")


### PR DESCRIPTION
## Summary
- Loads active recipe extra plugin files during `wordpress.run-php` bootstrap before user PHP executes.
- Adds structured `wp-codebox/run-php-plugin-load-diagnostic/v1` failures for unsafe, missing, unreadable, or unverifiable plugin files.
- Adds focused smoke coverage proving `wordpress.run-php` can call APIs/classes from active extra plugins and component plugin fixtures.

Fixes #601.

## Tests
- `npm run build`
- `npm run recipe-run-php-plugin-load-smoke`
- `npm run run-php-plugin-diagnostics-smoke`
- `npm run recipe-bench-smoke`
- `npm run recipe-site-seed-smoke`
- `git diff --check`
- `WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS=1 WP_CODEBOX_MAX_DOWNLOAD_BYTES=80000000 WP_CODEBOX_MAX_EXTRACTED_BYTES=220000000 WP_CODEBOX_MAX_EXTRACTED_FILES=10000 npm run wp-codebox -- recipe-run --recipe artifacts/wc-stripe-runphp-smoke.json --artifacts artifacts/wc-stripe-runphp-smoke --json`
  - Verified `stdout`: `{"wc":"10.8.1","stripe":true,"woocommerceActive":true,"stripeActive":true}`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the runtime bootstrap change, smoke coverage, and verification/PR text for Chris to review and test.