### PR TITLE
fix: avoid sandbox encoder redeclaration

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -273,7 +273,7 @@ function wp_codebox_import_sandbox_agent_bundles(array $bundle_specs): array {
     return $imports;
 }
 
-function wp_codebox_json_encode_runtime_payload($value): string {
+function wp_codebox_json_encode_agent_runtime_payload($value): string {
     $json = wp_json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
     if (false !== $json) {
         return $json;
@@ -348,7 +348,7 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
     }
 }
 
-echo wp_codebox_json_encode_runtime_payload($sandbox_agent_runtime);
+echo wp_codebox_json_encode_agent_runtime_payload($sandbox_agent_runtime);
 `
 }
 
@@ -546,7 +546,7 @@ function wp_codebox_provider_plugin_entries(array $provider_plugins): array {
     return $entries;
 }
 
-function wp_codebox_json_encode_runtime_payload($value): string {
+function wp_codebox_json_encode_sandbox_payload($value): string {
     $json = wp_json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
     if (false !== $json) {
         return $json;
@@ -609,7 +609,7 @@ ob_start();
 ${phpBody(code)}
 $sandbox_output = ob_get_clean();
 
-echo wp_codebox_json_encode_runtime_payload(
+echo wp_codebox_json_encode_sandbox_payload(
     array(
         'command' => 'agent-sandbox.run',
         'task' => $sandbox_task,

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -54,6 +54,7 @@ assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine-
 assert.equal(legacyExtraPlugins.find((plugin) => plugin?.slug === "data-machine")?.loadAs, "mu-plugin")
 
 const agentTaskRunSource = readFileSync(new URL("../packages/cli/src/commands/agent-task-run.ts", import.meta.url), "utf8")
+const agentCodeSource = readFileSync(new URL("../packages/cli/src/agent-code.ts", import.meta.url), "utf8")
 const recipeEvidenceSource = readFileSync(new URL("../packages/cli/src/recipe-evidence.ts", import.meta.url), "utf8")
 const sandboxCode = agentSandboxRunCode("Run a bundle", "echo json_encode(array('ok' => true));", [])
 assert.ok(
@@ -79,6 +80,14 @@ assert.ok(
 assert.ok(
   sandboxCode.includes("runtime_payload_json_encode_failed"),
   "sandbox runtime payload encoding failures should surface as structured diagnostics",
+)
+assert.ok(
+  agentCodeSource.includes("wp_codebox_json_encode_agent_runtime_payload"),
+  "nested agent runtime payloads should use their own encoder helper",
+)
+assert.ok(
+  agentCodeSource.includes("wp_codebox_json_encode_sandbox_payload"),
+  "outer sandbox payloads should use a distinct encoder helper",
 )
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))


### PR DESCRIPTION
## Summary
- Uses distinct generated PHP helper names for nested agent-runtime payload encoding and outer sandbox payload encoding.
- Prevents agent-mode sandbox runs from fatalling on `Cannot redeclare wp_codebox_json_encode_runtime_payload()` after the safe JSON encoder change.
- Extends the targeted smoke guard for the separate helper names.

## Verification
- `npm run build`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the generated PHP redeclaration in the WPSG rerun and drafted the helper-name fix under Chris's direction.