### PR TITLE
Support multi-role transfer proof bundles

### DIFF
--- a/packages/runtime-core/src/transfer-proof.ts
+++ b/packages/runtime-core/src/transfer-proof.ts
@@ -12,6 +12,51 @@ export type TransferProofViolationCode =
   | "transfer-digest-mismatch"
   | "unsafe-reviewer-evidence"
 
+export type TransferProofRuntimeRole = "source" | "target" | "sandbox" | (string & {})
+
+export interface TransferProofArtifactRef {
+  path: string
+  kind: string
+  contentType?: string
+  sha256?: {
+    algorithm: "sha256"
+    value: string
+  }
+  digest?: {
+    algorithm: "sha256"
+    value: string
+  }
+}
+
+export interface TransferProofRuntimeRoleBundle {
+  role: TransferProofRuntimeRole
+  runtimeId?: string
+  sessionId?: string
+  label?: string
+  evidence: {
+    sourceInventory?: TransferProofArtifactRef
+    runtime?: TransferProofArtifactRef
+    targetBefore?: TransferProofArtifactRef
+    targetAfter?: TransferProofArtifactRef
+    sandboxRehearsal?: TransferProofArtifactRef
+    previewEvidence?: TransferProofArtifactRef
+    previewSessionEvidence?: TransferProofArtifactRef
+    probes?: TransferProofArtifactRef[]
+    diagnostics?: TransferProofArtifactRef[]
+    digestRefs?: TransferProofArtifactRef[]
+    [name: string]: TransferProofArtifactRef | TransferProofArtifactRef[] | undefined
+  }
+}
+
+export interface TransferProofBundle {
+  schema: "wp-codebox/transfer-proof-bundle/v1"
+  createdAt?: string
+  summary?: string
+  roles: TransferProofRuntimeRoleBundle[]
+  previewSessionEvidence?: TransferProofArtifactRef
+  digestRefs?: TransferProofArtifactRef[]
+}
+
 export interface TransferProofViolation {
   code: TransferProofViolationCode
   path: string
@@ -73,6 +118,7 @@ type JsonPath = Array<string | number>
 
 const REQUIRED_TRANSFER_KINDS = new Set(["preview-evidence", "preview-session-evidence", "runtime-reference-manifest", "runtime-replay-index", "diagnostics", "log", "review"])
 const REVIEWER_EVIDENCE_KINDS = new Set([
+  "transfer-proof-bundle",
   "review",
   "preview-evidence",
   "preview-session-evidence",
@@ -84,6 +130,12 @@ const REVIEWER_EVIDENCE_KINDS = new Set([
   "browser-network",
   "runtime-reference-manifest",
   "runtime-replay-index",
+  "source-inventory",
+  "target-before-evidence",
+  "target-after-evidence",
+  "sandbox-rehearsal-evidence",
+  "transfer-digest-ref",
+  "probe-results",
 ])
 
 export async function verifyTransferProofBundle(directory: string): Promise<TransferProofBundleVerificationResult> {
@@ -95,6 +147,7 @@ export async function verifyTransferProofBundle(directory: string): Promise<Tran
   if (artifactVerification.manifest) {
     verifyRequiredTransferArtifacts(artifactVerification.manifest, violations)
     await verifyPreviewSessionEvidenceRef(bundleDirectory, artifactVerification.manifest, violations)
+    await verifyTransferProofMetadata(bundleDirectory, artifactVerification.manifest, violations)
     await verifyReviewerEvidenceSafety(bundleDirectory, artifactVerification.manifest, violations)
   }
 
@@ -187,6 +240,104 @@ function verifyRequiredTransferArtifacts(manifest: ArtifactManifest, violations:
       violations.push({ code: "missing-transfer-artifact", path: "manifest.files", message: `Transfer proof bundle requires a ${kind} artifact.` })
     }
   }
+}
+
+async function verifyTransferProofMetadata(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[]): Promise<void> {
+  const metadata = await readJson(join(directory, "metadata.json"))
+  const transferProofBundle = isRecord(metadata) && isRecord(metadata.transferProofBundle) ? metadata.transferProofBundle : undefined
+  if (!transferProofBundle) {
+    return
+  }
+
+  for (const finding of unsafeReviewerEvidenceFindings(`${JSON.stringify(transferProofBundle, null, 2)}\n`, "metadata.json")) {
+    violations.push(finding)
+  }
+
+  if (transferProofBundle.schema !== "wp-codebox/transfer-proof-bundle/v1") {
+    violations.push({ code: "malformed-transfer-artifact", path: "metadata.transferProofBundle.schema", message: "Transfer proof bundle metadata must use schema wp-codebox/transfer-proof-bundle/v1." })
+  }
+  if (!Array.isArray(transferProofBundle.roles) || transferProofBundle.roles.length === 0) {
+    violations.push({ code: "missing-transfer-artifact", path: "metadata.transferProofBundle.roles", message: "Transfer proof bundle metadata requires at least one runtime role." })
+    return
+  }
+
+  const seenRoles = new Set<string>()
+  for (const [index, roleBundle] of transferProofBundle.roles.entries()) {
+    const basePath = `metadata.transferProofBundle.roles[${index}]`
+    if (!isRecord(roleBundle)) {
+      violations.push({ code: "malformed-transfer-artifact", path: basePath, message: "Transfer proof runtime role must be an object." })
+      continue
+    }
+    const role = typeof roleBundle.role === "string" ? roleBundle.role : ""
+    if (!role) {
+      violations.push({ code: "malformed-transfer-artifact", path: `${basePath}.role`, message: "Transfer proof runtime role requires a role name." })
+    } else if (seenRoles.has(role)) {
+      violations.push({ code: "malformed-transfer-artifact", path: `${basePath}.role`, message: `Transfer proof runtime role '${role}' is duplicated.` })
+    } else {
+      seenRoles.add(role)
+    }
+    if (!isRecord(roleBundle.evidence)) {
+      violations.push({ code: "missing-transfer-artifact", path: `${basePath}.evidence`, message: "Transfer proof runtime role requires evidence refs." })
+      continue
+    }
+    await verifyTransferProofEvidenceRefs(directory, manifest, roleBundle.evidence, `${basePath}.evidence`, violations)
+  }
+
+  await verifyTransferProofEvidenceRefs(directory, manifest, transferProofBundle, "metadata.transferProofBundle", violations)
+}
+
+async function verifyTransferProofEvidenceRefs(directory: string, manifest: ArtifactManifest, refs: Record<string, unknown>, basePath: string, violations: TransferProofViolation[]): Promise<void> {
+  for (const [name, value] of Object.entries(refs)) {
+    if (name === "schema" || name === "createdAt" || name === "summary" || name === "roles") {
+      continue
+    }
+    if (isArtifactRef(value)) {
+      await verifyTransferProofArtifactRef(directory, manifest, value, `${basePath}.${name}`, violations)
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (const [index, item] of value.entries()) {
+        if (isArtifactRef(item)) {
+          await verifyTransferProofArtifactRef(directory, manifest, item, `${basePath}.${name}[${index}]`, violations)
+        } else {
+          violations.push({ code: "malformed-transfer-artifact", path: `${basePath}.${name}[${index}]`, message: "Transfer proof evidence arrays may only contain artifact refs." })
+        }
+      }
+      continue
+    }
+    if (value !== undefined) {
+      violations.push({ code: "malformed-transfer-artifact", path: `${basePath}.${name}`, message: "Transfer proof evidence values must be artifact refs or arrays of artifact refs." })
+    }
+  }
+}
+
+async function verifyTransferProofArtifactRef(directory: string, manifest: ArtifactManifest, ref: Record<string, unknown>, path: string, violations: TransferProofViolation[]): Promise<void> {
+  const artifactPath = typeof ref.path === "string" ? ref.path : undefined
+  const kind = typeof ref.kind === "string" ? ref.kind : undefined
+  const manifestFile = artifactPath ? manifest.files.find((file) => file.path === artifactPath) : undefined
+  if (!artifactPath || !kind || !manifestFile || manifestFile.kind !== kind) {
+    violations.push({ code: "missing-transfer-artifact", path, ...(artifactPath ? { file: artifactPath } : {}), message: "Transfer proof evidence ref must point at a manifest file with the same kind." })
+    return
+  }
+
+  const refDigest = digestValue(ref.sha256) ?? digestValue(ref.digest)
+  if (!refDigest) {
+    violations.push({ code: "transfer-digest-mismatch", path: `${path}.sha256`, file: artifactPath, message: "Transfer proof evidence ref must include a SHA-256 digest." })
+    return
+  }
+
+  const actual = artifactFileDigest(await readFile(join(directory, artifactPath))).value
+  if (actual !== refDigest || actual !== manifestFile.sha256.value) {
+    violations.push({ code: "transfer-digest-mismatch", path: `${path}.sha256`, file: artifactPath, message: "Transfer proof evidence ref digest must match the referenced artifact and manifest file hash." })
+  }
+}
+
+function isArtifactRef(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && typeof value.path === "string" && typeof value.kind === "string"
+}
+
+function digestValue(value: unknown): string | undefined {
+  return isRecord(value) && value.algorithm === "sha256" && typeof value.value === "string" ? value.value : undefined
 }
 
 async function verifyPreviewSessionEvidenceRef(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[]): Promise<void> {

--- a/scripts/transfer-proof-smoke.ts
+++ b/scripts/transfer-proof-smoke.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
 import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -47,6 +48,9 @@ try {
   unsafeReview.preview = { url: "http://localhost:8888" }
   unsafeReview.credentials = { token: "sk-testthisshouldberejectedbecauseitislong" }
   await writeJson(join(unsafe, "files/review.json"), unsafeReview)
+  const unsafeMetadata = JSON.parse(await readText(join(unsafe, "metadata.json")))
+  unsafeMetadata.transferProofBundle.summary = "Unsafe private proof bundle URL: https://10.0.0.2/proof"
+  await writeJson(join(unsafe, "metadata.json"), unsafeMetadata)
   await rewriteManifestHashes(unsafe)
   const unsafeResult = await verifyTransferProofBundle(unsafe)
   assert.equal(unsafeResult.valid, false)
@@ -90,6 +94,12 @@ async function writeTransferBundle(directory: string): Promise<void> {
   const previewSessionEvidenceText = `${JSON.stringify(previewSessionEvidence, null, 2)}\n`
   await writeFile(join(directory, "files/preview-session-evidence.json"), previewSessionEvidenceText)
   await writeJson(join(directory, "files/diagnostics.json"), { schema: "wp-codebox/artifact-diagnostics/v1", status: "clean", summary: { total: 0, error: 0, warning: 0, notice: 0, info: 0 }, diagnostics: [] })
+  await writeJson(join(directory, "files/source-inventory.json"), { schema: "wp-codebox/source-inventory/v1", status: "captured", resources: [{ id: "post:1", type: "post", title: "Source" }] })
+  await writeJson(join(directory, "files/source-runtime.json"), { schema: "wp-codebox/runtime-evidence/v1", runtimeId: "runtime-source", status: "destroyed" })
+  await writeJson(join(directory, "files/target-before.json"), { schema: "wp-codebox/target-evidence/v1", phase: "before", resources: [] })
+  await writeJson(join(directory, "files/target-after.json"), { schema: "wp-codebox/target-evidence/v1", phase: "after", resources: [{ id: "post:1", type: "post" }] })
+  await writeJson(join(directory, "files/sandbox-rehearsal.json"), { schema: "wp-codebox/sandbox-rehearsal-evidence/v1", status: "passed", planDigest: contentDigest })
+  await writeJson(join(directory, "files/transfer-digest-ref.json"), { schema: "wp-codebox/transfer-digest-ref/v1", contentDigest: { algorithm: "sha256", value: contentDigest } })
   await writeFile(join(directory, "files/runtime.log"), "runtime completed\n")
   await writeFile(join(directory, "files/browser/network.jsonl"), `${JSON.stringify({ type: "response", url: "https://example.com/", resourceType: "document", status: 200 })}\n`)
   await writeFile(join(directory, "files/browser/console.jsonl"), "")
@@ -130,7 +140,7 @@ async function writeTransferBundle(directory: string): Promise<void> {
   }
   await writeJson(join(directory, "files/review.json"), review)
 
-  await writeJson(join(directory, "metadata.json"), {
+  const metadata = {
     id: artifactId,
     contentDigest: { algorithm: "sha256", inputs: ["files/changed-files.json", "files/patch.diff"], value: contentDigest },
     artifacts: {
@@ -147,7 +157,50 @@ async function writeTransferBundle(directory: string): Promise<void> {
       browser: "files/browser/summary.json",
     },
     previewSessionEvidence: { path: "files/preview-session-evidence.json", kind: "preview-session-evidence", contentType: "application/json", sha256: artifactFileDigest(previewSessionEvidenceText) },
-  })
+    transferProofBundle: {
+      schema: "wp-codebox/transfer-proof-bundle/v1",
+      createdAt,
+      summary: "Multi-role transfer proof fixture.",
+      roles: [
+        {
+          role: "source",
+          runtimeId: "runtime-source",
+          sessionId: "session-source",
+          evidence: {
+            sourceInventory: artifactRef(directory, "files/source-inventory.json", "source-inventory", "application/json"),
+            runtime: artifactRef(directory, "files/source-runtime.json", "runtime-evidence", "application/json"),
+            previewEvidence: artifactRef(directory, "files/preview-evidence.json", "preview-evidence", "application/json"),
+            previewSessionEvidence: artifactRef(directory, "files/preview-session-evidence.json", "preview-session-evidence", "application/json"),
+            probes: [artifactRef(directory, "files/browser/summary.json", "browser-summary", "application/json")],
+          },
+        },
+        {
+          role: "target",
+          runtimeId: "runtime-target",
+          sessionId: "session-target",
+          evidence: {
+            targetBefore: artifactRef(directory, "files/target-before.json", "target-before-evidence", "application/json"),
+            targetAfter: artifactRef(directory, "files/target-after.json", "target-after-evidence", "application/json"),
+            diagnostics: [artifactRef(directory, "files/diagnostics.json", "diagnostics", "application/json")],
+            digestRefs: [artifactRef(directory, "files/transfer-digest-ref.json", "transfer-digest-ref", "application/json")],
+          },
+        },
+        {
+          role: "sandbox",
+          runtimeId: runtime.id,
+          sessionId: "session-fixture",
+          evidence: {
+            sandboxRehearsal: artifactRef(directory, "files/sandbox-rehearsal.json", "sandbox-rehearsal-evidence", "application/json"),
+            runtime: artifactRef(directory, "files/runtime-reference-manifest.json", "runtime-reference-manifest", "application/json"),
+            probes: [artifactRef(directory, "files/browser/network.jsonl", "browser-network", "application/x-ndjson")],
+          },
+        },
+      ],
+      previewSessionEvidence: artifactRef(directory, "files/preview-session-evidence.json", "preview-session-evidence", "application/json"),
+      digestRefs: [artifactRef(directory, "files/runtime-replay-index.json", "runtime-replay-index", "application/json")],
+    },
+  }
+  await writeJson(join(directory, "metadata.json"), metadata)
 
   const manifest = manifestFixture(createdAt, runtime, artifactId, contentDigest)
   await attachManifestFileHashes(directory, manifest)
@@ -168,6 +221,12 @@ function manifestFixture(createdAt: string, runtime: RuntimeInfo, artifactId: st
       fileFixture("files/review.json", "review", "application/json"),
       fileFixture("files/test-results.json", "test-results", "application/json"),
       fileFixture("files/diagnostics.json", "diagnostics", "application/json"),
+      fileFixture("files/source-inventory.json", "source-inventory", "application/json"),
+      fileFixture("files/source-runtime.json", "runtime-evidence", "application/json"),
+      fileFixture("files/target-before.json", "target-before-evidence", "application/json"),
+      fileFixture("files/target-after.json", "target-after-evidence", "application/json"),
+      fileFixture("files/sandbox-rehearsal.json", "sandbox-rehearsal-evidence", "application/json"),
+      fileFixture("files/transfer-digest-ref.json", "transfer-digest-ref", "application/json"),
       fileFixture("files/runtime.log", "log", "text/plain"),
       fileFixture("files/runtime-episode-trace.json", "runtime-episode-trace", "application/json"),
       fileFixture("files/runtime-episode.jsonl", "runtime-episode-events", "application/x-ndjson"),
@@ -236,6 +295,11 @@ function fileFixture(path: string, kind: string, contentType: string): ArtifactM
 }
 
 function fileRef(path: string, kind: string, contentType: string, sha256: string): ArtifactManifestFile {
+  return { path, kind, contentType, sha256: { algorithm: "sha256", value: sha256 } }
+}
+
+function artifactRef(directory: string, path: string, kind: string, contentType: string) {
+  const sha256 = createHash("sha256").update(readFileSync(join(directory, path))).digest("hex")
   return { path, kind, contentType, sha256: { algorithm: "sha256", value: sha256 } }
 }
 


### PR DESCRIPTION
## Summary
- Adds a reusable `wp-codebox/transfer-proof-bundle/v1` metadata shape for role-scoped transfer proof refs across source, target, and sandbox runtimes.
- Validates every role evidence ref against the manifest, referenced artifact digest, and reviewer-facing safety checks.
- Extends the transfer proof smoke fixture to cover source inventory/runtime evidence, target before/after evidence, sandbox rehearsal evidence, preview/session evidence, probes, and digest refs while preserving single-runtime artifact verification.

Fixes #670.

## Testing
- `npm run build`
- `npm run transfer-proof-smoke`
- `npm run artifact-bundle-verifier-smoke`
- `npm run recipe-runtime-evidence-smoke`
- `npm run artifact-redaction-smoke`

## Notes
- `npm run artifact-contract-smoke` currently fails on an unrelated stale assertion: `metadata.provenance.task.previewPublicUrl` is `undefined` while the smoke expects `https://preview.example.test/codebox/`. The output preview fields still contain the public preview URL; this PR does not change that provenance path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the TypeScript verifier changes, smoke fixture updates, and local verification commands for Chris to review.