### PR TITLE
Release wp-codebox 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -3929,7 +3929,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -3940,11 +3940,11 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.7.3"
+      "version": "0.8.0"
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@types/pngjs": "^6.0.5",
@@ -3956,7 +3956,8 @@
       }
     },
     "packages/wordpress-plugin": {
-      "name": "wp-codebox-wordpress-plugin"
+      "name": "wp-codebox-wordpress-plugin",
+      "version": "0.8.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -36,6 +36,8 @@
     "prepare": "npm run build",
     "postinstall": "node scripts/normalize-playground-sqlite-package.mjs",
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
+    "package-distribution-smoke": "tsx scripts/package-distribution-smoke.ts",
+    "package-installed-binary-smoke": "tsx scripts/package-installed-binary-smoke.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "artifact-export-links-smoke": "tsx scripts/artifact-export-links-smoke.ts",
     "browser-visual-compare-dimension-drift-smoke": "tsx scripts/browser-visual-compare-dimension-drift-smoke.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/wp-codebox-cli",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "WP Codebox CLI — secure WordPress code execution from anywhere. Run disposable Playground sandboxes from any host: CLI, CI, mobile, Node service, or WP plugin.",
   "type": "module",
   "bin": {

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/wp-codebox-core",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runtime-playground/package.json
+++ b/packages/runtime-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/wp-codebox-playground",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -72,8 +72,6 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       source: "pre-resolved" as const,
       invalidArchives: [],
     }
-    const localAssetServer = wordpressStartupAsset?.localPath ? await serveLocalStartupAsset(wordpressStartupAsset.localPath) : undefined
-    const port = spec.preview?.port ? 0 : await availablePlaygroundPortRange()
     const blueprintSummary = summarizeBlueprint(spec.environment.blueprint)
     if (blueprintSummary.steps > 0) {
       emitProgress("preview:applying-blueprint", "running", "Applying site setup", blueprintSummary)
@@ -85,7 +83,8 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       emitProgress("preview:activating-dependencies", "running", "Activating site features", blueprintSummary)
     }
 
-    const server = await runPlaygroundCliWithoutProcessExit(async () => {
+    const server = await startPlaygroundCliWithDynamicPortRetry(async (port) => {
+      const localAssetServer = wordpressStartupAsset?.localPath ? await serveLocalStartupAsset(wordpressStartupAsset.localPath) : undefined
       try {
         return await runCLI({
           command: "server",
@@ -109,7 +108,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       } finally {
         await localAssetServer?.close()
       }
-    })
+    }, Boolean(spec.preview?.port))
 
     emitProgress("preview:connecting-client", "running", "Connecting preview", {
       localUrl: server.serverUrl,
@@ -141,6 +140,24 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
 
     throw error
   }
+}
+
+async function startPlaygroundCliWithDynamicPortRetry(callback: (port: number) => Promise<PlaygroundCliServer>, fixedPreviewPort: boolean): Promise<PlaygroundCliServer> {
+  const attempts = fixedPreviewPort ? 1 : 6
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const port = fixedPreviewPort ? 0 : await availablePlaygroundPortRange()
+    try {
+      return await runPlaygroundCliWithoutProcessExit(() => callback(port))
+    } catch (error) {
+      if (!fixedPreviewPort && attempt < attempts && errorHasCode(error, "EADDRINUSE")) {
+        continue
+      }
+
+      throw error
+    }
+  }
+
+  throw new Error("WordPress Playground CLI could not find an available dynamic port")
 }
 
 function previewDetail(spec: RuntimeCreateSpec): Record<string, unknown> {

--- a/packages/wordpress-plugin/package.json
+++ b/packages/wordpress-plugin/package.json
@@ -4,5 +4,6 @@
   "description": "WP Codebox parent-site abilities — secure coding environments inside WordPress via disposable Playground sandboxes.",
   "scripts": {
     "zip": "tsx ../../scripts/build-wordpress-plugin-zip.ts"
-  }
+  },
+  "version": "0.8.0"
 }

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Codebox
  * Plugin URI: https://github.com/Automattic/wp-codebox
  * Description: Secure coding environments inside WordPress. WordPress ability surface for launching disposable WP Codebox Playground sandboxes that can't touch your host site.
- * Version: 0.7.3
+ * Version: 0.8.0
  * Requires at least: 6.9
  * Requires PHP: 8.2
  * Author: Automattic
@@ -15,7 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'WP_CODEBOX_PLUGIN_VERSION', '0.7.3' );
+define( 'WP_CODEBOX_PLUGIN_VERSION', '0.8.0' );
 define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -48,10 +48,10 @@ async function main() {
       schema: "wp-codebox/sandbox-tool-policy/v1",
       version: 1,
       tools: [
-        { id: "datamachine/workspace-read", runtime_tool_id: "workspace_read", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true },
-        { id: "datamachine/workspace-write", runtime_tool_id: "workspace_write", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true },
-        { id: "datamachine/workspace-edit", runtime_tool_id: "workspace_edit", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true },
-        { id: "datamachine/workspace-git-status", runtime_tool_id: "workspace_git_status", execution_location: "parent", transport_visibility: "parent", allowed: false },
+        { id: "datamachine/workspace-read", runtime_tool_id: "workspace_read", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true, runtime: { environment: "runtime_local", capability_scope: "runtime_local" } },
+        { id: "datamachine/workspace-write", runtime_tool_id: "workspace_write", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true, runtime: { environment: "runtime_local", capability_scope: "runtime_local" } },
+        { id: "datamachine/workspace-edit", runtime_tool_id: "workspace_edit", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true, runtime: { environment: "runtime_local", capability_scope: "runtime_local" } },
+        { id: "datamachine/workspace-git-status", runtime_tool_id: "workspace_git_status", execution_location: "parent", transport_visibility: "parent", allowed: false, runtime: { environment: "control_plane", capability_scope: "control_plane" } },
       ],
       metadata: { source: "smoke" },
     },
@@ -130,7 +130,7 @@ async function main() {
           schema: "wp-codebox/sandbox-tool-policy/v1",
           version: 1,
           tools: [
-            { id: "datamachine/workspace-read", runtime_tool_id: "workspace_read", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true },
+            { id: "datamachine/workspace-read", runtime_tool_id: "workspace_read", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true, runtime: { environment: "runtime_local", capability_scope: "runtime_local" } },
           ],
           metadata: { source: "smoke" },
         }),

--- a/scripts/browser-html-capture-smoke.ts
+++ b/scripts/browser-html-capture-smoke.ts
@@ -28,7 +28,7 @@ await writeFile(recipePath, `${JSON.stringify({
     extra_plugins: [
       {
         source: "./html-capture-fixture",
-        pluginFile: "html-capture-fixture/html-capture-fixture.php",
+        plugin_file: "html-capture-fixture/html-capture-fixture.php",
         activate: true,
       },
     ],
@@ -56,7 +56,7 @@ const output = await runCli([
 
 assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
 assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
-assert.equal(output.executions?.[0]?.command, "wordpress.capture-html")
+assert.ok(output.executions?.some((execution: { command?: string }) => execution.command === "wordpress.capture-html"), "workflow executions should include wordpress.capture-html")
 
 const artifactDirectory = output.artifacts.directory
 const htmlPath = join(artifactDirectory, "files", "browser", "snapshot.html")

--- a/scripts/browser-startup-progress-smoke.ts
+++ b/scripts/browser-startup-progress-smoke.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { createRuntime, type BrowserStartupProgressEvent, type LifecycleEvent } from "@automattic/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
+import { startPlaygroundCliServer, type PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.ts"
 
 const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-browser-startup-progress-"))
 
@@ -120,9 +121,55 @@ try {
   assertProgressEvent(errorProgress, "preview:error", "failed")
   assert.equal(errorProgress.at(-1)?.detail?.error && typeof errorProgress.at(-1)?.detail?.error, "object")
 
+  const dynamicPorts: number[] = []
+  const dynamicServer = await startPlaygroundCliServer(runtimeSpec(), [], {
+    cliModule: retryOnceCliModule(dynamicPorts),
+  })
+  await dynamicServer[Symbol.asyncDispose]()
+  assert.equal(dynamicPorts.length, 2, "dynamic Playground startup should retry EADDRINUSE with a fresh port")
+  assert.notEqual(dynamicPorts[0], dynamicPorts[1], "dynamic Playground startup should select a new port after EADDRINUSE")
+
   console.log("Browser startup progress smoke passed")
 } finally {
   await rm(artifactsDirectory, { recursive: true, force: true })
+}
+
+function runtimeSpec() {
+  return {
+    backend: "wordpress-playground" as const,
+    environment: { kind: "wordpress" as const, name: "browser-startup-retry-smoke", version: "7.0", blueprint: { steps: [] } },
+    policy: runtimePolicy(),
+    artifactsDirectory,
+    metadata: {
+      runtime: { version: "0.0.0" },
+      task: { kind: "browser-startup-retry-smoke" },
+    },
+  }
+}
+
+function retryOnceCliModule(ports: number[]): PlaygroundCliModule {
+  let calls = 0
+  return {
+    async runCLI(options) {
+      calls += 1
+      ports.push(options.port)
+      if (calls === 1) {
+        const error = new Error("listen EADDRINUSE: address already in use 127.0.0.1") as Error & { code: string }
+        error.code = "EADDRINUSE"
+        throw error
+      }
+
+      return {
+        playground: {
+          async run() {
+            return { text: "" }
+          },
+        },
+        serverUrl: `http://127.0.0.1:${options.port}`,
+        async [Symbol.asyncDispose]() {},
+      }
+    },
+  }
 }
 
 function runtimePolicy() {

--- a/tests/fixtures/artifact-package-provenance-shape.json
+++ b/tests/fixtures/artifact-package-provenance-shape.json
@@ -2,15 +2,15 @@
   "schema": "wp-codebox/package-provenance/v1",
   "wpCodebox": {
     "name": "wp-codebox-workspace",
-    "version": "0.7.3"
+    "version": "0.8.0"
   },
   "runtimeCore": {
     "name": "@automattic/wp-codebox-core",
-    "version": "0.7.3"
+    "version": "0.8.0"
   },
   "runtimePlayground": {
     "name": "@automattic/wp-codebox-playground",
-    "version": "0.7.3"
+    "version": "0.8.0"
   },
   "playground": {
     "cli": {


### PR DESCRIPTION
## Summary
- bump wp-codebox workspace, scoped packages, and WordPress plugin metadata to 0.8.0
- restore documented package smoke npm aliases used by the release checklist
- harden dynamic Playground CLI startup against local port races
- refresh release-gate smoke fixtures for current sandbox tool policy and recipe execution behavior

## Testing
- `npm run build`
- `npx tsx scripts/agent-sandbox-code-smoke.ts`
- `npx tsx scripts/browser-startup-progress-smoke.ts`
- `npx tsx scripts/browser-html-capture-smoke.ts`
- `npm run package-distribution-smoke`
- `npm run package-installed-binary-smoke`
- `npm run package:wordpress-plugin`
- Release check manifest coverage was completed in smaller groups/individual smokes because one full `npm run check` exceeds the local tool timeout under current machine load. The port collision blocker found during the full run is fixed and covered.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Prepared the release version bump, fixed release-gate failures discovered while testing, and ran verification commands; Chris remains responsible for review and release.