### PR TITLE
Expose artifact apply preflight helpers

### DIFF
--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -1,5 +1,5 @@
 import { routeCliCommand } from "./command-router.js"
-import { runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
+import { runArtifactsApplyPreflightCommand, runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
 import { runAgentTaskRunCommand } from "./commands/agent-task-run.js"
 import { runArtifactsBenchCompareCommand, runArtifactsBenchResultsCommand, runBenchCompareCommand, runBenchMatrixCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
 import { runCommandsCommand, runRecipeSchemaCommand } from "./commands/discovery.js"
@@ -22,6 +22,7 @@ export async function runCli(args: string[]): Promise<number> {
     recipeBuild: runRecipeBuildCommand,
     workspacePolicyCheck: runWorkspacePolicyCheckCommand,
     artifactsVerify: runArtifactsVerifyCommand,
+    artifactsApplyPreflight: runArtifactsApplyPreflightCommand,
     artifactsBrowserMetrics: runArtifactsBrowserMetricsCommand,
     artifactsBenchmark: runArtifactsBenchmarkCommand,
     artifactsBenchResults: runArtifactsBenchResultsCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -12,6 +12,7 @@ interface CliCommandRouter {
   agentTaskRun: CliCommandHandler
   workspacePolicyCheck: CliCommandHandler
   artifactsVerify: CliCommandHandler
+  artifactsApplyPreflight: CliCommandHandler
   artifactsBrowserMetrics: CliCommandHandler
   artifactsBenchmark: CliCommandHandler
   artifactsBenchResults: CliCommandHandler
@@ -78,6 +79,9 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
       const subcommand = args.shift()
       if (subcommand === "verify") {
         return router.artifactsVerify(args)
+      }
+      if (subcommand === "apply-preflight") {
+        return router.artifactsApplyPreflight(args)
       }
       if (subcommand === "browser-metrics") {
         return router.artifactsBrowserMetrics(args)

--- a/packages/cli/src/commands/artifacts.ts
+++ b/packages/cli/src/commands/artifacts.ts
@@ -1,12 +1,16 @@
 import { copyFile, mkdir, readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core"
+import { preflightArtifactBundleApply, verifyArtifactBundle, type ArtifactBundleApplyPreflightResult, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core"
 import { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "@automattic/wp-codebox-playground"
 import { printArtifactVerifyHumanOutput } from "../output.js"
 
 interface ArtifactVerifyOptions {
   bundleDirectory: string
   json: boolean
+}
+
+interface ArtifactApplyPreflightOptions extends ArtifactVerifyOptions {
+  approvedFiles: string[]
 }
 
 interface BenchmarkArtifactsOptions extends ArtifactVerifyOptions {
@@ -51,6 +55,18 @@ export async function runArtifactsVerifyCommand(args: string[]): Promise<number>
   return output.valid ? 0 : 1
 }
 
+export async function runArtifactsApplyPreflightCommand(args: string[]): Promise<number> {
+  const options = parseArtifactApplyPreflightOptions(args)
+  const output = await applyPreflight(options)
+  if (!options.json) {
+    printArtifactApplyPreflightHumanOutput(output)
+    return output.ready ? 0 : 1
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return output.ready ? 0 : 1
+}
+
 export async function runArtifactsBrowserMetricsCommand(args: string[]): Promise<number> {
   const options = parseArtifactBrowserMetricsOptions(args)
   const output = await browserMetrics(options)
@@ -79,6 +95,10 @@ async function verifyArtifacts(options: ArtifactVerifyOptions): Promise<Artifact
   return verifyArtifactBundle(resolve(options.bundleDirectory))
 }
 
+async function applyPreflight(options: ArtifactApplyPreflightOptions): Promise<ArtifactBundleApplyPreflightResult> {
+  return preflightArtifactBundleApply(resolve(options.bundleDirectory), { approvedFiles: options.approvedFiles })
+}
+
 async function browserMetrics(options: ArtifactVerifyOptions): Promise<BrowserArtifactMetricsResult> {
   return browserArtifactMetrics(resolve(options.bundleDirectory))
 }
@@ -104,6 +124,47 @@ async function benchmarkArtifacts(options: BenchmarkArtifactsOptions): Promise<B
 
 function parseArtifactBrowserMetricsOptions(args: string[]): ArtifactVerifyOptions {
   return parseArtifactVerifyOptions(args)
+}
+
+function parseArtifactApplyPreflightOptions(args: string[]): ArtifactApplyPreflightOptions {
+  const options: Partial<ArtifactApplyPreflightOptions> = { json: false, approvedFiles: [] }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--bundle":
+      case "--artifacts":
+        options.bundleDirectory = value
+        break
+      case "--approved-file":
+        options.approvedFiles?.push(value)
+        break
+      case "--approved-files":
+        options.approvedFiles?.push(...value.split(","))
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (!options.bundleDirectory) {
+    throw new Error("Missing required option: --bundle")
+  }
+
+  return options as ArtifactApplyPreflightOptions
 }
 
 function parseBenchmarkArtifactsOptions(args: string[]): BenchmarkArtifactsOptions {
@@ -161,6 +222,20 @@ function printArtifactBrowserMetricsHumanOutput(output: BrowserArtifactMetricsRe
     for (const [name, artifact] of Object.entries(output.artifacts).sort(([left], [right]) => left.localeCompare(right))) {
       console.log(`  ${name}: ${artifact.path}`)
     }
+  }
+}
+
+function printArtifactApplyPreflightHumanOutput(output: ArtifactBundleApplyPreflightResult): void {
+  console.log("WP Codebox artifact apply preflight")
+  console.log(`Bundle: ${output.bundleDirectory}`)
+  console.log(`Ready: ${output.ready ? "yes" : "no"}`)
+  if (output.payload) {
+    console.log(`Artifact: ${output.payload.artifactId}`)
+    console.log(`Changed files: ${output.payload.changedFiles.files.length}`)
+    console.log(`Patch: ${output.payload.patch.path}`)
+  }
+  for (const violation of output.violations) {
+    console.log(`- ${violation.code} ${violation.path}: ${violation.message}`)
   }
 }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -256,6 +256,7 @@ export function printHelp(): void {
   wp-codebox bench summarize (--input <recipe-run.json>|--bundle <dir>) [--json]
   wp-codebox bench compare --baseline-input <recipe-run.json> --candidate-input <recipe-run.json> [--json]
   wp-codebox artifacts verify --bundle <dir> [--json]
+  wp-codebox artifacts apply-preflight --bundle <dir> --approved-file <path> [--json]
   wp-codebox artifacts browser-metrics --bundle <dir> [--json]
   wp-codebox artifacts benchmark --bundle <dir> [--scenario-id <id>] [--extract-to <dir>] [--json]
   wp-codebox artifacts bench-results --bundle <dir> [--json]
@@ -277,7 +278,11 @@ Options:
                     Keep preview runtimes alive after agent-task-run/recipe-run.
   --preview-public-url <url>
                     Public preview URL passed through to agent-task-run/recipe-run.
-  --bundle <dir>      Artifact bundle directory for artifacts verify.
+  --bundle <dir>      Artifact bundle directory for artifacts verify and apply-preflight.
+  --approved-file <path>
+                       Changed file approved for artifacts apply-preflight. Repeatable.
+  --approved-files <paths>
+                       Comma-separated changed files approved for artifacts apply-preflight.
   --scenario-id <id>  Filter benchmark artifact refs to one scenario.
   --extract-to <dir>  Copy listed benchmark artifact refs to a directory.
   --input <path>      Saved recipe-run JSON output for benchmark summarization.

--- a/packages/runtime-core/src/artifact-bundle-verifier.ts
+++ b/packages/runtime-core/src/artifact-bundle-verifier.ts
@@ -1,7 +1,7 @@
 import { lstat, readdir, readFile, realpath } from "node:fs/promises"
 import { isAbsolute, join, normalize, relative, sep } from "node:path"
 import { artifactFileDigest, calculateArtifactContentDigest, calculateArtifactManifestFileSha256 } from "./artifact-manifest.js"
-import type { ArtifactFileDigest, ArtifactManifest, ArtifactManifestFile } from "./artifact-manifest.js"
+import type { ArtifactContentDigest, ArtifactFileDigest, ArtifactManifest, ArtifactManifestFile } from "./artifact-manifest.js"
 import { isPlainObject as isRecord } from "./object-utils.js"
 import { RUNTIME_EPISODE_TRACE_SCHEMA, validateRuntimeEpisodeTrace } from "./runtime-episode.js"
 import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest } from "./runtime-reference.js"
@@ -38,6 +38,50 @@ export interface ArtifactBundleVerificationResult {
   valid: boolean
   violations: ArtifactBundleVerificationViolation[]
   manifest?: ArtifactManifest
+}
+
+export interface ArtifactBundleApplyChangedFile {
+  path: string
+  status?: string
+  mountIndex?: number
+  mountTarget?: string
+  relativePath?: string
+  patchPath?: string
+  [key: string]: unknown
+}
+
+export interface ArtifactBundleApplyPreflightOptions extends VerifyArtifactBundleOptions {
+  approvedFiles?: string[]
+}
+
+export interface ArtifactBundleApplyPreflightResult {
+  schema: "wp-codebox/artifact-bundle-apply-preflight/v1"
+  bundleDirectory: string
+  ready: boolean
+  verification: ArtifactBundleVerificationResult
+  violations: ArtifactBundleVerificationViolation[]
+  manifest?: ArtifactManifest
+  payload?: {
+    schema: "wp-codebox/artifact-bundle-apply-payload/v1"
+    artifactId: string
+    contentDigest: ArtifactContentDigest
+    patch: {
+      path: string
+      sha256: ArtifactFileDigest
+      body: string
+    }
+    changedFiles: {
+      path: string
+      files: ArtifactBundleApplyChangedFile[]
+    }
+    review?: {
+      path: string
+      artifactId?: string
+      summary?: string
+      riskFlags?: string[]
+    }
+    approvedFiles: string[]
+  }
 }
 
 export interface VerifyArtifactBundleOptions {
@@ -119,6 +163,133 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   await verifyRuntimeReplayReferenceIndexArtifacts(bundleDirectory, manifest, manifestFiles, violations)
 
   return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
+}
+
+export async function preflightArtifactBundleApply(directory: string, options: ArtifactBundleApplyPreflightOptions = {}): Promise<ArtifactBundleApplyPreflightResult> {
+  const bundleDirectory = normalize(directory)
+  const verification = await verifyArtifactBundle(bundleDirectory, options)
+  const violations = [...verification.violations]
+  if (!verification.valid || !verification.manifest) {
+    return artifactBundleApplyPreflightResult(bundleDirectory, verification, violations)
+  }
+
+  const manifestFiles = new Set(verification.manifest.files.map((file) => file.path))
+  const reviewPath = manifestFiles.has("files/review.json") ? "files/review.json" : undefined
+  const review = reviewPath ? await readOptionalJson(bundleDirectory, reviewPath, violations) : undefined
+  const evidence = isRecord(review) && isRecord(review.evidence) ? review.evidence : undefined
+  const patchPath = typeof evidence?.patch === "string" ? evidence.patch : findManifestFileByKind(verification.manifest, "patch")?.path
+  const changedFilesPath = typeof evidence?.changedFiles === "string" ? evidence.changedFiles : findManifestFileByKind(verification.manifest, "changed-files")?.path
+
+  if (!patchPath) {
+    violations.push({ code: "malformed-reference", path: "files/review.json:evidence.patch", file: "files/review.json", message: "Apply preflight requires review evidence or a manifest patch file." })
+  } else {
+    validateArtifactReference(patchPath, "apply.patch", manifestFiles, violations)
+  }
+
+  if (!changedFilesPath) {
+    violations.push({ code: "malformed-reference", path: "files/review.json:evidence.changedFiles", file: "files/review.json", message: "Apply preflight requires review evidence or a manifest changed-files file." })
+  } else {
+    validateArtifactReference(changedFilesPath, "apply.changedFiles", manifestFiles, violations)
+  }
+
+  if (violations.length > 0 || !patchPath || !changedFilesPath) {
+    return artifactBundleApplyPreflightResult(bundleDirectory, verification, violations)
+  }
+
+  const [patchBody, changedFiles] = await Promise.all([
+    readFile(join(bundleDirectory, patchPath), "utf8").catch((error) => {
+      violations.push({ code: "missing-file", path: "apply.patch", file: patchPath, message: `Unable to read patch artifact: ${errorMessage(error)}` })
+      return undefined
+    }),
+    readChangedFiles(bundleDirectory, changedFilesPath, violations),
+  ])
+
+  if (patchBody === undefined || !changedFiles) {
+    return artifactBundleApplyPreflightResult(bundleDirectory, verification, violations)
+  }
+
+  const approvedFiles = normalizeApprovedFiles(options.approvedFiles ?? [])
+  const approvedFileSet = new Set(approvedFiles)
+  const missingApprovedFiles = changedFiles.files.map((file) => file.path).filter((path) => !approvedFileSet.has(path))
+  for (const file of missingApprovedFiles) {
+    violations.push({ code: "malformed-reference", path: "approvedFiles", file, message: `Changed file is not covered by approvedFiles: ${file}` })
+  }
+
+  if (violations.length > 0) {
+    return artifactBundleApplyPreflightResult(bundleDirectory, verification, violations)
+  }
+
+  return artifactBundleApplyPreflightResult(bundleDirectory, verification, violations, {
+    schema: "wp-codebox/artifact-bundle-apply-payload/v1",
+    artifactId: verification.manifest.id,
+    contentDigest: verification.manifest.contentDigest,
+    patch: {
+      path: patchPath,
+      sha256: artifactFileDigest(patchBody),
+      body: patchBody,
+    },
+    changedFiles: {
+      path: changedFilesPath,
+      files: changedFiles.files,
+    },
+    ...(reviewPath ? {
+      review: {
+        path: reviewPath,
+        ...(isRecord(review) && typeof review.artifactId === "string" ? { artifactId: review.artifactId } : {}),
+        ...(isRecord(review) && typeof review.summary === "string" ? { summary: review.summary } : {}),
+        ...(isRecord(review) && Array.isArray(review.riskFlags) ? { riskFlags: review.riskFlags.filter((flag): flag is string => typeof flag === "string") } : {}),
+      },
+    } : {}),
+    approvedFiles,
+  })
+}
+
+function artifactBundleApplyPreflightResult(bundleDirectory: string, verification: ArtifactBundleVerificationResult, violations: ArtifactBundleVerificationViolation[], payload?: ArtifactBundleApplyPreflightResult["payload"]): ArtifactBundleApplyPreflightResult {
+  return {
+    schema: "wp-codebox/artifact-bundle-apply-preflight/v1",
+    bundleDirectory,
+    ready: violations.length === 0 && payload !== undefined,
+    verification,
+    violations,
+    ...(verification.manifest ? { manifest: verification.manifest } : {}),
+    ...(payload ? { payload } : {}),
+  }
+}
+
+async function readOptionalJson(directory: string, path: string, violations: ArtifactBundleVerificationViolation[]): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(join(directory, path), "utf8"))
+  } catch (error) {
+    violations.push({ code: "malformed-reference", path, file: path, message: `Unable to read artifact JSON: ${errorMessage(error)}` })
+    return undefined
+  }
+}
+
+async function readChangedFiles(directory: string, path: string, violations: ArtifactBundleVerificationViolation[]): Promise<{ files: ArtifactBundleApplyChangedFile[] } | undefined> {
+  const value = await readOptionalJson(directory, path, violations)
+  if (!isRecord(value) || !Array.isArray(value.files)) {
+    violations.push({ code: "malformed-reference", path, file: path, message: "Changed-files artifact must include a files array." })
+    return undefined
+  }
+
+  const files: ArtifactBundleApplyChangedFile[] = []
+  for (const [index, file] of value.files.entries()) {
+    if (!isRecord(file) || typeof file.path !== "string" || file.path.trim().length === 0) {
+      violations.push({ code: "malformed-reference", path: `${path}:files[${index}]`, file: path, message: "Changed-file entries must include a non-empty path." })
+      continue
+    }
+    files.push({ ...file, path: file.path })
+  }
+
+  return { files }
+}
+
+function findManifestFileByKind(manifest: ArtifactManifest, kind: string): ArtifactManifestFile | undefined {
+  return manifest.files.find((file) => file.kind === kind)
+}
+
+function normalizeApprovedFiles(paths: string[]): string[] {
+  return [...new Set(paths.map((path) => path.trim()).filter(Boolean))]
 }
 
 async function verifyBundleFileTopology(directory: string, path: string, fieldPath: string, violations: ArtifactBundleVerificationViolation[]): Promise<void> {

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -5,7 +5,7 @@ import { cp, link, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promis
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { calculateArtifactContentDigest, calculateArtifactManifestFileSha256, verifyArtifactBundle } from "@automattic/wp-codebox-core"
+import { calculateArtifactContentDigest, calculateArtifactManifestFileSha256, preflightArtifactBundleApply, verifyArtifactBundle } from "@automattic/wp-codebox-core"
 import type { ArtifactManifest } from "@automattic/wp-codebox-core"
 
 const execFileAsync = promisify(execFile)
@@ -20,8 +20,17 @@ try {
   assert.equal(valid.valid, true)
   assert.deepEqual(valid.violations, [])
 
+  const validPreflight = await preflightArtifactBundleApply(validBundle, { approvedFiles: ["/wordpress/wp-content/plugins/example/file.txt"] })
+  assert.equal(validPreflight.ready, true)
+  assert.equal(validPreflight.payload?.patch.path, "files/patch.diff")
+  assert.equal(validPreflight.payload?.changedFiles.files[0]?.path, "/wordpress/wp-content/plugins/example/file.txt")
+  assert.equal(validPreflight.payload?.patch.body.includes("+cooked"), true)
+
   const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "verify", "--bundle", validBundle, "--json"], { cwd: root })
   assert.equal(JSON.parse(stdout).valid, true)
+
+  const applyPreflightCli = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "apply-preflight", "--bundle", validBundle, "--approved-file", "/wordpress/wp-content/plugins/example/file.txt", "--json"], { cwd: root })
+  assert.equal(JSON.parse(applyPreflightCli.stdout).ready, true)
 
   const artifactsOption = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "verify", "--artifacts", validBundle, "--json"], { cwd: root })
   assert.equal(JSON.parse(artifactsOption.stdout).valid, true)
@@ -33,6 +42,7 @@ try {
   const missingFile = await copyBundle(validBundle, join(workspace, "missing-file"))
   await rm(join(missingFile, "files/patch.diff"))
   assertViolation(await verifyArtifactBundle(missingFile), "missing-file")
+  assertPreflightViolation(await preflightArtifactBundleApply(missingFile, { approvedFiles: ["/wordpress/wp-content/plugins/example/file.txt"] }), "missing-file")
 
   const traversalPath = await copyBundle(validBundle, join(workspace, "traversal-path"))
   const traversalManifest = manifestFixture(await calculateArtifactContentDigest(traversalPath, ["files/changed-files.json", "files/patch.diff"]))
@@ -43,6 +53,11 @@ try {
   const digestMismatch = await copyBundle(validBundle, join(workspace, "digest-mismatch"))
   await writeFile(join(digestMismatch, "files/patch.diff"), "diff --git a/file.txt b/file.txt\n+tampered\n")
   assertViolation(await verifyArtifactBundle(digestMismatch), "digest-mismatch")
+  assertPreflightViolation(await preflightArtifactBundleApply(digestMismatch, { approvedFiles: ["/wordpress/wp-content/plugins/example/file.txt"] }), "digest-mismatch")
+
+  const missingApprovedFile = await preflightArtifactBundleApply(validBundle, { approvedFiles: [] })
+  assertPreflightViolation(missingApprovedFile, "malformed-reference")
+  assert.equal(missingApprovedFile.violations.some((violation) => violation.path === "approvedFiles" && violation.file === "/wordpress/wp-content/plugins/example/file.txt"), true)
 
   const fileHashMismatch = await copyBundle(validBundle, join(workspace, "file-hash-mismatch"))
   await writeFile(join(fileHashMismatch, "files/test-results.json"), "{\"tampered\":true}\n")
@@ -234,5 +249,10 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 
 function assertViolation(result: Awaited<ReturnType<typeof verifyArtifactBundle>>, code: string): void {
   assert.equal(result.valid, false)
+  assert.ok(result.violations.some((violation) => violation.code === code), `Expected ${code}, got ${result.violations.map((violation) => violation.code).join(", ")}`)
+}
+
+function assertPreflightViolation(result: Awaited<ReturnType<typeof preflightArtifactBundleApply>>, code: string): void {
+  assert.equal(result.ready, false)
   assert.ok(result.violations.some((violation) => violation.code === code), `Expected ${code}, got ${result.violations.map((violation) => violation.code).join(", ")}`)
 }


### PR DESCRIPTION
## Summary
- Adds `preflightArtifactBundleApply()` in runtime core to verify artifact bundles, load canonical patch/changed-files/review artifacts, validate approved-file coverage, and return an apply-ready payload without mutating git or approval state.
- Adds `wp-codebox artifacts apply-preflight` for parent control planes that need the same normalized payload via CLI.
- Extends artifact bundle verifier smoke coverage for valid preflight, digest mismatch, missing patch, and missing approved file coverage.

## Tests
- `npm ci`
- `npm run build`
- `npm run artifact-bundle-verifier-smoke`
- `npm run runtime-snapshot-restore-smoke`
- `npm run recipe-heavyweight-plugin-runtime-smoke`
- Partial `npm run check` twice; first run hit transient `EADDRINUSE 127.0.0.1:61878` at `runtime-snapshot-restore-smoke`, which passed standalone afterward. Second run progressed through `recipe-heavyweight-plugin-runtime-smoke` before the 60-minute shell timeout; remaining `preview-options-contract-smoke` passed standalone, but `preview-port-smoke` did not complete before a separate 30-minute shell timeout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and verified the runtime-core apply preflight helper, CLI wiring, and smoke coverage; Chris remains responsible for review and merge.

Closes #479