### PR TITLE
Add browser probe liveness diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "preview-public-url-canonical-smoke": "tsx scripts/preview-public-url-canonical-smoke.ts",
     "preview-response-body-smoke": "tsx scripts/preview-response-body-smoke.ts",
     "browser-startup-progress-smoke": "tsx scripts/browser-startup-progress-smoke.ts",
+    "recipe-browser-probe-liveness-smoke": "tsx scripts/recipe-browser-probe-liveness-smoke.ts",
     "boot-preview-smoke": "tsx scripts/boot-preview-smoke.ts",
     "blueprint-validation-smoke": "tsx scripts/blueprint-validation-smoke.ts",
     "ability-login-blueprint-smoke": "tsx scripts/ability-login-blueprint-smoke.ts",

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -334,7 +334,7 @@ class RecipePhaseTracker {
       })
       return result
     } catch (error) {
-      const phaseError = error instanceof RecipePhaseError ? error : new RecipePhaseError(name, data, error)
+      const phaseError = error instanceof RecipePhaseError || error instanceof RecipeRunTimeoutError ? error : new RecipePhaseError(name, data, error)
       this.phases.push({
         schema: "wp-codebox/recipe-phase-evidence/v1",
         name,

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -587,6 +587,16 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
       addIssue("invalid-duration", `${path}.args`, "wordpress.browser-probe duration must look like 500ms or 2s.")
     }
 
+    const stallTimeout = recipeStepArgValue(step.args ?? [], "stall-timeout")
+    if (stallTimeout && !/^(\d+(?:\.\d+)?)(ms|s)$/.test(stallTimeout)) {
+      addIssue("invalid-stall-timeout", `${path}.args`, "wordpress.browser-probe stall-timeout must look like 500ms or 2s.")
+    }
+
+    const failFast = recipeStepArgValue(step.args ?? [], "fail-fast")
+    if (failFast && !["1", "0", "true", "false", "yes", "no", "on", "off"].includes(failFast.toLowerCase())) {
+      addIssue("invalid-fail-fast", `${path}.args`, "wordpress.browser-probe fail-fast must be true or false.")
+    }
+
     const repeat = recipeStepArgValue(step.args ?? [], "repeat")
     if (repeat && !/^[1-9]\d*$/.test(repeat)) {
       addIssue("invalid-repeat", `${path}.args`, "wordpress.browser-probe repeat must be a positive integer.")

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -39,11 +39,31 @@ export interface BrowserProbeArtifact {
     metrics?: Record<string, number>
     networkEvents: number
     performance?: BrowserProbePerformanceSummary
+    progress?: BrowserProbeProgressSummary
     replayability: BrowserProbeReplayability
     screenshot: boolean
     scriptResult?: unknown
     viewport: BrowserProbeViewport | null
   }
+}
+
+export interface BrowserProbeProgressSummary {
+  status: "active" | "failed" | "stalled"
+  startedAt: string
+  lastProgressAt: string
+  lastProgressSource: BrowserProbeProgressSource
+  idleMs: number
+  stallTimeoutMs?: number
+  terminalFailure?: BrowserProbeTerminalFailure
+}
+
+export type BrowserProbeProgressSource = "navigation" | "network" | "console" | "pageerror" | "checkpoint" | "script" | "duration" | "probe-error"
+
+export interface BrowserProbeTerminalFailure {
+  message: string
+  reason?: string
+  details?: unknown
+  timestamp: string
 }
 
 export interface BrowserAssertionsSummary {

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -6,7 +6,7 @@ import { browserInteractionStepsFromArgs, durationStringMs } from "./browser-act
 import type { BrowserProbeArtifact, BrowserProbeCheckpointRecord, BrowserProbeErrorRecord, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
-import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, navigateBrowserProbe } from "./browser-probe.js"
+import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, navigateBrowserProbe } from "./browser-probe.js"
 import { argValue, cleanWpCliOutput, commaListArg } from "./commands.js"
 import { editorActionStepsFromArgs, editorOpenTargetFromArgs, type EditorActionStep } from "./editor-actions.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
@@ -63,6 +63,8 @@ export async function runBrowserProbeCommand({
   const durationMs = durationArg(args, "duration", 0)
   const requestedViewport = viewportArg(args, "viewport")
   const script = argValue(args, "script")
+  const failFast = booleanArg(args, "fail-fast", false)
+  const stallTimeoutMs = durationArg(args, "stall-timeout", 0)
   const capturesBrowserMetrics = capture.has("performance") || capture.has("memory")
   const targetUrl = resolveBrowserProbeUrl(urlArg, server.serverUrl)
   const browserDirectory = join(artifactRoot, "files", "browser")
@@ -83,6 +85,7 @@ export async function runBrowserProbeCommand({
   const screenshotPath = join(browserDirectory, "screenshot.png")
   const summaryPath = join(browserDirectory, "summary.json")
   const startedAt = now()
+  const progress = createBrowserProbeProgressTracker(startedAt, stallTimeoutMs)
   const { chromium } = await import("playwright")
   const browser = await chromium.launch()
   let finalUrl = targetUrl
@@ -94,56 +97,76 @@ export async function runBrowserProbeCommand({
   let performanceArtifact: BrowserProbePerformanceArtifact | undefined
   let page: import("playwright").Page | null = null
   let artifact: BrowserProbeArtifact | undefined
+  let pendingError: Error | undefined
 
   try {
     page = await browser.newPage()
     if (requestedViewport) {
       await page.setViewportSize(requestedViewport)
     }
+    await page.addInitScript(BROWSER_PROBE_STATE_INIT_SCRIPT)
     if (capturesBrowserMetrics) {
       await page.addInitScript(BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT)
     }
     viewport = await browserProbeViewport(page)
     if (capture.has("console")) {
-      page.on("console", (message) => consoleMessages.push(serializeBrowserConsoleMessage(message)))
+      page.on("console", (message) => {
+        progress.mark("console")
+        consoleMessages.push(serializeBrowserConsoleMessage(message))
+      })
     }
     if (capture.has("errors")) {
-      page.on("pageerror", (error) => errors.push(serializeBrowserError("pageerror", error)))
+      page.on("pageerror", (error) => {
+        progress.mark("pageerror")
+        errors.push(serializeBrowserError("pageerror", error))
+      })
     }
     if (capture.has("network")) {
       page.on("requestfinished", (request) => {
         const task = serializeBrowserFinishedRequest(request).then((record) => {
+          progress.mark("network")
           network.push(record)
         }).catch(() => undefined)
         networkTasks.push(task)
       })
-      page.on("requestfailed", (request) => network.push(serializeBrowserRequestFailure(request)))
+      page.on("requestfailed", (request) => {
+        progress.mark("network")
+        network.push(serializeBrowserRequestFailure(request))
+      })
     }
 
-    await navigateBrowserProbe(page, targetUrl, waitFor, durationMs)
+    await withBrowserProbeLiveness(page, progress, failFast, navigateBrowserProbe(page, targetUrl, waitFor, durationMs))
+    progress.mark("navigation")
     if (capturesBrowserMetrics) {
       checkpoints.push(await browserProbeCheckpoint(page, "after-navigation"))
     }
     if (script) {
-      scriptResult = await page.evaluate(async (source) => {
+      scriptResult = await withBrowserProbeLiveness(page, progress, failFast, page.evaluate(async (source) => {
         const run = new Function(`return (async () => {\n${source}\n})()`)
         return run()
-      }, script)
+      }, script))
+      progress.mark("script")
       if (capturesBrowserMetrics) {
-        checkpoints.push(...await browserProbePendingCheckpoints(page))
+        const pendingCheckpoints = await browserProbePendingCheckpoints(page)
+        if (pendingCheckpoints.length > 0) {
+          progress.mark("checkpoint")
+        }
+        checkpoints.push(...pendingCheckpoints)
         checkpoints.push(await browserProbeCheckpoint(page, "after-script"))
       }
     }
     if (durationMs > 0 && waitFor !== "duration") {
-      await page.waitForTimeout(durationMs)
+      await withBrowserProbeLiveness(page, progress, failFast, page.waitForTimeout(durationMs))
+      progress.mark("duration")
       if (capturesBrowserMetrics) {
         checkpoints.push(await browserProbeCheckpoint(page, "after-duration"))
       }
     }
     finalUrl = page.url()
   } catch (error) {
+    pendingError = error instanceof Error ? error : new Error(String(error))
+    progress.fail("probe-error", pendingError)
     errors.push(serializeBrowserError("probe-error", error))
-    throw error
   } finally {
     if (page) {
       finalUrl = page.url()
@@ -222,6 +245,7 @@ export async function runBrowserProbeCommand({
         ...(memoryArtifact || performanceArtifact ? { metrics: browserProbeBenchMetrics(memoryArtifact, performanceArtifact) } : {}),
         networkEvents: network.length,
         ...(performanceArtifact ? { performance: performanceArtifact.peak } : {}),
+        progress: progress.summary(),
         replayability: browserProbeReplayability(capture),
         screenshot: capture.has("screenshot"),
         ...(typeof scriptResult !== "undefined" ? { scriptResult } : {}),
@@ -234,6 +258,8 @@ export async function runBrowserProbeCommand({
       finalUrl,
       waitFor,
       durationMs,
+      failFast,
+      stallTimeoutMs,
       capture: [...capture].sort(),
       startedAt,
       finishedAt: now(),
@@ -245,6 +271,13 @@ export async function runBrowserProbeCommand({
       viewport,
       summary: artifact.summary,
     }, null, 2)}\n`)
+  }
+
+  if (pendingError) {
+    if (!artifact) {
+      throw pendingError
+    }
+    throw new BrowserCommandArtifactError(pendingError.message, artifact)
   }
 
   return {
@@ -1191,6 +1224,184 @@ async function fileSha256(path: string): Promise<string> {
 
 function sha256(contents: Buffer): string {
   return createHash("sha256").update(contents).digest("hex")
+}
+
+type BrowserProbeProgressSource = "navigation" | "network" | "console" | "pageerror" | "checkpoint" | "script" | "duration" | "probe-error"
+
+class BrowserProbeTerminalFailureError extends Error {
+  readonly code = "browser-probe-terminal-failure"
+
+  constructor(readonly failure: { message: string; reason?: string; details?: unknown; timestamp: string }) {
+    super(`Browser probe reported a terminal failure: ${failure.message}`)
+    this.name = "BrowserProbeTerminalFailureError"
+  }
+}
+
+class BrowserProbeStallError extends Error {
+  readonly code = "browser-probe-stalled"
+
+  constructor(readonly idleMs: number, readonly stallTimeoutMs: number, readonly lastProgressSource: BrowserProbeProgressSource) {
+    super(`Browser probe stalled after ${idleMs}ms without progress; last progress source was ${lastProgressSource}`)
+    this.name = "BrowserProbeStallError"
+  }
+}
+
+function createBrowserProbeProgressTracker(startedAt: string, stallTimeoutMs: number): {
+  mark(source: BrowserProbeProgressSource, timestamp?: string): void
+  fail(source: BrowserProbeProgressSource, error: Error): void
+  terminalFailure(failure: { message: string; reason?: string; details?: unknown; timestamp: string }): void
+  lastProgressElapsedMs(): number
+  summary(): {
+    status: "active" | "failed" | "stalled"
+    startedAt: string
+    lastProgressAt: string
+    lastProgressSource: BrowserProbeProgressSource
+    idleMs: number
+    stallTimeoutMs?: number
+    terminalFailure?: { message: string; reason?: string; details?: unknown; timestamp: string }
+  }
+} {
+  let status: "active" | "failed" | "stalled" = "active"
+  let lastProgressAt = startedAt
+  let lastProgressSource: BrowserProbeProgressSource = "navigation"
+  let terminalFailure: { message: string; reason?: string; details?: unknown; timestamp: string } | undefined
+
+  return {
+    mark(source, timestamp = now()) {
+      lastProgressAt = timestamp
+      lastProgressSource = source
+    },
+    fail(source, error) {
+      lastProgressAt = now()
+      lastProgressSource = source
+      status = error instanceof BrowserProbeStallError ? "stalled" : "failed"
+      if (error instanceof BrowserProbeTerminalFailureError) {
+        terminalFailure = error.failure
+      }
+    },
+    terminalFailure(failure) {
+      status = "failed"
+      terminalFailure = failure
+      lastProgressAt = failure.timestamp
+      lastProgressSource = "probe-error"
+    },
+    lastProgressElapsedMs() {
+      return Math.max(0, Date.now() - Date.parse(lastProgressAt))
+    },
+    summary() {
+      return {
+        status,
+        startedAt,
+        lastProgressAt,
+        lastProgressSource,
+        idleMs: this.lastProgressElapsedMs(),
+        ...(stallTimeoutMs > 0 ? { stallTimeoutMs } : {}),
+        ...(terminalFailure ? { terminalFailure } : {}),
+      }
+    },
+  }
+}
+
+async function withBrowserProbeLiveness<T>(page: import("playwright").Page, progress: ReturnType<typeof createBrowserProbeProgressTracker>, failFast: boolean, operation: Promise<T>): Promise<T> {
+  const stallTimeoutMs = progress.summary().stallTimeoutMs ?? 0
+  if (!failFast && stallTimeoutMs <= 0) {
+    return operation
+  }
+
+  let interval: NodeJS.Timeout | undefined
+  operation.catch(() => undefined)
+
+  try {
+    const result = await Promise.race([
+      operation,
+      new Promise<T>((_resolve, reject) => {
+        interval = setInterval(() => {
+          void (async () => {
+            try {
+              const state = await page.evaluate(() => {
+                const probe = (globalThis as typeof globalThis & {
+                  __wpCodeboxBrowserProbe?: {
+                    checkpoints?: Array<{ timestamp?: unknown }>
+                    terminalFailure?: { message?: unknown; reason?: unknown; details?: unknown; timestamp?: unknown }
+                  }
+                }).__wpCodeboxBrowserProbe
+                const checkpoints = Array.isArray(probe?.checkpoints) ? probe.checkpoints : []
+                const latestCheckpoint = [...checkpoints].reverse().find((checkpoint) => typeof checkpoint.timestamp === "string")
+                const failure = probe?.terminalFailure
+                return {
+                  checkpointTimestamp: latestCheckpoint?.timestamp,
+                  terminalFailure: failure && typeof failure.message === "string" ? {
+                    message: failure.message,
+                    reason: typeof failure.reason === "string" ? failure.reason : undefined,
+                    details: failure.details,
+                    timestamp: typeof failure.timestamp === "string" ? failure.timestamp : new Date().toISOString(),
+                  } : undefined,
+                }
+              })
+              if (typeof state.checkpointTimestamp === "string") {
+                progress.mark("checkpoint", state.checkpointTimestamp)
+              }
+              if (state.terminalFailure) {
+                progress.terminalFailure(state.terminalFailure)
+                reject(new BrowserProbeTerminalFailureError(state.terminalFailure))
+                return
+              }
+              if (stallTimeoutMs > 0 && progress.lastProgressElapsedMs() >= stallTimeoutMs) {
+                const summary = progress.summary()
+                reject(new BrowserProbeStallError(summary.idleMs, stallTimeoutMs, summary.lastProgressSource))
+              }
+            } catch {
+              // The page may be navigating or already closed; the outer operation remains authoritative.
+            }
+          })()
+        }, 250)
+        interval.unref()
+      }),
+    ])
+    const terminalFailure = failFast ? await browserProbeTerminalFailure(page) : undefined
+    if (terminalFailure) {
+      progress.terminalFailure(terminalFailure)
+      throw new BrowserProbeTerminalFailureError(terminalFailure)
+    }
+    return result
+  } finally {
+    if (interval) {
+      clearInterval(interval)
+    }
+  }
+}
+
+async function browserProbeTerminalFailure(page: import("playwright").Page): Promise<{ message: string; reason?: string; details?: unknown; timestamp: string } | undefined> {
+  return page.evaluate(() => {
+    const failure = (globalThis as typeof globalThis & {
+      __wpCodeboxBrowserProbe?: {
+        terminalFailure?: { message?: unknown; reason?: unknown; details?: unknown; timestamp?: unknown }
+      }
+    }).__wpCodeboxBrowserProbe?.terminalFailure
+    if (!failure || typeof failure.message !== "string") {
+      return undefined
+    }
+    return {
+      message: failure.message,
+      reason: typeof failure.reason === "string" ? failure.reason : undefined,
+      details: failure.details,
+      timestamp: typeof failure.timestamp === "string" ? failure.timestamp : new Date().toISOString(),
+    }
+  }).catch(() => undefined)
+}
+
+function booleanArg(args: string[], name: string, fallback: boolean): boolean {
+  const raw = argValue(args, name)?.trim().toLowerCase()
+  if (!raw) {
+    return fallback
+  }
+  if (["1", "true", "yes", "on"].includes(raw)) {
+    return true
+  }
+  if (["0", "false", "no", "off"].includes(raw)) {
+    return false
+  }
+  throw new Error(`${name} must be true or false`)
 }
 
 function durationArg(args: string[], name: string, fallbackMs: number): number {

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -11,10 +11,11 @@ import { browserProbeMemorySummary, browserProbePerformanceSummary, cdpDomCounte
 
 export const BROWSER_PROBE_CAPTURE_VALUES = ["console", "errors", "html", "network", "performance", "memory", "screenshot"] as const
 
-export const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
+export const BROWSER_PROBE_STATE_INIT_SCRIPT = `
 (() => {
   const state = globalThis.__wpCodeboxBrowserProbe = globalThis.__wpCodeboxBrowserProbe || { checkpoints: [], longTasks: [] };
   state.checkpoints = state.checkpoints || [];
+  state.longTasks = state.longTasks || [];
   globalThis.__wpCodeboxProbeCheckpoint = (name, metadata = {}) => {
     state.checkpoints.push({
       name: String(name || ''),
@@ -22,6 +23,21 @@ export const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
       timestamp: new Date().toISOString(),
     });
   };
+  globalThis.__wpCodeboxProbeFail = (message, details = undefined) => {
+    state.terminalFailure = {
+      message: String(message || 'Browser probe reported a terminal failure'),
+      details,
+      timestamp: new Date().toISOString(),
+    };
+  };
+})();
+`
+
+export const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
+(() => {
+  const state = globalThis.__wpCodeboxBrowserProbe = globalThis.__wpCodeboxBrowserProbe || { checkpoints: [], longTasks: [] };
+  state.checkpoints = state.checkpoints || [];
+  state.longTasks = state.longTasks || [];
   if (state.longTaskObserverInstalled || typeof PerformanceObserver === 'undefined') {
     return;
   }

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -417,7 +417,15 @@ class PlaygroundRuntime implements Runtime {
 
   async runBrowserProbe(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
-    const result = await runBrowserProbeCommand({ artifactRoot: this.artifactRoot, server, spec })
+    let result: Awaited<ReturnType<typeof runBrowserProbeCommand>>
+    try {
+      result = await runBrowserProbeCommand({ artifactRoot: this.artifactRoot, server, spec })
+    } catch (error) {
+      if (isBrowserCommandArtifactError(error)) {
+        this.browserProbes.push(error.artifact)
+      }
+      throw error
+    }
     this.browserProbes.push(result.artifact)
     return result.output
   }

--- a/scripts/recipe-browser-probe-liveness-smoke.ts
+++ b/scripts/recipe-browser-probe-liveness-smoke.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-browser-probe-liveness-"))
+
+try {
+  const terminal = await runRecipe("terminal", [
+    "url=/",
+    "fail-fast=true",
+    "script=__wpCodeboxProbeFail('terminal smoke failure', { reason: 'smoke' });",
+  ], 30_000)
+  assert.equal(terminal.exit.code, 1, `terminal failure should fail recipe-run; stdout: ${terminal.stdout}; stderr: ${terminal.stderr}`)
+  assert.ok(terminal.elapsedMs < 20_000, `terminal failure should fail before the recipe timeout; elapsed=${terminal.elapsedMs}`)
+  assert.match(terminal.output.error?.message ?? "", /terminal smoke failure/)
+  assert.equal(terminal.summary.summary.progress.status, "failed")
+  assert.equal(terminal.summary.summary.progress.terminalFailure.message, "terminal smoke failure")
+
+  const stall = await runRecipe("stall", [
+    "url=/",
+    "wait-for=duration",
+    "duration=5s",
+    "stall-timeout=1s",
+  ], 30_000)
+  assert.equal(stall.exit.code, 1, `idle stall should fail recipe-run; stdout: ${stall.stdout}; stderr: ${stall.stderr}`)
+  assert.ok(stall.elapsedMs < 20_000, `idle stall should fail before the recipe timeout; elapsed=${stall.elapsedMs}`)
+  assert.match(stall.output.error?.message ?? "", /stalled/i)
+  assert.equal(stall.summary.summary.progress.status, "stalled")
+  assert.equal(stall.summary.summary.progress.stallTimeoutMs, 1000)
+
+  console.log("Recipe browser probe liveness smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function runRecipe(name: string, args: string[], watchdogMs: number): Promise<{
+  exit: { code: number | null; signal: NodeJS.Signals | null }
+  output: Record<string, any>
+  summary: Record<string, any>
+  stdout: string
+  stderr: string
+  elapsedMs: number
+}> {
+  const artifacts = join(workspace, `${name}-artifacts`)
+  const recipePath = join(workspace, `${name}.json`)
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: "7.0" },
+    workflow: {
+      steps: [{ command: "wordpress.browser-probe", args }],
+    },
+    artifacts: {
+      directory: artifacts,
+      verify: false,
+      workspacePolicy: { strict: false, writableRoots: ["."], gitBacked: false },
+    },
+  }, null, 2)}\n`)
+
+  const startedAt = Date.now()
+  const child = spawn(process.execPath, [
+    "packages/cli/dist/index.js",
+    "recipe-run",
+    "--recipe",
+    recipePath,
+    "--artifacts",
+    artifacts,
+    "--timeout",
+    "20s",
+    "--json",
+  ], {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const watchdog = setTimeout(() => {
+    child.kill("SIGKILL")
+  }, watchdogMs)
+  const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit) => {
+    child.once("close", (code, signal) => resolveExit({ code, signal }))
+  })
+  const elapsedMs = Date.now() - startedAt
+  clearTimeout(watchdog)
+  assert.notEqual(exit.signal, "SIGKILL", `${name} recipe-run hung; stdout: ${stdout}; stderr: ${stderr}`)
+
+  const output = JSON.parse(stdout)
+  assert.equal(output.schema, "wp-codebox/recipe-run/v1")
+  assert.equal(output.success, false)
+  assert.ok(output.artifacts?.directory, `${name} recipe-run should report artifact directory`)
+
+  const summary = JSON.parse(await readFile(join(output.artifacts.directory, "files", "browser", "summary.json"), "utf8"))
+  assert.equal(summary.schema, "wp-codebox/browser-probe/v1")
+  return { exit, output, summary, stdout, stderr, elapsedMs }
+}


### PR DESCRIPTION
## Summary
- Adds generic `wordpress.browser-probe` liveness tracking with `fail-fast=true`, `stall-timeout=<duration>`, progress timestamps, terminal failure metadata, and idle/stalled summaries in browser probe artifacts.
- Adds page-level probe helpers for generic caller scripts: `__wpCodeboxProbeCheckpoint(name, metadata)` and `__wpCodeboxProbeFail(message, details)`.
- Preserves failed browser-probe artifacts on recipe-run failure and keeps `RecipeRunTimeoutError` classified as `recipe-run-timeout` instead of wrapping it as a phase failure.

Fixes #607.

## Verification
- `npm run build`
- `npm run recipe-browser-probe-liveness-smoke`
- `npm run recipe-run-timeout-smoke`
- `npm run browser-probe-artifact-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the implementation, targeted smoke coverage, and verification commands; Chris remains responsible for review and merge.