### PR TITLE
Add interrupted run evidence discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "artifact-patch-git-apply-smoke": "tsx scripts/artifact-patch-git-apply-smoke.ts",
     "artifact-reference-normalization-smoke": "tsx scripts/artifact-reference-normalization-smoke.ts",
     "partial-artifact-discovery-smoke": "tsx scripts/partial-artifact-discovery-smoke.ts",
+    "interrupted-run-evidence-smoke": "tsx scripts/interrupted-run-evidence-smoke.ts",
     "mounted-workspace-diff-smoke": "tsx scripts/mounted-workspace-diff-smoke.ts",
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",

--- a/packages/runtime-core/src/partial-artifact-discovery.ts
+++ b/packages/runtime-core/src/partial-artifact-discovery.ts
@@ -10,6 +10,7 @@ export interface PartialArtifactDiscoveryOptions {
   startedAt?: string
   finishedAt?: string
   timestampWindowMs?: number
+  maxDepth?: number
 }
 
 export interface PartialArtifactFileRef {
@@ -59,7 +60,38 @@ export interface PartialArtifactDiscoveryResult {
   artifacts: PartialRunArtifactEvidence[]
 }
 
+export interface InterruptedRunEvidenceRef {
+  kind: string
+  directory: string
+  path: string
+  relativePath: string
+  artifact_id?: string
+  content_type?: string
+  sha256?: ArtifactManifestFile["sha256"]
+}
+
+export interface InterruptedRunEvidenceResult {
+  schema: "wp-codebox/interrupted-run-evidence/v1"
+  artifactsRoot: string
+  sessionId?: string
+  startedAt?: string
+  finishedAt?: string
+  runtime_id?: string
+  last_known_phase?: string
+  last_heartbeat?: string
+  artifact_ref_count: number
+  artifacts: PartialRunArtifactEvidence[]
+  evidence_refs: InterruptedRunEvidenceRef[]
+}
+
+interface InterruptedRunPayloadCandidate {
+  payload: unknown
+  fallbackTimestamp: string
+  runtimeId?: string
+}
+
 const DEFAULT_TIMESTAMP_WINDOW_MS = 1000
+const DEFAULT_MAX_DEPTH = 1
 
 export async function discoverPartialRunArtifacts(options: PartialArtifactDiscoveryOptions): Promise<PartialArtifactDiscoveryResult> {
   const timestampWindowMs = options.timestampWindowMs ?? DEFAULT_TIMESTAMP_WINDOW_MS
@@ -67,7 +99,7 @@ export async function discoverPartialRunArtifacts(options: PartialArtifactDiscov
   const finishedMs = parseTimestampMs(options.finishedAt)
   const earliestMs = startedMs === undefined ? undefined : startedMs - timestampWindowMs
   const latestMs = finishedMs === undefined ? undefined : finishedMs + timestampWindowMs
-  const candidates = await artifactCandidateDirectories(options.artifactsRoot)
+  const candidates = await artifactCandidateDirectories(options.artifactsRoot, options.maxDepth ?? DEFAULT_MAX_DEPTH)
   const artifacts = (await Promise.all(candidates.map((directory) => artifactEvidence(directory, earliestMs, latestMs))))
     .filter((artifact): artifact is PartialRunArtifactEvidence => artifact !== undefined)
     .sort((left, right) => left.directory.localeCompare(right.directory))
@@ -93,22 +125,60 @@ export async function discoverPartialRunArtifacts(options: PartialArtifactDiscov
   }
 }
 
-async function artifactCandidateDirectories(artifactsRoot: string): Promise<string[]> {
+export async function discoverInterruptedRunEvidence(options: PartialArtifactDiscoveryOptions): Promise<InterruptedRunEvidenceResult> {
+  const partial = await discoverPartialRunArtifacts(options)
+  const evidenceRefs = partial.artifacts.flatMap(interruptedEvidenceRefs)
+  const payloads = partial.artifacts.map((artifact) => ({
+    payload: artifact.runtimeReferenceManifest.payload,
+    fallbackTimestamp: artifact.mtime,
+    runtimeId: artifact.bundle?.runtime?.id,
+  }))
+  const runtimeId = newestString(payloads, [["runtime", "id"], ["runtimeId"], ["runtime_id"]]) ?? firstString(payloads.map((payload) => payload.runtimeId))
+  const lastKnownPhase = newestString(payloads, [["lastKnownPhase"], ["last_known_phase"], ["phase"], ["lifecycle", "phase"], ["status"]])
+  const lastHeartbeat = latestTimestamp(payloads.map((payload) => payloadTimestamp(payload)))
+
+  return {
+    schema: "wp-codebox/interrupted-run-evidence/v1",
+    artifactsRoot: partial.artifactsRoot,
+    ...(partial.sessionId ? { sessionId: partial.sessionId } : {}),
+    ...(partial.startedAt ? { startedAt: partial.startedAt } : {}),
+    ...(partial.finishedAt ? { finishedAt: partial.finishedAt } : {}),
+    ...(runtimeId ? { runtime_id: runtimeId } : {}),
+    ...(lastKnownPhase ? { last_known_phase: lastKnownPhase } : {}),
+    ...(lastHeartbeat ? { last_heartbeat: lastHeartbeat } : {}),
+    artifact_ref_count: evidenceRefs.length,
+    artifacts: partial.artifacts,
+    evidence_refs: evidenceRefs,
+  }
+}
+
+async function artifactCandidateDirectories(artifactsRoot: string, maxDepth: number): Promise<string[]> {
   const rootStat = await stat(artifactsRoot).catch(() => undefined)
   if (!rootStat?.isDirectory()) {
     return []
   }
 
-  const entries = await readdir(artifactsRoot, { withFileTypes: true }).catch(() => [])
-  const directories = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(artifactsRoot, entry.name))
+  const boundedMaxDepth = Math.max(0, Math.floor(maxDepth))
+  const directories = await childDirectories(artifactsRoot, boundedMaxDepth)
   const rootManifest = await stat(join(artifactsRoot, ARTIFACT_MANIFEST_PATH)).catch(() => undefined)
   if (rootManifest?.isFile()) {
     directories.push(artifactsRoot)
   }
 
   return directories
+}
+
+async function childDirectories(directory: string, maxDepth: number, depth = 0): Promise<string[]> {
+  if (depth >= maxDepth) {
+    return []
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true }).catch(() => [])
+  const directories = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(directory, entry.name))
+  const nested = await Promise.all(directories.map((child) => childDirectories(child, maxDepth, depth + 1)))
+  return [...directories, ...nested.flat()]
 }
 
 async function artifactEvidence(directory: string, earliestMs: number | undefined, latestMs: number | undefined): Promise<PartialRunArtifactEvidence | undefined> {
@@ -173,6 +243,90 @@ function bundleMetadata(manifest: ArtifactManifest): PartialArtifactBundleMetada
     fileCount: files.length,
     contractFiles: files.filter((file) => contractPathSet.has(file.path)),
   }
+}
+
+function interruptedEvidenceRefs(artifact: PartialRunArtifactEvidence): InterruptedRunEvidenceRef[] {
+  const manifestFiles = artifact.bundle?.contractFiles ?? []
+  if (manifestFiles.length > 0) {
+    return manifestFiles.map((file) => artifactManifestEvidenceRef(artifact, file))
+  }
+
+  return [artifact.manifest, artifact.changedFiles, artifact.runtimeReferenceManifest]
+    .filter((ref) => ref.available)
+    .map((ref) => ({
+      kind: ref.manifestFile?.kind ?? fileArtifactKind(ref.relativePath),
+      directory: artifact.directory,
+      path: ref.path,
+      relativePath: ref.relativePath,
+      ...(ref.manifestFile?.contentType ? { content_type: ref.manifestFile.contentType } : {}),
+      ...(ref.manifestFile?.sha256 ? { sha256: ref.manifestFile.sha256 } : {}),
+    }))
+}
+
+function artifactManifestEvidenceRef(artifact: PartialRunArtifactEvidence, file: ArtifactManifestFile): InterruptedRunEvidenceRef {
+  return {
+    kind: file.kind,
+    directory: artifact.directory,
+    path: join(artifact.directory, file.path),
+    relativePath: file.path,
+    ...(artifact.bundle?.id ? { artifact_id: artifact.bundle.id } : {}),
+    content_type: file.contentType,
+    sha256: file.sha256,
+  }
+}
+
+function fileArtifactKind(relativePath: string): string {
+  if (relativePath === ARTIFACT_MANIFEST_PATH) {
+    return "manifest"
+  }
+  if (relativePath === CHANGED_FILES_ARTIFACT_PATH) {
+    return "changed-files"
+  }
+  if (relativePath === RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH) {
+    return "runtime-reference-manifest"
+  }
+  return "artifact"
+}
+
+function firstString(values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string" && value.length > 0)
+}
+
+function newestString(candidates: InterruptedRunPayloadCandidate[], paths: string[][]): string | undefined {
+  return [...candidates]
+    .sort((left, right) => candidateTimestampMs(right) - candidateTimestampMs(left))
+    .map((candidate) => firstString(paths.map((path) => readPath(candidate.payload, path))))
+    .find((value): value is string => value !== undefined)
+}
+
+function candidateTimestampMs(candidate: InterruptedRunPayloadCandidate): number {
+  return parseTimestampMs(payloadTimestamp(candidate)) ?? parseTimestampMs(candidate.fallbackTimestamp) ?? 0
+}
+
+function payloadTimestamp(candidate: InterruptedRunPayloadCandidate): string | undefined {
+  return firstString([
+    readPath(candidate.payload, ["lastHeartbeat"]),
+    readPath(candidate.payload, ["last_heartbeat"]),
+    readPath(candidate.payload, ["heartbeatAt"]),
+    readPath(candidate.payload, ["heartbeat_at"]),
+  ])
+}
+
+function latestTimestamp(values: unknown[]): string | undefined {
+  return values
+    .filter((value): value is string => typeof value === "string" && Number.isFinite(Date.parse(value)))
+    .sort((left, right) => Date.parse(right) - Date.parse(left))[0]
+}
+
+function readPath(value: unknown, path: string[]): unknown {
+  let current = value
+  for (const segment of path) {
+    if (!current || typeof current !== "object" || !(segment in current)) {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
 }
 
 async function directorySizeBytes(path: string): Promise<number | null> {

--- a/scripts/interrupted-run-evidence-smoke.ts
+++ b/scripts/interrupted-run-evidence-smoke.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile, utimes } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { discoverInterruptedRunEvidence } from "@automattic/wp-codebox-core"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-interrupted-run-evidence-"))
+const startedAt = "2026-06-06T12:00:00.000Z"
+const finishedAt = "2026-06-06T12:00:10.000Z"
+
+try {
+  const directDirectory = await writeArtifactBundle("sandbox-723-timeout", {
+    manifest: false,
+    changedFiles: true,
+    runtimeReferenceManifest: true,
+    runtimeId: "runtime-timeout-723",
+    lastKnownPhase: "collect_artifacts",
+    lastHeartbeat: "2026-06-06T12:00:06.000Z",
+    mtime: "2026-06-06T12:00:06.000Z",
+  })
+  const nestedDirectory = await writeArtifactBundle("nested/sandbox-723-interrupted", {
+    manifest: true,
+    changedFiles: true,
+    runtimeReferenceManifest: true,
+    runtimeId: "runtime-interrupted-723",
+    lastKnownPhase: "run_workloads",
+    lastHeartbeat: "2026-06-06T12:00:08.000Z",
+    mtime: "2026-06-06T12:00:08.000Z",
+  })
+  await writeArtifactBundle("outside-window", {
+    manifest: true,
+    changedFiles: true,
+    runtimeReferenceManifest: true,
+    runtimeId: "runtime-outside-window",
+    lastKnownPhase: "ignored",
+    lastHeartbeat: "2026-06-06T12:01:00.000Z",
+    mtime: "2026-06-06T12:01:00.000Z",
+  })
+
+  const defaultDepthEvidence = await discoverInterruptedRunEvidence({ artifactsRoot: root, startedAt, finishedAt })
+  assert.equal(defaultDepthEvidence.schema, "wp-codebox/interrupted-run-evidence/v1")
+  assert.deepEqual(defaultDepthEvidence.artifacts.map((artifact) => artifact.directory), [directDirectory])
+  assert.equal(defaultDepthEvidence.runtime_id, "runtime-timeout-723")
+  assert.equal(defaultDepthEvidence.last_known_phase, "collect_artifacts")
+  assert.equal(defaultDepthEvidence.last_heartbeat, "2026-06-06T12:00:06.000Z")
+  assert.equal(defaultDepthEvidence.artifact_ref_count, 2)
+  assert.deepEqual(defaultDepthEvidence.evidence_refs.map((ref) => ref.kind).sort(), ["changed-files", "runtime-reference-manifest"])
+
+  const nestedEvidence = await discoverInterruptedRunEvidence({ artifactsRoot: root, sessionId: "sandbox-723-interrupted", startedAt, finishedAt, maxDepth: 2 })
+  assert.deepEqual(nestedEvidence.artifacts.map((artifact) => artifact.directory), [nestedDirectory])
+  assert.equal(nestedEvidence.runtime_id, "runtime-interrupted-723")
+  assert.equal(nestedEvidence.last_known_phase, "run_workloads")
+  assert.equal(nestedEvidence.last_heartbeat, "2026-06-06T12:00:08.000Z")
+  assert.equal(nestedEvidence.artifact_ref_count, 3)
+  assert.ok(nestedEvidence.evidence_refs.every((ref) => ref.artifact_id === "artifact-nested-sandbox-723-interrupted"))
+  assert.ok(nestedEvidence.evidence_refs.every((ref) => ref.sha256?.algorithm === "sha256"))
+
+  const fallbackEvidence = await discoverInterruptedRunEvidence({ artifactsRoot: root, sessionId: "missing-session", startedAt, finishedAt, maxDepth: 2 })
+  assert.equal(fallbackEvidence.artifacts.length, 2)
+  assert.equal(fallbackEvidence.runtime_id, "runtime-interrupted-723")
+  assert.equal(fallbackEvidence.last_heartbeat, "2026-06-06T12:00:08.000Z")
+
+  console.log("interrupted run evidence smoke passed")
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+async function writeArtifactBundle(name: string, options: { manifest: boolean; changedFiles: boolean; runtimeReferenceManifest: boolean; runtimeId: string; lastKnownPhase: string; lastHeartbeat: string; mtime: string }): Promise<string> {
+  const directory = join(root, name)
+  const files = join(directory, "files")
+  await mkdir(files, { recursive: true })
+  const manifestFiles = []
+  if (options.changedFiles) {
+    const changedFilesPath = join(files, "changed-files.json")
+    await writeFile(changedFilesPath, `${JSON.stringify({ schema: "wp-codebox/changed-files/v1", files: [] }, null, 2)}\n`)
+    manifestFiles.push({ path: "files/changed-files.json", kind: "changed-files", contentType: "application/json", sha256: { algorithm: "sha256", value: "0".repeat(64) } })
+  }
+  if (options.runtimeReferenceManifest) {
+    const runtimeManifestPath = join(files, "runtime-reference-manifest.json")
+    await writeFile(runtimeManifestPath, `${JSON.stringify({
+      schema: "wp-codebox/runtime-reference-manifest/v1",
+      runtime: { id: options.runtimeId, backend: "wordpress-playground", environment: { kind: "wordpress" }, createdAt: startedAt, status: "created" },
+      lastKnownPhase: options.lastKnownPhase,
+      heartbeatAt: options.lastHeartbeat,
+    }, null, 2)}\n`)
+    manifestFiles.push({ path: "files/runtime-reference-manifest.json", kind: "runtime-reference-manifest", contentType: "application/json", sha256: { algorithm: "sha256", value: "1".repeat(64) } })
+  }
+  if (options.manifest) {
+    await writeFile(join(directory, "manifest.json"), `${JSON.stringify({
+      id: `artifact-${name.replace(/\//g, "-")}`,
+      contentDigest: { algorithm: "sha256", inputs: [], value: "2".repeat(64) },
+      createdAt: options.mtime,
+      runtime: { id: options.runtimeId, backend: "wordpress-playground", environment: { kind: "wordpress" }, createdAt: startedAt, status: "created" },
+      files: [
+        { path: "manifest.json", kind: "manifest", contentType: "application/json", sha256: { algorithm: "sha256", value: "3".repeat(64) } },
+        ...manifestFiles,
+      ],
+    }, null, 2)}\n`)
+  }
+  const mtime = new Date(options.mtime)
+  await utimes(directory, mtime, mtime)
+  return directory
+}


### PR DESCRIPTION
## Summary
- Adds `discoverInterruptedRunEvidence()` to runtime-core with the `wp-codebox/interrupted-run-evidence/v1` schema.
- Packages interrupted/timeout artifact refs, runtime id, last known phase, last heartbeat, and artifact ref counts from partial artifact discovery.
- Extends partial artifact discovery with bounded `maxDepth` scanning so nested run artifacts can be discovered without downstream local scans.

Closes #723.

## Tests
- `npm run build`
- `npm run partial-artifact-discovery-smoke`
- `npm run interrupted-run-evidence-smoke`
- `npm run recipe-interruption-artifacts-smoke`
- `npm run recipe-run-timeout-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runtime-core primitive, smoke coverage, and PR preparation; Chris remains responsible for review and testing.