### PR TITLE
Accept runtime component paths in agent task runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "discovery-command-smoke": "tsx scripts/discovery-command-smoke.ts",
     "doctor-command-smoke": "tsx scripts/doctor-command-smoke.ts",
     "agent-sandbox-code-smoke": "tsx scripts/agent-sandbox-code-smoke.ts",
+    "agent-task-run-runtime-components-smoke": "tsx scripts/agent-task-run-runtime-components-smoke.ts",
     "agent-runtime-failure-smoke": "tsx scripts/agent-runtime-failure-smoke.ts",
     "recipe-dry-run-smoke": "tsx scripts/recipe-dry-run-smoke.ts",
     "recipe-workflow-phases-smoke": "tsx scripts/recipe-workflow-phases-smoke.ts",

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -38,6 +38,7 @@ interface AgentTaskRunInput {
   agents_api_path?: string
   data_machine_path?: string
   data_machine_code_path?: string
+  runtime_component_paths?: Record<string, unknown>
   parent_request?: Record<string, unknown>
   orchestrator?: Record<string, unknown>
 }
@@ -127,7 +128,7 @@ async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskRunOptio
   }
 }
 
-function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: ReturnType<typeof normalizeTaskInput>, wpVersion: string): WorkspaceRecipe {
+export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: ReturnType<typeof normalizeTaskInput>, wpVersion: string): WorkspaceRecipe {
   const artifacts = stringValue(input.artifacts_path)
   const providerPlugins = stringList(input.provider_plugin_paths).map((source) => ({ source: prepareComposerPluginSource(source, slugFromPath(source), artifacts), slug: slugFromPath(source), activate: false }))
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
@@ -169,9 +170,9 @@ function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: ReturnType<ty
       mounts: Array.isArray(input.mounts) ? input.mounts : [],
       workspaces: Array.isArray(input.workspaces) ? input.workspaces : [],
       extraPlugins: [
-        componentPlugin(input.agents_api_path, "agents-api", artifacts),
-        componentPlugin(input.data_machine_path, "data-machine", artifacts),
-        componentPlugin(input.data_machine_code_path, "data-machine-code", artifacts),
+        componentPlugin(runtimeComponentPath(input, "agents_api", input.agents_api_path), "agents-api", artifacts),
+        componentPlugin(runtimeComponentPath(input, "agent_runtime", input.data_machine_path), "data-machine", artifacts),
+        componentPlugin(runtimeComponentPath(input, "agent_runtime_tools", input.data_machine_code_path), "data-machine-code", artifacts),
         ...providerPlugins,
       ].filter(Boolean),
       secretEnv: stringList(input.secret_env),
@@ -179,6 +180,11 @@ function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: ReturnType<ty
     }),
     workflow: { steps: [{ command: "wp-codebox.agent-sandbox-run", args: workflowArgs }] },
   }) as WorkspaceRecipe
+}
+
+function runtimeComponentPath(input: AgentTaskRunInput, key: string, fallback: unknown): unknown {
+  const paths = input.runtime_component_paths
+  return paths && typeof paths === "object" && !Array.isArray(paths) ? paths[key] || fallback : fallback
 }
 
 function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import { normalizeTaskInput } from "@automattic/wp-codebox-core"
+import { buildAgentTaskRecipe } from "../packages/cli/src/commands/agent-task-run.js"
+
+const input = {
+  goal: "Run a Data Machine bundle",
+  provider: "openai",
+  model: "gpt-5.5",
+  runtime_component_paths: {
+    agents_api: "/components/agents-api",
+    agent_runtime: "/components/data-machine",
+    agent_runtime_tools: "/components/data-machine-code",
+  },
+  provider_plugin_paths: ["/components/ai-provider-for-openai"],
+  artifacts_path: "/tmp/wp-codebox-artifacts",
+}
+
+const recipe = buildAgentTaskRecipe(input, normalizeTaskInput(input), "trunk")
+const extraPlugins = recipe.inputs?.extraPlugins ?? []
+
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "agents-api")?.source, "/components/agents-api")
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine")?.source, "/components/data-machine")
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.source, "/components/data-machine-code")
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai")?.source, "/components/ai-provider-for-openai")
+
+const legacyInput = {
+  goal: "Run a Data Machine bundle",
+  agents_api_path: "/legacy/agents-api",
+  data_machine_path: "/legacy/data-machine",
+  data_machine_code_path: "/legacy/data-machine-code",
+}
+const legacyRecipe = buildAgentTaskRecipe(legacyInput, normalizeTaskInput(legacyInput), "trunk")
+const legacyExtraPlugins = legacyRecipe.inputs?.extraPlugins ?? []
+
+assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "agents-api")?.source, "/legacy/agents-api")
+assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine")?.source, "/legacy/data-machine")
+assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.source, "/legacy/data-machine-code")


### PR DESCRIPTION
## Summary
- Teach `agent-task-run` to mount runtime components from the generic `runtime_component_paths` contract.
- Preserve legacy top-level component path inputs while allowing Homeboy Extensions to pass `agents_api`, `agent_runtime`, and `agent_runtime_tools`.
- Add a focused smoke covering generic and legacy component path recipe generation.

## Verification
- `npm run agent-task-run-runtime-components-smoke`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Site Generation Loop runtime-component handoff failure, drafted the WP Codebox patch, and ran local verification. Chris directed the publication.