### PR TITLE
Add browser capability diagnostics to probe evidence

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -110,6 +110,7 @@ export interface ArtifactReviewBrowserSummary {
       hasTouch: boolean
       userAgent: string
     } | null
+    capabilities?: ArtifactReviewBrowserCapabilities
     replayability?: "artifact-backed" | "partial" | "diagnostic-only"
     consoleMessages: number
     errors: number
@@ -134,6 +135,27 @@ export interface ArtifactReviewBrowserSummary {
     }
     summaryFile?: string
   }>
+}
+
+export interface ArtifactReviewBrowserCapabilities {
+  secureContext: boolean
+  userAgent: string
+  language?: string
+  languages?: string[]
+  locale?: string
+  timezone?: string
+  viewport: {
+    width: number
+    height: number
+    deviceScaleFactor: number
+    isMobile: boolean
+    hasTouch: boolean
+  } | null
+  maxTouchPoints: number
+  paymentRequest: {
+    available: boolean
+  }
+  permissions: Record<string, { state: "granted" | "denied" | "prompt" | "unsupported" | "error" }>
 }
 
 export interface ArtifactRedactionArtifactSummary {

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -45,11 +45,37 @@ export interface BrowserProbeArtifact {
     performance?: BrowserProbePerformanceSummary
     progress?: BrowserProbeProgressSummary
     context?: BrowserProbeContextDetails
+    capabilities?: BrowserProbeCapabilityDiagnostics
     replayability: BrowserProbeReplayability
     screenshot: boolean
     scriptResult?: unknown
     viewport: BrowserProbeViewport | null
   }
+}
+
+export interface BrowserProbeCapabilityDiagnostics {
+  secureContext: boolean
+  userAgent: string
+  language?: string
+  languages?: string[]
+  locale?: string
+  timezone?: string
+  viewport: {
+    width: number
+    height: number
+    deviceScaleFactor: number
+    isMobile: boolean
+    hasTouch: boolean
+  } | null
+  maxTouchPoints: number
+  paymentRequest: {
+    available: boolean
+  }
+  permissions: Record<string, BrowserProbePermissionState>
+}
+
+export interface BrowserProbePermissionState {
+  state: "granted" | "denied" | "prompt" | "unsupported" | "error"
 }
 
 export interface BrowserProbeContextDetails {
@@ -291,6 +317,7 @@ export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactRe
       effectivePreviewOrigin: probe.effectivePreviewOrigin,
       finalUrl: probe.summary.finalUrl,
       viewport: probe.summary.viewport,
+      capabilities: probe.summary.capabilities,
       replayability: probe.summary.replayability,
       consoleMessages: probe.summary.consoleMessages,
       errors: probe.summary.errors,

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { browserInteractionStepsFromArgs, durationStringMs } from "./browser-actions.js"
-import type { BrowserProbeArtifact, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
+import type { BrowserProbeArtifact, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
@@ -111,6 +111,7 @@ export async function runBrowserProbeCommand({
   let page: import("playwright").Page | null = null
   let context: import("playwright").BrowserContext | null = null
   let contextDetails: BrowserProbeContextDetails | undefined
+  let capabilityDiagnostics: BrowserProbeCapabilityDiagnostics | undefined
   let assertionResults: import("./browser-artifacts.js").BrowserStepAssertion[] = []
   let pendingError: Error | undefined
   let artifact: BrowserProbeArtifact | undefined
@@ -135,6 +136,7 @@ export async function runBrowserProbeCommand({
     }
     viewport = await browserProbeViewport(page)
     contextDetails = await browserProbeContextDetails(page, requestedContext, viewport)
+    capabilityDiagnostics = await browserProbeCapabilityDiagnostics(page, viewport)
     if (capture.has("console") || capturesConsoleForAssertions) {
       page.on("console", (message) => {
         progress.mark("console")
@@ -295,6 +297,7 @@ export async function runBrowserProbeCommand({
         ...(performanceArtifact ? { performance: performanceArtifact.peak } : {}),
         progress: progress.summary(),
         context: contextDetails,
+        capabilities: capabilityDiagnostics,
         replayability: browserProbeReplayability(capture),
         screenshot: capture.has("screenshot"),
         ...(typeof scriptResult !== "undefined" ? { scriptResult } : {}),
@@ -321,6 +324,7 @@ export async function runBrowserProbeCommand({
         ...(screenshotSha256 ? { screenshot: { algorithm: "sha256", value: screenshotSha256 } } : {}),
       },
       context: contextDetails,
+      capabilities: capabilityDiagnostics,
       viewport,
       summary: artifact.summary,
     }, null, 2)}\n`)
@@ -377,6 +381,73 @@ async function browserProbeContextDetails(page: import("playwright").Page, reque
       ...(effective.timezone ? { timezone: effective.timezone } : {}),
       viewport,
     },
+  }
+}
+
+async function browserProbeCapabilityDiagnostics(page: import("playwright").Page, viewport: BrowserProbeViewport | null): Promise<BrowserProbeCapabilityDiagnostics> {
+  const fallback: BrowserProbeCapabilityDiagnostics = {
+    secureContext: false,
+    userAgent: viewport?.userAgent ?? "",
+    viewport: viewport ? browserProbeCapabilityViewport(viewport) : null,
+    maxTouchPoints: 0,
+    paymentRequest: { available: false },
+    permissions: {},
+  }
+
+  return page.evaluate(async (probeViewport) => {
+    const resolvedOptions = Intl.DateTimeFormat().resolvedOptions()
+    const permissionNames = ["clipboard-read", "clipboard-write", "geolocation", "notifications", "payment-handler"]
+    const permissions: BrowserProbeCapabilityDiagnostics["permissions"] = {}
+    const permissionsApi = (navigator as typeof navigator & { permissions?: { query?: (descriptor: { name: string }) => Promise<{ state?: string }> } }).permissions
+    const normalizePermissionState = (state: unknown): BrowserProbeCapabilityDiagnostics["permissions"][string]["state"] => {
+      if (state === "granted" || state === "denied" || state === "prompt") {
+        return state
+      }
+      return typeof state === "string" ? "error" : "unsupported"
+    }
+
+    for (const name of permissionNames) {
+      if (!permissionsApi?.query) {
+        permissions[name] = { state: "unsupported" }
+        continue
+      }
+
+      try {
+        const status = await permissionsApi.query({ name })
+        permissions[name] = { state: normalizePermissionState(status.state) }
+      } catch {
+        permissions[name] = { state: "unsupported" }
+      }
+    }
+
+    return {
+      secureContext: Boolean(window.isSecureContext),
+      userAgent: navigator.userAgent || "",
+      language: navigator.language || undefined,
+      languages: Array.isArray(navigator.languages) ? navigator.languages.slice(0, 10).filter((language) => typeof language === "string" && language.length > 0) : undefined,
+      locale: resolvedOptions.locale || navigator.language || undefined,
+      timezone: resolvedOptions.timeZone || undefined,
+      viewport: probeViewport ? {
+        width: probeViewport.width,
+        height: probeViewport.height,
+        deviceScaleFactor: probeViewport.deviceScaleFactor,
+        isMobile: probeViewport.isMobile,
+        hasTouch: probeViewport.hasTouch,
+      } : null,
+      maxTouchPoints: typeof navigator.maxTouchPoints === "number" ? navigator.maxTouchPoints : 0,
+      paymentRequest: { available: typeof (window as typeof window & { PaymentRequest?: unknown }).PaymentRequest === "function" },
+      permissions,
+    }
+  }, viewport).catch(() => fallback)
+}
+
+function browserProbeCapabilityViewport(viewport: BrowserProbeViewport): BrowserProbeCapabilityDiagnostics["viewport"] {
+  return {
+    width: viewport.width,
+    height: viewport.height,
+    deviceScaleFactor: viewport.deviceScaleFactor,
+    isMobile: viewport.isMobile,
+    hasTouch: viewport.hasTouch,
   }
 }
 

--- a/scripts/browser-probe-artifact-smoke.ts
+++ b/scripts/browser-probe-artifact-smoke.ts
@@ -138,6 +138,18 @@ const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
   files: { checkpoints?: string; html?: string; memory?: string; network?: string; performance?: string; screenshot?: string }
   hashes: { html?: { value: string }; screenshot?: { value: string } }
   viewport: { width: number; height: number; userAgent: string }
+  capabilities?: {
+    secureContext: boolean
+    userAgent: string
+    language?: string
+    languages?: string[]
+    locale?: string
+    timezone?: string
+    viewport: { width: number; height: number; deviceScaleFactor: number; isMobile: boolean; hasTouch: boolean } | null
+    maxTouchPoints: number
+    paymentRequest: { available: boolean }
+    permissions: Record<string, { state: string }>
+  }
   summary: {
     replayability: string
     networkEvents: number
@@ -145,6 +157,18 @@ const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
     scriptResult?: { title?: string; hasBody?: boolean; observedCapabilities?: { applePay?: boolean; paymentRequest?: boolean; marker?: string } }
     memory?: { usedJSHeapSize: { final: number | null; peak: number | null }; domNodes: { final: number | null; peak: number | null } }
     performance?: { resources: number; domNodes: { final: number | null; peak: number | null }; longTasks: number }
+    capabilities?: {
+      secureContext: boolean
+      userAgent: string
+      language?: string
+      languages?: string[]
+      locale?: string
+      timezone?: string
+      viewport: { width: number; height: number; deviceScaleFactor: number; isMobile: boolean; hasTouch: boolean } | null
+      maxTouchPoints: number
+      paymentRequest: { available: boolean }
+      permissions: Record<string, { state: string }>
+    }
   }
 }
 assert.equal(summary.requestedUrl.endsWith("/"), true, "summary should include requested URL")
@@ -172,6 +196,19 @@ assert.ok((summary.summary.memory?.domNodes.final ?? 0) > 0, "summary should inc
 assert.ok((summary.summary.performance?.resources ?? 0) >= 1, "summary should include performance resource counts")
 assert.ok((summary.summary.performance?.domNodes.final ?? 0) > 0, "summary should include performance DOM node counts")
 assert.ok(summary.viewport.userAgent.length > 0, "summary should include user agent")
+assert.equal(summary.capabilities?.secureContext, false, "summary should record secure-context status")
+assert.equal(summary.summary.capabilities?.secureContext, false, "probe summary should expose capability diagnostics")
+assert.equal(summary.capabilities?.userAgent, summary.viewport.userAgent, "capabilities should include user agent")
+assert.equal(typeof summary.capabilities?.language, "string", "capabilities should include navigator language")
+assert.ok(Array.isArray(summary.capabilities?.languages), "capabilities should include navigator languages")
+assert.equal(typeof summary.capabilities?.locale, "string", "capabilities should include locale")
+assert.equal(typeof summary.capabilities?.timezone, "string", "capabilities should include timezone")
+assert.equal(summary.capabilities?.viewport?.width, 390, "capabilities should include viewport width")
+assert.equal(summary.capabilities?.viewport?.height, 844, "capabilities should include viewport height")
+assert.equal(typeof summary.capabilities?.maxTouchPoints, "number", "capabilities should include max touch points")
+assert.equal(typeof summary.capabilities?.paymentRequest.available, "boolean", "capabilities should include PaymentRequest presence")
+assert.ok(summary.capabilities?.permissions.geolocation, "capabilities should include safe permission states")
+assert.ok(["granted", "denied", "prompt", "unsupported", "error"].includes(summary.capabilities?.permissions.geolocation.state ?? ""), "permission state should be normalized")
 
 const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
 assert.ok(manifest.files.some((file) => file.path === "files/browser/console.jsonl" && file.kind === "browser-console"))
@@ -183,7 +220,7 @@ assert.ok(manifest.files.some((file) => file.path === "files/browser/network.jso
 assert.ok(manifest.files.some((file) => file.path === "files/browser/performance.json" && file.kind === "browser-performance"))
 assert.ok(manifest.files.some((file) => file.path === "files/browser/screenshot.png" && file.kind === "browser-screenshot"))
 
-const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ consoleMessages: number; errors: number; checkpoints?: string; html?: string; memory?: string; network?: string; performance?: string; finalUrl?: string; replayability?: string; viewport?: { width: number; height: number } }> } }
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ consoleMessages: number; errors: number; checkpoints?: string; html?: string; memory?: string; network?: string; performance?: string; finalUrl?: string; replayability?: string; viewport?: { width: number; height: number }; capabilities?: { secureContext: boolean; paymentRequest: { available: boolean }; maxTouchPoints: number; permissions: Record<string, { state: string }> } }> } }
 assert.ok(review.browser?.probes?.[0], "review should include browser probe summary")
 assert.ok(review.browser.probes[0].consoleMessages >= 1, "review should count console messages")
 assert.ok(review.browser.probes[0].errors >= 1, "review should count browser errors")
@@ -195,6 +232,8 @@ assert.equal(review.browser.probes[0].performance, "files/browser/performance.js
 assert.equal(review.browser.probes[0].replayability, "artifact-backed")
 assert.equal(review.browser.probes[0].viewport?.width, 390, "review should record requested viewport width")
 assert.equal(review.browser.probes[0].viewport?.height, 844, "review should record requested viewport height")
+assert.equal(review.browser.probes[0].capabilities?.secureContext, false, "review should include capability diagnostics")
+assert.equal(typeof review.browser.probes[0].capabilities?.paymentRequest.available, "boolean", "review should include PaymentRequest presence")
 assert.equal(review.browser.probes[0].finalUrl?.endsWith("/"), true, "review should include final URL")
 
 console.log(`Browser probe artifact smoke passed: ${artifactDirectory}`)


### PR DESCRIPTION
## Summary
- Records generic browser capability diagnostics in `wordpress.browser-probe` evidence summaries, including secure context, UA/language/locale/timezone, viewport/touch details, PaymentRequest presence, and normalized safe permission states.
- Surfaces the same diagnostics in browser review summaries so evidence consumers do not need to parse raw probe files.
- Extends the browser probe artifact smoke to verify deterministic diagnostics fields without assuming browser-specific feature availability.

Closes #663.

## Tests
- `npm run build`
- `npm run browser-probe-artifact-smoke`
- `npm run browser-probe-context-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the implementation, smoke coverage updates, and verification commands. Chris remains responsible for review and submission.