### PR TITLE
Separate browser task phase execution

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -458,9 +458,14 @@ final class WP_Codebox_Abilities {
 							array( 'type' => 'object', 'required' => array( 'task' ) ),
 						),
 						'properties' => $browser_contract_properties + array(
+							'execute_phases'     => array(
+								'type'        => 'boolean',
+								'description' => 'When true, explicitly execute host-side fanout and host-delegation phase requests after preparing the browser task contract. Defaults to false so contract creation remains side-effect-light.',
+								'default'     => false,
+							),
 							'phases'             => array(
 								'type'        => 'array',
-								'description' => 'Optional named browser task phases. Generic phases may carry wp-codebox/agent-fanout-request/v1 or wp-codebox/host-delegation-request/v1 in request/input for WP Codebox execution; materializer phases may override any primary session input through input.',
+								'description' => 'Optional named browser task phases. Generic phases may carry wp-codebox/agent-fanout-request/v1 or wp-codebox/host-delegation-request/v1 in request/input for explicit WP Codebox execution when execute_phases is true; materializer phases may override any primary session input through input.',
 								'items'       => array(
 									'type'       => 'object',
 									'properties' => array(

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -194,6 +194,16 @@ public static function create_browser_materializer_contract( array $input ): arr
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function create_browser_task_contract( array $input ): array|WP_Error {
+	$contract = self::prepare_browser_task_contract( $input );
+	if ( is_wp_error( $contract ) || true !== ( $input['execute_phases'] ?? false ) ) {
+		return $contract;
+	}
+
+	return self::execute_browser_task_phases( $contract );
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+private static function prepare_browser_task_contract( array $input ): array|WP_Error {
 	$primary = self::create_browser_playground_session( $input );
 	if ( is_wp_error( $primary ) ) {
 		return $primary;
@@ -222,7 +232,7 @@ public static function create_browser_task_contract( array $input ): array|WP_Er
 		return $contract;
 	}
 
-	$phases = self::browser_task_contract_phases( $input, $session_envelope );
+	$phases = self::prepare_browser_task_contract_phases( $input, $session_envelope );
 	if ( is_wp_error( $phases ) ) {
 		return $phases;
 	}
@@ -245,6 +255,70 @@ public static function create_browser_task_contract( array $input ): array|WP_Er
 	$contract['compact'] = self::compact_browser_task_contract_dto( $contract );
 
 	return $contract;
+}
+
+/** @param array<string,mixed> $contract Browser task contract. @return array<string,mixed>|WP_Error */
+private static function execute_browser_task_phases( array $contract ): array|WP_Error {
+	$session_envelope = is_array( $contract['session'] ?? null ) ? $contract['session'] : array();
+	$phases           = array();
+
+	foreach ( is_array( $contract['phases'] ?? null ) ? $contract['phases'] : array() as $phase ) {
+		if ( ! is_array( $phase ) ) {
+			continue;
+		}
+
+		$executed_phase = self::execute_browser_task_phase( $phase, $session_envelope );
+		if ( is_wp_error( $executed_phase ) ) {
+			return $executed_phase;
+		}
+
+		$phases[] = $executed_phase;
+	}
+
+	$contract['phases']            = $phases;
+	$contract['execution_metrics'] = self::browser_contract_execution_metrics( is_array( $contract['primary'] ?? null ) ? $contract['primary'] : array(), $phases );
+	$contract['compact']           = self::compact_browser_task_contract_dto( $contract );
+
+	return $contract;
+}
+
+/** @param array<string,mixed> $phase Browser task phase. @param array<string,mixed> $session_envelope Primary browser session envelope. @return array<string,mixed>|WP_Error */
+private static function execute_browser_task_phase( array $phase, array $session_envelope ): array|WP_Error {
+	$fanout_request = self::browser_task_phase_fanout_request( $phase );
+	if ( is_array( $fanout_request ) ) {
+		if ( empty( $fanout_request['sandbox_session_id'] ) && '' !== (string) ( $session_envelope['id'] ?? '' ) ) {
+			$fanout_request['sandbox_session_id'] = (string) $session_envelope['id'];
+		}
+
+		$result = self::run_agent_task_fanout( $fanout_request );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$phase['status'] = true === ( $result['success'] ?? false ) ? 'completed' : 'failed';
+		$phase['result'] = $result;
+
+		return array_filter( $phase, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
+	}
+
+	$host_delegation_request = self::browser_task_phase_host_delegation_request( $phase );
+	if ( is_array( $host_delegation_request ) ) {
+		if ( empty( $host_delegation_request['sandbox_session_id'] ) && '' !== (string) ( $session_envelope['id'] ?? '' ) ) {
+			$host_delegation_request['sandbox_session_id'] = (string) $session_envelope['id'];
+		}
+
+		$result = self::request_host_delegation( $host_delegation_request );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$phase['status'] = true === ( $result['success'] ?? false ) ? (string) ( $result['status'] ?? 'completed' ) : (string) ( $result['status'] ?? 'failed' );
+		$phase['result'] = $result;
+
+		return array_filter( $phase, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
+	}
+
+	return array_filter( $phase, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 }
 
 /** @param array<string,mixed> $contract Browser task contract. @return array<string,mixed> */
@@ -506,7 +580,7 @@ private static function compact_browser_dto_key_should_redact( string $key ): bo
 }
 
 /** @param array<string,mixed> $input Ability input. @param array<string,mixed> $session_envelope Primary browser session envelope. @return array<int,array<string,mixed>>|WP_Error */
-private static function browser_task_contract_phases( array $input, array $session_envelope ): array|WP_Error {
+private static function prepare_browser_task_contract_phases( array $input, array $session_envelope ): array|WP_Error {
 	$phase_specs = is_array( $input['phases'] ?? null ) ? $input['phases'] : array();
 	if ( empty( $phase_specs ) && is_array( $input['materializers'] ?? null ) ) {
 		$phase_specs = array_map(
@@ -544,13 +618,7 @@ private static function browser_task_contract_phases( array $input, array $sessi
 				$fanout_request['sandbox_session_id'] = (string) $session_envelope['id'];
 			}
 
-			$result = self::run_agent_task_fanout( $fanout_request );
-			if ( is_wp_error( $result ) ) {
-				return $result;
-			}
-
-			$phase_descriptor['status'] = true === ( $result['success'] ?? false ) ? 'completed' : 'failed';
-			$phase_descriptor['result'] = $result;
+			$phase_descriptor['request'] = $fanout_request;
 			$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 			continue;
 		}
@@ -561,13 +629,7 @@ private static function browser_task_contract_phases( array $input, array $sessi
 				$host_delegation_request['sandbox_session_id'] = (string) $session_envelope['id'];
 			}
 
-			$result = self::request_host_delegation( $host_delegation_request );
-			if ( is_wp_error( $result ) ) {
-				return $result;
-			}
-
-			$phase_descriptor['status'] = true === ( $result['success'] ?? false ) ? (string) ( $result['status'] ?? 'completed' ) : (string) ( $result['status'] ?? 'failed' );
-			$phase_descriptor['result'] = $result;
+			$phase_descriptor['request'] = $host_delegation_request;
 			$phases[] = array_filter( $phase_descriptor, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 			continue;
 		}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -376,7 +376,7 @@ private static function browser_task_contract_schema(): array {
 			'primary'          => self::browser_playground_session_schema(),
 			'phases'           => array(
 				'type'        => 'array',
-				'description' => 'Named browser task phases. Materializer phases include a browser-materializer-contract envelope; fanout phases execute wp-codebox/agent-fanout-request/v1 through WP Codebox; host-delegation phases execute wp-codebox/host-delegation-request/v1 through a host provider filter; other generic phases preserve product-neutral phase metadata for product UIs.',
+				'description' => 'Named browser task phases. Materializer phases include a browser-materializer-contract envelope; fanout and host-delegation phases preserve explicit request envelopes during contract preparation and include results only when host-side phase execution is requested.',
 				'items'       => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -386,6 +386,7 @@ private static function browser_task_contract_schema(): array {
 						'label'    => array( 'type' => 'string' ),
 						'status'   => array( 'type' => 'string' ),
 						'metadata' => array( 'type' => 'object' ),
+						'request'  => array( 'type' => 'object' ),
 						'contract' => array( 'type' => 'object' ),
 						'result'   => array( 'type' => 'object' ),
 					),

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -428,6 +428,7 @@ $assert( 'browser task contract ability is REST visible', true === ( $browser_ta
 $assert( 'browser task contract accepts goal or legacy task', array( 'goal' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][0]['required'] ?? array() ) && array( 'task' ) === ( $browser_task_contract_ability['input_schema']['anyOf'][1]['required'] ?? array() ) );
 $browser_task_phase_kinds = $browser_task_contract_ability['input_schema']['properties']['phases']['items']['properties']['kind']['enum'] ?? array();
 $assert( 'browser task contract exposes phase and compact schema', 'array' === ( $browser_task_contract_ability['input_schema']['properties']['phases']['type'] ?? '' ) && in_array( 'materializer', $browser_task_phase_kinds, true ) && in_array( 'agent', $browser_task_phase_kinds, true ) && in_array( 'aggregator', $browser_task_phase_kinds, true ) && in_array( 'host-delegation', $browser_task_phase_kinds, true ) && 'array' === ( $browser_task_contract_ability['output_schema']['properties']['phases']['type'] ?? '' ) && 'object' === ( $browser_task_contract_ability['output_schema']['properties']['compact']['type'] ?? '' ) );
+$assert( 'browser task contract exposes explicit host-side phase execution flag', 'boolean' === ( $browser_task_contract_ability['input_schema']['properties']['execute_phases']['type'] ?? '' ) && false === ( $browser_task_contract_ability['input_schema']['properties']['execute_phases']['default'] ?? null ) );
 
 $agents_api_executor_targets = apply_filters( 'agents_api_executor_targets', array() );
 $wp_agent_executor_targets = apply_filters( 'wp_agent_executor_targets', array() );
@@ -1006,6 +1007,45 @@ $generic_phase_task_contract = call_user_func(
 						'workers'         => array(
 							array( 'id' => 'browser_worker', 'goal' => 'Cook the browser phase worker.' ),
 						),
+						'artifacts_path'  => $root . '/artifacts/browser-phase-fanout-prepare',
+						'wp_codebox_bin'  => $browser_phase_fanout_bin,
+						'orchestrator'    => array( 'type' => 'browser-task-contract' ),
+					),
+				),
+				array(
+					'name'     => 'aggregate-results',
+					'kind'     => 'aggregator',
+					'label'    => 'Aggregate Results',
+					'metadata' => array(
+						'inputs' => array( 'agent-fanout' ),
+					),
+				),
+			),
+		)
+	)
+);
+$assert( 'browser task contract prepares agent and aggregator phase descriptors without executing host-side fanout', ! is_wp_error( $generic_phase_task_contract ) && 2 === count( $generic_phase_task_contract['phases'] ?? array() ) && 'agent' === ( $generic_phase_task_contract['phases'][0]['kind'] ?? '' ) && 'aggregator' === ( $generic_phase_task_contract['phases'][1]['kind'] ?? '' ) && ! isset( $generic_phase_task_contract['phases'][0]['contract'] ) && ! isset( $generic_phase_task_contract['phases'][0]['result'] ) && 'queued' === ( $generic_phase_task_contract['phases'][0]['status'] ?? '' ) && 'pending' === ( $generic_phase_task_contract['phases'][1]['status'] ?? '' ) && ! is_file( $root . '/artifacts/browser-phase-fanout-prepare/fanout/result.json' ) );
+$generic_phase_executed_task_contract = call_user_func(
+	$browser_task_contract_ability['execute_callback'],
+	array_replace_recursive(
+		$browser_session_input,
+		array(
+			'execute_phases' => true,
+			'phases'         => array(
+				array(
+					'name'     => 'agent-fanout',
+					'kind'     => 'agent',
+					'label'    => 'Agent Fanout',
+					'status'   => 'queued',
+					'metadata' => array(
+						'runner' => 'browser-playground',
+					),
+					'request'  => array(
+						'schema'          => 'wp-codebox/agent-fanout-request/v1',
+						'concurrency'     => 1,
+						'workers'         => array(
+							array( 'id' => 'browser_worker', 'goal' => 'Cook the browser phase worker.' ),
+						),
 						'artifacts_path'  => $root . '/artifacts/browser-phase-fanout',
 						'wp_codebox_bin'  => $browser_phase_fanout_bin,
 						'orchestrator'    => array( 'type' => 'browser-task-contract' ),
@@ -1023,9 +1063,8 @@ $generic_phase_task_contract = call_user_func(
 		)
 	)
 );
-$assert( 'browser task contract accepts agent and aggregator phase descriptors', ! is_wp_error( $generic_phase_task_contract ) && 2 === count( $generic_phase_task_contract['phases'] ?? array() ) && 'agent' === ( $generic_phase_task_contract['phases'][0]['kind'] ?? '' ) && 'aggregator' === ( $generic_phase_task_contract['phases'][1]['kind'] ?? '' ) && ! isset( $generic_phase_task_contract['phases'][0]['contract'] ) && 'completed' === ( $generic_phase_task_contract['phases'][0]['status'] ?? '' ) && 'pending' === ( $generic_phase_task_contract['phases'][1]['status'] ?? '' ) );
-$assert( 'browser task contract executes agent fanout phase requests', ! is_wp_error( $generic_phase_task_contract ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_task_contract['phases'][0]['result']['schema'] ?? '' ) && 1 === ( $generic_phase_task_contract['phases'][0]['result']['completed'] ?? 0 ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/result.json' ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/events.jsonl' ) );
-$assert( 'browser task compact DTO preserves generic phase metadata and fanout result for product UIs', ! is_wp_error( $generic_phase_task_contract ) && 'agent-fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['name'] ?? '' ) && 0 === ( $generic_phase_task_contract['compact']['phases'][0]['index'] ?? null ) && 'Agent Fanout' === ( $generic_phase_task_contract['compact']['phases'][0]['label'] ?? '' ) && 'browser-playground' === ( $generic_phase_task_contract['compact']['phases'][0]['metadata']['runner'] ?? '' ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_task_contract['compact']['phases'][0]['result']['schema'] ?? '' ) && 'aggregate-results' === ( $generic_phase_task_contract['compact']['phases'][1]['name'] ?? '' ) && 1 === ( $generic_phase_task_contract['compact']['phases'][1]['index'] ?? null ) );
+$assert( 'browser task contract executes agent fanout phase requests only when execute_phases is explicit', ! is_wp_error( $generic_phase_executed_task_contract ) && 'completed' === ( $generic_phase_executed_task_contract['phases'][0]['status'] ?? '' ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_executed_task_contract['phases'][0]['result']['schema'] ?? '' ) && 1 === ( $generic_phase_executed_task_contract['phases'][0]['result']['completed'] ?? 0 ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/result.json' ) && is_file( $root . '/artifacts/browser-phase-fanout/fanout/events.jsonl' ) );
+$assert( 'browser task compact DTO preserves generic phase metadata and explicit fanout result for product UIs', ! is_wp_error( $generic_phase_executed_task_contract ) && 'agent-fanout' === ( $generic_phase_executed_task_contract['compact']['phases'][0]['name'] ?? '' ) && 0 === ( $generic_phase_executed_task_contract['compact']['phases'][0]['index'] ?? null ) && 'Agent Fanout' === ( $generic_phase_executed_task_contract['compact']['phases'][0]['label'] ?? '' ) && 'browser-playground' === ( $generic_phase_executed_task_contract['compact']['phases'][0]['metadata']['runner'] ?? '' ) && 'wp-codebox/agent-fanout-result/v1' === ( $generic_phase_executed_task_contract['compact']['phases'][0]['result']['schema'] ?? '' ) && 'aggregate-results' === ( $generic_phase_executed_task_contract['compact']['phases'][1]['name'] ?? '' ) && 1 === ( $generic_phase_executed_task_contract['compact']['phases'][1]['index'] ?? null ) );
 
 $GLOBALS['wp_codebox_host_delegation_requests'] = array();
 add_filter(
@@ -1073,9 +1112,34 @@ $host_delegation_phase_task_contract = call_user_func(
 		)
 	)
 );
-$host_delegation_phase_events = ! is_wp_error( $host_delegation_phase_task_contract ) ? array_map( static fn( array $event ): string => (string) ( $event['event'] ?? '' ), $host_delegation_phase_task_contract['phases'][0]['result']['events'] ?? array() ) : array();
-$assert( 'browser task contract executes host delegation phase requests', ! is_wp_error( $host_delegation_phase_task_contract ) && 1 === count( $GLOBALS['wp_codebox_host_delegation_requests'] ?? array() ) && 'browser-session-123' === ( $GLOBALS['wp_codebox_host_delegation_requests'][0]['sandbox_session_id'] ?? '' ) && 'wp-codebox/host-delegation-result/v1' === ( $host_delegation_phase_task_contract['phases'][0]['result']['schema'] ?? '' ) && 'completed' === ( $host_delegation_phase_task_contract['phases'][0]['status'] ?? '' ) && 'smoke-host-provider' === ( $host_delegation_phase_task_contract['phases'][0]['result']['provider'] ?? '' ) && array( 'host-delegation.requested', 'host-delegation.completed' ) === $host_delegation_phase_events );
-$assert( 'browser task compact DTO preserves host delegation result for product UIs', ! is_wp_error( $host_delegation_phase_task_contract ) && 'host-delegation' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['kind'] ?? '' ) && 'server-workspace-offload' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['name'] ?? '' ) && 'workspace-required' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['metadata']['reason'] ?? '' ) && 'wp-codebox/host-delegation-result/v1' === ( $host_delegation_phase_task_contract['compact']['phases'][0]['result']['schema'] ?? '' ) );
+$assert( 'browser task contract prepares host delegation phase requests without executing host providers', ! is_wp_error( $host_delegation_phase_task_contract ) && 0 === count( $GLOBALS['wp_codebox_host_delegation_requests'] ?? array() ) && ! isset( $host_delegation_phase_task_contract['phases'][0]['result'] ) && 'pending' === ( $host_delegation_phase_task_contract['phases'][0]['status'] ?? '' ) );
+$host_delegation_phase_executed_task_contract = call_user_func(
+	$browser_task_contract_ability['execute_callback'],
+	array_replace_recursive(
+		$browser_session_input,
+		array(
+			'execute_phases' => true,
+			'phases'         => array(
+				array(
+					'name'     => 'server-workspace-offload',
+					'kind'     => 'host-delegation',
+					'label'    => 'Server Workspace Offload',
+					'metadata' => array( 'reason' => 'workspace-required' ),
+					'request'  => array(
+						'schema'     => 'wp-codebox/host-delegation-request/v1',
+						'request_id' => 'host-delegation-phase-1',
+						'goal'       => 'Run the workspace phase on a host provider.',
+						'execution'  => array( 'capability' => 'workspace-task' ),
+						'orchestrator' => array( 'type' => 'browser-task-contract' ),
+					),
+				),
+			),
+		)
+	)
+);
+$host_delegation_phase_events = ! is_wp_error( $host_delegation_phase_executed_task_contract ) ? array_map( static fn( array $event ): string => (string) ( $event['event'] ?? '' ), $host_delegation_phase_executed_task_contract['phases'][0]['result']['events'] ?? array() ) : array();
+$assert( 'browser task contract executes host delegation phase requests only when execute_phases is explicit', ! is_wp_error( $host_delegation_phase_executed_task_contract ) && 1 === count( $GLOBALS['wp_codebox_host_delegation_requests'] ?? array() ) && 'browser-session-123' === ( $GLOBALS['wp_codebox_host_delegation_requests'][0]['sandbox_session_id'] ?? '' ) && 'wp-codebox/host-delegation-result/v1' === ( $host_delegation_phase_executed_task_contract['phases'][0]['result']['schema'] ?? '' ) && 'completed' === ( $host_delegation_phase_executed_task_contract['phases'][0]['status'] ?? '' ) && 'smoke-host-provider' === ( $host_delegation_phase_executed_task_contract['phases'][0]['result']['provider'] ?? '' ) && array( 'host-delegation.requested', 'host-delegation.completed' ) === $host_delegation_phase_events );
+$assert( 'browser task compact DTO preserves host delegation result for product UIs', ! is_wp_error( $host_delegation_phase_executed_task_contract ) && 'host-delegation' === ( $host_delegation_phase_executed_task_contract['compact']['phases'][0]['kind'] ?? '' ) && 'server-workspace-offload' === ( $host_delegation_phase_executed_task_contract['compact']['phases'][0]['name'] ?? '' ) && 'workspace-required' === ( $host_delegation_phase_executed_task_contract['compact']['phases'][0]['metadata']['reason'] ?? '' ) && 'wp-codebox/host-delegation-result/v1' === ( $host_delegation_phase_executed_task_contract['compact']['phases'][0]['result']['schema'] ?? '' ) );
 $GLOBALS['wp_codebox_filters']['wp_codebox_host_delegation_request'] = static fn(): array => array( 'artifact_refs' => array( array( 'path' => 'bare-provider/result.json' ) ) );
 $host_delegation_bare_provider = call_user_func(
 	$host_delegation_ability['execute_callback'],


### PR DESCRIPTION
## Summary
- Split browser task contract preparation from host-side phase execution so contract creation is side-effect-light by default.
- Added explicit `execute_phases` handling for fanout and host-delegation phase execution.
- Updated browser task schemas and smoke coverage for default preparation vs explicit phase execution.

Closes #781.

## Testing
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php && php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l tests/smoke-wordpress-plugin.php`
- `npm run wordpress-plugin-smoke`
- `npm run fanout-contract-smoke && npm run host-delegation-contract-smoke && npm run fanout-aggregation-contract-smoke && npm run agent-fanout-execution-smoke`
- `npm run build`
- `npm run check` progressed through build, WordPress plugin smoke, and multiple check smoke scripts, then exceeded the 20-minute local tool timeout while running `runtime-stack-mount-smoke`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused browser task boundary refactor and smoke test updates; Chris remains responsible for review and merge.