### PR TITLE
Avoid WordPress JSON helper in VFS mount snapshots

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -5,7 +5,7 @@ import type { MountSpec } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { SKIPPED_CAPTURE_DIRECTORIES } from "./artifacts.js"
 
-interface HostMountSnapshot {
+export interface HostMountSnapshot {
   mountIndex: number
   target: string
   files: Record<string, string>
@@ -112,7 +112,7 @@ async function hostFileHashes(directory: string, relativeDirectory = ""): Promis
   return files
 }
 
-function vfsMountSnapshotPhp(hostSnapshots: HostMountSnapshot[]): string {
+export function vfsMountSnapshotPhp(hostSnapshots: HostMountSnapshot[]): string {
   const payload = JSON.stringify(JSON.stringify({ mounts: hostSnapshots }))
   return `<?php
 $payload = json_decode(${payload}, true);
@@ -178,6 +178,6 @@ foreach (($payload['mounts'] ?? array()) as $mount) {
     );
 }
 
-echo wp_json_encode(array('schema' => 'wp-codebox/vfs-mount-snapshot/v1', 'mounts' => $mounts), JSON_UNESCAPED_SLASHES);
+echo json_encode(array('schema' => 'wp-codebox/vfs-mount-snapshot/v1', 'mounts' => $mounts), JSON_UNESCAPED_SLASHES);
 `
 }

--- a/scripts/mounted-workspace-diff-smoke.ts
+++ b/scripts/mounted-workspace-diff-smoke.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
 import { execFile } from "node:child_process"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -6,7 +7,7 @@ import { join } from "node:path"
 import { promisify } from "node:util"
 import type { MountSpec } from "@automattic/wp-codebox-core"
 import { ArtifactRedactor, buildArtifactReview } from "../packages/runtime-playground/src/artifacts.js"
-import { applyVfsMountSnapshots } from "../packages/runtime-playground/src/mount-materialization.js"
+import { applyVfsMountSnapshots, vfsMountSnapshotPhp } from "../packages/runtime-playground/src/mount-materialization.js"
 import { captureMountDiffs } from "../packages/runtime-playground/src/mounted-artifact-capture.js"
 
 const execFileAsync = promisify(execFile)
@@ -169,6 +170,26 @@ try {
     mode: "readwrite",
     metadata: { kind: "homeboy-dmc-workspace", workspace_slug: "vfs-backed-repo" },
   }]
+
+  const rawPhpTarget = join(root, "raw-php-vfs-target")
+  const rawPhpFile = join(root, "vfs-mount-snapshot.php")
+  await mkdir(rawPhpTarget, { recursive: true })
+  await writeFile(join(rawPhpTarget, "changed.txt"), "changed inside raw php\n")
+  const rawPhp = vfsMountSnapshotPhp([{
+    mountIndex: 0,
+    target: rawPhpTarget,
+    files: {
+      "changed.txt": createHash("sha256").update("before raw php\n").digest("hex"),
+    },
+  }])
+  assert.doesNotMatch(rawPhp, /wp_json_encode/)
+  await writeFile(rawPhpFile, rawPhp)
+  const rawPhpResult = await execFileAsync("php", [rawPhpFile])
+  const rawPhpSnapshot = JSON.parse(rawPhpResult.stdout) as { schema?: string; mounts?: Array<{ files?: Array<{ relativePath?: string; contentsBase64?: string }> }> }
+  assert.equal(rawPhpSnapshot.schema, "wp-codebox/vfs-mount-snapshot/v1")
+  assert.equal(rawPhpSnapshot.mounts?.[0]?.files?.[0]?.relativePath, "changed.txt")
+  assert.equal(Buffer.from(rawPhpSnapshot.mounts?.[0]?.files?.[0]?.contentsBase64 ?? "", "base64").toString("utf8"), "changed inside raw php\n")
+
   const materialized = await applyVfsMountSnapshots(vfsMounts, [{
     mountIndex: 0,
     target: "/workspace/vfs-backed-repo",


### PR DESCRIPTION
## Summary
- Fixes the raw VFS mount snapshot PHP used during artifact collection so it no longer calls `wp_json_encode()` outside a bootstrapped WordPress context.
- Adds smoke coverage that executes the generated PHP with plain `php`, proving artifact collection snapshot code works without WordPress helpers.

Fixes #847.

## Verification
- `npx tsx scripts/mounted-workspace-diff-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the artifact collection fatal, implemented the standalone PHP JSON encoding fix, added smoke coverage, and ran targeted verification; Chris reviews and owns the submitted change.