### PR TITLE
Support recipe dependency overlays

### DIFF
--- a/packages/cli/src/agent-fanout.ts
+++ b/packages/cli/src/agent-fanout.ts
@@ -243,6 +243,7 @@ function inheritedAgentTaskInput(source: Record<string, unknown>): Record<string
     "secret_env",
     "mounts",
     "workspaces",
+    "dependency_overlays",
     "runtime_stack_mounts",
     "runtime_overlays",
     "agent_bundles",

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -24,6 +24,7 @@ export interface AgentTaskRunInput {
   secret_env?: string[]
   mounts?: NonNullable<WorkspaceRecipe["inputs"]>["mounts"]
   workspaces?: NonNullable<WorkspaceRecipe["inputs"]>["workspaces"]
+  dependency_overlays?: NonNullable<WorkspaceRecipe["inputs"]>["dependency_overlays"]
   runtime_stack_mounts?: Array<Record<string, unknown>>
   runtime_overlays?: Array<Record<string, unknown>>
   agent_bundles?: Array<Record<string, unknown>>
@@ -185,6 +186,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
     inputs: stripUndefined({
       mounts: Array.isArray(input.mounts) ? input.mounts : [],
       workspaces: Array.isArray(input.workspaces) ? input.workspaces : [],
+      dependency_overlays: Array.isArray(input.dependency_overlays) ? input.dependency_overlays : undefined,
       extra_plugins: [
         ...componentPlugins(input.component_contracts, artifacts),
         ...providerPlugins,

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -11,7 +11,7 @@ import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePrevi
 import { dryRunRecipe, planWorkspaceRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded } from "../recipe-dry-run.js"
 import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
-import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
+import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
 import { createRecipeRunContext } from "./recipe-run-context.js"
@@ -122,6 +122,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   const effectivePolicy = Object.keys(secretEnv).length > 0 ? { ...policy, secrets: "connector-scoped" as const } : policy
   let workspaceMounts: PreparedWorkspaceMount[] = []
   let extraPlugins: PreparedExtraPlugin[] = []
+  let dependencyOverlays: PreparedDependencyOverlay[] = []
   let stagedFiles: PreparedStagedFile[] = []
   let overlays: PreparedRuntimeOverlay[] = []
   let backendPackage: PreparedRuntimeBackendPackage | undefined
@@ -154,6 +155,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   try {
     workspaceMounts = await prepareRecipeWorkspaces(recipe, recipeDirectory)
     extraPlugins = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
+    dependencyOverlays = await prepareRecipeDependencyOverlays(recipe, recipeDirectory, extraPlugins)
     stagedFiles = await prepareRecipeStagedFiles(recipe, recipeDirectory)
     overlays = await prepareRecipeRuntimeOverlaysForRun(recipe, recipeDirectory)
     backendPackage = await prepareRecipeRuntimeBackendPackage(recipe, recipeDirectory)
@@ -179,7 +181,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       metadata: {
         ...runtimeMetadata(configuredArtifactsDirectory, plan.runtime.wp),
         run: { runId: runRecord.runId, registryDirectory: runRegistry.directory },
-        ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, stagedFiles, overlays, backendPackage, effectivePreview),
+        ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, dependencyOverlays, stagedFiles, overlays, backendPackage, effectivePreview),
       },
       preview: previewSpec(effectivePreview.publicUrl, effectivePreview.port, effectivePreview.bind, effectivePreview.siteUrl),
     }
@@ -208,6 +210,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         backend: runtimeCreateSpec.backend,
         environment: runtimeEnvironment,
         extraPlugins: extraPlugins.map(recipeRunExtraPlugin),
+        dependencyOverlays: dependencyOverlays.map(recipeRunDependencyOverlay),
         workspaces: workspaceMounts.map((workspace) => ({
           source: workspace.source,
           target: workspace.target,
@@ -291,6 +294,17 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         interruption?.throwIfInterrupted()
       }
     })
+
+    for (const overlay of dependencyOverlays) {
+      await awaitRecipe(`dependency-overlay.mount:${overlay.package}`, runtime.mount({
+        type: overlay.type,
+        source: overlay.source,
+        target: overlay.target,
+        mode: overlay.mode,
+        metadata: overlay.metadata,
+      }))
+      interruption?.throwIfInterrupted()
+    }
 
     for (const mount of recipe.inputs?.mounts ?? []) {
       const source = resolve(recipeDirectory, mount.source)
@@ -401,7 +415,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const activeRuntime = runtime
     cleanupEvidence = await runRecipeCleanup(runRegistry, runRecord, async () => {
       await awaitRecipe("runtime.release", releaseRuntime(activeRuntime, successfulRecipe ? options.previewHoldSeconds : 0))
-      await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays)
+      await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays, dependencyOverlays)
     })
     runRecord = await runRegistry.read(runRecord.runId)
     interruption?.throwIfInterrupted()
@@ -515,7 +529,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       }
     }
 
-    cleanupEvidence = await runRecipeCleanup(runRegistry, runRecord, () => cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays))
+    cleanupEvidence = await runRecipeCleanup(runRegistry, runRecord, () => cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays, dependencyOverlays))
     runRecord = await runRegistry.read(runRecord.runId)
     const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
     runRecord = await runRegistry.update(runRecord.runId, {
@@ -1539,7 +1553,7 @@ function effectiveRecipePreview(recipePreview: RuntimePreviewSpec | undefined, o
   })
 }
 
-function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[], overlays: PreparedRuntimeOverlay[], backendPackage: PreparedRuntimeBackendPackage | undefined, preview: RuntimePreviewSpec): Record<string, unknown> {
+function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspaceMounts: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], dependencyOverlays: PreparedDependencyOverlay[], stagedFiles: PreparedStagedFile[], overlays: PreparedRuntimeOverlay[], backendPackage: PreparedRuntimeBackendPackage | undefined, preview: RuntimePreviewSpec): Record<string, unknown> {
   const extraPluginMetadata = extraPlugins.map((plugin) => ({
     source: plugin.source,
     slug: plugin.slug,
@@ -1564,6 +1578,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: extraPluginMetadata,
+        dependency_overlays: recipe.inputs?.dependency_overlays ?? [],
         pluginRuntime: recipe.inputs?.pluginRuntime ?? {},
         fixtureDatabases: recipe.inputs?.fixtureDatabases ?? [],
         siteSeeds: recipe.inputs?.siteSeeds ?? [],
@@ -1591,6 +1606,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: extraPluginMetadata,
+        dependency_overlays: recipe.inputs?.dependency_overlays ?? [],
         pluginRuntime: recipe.inputs?.pluginRuntime ?? {},
         fixtureDatabases: recipe.inputs?.fixtureDatabases ?? [],
         siteSeeds: recipe.inputs?.siteSeeds ?? [],
@@ -1617,6 +1633,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       provenance: stagedFile.provenance,
       metadata: stagedFile.metadata,
     })),
+    preparedDependencyOverlays: dependencyOverlays.map(recipeRunDependencyOverlay),
     preparedRuntimeOverlays: overlays.map((overlay) => ({
       target: overlay.target,
       type: overlay.type,
@@ -1624,6 +1641,19 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
       metadata: overlay.metadata,
     })),
     ...(backendPackage ? { preparedRuntimeBackend: backendPackage.provenance } : {}),
+  }
+}
+
+function recipeRunDependencyOverlay(overlay: PreparedDependencyOverlay): Record<string, unknown> {
+  return {
+    source: overlay.source,
+    sourceRef: overlay.sourceRef,
+    target: overlay.target,
+    package: overlay.package,
+    consumer: overlay.consumer,
+    type: overlay.type,
+    mode: overlay.mode,
+    metadata: overlay.metadata,
   }
 }
 

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -1,7 +1,7 @@
 import { basename, dirname, resolve } from "node:path"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined, validateRuntimePolicy, type MountSpec, type RuntimePolicy, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { serializeError } from "./output.js"
-import { defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
+import { composerPackageVendorPath, defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
 import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
 
 export interface RecipeDryRunOptions {
@@ -330,6 +330,27 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
     },
     planned: "generated" as const,
   }))
+  const dependencyOverlays = (recipe.inputs?.dependency_overlays ?? []).map((overlay, index) => {
+    const consumer = extraPlugins.find((plugin) => plugin.slug === overlay.consumer)
+    const target = `${consumer?.target ?? pluginTarget(overlay.consumer, "plugin")}/vendor/${composerPackageVendorPath(overlay.package)}`
+    return {
+      type: "directory" as const,
+      source: resolve(recipeDirectory, overlay.source),
+      target,
+      mode: "readonly" as const,
+      metadata: {
+        kind: "dependency-overlay",
+        index,
+        overlayKind: overlay.kind,
+        package: overlay.package,
+        source: overlay.source,
+        consumer: overlay.consumer,
+        target,
+        ...(overlay.metadata ? { userMetadata: overlay.metadata } : {}),
+      },
+      planned: "existing" as const,
+    }
+  })
   const mounts: RecipeDryRunMount[] = [
     ...runtimeOverlays,
     ...(distribution?.sourceMounts ?? []).map((mount) => ({
@@ -365,6 +386,7 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
       },
       planned: "existing" as const,
     })),
+    ...dependencyOverlays,
     ...recipeMounts,
     ...stagedFiles.map((stagedFile) => ({
       type: stagedFile.type,

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -4,7 +4,7 @@ import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node
 import { tmpdir } from "node:os"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { promisify } from "node:util"
-import { SANDBOX_WORKSPACE_ROOT, type MountSpec, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
+import { SANDBOX_WORKSPACE_ROOT, type MountSpec, type WorkspaceRecipe, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeStagedFile, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 
 export interface PreparedWorkspaceMount {
   source: string
@@ -84,6 +84,18 @@ export interface PreparedStagedFile {
 export interface PreparedRuntimeOverlay {
   source: string
   target: string
+  type: "directory"
+  mode: "readonly"
+  cleanupPaths: string[]
+  metadata: Record<string, unknown>
+}
+
+export interface PreparedDependencyOverlay {
+  source: string
+  sourceRef: string
+  target: string
+  package: string
+  consumer: string
   type: "directory"
   mode: "readonly"
   cleanupPaths: string[]
@@ -252,12 +264,13 @@ async function cleanupRecipeWorkspaces(workspaces: PreparedWorkspaceMount[]): Pr
   await Promise.all(workspaces.flatMap((workspace) => workspace.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })))
 }
 
-export async function cleanupRecipePreparedSources(workspaces: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[] = [], overlays: PreparedRuntimeOverlay[] = []): Promise<void> {
+export async function cleanupRecipePreparedSources(workspaces: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[] = [], overlays: PreparedRuntimeOverlay[] = [], dependencyOverlays: PreparedDependencyOverlay[] = []): Promise<void> {
   await Promise.all([
     cleanupRecipeWorkspaces(workspaces),
     ...extraPlugins.flatMap((plugin) => plugin.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
     ...stagedFiles.flatMap((stagedFile) => stagedFile.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
     ...overlays.flatMap((overlay) => overlay.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
+    ...dependencyOverlays.flatMap((overlay) => overlay.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
   ])
 }
 
@@ -282,6 +295,56 @@ export async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeD
   }
 
   return plugins
+}
+
+export async function prepareRecipeDependencyOverlays(recipe: WorkspaceRecipe, recipeDirectory: string, extraPlugins: PreparedExtraPlugin[]): Promise<PreparedDependencyOverlay[]> {
+  const overlays: PreparedDependencyOverlay[] = []
+  for (const [index, overlay] of (recipe.inputs?.dependency_overlays ?? []).entries()) {
+    overlays.push(await prepareRecipeDependencyOverlay(overlay, recipeDirectory, extraPlugins, index))
+  }
+
+  return overlays
+}
+
+async function prepareRecipeDependencyOverlay(overlay: WorkspaceRecipeDependencyOverlay, recipeDirectory: string, extraPlugins: PreparedExtraPlugin[], index: number): Promise<PreparedDependencyOverlay> {
+  if (overlay.kind !== "composer-package") {
+    throw new Error(`Unsupported dependency overlay kind: ${overlay.kind}`)
+  }
+  if (!isComposerPackageName(overlay.package)) {
+    throw new Error(`Dependency overlay package must be a safe Composer package name: ${overlay.package}`)
+  }
+
+  const consumer = extraPlugins.find((plugin) => plugin.slug === overlay.consumer)
+  if (!consumer) {
+    throw new Error(`Dependency overlay consumer plugin was not found in inputs.extra_plugins: ${overlay.consumer}`)
+  }
+
+  const source = resolve(recipeDirectory, overlay.source)
+  await validateExistingDirectoryForOverlay(source, overlay.source)
+  const target = `${consumer.target}/vendor/${composerPackageVendorPath(overlay.package)}`
+  const digest = await directoryContentDigest(source)
+
+  return {
+    source,
+    sourceRef: overlay.source,
+    target,
+    package: overlay.package,
+    consumer: overlay.consumer,
+    type: "directory",
+    mode: "readonly",
+    cleanupPaths: [],
+    metadata: {
+      kind: "dependency-overlay",
+      index,
+      overlayKind: overlay.kind,
+      package: overlay.package,
+      source: overlay.source,
+      consumer: overlay.consumer,
+      target,
+      digest: { sha256: digest },
+      ...(overlay.metadata ? { userMetadata: overlay.metadata } : {}),
+    },
+  }
 }
 
 export async function prepareRecipeStagedFiles(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedStagedFile[]> {
@@ -1032,6 +1095,18 @@ export function pluginTarget(slug: string, loadAs: PreparedExtraPlugin["loadAs"]
   }
 
   return `/wordpress/wp-content/plugins/${slug}`
+}
+
+export function isComposerPackageName(value: string): boolean {
+  return /^[a-z0-9_.-]+\/[a-z0-9_.-]+$/.test(value)
+}
+
+export function composerPackageVendorPath(packageName: string): string {
+  if (!isComposerPackageName(packageName)) {
+    throw new Error(`Composer package name is not safe for a vendor path: ${packageName}`)
+  }
+
+  return packageName
 }
 
 export async function resolveRecipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin, recipeDirectory: string): Promise<string> {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,7 +1,7 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
-import { evaluateRecipeSourcePolicy, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
+import { recipeCommandDefinitions, validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 
 export interface RecipeValidationIssue {
   code: string
@@ -93,6 +93,7 @@ export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath
   validateRecipeRuntimeWordPressInstallMode(recipe.runtime?.wordpressInstallMode, recipePath)
   validateRecipeRuntimePreview(recipe.runtime?.preview, recipePath)
   validateRecipeMounts(recipe.inputs?.mounts, "mounts", recipePath)
+  validateRecipeDependencyOverlays(recipe.inputs?.dependency_overlays, recipePath)
 
   if (recipe.inputs && "extraPlugins" in recipe.inputs) {
     throw new Error(`Recipe inputs.extraPlugins is unsupported; use inputs.extra_plugins: ${recipePath}`)
@@ -354,6 +355,30 @@ function validateRecipeRuntimeOverlays(overlays: WorkspaceRecipeRuntimeOverlay[]
   }
 }
 
+function validateRecipeDependencyOverlays(overlays: WorkspaceRecipeDependencyOverlay[] | undefined, recipePath: string): void {
+  if (overlays && !Array.isArray(overlays)) {
+    throw new Error(`Recipe dependency_overlays must be an array: ${recipePath}`)
+  }
+
+  for (const overlay of overlays ?? []) {
+    if (overlay.kind !== "composer-package") {
+      throw new Error(`Recipe dependency overlay kind is unsupported: ${recipePath}`)
+    }
+    if (!overlay.package || typeof overlay.package !== "string") {
+      throw new Error(`Recipe dependency overlays must include package: ${recipePath}`)
+    }
+    if (!overlay.source || typeof overlay.source !== "string") {
+      throw new Error(`Recipe dependency overlays must include source: ${recipePath}`)
+    }
+    if (!overlay.consumer || typeof overlay.consumer !== "string") {
+      throw new Error(`Recipe dependency overlays must include consumer: ${recipePath}`)
+    }
+    if (overlay.metadata !== undefined && (!overlay.metadata || typeof overlay.metadata !== "object" || Array.isArray(overlay.metadata))) {
+      throw new Error(`Recipe dependency overlay metadata must be an object when provided: ${recipePath}`)
+    }
+  }
+}
+
 export async function validateWorkspaceRecipe(recipe: WorkspaceRecipe, recipePath: string): Promise<RecipeValidationIssue[]> {
   return validateWorkspaceRecipeSemantics(recipe, recipePath)
 }
@@ -447,6 +472,23 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
     if (pluginSource) {
       await validateExistingFile(join(pluginSource, pluginFile.slice(slug.length + 1)), `${path}.pluginFile`, addIssue)
     }
+  }
+
+  const extraPluginSlugs = new Set(recipeExtraPlugins(recipe).map((plugin) => recipeExtraPluginSlug(plugin)))
+  for (const [index, overlay] of (recipe.inputs?.dependency_overlays ?? []).entries()) {
+    const path = `$.inputs.dependency_overlays[${index}]`
+    await validateExistingDirectory(resolve(recipeDirectory, overlay.source), `${path}.source`, addIssue)
+    if (!extraPluginSlugs.has(overlay.consumer)) {
+      addIssue("unknown-dependency-overlay-consumer", `${path}.consumer`, `Dependency overlay consumer must match an inputs.extra_plugins slug: ${overlay.consumer}`)
+    }
+    if (!isComposerPackageName(overlay.package)) {
+      addIssue("invalid-composer-package", `${path}.package`, `Dependency overlay package must be a safe Composer package name: ${overlay.package}`)
+      continue
+    }
+
+    const consumerPlugin = recipeExtraPlugins(recipe).find((plugin) => recipeExtraPluginSlug(plugin) === overlay.consumer)
+    const loadAs = consumerPlugin?.loadAs ?? "plugin"
+    validateAbsoluteSandboxPath(`${pluginTarget(overlay.consumer, loadAs)}/vendor/${composerPackageVendorPath(overlay.package)}`, `${path}.target`, addIssue)
   }
 
   await validateRecipePluginRuntime(recipe.inputs?.pluginRuntime, addIssue)

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -63,6 +63,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "array",
             items: { $ref: "#/$defs/extraPlugin" },
           },
+          dependency_overlays: {
+            type: "array",
+            description: "Typed local dependency overlays mounted into a consumer plugin before setup, activation, and workflow steps.",
+            items: { $ref: "#/$defs/dependencyOverlay" },
+          },
           secretEnv: {
             type: "array",
             items: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" },
@@ -414,6 +419,18 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           activate: { type: "boolean" },
           loadAs: { enum: ["plugin", "mu-plugin"] },
           sha256: { type: "string", pattern: "^[a-fA-F0-9]{64}$" },
+        },
+      },
+      dependencyOverlay: {
+        type: "object",
+        additionalProperties: false,
+        required: ["kind", "package", "source", "consumer"],
+        properties: {
+          kind: { const: "composer-package" },
+          package: { type: "string", pattern: "^[a-z0-9_.-]+/[a-z0-9_.-]+$" },
+          source: { type: "string" },
+          consumer: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+          metadata: { $ref: "#/$defs/metadata" },
         },
       },
       pluginRuntime: {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -251,6 +251,14 @@ export interface WorkspaceRecipeExtraPlugin {
   loadAs?: "plugin" | "mu-plugin"
 }
 
+export interface WorkspaceRecipeDependencyOverlay {
+  kind: "composer-package"
+  package: string
+  source: string
+  consumer: string
+  metadata?: Record<string, unknown>
+}
+
 export type WorkspaceRecipeSiteSeedType = "fixture" | "parent_site"
 export type WorkspaceRecipeSiteSeedFormat = "json" | (string & {})
 
@@ -341,6 +349,7 @@ export interface WorkspaceRecipe {
     workspaces?: WorkspaceRecipeWorkspace[]
     mounts?: WorkspaceRecipeMount[]
     extra_plugins?: WorkspaceRecipeExtraPlugin[]
+    dependency_overlays?: WorkspaceRecipeDependencyOverlay[]
     secretEnv?: string[]
     pluginRuntime?: WorkspaceRecipePluginRuntime
     fixtureDatabases?: WorkspaceRecipeFixtureDatabase[]

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -16,6 +16,7 @@ const input = {
     { slug: "caller-runtime", path: "/components/caller-runtime", loadAs: "mu-plugin" },
     { slug: "caller-runtime-tools", path: "/components/caller-runtime-tools", loadAs: "mu-plugin" },
   ],
+  dependency_overlays: [{ kind: "composer-package", package: "acme/dependency", source: "/components/dependency", consumer: "caller-runtime" }],
   provider_plugin_paths: ["/components/ai-provider-for-openai"],
   artifacts_path: "/tmp/wp-codebox-artifacts",
 }
@@ -34,6 +35,8 @@ assert.equal(extraPlugins.find((plugin) => plugin?.slug === "ai-provider-for-ope
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "agents-api")?.activate, false)
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "caller-runtime")?.activate, false)
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "caller-runtime-tools")?.activate, false)
+assert.equal(recipe.inputs?.dependency_overlays?.[0]?.consumer, "caller-runtime")
+assert.equal(recipe.inputs?.dependency_overlays?.[0]?.package, "acme/dependency")
 
 const muPluginInstallCode = installMuPluginsCode(extraPlugins)
 assert.ok(muPluginInstallCode?.includes("define( 'DATAMACHINE_WORKSPACE_PATH', '/workspace' );"))

--- a/scripts/recipe-dependency-overlay-smoke.ts
+++ b/scripts/recipe-dependency-overlay-smoke.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-dependency-overlay-"))
+
+try {
+  const consumer = join(workspace, "consumer")
+  const dependency = join(workspace, "dependency")
+  await mkdir(consumer, { recursive: true })
+  await mkdir(dependency, { recursive: true })
+  await writeFile(join(consumer, "consumer.php"), `<?php
+/**
+ * Plugin Name: Consumer
+ */
+`)
+  await writeFile(join(dependency, "marker.txt"), "sibling dependency overlay\n")
+
+  const recipePath = join(workspace, "recipe.json")
+  const artifacts = join(workspace, "artifacts")
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: "latest" },
+    inputs: {
+      extra_plugins: [{
+        source: consumer,
+        slug: "consumer",
+        pluginFile: "consumer/consumer.php",
+        activate: false,
+      }],
+      dependency_overlays: [{
+        kind: "composer-package",
+        package: "acme/dependency",
+        source: dependency,
+        consumer: "consumer",
+        metadata: { ref: "sibling-dev" },
+      }],
+    },
+    workflow: {
+      steps: [{
+        command: "wordpress.run-php",
+        args: ["code=echo file_get_contents(WP_PLUGIN_DIR . '/consumer/vendor/acme/dependency/marker.txt');"],
+      }],
+    },
+    artifacts: { directory: artifacts },
+  }, null, 2)}\n`)
+
+  const dryRun = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--dry-run", "--json"], { cwd: root })
+  const dryRunOutput = JSON.parse(dryRun.stdout)
+  assert.equal(dryRunOutput.success, true, dryRunOutput.error?.message)
+  assert.equal(dryRunOutput.plan.mounts.some((mount: { target?: string; metadata?: { kind?: string; package?: string }; planned?: string }) => mount.metadata?.kind === "dependency-overlay" && mount.metadata.package === "acme/dependency" && mount.target === "/wordpress/wp-content/plugins/consumer/vendor/acme/dependency" && mount.planned === "existing"), true)
+
+  const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--json"], { cwd: root })
+  const output = JSON.parse(stdout)
+  assert.equal(output.success, true, output.error?.message)
+  assert.equal(output.executions[0]?.stdout, "sibling dependency overlay\n")
+
+  const metadata = JSON.parse(await readFile(join(output.artifacts.directory, "metadata.json"), "utf8"))
+  const overlay = metadata.context.preparedDependencyOverlays[0]
+  assert.equal(overlay.target, "/wordpress/wp-content/plugins/consumer/vendor/acme/dependency")
+  assert.equal(overlay.package, "acme/dependency")
+  assert.equal(overlay.consumer, "consumer")
+  assert.match(overlay.metadata.digest.sha256, /^[a-f0-9]{64}$/)
+
+  console.log("Recipe dependency overlay smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -147,6 +147,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-site-seed-smoke"),
       tsxSmoke("recipe-fixture-probes-smoke"),
       tsxSmoke("recipe-staged-files-smoke"),
+      tsxSmoke("recipe-dependency-overlay-smoke"),
       tsxSmoke("recipe-workspace-seed-excludes-smoke"),
       tsxSmoke("recipe-runtime-evidence-smoke"),
       tsxSmoke("recipe-run-timeout-smoke"),


### PR DESCRIPTION
## Summary
- Add `inputs.dependency_overlays` to the workspace recipe contract for typed Composer package overlays into mounted consumer plugins.
- Prepare, validate, mount, dry-run, and record dependency overlay provenance before plugin activation/setup/workflow steps.
- Pass dependency overlays through agent-task/fanout inputs and cover the contract with a focused Playground smoke.

Closes #836.

## Verification
- `npm run build`
- `npm run smoke -- --command=recipe-dependency-overlay-smoke`
- `npm run smoke -- --command=recipe-dry-run-smoke`
- `npm run smoke -- --command=agent-task-run-runtime-components-smoke`
- `npm run smoke -- --command=recipe-run-php-plugin-load-smoke`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the WP Codebox/Static Site Importer verification gap, drafted the tracking issue, implemented the dependency overlay contract and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge decisions.