### PR TITLE
Fix browser probe public preview routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",
     "browser-probe-assertions-smoke": "tsx scripts/browser-probe-assertions-smoke.ts",
     "browser-probe-context-smoke": "tsx scripts/browser-probe-context-smoke.ts",
+    "browser-probe-public-url-routing-smoke": "tsx scripts/browser-probe-public-url-routing-smoke.ts",
     "browser-probe-profile-matrix-smoke": "tsx scripts/browser-probe-profile-matrix-smoke.ts",
     "browser-lifecycle-observer-smoke": "tsx scripts/browser-lifecycle-observer-smoke.ts",
     "browser-probe-pre-page-script-smoke": "tsx scripts/browser-probe-pre-page-script-smoke.ts",

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -117,6 +117,7 @@ export interface ArtifactReviewBrowserSummary {
     requestedPreviewOrigin?: string
     effectivePreviewOrigin?: string
     finalUrl?: string
+    windowLocationOrigin?: string
     viewport?: {
       width: number
       height: number

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -40,6 +40,7 @@ export interface BrowserProbeArtifact {
     consoleMessages: number
     errors: number
     finalUrl: string
+    windowLocationOrigin?: string
     htmlSnapshot: boolean
     lifecycle?: BrowserProbeLifecycleSummary
     memory?: BrowserProbeMemorySummary
@@ -391,6 +392,7 @@ export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactRe
       requestedPreviewOrigin: probe.requestedPreviewOrigin,
       effectivePreviewOrigin: probe.effectivePreviewOrigin,
       finalUrl: probe.summary.finalUrl,
+      windowLocationOrigin: probe.summary.windowLocationOrigin,
       viewport: probe.summary.viewport,
       capabilities: probe.summary.capabilities,
       replayability: probe.summary.replayability,

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -204,6 +204,7 @@ async function runSingleBrowserProbeCommand({
   }
   const browser = await chromium.launch()
   let finalUrl = targetUrl
+  let windowLocationOrigin: string | undefined
   let htmlSha256: string | undefined
   let screenshotSha256: string | undefined
   let viewport: BrowserProbeViewport | null = null
@@ -281,7 +282,9 @@ async function runSingleBrowserProbeCommand({
 
     await withBrowserProbeLiveness(page, progress, failFast, navigateBrowserProbe(page, targetUrl, waitFor, durationMs))
     progress.mark("navigation")
-    preview.secureContext = await page.evaluate(() => window.isSecureContext).catch(() => undefined)
+    const browserLocation = await page.evaluate(() => ({ origin: window.location.origin, secureContext: window.isSecureContext })).catch(() => undefined)
+    windowLocationOrigin = browserLocation?.origin
+    preview.secureContext = browserLocation?.secureContext
     const secureContextError = browserProbeSecureContextError(preview)
     if (secureContextError) {
       throw secureContextError
@@ -330,6 +333,7 @@ async function runSingleBrowserProbeCommand({
   } finally {
     if (page) {
       finalUrl = page.url()
+      windowLocationOrigin = windowLocationOrigin ?? await page.evaluate(() => window.location.origin).catch(() => undefined)
       if (capturesBrowserMetrics) {
         checkpoints.push(await browserProbeCheckpoint(page, "final"))
         if (capture.has("memory")) {
@@ -424,6 +428,7 @@ async function runSingleBrowserProbeCommand({
         consoleMessages: consoleMessages.length,
         errors: errors.length,
         finalUrl,
+        ...(windowLocationOrigin ? { windowLocationOrigin } : {}),
         htmlSnapshot: capture.has("html"),
         ...(lifecycleArtifact ? { lifecycle: { schema: lifecycleArtifact.schema, version: lifecycleArtifact.version, startedAtMs: lifecycleArtifact.startedAtMs, selectors: lifecycleArtifact.selectors } } : {}),
         ...(memoryArtifact ? { memory: memoryArtifact.peak } : {}),
@@ -445,6 +450,7 @@ async function runSingleBrowserProbeCommand({
       preview,
       ...previewOrigins,
       finalUrl,
+      ...(windowLocationOrigin ? { windowLocationOrigin } : {}),
       waitFor,
       durationMs,
       ...(lifecycleSelectors.length > 0 ? { observe: lifecycleSelectors } : {}),
@@ -1836,8 +1842,8 @@ function browserProbePreviewOrigins(preview: BrowserProbePreviewRouting): { loca
 }
 
 function browserProbePreviewRouting(args: string[], runtimeSpec: RuntimeCreateSpec | undefined, localPreviewOrigin: string): BrowserProbePreviewRouting {
-  const requestedMode = browserProbePreviewMode(args)
   const publicOrigin = runtimeSpec?.preview?.publicUrl
+  const requestedMode = browserProbePreviewMode(args, publicOrigin)
   const effectiveMode: BrowserProbePreviewMode = requestedMode === "local" || !publicOrigin ? "local" : requestedMode
   const effectiveOrigin = effectiveMode === "local" ? localPreviewOrigin : (publicOrigin ?? localPreviewOrigin)
   const diagnostics: BrowserProbePreviewRouting["diagnostics"] = []
@@ -1873,8 +1879,8 @@ function browserProbePreviewRouting(args: string[], runtimeSpec: RuntimeCreateSp
   }
 }
 
-function browserProbePreviewMode(args: string[]): BrowserProbePreviewMode {
-  const raw = argValue(args, "preview-mode")?.trim() || "local"
+function browserProbePreviewMode(args: string[], publicOrigin: string | undefined): BrowserProbePreviewMode {
+  const raw = argValue(args, "preview-mode")?.trim() || (publicOrigin ? "public" : "local")
   if (raw === "local" || raw === "public" || raw === "secure") {
     return raw
   }

--- a/scripts/browser-probe-public-url-routing-smoke.ts
+++ b/scripts/browser-probe-public-url-routing-smoke.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict"
+import { createServer, type Server } from "node:http"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { runBrowserProbeCommand } from "../packages/runtime-playground/src/browser-command-runners.js"
+import type { PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-browser-probe-public-url-routing-"))
+let server: Server | undefined
+
+try {
+  server = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+    response.end(`<!doctype html><title>Probe</title><main data-path="${request.url ?? "/"}">OK</main>`)
+  })
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject)
+    server?.listen(0, "127.0.0.1", resolve)
+  })
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+
+  const localUrl = `http://127.0.0.1:${address.port}/local-route/`
+  const publicUrl = `http://127.0.0.1:${address.port}/public-route/`
+  const runtimeSpec: RuntimeCreateSpec = { preview: { publicUrl } }
+  const serverRef: PlaygroundCliServer = {
+    playground: {
+      async run() {
+        return { text: "" }
+      },
+    },
+    serverUrl: localUrl,
+    async [Symbol.asyncDispose]() {},
+  }
+
+  const publicProbe = await runBrowserProbeCommand({
+    artifactRoot: join(workspace, "public"),
+    runtimeSpec,
+    server: serverRef,
+    spec: { command: "wordpress.browser-probe", args: ["url=relative-probe", "wait-for=domcontentloaded", "capture=html"] },
+  })
+  assert.equal(publicProbe.artifact.requestedUrl, `${publicUrl}relative-probe`)
+  assert.equal(publicProbe.artifact.preview.requestedMode, "public")
+  assert.equal(publicProbe.artifact.preview.effectiveMode, "public")
+  assert.equal(publicProbe.artifact.preview.publicOrigin, publicUrl)
+  assert.equal(publicProbe.artifact.preview.effectiveOrigin, publicUrl)
+  assert.equal(publicProbe.artifact.summary.windowLocationOrigin, new URL(publicUrl).origin)
+
+  const localProbe = await runBrowserProbeCommand({
+    artifactRoot: join(workspace, "local"),
+    runtimeSpec,
+    server: serverRef,
+    spec: { command: "wordpress.browser-probe", args: ["url=relative-probe", "wait-for=domcontentloaded", "capture=html", "preview-mode=local"] },
+  })
+  assert.equal(localProbe.artifact.requestedUrl, `${localUrl}relative-probe`)
+  assert.equal(localProbe.artifact.preview.requestedMode, "local")
+  assert.equal(localProbe.artifact.preview.effectiveMode, "local")
+  assert.equal(localProbe.artifact.preview.publicOrigin, publicUrl)
+  assert.equal(localProbe.artifact.preview.effectiveOrigin, localUrl)
+  assert.equal(localProbe.artifact.summary.windowLocationOrigin, new URL(localUrl).origin)
+
+  console.log("Browser probe public URL routing smoke passed")
+} finally {
+  await new Promise<void>((resolve) => server?.close(() => resolve()) ?? resolve())
+  await rm(workspace, { recursive: true, force: true })
+}

--- a/scripts/recipe-preview-routing-browser-probe-smoke.ts
+++ b/scripts/recipe-preview-routing-browser-probe-smoke.ts
@@ -22,6 +22,7 @@ try {
   assert.equal(recipeSummary.preview.requestedMode, "public")
   assert.equal(recipeSummary.preview.effectiveMode, "public")
   assert.equal(recipeSummary.preview.secureContext, true)
+  assert.equal(recipeSummary.windowLocationOrigin, new URL(recipePublicUrl).origin)
   assert.equal(recipeSummary.localPreviewOrigin.startsWith("http://127.0.0.1:"), true)
   assert.equal(recipeSummary.requestedPreviewOrigin, recipePublicUrl)
   assert.equal(recipeSummary.effectivePreviewOrigin, recipePublicUrl)
@@ -38,7 +39,7 @@ try {
 
   const localDefaultPort = await reserveFreePort()
   const localDefaultPublicUrl = `http://127.0.0.1:${localDefaultPort}/public-route/`
-  const localDefaultRecipePath = await writeRecipe("recipe-preview-local-default.json", localDefaultPort, localDefaultPublicUrl, [])
+  const localDefaultRecipePath = await writeRecipe("recipe-preview-local-default.json", localDefaultPort, localDefaultPublicUrl, ["preview-mode=local"])
   const localDefaultOutput = await runCliJson(["recipe-run", "--recipe", localDefaultRecipePath, "--json"])
 
   assert.equal(localDefaultOutput.success, true, localDefaultOutput.error?.message ?? "recipe-run with default local preview failed")
@@ -137,7 +138,7 @@ async function writeRecipe(name: string, port: number, publicUrl: string | undef
   return recipePath
 }
 
-async function browserSummary(output: { artifacts?: { directory?: string } }): Promise<{ requestedUrl: string; preview: { requestedMode: string; effectiveMode: string; localOrigin: string; publicOrigin?: string; effectiveOrigin: string; secureContext?: boolean; diagnostics: Array<{ code: string }> }; localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string }> {
+async function browserSummary(output: { artifacts?: { directory?: string } }): Promise<{ requestedUrl: string; windowLocationOrigin?: string; preview: { requestedMode: string; effectiveMode: string; localOrigin: string; publicOrigin?: string; effectiveOrigin: string; secureContext?: boolean; diagnostics: Array<{ code: string }> }; localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string }> {
   assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
   return JSON.parse(await readFile(join(output.artifacts.directory, "files", "browser", "summary.json"), "utf8"))
 }


### PR DESCRIPTION
## Summary
- Default `wordpress.browser-probe` to the configured preview `publicUrl` when one exists, while keeping `preview-mode=local` available for local-only probes.
- Record `window.location.origin` in browser probe summaries and review output alongside requested/local/public/effective preview diagnostics.
- Add a lightweight browser-probe routing smoke that proves public-default and explicit-local behavior without booting WordPress Playground.

Closes #687.

## Testing
- `npm run build`
- `npm run browser-probe-public-url-routing-smoke`
- `git diff --check`

## Notes
- Attempted `npm run recipe-preview-routing-browser-probe-smoke`, but the local WordPress Playground recipe-run path hung on this machine before producing the relevant browser summary. I stopped only the orphaned processes from this worktree and added the direct runner smoke above to cover the routing contract without depending on the saturated local Playground runtime.
- Attempted `npm run preview-public-url-canonical-smoke`, but it failed locally with `ECONNREFUSED` against its temporary preview server, consistent with the same local runtime/process issue.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the routing/default-mode change, summary diagnostics, targeted smoke coverage, and local verification. Chris remains responsible for review and final acceptance.