### PR TITLE
Add Playground replay viewer metadata

### DIFF
--- a/packages/runtime-core/src/artifact-manifest.ts
+++ b/packages/runtime-core/src/artifact-manifest.ts
@@ -31,6 +31,27 @@ export interface ArtifactManifestFile {
     | (string & {})
   contentType: string
   sha256: ArtifactFileDigest
+  viewer?: ArtifactViewerMetadata
+}
+
+export interface ArtifactViewerMetadata {
+  kind: string
+  base: string
+  query: {
+    parameter: string
+    value: {
+      source: "public-artifact-url" | (string & {})
+      path: string
+      kind?: string
+      contentType?: string
+      sha256?: ArtifactFileDigest
+    }
+    encoding: "url" | (string & {})
+  }
+  replay: {
+    status: "full" | "partial" | "unavailable" | (string & {})
+    limitations: string[]
+  }
 }
 
 export interface ArtifactFileDigest {
@@ -58,8 +79,8 @@ export function artifactFileDigest(contents: string | Buffer): ArtifactFileDiges
   return { algorithm: "sha256", value: createHash("sha256").update(contents).digest("hex") }
 }
 
-export function artifactManifestFile(path: string, kind: ArtifactManifestFile["kind"], contentType: string, sha256: ArtifactFileDigest = placeholderArtifactFileDigest()): ArtifactManifestFile {
-  return { path, kind, contentType, sha256 }
+export function artifactManifestFile(path: string, kind: ArtifactManifestFile["kind"], contentType: string, sha256: ArtifactFileDigest = placeholderArtifactFileDigest(), viewer?: ArtifactViewerMetadata): ArtifactManifestFile {
+  return stripUndefined({ path, kind, contentType, sha256, viewer })
 }
 
 export function artifactManifestFileWithSha256(path: string, kind: ArtifactManifestFile["kind"], contentType: string, sha256: string): ArtifactManifestFile {
@@ -130,4 +151,8 @@ function manifestWithPlaceholderSelfHash(manifest: ArtifactManifest, manifestFil
       ? { ...file, sha256: placeholderArtifactFileDigest() }
       : file),
   }
+}
+
+function stripUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T
 }

--- a/packages/runtime-core/src/artifact-references.ts
+++ b/packages/runtime-core/src/artifact-references.ts
@@ -1,5 +1,5 @@
 import type { ArtifactBundle, RuntimeEpisodeContentDigest, RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
-import type { ArtifactFileDigest, ArtifactManifestFile } from "./artifact-manifest.js"
+import type { ArtifactFileDigest, ArtifactManifestFile, ArtifactViewerMetadata } from "./artifact-manifest.js"
 import type { RuntimeReferenceManifestArtifactBundleRef, RuntimeReferenceManifestFileRef } from "./runtime-reference.js"
 
 export const RUNTIME_EPISODE_TRACE_ARTIFACT_PATH = "files/runtime-episode-trace.json" as const
@@ -25,6 +25,7 @@ export interface ArtifactReferenceFileInput {
   mimeType?: string
   sha256?: string | ArtifactReferenceDigestInput
   digest?: string | ArtifactReferenceDigestInput
+  viewer?: ArtifactViewerMetadata
 }
 
 export interface ArtifactReferenceTraceInput extends ArtifactReferenceFileInput {
@@ -106,6 +107,7 @@ export function normalizeRuntimeReferenceManifestFileRef(input: ArtifactReferenc
     kind: input.kind,
     contentType: normalizeArtifactContentType(input),
     sha256,
+    ...(input.viewer ? { viewer: input.viewer } : {}),
   }
 }
 

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -1,7 +1,7 @@
 import { assertRuntimePolicy } from "./runtime-policy.js"
 import type { RuntimePolicy } from "./runtime-policy.js"
 import { SANDBOX_WORKSPACE_ROOT } from "./runtime-action-adapter.js"
-import type { ArtifactFileDigest, ArtifactSpec } from "./artifact-manifest.js"
+import type { ArtifactFileDigest, ArtifactSpec, ArtifactViewerMetadata } from "./artifact-manifest.js"
 import type { HostToolDefinition, HostToolRegistry } from "./host-tool-registry.js"
 import type {
   RUNTIME_EPISODE_ACTION_SCHEMA,
@@ -770,6 +770,7 @@ export interface ArtifactBundle {
   manifestPath: string
   metadataPath: string
   blueprintAfterPath: string
+  blueprintAfterViewer?: ArtifactViewerMetadata
   blueprintAfterNotesPath: string
   eventsPath: string
   commandsPath: string

--- a/packages/runtime-core/src/runtime-reference.ts
+++ b/packages/runtime-core/src/runtime-reference.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto"
 
-import type { ArtifactFileDigest } from "./artifact-manifest.js"
+import type { ArtifactFileDigest, ArtifactViewerMetadata } from "./artifact-manifest.js"
 import { normalizeObservationArtifactRefs, normalizeRuntimeReferenceManifestFileRef } from "./artifact-references.js"
 import { stableJson } from "./object-utils.js"
 import type {
@@ -22,6 +22,7 @@ export interface RuntimeReferenceManifestFileRef {
   kind: string
   contentType: string
   sha256: ArtifactFileDigest
+  viewer?: ArtifactViewerMetadata
 }
 
 export interface RuntimeReferenceManifestArtifactBundleRef {

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -14,6 +14,7 @@ import {
   type ArtifactDurablePreviewRef,
   type ArtifactManifest,
   type ArtifactManifestFile,
+  type ArtifactViewerMetadata,
   type ArtifactPreview,
   type ArtifactPreviewEvidence,
   type ArtifactPreviewSessionEvidence,
@@ -267,11 +268,12 @@ export class ArtifactBundleBuilder {
       mounts: source.mounts,
       capturedMounts,
     })
+    const blueprintAfterViewer = blueprintAfterReplayViewerMetadata()
 
     const manifestFiles: ArtifactManifestFile[] = [
       artifactManifestFile(manifestPath, "manifest", "application/json"),
       artifactManifestFile(metadataPath, "metadata", "application/json"),
-      artifactManifestFile(blueprintAfterPath, "blueprint-after", "application/json"),
+      artifactManifestFile(blueprintAfterPath, "blueprint-after", "application/json", undefined, cloneArtifactViewerMetadata(blueprintAfterViewer)),
       artifactManifestFile(blueprintAfterNotesPath, "blueprint-after-notes", "application/json"),
       artifactManifestFile(eventsPath, "events", "application/x-ndjson"),
       artifactManifestFile(commandsPath, "commands", "application/x-ndjson"),
@@ -373,7 +375,7 @@ export class ArtifactBundleBuilder {
       },
       files: manifest.files
         .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
-        .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 })),
+        .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256, ...(file.viewer ? { viewer: cloneArtifactViewerMetadata(file.viewer) } : {}) })),
       snapshots: runtimeSnapshots,
     })
     await writeFile(runtimeReferenceManifestPath, `${JSON.stringify(runtimeReferenceManifest, null, 2)}\n`)
@@ -393,7 +395,7 @@ export class ArtifactBundleBuilder {
       },
       files: manifest.files
         .filter((file) => !["manifest.json", "files/runtime-replay-index.json"].includes(file.path))
-        .map((file) => file.path === "files/runtime-reference-manifest.json" ? runtimeReferenceManifestRef : ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256 })),
+        .map((file) => file.path === "files/runtime-reference-manifest.json" ? runtimeReferenceManifestRef : ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256, ...(file.viewer ? { viewer: cloneArtifactViewerMetadata(file.viewer) } : {}) })),
       runtimeReferenceManifest: runtimeReferenceManifestRef,
       snapshots: runtimeSnapshots,
     })
@@ -407,6 +409,7 @@ export class ArtifactBundleBuilder {
       manifestPath,
       metadataPath,
       blueprintAfterPath,
+      blueprintAfterViewer,
       blueprintAfterNotesPath,
       eventsPath,
       commandsPath,
@@ -434,6 +437,33 @@ export class ArtifactBundleBuilder {
       createdAt,
     }
   }
+}
+
+function blueprintAfterReplayViewerMetadata(): ArtifactViewerMetadata {
+  return {
+    kind: "wordpress-playground-blueprint",
+    base: "https://playground.wordpress.net/",
+    query: {
+      parameter: "blueprint-url",
+      value: {
+        source: "public-artifact-url",
+        path: "blueprint.after.json",
+      },
+      encoding: "url",
+    },
+    replay: {
+      status: "partial",
+      limitations: [
+        "WP Codebox does not host public artifact URLs; consumers must provide a browser-fetchable URL for blueprint.after.json.",
+        "Text files from readwrite mounts are embedded in blueprint.after.json as writeFile steps; binary files are copied into artifacts but not replayed yet.",
+        "Database exports, option diffs, uploaded media, active theme/plugin state, and screenshots are not captured yet.",
+      ],
+    },
+  }
+}
+
+function cloneArtifactViewerMetadata(viewer: ArtifactViewerMetadata): ArtifactViewerMetadata {
+  return JSON.parse(JSON.stringify(viewer)) as ArtifactViewerMetadata
 }
 
 function buildPreviewEvidence({

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -103,6 +103,16 @@ try {
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-replay-index.json" && file.kind === "runtime-replay-index"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/preview-evidence.json" && file.kind === "preview-evidence"))
   assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-evidence/run-attestation.json" && file.kind === "run-attestation"))
+  const blueprintAfterManifestFile = manifestFile(manifest, "blueprint.after.json")
+  assert.equal(blueprintAfterManifestFile.viewer.kind, "wordpress-playground-blueprint")
+  assert.equal(blueprintAfterManifestFile.viewer.base, "https://playground.wordpress.net/")
+  assert.equal(blueprintAfterManifestFile.viewer.query.parameter, "blueprint-url")
+  assert.equal(blueprintAfterManifestFile.viewer.query.value.source, "public-artifact-url")
+  assert.equal(blueprintAfterManifestFile.viewer.query.value.path, "blueprint.after.json")
+  assert.equal(blueprintAfterManifestFile.viewer.query.encoding, "url")
+  assert.equal(blueprintAfterManifestFile.viewer.replay.status, "partial")
+  assert.ok(blueprintAfterManifestFile.viewer.replay.limitations.some((limitation: string) => limitation.includes("does not host public artifact URLs")))
+  assert.deepEqual(artifacts.blueprintAfterViewer, blueprintAfterManifestFile.viewer)
   const runtimeEvidence = metadata.artifacts.runtimeEvidence
   assert.match(runtimeEvidence["run-attestation"].sha256, /^[a-f0-9]{64}$/)
   assert.deepEqual(metadata.artifacts, {
@@ -245,6 +255,14 @@ try {
   assert.equal(runtimeReplayReferenceIndex.digest.value, runtimeReplayReferenceIndexDigest(runtimeReplayReferenceIndex).value)
   assert.equal(runtimeReplayReferenceIndex.id, `runtime-replay-reference-index-sha256-${runtimeReplayReferenceIndex.digest.value}`)
   assert.equal(runtimeReplayReferenceIndex.references.runtimeReferenceManifest.path, "files/runtime-reference-manifest.json")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.kind, "wordpress-playground-blueprint")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.parameter, "blueprint-url")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.source, "public-artifact-url")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.path, "blueprint.after.json")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.kind, "blueprint-after")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.contentType, "application/json")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.sha256.value, blueprintAfterManifestFile.sha256.value)
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.replay.status, "partial")
   assert.equal(runtimeReplayReferenceIndex.references.changedFiles.path, "files/changed-files.json")
   assert.equal(runtimeReplayReferenceIndex.references.patch.path, "files/patch.diff")
   assert.equal(runtimeReplayReferenceIndex.replay.status, "partial")
@@ -256,6 +274,15 @@ try {
   assert.equal(runtimeReferenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
   assert.equal(runtimeReferenceManifest.digest.value, runtimeReferenceManifestDigest(runtimeReferenceManifest).value)
   assert.equal(runtimeReferenceManifest.id, `runtime-reference-manifest-sha256-${runtimeReferenceManifest.digest.value}`)
+  const runtimeReferenceManifestBlueprintViewer = runtimeReferenceManifest.files.find((file: { path: string }) => file.path === "blueprint.after.json")?.viewer
+  assert.equal(runtimeReferenceManifestBlueprintViewer.kind, "wordpress-playground-blueprint")
+  assert.equal(runtimeReferenceManifestBlueprintViewer.query.parameter, "blueprint-url")
+  assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.source, "public-artifact-url")
+  assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.path, "blueprint.after.json")
+  assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.kind, "blueprint-after")
+  assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.contentType, "application/json")
+  assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.sha256.value, blueprintAfterManifestFile.sha256.value)
+  assert.equal(runtimeReferenceManifestBlueprintViewer.replay.status, "partial")
   assert.equal(runtimeReferenceManifest.snapshots.length, 0)
   assert.ok(runtimeReferenceManifest.files.some((file: { path: string }) => file.path === "files/runtime-reference-index.json"))
   assert.ok(runtimeReferenceManifest.files.some((file: { path: string }) => file.path === "files/changed-files.json"))
@@ -516,7 +543,7 @@ try {
   await rm(artifactsDirectory, { recursive: true, force: true })
 }
 
-function manifestFile(manifest: { files: Array<{ path: string; sha256: { value: string } }> }, path: string): { sha256: { value: string } } {
+function manifestFile(manifest: { files: Array<{ path: string; sha256: { value: string }; viewer?: any }> }, path: string): { sha256: { value: string }; viewer?: any } {
   const file = manifest.files.find((entry) => entry.path === path)
   assert.ok(file, `Expected manifest file ${path}`)
   return file

--- a/scripts/runtime-episode-smoke.ts
+++ b/scripts/runtime-episode-smoke.ts
@@ -194,6 +194,10 @@ try {
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === usersArtifactPath && file.kind === "wordpress-state-section"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-reference-manifest.json" && file.kind === "runtime-reference-manifest"))
     assert.ok(manifest.files.some((file: { path: string; kind: string }) => file.path === "files/runtime-replay-index.json" && file.kind === "runtime-replay-index"))
+    const blueprintAfterManifestFile = manifest.files.find((file: { path: string; sha256: { value: string }; viewer?: any }) => file.path === "blueprint.after.json")
+    assert.equal(blueprintAfterManifestFile?.viewer?.kind, "wordpress-playground-blueprint")
+    assert.equal(blueprintAfterManifestFile?.viewer?.query?.parameter, "blueprint-url")
+    assert.equal(blueprintAfterManifestFile?.viewer?.replay?.status, "partial")
     const snapshotBundleEntry = manifest.files.find((file: { path: string; kind: string }) => file.path.startsWith("files/runtime-snapshots/") && file.kind === "runtime-snapshot-bundle")
     assert.ok(snapshotBundleEntry, "runtime snapshot bundle should be listed in manifest")
 
@@ -218,6 +222,13 @@ try {
     assert.equal(replayIndex.references.trace.path, "files/runtime-episode-trace.json")
     assert.equal(replayIndex.references.events.path, "files/runtime-episode.jsonl")
     assert.equal(replayIndex.references.runtimeReferenceManifest.path, "files/runtime-reference-manifest.json")
+    assert.equal(replayIndex.references.blueprintAfter.viewer.kind, "wordpress-playground-blueprint")
+    assert.equal(replayIndex.references.blueprintAfter.viewer.query.value.source, "public-artifact-url")
+    assert.equal(replayIndex.references.blueprintAfter.viewer.query.value.path, "blueprint.after.json")
+    if (replayIndex.references.blueprintAfter.viewer.query.value.kind) {
+      assert.equal(replayIndex.references.blueprintAfter.viewer.query.value.kind, "blueprint-after")
+      assert.equal(replayIndex.references.blueprintAfter.viewer.query.value.sha256.value, blueprintAfterManifestFile?.sha256.value)
+    }
     assert.equal(replayIndex.references.observations.path, "observations.jsonl")
     assert.equal(replayIndex.actions.length, 3)
     assert.equal(replayIndex.observations.some((observation: { type: string }) => observation.type === "runtime-info"), true)
@@ -233,6 +244,7 @@ try {
     assert.equal(referenceManifest.artifactBundle.digest.value, artifacts.contentDigest)
     assert.equal(referenceManifest.trace.path, "files/runtime-episode-trace.json")
     assert.equal(referenceManifest.events.path, "files/runtime-episode.jsonl")
+    assert.deepEqual(referenceManifest.files.find((file: { path: string }) => file.path === "blueprint.after.json")?.viewer, blueprintAfterManifestFile?.viewer)
     assert.equal(referenceManifest.snapshots.length, 1)
     assert.equal(referenceManifest.snapshots[0].id, snapshot.id)
     assert.equal(referenceManifest.snapshots[0].semantics, "runtime-state-artifact")

--- a/tests/fixtures/artifact-package-provenance-shape.json
+++ b/tests/fixtures/artifact-package-provenance-shape.json
@@ -2,15 +2,15 @@
   "schema": "wp-codebox/package-provenance/v1",
   "wpCodebox": {
     "name": "wp-codebox-workspace",
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "runtimeCore": {
     "name": "@automattic/wp-codebox-core",
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "runtimePlayground": {
     "name": "@automattic/wp-codebox-playground",
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "playground": {
     "cli": {


### PR DESCRIPTION
## Summary
- Add a generic `viewer` metadata primitive for artifact manifest/reference entries.
- Mark `blueprint.after.json` as a replayable WordPress Playground blueprint artifact with base URL, query parameter construction, and partial replay limitations.
- Surface the same viewer metadata on artifact results and cover manifest/reference/result shape in focused smoke tests.

Fixes #885.

## Testing
- `npm run build`
- `./node_modules/.bin/tsx scripts/artifact-contract-smoke.ts`
- `./node_modules/.bin/tsx scripts/runtime-episode-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the artifact viewer metadata contract, added focused coverage, ran verification, and prepared this PR for Chris to review.