### PR TITLE
Expose runner workspace capture and command APIs

### DIFF
--- a/packages/runtime-core/src/runner-workspace-publication.ts
+++ b/packages/runtime-core/src/runner-workspace-publication.ts
@@ -72,3 +72,75 @@ export type RunnerWorkspacePublicationResult = {
   evidence?: Record<string, unknown>
   artifacts?: Record<string, unknown>
 }
+
+export type RunnerWorkspaceIdentity = {
+  workspace?: string
+  workspace_handle?: string
+  handle?: string
+  workspace_path?: string
+  workspace_backend?: string
+  runner_workspace?: Record<string, unknown>
+  repo?: string
+  target_repo?: string
+}
+
+export type RunnerWorkspaceCaptureRequest = RunnerWorkspaceIdentity & {
+  schema?: "wp-codebox/runner-workspace-capture-request/v1"
+  from?: string
+  to?: string
+  path?: string
+  include_diff?: boolean
+}
+
+export type RunnerWorkspaceCaptureResult = {
+  schema: "wp-codebox/runner-workspace-capture-result/v1"
+  success: boolean
+  backend: string
+  changed?: boolean
+  workspace?: Record<string, unknown>
+  status?: {
+    handle?: string
+    name?: string
+    repo?: string
+    path?: string
+    branch?: string
+    remote?: string
+    commit?: string
+    dirty?: number
+    files?: string[]
+    backend?: string
+  }
+  diff?: {
+    name?: string
+    diff?: string
+    backend?: string
+  }
+  failure_type?: string
+  error?: Record<string, unknown>
+}
+
+export type RunnerWorkspaceCommandRequest = RunnerWorkspaceIdentity & {
+  schema?: "wp-codebox/runner-workspace-command-request/v1"
+  command: string
+  description?: string
+  timeout_seconds?: number
+  env?: Record<string, string>
+  context?: Record<string, unknown>
+  allow_local_fallback?: boolean
+}
+
+export type RunnerWorkspaceCommandResult = {
+  schema: "wp-codebox/runner-workspace-command-result/v1"
+  success: boolean
+  status: "completed" | "failed" | "unavailable"
+  command?: string
+  description?: string
+  exit_code?: number
+  stdout?: string
+  stderr?: string
+  elapsed_ms?: number
+  backend: string
+  workspace?: Record<string, unknown>
+  failure_type?: string
+  error?: Record<string, unknown>
+}

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -412,6 +412,34 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/capture-runner-workspace',
+				array(
+					'label'               => 'Capture Runner Workspace',
+					'description'         => 'Capture runner-owned workspace status and diff metadata through the WP Codebox runner boundary without exposing backend workspace internals to callers.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_capture_input_schema(),
+					'output_schema'       => self::runner_workspace_capture_output_schema(),
+					'execute_callback'    => array( self::class, 'capture_runner_workspace' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/run-runner-workspace-command',
+				array(
+					'label'               => 'Run Runner Workspace Command',
+					'description'         => 'Run a bounded verification or drift-check command against a runner-owned workspace through the WP Codebox runner boundary.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_command_input_schema(),
+					'output_schema'       => self::runner_workspace_command_output_schema(),
+					'execute_callback'    => array( self::class, 'run_runner_workspace_command' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/create-browser-playground-session',
 				array(
 					'label'               => 'Create Browser Playground Session',

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -9,21 +9,28 @@ defined( 'ABSPATH' ) || exit;
 
 trait WP_Codebox_Abilities_Runner_Publication {
 	/** @return array<string,mixed> */
+	private static function runner_workspace_identity_schema(): array {
+		return array(
+			'workspace'         => array( 'type' => 'string', 'description' => 'Runner workspace handle. Alias: workspace_handle or handle.' ),
+			'workspace_handle'  => array( 'type' => 'string' ),
+			'handle'            => array( 'type' => 'string' ),
+			'workspace_path'    => array( 'type' => 'string' ),
+			'workspace_backend' => array( 'type' => 'string' ),
+			'runner_workspace'  => array( 'type' => 'object', 'description' => 'Opaque runner workspace identity and provenance.' ),
+			'repo'              => array( 'type' => 'string', 'description' => 'Target repository, for example Automattic/wp-codebox. Alias: target_repo.' ),
+			'target_repo'       => array( 'type' => 'string' ),
+		);
+	}
+
+	/** @return array<string,mixed> */
 	private static function runner_workspace_publication_input_schema(): array {
 		$string_array = array( 'type' => 'array', 'items' => array( 'type' => 'string' ) );
 
 		return array(
 			'type'       => 'object',
 			'required'   => array( 'workspace', 'repo', 'commit_message', 'title', 'body' ),
-			'properties' => array(
+			'properties' => self::runner_workspace_identity_schema() + array(
 				'schema'                => array( 'type' => 'string', 'const' => 'wp-codebox/runner-workspace-publication-request/v1' ),
-				'workspace'             => array( 'type' => 'string', 'description' => 'Runner workspace handle. Alias: workspace_handle.' ),
-				'workspace_handle'      => array( 'type' => 'string' ),
-				'workspace_path'        => array( 'type' => 'string' ),
-				'workspace_backend'     => array( 'type' => 'string' ),
-				'runner_workspace'      => array( 'type' => 'object', 'description' => 'Opaque runner workspace identity and provenance.' ),
-				'repo'                  => array( 'type' => 'string', 'description' => 'Target repository, for example Automattic/wp-codebox. Alias: target_repo.' ),
-				'target_repo'           => array( 'type' => 'string' ),
 				'base'                  => array( 'type' => 'string' ),
 				'base_branch'           => array( 'type' => 'string' ),
 				'head'                  => array( 'type' => 'string' ),
@@ -41,6 +48,78 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'evidence_context'      => array( 'type' => 'object' ),
 				'artifact_context'      => array( 'type' => 'object' ),
 				'context'               => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function runner_workspace_capture_input_schema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'workspace' ),
+			'properties' => self::runner_workspace_identity_schema() + array(
+				'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/runner-workspace-capture-request/v1' ),
+				'from'         => array( 'type' => 'string' ),
+				'to'           => array( 'type' => 'string' ),
+				'path'         => array( 'type' => 'string' ),
+				'include_diff' => array( 'type' => 'boolean', 'default' => true ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function runner_workspace_capture_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'      => array( 'type' => 'boolean' ),
+				'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/runner-workspace-capture-result/v1' ),
+				'status'       => array( 'type' => 'object' ),
+				'diff'         => array( 'type' => 'object' ),
+				'changed'      => array( 'type' => 'boolean' ),
+				'backend'      => array( 'type' => 'string' ),
+				'workspace'    => array( 'type' => 'object' ),
+				'failure_type' => array( 'type' => 'string' ),
+				'error'        => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function runner_workspace_command_input_schema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'workspace', 'command' ),
+			'properties' => self::runner_workspace_identity_schema() + array(
+				'schema'              => array( 'type' => 'string', 'const' => 'wp-codebox/runner-workspace-command-request/v1' ),
+				'command'             => array( 'type' => 'string' ),
+				'description'         => array( 'type' => 'string' ),
+				'timeout_seconds'     => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 600 ),
+				'env'                 => array( 'type' => 'object' ),
+				'context'             => array( 'type' => 'object' ),
+				'allow_local_fallback' => array( 'type' => 'boolean', 'default' => true ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function runner_workspace_command_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'      => array( 'type' => 'boolean' ),
+				'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/runner-workspace-command-result/v1' ),
+				'status'       => array( 'type' => 'string', 'enum' => array( 'completed', 'failed', 'unavailable' ) ),
+				'command'      => array( 'type' => 'string' ),
+				'description'  => array( 'type' => 'string' ),
+				'exit_code'    => array( 'type' => 'integer' ),
+				'stdout'       => array( 'type' => 'string' ),
+				'stderr'       => array( 'type' => 'string' ),
+				'elapsed_ms'   => array( 'type' => 'number' ),
+				'backend'      => array( 'type' => 'string' ),
+				'workspace'    => array( 'type' => 'object' ),
+				'failure_type' => array( 'type' => 'string' ),
+				'error'        => array( 'type' => 'object' ),
 			),
 		);
 	}
@@ -122,10 +201,136 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		return self::normalize_runner_workspace_publication_result( $result, $normalized );
 	}
 
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	public static function capture_runner_workspace( array $input ): array {
+		$normalized = self::normalize_runner_workspace_identity_input( $input );
+		if ( is_array( $normalized['error'] ?? null ) ) {
+			return self::runner_workspace_operation_failure( 'capture', 'invalid_request', $normalized['error'], 'failed', $normalized );
+		}
+
+		$status = self::execute_runner_workspace_backend_ability( 'datamachine-code/workspace-git-status', array( 'name' => $normalized['workspace'] ) );
+		if ( is_array( $status['error'] ?? null ) ) {
+			return self::runner_workspace_operation_failure( 'capture', (string) $status['failure_type'], $status['error'], 'unavailable', $normalized );
+		}
+
+		$status_result = is_array( $status['result'] ?? null ) ? $status['result'] : array();
+		$files         = self::runner_publication_string_list( $status_result['files'] ?? array() );
+		$dirty         = (int) ( $status_result['dirty'] ?? count( $files ) );
+		$backend       = (string) ( $status_result['backend'] ?? $normalized['workspace_backend'] ?? 'datamachine-code' );
+		$diff_result   = array();
+		$include_diff  = false !== ( $input['include_diff'] ?? true );
+
+		if ( $include_diff ) {
+			$diff_input = array_filter(
+				array(
+					'name' => $normalized['workspace'],
+					'from' => trim( (string) ( $input['from'] ?? '' ) ),
+					'to'   => trim( (string) ( $input['to'] ?? '' ) ),
+					'path' => trim( (string) ( $input['path'] ?? '' ) ),
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			);
+			$diff = self::execute_runner_workspace_backend_ability( 'datamachine-code/workspace-git-diff', $diff_input );
+			if ( is_array( $diff['error'] ?? null ) ) {
+				return self::runner_workspace_operation_failure( 'capture', (string) $diff['failure_type'], $diff['error'], 'unavailable', $normalized, array( 'status' => $status_result ) );
+			}
+
+			$diff_result = is_array( $diff['result'] ?? null ) ? $diff['result'] : array();
+		}
+
+		return array_filter(
+			array(
+				'success'   => true,
+				'schema'    => 'wp-codebox/runner-workspace-capture-result/v1',
+				'backend'   => $backend,
+				'changed'   => $dirty > 0 || array() !== $files,
+				'workspace' => self::runner_workspace_identity_result( $normalized, $backend ),
+				'status'    => array_filter(
+					array(
+						'handle'  => (string) ( $status_result['name'] ?? $normalized['workspace'] ),
+						'name'    => (string) ( $status_result['name'] ?? $normalized['workspace'] ),
+						'repo'    => (string) ( $status_result['repo'] ?? $normalized['repo'] ),
+						'path'    => (string) ( $status_result['path'] ?? $normalized['workspace_path'] ),
+						'branch'  => (string) ( $status_result['branch'] ?? '' ),
+						'remote'  => (string) ( $status_result['remote'] ?? '' ),
+						'commit'  => (string) ( $status_result['commit'] ?? '' ),
+						'dirty'   => $dirty,
+						'files'   => $files,
+						'backend' => $backend,
+					),
+					static fn( mixed $value ): bool => '' !== $value && array() !== $value
+				),
+				'diff'      => array_filter(
+					array(
+						'diff'    => (string) ( $diff_result['diff'] ?? '' ),
+						'name'    => (string) ( $diff_result['name'] ?? $normalized['workspace'] ),
+						'backend' => (string) ( $diff_result['backend'] ?? $backend ),
+					),
+					static fn( mixed $value ): bool => '' !== $value
+				),
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	public static function run_runner_workspace_command( array $input ): array {
+		$normalized = self::normalize_runner_workspace_identity_input( $input );
+		$command    = trim( (string) ( $input['command'] ?? '' ) );
+		if ( '' === $command ) {
+			$normalized['error'] = array(
+				'code'    => 'wp_codebox_runner_workspace_command_invalid_request',
+				'message' => 'Runner workspace command execution requires a command.',
+				'missing' => array( 'command' ),
+			);
+		}
+
+		if ( is_array( $normalized['error'] ?? null ) ) {
+			return self::runner_workspace_operation_failure( 'command', 'invalid_request', $normalized['error'], 'failed', $normalized );
+		}
+
+		$backend_input = array_filter(
+			array(
+				'workspace'         => $normalized['workspace'],
+				'workspace_handle'  => $normalized['workspace'],
+				'name'              => $normalized['workspace'],
+				'workspace_path'    => $normalized['workspace_path'],
+				'workspace_backend' => $normalized['workspace_backend'],
+				'repo'              => $normalized['repo'],
+				'target_repo'       => $normalized['repo'],
+				'command'           => $command,
+				'description'       => trim( (string) ( $input['description'] ?? '' ) ),
+				'timeout_seconds'   => max( 1, min( 600, (int) ( $input['timeout_seconds'] ?? 120 ) ) ),
+				'env'               => is_array( $input['env'] ?? null ) ? $input['env'] : array(),
+				'context'           => is_array( $input['context'] ?? null ) ? $input['context'] : array(),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value && null !== $value
+		);
+
+		$backend = self::execute_runner_workspace_backend_ability( 'datamachine-code/run-runner-workspace-command', $backend_input );
+		if ( ! is_array( $backend['error'] ?? null ) ) {
+			$result = is_array( $backend['result'] ?? null ) ? $backend['result'] : array();
+			return self::normalize_runner_workspace_command_result( $result, $normalized, $backend_input, (string) ( $result['backend'] ?? 'datamachine-code' ) );
+		}
+
+		if ( false !== ( $input['allow_local_fallback'] ?? true ) && '' !== $normalized['workspace_path'] && is_dir( $normalized['workspace_path'] ) ) {
+			return self::run_local_runner_workspace_command( $command, $normalized, $backend_input );
+		}
+
+		return self::runner_workspace_operation_failure(
+			'command',
+			(string) $backend['failure_type'],
+			$backend['error'],
+			'unavailable',
+			$normalized
+		);
+	}
+
 	/** @param array<string,mixed> $input Raw ability input. @return array<string,mixed> */
 	private static function normalize_runner_workspace_publication_input( array $input ): array {
-		$workspace = trim( (string) ( $input['workspace'] ?? $input['workspace_handle'] ?? '' ) );
-		$repo      = trim( (string) ( $input['repo'] ?? $input['target_repo'] ?? '' ) );
+		$identity  = self::normalize_runner_workspace_identity_input( $input );
+		$workspace = (string) $identity['workspace'];
+		$repo      = (string) $identity['repo'];
 		$title     = trim( (string) ( $input['title'] ?? $input['pr_title'] ?? '' ) );
 		$body      = (string) ( $input['body'] ?? $input['pr_body'] ?? '' );
 		$paths     = self::runner_publication_string_list( $input['paths'] ?? $input['changed_paths'] ?? array() );
@@ -133,9 +338,9 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		$normalized = array(
 			'workspace'             => $workspace,
 			'workspace_handle'      => $workspace,
-			'workspace_path'        => trim( (string) ( $input['workspace_path'] ?? '' ) ),
-			'workspace_backend'     => trim( (string) ( $input['workspace_backend'] ?? '' ) ),
-			'runner_workspace'      => is_array( $input['runner_workspace'] ?? null ) ? $input['runner_workspace'] : array(),
+			'workspace_path'        => (string) $identity['workspace_path'],
+			'workspace_backend'     => (string) $identity['workspace_backend'],
+			'runner_workspace'      => $identity['runner_workspace'],
 			'repo'                  => $repo,
 			'target_repo'           => $repo,
 			'base'                  => trim( (string) ( $input['base'] ?? $input['base_branch'] ?? '' ) ),
@@ -167,6 +372,35 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'code'    => 'wp_codebox_runner_workspace_publication_invalid_request',
 				'message' => 'Runner workspace publication requires workspace, repo, commit_message, title, and body.',
 				'missing' => $missing,
+			);
+		}
+
+		return $normalized;
+	}
+
+	/** @param array<string,mixed> $input Raw ability input. @return array<string,mixed> */
+	private static function normalize_runner_workspace_identity_input( array $input ): array {
+		$runner_workspace = is_array( $input['runner_workspace'] ?? null ) ? $input['runner_workspace'] : array();
+		$workspace        = trim( (string) ( $input['workspace'] ?? $input['workspace_handle'] ?? $input['handle'] ?? $runner_workspace['handle'] ?? $runner_workspace['name'] ?? '' ) );
+		$repo             = trim( (string) ( $input['repo'] ?? $input['target_repo'] ?? $runner_workspace['repo'] ?? '' ) );
+		$path             = trim( (string) ( $input['workspace_path'] ?? $runner_workspace['path'] ?? '' ) );
+		$backend          = trim( (string) ( $input['workspace_backend'] ?? $runner_workspace['backend'] ?? '' ) );
+
+		$normalized = array(
+			'workspace'         => $workspace,
+			'workspace_handle'  => $workspace,
+			'workspace_path'    => $path,
+			'workspace_backend' => $backend,
+			'runner_workspace'  => $runner_workspace,
+			'repo'              => $repo,
+			'target_repo'       => $repo,
+		);
+
+		if ( '' === $workspace ) {
+			$normalized['error'] = array(
+				'code'    => 'wp_codebox_runner_workspace_identity_invalid_request',
+				'message' => 'Runner workspace APIs require a workspace handle.',
+				'missing' => array( 'workspace' ),
 			);
 		}
 
@@ -278,6 +512,163 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'artifacts'    => is_array( $input['artifact_context'] ?? null ) ? $input['artifact_context'] : array(),
 			),
 			static fn( mixed $value ): bool => array() !== $value && '' !== $value && null !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array{result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
+	private static function execute_runner_workspace_backend_ability( string $ability_name, array $input ): array {
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
+		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
+			return array(
+				'failure_type' => 'backend_unavailable',
+				'error'        => array(
+					'code'    => 'wp_codebox_runner_workspace_backend_unavailable',
+					'message' => 'Runner workspace backend ability is not available for this operation.',
+					'ability' => $ability_name,
+				),
+			);
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'failure_type' => 'backend_error',
+				'error'        => array(
+					'code'    => $result->get_error_code(),
+					'message' => $result->get_error_message(),
+					'data'    => $result->get_error_data(),
+					'ability' => $ability_name,
+				),
+			);
+		}
+
+		if ( ! is_array( $result ) ) {
+			return array(
+				'failure_type' => 'backend_invalid_response',
+				'error'        => array(
+					'code'    => 'wp_codebox_runner_workspace_backend_invalid_response',
+					'message' => 'Runner workspace backend ability returned an invalid response.',
+					'ability' => $ability_name,
+				),
+			);
+		}
+
+		if ( false === ( $result['success'] ?? true ) ) {
+			return array(
+				'failure_type' => (string) ( $result['failure_type'] ?? 'backend_failed' ),
+				'error'        => is_array( $result['error'] ?? null ) ? $result['error'] : array( 'message' => (string) ( $result['error'] ?? 'Runner workspace backend operation failed.' ), 'ability' => $ability_name ),
+			);
+		}
+
+		return array( 'result' => $result );
+	}
+
+	/** @param array<string,mixed> $input Normalized input. @param array<string,mixed> $extra Extra response fields. @return array<string,mixed> */
+	private static function runner_workspace_operation_failure( string $operation, string $failure_type, array $error, string $status, array $input, array $extra = array() ): array {
+		return array_filter(
+			array_merge(
+				array(
+					'success'      => false,
+					'schema'       => 'command' === $operation ? 'wp-codebox/runner-workspace-command-result/v1' : 'wp-codebox/runner-workspace-capture-result/v1',
+					'status'       => $status,
+					'failure_type' => $failure_type,
+					'error'        => $error,
+					'backend'      => (string) ( $input['workspace_backend'] ?? 'unavailable' ),
+					'workspace'    => self::runner_workspace_identity_result( $input, (string) ( $input['workspace_backend'] ?? 'unavailable' ) ),
+				),
+				$extra
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value && null !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Normalized input. @return array<string,mixed> */
+	private static function runner_workspace_identity_result( array $input, string $backend ): array {
+		return array_filter(
+			array(
+				'handle'  => (string) ( $input['workspace'] ?? '' ),
+				'path'    => (string) ( $input['workspace_path'] ?? '' ),
+				'repo'    => (string) ( $input['repo'] ?? '' ),
+				'backend' => $backend,
+			),
+			static fn( mixed $value ): bool => '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $result Backend result. @param array<string,mixed> $input Normalized input. @param array<string,mixed> $command_input Command input. @return array<string,mixed> */
+	private static function normalize_runner_workspace_command_result( array $result, array $input, array $command_input, string $backend ): array {
+		$exit_code = (int) ( $result['exit_code'] ?? $result['code'] ?? 0 );
+
+		return array_filter(
+			array(
+				'success'     => (bool) ( $result['success'] ?? 0 === $exit_code ),
+				'schema'      => 'wp-codebox/runner-workspace-command-result/v1',
+				'status'      => (bool) ( $result['success'] ?? 0 === $exit_code ) ? 'completed' : 'failed',
+				'command'     => (string) ( $result['command'] ?? $command_input['command'] ?? '' ),
+				'description' => (string) ( $result['description'] ?? $command_input['description'] ?? '' ),
+				'exit_code'   => $exit_code,
+				'stdout'      => (string) ( $result['stdout'] ?? '' ),
+				'stderr'      => (string) ( $result['stderr'] ?? '' ),
+				'elapsed_ms'  => (float) ( $result['elapsed_ms'] ?? 0 ),
+				'backend'     => $backend,
+				'workspace'   => self::runner_workspace_identity_result( $input, $backend ),
+			),
+			static fn( mixed $value ): bool => '' !== $value && null !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Normalized input. @param array<string,mixed> $command_input Command input. @return array<string,mixed> */
+	private static function run_local_runner_workspace_command( string $command, array $input, array $command_input ): array {
+		if ( ! function_exists( 'proc_open' ) ) {
+			return self::runner_workspace_operation_failure(
+				'command',
+				'local_command_unavailable',
+				array( 'code' => 'wp_codebox_runner_workspace_local_command_unavailable', 'message' => 'Local command execution is unavailable in this PHP runtime.' ),
+				'unavailable',
+				$input
+			);
+		}
+
+		$started = hrtime( true );
+		$env     = is_array( $command_input['env'] ?? null ) ? array_map( 'strval', $command_input['env'] ) : array();
+		$process = proc_open(
+			$command,
+			array(
+				1 => array( 'pipe', 'w' ),
+				2 => array( 'pipe', 'w' ),
+			),
+			$pipes,
+			(string) $input['workspace_path'],
+			array() === $env ? null : $env
+		);
+
+		if ( ! is_resource( $process ) ) {
+			return self::runner_workspace_operation_failure(
+				'command',
+				'local_command_failed',
+				array( 'code' => 'wp_codebox_runner_workspace_local_command_failed', 'message' => 'Failed to start local runner workspace command.' ),
+				'failed',
+				$input
+			);
+		}
+
+		$stdout    = stream_get_contents( $pipes[1] );
+		$stderr    = stream_get_contents( $pipes[2] );
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
+		$exit_code = proc_close( $process );
+
+		return self::normalize_runner_workspace_command_result(
+			array(
+				'success'    => 0 === $exit_code,
+				'exit_code'  => $exit_code,
+				'stdout'     => is_string( $stdout ) ? trim( $stdout ) : '',
+				'stderr'     => is_string( $stderr ) ? trim( $stderr ) : '',
+				'elapsed_ms' => ( hrtime( true ) - $started ) / 1000000,
+			),
+			$input,
+			$command_input,
+			'local_path'
 		);
 	}
 

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -480,6 +480,95 @@ $assert( 'runner workspace publication forwards PR options and paths', array( 'a
 $assert( 'runner workspace publication normalizes backend result', ! is_wp_error( $publication_result ) && true === ( $publication_result['success'] ?? false ) && 'published' === ( $publication_result['status'] ?? '' ) && 'github_api' === ( $publication_result['backend'] ?? '' ) && 873 === ( $publication_result['pull_request']['number'] ?? 0 ) && true === ( $publication_result['pull_request']['reused'] ?? false ) && false === ( $publication_result['pull_request']['opened'] ?? true ) && 'abc123def456' === ( $publication_result['commit']['sha'] ?? '' ) );
 unset( $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/publish-runner-workspace'] );
 
+$capture_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/capture-runner-workspace'] ?? null;
+$assert( 'runner workspace capture ability registered', is_array( $capture_ability ) );
+$assert( 'runner workspace capture ability is REST visible', true === ( $capture_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'runner workspace capture ability exposes Codebox request/result schemas', 'wp-codebox/runner-workspace-capture-request/v1' === ( $capture_ability['input_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/runner-workspace-capture-result/v1' === ( $capture_ability['output_schema']['properties']['schema']['const'] ?? '' ) );
+$capture_unavailable = call_user_func( $capture_ability['execute_callback'], array( 'workspace' => 'wp-codebox@runner-docs', 'repo' => 'Automattic/wp-codebox' ) );
+$assert( 'runner workspace capture returns typed unavailable without backend', ! is_wp_error( $capture_unavailable ) && false === ( $capture_unavailable['success'] ?? true ) && 'unavailable' === ( $capture_unavailable['status'] ?? '' ) && 'backend_unavailable' === ( $capture_unavailable['failure_type'] ?? '' ) );
+
+$dmc_status_ability = new WP_Codebox_Smoke_Ability(
+	array(
+		'success' => true,
+		'backend' => 'github_api',
+		'name'    => 'wp-codebox@runner-docs',
+		'repo'    => 'Automattic/wp-codebox',
+		'branch'  => 'runner/docs',
+		'commit'  => 'abc123def456',
+		'dirty'   => 2,
+		'files'   => array( 'docs/architecture.md', 'docs/skill-contracts.md' ),
+	)
+);
+$dmc_diff_ability = new WP_Codebox_Smoke_Ability(
+	array(
+		'success' => true,
+		'backend' => 'github_api',
+		'name'    => 'wp-codebox@runner-docs',
+		'diff'    => "diff --git a/docs/architecture.md b/docs/architecture.md\n",
+	)
+);
+$GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-git-status'] = $dmc_status_ability;
+$GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-git-diff'] = $dmc_diff_ability;
+$capture_result = call_user_func(
+	$capture_ability['execute_callback'],
+	array(
+		'workspace'         => 'wp-codebox@runner-docs',
+		'workspace_backend' => 'github_api',
+		'repo'              => 'Automattic/wp-codebox',
+		'from'              => 'main',
+	)
+);
+$assert( 'runner workspace capture delegates to DMC status and diff', 'wp-codebox@runner-docs' === ( $dmc_status_ability->calls[0]['name'] ?? '' ) && 'wp-codebox@runner-docs' === ( $dmc_diff_ability->calls[0]['name'] ?? '' ) && 'main' === ( $dmc_diff_ability->calls[0]['from'] ?? '' ) );
+$assert( 'runner workspace capture normalizes status and diff', ! is_wp_error( $capture_result ) && true === ( $capture_result['success'] ?? false ) && true === ( $capture_result['changed'] ?? false ) && 'github_api' === ( $capture_result['backend'] ?? '' ) && 2 === ( $capture_result['status']['dirty'] ?? 0 ) && array( 'docs/architecture.md', 'docs/skill-contracts.md' ) === ( $capture_result['status']['files'] ?? array() ) && str_contains( (string) ( $capture_result['diff']['diff'] ?? '' ), 'docs/architecture.md' ) );
+unset( $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-git-status'], $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-git-diff'] );
+
+$command_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-runner-workspace-command'] ?? null;
+$assert( 'runner workspace command ability registered', is_array( $command_ability ) );
+$assert( 'runner workspace command ability is REST visible', true === ( $command_ability['meta']['show_in_rest'] ?? false ) );
+$assert( 'runner workspace command ability exposes Codebox request/result schemas', 'wp-codebox/runner-workspace-command-request/v1' === ( $command_ability['input_schema']['properties']['schema']['const'] ?? '' ) && 'wp-codebox/runner-workspace-command-result/v1' === ( $command_ability['output_schema']['properties']['schema']['const'] ?? '' ) );
+$command_unavailable = call_user_func( $command_ability['execute_callback'], array( 'workspace' => 'wp-codebox@runner-docs', 'command' => 'npm run verify', 'allow_local_fallback' => false ) );
+$assert( 'runner workspace command returns typed unavailable without backend', ! is_wp_error( $command_unavailable ) && false === ( $command_unavailable['success'] ?? true ) && 'unavailable' === ( $command_unavailable['status'] ?? '' ) && 'backend_unavailable' === ( $command_unavailable['failure_type'] ?? '' ) );
+
+$dmc_command_ability = new WP_Codebox_Smoke_Ability(
+	array(
+		'success'    => true,
+		'backend'    => 'github_api',
+		'command'    => 'pnpm verify',
+		'exit_code'  => 0,
+		'stdout'     => 'verified',
+		'stderr'     => '',
+		'elapsed_ms' => 12.5,
+	)
+);
+$GLOBALS['wp_codebox_mock_abilities']['datamachine-code/run-runner-workspace-command'] = $dmc_command_ability;
+$command_result = call_user_func(
+	$command_ability['execute_callback'],
+	array(
+		'workspace'         => 'wp-codebox@runner-docs',
+		'workspace_backend' => 'github_api',
+		'repo'              => 'Automattic/wp-codebox',
+		'command'           => 'pnpm verify',
+		'description'       => 'Run verification',
+		'timeout_seconds'   => 300,
+	)
+);
+$assert( 'runner workspace command delegates to backend command API', 'wp-codebox@runner-docs' === ( $dmc_command_ability->calls[0]['workspace'] ?? '' ) && 'pnpm verify' === ( $dmc_command_ability->calls[0]['command'] ?? '' ) && 300 === ( $dmc_command_ability->calls[0]['timeout_seconds'] ?? 0 ) );
+$assert( 'runner workspace command normalizes backend command result', ! is_wp_error( $command_result ) && true === ( $command_result['success'] ?? false ) && 'completed' === ( $command_result['status'] ?? '' ) && 'github_api' === ( $command_result['backend'] ?? '' ) && 0 === ( $command_result['exit_code'] ?? -1 ) && 'verified' === ( $command_result['stdout'] ?? '' ) );
+unset( $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/run-runner-workspace-command'] );
+
+$local_command_workspace = $root . '/runner-command-workspace';
+mkdir( $local_command_workspace, 0777, true );
+$local_command_result = call_user_func(
+	$command_ability['execute_callback'],
+	array(
+		'workspace'      => 'wp-codebox@local-runner',
+		'workspace_path' => $local_command_workspace,
+		'command'        => 'printf local-ok > verification.txt',
+		'description'    => 'Write local verification marker',
+	)
+);
+$assert( 'runner workspace command can execute via local WP Codebox fallback', ! is_wp_error( $local_command_result ) && true === ( $local_command_result['success'] ?? false ) && 'local_path' === ( $local_command_result['backend'] ?? '' ) && is_file( $local_command_workspace . '/verification.txt' ) );
+
 $browser_session_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/create-browser-playground-session'] ?? null;
 $assert( 'browser Playground session ability registered', is_array( $browser_session_ability ) );
 $assert( 'browser Playground session ability is REST visible', true === ( $browser_session_ability['meta']['show_in_rest'] ?? false ) );


### PR DESCRIPTION
## Summary
- Adds `wp-codebox/capture-runner-workspace` for runner workspace status/diff capture through the WP Codebox boundary.
- Adds `wp-codebox/run-runner-workspace-command` for verification/drift commands through the same boundary, with typed unavailable/failure results.
- Extends runner workspace TypeScript contracts and smoke coverage for DMC status/diff delegation, backend command delegation, unavailable states, and local fallback execution.

Fixes #877.

Related: Extra-Chill/homeboy-extensions#1259

## Verification
- `php tests/smoke-wordpress-plugin.php`
- `npm run build`
- `npm exec -- tsx scripts/package-distribution-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the WP Codebox runner workspace capture/command APIs, smoke coverage, and verification steps for Chris to review.