### PR TITLE
Fix preview proxy loopback asset delivery

### DIFF
--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -23,6 +23,8 @@ interface PlaygroundPreviewProxy {
   dispose(): Promise<void>
 }
 
+type PreviewProxyServer = ReturnType<typeof createHttpServer>
+
 export class PlaygroundPreviewPortUnavailableError extends Error {
   readonly code = "wp-codebox-preview-port-in-use"
 
@@ -53,7 +55,38 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
 
 async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
   const target = new URL(targetUrl)
-  const proxy = createHttpServer((incoming, outgoing) => {
+  const proxy = previewProxyServer(target)
+  const servers = [proxy]
+
+  await listenPreviewProxy(proxy, port, bind)
+
+  if (bind === "127.0.0.1") {
+    const ipv6Proxy = previewProxyServer(target)
+    try {
+      await listenPreviewProxy(ipv6Proxy, port, "::1")
+      servers.push(ipv6Proxy)
+    } catch (error) {
+      if (!errorHasCode(error, "EADDRNOTAVAIL")) {
+        await closePreviewProxyServers(servers)
+        throw error
+      }
+    }
+  }
+
+  const address = proxy.address()
+  const resolvedPort = address && typeof address === "object" ? address.port : port
+  const reportedHost = bind === "0.0.0.0" ? "127.0.0.1" : bind
+
+  return {
+    serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
+    async dispose() {
+      await closePreviewProxyServers(servers)
+    },
+  }
+}
+
+function previewProxyServer(target: URL): PreviewProxyServer {
+  return createHttpServer((incoming, outgoing) => {
     const targetRequest = httpRequest(
       {
         protocol: target.protocol,
@@ -74,27 +107,24 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
     incoming.on("error", () => targetRequest.destroy())
     incoming.pipe(targetRequest)
   })
+}
 
+async function listenPreviewProxy(proxy: PreviewProxyServer, port: number, bind: string): Promise<void> {
   await new Promise<void>((resolveListen, rejectListen) => {
     proxy.once("error", rejectListen)
     proxy.listen(port, bind, () => resolveListen())
   })
+}
 
-  const address = proxy.address()
-  const resolvedPort = address && typeof address === "object" ? address.port : port
-  const reportedHost = bind === "0.0.0.0" ? "127.0.0.1" : bind
+async function closePreviewProxyServers(servers: PreviewProxyServer[]): Promise<void> {
+  for (const proxy of servers) {
+    if (!proxy.listening) {
+      continue
+    }
 
-  return {
-    serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
-    async dispose() {
-      if (!proxy.listening) {
-        return
-      }
-
-      await new Promise<void>((resolveClose, rejectClose) => {
-        proxy.close((error) => error ? rejectClose(error) : resolveClose())
-      })
-    },
+    await new Promise<void>((resolveClose, rejectClose) => {
+      proxy.close((error) => error ? rejectClose(error) : resolveClose())
+    })
   }
 }
 

--- a/scripts/preview-mounted-plugin-asset-smoke.ts
+++ b/scripts/preview-mounted-plugin-asset-smoke.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { createServer, type Server } from "node:net"
+import { tmpdir } from "node:os"
+import { resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = await mkdtemp(`${tmpdir()}/wp-codebox-preview-plugin-asset-`)
+const port = await reserveFreePort()
+const publicHost = "preview-public.example.test"
+const publicUrl = `https://${publicHost}`
+const previewReadyTimeoutMs = 75_000
+
+await writeFile(`${workspace}/simple-plugin.php`, "<?php\n/** Plugin Name: Preview Asset Smoke */\n")
+await writeFile(`${workspace}/probe.js`, "window.__wpCodeboxPreviewAssetSmoke = true;\n")
+
+const child = spawn(process.execPath, [
+  "packages/cli/dist/index.js",
+  "run",
+  "--mount",
+  `${workspace}:/wordpress/wp-content/plugins/preview-asset-smoke`,
+  "--command",
+  "wordpress.run-php",
+  "--arg",
+  "code=echo 'ready';",
+  "--preview-port",
+  String(port),
+  "--preview-bind",
+  "127.0.0.1",
+  "--preview-public-url",
+  publicUrl,
+  "--preview-hold",
+  "60s",
+  "--json",
+], { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
+const exitPromise = new Promise<number | null>((resolveExit) => child.once("exit", resolveExit))
+
+let stdout = ""
+let stderr = ""
+let pendingError: unknown
+
+try {
+  child.stdout.setEncoding("utf8")
+  child.stderr.setEncoding("utf8")
+  child.stdout.on("data", (chunk) => { stdout += chunk })
+  child.stderr.on("data", (chunk) => { stderr += chunk })
+
+  try {
+    await assertMountedPluginAsset({ origin: `http://127.0.0.1:${port}`, host: publicHost })
+    await assertMountedPluginAsset({ origin: `http://[::1]:${port}`, host: publicHost })
+  } catch (error) {
+    pendingError = error
+  } finally {
+    if (child.exitCode === null) {
+      child.kill("SIGTERM")
+    }
+  }
+
+  const exitCode = await exitPromise
+  assert.ok(exitCode === 0 || exitCode === null, `wp-codebox exited with ${exitCode}\nstdout: ${stdout}\nstderr: ${stderr}`)
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+if (pendingError) {
+  throw pendingError
+}
+
+console.log("Preview mounted plugin asset smoke passed")
+
+async function assertMountedPluginAsset({ origin, host }: { origin: string; host: string }): Promise<void> {
+  const response = await waitForMountedPluginAsset(origin, host)
+  const body = await response.text()
+
+  assert.equal(response.status, 200)
+  assert.match(response.headers.get("content-type") ?? "", /javascript|text\/plain|application\/octet-stream/)
+  assert.match(body, /__wpCodeboxPreviewAssetSmoke/)
+}
+
+async function waitForMountedPluginAsset(origin: string, host: string): Promise<Response> {
+  const deadline = Date.now() + previewReadyTimeoutMs
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${origin}/wp-content/plugins/preview-asset-smoke/probe.js`, {
+        redirect: "manual",
+        headers: {
+          host,
+          "x-forwarded-host": host,
+          "x-forwarded-port": "443",
+          "x-forwarded-proto": "https",
+        },
+      })
+      if (response.status === 200) {
+        return response
+      }
+      const body = await response.text().catch(() => "")
+      lastError = new Error(`Unexpected asset response ${response.status}: ${body.slice(0, 200)}`)
+    } catch (error) {
+      lastError = error
+    }
+
+    await new Promise((resolvePoll) => setTimeout(resolvePoll, 250))
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError))
+}
+
+async function reserveFreePort(): Promise<number> {
+  const server = await listenOnPort(0)
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const reservedPort = address.port
+  await closeServer(server)
+  return reservedPort
+}
+
+async function listenOnPort(listenPort: number): Promise<Server> {
+  const server = createServer()
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen)
+    server.listen(listenPort, "127.0.0.1", () => resolveListen())
+  })
+  return server
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return
+  }
+
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose())
+  })
+}


### PR DESCRIPTION
## Summary
- Adds an IPv6 loopback listener alongside the existing IPv4 fixed preview proxy when WP Codebox binds to `127.0.0.1`.
- Keeps the reported local preview URL unchanged while allowing SSH `localhost` forwards to reach either `127.0.0.1` or `::1` reliably.
- Adds a mounted plugin asset smoke that fetches a preview asset through both loopback families with public-preview headers.

Related: Extra-Chill/homeboy#4062

## Testing
- `npm run build`
- `npx tsx scripts/preview-mounted-plugin-asset-smoke.ts`
- `npx tsx scripts/preview-public-url-canonical-smoke.ts`
- `npx tsx scripts/recipe-preview-routing-browser-probe-smoke.ts`
- `npx tsx scripts/preview-port-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated Homeboy/WP Codebox public-preview trace artifacts, identified the IPv4/IPv6 loopback mismatch, drafted the preview proxy fix and regression smoke, and ran targeted validation; Chris remains responsible for review and merge.