### PR TITLE
Resolve extra-plugin entry file by header when dir name differs

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -1128,9 +1128,51 @@ export async function resolveRecipeExtraPluginFile(plugin: WorkspaceRecipeExtraP
         // Try the next common plugin entrypoint.
       }
     }
+
+    // The conventional entrypoints (`<slug>.php`, `plugin.php`) do not exist.
+    // This is common when the source directory was renamed (e.g. a Lab
+    // workspace synced under a uniquified `<slug>-<hash>-<uuid>` directory), so
+    // the entry filename no longer matches the directory name. Fall back to the
+    // single top-level `*.php` file that declares a WordPress plugin header.
+    const headerEntry = await findPluginEntryFileByHeader(pluginSource)
+    if (headerEntry) {
+      return `${slug}/${headerEntry}`
+    }
   }
 
   return `${slug}/${slug}.php`
+}
+
+/**
+ * Locate a plugin's entry file by scanning top-level `*.php` files for a
+ * WordPress `Plugin Name:` header. Returns the entry filename (relative to the
+ * plugin source directory) or undefined when none is found.
+ */
+async function findPluginEntryFileByHeader(pluginSource: string): Promise<string | undefined> {
+  let entries: string[]
+  try {
+    entries = (await readdir(pluginSource, { withFileTypes: true }))
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".php"))
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return undefined
+  }
+
+  for (const name of entries) {
+    try {
+      // Plugin headers live in the file's opening comment block; reading the
+      // first 8 KiB is enough and avoids loading large files.
+      const handle = await readFile(join(pluginSource, name), "utf8")
+      if (/^[\s\S]{0,8192}?Plugin Name:\s*\S/m.test(handle)) {
+        return name
+      }
+    } catch {
+      // Unreadable file; try the next candidate.
+    }
+  }
+
+  return undefined
 }
 
 export function activeExtraPluginFiles(extraPlugins: BootActivePluginCandidate[]): string[] {

--- a/scripts/extra-plugin-entry-file-smoke.ts
+++ b/scripts/extra-plugin-entry-file-smoke.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict"
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { resolveRecipeExtraPluginFile } from "../packages/cli/src/recipe-sources.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-extra-plugin-entry-"))
+
+try {
+  // 1. Conventional <slug>/<slug>.php is preferred when present.
+  const conventional = join(root, "my-plugin")
+  await mkdir(conventional, { recursive: true })
+  await writeFile(join(conventional, "my-plugin.php"), "<?php\n/* Plugin Name: My Plugin */\n")
+  assert.equal(
+    await resolveRecipeExtraPluginFile({ source: conventional }, root),
+    "my-plugin/my-plugin.php",
+    "conventional <slug>/<slug>.php should resolve",
+  )
+
+  // 2. Renamed directory (e.g. a Lab-synced uniquified dir) whose entry file no
+  //    longer matches the directory name: resolve by Plugin Name header.
+  const renamed = join(root, "ai-provider-for-claude-code-352e5891f975-abc-123")
+  await mkdir(renamed, { recursive: true })
+  await writeFile(join(renamed, "readme.txt"), "not php")
+  await writeFile(join(renamed, "uninstall.php"), "<?php\n// no plugin header\n")
+  await writeFile(
+    join(renamed, "ai-provider-for-claude-code.php"),
+    "<?php\n/**\n * Plugin Name: AI Provider for Claude Code\n */\n",
+  )
+  assert.equal(
+    await resolveRecipeExtraPluginFile({ source: renamed }, root),
+    "ai-provider-for-claude-code-352e5891f975-abc-123/ai-provider-for-claude-code.php",
+    "renamed dir should resolve the entry file via the Plugin Name header",
+  )
+
+  // 3. plugin.php convention still works.
+  const pluginPhp = join(root, "weird-name")
+  await mkdir(pluginPhp, { recursive: true })
+  await writeFile(join(pluginPhp, "plugin.php"), "<?php\n/* Plugin Name: Weird */\n")
+  assert.equal(
+    await resolveRecipeExtraPluginFile({ source: pluginPhp }, root),
+    "weird-name/plugin.php",
+    "plugin.php convention should resolve",
+  )
+
+  // 4. Explicit pluginFile always wins.
+  assert.equal(
+    await resolveRecipeExtraPluginFile({ source: renamed, pluginFile: "custom/entry.php" }, root),
+    "custom/entry.php",
+    "explicit pluginFile should take precedence",
+  )
+
+  // 5. No php / no header: falls back to <slug>/<slug>.php (unchanged behavior).
+  const empty = join(root, "no-entry")
+  await mkdir(empty, { recursive: true })
+  assert.equal(
+    await resolveRecipeExtraPluginFile({ source: empty }, root),
+    "no-entry/no-entry.php",
+    "missing entry falls back to <slug>/<slug>.php",
+  )
+
+  console.log("extra-plugin-entry-file-smoke passed")
+} finally {
+  await rm(root, { recursive: true, force: true })
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -139,6 +139,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-build-cli-smoke"),
       tsxSmoke("recipe-run-php-plugin-load-smoke"),
       tsxSmoke("recipe-source-redirect-smoke"),
+      tsxSmoke("extra-plugin-entry-file-smoke"),
       tsxSmoke("run-php-plugin-diagnostics-smoke"),
       tsxSmoke("recipe-browser-smoke"),
       tsxSmoke("recipe-dry-run-smoke"),


### PR DESCRIPTION
## Summary
`resolveRecipeExtraPluginFile()` only tried `<slug>/<slug>.php` and `<slug>/plugin.php`, then fell back to `<slug>/<slug>.php`. When a plugin source directory is **renamed so its name no longer matches the entry file**, both conventional candidates miss and the recipe fails validation:

```
"code": "missing-path",
"path": "$.inputs.extra_plugins[3].pluginFile",
"message": "File does not exist: .../ai-provider-for-claude-code-352e5891f975-<uuid>-<ts>/
                                   ai-provider-for-claude-code-352e5891f975-<uuid>-<ts>.php"
```

This is exactly what happens with **Homeboy Lab cooking**: the provider plugin is synced to the runner under a uniquified `<slug>-<hash>-<uuid>-<ts>` directory, so the entry filename no longer equals the directory name.

## Fix
Add a header-based fallback in `resolveRecipeExtraPluginFile()`: when the conventional entrypoints are absent, scan the source directory's top-level `*.php` files for a WordPress `Plugin Name:` header and use that file as the entry. Behavior is otherwise unchanged:
- explicit `pluginFile` still wins,
- `<slug>/<slug>.php` and `<slug>/plugin.php` are still preferred,
- the `<slug>/<slug>.php` fallback is unchanged when no header is found.

## Testing
- New `scripts/extra-plugin-entry-file-smoke.ts` (registered in the recipe smoke group): conventional `<slug>.php`, **renamed dir resolved via Plugin Name header**, `plugin.php`, explicit `pluginFile` precedence, and no-entry fallback. All pass.
- `npm run build` clean; `recipe-source-redirect-smoke` still green (no regression).

## Context
Third and final layer of the Homeboy Lab cooking path (after the controller-side provider-config remap in Extra-Chill/homeboy#3774). With this, a Lab-synced provider plugin under a uniquified directory resolves its entry file and passes recipe validation.

Refs Extra-Chill/homeboy#3770.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Root-caused the `missing-path` recipe-validation failure to the basename-derived plugin entry file under Lab-uniquified dirs, implemented the header-scan fallback + smoke; Chris directed prioritizing Lab cooking.