### PR TITLE
Support recipe Playground backend package overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "playground-sqlite-alias-smoke": "tsx scripts/playground-sqlite-alias-smoke.ts",
     "php-wasm-preflight-smoke": "tsx scripts/php-wasm-preflight-smoke.ts",
     "recipe-playground-boot-failure-smoke": "tsx scripts/recipe-playground-boot-failure-smoke.ts",
+    "recipe-backend-package-smoke": "tsx scripts/recipe-backend-package-smoke.ts",
     "runtime-stack-mount-smoke": "tsx scripts/runtime-stack-mount-smoke.ts",
     "runtime-overlay-php-ai-client-smoke": "tsx scripts/runtime-overlay-php-ai-client-smoke.ts",
     "recipe-interruption-artifacts-smoke": "tsx scripts/recipe-interruption-artifacts-smoke.ts",

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -9,6 +9,7 @@ import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, 
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded, type RecipeDryRunOutput, type RecipeDryRunSiteSeed, type RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import { collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, type AgentSandboxResultSummary, type AgentTaskSingleResult, type SandboxCompletionOutcome } from "../recipe-evidence.js"
+import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { parseWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { DEFAULT_WORDPRESS_VERSION, previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
@@ -115,7 +116,7 @@ interface RecipePhaseEvidence {
 interface RecipePluginRuntimeDiagnostic {
   schema: "wp-codebox/plugin-runtime-diagnostic/v1"
   severity: "error"
-  phase: "setup" | "health-probe" | "runtime" | "overlay-preparation"
+  phase: "setup" | "health-probe" | "runtime" | "overlay-preparation" | "backend-preparation"
   name?: string
   command?: string
   exitCode?: number
@@ -555,6 +556,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let extraPlugins: PreparedExtraPlugin[] = []
   let stagedFiles: PreparedStagedFile[] = []
   let overlays: PreparedRuntimeOverlay[] = []
+  let backendPackage: PreparedRuntimeBackendPackage | undefined
   let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
   const executions: RecipeExecutionResult[] = []
   let artifacts: ArtifactBundle | undefined
@@ -571,6 +573,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     extraPlugins = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
     stagedFiles = await prepareRecipeStagedFiles(recipe, recipeDirectory)
     overlays = await prepareRecipeRuntimeOverlaysForRun(recipe, recipeDirectory)
+    backendPackage = await prepareRecipeRuntimeBackendPackage(recipe, recipeDirectory)
     interruption?.throwIfInterrupted()
 
     runRecord = await runRegistry.update(runRecord.runId, { status: "booting" })
@@ -590,7 +593,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       metadata: {
         ...runtimeMetadata(configuredArtifactsDirectory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
         run: { runId: runRecord.runId, registryDirectory: runRegistry.directory },
-        ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, stagedFiles, overlays, options.previewPublicUrl, options.previewPort, options.previewBind),
+        ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, stagedFiles, overlays, backendPackage, options.previewPublicUrl, options.previewPort, options.previewBind),
       },
       preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
     }
@@ -599,10 +602,11 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       runtime = await phaseTracker.run("runtime_startup", {
         operation: "runtime.create",
         backend: runtimeCreateSpec.backend,
+        ...(backendPackage ? { backendPackage: backendPackage.provenance } : {}),
         runtime: runtimeEnvironment,
       }, async () => await awaitRecipe("runtime.create", createRuntime(
         runtimeCreateSpec,
-        createPlaygroundRuntimeBackend(),
+        createPlaygroundRuntimeBackend({ cliModule: backendPackage?.cliModule }),
       )))
       startupDurationMs = Date.now() - startupStartedAtMs
     } catch (error) {
@@ -632,6 +636,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
           mode: overlay.mode,
           metadata: overlay.metadata,
         })),
+        ...(backendPackage ? { backendPackage: backendPackage.provenance } : {}),
       }, error)
     }
     if (!runtime) {
@@ -1549,11 +1554,11 @@ function recipeRuntimeDiagnostics(recipe: WorkspaceRecipe, executions: RecipeExe
     })
   }
 
-  if ((recipe.inputs?.pluginRuntime || recipe.runtime?.overlays || message.includes("plugin runtime") || message.includes("runtime overlay")) && diagnostics.length === 0) {
+  if ((recipe.inputs?.pluginRuntime || recipe.runtime?.overlays || recipe.runtime?.backendPackage || message.includes("plugin runtime") || message.includes("runtime overlay") || message.includes("backend package")) && diagnostics.length === 0) {
     diagnostics.push({
       schema: "wp-codebox/plugin-runtime-diagnostic/v1",
       severity: "error",
-      phase: message.includes("runtime overlay") ? "overlay-preparation" : message.includes("health probe") ? "health-probe" : message.includes("setup") ? "setup" : "runtime",
+      phase: message.includes("backend package") ? "backend-preparation" : message.includes("runtime overlay") ? "overlay-preparation" : message.includes("health probe") ? "health-probe" : message.includes("setup") ? "setup" : "runtime",
       message,
     })
   }
@@ -1621,7 +1626,7 @@ function recipeStepMetadata(step: WorkspaceRecipe["workflow"]["steps"][number]):
   return { command: step.command, args: step.args ?? [] }
 }
 
-function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[], overlays: PreparedRuntimeOverlay[], previewPublicUrl: string | undefined, previewPort: number | undefined, previewBind: string | undefined): Record<string, unknown> {
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[], overlays: PreparedRuntimeOverlay[], backendPackage: PreparedRuntimeBackendPackage | undefined, previewPublicUrl: string | undefined, previewPort: number | undefined, previewBind: string | undefined): Record<string, unknown> {
   const extraPluginMetadata = extraPlugins.map((plugin) => ({
     source: plugin.source,
     slug: plugin.slug,
@@ -1696,6 +1701,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       mode: overlay.mode,
       metadata: overlay.metadata,
     })),
+    ...(backendPackage ? { preparedRuntimeBackend: backendPackage.provenance } : {}),
   }
 }
 

--- a/packages/cli/src/recipe-backend-package.ts
+++ b/packages/cli/src/recipe-backend-package.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto"
+import { readFile, stat } from "node:fs/promises"
+import { basename, dirname, join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import type { WorkspaceRecipe, WorkspaceRecipeRuntimeBackendPackage } from "@automattic/wp-codebox-core"
+import type { PlaygroundCliModule } from "@automattic/wp-codebox-playground"
+
+export interface RuntimeBackendPackageProvenance {
+  schema: "wp-codebox/runtime-backend-package/v1"
+  kind: "playground"
+  source: string
+  resolvedSource: string
+  entrypoint: string
+  package?: {
+    name?: string
+    version?: string
+    digest?: { sha256: string }
+  }
+  entrypointDigest?: { sha256: string }
+  diagnostics: Array<{ status: "passed"; message: string }>
+  metadata?: Record<string, unknown>
+}
+
+export interface PreparedRuntimeBackendPackage {
+  cliModule: PlaygroundCliModule
+  provenance: RuntimeBackendPackageProvenance
+}
+
+export class RecipeRuntimeBackendPackageError extends Error {
+  readonly code = "recipe-runtime-backend-package-invalid"
+
+  constructor(message: string, readonly backendPackage: WorkspaceRecipeRuntimeBackendPackage, readonly diagnostics: Array<{ status: "failed"; message: string }>) {
+    super(message)
+    this.name = "RecipeRuntimeBackendPackageError"
+  }
+}
+
+export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedRuntimeBackendPackage | undefined> {
+  const backendPackage = recipe.runtime?.backendPackage
+  if (!backendPackage) {
+    return undefined
+  }
+
+  if (backendPackage.kind !== "playground") {
+    throw backendPackageError(backendPackage, `Unsupported runtime backend package kind: ${backendPackage.kind}`)
+  }
+
+  const resolvedSource = resolve(recipeDirectory, backendPackage.source)
+  const sourceStat = await statBackendSource(backendPackage, resolvedSource)
+  const packageRoot = sourceStat.isDirectory() ? resolvedSource : dirname(resolvedSource)
+  const manifest = sourceStat.isDirectory() ? await readPackageManifest(backendPackage, packageRoot) : undefined
+  if (backendPackage.package && manifest?.json.name !== backendPackage.package) {
+    throw backendPackageError(backendPackage, `Runtime backend package name mismatch: expected ${backendPackage.package}, found ${manifest?.json.name ?? "unknown"}`)
+  }
+
+  const entrypoint = sourceStat.isDirectory()
+    ? resolvePackageEntrypoint(backendPackage, packageRoot, manifest?.json)
+    : resolvedSource
+  const entrypointContents = await readBackendEntrypoint(backendPackage, entrypoint)
+  const module = await importBackendEntrypoint(backendPackage, entrypoint)
+  if (!isPlaygroundCliModule(module)) {
+    throw backendPackageError(backendPackage, `Runtime backend package entrypoint must export runCLI(): ${entrypoint}`)
+  }
+
+  return {
+    cliModule: module as PlaygroundCliModule,
+    provenance: {
+      schema: "wp-codebox/runtime-backend-package/v1",
+      kind: "playground",
+      source: backendPackage.source,
+      resolvedSource,
+      entrypoint,
+      ...(manifest ? { package: { name: stringField(manifest.json, "name"), version: stringField(manifest.json, "version"), digest: { sha256: sha256(manifest.raw) } } } : {}),
+      entrypointDigest: { sha256: sha256(entrypointContents) },
+      diagnostics: [
+        { status: "passed", message: "Source exists" },
+        { status: "passed", message: "Entrypoint resolved" },
+        { status: "passed", message: "Entrypoint exports runCLI" },
+      ],
+      ...(backendPackage.metadata ? { metadata: backendPackage.metadata } : {}),
+    },
+  }
+}
+
+async function statBackendSource(backendPackage: WorkspaceRecipeRuntimeBackendPackage, resolvedSource: string) {
+  try {
+    return await stat(resolvedSource)
+  } catch {
+    throw backendPackageError(backendPackage, `Runtime backend package source must exist: ${backendPackage.source}`)
+  }
+}
+
+async function readPackageManifest(backendPackage: WorkspaceRecipeRuntimeBackendPackage, packageRoot: string): Promise<{ raw: string; json: Record<string, unknown> }> {
+  const manifestPath = join(packageRoot, "package.json")
+  try {
+    const raw = await readFile(manifestPath, "utf8")
+    return { raw, json: JSON.parse(raw) as Record<string, unknown> }
+  } catch (error) {
+    const message = error instanceof SyntaxError ? `Runtime backend package package.json is invalid JSON: ${manifestPath}` : `Runtime backend package directory must contain package.json: ${manifestPath}`
+    throw backendPackageError(backendPackage, message)
+  }
+}
+
+function resolvePackageEntrypoint(backendPackage: WorkspaceRecipeRuntimeBackendPackage, packageRoot: string, manifest: Record<string, unknown> | undefined): string {
+  if (backendPackage.entrypoint) {
+    return resolve(packageRoot, backendPackage.entrypoint)
+  }
+
+  const candidates = [
+    exportEntrypoint(manifest?.exports),
+    stringField(manifest, "module"),
+    stringField(manifest, "main"),
+    "index.js",
+  ]
+
+  return resolve(packageRoot, candidates.find(Boolean) ?? "index.js")
+}
+
+function exportEntrypoint(exportsField: unknown): string | undefined {
+  if (typeof exportsField === "string") {
+    return exportsField
+  }
+  if (!exportsField || typeof exportsField !== "object") {
+    return undefined
+  }
+
+  const rootExport = "." in exportsField ? (exportsField as Record<string, unknown>)["."] : exportsField
+  if (typeof rootExport === "string") {
+    return rootExport
+  }
+  if (!rootExport || typeof rootExport !== "object") {
+    return undefined
+  }
+
+  return stringField(rootExport as Record<string, unknown>, "import")
+    ?? stringField(rootExport as Record<string, unknown>, "default")
+    ?? stringField(rootExport as Record<string, unknown>, "node")
+}
+
+async function readBackendEntrypoint(backendPackage: WorkspaceRecipeRuntimeBackendPackage, entrypoint: string): Promise<string> {
+  try {
+    return await readFile(entrypoint, "utf8")
+  } catch {
+    throw backendPackageError(backendPackage, `Runtime backend package entrypoint must exist: ${entrypoint}`)
+  }
+}
+
+async function importBackendEntrypoint(backendPackage: WorkspaceRecipeRuntimeBackendPackage, entrypoint: string): Promise<unknown> {
+  try {
+    return await import(pathToFileURL(entrypoint).href)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw backendPackageError(backendPackage, `Runtime backend package entrypoint could not be imported: ${basename(entrypoint)} (${message})`)
+  }
+}
+
+function isPlaygroundCliModule(value: unknown): value is PlaygroundCliModule {
+  return Boolean(value && typeof value === "object" && "runCLI" in value && typeof (value as { runCLI?: unknown }).runCLI === "function")
+}
+
+function backendPackageError(backendPackage: WorkspaceRecipeRuntimeBackendPackage, message: string): RecipeRuntimeBackendPackageError {
+  return new RecipeRuntimeBackendPackageError(message, backendPackage, [{ status: "failed", message }])
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key]
+  return typeof value === "string" ? value : undefined
+}
+
+function sha256(contents: string): string {
+  return createHash("sha256").update(contents).digest("hex")
+}

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -35,6 +35,13 @@ export interface RecipeDryRunOutput {
 export interface RecipeDryRunPlan {
   runtime: {
     backend: string
+    backendPackage?: {
+      kind: "playground"
+      source: string
+      package?: string
+      entrypoint?: string
+      metadata?: Record<string, unknown>
+    }
     name: string
     wp: string
     blueprint: unknown
@@ -286,6 +293,7 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
   return {
     runtime: {
       backend: recipe.runtime?.backend ?? "wordpress-playground",
+      ...(recipe.runtime?.backendPackage ? { backendPackage: recipe.runtime.backendPackage } : {}),
       name: recipe.runtime?.name ?? "wp-codebox-recipe",
       wp: recipe.runtime?.wp ?? context.defaultWordPressVersion,
       blueprint: recipeBlueprintWithBootActivePlugins(recipe.runtime?.blueprint, extraPlugins),

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,6 @@
 import { stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { ALLOW_NETWORK_DOWNLOADS_ENV, REQUIRE_SOURCE_SHA256_ENV, allowedDownloadHosts, isSha256, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile, sourceSha256Required } from "./recipe-sources.js"
 
 export interface RecipeValidationIssue {
@@ -49,6 +49,7 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   }
 
   validateRecipeMounts(recipe.runtime?.stack?.mounts, "runtime stack", recipePath)
+  validateRecipeRuntimeBackendPackage(recipe.runtime?.backendPackage, recipePath)
   validateRecipeRuntimeOverlays(recipe.runtime?.overlays, recipePath)
   validateRecipeRuntimeAssets(recipe.runtime?.assets, recipePath)
   validateRecipeMounts(recipe.inputs?.mounts, "mounts", recipePath)
@@ -176,6 +177,31 @@ function validateRecipeRuntimeAssets(assets: RuntimeAssetSpec | undefined, recip
   }
 }
 
+function validateRecipeRuntimeBackendPackage(backendPackage: WorkspaceRecipeRuntimeBackendPackage | undefined, recipePath: string): void {
+  if (backendPackage === undefined) {
+    return
+  }
+
+  if (!backendPackage || typeof backendPackage !== "object" || Array.isArray(backendPackage)) {
+    throw new Error(`Recipe runtime backendPackage must be an object: ${recipePath}`)
+  }
+  if (backendPackage.kind !== "playground") {
+    throw new Error(`Recipe runtime backendPackage kind is unsupported: ${recipePath}`)
+  }
+  if (!backendPackage.source || typeof backendPackage.source !== "string") {
+    throw new Error(`Recipe runtime backendPackage must include source: ${recipePath}`)
+  }
+  if (backendPackage.package !== undefined && typeof backendPackage.package !== "string") {
+    throw new Error(`Recipe runtime backendPackage package must be a string when provided: ${recipePath}`)
+  }
+  if (backendPackage.entrypoint !== undefined && typeof backendPackage.entrypoint !== "string") {
+    throw new Error(`Recipe runtime backendPackage entrypoint must be a string when provided: ${recipePath}`)
+  }
+  if (backendPackage.metadata !== undefined && (!backendPackage.metadata || typeof backendPackage.metadata !== "object" || Array.isArray(backendPackage.metadata))) {
+    throw new Error(`Recipe runtime backendPackage metadata must be an object when provided: ${recipePath}`)
+  }
+}
+
 function validateRecipeMounts(mounts: WorkspaceRecipeMount[] | undefined, label: string, recipePath: string): void {
   if (mounts && !Array.isArray(mounts)) {
     throw new Error(`Recipe ${label} mounts must be an array: ${recipePath}`)
@@ -236,6 +262,13 @@ export async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePat
 
   if (recipe.runtime?.backend && recipe.runtime.backend !== "wordpress-playground") {
     addIssue("unsupported-backend", "$.runtime.backend", `Unsupported recipe backend: ${recipe.runtime.backend}`)
+  }
+
+  if (recipe.runtime?.backendPackage) {
+    if ((recipe.runtime.backend ?? "wordpress-playground") !== "wordpress-playground") {
+      addIssue("unsupported-backend-package", "$.runtime.backendPackage", "Runtime backendPackage is only supported for the wordpress-playground backend")
+    }
+    await validateExistingBackendPackageSource(resolve(recipeDirectory, recipe.runtime.backendPackage.source), "$.runtime.backendPackage.source", addIssue)
   }
 
   for (const { phase, index, step } of recipeWorkflowSteps(recipe)) {
@@ -762,6 +795,19 @@ async function validateExistingDirectory(path: string, issuePath: string, addIss
   } catch {
     addIssue("missing-path", issuePath, `Directory does not exist: ${path}`)
   }
+}
+
+async function validateExistingBackendPackageSource(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
+  try {
+    const result = await stat(path)
+    if (result.isDirectory() || result.isFile()) {
+      return
+    }
+  } catch {
+    // Report below.
+  }
+
+  addIssue("missing-backend-package-source", issuePath, `Runtime backend package source must be an existing file or directory: ${path}`)
 }
 
 async function validateExistingFile(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -27,6 +27,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           wp: { type: "string" },
           blueprint: { type: "object" },
           assets: { $ref: "#/$defs/runtimeAssets" },
+          backendPackage: { $ref: "#/$defs/runtimeBackendPackage" },
           stack: { $ref: "#/$defs/runtimeStack" },
           overlays: {
             type: "array",
@@ -175,6 +176,19 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "array",
             items: { $ref: "#/$defs/mount" },
           },
+        },
+      },
+      runtimeBackendPackage: {
+        type: "object",
+        additionalProperties: false,
+        required: ["kind", "source"],
+        description: "Optional local Playground backend package or entrypoint used to boot the runtime. This selects the backend package itself and is separate from /wordpress filesystem overlays.",
+        properties: {
+          kind: { const: "playground" },
+          source: { type: "string" },
+          package: { type: "string" },
+          entrypoint: { type: "string" },
+          metadata: { $ref: "#/$defs/metadata" },
         },
       },
       runtimeOverlay: {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -95,6 +95,14 @@ export interface WorkspaceRecipeRuntimeOverlay {
   metadata?: Record<string, unknown>
 }
 
+export interface WorkspaceRecipeRuntimeBackendPackage {
+  kind: "playground"
+  source: string
+  package?: string
+  entrypoint?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface WorkspaceRecipeStagedFile {
   source: string
   target: string
@@ -222,6 +230,7 @@ export interface WorkspaceRecipe {
     wp?: string
     blueprint?: unknown
     assets?: RuntimeAssetSpec
+    backendPackage?: WorkspaceRecipeRuntimeBackendPackage
     stack?: WorkspaceRecipeRuntimeStack
     overlays?: WorkspaceRecipeRuntimeOverlay[]
   }
@@ -463,6 +472,7 @@ export interface ArtifactProvenance {
     backend: RuntimeBackendKind
     version?: string
     wordpressVersion?: string
+    backendPackage?: Record<string, unknown>
   }
   agent?: Record<string, unknown>
   mounts: Array<{

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -605,6 +605,7 @@ export function buildArtifactProvenance({
       backend: runtime.backend,
       version: provenanceString(provenanceContext(context, "runtime"), "version"),
       wordpressVersion: runtime.environment.version,
+      backendPackage: provenanceContext(context, "preparedRuntimeBackend"),
     }),
     agent: provenanceContext(context, "agent"),
     mounts: mounts.map((mount) => stripUndefined({

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -4,3 +4,4 @@ export { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "./bro
 export { createHostCommandTool, type HostCommandToolConfig } from "./host-command-tool.js"
 export { PlaygroundRuntimeBackend, createPlaygroundRuntimeBackend } from "./playground-runtime.js"
 export { preflightPhpWasmRuntimeAssets, PhpWasmRuntimeAssetIntegrityError, type PhpWasmRuntimeAssetPreflight, type PhpWasmRuntimeAssetPreflightOptions } from "./php-wasm-preflight.js"
+export type { PlaygroundCliModule } from "./playground-cli-runner.js"

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -11,7 +11,7 @@ import { basename, join } from "node:path"
 import { createServer as createNetServer } from "node:net"
 import { resolveWordPressRelease } from "@wp-playground/wordpress"
 
-interface PlaygroundCliModule {
+export interface PlaygroundCliModule {
   runCLI(options: {
     command: "server"
     port: number
@@ -29,6 +29,7 @@ const PLAYGROUND_WORDPRESS_CACHE_DIRECTORY_ENV = "WP_CODEBOX_PLAYGROUND_WORDPRES
 
 export interface PlaygroundCliStartupOptions {
   onProgress?: (event: BrowserStartupProgressEvent) => void | Promise<void>
+  cliModule?: PlaygroundCliModule
 }
 
 export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: MountSpec[], options: PlaygroundCliStartupOptions = {}): Promise<PlaygroundCliServer> {
@@ -51,7 +52,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
   })
   emitProgress("preview:loading-client", "running", "Loading preview")
   try {
-    const { runCLI } = (await import("@wp-playground/cli")) as unknown as PlaygroundCliModule
+    const { runCLI } = options.cliModule ?? (await import("@wp-playground/cli")) as unknown as PlaygroundCliModule
     if (spec.preview?.port) {
       await assertPreviewPortAvailable(spec.preview.port)
     }

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -10,7 +10,7 @@ import { cleanWpCliOutput, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } fro
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { observeHttpResponse as observeHttpResponseArtifact, observeWordPressState as observeWordPressStateArtifact } from "./observation-artifacts.js"
 import { PlaygroundCommandCrashError, assertPlaygroundResponseOk, errorMessage, type PlaygroundRunResponse } from "./playground-command-errors.js"
-import { startPlaygroundCliServer } from "./playground-cli-runner.js"
+import { startPlaygroundCliServer, type PlaygroundCliModule } from "./playground-cli-runner.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { collectPlaygroundArtifacts } from "./runtime-artifact-helpers.js"
 import { runAbilityCommand, runBenchCommand, runCorePhpunitCommand, runPhpCommand, runPhpunitCommand, runPluginCheckCommand, runRestRequestCommand, runThemeCheckCommand } from "./wordpress-command-runners.js"
@@ -60,6 +60,7 @@ export class PlaygroundRuntimeBackend implements RuntimeBackend {
 
 export interface PlaygroundRuntimeBackendOptions {
   hostTools?: HostToolRegistry
+  cliModule?: PlaygroundCliModule
 }
 
 class PlaygroundRuntime implements Runtime {
@@ -78,13 +79,13 @@ class PlaygroundRuntime implements Runtime {
   private readonly hostTools?: HostToolRegistry
   private cliServerPromise?: Promise<PlaygroundCliServer>
 
-  private constructor(private readonly spec: RuntimeCreateSpec, options: PlaygroundRuntimeBackendOptions = {}) {
+  private constructor(private readonly spec: RuntimeCreateSpec, private readonly backendOptions: PlaygroundRuntimeBackendOptions = {}) {
     this.artifactRoot = resolve(spec.artifactsDirectory ?? "artifacts", this.runtimeId)
     this.hostTools = spec.hostTools instanceof HostToolRegistry
       ? spec.hostTools
       : Array.isArray(spec.hostTools)
         ? createHostToolRegistry(spec.hostTools)
-        : options.hostTools
+        : backendOptions.hostTools
   }
 
   static async create(spec: RuntimeCreateSpec, options: PlaygroundRuntimeBackendOptions = {}): Promise<PlaygroundRuntime> {
@@ -676,6 +677,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
   private async startPlayground(): Promise<PlaygroundCliServer> {
     return startPlaygroundCliServer(this.spec, this.mounts, {
       onProgress: (event) => this.recordBrowserStartupProgress(event),
+      cliModule: this.backendOptions.cliModule,
     })
   }
 

--- a/scripts/recipe-backend-package-smoke.ts
+++ b/scripts/recipe-backend-package-smoke.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-backend-package-"))
+
+try {
+  const fixtureBackendPackage = join(workspace, "fixture-playground-cli")
+  const fixtureBackend = join(fixtureBackendPackage, "index.mjs")
+  const incompatibleBackend = join(workspace, "incompatible-playground-cli.mjs")
+  const marker = join(workspace, "fixture-options.json")
+  const artifacts = join(workspace, "artifacts")
+  const recipePath = join(workspace, "recipe.json")
+  const incompatibleRecipePath = join(workspace, "incompatible-recipe.json")
+
+  await mkdir(fixtureBackendPackage, { recursive: true })
+  await writeFile(join(fixtureBackendPackage, "package.json"), `${JSON.stringify({ name: "@wp-playground/cli-fixture", version: "0.0.408", type: "module", exports: "./index.mjs" }, null, 2)}\n`)
+  await writeFile(fixtureBackend, `import { writeFileSync } from "node:fs"
+
+export async function runCLI(options) {
+  writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ mount: options.mount, wp: options.wp, siteUrl: options["site-url"] }, null, 2))
+  return {
+    serverUrl: "http://127.0.0.1:49999",
+    playground: {
+      async run() {
+        return { exitCode: 0, text: "fixture-backend\\n" }
+      },
+      async writeFile() {},
+    },
+    async [Symbol.asyncDispose]() {},
+  }
+}
+`)
+  await writeFile(incompatibleBackend, `export const notRunCLI = true
+`)
+
+  const recipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: {
+      backend: "wordpress-playground",
+      name: "backend-package-smoke",
+      wp: "7.0",
+      backendPackage: {
+        kind: "playground",
+        source: fixtureBackendPackage,
+        package: "@wp-playground/cli-fixture",
+        metadata: { ref: "fixture-ref" },
+      },
+    },
+    workflow: {
+      steps: [{ command: "wordpress.run-php", args: ["code=echo 'default backend must be replaced';"] }],
+    },
+    artifacts: { directory: artifacts },
+  }
+  await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`)
+  await writeFile(incompatibleRecipePath, `${JSON.stringify({ ...recipe, runtime: { ...recipe.runtime, backendPackage: { kind: "playground", source: incompatibleBackend } }, artifacts: { directory: join(workspace, "bad-artifacts") } }, null, 2)}\n`)
+
+  const dryRun = await recipeRunJson(["--recipe", recipePath, "--dry-run", "--json"])
+  assert.equal(dryRun.success, true, dryRun.error?.message)
+  assert.equal(dryRun.plan.runtime.backendPackage.source, fixtureBackendPackage)
+  assert.equal(dryRun.plan.mounts.some((mount: { metadata?: { kind?: string } }) => mount.metadata?.kind === "runtime-overlay"), false)
+
+  const output = await recipeRunJson(["--recipe", recipePath, "--json"])
+  assert.equal(output.success, true, output.error?.message)
+  assert.equal(output.executions[0]?.stdout, "fixture-backend\n")
+
+  const fixtureOptions = JSON.parse(await readFile(marker, "utf8"))
+  assert.deepEqual(fixtureOptions.mount, [])
+
+  const metadata = JSON.parse(await readFile(join(output.artifacts.directory, "metadata.json"), "utf8"))
+  assert.equal(metadata.context.preparedRuntimeOverlays.length, 0)
+  assert.equal(metadata.context.preparedRuntimeBackend.schema, "wp-codebox/runtime-backend-package/v1")
+  assert.equal(metadata.context.preparedRuntimeBackend.source, fixtureBackendPackage)
+  assert.equal(metadata.context.preparedRuntimeBackend.package.name, "@wp-playground/cli-fixture")
+  assert.equal(metadata.context.preparedRuntimeBackend.package.version, "0.0.408")
+  assert.match(metadata.context.preparedRuntimeBackend.package.digest.sha256, /^[a-f0-9]{64}$/)
+  assert.equal(metadata.context.preparedRuntimeBackend.metadata.ref, "fixture-ref")
+  assert.match(metadata.context.preparedRuntimeBackend.entrypointDigest.sha256, /^[a-f0-9]{64}$/)
+  assert.equal(metadata.provenance.runtime.backendPackage.source, fixtureBackendPackage)
+
+  const bad = await recipeRunJson(["--recipe", incompatibleRecipePath, "--json"], false)
+  assert.equal(bad.success, false)
+  assert.equal(bad.runtime, undefined, "incompatible backend packages must fail before runtime creation")
+  assert.equal(bad.error.code, "recipe-runtime-backend-package-invalid")
+  assert.equal(bad.diagnostics[0]?.phase, "backend-preparation")
+
+  console.log("Recipe backend package smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function recipeRunJson(args: string[], expectSuccess = true): Promise<any> {
+  try {
+    const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", ...args], { cwd: root })
+    return JSON.parse(stdout)
+  } catch (error) {
+    if (!expectSuccess && error && typeof error === "object" && "stdout" in error) {
+      return JSON.parse(String((error as { stdout: string }).stdout))
+    }
+    throw error
+  }
+}

--- a/tests/fixtures/artifact-package-provenance-shape.json
+++ b/tests/fixtures/artifact-package-provenance-shape.json
@@ -2,15 +2,15 @@
   "schema": "wp-codebox/package-provenance/v1",
   "wpCodebox": {
     "name": "wp-codebox-workspace",
-    "version": "0.5.1"
+    "version": "0.6.0"
   },
   "runtimeCore": {
     "name": "@automattic/wp-codebox-core",
-    "version": "0.5.1"
+    "version": "0.6.0"
   },
   "runtimePlayground": {
     "name": "@automattic/wp-codebox-playground",
-    "version": "0.5.1"
+    "version": "0.6.0"
   },
   "playground": {
     "cli": {

--- a/tests/fixtures/artifact-package-provenance-shape.json
+++ b/tests/fixtures/artifact-package-provenance-shape.json
@@ -2,15 +2,15 @@
   "schema": "wp-codebox/package-provenance/v1",
   "wpCodebox": {
     "name": "wp-codebox-workspace",
-    "version": "0.4.0"
+    "version": "0.5.1"
   },
   "runtimeCore": {
     "name": "@automattic/wp-codebox-core",
-    "version": "0.4.0"
+    "version": "0.5.1"
   },
   "runtimePlayground": {
     "name": "@automattic/wp-codebox-playground",
-    "version": "0.4.0"
+    "version": "0.5.1"
   },
   "playground": {
     "cli": {


### PR DESCRIPTION
## Summary
- Adds a recipe-level `runtime.backendPackage` contract for selecting a local Playground backend package or entrypoint separately from `/wordpress` stack mounts and runtime overlays.
- Validates local backend sources before runtime creation, imports an entrypoint that exports `runCLI`, and fails clearly for missing/incompatible selections.
- Records backend package provenance in recipe context and artifact provenance, including source, entrypoint, package name/version/digest, entrypoint digest, diagnostics, and user metadata.
- Adds a focused smoke fixture proving a recipe can boot through a local backend entrypoint without adding WordPress filesystem overlay mounts.

## Tests
- `npm run build`
- `npm run recipe-backend-package-smoke`
- `npm run recipe-dry-run-smoke`
- `npm run runtime-stack-mount-smoke`
- `npm run runtime-overlay-php-ai-client-smoke`
- `npm run artifact-contract-smoke`
- `npm run check` completed once before the final `v0.6.0` rebase; after the final rebase, the focused build/backend/provenance smokes above were rerun successfully.

## Caveats
- This is the minimal contract/validation/provenance slice. It supports a local backend package/entrypoint that exports the same `runCLI` shape WP Codebox already uses.
- It does not yet implement dependency installation/build orchestration for an arbitrary local `@wp-playground/cli` workspace; callers must point at a built/importable package entrypoint.

Closes #408.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the minimal backend override contract/provenance slice, smoke coverage, verification, and PR drafting. Chris remains responsible for review and merge decisions.