### PR TITLE
Add visual compare matrix support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "release:package": "tsx scripts/package-release-artifact.ts",
     "artifact-export-links-smoke": "tsx scripts/artifact-export-links-smoke.ts",
     "browser-visual-compare-dimension-drift-smoke": "tsx scripts/browser-visual-compare-dimension-drift-smoke.ts",
+    "browser-visual-compare-matrix-smoke": "tsx scripts/browser-visual-compare-matrix-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "smoke": "tsx scripts/run-smoke.ts",
     "check": "npm run smoke -- --group=check"

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -270,6 +270,7 @@ export const commandRegistry = [
     acceptedArgs: [
       { name: "source-url", description: "Source browser target path or absolute URL.", format: "path or URL" },
       { name: "candidate-url", description: "Candidate browser target path or absolute URL.", format: "path or URL" },
+      { name: "matrix-json", description: "Optional comparison matrix object with comparisons and optional viewports arrays; each comparison may provide source/candidate targets, labels, viewport, and wait settings.", format: "JSON object" },
       { name: "source-screenshot", description: "Existing source PNG screenshot path on the host.", format: "path" },
       { name: "candidate-screenshot", description: "Existing candidate PNG screenshot path on the host.", format: "path" },
       { name: "source-dom-snapshot", description: "Optional source DOM/style sidecar snapshot path for screenshot-backed visual explanations.", format: "path" },
@@ -287,7 +288,7 @@ export const commandRegistry = [
       { name: "include-aa", description: "Include anti-aliased pixels in mismatch count; defaults to false.", format: "boolean" },
       { name: "max-regions", description: "Maximum mismatch regions to report; defaults to 8.", format: "positive integer" },
     ],
-    outputShape: "wp-codebox/visual-compare/v1 JSON summary plus files/browser/visual-compare/source.png, candidate.png, diff.png, visual-diff.json, visual-explanation.json when DOM/style context is available, and optional baseline delta evidence when a previous visual comparison artifact is supplied.",
+    outputShape: "wp-codebox/visual-compare/v1 JSON summary plus files/browser/visual-compare/source.png, candidate.png, diff.png, visual-diff.json, visual-explanation.json when DOM/style context is available, and optional baseline delta evidence when a previous visual comparison artifact is supplied. Matrix runs emit wp-codebox/visual-compare-matrix/v1 in files/browser/visual-compare/matrix-summary.json plus per-comparison subdirectories.",
     policyRequirement: "Runtime policy commands must include wordpress.visual-compare.",
     recipe: true,
     handler: { kind: "playground", method: "runVisualCompare" },

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -49,7 +49,7 @@ export interface BrowserScenarioArtifact extends BrowserArtifactBase {
 
 export interface BrowserVisualCompareArtifact extends BrowserArtifactBase {
   artifactType: "visual-compare"
-  files: BrowserArtifactFiles & { summary: string; sourceScreenshot: string; candidateScreenshot: string; diffScreenshot: string; visualDiff: string }
+  files: BrowserArtifactFiles & { summary: string; sourceScreenshot: string | string[]; candidateScreenshot: string | string[]; diffScreenshot: string | string[]; visualDiff: string | string[] }
   summary: BrowserArtifactSummary & { visualCompare: NonNullable<BrowserArtifactSummary["visualCompare"]> }
 }
 
@@ -68,11 +68,11 @@ export interface BrowserArtifactFiles {
   review?: string
   screenshot?: string
   domSnapshots?: string[]
-  sourceScreenshot?: string
-  candidateScreenshot?: string
-  diffScreenshot?: string
-  visualDiff?: string
-  visualExplanation?: string
+  sourceScreenshot?: string | string[]
+  candidateScreenshot?: string | string[]
+  diffScreenshot?: string | string[]
+  visualDiff?: string | string[]
+  visualExplanation?: string | string[]
   summary: string
 }
 

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -2611,6 +2611,27 @@ export async function runVisualCompareCommand({
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
+  const matrixJson = argValue(args, "matrix-json")?.trim()
+  if (matrixJson) {
+    return runVisualCompareMatrixCommand({ artifactRoot, runtimeSpec, server, args, matrixJson })
+  }
+
+  return runVisualComparePairCommand({ artifactRoot, runtimeSpec, server, args })
+}
+
+async function runVisualComparePairCommand({
+  artifactRoot,
+  runtimeSpec,
+  server,
+  args,
+  artifactPathPrefix = "files/browser/visual-compare",
+}: {
+  artifactRoot: string
+  runtimeSpec?: RuntimeCreateSpec
+  server: PlaygroundCliServer
+  args: string[]
+  artifactPathPrefix?: string
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
   const sourceUrl = argValue(args, "source-url")?.trim()
   const candidateUrl = argValue(args, "candidate-url")?.trim()
   const sourceScreenshot = argValue(args, "source-screenshot")?.trim()
@@ -2644,7 +2665,7 @@ export async function runVisualCompareCommand({
     throw new Error("wordpress.visual-compare requires source-url/candidate-url or source-screenshot/candidate-screenshot")
   }
 
-  const browserDirectory = join(artifactRoot, "files", "browser", "visual-compare")
+  const browserDirectory = join(artifactRoot, artifactPathPrefix)
   await mkdir(browserDirectory, { recursive: true })
   const sourcePath = join(browserDirectory, "source.png")
   const candidatePath = join(browserDirectory, "candidate.png")
@@ -2724,12 +2745,12 @@ export async function runVisualCompareCommand({
       })
     : undefined
   const files = {
-    sourceScreenshot: "files/browser/visual-compare/source.png",
-    candidateScreenshot: "files/browser/visual-compare/candidate.png",
-    diffScreenshot: "files/browser/visual-compare/diff.png",
-    visualDiff: "files/browser/visual-compare/visual-diff.json",
-    ...(explanation ? { visualExplanation: "files/browser/visual-compare/visual-explanation.json" } : {}),
-    summary: "files/browser/visual-compare/summary.json",
+    sourceScreenshot: `${artifactPathPrefix}/source.png`,
+    candidateScreenshot: `${artifactPathPrefix}/candidate.png`,
+    diffScreenshot: `${artifactPathPrefix}/diff.png`,
+    visualDiff: `${artifactPathPrefix}/visual-diff.json`,
+    ...(explanation ? { visualExplanation: `${artifactPathPrefix}/visual-explanation.json` } : {}),
+    summary: `${artifactPathPrefix}/summary.json`,
   }
   const summary = {
     schema: "wp-codebox/visual-compare/v1",
@@ -2792,6 +2813,219 @@ export async function runVisualCompareCommand({
     artifact,
     output: `${JSON.stringify(summary, null, 2)}\n`,
   }
+}
+
+async function runVisualCompareMatrixCommand({
+  artifactRoot,
+  runtimeSpec,
+  server,
+  args,
+  matrixJson,
+}: {
+  artifactRoot: string
+  runtimeSpec?: RuntimeCreateSpec
+  server: PlaygroundCliServer
+  args: string[]
+  matrixJson: string
+}): Promise<{ artifact: BrowserArtifact; output: string }> {
+  const matrix = normalizeVisualCompareMatrixSpec(JSON.parse(matrixJson))
+  const baseArgs = args.filter((arg) => !arg.startsWith("matrix-json="))
+  const startedAt = now()
+  const entries: Array<{ name: string; artifact: BrowserArtifact; summary: VisualComparePairSummary }> = []
+
+  for (const entry of matrix.entries) {
+    const result = await runVisualComparePairCommand({
+      artifactRoot,
+      runtimeSpec,
+      server,
+      args: mergeVisualCompareMatrixArgs(baseArgs, entry.args),
+      artifactPathPrefix: `files/browser/visual-compare/${entry.name}`,
+    })
+    entries.push({ name: entry.name, artifact: result.artifact, summary: JSON.parse(result.output) as VisualComparePairSummary })
+  }
+
+  const finishedAt = now()
+  const comparisons = entries.map((entry) => ({
+    name: entry.name,
+    status: entry.summary.status,
+    source: entry.summary.source,
+    candidate: entry.summary.candidate,
+    options: entry.summary.options,
+    viewport: entry.summary.viewport,
+    files: entry.summary.files,
+    comparison: entry.summary.comparison,
+  }))
+  const mismatchRatios = comparisons.map((entry) => entry.comparison.mismatchRatio)
+  const mismatchPixels = comparisons.map((entry) => entry.comparison.mismatchPixels)
+  const matrixSummary = {
+    schema: "wp-codebox/visual-compare-matrix/v1",
+    command: "wordpress.visual-compare",
+    status: comparisons.every((entry) => entry.status === "identical") ? "identical" : "different",
+    startedAt,
+    finishedAt,
+    metrics: {
+      comparisons: comparisons.length,
+      identical: comparisons.filter((entry) => entry.status === "identical").length,
+      different: comparisons.filter((entry) => entry.status !== "identical").length,
+      maxMismatchRatio: Math.max(...mismatchRatios),
+      meanMismatchRatio: mismatchRatios.reduce((total, value) => total + value, 0) / mismatchRatios.length,
+      maxMismatchPixels: Math.max(...mismatchPixels),
+      meanMismatchPixels: mismatchPixels.reduce((total, value) => total + value, 0) / mismatchPixels.length,
+    },
+    comparisons,
+    files: {
+      summary: "files/browser/visual-compare/matrix-summary.json",
+    },
+  }
+  const browserDirectory = join(artifactRoot, "files", "browser", "visual-compare")
+  await mkdir(browserDirectory, { recursive: true })
+  await writeFile(join(browserDirectory, "matrix-summary.json"), `${JSON.stringify(matrixSummary, null, 2)}\n`)
+
+  const sourceScreenshots = entries.map((entry) => entry.artifact.files.sourceScreenshot).filter((file): file is string => typeof file === "string")
+  const candidateScreenshots = entries.map((entry) => entry.artifact.files.candidateScreenshot).filter((file): file is string => typeof file === "string")
+  const diffScreenshots = entries.map((entry) => entry.artifact.files.diffScreenshot).filter((file): file is string => typeof file === "string")
+  const visualDiffs = entries.map((entry) => entry.artifact.files.visualDiff).filter((file): file is string => typeof file === "string")
+  const visualExplanations = entries.map((entry) => entry.artifact.files.visualExplanation).filter((file): file is string => typeof file === "string")
+  const firstArtifact = entries[0]?.artifact
+  const artifact: BrowserArtifact = {
+    artifactType: "visual-compare",
+    requestedUrl: matrix.entries.map((entry) => entry.name).join(","),
+    url: firstArtifact?.url ?? "visual-compare-matrix",
+    preview: firstArtifact?.preview ?? browserProbePreviewRouting([], runtimeSpec, server.serverUrl),
+    files: {
+      summary: matrixSummary.files.summary,
+      visualDiff: visualDiffs,
+      sourceScreenshot: sourceScreenshots,
+      candidateScreenshot: candidateScreenshots,
+      diffScreenshot: diffScreenshots,
+      ...(visualExplanations.length > 0 ? { visualExplanation: visualExplanations } : {}),
+    },
+    summary: {
+      steps: 0,
+      consoleMessages: entries.reduce((total, entry) => total + entry.artifact.summary.consoleMessages, 0),
+      errors: entries.reduce((total, entry) => total + entry.artifact.summary.errors, 0),
+      finalUrl: firstArtifact?.summary.finalUrl ?? "",
+      htmlSnapshot: false,
+      networkEvents: entries.reduce((total, entry) => total + entry.artifact.summary.networkEvents, 0),
+      replayability: "artifact-backed",
+      screenshot: entries.length > 0,
+      visualCompare: {
+        status: matrixSummary.status,
+        mismatchRatio: matrixSummary.metrics.maxMismatchRatio,
+        mismatchPixels: matrixSummary.metrics.maxMismatchPixels,
+        totalPixels: comparisons.reduce((total, entry) => total + entry.comparison.totalPixels, 0),
+        dimensionMismatch: comparisons.some((entry) => entry.comparison.dimensionMismatch),
+        explanation: matrixSummary.files.summary,
+      },
+      viewport: firstArtifact?.summary.viewport ?? null,
+    },
+  }
+
+  return {
+    artifact,
+    output: `${JSON.stringify(matrixSummary, null, 2)}\n`,
+  }
+}
+
+interface VisualComparePairSummary {
+  status: string
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  options: Record<string, unknown>
+  viewport: BrowserProbeViewport | null
+  files: Record<string, string>
+  comparison: { mismatchRatio: number; mismatchPixels: number; totalPixels: number; dimensionMismatch: boolean }
+}
+
+interface VisualCompareMatrixEntry {
+  name: string
+  args: string[]
+}
+
+function normalizeVisualCompareMatrixSpec(input: unknown): { entries: VisualCompareMatrixEntry[] } {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("matrix-json must be a JSON object")
+  }
+  const record = input as Record<string, unknown>
+  const comparisons = record.comparisons
+  if (!Array.isArray(comparisons) || comparisons.length === 0) {
+    throw new Error("matrix-json.comparisons must be a non-empty array")
+  }
+  const viewports = Array.isArray(record.viewports) && record.viewports.length > 0 ? record.viewports : [undefined]
+  const entries: VisualCompareMatrixEntry[] = []
+  for (const comparison of comparisons) {
+    const comparisonRecord = visualCompareMatrixRecord(comparison, "matrix-json.comparisons entries")
+    const comparisonName = visualCompareMatrixString(comparisonRecord, ["name", "id", "label"]) ?? `comparison-${entries.length + 1}`
+    for (const viewport of viewports) {
+      const viewportRecord = viewport === undefined || typeof viewport === "string" ? undefined : visualCompareMatrixRecord(viewport, "matrix-json.viewports entries")
+      const viewportValue = typeof viewport === "string" ? viewport : viewportRecord ? visualCompareMatrixString(viewportRecord, ["viewport", "size"]) : undefined
+      const viewportName = viewportRecord ? visualCompareMatrixString(viewportRecord, ["name", "id", "label"]) : viewportValue
+      const name = sanitizeVisualCompareMatrixName([comparisonName, viewportName].filter(Boolean).join("-"))
+      const args = visualCompareMatrixArgs(comparisonRecord)
+      if (viewportValue) {
+        args.push(`viewport=${viewportValue}`)
+      }
+      entries.push({ name, args })
+    }
+  }
+  return { entries }
+}
+
+function visualCompareMatrixRecord(input: unknown, label: string): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`${label} must be JSON objects`)
+  }
+  return input as Record<string, unknown>
+}
+
+function visualCompareMatrixArgs(record: Record<string, unknown>): string[] {
+  const fields: Array<[string, string[]]> = [
+    ["source-url", ["source-url", "sourceUrl"]],
+    ["candidate-url", ["candidate-url", "candidateUrl"]],
+    ["source-screenshot", ["source-screenshot", "sourceScreenshot"]],
+    ["candidate-screenshot", ["candidate-screenshot", "candidateScreenshot"]],
+    ["source-dom-snapshot", ["source-dom-snapshot", "sourceDomSnapshot"]],
+    ["candidate-dom-snapshot", ["candidate-dom-snapshot", "candidateDomSnapshot"]],
+    ["source-label", ["source-label", "sourceLabel"]],
+    ["candidate-label", ["candidate-label", "candidateLabel"]],
+    ["wait-for", ["wait-for", "waitFor"]],
+    ["duration", ["duration", "durationMs"]],
+    ["viewport", ["viewport"]],
+    ["full-page", ["full-page", "fullPage"]],
+    ["threshold", ["threshold"]],
+    ["include-aa", ["include-aa", "includeAA"]],
+    ["max-regions", ["max-regions", "maxRegions"]],
+    ["max-explanation-elements", ["max-explanation-elements", "maxExplanationElements"]],
+    ["max-explanation-candidates", ["max-explanation-candidates", "maxExplanationCandidates"]],
+  ]
+  return fields.flatMap(([argName, keys]) => {
+    const value = visualCompareMatrixValue(record, keys)
+    return value === undefined ? [] : [`${argName}=${String(value)}`]
+  })
+}
+
+function visualCompareMatrixString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  const value = visualCompareMatrixValue(record, keys)
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+function visualCompareMatrixValue(record: Record<string, unknown>, keys: string[]): unknown {
+  for (const key of keys) {
+    if (record[key] !== undefined && record[key] !== null && record[key] !== "") {
+      return record[key]
+    }
+  }
+  return undefined
+}
+
+function sanitizeVisualCompareMatrixName(name: string): string {
+  return name.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "comparison"
+}
+
+function mergeVisualCompareMatrixArgs(baseArgs: string[], entryArgs: string[]): string[] {
+  const merged = baseArgs.filter((arg) => !entryArgs.some((entryArg) => arg.slice(0, arg.indexOf("=") + 1) === entryArg.slice(0, entryArg.indexOf("=") + 1)))
+  merged.push(...entryArgs)
+  return merged
 }
 
 async function resolveVisualCompareScreenshotPath(requestedPath: string, artifactRoot: string): Promise<string> {

--- a/scripts/browser-visual-compare-matrix-smoke.ts
+++ b/scripts/browser-visual-compare-matrix-smoke.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "browser-visual-compare-matrix-smoke")
+const pluginDir = join(workspace, "visual-compare-matrix-fixture")
+const recipePath = join(workspace, "recipe.json")
+const artifactsRoot = join(workspace, "artifacts")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(pluginDir, { recursive: true })
+
+await writeFile(join(pluginDir, "visual-compare-matrix-fixture.php"), `<?php
+/**
+ * Plugin Name: Visual Compare Matrix Fixture
+ */
+add_action( 'template_redirect', function () {
+    if ( ! isset( $_GET['wp_codebox_visual_compare_matrix_fixture'] ) ) {
+        return;
+    }
+
+    $page    = isset( $_GET['page'] ) ? sanitize_key( $_GET['page'] ) : 'one';
+    $variant = isset( $_GET['variant'] ) ? sanitize_key( $_GET['variant'] ) : 'source';
+    $color   = 'candidate' === $variant ? '#2563eb' : '#dc2626';
+    nocache_headers();
+    echo '<!doctype html><html><head><style>body{margin:0}.card{width:220px;height:120px;background:' . esc_attr( $color ) . ';color:white;font:24px sans-serif;display:grid;place-items:center}</style></head><body><main class="card">' . esc_html( $page . '-' . $variant ) . '</main></body></html>';
+    exit;
+} );
+`)
+
+const matrix = {
+  comparisons: [
+    {
+      name: "first",
+      sourceUrl: "/?wp_codebox_visual_compare_matrix_fixture=1&page=one&variant=source",
+      candidateUrl: "/?wp_codebox_visual_compare_matrix_fixture=1&page=one&variant=candidate",
+      sourceLabel: "first-source",
+      candidateLabel: "first-candidate",
+    },
+    {
+      name: "second",
+      sourceUrl: "/?wp_codebox_visual_compare_matrix_fixture=1&page=two&variant=source",
+      candidateUrl: "/?wp_codebox_visual_compare_matrix_fixture=1&page=two&variant=candidate",
+      sourceLabel: "second-source",
+      candidateLabel: "second-candidate",
+    },
+  ],
+  viewports: [
+    { name: "small", viewport: "320x240" },
+    { name: "wide", viewport: "480x240" },
+  ],
+}
+
+await writeFile(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extra_plugins: [
+      {
+        source: "./visual-compare-matrix-fixture",
+        plugin_file: "visual-compare-matrix-fixture/visual-compare-matrix-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.visual-compare",
+        args: [
+          `matrix-json=${JSON.stringify(matrix)}`,
+          "full-page=false",
+          "wait-for=load",
+          "threshold=0.1",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const output = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--json",
+])
+
+assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
+assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+
+const artifactDirectory = output.artifacts.directory
+const matrixSummaryPath = join(artifactDirectory, "files", "browser", "visual-compare", "matrix-summary.json")
+const manifestPath = join(artifactDirectory, "manifest.json")
+const reviewPath = join(artifactDirectory, "files", "review.json")
+
+assert.equal(existsSync(matrixSummaryPath), true, "matrix summary should be captured")
+
+const summary = JSON.parse(await readFile(matrixSummaryPath, "utf8")) as {
+  schema: string
+  status: string
+  metrics: { comparisons: number; different: number; maxMismatchPixels: number; meanMismatchRatio: number }
+  comparisons: Array<{ name: string; status: string; files: Record<string, string>; comparison: { mismatchPixels: number } }>
+}
+assert.equal(summary.schema, "wp-codebox/visual-compare-matrix/v1")
+assert.equal(summary.status, "different")
+assert.equal(summary.metrics.comparisons, 4)
+assert.equal(summary.metrics.different, 4)
+assert.ok(summary.metrics.maxMismatchPixels > 0, "aggregate should expose max mismatch pixels")
+assert.ok(summary.metrics.meanMismatchRatio > 0, "aggregate should expose mean mismatch ratio")
+assert.deepEqual(summary.comparisons.map((comparison) => comparison.name), ["first-small", "first-wide", "second-small", "second-wide"])
+
+for (const comparison of summary.comparisons) {
+  assert.equal(comparison.status, "different")
+  assert.ok(comparison.comparison.mismatchPixels > 0, "per-comparison mismatch pixels should be preserved")
+  assert.equal(existsSync(join(artifactDirectory, comparison.files.sourceScreenshot)), true, `${comparison.name} source screenshot should exist`)
+  assert.equal(existsSync(join(artifactDirectory, comparison.files.candidateScreenshot)), true, `${comparison.name} candidate screenshot should exist`)
+  assert.equal(existsSync(join(artifactDirectory, comparison.files.diffScreenshot)), true, `${comparison.name} diff screenshot should exist`)
+  assert.equal(existsSync(join(artifactDirectory, comparison.files.visualDiff)), true, `${comparison.name} visual diff should exist`)
+}
+
+const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
+assert.ok(manifest.files.some((file) => file.path === "files/browser/visual-compare/matrix-summary.json" && file.kind === "browser-summary"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/visual-compare/first-small/source.png" && file.kind === "browser-visual-source-screenshot"))
+assert.ok(manifest.files.some((file) => file.path === "files/browser/visual-compare/second-wide/diff.png" && file.kind === "browser-visual-diff-screenshot"))
+
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ visualCompare?: { status?: string; mismatchPixels?: number; explanation?: string } }> } }
+assert.equal(review.browser?.probes?.[0]?.visualCompare?.status, "different", "review summary should expose matrix visual compare status")
+assert.ok((review.browser?.probes?.[0]?.visualCompare?.mismatchPixels ?? 0) > 0, "review summary should expose matrix max mismatch count")
+assert.equal(review.browser?.probes?.[0]?.visualCompare?.explanation, "files/browser/visual-compare/matrix-summary.json", "review summary should expose aggregate artifact")
+
+console.log("Browser visual compare matrix smoke passed")
+
+async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
+  const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => { stdout += chunk })
+  child.stderr.on("data", (chunk) => { stderr += chunk })
+  const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
+  if (code !== 0) {
+    throw new Error(`CLI exited with ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  }
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
## Summary
- Add `matrix-json` support to `wordpress.visual-compare` for running multiple named comparisons and optional viewport matrices in one recipe step.
- Preserve existing single-comparison behavior and artifact paths.
- Emit a stable aggregate `wp-codebox/visual-compare-matrix/v1` summary with per-comparison artifacts and max/mean mismatch metrics.

## Tests
- `npm run build`
- `npx tsx scripts/browser-visual-compare-smoke.ts`
- `npx tsx scripts/browser-visual-compare-matrix-smoke.ts`

Closes #808.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the visual compare matrix support, added focused smoke coverage, and ran verification; Chris remains responsible for review and merge.