### PR TITLE
Create sandbox workspace root before agent imports

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -107,6 +107,13 @@ if (${timeoutLimit} > 0 && function_exists('set_time_limit')) {
 if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
     define('DATAMACHINE_WORKSPACE_PATH', ${JSON.stringify(SANDBOX_WORKSPACE_ROOT)});
 }
+if (!is_dir(DATAMACHINE_WORKSPACE_PATH)) {
+    if (function_exists('wp_mkdir_p')) {
+        wp_mkdir_p(DATAMACHINE_WORKSPACE_PATH);
+    } else {
+        mkdir(DATAMACHINE_WORKSPACE_PATH, 0775, true);
+    }
+}
 
 add_filter('datamachine_code_remote_workspace_backend_should_handle', '__return_false', 100);
 
@@ -500,6 +507,13 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 if (!defined('DATAMACHINE_WORKSPACE_PATH')) {
     define('DATAMACHINE_WORKSPACE_PATH', ${JSON.stringify(SANDBOX_WORKSPACE_ROOT)});
+}
+if (!is_dir(DATAMACHINE_WORKSPACE_PATH)) {
+    if (function_exists('wp_mkdir_p')) {
+        wp_mkdir_p(DATAMACHINE_WORKSPACE_PATH);
+    } else {
+        mkdir(DATAMACHINE_WORKSPACE_PATH, 0775, true);
+    }
 }
 
 add_filter('datamachine_code_remote_workspace_backend_should_handle', '__return_false', 100);

--- a/scripts/agent-sandbox-workspace-root-smoke.ts
+++ b/scripts/agent-sandbox-workspace-root-smoke.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+async function main() {
+  const source = await readFile("packages/cli/src/agent-code.ts", "utf8")
+  const defineNeedle = "define('DATAMACHINE_WORKSPACE_PATH'"
+  const mkdirNeedle = "wp_mkdir_p(DATAMACHINE_WORKSPACE_PATH)"
+  const importNeedle = "wp_codebox_import_sandbox_agent_bundles"
+
+  assert.match(source, /define\('DATAMACHINE_WORKSPACE_PATH'/, "sandbox code should define the DMC workspace path")
+  assert.match(source, /wp_mkdir_p\(DATAMACHINE_WORKSPACE_PATH\)/, "sandbox code should create the DMC workspace path")
+  assert.ok(source.indexOf(defineNeedle) < source.indexOf(mkdirNeedle), "workspace root should be defined before creation")
+  assert.ok(source.indexOf(mkdirNeedle) < source.indexOf(importNeedle), "workspace root should exist before runtime bundle imports")
+
+  console.log("agent sandbox workspace root smoke ok")
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -122,6 +122,7 @@ export const smokeGroups = {
     commands: [
       tsxSmoke("agent-task-run-result-normalizer-smoke"),
       tsxSmoke("agent-runtime-workload-normalizer-smoke"),
+      tsxSmoke("agent-sandbox-workspace-root-smoke"),
       tsxSmoke("agent-sandbox-incomplete-scope-smoke"),
       tsxSmoke("recipe-run-summary-smoke"),
       tsxSmoke("fanout-contract-smoke"),


### PR DESCRIPTION
## Summary
- create `DATAMACHINE_WORKSPACE_PATH` inside generated sandbox PHP before runtime bundle imports run
- cover the ordering with an agent smoke test

## Testing
- npm install
- npm run build
- npm run smoke -- --command=agent-sandbox-workspace-root-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the sandbox workspace-root visibility failure, drafted the generated-code fix, and added/regressed smoke coverage. Chris remains responsible for review and merge.
