### PR TITLE
fix: escape sandbox permission helper reference

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -248,7 +248,7 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
         return $ability->execute($runtime_task_run ? $runtime_task_input : json_decode($agent_input, true));
     };
     $agent_result = class_exists('DataMachine\\Abilities\\PermissionHelper')
-        ? DataMachine\Abilities\PermissionHelper::run_as_authenticated($agent_execute_callback, 1)
+        ? DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($agent_execute_callback, 1)
         : $agent_execute_callback();
     if (is_wp_error($agent_result)) {
         $sandbox_agent_runtime = array(

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -67,6 +67,8 @@ async function main() {
   assert.match(code, /\\"workspace_read\\"/, "sandbox agent should allow workspace read tool")
   assert.match(code, /agents_chat_runtime_principal_permission/, "sandbox chat should authorize through Agents API runtime-principal permission")
   assert.match(code, /PermissionHelper::run_as_authenticated/, "sandbox chat should execute runtime abilities in an authenticated Data Machine context")
+  assert.match(code, /DataMachine\\Abilities\\PermissionHelper::run_as_authenticated/, "sandbox chat should emit a valid namespaced PermissionHelper class reference")
+  assert.doesNotMatch(code, /DataMachineAbilitiesPermissionHelper/, "sandbox chat should not collapse namespaced PermissionHelper references")
   assert.doesNotMatch(code, /datamachine_agent_mode_sandbox/, "sandbox chat should not depend on Data Machine agent mode filters")
   assert.doesNotMatch(code, /WP_Codebox_Sandbox_Perception_Directive/, "sandbox chat should not register Data Machine directives")
   assert.match(code, /sandbox_workspace/, "sandbox request should include mounted workspace context")


### PR DESCRIPTION
## Summary
- Escape the generated PHP namespace separator for the Data Machine PermissionHelper class reference.
- Add smoke coverage so the sandbox generated code keeps the namespaced class reference and does not collapse it to `DataMachineAbilitiesPermissionHelper`.

## Verification
- `npm run agent-sandbox-code-smoke`
- `npm run build`
- `git diff --check`

## Evidence
- Follow-up to failed site-generation proof run: https://github.com/chubes4/wp-site-generator/actions/runs/26976447576
- Failure showed `Class \"DataMachineAbilitiesPermissionHelper\" not found` from the WP Codebox-generated PHP bridge.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the proof-run artifact failure, drafted the minimal escaping fix, added smoke assertions, and ran local verification. Chris remains responsible for review and merge.