### PR TITLE
Emit phase-scoped browser metrics

### DIFF
--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -107,6 +107,7 @@ export interface BrowserArtifactSummary {
   memory?: BrowserProbeMemorySummary
   metrics?: Record<string, number>
   networkEvents: number
+  phaseMetrics?: BrowserProbePhaseMetricsArtifact
   performance?: BrowserProbePerformanceSummary
   progress?: BrowserProbeProgressSummary
   review?: BrowserProbeReviewSummary
@@ -575,7 +576,53 @@ export interface BrowserProbePerformanceArtifact {
   capturedAt: string
   final: BrowserProbeMetricsSnapshot["performance"]
   peak: BrowserProbePerformanceSummary
+  phaseMetrics?: BrowserProbePhaseMetricsArtifact
   checkpoints: BrowserProbeCheckpointRecord[]
+}
+
+export interface BrowserProbePhaseMetricsArtifact {
+  schema: "wp-codebox/browser-phase-metrics/v1"
+  version: 1
+  capturedAt: string
+  phases: BrowserProbePhaseMetric[]
+}
+
+export interface BrowserProbePhaseMetric {
+  name: string
+  checkpoint: string
+  timestamp: string
+  elapsedMs: number | null
+  network: {
+    requests: number
+    responses: number
+    failures: number
+    transferSizeBytes: number
+    responseBodySizeBytes: number
+    firstRequest: BrowserProbePhaseFirstRequest | null
+    firstRequestByHost: Record<string, BrowserProbePhaseFirstRequest>
+  }
+  errors: {
+    console: number
+    page: number
+    probe: number
+  }
+  performance: {
+    resources: number
+    transferSizeBytes: number
+    domNodes: number
+    firstContentfulPaintMs: number | null
+    largestContentfulPaintMs: number | null
+  }
+}
+
+export interface BrowserProbePhaseFirstRequest {
+  url: string
+  host: string
+  method: string
+  resourceType: string
+  timestamp: string
+  elapsedMs: number | null
+  status?: number
 }
 
 export interface BrowserProbeViewport {

--- a/packages/runtime-playground/src/browser-capture-session.ts
+++ b/packages/runtime-playground/src/browser-capture-session.ts
@@ -58,7 +58,8 @@ export function attachBrowserCaptureListeners({
   }
   if (captureNetwork) {
     page.on("requestfinished", (request) => {
-      const task = serializeBrowserFinishedRequest(request).then((record) => {
+      const timestamp = new Date().toISOString()
+      const task = serializeBrowserFinishedRequest(request, timestamp).then((record) => {
         onNetwork?.()
         network.push(record)
       }).catch(() => undefined)
@@ -66,7 +67,7 @@ export function attachBrowserCaptureListeners({
     })
     page.on("requestfailed", (request) => {
       onNetwork?.()
-      network.push(serializeBrowserRequestFailure(request))
+      network.push(serializeBrowserRequestFailure(request, new Date().toISOString()))
     })
   }
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -563,7 +563,7 @@ async function runSingleBrowserProbeCommand({
           memoryArtifact = browserProbeMemoryArtifact(checkpoints)
         }
         if (capture.has("performance")) {
-          performanceArtifact = browserProbePerformanceArtifact(checkpoints)
+          performanceArtifact = browserProbePerformanceArtifact(checkpoints, { consoleMessages, errors, network, startedAt })
         }
       }
       const lifecycle = lifecycleSelectors.length > 0 ? await collectBrowserProbeLifecycle(page) : undefined
@@ -691,6 +691,7 @@ async function runSingleBrowserProbeCommand({
         ...(memoryArtifact ? { memory: memoryArtifact.peak } : {}),
         ...(memoryArtifact || performanceArtifact ? { metrics: browserProbeBenchMetrics(memoryArtifact, performanceArtifact) } : {}),
         networkEvents: network.length,
+        ...(performanceArtifact?.phaseMetrics ? { phaseMetrics: performanceArtifact.phaseMetrics } : {}),
         ...(performanceArtifact ? { performance: performanceArtifact.peak } : {}),
         progress: progress.summary(),
         review,

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -11,6 +11,9 @@ import type {
   BrowserProbeMetricDigest,
   BrowserProbeNetworkRecord,
   BrowserProbeNetworkSizes,
+  BrowserProbePhaseFirstRequest,
+  BrowserProbePhaseMetric,
+  BrowserProbePhaseMetricsArtifact,
   BrowserProbePerformanceArtifact,
   BrowserProbePerformanceSummary,
 } from "./browser-artifacts.js"
@@ -172,7 +175,177 @@ export function browserProbeBenchMetrics(memoryArtifact?: BrowserProbeMemoryArti
     browser_cls: performance?.layoutShifts.cls ?? 0,
     browser_layout_shift_count: performance?.layoutShifts.count ?? 0,
     browser_layout_shift_max: performance?.layoutShifts.max ?? 0,
+    ...browserProbePhaseBenchMetrics(performanceArtifact?.phaseMetrics),
   }
+}
+
+export function browserProbePhaseMetrics(input: {
+  checkpoints: BrowserProbeCheckpointRecord[]
+  consoleMessages: Record<string, unknown>[]
+  errors: BrowserProbeErrorRecord[]
+  network: BrowserProbeNetworkRecord[]
+  startedAt: string
+}): BrowserProbePhaseMetricsArtifact | undefined {
+  const phases = browserProbePhaseBoundaries(input.checkpoints).map((checkpoint): BrowserProbePhaseMetric => {
+    const network = recordsBefore(input.network, checkpoint.timestamp)
+    const consoleErrors = recordsBefore(input.consoleMessages, checkpoint.timestamp).filter((message) => message.type === "error").length
+    const pageErrors = recordsBefore(input.errors, checkpoint.timestamp).filter((error) => error.type === "pageerror").length
+    const probeErrors = recordsBefore(input.errors, checkpoint.timestamp).filter((error) => error.type === "probe-error").length
+    const firstRequest = firstNetworkRequest(network, input.startedAt)
+    return {
+      name: phaseNameForCheckpoint(checkpoint.name),
+      checkpoint: checkpoint.name,
+      timestamp: checkpoint.timestamp,
+      elapsedMs: elapsedMs(input.startedAt, checkpoint.timestamp),
+      network: {
+        requests: network.length,
+        responses: network.filter((record) => record.type === "response").length,
+        failures: network.filter((record) => record.type === "requestfailed").length,
+        transferSizeBytes: sumNetworkField(network, "transferSize"),
+        responseBodySizeBytes: sumNetworkField(network, "responseBodySize"),
+        firstRequest,
+        firstRequestByHost: firstNetworkRequestByHost(network, input.startedAt),
+      },
+      errors: {
+        console: consoleErrors,
+        page: pageErrors,
+        probe: probeErrors,
+      },
+      performance: {
+        resources: checkpoint.metrics.performance.resources.count,
+        transferSizeBytes: checkpoint.metrics.performance.resources.transferSizeBytes,
+        domNodes: checkpoint.metrics.performance.dom.nodes,
+        firstContentfulPaintMs: checkpoint.metrics.performance.paint.firstContentfulPaintMs,
+        largestContentfulPaintMs: checkpoint.metrics.performance.paint.largestContentfulPaintMs,
+      },
+    }
+  })
+
+  if (phases.length === 0) {
+    return undefined
+  }
+
+  return {
+    schema: "wp-codebox/browser-phase-metrics/v1",
+    version: 1,
+    capturedAt: now(),
+    phases,
+  }
+}
+
+function browserProbePhaseBenchMetrics(phaseMetrics: BrowserProbePhaseMetricsArtifact | undefined): Record<string, number> {
+  if (!phaseMetrics) {
+    return {}
+  }
+
+  const metrics: Record<string, number> = {}
+  for (const phase of phaseMetrics.phases) {
+    const prefix = `browser_phase_${metricNameFragment(phase.name)}`
+    metrics[`${prefix}_elapsed_ms`] = phase.elapsedMs ?? 0
+    metrics[`${prefix}_request_count`] = phase.network.requests
+    metrics[`${prefix}_response_count`] = phase.network.responses
+    metrics[`${prefix}_failure_count`] = phase.network.failures
+    metrics[`${prefix}_transfer_size_bytes`] = phase.network.transferSizeBytes
+    metrics[`${prefix}_response_body_size_bytes`] = phase.network.responseBodySizeBytes
+    metrics[`${prefix}_console_error_count`] = phase.errors.console
+    metrics[`${prefix}_page_error_count`] = phase.errors.page
+    metrics[`${prefix}_probe_error_count`] = phase.errors.probe
+    metrics[`${prefix}_resource_count`] = phase.performance.resources
+    metrics[`${prefix}_resource_transfer_size_bytes`] = phase.performance.transferSizeBytes
+    metrics[`${prefix}_dom_node_count`] = phase.performance.domNodes
+    metrics[`${prefix}_fcp_ms`] = phase.performance.firstContentfulPaintMs ?? 0
+    metrics[`${prefix}_lcp_ms`] = phase.performance.largestContentfulPaintMs ?? 0
+  }
+  return metrics
+}
+
+function browserProbePhaseBoundaries(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbeCheckpointRecord[] {
+  const seen = new Set<string>()
+  const boundaries: BrowserProbeCheckpointRecord[] = []
+  for (const checkpoint of checkpoints) {
+    const name = phaseNameForCheckpoint(checkpoint.name)
+    if (!name || seen.has(name)) {
+      continue
+    }
+    seen.add(name)
+    boundaries.push(checkpoint)
+  }
+  return boundaries
+}
+
+function phaseNameForCheckpoint(name: string): string {
+  if (name.startsWith("after-")) {
+    return `before-${name.slice("after-".length)}-complete`
+  }
+  if (name === "final") {
+    return "before-final"
+  }
+  return `before-${name}`
+}
+
+function recordsBefore<T extends { timestamp?: unknown }>(records: T[], timestamp: string): T[] {
+  const boundary = Date.parse(timestamp)
+  if (!Number.isFinite(boundary)) {
+    return []
+  }
+  return records.filter((record) => {
+    const value = typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN
+    return Number.isFinite(value) && value <= boundary
+  })
+}
+
+function firstNetworkRequest(records: BrowserProbeNetworkRecord[], startedAt: string): BrowserProbePhaseFirstRequest | null {
+  const sorted = [...records].sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp))
+  const first = sorted[0]
+  return first ? networkRequestSummary(first, startedAt) : null
+}
+
+function firstNetworkRequestByHost(records: BrowserProbeNetworkRecord[], startedAt: string): Record<string, BrowserProbePhaseFirstRequest> {
+  const byHost: Record<string, BrowserProbePhaseFirstRequest> = {}
+  for (const record of [...records].sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp))) {
+    const host = requestHost(record.url) || "unknown"
+    if (!byHost[host]) {
+      byHost[host] = networkRequestSummary(record, startedAt, host)
+    }
+  }
+  return Object.fromEntries(Object.entries(byHost).sort(([left], [right]) => left.localeCompare(right)))
+}
+
+function networkRequestSummary(record: BrowserProbeNetworkRecord, startedAt: string, host = requestHost(record.url) || "unknown"): BrowserProbePhaseFirstRequest {
+  return {
+    url: record.url,
+    host,
+    method: record.method,
+    resourceType: record.resourceType,
+    timestamp: record.timestamp,
+    elapsedMs: elapsedMs(startedAt, record.timestamp),
+    ...(typeof record.status === "number" ? { status: record.status } : {}),
+  }
+}
+
+function sumNetworkField(records: BrowserProbeNetworkRecord[], field: "transferSize" | "responseBodySize"): number {
+  return records.reduce((total, record) => {
+    const value = record[field]
+    return total + (typeof value === "number" && Number.isFinite(value) ? value : 0)
+  }, 0)
+}
+
+function requestHost(url: string): string | undefined {
+  try {
+    return new URL(url).host
+  } catch {
+    return undefined
+  }
+}
+
+function elapsedMs(startedAt: string, timestamp: string): number | null {
+  const start = Date.parse(startedAt)
+  const end = Date.parse(timestamp)
+  return Number.isFinite(start) && Number.isFinite(end) && end >= start ? end - start : null
+}
+
+function metricNameFragment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "").toLowerCase()
 }
 
 export function promoteBrowserMetricsToBenchResults(raw: string, probes: BrowserArtifact[]): string {
@@ -337,7 +510,12 @@ function combinedBrowserBenchMetrics(probes: BrowserArtifact[]): Record<string, 
     browser_cls: sumMetric(metricSets, "browser_cls"),
     browser_layout_shift_count: sumMetric(metricSets, "browser_layout_shift_count"),
     browser_layout_shift_max: maxMetric(metricSets, "browser_layout_shift_max"),
+    ...finalPhaseBenchMetrics(finalMetrics),
   }
+}
+
+function finalPhaseBenchMetrics(metrics: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(Object.entries(metrics).filter(([name]) => name.startsWith("browser_phase_")))
 }
 
 function sumMetric(metricSets: Array<Record<string, number>>, name: string): number {
@@ -348,7 +526,7 @@ function maxMetric(metricSets: Array<Record<string, number>>, name: string): num
   return Math.max(...metricSets.map((metrics) => metrics[name] ?? 0))
 }
 
-export async function serializeBrowserFinishedRequest(request: Request): Promise<BrowserProbeNetworkRecord> {
+export async function serializeBrowserFinishedRequest(request: Request, timestamp = now()): Promise<BrowserProbeNetworkRecord> {
   const response = await request.response()
   if (!response) {
     return {
@@ -356,15 +534,15 @@ export async function serializeBrowserFinishedRequest(request: Request): Promise
       url: request.url(),
       method: request.method(),
       resourceType: request.resourceType(),
-      timestamp: now(),
+      timestamp,
       timing: browserRequestTiming(request),
     }
   }
 
-  return serializeBrowserResponse(response)
+  return serializeBrowserResponse(response, timestamp)
 }
 
-export async function serializeBrowserResponse(response: Response): Promise<BrowserProbeNetworkRecord> {
+export async function serializeBrowserResponse(response: Response, timestamp = now()): Promise<BrowserProbeNetworkRecord> {
   const request = response.request()
   const sizes = await browserRequestSizes(request)
   const transferSize = sizes ? sizes.responseHeadersSize + sizes.responseBodySize : undefined
@@ -383,11 +561,11 @@ export async function serializeBrowserResponse(response: Response): Promise<Brow
     ...(sizes ? { bodySize: sizes.responseBodySize } : {}),
     ...(sizes ? { requestBodySize: sizes.requestBodySize } : {}),
     ...(sizes ? { responseBodySize: sizes.responseBodySize } : {}),
-    timestamp: now(),
+    timestamp,
   }
 }
 
-export function serializeBrowserRequestFailure(request: Request): BrowserProbeNetworkRecord {
+export function serializeBrowserRequestFailure(request: Request, timestamp = now()): BrowserProbeNetworkRecord {
   return {
     type: "requestfailed",
     url: request.url(),
@@ -395,7 +573,7 @@ export function serializeBrowserRequestFailure(request: Request): BrowserProbeNe
     resourceType: request.resourceType(),
     timing: browserRequestTiming(request),
     failure: request.failure(),
-    timestamp: now(),
+    timestamp,
   }
 }
 

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -1,6 +1,7 @@
 import type { Frame, Page } from "playwright"
 import type {
   BrowserProbeCheckpointRecord,
+  BrowserProbeErrorRecord,
   BrowserProbeMemoryArtifact,
   BrowserProbeMetricsSnapshot,
   BrowserProbeNetworkRecord,
@@ -9,7 +10,7 @@ import type {
   BrowserProbeViewport,
   BrowserStepAssertion,
 } from "./browser-artifacts.js"
-import { browserProbeMemorySummary, browserProbePerformanceSummary, cdpDomCounters, cdpHeapUsage, cdpPerformanceMetrics } from "./browser-metrics.js"
+import { browserProbeMemorySummary, browserProbePerformanceSummary, browserProbePhaseMetrics, cdpDomCounters, cdpHeapUsage, cdpPerformanceMetrics } from "./browser-metrics.js"
 
 export const BROWSER_PROBE_CAPTURE_VALUES = ["console", "errors", "html", "network", "performance", "memory", "screenshot"] as const
 
@@ -903,7 +904,12 @@ export function browserProbeMemoryArtifact(checkpoints: BrowserProbeCheckpointRe
   }
 }
 
-export function browserProbePerformanceArtifact(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbePerformanceArtifact {
+export function browserProbePerformanceArtifact(checkpoints: BrowserProbeCheckpointRecord[], phaseInput?: {
+  consoleMessages: Record<string, unknown>[]
+  errors: BrowserProbeErrorRecord[]
+  network: BrowserProbeNetworkRecord[]
+  startedAt: string
+}): BrowserProbePerformanceArtifact {
   const final = checkpoints.at(-1)?.metrics.performance ?? {
     cdpMetrics: {},
     navigation: emptyNavigationTimingSummary(),
@@ -914,12 +920,15 @@ export function browserProbePerformanceArtifact(checkpoints: BrowserProbeCheckpo
     layoutShifts: { cls: 0, count: 0, totalCount: 0, max: 0, entries: [] },
   }
 
+  const phaseMetrics = phaseInput ? browserProbePhaseMetrics({ checkpoints, ...phaseInput }) : undefined
+
   return {
     schema: "wp-codebox/browser-performance/v1",
     version: 1,
     capturedAt: now(),
     final,
     peak: browserProbePerformanceSummary(checkpoints),
+    ...(phaseMetrics ? { phaseMetrics } : {}),
     checkpoints,
   }
 }

--- a/scripts/browser-phase-metrics-smoke.ts
+++ b/scripts/browser-phase-metrics-smoke.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict"
+import { browserProbeBenchMetrics } from "../packages/runtime-playground/src/browser-metrics.js"
+import { browserProbePerformanceArtifact } from "../packages/runtime-playground/src/browser-probe.js"
+import type { BrowserProbeCheckpointRecord, BrowserProbeNetworkRecord } from "../packages/runtime-playground/src/browser-artifacts.js"
+
+const startedAt = "2026-06-11T00:00:00.000Z"
+const checkpoints: BrowserProbeCheckpointRecord[] = [
+  checkpoint("after-navigation", "2026-06-11T00:00:01.000Z", 2, 4096, 42, 320),
+  checkpoint("after-script", "2026-06-11T00:00:02.000Z", 4, 8192, 48, 320),
+  checkpoint("final", "2026-06-11T00:00:03.000Z", 5, 12288, 52, 640),
+]
+const network: BrowserProbeNetworkRecord[] = [
+  networkRecord("https://example.test/", "document", "2026-06-11T00:00:00.500Z", 200, 1000),
+  networkRecord("https://cdn.example.test/app.js", "script", "2026-06-11T00:00:01.500Z", 200, 2000),
+  networkRecord("https://cdn.example.test/missing.css", "stylesheet", "2026-06-11T00:00:02.500Z", 404, 3000),
+]
+const performance = browserProbePerformanceArtifact(checkpoints, {
+  startedAt,
+  network,
+  consoleMessages: [
+    { type: "error", text: "early console error", timestamp: "2026-06-11T00:00:01.250Z" },
+    { type: "error", text: "late console error", timestamp: "2026-06-11T00:00:02.750Z" },
+  ],
+  errors: [
+    { type: "pageerror", name: "Error", message: "script failed", timestamp: "2026-06-11T00:00:01.750Z" },
+    { type: "probe-error", name: "Error", message: "probe failed", timestamp: "2026-06-11T00:00:02.900Z" },
+  ],
+})
+
+assert.equal(performance.phaseMetrics?.schema, "wp-codebox/browser-phase-metrics/v1")
+assert.equal(performance.phaseMetrics?.phases.length, 3)
+
+const navigation = performance.phaseMetrics?.phases.find((phase) => phase.name === "before-navigation-complete")
+assert.ok(navigation, "after-navigation checkpoint should become a navigation phase")
+assert.equal(navigation.elapsedMs, 1000)
+assert.equal(navigation.network.requests, 1)
+assert.equal(navigation.network.responses, 1)
+assert.equal(navigation.network.failures, 0)
+assert.equal(navigation.network.transferSizeBytes, 1000)
+assert.equal(navigation.errors.console, 0)
+assert.equal(navigation.errors.page, 0)
+assert.equal(navigation.performance.resources, 2)
+assert.equal(navigation.performance.firstContentfulPaintMs, 320)
+assert.equal(navigation.network.firstRequest?.host, "example.test")
+
+const script = performance.phaseMetrics?.phases.find((phase) => phase.name === "before-script-complete")
+assert.ok(script, "after-script checkpoint should become a script phase")
+assert.equal(script.network.requests, 2)
+assert.equal(script.network.transferSizeBytes, 3000)
+assert.equal(script.errors.console, 1)
+assert.equal(script.errors.page, 1)
+assert.equal(script.network.firstRequestByHost["cdn.example.test"]?.resourceType, "script")
+
+const final = performance.phaseMetrics?.phases.find((phase) => phase.name === "before-final")
+assert.ok(final, "final checkpoint should become a final phase")
+assert.equal(final.network.requests, 3)
+assert.equal(final.network.responses, 3)
+assert.equal(final.errors.console, 2)
+assert.equal(final.errors.page, 1)
+assert.equal(final.errors.probe, 1)
+assert.equal(final.performance.largestContentfulPaintMs, 640)
+
+const metrics = browserProbeBenchMetrics(undefined, performance)
+assert.equal(metrics.browser_phase_before_navigation_complete_request_count, 1)
+assert.equal(metrics.browser_phase_before_navigation_complete_elapsed_ms, 1000)
+assert.equal(metrics.browser_phase_before_script_complete_transfer_size_bytes, 3000)
+assert.equal(metrics.browser_phase_before_script_complete_console_error_count, 1)
+assert.equal(metrics.browser_phase_before_final_page_error_count, 1)
+assert.equal(metrics.browser_phase_before_final_probe_error_count, 1)
+assert.equal(metrics.browser_phase_before_final_lcp_ms, 640)
+
+console.log("Browser phase metrics smoke passed")
+
+function checkpoint(name: string, timestamp: string, resources: number, transferSizeBytes: number, domNodes: number, lcpMs: number): BrowserProbeCheckpointRecord {
+  return {
+    schema: "wp-codebox/browser-checkpoint/v1",
+    name,
+    timestamp,
+    metrics: {
+      timestamp,
+      memory: {
+        performanceMemory: { usedJSHeapSize: null, totalJSHeapSize: null, jsHeapSizeLimit: null },
+        cdpHeap: { usedSize: null, totalSize: null },
+        domCounters: { documents: null, nodes: domNodes, jsEventListeners: null },
+      },
+      performance: {
+        cdpMetrics: {},
+        navigation: { type: "navigate", redirectCount: 0, durationMs: null, domContentLoadedMs: null, loadEventMs: null, responseStartMs: null, responseEndMs: null, requestStartMs: null, ttfbMs: null, redirectMs: null },
+        paint: { firstPaintMs: null, firstContentfulPaintMs: 320, largestContentfulPaintMs: lcpMs, largestContentfulPaintSize: null, largestContentfulPaintElement: null, largestContentfulPaintUrl: null },
+        dom: { nodes: domNodes, documents: 1, iframes: 0 },
+        resources: { count: resources, transferSizeBytes, encodedBodySizeBytes: 0, decodedBodySizeBytes: 0 },
+        longTasks: { count: 0, totalDurationMs: 0, maxDurationMs: 0 },
+        layoutShifts: { cls: 0, count: 0, totalCount: 0, max: 0, entries: [] },
+      },
+    },
+  }
+}
+
+function networkRecord(url: string, resourceType: string, timestamp: string, status: number, transferSize: number): BrowserProbeNetworkRecord {
+  return {
+    type: "response",
+    url,
+    method: "GET",
+    resourceType,
+    status,
+    statusText: status === 200 ? "OK" : "Not Found",
+    ok: status >= 200 && status < 400,
+    timestamp,
+    transferSize,
+    responseBodySize: transferSize,
+  }
+}

--- a/scripts/browser-probe-web-performance-smoke.ts
+++ b/scripts/browser-probe-web-performance-smoke.ts
@@ -55,6 +55,7 @@ const performance = JSON.parse(await readFile(performancePath, "utf8")) as {
     navigation: { durationMs: number | null; ttfbMs: number | null; responseStartMs: number | null }
     paint: { firstContentfulPaintMs: number | null; largestContentfulPaintMs: number | null; largestContentfulPaintElement: string | null }
   }
+  phaseMetrics?: { phases: Array<{ name: string; elapsedMs: number | null; performance: { resources: number } }> }
 }
 const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
   context?: { requested?: { profile?: string; throttle?: string }; effective?: { profile?: string; throttle?: string } }
@@ -77,6 +78,9 @@ assert.equal(typeof summary.summary?.metrics?.browser_lcp_ms, "number", "summary
 assert.equal(typeof summary.summary?.metrics?.browser_fcp_ms, "number", "summary metrics should expose browser_fcp_ms")
 assert.equal(typeof summary.summary?.metrics?.browser_ttfb_ms, "number", "summary metrics should expose browser_ttfb_ms")
 assert.equal(typeof summary.summary?.metrics?.browser_nav_duration_ms, "number", "summary metrics should expose browser_nav_duration_ms")
+assert.ok(performance.phaseMetrics?.phases.some((phase) => phase.name === "before-navigation-complete"), "performance artifact should include phase metrics")
+assert.equal(typeof summary.summary?.metrics?.browser_phase_before_navigation_complete_elapsed_ms, "number", "summary metrics should expose phase elapsed time")
+assert.equal(typeof summary.summary?.metrics?.browser_phase_before_final_resource_count, "number", "summary metrics should expose final phase resource count")
 
 const failingRecipePath = await writeRecipe("failing", [
   "url=/",

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -191,6 +191,7 @@ export const smokeGroups = {
       tsxSmoke("browser-probe-artifact-smoke"),
       tsxSmoke("browser-probe-assertions-smoke"),
       tsxSmoke("browser-probe-web-performance-smoke"),
+      tsxSmoke("browser-phase-metrics-smoke"),
       tsxSmoke("browser-probe-layout-shift-smoke"),
       tsxSmoke("browser-probe-context-smoke"),
       tsxSmoke("browser-probe-public-url-routing-smoke"),


### PR DESCRIPTION
## Summary
- Adds `phaseMetrics` to browser performance artifacts and browser probe summaries, derived from existing probe checkpoints such as `after-navigation`, `after-duration`, `after-assertions`, and `final`.
- Promotes generic `browser_phase_*` numeric metrics for phase-scoped elapsed time, request/response/failure counts, bytes, errors, resources, DOM nodes, FCP, and LCP.
- Preserves request event timestamps at Playwright listener time so async network serialization does not skew phase boundaries.

Fixes #868.

## Tests
- `npm run build`
- `npx tsx scripts/browser-phase-metrics-smoke.ts`
- `npx tsx scripts/browser-probe-web-performance-smoke.ts`
- `git diff --check`

## Notes
- This uses the existing checkpoint surface as the first coherent generic phase marker slice. A richer explicit marker API can build on the same `phaseMetrics` artifact shape later.
- Network phase counts require network capture or network-backed assertions, matching the existing browser probe capture behavior.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the phase metric artifact and smoke coverage; Chris remains responsible for review and validation.