### PR TITLE
Add host delegation seam

### DIFF
--- a/docs/agent-fanout-contract.md
+++ b/docs/agent-fanout-contract.md
@@ -6,6 +6,12 @@ provide the worker list and review the resulting parent artifact envelope; WP
 Codebox owns bounded execution, lifecycle events, and parent/child artifact
 layout.
 
+Host delegation is a separate generic runtime primitive for an explicit phase
+that asks the product host to run work outside the browser Playground. WP
+Codebox owns only the request/result/event envelopes and provider seam; product
+hosts own placement policy, scoring, provider selection, review, and any
+server-side implementation behind the seam.
+
 ## Schemas
 
 - `wp-codebox/agent-fanout-request/v1`: caller request accepted by
@@ -20,6 +26,12 @@ layout.
   persisted at `fanout/result.json`.
 - `wp-codebox/agent-fanout-artifacts/v1`: artifact locator block inside the
   parent result.
+- `wp-codebox/host-delegation-request/v1`: explicit product-neutral request for
+  a host-side provider.
+- `wp-codebox/host-delegation-event/v1`: lifecycle events included in the
+  delegation result.
+- `wp-codebox/host-delegation-result/v1`: structured provider result or
+  unavailable evidence.
 
 Aggregation contracts that are usable by products or future aggregator agents
 live in runtime-core as `wp-codebox/agent-fanout-aggregation-input/v1` and
@@ -106,3 +118,62 @@ The parent result includes `session.children`, aggregate counts, the requested
 concurrency, worker run summaries, failure summaries, and artifact references.
 Parent products remain responsible for review, apply, PR creation, deployment,
 or any other mutation outside the sandbox.
+
+## Host Delegation
+
+Host delegation lets a browser task phase request server-side execution without
+embedding product placement policy in WP Codebox. A phase carries a request in
+`request` or `input`:
+
+```json
+{
+  "name": "server-workspace-offload",
+  "kind": "host-delegation",
+  "request": {
+    "schema": "wp-codebox/host-delegation-request/v1",
+    "request_id": "phase-123",
+    "goal": "Run the workspace phase on a host provider.",
+    "execution": {
+      "capability": "workspace-task"
+    },
+    "orchestrator": {
+      "request_id": "project-123"
+    }
+  }
+}
+```
+
+WP Codebox passes the canonical request to the WordPress filter
+`wp_codebox_host_delegation_request`. Product hosts may satisfy it with any
+server-side implementation, including an Agents API safe workspace primitive, a
+queue-backed worker, or another host runtime. WP Codebox does not call Agents
+API, Data Machine, Data Machine Code, or product-specific APIs from this seam.
+
+If no provider handles the request, WP Codebox returns a structured result:
+
+```json
+{
+  "success": false,
+  "schema": "wp-codebox/host-delegation-result/v1",
+  "execution": "host-delegation",
+  "status": "unavailable",
+  "error": {
+    "code": "wp_codebox_host_delegation_unavailable",
+    "message": "No host delegation provider handled the request."
+  },
+  "events": [
+    { "schema": "wp-codebox/host-delegation-event/v1", "event": "host-delegation.requested" },
+    { "schema": "wp-codebox/host-delegation-event/v1", "event": "host-delegation.unavailable" }
+  ]
+}
+```
+
+Provider results may report `accepted`, `completed`, or `failed`. Product UIs
+should render delegation events as progress only; durable decisions should use
+the final `wp-codebox/host-delegation-result/v1` envelope plus product-owned
+evidence and artifacts.
+
+Product hosts such as Studio Web own placement scoring and policy. They may
+decide when to emit a host-delegation phase and how to interpret provider
+evidence, but WP Codebox remains product-neutral and only standardizes the
+delegation envelope.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
     "agent-task-run-result-normalizer-smoke": "tsx scripts/agent-task-run-result-normalizer-smoke.ts",
     "fanout-contract-smoke": "tsx scripts/fanout-contract-smoke.ts",
+    "host-delegation-contract-smoke": "tsx scripts/host-delegation-contract-smoke.ts",
     "fanout-aggregation-contract-smoke": "tsx scripts/fanout-aggregation-contract-smoke.ts",
     "agent-fanout-execution-smoke": "tsx scripts/agent-fanout-execution-smoke.ts",
     "run-registry-smoke": "tsx scripts/run-registry-smoke.ts",

--- a/packages/runtime-core/src/fanout-contracts.ts
+++ b/packages/runtime-core/src/fanout-contracts.ts
@@ -3,6 +3,9 @@ export const FANOUT_PLAN_SCHEMA = "wp-codebox/agent-fanout-plan/v1" as const
 export const FANOUT_WORKER_SCHEMA = "wp-codebox/agent-fanout-worker/v1" as const
 export const FANOUT_RESULT_SCHEMA = "wp-codebox/agent-fanout-result/v1" as const
 export const FANOUT_EVENT_SCHEMA = "wp-codebox/agent-fanout-event/v1" as const
+export const HOST_DELEGATION_REQUEST_SCHEMA = "wp-codebox/host-delegation-request/v1" as const
+export const HOST_DELEGATION_RESULT_SCHEMA = "wp-codebox/host-delegation-result/v1" as const
+export const HOST_DELEGATION_EVENT_SCHEMA = "wp-codebox/host-delegation-event/v1" as const
 
 export const FANOUT_EVENT_TYPES = [
   "fanout.started",
@@ -15,8 +18,18 @@ export const FANOUT_EVENT_TYPES = [
   "fanout.failed",
 ] as const
 
+export const HOST_DELEGATION_EVENT_TYPES = [
+  "host-delegation.requested",
+  "host-delegation.unavailable",
+  "host-delegation.accepted",
+  "host-delegation.completed",
+  "host-delegation.failed",
+] as const
+
 export type FanoutEventType = (typeof FANOUT_EVENT_TYPES)[number]
+export type HostDelegationEventType = (typeof HOST_DELEGATION_EVENT_TYPES)[number]
 export type FanoutExecutionStrategy = "bounded-concurrent-isolated-sandboxes"
+export type HostDelegationStatus = "unavailable" | "accepted" | "completed" | "failed"
 
 export interface FanoutWorkerContract {
   schema?: typeof FANOUT_WORKER_SCHEMA
@@ -66,6 +79,49 @@ export interface FanoutLifecycleEvent {
   cancelled?: number
 }
 
+export interface HostDelegationRequestContract {
+  schema?: typeof HOST_DELEGATION_REQUEST_SCHEMA
+  request_id?: string
+  goal?: string
+  task?: string
+  target?: Record<string, unknown>
+  context?: Record<string, unknown>
+  expected_artifacts?: unknown[]
+  execution?: Record<string, unknown>
+  orchestrator?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface HostDelegationLifecycleEvent {
+  schema: typeof HOST_DELEGATION_EVENT_SCHEMA
+  event: HostDelegationEventType
+  time: string
+  request_id: string
+  status?: HostDelegationStatus
+  provider?: string
+}
+
+export interface HostDelegationResultContract {
+  success: boolean
+  schema: typeof HOST_DELEGATION_RESULT_SCHEMA
+  execution: "host-delegation"
+  status: HostDelegationStatus
+  request_id: string
+  request: HostDelegationRequestContract
+  provider?: string
+  result?: Record<string, unknown> | null
+  error?: { code: string; message: string; data?: unknown } | null
+  events: HostDelegationLifecycleEvent[]
+  artifacts?: Record<string, unknown>
+  timings?: Record<string, unknown>
+  orchestrator?: Record<string, unknown>
+}
+
 export function isFanoutEventType(event: string): event is FanoutEventType {
   return FANOUT_EVENT_TYPES.includes(event as FanoutEventType)
+}
+
+export function isHostDelegationEventType(event: string): event is HostDelegationEventType {
+  return HOST_DELEGATION_EVENT_TYPES.includes(event as HostDelegationEventType)
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -484,6 +484,55 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/request-host-delegation',
+				array(
+					'label'               => 'Request Host Delegation',
+					'description'         => 'Request an explicit product-neutral host-side delegation. Product hosts may satisfy the request through the wp_codebox_host_delegation_request filter; WP Codebox returns structured unavailable evidence when no provider handles it.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'schema'             => array( 'type' => 'string', 'const' => 'wp-codebox/host-delegation-request/v1' ),
+							'request_id'         => array( 'type' => 'string' ),
+							'goal'               => $task_input_schema['properties']['goal'],
+							'task'               => array( 'type' => 'string' ),
+							'target'             => $task_input_schema['properties']['target'],
+							'context'            => $task_input_schema['properties']['context'],
+							'expected_artifacts' => $task_input_schema['properties']['expected_artifacts'],
+							'execution'          => array(
+								'type'        => 'object',
+								'description' => 'Product-neutral host execution preferences or requirements. WP Codebox preserves this for the host provider without interpreting product policy.',
+							),
+							'orchestrator'       => $session_input['orchestrator'],
+							'sandbox_session_id' => $session_input['sandbox_session_id'],
+							'metadata'           => array( 'type' => 'object' ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'success'    => array( 'type' => 'boolean' ),
+							'schema'     => array( 'type' => 'string', 'const' => 'wp-codebox/host-delegation-result/v1' ),
+							'execution'  => array( 'type' => 'string', 'const' => 'host-delegation' ),
+							'status'     => array( 'type' => 'string', 'enum' => array( 'unavailable', 'accepted', 'completed', 'failed' ) ),
+							'request_id' => array( 'type' => 'string' ),
+							'session_id' => array( 'type' => 'string' ),
+							'request'    => array( 'type' => 'object' ),
+							'provider'   => array( 'type' => 'string' ),
+							'result'     => array( 'type' => 'object' ),
+							'error'      => array( 'type' => 'object' ),
+							'events'     => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
+							'artifacts'  => array( 'type' => 'object' ),
+							'timings'    => array( 'type' => 'object' ),
+						),
+					),
+					'execute_callback'    => array( self::class, 'request_host_delegation' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/create-browser-playground-session',
 				array(
 					'label'               => 'Create Browser Playground Session',
@@ -739,7 +788,7 @@ final class WP_Codebox_Abilities {
 							'artifact_files'     => array( 'type' => 'array' ),
 							'phases'             => array(
 								'type'        => 'array',
-								'description' => 'Optional named browser task phases. Generic phases may carry wp-codebox/agent-fanout-request/v1 in request/input for WP Codebox execution; materializer phases may override any primary session input through input.',
+								'description' => 'Optional named browser task phases. Generic phases may carry wp-codebox/agent-fanout-request/v1 or wp-codebox/host-delegation-request/v1 in request/input for WP Codebox execution; materializer phases may override any primary session input through input.',
 								'items'       => array(
 									'type'       => 'object',
 									'properties' => array(

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -24,6 +24,11 @@ public static function run_agent_task_fanout( array $input ): array|WP_Error {
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+public static function request_host_delegation( array $input ): array|WP_Error {
+	return self::execute_host_delegation_request( $input );
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function create_browser_playground_session( array $input ): array|WP_Error {
 	$task_input = self::normalize_task_input( $input );
 	if ( is_wp_error( $task_input ) ) {
@@ -517,7 +522,7 @@ private static function browser_task_contract_phases( array $input, array $sessi
 
 		$kind = self::safe_key( (string) ( $phase['kind'] ?? 'materializer' ) );
 		if ( ! in_array( $kind, self::browser_task_phase_kinds(), true ) ) {
-			return new WP_Error( 'wp_codebox_browser_phase_kind_invalid', 'Browser task phases support materializer, agent, validator, repair, and aggregator kinds.', array( 'status' => 400, 'index' => $index, 'kind' => $kind ) );
+			return new WP_Error( 'wp_codebox_browser_phase_kind_invalid', 'Browser task phases support materializer, agent, validator, repair, aggregator, and host-delegation kinds.', array( 'status' => 400, 'index' => $index, 'kind' => $kind ) );
 		}
 
 		$phase_descriptor = array(
@@ -541,6 +546,23 @@ private static function browser_task_contract_phases( array $input, array $sessi
 			}
 
 			$phase_descriptor['status'] = true === ( $result['success'] ?? false ) ? 'completed' : 'failed';
+			$phase_descriptor['result'] = $result;
+			$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
+			continue;
+		}
+
+		$host_delegation_request = self::browser_task_phase_host_delegation_request( $phase );
+		if ( is_array( $host_delegation_request ) ) {
+			if ( empty( $host_delegation_request['sandbox_session_id'] ) && '' !== (string) ( $session_envelope['id'] ?? '' ) ) {
+				$host_delegation_request['sandbox_session_id'] = (string) $session_envelope['id'];
+			}
+
+			$result = self::request_host_delegation( $host_delegation_request );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$phase_descriptor['status'] = true === ( $result['success'] ?? false ) ? (string) ( $result['status'] ?? 'completed' ) : (string) ( $result['status'] ?? 'failed' );
 			$phase_descriptor['result'] = $result;
 			$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 			continue;
@@ -581,6 +603,125 @@ private static function browser_task_phase_fanout_request( array $phase ): ?arra
 	}
 
 	return null;
+}
+
+/** @param array<string,mixed> $phase Browser task phase. @return array<string,mixed>|null */
+private static function browser_task_phase_host_delegation_request( array $phase ): ?array {
+	$candidates = array( $phase['request'] ?? null, $phase['input'] ?? null );
+	foreach ( $candidates as $candidate ) {
+		if ( is_array( $candidate ) && 'wp-codebox/host-delegation-request/v1' === (string) ( $candidate['schema'] ?? '' ) ) {
+			return $candidate;
+		}
+	}
+
+	return null;
+}
+
+/** @param array<string,mixed> $request Host delegation request. @return array<string,mixed>|WP_Error */
+private static function execute_host_delegation_request( array $request ): array|WP_Error {
+	if ( isset( $request['schema'] ) && 'wp-codebox/host-delegation-request/v1' !== (string) $request['schema'] ) {
+		return new WP_Error( 'wp_codebox_host_delegation_schema_invalid', 'Host delegation requests must use wp-codebox/host-delegation-request/v1.', array( 'status' => 400 ) );
+	}
+
+	$request['schema'] = 'wp-codebox/host-delegation-request/v1';
+	$request_id        = self::safe_key( (string) ( $request['request_id'] ?? $request['id'] ?? '' ) );
+	if ( '' === $request_id ) {
+		$request_id = self::generate_id();
+	}
+	$request['request_id'] = $request_id;
+	$started_at            = microtime( true );
+	$events                = array( self::host_delegation_event( 'host-delegation.requested', $request_id ) );
+
+	/**
+	 * Lets products satisfy an explicit host-delegation request.
+	 *
+	 * Return an array shaped like wp-codebox/host-delegation-result/v1, a provider
+	 * payload to wrap, or null when the host has no delegation provider.
+	 *
+	 * @param mixed               $result  Provider result. Null means unavailable.
+	 * @param array<string,mixed> $request Canonical host delegation request.
+	 */
+	$provider_result = apply_filters( 'wp_codebox_host_delegation_request', null, $request );
+	$ended_at        = microtime( true );
+
+	if ( null === $provider_result ) {
+		$events[] = self::host_delegation_event( 'host-delegation.unavailable', $request_id, 'unavailable' );
+		return self::host_delegation_result( false, 'unavailable', $request, null, array( 'code' => 'wp_codebox_host_delegation_unavailable', 'message' => 'No host delegation provider handled the request.', 'data' => null ), $events, $started_at, $ended_at );
+	}
+
+	if ( is_wp_error( $provider_result ) ) {
+		$events[] = self::host_delegation_event( 'host-delegation.failed', $request_id, 'failed' );
+		return self::host_delegation_result( false, 'failed', $request, null, array( 'code' => $provider_result->get_error_code(), 'message' => $provider_result->get_error_message(), 'data' => $provider_result->get_error_data() ), $events, $started_at, $ended_at );
+	}
+
+	if ( ! is_array( $provider_result ) ) {
+		$events[] = self::host_delegation_event( 'host-delegation.failed', $request_id, 'failed' );
+		return self::host_delegation_result( false, 'failed', $request, null, array( 'code' => 'wp_codebox_host_delegation_provider_result_invalid', 'message' => 'Host delegation providers must return an array, WP_Error, or null.', 'data' => array( 'type' => get_debug_type( $provider_result ) ) ), $events, $started_at, $ended_at );
+	}
+
+	$has_success = array_key_exists( 'success', $provider_result );
+	$has_status  = array_key_exists( 'status', $provider_result );
+	$status      = self::safe_key( (string) ( $provider_result['status'] ?? ( $has_success && false === $provider_result['success'] ? 'failed' : 'completed' ) ) );
+	$success     = $has_success ? true === $provider_result['success'] : in_array( $status, array( 'accepted', 'completed' ), true );
+	if ( ! $has_status && ! $has_success && isset( $provider_result['error'] ) ) {
+		$status  = 'failed';
+		$success = false;
+	}
+	if ( ! in_array( $status, array( 'accepted', 'completed', 'failed', 'unavailable' ), true ) ) {
+		$status = $success ? 'completed' : 'failed';
+	}
+
+	$events[] = self::host_delegation_event( $success ? ( 'accepted' === $status ? 'host-delegation.accepted' : 'host-delegation.completed' ) : ( 'unavailable' === $status ? 'host-delegation.unavailable' : 'host-delegation.failed' ), $request_id, $status, (string) ( $provider_result['provider'] ?? '' ) );
+	$error    = is_array( $provider_result['error'] ?? null ) ? $provider_result['error'] : null;
+	$result   = is_array( $provider_result['result'] ?? null ) ? $provider_result['result'] : $provider_result;
+
+	$envelope = self::host_delegation_result( $success, $status, $request, $result, $success ? null : $error, $events, $started_at, $ended_at );
+	foreach ( array( 'provider', 'artifacts', 'orchestrator' ) as $field ) {
+		if ( isset( $provider_result[ $field ] ) ) {
+			$envelope[ $field ] = $provider_result[ $field ];
+		}
+	}
+
+	return $envelope;
+}
+
+private static function host_delegation_event( string $event, string $request_id, string $status = '', string $provider = '' ): array {
+	return array_filter(
+		array(
+			'schema'     => 'wp-codebox/host-delegation-event/v1',
+			'event'      => $event,
+			'time'       => gmdate( 'c' ),
+			'request_id' => $request_id,
+			'status'     => $status,
+			'provider'   => $provider,
+		),
+		static fn( mixed $value ): bool => '' !== $value
+	);
+}
+
+/** @param array<string,mixed> $request Host delegation request. @param array<string,mixed>|null $result Provider result. @param array<string,mixed>|null $error Error payload. @param array<int,array<string,mixed>> $events Events. @return array<string,mixed> */
+private static function host_delegation_result( bool $success, string $status, array $request, ?array $result, ?array $error, array $events, float $started_at, float $ended_at ): array {
+	return array_filter(
+		array(
+			'success'   => $success,
+			'schema'    => 'wp-codebox/host-delegation-result/v1',
+			'execution' => 'host-delegation',
+			'status'    => $status,
+			'request_id' => (string) ( $request['request_id'] ?? '' ),
+			'session_id' => (string) ( $request['sandbox_session_id'] ?? $request['session_id'] ?? '' ),
+			'request'   => $request,
+			'result'    => $result,
+			'error'     => $error,
+			'events'    => $events,
+			'timings'   => array(
+				'started_at'  => gmdate( 'c', (int) $started_at ),
+				'ended_at'    => gmdate( 'c', (int) $ended_at ),
+				'duration_ms' => (int) round( ( $ended_at - $started_at ) * 1000 ),
+			),
+			'orchestrator' => is_array( $request['orchestrator'] ?? null ) ? $request['orchestrator'] : array(),
+		),
+		static fn( mixed $value ): bool => array() !== $value && null !== $value && '' !== $value
+	);
 }
 
 /**

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -376,7 +376,7 @@ private static function browser_task_contract_schema(): array {
 			'primary'          => self::browser_playground_session_schema(),
 			'phases'           => array(
 				'type'        => 'array',
-				'description' => 'Named browser task phases. Materializer phases include a browser-materializer-contract envelope; fanout phases execute wp-codebox/agent-fanout-request/v1 through WP Codebox; other generic phases preserve product-neutral phase metadata for product UIs.',
+				'description' => 'Named browser task phases. Materializer phases include a browser-materializer-contract envelope; fanout phases execute wp-codebox/agent-fanout-request/v1 through WP Codebox; host-delegation phases execute wp-codebox/host-delegation-request/v1 through a host provider filter; other generic phases preserve product-neutral phase metadata for product UIs.',
 				'items'       => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -400,7 +400,7 @@ private static function browser_task_contract_schema(): array {
 
 /** @return array<int,string> */
 private static function browser_task_phase_kinds(): array {
-	return array( 'materializer', 'agent', 'validator', 'repair', 'aggregator' );
+	return array( 'materializer', 'agent', 'validator', 'repair', 'aggregator', 'host-delegation' );
 }
 
 /** @return array<string,mixed> */

--- a/scripts/host-delegation-contract-smoke.ts
+++ b/scripts/host-delegation-contract-smoke.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import {
+  HOST_DELEGATION_EVENT_SCHEMA,
+  HOST_DELEGATION_EVENT_TYPES,
+  HOST_DELEGATION_REQUEST_SCHEMA,
+  HOST_DELEGATION_RESULT_SCHEMA,
+  isHostDelegationEventType,
+  type HostDelegationLifecycleEvent,
+  type HostDelegationRequestContract,
+  type HostDelegationResultContract,
+} from "@automattic/wp-codebox-core"
+
+const request: HostDelegationRequestContract = {
+  schema: HOST_DELEGATION_REQUEST_SCHEMA,
+  request_id: "host-delegation-1",
+  goal: "Run the workspace task server-side.",
+  execution: { capability: "workspace-task" },
+  orchestrator: { product: "example", request_id: "project-123" },
+}
+
+const events: HostDelegationLifecycleEvent[] = HOST_DELEGATION_EVENT_TYPES.map((event, index) => ({
+  schema: HOST_DELEGATION_EVENT_SCHEMA,
+  event,
+  time: `2026-06-06T00:00:0${index}Z`,
+  request_id: request.request_id ?? "",
+  status: event.endsWith("unavailable") ? "unavailable" : event.endsWith("failed") ? "failed" : "completed",
+}))
+
+const result: HostDelegationResultContract = {
+  success: true,
+  schema: HOST_DELEGATION_RESULT_SCHEMA,
+  execution: "host-delegation",
+  status: "completed",
+  request_id: request.request_id ?? "",
+  request,
+  provider: "fake-host-provider",
+  result: { artifact_refs: [{ path: "host/result.json" }] },
+  events: events.filter((event) => event.event !== "host-delegation.unavailable" && event.event !== "host-delegation.failed"),
+  orchestrator: request.orchestrator,
+}
+
+assert.equal(HOST_DELEGATION_REQUEST_SCHEMA, "wp-codebox/host-delegation-request/v1")
+assert.equal(HOST_DELEGATION_RESULT_SCHEMA, "wp-codebox/host-delegation-result/v1")
+assert.equal(result.schema, HOST_DELEGATION_RESULT_SCHEMA)
+assert.equal(result.execution, "host-delegation")
+assert.equal(result.status, "completed")
+assert.ok(events.every((event) => event.schema === HOST_DELEGATION_EVENT_SCHEMA && isHostDelegationEventType(event.event)))
+assert.equal(isHostDelegationEventType("host-delegation.completed"), true)
+assert.equal(isHostDelegationEventType("host_delegation.completed"), false)
+
+console.log("host delegation contract smoke ok")

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -387,6 +387,20 @@ $assert( 'fanout ability exposes canonical request and worker schemas', 'wp-code
 $assert( 'fanout ability output exposes parent child rollup fields', isset( $fanout_ability['output_schema']['properties']['completed'] ) && isset( $fanout_ability['output_schema']['properties']['cancelled'] ) && isset( $fanout_ability['output_schema']['properties']['failures'] ) && isset( $fanout_ability['output_schema']['properties']['runs'] ) );
 $assert( 'fanout ability pins result and artifact event references', 'wp-codebox/agent-fanout-result/v1' === ( $fanout_ability['output_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/agent-fanout-artifacts/v1' === ( $fanout_ability['output_schema']['properties']['artifacts']['properties']['schema']['const'] ?? '' ) && 'string' === ( $fanout_ability['output_schema']['properties']['artifacts']['properties']['events']['type'] ?? '' ) );
 
+$host_delegation_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/request-host-delegation'] ?? null;
+$assert( 'host delegation ability registered', is_array( $host_delegation_ability ) );
+$assert( 'host delegation ability is REST visible', true === ( $host_delegation_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'host delegation ability exposes canonical request and result schemas', 'wp-codebox/host-delegation-request/v1' === ( $host_delegation_ability['input_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/host-delegation-result/v1' === ( $host_delegation_ability['output_schema']['properties']['schema']['const'] ?? '' ) && array( 'unavailable', 'accepted', 'completed', 'failed' ) === ( $host_delegation_ability['output_schema']['properties']['status']['enum'] ?? array() ) );
+$host_delegation_unavailable = call_user_func(
+	$host_delegation_ability['execute_callback'],
+	array(
+		'schema'     => 'wp-codebox/host-delegation-request/v1',
+		'request_id' => 'host-delegation-unavailable',
+		'goal'       => 'Run this on the host if available.',
+	)
+);
+$assert( 'host delegation returns structured unavailable result without provider', ! is_wp_error( $host_delegation_unavailable ) && false === ( $host_delegation_unavailable['success'] ?? true ) && 'unavailable' === ( $host_delegation_unavailable['status'] ?? '' ) && 'wp_codebox_host_delegation_unavailable' === ( $host_delegation_unavailable['error']['code'] ?? '' ) && array( 'host-delegation.requested', 'host-delegation.unavailable' ) === array_map( static fn( array $event ): string => (string) ( $event['event'] ?? '' ), $host_delegation_unavailable['events'] ?? array() ) );
+
 $browser_session_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/create-browser-playground-session'] ?? null;
 $assert( 'browser Playground session ability registered', is_array( $browser_session_ability ) );
 $assert( 'browser Playground session ability is REST visible', true === ( $browser_session_ability['meta']['show_in_rest'] ?? false ) );
@@ -411,7 +425,7 @@ $assert( 'browser task contract ability registered', is_array( $browser_task_con
 $assert( 'browser task contract ability is REST visible', true === ( $browser_task_contract_ability['meta']['show_in_rest'] ?? false ) );
 $assert( 'browser task contract accepts goal or legacy task', array( 'goal' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
 $browser_task_phase_kinds = $browser_task_contract_ability['input_schema']['properties']['phases']['items']['properties']['kind']['enum'] ?? array();
-$assert( 'browser task contract exposes phase and compact schema', 'array' === ( $browser_task_contract_ability['input_schema']['properties']['phases']['type'] ?? '' ) && in_array( 'materializer', $browser_task_phase_kinds, true ) && in_array( 'agent', $browser_task_phase_kinds, true ) && in_array( 'aggregator', $browser_task_phase_kinds, true ) && 'array' === ( $browser_task_contract_ability['output_schema']['properties']['phases']['type'] ?? '' ) && 'object' === ( $browser_task_contract_ability['output_schema']['properties']['compact']['type'] ?? '' ) );
+$assert( 'browser task contract exposes phase and compact schema', 'array' === ( $browser_task_contract_ability['input_schema']['properties']['phases']['type'] ?? '' ) && in_array( 'materializer', $browser_task_phase_kinds, true ) && in_array( 'agent', $browser_task_phase_kinds, true ) && in_array( 'aggregator', $browser_task_phase_kinds, true ) && in_array( 'host-delegation', $browser_task_phase_kinds, true ) && 'array' === ( $browser_task_contract_ability['output_schema']['properties']['phases']['type'] ?? '' ) && 'object' === ( $browser_task_contract_ability['output_schema']['properties']['compact']['type'] ?? '' ) );
 
 $agents_api_executor_targets = apply_filters( 'agents_api_executor_targets', array() );
 $wp_agent_executor_targets = apply_filters( 'wp_agent_executor_targets', array() );
@@ -980,6 +994,66 @@ $generic_phase_task_contract = call_user_func(
 $assert( 'browser task contract accepts agent and aggregator phase descriptors', ! is_wp_error( $generic_phase_task_contract ) && 2 === count( $generic_phase_task_contract['phases'] ?? array() ) && 'agent' === ( $generic_phase_task_contract['phases'][0]['kind'] ?? '' ) && 'aggregator' === ( $generic_phase_task_contract['phases'][1]['kind'] ?? '' ) && ! isset( $generic_phase_task_contract['phases'][0]['contract'] ) && 'completed' === ( $generic_phase_task_contract['phases'][0]['status'] ?? '' ) && 'pending' === ( $generic_phase_task_contract['phases'][1]['status'] ?? '' ) );
 $assert( 'browser task contract executes agent fanout phase requests', ! is_wp_error( $generic_phase_task_contract ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_task_contract['phases'][0]['result']['schema'] ?? '' ) && 1 === ( $generic_phase_task_contract['phases'][0]['result']['completed'] ?? 0 ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/result.json' ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/events.jsonl' ) );
 $assert( 'browser task compact DTO preserves generic phase metadata and fanout result for product UIs', ! is_wp_error( $generic_phase_task_contract ) && 'agent-fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['name'] ?? '' ) && 0 === ( $generic_phase_task_contract['compact']['phases'][0]['index'] ?? null ) && 'Agent Fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['label'] ?? '' ) && 'browser-playground' === ( $generic_phase_task_contract['compact']['phases'][0]['metadata']['runner'] ?? '' ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_task_contract['compact']['phases'][0]['result']['schema'] ?? '' ) && 'aggregate-results' === ( $generic_phase_task_contract['compact']['phases'][1]['name'] ?? '' ) && 1 === ( $generic_phase_task_contract['compact']['phases'][1]['index'] ?? null ) );
+
+$GLOBALS['wp_codebox_host_delegation_requests'] = array();
+add_filter(
+	'wp_codebox_host_delegation_request',
+	static function ( mixed $result, array $request ): array {
+		$GLOBALS['wp_codebox_host_delegation_requests'][] = $request;
+		return array(
+			'success'  => true,
+			'schema'   => 'wp-codebox/host-delegation-result/v1',
+			'status'   => 'completed',
+			'provider' => 'smoke-host-provider',
+			'result'   => array(
+				'summary'       => 'Host provider completed the delegated request.',
+				'artifact_refs' => array(
+					array( 'path' => 'host-delegation/result.json', 'kind' => 'host-delegation-result' ),
+				),
+			),
+			'artifacts' => array(
+				'schema' => 'wp-codebox/host-delegation-artifacts/v1',
+				'path'   => 'host-delegation',
+			),
+		);
+	}
+);
+$host_delegation_phase_task_contract = call_user_func(
+	$browser_task_contract_ability['execute_callback'],
+	array_replace_recursive(
+		$browser_session_input,
+		array(
+			'phases' => array(
+				array(
+					'name'     => 'server-workspace-offload',
+					'kind'     => 'host-delegation',
+					'label'    => 'Server Workspace Offload',
+					'metadata' => array( 'reason' => 'workspace-required' ),
+					'request'  => array(
+						'schema'     => 'wp-codebox/host-delegation-request/v1',
+						'request_id' => 'host-delegation-phase-1',
+						'goal'       => 'Run the workspace phase on a host provider.',
+						'execution'  => array( 'capability' => 'workspace-task' ),
+						'orchestrator' => array( 'type' => 'browser-task-contract' ),
+					),
+				),
+			),
+		)
+	)
+);
+$host_delegation_phase_events = ! is_wp_error( $host_delegation_phase_task_contract ) ? array_map( static fn( array $event ): string => (string) ( $event['event'] ?? '' ), $host_delegation_phase_task_contract['phases'][0]['result']['events'] ?? array() ) : array();
+$assert( 'browser task contract executes host delegation phase requests', ! is_wp_error( $host_delegation_phase_task_contract ) && 1 === count( $GLOBALS['wp_codebox_host_delegation_requests'] ?? array() ) && 'browser-session-123' === ( $GLOBALS['wp_codebox_host_delegation_requests'][0]['sandbox_session_id'] ?? '' ) && 'wp-codebox/host-delegation-result/v1' === ( $host_delegation_phase_task_contract['phases'][0]['result']['schema'] ?? '' ) && 'completed' === ( $host_delegation_phase_task_contract['phases'][0]['status'] ?? '' ) && 'smoke-host-provider' === ( $host_delegation_phase_task_contract['phases'][0]['result']['provider'] ?? '' ) && array( 'host-delegation.requested', 'host-delegation.completed' ) === $host_delegation_phase_events );
+$assert( 'browser task compact DTO preserves host delegation result for product UIs', ! is_wp_error( $host_delegation_phase_task_contract ) && 'host-delegation' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['kind'] ?? '' ) && 'server-workspace-offload' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['name'] ?? '' ) && 'workspace-required' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['metadata']['reason'] ?? '' ) && 'wp-codebox/host-delegation-result/v1' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['result']['schema'] ?? '' ) );
+$GLOBALS['wp_codebox_filters']['wp_codebox_host_delegation_request'] = static fn(): array => array( 'artifact_refs' => array( array( 'path' => 'bare-provider/result.json' ) ) );
+$host_delegation_bare_provider = call_user_func(
+	$host_delegation_ability['execute_callback'],
+	array(
+		'schema'     => 'wp-codebox/host-delegation-request/v1',
+		'request_id' => 'host-delegation-bare-provider',
+		'goal'       => 'Wrap a bare provider payload.',
+	)
+);
+$assert( 'host delegation wraps bare provider payloads as completed results', ! is_wp_error( $host_delegation_bare_provider ) && true === ( $host_delegation_bare_provider['success'] ?? false ) && 'completed' === ( $host_delegation_bare_provider['status'] ?? '' ) && 'bare-provider/result.json' === ( $host_delegation_bare_provider['result']['artifact_refs'][0]['path'] ?? '' ) );
 
 $agents_api_browser_executor_result = apply_filters(
 	'agents_api_execute_task',


### PR DESCRIPTION
## Summary
- Add product-neutral host delegation request/result/event contracts for explicit host-side phases.
- Register `wp-codebox/request-host-delegation` and wire browser task `host-delegation` phases through the `wp_codebox_host_delegation_request` provider filter.
- Document the delegation boundary so WP Codebox owns envelopes/seams while product hosts own placement policy and server-side implementations.

Closes #703.

## Testing
- `npm run build`
- `npm run host-delegation-contract-smoke`
- `npm run fanout-contract-smoke`
- `npm run wordpress-plugin-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Rebasing and landing the host delegation seam drafted in the local worktree, reviewing boundary fit, running verification, and preparing this PR. Chris remains responsible for review and merge.