### PR TITLE
Clarify recipe evidence manifest refresh

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -1178,10 +1178,15 @@ async function updateRecipeArtifactEvidenceReferences(artifacts: ArtifactBundle,
   review.evidence = { ...reviewEvidence, runtimeEvidence: { ...(isRecord(reviewEvidence.runtimeEvidence) ? reviewEvidence.runtimeEvidence : {}), ...evidence } }
   await writeFile(artifacts.reviewPath, `${JSON.stringify(review, null, 2)}\n`)
 
-  await refreshArtifactManifestFileSha256s(artifacts.directory, manifest)
-  await refreshRuntimeReferenceFiles(artifacts.directory, manifest)
-  await refreshArtifactManifestFileSha256s(artifacts.directory, manifest)
+  await refreshManifestAfterEvidenceMutation(artifacts.directory, manifest)
   await writeFile(artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+async function refreshManifestAfterEvidenceMutation(artifactRoot: string, manifest: ArtifactManifest): Promise<void> {
+  // Runtime reference files embed manifest hashes, then become manifest-hashed artifacts themselves.
+  await refreshArtifactManifestFileSha256s(artifactRoot, manifest)
+  await refreshRuntimeReferenceFiles(artifactRoot, manifest)
+  await refreshArtifactManifestFileSha256s(artifactRoot, manifest)
 }
 
 async function refreshRuntimeReferenceFiles(artifactRoot: string, manifest: ArtifactManifest): Promise<void> {

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -238,6 +238,8 @@ try {
   assert.equal(runtimeReferenceIndex.summary.present, runtimeReferenceIndex.present.length)
   assert.equal(runtimeReferenceIndex.summary.missing, runtimeReferenceIndex.missing.length)
   assert.equal(runtimeReplayReferenceIndex.schema, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA)
+  const runtimeReplayManifestFile = manifestFile(manifest, "files/runtime-replay-index.json")
+  assert.equal(runtimeReplayManifestFile.sha256.value, sha256(await readFile(join(artifacts.directory, "files/runtime-replay-index.json"))))
   assert.equal(runtimeReplayReferenceIndex.artifactBundle.id, artifacts.id)
   assert.equal(runtimeReplayReferenceIndex.artifactBundle.digest.value, artifacts.contentDigest)
   assert.equal(runtimeReplayReferenceIndex.digest.value, runtimeReplayReferenceIndexDigest(runtimeReplayReferenceIndex).value)
@@ -248,6 +250,8 @@ try {
   assert.equal(runtimeReplayReferenceIndex.replay.status, "partial")
   assert.equal(runtimeReplayReferenceIndex.snapshots.length, 0)
   assert.equal(runtimeReferenceManifest.schema, RUNTIME_REFERENCE_MANIFEST_SCHEMA)
+  const runtimeReferenceManifestFile = manifestFile(manifest, "files/runtime-reference-manifest.json")
+  assert.equal(runtimeReferenceManifestFile.sha256.value, sha256(await readFile(join(artifacts.directory, "files/runtime-reference-manifest.json"))))
   assert.equal(runtimeReferenceManifest.artifactBundle.id, artifacts.id)
   assert.equal(runtimeReferenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
   assert.equal(runtimeReferenceManifest.digest.value, runtimeReferenceManifestDigest(runtimeReferenceManifest).value)
@@ -510,4 +514,14 @@ try {
   console.log("Artifact contract smoke passed")
 } finally {
   await rm(artifactsDirectory, { recursive: true, force: true })
+}
+
+function manifestFile(manifest: { files: Array<{ path: string; sha256: { value: string } }> }, path: string): { sha256: { value: string } } {
+  const file = manifest.files.find((entry) => entry.path === path)
+  assert.ok(file, `Expected manifest file ${path}`)
+  return file
+}
+
+function sha256(contents: Buffer): string {
+  return createHash("sha256").update(contents).digest("hex")
 }

--- a/tests/fixtures/artifact-package-provenance-shape.json
+++ b/tests/fixtures/artifact-package-provenance-shape.json
@@ -2,15 +2,15 @@
   "schema": "wp-codebox/package-provenance/v1",
   "wpCodebox": {
     "name": "wp-codebox-workspace",
-    "version": "0.7.2"
+    "version": "0.7.3"
   },
   "runtimeCore": {
     "name": "@automattic/wp-codebox-core",
-    "version": "0.7.2"
+    "version": "0.7.3"
   },
   "runtimePlayground": {
     "name": "@automattic/wp-codebox-playground",
-    "version": "0.7.2"
+    "version": "0.7.3"
   },
   "playground": {
     "cli": {


### PR DESCRIPTION
## Summary
- Extracts the recipe evidence manifest refresh sequence into `refreshManifestAfterEvidenceMutation()` so the required ordering has a single named owner.
- Keeps the pre/post runtime-reference refresh passes because runtime reference files embed manifest hashes and then become manifest-hashed artifacts themselves.
- Extends `artifact-contract-smoke` to assert runtime reference/replay manifest entries match the final file bytes, and updates the stale package provenance fixture to the current `0.7.3` package version.

Closes https://github.com/Automattic/wp-codebox/issues/773

## Checks
- `npm run build`
- `npm run artifact-contract-smoke`
- `npm run recipe-runtime-evidence-smoke`
- `npm run runtime-reference-index-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the manifest refresh sequence, drafted the helper/test changes, ran focused checks, and prepared this PR for Chris to review.