### PR TITLE
Honor explicit sandbox code before chat generation

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -30,16 +30,16 @@ export interface AgentSandboxCodeOptions {
 }
 
 export async function resolveSandboxTaskCode(options: AgentSandboxCodeOptions): Promise<string> {
-  if (options.agent) {
-    return agentChatTaskCode(options)
-  }
-
   if (options.code) {
     return options.code
   }
 
   if (options.codeFile) {
     return readFile(resolve(options.codeFile), "utf8")
+  }
+
+  if (options.agent) {
+    return agentChatTaskCode(options)
   }
 
   return `echo json_encode(array('task_received' => true), JSON_PRETTY_PRINT);`

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -3,6 +3,20 @@ import { recipeExecutionSpec } from "../packages/cli/src/agent-sandbox.ts"
 import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.ts"
 
 async function main() {
+  const explicitInlineCode = await resolveSandboxTaskCode({
+    task: "Run explicit code",
+    agent: "sandbox-agent",
+    code: "echo 'explicit';",
+  })
+  assert.equal(explicitInlineCode, "echo 'explicit';", "explicit sandbox code should take precedence over generated agent chat code")
+
+  const explicitFileCode = await resolveSandboxTaskCode({
+    task: "Run explicit code file",
+    agent: "sandbox-agent",
+    codeFile: "scripts/agent-sandbox-code-smoke.ts",
+  })
+  assert.match(explicitFileCode, /resolveSandboxTaskCode/, "explicit sandbox code files should take precedence over generated agent chat code")
+
   const sandboxWorkspace = {
     schema: "wp-codebox/sandbox-workspace/v1" as const,
     root: "/workspace",


### PR DESCRIPTION
## Summary
- Honor explicit sandbox `code` and `codeFile` before generating an `agents/chat` task from an agent slug.
- Add smoke coverage for the Homeboy Data Machine bundle shape where an explicit wrapper file is supplied alongside the sandbox agent metadata.

## Verification
- `npm run agent-sandbox-code-smoke`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Site Generation Loop regression, drafted the focused precedence fix and smoke coverage, and ran local verification; Chris remains responsible for review and merge.