### PR TITLE
Generalize browser task phases

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -641,13 +641,16 @@ final class WP_Codebox_Abilities {
 							'artifact_files'     => array( 'type' => 'array' ),
 							'phases'             => array(
 								'type'        => 'array',
-								'description' => 'Optional named browser task phases. Each materializer phase may override any primary session input through input.',
+								'description' => 'Optional named browser task phases. Generic phases describe product-owned agent fanout steps; materializer phases may override any primary session input through input.',
 								'items'       => array(
 									'type'       => 'object',
 									'properties' => array(
-										'name'  => array( 'type' => 'string' ),
-										'kind'  => array( 'type' => 'string', 'enum' => array( 'materializer' ) ),
-										'input' => array( 'type' => 'object' ),
+										'name'     => array( 'type' => 'string' ),
+										'kind'     => array( 'type' => 'string', 'enum' => self::browser_task_phase_kinds() ),
+										'label'    => array( 'type' => 'string' ),
+										'status'   => array( 'type' => 'string' ),
+										'metadata' => array( 'type' => 'object' ),
+										'input'    => array( 'type' => 'object' ),
 									),
 								),
 							),

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -242,9 +242,12 @@ private static function compact_browser_task_contract_dto( array $contract ): ar
 		}
 
 		$phase_dto = array(
-			'name'  => (string) ( $phase['name'] ?? '' ),
-			'kind'  => (string) ( $phase['kind'] ?? '' ),
-			'index' => (int) ( $phase['index'] ?? 0 ),
+			'name'     => (string) ( $phase['name'] ?? '' ),
+			'kind'     => (string) ( $phase['kind'] ?? '' ),
+			'index'    => (int) ( $phase['index'] ?? 0 ),
+			'label'    => (string) ( $phase['label'] ?? '' ),
+			'status'   => (string) ( $phase['status'] ?? '' ),
+			'metadata' => is_array( $phase['metadata'] ?? null ) ? self::compact_browser_dto_value( $phase['metadata'] ) : array(),
 		);
 		if ( is_array( $phase['contract'] ?? null ) ) {
 			$phase_dto['contract'] = self::compact_browser_materializer_contract_dto( $phase['contract'] );
@@ -311,7 +314,8 @@ private static function browser_contract_execution_metrics( array $primary, arra
 				'expected_count'       => is_array( $artifacts['expected_artifacts'] ?? null ) ? count( $artifacts['expected_artifacts'] ) : 0,
 				'declared_file_count'  => is_array( $artifacts['files'] ?? null ) ? count( $artifacts['files'] ) : 0,
 				'capture_path_count'   => count( $captures ),
-				'materializer_phases'  => count( $phases ),
+				'phase_count'          => count( $phases ),
+				'materializer_phases'  => count( array_filter( $phases, static fn( mixed $phase ): bool => is_array( $phase ) && 'materializer' === (string) ( $phase['kind'] ?? '' ) ) ),
 			),
 			'diagnostics_refs' => array_filter(
 				array(
@@ -504,8 +508,22 @@ private static function browser_task_contract_phases( array $input, array $sessi
 		}
 
 		$kind = self::safe_key( (string) ( $phase['kind'] ?? 'materializer' ) );
+		if ( ! in_array( $kind, self::browser_task_phase_kinds(), true ) ) {
+			return new WP_Error( 'wp_codebox_browser_phase_kind_invalid', 'Browser task phases support materializer, agent, validator, repair, and aggregator kinds.', array( 'status' => 400, 'index' => $index, 'kind' => $kind ) );
+		}
+
+		$phase_descriptor = array(
+			'name'     => self::safe_key( (string) ( $phase['name'] ?? $kind . '-' . ( $index + 1 ) ) ),
+			'kind'     => $kind,
+			'index'    => $index,
+			'label'    => (string) ( $phase['label'] ?? '' ),
+			'status'   => (string) ( $phase['status'] ?? 'pending' ),
+			'metadata' => is_array( $phase['metadata'] ?? null ) ? self::compact_browser_dto_value( $phase['metadata'] ) : array(),
+		);
+
 		if ( 'materializer' !== $kind ) {
-			return new WP_Error( 'wp_codebox_browser_phase_kind_invalid', 'Browser task phases currently support materializer phases only.', array( 'status' => 400, 'index' => $index, 'kind' => $kind ) );
+			$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
+			continue;
 		}
 
 		$phase_input = is_array( $phase['input'] ?? null ) ? $phase['input'] : array();
@@ -521,12 +539,8 @@ private static function browser_task_contract_phases( array $input, array $sessi
 			return $contract;
 		}
 
-		$phases[] = array(
-			'name'     => self::safe_key( (string) ( $phase['name'] ?? $kind . '-' . ( $index + 1 ) ) ),
-			'kind'     => $kind,
-			'index'    => $index,
-			'contract' => $contract,
-		);
+		$phase_descriptor['contract'] = $contract;
+		$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 	}
 
 	return $phases;

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -376,14 +376,30 @@ private static function browser_task_contract_schema(): array {
 			'primary'          => self::browser_playground_session_schema(),
 			'phases'           => array(
 				'type'        => 'array',
-				'description' => 'Named browser task phases. The first supported kind is materializer, which returns a browser-materializer-contract envelope.',
-				'items'       => array( 'type' => 'object' ),
+				'description' => 'Named browser task phases. Materializer phases include a browser-materializer-contract envelope; generic phases preserve product-neutral phase metadata for product UIs.',
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'name'     => array( 'type' => 'string' ),
+						'kind'     => array( 'type' => 'string', 'enum' => self::browser_task_phase_kinds() ),
+						'index'    => array( 'type' => 'integer' ),
+						'label'    => array( 'type' => 'string' ),
+						'status'   => array( 'type' => 'string' ),
+						'metadata' => array( 'type' => 'object' ),
+						'contract' => array( 'type' => 'object' ),
+					),
+				),
 			),
 			'execution_metrics' => array( 'type' => 'object' ),
 			'provenance'       => array( 'type' => 'object' ),
 			'compact'          => self::browser_product_dto_schema(),
 		),
 	);
+}
+
+/** @return array<int,string> */
+private static function browser_task_phase_kinds(): array {
+	return array( 'materializer', 'agent', 'validator', 'repair', 'aggregator' );
 }
 
 /** @return array<string,mixed> */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -401,7 +401,8 @@ $browser_task_contract_ability = $GLOBALS['wp_codebox_registered_abilities']['wp
 $assert( 'browser task contract ability registered', is_array( $browser_task_contract_ability ) );
 $assert( 'browser task contract ability is REST visible', true === ( $browser_task_contract_ability['meta']['show_in_rest'] ?? false ) );
 $assert( 'browser task contract accepts goal or legacy task', array( 'goal' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
-$assert( 'browser task contract exposes phase and compact schema', 'array' === ( $browser_task_contract_ability['input_schema']['properties']['phases']['type'] ?? '' ) && array( 'materializer' ) === ( $browser_task_contract_ability['input_schema']['properties']['phases']['items']['properties']['kind']['enum'] ?? array() ) && 'array' === ( $browser_task_contract_ability['output_schema']['properties']['phases']['type'] ?? '' ) && 'object' === ( $browser_task_contract_ability['output_schema']['properties']['compact']['type'] ?? '' ) );
+$browser_task_phase_kinds = $browser_task_contract_ability['input_schema']['properties']['phases']['items']['properties']['kind']['enum'] ?? array();
+$assert( 'browser task contract exposes phase and compact schema', 'array' === ( $browser_task_contract_ability['input_schema']['properties']['phases']['type'] ?? '' ) && in_array( 'materializer', $browser_task_phase_kinds, true ) && in_array( 'agent', $browser_task_phase_kinds, true ) && in_array( 'aggregator', $browser_task_phase_kinds, true ) && 'array' === ( $browser_task_contract_ability['output_schema']['properties']['phases']['type'] ?? '' ) && 'object' === ( $browser_task_contract_ability['output_schema']['properties']['compact']['type'] ?? '' ) );
 
 $agents_api_executor_targets = apply_filters( 'agents_api_executor_targets', array() );
 $wp_agent_executor_targets = apply_filters( 'wp_agent_executor_targets', array() );
@@ -875,6 +876,54 @@ $browser_task_compact_encoded = wp_json_encode( $browser_task_contract['compact'
 $assert( 'browser task contract exposes compact product DTO with primary runner fields', ! is_wp_error( $browser_task_contract ) && 'wp-codebox/browser-task-product-dto/v1' === ( $browser_task_contract['compact']['schema'] ?? '' ) && 'wp-codebox/browser-playground-session/v1' === ( $browser_task_contract['compact']['primary']['schema'] ?? '' ) && 'wp-codebox/browser-session-product-dto/v1' === ( $browser_task_contract['compact']['primary']['dto_schema'] ?? '' ) && 'wp-codebox/workspace-recipe/v1' === ( $browser_task_contract['compact']['primary']['recipe']['schema'] ?? '' ) && isset( $browser_task_contract['compact']['primary']['recipe']['workflow'] ) && isset( $browser_task_contract['compact']['primary']['recipe']['browser']['task_path'] ) && isset( $browser_task_contract['compact']['primary']['task_payload']['schema'] ) );
 $assert( 'browser task compact DTO preserves named materializer phases', ! is_wp_error( $browser_task_contract ) && 'static-site-materializer' === ( $browser_task_contract['compact']['phases'][0]['name'] ?? '' ) && 'materializer' === ( $browser_task_contract['compact']['phases'][0]['kind'] ?? '' ) && 'wp-codebox/browser-materializer-product-dto/v1' === ( $browser_task_contract['compact']['phases'][0]['contract']['schema'] ?? '' ) && '/tmp/materializer-result.json' === ( $browser_task_contract['compact']['phases'][0]['contract']['materialization']['result_path'] ?? '' ) );
 $assert( 'browser task compact DTO omits raw runtime payloads', is_string( $browser_task_compact_encoded ) && ! str_contains( $browser_task_compact_encoded, '"pluginData"' ) && ! str_contains( $browser_task_compact_encoded, '"content"' ) && ! str_contains( $browser_task_compact_encoded, '"content_base64"' ) && ! str_contains( $browser_task_compact_encoded, 'data:application/zip;base64' ) && ! str_contains( $browser_task_compact_encoded, 'sk-browser-provider-secret' ) );
+
+$legacy_materializer_task_contract = call_user_func(
+	$browser_task_contract_ability['execute_callback'],
+	array_replace_recursive(
+		$browser_session_input,
+		array(
+			'materializers' => array(
+				array(
+					'goal'           => 'Materialize generated browser artifacts through legacy input.',
+					'browser_runner' => array(
+						'result_path' => '/tmp/legacy-materializer-result.json',
+					),
+				),
+			),
+		)
+	)
+);
+$assert( 'browser task contract preserves legacy materializers input compatibility', ! is_wp_error( $legacy_materializer_task_contract ) && 1 === count( $legacy_materializer_task_contract['phases'] ?? array() ) && 'materializer' === ( $legacy_materializer_task_contract['phases'][0]['kind'] ?? '' ) && 'wp-codebox/browser-materializer-contract/v1' === ( $legacy_materializer_task_contract['phases'][0]['contract']['schema'] ?? '' ) && '/tmp/legacy-materializer-result.json' === ( $legacy_materializer_task_contract['phases'][0]['contract']['materialization']['result_path'] ?? '' ) );
+
+$generic_phase_task_contract = call_user_func(
+	$browser_task_contract_ability['execute_callback'],
+	array_replace_recursive(
+		$browser_session_input,
+		array(
+			'phases' => array(
+				array(
+					'name'     => 'agent-fanout',
+					'kind'     => 'agent',
+					'label'    => 'Agent Fanout',
+					'status'   => 'queued',
+					'metadata' => array(
+						'runner' => 'browser-playground',
+					),
+				),
+				array(
+					'name'     => 'aggregate-results',
+					'kind'     => 'aggregator',
+					'label'    => 'Aggregate Results',
+					'metadata' => array(
+						'inputs' => array( 'agent-fanout' ),
+					),
+				),
+			),
+		)
+	)
+);
+$assert( 'browser task contract accepts agent and aggregator phase descriptors', ! is_wp_error( $generic_phase_task_contract ) && 2 === count( $generic_phase_task_contract['phases'] ?? array() ) && 'agent' === ( $generic_phase_task_contract['phases'][0]['kind'] ?? '' ) && 'aggregator' === ( $generic_phase_task_contract['phases'][1]['kind'] ?? '' ) && ! isset( $generic_phase_task_contract['phases'][0]['contract'] ) && 'queued' === ( $generic_phase_task_contract['phases'][0]['status'] ?? '' ) && 'pending' === ( $generic_phase_task_contract['phases'][1]['status'] ?? '' ) );
+$assert( 'browser task compact DTO preserves generic phase metadata for product UIs', ! is_wp_error( $generic_phase_task_contract ) && 'agent-fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['name'] ?? '' ) && 0 === ( $generic_phase_task_contract['compact']['phases'][0]['index'] ?? null ) && 'Agent Fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['label'] ?? '' ) && 'browser-playground' === ( $generic_phase_task_contract['compact']['phases'][0]['metadata']['runner'] ?? '' ) && 'aggregate-results' === ( $generic_phase_task_contract['compact']['phases'][1]['name'] ?? '' ) && 1 === ( $generic_phase_task_contract['compact']['phases'][1]['index'] ?? null ) );
 
 $agents_api_browser_executor_result = apply_filters(
 	'agents_api_execute_task',


### PR DESCRIPTION
## Summary
- Generalizes `wp-codebox/create-browser-task-contract` phase kinds to support `materializer`, `agent`, `validator`, `repair`, and `aggregator` descriptors.
- Preserves existing materializer behavior by still building nested browser materializer contracts only for materializer phases.
- Keeps compact phase DTOs product-neutral by preserving `name`, `kind`, `index`, `label`, `status`, and `metadata` for product UIs.

## Tests
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php && php -l tests/smoke-wordpress-plugin.php`
- `git diff --check`

Closes https://github.com/Automattic/wp-codebox/issues/681

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the browser task phase schema/DTO changes, added smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.