### PR TITLE
Centralize default WordPress runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ It records `files/browser/steps.jsonl` (per-step index, kind, selector, ok/fail,
 ]
 ```
 
-WP Codebox defaults to WordPress `7.0` because the agent and AI plugin stacks need the modern WordPress AI surface. Override with `--wp trunk`, `--wp nightly`, or another supported Playground version.
+WP Codebox defaults to WordPress `latest` because the agent and AI plugin stacks need the current WordPress runtime surface. Override with `--wp trunk`, `--wp nightly`, or another supported Playground version.
 
 `--preview-port` fixes the local WP Codebox proxy port for tunnel/proxy wiring. Omit it to keep the current random-port behavior from upstream Playground. `--preview-bind` changes that fixed-port proxy bind address and requires `--preview-port`; it does not change the upstream Playground server bind. `--preview-public-url` is metadata and site-url alignment only; it does not make a loopback-only preview reachable without a tunnel/proxy or explicit proxy bind.
 

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
 import { spawnSync } from "node:child_process"
-import { normalizeTaskInput, stripUndefined, type SandboxToolPolicySnapshot, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, normalizeTaskInput, stripUndefined, type SandboxToolPolicySnapshot, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { runRecipeRunCommand } from "./recipe-run.js"
 
 export interface AgentTaskRunOptions {
@@ -78,7 +78,7 @@ export async function runAgentTaskRunCommand(args: string[]): Promise<number> {
 export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskRunOptions): Promise<AgentTaskRunOutput> {
   const taskInput = normalizeTaskInput(input)
   const task = taskInput.goal
-  const wpVersion = stringValue(input.wp) || "trunk"
+  const wpVersion = stringValue(input.wp) || DEFAULT_WORDPRESS_VERSION
   const artifacts = stringValue(input.artifacts_path) || await mkdtemp(join(tmpdir(), "wp-codebox-agent-task-artifacts-"))
   const recipeDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-agent-task-recipe-"))
   const recipePath = join(recipeDirectory, "recipe.json")

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -3,7 +3,7 @@ import { fstatSync } from "node:fs"
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
-import { RuntimeRunRegistry, artifactBundleRunRef, artifactManifestFile, createBenchResultsJsonSchema, createRuntimeRunId, defaultRunRegistryDirectory, createRuntime, refreshArtifactManifestFileSha256s, stripUndefined, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimeInfo, type RuntimePreviewSpec, type RuntimeRunRecord, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, RuntimeRunRegistry, artifactBundleRunRef, artifactManifestFile, createBenchResultsJsonSchema, createRuntimeRunId, defaultRunRegistryDirectory, createRuntime, refreshArtifactManifestFileSha256s, stripUndefined, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimeInfo, type RuntimePreviewSpec, type RuntimeRunRecord, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -15,7 +15,7 @@ import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, f
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { parseWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "../recipe-validation.js"
-import { DEFAULT_WORDPRESS_VERSION, previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
+import { previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
 
 interface RecipeRunOptions {
   recipePath: string

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -313,7 +313,7 @@ Options:
   --mount <host:vfs>   Mount a host path into the runtime. Repeatable.
   --command <id>       Command/action id to execute.
   --arg <key=value>    Command argument. Repeatable. Recipe commands include wordpress.run-php, wordpress.phpunit, wordpress.core-phpunit, wordpress.plugin-check, wordpress.wp-cli, wordpress.ability, wordpress.bench, and wordpress.browser-probe.
-  --wp <version>       WordPress version for Playground. Defaults to 7.0; accepts latest, trunk, nightly, or numeric versions.
+  --wp <version>       WordPress version for Playground. Defaults to latest; accepts trunk, nightly, or numeric versions.
   --blueprint <json|file>
                        WordPress Playground blueprint JSON or path for boot or validate-blueprint.
   --artifacts <dir>    Artifact root directory.

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { artifactFileDigest, artifactManifestFileWithSha256, checkWorkspacePolicy, isPlainObject as isRecord, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, sha256StableJson, stripUndefined, upsertArtifactManifestFiles, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ArtifactManifestFile, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, artifactFileDigest, artifactManifestFileWithSha256, checkWorkspacePolicy, isPlainObject as isRecord, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, sha256StableJson, stripUndefined, upsertArtifactManifestFiles, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ArtifactManifestFile, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 
 export interface RecipeArtifactEvidenceFile {
   path: string
@@ -256,7 +256,6 @@ export interface RecipeArtifactsFinalizationController {
   readonly metadata: { artifactsFinalized: boolean } | undefined
 }
 
-const DEFAULT_WORDPRESS_VERSION = "7.0"
 const execFileAsync = promisify(execFile)
 const moduleDirectory = dirname(fileURLToPath(import.meta.url))
 const workspaceRoot = resolve(moduleDirectory, "..", "..", "..")

--- a/packages/cli/src/runtime-command-wrappers.ts
+++ b/packages/cli/src/runtime-command-wrappers.ts
@@ -1,11 +1,10 @@
-import { createRuntime, stripUndefined, type ArtifactBundle, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, stripUndefined, type ArtifactBundle, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy } from "@automattic/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
 import { serializeError } from "./output.js"
 import { recipeMountType } from "./recipe-sources.js"
 import { defaultPolicy, runPolicy } from "./recipe-validation.js"
 
 export const WP_CODEBOX_RUNTIME_VERSION = "0.0.0"
-export const DEFAULT_WORDPRESS_VERSION = "7.0"
 
 export interface RunOptions {
   mounts: Array<{ type?: MountSpec["type"]; source: string; target: string; mode: "readonly" | "readwrite"; metadata?: Record<string, unknown> }>

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -3,6 +3,7 @@ import type { ArtifactPreview, ArtifactProvenance } from "./runtime-contracts.js
 export * from "./artifact-manifest.js"
 export * from "./artifact-references.js"
 export * from "./runtime-contracts.js"
+export * from "./runtime-defaults.js"
 export * from "./runtime-policy.js"
 export * from "./workspace-policy.js"
 export * from "./sandbox-tool-policy.js"

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount } from "./runtime-contracts.js"
+import { DEFAULT_WORDPRESS_VERSION } from "./runtime-defaults.js"
 
 type JsonObject = Record<string, unknown>
 
@@ -75,7 +76,7 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
   return {
     schema: "wp-codebox/workspace-recipe/v1",
     runtime: {
-      wp: options.wordpressVersion,
+      wp: options.wordpressVersion ?? DEFAULT_WORDPRESS_VERSION,
       blueprint: options.blueprint ?? { steps: [] },
     },
     inputs: {
@@ -111,7 +112,7 @@ export function buildWordPressBenchRecipe(options: WordPressBenchRecipeOptions):
   return {
     schema: "wp-codebox/workspace-recipe/v1",
     runtime: {
-      wp: options.wordpressVersion,
+      wp: options.wordpressVersion ?? DEFAULT_WORDPRESS_VERSION,
       blueprint: blueprintWithWpConfigDefines(options.blueprint ?? {}, options.wpConfigDefines ?? {}),
     },
     inputs: {

--- a/packages/runtime-core/src/runtime-defaults.ts
+++ b/packages/runtime-core/src/runtime-defaults.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_WORDPRESS_VERSION = "latest"

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -14,6 +14,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const FANOUT_PLAN_SCHEMA = 'wp-codebox/agent-fanout-plan/v1';
 	private const FANOUT_EVENT_SCHEMA = 'wp-codebox/agent-fanout-event/v1';
 	private const FANOUT_SCHEMA = 'wp-codebox/agent-fanout-result/v1';
+	private const DEFAULT_WORDPRESS_VERSION = 'latest';
 	private const FANOUT_MAX_CONCURRENCY = 8;
 	private const SESSION_SCHEMA = WP_Codebox_Agent_Task::SESSION_SCHEMA;
 	private const TASK_INPUT_SCHEMA = WP_Codebox_Agent_Task::INPUT_SCHEMA;
@@ -209,9 +210,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		$artifacts = $this->clean_path( (string) ( $input['artifacts_path'] ?? $this->default_artifacts_path() ) );
-		$wp_version = trim( (string) ( $input['wp'] ?? 'trunk' ) );
+		$wp_version = trim( (string) ( $input['wp'] ?? self::DEFAULT_WORDPRESS_VERSION ) );
 		if ( '' === $wp_version ) {
-			$wp_version = 'trunk';
+			$wp_version = self::DEFAULT_WORDPRESS_VERSION;
 		}
 
 		$bin = trim( (string) ( $input['wp_codebox_bin'] ?? $this->default_bin() ) );
@@ -379,9 +380,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		$artifacts  = $this->clean_path( (string) ( $input['artifacts_path'] ?? $this->default_artifacts_path() ) );
-		$wp_version = trim( (string) ( $input['wp'] ?? 'trunk' ) );
+		$wp_version = trim( (string) ( $input['wp'] ?? self::DEFAULT_WORDPRESS_VERSION ) );
 		if ( '' === $wp_version ) {
-			$wp_version = 'trunk';
+			$wp_version = self::DEFAULT_WORDPRESS_VERSION;
 		}
 
 		$bin = trim( (string) ( $input['wp_codebox_bin'] ?? $this->default_bin() ) );

--- a/scripts/wordpress-recipe-builders-smoke.ts
+++ b/scripts/wordpress-recipe-builders-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, createBenchmarkDefinitionJsonSchema, createBenchResultsJsonSchema, createWorkspaceRecipeJsonSchema, recipeCommandDefinitions } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, createBenchmarkDefinitionJsonSchema, createBenchResultsJsonSchema, createWorkspaceRecipeJsonSchema, recipeCommandDefinitions } from "@automattic/wp-codebox-core"
 import Ajv2020 from "ajv/dist/2020.js"
 
 const recipeCommandIds = recipeCommandDefinitions().filter((command) => command.recipe).map((command) => command.id)
@@ -26,6 +26,9 @@ const phpunitRecipe = buildWordPressPhpunitRecipe({
     { source: "/repo/vendor", target: "/wp-codebox-vendor", mode: "readonly" },
   ],
 })
+
+assert.equal(buildWordPressPhpunitRecipe({ pluginSlug: "demo-plugin" }).runtime?.wp, DEFAULT_WORDPRESS_VERSION)
+assert.equal(buildWordPressBenchRecipe({ pluginSlug: "demo-plugin" }).runtime?.wp, DEFAULT_WORDPRESS_VERSION)
 
 assert.equal(phpunitRecipe.inputs?.mounts?.[0]?.mode, "readwrite")
 assert.deepEqual(phpunitRecipe.workflow.steps[0]?.args, [


### PR DESCRIPTION
## Summary
- Add a single exported `DEFAULT_WORDPRESS_VERSION` in WP Codebox core, set to `latest`.
- Update CLI runtime paths, recipe evidence, agent task runs, and recipe builders to consume that default instead of local `7.0`/`trunk` fallbacks.
- Align docs and smoke coverage with the `latest` default.

## Testing
- `npm run build`
- `npm run wordpress-recipe-builders-smoke`
- `php tests/smoke-wordpress-plugin.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the default-runtime consolidation and targeted smoke updates; Chris reviewed the direction and constraints.