### PR TITLE
Add browser probe CLS metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "headless-browser-agent-recipe-smoke": "tsx scripts/headless-browser-agent-recipe-smoke.ts",
     "browser-probe-artifact-smoke": "tsx scripts/browser-probe-artifact-smoke.ts",
     "browser-probe-assertions-smoke": "tsx scripts/browser-probe-assertions-smoke.ts",
+    "browser-probe-layout-shift-smoke": "tsx scripts/browser-probe-layout-shift-smoke.ts",
     "browser-probe-context-smoke": "tsx scripts/browser-probe-context-smoke.ts",
     "browser-probe-public-url-routing-smoke": "tsx scripts/browser-probe-public-url-routing-smoke.ts",
     "browser-probe-profile-matrix-smoke": "tsx scripts/browser-probe-profile-matrix-smoke.ts",

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -219,8 +219,32 @@ export interface BrowserProbePerformanceSummary {
   decodedBodySizeBytes: number
   longTasks: number
   longTaskDurationMs: number
+  layoutShifts: BrowserProbeLayoutShiftSummary
   domNodes: BrowserProbeMetricDigest
   cdpMetrics: Record<string, BrowserProbeMetricDigest>
+}
+
+export interface BrowserProbeLayoutShiftSummary {
+  cls: number
+  count: number
+  totalCount: number
+  max: number
+}
+
+export interface BrowserProbeLayoutShiftSourceRecord {
+  selector: string | null
+  node: string | null
+  previousRect: Record<string, number | null>
+  currentRect: Record<string, number | null>
+}
+
+export interface BrowserProbeLayoutShiftRecord {
+  name: string
+  startTime: number
+  duration: number
+  value: number
+  hadRecentInput: boolean
+  sources: BrowserProbeLayoutShiftSourceRecord[]
 }
 
 export interface BrowserProbeCheckpointRecord {
@@ -266,6 +290,9 @@ export interface BrowserProbeMetricsSnapshot {
       count: number
       totalDurationMs: number
       maxDurationMs: number
+    }
+    layoutShifts: BrowserProbeLayoutShiftSummary & {
+      entries: BrowserProbeLayoutShiftRecord[]
     }
   }
 }

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -57,6 +57,12 @@ export function browserProbePerformanceSummary(checkpoints: BrowserProbeCheckpoi
     decodedBodySizeBytes: final?.resources.decodedBodySizeBytes ?? 0,
     longTasks: final?.longTasks.count ?? 0,
     longTaskDurationMs: final?.longTasks.totalDurationMs ?? 0,
+    layoutShifts: {
+      cls: final?.layoutShifts.cls ?? 0,
+      count: final?.layoutShifts.count ?? 0,
+      totalCount: final?.layoutShifts.totalCount ?? 0,
+      max: final?.layoutShifts.max ?? 0,
+    },
     domNodes: metricDigest(checkpoints.map((checkpoint) => checkpoint.metrics.performance.dom.nodes)),
     cdpMetrics: Object.fromEntries([...metricNames].sort().map((name) => [name, metricDigest(checkpoints.map((checkpoint) => checkpoint.metrics.performance.cdpMetrics[name]))])),
   }
@@ -130,6 +136,9 @@ export function browserProbeBenchMetrics(memoryArtifact?: BrowserProbeMemoryArti
     browser_transfer_size_bytes: performance?.resources.transferSizeBytes ?? 0,
     browser_long_task_count: performance?.longTasks.count ?? 0,
     browser_long_task_total_ms: performance?.longTasks.totalDurationMs ?? 0,
+    browser_cls: performance?.layoutShifts.cls ?? 0,
+    browser_layout_shift_count: performance?.layoutShifts.count ?? 0,
+    browser_layout_shift_max: performance?.layoutShifts.max ?? 0,
   }
 }
 
@@ -257,11 +266,18 @@ function combinedBrowserBenchMetrics(probes: BrowserProbeArtifact[]): Record<str
     browser_transfer_size_bytes: finalMetrics.browser_transfer_size_bytes ?? 0,
     browser_long_task_count: sumMetric(metricSets, "browser_long_task_count"),
     browser_long_task_total_ms: sumMetric(metricSets, "browser_long_task_total_ms"),
+    browser_cls: sumMetric(metricSets, "browser_cls"),
+    browser_layout_shift_count: sumMetric(metricSets, "browser_layout_shift_count"),
+    browser_layout_shift_max: maxMetric(metricSets, "browser_layout_shift_max"),
   }
 }
 
 function sumMetric(metricSets: Array<Record<string, number>>, name: string): number {
   return metricSets.reduce((total, metrics) => total + (metrics[name] ?? 0), 0)
+}
+
+function maxMetric(metricSets: Array<Record<string, number>>, name: string): number {
+  return Math.max(...metricSets.map((metrics) => metrics[name] ?? 0))
 }
 
 export async function serializeBrowserFinishedRequest(request: Request): Promise<BrowserProbeNetworkRecord> {

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -37,11 +37,13 @@ export const BROWSER_PROBE_STATE_INIT_SCRIPT = `
 
 export const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
 (() => {
-  const state = globalThis.__wpCodeboxBrowserProbe = globalThis.__wpCodeboxBrowserProbe || { checkpoints: [], longTasks: [] };
+  const state = globalThis.__wpCodeboxBrowserProbe = globalThis.__wpCodeboxBrowserProbe || { checkpoints: [], longTasks: [], layoutShifts: [], cls: 0 };
   state.checkpoints = state.checkpoints || [];
   state.longTasks = state.longTasks || [];
+  state.layoutShifts = state.layoutShifts || [];
+  state.cls = typeof state.cls === 'number' ? state.cls : 0;
   if (state.longTaskObserverInstalled || typeof PerformanceObserver === 'undefined') {
-    return;
+    return installLayoutShiftObserver();
   }
   try {
     const observer = new PerformanceObserver((list) => {
@@ -57,6 +59,94 @@ export const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
     state.longTaskObserverInstalled = true;
   } catch {
     state.longTaskObserverInstalled = false;
+  }
+  installLayoutShiftObserver();
+
+  function installLayoutShiftObserver() {
+    if (state.layoutShiftObserverInstalled || typeof PerformanceObserver === 'undefined') {
+      return;
+    }
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          const value = Number(entry.value || 0);
+          const hadRecentInput = entry.hadRecentInput === true;
+          if (!hadRecentInput && Number.isFinite(value) && value > 0) {
+            state.cls += value;
+          }
+          state.layoutShifts.push({
+            name: String(entry.name || 'layout-shift'),
+            startTime: entry.startTime,
+            duration: entry.duration,
+            value,
+            hadRecentInput,
+            sources: Array.from(entry.sources || []).slice(0, 5).map((source) => ({
+              selector: sourceSelector(source.node),
+              node: sourceNodeName(source.node),
+              previousRect: sourceRect(source.previousRect),
+              currentRect: sourceRect(source.currentRect),
+            })),
+          });
+          if (state.layoutShifts.length > 100) {
+            state.layoutShifts.splice(0, state.layoutShifts.length - 100);
+          }
+        }
+      });
+      observer.observe({ type: 'layout-shift', buffered: true });
+      state.layoutShiftObserverInstalled = true;
+    } catch {
+      state.layoutShiftObserverInstalled = false;
+    }
+  }
+
+  function sourceNodeName(node) {
+    return node && typeof node.nodeName === 'string' ? node.nodeName.toLowerCase() : null;
+  }
+
+  function sourceSelector(node) {
+    if (!node || node.nodeType !== 1) {
+      return null;
+    }
+    const parts = [];
+    let current = node;
+    while (current && current.nodeType === 1 && parts.length < 4) {
+      let part = current.nodeName.toLowerCase();
+      if (current.id) {
+        part += '#' + cssEscape(current.id);
+        parts.unshift(part);
+        break;
+      }
+      if (current.classList && current.classList.length > 0) {
+        part += '.' + Array.from(current.classList).slice(0, 2).map(cssEscape).join('.');
+      }
+      parts.unshift(part);
+      current = current.parentElement;
+    }
+    return parts.join(' > ') || null;
+  }
+
+  function cssEscape(value) {
+    if (globalThis.CSS && typeof globalThis.CSS.escape === 'function') {
+      return globalThis.CSS.escape(String(value));
+    }
+    return String(value).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+  }
+
+  function sourceRect(rect) {
+    return {
+      x: finiteNumberOrNull(rect && rect.x),
+      y: finiteNumberOrNull(rect && rect.y),
+      width: finiteNumberOrNull(rect && rect.width),
+      height: finiteNumberOrNull(rect && rect.height),
+      top: finiteNumberOrNull(rect && rect.top),
+      right: finiteNumberOrNull(rect && rect.right),
+      bottom: finiteNumberOrNull(rect && rect.bottom),
+      left: finiteNumberOrNull(rect && rect.left),
+    };
+  }
+
+  function finiteNumberOrNull(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
   }
 })();
 `
@@ -430,6 +520,40 @@ async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetr
       const longTasks = ((globalThis as typeof globalThis & { __wpCodeboxBrowserProbe?: { longTasks?: Array<{ duration?: number }> } }).__wpCodeboxBrowserProbe?.longTasks ?? [])
         .map((entry) => Number(entry.duration ?? 0))
         .filter((duration) => Number.isFinite(duration) && duration >= 0)
+      const layoutShiftState = (globalThis as typeof globalThis & {
+        __wpCodeboxBrowserProbe?: {
+          cls?: number
+          layoutShifts?: Array<{
+            name?: string
+            startTime?: number
+            duration?: number
+            value?: number
+            hadRecentInput?: boolean
+            sources?: Array<{
+              selector?: string | null
+              node?: string | null
+              previousRect?: Record<string, number | null>
+              currentRect?: Record<string, number | null>
+            }>
+          }>
+        }
+      }).__wpCodeboxBrowserProbe
+      const layoutShifts = (layoutShiftState?.layoutShifts ?? [])
+        .map((entry) => ({
+          name: typeof entry.name === "string" ? entry.name : "layout-shift",
+          startTime: finiteNumberOrZero(entry.startTime),
+          duration: finiteNumberOrZero(entry.duration),
+          value: finiteNumberOrZero(entry.value),
+          hadRecentInput: entry.hadRecentInput === true,
+          sources: Array.isArray(entry.sources) ? entry.sources.map((source) => ({
+            selector: typeof source.selector === "string" ? source.selector : null,
+            node: typeof source.node === "string" ? source.node : null,
+            previousRect: source.previousRect && typeof source.previousRect === "object" ? source.previousRect : {},
+            currentRect: source.currentRect && typeof source.currentRect === "object" ? source.currentRect : {},
+          })) : [],
+        }))
+        .filter((entry) => entry.value >= 0)
+      const layoutShiftsWithoutRecentInput = layoutShifts.filter((entry) => !entry.hadRecentInput)
 
       return {
         performanceMemory: {
@@ -453,10 +577,21 @@ async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetr
           totalDurationMs: longTasks.reduce((total, duration) => total + duration, 0),
           maxDurationMs: longTasks.reduce((max, duration) => Math.max(max, duration), 0),
         },
+        layoutShifts: {
+          cls: finiteNumberOrZero(layoutShiftState?.cls),
+          count: layoutShiftsWithoutRecentInput.length,
+          totalCount: layoutShifts.length,
+          max: layoutShiftsWithoutRecentInput.reduce((max, entry) => Math.max(max, entry.value), 0),
+          entries: layoutShifts,
+        },
       }
 
       function finiteNumberOrNull(value: unknown): number | null {
         return typeof value === "number" && Number.isFinite(value) ? value : null
+      }
+
+      function finiteNumberOrZero(value: unknown): number {
+        return typeof value === "number" && Number.isFinite(value) ? value : 0
       }
 
       function resourceTotal(resources: PerformanceResourceTiming[], field: "transferSize" | "encodedBodySize" | "decodedBodySize"): number {
@@ -485,6 +620,7 @@ async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetr
       },
       resources: pageMetrics.resources,
       longTasks: pageMetrics.longTasks,
+      layoutShifts: pageMetrics.layoutShifts,
     },
   }
 }
@@ -545,6 +681,7 @@ export function browserProbePerformanceArtifact(checkpoints: BrowserProbeCheckpo
     dom: { nodes: 0, documents: 0, iframes: 0 },
     resources: { count: 0, transferSizeBytes: 0, encodedBodySizeBytes: 0, decodedBodySizeBytes: 0 },
     longTasks: { count: 0, totalDurationMs: 0, maxDurationMs: 0 },
+    layoutShifts: { cls: 0, count: 0, totalCount: 0, max: 0, entries: [] },
   }
 
   return {

--- a/scripts/browser-probe-layout-shift-smoke.ts
+++ b/scripts/browser-probe-layout-shift-smoke.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "browser-probe-layout-shift-smoke")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(workspace, { recursive: true })
+
+const shifting = await runProbe("shifting", shiftingPage(), [
+  "assert=metric:browser_cls>0",
+  "assert=metric:browser_layout_shift_count>=1",
+])
+const shiftingSummary = await readSummary(shifting)
+const shiftingPerformance = await readPerformance(shifting)
+assert.ok(shiftingSummary.summary.metrics.browser_cls > 0, "shifting page should report non-zero CLS")
+assert.ok(shiftingSummary.summary.metrics.browser_layout_shift_count >= 1, "shifting page should report layout-shift count")
+assert.ok(shiftingSummary.summary.metrics.browser_layout_shift_max > 0, "shifting page should report max layout shift")
+assert.ok(shiftingPerformance.final.layoutShifts.entries.length >= 1, "performance artifact should include layout-shift entries")
+assert.equal(shiftingPerformance.final.layoutShifts.entries[0]?.hadRecentInput, false, "synthetic layout shift should not be user-input excluded")
+assert.ok(shiftingPerformance.final.layoutShifts.entries[0]?.sources.length >= 1, "layout-shift entries should include source details")
+
+const reserved = await runProbe("reserved", reservedPage(), [
+  "assert=metric:browser_cls<=0.001",
+  "assert=metric:browser_layout_shift_count=0",
+])
+const reservedSummary = await readSummary(reserved)
+assert.ok(reservedSummary.summary.metrics.browser_cls <= 0.001, "reserved page should report near-zero CLS")
+assert.equal(reservedSummary.summary.metrics.browser_layout_shift_count, 0, "reserved page should not report layout shifts")
+
+assert.equal(shiftingSummary.summary.scriptResult.text, reservedSummary.summary.scriptResult.text, "both pages should finish with the same visible inserted content")
+assert.equal(commandOutput(shifting).summary.metrics.browser_cls, shiftingSummary.summary.metrics.browser_cls, "command JSON should expose CLS metric")
+
+console.log("Browser probe layout-shift smoke passed")
+
+function shiftingPage(): string {
+  return pageShell(`
+    <main id="content" class="content">
+      <h1>Layout Shift Fixture</h1>
+      <p>This content moves when the banner is inserted above it.</p>
+    </main>
+    <script>
+      setTimeout(() => {
+        const banner = document.createElement('section');
+        banner.id = 'inserted-banner';
+        banner.className = 'banner';
+        banner.textContent = 'Synthetic ECE button ready';
+        document.body.insertBefore(banner, document.body.firstChild);
+      }, 50);
+    </script>
+  `)
+}
+
+function reservedPage(): string {
+  return pageShell(`
+    <section id="reserved-space" class="banner" aria-live="polite"></section>
+    <main id="content" class="content">
+      <h1>Layout Shift Fixture</h1>
+      <p>This content keeps its position while the banner fills reserved space.</p>
+    </main>
+    <script>
+      setTimeout(() => {
+        const banner = document.getElementById('reserved-space');
+        banner.id = 'inserted-banner';
+        banner.textContent = 'Synthetic ECE button ready';
+      }, 50);
+    </script>
+  `)
+}
+
+function pageShell(body: string): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>WP Codebox Layout Shift Fixture</title>
+    <style>
+      body { margin: 0; font-family: system-ui, sans-serif; }
+      .banner { box-sizing: border-box; display: flex; align-items: center; min-height: 160px; padding: 24px; background: #f6d365; font-size: 24px; font-weight: 700; }
+      .content { min-height: 900px; padding: 24px; background: #ffffff; font-size: 20px; }
+    </style>
+  </head>
+  <body>${body}</body>
+</html>`
+}
+
+async function runProbe(name: string, html: string, assertions: string[]): Promise<any> {
+  const recipePath = join(workspace, `${name}.recipe.json`)
+  const artifactsRoot = join(workspace, `${name}-artifacts`)
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    workflow: {
+      steps: [
+        {
+          command: "wordpress.browser-probe",
+          args: [
+            `url=${dataUrl(html)}`,
+            "wait-for=duration",
+            "duration=500ms",
+            "viewport=1280x720",
+            "capture=html,performance",
+            "script=return { text: document.getElementById('inserted-banner')?.textContent ?? null };",
+            ...assertions,
+          ],
+        },
+      ],
+    },
+    artifacts: {
+      directory: artifactsRoot,
+    },
+  }, null, 2)}\n`)
+
+  return runCli([
+    "packages/cli/dist/index.js",
+    "recipe-run",
+    "--recipe",
+    recipePath,
+    "--json",
+  ])
+}
+
+function dataUrl(html: string): string {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+}
+
+async function readSummary(output: any): Promise<any> {
+  const artifactDirectory = artifactDirectoryFromOutput(output)
+  const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
+  assert.equal(existsSync(summaryPath), true, "summary.json should be captured")
+  return JSON.parse(await readFile(summaryPath, "utf8"))
+}
+
+async function readPerformance(output: any): Promise<any> {
+  const artifactDirectory = artifactDirectoryFromOutput(output)
+  const performancePath = join(artifactDirectory, "files", "browser", "performance.json")
+  assert.equal(existsSync(performancePath), true, "performance.json should be captured")
+  return JSON.parse(await readFile(performancePath, "utf8"))
+}
+
+function artifactDirectoryFromOutput(output: any): string {
+  const artifactDirectory = output.artifacts?.directory ?? output.run?.artifactRefs?.find((ref: { kind?: string }) => ref.kind === "artifact-bundle")?.directory
+  assert.equal(typeof artifactDirectory, "string", "recipe-run should return artifact bundle directory")
+  return artifactDirectory
+}
+
+function commandOutput(output: any): any {
+  const execution = output.executions?.find((item: { command?: string }) => item.command === "wordpress.browser-probe")
+  assert.equal(typeof execution?.stdout, "string", "recipe-run should include browser-probe command stdout")
+  return JSON.parse(execution.stdout)
+}
+
+async function runCli(args: string[]): Promise<any> {
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const exitCode = await new Promise<number | null>((resolveExit) => child.once("exit", (code) => resolveExit(code)))
+  assert.equal(exitCode, 0, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  return JSON.parse(stdout)
+}

--- a/scripts/recipe-browser-bench-metrics-smoke.ts
+++ b/scripts/recipe-browser-bench-metrics-smoke.ts
@@ -82,10 +82,16 @@ const expectedBrowserMetrics = {
   browser_transfer_size_bytes: metrics.browser_transfer_size_bytes.samples.mean,
   browser_long_task_count: metrics.browser_long_task_count.samples.mean,
   browser_long_task_total_ms: metrics.browser_long_task_total_ms.samples.mean,
+  browser_cls: metrics.browser_cls.samples.mean,
+  browser_layout_shift_count: metrics.browser_layout_shift_count.samples.mean,
+  browser_layout_shift_max: metrics.browser_layout_shift_max.samples.mean,
 }
 assert.equal(metrics.browser_peak_used_js_heap_bytes.unit, "bytes")
 assert.equal(metrics.browser_long_task_total_ms.unit, "ms")
 assert.equal(metrics.browser_checkpoint_count.unit, "count")
+assert.equal(metrics.browser_cls.unit, "unitless")
+assert.equal(metrics.browser_layout_shift_count.unit, "count")
+assert.equal(metrics.browser_layout_shift_max.unit, "unitless")
 assert.ok(metrics.browser_checkpoint_count.samples.mean >= 3, "browser_checkpoint_count should include probe checkpoints")
 assert.ok(metrics.browser_dom_node_count.samples.mean > 0, "browser_dom_node_count should be numeric")
 assert.equal(metrics.browser_iframe_count.samples.mean, 1)
@@ -93,6 +99,9 @@ assert.ok(metrics.browser_resource_count.samples.mean >= 0, "browser_resource_co
 assert.ok(metrics.browser_transfer_size_bytes.samples.mean >= 0, "browser_transfer_size_bytes should be numeric")
 assert.ok(metrics.browser_long_task_count.samples.mean >= 0, "browser_long_task_count should be numeric")
 assert.ok(metrics.browser_long_task_total_ms.samples.mean >= 0, "browser_long_task_total_ms should be numeric")
+assert.ok(metrics.browser_cls.samples.mean >= 0, "browser_cls should be numeric")
+assert.ok(metrics.browser_layout_shift_count.samples.mean >= 0, "browser_layout_shift_count should be numeric")
+assert.ok(metrics.browser_layout_shift_max.samples.mean >= 0, "browser_layout_shift_max should be numeric")
 assert.ok(metrics.browser_peak_used_js_heap_bytes.samples.mean >= 0, "browser_peak_used_js_heap_bytes should be numeric")
 assert.ok(metrics.browser_final_used_js_heap_bytes.samples.mean >= 0, "browser_final_used_js_heap_bytes should be numeric")
 assert.ok(artifactRefs.some((ref: { path: string; source: string }) => ref.path === "files/browser/performance.json" && ref.source === "browser-artifact"), "browser performance artifact should be scenario-linked")


### PR DESCRIPTION
## Summary
- Add generic `layout-shift` PerformanceObserver capture to browser probes when performance metrics are enabled.
- Surface `browser_cls`, `browser_layout_shift_count`, and `browser_layout_shift_max` through probe summaries, artifacts, metric assertions, and bench metric promotion.
- Add deterministic data-URL smoke coverage for shifting vs reserved-space pages without plugin fixtures.

Closes #699.

## Verification
- `npm run build && npm run browser-probe-layout-shift-smoke && npm run browser-probe-assertions-smoke && npm run browser-probe-artifact-smoke && npm run recipe-browser-bench-metrics-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the browser-probe CLS capture path, metric plumbing, deterministic smoke coverage, and verification commands; Chris remains responsible for review and acceptance.