### PR TITLE
Sync package lock version for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -3814,7 +3814,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -3825,11 +3825,11 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.4.0"
+      "version": "0.5.0"
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@wp-playground/cli": "^3.1.35",


### PR DESCRIPTION
## Summary
- Sync package-lock workspace package versions to the current 0.5.0 package metadata.
- Keeps npm install from dirtying a fresh checkout before the next Homeboy release.

## Testing
- npm install
- npm run build (via npm prepare)
- homeboy release wp-codebox --dry-run --path /Users/chubes/Developer/wp-codebox@release-wp-codebox-20260604 (confirmed the previous blocker was the dirty package-lock.json)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the release dry-run blocker and prepared the lockfile sync PR. Chris remains responsible for review and merge.