### PR TITLE
Allow browser probe Chrome channel override

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -248,7 +248,11 @@ async function runSingleBrowserProbeCommand({
   if (requestedContext.device && !deviceProfile) {
     throw new Error(`wordpress.browser-probe unknown Playwright device profile: ${requestedContext.device}`)
   }
-  const browser = await chromium.launch()
+  const browser = await chromium.launch(
+    process.env.WP_CODEBOX_BROWSER_CHANNEL
+      ? { channel: process.env.WP_CODEBOX_BROWSER_CHANNEL }
+      : undefined,
+  )
   let finalUrl = targetUrl
   let windowLocationOrigin: string | undefined
   let htmlSha256: string | undefined


### PR DESCRIPTION
## Summary
- Allows `wordpress.browser-probe` to launch a configured Chromium channel via `WP_CODEBOX_BROWSER_CHANNEL`.
- Keeps the existing default Playwright Chromium behavior unchanged when the env var is absent.

## Why
Some lab runners can install system Chrome but cannot install Playwright's bundled Chromium for the host OS. This lets browser probes use the installed Chrome channel while preserving the existing browser-probe contract.

## Evidence
- `npm run build -- --force`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small runtime hook and validated the build; Chris remains responsible for review and merge.