### PR TITLE
Let rig bench workloads override discovered scenarios

### DIFF
--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -658,19 +658,23 @@ function wp_codebox_bench_configured_scenario_source(array $workload): string {
     return isset($workload['source']) && is_string($workload['source']) && trim($workload['source']) !== '' ? trim($workload['source']) : 'config';
 }
 
+function wp_codebox_bench_configured_overrides_discovered(array $workload): bool {
+    return isset($workload['overridesDiscovered']) && $workload['overridesDiscovered'] === true;
+}
+
 $bench_dir = $plugin_path . '/tests/bench';
 $workload_files = is_dir($bench_dir) ? glob($bench_dir . '/*.php') : array();
 sort($workload_files, SORT_STRING);
 
 $selected_scenario_ids = is_array($selected_scenario_ids) ? wp_codebox_bench_selected_scenario_ids($selected_scenario_ids) : array();
 $configured_workloads = is_array($configured_workloads) ? $configured_workloads : array();
-$configured_rig_scenario_ids = array();
+$configured_override_scenario_ids = array();
 foreach ($configured_workloads as $index => $workload) {
     if (!is_array($workload)) {
         continue;
     }
-    if (wp_codebox_bench_configured_scenario_source($workload) === 'rig') {
-        $configured_rig_scenario_ids[wp_codebox_bench_configured_scenario_id($workload, $index)] = true;
+    if (wp_codebox_bench_configured_overrides_discovered($workload)) {
+        $configured_override_scenario_ids[wp_codebox_bench_configured_scenario_id($workload, $index)] = true;
     }
 }
 if (!empty($selected_scenario_ids)) {
@@ -706,7 +710,7 @@ foreach ($workload_files as $workload_file) {
     if (!wp_codebox_bench_scenario_selected($scenario_id, $selected_scenario_ids)) {
         continue;
     }
-    if (isset($configured_rig_scenario_ids[$scenario_id])) {
+    if (isset($configured_override_scenario_ids[$scenario_id])) {
         continue;
     }
 

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -650,21 +650,39 @@ function wp_codebox_bench_scenario_selected(string $scenario_id, array $selected
     return empty($selected_ids) || isset($selected_ids[$scenario_id]);
 }
 
+function wp_codebox_bench_configured_scenario_id(array $workload, int $index): string {
+    return isset($workload['id']) && is_string($workload['id']) ? $workload['id'] : 'configured-' . $index;
+}
+
+function wp_codebox_bench_configured_scenario_source(array $workload): string {
+    return isset($workload['source']) && is_string($workload['source']) && trim($workload['source']) !== '' ? trim($workload['source']) : 'config';
+}
+
 $bench_dir = $plugin_path . '/tests/bench';
 $workload_files = is_dir($bench_dir) ? glob($bench_dir . '/*.php') : array();
 sort($workload_files, SORT_STRING);
 
 $selected_scenario_ids = is_array($selected_scenario_ids) ? wp_codebox_bench_selected_scenario_ids($selected_scenario_ids) : array();
+$configured_workloads = is_array($configured_workloads) ? $configured_workloads : array();
+$configured_rig_scenario_ids = array();
+foreach ($configured_workloads as $index => $workload) {
+    if (!is_array($workload)) {
+        continue;
+    }
+    if (wp_codebox_bench_configured_scenario_source($workload) === 'rig') {
+        $configured_rig_scenario_ids[wp_codebox_bench_configured_scenario_id($workload, $index)] = true;
+    }
+}
 if (!empty($selected_scenario_ids)) {
     $available_scenario_ids = array();
     foreach ($workload_files as $workload_file) {
         $available_scenario_ids[preg_replace('/\\.php$/', '', basename($workload_file))] = true;
     }
-    foreach (is_array($configured_workloads) ? $configured_workloads : array() as $index => $workload) {
+    foreach ($configured_workloads as $index => $workload) {
         if (!is_array($workload)) {
             continue;
         }
-        $available_scenario_ids[isset($workload['id']) && is_string($workload['id']) ? $workload['id'] : 'configured-' . $index] = true;
+        $available_scenario_ids[wp_codebox_bench_configured_scenario_id($workload, $index)] = true;
     }
     if (empty(array_intersect_key($selected_scenario_ids, $available_scenario_ids))) {
         throw new RuntimeException('wordpress.bench selected scenario ids did not match any known scenarios. diagnostic=' . wp_json_encode(array(
@@ -686,6 +704,9 @@ $scenarios = array();
 foreach ($workload_files as $workload_file) {
     $scenario_id = preg_replace('/\\.php$/', '', basename($workload_file));
     if (!wp_codebox_bench_scenario_selected($scenario_id, $selected_scenario_ids)) {
+        continue;
+    }
+    if (isset($configured_rig_scenario_ids[$scenario_id])) {
         continue;
     }
 
@@ -753,11 +774,11 @@ foreach ($workload_files as $workload_file) {
     $scenarios[] = $scenario;
 }
 
-foreach (is_array($configured_workloads) ? $configured_workloads : array() as $index => $workload) {
+foreach ($configured_workloads as $index => $workload) {
     if (!is_array($workload)) {
         continue;
     }
-    $scenario_id = isset($workload['id']) && is_string($workload['id']) ? $workload['id'] : 'configured-' . $index;
+    $scenario_id = wp_codebox_bench_configured_scenario_id($workload, $index);
     if (!wp_codebox_bench_scenario_selected($scenario_id, $selected_scenario_ids)) {
         continue;
     }
@@ -786,7 +807,7 @@ foreach (is_array($configured_workloads) ? $configured_workloads : array() as $i
     }
     $scenario = array(
         'id' => $scenario_id,
-        'source' => 'config',
+        'source' => wp_codebox_bench_configured_scenario_source($workload),
         'iterations' => $iterations,
         'metrics' => wp_codebox_bench_metrics($timings, $metric_samples),
         'memory' => array('peak_bytes' => memory_get_peak_usage(true)),

--- a/scripts/recipe-bench-smoke.ts
+++ b/scripts/recipe-bench-smoke.ts
@@ -52,9 +52,10 @@ writeFileSync(recipePath, `${JSON.stringify({
           `workloads-json=${JSON.stringify([
             {
               id: "noop",
-              source: "rig",
+              source: "external",
+              overridesDiscovered: true,
               run: [{ type: "php", file: "tests/bench/noop.php" }],
-              metadata: { kind: "rig" },
+              metadata: { kind: "external" },
             },
             {
               id: "configured-env",
@@ -111,7 +112,7 @@ assert.equal(output.benchResults.provenance.definition.schema, "wp-codebox/bench
 
 const scenario = output.benchResults.scenarios[0]
 assert.equal(scenario.id, "noop")
-assert.equal(scenario.source, "rig")
+assert.equal(scenario.source, "external")
 assert.equal(scenario.file, undefined)
 assert.equal(scenario.iterations, 2)
 assert.equal(scenario.metrics.duration.unit, "ms")
@@ -133,7 +134,7 @@ assert.equal(scenario.metrics.dependency_init_callback_count.samples.mean, 1)
 assert.equal(scenario.metrics.duration.samples.values.length, 2)
 assert.deepEqual(scenario.metrics.fixture_value.samples.values, [7, 7])
 assert.equal(scenario.metrics.fixture_value.samples.standard_deviation, 0)
-assert.equal(scenario.metadata.kind, "rig")
+assert.equal(scenario.metadata.kind, "external")
 assert.equal(scenario.metadata.fixture, "bench-plugin")
 const configured = output.benchResults.scenarios[1]
 assert.equal(configured.id, "configured-env")

--- a/scripts/recipe-bench-smoke.ts
+++ b/scripts/recipe-bench-smoke.ts
@@ -51,6 +51,12 @@ writeFileSync(recipePath, `${JSON.stringify({
           `env-json=${JSON.stringify({ BENCH_FIXTURE_ENV: "13" })}`,
           `workloads-json=${JSON.stringify([
             {
+              id: "noop",
+              source: "rig",
+              run: [{ type: "php", file: "tests/bench/noop.php" }],
+              metadata: { kind: "rig" },
+            },
+            {
               id: "configured-env",
               run: [
                 { type: "wp-cli", command: "wp option update wp_codebox_bench_wp_cli yes", parse: "json" },
@@ -105,12 +111,13 @@ assert.equal(output.benchResults.provenance.definition.schema, "wp-codebox/bench
 
 const scenario = output.benchResults.scenarios[0]
 assert.equal(scenario.id, "noop")
-assert.equal(scenario.file, "tests/bench/noop.php")
+assert.equal(scenario.source, "rig")
+assert.equal(scenario.file, undefined)
 assert.equal(scenario.iterations, 2)
 assert.equal(scenario.metrics.duration.unit, "ms")
 assert.equal(scenario.metrics.duration.samples.count, 2)
 assert.equal(scenario.diagnostics.length, 0)
-assert.equal(scenario.provenance.workload_file, "tests/bench/noop.php")
+assert.equal(scenario.provenance.workload_index, 0)
 assert.equal(scenario.metrics.fixture_value.samples.mean, 7)
 assert.equal(scenario.metrics.rest_route_visible.samples.mean, 1)
 assert.equal(scenario.metrics.included_before_plugins_loaded.samples.mean, 1)
@@ -126,6 +133,7 @@ assert.equal(scenario.metrics.dependency_init_callback_count.samples.mean, 1)
 assert.equal(scenario.metrics.duration.samples.values.length, 2)
 assert.deepEqual(scenario.metrics.fixture_value.samples.values, [7, 7])
 assert.equal(scenario.metrics.fixture_value.samples.standard_deviation, 0)
+assert.equal(scenario.metadata.kind, "rig")
 assert.equal(scenario.metadata.fixture, "bench-plugin")
 const configured = output.benchResults.scenarios[1]
 assert.equal(configured.id, "configured-env")


### PR DESCRIPTION
## Summary
- Add a generic `overridesDiscovered: true` flag for explicit `wordpress.bench` workloads.
- Skip same-id discovered `tests/bench/*.php` workloads when an explicit configured workload opts into overriding discovery.
- Continue preserving the configured workload `source` string in bench results as provenance only; WP Codebox does not special-case Homeboy or rig vocabulary.

Upstream generic execution fix for Extra-Chill/homeboy-extensions#1266.

## Tests
- `npm run build`
- `npx tsx scripts/recipe-bench-smoke.ts`
- `npx tsx scripts/wordpress-recipe-builders-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic `wordpress.bench` same-ID configured workload override behavior and updated targeted smoke coverage. Chris remains responsible for review and merge.