### PR TITLE
Fail CLI commands that drain before settling

### DIFF
--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -1,0 +1,32 @@
+import { runCli } from "./cli-entry.js"
+import { serializeError } from "./output.js"
+
+export type CliRunner = (args: string[]) => Promise<number>
+
+const UNSETTLED_COMMAND_MESSAGE = "WP Codebox CLI command did not settle before the Node.js event loop drained."
+
+export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): void {
+  let settled = false
+  const handleBeforeExit = () => {
+    if (settled) {
+      return
+    }
+    console.error(UNSETTLED_COMMAND_MESSAGE)
+    process.exitCode = 1
+  }
+
+  process.once("beforeExit", handleBeforeExit)
+  runner(args).then(
+    (code) => {
+      settled = true
+      process.off("beforeExit", handleBeforeExit)
+      process.exitCode = code
+    },
+    (error) => {
+      settled = true
+      process.off("beforeExit", handleBeforeExit)
+      console.error(serializeError(error)?.message ?? String(error))
+      process.exitCode = 1
+    },
+  )
+}

--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -7,11 +7,12 @@ const UNSETTLED_COMMAND_MESSAGE = "WP Codebox CLI command did not settle before 
 
 export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): void {
   let settled = false
+  const writeStderr = process.stderr.write.bind(process.stderr)
   const handleBeforeExit = () => {
     if (settled) {
       return
     }
-    console.error(UNSETTLED_COMMAND_MESSAGE)
+    writeStderr(`${UNSETTLED_COMMAND_MESSAGE}\n`)
     process.exitCode = 1
   }
 
@@ -25,7 +26,7 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): vo
     (error) => {
       settled = true
       process.off("beforeExit", handleBeforeExit)
-      console.error(serializeError(error)?.message ?? String(error))
+      writeStderr(`${serializeError(error)?.message ?? String(error)}\n`)
       process.exitCode = 1
     },
   )

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,13 +1,4 @@
 #!/usr/bin/env node
-import { runCli } from "./cli-entry.js"
-import { serializeError } from "./output.js"
+import { runCliEntrypoint } from "./cli-main.js"
 
-runCli(process.argv.slice(2)).then(
-  (code) => {
-    process.exitCode = code
-  },
-  (error) => {
-    console.error(serializeError(error)?.message ?? String(error))
-    process.exitCode = 1
-  },
-)
+runCliEntrypoint(process.argv.slice(2))

--- a/scripts/cli-unsettled-command-smoke.ts
+++ b/scripts/cli-unsettled-command-smoke.ts
@@ -4,6 +4,7 @@ import { runCliEntrypoint } from "../packages/cli/src/cli-main.js"
 const originalExitCode = process.exitCode
 const originalStderrWrite = process.stderr.write.bind(process.stderr)
 let stderr = ""
+let hijackedStderr = ""
 
 process.exitCode = undefined
 ;(process.stderr.write as typeof process.stderr.write) = ((chunk: unknown, ..._args: unknown[]) => {
@@ -12,11 +13,18 @@ process.exitCode = undefined
 }) as typeof process.stderr.write
 
 try {
-  runCliEntrypoint(["agent-task-run"], async () => new Promise<number>(() => undefined))
+  runCliEntrypoint(["agent-task-run"], async () => {
+    ;(process.stderr.write as typeof process.stderr.write) = ((chunk: unknown, ..._args: unknown[]) => {
+      hijackedStderr += String(chunk)
+      return true
+    }) as typeof process.stderr.write
+    return new Promise<number>(() => undefined)
+  })
   process.emit("beforeExit", 0)
 
   assert.equal(process.exitCode, 1)
   assert.match(stderr, /did not settle before the Node\.js event loop drained/)
+  assert.equal(hijackedStderr, "")
 } finally {
   process.stderr.write = originalStderrWrite
   process.exitCode = originalExitCode

--- a/scripts/cli-unsettled-command-smoke.ts
+++ b/scripts/cli-unsettled-command-smoke.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict"
+import { runCliEntrypoint } from "../packages/cli/src/cli-main.js"
+
+const originalExitCode = process.exitCode
+const originalStderrWrite = process.stderr.write.bind(process.stderr)
+let stderr = ""
+
+process.exitCode = undefined
+;(process.stderr.write as typeof process.stderr.write) = ((chunk: unknown, ..._args: unknown[]) => {
+  stderr += String(chunk)
+  return true
+}) as typeof process.stderr.write
+
+try {
+  runCliEntrypoint(["agent-task-run"], async () => new Promise<number>(() => undefined))
+  process.emit("beforeExit", 0)
+
+  assert.equal(process.exitCode, 1)
+  assert.match(stderr, /did not settle before the Node\.js event loop drained/)
+} finally {
+  process.stderr.write = originalStderrWrite
+  process.exitCode = originalExitCode
+}
+
+console.log("cli-unsettled-command-smoke: ok")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -46,6 +46,7 @@ export const smokeGroups = {
       tsxSmoke("task-input-contract-smoke"),
       tsxSmoke("discovery-command-smoke"),
       tsxSmoke("doctor-command-smoke"),
+      tsxSmoke("cli-unsettled-command-smoke"),
       tsxSmoke("agent-sandbox-code-smoke"),
       tsxSmoke("agent-runtime-failure-smoke"),
     ],


### PR DESCRIPTION
## Summary
- Add a CLI entrypoint guard that fails with a diagnostic if a routed command promise is still unsettled when Node's event loop drains.
- Move entrypoint wiring into a testable wrapper and add smoke coverage for the drained-command path.

Fixes #896.

## Testing
- `npx tsx scripts/cli-unsettled-command-smoke.ts`
- `npm run build`
- `npm run smoke -- --command=cli-unsettled-command-smoke`
- `node --input-type=module -e "import { runCliEntrypoint } from './packages/cli/dist/cli-main.js'; runCliEntrypoint(['agent-task-run'], async () => new Promise(() => undefined));"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the WP Codebox empty-output CLI failure, drafting the generic CLI guard and smoke coverage, and running verification commands. Chris remains responsible for review and submission.