### PR TITLE
Capture diffs for readwrite git-repo mounts via git HEAD

### DIFF
--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto"
+import { execFile } from "node:child_process"
 import { createRequire } from "node:module"
 import { readFileSync } from "node:fs"
-import { readdir, readFile } from "node:fs/promises"
+import { mkdtemp, readdir, readFile, realpath, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
+import { promisify } from "node:util"
 import { normalizeBlueprint, preferredVersionsForEnvironment } from "./blueprint.js"
 import { artifactFileDigest, stripUndefined } from "@automattic/wp-codebox-core"
 import type {
@@ -683,6 +686,68 @@ export async function directoryDiff(baselineDirectory: string, currentDirectory:
   return {
     patch: patches.join("\n"),
     files,
+  }
+}
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Detect whether a directory is the top level of a git work tree.
+ *
+ * Only returns true when the directory itself is the work-tree root, so a
+ * mount that happens to live inside an unrelated parent repository is not
+ * mistaken for a tracked workspace.
+ */
+export async function isGitWorkTree(directory: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", directory, "rev-parse", "--show-toplevel"], {
+      maxBuffer: 1024 * 1024,
+    })
+    const toplevel = stdout.trim()
+    if (!toplevel) {
+      return false
+    }
+    const [resolvedToplevel, resolvedDirectory] = await Promise.all([realpath(toplevel), realpath(directory)])
+    return resolvedToplevel === resolvedDirectory
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Diff a git work tree's current state (tracked changes + untracked files)
+ * against its committed HEAD, returning the same shape as `directoryDiff`.
+ *
+ * HEAD is materialized into a temporary directory via `git archive`, then the
+ * existing directory comparison machinery is reused so patch formatting,
+ * redaction, and digests stay identical across both diff strategies. Untracked
+ * files appear as additions because they are absent from the HEAD archive.
+ */
+export async function gitWorkingTreeDiff(repoDirectory: string, targetPrefix: string): Promise<DirectoryDiffResult> {
+  const headDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-git-head-"))
+  try {
+    let hasHead = true
+    try {
+      await execFileAsync("git", ["-C", repoDirectory, "rev-parse", "--verify", "HEAD"], { maxBuffer: 1024 * 1024 })
+    } catch {
+      hasHead = false
+    }
+
+    if (hasHead) {
+      // Materialize the committed tree without checking it out (the live work
+      // tree stays untouched): write HEAD to a tar file, then extract it into a
+      // temp directory the existing directory-diff machinery can read.
+      const archivePath = join(headDirectory, ".wp-codebox-head.tar")
+      await execFileAsync("git", ["-C", repoDirectory, "archive", "--format=tar", "-o", archivePath, "HEAD"], {
+        maxBuffer: 1024 * 1024,
+      })
+      await execFileAsync("tar", ["-x", "-f", archivePath, "-C", headDirectory], { maxBuffer: 1024 * 1024 })
+      await rm(archivePath, { force: true })
+    }
+
+    return await directoryDiff(headDirectory, repoDirectory, targetPrefix)
+  } finally {
+    await rm(headDirectory, { recursive: true, force: true })
   }
 }
 

--- a/packages/runtime-playground/src/mounted-artifact-capture.ts
+++ b/packages/runtime-playground/src/mounted-artifact-capture.ts
@@ -12,6 +12,8 @@ import {
   type MountDiff,
   type MountDiffsResult,
   directoryDiff,
+  gitWorkingTreeDiff,
+  isGitWorkTree,
   isReplayableText,
   mountTargetPath,
 } from "./artifacts.js"
@@ -61,7 +63,13 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
     }
 
     const artifactPath = `files/diffs/mount-${mountIndex}.patch`
-    if (!baselineSource) {
+
+    // Choose the diff baseline: an explicitly supplied filesystem snapshot
+    // (recipe `workspaces`) takes precedence; otherwise a mounted git work tree
+    // diffs against its committed HEAD. Mounts that are neither are skipped
+    // because there is no authoritative before-state to compare against.
+    const useGitWorkTree = !baselineSource && (await isGitWorkTree(mount.source))
+    if (!baselineSource && !useGitWorkTree) {
       await writeFile(join(artifactRoot, artifactPath), "")
       diffs.push({
         mountIndex,
@@ -77,7 +85,9 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
 
     let diff: Awaited<ReturnType<typeof directoryDiff>>
     try {
-      diff = await directoryDiff(baselineSource, mount.source, mount.target)
+      diff = useGitWorkTree
+        ? await gitWorkingTreeDiff(mount.source, mount.target)
+        : await directoryDiff(baselineSource, mount.source, mount.target)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       await writeFile(join(artifactRoot, artifactPath), "")
@@ -85,7 +95,7 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
         mountIndex,
         source: mount.source,
         target: mount.target,
-        baselineSource,
+        ...(baselineSource ? { baselineSource } : {}),
         artifactPath,
         changed: false,
         status: "failed",
@@ -96,12 +106,12 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
         id: `mount-${mountIndex}-diff-extraction-failed`,
         type: "mount-diff-extraction-failed",
         severity: "error",
-        message: `Failed to compare mounted workspace ${mount.target} against its baseline: ${message}`,
+        message: `Failed to compare mounted workspace ${mount.target} against its ${useGitWorkTree ? "git HEAD" : "baseline"}: ${message}`,
         category: "artifact-capture",
         source: mount.source,
         path: mount.target,
         refs: [{ path: artifactPath, kind: "diff" }],
-        details: { mountIndex, baselineSource, target: mount.target },
+        details: { mountIndex, baselineSource: baselineSource || undefined, baselineStrategy: useGitWorkTree ? "git-head" : "filesystem", target: mount.target },
       })
       continue
     }
@@ -111,7 +121,7 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
       mountIndex,
       source: mount.source,
       target: mount.target,
-      baselineSource,
+      ...(baselineSource ? { baselineSource } : {}),
       artifactPath,
       changed: diff.patch.trim().length > 0,
       status: diff.patch.trim().length > 0 ? "changed" : "unchanged",

--- a/scripts/mounted-workspace-diff-smoke.ts
+++ b/scripts/mounted-workspace-diff-smoke.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { promisify } from "node:util"
 import type { MountSpec } from "@automattic/wp-codebox-core"
 import { ArtifactRedactor, buildArtifactReview } from "../packages/runtime-playground/src/artifacts.js"
 import { captureMountDiffs } from "../packages/runtime-playground/src/mounted-artifact-capture.js"
+
+const execFileAsync = promisify(execFile)
 
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-mounted-diff-smoke-"))
 
@@ -104,6 +108,49 @@ try {
     ...numberedLines("after", 60).map((line) => `+${line}`),
     "",
   ].join("\n")
+  // A readwrite git work tree with no explicit baselineSource diffs against its
+  // committed HEAD, so homeboy-style repo mounts capture the agent's edits
+  // without the caller supplying a filesystem baseline snapshot.
+  const gitRepo = join(root, "git-repo")
+  await mkdir(gitRepo, { recursive: true })
+  await execFileAsync("git", ["-C", gitRepo, "init", "-q"])
+  await execFileAsync("git", ["-C", gitRepo, "config", "user.email", "smoke@wp-codebox.test"])
+  await execFileAsync("git", ["-C", gitRepo, "config", "user.name", "wp-codebox smoke"])
+  await writeFile(join(gitRepo, "committed.php"), "<?php\n// committed\n")
+  await writeFile(join(gitRepo, "remove-me.txt"), "delete this\n")
+  await execFileAsync("git", ["-C", gitRepo, "add", "."])
+  await execFileAsync("git", ["-C", gitRepo, "commit", "-q", "-m", "baseline"])
+
+  // Mutations the agent would make in the sandbox: edit a tracked file, delete a
+  // tracked file, and create an untracked file.
+  await writeFile(join(gitRepo, "committed.php"), "<?php\n// edited by agent\n")
+  await rm(join(gitRepo, "remove-me.txt"), { force: true })
+  await writeFile(join(gitRepo, "AGENT_WROTE_THIS.md"), "cooked by the agent\n")
+
+  const gitResult = await captureMountDiffs(artifactRoot, filesDirectory, [
+    {
+      type: "directory",
+      source: gitRepo,
+      target: "/workspace/wp-coding-agents",
+      mode: "readwrite",
+      metadata: { kind: "homeboy-dmc-workspace", workspace_slug: "wp-coding-agents" },
+    },
+  ], new ArtifactRedactor())
+  const gitChanged = new Map(gitResult.changedFiles.files.map((file) => [file.relativePath, file]))
+
+  assert.equal(gitResult.diagnostics.length, 0)
+  assert.equal(gitResult.mountDiffs.length, 1)
+  assert.equal(gitResult.mountDiffs[0].status, "changed")
+  assert.equal(gitResult.mountDiffs[0].changed, true)
+  assert.equal(gitResult.mountDiffs[0].reason, undefined)
+  assert.equal(gitChanged.get("AGENT_WROTE_THIS.md")?.status, "added")
+  assert.equal(gitChanged.get("committed.php")?.status, "modified")
+  assert.equal(gitChanged.get("remove-me.txt")?.status, "deleted")
+  assert.match(gitResult.patch, /diff --git a\/workspace\/wp-coding-agents\/AGENT_WROTE_THIS\.md b\/workspace\/wp-coding-agents\/AGENT_WROTE_THIS\.md/)
+  assert.match(gitResult.patch, /\+cooked by the agent/)
+  assert.match(gitResult.patch, /\+\/\/ edited by agent/)
+  assert.match(gitResult.patch, /deleted file mode 100644/)
+
   const review = buildArtifactReview({
     artifactId: "artifact-bundle-test",
     createdAt: "2026-06-01T00:00:00.000Z",


### PR DESCRIPTION
## Summary
- `captureMountDiffs` only produced a patch when a mount carried an explicit `metadata.baselineSource`, which is set **only** by `prepareRecipeWorkspace` for the recipe `workspaces` input.
- Repo mounts supplied through the `mounts` input (e.g. homeboy-extensions' `defaultWorkspaceMounts`, which mounts the workspace at `/workspace/<slug>` with no baseline) were always skipped with `missing-baseline-source`, so the coding agent's file edits never surfaced in `changed-files.json` / `patch.diff` — even though the writes succeeded inside the sandbox.
- A mounted git checkout already carries its own authoritative before-state: **HEAD**. When a readwrite mount has no `baselineSource` but is a git work tree, we now diff its current state (tracked edits + untracked files) against HEAD.

## How
- New `isGitWorkTree(dir)` and `gitWorkingTreeDiff(repoDir, targetPrefix)` helpers in `artifacts.ts`.
- `gitWorkingTreeDiff` materializes HEAD into a temp dir via `git archive` (the live work tree is never touched), then reuses the existing `directoryDiff` machinery so patch formatting, redaction, and digests are identical across both strategies. Untracked files naturally appear as additions (absent from the HEAD archive).
- `captureMountDiffs` now selects the baseline: explicit `baselineSource` (recipe workspaces) takes precedence; otherwise a git work tree diffs against HEAD; non-git mounts without a baseline keep skipping as before.

## Why wp-codebox owns this
The orchestration layer (homeboy-extensions) is a pure consumer — it forwards `agentResult.changedFiles` / `patch` into `codebox-changed-files` / `codebox-patch` artifacts and never computes a diff itself. The producer→consumer contract already routes the result correctly; the producer just couldn't diff a git-repo mount. Fixing it here makes capture work for **any** caller that mounts a git repo readwrite, with no orchestration changes and no per-caller baseline-snapshot shim.

## Testing
- Extended `scripts/mounted-workspace-diff-smoke.ts` with a git work tree mount that has **no** `baselineSource`, asserting an edited file (`modified`), a removed tracked file (`deleted`), and a new untracked file (`added`) are all captured in both `changedFiles` and `patch`.
- `npm run build` clean. Mount-diff smoke passes. The pre-existing `runtime-action-adapter-smoke` failure (browser-actions capture types) reproduces on clean `origin/main` and is unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Root-cause analysis of the missing-baseline-source skip, drafting the git-HEAD diff path and smoke coverage; Chris reviewed and verified.