### PR TITLE
Add Agents API executor adapters

### DIFF
--- a/packages/runtime-core/src/task-input.ts
+++ b/packages/runtime-core/src/task-input.ts
@@ -4,6 +4,7 @@ import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 export type TaskTargetKind = "repo" | "site" | "plugin" | "theme" | (string & {})
 
 export const TASK_INPUT_SCHEMA = "wp-codebox/task-input/v1" as const
+export const AGENTS_API_TASK_INPUT_SCHEMA = "agents-api/task-input/v1" as const
 export const TASK_INPUT_VERSION = 1 as const
 
 export interface TaskTarget {
@@ -30,7 +31,7 @@ export interface TaskInputAgentBundle {
 }
 
 export interface TaskInput {
-  schema: typeof TASK_INPUT_SCHEMA
+  schema: typeof TASK_INPUT_SCHEMA | typeof AGENTS_API_TASK_INPUT_SCHEMA
   version: typeof TASK_INPUT_VERSION
   goal: string
   target: Partial<TaskTarget>
@@ -53,7 +54,7 @@ export const TASK_INPUT_JSON_SCHEMA = {
   type: "object",
   required: ["schema", "version", "goal", "target", "allowed_tools", "expected_artifacts", "agent_bundles", "sandbox_tool_policy", "policy", "context"],
   properties: {
-    schema: { const: TASK_INPUT_SCHEMA, description: "Task input contract schema id." },
+    schema: { enum: [TASK_INPUT_SCHEMA, AGENTS_API_TASK_INPUT_SCHEMA], description: "Task input contract schema id. The legacy WP Codebox schema remains accepted alongside the generic Agents API schema." },
     version: { const: TASK_INPUT_VERSION, description: "Task input contract version." },
     goal: { type: "string", description: "User-facing outcome the sandboxed coding agent should accomplish." },
     target: {

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/trait-wp-codebox-abilities-browser-runtime.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-blueprint.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-runner.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-connectors.php';
+require_once __DIR__ . '/trait-wp-codebox-abilities-agents-api-executors.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-utils.php';
 
 final class WP_Codebox_Abilities {
@@ -39,6 +40,7 @@ final class WP_Codebox_Abilities {
 	use WP_Codebox_Abilities_Browser_Blueprint;
 	use WP_Codebox_Abilities_Browser_Runner;
 	use WP_Codebox_Abilities_Browser_Connectors;
+	use WP_Codebox_Abilities_Agents_API_Executors;
 	use WP_Codebox_Abilities_Utils;
 
 	public function __construct() {
@@ -51,6 +53,7 @@ final class WP_Codebox_Abilities {
 		}
 
 		$this->register_category();
+		$this->register_agents_api_executor_adapters();
 		$this->register();
 		add_action( 'rest_api_init', array( self::class, 'register_rest_routes' ) );
 		self::$registered = true;

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Agents API task executor adapters for WP Codebox.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+trait WP_Codebox_Abilities_Agents_API_Executors {
+
+	private const AGENTS_API_TASK_INPUT_SCHEMA = 'agents-api/task-input/v1';
+
+	private function register_agents_api_executor_adapters(): void {
+		if ( ! function_exists( 'add_filter' ) ) {
+			return;
+		}
+
+		add_filter( 'agents_api_executor_targets', array( self::class, 'register_agents_api_executor_targets' ) );
+		add_filter( 'wp_agent_executor_targets', array( self::class, 'register_agents_api_executor_targets' ) );
+		add_filter( 'agents_api_execute_task', array( self::class, 'execute_agents_api_task' ), 10, 3 );
+		add_filter( 'wp_agent_task_handler', array( self::class, 'execute_agents_api_task' ), 10, 2 );
+	}
+
+	/** @param mixed $targets Existing executor targets. @return array<int|string,mixed> */
+	public static function register_agents_api_executor_targets( mixed $targets ): array {
+		$targets = is_array( $targets ) ? $targets : array();
+		foreach ( self::agents_api_executor_target_declarations() as $target ) {
+			$targets[ (string) $target['id'] ] = $target;
+		}
+
+		return $targets;
+	}
+
+	/** @param mixed $pre Existing dispatch result. @param mixed $request Generic task request. @param mixed $target Target id or declaration. @return mixed */
+	public static function execute_agents_api_task( mixed $pre, mixed $request, mixed $target = null ): mixed {
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
+		$target_id = self::agents_api_executor_target_id( $target, $request );
+		if ( ! in_array( $target_id, array( 'wp-codebox/browser-playground', 'wp-codebox/host-playground' ), true ) ) {
+			return $pre;
+		}
+
+		if ( ! is_array( $request ) ) {
+			return new WP_Error( 'wp_codebox_agents_api_task_request_invalid', 'Agents API task requests must be objects.', array( 'status' => 400 ) );
+		}
+
+		$input = self::agents_api_task_request_input( $request );
+		return 'wp-codebox/browser-playground' === $target_id
+			? self::create_browser_task_contract( $input )
+			: self::run_agent_task( $input );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function agents_api_executor_target_declarations(): array {
+		$task_input_schema          = self::agents_api_task_input_schema();
+		$browser_task_output_schema = self::browser_task_contract_schema();
+		$browser_task_output_schema['properties']['schema']['const'] = 'wp-codebox/browser-task-contract/v1';
+
+		return array(
+			array(
+				'schema'       => 'agents-api/executor-target/v1',
+				'id'           => 'wp-codebox/browser-playground',
+				'label'        => 'WP Codebox Browser Playground',
+				'description'  => 'Prepare the existing WP Codebox browser task contract for execution inside a browser-owned WordPress Playground.',
+				'provider'     => 'wp-codebox',
+				'kind'         => 'browser-playground',
+				'capabilities' => array( 'wordpress-playground', 'browser-runtime', 'browser-task-contract' ),
+				'input_schema'      => $task_input_schema,
+				'output_schema'     => $browser_task_output_schema,
+				'legacy_abilities' => array( 'wp-codebox/create-browser-task-contract' ),
+			),
+			array(
+				'schema'       => 'agents-api/executor-target/v1',
+				'id'           => 'wp-codebox/host-playground',
+				'label'        => 'WP Codebox Host Playground',
+				'description'  => 'Run the existing WP Codebox host sandbox runner and return the wp-codebox/run-agent-task result shape.',
+				'provider'     => 'wp-codebox',
+				'kind'         => 'host-playground',
+				'capabilities' => array( 'wordpress-playground', 'host-sandbox-runner', 'artifact-capture' ),
+				'input_schema'      => $task_input_schema,
+				'output_schema'     => array( 'type' => 'object' ),
+				'legacy_abilities' => array( 'wp-codebox/run-agent-task' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function agents_api_task_input_schema(): array {
+		$schema = self::task_input_schema();
+		$schema['$id'] = self::AGENTS_API_TASK_INPUT_SCHEMA;
+		$schema['properties']['schema']['const'] = self::AGENTS_API_TASK_INPUT_SCHEMA;
+		$schema['properties']['schema']['description'] = 'Generic Agents API task input schema id. WP Codebox also accepts legacy wp-codebox/task-input/v1 inputs for compatibility.';
+		$schema['x-wp-codebox-accepted-schemas'] = array( self::AGENTS_API_TASK_INPUT_SCHEMA, WP_Codebox_Task_Input_Contract::SCHEMA );
+
+		return $schema;
+	}
+
+	private static function agents_api_executor_target_id( mixed $target, mixed $request ): string {
+		if ( is_string( $target ) ) {
+			return $target;
+		}
+		if ( is_array( $target ) ) {
+			return trim( (string) ( $target['id'] ?? $target['target'] ?? '' ) );
+		}
+		if ( is_array( $request ) ) {
+			foreach ( array( 'executor_id', 'executor', 'target_id', 'target' ) as $field ) {
+				if ( is_string( $request[ $field ] ?? null ) ) {
+					return trim( (string) $request[ $field ] );
+				}
+				if ( is_array( $request[ $field ] ?? null ) ) {
+					$nested = $request[ $field ];
+					return trim( (string) ( $nested['id'] ?? $nested['target'] ?? '' ) );
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $request Generic task request. @return array<string,mixed> */
+	private static function agents_api_task_request_input( array $request ): array {
+		foreach ( array( 'input', 'task_input', 'task' ) as $field ) {
+			if ( is_array( $request[ $field ] ?? null ) ) {
+				return self::agents_api_task_input_with_legacy_compat( $request[ $field ], $request );
+			}
+		}
+
+		return self::agents_api_task_input_with_legacy_compat( $request, $request );
+	}
+
+	/** @param array<string,mixed> $input Task input. @param array<string,mixed> $request Full request. @return array<string,mixed> */
+	private static function agents_api_task_input_with_legacy_compat( array $input, array $request ): array {
+		if ( self::AGENTS_API_TASK_INPUT_SCHEMA === (string) ( $input['schema'] ?? '' ) ) {
+			$input['schema'] = WP_Codebox_Task_Input_Contract::SCHEMA;
+		}
+
+		$passthrough_fields = array(
+			'agent',
+			'mode',
+			'provider',
+			'model',
+			'provider_plugin_paths',
+			'agent_bundles',
+			'runtime_task',
+			'parent_request',
+			'mounts',
+			'workspaces',
+			'runtime_stack_mounts',
+			'runtime_overlays',
+			'inherit',
+			'secret_env',
+			'sandbox_session_id',
+			'orchestrator',
+			'session_id',
+			'max_turns',
+			'task_timeout_seconds',
+			'preview_hold_seconds',
+			'preview_port',
+			'preview_bind',
+			'preview_public_url',
+			'wp',
+			'artifacts_path',
+			'wp_codebox_bin',
+			'agents_api_path',
+			'data_machine_path',
+			'data_machine_code_path',
+			'authorization',
+			'playground',
+			'browser_runner',
+			'browser_plugins',
+			'runtime',
+			'blueprint',
+			'site_blueprint_artifact',
+			'artifact_files',
+			'phases',
+			'materializers',
+		);
+
+		foreach ( $passthrough_fields as $field ) {
+			if ( ! array_key_exists( $field, $input ) && array_key_exists( $field, $request ) ) {
+				$input[ $field ] = $request[ $field ];
+			}
+		}
+
+		return $input;
+	}
+}

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -403,6 +403,16 @@ $assert( 'browser task contract ability is REST visible', true === ( $browser_ta
 $assert( 'browser task contract accepts goal or legacy task', array( 'goal' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
 $assert( 'browser task contract exposes phase and compact schema', 'array' === ( $browser_task_contract_ability['input_schema']['properties']['phases']['type'] ?? '' ) && array( 'materializer' ) === ( $browser_task_contract_ability['input_schema']['properties']['phases']['items']['properties']['kind']['enum'] ?? array() ) && 'array' === ( $browser_task_contract_ability['output_schema']['properties']['phases']['type'] ?? '' ) && 'object' === ( $browser_task_contract_ability['output_schema']['properties']['compact']['type'] ?? '' ) );
 
+$agents_api_executor_targets = apply_filters( 'agents_api_executor_targets', array() );
+$wp_agent_executor_targets = apply_filters( 'wp_agent_executor_targets', array() );
+$assert( 'Agents API executor registry advertises browser and host targets', isset( $agents_api_executor_targets['wp-codebox/browser-playground'] ) && isset( $agents_api_executor_targets['wp-codebox/host-playground'] ) );
+$assert( 'WP Agent executor registry alias advertises browser and host targets', isset( $wp_agent_executor_targets['wp-codebox/browser-playground'] ) && isset( $wp_agent_executor_targets['wp-codebox/host-playground'] ) );
+$assert( 'Agents API browser executor target delegates to browser task contract shape', 'wp-codebox/browser-playground' === ( $agents_api_executor_targets['wp-codebox/browser-playground']['id'] ?? '' ) && 'wp-codebox/create-browser-task-contract' === ( $agents_api_executor_targets['wp-codebox/browser-playground']['legacy_abilities'][0] ?? '' ) && 'wp-codebox/browser-task-contract/v1' === ( $agents_api_executor_targets['wp-codebox/browser-playground']['output_schema']['properties']['schema']['const'] ?? '' ) );
+$assert( 'Agents API host executor target delegates to host sandbox result shape', 'wp-codebox/host-playground' === ( $agents_api_executor_targets['wp-codebox/host-playground']['id'] ?? '' ) && 'wp-codebox/run-agent-task' === ( $agents_api_executor_targets['wp-codebox/host-playground']['legacy_abilities'][0] ?? '' ) );
+$assert( 'Agents API executor targets accept generic and legacy task input schemas', 'agents-api/task-input/v1' === ( $agents_api_executor_targets['wp-codebox/browser-playground']['input_schema']['properties']['schema']['const'] ?? '' ) && in_array( 'wp-codebox/task-input/v1', $agents_api_executor_targets['wp-codebox/browser-playground']['input_schema']['x-wp-codebox-accepted-schemas'] ?? array(), true ) );
+$sentinel_executor_result = array( 'schema' => 'sentinel/result' );
+$assert( 'Agents API executor dispatch leaves unrelated targets untouched', $sentinel_executor_result === apply_filters( 'agents_api_execute_task', $sentinel_executor_result, array( 'goal' => 'Ignore unrelated target.' ), 'other/executor' ) );
+
 $browser_connector_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/browser-connector-request'] ?? null;
 $assert( 'browser connector request ability registered', is_array( $browser_connector_ability ) );
 $assert( 'browser connector request ability is REST visible', true === ( $browser_connector_ability['meta']['show_in_rest'] ?? false ) );
@@ -865,6 +875,27 @@ $browser_task_compact_encoded = wp_json_encode( $browser_task_contract['compact'
 $assert( 'browser task contract exposes compact product DTO with primary runner fields', ! is_wp_error( $browser_task_contract ) && 'wp-codebox/browser-task-product-dto/v1' === ( $browser_task_contract['compact']['schema'] ?? '' ) && 'wp-codebox/browser-playground-session/v1' === ( $browser_task_contract['compact']['primary']['schema'] ?? '' ) && 'wp-codebox/browser-session-product-dto/v1' === ( $browser_task_contract['compact']['primary']['dto_schema'] ?? '' ) && 'wp-codebox/workspace-recipe/v1' === ( $browser_task_contract['compact']['primary']['recipe']['schema'] ?? '' ) && isset( $browser_task_contract['compact']['primary']['recipe']['workflow'] ) && isset( $browser_task_contract['compact']['primary']['recipe']['browser']['task_path'] ) && isset( $browser_task_contract['compact']['primary']['task_payload']['schema'] ) );
 $assert( 'browser task compact DTO preserves named materializer phases', ! is_wp_error( $browser_task_contract ) && 'static-site-materializer' === ( $browser_task_contract['compact']['phases'][0]['name'] ?? '' ) && 'materializer' === ( $browser_task_contract['compact']['phases'][0]['kind'] ?? '' ) && 'wp-codebox/browser-materializer-product-dto/v1' === ( $browser_task_contract['compact']['phases'][0]['contract']['schema'] ?? '' ) && '/tmp/materializer-result.json' === ( $browser_task_contract['compact']['phases'][0]['contract']['materialization']['result_path'] ?? '' ) );
 $assert( 'browser task compact DTO omits raw runtime payloads', is_string( $browser_task_compact_encoded ) && ! str_contains( $browser_task_compact_encoded, '"pluginData"' ) && ! str_contains( $browser_task_compact_encoded, '"content"' ) && ! str_contains( $browser_task_compact_encoded, '"content_base64"' ) && ! str_contains( $browser_task_compact_encoded, 'data:application/zip;base64' ) && ! str_contains( $browser_task_compact_encoded, 'sk-browser-provider-secret' ) );
+
+$agents_api_browser_executor_result = apply_filters(
+	'agents_api_execute_task',
+	null,
+	array(
+		'target'     => 'wp-codebox/browser-playground',
+		'task_input' => array_replace( $browser_task_contract_input, array( 'schema' => 'agents-api/task-input/v1' ) ),
+	),
+	'wp-codebox/browser-playground'
+);
+$assert( 'Agents API browser executor returns the legacy browser task contract shape', ! is_wp_error( $agents_api_browser_executor_result ) && ( $browser_task_contract['schema'] ?? '' ) === ( $agents_api_browser_executor_result['schema'] ?? '' ) && ( $browser_task_contract['session']['id'] ?? '' ) === ( $agents_api_browser_executor_result['session']['id'] ?? '' ) && ( $browser_task_contract['compact']['schema'] ?? '' ) === ( $agents_api_browser_executor_result['compact']['schema'] ?? '' ) );
+
+$wp_agent_browser_task_handler_result = apply_filters(
+	'wp_agent_task_handler',
+	null,
+	array(
+		'target' => 'wp-codebox/browser-playground',
+		'input'  => $browser_task_contract_input,
+	)
+);
+$assert( 'WP Agent task handler alias returns the legacy browser task contract shape', ! is_wp_error( $wp_agent_browser_task_handler_result ) && ( $browser_task_contract['schema'] ?? '' ) === ( $wp_agent_browser_task_handler_result['schema'] ?? '' ) && ( $browser_task_contract['session']['id'] ?? '' ) === ( $wp_agent_browser_task_handler_result['session']['id'] ?? '' ) );
 
 $invalid_browser_task_contract = call_user_func(
 	$browser_task_contract_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Registers WP Codebox browser and host Playground executor targets for the Agents API task execution substrate.
- Delegates browser execution to the existing browser task contract path and host execution to the existing `wp-codebox/run-agent-task` sandbox runner path.
- Accepts the generic `agents-api/task-input/v1` schema while preserving legacy `wp-codebox/task-input/v1` compatibility and Codebox-owned runtime fields.

## Notes
- Agents API issue #309 is still open and no implementation PR was discoverable, so this keeps the adapter behind filter-based compatibility hooks and aliases matching the existing Agents API chat handler style.
- Existing WP Codebox abilities remain registered unchanged for compatibility.

Closes #674.
Depends on Automattic/agents-api#309.

## Testing
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php`
- `npm run build`
- `npm run task-input-contract-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the executor adapter wiring, compatibility normalization, and smoke coverage; Chris remains responsible for review and merge.