### PR TITLE
Fix agent task JSON capture settlement

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -386,12 +386,14 @@ async function captureOutput<T>(callback: () => Promise<T>): Promise<CapturedOut
   const originalErrorWrite = process.stderr.write.bind(process.stderr)
   let stdout = ""
   let stderr = ""
-  ;(process.stdout.write as typeof process.stdout.write) = ((chunk: unknown, ...args: unknown[]) => {
-    stdout += String(chunk)
+  ;(process.stdout.write as typeof process.stdout.write) = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdout += typeof chunk === "string" ? chunk : chunk.toString()
+    callWriteCallback(encodingOrCallback, callback)
     return true
   }) as typeof process.stdout.write
-  ;(process.stderr.write as typeof process.stderr.write) = ((chunk: unknown, ...args: unknown[]) => {
-    stderr += String(chunk)
+  ;(process.stderr.write as typeof process.stderr.write) = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stderr += typeof chunk === "string" ? chunk : chunk.toString()
+    callWriteCallback(encodingOrCallback, callback)
     return true
   }) as typeof process.stderr.write
   try {
@@ -400,6 +402,14 @@ async function captureOutput<T>(callback: () => Promise<T>): Promise<CapturedOut
   } finally {
     process.stdout.write = originalWrite
     process.stderr.write = originalErrorWrite
+  }
+}
+
+function callWriteCallback(encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void): void {
+  if (typeof encodingOrCallback === "function") {
+    encodingOrCallback()
+  } else if (callback) {
+    callback()
   }
 }
 

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -121,6 +121,17 @@ assert.equal((failureEvidence?.sandbox as Record<string, unknown>)?.sandbox_sess
 assert.equal(Array.isArray(failingOutput.diagnostics) && failingOutput.diagnostics.length > 0, true, "failure diagnostics should be emitted")
 assert.equal(failingOutput.evidence_refs.some((ref) => ref.kind === "codebox-agent-task-failure-evidence"), true, "failure evidence ref should be emitted")
 
+const semanticFailureOutput = await promiseMustSettle(runAgentTask({
+  goal: "Fail recipe validation and still settle",
+  dependency_overlays: [{ kind: "composer-package", package: "acme/missing", source: "/components/missing", consumer: "missing-consumer" }],
+  sandbox_session_id: "sandbox-semantic-failure-smoke",
+  artifacts_path: mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-semantic-failure-smoke-")),
+}, { inputPath: "", json: true, previewHoldSeconds: "", previewPublicUrl: "" }), 2_000)
+assert.equal(semanticFailureOutput.success, false, "recipe validation failures should return a failed agent-task payload")
+assert.equal(semanticFailureOutput.status, "failed", "recipe validation failures should report failed status")
+assert.equal(semanticFailureOutput.failure_evidence?.schema, "wp-codebox/agent-task-run-failure-evidence/v1", "recipe validation failures should include failure evidence")
+assert.equal(semanticFailureOutput.diagnostics.some((diagnostic) => diagnostic.class === "wp-codebox.agent_task_run_failed"), true, "recipe validation failures should include agent-task diagnostics")
+
 const structuredInput = {
   goal: "Transform a concept packet into a design packet",
   provider: "openai",
@@ -306,3 +317,19 @@ assert.equal(codexOverlays[0]?.kind, "bundled-library")
 assert.equal(codexOverlays[0]?.library, "php-ai-client")
 assert.equal(codexOverlays[0]?.source, phpAiClientPath)
 assert.equal(codexOverlays[0]?.strategy, "wordpress-scoped-bundle")
+
+async function promiseMustSettle<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Promise did not settle within ${timeoutMs}ms`)), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Preserve `process.stdout.write` / `stderr.write` callback behavior while `agent-task-run` captures nested `recipe-run --json` output.
- Add smoke coverage for a generic `runAgentTask()` recipe validation failure that must settle with structured failure evidence instead of hanging.

Fixes #899.

## Testing
- `npm run build`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `node packages/cli/dist/index.js agent-task-run --input-file=<semantic-failure-input> --json`
- Direct import check: `runAgentTaskRunCommand(["--input-file", <semantic-failure-input>, "--json"])` printed `before`, structured failure JSON, and `after code=1`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the unsettled generic agent-task command path, drafted the fix and smoke coverage, and ran targeted verification for Chris to review.