### PR TITLE
Fix recipe evidence completion contracts

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -138,6 +138,34 @@ come from the command catalog:
 npm run wp-codebox -- commands --json
 ```
 
+Use `allowFailure: true` or `advisory: true` for evidence-only workflow steps.
+Failed advisory steps are reported in `advisoryFailures` and do not make an
+otherwise successful recipe return `success: false`.
+
+```json
+{
+  "command": "wordpress.browser-actions",
+  "args": ["url=/", "steps-json=[...]"],
+  "advisory": true
+}
+```
+
+## Recipe Output Evidence
+
+`recipe-run --json` returns `wp-codebox/recipe-run/v1`. Browser command sidecars
+are promoted into `browserEvidence` so callers can discover stable evidence
+without hardcoding artifact paths or parsing command stdout.
+
+Each `browserEvidence` entry includes the workflow phase/index, command,
+summary file, artifact file refs, summary payload, and `scriptResult` when the
+browser command produced one. The same browser evidence is mirrored into
+`latest-runtime.json` under the run artifact pointer.
+
+`--preview-hold <duration>` records held-preview lifecycle metadata in the
+artifact bundle and returns after recipe work finishes. Use
+`--preview-hold-blocking` only for operator workflows that need the CLI process
+to keep a live preview server open for the hold duration.
+
 ## Browser Assertions
 
 `wordpress.browser-probe` accepts repeated `assert=<assertion>` arguments.

--- a/packages/cli/src/commands/recipe-run-artifact-pointers.ts
+++ b/packages/cli/src/commands/recipe-run-artifact-pointers.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { stripUndefined, type ArtifactBundle, type RuntimeInfo } from "@automattic/wp-codebox-core"
 import type { RunOutput } from "../runtime-command-wrappers.js"
-import type { RecipeArtifactPointerCommandStatus, RecipeArtifactPointerState, RecipePhaseEvidence } from "./recipe-run-types.js"
+import type { RecipeArtifactPointerCommandStatus, RecipeArtifactPointerState, RecipeBrowserEvidence, RecipePhaseEvidence } from "./recipe-run-types.js"
 
 export class RecipeArtifactPointerTracker {
   private command: string | undefined
@@ -11,6 +11,7 @@ export class RecipeArtifactPointerTracker {
   private artifacts: ArtifactBundle | undefined
   private failure: RunOutput["error"] | undefined
   private phases: RecipePhaseEvidence[] = []
+  private browserEvidence: RecipeBrowserEvidence[] = []
 
   constructor(private readonly directory: string | undefined, private readonly runId: string, private readonly recipePath: string, private readonly startedAt: string) {}
 
@@ -23,8 +24,9 @@ export class RecipeArtifactPointerTracker {
     this.commandStatus = state.commandStatus ?? this.commandStatus
     this.runtime = state.runtime ?? this.runtime
     this.artifacts = state.artifacts ?? this.artifacts
-    this.failure = state.failure ?? this.failure
+    this.failure = state.failure ?? (state.commandStatus === "completed" || state.commandStatus === "running" ? undefined : this.failure)
     this.phases = state.phases ?? this.phases
+    this.browserEvidence = state.browserEvidence ?? this.browserEvidence
 
     const pointer = stripUndefined({
       schema: "wp-codebox/recipe-run-artifact-pointer/v1",
@@ -39,6 +41,7 @@ export class RecipeArtifactPointerTracker {
       commandStatus: this.commandStatus,
       failure: this.failure,
       failurePhase: recipeArtifactPointerFailurePhase(this.failure, this.phases),
+      browserEvidence: this.browserEvidence.length > 0 ? this.browserEvidence : undefined,
       paths: recipeArtifactPointerPaths(this.directory, this.runtime, this.artifacts),
     })
 

--- a/packages/cli/src/commands/recipe-run-interruption.ts
+++ b/packages/cli/src/commands/recipe-run-interruption.ts
@@ -130,6 +130,9 @@ export function createRecipeInterruptionController(): RecipeInterruptionControll
       controller.dispose()
       process.kill(process.pid, metadata.signal)
     },
+    clear() {
+      metadata = undefined
+    },
   }
 
   return controller

--- a/packages/cli/src/commands/recipe-run-output.ts
+++ b/packages/cli/src/commands/recipe-run-output.ts
@@ -51,7 +51,7 @@ export class RecipeDeclaredArtifactFailureError extends Error {
 
 export function exitAfterPlaygroundCliBootFailure(output: RecipeRunCommandOutput): void {
   if (output.schema === "wp-codebox/recipe-run/v1" && hasSerializedErrorCode(output.error, "wp-codebox-playground-cli-exited")) {
-    process.exit(output.success ? 0 : 1)
+    process.exitCode = output.success ? 0 : 1
   }
 }
 
@@ -74,8 +74,24 @@ function hasSerializedErrorCode(error: RunOutput["error"] | undefined, code: str
 
 export function exitAfterRecipeRunTimeout(output: RecipeRunCommandOutput): void {
   if (output.schema === "wp-codebox/recipe-run/v1" && output.error?.code === "recipe-run-timeout") {
-    process.exit(output.success ? 0 : 1)
+    process.exitCode = output.success ? 0 : 1
   }
+}
+
+export async function writeRecipeJsonOutput(output: unknown): Promise<void> {
+  await writeStdout(`${JSON.stringify(output, null, 2)}\n`)
+}
+
+function writeStdout(contents: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(contents, (error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
 }
 
 export function printJsonFailureDiagnostic(output: { success: boolean; error?: { message?: string }; logs?: string[] }): void {

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -12,6 +12,7 @@ export interface RecipeRunOptions {
   previewPublicUrl?: string
   previewPort?: number
   previewBind?: string
+  previewHoldBlocking: boolean
   timeoutMs: number
   json: boolean
   dryRun: boolean
@@ -50,6 +51,8 @@ export interface RecipeRunOutput {
   probes?: RecipeRunProbe[]
   declaredArtifacts?: RecipeRunDeclaredArtifact[]
   phaseEvidence?: RecipePhaseEvidence[]
+  advisoryFailures?: RecipeAdvisoryFailure[]
+  browserEvidence?: RecipeBrowserEvidence[]
   diagnostics?: RecipeRuntimeDiagnostic[]
   validation?: {
     issues: RecipeValidationIssue[]
@@ -72,6 +75,37 @@ export type RecipeExecutionResult = ExecutionResult & {
   recipePhase?: RecipeWorkflowPhase
   recipeStepIndex?: number
   recipeCommand?: string
+  recipeAdvisory?: boolean
+}
+
+export interface RecipeAdvisoryFailure {
+  schema: "wp-codebox/recipe-advisory-failure/v1"
+  phase: RecipeWorkflowPhase
+  index: number
+  command: string
+  status: "failed"
+  error: RunOutput["error"]
+}
+
+export interface RecipeBrowserEvidenceFileRef {
+  path: string
+  kind?: string
+  contentType?: string
+  sha256?: { algorithm: "sha256"; value: string }
+}
+
+export interface RecipeBrowserEvidence {
+  schema: "wp-codebox/recipe-browser-evidence/v1"
+  phase?: RecipeWorkflowPhase
+  index?: number
+  command: string
+  status: "completed" | "failed"
+  requestedUrl?: string
+  finalUrl?: string
+  summaryFile?: RecipeBrowserEvidenceFileRef
+  files: Record<string, RecipeBrowserEvidenceFileRef | RecipeBrowserEvidenceFileRef[]>
+  summary?: unknown
+  scriptResult?: unknown
 }
 
 export type RecipeArtifactPointerCommandStatus = "queued" | "running" | "completed" | "failed"
@@ -83,6 +117,7 @@ export interface RecipeArtifactPointerState {
   artifacts?: ArtifactBundle
   failure?: RunOutput["error"]
   phases?: RecipePhaseEvidence[]
+  browserEvidence?: RecipeBrowserEvidence[]
 }
 
 export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "import_fixture_databases" | "run_workloads" | "run_probes" | "collect_artifacts"
@@ -212,4 +247,5 @@ export interface RecipeInterruptionController {
   interruptible<T>(promise: Promise<T>): Promise<T>
   throwIfInterrupted(): void
   propagateIfInterrupted(): void
+  clear(): void
 }

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -17,9 +17,9 @@ import { loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipe
 import { previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
 import { createRecipeRunContext } from "./recipe-run-context.js"
 import { createRecipeInterruptionController, interruptedRecipeOutput, markRecipeArtifactsFinalized, recipeInterruptionSerializedError } from "./recipe-run-interruption.js"
-import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, isRecipeRunTimeoutError, printJsonFailureDiagnostic, recipeRunFailureStatus, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError, RecipeRunTimeoutError, RecipeRuntimeCreateError, remainingRecipeTimeoutMs, serializeRecipeRunError, watchRecipeOperation } from "./recipe-run-output.js"
+import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, isRecipeRunTimeoutError, printJsonFailureDiagnostic, recipeRunFailureStatus, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError, RecipeRunTimeoutError, RecipeRuntimeCreateError, remainingRecipeTimeoutMs, serializeRecipeRunError, watchRecipeOperation, writeRecipeJsonOutput } from "./recipe-run-output.js"
 import { RecipePhaseError, RecipePhaseTracker } from "./recipe-run-phases.js"
-import type { RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 
@@ -66,7 +66,7 @@ export async function runRecipeRunCommand(args: string[]): Promise<number> {
     const { result, logs } = await captureStdout(execute)
     const interruptedResult = interruptedRecipeOutput(result, interruption)
     const output = logs.length > 0 ? { ...interruptedResult, logs } : interruptedResult
-    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+    await writeRecipeJsonOutput(output)
     printJsonFailureDiagnostic(output)
     interruption?.propagateIfInterrupted()
     exitAfterRecipeRunTimeout(output)
@@ -85,7 +85,7 @@ export async function runRecipeValidateCommand(args: string[]): Promise<number> 
     return output.success ? 0 : 1
   }
 
-  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  await writeRecipeJsonOutput(output)
   return output.success ? 0 : 1
 }
 
@@ -133,6 +133,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let fixtureDatabases: RecipeRunFixtureDatabase[] = []
   let probes: RecipeRunProbe[] = []
   let declaredArtifacts: RecipeRunDeclaredArtifact[] = []
+  let advisoryFailures: RecipeAdvisoryFailure[] = []
+  let browserEvidence: RecipeBrowserEvidence[] = []
   let artifacts: ArtifactBundle | undefined
   let startupDurationMs: number | undefined
   let cleanupEvidence: RunResourceCleanupEvidence | undefined
@@ -370,8 +372,18 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const workflowSteps = recipeWorkflowSteps(recipe)
     await phaseTracker.run("run_workloads", phaseWorkflowData(workflowSteps), async () => {
       for (const workflowStep of workflowSteps) {
-        executions.push(await awaitRecipe(`workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`, () => executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options)))
-        interruption?.throwIfInterrupted()
+        const operation = `workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`
+        try {
+          const execution = await awaitRecipe(operation, () => executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options))
+          executions.push({ ...execution, ...(recipeWorkflowStepIsAdvisory(workflowStep.step) ? { recipeAdvisory: true } : {}) })
+          interruption?.throwIfInterrupted()
+        } catch (error) {
+          if (!recipeWorkflowStepIsAdvisory(workflowStep.step)) {
+            throw error
+          }
+          advisoryFailures.push(recipeAdvisoryFailure(workflowStep, error))
+          interruption?.clear()
+        }
       }
     })
 
@@ -388,7 +400,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       await awaitRecipe("runtime.observe:mounts", runtime!.observe({ type: "mounts" }))
       runRecord = await runRegistry.update(runRecord.runId, { status: "collecting_artifacts", runtime: await runtime!.info() })
       artifacts = await awaitRecipe("runtime.collect-artifacts", runtime!.collectArtifacts({ includeLogs: true, includeObservations: true }))
-      await artifactPointer.update({ runtime: await runtime!.info(), artifacts, phases: phaseTracker.list() })
+      browserEvidence = await recipeBrowserEvidence(artifacts, executions)
+      await artifactPointer.update({ runtime: await runtime!.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts))
       if (declaredArtifactFailure) {
         throw declaredArtifactFailure
@@ -409,7 +422,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const successfulRecipe = !recipeFailure
     if (successfulRecipe && options.previewHoldSeconds) {
       artifacts = await awaitRecipe("runtime.collect-artifacts.preview-hold", runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds }))
-      await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list() })
+      browserEvidence = await recipeBrowserEvidence(artifacts, executions)
+      await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)
       const previewAgentEvidence = await finalizeAgentSandboxEvidence(artifacts, executions)
       Object.assign(evidence, previewAgentEvidence)
@@ -417,7 +431,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const runtimeInfo = successfulRecipe && options.previewHoldSeconds ? await runtime.info() : undefined
     const activeRuntime = runtime
     cleanupEvidence = await runRecipeCleanup(runRegistry, runRecord, async () => {
-      await awaitRecipe("runtime.release", releaseRuntime(activeRuntime, successfulRecipe ? options.previewHoldSeconds : 0))
+      await awaitRecipe("runtime.release", releaseRuntime(activeRuntime, successfulRecipe && options.previewHoldBlocking ? options.previewHoldSeconds : 0))
       await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays, dependencyOverlays)
       await cleanupInputMountBaselines(inputMountBaselinePaths)
     })
@@ -441,7 +455,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: recipeFailure, phaseEvidence: phaseTracker.list() }) },
         error: recipeFailure,
       })
-      await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: recipeFailure, phases: phaseTracker.list() })
+      await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: recipeFailure, phases: phaseTracker.list(), browserEvidence })
       return {
         success: false,
         schema: "wp-codebox/recipe-run/v1",
@@ -454,6 +468,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         probes,
         declaredArtifacts,
         phaseEvidence: phaseTracker.list(),
+        ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
+        ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
         ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
         ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
         ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
@@ -472,7 +488,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       artifactRefs: artifactBundleRunRef(artifacts),
       metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "succeeded", startupDurationMs, cleanup: cleanupEvidence, artifacts, phaseEvidence: phaseTracker.list() }) },
     })
-    await artifactPointer.update({ commandStatus: "completed", runtime: runtimeInfo ?? await runtime.info(), artifacts, phases: phaseTracker.list() })
+    await artifactPointer.update({ commandStatus: "completed", runtime: runtimeInfo ?? await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
     return {
       success: true,
       schema: "wp-codebox/recipe-run/v1",
@@ -485,6 +501,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       probes,
       declaredArtifacts,
       phaseEvidence: phaseTracker.list(),
+      ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
+      ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
       ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
       ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
       ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
@@ -508,7 +526,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         interruption,
       }))
       if (artifacts) {
-        await artifactPointer.update({ runtime: await activeRuntime.info(), artifacts, phases: phaseTracker.list() })
+        browserEvidence = await recipeBrowserEvidence(artifacts, executions)
+        await artifactPointer.update({ runtime: await activeRuntime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
         try {
           if (declaredArtifacts.length === 0) {
             declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, activeRuntime)
@@ -546,7 +565,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: recipeRunFailureStatus(error, interruption), startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: serializedError, phaseEvidence: phaseTracker.list() }) },
       error: serializedError,
     })
-    await artifactPointer.update({ commandStatus: "failed", ...(runtime ? { runtime: await runtime.info() } : {}), ...(artifacts ? { artifacts } : {}), failure: serializedError, phases: phaseTracker.list() })
+    await artifactPointer.update({ commandStatus: "failed", ...(runtime ? { runtime: await runtime.info() } : {}), ...(artifacts ? { artifacts } : {}), failure: serializedError, phases: phaseTracker.list(), browserEvidence })
 
     return {
       success: false,
@@ -559,6 +578,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       probes,
       declaredArtifacts,
       phaseEvidence: phaseTracker.list(),
+      ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
+      ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
       diagnostics: recipeRuntimeDiagnostics(recipe, executions, error),
       ...(artifacts ? { artifacts } : {}),
       run: runRecord,
@@ -962,7 +983,7 @@ function resolveSecretEnv(names: string[]): Record<string, string> {
 }
 
 function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
-  const options: Partial<RecipeRunOptions> = { json: false, dryRun: false, timeoutMs: DEFAULT_RECIPE_RUN_TIMEOUT_MS }
+  const options: Partial<RecipeRunOptions> = { json: false, dryRun: false, previewHoldBlocking: false, timeoutMs: DEFAULT_RECIPE_RUN_TIMEOUT_MS }
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -974,6 +995,11 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
 
     if (arg === "--dry-run") {
       options.dryRun = true
+      continue
+    }
+
+    if (arg === "--preview-hold-blocking") {
+      options.previewHoldBlocking = true
       continue
     }
 
@@ -1080,6 +1106,129 @@ function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: Recip
     recipeStepIndex,
     recipeCommand,
   }
+}
+
+function recipeWorkflowStepIsAdvisory(step: WorkspaceRecipe["workflow"]["steps"][number]): boolean {
+  return step.allowFailure === true || step.advisory === true
+}
+
+function recipeAdvisoryFailure(workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], error: unknown): RecipeAdvisoryFailure {
+  return {
+    schema: "wp-codebox/recipe-advisory-failure/v1",
+    phase: workflowStep.phase,
+    index: workflowStep.index,
+    command: workflowStep.step.command,
+    status: "failed",
+    error: serializeRecipeRunError(error),
+  }
+}
+
+async function recipeBrowserEvidence(artifacts: ArtifactBundle, executions: RecipeExecutionResult[]): Promise<RecipeBrowserEvidence[]> {
+  const manifestFiles = await artifactManifestFilesByPath(artifacts)
+  return executions.flatMap((execution) => recipeBrowserEvidenceForExecution(execution, manifestFiles))
+}
+
+function recipeBrowserEvidenceForExecution(execution: RecipeExecutionResult, manifestFiles: Map<string, ArtifactManifestFile>): RecipeBrowserEvidence[] {
+  const command = execution.recipeCommand ?? execution.command
+  if (!recipeCommandProducesBrowserEvidence(command)) {
+    return []
+  }
+
+  const parsed = parseJsonObject(execution.stdout)
+  if (!parsed) {
+    return []
+  }
+
+  if (Array.isArray(parsed.profiles)) {
+    return parsed.profiles.flatMap((profile) => {
+      const profileEvidence = recipeBrowserEvidenceFromParsedExecution(execution, command, profile, manifestFiles)
+      return profileEvidence ? [profileEvidence] : []
+    })
+  }
+
+  const evidence = recipeBrowserEvidenceFromParsedExecution(execution, command, parsed, manifestFiles)
+  return evidence ? [evidence] : []
+}
+
+function recipeBrowserEvidenceFromParsedExecution(execution: RecipeExecutionResult, command: string, parsed: Record<string, unknown>, manifestFiles: Map<string, ArtifactManifestFile>): RecipeBrowserEvidence | undefined {
+  const files = recipeBrowserEvidenceFiles(parsed.files, manifestFiles)
+  const summaryFile = browserEvidenceFileRef(stringValue((parsed.files as Record<string, unknown> | undefined)?.summary), manifestFiles)
+  if (Object.keys(files).length === 0 && !summaryFile) {
+    return undefined
+  }
+
+  const summary = parsed.summary
+  const summaryObject = isRecord(summary) ? summary : undefined
+  return stripUndefined({
+    schema: "wp-codebox/recipe-browser-evidence/v1",
+    phase: execution.recipePhase,
+    index: execution.recipeStepIndex,
+    command,
+    status: execution.exitCode === 0 ? "completed" : "failed",
+    requestedUrl: stringValue(parsed.requestedUrl),
+    finalUrl: stringValue(parsed.finalUrl ?? summaryObject?.finalUrl),
+    summaryFile,
+    files,
+    summary,
+    scriptResult: summaryObject?.scriptResult,
+  }) as RecipeBrowserEvidence
+}
+
+function recipeBrowserEvidenceFiles(files: unknown, manifestFiles: Map<string, ArtifactManifestFile>): Record<string, RecipeBrowserEvidenceFileRef | RecipeBrowserEvidenceFileRef[]> {
+  if (!isRecord(files)) {
+    return {}
+  }
+
+  const refs: Record<string, RecipeBrowserEvidenceFileRef | RecipeBrowserEvidenceFileRef[]> = {}
+  for (const [name, value] of Object.entries(files)) {
+    const ref = Array.isArray(value)
+      ? value.map((entry) => browserEvidenceFileRef(stringValue(entry), manifestFiles)).filter((entry): entry is RecipeBrowserEvidenceFileRef => Boolean(entry))
+      : browserEvidenceFileRef(stringValue(value), manifestFiles)
+    if (Array.isArray(ref)) {
+      if (ref.length > 0) {
+        refs[name] = ref
+      }
+      continue
+    }
+    if (ref) {
+      refs[name] = ref
+    }
+  }
+  return refs
+}
+
+function browserEvidenceFileRef(path: string | undefined, manifestFiles: Map<string, ArtifactManifestFile>): RecipeBrowserEvidenceFileRef | undefined {
+  if (!path) {
+    return undefined
+  }
+  const manifestFile = manifestFiles.get(path)
+  return stripUndefined({
+    path,
+    kind: manifestFile?.kind,
+    contentType: manifestFile?.contentType,
+    sha256: manifestFile?.sha256,
+  }) as RecipeBrowserEvidenceFileRef
+}
+
+function recipeCommandProducesBrowserEvidence(command: string): boolean {
+  return command.startsWith("wordpress.browser-") || command === "wordpress.editor-canvas-probe" || command === "wordpress.html-capture"
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(raw)
+    return isRecord(parsed) ? parsed : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
 }
 
 async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, artifactRoot?: string, options?: RecipeRunOptions): Promise<RecipeExecutionResult> {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -64,6 +64,14 @@ export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath
     if (step.args && !Array.isArray(step.args)) {
       throw new Error(`Recipe workflow ${phase} args must be arrays: ${recipePath}`)
     }
+
+    if (step.allowFailure !== undefined && typeof step.allowFailure !== "boolean") {
+      throw new Error(`Recipe workflow ${phase} allowFailure must be boolean: ${recipePath}`)
+    }
+
+    if (step.advisory !== undefined && typeof step.advisory !== "boolean") {
+      throw new Error(`Recipe workflow ${phase} advisory must be boolean: ${recipePath}`)
+    }
   }
 
   if (recipe.distribution !== undefined) {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -603,6 +603,8 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "array",
             items: { type: "string" },
           },
+          allowFailure: { type: "boolean" },
+          advisory: { type: "boolean" },
         },
       },
       inheritanceRequest: {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -180,6 +180,8 @@ export interface WorkspaceRecipeStagedFile {
 export interface WorkspaceRecipeStep {
   command: string
   args?: string[]
+  allowFailure?: boolean
+  advisory?: boolean
 }
 
 export interface WorkspaceRecipeFixtureDatabaseReset {

--- a/scripts/recipe-advisory-preview-smoke.ts
+++ b/scripts/recipe-advisory-preview-smoke.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const root = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-recipe-advisory-preview-"))
+const execFileAsync = promisify(execFile)
+
+try {
+  const artifacts = join(workspace, "artifacts")
+  const recipePath = join(workspace, "recipe.json")
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { wp: "7.0" },
+    workflow: {
+      steps: [
+        {
+          command: "wordpress.run-php",
+          args: ["code=<?php echo 'primary generation complete';"],
+        },
+        {
+          command: "wordpress.run-php",
+          args: ["code=<?php throw new Exception('optional evidence failed');"],
+          allowFailure: true,
+        },
+      ],
+    },
+    artifacts: {
+      directory: artifacts,
+      verify: true,
+      workspacePolicy: { strict: false, writableRoots: ["."], gitBacked: false },
+    },
+  }, null, 2)}\n`)
+
+  const startedAt = Date.now()
+  const { stdout } = await execFileAsync(process.execPath, [
+    "packages/cli/dist/index.js",
+    "recipe-run",
+    "--recipe",
+    recipePath,
+    "--artifacts",
+    artifacts,
+    "--preview-hold",
+    "20s",
+    "--json",
+  ], { cwd: root, timeout: 60_000 })
+  const elapsedMs = Date.now() - startedAt
+  assert.ok(elapsedMs < 20_000, `preview-hold should not block recipe-run completion; elapsed ${elapsedMs}ms`)
+
+  const output = JSON.parse(stdout)
+  assert.equal(output.schema, "wp-codebox/recipe-run/v1")
+  assert.equal(output.success, true)
+  assert.equal(output.advisoryFailures?.length, 1)
+  assert.equal(output.advisoryFailures[0].command, "wordpress.run-php")
+  assert.match(output.advisoryFailures[0].error.message, /optional evidence failed/)
+  assert.equal(output.artifacts?.preview?.holdSeconds, 20)
+  assert.equal(output.artifacts.preview.lifecycle, "held-after-run")
+
+  const latestRuntime = JSON.parse(await readFile(join(artifacts, "latest-runtime.json"), "utf8"))
+  assert.equal(latestRuntime.commandStatus, "completed")
+  assert.equal(latestRuntime.failure, undefined)
+
+  console.log("Recipe advisory preview smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}

--- a/scripts/recipe-browser-smoke.ts
+++ b/scripts/recipe-browser-smoke.ts
@@ -43,6 +43,7 @@ const recipe = spawn(process.execPath, [
   runArtifactsRoot,
   "--preview-hold",
   `${holdSeconds}s`,
+  "--preview-hold-blocking",
   "--json",
 ], {
   cwd: repoRoot,

--- a/scripts/recipe-interruption-artifacts-smoke.ts
+++ b/scripts/recipe-interruption-artifacts-smoke.ts
@@ -30,7 +30,7 @@ try {
       steps: [
         {
           command: "wordpress.run-php",
-          args: ["code=<?php sleep(120); echo 'unreachable';"],
+          args: [`code=<?php for ($i = 0; $i < 2000; $i++) { echo str_repeat('large-output-', 8) . $i . "\\n"; flush(); } sleep(120); echo 'unreachable';`],
         },
       ],
     },

--- a/scripts/recipe-preview-routing-browser-probe-smoke.ts
+++ b/scripts/recipe-preview-routing-browser-probe-smoke.ts
@@ -3,7 +3,7 @@ import { execFile } from "node:child_process"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createServer, type Server } from "node:net"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 
 const execFileAsync = promisify(execFile)
@@ -28,6 +28,9 @@ try {
   assert.equal(recipeSummary.effectivePreviewOrigin, recipePublicUrl)
   assert.equal(recipeOutput.artifacts.preview.url, recipePublicUrl)
   assert.equal(recipeOutput.artifacts.preview.localUrl.startsWith("http://127.0.0.1:"), true)
+  assert.equal(recipeOutput.browserEvidence?.[0]?.command, "wordpress.browser-probe")
+  assert.equal(recipeOutput.browserEvidence?.[0]?.summaryFile?.path, "files/browser/summary.json")
+  assert.equal(recipeOutput.browserEvidence?.[0]?.files?.html?.path, "files/browser/snapshot.html")
 
   const recipeReview = await review(recipeOutput)
   assert.equal(recipeReview.browser?.probes?.[0]?.requestedUrl, `${recipePublicUrl}relative-probe`)
@@ -71,6 +74,9 @@ try {
   assert.equal(overrideSummary.requestedPreviewOrigin, overridePublicUrl)
   assert.equal(overrideSummary.effectivePreviewOrigin, overridePublicUrl)
   assert.equal(overrideOutput.artifacts.preview.url, overridePublicUrl)
+  const overridePointer = JSON.parse(await readFile(join(dirname(overrideOutput.artifacts.directory), "latest-runtime.json"), "utf8"))
+  assert.equal(overridePointer.browserEvidence?.[0]?.command, "wordpress.browser-probe")
+  assert.equal(overridePointer.browserEvidence?.[0]?.summaryFile?.path, "files/browser/summary.json")
 
   const overrideMetadata = JSON.parse(await readFile(overrideOutput.artifacts.metadataPath, "utf8")) as { provenance?: { task?: { preview?: { requested?: { publicUrl?: string }; effective?: { publicUrl?: string }; cliOverrides?: { publicUrl?: string } } } } }
   assert.equal(overrideMetadata.provenance?.task?.preview?.requested?.publicUrl, staleRecipePublicUrl)


### PR DESCRIPTION
## Summary
- Add advisory workflow-step support so evidence-only steps can fail without flipping otherwise successful recipe runs.
- Make recipe preview holds nonblocking by default, with an explicit `--preview-hold-blocking` mode for live operator previews.
- Promote browser command sidecars into first-class `browserEvidence` in recipe output and runtime pointers, and make JSON output writes flush through the normal event loop.

Fixes #851.
Fixes #852.
Fixes #853.
Fixes #854.

## Testing
- `npm run build`
- `npx tsx scripts/recipe-advisory-preview-smoke.ts`
- `npx tsx scripts/recipe-interruption-artifacts-smoke.ts`
- `npx tsx scripts/recipe-browser-smoke.ts`
- `npx tsx scripts/recipe-preview-routing-browser-probe-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and implemented the recipe-run contract changes, smoke coverage, and documentation updates for Chris to review and test.