### PR TITLE
Define agent fanout contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For the Automattic transfer review surface, see
 [`docs/transfer-readiness-checklist.md`](./docs/transfer-readiness-checklist.md).
 For browser runtime dependency classification and packaging provenance, see
 [`docs/browser-runtime-dependency-audit.md`](./docs/browser-runtime-dependency-audit.md).
+For the generic multi-agent fanout contract, see
+[`docs/agent-fanout-contract.md`](./docs/agent-fanout-contract.md).
 
 ```text
 Any host: CLI, CI, mobile, Node service, WP plugin, GitHub Action, ...

--- a/docs/agent-fanout-contract.md
+++ b/docs/agent-fanout-contract.md
@@ -1,0 +1,108 @@
+# Agent Fanout Contract
+
+WP Codebox fanout is a generic runtime primitive for running multiple agent
+workers in isolated Playground sandboxes under one parent session. Product hosts
+provide the worker list and review the resulting parent artifact envelope; WP
+Codebox owns bounded execution, lifecycle events, and parent/child artifact
+layout.
+
+## Schemas
+
+- `wp-codebox/agent-fanout-request/v1`: caller request accepted by
+  `wp-codebox/run-agent-task-fanout`.
+- `wp-codebox/agent-fanout-worker/v1`: optional per-worker marker schema for
+  worker definitions inside the request.
+- `wp-codebox/agent-fanout-plan/v1`: persisted parent plan at
+  `fanout/plan.json`.
+- `wp-codebox/agent-fanout-event/v1`: JSONL lifecycle event schema at
+  `fanout/events.jsonl`.
+- `wp-codebox/agent-fanout-result/v1`: parent result returned by the ability and
+  persisted at `fanout/result.json`.
+- `wp-codebox/agent-fanout-artifacts/v1`: artifact locator block inside the
+  parent result.
+
+Aggregation contracts that are usable by products or future aggregator agents
+live in runtime-core as `wp-codebox/agent-fanout-aggregation-input/v1` and
+`wp-codebox/agent-fanout-aggregation-output/v1`.
+
+## Request Shape
+
+```json
+{
+  "schema": "wp-codebox/agent-fanout-request/v1",
+  "concurrency": 2,
+  "workers": [
+    {
+      "schema": "wp-codebox/agent-fanout-worker/v1",
+      "id": "design",
+      "goal": "Draft a homepage design direction.",
+      "agent": "design-agent"
+    }
+  ],
+  "orchestrator": {
+    "product": "studio-web",
+    "request_id": "project-123"
+  }
+}
+```
+
+Worker IDs are stable artifact namespaces. They must be unique and match the
+safe path segment policy used by the runner. A worker may override task policy,
+allowed tools, context, expected artifacts, agent, and timeout while inheriting
+the parent runtime stack and mounts.
+
+## Execution Strategy
+
+The v1 execution strategy is `bounded-concurrent-isolated-sandboxes`.
+
+Each worker receives its own child sandbox session ID in the form
+`<parent-session-id>:<worker-id>` and writes to
+`fanout/workers/<worker-id>/artifacts`. Concurrency defaults to `1` and is capped
+by the host runtime. The WordPress plugin cap is `8`, filterable through
+`wp_codebox_agent_fanout_max_concurrency`.
+
+Browser-runtime fanout should use the same strategy at the product boundary:
+start separate browser Playground sessions per worker, keep mutable WordPress
+state isolated per session, and aggregate only from captured artifacts. Running
+several agents concurrently inside one browser Playground is not the v1 contract
+because shared WordPress state, option writes, uploads, and tool events can
+interleave in ways the parent cannot audit reliably.
+
+## Lifecycle Events
+
+The parent writes JSONL lifecycle events with schema
+`wp-codebox/agent-fanout-event/v1`:
+
+- `fanout.started`
+- `worker.started`
+- `worker.completed`
+- `worker.failed`
+- `aggregation.started`
+- `aggregation.completed`
+- `fanout.completed`
+- `fanout.failed`
+
+Product UIs should render these events as progress only. Durable decisions must
+use the final `wp-codebox/agent-fanout-result/v1` envelope and referenced worker
+artifacts.
+
+## Artifact Layout
+
+```text
+fanout/
+  plan.json
+  events.jsonl
+  result.json
+  workers/
+    <worker-id>/
+      result.json
+      artifacts/
+  aggregate/
+    result.json
+    artifacts/
+```
+
+The parent result includes `session.children`, aggregate counts, the requested
+concurrency, worker run summaries, failure summaries, and artifact references.
+Parent products remain responsible for review, apply, PR creation, deployment,
+or any other mutation outside the sandbox.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "host-command-tool-smoke": "tsx scripts/host-command-tool-smoke.ts",
     "sandbox-tool-policy-smoke": "tsx scripts/sandbox-tool-policy-smoke.ts",
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
+    "fanout-contract-smoke": "tsx scripts/fanout-contract-smoke.ts",
     "fanout-aggregation-contract-smoke": "tsx scripts/fanout-aggregation-contract-smoke.ts",
     "run-registry-smoke": "tsx scripts/run-registry-smoke.ts",
     "benchmark-substrate-smoke": "tsx scripts/benchmark-substrate-smoke.ts",

--- a/packages/runtime-core/src/fanout-contracts.ts
+++ b/packages/runtime-core/src/fanout-contracts.ts
@@ -1,0 +1,71 @@
+export const FANOUT_REQUEST_SCHEMA = "wp-codebox/agent-fanout-request/v1" as const
+export const FANOUT_PLAN_SCHEMA = "wp-codebox/agent-fanout-plan/v1" as const
+export const FANOUT_WORKER_SCHEMA = "wp-codebox/agent-fanout-worker/v1" as const
+export const FANOUT_RESULT_SCHEMA = "wp-codebox/agent-fanout-result/v1" as const
+export const FANOUT_EVENT_SCHEMA = "wp-codebox/agent-fanout-event/v1" as const
+
+export const FANOUT_EVENT_TYPES = [
+  "fanout.started",
+  "worker.started",
+  "worker.completed",
+  "worker.failed",
+  "aggregation.started",
+  "aggregation.completed",
+  "fanout.completed",
+  "fanout.failed",
+] as const
+
+export type FanoutEventType = (typeof FANOUT_EVENT_TYPES)[number]
+export type FanoutExecutionStrategy = "bounded-concurrent-isolated-sandboxes"
+
+export interface FanoutWorkerContract {
+  schema?: typeof FANOUT_WORKER_SCHEMA
+  id: string
+  goal: string
+  task?: string
+  agent?: string
+  dependsOn?: string[]
+  artifactNamespace?: string
+  metadata?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface FanoutRequestContract {
+  schema?: typeof FANOUT_REQUEST_SCHEMA
+  workers: FanoutWorkerContract[]
+  concurrency?: number
+  agent?: string
+  orchestrator?: Record<string, unknown>
+  aggregation?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface FanoutPlanContract {
+  schema: typeof FANOUT_PLAN_SCHEMA
+  session_id: string
+  concurrency: number
+  orchestrator: Record<string, unknown>
+  workers: Array<{
+    id: string
+    agent: string
+    goal: string
+    artifact_namespace: string
+  }>
+}
+
+export interface FanoutLifecycleEvent {
+  schema: typeof FANOUT_EVENT_SCHEMA
+  event: FanoutEventType
+  time: string
+  worker_id?: string
+  status?: string
+  active?: number
+  total?: number
+  completed?: number
+  failed?: number
+  cancelled?: number
+}
+
+export function isFanoutEventType(event: string): event is FanoutEventType {
+  return FANOUT_EVENT_TYPES.includes(event as FanoutEventType)
+}

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -22,6 +22,7 @@ export * from "./artifact-bundle-verifier.js"
 export * from "./transfer-proof.js"
 export * from "./host-tool-registry.js"
 export * from "./run-registry.js"
+export * from "./fanout-contracts.js"
 export * from "./fanout-aggregation.js"
 
 export type ArtifactReviewProgressEventType =

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -395,6 +395,7 @@ final class WP_Codebox_Abilities {
 						'type'       => 'object',
 						'required'   => array( 'workers' ),
 						'properties' => array(
+							'schema'                => array( 'type' => 'string', 'const' => 'wp-codebox/agent-fanout-request/v1' ),
 							'workers'               => array(
 								'type'        => 'array',
 								'description' => 'Explicit fanout worker definitions. Each worker runs in its own isolated sandbox and artifact namespace.',
@@ -402,6 +403,7 @@ final class WP_Codebox_Abilities {
 									'type'       => 'object',
 									'required'   => array( 'id', 'goal' ),
 									'properties' => array(
+										'schema'             => array( 'type' => 'string', 'const' => 'wp-codebox/agent-fanout-worker/v1' ),
 										'id'                 => array( 'type' => 'string' ),
 										'goal'               => $task_input_schema['properties']['goal'],
 										'task'               => array( 'type' => 'string' ),
@@ -453,7 +455,7 @@ final class WP_Codebox_Abilities {
 						'type'       => 'object',
 						'properties' => array(
 							'success'     => array( 'type' => 'boolean' ),
-							'schema'      => array( 'type' => 'string' ),
+							'schema'      => array( 'type' => 'string', 'const' => 'wp-codebox/agent-fanout-result/v1' ),
 							'execution'   => array( 'type' => 'string' ),
 							'session'     => array( 'type' => 'object' ),
 							'concurrency' => array( 'type' => 'integer' ),
@@ -462,7 +464,14 @@ final class WP_Codebox_Abilities {
 							'failed'      => array( 'type' => 'integer' ),
 							'cancelled'   => array( 'type' => 'integer' ),
 							'timings'     => array( 'type' => 'object' ),
-							'artifacts'   => array( 'type' => 'object' ),
+							'artifacts'   => array(
+								'type'       => 'object',
+								'properties' => array(
+									'schema' => array( 'type' => 'string', 'const' => 'wp-codebox/agent-fanout-artifacts/v1' ),
+									'plan'   => array( 'type' => 'string' ),
+									'events' => array( 'type' => 'string' ),
+								),
+							),
 							'orchestrator' => array( 'type' => 'object' ),
 							'runs'        => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
 							'failures'    => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -11,6 +11,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	private const SCHEMA = 'wp-codebox/agent-task-run/v1';
 	private const BATCH_SCHEMA = 'wp-codebox/agent-task-batch/v1';
+	private const FANOUT_PLAN_SCHEMA = 'wp-codebox/agent-fanout-plan/v1';
+	private const FANOUT_EVENT_SCHEMA = 'wp-codebox/agent-fanout-event/v1';
 	private const FANOUT_SCHEMA = 'wp-codebox/agent-fanout-result/v1';
 	private const FANOUT_MAX_CONCURRENCY = 8;
 	private const SESSION_SCHEMA = WP_Codebox_Agent_Task::SESSION_SCHEMA;
@@ -89,7 +91,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		$plan = array(
-			'schema'      => 'wp-codebox/agent-fanout-plan/v1',
+			'schema'      => self::FANOUT_PLAN_SCHEMA,
 			'session_id'  => $parent_session_id,
 			'concurrency' => $concurrency,
 			'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
@@ -104,6 +106,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			),
 		);
 		$this->write_json_file( $fanout_path . DIRECTORY_SEPARATOR . 'plan.json', $plan );
+		$this->append_fanout_event( $fanout_path, array( 'event' => 'fanout.started', 'total' => count( $workers ), 'concurrency' => $concurrency ) );
 
 		$prepared_workers = array();
 		foreach ( $workers as $index => $worker ) {
@@ -141,6 +144,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$cancelled = count( array_filter( $runs, static fn( array $run ): bool => 'cancelled' === ( $run['status'] ?? '' ) ) );
 		$failed    = count( $runs ) - $completed - $cancelled;
 		$success   = 0 === $failed && 0 === $cancelled;
+		$this->append_fanout_event( $fanout_path, array( 'event' => 'aggregation.started', 'completed' => $completed, 'failed' => $failed, 'cancelled' => $cancelled ) );
 
 		$result = array(
 			'success'     => $success,
@@ -172,7 +176,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		);
 
 		$this->write_json_file( $aggregate_path . DIRECTORY_SEPARATOR . 'result.json', array( 'schema' => 'wp-codebox/agent-fanout-aggregate/v1', 'status' => $success ? 'completed' : 'failed', 'completed' => $completed, 'failed' => $failed, 'cancelled' => $cancelled ) );
+		$this->append_fanout_event( $fanout_path, array( 'event' => 'aggregation.completed', 'status' => $success ? 'completed' : 'failed' ) );
 		$this->write_json_file( $fanout_path . DIRECTORY_SEPARATOR . 'result.json', $result );
+		$this->append_fanout_event( $fanout_path, array( 'event' => $success ? 'fanout.completed' : 'fanout.failed', 'status' => $success ? 'completed' : 'failed', 'completed' => $completed, 'failed' => $failed, 'cancelled' => $cancelled ) );
 
 		return $result;
 	}
@@ -544,7 +550,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				}
 
 				$active[] = $started;
-				$this->append_fanout_event( $fanout_path, array( 'event' => 'worker_started', 'worker_id' => (string) $item['id'], 'active' => count( $active ) ) );
+				$this->append_fanout_event( $fanout_path, array( 'event' => 'worker.started', 'worker_id' => (string) $item['id'], 'active' => count( $active ) ) );
 			}
 
 			foreach ( $active as $active_index => &$worker ) {
@@ -586,7 +592,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				$completed = $this->complete_agent_task_run( $worker['prepared'], $result );
 				$runs[ (int) $worker['index'] ] = is_wp_error( $completed ) ? $this->fanout_worker_error_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) ) : $this->fanout_worker_success_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) );
 				$this->write_json_file( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $worker['index'] ] );
-				$this->append_fanout_event( $fanout_path, array( 'event' => 'worker_finished', 'worker_id' => (string) $worker['id'], 'status' => (string) $runs[ (int) $worker['index'] ]['status'] ) );
+				$this->append_fanout_event( $fanout_path, array( 'event' => true === ( $runs[ (int) $worker['index'] ]['success'] ?? false ) ? 'worker.completed' : 'worker.failed', 'worker_id' => (string) $worker['id'], 'status' => (string) $runs[ (int) $worker['index'] ]['status'] ) );
 				unset( $active[ $active_index ] );
 			}
 			unset( $worker );
@@ -742,7 +748,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $event Event data. */
 	private function append_fanout_event( string $fanout_path, array $event ): void {
-		$event = array_merge( array( 'schema' => 'wp-codebox/agent-fanout-event/v1', 'time' => gmdate( 'c' ) ), $event );
+		$event = array_merge( array( 'schema' => self::FANOUT_EVENT_SCHEMA, 'time' => gmdate( 'c' ) ), $event );
 		$encoded = function_exists( 'wp_json_encode' ) ? wp_json_encode( $event, JSON_UNESCAPED_SLASHES ) : json_encode( $event, JSON_UNESCAPED_SLASHES );
 		if ( is_string( $encoded ) ) {
 			file_put_contents( $fanout_path . DIRECTORY_SEPARATOR . 'events.jsonl', $encoded . "\n", FILE_APPEND );

--- a/scripts/fanout-contract-smoke.ts
+++ b/scripts/fanout-contract-smoke.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import {
+  FANOUT_EVENT_SCHEMA,
+  FANOUT_EVENT_TYPES,
+  FANOUT_PLAN_SCHEMA,
+  FANOUT_REQUEST_SCHEMA,
+  FANOUT_RESULT_SCHEMA,
+  FANOUT_WORKER_SCHEMA,
+  isFanoutEventType,
+  type FanoutExecutionStrategy,
+  type FanoutLifecycleEvent,
+  type FanoutPlanContract,
+  type FanoutRequestContract,
+} from "@automattic/wp-codebox-core"
+
+const request: FanoutRequestContract = {
+  schema: FANOUT_REQUEST_SCHEMA,
+  concurrency: 2,
+  workers: [
+    { schema: FANOUT_WORKER_SCHEMA, id: "design", goal: "Draft design direction.", artifactNamespace: "design" },
+    { schema: FANOUT_WORKER_SCHEMA, id: "copy", goal: "Draft page copy.", artifactNamespace: "copy" },
+  ],
+}
+
+const plan: FanoutPlanContract = {
+  schema: FANOUT_PLAN_SCHEMA,
+  session_id: "fanout-parent-1",
+  concurrency: request.concurrency ?? 1,
+  orchestrator: { product: "example" },
+  workers: request.workers.map((worker) => ({
+    id: worker.id,
+    agent: worker.agent ?? "",
+    goal: worker.goal,
+    artifact_namespace: worker.artifactNamespace ?? worker.id,
+  })),
+}
+
+const events: FanoutLifecycleEvent[] = FANOUT_EVENT_TYPES.map((event, index) => ({
+  schema: FANOUT_EVENT_SCHEMA,
+  event,
+  time: `2026-06-06T00:00:0${index}Z`,
+}))
+
+const execution: FanoutExecutionStrategy = "bounded-concurrent-isolated-sandboxes"
+
+assert.equal(FANOUT_RESULT_SCHEMA, "wp-codebox/agent-fanout-result/v1")
+assert.equal(execution, "bounded-concurrent-isolated-sandboxes")
+assert.equal(plan.schema, FANOUT_PLAN_SCHEMA)
+assert.equal(plan.workers[0].artifact_namespace, "design")
+assert.ok(events.every((event) => event.schema === FANOUT_EVENT_SCHEMA && isFanoutEventType(event.event)))
+assert.equal(isFanoutEventType("worker_finished"), false)
+assert.equal(isFanoutEventType("worker.completed"), true)
+
+console.log("fanout contract smoke ok")

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -383,7 +383,9 @@ $fanout_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-ag
 $assert( 'run-agent-task-fanout ability registered', is_array( $fanout_ability ) );
 $assert( 'fanout ability is REST visible', true === ( $fanout_ability['meta']['show_in_rest'] ?? false ) );
 $assert( 'fanout ability requires workers and exposes concurrency', array( 'workers' ) === ( $fanout_ability['input_schema']['required'] ?? array() ) && 'integer' === ( $fanout_ability['input_schema']['properties']['concurrency']['type'] ?? '' ) );
+$assert( 'fanout ability exposes canonical request and worker schemas', 'wp-codebox/agent-fanout-request/v1' === ( $fanout_ability['input_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/agent-fanout-worker/v1' === ( $fanout_ability['input_schema']['properties']['workers']['items']['properties']['schema']['const'] ?? '' ) );
 $assert( 'fanout ability output exposes parent child rollup fields', isset( $fanout_ability['output_schema']['properties']['completed'] ) && isset( $fanout_ability['output_schema']['properties']['cancelled'] ) && isset( $fanout_ability['output_schema']['properties']['failures'] ) && isset( $fanout_ability['output_schema']['properties']['runs'] ) );
+$assert( 'fanout ability pins result and artifact event references', 'wp-codebox/agent-fanout-result/v1' === ( $fanout_ability['output_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/agent-fanout-artifacts/v1' === ( $fanout_ability['output_schema']['properties']['artifacts']['properties']['schema']['const'] ?? '' ) && 'string' === ( $fanout_ability['output_schema']['properties']['artifacts']['properties']['events']['type'] ?? '' ) );
 
 $browser_session_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/create-browser-playground-session'] ?? null;
 $assert( 'browser Playground session ability registered', is_array( $browser_session_ability ) );
@@ -2686,10 +2688,14 @@ $fanout_result = $fanout_runner->run_fanout(
 	)
 );
 $fanout_active = json_decode( (string) file_get_contents( $root . '/artifacts/fanout-success/fanout/active.json' ), true );
+$fanout_event_lines = array_values( array_filter( explode( "\n", trim( (string) file_get_contents( $root . '/artifacts/fanout-success/fanout/events.jsonl' ) ) ) ) );
+$fanout_events      = array_map( static fn( string $line ): array => json_decode( $line, true ), $fanout_event_lines );
+$fanout_event_names = array_map( static fn( array $event ): string => (string) ( $event['event'] ?? '' ), $fanout_events );
 $assert( 'fanout runner succeeds with bounded parallel workers', ! is_wp_error( $fanout_result ) && true === ( $fanout_result['success'] ?? false ) && 3 === ( $fanout_result['completed'] ?? 0 ) && 0 === ( $fanout_result['failed'] ?? -1 ) && 2 === ( $fanout_result['concurrency'] ?? 0 ) );
 $assert( 'fanout runner enforces concurrency bound while running concurrently', ! is_wp_error( $fanout_result ) && 2 === ( $fanout_active['max'] ?? 0 ) );
 $assert( 'fanout runner assigns parent and child session envelopes', ! is_wp_error( $fanout_result ) && 'parent-fanout-123' === ( $fanout_result['session']['id'] ?? '' ) && 'parent-fanout-123:alpha' === ( $fanout_result['runs'][0]['session']['id'] ?? '' ) && 'parent-fanout-123:bravo' === ( $fanout_result['session']['children'][1]['session_id'] ?? '' ) );
-$assert( 'fanout runner writes stable namespaced artifacts', ! is_wp_error( $fanout_result ) && is_file( $root . '/artifacts/fanout-success/fanout/plan.json' ) && is_file( $root . '/artifacts/fanout-success/fanout/events.jsonl' ) && is_file( $root . '/artifacts/fanout-success/fanout/workers/alpha/result.json' ) && is_file( $root . '/artifacts/fanout-success/fanout/aggregate/result.json' ) && 'alpha' === ( $fanout_result['runs'][0]['artifacts']['namespace'] ?? '' ) );
+$assert( 'fanout runner writes stable namespaced artifacts', ! is_wp_error( $fanout_result ) && is_file( $root . '/artifacts/fanout-success/fanout/plan.json' ) && is_file( $root . '/artifacts/fanout-success/fanout/events.jsonl' ) && is_file( $root . '/artifacts/fanout-success/fanout/workers/alpha/result.json' ) && is_file( $root . '/artifacts/fanout-success/fanout/aggregate/result.json' ) && 'wp-codebox/agent-fanout-artifacts/v1' === ( $fanout_result['artifacts']['schema'] ?? '' ) && 'alpha' === ( $fanout_result['runs'][0]['artifacts']['namespace'] ?? '' ) );
+$assert( 'fanout runner emits canonical lifecycle events', ! is_wp_error( $fanout_result ) && array( 'fanout.started', 'worker.started', 'worker.completed', 'aggregation.started', 'aggregation.completed', 'fanout.completed' ) === array_values( array_intersect( array( 'fanout.started', 'worker.started', 'worker.completed', 'aggregation.started', 'aggregation.completed', 'fanout.completed' ), $fanout_event_names ) ) && count( array_filter( $fanout_events, static fn( array $event ): bool => 'wp-codebox/agent-fanout-event/v1' === ( $event['schema'] ?? '' ) ) ) === count( $fanout_events ) );
 $assert( 'fanout runner preserves opaque orchestrator metadata', ! is_wp_error( $fanout_result ) && 'studio-web' === ( $fanout_result['orchestrator']['type'] ?? '' ) && 'fanout-smoke' === ( $fanout_result['session']['orchestrator']['id'] ?? '' ) );
 
 $fanout_failure = $fanout_runner->run_fanout(
@@ -2707,6 +2713,10 @@ $fanout_failure = $fanout_runner->run_fanout(
 );
 $assert( 'fanout runner rolls up worker failures', ! is_wp_error( $fanout_failure ) && false === ( $fanout_failure['success'] ?? true ) && 1 === ( $fanout_failure['completed'] ?? 0 ) && 1 === ( $fanout_failure['failed'] ?? 0 ) && 'fail-worker' === ( $fanout_failure['failures'][0]['worker_id'] ?? '' ) );
 $assert( 'fanout failure includes worker id agent error and artifact refs', ! is_wp_error( $fanout_failure ) && 'wp_codebox_run_failed' === ( $fanout_failure['failures'][0]['error']['code'] ?? '' ) && str_contains( (string) ( $fanout_failure['failures'][0]['artifacts']['path'] ?? '' ), '/workers/fail-worker/artifacts' ) );
+$fanout_failure_event_lines = array_values( array_filter( explode( "\n", trim( (string) file_get_contents( $root . '/artifacts/fanout-failure/fanout/events.jsonl' ) ) ) ) );
+$fanout_failure_events      = array_map( static fn( string $line ): array => json_decode( $line, true ), $fanout_failure_event_lines );
+$fanout_failure_names       = array_map( static fn( array $event ): string => (string) ( $event['event'] ?? '' ), $fanout_failure_events );
+$assert( 'fanout runner emits failure lifecycle events', in_array( 'worker.failed', $fanout_failure_names, true ) && in_array( 'fanout.failed', $fanout_failure_names, true ) );
 
 $fanout_timeout = $fanout_runner->run_fanout(
 	array(


### PR DESCRIPTION
## Summary
- Adds exported runtime-core constants and types for the generic agent fanout request, worker, plan, result, and event contracts.
- Pins the WordPress ability/result schemas and emits documented dotted lifecycle events for fanout progress.
- Documents the v1 browser/runtime fanout concurrency strategy as bounded concurrent isolated sandboxes.

Closes #679
Closes #682
Closes #683
Closes #685

## Verification
- npm run build
- npm run fanout-contract-smoke
- npm run fanout-aggregation-contract-smoke
- npm run wordpress-plugin-smoke
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the contract hardening, docs, and smoke coverage; Chris remains responsible for review and merge.