### PR TITLE
Add transfer proof verification and probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "package-installed-binary-smoke": "tsx scripts/package-installed-binary-smoke.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "artifact-bundle-verifier-smoke": "tsx scripts/artifact-bundle-verifier-smoke.ts",
+    "transfer-proof-smoke": "tsx scripts/transfer-proof-smoke.ts",
     "artifact-redaction-smoke": "tsx scripts/artifact-redaction-smoke.ts",
     "artifact-patch-git-apply-smoke": "tsx scripts/artifact-patch-git-apply-smoke.ts",
     "artifact-reference-normalization-smoke": "tsx scripts/artifact-reference-normalization-smoke.ts",

--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -1,5 +1,5 @@
 import { routeCliCommand } from "./command-router.js"
-import { runArtifactsApplyPreflightCommand, runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
+import { runArtifactsApplyPreflightCommand, runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsTransferProbesCommand, runArtifactsTransferVerifyCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
 import { runAgentTaskRunCommand } from "./commands/agent-task-run.js"
 import { runArtifactsBenchCompareCommand, runArtifactsBenchResultsCommand, runBenchCompareCommand, runBenchMatrixCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
 import { runCommandsCommand, runRecipeSchemaCommand } from "./commands/discovery.js"
@@ -24,6 +24,8 @@ export async function runCli(args: string[]): Promise<number> {
     artifactsVerify: runArtifactsVerifyCommand,
     artifactsApplyPreflight: runArtifactsApplyPreflightCommand,
     artifactsBrowserMetrics: runArtifactsBrowserMetricsCommand,
+    artifactsTransferVerify: runArtifactsTransferVerifyCommand,
+    artifactsTransferProbes: runArtifactsTransferProbesCommand,
     artifactsBenchmark: runArtifactsBenchmarkCommand,
     artifactsBenchResults: runArtifactsBenchResultsCommand,
     benchMatrix: runBenchMatrixCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -14,6 +14,8 @@ interface CliCommandRouter {
   artifactsVerify: CliCommandHandler
   artifactsApplyPreflight: CliCommandHandler
   artifactsBrowserMetrics: CliCommandHandler
+  artifactsTransferVerify: CliCommandHandler
+  artifactsTransferProbes: CliCommandHandler
   artifactsBenchmark: CliCommandHandler
   artifactsBenchResults: CliCommandHandler
   benchMatrix: CliCommandHandler
@@ -85,6 +87,12 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
       }
       if (subcommand === "browser-metrics") {
         return router.artifactsBrowserMetrics(args)
+      }
+      if (subcommand === "transfer-verify") {
+        return router.artifactsTransferVerify(args)
+      }
+      if (subcommand === "transfer-probes") {
+        return router.artifactsTransferProbes(args)
       }
       if (subcommand === "benchmark") {
         return router.artifactsBenchmark(args)

--- a/packages/cli/src/commands/artifacts.ts
+++ b/packages/cli/src/commands/artifacts.ts
@@ -1,6 +1,6 @@
 import { copyFile, mkdir, readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { preflightArtifactBundleApply, verifyArtifactBundle, type ArtifactBundleApplyPreflightResult, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core"
+import { buildTransferProbeDiagnostics, preflightArtifactBundleApply, verifyArtifactBundle, verifyTransferProofBundle, type ArtifactBundleApplyPreflightResult, type ArtifactBundleVerificationResult, type TransferProbeDiagnosticsResult, type TransferProofBundleVerificationResult } from "@automattic/wp-codebox-core"
 import { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "@automattic/wp-codebox-playground"
 import { printArtifactVerifyHumanOutput } from "../output.js"
 
@@ -79,6 +79,30 @@ export async function runArtifactsBrowserMetricsCommand(args: string[]): Promise
   return 0
 }
 
+export async function runArtifactsTransferVerifyCommand(args: string[]): Promise<number> {
+  const options = parseArtifactVerifyOptions(args)
+  const output = await transferVerify(options)
+  if (!options.json) {
+    printArtifactTransferVerifyHumanOutput(output)
+    return output.valid ? 0 : 1
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return output.valid ? 0 : 1
+}
+
+export async function runArtifactsTransferProbesCommand(args: string[]): Promise<number> {
+  const options = parseArtifactVerifyOptions(args)
+  const output = await transferProbes(options)
+  if (!options.json) {
+    printArtifactTransferProbesHumanOutput(output)
+    return output.status === "passed" ? 0 : 1
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return output.status === "passed" ? 0 : 1
+}
+
 export async function runArtifactsBenchmarkCommand(args: string[]): Promise<number> {
   const options = parseBenchmarkArtifactsOptions(args)
   const output = await benchmarkArtifacts(options)
@@ -101,6 +125,14 @@ async function applyPreflight(options: ArtifactApplyPreflightOptions): Promise<A
 
 async function browserMetrics(options: ArtifactVerifyOptions): Promise<BrowserArtifactMetricsResult> {
   return browserArtifactMetrics(resolve(options.bundleDirectory))
+}
+
+async function transferVerify(options: ArtifactVerifyOptions): Promise<TransferProofBundleVerificationResult> {
+  return verifyTransferProofBundle(resolve(options.bundleDirectory))
+}
+
+async function transferProbes(options: ArtifactVerifyOptions): Promise<TransferProbeDiagnosticsResult> {
+  return buildTransferProbeDiagnostics(resolve(options.bundleDirectory))
 }
 
 async function benchmarkArtifacts(options: BenchmarkArtifactsOptions): Promise<BenchmarkArtifactsOutput> {
@@ -222,6 +254,27 @@ function printArtifactBrowserMetricsHumanOutput(output: BrowserArtifactMetricsRe
     for (const [name, artifact] of Object.entries(output.artifacts).sort(([left], [right]) => left.localeCompare(right))) {
       console.log(`  ${name}: ${artifact.path}`)
     }
+  }
+}
+
+function printArtifactTransferVerifyHumanOutput(output: TransferProofBundleVerificationResult): void {
+  console.log("WP Codebox transfer proof verification")
+  console.log(`Bundle: ${output.bundleDirectory}`)
+  console.log(`Valid: ${output.valid ? "yes" : "no"}`)
+  console.log(`Transfer violations: ${output.violations.length}`)
+  console.log(`Probe diagnostics: ${output.diagnostics.summary.errors} error(s), ${output.diagnostics.summary.warnings} warning(s)`)
+  for (const violation of output.violations) {
+    console.log(`- ${violation.code}: ${violation.message}`)
+  }
+}
+
+function printArtifactTransferProbesHumanOutput(output: TransferProbeDiagnosticsResult): void {
+  console.log("WP Codebox transfer probe diagnostics")
+  console.log(`Bundle: ${output.bundleDirectory}`)
+  console.log(`Status: ${output.status}`)
+  console.log(`Diagnostics: ${output.summary.total} (${output.summary.errors} error(s), ${output.summary.warnings} warning(s))`)
+  for (const diagnostic of output.diagnostics) {
+    console.log(`- ${diagnostic.severity} ${diagnostic.code}: ${diagnostic.message}`)
   }
 }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -258,6 +258,8 @@ export function printHelp(): void {
   wp-codebox artifacts verify --bundle <dir> [--json]
   wp-codebox artifacts apply-preflight --bundle <dir> --approved-file <path> [--json]
   wp-codebox artifacts browser-metrics --bundle <dir> [--json]
+  wp-codebox artifacts transfer-verify --bundle <dir> [--json]
+  wp-codebox artifacts transfer-probes --bundle <dir> [--json]
   wp-codebox artifacts benchmark --bundle <dir> [--scenario-id <id>] [--extract-to <dir>] [--json]
   wp-codebox artifacts bench-results --bundle <dir> [--json]
   wp-codebox artifacts bench-compare --baseline-bundle <dir> --candidate-bundle <dir> [--json]
@@ -278,7 +280,7 @@ Options:
                     Keep preview runtimes alive after agent-task-run/recipe-run.
   --preview-public-url <url>
                     Public preview URL passed through to agent-task-run/recipe-run.
-  --bundle <dir>      Artifact bundle directory for artifacts verify and apply-preflight.
+  --bundle <dir>      Artifact bundle directory for artifact verification/probe commands.
   --approved-file <path>
                        Changed file approved for artifacts apply-preflight. Repeatable.
   --approved-files <paths>

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -19,6 +19,7 @@ export * from "./runtime-reference.js"
 export * from "./object-utils.js"
 export * from "./runtime-action-adapter.js"
 export * from "./artifact-bundle-verifier.js"
+export * from "./transfer-proof.js"
 export * from "./host-tool-registry.js"
 export * from "./run-registry.js"
 

--- a/packages/runtime-core/src/transfer-proof.ts
+++ b/packages/runtime-core/src/transfer-proof.ts
@@ -1,0 +1,414 @@
+import { readFile } from "node:fs/promises"
+import { join, normalize } from "node:path"
+import { artifactFileDigest } from "./artifact-manifest.js"
+import { verifyArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactBundleVerificationViolation } from "./artifact-bundle-verifier.js"
+import type { ArtifactManifest, ArtifactManifestFile } from "./artifact-manifest.js"
+import { isPlainObject as isRecord } from "./object-utils.js"
+
+export type TransferProofViolationCode =
+  | "artifact-bundle-invalid"
+  | "missing-transfer-artifact"
+  | "malformed-transfer-artifact"
+  | "transfer-digest-mismatch"
+  | "unsafe-reviewer-evidence"
+
+export interface TransferProofViolation {
+  code: TransferProofViolationCode
+  path: string
+  message: string
+  file?: string
+  details?: Record<string, unknown>
+}
+
+export interface TransferProofBundleVerificationResult {
+  schema: "wp-codebox/transfer-proof-bundle-verification/v1"
+  bundleDirectory: string
+  valid: boolean
+  artifactVerification: ArtifactBundleVerificationResult
+  violations: TransferProofViolation[]
+  diagnostics: TransferProbeDiagnosticsResult
+}
+
+export type TransferProbeDiagnosticCode =
+  | "page-unavailable"
+  | "broken-link"
+  | "missing-media"
+  | "block-validation-error"
+  | "plugin-runtime-diagnostic"
+  | "browser-runtime-error"
+  | "visual-content-parity"
+
+export interface TransferProbeDiagnostic {
+  code: TransferProbeDiagnosticCode
+  severity: "error" | "warning" | "info"
+  message: string
+  probe?: string
+  artifact?: string
+  url?: string
+  details?: Record<string, unknown>
+}
+
+export interface TransferProbeDiagnosticsResult {
+  schema: "wp-codebox/transfer-probe-diagnostics/v1"
+  bundleDirectory: string
+  status: "passed" | "failed"
+  summary: {
+    total: number
+    errors: number
+    warnings: number
+    browserProbes: number
+  }
+  probes: {
+    pageAvailability: TransferProbeDiagnostic[]
+    brokenLinksAndMissingMedia: TransferProbeDiagnostic[]
+    blockValidation: TransferProbeDiagnostic[]
+    pluginRuntime: TransferProbeDiagnostic[]
+    visualContentParity: TransferProbeDiagnostic[]
+    runtimeErrors: TransferProbeDiagnostic[]
+  }
+  diagnostics: TransferProbeDiagnostic[]
+}
+
+type JsonPath = Array<string | number>
+
+const REQUIRED_TRANSFER_KINDS = new Set(["preview-evidence", "preview-session-evidence", "runtime-reference-manifest", "runtime-replay-index", "diagnostics", "log", "review"])
+const REVIEWER_EVIDENCE_KINDS = new Set([
+  "review",
+  "preview-evidence",
+  "preview-session-evidence",
+  "diagnostics",
+  "log",
+  "browser-summary",
+  "browser-console",
+  "browser-errors",
+  "browser-network",
+  "runtime-reference-manifest",
+  "runtime-replay-index",
+])
+
+export async function verifyTransferProofBundle(directory: string): Promise<TransferProofBundleVerificationResult> {
+  const bundleDirectory = normalize(directory)
+  const artifactVerification = await verifyArtifactBundle(bundleDirectory)
+  const diagnostics = await buildTransferProbeDiagnostics(bundleDirectory, artifactVerification.manifest)
+  const violations: TransferProofViolation[] = artifactVerification.valid ? [] : artifactVerification.violations.map(artifactViolationToTransferViolation)
+
+  if (artifactVerification.manifest) {
+    verifyRequiredTransferArtifacts(artifactVerification.manifest, violations)
+    await verifyPreviewSessionEvidenceRef(bundleDirectory, artifactVerification.manifest, violations)
+    await verifyReviewerEvidenceSafety(bundleDirectory, artifactVerification.manifest, violations)
+  }
+
+  return {
+    schema: "wp-codebox/transfer-proof-bundle-verification/v1",
+    bundleDirectory,
+    valid: violations.length === 0 && diagnostics.status === "passed",
+    artifactVerification,
+    violations,
+    diagnostics,
+  }
+}
+
+export async function buildTransferProbeDiagnostics(directory: string, manifest?: ArtifactManifest): Promise<TransferProbeDiagnosticsResult> {
+  const bundleDirectory = normalize(directory)
+  const resolvedManifest = manifest ?? await readManifest(bundleDirectory)
+  const browserProbes = await readBrowserProbeSummaries(bundleDirectory, resolvedManifest)
+  const pageAvailability: TransferProbeDiagnostic[] = []
+  const brokenLinksAndMissingMedia: TransferProbeDiagnostic[] = []
+  const blockValidation: TransferProbeDiagnostic[] = []
+  const pluginRuntime: TransferProbeDiagnostic[] = []
+  const visualContentParity: TransferProbeDiagnostic[] = []
+  const runtimeErrors: TransferProbeDiagnostic[] = []
+
+  for (const probe of browserProbes) {
+    const label = typeof probe.finalUrl === "string" ? probe.finalUrl : typeof probe.url === "string" ? probe.url : "browser probe"
+    const errors = numeric(probe.errors)
+    if (!probe.finalUrl || errors > 0) {
+      pageAvailability.push({ code: "page-unavailable", severity: "error", message: `Browser probe reported unavailable or errored page: ${label}`, probe: label, details: { errors } })
+    }
+    if (isRecord(probe.assertions) && numeric(probe.assertions.failed) > 0) {
+      visualContentParity.push({ code: "visual-content-parity", severity: "warning", message: `Browser probe reported ${numeric(probe.assertions.failed)} failed assertion(s): ${label}`, probe: label, details: { assertions: probe.assertions } })
+    }
+  }
+
+  for (const file of resolvedManifest?.files ?? []) {
+    if (file.kind === "browser-network") {
+      brokenLinksAndMissingMedia.push(...await readNetworkDiagnostics(bundleDirectory, file.path))
+    }
+    if (file.kind === "browser-console" || file.kind === "browser-errors") {
+      const diagnostics = await readTextRuntimeDiagnostics(bundleDirectory, file.path)
+      blockValidation.push(...diagnostics.filter((diagnostic) => diagnostic.code === "block-validation-error"))
+      runtimeErrors.push(...diagnostics.filter((diagnostic) => diagnostic.code === "browser-runtime-error"))
+    }
+    if (file.kind === "diagnostics") {
+      pluginRuntime.push(...await readPluginRuntimeDiagnostics(bundleDirectory, file.path))
+    }
+  }
+
+  const diagnostics = [pageAvailability, brokenLinksAndMissingMedia, blockValidation, pluginRuntime, visualContentParity, runtimeErrors].flat()
+  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length
+  const warnings = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length
+
+  return {
+    schema: "wp-codebox/transfer-probe-diagnostics/v1",
+    bundleDirectory,
+    status: errors === 0 ? "passed" : "failed",
+    summary: {
+      total: diagnostics.length,
+      errors,
+      warnings,
+      browserProbes: browserProbes.length,
+    },
+    probes: {
+      pageAvailability,
+      brokenLinksAndMissingMedia,
+      blockValidation,
+      pluginRuntime,
+      visualContentParity,
+      runtimeErrors,
+    },
+    diagnostics,
+  }
+}
+
+function artifactViolationToTransferViolation(violation: ArtifactBundleVerificationViolation): TransferProofViolation {
+  return {
+    code: "artifact-bundle-invalid",
+    path: violation.path,
+    message: violation.message,
+    ...(violation.file ? { file: violation.file } : {}),
+    details: { artifactViolationCode: violation.code, ...(violation.details ?? {}) },
+  }
+}
+
+function verifyRequiredTransferArtifacts(manifest: ArtifactManifest, violations: TransferProofViolation[]): void {
+  const kinds = new Set(manifest.files.map((file) => file.kind))
+  for (const kind of REQUIRED_TRANSFER_KINDS) {
+    if (!kinds.has(kind)) {
+      violations.push({ code: "missing-transfer-artifact", path: "manifest.files", message: `Transfer proof bundle requires a ${kind} artifact.` })
+    }
+  }
+}
+
+async function verifyPreviewSessionEvidenceRef(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[]): Promise<void> {
+  const metadata = await readJson(join(directory, "metadata.json"))
+  const ref = isRecord(metadata) && isRecord(metadata.previewSessionEvidence) ? metadata.previewSessionEvidence : undefined
+  if (!ref) {
+    violations.push({ code: "missing-transfer-artifact", path: "metadata.previewSessionEvidence", message: "Transfer proof bundle requires preview session evidence ref metadata." })
+    return
+  }
+
+  const path = typeof ref.path === "string" ? ref.path : undefined
+  const sha256 = isRecord(ref.sha256) && ref.sha256.algorithm === "sha256" && typeof ref.sha256.value === "string" ? ref.sha256.value : undefined
+  const manifestFile = path ? manifest.files.find((file) => file.path === path && file.kind === "preview-session-evidence") : undefined
+  if (!path || !manifestFile) {
+    violations.push({ code: "missing-transfer-artifact", path: "metadata.previewSessionEvidence.path", message: "Preview session evidence ref must point at a manifest preview-session-evidence file." })
+    return
+  }
+  if (!sha256) {
+    violations.push({ code: "transfer-digest-mismatch", path: "metadata.previewSessionEvidence.sha256", file: path, message: "Preview session evidence ref must include a SHA-256 digest." })
+    return
+  }
+
+  const actual = artifactFileDigest(await readFile(join(directory, path))).value
+  if (actual !== sha256 || actual !== manifestFile.sha256.value) {
+    violations.push({ code: "transfer-digest-mismatch", path: "metadata.previewSessionEvidence.sha256", file: path, message: "Preview session evidence ref digest must match the referenced artifact and manifest file hash." })
+  }
+}
+
+async function verifyReviewerEvidenceSafety(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[]): Promise<void> {
+  for (const file of manifest.files) {
+    if (!REVIEWER_EVIDENCE_KINDS.has(file.kind)) {
+      continue
+    }
+    const text = await readFile(join(directory, file.path), "utf8")
+    for (const finding of unsafeReviewerEvidenceFindings(text, file.path)) {
+      violations.push(finding)
+    }
+  }
+}
+
+function unsafeReviewerEvidenceFindings(text: string, file: string): TransferProofViolation[] {
+  const findings: TransferProofViolation[] = []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    parsed = undefined
+  }
+
+  if (parsed !== undefined) {
+    walkReviewerEvidence(parsed, [], file, findings)
+  } else {
+    for (const [index, line] of text.split(/\r?\n/).entries()) {
+      scanReviewerEvidenceString(line, [`line:${index + 1}`], file, findings)
+    }
+  }
+  return findings
+}
+
+function walkReviewerEvidence(value: unknown, path: JsonPath, file: string, findings: TransferProofViolation[]): void {
+  if (typeof value === "string") {
+    scanReviewerEvidenceString(value, path, file, findings)
+    if (isSecretKeyPath(path) && !isRedactedSecretValue(value)) {
+      findings.push(unsafeFinding(file, path, "secret-shaped value", "Reviewer-facing evidence includes a secret-shaped field value."))
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => walkReviewerEvidence(item, [...path, index], file, findings))
+    return
+  }
+  if (isRecord(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      walkReviewerEvidence(item, [...path, key], file, findings)
+    }
+  }
+}
+
+function scanReviewerEvidenceString(value: string, path: JsonPath, file: string, findings: TransferProofViolation[]): void {
+  if (unsafeUrl(value)) {
+    findings.push(unsafeFinding(file, path, "unsafe URL", "Reviewer-facing evidence includes a localhost, local, or private URL."))
+  }
+  if (unsafeLocalPath(value)) {
+    findings.push(unsafeFinding(file, path, "local path", "Reviewer-facing evidence includes a host-local filesystem path."))
+  }
+  if (secretShapedValue(value)) {
+    findings.push(unsafeFinding(file, path, "secret-shaped value", "Reviewer-facing evidence includes a secret-shaped value."))
+  }
+}
+
+function unsafeFinding(file: string, path: JsonPath, kind: string, message: string): TransferProofViolation {
+  return { code: "unsafe-reviewer-evidence", path: `${file}:${formatJsonPath(path)}`, file, message, details: { kind } }
+}
+
+function unsafeUrl(value: string): boolean {
+  const matches = value.matchAll(/\b(?:https?|file):\/\/[^\s"'<>]+/gi)
+  for (const match of matches) {
+    try {
+      const url = new URL(match[0])
+      const host = url.hostname.toLowerCase()
+      if (url.protocol === "file:" || host === "localhost" || host === "0.0.0.0" || host === "127.0.0.1" || host === "::1") {
+        return true
+      }
+      if (/^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host) || host.endsWith(".local") || host.endsWith(".internal") || host.endsWith(".corp") || host.endsWith(".lan") || host === "github.a8c.com") {
+        return true
+      }
+    } catch {
+      continue
+    }
+  }
+  return false
+}
+
+function unsafeLocalPath(value: string): boolean {
+  return /(?:^|\s)(?:\/Users\/|\/private\/var\/|\/var\/folders\/|\/tmp\/|[A-Za-z]:\\)/.test(value)
+}
+
+function secretShapedValue(value: string): boolean {
+  if (isRedactedSecretValue(value)) {
+    return false
+  }
+  return /\b(?:sk-[A-Za-z0-9_-]{20,}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16})\b/.test(value)
+}
+
+function isSecretKeyPath(path: JsonPath): boolean {
+  const last = String(path.at(-1) ?? "")
+  return /(?:secret|token|password|credential|private[_-]?key|api[_-]?key|authorization)/i.test(last)
+}
+
+function isRedactedSecretValue(value: string): boolean {
+  return /^\[?redacted\]?$/i.test(value) || value === "" || value === "***"
+}
+
+async function readBrowserProbeSummaries(directory: string, manifest?: ArtifactManifest): Promise<Array<Record<string, unknown>>> {
+  const review = await readJson(join(directory, "files", "review.json"))
+  const reviewProbes = isRecord(review) && isRecord(review.browser) && Array.isArray(review.browser.probes) ? review.browser.probes.filter(isRecord) : []
+  if (reviewProbes.length > 0) {
+    return reviewProbes
+  }
+  const probes: Array<Record<string, unknown>> = []
+  for (const file of manifest?.files ?? []) {
+    if (file.kind !== "browser-summary") {
+      continue
+    }
+    const summary = await readJson(join(directory, file.path))
+    if (isRecord(summary)) {
+      probes.push(summary)
+    }
+  }
+  return probes
+}
+
+async function readNetworkDiagnostics(directory: string, path: string): Promise<TransferProbeDiagnostic[]> {
+  const lines = await readFile(join(directory, path), "utf8").catch(() => "")
+  return lines.split(/\r?\n/).filter(Boolean).flatMap((line) => {
+    const entry = parseJsonLine(line)
+    if (!isRecord(entry)) {
+      return []
+    }
+    const url = typeof entry.url === "string" ? entry.url : undefined
+    const resourceType = typeof entry.resourceType === "string" ? entry.resourceType : undefined
+    const status = numeric(entry.status)
+    const failed = entry.type === "requestfailed" || status >= 400
+    if (!failed) {
+      return []
+    }
+    const code: TransferProbeDiagnosticCode = resourceType === "image" || resourceType === "media" ? "missing-media" : "broken-link"
+    return [{ code, severity: "error", message: `${code === "missing-media" ? "Missing media" : "Broken link"} observed during browser probe: ${url ?? "unknown URL"}`, artifact: path, url, details: { status, resourceType } }]
+  })
+}
+
+async function readTextRuntimeDiagnostics(directory: string, path: string): Promise<TransferProbeDiagnostic[]> {
+  const text = await readFile(join(directory, path), "utf8").catch(() => "")
+  const diagnostics: TransferProbeDiagnostic[] = []
+  if (/block validation|Block validation failed|unexpected or invalid content/i.test(text)) {
+    diagnostics.push({ code: "block-validation-error", severity: "error", message: "Browser evidence includes a block validation error.", artifact: path })
+  }
+  if (/fatal error|uncaught|pageerror|console\.error|TypeError|ReferenceError/i.test(text)) {
+    diagnostics.push({ code: "browser-runtime-error", severity: "error", message: "Browser evidence includes a user-visible runtime error.", artifact: path })
+  }
+  return diagnostics
+}
+
+async function readPluginRuntimeDiagnostics(directory: string, path: string): Promise<TransferProbeDiagnostic[]> {
+  const diagnostics = await readJson(join(directory, path))
+  const list = isRecord(diagnostics) && Array.isArray(diagnostics.diagnostics) ? diagnostics.diagnostics.filter(isRecord) : []
+  return list
+    .filter((item) => item.severity === "error" || item.severity === "warning")
+    .map((item) => ({
+      code: "plugin-runtime-diagnostic" as const,
+      severity: item.severity === "error" ? "error" as const : "warning" as const,
+      message: typeof item.message === "string" ? item.message : "Runtime diagnostic reported during transfer probe.",
+      artifact: path,
+      details: { phase: item.phase, source: item.source },
+    }))
+}
+
+async function readManifest(directory: string): Promise<ArtifactManifest | undefined> {
+  const manifest = await readJson(join(directory, "manifest.json"))
+  return isRecord(manifest) && Array.isArray(manifest.files) ? manifest as unknown as ArtifactManifest : undefined
+}
+
+async function readJson(path: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, "utf8"))
+  } catch {
+    return undefined
+  }
+}
+
+function parseJsonLine(line: string): unknown {
+  try {
+    return JSON.parse(line)
+  } catch {
+    return undefined
+  }
+}
+
+function numeric(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+function formatJsonPath(path: JsonPath): string {
+  return path.map((part) => typeof part === "number" ? `[${part}]` : part).join(".") || "$"
+}

--- a/scripts/transfer-proof-smoke.ts
+++ b/scripts/transfer-proof-smoke.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { createHash } from "node:crypto"
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+import {
+  artifactFileDigest,
+  calculateArtifactContentDigest,
+  calculateArtifactManifestFileSha256,
+  buildRuntimeReferenceManifest,
+  buildRuntimeReplayReferenceIndex,
+  verifyTransferProofBundle,
+  buildTransferProbeDiagnostics,
+  type ArtifactManifest,
+  type ArtifactManifestFile,
+  type RuntimeInfo,
+} from "@automattic/wp-codebox-core"
+
+const execFileAsync = promisify(execFile)
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-transfer-proof-"))
+
+try {
+  const validBundle = join(workspace, "valid")
+  await writeTransferBundle(validBundle)
+
+  const valid = await verifyTransferProofBundle(validBundle)
+  assert.equal(valid.schema, "wp-codebox/transfer-proof-bundle-verification/v1")
+  assert.equal(valid.valid, true)
+  assert.deepEqual(valid.violations, [])
+  assert.equal(valid.diagnostics.schema, "wp-codebox/transfer-probe-diagnostics/v1")
+  assert.equal(valid.diagnostics.status, "passed")
+
+  const probes = await buildTransferProbeDiagnostics(validBundle)
+  assert.equal(probes.status, "passed")
+
+  const cliVerify = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "transfer-verify", "--bundle", validBundle, "--json"], { cwd: root })
+  assert.equal(JSON.parse(cliVerify.stdout).valid, true)
+
+  const cliProbes = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "artifacts", "transfer-probes", "--bundle", validBundle, "--json"], { cwd: root })
+  assert.equal(JSON.parse(cliProbes.stdout).status, "passed")
+
+  const unsafe = await copyBundle(validBundle, join(workspace, "unsafe"))
+  const unsafeReview = JSON.parse(await readText(join(unsafe, "files/review.json")))
+  unsafeReview.preview = { url: "http://localhost:8888" }
+  unsafeReview.credentials = { token: "sk-testthisshouldberejectedbecauseitislong" }
+  await writeJson(join(unsafe, "files/review.json"), unsafeReview)
+  await rewriteManifestHashes(unsafe)
+  const unsafeResult = await verifyTransferProofBundle(unsafe)
+  assert.equal(unsafeResult.valid, false)
+  assert.ok(unsafeResult.violations.some((violation) => violation.code === "unsafe-reviewer-evidence"), unsafeResult.violations.map((violation) => violation.code).join(", "))
+
+  const broken = await copyBundle(validBundle, join(workspace, "broken"))
+  await writeFile(join(broken, "files/browser/network.jsonl"), `${JSON.stringify({ type: "response", url: "https://example.com/missing.png", resourceType: "image", status: 404 })}\n`)
+  await rewriteManifestHashes(broken)
+  const brokenResult = await verifyTransferProofBundle(broken)
+  assert.equal(brokenResult.valid, false)
+  assert.ok(brokenResult.diagnostics.diagnostics.some((diagnostic) => diagnostic.code === "missing-media"), JSON.stringify(brokenResult.diagnostics, null, 2))
+
+  const missingPreviewRef = await copyBundle(validBundle, join(workspace, "missing-preview-ref"))
+  const metadata = JSON.parse(await readText(join(missingPreviewRef, "metadata.json")))
+  delete metadata.previewSessionEvidence
+  await writeJson(join(missingPreviewRef, "metadata.json"), metadata)
+  await rewriteManifestHashes(missingPreviewRef)
+  const missingPreviewRefResult = await verifyTransferProofBundle(missingPreviewRef)
+  assert.equal(missingPreviewRefResult.valid, false)
+  assert.ok(missingPreviewRefResult.violations.some((violation) => violation.code === "missing-transfer-artifact"), missingPreviewRefResult.violations.map((violation) => violation.code).join(", "))
+
+  console.log("Transfer proof verifier smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function writeTransferBundle(directory: string): Promise<void> {
+  await mkdir(join(directory, "files/browser"), { recursive: true })
+  const createdAt = "2026-06-05T00:00:00.000Z"
+  const runtime = runtimeFixture(createdAt)
+  const changedFiles = `${JSON.stringify({ schema: "wp-codebox/changed-files/v1", files: [{ path: "/wordpress/wp-content/plugins/example/file.txt", status: "added" }] }, null, 2)}\n`
+  const patch = "diff --git a/wordpress/wp-content/plugins/example/file.txt b/wordpress/wp-content/plugins/example/file.txt\nnew file mode 100644\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
+  await writeFile(join(directory, "files/changed-files.json"), changedFiles)
+  await writeFile(join(directory, "files/patch.diff"), patch)
+  const contentDigest = await calculateArtifactContentDigest(directory, ["files/changed-files.json", "files/patch.diff"])
+  const artifactId = `artifact-bundle-sha256-${contentDigest}`
+  const artifactBundle = { kind: "artifact-bundle" as const, id: artifactId, digest: { algorithm: "sha256" as const, value: contentDigest } }
+
+  await writeJson(join(directory, "files/preview-evidence.json"), previewEvidenceFixture(createdAt, runtime, artifactBundle))
+  const previewSessionEvidence = previewSessionEvidenceFixture(createdAt, artifactId, contentDigest, runtime)
+  const previewSessionEvidenceText = `${JSON.stringify(previewSessionEvidence, null, 2)}\n`
+  await writeFile(join(directory, "files/preview-session-evidence.json"), previewSessionEvidenceText)
+  await writeJson(join(directory, "files/diagnostics.json"), { schema: "wp-codebox/artifact-diagnostics/v1", status: "clean", summary: { total: 0, error: 0, warning: 0, notice: 0, info: 0 }, diagnostics: [] })
+  await writeFile(join(directory, "files/runtime.log"), "runtime completed\n")
+  await writeFile(join(directory, "files/browser/network.jsonl"), `${JSON.stringify({ type: "response", url: "https://example.com/", resourceType: "document", status: 200 })}\n`)
+  await writeFile(join(directory, "files/browser/console.jsonl"), "")
+  await writeFile(join(directory, "files/browser/errors.jsonl"), "")
+  await writeJson(join(directory, "files/browser/summary.json"), { schema: "wp-codebox/browser-probe/v1", finalUrl: "https://example.com/", errors: 0, assertions: { total: 1, passed: 1, failed: 0 } })
+  await writeJson(join(directory, "files/test-results.json"), { schema: "wp-codebox/test-results/v1", status: "passed" })
+  await writeJson(join(directory, "files/runtime-episode-trace.json"), runtimeEpisodeTraceFixture(createdAt, runtime, artifactId, contentDigest))
+  await writeFile(join(directory, "files/runtime-episode.jsonl"), `${JSON.stringify({ type: "episode.artifacts", id: artifactId })}\n`)
+
+  const runtimeReferenceManifest = buildRuntimeReferenceManifest({ createdAt, runtime, artifactBundle, files: [] })
+  const runtimeReferenceManifestText = `${JSON.stringify(runtimeReferenceManifest, null, 2)}\n`
+  await writeFile(join(directory, "files/runtime-reference-manifest.json"), runtimeReferenceManifestText)
+  const runtimeReferenceManifestFile = fileRef("files/runtime-reference-manifest.json", "runtime-reference-manifest", "application/json", artifactFileDigest(runtimeReferenceManifestText).value)
+  const runtimeReplayIndex = buildRuntimeReplayReferenceIndex({ createdAt, runtime, artifactBundle, files: [runtimeReferenceManifestFile], runtimeReferenceManifest: runtimeReferenceManifestFile })
+  await writeJson(join(directory, "files/runtime-replay-index.json"), runtimeReplayIndex)
+
+  const review = {
+    schema: "wp-codebox/artifact-review/v1",
+    artifactId,
+    createdAt,
+    summary: "Transfer proof fixture.",
+    evidence: {
+      patch: "files/patch.diff",
+      patchSha256: createHash("sha256").update(patch).digest("hex"),
+      artifactContentDigest: contentDigest,
+      changedFiles: "files/changed-files.json",
+      diagnostics: "files/diagnostics.json",
+      runtimeEpisodeTrace: "files/runtime-episode-trace.json",
+      runtimeReferenceManifest: "files/runtime-reference-manifest.json",
+      runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
+      previewEvidence: "files/preview-evidence.json",
+      previewSessionEvidence: "files/preview-session-evidence.json",
+    },
+    changedFiles: [{ path: "/wordpress/wp-content/plugins/example/file.txt", status: "added" }],
+    browser: {
+      probes: [{ url: "https://example.com/", requestedUrl: "https://example.com/", finalUrl: "https://example.com/", errors: 0, network: "files/browser/network.jsonl", console: "files/browser/console.jsonl", errorsFile: "files/browser/errors.jsonl", summaryFile: "files/browser/summary.json", assertions: { total: 1, passed: 1, failed: 0 } }],
+    },
+  }
+  await writeJson(join(directory, "files/review.json"), review)
+
+  await writeJson(join(directory, "metadata.json"), {
+    id: artifactId,
+    contentDigest: { algorithm: "sha256", inputs: ["files/changed-files.json", "files/patch.diff"], value: contentDigest },
+    artifacts: {
+      changedFiles: "files/changed-files.json",
+      patch: "files/patch.diff",
+      review: "files/review.json",
+      diagnostics: "files/diagnostics.json",
+      runtimeEpisodeTrace: "files/runtime-episode-trace.json",
+      runtimeEpisodeEvents: "files/runtime-episode.jsonl",
+      runtimeReferenceManifest: "files/runtime-reference-manifest.json",
+      runtimeReplayReferenceIndex: "files/runtime-replay-index.json",
+      previewEvidence: "files/preview-evidence.json",
+      previewSessionEvidence: "files/preview-session-evidence.json",
+      browser: "files/browser/summary.json",
+    },
+    previewSessionEvidence: { path: "files/preview-session-evidence.json", kind: "preview-session-evidence", contentType: "application/json", sha256: artifactFileDigest(previewSessionEvidenceText) },
+  })
+
+  const manifest = manifestFixture(createdAt, runtime, artifactId, contentDigest)
+  await attachManifestFileHashes(directory, manifest)
+  await writeJson(join(directory, "manifest.json"), manifest)
+}
+
+function manifestFixture(createdAt: string, runtime: RuntimeInfo, artifactId: string, contentDigest: string): ArtifactManifest {
+  return {
+    id: artifactId,
+    contentDigest: { algorithm: "sha256", inputs: ["files/changed-files.json", "files/patch.diff"], value: contentDigest },
+    createdAt,
+    runtime,
+    files: [
+      fileFixture("manifest.json", "manifest", "application/json"),
+      fileFixture("metadata.json", "metadata", "application/json"),
+      fileFixture("files/changed-files.json", "changed-files", "application/json"),
+      fileFixture("files/patch.diff", "patch", "text/x-diff"),
+      fileFixture("files/review.json", "review", "application/json"),
+      fileFixture("files/test-results.json", "test-results", "application/json"),
+      fileFixture("files/diagnostics.json", "diagnostics", "application/json"),
+      fileFixture("files/runtime.log", "log", "text/plain"),
+      fileFixture("files/runtime-episode-trace.json", "runtime-episode-trace", "application/json"),
+      fileFixture("files/runtime-episode.jsonl", "runtime-episode-events", "application/x-ndjson"),
+      fileFixture("files/runtime-reference-manifest.json", "runtime-reference-manifest", "application/json"),
+      fileFixture("files/runtime-replay-index.json", "runtime-replay-index", "application/json"),
+      fileFixture("files/preview-evidence.json", "preview-evidence", "application/json"),
+      fileFixture("files/preview-session-evidence.json", "preview-session-evidence", "application/json"),
+      fileFixture("files/browser/network.jsonl", "browser-network", "application/x-ndjson"),
+      fileFixture("files/browser/console.jsonl", "browser-console", "application/x-ndjson"),
+      fileFixture("files/browser/errors.jsonl", "browser-errors", "application/x-ndjson"),
+      fileFixture("files/browser/summary.json", "browser-summary", "application/json"),
+    ],
+  }
+}
+
+function runtimeFixture(createdAt: string): RuntimeInfo {
+  return {
+    id: "runtime-fixture",
+    backend: "wordpress-playground",
+    status: "destroyed",
+    environment: { kind: "wordpress", version: "latest" },
+    createdAt,
+  }
+}
+
+function previewEvidenceFixture(createdAt: string, runtime: RuntimeInfo, artifactBundleRef: { kind: "artifact-bundle"; id: string; digest: { algorithm: "sha256"; value: string } }) {
+  return {
+    schema: "wp-codebox/preview-evidence/v1",
+    createdAt,
+    session: { kind: "browser-playground-session", id: "session-fixture", runtimeId: runtime.id, backend: runtime.backend, environment: { kind: "wordpress", name: "WordPress", version: "latest" } },
+    run: { ...artifactBundleRef, path: "manifest.json" },
+    preview: { status: "available", lifecycle: "held-after-run", source: "public-url-override", url: { kind: "preview-url", availability: "reviewer-safe", reviewerSafe: true, url: "https://example.com/" } },
+    readiness: { ready: true, status: "ready", events: [] },
+    components: { runtime: { backend: runtime.backend, wordpressVersion: "latest" } },
+  }
+}
+
+function previewSessionEvidenceFixture(createdAt: string, artifactId: string, contentDigest: string, runtime: RuntimeInfo) {
+  return {
+    schema: "wp-codebox/preview-session-evidence/v1",
+    createdAt,
+    artifact: { id: artifactId, contentDigest: { algorithm: "sha256", value: contentDigest } },
+    session: { id: "session-fixture", runtimeId: runtime.id, backend: runtime.backend },
+    preview: { status: "available", url: { kind: "preview-url", availability: "reviewer-safe", reviewerSafe: true, url: "https://example.com/" } },
+    artifacts: { manifest: "manifest.json", review: "files/review.json", runtimeLog: "files/runtime.log", runtimeReferenceManifest: "files/runtime-reference-manifest.json", runtimeReplayReferenceIndex: "files/runtime-replay-index.json", browserSummary: "files/browser/summary.json" },
+    browser: { probes: [{ finalUrl: "https://example.com/", errors: 0, summaryFile: "files/browser/summary.json" }] },
+  }
+}
+
+function runtimeEpisodeTraceFixture(createdAt: string, runtime: RuntimeInfo, artifactId: string, contentDigest: string) {
+  return {
+    schema: "wp-codebox/runtime-episode-trace/v1",
+    version: 1,
+    id: "trace-runtime-fixture",
+    createdAt,
+    runtime,
+    reset: { id: "runtime-fixture:reset:0", runtime, observations: [], observationRefs: [] },
+    steps: [],
+    snapshots: [],
+    artifactRef: { kind: "artifact-bundle", id: artifactId, artifactId, path: "manifest.json", digest: { algorithm: "sha256", value: contentDigest } },
+  }
+}
+
+function fileFixture(path: string, kind: string, contentType: string): ArtifactManifestFile {
+  return { path, kind, contentType, sha256: { algorithm: "sha256", value: "0".repeat(64) } }
+}
+
+function fileRef(path: string, kind: string, contentType: string, sha256: string): ArtifactManifestFile {
+  return { path, kind, contentType, sha256: { algorithm: "sha256", value: sha256 } }
+}
+
+async function rewriteManifestHashes(directory: string): Promise<void> {
+  const manifest = JSON.parse(await readText(join(directory, "manifest.json"))) as ArtifactManifest
+  await attachManifestFileHashes(directory, manifest)
+  await writeJson(join(directory, "manifest.json"), manifest)
+}
+
+async function attachManifestFileHashes(directory: string, manifest: ArtifactManifest): Promise<void> {
+  for (const file of manifest.files) {
+    if (file.path !== "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
+    }
+  }
+  for (const file of manifest.files) {
+    if (file.path === "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
+    }
+  }
+}
+
+async function copyBundle(source: string, target: string): Promise<string> {
+  await cp(source, target, { recursive: true })
+  return target
+}
+
+async function readText(path: string): Promise<string> {
+  return readFile(path, "utf8")
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}


### PR DESCRIPTION
## Summary
- Add a stricter transfer proof bundle verifier for reviewer-facing WP Codebox evidence.
- Reject localhost/local/private URLs, host-local filesystem paths, and secret-shaped values in reviewer-facing evidence.
- Add machine-readable transfer probe diagnostics for page availability, broken links/missing media, block validation, plugin/runtime diagnostics, parity hooks, and browser/runtime errors.

Closes #640.
Closes #641.

## Checks
- `npm run build`
- `npm run transfer-proof-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `npm run discovery-command-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the verifier/probe implementation, CLI wiring, and smoke fixtures; Chris remains responsible for review and validation.