### PR TITLE
Escape runtime mu-plugin loader values

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -60,6 +60,10 @@ export interface PreparedExtraPlugin {
 
 type BootActivePluginCandidate = Pick<PreparedExtraPlugin, "pluginFile" | "activate" | "loadAs">
 
+function phpSingleQuotedLiteral(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`
+}
+
 export interface RecipeStagedFileProvenance {
   kind: "local"
   original: string
@@ -1053,6 +1057,8 @@ export function installMuPluginsCode(extraPlugins: PreparedExtraPlugin[]): strin
     return null
   }
 
+  const workspaceRootLiteral = phpSingleQuotedLiteral(SANDBOX_WORKSPACE_ROOT)
+
   return `$plugins = ${JSON.stringify(muPlugins)};
 $runtime_dir = WPMU_PLUGIN_DIR . '/wp-codebox-runtime';
 if (!is_dir(WPMU_PLUGIN_DIR) && !mkdir(WPMU_PLUGIN_DIR, 0777, true) && !is_dir(WPMU_PLUGIN_DIR)) {
@@ -1072,7 +1078,7 @@ $lines = array(
     "defined( 'ABSPATH' ) || exit;",
     '',
     "if ( ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {",
-    "    define( 'DATAMACHINE_WORKSPACE_PATH', ${JSON.stringify(SANDBOX_WORKSPACE_ROOT)} );",
+    "    define( 'DATAMACHINE_WORKSPACE_PATH', ${workspaceRootLiteral} );",
     "}",
     "add_filter( 'datamachine_should_load_full_runtime', '__return_true', 1 );",
     '',

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { normalizeTaskInput } from "@automattic/wp-codebox-core"
 import { buildAgentTaskRecipe } from "../packages/cli/src/commands/agent-task-run.js"
+import { installMuPluginsCode } from "../packages/cli/src/recipe-sources.js"
 
 const input = {
   goal: "Run a Data Machine bundle",
@@ -33,6 +34,10 @@ assert.equal(extraPlugins.find((plugin) => plugin?.slug === "ai-provider-for-ope
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "agents-api")?.activate, false)
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine")?.activate, false)
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.activate, false)
+
+const muPluginInstallCode = installMuPluginsCode(extraPlugins)
+assert.ok(muPluginInstallCode?.includes("define( 'DATAMACHINE_WORKSPACE_PATH', '/workspace' );"))
+assert.ok(!muPluginInstallCode?.includes('define( \'DATAMACHINE_WORKSPACE_PATH\', "/workspace" );'))
 
 const legacyInput = {
   goal: "Run a Data Machine bundle",


### PR DESCRIPTION
## Summary
- Fixes the generated runtime mu-plugin loader source so `DATAMACHINE_WORKSPACE_PATH` is written as a valid PHP literal.
- Extends the `agent-task-run` runtime component smoke to catch the broken nested double-quote form.

Fixes #756.

## Testing
- `npm run agent-task-run-runtime-components-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the wp-site-generator loop failure, implementing the escaping fix, and drafting the PR text. Chris remains responsible for review and testing.