### PR TITLE
Return single runtime agent task results

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -53,6 +53,7 @@ interface AgentTaskRunOutput {
   wp: string
   artifacts: string
   agent_result: Record<string, unknown>
+  agent_task_result: Record<string, unknown>
   completion_outcome: Record<string, unknown>
   run: Record<string, unknown>
   diagnostics: Array<Record<string, unknown>>
@@ -108,6 +109,7 @@ async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskRunOptio
       wp: wpVersion,
       artifacts,
       agent_result: objectValue(run.agentResult) || objectValue(runRecord.agentResult) || objectValue(artifactsRecord.agentResult) || {},
+      agent_task_result: objectValue(run.agentTaskResult) || objectValue(runRecord.agentTaskResult) || objectValue(artifactsRecord.agentTaskResult) || {},
       completion_outcome: objectValue(run.completionOutcome) || objectValue(artifactsRecord.completionOutcome) || {},
       run,
       diagnostics: diagnostics(run, capture.exitCode),

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -8,7 +8,7 @@ import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded, type RecipeDryRunOutput, type RecipeDryRunSiteSeed, type RecipeDryRunStagedFile } from "../recipe-dry-run.js"
-import { collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput } from "../recipe-evidence.js"
+import { collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, type AgentSandboxResultSummary, type AgentTaskSingleResult, type SandboxCompletionOutcome } from "../recipe-evidence.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { parseWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { DEFAULT_WORDPRESS_VERSION, previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
@@ -79,6 +79,9 @@ interface RecipeRunOutput {
   }
   benchResults?: BenchResults
   benchResultsList?: BenchResults[]
+  agentResult?: AgentSandboxResultSummary
+  agentTaskResult?: AgentTaskSingleResult
+  completionOutcome?: SandboxCompletionOutcome
   artifacts?: ArtifactBundle
   run?: RuntimeRunRecord
   interruption?: RecipeInterruptionMetadata
@@ -814,6 +817,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
         ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
         ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
+        ...(evidence.agentTaskResult ? { agentTaskResult: recipeAgentTaskResultOutput(evidence.agentTaskResult) } : {}),
         ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
         artifacts,
         run: runRecord,
@@ -840,6 +844,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
       ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
       ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
+      ...(evidence.agentTaskResult ? { agentTaskResult: recipeAgentTaskResultOutput(evidence.agentTaskResult) } : {}),
       ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
       artifacts,
       run: runRecord,

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -28,11 +28,26 @@ export interface RecipeArtifactEvidenceResult {
   agentResult?: AgentSandboxResultSummary & {
     artifact: RecipeArtifactEvidenceFile
   }
+  agentTaskResult?: AgentTaskSingleResult & {
+    artifact: RecipeArtifactEvidenceFile
+  }
   completionOutcome?: SandboxCompletionOutcome & {
     artifact: RecipeArtifactEvidenceFile
   }
   transcript?: AgentSandboxTranscript & {
     artifact: RecipeArtifactEvidenceFile
+  }
+}
+
+export interface AgentTaskSingleResult {
+  schema: "wp-codebox/agent-task-result/v1"
+  success: boolean
+  status: "completed" | "failed"
+  outputs: Record<string, unknown>
+  diagnostics: Record<string, unknown>
+  raw: {
+    agent_runtime?: Record<string, unknown>
+    result?: unknown
   }
 }
 
@@ -342,7 +357,7 @@ export async function finalizeRecipeArtifactEvidence(
   return result
 }
 
-export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, executions: RecipeEvidenceExecutionResult[]): Promise<Pick<RecipeArtifactEvidenceResult, "agentResult" | "completionOutcome" | "transcript">> {
+export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, executions: RecipeEvidenceExecutionResult[]): Promise<Pick<RecipeArtifactEvidenceResult, "agentResult" | "agentTaskResult" | "completionOutcome" | "transcript">> {
   const transcript = buildAgentSandboxTranscript(executions)
   if (transcript.executions.length === 0) {
     return {}
@@ -350,16 +365,20 @@ export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, ex
 
   const transcriptPath = join(dirname(artifacts.reviewPath), "transcript.json")
   const agentResultPath = join(dirname(artifacts.reviewPath), "agent-result.json")
+  const agentTaskResultPath = join(dirname(artifacts.reviewPath), "agent-task-result.json")
   const completionOutcomePath = join(dirname(artifacts.reviewPath), "completion-outcome.json")
   const transcriptFile = await writeRecipeEvidenceJson(artifacts.directory, transcriptPath, transcript, "agent-transcript")
   const agentResult = await buildAgentSandboxResultSummary(artifacts, transcript, transcriptFile.path)
   const agentResultFile = await writeRecipeEvidenceJson(artifacts.directory, agentResultPath, agentResult, "agent-result")
+  const agentTaskResult = buildAgentTaskSingleResult(transcript)
+  const agentTaskResultFile = agentTaskResult ? await writeRecipeEvidenceJson(artifacts.directory, agentTaskResultPath, agentTaskResult, "agent-task-result") : undefined
   const completionOutcome = buildSandboxCompletionOutcome(artifacts, agentResult, transcript)
   const completionOutcomeFile = await writeRecipeEvidenceJson(artifacts.directory, completionOutcomePath, completionOutcome, "completion-outcome")
-  await updateRecipeArtifactEvidenceReferences(artifacts, [agentResultFile, completionOutcomeFile, transcriptFile])
+  await updateRecipeArtifactEvidenceReferences(artifacts, [agentResultFile, ...(agentTaskResultFile ? [agentTaskResultFile] : []), completionOutcomeFile, transcriptFile])
 
   return {
     agentResult: { ...agentResult, artifact: agentResultFile },
+    ...(agentTaskResult && agentTaskResultFile ? { agentTaskResult: { ...agentTaskResult, artifact: agentTaskResultFile } } : {}),
     completionOutcome: { ...completionOutcome, artifact: completionOutcomeFile },
     transcript: { ...transcript, artifact: transcriptFile },
   }
@@ -466,6 +485,68 @@ function buildSandboxCompletionOutcome(artifacts: ArtifactBundle, agentResult: A
       artifactDirectory: artifacts.directory,
     },
   })
+}
+
+export function buildAgentTaskSingleResult(transcript: AgentSandboxTranscript): AgentTaskSingleResult | undefined {
+  const runtime = latestAgentRuntime(transcript)
+  if (!runtime) {
+    return undefined
+  }
+
+  const rawResult = runtime.result
+  const resultRecord = isRecord(rawResult) ? rawResult : undefined
+  const success = runtime.success === true
+  return {
+    schema: "wp-codebox/agent-task-result/v1",
+    success,
+    status: success ? "completed" : "failed",
+    outputs: semanticOutputs(resultRecord),
+    diagnostics: stripUndefined({
+      runtime: isRecord(resultRecord?.diagnostics) || Array.isArray(resultRecord?.diagnostics) ? resultRecord?.diagnostics : undefined,
+      error: isRecord(runtime.error) ? runtime.error : undefined,
+      adapter: resultRecord ? undefined : { code: "agent_task_result_not_object", message: "Runtime agent task result was preserved under raw.result but did not expose object-shaped semantic outputs." },
+    }),
+    raw: stripUndefined({
+      agent_runtime: runtime,
+      result: rawResult,
+    }),
+  }
+}
+
+function latestAgentRuntime(transcript: AgentSandboxTranscript): Record<string, unknown> | undefined {
+  for (const execution of [...transcript.executions].reverse()) {
+    const runtime = agentRuntimeFromParsed(execution.parsed)
+    if (runtime) {
+      return runtime
+    }
+  }
+
+  return undefined
+}
+
+function agentRuntimeFromParsed(parsed: unknown): Record<string, unknown> | undefined {
+  const record = isRecord(parsed) ? parsed : undefined
+  const runtime = isRecord(record?.agent_runtime) ? record.agent_runtime : undefined
+  if (runtime) {
+    return runtime
+  }
+
+  const output = typeof record?.output === "string" ? decodeJsonFragment(record.output) : undefined
+  const outputRecord = isRecord(output) ? output : undefined
+  return isRecord(outputRecord?.agent_runtime) ? outputRecord.agent_runtime : undefined
+}
+
+function semanticOutputs(result: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!result) {
+    return {}
+  }
+
+  const outputs = isRecord(result.outputs) ? result.outputs : isRecord(result.output) ? result.output : undefined
+  if (outputs) {
+    return outputs
+  }
+
+  return Object.fromEntries(Object.entries(result).filter(([key]) => !["schema", "success", "status", "diagnostics", "raw", "error", "metadata"].includes(key)))
 }
 
 async function readChangedFileSummary(path: string): Promise<AgentSandboxResultSummary["changedFiles"]> {
@@ -688,6 +769,15 @@ export function recipeAgentResultOutput(agentResult: RecipeArtifactEvidenceResul
   }
 
   const { artifact: _artifact, ...result } = agentResult
+  return result
+}
+
+export function recipeAgentTaskResultOutput(agentTaskResult: RecipeArtifactEvidenceResult["agentTaskResult"]): AgentTaskSingleResult | undefined {
+  if (!agentTaskResult) {
+    return undefined
+  }
+
+  const { artifact: _artifact, ...result } = agentTaskResult
   return result
 }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -151,6 +151,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'artifacts'    => $artifacts,
 			'exit_code'    => $exit_code,
 			'agent_result' => is_array( $decoded['agentResult'] ?? null ) ? $decoded['agentResult'] : array(),
+			'agent_task_result' => is_array( $decoded['agentTaskResult'] ?? null ) ? $decoded['agentTaskResult'] : array(),
 			'completion_outcome' => $this->completion_outcome( $decoded ),
 			'run'          => $decoded,
 		);
@@ -244,6 +245,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'preview_url' => (string) ( $task_result['session']['artifacts']['preview_url'] ?? '' ),
 				'artifacts'    => $task_result['session']['artifacts'] ?? array(),
 				'agent_result' => $task_result['agent_result'] ?? array(),
+				'agent_task_result' => $task_result['agent_task_result'] ?? array(),
 				'completion_outcome' => $task_result['completion_outcome'] ?? array(),
 				'run'          => $task_result['run'] ?? array(),
 			);
@@ -2316,6 +2318,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 					'path'        => $artifacts,
 					'bundle_id'   => is_array( $run['artifacts'] ?? null ) ? (string) ( $run['artifacts']['id'] ?? '' ) : '',
 					'preview_url' => is_array( $run['artifacts']['preview'] ?? null ) ? (string) ( $run['artifacts']['preview']['url'] ?? '' ) : '',
+					'agent_task_result' => is_array( $run['agentTaskResult'] ?? null ) ? 'files/agent-task-result.json' : '',
 					'completion_outcome' => is_array( $run['completionOutcome'] ?? null ) ? 'files/completion-outcome.json' : '',
 				),
 				static fn( mixed $value ): bool => '' !== $value
@@ -2326,6 +2329,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	/** @param array<string,mixed> $run Decoded CLI run output. @param array<string,mixed>|null $outcome Strict remediation outcome when requested. @return array<string,mixed> */
 	private function run_diagnostics( array $run, int $exit_code, ?array $outcome ): array {
 		$agent_result = is_array( $run['agentResult'] ?? null ) ? $run['agentResult'] : array();
+		$agent_task_result = is_array( $run['agentTaskResult'] ?? null ) ? $run['agentTaskResult'] : array();
 
 		return array_filter(
 			array(
@@ -2333,6 +2337,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'exit_code'                 => $exit_code,
 				'recipe_run_schema'         => (string) ( $run['schema'] ?? '' ),
 				'agent_result_schema'       => (string) ( $agent_result['schema'] ?? '' ),
+				'agent_task_result_schema'  => (string) ( $agent_task_result['schema'] ?? '' ),
+				'agent_task_result_status'  => (string) ( $agent_task_result['status'] ?? '' ),
 				'agent_actionable'          => array_key_exists( 'actionable', $agent_result ) ? (bool) $agent_result['actionable'] : null,
 				'agent_no_op_reason'        => (string) ( $agent_result['noOpReason'] ?? '' ),
 				'completion_outcome_status' => is_array( $run['completionOutcome'] ?? null ) ? (string) ( $run['completionOutcome']['status'] ?? '' ) : '',
@@ -2356,6 +2362,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'artifacts_path'     => (string) ( $session_artifacts['path'] ?? '' ),
 				'artifact_bundle_id' => (string) ( $session_artifacts['bundle_id'] ?? $run_artifacts['id'] ?? '' ),
 				'preview_url'        => (string) ( $session_artifacts['preview_url'] ?? '' ),
+				'agent_task_result'  => (string) ( $session_artifacts['agent_task_result'] ?? '' ),
 				'completion_outcome' => (string) ( $session_artifacts['completion_outcome'] ?? '' ),
 				'transcript'         => (string) ( $transcript['artifact'] ?? '' ),
 			),

--- a/scripts/agent-runtime-failure-smoke.ts
+++ b/scripts/agent-runtime-failure-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { agentSandboxRuntimeFailure, recipeAgentResultFailure, type RecipeArtifactEvidenceResult } from "../packages/cli/src/recipe-evidence.ts"
+import { agentSandboxRuntimeFailure, buildAgentTaskSingleResult, recipeAgentResultFailure, type RecipeArtifactEvidenceResult } from "../packages/cli/src/recipe-evidence.ts"
 
 const nestedFailure = agentSandboxRuntimeFailure({
   executionIndex: 0,
@@ -54,6 +54,73 @@ const agentFailure = recipeAgentResultFailure({
 assert.equal(agentFailure?.code, "agent-runtime-failed")
 assert.equal(agentFailure?.message, "Provider codex is not registered in wp-ai-client")
 assert.equal(agentFailure?.name, "AgentRuntimeError")
+
+const singleResult = buildAgentTaskSingleResult({
+  schema: "wp-codebox/agent-transcript/v1",
+  executions: [{
+    executionIndex: 0,
+    command: "wordpress.run-php",
+    exitCode: 0,
+    recipeCommand: "wp-codebox.agent-sandbox-run",
+    stdout: JSON.stringify({
+      agent_runtime: {
+        success: true,
+        result: {
+          schema: "datamachine/agent-bundle-result/v1",
+          success: true,
+          status: "completed",
+          outputs: {
+            issue_number: 614,
+            issue_url: "https://github.com/Automattic/wp-codebox/issues/614",
+          },
+          diagnostics: { run_id: "runtime-run-123" },
+        },
+      },
+    }),
+    stderr: "",
+    parsed: {
+      agent_runtime: {
+        success: true,
+        result: {
+          schema: "datamachine/agent-bundle-result/v1",
+          success: true,
+          status: "completed",
+          outputs: {
+            issue_number: 614,
+            issue_url: "https://github.com/Automattic/wp-codebox/issues/614",
+          },
+          diagnostics: { run_id: "runtime-run-123" },
+        },
+      },
+    },
+  }],
+})
+
+assert.equal(singleResult?.schema, "wp-codebox/agent-task-result/v1")
+assert.equal(singleResult?.success, true)
+assert.equal(singleResult?.status, "completed")
+assert.deepEqual(singleResult?.outputs, {
+  issue_number: 614,
+  issue_url: "https://github.com/Automattic/wp-codebox/issues/614",
+})
+assert.deepEqual(singleResult?.diagnostics.runtime, { run_id: "runtime-run-123" })
+assert.ok(!("scenarios" in (singleResult ?? {})))
+
+const failedSingleResult = buildAgentTaskSingleResult({
+  schema: "wp-codebox/agent-transcript/v1",
+  executions: [{
+    executionIndex: 0,
+    command: "wordpress.run-php",
+    exitCode: 0,
+    recipeCommand: "wp-codebox.agent-sandbox-run",
+    stdout: JSON.stringify({ agent_runtime: { success: false, error: { code: "runtime_failed", message: "Runtime task failed." } } }),
+    stderr: "",
+    parsed: { agent_runtime: { success: false, error: { code: "runtime_failed", message: "Runtime task failed." } } },
+  }],
+})
+
+assert.equal(failedSingleResult?.status, "failed")
+assert.equal((failedSingleResult?.diagnostics.error as { code?: string } | undefined)?.code, "runtime_failed")
 
 const pendingToolsFailure = agentSandboxRuntimeFailure({
   executionIndex: 1,

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -1682,6 +1682,24 @@ $runner           = new WP_Codebox_Agent_Sandbox_Runner(
 								'executionCount' => 1,
 							),
 						),
+						'agentTaskResult' => array(
+							'schema'      => 'wp-codebox/agent-task-result/v1',
+							'success'     => true,
+							'status'      => 'completed',
+							'outputs'     => array(
+								'issue_number' => 614,
+								'issue_url'    => 'https://github.com/Automattic/wp-codebox/issues/614',
+							),
+							'diagnostics' => array(
+								'runtime' => array( 'run_id' => 'runtime-run-123' ),
+							),
+							'raw'         => array(
+								'agent_runtime' => array(
+									'success' => true,
+									'result'  => array( 'outputs' => array( 'issue_number' => 614 ) ),
+								),
+							),
+						),
 						'completionOutcome' => array(
 							'schema'       => 'wp-codebox/sandbox-completion-outcome/v1',
 							'status'       => 'partial',
@@ -1756,6 +1774,7 @@ $assert( 'runner keeps agent session separate from sandbox session', ! is_wp_err
 $assert( 'runner returns orchestrator correlation and artifact refs', ! is_wp_error( $result ) && 'job-123' === ( $result['session']['orchestrator']['job_id'] ?? '' ) && 'artifact-bundle-sha256-fixture' === ( $result['session']['artifacts']['bundle_id'] ?? '' ) );
 $assert( 'runner returns public preview URL in session artifact metadata', ! is_wp_error( $result ) && 'https://preview.example.test/session-123/' === ( $result['session']['artifacts']['preview_url'] ?? '' ) && 'https://preview.example.test/session-123/' === ( $result['run']['artifacts']['preview']['url'] ?? '' ) );
 $assert( 'runner surfaces normalized agent result summary', ! is_wp_error( $result ) && 'wp-codebox/agent-result/v1' === ( $result['agent_result']['schema'] ?? '' ) && false === ( $result['agent_result']['actionable'] ?? true ) && 'no_file_changes' === ( $result['agent_result']['noOpReason'] ?? '' ) && 'files/transcript.json' === ( $result['agent_result']['transcript']['artifact'] ?? '' ) );
+$assert( 'runner surfaces single runtime agent task result envelope', ! is_wp_error( $result ) && 'wp-codebox/agent-task-result/v1' === ( $result['agent_task_result']['schema'] ?? '' ) && 614 === ( $result['agent_task_result']['outputs']['issue_number'] ?? 0 ) && ! isset( $result['agent_task_result']['scenarios'] ) && 'files/agent-task-result.json' === ( $result['session']['artifacts']['agent_task_result'] ?? '' ) );
 $assert( 'runner surfaces generic completion outcome', ! is_wp_error( $result ) && 'wp-codebox/sandbox-completion-outcome/v1' === ( $result['completion_outcome']['schema'] ?? '' ) && 'partial' === ( $result['completion_outcome']['status'] ?? '' ) && 'files/completion-outcome.json' === ( $result['session']['artifacts']['completion_outcome'] ?? '' ) );
 $assert( 'runner returns normalized task input for legacy task', ! is_wp_error( $result ) && 'wp-codebox/task-input/v1' === ( $result['task_input']['schema'] ?? '' ) && 'Run a chat-requested sandbox task.' === ( $result['task_input']['goal'] ?? '' ) );
 $legacy_task_fixture = $task_input_fixture_by_name['legacy task maps to canonical goal with empty optionals']['normalized'] ?? array();
@@ -1874,7 +1893,7 @@ foreach ( $homeboy_step_args as $homeboy_step_arg ) {
 $homeboy_runtime_task = '' !== $homeboy_runtime_task_arg ? json_decode( $homeboy_runtime_task_arg, true ) : array();
 $assert( 'runner accepts Homeboy-shaped parent request', ! is_wp_error( $homeboy_result ) && true === ( $homeboy_result['success'] ?? false ) && 'homeboy-sandbox-session-123' === ( $homeboy_result['session']['id'] ?? '' ) );
 $assert( 'runner maps Homeboy artifacts and orchestrator metadata', ! is_wp_error( $homeboy_result ) && $root . '/artifacts/homeboy' === ( $homeboy_result['artifacts'] ?? '' ) && 'homeboy-job-123' === ( $homeboy_result['session']['orchestrator']['job_id'] ?? '' ) && 'agent-task-123' === ( $homeboy_result['session']['orchestrator']['agent_task_id'] ?? '' ) );
-$assert( 'runner returns stable Homeboy status diagnostics evidence and metadata refs', ! is_wp_error( $homeboy_result ) && in_array( (string) ( $homeboy_result['status'] ?? '' ), array( 'completed', 'failed' ), true ) && 'wp-codebox/agent-task-diagnostics/v1' === ( $homeboy_result['diagnostics']['schema'] ?? '' ) && 'wp-codebox/agent-task-evidence-refs/v1' === ( $homeboy_result['evidence_refs']['schema'] ?? '' ) && 'artifact-bundle-sha256-fixture-2' === ( $homeboy_result['evidence_refs']['artifact_bundle_id'] ?? '' ) && 'files/transcript.json' === ( $homeboy_result['evidence_refs']['transcript'] ?? '' ) && 'wp-codebox/agent-task-run-metadata/v1' === ( $homeboy_result['run_metadata']['schema'] ?? '' ) && 'homeboy-sandbox-session-123' === ( $homeboy_result['run_metadata']['sandbox_session_id'] ?? '' ) );
+$assert( 'runner returns stable Homeboy status diagnostics evidence and metadata refs', ! is_wp_error( $homeboy_result ) && in_array( (string) ( $homeboy_result['status'] ?? '' ), array( 'completed', 'failed' ), true ) && 'wp-codebox/agent-task-diagnostics/v1' === ( $homeboy_result['diagnostics']['schema'] ?? '' ) && 'wp-codebox/agent-task-evidence-refs/v1' === ( $homeboy_result['evidence_refs']['schema'] ?? '' ) && 'artifact-bundle-sha256-fixture-2' === ( $homeboy_result['evidence_refs']['artifact_bundle_id'] ?? '' ) && 'files/agent-task-result.json' === ( $homeboy_result['evidence_refs']['agent_task_result'] ?? '' ) && 'files/transcript.json' === ( $homeboy_result['evidence_refs']['transcript'] ?? '' ) && 'wp-codebox/agent-task-run-metadata/v1' === ( $homeboy_result['run_metadata']['schema'] ?? '' ) && 'homeboy-sandbox-session-123' === ( $homeboy_result['run_metadata']['sandbox_session_id'] ?? '' ) );
 $assert( 'runner maps Homeboy provider plugins and secrets', in_array( 'provider-plugin-slugs=ai-provider-test', $homeboy_step_args, true ) && str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
 $assert( 'runner preserves multiple runtime agent bundles in recipe inputs and step args', 2 === count( $homeboy_recipe['inputs']['agent_bundles'] ?? array() ) && str_contains( implode( "\n", $homeboy_step_args ), 'agent-bundles-json=' ) && str_contains( $captured_recipe, 'site-generator-agent.json' ) && str_contains( $captured_recipe, 'repair-agent' ) );
 $assert( 'runner passes generic runtime task execution request to sandbox step', is_array( $homeboy_runtime_task ) && 'runtime/run-agent-bundle' === ( $homeboy_runtime_task['ability'] ?? '' ) && 'static-site-manual-flow' === ( $homeboy_runtime_task['input']['flow'] ?? '' ) && true === ( $homeboy_runtime_task['input']['wait_for_completion'] ?? false ) && true === ( $homeboy_runtime_task['input']['dry_run'] ?? false ) );


### PR DESCRIPTION
## Summary
- Adds a canonical `wp-codebox/agent-task-result/v1` envelope for ordinary runtime agent-task executions, with semantic `outputs`, `diagnostics`, and preserved raw runtime data.
- Writes the single-result envelope to artifact evidence at `files/agent-task-result.json` and exposes it through recipe-run, agent-task-run, and the WordPress runner surfaces.
- Keeps benchmark/eval `scenarios` on benchmark result paths only and adds smoke coverage for non-scenario runtime task output.

Fixes #614.

## Testing
- `npm run build`
- `node --experimental-strip-types scripts/agent-runtime-failure-smoke.ts`
- `npm run wordpress-plugin-smoke`
- `node --experimental-strip-types scripts/recipe-bench-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting and testing the runtime result-envelope implementation; Chris remains responsible for review and final acceptance.