### PR TITLE
Add browser lifecycle observer artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "browser-probe-assertions-smoke": "tsx scripts/browser-probe-assertions-smoke.ts",
     "browser-probe-context-smoke": "tsx scripts/browser-probe-context-smoke.ts",
     "browser-probe-profile-matrix-smoke": "tsx scripts/browser-probe-profile-matrix-smoke.ts",
+    "browser-lifecycle-observer-smoke": "tsx scripts/browser-lifecycle-observer-smoke.ts",
     "browser-probe-pre-page-script-smoke": "tsx scripts/browser-probe-pre-page-script-smoke.ts",
     "browser-actions-artifact-smoke": "tsx scripts/browser-actions-artifact-smoke.ts",
     "browser-scenario-artifact-smoke": "tsx scripts/browser-scenario-artifact-smoke.ts",

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -115,6 +115,7 @@ export interface ArtifactReviewBrowserSummary {
     consoleMessages: number
     errors: number
     html?: string
+    lifecycle?: string
     network?: string
     networkEvents?: number
     checkpoints?: string

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -17,6 +17,7 @@ export interface BrowserProbeArtifact {
     console?: string
     errors?: string
     html?: string
+    lifecycle?: string
     memory?: string
     network?: string
     performance?: string
@@ -39,6 +40,7 @@ export interface BrowserProbeArtifact {
     errors: number
     finalUrl: string
     htmlSnapshot: boolean
+    lifecycle?: BrowserProbeLifecycleSummary
     memory?: BrowserProbeMemorySummary
     metrics?: Record<string, number>
     networkEvents: number
@@ -149,6 +151,44 @@ export interface BrowserProbeMemorySummary {
   domNodes: BrowserProbeMetricDigest
   documents: BrowserProbeMetricDigest
   jsEventListeners: BrowserProbeMetricDigest
+}
+
+export interface BrowserProbeLifecycleMetric {
+  selector: string
+  first_seen_ms: number | null
+  first_visible_ms: number | null
+  first_child_ms: number | null
+  first_iframe_ms: number | null
+  first_visible_iframe_ms: number | null
+  first_button_ms: number | null
+  first_visible_button_ms: number | null
+  stable_visible_ms: number | null
+  removed_count: number
+  peak_child_count: number
+  peak_iframe_count: number
+  peak_visible_iframe_count: number
+  peak_button_count: number
+  peak_visible_button_count: number
+  final_child_count: number
+  final_iframe_count: number
+  final_visible_iframe_count: number
+  final_button_count: number
+  final_visible_button_count: number
+}
+
+export interface BrowserProbeLifecycleSummary {
+  schema: "wp-codebox/browser-lifecycle/v1"
+  version: 1
+  startedAtMs: number
+  selectors: Record<string, BrowserProbeLifecycleMetric>
+}
+
+export interface BrowserProbeLifecycleArtifact {
+  schema: "wp-codebox/browser-lifecycle/v1"
+  version: 1
+  capturedAt: string
+  startedAtMs: number
+  selectors: Record<string, BrowserProbeLifecycleMetric>
 }
 
 export interface BrowserProbePerformanceSummary {
@@ -336,6 +376,7 @@ export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactRe
       consoleMessages: probe.summary.consoleMessages,
       errors: probe.summary.errors,
       html: probe.files.html,
+      lifecycle: probe.files.lifecycle,
       network: probe.files.network,
       networkEvents: probe.summary.networkEvents,
       screenshot: probe.files.screenshot,
@@ -383,6 +424,9 @@ export function browserManifestFiles(artifactRoot: string, probes: BrowserProbeA
     if (probe.files.html) {
       files.set(probe.files.html, { kind: "browser-html-snapshot", contentType: "text/html; charset=utf-8" })
     }
+    if (probe.files.lifecycle) {
+      files.set(probe.files.lifecycle, { kind: "browser-lifecycle", contentType: "application/json" })
+    }
     if (probe.files.memory) {
       files.set(probe.files.memory, { kind: "browser-memory", contentType: "application/json" })
     }
@@ -402,6 +446,6 @@ export function browserManifestFiles(artifactRoot: string, probes: BrowserProbeA
 }
 
 export function browserRedactionPaths(probe: BrowserProbeArtifact): string[] {
-  return [probe.files.steps, probe.files.actions, probe.files.editorState, probe.files.checkpoints, probe.files.console, probe.files.errors, probe.files.html, probe.files.memory, probe.files.network, probe.files.performance, probe.files.summary]
+  return [probe.files.steps, probe.files.actions, probe.files.editorState, probe.files.checkpoints, probe.files.console, probe.files.errors, probe.files.html, probe.files.lifecycle, probe.files.memory, probe.files.network, probe.files.performance, probe.files.summary]
     .filter((path): path is string => typeof path === "string" && path.length > 0)
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -3,8 +3,9 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { browserInteractionStepsFromArgs, durationStringMs } from "./browser-actions.js"
-import type { BrowserProbeArtifact, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
+import type { BrowserProbeArtifact, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
+import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
 import { argValue, cleanWpCliOutput, commaListArg } from "./commands.js"
@@ -66,7 +67,7 @@ export async function runBrowserProbeCommand({
 }: {
   artifactRoot: string
   command?: string
-  runtimeSpec: RuntimeCreateSpec
+  runtimeSpec?: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserProbeArtifact; artifacts?: BrowserProbeArtifact[]; output: string }> {
@@ -128,7 +129,7 @@ async function runSingleBrowserProbeCommand({
 }: {
   artifactRoot: string
   command: string
-  runtimeSpec: RuntimeCreateSpec
+  runtimeSpec?: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
   browserFilesDirectory: string
@@ -163,6 +164,7 @@ async function runSingleBrowserProbeCommand({
   const script = argValue(args, "script")
   const failFast = booleanArg(args, "fail-fast", false)
   const stallTimeoutMs = durationArg(args, "stall-timeout", 0)
+  const lifecycleSelectors = commaListArg(args, "observe")
   const assertions = browserProbeAssertionsFromArgs(args)
   const capturesConsoleForAssertions = assertions.some((assertion) => assertion.type === "no-console-errors" || assertion.type === "no-errors")
   const capturesErrorsForAssertions = assertions.some((assertion) => assertion.type === "no-page-errors" || assertion.type === "no-errors")
@@ -184,6 +186,7 @@ async function runSingleBrowserProbeCommand({
   const errorsPath = join(browserDirectory, "errors.jsonl")
   const htmlPath = join(browserDirectory, "snapshot.html")
   const memoryPath = join(browserDirectory, "memory.json")
+  const lifecyclePath = join(browserDirectory, "lifecycle.json")
   const networkPath = join(browserDirectory, "network.jsonl")
   const performancePath = join(browserDirectory, "performance.json")
   const screenshotPath = join(browserDirectory, "screenshot.png")
@@ -204,6 +207,7 @@ async function runSingleBrowserProbeCommand({
   let screenshotSha256: string | undefined
   let viewport: BrowserProbeViewport | null = null
   let scriptResult: unknown
+  let lifecycleArtifact: BrowserProbeLifecycleArtifact | undefined
   let memoryArtifact: BrowserProbeMemoryArtifact | undefined
   let performanceArtifact: BrowserProbePerformanceArtifact | undefined
   let page: import("playwright").Page | null = null
@@ -231,6 +235,9 @@ async function runSingleBrowserProbeCommand({
       await page.setViewportSize(requestedViewport)
     }
     await page.addInitScript(BROWSER_PROBE_STATE_INIT_SCRIPT)
+    if (lifecycleSelectors.length > 0) {
+      await page.addInitScript(browserProbeLifecycleInitScript(lifecycleSelectors))
+    }
     if (capturesBrowserMetrics) {
       await page.addInitScript(BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT)
     }
@@ -321,6 +328,10 @@ async function runSingleBrowserProbeCommand({
           performanceArtifact = browserProbePerformanceArtifact(checkpoints)
         }
       }
+      const lifecycle = lifecycleSelectors.length > 0 ? await collectBrowserProbeLifecycle(page) : undefined
+      if (lifecycle) {
+        lifecycleArtifact = browserProbeLifecycleArtifact(lifecycle)
+      }
 
       if (capture.has("html")) {
         try {
@@ -360,6 +371,9 @@ async function runSingleBrowserProbeCommand({
     if (memoryArtifact) {
       await writeFile(memoryPath, `${JSON.stringify(memoryArtifact, null, 2)}\n`)
     }
+    if (lifecycleArtifact) {
+      await writeFile(lifecyclePath, `${JSON.stringify(lifecycleArtifact, null, 2)}\n`)
+    }
     if (performanceArtifact) {
       await writeFile(performancePath, `${JSON.stringify(performanceArtifact, null, 2)}\n`)
     }
@@ -386,6 +400,7 @@ async function runSingleBrowserProbeCommand({
         ...(checkpoints.length > 0 ? { checkpoints: `${browserFilesDirectory}/checkpoints.jsonl` } : {}),
         ...(capture.has("errors") || capturesErrorsForAssertions ? { errors: `${browserFilesDirectory}/errors.jsonl` } : {}),
         ...(capture.has("html") ? { html: `${browserFilesDirectory}/snapshot.html` } : {}),
+        ...(lifecycleArtifact ? { lifecycle: `${browserFilesDirectory}/lifecycle.json` } : {}),
         ...(memoryArtifact ? { memory: `${browserFilesDirectory}/memory.json` } : {}),
         ...(capture.has("network") || capturesNetworkForAssertions ? { network: `${browserFilesDirectory}/network.jsonl` } : {}),
         ...(performanceArtifact ? { performance: `${browserFilesDirectory}/performance.json` } : {}),
@@ -398,6 +413,7 @@ async function runSingleBrowserProbeCommand({
         errors: errors.length,
         finalUrl,
         htmlSnapshot: capture.has("html"),
+        ...(lifecycleArtifact ? { lifecycle: { schema: lifecycleArtifact.schema, version: lifecycleArtifact.version, startedAtMs: lifecycleArtifact.startedAtMs, selectors: lifecycleArtifact.selectors } } : {}),
         ...(memoryArtifact ? { memory: memoryArtifact.peak } : {}),
         ...(memoryArtifact || performanceArtifact ? { metrics: browserProbeBenchMetrics(memoryArtifact, performanceArtifact) } : {}),
         networkEvents: network.length,
@@ -418,6 +434,7 @@ async function runSingleBrowserProbeCommand({
       finalUrl,
       waitFor,
       durationMs,
+      ...(lifecycleSelectors.length > 0 ? { observe: lifecycleSelectors } : {}),
       failFast,
       stallTimeoutMs,
       capture: [...capture].sort(),
@@ -1784,11 +1801,11 @@ function now(): string {
   return new Date().toISOString()
 }
 
-function browserProbePreviewOrigins(runtimeSpec: RuntimeCreateSpec, localPreviewOrigin: string): { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string } {
+function browserProbePreviewOrigins(runtimeSpec: RuntimeCreateSpec | undefined, localPreviewOrigin: string): { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string } {
   return {
     localPreviewOrigin,
-    requestedPreviewOrigin: runtimeSpec.preview?.publicUrl,
-    effectivePreviewOrigin: runtimeSpec.preview?.publicUrl ?? localPreviewOrigin,
+    requestedPreviewOrigin: runtimeSpec?.preview?.publicUrl,
+    effectivePreviewOrigin: runtimeSpec?.preview?.publicUrl ?? localPreviewOrigin,
   }
 }
 

--- a/packages/runtime-playground/src/browser-lifecycle.ts
+++ b/packages/runtime-playground/src/browser-lifecycle.ts
@@ -1,0 +1,230 @@
+import type { Page } from "playwright"
+import type { BrowserProbeLifecycleArtifact, BrowserProbeLifecycleSummary } from "./browser-artifacts.js"
+
+export function browserProbeLifecycleInitScript(selectors: string[]): string {
+  return `
+(() => {
+  const selectors = ${JSON.stringify(selectors)};
+  const state = globalThis.__wpCodeboxBrowserProbe = globalThis.__wpCodeboxBrowserProbe || { checkpoints: [], longTasks: [] };
+  if (!Array.isArray(selectors) || selectors.length === 0 || state.lifecycleObserverInstalled) {
+    return;
+  }
+
+  const now = () => {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+      return performance.now();
+    }
+    return Date.now();
+  };
+
+  const lifecycle = state.lifecycle = state.lifecycle || {
+    schema: 'wp-codebox/browser-lifecycle/v1',
+    version: 1,
+    startedAtMs: now(),
+    selectors: {},
+  };
+
+  const selectorStates = new Map();
+  for (const selector of selectors) {
+    const key = String(selector || '').trim();
+    if (!key || selectorStates.has(key)) {
+      continue;
+    }
+    const metrics = lifecycle.selectors[key] = lifecycle.selectors[key] || {
+      selector: key,
+      first_seen_ms: null,
+      first_visible_ms: null,
+      first_child_ms: null,
+      first_iframe_ms: null,
+      first_visible_iframe_ms: null,
+      first_button_ms: null,
+      first_visible_button_ms: null,
+      stable_visible_ms: null,
+      removed_count: 0,
+      peak_child_count: 0,
+      peak_iframe_count: 0,
+      peak_visible_iframe_count: 0,
+      peak_button_count: 0,
+      peak_visible_button_count: 0,
+      final_child_count: 0,
+      final_iframe_count: 0,
+      final_visible_iframe_count: 0,
+      final_button_count: 0,
+      final_visible_button_count: 0,
+    };
+    selectorStates.set(key, { metrics, elements: new Set(), visibleSinceMs: null, stableTimer: null });
+  }
+
+  const visibleStableDelayMs = 250;
+  const buttonSelector = 'button, input[type="button"], input[type="submit"], input[type="reset"], [role="button"]';
+
+  function elapsedMs() {
+    return Math.max(0, Math.round(now() - lifecycle.startedAtMs));
+  }
+
+  function isVisible(element) {
+    if (!element || typeof element.getClientRects !== 'function') {
+      return false;
+    }
+    const style = typeof getComputedStyle === 'function' ? getComputedStyle(element) : null;
+    if (style && (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0')) {
+      return false;
+    }
+    return element.getClientRects().length > 0;
+  }
+
+  function descendants(element, selector) {
+    if (!element || typeof element.querySelectorAll !== 'function') {
+      return [];
+    }
+    try {
+      return Array.from(element.querySelectorAll(selector));
+    } catch {
+      return [];
+    }
+  }
+
+  function updateFirst(metrics, field, count, sampleMs) {
+    if (count > 0 && metrics[field] === null) {
+      metrics[field] = sampleMs;
+    }
+  }
+
+  function sampleSelector(selector, tracked) {
+    const metrics = tracked.metrics;
+    const sampleMs = elapsedMs();
+    let elements = [];
+    try {
+      elements = Array.from(document.querySelectorAll(selector));
+    } catch {
+      elements = [];
+    }
+
+    for (const element of tracked.elements) {
+      if (!elements.includes(element)) {
+        metrics.removed_count += 1;
+      }
+    }
+    tracked.elements = new Set(elements);
+
+    const visibleElements = elements.filter(isVisible);
+    const childCount = elements.reduce((total, element) => total + (element.children ? element.children.length : 0), 0);
+    const iframes = elements.flatMap((element) => descendants(element, 'iframe'));
+    const buttons = elements.flatMap((element) => descendants(element, buttonSelector));
+    const visibleIframeCount = iframes.filter(isVisible).length;
+    const visibleButtonCount = buttons.filter(isVisible).length;
+
+    updateFirst(metrics, 'first_seen_ms', elements.length, sampleMs);
+    updateFirst(metrics, 'first_visible_ms', visibleElements.length, sampleMs);
+    updateFirst(metrics, 'first_child_ms', childCount, sampleMs);
+    updateFirst(metrics, 'first_iframe_ms', iframes.length, sampleMs);
+    updateFirst(metrics, 'first_visible_iframe_ms', visibleIframeCount, sampleMs);
+    updateFirst(metrics, 'first_button_ms', buttons.length, sampleMs);
+    updateFirst(metrics, 'first_visible_button_ms', visibleButtonCount, sampleMs);
+
+    metrics.peak_child_count = Math.max(metrics.peak_child_count, childCount);
+    metrics.peak_iframe_count = Math.max(metrics.peak_iframe_count, iframes.length);
+    metrics.peak_visible_iframe_count = Math.max(metrics.peak_visible_iframe_count, visibleIframeCount);
+    metrics.peak_button_count = Math.max(metrics.peak_button_count, buttons.length);
+    metrics.peak_visible_button_count = Math.max(metrics.peak_visible_button_count, visibleButtonCount);
+    metrics.final_child_count = childCount;
+    metrics.final_iframe_count = iframes.length;
+    metrics.final_visible_iframe_count = visibleIframeCount;
+    metrics.final_button_count = buttons.length;
+    metrics.final_visible_button_count = visibleButtonCount;
+
+    if (visibleElements.length > 0) {
+      if (tracked.visibleSinceMs === null) {
+        tracked.visibleSinceMs = sampleMs;
+      }
+      if (metrics.stable_visible_ms === null && tracked.stableTimer === null) {
+        tracked.stableTimer = setTimeout(() => {
+          tracked.stableTimer = null;
+          sampleSelector(selector, tracked);
+          if (tracked.visibleSinceMs !== null && tracked.metrics.stable_visible_ms === null) {
+            tracked.metrics.stable_visible_ms = tracked.visibleSinceMs;
+          }
+        }, visibleStableDelayMs);
+      }
+    } else {
+      tracked.visibleSinceMs = null;
+      if (tracked.stableTimer !== null) {
+        clearTimeout(tracked.stableTimer);
+        tracked.stableTimer = null;
+      }
+    }
+  }
+
+  function sampleAll() {
+    for (const [selector, tracked] of selectorStates) {
+      sampleSelector(selector, tracked);
+    }
+  }
+
+  function installRootObserver() {
+    sampleAll();
+    if (typeof MutationObserver === 'undefined' || !document.documentElement) {
+      return false;
+    }
+    const observer = new MutationObserver(sampleAll);
+    observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ['class', 'style', 'hidden', 'aria-hidden'] });
+    state.lifecycleObserverInstalled = true;
+    return true;
+  }
+
+  if (!installRootObserver()) {
+    if (typeof MutationObserver !== 'undefined') {
+      const documentObserver = new MutationObserver(() => {
+        if (document.documentElement && installRootObserver()) {
+          documentObserver.disconnect();
+        }
+      });
+      documentObserver.observe(document, { childList: true });
+    }
+    if (typeof document.addEventListener === 'function') {
+      document.addEventListener('DOMContentLoaded', installRootObserver, { once: true });
+    }
+    const interval = setInterval(() => {
+      if (document.documentElement && installRootObserver()) {
+        clearInterval(interval);
+      }
+    }, 25);
+  }
+
+  state.collectLifecycle = () => {
+    sampleAll();
+    return lifecycle;
+  };
+})();
+`
+}
+
+export async function collectBrowserProbeLifecycle(page: Page): Promise<BrowserProbeLifecycleSummary | undefined> {
+  const lifecycle = await page.evaluate(() => {
+    const state = (globalThis as typeof globalThis & { __wpCodeboxBrowserProbe?: { collectLifecycle?: () => unknown; lifecycle?: unknown } }).__wpCodeboxBrowserProbe
+    if (typeof state?.collectLifecycle === "function") {
+      return state.collectLifecycle()
+    }
+    return state?.lifecycle
+  })
+
+  if (!isLifecycleSummary(lifecycle) || Object.keys(lifecycle.selectors).length === 0) {
+    return undefined
+  }
+
+  return lifecycle
+}
+
+export function browserProbeLifecycleArtifact(lifecycle: BrowserProbeLifecycleSummary): BrowserProbeLifecycleArtifact {
+  return {
+    schema: "wp-codebox/browser-lifecycle/v1",
+    version: 1,
+    capturedAt: new Date().toISOString(),
+    startedAtMs: lifecycle.startedAtMs,
+    selectors: lifecycle.selectors,
+  }
+}
+
+function isLifecycleSummary(value: unknown): value is BrowserProbeLifecycleSummary {
+  return typeof value === "object" && value !== null && !Array.isArray(value) && (value as { schema?: unknown }).schema === "wp-codebox/browser-lifecycle/v1" && typeof (value as { selectors?: unknown }).selectors === "object" && (value as { selectors?: unknown }).selectors !== null
+}

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -189,6 +189,7 @@ export async function browserArtifactMetrics(bundleDirectory: string): Promise<B
   const artifacts: BrowserArtifactMetricsResult["artifacts"] = {}
 
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "summary", "summary.json", "json")
+  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "lifecycle", "lifecycle.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "memory", "memory.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "performance", "performance.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "checkpoints", "checkpoints.jsonl", "jsonl")

--- a/scripts/browser-lifecycle-observer-smoke.ts
+++ b/scripts/browser-lifecycle-observer-smoke.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict"
+import { createServer } from "node:http"
+import vm from "node:vm"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm } from "node:fs/promises"
+import { resolve } from "node:path"
+import { browserProbeLifecycleInitScript } from "../packages/runtime-playground/src/browser-lifecycle.js"
+import { runBrowserProbeCommand } from "../packages/runtime-playground/src/browser-command-runners.js"
+import type { PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const artifactRoot = resolve(repoRoot, "artifacts", "browser-lifecycle-observer-smoke")
+
+await rm(artifactRoot, { recursive: true, force: true })
+await mkdir(artifactRoot, { recursive: true })
+
+smokeEarlyInstallationBeforeDocumentElement()
+await smokeDelayedLifecycleMetrics()
+
+console.log(`Browser lifecycle observer smoke passed: ${artifactRoot}`)
+
+function smokeEarlyInstallationBeforeDocumentElement(): void {
+  const mutationObservers: Array<{ target?: unknown; options?: unknown; callback: () => void; disconnected: boolean }> = []
+  const documentListeners = new Map<string, () => void>()
+  let performanceNow = 0
+  const delayedElement = fakeElement({ children: [fakeElement(), fakeElement()], iframes: [fakeElement()], buttons: [fakeElement()] })
+  const fakeDocument = {
+    documentElement: null as null | ReturnType<typeof fakeElement>,
+    addEventListener(name: string, callback: () => void) {
+      documentListeners.set(name, callback)
+    },
+    querySelectorAll() {
+      return this.documentElement ? [delayedElement] : []
+    },
+  }
+  const context = vm.createContext({
+    document: fakeDocument,
+    globalThis: {},
+    performance: { now: () => performanceNow },
+    getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+    setTimeout: () => 1,
+    clearTimeout: () => undefined,
+    setInterval: () => 1,
+    clearInterval: () => undefined,
+    MutationObserver: class {
+      readonly record = { callback: () => undefined, disconnected: false } as { target?: unknown; options?: unknown; callback: () => void; disconnected: boolean }
+
+      constructor(callback: () => void) {
+        this.record.callback = callback
+        mutationObservers.push(this.record)
+      }
+
+      observe(target: unknown, options: unknown) {
+        this.record.target = target
+        this.record.options = options
+      }
+
+      disconnect() {
+        this.record.disconnected = true
+      }
+    },
+  })
+
+  assert.doesNotThrow(() => vm.runInContext(browserProbeLifecycleInitScript(["#early"]), context))
+  assert.equal(mutationObservers[0]?.target, fakeDocument, "observer should wait on the document when the root is missing")
+
+  performanceNow = 20
+  fakeDocument.documentElement = fakeElement()
+  mutationObservers[0]?.callback()
+  documentListeners.get("DOMContentLoaded")?.()
+
+  const lifecycle = vm.runInContext("globalThis.__wpCodeboxBrowserProbe.collectLifecycle()", context) as {
+    selectors: Record<string, { first_seen_ms: number | null; first_visible_ms: number | null; final_child_count: number; final_iframe_count: number; final_button_count: number }>
+  }
+  assert.equal(lifecycle.selectors["#early"].first_seen_ms, 20)
+  assert.equal(lifecycle.selectors["#early"].first_visible_ms, 20)
+  assert.equal(lifecycle.selectors["#early"].final_child_count, 2)
+  assert.equal(lifecycle.selectors["#early"].final_iframe_count, 1)
+  assert.equal(lifecycle.selectors["#early"].final_button_count, 1)
+}
+
+async function smokeDelayedLifecycleMetrics(): Promise<void> {
+  const httpServer = createServer((_request, response) => {
+    response.setHeader("content-type", "text/html; charset=utf-8")
+    response.end(`<!doctype html>
+      <html>
+        <head><title>Lifecycle fixture</title></head>
+        <body>
+          <script>
+            setTimeout(() => {
+              const delayed = document.createElement('section');
+              delayed.id = 'delayed';
+              delayed.innerHTML = '<button>Ready</button><iframe src="about:blank"></iframe>';
+              document.body.appendChild(delayed);
+            }, 75);
+            setTimeout(() => {
+              const replacement = document.createElement('section');
+              replacement.id = 'replacement';
+              replacement.innerHTML = '<button>First</button>';
+              document.body.appendChild(replacement);
+            }, 125);
+            setTimeout(() => {
+              document.querySelector('#replacement')?.remove();
+              const replacement = document.createElement('section');
+              replacement.id = 'replacement';
+              replacement.innerHTML = '<button>Second</button><button>Third</button>';
+              document.body.appendChild(replacement);
+            }, 250);
+          </script>
+        </body>
+      </html>`)
+  })
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    httpServer.once("error", rejectListen)
+    httpServer.listen(0, "127.0.0.1", () => resolveListen())
+  })
+
+  try {
+    const address = httpServer.address()
+    assert.ok(address && typeof address === "object", "fixture server should expose an address")
+    const serverUrl = `http://127.0.0.1:${address.port}`
+    const server: PlaygroundCliServer = {
+      serverUrl,
+      playground: {
+        async run() {
+          return { text: "" }
+        },
+      },
+      async [Symbol.asyncDispose]() {},
+    }
+
+    const result = await runBrowserProbeCommand({
+      artifactRoot,
+      runtimeSpec: {
+        backend: "wordpress-playground",
+        environment: { kind: "wordpress", name: "browser-lifecycle-observer-smoke", version: "7.0" },
+        policy: {
+          network: "deny",
+          filesystem: "readwrite-mounts",
+          commands: ["wordpress.browser-probe"],
+          secrets: "none",
+          approvals: "never",
+        },
+      },
+      server,
+      spec: {
+        command: "wordpress.browser-probe",
+        args: [
+          "url=/",
+          "wait-for=load",
+          "duration=700ms",
+          "capture=html,console,errors",
+          "observe=#delayed,#replacement",
+        ],
+      },
+    })
+
+    assert.equal(result.artifact.files.lifecycle, "files/browser/lifecycle.json")
+    assert.equal(existsSync(resolve(artifactRoot, "files", "browser", "lifecycle.json")), true, "lifecycle artifact should be written")
+
+    const delayed = result.artifact.summary.lifecycle?.selectors["#delayed"]
+    const replacement = result.artifact.summary.lifecycle?.selectors["#replacement"]
+    assert.ok(delayed, "delayed selector should be summarized")
+    assert.ok(replacement, "replacement selector should be summarized")
+    assert.equal(typeof delayed.first_seen_ms, "number", "delayed element should be observed after load")
+    assert.equal(typeof delayed.first_visible_ms, "number", "delayed visible element should be observed")
+    assert.equal(delayed.final_iframe_count, 1)
+    assert.equal(delayed.final_button_count, 1)
+    assert.equal(replacement.removed_count, 1, "replacement should record the removed original element")
+    assert.equal(replacement.peak_button_count, 2)
+    assert.equal(replacement.final_button_count, 2)
+
+    const summary = JSON.parse(await readFile(resolve(artifactRoot, "files", "browser", "summary.json"), "utf8")) as {
+      observe?: string[]
+      files?: { lifecycle?: string }
+      summary?: { lifecycle?: { selectors?: Record<string, unknown> } }
+    }
+    assert.deepEqual(summary.observe, ["#delayed", "#replacement"])
+    assert.equal(summary.files?.lifecycle, "files/browser/lifecycle.json")
+    assert.ok(summary.summary?.lifecycle?.selectors?.["#delayed"], "summary file should include lifecycle metrics")
+
+    const lifecycleArtifact = JSON.parse(await readFile(resolve(artifactRoot, "files", "browser", "lifecycle.json"), "utf8")) as {
+      schema?: string
+      selectors?: Record<string, unknown>
+    }
+    assert.equal(lifecycleArtifact.schema, "wp-codebox/browser-lifecycle/v1")
+    assert.ok(lifecycleArtifact.selectors?.["#replacement"], "lifecycle artifact should include every observed selector")
+  } finally {
+    await new Promise<void>((resolveClose, rejectClose) => {
+      httpServer.close((error) => error ? rejectClose(error) : resolveClose())
+    })
+  }
+}
+
+function fakeElement(options: { children?: ReturnType<typeof fakeElement>[]; iframes?: ReturnType<typeof fakeElement>[]; buttons?: ReturnType<typeof fakeElement>[] } = {}) {
+  return {
+    children: options.children ?? [],
+    getClientRects: () => [true],
+    querySelectorAll(selector: string) {
+      if (selector === "iframe") {
+        return options.iframes ?? []
+      }
+      if (selector.includes("button")) {
+        return options.buttons ?? []
+      }
+      return []
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Add product-agnostic `wordpress.browser-probe` lifecycle observers via `observe=<selector>[,<selector>]`.
- Emit selector lifecycle metrics in `files/browser/lifecycle.json`, probe summaries, manifests, review metadata, and browser metrics discovery.
- Cover delayed element appearance/replacement/removal and safe installation before `document.documentElement` exists.

Closes #661.

## Testing
- `npm run build`
- `npm run browser-lifecycle-observer-smoke`
- `npm run browser-probe-pre-page-script-smoke`
- `npm run browser-probe-artifact-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the lifecycle observer helper, browser artifact wiring, smoke coverage, and verification under Chris's direction.