### PR TITLE
Materialize sandbox mount writes before artifact capture

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -1,0 +1,183 @@
+import { createHash } from "node:crypto"
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import type { MountSpec } from "@automattic/wp-codebox-core"
+import type { PlaygroundCliServer } from "./preview-server.js"
+import { SKIPPED_CAPTURE_DIRECTORIES } from "./artifacts.js"
+
+interface HostMountSnapshot {
+  mountIndex: number
+  target: string
+  files: Record<string, string>
+}
+
+export interface VfsMountSnapshot {
+  mountIndex: number
+  target: string
+  files: Array<{
+    relativePath: string
+    sha256: string
+    contentsBase64?: string
+  }>
+}
+
+export interface MountMaterializationResult {
+  materialized: number
+  deleted: number
+  skipped: number
+}
+
+export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliServer, mounts: MountSpec[]): Promise<MountMaterializationResult> {
+  const writableDirectoryMounts = mounts
+    .map((mount, mountIndex) => ({ mount, mountIndex }))
+    .filter(({ mount }) => mount.mode === "readwrite" && mount.type !== "file")
+  if (writableDirectoryMounts.length === 0) {
+    return { materialized: 0, deleted: 0, skipped: 0 }
+  }
+
+  const hostSnapshots: HostMountSnapshot[] = []
+  for (const { mount, mountIndex } of writableDirectoryMounts) {
+    hostSnapshots.push({
+      mountIndex,
+      target: mount.target,
+      files: await hostFileHashes(mount.source),
+    })
+  }
+
+  const response = await server.playground.run({ code: vfsMountSnapshotPhp(hostSnapshots) })
+  const parsed = JSON.parse(response.text || "{}") as { mounts?: VfsMountSnapshot[] }
+  return applyVfsMountSnapshots(mounts, parsed.mounts ?? [])
+}
+
+export async function applyVfsMountSnapshots(mounts: MountSpec[], snapshots: VfsMountSnapshot[]): Promise<MountMaterializationResult> {
+  const result: MountMaterializationResult = { materialized: 0, deleted: 0, skipped: 0 }
+
+  for (const snapshot of snapshots) {
+    const mount = mounts[snapshot.mountIndex]
+    if (!mount || mount.mode !== "readwrite" || mount.type === "file") {
+      result.skipped++
+      continue
+    }
+
+    const present = new Set(snapshot.files.map((file) => file.relativePath))
+    const existing = await hostFileHashes(mount.source)
+
+    for (const file of snapshot.files) {
+      if (!file.contentsBase64) {
+        continue
+      }
+      const hostPath = join(mount.source, file.relativePath)
+      await mkdir(dirname(hostPath), { recursive: true })
+      await writeFile(hostPath, Buffer.from(file.contentsBase64, "base64"))
+      result.materialized++
+    }
+
+    for (const relativePath of Object.keys(existing)) {
+      if (present.has(relativePath)) {
+        continue
+      }
+      await rm(join(mount.source, relativePath), { force: true })
+      result.deleted++
+    }
+  }
+
+  return result
+}
+
+async function hostFileHashes(directory: string, relativeDirectory = ""): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+  let entries
+  try {
+    entries = await readdir(join(directory, relativeDirectory), { withFileTypes: true })
+  } catch {
+    return files
+  }
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && SKIPPED_CAPTURE_DIRECTORIES.has(entry.name)) {
+      continue
+    }
+    const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
+    const absolutePath = join(directory, relativePath)
+    if (entry.isDirectory()) {
+      Object.assign(files, await hostFileHashes(directory, relativePath))
+      continue
+    }
+    if (!entry.isFile()) {
+      continue
+    }
+    files[relativePath] = createHash("sha256").update(await readFile(absolutePath)).digest("hex")
+  }
+
+  return files
+}
+
+function vfsMountSnapshotPhp(hostSnapshots: HostMountSnapshot[]): string {
+  const payload = JSON.stringify(JSON.stringify({ mounts: hostSnapshots }))
+  return `<?php
+$payload = json_decode(${payload}, true);
+$skip = array_fill_keys(array('.git', 'node_modules'), true);
+
+function wp_codebox_vfs_mount_files(string $root, array $host_hashes, array $skip): array {
+    $files = array();
+    $walk = function (string $directory, string $relative_directory) use (&$walk, &$files, $root, $host_hashes, $skip): void {
+        if (!is_dir($directory)) {
+            return;
+        }
+        $entries = scandir($directory);
+        if (false === $entries) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+            if (isset($skip[$entry]) && is_dir($directory . '/' . $entry)) {
+                continue;
+            }
+            $relative_path = '' === $relative_directory ? $entry : $relative_directory . '/' . $entry;
+            $path = $directory . '/' . $entry;
+            if (is_dir($path)) {
+                $walk($path, $relative_path);
+                continue;
+            }
+            if (!is_file($path)) {
+                continue;
+            }
+            $hash = hash_file('sha256', $path);
+            $file = array(
+                'relativePath' => $relative_path,
+                'sha256' => $hash,
+            );
+            if (($host_hashes[$relative_path] ?? '') !== $hash) {
+                $contents = file_get_contents($path);
+                $file['contentsBase64'] = false === $contents ? '' : base64_encode($contents);
+            }
+            $files[] = $file;
+        }
+    };
+    $walk(rtrim($root, '/'), '');
+    return $files;
+}
+
+$mounts = array();
+foreach (($payload['mounts'] ?? array()) as $mount) {
+    $target = (string) ($mount['target'] ?? '');
+    if ('' === $target || !is_dir($target)) {
+        $mounts[] = array(
+            'mountIndex' => (int) ($mount['mountIndex'] ?? -1),
+            'target' => $target,
+            'files' => array(),
+        );
+        continue;
+    }
+    $mounts[] = array(
+        'mountIndex' => (int) ($mount['mountIndex'] ?? -1),
+        'target' => $target,
+        'files' => wp_codebox_vfs_mount_files($target, is_array($mount['files'] ?? null) ? $mount['files'] : array(), $skip),
+    );
+}
+
+echo wp_json_encode(array('schema' => 'wp-codebox/vfs-mount-snapshot/v1', 'mounts' => $mounts), JSON_UNESCAPED_SLASHES);
+`
+}

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -13,6 +13,7 @@ import { PlaygroundCommandCrashError, assertPlaygroundResponseOk, errorMessage, 
 import { startPlaygroundCliServer, type PlaygroundCliModule } from "./playground-cli-runner.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { collectPlaygroundArtifacts } from "./runtime-artifact-helpers.js"
+import { materializePlaygroundMountsFromVfs } from "./mount-materialization.js"
 import { runAbilityCommand, runBenchCommand, runCorePhpunitCommand, runPhpCommand, runPhpunitCommand, runPluginCheckCommand, runRestRequestCommand, runThemeCheckCommand } from "./wordpress-command-runners.js"
 import { PlaygroundSnapshotRestoreError, contentDigest, mountsFromSnapshot, runtimeSnapshotExportPhp, runtimeSnapshotPayload, runtimeSnapshotRestorePhp, runtimeSpecFromSnapshot, snapshotDigest, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
 import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
@@ -335,6 +336,13 @@ class PlaygroundRuntime implements Runtime {
   }
 
   async collectArtifacts(spec: ArtifactSpec = {}): Promise<ArtifactBundle> {
+    if (this.cliServerPromise) {
+      const materialization = await materializePlaygroundMountsFromVfs(await this.cliServerPromise, this.mounts)
+      if (materialization.materialized > 0 || materialization.deleted > 0 || materialization.skipped > 0) {
+        this.recordEvent("runtime.mounts.materialized", { ...materialization })
+      }
+    }
+
     return collectPlaygroundArtifacts({
       artifactRoot: this.artifactRoot,
       runtimeId: this.runtimeId,

--- a/scripts/mounted-workspace-diff-smoke.ts
+++ b/scripts/mounted-workspace-diff-smoke.ts
@@ -6,6 +6,7 @@ import { join } from "node:path"
 import { promisify } from "node:util"
 import type { MountSpec } from "@automattic/wp-codebox-core"
 import { ArtifactRedactor, buildArtifactReview } from "../packages/runtime-playground/src/artifacts.js"
+import { applyVfsMountSnapshots } from "../packages/runtime-playground/src/mount-materialization.js"
 import { captureMountDiffs } from "../packages/runtime-playground/src/mounted-artifact-capture.js"
 
 const execFileAsync = promisify(execFile)
@@ -150,6 +151,50 @@ try {
   assert.match(gitResult.patch, /\+cooked by the agent/)
   assert.match(gitResult.patch, /\+\/\/ edited by agent/)
   assert.match(gitResult.patch, /deleted file mode 100644/)
+
+  const vfsBackedRepo = join(root, "vfs-backed-repo")
+  await mkdir(vfsBackedRepo, { recursive: true })
+  await execFileAsync("git", ["-C", vfsBackedRepo, "init", "-q"])
+  await execFileAsync("git", ["-C", vfsBackedRepo, "config", "user.email", "smoke@wp-codebox.test"])
+  await execFileAsync("git", ["-C", vfsBackedRepo, "config", "user.name", "wp-codebox smoke"])
+  await writeFile(join(vfsBackedRepo, "committed.php"), "<?php\n// committed\n")
+  await writeFile(join(vfsBackedRepo, "remove-me.txt"), "delete this\n")
+  await execFileAsync("git", ["-C", vfsBackedRepo, "add", "."])
+  await execFileAsync("git", ["-C", vfsBackedRepo, "commit", "-q", "-m", "baseline"])
+
+  const vfsMounts: MountSpec[] = [{
+    type: "directory",
+    source: vfsBackedRepo,
+    target: "/workspace/vfs-backed-repo",
+    mode: "readwrite",
+    metadata: { kind: "homeboy-dmc-workspace", workspace_slug: "vfs-backed-repo" },
+  }]
+  const materialized = await applyVfsMountSnapshots(vfsMounts, [{
+    mountIndex: 0,
+    target: "/workspace/vfs-backed-repo",
+    files: [
+      {
+        relativePath: "committed.php",
+        sha256: "unused",
+        contentsBase64: Buffer.from("<?php\n// edited inside playground\n").toString("base64"),
+      },
+      {
+        relativePath: "AGENT_WROTE_THIS.md",
+        sha256: "unused",
+        contentsBase64: Buffer.from("created inside playground\n").toString("base64"),
+      },
+    ],
+  }])
+  assert.equal(materialized.materialized, 2)
+  assert.equal(materialized.deleted, 1)
+
+  const vfsResult = await captureMountDiffs(artifactRoot, filesDirectory, vfsMounts, new ArtifactRedactor())
+  const vfsChanged = new Map(vfsResult.changedFiles.files.map((file) => [file.relativePath, file]))
+  assert.equal(vfsChanged.get("AGENT_WROTE_THIS.md")?.status, "added")
+  assert.equal(vfsChanged.get("committed.php")?.status, "modified")
+  assert.equal(vfsChanged.get("remove-me.txt")?.status, "deleted")
+  assert.match(vfsResult.patch, /created inside playground/)
+  assert.match(vfsResult.patch, /edited inside playground/)
 
   const review = buildArtifactReview({
     artifactId: "artifact-bundle-test",


### PR DESCRIPTION
## Summary
- Materializes readwrite Playground VFS mount changes back into host mount sources before artifact capture.
- Preserves the existing mount diff pipeline so `changed-files.json` and `patch.diff` reflect sandbox workspace writes.
- Adds smoke coverage for VFS-only edits producing added, modified, and deleted files in promotion artifacts.

Fixes #845.

## Testing
- `npm run smoke -- --command=mounted-workspace-diff-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the sandbox artifact capture gap, implemented the VFS mount materialization helper, and added targeted smoke coverage; Chris reviews and owns the change.