### PR TITLE
Validate Codex overlay provider profile

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -319,9 +319,45 @@ function wp_codebox_json_encode_agent_runtime_payload($value): string {
     return (string) wp_json_encode($fallback, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
 }
 
+function wp_codebox_validate_requested_provider(array $agent_input, array $sandbox_stack) {
+    $provider = trim((string) ($agent_input['provider'] ?? ''));
+    if ('' === $provider) {
+        return null;
+    }
+    if (!class_exists('WordPress\\AiClient\\Providers\\ProviderRegistry')) {
+        return array(
+            'code' => 'wp_codebox_provider_registry_unavailable',
+            'message' => 'The requested provider could not be validated because the wp-ai-client provider registry is unavailable inside the sandbox.',
+            'data' => array(
+                'provider' => $provider,
+                'provider_plugins' => $sandbox_stack['signals']['provider_plugins'] ?? array(),
+                'plugin_activation' => $sandbox_stack['plugins'] ?? array(),
+            ),
+        );
+    }
+
+    $registry = new WordPress\AiClient\Providers\ProviderRegistry();
+    if (method_exists($registry, 'isProviderConfigured') && $registry->isProviderConfigured($provider)) {
+        return null;
+    }
+
+    return array(
+        'code' => 'wp_codebox_provider_not_registered',
+        'message' => sprintf('Requested provider "%s" is not registered in wp-ai-client after sandbox provider plugins were loaded.', $provider),
+        'data' => array(
+            'provider' => $provider,
+            'provider_plugins' => $sandbox_stack['signals']['provider_plugins'] ?? array(),
+            'plugin_activation' => $sandbox_stack['plugins'] ?? array(),
+        ),
+    );
+}
+
 $runtime_task_run = is_array($sandbox_runtime_task) && !empty($sandbox_runtime_task);
 $ability_name = $runtime_task_run ? (string) ($sandbox_runtime_task['ability'] ?? '') : 'agents/chat';
 $ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability($ability_name) : null;
+$agent_input = ${JSON.stringify(JSON.stringify(input))};
+$decoded_agent_input = json_decode($agent_input, true);
+$provider_validation_error = wp_codebox_validate_requested_provider(is_array($decoded_agent_input) ? $decoded_agent_input : array(), $sandbox_stack);
 if (!empty($sandbox_agent_bundle_import_failures)) {
     $sandbox_agent_runtime = array(
         'agent_runtime' => array(
@@ -331,6 +367,14 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
                 'message' => 'One or more runtime agent bundles failed to import before sandbox invocation.',
                 'data' => array('agent_bundle_imports' => array_values($sandbox_agent_bundle_import_failures)),
             ),
+        ),
+    );
+} elseif (null !== $provider_validation_error) {
+    $sandbox_agent_runtime = array(
+        'agent_runtime' => array(
+            'success' => false,
+            'input' => is_array($decoded_agent_input) ? $decoded_agent_input : null,
+            'error' => $provider_validation_error,
         ),
     );
 } elseif (!$ability || !method_exists($ability, 'execute')) {
@@ -344,10 +388,9 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
         ),
     );
 } else {
-    $agent_input = ${JSON.stringify(JSON.stringify(input))};
     $runtime_task_input = $runtime_task_run && is_array($sandbox_runtime_task['input'] ?? null) ? $sandbox_runtime_task['input'] : array();
-    $agent_execute_callback = static function () use ($ability, $runtime_task_run, $runtime_task_input, $agent_input) {
-        return $ability->execute($runtime_task_run ? $runtime_task_input : json_decode($agent_input, true));
+    $agent_execute_callback = static function () use ($ability, $runtime_task_run, $runtime_task_input, $decoded_agent_input) {
+        return $ability->execute($runtime_task_run ? $runtime_task_input : $decoded_agent_input);
     };
     $agent_result = class_exists('DataMachine\\Abilities\\PermissionHelper')
         ? DataMachine\\Abilities\\PermissionHelper::run_as_authenticated($agent_execute_callback)

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
@@ -290,7 +290,7 @@ function runtimeOverlayProfileDefaults(input: AgentTaskRunInput): RuntimeOverlay
       defaults.providerPluginPaths.push(requiredProfilePath(CODEX_SUBSCRIPTION_PROFILE, CODEX_PROVIDER_PLUGIN_ENV, [
         "~/Developer/ai-provider-for-openai@codex-oauth-provider",
         "~/Developer/ai-provider-for-openai",
-      ], hasComposerPackage, hasCodexProviderRegistration, "provider plugin must register provider: codex"))
+      ], hasComposerPackage))
       defaults.runtimeOverlays.push({
         kind: "bundled-library",
         library: "php-ai-client",
@@ -309,17 +309,14 @@ function runtimeOverlayProfileDefaults(input: AgentTaskRunInput): RuntimeOverlay
   return defaults
 }
 
-function requiredProfilePath(profile: string, envName: string, candidates: string[], isUsablePath: (path: string) => boolean = existsSync, satisfiesProfile: (path: string) => boolean = () => true, requirement = "profile requirements"): string {
+function requiredProfilePath(profile: string, envName: string, candidates: string[], isUsablePath: (path: string) => boolean = existsSync): string {
   const explicit = stringValue(process.env[envName])
-  const resolved = explicit || candidates.map(resolveProfilePathCandidate).find((candidate) => isUsablePath(candidate) && satisfiesProfile(candidate)) || ""
+  const resolved = explicit || candidates.map(resolveProfilePathCandidate).find((candidate) => isUsablePath(candidate)) || ""
   if (!resolved) {
-    throw new Error(`${profile} runtime overlay profile requires ${envName} or one of: ${candidates.join(", ")} (${requirement})`)
+    throw new Error(`${profile} runtime overlay profile requires ${envName} or one of: ${candidates.join(", ")}`)
   }
   if (!isUsablePath(resolved)) {
     throw new Error(`${profile} runtime overlay profile path from ${envName} is not prepared: ${resolved}`)
-  }
-  if (!satisfiesProfile(resolved)) {
-    throw new Error(`${profile} runtime overlay profile path from ${envName} does not satisfy profile requirements: ${resolved} (${requirement})`)
   }
   return resolved
 }
@@ -330,18 +327,6 @@ function resolveProfilePathCandidate(candidate: string): string {
 
 function hasComposerPackage(candidate: string): boolean {
   return existsSync(join(candidate, "composer.json"))
-}
-
-function hasCodexProviderRegistration(candidate: string): boolean {
-  const pluginFile = join(candidate, "plugin.php")
-  const providerFile = join(candidate, "src", "Codex", "CodexProvider.php")
-  if (!existsSync(pluginFile) || !existsSync(providerFile)) return false
-  try {
-    const plugin = readFileSync(pluginFile, "utf8")
-    return plugin.includes("CodexProvider") && plugin.includes("registerProvider(CodexProvider::class)")
-  } catch {
-    return false
-  }
 }
 
 function hasInstalledComposerPackage(candidate: string): boolean {

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
@@ -290,7 +290,7 @@ function runtimeOverlayProfileDefaults(input: AgentTaskRunInput): RuntimeOverlay
       defaults.providerPluginPaths.push(requiredProfilePath(CODEX_SUBSCRIPTION_PROFILE, CODEX_PROVIDER_PLUGIN_ENV, [
         "~/Developer/ai-provider-for-openai@codex-oauth-provider",
         "~/Developer/ai-provider-for-openai",
-      ], hasComposerPackage))
+      ], hasComposerPackage, hasCodexProviderRegistration, "provider plugin must register provider: codex"))
       defaults.runtimeOverlays.push({
         kind: "bundled-library",
         library: "php-ai-client",
@@ -309,14 +309,17 @@ function runtimeOverlayProfileDefaults(input: AgentTaskRunInput): RuntimeOverlay
   return defaults
 }
 
-function requiredProfilePath(profile: string, envName: string, candidates: string[], isUsablePath: (path: string) => boolean = existsSync): string {
+function requiredProfilePath(profile: string, envName: string, candidates: string[], isUsablePath: (path: string) => boolean = existsSync, satisfiesProfile: (path: string) => boolean = () => true, requirement = "profile requirements"): string {
   const explicit = stringValue(process.env[envName])
-  const resolved = explicit || candidates.map(resolveProfilePathCandidate).find((candidate) => isUsablePath(candidate)) || ""
+  const resolved = explicit || candidates.map(resolveProfilePathCandidate).find((candidate) => isUsablePath(candidate) && satisfiesProfile(candidate)) || ""
   if (!resolved) {
-    throw new Error(`${profile} runtime overlay profile requires ${envName} or one of: ${candidates.join(", ")}`)
+    throw new Error(`${profile} runtime overlay profile requires ${envName} or one of: ${candidates.join(", ")} (${requirement})`)
   }
   if (!isUsablePath(resolved)) {
     throw new Error(`${profile} runtime overlay profile path from ${envName} is not prepared: ${resolved}`)
+  }
+  if (!satisfiesProfile(resolved)) {
+    throw new Error(`${profile} runtime overlay profile path from ${envName} does not satisfy profile requirements: ${resolved} (${requirement})`)
   }
   return resolved
 }
@@ -327,6 +330,18 @@ function resolveProfilePathCandidate(candidate: string): string {
 
 function hasComposerPackage(candidate: string): boolean {
   return existsSync(join(candidate, "composer.json"))
+}
+
+function hasCodexProviderRegistration(candidate: string): boolean {
+  const pluginFile = join(candidate, "plugin.php")
+  const providerFile = join(candidate, "src", "Codex", "CodexProvider.php")
+  if (!existsSync(pluginFile) || !existsSync(providerFile)) return false
+  try {
+    const plugin = readFileSync(pluginFile, "utf8")
+    return plugin.includes("CodexProvider") && plugin.includes("registerProvider(CodexProvider::class)")
+  } catch {
+    return false
+  }
 }
 
 function hasInstalledComposerPackage(candidate: string): boolean {

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -292,11 +292,22 @@ assert.equal(structuredIndex.artifacts[0]?.payload?.theme, "warm editorial")
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))
 const codexProviderPath = join(profileRoot, "ai-provider-for-openai@codex-oauth-provider")
+const openAiProviderPath = join(profileRoot, "ai-provider-for-openai")
 const phpAiClientPath = join(profileRoot, "php-ai-client@custom-provider-auth")
 mkdirSync(codexProviderPath, { recursive: true })
+mkdirSync(openAiProviderPath, { recursive: true })
+mkdirSync(join(codexProviderPath, "src", "Codex"), { recursive: true })
 mkdirSync(join(phpAiClientPath, "vendor"), { recursive: true })
 writeFileSync(join(codexProviderPath, "composer.json"), "{}\n")
+writeFileSync(join(openAiProviderPath, "composer.json"), "{}\n")
+writeFileSync(join(codexProviderPath, "plugin.php"), "<?php\n$registry->registerProvider(CodexProvider::class);\n")
+writeFileSync(join(codexProviderPath, "src", "Codex", "CodexProvider.php"), "<?php\nclass CodexProvider {}\n")
 writeFileSync(join(phpAiClientPath, "composer.json"), "{}\n")
+process.env.WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH = openAiProviderPath
+assert.throws(
+  () => buildAgentTaskRecipe({ goal: "Run a Codex subscription-backed agent", provider: "codex", runtime_overlay_profiles: ["codex-subscription"] }, normalizeTaskInput({ goal: "Run a Codex subscription-backed agent", provider: "codex", runtime_overlay_profiles: ["codex-subscription"] }), "trunk"),
+  /codex-subscription runtime overlay profile path from WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH does not satisfy profile requirements: .*provider plugin must register provider: codex/,
+)
 process.env.WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH = codexProviderPath
 process.env.WP_CODEBOX_PHP_AI_CLIENT_PATH = phpAiClientPath
 

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -292,22 +292,11 @@ assert.equal(structuredIndex.artifacts[0]?.payload?.theme, "warm editorial")
 
 const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))
 const codexProviderPath = join(profileRoot, "ai-provider-for-openai@codex-oauth-provider")
-const openAiProviderPath = join(profileRoot, "ai-provider-for-openai")
 const phpAiClientPath = join(profileRoot, "php-ai-client@custom-provider-auth")
 mkdirSync(codexProviderPath, { recursive: true })
-mkdirSync(openAiProviderPath, { recursive: true })
-mkdirSync(join(codexProviderPath, "src", "Codex"), { recursive: true })
 mkdirSync(join(phpAiClientPath, "vendor"), { recursive: true })
 writeFileSync(join(codexProviderPath, "composer.json"), "{}\n")
-writeFileSync(join(openAiProviderPath, "composer.json"), "{}\n")
-writeFileSync(join(codexProviderPath, "plugin.php"), "<?php\n$registry->registerProvider(CodexProvider::class);\n")
-writeFileSync(join(codexProviderPath, "src", "Codex", "CodexProvider.php"), "<?php\nclass CodexProvider {}\n")
 writeFileSync(join(phpAiClientPath, "composer.json"), "{}\n")
-process.env.WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH = openAiProviderPath
-assert.throws(
-  () => buildAgentTaskRecipe({ goal: "Run a Codex subscription-backed agent", provider: "codex", runtime_overlay_profiles: ["codex-subscription"] }, normalizeTaskInput({ goal: "Run a Codex subscription-backed agent", provider: "codex", runtime_overlay_profiles: ["codex-subscription"] }), "trunk"),
-  /codex-subscription runtime overlay profile path from WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH does not satisfy profile requirements: .*provider plugin must register provider: codex/,
-)
 process.env.WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH = codexProviderPath
 process.env.WP_CODEBOX_PHP_AI_CLIENT_PATH = phpAiClientPath
 
@@ -328,6 +317,10 @@ assert.equal(codexOverlays[0]?.kind, "bundled-library")
 assert.equal(codexOverlays[0]?.library, "php-ai-client")
 assert.equal(codexOverlays[0]?.source, phpAiClientPath)
 assert.equal(codexOverlays[0]?.strategy, "wordpress-scoped-bundle")
+assert.ok(agentCodeSource.includes("wp_codebox_validate_requested_provider"))
+assert.ok(agentCodeSource.includes("WordPress\\\\AiClient\\\\Providers\\\\ProviderRegistry"))
+assert.ok(agentCodeSource.includes("wp_codebox_provider_not_registered"))
+assert.ok(!agentTaskRunSource.includes("CodexProvider"))
 
 async function promiseMustSettle<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timeout: NodeJS.Timeout | undefined


### PR DESCRIPTION
## Summary
- Add a generic sandbox preflight that validates the requested provider ID against the `wp-ai-client` provider registry after provider plugins are loaded.
- Return a structured WP Codebox runtime diagnostic when the registry is unavailable or the requested provider is not registered, instead of reaching the later agent runtime failure.
- Extend the focused agent-task runtime-components smoke to verify the provider-agnostic registry preflight is present and no provider-specific Codex class validation is introduced.

Fixes #901.

## Tests
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the WP Codebox provider registration failure, implemented the provider-agnostic registry diagnostic and smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.