### PR TITLE
Handle recipe-run parent disconnects

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto"
+import { fstatSync } from "node:fs"
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
@@ -29,9 +30,11 @@ interface RecipeRunOptions {
 }
 
 type RecipeInterruptionSignal = "SIGINT" | "SIGTERM" | "SIGHUP"
+type RecipeInterruptionReason = "signal" | "parent-disconnect" | "stdio-closed"
 
 interface RecipeInterruptionMetadata {
   signal: RecipeInterruptionSignal
+  reason: RecipeInterruptionReason
   receivedAt: string
   artifactsFinalized: boolean
 }
@@ -324,8 +327,8 @@ function printJsonFailureDiagnostic(output: { success: boolean; error?: { messag
 class RecipeInterruptedError extends Error {
   readonly code = "recipe-interrupted"
 
-  constructor(readonly signal: RecipeInterruptionSignal, readonly receivedAt: string) {
-    super(`Recipe run interrupted by ${signal}`)
+  constructor(readonly signal: RecipeInterruptionSignal, readonly reason: RecipeInterruptionReason, readonly receivedAt: string) {
+    super(recipeInterruptionMessage({ signal, reason }))
     this.name = "RecipeInterruptedError"
   }
 }
@@ -499,12 +502,30 @@ function createRecipeInterruptionController(): RecipeInterruptionController {
   let metadata: RecipeInterruptionMetadata | undefined
   let rejectInterrupted: ((error: RecipeInterruptedError) => void) | undefined
   let installed = false
+  let parentWatcher: NodeJS.Timeout | undefined
+  let stdinWatcherInstalled = false
+  let stdioErrorWatcherInstalled = false
+  const initialParentPid = process.ppid
   const signals: RecipeInterruptionSignal[] = ["SIGINT", "SIGTERM", "SIGHUP"]
-  const handler = (signal: RecipeInterruptionSignal): void => {
+  const interrupt = (signal: RecipeInterruptionSignal, reason: RecipeInterruptionReason): void => {
     if (!metadata) {
-      metadata = { signal, receivedAt: new Date().toISOString(), artifactsFinalized: false }
+      metadata = { signal, reason, receivedAt: new Date().toISOString(), artifactsFinalized: false }
     }
-    rejectInterrupted?.(new RecipeInterruptedError(metadata.signal, metadata.receivedAt))
+    rejectInterrupted?.(new RecipeInterruptedError(metadata.signal, metadata.reason, metadata.receivedAt))
+  }
+  const handler = (signal: RecipeInterruptionSignal): void => {
+    interrupt(signal, "signal")
+  }
+  const parentDisconnectHandler = (): void => {
+    interrupt("SIGHUP", "parent-disconnect")
+  }
+  const stdinClosedHandler = (): void => {
+    interrupt("SIGHUP", "stdio-closed")
+  }
+  const stdioErrorHandler = (error: NodeJS.ErrnoException): void => {
+    if (error.code === "EPIPE" || error.code === "ERR_STREAM_DESTROYED") {
+      interrupt("SIGHUP", "stdio-closed")
+    }
   }
 
   const controller: RecipeInterruptionController = {
@@ -518,6 +539,23 @@ function createRecipeInterruptionController(): RecipeInterruptionController {
       for (const signal of signals) {
         process.on(signal, handler)
       }
+      if (initialParentPid > 1) {
+        parentWatcher = setInterval(() => {
+          if (process.ppid === 1 || process.ppid !== initialParentPid) {
+            parentDisconnectHandler()
+          }
+        }, 1_000)
+        parentWatcher.unref()
+      }
+      if (!process.stdin.isTTY && process.stdin.readable && stdinCanSignalParentDisconnect()) {
+        process.stdin.on("end", stdinClosedHandler)
+        process.stdin.on("close", stdinClosedHandler)
+        process.stdin.resume()
+        stdinWatcherInstalled = true
+      }
+      process.stdout.on("error", stdioErrorHandler)
+      process.stderr.on("error", stdioErrorHandler)
+      stdioErrorWatcherInstalled = true
       installed = true
     },
     dispose() {
@@ -527,11 +565,26 @@ function createRecipeInterruptionController(): RecipeInterruptionController {
       for (const signal of signals) {
         process.off(signal, handler)
       }
+      if (parentWatcher) {
+        clearInterval(parentWatcher)
+        parentWatcher = undefined
+      }
+      if (stdinWatcherInstalled) {
+        process.stdin.off("end", stdinClosedHandler)
+        process.stdin.off("close", stdinClosedHandler)
+        process.stdin.pause()
+        stdinWatcherInstalled = false
+      }
+      if (stdioErrorWatcherInstalled) {
+        process.stdout.off("error", stdioErrorHandler)
+        process.stderr.off("error", stdioErrorHandler)
+        stdioErrorWatcherInstalled = false
+      }
       installed = false
     },
     async interruptible<T>(promise: Promise<T>): Promise<T> {
       if (metadata) {
-        throw new RecipeInterruptedError(metadata.signal, metadata.receivedAt)
+        throw new RecipeInterruptedError(metadata.signal, metadata.reason, metadata.receivedAt)
       }
 
       let settled = false
@@ -554,11 +607,11 @@ function createRecipeInterruptionController(): RecipeInterruptionController {
     },
     throwIfInterrupted() {
       if (metadata) {
-        throw new RecipeInterruptedError(metadata.signal, metadata.receivedAt)
+        throw new RecipeInterruptedError(metadata.signal, metadata.reason, metadata.receivedAt)
       }
     },
     propagateIfInterrupted() {
-      if (!metadata) {
+      if (!metadata || metadata.reason !== "signal") {
         return
       }
       controller.dispose()
@@ -567,6 +620,15 @@ function createRecipeInterruptionController(): RecipeInterruptionController {
   }
 
   return controller
+}
+
+function stdinCanSignalParentDisconnect(): boolean {
+  try {
+    const stats = fstatSync(0)
+    return stats.isFIFO() || stats.isSocket()
+  } catch {
+    return false
+  }
 }
 
 function markRecipeArtifactsFinalized(interruption: RecipeInterruptionController | undefined, artifactsFinalized: boolean): void {
@@ -591,9 +653,19 @@ function interruptedRecipeOutput<T extends RecipeRunCommandOutput>(output: T, in
 function recipeInterruptionSerializedError(metadata: RecipeInterruptionMetadata): RunOutput["error"] {
   return {
     name: "RecipeInterruptedError",
-    message: `Recipe run interrupted by ${metadata.signal}`,
+    message: recipeInterruptionMessage(metadata),
     code: "recipe-interrupted",
   }
+}
+
+function recipeInterruptionMessage(metadata: Pick<RecipeInterruptionMetadata, "signal" | "reason">): string {
+  if (metadata.reason === "parent-disconnect") {
+    return "Recipe run interrupted after parent process disconnected"
+  }
+  if (metadata.reason === "stdio-closed") {
+    return "Recipe run interrupted after stdio closed"
+  }
+  return `Recipe run interrupted by ${metadata.signal}`
 }
 
 function remainingRecipeTimeoutMs(startedAtMs: number, timeoutMs: number): number {

--- a/scripts/recipe-interruption-artifacts-smoke.ts
+++ b/scripts/recipe-interruption-artifacts-smoke.ts
@@ -100,6 +100,87 @@ try {
   assertManifestFile(manifest, "files/runtime-evidence/artifact-bundle-verification.json", "artifact-bundle-verification")
   assertManifestFile(manifest, "files/runtime-evidence/workspace-policy.json", "workspace-policy-result")
 
+  const disconnectSource = join(workspace, "disconnect-source")
+  const disconnectArtifacts = join(workspace, "disconnect-artifacts")
+  const disconnectRecipePath = join(workspace, "disconnect-recipe.json")
+  await mkdir(join(disconnectSource, "src"), { recursive: true })
+  await writeFile(join(disconnectSource, "src", "index.php"), "<?php\n")
+  await writeFile(disconnectRecipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: "7.0" },
+    inputs: {
+      workspaces: [
+        {
+          target: "/workspace",
+          mode: "readwrite",
+          seed: { type: "directory", source: disconnectSource },
+        },
+      ],
+    },
+    workflow: {
+      steps: [
+        {
+          command: "wordpress.run-php",
+          args: ["code=<?php sleep(120); echo 'unreachable';"],
+        },
+      ],
+    },
+    artifacts: {
+      directory: disconnectArtifacts,
+      verify: true,
+      workspacePolicy: { strict: false, writableRoots: ["."], gitBacked: false },
+    },
+  }, null, 2)}\n`)
+
+  const disconnectChild = spawn(process.execPath, [
+    "packages/cli/dist/index.js",
+    "recipe-run",
+    "--recipe",
+    disconnectRecipePath,
+    "--artifacts",
+    disconnectArtifacts,
+    "--json",
+  ], {
+    cwd: root,
+    stdio: ["pipe", "pipe", "pipe"],
+  })
+
+  let disconnectStdout = ""
+  let disconnectStderr = ""
+  disconnectChild.stdout.on("data", (chunk) => {
+    disconnectStdout += chunk.toString()
+  })
+  disconnectChild.stderr.on("data", (chunk) => {
+    disconnectStderr += chunk.toString()
+  })
+
+  await waitForPointerCommand(disconnectArtifacts, "workflow.steps[0]:wordpress.run-php", 60_000)
+  disconnectChild.stdin.end()
+
+  const disconnectExit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit) => {
+    disconnectChild.once("close", (code, signal) => resolveExit({ code, signal }))
+  })
+
+  assert.equal(disconnectExit.code, 1, `Parent-disconnected recipe should exit with a failure code; stderr: ${disconnectStderr}`)
+  assert.equal(disconnectExit.signal, null, `Parent-disconnected recipe should not propagate a signal; stderr: ${disconnectStderr}`)
+  assert.ok(disconnectStdout.trim(), `Parent-disconnected recipe should emit JSON output; stderr: ${disconnectStderr}`)
+
+  const disconnectOutput = JSON.parse(disconnectStdout)
+  assert.equal(disconnectOutput.schema, "wp-codebox/recipe-run/v1")
+  assert.equal(disconnectOutput.success, false)
+  assert.equal(disconnectOutput.error?.code, "recipe-interrupted")
+  assert.equal(disconnectOutput.interruption?.signal, "SIGHUP")
+  assert.equal(disconnectOutput.interruption?.reason, "stdio-closed")
+  assert.equal(disconnectOutput.interruption?.artifactsFinalized, true)
+  assert.equal(disconnectOutput.run?.status, "cancelled")
+  assert.ok(disconnectOutput.artifacts?.directory, "Parent-disconnected recipe should report artifact directory")
+
+  const disconnectLatestRuntime = JSON.parse(await readFile(join(disconnectArtifacts, "latest-runtime.json"), "utf8"))
+  assert.equal(disconnectLatestRuntime.schema, "wp-codebox/recipe-run-artifact-pointer/v1")
+  assert.equal(disconnectLatestRuntime.commandStatus, "failed")
+  assert.equal(disconnectLatestRuntime.failure.code, "recipe-interrupted")
+  assert.equal(disconnectLatestRuntime.paths.runtimeManifest, `${disconnectOutput.runtime.id}/manifest.json`)
+
   console.log("Recipe interruption artifact smoke passed")
 } finally {
   await rm(workspace, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Treat parent process disconnects and broken stdio as recipe-run interruptions so long-running runs stop cleanly instead of lingering.
- Reuse the existing interruption recovery path to destroy runtime resources, update run state to cancelled, and write partial artifact pointer/status markers.
- Extend the interruption artifact smoke to cover stdio/parent-disconnect cleanup in addition to explicit SIGTERM handling.

Fixes https://github.com/Automattic/wp-codebox/issues/688

## Verification
- `npm run build`
- `npm run recipe-interruption-artifacts-smoke`
- `npm run recipe-run-timeout-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the interruption handling changes, smoke coverage, and verification commands; Chris remains responsible for review and merge.