### PR TITLE
Fix sandbox workspace artifact materialization

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -120,7 +120,7 @@ add_filter('datamachine_code_remote_workspace_backend_should_handle', '__return_
 $sandbox_workspace_adoptions = array();
 if (function_exists('wp_get_ability')) {
     $sandbox_adopt_callback = static function () use (&$sandbox_workspace_adoptions): void {
-        $sandbox_adopt_ability = wp_get_ability('datamachine/workspace-adopt');
+        $sandbox_adopt_ability = wp_get_ability('datamachine-code/workspace-adopt') ?: wp_get_ability('datamachine/workspace-adopt');
         if (!$sandbox_adopt_ability || !method_exists($sandbox_adopt_ability, 'execute')) {
             return;
         }

--- a/scripts/agent-sandbox-code-smoke.ts
+++ b/scripts/agent-sandbox-code-smoke.ts
@@ -84,6 +84,7 @@ async function main() {
   assert.doesNotMatch(code, /AgentsAPIAIWP_Agent_Execution_Principal/, "sandbox chat should not collapse namespaced runtime principal references")
   assert.match(code, /PermissionHelper::run_as_authenticated/, "sandbox chat should execute runtime abilities in an authenticated Data Machine context")
   assert.match(code, /DataMachine\\Abilities\\PermissionHelper::run_as_authenticated/, "sandbox chat should emit a valid namespaced PermissionHelper class reference")
+  assert.match(code, /datamachine-code\/workspace-adopt/, "sandbox setup should use the canonical Data Machine Code workspace adopt ability")
   assert.doesNotMatch(code, /PermissionHelper::run_as_authenticated\([^\)]*,\s*1\)/, "sandbox chat should not force a user-specific Data Machine capability check")
   assert.doesNotMatch(code, /DataMachineAbilitiesPermissionHelper/, "sandbox chat should not collapse namespaced PermissionHelper references")
   assert.doesNotMatch(code, /datamachine_agent_mode_sandbox/, "sandbox chat should not depend on Data Machine agent mode filters")

--- a/scripts/recipe-workspace-vfs-materialization-smoke.ts
+++ b/scripts/recipe-workspace-vfs-materialization-smoke.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-recipe-workspace-vfs-materialization-"))
+
+try {
+  const seed = join(workspace, "seed")
+  const recipePath = join(workspace, "recipe.json")
+  const artifacts = join(workspace, "artifacts")
+  await mkdir(seed, { recursive: true })
+  await writeFile(join(seed, "plugin.php"), "<?php\n// before\n")
+  await writeFile(join(seed, "remove-me.txt"), "delete this\n")
+
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: "7.0" },
+    inputs: {
+      workspaces: [
+        {
+          target: "/workspace/materialization-smoke",
+          sourceMode: "repo-backed",
+          seed: {
+            type: "directory",
+            source: "./seed",
+            slug: "materialization-smoke",
+          },
+        },
+      ],
+    },
+    workflow: {
+      steps: [
+        {
+          command: "wordpress.run-php",
+          args: [
+            "code=" + [
+              "file_put_contents('/workspace/materialization-smoke/plugin.php', \"<?php\\n// after from playground\\n\");",
+              "file_put_contents('/workspace/materialization-smoke/generated.txt', \"created inside playground\\n\");",
+              "unlink('/workspace/materialization-smoke/remove-me.txt');",
+              "echo 'workspace mutated';",
+            ].join(" "),
+          ],
+        },
+      ],
+    },
+    artifacts: { directory: artifacts },
+  }, null, 2)}\n`)
+
+  const { stdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "recipe-run", "--recipe", recipePath, "--json"], { cwd: root, timeout: 120_000 })
+  const output = JSON.parse(stdout)
+  assert.equal(output.success, true, output.error?.message ?? "recipe-run failed")
+  assert.ok(output.artifacts?.directory, "recipe-run should return an artifact directory")
+
+  const changedFiles = JSON.parse(await readFile(join(output.artifacts.directory, "files", "changed-files.json"), "utf8"))
+  const changed = new Map(changedFiles.files.map((file: { relativePath: string }) => [file.relativePath, file]))
+  assert.equal(changed.get("generated.txt")?.status, "added")
+  assert.equal(changed.get("plugin.php")?.status, "modified")
+  assert.equal(changed.get("remove-me.txt")?.status, "deleted")
+
+  const patch = await readFile(join(output.artifacts.directory, "files", "patch.diff"), "utf8")
+  assert.match(patch, /diff --git a\/workspace\/materialization-smoke\/generated\.txt b\/workspace\/materialization-smoke\/generated\.txt/)
+  assert.match(patch, /\+created inside playground/)
+  assert.match(patch, /\+\/\/ after from playground/)
+  assert.match(patch, /deleted file mode 100644/)
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -151,6 +151,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-staged-files-smoke"),
       tsxSmoke("recipe-dependency-overlay-smoke"),
       tsxSmoke("recipe-workspace-seed-excludes-smoke"),
+      tsxSmoke("recipe-workspace-vfs-materialization-smoke"),
       tsxSmoke("recipe-runtime-evidence-smoke"),
       tsxSmoke("recipe-run-timeout-smoke"),
       tsxSmoke("recipe-playground-boot-failure-smoke"),


### PR DESCRIPTION
## Summary
- Use the canonical Data Machine Code `datamachine-code/workspace-adopt` ability in sandbox setup, with the old ability name as a fallback.
- Add a real `recipe-run` regression smoke proving Playground workspace writes materialize into `changed-files.json` and `patch.diff`.
- Covers the artifact path involved in #845 while the upstream mounted `workspace_write` normalization fix lands separately in Extra-Chill/data-machine-code#614.

Fixes #845.

## Testing
- `npm run build`
- `npx tsx scripts/agent-sandbox-code-smoke.ts`
- `npx tsx scripts/recipe-workspace-vfs-materialization-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the sandbox artifact materialization path, drafted the sandbox adoption update and regression smoke, and ran targeted verification. Chris remains responsible for review and merge.