### PR TITLE
Split browser artifact variants

### DIFF
--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -30,7 +30,7 @@ import {
   type RuntimeInfo,
   type Snapshot,
 } from "@automattic/wp-codebox-core"
-import type { BrowserProbeArtifact } from "./browser-artifacts.js"
+import type { BrowserArtifact } from "./browser-artifacts.js"
 import {
   ArtifactRedactor,
   artifactContentDigest,
@@ -60,7 +60,7 @@ export interface ArtifactBundleBuilderSource {
   info(): Promise<RuntimeInfo>
   previewInfo(createdAt: string, previewHoldSeconds?: number): Promise<ArtifactPreview | undefined>
   browserReviewSummary(): ArtifactReviewBrowserSummary | undefined
-  browserArtifacts(): BrowserProbeArtifact[]
+  browserArtifacts(): BrowserArtifact[]
   captureMountedFiles(filesDirectory: string, redactor: ArtifactRedactor): Promise<CapturedMountFiles>
   captureMountDiffs(filesDirectory: string, redactor: ArtifactRedactor): Promise<MountDiffsResult>
   redactBrowserArtifacts(redactor: ArtifactRedactor): Promise<void>
@@ -684,7 +684,7 @@ async function buildDurableArtifactPreview({
 }: {
   artifactRoot: string
   createdAt: string
-  probes: BrowserProbeArtifact[]
+  probes: BrowserArtifact[]
   redactor: ArtifactRedactor
 }): Promise<DurableArtifactPreviewBuildResult | undefined> {
   const bundle = findBrowserArtifactBundleWithFiles(probes)
@@ -763,7 +763,7 @@ async function buildDurableArtifactPreview({
   return { preview, manifestFiles }
 }
 
-function findBrowserArtifactBundleWithFiles(probes: BrowserProbeArtifact[]): BrowserArtifactBundleWithFiles | undefined {
+function findBrowserArtifactBundleWithFiles(probes: BrowserArtifact[]): BrowserArtifactBundleWithFiles | undefined {
   for (const [index, probe] of probes.entries()) {
     const scriptResult = asRecord(probe.summary.scriptResult)
     const candidate = asRecord(scriptResult?.artifact_bundle) ?? asRecord(scriptResult?.artifactBundle) ?? scriptResult

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -2,7 +2,12 @@ import { join } from "node:path"
 import { artifactManifestFile, type ArtifactManifestFile, type ArtifactReviewBrowserSummary } from "@automattic/wp-codebox-core"
 import type { Request } from "playwright"
 
-export interface BrowserProbeArtifact {
+export type BrowserArtifact = BrowserProbeArtifact | BrowserActionsArtifact | BrowserEditorOpenArtifact | BrowserEditorActionsArtifact | BrowserScenarioArtifact | BrowserVisualCompareArtifact
+
+export type BrowserArtifactType = BrowserArtifact["artifactType"]
+
+export interface BrowserArtifactBase {
+  artifactType: "probe" | "actions" | "editor-open" | "editor-actions" | "scenario" | "visual-compare"
   requestedUrl: string
   url: string
   preview: BrowserProbePreviewRouting
@@ -11,78 +16,115 @@ export interface BrowserProbeArtifact {
   requestedPreviewOrigin?: string
   effectivePreviewOrigin?: string
   prePageScript?: BrowserProbeScriptMetadata
-  files: {
-    actions?: string
-    editorState?: string
-    steps?: string
-    checkpoints?: string
-    console?: string
-    errors?: string
-    html?: string
-    lifecycle?: string
-    memory?: string
-    network?: string
-    performance?: string
-    review?: string
-    screenshot?: string
-    domSnapshots?: string[]
-    sourceScreenshot?: string
-    candidateScreenshot?: string
-    diffScreenshot?: string
-    visualDiff?: string
-    visualExplanation?: string
-    summary: string
+  files: BrowserArtifactFiles
+  summary: BrowserArtifactSummary
+}
+
+export interface BrowserProbeArtifact extends BrowserArtifactBase {
+  artifactType: "probe"
+  files: BrowserArtifactFiles & { summary: string }
+}
+
+export interface BrowserActionsArtifact extends BrowserArtifactBase {
+  artifactType: "actions"
+  files: BrowserArtifactFiles & { summary: string }
+  summary: BrowserArtifactSummary & { actions: number; steps: number }
+}
+
+export interface BrowserEditorOpenArtifact extends BrowserArtifactBase {
+  artifactType: "editor-open"
+  files: BrowserArtifactFiles & { summary: string }
+}
+
+export interface BrowserEditorActionsArtifact extends BrowserArtifactBase {
+  artifactType: "editor-actions"
+  files: BrowserArtifactFiles & { summary: string }
+  summary: BrowserArtifactSummary & { actions: number; steps: number }
+}
+
+export interface BrowserScenarioArtifact extends BrowserArtifactBase {
+  artifactType: "scenario"
+  files: BrowserArtifactFiles & { summary: string }
+}
+
+export interface BrowserVisualCompareArtifact extends BrowserArtifactBase {
+  artifactType: "visual-compare"
+  files: BrowserArtifactFiles & { summary: string; sourceScreenshot: string; candidateScreenshot: string; diffScreenshot: string; visualDiff: string }
+  summary: BrowserArtifactSummary & { visualCompare: NonNullable<BrowserArtifactSummary["visualCompare"]> }
+}
+
+export interface BrowserArtifactFiles {
+  actions?: string
+  editorState?: string
+  steps?: string
+  checkpoints?: string
+  console?: string
+  errors?: string
+  html?: string
+  lifecycle?: string
+  memory?: string
+  network?: string
+  performance?: string
+  review?: string
+  screenshot?: string
+  domSnapshots?: string[]
+  sourceScreenshot?: string
+  candidateScreenshot?: string
+  diffScreenshot?: string
+  visualDiff?: string
+  visualExplanation?: string
+  summary: string
+}
+
+export interface BrowserArtifactSummary {
+  actions?: number
+  editor?: {
+    kind: string
+    postId?: number
+    postType?: string
+    title?: string
+    blockCount?: number
+    storesAvailable: boolean
   }
-  summary: {
-    actions?: number
-    editor?: {
-      kind: string
-      postId?: number
-      postType?: string
-      title?: string
-      blockCount?: number
-      storesAvailable: boolean
-    }
-    editorCanvas?: BrowserEditorCanvasProbeSummary
-    steps?: number
-    assertions?: BrowserAssertionsSummary
-    consoleMessages: number
-    errors: number
-    finalUrl: string
-    windowLocationOrigin?: string
-    htmlSnapshot: boolean
-    domSnapshots?: Array<{
-      screenshot: string
-      snapshot: string
-      step?: { index: number; name?: string; kind: string }
-      elementCount: number
-      capturedElements: number
-      truncated: boolean
-    }>
-    networkPolicy?: BrowserProbeNetworkPolicySummary
-    lifecycle?: BrowserProbeLifecycleSummary
-    memory?: BrowserProbeMemorySummary
-    metrics?: Record<string, number>
-    networkEvents: number
-    performance?: BrowserProbePerformanceSummary
-    progress?: BrowserProbeProgressSummary
-    review?: BrowserProbeReviewSummary
-    context?: BrowserProbeContextDetails
-    auth?: BrowserProbeAuthSummary
-    capabilities?: BrowserProbeCapabilityDiagnostics
-    replayability: BrowserProbeReplayability
-    screenshot: boolean
-    visualCompare?: {
-      status: string
-      mismatchRatio?: number
-      mismatchPixels?: number
-      totalPixels?: number
-      dimensionMismatch?: boolean
-      explanation?: string
-    }
-    scriptResult?: unknown
-    viewport: BrowserProbeViewport | null
+  editorCanvas?: BrowserEditorCanvasProbeSummary
+  steps?: number
+  assertions?: BrowserAssertionsSummary
+  consoleMessages: number
+  errors: number
+  finalUrl: string
+  windowLocationOrigin?: string
+  htmlSnapshot: boolean
+  domSnapshots?: Array<{
+    screenshot: string
+    snapshot: string
+    step?: { index: number; name?: string; kind: string }
+    elementCount: number
+    capturedElements: number
+    truncated: boolean
+  }>
+  networkPolicy?: BrowserProbeNetworkPolicySummary
+  lifecycle?: BrowserProbeLifecycleSummary
+  memory?: BrowserProbeMemorySummary
+  metrics?: Record<string, number>
+  networkEvents: number
+  performance?: BrowserProbePerformanceSummary
+  progress?: BrowserProbeProgressSummary
+  review?: BrowserProbeReviewSummary
+  context?: BrowserProbeContextDetails
+  auth?: BrowserProbeAuthSummary
+  capabilities?: BrowserProbeCapabilityDiagnostics
+  replayability: BrowserProbeReplayability
+  screenshot: boolean
+  visualCompare?: {
+    status: string
+    mismatchRatio?: number
+    mismatchPixels?: number
+    totalPixels?: number
+    dimensionMismatch?: boolean
+    explanation?: string
   }
+  scriptResult?: unknown
+  viewport: BrowserProbeViewport | null
 }
 
 export interface BrowserProbeAuthSummary {
@@ -643,7 +685,7 @@ export interface BrowserProbeNetworkSizes {
   responseHeadersSize: number
 }
 
-export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactReviewBrowserSummary | undefined {
+export function browserReviewSummary(probes: BrowserArtifact[]): ArtifactReviewBrowserSummary | undefined {
   if (probes.length === 0) {
     return undefined
   }
@@ -692,79 +734,65 @@ export function browserReviewSummary(probes: BrowserProbeArtifact[]): ArtifactRe
   }
 }
 
-export function browserManifestFiles(artifactRoot: string, probes: BrowserProbeArtifact[]): ArtifactManifestFile[] {
+export function browserManifestFiles(artifactRoot: string, probes: BrowserArtifact[]): ArtifactManifestFile[] {
   if (probes.length === 0) {
     return []
   }
 
-  const files = new Map<string, { kind: string; contentType: string }>()
+  const files = new Map<string, BrowserArtifactFileManifestEntry>()
   for (const probe of probes) {
-    if (probe.files.steps) {
-      files.set(probe.files.steps, { kind: "browser-steps", contentType: "application/x-ndjson" })
+    for (const file of browserArtifactFileEntries(probe)) {
+      files.set(file.path, file.manifest)
     }
-    if (probe.files.actions) {
-      files.set(probe.files.actions, { kind: "browser-actions", contentType: "application/x-ndjson" })
-    }
-    if (probe.files.editorState) {
-      files.set(probe.files.editorState, { kind: "browser-editor-state", contentType: "application/json" })
-    }
-    if (probe.files.console) {
-      files.set(probe.files.console, { kind: "browser-console", contentType: "application/x-ndjson" })
-    }
-    if (probe.files.checkpoints) {
-      files.set(probe.files.checkpoints, { kind: "browser-checkpoints", contentType: "application/x-ndjson" })
-    }
-    if (probe.files.errors) {
-      files.set(probe.files.errors, { kind: "browser-errors", contentType: "application/x-ndjson" })
-    }
-    if (probe.files.html) {
-      files.set(probe.files.html, { kind: "browser-html-snapshot", contentType: "text/html; charset=utf-8" })
-    }
-    if (probe.files.lifecycle) {
-      files.set(probe.files.lifecycle, { kind: "browser-lifecycle", contentType: "application/json" })
-    }
-    if (probe.files.memory) {
-      files.set(probe.files.memory, { kind: "browser-memory", contentType: "application/json" })
-    }
-    if (probe.files.network) {
-      files.set(probe.files.network, { kind: "browser-network", contentType: "application/x-ndjson" })
-    }
-    if (probe.files.performance) {
-      files.set(probe.files.performance, { kind: "browser-performance", contentType: "application/json" })
-    }
-    if (probe.files.review) {
-      files.set(probe.files.review, { kind: "browser-review", contentType: "application/json" })
-    }
-    if (probe.files.screenshot) {
-      files.set(probe.files.screenshot, { kind: "browser-screenshot", contentType: "image/png" })
-    }
-    if (probe.files.domSnapshots) {
-      for (const domSnapshot of probe.files.domSnapshots) {
-        files.set(domSnapshot, { kind: "browser-dom-snapshot", contentType: "application/json" })
-      }
-    }
-    if (probe.files.sourceScreenshot) {
-      files.set(probe.files.sourceScreenshot, { kind: "browser-visual-source-screenshot", contentType: "image/png" })
-    }
-    if (probe.files.candidateScreenshot) {
-      files.set(probe.files.candidateScreenshot, { kind: "browser-visual-candidate-screenshot", contentType: "image/png" })
-    }
-    if (probe.files.diffScreenshot) {
-      files.set(probe.files.diffScreenshot, { kind: "browser-visual-diff-screenshot", contentType: "image/png" })
-    }
-    if (probe.files.visualDiff) {
-      files.set(probe.files.visualDiff, { kind: "browser-visual-diff", contentType: "application/json" })
-    }
-    if (probe.files.visualExplanation) {
-      files.set(probe.files.visualExplanation, { kind: "browser-visual-explanation", contentType: "application/json" })
-    }
-    files.set(probe.files.summary, { kind: "browser-summary", contentType: "application/json" })
   }
 
   return [...files.entries()].map(([path, entry]) => artifactManifestFile(join(artifactRoot, path), entry.kind, entry.contentType))
 }
 
-export function browserRedactionPaths(probe: BrowserProbeArtifact): string[] {
-  return [probe.files.steps, probe.files.actions, probe.files.editorState, probe.files.checkpoints, probe.files.console, probe.files.errors, probe.files.html, probe.files.lifecycle, probe.files.memory, probe.files.network, probe.files.performance, probe.files.review, ...(probe.files.domSnapshots ?? []), probe.files.visualDiff, probe.files.visualExplanation, probe.files.summary]
-    .filter((path): path is string => typeof path === "string" && path.length > 0)
+export function browserRedactionPaths(probe: BrowserArtifact): string[] {
+  return browserArtifactFileEntries(probe)
+    .filter((file) => file.manifest.redact)
+    .map((file) => file.path)
+}
+
+interface BrowserArtifactFileManifestEntry {
+  kind: string
+  contentType: string
+  redact: boolean
+}
+
+const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, BrowserArtifactFileManifestEntry> = {
+  actions: { kind: "browser-actions", contentType: "application/x-ndjson", redact: true },
+  editorState: { kind: "browser-editor-state", contentType: "application/json", redact: true },
+  steps: { kind: "browser-steps", contentType: "application/x-ndjson", redact: true },
+  checkpoints: { kind: "browser-checkpoints", contentType: "application/x-ndjson", redact: true },
+  console: { kind: "browser-console", contentType: "application/x-ndjson", redact: true },
+  errors: { kind: "browser-errors", contentType: "application/x-ndjson", redact: true },
+  html: { kind: "browser-html-snapshot", contentType: "text/html; charset=utf-8", redact: true },
+  lifecycle: { kind: "browser-lifecycle", contentType: "application/json", redact: true },
+  memory: { kind: "browser-memory", contentType: "application/json", redact: true },
+  network: { kind: "browser-network", contentType: "application/x-ndjson", redact: true },
+  performance: { kind: "browser-performance", contentType: "application/json", redact: true },
+  review: { kind: "browser-review", contentType: "application/json", redact: true },
+  screenshot: { kind: "browser-screenshot", contentType: "image/png", redact: false },
+  domSnapshots: { kind: "browser-dom-snapshot", contentType: "application/json", redact: true },
+  sourceScreenshot: { kind: "browser-visual-source-screenshot", contentType: "image/png", redact: false },
+  candidateScreenshot: { kind: "browser-visual-candidate-screenshot", contentType: "image/png", redact: false },
+  diffScreenshot: { kind: "browser-visual-diff-screenshot", contentType: "image/png", redact: false },
+  visualDiff: { kind: "browser-visual-diff", contentType: "application/json", redact: true },
+  visualExplanation: { kind: "browser-visual-explanation", contentType: "application/json", redact: true },
+  summary: { kind: "browser-summary", contentType: "application/json", redact: true },
+}
+
+function browserArtifactFileEntries(probe: BrowserArtifact): Array<{ path: string; manifest: BrowserArtifactFileManifestEntry }> {
+  const entries: Array<{ path: string; manifest: BrowserArtifactFileManifestEntry }> = []
+  for (const [key, manifest] of Object.entries(BROWSER_ARTIFACT_FILE_MANIFEST) as Array<[keyof BrowserArtifactFiles, BrowserArtifactFileManifestEntry]>) {
+    const value = probe.files[key]
+    if (Array.isArray(value)) {
+      entries.push(...value.map((path) => ({ path, manifest })))
+    } else if (typeof value === "string" && value.length > 0) {
+      entries.push({ path: value, manifest })
+    }
+  }
+  return entries
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -5,7 +5,7 @@ import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, type
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
 import { browserInteractionStepsFromArgs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
-import type { BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkPolicySummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewMode, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
+import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkPolicySummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewMode, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
@@ -142,7 +142,7 @@ const BROWSER_PROBE_THROTTLE_PROFILES: Record<string, BrowserProbeThrottleProfil
 }
 
 export class BrowserCommandArtifactError extends Error {
-  constructor(message: string, readonly artifact: BrowserProbeArtifact) {
+  constructor(message: string, readonly artifact: BrowserArtifact) {
     super(message)
     this.name = "BrowserCommandArtifactError"
   }
@@ -583,6 +583,7 @@ async function runSingleBrowserProbeCommand({
     await writeFile(reviewPath, `${JSON.stringify(review, null, 2)}\n`)
 
     artifact = {
+      artifactType: "probe",
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
@@ -1050,7 +1051,7 @@ export async function runHtmlCaptureCommand(input: {
   runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
   server: PlaygroundCliServer
   spec: ExecutionSpec
-}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = [...(input.spec.args ?? [])]
   if (!args.some((arg) => arg.startsWith("capture="))) {
     args.push("capture=html,console,errors,network")
@@ -1073,7 +1074,7 @@ export async function runEditorCanvasProbeCommand({
   runtimeSpec: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
-}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
   const urlArg = argValue(args, "url")?.trim()
   if (!urlArg) {
@@ -1108,7 +1109,7 @@ export async function runEditorCanvasProbeCommand({
   const { chromium } = await import("playwright")
   const browser = await chromium.launch(process.env.WP_CODEBOX_BROWSER_CHANNEL ? { channel: process.env.WP_CODEBOX_BROWSER_CHANNEL } : undefined)
   const errors: BrowserProbeErrorRecord[] = []
-  let artifact: BrowserProbeArtifact | undefined
+  let artifact: BrowserArtifact | undefined
   let finalUrl = targetUrl
   let windowLocationOrigin: string | undefined
   let viewport: BrowserProbeViewport | null = null
@@ -1158,6 +1159,7 @@ export async function runEditorCanvasProbeCommand({
 
     const summary = probe.summary
     artifact = {
+      artifactType: "probe",
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
@@ -1216,6 +1218,7 @@ export async function runEditorCanvasProbeCommand({
         selectorSummary: emptyEditorCanvasSelectorSummary(selectorGroups),
       }
       artifact = {
+        artifactType: "probe",
         requestedUrl: targetUrl,
         url: targetUrl,
         preview,
@@ -1518,7 +1521,7 @@ export async function runBrowserActionsCommand({
   runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
   server: PlaygroundCliServer
   spec: ExecutionSpec
-}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
   const steps = await browserInteractionStepsFromArgs(args)
   const initialUrl = argValue(args, "url")?.trim()
@@ -1594,7 +1597,7 @@ export async function runBrowserActionsCommand({
   let viewport: BrowserProbeViewport | null = null
   let authSummary: BrowserProbeAuthSummary | undefined
   let pendingError: Error | undefined
-  let artifact: BrowserProbeArtifact | undefined
+  let artifact: BrowserArtifact | undefined
 
   try {
     const page = await browser.newPage()
@@ -1726,6 +1729,7 @@ export async function runBrowserActionsCommand({
 
     const assertions = browserAssertionsSummary(stepRecords)
     artifact = {
+      artifactType: "actions",
       requestedUrl,
       url: requestedUrl,
       preview,
@@ -1886,7 +1890,7 @@ export async function runBrowserScenarioCommand({
   runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
   server: PlaygroundCliServer
   spec: ExecutionSpec
-}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
   const scenario = await browserScenarioFromArgs(args)
   const url = scenario.url?.trim() || argValue(args, "url")?.trim()
@@ -1931,7 +1935,7 @@ export async function runBrowserScenarioCommand({
     try {
       probeResult = await runBrowserProbeCommand({ artifactRoot, runtimeSpec, runPlaygroundCommand, server, spec: { ...spec, command: "wordpress.browser-probe", args: probeArgs } })
     } catch (error) {
-      if (isBrowserCommandArtifactError(error)) {
+      if (isBrowserCommandArtifactError(error) && error.artifact.artifactType === "probe") {
         probeResult = { artifact: error.artifact, output: "" }
       }
       pendingError = error instanceof Error ? error : new Error(String(error))
@@ -1955,7 +1959,7 @@ export async function runBrowserScenarioCommand({
     try {
       actionsResult = await runBrowserActionsCommand({ artifactRoot, runtimeSpec, runPlaygroundCommand, server, spec: { ...spec, command: "wordpress.browser-actions", args: actionsArgs } })
     } catch (error) {
-      if (isBrowserCommandArtifactError(error)) {
+      if (isBrowserCommandArtifactError(error) && error.artifact.artifactType === "actions") {
         actionsResult = { artifact: error.artifact, output: "" }
       }
       pendingError = error instanceof Error ? error : new Error(String(error))
@@ -1998,8 +2002,9 @@ export async function runBrowserScenarioCommand({
   }
   await writeFile(scenarioSummaryPath, `${JSON.stringify(scenarioSummary, null, 2)}\n`)
 
-  const artifact: BrowserProbeArtifact = {
+  const artifact: BrowserArtifact = {
     ...primaryArtifact,
+    artifactType: "scenario",
     files: {
       ...primaryArtifact.files,
       summary: "files/browser/scenario-summary.json",
@@ -2138,7 +2143,7 @@ export async function runEditorOpenCommand({
   runtimeSpec: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
-}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
   const target = editorOpenTargetFromArgs(args)
   const capture = new Set(commaListArg(args, "capture"))
@@ -2181,7 +2186,7 @@ export async function runEditorOpenCommand({
   let viewport: BrowserProbeViewport | null = null
   let editorState: EditorStateSnapshot | undefined
   let pendingError: Error | undefined
-  let artifact: BrowserProbeArtifact | undefined
+  let artifact: BrowserArtifact | undefined
 
   try {
     const page = await browser.newPage()
@@ -2249,6 +2254,7 @@ export async function runEditorOpenCommand({
 
     const editorSummary = editorState ? summarizeEditorState(target, editorState) : undefined
     artifact = {
+      artifactType: "editor-open",
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
@@ -2326,7 +2332,7 @@ export async function runEditorActionsCommand({
   runtimeSpec: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
-}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
   const target = editorOpenTargetFromArgs(args)
   const actionSteps = await editorActionStepsFromArgs(args)
@@ -2373,7 +2379,7 @@ export async function runEditorActionsCommand({
   let viewport: BrowserProbeViewport | null = null
   let editorState: EditorStateSnapshot | undefined
   let pendingError: Error | undefined
-  let artifact: BrowserProbeArtifact | undefined
+  let artifact: BrowserArtifact | undefined
 
   try {
     const page = await browser.newPage()
@@ -2464,6 +2470,7 @@ export async function runEditorActionsCommand({
 
     const editorSummary = editorState ? summarizeEditorState(target, editorState) : undefined
     artifact = {
+      artifactType: "editor-actions",
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
@@ -2544,7 +2551,7 @@ export async function runVisualCompareCommand({
   runtimeSpec?: RuntimeCreateSpec
   server: PlaygroundCliServer
   spec: ExecutionSpec
-}): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
   const sourceUrl = argValue(args, "source-url")?.trim()
   const candidateUrl = argValue(args, "candidate-url")?.trim()
@@ -2682,7 +2689,8 @@ export async function runVisualCompareCommand({
   }
   await writeFile(summaryPath, summaryJson)
 
-  const artifact: BrowserProbeArtifact = {
+  const artifact: BrowserArtifact = {
+    artifactType: "visual-compare",
     requestedUrl: sourceTargetUrl ?? sourceScreenshot ?? sourceLabel,
     url: candidateTargetUrl ?? candidateScreenshot ?? candidateLabel,
     preview,
@@ -3260,7 +3268,7 @@ async function captureEditorState(page: import("playwright").Page, target: Retur
   }
 }
 
-function summarizeEditorState(target: ReturnType<typeof editorOpenTargetFromArgs>, state: EditorStateSnapshot): NonNullable<BrowserProbeArtifact["summary"]["editor"]> {
+function summarizeEditorState(target: ReturnType<typeof editorOpenTargetFromArgs>, state: EditorStateSnapshot): NonNullable<BrowserArtifactSummary["editor"]> {
   return {
     kind: target.kind,
     ...(typeof state.post?.id === "number" ? { postId: state.post.id } : {}),

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -3,7 +3,7 @@ import { join } from "node:path"
 import type { ArtifactManifest } from "@automattic/wp-codebox-core"
 import type { ConsoleMessage, Request, Response } from "playwright"
 import type {
-  BrowserProbeArtifact,
+  BrowserArtifact,
   BrowserProbeCheckpointRecord,
   BrowserProbeErrorRecord,
   BrowserProbeMemoryArtifact,
@@ -175,7 +175,7 @@ export function browserProbeBenchMetrics(memoryArtifact?: BrowserProbeMemoryArti
   }
 }
 
-export function promoteBrowserMetricsToBenchResults(raw: string, probes: BrowserProbeArtifact[]): string {
+export function promoteBrowserMetricsToBenchResults(raw: string, probes: BrowserArtifact[]): string {
   const metrics = combinedBrowserBenchMetrics(probes)
   if (!metrics) {
     return raw
@@ -317,7 +317,7 @@ function isMissingFileError(error: unknown): boolean {
   return isRecord(error) && error.code === "ENOENT"
 }
 
-function combinedBrowserBenchMetrics(probes: BrowserProbeArtifact[]): Record<string, number> | undefined {
+function combinedBrowserBenchMetrics(probes: BrowserArtifact[]): Record<string, number> | undefined {
   const metricSets = probes.map((probe) => probe.summary.metrics).filter((metrics): metrics is Record<string, number> => isRecord(metrics))
   if (metricSets.length === 0) {
     return undefined

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { mkdir, realpath, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, createHostToolRegistry, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
-import { browserReviewSummary as browserArtifactReviewSummary, type BrowserProbeArtifact } from "./browser-artifacts.js"
+import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
 import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
@@ -72,7 +72,7 @@ class PlaygroundRuntime implements Runtime {
   private readonly observations: ObservationResult[] = []
   private readonly snapshots: Snapshot[] = []
   private readonly events: LifecycleEvent[] = []
-  private readonly browserProbes: BrowserProbeArtifact[] = []
+  private readonly browserProbes: BrowserArtifact[] = []
   private readonly pluginChecks: PluginCheckArtifact[] = []
   private readonly themeChecks: ThemeCheckArtifact[] = []
   private readonly artifactRoot: string

--- a/packages/runtime-playground/src/runtime-artifact-helpers.ts
+++ b/packages/runtime-playground/src/runtime-artifact-helpers.ts
@@ -17,7 +17,7 @@ import type {
 } from "@automattic/wp-codebox-core"
 import { ArtifactBundleBuilder } from "./artifact-bundle-builder.js"
 import type { ArtifactRedactor } from "./artifacts.js"
-import { browserManifestFiles as browserArtifactManifestFiles, browserRedactionPaths, browserReviewSummary as browserArtifactReviewSummary, type BrowserProbeArtifact } from "./browser-artifacts.js"
+import { browserManifestFiles as browserArtifactManifestFiles, browserRedactionPaths, browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
 import { pluginCheckManifestFiles, redactPluginCheckArtifacts, redactThemeCheckArtifacts, themeCheckManifestFiles, type PluginCheckArtifact, type ThemeCheckArtifact } from "./check-artifacts.js"
 import { captureMountDiffs, captureMountedFiles } from "./mounted-artifact-capture.js"
 
@@ -39,7 +39,7 @@ export async function collectPlaygroundArtifacts({
   themeChecks,
 }: {
   artifactRoot: string
-  browserProbes: BrowserProbeArtifact[]
+  browserProbes: BrowserArtifact[]
   commands: ExecutionResult[]
   createdAt: string
   events: LifecycleEvent[]
@@ -109,7 +109,7 @@ function observationManifestFiles(artifactRoot: string, observations: Observatio
   )
 }
 
-async function redactBrowserArtifacts(artifactRoot: string, browserProbes: BrowserProbeArtifact[], redactor: ArtifactRedactor): Promise<void> {
+async function redactBrowserArtifacts(artifactRoot: string, browserProbes: BrowserArtifact[], redactor: ArtifactRedactor): Promise<void> {
   for (const probe of browserProbes) {
     for (const path of browserRedactionPaths(probe)) {
       const absolutePath = join(artifactRoot, path)

--- a/packages/runtime-playground/src/runtime-reference-index.ts
+++ b/packages/runtime-playground/src/runtime-reference-index.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { dirname, extname, join, posix } from "node:path"
 import type { ArtifactManifestFile } from "@automattic/wp-codebox-core"
-import type { BrowserProbeArtifact } from "./browser-artifacts.js"
+import type { BrowserArtifact } from "./browser-artifacts.js"
 import type { CapturedMountFiles } from "./artifacts.js"
 
 export interface RuntimeReferenceIndex {
@@ -52,7 +52,7 @@ interface RuntimeReferenceIndexInput {
   createdAt: string
   manifestFiles: ArtifactManifestFile[]
   capturedMounts: CapturedMountFiles
-  browserProbes: BrowserProbeArtifact[]
+  browserProbes: BrowserArtifact[]
 }
 
 interface ScannableArtifactFile {
@@ -75,7 +75,7 @@ export async function buildRuntimeReferenceIndex({ artifactRoot, createdAt, mani
   const artifactPaths = new Set(manifestFiles.map((file) => normalizeArtifactPath(file.path)))
   const capturedByArtifactPath = new Map(capturedMounts.files.map((file) => [normalizeArtifactPath(file.artifactPath), file]))
   const capturedByRuntimePath = new Map(capturedMounts.files.map((file) => [normalizeRuntimePath(file.target), file]))
-  const browserHtmlByPath = new Map<string, BrowserProbeArtifact>()
+  const browserHtmlByPath = new Map<string, BrowserArtifact>()
   for (const probe of browserProbes) {
     if (probe.files.html) {
       browserHtmlByPath.set(normalizeArtifactPath(probe.files.html), probe)
@@ -126,7 +126,7 @@ export async function buildRuntimeReferenceIndex({ artifactRoot, createdAt, mani
   }
 }
 
-function scannableArtifactFile(file: ArtifactManifestFile, capturedByArtifactPath: Map<string, CapturedMountFiles["files"][number]>, browserHtmlByPath: Map<string, BrowserProbeArtifact>): ScannableArtifactFile | undefined {
+function scannableArtifactFile(file: ArtifactManifestFile, capturedByArtifactPath: Map<string, CapturedMountFiles["files"][number]>, browserHtmlByPath: Map<string, BrowserArtifact>): ScannableArtifactFile | undefined {
   const path = normalizeArtifactPath(file.path)
   const extension = extname(path).toLowerCase()
   if (!LOCAL_REFERENCE_EXTENSIONS.has(extension)) {

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -1,4 +1,4 @@
-import type { BrowserProbeArtifact } from "./browser-artifacts.js"
+import type { BrowserArtifact } from "./browser-artifacts.js"
 import { promoteBrowserMetricsToBenchResults } from "./browser-metrics.js"
 import { writePluginCheckArtifacts, writeThemeCheckArtifacts, type PluginCheckArtifact, type ThemeCheckArtifact } from "./check-artifacts.js"
 import {
@@ -335,7 +335,7 @@ export async function runBenchCommand({
   server,
   spec,
 }: {
-  browserProbes: BrowserProbeArtifact[]
+  browserProbes: BrowserArtifact[]
   createRuntimeWpCliBridge: CreateRuntimeWpCliBridge
   runPlaygroundCommand: RunPlaygroundCommand
   runtimeSpec: RuntimeCreateSpec


### PR DESCRIPTION
## Summary
- Splits the browser artifact contract into explicit variants for probe, actions, editor open/actions, scenario, and visual compare artifacts.
- Replaces duplicated browser manifest/redaction file handling with a single declared file manifest map.
- Updates browser artifact consumers to operate on the `BrowserArtifact` union instead of probe-only typing.

Fixes #775.

## Testing
- `npm run build`
- `npm run browser-probe-artifact-smoke`
- `npm run browser-actions-artifact-smoke`
- `npm run browser-scenario-artifact-smoke`
- `npm run editor-open-artifact-smoke`
- `npm run editor-actions-artifact-smoke`
- `npm run browser-review-bridge-smoke`
- `npm run recipe-browser-bench-metrics-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the TypeScript refactor and ran targeted verification; Chris remains responsible for review and acceptance.