### PR TITLE
Surface Playground run PHP crash diagnostics

### DIFF
--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -23,7 +23,7 @@ export class PlaygroundCommandCrashError extends Error {
   readonly code = "wp-codebox-playground-command-crashed"
 
   constructor(readonly command: string, readonly cause: unknown) {
-    super(`${command} crashed before producing a structured response\n\n${errorMessage(cause)}`)
+    super(playgroundCrashMessage(command, cause))
     this.name = "PlaygroundCommandCrashError"
   }
 }
@@ -99,6 +99,95 @@ function playgroundFailureMessage(command: string, response: PlaygroundRunRespon
   }
 
   return lines.join("\n")
+}
+
+function playgroundCrashMessage(command: string, cause: unknown): string {
+  const lines = [`${command} crashed before producing a structured response`, "", errorMessage(cause)]
+  const diagnostics = playgroundCrashDiagnostics(cause)
+
+  if (diagnostics.length > 0) {
+    lines.push("", "--- Playground crash diagnostics ---", ...diagnostics)
+  }
+
+  return lines.join("\n")
+}
+
+function playgroundCrashDiagnostics(cause: unknown): string[] {
+  const records = diagnosticRecords(cause)
+  const metadata: string[] = []
+  const sections: string[] = []
+  const seenSections = new Set<string>()
+
+  for (const record of records) {
+    for (const [key, label] of [
+      ["httpStatusCode", "httpStatusCode"],
+      ["statusCode", "statusCode"],
+      ["status", "status"],
+      ["exitCode", "exitCode"],
+    ] as const) {
+      const value = record[key]
+      if ((typeof value === "number" || typeof value === "string") && !metadata.includes(`${label}=${value}`)) {
+        metadata.push(`${label}=${value}`)
+      }
+    }
+
+    for (const [key, label] of [
+      ["stderr", "Playground stderr"],
+      ["stdout", "Playground stdout"],
+      ["errors", "Playground errors"],
+      ["body", "Playground response body"],
+      ["text", "Playground response text"],
+      ["output", "Playground output"],
+    ] as const) {
+      const value = diagnosticText(record[key])
+      const sectionKey = `${label}\n${value}`
+      if (value && !seenSections.has(sectionKey)) {
+        sections.push(`--- ${label} ---`, value)
+        seenSections.add(sectionKey)
+      }
+    }
+  }
+
+  return [...metadata, ...sections]
+}
+
+function diagnosticRecords(value: unknown, seen = new Set<unknown>()): Record<string, unknown>[] {
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return []
+  }
+  seen.add(value)
+
+  const record = value as Record<string, unknown>
+  return [
+    record,
+    ...["cause", "response", "result", "data", "output"].flatMap((key) => diagnosticRecords(record[key], seen)),
+  ]
+}
+
+function diagnosticText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return truncateDiagnostic(value.trim())
+  }
+  if (value instanceof Uint8Array) {
+    return truncateDiagnostic(new TextDecoder().decode(value).trim())
+  }
+  if (!value || typeof value !== "object" || typeof value === "function") {
+    return undefined
+  }
+
+  try {
+    return truncateDiagnostic(JSON.stringify(value, null, 2))
+  } catch {
+    return undefined
+  }
+}
+
+function truncateDiagnostic(value: string): string | undefined {
+  if (!value) {
+    return undefined
+  }
+  const maxLength = 20_000
+  return value.length > maxLength ? `${value.slice(0, maxLength)}\n[diagnostic truncated]` : value
 }
 
 function playgroundCliExitMessage(exitCode: number, output: PlaygroundCliBufferedOutput | undefined): string {

--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import { createRuntime } from "../packages/runtime-core/src/index.js"
+import { PlaygroundCommandCrashError } from "../packages/runtime-playground/src/playground-command-errors.js"
+import { createPlaygroundRuntimeBackend, type PlaygroundCliModule } from "../packages/runtime-playground/src/index.js"
+
+const hiddenFatal = new Error("PHP.run() failed with exit code 255") as Error & {
+  httpStatusCode?: number
+  exitCode?: number
+  stdout?: string
+  stderr?: string
+  response?: { body?: string; headers?: Record<string, string> }
+}
+
+hiddenFatal.httpStatusCode = 500
+hiddenFatal.exitCode = 255
+hiddenFatal.stdout = ""
+hiddenFatal.stderr = ""
+hiddenFatal.response = {
+  body: "Fatal error: Uncaught RuntimeException: Local wp-admin auth fixture user could not be loaded.",
+  headers: { "content-type": "text/html; charset=UTF-8" },
+}
+
+const hiddenFatalMessage = new PlaygroundCommandCrashError("wordpress.run-php", hiddenFatal).message
+
+assert.match(hiddenFatalMessage, /wordpress\.run-php crashed before producing a structured response/)
+assert.match(hiddenFatalMessage, /PHP\.run\(\) failed with exit code 255/)
+assert.match(hiddenFatalMessage, /httpStatusCode=500/)
+assert.match(hiddenFatalMessage, /exitCode=255/)
+assert.match(hiddenFatalMessage, /--- Playground response body ---/)
+assert.match(hiddenFatalMessage, /Local wp-admin auth fixture user could not be loaded/)
+assert.doesNotMatch(hiddenFatalMessage, /--- Playground stdout ---\n\s*---/)
+assert.doesNotMatch(hiddenFatalMessage, /--- Playground stderr ---\n\s*---/)
+
+const nestedResponseError = new Error("Playground request failed") as Error & {
+  response?: { status?: number; text?: string }
+}
+nestedResponseError.response = {
+  status: 500,
+  text: "Uncaught Error: Call to undefined function wp_codebox_missing_fixture()",
+}
+
+const nestedResponseMessage = new PlaygroundCommandCrashError("wordpress.run-php", nestedResponseError).message
+
+assert.match(nestedResponseMessage, /status=500/)
+assert.match(nestedResponseMessage, /--- Playground response text ---/)
+assert.match(nestedResponseMessage, /wp_codebox_missing_fixture/)
+
+let receivedRunPhpCode = ""
+const fakeCliModule: PlaygroundCliModule = {
+  runCLI: async () => ({
+    serverUrl: "http://127.0.0.1:9400",
+    playground: {
+      run: async (options: { code?: string }) => {
+        receivedRunPhpCode = options.code ?? ""
+        throw hiddenFatal
+      },
+    },
+    close: async () => undefined,
+  }),
+}
+
+const runtime = await createRuntime({
+  backend: "wordpress-playground",
+  environment: { kind: "wordpress", name: "hidden-fatal-smoke", version: "7.0", blueprint: { steps: [] } },
+  policy: {
+    network: "deny",
+    filesystem: "sandbox",
+    commands: ["wordpress.run-php"],
+    secrets: "none",
+    approvals: "never",
+  },
+}, createPlaygroundRuntimeBackend({ cliModule: fakeCliModule }))
+
+await assert.rejects(
+  () => runtime.execute({
+    command: "wordpress.run-php",
+    args: ["code=throw new RuntimeException('Local wp-admin auth fixture user could not be loaded.');"],
+  }),
+  (error) => {
+    assert.ok(error instanceof Error)
+    assert.match(error.message, /wordpress\.run-php crashed before producing a structured response/)
+    assert.match(error.message, /httpStatusCode=500/)
+    assert.match(error.message, /exitCode=255/)
+    assert.match(error.message, /--- Playground response body ---/)
+    assert.match(error.message, /Local wp-admin auth fixture user could not be loaded/)
+    return true
+  },
+)
+
+assert.match(receivedRunPhpCode, /RuntimeException/)
+
+console.log("playground command errors smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -95,6 +95,7 @@ export const smokeGroups = {
       tsxSmoke("runtime-snapshot-restore-smoke"),
       tsxSmoke("runtime-action-adapter-smoke"),
       tsxSmoke("rest-request-runtime-smoke"),
+      tsxSmoke("playground-command-errors-smoke"),
       tsxSmoke("runtime-reference-index-smoke"),
       tsxSmoke("core-phpunit-command-smoke"),
       tsxSmoke("theme-check-normalization-smoke"),


### PR DESCRIPTION
## Summary
- Preserve diagnostic fields attached to Playground `run()` crashes, including HTTP status, exit code, response body/text, stdout, stderr, and nested response/result data.
- Add regression coverage for a `wordpress.run-php` crash shaped like a PHP fatal/exception with `500/255`, empty stdout/stderr, and a hidden response body.

## Verification
- `npm install`
- `npm run build`
- `npx tsx scripts/playground-command-errors-smoke.ts`
- `npx tsx scripts/run-smoke.ts --command=playground-command-errors-smoke`

Fixes #890.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the diagnostic preservation path, adding focused regression coverage, and running targeted verification. Chris remains responsible for review and merge.