### PR TITLE
Fix visual compare artifact screenshot paths

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto"
-import { mkdir, readFile, writeFile } from "node:fs/promises"
-import { join } from "node:path"
+import { access, mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, join, relative } from "node:path"
 import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
@@ -2417,8 +2417,8 @@ export async function runVisualCompareCommand({
       await browser.close()
     }
   } else if (sourceScreenshot && candidateScreenshot) {
-    await writeFile(sourcePath, await readFile(sourceScreenshot))
-    await writeFile(candidatePath, await readFile(candidateScreenshot))
+    await writeFile(sourcePath, await readFile(await resolveVisualCompareScreenshotPath(sourceScreenshot, artifactRoot)))
+    await writeFile(candidatePath, await readFile(await resolveVisualCompareScreenshotPath(candidateScreenshot, artifactRoot)))
   }
 
   const comparison = await comparePngFiles(sourcePath, candidatePath, diffPath, { threshold, includeAA, maxRegions })
@@ -2489,6 +2489,25 @@ export async function runVisualCompareCommand({
   return {
     artifact,
     output: `${JSON.stringify(summary, null, 2)}\n`,
+  }
+}
+
+async function resolveVisualCompareScreenshotPath(requestedPath: string, artifactRoot: string): Promise<string> {
+  try {
+    await access(requestedPath)
+    return requestedPath
+  } catch {
+    // Recipes are authored before the runtime id exists, so callers may point to
+    // the stable artifacts root while browser captures live under the current runtime root.
+    const stableBrowserRoot = join(dirname(artifactRoot), "files", "browser")
+    const browserRelativePath = relative(stableBrowserRoot, requestedPath)
+    if (browserRelativePath && !browserRelativePath.startsWith("..")) {
+      const runtimePath = join(artifactRoot, "files", "browser", browserRelativePath)
+      await access(runtimePath)
+      return runtimePath
+    }
+
+    throw new Error(`Visual compare screenshot not found: ${requestedPath}`)
   }
 }
 


### PR DESCRIPTION
## Summary
- Resolves visual-compare screenshot inputs from the current runtime artifact root when recipes pass the stable parent artifact path before the runtime id exists.
- Preserves existing absolute screenshot behavior when the requested path already exists.
- Keeps the earlier GitHub release redirect and archive-size source policy fixes on this branch.

## Verification
- `npm run build`
- `npm run recipe-source-redirect-smoke`
- `npm run recipe-dry-run-smoke`

## Evidence
- Studio Web Workflow Bench live verification no longer fails visual-compare with missing `files/browser/screenshot-source-artifact-*.png` paths.
- The final live row reached editable preview, captured an artifact bundle, and produced visual-compare evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed runtime artifact path resolution after Studio Web Workflow Bench reached visual comparison, drafted the fallback path fix, and ran build/smoke/live verification for Chris to review.