### PR TITLE
Add browser probe assertion budgets

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -959,6 +959,10 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
         && normalized !== "no-console-errors"
         && normalized !== "no-page-errors"
         && normalized !== "no-errors"
+        && !normalized.startsWith("request-count-by-host:")
+        && !normalized.startsWith("request-count-by-type:")
+        && !normalized.startsWith("total-transfer-size")
+        && !normalized.startsWith("metric:")
       ) {
         addIssue("invalid-assert", `${path}.args`, `wordpress.browser-probe assert does not support: ${assertion}`)
       }

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -225,6 +225,8 @@ export interface BrowserStepRecord {
 
 export interface BrowserStepAssertion {
   kind: "expect" | "evaluate" | "probe"
+  id?: string
+  status?: "pass" | "fail" | "warn" | "skipped"
   assertion?: string
   advisory?: boolean
   message?: string
@@ -234,7 +236,10 @@ export interface BrowserStepAssertion {
   expression?: string
   operator?: string
   expected?: unknown
+  expectedBudget?: unknown
   actual?: unknown
+  observed?: unknown
+  supportingArtifacts?: string[]
   passed: boolean
 }
 

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -6,7 +6,7 @@ import { browserInteractionStepsFromArgs, durationStringMs } from "./browser-act
 import type { BrowserProbeArtifact, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
-import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
+import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
 import { argValue, cleanWpCliOutput, commaListArg } from "./commands.js"
 import { editorActionStepsFromArgs, editorOpenTargetFromArgs, type EditorActionStep } from "./editor-actions.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
@@ -72,7 +72,8 @@ export async function runBrowserProbeCommand({
   const assertions = browserProbeAssertionsFromArgs(args)
   const capturesConsoleForAssertions = assertions.some((assertion) => assertion.type === "no-console-errors" || assertion.type === "no-errors")
   const capturesErrorsForAssertions = assertions.some((assertion) => assertion.type === "no-page-errors" || assertion.type === "no-errors")
-  const capturesBrowserMetrics = capture.has("performance") || capture.has("memory")
+  const capturesNetworkForAssertions = browserProbeAssertionsNeedNetwork(assertions)
+  const capturesBrowserMetrics = capture.has("performance") || capture.has("memory") || browserProbeAssertionsNeedMetrics(assertions)
   const prePageScriptMetadata = prePageScript ? browserProbeScriptMetadata(prePageScript) : undefined
   const previewOrigins = browserProbePreviewOrigins(runtimeSpec, server.serverUrl)
   const targetUrl = resolveBrowserProbeUrl(urlArg, previewOrigins.effectivePreviewOrigin)
@@ -147,7 +148,7 @@ export async function runBrowserProbeCommand({
         errors.push(serializeBrowserError("pageerror", error))
       })
     }
-    if (capture.has("network")) {
+    if (capture.has("network") || capturesNetworkForAssertions) {
       page.on("requestfinished", (request) => {
         const task = serializeBrowserFinishedRequest(request).then((record) => {
           progress.mark("network")
@@ -189,7 +190,11 @@ export async function runBrowserProbeCommand({
       }
     }
     if (assertions.length > 0) {
-      assertionResults = await executeBrowserProbeAssertions(page, assertions, consoleMessages, errors)
+      if (networkTasks.length > 0) {
+        await Promise.all(networkTasks)
+      }
+      const assertionMetrics = capturesBrowserMetrics ? browserProbeBenchMetrics(browserProbeMemoryArtifact(checkpoints), browserProbePerformanceArtifact(checkpoints)) : {}
+      assertionResults = await executeBrowserProbeAssertions(page, assertions, consoleMessages, errors, network, assertionMetrics)
       const fatalFailures = assertionResults.filter((assertion) => !assertion.passed && !assertion.advisory)
       if (fatalFailures.length > 0) {
         pendingError = new Error(`wordpress.browser-probe assertion failed: ${fatalFailures.map((assertion) => assertion.assertion).join(", ")}`)
@@ -236,13 +241,13 @@ export async function runBrowserProbeCommand({
       await Promise.all(networkTasks)
     }
     await browser.close()
-    if (capture.has("console")) {
+    if (capture.has("console") || capturesConsoleForAssertions) {
       await writeFile(consolePath, jsonLines(consoleMessages))
     }
-    if (capture.has("errors")) {
+    if (capture.has("errors") || capturesErrorsForAssertions) {
       await writeFile(errorsPath, jsonLines(errors))
     }
-    if (capture.has("network")) {
+    if (capture.has("network") || capturesNetworkForAssertions) {
       await writeFile(networkPath, jsonLines(network))
     }
     if (checkpoints.length > 0) {
@@ -273,12 +278,12 @@ export async function runBrowserProbeCommand({
       ...previewOrigins,
       ...(prePageScriptMetadata ? { prePageScript: prePageScriptMetadata } : {}),
       files: {
-        ...(capture.has("console") ? { console: "files/browser/console.jsonl" } : {}),
+        ...(capture.has("console") || capturesConsoleForAssertions ? { console: "files/browser/console.jsonl" } : {}),
         ...(checkpoints.length > 0 ? { checkpoints: "files/browser/checkpoints.jsonl" } : {}),
-        ...(capture.has("errors") ? { errors: "files/browser/errors.jsonl" } : {}),
+        ...(capture.has("errors") || capturesErrorsForAssertions ? { errors: "files/browser/errors.jsonl" } : {}),
         ...(capture.has("html") ? { html: "files/browser/snapshot.html" } : {}),
         ...(memoryArtifact ? { memory: "files/browser/memory.json" } : {}),
-        ...(capture.has("network") ? { network: "files/browser/network.jsonl" } : {}),
+        ...(capture.has("network") || capturesNetworkForAssertions ? { network: "files/browser/network.jsonl" } : {}),
         ...(performanceArtifact ? { performance: "files/browser/performance.json" } : {}),
         ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
         summary: "files/browser/summary.json",

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -3,6 +3,7 @@ import type {
   BrowserProbeCheckpointRecord,
   BrowserProbeMemoryArtifact,
   BrowserProbeMetricsSnapshot,
+  BrowserProbeNetworkRecord,
   BrowserProbePerformanceArtifact,
   BrowserProbeReplayability,
   BrowserProbeViewport,
@@ -122,7 +123,7 @@ export function browserProbeReplayability(capture: Set<string>): BrowserProbeRep
 export interface BrowserProbeAssertionSpec {
   raw: string
   advisory: boolean
-  type: "exists" | "not-exists" | "visible" | "hidden" | "count" | "text" | "attr" | "no-console-errors" | "no-page-errors" | "no-errors"
+  type: "exists" | "not-exists" | "visible" | "hidden" | "count" | "text" | "attr" | "no-console-errors" | "no-page-errors" | "no-errors" | "request-count-by-host" | "request-count-by-type" | "total-transfer-size" | "metric"
   selector?: string
   operator?: "=" | "==" | "!=" | ">" | ">=" | "<" | "<="
   expected?: string | number | boolean
@@ -140,12 +141,22 @@ export async function executeBrowserProbeAssertions(
   assertions: BrowserProbeAssertionSpec[],
   consoleMessages: Record<string, unknown>[],
   pageErrors: Array<{ type?: string }>,
+  network: BrowserProbeNetworkRecord[],
+  metrics: Record<string, number>,
 ): Promise<BrowserStepAssertion[]> {
   const results: BrowserStepAssertion[] = []
   for (const assertion of assertions) {
-    results.push(await executeBrowserProbeAssertion(page, assertion, consoleMessages, pageErrors))
+    results.push(await executeBrowserProbeAssertion(page, assertion, consoleMessages, pageErrors, network, metrics))
   }
   return results
+}
+
+export function browserProbeAssertionsNeedNetwork(assertions: BrowserProbeAssertionSpec[]): boolean {
+  return assertions.some((assertion) => assertion.type === "request-count-by-host" || assertion.type === "request-count-by-type" || assertion.type === "total-transfer-size")
+}
+
+export function browserProbeAssertionsNeedMetrics(assertions: BrowserProbeAssertionSpec[]): boolean {
+  return assertions.some((assertion) => assertion.type === "metric")
 }
 
 function parseBrowserProbeAssertion(value: string): BrowserProbeAssertionSpec {
@@ -205,7 +216,42 @@ function parseBrowserProbeAssertion(value: string): BrowserProbeAssertionSpec {
     return { raw: value, advisory, type: raw }
   }
 
-  throw new Error(`wordpress.browser-probe assert supports exists, not-exists, visible, hidden, count, text contains, attr, no-console-errors, no-page-errors, and no-errors: ${value}`)
+  for (const type of ["request-count-by-host", "request-count-by-type"] as const) {
+    const prefix = `${type}:`
+    if (raw.startsWith(prefix)) {
+      const parsed = parseBudgetBody(raw.slice(prefix.length).trim(), value)
+      return { raw: value, advisory, type, name: parsed.name, operator: parsed.operator, expected: parsed.expected }
+    }
+  }
+
+  if (raw.startsWith("total-transfer-size")) {
+    const parsed = parseBudgetBody(raw.slice("total-transfer-size".length).trim(), value, false)
+    return { raw: value, advisory, type: "total-transfer-size", operator: parsed.operator, expected: parsed.expected }
+  }
+
+  if (raw.startsWith("metric:")) {
+    const parsed = parseBudgetBody(raw.slice("metric:".length).trim(), value)
+    return { raw: value, advisory, type: "metric", name: parsed.name, operator: parsed.operator, expected: parsed.expected }
+  }
+
+  throw new Error(`wordpress.browser-probe assert supports exists, not-exists, visible, hidden, count, text contains, attr, no-console-errors, no-page-errors, no-errors, request-count-by-host, request-count-by-type, total-transfer-size, and metric budgets: ${value}`)
+}
+
+function parseBudgetBody(body: string, raw: string, requiresName = true): { name?: string; operator: NonNullable<BrowserProbeAssertionSpec["operator"]>; expected: number } {
+  const pattern = requiresName ? /^(.*?)(>=|<=|==|!=|=|>|<)\s*(\d+(?:\.\d+)?)$/ : /^(>=|<=|==|!=|=|>|<)\s*(\d+(?:\.\d+)?)$/
+  const parsed = body.match(pattern)
+  if (!parsed) {
+    throw new Error(`wordpress.browser-probe budget assertion must look like <name><op><number> or total-transfer-size<op><number>: ${raw}`)
+  }
+
+  const operator = (requiresName ? parsed[2] : parsed[1]) as NonNullable<BrowserProbeAssertionSpec["operator"]>
+  const expected = Number.parseFloat(requiresName ? parsed[3] : parsed[2])
+  const name = requiresName ? parsed[1].trim() : undefined
+  if (requiresName && !name) {
+    throw new Error(`wordpress.browser-probe budget assertion requires a name: ${raw}`)
+  }
+
+  return { name, operator, expected }
 }
 
 function requireSelectorAssertion(raw: string, advisory: boolean, type: BrowserProbeAssertionSpec["type"], selector: string): BrowserProbeAssertionSpec {
@@ -220,9 +266,12 @@ async function executeBrowserProbeAssertion(
   assertion: BrowserProbeAssertionSpec,
   consoleMessages: Record<string, unknown>[],
   pageErrors: Array<{ type?: string }>,
+  network: BrowserProbeNetworkRecord[],
+  metrics: Record<string, number>,
 ): Promise<BrowserStepAssertion> {
   const base = {
     kind: "probe" as const,
+    id: assertion.raw,
     assertion: assertion.raw,
     advisory: assertion.advisory,
     selector: assertion.selector,
@@ -235,50 +284,95 @@ async function executeBrowserProbeAssertion(
   switch (assertion.type) {
     case "exists": {
       const actual = await page.locator(assertion.selector ?? "").count()
-      return { ...base, actual, passed: actual > 0 }
+      return finalizeProbeAssertion(base, actual, assertion.expected, actual > 0)
     }
     case "not-exists": {
       const actual = await page.locator(assertion.selector ?? "").count()
-      return { ...base, actual, passed: actual === 0 }
+      return finalizeProbeAssertion(base, actual, assertion.expected, actual === 0)
     }
     case "visible": {
       const actual = await page.locator(assertion.selector ?? "").first().isVisible().catch(() => false)
-      return { ...base, actual, passed: actual === true }
+      return finalizeProbeAssertion(base, actual, assertion.expected, actual === true)
     }
     case "hidden": {
       const locator = page.locator(assertion.selector ?? "")
       const count = await locator.count()
       const visible = count > 0 ? await locator.first().isVisible().catch(() => false) : false
-      return { ...base, actual: { count, visible }, passed: !visible }
+      return finalizeProbeAssertion(base, { count, visible }, assertion.expected, !visible)
     }
     case "count": {
       const actual = await page.locator(assertion.selector ?? "").count()
-      return { ...base, actual, passed: compareNumbers(actual, Number(assertion.expected), assertion.operator ?? "=") }
+      return finalizeProbeAssertion(base, actual, assertion.expected, compareNumbers(actual, Number(assertion.expected), assertion.operator ?? "="))
     }
     case "text": {
       const actual = await page.locator(assertion.selector ?? "").first().textContent().catch(() => null)
       const expected = String(assertion.expected ?? "")
-      return { ...base, actual, passed: typeof actual === "string" && actual.includes(expected) }
+      return finalizeProbeAssertion(base, actual, expected, typeof actual === "string" && actual.includes(expected))
     }
     case "attr": {
       const actual = await page.locator(assertion.selector ?? "").first().getAttribute(assertion.name ?? "").catch(() => null)
       const passed = typeof assertion.expected === "undefined" ? actual !== null : actual === String(assertion.expected)
-      return { ...base, actual, passed }
+      return finalizeProbeAssertion(base, actual, assertion.expected, passed)
     }
     case "no-console-errors": {
       const actual = consoleMessages.filter((message) => message.type === "error").length
-      return { ...base, actual, expected: 0, passed: actual === 0 }
+      return finalizeProbeAssertion(base, actual, 0, actual === 0, ["files/browser/console.jsonl"])
     }
     case "no-page-errors": {
       const actual = pageErrors.filter((error) => error.type === "pageerror").length
-      return { ...base, actual, expected: 0, passed: actual === 0 }
+      return finalizeProbeAssertion(base, actual, 0, actual === 0, ["files/browser/errors.jsonl"])
     }
     case "no-errors": {
       const consoleErrorCount = consoleMessages.filter((message) => message.type === "error").length
       const pageErrorCount = pageErrors.filter((error) => error.type === "pageerror").length
       const actual = { consoleErrors: consoleErrorCount, pageErrors: pageErrorCount }
-      return { ...base, actual, expected: { consoleErrors: 0, pageErrors: 0 }, passed: consoleErrorCount === 0 && pageErrorCount === 0 }
+      return finalizeProbeAssertion(base, actual, { consoleErrors: 0, pageErrors: 0 }, consoleErrorCount === 0 && pageErrorCount === 0, ["files/browser/console.jsonl", "files/browser/errors.jsonl"])
     }
+    case "request-count-by-host": {
+      const actual = network.filter((record) => requestHost(record.url) === assertion.name).length
+      return finalizeProbeAssertion(base, actual, assertion.expected, compareNumbers(actual, Number(assertion.expected), assertion.operator ?? "<="), ["files/browser/network.jsonl"])
+    }
+    case "request-count-by-type": {
+      const actual = network.filter((record) => record.resourceType === assertion.name).length
+      return finalizeProbeAssertion(base, actual, assertion.expected, compareNumbers(actual, Number(assertion.expected), assertion.operator ?? "<="), ["files/browser/network.jsonl"])
+    }
+    case "total-transfer-size": {
+      const actual = network.reduce((total, record) => total + (typeof record.transferSize === "number" && Number.isFinite(record.transferSize) ? record.transferSize : 0), 0)
+      return finalizeProbeAssertion(base, actual, assertion.expected, compareNumbers(actual, Number(assertion.expected), assertion.operator ?? "<="), ["files/browser/network.jsonl"])
+    }
+    case "metric": {
+      const actual = metrics[assertion.name ?? ""]
+      const observed = typeof actual === "number" && Number.isFinite(actual) ? actual : null
+      const passed = typeof observed === "number" && compareNumbers(observed, Number(assertion.expected), assertion.operator ?? "<=")
+      return finalizeProbeAssertion(base, observed, assertion.expected, passed, ["files/browser/performance.json", "files/browser/memory.json"])
+    }
+  }
+}
+
+function finalizeProbeAssertion(
+  base: Omit<BrowserStepAssertion, "passed">,
+  observed: unknown,
+  expectedBudget: unknown,
+  passed: boolean,
+  supportingArtifacts: string[] = [],
+): BrowserStepAssertion {
+  return {
+    ...base,
+    status: passed ? "pass" : base.advisory ? "warn" : "fail",
+    expected: expectedBudget,
+    expectedBudget,
+    actual: observed,
+    observed,
+    ...(supportingArtifacts.length > 0 ? { supportingArtifacts } : {}),
+    passed,
+  }
+}
+
+function requestHost(url: string): string | undefined {
+  try {
+    return new URL(url).host
+  } catch {
+    return undefined
   }
 }
 

--- a/scripts/browser-probe-assertions-smoke.ts
+++ b/scripts/browser-probe-assertions-smoke.ts
@@ -37,15 +37,28 @@ const passing = await runRecipe("passing", [
   "assert=no-console-errors",
   "assert=no-page-errors",
   "assert=no-errors",
+  "assert=request-count-by-type:document>=1",
+  "assert=total-transfer-size>=0",
+  "assert=metric:browser_resource_count>=0",
 ])
 
 assert.equal(passing.success, true, passing.error?.message ?? "passing assertions should succeed")
 const passingSummary = await readSummary(passing)
-assert.equal(passingSummary.assertions.total, 10)
+assert.equal(passingSummary.assertions.total, 13)
 assert.equal(passingSummary.assertions.failed, 0)
-assert.equal(passingSummary.summary.assertions.total, 10)
+assert.equal(passingSummary.summary.assertions.total, 13)
 assert.equal(passingSummary.summary.assertions.failed, 0)
-assert.equal(commandOutput(passing).summary.assertions.total, 10, "command JSON should include assertion totals")
+const passingRequestBudget = passingSummary.assertions.results.find((result: { assertion?: string }) => result.assertion === "request-count-by-type:document>=1")
+assert.equal(passingRequestBudget.status, "pass")
+assert.equal(passingRequestBudget.expectedBudget, 1)
+assert.equal(typeof passingRequestBudget.observed, "number")
+assert.deepEqual(passingRequestBudget.supportingArtifacts, ["files/browser/network.jsonl"])
+const passingMetricBudget = passingSummary.assertions.results.find((result: { assertion?: string }) => result.assertion === "metric:browser_resource_count>=0")
+assert.equal(passingMetricBudget.status, "pass")
+assert.equal(passingMetricBudget.expectedBudget, 0)
+assert.equal(typeof passingMetricBudget.observed, "number")
+assert.deepEqual(passingMetricBudget.supportingArtifacts, ["files/browser/performance.json", "files/browser/memory.json"])
+assert.equal(commandOutput(passing).summary.assertions.total, 13, "command JSON should include assertion totals")
 
 const advisory = await runRecipe("advisory", [
   "url=/",
@@ -56,6 +69,7 @@ const advisory = await runRecipe("advisory", [
 ])
 
 assert.equal(advisory.success, true, advisory.error?.message ?? "advisory assertion failures should not fail")
+assert.equal(advisory.__exitCode, 0, "advisory assertion failures should keep command exit zero")
 const advisorySummary = await readSummary(advisory)
 assert.equal(advisorySummary.assertions.total, 2)
 assert.equal(advisorySummary.assertions.failed, 1)
@@ -67,11 +81,16 @@ const failing = await runRecipe("failing", [
   "wait-for=load",
   "capture=html",
   "assert=exists:#probe-target",
-  "assert=exists:#probe-missing",
+  "assert=request-count-by-type:document<0",
 ])
 
 assert.equal(failing.success, false, "fatal assertion failure should fail recipe-run")
+assert.notEqual(failing.__exitCode, 0, "fatal assertion failures should make command execution fail")
 const failingSummary = await readSummary(failing)
+const failingBudget = failingSummary.assertions.results.find((result: { assertion?: string }) => result.assertion === "request-count-by-type:document<0")
+assert.equal(failingBudget.status, "fail")
+assert.equal(typeof failingBudget.observed, "number")
+assert.equal(failingBudget.expectedBudget, 0)
 assert.equal(failingSummary.assertions.total, 2)
 assert.equal(failingSummary.assertions.failed, 1)
 assert.equal(failingSummary.assertions.fatalFailed, 1)
@@ -117,8 +136,8 @@ async function runRecipe(name: string, args: string[]): Promise<any> {
 }
 
 async function readSummary(output: any): Promise<any> {
-  const artifactDirectory = output.artifacts?.directory
-  assert.equal(typeof artifactDirectory, "string", "recipe-run should return artifact directory")
+  const artifactDirectory = output.artifacts?.directory ?? output.run?.artifactRefs?.find((ref: { kind?: string }) => ref.kind === "artifact-bundle")?.directory
+  assert.equal(typeof artifactDirectory, "string", "recipe-run should return artifact bundle directory")
   const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
   assert.equal(existsSync(summaryPath), true, "summary.json should be captured")
   return JSON.parse(await readFile(summaryPath, "utf8"))
@@ -151,5 +170,5 @@ async function runCli(args: string[]): Promise<any> {
   if (output.success !== false) {
     assert.equal(exitCode, 0, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
   }
-  return output
+  return { ...output, __exitCode: exitCode }
 }


### PR DESCRIPTION
## Summary
- Adds generic browser probe budget assertions for request counts by host/resource type, total transfer size, and browser metrics.
- Normalizes assertion results with machine-readable `id`, `status`, `observed`, `expectedBudget`, and supporting artifact references.
- Extends smoke coverage with passing budget assertions, advisory warning behavior, and a fatal failing budget assertion that produces non-zero command execution.

Fixes #659.

## Tests
- `npm run build`
- `npm run browser-probe-assertions-smoke`
- `npm run browser-probe-artifact-smoke`
- `npm run recipe-browser-bench-metrics-smoke`
- `npm run recipe-dry-run-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the browser assertion budget path, smoke fixture updates, and local verification; Chris remains responsible for review and merge.