### PR TITLE
Persist browser auth session tokens

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -4871,6 +4871,10 @@ if ( ! $user ) {
 }
 wp_set_current_user( $user_id );
 $expiration = time() + HOUR_IN_SECONDS;
+$token = '';
+if ( class_exists( 'WP_Session_Tokens' ) ) {
+    $token = WP_Session_Tokens::get_instance( $user_id )->create( $expiration );
+}
 $browser_urls = ${JSON.stringify(browserUrls)};
 $cookies = array();
 foreach ( $browser_urls as $browser_url ) {
@@ -4879,20 +4883,21 @@ foreach ( $browser_urls as $browser_url ) {
         continue;
     }
     $secure = 'https' === wp_parse_url( $browser_url, PHP_URL_SCHEME );
-    $auth_scheme = $secure ? 'secure_auth' : 'auth';
-    $cookies[] = array(
-        'name'     => $secure ? SECURE_AUTH_COOKIE : AUTH_COOKIE,
-        'value'    => wp_generate_auth_cookie( $user_id, $expiration, $auth_scheme ),
-        'domain'   => $browser_host,
-        'path'     => defined( 'ADMIN_COOKIE_PATH' ) && ADMIN_COOKIE_PATH ? ADMIN_COOKIE_PATH : '/wp-admin',
-        'expires'  => $expiration,
-        'httpOnly' => true,
-        'secure'   => $secure,
-        'sameSite' => 'Lax',
-    );
+    foreach ( array( array( AUTH_COOKIE, 'auth', false ), array( SECURE_AUTH_COOKIE, 'secure_auth', true ) ) as $admin_cookie ) {
+        $cookies[] = array(
+            'name'     => $admin_cookie[0],
+            'value'    => wp_generate_auth_cookie( $user_id, $expiration, $admin_cookie[1], $token ),
+            'domain'   => $browser_host,
+            'path'     => defined( 'ADMIN_COOKIE_PATH' ) && ADMIN_COOKIE_PATH ? ADMIN_COOKIE_PATH : '/wp-admin',
+            'expires'  => $expiration,
+            'httpOnly' => true,
+            'secure'   => $admin_cookie[2],
+            'sameSite' => 'Lax',
+        );
+    }
     $logged_in_cookie = array(
         'name'     => LOGGED_IN_COOKIE,
-        'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in' ),
+        'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in', $token ),
         'domain'   => $browser_host,
         'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
         'expires'  => $expiration,

--- a/scripts/browser-auth-session-token-smoke.ts
+++ b/scripts/browser-auth-session-token-smoke.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const source = await readFile(resolve(repoRoot, "packages/runtime-playground/src/browser-command-runners.ts"), "utf8")
+const helper = source.slice(source.indexOf("function wordpressAdminAuthCookiePhpCode"), source.indexOf("function browserAuthCookieUrls"))
+
+assert.match(helper, /WP_Session_Tokens::get_instance\( \$user_id \)->create\( \$expiration \)/, "browser admin auth must create a persisted WordPress session token")
+assert.match(helper, /array\( AUTH_COOKIE, 'auth', false \), array\( SECURE_AUTH_COOKIE, 'secure_auth', true \)/, "browser admin auth must install both non-secure and secure admin cookie schemes")
+assert.match(helper, /wp_generate_auth_cookie\( \$user_id, \$expiration, \$admin_cookie\[1\], \$token \)/, "browser admin auth cookies must reuse the persisted token")
+assert.match(helper, /wp_generate_auth_cookie\( \$user_id, \$expiration, 'logged_in', \$token \)/, "logged-in browser auth cookies must reuse the persisted token")
+assert.doesNotMatch(helper, /echo\s+\$token|token_printed|value_printed/i, "browser auth helper must not expose session token values")
+
+console.log("Browser auth session token smoke passed.")


### PR DESCRIPTION
## Summary
- Create a persisted WordPress session token before generating browser `auth=wordpress-admin` cookies.
- Reuse that token for all generated admin/logged-in cookies.
- Install both non-secure and secure admin auth cookie schemes for each browser host so routed local previews that move between local HTTP and HTTPS host routes can still authenticate.

## Verification
- `npm run build`
- `npx tsx scripts/browser-auth-session-token-smoke.ts`
- Downstream `wpcom-codebox` proof advanced from `local-editor-auth-redirect-loop` to `local-editor-http-500` with `browser_auth_count: 12`.

Fixes #906

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the browser auth/session-token mismatch, implemented the auth helper fix and smoke coverage, and verified against the downstream WPCOM proof; Chris remains responsible for review and merge.