### PR TITLE
Add recipe preview routing for browser probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "preview-port-smoke": "tsx scripts/preview-port-smoke.ts",
     "preview-options-contract-smoke": "tsx scripts/preview-options-contract-smoke.ts",
     "preview-public-url-canonical-smoke": "tsx scripts/preview-public-url-canonical-smoke.ts",
+    "recipe-preview-routing-browser-probe-smoke": "tsx scripts/recipe-preview-routing-browser-probe-smoke.ts",
     "preview-response-body-smoke": "tsx scripts/preview-response-body-smoke.ts",
     "browser-startup-progress-smoke": "tsx scripts/browser-startup-progress-smoke.ts",
     "recipe-browser-probe-liveness-smoke": "tsx scripts/recipe-browser-probe-liveness-smoke.ts",

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat, writeFile } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
-import { RuntimeRunRegistry, artifactBundleRunRef, artifactManifestFile, createBenchResultsJsonSchema, createRuntimeRunId, defaultRunRegistryDirectory, createRuntime, refreshArtifactManifestFileSha256s, stripUndefined, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimeInfo, type RuntimeRunRecord, type WorkspaceRecipe, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { RuntimeRunRegistry, artifactBundleRunRef, artifactManifestFile, createBenchResultsJsonSchema, createRuntimeRunId, defaultRunRegistryDirectory, createRuntime, refreshArtifactManifestFileSha256s, stripUndefined, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimeInfo, type RuntimePreviewSpec, type RuntimeRunRecord, type WorkspaceRecipe, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -584,6 +584,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       blueprint: recipeBlueprintWithBootActivePlugins(recipe.runtime?.blueprint, extraPlugins),
       assets: resolveRecipeRuntimeAssets(recipe, recipeDirectory),
     }
+    const effectivePreview = effectiveRecipePreview(recipe.runtime?.preview, options)
     const runtimeCreateSpec = {
       backend: recipe.runtime?.backend ?? "wordpress-playground",
       environment: runtimeEnvironment,
@@ -593,9 +594,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       metadata: {
         ...runtimeMetadata(configuredArtifactsDirectory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
         run: { runId: runRecord.runId, registryDirectory: runRegistry.directory },
-        ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, stagedFiles, overlays, backendPackage, options.previewPublicUrl, options.previewPort, options.previewBind),
+        ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, stagedFiles, overlays, backendPackage, effectivePreview),
       },
-      preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
+      preview: previewSpec(effectivePreview.publicUrl, effectivePreview.port, effectivePreview.bind, effectivePreview.siteUrl),
     }
     try {
       const startupStartedAtMs = Date.now()
@@ -1626,7 +1627,16 @@ function recipeStepMetadata(step: WorkspaceRecipe["workflow"]["steps"][number]):
   return { command: step.command, args: step.args ?? [] }
 }
 
-function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[], overlays: PreparedRuntimeOverlay[], backendPackage: PreparedRuntimeBackendPackage | undefined, previewPublicUrl: string | undefined, previewPort: number | undefined, previewBind: string | undefined): Record<string, unknown> {
+function effectiveRecipePreview(recipePreview: RuntimePreviewSpec | undefined, options: RecipeRunOptions): RuntimePreviewSpec {
+  return stripUndefined({
+    publicUrl: options.previewPublicUrl ?? recipePreview?.publicUrl,
+    siteUrl: recipePreview?.siteUrl,
+    port: options.previewPort ?? recipePreview?.port,
+    bind: options.previewBind ?? recipePreview?.bind,
+  })
+}
+
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[], overlays: PreparedRuntimeOverlay[], backendPackage: PreparedRuntimeBackendPackage | undefined, preview: RuntimePreviewSpec): Record<string, unknown> {
   const extraPluginMetadata = extraPlugins.map((plugin) => ({
     source: plugin.source,
     slug: plugin.slug,
@@ -1665,9 +1675,12 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
     task: {
       kind: "recipe-run",
       recipePath,
-      previewPublicUrl,
-      previewPort,
-      previewBind,
+      preview: stripUndefined({
+        requested: recipe.runtime?.preview,
+        effective: preview,
+        source: previewMetadataSource(recipe.runtime?.preview, preview),
+        cliOverrides: previewCliOverrides(recipe.runtime?.preview, preview),
+      }),
       workflow,
       inputs: {
         workspaces: recipe.inputs?.workspaces ?? [],
@@ -1703,6 +1716,23 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
     })),
     ...(backendPackage ? { preparedRuntimeBackend: backendPackage.provenance } : {}),
   }
+}
+
+function previewCliOverrides(recipePreview: RuntimePreviewSpec | undefined, effectivePreview: RuntimePreviewSpec): RuntimePreviewSpec | undefined {
+  const overrides = stripUndefined({
+    publicUrl: recipePreview?.publicUrl !== effectivePreview.publicUrl ? effectivePreview.publicUrl : undefined,
+    port: recipePreview?.port !== effectivePreview.port ? effectivePreview.port : undefined,
+    bind: recipePreview?.bind !== effectivePreview.bind ? effectivePreview.bind : undefined,
+  })
+  return Object.keys(overrides).length > 0 ? overrides : undefined
+}
+
+function previewMetadataSource(recipePreview: RuntimePreviewSpec | undefined, effectivePreview: RuntimePreviewSpec): string | undefined {
+  if (Object.keys(effectivePreview).length === 0) {
+    return undefined
+  }
+
+  return recipePreview ? "recipe-runtime-preview" : "cli-preview-options"
 }
 
 function recipeRunStagedFile(stagedFile: PreparedStagedFile): RecipeRunStagedFile {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,6 @@
 import { stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { ALLOW_NETWORK_DOWNLOADS_ENV, REQUIRE_SOURCE_SHA256_ENV, allowedDownloadHosts, isSha256, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile, sourceSha256Required } from "./recipe-sources.js"
 
 export interface RecipeValidationIssue {
@@ -52,6 +52,7 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   validateRecipeRuntimeBackendPackage(recipe.runtime?.backendPackage, recipePath)
   validateRecipeRuntimeOverlays(recipe.runtime?.overlays, recipePath)
   validateRecipeRuntimeAssets(recipe.runtime?.assets, recipePath)
+  validateRecipeRuntimePreview(recipe.runtime?.preview, recipePath)
   validateRecipeMounts(recipe.inputs?.mounts, "mounts", recipePath)
 
   const workspaces = recipe.inputs?.workspaces ?? []
@@ -161,6 +162,50 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   }
 
   return recipe
+}
+
+function validateRecipeRuntimePreview(preview: RuntimePreviewSpec | undefined, recipePath: string): void {
+  if (preview === undefined) {
+    return
+  }
+
+  if (!preview || typeof preview !== "object" || Array.isArray(preview)) {
+    throw new Error(`Recipe runtime preview must be an object: ${recipePath}`)
+  }
+
+  for (const key of ["publicUrl", "siteUrl"] as const) {
+    if (preview[key] !== undefined) {
+      if (typeof preview[key] !== "string") {
+        throw new Error(`Recipe runtime preview ${key} must be a string: ${recipePath}`)
+      }
+      validatePreviewHttpUrl(preview[key], `Recipe runtime preview ${key}`, recipePath)
+    }
+  }
+
+  if (preview.port !== undefined && (!Number.isSafeInteger(preview.port) || preview.port < 1 || preview.port > 65535)) {
+    throw new Error(`Recipe runtime preview port must be an integer between 1 and 65535: ${recipePath}`)
+  }
+
+  if (preview.bind !== undefined && (typeof preview.bind !== "string" || preview.bind.trim() === "" || /[/\\\s]/.test(preview.bind))) {
+    throw new Error(`Recipe runtime preview bind must be a hostname or IP address: ${recipePath}`)
+  }
+
+  if (preview.bind !== undefined && preview.port === undefined) {
+    throw new Error(`Recipe runtime preview bind requires port: ${recipePath}`)
+  }
+}
+
+function validatePreviewHttpUrl(value: string, label: string, recipePath: string): void {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${label} must be an http or https URL with a hostname: ${recipePath}`)
+  }
+
+  if ((url.protocol !== "http:" && url.protocol !== "https:") || !url.hostname) {
+    throw new Error(`${label} must be an http or https URL with a hostname: ${recipePath}`)
+  }
 }
 
 function validateRecipeRuntimeAssets(assets: RuntimeAssetSpec | undefined, recipePath: string): void {

--- a/packages/cli/src/runtime-command-wrappers.ts
+++ b/packages/cli/src/runtime-command-wrappers.ts
@@ -99,12 +99,12 @@ export function runtimeMetadata(artifactsDirectory: string | undefined, wpVersio
   }
 }
 
-export function previewSpec(publicUrl: string | undefined, port: number | undefined, bind: string | undefined): { publicUrl?: string; siteUrl?: string; port?: number; bind?: string } | undefined {
+export function previewSpec(publicUrl: string | undefined, port: number | undefined, bind: string | undefined, siteUrl?: string): { publicUrl?: string; siteUrl?: string; port?: number; bind?: string } | undefined {
   if (bind && port === undefined) {
     throw new Error("--preview-bind requires --preview-port because upstream Playground does not expose bind-host control yet")
   }
 
-  if (!publicUrl && port === undefined && !bind) {
+  if (!publicUrl && !siteUrl && port === undefined && !bind) {
     return undefined
   }
 
@@ -112,7 +112,7 @@ export function previewSpec(publicUrl: string | undefined, port: number | undefi
 
   return stripUndefined({
     publicUrl,
-    siteUrl: publicUrl ?? localUrl,
+    siteUrl: siteUrl ?? publicUrl ?? localUrl,
     port,
     bind,
   })

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -98,6 +98,9 @@ export interface ArtifactReviewBrowserSummary {
   probes: Array<{
     url: string
     requestedUrl?: string
+    localPreviewOrigin?: string
+    requestedPreviewOrigin?: string
+    effectivePreviewOrigin?: string
     finalUrl?: string
     viewport?: {
       width: number

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -26,6 +26,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           name: { type: "string" },
           wp: { type: "string" },
           blueprint: { type: "object" },
+          preview: { $ref: "#/$defs/runtimePreview" },
           assets: { $ref: "#/$defs/runtimeAssets" },
           backendPackage: { $ref: "#/$defs/runtimeBackendPackage" },
           stack: { $ref: "#/$defs/runtimeStack" },
@@ -143,6 +144,31 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
       metadata: {
         type: "object",
         additionalProperties: true,
+      },
+      runtimePreview: {
+        type: "object",
+        additionalProperties: false,
+        description: "Recipe-declared preview defaults. CLI preview flags override these values for a run.",
+        properties: {
+          publicUrl: {
+            type: "string",
+            description: "Public http/https preview URL used for metadata and relative browser-probe URL resolution.",
+          },
+          siteUrl: {
+            type: "string",
+            description: "Optional WordPress site URL passed to the sandbox. Defaults to publicUrl or the local preview URL.",
+          },
+          port: {
+            type: "integer",
+            minimum: 1,
+            maximum: 65535,
+            description: "Optional fixed local preview proxy port.",
+          },
+          bind: {
+            type: "string",
+            description: "Optional fixed-port preview proxy bind host or IP. Requires port.",
+          },
+        },
       },
       runtimeAssets: {
         type: "object",

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -229,6 +229,7 @@ export interface WorkspaceRecipe {
     name?: string
     wp?: string
     blueprint?: unknown
+    preview?: RuntimePreviewSpec
     assets?: RuntimeAssetSpec
     backendPackage?: WorkspaceRecipeRuntimeBackendPackage
     stack?: WorkspaceRecipeRuntimeStack

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -5,6 +5,9 @@ import type { Request } from "playwright"
 export interface BrowserProbeArtifact {
   requestedUrl: string
   url: string
+  localPreviewOrigin?: string
+  requestedPreviewOrigin?: string
+  effectivePreviewOrigin?: string
   prePageScript?: BrowserProbeScriptMetadata
   files: {
     actions?: string
@@ -265,6 +268,9 @@ export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactRe
     probes: probes.map((probe) => ({
       url: probe.url,
       requestedUrl: probe.requestedUrl,
+      localPreviewOrigin: probe.localPreviewOrigin,
+      requestedPreviewOrigin: probe.requestedPreviewOrigin,
+      effectivePreviewOrigin: probe.effectivePreviewOrigin,
       finalUrl: probe.summary.finalUrl,
       viewport: probe.summary.viewport,
       replayability: probe.summary.replayability,

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -30,11 +30,13 @@ export function isBrowserCommandArtifactError(error: unknown): error is BrowserC
 export async function runBrowserProbeCommand({
   artifactRoot,
   command = "wordpress.browser-probe",
+  runtimeSpec,
   server,
   spec,
 }: {
   artifactRoot: string
   command?: string
+  runtimeSpec: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
@@ -71,7 +73,8 @@ export async function runBrowserProbeCommand({
   const capturesErrorsForAssertions = assertions.some((assertion) => assertion.type === "no-page-errors" || assertion.type === "no-errors")
   const capturesBrowserMetrics = capture.has("performance") || capture.has("memory")
   const prePageScriptMetadata = prePageScript ? browserProbeScriptMetadata(prePageScript) : undefined
-  const targetUrl = resolveBrowserProbeUrl(urlArg, server.serverUrl)
+  const previewOrigins = browserProbePreviewOrigins(runtimeSpec, server.serverUrl)
+  const targetUrl = resolveBrowserProbeUrl(urlArg, previewOrigins.effectivePreviewOrigin)
   const browserDirectory = join(artifactRoot, "files", "browser")
   await mkdir(browserDirectory, { recursive: true })
 
@@ -253,6 +256,7 @@ export async function runBrowserProbeCommand({
     artifact = {
       requestedUrl: targetUrl,
       url: targetUrl,
+      ...previewOrigins,
       ...(prePageScriptMetadata ? { prePageScript: prePageScriptMetadata } : {}),
       files: {
         ...(capture.has("console") ? { console: "files/browser/console.jsonl" } : {}),
@@ -285,6 +289,7 @@ export async function runBrowserProbeCommand({
     await writeFile(summaryPath, `${JSON.stringify({
       schema: "wp-codebox/browser-probe/v1",
       requestedUrl: targetUrl,
+      ...previewOrigins,
       finalUrl,
       waitFor,
       durationMs,
@@ -317,6 +322,7 @@ export async function runBrowserProbeCommand({
     output: `${JSON.stringify({
       command,
       requestedUrl: targetUrl,
+      ...previewOrigins,
       finalUrl: artifact.summary.finalUrl ?? targetUrl,
       files: artifact.files,
       summary: artifact.summary,
@@ -333,6 +339,7 @@ function browserProbeScriptMetadata(source: string): BrowserProbeScriptMetadata 
 
 export async function runHtmlCaptureCommand(input: {
   artifactRoot: string
+  runtimeSpec: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
@@ -1251,6 +1258,14 @@ echo wp_json_encode( $cookies );
 
 function now(): string {
   return new Date().toISOString()
+}
+
+function browserProbePreviewOrigins(runtimeSpec: RuntimeCreateSpec, localPreviewOrigin: string): { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string } {
+  return {
+    localPreviewOrigin,
+    requestedPreviewOrigin: runtimeSpec.preview?.publicUrl,
+    effectivePreviewOrigin: runtimeSpec.preview?.publicUrl ?? localPreviewOrigin,
+  }
 }
 
 function resolveBrowserProbeUrl(pathOrUrl: string, baseUrl: string): string {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -429,7 +429,7 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     let result: Awaited<ReturnType<typeof runBrowserProbeCommand>>
     try {
-      result = await runBrowserProbeCommand({ artifactRoot: this.artifactRoot, server, spec })
+      result = await runBrowserProbeCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, server, spec })
     } catch (error) {
       if (isBrowserCommandArtifactError(error)) {
         this.browserProbes.push(error.artifact)
@@ -442,7 +442,7 @@ class PlaygroundRuntime implements Runtime {
 
   async runHtmlCapture(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
-    const result = await runHtmlCaptureCommand({ artifactRoot: this.artifactRoot, server, spec })
+    const result = await runHtmlCaptureCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, server, spec })
     this.browserProbes.push(result.artifact)
     return result.output
   }

--- a/scripts/recipe-preview-routing-browser-probe-smoke.ts
+++ b/scripts/recipe-preview-routing-browser-probe-smoke.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { createServer, type Server } from "node:net"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-recipe-preview-routing-"))
+
+try {
+  const recipePort = await reserveFreePort()
+  const recipePublicUrl = `http://127.0.0.1:${recipePort}/public-route/`
+  const recipePath = await writeRecipe("recipe-preview.json", recipePort, recipePublicUrl)
+  const recipeOutput = await runCliJson(["recipe-run", "--recipe", recipePath, "--json"])
+
+  assert.equal(recipeOutput.success, true, recipeOutput.error?.message ?? "recipe-run failed")
+  const recipeSummary = await browserSummary(recipeOutput)
+  assert.equal(recipeSummary.requestedUrl, `${recipePublicUrl}relative-probe`)
+  assert.equal(recipeSummary.localPreviewOrigin.startsWith("http://127.0.0.1:"), true)
+  assert.equal(recipeSummary.requestedPreviewOrigin, recipePublicUrl)
+  assert.equal(recipeSummary.effectivePreviewOrigin, recipePublicUrl)
+  assert.equal(recipeOutput.artifacts.preview.url, recipePublicUrl)
+  assert.equal(recipeOutput.artifacts.preview.localUrl.startsWith("http://127.0.0.1:"), true)
+
+  const recipeReview = await review(recipeOutput)
+  assert.equal(recipeReview.browser?.probes?.[0]?.requestedUrl, `${recipePublicUrl}relative-probe`)
+  assert.equal(recipeReview.browser?.probes?.[0]?.localPreviewOrigin?.startsWith("http://127.0.0.1:"), true)
+  assert.equal(recipeReview.browser?.probes?.[0]?.requestedPreviewOrigin, recipePublicUrl)
+  assert.equal(recipeReview.browser?.probes?.[0]?.effectivePreviewOrigin, recipePublicUrl)
+
+  const overridePort = await reserveFreePort()
+  const staleRecipePublicUrl = "https://stale-preview.example.test/"
+  const overridePublicUrl = `http://127.0.0.1:${overridePort}/cli-route/`
+  const overrideRecipePath = await writeRecipe("recipe-preview-override.json", overridePort, staleRecipePublicUrl)
+  const overrideOutput = await runCliJson([
+    "recipe-run",
+    "--recipe",
+    overrideRecipePath,
+    "--preview-public-url",
+    overridePublicUrl,
+    "--json",
+  ])
+
+  assert.equal(overrideOutput.success, true, overrideOutput.error?.message ?? "recipe-run with CLI preview override failed")
+  const overrideSummary = await browserSummary(overrideOutput)
+  assert.equal(overrideSummary.requestedUrl, `${overridePublicUrl}relative-probe`)
+  assert.equal(overrideSummary.requestedPreviewOrigin, overridePublicUrl)
+  assert.equal(overrideSummary.effectivePreviewOrigin, overridePublicUrl)
+  assert.equal(overrideOutput.artifacts.preview.url, overridePublicUrl)
+
+  const overrideMetadata = JSON.parse(await readFile(overrideOutput.artifacts.metadataPath, "utf8")) as { provenance?: { task?: { preview?: { requested?: { publicUrl?: string }; effective?: { publicUrl?: string }; cliOverrides?: { publicUrl?: string } } } } }
+  assert.equal(overrideMetadata.provenance?.task?.preview?.requested?.publicUrl, staleRecipePublicUrl)
+  assert.equal(overrideMetadata.provenance?.task?.preview?.effective?.publicUrl, overridePublicUrl)
+  assert.equal(overrideMetadata.provenance?.task?.preview?.cliOverrides?.publicUrl, overridePublicUrl)
+
+  console.log("Recipe preview routing browser probe smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function writeRecipe(name: string, port: number, publicUrl: string): Promise<string> {
+  const recipePath = join(workspace, name)
+  const artifactsDirectory = join(workspace, `${name}-artifacts`)
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: {
+      preview: {
+        port,
+        publicUrl,
+      },
+    },
+    workflow: {
+      steps: [
+        {
+          command: "wordpress.browser-probe",
+          args: [
+            "url=relative-probe",
+            "wait-for=domcontentloaded",
+            "capture=html",
+          ],
+        },
+      ],
+    },
+    artifacts: {
+      directory: artifactsDirectory,
+    },
+  }, null, 2)}\n`)
+
+  return recipePath
+}
+
+async function browserSummary(output: { artifacts?: { directory?: string } }): Promise<{ requestedUrl: string; localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string }> {
+  assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+  return JSON.parse(await readFile(join(output.artifacts.directory, "files", "browser", "summary.json"), "utf8"))
+}
+
+async function review(output: { artifacts?: { directory?: string } }): Promise<{ browser?: { probes?: Array<{ requestedUrl?: string; localPreviewOrigin?: string; requestedPreviewOrigin?: string; effectivePreviewOrigin?: string }> } }> {
+  assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+  return JSON.parse(await readFile(join(output.artifacts.directory, "files", "review.json"), "utf8"))
+}
+
+async function runCliJson(args: string[]): Promise<any> {
+  const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", ...args], {
+    cwd: repoRoot,
+    maxBuffer: 1024 * 1024 * 10,
+  })
+  return JSON.parse(stdout)
+}
+
+async function reserveFreePort(): Promise<number> {
+  const server = await listenOnPort(0)
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const port = address.port
+  await closeServer(server)
+  return port
+}
+
+async function listenOnPort(port: number): Promise<Server> {
+  const server = createServer()
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen)
+    server.listen(port, "127.0.0.1", () => resolveListen())
+  })
+  return server
+}
+
+async function closeServer(server: Server | undefined): Promise<void> {
+  if (!server?.listening) {
+    return
+  }
+
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose())
+  })
+}


### PR DESCRIPTION
## Summary
- Adds generic `runtime.preview` support to workspace recipe types, schema, and validation.
- Threads recipe preview defaults into `recipe-run` runtime creation while preserving CLI preview flags as run-level overrides.
- Resolves relative `wordpress.browser-probe` URLs against the effective public preview origin when configured and records local/requested/effective preview origin metadata in browser artifacts and review summaries.

Closes #651.

## Verification
- `npm run build`
- `npm run recipe-preview-routing-browser-probe-smoke`
- `npm run wordpress-recipe-builders-smoke`
- `npm run preview-port-smoke`
- `npm run browser-probe-artifact-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the recipe preview routing changes, focused smoke coverage, and verification. Chris directed the issue scope and constraints.