### PR TITLE
Use generic artifact preview naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "policy-validation-smoke": "tsx scripts/policy-validation-smoke.ts",
     "workspace-policy-smoke": "tsx scripts/workspace-policy-smoke.ts",
     "artifact-contract-smoke": "tsx scripts/artifact-contract-smoke.ts",
-    "durable-static-preview-smoke": "tsx scripts/durable-static-preview-smoke.ts",
+    "durable-artifact-preview-smoke": "tsx scripts/durable-artifact-preview-smoke.ts",
     "external-adapter-contract-smoke": "tsx scripts/external-adapter-contract-smoke.ts",
     "command-registry-smoke": "tsx scripts/command-registry-smoke.ts",
     "host-tool-registry-smoke": "tsx scripts/host-tool-registry-smoke.ts",

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -689,7 +689,7 @@ export interface ArtifactPreviewUrlRef {
 }
 
 export interface ArtifactDurablePreviewRef {
-  kind: "static-artifact-preview"
+  kind: "artifact-preview"
   reviewerSafe: true
   durable: true
   entrypoint: string

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -121,7 +121,7 @@ export class ArtifactBundleBuilder {
     const preview = await source.previewInfo(createdAt, spec.previewHoldSeconds)
     const browser = source.browserReviewSummary()
     const runtime = await source.info()
-    const durablePreview = await buildDurableStaticPreview({
+    const durablePreview = await buildDurableArtifactPreview({
       artifactRoot: source.artifactRoot,
       createdAt,
       probes: source.browserArtifacts(),
@@ -646,7 +646,7 @@ function buildPreviewSessionEvidence({
       runtimeReferenceManifest: evidenceRef(paths.runtimeReferenceManifest, "runtime-reference-manifest"),
       runtimeReplayReferenceIndex: evidenceRef(paths.runtimeReplayReferenceIndex, "runtime-replay-index"),
       browserSummary: browser && paths.browserSummary ? evidenceRef(paths.browserSummary, "browser-summary") : undefined,
-      durablePreview: durablePreview && paths.durablePreview ? evidenceRef(paths.durablePreview, "static-artifact-preview") : undefined,
+      durablePreview: durablePreview && paths.durablePreview ? evidenceRef(paths.durablePreview, "artifact-preview") : undefined,
     }),
     components: packages,
   })
@@ -656,27 +656,27 @@ function evidenceRef(path: string, kind: string, contentType = "application/json
   return { path, kind, contentType }
 }
 
-interface DurableStaticPreviewBuildResult {
+interface DurableArtifactPreviewBuildResult {
   preview: ArtifactDurablePreviewRef
   manifestFiles: ArtifactManifestFile[]
 }
 
-interface BrowserStaticArtifactBundle {
+interface BrowserArtifactBundleWithFiles {
   probe: number
   schema?: string
   root?: string
   entrypoint?: string
-  files: BrowserStaticArtifactFile[]
+  files: BrowserArtifactFile[]
 }
 
-interface BrowserStaticArtifactFile {
+interface BrowserArtifactFile {
   path: string
   content: string
   encoding: string
   contentType: string
 }
 
-async function buildDurableStaticPreview({
+async function buildDurableArtifactPreview({
   artifactRoot,
   createdAt,
   probes,
@@ -686,25 +686,25 @@ async function buildDurableStaticPreview({
   createdAt: string
   probes: BrowserProbeArtifact[]
   redactor: ArtifactRedactor
-}): Promise<DurableStaticPreviewBuildResult | undefined> {
-  const bundle = findBrowserStaticArtifactBundle(probes)
+}): Promise<DurableArtifactPreviewBuildResult | undefined> {
+  const bundle = findBrowserArtifactBundleWithFiles(probes)
   if (!bundle) {
     return undefined
   }
 
-  const staticRoot = "files/static-preview/site"
-  const manifestPath = "files/static-preview/manifest.json"
+  const previewRoot = "files/artifact-preview/files"
+  const manifestPath = "files/artifact-preview/manifest.json"
   const files: ArtifactEvidenceRef[] = []
   const manifestFiles: ArtifactManifestFile[] = []
   const writtenPaths = new Set<string>()
 
   for (const file of bundle.files) {
-    const relativePath = safeStaticPreviewPath(file.path)
+    const relativePath = safeArtifactPreviewPath(file.path)
     if (!relativePath || writtenPaths.has(relativePath)) {
       continue
     }
 
-    const artifactPath = `${staticRoot}/${relativePath}`
+    const artifactPath = `${previewRoot}/${relativePath}`
     const absolutePath = join(artifactRoot, artifactPath)
     const contents = file.encoding === "base64" ? Buffer.from(file.content, "base64") : Buffer.from(file.content, "utf8")
     const writtenContents = file.encoding === "base64" ? contents : Buffer.from(redactor.redact(artifactPath, contents.toString("utf8")), "utf8")
@@ -713,7 +713,7 @@ async function buildDurableStaticPreview({
 
     const ref = {
       path: artifactPath,
-      kind: relativePath === "index.html" ? "static-preview-entrypoint" : "static-preview-file",
+      kind: relativePath === "index.html" ? "artifact-preview-entrypoint" : "artifact-preview-file",
       contentType: file.contentType,
       sha256: artifactFileDigest(writtenContents),
     }
@@ -726,17 +726,17 @@ async function buildDurableStaticPreview({
     return undefined
   }
 
-  const entrypoint = durablePreviewEntrypoint(bundle, files, staticRoot)
+  const entrypoint = durablePreviewEntrypoint(bundle, files, previewRoot)
   if (!entrypoint) {
     return undefined
   }
 
   const preview: ArtifactDurablePreviewRef = {
-    kind: "static-artifact-preview",
+    kind: "artifact-preview",
     reviewerSafe: true,
     durable: true,
     entrypoint,
-    manifest: evidenceRef(manifestPath, "static-artifact-preview"),
+    manifest: evidenceRef(manifestPath, "artifact-preview"),
     source: stripUndefined({
       kind: "browser-runtime-artifact-bundle" as const,
       probe: bundle.probe,
@@ -747,7 +747,7 @@ async function buildDurableStaticPreview({
     files,
   }
   const manifest = {
-    schema: "wp-codebox/static-artifact-preview/v1",
+    schema: "wp-codebox/artifact-preview/v1",
     createdAt,
     reviewerSafe: true,
     durable: true,
@@ -758,12 +758,12 @@ async function buildDurableStaticPreview({
   const manifestJson = redactor.redact(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
   await writeFile(join(artifactRoot, manifestPath), manifestJson)
   preview.manifest.sha256 = artifactFileDigest(manifestJson)
-  manifestFiles.unshift(artifactManifestFile(join(artifactRoot, manifestPath), "static-artifact-preview", "application/json"))
+  manifestFiles.unshift(artifactManifestFile(join(artifactRoot, manifestPath), "artifact-preview", "application/json"))
 
   return { preview, manifestFiles }
 }
 
-function findBrowserStaticArtifactBundle(probes: BrowserProbeArtifact[]): BrowserStaticArtifactBundle | undefined {
+function findBrowserArtifactBundleWithFiles(probes: BrowserProbeArtifact[]): BrowserArtifactBundleWithFiles | undefined {
   for (const [index, probe] of probes.entries()) {
     const scriptResult = asRecord(probe.summary.scriptResult)
     const candidate = asRecord(scriptResult?.artifact_bundle) ?? asRecord(scriptResult?.artifactBundle) ?? scriptResult
@@ -777,7 +777,7 @@ function findBrowserStaticArtifactBundle(probes: BrowserProbeArtifact[]): Browse
       continue
     }
 
-    const materializableFiles = files.flatMap((file) => materializableStaticFile(file))
+    const materializableFiles = files.flatMap((file) => materializableArtifactFile(file))
     if (materializableFiles.length === 0) {
       continue
     }
@@ -794,7 +794,7 @@ function findBrowserStaticArtifactBundle(probes: BrowserProbeArtifact[]): Browse
   return undefined
 }
 
-function materializableStaticFile(value: unknown): BrowserStaticArtifactFile[] {
+function materializableArtifactFile(value: unknown): BrowserArtifactFile[] {
   const file = asRecord(value)
   if (!file) {
     return []
@@ -815,30 +815,30 @@ function materializableStaticFile(value: unknown): BrowserStaticArtifactFile[] {
     path,
     content,
     encoding: encoding === "utf-8" ? "utf8" : encoding,
-    contentType: stringValue(file.contentType) ?? stringValue(file.content_type) ?? stringValue(file.mime_type) ?? staticPreviewContentType(path),
+    contentType: stringValue(file.contentType) ?? stringValue(file.content_type) ?? stringValue(file.mime_type) ?? artifactPreviewContentType(path),
   }]
 }
 
-function durablePreviewEntrypoint(bundle: BrowserStaticArtifactBundle, files: ArtifactEvidenceRef[], staticRoot: string): string | undefined {
-  const relativePaths = new Set(files.map((file) => file.path.slice(`${staticRoot}/`.length)))
+function durablePreviewEntrypoint(bundle: BrowserArtifactBundleWithFiles, files: ArtifactEvidenceRef[], previewRoot: string): string | undefined {
+  const relativePaths = new Set(files.map((file) => file.path.slice(`${previewRoot}/`.length)))
   const candidates = [
     bundle.entrypoint,
-    stripStaticPreviewRoot(bundle.entrypoint, bundle.root),
+    stripArtifactPreviewRoot(bundle.entrypoint, bundle.root),
     "index.html",
-  ].flatMap((path) => path ? [safeStaticPreviewPath(path)] : []).filter((path): path is string => Boolean(path))
+  ].flatMap((path) => path ? [safeArtifactPreviewPath(path)] : []).filter((path): path is string => Boolean(path))
 
   for (const candidate of candidates) {
     if (relativePaths.has(candidate)) {
-      return `${staticRoot}/${candidate}`
+      return `${previewRoot}/${candidate}`
     }
   }
 
   return files.find((file) => file.path.endsWith(".html"))?.path ?? files[0]?.path
 }
 
-function stripStaticPreviewRoot(path: string | undefined, root: string | undefined): string | undefined {
-  const safeRoot = root ? safeStaticPreviewPath(root) : undefined
-  const safePath = path ? safeStaticPreviewPath(path) : undefined
+function stripArtifactPreviewRoot(path: string | undefined, root: string | undefined): string | undefined {
+  const safeRoot = root ? safeArtifactPreviewPath(root) : undefined
+  const safePath = path ? safeArtifactPreviewPath(path) : undefined
   if (!safeRoot || !safePath || safePath === safeRoot) {
     return undefined
   }
@@ -846,7 +846,7 @@ function stripStaticPreviewRoot(path: string | undefined, root: string | undefin
   return safePath.startsWith(`${safeRoot}/`) ? safePath.slice(safeRoot.length + 1) : undefined
 }
 
-function safeStaticPreviewPath(path: string): string | undefined {
+function safeArtifactPreviewPath(path: string): string | undefined {
   const normalized = path.replace(/\\/g, "/").replace(/^\/+/, "").split("/").filter((part) => part.length > 0 && part !== ".")
   if (normalized.length === 0 || normalized.some((part) => part === "..")) {
     return undefined
@@ -855,7 +855,7 @@ function safeStaticPreviewPath(path: string): string | undefined {
   return normalized.join("/")
 }
 
-function staticPreviewContentType(path: string): string {
+function artifactPreviewContentType(path: string): string {
   const normalized = path.toLowerCase()
   if (normalized.endsWith(".html") || normalized.endsWith(".htm")) {
     return "text/html; charset=utf-8"

--- a/scripts/durable-artifact-preview-smoke.ts
+++ b/scripts/durable-artifact-preview-smoke.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { ArtifactBundleBuilder, type ArtifactBundleBuilderSource } from "../packages/runtime-playground/src/artifact-bundle-builder.js"
 
-const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-durable-static-preview-"))
+const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-durable-artifact-preview-"))
 
 try {
   const browserArtifact = {
@@ -30,7 +30,7 @@ try {
       scriptResult: {
         phase: "editable_preview_ready",
         artifact_bundle: {
-          schema: "wp-codebox/browser-runtime-website-artifact/v1",
+          schema: "wp-codebox/browser-runtime-artifact-bundle/v1",
           root: "public",
           entrypoint: "public/index.html",
           files: [
@@ -53,11 +53,11 @@ try {
 
   const source: ArtifactBundleBuilderSource = {
     artifactRoot,
-    runtimeId: "runtime-durable-static-preview-smoke",
+    runtimeId: "runtime-durable-artifact-preview-smoke",
     runtimeCreatedAt: "2026-01-01T00:00:00.000Z",
     spec: {
       backend: "wordpress-playground",
-      environment: { kind: "wordpress", name: "durable-static-preview-smoke", version: "latest" },
+      environment: { kind: "wordpress", name: "durable-artifact-preview-smoke", version: "latest" },
       policy: { network: "allow", filesystem: "readwrite-mounts", commands: ["wordpress.browser-probe"], secrets: "none", approvals: "never" },
     },
     mounts: [],
@@ -67,9 +67,9 @@ try {
     events: [],
     async info() {
       return {
-        id: "runtime-durable-static-preview-smoke",
+        id: "runtime-durable-artifact-preview-smoke",
         backend: "wordpress-playground",
-        environment: { kind: "wordpress", name: "durable-static-preview-smoke", version: "latest" },
+        environment: { kind: "wordpress", name: "durable-artifact-preview-smoke", version: "latest" },
         createdAt: "2026-01-01T00:00:00.000Z",
         status: "destroyed",
       }
@@ -120,30 +120,30 @@ try {
   }
 
   const bundle = await new ArtifactBundleBuilder(source).build()
-  assert.equal(bundle.durablePreview?.kind, "static-artifact-preview")
+  assert.equal(bundle.durablePreview?.kind, "artifact-preview")
   assert.equal(bundle.durablePreview?.reviewerSafe, true)
   assert.equal(bundle.durablePreview?.durable, true)
-  assert.equal(bundle.durablePreview?.entrypoint, "files/static-preview/site/public/index.html")
+  assert.equal(bundle.durablePreview?.entrypoint, "files/artifact-preview/files/public/index.html")
   assert.equal(bundle.durablePreview?.source.kind, "browser-runtime-artifact-bundle")
-  assert.equal(bundle.durablePreview?.source.schema, "wp-codebox/browser-runtime-website-artifact/v1")
+  assert.equal(bundle.durablePreview?.source.schema, "wp-codebox/browser-runtime-artifact-bundle/v1")
 
-  const staticHtml = await readFile(join(artifactRoot, "files/static-preview/site/public/index.html"), "utf8")
-  assert.match(staticHtml, /Reviewer safe/)
+  const artifactHtml = await readFile(join(artifactRoot, "files/artifact-preview/files/public/index.html"), "utf8")
+  assert.match(artifactHtml, /Reviewer safe/)
 
-  const staticManifest = JSON.parse(await readFile(join(artifactRoot, "files/static-preview/manifest.json"), "utf8"))
-  assert.equal(staticManifest.schema, "wp-codebox/static-artifact-preview/v1")
-  assert.equal(staticManifest.entrypoint, "files/static-preview/site/public/index.html")
-  assert.equal(staticManifest.files.length, 2)
+  const previewManifest = JSON.parse(await readFile(join(artifactRoot, "files/artifact-preview/manifest.json"), "utf8"))
+  assert.equal(previewManifest.schema, "wp-codebox/artifact-preview/v1")
+  assert.equal(previewManifest.entrypoint, "files/artifact-preview/files/public/index.html")
+  assert.equal(previewManifest.files.length, 2)
 
   const metadata = JSON.parse(await readFile(bundle.metadataPath, "utf8"))
   const previewEvidence = JSON.parse(await readFile(bundle.previewEvidencePath ?? "", "utf8"))
   const previewSessionEvidence = JSON.parse(await readFile(bundle.previewSessionEvidencePath ?? "", "utf8"))
-  assert.equal(metadata.artifacts.durablePreview, "files/static-preview/manifest.json")
-  assert.equal(metadata.durablePreview.entrypoint, "files/static-preview/site/public/index.html")
-  assert.equal(previewEvidence.preview.durablePreview.entrypoint, "files/static-preview/site/public/index.html")
-  assert.equal(previewSessionEvidence.refs.durablePreview.path, "files/static-preview/manifest.json")
+  assert.equal(metadata.artifacts.durablePreview, "files/artifact-preview/manifest.json")
+  assert.equal(metadata.durablePreview.entrypoint, "files/artifact-preview/files/public/index.html")
+  assert.equal(previewEvidence.preview.durablePreview.entrypoint, "files/artifact-preview/files/public/index.html")
+  assert.equal(previewSessionEvidence.refs.durablePreview.path, "files/artifact-preview/manifest.json")
 } finally {
   await rm(artifactRoot, { recursive: true, force: true })
 }
 
-console.log("Durable static preview smoke passed")
+console.log("Durable artifact preview smoke passed")


### PR DESCRIPTION
## Summary
- Renames the durable preview contract from `static-artifact-preview` to the generic `artifact-preview` kind.
- Moves materialized preview files from `files/static-preview/site/*` to `files/artifact-preview/files/*` so WP Codebox does not encode site/website semantics.
- Updates the smoke fixture schema and command from website/static-preview wording to generic artifact-bundle/artifact-preview wording.

## Why
PR #736 added the right durable preview behavior, but its names implied WP Codebox understood static sites or website artifacts. WP Codebox should only know how to expose a preview for a generic artifact bundle with files and an entrypoint.

## Verification
- `npm run durable-artifact-preview-smoke`
- `npm run artifact-contract-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Renaming the durable preview contract and smoke coverage to preserve the generic WP Codebox boundary after Chris identified leaked static-site/website terminology.