### PR TITLE
Report missing visual compare inputs

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -2830,9 +2830,43 @@ async function runVisualComparePairCommand({
       await browser.close()
     }
   } else if (sourceScreenshot && candidateScreenshot) {
-    await writeFile(sourcePath, await readFile(await resolveVisualCompareScreenshotPath(sourceScreenshot, artifactRoot)))
+    const sourceResolvedPath = await maybeResolveVisualCompareScreenshotPath(sourceScreenshot, artifactRoot)
+    const candidateResolvedPath = await maybeResolveVisualCompareScreenshotPath(candidateScreenshot, artifactRoot)
+    const missingInputs = visualCompareMissingScreenshotInputs({ sourceScreenshot, candidateScreenshot, sourceResolvedPath, candidateResolvedPath })
+    if (missingInputs.length > 0) {
+      const copiedFiles: Partial<{ sourceScreenshot: string; candidateScreenshot: string }> = {}
+      if (sourceResolvedPath) {
+        await writeFile(sourcePath, await readFile(sourceResolvedPath))
+        copiedFiles.sourceScreenshot = `${artifactPathPrefix}/source.png`
+      }
+      if (candidateResolvedPath) {
+        await writeFile(candidatePath, await readFile(candidateResolvedPath))
+        copiedFiles.candidateScreenshot = `${artifactPathPrefix}/candidate.png`
+      }
+      const result = await writeVisualCompareMissingInputSummary({
+        summaryPath,
+        visualDiffPath,
+        artifactPathPrefix,
+        startedAt,
+        source: sourceSummary(),
+        candidate: candidateSummary(),
+        options: { waitFor, durationMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+        preview,
+        viewport,
+        missingInputs,
+        copiedFiles,
+      })
+      throw new BrowserCommandArtifactError("wordpress.visual-compare missing expected screenshot input", visualCompareMissingInputArtifact({ source: sourceSummary(), candidate: candidateSummary(), preview, viewport, files: result.files, summary: result.summary }))
+    }
+
+    const resolvedSourceScreenshotPath = sourceResolvedPath
+    const resolvedCandidateScreenshotPath = candidateResolvedPath
+    if (!resolvedSourceScreenshotPath || !resolvedCandidateScreenshotPath) {
+      throw new Error("wordpress.visual-compare expected screenshot inputs to be resolved after missing-input guard")
+    }
+    await writeFile(sourcePath, await readFile(resolvedSourceScreenshotPath))
     await writePartialSummary("source-captured")
-    await writeFile(candidatePath, await readFile(await resolveVisualCompareScreenshotPath(candidateScreenshot, artifactRoot)))
+    await writeFile(candidatePath, await readFile(resolvedCandidateScreenshotPath))
     if (sourceDomSnapshotRef && candidateDomSnapshotRef) {
       const sourceArtifact = await readVisualCompareDomSnapshotArtifact(sourceDomSnapshotRef, artifactRoot)
       const candidateArtifact = await readVisualCompareDomSnapshotArtifact(candidateDomSnapshotRef, artifactRoot)
@@ -3067,6 +3101,109 @@ async function writeVisualComparePartialSummary(summaryPath: string, input: {
   await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`)
 }
 
+async function writeVisualCompareMissingInputSummary(input: {
+  summaryPath: string
+  visualDiffPath: string
+  artifactPathPrefix: string
+  startedAt: string
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  options: Record<string, unknown>
+  preview: ReturnType<typeof browserPreviewRouting>
+  viewport: BrowserProbeViewport | null
+  missingInputs: VisualCompareMissingInput[]
+  copiedFiles: Partial<{ sourceScreenshot: string; candidateScreenshot: string }>
+}): Promise<{ files: { sourceScreenshot: string | string[]; candidateScreenshot: string | string[]; diffScreenshot: string | string[]; visualDiff: string; summary: string }; summary: VisualCompareMissingInputSummary }> {
+  const files = {
+    sourceScreenshot: input.copiedFiles.sourceScreenshot ?? [],
+    candidateScreenshot: input.copiedFiles.candidateScreenshot ?? [],
+    diffScreenshot: [],
+    visualDiff: `${input.artifactPathPrefix}/visual-diff.json`,
+    summary: `${input.artifactPathPrefix}/summary.json`,
+  }
+  const summary: VisualCompareMissingInputSummary = {
+    schema: "wp-codebox/visual-compare/v1",
+    command: "wordpress.visual-compare",
+    status: "missing",
+    partial: true,
+    stage: "missing-input",
+    source: input.source,
+    candidate: input.candidate,
+    options: input.options,
+    limitations: ["visual compare could not run because one or more expected screenshot inputs were missing; recovered files show any screenshots that were available before comparison"],
+    preview: input.preview,
+    viewport: input.viewport,
+    startedAt: input.startedAt,
+    updatedAt: now(),
+    files,
+    diagnostic: {
+      type: "missing-input",
+      message: "Visual compare is missing expected screenshot input.",
+      missingInputs: input.missingInputs,
+    },
+  }
+  const json = `${JSON.stringify(summary, null, 2)}\n`
+  await writeFile(input.visualDiffPath, json)
+  await writeFile(input.summaryPath, json)
+  return { files, summary }
+}
+
+function visualCompareMissingInputArtifact(input: {
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  preview: ReturnType<typeof browserPreviewRouting>
+  viewport: BrowserProbeViewport | null
+  files: { sourceScreenshot: string | string[]; candidateScreenshot: string | string[]; diffScreenshot: string | string[]; visualDiff: string; summary: string }
+  summary: VisualCompareMissingInputSummary
+}): BrowserArtifact {
+  return {
+    artifactType: "visual-compare",
+    requestedUrl: typeof input.source.url === "string" ? input.source.url : typeof input.source.screenshot === "string" ? input.source.screenshot : "source",
+    url: typeof input.candidate.url === "string" ? input.candidate.url : typeof input.candidate.screenshot === "string" ? input.candidate.screenshot : "candidate",
+    preview: input.preview,
+    files: input.files,
+    summary: {
+      steps: 0,
+      consoleMessages: 0,
+      errors: 0,
+      finalUrl: "",
+      htmlSnapshot: false,
+      networkEvents: 0,
+      replayability: "artifact-backed",
+      screenshot: Array.isArray(input.files.sourceScreenshot) ? input.files.sourceScreenshot.length > 0 : Boolean(input.files.sourceScreenshot),
+      visualCompare: {
+        status: input.summary.status,
+        explanation: input.files.visualDiff,
+      },
+      viewport: input.viewport,
+    },
+  }
+}
+
+function visualCompareMissingScreenshotInputs(input: {
+  sourceScreenshot: string
+  candidateScreenshot: string
+  sourceResolvedPath?: string
+  candidateResolvedPath?: string
+}): VisualCompareMissingInput[] {
+  const missingInputs: VisualCompareMissingInput[] = []
+  if (!input.sourceResolvedPath) {
+    missingInputs.push({ role: "sourceScreenshot", path: input.sourceScreenshot })
+  }
+  if (!input.candidateResolvedPath) {
+    missingInputs.push({ role: "candidateScreenshot", path: input.candidateScreenshot })
+  }
+  return missingInputs
+}
+
+async function maybeResolveVisualCompareScreenshotPath(requestedPath: string, artifactRoot: string): Promise<string | undefined> {
+  try {
+    return await resolveVisualCompareScreenshotPath(requestedPath, artifactRoot)
+  } catch {
+    return undefined
+  }
+}
+
 async function writeVisualCompareMatrixSummary(
   artifactRoot: string,
   args: string[],
@@ -3206,6 +3343,33 @@ interface VisualComparePairSummary {
   viewport: BrowserProbeViewport | null
   files: Record<string, string>
   comparison: { mismatchRatio: number; mismatchPixels: number; totalPixels: number; dimensionMismatch: boolean }
+}
+
+interface VisualCompareMissingInput {
+  role: "sourceScreenshot" | "candidateScreenshot"
+  path: string
+}
+
+interface VisualCompareMissingInputSummary {
+  schema: "wp-codebox/visual-compare/v1"
+  command: "wordpress.visual-compare"
+  status: "missing"
+  partial: true
+  stage: "missing-input"
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  options: Record<string, unknown>
+  limitations: string[]
+  preview: ReturnType<typeof browserPreviewRouting>
+  viewport: BrowserProbeViewport | null
+  startedAt: string
+  updatedAt: string
+  files: { sourceScreenshot: string | string[]; candidateScreenshot: string | string[]; diffScreenshot: string | string[]; visualDiff: string; summary: string }
+  diagnostic: {
+    type: "missing-input"
+    message: string
+    missingInputs: VisualCompareMissingInput[]
+  }
 }
 
 interface VisualCompareMatrixSummary {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -502,7 +502,15 @@ class PlaygroundRuntime implements Runtime {
 
   async runVisualCompare(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
-    const result = await runVisualCompareCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, server, spec })
+    let result: Awaited<ReturnType<typeof runVisualCompareCommand>>
+    try {
+      result = await runVisualCompareCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, server, spec })
+    } catch (error) {
+      if (isBrowserCommandArtifactError(error)) {
+        this.browserProbes.push(error.artifact)
+      }
+      throw error
+    }
     this.browserProbes.push(result.artifact)
     return result.output
   }

--- a/scripts/browser-visual-compare-smoke.ts
+++ b/scripts/browser-visual-compare-smoke.ts
@@ -211,6 +211,70 @@ assert.equal(baselineSummary.baseline?.delta.mismatchPixels?.absoluteDelta, 0, "
 assert.equal(baselineSummary.baseline?.delta.mismatchRatio?.absoluteDelta, 0, "same screenshots should not change mismatch ratio relative to baseline")
 assert.equal(baselineSummary.baseline?.delta.dimensionMismatch?.changed, false, "same screenshots should not change dimension mismatch status relative to baseline")
 
+const missingInputRecipePath = join(workspace, "missing-input-recipe.json")
+const missingInputArtifactsRoot = join(workspace, "missing-input-artifacts")
+const missingCandidatePath = join(workspace, "missing-candidate-after-interruption.png")
+await writeFile(missingInputRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.visual-compare",
+        args: [
+          `source-screenshot=${sourcePath}`,
+          `candidate-screenshot=${missingCandidatePath}`,
+          "source-label=source-after-browser-actions",
+          "candidate-label=candidate-after-browser-actions",
+          "threshold=0.1",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: missingInputArtifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const missingInputOutput = await runCliAllowFailure([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  missingInputRecipePath,
+  "--json",
+])
+
+assert.equal(missingInputOutput.success, false, "missing visual compare input should fail the recipe")
+assert.ok(missingInputOutput.artifacts?.directory, "missing visual compare input should still return artifacts")
+assert.ok(missingInputOutput.error?.message?.includes("wordpress.visual-compare missing expected screenshot input"), "missing input failure should be reported as a structured visual compare failure")
+assert.equal(missingInputOutput.error?.message?.includes("ENOENT"), false, "missing input failure should not surface bare filesystem ENOENT as the primary signal")
+
+const missingInputSummaryPath = join(missingInputOutput.artifacts.directory, "files", "browser", "visual-compare", "visual-diff.json")
+const missingInputReviewPath = join(missingInputOutput.artifacts.directory, "files", "review.json")
+const missingInputSourcePath = join(missingInputOutput.artifacts.directory, "files", "browser", "visual-compare", "source.png")
+assert.equal(existsSync(missingInputSummaryPath), true, "missing input visual summary should be captured")
+assert.equal(existsSync(missingInputSourcePath), true, "available source screenshot should be preserved")
+
+const missingInputSummary = JSON.parse(await readFile(missingInputSummaryPath, "utf8")) as {
+  schema: string
+  status: string
+  partial: boolean
+  stage: string
+  files: { sourceScreenshot?: string | string[]; candidateScreenshot?: string | string[]; visualDiff?: string }
+  diagnostic?: { type: string; message: string; missingInputs?: Array<{ role: string; path: string }> }
+}
+assert.equal(missingInputSummary.schema, "wp-codebox/visual-compare/v1")
+assert.equal(missingInputSummary.status, "missing")
+assert.equal(missingInputSummary.partial, true)
+assert.equal(missingInputSummary.stage, "missing-input")
+assert.equal(missingInputSummary.files.sourceScreenshot, "files/browser/visual-compare/source.png")
+assert.deepEqual(missingInputSummary.files.candidateScreenshot, [])
+assert.equal(missingInputSummary.diagnostic?.type, "missing-input")
+assert.deepEqual(missingInputSummary.diagnostic?.missingInputs?.map((input) => input.role), ["candidateScreenshot"])
+
+const missingInputReview = JSON.parse(await readFile(missingInputReviewPath, "utf8")) as { browser?: { probes?: Array<{ visualCompare?: { status?: string; explanation?: string } }> } }
+assert.equal(missingInputReview.browser?.probes?.[0]?.visualCompare?.status, "missing", "review summary should expose missing visual compare status")
+assert.equal(missingInputReview.browser?.probes?.[0]?.visualCompare?.explanation, "files/browser/visual-compare/visual-diff.json", "review summary should point to missing-input visual summary")
+
 console.log("Browser visual compare smoke passed")
 
 async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
@@ -222,6 +286,19 @@ async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: 
   const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
   if (code !== 0) {
     throw new Error(`CLI exited with ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  }
+  return JSON.parse(stdout)
+}
+
+async function runCliAllowFailure(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
+  const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => { stdout += chunk })
+  child.stderr.on("data", (chunk) => { stderr += chunk })
+  const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
+  if (code === 0) {
+    throw new Error(`CLI unexpectedly exited with 0\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
   }
   return JSON.parse(stdout)
 }


### PR DESCRIPTION
## Summary
- Handle screenshot-pair `wordpress.visual-compare` runs where one expected screenshot input is missing after an earlier interrupted browser action.
- Emit artifact-backed partial visual compare output with `status: \"missing\"`, `stage: \"missing-input\"`, and structured missing-input diagnostics instead of surfacing bare filesystem `ENOENT` as the primary signal.
- Record failed visual compare artifacts in the runtime so `review.json` and the manifest include the structured partial evidence.

Follow-up to #872.
Fixes #871.

Validation evidence this targets: https://github.com/Automattic/wp-codebox/issues/871#issuecomment-4681951111

## Testing
- `npm run build`
- `npx tsx scripts/browser-visual-compare-smoke.ts`
- `npm run browser-visual-compare-matrix-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the missing screenshot-input visual compare fix and focused smoke coverage; Chris remains responsible for review and merge.