### PR TITLE
Capture browser redirect diagnostics

### DIFF
--- a/packages/runtime-core/src/artifact-review.ts
+++ b/packages/runtime-core/src/artifact-review.ts
@@ -136,9 +136,27 @@ export interface ArtifactReviewBrowserSummary {
       passed: number
       failed: number
     }
+    redirectDiagnostics?: ArtifactReviewBrowserRedirectDiagnosticsSummary
     wordpressDiagnostics?: ArtifactReviewBrowserWordPressDiagnosticsSummary
     summaryFile?: string
   }>
+}
+
+export interface ArtifactReviewBrowserRedirectDiagnosticsSummary {
+  status: "captured" | "not-applicable"
+  artifact?: string
+  classification: "redirect-loop" | "redirect-chain"
+  reason: string
+  documentEvents: number
+  redirectResponses: number
+  repeatedUrls: Array<{ url: string; count: number }>
+  repeatedHosts: Array<{ host: string; count: number }>
+  repeatedPaths: Array<{ path: string; count: number }>
+  firstUrl?: string
+  lastUrl?: string
+  finalAttemptedUrl?: string
+  sanitizedQueryKeys: string[]
+  redactedQueryKeys: string[]
 }
 
 export interface ArtifactReviewBrowserWordPressDiagnosticsSummary {

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -73,8 +73,26 @@ export interface BrowserArtifactFiles {
   diffScreenshot?: string | string[]
   visualDiff?: string | string[]
   visualExplanation?: string | string[]
+  redirectDiagnostics?: string
   wordpressDiagnostics?: string
   summary: string
+}
+
+export interface BrowserRedirectDiagnosticsSummary {
+  status: "captured" | "not-applicable"
+  artifact?: string
+  classification: "redirect-loop" | "redirect-chain"
+  reason: string
+  documentEvents: number
+  redirectResponses: number
+  repeatedUrls: Array<{ url: string; count: number }>
+  repeatedHosts: Array<{ host: string; count: number }>
+  repeatedPaths: Array<{ path: string; count: number }>
+  firstUrl?: string
+  lastUrl?: string
+  finalAttemptedUrl?: string
+  sanitizedQueryKeys: string[]
+  redactedQueryKeys: string[]
 }
 
 export interface BrowserWordPressDiagnosticsSummary {
@@ -121,6 +139,7 @@ export interface BrowserArtifactSummary {
   performance?: BrowserProbePerformanceSummary
   progress?: BrowserProbeProgressSummary
   review?: BrowserProbeReviewSummary
+  redirectDiagnostics?: BrowserRedirectDiagnosticsSummary
   wordpressDiagnostics?: BrowserWordPressDiagnosticsSummary
   context?: BrowserProbeContextDetails
   auth?: BrowserProbeAuthSummary
@@ -242,6 +261,7 @@ export interface BrowserProbeReviewSummary {
     probe: BrowserProbeIssueSummary
   }
   network: BrowserProbeNetworkReviewSummary
+  redirectDiagnostics?: BrowserRedirectDiagnosticsSummary
   wordpressDiagnostics?: BrowserWordPressDiagnosticsSummary
   milestones: BrowserProbeMilestoneSummary
   artifacts: Record<string, BrowserProbeArtifactRef>
@@ -797,6 +817,7 @@ export function browserReviewSummary(probes: BrowserArtifact[]): ArtifactReviewB
       ...(probe.summary.assertions ? { assertions: { total: probe.summary.assertions.total, passed: probe.summary.assertions.passed, failed: probe.summary.assertions.failed } } : {}),
       performance: probe.files.performance,
       visualCompare: probe.summary.visualCompare,
+      redirectDiagnostics: probe.summary.redirectDiagnostics,
       wordpressDiagnostics: probe.summary.wordpressDiagnostics,
       summaryFile: probe.files.summary,
     })),
@@ -850,6 +871,7 @@ const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, Browser
   diffScreenshot: { kind: "browser-visual-diff-screenshot", contentType: "image/png", redact: false },
   visualDiff: { kind: "browser-visual-diff", contentType: "application/json", redact: true },
   visualExplanation: { kind: "browser-visual-explanation", contentType: "application/json", redact: true },
+  redirectDiagnostics: { kind: "browser-redirect-diagnostics", contentType: "application/json", redact: true },
   wordpressDiagnostics: { kind: "browser-wordpress-diagnostics", contentType: "application/json", redact: true },
   summary: { kind: "browser-summary", contentType: "application/json", redact: true },
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -5,7 +5,7 @@ import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, vali
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
 import { browserInteractionStepsFromArgs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
-import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserStepRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
+import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserRedirectDiagnosticsSummary, BrowserStepRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
@@ -409,6 +409,7 @@ async function runSingleBrowserProbeCommand({
   const reviewPath = join(browserDirectory, "review.json")
   const screenshotPath = join(browserDirectory, "screenshot.png")
   const summaryPath = join(browserDirectory, "summary.json")
+  const redirectDiagnosticsPath = join(browserDirectory, "redirect-diagnostics.json")
   const wordpressDiagnosticsPath = join(browserDirectory, "wordpress-diagnostics.json")
   const startedAt = now()
   const startedAtMs = Date.now()
@@ -615,6 +616,18 @@ async function runSingleBrowserProbeCommand({
       await writeFile(performancePath, `${JSON.stringify(performanceArtifact, null, 2)}\n`)
     }
 
+    const redirectDiagnostics = browserRedirectDiagnosticsArtifact({
+      artifactPath: `${browserFilesDirectory}/redirect-diagnostics.json`,
+      error: pendingError,
+      finalAttemptedUrl: finalUrl,
+      network,
+      requestedUrl: targetUrl,
+    })
+    if (redirectDiagnostics) {
+      await writeFile(redirectDiagnosticsPath, `${JSON.stringify(redirectDiagnostics, null, 2)}\n`)
+    }
+    const redirectDiagnosticsSummary = redirectDiagnostics?.summary
+
     const wordpressDiagnostics = await browserWordPressDiagnosticsArtifact({
       artifactPath: `${browserFilesDirectory}/wordpress-diagnostics.json`,
       network,
@@ -655,6 +668,7 @@ async function runSingleBrowserProbeCommand({
         memory: Boolean(memoryArtifact),
         network: capture.has("network") || capturesNetworkForAssertions,
         performance: Boolean(performanceArtifact),
+        redirectDiagnostics: Boolean(redirectDiagnostics),
         screenshot: capture.has("screenshot") ? screenshotSha256 : undefined,
         wordpressDiagnostics: Boolean(wordpressDiagnostics),
       }),
@@ -666,6 +680,7 @@ async function runSingleBrowserProbeCommand({
       totalDurationMs: Date.now() - startedAtMs,
       viewport,
       waitFor,
+      redirectDiagnostics: redirectDiagnosticsSummary,
       wordpressDiagnostics: wordpressDiagnosticsSummary,
     })
     await writeFile(reviewPath, `${JSON.stringify(review, null, 2)}\n`)
@@ -682,11 +697,12 @@ async function runSingleBrowserProbeCommand({
         ...(capture.has("console") || capturesConsoleForAssertions ? { console: `${browserFilesDirectory}/console.jsonl` } : {}),
         ...(checkpoints.length > 0 ? { checkpoints: `${browserFilesDirectory}/checkpoints.jsonl` } : {}),
         ...(capture.has("errors") || capturesErrorsForAssertions ? { errors: `${browserFilesDirectory}/errors.jsonl` } : {}),
-        ...(capture.has("html") ? { html: `${browserFilesDirectory}/snapshot.html` } : {}),
+        ...(htmlSha256 ? { html: `${browserFilesDirectory}/snapshot.html` } : {}),
         ...(lifecycleArtifact ? { lifecycle: `${browserFilesDirectory}/lifecycle.json` } : {}),
         ...(memoryArtifact ? { memory: `${browserFilesDirectory}/memory.json` } : {}),
         ...(capture.has("network") || capturesNetworkForAssertions ? { network: `${browserFilesDirectory}/network.jsonl` } : {}),
         ...(performanceArtifact ? { performance: `${browserFilesDirectory}/performance.json` } : {}),
+        ...(redirectDiagnostics ? { redirectDiagnostics: `${browserFilesDirectory}/redirect-diagnostics.json` } : {}),
         review: `${browserFilesDirectory}/review.json`,
         ...(capture.has("screenshot") ? { screenshot: `${browserFilesDirectory}/screenshot.png` } : {}),
         ...(wordpressDiagnostics ? { wordpressDiagnostics: `${browserFilesDirectory}/wordpress-diagnostics.json` } : {}),
@@ -698,7 +714,7 @@ async function runSingleBrowserProbeCommand({
         errors: errors.length,
         finalUrl,
         ...(windowLocationOrigin ? { windowLocationOrigin } : {}),
-        htmlSnapshot: capture.has("html"),
+        htmlSnapshot: Boolean(htmlSha256),
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(lifecycleArtifact ? { lifecycle: { schema: lifecycleArtifact.schema, version: lifecycleArtifact.version, startedAtMs: lifecycleArtifact.startedAtMs, selectors: lifecycleArtifact.selectors } } : {}),
         ...(memoryArtifact ? { memory: memoryArtifact.peak } : {}),
@@ -708,6 +724,7 @@ async function runSingleBrowserProbeCommand({
         ...(performanceArtifact ? { performance: performanceArtifact.peak } : {}),
         progress: progress.summary(),
         review,
+        ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
         ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
         context: contextDetails,
         auth: authSummary,
@@ -745,6 +762,7 @@ async function runSingleBrowserProbeCommand({
       auth: authSummary,
       capabilities: capabilityDiagnostics,
       review,
+      ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
       ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
       viewport,
       summary: artifact.summary,
@@ -993,6 +1011,7 @@ function browserProbeReviewSummary(input: {
   totalDurationMs: number
   viewport: BrowserProbeViewport | null
   waitFor: string
+  redirectDiagnostics?: BrowserRedirectDiagnosticsSummary
   wordpressDiagnostics?: BrowserWordPressDiagnosticsSummary
 }): BrowserProbeReviewSummary {
   const performance = input.performanceArtifact?.final
@@ -1056,6 +1075,7 @@ function browserProbeReviewSummary(input: {
       probe: browserProbeIssueSummary(probeErrors.length, Boolean(input.files.errors), input.files.errors?.path),
     },
     network: browserProbeNetworkReviewSummary(input.network, input.files.network),
+    ...(input.redirectDiagnostics ? { redirectDiagnostics: input.redirectDiagnostics } : {}),
     ...(input.wordpressDiagnostics ? { wordpressDiagnostics: input.wordpressDiagnostics } : {}),
     milestones: {
       status: input.checkpoints.length > 0 ? "captured" : "not-captured",
@@ -1141,6 +1161,7 @@ function browserProbeArtifactRefs(browserFilesDirectory: string, capture: Set<st
   memory: boolean
   network: boolean
   performance: boolean
+  redirectDiagnostics: boolean
   screenshot?: string
   wordpressDiagnostics: boolean
 }): Record<string, BrowserProbeArtifactRef> {
@@ -1148,11 +1169,12 @@ function browserProbeArtifactRefs(browserFilesDirectory: string, capture: Set<st
     ...(input.console ? { console: { path: `${browserFilesDirectory}/console.jsonl`, kind: "jsonl" as const } } : {}),
     ...(input.checkpoints ? { checkpoints: { path: `${browserFilesDirectory}/checkpoints.jsonl`, kind: "jsonl" as const } } : {}),
     ...(input.errors ? { errors: { path: `${browserFilesDirectory}/errors.jsonl`, kind: "jsonl" as const } } : {}),
-    ...(capture.has("html") ? { html: { path: `${browserFilesDirectory}/snapshot.html`, kind: "html" as const, ...(input.html ? { sha256: input.html } : {}) } } : {}),
+    ...(input.html ? { html: { path: `${browserFilesDirectory}/snapshot.html`, kind: "html" as const, sha256: input.html } } : {}),
     ...(input.lifecycle ? { lifecycle: { path: `${browserFilesDirectory}/lifecycle.json`, kind: "json" as const } } : {}),
     ...(input.memory ? { memory: { path: `${browserFilesDirectory}/memory.json`, kind: "json" as const } } : {}),
     ...(input.network ? { network: { path: `${browserFilesDirectory}/network.jsonl`, kind: "jsonl" as const } } : {}),
     ...(input.performance ? { performance: { path: `${browserFilesDirectory}/performance.json`, kind: "json" as const } } : {}),
+    ...(input.redirectDiagnostics ? { redirectDiagnostics: { path: `${browserFilesDirectory}/redirect-diagnostics.json`, kind: "json" as const } } : {}),
     review: { path: `${browserFilesDirectory}/review.json`, kind: "json" as const },
     ...(capture.has("screenshot") ? { screenshot: { path: `${browserFilesDirectory}/screenshot.png`, kind: "png" as const, ...(input.screenshot ? { sha256: input.screenshot } : {}) } } : {}),
     ...(input.wordpressDiagnostics ? { wordpressDiagnostics: { path: `${browserFilesDirectory}/wordpress-diagnostics.json`, kind: "json" as const } } : {}),
@@ -1168,6 +1190,165 @@ function safeBrowserProbeUrl(value: string | undefined): string | null {
     return "data:[redacted]"
   }
   return value
+}
+
+interface BrowserRedirectDiagnosticsArtifact {
+  schema: "wp-codebox/browser-redirect-diagnostics/v1"
+  version: 1
+  capturedAt: string
+  status: BrowserRedirectDiagnosticsSummary["status"]
+  classification: BrowserRedirectDiagnosticsSummary["classification"]
+  reason: string
+  error?: { name: string; message: string }
+  chain: BrowserRedirectDiagnosticsChainEntry[]
+  summary: BrowserRedirectDiagnosticsSummary
+}
+
+interface BrowserRedirectDiagnosticsChainEntry {
+  url: string
+  method: string
+  status?: number
+  statusText?: string
+  timestamp: string
+  host?: string
+  path?: string
+  queryKeys: string[]
+  redactedQueryKeys: string[]
+}
+
+function browserRedirectDiagnosticsArtifact({
+  artifactPath,
+  error,
+  finalAttemptedUrl,
+  network,
+  requestedUrl,
+}: {
+  artifactPath: string
+  error?: Error
+  finalAttemptedUrl: string
+  network: BrowserProbeNetworkRecord[]
+  requestedUrl: string
+}): BrowserRedirectDiagnosticsArtifact | undefined {
+  const errorMessage = error?.message ?? ""
+  const tooManyRedirects = /ERR_TOO_MANY_REDIRECTS/i.test(errorMessage)
+  const documentEvents = network.filter((record) => record.resourceType === "document")
+  const redirectResponses = documentEvents.filter((record) => record.type === "response" && typeof record.status === "number" && record.status >= 300 && record.status < 400)
+  const chain = documentEvents.map(browserRedirectDiagnosticsChainEntry)
+  const repeatedUrls = repeatedBrowserRedirectValues(chain.map((entry) => entry.url), "url")
+  const repeatedHosts = repeatedBrowserRedirectValues(chain.map((entry) => entry.host).filter((host): host is string => Boolean(host)), "host")
+  const repeatedPaths = repeatedBrowserRedirectValues(chain.map((entry) => entry.path).filter((path): path is string => Boolean(path)), "path")
+  const hasRepeatedTarget = repeatedUrls.length > 0 || repeatedHosts.length > 0 || repeatedPaths.length > 0
+
+  if (!tooManyRedirects && redirectResponses.length === 0 && !hasRepeatedTarget) {
+    return undefined
+  }
+
+  const finalAttempted = browserRedirectSafeUrl(extractBrowserNavigationUrl(errorMessage) ?? finalAttemptedUrl)
+  const firstUrl = chain[0]?.url ?? browserRedirectSafeUrl(requestedUrl)
+  const lastUrl = chain.at(-1)?.url ?? finalAttempted
+  const sanitizedQueryKeys = [...new Set(chain.flatMap((entry) => entry.queryKeys))].sort()
+  const redactedQueryKeys = [...new Set(chain.flatMap((entry) => entry.redactedQueryKeys))].sort()
+  const classification: BrowserRedirectDiagnosticsSummary["classification"] = tooManyRedirects || hasRepeatedTarget ? "redirect-loop" : "redirect-chain"
+  const reason = tooManyRedirects
+    ? "playwright reported ERR_TOO_MANY_REDIRECTS"
+    : hasRepeatedTarget ? "document navigation repeated URL, host, or path values" : "document navigation included redirect responses"
+  const summary: BrowserRedirectDiagnosticsSummary = {
+    status: "captured",
+    artifact: artifactPath,
+    classification,
+    reason,
+    documentEvents: chain.length,
+    redirectResponses: redirectResponses.length,
+    repeatedUrls,
+    repeatedHosts,
+    repeatedPaths,
+    ...(firstUrl ? { firstUrl } : {}),
+    ...(lastUrl ? { lastUrl } : {}),
+    ...(finalAttempted ? { finalAttemptedUrl: finalAttempted } : {}),
+    sanitizedQueryKeys,
+    redactedQueryKeys,
+  }
+
+  return {
+    schema: "wp-codebox/browser-redirect-diagnostics/v1",
+    version: 1,
+    capturedAt: now(),
+    status: "captured",
+    classification,
+    reason,
+    ...(error ? { error: { name: error.name, message: sanitizeBrowserRedirectMessage(error.message) } } : {}),
+    chain,
+    summary,
+  }
+}
+
+function browserRedirectDiagnosticsChainEntry(record: BrowserProbeNetworkRecord): BrowserRedirectDiagnosticsChainEntry {
+  const parsed = parseBrowserRedirectUrl(record.url)
+  return {
+    url: browserRedirectSafeUrl(record.url),
+    method: record.method,
+    ...(typeof record.status === "number" ? { status: record.status } : {}),
+    ...(record.statusText ? { statusText: record.statusText } : {}),
+    timestamp: record.timestamp,
+    ...(parsed ? { host: parsed.host, path: parsed.pathname } : {}),
+    queryKeys: parsed?.queryKeys ?? [],
+    redactedQueryKeys: parsed?.redactedQueryKeys ?? [],
+  }
+}
+
+function browserRedirectSafeUrl(value: string): string {
+  if (/^data:/i.test(value)) {
+    return "data:[redacted]"
+  }
+  const parsed = parseBrowserRedirectUrl(value)
+  if (!parsed) {
+    return value
+  }
+  const search = parsed.queryKeys.length > 0
+    ? `?${parsed.queryKeys.map((key) => `${encodeURIComponent(key)}=[redacted]`).join("&")}`
+    : ""
+  return `${parsed.origin}${parsed.pathname}${search}${parsed.hash ? "#[redacted]" : ""}`
+}
+
+function parseBrowserRedirectUrl(value: string): { origin: string; host: string; pathname: string; hash: string; queryKeys: string[]; redactedQueryKeys: string[] } | undefined {
+  try {
+    const url = new URL(value)
+    const queryKeys = [...new Set([...url.searchParams.keys()])].sort()
+    return {
+      origin: url.origin,
+      host: url.host,
+      pathname: url.pathname || "/",
+      hash: url.hash,
+      queryKeys,
+      redactedQueryKeys: queryKeys.filter(isSensitiveBrowserRedirectQueryKey),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function isSensitiveBrowserRedirectQueryKey(key: string): boolean {
+  const tokens = key.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+  return tokens.some((token) => ["auth", "bearer", "code", "cookie", "credential", "key", "login", "nonce", "pass", "password", "secret", "session", "state", "token"].includes(token))
+}
+
+function repeatedBrowserRedirectValues<Key extends "url" | "host" | "path">(values: string[], key: Key): Array<Record<Key, string> & { count: number }> {
+  const counts = new Map<string, number>()
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .sort(([leftValue, leftCount], [rightValue, rightCount]) => rightCount - leftCount || leftValue.localeCompare(rightValue))
+    .map(([value, count]) => ({ [key]: value, count }) as Record<Key, string> & { count: number })
+}
+
+function extractBrowserNavigationUrl(message: string): string | undefined {
+  return message.match(/\bat\s+(https?:\/\/\S+)/i)?.[1]?.replace(/[),.]+$/, "")
+}
+
+function sanitizeBrowserRedirectMessage(message: string): string {
+  return message.replace(/https?:\/\/[^\s"')]+/gi, (url) => browserRedirectSafeUrl(url.replace(/[),.]+$/, "")))
 }
 
 interface BrowserWordPressDiagnosticRecord {
@@ -1900,6 +2081,7 @@ export async function runBrowserActionsCommand({
   const screenshotPath = join(browserDirectory, "screenshot.png")
   const domSnapshotPath = join(browserDirectory, "dom-snapshot.json")
   const summaryPath = join(browserDirectory, "action-summary.json")
+  const redirectDiagnosticsPath = join(browserDirectory, "redirect-diagnostics.json")
   const wordpressDiagnosticsPath = join(browserDirectory, "wordpress-diagnostics.json")
   const startedAt = now()
   const startedAtMs = Date.now()
@@ -2044,6 +2226,18 @@ export async function runBrowserActionsCommand({
       await writeFile(networkPath, jsonLines(network))
     }
 
+    const redirectDiagnostics = browserRedirectDiagnosticsArtifact({
+      artifactPath: "files/browser/redirect-diagnostics.json",
+      error: pendingError,
+      finalAttemptedUrl: finalUrl,
+      network,
+      requestedUrl,
+    })
+    if (redirectDiagnostics) {
+      await writeFile(redirectDiagnosticsPath, `${JSON.stringify(redirectDiagnostics, null, 2)}\n`)
+    }
+    const redirectDiagnosticsSummary = redirectDiagnostics?.summary
+
     const wordpressDiagnostics = await browserWordPressDiagnosticsArtifact({
       artifactPath: "files/browser/wordpress-diagnostics.json",
       network,
@@ -2067,8 +2261,9 @@ export async function runBrowserActionsCommand({
         ...(capture.has("steps") ? { steps: "files/browser/steps.jsonl" } : {}),
         ...(capture.has("console") ? { console: "files/browser/console.jsonl" } : {}),
         ...(capture.has("errors") ? { errors: "files/browser/errors.jsonl" } : {}),
-        ...(capture.has("html") ? { html: "files/browser/snapshot.html" } : {}),
+        ...(htmlSha256 ? { html: "files/browser/snapshot.html" } : {}),
         ...(capture.has("network") ? { network: "files/browser/network.jsonl" } : {}),
+        ...(redirectDiagnostics ? { redirectDiagnostics: "files/browser/redirect-diagnostics.json" } : {}),
         ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots: domSnapshots.map((snapshot) => snapshot.snapshot) } : {}),
         ...(wordpressDiagnostics ? { wordpressDiagnostics: "files/browser/wordpress-diagnostics.json" } : {}),
@@ -2081,10 +2276,11 @@ export async function runBrowserActionsCommand({
         consoleMessages: consoleMessages.length,
         errors: errors.length,
         finalUrl,
-        htmlSnapshot: capture.has("html"),
+        htmlSnapshot: Boolean(htmlSha256),
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots } : {}),
         networkEvents: network.length,
+        ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
         ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
         replayability: browserProbeReplayability(capture),
         screenshot: capture.has("screenshot"),
@@ -2112,6 +2308,7 @@ export async function runBrowserActionsCommand({
       limits: {
         maxDomSnapshotElements,
       },
+      ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
       ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
       viewport,
       summary: artifact.summary,

--- a/scripts/browser-redirect-chain-diagnostics-smoke.ts
+++ b/scripts/browser-redirect-chain-diagnostics-smoke.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const workspace = resolve(repoRoot, "artifacts", "browser-redirect-chain-diagnostics-smoke")
+const pluginDir = join(workspace, "redirect-loop-fixture")
+const recipePath = join(workspace, "recipe.json")
+const actionRecipePath = join(workspace, "action-recipe.json")
+const artifactsRoot = join(workspace, "artifacts")
+const actionArtifactsRoot = join(workspace, "action-artifacts")
+
+await rm(workspace, { recursive: true, force: true })
+await mkdir(pluginDir, { recursive: true })
+
+await writeFile(join(pluginDir, "redirect-loop-fixture.php"), `<?php
+/**
+ * Plugin Name: Browser Redirect Loop Diagnostics Fixture
+ */
+
+add_action( 'template_redirect', static function (): void {
+    if ( isset( $_GET['wp_codebox_redirect_loop'] ) ) {
+        wp_safe_redirect( home_url( '/?wp_codebox_redirect_loop=1&token=super-secret-token&safe=visible' ), 302 );
+        exit;
+    }
+} );
+`)
+
+await writeFile(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extra_plugins: [
+      {
+        source: "./redirect-loop-fixture",
+        plugin_file: "redirect-loop-fixture/redirect-loop-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.browser-probe",
+        args: ["url=/?wp_codebox_redirect_loop=1&token=super-secret-token&safe=visible", "capture=network,errors,html"],
+      },
+    ],
+  },
+  artifacts: {
+    directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+await writeFile(actionRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extra_plugins: [
+      {
+        source: "./redirect-loop-fixture",
+        plugin_file: "redirect-loop-fixture/redirect-loop-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.browser-actions",
+        args: [
+          "url=/",
+          `steps-json=${JSON.stringify([{ kind: "navigate", url: "/?wp_codebox_redirect_loop=1&token=super-secret-token&safe=visible" }])}`,
+          "capture=steps,network,errors,html",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: actionArtifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const run = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--json",
+])
+
+assert.notEqual(run.exitCode, 0, "redirect-loop recipe should fail navigation")
+assert.equal(run.output.success, false, "recipe-run should report navigation failure")
+assert.match(run.output.error?.message ?? "", /ERR_TOO_MANY_REDIRECTS|redirect/i)
+assert.ok(run.output.artifacts?.directory, "failed recipe-run should return an artifact directory")
+
+const artifactDirectory = run.output.artifacts.directory
+const diagnosticsPath = join(artifactDirectory, "files", "browser", "redirect-diagnostics.json")
+const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
+const reviewPath = join(artifactDirectory, "files", "review.json")
+const manifestPath = join(artifactDirectory, "manifest.json")
+
+assert.equal(existsSync(diagnosticsPath), true, "redirect-diagnostics.json should be captured for document redirect loops")
+
+const diagnostics = JSON.parse(await readFile(diagnosticsPath, "utf8")) as {
+  schema: string
+  status: string
+  classification: string
+  reason: string
+  chain: Array<{ url: string; status?: number; host?: string; path?: string; queryKeys: string[]; redactedQueryKeys: string[] }>
+  summary: {
+    artifact?: string
+    classification: string
+    documentEvents: number
+    redirectResponses: number
+    repeatedUrls: Array<{ url: string; count: number }>
+    repeatedHosts: Array<{ host: string; count: number }>
+    repeatedPaths: Array<{ path: string; count: number }>
+    firstUrl?: string
+    lastUrl?: string
+    finalAttemptedUrl?: string
+    sanitizedQueryKeys: string[]
+    redactedQueryKeys: string[]
+  }
+}
+
+assert.equal(diagnostics.schema, "wp-codebox/browser-redirect-diagnostics/v1")
+assert.equal(diagnostics.status, "captured")
+assert.equal(diagnostics.classification, "redirect-loop")
+assert.match(diagnostics.reason, /ERR_TOO_MANY_REDIRECTS|repeated/i)
+assert.ok(diagnostics.chain.length >= 2, "diagnostic chain should include repeated document navigation events")
+assert.ok(diagnostics.summary.redirectResponses >= 1, "summary should count document redirect responses")
+assert.ok(diagnostics.summary.repeatedUrls.some((entry) => entry.count >= 2), "summary should report repeated sanitized URLs")
+assert.ok(diagnostics.summary.repeatedHosts.some((entry) => entry.count >= 2), "summary should report repeated hosts")
+assert.ok(diagnostics.summary.repeatedPaths.some((entry) => entry.path === "/" && entry.count >= 2), "summary should report repeated paths")
+assert.equal(diagnostics.summary.artifact, "files/browser/redirect-diagnostics.json")
+assert.ok(diagnostics.summary.firstUrl?.includes("token=[redacted]"), "summary should redact query values")
+assert.ok(diagnostics.summary.lastUrl?.includes("token=[redacted]"), "summary should redact query values")
+assert.ok(diagnostics.summary.finalAttemptedUrl?.includes("token=[redacted]"), "summary should redact final attempted query values")
+assert.deepEqual(diagnostics.summary.sanitizedQueryKeys, ["safe", "token", "wp_codebox_redirect_loop"])
+assert.deepEqual(diagnostics.summary.redactedQueryKeys, ["token"])
+assert.doesNotMatch(JSON.stringify(diagnostics), /super-secret-token/, "diagnostics artifact must not expose sensitive query values")
+
+const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
+  files: { redirectDiagnostics?: string }
+  summary: { redirectDiagnostics?: { artifact?: string; classification: string; redirectResponses: number } }
+  redirectDiagnostics?: { artifact?: string; classification: string }
+}
+assert.equal(summary.files.redirectDiagnostics, "files/browser/redirect-diagnostics.json")
+assert.equal(summary.redirectDiagnostics?.artifact, "files/browser/redirect-diagnostics.json")
+assert.equal(summary.redirectDiagnostics?.classification, "redirect-loop")
+assert.equal(summary.summary.redirectDiagnostics?.artifact, "files/browser/redirect-diagnostics.json")
+assert.equal(summary.summary.redirectDiagnostics?.classification, "redirect-loop")
+assert.ok(summary.summary.redirectDiagnostics?.redirectResponses ?? 0 >= 1)
+
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ redirectDiagnostics?: { artifact?: string; classification: string } }> } }
+assert.equal(review.browser?.probes?.[0]?.redirectDiagnostics?.artifact, "files/browser/redirect-diagnostics.json")
+assert.equal(review.browser?.probes?.[0]?.redirectDiagnostics?.classification, "redirect-loop")
+
+const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
+assert.ok(manifest.files.some((file) => file.path === "files/browser/redirect-diagnostics.json" && file.kind === "browser-redirect-diagnostics"))
+
+const actionRun = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  actionRecipePath,
+  "--json",
+])
+
+assert.notEqual(actionRun.exitCode, 0, "redirect-loop browser-actions recipe should fail navigation")
+assert.equal(actionRun.output.success, false, "browser-actions recipe-run should report navigation failure")
+assert.match(actionRun.output.error?.message ?? "", /ERR_TOO_MANY_REDIRECTS|redirect/i)
+assert.ok(actionRun.output.artifacts?.directory, "failed browser-actions recipe-run should return an artifact directory")
+
+const actionArtifactDirectory = actionRun.output.artifacts.directory
+const actionDiagnosticsPath = join(actionArtifactDirectory, "files", "browser", "redirect-diagnostics.json")
+const actionSummaryPath = join(actionArtifactDirectory, "files", "browser", "action-summary.json")
+const actionReviewPath = join(actionArtifactDirectory, "files", "review.json")
+const actionManifestPath = join(actionArtifactDirectory, "manifest.json")
+
+assert.equal(existsSync(actionDiagnosticsPath), true, "browser-actions should capture redirect-diagnostics.json")
+assert.doesNotMatch(await readFile(actionDiagnosticsPath, "utf8"), /super-secret-token/, "browser-actions diagnostics must not expose sensitive query values")
+
+const actionSummary = JSON.parse(await readFile(actionSummaryPath, "utf8")) as {
+  files: { redirectDiagnostics?: string }
+  redirectDiagnostics?: { artifact?: string; classification: string }
+  summary: { redirectDiagnostics?: { artifact?: string; classification: string; redirectResponses: number } }
+}
+assert.equal(actionSummary.files.redirectDiagnostics, "files/browser/redirect-diagnostics.json")
+assert.equal(actionSummary.redirectDiagnostics?.artifact, "files/browser/redirect-diagnostics.json")
+assert.equal(actionSummary.redirectDiagnostics?.classification, "redirect-loop")
+assert.equal(actionSummary.summary.redirectDiagnostics?.artifact, "files/browser/redirect-diagnostics.json")
+assert.equal(actionSummary.summary.redirectDiagnostics?.classification, "redirect-loop")
+assert.ok(actionSummary.summary.redirectDiagnostics?.redirectResponses ?? 0 >= 1)
+
+const actionReview = JSON.parse(await readFile(actionReviewPath, "utf8")) as { browser?: { probes?: Array<{ redirectDiagnostics?: { artifact?: string; classification: string } }> } }
+assert.equal(actionReview.browser?.probes?.[0]?.redirectDiagnostics?.artifact, "files/browser/redirect-diagnostics.json")
+assert.equal(actionReview.browser?.probes?.[0]?.redirectDiagnostics?.classification, "redirect-loop")
+
+const actionManifest = JSON.parse(await readFile(actionManifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
+assert.ok(actionManifest.files.some((file) => file.path === "files/browser/redirect-diagnostics.json" && file.kind === "browser-redirect-diagnostics"))
+
+console.log(`Browser redirect-chain diagnostics smoke passed: probe=${artifactDirectory} actions=${actionArtifactDirectory}`)
+
+async function runCli(args: string[]): Promise<{ exitCode: number | null; output: any; stdout: string; stderr: string }> {
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+
+  let stdout = ""
+  let stderr = ""
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString()
+  })
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString()
+  })
+
+  const exitCode = await new Promise<number | null>((resolveExit) => child.once("exit", (code) => resolveExit(code)))
+  assert.ok(stdout.trim().length > 0, `CLI should emit JSON to stdout\nSTDERR:\n${stderr}`)
+  return { exitCode, output: JSON.parse(stdout), stdout, stderr }
+}


### PR DESCRIPTION
## Summary
- Capture sanitized redirect-chain diagnostics for browser probe and browser actions runs when navigation redirects or loops.
- Surface the redirect diagnostics in browser summaries, review output, artifact manifests, and artifact-review summaries.
- Avoid dangling HTML artifact references when failed navigation prevents `snapshot.html` capture, preserving failed-run artifact bundles.

## Verification
- `npm run build`
- `npx tsx scripts/browser-redirect-chain-diagnostics-smoke.ts`

Fixes #898

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the redirect diagnostics capture, smoke coverage, conflict resolution, and local verification; Chris remains responsible for review and merge.