### PR TITLE
Suppress stale agent task failure diagnostics

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -122,7 +122,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       agent_task_result: objectValue(run.agentTaskResult) || objectValue(runRecord.agentTaskResult) || objectValue(artifactsRecord.agentTaskResult) || {},
       completion_outcome: objectValue(run.completionOutcome) || objectValue(artifactsRecord.completionOutcome) || {},
       run,
-      diagnostics: [...diagnostics(run, capture.exitCode), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])],
+      diagnostics: [...diagnostics(run, success ? 0 : capture.exitCode), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])],
       evidence_refs: evidenceRefs(run, artifacts),
       run_metadata: stripUndefined({
         run_id: stringValue(runRecord.runId),

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { normalizeTaskInput } from "@automattic/wp-codebox-core"
@@ -51,6 +51,12 @@ assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "agents-api")?
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine")?.source, "/legacy/data-machine")
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine-code")?.source, "/legacy/data-machine-code")
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine")?.loadAs, "mu-plugin")
+
+const agentTaskRunSource = readFileSync(new URL("../packages/cli/src/commands/agent-task-run.ts", import.meta.url), "utf8")
+assert.ok(
+  agentTaskRunSource.includes("diagnostics(run, success ? 0 : capture.exitCode)"),
+  "successful normalized agent-bundle workloads should not keep stale recipe-run failure diagnostics",
+)
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))
 const codexProviderPath = join(profileRoot, "ai-provider-for-openai@codex-oauth-provider")


### PR DESCRIPTION
## Summary
- Suppress stale recipe-run failure diagnostics when an agent-bundle workload normalizes to a successful WP Codebox agent-task result.
- Add smoke coverage to keep successful normalized agent-bundle workloads from reporting old recipe-run failure diagnostics.

## Testing
- `npm ci` (postinstall ran `npm run build`)
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WPSG proof failure, traced the stale diagnostic to WP Codebox agent-task normalization, drafted the fix and smoke assertion, and ran targeted verification for Chris to review.