### PR TITLE
Fix package lock version metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -3929,7 +3929,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -3940,11 +3940,11 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.8.0"
+      "version": "0.8.1"
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@types/pngjs": "^6.0.5",


### PR DESCRIPTION
## Summary
- Refresh `package-lock.json` version metadata so the root workspace and published workspace packages match their `0.8.1` manifests.
- Leave `packages/wordpress-plugin` at `0.8.0` because its manifest still declares `0.8.0`.
- Fixes #879.

## Testing
- `npm install`
- `npm install` again with lockfile diff checksum comparison to confirm no further lockfile churn
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the issue/manifests, regenerated the lockfile metadata, and ran the targeted verification. Chris remains responsible for review and merge.