### PR TITLE
fix: escape sandbox principal class reference

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -151,7 +151,7 @@ $sandbox_runtime_task = json_decode(${JSON.stringify(JSON.stringify(runtimeTask)
 $sandbox_stack['runtime_task'] = is_array($sandbox_runtime_task) ? $sandbox_runtime_task : null;
 
 add_filter('agents_chat_runtime_principal_permission', static function (bool $allowed, $principal, array $input): bool {
-    if (!$principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal) {
+    if (!$principal instanceof AgentsAPI\\AI\\WP_Agent_Execution_Principal) {
         return $allowed;
     }
     if ('runtime' !== $principal->auth_source || 'runtime' !== $principal->request_context) {

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -66,6 +66,8 @@ async function main() {
   assert.match(code, /\\"mode\\":\\"allow\\"/, "sandbox agent should use allow-mode tool policy")
   assert.match(code, /\\"workspace_read\\"/, "sandbox agent should allow workspace read tool")
   assert.match(code, /agents_chat_runtime_principal_permission/, "sandbox chat should authorize through Agents API runtime-principal permission")
+  assert.match(code, /AgentsAPI\\AI\\WP_Agent_Execution_Principal/, "sandbox chat should emit a valid namespaced runtime principal class reference")
+  assert.doesNotMatch(code, /AgentsAPIAIWP_Agent_Execution_Principal/, "sandbox chat should not collapse namespaced runtime principal references")
   assert.match(code, /PermissionHelper::run_as_authenticated/, "sandbox chat should execute runtime abilities in an authenticated Data Machine context")
   assert.match(code, /DataMachine\\Abilities\\PermissionHelper::run_as_authenticated/, "sandbox chat should emit a valid namespaced PermissionHelper class reference")
   assert.doesNotMatch(code, /PermissionHelper::run_as_authenticated\([^\)]*,\s*1\)/, "sandbox chat should not force a user-specific Data Machine capability check")


### PR DESCRIPTION
## Summary
- Escape the generated PHP namespace separator for `AgentsAPI\\AI\\WP_Agent_Execution_Principal` in the sandbox runtime-principal permission filter.
- Add smoke coverage so the generated bridge keeps the namespaced class reference and does not collapse it to `AgentsAPIAIWP_Agent_Execution_Principal`.

## Verification
- `npm run agent-sandbox-code-smoke`
- `npm run build`
- `git diff --check`

## Evidence
- Follow-up to failed site-generation proof run: https://github.com/chubes4/wp-site-generator/actions/runs/26977868273
- Runtime had the Agents API `agents_chat_runtime_principal_permission` seam, but the WP Codebox-generated `instanceof` reference was emitted from a JS template with unescaped namespace separators, so the scoped runtime-principal authorization did not match.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the latest proof-run artifacts, verified Agents API already had the runtime-principal permission seam, identified the generated PHP escaping issue, drafted the minimal fix, added smoke assertions, and ran local verification. Chris remains responsible for review and merge.