### PR TITLE
Route browser probe redirects locally

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -277,7 +277,7 @@ async function runSingleBrowserProbeCommand({
   let artifact: BrowserProbeArtifact | undefined
 
   try {
-    context = requestedContext.device || requestedContext.locale || requestedContext.timezone || requestedContext.userAgent || (requestedContext.permissions?.length ?? 0) > 0
+    context = routedHosts.length > 0 || requestedContext.device || requestedContext.locale || requestedContext.timezone || requestedContext.userAgent || (requestedContext.permissions?.length ?? 0) > 0
       ? await browser.newContext({
         ...(deviceProfile ?? {}),
         ...(requestedContext.locale ? { locale: requestedContext.locale } : {}),
@@ -288,6 +288,9 @@ async function runSingleBrowserProbeCommand({
     if (context && requestedContext.permissions && requestedContext.permissions.length > 0) {
       await context.grantPermissions(requestedContext.permissions)
     }
+    if (context && routedHosts.length > 0) {
+      await routeBrowserProbeContextHosts(context, routedHosts, preview.localOrigin)
+    }
     page = context ? await context.newPage() : await browser.newPage()
     if (requestedViewport) {
       await page.setViewportSize(requestedViewport)
@@ -295,8 +298,8 @@ async function runSingleBrowserProbeCommand({
     if (throttleProfile) {
       await applyBrowserProbeThrottleProfile(page, throttleProfile)
     }
-    if (routedHosts.length > 0) {
-      await routeBrowserProbeHosts(page, routedHosts, preview.localOrigin)
+    if (!context && routedHosts.length > 0) {
+      await routeBrowserProbePageHosts(page, routedHosts, preview.localOrigin)
     }
     await page.addInitScript(BROWSER_PROBE_STATE_INIT_SCRIPT)
     if (lifecycleSelectors.length > 0) {
@@ -2371,14 +2374,22 @@ function now(): string {
   return new Date().toISOString()
 }
 
-async function routeBrowserProbeHosts(page: Page, hosts: string[], localPreviewOrigin: string): Promise<void> {
+async function routeBrowserProbePageHosts(page: Page, hosts: string[], localPreviewOrigin: string): Promise<void> {
+  await routeBrowserProbeHosts(page.route.bind(page), hosts, localPreviewOrigin)
+}
+
+async function routeBrowserProbeContextHosts(context: import("playwright").BrowserContext, hosts: string[], localPreviewOrigin: string): Promise<void> {
+  await routeBrowserProbeHosts(context.route.bind(context), hosts, localPreviewOrigin)
+}
+
+async function routeBrowserProbeHosts(routePattern: (url: string, handler: (route: Route) => Promise<void>) => Promise<unknown>, hosts: string[], localPreviewOrigin: string): Promise<void> {
   const routedHosts = new Set(hosts.map((host) => host.trim().toLowerCase()).filter(Boolean))
   if (routedHosts.size === 0) {
     return
   }
 
   const localOrigin = new URL(localPreviewOrigin)
-  await page.context().route("**/*", async (route) => {
+  await routePattern("**/*", async (route) => {
     const request = route.request()
     let requestUrl: URL
     try {
@@ -2393,7 +2404,15 @@ async function routeBrowserProbeHosts(page: Page, hosts: string[], localPreviewO
       return
     }
 
-    const routedUrl = new URL(requestUrl.toString())
+    const response = await fetchBrowserProbeRoutedHost(route, requestUrl, routedHosts, localOrigin)
+    await route.fulfill({ response })
+  })
+}
+
+async function fetchBrowserProbeRoutedHost(route: Route, requestUrl: URL, routedHosts: Set<string>, localOrigin: URL): Promise<Awaited<ReturnType<Route["fetch"]>>> {
+  let currentUrl = requestUrl
+  for (let redirectCount = 0; redirectCount < 10; redirectCount++) {
+    const routedUrl = new URL(currentUrl.toString())
     routedUrl.protocol = localOrigin.protocol
     routedUrl.hostname = localOrigin.hostname
     routedUrl.port = localOrigin.port
@@ -2401,16 +2420,29 @@ async function routeBrowserProbeHosts(page: Page, hosts: string[], localPreviewO
     const response = await route.fetch({
       url: routedUrl.toString(),
       headers: {
-        ...request.headers(),
-        host: requestUrl.host,
-        "x-forwarded-host": requestUrl.host,
-        "x-forwarded-port": requestUrl.port || (requestUrl.protocol === "https:" ? "443" : "80"),
-        "x-forwarded-proto": requestUrl.protocol.replace(":", ""),
+        ...route.request().headers(),
+        host: currentUrl.host,
+        "x-forwarded-host": currentUrl.host,
+        "x-forwarded-port": currentUrl.port || (currentUrl.protocol === "https:" ? "443" : "80"),
+        "x-forwarded-proto": currentUrl.protocol.replace(":", ""),
       },
       maxRedirects: 0,
     })
-    await route.fulfill({ response })
-  })
+
+    const location = response.headers().location
+    if (!location || response.status() < 300 || response.status() >= 400) {
+      return response
+    }
+
+    const redirectedUrl = new URL(location, currentUrl)
+    if (!routedHosts.has(redirectedUrl.hostname.toLowerCase())) {
+      return response
+    }
+
+    currentUrl = redirectedUrl
+  }
+
+  throw new Error(`wordpress.browser-probe route-host exceeded redirect limit for ${requestUrl.href}`)
 }
 
 function browserProbePreviewOrigins(preview: BrowserProbePreviewRouting): { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string } {

--- a/scripts/browser-probe-route-host-smoke.ts
+++ b/scripts/browser-probe-route-host-smoke.ts
@@ -16,6 +16,11 @@ try {
     const forwardedHost = request.headers["x-forwarded-host"] ?? ""
     const forwardedPort = request.headers["x-forwarded-port"] ?? ""
     const forwardedProto = request.headers["x-forwarded-proto"] ?? ""
+    if (request.url === "/redirect-to-https/") {
+      response.writeHead(301, { location: `https://${host}/redirected/` })
+      response.end("redirect")
+      return
+    }
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" })
     response.end(`<!doctype html><title>Probe</title><main data-path="${request.url ?? "/"}" data-host="${host}" data-forwarded-host="${forwardedHost}" data-forwarded-port="${forwardedPort}" data-forwarded-proto="${forwardedProto}">OK</main>`)
   })
@@ -65,6 +70,29 @@ try {
   assert.match(html, /data-forwarded-host="example\.test"/)
   assert.match(html, /data-forwarded-port="443"/)
   assert.match(html, /data-forwarded-proto="https"/)
+
+  const redirectProbe = await runBrowserProbeCommand({
+    artifactRoot: workspace,
+    runtimeSpec,
+    server: serverRef,
+    spec: {
+      command: "wordpress.browser-probe",
+      args: [
+        "url=http://example.test/redirect-to-https/",
+        "route-host=example.test",
+        "wait-for=domcontentloaded",
+        "capture=html,network",
+      ],
+    },
+  })
+
+  assert.equal(redirectProbe.artifact.requestedUrl, "http://example.test/redirect-to-https/")
+  assert.equal(redirectProbe.artifact.summary.finalUrl, "http://example.test/redirect-to-https/")
+
+  const redirectedHtml = await readFile(join(workspace, "files", "browser", "snapshot.html"), "utf8")
+  assert.match(redirectedHtml, /data-path="\/redirected\/"/)
+  assert.match(redirectedHtml, /data-host="example\.test"/)
+  assert.match(redirectedHtml, /data-forwarded-proto="https"/)
 
   console.log("Browser probe route-host smoke passed")
 } finally {


### PR DESCRIPTION
## Summary
- Route `wordpress.browser-probe` `route-host` requests at the browser-context level so navigation redirects are captured before page creation.
- Follow redirects locally when the redirect target host is also routed, preserving `Host` and forwarded protocol headers for WPCOM-style HTTP-to-HTTPS flows.
- Extend the route-host smoke test to cover routed HTTPS redirects.

## Verification
- `npm run build -- --pretty false`
- `npm run php-wasm-preflight-smoke`
- `npm run playground-wordpress-directory-asset-smoke`
- `npm run browser-probe-route-host-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting and verifying the browser routing fix and smoke coverage; Chris remains responsible for review and merge.