### PR TITLE
Fix empty artifact diagnostics containers

### DIFF
--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -291,13 +291,17 @@ function diagnosticsFromArtifactObservation(observation: unknown, observationInd
     ...arrayPayload(payload.diagnostic),
   ]
 
-  if (rawDiagnostics.length === 0 && !("data" in record)) {
+  if (rawDiagnostics.length === 0 && !("data" in record) && !hasDiagnosticContainer(record)) {
     rawDiagnostics.push(record)
   }
 
   return rawDiagnostics
     .map((raw, diagnosticIndex) => normalizeArtifactDiagnostic(raw, record, observationIndex, diagnosticIndex, options))
     .filter((diagnostic): diagnostic is ArtifactDiagnostic => diagnostic !== null)
+}
+
+function hasDiagnosticContainer(record: Record<string, unknown>): boolean {
+  return ["diagnostics", "findings", "issues", "diagnostic"].some((key) => key in record)
 }
 
 function normalizeArtifactDiagnostic(raw: unknown, observation: Record<string, unknown>, observationIndex: number, diagnosticIndex: number, options: ArtifactDiagnosticNormalizerOptions): ArtifactDiagnostic | null {

--- a/scripts/artifact-diagnostics-normalizer-smoke.ts
+++ b/scripts/artifact-diagnostics-normalizer-smoke.ts
@@ -66,6 +66,11 @@ try {
   assert.equal(observation.diagnostics[0]?.provenance?.observationId, "plugin-check")
   assert.equal(observation.diagnostics[0]?.provenance?.observationType, "wordpress.plugin-check")
 
+  const emptyContainer = buildArtifactDiagnostics({ diagnostics: [] })
+  assert.equal(emptyContainer.status, "clean")
+  assert.deepEqual(emptyContainer.summary, { total: 0, error: 0, warning: 0, notice: 0, info: 0 })
+  assert.deepEqual(emptyContainer.diagnostics, [])
+
   const { stdout } = await execFileAsync(
     process.execPath,
     [


### PR DESCRIPTION
## Summary
- Keeps `buildArtifactDiagnostics({ diagnostics: [] })` clean instead of treating the empty container object as one generic diagnostic.
- Adds smoke coverage for empty diagnostic containers.

Follow-up to #749, found while adopting the normalizer in chubes4/static-site-importer#288.

## Testing
- `npm run build`
- `npm run artifact-diagnostics-normalizer-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying the empty-container edge case while wiring downstream adoption and drafting the focused fix/test; Chris remains responsible for review and testing.