### PR TITLE
Serialize Playground archive cache warmup

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "recipe-runtime-evidence-smoke": "tsx scripts/recipe-runtime-evidence-smoke.ts",
     "recipe-run-timeout-smoke": "tsx scripts/recipe-run-timeout-smoke.ts",
     "playground-archive-cache-validation-smoke": "tsx scripts/playground-archive-cache-validation-smoke.ts",
+    "recipe-run-concurrent-playground-cache-smoke": "tsx scripts/recipe-run-concurrent-playground-cache-smoke.ts",
     "playground-sqlite-alias-smoke": "tsx scripts/playground-sqlite-alias-smoke.ts",
     "recipe-playground-boot-failure-smoke": "tsx scripts/recipe-playground-boot-failure-smoke.ts",
     "runtime-stack-mount-smoke": "tsx scripts/runtime-stack-mount-smoke.ts",

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -5,7 +5,7 @@ import type { BrowserStartupProgressEvent, BrowserStartupProgressPhase, BrowserS
 import { randomInt } from "node:crypto"
 import { existsSync } from "node:fs"
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http"
-import { readFile, stat, unlink } from "node:fs/promises"
+import { mkdir, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { basename, join } from "node:path"
 import { createServer as createNetServer } from "node:net"
@@ -24,6 +24,8 @@ interface PlaygroundCliModule {
     "site-url"?: string
   }): Promise<PlaygroundCliServer>
 }
+
+const PLAYGROUND_WORDPRESS_CACHE_DIRECTORY_ENV = "WP_CODEBOX_PLAYGROUND_WORDPRESS_CACHE_DIR"
 
 export interface PlaygroundCliStartupOptions {
   onProgress?: (event: BrowserStartupProgressEvent) => void | Promise<void>
@@ -176,6 +178,12 @@ export interface PlaygroundWordPressArchiveCacheValidation {
   version: string
   sourceUrl: string
   source: "pre-resolved" | "cache" | "inferred" | "api"
+  cache?: {
+    status: "hit" | "downloaded"
+    archivePath: string
+    lockPath: string
+    waitedMs: number
+  }
   invalidArchives: Array<{
     path: string
     size: number
@@ -188,7 +196,7 @@ export interface PlaygroundWordPressArchiveCacheValidationOptions {
   deleteInvalid?: boolean
 }
 
-export async function validatePlaygroundWordPressArchiveCache(versionQuery: string | undefined, cacheDirectory = join(homedir(), ".wordpress-playground"), options: PlaygroundWordPressArchiveCacheValidationOptions = { deleteInvalid: true }): Promise<PlaygroundWordPressArchiveCacheValidation> {
+export async function validatePlaygroundWordPressArchiveCache(versionQuery: string | undefined, cacheDirectory = defaultPlaygroundWordPressArchiveCacheDirectory(), options: PlaygroundWordPressArchiveCacheValidationOptions = { deleteInvalid: true }): Promise<PlaygroundWordPressArchiveCacheValidation> {
   const release = await resolveWordPressReleaseForStartup(versionQuery)
   const version = release.version
   const sourceUrl = release.releaseUrl
@@ -238,26 +246,108 @@ interface ResolvedWordPressReleaseForStartup {
   source: PlaygroundWordPressArchiveCacheValidation["source"]
 }
 
-export async function resolvePlaygroundWordPressStartupAsset(versionQuery: string | undefined, wordpressZip?: string, cacheDirectory = join(homedir(), ".wordpress-playground")): Promise<PlaygroundWordPressStartupAsset> {
+export async function resolvePlaygroundWordPressStartupAsset(versionQuery: string | undefined, wordpressZip?: string, cacheDirectory = defaultPlaygroundWordPressArchiveCacheDirectory()): Promise<PlaygroundWordPressStartupAsset> {
   if (wordpressZip) {
     const version = startupAssetVersion(versionQuery, wordpressZip)
     const cacheValidation = await validateWordPressArchivePaths(version, wordpressZip, isHttpUrl(wordpressZip) ? [] : [wordpressZip], { deleteInvalid: false })
     return { wp: isHttpUrl(wordpressZip) ? wordpressZip : undefined, localPath: isHttpUrl(wordpressZip) ? undefined : wordpressZip, cacheValidation: { ...cacheValidation, sourceUrl: wordpressZip, source: "pre-resolved" } }
   }
 
-  const cachedVersion = exactWordPressVersion(versionQuery)
-  if (cachedVersion) {
-    const cachedArchivePath = join(cacheDirectory, `${cachedVersion}.zip`)
+  const release = await resolveWordPressReleaseForStartup(versionQuery)
+  return await withPlaygroundArchiveCacheLock(cacheDirectory, release.version, async (lock) => {
+    const cachedArchivePath = join(cacheDirectory, `${release.version}.zip`)
+    const archivePaths = [cachedArchivePath, join(cacheDirectory, `prebuilt-wp-content-for-wp-${release.version}.zip`)]
+    const cacheValidation = await validateWordPressArchivePaths(release.version, release.releaseUrl, archivePaths, { deleteInvalid: true })
     if (existsSync(cachedArchivePath)) {
-      const cacheValidation = await validateWordPressArchivePaths(cachedVersion, `cache:${cachedArchivePath}`, [cachedArchivePath, join(cacheDirectory, `prebuilt-wp-content-for-wp-${cachedVersion}.zip`)], { deleteInvalid: true })
-      if (existsSync(cachedArchivePath)) {
-        return { wp: undefined, localPath: cachedArchivePath, cacheValidation: { ...cacheValidation, source: "cache" } }
+      return {
+        wp: undefined,
+        localPath: cachedArchivePath,
+        cacheValidation: {
+          ...cacheValidation,
+          source: "cache",
+          cache: { status: "hit", archivePath: cachedArchivePath, lockPath: lock.path, waitedMs: lock.waitedMs },
+        },
       }
+    }
+
+    await downloadWordPressArchiveToCache(release.releaseUrl, cachedArchivePath)
+    const downloadedValidation = await validateWordPressArchivePaths(release.version, release.releaseUrl, [cachedArchivePath], { deleteInvalid: false })
+    const invalidDownloadedArchive = downloadedValidation.invalidArchives[0]
+    if (invalidDownloadedArchive) {
+      throw new PlaygroundStartupAssetError("wordpress-archive-cache", release.releaseUrl, versionQuery ?? "latest", new Error(`Downloaded WordPress archive is invalid: ${invalidDownloadedArchive.reason}`))
+    }
+
+    return {
+      wp: undefined,
+      localPath: cachedArchivePath,
+      cacheValidation: {
+        ...downloadedValidation,
+        invalidArchives: [...cacheValidation.invalidArchives, ...downloadedValidation.invalidArchives],
+        source: release.source,
+        cache: { status: "downloaded", archivePath: cachedArchivePath, lockPath: lock.path, waitedMs: lock.waitedMs },
+      },
+    }
+  })
+}
+
+function defaultPlaygroundWordPressArchiveCacheDirectory(): string {
+  return process.env[PLAYGROUND_WORDPRESS_CACHE_DIRECTORY_ENV] || join(homedir(), ".wordpress-playground")
+}
+
+interface PlaygroundArchiveCacheLock {
+  path: string
+  waitedMs: number
+}
+
+async function withPlaygroundArchiveCacheLock<T>(cacheDirectory: string, version: string, callback: (lock: PlaygroundArchiveCacheLock) => Promise<T>): Promise<T> {
+  await mkdir(cacheDirectory, { recursive: true })
+  const lockPath = join(cacheDirectory, `${version}.zip.lock`)
+  const startedAt = Date.now()
+
+  for (;;) {
+    try {
+      await mkdir(lockPath)
+      break
+    } catch (error) {
+      if (!errorHasCode(error, "EEXIST")) {
+        throw error
+      }
+      if (Date.now() - startedAt > 120_000) {
+        throw new PlaygroundStartupAssetError("wordpress-archive-cache-lock", lockPath, version, new Error("Timed out waiting for WordPress archive cache lock"))
+      }
+      await delay(100)
     }
   }
 
-  const cacheValidation = await validatePlaygroundWordPressArchiveCache(versionQuery, cacheDirectory)
-  return { wp: cacheValidation.sourceUrl, cacheValidation }
+  try {
+    return await callback({ path: lockPath, waitedMs: Date.now() - startedAt })
+  } finally {
+    await rm(lockPath, { recursive: true, force: true })
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, ms))
+}
+
+async function downloadWordPressArchiveToCache(sourceUrl: string, archivePath: string): Promise<void> {
+  const tempPath = `${archivePath}.${process.pid}.${Date.now()}.partial`
+  try {
+    const response = await fetch(sourceUrl)
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`.trim())
+    }
+    const archive = new Uint8Array(await response.arrayBuffer())
+    const reason = await invalidZipBufferReason(archive)
+    if (reason) {
+      throw new Error(`Downloaded WordPress archive is invalid: ${reason}`)
+    }
+    await writeFile(tempPath, archive, { flag: "wx" })
+    await rename(tempPath, archivePath)
+  } catch (error) {
+    await rm(tempPath, { force: true })
+    throw new PlaygroundStartupAssetError("wordpress-archive-cache", sourceUrl, basename(archivePath, ".zip"), error)
+  }
 }
 
 async function resolveWordPressReleaseForStartup(versionQuery: string | undefined): Promise<ResolvedWordPressReleaseForStartup> {
@@ -394,16 +484,28 @@ async function invalidZipReason(archivePath: string, size: number): Promise<stri
   }
 
   const header = await readFile(archivePath, { encoding: null, flag: "r" }).then((buffer) => buffer.subarray(0, 4))
+  return invalidZipHeaderReason(header)
+}
+
+async function invalidZipBufferReason(buffer: Uint8Array): Promise<string | undefined> {
+  if (buffer.byteLength < 22) {
+    return "too small to be a zip archive"
+  }
+
+  return invalidZipHeaderReason(buffer.subarray(0, 4))
+}
+
+function invalidZipHeaderReason(header: Uint8Array): string | undefined {
   if (header.length < 4) {
     return "missing zip header"
   }
 
   if (header[0] !== 0x50 || header[1] !== 0x4b) {
-    return `unexpected zip header ${header.toString("hex")}`
+    return `unexpected zip header ${Buffer.from(header).toString("hex")}`
   }
 
   if (![0x03, 0x05, 0x07].includes(header[2])) {
-    return `unexpected zip header ${header.toString("hex")}`
+    return `unexpected zip header ${Buffer.from(header).toString("hex")}`
   }
 
   return undefined

--- a/scripts/playground-archive-cache-validation-smoke.ts
+++ b/scripts/playground-archive-cache-validation-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { existsSync } from "node:fs"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { resolvePlaygroundWordPressStartupAsset, validatePlaygroundWordPressArchiveCache } from "../packages/runtime-playground/src/playground-cli-runner.js"
@@ -27,17 +27,49 @@ try {
   assert.equal(cachedStartupAsset.wp, undefined)
   assert.equal(cachedStartupAsset.localPath, join(cacheDirectory, "7.2.zip"))
   assert.equal(cachedStartupAsset.cacheValidation.source, "cache")
-  assert.equal(cachedStartupAsset.cacheValidation.sourceUrl, `cache:${join(cacheDirectory, "7.2.zip")}`)
-
-  const inferredStartupAsset = await resolvePlaygroundWordPressStartupAsset("7.3", undefined, cacheDirectory)
-  assert.equal(inferredStartupAsset.wp, "https://wordpress.org/wordpress-7.3.zip")
-  assert.equal(inferredStartupAsset.cacheValidation.source, "inferred")
-  assert.equal(inferredStartupAsset.cacheValidation.sourceUrl, "https://wordpress.org/wordpress-7.3.zip")
+  assert.equal(cachedStartupAsset.cacheValidation.sourceUrl, "https://wordpress.org/wordpress-7.2.zip")
+  assert.equal(cachedStartupAsset.cacheValidation.cache?.archivePath, join(cacheDirectory, "7.2.zip"))
+  assert.equal(cachedStartupAsset.cacheValidation.cache?.status, "hit")
 
   const preResolvedStartupAsset = await resolvePlaygroundWordPressStartupAsset("7.4", join(cacheDirectory, "7.2.zip"), cacheDirectory)
   assert.equal(preResolvedStartupAsset.wp, undefined)
   assert.equal(preResolvedStartupAsset.localPath, join(cacheDirectory, "7.2.zip"))
   assert.equal(preResolvedStartupAsset.cacheValidation.source, "pre-resolved")
+
+  const originalFetch = globalThis.fetch
+  let downloads = 0
+  globalThis.fetch = async () => {
+    downloads++
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100))
+    return new Response(minimalZipArchive(), { status: 200, headers: { "content-type": "application/zip" } })
+  }
+  try {
+    const inferredStartupAsset = await resolvePlaygroundWordPressStartupAsset("7.3", undefined, cacheDirectory)
+    assert.equal(inferredStartupAsset.wp, undefined)
+    assert.equal(inferredStartupAsset.localPath, join(cacheDirectory, "7.3.zip"))
+    assert.equal(inferredStartupAsset.cacheValidation.source, "inferred")
+    assert.equal(inferredStartupAsset.cacheValidation.sourceUrl, "https://wordpress.org/wordpress-7.3.zip")
+    assert.equal(inferredStartupAsset.cacheValidation.cache?.status, "downloaded")
+
+    await writeFile(join(cacheDirectory, "7.5.zip"), "corrupt archive")
+    const [firstConcurrentAsset, secondConcurrentAsset] = await Promise.all([
+      resolvePlaygroundWordPressStartupAsset("7.5", undefined, cacheDirectory),
+      resolvePlaygroundWordPressStartupAsset("7.5", undefined, cacheDirectory),
+    ])
+
+    assert.equal(downloads, 2, "one inferred warmup plus one concurrent cache warmup should download two archives")
+    assert.equal(firstConcurrentAsset.localPath, join(cacheDirectory, "7.5.zip"))
+    assert.equal(secondConcurrentAsset.localPath, join(cacheDirectory, "7.5.zip"))
+    assert.deepEqual(await readFile(join(cacheDirectory, "7.5.zip")), Buffer.from(minimalZipArchive()))
+    const statuses = [firstConcurrentAsset, secondConcurrentAsset].map((asset) => asset.cacheValidation.cache?.status).sort()
+    assert.deepEqual(statuses, ["downloaded", "hit"])
+    assert.ok([firstConcurrentAsset, secondConcurrentAsset].every((asset) => (asset.cacheValidation.cache?.waitedMs ?? 0) >= 0))
+    const invalidArchives = [firstConcurrentAsset, secondConcurrentAsset].flatMap((asset) => asset.cacheValidation.invalidArchives)
+    assert.equal(invalidArchives.length, 1)
+    assert.equal(invalidArchives[0]?.deleted, true)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 
   console.log("Playground archive cache validation smoke passed")
 } finally {

--- a/scripts/recipe-run-concurrent-playground-cache-smoke.ts
+++ b/scripts/recipe-run-concurrent-playground-cache-smoke.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-recipe-cache-concurrency-"))
+const cacheDirectory = join(workspace, "playground-cache")
+
+try {
+  await writeFile(join(workspace, "recipe.json"), `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: "7.0" },
+    workflow: {
+      steps: [{ command: "wordpress.run-php", args: ["code=<?php echo 'cache-safe';"] }],
+    },
+  }, null, 2)}\n`)
+
+  await mkdir(cacheDirectory, { recursive: true })
+  await writeFile(join(cacheDirectory, "7.0.zip"), "not a complete zip")
+
+  const [first, second] = await Promise.all([
+    runRecipe(join(workspace, "recipe.json"), cacheDirectory),
+    runRecipe(join(workspace, "recipe.json"), cacheDirectory),
+  ])
+
+  assert.equal(first.exit.code, 0, `first recipe-run failed; stdout: ${first.stdout}; stderr: ${first.stderr}`)
+  assert.equal(second.exit.code, 0, `second recipe-run failed; stdout: ${second.stdout}; stderr: ${second.stderr}`)
+
+  const firstOutput = JSON.parse(first.stdout)
+  const secondOutput = JSON.parse(second.stdout)
+  assert.equal(firstOutput.success, true)
+  assert.equal(secondOutput.success, true)
+  assert.equal(firstOutput.schema, "wp-codebox/recipe-run/v1")
+  assert.equal(secondOutput.schema, "wp-codebox/recipe-run/v1")
+  assert.equal(firstOutput.executions[0]?.stdout, "cache-safe")
+  assert.equal(secondOutput.executions[0]?.stdout, "cache-safe")
+  assert.equal(existsSync(join(cacheDirectory, "7.0.zip")), true, "successful concurrent runs should leave a reusable archive")
+
+  console.log("Recipe concurrent Playground cache smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function runRecipe(recipePath: string, cacheDirectory: string): Promise<{ exit: { code: number | null; signal: NodeJS.Signals | null }; stdout: string; stderr: string }> {
+  const child = spawn(process.execPath, [
+    "packages/cli/dist/index.js",
+    "recipe-run",
+    "--recipe",
+    recipePath,
+    "--json",
+  ], {
+    cwd: root,
+    env: { ...process.env, WP_CODEBOX_PLAYGROUND_WORDPRESS_CACHE_DIR: cacheDirectory },
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const timeout = setTimeout(() => {
+    child.kill("SIGKILL")
+  }, 120_000)
+  const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit) => {
+    child.once("close", (code, signal) => resolveExit({ code, signal }))
+  })
+  clearTimeout(timeout)
+
+  assert.notEqual(exit.signal, "SIGKILL", `recipe-run hung; stdout: ${stdout}; stderr: ${stderr}`)
+  return { exit, stdout, stderr }
+}

--- a/scripts/recipe-run-concurrent-playground-cache-smoke.ts
+++ b/scripts/recipe-run-concurrent-playground-cache-smoke.ts
@@ -46,6 +46,8 @@ try {
 
 async function runRecipe(recipePath: string, cacheDirectory: string): Promise<{ exit: { code: number | null; signal: NodeJS.Signals | null }; stdout: string; stderr: string }> {
   const child = spawn(process.execPath, [
+    "--experimental-wasm-jspi",
+    "--experimental-wasm-stack-switching",
     "packages/cli/dist/index.js",
     "recipe-run",
     "--recipe",


### PR DESCRIPTION
## Summary
- Warms WordPress Playground archives inside WP Codebox under a host-wide per-version cache lock before starting the Playground CLI.
- Passes Playground a local archive URL after warmup so concurrent recipe runs do not race over shared `.partial` archive writes.
- Preserves structured startup/cache diagnostics, including cache hit/download metadata and corrupt archive cleanup evidence.

Fixes #564.

## Testing
- `npm run build`
- `npm run playground-archive-cache-validation-smoke`
- `npm run recipe-run-concurrent-playground-cache-smoke`
- `npm run recipe-playground-boot-failure-smoke`
- `npm run browser-startup-progress-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and tested the archive cache locking implementation, focused smoke coverage, and PR description; Chris remains responsible for review and acceptance.