### PR TITLE
Authenticate sandbox runtime ability calls

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -244,7 +244,12 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
 } else {
     $agent_input = ${JSON.stringify(JSON.stringify(input))};
     $runtime_task_input = $runtime_task_run && is_array($sandbox_runtime_task['input'] ?? null) ? $sandbox_runtime_task['input'] : array();
-    $agent_result = $ability->execute($runtime_task_run ? $runtime_task_input : json_decode($agent_input, true));
+    $agent_execute_callback = static function () use ($ability, $runtime_task_run, $runtime_task_input, $agent_input) {
+        return $ability->execute($runtime_task_run ? $runtime_task_input : json_decode($agent_input, true));
+    };
+    $agent_result = class_exists('DataMachine\\Abilities\\PermissionHelper')
+        ? DataMachine\Abilities\PermissionHelper::run_as_authenticated($agent_execute_callback, 1)
+        : $agent_execute_callback();
     if (is_wp_error($agent_result)) {
         $sandbox_agent_runtime = array(
             'agent_runtime' => array(

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -66,6 +66,7 @@ async function main() {
   assert.match(code, /\\"mode\\":\\"allow\\"/, "sandbox agent should use allow-mode tool policy")
   assert.match(code, /\\"workspace_read\\"/, "sandbox agent should allow workspace read tool")
   assert.match(code, /agents_chat_runtime_principal_permission/, "sandbox chat should authorize through Agents API runtime-principal permission")
+  assert.match(code, /PermissionHelper::run_as_authenticated/, "sandbox chat should execute runtime abilities in an authenticated Data Machine context")
   assert.doesNotMatch(code, /datamachine_agent_mode_sandbox/, "sandbox chat should not depend on Data Machine agent mode filters")
   assert.doesNotMatch(code, /WP_Codebox_Sandbox_Perception_Directive/, "sandbox chat should not register Data Machine directives")
   assert.match(code, /sandbox_workspace/, "sandbox request should include mounted workspace context")


### PR DESCRIPTION
## Summary
- Execute sandbox runtime ability calls inside Data Machine's authenticated ability context when Data Machine is present.
- Keep the generic fallback path for runtimes without Data Machine.
- Extend the sandbox code smoke to lock this permission bridge.

## Verification
- `npm run agent-sandbox-code-smoke`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Site Generation Loop permission failure after PR #615, drafted the runtime permission bridge, and ran local verification. Chris directed the publication.