### PR TITLE
Fix partial visual compare evidence recovery

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -2786,6 +2786,31 @@ async function runVisualComparePairCommand({
   let viewport: BrowserProbeViewport | null = null
   let sourceDomSnapshot: VisualCompareDomSnapshot | undefined
   let candidateDomSnapshot: VisualCompareDomSnapshot | undefined
+  const sourceSummary = (): Record<string, unknown> => ({
+    label: sourceLabel,
+    ...(sourceUrl ? { url: sourceUrl, finalUrl: finalSourceUrl } : {}),
+    ...(sourceScreenshot ? { screenshot: sourceScreenshot } : {}),
+    ...(sourceDomSnapshotRef ? { domSnapshot: sourceDomSnapshotRef } : {}),
+  })
+  const candidateSummary = (): Record<string, unknown> => ({
+    label: candidateLabel,
+    ...(candidateUrl ? { url: candidateUrl, finalUrl: finalCandidateUrl } : {}),
+    ...(candidateScreenshot ? { screenshot: candidateScreenshot } : {}),
+    ...(candidateDomSnapshotRef ? { domSnapshot: candidateDomSnapshotRef } : {}),
+  })
+
+  const writePartialSummary = async (stage: "source-captured" | "candidate-captured"): Promise<void> => {
+    await writeVisualComparePartialSummary(summaryPath, {
+      artifactPathPrefix,
+      stage,
+      startedAt,
+      source: sourceSummary(),
+      candidate: candidateSummary(),
+      options: { waitFor, durationMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+      preview,
+      viewport,
+    })
+  }
 
   if (sourceTargetUrl && candidateTargetUrl) {
     const browser = await launchChromiumBrowser()
@@ -2795,14 +2820,17 @@ async function runVisualComparePairCommand({
       const sourceCapture = await captureVisualCompareUrl(page, sourceTargetUrl, sourcePath, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors)
       finalSourceUrl = sourceCapture.finalUrl
       sourceDomSnapshot = sourceCapture.domSnapshot
+      await writePartialSummary("source-captured")
       const candidateCapture = await captureVisualCompareUrl(page, candidateTargetUrl, candidatePath, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors)
       finalCandidateUrl = candidateCapture.finalUrl
       candidateDomSnapshot = candidateCapture.domSnapshot
+      await writePartialSummary("candidate-captured")
     } finally {
       await browser.close()
     }
   } else if (sourceScreenshot && candidateScreenshot) {
     await writeFile(sourcePath, await readFile(await resolveVisualCompareScreenshotPath(sourceScreenshot, artifactRoot)))
+    await writePartialSummary("source-captured")
     await writeFile(candidatePath, await readFile(await resolveVisualCompareScreenshotPath(candidateScreenshot, artifactRoot)))
     if (sourceDomSnapshotRef && candidateDomSnapshotRef) {
       const sourceArtifact = await readVisualCompareDomSnapshotArtifact(sourceDomSnapshotRef, artifactRoot)
@@ -2813,6 +2841,7 @@ async function runVisualComparePairCommand({
       finalCandidateUrl = candidateArtifact.finalUrl || candidateArtifact.snapshot.url
       viewport = candidateArtifact.viewport ?? sourceArtifact.viewport ?? viewport
     }
+    await writePartialSummary("candidate-captured")
   }
 
   const comparison = await comparePngFiles(sourcePath, candidatePath, diffPath, { threshold, includeAA, maxRegions })
@@ -2828,23 +2857,11 @@ async function runVisualComparePairCommand({
   })
   const finishedAt = now()
   const status = comparison.mismatchPixels === 0 && !comparison.dimensionMismatch ? "identical" : "different"
-  const sourceSummary = {
-    label: sourceLabel,
-    ...(sourceUrl ? { url: sourceUrl, finalUrl: finalSourceUrl } : {}),
-    ...(sourceScreenshot ? { screenshot: sourceScreenshot } : {}),
-    ...(sourceDomSnapshotRef ? { domSnapshot: sourceDomSnapshotRef } : {}),
-  }
-  const candidateSummary = {
-    label: candidateLabel,
-    ...(candidateUrl ? { url: candidateUrl, finalUrl: finalCandidateUrl } : {}),
-    ...(candidateScreenshot ? { screenshot: candidateScreenshot } : {}),
-    ...(candidateDomSnapshotRef ? { domSnapshot: candidateDomSnapshotRef } : {}),
-  }
   const baseline = baselineRef
     ? await createVisualCompareBaselineDelta({
         baselineRef,
         artifactRoot,
-        current: { status, comparison, source: sourceSummary, candidate: candidateSummary },
+        current: { status, comparison, source: sourceSummary(), candidate: candidateSummary() },
       })
     : undefined
   const files = {
@@ -2859,8 +2876,8 @@ async function runVisualComparePairCommand({
     schema: "wp-codebox/visual-compare/v1",
     command: "wordpress.visual-compare",
     status,
-    source: sourceSummary,
-    candidate: candidateSummary,
+    source: sourceSummary(),
+    candidate: candidateSummary(),
     options: { waitFor, durationMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
     limitations: explanation
       ? explanation.limitations
@@ -2945,44 +2962,10 @@ async function runVisualCompareMatrixCommand({
       artifactPathPrefix: `files/browser/visual-compare/${entry.name}`,
     })
     entries.push({ name: entry.name, artifact: result.artifact, summary: JSON.parse(result.output) as VisualComparePairSummary })
+    await writeVisualCompareMatrixSummary(artifactRoot, args, runtimeSpec, server, matrix.entries, entries, startedAt, false)
   }
 
-  const finishedAt = now()
-  const comparisons = entries.map((entry) => ({
-    name: entry.name,
-    status: entry.summary.status,
-    source: entry.summary.source,
-    candidate: entry.summary.candidate,
-    options: entry.summary.options,
-    viewport: entry.summary.viewport,
-    files: entry.summary.files,
-    comparison: entry.summary.comparison,
-  }))
-  const mismatchRatios = comparisons.map((entry) => entry.comparison.mismatchRatio)
-  const mismatchPixels = comparisons.map((entry) => entry.comparison.mismatchPixels)
-  const matrixSummary = {
-    schema: "wp-codebox/visual-compare-matrix/v1",
-    command: "wordpress.visual-compare",
-    status: comparisons.every((entry) => entry.status === "identical") ? "identical" : "different",
-    startedAt,
-    finishedAt,
-    metrics: {
-      comparisons: comparisons.length,
-      identical: comparisons.filter((entry) => entry.status === "identical").length,
-      different: comparisons.filter((entry) => entry.status !== "identical").length,
-      maxMismatchRatio: Math.max(...mismatchRatios),
-      meanMismatchRatio: mismatchRatios.reduce((total, value) => total + value, 0) / mismatchRatios.length,
-      maxMismatchPixels: Math.max(...mismatchPixels),
-      meanMismatchPixels: mismatchPixels.reduce((total, value) => total + value, 0) / mismatchPixels.length,
-    },
-    comparisons,
-    files: {
-      summary: "files/browser/visual-compare/matrix-summary.json",
-    },
-  }
-  const browserDirectory = join(artifactRoot, "files", "browser", "visual-compare")
-  await mkdir(browserDirectory, { recursive: true })
-  await writeFile(join(browserDirectory, "matrix-summary.json"), `${JSON.stringify(matrixSummary, null, 2)}\n`)
+  const matrixSummary = await writeVisualCompareMatrixSummary(artifactRoot, args, runtimeSpec, server, matrix.entries, entries, startedAt, true)
 
   const sourceScreenshots = entries.map((entry) => entry.artifact.files.sourceScreenshot).filter((file): file is string => typeof file === "string")
   const candidateScreenshots = entries.map((entry) => entry.artifact.files.candidateScreenshot).filter((file): file is string => typeof file === "string")
@@ -3016,8 +2999,8 @@ async function runVisualCompareMatrixCommand({
         status: matrixSummary.status,
         mismatchRatio: matrixSummary.metrics.maxMismatchRatio,
         mismatchPixels: matrixSummary.metrics.maxMismatchPixels,
-        totalPixels: comparisons.reduce((total, entry) => total + entry.comparison.totalPixels, 0),
-        dimensionMismatch: comparisons.some((entry) => entry.comparison.dimensionMismatch),
+        totalPixels: matrixSummary.comparisons.reduce((total, entry) => total + entry.comparison.totalPixels, 0),
+        dimensionMismatch: matrixSummary.comparisons.some((entry) => entry.comparison.dimensionMismatch),
         explanation: matrixSummary.files.summary,
       },
       viewport: firstArtifact?.summary.viewport ?? null,
@@ -3030,6 +3013,98 @@ async function runVisualCompareMatrixCommand({
   }
 }
 
+async function writeVisualComparePartialSummary(summaryPath: string, input: {
+  artifactPathPrefix: string
+  stage: "source-captured" | "candidate-captured"
+  startedAt: string
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  options: Record<string, unknown>
+  preview: ReturnType<typeof browserPreviewRouting>
+  viewport: BrowserProbeViewport | null
+}): Promise<void> {
+  const files = {
+    sourceScreenshot: `${input.artifactPathPrefix}/source.png`,
+    ...(input.stage === "candidate-captured" ? { candidateScreenshot: `${input.artifactPathPrefix}/candidate.png` } : {}),
+    summary: `${input.artifactPathPrefix}/summary.json`,
+  }
+  const summary = {
+    schema: "wp-codebox/visual-compare/v1",
+    command: "wordpress.visual-compare",
+    status: "partial",
+    partial: true,
+    stage: input.stage,
+    source: input.source,
+    candidate: input.candidate,
+    options: input.options,
+    limitations: ["visual compare was interrupted before full diff metrics were available; recovered files show the latest completed capture stage"],
+    preview: input.preview,
+    viewport: input.viewport,
+    startedAt: input.startedAt,
+    updatedAt: now(),
+    files,
+  }
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`)
+}
+
+async function writeVisualCompareMatrixSummary(
+  artifactRoot: string,
+  args: string[],
+  runtimeSpec: RuntimeCreateSpec | undefined,
+  server: PlaygroundCliServer,
+  expectedEntries: VisualCompareMatrixEntry[],
+  entries: Array<{ name: string; artifact: BrowserArtifact; summary: VisualComparePairSummary }>,
+  startedAt: string,
+  complete: boolean,
+): Promise<VisualCompareMatrixSummary> {
+  const comparisons = entries.map((entry) => ({
+    name: entry.name,
+    status: entry.summary.status,
+    source: entry.summary.source,
+    candidate: entry.summary.candidate,
+    options: entry.summary.options,
+    viewport: entry.summary.viewport,
+    files: entry.summary.files,
+    comparison: entry.summary.comparison,
+  }))
+  const mismatchRatios = comparisons.map((entry) => entry.comparison.mismatchRatio)
+  const mismatchPixels = comparisons.map((entry) => entry.comparison.mismatchPixels)
+  const maxMismatchRatio = mismatchRatios.length > 0 ? Math.max(...mismatchRatios) : 0
+  const maxMismatchPixels = mismatchPixels.length > 0 ? Math.max(...mismatchPixels) : 0
+  const matrixSummary: VisualCompareMatrixSummary = {
+    schema: "wp-codebox/visual-compare-matrix/v1",
+    command: "wordpress.visual-compare",
+    status: complete
+      ? comparisons.every((entry) => entry.status === "identical") ? "identical" : "different"
+      : "partial",
+    complete,
+    startedAt,
+    ...(complete ? { finishedAt: now() } : { updatedAt: now() }),
+    metrics: {
+      expectedComparisons: expectedEntries.length,
+      comparisons: comparisons.length,
+      identical: comparisons.filter((entry) => entry.status === "identical").length,
+      different: comparisons.filter((entry) => entry.status !== "identical").length,
+      maxMismatchRatio,
+      meanMismatchRatio: mismatchRatios.length > 0 ? mismatchRatios.reduce((total, value) => total + value, 0) / mismatchRatios.length : 0,
+      maxMismatchPixels,
+      meanMismatchPixels: mismatchPixels.length > 0 ? mismatchPixels.reduce((total, value) => total + value, 0) / mismatchPixels.length : 0,
+    },
+    comparisons,
+    files: {
+      summary: "files/browser/visual-compare/matrix-summary.json",
+    },
+    ...(!complete ? {
+      preview: entries[0]?.artifact.preview ?? browserPreviewRouting(args, runtimeSpec, server.serverUrl),
+      limitations: ["visual compare matrix was interrupted before all comparisons completed; recovered comparisons contain complete per-entry evidence for finished viewports"],
+    } : {}),
+  }
+  const browserDirectory = join(artifactRoot, "files", "browser", "visual-compare")
+  await mkdir(browserDirectory, { recursive: true })
+  await writeFile(join(browserDirectory, "matrix-summary.json"), `${JSON.stringify(matrixSummary, null, 2)}\n`)
+  return matrixSummary
+}
+
 interface VisualComparePairSummary {
   status: string
   source: Record<string, unknown>
@@ -3038,6 +3113,39 @@ interface VisualComparePairSummary {
   viewport: BrowserProbeViewport | null
   files: Record<string, string>
   comparison: { mismatchRatio: number; mismatchPixels: number; totalPixels: number; dimensionMismatch: boolean }
+}
+
+interface VisualCompareMatrixSummary {
+  schema: "wp-codebox/visual-compare-matrix/v1"
+  command: "wordpress.visual-compare"
+  status: string
+  complete: boolean
+  startedAt: string
+  finishedAt?: string
+  updatedAt?: string
+  metrics: {
+    expectedComparisons: number
+    comparisons: number
+    identical: number
+    different: number
+    maxMismatchRatio: number
+    meanMismatchRatio: number
+    maxMismatchPixels: number
+    meanMismatchPixels: number
+  }
+  comparisons: Array<{
+    name: string
+    status: string
+    source: Record<string, unknown>
+    candidate: Record<string, unknown>
+    options: Record<string, unknown>
+    viewport: BrowserProbeViewport | null
+    files: Record<string, string>
+    comparison: VisualComparePairSummary["comparison"]
+  }>
+  files: { summary: string }
+  preview?: ReturnType<typeof browserPreviewRouting>
+  limitations?: string[]
 }
 
 interface VisualCompareMatrixEntry {

--- a/scripts/browser-visual-compare-matrix-smoke.ts
+++ b/scripts/browser-visual-compare-matrix-smoke.ts
@@ -104,11 +104,14 @@ assert.equal(existsSync(matrixSummaryPath), true, "matrix summary should be capt
 const summary = JSON.parse(await readFile(matrixSummaryPath, "utf8")) as {
   schema: string
   status: string
-  metrics: { comparisons: number; different: number; maxMismatchPixels: number; meanMismatchRatio: number }
+  complete: boolean
+  metrics: { expectedComparisons: number; comparisons: number; different: number; maxMismatchPixels: number; meanMismatchRatio: number }
   comparisons: Array<{ name: string; status: string; files: Record<string, string>; comparison: { mismatchPixels: number } }>
 }
 assert.equal(summary.schema, "wp-codebox/visual-compare-matrix/v1")
 assert.equal(summary.status, "different")
+assert.equal(summary.complete, true)
+assert.equal(summary.metrics.expectedComparisons, 4)
 assert.equal(summary.metrics.comparisons, 4)
 assert.equal(summary.metrics.different, 4)
 assert.ok(summary.metrics.maxMismatchPixels > 0, "aggregate should expose max mismatch pixels")
@@ -134,6 +137,76 @@ assert.equal(review.browser?.probes?.[0]?.visualCompare?.status, "different", "r
 assert.ok((review.browser?.probes?.[0]?.visualCompare?.mismatchPixels ?? 0) > 0, "review summary should expose matrix max mismatch count")
 assert.equal(review.browser?.probes?.[0]?.visualCompare?.explanation, "files/browser/visual-compare/matrix-summary.json", "review summary should expose aggregate artifact")
 
+const partialRecipePath = join(workspace, "partial-recipe.json")
+const partialArtifactsRoot = join(workspace, "partial-artifacts")
+const completedComparison = summary.comparisons[0]
+assert.ok(completedComparison, "matrix smoke should have a completed comparison to reuse")
+const partialMatrix = {
+  comparisons: [
+    {
+      name: "desktop",
+      sourceScreenshot: join(artifactDirectory, completedComparison.files.sourceScreenshot),
+      candidateScreenshot: join(artifactDirectory, completedComparison.files.candidateScreenshot),
+      sourceLabel: "desktop-source",
+      candidateLabel: "desktop-candidate",
+    },
+    {
+      name: "mobile",
+      sourceScreenshot: join(workspace, "missing-source.png"),
+      candidateScreenshot: join(workspace, "missing-candidate.png"),
+      sourceLabel: "mobile-source",
+      candidateLabel: "mobile-candidate",
+    },
+  ],
+}
+await writeFile(partialRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.visual-compare",
+        args: [
+          `matrix-json=${JSON.stringify(partialMatrix)}`,
+          "threshold=0.1",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: partialArtifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const partialOutput = await runCliAllowFailure([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  partialRecipePath,
+  "--json",
+])
+
+assert.equal(partialOutput.success, false, "partial matrix recipe should fail on the later missing screenshot")
+assert.ok(partialOutput.artifacts?.directory, "partial matrix failure should return an artifact directory")
+const partialSummaryPath = join(partialOutput.artifacts.directory, "files", "browser", "visual-compare", "matrix-summary.json")
+assert.equal(existsSync(partialSummaryPath), true, "partial matrix summary should be recoverable after later command failure")
+const partialSummary = JSON.parse(await readFile(partialSummaryPath, "utf8")) as {
+  schema: string
+  status: string
+  complete: boolean
+  limitations?: string[]
+  metrics: { expectedComparisons: number; comparisons: number }
+  comparisons: Array<{ name: string; files: Record<string, string>; comparison: { mismatchPixels: number } }>
+}
+assert.equal(partialSummary.schema, "wp-codebox/visual-compare-matrix/v1")
+assert.equal(partialSummary.status, "partial")
+assert.equal(partialSummary.complete, false)
+assert.equal(partialSummary.metrics.expectedComparisons, 2)
+assert.equal(partialSummary.metrics.comparisons, 1)
+assert.equal(partialSummary.comparisons[0]?.name, "desktop")
+assert.ok(partialSummary.limitations?.some((limitation) => limitation.includes("interrupted before all comparisons completed")), "partial summary should explain the interrupted contract")
+assert.equal(existsSync(join(partialOutput.artifacts.directory, partialSummary.comparisons[0]!.files.sourceScreenshot)), true, "partial summary should point to recovered source screenshot")
+assert.equal(existsSync(join(partialOutput.artifacts.directory, partialSummary.comparisons[0]!.files.candidateScreenshot)), true, "partial summary should point to recovered candidate screenshot")
+
 console.log("Browser visual compare matrix smoke passed")
 
 async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
@@ -145,6 +218,19 @@ async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: 
   const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
   if (code !== 0) {
     throw new Error(`CLI exited with ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  }
+  return JSON.parse(stdout)
+}
+
+async function runCliAllowFailure(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
+  const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => { stdout += chunk })
+  child.stderr.on("data", (chunk) => { stderr += chunk })
+  const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
+  if (code === 0) {
+    throw new Error(`CLI unexpectedly exited with 0\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
   }
   return JSON.parse(stdout)
 }


### PR DESCRIPTION
## Summary
- Persist `wordpress.visual-compare` pair summaries as source/candidate screenshots are captured so interrupted runs leave an explicit partial contract.
- Persist matrix-level `matrix-summary.json` after each completed comparison, making completed viewports recoverable when a later viewport fails or times out.
- Extend the matrix smoke to assert complete summaries and recovered partial summaries after a later comparison fails.

Fixes #865.

## Testing
- `npm run build`
- `npm run browser-visual-compare-matrix-smoke`
- `./node_modules/.bin/tsx scripts/recipe-run-timeout-smoke.ts`
- `./node_modules/.bin/tsx scripts/browser-visual-compare-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and focused smoke coverage; Chris remains responsible for review and validation.