### PR TITLE
Use mounted runner checkout during preparation

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -202,10 +202,9 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			define( 'DATAMACHINE_WORKSPACE_PATH', rtrim( dirname( $checkout_path ), '/' ) );
 		}
 
-		$required = array( 'datamachine-code/workspace-show', 'datamachine-code/workspace-clone', 'datamachine-code/workspace-worktree-add' );
-		if ( '' !== $checkout_path ) {
-			$required[] = 'datamachine-code/workspace-adopt';
-		}
+		$required = '' !== $checkout_path
+			? array( 'datamachine-code/workspace-adopt' )
+			: array( 'datamachine-code/workspace-show', 'datamachine-code/workspace-clone', 'datamachine-code/workspace-worktree-add' );
 
 		foreach ( $required as $ability_name ) {
 			$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
@@ -227,6 +226,23 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			if ( ! is_array( $adopt ) || empty( $adopt['success'] ) ) {
 				return self::runner_workspace_prepare_failure( 'backend_failed', array( 'code' => 'wp_codebox_runner_workspace_prepare_adopt_failed', 'message' => 'Runner workspace backend could not adopt the mounted checkout.', 'result' => $adopt ), 'failed', $normalized );
 			}
+
+			return array_filter(
+				array(
+					'success'      => true,
+					'schema'       => 'wp-codebox/runner-workspace-prepare-result/v1',
+					'status'       => 'prepared',
+					'backend'      => 'datamachine-code',
+					'repo'         => $normalized['repo'],
+					'branch'       => $normalized['branch'],
+					'handle'       => (string) ( $adopt['handle'] ?? $adopt['name'] ?? $normalized['repo'] ),
+					'path'         => (string) ( $adopt['path'] ?? $checkout_path ),
+					'capabilities' => array( 'capture' => true, 'command' => true, 'publish' => true ),
+					'input'        => array( 'path' => $checkout_path, 'name' => $normalized['repo'] ),
+					'result'       => $adopt,
+				),
+				static fn( mixed $value ): bool => '' !== $value && array() !== $value && null !== $value
+			);
 		}
 
 		$show = wp_get_ability( 'datamachine-code/workspace-show' )->execute( array( 'name' => $normalized['repo'] ) );

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -431,7 +431,7 @@ $assert( 'runner workspace prepare returns typed unavailable without backend', !
 
 $dmc_prepare_show_ability     = new WP_Codebox_Smoke_Ability( array( 'success' => true, 'name' => 'wp-codebox' ) );
 $dmc_prepare_clone_ability    = new WP_Codebox_Smoke_Ability( array( 'success' => true ) );
-$dmc_prepare_adopt_ability    = new WP_Codebox_Smoke_Ability( array( 'success' => true ) );
+$dmc_prepare_adopt_ability    = new WP_Codebox_Smoke_Ability( array( 'success' => true, 'name' => 'wp-codebox', 'path' => '/runner/workspace/wp-codebox' ) );
 $dmc_prepare_worktree_ability = new WP_Codebox_Smoke_Ability( array( 'success' => true, 'handle' => 'wp-codebox@runner-docs', 'branch' => 'runner/docs', 'path' => '/runner/workspace/wp-codebox@runner-docs' ) );
 $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-show']         = $dmc_prepare_show_ability;
 $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-clone']        = $dmc_prepare_clone_ability;
@@ -451,8 +451,8 @@ $prepare_result = call_user_func(
 	)
 );
 $assert( 'runner workspace prepare adopts mounted checkout behind WP Codebox', '/runner/workspace/wp-codebox' === ( $dmc_prepare_adopt_ability->calls[0]['path'] ?? '' ) && 'wp-codebox' === ( $dmc_prepare_adopt_ability->calls[0]['name'] ?? '' ) );
-$assert( 'runner workspace prepare delegates DMC worktree creation', 'wp-codebox' === ( $dmc_prepare_worktree_ability->calls[0]['repo'] ?? '' ) && 'runner/docs' === ( $dmc_prepare_worktree_ability->calls[0]['branch'] ?? '' ) && 'origin/main' === ( $dmc_prepare_worktree_ability->calls[0]['from'] ?? '' ) && true === ( $dmc_prepare_worktree_ability->calls[0]['allow_stale'] ?? false ) );
-$assert( 'runner workspace prepare normalizes result and capabilities', ! is_wp_error( $prepare_result ) && true === ( $prepare_result['success'] ?? false ) && 'prepared' === ( $prepare_result['status'] ?? '' ) && 'datamachine-code' === ( $prepare_result['backend'] ?? '' ) && 'wp-codebox@runner-docs' === ( $prepare_result['handle'] ?? '' ) && true === ( $prepare_result['capabilities']['publish'] ?? false ) );
+$assert( 'runner workspace prepare uses mounted checkout without creating a sandbox worktree', array() === $dmc_prepare_worktree_ability->calls );
+$assert( 'runner workspace prepare normalizes mounted checkout result and capabilities', ! is_wp_error( $prepare_result ) && true === ( $prepare_result['success'] ?? false ) && 'prepared' === ( $prepare_result['status'] ?? '' ) && 'datamachine-code' === ( $prepare_result['backend'] ?? '' ) && 'wp-codebox' === ( $prepare_result['handle'] ?? '' ) && '/runner/workspace/wp-codebox' === ( $prepare_result['path'] ?? '' ) && true === ( $prepare_result['capabilities']['publish'] ?? false ) );
 unset( $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-show'], $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-clone'], $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-adopt'], $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-worktree-add'] );
 
 $publication_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/publish-runner-workspace'] ?? null;


### PR DESCRIPTION
## Summary
- Treat `checkout_path` as an already-mounted runner workspace in `wp-codebox/prepare-runner-workspace`.
- Avoid creating a DMC worktree inside constrained WP Codebox Playground PHP runtimes where `git` is unavailable.
- Keep the non-mounted prepare path on the existing DMC clone/worktree flow.

## Verification
- `php tests/smoke-wordpress-plugin.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php`
- `php -l tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner workspace prepare failure, updated the mounted-checkout path, and ran smoke/syntax verification for review.