### PR TITLE
Resolve agent-task secret env forwarding

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -935,11 +935,41 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	/** @param array<string,mixed> $input Ability input. @return array{inheritance_audit:array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>},process_secret_env:array<string,string>} */
 	private function inheritance_resolution_payload( array $input ): array {
 		$payload = WP_Codebox_Inheritance::resolution_payload( $input, fn( string $path ): string => $this->clean_path( $path ) );
+		$secret_env_names = $this->secret_env_names( $input, $payload['inheritance'] );
 
 		return array(
 			'inheritance_audit'  => $payload['inheritance'],
-			'process_secret_env' => $this->inheritance_process_secret_env_values( $payload['resolution']['connectors'] ?? array() ),
+			'process_secret_env' => array_merge(
+				$this->parent_process_secret_env_values( $secret_env_names ),
+				$this->inheritance_process_secret_env_values( $payload['resolution']['connectors'] ?? array() )
+			),
 		);
+	}
+
+	/** @param string[] $names Secret env names declared by the caller. @return array<string,string> */
+	private function parent_process_secret_env_values( array $names ): array {
+		$values = array();
+		foreach ( $names as $name ) {
+			$name = trim( (string) $name );
+			if ( 1 !== preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) {
+				continue;
+			}
+
+			$value = getenv( $name );
+			if ( false === $value && isset( $_ENV[ $name ] ) ) {
+				$value = $_ENV[ $name ];
+			}
+			if ( false === $value && isset( $_SERVER[ $name ] ) ) {
+				$value = $_SERVER[ $name ];
+			}
+
+			$value = false === $value ? '' : (string) $value;
+			if ( '' !== $value ) {
+				$values[ $name ] = $value;
+			}
+		}
+
+		return $values;
 	}
 
 	/** @param array<int,mixed> $connectors Raw inheritance connector rows. @return array<string,string> */

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -2044,6 +2044,10 @@ $captured_recipes  = array();
 $captured_secret_env = array();
 $captured_timeout  = null;
 $command_count     = 0;
+
+putenv( 'GITHUB_TOKEN=ghp-parent-env-fixture' );
+$_ENV['GITHUB_TOKEN'] = 'ghp-parent-env-fixture';
+
 $runner           = new WP_Codebox_Agent_Sandbox_Runner(
 	array(
 		'shell_available' => fn() => true,
@@ -2202,8 +2206,14 @@ $assert( 'runner recipe passes provider plugin path', str_contains( $captured_re
 $assert( 'runner recipe loads runtime components as mu-plugins', str_contains( $captured_recipe, '"slug":"agents-api","activate":false,"loadAs":"mu-plugin"' ) && str_contains( $captured_recipe, '"slug":"data-machine","activate":false,"loadAs":"mu-plugin"' ) && str_contains( $captured_recipe, '"slug":"data-machine-code","activate":false,"loadAs":"mu-plugin"' ) );
 $assert( 'runner recipe passes generic mount metadata', str_contains( $captured_recipe, 'example/editable-plugin' ) && str_contains( $captured_recipe, 'repo_root_relative_to_mount' ) );
 $assert( 'runner recipe passes secret env name only', str_contains( $captured_recipe, 'GITHUB_TOKEN' ) && ! str_contains( $captured_recipe, 'GITHUB_TOKEN=' ) );
+$assert( 'runner passes declared secret env value to command runner', ! is_wp_error( $result ) && 'ghp-parent-env-fixture' === ( $captured_secret_env['GITHUB_TOKEN'] ?? '' ) );
+$assert( 'runner keeps declared secret value out of recipe', ! str_contains( $captured_recipe, 'ghp-parent-env-fixture' ) );
+$assert( 'runner keeps declared secret value out of response', ! str_contains( json_encode( $result, JSON_UNESCAPED_SLASHES ), 'ghp-parent-env-fixture' ) );
 $assert( 'runner passes timeout to command runner and recipe', 7200 === $captured_timeout && str_contains( $captured_recipe, 'timeout-seconds=7200' ) );
 $assert( 'runner does not pass raw code options', ! str_contains( $captured_command, '--code ' ) && ! str_contains( $captured_command, '--code-file' ) );
+
+putenv( 'GITHUB_TOKEN' );
+unset( $_ENV['GITHUB_TOKEN'] );
 
 $caller_adapter_result = $runner->run(
 	array(


### PR DESCRIPTION
## Summary
- Forward declared `secret_env` names from the parent process environment into agent-task sandbox command execution.
- Preserve existing inheritance connector behavior, with connector-provided secret values overriding parent env values when both are present.
- Extend the WordPress plugin smoke test to prove declared secrets reach the command runner without leaking into recipes or responses.

## Testing
- `npm ci`
- `php tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Homeboy/WP Codebox secret propagation failure, drafted the implementation and smoke-test assertions; Chris reviews and owns the change.