### PR TITLE
Add partial artifact discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,26 @@ present as regular files under the bundle directory. Symlinks, special files, an
 regular files with multiple hard links are rejected so downstream consumers do
 not trust artifact evidence that may alias protected content outside the bundle.
 
+### Partial Artifact Discovery
+
+When a run fails, is killed, or times out before its normal result envelope is
+available, callers can recover partial evidence with:
+
+```bash
+wp-codebox artifacts discover-partial --artifacts <dir> --session-id <id> --started-at <iso> --finished-at <iso> --json
+```
+
+The TypeScript API is `discoverPartialRunArtifacts({ artifactsRoot, sessionId,
+startedAt, finishedAt })` from `@automattic/wp-codebox-core`. Discovery scans
+artifact directories under `artifactsRoot`, filters by the run timestamp window,
+prefers directories whose path includes `sessionId`, and falls back to all
+timestamp-matching candidates when no session match exists.
+
+Stable contract paths returned by discovery are `manifest.json`,
+`files/changed-files.json`, and `files/runtime-reference-manifest.json`. The
+directory `mtime`, recursive byte size, missing-manifest status, and redacted
+runtime-reference payload are best-effort diagnostics for failure enrichment.
+
 ### `files/review.json`
 
 `files/review.json` is the frontend contract for chat and owner review flows. It is derived from canonical artifacts and should be safe for a generic frontend to render without parsing unified diffs.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "artifact-redaction-smoke": "tsx scripts/artifact-redaction-smoke.ts",
     "artifact-patch-git-apply-smoke": "tsx scripts/artifact-patch-git-apply-smoke.ts",
     "artifact-reference-normalization-smoke": "tsx scripts/artifact-reference-normalization-smoke.ts",
+    "partial-artifact-discovery-smoke": "tsx scripts/partial-artifact-discovery-smoke.ts",
     "mounted-workspace-diff-smoke": "tsx scripts/mounted-workspace-diff-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",

--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -1,5 +1,5 @@
 import { routeCliCommand } from "./command-router.js"
-import { runArtifactsApplyPreflightCommand, runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsTransferProbesCommand, runArtifactsTransferVerifyCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
+import { runArtifactsApplyPreflightCommand, runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsDiscoverPartialCommand, runArtifactsTransferProbesCommand, runArtifactsTransferVerifyCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
 import { runAgentTaskRunCommand } from "./commands/agent-task-run.js"
 import { runArtifactsBenchCompareCommand, runArtifactsBenchResultsCommand, runBenchCompareCommand, runBenchMatrixCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
 import { runCommandsCommand, runRecipeSchemaCommand } from "./commands/discovery.js"
@@ -27,6 +27,7 @@ export async function runCli(args: string[]): Promise<number> {
     artifactsTransferVerify: runArtifactsTransferVerifyCommand,
     artifactsTransferProbes: runArtifactsTransferProbesCommand,
     artifactsBenchmark: runArtifactsBenchmarkCommand,
+    artifactsDiscoverPartial: runArtifactsDiscoverPartialCommand,
     artifactsBenchResults: runArtifactsBenchResultsCommand,
     benchMatrix: runBenchMatrixCommand,
     artifactsBenchCompare: runArtifactsBenchCompareCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -17,6 +17,7 @@ interface CliCommandRouter {
   artifactsTransferVerify: CliCommandHandler
   artifactsTransferProbes: CliCommandHandler
   artifactsBenchmark: CliCommandHandler
+  artifactsDiscoverPartial: CliCommandHandler
   artifactsBenchResults: CliCommandHandler
   benchMatrix: CliCommandHandler
   artifactsBenchCompare: CliCommandHandler
@@ -96,6 +97,9 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
       }
       if (subcommand === "benchmark") {
         return router.artifactsBenchmark(args)
+      }
+      if (subcommand === "discover-partial") {
+        return router.artifactsDiscoverPartial(args)
       }
       if (subcommand === "bench-results") {
         return router.artifactsBenchResults(args)

--- a/packages/cli/src/commands/artifacts.ts
+++ b/packages/cli/src/commands/artifacts.ts
@@ -1,6 +1,6 @@
 import { copyFile, mkdir, readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { buildTransferProbeDiagnostics, preflightArtifactBundleApply, verifyArtifactBundle, verifyTransferProofBundle, type ArtifactBundleApplyPreflightResult, type ArtifactBundleVerificationResult, type TransferProbeDiagnosticsResult, type TransferProofBundleVerificationResult } from "@automattic/wp-codebox-core"
+import { buildTransferProbeDiagnostics, discoverPartialRunArtifacts, preflightArtifactBundleApply, verifyArtifactBundle, verifyTransferProofBundle, type ArtifactBundleApplyPreflightResult, type ArtifactBundleVerificationResult, type PartialArtifactDiscoveryResult, type TransferProbeDiagnosticsResult, type TransferProofBundleVerificationResult } from "@automattic/wp-codebox-core"
 import { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "@automattic/wp-codebox-playground"
 import { printArtifactVerifyHumanOutput } from "../output.js"
 
@@ -16,6 +16,14 @@ interface ArtifactApplyPreflightOptions extends ArtifactVerifyOptions {
 interface BenchmarkArtifactsOptions extends ArtifactVerifyOptions {
   scenarioId?: string
   copyTo?: string
+}
+
+interface ArtifactDiscoverPartialOptions {
+  artifactsRoot: string
+  sessionId?: string
+  startedAt?: string
+  finishedAt?: string
+  json: boolean
 }
 
 interface BenchmarkArtifactRef {
@@ -115,6 +123,18 @@ export async function runArtifactsBenchmarkCommand(args: string[]): Promise<numb
   return 0
 }
 
+export async function runArtifactsDiscoverPartialCommand(args: string[]): Promise<number> {
+  const options = parseArtifactDiscoverPartialOptions(args)
+  const output = await discoverPartialArtifacts(options)
+  if (!options.json) {
+    printArtifactDiscoverPartialHumanOutput(output)
+    return 0
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return 0
+}
+
 async function verifyArtifacts(options: ArtifactVerifyOptions): Promise<ArtifactBundleVerificationResult> {
   return verifyArtifactBundle(resolve(options.bundleDirectory))
 }
@@ -152,6 +172,56 @@ async function benchmarkArtifacts(options: BenchmarkArtifactsOptions): Promise<B
   }
 
   return output
+}
+
+async function discoverPartialArtifacts(options: ArtifactDiscoverPartialOptions): Promise<PartialArtifactDiscoveryResult> {
+  return discoverPartialRunArtifacts({
+    artifactsRoot: resolve(options.artifactsRoot),
+    sessionId: options.sessionId,
+    startedAt: options.startedAt,
+    finishedAt: options.finishedAt,
+  })
+}
+
+function parseArtifactDiscoverPartialOptions(args: string[]): ArtifactDiscoverPartialOptions {
+  const options: Partial<ArtifactDiscoverPartialOptions> = { json: false }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--artifacts":
+      case "--artifacts-root":
+        options.artifactsRoot = value
+        break
+      case "--session-id":
+        options.sessionId = value
+        break
+      case "--started-at":
+        options.startedAt = value
+        break
+      case "--finished-at":
+        options.finishedAt = value
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (!options.artifactsRoot) {
+    throw new Error("Missing required option: --artifacts")
+  }
+
+  return options as ArtifactDiscoverPartialOptions
 }
 
 function parseArtifactBrowserMetricsOptions(args: string[]): ArtifactVerifyOptions {
@@ -310,6 +380,19 @@ function printBenchmarkArtifactsHumanOutput(output: BenchmarkArtifactsOutput): v
     for (const copy of output.copied) {
       console.log(`  ${copy.from} -> ${copy.to}`)
     }
+  }
+}
+
+function printArtifactDiscoverPartialHumanOutput(output: PartialArtifactDiscoveryResult): void {
+  console.log("WP Codebox partial artifact discovery")
+  console.log(`Artifacts root: ${output.artifactsRoot}`)
+  console.log(`Selected by: ${output.selectedBy}`)
+  console.log(`Artifacts: ${output.artifacts.length}/${output.candidateCount}`)
+  for (const artifact of output.artifacts) {
+    console.log(`  ${artifact.directory}`)
+    console.log(`    manifest: ${artifact.hasManifest ? "yes" : "no"}`)
+    console.log(`    changed files: ${artifact.hasChangedFiles ? artifact.changedFiles.path : "no"}`)
+    console.log(`    runtime reference manifest: ${artifact.hasRuntimeReferenceManifest ? artifact.runtimeReferenceManifest.path : "no"}`)
   }
 }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -260,6 +260,7 @@ export function printHelp(): void {
   wp-codebox artifacts browser-metrics --bundle <dir> [--json]
   wp-codebox artifacts transfer-verify --bundle <dir> [--json]
   wp-codebox artifacts transfer-probes --bundle <dir> [--json]
+  wp-codebox artifacts discover-partial --artifacts <dir> [--session-id <id>] [--started-at <iso>] [--finished-at <iso>] [--json]
   wp-codebox artifacts benchmark --bundle <dir> [--scenario-id <id>] [--extract-to <dir>] [--json]
   wp-codebox artifacts bench-results --bundle <dir> [--json]
   wp-codebox artifacts bench-compare --baseline-bundle <dir> --candidate-bundle <dir> [--json]
@@ -302,6 +303,9 @@ Options:
   --candidate-index <n>
                        Benchmark envelope index to compare when a source has multiple results.
   --artifacts <dir>   Artifact root directory. Also accepted by artifacts verify.
+  --session-id <id>   Prefer partial artifact directories matching this sandbox/session id.
+  --started-at <iso>  Lower timestamp bound for partial artifact discovery.
+  --finished-at <iso> Upper timestamp bound for partial artifact discovery.
   --run-registry <dir>
                        Durable run registry directory for recipe-run.
   --registry <dir>    Durable run registry directory for runs lookup commands.

--- a/packages/runtime-core/src/artifact-references.ts
+++ b/packages/runtime-core/src/artifact-references.ts
@@ -6,6 +6,7 @@ export const RUNTIME_EPISODE_TRACE_ARTIFACT_PATH = "files/runtime-episode-trace.
 export const RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH = "files/runtime-episode.jsonl" as const
 export const RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH = "files/runtime-reference-manifest.json" as const
 export const RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH = "files/runtime-replay-index.json" as const
+export const CHANGED_FILES_ARTIFACT_PATH = "files/changed-files.json" as const
 export const ARTIFACT_MANIFEST_PATH = "manifest.json" as const
 
 export interface ArtifactReferenceDigestInput {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -24,6 +24,7 @@ export * from "./host-tool-registry.js"
 export * from "./run-registry.js"
 export * from "./fanout-contracts.js"
 export * from "./fanout-aggregation.js"
+export * from "./partial-artifact-discovery.js"
 
 export type ArtifactReviewProgressEventType =
   | "boot"

--- a/packages/runtime-core/src/partial-artifact-discovery.ts
+++ b/packages/runtime-core/src/partial-artifact-discovery.ts
@@ -1,0 +1,222 @@
+import { readdir, readFile, stat } from "node:fs/promises"
+import { join } from "node:path"
+
+import type { ArtifactManifest, ArtifactManifestFile } from "./artifact-manifest.js"
+import { ARTIFACT_MANIFEST_PATH, CHANGED_FILES_ARTIFACT_PATH, RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH } from "./artifact-references.js"
+
+export interface PartialArtifactDiscoveryOptions {
+  artifactsRoot: string
+  sessionId?: string
+  startedAt?: string
+  finishedAt?: string
+  timestampWindowMs?: number
+}
+
+export interface PartialArtifactFileRef {
+  path: string
+  relativePath: string
+  available: boolean
+  manifestFile?: ArtifactManifestFile
+  payload?: unknown
+  error?: string
+}
+
+export interface PartialArtifactBundleMetadata {
+  id?: string
+  createdAt?: string
+  contentDigest?: ArtifactManifest["contentDigest"]
+  runtime?: ArtifactManifest["runtime"]
+  fileCount: number
+  contractFiles: ArtifactManifestFile[]
+}
+
+export interface PartialRunArtifactEvidence {
+  directory: string
+  bytes: number | null
+  mtime: string
+  hasManifest: boolean
+  hasChangedFiles: boolean
+  hasRuntimeReferenceManifest: boolean
+  manifest: PartialArtifactFileRef
+  changedFiles: PartialArtifactFileRef
+  runtimeReferenceManifest: PartialArtifactFileRef
+  bundle?: PartialArtifactBundleMetadata
+}
+
+export interface PartialArtifactDiscoveryResult {
+  schema: "wp-codebox/partial-artifact-discovery/v1"
+  artifactsRoot: string
+  sessionId?: string
+  startedAt?: string
+  finishedAt?: string
+  selectedBy: "session-id" | "time-window" | "all-candidates"
+  contractPaths: {
+    manifest: typeof ARTIFACT_MANIFEST_PATH
+    changedFiles: typeof CHANGED_FILES_ARTIFACT_PATH
+    runtimeReferenceManifest: typeof RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH
+  }
+  candidateCount: number
+  artifacts: PartialRunArtifactEvidence[]
+}
+
+const DEFAULT_TIMESTAMP_WINDOW_MS = 1000
+
+export async function discoverPartialRunArtifacts(options: PartialArtifactDiscoveryOptions): Promise<PartialArtifactDiscoveryResult> {
+  const timestampWindowMs = options.timestampWindowMs ?? DEFAULT_TIMESTAMP_WINDOW_MS
+  const startedMs = parseTimestampMs(options.startedAt)
+  const finishedMs = parseTimestampMs(options.finishedAt)
+  const earliestMs = startedMs === undefined ? undefined : startedMs - timestampWindowMs
+  const latestMs = finishedMs === undefined ? undefined : finishedMs + timestampWindowMs
+  const candidates = await artifactCandidateDirectories(options.artifactsRoot)
+  const artifacts = (await Promise.all(candidates.map((directory) => artifactEvidence(directory, earliestMs, latestMs))))
+    .filter((artifact): artifact is PartialRunArtifactEvidence => artifact !== undefined)
+    .sort((left, right) => left.directory.localeCompare(right.directory))
+  const sessionArtifacts = options.sessionId
+    ? artifacts.filter((artifact) => artifact.directory.includes(options.sessionId ?? ""))
+    : []
+  const selected = sessionArtifacts.length > 0 ? sessionArtifacts : artifacts
+
+  return {
+    schema: "wp-codebox/partial-artifact-discovery/v1",
+    artifactsRoot: options.artifactsRoot,
+    ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+    ...(options.startedAt ? { startedAt: options.startedAt } : {}),
+    ...(options.finishedAt ? { finishedAt: options.finishedAt } : {}),
+    selectedBy: sessionArtifacts.length > 0 ? "session-id" : (earliestMs !== undefined || latestMs !== undefined ? "time-window" : "all-candidates"),
+    contractPaths: {
+      manifest: ARTIFACT_MANIFEST_PATH,
+      changedFiles: CHANGED_FILES_ARTIFACT_PATH,
+      runtimeReferenceManifest: RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH,
+    },
+    candidateCount: artifacts.length,
+    artifacts: selected,
+  }
+}
+
+async function artifactCandidateDirectories(artifactsRoot: string): Promise<string[]> {
+  const rootStat = await stat(artifactsRoot).catch(() => undefined)
+  if (!rootStat?.isDirectory()) {
+    return []
+  }
+
+  const entries = await readdir(artifactsRoot, { withFileTypes: true }).catch(() => [])
+  const directories = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(artifactsRoot, entry.name))
+  const rootManifest = await stat(join(artifactsRoot, ARTIFACT_MANIFEST_PATH)).catch(() => undefined)
+  if (rootManifest?.isFile()) {
+    directories.push(artifactsRoot)
+  }
+
+  return directories
+}
+
+async function artifactEvidence(directory: string, earliestMs: number | undefined, latestMs: number | undefined): Promise<PartialRunArtifactEvidence | undefined> {
+  const directoryStat = await stat(directory).catch(() => undefined)
+  if (!directoryStat?.isDirectory()) {
+    return undefined
+  }
+  if (earliestMs !== undefined && directoryStat.mtimeMs < earliestMs) {
+    return undefined
+  }
+  if (latestMs !== undefined && directoryStat.mtimeMs > latestMs) {
+    return undefined
+  }
+
+  const manifest = await fileRef(directory, ARTIFACT_MANIFEST_PATH)
+  const changedFiles = await fileRef(directory, CHANGED_FILES_ARTIFACT_PATH)
+  const runtimeReferenceManifest = await fileRef(directory, RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH, { parsePayload: true })
+  const parsedManifest = manifest.available ? await readJsonFile<ArtifactManifest>(manifest.path).catch(() => undefined) : undefined
+
+  return {
+    directory,
+    bytes: await directorySizeBytes(directory),
+    mtime: directoryStat.mtime.toISOString(),
+    hasManifest: manifest.available,
+    hasChangedFiles: changedFiles.available,
+    hasRuntimeReferenceManifest: runtimeReferenceManifest.available,
+    manifest,
+    changedFiles,
+    runtimeReferenceManifest,
+    ...(parsedManifest ? { bundle: bundleMetadata(parsedManifest) } : {}),
+  }
+}
+
+async function fileRef(directory: string, relativePath: string, options: { parsePayload?: boolean } = {}): Promise<PartialArtifactFileRef> {
+  const absolutePath = join(directory, relativePath)
+  const fileStat = await stat(absolutePath).catch(() => undefined)
+  const ref: PartialArtifactFileRef = {
+    path: absolutePath,
+    relativePath,
+    available: Boolean(fileStat?.isFile()),
+  }
+  if (!ref.available || !options.parsePayload) {
+    return ref
+  }
+
+  try {
+    ref.payload = redact(await readJsonFile(absolutePath))
+  } catch (error) {
+    ref.error = error instanceof Error ? error.message : String(error)
+  }
+  return ref
+}
+
+function bundleMetadata(manifest: ArtifactManifest): PartialArtifactBundleMetadata {
+  const files = Array.isArray(manifest.files) ? manifest.files : []
+  const contractPathSet = new Set<string>([ARTIFACT_MANIFEST_PATH, CHANGED_FILES_ARTIFACT_PATH, RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH])
+  return {
+    id: manifest.id,
+    createdAt: manifest.createdAt,
+    contentDigest: manifest.contentDigest,
+    runtime: manifest.runtime,
+    fileCount: files.length,
+    contractFiles: files.filter((file) => contractPathSet.has(file.path)),
+  }
+}
+
+async function directorySizeBytes(path: string): Promise<number | null> {
+  try {
+    const pathStat = await stat(path)
+    if (!pathStat.isDirectory()) {
+      return pathStat.size
+    }
+    const entries = await readdir(path)
+    const sizes = await Promise.all(entries.map((entry) => directorySizeBytes(join(path, entry))))
+    return sizes.reduce<number>((total, size) => total + (size ?? 0), 0)
+  } catch {
+    return null
+  }
+}
+
+async function readJsonFile<T = unknown>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T
+}
+
+function parseTimestampMs(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined
+  }
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function redact(value: unknown, key = ""): unknown {
+  if (isRedactedKey(key)) {
+    return "[redacted]"
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redact(entry))
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey)]))
+  }
+  if (typeof value === "string") {
+    return value.replace(/(bearer|token|api[_-]?key|password|cookie|authorization|private[_-]?key)(\s*[:=]\s*)[^\s,;]+/gi, "$1$2[redacted]")
+  }
+  return value
+}
+
+function isRedactedKey(key: string): boolean {
+  return /secret|token|credential|password|api[_-]?key|authorization|cookie|private[_-]?key/i.test(key)
+}

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -48,6 +48,7 @@ const expectedCommandIds = [
   "wordpress.editor-actions",
   "wp-codebox.agent-runtime-probe",
   "wp-codebox.agent-sandbox-run",
+  "wp-codebox.agent-fanout",
 ]
 
 // Full command catalog (every registered command, including policy-only capabilities
@@ -72,6 +73,7 @@ const expectedCatalogCommandIds = [
   "wordpress.browser-actions.evaluate",
   "wp-codebox.agent-runtime-probe",
   "wp-codebox.agent-sandbox-run",
+  "wp-codebox.agent-fanout",
 ]
 
 const representativeRecipes = [

--- a/scripts/partial-artifact-discovery-smoke.ts
+++ b/scripts/partial-artifact-discovery-smoke.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, rm, writeFile, utimes } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+import { discoverPartialRunArtifacts } from "@automattic/wp-codebox-core"
+
+const execFileAsync = promisify(execFile)
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-partial-artifacts-"))
+const startedAt = "2026-06-06T12:00:00.000Z"
+const finishedAt = "2026-06-06T12:00:10.000Z"
+
+try {
+  const successDirectory = await writeArtifactBundle("successful-session", {
+    manifest: true,
+    changedFiles: true,
+    runtimeReferenceManifest: true,
+    mtime: "2026-06-06T12:00:05.000Z",
+  })
+  const timeoutDirectory = await writeArtifactBundle("sandbox-705-timeout-partial", {
+    manifest: false,
+    changedFiles: true,
+    runtimeReferenceManifest: true,
+    mtime: "2026-06-06T12:00:06.000Z",
+  })
+  await writeArtifactBundle("outside-window", {
+    manifest: true,
+    changedFiles: true,
+    runtimeReferenceManifest: false,
+    mtime: "2026-06-06T12:01:00.000Z",
+  })
+
+  const timestampDiscovery = await discoverPartialRunArtifacts({ artifactsRoot: root, startedAt, finishedAt })
+  assert.equal(timestampDiscovery.schema, "wp-codebox/partial-artifact-discovery/v1")
+  assert.equal(timestampDiscovery.selectedBy, "time-window")
+  assert.equal(timestampDiscovery.artifacts.length, 2)
+  assert.ok(timestampDiscovery.artifacts.some((artifact) => artifact.directory === successDirectory && artifact.hasManifest))
+  const timeoutArtifact = timestampDiscovery.artifacts.find((artifact) => artifact.directory === timeoutDirectory)
+  assert.ok(timeoutArtifact, "timeout partial artifact should be discovered")
+  assert.equal(timeoutArtifact.hasManifest, false)
+  assert.equal(timeoutArtifact.hasChangedFiles, true)
+  assert.equal(timeoutArtifact.hasRuntimeReferenceManifest, true)
+  assert.equal((timeoutArtifact.runtimeReferenceManifest.payload as { cookie?: string }).cookie, "[redacted]")
+
+  const sessionDiscovery = await discoverPartialRunArtifacts({ artifactsRoot: root, sessionId: "sandbox-705", startedAt, finishedAt })
+  assert.equal(sessionDiscovery.selectedBy, "session-id")
+  assert.deepEqual(sessionDiscovery.artifacts.map((artifact) => artifact.directory), [timeoutDirectory])
+
+  const fallbackDiscovery = await discoverPartialRunArtifacts({ artifactsRoot: root, sessionId: "missing-session", startedAt, finishedAt })
+  assert.equal(fallbackDiscovery.selectedBy, "time-window")
+  assert.equal(fallbackDiscovery.artifacts.length, 2)
+
+  const { stdout } = await execFileAsync(process.execPath, [
+    "packages/cli/dist/index.js",
+    "artifacts",
+    "discover-partial",
+    "--artifacts",
+    root,
+    "--session-id",
+    "sandbox-705",
+    "--started-at",
+    startedAt,
+    "--finished-at",
+    finishedAt,
+    "--json",
+  ], { cwd: resolve(import.meta.dirname, "..") })
+  const cliOutput = JSON.parse(stdout)
+  assert.equal(cliOutput.schema, "wp-codebox/partial-artifact-discovery/v1")
+  assert.equal(cliOutput.selectedBy, "session-id")
+  assert.equal(cliOutput.artifacts.length, 1)
+  assert.equal(cliOutput.artifacts[0].hasChangedFiles, true)
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+async function writeArtifactBundle(name: string, options: { manifest: boolean; changedFiles: boolean; runtimeReferenceManifest: boolean; mtime: string }): Promise<string> {
+  const directory = join(root, name)
+  const files = join(directory, "files")
+  await mkdir(files, { recursive: true })
+  const manifestFiles = []
+  if (options.changedFiles) {
+    const changedFilesPath = join(files, "changed-files.json")
+    await writeFile(changedFilesPath, `${JSON.stringify({ schema: "wp-codebox/changed-files/v1", files: [] }, null, 2)}\n`)
+    manifestFiles.push({ path: "files/changed-files.json", kind: "changed-files", contentType: "application/json", sha256: { algorithm: "sha256", value: "0".repeat(64) } })
+  }
+  if (options.runtimeReferenceManifest) {
+    const runtimeManifestPath = join(files, "runtime-reference-manifest.json")
+    await writeFile(runtimeManifestPath, `${JSON.stringify({ schema: "wp-codebox/runtime-reference-manifest/v1", cookie: "wordpress_logged_in=secret" }, null, 2)}\n`)
+    manifestFiles.push({ path: "files/runtime-reference-manifest.json", kind: "runtime-reference-manifest", contentType: "application/json", sha256: { algorithm: "sha256", value: "1".repeat(64) } })
+  }
+  if (options.manifest) {
+    await writeFile(join(directory, "manifest.json"), `${JSON.stringify({
+      id: `artifact-${name}`,
+      contentDigest: { algorithm: "sha256", inputs: [], value: "2".repeat(64) },
+      createdAt: options.mtime,
+      runtime: { backend: "wordpress-playground", version: "0.0.0" },
+      files: [
+        { path: "manifest.json", kind: "manifest", contentType: "application/json", sha256: { algorithm: "sha256", value: "3".repeat(64) } },
+        ...manifestFiles,
+      ],
+    }, null, 2)}\n`)
+  }
+  const mtime = new Date(options.mtime)
+  await utimes(directory, mtime, mtime)
+  return directory
+}


### PR DESCRIPTION
## Summary
- Adds `discoverPartialRunArtifacts()` in `@automattic/wp-codebox-core` so failed, killed, or timed-out runs can recover partial artifact evidence from Codebox-owned artifact layout contracts.
- Exposes `wp-codebox artifacts discover-partial --artifacts <dir> --session-id <id> --started-at <iso> --finished-at <iso> --json` for downstream orchestrators.
- Documents stable contract paths and adds a targeted smoke for successful, timeout partial, missing-manifest, multi-session, and timestamp-filtered discovery.

Closes #705.

## Verification
- `npm run build`
- `npm run partial-artifact-discovery-smoke`
- `npm run discovery-command-smoke`
- `npm run artifact-bundle-verifier-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the Codebox-owned partial artifact discovery helper/CLI, targeted smoke coverage, documentation, and verification command execution; Chris remains responsible for review and merge.