### PR TITLE
Fix browser network capture hangs

### DIFF
--- a/packages/runtime-playground/src/browser-capture-session.ts
+++ b/packages/runtime-playground/src/browser-capture-session.ts
@@ -2,6 +2,8 @@ import type { BrowserProbeErrorRecord, BrowserProbeNetworkRecord } from "./brows
 import { serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import type { Browser, Page } from "playwright"
 
+const BROWSER_NETWORK_TASK_SETTLE_TIMEOUT_MS = 1_000
+
 export async function launchChromiumBrowser(): Promise<Browser> {
   const { chromium } = await import("playwright")
   return chromium.launch(
@@ -69,5 +71,25 @@ export function attachBrowserCaptureListeners({
       onNetwork?.()
       network.push(serializeBrowserRequestFailure(request, new Date().toISOString()))
     })
+  }
+}
+
+export async function settleBrowserNetworkTasks(networkTasks: Array<Promise<void>>, timeoutMs = BROWSER_NETWORK_TASK_SETTLE_TIMEOUT_MS): Promise<void> {
+  if (networkTasks.length === 0) {
+    return
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      Promise.allSettled(networkTasks),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
   }
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -6,7 +6,7 @@ import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
 import { browserInteractionStepsFromArgs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
-import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser } from "./browser-capture-session.js"
+import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserError } from "./browser-metrics.js"
@@ -538,9 +538,7 @@ async function runSingleBrowserProbeCommand({
       }
     }
     if (assertions.length > 0) {
-      if (networkTasks.length > 0) {
-        await Promise.all(networkTasks)
-      }
+      await settleBrowserNetworkTasks(networkTasks)
       const assertionMetrics = capturesBrowserMetrics ? browserProbeBenchMetrics(browserProbeMemoryArtifact(checkpoints), browserProbePerformanceArtifact(checkpoints)) : {}
       assertionResults = await executeBrowserProbeAssertions(page, assertions, consoleMessages, errors, network, assertionMetrics)
       if (capturesBrowserMetrics) {
@@ -593,9 +591,7 @@ async function runSingleBrowserProbeCommand({
         }
       }
     }
-    if (networkTasks.length > 0) {
-      await Promise.all(networkTasks)
-    }
+    await settleBrowserNetworkTasks(networkTasks)
     await browser.close()
     if (capture.has("console") || capturesConsoleForAssertions) {
       await writeFile(consolePath, jsonLines(consoleMessages))
@@ -2033,9 +2029,7 @@ export async function runBrowserActionsCommand({
       }
     }
   } finally {
-    if (networkTasks.length > 0) {
-      await Promise.all(networkTasks)
-    }
+    await settleBrowserNetworkTasks(networkTasks)
     await browser.close()
     if (capture.has("steps")) {
       await writeFile(stepsPath, jsonLines(stepRecords))

--- a/scripts/browser-network-task-settle-smoke.ts
+++ b/scripts/browser-network-task-settle-smoke.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict"
+import { settleBrowserNetworkTasks } from "../packages/runtime-playground/src/browser-capture-session.js"
+
+const startedAt = Date.now()
+await settleBrowserNetworkTasks([new Promise<void>(() => undefined)], 25)
+const elapsedMs = Date.now() - startedAt
+
+assert.ok(elapsedMs < 1_000, `network task settlement should be bounded, got ${elapsedMs}ms`)
+
+console.log("browser network task settlement smoke passed")


### PR DESCRIPTION
## Summary
- Bound browser network capture task settlement so diagnostic request metadata cannot keep browser commands alive indefinitely.
- Apply the bounded drain to browser probe assertion/finalization and browser actions finalization.
- Add a smoke proving unsettled network tasks do not block command completion.

Fixes #903.

## Testing
- `./node_modules/.bin/tsx scripts/browser-network-task-settle-smoke.ts`
- `./node_modules/.bin/tsx scripts/browser-actions-artifact-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Lab timeout evidence, implemented the bounded network capture settlement, added regression smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.