### PR TITLE
Emit browser executor metrics

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -203,6 +203,7 @@ $payload = ' . var_export( $default_payload, true ) . ';
 $invocation = ' . var_export( $default_invocation, true ) . ';
 $capture_paths = ' . var_export( $default_captures, true ) . ';
 $started_at = gmdate( \'c\' );
+$started_monotonic = microtime( true );
 
 function wp_codebox_browser_normalize_error( $error ) {
 if ( is_wp_error( $error ) ) {
@@ -256,7 +257,7 @@ if ( $max_bytes > 0 ) {
 		$record[\'encoding\'] = \'base64\';
 	}
 }
-return array_filter( $record, static fn( $value ) => \'\' !== $value );
+return array_filter( $record, static fn( $value ) => array() !== $value && \'\' !== $value );
 }
 
 function wp_codebox_browser_event_scalar( $value, string $key = "" ) {
@@ -747,6 +748,185 @@ return array_filter( array(
 ) );
 }
 
+function wp_codebox_browser_json_bytes( $value ): int {
+$encoded = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+return is_string( $encoded ) ? strlen( $encoded ) : 0;
+}
+
+function wp_codebox_browser_failure_class( string $code ): string {
+if ( "" === $code ) {
+    return "";
+}
+if ( str_contains( $code, "timeout" ) ) {
+    return "timeout";
+}
+if ( str_contains( $code, "permission" ) || str_contains( $code, "authorization" ) || str_contains( $code, "not_playground" ) ) {
+    return "authorization";
+}
+if ( str_contains( $code, "unavailable" ) || str_contains( $code, "missing" ) ) {
+    return "dependency_unavailable";
+}
+if ( str_contains( $code, "invalid" ) ) {
+    return "invalid_request";
+}
+
+return "runtime_error";
+}
+
+function wp_codebox_browser_artifact_metrics( array $artifact_bundle ): array {
+$files = is_array( $artifact_bundle["files"] ?? null ) ? $artifact_bundle["files"] : array();
+$bytes = 0;
+foreach ( $files as $file ) {
+    if ( ! is_array( $file ) ) {
+        continue;
+    }
+    if ( is_string( $file["content"] ?? null ) ) {
+        $bytes += strlen( $file["content"] );
+    } elseif ( is_string( $file["content_base64"] ?? null ) ) {
+        $decoded = base64_decode( $file["content_base64"], true );
+        $bytes += is_string( $decoded ) ? strlen( $decoded ) : strlen( $file["content_base64"] );
+    }
+}
+
+return array_filter( array(
+    "schema" => (string) ( $artifact_bundle["schema"] ?? "" ),
+    "file_count" => count( $files ),
+    "bytes" => $bytes,
+    "entrypoint" => (string) ( $artifact_bundle["entrypoint"] ?? "" ),
+) );
+}
+
+function wp_codebox_browser_capture_metrics( array $captures ): array {
+$records = array();
+$bytes = 0;
+foreach ( $captures as $capture ) {
+    if ( ! is_array( $capture ) ) {
+        continue;
+    }
+    $size = isset( $capture["size"] ) ? (int) $capture["size"] : 0;
+    $bytes += $size;
+    $records[] = array_filter( array(
+        "path" => (string) ( $capture["path"] ?? "" ),
+        "name" => (string) ( $capture["name"] ?? "" ),
+        "kind" => (string) ( $capture["kind"] ?? "" ),
+        "exists" => isset( $capture["exists"] ) ? (bool) $capture["exists"] : null,
+        "bytes" => $size,
+        "sha256" => (string) ( $capture["sha256"] ?? "" ),
+        "truncated" => isset( $capture["truncated"] ) ? (bool) $capture["truncated"] : null,
+    ), static fn( $value ) => null !== $value && "" !== $value );
+}
+
+return array(
+    "count" => count( $captures ),
+    "bytes" => $bytes,
+    "records" => $records,
+);
+}
+
+function wp_codebox_browser_event_metrics( string $event_path ): array {
+$metrics = array(
+    "path" => $event_path,
+    "exists" => is_readable( $event_path ),
+    "bytes" => is_readable( $event_path ) ? (int) filesize( $event_path ) : 0,
+    "event_count" => 0,
+    "tool_call_count" => 0,
+    "tool_duration_ms" => 0,
+    "tools" => array(),
+);
+if ( ! is_readable( $event_path ) ) {
+    return $metrics;
+}
+
+$lines = file( $event_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES );
+foreach ( is_array( $lines ) ? $lines : array() as $line ) {
+    $event = json_decode( (string) $line, true );
+    if ( ! is_array( $event ) ) {
+        continue;
+    }
+    ++$metrics["event_count"];
+    $payload = is_array( $event["payload"] ?? null ) ? $event["payload"] : array();
+    $tool_name = is_scalar( $payload["tool_name"] ?? null ) ? (string) $payload["tool_name"] : "";
+    if ( "" === $tool_name && is_string( $event["event"] ?? null ) && str_contains( (string) $event["event"], "tool" ) ) {
+        $tool_name = "unknown";
+    }
+    if ( "" === $tool_name ) {
+        continue;
+    }
+
+    ++$metrics["tool_call_count"];
+    $duration = isset( $payload["duration_ms"] ) && is_numeric( $payload["duration_ms"] ) ? (int) $payload["duration_ms"] : ( isset( $payload["elapsed_ms"] ) && is_numeric( $payload["elapsed_ms"] ) ? (int) $payload["elapsed_ms"] : 0 );
+    $metrics["tool_duration_ms"] += $duration;
+    if ( ! isset( $metrics["tools"][ $tool_name ] ) ) {
+        $metrics["tools"][ $tool_name ] = array( "count" => 0, "duration_ms" => 0 );
+    }
+    ++$metrics["tools"][ $tool_name ]["count"];
+    $metrics["tools"][ $tool_name ]["duration_ms"] += $duration;
+}
+
+ksort( $metrics["tools"] );
+return $metrics;
+}
+
+function wp_codebox_browser_execution_metrics( array $payload, array $invocation_metadata, array $captures, array $artifact_bundle, array $diagnostics, $response, float $started_monotonic ): array {
+$failed = is_wp_error( $response ) || $response instanceof Throwable;
+$error = $failed ? wp_codebox_browser_normalize_error( $response ) : array();
+$event_metrics = wp_codebox_browser_event_metrics( (string) ( $diagnostics["event_stream"]["path"] ?? "/tmp/wp-codebox-agent-events.jsonl" ) );
+$capture_metrics = wp_codebox_browser_capture_metrics( $captures );
+$artifact_metrics = wp_codebox_browser_artifact_metrics( $artifact_bundle );
+$elapsed_ms = max( 0, (int) round( ( microtime( true ) - $started_monotonic ) * 1000 ) );
+
+return array_filter( array(
+    "schema" => "agents-api/execution-metrics/v1",
+    "executor" => "wp-codebox/browser-playground",
+    "phase" => "execution",
+    "status" => $failed ? "error" : "completed",
+    "execution" => "browser-playground",
+    "execution_scope" => "disposable-playground",
+    "permission_model" => "runtime-principal",
+    "timings_ms" => array(
+        "total_ms" => $elapsed_ms,
+        "agent_loop_ms" => $elapsed_ms,
+        "tool_calls_ms" => (int) $event_metrics["tool_duration_ms"],
+        "browser_startup_ms" => null,
+        "playground_startup_ms" => null,
+        "blueprint_run_ms" => null,
+    ),
+    "tool_calls" => array(
+        "count" => (int) $event_metrics["tool_call_count"],
+        "duration_ms" => (int) $event_metrics["tool_duration_ms"],
+        "by_tool" => $event_metrics["tools"],
+    ),
+    "payload_bytes" => array_filter( array(
+        "task_payload" => wp_codebox_browser_json_bytes( $payload ),
+        "invocation" => wp_codebox_browser_json_bytes( $invocation_metadata ),
+        "response_summary" => wp_codebox_browser_json_bytes( $diagnostics["response"] ?? array() ),
+    ), static fn( $bytes ) => is_int( $bytes ) && $bytes > 0 ),
+    "artifact_bytes" => array(
+        "captures" => (int) $capture_metrics["bytes"],
+        "artifact_bundle" => (int) ( $artifact_metrics["bytes"] ?? 0 ),
+    ),
+    "artifacts" => array(
+        "capture_count" => (int) $capture_metrics["count"],
+        "artifact_file_count" => (int) ( $artifact_metrics["file_count"] ?? 0 ),
+        "artifact_schema" => (string) ( $artifact_metrics["schema"] ?? "" ),
+        "entrypoint" => (string) ( $artifact_metrics["entrypoint"] ?? "" ),
+    ),
+    "diagnostics_refs" => array(
+        "event_stream" => array_diff_key( $event_metrics, array( "tools" => true ) ),
+        "captures" => $capture_metrics["records"],
+        "provider_proxy" => array_filter( array(
+            "installed" => isset( $diagnostics["provider_proxy"]["installed"] ) ? (bool) $diagnostics["provider_proxy"]["installed"] : null,
+            "early_return" => (string) ( $diagnostics["provider_proxy"]["early_return"] ?? "" ),
+            "connector_count" => isset( $diagnostics["provider_proxy"]["connector_count"] ) ? (int) $diagnostics["provider_proxy"]["connector_count"] : null,
+        ), static fn( $value ) => null !== $value && "" !== $value ),
+    ),
+    "failure" => $failed ? array(
+        "class" => wp_codebox_browser_failure_class( (string) ( $error["code"] ?? "" ) ),
+        "code" => (string) ( $error["code"] ?? "" ),
+    ) : array(),
+) );
+}
+
 function wp_codebox_browser_input_control_diagnostics( array $input ): array {
 return array_filter( array(
 	\'has_tool_policy\' => is_array( $input[\'tool_policy\'] ?? null ),
@@ -1136,6 +1316,7 @@ $diagnostics = array(
 \'artifact_capture\' => wp_codebox_browser_artifact_capture_diagnostics( $payload, $artifact_bundle ),
 \'response\' => wp_codebox_browser_response_diagnostics( $response ?? null ),
 );
+$execution_metrics = wp_codebox_browser_execution_metrics( $payload, $invocation_metadata, $captures, $artifact_bundle, $diagnostics, $response ?? null, $started_monotonic );
 $provenance = array(
 \'generated_by\' => \'wp-codebox/browser-runner\',
 \'session_id\' => $session_id,
@@ -1161,6 +1342,7 @@ $result = array(
 		\'invocation\' => $invocation_metadata,
 		\'captures\' => $captures,
 		\'diagnostics\' => $diagnostics,
+		\'execution_metrics\' => $execution_metrics,
 		\'error\' => $error,
 		\'errors\' => array( $error ),
 		\'provenance\' => $provenance,
@@ -1178,6 +1360,7 @@ $result = array(
 		\'response\' => $response,
 		\'captures\' => $captures,
 		\'diagnostics\' => $diagnostics,
+		\'execution_metrics\' => $execution_metrics,
 		\'errors\' => array(),
 		\'provenance\' => $provenance,
 		\'artifacts\' => $payload[\'artifacts\'] ?? array(),

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -199,6 +199,7 @@ public static function create_browser_task_contract( array $input ): array|WP_Er
 				'session'          => $session_envelope,
 				'primary'          => $primary,
 				'phases'           => array(),
+				'execution_metrics' => self::browser_contract_execution_metrics( $primary, array() ),
 			),
 			static fn( mixed $value ): bool => array() !== $value && '' !== $value
 		);
@@ -221,6 +222,7 @@ public static function create_browser_task_contract( array $input ): array|WP_Er
 		'session'          => $session_envelope,
 		'primary'          => $primary,
 		'phases'           => $phases,
+		'execution_metrics' => self::browser_contract_execution_metrics( $primary, $phases ),
 		'provenance'       => array(
 			'generated_by' => 'wp-codebox/browser-task-contract',
 			'source'       => 'wp-codebox/create-browser-playground-session',
@@ -264,10 +266,94 @@ private static function compact_browser_task_contract_dto( array $contract ): ar
 			'session'          => is_array( $contract['session'] ?? null ) ? self::compact_browser_dto_value( $contract['session'] ) : array(),
 			'primary'          => is_array( $contract['primary'] ?? null ) ? self::compact_browser_session_dto( $contract['primary'] ) : array(),
 			'phases'           => $phases,
+			'execution_metrics' => is_array( $contract['execution_metrics'] ?? null ) ? self::compact_browser_dto_value( $contract['execution_metrics'] ) : array(),
 			'provenance'       => is_array( $contract['provenance'] ?? null ) ? self::compact_browser_dto_value( $contract['provenance'] ) : array(),
 		),
 		static fn( mixed $value ): bool => array() !== $value && '' !== $value
 	);
+}
+
+/** @param array<string,mixed> $primary Primary browser session. @param array<int,array<string,mixed>> $phases Browser phases. @return array<string,mixed> */
+private static function browser_contract_execution_metrics( array $primary, array $phases ): array {
+	$recipe       = is_array( $primary['recipe'] ?? null ) ? $primary['recipe'] : array();
+	$playground   = is_array( $primary['playground'] ?? null ) ? $primary['playground'] : array();
+	$blueprint    = is_array( $playground['blueprint'] ?? null ) ? $playground['blueprint'] : array();
+	$browser      = is_array( $recipe['browser'] ?? null ) ? $recipe['browser'] : array();
+	$captures     = is_array( $browser['captures'] ?? null ) ? $browser['captures'] : array();
+	$task_payload = is_array( $primary['task_payload'] ?? null ) ? $primary['task_payload'] : array();
+	$artifacts    = is_array( $primary['artifacts'] ?? null ) ? $primary['artifacts'] : array();
+	$error        = is_array( $primary['error'] ?? null ) ? $primary['error'] : array();
+
+	return array_filter(
+		array(
+			'schema'           => 'agents-api/execution-metrics/v1',
+			'executor'         => 'wp-codebox/browser-playground',
+			'phase'            => 'contract',
+			'status'           => true === ( $primary['success'] ?? false ) ? 'pending' : (string) ( $primary['status'] ?? 'blocked' ),
+			'execution'        => 'browser-playground',
+			'execution_scope'  => 'disposable-playground',
+			'permission_model' => 'runtime-principal',
+			'timings_ms'       => array(
+				'browser_startup_ms'    => null,
+				'playground_startup_ms' => null,
+				'blueprint_run_ms'      => null,
+				'agent_loop_ms'         => null,
+			),
+			'payload_bytes'    => array_filter(
+				array(
+					'task_payload' => self::browser_metrics_json_bytes( $task_payload ),
+					'recipe'       => self::browser_metrics_json_bytes( $recipe ),
+					'blueprint'    => self::browser_metrics_json_bytes( $blueprint ),
+				),
+				static fn( int $bytes ): bool => $bytes > 0
+			),
+			'artifacts'        => array(
+				'expected_count'       => is_array( $artifacts['expected_artifacts'] ?? null ) ? count( $artifacts['expected_artifacts'] ) : 0,
+				'declared_file_count'  => is_array( $artifacts['files'] ?? null ) ? count( $artifacts['files'] ) : 0,
+				'capture_path_count'   => count( $captures ),
+				'materializer_phases'  => count( $phases ),
+			),
+			'diagnostics_refs' => array_filter(
+				array(
+					'materialization_result_path' => (string) ( $browser['result_path'] ?? '' ),
+					'event_stream_path'           => '/tmp/wp-codebox-agent-events.jsonl',
+					'capture_paths'               => array_values( array_filter( array_map( static fn( mixed $capture ): string => is_array( $capture ) ? (string) ( $capture['path'] ?? '' ) : '', $captures ) ) ),
+					'provider_proxy'              => 'browser-result.diagnostics.provider_proxy',
+				),
+				static fn( mixed $value ): bool => array() !== $value && '' !== $value
+			),
+			'failure'          => empty( $error ) ? array() : array(
+				'class' => self::browser_metrics_failure_class( (string) ( $error['code'] ?? '' ) ),
+				'code'  => (string) ( $error['code'] ?? '' ),
+			),
+		),
+		static fn( mixed $value ): bool => array() !== $value && '' !== $value
+	);
+}
+
+private static function browser_metrics_json_bytes( mixed $value ): int {
+	$encoded = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+	return is_string( $encoded ) ? strlen( $encoded ) : 0;
+}
+
+private static function browser_metrics_failure_class( string $code ): string {
+	if ( '' === $code ) {
+		return '';
+	}
+	if ( str_contains( $code, 'timeout' ) ) {
+		return 'timeout';
+	}
+	if ( str_contains( $code, 'permission' ) || str_contains( $code, 'authorization' ) || str_contains( $code, 'not_playground' ) ) {
+		return 'authorization';
+	}
+	if ( str_contains( $code, 'unavailable' ) || str_contains( $code, 'missing' ) ) {
+		return 'dependency_unavailable';
+	}
+	if ( str_contains( $code, 'invalid' ) ) {
+		return 'invalid_request';
+	}
+
+	return 'runtime_error';
 }
 
 /** @param array<string,mixed> $contract Browser materializer contract. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -379,6 +379,7 @@ private static function browser_task_contract_schema(): array {
 				'description' => 'Named browser task phases. The first supported kind is materializer, which returns a browser-materializer-contract envelope.',
 				'items'       => array( 'type' => 'object' ),
 			),
+			'execution_metrics' => array( 'type' => 'object' ),
 			'provenance'       => array( 'type' => 'object' ),
 			'compact'          => self::browser_product_dto_schema(),
 		),
@@ -407,6 +408,7 @@ private static function browser_product_dto_schema(): array {
 			'playground'       => array( 'type' => 'object' ),
 			'recipe'           => array( 'type' => 'object' ),
 			'artifacts'        => array( 'type' => 'object' ),
+			'execution_metrics' => array( 'type' => 'object' ),
 		),
 	);
 }

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -886,6 +886,9 @@ $agents_api_browser_executor_result = apply_filters(
 	'wp-codebox/browser-playground'
 );
 $assert( 'Agents API browser executor returns the legacy browser task contract shape', ! is_wp_error( $agents_api_browser_executor_result ) && ( $browser_task_contract['schema'] ?? '' ) === ( $agents_api_browser_executor_result['schema'] ?? '' ) && ( $browser_task_contract['session']['id'] ?? '' ) === ( $agents_api_browser_executor_result['session']['id'] ?? '' ) && ( $browser_task_contract['compact']['schema'] ?? '' ) === ( $agents_api_browser_executor_result['compact']['schema'] ?? '' ) );
+$agents_api_browser_executor_metrics_encoded = wp_json_encode( $agents_api_browser_executor_result['execution_metrics'] ?? array() );
+$assert( 'Agents API browser executor exposes normalized execution metrics', ! is_wp_error( $agents_api_browser_executor_result ) && 'agents-api/execution-metrics/v1' === ( $agents_api_browser_executor_result['execution_metrics']['schema'] ?? '' ) && 'wp-codebox/browser-playground' === ( $agents_api_browser_executor_result['execution_metrics']['executor'] ?? '' ) && 'contract' === ( $agents_api_browser_executor_result['execution_metrics']['phase'] ?? '' ) && 'pending' === ( $agents_api_browser_executor_result['execution_metrics']['status'] ?? '' ) && isset( $agents_api_browser_executor_result['execution_metrics']['payload_bytes']['task_payload'] ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $agents_api_browser_executor_result['execution_metrics']['diagnostics_refs']['event_stream_path'] ?? '' ) );
+$assert( 'Agents API browser executor metrics are secret-safe summaries', is_string( $agents_api_browser_executor_metrics_encoded ) && ! str_contains( $agents_api_browser_executor_metrics_encoded, 'sk-browser-provider-secret' ) && ! str_contains( $agents_api_browser_executor_metrics_encoded, 'data:application/zip;base64' ) && ! str_contains( $agents_api_browser_executor_metrics_encoded, 'pluginData' ) );
 
 $wp_agent_browser_task_handler_result = apply_filters(
 	'wp_agent_task_handler',
@@ -916,6 +919,21 @@ $runner_report_path = $root . '/browser-materialization-report.json';
 add_filter(
 	'caller_runtime_task',
 	static function ( $result, array $input, array $payload ) use ( $runner_report_path ): array {
+		file_put_contents(
+			'/tmp/wp-codebox-agent-events.jsonl',
+			wp_json_encode(
+				array(
+					'schema'     => 'wp-codebox/browser-agent-event/v1',
+					'event'      => 'tool.completed',
+					'payload'    => array(
+						'tool_name'   => 'client/filesystem-write',
+						'duration_ms' => 37,
+						'success'     => true,
+					),
+					'emitted_at' => gmdate( 'c' ),
+				)
+			) . "\n"
+		);
 		file_put_contents(
 			$runner_report_path,
 			wp_json_encode(
@@ -1013,6 +1031,9 @@ $assert( 'browser Playground generated runner captures normalized materializatio
 $assert( 'browser Playground generated runner writes result evidence file', is_array( $runner_result_file ) && $runner_result === $runner_result_file );
 $assert( 'browser Playground generated runner records diagnostics and provenance', is_array( $runner_result ) && array() === ( $runner_result['errors'] ?? null ) && 'wp-codebox/browser-runner' === ( $runner_result['provenance']['generated_by'] ?? '' ) && '/tmp/wp-codebox-agent-result.json' === ( $runner_result['provenance']['result_path'] ?? '' ) );
 $assert( 'browser Playground generated runner captures agent event stream diagnostics', is_array( $runner_result ) && 2 === ( $runner_result['diagnostics']['capture_count'] ?? 0 ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $runner_result['diagnostics']['event_stream']['path'] ?? '' ) && false === ( $runner_result['diagnostics']['event_stream']['sink_attached'] ?? true ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $runner_result['captures'][1]['path'] ?? '' ) && 'events' === ( $runner_result['captures'][1]['kind'] ?? '' ) );
+$runner_metrics_encoded = wp_json_encode( $runner_result['execution_metrics'] ?? array() );
+$assert( 'browser Playground generated runner emits normalized execution metrics', is_array( $runner_result ) && 'agents-api/execution-metrics/v1' === ( $runner_result['execution_metrics']['schema'] ?? '' ) && 'wp-codebox/browser-playground' === ( $runner_result['execution_metrics']['executor'] ?? '' ) && 'execution' === ( $runner_result['execution_metrics']['phase'] ?? '' ) && 'completed' === ( $runner_result['execution_metrics']['status'] ?? '' ) && 1 === ( $runner_result['execution_metrics']['tool_calls']['count'] ?? 0 ) && 37 === ( $runner_result['execution_metrics']['tool_calls']['duration_ms'] ?? 0 ) && 2 === ( $runner_result['execution_metrics']['artifacts']['capture_count'] ?? 0 ) );
+$assert( 'browser Playground execution metrics summarize artifacts without raw payloads or secrets', is_string( $runner_metrics_encoded ) && isset( $runner_result['execution_metrics']['artifact_bytes']['captures'] ) && ! str_contains( $runner_metrics_encoded, 'sk-browser-provider-secret' ) && ! str_contains( $runner_metrics_encoded, '<main>Generic caller artifact</main>' ) && ! str_contains( $runner_metrics_encoded, 'RIFFfixtureWEBP' ) );
 $assert( 'browser Playground generated runner captures caller-owned artifact schema', is_array( $runner_result ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['artifact_bundle']['schema'] ?? '' ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['response']['artifact_bundle']['schema'] ?? '' ) );
 $assert( 'browser Playground generated runner preserves caller artifact metadata and roles', is_array( $runner_result ) && array( 'non-studio-web' ) === ( $runner_result['artifact_bundle']['metadata']['labels'] ?? array() ) && array( 'preview' => 'generic-output/index.html' ) === ( $runner_result['artifact_bundle']['roles'] ?? array() ) && array( 'preview' ) === ( $runner_result['artifact_bundle']['files'][0]['roles'] ?? array() ) && 'entrypoint' === ( $runner_result['artifact_bundle']['files'][0]['metadata']['opaque'] ?? '' ) );
 $assert( 'browser Playground generated runner captures text and base64 artifact files', is_array( $runner_result ) && 2 === count( $runner_result['artifact_bundle']['files'] ?? array() ) && '<main>Generic caller artifact</main>' === ( $runner_result['artifact_bundle']['files'][0]['content'] ?? '' ) && 'utf-8' === ( $runner_result['artifact_bundle']['files'][0]['encoding'] ?? '' ) && 'base64' === ( $runner_result['artifact_bundle']['files'][1]['encoding'] ?? '' ) && hash( 'sha256', "\x89PNG\r\n\x1a\ngeneric" ) === ( $runner_result['artifact_bundle']['files'][1]['sha256'] ?? '' ) );


### PR DESCRIPTION
## Summary
- Adds normalized `execution_metrics` summaries to WP Codebox browser task contracts and generated browser runner results.
- Summarizes payload, tool-call, capture, artifact, provider-diagnostic, timing, and failure-class signals without duplicating raw artifacts or secret-bearing payloads.
- Extends the WordPress plugin smoke to prove Agents API browser executor metrics are present and secret-safe.

Closes #677.

## Testing
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php`
- `npm run task-input-contract-smoke`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the browser executor metrics emission path, added smoke coverage, and ran verification; Chris remains responsible for review and merge.