### PR TITLE
Harden frame browser-probe assertions

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -988,7 +988,7 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
 
     for (const assertion of (step.args ?? []).filter((arg) => arg.startsWith("assert=")).map((arg) => arg.slice("assert=".length).trim())) {
       const rawNormalized = assertion.startsWith("advisory:") ? assertion.slice("advisory:".length).trim() : assertion
-      const frameSeparator = rawNormalized.startsWith("frame:") ? rawNormalized.indexOf("|") : -1
+      const frameSeparator = rawNormalized.startsWith("frame:") || rawNormalized.startsWith("frame-url:") ? rawNormalized.indexOf("|") : -1
       const normalized = frameSeparator > -1 ? rawNormalized.slice(frameSeparator + 1).trim() : rawNormalized
       const frameAssertionIsSupported = frameSeparator === -1 || normalized.startsWith("exists:") || normalized.startsWith("not-exists:") || normalized.startsWith("visible:") || normalized.startsWith("hidden:") || normalized.startsWith("count:") || normalized.startsWith("text:") || normalized.startsWith("attr:")
       if (

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -565,6 +565,7 @@ export interface BrowserStepAssertion {
   message?: string
   selector?: string
   frameSelector?: string
+  frameTarget?: BrowserStepAssertionFrameTarget
   frameUrl?: string
   name?: string
   state?: string
@@ -576,6 +577,13 @@ export interface BrowserStepAssertion {
   observed?: unknown
   supportingArtifacts?: string[]
   passed: boolean
+}
+
+export interface BrowserStepAssertionFrameTarget {
+  kind: "selector" | "url"
+  value: string
+  status: "resolved"
+  url: string
 }
 
 export interface BrowserProbeErrorRecord {

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -406,6 +406,9 @@ async function runSingleBrowserProbeCommand({
       }
       const assertionMetrics = capturesBrowserMetrics ? browserProbeBenchMetrics(browserProbeMemoryArtifact(checkpoints), browserProbePerformanceArtifact(checkpoints)) : {}
       assertionResults = await executeBrowserProbeAssertions(page, assertions, consoleMessages, errors, network, assertionMetrics)
+      if (capturesBrowserMetrics) {
+        checkpoints.push(await browserProbeCheckpoint(page, "after-assertions"))
+      }
       const fatalFailures = assertionResults.filter((assertion) => !assertion.passed && !assertion.advisory)
       if (fatalFailures.length > 0) {
         pendingError = new Error(`wordpress.browser-probe assertion failed: ${fatalFailures.map((assertion) => assertion.assertion).join(", ")}`)

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -268,7 +268,10 @@ export interface BrowserProbeAssertionSpec {
   operator?: "=" | "==" | "!=" | ">" | ">=" | "<" | "<="
   expected?: string | number | boolean
   name?: string
+  frameUrl?: string
 }
+
+const BROWSER_PROBE_ASSERTION_STRING_PREVIEW_CHARS = 512
 
 export function browserProbeAssertionsFromArgs(args: string[]): BrowserProbeAssertionSpec[] {
   return args
@@ -313,12 +316,13 @@ function parseBrowserProbeAssertion(value: string): BrowserProbeAssertionSpec {
 
   const framed = parseBrowserProbeAssertionFrame(raw)
   const frameSelector = framed.frameSelector
+  const frameUrl = framed.frameUrl
   raw = framed.raw
 
   for (const type of ["not-exists", "exists", "visible", "hidden"] as const) {
     const prefix = `${type}:`
     if (raw.startsWith(prefix)) {
-      return requireSelectorAssertion(value, advisory, type, raw.slice(prefix.length).trim(), frameSelector)
+      return requireSelectorAssertion(value, advisory, type, raw.slice(prefix.length).trim(), frameSelector, frameUrl)
     }
   }
 
@@ -333,6 +337,7 @@ function parseBrowserProbeAssertion(value: string): BrowserProbeAssertionSpec {
       type: "count",
       selector: parsed[1].trim(),
       frameSelector,
+      frameUrl,
       operator: parsed[2] as BrowserProbeAssertionSpec["operator"],
       expected: Number.parseInt(parsed[3], 10),
     }
@@ -343,7 +348,7 @@ function parseBrowserProbeAssertion(value: string): BrowserProbeAssertionSpec {
     if (!parsed) {
       throw new Error(`wordpress.browser-probe text assertion must look like text:<selector> contains <text>: ${value}`)
     }
-    return { raw: value, advisory, type: "text", selector: parsed[1].trim(), frameSelector, operator: "contains" as BrowserProbeAssertionSpec["operator"], expected: parsed[2] }
+    return { raw: value, advisory, type: "text", selector: parsed[1].trim(), frameSelector, frameUrl, operator: "contains" as BrowserProbeAssertionSpec["operator"], expected: parsed[2] }
   }
 
   if (raw.startsWith("attr:")) {
@@ -354,10 +359,10 @@ function parseBrowserProbeAssertion(value: string): BrowserProbeAssertionSpec {
     if (!parsed) {
       throw new Error(`wordpress.browser-probe attr assertion must look like attr:<selector>[name][=value] or attr:<selector>@name[=value]: ${value}`)
     }
-    return { raw: value, advisory, type: "attr", selector: parsed[1].trim(), frameSelector, name: parsed[2].trim(), operator: typeof parsed[3] === "undefined" ? undefined : "=", expected: parsed[3] }
+    return { raw: value, advisory, type: "attr", selector: parsed[1].trim(), frameSelector, frameUrl, name: parsed[2].trim(), operator: typeof parsed[3] === "undefined" ? undefined : "=", expected: parsed[3] }
   }
 
-  if (frameSelector) {
+  if (frameSelector || frameUrl) {
     throw new Error(`wordpress.browser-probe frame assertions support selector assertions only: ${value}`)
   }
 
@@ -391,24 +396,26 @@ function parseBrowserProbeAssertion(value: string): BrowserProbeAssertionSpec {
   throw new Error(`wordpress.browser-probe assert supports exists, not-exists, visible, hidden, count, text contains, attr, no-console-errors, no-page-errors, no-errors, request-count-by-host, request-count-by-type, total-transfer-size, and metric budgets: ${value}`)
 }
 
-function parseBrowserProbeAssertionFrame(raw: string): { raw: string; frameSelector?: string } {
-  const prefix = "frame:"
-  if (!raw.startsWith(prefix)) {
+function parseBrowserProbeAssertionFrame(raw: string): { raw: string; frameSelector?: string; frameUrl?: string } {
+  const selectorPrefix = "frame:"
+  const urlPrefix = "frame-url:"
+  const prefix = raw.startsWith(selectorPrefix) ? selectorPrefix : raw.startsWith(urlPrefix) ? urlPrefix : undefined
+  if (!prefix) {
     return { raw }
   }
 
   const separator = raw.indexOf("|")
   if (separator === -1) {
-    throw new Error(`wordpress.browser-probe frame assertion must look like frame:<iframe-selector>|<assertion>: ${raw}`)
+    throw new Error(`wordpress.browser-probe frame assertion must look like frame:<iframe-selector>|<assertion> or frame-url:<url-fragment>|<assertion>: ${raw}`)
   }
 
-  const frameSelector = raw.slice(prefix.length, separator).trim()
+  const frameTarget = raw.slice(prefix.length, separator).trim()
   const assertion = raw.slice(separator + 1).trim()
-  if (!frameSelector || !assertion) {
-    throw new Error(`wordpress.browser-probe frame assertion requires an iframe selector and assertion: ${raw}`)
+  if (!frameTarget || !assertion) {
+    throw new Error(`wordpress.browser-probe frame assertion requires an iframe selector or URL fragment and assertion: ${raw}`)
   }
 
-  return { raw: assertion, frameSelector }
+  return prefix === selectorPrefix ? { raw: assertion, frameSelector: frameTarget } : { raw: assertion, frameUrl: frameTarget }
 }
 
 function parseBudgetBodyOrUndefined(body: string): { name?: string; operator: NonNullable<BrowserProbeAssertionSpec["operator"]>; expected: number } | undefined {
@@ -445,11 +452,11 @@ function parseBudgetBody(body: string, raw: string, requiresName = true): { name
   return { name, operator, expected }
 }
 
-function requireSelectorAssertion(raw: string, advisory: boolean, type: BrowserProbeAssertionSpec["type"], selector: string, frameSelector?: string): BrowserProbeAssertionSpec {
+function requireSelectorAssertion(raw: string, advisory: boolean, type: BrowserProbeAssertionSpec["type"], selector: string, frameSelector?: string, frameUrl?: string): BrowserProbeAssertionSpec {
   if (!selector) {
     throw new Error(`wordpress.browser-probe ${type} assertion requires a selector: ${raw}`)
   }
-  return { raw, advisory, type, selector, frameSelector }
+  return { raw, advisory, type, selector, frameSelector, frameUrl }
 }
 
 type BrowserProbeDomTarget = Page | Frame
@@ -475,38 +482,39 @@ async function executeBrowserProbeAssertion(
     expected: assertion.expected,
   }
   const target = await browserProbeAssertionTarget(page, assertion)
-  const targetBase = assertion.frameSelector ? { ...base, frameUrl: target.url() } : base
+  const targetBase = target.kind === "frame" ? { ...base, frameTarget: target.frameTarget, frameUrl: target.frameTarget.url } : base
+  const domTarget = target.target
 
   switch (assertion.type) {
     case "exists": {
-      const actual = await target.locator(assertion.selector ?? "").count()
+      const actual = await domTarget.locator(assertion.selector ?? "").count()
       return finalizeProbeAssertion(targetBase, actual, assertion.expected, actual > 0)
     }
     case "not-exists": {
-      const actual = await target.locator(assertion.selector ?? "").count()
+      const actual = await domTarget.locator(assertion.selector ?? "").count()
       return finalizeProbeAssertion(targetBase, actual, assertion.expected, actual === 0)
     }
     case "visible": {
-      const actual = await target.locator(assertion.selector ?? "").first().isVisible().catch(() => false)
+      const actual = await domTarget.locator(assertion.selector ?? "").first().isVisible().catch(() => false)
       return finalizeProbeAssertion(targetBase, actual, assertion.expected, actual === true)
     }
     case "hidden": {
-      const locator = target.locator(assertion.selector ?? "")
+      const locator = domTarget.locator(assertion.selector ?? "")
       const count = await locator.count()
       const visible = count > 0 ? await locator.first().isVisible().catch(() => false) : false
       return finalizeProbeAssertion(targetBase, { count, visible }, assertion.expected, !visible)
     }
     case "count": {
-      const actual = await target.locator(assertion.selector ?? "").count()
+      const actual = await domTarget.locator(assertion.selector ?? "").count()
       return finalizeProbeAssertion(targetBase, actual, assertion.expected, compareNumbers(actual, Number(assertion.expected), assertion.operator ?? "="))
     }
     case "text": {
-      const actual = await target.locator(assertion.selector ?? "").first().textContent().catch(() => null)
+      const actual = await domTarget.locator(assertion.selector ?? "").first().textContent().catch(() => null)
       const expected = String(assertion.expected ?? "")
       return finalizeProbeAssertion(targetBase, actual, expected, typeof actual === "string" && actual.includes(expected))
     }
     case "attr": {
-      const actual = await target.locator(assertion.selector ?? "").first().getAttribute(assertion.name ?? "").catch(() => null)
+      const actual = await domTarget.locator(assertion.selector ?? "").first().getAttribute(assertion.name ?? "").catch(() => null)
       const passed = typeof assertion.expected === "undefined" ? actual !== null : actual === String(assertion.expected)
       return finalizeProbeAssertion(targetBase, actual, assertion.expected, passed)
     }
@@ -545,24 +553,33 @@ async function executeBrowserProbeAssertion(
   }
 }
 
-async function browserProbeAssertionTarget(page: Page, assertion: BrowserProbeAssertionSpec): Promise<BrowserProbeDomTarget> {
-  if (!assertion.frameSelector) {
-    return page
+async function browserProbeAssertionTarget(page: Page, assertion: BrowserProbeAssertionSpec): Promise<{ target: BrowserProbeDomTarget; kind: "page" } | { target: Frame; kind: "frame"; frameTarget: NonNullable<BrowserStepAssertion["frameTarget"]> }> {
+  if (!assertion.frameSelector && !assertion.frameUrl) {
+    return { target: page, kind: "page" }
   }
 
-  const locator = page.locator(assertion.frameSelector).first()
+  if (assertion.frameUrl) {
+    const frame = page.frames().find((candidate) => candidate.url().includes(assertion.frameUrl ?? ""))
+    if (frame) {
+      return { target: frame, kind: "frame", frameTarget: { kind: "url", value: assertion.frameUrl, status: "resolved", url: frame.url() } }
+    }
+    throw new Error(`wordpress.browser-probe frame assertion could not resolve iframe URL fragment: ${assertion.frameUrl}`)
+  }
+
+  const frameSelector = assertion.frameSelector ?? ""
+  const locator = page.locator(frameSelector).first()
   await locator.waitFor({ state: "attached", timeout: 30_000 })
   const startedAt = Date.now()
   while (Date.now() - startedAt < 30_000) {
     const element = await locator.elementHandle().catch(() => null)
     const frame = await element?.contentFrame().catch(() => null)
     if (frame) {
-      return frame
+      return { target: frame, kind: "frame", frameTarget: { kind: "selector", value: frameSelector, status: "resolved", url: frame.url() } }
     }
     await page.waitForTimeout(100)
   }
 
-  throw new Error(`wordpress.browser-probe frame assertion could not resolve iframe: ${assertion.frameSelector}`)
+  throw new Error(`wordpress.browser-probe frame assertion could not resolve iframe: ${frameSelector}`)
 }
 
 function finalizeProbeAssertion(
@@ -575,12 +592,25 @@ function finalizeProbeAssertion(
   return {
     ...base,
     status: passed ? "pass" : base.advisory ? "warn" : "fail",
-    expected: expectedBudget,
-    expectedBudget,
-    actual: observed,
-    observed,
+    expected: compactProbeAssertionValue(expectedBudget),
+    expectedBudget: compactProbeAssertionValue(expectedBudget),
+    actual: compactProbeAssertionValue(observed),
+    observed: compactProbeAssertionValue(observed),
     ...(supportingArtifacts.length > 0 ? { supportingArtifacts } : {}),
     passed,
+  }
+}
+
+function compactProbeAssertionValue(value: unknown): unknown {
+  if (typeof value !== "string" || value.length <= BROWSER_PROBE_ASSERTION_STRING_PREVIEW_CHARS) {
+    return value
+  }
+
+  return {
+    type: "string",
+    length: value.length,
+    preview: value.slice(0, BROWSER_PROBE_ASSERTION_STRING_PREVIEW_CHARS),
+    truncated: true,
   }
 }
 

--- a/scripts/browser-probe-assertions-smoke.ts
+++ b/scripts/browser-probe-assertions-smoke.ts
@@ -16,7 +16,8 @@ await writeFile(join(pluginDir, "browser-assertion-fixture.php"), `<?php
  * Plugin Name: Browser Assertion Fixture
  */
 add_action('wp_footer', function () {
-    $frame_srcdoc = esc_attr('<!doctype html><html><body><div id="frame-target" data-frame-state="ready">Frame Target Ready</div><ul id="frame-list"><li>Alpha</li><li>Beta</li></ul></body></html>');
+    $large_text = str_repeat('Large Frame Body ', 700);
+    $frame_srcdoc = esc_attr('<!doctype html><html><body><div id="frame-target" data-frame-state="ready">Frame Target Ready</div><div id="large-frame-body">' . $large_text . 'Needle Text</div><ul id="frame-list"><li>Alpha</li><li>Beta</li></ul></body></html>');
     echo '<style>.wp-codebox-hidden-fixture{display:none}</style>';
     echo '<div id="probe-target" data-state="ready">Probe Target Ready</div>';
     echo '<div id="probe-hidden" class="wp-codebox-hidden-fixture">Hidden Fixture</div>';
@@ -38,6 +39,7 @@ const passing = await runRecipe("passing", [
   "assert=attr:#probe-target[data-state]=ready",
   "assert=frame:#probe-frame|exists:#frame-target",
   "assert=frame:#probe-frame|text:#frame-target contains Frame Target Ready",
+  "assert=frame-url:about:srcdoc|text:#large-frame-body contains Needle Text",
   "assert=frame:#probe-frame|count:#frame-list li=2",
   "assert=frame:#probe-frame|attr:#frame-target[data-frame-state]=ready",
   "assert=no-console-errors",
@@ -50,14 +52,26 @@ const passing = await runRecipe("passing", [
 
 assert.equal(passing.success, true, passing.error?.message ?? "passing assertions should succeed")
 const passingSummary = await readSummary(passing)
-assert.equal(passingSummary.assertions.total, 17)
+const passingCheckpoints = await readCheckpointNames(passing)
+assert.equal(passingSummary.assertions.total, 18)
 assert.equal(passingSummary.assertions.failed, 0)
-assert.equal(passingSummary.summary.assertions.total, 17)
+assert.equal(passingSummary.summary.assertions.total, 18)
 assert.equal(passingSummary.summary.assertions.failed, 0)
+assert.equal(passingCheckpoints.includes("after-assertions"), true, "browser-probe should capture a deterministic checkpoint after assertions complete")
 const passingFrameAssertion = passingSummary.assertions.results.find((result: { assertion?: string }) => result.assertion === "frame:#probe-frame|exists:#frame-target")
 assert.equal(passingFrameAssertion.status, "pass")
 assert.equal(passingFrameAssertion.frameSelector, "#probe-frame")
 assert.equal(typeof passingFrameAssertion.frameUrl, "string")
+assert.deepEqual(passingFrameAssertion.frameTarget, { kind: "selector", value: "#probe-frame", status: "resolved", url: passingFrameAssertion.frameUrl })
+const passingFrameUrlAssertion = passingSummary.assertions.results.find((result: { assertion?: string }) => result.assertion === "frame-url:about:srcdoc|text:#large-frame-body contains Needle Text")
+assert.equal(passingFrameUrlAssertion.status, "pass")
+assert.equal(passingFrameUrlAssertion.frameTarget.kind, "url")
+assert.equal(passingFrameUrlAssertion.frameTarget.value, "about:srcdoc")
+assert.equal(typeof passingFrameUrlAssertion.frameUrl, "string")
+assert.equal(passingFrameUrlAssertion.observed.type, "string")
+assert.equal(passingFrameUrlAssertion.observed.truncated, true)
+assert.equal(passingFrameUrlAssertion.observed.preview.length <= 512, true)
+assert.equal(commandOutput(passing).summary.assertions.results.find((result: { assertion?: string }) => result.assertion === passingFrameUrlAssertion.assertion).observed.truncated, true, "command stdout should include compact frame assertion evidence")
 const passingRequestBudget = passingSummary.assertions.results.find((result: { assertion?: string }) => result.assertion === "request-count-by-type:document>=1")
 assert.equal(passingRequestBudget.status, "pass")
 assert.equal(passingRequestBudget.expectedBudget, 1)
@@ -68,7 +82,8 @@ assert.equal(passingMetricBudget.status, "pass")
 assert.equal(passingMetricBudget.expectedBudget, 0)
 assert.equal(typeof passingMetricBudget.observed, "number")
 assert.deepEqual(passingMetricBudget.supportingArtifacts, ["files/browser/performance.json", "files/browser/memory.json"])
-assert.equal(commandOutput(passing).summary.assertions.total, 17, "command JSON should include assertion totals")
+assert.equal(commandOutput(passing).summary.assertions.total, 18, "command JSON should include assertion totals")
+assert.equal(commandOutput(passing).summary.assertions.results.map((result: unknown) => JSON.stringify(result)).join("\n").includes("Large Frame Body ".repeat(100)), false, "command stdout should not include unbounded large frame text")
 
 const advisory = await runRecipe("advisory", [
   "url=/",
@@ -146,11 +161,27 @@ async function runRecipe(name: string, args: string[]): Promise<any> {
 }
 
 async function readSummary(output: any): Promise<any> {
-  const artifactDirectory = output.artifacts?.directory ?? output.run?.artifactRefs?.find((ref: { kind?: string }) => ref.kind === "artifact-bundle")?.directory
-  assert.equal(typeof artifactDirectory, "string", "recipe-run should return artifact bundle directory")
+  const artifactDirectory = artifactDirectoryFromOutput(output)
   const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
   assert.equal(existsSync(summaryPath), true, "summary.json should be captured")
   return JSON.parse(await readFile(summaryPath, "utf8"))
+}
+
+async function readCheckpointNames(output: any): Promise<string[]> {
+  const artifactDirectory = artifactDirectoryFromOutput(output)
+  const checkpointPath = join(artifactDirectory, "files", "browser", "checkpoints.jsonl")
+  assert.equal(existsSync(checkpointPath), true, "checkpoints.jsonl should be captured")
+  return (await readFile(checkpointPath, "utf8"))
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line).name)
+}
+
+function artifactDirectoryFromOutput(output: any): string {
+  const artifactDirectory = output.artifacts?.directory ?? output.run?.artifactRefs?.find((ref: { kind?: string }) => ref.kind === "artifact-bundle")?.directory
+  assert.equal(typeof artifactDirectory, "string", "recipe-run should return artifact bundle directory")
+  return artifactDirectory
 }
 
 function commandOutput(output: any): any {


### PR DESCRIPTION
## Summary
- Bound large string assertion evidence so iframe body text matches stay inspectable without flooding `summary.json` or command stdout.
- Add frame result metadata (`frameTarget` plus matched `frameUrl`) and support `frame-url:<fragment>|...` targeting for browser-probe selector assertions.
- Capture an `after-assertions` checkpoint when metrics/checkpoints are active so assertion completion has a deterministic artifact marker.

Closes #760.

## Testing
- `npm run build`
- `npm run recipe-dry-run-smoke`
- `npm run browser-probe-artifact-smoke`
- `npm run browser-probe-assertions-smoke`
- `npm run browser-probe-web-performance-smoke`
- `npm run browser-probe-layout-shift-smoke`
- `git diff --check`

## Notes
- `npm run browser-probe-assertions-smoke` hit one transient WordPress.org startup asset fetch failure, then passed on rerun without code changes.
- Dist and `.tsbuildinfo` output from local builds is ignored in this checkout, so the synced-source dogfood trap did not reproduce as a worktree-dirtying WP Codebox change. The remaining source-sync behavior appears to belong to the caller/sync policy rather than this browser-probe hardening path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the browser-probe assertion hardening, updated smoke coverage, ran focused verification, and drafted this PR description for Chris to review.