### PR TITLE
Add painted readiness waits for browser actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "browser-lifecycle-observer-smoke": "tsx scripts/browser-lifecycle-observer-smoke.ts",
     "browser-probe-pre-page-script-smoke": "tsx scripts/browser-probe-pre-page-script-smoke.ts",
     "browser-actions-artifact-smoke": "tsx scripts/browser-actions-artifact-smoke.ts",
+    "browser-actions-painted-readiness-smoke": "tsx scripts/browser-actions-painted-readiness-smoke.ts",
     "browser-scenario-artifact-smoke": "tsx scripts/browser-scenario-artifact-smoke.ts",
     "browser-visual-compare-smoke": "tsx scripts/browser-visual-compare-smoke.ts",
     "browser-action-visual-compare-smoke": "tsx scripts/browser-action-visual-compare-smoke.ts",

--- a/packages/runtime-core/src/browser-interaction.ts
+++ b/packages/runtime-core/src/browser-interaction.ts
@@ -50,7 +50,7 @@ export interface BrowserInteractionStep {
   value?: string
   /** Keyboard key for `press`. */
   key?: string
-  /** Wait/load condition: domcontentloaded|load|networkidle|selector:<sel>|duration. */
+  /** Wait/load condition: domcontentloaded|load|networkidle|selector:<sel>|duration|painted|frame-painted:<iframe-selector>|frame-url-painted:<url-fragment>. */
   waitFor?: string
   /** Drag source selector for `drag`. */
   from?: string
@@ -64,7 +64,7 @@ export interface BrowserInteractionStep {
   assert?: unknown
   /** Expected locator state for `expect`. */
   state?: BrowserInteractionExpectState
-  /** Optional screenshot name for `screenshot`. */
+  /** Optional screenshot name for `screenshot`; screenshot steps may also use waitFor for painted-readiness waits before capture. */
   name?: string
   /** Optional wait duration (e.g. 500ms, 2s) for `waitFor`/`navigate`. */
   duration?: string

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -229,7 +229,7 @@ export const commandRegistry = [
     description: "Drive the live Playground preview with an ordered interaction script and capture replay/audit evidence artifacts, including per-step results and machine-readable assertions.",
     acceptedArgs: [
       { name: "url", description: "Initial preview path or absolute URL to visit when the script omits an initial navigate step.", format: "path or URL" },
-      { name: "steps-json", description: "Ordered interaction script: navigate, click, fill, type, press, drag, hover, select, waitFor, evaluate, expect, screenshot, and capture steps.", format: "JSON array (inline or @<path>)" },
+      { name: "steps-json", description: "Ordered interaction script: navigate, click, fill, type, press, drag, hover, select, waitFor, evaluate, expect, screenshot, and capture steps. waitFor and screenshot steps support generic painted-readiness waits: painted, frame-painted:<iframe-selector>, and frame-url-painted:<url-fragment>.", format: "JSON array (inline or @<path>)" },
       { name: "actions-json", description: "Back-compat alias for steps-json accepting the legacy navigate/click/fill/press/wait/capture action shape.", format: "JSON array" },
       { name: "step-timeout", description: "Per-step timeout applied to each interaction step.", format: "duration, e.g. 5s or 500ms" },
       { name: "timeout", description: "Total-script timeout bounding the whole interaction run.", format: "duration, e.g. 30s or 1500ms" },

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -562,9 +562,21 @@ export interface BrowserStepRecord {
   duration?: string
   /** Machine-readable assertion outcome for expect/evaluate steps. */
   assertion?: BrowserStepAssertion
+  readiness?: BrowserStepReadiness
   screenshot?: string
   finalUrl?: string
   error?: BrowserProbeErrorRecord
+}
+
+export interface BrowserStepReadiness {
+  mode: "page" | "frame-selector" | "frame-url"
+  selector?: string
+  urlFragment?: string
+  ready: boolean
+  waitedMs: number
+  visibleElementCount: number
+  textLength: number
+  frameUrl?: string
 }
 
 export interface BrowserStepAssertion {

--- a/packages/runtime-playground/src/browser-interactions.ts
+++ b/packages/runtime-playground/src/browser-interactions.ts
@@ -1,14 +1,25 @@
 import { basename, join } from "node:path"
 import type { BrowserInteractionStep } from "@automattic/wp-codebox-core"
-import type { Page } from "playwright"
+import type { Frame, Page } from "playwright"
 import { browserActionLoadState, browserDeepEqual, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
-import type { BrowserProbeErrorRecord, BrowserStepAssertion, BrowserStepRecord } from "./browser-artifacts.js"
+import type { BrowserProbeErrorRecord, BrowserStepAssertion, BrowserStepReadiness, BrowserStepRecord } from "./browser-artifacts.js"
 
 export interface BrowserStepOutcome {
   assertion?: BrowserStepAssertion
+  readiness?: BrowserPaintedReadinessSummary
   screenshot?: string
   screenshotIsDefault?: boolean
   error?: BrowserProbeErrorRecord
+}
+
+type BrowserPaintedReadinessSummary = BrowserStepReadiness
+type BrowserPaintedReadinessWait = "painted" | `frame-painted:${string}` | `frame-url-painted:${string}`
+
+interface BrowserPaintedReadinessTarget {
+  mode: "page" | "frame-selector" | "frame-url"
+  frame: Page | Frame
+  selector?: string
+  urlFragment?: string
 }
 
 function now(): string {
@@ -28,7 +39,12 @@ export async function executeBrowserInteractionStep(
   switch (step.kind) {
     case "navigate": {
       const url = resolveBrowserActionUrl((step.url ?? "").trim(), baseUrl)
-      await page.goto(url, { waitUntil: browserActionLoadState(step.waitFor), timeout })
+      const waitFor = step.waitFor
+      if (isPaintedReadinessWait(waitFor)) {
+        await page.goto(url, { waitUntil: "domcontentloaded", timeout })
+        return { readiness: await waitForPaintedReadiness(page, waitFor, timeout) }
+      }
+      await page.goto(url, { waitUntil: browserActionLoadState(waitFor), timeout })
       return {}
     }
     case "click": {
@@ -80,8 +96,7 @@ export async function executeBrowserInteractionStep(
       return {}
     }
     case "waitFor": {
-      await browserStepWaitFor(page, step, timeout)
-      return {}
+      return await browserStepWaitFor(page, step, timeout)
     }
     case "evaluate": {
       const result = await page.evaluate(async (source) => {
@@ -107,12 +122,14 @@ export async function executeBrowserInteractionStep(
       return { assertion: { kind: "expect", selector, state, passed } }
     }
     case "screenshot": {
+      const readiness = isPaintedReadinessWait(step.waitFor) ? await waitForPaintedReadiness(page, step.waitFor, timeout) : undefined
       const path = typeof step.name === "string" && step.name.length > 0
         ? join(browserDirectory, `screenshot-${sanitizeScreenshotName(step.name)}.png`)
         : defaultScreenshotPath
       await page.screenshot({ path, fullPage: true })
       const isDefault = path === defaultScreenshotPath
       return {
+        ...(readiness ? { readiness } : {}),
         screenshot: isDefault ? "files/browser/screenshot.png" : `files/browser/${basename(path)}`,
         screenshotIsDefault: isDefault,
       }
@@ -148,25 +165,106 @@ function requireFrom(step: BrowserInteractionStep): string {
   return step.from
 }
 
-async function browserStepWaitFor(page: Page, step: BrowserInteractionStep, timeout: number): Promise<void> {
+async function browserStepWaitFor(page: Page, step: BrowserInteractionStep, timeout: number): Promise<BrowserStepOutcome> {
   if (typeof step.selector === "string" && step.selector.length > 0) {
     await page.locator(step.selector).waitFor({ timeout })
-    return
+    return {}
   }
-  const waitFor = typeof step.waitFor === "string" ? step.waitFor : "load"
+  const waitFor: string = typeof step.waitFor === "string" ? step.waitFor : "load"
+  if (isPaintedReadinessWait(waitFor)) {
+    return { readiness: await waitForPaintedReadiness(page, waitFor, timeout) }
+  }
   if (waitFor === "domcontentloaded" || waitFor === "load" || waitFor === "networkidle") {
     await page.waitForLoadState(waitFor)
-    return
+    return {}
   }
   if (waitFor === "duration") {
     await page.waitForTimeout(durationStringMs(step.duration))
-    return
+    return {}
   }
   if (waitFor.startsWith("selector:")) {
     await page.locator(waitFor.slice("selector:".length)).waitFor({ timeout })
-    return
+    return {}
   }
-  throw new Error(`wordpress.browser-actions waitFor supports selector, domcontentloaded, load, networkidle, duration, selector:<sel>: ${waitFor}`)
+  throw new Error(`wordpress.browser-actions waitFor supports selector, domcontentloaded, load, networkidle, duration, selector:<sel>, painted, frame-painted:<iframe-selector>, frame-url-painted:<url-fragment>: ${waitFor}`)
+}
+
+function isPaintedReadinessWait(waitFor: unknown): waitFor is BrowserPaintedReadinessWait {
+  return waitFor === "painted" || (typeof waitFor === "string" && (waitFor.startsWith("frame-painted:") || waitFor.startsWith("frame-url-painted:")))
+}
+
+async function waitForPaintedReadiness(page: Page, waitFor: BrowserPaintedReadinessWait, timeout: number): Promise<BrowserPaintedReadinessSummary> {
+  const startedAt = Date.now()
+  const target = await paintedReadinessTarget(page, waitFor, timeout)
+  const result = await target.frame.waitForFunction(() => {
+    const visible = Array.from(document.body?.querySelectorAll("*") ?? [])
+      .map((element) => {
+        const rect = element.getBoundingClientRect()
+        const computed = window.getComputedStyle(element)
+        if (rect.width <= 0 || rect.height <= 0 || computed.display === "none" || computed.visibility === "hidden" || computed.opacity === "0") {
+          return null
+        }
+        const text = (element.textContent || "").replace(/\s+/g, " ").trim()
+        const hasPaintedBox = computed.backgroundColor !== "rgba(0, 0, 0, 0)" || computed.backgroundImage !== "none" || Number.parseFloat(computed.borderTopWidth || "0") > 0 || Number.parseFloat(computed.borderRightWidth || "0") > 0 || Number.parseFloat(computed.borderBottomWidth || "0") > 0 || Number.parseFloat(computed.borderLeftWidth || "0") > 0
+        return { textLength: text.length, hasPaintedBox }
+      })
+      .filter((entry): entry is { textLength: number; hasPaintedBox: boolean } => Boolean(entry))
+    const visibleElementCount = visible.length
+    const textLength = visible.reduce((total, entry) => total + entry.textLength, 0)
+    const paintedBoxCount = visible.filter((entry) => entry.hasPaintedBox).length
+    if (visibleElementCount === 0 || (textLength === 0 && paintedBoxCount === 0)) {
+      return false
+    }
+    return { visibleElementCount, textLength }
+  }, undefined, { timeout })
+  const summary = await result.jsonValue() as { visibleElementCount: number; textLength: number }
+  await target.frame.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))))
+  return {
+    mode: target.mode,
+    ...(target.selector ? { selector: target.selector } : {}),
+    ...(target.urlFragment ? { urlFragment: target.urlFragment } : {}),
+    ready: true,
+    waitedMs: Math.max(0, Date.now() - startedAt),
+    visibleElementCount: summary.visibleElementCount,
+    textLength: summary.textLength,
+    ...(target.frame.url() ? { frameUrl: target.frame.url() } : {}),
+  }
+}
+
+async function paintedReadinessTarget(page: Page, waitFor: BrowserPaintedReadinessWait, timeout: number): Promise<BrowserPaintedReadinessTarget> {
+  if (waitFor === "painted") {
+    return { mode: "page", frame: page }
+  }
+  if (waitFor.startsWith("frame-painted:")) {
+    const selector = waitFor.slice("frame-painted:".length).trim()
+    if (!selector) {
+      throw new Error("wordpress.browser-actions frame-painted wait requires an iframe selector")
+    }
+    const locator = page.locator(selector).first()
+    await locator.waitFor({ state: "attached", timeout })
+    const handle = await locator.elementHandle({ timeout })
+    const frame = await handle?.contentFrame()
+    if (!frame) {
+      throw new Error(`wordpress.browser-actions frame-painted wait could not resolve iframe: ${selector}`)
+    }
+    return { mode: "frame-selector", frame, selector }
+  }
+  if (waitFor.startsWith("frame-url-painted:")) {
+    const urlFragment = waitFor.slice("frame-url-painted:".length).trim()
+    if (!urlFragment) {
+      throw new Error("wordpress.browser-actions frame-url-painted wait requires a URL fragment")
+    }
+    const deadline = Date.now() + timeout
+    while (Date.now() <= deadline) {
+      const frame = page.frames().find((candidate) => candidate !== page.mainFrame() && candidate.url().includes(urlFragment))
+      if (frame) {
+        return { mode: "frame-url", frame, urlFragment }
+      }
+      await page.waitForTimeout(100)
+    }
+    throw new Error(`wordpress.browser-actions frame-url-painted wait could not resolve iframe URL fragment: ${urlFragment}`)
+  }
+  throw new Error(`Unsupported painted readiness wait: ${waitFor}`)
 }
 
 async function browserExpectState(page: Page, selector: string, state: string, timeout: number): Promise<boolean> {
@@ -225,6 +323,7 @@ export function browserStepRecord(
     ...(typeof step.waitFor === "string" ? { waitFor: step.waitFor } : {}),
     ...(typeof step.duration === "string" ? { duration: step.duration } : {}),
     ...(outcome.assertion ? { assertion: outcome.assertion } : {}),
+    ...(outcome.readiness ? { readiness: outcome.readiness } : {}),
     ...(outcome.screenshot ? { screenshot: outcome.screenshot } : {}),
     finalUrl,
     ...(outcome.error ? { error: outcome.error } : {}),

--- a/scripts/browser-actions-painted-readiness-smoke.ts
+++ b/scripts/browser-actions-painted-readiness-smoke.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "browser-actions-painted-readiness-smoke")
+const pluginDir = join(workspace, "browser-painted-readiness-fixture")
+const recipePath = join(workspace, "recipe.json")
+const artifactsRoot = join(workspace, "artifacts")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(pluginDir, { recursive: true })
+
+await writeFile(join(pluginDir, "browser-painted-readiness-fixture.php"), `<?php
+/**
+ * Plugin Name: Browser Painted Readiness Fixture
+ */
+add_action('template_redirect', function () {
+    if ( ! isset( $_GET['wp_codebox_painted_readiness_fixture'] ) ) {
+        return;
+    }
+
+    nocache_headers();
+    $frame_html = '<!doctype html><html><body style="margin:0;background:#0f766e;color:white;font:24px sans-serif;display:grid;place-items:center;height:100vh"><main id="rendered">Rendered iframe content</main></body></html>';
+    echo '<!doctype html><html><head><style>body{font-family:sans-serif;margin:0;padding:24px}iframe{width:360px;height:160px;border:4px solid #111827}</style></head><body><button id="render-frame" type="button">Render frame</button><iframe id="preview-frame" title="Preview frame"></iframe><script>const frameHtml = ' . wp_json_encode( $frame_html ) . '; document.getElementById("render-frame").addEventListener("click", function () { setTimeout(function () { document.getElementById("preview-frame").srcdoc = frameHtml; }, 250); });</script></body></html>';
+    exit;
+} );
+`)
+
+await writeFile(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extraPlugins: [
+      {
+        source: "./browser-painted-readiness-fixture",
+        pluginFile: "browser-painted-readiness-fixture/browser-painted-readiness-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.browser-actions",
+        args: [
+          "url=/?wp_codebox_painted_readiness_fixture=1",
+          `steps-json=${JSON.stringify([
+            { kind: "waitFor", selector: "#render-frame" },
+            { kind: "click", selector: "#render-frame" },
+            { kind: "screenshot", name: "frame-painted", waitFor: "frame-painted:#preview-frame" },
+          ])}`,
+          "viewport=480x320",
+          "step-timeout=8s",
+          "capture=steps,errors,screenshot,dom-snapshot",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const output = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--json",
+])
+
+assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
+assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+
+const artifactDirectory = output.artifacts.directory
+const stepsPath = join(artifactDirectory, "files", "browser", "steps.jsonl")
+const screenshotPath = join(artifactDirectory, "files", "browser", "screenshot-frame-painted.png")
+const domSnapshotPath = join(artifactDirectory, "files", "browser", "dom-snapshot-frame-painted.json")
+const summaryPath = join(artifactDirectory, "files", "browser", "action-summary.json")
+
+assert.equal(existsSync(stepsPath), true, "steps.jsonl should be captured")
+assert.equal(existsSync(screenshotPath), true, "painted iframe screenshot should be captured")
+assert.equal(existsSync(domSnapshotPath), true, "painted iframe screenshot should have a DOM sidecar")
+assert.equal(existsSync(summaryPath), true, "action summary should be captured")
+
+const steps = (await readFile(stepsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line)) as Array<{
+  kind: string
+  screenshot?: string
+  readiness?: { mode: string; selector?: string; ready: boolean; visibleElementCount: number; textLength: number; frameUrl?: string }
+}>
+const screenshotStep = steps.find((step) => step.kind === "screenshot")
+assert.equal(screenshotStep?.screenshot, "files/browser/screenshot-frame-painted.png")
+assert.equal(screenshotStep?.readiness?.mode, "frame-selector")
+assert.equal(screenshotStep?.readiness?.selector, "#preview-frame")
+assert.equal(screenshotStep?.readiness?.ready, true)
+assert.ok((screenshotStep?.readiness?.visibleElementCount ?? 0) > 0, "readiness should observe visible rendered iframe elements")
+assert.ok((screenshotStep?.readiness?.textLength ?? 0) > 0, "readiness should observe rendered iframe text")
+assert.match(screenshotStep?.readiness?.frameUrl ?? "", /about:srcdoc|wp_codebox_painted_readiness_fixture/)
+
+const summary = JSON.parse(await readFile(summaryPath, "utf8")) as { steps: Array<{ kind: string; readiness?: unknown }>; files: { domSnapshots?: string[] } }
+assert.ok(summary.steps.some((step) => step.kind === "screenshot" && step.readiness), "summary should preserve screenshot readiness evidence")
+assert.ok(summary.files.domSnapshots?.includes("files/browser/dom-snapshot-frame-painted.json"), "summary should include the screenshot DOM sidecar")
+
+console.log(`Browser actions painted readiness smoke passed: ${artifactDirectory}`)
+
+async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
+  const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => { stdout += chunk })
+  child.stderr.on("data", (chunk) => { stderr += chunk })
+  const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
+  if (code !== 0) {
+    throw new Error(`CLI exited with ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  }
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- Add generic painted-readiness waits for browser action scripts: `painted`, `frame-painted:<iframe-selector>`, and `frame-url-painted:<url-fragment>`.
- Allow screenshot steps to wait for page/frame painted readiness before capture and record machine-readable readiness evidence in `steps.jsonl` / action summaries.
- Add a smoke fixture that clicks an iframe-rendering UI, waits for iframe content to paint, captures a named screenshot, and verifies readiness evidence plus DOM sidecar output.

## Verification
- `npm run build`
- `npm run browser-actions-painted-readiness-smoke`
- `npm run browser-actions-artifact-smoke`
- `npm run browser-action-visual-compare-smoke`
- `npm run browser-scenario-artifact-smoke`
- `npm run discovery-command-smoke`
- `npm run command-args-smoke`

## Issue
- Closes https://github.com/Automattic/wp-codebox/issues/792

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the generic painted-readiness primitive, typed readiness evidence, command metadata updates, and targeted smoke coverage; Chris remains responsible for review and merge.