### PR TITLE
Support PHPUnit prepare recipe steps

### DIFF
--- a/packages/cli/src/commands/recipe-build.ts
+++ b/packages/cli/src/commands/recipe-build.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises"
-import { buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
+import { buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount, type WorkspaceRecipeStep } from "@automattic/wp-codebox-core"
 
 interface RecipeBuildOptions {
   recipeType: "phpunit" | "bench"
@@ -26,6 +26,7 @@ interface WordPressPhpunitBuilderOptions {
   bootstrapMode?: string
   projectBootstrap?: string
   multisite?: boolean
+  prepareSteps?: WorkspaceRecipeStep[]
 }
 
 interface WordPressBenchBuilderOptions {
@@ -81,6 +82,7 @@ function buildRecipe(recipeType: RecipeBuildOptions["recipeType"], options: Word
         bootstrapMode: stringOrUndefined((options as WordPressPhpunitBuilderOptions).bootstrapMode),
         projectBootstrap: stringOrUndefined((options as WordPressPhpunitBuilderOptions).projectBootstrap),
         multisite: Boolean((options as WordPressPhpunitBuilderOptions).multisite),
+        prepareSteps: Array.isArray((options as WordPressPhpunitBuilderOptions).prepareSteps) ? (options as WordPressPhpunitBuilderOptions).prepareSteps : [],
       })
     case "bench":
       return buildWordPressBenchRecipe({

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -20,6 +20,7 @@ export const defaultPolicy: RuntimePolicy = {
 }
 
 const supportedRecipeCommands = new Set(recipeCommandDefinitions().map((command) => command.id))
+const hostRecipeCommandPattern = /^host\/[A-Za-z0-9._/-]+$/
 
 export async function loadWorkspaceRecipe(recipePath: string): Promise<WorkspaceRecipe> {
   return parseWorkspaceRecipe(await readFile(recipePath, "utf8"), recipePath)
@@ -413,7 +414,7 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
 
   for (const { phase, index, step } of recipeWorkflowSteps(recipe)) {
     const path = `$.workflow.${phase}[${index}]`
-    if (!supportedRecipeCommands.has(step.command)) {
+    if (!supportedRecipeCommands.has(step.command) && !hostRecipeCommandPattern.test(step.command)) {
       addIssue("unsupported-command", `${path}.command`, `Unsupported recipe command: ${step.command}`)
       continue
     }

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount } from "./runtime-contracts.js"
+import type { WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipeStep } from "./runtime-contracts.js"
 import { DEFAULT_WORDPRESS_VERSION } from "./runtime-defaults.js"
 
 type JsonObject = Record<string, unknown>
@@ -26,6 +26,7 @@ export interface WordPressPhpunitRecipeOptions {
   bootstrapMode?: "managed" | "project" | (string & {})
   projectBootstrap?: string
   multisite?: boolean
+  prepareSteps?: WorkspaceRecipeStep[]
 }
 
 export interface WordPressBenchRecipeOptions {
@@ -89,6 +90,7 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
       ]),
     },
     workflow: {
+      ...(options.prepareSteps && options.prepareSteps.length > 0 ? { before: normalizeRecipeSteps(options.prepareSteps, "prepareSteps") } : {}),
       steps: [{
         command: "wordpress.phpunit",
         args: [
@@ -110,6 +112,21 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
       }],
     },
   }
+}
+
+function normalizeRecipeSteps(steps: readonly WorkspaceRecipeStep[], label: string): WorkspaceRecipeStep[] {
+  return steps.map((step, index) => {
+    if (!step.command || typeof step.command !== "string") {
+      throw new Error(`${label}[${index}] requires command`)
+    }
+
+    return {
+      command: step.command,
+      ...(step.args !== undefined ? { args: step.args } : {}),
+      ...(step.allowFailure !== undefined ? { allowFailure: step.allowFailure } : {}),
+      ...(step.advisory !== undefined ? { advisory: step.advisory } : {}),
+    }
+  })
 }
 
 export function buildWordPressBenchRecipe(options: WordPressBenchRecipeOptions): WorkspaceRecipe {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -6,7 +6,7 @@ export interface WorkspaceRecipeJsonSchemaOptions {
 
 export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSchemaOptions = {}): WorkspaceRecipeJsonSchema {
   const commandSchema = options.recipeCommandIds && options.recipeCommandIds.length > 0
-    ? { enum: [...options.recipeCommandIds] }
+    ? { anyOf: [{ enum: [...options.recipeCommandIds] }, { type: "string", pattern: "^host/[A-Za-z0-9._/-]+$" }] }
     : { type: "string" }
 
   return {

--- a/scripts/wordpress-recipe-builders-smoke.ts
+++ b/scripts/wordpress-recipe-builders-smoke.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import { DEFAULT_WORDPRESS_VERSION, buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, createBenchmarkDefinitionJsonSchema, createBenchResultsJsonSchema, createWorkspaceRecipeJsonSchema, recipeCommandDefinitions } from "@automattic/wp-codebox-core"
 import Ajv2020 from "ajv/dist/2020.js"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
 
 const recipeCommandIds = recipeCommandDefinitions().filter((command) => command.recipe).map((command) => command.id)
 const ajv = new Ajv2020({ strict: false })
@@ -23,6 +31,10 @@ const phpunitRecipe = buildWordPressPhpunitRecipe({
   bootstrapMode: "project",
   projectBootstrap: "tests/bootstrap.php",
   multisite: true,
+  prepareSteps: [{
+    command: "host/prepare-php",
+    args: ['input-json={"args":["bin/generate-feature-config.php"],"cwd":"/repo/demo-plugin-source"}'],
+  }],
   mounts: [
     { source: "/repo/vendor", target: "/wp-codebox-vendor", mode: "readonly" },
   ],
@@ -34,6 +46,10 @@ assert.equal(buildWordPressBenchRecipe({ pluginSlug: "demo-plugin" }).runtime?.w
 assert.equal(phpunitRecipe.inputs?.mounts?.[0]?.mode, "readwrite")
 assert.deepEqual(phpunitRecipe.inputs?.mounts?.[0], { source: "/repo/demo-plugin-source", target: "/wordpress/wp-content/plugins/demo-plugin", mode: "readwrite" })
 assert.deepEqual(phpunitRecipe.inputs?.mounts?.[1], { source: "/repo/vendor", target: "/wp-codebox-vendor", mode: "readonly" })
+assert.deepEqual(phpunitRecipe.workflow.before, [{
+  command: "host/prepare-php",
+  args: ['input-json={"args":["bin/generate-feature-config.php"],"cwd":"/repo/demo-plugin-source"}'],
+}])
 assert.deepEqual(phpunitRecipe.workflow.steps[0]?.args, [
   "plugin-slug=demo-plugin",
   "cwd=tests/phpunit",
@@ -51,6 +67,19 @@ assert.deepEqual(phpunitRecipe.workflow.steps[0]?.args, [
   "multisite=1",
 ])
 assert.ok(validate(phpunitRecipe), ajv.errorsText(validate.errors))
+
+const workspace = mkdtempSync(join(tmpdir(), "wp-codebox-phpunit-prepare-builder-"))
+const recipePath = join(workspace, "recipe.json")
+writeFileSync(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    before: phpunitRecipe.workflow.before,
+    steps: [{ command: "wordpress.run-php", args: ["code=echo 'ok';"] }],
+  },
+}, null, 2)}\n`)
+const validateRecipe = spawnSync(process.execPath, [cli, "recipe", "validate", "--recipe", recipePath, "--json"], { cwd: root, encoding: "utf8" })
+assert.equal(validateRecipe.status, 0, validateRecipe.stderr || validateRecipe.stdout)
+assert.equal(JSON.parse(validateRecipe.stdout).valid, true)
 
 const benchRecipe = buildWordPressBenchRecipe({
   wordpressVersion: "7.0",


### PR DESCRIPTION
## Summary
- Adds `prepareSteps` to the WordPress PHPUnit recipe builder and emits them as `workflow.before` so pre-test preparation is captured in normal recipe evidence.
- Allows recipe validation and exported schema to accept caller-provided `host/...` recipe commands for registered host tools, while runtime policy still gates execution.
- Covers the generated prepare phase and CLI recipe validation path in the recipe builder smoke test.

Fixes #858.

## Testing
- `npm run build`
- `npx tsx scripts/wordpress-recipe-builders-smoke.ts`
- `npx tsx scripts/recipe-workflow-phases-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic prepare-step plumbing, updated targeted smoke coverage, and ran verification; Chris remains responsible for review and merge.