### PR TITLE
Honor mount artifact exclusions

### DIFF
--- a/packages/runtime-playground/src/artifacts.ts
+++ b/packages/runtime-playground/src/artifacts.ts
@@ -656,10 +656,10 @@ export function serializeCapturedMountFiles(captured: CapturedMountFiles): Captu
   }
 }
 
-export async function directoryDiff(baselineDirectory: string, currentDirectory: string, targetPrefix: string): Promise<DirectoryDiffResult> {
+export async function directoryDiff(baselineDirectory: string, currentDirectory: string, targetPrefix: string, excludePaths: string[] = []): Promise<DirectoryDiffResult> {
   const [baselineFiles, currentFiles] = await Promise.all([
-    listTextFiles(baselineDirectory),
-    listTextFiles(currentDirectory),
+    listTextFiles(baselineDirectory, "", excludePaths),
+    listTextFiles(currentDirectory, "", excludePaths),
   ])
   const paths = [...new Set([...baselineFiles.keys(), ...currentFiles.keys()])].sort()
   const patches: string[] = []
@@ -723,7 +723,7 @@ export async function isGitWorkTree(directory: string): Promise<boolean> {
  * redaction, and digests stay identical across both diff strategies. Untracked
  * files appear as additions because they are absent from the HEAD archive.
  */
-export async function gitWorkingTreeDiff(repoDirectory: string, targetPrefix: string): Promise<DirectoryDiffResult> {
+export async function gitWorkingTreeDiff(repoDirectory: string, targetPrefix: string, excludePaths: string[] = []): Promise<DirectoryDiffResult> {
   const headDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-git-head-"))
   try {
     let hasHead = true
@@ -745,13 +745,13 @@ export async function gitWorkingTreeDiff(repoDirectory: string, targetPrefix: st
       await rm(archivePath, { force: true })
     }
 
-    return await directoryDiff(headDirectory, repoDirectory, targetPrefix)
+    return await directoryDiff(headDirectory, repoDirectory, targetPrefix, excludePaths)
   } finally {
     await rm(headDirectory, { recursive: true, force: true })
   }
 }
 
-async function listTextFiles(directory: string, prefix = ""): Promise<Map<string, string>> {
+async function listTextFiles(directory: string, prefix = "", excludePaths: string[] = []): Promise<Map<string, string>> {
   const files = new Map<string, string>()
   for (const entry of await readdir(directory, { withFileTypes: true })) {
     if (SKIPPED_CAPTURE_DIRECTORIES.has(entry.name)) {
@@ -759,9 +759,12 @@ async function listTextFiles(directory: string, prefix = ""): Promise<Map<string
     }
 
     const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
+    if (relativePathExcluded(relativePath, excludePaths)) {
+      continue
+    }
     const fullPath = join(directory, entry.name)
     if (entry.isDirectory()) {
-      for (const [path, contents] of await listTextFiles(fullPath, relativePath)) {
+      for (const [path, contents] of await listTextFiles(fullPath, relativePath, excludePaths)) {
         files.set(path, contents)
       }
       continue
@@ -779,6 +782,25 @@ async function listTextFiles(directory: string, prefix = ""): Promise<Map<string
   }
 
   return files
+}
+
+function relativePathExcluded(relativePath: string, excludePaths: string[]): boolean {
+  const normalized = relativePath.replace(/^\/+/, "")
+  return excludePaths.some((pattern) => excludePathMatches(normalized, pattern))
+}
+
+function excludePathMatches(relativePath: string, pattern: string): boolean {
+  const normalizedPattern = pattern.trim().replace(/^\/+/, "").replace(/\/+$/, "")
+  if (!normalizedPattern) {
+    return false
+  }
+
+  if (normalizedPattern.endsWith("/**")) {
+    const prefix = normalizedPattern.slice(0, -3).replace(/\/+$/, "")
+    return relativePath === prefix || relativePath.startsWith(`${prefix}/`)
+  }
+
+  return relativePath === normalizedPattern || relativePath.startsWith(`${normalizedPattern}/`)
 }
 
 function provenanceContext(context: Record<string, unknown>, key: string): Record<string, unknown> | undefined {

--- a/packages/runtime-playground/src/mounted-artifact-capture.ts
+++ b/packages/runtime-playground/src/mounted-artifact-capture.ts
@@ -33,15 +33,16 @@ export async function captureMountedFiles(filesDirectory: string, mounts: MountS
     if (mount.mode !== "readwrite") {
       continue
     }
+    const artifactExcludePaths = mountArtifactExcludePaths(mount)
 
     const mountStats = await stat(mount.source)
     if (mountStats.isDirectory()) {
-      await captureMountedDirectory(filesDirectory, captured, mount, mountIndex, mount.source, "", redactor)
+      await captureMountedDirectory(filesDirectory, captured, mount, mountIndex, mount.source, "", redactor, artifactExcludePaths)
       continue
     }
 
     if (mountStats.isFile()) {
-      await captureMountedFile(filesDirectory, captured, mount, mountIndex, mount.source, basename(mount.source), redactor)
+      await captureMountedFile(filesDirectory, captured, mount, mountIndex, mount.source, basename(mount.source), redactor, artifactExcludePaths)
     }
   }
 
@@ -61,6 +62,7 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
     if (mount.mode !== "readwrite") {
       continue
     }
+    const artifactExcludePaths = mountArtifactExcludePaths(mount)
 
     const artifactPath = `files/diffs/mount-${mountIndex}.patch`
 
@@ -86,8 +88,8 @@ export async function captureMountDiffs(artifactRoot: string, filesDirectory: st
     let diff: Awaited<ReturnType<typeof directoryDiff>>
     try {
       diff = useGitWorkTree
-        ? await gitWorkingTreeDiff(mount.source, mount.target)
-        : await directoryDiff(baselineSource, mount.source, mount.target)
+        ? await gitWorkingTreeDiff(mount.source, mount.target, artifactExcludePaths)
+        : await directoryDiff(baselineSource, mount.source, mount.target, artifactExcludePaths)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       await writeFile(join(artifactRoot, artifactPath), "")
@@ -156,12 +158,23 @@ async function captureMountedDirectory(
   directory: string,
   relativeDirectory: string,
   redactor: ArtifactRedactor,
+  artifactExcludePaths: string[] = [],
 ): Promise<void> {
   const entries = await readdir(directory, { withFileTypes: true })
 
   for (const entry of entries) {
     const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
     const sourcePath = join(directory, entry.name)
+    if (relativePathExcluded(relativePath, artifactExcludePaths)) {
+      captured.skipped.push({
+        mountIndex,
+        source: sourcePath,
+        target: mountTargetPath(mount, relativePath),
+        relativePath,
+        reason: "artifact-excluded",
+      })
+      continue
+    }
 
     if (entry.isDirectory()) {
       if (SKIPPED_CAPTURE_DIRECTORIES.has(entry.name)) {
@@ -175,12 +188,12 @@ async function captureMountedDirectory(
         continue
       }
 
-      await captureMountedDirectory(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath, redactor)
+      await captureMountedDirectory(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath, redactor, artifactExcludePaths)
       continue
     }
 
     if (entry.isFile()) {
-      await captureMountedFile(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath, redactor)
+      await captureMountedFile(filesDirectory, captured, mount, mountIndex, sourcePath, relativePath, redactor, artifactExcludePaths)
     }
   }
 }
@@ -193,8 +206,13 @@ async function captureMountedFile(
   sourcePath: string,
   relativePath: string,
   redactor: ArtifactRedactor,
+  artifactExcludePaths: string[] = [],
 ): Promise<void> {
   const target = mount.type === "file" ? mount.target : mountTargetPath(mount, relativePath)
+  if (relativePathExcluded(relativePath, artifactExcludePaths)) {
+    captured.skipped.push({ mountIndex, source: sourcePath, target, relativePath, reason: "artifact-excluded" })
+    return
+  }
 
   if (captured.files.length >= MAX_CAPTURED_MOUNT_FILES) {
     captured.skipped.push({ mountIndex, source: sourcePath, target, relativePath, reason: "max-files-exceeded" })
@@ -235,4 +253,32 @@ async function captureMountedFile(
     replayable,
     ...(replayable ? { replayContents: artifactContents as string } : {}),
   })
+}
+
+function mountArtifactExcludePaths(mount: MountSpec): string[] {
+  const value = mount.metadata?.artifactExcludePaths
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.map((item) => String(item).trim()).filter((item) => item.length > 0)
+}
+
+function relativePathExcluded(relativePath: string, excludePaths: string[]): boolean {
+  const normalized = relativePath.replace(/^\/+/, "")
+  return excludePaths.some((pattern) => excludePathMatches(normalized, pattern))
+}
+
+function excludePathMatches(relativePath: string, pattern: string): boolean {
+  const normalizedPattern = pattern.replace(/^\/+/, "").replace(/\/+$/, "")
+  if (!normalizedPattern) {
+    return false
+  }
+
+  if (normalizedPattern.endsWith("/**")) {
+    const prefix = normalizedPattern.slice(0, -3).replace(/\/+$/, "")
+    return relativePath === prefix || relativePath.startsWith(`${prefix}/`)
+  }
+
+  return relativePath === normalizedPattern || relativePath.startsWith(`${normalizedPattern}/`)
 }


### PR DESCRIPTION
## Summary
- Add per-mount `metadata.artifactExcludePaths` support to mounted artifact capture.
- Apply exclusions to mounted-file snapshots, changed-files generation, and diff/patch generation.
- Keep the existing global skipped-directory behavior unchanged so exclusions stay explicit per mount.

## Context
This prevents runner-owned directories mounted inside a writable workspace, such as `.ci/**`, from being treated as target repository changes in artifact evidence.

## Verification
- `npm run build`
- `php tests/smoke-wordpress-plugin.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the artifact-level runner workspace capture leak, drafted the explicit mount exclusion implementation, and ran local verification; Chris remains responsible for review and merge.