### PR TITLE
fix: allow loopback browser runtime packages

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -1159,11 +1159,12 @@ private static function browser_remote_plugin_package_url( string $url, int $ind
 
 	$scheme = strtolower( (string) $parts['scheme'] );
 	$host   = strtolower( (string) $parts['host'] );
-	if ( 'https' !== $scheme ) {
+	$allow_http = self::is_loopback_host( $host );
+	if ( 'https' !== $scheme && ! ( $allow_http && 'http' === $scheme ) ) {
 		return new WP_Error( 'wp_codebox_browser_plugin_url_insecure', 'Browser plugin URL must use https://.', array( 'status' => 400, 'index' => $index ) );
 	}
 
-	$default_hosts = array( 'downloads.wordpress.org', 'github.com', 'codeload.github.com' );
+	$default_hosts = self::is_loopback_host( $host ) ? array( 'downloads.wordpress.org', 'github.com', 'codeload.github.com', $host ) : array( 'downloads.wordpress.org', 'github.com', 'codeload.github.com' );
 	$allowed_hosts = array_map( 'strtolower', self::string_list( apply_filters( 'wp_codebox_browser_runtime_plugin_package_allowed_hosts', $default_hosts, $url, $index ) ) );
 	if ( ! in_array( $host, $allowed_hosts, true ) ) {
 		return new WP_Error( 'wp_codebox_browser_plugin_host_not_allowed', 'Browser plugin URL host is not allowed.', array( 'status' => 400, 'index' => $index, 'host' => $host ) );

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -642,6 +642,10 @@ $GLOBALS['wp_codebox_remote_responses']['https://github.com/example/generic-mu-r
 	'response' => array( 'code' => 200 ),
 	'body'     => "PK\x03\x04generic-mu-runtime",
 );
+$GLOBALS['wp_codebox_remote_responses']['http://127.0.0.1:63498/runtime/generic-mu-runtime.zip'] = array(
+	'response' => array( 'code' => 200 ),
+	'body'     => "PK\x03\x04generic-mu-runtime-loopback",
+);
 $GLOBALS['wp_codebox_remote_responses']['https://github.com/Automattic/agents-api/releases/latest/download/agents-api.zip'] = array(
 	'response' => array( 'code' => 200 ),
 	'body'     => "PK\x03\x04agents-api",
@@ -1693,6 +1697,27 @@ $packaged_mu_steps = ! is_wp_error( $browser_packaged_mu_session ) ? ( $browser_
 $packaged_mu_code  = (string) ( $packaged_mu_steps[1]['code'] ?? '' );
 $assert( 'browser Playground session packages runtime mu-plugin dependencies through safe delivery', ! is_wp_error( $browser_packaged_mu_session ) && 1 === ( $browser_packaged_mu_session['runtime']['summary']['mu_plugins'] ?? 0 ) && str_starts_with( (string) ( $browser_packaged_mu_session['runtime']['mu_plugins'][0]['url'] ?? '' ), 'data:application/zip;base64,' ) && ! str_contains( (string) ( $browser_packaged_mu_session['runtime']['mu_plugins'][0]['local_package_fetch_url'] ?? '' ), 'github.com' ) && 'runtime-mu-plugin-remote-package' === ( $browser_packaged_mu_session['runtime']['mu_plugins'][0]['provenance']['source'] ?? '' ) );
 $assert( 'browser Playground session installs packaged runtime mu-plugin into visible Playground without source URL fetches', ! is_wp_error( $browser_packaged_mu_session ) && 'runPHP' === ( $packaged_mu_steps[1]['step'] ?? '' ) && ! in_array( 'installPlugin', array_map( static fn( array $step ): string => (string) ( $step['step'] ?? '' ), $packaged_mu_steps ), true ) && ! str_contains( $packaged_mu_code, 'github.com/example/generic-mu-runtime' ) && str_contains( $packaged_mu_code, 'data:application/zip;base64,' ) && str_contains( $packaged_mu_code, '/wordpress/wp-content/mu-plugins/generic-mu-runtime' ) && str_contains( $packaged_mu_code, '/wordpress/wp-content/mu-plugins/generic-mu-runtime-loader.php' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] = static fn(): int => 1;
+$browser_loopback_mu_session = call_user_func(
+	$browser_session_ability['execute_callback'],
+	array(
+		'goal'    => 'Prepare a browser Playground with a loopback packaged runtime mu-plugin.',
+		'runtime' => array(
+			'mu_plugins' => array(
+				array(
+					'slug'             => 'generic-mu-runtime',
+					'file'             => 'generic-mu-runtime-loader.php',
+					'url'              => 'http://127.0.0.1:63498/runtime/generic-mu-runtime.zip',
+					'targetFolderName' => 'generic-mu-runtime',
+					'entry'            => 'generic-mu-runtime.php',
+				),
+			),
+		),
+	)
+);
+unset( $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] );
+$assert( 'browser Playground session accepts loopback runtime mu-plugin package URLs through safe delivery', ! is_wp_error( $browser_loopback_mu_session ) && ! str_starts_with( (string) ( $browser_loopback_mu_session['runtime']['mu_plugins'][0]['url'] ?? '' ), 'http://127.0.0.1:63498/runtime/' ) && str_starts_with( (string) ( $browser_loopback_mu_session['runtime']['mu_plugins'][0]['local_package_fetch_url'] ?? '' ), 'https://parent.example.test/uploads/wp-codebox/browser-runtime-plugins/' ) && 'http://127.0.0.1:63498/runtime/generic-mu-runtime.zip' === ( $browser_loopback_mu_session['runtime']['mu_plugins'][0]['provenance']['url'] ?? '' ) && 'runtime-mu-plugin-remote-package' === ( $browser_loopback_mu_session['runtime']['mu_plugins'][0]['provenance']['source'] ?? '' ) );
 
 $GLOBALS['wp_codebox_filters']['wp_codebox_browser_plugin_data_url_max_bytes'] = static fn(): int => 1;
 $browser_url_package_session = call_user_func(


### PR DESCRIPTION
## Summary
- allow browser runtime package URLs to use HTTP when the source host is loopback
- keep non-loopback package URLs on HTTPS and preserve allowed-host validation
- add smoke coverage proving loopback mu-plugin packages are accepted and re-served through safe delivery

## Testing
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
- php -l tests/smoke-wordpress-plugin.php
- git diff --check
- php tests/smoke-wordpress-plugin.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Root-cause inspection, code change, smoke coverage, and local verification; Chris remains responsible for review and merge.