### PR TITLE
Clarify recipe validation pipeline

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -14,7 +14,7 @@ import { dryRunRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStep
 import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, type AgentSandboxResultSummary, type AgentTaskSingleResult, type SandboxCompletionOutcome } from "../recipe-evidence.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
-import { parseWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "../recipe-validation.js"
+import { loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
 
 interface RecipeRunOptions {
@@ -787,7 +787,7 @@ function recipeArtifactPointerPaths(directory: string, runtime: RuntimeInfo | un
 async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterruptionController): Promise<RecipeRunOutput> {
   const recipePath = resolve(options.recipePath)
   const recipeDirectory = dirname(recipePath)
-  const recipe = parseWorkspaceRecipe(await readFile(recipePath, "utf8"), recipePath)
+  const recipe = await loadWorkspaceRecipe(recipePath)
   const configuredArtifactsDirectory = options.artifactsDirectory ?? recipe.artifacts?.directory
   const runRegistry = new RuntimeRunRegistry(options.runRegistryDirectory ?? defaultRunRegistryDirectory(configuredArtifactsDirectory))
   const startedAtMs = Date.now()
@@ -1463,8 +1463,7 @@ async function prepareRecipeRuntimeOverlaysForRun(recipe: WorkspaceRecipe, recip
 async function validateRecipe(options: RecipeValidateOptions): Promise<RecipeValidateOutput> {
   const recipePath = resolve(options.recipePath)
   try {
-    const raw = await readFile(recipePath, "utf8")
-    const recipe = parseWorkspaceRecipe(raw, recipePath)
+    const recipe = await loadWorkspaceRecipe(recipePath)
     const issues = await validateWorkspaceRecipe(recipe, recipePath)
 
     return {

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -1,9 +1,8 @@
-import { readFile } from "node:fs/promises"
 import { basename, dirname, resolve } from "node:path"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined, validateRuntimePolicy, type MountSpec, type RuntimePolicy, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { serializeError } from "./output.js"
 import { defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
-import { hasExplicitSiteSeedSelectors, parseWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
+import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
 
 export interface RecipeDryRunOptions {
   recipePath: string
@@ -237,8 +236,7 @@ export async function dryRunRecipe(options: RecipeDryRunOptions, context: Recipe
   const recipePath = resolve(options.recipePath)
   try {
     const recipeDirectory = dirname(recipePath)
-    const raw = await readFile(recipePath, "utf8")
-    const recipe = parseWorkspaceRecipe(raw, recipePath)
+    const recipe = await loadWorkspaceRecipe(recipePath)
     const issues = await validateWorkspaceRecipe(recipe, recipePath)
 
     if (issues.length > 0) {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { evaluateRecipeSourcePolicy, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
@@ -21,9 +21,32 @@ export const defaultPolicy: RuntimePolicy = {
 
 const supportedRecipeCommands = new Set(recipeCommandDefinitions().map((command) => command.id))
 
-export function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe {
-  const recipe = JSON.parse(raw) as WorkspaceRecipe
+export async function loadWorkspaceRecipe(recipePath: string): Promise<WorkspaceRecipe> {
+  return parseWorkspaceRecipe(await readFile(recipePath, "utf8"), recipePath)
+}
 
+export function parseWorkspaceRecipe(raw: string, recipePath: string): WorkspaceRecipe {
+  const recipe = parseWorkspaceRecipeJson(raw)
+  normalizeWorkspaceRecipeCompatibility(recipe)
+  validateWorkspaceRecipeShape(recipe, recipePath)
+
+  return recipe
+}
+
+export function parseWorkspaceRecipeJson(raw: string): WorkspaceRecipe {
+  return JSON.parse(raw) as WorkspaceRecipe
+}
+
+export function normalizeWorkspaceRecipeCompatibility(recipe: WorkspaceRecipe): WorkspaceRecipe {
+  if (recipe.inputs?.extraPlugins !== undefined) {
+    recipe.inputs.extra_plugins ??= recipe.inputs.extraPlugins
+    delete recipe.inputs.extraPlugins
+  }
+
+  return recipe
+}
+
+export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath: string): void {
   if (recipe.schema !== "wp-codebox/workspace-recipe/v1") {
     throw new Error(`Unsupported recipe schema in ${recipePath}`)
   }
@@ -107,7 +130,7 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
     }
   }
 
-  const rawExtraPlugins = recipe.inputs?.extra_plugins ?? recipe.inputs?.extraPlugins
+  const rawExtraPlugins = recipe.inputs?.extra_plugins
   if (rawExtraPlugins && !Array.isArray(rawExtraPlugins)) {
     throw new Error(`Recipe extra_plugins must be an array: ${recipePath}`)
   }
@@ -186,7 +209,6 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
     }
   }
 
-  return recipe
 }
 
 function validateRecipeRuntimePreview(preview: RuntimePreviewSpec | undefined, recipePath: string): void {
@@ -334,6 +356,10 @@ function validateRecipeRuntimeOverlays(overlays: WorkspaceRecipeRuntimeOverlay[]
 }
 
 export async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: string): Promise<RecipeValidationIssue[]> {
+  return validateWorkspaceRecipeSemantics(recipe, recipePath)
+}
+
+export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, recipePath: string): Promise<RecipeValidationIssue[]> {
   const recipeDirectory = dirname(recipePath)
   const issues: RecipeValidationIssue[] = []
   const addIssue = (code: string, path: string, message: string): void => {

--- a/scripts/recipe-dry-run-smoke.ts
+++ b/scripts/recipe-dry-run-smoke.ts
@@ -13,6 +13,7 @@ const externalRecipePath = resolve(workspace, "external-recipe.json")
 const externalDisabledRecipePath = resolve(workspace, "external-disabled-recipe.json")
 const externalUntrustedHostRecipePath = resolve(workspace, "external-untrusted-host-recipe.json")
 const externalStrictDigestRecipePath = resolve(workspace, "external-strict-digest-recipe.json")
+const legacyExtraPluginsRecipePath = resolve(workspace, "legacy-extra-plugins-recipe.json")
 const distributionRecipePath = resolve(workspace, "distribution-recipe.json")
 const invalidDistributionRecipePath = resolve(workspace, "invalid-distribution-recipe.json")
 const invalidSiteSeedRecipePath = resolve(workspace, "invalid-site-seed-recipe.json")
@@ -182,6 +183,19 @@ const externalRecipe = {
 
 writeFileSync(externalRecipePath, `${JSON.stringify(externalRecipe, null, 2)}\n`)
 writeFileSync(externalDisabledRecipePath, `${JSON.stringify(externalRecipe, null, 2)}\n`)
+writeFileSync(legacyExtraPluginsRecipePath, `${JSON.stringify({
+  ...externalRecipe,
+  inputs: {
+    extraPlugins: [
+      {
+        source: "../../examples/simple-plugin",
+        slug: "simple-plugin",
+        pluginFile: "simple-plugin/simple-plugin.php",
+        activate: false,
+      },
+    ],
+  },
+}, null, 2)}\n`)
 writeFileSync(externalUntrustedHostRecipePath, `${JSON.stringify({
   ...externalRecipe,
   inputs: {
@@ -416,6 +430,21 @@ assert.equal(externalOutput.plan.extra_plugins[0].provenance.resolvedUrl, "https
 assert.equal(externalOutput.plan.extra_plugins[1].sourceType, "https_zip")
 assert.equal(externalOutput.plan.extra_plugins[1].provenance.kind, "https_zip")
 assert.equal(externalOutput.plan.extra_plugins[1].provenance.policy.host, "example.com")
+
+const legacyExtraPluginsResult = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  legacyExtraPluginsRecipePath,
+  "--dry-run",
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(legacyExtraPluginsResult.status, 0, legacyExtraPluginsResult.stderr || legacyExtraPluginsResult.stdout)
+const legacyExtraPluginsOutput = JSON.parse(legacyExtraPluginsResult.stdout)
+assert.equal(legacyExtraPluginsOutput.success, true)
+assert.equal(legacyExtraPluginsOutput.plan.extra_plugins.length, 1)
+assert.equal(legacyExtraPluginsOutput.plan.extra_plugins[0].slug, "simple-plugin")
 
 const externalUntrustedHostResult = spawnSync(process.execPath, [
   cli,


### PR DESCRIPTION
## Summary
- Split recipe loading into explicit JSON parsing, compatibility normalization, shape validation, and semantic validation boundaries.
- Normalize the legacy `inputs.extraPlugins` alias to canonical `inputs.extra_plugins` once when a recipe is loaded.
- Add dry-run smoke coverage for the legacy alias path while preserving existing recipe validation behavior.

## Testing
- `npm run build`
- `npm run recipe-dry-run-smoke`
- `node packages/cli/dist/index.js recipe validate --recipe examples/recipes/cookbook/multisite-network.json --json`
- `node packages/cli/dist/index.js recipe validate --recipe artifacts/recipe-dry-run-smoke/legacy-extra-plugins-recipe.json --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the recipe validation pipeline refactor and targeted smoke coverage; Chris remains responsible for review and testing.

Closes #765.