### PR TITLE
Filter runner workspace capture paths

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -105,6 +105,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'from'         => array( 'type' => 'string' ),
 				'to'           => array( 'type' => 'string' ),
 				'path'         => array( 'type' => 'string' ),
+				'exclude_paths' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
 				'include_diff' => array( 'type' => 'boolean', 'default' => true ),
 			),
 		);
@@ -369,8 +370,9 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		}
 
 		$status_result = is_array( $status['result'] ?? null ) ? $status['result'] : array();
-		$files         = self::runner_publication_string_list( $status_result['files'] ?? array() );
-		$dirty         = (int) ( $status_result['dirty'] ?? count( $files ) );
+		$exclude_paths = self::runner_publication_string_list( $input['exclude_paths'] ?? array() );
+		$files         = self::filter_runner_workspace_capture_files( self::runner_publication_string_list( $status_result['files'] ?? array() ), $exclude_paths );
+		$dirty         = count( $files );
 		$backend       = (string) ( $status_result['backend'] ?? $normalized['workspace_backend'] ?? 'datamachine-code' );
 		$diff_result   = array();
 		$include_diff  = false !== ( $input['include_diff'] ?? true );
@@ -391,6 +393,9 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			}
 
 			$diff_result = is_array( $diff['result'] ?? null ) ? $diff['result'] : array();
+			if ( ! empty( $exclude_paths ) && is_string( $diff_result['diff'] ?? null ) ) {
+				$diff_result['diff'] = self::filter_runner_workspace_capture_diff( (string) $diff_result['diff'], $exclude_paths );
+			}
 		}
 
 		return array_filter(
@@ -913,5 +918,76 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		}
 
 		return array_values( array_filter( array_map( static fn( mixed $item ): string => trim( (string) $item ), $value ), static fn( string $item ): bool => '' !== $item ) );
+	}
+
+	/** @param array<int,string> $files @param array<int,string> $exclude_paths @return array<int,string> */
+	private static function filter_runner_workspace_capture_files( array $files, array $exclude_paths ): array {
+		$filtered = array();
+		foreach ( $files as $file ) {
+			$path = self::runner_workspace_status_path( $file );
+			if ( '' !== $path && ( empty( $exclude_paths ) || ! self::runner_workspace_capture_path_excluded( $path, $exclude_paths ) ) ) {
+				$filtered[] = $path;
+			}
+		}
+
+		return array_values( array_unique( $filtered ) );
+	}
+
+	/** @param array<int,string> $exclude_paths */
+	private static function filter_runner_workspace_capture_diff( string $diff, array $exclude_paths ): string {
+		if ( '' === $diff || empty( $exclude_paths ) ) {
+			return $diff;
+		}
+
+		$sections = preg_split( '/(?=^diff --git )/m', $diff );
+		if ( ! is_array( $sections ) ) {
+			return $diff;
+		}
+
+		$kept = array();
+		foreach ( $sections as $section ) {
+			if ( '' === $section ) {
+				continue;
+			}
+			if ( preg_match( '/^diff --git a\/(.*?) b\//m', $section, $matches ) && self::runner_workspace_capture_path_excluded( $matches[1], $exclude_paths ) ) {
+				continue;
+			}
+			$kept[] = $section;
+		}
+
+		return implode( '', $kept );
+	}
+
+	private static function runner_workspace_status_path( string $status_line ): string {
+		$line = trim( $status_line );
+		if ( preg_match( '/^(?:[ MADRCU?!]{1,2})\s+(.+)$/', $line, $matches ) ) {
+			$line = $matches[1];
+		}
+		if ( str_contains( $line, ' -> ' ) ) {
+			$parts = explode( ' -> ', $line );
+			$line  = (string) end( $parts );
+		}
+
+		return trim( $line, " \t\n\r\0\x0B\"'" );
+	}
+
+	/** @param array<int,string> $exclude_paths */
+	private static function runner_workspace_capture_path_excluded( string $path, array $exclude_paths ): bool {
+		$path = ltrim( trim( $path ), '/' );
+		foreach ( $exclude_paths as $pattern ) {
+			$pattern = ltrim( trim( $pattern ), '/' );
+			if ( '' === $pattern ) {
+				continue;
+			}
+			$prefix = str_ends_with( $pattern, '/**' ) ? substr( $pattern, 0, -3 ) : null;
+			if ( null !== $prefix && ( $path === rtrim( $prefix, '/' ) || str_starts_with( $path, rtrim( $prefix, '/' ) . '/' ) ) ) {
+				return true;
+			}
+			if ( $path === rtrim( $pattern, '/' ) || str_starts_with( $path, rtrim( $pattern, '/' ) . '/' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -529,8 +529,8 @@ $dmc_status_ability = new WP_Codebox_Smoke_Ability(
 		'repo'    => 'Automattic/wp-codebox',
 		'branch'  => 'runner/docs',
 		'commit'  => 'abc123def456',
-		'dirty'   => 2,
-		'files'   => array( 'docs/architecture.md', 'docs/skill-contracts.md' ),
+		'dirty'   => 3,
+		'files'   => array( ' M docs/architecture.md', '?? .ci/wp-codebox/package.json', 'docs/skill-contracts.md' ),
 	)
 );
 $dmc_diff_ability = new WP_Codebox_Smoke_Ability(
@@ -538,7 +538,7 @@ $dmc_diff_ability = new WP_Codebox_Smoke_Ability(
 		'success' => true,
 		'backend' => 'github_api',
 		'name'    => 'wp-codebox@runner-docs',
-		'diff'    => "diff --git a/docs/architecture.md b/docs/architecture.md\n",
+		'diff'    => "diff --git a/docs/architecture.md b/docs/architecture.md\n+docs\ndiff --git a/.ci/wp-codebox/package.json b/.ci/wp-codebox/package.json\n+runtime\n",
 	)
 );
 $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-git-status'] = $dmc_status_ability;
@@ -550,10 +550,11 @@ $capture_result = call_user_func(
 		'workspace_backend' => 'github_api',
 		'repo'              => 'Automattic/wp-codebox',
 		'from'              => 'main',
+		'exclude_paths'     => array( '.ci/**' ),
 	)
 );
 $assert( 'runner workspace capture delegates to DMC status and diff', 'wp-codebox@runner-docs' === ( $dmc_status_ability->calls[0]['name'] ?? '' ) && 'wp-codebox@runner-docs' === ( $dmc_diff_ability->calls[0]['name'] ?? '' ) && 'main' === ( $dmc_diff_ability->calls[0]['from'] ?? '' ) );
-$assert( 'runner workspace capture normalizes status and diff', ! is_wp_error( $capture_result ) && true === ( $capture_result['success'] ?? false ) && true === ( $capture_result['changed'] ?? false ) && 'github_api' === ( $capture_result['backend'] ?? '' ) && 2 === ( $capture_result['status']['dirty'] ?? 0 ) && array( 'docs/architecture.md', 'docs/skill-contracts.md' ) === ( $capture_result['status']['files'] ?? array() ) && str_contains( (string) ( $capture_result['diff']['diff'] ?? '' ), 'docs/architecture.md' ) );
+$assert( 'runner workspace capture normalizes status and diff', ! is_wp_error( $capture_result ) && true === ( $capture_result['success'] ?? false ) && true === ( $capture_result['changed'] ?? false ) && 'github_api' === ( $capture_result['backend'] ?? '' ) && 2 === ( $capture_result['status']['dirty'] ?? 0 ) && array( 'docs/architecture.md', 'docs/skill-contracts.md' ) === ( $capture_result['status']['files'] ?? array() ) && str_contains( (string) ( $capture_result['diff']['diff'] ?? '' ), 'docs/architecture.md' ) && ! str_contains( (string) ( $capture_result['diff']['diff'] ?? '' ), '.ci/wp-codebox' ) );
 unset( $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-git-status'], $GLOBALS['wp_codebox_mock_abilities']['datamachine-code/workspace-git-diff'] );
 
 $command_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/run-runner-workspace-command'] ?? null;


### PR DESCRIPTION
## Summary
- Add `exclude_paths` to `wp-codebox/capture-runner-workspace` so callers can omit runner-owned directories from captured target changes.
- Normalize captured git-status entries to clean relative paths and filter excluded diff sections before returning capture evidence.
- Cover `.ci/**` exclusion behavior in the WordPress plugin smoke test.

## Verification
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php`
- `php tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runner workspace capture boundary issue, drafted the implementation and smoke coverage, and ran local verification; Chris remains responsible for review and merge.