### PR TITLE
Fix PHPUnit cwd backslash escaping

### DIFF
--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -550,7 +550,7 @@ CONFIG;
 }
 
 function pg_resolve_runtime_cwd(string $cwd, string $plugin_path): string {
-    $cwd = trim(str_replace('\\', '/', $cwd));
+    $cwd = trim(str_replace('\\\\', '/', $cwd));
     if ($cwd === '') {
         return $plugin_path;
     }

--- a/scripts/core-phpunit-command-smoke.ts
+++ b/scripts/core-phpunit-command-smoke.ts
@@ -83,6 +83,7 @@ assert.match(pluginCode, /pg_activate_plugin_file\(\$plugin_file, !empty\(\$cfg\
 assert.match(pluginCode, /do_action\('activate_' \. \$plugin_basename, \$network_wide\)/)
 assert.match(pluginCode, /update_site_option\('active_sitewide_plugins', \$active_plugins\)/)
 assert.match(pluginCode, /putenv\('WP_MULTISITE=1'\)/)
+assert.ok(pluginCode.includes("str_replace('\\\\', '/', $cwd)"))
 
 const fixtureRoot = mkdtempSync(join(tmpdir(), "wp-codebox-core-phpunit-"))
 const coreRoot = join(fixtureRoot, "wordpress")


### PR DESCRIPTION
## Summary
- Fixes the generated `wordpress.phpunit` runner so `pg_resolve_runtime_cwd()` emits a valid PHP `str_replace('\\\\', '/', $cwd)` call.
- Adds smoke coverage for the generated plugin PHPUnit runner code so this template escaping regression is caught.

## Verification
- `npm run build`
- `npx tsx scripts/core-phpunit-command-smoke.ts`
- `php -l /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/wp-codebox-generated-phpunit-fixed.php`
- `HOMEBOY_WP_CODEBOX_BIN=/Users/chubes/Developer/wp-codebox@fix-escape-phpunit-cwd-backslash/packages/cli/dist/index.js HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-escape-phpunit-cwd-backslash/packages/runtime-core/dist/index.js homeboy --force-hot --allow-local-hot test data-machine-code --path /Users/chubes/Developer/data-machine-code@fix-issue-615-cleanup-artifacts-dry-run-apply --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the generated PHP parse error, drafted the minimal template fix and smoke assertion, and ran local verification. Chris remains responsible for review and testing.