### PR TITLE
Fix routed admin auth browser cookies

### DIFF
--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -132,6 +132,7 @@ export interface BrowserProbeAuthSummary {
   mode: "wordpress-admin"
   userId: number
   cookieCount: number
+  cookieHosts: Array<{ host: string; cookieCount: number }>
 }
 
 export interface BrowserEditorCanvasProbeSummary {

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -457,7 +457,7 @@ async function runSingleBrowserProbeCommand({
     }
     page = context ? await context.newPage() : await browser.newPage()
     if (authRequest) {
-      authSummary = await installWordPressAdminAuthCookies({ command, page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
+      authSummary = await installWordPressAdminAuthCookies({ command, cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
     }
     if (requestedViewport) {
       await page.setViewportSize(requestedViewport)
@@ -1669,6 +1669,7 @@ export async function runBrowserActionsCommand({
   const requestedViewport = runPlan.requestedViewport
   const authRequest = runPlan.authRequest
   const maxDomSnapshotElements = runPlan.maxDomSnapshotElements
+  const routedHosts = commaListArg(args, "route-host")
 
   const browserDirectory = join(artifactRoot, "files", "browser")
   await mkdir(browserDirectory, { recursive: true })
@@ -1690,6 +1691,8 @@ export async function runBrowserActionsCommand({
   const startedAtMs = Date.now()
   const browser = await launchChromiumBrowser()
   const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
+  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
+  const previewOrigins = browserPreviewOrigins(preview)
   let requestedUrl = initialUrl ? resolveBrowserPreviewUrl(initialUrl, preview.effectiveOrigin) : preview.effectiveOrigin
   let finalUrl = requestedUrl
   let htmlSha256: string | undefined
@@ -1701,9 +1704,13 @@ export async function runBrowserActionsCommand({
   let artifact: BrowserArtifact | undefined
 
   try {
-    const page = await browser.newPage()
+    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
+    if (context) {
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
+    }
+    const page = context ? await context.newPage() : await browser.newPage()
     if (authRequest) {
-      authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.browser-actions", page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
+      authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.browser-actions", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, browserActionTargetUrls(steps, preview.effectiveOrigin, requestedUrl)), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
     }
     if (requestedViewport) {
       await page.setViewportSize(requestedViewport)
@@ -1829,6 +1836,8 @@ export async function runBrowserActionsCommand({
       requestedUrl,
       url: requestedUrl,
       preview,
+      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
+      ...previewOrigins,
       files: {
         ...(capture.has("steps") ? { steps: "files/browser/steps.jsonl" } : {}),
         ...(capture.has("console") ? { console: "files/browser/console.jsonl" } : {}),
@@ -1847,6 +1856,7 @@ export async function runBrowserActionsCommand({
         errors: errors.length,
         finalUrl,
         htmlSnapshot: capture.has("html"),
+        ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots } : {}),
         networkEvents: network.length,
         replayability: browserProbeReplayability(capture),
@@ -2321,7 +2331,10 @@ export async function runEditorOpenCommand({
   }
 
   const waitTimeoutMs = durationArg(args, "wait-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
+  const routedHosts = commaListArg(args, "route-host")
   const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
+  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
+  const previewOrigins = browserPreviewOrigins(preview)
   const targetUrl = resolveBrowserPreviewUrl(target.url, preview.effectiveOrigin)
   const browserDirectory = join(artifactRoot, "files", "browser")
   await mkdir(browserDirectory, { recursive: true })
@@ -2343,12 +2356,17 @@ export async function runEditorOpenCommand({
   let screenshotSha256: string | undefined
   let viewport: BrowserProbeViewport | null = null
   let editorState: EditorStateSnapshot | undefined
+  let authSummary: BrowserProbeAuthSummary | undefined
   let pendingError: Error | undefined
   let artifact: BrowserArtifact | undefined
 
   try {
-    const page = await browser.newPage()
-    await installWordPressAdminAuthCookies({ command: "wordpress.editor-open", page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
+    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
+    if (context) {
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
+    }
+    const page = context ? await context.newPage() : await browser.newPage()
+    authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-open", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
     viewport = await browserProbeViewport(page)
     attachBrowserCaptureListeners({
       captureConsole: capture.has("console"),
@@ -2419,6 +2437,8 @@ export async function runEditorOpenCommand({
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
+      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
+      ...previewOrigins,
       files: {
         ...(capture.has("steps") ? { steps: "files/browser/editor-steps.jsonl" } : {}),
         ...(capture.has("console") ? { console: "files/browser/editor-console.jsonl" } : {}),
@@ -2434,6 +2454,8 @@ export async function runEditorOpenCommand({
         errors: errors.length,
         finalUrl,
         htmlSnapshot: capture.has("html"),
+        auth: authSummary,
+        ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         networkEvents: 0,
         replayability: browserProbeReplayability(capture),
         screenshot: capture.has("screenshot"),
@@ -2446,6 +2468,8 @@ export async function runEditorOpenCommand({
       target,
       requestedUrl: targetUrl,
       preview,
+      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
+      ...previewOrigins,
       finalUrl,
       capture: [...capture].sort(),
       waitTimeoutMs,
@@ -2515,7 +2539,10 @@ export async function runEditorActionsCommand({
   const waitTimeoutMs = durationArg(args, "wait-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
   const stepTimeoutMs = durationArg(args, "step-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
   const totalTimeoutMs = durationArg(args, "timeout", BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS)
+  const routedHosts = commaListArg(args, "route-host")
   const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
+  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
+  const previewOrigins = browserPreviewOrigins(preview)
   const targetUrl = resolveBrowserPreviewUrl(target.url, preview.effectiveOrigin)
   const browserDirectory = join(artifactRoot, "files", "browser")
   await mkdir(browserDirectory, { recursive: true })
@@ -2538,12 +2565,17 @@ export async function runEditorActionsCommand({
   let screenshotSha256: string | undefined
   let viewport: BrowserProbeViewport | null = null
   let editorState: EditorStateSnapshot | undefined
+  let authSummary: BrowserProbeAuthSummary | undefined
   let pendingError: Error | undefined
   let artifact: BrowserArtifact | undefined
 
   try {
-    const page = await browser.newPage()
-    await installWordPressAdminAuthCookies({ command: "wordpress.editor-actions", page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
+    const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
+    if (context) {
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
+    }
+    const page = context ? await context.newPage() : await browser.newPage()
+    authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-actions", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
     viewport = await browserProbeViewport(page)
     attachBrowserCaptureListeners({
       captureConsole: capture.has("console"),
@@ -2637,6 +2669,8 @@ export async function runEditorActionsCommand({
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
+      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
+      ...previewOrigins,
       files: {
         ...(capture.has("steps") ? { steps: "files/browser/editor-action-steps.jsonl" } : {}),
         ...(capture.has("console") ? { console: "files/browser/editor-action-console.jsonl" } : {}),
@@ -2653,6 +2687,8 @@ export async function runEditorActionsCommand({
         errors: errors.length,
         finalUrl,
         htmlSnapshot: capture.has("html"),
+        auth: authSummary,
+        ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         networkEvents: 0,
         replayability: browserProbeReplayability(capture),
         screenshot: capture.has("screenshot"),
@@ -2666,6 +2702,8 @@ export async function runEditorActionsCommand({
       actions: actionSteps,
       requestedUrl: targetUrl,
       preview,
+      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
+      ...previewOrigins,
       finalUrl,
       capture: [...capture].sort(),
       waitTimeoutMs,
@@ -4357,6 +4395,7 @@ function summarizeEditorState(target: ReturnType<typeof editorOpenTargetFromArgs
 }
 
 async function installWordPressAdminAuthCookies({
+  cookieUrls,
   command,
   page,
   runPlaygroundCommand,
@@ -4364,6 +4403,7 @@ async function installWordPressAdminAuthCookies({
   server,
   userId,
 }: {
+  cookieUrls?: string[]
   command: string
   page: import("playwright").Page
   runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
@@ -4379,14 +4419,14 @@ async function installWordPressAdminAuthCookies({
   }
 
   const authCommand = `${command}.auth`
-  const response = await runPlaygroundCommand(authCommand, server, { code: bootstrapPhpCode(runtimeSpec, wordpressAdminAuthCookiePhpCode(server.serverUrl, userId), []) })
+  const urls = uniqueBrowserAuthCookieUrls(cookieUrls ?? [server.serverUrl])
+  const response = await runPlaygroundCommand(authCommand, server, { code: bootstrapPhpCode(runtimeSpec, wordpressAdminAuthCookiePhpCode(urls, userId), []) })
   assertPlaygroundResponseOk(authCommand, response)
-  const cookies = JSON.parse(cleanWpCliOutput(response.text)) as Array<{ name?: string; value?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: "Lax" }>
-  const cookieDomain = new URL(server.serverUrl).hostname
+  const cookies = JSON.parse(cleanWpCliOutput(response.text)) as Array<{ name?: string; value?: string; domain?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: "Lax" }>
   await page.context().addCookies(cookies.map((cookie) => ({
     name: String(cookie.name ?? ""),
     value: String(cookie.value ?? ""),
-    domain: cookieDomain,
+    domain: String(cookie.domain ?? new URL(server.serverUrl).hostname),
     path: typeof cookie.path === "string" && cookie.path.length > 0 ? cookie.path : "/",
     expires: typeof cookie.expires === "number" ? cookie.expires : Math.floor(Date.now() / 1000) + 3600,
     httpOnly: cookie.httpOnly !== false,
@@ -4394,10 +4434,10 @@ async function installWordPressAdminAuthCookies({
     sameSite: cookie.sameSite ?? "Lax",
   })))
 
-  return { mode: "wordpress-admin", userId, cookieCount: cookies.length }
+  return { mode: "wordpress-admin", userId, cookieCount: cookies.length, cookieHosts: browserAuthCookieHostSummary(cookies) }
 }
 
-function wordpressAdminAuthCookiePhpCode(browserUrl: string, userId: number): string {
+function wordpressAdminAuthCookiePhpCode(browserUrls: string[], userId: number): string {
   return `
 $user_id = ${JSON.stringify(userId)};
 $user = get_user_by( 'id', $user_id );
@@ -4406,44 +4446,106 @@ if ( ! $user ) {
 }
 wp_set_current_user( $user_id );
 $expiration = time() + HOUR_IN_SECONDS;
-$browser_url = ${JSON.stringify(browserUrl)};
-$auth_scheme = is_ssl() ? 'secure_auth' : 'auth';
-$cookies = array(
-    array(
-        'name'     => AUTH_COOKIE,
+$browser_urls = ${JSON.stringify(browserUrls)};
+$cookies = array();
+foreach ( $browser_urls as $browser_url ) {
+    $browser_host = wp_parse_url( $browser_url, PHP_URL_HOST );
+    if ( ! $browser_host ) {
+        continue;
+    }
+    $secure = 'https' === wp_parse_url( $browser_url, PHP_URL_SCHEME );
+    $auth_scheme = $secure ? 'secure_auth' : 'auth';
+    $cookies[] = array(
+        'name'     => $secure ? SECURE_AUTH_COOKIE : AUTH_COOKIE,
         'value'    => wp_generate_auth_cookie( $user_id, $expiration, $auth_scheme ),
-        'url'      => $browser_url,
+        'domain'   => $browser_host,
         'path'     => defined( 'ADMIN_COOKIE_PATH' ) && ADMIN_COOKIE_PATH ? ADMIN_COOKIE_PATH : '/wp-admin',
         'expires'  => $expiration,
         'httpOnly' => true,
-        'secure'   => is_ssl(),
+        'secure'   => $secure,
         'sameSite' => 'Lax',
-    ),
-    array(
+    );
+    $logged_in_cookie = array(
         'name'     => LOGGED_IN_COOKIE,
         'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in' ),
-        'url'      => $browser_url,
+        'domain'   => $browser_host,
         'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
         'expires'  => $expiration,
         'httpOnly' => true,
-        'secure'   => is_ssl(),
-        'sameSite' => 'Lax',
-    ),
-);
-if ( defined( 'SITECOOKIEPATH' ) && SITECOOKIEPATH && SITECOOKIEPATH !== COOKIEPATH ) {
-    $cookies[] = array(
-        'name'     => LOGGED_IN_COOKIE,
-        'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in' ),
-        'url'      => $browser_url,
-        'path'     => SITECOOKIEPATH,
-        'expires'  => $expiration,
-        'httpOnly' => true,
-        'secure'   => is_ssl(),
+        'secure'   => $secure,
         'sameSite' => 'Lax',
     );
+    $cookies[] = $logged_in_cookie;
+    if ( defined( 'SITECOOKIEPATH' ) && SITECOOKIEPATH && SITECOOKIEPATH !== COOKIEPATH ) {
+        $logged_in_cookie['path'] = SITECOOKIEPATH;
+        $cookies[] = $logged_in_cookie;
+    }
 }
 echo wp_json_encode( $cookies );
 `
+}
+
+function browserAuthCookieUrls(serverUrl: string, routedHosts: string[], targetUrls: string[]): string[] {
+  const urls = [serverUrl]
+  for (const host of routedHosts.map(normalizeBrowserCookieHost).filter(Boolean)) {
+    const matchingTarget = targetUrls.find((targetUrl) => normalizeBrowserCookieHost(browserUrlHostname(targetUrl) ?? "") === host)
+    const protocol = matchingTarget ? new URL(matchingTarget).protocol : browserAuthCookieProtocol(targetUrls)
+    urls.push(`${protocol}//${host}/`)
+  }
+  return uniqueBrowserAuthCookieUrls(urls)
+}
+
+function browserActionTargetUrls(steps: BrowserInteractionStep[], effectiveOrigin: string, fallbackUrl: string): string[] {
+  const urls = steps
+    .filter((step) => step.kind === "navigate" && typeof step.url === "string" && step.url.trim().length > 0)
+    .map((step) => resolveBrowserPreviewUrl(String(step.url), effectiveOrigin))
+  return urls.length > 0 ? urls : [fallbackUrl]
+}
+
+function uniqueBrowserAuthCookieUrls(urls: string[]): string[] {
+  const unique = new Map<string, string>()
+  for (const url of urls) {
+    try {
+      const parsed = new URL(url)
+      unique.set(`${parsed.protocol}//${normalizeBrowserCookieHost(parsed.hostname)}`, `${parsed.protocol}//${parsed.hostname}/`)
+    } catch {
+      // Ignore invalid cookie URL inputs; callers still include the local server URL.
+    }
+  }
+  return [...unique.values()]
+}
+
+function browserAuthCookieProtocol(targetUrls: string[]): string {
+  for (const targetUrl of targetUrls) {
+    try {
+      return new URL(targetUrl).protocol
+    } catch {
+      // Keep looking for a usable target URL.
+    }
+  }
+  return "http:"
+}
+
+function browserUrlHostname(url: string): string | undefined {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeBrowserCookieHost(host: string): string {
+  return host.trim().toLowerCase().replace(/:\d+$/, "")
+}
+
+function browserAuthCookieHostSummary(cookies: Array<{ domain?: string }>): Array<{ host: string; cookieCount: number }> {
+  const counts = new Map<string, number>()
+  for (const cookie of cookies) {
+    const host = normalizeBrowserCookieHost(String(cookie.domain ?? ""))
+    if (!host) continue
+    counts.set(host, (counts.get(host) ?? 0) + 1)
+  }
+  return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([host, cookieCount]) => ({ host, cookieCount }))
 }
 
 function browserAuthRequest(args: string[]): { userId: number } | undefined {

--- a/scripts/browser-probe-routed-admin-auth-smoke.ts
+++ b/scripts/browser-probe-routed-admin-auth-smoke.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict"
+import { createServer, type Server } from "node:http"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { runBrowserProbeCommand } from "../packages/runtime-playground/src/browser-command-runners.js"
+import type { PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-routed-admin-auth-"))
+let server: Server | undefined
+
+try {
+  server = createServer((request, response) => {
+    const cookieHeader = request.headers.cookie ?? ""
+    if (request.url === "/wp-admin/" && !cookieHeader.includes("wp_codebox_logged_in=1")) {
+      response.writeHead(302, { location: "https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2Fwp-admin%2F" })
+      response.end("missing auth")
+      return
+    }
+
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+    response.end(`<!doctype html><title>Admin</title><main data-path="${request.url ?? "/"}" data-authenticated="${cookieHeader.includes("wp_codebox_logged_in=1")}">WP Admin</main>`)
+  })
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject)
+    server?.listen(0, "127.0.0.1", resolve)
+  })
+
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+
+  const localUrl = `http://127.0.0.1:${address.port}/`
+  const targetUrl = "https://wordpress.com/wp-admin/"
+  const runtimeSpec: RuntimeCreateSpec = { preview: { publicUrl: targetUrl } }
+  const serverRef: PlaygroundCliServer = {
+    playground: {
+      async run() {
+        return { text: "" }
+      },
+    },
+    serverUrl: localUrl,
+    async [Symbol.asyncDispose]() {},
+  }
+
+  const probe = await runBrowserProbeCommand({
+    artifactRoot: workspace,
+    runtimeSpec,
+    runPlaygroundCommand: async (_command, _server, options) => ({ text: mockedAuthCookieResponse("code" in options ? options.code : "") }),
+    server: serverRef,
+    spec: {
+      command: "wordpress.browser-probe",
+      args: [
+        `url=${targetUrl}`,
+        "route-host=wordpress.com",
+        "auth=wordpress-admin",
+        "wait-for=domcontentloaded",
+        "capture=html,network",
+      ],
+    },
+  })
+
+  assert.equal(probe.artifact.requestedUrl, targetUrl)
+  assert.equal(probe.artifact.summary.finalUrl, targetUrl)
+  assert.equal(probe.artifact.summary.auth?.mode, "wordpress-admin")
+  assert.deepEqual(probe.artifact.summary.auth?.cookieHosts.map((host) => host.host).sort(), ["127.0.0.1", "wordpress.com"])
+  assert.equal(probe.artifact.summary.networkPolicy?.routeHosts.includes("wordpress.com"), true)
+
+  const html = await readFile(join(workspace, "files", "browser", "snapshot.html"), "utf8")
+  assert.match(html, /data-path="\/wp-admin\/"/)
+  assert.match(html, /data-authenticated="true"/)
+  assert.doesNotMatch(probe.artifact.summary.finalUrl, /log-in/)
+
+  const summary = JSON.parse(await readFile(join(workspace, "files", "browser", "summary.json"), "utf8"))
+  assert.deepEqual(summary.summary.auth.cookieHosts.map((host: { host: string }) => host.host).sort(), ["127.0.0.1", "wordpress.com"])
+  assert.doesNotMatch(JSON.stringify(summary), /wp_codebox_logged_in|secret-cookie-value/i, "artifact summary should list cookie hosts without cookie names or values")
+
+  console.log("Browser probe routed admin auth smoke passed")
+} finally {
+  await new Promise<void>((resolve) => server?.close(() => resolve()) ?? resolve())
+  await rm(workspace, { recursive: true, force: true })
+}
+
+function mockedAuthCookieResponse(source: string): string {
+  const urls = parseBrowserUrlsFromPhp(source)
+  const expires = Math.floor(Date.now() / 1000) + 3600
+  return `${JSON.stringify(urls.flatMap((url) => {
+    const parsed = new URL(url)
+    return [
+      { name: "wp_codebox_admin", value: "secret-cookie-value", domain: parsed.hostname, path: "/wp-admin", expires, httpOnly: true, secure: parsed.protocol === "https:", sameSite: "Lax" },
+      { name: "wp_codebox_logged_in", value: "1", domain: parsed.hostname, path: "/", expires, httpOnly: true, secure: parsed.protocol === "https:", sameSite: "Lax" },
+    ]
+  }))}\n`
+}
+
+function parseBrowserUrlsFromPhp(source: string): string[] {
+  const match = source.match(/\$browser_urls = (\[[^;]+\]);/)
+  assert.ok(match?.[1], "auth PHP should embed browser_urls")
+  const parsed = JSON.parse(match[1]) as unknown
+  assert.ok(Array.isArray(parsed), "browser_urls should be an array")
+  return parsed.map(String)
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -197,6 +197,7 @@ export const smokeGroups = {
       tsxSmoke("browser-probe-context-smoke"),
       tsxSmoke("browser-probe-public-url-routing-smoke"),
       tsxSmoke("browser-probe-route-host-smoke"),
+      tsxSmoke("browser-probe-routed-admin-auth-smoke"),
       tsxSmoke("browser-probe-network-policy-smoke"),
       tsxSmoke("browser-probe-profile-matrix-smoke"),
       tsxSmoke("browser-lifecycle-observer-smoke"),


### PR DESCRIPTION
## Summary
- Install WordPress admin auth cookies for routed browser hosts in addition to the local preview host.
- Route `wordpress.browser-actions`, `wordpress.editor-open`, and `wordpress.editor-actions` through the preview network policy when `route-host` is used.
- Add a smoke test proving routed `https://wordpress.com/wp-admin/` requests stay authenticated without exposing cookie values in artifacts.

## Testing
- `npm run build`
- `npx tsx scripts/browser-probe-routed-admin-auth-smoke.ts`

Fixes #892.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Continued the interrupted implementation, patched routed browser auth handling, added verification, and drafted this PR description for Chris to review.