### PR TITLE
Surface agent task failure evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1308,6 +1308,8 @@ Generic caller-owned `request.json` payloads may use this shape:
 
 WP Codebox normalizes the task input, writes the private temporary recipe, runs `wp-codebox recipe-run`, then deletes temporary recipe/seed files. The JSON response keeps `schema: "wp-codebox/agent-task-run/v1"` and includes stable top-level `status`, `session`, `artifacts`, `diagnostics`, `evidence_refs`, `run_metadata`, `completion_outcome`, and raw `run` fields. Secret values are never accepted in the request or returned in the response; `secret_env` carries names only.
 
+Failed `agent-task-run` responses also include `failure_evidence` with `schema: "wp-codebox/agent-task-run-failure-evidence/v1"`. This block is intentionally safe for parent orchestrators to persist alongside their own task failure record. It includes the best available `phase`, `command`, `exit_code`, message, stdout/stderr snippets, runtime and sandbox identifiers, artifact directory or bundle identifiers, recipe-run status/run ID, diagnostics, phase evidence, and the serialized error. If recipe-run fails before normal runtime artifacts exist or returns malformed output, `agent-task-run` still emits this fallback evidence block in the CLI JSON payload and references it from `evidence_refs` with kind `codebox-agent-task-failure-evidence`.
+
 `runtime_overlay_profiles` is a convenience layer for reusable runtime stack examples. The raw primitives remain `provider_plugin_paths`, `component_contracts`, `runtime_stack_mounts`, `runtime_overlays`, and `secret_env`; profiles only expand those fields before the private recipe is written.
 
 The built-in `codex-subscription` profile is an example of packaging a provider plugin plus a scoped bundled-library overlay for subscription-backed model access. It expands to:

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -60,9 +60,30 @@ interface AgentTaskRunOutput {
   run: Record<string, unknown>
   diagnostics: Array<Record<string, unknown>>
   evidence_refs: Array<Record<string, unknown>>
+  failure_evidence?: Record<string, unknown>
   run_metadata: Record<string, unknown>
   metadata: Record<string, unknown>
 }
+
+interface CapturedOutput<T> {
+  result: T
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+interface FailureEvidenceInput {
+  input: AgentTaskRunInput
+  task: string
+  wpVersion: string
+  artifacts: string
+  recipePath: string
+  run: Record<string, unknown>
+  capture?: CapturedOutput<unknown>
+  error?: unknown
+}
+
+const FAILURE_SNIPPET_CHARS = 4000
 
 export async function runAgentTaskRunCommand(args: string[]): Promise<number> {
   const options = parseAgentTaskRunOptions(args)
@@ -85,10 +106,11 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
   const artifacts = stringValue(input.artifacts_path) || await mkdtemp(join(tmpdir(), "wp-codebox-agent-task-artifacts-"))
   const recipeDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-agent-task-recipe-"))
   const recipePath = join(recipeDirectory, "recipe.json")
-  const recipe = buildAgentTaskRecipe(input, taskInput, wpVersion)
+  let capture: CapturedOutput<number> | undefined
 
-  await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`)
   try {
+    const recipe = buildAgentTaskRecipe(input, taskInput, wpVersion)
+    await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`)
     const recipeRunArgs = ["--recipe", recipePath, "--artifacts", artifacts, "--json"]
     if (options.previewHoldSeconds) {
       recipeRunArgs.push("--preview-hold-seconds", options.previewHoldSeconds)
@@ -96,7 +118,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     if (options.previewPublicUrl) {
       recipeRunArgs.push("--preview-public-url", options.previewPublicUrl)
     }
-    const capture = await captureStdout(() => runRecipeRunCommand(recipeRunArgs))
+    capture = await captureOutput(() => runRecipeRunCommand(recipeRunArgs))
     const run = parseRecipeRunOutput(capture.stdout)
     const runRecord = objectValue(run.run) || {}
     const artifactsRecord = objectValue(run.artifacts) || {}
@@ -110,6 +132,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     const hasAgentBundle = Object.keys(agentBundle).length > 0
     const success = Boolean(run.success) && (!hasAgentBundle || workload.success)
     const agentTaskResult = objectValue(run.agentTaskResult) || objectValue(runRecord.agentTaskResult) || objectValue(artifactsRecord.agentTaskResult) || {}
+    const failureEvidence = success ? undefined : buildFailureEvidence({ input, task, wpVersion, artifacts, recipePath, run, capture })
     const output: AgentTaskRunOutput = {
       success,
       schema: "wp-codebox/agent-task-run/v1",
@@ -124,8 +147,9 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       completion_outcome: objectValue(run.completionOutcome) || objectValue(artifactsRecord.completionOutcome) || {},
       structured_artifacts: structuredArtifactRefs(agentTaskResult),
       run,
-      diagnostics: [...diagnostics(run, success ? 0 : capture.exitCode, success), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])],
-      evidence_refs: evidenceRefs(run, artifacts),
+      diagnostics: [...diagnostics(run, success ? 0 : capture.exitCode, success, failureEvidence), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])],
+      evidence_refs: evidenceRefs(run, artifacts, failureEvidence),
+      failure_evidence: failureEvidence,
       run_metadata: stripUndefined({
         run_id: stringValue(runRecord.runId),
         run_status: stringValue(runRecord.status),
@@ -142,6 +166,41 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       },
     }
     return output
+  } catch (error) {
+    const run = { success: false, error: serializeUnknownError(error) }
+    const failureEvidence = buildFailureEvidence({ input, task, wpVersion, artifacts, recipePath, run, capture, error })
+    const failureDiagnostics = diagnostics(run, capture?.exitCode ?? 1, false, failureEvidence)
+    return {
+      success: false,
+      schema: "wp-codebox/agent-task-run/v1",
+      status: "failed",
+      session: sandboxSession(input, run, artifacts, "failed"),
+      task,
+      task_input: taskInput,
+      wp: wpVersion,
+      artifacts,
+      agent_result: {},
+      agent_task_result: {},
+      completion_outcome: {},
+      structured_artifacts: [],
+      run,
+      diagnostics: failureDiagnostics,
+      evidence_refs: evidenceRefs(run, artifacts, failureEvidence),
+      failure_evidence: failureEvidence,
+      run_metadata: stripUndefined({
+        sandbox_session_id: stringValue(input.sandbox_session_id),
+        orchestrator: input.orchestrator,
+        parent_request_schema: stringValue(input.parent_request?.schema),
+      }),
+      metadata: {
+        agent_runtime: {
+          workload: {
+            success: false,
+            diagnostics: failureDiagnostics,
+          },
+        },
+      },
+    }
   } finally {
     await rm(recipeDirectory, { recursive: true, force: true })
   }
@@ -322,18 +381,25 @@ function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
   return { inputPath, json, previewHoldSeconds, previewPublicUrl }
 }
 
-async function captureStdout<T>(callback: () => Promise<T>): Promise<{ result: T; stdout: string; exitCode: number }> {
+async function captureOutput<T>(callback: () => Promise<T>): Promise<CapturedOutput<T>> {
   const originalWrite = process.stdout.write.bind(process.stdout)
+  const originalErrorWrite = process.stderr.write.bind(process.stderr)
   let stdout = ""
+  let stderr = ""
   ;(process.stdout.write as typeof process.stdout.write) = ((chunk: unknown, ...args: unknown[]) => {
     stdout += String(chunk)
     return true
   }) as typeof process.stdout.write
+  ;(process.stderr.write as typeof process.stderr.write) = ((chunk: unknown, ...args: unknown[]) => {
+    stderr += String(chunk)
+    return true
+  }) as typeof process.stderr.write
   try {
     const result = await callback()
-    return { result, stdout, exitCode: Number(result) || 0 }
+    return { result, stdout, stderr, exitCode: Number(result) || 0 }
   } finally {
     process.stdout.write = originalWrite
+    process.stderr.write = originalErrorWrite
   }
 }
 
@@ -363,7 +429,7 @@ function sandboxSession(input: AgentTaskRunInput, run: Record<string, unknown>, 
   })
 }
 
-function diagnostics(run: Record<string, unknown>, exitCode: number, normalizedSuccess = false): Array<Record<string, unknown>> {
+function diagnostics(run: Record<string, unknown>, exitCode: number, normalizedSuccess = false, failureEvidence?: Record<string, unknown>): Array<Record<string, unknown>> {
   const existing = Array.isArray(run.diagnostics) ? run.diagnostics.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
   if (normalizedSuccess) {
     return existing.filter((entry) => stringValue(entry.class) !== "wp-codebox.agent_task_run_failed")
@@ -375,18 +441,100 @@ function diagnostics(run: Record<string, unknown>, exitCode: number, normalizedS
     return []
   }
   const errorRecord = objectValue(run.error) || {}
-  return [{ class: "wp-codebox.agent_task_run_failed", message: stringValue(errorRecord.message) || "WP Codebox agent task run failed.", data: { exit_code: exitCode } }]
+  return [{
+    class: "wp-codebox.agent_task_run_failed",
+    message: stringValue(errorRecord.message) || "WP Codebox agent task run failed.",
+    data: stripUndefined({
+      exit_code: exitCode,
+      phase: stringValue(failureEvidence?.phase),
+      command: stringValue(failureEvidence?.command),
+      failure_evidence: failureEvidence,
+    }),
+  }]
 }
 
-function evidenceRefs(run: Record<string, unknown>, artifacts: string): Array<Record<string, unknown>> {
+function evidenceRefs(run: Record<string, unknown>, artifacts: string, failureEvidence?: Record<string, unknown>): Array<Record<string, unknown>> {
   const artifactsRecord = objectValue(run.artifacts) || {}
   const refs: Array<Record<string, unknown> | null> = [
     { kind: "codebox-artifacts", uri: artifacts, label: "WP Codebox artifacts" },
     stringValue(artifactsRecord.manifestPath) ? { kind: "codebox-manifest", uri: stringValue(artifactsRecord.manifestPath), label: "WP Codebox artifact manifest" } : null,
     stringValue(artifactsRecord.reviewPath) ? { kind: "codebox-review", uri: stringValue(artifactsRecord.reviewPath), label: "WP Codebox review payload" } : null,
     stringValue(artifactsRecord.patchPath) ? { kind: "codebox-patch", uri: stringValue(artifactsRecord.patchPath), label: "WP Codebox patch" } : null,
+    failureEvidence ? { kind: "codebox-agent-task-failure-evidence", uri: artifacts, label: "WP Codebox agent task failure evidence", metadata: failureEvidenceSummary(failureEvidence) } : null,
   ]
   return refs.filter((entry): entry is Record<string, unknown> => Boolean(entry))
+}
+
+function buildFailureEvidence(values: FailureEvidenceInput): Record<string, unknown> {
+  const runRecord = objectValue(values.run.run) || {}
+  const runtimeRecord = objectValue(values.run.runtime) || objectValue(runRecord.runtime) || {}
+  const artifactsRecord = objectValue(values.run.artifacts) || {}
+  const execution = failedExecution(values.run)
+  const phase = failedPhase(values.run)
+  const errorRecord = objectValue(values.run.error) || serializeUnknownError(values.error)
+  const stdout = stringValue(execution?.stdout) || values.capture?.stdout || ""
+  const stderr = stringValue(execution?.stderr) || values.capture?.stderr || ""
+  const recipeRunEvidence = stripUndefined({
+    schema: stringValue(values.run.schema) || undefined,
+    recipe_path: values.recipePath,
+    status: stringValue(runRecord.status) || stringValue(values.run.status) || undefined,
+    run_id: stringValue(runRecord.runId) || undefined,
+  })
+  const runtimeEvidence = nonEmptyObject(stripUndefined({
+    id: stringValue(runtimeRecord.id) || undefined,
+    status: stringValue(runtimeRecord.status) || undefined,
+  }))
+
+  return stripUndefined({
+    schema: "wp-codebox/agent-task-run-failure-evidence/v1",
+    phase: stringValue(execution?.recipePhase) || stringValue(phase?.name) || "agent-task-run",
+    command: stringValue(execution?.recipeCommand) || stringValue(execution?.command) || "wp-codebox recipe-run --json",
+    exit_code: numberValue(execution?.exitCode) ?? values.capture?.exitCode ?? 1,
+    message: stringValue(errorRecord.message) || "WP Codebox agent task run failed.",
+    task: values.task,
+    recipe_run: recipeRunEvidence,
+    runtime: runtimeEvidence,
+    sandbox: stripUndefined({
+      sandbox_session_id: stringValue(values.input.sandbox_session_id) || undefined,
+      orchestrator: values.input.orchestrator,
+      artifacts_directory: values.artifacts,
+      artifact_bundle_id: stringValue(artifactsRecord.id) || stringValue(artifactsRecord.bundle_id) || stringValue(artifactsRecord.bundleId) || undefined,
+    }),
+    stdout: outputSnippet(stdout),
+    stderr: outputSnippet(stderr),
+    diagnostics: Array.isArray(values.run.diagnostics) ? values.run.diagnostics.filter((entry) => Boolean(objectValue(entry))) : undefined,
+    phase_evidence: Array.isArray(values.run.phaseEvidence) ? values.run.phaseEvidence.filter((entry) => Boolean(objectValue(entry))) : undefined,
+    error: Object.keys(errorRecord).length > 0 ? errorRecord : undefined,
+    wp: values.wpVersion,
+  })
+}
+
+function failedExecution(run: Record<string, unknown>): Record<string, unknown> | undefined {
+  const executions = Array.isArray(run.executions) ? run.executions.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
+  return [...executions].reverse().find((execution) => numberValue(execution.exitCode) !== undefined && numberValue(execution.exitCode) !== 0)
+}
+
+function failedPhase(run: Record<string, unknown>): Record<string, unknown> | undefined {
+  const phases = Array.isArray(run.phaseEvidence) ? run.phaseEvidence.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
+  return [...phases].reverse().find((phase) => stringValue(phase.status) === "failed")
+}
+
+function outputSnippet(value: string): Record<string, unknown> | undefined {
+  if (!value) return undefined
+  const truncated = value.length > FAILURE_SNIPPET_CHARS
+  const snippet = truncated ? value.slice(-FAILURE_SNIPPET_CHARS) : value
+  return { bytes: Buffer.byteLength(value), truncated, value: snippet }
+}
+
+function failureEvidenceSummary(failureEvidence: Record<string, unknown>): Record<string, unknown> {
+  return stripUndefined({
+    schema: stringValue(failureEvidence.schema) || undefined,
+    phase: stringValue(failureEvidence.phase) || undefined,
+    command: stringValue(failureEvidence.command) || undefined,
+    exit_code: numberValue(failureEvidence.exit_code),
+    runtime: nonEmptyObject(objectValue(failureEvidence.runtime)),
+    sandbox: nonEmptyObject(objectValue(failureEvidence.sandbox)),
+  })
 }
 
 function structuredArtifactRefs(agentTaskResult: Record<string, unknown>): Array<Record<string, unknown>> {
@@ -497,4 +645,19 @@ function stringRecord(value: unknown): Record<string, string> | undefined {
 
 function stringValue(value: unknown): string {
   return value === undefined || value === null ? "" : String(value).trim()
+}
+
+function nonEmptyObject(value: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  return value && Object.keys(value).length > 0 ? value : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function serializeUnknownError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return stripUndefined({ name: error.name, message: error.message, stack: error.stack })
+  }
+  return { message: stringValue(error) || "Unknown WP Codebox agent task run failure." }
 }

--- a/packages/runtime-core/src/agent-task-run-result.ts
+++ b/packages/runtime-core/src/agent-task-run-result.ts
@@ -95,6 +95,7 @@ export function normalizeAgentTaskRunResult(raw: unknown, options: AgentTaskRunR
       confidence: stringValue(completionOutcome.confidence),
       provider_error: objectValue(result.provider_error),
       timeout: result.timeout === true ? true : undefined,
+      failure_evidence: objectValue(result.failure_evidence),
     }),
     no_op: noOp,
     failure_classification: failureClassification || undefined,

--- a/scripts/agent-task-run-result-normalizer-smoke.ts
+++ b/scripts/agent-task-run-result-normalizer-smoke.ts
@@ -17,6 +17,19 @@ const failed = normalizeAgentTaskRunResult({ success: false, status: "completed"
 assertEqual(failed.status, "failed", "completed failure normalizes to failed")
 assertEqual(failed.failure_classification, "runtime", "failed result classifies as runtime")
 
+const failedWithEvidence = normalizeAgentTaskRunResult({
+  success: false,
+  status: "failed",
+  failure_evidence: {
+    schema: "wp-codebox/agent-task-run-failure-evidence/v1",
+    phase: "run_workloads",
+    command: "workflow.main[0]:wp-codebox.agent-sandbox-run",
+    exit_code: 1,
+  },
+})
+assertEqual((failedWithEvidence.metadata.failure_evidence as Record<string, unknown>).phase, "run_workloads", "failure evidence is retained in normalized metadata")
+assertEqual((failedWithEvidence.metadata.failure_evidence as Record<string, unknown>).command, "workflow.main[0]:wp-codebox.agent-sandbox-run", "failure command evidence is retained in normalized metadata")
+
 const timeout = normalizeAgentTaskRunResult({ success: false, timeout: true })
 assertEqual(timeout.status, "timeout", "timeout flag normalizes to timeout")
 assertEqual(timeout.failure_classification, "timeout", "timeout result classifies as timeout")

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { artifactManifestFile, normalizeTaskInput, type ArtifactBundle } from "@automattic/wp-codebox-core"
-import { buildAgentTaskRecipe } from "../packages/cli/src/commands/agent-task-run.js"
+import { buildAgentTaskRecipe, runAgentTask } from "../packages/cli/src/commands/agent-task-run.js"
 import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { installMuPluginsCode } from "../packages/cli/src/recipe-sources.js"
 import { buildAgentTaskSingleResult, finalizeAgentSandboxEvidence } from "../packages/cli/src/recipe-evidence.js"
@@ -48,7 +48,7 @@ const agentCodeSource = readFileSync(new URL("../packages/cli/src/agent-code.ts"
 const recipeEvidenceSource = readFileSync(new URL("../packages/cli/src/recipe-evidence.ts", import.meta.url), "utf8")
 const sandboxCode = agentSandboxRunCode("Run a bundle", "echo json_encode(array('ok' => true));", [])
 assert.ok(
-  agentTaskRunSource.includes("diagnostics(run, success ? 0 : capture.exitCode, success)"),
+  agentTaskRunSource.includes("diagnostics(run, success ? 0 : capture.exitCode, success, failureEvidence)"),
   "successful normalized agent-bundle workloads should not keep stale recipe-run failure diagnostics",
 )
 assert.ok(
@@ -103,6 +103,23 @@ assert.equal(verifyRecipe.workflow.after?.[0]?.command, "wordpress.phpunit", "af
 // Without verify_steps, no after phase is emitted (back-compat with current runs).
 const noVerifyRecipe = buildAgentTaskRecipe(input, normalizeTaskInput(input), "trunk")
 assert.equal(noVerifyRecipe.workflow.after, undefined, "no verify_steps should leave workflow.after unset")
+
+const failingOutput = await runAgentTask({
+  goal: "Fail before runtime startup so callers still receive evidence",
+  runtime_overlay_profiles: ["unknown-profile"],
+  sandbox_session_id: "sandbox-failure-smoke",
+  orchestrator: { agent_task_id: "agent-task-failure-smoke" },
+  artifacts_path: mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-failure-smoke-")),
+}, { inputPath: "", json: true, previewHoldSeconds: "", previewPublicUrl: "" })
+const failureEvidence = failingOutput.failure_evidence as Record<string, unknown>
+assert.equal(failingOutput.success, false, "failing agent-task-run should return a failed JSON payload")
+assert.equal(failingOutput.status, "failed", "failing agent-task-run status should be failed")
+assert.equal(failureEvidence?.schema, "wp-codebox/agent-task-run-failure-evidence/v1", "failure evidence schema should be stable")
+assert.equal(failureEvidence?.phase, "agent-task-run", "pre-runtime failures should still include a phase")
+assert.equal(failureEvidence?.command, "wp-codebox recipe-run --json", "pre-runtime failures should still include a command")
+assert.equal((failureEvidence?.sandbox as Record<string, unknown>)?.sandbox_session_id, "sandbox-failure-smoke", "failure evidence should include sandbox identifiers")
+assert.equal(Array.isArray(failingOutput.diagnostics) && failingOutput.diagnostics.length > 0, true, "failure diagnostics should be emitted")
+assert.equal(failingOutput.evidence_refs.some((ref) => ref.kind === "codebox-agent-task-failure-evidence"), true, "failure evidence ref should be emitted")
 
 const structuredInput = {
   goal: "Transform a concept packet into a design packet",


### PR DESCRIPTION
## Summary
- Adds a stable `failure_evidence` envelope to failed `wp-codebox agent-task-run --json` responses, including phase/command, exit code, stdout/stderr snippets, recipe/runtime/sandbox identifiers, diagnostics, phase evidence, and serialized error details.
- Preserves failure evidence through diagnostics, `evidence_refs`, and `normalizeAgentTaskRunResult()` metadata so upstream orchestrators can persist actionable failure details.
- Documents the failure payload contract and adds smoke coverage for deliberate agent-task-run failure output.

Fixes #867.

## Tests
- `npm run build`
- `npx tsx scripts/agent-task-run-result-normalizer-smoke.ts`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npm run smoke -- --group=agent`
- Direct failing CLI probe: `wp-codebox agent-task-run --json` with an unknown runtime overlay profile exits `1` and includes `failure_evidence`, `codebox-agent-task-failure-evidence`, and diagnostic evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and implemented the failure payload contract, smoke coverage, docs, and verification commands. Chris remains responsible for review and merge.