### PR TITLE
Add Playground WordPress directory startup assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "recipe-run-timeout-smoke": "tsx scripts/recipe-run-timeout-smoke.ts",
     "playground-archive-cache-validation-smoke": "tsx scripts/playground-archive-cache-validation-smoke.ts",
     "playground-cli-startup-output-smoke": "tsx scripts/playground-cli-startup-output-smoke.ts",
+    "playground-wordpress-directory-asset-smoke": "tsx scripts/playground-wordpress-directory-asset-smoke.ts",
     "recipe-run-concurrent-playground-cache-smoke": "tsx scripts/recipe-run-concurrent-playground-cache-smoke.ts",
     "playground-sqlite-alias-smoke": "tsx scripts/playground-sqlite-alias-smoke.ts",
     "php-wasm-preflight-smoke": "tsx scripts/php-wasm-preflight-smoke.ts",

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -284,9 +284,26 @@ export async function runRecipeRunCommand(args: string[]): Promise<number> {
 }
 
 function exitAfterPlaygroundCliBootFailure(output: RecipeRunCommandOutput): void {
-  if (output.schema === "wp-codebox/recipe-run/v1" && output.error?.code === "wp-codebox-playground-cli-exited") {
+  if (output.schema === "wp-codebox/recipe-run/v1" && hasSerializedErrorCode(output.error, "wp-codebox-playground-cli-exited")) {
     process.exit(output.success ? 0 : 1)
   }
+}
+
+function hasSerializedErrorCode(error: RunOutput["error"] | undefined, code: string): boolean {
+  if (!error) {
+    return false
+  }
+
+  if (error.code === code) {
+    return true
+  }
+
+  const cause = error.cause
+  if (!cause || typeof cause !== "object" || Array.isArray(cause)) {
+    return false
+  }
+
+  return hasSerializedErrorCode(cause as RunOutput["error"], code)
 }
 
 function exitAfterRecipeRunTimeout(output: RecipeRunCommandOutput): void {
@@ -1239,13 +1256,14 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
 
 function resolveRecipeRuntimeAssets(recipe: WorkspaceRecipe, recipeDirectory: string): RuntimeAssetSpec | undefined {
   const assets = recipe.runtime?.assets
-  if (!assets?.wordpressZip) {
+  if (!assets?.wordpressDirectory && !assets?.wordpressZip) {
     return undefined
   }
 
   return {
     ...assets,
-    wordpressZip: isUrl(assets.wordpressZip) ? assets.wordpressZip : resolve(recipeDirectory, assets.wordpressZip),
+    ...(assets.wordpressDirectory ? { wordpressDirectory: resolve(recipeDirectory, assets.wordpressDirectory) } : {}),
+    ...(assets.wordpressZip ? { wordpressZip: isUrl(assets.wordpressZip) ? assets.wordpressZip : resolve(recipeDirectory, assets.wordpressZip) } : {}),
   }
 }
 

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -313,6 +313,10 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
         additionalProperties: false,
         description: "Pre-resolved runtime assets. Use local paths or URLs to make recipe startup deterministic without live release metadata lookups.",
         properties: {
+          wordpressDirectory: {
+            type: "string",
+            description: "Local WordPress source directory mounted at /wordpress before Playground installs or boots WordPress. Use a disposable source snapshot because Playground may write setup files into the mounted tree.",
+          },
           wordpressZip: {
             type: "string",
             description: "Local path or HTTP(S) URL for a WordPress release zip used to boot the Playground runtime.",

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -23,6 +23,7 @@ export interface EnvironmentSpec {
 }
 
 export interface RuntimeAssetSpec {
+  wordpressDirectory?: string
   wordpressZip?: string
 }
 

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -19,8 +19,10 @@ export interface PlaygroundCliModule {
     verbosity?: "quiet"
     skipBrowser: boolean
     mount: Array<{ hostPath: string; vfsPath: string }>
+    "mount-before-install"?: Array<{ hostPath: string; vfsPath: string }>
     blueprint?: unknown
     wp?: string
+    wordpressInstallMode?: "install-from-existing-files"
     "site-url"?: string
   }): Promise<PlaygroundCliServer>
 }
@@ -60,9 +62,15 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
     emitProgress("preview:loading-wordpress", "running", "Loading your site", {
       wordpressVersion: spec.environment.version,
     })
-    const wordpressStartupAsset = await resolvePlaygroundWordPressStartupAsset(spec.environment.version, spec.environment.assets?.wordpressZip)
-    const cacheValidation = wordpressStartupAsset.cacheValidation
-    const localAssetServer = wordpressStartupAsset.localPath ? await serveLocalStartupAsset(wordpressStartupAsset.localPath) : undefined
+    const wordpressDirectory = spec.environment.assets?.wordpressDirectory
+    const wordpressStartupAsset = wordpressDirectory ? undefined : await resolvePlaygroundWordPressStartupAsset(spec.environment.version, spec.environment.assets?.wordpressZip)
+    const cacheValidation = wordpressStartupAsset?.cacheValidation ?? {
+      version: spec.environment.version ?? "mounted-wordpress-source",
+      sourceUrl: wordpressDirectory ?? "",
+      source: "pre-resolved" as const,
+      invalidArchives: [],
+    }
+    const localAssetServer = wordpressStartupAsset?.localPath ? await serveLocalStartupAsset(wordpressStartupAsset.localPath) : undefined
     const port = spec.preview?.port ? 0 : await availablePlaygroundPortRange()
     const blueprintSummary = summarizeBlueprint(spec.environment.blueprint)
     if (blueprintSummary.steps > 0) {
@@ -87,7 +95,11 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
             hostPath: mount.source,
             vfsPath: mount.target,
           })),
-          wp: localAssetServer?.url ?? wordpressStartupAsset.wp,
+          ...(wordpressDirectory ? {
+            "mount-before-install": [{ hostPath: wordpressDirectory, vfsPath: "/wordpress" }],
+            wordpressInstallMode: "install-from-existing-files" as const,
+          } : {}),
+          wp: localAssetServer?.url ?? wordpressStartupAsset?.wp,
           "site-url": spec.preview?.siteUrl,
           blueprint: playgroundBlueprint(spec.environment.blueprint, spec.policy, spec.preview?.siteUrl),
         })

--- a/scripts/playground-wordpress-directory-asset-smoke.ts
+++ b/scripts/playground-wordpress-directory-asset-smoke.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { startPlaygroundCliServer, type PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-wordpress-directory-asset-"))
+
+try {
+  const wordpressDirectory = join(workspace, "wordpress")
+  let cliOptions: Parameters<PlaygroundCliModule["runCLI"]>[0] | undefined
+  const cliModule: PlaygroundCliModule = {
+    async runCLI(options) {
+      cliOptions = options
+      return {
+        serverUrl: "http://127.0.0.1:9999",
+        close: async () => undefined,
+      }
+    },
+  }
+
+  const spec: RuntimeCreateSpec = {
+    backend: "wordpress-playground",
+    environment: {
+      kind: "wordpress",
+      name: "playground-wordpress-directory-asset-smoke",
+      version: "mounted-wordpress-source",
+      assets: { wordpressDirectory },
+      blueprint: { steps: [] },
+    },
+    policy: {
+      filesystem: "readwrite-mounts",
+      network: "deny",
+      commands: ["wordpress.run-php"],
+      secrets: "none",
+      approvals: "never",
+    },
+    secretEnv: {},
+    artifactsDirectory: workspace,
+  }
+
+  const server = await startPlaygroundCliServer(spec, [], { cliModule })
+  await server.close?.()
+
+  assert.ok(cliOptions)
+  assert.deepEqual(cliOptions["mount-before-install"], [{ hostPath: wordpressDirectory, vfsPath: "/wordpress" }])
+  assert.equal(cliOptions.wordpressInstallMode, "install-from-existing-files")
+  assert.equal(cliOptions.wp, undefined)
+
+  console.log("Playground WordPress directory asset smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Add generic `runtime.assets.wordpressDirectory` support so recipes can mount a prepared WordPress source tree at `/wordpress` before Playground boots.
- Skip WordPress release zip resolution when a directory asset is provided, and pass `wordpressInstallMode: \"install-from-existing-files\"` to Playground.
- Ensure JSON recipe runs exit promptly when a nested Playground CLI boot failure is serialized under a recipe phase failure.

## Why
Large WordPress distributions can be too expensive to pass through the existing zip startup path. Mounting a prepared source directory keeps startup deterministic without forcing multi-GB archive expansion through the runtime package path, and keeps the behavior generic for any consumer.

## Verification
- `npm run build`
- `npm run playground-wordpress-directory-asset-smoke`
- Lab WPCOM source-mount proof showed the directory path avoided the previous high-memory/ENOSPC startup pattern, reducing peak RSS from roughly 12-13GB to about 1.4GB before surfacing the next real WPCOM SQLite readiness blocker.

## Notes
- The mounted WordPress directory should be disposable because Playground may write setup files into it.
- This does not make WPCOM boot fully yet; it removes the generic WP Codebox startup-asset bottleneck and fixes the nested failure exit path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and tested the generic runtime asset implementation, smoke coverage, and PR description; Chris directed the scope and reviewed the direction during debugging.