### PR TITLE
Share recipe dry-run planning with execution

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -10,7 +10,7 @@ import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.
 import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
-import { dryRunRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded, type RecipeDryRunOutput, type RecipeDryRunSiteSeed, type RecipeDryRunStagedFile } from "../recipe-dry-run.js"
+import { dryRunRecipe, planWorkspaceRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded, type RecipeDryRunOutput, type RecipeDryRunSiteSeed, type RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, type AgentSandboxResultSummary, type AgentTaskSingleResult, type SandboxCompletionOutcome } from "../recipe-evidence.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
@@ -829,7 +829,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     }
   }
 
-  const policy = recipePolicy(recipe)
+  const plan = await planWorkspaceRecipe(recipe, recipeDirectory, { recipePath, artifactsDirectory: configuredArtifactsDirectory }, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec })
+  const { valid: _policyValid, issues: _policyIssues, ...policy } = plan.policy
   const secretEnv = resolveSecretEnv(recipe.inputs?.secretEnv ?? [])
   const effectivePolicy = Object.keys(secretEnv).length > 0 ? { ...policy, secrets: "connector-scoped" as const } : policy
   let workspaceMounts: PreparedWorkspaceMount[] = []
@@ -874,22 +875,22 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     runRecord = await runRegistry.update(runRecord.runId, { status: "booting" })
     const runtimeEnvironment = {
       kind: "wordpress" as const,
-      name: recipe.runtime?.name ?? "wp-codebox-recipe",
-      version: recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION,
-      phpVersion: recipe.runtime?.phpVersion,
-      wordpressInstallMode: recipe.runtime?.wordpressInstallMode,
-      blueprint: recipeBlueprintWithBootActivePlugins(recipe.runtime?.blueprint, extraPlugins),
+      name: plan.runtime.name,
+      version: plan.runtime.wp,
+      phpVersion: plan.runtime.phpVersion,
+      wordpressInstallMode: plan.runtime.wordpressInstallMode,
+      blueprint: plan.runtime.blueprint,
       assets: resolveRecipeRuntimeAssets(recipe, recipeDirectory),
     }
     const effectivePreview = effectiveRecipePreview(recipe.runtime?.preview, options)
     const runtimeCreateSpec = {
-      backend: recipe.runtime?.backend ?? "wordpress-playground",
+      backend: plan.runtime.backend,
       environment: runtimeEnvironment,
       policy: effectivePolicy,
       secretEnv,
       artifactsDirectory: configuredArtifactsDirectory,
       metadata: {
-        ...runtimeMetadata(configuredArtifactsDirectory, recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION),
+        ...runtimeMetadata(configuredArtifactsDirectory, plan.runtime.wp),
         run: { runId: runRecord.runId, registryDirectory: runRegistry.directory },
         ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, stagedFiles, overlays, backendPackage, effectivePreview),
       },

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, resolve } from "node:path"
-import { SANDBOX_WORKSPACE_ROOT, stripUndefined, validateRuntimePolicy, type MountSpec, type RuntimePolicy, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
+import { SANDBOX_WORKSPACE_ROOT, stripUndefined, validateRuntimePolicy, type MountSpec, type RuntimePolicy, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { serializeError } from "./output.js"
 import { defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
 import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
@@ -13,6 +13,9 @@ export interface RecipeDryRunContext {
   defaultWordPressVersion: string
   resolveExecutionSpec(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string): Promise<{ command: string; args: string[] }>
 }
+
+export type RecipePlanOptions = RecipeDryRunOptions
+export type RecipePlanContext = RecipeDryRunContext
 
 export interface RecipeDryRunOutput {
   success: boolean
@@ -31,7 +34,7 @@ export interface RecipeDryRunOutput {
   }
 }
 
-export interface RecipeDryRunPlan {
+export interface RecipePlan {
   runtime: {
     backend: string
     backendPackage?: {
@@ -43,6 +46,8 @@ export interface RecipeDryRunPlan {
     }
     name: string
     wp: string
+    phpVersion?: string
+    wordpressInstallMode?: RuntimeWordPressInstallMode
     blueprint: unknown
   }
   distribution?: RecipeDryRunDistribution
@@ -69,6 +74,8 @@ export interface RecipeDryRunPlan {
     after?: RecipeDryRunStep[]
   }
 }
+
+export type RecipeDryRunPlan = RecipePlan
 
 interface RecipeDryRunDistribution {
   name: string
@@ -261,7 +268,7 @@ export async function dryRunRecipe(options: RecipeDryRunOptions, context: Recipe
       dryRun: true,
       valid: true,
       validation: { issues },
-      plan: await recipeDryRunPlan(recipe, recipeDirectory, options, context),
+      plan: await planWorkspaceRecipe(recipe, recipeDirectory, options, context),
     }
   } catch (error) {
     return {
@@ -284,7 +291,7 @@ export async function dryRunRecipe(options: RecipeDryRunOptions, context: Recipe
   }
 }
 
-async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string, options: RecipeDryRunOptions, context: RecipeDryRunContext): Promise<RecipeDryRunPlan> {
+export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirectory: string, options: RecipePlanOptions, context: RecipePlanContext): Promise<RecipePlan> {
   const policy = recipePolicy(recipe)
   const policyValidation = validateRuntimePolicy(policy)
   const workspaces = recipeDryRunWorkspaces(recipe, recipeDirectory)
@@ -379,6 +386,8 @@ async function recipeDryRunPlan(recipe: WorkspaceRecipe, recipeDirectory: string
       ...(recipe.runtime?.backendPackage ? { backendPackage: recipe.runtime.backendPackage } : {}),
       name: recipe.runtime?.name ?? "wp-codebox-recipe",
       wp: recipe.runtime?.wp ?? context.defaultWordPressVersion,
+      ...(recipe.runtime?.phpVersion ? { phpVersion: recipe.runtime.phpVersion } : {}),
+      ...(recipe.runtime?.wordpressInstallMode ? { wordpressInstallMode: recipe.runtime.wordpressInstallMode } : {}),
       blueprint: recipeBlueprintWithBootActivePlugins(recipe.runtime?.blueprint, extraPlugins),
     },
     ...(distribution ? { distribution } : {}),


### PR DESCRIPTION
## Summary
- export a shared recipe plan contract from the dry-run path
- route recipe execution through the shared plan for runtime, policy, and artifact metadata fields
- preserve existing execution behavior while reducing dry-run/run drift

Closes #813

## Testing
- npm run build
- npm run smoke -- --command recipe-dry-run-smoke
- npm run smoke -- --command recipe-workflow-phases-smoke
- npm run smoke -- --command recipe-runtime-evidence-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused refactor, ran verification, and prepared the PR notes for Chris to review.