### PR TITLE
Add recipe run summary normalizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "sandbox-tool-policy-smoke": "tsx scripts/sandbox-tool-policy-smoke.ts",
     "task-input-contract-smoke": "tsx scripts/task-input-contract-smoke.ts",
     "agent-task-run-result-normalizer-smoke": "tsx scripts/agent-task-run-result-normalizer-smoke.ts",
+    "recipe-run-summary-smoke": "tsx scripts/recipe-run-summary-smoke.ts",
     "fanout-contract-smoke": "tsx scripts/fanout-contract-smoke.ts",
     "host-delegation-contract-smoke": "tsx scripts/host-delegation-contract-smoke.ts",
     "fanout-aggregation-contract-smoke": "tsx scripts/fanout-aggregation-contract-smoke.ts",

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -28,6 +28,7 @@ export * from "./run-registry.js"
 export * from "./fanout-contracts.js"
 export * from "./fanout-aggregation.js"
 export * from "./partial-artifact-discovery.js"
+export * from "./recipe-run-summary.js"
 
 export type ArtifactReviewProgressEventType =
   | "boot"

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -1,0 +1,183 @@
+import { normalizeAgentTaskRunResult, type AgentTaskRunArtifactRef } from "./agent-task-run-result.js"
+import { normalizeBrowserArtifactSummaryRefs } from "./artifact-references.js"
+import { isPlainObject, stripUndefined } from "./object-utils.js"
+
+export const RECIPE_RUN_SUMMARY_SCHEMA = "wp-codebox/recipe-run-summary/v1" as const
+
+export type RecipeRunSummaryStatus = "succeeded" | "failed" | "timeout" | "interrupted" | (string & {})
+
+export interface RecipeRunSummary {
+  schema: typeof RECIPE_RUN_SUMMARY_SCHEMA
+  success: boolean
+  status: RecipeRunSummaryStatus
+  failed_phase?: string
+  failure_summary?: string
+  diagnostics: Array<Record<string, unknown>>
+  artifacts: AgentTaskRunArtifactRef[]
+  refs: {
+    startup_logs: AgentTaskRunArtifactRef[]
+    probe_json: AgentTaskRunArtifactRef[]
+    screenshots: AgentTaskRunArtifactRef[]
+    side_effects: AgentTaskRunArtifactRef[]
+    declared_artifacts: AgentTaskRunArtifactRef[]
+    artifact_bundles: AgentTaskRunArtifactRef[]
+    changed_files: AgentTaskRunArtifactRef[]
+    patches: AgentTaskRunArtifactRef[]
+    transcripts: AgentTaskRunArtifactRef[]
+    logs: AgentTaskRunArtifactRef[]
+    runtimes: AgentTaskRunArtifactRef[]
+  }
+  metadata: Record<string, unknown>
+}
+
+export interface RecipeRunSummaryOptions {
+  exitStatus?: number
+}
+
+export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummaryOptions = {}): RecipeRunSummary {
+  const result = objectValue(raw)
+  const agentTask = normalizeAgentTaskRunResult(result, { exitStatus: options.exitStatus })
+  const success = result.success === true || agentTask.success
+  const failedPhase = failedPhaseFromRecipeRun(result)
+  const diagnostics = arrayObjects(result.diagnostics)
+  const artifacts = normalizeRecipeRunArtifacts(result, agentTask.artifacts)
+  const summary = failureSummary(result, diagnostics, failedPhase)
+
+  return stripUndefined({
+    schema: RECIPE_RUN_SUMMARY_SCHEMA,
+    success,
+    status: recipeRunStatus(result, success),
+    failed_phase: failedPhase,
+    failure_summary: success ? undefined : summary,
+    diagnostics,
+    artifacts,
+    refs: {
+      startup_logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log" || artifact.kind === "codebox-event-log" || artifact.kind === "codebox-runtime-metadata"),
+      probe_json: artifacts.filter((artifact) => artifact.kind === "browser-summary" || artifact.kind === "recipe-probe-results"),
+      screenshots: artifacts.filter((artifact) => artifact.kind === "browser-screenshot" || artifact.kind === "screenshot"),
+      side_effects: artifacts.filter((artifact) => artifact.kind === "recipe-side-effects" || artifact.kind === "runtime-side-effects" || artifact.kind === "codebox-observations"),
+      declared_artifacts: artifacts.filter((artifact) => artifact.kind === "recipe-declared-artifact" || artifact.kind === "recipe-declared-artifact-results"),
+      artifact_bundles: artifacts.filter((artifact) => artifact.kind === "artifact-bundle" || artifact.kind === "codebox-artifact-bundle"),
+      changed_files: artifacts.filter((artifact) => artifact.kind === "codebox-changed-files"),
+      patches: artifacts.filter((artifact) => artifact.kind === "codebox-patch"),
+      transcripts: artifacts.filter((artifact) => artifact.kind === "codebox-transcript"),
+      logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log" || artifact.kind === "codebox-event-log"),
+      runtimes: agentTask.refs.runtimes,
+    },
+    metadata: stripUndefined({
+      run_id: stringValue(objectValue(result.run).runId) || stringValue(objectValue(result.run_metadata).run_id) || stringValue(agentTask.metadata.run_id),
+      run_status: stringValue(objectValue(result.run).status) || stringValue(objectValue(result.run_metadata).run_status) || stringValue(agentTask.metadata.run_status),
+      runtime_id: stringValue(objectValue(result.runtime).id) || stringValue(objectValue(result.run_metadata).runtime_id) || stringValue(agentTask.metadata.runtime_id),
+      runtime_status: stringValue(objectValue(result.runtime).status) || stringValue(objectValue(result.run_metadata).runtime_status) || stringValue(agentTask.metadata.runtime_status),
+      failure_classification: failureClassificationValue(result),
+      failure_phase: failedPhase,
+      artifact_directory: stringValue(objectValue(result.artifacts).directory) || stringValue(result.artifacts),
+      recipe_path: stringValue(result.recipePath),
+    }),
+  }) as RecipeRunSummary
+}
+
+function recipeRunStatus(result: Record<string, unknown>, success: boolean): RecipeRunSummaryStatus {
+  const explicit = stringValue(result.status)
+  if (explicit === "completed") return success ? "succeeded" : "failed"
+  if (explicit) return explicit
+  if (result.interruption) return "interrupted"
+  if (objectValue(result.error).name === "RecipeRunTimeoutError") return "timeout"
+  return success ? "succeeded" : "failed"
+}
+
+function failedPhaseFromRecipeRun(result: Record<string, unknown>): string | undefined {
+  const phaseEvidence = arrayObjects(result.phaseEvidence)
+  const failedPhase = [...phaseEvidence].reverse().find((phase) => stringValue(phase.status) === "failed")
+  if (failedPhase) return stringValue(failedPhase.name) || undefined
+
+  const diagnosticPhase = arrayObjects(result.diagnostics).map((diagnostic) => stringValue(diagnostic.phase)).find(Boolean)
+  if (diagnosticPhase) return diagnosticPhase
+
+  const classification = objectValue(objectValue(objectValue(result.run).metadata).runResourceEvidence).reliability
+  const failureClassification = objectValue(objectValue(classification).failureClassification)
+  return stringValue(failureClassification.phase) || stringValue(objectValue(result.error).activeOperation) || undefined
+}
+
+function failureClassificationValue(result: Record<string, unknown>): string {
+  const runResourceEvidence = objectValue(objectValue(objectValue(result.run).metadata).runResourceEvidence)
+  const reliability = objectValue(runResourceEvidence.reliability)
+  const failureClassification = objectValue(reliability.failureClassification)
+  return stringValue(failureClassification.value)
+}
+
+function failureSummary(result: Record<string, unknown>, diagnostics: Array<Record<string, unknown>>, failedPhase?: string): string {
+  const diagnosticMessage = diagnostics.map((diagnostic) => stringValue(diagnostic.message)).find(Boolean)
+  const error = objectValue(result.error)
+  const message = stringValue(error.message) || stringValue(result.message) || diagnosticMessage || "WP Codebox recipe run failed."
+  return failedPhase ? `${failedPhase}: ${message}` : message
+}
+
+function normalizeRecipeRunArtifacts(result: Record<string, unknown>, agentTaskArtifacts: AgentTaskRunArtifactRef[]): AgentTaskRunArtifactRef[] {
+  const artifacts: AgentTaskRunArtifactRef[] = []
+  for (const artifact of agentTaskArtifacts) appendUniqueArtifact(artifacts, artifact)
+
+  const bundle = objectValue(result.artifacts)
+  const bundleDirectory = stringValue(bundle.directory) || stringValue(result.artifacts)
+  appendUniqueArtifact(artifacts, stripUndefined({ id: stringValue(bundle.id), kind: "codebox-artifact-bundle", path: bundleDirectory, sha256: stringValue(bundle.contentDigest) }))
+  appendPathArtifact(artifacts, "codebox-event-log", bundle.eventsPath)
+  appendPathArtifact(artifacts, "codebox-command-log", bundle.commandsLogPath || bundle.commandsPath)
+  appendPathArtifact(artifacts, "codebox-runtime-log", bundle.runtimeLogPath)
+  appendPathArtifact(artifacts, "codebox-runtime-metadata", bundle.metadataPath)
+  appendPathArtifact(artifacts, "codebox-observations", bundle.observationsPath)
+  appendPathArtifact(artifacts, "codebox-changed-files", bundle.changedFilesPath)
+  appendPathArtifact(artifacts, "codebox-patch", bundle.patchPath)
+  appendPathArtifact(artifacts, "recipe-side-effects", bundle.diffsPath)
+
+  for (const probe of arrayObjects(result.probes)) {
+    appendUniqueArtifact(artifacts, stripUndefined({
+      id: stringValue(probe.name) || `recipe-probe-${numberValue(probe.index) ?? artifacts.length + 1}`,
+      kind: "recipe-probe-result",
+      metadata: probe,
+    }))
+  }
+
+  for (const artifact of arrayObjects(result.declaredArtifacts)) {
+    appendUniqueArtifact(artifacts, stripUndefined({
+      id: stringValue(artifact.name) || stringValue(artifact.path),
+      kind: "recipe-declared-artifact",
+      path: stringValue(artifact.path),
+      metadata: artifact,
+    }))
+  }
+
+  for (const ref of normalizeBrowserArtifactSummaryRefs({ probes: arrayObjects(result.probes).map((probe) => objectValue(probe.artifacts || probe.files || probe.summary)) })) {
+    appendUniqueArtifact(artifacts, { id: ref.path, kind: ref.kind, path: ref.path, metadata: { ...ref } })
+  }
+
+  return artifacts
+}
+
+function appendPathArtifact(artifacts: AgentTaskRunArtifactRef[], kind: string, value: unknown): void {
+  const path = stringValue(value)
+  appendUniqueArtifact(artifacts, { id: path, kind, path })
+}
+
+function appendUniqueArtifact(artifacts: AgentTaskRunArtifactRef[], artifact: AgentTaskRunArtifactRef): void {
+  if (!artifact.kind) return
+  const key = artifact.path || artifact.url || artifact.id
+  if (!key) return
+  if (artifacts.some((existing) => (existing.path || existing.url || existing.id) === key)) return
+  artifacts.push(artifact)
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {}
+}
+
+function arrayObjects(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter(isPlainObject) : []
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" && value.length > 0 ? value : ""
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}

--- a/scripts/recipe-run-summary-smoke.ts
+++ b/scripts/recipe-run-summary-smoke.ts
@@ -1,0 +1,69 @@
+import { normalizeRecipeRunSummary } from "@automattic/wp-codebox-core"
+
+const success = normalizeRecipeRunSummary({
+  success: true,
+  schema: "wp-codebox/recipe-run/v1",
+  artifacts: {
+    id: "bundle-ok",
+    directory: "/tmp/codebox/bundle-ok",
+    runtimeLogPath: "/tmp/codebox/bundle-ok/logs/runtime.log",
+    commandsLogPath: "/tmp/codebox/bundle-ok/logs/commands.log",
+    changedFilesPath: "/tmp/codebox/bundle-ok/files/changed-files.json",
+    patchPath: "/tmp/codebox/bundle-ok/files/patch.diff",
+  },
+  run: { runId: "run-ok", status: "succeeded" },
+  phaseEvidence: [{ name: "runtime_startup", status: "completed" }],
+})
+assertEqual(success.status, "succeeded", "success normalizes to succeeded")
+assertEqual(success.refs.startup_logs.length, 2, "startup logs are grouped")
+assertEqual(success.refs.changed_files[0]?.path, "/tmp/codebox/bundle-ok/files/changed-files.json", "changed files path is grouped")
+assertEqual(success.metadata.run_id, "run-ok", "run metadata is exposed")
+
+const startupFailure = normalizeRecipeRunSummary({
+  success: false,
+  schema: "wp-codebox/recipe-run/v1",
+  error: { message: "Unable to prepare backend package." },
+  diagnostics: [{ schema: "wp-codebox/plugin-runtime-diagnostic/v1", phase: "backend-preparation", message: "Backend package failed" }],
+})
+assertEqual(startupFailure.status, "failed", "startup failure normalizes to failed")
+assertEqual(startupFailure.failed_phase, "backend-preparation", "diagnostic phase is used when phase evidence is absent")
+assertEqual(startupFailure.failure_summary, "backend-preparation: Unable to prepare backend package.", "failure summary includes phase")
+
+const probeFailure = normalizeRecipeRunSummary({
+  success: false,
+  schema: "wp-codebox/recipe-run/v1",
+  error: { message: "Recipe probe failed" },
+  phaseEvidence: [{ name: "run_probes", status: "failed" }],
+  probes: [{
+    index: 0,
+    name: "homepage",
+    status: "failed",
+    summary: {
+      summaryFile: "/tmp/codebox/probe-summary.json",
+      screenshot: "/tmp/codebox/homepage.png",
+    },
+  }],
+})
+assertEqual(probeFailure.failed_phase, "run_probes", "failed phase evidence wins")
+assertEqual(probeFailure.refs.probe_json[0]?.path, "/tmp/codebox/probe-summary.json", "probe summary JSON is grouped")
+assertEqual(probeFailure.refs.screenshots[0]?.path, "/tmp/codebox/homepage.png", "probe screenshots are grouped")
+
+const artifactFailure = normalizeRecipeRunSummary({
+  success: false,
+  schema: "wp-codebox/recipe-run/v1",
+  error: { message: "Required declared artifacts were not collected" },
+  phaseEvidence: [{ name: "collect_artifacts", status: "failed" }],
+  declaredArtifacts: [{ name: "report", required: true, status: "missing", path: "/tmp/codebox/report.json" }],
+  artifacts: { diffsPath: "/tmp/codebox/side-effects.json" },
+})
+assertEqual(artifactFailure.failed_phase, "collect_artifacts", "artifact collection failure exposes failed phase")
+assertEqual(artifactFailure.refs.declared_artifacts[0]?.path, "/tmp/codebox/report.json", "declared artifacts are grouped")
+assertEqual(artifactFailure.refs.side_effects[0]?.path, "/tmp/codebox/side-effects.json", "side-effect artifacts are grouped")
+
+console.log("recipe run summary smoke ok")
+
+function assertEqual(actual: unknown, expected: unknown, message: string): void {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`)
+  }
+}


### PR DESCRIPTION
## Summary
- Export `normalizeRecipeRunSummary()` from runtime-core so orchestration providers can consume Codebox-owned recipe-run status, failed phase, diagnostics, artifacts, and grouped refs.
- Normalize startup logs, browser probe summaries/screenshots, side effects, declared artifacts, bundle refs, changed files, patches, transcripts, logs, and runtime metadata from recipe-run output.
- Add a smoke covering successful runs plus startup, probe, and artifact-collection failure cases.

Closes #718.

## Verification
- `npm run build`
- `npm run recipe-run-summary-smoke`
- `npm run agent-task-run-result-normalizer-smoke`
- `npm run recipe-workflow-phases-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the issue and consumer duplication, drafted the normalizer and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.