### PR TITLE
Add post-agent verification gate to agent-task runs

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -37,6 +37,7 @@ export interface AgentTaskRunInput {
   artifacts_path?: string
   wp?: string
   component_contracts?: Array<Record<string, unknown>>
+  verify_steps?: WorkspaceRecipe["workflow"]["after"]
   parent_request?: Record<string, unknown>
   orchestrator?: Record<string, unknown>
 }
@@ -191,7 +192,14 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
       secretEnv: stringList(input.secret_env),
       agent_bundles: Array.isArray(input.agent_bundles) && input.agent_bundles.length > 0 ? input.agent_bundles : undefined,
     }),
-    workflow: { steps: [{ command: "wp-codebox.agent-sandbox-run", args: workflowArgs }] },
+    workflow: stripUndefined({
+      steps: [{ command: "wp-codebox.agent-sandbox-run", args: workflowArgs }],
+      // Post-agent verification gate: these run after the agent finishes editing
+      // (e.g. `wordpress.phpunit` / `wordpress.run-php` smoke gates). A non-zero
+      // exit in any after-phase step fails the whole run, so the orchestrator
+      // cannot report success until the supplied gates are green.
+      after: Array.isArray(input.verify_steps) && input.verify_steps.length > 0 ? input.verify_steps : undefined,
+    }),
   }) as WorkspaceRecipe
 }
 

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -9,7 +9,7 @@ import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded } from "../recipe-dry-run.js"
-import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput } from "../recipe-evidence.js"
+import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -387,7 +387,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     }
     const strictFailure = recipeArtifactEvidenceFailure(evidence)
     const agentFailure = recipeAgentResultFailure(evidence.agentResult)
-    const successfulRecipe = !strictFailure && !agentFailure
+    const verifyFailure = recipeVerifyStepFailure(executions)
+    const recipeFailure = strictFailure ?? agentFailure ?? verifyFailure
+    const successfulRecipe = !recipeFailure
     if (successfulRecipe && options.previewHoldSeconds) {
       artifacts = await awaitRecipe("runtime.collect-artifacts.preview-hold", runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds }))
       await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list() })
@@ -412,16 +414,16 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       await writeBenchmarkArtifactEvidence(artifacts, benchResultsList)
     }
 
-    if (strictFailure || agentFailure) {
+    if (recipeFailure) {
       runRecord = await runRegistry.update(runRecord.runId, {
         status: "failed",
         runtime: runtimeInfo ?? await runtime.info(),
         preview: artifacts.preview,
         artifactRefs: artifactBundleRunRef(artifacts),
-        metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: strictFailure ?? agentFailure, phaseEvidence: phaseTracker.list() }) },
-        error: strictFailure ?? agentFailure,
+        metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: recipeFailure, phaseEvidence: phaseTracker.list() }) },
+        error: recipeFailure,
       })
-      await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: strictFailure ?? agentFailure, phases: phaseTracker.list() })
+      await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: recipeFailure, phases: phaseTracker.list() })
       return {
         success: false,
         schema: "wp-codebox/recipe-run/v1",
@@ -441,7 +443,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
         artifacts,
         run: runRecord,
-        error: strictFailure ?? agentFailure,
+        error: recipeFailure,
       }
     }
 

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -805,6 +805,32 @@ export function recipeAgentResultFailure(agentResult: RecipeArtifactEvidenceResu
   }
 }
 
+/**
+ * Gate recipe success on post-agent verification steps.
+ *
+ * Steps in the recipe `workflow.after` phase (e.g. a `wordpress.phpunit` or
+ * `wordpress.run-php` smoke gate run after the agent finishes editing) execute
+ * but do not throw on a non-zero exit, so without this check a red test gate
+ * would still report the run as succeeded. Any failing after-phase step turns
+ * the whole run into a failure, so the orchestrator cannot accept an agent
+ * change until its verification gates are green.
+ */
+export function recipeVerifyStepFailure(
+  executions: ReadonlyArray<{ exitCode: number; recipePhase?: string; recipeCommand?: string; command?: string }>,
+): { name: string; code: string; message: string } | undefined {
+  const failed = executions.find((execution) => execution.recipePhase === "after" && execution.exitCode !== 0)
+  if (!failed) {
+    return undefined
+  }
+
+  const stepName = failed.recipeCommand || failed.command || "verify"
+  return {
+    name: "RecipeVerifyError",
+    code: "verify-step-failed",
+    message: `Verification step ${stepName} failed with exit code ${failed.exitCode}.`,
+  }
+}
+
 function workspaceToolDiagnostics(transcript: AgentSandboxTranscript): AgentSandboxResultSummary["workspaceTools"] | undefined {
   const diagnostics = new Set<string>()
   const text = transcript.executions.map((execution) => `${execution.stdout}\n${execution.stderr}`).join("\n").toLowerCase()

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -76,6 +76,26 @@ assert.ok(
   "outer sandbox payloads should use a distinct encoder helper",
 )
 
+// Verify steps are emitted into workflow.after so a post-agent test gate runs
+// after the agent finishes editing.
+const verifyInput = {
+  goal: "Fix a bug and prove it with the smoke suite",
+  provider: "openai",
+  model: "gpt-5.5",
+  artifacts_path: "/tmp/wp-codebox-artifacts",
+  verify_steps: [
+    { command: "wordpress.phpunit", args: ["plugin-slug=data-machine"] },
+  ],
+}
+const verifyRecipe = buildAgentTaskRecipe(verifyInput, normalizeTaskInput(verifyInput), "trunk")
+assert.equal(verifyRecipe.workflow.steps[0]?.command, "wp-codebox.agent-sandbox-run", "agent run remains the primary workflow step")
+assert.equal(verifyRecipe.workflow.after?.length, 1, "verify_steps should be emitted as workflow.after")
+assert.equal(verifyRecipe.workflow.after?.[0]?.command, "wordpress.phpunit", "after step should be the supplied verify command")
+
+// Without verify_steps, no after phase is emitted (back-compat with current runs).
+const noVerifyRecipe = buildAgentTaskRecipe(input, normalizeTaskInput(input), "trunk")
+assert.equal(noVerifyRecipe.workflow.after, undefined, "no verify_steps should leave workflow.after unset")
+
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))
 const codexProviderPath = join(profileRoot, "ai-provider-for-openai@codex-oauth-provider")
 const phpAiClientPath = join(profileRoot, "php-ai-client@custom-provider-auth")

--- a/scripts/recipe-verify-gate-smoke.ts
+++ b/scripts/recipe-verify-gate-smoke.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { recipeVerifyStepFailure } from "../packages/cli/src/recipe-evidence.js"
+
+// A failing after-phase step (e.g. a red phpunit/smoke gate) must fail the run.
+const failed = recipeVerifyStepFailure([
+  { exitCode: 0, recipePhase: "steps", recipeCommand: "wp-codebox.agent-sandbox-run" },
+  { exitCode: 1, recipePhase: "after", recipeCommand: "wordpress.phpunit" },
+])
+assert.ok(failed, "a non-zero after-phase step should produce a verify failure")
+assert.equal(failed?.code, "verify-step-failed")
+assert.match(failed?.message ?? "", /wordpress\.phpunit/)
+assert.match(failed?.message ?? "", /exit code 1/)
+
+// A green after-phase gate passes.
+const passed = recipeVerifyStepFailure([
+  { exitCode: 0, recipePhase: "steps", recipeCommand: "wp-codebox.agent-sandbox-run" },
+  { exitCode: 0, recipePhase: "after", recipeCommand: "wordpress.phpunit" },
+])
+assert.equal(passed, undefined, "a green after-phase gate should not fail the run")
+
+// A non-zero exit in a non-after phase (setup/steps) is NOT treated as a verify
+// failure here; those are handled by their own failure signals.
+const stepsExit = recipeVerifyStepFailure([
+  { exitCode: 1, recipePhase: "steps", recipeCommand: "wp-codebox.agent-sandbox-run" },
+])
+assert.equal(stepsExit, undefined, "non-after phase exit codes are not verify-gate failures")
+
+// No after steps at all → no gate failure (back-compat with current single-step runs).
+const noAfter = recipeVerifyStepFailure([
+  { exitCode: 0, recipePhase: "steps", recipeCommand: "wp-codebox.agent-sandbox-run" },
+])
+assert.equal(noAfter, undefined, "runs without an after phase should not fail the verify gate")
+
+// First failing after step is reported when multiple exist.
+const multi = recipeVerifyStepFailure([
+  { exitCode: 0, recipePhase: "after", recipeCommand: "wordpress.run-php" },
+  { exitCode: 2, recipePhase: "after", recipeCommand: "wordpress.phpunit" },
+])
+assert.match(multi?.message ?? "", /wordpress\.phpunit/)
+assert.match(multi?.message ?? "", /exit code 2/)
+
+console.log("recipe-verify-gate-smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -143,6 +143,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-browser-smoke"),
       tsxSmoke("recipe-dry-run-smoke"),
       tsxSmoke("recipe-workflow-phases-smoke"),
+      tsxSmoke("recipe-verify-gate-smoke"),
       tsxSmoke("recipe-site-seed-smoke"),
       tsxSmoke("recipe-fixture-probes-smoke"),
       tsxSmoke("recipe-staged-files-smoke"),


### PR DESCRIPTION
## Summary
Agent-task recipes ran a single workflow step (the agent) and reported success when the agent finished, with no gate on whether the resulting code actually passes tests. A coding agent could apply a wrong fix and the run would still report `succeeded`.

This adds an opt-in verification gate:
- `agent-task-run` accepts `input.verify_steps` and emits them as recipe **`workflow.after`** steps that run once the agent finishes editing.
- `recipeVerifyStepFailure()` fails the recipe when any after-phase step exits non-zero, folded into the existing success computation so the run reports `failed` and surfaces the failing gate.

After-phase steps already executed via the recipe runner, but a step that ran and returned a non-zero exit (without throwing) did not propagate to the run's success — this closes that gap so a red test gate blocks success. Runs without `verify_steps` are unaffected (`workflow.after` stays unset).

## How it's used
A caller (e.g. homeboy-extensions) passes `verify_steps` like:
```json
{ "verify_steps": [ { "command": "wordpress.phpunit", "args": ["plugin-slug=data-machine"] } ] }
```
The agent runs, then the gate runs against booted WordPress; a red gate fails the run.

## Evidence (end-to-end via homeboy agent-task dispatch)
- **Green gate → succeeded:** agent applied its fix, the verify step ran the smoke in-sandbox (`OK 14 assertions`), run reported `succeeded`.
- **Failing gate → failed:** a forced-failing verify step produced `state: failed` with `Recipe workflow after[0] failed`, even though the agent itself completed.

## Testing
- `scripts/recipe-verify-gate-smoke.ts` — gate failure semantics (after-phase non-zero → failure; green/none → pass; non-after exits ignored; first failing step reported).
- `scripts/agent-task-run-runtime-components-smoke.ts` — asserts `verify_steps` → `workflow.after`, and that no `verify_steps` leaves `workflow.after` unset.
- Registered in `scripts/smoke-manifest.ts`. `npm run build` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Root-cause analysis (single-step recipe with no gate; after-phase non-zero exits not propagated), drafting the gate + smokes; Chris reviewed and directed.