### PR TITLE
Add replayable WordPress site bundle foundation

### DIFF
--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -4,4 +4,6 @@ export { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "./bro
 export { createHostCommandTool, type HostCommandToolConfig } from "./host-command-tool.js"
 export { PlaygroundRuntimeBackend, createPlaygroundRuntimeBackend } from "./playground-runtime.js"
 export { preflightPhpWasmRuntimeAssets, PhpWasmRuntimeAssetIntegrityError, type PhpWasmRuntimeAssetPreflight, type PhpWasmRuntimeAssetPreflightOptions } from "./php-wasm-preflight.js"
+export { buildReplayableWordPressSiteBlueprint, buildReplayableWordPressSiteLimitations, writeReplayableWordPressSiteBundle, type ReplayableWordPressSiteBundle, type ReplayableWordPressSiteBundleManifest, type ReplayableWordPressSiteBundleOptions } from "./replayable-wordpress-site-bundle.js"
+export type { RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
 export type { PlaygroundCliModule } from "./playground-cli-runner.js"

--- a/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
+++ b/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
@@ -1,0 +1,172 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import {
+  artifactManifestFile,
+  calculateArtifactContentDigest,
+  refreshArtifactManifestFileSha256s,
+  type ArtifactManifest,
+  type RuntimeInfo,
+} from "@automattic/wp-codebox-core"
+import { runtimeSnapshotRestorePhp, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
+
+export interface ReplayableWordPressSiteBundleOptions {
+  directory: string
+  id?: string
+  createdAt?: string
+  source?: Record<string, unknown>
+  landingPage?: string
+}
+
+export interface ReplayableWordPressSiteBundleManifest extends ArtifactManifest {
+  schema: "wp-codebox/replayable-wordpress-site/v1"
+  version: 1
+  replayableWordPressSite: {
+    blueprintPath: "blueprint.json"
+    snapshotPath: "files/runtime-snapshot.json"
+    limitationsPath: "files/replay-limitations.json"
+    replayStatus: "replayable-runtime-state"
+    source?: Record<string, unknown>
+  }
+}
+
+export interface ReplayableWordPressSiteBundle {
+  id: string
+  directory: string
+  manifestPath: string
+  blueprintPath: string
+  snapshotPath: string
+  limitationsPath: string
+  contentDigest: string
+  createdAt: string
+  manifest: ReplayableWordPressSiteBundleManifest
+}
+
+export async function writeReplayableWordPressSiteBundle(
+  snapshot: RuntimeSnapshotArtifact,
+  options: ReplayableWordPressSiteBundleOptions,
+): Promise<ReplayableWordPressSiteBundle> {
+  const createdAt = options.createdAt ?? new Date().toISOString()
+  const directory = options.directory
+  const filesDirectory = join(directory, "files")
+  await mkdir(filesDirectory, { recursive: true })
+
+  const blueprint = buildReplayableWordPressSiteBlueprint(snapshot, options)
+  const limitations = buildReplayableWordPressSiteLimitations(snapshot, options)
+
+  await writeJson(join(directory, "blueprint.json"), blueprint)
+  await writeJson(join(filesDirectory, "runtime-snapshot.json"), snapshot)
+  await writeJson(join(filesDirectory, "replay-limitations.json"), limitations)
+
+  const contentInputs = ["blueprint.json", "files/runtime-snapshot.json", "files/replay-limitations.json"]
+  const contentDigest = await calculateArtifactContentDigest(directory, contentInputs)
+  const id = options.id ?? `replayable-wordpress-site-sha256-${contentDigest}`
+  const manifest: ReplayableWordPressSiteBundleManifest = {
+    schema: "wp-codebox/replayable-wordpress-site/v1",
+    version: 1,
+    id,
+    contentDigest: {
+      algorithm: "sha256",
+      inputs: contentInputs,
+      value: contentDigest,
+    },
+    createdAt,
+    runtime: runtimeInfoForReplayableWordPressSite(snapshot, id, createdAt, blueprint),
+    files: [
+      artifactManifestFile("manifest.json", "manifest", "application/json"),
+      artifactManifestFile("blueprint.json", "playground-blueprint", "application/json"),
+      artifactManifestFile("files/runtime-snapshot.json", "runtime-snapshot", "application/json"),
+      artifactManifestFile("files/replay-limitations.json", "replay-limitations", "application/json"),
+    ],
+    replayableWordPressSite: {
+      blueprintPath: "blueprint.json",
+      snapshotPath: "files/runtime-snapshot.json",
+      limitationsPath: "files/replay-limitations.json",
+      replayStatus: "replayable-runtime-state",
+      ...(options.source ? { source: options.source } : {}),
+    },
+  }
+
+  await refreshArtifactManifestFileSha256s(directory, manifest)
+  await writeJson(join(directory, "manifest.json"), manifest)
+  await refreshArtifactManifestFileSha256s(directory, manifest)
+  await writeJson(join(directory, "manifest.json"), manifest)
+
+  return {
+    id,
+    directory,
+    manifestPath: join(directory, "manifest.json"),
+    blueprintPath: join(directory, "blueprint.json"),
+    snapshotPath: join(filesDirectory, "runtime-snapshot.json"),
+    limitationsPath: join(filesDirectory, "replay-limitations.json"),
+    contentDigest,
+    createdAt,
+    manifest,
+  }
+}
+
+export function buildReplayableWordPressSiteBlueprint(
+  snapshot: RuntimeSnapshotArtifact,
+  options: Pick<ReplayableWordPressSiteBundleOptions, "landingPage"> = {},
+): Record<string, unknown> {
+  return {
+    $schema: "https://playground.wordpress.net/blueprint-schema.json",
+    preferredVersions: {
+      wp: snapshot.compatibility.wordpressVersion,
+      php: snapshot.compatibility.phpVersion,
+    },
+    landingPage: options.landingPage ?? "/",
+    steps: [
+      {
+        step: "runPHP",
+        code: runtimeSnapshotRestorePhp(snapshot),
+      },
+    ],
+  }
+}
+
+export function buildReplayableWordPressSiteLimitations(
+  snapshot: RuntimeSnapshotArtifact,
+  options: Pick<ReplayableWordPressSiteBundleOptions, "source"> = {},
+): Record<string, unknown> {
+  return {
+    schema: "wp-codebox/replayable-wordpress-site-limitations/v1",
+    replayStatus: "replayable-runtime-state",
+    captured: {
+      databaseTables: snapshot.database.tables.length,
+      wpContentFiles: snapshot.files.length,
+      activeTheme: snapshot.metadata.activeTheme,
+      activePlugins: snapshot.metadata.activePlugins,
+    },
+    source: options.source ?? { kind: "unspecified" },
+    limitations: [
+      "The bundle replays captured database tables and wp-content files only.",
+      "The exporter input must be policy-approved by the caller; this builder does not acquire or authorize private site sources.",
+      "Browser/editor session state and external services are not captured.",
+    ],
+  }
+}
+
+function runtimeInfoForReplayableWordPressSite(
+  snapshot: RuntimeSnapshotArtifact,
+  id: string,
+  createdAt: string,
+  blueprint: Record<string, unknown>,
+): RuntimeInfo {
+  return {
+    id,
+    backend: "wordpress-playground",
+    status: "destroyed",
+    createdAt,
+    environment: {
+      kind: "wordpress",
+      name: snapshot.metadata.activeTheme ? `replayable-site-${snapshot.metadata.activeTheme}` : "replayable-wordpress-site",
+      version: snapshot.compatibility.wordpressVersion,
+      phpVersion: snapshot.compatibility.phpVersion,
+      blueprint,
+    },
+  }
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}

--- a/scripts/replayable-wordpress-site-bundle-smoke.ts
+++ b/scripts/replayable-wordpress-site-bundle-smoke.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { verifyArtifactBundle } from "@automattic/wp-codebox-core"
+import { writeReplayableWordPressSiteBundle, type RuntimeSnapshotArtifact } from "../packages/runtime-playground/src/index.js"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-replayable-site-"))
+
+try {
+  const bundleDirectory = join(workspace, "bundle")
+  const snapshot = snapshotFixture()
+  const bundle = await writeReplayableWordPressSiteBundle(snapshot, {
+    directory: bundleDirectory,
+    createdAt: "2026-06-08T00:00:00.000Z",
+    source: { kind: "external-wordpress-site", policy: "caller-approved" },
+    landingPage: "/sample-page/",
+  })
+
+  const verification = await verifyArtifactBundle(bundleDirectory)
+  assert.equal(verification.valid, true)
+  assert.deepEqual(verification.violations, [])
+
+  const manifest = JSON.parse(await readFile(bundle.manifestPath, "utf8"))
+  assert.equal(manifest.schema, "wp-codebox/replayable-wordpress-site/v1")
+  assert.equal(manifest.replayableWordPressSite.blueprintPath, "blueprint.json")
+  assert.equal(manifest.replayableWordPressSite.snapshotPath, "files/runtime-snapshot.json")
+  assert.equal(manifest.replayableWordPressSite.replayStatus, "replayable-runtime-state")
+  assert.equal(manifest.contentDigest.value, bundle.contentDigest)
+  assert.equal(manifest.files.every((file: { sha256?: { value?: string } }) => /^[a-f0-9]{64}$/.test(file.sha256?.value ?? "")), true)
+
+  const blueprint = JSON.parse(await readFile(bundle.blueprintPath, "utf8"))
+  assert.equal(blueprint.landingPage, "/sample-page/")
+  assert.equal(blueprint.preferredVersions.wp, "6.8.1")
+  assert.equal(blueprint.steps[0].step, "runPHP")
+  assert.match(blueprint.steps[0].code, /wp-codebox\/wordpress-runtime-snapshot\/v1/)
+  assert.match(blueprint.steps[0].code, /Sample Page/)
+
+  const limitations = JSON.parse(await readFile(bundle.limitationsPath, "utf8"))
+  assert.equal(limitations.schema, "wp-codebox/replayable-wordpress-site-limitations/v1")
+  assert.equal(limitations.captured.databaseTables, 1)
+  assert.equal(limitations.captured.wpContentFiles, 1)
+  assert.equal(limitations.source.kind, "external-wordpress-site")
+
+  console.log("Replayable WordPress site bundle smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+function snapshotFixture(): RuntimeSnapshotArtifact {
+  return {
+    schema: "wp-codebox/wordpress-runtime-snapshot/v1",
+    version: 1,
+    id: "snapshot-fixture",
+    createdAt: "2026-06-08T00:00:00.000Z",
+    compatibility: {
+      backend: "wordpress-playground",
+      wordpressVersion: "6.8.1",
+      phpVersion: "8.3",
+    },
+    metadata: {
+      runtime: {
+        id: "external-source-fixture",
+        backend: "wordpress-playground",
+        environment: { kind: "wordpress", name: "external-source-fixture", version: "6.8.1" },
+        createdAt: "2026-06-08T00:00:00.000Z",
+        status: "destroyed",
+      },
+      mounts: [],
+      mountedInputs: [],
+      activeTheme: "twentytwentyfive",
+      activePlugins: ["hello.php"],
+      wpContentPath: "/example/wp-content",
+    },
+    database: {
+      tables: [
+        {
+          name: "wp_posts",
+          createSql: "CREATE TABLE wp_posts (ID bigint unsigned NOT NULL, post_title text NOT NULL)",
+          rows: [{ ID: 1, post_title: "Sample Page" }],
+          rowCount: 1,
+        },
+      ],
+    },
+    files: [
+      {
+        scope: "wp-content",
+        path: "themes/twentytwentyfive/style.css",
+        bytes: 20,
+        sha256: "0".repeat(64),
+        base64: Buffer.from("/* fixture theme */\n").toString("base64"),
+      },
+    ],
+    hashes: {
+      database: { algorithm: "sha256", value: "1".repeat(64) },
+      files: { algorithm: "sha256", value: "2".repeat(64) },
+    },
+  }
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -82,6 +82,7 @@ export const smokeGroups = {
       tsxSmoke("mounted-workspace-diff-smoke"),
       tsxSmoke("artifact-contract-smoke"),
       tsxSmoke("durable-artifact-preview-smoke"),
+      tsxSmoke("replayable-wordpress-site-bundle-smoke"),
       tsxSmoke("external-adapter-contract-smoke"),
     ],
   },


### PR DESCRIPTION
## Summary
- Adds a reusable `wp-codebox/replayable-wordpress-site/v1` bundle writer that turns a captured WordPress runtime snapshot payload into a verified replay bundle.
- Emits `manifest.json`, `blueprint.json`, `files/runtime-snapshot.json`, and `files/replay-limitations.json` with SHA-256 manifest coverage.
- Exports the new playground helpers and adds a smoke test to the artifact smoke group.

## Scope
This is the narrow upstream foundation for #838. It does not yet acquire arbitrary local/remote WordPress sources; callers still need to capture or provide a `RuntimeSnapshotArtifact` through a policy-approved source path.

## Verification
- `npm run build`
- `npx tsx scripts/replayable-wordpress-site-bundle-smoke.ts`
- `npx tsx scripts/artifact-bundle-verifier-smoke.ts`
- `npx tsx scripts/runtime-snapshot-restore-smoke.ts`

## Remaining contract
- Add a policy-controlled arbitrary-site acquisition command/API that can capture a WordPress site path or WP-CLI target into the existing `RuntimeSnapshotArtifact` shape.
- Decide how large external-site snapshots should be packaged when inline `runPHP` blueprint payloads become too large for practical Playground replay.
- Wire Workflow Bench to consume the `wp-codebox/replayable-wordpress-site/v1` bundle as a durable generated-site artifact.

Closes part of #838.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting existing snapshot/artifact code, drafting the reusable bundle foundation, adding the smoke test, and running targeted verification. Chris remains responsible for review and merge.