### PR TITLE
Filter WP Codebox benchmark scenarios

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -976,6 +976,7 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
     }
 
     validateInlineJsonArg(step, "workloads-json", "array", path, addIssue)
+    validateInlineJsonArg(step, "scenario-ids-json", "array", path, addIssue)
     validateInlineJsonArg(step, "lifecycle-json", "object", path, addIssue)
     const resetPolicy = validateInlineJsonArg(step, "reset-policy-json", "object", path, addIssue)
     if (resetPolicy && typeof resetPolicy === "object" && !Array.isArray(resetPolicy)) {

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -92,6 +92,7 @@ export const commandRegistry = [
       { name: "env-json", description: "Benchmark environment object.", format: "JSON object" },
       { name: "bootstrap-files-json", description: "Component-relative bootstrap file fallbacks; the first existing file is loaded before workloads execute.", format: "JSON array" },
       { name: "workloads-json", description: "Explicit workload list. Configured workload steps support php, ability, wp-cli, and rest-request mechanics.", format: "JSON array" },
+      { name: "scenario-ids-json", description: "Optional selected benchmark scenario ids. Filters both discovered tests/bench workloads and explicit workloads by id.", format: "JSON array" },
       { name: "lifecycle-json", description: "Generic benchmark lifecycle hooks keyed by setup, prepare, warmup, measure, or teardown. Hook entries use the same php/ability/wp-cli step format as configured workloads.", format: "JSON object" },
       { name: "reset-policy-json", description: "Explicit benchmark reset policy. Supports betweenIterations and betweenScenarios modes: none or object-cache.", format: "JSON object" },
     ],

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -43,6 +43,7 @@ export interface WordPressBenchRecipeOptions {
   wpConfigDefines?: JsonObject
   bootstrapFiles?: string[]
   workloads?: unknown[]
+  scenarioIds?: string[]
   lifecycle?: JsonObject
   resetPolicy?: JsonObject
 }
@@ -155,6 +156,7 @@ export function buildWordPressBenchRecipe(options: WordPressBenchRecipeOptions):
           `env-json=${JSON.stringify(options.env ?? {})}`,
           `bootstrap-files-json=${JSON.stringify(options.bootstrapFiles ?? [])}`,
           `workloads-json=${JSON.stringify(options.workloads ?? [])}`,
+          `scenario-ids-json=${JSON.stringify(normalizeScenarioIds(options.scenarioIds ?? []))}`,
           `lifecycle-json=${JSON.stringify(options.lifecycle ?? {})}`,
           `reset-policy-json=${JSON.stringify(options.resetPolicy ?? {})}`,
         ],
@@ -223,6 +225,10 @@ function positiveInteger(value: number | undefined, fallback: number): number {
 
 function nonNegativeInteger(value: number | undefined, fallback: number): number {
   return value !== undefined && Number.isSafeInteger(value) && value >= 0 ? value : fallback
+}
+
+function normalizeScenarioIds(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))]
 }
 
 function isPlainObject(value: unknown): value is JsonObject {

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -7,6 +7,7 @@ export interface BenchRunCodeOptions {
   env: Record<string, unknown>
   bootstrapFiles: string[]
   workloads: unknown[]
+  scenarioIds?: string[]
   lifecycle: Record<string, unknown>
   resetPolicy: Record<string, unknown>
   wpCliBridge?: { url: string; token: string }
@@ -24,6 +25,7 @@ $dependency_slugs = ${phpJsonDecodeExpression(options.dependencySlugs)};
 $bench_env = ${phpJsonDecodeExpression(options.env)};
 $bootstrap_files = ${phpJsonDecodeExpression(options.bootstrapFiles)};
 $configured_workloads = ${phpJsonDecodeExpression(options.workloads)};
+$selected_scenario_ids = ${phpJsonDecodeExpression(options.scenarioIds ?? [])};
 $bench_lifecycle = ${phpJsonDecodeExpression(options.lifecycle)};
 $bench_reset_policy = ${phpJsonDecodeExpression(options.resetPolicy)};
 $wp_cli_bridge_url = ${JSON.stringify(options.wpCliBridge?.url ?? null)};
@@ -630,9 +632,48 @@ function wp_codebox_bench_run_configured_workload(array $workload, string $plugi
     return $payload;
 }
 
+function wp_codebox_bench_selected_scenario_ids(array $ids): array {
+    $selected = array();
+    foreach ($ids as $id) {
+        if (!is_string($id)) {
+            continue;
+        }
+        $id = trim($id);
+        if ($id !== '') {
+            $selected[$id] = true;
+        }
+    }
+    return $selected;
+}
+
+function wp_codebox_bench_scenario_selected(string $scenario_id, array $selected_ids): bool {
+    return empty($selected_ids) || isset($selected_ids[$scenario_id]);
+}
+
 $bench_dir = $plugin_path . '/tests/bench';
 $workload_files = is_dir($bench_dir) ? glob($bench_dir . '/*.php') : array();
 sort($workload_files, SORT_STRING);
+
+$selected_scenario_ids = is_array($selected_scenario_ids) ? wp_codebox_bench_selected_scenario_ids($selected_scenario_ids) : array();
+if (!empty($selected_scenario_ids)) {
+    $available_scenario_ids = array();
+    foreach ($workload_files as $workload_file) {
+        $available_scenario_ids[preg_replace('/\\.php$/', '', basename($workload_file))] = true;
+    }
+    foreach (is_array($configured_workloads) ? $configured_workloads : array() as $index => $workload) {
+        if (!is_array($workload)) {
+            continue;
+        }
+        $available_scenario_ids[isset($workload['id']) && is_string($workload['id']) ? $workload['id'] : 'configured-' . $index] = true;
+    }
+    if (empty(array_intersect_key($selected_scenario_ids, $available_scenario_ids))) {
+        throw new RuntimeException('wordpress.bench selected scenario ids did not match any known scenarios. diagnostic=' . wp_json_encode(array(
+            'schema' => 'wp-codebox/bench-scenario-selection-diagnostic/v1',
+            'selected_scenario_ids' => array_keys($selected_scenario_ids),
+            'available_scenario_ids' => array_keys($available_scenario_ids),
+        ), JSON_UNESCAPED_SLASHES));
+    }
+}
 
 $bench_lifecycle = is_array($bench_lifecycle) ? $bench_lifecycle : array();
 $bench_reset_policy = is_array($bench_reset_policy) ? $bench_reset_policy : array();
@@ -643,6 +684,11 @@ wp_codebox_bench_run_lifecycle_phase($bench_lifecycle, 'setup', $plugin_path, $l
 
 $scenarios = array();
 foreach ($workload_files as $workload_file) {
+    $scenario_id = preg_replace('/\\.php$/', '', basename($workload_file));
+    if (!wp_codebox_bench_scenario_selected($scenario_id, $selected_scenario_ids)) {
+        continue;
+    }
+
     $callable = require $workload_file;
     if (!is_callable($callable)) {
         continue;
@@ -679,7 +725,7 @@ foreach ($workload_files as $workload_file) {
 
     $relative_file = substr($workload_file, strlen($plugin_path) + 1);
     $scenario = array(
-        'id' => preg_replace('/\\.php$/', '', basename($workload_file)),
+        'id' => $scenario_id,
         'source' => 'in_tree',
         'file' => $relative_file,
         'iterations' => $iterations,
@@ -712,6 +758,10 @@ foreach (is_array($configured_workloads) ? $configured_workloads : array() as $i
         continue;
     }
     $scenario_id = isset($workload['id']) && is_string($workload['id']) ? $workload['id'] : 'configured-' . $index;
+    if (!wp_codebox_bench_scenario_selected($scenario_id, $selected_scenario_ids)) {
+        continue;
+    }
+
     $timings = array();
     $metric_samples = array();
     $metadata = null;
@@ -757,6 +807,13 @@ foreach (is_array($configured_workloads) ? $configured_workloads : array() as $i
     }
     wp_codebox_bench_run_lifecycle_phase($bench_lifecycle, 'teardown', $plugin_path, $lifecycle_diagnostics);
     $scenarios[] = $scenario;
+}
+
+if (!empty($selected_scenario_ids) && empty($scenarios)) {
+    throw new RuntimeException('wordpress.bench selected scenario ids did not match any runnable scenarios. diagnostic=' . wp_json_encode(array(
+        'schema' => 'wp-codebox/bench-scenario-selection-diagnostic/v1',
+        'selected_scenario_ids' => array_keys($selected_scenario_ids),
+    ), JSON_UNESCAPED_SLASHES));
 }
 
 echo wp_json_encode(array(

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -355,13 +355,14 @@ export async function runBenchCommand({
   const env = jsonObjectArg(args, "env-json")
   const bootstrapFiles = jsonArrayArg(args, "bootstrap-files-json").filter((file): file is string => typeof file === "string")
   const workloads = jsonArrayArg(args, "workloads-json")
+  const scenarioIds = jsonArrayArg(args, "scenario-ids-json").filter((id): id is string => typeof id === "string" && id.trim() !== "").map((id) => id.trim())
   const lifecycle = jsonObjectArg(args, "lifecycle-json")
   const resetPolicy = jsonObjectArg(args, "reset-policy-json")
   const bridge = benchWorkloadsUseWpCli([workloads, lifecycle]) ? await createRuntimeWpCliBridge(server) : undefined
   let response: PlaygroundRunResponse
   try {
     response = await runPlaygroundCommand("wordpress.bench", server, {
-      code: bootstrapPhpCode(runtimeSpec, benchRunCode({ componentId, pluginSlug, iterations, warmupIterations, dependencySlugs, env, bootstrapFiles, workloads, lifecycle, resetPolicy, wpCliBridge: bridge }), []),
+      code: bootstrapPhpCode(runtimeSpec, benchRunCode({ componentId, pluginSlug, iterations, warmupIterations, dependencySlugs, env, bootstrapFiles, workloads, scenarioIds, lifecycle, resetPolicy, wpCliBridge: bridge }), []),
     })
     assertPlaygroundResponseOk("wordpress.bench", response)
   } finally {

--- a/scripts/bench-bootstrap-files-smoke.ts
+++ b/scripts/bench-bootstrap-files-smoke.ts
@@ -10,6 +10,7 @@ const code = benchRunCode({
   env: {},
   bootstrapFiles: ["lib/compat/new.php", "lib/compat/old.php"],
   workloads: [{ id: "php-variable", code: "$value = 1; return array('metrics' => array('value' => $value));" }],
+  scenarioIds: ["discovered-only"],
   lifecycle: {},
   resetPolicy: {},
 })
@@ -26,6 +27,17 @@ assert.match(code, /wp-codebox\/bench-plugin-load-diagnostic\/v1/)
 assert.match(code, /expected_file_path/)
 assert.match(code, /'active' => function_exists\('is_plugin_active'\) \? is_plugin_active\(\$plugin_basename\) : null/)
 assert.match(code, /'included' => \$included/)
+assert.match(code, /\$selected_scenario_ids = json_decode\(base64_decode/)
+assert.match(code, new RegExp(Buffer.from(JSON.stringify(["discovered-only"]), "utf8").toString("base64")))
+assert.match(code, /wp_codebox_bench_scenario_selected\(string \$scenario_id, array \$selected_ids\): bool/)
+assert.ok(
+  code.indexOf("if (!wp_codebox_bench_scenario_selected($scenario_id, $selected_scenario_ids))") < code.indexOf("$callable = require $workload_file"),
+  "discovered tests/bench workload files should be filtered before require/execution"
+)
+assert.ok(
+  code.indexOf("$scenario_id = isset($workload['id'])") < code.indexOf("$payload = wp_codebox_bench_run_configured_workload($workload, $plugin_path)"),
+  "configured workloads should be filtered before execution"
+)
 assert.ok(
   code.indexOf("require_once $bootstrap_path") < code.indexOf("wp_codebox_bench_run_deferred_wordpress_hook_callbacks($deferred_plugins_loaded_callbacks"),
   "bootstrap files should load before synthetic plugins_loaded/init hooks"

--- a/scripts/wordpress-recipe-builders-smoke.ts
+++ b/scripts/wordpress-recipe-builders-smoke.ts
@@ -92,6 +92,7 @@ const benchRecipe = buildWordPressBenchRecipe({
   wpConfigDefines: { BENCH_DEFINE: "defined" },
   bootstrapFiles: ["tests/bench/bootstrap.php"],
   workloads: [{ id: "noop", file: "tests/bench/noop.php" }],
+  scenarioIds: ["noop", " ", "noop"],
   lifecycle: { setup: [{ type: "php", code: "update_option('bench_setup', 'yes');" }] },
   resetPolicy: { betweenIterations: "object-cache" },
   extra_plugins: [{ source: "/repo/demo-plugin", slug: "demo-plugin", pluginFile: "demo-plugin/demo.php", activate: false }],
@@ -111,10 +112,16 @@ assert.deepEqual(benchRecipe.workflow.steps[0]?.args, [
   'env-json={"BENCH_ENV":"yes"}',
   'bootstrap-files-json=["tests/bench/bootstrap.php"]',
   'workloads-json=[{"id":"noop","file":"tests/bench/noop.php"}]',
+  'scenario-ids-json=["noop"]',
   'lifecycle-json={"setup":[{"type":"php","code":"update_option(\'bench_setup\', \'yes\');"}]}',
   'reset-policy-json={"betweenIterations":"object-cache"}',
 ])
 assert.ok(validate(benchRecipe), ajv.errorsText(validate.errors))
+const benchRecipePath = join(workspace, "bench-recipe.json")
+writeFileSync(benchRecipePath, `${JSON.stringify(buildWordPressBenchRecipe({ pluginSlug: "demo-plugin", scenarioIds: ["noop"] }), null, 2)}\n`)
+const validateBenchRecipe = spawnSync(process.execPath, [cli, "recipe", "validate", "--recipe", benchRecipePath, "--json"], { cwd: root, encoding: "utf8" })
+assert.equal(validateBenchRecipe.status, 0, validateBenchRecipe.stderr || validateBenchRecipe.stdout)
+assert.equal(JSON.parse(validateBenchRecipe.stdout).valid, true)
 assert.ok(validateBenchmarkDefinition({
   schema: "wp-codebox/benchmark-definition/v1",
   component_id: "demo-component",
@@ -126,6 +133,19 @@ assert.ok(validateBenchmarkDefinition({
   bootstrap_files: ["tests/bench/bootstrap.php"],
   workloads: [{ id: "noop", file: "tests/bench/noop.php" }],
 }), ajv.errorsText(validateBenchmarkDefinition.errors))
+assert.deepEqual(buildWordPressBenchRecipe({ pluginSlug: "demo-plugin" }).workflow.steps[0]?.args, [
+  "component-id=demo-plugin",
+  "plugin-slug=demo-plugin",
+  "iterations=3",
+  "warmup=1",
+  "dependency-slugs=",
+  "env-json={}",
+  "bootstrap-files-json=[]",
+  "workloads-json=[]",
+  "scenario-ids-json=[]",
+  "lifecycle-json={}",
+  "reset-policy-json={}",
+])
 assert.ok(validateBenchResults({
   schema: "wp-codebox/bench-results/v1",
   component_id: "demo-component",


### PR DESCRIPTION
## Summary
- Add a `scenario-ids-json` contract to `wordpress.bench` recipes so upstream callers can pass selected benchmark scenario IDs through WP Codebox.
- Filter both discovered `tests/bench/*.php` workloads and explicit configured workloads before execution while preserving no-filter behavior.
- Add focused smokes for recipe emission, CLI recipe validation, generated PHP filtering, and default no-filter args.

## Tests
- `npm run build`
- `npx tsx scripts/wordpress-recipe-builders-smoke.ts`
- `npx tsx scripts/bench-bootstrap-files-smoke.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the WP Codebox benchmark scenario-selection contract and tests; Chris remains responsible for review and merge.