### PR TITLE
Harden browser evidence capture

### DIFF
--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -181,7 +181,7 @@ export interface BrowserEditorCanvasProbeSummary {
 }
 
 export interface BrowserEditorCanvasProbeDiagnostic {
-  code: "iframe-missing" | "layout-missing" | "no-blocks" | "loading-state" | "timeout" | "screenshot-failed"
+  code: "iframe-missing" | "layout-missing" | "no-blocks" | "loading-state" | "timeout" | "screenshot-failed" | "screenshot-fallback"
   severity: "error" | "warning" | "info"
   message: string
   details?: Record<string, unknown>
@@ -692,8 +692,14 @@ export interface BrowserStepRecord {
   readiness?: BrowserStepReadiness
   target?: BrowserStepScreenshotTarget
   screenshot?: string
+  screenshotFallback?: BrowserStepScreenshotFallback
   finalUrl?: string
   error?: BrowserProbeErrorRecord
+}
+
+export interface BrowserStepScreenshotFallback {
+  mode: "page-screenshot"
+  reason: string
 }
 
 export interface BrowserStepScreenshotTarget {

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -73,6 +73,19 @@ interface BrowserRunPlan {
   actions?: BrowserActionsRunPlan
 }
 
+interface BrowserCommandProgressEvent {
+  command: string
+  phase: "checkpoint"
+  checkpoint: BrowserProbeScriptCheckpoint
+  progress: ReturnType<ReturnType<typeof createBrowserProbeProgressTracker>["summary"]>
+}
+
+interface BrowserProbeScriptCheckpoint {
+  name: string
+  metadata?: unknown
+  timestamp: string
+}
+
 interface VisualCompareDomElementSnapshot {
   path: string
   tag: string
@@ -258,6 +271,7 @@ export async function runBrowserProbeCommand({
   runPlaygroundCommand,
   server,
   spec,
+  onProgress,
 }: {
   artifactRoot: string
   command?: string
@@ -266,9 +280,10 @@ export async function runBrowserProbeCommand({
   runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
   server: PlaygroundCliServer
   spec: ExecutionSpec
+  onProgress?: (event: BrowserCommandProgressEvent) => void
 }): Promise<{ artifact: BrowserProbeArtifact; artifacts?: BrowserProbeArtifact[]; output: string }> {
   if (plan) {
-    return runSingleBrowserProbeCommand({ artifactRoot, command, plan, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser" })
+    return runSingleBrowserProbeCommand({ artifactRoot, command, plan, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser", onProgress })
   }
 
   const profileIds = browserProbeProfileIds(spec.args ?? [])
@@ -288,9 +303,10 @@ export async function runBrowserProbeCommand({
         spec: { ...spec, args: browserProbeProfileArgs(spec.args ?? [], profile) },
         browserFilesDirectory: "files/browser",
         profileId: profile.id,
+        onProgress,
       })
     }
-    return runSingleBrowserProbeCommand({ artifactRoot, command, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser" })
+    return runSingleBrowserProbeCommand({ artifactRoot, command, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser", onProgress })
   }
 
   const profiles = profileIds.map((profileId) => browserProbeProfile(profileId))
@@ -315,6 +331,7 @@ export async function runBrowserProbeCommand({
       },
       browserFilesDirectory: `files/browser/${profile.id}`,
       profileId: profile.id,
+      onProgress,
     })
     artifacts.push(result.artifact)
     outputs.push(JSON.parse(result.output))
@@ -346,6 +363,7 @@ async function runSingleBrowserProbeCommand({
   spec,
   browserFilesDirectory,
   profileId,
+  onProgress,
 }: {
   artifactRoot: string
   command: string
@@ -356,6 +374,7 @@ async function runSingleBrowserProbeCommand({
   spec: ExecutionSpec
   browserFilesDirectory: string
   profileId?: string
+  onProgress?: (event: BrowserCommandProgressEvent) => void
 }): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
   const args = spec.args ?? []
   const runPlan = plan ?? browserProbeRunPlanFromArgs(args, profileId)
@@ -464,6 +483,16 @@ async function runSingleBrowserProbeCommand({
       await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
     }
     page = context ? await context.newPage() : await browser.newPage()
+    if (onProgress) {
+      await page.exposeFunction("__wpCodeboxProbeCheckpointEvent", (checkpoint: unknown) => {
+        const normalized = normalizeBrowserProbeScriptCheckpoint(checkpoint)
+        if (!normalized) {
+          return
+        }
+        progress.mark("checkpoint", normalized.timestamp, normalized)
+        onProgress({ command, phase: "checkpoint", checkpoint: normalized, progress: progress.summary() })
+      })
+    }
     if (authRequest) {
       authSummary = await installWordPressAdminAuthCookies({ command, cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
     }
@@ -1667,7 +1696,16 @@ export async function runEditorCanvasProbeCommand({
 
     if (probe.ready && capture.has("screenshot")) {
       try {
-        await probe.frame.locator(layoutSelector).first().screenshot({ path: screenshotPath, timeout: timeoutMs })
+        try {
+          await probe.frame.locator(layoutSelector).first().screenshot({ path: screenshotPath, timeout: timeoutMs })
+        } catch (error) {
+          probe.summary.diagnostics.push({
+            code: "screenshot-fallback",
+            severity: "warning",
+            message: `Frame screenshot was unstable; captured full page fallback instead: ${error instanceof Error ? error.message : String(error)}`,
+          })
+          await probe.frame.page().screenshot({ path: screenshotPath, fullPage: true })
+        }
         screenshotSha256 = await fileSha256(screenshotPath)
       } catch (error) {
         probe.summary.diagnostics.push({
@@ -2037,6 +2075,7 @@ export async function runBrowserActionsCommand({
   runPlaygroundCommand,
   server,
   spec,
+  onProgress,
 }: {
   artifactRoot: string
   plan?: BrowserActionsRunPlan
@@ -2044,6 +2083,7 @@ export async function runBrowserActionsCommand({
   runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
   server: PlaygroundCliServer
   spec: ExecutionSpec
+  onProgress?: (event: BrowserCommandProgressEvent) => void
 }): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
   const runPlan = plan ?? await browserActionsRunPlanFromArgs(args)
@@ -2100,6 +2140,7 @@ export async function runBrowserActionsCommand({
   const wordpressDiagnosticsPath = join(browserDirectory, "wordpress-diagnostics.json")
   const startedAt = now()
   const startedAtMs = Date.now()
+  const progress = createBrowserProbeProgressTracker(startedAt, 0)
   const browser = await launchChromiumBrowser()
   const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
   const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
@@ -2121,6 +2162,17 @@ export async function runBrowserActionsCommand({
       await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
+    if (onProgress) {
+      await page.exposeFunction("__wpCodeboxProbeCheckpointEvent", (checkpoint: unknown) => {
+        const normalized = normalizeBrowserProbeScriptCheckpoint(checkpoint)
+        if (!normalized) {
+          return
+        }
+        progress.mark("checkpoint", normalized.timestamp, normalized)
+        onProgress({ command: "wordpress.browser-actions", phase: "checkpoint", checkpoint: normalized, progress: progress.summary() })
+      })
+    }
+    await page.addInitScript(BROWSER_PROBE_STATE_INIT_SCRIPT)
     if (authRequest) {
       authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.browser-actions", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, browserActionTargetUrls(steps, preview.effectiveOrigin, requestedUrl)), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
     }
@@ -5188,14 +5240,14 @@ class BrowserProbeTerminalFailureError extends Error {
 class BrowserProbeStallError extends Error {
   readonly code = "browser-probe-stalled"
 
-  constructor(readonly idleMs: number, readonly stallTimeoutMs: number, readonly lastProgressSource: BrowserProbeProgressSource) {
-    super(`Browser probe stalled after ${idleMs}ms without progress; last progress source was ${lastProgressSource}`)
+  constructor(readonly idleMs: number, readonly stallTimeoutMs: number, readonly lastProgressSource: BrowserProbeProgressSource, readonly lastCheckpoint?: BrowserProbeScriptCheckpoint) {
+    super(`Browser probe stalled after ${idleMs}ms without progress; last progress source was ${lastProgressSource}${lastCheckpoint ? ` (${lastCheckpoint.name})` : ""}`)
     this.name = "BrowserProbeStallError"
   }
 }
 
 function createBrowserProbeProgressTracker(startedAt: string, stallTimeoutMs: number): {
-  mark(source: BrowserProbeProgressSource, timestamp?: string): void
+  mark(source: BrowserProbeProgressSource, timestamp?: string, checkpoint?: BrowserProbeScriptCheckpoint): void
   fail(source: BrowserProbeProgressSource, error: Error): void
   terminalFailure(failure: { message: string; reason?: string; details?: unknown; timestamp: string }): void
   lastProgressElapsedMs(): number
@@ -5206,18 +5258,23 @@ function createBrowserProbeProgressTracker(startedAt: string, stallTimeoutMs: nu
     lastProgressSource: BrowserProbeProgressSource
     idleMs: number
     stallTimeoutMs?: number
+    lastCheckpoint?: BrowserProbeScriptCheckpoint
     terminalFailure?: { message: string; reason?: string; details?: unknown; timestamp: string }
   }
 } {
   let status: "active" | "failed" | "stalled" = "active"
   let lastProgressAt = startedAt
   let lastProgressSource: BrowserProbeProgressSource = "navigation"
+  let lastCheckpoint: BrowserProbeScriptCheckpoint | undefined
   let terminalFailure: { message: string; reason?: string; details?: unknown; timestamp: string } | undefined
 
   return {
-    mark(source, timestamp = now()) {
+    mark(source, timestamp = now(), checkpoint) {
       lastProgressAt = timestamp
       lastProgressSource = source
+      if (checkpoint) {
+        lastCheckpoint = checkpoint
+      }
     },
     fail(source, error) {
       lastProgressAt = now()
@@ -5244,6 +5301,7 @@ function createBrowserProbeProgressTracker(startedAt: string, stallTimeoutMs: nu
         lastProgressSource,
         idleMs: this.lastProgressElapsedMs(),
         ...(stallTimeoutMs > 0 ? { stallTimeoutMs } : {}),
+        ...(lastCheckpoint ? { lastCheckpoint } : {}),
         ...(terminalFailure ? { terminalFailure } : {}),
       }
     },
@@ -5265,15 +5323,21 @@ async function withBrowserProbeLiveness<T>(page: import("playwright").Page, prog
         const state = await page.evaluate(() => {
           const probe = (globalThis as typeof globalThis & {
             __wpCodeboxBrowserProbe?: {
-              checkpoints?: Array<{ timestamp?: unknown }>
+              checkpoints?: Array<{ name?: unknown; metadata?: unknown; timestamp?: unknown }>
               terminalFailure?: { message?: unknown; reason?: unknown; details?: unknown; timestamp?: unknown }
             }
           }).__wpCodeboxBrowserProbe
           const checkpoints = Array.isArray(probe?.checkpoints) ? probe.checkpoints : []
           const latestCheckpoint = [...checkpoints].reverse().find((checkpoint) => typeof checkpoint.timestamp === "string")
+          const latestCheckpointTimestamp = typeof latestCheckpoint?.timestamp === "string" ? latestCheckpoint.timestamp : undefined
+          const checkpoint = latestCheckpoint && latestCheckpointTimestamp ? {
+            name: typeof latestCheckpoint.name === "string" ? latestCheckpoint.name : "checkpoint",
+            metadata: latestCheckpoint.metadata,
+            timestamp: latestCheckpointTimestamp,
+          } : undefined
           const failure = probe?.terminalFailure
           return {
-            checkpointTimestamp: latestCheckpoint?.timestamp,
+            checkpoint,
             terminalFailure: failure && typeof failure.message === "string" ? {
               message: failure.message,
               reason: typeof failure.reason === "string" ? failure.reason : undefined,
@@ -5282,8 +5346,8 @@ async function withBrowserProbeLiveness<T>(page: import("playwright").Page, prog
             } : undefined,
           }
         })
-        if (typeof state.checkpointTimestamp === "string") {
-          progress.mark("checkpoint", state.checkpointTimestamp)
+        if (state.checkpoint) {
+          progress.mark("checkpoint", state.checkpoint.timestamp, state.checkpoint)
         }
         if (state.terminalFailure) {
           progress.terminalFailure(state.terminalFailure)
@@ -5299,7 +5363,7 @@ async function withBrowserProbeLiveness<T>(page: import("playwright").Page, prog
   }).catch((error) => {
     if (error instanceof BrowserCommandLivenessError && error.code === "browser-command-idle-timeout") {
       const summary = progress.summary()
-      throw new BrowserProbeStallError(summary.idleMs, policy.idleTimeoutMs, summary.lastProgressSource)
+      throw new BrowserProbeStallError(summary.idleMs, policy.idleTimeoutMs, summary.lastProgressSource, summary.lastCheckpoint)
     }
     throw error
   })
@@ -5316,6 +5380,18 @@ function livenessRemainingWallTimeMs(startedAtMs: number, totalTimeoutMs: number
     return browserCommandLivenessPolicy().wallTimeoutMs
   }
   return Math.max(1, totalTimeoutMs - (Date.now() - startedAtMs))
+}
+
+function normalizeBrowserProbeScriptCheckpoint(checkpoint: unknown): BrowserProbeScriptCheckpoint | undefined {
+  if (!checkpoint || typeof checkpoint !== "object") {
+    return undefined
+  }
+  const record = checkpoint as { name?: unknown; metadata?: unknown; timestamp?: unknown }
+  return {
+    name: typeof record.name === "string" && record.name.length > 0 ? record.name : "checkpoint",
+    ...(typeof record.metadata !== "undefined" ? { metadata: record.metadata } : {}),
+    timestamp: typeof record.timestamp === "string" ? record.timestamp : now(),
+  }
 }
 
 async function browserProbeTerminalFailure(page: import("playwright").Page): Promise<{ message: string; reason?: string; details?: unknown; timestamp: string } | undefined> {

--- a/packages/runtime-playground/src/browser-interactions.ts
+++ b/packages/runtime-playground/src/browser-interactions.ts
@@ -11,6 +11,7 @@ export interface BrowserStepOutcome {
   target?: BrowserStepRecord["target"]
   screenshot?: string
   screenshotIsDefault?: boolean
+  screenshotFallback?: { reason: string; mode: "page-screenshot" }
   error?: BrowserProbeErrorRecord
 }
 
@@ -129,8 +130,14 @@ export async function executeBrowserInteractionStep(
         ? join(browserDirectory, `screenshot-${sanitizeScreenshotName(step.name)}.png`)
         : defaultScreenshotPath
       const frameTarget = await screenshotFrameTarget(page, step, timeout)
+      let fallback: { reason: string; mode: "page-screenshot" } | undefined
       if (frameTarget) {
-        await frameTarget.frame.locator("html").first().screenshot({ path, timeout })
+        try {
+          await frameTarget.frame.locator("html").first().screenshot({ path, timeout })
+        } catch (error) {
+          fallback = { reason: error instanceof Error ? error.message : String(error), mode: "page-screenshot" }
+          await page.screenshot({ path, fullPage: true })
+        }
       } else {
         await page.screenshot({ path, fullPage: true })
       }
@@ -138,6 +145,7 @@ export async function executeBrowserInteractionStep(
       return {
         ...(readiness ? { readiness } : {}),
         ...(frameTarget ? { target: { mode: frameTarget.mode as "frame-selector" | "frame-url", ...(frameTarget.selector ? { selector: frameTarget.selector } : {}), ...(frameTarget.urlFragment ? { urlFragment: frameTarget.urlFragment } : {}), ...(frameTarget.frame.url() ? { frameUrl: frameTarget.frame.url() } : {}) } } : {}),
+        ...(fallback ? { screenshotFallback: fallback } : {}),
         screenshot: isDefault ? "files/browser/screenshot.png" : `files/browser/${basename(path)}`,
         screenshotIsDefault: isDefault,
       }
@@ -368,6 +376,7 @@ export function browserStepRecord(
     ...(outcome.readiness ? { readiness: outcome.readiness } : {}),
     ...(outcome.target ? { target: outcome.target } : {}),
     ...(outcome.screenshot ? { screenshot: outcome.screenshot } : {}),
+    ...(outcome.screenshotFallback ? { screenshotFallback: outcome.screenshotFallback } : {}),
     finalUrl,
     ...(outcome.error ? { error: outcome.error } : {}),
   }

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -20,11 +20,18 @@ export const BROWSER_PROBE_STATE_INIT_SCRIPT = `
   state.checkpoints = state.checkpoints || [];
   state.longTasks = state.longTasks || [];
   globalThis.__wpCodeboxProbeCheckpoint = (name, metadata = {}) => {
-    state.checkpoints.push({
+    const checkpoint = {
       name: String(name || ''),
       metadata,
       timestamp: new Date().toISOString(),
-    });
+    };
+    state.checkpoints.push(checkpoint);
+    try {
+      const sink = globalThis.__wpCodeboxProbeCheckpointEvent;
+      if (typeof sink === 'function') {
+        void sink(checkpoint);
+      }
+    } catch {}
   };
   globalThis.__wpCodeboxProbeFail = (message, details = undefined) => {
     state.terminalFailure = {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -437,7 +437,7 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     let result: Awaited<ReturnType<typeof runBrowserProbeCommand>>
     try {
-      result = await runBrowserProbeCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec })
+      result = await runBrowserProbeCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec, onProgress: (event) => this.recordEvent("runtime.browser-command-progress", { ...event, specCommand: spec.command }) })
     } catch (error) {
       if (isBrowserCommandArtifactError(error)) {
         this.browserProbes.push(error.artifact)
@@ -474,7 +474,7 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     let result: Awaited<ReturnType<typeof runBrowserActionsCommand>>
     try {
-      result = await runBrowserActionsCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec })
+      result = await runBrowserActionsCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec, onProgress: (event) => this.recordEvent("runtime.browser-command-progress", { ...event, specCommand: spec.command }) })
     } catch (error) {
       if (isBrowserCommandArtifactError(error)) {
         this.browserProbes.push(error.artifact)

--- a/scripts/browser-actions-frame-screenshot-fallback-smoke.ts
+++ b/scripts/browser-actions-frame-screenshot-fallback-smoke.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { browserStepRecord, executeBrowserInteractionStep } from "../packages/runtime-playground/src/browser-interactions.js"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-frame-screenshot-fallback-"))
+const screenshotPath = join(workspace, "screenshot.png")
+
+let frameScreenshotAttempted = false
+let pageScreenshotAttempted = false
+
+const frame = {
+  url: () => "https://example.test/frame",
+  locator: () => ({
+    first: () => ({
+      screenshot: async () => {
+        frameScreenshotAttempted = true
+        throw new Error("locator.screenshot: Timeout 1000ms exceeded. waiting for element to be stable")
+      },
+    }),
+  }),
+}
+
+const page = {
+  locator: () => ({
+    first: () => ({
+      waitFor: async () => undefined,
+      elementHandle: async () => ({ contentFrame: async () => frame }),
+    }),
+  }),
+  screenshot: async ({ path, fullPage }: { path: string; fullPage?: boolean }) => {
+    pageScreenshotAttempted = path === join(workspace, "screenshot-frame.png") && fullPage === true
+  },
+}
+
+try {
+  const outcome = await executeBrowserInteractionStep(
+    page as never,
+    { kind: "screenshot", frameSelector: "iframe", name: "frame" } as never,
+    "https://example.test/",
+    1000,
+    screenshotPath,
+    workspace,
+  )
+
+  assert.equal(frameScreenshotAttempted, true, "frame locator screenshot should be attempted first")
+  assert.equal(pageScreenshotAttempted, true, "page screenshot fallback should be used after locator instability")
+  assert.equal(outcome.screenshot, "files/browser/screenshot-frame.png")
+  assert.equal(outcome.screenshotFallback?.mode, "page-screenshot")
+  assert.match(outcome.screenshotFallback?.reason ?? "", /waiting for element to be stable/)
+
+  const record = browserStepRecord(0, { kind: "screenshot", frameSelector: "iframe", name: "frame" } as never, "ok", new Date().toISOString(), Date.now(), "https://example.test/", outcome)
+  assert.equal(record.screenshotFallback?.mode, "page-screenshot")
+  assert.match(record.screenshotFallback?.reason ?? "", /waiting for element to be stable/)
+
+  console.log("Browser actions frame screenshot fallback smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}

--- a/scripts/browser-probe-artifact-smoke.ts
+++ b/scripts/browser-probe-artifact-smoke.ts
@@ -80,6 +80,7 @@ const screenshotPath = join(artifactDirectory, "files", "browser", "screenshot.p
 const summaryPath = join(artifactDirectory, "files", "browser", "summary.json")
 const manifestPath = join(artifactDirectory, "manifest.json")
 const reviewPath = join(artifactDirectory, "files", "review.json")
+const runtimeEventsPath = join(artifactDirectory, "events.jsonl")
 
 assert.equal(existsSync(consolePath), true, "console.jsonl should be captured")
 assert.equal(existsSync(checkpointsPath), true, "checkpoints.jsonl should be captured")
@@ -97,6 +98,7 @@ const errorLog = await readFile(errorsPath, "utf8")
 const htmlSnapshot = await readFile(htmlPath, "utf8")
 const networkLog = await readFile(networkPath, "utf8")
 const checkpointsLog = await readFile(checkpointsPath, "utf8")
+const runtimeEventsLog = await readFile(runtimeEventsPath, "utf8")
 assert.match(consoleLog, /wp-codebox fixture console error/)
 assert.match(consoleLog, /wp-codebox fixture browser script/)
 assert.match(errorLog, /wp-codebox fixture browser error/)
@@ -104,6 +106,9 @@ assert.match(htmlSnapshot, /Browser Error Fixture|wp-codebox fixture console err
 assert.match(networkLog, /"type":"response"/)
 assert.match(checkpointsLog, /"schema":"wp-codebox\/browser-checkpoint\/v1"/)
 assert.match(checkpointsLog, /"name":"fixture-before-return"/)
+assert.match(runtimeEventsLog, /"type":"runtime\.browser-command-progress"/)
+assert.match(runtimeEventsLog, /"name":"fixture-before-return"/)
+assert.match(runtimeEventsLog, /"lastCheckpoint":\{"name":"fixture-before-return"/)
 
 const networkEvents = networkLog.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line)) as Array<{
   type: string

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -204,6 +204,7 @@ export const smokeGroups = {
       tsxSmoke("browser-lifecycle-observer-smoke"),
       tsxSmoke("browser-probe-pre-page-script-smoke"),
       tsxSmoke("browser-actions-artifact-smoke"),
+      tsxSmoke("browser-actions-frame-screenshot-fallback-smoke"),
       tsxSmoke("browser-actions-painted-readiness-smoke"),
       tsxSmoke("browser-scenario-artifact-smoke"),
       tsxSmoke("browser-visual-compare-smoke"),


### PR DESCRIPTION
## Summary
- Fall back to a full-page screenshot when frame/iframe locator screenshots fail because Playwright is waiting for element stability, while recording fallback metadata in browser action steps and editor-canvas diagnostics.
- Mirror `window.__wpCodeboxProbeCheckpoint(name, metadata)` calls from browser probe and browser actions evaluate scripts into live `runtime.browser-command-progress` events.
- Preserve the latest script checkpoint in browser probe liveness summaries and stall errors so `events.jsonl` shows what long scripts are waiting on.

Closes #910.
Closes #911.

## Testing
- `./node_modules/.bin/tsx scripts/browser-actions-frame-screenshot-fallback-smoke.ts`
- `./node_modules/.bin/tsx scripts/browser-probe-artifact-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the browser evidence fallback/progress plumbing, added smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.