### PR TITLE
Execute browser agent fanout phases

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
     "fanout-contract-smoke": "tsx scripts/fanout-contract-smoke.ts",
     "fanout-aggregation-contract-smoke": "tsx scripts/fanout-aggregation-contract-smoke.ts",
+    "agent-fanout-execution-smoke": "tsx scripts/agent-fanout-execution-smoke.ts",
     "run-registry-smoke": "tsx scripts/run-registry-smoke.ts",
     "benchmark-substrate-smoke": "tsx scripts/benchmark-substrate-smoke.ts",
     "benchmark-matrix-cli-smoke": "tsx scripts/benchmark-matrix-cli-smoke.ts",

--- a/packages/cli/src/agent-fanout.ts
+++ b/packages/cli/src/agent-fanout.ts
@@ -1,0 +1,327 @@
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { aggregateFanoutOutputs, FANOUT_EVENT_SCHEMA, FANOUT_PLAN_SCHEMA, FANOUT_REQUEST_SCHEMA, FANOUT_RESULT_SCHEMA, stripUndefined, type FanoutAggregationOutput, type FanoutLifecycleEvent, type FanoutRequestContract } from "@automattic/wp-codebox-core"
+import { runAgentTask, type AgentTaskRunInput, type AgentTaskRunOptions } from "./commands/agent-task-run.js"
+
+const MAX_FANOUT_CONCURRENCY = 8
+
+export interface AgentFanoutExecutionOptions {
+  artifactRoot: string
+  recipeDirectory: string
+  previewHoldSeconds?: string
+  previewPublicUrl?: string
+  runWorker?: (input: AgentTaskRunInput, options: AgentTaskRunOptions) => Promise<AgentFanoutWorkerOutput>
+}
+
+export interface AgentFanoutExecutionResult {
+  schema: typeof FANOUT_RESULT_SCHEMA
+  status: "completed" | "failed"
+  success: boolean
+  session: {
+    id: string
+    children: Array<{ id: string; worker_id: string; status: string; artifacts: string }>
+  }
+  concurrency: number
+  plan: Record<string, unknown>
+  artifacts: Record<string, unknown>
+  workers: AgentFanoutWorkerResult[]
+  aggregate: FanoutAggregationOutput
+  counts: { total: number; completed: number; failed: number; cancelled: number }
+  events_path: string
+  result_path: string
+}
+
+interface AgentFanoutWorkerResult {
+  worker_id: string
+  status: "succeeded" | "failed"
+  required: boolean
+  session_id: string
+  result_ref: string
+  artifact_refs: Array<Record<string, unknown>>
+  error?: { code: string; message: string }
+  output?: Record<string, unknown>
+}
+
+type AgentFanoutWorkerOutput = Record<string, unknown> & { success?: boolean; evidence_refs?: unknown[]; error?: unknown }
+
+export async function executeAgentFanoutRequest(request: FanoutRequestContract, options: AgentFanoutExecutionOptions): Promise<AgentFanoutExecutionResult> {
+  if (request.schema && request.schema !== FANOUT_REQUEST_SCHEMA) {
+    throw new Error(`wp-codebox.agent-fanout requires ${FANOUT_REQUEST_SCHEMA}`)
+  }
+  if (!Array.isArray(request.workers) || request.workers.length === 0) {
+    throw new Error("wp-codebox.agent-fanout requires at least one worker")
+  }
+
+  const sessionId = stringValue(request.orchestrator?.session_id) || stringValue(request.orchestrator?.request_id) || `fanout-${Date.now()}`
+  const concurrency = Math.max(1, Math.min(MAX_FANOUT_CONCURRENCY, Math.floor(Number(request.concurrency) || 1)))
+  const fanoutRoot = join(options.artifactRoot, "fanout")
+  const workersRoot = join(fanoutRoot, "workers")
+  const aggregateRoot = join(fanoutRoot, "aggregate")
+  const aggregateFinalRoot = join(aggregateRoot, "final")
+  const eventsPath = join(fanoutRoot, "events.jsonl")
+  const planPath = join(fanoutRoot, "plan.json")
+  const resultPath = join(fanoutRoot, "result.json")
+  await mkdir(workersRoot, { recursive: true })
+  await mkdir(aggregateFinalRoot, { recursive: true })
+
+  const workers = request.workers.map((worker) => {
+    const id = safeWorkerId(worker.id)
+    return {
+      ...worker,
+      id,
+      agent: stringValue(worker.agent) || stringValue(request.agent),
+      artifact_namespace: safeArtifactNamespace(worker.artifactNamespace, id),
+      required: worker.required !== false,
+    }
+  })
+
+  if (new Set(workers.map((worker) => worker.id)).size !== workers.length) {
+    throw new Error("wp-codebox.agent-fanout worker ids must be unique")
+  }
+
+  const plan = {
+    schema: FANOUT_PLAN_SCHEMA,
+    session_id: sessionId,
+    concurrency,
+    orchestrator: request.orchestrator ?? {},
+    workers: workers.map((worker) => ({
+      id: worker.id,
+      agent: worker.agent,
+      goal: worker.goal,
+      artifact_namespace: worker.artifact_namespace,
+    })),
+  }
+  await writeJson(planPath, plan)
+  await emitEvent(eventsPath, { event: "fanout.started", total: workers.length, active: 0, completed: 0, failed: 0, cancelled: 0 })
+
+  const runWorker = options.runWorker ?? (async (input: AgentTaskRunInput, workerOptions: AgentTaskRunOptions): Promise<AgentFanoutWorkerOutput> => runAgentTask(input, workerOptions) as unknown as AgentFanoutWorkerOutput)
+  const workerResults = await runBounded(workers, concurrency, async (worker): Promise<AgentFanoutWorkerResult> => {
+    const workerArtifacts = join(workersRoot, worker.id, "artifacts")
+    const childSessionId = `${sessionId}:${worker.id}`
+    await mkdir(workerArtifacts, { recursive: true })
+    await emitEvent(eventsPath, { event: "worker.started", worker_id: worker.id })
+    try {
+      const output = await runWorker(workerInput(request, worker, childSessionId, workerArtifacts), {
+        inputPath: "",
+        json: true,
+        previewHoldSeconds: options.previewHoldSeconds ?? "",
+        previewPublicUrl: options.previewPublicUrl ?? "",
+      })
+      const success = output.success === true
+      const resultRef = `fanout/workers/${worker.id}/result.json`
+      const workerResult = stripUndefined({
+        worker_id: worker.id,
+        status: success ? "succeeded" : "failed",
+        required: worker.required,
+        session_id: childSessionId,
+        result_ref: resultRef,
+        artifact_refs: workerArtifactRefs(worker.id, output),
+        output,
+        ...(!success ? { error: { code: "worker-failed", message: stringValue(objectValue(output.error)?.message) || `Fanout worker ${worker.id} failed.` } } : {}),
+      }) as AgentFanoutWorkerResult
+      await writeJson(join(workersRoot, worker.id, "result.json"), workerResult)
+      await emitEvent(eventsPath, { event: success ? "worker.completed" : "worker.failed", worker_id: worker.id, status: workerResult.status })
+      return workerResult
+    } catch (error) {
+      const resultRef = `fanout/workers/${worker.id}/result.json`
+      const workerResult = {
+        worker_id: worker.id,
+        status: "failed" as const,
+        required: worker.required,
+        session_id: childSessionId,
+        result_ref: resultRef,
+        artifact_refs: [],
+        error: { code: "worker-exception", message: error instanceof Error ? error.message : String(error) },
+      }
+      await writeJson(join(workersRoot, worker.id, "result.json"), workerResult)
+      await emitEvent(eventsPath, { event: "worker.failed", worker_id: worker.id, status: "failed" })
+      return workerResult
+    }
+  })
+
+  await emitEvent(eventsPath, { event: "aggregation.started", total: workers.length, completed: workerResults.filter((worker) => worker.status === "succeeded").length, failed: workerResults.filter((worker) => worker.status === "failed").length })
+  const aggregate = aggregateFanoutOutputs({
+    plan: { id: sessionId, workers: workers.map((worker) => ({ id: worker.id, dependsOn: Array.isArray(worker.dependsOn) ? worker.dependsOn.filter((dependency): dependency is string => typeof dependency === "string") : [], required: worker.required, artifactNamespace: worker.artifact_namespace })) },
+    policy: stringValue(request.aggregation?.policy) || "fail",
+    aggregation: request.aggregation,
+    worker_results: workerResults.map((worker) => ({
+      worker_id: worker.worker_id,
+      status: worker.status,
+      required: worker.required,
+      result_ref: worker.result_ref,
+      artifact_refs: worker.artifact_refs,
+      error: worker.error,
+    })),
+  }, {
+    finalArtifactRefs: [{ path: "fanout/aggregate/final/result.json", kind: "agent-fanout-aggregate", namespace: "aggregate/final" }],
+  })
+  await writeJson(join(aggregateRoot, "result.json"), aggregate)
+  await writeJson(join(aggregateFinalRoot, "result.json"), aggregate)
+  await emitEvent(eventsPath, { event: "aggregation.completed", status: aggregate.status })
+
+  const counts = {
+    total: workerResults.length,
+    completed: workerResults.filter((worker) => worker.status === "succeeded").length,
+    failed: workerResults.filter((worker) => worker.status === "failed").length,
+    cancelled: 0,
+  }
+  const success = aggregate.status === "succeeded"
+  const result: AgentFanoutExecutionResult = {
+    schema: FANOUT_RESULT_SCHEMA,
+    status: success ? "completed" : "failed",
+    success,
+    session: {
+      id: sessionId,
+      children: workerResults.map((worker) => ({ id: worker.session_id, worker_id: worker.worker_id, status: worker.status, artifacts: join(workersRoot, worker.worker_id, "artifacts") })),
+    },
+    concurrency,
+    plan,
+    artifacts: {
+      root: fanoutRoot,
+      plan: "fanout/plan.json",
+      events: "fanout/events.jsonl",
+      result: "fanout/result.json",
+      workers: "fanout/workers",
+      aggregate: "fanout/aggregate/result.json",
+      final: "fanout/aggregate/final/result.json",
+    },
+    workers: workerResults,
+    aggregate,
+    counts,
+    events_path: eventsPath,
+    result_path: resultPath,
+  }
+  await writeJson(resultPath, result)
+  await emitEvent(eventsPath, { event: success ? "fanout.completed" : "fanout.failed", total: counts.total, completed: counts.completed, failed: counts.failed, cancelled: counts.cancelled })
+  return result
+}
+
+export async function executeAgentFanoutFromArgs(args: string[], options: AgentFanoutExecutionOptions): Promise<AgentFanoutExecutionResult> {
+  const request = await fanoutRequestFromArgs(args, options.recipeDirectory)
+  return executeAgentFanoutRequest(request, options)
+}
+
+async function fanoutRequestFromArgs(args: string[], recipeDirectory: string): Promise<FanoutRequestContract> {
+  const raw = argValue(args, "fanout-json") || argValue(args, "request-json")
+  if (!raw) {
+    throw new Error("wp-codebox.agent-fanout requires fanout-json=<json-or-@file>")
+  }
+  const text = raw.startsWith("@") ? await readFile(join(recipeDirectory, raw.slice(1)), "utf8") : raw
+  const parsed = JSON.parse(text) as unknown
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("wp-codebox.agent-fanout fanout-json must be a JSON object")
+  }
+  return parsed as FanoutRequestContract
+}
+
+function workerInput(request: FanoutRequestContract, worker: Record<string, unknown>, childSessionId: string, artifactsPath: string): AgentTaskRunInput {
+  const parentInput = objectValue(request.task_input) || objectValue(request.taskInput) || {}
+  const workerTaskInput = objectValue(worker.task_input) || objectValue(worker.taskInput) || {}
+  const inherited = inheritedAgentTaskInput(request)
+  const workerInherited = inheritedAgentTaskInput(worker)
+  return stripUndefined({
+    ...inherited,
+    ...parentInput,
+    ...workerInherited,
+    ...workerTaskInput,
+    goal: stringValue(worker.task) || stringValue(worker.goal),
+    agent: stringValue(worker.agent) || stringValue(parentInput.agent) || stringValue(request.agent),
+    artifacts_path: artifactsPath,
+    session_id: childSessionId,
+    sandbox_session_id: childSessionId,
+    parent_request: request as unknown as Record<string, unknown>,
+    orchestrator: stripUndefined({ ...(request.orchestrator ?? {}), fanout_worker_id: worker.id }),
+  }) as AgentTaskRunInput
+}
+
+function inheritedAgentTaskInput(source: Record<string, unknown>): Record<string, unknown> {
+  const keys = [
+    "mode",
+    "provider",
+    "model",
+    "provider_plugin_paths",
+    "secret_env",
+    "mounts",
+    "workspaces",
+    "runtime_stack_mounts",
+    "runtime_overlays",
+    "agent_bundles",
+    "runtime_task",
+    "sandbox_tool_policy",
+    "max_turns",
+    "task_timeout_seconds",
+    "wp",
+    "agents_api_path",
+    "data_machine_path",
+    "data_machine_code_path",
+    "runtime_component_paths",
+  ]
+  const result: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (source[key] !== undefined) result[key] = source[key]
+  }
+  return result
+}
+
+async function runBounded<T, R>(items: T[], concurrency: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await worker(items[index])
+    }
+  })
+  await Promise.all(runners)
+  return results
+}
+
+async function emitEvent(path: string, event: Omit<FanoutLifecycleEvent, "schema" | "time" | "worker_id"> & { worker_id?: string }): Promise<void> {
+  await appendFile(path, `${JSON.stringify({ schema: FANOUT_EVENT_SCHEMA, time: new Date().toISOString(), ...event })}\n`)
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(join(path, ".."), { recursive: true })
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function workerArtifactRefs(workerId: string, output: Record<string, unknown>): Array<Record<string, unknown>> {
+  const refs = Array.isArray(output.evidence_refs) ? output.evidence_refs.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
+  return refs.map((ref, index) => stripUndefined({
+    id: `${workerId}:${index}`,
+    worker_id: workerId,
+    namespace: `workers/${workerId}`,
+    path: stringValue(ref.uri) || stringValue(ref.path),
+    kind: stringValue(ref.kind) || "codebox-evidence",
+    metadata: ref,
+  }))
+}
+
+function safeWorkerId(value: unknown): string {
+  const id = stringValue(value)
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id)) {
+    throw new Error(`wp-codebox.agent-fanout worker id must be a safe path segment: ${id || "<empty>"}`)
+  }
+  return id
+}
+
+function safeArtifactNamespace(value: unknown, fallback: string): string {
+  const namespace = stringValue(value) || fallback
+  if (namespace.split("/").some((segment) => !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment))) {
+    throw new Error(`wp-codebox.agent-fanout artifact namespace must contain safe path segments: ${namespace}`)
+  }
+  return namespace
+}
+
+function argValue(args: string[], name: string): string | undefined {
+  const prefix = `${name}=`
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length)
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}
+
+function stringValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value).trim()
+}

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -6,14 +6,14 @@ import { spawnSync } from "node:child_process"
 import { normalizeTaskInput, stripUndefined, type SandboxToolPolicySnapshot, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { runRecipeRunCommand } from "./recipe-run.js"
 
-interface AgentTaskRunOptions {
+export interface AgentTaskRunOptions {
   inputPath: string
   json: boolean
   previewHoldSeconds: string
   previewPublicUrl: string
 }
 
-interface AgentTaskRunInput {
+export interface AgentTaskRunInput {
   goal?: string
   task?: string
   agent?: string
@@ -75,7 +75,7 @@ export async function runAgentTaskRunCommand(args: string[]): Promise<number> {
   return output.success ? 0 : 1
 }
 
-async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskRunOptions): Promise<AgentTaskRunOutput> {
+export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskRunOptions): Promise<AgentTaskRunOutput> {
   const taskInput = normalizeTaskInput(input)
   const task = taskInput.goal
   const wpVersion = stringValue(input.wp) || "trunk"

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -7,6 +7,7 @@ import { RuntimeRunRegistry, artifactBundleRunRef, artifactManifestFile, createB
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
+import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded, type RecipeDryRunOutput, type RecipeDryRunSiteSeed, type RecipeDryRunStagedFile } from "../recipe-dry-run.js"
@@ -1040,7 +1041,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const workflowSteps = recipeWorkflowSteps(recipe)
     await phaseTracker.run("run_workloads", phaseWorkflowData(workflowSteps), async () => {
       for (const workflowStep of workflowSteps) {
-        executions.push(await awaitRecipe(`workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`, executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace)))
+        executions.push(await awaitRecipe(`workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`, executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options)))
         interruption?.throwIfInterrupted()
       }
     })
@@ -1758,8 +1759,28 @@ function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: Recip
   }
 }
 
-async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>): Promise<RecipeExecutionResult> {
+async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, artifactRoot?: string, options?: RecipeRunOptions): Promise<RecipeExecutionResult> {
   try {
+    if (workflowStep.step.command === "wp-codebox.agent-fanout") {
+      const startedAt = new Date().toISOString()
+      const result = await executeAgentFanoutFromArgs(workflowStep.step.args ?? [], {
+        artifactRoot: artifactRoot || recipeDirectory,
+        recipeDirectory,
+        previewHoldSeconds: options?.previewHoldSeconds === undefined ? "" : String(options.previewHoldSeconds),
+        previewPublicUrl: options?.previewPublicUrl,
+      })
+      const finishedAt = new Date().toISOString()
+      return withRecipeExecutionPhase({
+        id: `agent-fanout-${workflowStep.index}`,
+        command: workflowStep.step.command,
+        args: workflowStep.step.args ?? [],
+        exitCode: result.success ? 0 : 1,
+        stdout: `${JSON.stringify(result, null, 2)}\n`,
+        stderr: "",
+        startedAt,
+        finishedAt,
+      }, workflowStep.phase, workflowStep.index, workflowStep.step.command)
+    }
     const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory, sandboxWorkspace))
     return withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, workflowStep.step.command)
   } catch (error) {

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -739,7 +739,7 @@ final class WP_Codebox_Abilities {
 							'artifact_files'     => array( 'type' => 'array' ),
 							'phases'             => array(
 								'type'        => 'array',
-								'description' => 'Optional named browser task phases. Generic phases describe product-owned agent fanout steps; materializer phases may override any primary session input through input.',
+								'description' => 'Optional named browser task phases. Generic phases may carry wp-codebox/agent-fanout-request/v1 in request/input for WP Codebox execution; materializer phases may override any primary session input through input.',
 								'items'       => array(
 									'type'       => 'object',
 									'properties' => array(
@@ -748,6 +748,7 @@ final class WP_Codebox_Abilities {
 										'label'    => array( 'type' => 'string' ),
 										'status'   => array( 'type' => 'string' ),
 										'metadata' => array( 'type' => 'object' ),
+										'request'  => array( 'type' => 'object' ),
 										'input'    => array( 'type' => 'object' ),
 									),
 								),

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -257,6 +257,9 @@ private static function compact_browser_task_contract_dto( array $contract ): ar
 		if ( is_array( $phase['contract'] ?? null ) ) {
 			$phase_dto['contract'] = self::compact_browser_materializer_contract_dto( $phase['contract'] );
 		}
+		if ( is_array( $phase['result'] ?? null ) ) {
+			$phase_dto['result'] = self::compact_browser_dto_value( $phase['result'] );
+		}
 
 		$phases[] = array_filter( $phase_dto, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 	}
@@ -526,6 +529,23 @@ private static function browser_task_contract_phases( array $input, array $sessi
 			'metadata' => is_array( $phase['metadata'] ?? null ) ? self::compact_browser_dto_value( $phase['metadata'] ) : array(),
 		);
 
+		$fanout_request = self::browser_task_phase_fanout_request( $phase );
+		if ( is_array( $fanout_request ) ) {
+			if ( empty( $fanout_request['sandbox_session_id'] ) && '' !== (string) ( $session_envelope['id'] ?? '' ) ) {
+				$fanout_request['sandbox_session_id'] = (string) $session_envelope['id'];
+			}
+
+			$result = self::run_agent_task_fanout( $fanout_request );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$phase_descriptor['status'] = true === ( $result['success'] ?? false ) ? 'completed' : 'failed';
+			$phase_descriptor['result'] = $result;
+			$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
+			continue;
+		}
+
 		if ( 'materializer' !== $kind ) {
 			$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 			continue;
@@ -549,6 +569,18 @@ private static function browser_task_contract_phases( array $input, array $sessi
 	}
 
 	return $phases;
+}
+
+/** @param array<string,mixed> $phase Browser task phase. @return array<string,mixed>|null */
+private static function browser_task_phase_fanout_request( array $phase ): ?array {
+	$candidates = array( $phase['request'] ?? null, $phase['input'] ?? null );
+	foreach ( $candidates as $candidate ) {
+		if ( is_array( $candidate ) && 'wp-codebox/agent-fanout-request/v1' === (string) ( $candidate['schema'] ?? '' ) ) {
+			return $candidate;
+		}
+	}
+
+	return null;
 }
 
 /**

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -376,7 +376,7 @@ private static function browser_task_contract_schema(): array {
 			'primary'          => self::browser_playground_session_schema(),
 			'phases'           => array(
 				'type'        => 'array',
-				'description' => 'Named browser task phases. Materializer phases include a browser-materializer-contract envelope; generic phases preserve product-neutral phase metadata for product UIs.',
+				'description' => 'Named browser task phases. Materializer phases include a browser-materializer-contract envelope; fanout phases execute wp-codebox/agent-fanout-request/v1 through WP Codebox; other generic phases preserve product-neutral phase metadata for product UIs.',
 				'items'       => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -387,6 +387,7 @@ private static function browser_task_contract_schema(): array {
 						'status'   => array( 'type' => 'string' ),
 						'metadata' => array( 'type' => 'object' ),
 						'contract' => array( 'type' => 'object' ),
+						'result'   => array( 'type' => 'object' ),
 					),
 				),
 			),

--- a/scripts/agent-fanout-execution-smoke.ts
+++ b/scripts/agent-fanout-execution-smoke.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { FANOUT_EVENT_SCHEMA, FANOUT_REQUEST_SCHEMA, FANOUT_RESULT_SCHEMA } from "@automattic/wp-codebox-core"
+import { executeAgentFanoutRequest } from "../packages/cli/src/agent-fanout.js"
+
+const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-agent-fanout-execution-"))
+const seenWorkers: string[] = []
+
+const result = await executeAgentFanoutRequest({
+  schema: FANOUT_REQUEST_SCHEMA,
+  concurrency: 2,
+  agent: "sandbox-worker",
+  orchestrator: { request_id: "browser-task-123", product: "smoke" },
+  aggregation: { policy: "fail", outputNamespace: "aggregate/final" },
+  workers: [
+    { id: "design", goal: "Draft a design candidate.", artifactNamespace: "workers/design" },
+    { id: "copy", goal: "Draft a copy candidate.", artifactNamespace: "workers/copy" },
+  ],
+}, {
+  artifactRoot,
+  recipeDirectory: artifactRoot,
+  runWorker: async (input) => {
+    seenWorkers.push(String(input.orchestrator?.fanout_worker_id))
+    return {
+      success: true,
+      evidence_refs: [
+        { kind: "worker-result", uri: `${input.artifacts_path}/result.json`, label: String(input.goal) },
+      ],
+      session: { id: input.sandbox_session_id },
+    }
+  },
+})
+
+assert.equal(result.schema, FANOUT_RESULT_SCHEMA)
+assert.equal(result.success, true)
+assert.equal(result.status, "completed")
+assert.equal(result.concurrency, 2)
+assert.deepEqual(seenWorkers.sort(), ["copy", "design"])
+assert.equal(result.session.children.length, 2)
+assert.equal(result.workers.every((worker) => worker.status === "succeeded"), true)
+assert.equal(result.aggregate.status, "succeeded")
+assert.deepEqual(result.aggregate.finalArtifactRefs, [{ path: "fanout/aggregate/final/result.json", kind: "agent-fanout-aggregate", namespace: "aggregate/final" }])
+
+const events = (await readFile(result.events_path, "utf8")).trim().split("\n").map((line) => JSON.parse(line) as Record<string, unknown>)
+assert.equal(events.every((event) => event.schema === FANOUT_EVENT_SCHEMA), true)
+assert.deepEqual(events.map((event) => event.event).sort(), [
+  "aggregation.completed",
+  "aggregation.started",
+  "fanout.completed",
+  "fanout.started",
+  "worker.completed",
+  "worker.completed",
+  "worker.started",
+  "worker.started",
+])
+
+const persisted = JSON.parse(await readFile(result.result_path, "utf8")) as Record<string, unknown>
+assert.equal(persisted.schema, FANOUT_RESULT_SCHEMA)
+assert.equal((persisted.counts as Record<string, unknown>).completed, 2)
+
+console.log("agent fanout execution smoke ok")

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -904,6 +904,42 @@ $legacy_materializer_task_contract = call_user_func(
 );
 $assert( 'browser task contract preserves legacy materializers input compatibility', ! is_wp_error( $legacy_materializer_task_contract ) && 1 === count( $legacy_materializer_task_contract['phases'] ?? array() ) && 'materializer' === ( $legacy_materializer_task_contract['phases'][0]['kind'] ?? '' ) && 'wp-codebox/browser-materializer-contract/v1' === ( $legacy_materializer_task_contract['phases'][0]['contract']['schema'] ?? '' ) && '/tmp/legacy-materializer-result.json' === ( $legacy_materializer_task_contract['phases'][0]['contract']['materialization']['result_path'] ?? '' ) );
 
+$browser_phase_fanout_bin = $root . '/wp-codebox-browser-phase-fanout-fixture';
+file_put_contents(
+	$browser_phase_fanout_bin,
+	 <<<'PHP'
+#!/usr/bin/env php
+<?php
+$artifacts = '';
+for ( $i = 1; $i < $argc; $i++ ) {
+	if ( '--artifacts' === $argv[ $i ] && isset( $argv[ $i + 1 ] ) ) {
+		$artifacts = $argv[ $i + 1 ];
+	}
+}
+if ( '' === $artifacts ) {
+	fwrite( STDERR, "missing artifacts\n" );
+	exit( 2 );
+}
+@mkdir( $artifacts, 0777, true );
+$worker_id = basename( dirname( $artifacts ) );
+echo json_encode(
+	array(
+		'success' => true,
+		'session' => array(
+			'artifacts' => array(
+				'id' => 'browser-phase-artifact-' . $worker_id,
+			),
+		),
+		'evidence_refs' => array(
+			array( 'kind' => 'worker-result', 'uri' => $artifacts . '/result.json' ),
+		),
+	),
+	JSON_UNESCAPED_SLASHES
+) . "\n";
+PHP
+);
+chmod( $browser_phase_fanout_bin, 0755 );
+
 $generic_phase_task_contract = call_user_func(
 	$browser_task_contract_ability['execute_callback'],
 	array_replace_recursive(
@@ -918,6 +954,16 @@ $generic_phase_task_contract = call_user_func(
 					'metadata' => array(
 						'runner' => 'browser-playground',
 					),
+					'request'  => array(
+						'schema'          => 'wp-codebox/agent-fanout-request/v1',
+						'concurrency'     => 1,
+						'workers'         => array(
+							array( 'id' => 'browser_worker', 'goal' => 'Cook the browser phase worker.' ),
+						),
+						'artifacts_path'  => $root . '/artifacts/browser-phase-fanout',
+						'wp_codebox_bin'  => $browser_phase_fanout_bin,
+						'orchestrator'    => array( 'type' => 'browser-task-contract' ),
+					),
 				),
 				array(
 					'name'     => 'aggregate-results',
@@ -931,8 +977,9 @@ $generic_phase_task_contract = call_user_func(
 		)
 	)
 );
-$assert( 'browser task contract accepts agent and aggregator phase descriptors', ! is_wp_error( $generic_phase_task_contract ) && 2 === count( $generic_phase_task_contract['phases'] ?? array() ) && 'agent' === ( $generic_phase_task_contract['phases'][0]['kind'] ?? '' ) && 'aggregator' === ( $generic_phase_task_contract['phases'][1]['kind'] ?? '' ) && ! isset( $generic_phase_task_contract['phases'][0]['contract'] ) && 'queued' === ( $generic_phase_task_contract['phases'][0]['status'] ?? '' ) && 'pending' === ( $generic_phase_task_contract['phases'][1]['status'] ?? '' ) );
-$assert( 'browser task compact DTO preserves generic phase metadata for product UIs', ! is_wp_error( $generic_phase_task_contract ) && 'agent-fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['name'] ?? '' ) && 0 === ( $generic_phase_task_contract['compact']['phases'][0]['index'] ?? null ) && 'Agent Fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['label'] ?? '' ) && 'browser-playground' === ( $generic_phase_task_contract['compact']['phases'][0]['metadata']['runner'] ?? '' ) && 'aggregate-results' === ( $generic_phase_task_contract['compact']['phases'][1]['name'] ?? '' ) && 1 === ( $generic_phase_task_contract['compact']['phases'][1]['index'] ?? null ) );
+$assert( 'browser task contract accepts agent and aggregator phase descriptors', ! is_wp_error( $generic_phase_task_contract ) && 2 === count( $generic_phase_task_contract['phases'] ?? array() ) && 'agent' === ( $generic_phase_task_contract['phases'][0]['kind'] ?? '' ) && 'aggregator' === ( $generic_phase_task_contract['phases'][1]['kind'] ?? '' ) && ! isset( $generic_phase_task_contract['phases'][0]['contract'] ) && 'completed' === ( $generic_phase_task_contract['phases'][0]['status'] ?? '' ) && 'pending' === ( $generic_phase_task_contract['phases'][1]['status'] ?? '' ) );
+$assert( 'browser task contract executes agent fanout phase requests', ! is_wp_error( $generic_phase_task_contract ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_task_contract['phases'][0]['result']['schema'] ?? '' ) && 1 === ( $generic_phase_task_contract['phases'][0]['result']['completed'] ?? 0 ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/result.json' ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/events.jsonl' ) );
+$assert( 'browser task compact DTO preserves generic phase metadata and fanout result for product UIs', ! is_wp_error( $generic_phase_task_contract ) && 'agent-fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['name'] ?? '' ) && 0 === ( $generic_phase_task_contract['compact']['phases'][0]['index'] ?? null ) && 'Agent Fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['label'] ?? '' ) && 'browser-playground' === ( $generic_phase_task_contract['compact']['phases'][0]['metadata']['runner'] ?? '' ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_task_contract['compact']['phases'][0]['result']['schema'] ?? '' ) && 'aggregate-results' === ( $generic_phase_task_contract['compact']['phases'][1]['name'] ?? '' ) && 1 === ( $generic_phase_task_contract['compact']['phases'][1]['index'] ?? null ) );
 
 $agents_api_browser_executor_result = apply_filters(
 	'agents_api_execute_task',


### PR DESCRIPTION
## Summary
- Executes browser task contract phases that carry `wp-codebox/agent-fanout-request/v1` through WP Codebox's generic fanout runner instead of preserving them as metadata only.
- Adds a CLI recipe workflow primitive for `wp-codebox.agent-fanout`, with bounded worker execution, stable fanout artifacts, lifecycle events, and aggregate output.
- Extends smoke coverage for direct fanout execution and browser task contract phase execution.

Closes https://github.com/Automattic/wp-codebox/issues/697

## Tests
- `npm run build`
- `npm run agent-fanout-execution-smoke`
- `npm run fanout-contract-smoke`
- `npm run fanout-aggregation-contract-smoke`
- `npm run wordpress-plugin-smoke`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php && php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l tests/smoke-wordpress-plugin.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the fanout phase execution path, added smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.