### PR TITLE
Resolve provider plugin entry file by header in sandbox boot

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -581,7 +581,7 @@ function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
         sort($files);
         foreach ($files as $file) {
             $header = @file_get_contents($file, false, null, 0, 8192);
-            if (false !== $header && preg_match('/Plugin Name:\s*\S/', $header)) {
+            if (false !== $header && preg_match('/Plugin Name:[ \\t]*[^ \\t\\r\\n]/', $header)) {
                 $candidate = $slug . '/' . basename($file);
                 if (wp_codebox_plugin_entry_path($candidate)) {
                     return $candidate;
@@ -743,7 +743,7 @@ function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
         sort($files);
         foreach ($files as $file) {
             $header = @file_get_contents($file, false, null, 0, 8192);
-            if (false !== $header && preg_match('/Plugin Name:\s*\S/', $header)) {
+            if (false !== $header && preg_match('/Plugin Name:[ \\t]*[^ \\t\\r\\n]/', $header)) {
                 $candidate = $slug . '/' . basename($file);
                 if (wp_codebox_plugin_entry_path($candidate)) {
                     return $candidate;

--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -550,14 +550,46 @@ function wp_codebox_provider_plugin_entries(array $provider_plugins): array {
             continue;
         }
         $candidates = array($slug . '/plugin.php', $slug . '/' . $slug . '.php');
+        $matched = null;
         foreach ($candidates as $candidate) {
             if (wp_codebox_plugin_entry_path($candidate)) {
-                $entries[] = $candidate;
+                $matched = $candidate;
                 break;
             }
         }
+        if (null === $matched) {
+            $matched = wp_codebox_provider_plugin_entry_by_header($slug);
+        }
+        if (null !== $matched) {
+            $entries[] = $matched;
+        }
     }
     return $entries;
+}
+
+function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
+    // The conventional entries (<slug>/plugin.php, <slug>/<slug>.php) are absent.
+    // This happens when the plugin directory was renamed so its name no longer
+    // matches the entry file (e.g. a Lab workspace synced under a uniquified
+    // <slug>-<hash>-<uuid> directory). Fall back to the single top-level *.php
+    // file declaring a WordPress plugin header.
+    foreach (array(WP_PLUGIN_DIR . '/' . $slug, WPMU_PLUGIN_DIR . '/wp-codebox-runtime/' . $slug) as $dir) {
+        if (!is_dir($dir)) {
+            continue;
+        }
+        $files = glob($dir . '/*.php') ?: array();
+        sort($files);
+        foreach ($files as $file) {
+            $header = @file_get_contents($file, false, null, 0, 8192);
+            if (false !== $header && preg_match('/Plugin Name:\s*\S/', $header)) {
+                $candidate = $slug . '/' . basename($file);
+                if (wp_codebox_plugin_entry_path($candidate)) {
+                    return $candidate;
+                }
+            }
+        }
+    }
+    return null;
 }
 
 function wp_codebox_json_encode_sandbox_payload($value): string {
@@ -680,14 +712,46 @@ function wp_codebox_provider_plugin_entries(array $provider_plugins): array {
             continue;
         }
         $candidates = array($slug . '/plugin.php', $slug . '/' . $slug . '.php');
+        $matched = null;
         foreach ($candidates as $candidate) {
             if (wp_codebox_plugin_entry_path($candidate)) {
-                $entries[] = $candidate;
+                $matched = $candidate;
                 break;
             }
         }
+        if (null === $matched) {
+            $matched = wp_codebox_provider_plugin_entry_by_header($slug);
+        }
+        if (null !== $matched) {
+            $entries[] = $matched;
+        }
     }
     return $entries;
+}
+
+function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
+    // The conventional entries (<slug>/plugin.php, <slug>/<slug>.php) are absent.
+    // This happens when the plugin directory was renamed so its name no longer
+    // matches the entry file (e.g. a Lab workspace synced under a uniquified
+    // <slug>-<hash>-<uuid> directory). Fall back to the single top-level *.php
+    // file declaring a WordPress plugin header.
+    foreach (array(WP_PLUGIN_DIR . '/' . $slug, WPMU_PLUGIN_DIR . '/wp-codebox-runtime/' . $slug) as $dir) {
+        if (!is_dir($dir)) {
+            continue;
+        }
+        $files = glob($dir . '/*.php') ?: array();
+        sort($files);
+        foreach ($files as $file) {
+            $header = @file_get_contents($file, false, null, 0, 8192);
+            if (false !== $header && preg_match('/Plugin Name:\s*\S/', $header)) {
+                $candidate = $slug . '/' . basename($file);
+                if (wp_codebox_plugin_entry_path($candidate)) {
+                    return $candidate;
+                }
+            }
+        }
+    }
+    return null;
 }
 
 $activation_results = array();


### PR DESCRIPTION
## Summary
The sandbox boot loader (`agentSandboxRunCode` / `agentRuntimeProbeCode`) resolved provider plugin entries only as `<slug>/plugin.php` or `<slug>/<slug>.php`. When the plugin directory is renamed so its name no longer matches the entry file — notably a Homeboy **Lab** workspace synced under a uniquified `<slug>-<hash>-<uuid>` directory — neither candidate exists, the provider plugin is **never loaded**, and the provider fails to register (`Provider claude-code is not registered in wp-ai-client`) even though it is mounted.

Add a header-based fallback (`wp_codebox_provider_plugin_entry_by_header`): when the conventional entries are absent, scan the plugin directory's top-level `*.php` files for a WordPress `Plugin Name:` header and load that file. Mirrors the recipe-builder fix in #840 but for the runtime boot loader. Conventional candidates are still preferred.

The header regex uses explicit character classes (`[ \t]`, `[^ \t\r\n]`) rather than `\s`/`\S` because the PHP is emitted from a JS template literal where `\s`/`\S` collapse — the escape-safe form survives into valid PHP.

## Evidence
End-to-end on the homeboy-lab runner: with this fix the renamed provider plugin loads, the `claude-code` provider registers, and a real Lab cook **succeeds** (agent wrote its file on the runner; `changed-files`/`agent_runtime success` captured).

## Testing
`agent-sandbox-code-smoke` passes; `npm run build` clean. Verified the emitted PHP regex matches a real `Plugin Name:` header.

Refs Extra-Chill/homeboy#3770.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Root-caused the empty provider_plugins (basename mismatch on Lab-uniquified dirs) and the template-literal regex-escaping bug, implemented + verified the header-scan on the live runner; Chris directed prioritizing Lab cooking.