### PR TITLE
Improve visual compare dimension drift regions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "artifact-export-links-smoke": "tsx scripts/artifact-export-links-smoke.ts",
+    "browser-visual-compare-dimension-drift-smoke": "tsx scripts/browser-visual-compare-dimension-drift-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "smoke": "tsx scripts/run-smoke.ts",
     "check": "npm run smoke -- --group=check"

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -83,12 +83,31 @@ interface VisualCompareElementDelta {
   }
 }
 
+interface VisualCompareMismatchRegion {
+  x: number
+  y: number
+  width: number
+  height: number
+  pixels: number
+}
+
+interface VisualCompareDimensionDriftRegion extends VisualCompareMismatchRegion {
+  owner: "source" | "candidate"
+}
+
+interface VisualCompareDimensionDrift {
+  widthDelta: number
+  heightDelta: number
+  sourceOnly: VisualCompareDimensionDriftRegion[]
+  candidateOnly: VisualCompareDimensionDriftRegion[]
+}
+
 interface VisualCompareExplanation {
   schema: "wp-codebox/visual-explanation/v1"
   source: { label: string; url: string; title: string; elementCount: number; capturedElements: number; truncated: boolean }
   candidate: { label: string; url: string; title: string; elementCount: number; capturedElements: number; truncated: boolean }
   viewport: BrowserProbeViewport | null
-  mismatchRegions: Array<{ x: number; y: number; width: number; height: number; pixels: number }>
+  mismatchRegions: VisualCompareMismatchRegion[]
   selectors?: Array<{ selector: string; source: VisualCompareSelectorSnapshot; candidate: VisualCompareSelectorSnapshot }>
   missingSelectors?: Array<{ selector: string; sourceMatched: boolean; candidateMatched: boolean; sourceError?: string; candidateError?: string }>
   limits: { maxElements: number; maxCandidates: number }
@@ -3285,30 +3304,34 @@ async function comparePngFiles(sourcePath: string, candidatePath: string, diffPa
   candidate: { width: number; height: number }
   diff: { width: number; height: number }
   dimensionMismatch: boolean
+  dimensionDrift?: VisualCompareDimensionDrift
   mismatchPixels: number
   totalPixels: number
   mismatchRatio: number
-  regions: Array<{ x: number; y: number; width: number; height: number; pixels: number }>
+  regions: VisualCompareMismatchRegion[]
 }> {
   const source = PNG.sync.read(await readFile(sourcePath))
   const candidate = PNG.sync.read(await readFile(candidatePath))
   const width = Math.max(source.width, candidate.width)
   const height = Math.max(source.height, candidate.height)
+  const overlap = { width: Math.min(source.width, candidate.width), height: Math.min(source.height, candidate.height) }
   const sourceCanvas = visualCompareCanvas(source, width, height)
   const candidateCanvas = visualCompareCanvas(candidate, width, height)
   const diff = new PNG({ width, height })
   const mismatchPixels = pixelmatch(sourceCanvas.data, candidateCanvas.data, diff.data, width, height, { threshold: options.threshold, includeAA: options.includeAA })
   await writeFile(diffPath, PNG.sync.write(diff))
+  const dimensionMismatch = source.width !== candidate.width || source.height !== candidate.height
 
   return {
     source: { width: source.width, height: source.height },
     candidate: { width: candidate.width, height: candidate.height },
     diff: { width, height },
-    dimensionMismatch: source.width !== candidate.width || source.height !== candidate.height,
+    dimensionMismatch,
+    ...(dimensionMismatch ? { dimensionDrift: visualCompareDimensionDrift(source, candidate) } : {}),
     mismatchPixels,
     totalPixels: width * height,
     mismatchRatio: width * height > 0 ? mismatchPixels / (width * height) : 0,
-    regions: visualCompareMismatchRegions(diff, options.maxRegions),
+    regions: visualCompareMismatchRegions(diff, options.maxRegions, overlap),
   }
 }
 
@@ -3325,22 +3348,49 @@ function visualCompareCanvas(image: PNG, width: number, height: number): PNG {
   return canvas
 }
 
-function visualCompareMismatchRegions(diff: PNG, maxRegions: number): Array<{ x: number; y: number; width: number; height: number; pixels: number }> {
+function visualCompareDimensionDrift(source: PNG, candidate: PNG): VisualCompareDimensionDrift {
+  const sourceOnly: VisualCompareDimensionDriftRegion[] = []
+  const candidateOnly: VisualCompareDimensionDriftRegion[] = []
+  const minWidth = Math.min(source.width, candidate.width)
+  const minHeight = Math.min(source.height, candidate.height)
+  collectDimensionDriftRegions(source, candidate, "source", sourceOnly, minWidth, minHeight)
+  collectDimensionDriftRegions(candidate, source, "candidate", candidateOnly, minWidth, minHeight)
+  return {
+    widthDelta: candidate.width - source.width,
+    heightDelta: candidate.height - source.height,
+    sourceOnly,
+    candidateOnly,
+  }
+}
+
+function collectDimensionDriftRegions(image: PNG, other: PNG, owner: "source" | "candidate", regions: VisualCompareDimensionDriftRegion[], minWidth: number, minHeight: number): void {
+  if (image.width > other.width) {
+    regions.push({ owner, x: minWidth, y: 0, width: image.width - minWidth, height: image.height, pixels: (image.width - minWidth) * image.height })
+  }
+  if (image.height > other.height) {
+    regions.push({ owner, x: 0, y: minHeight, width: minWidth, height: image.height - minHeight, pixels: minWidth * (image.height - minHeight) })
+  }
+}
+
+function visualCompareMismatchRegions(diff: PNG, maxRegions: number, bounds: { width: number; height: number } = { width: diff.width, height: diff.height }): VisualCompareMismatchRegion[] {
   const visited = new Uint8Array(diff.width * diff.height)
-  const regions: Array<{ x: number; y: number; width: number; height: number; pixels: number }> = []
-  for (let y = 0; y < diff.height; y += 1) {
-    for (let x = 0; x < diff.width; x += 1) {
+  const regions: VisualCompareMismatchRegion[] = []
+  const width = Math.min(diff.width, Math.max(0, bounds.width))
+  const height = Math.min(diff.height, Math.max(0, bounds.height))
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
       const index = y * diff.width + x
       if (visited[index] || !visualCompareDiffPixel(diff, x, y)) {
         continue
       }
-      regions.push(visualCompareFloodRegion(diff, x, y, visited))
+      const region = visualCompareFloodRegion(diff, x, y, visited, { width, height })
+      regions.push(...visualCompareSegmentLargeRegion(diff, region, maxRegions))
     }
   }
   return regions.sort((a, b) => b.pixels - a.pixels).slice(0, maxRegions)
 }
 
-function visualCompareFloodRegion(diff: PNG, startX: number, startY: number, visited: Uint8Array): { x: number; y: number; width: number; height: number; pixels: number } {
+function visualCompareFloodRegion(diff: PNG, startX: number, startY: number, visited: Uint8Array, bounds: { width: number; height: number }): VisualCompareMismatchRegion {
   const stack: Array<[number, number]> = [[startX, startY]]
   let minX = startX
   let maxX = startX
@@ -3349,7 +3399,7 @@ function visualCompareFloodRegion(diff: PNG, startX: number, startY: number, vis
   let pixels = 0
   while (stack.length > 0) {
     const [x, y] = stack.pop() ?? [0, 0]
-    if (x < 0 || y < 0 || x >= diff.width || y >= diff.height) {
+    if (x < 0 || y < 0 || x >= bounds.width || y >= bounds.height) {
       continue
     }
     const index = y * diff.width + x
@@ -3365,6 +3415,44 @@ function visualCompareFloodRegion(diff: PNG, startX: number, startY: number, vis
     stack.push([x + 1, y], [x - 1, y], [x, y + 1], [x, y - 1])
   }
   return { x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1, pixels }
+}
+
+function visualCompareSegmentLargeRegion(diff: PNG, region: VisualCompareMismatchRegion, maxRegions: number): VisualCompareMismatchRegion[] {
+  const coversMostCanvas = region.width >= diff.width * 0.8 && region.height >= diff.height * 0.8
+  if (!coversMostCanvas || maxRegions < 2 || region.height < 2) {
+    return [region]
+  }
+
+  const segmentHeight = Math.max(1, Math.ceil(region.height / maxRegions))
+  const segments: VisualCompareMismatchRegion[] = []
+  for (let y = region.y; y < region.y + region.height; y += segmentHeight) {
+    const segment = visualCompareRegionBounds(diff, region.x, y, region.width, Math.min(segmentHeight, region.y + region.height - y))
+    if (segment) {
+      segments.push(segment)
+    }
+  }
+  return segments.length > 0 ? segments : [region]
+}
+
+function visualCompareRegionBounds(diff: PNG, x: number, y: number, width: number, height: number): VisualCompareMismatchRegion | undefined {
+  let minX = x + width
+  let maxX = x
+  let minY = y + height
+  let maxY = y
+  let pixels = 0
+  for (let row = y; row < y + height; row += 1) {
+    for (let column = x; column < x + width; column += 1) {
+      if (!visualCompareDiffPixel(diff, column, row)) {
+        continue
+      }
+      pixels += 1
+      minX = Math.min(minX, column)
+      maxX = Math.max(maxX, column)
+      minY = Math.min(minY, row)
+      maxY = Math.max(maxY, row)
+    }
+  }
+  return pixels > 0 ? { x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1, pixels } : undefined
 }
 
 function visualCompareDiffPixel(diff: PNG, x: number, y: number): boolean {

--- a/scripts/browser-visual-compare-dimension-drift-smoke.ts
+++ b/scripts/browser-visual-compare-dimension-drift-smoke.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+import { PNG } from "pngjs"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "browser-visual-compare-dimension-drift-smoke")
+const inputDirectory = join(workspace, "inputs")
+const recipePath = join(workspace, "recipe.json")
+const artifactsRoot = join(workspace, "artifacts")
+const sourceScreenshot = join(inputDirectory, "source.png")
+const candidateScreenshot = join(inputDirectory, "candidate.png")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(inputDirectory, { recursive: true })
+
+await writePng(sourceScreenshot, createFixturePng(120, 120, 20))
+await writePng(candidateScreenshot, createFixturePng(120, 150, 36))
+
+await writeFile(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.visual-compare",
+        args: [
+          `source-screenshot=${sourceScreenshot}`,
+          `candidate-screenshot=${candidateScreenshot}`,
+          "source-label=source-fixture",
+          "candidate-label=candidate-fixture",
+          "threshold=0.1",
+          "max-regions=4",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const output = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--json",
+])
+
+assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
+assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+
+const summaryPath = join(output.artifacts.directory, "files", "browser", "visual-compare", "visual-diff.json")
+const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
+  status: string
+  comparison: {
+    source: { width: number; height: number }
+    candidate: { width: number; height: number }
+    dimensionMismatch: boolean
+    dimensionDrift?: {
+      widthDelta: number
+      heightDelta: number
+      sourceOnly: unknown[]
+      candidateOnly: Array<{ x: number; y: number; width: number; height: number; pixels: number; owner: string }>
+    }
+    regions: Array<{ x: number; y: number; width: number; height: number; pixels: number }>
+  }
+}
+
+assert.equal(summary.status, "different")
+assert.deepEqual(summary.comparison.source, { width: 120, height: 120 })
+assert.deepEqual(summary.comparison.candidate, { width: 120, height: 150 })
+assert.equal(summary.comparison.dimensionMismatch, true, "comparison should flag dimension mismatch")
+assert.equal(summary.comparison.dimensionDrift?.widthDelta, 0, "dimension drift should report width delta")
+assert.equal(summary.comparison.dimensionDrift?.heightDelta, 30, "dimension drift should report height delta")
+assert.deepEqual(summary.comparison.dimensionDrift?.sourceOnly, [], "source should not own extra canvas area")
+assert.deepEqual(summary.comparison.dimensionDrift?.candidateOnly, [
+  { owner: "candidate", x: 0, y: 120, width: 120, height: 30, pixels: 3600 },
+])
+assert.ok(summary.comparison.regions.length > 0, "comparison should still report local mismatch regions")
+assert.ok(summary.comparison.regions.length <= 4, "comparison should honor max-regions")
+assert.ok(summary.comparison.regions.every((region) => region.y + region.height <= 120), "local regions should stay inside the shared overlap")
+assert.ok(summary.comparison.regions.some((region) => region.y < 80 && region.y + region.height > 36), "local regions should include the shifted element")
+
+console.log("Browser visual compare dimension drift smoke passed")
+
+function createFixturePng(width: number, height: number, boxY: number): PNG {
+  const image = new PNG({ width, height })
+  fillRect(image, 0, 0, width, height, [255, 255, 255, 255])
+  fillRect(image, 24, boxY, 72, 40, [37, 99, 235, 255])
+  return image
+}
+
+function fillRect(image: PNG, x: number, y: number, width: number, height: number, rgba: [number, number, number, number]): void {
+  for (let row = y; row < y + height; row += 1) {
+    for (let column = x; column < x + width; column += 1) {
+      const offset = ((row * image.width) + column) << 2
+      image.data[offset] = rgba[0]
+      image.data[offset + 1] = rgba[1]
+      image.data[offset + 2] = rgba[2]
+      image.data[offset + 3] = rgba[3]
+    }
+  }
+}
+
+async function writePng(path: string, image: PNG): Promise<void> {
+  await writeFile(path, PNG.sync.write(image))
+}
+
+async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
+  const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => { stdout += chunk })
+  child.stderr.on("data", (chunk) => { stderr += chunk })
+  const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
+  if (code !== 0) {
+    throw new Error(`CLI exited with ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  }
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- keep full-canvas visual diff metrics as the source of truth while deriving local mismatch regions from the shared screenshot overlap
- add dimension drift metadata for source-only and candidate-only canvas areas
- add a focused synthetic PNG smoke for dimension drift reporting

## Tests
- npm install
- npm run build
- npm run browser-visual-compare-dimension-drift-smoke
- npx tsx scripts/browser-visual-compare-smoke.ts
- npx tsx scripts/browser-action-visual-compare-smoke.ts

Fixes #809

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused smoke coverage; Chris remains responsible for review and testing.