### PR TITLE
Refactor runtime command argument parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "durable-artifact-preview-smoke": "tsx scripts/durable-artifact-preview-smoke.ts",
     "external-adapter-contract-smoke": "tsx scripts/external-adapter-contract-smoke.ts",
     "command-registry-smoke": "tsx scripts/command-registry-smoke.ts",
+    "command-args-smoke": "tsx scripts/command-args-smoke.ts",
     "host-tool-registry-smoke": "tsx scripts/host-tool-registry-smoke.ts",
     "host-command-tool-smoke": "tsx scripts/host-command-tool-smoke.ts",
     "sandbox-tool-policy-smoke": "tsx scripts/sandbox-tool-policy-smoke.ts",

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -10,7 +10,7 @@ import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionS
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
-import { argValue, cleanWpCliOutput, commaListArg, jsonArrayArg } from "./commands.js"
+import { argValue, cleanWpCliOutput, commaListArg, durationArg, jsonArrayArg, strictBooleanArg, viewportArg } from "./commands.js"
 import { editorActionStepsFromArgs, editorOpenTargetFromArgs, type EditorActionStep } from "./editor-actions.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
@@ -222,7 +222,7 @@ async function runSingleBrowserProbeCommand({
   const prePageScript = argValue(args, "pre-page-script")
   const script = argValue(args, "script")
   const authRequest = browserAuthRequest(args)
-  const failFast = booleanArg(args, "fail-fast", false)
+  const failFast = strictBooleanArg(args, "fail-fast", false)
   const stallTimeoutMs = durationArg(args, "stall-timeout", 0)
   const lifecycleSelectors = commaListArg(args, "observe")
   const routedHosts = commaListArg(args, "route-host")
@@ -1023,7 +1023,7 @@ export async function runEditorCanvasProbeCommand({
   }
 
   const capture = new Set(commaListArg(args, "capture"))
-  if (booleanArg(args, "screenshot", false)) {
+  if (strictBooleanArg(args, "screenshot", false)) {
     capture.add("screenshot")
   }
   for (const item of capture) {
@@ -2414,9 +2414,9 @@ export async function runVisualCompareCommand({
   const waitFor = argValue(args, "wait-for")?.trim() || "domcontentloaded"
   const durationMs = durationArg(args, "duration", 0)
   const requestedViewport = viewportArg(args, "viewport")
-  const fullPage = booleanArg(args, "full-page", true)
+  const fullPage = strictBooleanArg(args, "full-page", true)
   const threshold = numberArg(args, "threshold", 0.1)
-  const includeAA = booleanArg(args, "include-aa", false)
+  const includeAA = strictBooleanArg(args, "include-aa", false)
   const maxRegions = positiveIntegerArg(args, "max-regions", 8)
 
   if (threshold < 0 || threshold > 1) {
@@ -3022,7 +3022,7 @@ function browserProbeNetworkPolicy(args: string[], routeHosts: string[], preview
     blockHosts,
     routeHosts: routedHosts,
     firstPartyHosts,
-    recordExternal: booleanArg(args, "record-external", false),
+    recordExternal: strictBooleanArg(args, "record-external", false),
     stats: new Map(),
   }
 }
@@ -3382,20 +3382,6 @@ async function browserProbeTerminalFailure(page: import("playwright").Page): Pro
   }).catch(() => undefined)
 }
 
-function booleanArg(args: string[], name: string, fallback: boolean): boolean {
-  const raw = argValue(args, name)?.trim().toLowerCase()
-  if (!raw) {
-    return fallback
-  }
-  if (["1", "true", "yes", "on"].includes(raw)) {
-    return true
-  }
-  if (["0", "false", "no", "off"].includes(raw)) {
-    return false
-  }
-  throw new Error(`${name} must be true or false`)
-}
-
 function numberArg(args: string[], name: string, fallback: number): number {
   const raw = argValue(args, name)?.trim()
   if (!raw) {
@@ -3418,39 +3404,4 @@ function positiveIntegerArg(args: string[], name: string, fallback: number): num
     throw new Error(`${name} must be a positive integer`)
   }
   return parsed
-}
-
-function durationArg(args: string[], name: string, fallbackMs: number): number {
-  const raw = argValue(args, name)?.trim()
-  if (!raw) {
-    return fallbackMs
-  }
-
-  const match = raw.match(/^(\d+(?:\.\d+)?)(ms|s)$/)
-  if (!match) {
-    throw new Error(`${name} must be a duration like 500ms or 2s`)
-  }
-
-  const value = Number.parseFloat(match[1])
-  return Math.max(0, Math.round(match[2] === "ms" ? value : value * 1000))
-}
-
-function viewportArg(args: string[], name: string): { width: number; height: number } | undefined {
-  const raw = argValue(args, name)?.trim()
-  if (!raw) {
-    return undefined
-  }
-
-  const match = raw.match(/^(\d+)x(\d+)$/i)
-  if (!match) {
-    throw new Error(`${name} must use <width>x<height>, for example 390x844: ${raw}`)
-  }
-
-  const width = Number.parseInt(match[1] ?? "", 10)
-  const height = Number.parseInt(match[2] ?? "", 10)
-  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
-    throw new Error(`${name} width and height must be positive integers: ${raw}`)
-  }
-
-  return { width, height }
 }

--- a/packages/runtime-playground/src/command-args.ts
+++ b/packages/runtime-playground/src/command-args.ts
@@ -33,6 +33,55 @@ export function booleanArg(args: string[], name: string, fallback = false): bool
   return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase())
 }
 
+export function strictBooleanArg(args: string[], name: string, fallback: boolean): boolean {
+  const raw = argValue(args, name)?.trim().toLowerCase()
+  if (!raw) {
+    return fallback
+  }
+  if (["1", "true", "yes", "on"].includes(raw)) {
+    return true
+  }
+  if (["0", "false", "no", "off"].includes(raw)) {
+    return false
+  }
+  throw new Error(`${name} must be true or false`)
+}
+
+export function durationArg(args: string[], name: string, fallbackMs: number): number {
+  const raw = argValue(args, name)?.trim()
+  if (!raw) {
+    return fallbackMs
+  }
+
+  const match = raw.match(/^(\d+(?:\.\d+)?)(ms|s)$/)
+  if (!match) {
+    throw new Error(`${name} must be a duration like 500ms or 2s`)
+  }
+
+  const value = Number.parseFloat(match[1])
+  return Math.max(0, Math.round(match[2] === "ms" ? value : value * 1000))
+}
+
+export function viewportArg(args: string[], name: string): { width: number; height: number } | undefined {
+  const raw = argValue(args, name)?.trim()
+  if (!raw) {
+    return undefined
+  }
+
+  const match = raw.match(/^(\d+)x(\d+)$/i)
+  if (!match) {
+    throw new Error(`${name} must use <width>x<height>, for example 390x844: ${raw}`)
+  }
+
+  const width = Number.parseInt(match[1] ?? "", 10)
+  const height = Number.parseInt(match[2] ?? "", 10)
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    throw new Error(`${name} width and height must be positive integers: ${raw}`)
+  }
+
+  return { width, height }
+}
+
 export function commaListArg(args: string[], name: string): string[] {
   return (argValue(args, name) ?? "").split(",").map((item) => item.trim()).filter(Boolean)
 }

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -1,5 +1,6 @@
 import { createHostToolTransportError, executeHostTool, getCommandDefinition, type HostToolRegistry, type JsonValue, type PlaygroundRuntimeCommandId } from "@automattic/wp-codebox-core"
 import type { ExecutionSpec } from "@automattic/wp-codebox-core"
+import { argValue } from "./command-args.js"
 
 interface PlaygroundCommandRuntime {
   inspectMountedInputs(): Promise<string>
@@ -92,9 +93,4 @@ function hostToolInput(args: string[]): JsonValue {
     }
   }
   return input
-}
-
-function argValue(args: string[], name: string): string | undefined {
-  const prefix = `${name}=`
-  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length)
 }

--- a/scripts/command-args-smoke.ts
+++ b/scripts/command-args-smoke.ts
@@ -1,0 +1,35 @@
+import { durationArg, strictBooleanArg, viewportArg } from "../packages/runtime-playground/src/command-args.js"
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function assertThrows(fn: () => unknown, message: string): void {
+  try {
+    fn()
+  } catch {
+    return
+  }
+  throw new Error(message)
+}
+
+function main(): void {
+  assert(strictBooleanArg(["flag=true"], "flag", false) === true, "strict boolean parses true")
+  assert(strictBooleanArg(["flag=0"], "flag", true) === false, "strict boolean parses false")
+  assert(strictBooleanArg([], "flag", true) === true, "strict boolean preserves fallback")
+  assertThrows(() => strictBooleanArg(["flag=maybe"], "flag", false), "strict boolean rejects invalid values")
+
+  assert(durationArg(["timeout=500ms"], "timeout", 0) === 500, "duration parses milliseconds")
+  assert(durationArg(["timeout=1.5s"], "timeout", 0) === 1500, "duration parses seconds")
+  assert(durationArg([], "timeout", 250) === 250, "duration preserves fallback")
+  assertThrows(() => durationArg(["timeout=5m"], "timeout", 0), "duration rejects unsupported units")
+
+  const viewport = viewportArg(["viewport=390x844"], "viewport")
+  assert(viewport?.width === 390 && viewport.height === 844, "viewport parses width and height")
+  assert(viewportArg([], "viewport") === undefined, "viewport preserves empty fallback")
+  assertThrows(() => viewportArg(["viewport=0x844"], "viewport"), "viewport rejects non-positive dimensions")
+}
+
+main()


### PR DESCRIPTION
## Summary
- Centralizes runtime command arg helpers for strict booleans, durations, and viewport values in `command-args.ts`.
- Updates the command router and browser command runners to use shared parsing helpers instead of local duplicates.
- Adds a focused command-argument smoke test for strict boolean, duration, and viewport parsing behavior.

Closes #762.

## Checks
- `npm run build`
- `npm run command-args-smoke`
- `npm run command-registry-smoke`
- `npm run browser-probe-artifact-smoke`
- `npm run browser-probe-context-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused parser refactor, added smoke coverage, and ran local verification. Chris remains responsible for review and acceptance.