### PR TITLE
fix: reconcile successful agent task evidence

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -417,9 +417,12 @@ export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, ex
   const agentTaskResultPath = join(dirname(artifacts.reviewPath), "agent-task-result.json")
   const completionOutcomePath = join(dirname(artifacts.reviewPath), "completion-outcome.json")
   const transcriptFile = await writeRecipeEvidenceJson(artifacts.directory, transcriptPath, transcript, "agent-transcript")
-  const agentResult = await buildAgentSandboxResultSummary(artifacts, transcript, transcriptFile.path)
-  const agentResultFile = await writeRecipeEvidenceJson(artifacts.directory, agentResultPath, agentResult, "agent-result")
   const agentTaskResult = buildAgentTaskSingleResult(transcript)
+  const agentResult = reconcileAgentSandboxResult(
+    await buildAgentSandboxResultSummary(artifacts, transcript, transcriptFile.path),
+    agentTaskResult,
+  )
+  const agentResultFile = await writeRecipeEvidenceJson(artifacts.directory, agentResultPath, agentResult, "agent-result")
   const agentTaskResultFile = agentTaskResult ? await writeRecipeEvidenceJson(artifacts.directory, agentTaskResultPath, agentTaskResult, "agent-task-result") : undefined
   const completionOutcome = buildSandboxCompletionOutcome(artifacts, agentResult, transcript)
   const completionOutcomeFile = await writeRecipeEvidenceJson(artifacts.directory, completionOutcomePath, completionOutcome, "completion-outcome")
@@ -431,6 +434,24 @@ export async function finalizeAgentSandboxEvidence(artifacts: ArtifactBundle, ex
     completionOutcome: { ...completionOutcome, artifact: completionOutcomeFile },
     transcript: { ...transcript, artifact: transcriptFile },
   }
+}
+
+function reconcileAgentSandboxResult(agentResult: AgentSandboxResultSummary, agentTaskResult: AgentTaskSingleResult | undefined): AgentSandboxResultSummary {
+  if (agentTaskResult?.success !== true || agentResult.status !== "failed") {
+    return agentResult
+  }
+
+  const actionable = agentResult.changedFiles.count > 0 || agentResult.patch.bytes > 0
+  return stripUndefined({
+    ...agentResult,
+    status: "completed" as const,
+    actionable,
+    summary: actionable
+      ? `Agent sandbox produced ${agentResult.changedFiles.count === 1 ? "1 changed file" : `${agentResult.changedFiles.count} changed files`} and a ${agentResult.patch.bytes}-byte patch.`
+      : "Agent sandbox completed successfully without actionable file changes.",
+    failures: [],
+    noOpReason: actionable ? undefined : "no_file_changes",
+  })
 }
 
 function buildAgentSandboxTranscript(executions: RecipeEvidenceExecutionResult[]): AgentSandboxTranscript {

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -53,6 +53,7 @@ assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine-
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine")?.loadAs, "mu-plugin")
 
 const agentTaskRunSource = readFileSync(new URL("../packages/cli/src/commands/agent-task-run.ts", import.meta.url), "utf8")
+const recipeEvidenceSource = readFileSync(new URL("../packages/cli/src/recipe-evidence.ts", import.meta.url), "utf8")
 assert.ok(
   agentTaskRunSource.includes("diagnostics(run, success ? 0 : capture.exitCode, success)"),
   "successful normalized agent-bundle workloads should not keep stale recipe-run failure diagnostics",
@@ -60,6 +61,14 @@ assert.ok(
 assert.ok(
   agentTaskRunSource.includes('stringValue(entry.class) !== "wp-codebox.agent_task_run_failed"'),
   "successful normalized agent-bundle workloads should filter stale agent-task failure diagnostics",
+)
+assert.ok(
+  recipeEvidenceSource.includes("reconcileAgentSandboxResult("),
+  "successful agent task results should reconcile stale failed sandbox summaries",
+)
+assert.ok(
+  recipeEvidenceSource.includes('agentTaskResult?.success !== true || agentResult.status !== "failed"'),
+  "only successful agent task results should override failed sandbox evidence",
 )
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))


### PR DESCRIPTION
## Summary
- Reconciles agent sandbox evidence when the nested `agent-task-result` reports success, preventing stale runtime-failure transcript state from marking `agent-result.json` and `completion-outcome.json` as failed.
- Extends the agent task runtime-components smoke guard for the evidence reconciliation path.

## Verification
- `npm ci`
- `npm run build`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the evidence reconciliation fix under Chris's direction.