### PR TITLE
Fix GitHub release recipe source redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "recipe-build-cli-smoke": "tsx scripts/recipe-build-cli-smoke.ts",
     "recipe-browser-bench-metrics-smoke": "tsx scripts/recipe-browser-bench-metrics-smoke.ts",
     "recipe-run-php-plugin-load-smoke": "tsx scripts/recipe-run-php-plugin-load-smoke.ts",
+    "recipe-source-redirect-smoke": "tsx scripts/recipe-source-redirect-smoke.ts",
     "run-php-plugin-diagnostics-smoke": "tsx scripts/run-php-plugin-diagnostics-smoke.ts",
     "recipe-browser-smoke": "tsx scripts/recipe-browser-smoke.ts",
     "headless-browser-agent-recipe-smoke": "tsx scripts/headless-browser-agent-recipe-smoke.ts",

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -104,7 +104,7 @@ export const MAX_EXTRACTED_FILES_ENV = "WP_CODEBOX_MAX_EXTRACTED_FILES"
 const DEFAULT_ALLOWED_DOWNLOAD_HOSTS = ["downloads.wordpress.org"]
 const DEFAULT_MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
 const DEFAULT_MAX_EXTRACTED_BYTES = 100 * 1024 * 1024
-const DEFAULT_MAX_EXTRACTED_FILES = 2000
+const DEFAULT_MAX_EXTRACTED_FILES = 5000
 const execFileAsync = promisify(execFile)
 const PHP_SCOPER_VERSION = "0.18.17"
 const PHP_SCOPER_URL = `https://github.com/humbug/php-scoper/releases/download/${PHP_SCOPER_VERSION}/php-scoper.phar`
@@ -671,7 +671,7 @@ async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, s
   const zipPath = join(directory, "source.zip")
   const extractDirectory = join(directory, "extracted")
   await mkdir(extractDirectory, { recursive: true })
-  const digest = await downloadRecipeSourceZip(source.resolvedUrl, zipPath, source.expectedSha256)
+  const digest = await downloadRecipeSourceZip(source, zipPath)
   await assertSafeZipEntries(zipPath)
   await execFileAsync("unzip", ["-q", zipPath, "-d", extractDirectory])
   await assertExtractedSourceBounds(extractDirectory)
@@ -694,37 +694,31 @@ async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, s
   }
 }
 
-async function downloadRecipeSourceZip(url: string, targetPath: string, expectedSha256?: string): Promise<string> {
-  const response = await fetch(url)
+async function downloadRecipeSourceZip(source: ParsedRecipeSource, targetPath: string): Promise<string> {
+  const response = await fetch(source.resolvedUrl)
   if (!response.ok || !response.body) {
-    throw new Error(`Failed to download recipe source ${url}: HTTP ${response.status}`)
+    throw new Error(`Failed to download recipe source ${source.resolvedUrl}: HTTP ${response.status}`)
   }
 
-  const finalUrl = response.url || url
-  let finalSource: ParsedRecipeSource
-  try {
-    finalSource = recipeSource(finalUrl, expectedSha256)
-  } catch (error) {
-    throw new Error(`Recipe source redirected to an invalid URL: ${error instanceof Error ? error.message : String(error)}`)
-  }
+  const finalSource = recipeRedirectSource(source, response.url || source.resolvedUrl, response.headers)
 
   if (finalSource.type === "local" || !allowedDownloadHosts().includes(finalSource.host)) {
-    throw new Error(`Recipe source redirected to a host that is not allowed: ${finalSource.host || finalUrl}`)
+    throw new Error(`Recipe source redirected to a host that is not allowed: ${finalSource.host || finalSource.resolvedUrl}`)
   }
 
   const contentLength = Number(response.headers.get("content-length") ?? "0")
   if (contentLength > maxDownloadBytes()) {
-    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${url}`)
+    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${source.resolvedUrl}`)
   }
 
   const buffer = Buffer.from(await response.arrayBuffer())
   if (buffer.byteLength > maxDownloadBytes()) {
-    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${url}`)
+    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${source.resolvedUrl}`)
   }
 
   const digest = createHash("sha256").update(buffer).digest("hex")
-  if (expectedSha256 && digest !== expectedSha256.toLowerCase()) {
-    throw new Error(`Recipe source sha256 mismatch for ${url}: expected ${expectedSha256.toLowerCase()}, got ${digest}`)
+  if (source.expectedSha256 && digest !== source.expectedSha256.toLowerCase()) {
+    throw new Error(`Recipe source sha256 mismatch for ${source.resolvedUrl}: expected ${source.expectedSha256.toLowerCase()}, got ${digest}`)
   }
 
   await writeFile(targetPath, buffer)
@@ -911,6 +905,36 @@ export function recipeSource(sourceRef: string, expectedSha256?: string): Parsed
   }
 
   return { type: "https_zip", resolvedUrl: url.toString(), host: url.hostname, ...(expectedSha256 ? { expectedSha256: expectedSha256.toLowerCase() } : {}) }
+}
+
+export function recipeRedirectSource(source: ParsedRecipeSource, finalSourceRef: string, headers?: Headers): ParsedRecipeSource {
+  if (finalSourceRef === source.resolvedUrl) {
+    return source
+  }
+
+  let url: URL
+  try {
+    url = new URL(finalSourceRef)
+  } catch (error) {
+    throw new Error(`Recipe source redirected to an invalid URL: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  if (url.protocol !== "https:") {
+    throw new Error(`Recipe source redirected to a non-HTTPS URL: ${finalSourceRef}`)
+  }
+
+  const disposition = [headers?.get("content-disposition") ?? "", url.searchParams.get("response-content-disposition") ?? "", url.searchParams.get("rscd") ?? ""].join("\n")
+  const finalPathIsZip = url.pathname.toLowerCase().endsWith(".zip")
+  const finalNameIsZip = /filename\*?\s*=.*\.zip(?:[\s"']|$)/i.test(decodeURIComponent(disposition))
+  if (!finalPathIsZip && !finalNameIsZip) {
+    throw new Error(`Recipe source redirected to a URL that does not identify a zip archive: ${finalSourceRef}`)
+  }
+
+  return {
+    ...source,
+    resolvedUrl: url.toString(),
+    host: url.hostname,
+  }
 }
 
 export function recipeSourceProvenance(source: ParsedRecipeSource, recipeDirectory: string): RecipeSourceProvenance {

--- a/scripts/recipe-source-redirect-smoke.ts
+++ b/scripts/recipe-source-redirect-smoke.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+
+import { recipeRedirectSource, recipeSource } from "../packages/cli/src/recipe-sources.js"
+
+const source = recipeSource(
+  "https://github.com/Extra-Chill/data-machine/releases/download/v0.140.1/data-machine.zip",
+  "2259c9cbf24d9ad199e4b5d64f1fe314640e75b5bf9a4ac4c2dae5360afebc12",
+)
+
+const redirected = recipeRedirectSource(
+  source,
+  "https://release-assets.githubusercontent.com/github-production-release-asset/123/asset-id?response-content-disposition=attachment%3B%20filename%3Ddata-machine.zip&response-content-type=application%2Foctet-stream",
+)
+
+assert.equal(redirected.type, "https_zip")
+assert.equal(redirected.host, "release-assets.githubusercontent.com")
+assert.equal(redirected.expectedSha256, source.expectedSha256)
+
+assert.throws(
+  () => recipeRedirectSource(source, "https://release-assets.githubusercontent.com/github-production-release-asset/123/asset-id?response-content-disposition=attachment%3B%20filename%3Ddata-machine.tar.gz"),
+  /does not identify a zip archive/,
+)
+
+assert.throws(
+  () => recipeRedirectSource(source, "http://release-assets.githubusercontent.com/github-production-release-asset/123/data-machine.zip"),
+  /non-HTTPS URL/,
+)


### PR DESCRIPTION
## Summary
- Allows external recipe source downloads to validate redirected zip archive URLs using response/final URL archive identity instead of requiring the signed redirect path itself to end in `.zip`.
- Keeps final redirect hosts subject to the existing explicit allowlist policy.
- Raises the default extracted-file budget so real packaged WordPress plugin releases such as Data Machine fit under the default source policy.

## Verification
- `npm run build`
- `npm run recipe-source-redirect-smoke`
- `npm run recipe-dry-run-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed GitHub release asset redirect handling during Studio Web Workflow Bench verification, drafted the source-policy fix and smoke coverage, and ran targeted checks for Chris to review.