### PR TITLE
Add browser probe review artifacts

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -846,9 +846,10 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let startupDurationMs: number | undefined
   let cleanupEvidence: RunResourceCleanupEvidence | undefined
   const phaseTracker = new RecipePhaseTracker()
-  const awaitRecipe = <T>(operation: string, promise: Promise<T>, timeoutMs = remainingRecipeTimeoutMs(startedAtMs, options.timeoutMs)): Promise<T> => {
+  const awaitRecipe = <T>(operation: string, promiseOrFactory: Promise<T> | (() => Promise<T>), timeoutMs = remainingRecipeTimeoutMs(startedAtMs, options.timeoutMs)): Promise<T> => {
     return artifactPointer.update({ command: operation, commandStatus: "running", phases: phaseTracker.list() })
       .then(() => {
+        const promise = typeof promiseOrFactory === "function" ? promiseOrFactory() : promiseOrFactory
         const guarded = watchRecipeOperation(operation, promise, startedAtMs, timeoutMs, options.timeoutMs)
         return interruption ? interruption.interruptible(guarded) : guarded
       })
@@ -1062,7 +1063,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const workflowSteps = recipeWorkflowSteps(recipe)
     await phaseTracker.run("run_workloads", phaseWorkflowData(workflowSteps), async () => {
       for (const workflowStep of workflowSteps) {
-        executions.push(await awaitRecipe(`workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`, executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options)))
+        executions.push(await awaitRecipe(`workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`, () => executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options)))
         interruption?.throwIfInterrupted()
       }
     })

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -145,6 +145,7 @@ export interface ArtifactReviewBrowserSummary {
     checkpoints?: string
     memory?: string
     performance?: string
+    review?: string
     screenshot?: string
     console?: string
     errorsFile?: string

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -22,6 +22,7 @@ export interface BrowserProbeArtifact {
     memory?: string
     network?: string
     performance?: string
+    review?: string
     screenshot?: string
     summary: string
   }
@@ -49,6 +50,7 @@ export interface BrowserProbeArtifact {
     networkEvents: number
     performance?: BrowserProbePerformanceSummary
     progress?: BrowserProbeProgressSummary
+    review?: BrowserProbeReviewSummary
     context?: BrowserProbeContextDetails
     capabilities?: BrowserProbeCapabilityDiagnostics
     replayability: BrowserProbeReplayability
@@ -109,6 +111,96 @@ export interface BrowserEditorCanvasSelectorMatchSummary {
     text: string
   } | null
   error: string
+}
+
+export interface BrowserProbeReviewSummary {
+  schema: "wp-codebox/browser-probe-review/v1"
+  version: 1
+  browser: {
+    name: string
+    channel: string
+    version: string | null
+  }
+  runtime: {
+    node: string
+    platform: string
+    arch: string
+  }
+  profile: {
+    viewport: BrowserProbeViewport | null
+    userAgent: string | null
+    throttle: string | null
+    waitFor: string
+    durationMs: number
+  }
+  timings: {
+    startedAt: string
+    finishedAt: string
+    totalDurationMs: BrowserProbeMeasuredMetric
+    navigation: BrowserProbeNavigationTimingSummary
+    ttfbMs: BrowserProbeMeasuredMetric
+    firstContentfulPaintMs: BrowserProbeMeasuredMetric
+    largestContentfulPaintMs: BrowserProbeMeasuredMetric
+    loadEventMs: BrowserProbeMeasuredMetric
+  }
+  lcp: {
+    status: "available" | "missing"
+    reason?: string
+    element: string | null
+    size: number | null
+    url: string | null
+  }
+  errors: {
+    console: BrowserProbeIssueSummary
+    page: BrowserProbeIssueSummary
+    probe: BrowserProbeIssueSummary
+  }
+  network: BrowserProbeNetworkReviewSummary
+  milestones: BrowserProbeMilestoneSummary
+  artifacts: Record<string, BrowserProbeArtifactRef>
+}
+
+export interface BrowserProbeMeasuredMetric {
+  status: "available" | "missing"
+  value: number | null
+  unit: "ms"
+  reason?: string
+}
+
+export interface BrowserProbeIssueSummary {
+  count: number
+  status: "ok" | "issues" | "not-captured"
+  artifact?: string
+}
+
+export interface BrowserProbeNetworkReviewSummary {
+  status: "captured" | "not-captured"
+  events: number
+  responses: number
+  failures: number
+  byHost: Record<string, BrowserProbeNetworkCountSummary>
+  byType: Record<string, BrowserProbeNetworkCountSummary>
+  waterfall?: BrowserProbeArtifactRef
+}
+
+export interface BrowserProbeNetworkCountSummary {
+  requests: number
+  responses: number
+  failures: number
+  transferSizeBytes: number
+}
+
+export interface BrowserProbeMilestoneSummary {
+  status: "captured" | "not-captured"
+  count: number
+  names: string[]
+  artifact?: string
+}
+
+export interface BrowserProbeArtifactRef {
+  path: string
+  kind: "json" | "jsonl" | "html" | "png"
+  sha256?: string
 }
 
 export interface BrowserProbeCapabilityDiagnostics {
@@ -301,6 +393,7 @@ export interface BrowserProbePaintTimingSummary {
   largestContentfulPaintMs: number | null
   largestContentfulPaintSize: number | null
   largestContentfulPaintElement: string | null
+  largestContentfulPaintUrl: string | null
 }
 
 export interface BrowserProbeLayoutShiftSummary {
@@ -516,6 +609,7 @@ export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactRe
       errorsFile: probe.files.errors,
       editorState: probe.files.editorState,
       memory: probe.files.memory,
+      review: probe.files.review,
       actions: probe.files.steps ?? probe.files.actions,
       actionCount: probe.summary.steps ?? probe.summary.actions,
       steps: probe.files.steps,
@@ -567,6 +661,9 @@ export function browserManifestFiles(artifactRoot: string, probes: BrowserProbeA
     if (probe.files.performance) {
       files.set(probe.files.performance, { kind: "browser-performance", contentType: "application/json" })
     }
+    if (probe.files.review) {
+      files.set(probe.files.review, { kind: "browser-review", contentType: "application/json" })
+    }
     if (probe.files.screenshot) {
       files.set(probe.files.screenshot, { kind: "browser-screenshot", contentType: "image/png" })
     }
@@ -577,6 +674,6 @@ export function browserManifestFiles(artifactRoot: string, probes: BrowserProbeA
 }
 
 export function browserRedactionPaths(probe: BrowserProbeArtifact): string[] {
-  return [probe.files.steps, probe.files.actions, probe.files.editorState, probe.files.checkpoints, probe.files.console, probe.files.errors, probe.files.html, probe.files.lifecycle, probe.files.memory, probe.files.network, probe.files.performance, probe.files.summary]
+  return [probe.files.steps, probe.files.actions, probe.files.editorState, probe.files.checkpoints, probe.files.console, probe.files.errors, probe.files.html, probe.files.lifecycle, probe.files.memory, probe.files.network, probe.files.performance, probe.files.review, probe.files.summary]
     .filter((path): path is string => typeof path === "string" && path.length > 0)
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { browserInteractionStepsFromArgs, durationStringMs } from "./browser-actions.js"
-import type { BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbePreviewMode, BrowserProbePreviewRouting, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
+import type { BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewMode, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
@@ -240,9 +240,11 @@ async function runSingleBrowserProbeCommand({
   const lifecyclePath = join(browserDirectory, "lifecycle.json")
   const networkPath = join(browserDirectory, "network.jsonl")
   const performancePath = join(browserDirectory, "performance.json")
+  const reviewPath = join(browserDirectory, "review.json")
   const screenshotPath = join(browserDirectory, "screenshot.png")
   const summaryPath = join(browserDirectory, "summary.json")
   const startedAt = now()
+  const startedAtMs = Date.now()
   const progress = createBrowserProbeProgressTracker(startedAt, stallTimeoutMs)
   const { chromium, devices } = await import("playwright")
   if (requestedContext.browser && requestedContext.browser !== "chromium") {
@@ -257,6 +259,11 @@ async function runSingleBrowserProbeCommand({
       ? { channel: process.env.WP_CODEBOX_BROWSER_CHANNEL }
       : undefined,
   )
+  const browserMetadata = {
+    name: "chromium",
+    channel: process.env.WP_CODEBOX_BROWSER_CHANNEL || "bundled",
+    version: browser.version(),
+  }
   let finalUrl = targetUrl
   let windowLocationOrigin: string | undefined
   let htmlSha256: string | undefined
@@ -462,6 +469,36 @@ async function runSingleBrowserProbeCommand({
       results: assertionResults,
     }
 
+    const finishedAt = now()
+    const review = browserProbeReviewSummary({
+      browser: browserMetadata,
+      capture,
+      checkpoints,
+      consoleMessages,
+      durationMs,
+      errors,
+      files: browserProbeArtifactRefs(browserFilesDirectory, capture, {
+        checkpoints: checkpoints.length > 0,
+        console: capture.has("console") || capturesConsoleForAssertions,
+        errors: capture.has("errors") || capturesErrorsForAssertions,
+        html: capture.has("html") ? htmlSha256 : undefined,
+        lifecycle: Boolean(lifecycleArtifact),
+        memory: Boolean(memoryArtifact),
+        network: capture.has("network") || capturesNetworkForAssertions,
+        performance: Boolean(performanceArtifact),
+        screenshot: capture.has("screenshot") ? screenshotSha256 : undefined,
+      }),
+      finishedAt,
+      network,
+      performanceArtifact,
+      startedAt,
+      throttle: throttleProfile?.id ?? null,
+      totalDurationMs: Date.now() - startedAtMs,
+      viewport,
+      waitFor,
+    })
+    await writeFile(reviewPath, `${JSON.stringify(review, null, 2)}\n`)
+
     artifact = {
       requestedUrl: targetUrl,
       url: targetUrl,
@@ -477,6 +514,7 @@ async function runSingleBrowserProbeCommand({
         ...(memoryArtifact ? { memory: `${browserFilesDirectory}/memory.json` } : {}),
         ...(capture.has("network") || capturesNetworkForAssertions ? { network: `${browserFilesDirectory}/network.jsonl` } : {}),
         ...(performanceArtifact ? { performance: `${browserFilesDirectory}/performance.json` } : {}),
+        review: `${browserFilesDirectory}/review.json`,
         ...(capture.has("screenshot") ? { screenshot: `${browserFilesDirectory}/screenshot.png` } : {}),
         summary: `${browserFilesDirectory}/summary.json`,
       },
@@ -493,6 +531,7 @@ async function runSingleBrowserProbeCommand({
         networkEvents: network.length,
         ...(performanceArtifact ? { performance: performanceArtifact.peak } : {}),
         progress: progress.summary(),
+        review,
         context: contextDetails,
         capabilities: capabilityDiagnostics,
         replayability: browserProbeReplayability(capture),
@@ -517,7 +556,7 @@ async function runSingleBrowserProbeCommand({
       ...(assertionSummary.total > 0 ? { assertions: assertionSummary } : {}),
       ...(prePageScriptMetadata ? { prePageScript: prePageScriptMetadata } : {}),
       startedAt,
-      finishedAt: now(),
+      finishedAt,
       files: artifact.files,
       hashes: {
         ...(htmlSha256 ? { html: { algorithm: "sha256", value: htmlSha256 } } : {}),
@@ -525,6 +564,7 @@ async function runSingleBrowserProbeCommand({
       },
       context: contextDetails,
       capabilities: capabilityDiagnostics,
+      review,
       viewport,
       summary: artifact.summary,
     }, null, 2)}\n`)
@@ -724,6 +764,195 @@ function browserProbeCapabilityViewport(viewport: BrowserProbeViewport): Browser
     isMobile: viewport.isMobile,
     hasTouch: viewport.hasTouch,
   }
+}
+
+function browserProbeReviewSummary(input: {
+  browser: BrowserProbeReviewSummary["browser"]
+  capture: Set<string>
+  checkpoints: BrowserProbeCheckpointRecord[]
+  consoleMessages: Record<string, unknown>[]
+  durationMs: number
+  errors: BrowserProbeErrorRecord[]
+  files: Record<string, BrowserProbeArtifactRef>
+  finishedAt: string
+  network: BrowserProbeNetworkRecord[]
+  performanceArtifact?: BrowserProbePerformanceArtifact
+  startedAt: string
+  throttle: string | null
+  totalDurationMs: number
+  viewport: BrowserProbeViewport | null
+  waitFor: string
+}): BrowserProbeReviewSummary {
+  const performance = input.performanceArtifact?.final
+  const paint = performance?.paint
+  const navigation = performance?.navigation ?? {
+    type: null,
+    redirectCount: 0,
+    durationMs: null,
+    domContentLoadedMs: null,
+    loadEventMs: null,
+    responseStartMs: null,
+    responseEndMs: null,
+    requestStartMs: null,
+    ttfbMs: null,
+    redirectMs: null,
+  }
+  const missingReason = input.capture.has("performance")
+    ? "metric not reported by browser"
+    : "capture=performance was not requested"
+  const pageErrors = input.errors.filter((error) => error.type === "pageerror")
+  const probeErrors = input.errors.filter((error) => error.type === "probe-error")
+  const consoleErrors = input.consoleMessages.filter((message) => message.type === "error")
+  const lcpUrl = safeBrowserProbeUrl(paint?.largestContentfulPaintUrl ?? undefined)
+
+  return {
+    schema: "wp-codebox/browser-probe-review/v1",
+    version: 1,
+    browser: input.browser,
+    runtime: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    profile: {
+      viewport: input.viewport,
+      userAgent: input.viewport?.userAgent ?? null,
+      throttle: input.throttle,
+      waitFor: input.waitFor,
+      durationMs: input.durationMs,
+    },
+    timings: {
+      startedAt: input.startedAt,
+      finishedAt: input.finishedAt,
+      totalDurationMs: browserProbeMetric(input.totalDurationMs, "probe wall-clock duration unavailable"),
+      navigation,
+      ttfbMs: browserProbeMetric(navigation.ttfbMs, missingReason),
+      firstContentfulPaintMs: browserProbeMetric(paint?.firstContentfulPaintMs, missingReason),
+      largestContentfulPaintMs: browserProbeMetric(paint?.largestContentfulPaintMs, missingReason),
+      loadEventMs: browserProbeMetric(navigation.loadEventMs, missingReason),
+    },
+    lcp: {
+      status: typeof paint?.largestContentfulPaintMs === "number" ? "available" : "missing",
+      ...(typeof paint?.largestContentfulPaintMs === "number" ? {} : { reason: missingReason }),
+      element: paint?.largestContentfulPaintElement ?? null,
+      size: paint?.largestContentfulPaintSize ?? null,
+      url: lcpUrl ?? null,
+    },
+    errors: {
+      console: browserProbeIssueSummary(consoleErrors.length, Boolean(input.files.console), input.files.console?.path),
+      page: browserProbeIssueSummary(pageErrors.length, Boolean(input.files.errors), input.files.errors?.path),
+      probe: browserProbeIssueSummary(probeErrors.length, Boolean(input.files.errors), input.files.errors?.path),
+    },
+    network: browserProbeNetworkReviewSummary(input.network, input.files.network),
+    milestones: {
+      status: input.checkpoints.length > 0 ? "captured" : "not-captured",
+      count: input.checkpoints.length,
+      names: [...new Set(input.checkpoints.map((checkpoint) => checkpoint.name).filter(Boolean))].sort(),
+      ...(input.files.checkpoints ? { artifact: input.files.checkpoints.path } : {}),
+    },
+    artifacts: input.files,
+  }
+}
+
+function browserProbeMetric(value: number | null | undefined, reason: string): BrowserProbeMeasuredMetric {
+  return typeof value === "number" && Number.isFinite(value)
+    ? { status: "available", value, unit: "ms" }
+    : { status: "missing", value: null, unit: "ms", reason }
+}
+
+function browserProbeIssueSummary(count: number, captured: boolean, artifact?: string): BrowserProbeReviewSummary["errors"]["console"] {
+  if (!captured && count === 0) {
+    return { count: 0, status: "not-captured" }
+  }
+  return {
+    count,
+    status: count > 0 ? "issues" : "ok",
+    ...(artifact ? { artifact } : {}),
+  }
+}
+
+function browserProbeNetworkReviewSummary(network: BrowserProbeNetworkRecord[], artifact?: BrowserProbeArtifactRef): BrowserProbeNetworkReviewSummary {
+  if (!artifact) {
+    return { status: "not-captured", events: 0, responses: 0, failures: 0, byHost: {}, byType: {} }
+  }
+
+  const byHost: Record<string, BrowserProbeNetworkCountSummary> = {}
+  const byType: Record<string, BrowserProbeNetworkCountSummary> = {}
+  for (const record of network) {
+    addBrowserProbeNetworkCount(byHost, requestHost(record.url) || "unknown", record)
+    addBrowserProbeNetworkCount(byType, record.resourceType || "unknown", record)
+  }
+
+  return {
+    status: "captured",
+    events: network.length,
+    responses: network.filter((record) => record.type === "response").length,
+    failures: network.filter((record) => record.type === "requestfailed").length,
+    byHost: sortBrowserProbeNetworkCounts(byHost),
+    byType: sortBrowserProbeNetworkCounts(byType),
+    waterfall: artifact,
+  }
+}
+
+function addBrowserProbeNetworkCount(target: Record<string, BrowserProbeNetworkCountSummary>, key: string, record: BrowserProbeNetworkRecord): void {
+  const summary = target[key] ?? { requests: 0, responses: 0, failures: 0, transferSizeBytes: 0 }
+  summary.requests += 1
+  if (record.type === "response") {
+    summary.responses += 1
+  }
+  if (record.type === "requestfailed") {
+    summary.failures += 1
+  }
+  summary.transferSizeBytes += typeof record.transferSize === "number" && Number.isFinite(record.transferSize) ? record.transferSize : 0
+  target[key] = summary
+}
+
+function sortBrowserProbeNetworkCounts(value: Record<string, BrowserProbeNetworkCountSummary>): Record<string, BrowserProbeNetworkCountSummary> {
+  return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)))
+}
+
+function requestHost(url: string): string | undefined {
+  try {
+    return new URL(url).host
+  } catch {
+    return undefined
+  }
+}
+
+function browserProbeArtifactRefs(browserFilesDirectory: string, capture: Set<string>, input: {
+  checkpoints: boolean
+  console: boolean
+  errors: boolean
+  html?: string
+  lifecycle: boolean
+  memory: boolean
+  network: boolean
+  performance: boolean
+  screenshot?: string
+}): Record<string, BrowserProbeArtifactRef> {
+  return {
+    ...(input.console ? { console: { path: `${browserFilesDirectory}/console.jsonl`, kind: "jsonl" as const } } : {}),
+    ...(input.checkpoints ? { checkpoints: { path: `${browserFilesDirectory}/checkpoints.jsonl`, kind: "jsonl" as const } } : {}),
+    ...(input.errors ? { errors: { path: `${browserFilesDirectory}/errors.jsonl`, kind: "jsonl" as const } } : {}),
+    ...(capture.has("html") ? { html: { path: `${browserFilesDirectory}/snapshot.html`, kind: "html" as const, ...(input.html ? { sha256: input.html } : {}) } } : {}),
+    ...(input.lifecycle ? { lifecycle: { path: `${browserFilesDirectory}/lifecycle.json`, kind: "json" as const } } : {}),
+    ...(input.memory ? { memory: { path: `${browserFilesDirectory}/memory.json`, kind: "json" as const } } : {}),
+    ...(input.network ? { network: { path: `${browserFilesDirectory}/network.jsonl`, kind: "jsonl" as const } } : {}),
+    ...(input.performance ? { performance: { path: `${browserFilesDirectory}/performance.json`, kind: "json" as const } } : {}),
+    review: { path: `${browserFilesDirectory}/review.json`, kind: "json" as const },
+    ...(capture.has("screenshot") ? { screenshot: { path: `${browserFilesDirectory}/screenshot.png`, kind: "png" as const, ...(input.screenshot ? { sha256: input.screenshot } : {}) } } : {}),
+    summary: { path: `${browserFilesDirectory}/summary.json`, kind: "json" as const },
+  }
+}
+
+function safeBrowserProbeUrl(value: string | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  if (/^data:/i.test(value)) {
+    return "data:[redacted]"
+  }
+  return value
 }
 
 export async function runHtmlCaptureCommand(input: {

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -69,6 +69,7 @@ export function browserProbePerformanceSummary(checkpoints: BrowserProbeCheckpoi
       largestContentfulPaintMs: null,
       largestContentfulPaintSize: null,
       largestContentfulPaintElement: null,
+      largestContentfulPaintUrl: null,
     },
     resources: final?.resources.count ?? 0,
     transferSizeBytes: final?.resources.transferSizeBytes ?? 0,

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -614,6 +614,7 @@ async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetr
             loadTime?: number
             size?: number
             element?: string | null
+            url?: string
           } | null
         }
       }).__wpCodeboxBrowserProbe
@@ -699,7 +700,7 @@ async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetr
         }
       }
 
-      function paintTimingSummary(entries: Array<{ name?: string; startTime?: number }>, lcp: { startTime?: number; renderTime?: number; loadTime?: number; size?: number; element?: string | null } | null) {
+      function paintTimingSummary(entries: Array<{ name?: string; startTime?: number }>, lcp: { startTime?: number; renderTime?: number; loadTime?: number; size?: number; element?: string | null; url?: string } | null) {
         const paintEntries = [...performance.getEntriesByType("paint"), ...entries]
         return {
           firstPaintMs: firstEntryStartTime(paintEntries, "first-paint"),
@@ -707,6 +708,7 @@ async function browserProbeMetricsSnapshot(page: Page): Promise<BrowserProbeMetr
           largestContentfulPaintMs: lcpTiming(lcp),
           largestContentfulPaintSize: finiteNumberOrNull(lcp?.size),
           largestContentfulPaintElement: typeof lcp?.element === "string" ? lcp.element : null,
+          largestContentfulPaintUrl: typeof lcp?.url === "string" && lcp.url.length > 0 ? lcp.url : null,
         }
       }
 
@@ -859,5 +861,6 @@ function emptyPaintTimingSummary() {
     largestContentfulPaintMs: null,
     largestContentfulPaintSize: null,
     largestContentfulPaintElement: null,
+    largestContentfulPaintUrl: null,
   }
 }

--- a/scripts/browser-probe-artifact-smoke.ts
+++ b/scripts/browser-probe-artifact-smoke.ts
@@ -75,6 +75,7 @@ const htmlPath = join(artifactDirectory, "files", "browser", "snapshot.html")
 const memoryPath = join(artifactDirectory, "files", "browser", "memory.json")
 const networkPath = join(artifactDirectory, "files", "browser", "network.jsonl")
 const performancePath = join(artifactDirectory, "files", "browser", "performance.json")
+const browserReviewPath = join(artifactDirectory, "files", "browser", "review.json")
 const screenshotPath = join(artifactDirectory, "files", "browser", "screenshot.png")
 const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
 const manifestPath = join(artifactDirectory, "manifest.json")
@@ -87,6 +88,7 @@ assert.equal(existsSync(htmlPath), true, "snapshot.html should be captured")
 assert.equal(existsSync(memoryPath), true, "memory.json should be captured")
 assert.equal(existsSync(networkPath), true, "network.jsonl should be captured")
 assert.equal(existsSync(performancePath), true, "performance.json should be captured")
+assert.equal(existsSync(browserReviewPath), true, "review.json should be captured")
 assert.equal(existsSync(screenshotPath), true, "screenshot.png should be captured")
 assert.equal(existsSync(summaryPath), true, "summary.json should be captured")
 
@@ -135,7 +137,7 @@ const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
   requestedUrl: string
   finalUrl: string
   prePageScript?: { sha256?: string; bytes?: number }
-  files: { checkpoints?: string; html?: string; memory?: string; network?: string; performance?: string; screenshot?: string }
+  files: { checkpoints?: string; html?: string; memory?: string; network?: string; performance?: string; review?: string; screenshot?: string }
   hashes: { html?: { value: string }; screenshot?: { value: string } }
   viewport: { width: number; height: number; userAgent: string }
   capabilities?: {
@@ -157,6 +159,7 @@ const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
     scriptResult?: { title?: string; hasBody?: boolean; observedCapabilities?: { applePay?: boolean; paymentRequest?: boolean; marker?: string } }
     memory?: { usedJSHeapSize: { final: number | null; peak: number | null }; domNodes: { final: number | null; peak: number | null } }
     performance?: { resources: number; domNodes: { final: number | null; peak: number | null }; longTasks: number }
+    review?: { schema: string; timings: { totalDurationMs: { status: string; value: number | null }; ttfbMs: { status: string }; firstContentfulPaintMs: { status: string }; largestContentfulPaintMs: { status: string }; loadEventMs: { status: string } }; network: { status: string; events: number; byHost: Record<string, { requests: number; responses: number; failures: number }>; waterfall?: { path: string } }; milestones: { status: string; count: number; names: string[] }; artifacts: { network?: { path: string }; performance?: { path: string }; screenshot?: { sha256?: string } } }
     capabilities?: {
       secureContext: boolean
       userAgent: string
@@ -178,6 +181,7 @@ assert.equal(summary.files.checkpoints, "files/browser/checkpoints.jsonl")
 assert.equal(summary.files.memory, "files/browser/memory.json")
 assert.equal(summary.files.network, "files/browser/network.jsonl")
 assert.equal(summary.files.performance, "files/browser/performance.json")
+assert.equal(summary.files.review, "files/browser/review.json")
 assert.match(summary.hashes.html?.value ?? "", /^[a-f0-9]{64}$/)
 assert.match(summary.hashes.screenshot?.value ?? "", /^[a-f0-9]{64}$/)
 assert.equal(summary.viewport.width, 390, "summary should record requested viewport width")
@@ -210,6 +214,24 @@ assert.equal(typeof summary.capabilities?.paymentRequest.available, "boolean", "
 assert.ok(summary.capabilities?.permissions.geolocation, "capabilities should include safe permission states")
 assert.ok(["granted", "denied", "prompt", "unsupported", "error"].includes(summary.capabilities?.permissions.geolocation.state ?? ""), "permission state should be normalized")
 
+const browserReview = JSON.parse(await readFile(browserReviewPath, "utf8")) as NonNullable<typeof summary.summary.review>
+assert.equal(browserReview.schema, "wp-codebox/browser-probe-review/v1")
+assert.equal(browserReview.timings.totalDurationMs.status, "available", "review should include wall-clock duration status")
+assert.equal(typeof browserReview.timings.totalDurationMs.value, "number", "review should include wall-clock duration value")
+assert.equal(browserReview.timings.ttfbMs.status, "available", "review should include TTFB status")
+assert.equal(browserReview.timings.firstContentfulPaintMs.status, "available", "review should include FCP status")
+assert.equal(browserReview.timings.largestContentfulPaintMs.status, "available", "review should include LCP status")
+assert.equal(browserReview.timings.loadEventMs.status, "available", "review should include load status")
+assert.equal(browserReview.network.status, "captured", "review should include network status")
+assert.ok(browserReview.network.events >= 1, "review should include network event count")
+assert.ok(Object.keys(browserReview.network.byHost).length >= 1, "review should include network counts by host")
+assert.equal(browserReview.network.waterfall?.path, "files/browser/network.jsonl", "review should link waterfall-friendly network events")
+assert.equal(browserReview.milestones.status, "captured", "review should include script milestone status")
+assert.ok(browserReview.milestones.names.includes("fixture-before-return"), "review should include script milestone names")
+assert.equal(browserReview.artifacts.performance?.path, "files/browser/performance.json", "review should include performance artifact ref")
+assert.match(browserReview.artifacts.screenshot?.sha256 ?? "", /^[a-f0-9]{64}$/)
+assert.deepEqual(summary.summary.review, browserReview, "summary should embed the same stable browser review artifact")
+
 const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
 assert.ok(manifest.files.some((file) => file.path === "files/browser/console.jsonl" && file.kind === "browser-console"))
 assert.ok(manifest.files.some((file) => file.path === "files/browser/checkpoints.jsonl" && file.kind === "browser-checkpoints"))
@@ -218,6 +240,7 @@ assert.ok(manifest.files.some((file) => file.path === "files/browser/snapshot.ht
 assert.ok(manifest.files.some((file) => file.path === "files/browser/memory.json" && file.kind === "browser-memory"))
 assert.ok(manifest.files.some((file) => file.path === "files/browser/network.jsonl" && file.kind === "browser-network"))
 assert.ok(manifest.files.some((file) => file.path === "files/browser/performance.json" && file.kind === "browser-performance"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/review.json" && file.kind === "browser-review"))
 assert.ok(manifest.files.some((file) => file.path === "files/browser/screenshot.png" && file.kind === "browser-screenshot"))
 
 const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ consoleMessages: number; errors: number; checkpoints?: string; html?: string; memory?: string; network?: string; performance?: string; finalUrl?: string; replayability?: string; viewport?: { width: number; height: number }; capabilities?: { secureContext: boolean; paymentRequest: { available: boolean }; maxTouchPoints: number; permissions: Record<string, { state: string }> } }> } }

--- a/scripts/browser-probe-context-smoke.ts
+++ b/scripts/browser-probe-context-smoke.ts
@@ -46,6 +46,14 @@ try {
   assert.equal(summary.context?.effective?.viewport?.isMobile, true)
   assert.equal(summary.context?.effective?.viewport?.width, summary.viewport.width)
   assert.equal(summary.context?.effective?.viewport?.height, summary.viewport.height)
+  assert.equal(summary.files?.review, "files/browser/review.json")
+  assert.equal(summary.summary?.review?.timings?.ttfbMs?.status, "missing", "review should explicitly mark missing TTFB without performance capture")
+  assert.equal(summary.summary?.review?.timings?.ttfbMs?.reason, "capture=performance was not requested")
+  assert.equal(summary.summary?.review?.network?.status, "not-captured", "review should explicitly mark missing network capture")
+
+  const browserReview = JSON.parse(await readFile(join(output.artifacts.directory, "files", "browser", "review.json"), "utf8"))
+  assert.equal(browserReview.timings.ttfbMs.status, "missing")
+  assert.equal(browserReview.timings.ttfbMs.reason, "capture=performance was not requested")
 
   console.log("Browser probe context smoke passed")
 } finally {

--- a/scripts/recipe-browser-bench-metrics-smoke.ts
+++ b/scripts/recipe-browser-bench-metrics-smoke.ts
@@ -129,7 +129,11 @@ const browserMetrics = await runCli([
 
 assert.equal(browserMetrics.schema, "wp-codebox/browser-metrics/v1")
 assert.equal(browserMetrics.hasBrowserMetrics, true)
-assert.deepEqual(browserMetrics.metrics, expectedBrowserMetrics)
+assert.deepEqual(pick(browserMetrics.metrics, Object.keys(expectedBrowserMetrics)), expectedBrowserMetrics)
+for (const metric of ["browser_nav_duration_ms", "browser_dom_content_loaded_ms", "browser_load_event_ms", "browser_response_start_ms", "browser_response_end_ms", "browser_request_start_ms", "browser_ttfb_ms", "browser_redirect_ms", "browser_first_paint_ms", "browser_fcp_ms", "browser_lcp_ms", "browser_lcp_size"]) {
+  assert.equal(typeof browserMetrics.metrics[metric], "number", `${metric} should be exposed by browser-metrics`)
+  assert.ok(browserMetrics.metrics[metric] >= 0, `${metric} should be non-negative`)
+}
 assert.equal(browserMetrics.artifacts.summary.path, "files/browser/summary.json")
 assert.equal(browserMetrics.artifacts.memory.path, "files/browser/memory.json")
 assert.equal(browserMetrics.artifacts.performance.path, "files/browser/performance.json")
@@ -185,4 +189,8 @@ async function runCli(args: string[]): Promise<any> {
   const exitCode = await new Promise<number | null>((resolveExit) => child.once("exit", (code) => resolveExit(code)))
   assert.equal(exitCode, 0, `CLI exited with ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
   return JSON.parse(stdout)
+}
+
+function pick(source: Record<string, number>, keys: string[]): Record<string, number> {
+  return Object.fromEntries(keys.map((key) => [key, source[key]]))
 }

--- a/tests/fixtures/artifact-package-provenance-shape.json
+++ b/tests/fixtures/artifact-package-provenance-shape.json
@@ -2,15 +2,15 @@
   "schema": "wp-codebox/package-provenance/v1",
   "wpCodebox": {
     "name": "wp-codebox-workspace",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "runtimeCore": {
     "name": "@automattic/wp-codebox-core",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "runtimePlayground": {
     "name": "@automattic/wp-codebox-playground",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "playground": {
     "cli": {


### PR DESCRIPTION
## Summary
- Adds a stable `wp-codebox/browser-probe-review/v1` JSON artifact for `wordpress.browser-probe` runs, linked from `summary.json` and the artifact manifest.
- Captures reviewer-safe browser/runtime/profile metadata, explicit metric availability statuses, timing summaries, LCP details, network breakdowns, milestone refs, and artifact refs without embedding large payloads.
- Fixes standard-gate issues surfaced during verification: stale package provenance fixture, richer browser-metrics smoke expectations, and lazy workflow-step execution so fast `recipe-run --json` failures serialize instead of escaping as uncaught errors.

Closes #721.

## Verification
- `npm run build`
- `npm run browser-probe-artifact-smoke`
- `npm run browser-probe-web-performance-smoke`
- `npm run browser-probe-context-smoke`
- `npm run artifact-redaction-smoke`
- `npm run browser-probe-assertions-smoke`
- `npm run browser-probe-layout-shift-smoke`
- `npm run browser-probe-public-url-routing-smoke`
- `npm run browser-probe-profile-matrix-smoke`
- `npm run browser-probe-pre-page-script-smoke`
- `npm run recipe-browser-probe-liveness-smoke`
- `npm run artifact-contract-smoke`
- `npm run recipe-browser-bench-metrics-smoke`
- `npm run recipe-playground-boot-failure-smoke`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and iterated on the browser-probe review artifact implementation, smoke coverage, and gate fixes; Chris remains responsible for review and validation.