### PR TITLE
Align recipe docs with runtime contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,10 @@ WordPress has historically lacked a clean scratch space for code execution. Mode
 
 WP Codebox is the runtime boundary for agent-built or workflow-built outputs. It is not the agent framework, the review UI, the deploy system, or the production site mutator. The WordPress plugin in this repo is one optional host adapter (useful when the host *is* a WordPress site); the core CLI/runtime works anywhere `node` can run.
 
-For the durable architecture boundary, see [`docs/architecture.md`](./docs/architecture.md).
-For the Automattic transfer review surface, see
-[`docs/transfer-readiness-checklist.md`](./docs/transfer-readiness-checklist.md).
-For browser runtime dependency classification and packaging provenance, see
-[`docs/browser-runtime-dependency-audit.md`](./docs/browser-runtime-dependency-audit.md).
-For the generic multi-agent fanout contract, see
-[`docs/agent-fanout-contract.md`](./docs/agent-fanout-contract.md).
+For the docs map, see [`docs/README.md`](./docs/README.md). For the durable
+architecture boundary, see [`docs/architecture.md`](./docs/architecture.md). For
+recipe authoring, supported input names, and assertion syntax, see
+[`docs/recipe-contract.md`](./docs/recipe-contract.md).
 
 ```text
 Any host: CLI, CI, mobile, Node service, WP plugin, GitHub Action, ...
@@ -819,7 +816,7 @@ npm run wp-codebox -- recipe-run \
   --json
 ```
 
-Recipes are JSON declarations for a sandbox setup plus workflow steps. They can mount existing directories, create disposable plugin/theme workspaces, activate extra plugins, allow-list selected secret environment variable names, and capture the output as artifacts.
+Recipes are JSON declarations for a sandbox setup plus workflow steps. They can mount existing directories, create disposable plugin/theme workspaces, activate extra plugins, allow-list selected secret environment variable names, and capture the output as artifacts. See [`docs/recipe-contract.md`](./docs/recipe-contract.md) for the current recipe field names and assertion syntax.
 
 Pass `--dry-run --json` to validate the same recipe and emit the resolved plan without booting Playground, creating temp workspaces, mounting files, executing commands, or writing artifacts:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# WP Codebox Docs
+
+Start here when authoring or maintaining WP Codebox integrations. The current
+contracts are generated from code where possible; planning docs are historical
+unless this index says otherwise.
+
+## Current Contracts
+
+- [Architecture](./architecture.md) explains the product boundary, package map,
+  and ownership rules.
+- [Recipe contract](./recipe-contract.md) is the authoring guide for
+  `wp-codebox/workspace-recipe/v1` recipes, including supported input names and
+  assertion syntax.
+- [Sandbox session contract](./sandbox-session-contract.md) defines the parent
+  orchestration boundary for sandbox sessions.
+- [External apply adapter contract](./external-apply-adapter-contract.md)
+  documents reviewed artifact apply-back.
+- [Agent fanout contract](./agent-fanout-contract.md) documents generic
+  multi-sandbox fanout inputs and outputs.
+- [Portable WP Codebox](./portable-wp-codebox.md) documents portable runtime
+  packaging and invocation.
+- [Benchmark contract](./benchmark-contract.md) documents benchmark evidence
+  shape without making benchmark scoring a core runtime concern.
+
+## Audits And Historical Plans
+
+- [Browser runtime dependency audit](./browser-runtime-dependency-audit.md) is a
+  current dependency classification reference.
+- [Transfer readiness checklist](./transfer-readiness-checklist.md) and
+  [transfer namespace plan](./transfer-namespace-plan.md) are historical transfer
+  planning records. Keep them for provenance, but do not treat them as onboarding
+  docs or current recipe contract authority.
+- [Reprint parent-site snapshots](./reprint-parent-site-snapshots.md) is a
+  planning note for a bounded parent-site snapshot surface.
+
+## Contract Authority
+
+- Recipe schema: `npm run wp-codebox -- schema recipe --json`.
+- Command catalog: `npm run wp-codebox -- commands --json`.
+- Runtime TypeScript contracts:
+  `packages/runtime-core/src/runtime-contracts.ts`.
+- JSON Schema factory: `packages/runtime-core/src/recipe-schema.ts`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -441,10 +441,9 @@ refs, and adapter hooks.
   preview URLs, statuses, and errors. Parent orchestrators own parallelism,
   track their own jobs, pass correlation metadata into each sandbox run, and
   store the returned artifact ids as evidence.
-- **Transfer-readiness checklist:** package boundaries, artifact lifecycle,
-  extension seams, browser runtime dependencies, ability contracts, security
-  gates, and external integration review points are tracked in
-  [`transfer-readiness-checklist.md`](./transfer-readiness-checklist.md).
+- **Recipe contract:** current recipe field names, extra plugin loading, workflow
+  step shape, and browser assertion syntax are documented in
+  [`recipe-contract.md`](./recipe-contract.md).
 
 ## Ownership Boundaries
 
@@ -479,3 +478,8 @@ or agent framework.
 
 For dependency-role classification and browser runtime packaging boundaries, see
 [`browser-runtime-dependency-audit.md`](./browser-runtime-dependency-audit.md).
+
+Historical transfer planning records remain in
+[`transfer-readiness-checklist.md`](./transfer-readiness-checklist.md) and
+[`transfer-namespace-plan.md`](./transfer-namespace-plan.md), but they are not
+the current onboarding path or recipe contract authority.

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -1,0 +1,192 @@
+# Recipe Contract
+
+WP Codebox recipes use the `wp-codebox/workspace-recipe/v1` schema. A recipe is
+a declarative sandbox setup plus ordered workflow steps. The CLI validates the
+recipe before booting WordPress Playground, then returns a structured artifact
+bundle after execution.
+
+Use the generated schema and command catalog as the source of truth:
+
+```bash
+npm run wp-codebox -- schema recipe --json
+npm run wp-codebox -- commands --json
+```
+
+Validate recipes before using them in CI or documentation examples:
+
+```bash
+npm run wp-codebox -- recipe validate --recipe ./path/to/recipe.json --json
+npm run wp-codebox -- recipe-run --recipe ./path/to/recipe.json --dry-run --json
+```
+
+## Minimal Shape
+
+```json
+{
+  "schema": "wp-codebox/workspace-recipe/v1",
+  "runtime": {
+    "backend": "wordpress-playground",
+    "wp": "latest"
+  },
+  "inputs": {
+    "mounts": [
+      {
+        "source": "../my-plugin",
+        "target": "/wordpress/wp-content/plugins/my-plugin",
+        "mode": "readonly"
+      }
+    ]
+  },
+  "workflow": {
+    "steps": [
+      {
+        "command": "wordpress.run-php",
+        "args": ["code=echo get_bloginfo( 'name' );"]
+      }
+    ]
+  }
+}
+```
+
+## Stable Field Names
+
+Recipe field names are case-sensitive. The current recipe schema accepts these
+top-level fields:
+
+- `schema`
+- `distribution`
+- `runtime`
+- `inputs`
+- `workflow`
+- `artifacts`
+- `probes`
+
+`inputs` accepts these fields:
+
+- `mounts`
+- `workspaces`
+- `extra_plugins`
+- `secretEnv`
+- `pluginRuntime`
+- `fixtureDatabases`
+- `siteSeeds`
+- `stagedFiles`
+- `agent_bundles`
+- `inherit`
+- `inheritance`
+
+Use `inputs.extra_plugins`, not `inputs.extraPlugins`. The camelCase form is an
+old docs/example drift and is not part of `wp-codebox/workspace-recipe/v1`.
+
+Use `inputs.agent_bundles`, not `inputs.agentBundles`, for runtime agent bundle
+imports.
+
+## Extra Plugins
+
+`inputs.extra_plugins` mounts additional WordPress plugins before workflow steps
+run. Each entry requires `source` and may include `slug`, `pluginFile`,
+`activate`, `loadAs`, and `sha256`.
+
+```json
+{
+  "inputs": {
+    "extra_plugins": [
+      {
+        "source": "https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
+        "pluginFile": "bbpress/bbpress.php",
+        "activate": false
+      },
+      {
+        "source": "../agents-api",
+        "slug": "agents-api",
+        "pluginFile": "agents-api/agents-api.php",
+        "activate": false,
+        "loadAs": "mu-plugin"
+      }
+    ]
+  }
+}
+```
+
+Supported `loadAs` values:
+
+- `plugin`: mount below `/wordpress/wp-content/plugins/<slug>` and activate when
+  `activate` is not `false`.
+- `mu-plugin`: mount below
+  `/wordpress/wp-content/mu-plugins/wp-codebox-runtime/<slug>` and load through
+  WP Codebox's generated MU-plugin loader. Use this for sandbox runtime
+  substrate, not user-visible plugins.
+
+External HTTPS zip downloads are gated by `WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS=1`.
+Local paths are resolved relative to the recipe file.
+
+## Workflow Steps
+
+Workflow steps are ordered command invocations:
+
+```json
+{
+  "command": "wordpress.wp-cli",
+  "args": ["command=option get home"]
+}
+```
+
+Each `args` entry is a string. Command-specific argument names and repeatability
+come from the command catalog:
+
+```bash
+npm run wp-codebox -- commands --json
+```
+
+## Browser Assertions
+
+`wordpress.browser-probe` accepts repeated `assert=<assertion>` arguments.
+Supported assertion forms are the current command contract:
+
+- `exists:<selector>`
+- `not-exists:<selector>`
+- `visible:<selector>`
+- `hidden:<selector>`
+- `count:<selector><op><number>`
+- `text:<selector> contains <text>`
+- `attr:<selector>[name][=value]`
+- `no-console-errors`
+- `no-page-errors`
+- `no-errors`
+- `request-count-by-host:<host><op><number>`
+- `request-count-by-type:<type><op><number>`
+- `total-transfer-size<op><number>`
+- metric budgets such as `lcp_ms<=2500`, `fcp_ms<=1800`,
+  `ttfb_ms<=800`, and `nav_duration_ms<=5000`
+
+Prefix an assertion with `advisory:` to record a failing assertion without
+failing the command.
+
+Do not use `assert=script:passed equals true`. That syntax is not supported by
+the current WP Codebox browser assertion contract. Use `wordpress.browser-actions`
+with an `evaluate` step and `assert` value when a page script must prove state:
+
+```json
+{
+  "command": "wordpress.browser-actions",
+  "args": [
+    "url=/wp-admin/tools.php?page=my-plugin",
+    "steps-json=[{\"kind\":\"evaluate\",\"expression\":\"window.myPluginReady === true\",\"assert\":true}]"
+  ]
+}
+```
+
+Recipes that use a browser-actions `evaluate` step require the runtime policy to
+allow `wordpress.browser-actions.evaluate` in addition to
+`wordpress.browser-actions`.
+
+## Keeping Examples Current
+
+When editing docs or example recipes:
+
+- Prefer generated schema output over hand-written field lists.
+- Run `recipe validate` against every recipe changed.
+- Run `recipe-run --dry-run --json` when changing mounts, workspaces,
+  `extra_plugins`, secrets, or workflow args.
+- Keep product-specific orchestration, scoring, PR creation, and deployment out
+  of recipes. Parent control planes own those behaviors.

--- a/docs/transfer-namespace-plan.md
+++ b/docs/transfer-namespace-plan.md
@@ -1,5 +1,10 @@
 # Transfer Namespace Plan
 
+Historical note: this is a transfer planning record, not the current onboarding
+path or recipe contract reference. Start with [`README.md`](./README.md),
+[`architecture.md`](./architecture.md), and
+[`recipe-contract.md`](./recipe-contract.md) for current docs.
+
 WP Codebox is moving from personal ownership assumptions toward Automattic
 ownership. This plan inventories the current personal namespace assumptions and
 defines the mechanical update path once the target package namespace and

--- a/docs/transfer-readiness-checklist.md
+++ b/docs/transfer-readiness-checklist.md
@@ -1,5 +1,10 @@
 # Transfer Readiness Architecture Checklist
 
+Historical note: this is a transfer planning record, not the current onboarding
+path or recipe contract reference. Start with [`README.md`](./README.md),
+[`architecture.md`](./architecture.md), and
+[`recipe-contract.md`](./recipe-contract.md) for current docs.
+
 WP Codebox is preparing to move from a personal prototype substrate toward
 Automattic-owned infrastructure. This checklist defines the architecture review
 surface that should be clean before transfer: package boundaries, artifact

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -234,7 +234,7 @@ export const commandRegistry = [
       { name: "timeout", description: "Total-script timeout bounding the whole interaction run.", format: "duration, e.g. 30s or 1500ms" },
       { name: "auth", description: "Optional in-memory browser authentication mode. Use wordpress-admin to bootstrap WordPress admin cookies from PHP without writing token-bearing storage-state artifacts.", format: "wordpress-admin" },
       { name: "auth-user-id", description: "WordPress user ID used with auth=wordpress-admin; defaults to 1.", format: "positive integer" },
-      { name: "capture", description: "Comma-separated artifacts to capture after interactions.", format: "steps,console,errors,html,network,screenshot,dom-snapshot" },
+      { name: "capture", description: "Comma-separated artifacts to capture after interactions. actions is accepted as an alias for steps.", format: "steps|actions,console,errors,html,network,screenshot,dom-snapshot" },
       { name: "max-dom-snapshot-elements", description: "Maximum visible elements captured in each screenshot sidecar DOM/style snapshot; defaults to 160.", format: "positive integer" },
     ],
     outputShape: "JSON summary plus files/browser/steps.jsonl, action-summary.json (with assertions pass/fail), named screenshots, sidecar DOM/style snapshots, and optional console/errors/network/html/screenshot artifacts.",

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -412,6 +412,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           slug: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
           pluginFile: { type: "string" },
           activate: { type: "boolean" },
+          loadAs: { enum: ["plugin", "mu-plugin"] },
           sha256: { type: "string", pattern: "^[a-fA-F0-9]{64}$" },
         },
       },

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -1898,7 +1898,7 @@ export async function runBrowserActionsCommand({
 }
 
 async function browserActionsRunPlanFromArgs(args: string[]): Promise<BrowserActionsRunPlan> {
-  const capture = new Set(commaListArg(args, "capture"))
+  const capture = new Set(commaListArg(args, "capture").map((item) => item === "actions" ? "steps" : item))
   if (capture.size === 0) {
     capture.add("steps")
     capture.add("console")


### PR DESCRIPTION
## Summary
- Add a docs index and recipe contract guide that document current recipe field names, extra plugin loading, and browser assertion syntax.
- Demote transfer planning docs from the onboarding path and point new readers at current contract docs.
- Align runtime contracts by adding `extra_plugins[].loadAs` to the generated recipe schema and accepting `capture=actions` as a browser-actions alias for `steps`.

## Testing
- `npm run wp-codebox -- schema recipe --json`
- `npx tsx scripts/recipe-dry-run-smoke.ts`
- `npx tsx scripts/runtime-action-adapter-smoke.ts`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the docs updates and small runtime/schema alignment fixes; Chris retains responsibility for review and testing.