### PR TITLE
Load agent task runtime components as mu-plugins

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -364,9 +364,9 @@ function evidenceRefs(run: Record<string, unknown>, artifacts: string): Array<Re
   return refs.filter((entry): entry is Record<string, unknown> => Boolean(entry))
 }
 
-function componentPlugin(source: unknown, slug: string, artifactsRoot: string): { source: string; slug: string; activate: boolean } | undefined {
+function componentPlugin(source: unknown, slug: string, artifactsRoot: string): { source: string; slug: string; activate: boolean; loadAs: "mu-plugin" } | undefined {
   const path = stringValue(source)
-  return path ? { source: prepareComposerPluginSource(path, slug, artifactsRoot), slug, activate: true } : undefined
+  return path ? { source: prepareComposerPluginSource(path, slug, artifactsRoot), slug, activate: false, loadAs: "mu-plugin" } : undefined
 }
 
 function prepareComposerPluginSource(source: string, slug: string, artifactsRoot: string): string {

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -26,6 +26,13 @@ assert.equal(extraPlugins.find((plugin) => plugin?.slug === "agents-api")?.sourc
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine")?.source, "/components/data-machine")
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.source, "/components/data-machine-code")
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai")?.source, "/components/ai-provider-for-openai")
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "agents-api")?.loadAs, "mu-plugin")
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine")?.loadAs, "mu-plugin")
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.loadAs, "mu-plugin")
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai")?.loadAs, undefined)
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "agents-api")?.activate, false)
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine")?.activate, false)
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.activate, false)
 
 const legacyInput = {
   goal: "Run a Data Machine bundle",
@@ -39,6 +46,7 @@ const legacyExtraPlugins = legacyRecipe.inputs?.extraPlugins ?? []
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "agents-api")?.source, "/legacy/agents-api")
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine")?.source, "/legacy/data-machine")
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.source, "/legacy/data-machine-code")
+assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine")?.loadAs, "mu-plugin")
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))
 const codexProviderPath = join(profileRoot, "ai-provider-for-openai@codex-oauth-provider")


### PR DESCRIPTION
## Summary
- Make the CLI `agent-task-run` recipe builder load Agents API, Data Machine, and Data Machine Code as runtime mu-plugins instead of normal active plugins.
- This lets the runtime loader install `datamachine_should_load_full_runtime` before Data Machine and DMC are required.
- Keeps provider plugins as normal plugin entries.

Fixes #751.

## Verification
- `npm run build`
- `npm run agent-task-run-runtime-components-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the site-generation-loop runtime activation-order failure, implementing the CLI recipe fix, and running targeted smoke verification.