### PR TITLE
Add artifact diagnostics normalization seam

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "artifact-redaction-smoke": "tsx scripts/artifact-redaction-smoke.ts",
     "artifact-patch-git-apply-smoke": "tsx scripts/artifact-patch-git-apply-smoke.ts",
     "artifact-reference-normalization-smoke": "tsx scripts/artifact-reference-normalization-smoke.ts",
+    "artifact-diagnostics-normalizer-smoke": "tsx scripts/artifact-diagnostics-normalizer-smoke.ts",
     "browser-result-shapes-smoke": "tsx scripts/browser-result-shapes-smoke.ts",
     "partial-artifact-discovery-smoke": "tsx scripts/partial-artifact-discovery-smoke.ts",
     "interrupted-run-evidence-smoke": "tsx scripts/interrupted-run-evidence-smoke.ts",

--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -1,5 +1,5 @@
 import { routeCliCommand } from "./command-router.js"
-import { runArtifactsApplyPreflightCommand, runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsDiscoverPartialCommand, runArtifactsTransferProbesCommand, runArtifactsTransferVerifyCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
+import { runArtifactsApplyPreflightCommand, runArtifactsBenchmarkCommand, runArtifactsBrowserMetricsCommand, runArtifactsDiagnosticsCommand, runArtifactsDiscoverPartialCommand, runArtifactsTransferProbesCommand, runArtifactsTransferVerifyCommand, runArtifactsVerifyCommand } from "./commands/artifacts.js"
 import { runAgentTaskRunCommand } from "./commands/agent-task-run.js"
 import { runArtifactsBenchCompareCommand, runArtifactsBenchResultsCommand, runBenchCompareCommand, runBenchMatrixCommand, runBenchSummarizeCommand } from "./commands/benchmark.js"
 import { runCommandsCommand, runRecipeSchemaCommand } from "./commands/discovery.js"
@@ -24,6 +24,7 @@ export async function runCli(args: string[]): Promise<number> {
     artifactsVerify: runArtifactsVerifyCommand,
     artifactsApplyPreflight: runArtifactsApplyPreflightCommand,
     artifactsBrowserMetrics: runArtifactsBrowserMetricsCommand,
+    artifactsDiagnostics: runArtifactsDiagnosticsCommand,
     artifactsTransferVerify: runArtifactsTransferVerifyCommand,
     artifactsTransferProbes: runArtifactsTransferProbesCommand,
     artifactsBenchmark: runArtifactsBenchmarkCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -14,6 +14,7 @@ interface CliCommandRouter {
   artifactsVerify: CliCommandHandler
   artifactsApplyPreflight: CliCommandHandler
   artifactsBrowserMetrics: CliCommandHandler
+  artifactsDiagnostics: CliCommandHandler
   artifactsTransferVerify: CliCommandHandler
   artifactsTransferProbes: CliCommandHandler
   artifactsBenchmark: CliCommandHandler
@@ -88,6 +89,9 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
       }
       if (subcommand === "browser-metrics") {
         return router.artifactsBrowserMetrics(args)
+      }
+      if (subcommand === "diagnostics") {
+        return router.artifactsDiagnostics(args)
       }
       if (subcommand === "transfer-verify") {
         return router.artifactsTransferVerify(args)

--- a/packages/cli/src/commands/artifacts.ts
+++ b/packages/cli/src/commands/artifacts.ts
@@ -1,6 +1,6 @@
 import { copyFile, mkdir, readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { buildTransferProbeDiagnostics, discoverPartialRunArtifacts, preflightArtifactBundleApply, verifyArtifactBundle, verifyTransferProofBundle, type ArtifactBundleApplyPreflightResult, type ArtifactBundleVerificationResult, type PartialArtifactDiscoveryResult, type TransferProbeDiagnosticsResult, type TransferProofBundleVerificationResult } from "@automattic/wp-codebox-core"
+import { buildArtifactDiagnostics, buildTransferProbeDiagnostics, discoverPartialRunArtifacts, preflightArtifactBundleApply, verifyArtifactBundle, verifyTransferProofBundle, type ArtifactBundleApplyPreflightResult, type ArtifactBundleVerificationResult, type ArtifactDiagnosticNormalizerOptions, type ArtifactDiagnostics, type PartialArtifactDiscoveryResult, type TransferProbeDiagnosticsResult, type TransferProofBundleVerificationResult } from "@automattic/wp-codebox-core"
 import { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "@automattic/wp-codebox-playground"
 import { printArtifactVerifyHumanOutput } from "../output.js"
 
@@ -23,6 +23,11 @@ interface ArtifactDiscoverPartialOptions {
   sessionId?: string
   startedAt?: string
   finishedAt?: string
+  json: boolean
+}
+
+interface ArtifactDiagnosticsOptions extends ArtifactDiagnosticNormalizerOptions {
+  inputFile: string
   json: boolean
 }
 
@@ -135,6 +140,18 @@ export async function runArtifactsDiscoverPartialCommand(args: string[]): Promis
   return 0
 }
 
+export async function runArtifactsDiagnosticsCommand(args: string[]): Promise<number> {
+  const options = parseArtifactDiagnosticsOptions(args)
+  const output = await normalizeDiagnostics(options)
+  if (!options.json) {
+    printArtifactDiagnosticsHumanOutput(output)
+    return 0
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return 0
+}
+
 async function verifyArtifacts(options: ArtifactVerifyOptions): Promise<ArtifactBundleVerificationResult> {
   return verifyArtifactBundle(resolve(options.bundleDirectory))
 }
@@ -181,6 +198,67 @@ async function discoverPartialArtifacts(options: ArtifactDiscoverPartialOptions)
     startedAt: options.startedAt,
     finishedAt: options.finishedAt,
   })
+}
+
+async function normalizeDiagnostics(options: ArtifactDiagnosticsOptions): Promise<ArtifactDiagnostics> {
+  const input = JSON.parse(await readFile(resolve(options.inputFile), "utf8")) as unknown
+  return buildArtifactDiagnostics(input, {
+    source: options.source,
+    stage: options.stage,
+    observationType: options.observationType,
+    refs: options.refs,
+  })
+}
+
+function parseArtifactDiagnosticsOptions(args: string[]): ArtifactDiagnosticsOptions {
+  const options: Partial<ArtifactDiagnosticsOptions> = { json: false, refs: [] }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--input":
+      case "--observations":
+      case "--diagnostics":
+      case "--import-report":
+        options.inputFile = value
+        break
+      case "--source":
+        options.source = value
+        break
+      case "--stage":
+        options.stage = value
+        break
+      case "--observation-type":
+        options.observationType = value
+        break
+      case "--ref":
+        options.refs?.push(parseDiagnosticRef(value))
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  if (!options.inputFile) {
+    throw new Error("Missing required option: --input")
+  }
+
+  return options as ArtifactDiagnosticsOptions
+}
+
+function parseDiagnosticRef(value: string): NonNullable<ArtifactDiagnosticNormalizerOptions["refs"]>[number] {
+  const [path, kind] = value.split(":", 2)
+  return { path, ...(kind ? { kind } : {}) }
 }
 
 function parseArtifactDiscoverPartialOptions(args: string[]): ArtifactDiscoverPartialOptions {
@@ -345,6 +423,15 @@ function printArtifactTransferProbesHumanOutput(output: TransferProbeDiagnostics
   console.log(`Diagnostics: ${output.summary.total} (${output.summary.errors} error(s), ${output.summary.warnings} warning(s))`)
   for (const diagnostic of output.diagnostics) {
     console.log(`- ${diagnostic.severity} ${diagnostic.code}: ${diagnostic.message}`)
+  }
+}
+
+function printArtifactDiagnosticsHumanOutput(output: ArtifactDiagnostics): void {
+  console.log("WP Codebox artifact diagnostics")
+  console.log(`Status: ${output.status}`)
+  console.log(`Diagnostics: ${output.summary.total} (${output.summary.error} error(s), ${output.summary.warning} warning(s), ${output.summary.notice} notice(s), ${output.summary.info} info)`)
+  for (const diagnostic of output.diagnostics) {
+    console.log(`- ${diagnostic.severity} ${diagnostic.code ?? diagnostic.type}: ${diagnostic.message}`)
   }
 }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -258,6 +258,7 @@ export function printHelp(): void {
   wp-codebox artifacts verify --bundle <dir> [--json]
   wp-codebox artifacts apply-preflight --bundle <dir> --approved-file <path> [--json]
   wp-codebox artifacts browser-metrics --bundle <dir> [--json]
+  wp-codebox artifacts diagnostics --input <json> [--source <id>] [--stage <id>] [--observation-type <id>] [--ref <path[:kind]>] [--json]
   wp-codebox artifacts transfer-verify --bundle <dir> [--json]
   wp-codebox artifacts transfer-probes --bundle <dir> [--json]
   wp-codebox artifacts discover-partial --artifacts <dir> [--session-id <id>] [--started-at <iso>] [--finished-at <iso>] [--json]
@@ -282,6 +283,11 @@ Options:
   --preview-public-url <url>
                     Public preview URL passed through to agent-task-run/recipe-run.
   --bundle <dir>      Artifact bundle directory for artifact verification/probe commands.
+  --source <id>       Default source for artifacts diagnostics normalization.
+  --stage <id>        Default stage for artifacts diagnostics normalization.
+  --observation-type <id>
+                       Default observation type for artifacts diagnostics normalization.
+  --ref <path[:kind]> Default artifact diagnostic reference. Repeatable.
   --approved-file <path>
                        Changed file approved for artifacts apply-preflight. Repeatable.
   --approved-files <paths>

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,3 +1,4 @@
+import { stripUndefined } from "./object-utils.js"
 import type { ArtifactPreview, ArtifactProvenance } from "./runtime-contracts.js"
 
 export * from "./artifact-manifest.js"
@@ -246,6 +247,149 @@ export interface ArtifactDiagnostics {
     info: number
   }
   diagnostics: ArtifactDiagnostic[]
+}
+
+export type ArtifactDiagnosticNormalizerRef = ArtifactDiagnosticRef
+
+export interface ArtifactDiagnosticNormalizerOptions {
+  source?: string
+  stage?: string
+  observationType?: string
+  refs?: ArtifactDiagnosticNormalizerRef[]
+}
+
+export function buildArtifactDiagnostics(input: unknown, options: ArtifactDiagnosticNormalizerOptions = {}): ArtifactDiagnostics {
+  const observations = Array.isArray(input) ? input : [input]
+  const diagnostics = observations.flatMap((observation, observationIndex) => diagnosticsFromArtifactObservation(observation, observationIndex, options))
+  const summary = {
+    total: diagnostics.length,
+    error: diagnostics.filter((diagnostic) => diagnostic.severity === "error").length,
+    warning: diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length,
+    notice: diagnostics.filter((diagnostic) => diagnostic.severity === "notice").length,
+    info: diagnostics.filter((diagnostic) => diagnostic.severity === "info").length,
+  }
+
+  return {
+    schema: "wp-codebox/artifact-diagnostics/v1",
+    status: diagnostics.length > 0 ? "reported" : "clean",
+    summary,
+    diagnostics,
+  }
+}
+
+function diagnosticsFromArtifactObservation(observation: unknown, observationIndex: number, options: ArtifactDiagnosticNormalizerOptions): ArtifactDiagnostic[] {
+  if (!observation || typeof observation !== "object" || Array.isArray(observation)) {
+    return []
+  }
+
+  const record = observation as Record<string, unknown>
+  const payload = record.data && typeof record.data === "object" && !Array.isArray(record.data) ? record.data as Record<string, unknown> : record
+  const rawDiagnostics = [
+    ...arrayPayload(payload.diagnostics),
+    ...arrayPayload(payload.findings),
+    ...arrayPayload(payload.issues),
+    ...arrayPayload(payload.diagnostic),
+  ]
+
+  if (rawDiagnostics.length === 0 && !("data" in record)) {
+    rawDiagnostics.push(record)
+  }
+
+  return rawDiagnostics
+    .map((raw, diagnosticIndex) => normalizeArtifactDiagnostic(raw, record, observationIndex, diagnosticIndex, options))
+    .filter((diagnostic): diagnostic is ArtifactDiagnostic => diagnostic !== null)
+}
+
+function normalizeArtifactDiagnostic(raw: unknown, observation: Record<string, unknown>, observationIndex: number, diagnosticIndex: number, options: ArtifactDiagnosticNormalizerOptions): ArtifactDiagnostic | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null
+  }
+
+  const value = raw as Record<string, unknown>
+  const type = stringField(value.type) || stringField(value.kind) || stringField(value.code) || stringField(value.reason_code) || "diagnostic"
+  const message = stringField(value.message) || stringField(value.summary) || stringField(value.reason) || stringField(value.excerpt) || stringField(value.error_message) || type
+  const details = stripUndefined(Object.fromEntries(Object.entries(value).filter(([key]) => ![
+    "id",
+    "diagnostic_id",
+    "type",
+    "kind",
+    "code",
+    "reason_code",
+    "message",
+    "summary",
+    "reason",
+    "excerpt",
+    "error_message",
+    "severity",
+    "category",
+    "source",
+    "path",
+    "source_path",
+    "selector",
+    "stage",
+    "refs",
+    "references",
+    "artifactRefs",
+  ].includes(key))))
+
+  return stripUndefined({
+    id: stringField(value.id) || stringField(value.diagnostic_id) || `${stringField(observation.id) ?? `observation-${observationIndex}`}-diagnostic-${diagnosticIndex + 1}`,
+    type,
+    severity: normalizeArtifactDiagnosticSeverity(value.severity),
+    message,
+    category: stringField(value.category),
+    source: stringField(value.source) || options.source,
+    path: stringField(value.path) || stringField(value.source_path),
+    selector: stringField(value.selector),
+    stage: stringField(value.stage) || options.stage,
+    code: stringField(value.code) || stringField(value.reason_code),
+    provenance: stripUndefined({
+      observationId: stringField(observation.id),
+      observationType: stringField(observation.type) || options.observationType,
+      observedAt: stringField(observation.observedAt),
+    }),
+    refs: artifactDiagnosticRefs(value.refs ?? value.references ?? value.artifactRefs, options.refs),
+    details: Object.keys(details).length > 0 ? details : undefined,
+  }) as ArtifactDiagnostic
+}
+
+function artifactDiagnosticRefs(raw: unknown, defaults: ArtifactDiagnosticNormalizerRef[] = []): ArtifactDiagnostic["refs"] {
+  return [
+    ...defaults,
+    ...arrayPayload(raw)
+      .filter((value) => value && typeof value === "object" && !Array.isArray(value))
+      .map((value) => {
+        const record = value as Record<string, unknown>
+        return stripUndefined({
+          path: stringField(record.path),
+          kind: stringField(record.kind),
+          id: stringField(record.id),
+          url: stringField(record.url),
+        })
+      }),
+  ].filter((value) => Object.keys(value).length > 0)
+}
+
+function arrayPayload(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value
+  }
+  return value && typeof value === "object" ? [value] : []
+}
+
+function stringField(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim() !== "") {
+    return value
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+  return undefined
+}
+
+function normalizeArtifactDiagnosticSeverity(value: unknown): ArtifactDiagnostic["severity"] {
+  const severity = stringField(value)?.toLowerCase()
+  return severity === "error" || severity === "warning" || severity === "notice" || severity === "info" ? severity : "warning"
 }
 
 export interface ArtifactTestResultsSuite {

--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -7,7 +7,6 @@ import { normalizeBlueprint, preferredVersionsForEnvironment } from "./blueprint
 import { artifactFileDigest, stripUndefined } from "@automattic/wp-codebox-core"
 import type {
   ArtifactDiagnostic,
-  ArtifactDiagnostics,
   ArtifactPackageIdentity,
   ArtifactPackageProvenance,
   ArtifactPreview,
@@ -22,6 +21,8 @@ import type {
   RuntimeInfo,
   SandboxWorkspaceContract,
 } from "@automattic/wp-codebox-core"
+
+export { buildArtifactDiagnostics } from "@automattic/wp-codebox-core"
 
 export interface CapturedMountFile {
   mountIndex: number
@@ -446,128 +447,9 @@ export function buildWorkspacePatchArtifact({
   }
 }
 
-export function buildArtifactDiagnostics(observations: ObservationResult[]): ArtifactDiagnostics {
-  const diagnostics = observations.flatMap((observation, observationIndex) => diagnosticsFromObservation(observation, observationIndex))
-  const summary = {
-    total: diagnostics.length,
-    error: diagnostics.filter((diagnostic) => diagnostic.severity === "error").length,
-    warning: diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length,
-    notice: diagnostics.filter((diagnostic) => diagnostic.severity === "notice").length,
-    info: diagnostics.filter((diagnostic) => diagnostic.severity === "info").length,
-  }
-
-  return {
-    schema: "wp-codebox/artifact-diagnostics/v1",
-    status: diagnostics.length > 0 ? "reported" : "clean",
-    summary,
-    diagnostics,
-  }
-}
-
-function diagnosticsFromObservation(observation: ObservationResult, observationIndex: number): ArtifactDiagnostic[] {
-  const payload = observation.data && typeof observation.data === "object" ? observation.data as Record<string, unknown> : {}
-  const rawDiagnostics = [
-    ...arrayPayload(payload.diagnostics),
-    ...arrayPayload(payload.findings),
-    ...arrayPayload(payload.issues),
-    ...arrayPayload(payload.diagnostic),
-  ]
-
-  return rawDiagnostics
-    .map((raw, diagnosticIndex) => normalizeArtifactDiagnostic(raw, observation, observationIndex, diagnosticIndex))
-    .filter((diagnostic): diagnostic is ArtifactDiagnostic => diagnostic !== null)
-}
-
-function normalizeArtifactDiagnostic(raw: unknown, observation: ObservationResult, observationIndex: number, diagnosticIndex: number): ArtifactDiagnostic | null {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return null
-  }
-
-  const value = raw as Record<string, unknown>
-  const type = stringField(value.type) || stringField(value.kind) || stringField(value.code) || "diagnostic"
-  const message = stringField(value.message) || stringField(value.summary) || stringField(value.reason) || type
-  const details = stripUndefined(Object.fromEntries(Object.entries(value).filter(([key]) => ![
-    "id",
-    "diagnostic_id",
-    "type",
-    "kind",
-    "code",
-    "message",
-    "summary",
-    "reason",
-    "severity",
-    "category",
-    "source",
-    "path",
-    "source_path",
-    "selector",
-    "stage",
-    "refs",
-    "references",
-    "artifactRefs",
-  ].includes(key))))
-
-  return stripUndefined({
-    id: stringField(value.id) || stringField(value.diagnostic_id) || `${observation.id ?? `observation-${observationIndex}`}-diagnostic-${diagnosticIndex + 1}`,
-    type,
-    severity: normalizeSeverity(value.severity),
-    message,
-    category: stringField(value.category),
-    source: stringField(value.source),
-    path: stringField(value.path) || stringField(value.source_path),
-    selector: stringField(value.selector),
-    stage: stringField(value.stage),
-    code: stringField(value.code),
-    provenance: stripUndefined({
-      observationId: observation.id,
-      observationType: observation.type,
-      observedAt: observation.observedAt,
-    }),
-    refs: artifactDiagnosticRefs(value.refs ?? value.references ?? value.artifactRefs),
-    details: Object.keys(details).length > 0 ? details : undefined,
-  }) as ArtifactDiagnostic
-}
-
-function artifactDiagnosticRefs(raw: unknown): ArtifactDiagnostic["refs"] {
-  return arrayPayload(raw)
-    .filter((value) => value && typeof value === "object" && !Array.isArray(value))
-    .map((value) => {
-      const record = value as Record<string, unknown>
-      return stripUndefined({
-        path: stringField(record.path),
-        kind: stringField(record.kind),
-        id: stringField(record.id),
-        url: stringField(record.url),
-      })
-    })
-    .filter((value) => Object.keys(value).length > 0)
-}
-
-function arrayPayload(value: unknown): unknown[] {
-  if (Array.isArray(value)) {
-    return value
-  }
-  return value && typeof value === "object" ? [value] : []
-}
-
-function stringField(value: unknown): string | undefined {
-  if (typeof value === "string" && value.trim() !== "") {
-    return value
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value)
-  }
-  return undefined
-}
-
 function stringMetadata(metadata: Record<string, unknown>, key: string): string | undefined {
   const value = metadata[key]
   return typeof value === "string" && value.length > 0 ? value : undefined
-}
-
-function normalizeSeverity(value: unknown): ArtifactDiagnostic["severity"] {
-  const severity = stringField(value)?.toLowerCase()
-  return severity === "error" || severity === "warning" || severity === "notice" || severity === "info" ? severity : "warning"
 }
 
 export function buildTestResults(): ArtifactTestResults {

--- a/scripts/artifact-diagnostics-normalizer-smoke.ts
+++ b/scripts/artifact-diagnostics-normalizer-smoke.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+import { buildArtifactDiagnostics } from "@automattic/wp-codebox-core"
+
+const execFileAsync = promisify(execFile)
+const directory = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-diagnostics-"))
+
+try {
+  const importReport = {
+    diagnostics: [
+      {
+        id: "fallback-1",
+        type: "fallback_block",
+        severity: "notice",
+        reason_code: "unsupported-layout",
+        source_path: "pages/home.html",
+        selector: ".hero",
+        message: "Used fallback block for unsupported layout.",
+        blockName: "core/html",
+      },
+      {
+        type: "missing_asset",
+        error_message: "Image file is missing.",
+        source_path: "assets/hero.jpg",
+      },
+    ],
+  }
+  const importReportPath = join(directory, "import-report.json")
+  await writeFile(importReportPath, `${JSON.stringify(importReport, null, 2)}\n`)
+
+  const direct = buildArtifactDiagnostics(importReport, {
+    source: "static-site-importer",
+    stage: "import",
+    observationType: "static-site-importer/import-report",
+    refs: [{ path: "import-report.json", kind: "static-site-importer/import-report" }],
+  })
+
+  assert.equal(direct.schema, "wp-codebox/artifact-diagnostics/v1")
+  assert.equal(direct.status, "reported")
+  assert.deepEqual(direct.summary, { total: 2, error: 0, warning: 1, notice: 1, info: 0 })
+  assert.equal(direct.diagnostics[0]?.id, "fallback-1")
+  assert.equal(direct.diagnostics[0]?.code, "unsupported-layout")
+  assert.equal(direct.diagnostics[0]?.source, "static-site-importer")
+  assert.equal(direct.diagnostics[0]?.stage, "import")
+  assert.equal(direct.diagnostics[0]?.path, "pages/home.html")
+  assert.equal(direct.diagnostics[0]?.provenance?.observationType, "static-site-importer/import-report")
+  assert.deepEqual(direct.diagnostics[0]?.refs, [{ path: "import-report.json", kind: "static-site-importer/import-report" }])
+  assert.equal(direct.diagnostics[0]?.details?.blockName, "core/html")
+  assert.equal(direct.diagnostics[1]?.message, "Image file is missing.")
+  assert.equal(direct.diagnostics[1]?.severity, "warning")
+
+  const observation = buildArtifactDiagnostics([
+    {
+      id: "plugin-check",
+      type: "wordpress.plugin-check",
+      observedAt: "2026-06-07T00:00:00.000Z",
+      data: { findings: [{ code: "late-escaping", message: "Output is not escaped.", severity: "error" }] },
+    },
+  ])
+  assert.equal(observation.summary.error, 1)
+  assert.equal(observation.diagnostics[0]?.id, "plugin-check-diagnostic-1")
+  assert.equal(observation.diagnostics[0]?.provenance?.observationId, "plugin-check")
+  assert.equal(observation.diagnostics[0]?.provenance?.observationType, "wordpress.plugin-check")
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "packages/cli/dist/index.js",
+      "artifacts",
+      "diagnostics",
+      "--input",
+      importReportPath,
+      "--source",
+      "static-site-importer",
+      "--stage",
+      "import",
+      "--observation-type",
+      "static-site-importer/import-report",
+      "--ref",
+      "import-report.json:static-site-importer/import-report",
+      "--json",
+    ],
+    { cwd: resolve(import.meta.dirname, "..") },
+  )
+  assert.deepEqual(JSON.parse(stdout), direct)
+
+  console.log("artifact diagnostics normalizer smoke passed")
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Moves artifact diagnostics normalization into `@automattic/wp-codebox-core` so callers can build `wp-codebox/artifact-diagnostics/v1` without duplicating schema logic.
- Keeps the playground `buildArtifactDiagnostics()` export source-compatible while delegating to the shared core helper.
- Adds `wp-codebox artifacts diagnostics --input <json>` for normalizing observation/import-report JSON from downstream tools.

Fixes #747.

## Testing
- `npm run build`
- `npm run artifact-diagnostics-normalizer-smoke`
- `npm run artifact-contract-smoke`
- `npm run artifact-reference-normalization-smoke`
- `npm run command-registry-smoke`

## Downstream follow-up
- Static Site Importer can replace `codebox_artifact_diagnostics()` / `codebox_artifact_diagnostic()` with the native WP Codebox CLI/API seam once this lands.
- wp-site-generator should not need generation-loop changes for this PR; it can continue consuming SSI reports until SSI adopts the seam.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the core normalizer extraction, CLI seam, and smoke coverage; Chris remains responsible for review and testing.