### PR TITLE
fix: scope agent sandbox incomplete detection

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -713,7 +713,7 @@ function agentRuntimeIncompleteFromRecord(record: Record<string, unknown> | unde
 
   const runtime = isRecord(record?.agent_runtime) ? record.agent_runtime : undefined
   const runtimeResult = runtime?.success === true && isRecord(runtime.result) ? runtime.result : undefined
-  const candidates = [...(runtimeResult ? [runtimeResult] : []), ...collectRecords(record)]
+  const candidates = [runtimeResult, record].filter(isRecord)
 
   for (const result of candidates) {
     if (!isIncompleteAgentResult(result)) {
@@ -761,18 +761,6 @@ function incompleteAgentResultData(payload: Record<string, unknown>): Record<str
     has_pending_tools: truthyKey(payload, ["has_pending_tools", "hasPendingTools"]) || undefined,
     max_turns_reached: truthyKey(payload, ["max_turns_reached", "maxTurnsReached"]) || undefined,
   })
-}
-
-function collectRecords(value: unknown): Record<string, unknown>[] {
-  if (Array.isArray(value)) {
-    return value.flatMap(collectRecords)
-  }
-
-  if (!isRecord(value)) {
-    return []
-  }
-
-  return [value, ...Object.values(value).flatMap(collectRecords)]
 }
 
 function truthyKey(record: Record<string, unknown>, keys: string[]): boolean {

--- a/scripts/agent-sandbox-incomplete-scope-smoke.ts
+++ b/scripts/agent-sandbox-incomplete-scope-smoke.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { agentSandboxRuntimeFailure } from "../packages/cli/src/recipe-evidence.ts"
+
+const completedWithHistoricalProcessingMetadata = {
+  parsed: {
+    output: JSON.stringify({
+      command: "agent-sandbox.run",
+      agent_runtime: {
+        success: true,
+        result: {
+          status: "completed",
+          outputs: { upstream_action_url: "https://example.test/pr/1" },
+          metadata: {
+            drain_history: [{ job_status: "processing" }],
+            child_jobs: [{ status: "processing" }],
+          },
+        },
+      },
+    }),
+  },
+} as any
+
+const pendingRuntimeResult = {
+  parsed: {
+    output: JSON.stringify({
+      command: "agent-sandbox.run",
+      agent_runtime: {
+        success: true,
+        result: {
+          status: "processing",
+          completed: false,
+          has_pending_tools: true,
+        },
+      },
+    }),
+  },
+} as any
+
+assert.equal(agentSandboxRuntimeFailure(completedWithHistoricalProcessingMetadata), undefined)
+assert.equal(agentSandboxRuntimeFailure(pendingRuntimeResult)?.code, "agent_runtime_incomplete")
+
+console.log("agent sandbox incomplete-scope smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -122,6 +122,7 @@ export const smokeGroups = {
     commands: [
       tsxSmoke("agent-task-run-result-normalizer-smoke"),
       tsxSmoke("agent-runtime-workload-normalizer-smoke"),
+      tsxSmoke("agent-sandbox-incomplete-scope-smoke"),
       tsxSmoke("recipe-run-summary-smoke"),
       tsxSmoke("fanout-contract-smoke"),
       tsxSmoke("host-delegation-contract-smoke"),


### PR DESCRIPTION
## Summary
- Scope agent-sandbox incomplete detection to the current runtime result/output envelope instead of recursively scanning every nested metadata record.
- Preserve detection for genuinely pending top-level runtime results.
- Add smoke coverage for completed runtime results that contain historical nested `processing` metadata.

## Tests
- `npx tsx scripts/agent-sandbox-incomplete-scope-smoke.ts`
- `npm run smoke -- --group=agent`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed iterator failures caused by WP Codebox evidence classification, drafted the focused scope fix and regression smoke, and ran targeted verification; Chris remains responsible for review and merge.