### PR TITLE
Sync package lock version after v0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -3814,7 +3814,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -3825,11 +3825,11 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.5.0"
+      "version": "0.5.2"
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@wp-playground/cli": "^3.1.35",


### PR DESCRIPTION
## Summary
- Sync package-lock workspace/package versions to the already-released 0.5.2 manifests.
- Keeps fresh installs from dirtying the worktree before the next release.

## Testing
- npm install

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the release-blocking lockfile drift and drafting this focused sync change.