### PR TITLE
Add browser probe profile matrix support

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",
     "browser-probe-assertions-smoke": "tsx scripts/browser-probe-assertions-smoke.ts",
     "browser-probe-context-smoke": "tsx scripts/browser-probe-context-smoke.ts",
+    "browser-probe-profile-matrix-smoke": "tsx scripts/browser-probe-profile-matrix-smoke.ts",
     "browser-probe-pre-page-script-smoke": "tsx scripts/browser-probe-pre-page-script-smoke.ts",
     "browser-actions-artifact-smoke": "tsx scripts/browser-actions-artifact-smoke.ts",
     "browser-scenario-artifact-smoke": "tsx scripts/browser-scenario-artifact-smoke.ts",

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -937,6 +937,25 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
       addIssue("invalid-reset-between", `${path}.args`, "wordpress.browser-probe reset-between must be none, reload, or new-page.")
     }
 
+    const profiles = recipeStepArgValue(step.args ?? [], "profiles")
+    if (profiles) {
+      for (const profile of profiles.split(",").map((value) => value.trim()).filter(Boolean)) {
+        if (!["desktop-chrome", "mobile-chrome", "desktop-webkit", "mobile-webkit"].includes(profile)) {
+          addIssue("invalid-profile", `${path}.args`, `wordpress.browser-probe profile is unsupported: ${profile}`)
+        }
+      }
+    }
+
+    const browser = recipeStepArgValue(step.args ?? [], "browser")
+    if (browser && !["chromium", "webkit"].includes(browser)) {
+      addIssue("invalid-browser", `${path}.args`, "wordpress.browser-probe browser must be chromium or webkit.")
+    }
+
+    const viewport = recipeStepArgValue(step.args ?? [], "viewport")
+    if (viewport && !/^\d+x\d+$/i.test(viewport)) {
+      addIssue("invalid-viewport", `${path}.args`, "wordpress.browser-probe viewport must use <width>x<height>, for example 390x844.")
+    }
+
     const capture = recipeStepArgValue(step.args ?? [], "capture")
     if (capture) {
       for (const item of capture.split(",").map((value) => value.trim()).filter(Boolean)) {

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -80,17 +80,26 @@ export interface BrowserProbePermissionState {
 
 export interface BrowserProbeContextDetails {
   requested: {
+    browser?: string
     device?: string
     locale?: string
+    permissions?: string[]
+    profile?: string
+    timezone?: string
+    userAgent?: string
     viewport?: {
       width: number
       height: number
     }
   }
   effective: {
+    browser?: string
     device?: string
     locale?: string
+    permissions?: string[]
+    profile?: string
     timezone?: string
+    userAgent?: string
     viewport: BrowserProbeViewport | null
   }
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -15,6 +15,36 @@ import type { PlaygroundCliServer } from "./preview-server.js"
 
 const BROWSER_STEP_DEFAULT_TIMEOUT_MS = 15_000
 const BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS = 120_000
+const BROWSER_PROBE_PROFILE_OVERRIDES = new Set(["browser", "device", "locale", "permissions", "timezone", "user-agent", "viewport"])
+
+interface BrowserProbeProfileDefinition {
+  id: string
+  browser: "chromium" | "webkit"
+  args: string[]
+}
+
+const BROWSER_PROBE_PROFILES: Record<string, BrowserProbeProfileDefinition> = {
+  "desktop-chrome": {
+    id: "desktop-chrome",
+    browser: "chromium",
+    args: ["browser=chromium", "viewport=1280x720"],
+  },
+  "mobile-chrome": {
+    id: "mobile-chrome",
+    browser: "chromium",
+    args: ["browser=chromium", "device=Pixel 5"],
+  },
+  "desktop-webkit": {
+    id: "desktop-webkit",
+    browser: "webkit",
+    args: ["browser=webkit", "viewport=1280x720"],
+  },
+  "mobile-webkit": {
+    id: "mobile-webkit",
+    browser: "webkit",
+    args: ["browser=webkit", "device=iPhone 13"],
+  },
+}
 
 export class BrowserCommandArtifactError extends Error {
   constructor(message: string, readonly artifact: BrowserProbeArtifact) {
@@ -39,6 +69,70 @@ export async function runBrowserProbeCommand({
   runtimeSpec: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
+}): Promise<{ artifact: BrowserProbeArtifact; artifacts?: BrowserProbeArtifact[]; output: string }> {
+  const profileIds = browserProbeProfileIds(spec.args ?? [])
+  if (profileIds.length === 0) {
+    return runSingleBrowserProbeCommand({ artifactRoot, command, runtimeSpec, server, spec, browserFilesDirectory: "files/browser" })
+  }
+
+  const profiles = profileIds.map((profileId) => browserProbeProfile(profileId))
+  for (const profile of profiles) {
+    if (profile.browser !== "chromium") {
+      throw new Error(`wordpress.browser-probe profile ${profile.id} requests ${profile.browser}, but this runner currently supports Chromium profiles only. Supported profiles: desktop-chrome, mobile-chrome.`)
+    }
+  }
+
+  const artifacts: BrowserProbeArtifact[] = []
+  const outputs: unknown[] = []
+  for (const profile of profiles) {
+    const result = await runSingleBrowserProbeCommand({
+      artifactRoot,
+      command,
+      runtimeSpec,
+      server,
+      spec: {
+        ...spec,
+        args: browserProbeProfileArgs(spec.args ?? [], profile),
+      },
+      browserFilesDirectory: `files/browser/${profile.id}`,
+      profileId: profile.id,
+    })
+    artifacts.push(result.artifact)
+    outputs.push(JSON.parse(result.output))
+  }
+
+  const artifact = artifacts[0]
+  if (!artifact) {
+    throw new Error("wordpress.browser-probe profiles requires at least one profile")
+  }
+
+  return {
+    artifact,
+    artifacts,
+    output: `${JSON.stringify({
+      command,
+      schema: "wp-codebox/browser-probe-profile-matrix/v1",
+      profiles: outputs,
+    }, null, 2)}\n`,
+  }
+}
+
+async function runSingleBrowserProbeCommand({
+  artifactRoot,
+  command,
+  runtimeSpec,
+  server,
+  spec,
+  browserFilesDirectory,
+  profileId,
+}: {
+  artifactRoot: string
+  command: string
+  runtimeSpec: RuntimeCreateSpec
+  server: PlaygroundCliServer
+  spec: ExecutionSpec
+  browserFilesDirectory: string
+  profileId?: string
 }): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
   const args = spec.args ?? []
   const urlArg = argValue(args, "url")?.trim()
@@ -64,7 +158,7 @@ export async function runBrowserProbeCommand({
   const waitFor = argValue(args, "wait-for")?.trim() || "domcontentloaded"
   const durationMs = durationArg(args, "duration", 0)
   const requestedViewport = viewportArg(args, "viewport")
-  const requestedContext = browserProbeContextRequest(args, requestedViewport)
+  const requestedContext = browserProbeContextRequest(args, requestedViewport, profileId)
   const prePageScript = argValue(args, "pre-page-script")
   const script = argValue(args, "script")
   const failFast = booleanArg(args, "fail-fast", false)
@@ -77,7 +171,7 @@ export async function runBrowserProbeCommand({
   const prePageScriptMetadata = prePageScript ? browserProbeScriptMetadata(prePageScript) : undefined
   const previewOrigins = browserProbePreviewOrigins(runtimeSpec, server.serverUrl)
   const targetUrl = resolveBrowserProbeUrl(urlArg, previewOrigins.effectivePreviewOrigin)
-  const browserDirectory = join(artifactRoot, "files", "browser")
+  const browserDirectory = join(artifactRoot, browserFilesDirectory)
   await mkdir(browserDirectory, { recursive: true })
 
   const consoleMessages: Record<string, unknown>[] = []
@@ -97,6 +191,9 @@ export async function runBrowserProbeCommand({
   const startedAt = now()
   const progress = createBrowserProbeProgressTracker(startedAt, stallTimeoutMs)
   const { chromium, devices } = await import("playwright")
+  if (requestedContext.browser && requestedContext.browser !== "chromium") {
+    throw new Error(`wordpress.browser-probe browser=${requestedContext.browser} is unsupported by this runner; use browser=chromium or a Chromium profile.`)
+  }
   const deviceProfile = requestedContext.device ? devices[requestedContext.device] : undefined
   if (requestedContext.device && !deviceProfile) {
     throw new Error(`wordpress.browser-probe unknown Playwright device profile: ${requestedContext.device}`)
@@ -118,12 +215,17 @@ export async function runBrowserProbeCommand({
   let artifact: BrowserProbeArtifact | undefined
 
   try {
-    context = requestedContext.device || requestedContext.locale
+    context = requestedContext.device || requestedContext.locale || requestedContext.timezone || requestedContext.userAgent || (requestedContext.permissions?.length ?? 0) > 0
       ? await browser.newContext({
         ...(deviceProfile ?? {}),
         ...(requestedContext.locale ? { locale: requestedContext.locale } : {}),
+        ...(requestedContext.timezone ? { timezoneId: requestedContext.timezone } : {}),
+        ...(requestedContext.userAgent ? { userAgent: requestedContext.userAgent } : {}),
       })
       : null
+    if (context && requestedContext.permissions && requestedContext.permissions.length > 0) {
+      await context.grantPermissions(requestedContext.permissions)
+    }
     page = context ? await context.newPage() : await browser.newPage()
     if (requestedViewport) {
       await page.setViewportSize(requestedViewport)
@@ -280,15 +382,15 @@ export async function runBrowserProbeCommand({
       ...previewOrigins,
       ...(prePageScriptMetadata ? { prePageScript: prePageScriptMetadata } : {}),
       files: {
-        ...(capture.has("console") || capturesConsoleForAssertions ? { console: "files/browser/console.jsonl" } : {}),
-        ...(checkpoints.length > 0 ? { checkpoints: "files/browser/checkpoints.jsonl" } : {}),
-        ...(capture.has("errors") || capturesErrorsForAssertions ? { errors: "files/browser/errors.jsonl" } : {}),
-        ...(capture.has("html") ? { html: "files/browser/snapshot.html" } : {}),
-        ...(memoryArtifact ? { memory: "files/browser/memory.json" } : {}),
-        ...(capture.has("network") || capturesNetworkForAssertions ? { network: "files/browser/network.jsonl" } : {}),
-        ...(performanceArtifact ? { performance: "files/browser/performance.json" } : {}),
-        ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
-        summary: "files/browser/summary.json",
+        ...(capture.has("console") || capturesConsoleForAssertions ? { console: `${browserFilesDirectory}/console.jsonl` } : {}),
+        ...(checkpoints.length > 0 ? { checkpoints: `${browserFilesDirectory}/checkpoints.jsonl` } : {}),
+        ...(capture.has("errors") || capturesErrorsForAssertions ? { errors: `${browserFilesDirectory}/errors.jsonl` } : {}),
+        ...(capture.has("html") ? { html: `${browserFilesDirectory}/snapshot.html` } : {}),
+        ...(memoryArtifact ? { memory: `${browserFilesDirectory}/memory.json` } : {}),
+        ...(capture.has("network") || capturesNetworkForAssertions ? { network: `${browserFilesDirectory}/network.jsonl` } : {}),
+        ...(performanceArtifact ? { performance: `${browserFilesDirectory}/performance.json` } : {}),
+        ...(capture.has("screenshot") ? { screenshot: `${browserFilesDirectory}/screenshot.png` } : {}),
+        summary: `${browserFilesDirectory}/summary.json`,
       },
       summary: {
         ...(assertionSummary.total > 0 ? { assertions: assertionSummary } : {}),
@@ -355,6 +457,34 @@ export async function runBrowserProbeCommand({
   }
 }
 
+function browserProbeProfileIds(args: string[]): string[] {
+  const raw = argValue(args, "profiles")?.trim()
+  if (!raw) {
+    return []
+  }
+  return raw.split(",").map((profile) => profile.trim()).filter(Boolean)
+}
+
+function browserProbeProfile(profileId: string): BrowserProbeProfileDefinition {
+  const profile = BROWSER_PROBE_PROFILES[profileId]
+  if (!profile) {
+    throw new Error(`wordpress.browser-probe unknown profile: ${profileId}. Supported profiles: ${Object.keys(BROWSER_PROBE_PROFILES).join(", ")}`)
+  }
+  return profile
+}
+
+function browserProbeProfileArgs(args: string[], profile: BrowserProbeProfileDefinition): string[] {
+  const explicitOverrideKeys = new Set(args.map((arg) => arg.match(/^([^=]+)=/)?.[1]).filter((key): key is string => typeof key === "string" && BROWSER_PROBE_PROFILE_OVERRIDES.has(key)))
+  return [
+    ...args.filter((arg) => !arg.startsWith("profiles=")),
+    `profile=${profile.id}`,
+    ...profile.args.filter((arg) => {
+      const key = arg.match(/^([^=]+)=/)?.[1]
+      return !key || !explicitOverrideKeys.has(key)
+    }),
+  ]
+}
+
 function browserProbeScriptMetadata(source: string): BrowserProbeScriptMetadata {
   return {
     sha256: sha256(Buffer.from(source, "utf8")),
@@ -362,12 +492,21 @@ function browserProbeScriptMetadata(source: string): BrowserProbeScriptMetadata 
   }
 }
 
-function browserProbeContextRequest(args: string[], viewport: { width: number; height: number } | undefined): BrowserProbeContextDetails["requested"] {
+function browserProbeContextRequest(args: string[], viewport: { width: number; height: number } | undefined, profileId?: string): BrowserProbeContextDetails["requested"] {
+  const browser = argValue(args, "browser")?.trim()
   const device = argValue(args, "device")?.trim()
   const locale = argValue(args, "locale")?.trim()
+  const permissions = commaListArg(args, "permissions")
+  const timezone = argValue(args, "timezone")?.trim()
+  const userAgent = argValue(args, "user-agent")?.trim()
   return {
+    ...(browser ? { browser } : {}),
     ...(device ? { device } : {}),
     ...(locale ? { locale } : {}),
+    ...(permissions.length > 0 ? { permissions } : {}),
+    ...(profileId ? { profile: profileId } : {}),
+    ...(timezone ? { timezone } : {}),
+    ...(userAgent ? { userAgent } : {}),
     ...(viewport ? { viewport } : {}),
   }
 }
@@ -381,9 +520,13 @@ async function browserProbeContextDetails(page: import("playwright").Page, reque
   return {
     requested,
     effective: {
+      ...(requested.browser ? { browser: requested.browser } : {}),
       ...(requested.device ? { device: requested.device } : {}),
       ...(effective.locale ? { locale: effective.locale } : {}),
+      ...(requested.permissions ? { permissions: requested.permissions } : {}),
+      ...(requested.profile ? { profile: requested.profile } : {}),
       ...(effective.timezone ? { timezone: effective.timezone } : {}),
+      ...(viewport?.userAgent ? { userAgent: viewport.userAgent } : {}),
       viewport,
     },
   }

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -436,7 +436,7 @@ class PlaygroundRuntime implements Runtime {
       }
       throw error
     }
-    this.browserProbes.push(result.artifact)
+    this.browserProbes.push(...(result.artifacts ?? [result.artifact]))
     return result.output
   }
 

--- a/scripts/browser-probe-profile-matrix-smoke.ts
+++ b/scripts/browser-probe-profile-matrix-smoke.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-browser-profile-matrix-"))
+
+try {
+  const artifacts = join(workspace, "artifacts")
+  const recipePath = join(workspace, "recipe.json")
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: "7.0" },
+    workflow: {
+      steps: [{
+        command: "wordpress.browser-probe",
+        args: [
+          "url=/",
+          "capture=html,screenshot",
+          "profiles=desktop-chrome,mobile-chrome",
+        ],
+      }],
+    },
+    artifacts: {
+      directory: artifacts,
+      verify: false,
+      workspacePolicy: { strict: false, writableRoots: ["."], gitBacked: false },
+    },
+  }, null, 2)}\n`)
+
+  const output = await runRecipe(recipePath, artifacts)
+  assert.equal(output.schema, "wp-codebox/recipe-run/v1")
+  assert.equal(output.success, true, `recipe-run should succeed: ${JSON.stringify(output, null, 2)}`)
+  assert.ok(output.artifacts?.directory, "recipe-run should report artifact directory")
+
+  const artifactDirectory = output.artifacts.directory
+  const desktopSummaryPath = join(artifactDirectory, "files", "browser", "desktop-chrome", "summary.json")
+  const mobileSummaryPath = join(artifactDirectory, "files", "browser", "mobile-chrome", "summary.json")
+  const reviewPath = join(artifactDirectory, "files", "review.json")
+
+  assert.equal(existsSync(desktopSummaryPath), true, "desktop profile summary should exist")
+  assert.equal(existsSync(mobileSummaryPath), true, "mobile profile summary should exist")
+
+  const desktop = JSON.parse(await readFile(desktopSummaryPath, "utf8"))
+  const mobile = JSON.parse(await readFile(mobileSummaryPath, "utf8"))
+  assert.equal(desktop.schema, "wp-codebox/browser-probe/v1")
+  assert.equal(mobile.schema, "wp-codebox/browser-probe/v1")
+  assert.equal(desktop.context?.requested?.profile, "desktop-chrome")
+  assert.equal(desktop.context?.requested?.browser, "chromium")
+  assert.equal(desktop.context?.requested?.viewport?.width, 1280)
+  assert.equal(desktop.context?.effective?.profile, "desktop-chrome")
+  assert.equal(desktop.context?.effective?.browser, "chromium")
+  assert.equal(desktop.viewport?.width, 1280)
+  assert.equal(desktop.files.html, "files/browser/desktop-chrome/snapshot.html")
+  assert.equal(desktop.files.screenshot, "files/browser/desktop-chrome/screenshot.png")
+
+  assert.equal(mobile.context?.requested?.profile, "mobile-chrome")
+  assert.equal(mobile.context?.requested?.browser, "chromium")
+  assert.equal(mobile.context?.requested?.device, "Pixel 5")
+  assert.equal(mobile.context?.effective?.profile, "mobile-chrome")
+  assert.equal(mobile.context?.effective?.browser, "chromium")
+  assert.equal(mobile.context?.effective?.viewport?.isMobile, true)
+  assert.equal(mobile.files.html, "files/browser/mobile-chrome/snapshot.html")
+  assert.equal(mobile.files.screenshot, "files/browser/mobile-chrome/screenshot.png")
+
+  const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ summaryFile?: string; html?: string; screenshot?: string }> } }
+  assert.equal(review.browser?.probes?.length, 2, "review should include both profile probes")
+  assert.ok(review.browser?.probes?.some((probe) => probe.summaryFile === "files/browser/desktop-chrome/summary.json"), "review should include desktop profile summary")
+  assert.ok(review.browser?.probes?.some((probe) => probe.summaryFile === "files/browser/mobile-chrome/summary.json"), "review should include mobile profile summary")
+
+  console.log("Browser probe profile matrix smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function runRecipe(recipePath: string, artifacts: string): Promise<Record<string, any>> {
+  const child = spawn(process.execPath, [
+    "packages/cli/dist/index.js",
+    "recipe-run",
+    "--recipe",
+    recipePath,
+    "--artifacts",
+    artifacts,
+    "--timeout",
+    "120s",
+    "--json",
+  ], {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit) => {
+    child.once("close", (code, signal) => resolveExit({ code, signal }))
+  })
+  assert.equal(exit.signal, null, `recipe-run should not be killed; stdout: ${stdout}; stderr: ${stderr}`)
+  assert.equal(exit.code, 0, `recipe-run should exit cleanly; stdout: ${stdout}; stderr: ${stderr}`)
+
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- Add `wordpress.browser-probe` profile matrix support via `profiles=desktop-chrome,mobile-chrome`, preserving the existing single-profile artifact layout when `profiles` is omitted.
- Record requested/effective browser profile context per profile and store per-profile browser artifacts under `files/browser/<profile>/`.
- Fail unsupported WebKit profiles with a clear Chromium-only diagnostic for the current runner.

Fixes #660.

## Testing
- `npm run build`
- `npm run browser-probe-profile-matrix-smoke`
- `npm run browser-probe-context-smoke`
- `npm run browser-probe-artifact-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the browser profile matrix support, added smoke coverage, and ran verification; Chris remains responsible for review and merge.