### PR TITLE
Unify inheritance normalization

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1044,12 +1044,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $input Ability input. @return array{connectors:string[],settings:string[]} */
 	private function inheritance_request( array $input ): array {
-		$inherit = is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array();
-
-		return array(
-			'connectors' => $this->string_list( $inherit['connectors'] ?? array() ),
-			'settings'   => $this->string_list( $inherit['settings'] ?? array() ),
-		);
+		return WP_Codebox_Inheritance::request( $input );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} */
@@ -1059,37 +1054,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $input Ability input. @return array{inheritance_audit:array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>},process_secret_env:array<string,string>} */
 	private function inheritance_resolution_payload( array $input ): array {
-		$request    = $this->inheritance_request( $input );
-		$resolution = array(
-			'connectors' => array_map(
-				static fn( string $name ): array => array(
-					'name'   => $name,
-					'status' => 'unresolved',
-				),
-				$request['connectors']
-			),
-			'settings'   => array_map(
-				static fn( string $name ): array => array(
-					'name'   => $name,
-					'status' => 'unresolved',
-				),
-				$request['settings']
-			),
-		);
-
-		if ( function_exists( 'apply_filters' ) && ( ! empty( $request['connectors'] ) || ! empty( $request['settings'] ) ) ) {
-			$filtered = apply_filters( 'wp_codebox_resolve_inheritance', $resolution, $request, $input );
-			if ( is_array( $filtered ) ) {
-				$resolution = $filtered;
-			}
-		}
+		$payload = WP_Codebox_Inheritance::resolution_payload( $input, fn( string $path ): string => $this->clean_path( $path ) );
 
 		return array(
-			'inheritance_audit'  => array(
-				'connectors' => $this->sanitize_inheritance_connectors( $resolution['connectors'] ?? array() ),
-				'settings'   => $this->sanitize_inheritance_settings( $resolution['settings'] ?? array() ),
-			),
-			'process_secret_env' => $this->inheritance_process_secret_env_values( $resolution['connectors'] ?? array() ),
+			'inheritance_audit'  => $payload['inheritance'],
+			'process_secret_env' => $this->inheritance_process_secret_env_values( $payload['resolution']['connectors'] ?? array() ),
 		);
 	}
 
@@ -1152,186 +1121,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return $values;
 	}
 
-	/** @param array<int,mixed> $connectors Inheritance connector rows. @return array<int,array<string,mixed>> */
-	private function sanitize_inheritance_connectors( array $connectors ): array {
-		$sanitized = array();
-		foreach ( $connectors as $connector ) {
-			if ( ! is_array( $connector ) ) {
-				continue;
-			}
-
-			$name = trim( (string) ( $connector['name'] ?? '' ) );
-			if ( '' === $name ) {
-				continue;
-			}
-
-			$entry = array(
-				'name'   => $name,
-				'status' => trim( (string) ( $connector['status'] ?? 'resolved' ) ),
-			);
-
-			foreach ( array( 'provider', 'model' ) as $field ) {
-				$value = trim( (string) ( $connector[ $field ] ?? '' ) );
-				if ( '' !== $value ) {
-					$entry[ $field ] = $value;
-				}
-			}
-
-			$provider_plugin_paths = $this->string_list( $connector['provider_plugin_paths'] ?? $connector['providerPluginPaths'] ?? array() );
-			$provider_plugin_paths = array_values(
-				array_filter(
-					array_map( fn( string $path ): string => $this->clean_path( $path ), $provider_plugin_paths ),
-					static fn( string $path ): bool => '' !== $path && is_dir( $path )
-				)
-			);
-			if ( ! empty( $provider_plugin_paths ) ) {
-				$entry['providerPluginPaths'] = array_values( array_unique( $provider_plugin_paths ) );
-			}
-
-			$secret_env = $this->string_list( $connector['secret_env'] ?? $connector['secretEnv'] ?? array() );
-			$secret_env = array_values( array_filter( $secret_env, static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) );
-			if ( ! empty( $secret_env ) ) {
-				$entry['secretEnv'] = array_values( array_unique( $secret_env ) );
-			}
-
-			$credentials = $this->sanitize_connector_credentials( $connector['credentials'] ?? null, $name );
-			if ( ! empty( $credentials ) ) {
-				$entry['credentials'] = $credentials;
-			}
-
-			$sanitized[] = $entry;
-		}
-
-		return $sanitized;
-	}
-
-	/** @return array<string,mixed> */
-	private function sanitize_connector_credentials( mixed $credentials, string $connector_name ): array {
-		if ( ! is_array( $credentials ) ) {
-			return array();
-		}
-
-		$status = $this->credential_status( (string) ( $credentials['status'] ?? 'missing' ) );
-		$entry  = array(
-			'schema'    => 'wp-codebox/connector-credentials/v1',
-			'connector' => $connector_name,
-			'scope'     => 'connector',
-			'status'    => $status,
-			'secrets'   => array(),
-		);
-
-		$reason = $this->redacted_reason( $credentials['reason'] ?? '' );
-		if ( '' !== $reason ) {
-			$entry['reason'] = $reason;
-		}
-
-		foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
-			if ( ! is_array( $secret ) ) {
-				continue;
-			}
-
-			$name = trim( (string) ( $secret['name'] ?? '' ) );
-			if ( 1 !== preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) {
-				continue;
-			}
-
-			$secret_entry = array(
-				'name'   => $name,
-				'status' => $this->credential_status( (string) ( $secret['status'] ?? $status ) ),
-			);
-
-			foreach ( array( 'scope', 'source', 'reason' ) as $field ) {
-				$value = 'reason' === $field ? $this->redacted_reason( $secret[ $field ] ?? '' ) : trim( (string) ( $secret[ $field ] ?? '' ) );
-				if ( '' !== $value ) {
-					$secret_entry[ $field ] = $value;
-				}
-			}
-
-			$entry['secrets'][] = $secret_entry;
-		}
-
-		return $entry;
-	}
-
-	private function credential_status( string $status ): string {
-		return in_array( $status, array( 'available', 'missing', 'denied' ), true ) ? $status : 'missing';
-	}
-
-	private function redacted_reason( mixed $reason ): string {
-		$reason = trim( (string) $reason );
-		if ( '' === $reason ) {
-			return '';
-		}
-
-		return substr( preg_replace( '/[^A-Za-z0-9 .:_-]/', '', $reason ) ?? '', 0, 160 );
-	}
-
 	/** @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
 	private function connector_credentials_error( array $inheritance ): WP_Error|null {
-		$failures = array();
-		foreach ( $inheritance['connectors'] as $connector ) {
-			$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
-			if ( empty( $credentials ) ) {
-				continue;
-			}
-
-			$status = (string) ( $credentials['status'] ?? 'missing' );
-			$secrets = array_filter(
-				is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array(),
-				static fn( mixed $secret ): bool => is_array( $secret ) && in_array( (string) ( $secret['status'] ?? '' ), array( 'missing', 'denied' ), true )
-			);
-
-			if ( in_array( $status, array( 'missing', 'denied' ), true ) || ! empty( $secrets ) ) {
-				$failures[] = array(
-					'name'        => (string) ( $connector['name'] ?? '' ),
-					'status'      => (string) ( $connector['status'] ?? '' ),
-					'credentials' => $credentials,
-				);
-			}
-		}
-
-		if ( empty( $failures ) ) {
-			return null;
-		}
-
-		return new WP_Error(
-			'wp_codebox_connector_credentials_unavailable',
-			'Requested connector credentials are missing or denied for this sandbox scope.',
-			array(
-				'status'     => 403,
-				'schema'     => 'wp-codebox/connector-credential-failure/v1',
-				'connectors' => $failures,
-			)
-		);
-	}
-
-	/** @param array<int,mixed> $settings Inheritance setting rows. @return array<int,array<string,mixed>> */
-	private function sanitize_inheritance_settings( array $settings ): array {
-		$sanitized = array();
-		foreach ( $settings as $setting ) {
-			if ( ! is_array( $setting ) ) {
-				continue;
-			}
-
-			$name = trim( (string) ( $setting['name'] ?? '' ) );
-			if ( '' === $name ) {
-				continue;
-			}
-
-			$entry = array(
-				'name'   => $name,
-				'status' => trim( (string) ( $setting['status'] ?? 'resolved' ) ),
-			);
-
-			$scope = trim( (string) ( $setting['scope'] ?? '' ) );
-			if ( '' !== $scope ) {
-				$entry['scope'] = $scope;
-			}
-
-			$sanitized[] = $entry;
-		}
-
-		return $sanitized;
+		return WP_Codebox_Inheritance::connector_credentials_error( $inheritance, 'Requested connector credentials are missing or denied for this sandbox scope.' );
 	}
 
 	/** @param array<string,mixed> $input Ability input. */
@@ -1370,21 +1162,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */
 	private function inheritance_secret_env_names( array $input, ?array $inheritance = null ): array {
-		$names = array();
-		foreach ( ( $inheritance ?? $this->inheritance_resolution( $input ) )['connectors'] as $connector ) {
-			if ( is_array( $connector['secretEnv'] ?? null ) ) {
-				$names = array_merge( $names, $connector['secretEnv'] );
-			}
-
-			$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
-			foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
-				if ( is_array( $secret ) && 'available' === ( $secret['status'] ?? '' ) ) {
-					$names[] = (string) ( $secret['name'] ?? '' );
-				}
-			}
-		}
-
-		return $names;
+		return WP_Codebox_Inheritance::secret_env_names( $inheritance ?? $this->inheritance_resolution( $input ) );
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return string[] */

--- a/packages/wordpress-plugin/src/class-wp-codebox-inheritance.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-inheritance.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * Shared inheritance request and audit normalization.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Inheritance {
+	/** @param array<string,mixed> $input Ability input. @return array{connectors:string[],settings:string[]} */
+	public static function request( array $input ): array {
+		$inherit = is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array();
+
+		return array(
+			'connectors' => self::string_list( $inherit['connectors'] ?? array() ),
+			'settings'   => self::string_list( $inherit['settings'] ?? array() ),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array{request:array{connectors:string[],settings:string[]},resolution:array<string,mixed>} */
+	public static function resolve( array $input ): array {
+		$request    = self::request( $input );
+		$resolution = array(
+			'connectors' => array_map(
+				static fn( string $name ): array => array(
+					'name'   => $name,
+					'status' => 'unresolved',
+				),
+				$request['connectors']
+			),
+			'settings'   => array_map(
+				static fn( string $name ): array => array(
+					'name'   => $name,
+					'status' => 'unresolved',
+				),
+				$request['settings']
+			),
+		);
+
+		if ( function_exists( 'apply_filters' ) && ( ! empty( $request['connectors'] ) || ! empty( $request['settings'] ) ) ) {
+			$filtered = apply_filters( 'wp_codebox_resolve_inheritance', $resolution, $request, $input );
+			if ( is_array( $filtered ) ) {
+				$resolution = $filtered;
+			}
+		}
+
+		return array(
+			'request'    => $request,
+			'resolution' => $resolution,
+		);
+	}
+
+	/** @param array<string,mixed> $resolution Raw inheritance resolution. @param callable|null $clean_path Path cleaner. @return array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} */
+	public static function sanitize_resolution( array $resolution, ?callable $clean_path = null ): array {
+		return array(
+			'connectors' => self::sanitize_connectors( $resolution['connectors'] ?? array(), $clean_path ),
+			'settings'   => self::sanitize_settings( $resolution['settings'] ?? array() ),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param callable|null $clean_path Path cleaner. @return array{request:array{connectors:string[],settings:string[]},resolution:array<string,mixed>,inheritance:array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>}} */
+	public static function resolution_payload( array $input, ?callable $clean_path = null ): array {
+		$resolved = self::resolve( $input );
+
+		return array(
+			'request'     => $resolved['request'],
+			'resolution'  => $resolved['resolution'],
+			'inheritance' => self::sanitize_resolution( $resolved['resolution'], $clean_path ),
+		);
+	}
+
+	/** @param array<int,mixed> $connectors Inheritance connector rows. @param callable|null $clean_path Path cleaner. @return array<int,array<string,mixed>> */
+	public static function sanitize_connectors( array $connectors, ?callable $clean_path = null ): array {
+		$sanitized = array();
+		foreach ( $connectors as $connector ) {
+			if ( ! is_array( $connector ) ) {
+				continue;
+			}
+
+			$name = trim( (string) ( $connector['name'] ?? '' ) );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$entry = array(
+				'name'   => $name,
+				'status' => trim( (string) ( $connector['status'] ?? 'resolved' ) ),
+			);
+			foreach ( array( 'provider', 'model' ) as $field ) {
+				$value = trim( (string) ( $connector[ $field ] ?? '' ) );
+				if ( '' !== $value ) {
+					$entry[ $field ] = $value;
+				}
+			}
+
+			$provider_plugin_paths = array_values(
+				array_filter(
+					array_map(
+						static fn( string $path ): string => null !== $clean_path ? (string) $clean_path( $path ) : $path,
+						self::string_list( $connector['provider_plugin_paths'] ?? $connector['providerPluginPaths'] ?? array() )
+					),
+					static fn( string $path ): bool => '' !== $path && is_dir( $path )
+				)
+			);
+			if ( ! empty( $provider_plugin_paths ) ) {
+				$entry['providerPluginPaths'] = array_values( array_unique( $provider_plugin_paths ) );
+			}
+
+			$secret_env = array_values( array_filter( self::string_list( $connector['secret_env'] ?? $connector['secretEnv'] ?? array() ), static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) );
+			if ( ! empty( $secret_env ) ) {
+				$entry['secretEnv'] = array_values( array_unique( $secret_env ) );
+			}
+
+			$credentials = self::sanitize_connector_credentials( $connector['credentials'] ?? null, $name );
+			if ( ! empty( $credentials ) ) {
+				$entry['credentials'] = $credentials;
+			}
+
+			$sanitized[] = $entry;
+		}
+
+		return $sanitized;
+	}
+
+	/** @return array<string,mixed> */
+	public static function sanitize_connector_credentials( mixed $credentials, string $connector_name ): array {
+		if ( ! is_array( $credentials ) ) {
+			return array();
+		}
+
+		$status = self::credential_status( (string) ( $credentials['status'] ?? 'missing' ) );
+		$entry  = array(
+			'schema'    => 'wp-codebox/connector-credentials/v1',
+			'connector' => $connector_name,
+			'scope'     => 'connector',
+			'status'    => $status,
+			'secrets'   => array(),
+		);
+		$reason = self::redacted_reason( $credentials['reason'] ?? '' );
+		if ( '' !== $reason ) {
+			$entry['reason'] = $reason;
+		}
+
+		foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
+			if ( ! is_array( $secret ) ) {
+				continue;
+			}
+
+			$name = trim( (string) ( $secret['name'] ?? '' ) );
+			if ( 1 !== preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) {
+				continue;
+			}
+
+			$secret_entry = array(
+				'name'   => $name,
+				'status' => self::credential_status( (string) ( $secret['status'] ?? $status ) ),
+			);
+			foreach ( array( 'scope', 'source', 'reason' ) as $field ) {
+				$value = 'reason' === $field ? self::redacted_reason( $secret[ $field ] ?? '' ) : trim( (string) ( $secret[ $field ] ?? '' ) );
+				if ( '' !== $value ) {
+					$secret_entry[ $field ] = $value;
+				}
+			}
+
+			$entry['secrets'][] = $secret_entry;
+		}
+
+		return $entry;
+	}
+
+	/** @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return string[] */
+	public static function secret_env_names( array $inheritance ): array {
+		$names = array();
+		foreach ( $inheritance['connectors'] as $connector ) {
+			$names       = array_merge( $names, self::string_list( $connector['secretEnv'] ?? array() ) );
+			$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
+			foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
+				if ( is_array( $secret ) && 'available' === ( $secret['status'] ?? '' ) ) {
+					$names[] = (string) ( $secret['name'] ?? '' );
+				}
+			}
+		}
+
+		return array_values( array_unique( array_filter( $names ) ) );
+	}
+
+	/** @param array<int,array<string,mixed>> $connectors Resolved connectors. @return array<string,mixed> */
+	public static function resolved_connector( array $connectors, string $connector_name ): array {
+		foreach ( $connectors as $connector ) {
+			if ( $connector_name === (string) ( $connector['name'] ?? '' ) ) {
+				return $connector;
+			}
+		}
+
+		return array();
+	}
+
+	/** @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
+	public static function connector_credentials_error( array $inheritance, string $message ): WP_Error|null {
+		$failures = array();
+		foreach ( $inheritance['connectors'] as $connector ) {
+			$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
+			if ( empty( $credentials ) ) {
+				continue;
+			}
+
+			$status  = (string) ( $credentials['status'] ?? 'missing' );
+			$secrets = array_filter( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array(), static fn( mixed $secret ): bool => is_array( $secret ) && in_array( (string) ( $secret['status'] ?? '' ), array( 'missing', 'denied' ), true ) );
+			if ( in_array( $status, array( 'missing', 'denied' ), true ) || ! empty( $secrets ) ) {
+				$failures[] = array(
+					'name'        => (string) ( $connector['name'] ?? '' ),
+					'status'      => (string) ( $connector['status'] ?? '' ),
+					'credentials' => $credentials,
+				);
+			}
+		}
+
+		return empty( $failures ) ? null : new WP_Error( 'wp_codebox_connector_credentials_unavailable', $message, array( 'status' => 403, 'schema' => 'wp-codebox/connector-credential-failure/v1', 'connectors' => $failures ) );
+	}
+
+	/** @param array<int,mixed> $settings Inheritance setting rows. @return array<int,array<string,mixed>> */
+	public static function sanitize_settings( array $settings ): array {
+		$sanitized = array();
+		foreach ( $settings as $setting ) {
+			if ( ! is_array( $setting ) ) {
+				continue;
+			}
+			$name = trim( (string) ( $setting['name'] ?? '' ) );
+			if ( '' === $name ) {
+				continue;
+			}
+			$entry = array(
+				'name'   => $name,
+				'status' => trim( (string) ( $setting['status'] ?? 'resolved' ) ),
+			);
+			$scope = trim( (string) ( $setting['scope'] ?? '' ) );
+			if ( '' !== $scope ) {
+				$entry['scope'] = $scope;
+			}
+			$sanitized[] = $entry;
+		}
+
+		return $sanitized;
+	}
+
+	private static function credential_status( string $status ): string {
+		return in_array( $status, array( 'available', 'missing', 'denied' ), true ) ? $status : 'missing';
+	}
+
+	private static function redacted_reason( mixed $reason ): string {
+		$reason = trim( (string) $reason );
+		return '' === $reason ? '' : substr( preg_replace( '/[^A-Za-z0-9 .:_-]/', '', $reason ) ?? '', 0, 160 );
+	}
+
+	/** @return string[] */
+	private static function string_list( mixed $value ): array {
+		return WP_Codebox_Agent_Task::string_list( $value );
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-connectors.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-connectors.php
@@ -55,16 +55,17 @@ trait WP_Codebox_Abilities_Browser_Connectors {
 			return new WP_Error( 'wp_codebox_browser_connector_request_invalid', 'Browser connector requests require connector and operation.', array( 'status' => 400, 'schema' => 'wp-codebox/browser-connector-response/v1' ) );
 		}
 
-		$raw_resolution = self::browser_connector_raw_resolution( $connector_name, $input );
-		$inheritance_payload = self::browser_inheritance_resolution_payload( array( 'inherit' => array( 'connectors' => array( $connector_name ) ) ) );
-		if ( is_wp_error( $inheritance_payload ) ) {
-			$error_data       = $inheritance_payload->get_error_data();
+		$inheritance_payload = WP_Codebox_Inheritance::resolution_payload( array_merge( $input, array( 'inherit' => array( 'connectors' => array( $connector_name ) ) ) ), static fn( string $path ): string => self::browser_clean_path( $path ) );
+		$raw_resolution      = array_values( array_filter( is_array( $inheritance_payload['resolution']['connectors'] ?? null ) ? $inheritance_payload['resolution']['connectors'] : array(), 'is_array' ) );
+		$credential_error    = self::browser_connector_credentials_error( $inheritance_payload['inheritance'] );
+		if ( null !== $credential_error ) {
+			$error_data       = $credential_error->get_error_data();
 			$error_connectors = is_array( $error_data['connectors'] ?? null ) ? $error_data['connectors'] : array();
 			$error_connector  = is_array( $error_connectors[0] ?? null ) ? $error_connectors[0] : array();
-			return self::browser_connector_error_response( $input, $connector_name, $operation, $inheritance_payload, $error_connector );
+			return self::browser_connector_error_response( $input, $connector_name, $operation, $credential_error, $error_connector );
 		}
 
-		$connector = self::browser_resolved_connector( $inheritance_payload['inheritance']['connectors'] ?? array(), $connector_name );
+		$connector = WP_Codebox_Inheritance::resolved_connector( $inheritance_payload['inheritance']['connectors'] ?? array(), $connector_name );
 		if ( empty( $connector ) || 'resolved' !== (string) ( $connector['status'] ?? '' ) ) {
 			return self::browser_connector_error_response( $input, $connector_name, $operation, new WP_Error( 'wp_codebox_browser_connector_unresolved', 'Requested browser connector is not available for this scope.', array( 'status' => 403 ) ) );
 		}
@@ -102,39 +103,6 @@ trait WP_Codebox_Abilities_Browser_Connectors {
 		}
 
 		return self::sanitize_browser_connector_response( $response, $connector, $operation, $input );
-	}
-
-	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>> */
-	private static function browser_connector_raw_resolution( string $connector_name, array $input ): array {
-		$resolution = array(
-			'connectors' => array(
-				array(
-					'name'   => $connector_name,
-					'status' => 'unresolved',
-				),
-			),
-			'settings'   => array(),
-		);
-
-		if ( function_exists( 'apply_filters' ) ) {
-			$filtered = apply_filters( 'wp_codebox_resolve_inheritance', $resolution, array( 'connectors' => array( $connector_name ), 'settings' => array() ), $input );
-			if ( is_array( $filtered ) ) {
-				$resolution = $filtered;
-			}
-		}
-
-		return array_values( array_filter( is_array( $resolution['connectors'] ?? null ) ? $resolution['connectors'] : array(), 'is_array' ) );
-	}
-
-	/** @param array<int,array<string,mixed>> $connectors Resolved connectors. @return array<string,mixed> */
-	private static function browser_resolved_connector( array $connectors, string $connector_name ): array {
-		foreach ( $connectors as $connector ) {
-			if ( $connector_name === (string) ( $connector['name'] ?? '' ) ) {
-				return $connector;
-			}
-		}
-
-		return array();
 	}
 
 	/** @param array<string,mixed> $connector Resolved connector. @return array<string,string> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -15,45 +15,13 @@ private static function normalize_task_input( array $input ): array|WP_Error {
 
 /** @param array<string,mixed> $input Ability input. @return array{connectors:string[],settings:string[]} */
 private static function browser_inheritance_request( array $input ): array {
-	$inherit = is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array();
-
-	return array(
-		'connectors' => self::string_list( $inherit['connectors'] ?? array() ),
-		'settings'   => self::string_list( $inherit['settings'] ?? array() ),
-	);
+	return WP_Codebox_Inheritance::request( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array{inheritance:array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>}}|WP_Error */
 private static function browser_inheritance_resolution_payload( array $input ): array|WP_Error {
-	$request    = self::browser_inheritance_request( $input );
-	$resolution = array(
-		'connectors' => array_map(
-			static fn( string $name ): array => array(
-				'name'   => $name,
-				'status' => 'unresolved',
-			),
-			$request['connectors']
-		),
-		'settings'   => array_map(
-			static fn( string $name ): array => array(
-				'name'   => $name,
-				'status' => 'unresolved',
-			),
-			$request['settings']
-		),
-	);
-
-	if ( function_exists( 'apply_filters' ) && ( ! empty( $request['connectors'] ) || ! empty( $request['settings'] ) ) ) {
-		$filtered = apply_filters( 'wp_codebox_resolve_inheritance', $resolution, $request, $input );
-		if ( is_array( $filtered ) ) {
-			$resolution = $filtered;
-		}
-	}
-
-	$inheritance = array(
-		'connectors' => self::sanitize_browser_inheritance_connectors( $resolution['connectors'] ?? array() ),
-		'settings'   => self::sanitize_browser_inheritance_settings( $resolution['settings'] ?? array() ),
-	);
+	$payload     = WP_Codebox_Inheritance::resolution_payload( $input, static fn( string $path ): string => self::browser_clean_path( $path ) );
+	$inheritance = $payload['inheritance'];
 	$credential_error = self::browser_connector_credentials_error( $inheritance );
 	if ( null !== $credential_error ) {
 		return $credential_error;
@@ -243,166 +211,12 @@ private static function browser_inheritance_provider_plugin_paths( array $inheri
 
 /** @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return string[] */
 private static function browser_inheritance_secret_env_names( array $inheritance ): array {
-	$names = array();
-	foreach ( $inheritance['connectors'] as $connector ) {
-		$names = array_merge( $names, self::string_list( $connector['secretEnv'] ?? array() ) );
-		$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
-		foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
-			if ( is_array( $secret ) && 'available' === ( $secret['status'] ?? '' ) ) {
-				$names[] = (string) ( $secret['name'] ?? '' );
-			}
-		}
-	}
-
-	return array_values( array_unique( array_filter( $names ) ) );
-}
-
-/** @param array<int,mixed> $connectors Inheritance connector rows. @return array<int,array<string,mixed>> */
-private static function sanitize_browser_inheritance_connectors( array $connectors ): array {
-	$sanitized = array();
-	foreach ( $connectors as $connector ) {
-		if ( ! is_array( $connector ) ) {
-			continue;
-		}
-
-		$name = trim( (string) ( $connector['name'] ?? '' ) );
-		if ( '' === $name ) {
-			continue;
-		}
-
-		$entry = array(
-			'name'   => $name,
-			'status' => trim( (string) ( $connector['status'] ?? 'resolved' ) ),
-		);
-		foreach ( array( 'provider', 'model' ) as $field ) {
-			$value = trim( (string) ( $connector[ $field ] ?? '' ) );
-			if ( '' !== $value ) {
-				$entry[ $field ] = $value;
-			}
-		}
-
-		$provider_plugin_paths = array_values( array_filter( array_map( static fn( string $path ): string => self::browser_clean_path( $path ), self::string_list( $connector['provider_plugin_paths'] ?? $connector['providerPluginPaths'] ?? array() ) ), static fn( string $path ): bool => '' !== $path && is_dir( $path ) ) );
-		if ( ! empty( $provider_plugin_paths ) ) {
-			$entry['providerPluginPaths'] = array_values( array_unique( $provider_plugin_paths ) );
-		}
-
-		$secret_env = array_values( array_filter( self::string_list( $connector['secret_env'] ?? $connector['secretEnv'] ?? array() ), static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) );
-		if ( ! empty( $secret_env ) ) {
-			$entry['secretEnv'] = array_values( array_unique( $secret_env ) );
-		}
-
-		$credentials = self::sanitize_browser_connector_credentials( $connector['credentials'] ?? null, $name );
-		if ( ! empty( $credentials ) ) {
-			$entry['credentials'] = $credentials;
-		}
-
-		$sanitized[] = $entry;
-	}
-
-	return $sanitized;
-}
-
-/** @return array<string,mixed> */
-private static function sanitize_browser_connector_credentials( mixed $credentials, string $connector_name ): array {
-	if ( ! is_array( $credentials ) ) {
-		return array();
-	}
-
-	$status = self::browser_credential_status( (string) ( $credentials['status'] ?? 'missing' ) );
-	$entry  = array(
-		'schema'    => 'wp-codebox/connector-credentials/v1',
-		'connector' => $connector_name,
-		'scope'     => 'connector',
-		'status'    => $status,
-		'secrets'   => array(),
-	);
-	$reason = self::browser_redacted_reason( $credentials['reason'] ?? '' );
-	if ( '' !== $reason ) {
-		$entry['reason'] = $reason;
-	}
-
-	foreach ( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array() as $secret ) {
-		if ( ! is_array( $secret ) ) {
-			continue;
-		}
-
-		$name = trim( (string) ( $secret['name'] ?? '' ) );
-		if ( 1 !== preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) {
-			continue;
-		}
-
-		$secret_entry = array(
-			'name'   => $name,
-			'status' => self::browser_credential_status( (string) ( $secret['status'] ?? $status ) ),
-		);
-		foreach ( array( 'scope', 'source', 'reason' ) as $field ) {
-			$value = 'reason' === $field ? self::browser_redacted_reason( $secret[ $field ] ?? '' ) : trim( (string) ( $secret[ $field ] ?? '' ) );
-			if ( '' !== $value ) {
-				$secret_entry[ $field ] = $value;
-			}
-		}
-
-		$entry['secrets'][] = $secret_entry;
-	}
-
-	return $entry;
-}
-
-private static function browser_credential_status( string $status ): string {
-	return in_array( $status, array( 'available', 'missing', 'denied' ), true ) ? $status : 'missing';
-}
-
-private static function browser_redacted_reason( mixed $reason ): string {
-	$reason = trim( (string) $reason );
-	return '' === $reason ? '' : substr( preg_replace( '/[^A-Za-z0-9 .:_-]/', '', $reason ) ?? '', 0, 160 );
+	return WP_Codebox_Inheritance::secret_env_names( $inheritance );
 }
 
 /** @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
 private static function browser_connector_credentials_error( array $inheritance ): WP_Error|null {
-	$failures = array();
-	foreach ( $inheritance['connectors'] as $connector ) {
-		$credentials = is_array( $connector['credentials'] ?? null ) ? $connector['credentials'] : array();
-		if ( empty( $credentials ) ) {
-			continue;
-		}
-
-		$status  = (string) ( $credentials['status'] ?? 'missing' );
-		$secrets = array_filter( is_array( $credentials['secrets'] ?? null ) ? $credentials['secrets'] : array(), static fn( mixed $secret ): bool => is_array( $secret ) && in_array( (string) ( $secret['status'] ?? '' ), array( 'missing', 'denied' ), true ) );
-		if ( in_array( $status, array( 'missing', 'denied' ), true ) || ! empty( $secrets ) ) {
-			$failures[] = array(
-				'name'        => (string) ( $connector['name'] ?? '' ),
-				'status'      => (string) ( $connector['status'] ?? '' ),
-				'credentials' => $credentials,
-			);
-		}
-	}
-
-	return empty( $failures ) ? null : new WP_Error( 'wp_codebox_connector_credentials_unavailable', 'Requested connector credentials are missing or denied for this browser sandbox scope.', array( 'status' => 403, 'schema' => 'wp-codebox/connector-credential-failure/v1', 'connectors' => $failures ) );
-}
-
-/** @param array<int,mixed> $settings Inheritance setting rows. @return array<int,array<string,mixed>> */
-private static function sanitize_browser_inheritance_settings( array $settings ): array {
-	$sanitized = array();
-	foreach ( $settings as $setting ) {
-		if ( ! is_array( $setting ) ) {
-			continue;
-		}
-		$name = trim( (string) ( $setting['name'] ?? '' ) );
-		if ( '' === $name ) {
-			continue;
-		}
-		$entry = array(
-			'name'   => $name,
-			'status' => trim( (string) ( $setting['status'] ?? 'resolved' ) ),
-		);
-		$scope = trim( (string) ( $setting['scope'] ?? '' ) );
-		if ( '' !== $scope ) {
-			$entry['scope'] = $scope;
-		}
-		$sanitized[] = $entry;
-	}
-
-	return $sanitized;
+	return WP_Codebox_Inheritance::connector_credentials_error( $inheritance, 'Requested connector credentials are missing or denied for this browser sandbox scope.' );
 }
 
 /** @return string[] */

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -21,6 +21,7 @@ define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
+require_once __DIR__ . '/src/class-wp-codebox-inheritance.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-data-machine-pending-actions.php';

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -182,6 +182,7 @@ function get_users( array $args ): array { return array( new WP_User( 11, 'Priva
 
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
+require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-inheritance.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php';


### PR DESCRIPTION
## Summary
- Add a shared `WP_Codebox_Inheritance` helper for inheritance request resolution, sanitized connector/settings audit shapes, credential provenance redaction, credential failure envelopes, and connector lookup.
- Route host runner, browser session, and browser connector paths through the shared normalizer while keeping host-only process secret injection and browser connector redacted envelopes in their transport-specific callers.
- Keep issue #780 scoped to inheritance normalization; this does not introduce product component assumptions from #768 or runner decomposition from #769.

Closes #780.

## Testing
- `php -l packages/wordpress-plugin/src/class-wp-codebox-inheritance.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-connectors.php && php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l tests/smoke-wordpress-plugin.php`
- `npm run build`
- `npm run wordpress-plugin-smoke`
- `npm run check` progressed through build/core/policy/package/artifact/runtime and into recipe checks, then the shell timed out while running `recipe-runtime-evidence-smoke`; rerun directly below passed.
- `npm run recipe-runtime-evidence-smoke`
- Remaining check-group commands after the timeout: `npm run recipe-playground-boot-failure-smoke`, `npm run runtime-stack-mount-smoke`, `npm run runtime-overlay-php-ai-client-smoke`, `npm run recipe-interruption-artifacts-smoke`, `npm run recipe-heavyweight-plugin-runtime-smoke`, `npm run smoke -- --group=preview`
- `npm run smoke -- --group=browser` timed out on `browser-probe-artifact-smoke`; rerun directly and the remaining browser commands below passed.
- `npm run browser-probe-artifact-smoke`
- `npm run browser-probe-pre-page-script-smoke && npm run browser-actions-artifact-smoke && npm run browser-scenario-artifact-smoke && npm run headless-browser-agent-recipe-smoke && npm run wp-codebox -- run --mount ./examples/simple-plugin:/wordpress/wp-content/plugins/simple-plugin --command wordpress.run-php --arg code-file=./examples/simple-plugin/probe.php --artifacts ./artifacts --json`
- After rebasing onto current `origin/main`: PHP syntax checks, `npm run build`, and `npm run wordpress-plugin-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the shared helper refactor, updated callers/tests, and ran local verification; Chris remains responsible for review and merge.