### PR TITLE
Preserve explicit agent task artifacts

### DIFF
--- a/packages/runtime-core/src/agent-task-run-result.ts
+++ b/packages/runtime-core/src/agent-task-run-result.ts
@@ -116,6 +116,10 @@ function normalizeStatus(result: Record<string, unknown>, agentResult: Record<st
 
 function normalizeArtifacts(result: Record<string, unknown>, agentResult: Record<string, unknown>, completionOutcome: Record<string, unknown>): AgentTaskRunArtifactRef[] {
   const artifacts: AgentTaskRunArtifactRef[] = []
+  for (const artifact of arrayObjects(result.artifacts)) {
+    appendUniqueArtifact(artifacts, artifactFromResultArtifact(artifact))
+  }
+
   for (const ref of arrayObjects(runRecord(result).artifactRefs)) {
     const digest = objectValue(ref.digest)
     appendUniqueArtifact(artifacts, stripUndefined({
@@ -161,6 +165,18 @@ function normalizeArtifacts(result: Record<string, unknown>, agentResult: Record
   }))
 
   return artifacts
+}
+
+function artifactFromResultArtifact(artifact: Record<string, unknown>): AgentTaskRunArtifactRef {
+  return stripUndefined({
+    id: stringValue(artifact.id),
+    kind: stringValue(artifact.kind),
+    path: stringValue(artifact.path),
+    url: stringValue(artifact.url) || stringValue(artifact.uri),
+    sha256: stringValue(artifact.sha256),
+    size_bytes: numberValue(artifact.size_bytes) ?? numberValue(artifact.sizeBytes),
+    metadata: objectValue(artifact.metadata),
+  }) as AgentTaskRunArtifactRef
 }
 
 function artifactFromAgentResult(id: string, kind: string, root: string, metadata: Record<string, unknown>): AgentTaskRunArtifactRef {

--- a/scripts/agent-task-run-result-normalizer-smoke.ts
+++ b/scripts/agent-task-run-result-normalizer-smoke.ts
@@ -5,6 +5,14 @@ assertEqual(success.status, "succeeded", "completed success normalizes to succee
 assertEqual(success.success, true, "succeeded result is successful")
 assertEqual(success.refs.runtimes[0]?.id, "runtime-ok", "runtime ref is exposed")
 
+const explicitArtifacts = normalizeAgentTaskRunResult({
+  success: true,
+  status: "completed",
+  artifacts: [{ id: "screenshot-1", kind: "screenshot", path: "/artifacts/screenshot.png" }],
+})
+assertEqual(explicitArtifacts.artifacts[0]?.kind, "screenshot", "explicit top-level artifact kind is preserved")
+assertEqual(explicitArtifacts.artifacts[0]?.path, "/artifacts/screenshot.png", "explicit top-level artifact path is preserved")
+
 const failed = normalizeAgentTaskRunResult({ success: false, status: "completed" })
 assertEqual(failed.status, "failed", "completed failure normalizes to failed")
 assertEqual(failed.failure_classification, "runtime", "failed result classifies as runtime")


### PR DESCRIPTION
## Summary
- Preserve explicit top-level `artifacts[]` emitted by agent task runners during result normalization.
- Keep derived Codebox runtime, bundle, patch, transcript, and log refs intact.
- Add smoke coverage for screenshot artifact preservation.

## Verification
- `npm ci && npm run build && npm run agent-task-run-result-normalizer-smoke`
- Cross-repo proof with Homeboy Extensions merged adoption branch:
  - `HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-agent-task-normalizer-artifacts/packages/runtime-core/dist/index.js npm run test:codebox-agent-task-executor`
  - `HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-agent-task-normalizer-artifacts/packages/runtime-core/dist/index.js npm run test:wp-codebox-apply-adapter`
  - `HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-agent-task-normalizer-artifacts/packages/runtime-core/dist/index.js npm run test:audit-wp-codebox-fanout`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the downstream adoption proof failure, drafted the normalizer artifact preservation fix, and ran local/cross-repo verification; Chris remains responsible for review and landing.