### PR TITLE
Filter stale successful agent task diagnostics

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -122,7 +122,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       agent_task_result: objectValue(run.agentTaskResult) || objectValue(runRecord.agentTaskResult) || objectValue(artifactsRecord.agentTaskResult) || {},
       completion_outcome: objectValue(run.completionOutcome) || objectValue(artifactsRecord.completionOutcome) || {},
       run,
-      diagnostics: [...diagnostics(run, success ? 0 : capture.exitCode), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])],
+      diagnostics: [...diagnostics(run, success ? 0 : capture.exitCode, success), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])],
       evidence_refs: evidenceRefs(run, artifacts),
       run_metadata: stripUndefined({
         run_id: stringValue(runRecord.runId),
@@ -357,8 +357,11 @@ function sandboxSession(input: AgentTaskRunInput, run: Record<string, unknown>, 
   })
 }
 
-function diagnostics(run: Record<string, unknown>, exitCode: number): Array<Record<string, unknown>> {
+function diagnostics(run: Record<string, unknown>, exitCode: number, normalizedSuccess = false): Array<Record<string, unknown>> {
   const existing = Array.isArray(run.diagnostics) ? run.diagnostics.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
+  if (normalizedSuccess) {
+    return existing.filter((entry) => stringValue(entry.class) !== "wp-codebox.agent_task_run_failed")
+  }
   if (existing.length > 0) {
     return existing
   }

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -54,8 +54,12 @@ assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine"
 
 const agentTaskRunSource = readFileSync(new URL("../packages/cli/src/commands/agent-task-run.ts", import.meta.url), "utf8")
 assert.ok(
-  agentTaskRunSource.includes("diagnostics(run, success ? 0 : capture.exitCode)"),
+  agentTaskRunSource.includes("diagnostics(run, success ? 0 : capture.exitCode, success)"),
   "successful normalized agent-bundle workloads should not keep stale recipe-run failure diagnostics",
+)
+assert.ok(
+  agentTaskRunSource.includes('stringValue(entry.class) !== "wp-codebox.agent_task_run_failed"'),
+  "successful normalized agent-bundle workloads should filter stale agent-task failure diagnostics",
 )
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))


### PR DESCRIPTION
## Summary
- Filter stale `wp-codebox.agent_task_run_failed` diagnostics from recipe-run output when the normalized agent-task result is successful.
- Keep the agent-task runtime components smoke pinned to the normalized-success diagnostic behavior.

## Testing
- `npm run build`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the remaining WPSG proof failure after PR #797, traced the stale diagnostic preservation path, drafted the follow-up filter, and ran build/smoke verification for Chris to review.