### PR TITLE
fix: use authenticated sandbox context

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -136,7 +136,7 @@ if (function_exists('wp_get_ability')) {
         }
     };
     if (class_exists('DataMachine\\Abilities\\PermissionHelper')) {
-        DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($sandbox_adopt_callback, 1);
+        DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($sandbox_adopt_callback);
     } else {
         $sandbox_adopt_callback();
     }
@@ -248,7 +248,7 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
         return $ability->execute($runtime_task_run ? $runtime_task_input : json_decode($agent_input, true));
     };
     $agent_result = class_exists('DataMachine\\Abilities\\PermissionHelper')
-        ? DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($agent_execute_callback, 1)
+        ? DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($agent_execute_callback)
         : $agent_execute_callback();
     if (is_wp_error($agent_result)) {
         $sandbox_agent_runtime = array(

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -68,6 +68,7 @@ async function main() {
   assert.match(code, /agents_chat_runtime_principal_permission/, "sandbox chat should authorize through Agents API runtime-principal permission")
   assert.match(code, /PermissionHelper::run_as_authenticated/, "sandbox chat should execute runtime abilities in an authenticated Data Machine context")
   assert.match(code, /DataMachine\\Abilities\\PermissionHelper::run_as_authenticated/, "sandbox chat should emit a valid namespaced PermissionHelper class reference")
+  assert.doesNotMatch(code, /PermissionHelper::run_as_authenticated\([^\)]*,\s*1\)/, "sandbox chat should not force a user-specific Data Machine capability check")
   assert.doesNotMatch(code, /DataMachineAbilitiesPermissionHelper/, "sandbox chat should not collapse namespaced PermissionHelper references")
   assert.doesNotMatch(code, /datamachine_agent_mode_sandbox/, "sandbox chat should not depend on Data Machine agent mode filters")
   assert.doesNotMatch(code, /WP_Codebox_Sandbox_Perception_Directive/, "sandbox chat should not register Data Machine directives")


### PR DESCRIPTION
## Summary
- Run sandbox Data Machine ability calls in a pre-authenticated runtime context without forcing user `1` through Data Machine capability checks.
- Keep the current WordPress user available for runtime ownership while allowing the permission helper to authorize the bridge as intended.
- Add smoke coverage so generated sandbox code does not pass `1` into `PermissionHelper::run_as_authenticated()`.

## Verification
- `npm run agent-sandbox-code-smoke`
- `npm run build`
- `git diff --check`

## Evidence
- Follow-up to failed site-generation proof run: https://github.com/chubes4/wp-site-generator/actions/runs/26977303238
- Runtime signals showed `data_machine_permission_helper: true`, but `agents/chat` still returned `ability_invalid_permissions` because the bridge forced a user-specific Data Machine capability check.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the latest proof-run artifacts, identified the permission-helper acting-user issue, drafted the minimal bridge fix, added smoke assertions, and ran local verification. Chris remains responsible for review and merge.