### PR TITLE
fix: preserve agent runtime json payloads

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -273,6 +273,25 @@ function wp_codebox_import_sandbox_agent_bundles(array $bundle_specs): array {
     return $imports;
 }
 
+function wp_codebox_json_encode_runtime_payload($value): string {
+    $json = wp_json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    if (false !== $json) {
+        return $json;
+    }
+
+    $fallback = array(
+        'agent_runtime' => array(
+            'success' => false,
+            'error' => array(
+                'code' => 'runtime_payload_json_encode_failed',
+                'message' => function_exists('json_last_error_msg') ? json_last_error_msg() : 'Runtime payload JSON encoding failed.',
+            ),
+        ),
+    );
+
+    return (string) wp_json_encode($fallback, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+}
+
 $runtime_task_run = is_array($sandbox_runtime_task) && !empty($sandbox_runtime_task);
 $ability_name = $runtime_task_run ? (string) ($sandbox_runtime_task['ability'] ?? '') : 'agents/chat';
 $ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability($ability_name) : null;
@@ -329,7 +348,7 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
     }
 }
 
-echo json_encode($sandbox_agent_runtime, JSON_PRETTY_PRINT);
+echo wp_codebox_json_encode_runtime_payload($sandbox_agent_runtime);
 `
 }
 
@@ -527,6 +546,25 @@ function wp_codebox_provider_plugin_entries(array $provider_plugins): array {
     return $entries;
 }
 
+function wp_codebox_json_encode_runtime_payload($value): string {
+    $json = wp_json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    if (false !== $json) {
+        return $json;
+    }
+
+    $fallback = array(
+        'command' => 'agent-sandbox.run',
+        'wp_loaded' => function_exists('wp_insert_post'),
+        'output' => '',
+        'error' => array(
+            'code' => 'runtime_payload_json_encode_failed',
+            'message' => function_exists('json_last_error_msg') ? json_last_error_msg() : 'Runtime payload JSON encoding failed.',
+        ),
+    );
+
+    return (string) wp_json_encode($fallback, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+}
+
 $activation_results = array();
 
 foreach ($plugins as $plugin) {
@@ -571,15 +609,14 @@ ob_start();
 ${phpBody(code)}
 $sandbox_output = ob_get_clean();
 
-echo json_encode(
+echo wp_codebox_json_encode_runtime_payload(
     array(
         'command' => 'agent-sandbox.run',
         'task' => $sandbox_task,
         'wp_loaded' => function_exists('wp_insert_post'),
         'stack' => $sandbox_stack,
         'output' => $sandbox_output,
-    ),
-    JSON_PRETTY_PRINT
+    )
 );
 `
 }

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { normalizeTaskInput } from "@automattic/wp-codebox-core"
 import { buildAgentTaskRecipe } from "../packages/cli/src/commands/agent-task-run.js"
+import { agentSandboxRunCode } from "../packages/cli/src/agent-code.js"
 import { installMuPluginsCode } from "../packages/cli/src/recipe-sources.js"
 
 const input = {
@@ -54,6 +55,7 @@ assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine"
 
 const agentTaskRunSource = readFileSync(new URL("../packages/cli/src/commands/agent-task-run.ts", import.meta.url), "utf8")
 const recipeEvidenceSource = readFileSync(new URL("../packages/cli/src/recipe-evidence.ts", import.meta.url), "utf8")
+const sandboxCode = agentSandboxRunCode("Run a bundle", "echo json_encode(array('ok' => true));", [])
 assert.ok(
   agentTaskRunSource.includes("diagnostics(run, success ? 0 : capture.exitCode, success)"),
   "successful normalized agent-bundle workloads should not keep stale recipe-run failure diagnostics",
@@ -69,6 +71,14 @@ assert.ok(
 assert.ok(
   recipeEvidenceSource.includes('agentTaskResult?.success !== true || agentResult.status !== "failed"'),
   "only successful agent task results should override failed sandbox evidence",
+)
+assert.ok(
+  sandboxCode.includes("JSON_INVALID_UTF8_SUBSTITUTE"),
+  "sandbox runtime payload encoding should preserve results with invalid UTF-8 instead of returning an empty output",
+)
+assert.ok(
+  sandboxCode.includes("runtime_payload_json_encode_failed"),
+  "sandbox runtime payload encoding failures should surface as structured diagnostics",
 )
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))


### PR DESCRIPTION
## Summary
- Encodes sandbox runtime payloads with `wp_json_encode()` plus `JSON_INVALID_UTF8_SUBSTITUTE` so agent-bundle results do not silently become an empty output when `json_encode()` fails.
- Emits a structured `runtime_payload_json_encode_failed` fallback instead of returning an empty string.
- Extends the agent task smoke to guard the safe encoder path.

## Verification
- `npm run build`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the WPSG empty runtime output and drafted the safe JSON encoding fix under Chris's direction.