### PR TITLE
Sync package lock version after v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -3814,7 +3814,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -3825,11 +3825,11 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.5.2"
+      "version": "0.6.0"
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@wp-playground/cli": "^3.1.35",


### PR DESCRIPTION
## Summary
- Sync package-lock workspace/package versions to the v0.6.0 package manifests.
- Keeps fresh installs from dirtying current main after the release.

## Testing
- npm install
- npm run runtime-overlay-php-ai-client-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the post-release lockfile drift and drafting this focused sync change.