### PR TITLE
Preserve inline runtime bundle specs

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -966,6 +966,9 @@ foreach ( $bundle_specs as $index => $spec ) {
 			$input[ $field ] = trim( (string) $spec[ $field ] );
 		}
 	}
+	if ( isset( $spec[\'bundle\'] ) && is_array( $spec[\'bundle\'] ) ) {
+		$input[\'bundle\'] = $spec[\'bundle\'];
+	}
 	$input[\'owner_id\'] = isset( $spec[\'owner_id\'] ) && (int) $spec[\'owner_id\'] > 0 ? (int) $spec[\'owner_id\'] : ( get_current_user_id() ?: 1 );
 	if ( isset( $spec[\'import_principal\'] ) && is_array( $spec[\'import_principal\'] ) ) {
 		$input[\'import_principal\'] = $spec[\'import_principal\'];


### PR DESCRIPTION
## Summary
- Preserves inline `bundle` payloads in WP Codebox's fallback browser runtime bundle importer before invoking the generic runtime import filter.
- Keeps inline agent bundles importable when a runtime provides specs directly instead of a source URL.

## Testing
- `npm run task-input-contract-smoke`
- `npm run agent-runtime-workload-normalizer-smoke`
- `npm run durable-artifact-preview-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the browser runtime bundle import failure, drafting the importer contract fix, and running targeted verification. Chris remains responsible for review and testing.