### PR TITLE
Preserve capture-html failure artifacts

### DIFF
--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -450,7 +450,15 @@ class PlaygroundRuntime implements Runtime {
 
   async runHtmlCapture(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
-    const result = await runHtmlCaptureCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec })
+    let result: Awaited<ReturnType<typeof runHtmlCaptureCommand>>
+    try {
+      result = await runHtmlCaptureCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec })
+    } catch (error) {
+      if (isBrowserCommandArtifactError(error)) {
+        this.browserProbes.push(error.artifact)
+      }
+      throw error
+    }
     this.browserProbes.push(result.artifact)
     return result.output
   }


### PR DESCRIPTION
## Summary
- Preserve partial `wordpress.capture-html` browser artifacts when navigation fails, matching `wordpress.browser-probe` failure handling.
- Ensures redirect-chain diagnostics from #905 remain visible in review/manifest metadata for capture-html failures.

## Tests
- `npm run build`
- `npx tsx scripts/browser-redirect-chain-diagnostics-smoke.ts`
- `npx tsx scripts/browser-wordpress-500-diagnostics-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the capture-html failure artifact preservation follow-up, inspected #898/#894/#895/#905 context, and ran verification commands; Chris remains responsible for review and merge.