### PR TITLE
Make browser metrics artifact-shape aware

### DIFF
--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -1,5 +1,6 @@
 import { access, readFile } from "node:fs/promises"
 import { join } from "node:path"
+import type { ArtifactManifest } from "@automattic/wp-codebox-core"
 import type { ConsoleMessage, Request, Response } from "playwright"
 import type {
   BrowserProbeArtifact,
@@ -226,23 +227,30 @@ function benchMetricUnit(name: string): string {
 }
 
 export async function browserArtifactMetrics(bundleDirectory: string): Promise<BrowserArtifactMetricsResult> {
-  const summaryPath = join(bundleDirectory, "files", "browser", "summary.json")
   const artifacts: BrowserArtifactMetricsResult["artifacts"] = {}
 
-  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "summary", "summary.json", "json")
+  const summaryPaths = await browserSummaryArtifactPaths(bundleDirectory)
+  for (const [index, summaryPath] of summaryPaths.entries()) {
+    artifacts[index === 0 ? "summary" : `summary_${index + 1}`] = { path: summaryPath, kind: "json" }
+  }
+
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "lifecycle", "lifecycle.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "memory", "memory.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "performance", "performance.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "checkpoints", "checkpoints.jsonl", "jsonl")
 
   let metrics: Record<string, number> = {}
-  try {
-    const summary = JSON.parse(await readFile(summaryPath, "utf8")) as Record<string, unknown>
-    const browserSummary = isRecord(summary.summary) ? summary.summary : {}
-    metrics = isNumericMetricRecord(browserSummary.metrics) ? browserSummary.metrics : {}
-  } catch (error) {
-    if (!isMissingFileError(error)) {
-      throw error
+  for (const summaryPath of summaryPaths) {
+    try {
+      const summary = JSON.parse(await readFile(join(bundleDirectory, summaryPath), "utf8")) as Record<string, unknown>
+      const browserSummary = isRecord(summary.summary) ? summary.summary : {}
+      if (isNumericMetricRecord(browserSummary.metrics)) {
+        metrics = { ...metrics, ...browserSummary.metrics }
+      }
+    } catch (error) {
+      if (!isMissingFileError(error)) {
+        throw error
+      }
     }
   }
 
@@ -253,6 +261,34 @@ export async function browserArtifactMetrics(bundleDirectory: string): Promise<B
     metrics,
     artifacts,
   }
+}
+
+async function browserSummaryArtifactPaths(bundleDirectory: string): Promise<string[]> {
+  const paths = new Set<string>()
+
+  try {
+    const manifest = JSON.parse(await readFile(join(bundleDirectory, "manifest.json"), "utf8")) as ArtifactManifest
+    for (const file of Array.isArray(manifest.files) ? manifest.files : []) {
+      if (file.kind === "browser-summary" && typeof file.path === "string" && file.path.length > 0) {
+        paths.add(file.path)
+      }
+    }
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error
+    }
+  }
+
+  try {
+    await access(join(bundleDirectory, "files", "browser", "summary.json"))
+    paths.add("files/browser/summary.json")
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error
+    }
+  }
+
+  return [...paths]
 }
 
 async function addBrowserArtifactIfPresent(artifacts: BrowserArtifactMetricsResult["artifacts"], bundleDirectory: string, name: string, file: string, kind: "json" | "jsonl"): Promise<void> {

--- a/scripts/recipe-browser-bench-metrics-smoke.ts
+++ b/scripts/recipe-browser-bench-metrics-smoke.ts
@@ -9,10 +9,12 @@ const workspace = resolve(repoRoot, "artifacts", "recipe-browser-bench-metrics-s
 const recipePath = join(workspace, "recipe.json")
 const artifactsRoot = join(workspace, "artifacts")
 const emptyArtifactsRoot = join(workspace, "empty-artifacts")
+const shapedArtifactsRoot = join(workspace, "shaped-artifacts")
 
 await rm(workspace, { recursive: true, force: true })
 await mkdir(workspace, { recursive: true })
 await mkdir(emptyArtifactsRoot, { recursive: true })
+await mkdir(join(shapedArtifactsRoot, "files", "browser"), { recursive: true })
 
 await writeFile(recipePath, `${JSON.stringify({
   schema: "wp-codebox/workspace-recipe/v1",
@@ -168,6 +170,40 @@ assert.equal(emptyBrowserMetrics.schema, "wp-codebox/browser-metrics/v1")
 assert.equal(emptyBrowserMetrics.hasBrowserMetrics, false)
 assert.deepEqual(emptyBrowserMetrics.metrics, {})
 assert.deepEqual(emptyBrowserMetrics.artifacts, {})
+
+await writeFile(join(shapedArtifactsRoot, "manifest.json"), `${JSON.stringify({
+  id: "shaped-browser-summary",
+  contentDigest: { algorithm: "sha256", inputs: [], value: "0".repeat(64) },
+  createdAt: new Date(0).toISOString(),
+  runtime: { kind: "test" },
+  files: [
+    { path: "files/browser/editor-action-summary.json", kind: "browser-summary", contentType: "application/json", sha256: { algorithm: "sha256", value: "0".repeat(64) } },
+  ],
+}, null, 2)}\n`)
+await writeFile(join(shapedArtifactsRoot, "files", "browser", "editor-action-summary.json"), `${JSON.stringify({
+  schema: "wp-codebox/browser-probe/v1",
+  summary: {
+    metrics: {
+      browser_checkpoint_count: 7,
+      browser_dom_node_count: 42,
+    },
+  },
+}, null, 2)}\n`)
+
+const shapedBrowserMetrics = await runCli([
+  "packages/cli/dist/index.js",
+  "artifacts",
+  "browser-metrics",
+  "--bundle",
+  shapedArtifactsRoot,
+  "--json",
+])
+
+assert.equal(shapedBrowserMetrics.schema, "wp-codebox/browser-metrics/v1")
+assert.equal(shapedBrowserMetrics.hasBrowserMetrics, true)
+assert.equal(shapedBrowserMetrics.metrics.browser_checkpoint_count, 7)
+assert.equal(shapedBrowserMetrics.metrics.browser_dom_node_count, 42)
+assert.equal(shapedBrowserMetrics.artifacts.summary.path, "files/browser/editor-action-summary.json")
 
 console.log(`Recipe browser bench metrics smoke passed: ${artifactDirectory}`)
 


### PR DESCRIPTION
## Summary
- Make `artifacts browser-metrics` discover browser summary artifacts from `manifest.json` entries with `kind: \"browser-summary\"` instead of assuming only `files/browser/summary.json`.
- Preserve the existing fixed sidecar artifact detection for lifecycle, memory, performance, and checkpoints.
- Add smoke coverage for a non-default browser summary path such as editor/action/scenario artifacts expose.

Closes #774.

## Testing
- `npm install`
- `npm run build`
- `npm run recipe-browser-bench-metrics-smoke`
- `npm run benchmark-summary-smoke`
- `npm run benchmark-substrate-smoke`
- `npm run benchmark-matrix-cli-smoke`
- `npm run benchmark-comparison-smoke`
- `npm run editor-actions-artifact-smoke`
- `npm run browser-scenario-artifact-smoke`
- `npm run browser-probe-profile-matrix-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused metrics extraction change, added smoke coverage, and ran local verification. Chris remains responsible for review and merge decisions.