### PR TITLE
Fix default sandbox tool policy metadata

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -454,7 +454,7 @@ function sandboxToolPolicy(input: AgentTaskRunInput, taskInput: ReturnType<typeo
   return {
     schema: "wp-codebox/sandbox-tool-policy/v1",
     version: 1,
-    tools: [{ id: "deny-all", runtime_tool_id: "deny-all", execution_location: "parent", transport_visibility: "hidden", allowed: false }],
+    tools: [{ id: "deny-all", runtime_tool_id: "deny-all", execution_location: "parent", transport_visibility: "hidden", allowed: false, runtime: { environment: "control_plane", capability_scope: "control_plane" } }],
     metadata: { source: "wp-codebox.agent-task-run.default-deny" },
   }
 }

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -55,6 +55,10 @@ assert.ok(
   "successful normalized agent-bundle workloads should filter stale agent-task failure diagnostics",
 )
 assert.ok(
+  agentTaskRunSource.includes('runtime: { environment: "control_plane", capability_scope: "control_plane" }'),
+  "default deny-all sandbox policy should satisfy required runtime metadata",
+)
+assert.ok(
   recipeEvidenceSource.includes("reconcileAgentSandboxResult("),
   "successful agent task results should reconcile stale failed sandbox summaries",
 )


### PR DESCRIPTION
## Summary
- Include required runtime metadata in WP Codebox's fallback deny-all sandbox tool policy.
- Add a focused smoke assertion so the fallback remains valid under the sandbox policy validator.

## Verification
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the default policy validator failure, drafted the metadata fix and smoke assertion, and ran verification; Chris reviewed the behavior through the end-to-end Lab proof.