### PR TITLE
Capture Playground startup output

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "recipe-runtime-evidence-smoke": "tsx scripts/recipe-runtime-evidence-smoke.ts",
     "recipe-run-timeout-smoke": "tsx scripts/recipe-run-timeout-smoke.ts",
     "playground-archive-cache-validation-smoke": "tsx scripts/playground-archive-cache-validation-smoke.ts",
+    "playground-cli-startup-output-smoke": "tsx scripts/playground-cli-startup-output-smoke.ts",
     "recipe-run-concurrent-playground-cache-smoke": "tsx scripts/recipe-run-concurrent-playground-cache-smoke.ts",
     "playground-sqlite-alias-smoke": "tsx scripts/playground-sqlite-alias-smoke.ts",
     "php-wasm-preflight-smoke": "tsx scripts/php-wasm-preflight-smoke.ts",

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -1,5 +1,5 @@
 import { playgroundBlueprint } from "./blueprint.js"
-import { PlaygroundCliExitError } from "./playground-command-errors.js"
+import { PlaygroundCliExitError, type PlaygroundCliBufferedOutput } from "./playground-command-errors.js"
 import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
 import type { BrowserStartupProgressEvent, BrowserStartupProgressPhase, BrowserStartupProgressStatus, MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { randomInt } from "node:crypto"
@@ -558,10 +558,11 @@ async function portAvailable(port: number): Promise<boolean> {
 
 async function runPlaygroundCliWithoutProcessExit<T>(callback: () => Promise<T>): Promise<T> {
   const exit = process.exit
+  const outputCapture = capturePlaygroundCliProcessOutput()
   const activeHandles = activeProcessHandles()
   process.exit = ((code?: string | number | null | undefined): never => {
     const exitCode = typeof code === "number" ? code : 1
-    throw new PlaygroundCliExitError(exitCode)
+    throw new PlaygroundCliExitError(exitCode, outputCapture.output())
   }) as typeof process.exit
 
   try {
@@ -570,7 +571,70 @@ async function runPlaygroundCliWithoutProcessExit<T>(callback: () => Promise<T>)
     await disposeNewProcessHandles(activeHandles)
     throw error
   } finally {
+    outputCapture.dispose()
     process.exit = exit
+  }
+}
+
+function capturePlaygroundCliProcessOutput(maxBytes = 32_768): { output: () => PlaygroundCliBufferedOutput | undefined; dispose: () => void } {
+  const stdoutWrite = process.stdout.write.bind(process.stdout)
+  const stderrWrite = process.stderr.write.bind(process.stderr)
+  const stdout: Buffer[] = []
+  const stderr: Buffer[] = []
+  let stdoutBytes = 0
+  let stderrBytes = 0
+  let truncated = false
+
+  const capture = (chunks: Buffer[], currentBytes: number, chunk: string | Uint8Array): number => {
+    if (currentBytes >= maxBytes) {
+      truncated = true
+      return currentBytes
+    }
+
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    const remaining = maxBytes - currentBytes
+    if (buffer.byteLength > remaining) {
+      chunks.push(buffer.subarray(0, remaining))
+      truncated = true
+      return maxBytes
+    }
+
+    chunks.push(buffer)
+    return currentBytes + buffer.byteLength
+  }
+
+  const acknowledgeWrite = (encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): true => {
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback()
+    } else if (callback) {
+      callback()
+    }
+
+    return true
+  }
+
+  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdoutBytes = capture(stdout, stdoutBytes, chunk)
+    return acknowledgeWrite(encodingOrCallback, callback)
+  }) as typeof process.stdout.write
+  process.stderr.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stderrBytes = capture(stderr, stderrBytes, chunk)
+    return acknowledgeWrite(encodingOrCallback, callback)
+  }) as typeof process.stderr.write
+
+  return {
+    output: () => {
+      const output: PlaygroundCliBufferedOutput = {
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        ...(truncated ? { truncated } : {}),
+      }
+      return output.stdout || output.stderr || output.truncated ? output : undefined
+    },
+    dispose: () => {
+      process.stdout.write = stdoutWrite as typeof process.stdout.write
+      process.stderr.write = stderrWrite as typeof process.stderr.write
+    },
   }
 }
 

--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -4,6 +4,12 @@ export interface PlaygroundRunResponse {
   text: string
 }
 
+export interface PlaygroundCliBufferedOutput {
+  stdout?: string
+  stderr?: string
+  truncated?: boolean
+}
+
 export class PlaygroundCommandError extends Error {
   readonly code = "wp-codebox-playground-command-failed"
 
@@ -25,8 +31,8 @@ export class PlaygroundCommandCrashError extends Error {
 export class PlaygroundCliExitError extends Error {
   readonly code = "wp-codebox-playground-cli-exited"
 
-  constructor(readonly exitCode: number) {
-    super(`WordPress Playground CLI exited while booting the runtime with exit code ${exitCode}.`)
+  constructor(readonly exitCode: number, readonly output?: PlaygroundCliBufferedOutput) {
+    super(playgroundCliExitMessage(exitCode, output))
     this.name = "PlaygroundCliExitError"
   }
 }
@@ -90,6 +96,26 @@ function playgroundFailureMessage(command: string, response: PlaygroundRunRespon
 
   if (text) {
     lines.push("", "--- Playground output ---", text)
+  }
+
+  return lines.join("\n")
+}
+
+function playgroundCliExitMessage(exitCode: number, output: PlaygroundCliBufferedOutput | undefined): string {
+  const lines = [`WordPress Playground CLI exited while booting the runtime with exit code ${exitCode}.`]
+  const stderr = output?.stderr?.trim()
+  const stdout = output?.stdout?.trim()
+
+  if (stderr) {
+    lines.push("", "--- Playground CLI stderr ---", stderr)
+  }
+
+  if (stdout) {
+    lines.push("", "--- Playground CLI stdout ---", stdout)
+  }
+
+  if (output?.truncated) {
+    lines.push("", "[Playground CLI output was truncated]")
   }
 
   return lines.join("\n")

--- a/scripts/playground-cli-startup-output-smoke.ts
+++ b/scripts/playground-cli-startup-output-smoke.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { startPlaygroundCliServer, type PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-playground-cli-startup-output-"))
+
+try {
+  const wordpressZip = join(workspace, "wordpress.zip")
+  await writeFile(wordpressZip, Buffer.from("504b0506000000000000000000000000000000000000", "hex"))
+
+  const cliModule: PlaygroundCliModule = {
+    async runCLI(): Promise<never> {
+      process.stderr.write("PHP Fatal error: startup asset bootstrap failed\n")
+      process.stdout.write("Playground bootstrap stdout marker\n")
+      process.exit(1)
+    },
+  }
+
+  const spec: RuntimeCreateSpec = {
+    backend: "wordpress-playground",
+    environment: {
+      kind: "wordpress",
+      name: "playground-cli-startup-output-smoke",
+      version: "7.0",
+      assets: { wordpressZip },
+      blueprint: { steps: [] },
+    },
+    policy: {
+      filesystem: "readwrite-mounts",
+      network: "deny",
+      commands: ["wordpress.run-php"],
+      secrets: "none",
+      approvals: "never",
+    },
+    secretEnv: {},
+    artifactsDirectory: workspace,
+  }
+
+  await assert.rejects(
+    () => startPlaygroundCliServer(spec, [], { cliModule }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error)
+      assert.equal(error.name, "PlaygroundCliExitError", error.stack)
+      assert.match(error.message, /exit code 1/)
+      assert.match(error.message, /PHP Fatal error: startup asset bootstrap failed/)
+      assert.match(error.message, /Playground bootstrap stdout marker/)
+      assert.equal((error as { output?: { stderr?: string; stdout?: string } }).output?.stderr, "PHP Fatal error: startup asset bootstrap failed\n")
+      assert.equal((error as { output?: { stderr?: string; stdout?: string } }).output?.stdout, "Playground bootstrap stdout marker\n")
+      return true
+    },
+  )
+
+  console.log("Playground CLI startup output smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Capture bounded stdout/stderr emitted by the embedded Playground CLI during runtime startup.
- Include captured startup output on `PlaygroundCliExitError` messages and serialized error data so recipe failures expose useful boot diagnostics instead of only an exit code.
- Add a focused smoke test using a fake Playground CLI module and custom `runtime.assets.wordpressZip` startup asset.

## Verification
- `npm run build`
- `npm run playground-cli-startup-output-smoke`

## Known follow-up
- `npm run recipe-playground-boot-failure-smoke` currently fails because a preview-port conflict during a workflow command escapes as an unhandled CLI exception with empty JSON output. That is a separate existing workflow error-handling path, not the custom startup-asset diagnostics path changed here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the bounded startup-output capture and targeted smoke coverage; Chris remains responsible for review and testing.