### PR TITLE
Share recipe source policy evaluation

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -98,6 +98,11 @@ export interface ParsedRecipeSource {
   wporgSlug?: string
 }
 
+export interface RecipeSourcePolicyIssue {
+  code: string
+  message: string
+}
+
 export const ALLOW_NETWORK_DOWNLOADS_ENV = "WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS"
 export const ALLOWED_DOWNLOAD_HOSTS_ENV = "WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS"
 export const REQUIRE_SOURCE_SHA256_ENV = "WP_CODEBOX_REQUIRE_SOURCE_SHA256"
@@ -115,6 +120,43 @@ const PHP_SCOPER_URL = `https://github.com/humbug/php-scoper/releases/download/$
 
 export function isSha256(value: string): boolean {
   return /^[a-f0-9]{64}$/i.test(value)
+}
+
+export function evaluateRecipeSourcePolicy(source: ParsedRecipeSource, expectedSha256?: string): RecipeSourcePolicyIssue[] {
+  if (source.type === "local") {
+    return []
+  }
+
+  const issues: RecipeSourcePolicyIssue[] = []
+  if (process.env[ALLOW_NETWORK_DOWNLOADS_ENV] !== "1") {
+    issues.push({
+      code: "network-downloads-disabled",
+      message: `External recipe sources require ${ALLOW_NETWORK_DOWNLOADS_ENV}=1 before WP Codebox downloads anything.`,
+    })
+  }
+
+  if (!allowedDownloadHosts().includes(source.host)) {
+    issues.push({
+      code: "download-host-not-allowed",
+      message: `External recipe source host is not allowed: ${source.host}`,
+    })
+  }
+
+  if (expectedSha256 !== undefined && !isSha256(expectedSha256)) {
+    issues.push({
+      code: "invalid-source-sha256",
+      message: "External recipe source sha256 must be a 64-character hex digest.",
+    })
+  }
+
+  if (sourceSha256Required() && !expectedSha256) {
+    issues.push({
+      code: "missing-source-sha256",
+      message: `External recipe sources require sha256 when ${REQUIRE_SOURCE_SHA256_ENV}=1.`,
+    })
+  }
+
+  return issues
 }
 
 export function sourceSha256Required(): boolean {
@@ -663,12 +705,9 @@ async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, s
     }
   }
 
-  if (process.env[ALLOW_NETWORK_DOWNLOADS_ENV] !== "1") {
-    throw new Error(`External recipe sources require ${ALLOW_NETWORK_DOWNLOADS_ENV}=1 before WP Codebox downloads anything.`)
-  }
-
-  if (!allowedDownloadHosts().includes(source.host)) {
-    throw new Error(`External recipe source host is not allowed: ${source.host}`)
+  const [policyIssue] = evaluateRecipeSourcePolicy(source, expectedSha256)
+  if (policyIssue) {
+    throw new Error(policyIssue.message)
   }
 
   const directory = await mkdtemp(join(tmpdir(), `wp-codebox-source-${slug}-`))

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,7 +1,7 @@
 import { stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
-import { ALLOW_NETWORK_DOWNLOADS_ENV, REQUIRE_SOURCE_SHA256_ENV, allowedDownloadHosts, isSha256, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile, sourceSha256Required } from "./recipe-sources.js"
+import { evaluateRecipeSourcePolicy, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 
 export interface RecipeValidationIssue {
   code: string
@@ -1302,28 +1302,8 @@ function validateAbsoluteSandboxPath(path: string, issuePath: string, addIssue: 
 }
 
 function validateRecipeSource(source: ReturnType<typeof recipeSource>, issuePath: string, addIssue: (code: string, path: string, message: string) => void, expectedSha256?: string): void {
-  if (source.type === "local") {
-    return
-  }
-
-  if (process.env[ALLOW_NETWORK_DOWNLOADS_ENV] !== "1") {
-    addIssue(
-      "network-downloads-disabled",
-      issuePath,
-      `External recipe sources require ${ALLOW_NETWORK_DOWNLOADS_ENV}=1 before WP Codebox downloads anything.`,
-    )
-  }
-
-  if (!allowedDownloadHosts().includes(source.host)) {
-    addIssue("download-host-not-allowed", issuePath, `External recipe source host is not allowed: ${source.host}`)
-  }
-
-  if (expectedSha256 !== undefined && !isSha256(expectedSha256)) {
-    addIssue("invalid-source-sha256", issuePath, "External recipe source sha256 must be a 64-character hex digest.")
-  }
-
-  if (sourceSha256Required() && !expectedSha256) {
-    addIssue("missing-source-sha256", issuePath, `External recipe sources require sha256 when ${REQUIRE_SOURCE_SHA256_ENV}=1.`)
+  for (const issue of evaluateRecipeSourcePolicy(source, expectedSha256)) {
+    addIssue(issue.code, issuePath, issue.message)
   }
 }
 

--- a/scripts/recipe-source-redirect-smoke.ts
+++ b/scripts/recipe-source-redirect-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 
-import { recipeRedirectSource, recipeSource } from "../packages/cli/src/recipe-sources.js"
+import { evaluateRecipeSourcePolicy, prepareRecipeExtraPlugins, recipeRedirectSource, recipeSource } from "../packages/cli/src/recipe-sources.js"
 
 const source = recipeSource(
   "https://github.com/Extra-Chill/data-machine/releases/download/v0.140.1/data-machine.zip",
@@ -25,3 +25,80 @@ assert.throws(
   () => recipeRedirectSource(source, "http://release-assets.githubusercontent.com/github-production-release-asset/123/data-machine.zip"),
   /non-HTTPS URL/,
 )
+
+const originalAllowNetworkDownloads = process.env.WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS
+const originalAllowedDownloadHosts = process.env.WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS
+const originalRequireSourceSha256 = process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256
+
+try {
+  process.env.WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS = ""
+  process.env.WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS = "downloads.wordpress.org"
+  process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256 = ""
+  assert.deepEqual(evaluateRecipeSourcePolicy(source, source.expectedSha256).map((issue) => issue.code), [
+    "network-downloads-disabled",
+    "download-host-not-allowed",
+  ])
+
+  process.env.WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS = "1"
+  process.env.WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS = "github.com"
+  process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256 = "1"
+  assert.deepEqual(evaluateRecipeSourcePolicy(recipeSource("https://github.com/example/plugin.zip")).map((issue) => issue.code), [
+    "missing-source-sha256",
+  ])
+
+  assert.deepEqual(evaluateRecipeSourcePolicy(recipeSource("https://github.com/example/plugin.zip", "not-a-digest"), "not-a-digest").map((issue) => issue.code), [
+    "invalid-source-sha256",
+  ])
+
+  process.env.WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS = "downloads.wordpress.org"
+  await assert.rejects(
+    () => prepareRecipeExtraPlugins({
+      schema: "wp-codebox/workspace-recipe/v1",
+      inputs: {
+        extraPlugins: [
+          {
+            source: "https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
+            pluginFile: "bbpress/bbpress.php",
+          },
+        ],
+      },
+      workflow: { steps: [{ command: "wordpress.run-php", args: ["code=echo 'source policy';"] }] },
+    }, process.cwd()),
+    /External recipe sources require sha256 when WP_CODEBOX_REQUIRE_SOURCE_SHA256=1\./,
+  )
+
+  process.env.WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS = ""
+  process.env.WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS = "downloads.wordpress.org"
+  process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256 = ""
+  await assert.rejects(
+    () => prepareRecipeExtraPlugins({
+      schema: "wp-codebox/workspace-recipe/v1",
+      inputs: {
+        extraPlugins: [
+          {
+            source: "https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
+            pluginFile: "bbpress/bbpress.php",
+          },
+        ],
+      },
+      workflow: { steps: [{ command: "wordpress.run-php", args: ["code=echo 'source policy';"] }] },
+    }, process.cwd()),
+    /External recipe sources require WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS=1 before WP Codebox downloads anything\./,
+  )
+} finally {
+  if (originalAllowNetworkDownloads === undefined) {
+    delete process.env.WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS
+  } else {
+    process.env.WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS = originalAllowNetworkDownloads
+  }
+  if (originalAllowedDownloadHosts === undefined) {
+    delete process.env.WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS
+  } else {
+    process.env.WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS = originalAllowedDownloadHosts
+  }
+  if (originalRequireSourceSha256 === undefined) {
+    delete process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256
+  } else {
+    process.env.WP_CODEBOX_REQUIRE_SOURCE_SHA256 = originalRequireSourceSha256
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared recipe source policy evaluator for network, host, and sha256 source checks.
- Use the shared evaluator from both recipe validation and source preparation so both paths keep the same policy messages.
- Extend the source redirect smoke to cover evaluator output and preparation-side policy failures before download.

Closes #771.

## Checks
- npm run build
- npm run recipe-dry-run-smoke
- npm run recipe-source-redirect-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the shared source policy evaluator, updated validation/preparation call sites, added focused smoke coverage, and ran the checks above. Chris remains responsible for review and testing.