### PR TITLE
Consolidate browser command liveness policy

### DIFF
--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -132,6 +132,11 @@ export interface BrowserArtifactSummary {
   }>
   networkPolicy?: BrowserProbeNetworkPolicySummary
   lifecycle?: BrowserProbeLifecycleSummary
+  liveness?: {
+    wallTimeoutMs?: number
+    stallTimeoutMs?: number
+    networkSettleTimeoutMs?: number
+  }
   memory?: BrowserProbeMemorySummary
   metrics?: Record<string, number>
   networkEvents: number

--- a/packages/runtime-playground/src/browser-capture-session.ts
+++ b/packages/runtime-playground/src/browser-capture-session.ts
@@ -1,8 +1,7 @@
 import type { BrowserProbeErrorRecord, BrowserProbeNetworkRecord } from "./browser-artifacts.js"
+import { browserCommandLivenessPolicy } from "./browser-liveness.js"
 import { serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import type { Browser, Page } from "playwright"
-
-const BROWSER_NETWORK_TASK_SETTLE_TIMEOUT_MS = 1_000
 
 export async function launchChromiumBrowser(): Promise<Browser> {
   const { chromium } = await import("playwright")
@@ -74,7 +73,7 @@ export function attachBrowserCaptureListeners({
   }
 }
 
-export async function settleBrowserNetworkTasks(networkTasks: Array<Promise<void>>, timeoutMs = BROWSER_NETWORK_TASK_SETTLE_TIMEOUT_MS): Promise<void> {
+export async function settleBrowserNetworkTasks(networkTasks: Array<Promise<void>>, timeoutMs = browserCommandLivenessPolicy().networkSettleTimeoutMs): Promise<void> {
   if (networkTasks.length === 0) {
     return
   }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -4,10 +4,11 @@ import { dirname, join, relative } from "node:path"
 import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, validateBrowserInteractionScript, type BrowserInteractionStep, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
-import { browserInteractionStepsFromArgs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
+import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserRedirectDiagnosticsSummary, BrowserStepRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
+import { BrowserCommandLivenessError, browserCommandLivenessPolicy, withBrowserCommandLiveness, type BrowserCommandLivenessPolicy } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserError } from "./browser-metrics.js"
 import { browserPreviewNetworkPolicy, browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
@@ -48,6 +49,7 @@ interface BrowserProbeRunPlan {
   authRequest?: { userId: number }
   failFast: boolean
   stallTimeoutMs: number
+  wallTimeoutMs: number
   lifecycleSelectors: string[]
   assertions: ReturnType<typeof browserProbeAssertionsFromArgs>
 }
@@ -58,6 +60,7 @@ interface BrowserActionsRunPlan {
   capture: Set<string>
   stepTimeoutMs: number
   totalTimeoutMs: number
+  networkSettleTimeoutMs: number
   requestedViewport?: { width: number; height: number }
   authRequest?: { userId: number }
   maxDomSnapshotElements: number
@@ -378,6 +381,8 @@ async function runSingleBrowserProbeCommand({
   const authRequest = runPlan.authRequest
   const failFast = runPlan.failFast
   const stallTimeoutMs = runPlan.stallTimeoutMs
+  const wallTimeoutMs = runPlan.wallTimeoutMs
+  const livenessPolicy = browserCommandLivenessPolicy({ wallTimeoutMs, idleTimeoutMs: stallTimeoutMs })
   const lifecycleSelectors = runPlan.lifecycleSelectors
   const routedHosts = commaListArg(args, "route-host")
   const assertions = runPlan.assertions
@@ -504,7 +509,7 @@ async function runSingleBrowserProbeCommand({
       throw previewReadinessError
     }
 
-    await withBrowserProbeLiveness(page, progress, failFast, navigateBrowserProbe(page, targetUrl, waitFor, durationMs))
+    await withBrowserProbeLiveness(page, progress, failFast, navigateBrowserProbe(page, targetUrl, waitFor, durationMs), livenessPolicy, "navigation")
     progress.mark("navigation")
     const browserLocation = await page.evaluate(() => ({ origin: window.location.origin, secureContext: window.isSecureContext })).catch(() => undefined)
     windowLocationOrigin = browserLocation?.origin
@@ -520,7 +525,7 @@ async function runSingleBrowserProbeCommand({
       scriptResult = await withBrowserProbeLiveness(page, progress, failFast, page.evaluate(async (source) => {
         const run = new Function(`return (async () => {\n${source}\n})()`)
         return run()
-      }, script))
+      }, script), livenessPolicy, "script")
       progress.mark("script")
       if (capturesBrowserMetrics) {
         const pendingCheckpoints = await browserProbePendingCheckpoints(page)
@@ -532,14 +537,14 @@ async function runSingleBrowserProbeCommand({
       }
     }
     if (durationMs > 0 && waitFor !== "duration") {
-      await withBrowserProbeLiveness(page, progress, failFast, page.waitForTimeout(durationMs))
+      await withBrowserProbeLiveness(page, progress, failFast, page.waitForTimeout(durationMs), livenessPolicy, "duration")
       progress.mark("duration")
       if (capturesBrowserMetrics) {
         checkpoints.push(await browserProbeCheckpoint(page, "after-duration"))
       }
     }
     if (assertions.length > 0) {
-      await settleBrowserNetworkTasks(networkTasks)
+      await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
       const assertionMetrics = capturesBrowserMetrics ? browserProbeBenchMetrics(browserProbeMemoryArtifact(checkpoints), browserProbePerformanceArtifact(checkpoints)) : {}
       assertionResults = await executeBrowserProbeAssertions(page, assertions, consoleMessages, errors, network, assertionMetrics)
       if (capturesBrowserMetrics) {
@@ -553,6 +558,10 @@ async function runSingleBrowserProbeCommand({
     finalUrl = page.url()
   } catch (error) {
     pendingError = error instanceof Error ? error : new Error(String(error))
+    if (pendingError instanceof BrowserCommandLivenessError) {
+      await page?.close().catch(() => undefined)
+      page = null
+    }
     progress.fail("probe-error", pendingError)
     errors.push(serializeBrowserError("probe-error", error))
   } finally {
@@ -592,7 +601,7 @@ async function runSingleBrowserProbeCommand({
         }
       }
     }
-    await settleBrowserNetworkTasks(networkTasks)
+    await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
     await browser.close()
     if (capture.has("console") || capturesConsoleForAssertions) {
       await writeFile(consolePath, jsonLines(consoleMessages))
@@ -717,6 +726,7 @@ async function runSingleBrowserProbeCommand({
         htmlSnapshot: Boolean(htmlSha256),
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(lifecycleArtifact ? { lifecycle: { schema: lifecycleArtifact.schema, version: lifecycleArtifact.version, startedAtMs: lifecycleArtifact.startedAtMs, selectors: lifecycleArtifact.selectors } } : {}),
+        liveness: { wallTimeoutMs, stallTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
         ...(memoryArtifact ? { memory: memoryArtifact.peak } : {}),
         ...(memoryArtifact || performanceArtifact ? { metrics: browserProbeBenchMetrics(memoryArtifact, performanceArtifact) } : {}),
         networkEvents: network.length,
@@ -775,6 +785,9 @@ async function runSingleBrowserProbeCommand({
     }
     throw new BrowserCommandArtifactError(pendingError.message, artifact)
   }
+  if (!artifact) {
+    throw new Error("wordpress.browser-probe did not produce a browser artifact")
+  }
 
   return {
     artifact,
@@ -831,6 +844,7 @@ function browserProbeRunPlanFromArgs(args: string[], profileId?: string): Browse
     authRequest: browserAuthRequest(args),
     failFast: strictBooleanArg(args, "fail-fast", false),
     stallTimeoutMs: durationArg(args, "stall-timeout", 0),
+    wallTimeoutMs: durationArg(args, "timeout", browserCommandLivenessPolicy().wallTimeoutMs),
     lifecycleSelectors: commaListArg(args, "observe"),
     assertions: browserProbeAssertionsFromArgs(args),
   }
@@ -2060,6 +2074,7 @@ export async function runBrowserActionsCommand({
 
   const stepTimeoutMs = runPlan.stepTimeoutMs
   const totalTimeoutMs = runPlan.totalTimeoutMs
+  const livenessPolicy = browserCommandLivenessPolicy({ wallTimeoutMs: totalTimeoutMs, networkSettleTimeoutMs: runPlan.networkSettleTimeoutMs })
   const requestedViewport = runPlan.requestedViewport
   const authRequest = runPlan.authRequest
   const maxDomSnapshotElements = runPlan.maxDomSnapshotElements
@@ -2138,7 +2153,12 @@ export async function runBrowserActionsCommand({
         break
       }
       try {
-        const outcome = await executeBrowserInteractionStep(page, step, preview.effectiveOrigin, stepTimeoutMs, screenshotPath, browserDirectory)
+        const outcome = await withBrowserCommandLiveness({
+          command: "wordpress.browser-actions",
+          phase: `step ${index} (${step.kind})`,
+          operation: executeBrowserInteractionStep(page, step, preview.effectiveOrigin, stepTimeoutMs, screenshotPath, browserDirectory),
+          policy: { wallTimeoutMs: Math.min(browserStepTimeoutMs(step, stepTimeoutMs), livenessRemainingWallTimeMs(startedAtMs, totalTimeoutMs)), idleTimeoutMs: 0 },
+        })
         finalUrl = page.url()
         if (step.kind === "navigate") {
           requestedUrl = resolveBrowserPreviewUrl((step.url ?? "").trim(), preview.effectiveOrigin)
@@ -2169,6 +2189,9 @@ export async function runBrowserActionsCommand({
         errors.push(serialized)
         stepRecords.push(browserStepRecord(index, step, "failed", recordStartedAt, recordStartedAtMs, page.url(), { error: serialized }))
         pendingError = error instanceof Error ? error : new Error(String(error))
+        if (pendingError instanceof BrowserCommandLivenessError) {
+          await page.close().catch(() => undefined)
+        }
         break
       }
     }
@@ -2211,7 +2234,7 @@ export async function runBrowserActionsCommand({
       }
     }
   } finally {
-    await settleBrowserNetworkTasks(networkTasks)
+    await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
     await browser.close()
     if (capture.has("steps")) {
       await writeFile(stepsPath, jsonLines(stepRecords))
@@ -2279,6 +2302,7 @@ export async function runBrowserActionsCommand({
         htmlSnapshot: Boolean(htmlSha256),
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots } : {}),
+        liveness: { wallTimeoutMs: totalTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
         networkEvents: network.length,
         ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
         ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
@@ -2296,6 +2320,7 @@ export async function runBrowserActionsCommand({
       capture: [...capture].sort(),
       stepTimeoutMs,
       totalTimeoutMs,
+      networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs,
       steps: stepRecords,
       ...(assertions.total > 0 ? { assertions } : {}),
       startedAt,
@@ -2316,7 +2341,13 @@ export async function runBrowserActionsCommand({
   }
 
   if (pendingError) {
+    if (!artifact) {
+      throw pendingError
+    }
     throw new BrowserCommandArtifactError(`wordpress.browser-actions failed after ${stepRecords.length} step(s): ${pendingError.message}`, artifact)
+  }
+  if (!artifact) {
+    throw new Error("wordpress.browser-actions did not produce a browser artifact")
   }
 
   return {
@@ -2350,6 +2381,7 @@ async function browserActionsRunPlanFromArgs(args: string[]): Promise<BrowserAct
     capture,
     stepTimeoutMs: durationArg(args, "step-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS),
     totalTimeoutMs: durationArg(args, "timeout", BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS),
+    networkSettleTimeoutMs: durationArg(args, "network-settle-timeout", browserCommandLivenessPolicy().networkSettleTimeoutMs),
     requestedViewport: viewportArg(args, "viewport"),
     authRequest: browserAuthRequest(args),
     maxDomSnapshotElements: positiveIntegerArg(args, "max-dom-snapshot-elements", 160),
@@ -2601,6 +2633,7 @@ function browserScenarioRunPlan(scenario: BrowserScenarioInput, args: string[], 
       authRequest,
       failFast: false,
       stallTimeoutMs: 0,
+      wallTimeoutMs: durationStringMs(scenario.timeout ?? argValue(args, "timeout")) || browserCommandLivenessPolicy().wallTimeoutMs,
       lifecycleSelectors: [],
       assertions: [],
     }
@@ -2617,6 +2650,7 @@ function browserScenarioRunPlan(scenario: BrowserScenarioInput, args: string[], 
       capture: new Set(browserScenarioActionCaptures(captures)),
       stepTimeoutMs: durationStringMs(scenario.stepTimeout ?? argValue(args, "step-timeout")) || BROWSER_STEP_DEFAULT_TIMEOUT_MS,
       totalTimeoutMs: durationStringMs(scenario.timeout ?? argValue(args, "timeout")) || BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS,
+      networkSettleTimeoutMs: durationArg(args, "network-settle-timeout", browserCommandLivenessPolicy().networkSettleTimeoutMs),
       requestedViewport: requestedViewport ? parseBrowserViewport(requestedViewport, "viewport") : undefined,
       authRequest,
       maxDomSnapshotElements: positiveIntegerArg(args, "max-dom-snapshot-elements", 160),
@@ -3211,6 +3245,7 @@ async function runVisualComparePairCommand({
   const candidateLabel = argValue(args, "candidate-label")?.trim() || "candidate"
   const waitFor = argValue(args, "wait-for")?.trim() || "domcontentloaded"
   const durationMs = durationArg(args, "duration", 0)
+  const visualTimeoutMs = durationArg(args, "timeout", browserCommandLivenessPolicy().wallTimeoutMs)
   const requestedViewport = viewportArg(args, "viewport")
   const fullPage = strictBooleanArg(args, "full-page", true)
   const threshold = numberArg(args, "threshold", 0.1)
@@ -3270,7 +3305,7 @@ async function runVisualComparePairCommand({
       startedAt,
       source: sourceSummary(),
       candidate: candidateSummary(),
-      options: { waitFor, durationMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+      options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
       preview,
       viewport,
     })
@@ -3281,14 +3316,44 @@ async function runVisualComparePairCommand({
     try {
       const page = await browser.newPage(requestedViewport ? { viewport: requestedViewport } : undefined)
       viewport = await browserProbeViewport(page)
-      const sourceCapture = await captureVisualCompareUrl(page, sourceTargetUrl, sourcePath, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors)
-      finalSourceUrl = sourceCapture.finalUrl
-      sourceDomSnapshot = sourceCapture.domSnapshot
-      await writePartialSummary("source-captured")
-      const candidateCapture = await captureVisualCompareUrl(page, candidateTargetUrl, candidatePath, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors)
-      finalCandidateUrl = candidateCapture.finalUrl
-      candidateDomSnapshot = candidateCapture.domSnapshot
-      await writePartialSummary("candidate-captured")
+      try {
+        const sourceCapture = await withBrowserCommandLiveness({
+          command: "wordpress.visual-compare",
+          phase: "source-capture",
+          operation: captureVisualCompareUrl(page, sourceTargetUrl, sourcePath, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors, visualTimeoutMs),
+          policy: { wallTimeoutMs: visualTimeoutMs, idleTimeoutMs: 0 },
+        })
+        finalSourceUrl = sourceCapture.finalUrl
+        sourceDomSnapshot = sourceCapture.domSnapshot
+        await writePartialSummary("source-captured")
+        const candidateCapture = await withBrowserCommandLiveness({
+          command: "wordpress.visual-compare",
+          phase: "candidate-capture",
+          operation: captureVisualCompareUrl(page, candidateTargetUrl, candidatePath, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors, visualTimeoutMs),
+          policy: { wallTimeoutMs: visualTimeoutMs, idleTimeoutMs: 0 },
+        })
+        finalCandidateUrl = candidateCapture.finalUrl
+        candidateDomSnapshot = candidateCapture.domSnapshot
+        await writePartialSummary("candidate-captured")
+      } catch (error) {
+        const result = await writeVisualCompareFailureSummary({
+          summaryPath,
+          visualDiffPath,
+          artifactPathPrefix,
+          startedAt,
+          source: sourceSummary(),
+          candidate: candidateSummary(),
+          options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+          preview,
+          viewport,
+          message: errorMessage(error),
+          copiedFiles: {
+            ...(await fileExists(sourcePath) ? { sourceScreenshot: `${artifactPathPrefix}/source.png` } : {}),
+            ...(await fileExists(candidatePath) ? { candidateScreenshot: `${artifactPathPrefix}/candidate.png` } : {}),
+          },
+        })
+        throw new BrowserCommandArtifactError(`wordpress.visual-compare failed during capture: ${errorMessage(error)}`, visualCompareFailureArtifact({ source: sourceSummary(), candidate: candidateSummary(), preview, viewport, files: result.files, summary: result.summary }))
+      }
     } finally {
       await browser.close()
     }
@@ -3313,7 +3378,7 @@ async function runVisualComparePairCommand({
         startedAt,
         source: sourceSummary(),
         candidate: candidateSummary(),
-        options: { waitFor, durationMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+        options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
         preview,
         viewport,
         missingInputs,
@@ -3376,7 +3441,7 @@ async function runVisualComparePairCommand({
     status,
     source: sourceSummary(),
     candidate: candidateSummary(),
-    options: { waitFor, durationMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+    options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
     limitations: explanation
       ? explanation.limitations
       : ["visual explanations require source-url/candidate-url targets or source-dom-snapshot/candidate-dom-snapshot sidecars so WP Codebox can include DOM and computed style context; screenshot-only comparisons include pixel evidence only"],
@@ -3611,6 +3676,52 @@ async function writeVisualCompareMissingInputSummary(input: {
   return { files, summary }
 }
 
+async function writeVisualCompareFailureSummary(input: {
+  summaryPath: string
+  visualDiffPath: string
+  artifactPathPrefix: string
+  startedAt: string
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  options: Record<string, unknown>
+  preview: ReturnType<typeof browserPreviewRouting>
+  viewport: BrowserProbeViewport | null
+  message: string
+  copiedFiles: Partial<{ sourceScreenshot: string; candidateScreenshot: string }>
+}): Promise<{ files: { sourceScreenshot: string | string[]; candidateScreenshot: string | string[]; diffScreenshot: string | string[]; visualDiff: string; summary: string }; summary: VisualCompareFailureSummary }> {
+  const files = {
+    sourceScreenshot: input.copiedFiles.sourceScreenshot ?? [],
+    candidateScreenshot: input.copiedFiles.candidateScreenshot ?? [],
+    diffScreenshot: [],
+    visualDiff: `${input.artifactPathPrefix}/visual-diff.json`,
+    summary: `${input.artifactPathPrefix}/summary.json`,
+  }
+  const summary: VisualCompareFailureSummary = {
+    schema: "wp-codebox/visual-compare/v1",
+    command: "wordpress.visual-compare",
+    status: "failed",
+    partial: true,
+    stage: "capture-failed",
+    source: input.source,
+    candidate: input.candidate,
+    options: input.options,
+    limitations: ["visual compare capture failed before full diff metrics were available; recovered files show any screenshots captured before failure"],
+    preview: input.preview,
+    viewport: input.viewport,
+    startedAt: input.startedAt,
+    updatedAt: now(),
+    files,
+    diagnostic: {
+      type: "comparison-failed",
+      message: input.message,
+    },
+  }
+  const json = `${JSON.stringify(summary, null, 2)}\n`
+  await writeFile(input.visualDiffPath, json)
+  await writeFile(input.summaryPath, json)
+  return { files, summary }
+}
+
 function visualCompareMissingInputArtifact(input: {
   source: Record<string, unknown>
   candidate: Record<string, unknown>
@@ -3629,6 +3740,38 @@ function visualCompareMissingInputArtifact(input: {
       steps: 0,
       consoleMessages: 0,
       errors: 0,
+      finalUrl: "",
+      htmlSnapshot: false,
+      networkEvents: 0,
+      replayability: "artifact-backed",
+      screenshot: Array.isArray(input.files.sourceScreenshot) ? input.files.sourceScreenshot.length > 0 : Boolean(input.files.sourceScreenshot),
+      visualCompare: {
+        status: input.summary.status,
+        explanation: input.files.visualDiff,
+      },
+      viewport: input.viewport,
+    },
+  }
+}
+
+function visualCompareFailureArtifact(input: {
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  preview: ReturnType<typeof browserPreviewRouting>
+  viewport: BrowserProbeViewport | null
+  files: { sourceScreenshot: string | string[]; candidateScreenshot: string | string[]; diffScreenshot: string | string[]; visualDiff: string; summary: string }
+  summary: VisualCompareFailureSummary
+}): BrowserArtifact {
+  return {
+    artifactType: "visual-compare",
+    requestedUrl: typeof input.source.url === "string" ? input.source.url : typeof input.source.screenshot === "string" ? input.source.screenshot : "source",
+    url: typeof input.candidate.url === "string" ? input.candidate.url : typeof input.candidate.screenshot === "string" ? input.candidate.screenshot : "candidate",
+    preview: input.preview,
+    files: input.files,
+    summary: {
+      steps: 0,
+      consoleMessages: 0,
+      errors: 1,
       finalUrl: "",
       htmlSnapshot: false,
       networkEvents: 0,
@@ -3664,6 +3807,15 @@ async function maybeResolveVisualCompareScreenshotPath(requestedPath: string, ar
     return await resolveVisualCompareScreenshotPath(requestedPath, artifactRoot)
   } catch {
     return undefined
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
   }
 }
 
@@ -3832,6 +3984,27 @@ interface VisualCompareMissingInputSummary {
     type: "missing-input"
     message: string
     missingInputs: VisualCompareMissingInput[]
+  }
+}
+
+interface VisualCompareFailureSummary {
+  schema: "wp-codebox/visual-compare/v1"
+  command: "wordpress.visual-compare"
+  status: "failed"
+  partial: true
+  stage: "capture-failed"
+  source: Record<string, unknown>
+  candidate: Record<string, unknown>
+  options: Record<string, unknown>
+  limitations: string[]
+  preview: ReturnType<typeof browserPreviewRouting>
+  viewport: BrowserProbeViewport | null
+  startedAt: string
+  updatedAt: string
+  files: { sourceScreenshot: string | string[]; candidateScreenshot: string | string[]; diffScreenshot: string | string[]; visualDiff: string; summary: string }
+  diagnostic: {
+    type: "comparison-failed"
+    message: string
   }
 }
 
@@ -4196,28 +4369,28 @@ function visualCompareExplainSelectors(args: string[]): string[] {
   return [...selectors]
 }
 
-async function captureVisualCompareUrl(page: Page, targetUrl: string, outputPath: string, waitFor: string, durationMs: number, fullPage: boolean, maxExplanationCandidates: number, explainSelectors: string[]): Promise<{ finalUrl: string; domSnapshot: VisualCompareDomSnapshot }> {
+async function captureVisualCompareUrl(page: Page, targetUrl: string, outputPath: string, waitFor: string, durationMs: number, fullPage: boolean, maxExplanationCandidates: number, explainSelectors: string[], timeoutMs: number): Promise<{ finalUrl: string; domSnapshot: VisualCompareDomSnapshot }> {
   if (waitFor === "duration") {
-    await page.goto(targetUrl, { waitUntil: "domcontentloaded" })
+    await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs })
     if (durationMs > 0) {
-      await page.waitForTimeout(durationMs)
+      await withBrowserCommandLiveness({ command: "wordpress.visual-compare", phase: "duration", operation: page.waitForTimeout(durationMs), policy: { wallTimeoutMs: Math.min(durationMs + 1_000, timeoutMs), idleTimeoutMs: 0 } })
     }
   } else if (waitFor.startsWith("selector:")) {
-    await page.goto(targetUrl, { waitUntil: "domcontentloaded" })
-    await page.waitForSelector(waitFor.slice("selector:".length), { state: "visible" })
+    await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs })
+    await page.waitForSelector(waitFor.slice("selector:".length), { state: "visible", timeout: timeoutMs })
     if (durationMs > 0) {
-      await page.waitForTimeout(durationMs)
+      await withBrowserCommandLiveness({ command: "wordpress.visual-compare", phase: "duration", operation: page.waitForTimeout(durationMs), policy: { wallTimeoutMs: Math.min(durationMs + 1_000, timeoutMs), idleTimeoutMs: 0 } })
     }
   } else if (waitFor === "domcontentloaded" || waitFor === "load" || waitFor === "networkidle") {
-    await page.goto(targetUrl, { waitUntil: waitFor })
+    await page.goto(targetUrl, { waitUntil: waitFor, timeout: timeoutMs })
     if (durationMs > 0) {
-      await page.waitForTimeout(durationMs)
+      await withBrowserCommandLiveness({ command: "wordpress.visual-compare", phase: "duration", operation: page.waitForTimeout(durationMs), policy: { wallTimeoutMs: Math.min(durationMs + 1_000, timeoutMs), idleTimeoutMs: 0 } })
     }
   } else {
     throw new Error(`wait-for supports domcontentloaded, load, networkidle, selector:<selector>, or duration: ${waitFor}`)
   }
-  const domSnapshot = await captureVisualCompareDomSnapshot(page, maxExplanationCandidates, explainSelectors)
-  await page.screenshot({ path: outputPath, fullPage })
+  const domSnapshot = await withBrowserCommandLiveness({ command: "wordpress.visual-compare", phase: "dom-snapshot", operation: captureVisualCompareDomSnapshot(page, maxExplanationCandidates, explainSelectors), policy: { wallTimeoutMs: timeoutMs, idleTimeoutMs: 0 } })
+  await page.screenshot({ path: outputPath, fullPage, timeout: timeoutMs })
   return { finalUrl: page.url(), domSnapshot }
 }
 
@@ -5077,73 +5250,72 @@ function createBrowserProbeProgressTracker(startedAt: string, stallTimeoutMs: nu
   }
 }
 
-async function withBrowserProbeLiveness<T>(page: import("playwright").Page, progress: ReturnType<typeof createBrowserProbeProgressTracker>, failFast: boolean, operation: Promise<T>): Promise<T> {
-  const stallTimeoutMs = progress.summary().stallTimeoutMs ?? 0
-  if (!failFast && stallTimeoutMs <= 0) {
-    return operation
-  }
-
-  let interval: NodeJS.Timeout | undefined
-  operation.catch(() => undefined)
-
-  try {
-    const result = await Promise.race([
-      operation,
-      new Promise<T>((_resolve, reject) => {
-        interval = setInterval(() => {
-          void (async () => {
-            try {
-              const state = await page.evaluate(() => {
-                const probe = (globalThis as typeof globalThis & {
-                  __wpCodeboxBrowserProbe?: {
-                    checkpoints?: Array<{ timestamp?: unknown }>
-                    terminalFailure?: { message?: unknown; reason?: unknown; details?: unknown; timestamp?: unknown }
-                  }
-                }).__wpCodeboxBrowserProbe
-                const checkpoints = Array.isArray(probe?.checkpoints) ? probe.checkpoints : []
-                const latestCheckpoint = [...checkpoints].reverse().find((checkpoint) => typeof checkpoint.timestamp === "string")
-                const failure = probe?.terminalFailure
-                return {
-                  checkpointTimestamp: latestCheckpoint?.timestamp,
-                  terminalFailure: failure && typeof failure.message === "string" ? {
-                    message: failure.message,
-                    reason: typeof failure.reason === "string" ? failure.reason : undefined,
-                    details: failure.details,
-                    timestamp: typeof failure.timestamp === "string" ? failure.timestamp : new Date().toISOString(),
-                  } : undefined,
-                }
-              })
-              if (typeof state.checkpointTimestamp === "string") {
-                progress.mark("checkpoint", state.checkpointTimestamp)
-              }
-              if (state.terminalFailure) {
-                progress.terminalFailure(state.terminalFailure)
-                reject(new BrowserProbeTerminalFailureError(state.terminalFailure))
-                return
-              }
-              if (stallTimeoutMs > 0 && progress.lastProgressElapsedMs() >= stallTimeoutMs) {
-                const summary = progress.summary()
-                reject(new BrowserProbeStallError(summary.idleMs, stallTimeoutMs, summary.lastProgressSource))
-              }
-            } catch {
-              // The page may be navigating or already closed; the outer operation remains authoritative.
+async function withBrowserProbeLiveness<T>(page: import("playwright").Page, progress: ReturnType<typeof createBrowserProbeProgressTracker>, failFast: boolean, operation: Promise<T>, policy: Required<BrowserCommandLivenessPolicy>, phase: string): Promise<T> {
+  const result = await withBrowserCommandLiveness({
+    command: "wordpress.browser-probe",
+    phase,
+    operation,
+    policy,
+    idle: () => {
+      const summary = progress.summary()
+      return { idleMs: summary.idleMs, lastProgressSource: summary.lastProgressSource }
+    },
+    poll: async () => {
+      try {
+        const state = await page.evaluate(() => {
+          const probe = (globalThis as typeof globalThis & {
+            __wpCodeboxBrowserProbe?: {
+              checkpoints?: Array<{ timestamp?: unknown }>
+              terminalFailure?: { message?: unknown; reason?: unknown; details?: unknown; timestamp?: unknown }
             }
-          })()
-        }, 250)
-        interval.unref()
-      }),
-    ])
-    const terminalFailure = failFast ? await browserProbeTerminalFailure(page) : undefined
-    if (terminalFailure) {
-      progress.terminalFailure(terminalFailure)
-      throw new BrowserProbeTerminalFailureError(terminalFailure)
+          }).__wpCodeboxBrowserProbe
+          const checkpoints = Array.isArray(probe?.checkpoints) ? probe.checkpoints : []
+          const latestCheckpoint = [...checkpoints].reverse().find((checkpoint) => typeof checkpoint.timestamp === "string")
+          const failure = probe?.terminalFailure
+          return {
+            checkpointTimestamp: latestCheckpoint?.timestamp,
+            terminalFailure: failure && typeof failure.message === "string" ? {
+              message: failure.message,
+              reason: typeof failure.reason === "string" ? failure.reason : undefined,
+              details: failure.details,
+              timestamp: typeof failure.timestamp === "string" ? failure.timestamp : new Date().toISOString(),
+            } : undefined,
+          }
+        })
+        if (typeof state.checkpointTimestamp === "string") {
+          progress.mark("checkpoint", state.checkpointTimestamp)
+        }
+        if (state.terminalFailure) {
+          progress.terminalFailure(state.terminalFailure)
+          throw new BrowserProbeTerminalFailureError(state.terminalFailure)
+        }
+      } catch (error) {
+        if (error instanceof BrowserProbeTerminalFailureError) {
+          throw error
+        }
+        // The page may be navigating or already closed; the outer operation remains authoritative.
+      }
+    },
+  }).catch((error) => {
+    if (error instanceof BrowserCommandLivenessError && error.code === "browser-command-idle-timeout") {
+      const summary = progress.summary()
+      throw new BrowserProbeStallError(summary.idleMs, policy.idleTimeoutMs, summary.lastProgressSource)
     }
-    return result
-  } finally {
-    if (interval) {
-      clearInterval(interval)
-    }
+    throw error
+  })
+  const terminalFailure = failFast ? await browserProbeTerminalFailure(page) : undefined
+  if (terminalFailure) {
+    progress.terminalFailure(terminalFailure)
+    throw new BrowserProbeTerminalFailureError(terminalFailure)
   }
+  return result
+}
+
+function livenessRemainingWallTimeMs(startedAtMs: number, totalTimeoutMs: number): number {
+  if (totalTimeoutMs <= 0) {
+    return browserCommandLivenessPolicy().wallTimeoutMs
+  }
+  return Math.max(1, totalTimeoutMs - (Date.now() - startedAtMs))
 }
 
 async function browserProbeTerminalFailure(page: import("playwright").Page): Promise<{ message: string; reason?: string; details?: unknown; timestamp: string } | undefined> {

--- a/packages/runtime-playground/src/browser-interactions.ts
+++ b/packages/runtime-playground/src/browser-interactions.ts
@@ -3,6 +3,7 @@ import type { BrowserInteractionStep } from "@automattic/wp-codebox-core"
 import type { Frame, Page } from "playwright"
 import { browserActionLoadState, browserDeepEqual, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import type { BrowserProbeErrorRecord, BrowserStepAssertion, BrowserStepReadiness, BrowserStepRecord } from "./browser-artifacts.js"
+import { browserCommandLivenessPolicy, withBrowserCommandLiveness } from "./browser-liveness.js"
 
 export interface BrowserStepOutcome {
   assertion?: BrowserStepAssertion
@@ -254,7 +255,12 @@ async function waitForPaintedReadiness(page: Page, waitFor: BrowserPaintedReadin
     return { visibleElementCount, textLength }
   }, undefined, { timeout })
   const summary = await result.jsonValue() as { visibleElementCount: number; textLength: number }
-  await target.frame.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))))
+  await withBrowserCommandLiveness({
+    command: "wordpress.browser-actions",
+    phase: "painted-readiness-stabilization",
+    operation: target.frame.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))),
+    policy: { wallTimeoutMs: browserCommandLivenessPolicy().readinessStabilizationTimeoutMs, idleTimeoutMs: 0 },
+  })
   return {
     mode: target.mode,
     ...(target.selector ? { selector: target.selector } : {}),

--- a/packages/runtime-playground/src/browser-liveness.ts
+++ b/packages/runtime-playground/src/browser-liveness.ts
@@ -1,0 +1,123 @@
+export interface BrowserCommandLivenessPolicy {
+  wallTimeoutMs?: number
+  idleTimeoutMs?: number
+  networkSettleTimeoutMs?: number
+  readinessStabilizationTimeoutMs?: number
+  pollIntervalMs?: number
+}
+
+export const BROWSER_COMMAND_LIVENESS_DEFAULTS = {
+  wallTimeoutMs: 120_000,
+  idleTimeoutMs: 30_000,
+  networkSettleTimeoutMs: 1_000,
+  readinessStabilizationTimeoutMs: 1_000,
+  pollIntervalMs: 250,
+} as const
+
+export class BrowserCommandLivenessError extends Error {
+  readonly code: "browser-command-wall-timeout" | "browser-command-idle-timeout"
+
+  constructor(readonly details: {
+    command: string
+    phase: string
+    type: "wall" | "idle"
+    elapsedMs: number
+    timeoutMs: number
+    lastProgressSource?: string
+  }) {
+    const source = details.lastProgressSource ? `; last progress source was ${details.lastProgressSource}` : ""
+    super(`Browser command ${details.command} ${details.phase} ${details.type === "wall" ? "exceeded" : "stalled after"} ${details.timeoutMs}ms${source}`)
+    this.name = "BrowserCommandLivenessError"
+    this.code = details.type === "wall" ? "browser-command-wall-timeout" : "browser-command-idle-timeout"
+  }
+}
+
+export function browserCommandLivenessPolicy(overrides: BrowserCommandLivenessPolicy = {}): Required<BrowserCommandLivenessPolicy> {
+  return {
+    wallTimeoutMs: normalizeNonNegative(overrides.wallTimeoutMs, BROWSER_COMMAND_LIVENESS_DEFAULTS.wallTimeoutMs),
+    idleTimeoutMs: normalizeNonNegative(overrides.idleTimeoutMs, BROWSER_COMMAND_LIVENESS_DEFAULTS.idleTimeoutMs),
+    networkSettleTimeoutMs: normalizeNonNegative(overrides.networkSettleTimeoutMs, BROWSER_COMMAND_LIVENESS_DEFAULTS.networkSettleTimeoutMs),
+    readinessStabilizationTimeoutMs: normalizeNonNegative(overrides.readinessStabilizationTimeoutMs, BROWSER_COMMAND_LIVENESS_DEFAULTS.readinessStabilizationTimeoutMs),
+    pollIntervalMs: Math.max(10, normalizeNonNegative(overrides.pollIntervalMs, BROWSER_COMMAND_LIVENESS_DEFAULTS.pollIntervalMs)),
+  }
+}
+
+export async function withBrowserCommandLiveness<T>({
+  command,
+  phase,
+  operation,
+  policy: policyOverrides,
+  poll,
+  idle,
+}: {
+  command: string
+  phase: string
+  operation: Promise<T>
+  policy?: BrowserCommandLivenessPolicy
+  poll?: () => Promise<void> | void
+  idle?: () => { idleMs: number; lastProgressSource?: string }
+}): Promise<T> {
+  const policy = browserCommandLivenessPolicy(policyOverrides)
+  if (policy.wallTimeoutMs <= 0 && (!idle || policy.idleTimeoutMs <= 0) && !poll) {
+    return operation
+  }
+
+  const startedAtMs = Date.now()
+  let interval: NodeJS.Timeout | undefined
+  operation.catch(() => undefined)
+
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<T>((_resolve, reject) => {
+        interval = setInterval(() => {
+          void (async () => {
+            try {
+              await poll?.()
+              if (idle && policy.idleTimeoutMs > 0) {
+                const summary = idle()
+                if (summary.idleMs >= policy.idleTimeoutMs) {
+                  reject(new BrowserCommandLivenessError({
+                    command,
+                    phase,
+                    type: "idle",
+                    elapsedMs: summary.idleMs,
+                    timeoutMs: policy.idleTimeoutMs,
+                    lastProgressSource: summary.lastProgressSource,
+                  }))
+                  return
+                }
+              }
+              if (policy.wallTimeoutMs > 0) {
+                const elapsedMs = Date.now() - startedAtMs
+                if (elapsedMs >= policy.wallTimeoutMs) {
+                  reject(new BrowserCommandLivenessError({
+                    command,
+                    phase,
+                    type: "wall",
+                    elapsedMs,
+                    timeoutMs: policy.wallTimeoutMs,
+                  }))
+                }
+              }
+            } catch (error) {
+              reject(error)
+            }
+          })()
+        }, policy.pollIntervalMs)
+        interval.unref()
+      }),
+    ])
+  } finally {
+    if (interval) {
+      clearInterval(interval)
+    }
+  }
+}
+
+function normalizeNonNegative(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback
+  }
+  return Math.max(0, Math.round(value))
+}

--- a/scripts/browser-actions-painted-readiness-smoke.ts
+++ b/scripts/browser-actions-painted-readiness-smoke.ts
@@ -8,7 +8,9 @@ const repoRoot = resolve(import.meta.dirname, "..")
 const workspace = resolve(repoRoot, "artifacts", "browser-actions-painted-readiness-smoke")
 const pluginDir = join(workspace, "browser-painted-readiness-fixture")
 const recipePath = join(workspace, "recipe.json")
+const stalledRecipePath = join(workspace, "stalled-recipe.json")
 const artifactsRoot = join(workspace, "artifacts")
+const stalledArtifactsRoot = join(workspace, "stalled-artifacts")
 
 await rm(workspace, { recursive: true, force: true })
 await mkdir(pluginDir, { recursive: true })
@@ -113,17 +115,80 @@ const summary = JSON.parse(await readFile(summaryPath, "utf8")) as { steps: Arra
 assert.ok(summary.steps.some((step) => step.kind === "screenshot" && step.readiness), "summary should preserve screenshot readiness evidence")
 assert.ok(summary.files.domSnapshots?.includes("files/browser/dom-snapshot-frame-painted.json"), "summary should include the screenshot DOM sidecar")
 
+await writeFile(stalledRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extra_plugins: [
+      {
+        source: "./browser-painted-readiness-fixture",
+        pluginFile: "browser-painted-readiness-fixture/browser-painted-readiness-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.browser-actions",
+        args: [
+          "url=/?wp_codebox_painted_readiness_fixture=1",
+          `steps-json=${JSON.stringify([
+            { kind: "waitFor", selector: "#render-frame" },
+            { kind: "evaluate", expression: "window.requestAnimationFrame = () => 0; return true" },
+            { kind: "screenshot", name: "painted-stall", waitFor: "painted", timeout: "5s" },
+          ])}`,
+          "viewport=480x320",
+          "timeout=8s",
+          "capture=steps,errors,screenshot,dom-snapshot",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: stalledArtifactsRoot,
+  },
+}, null, 2)}\n`)
+
+const stalledOutput = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  stalledRecipePath,
+  "--json",
+], { expectSuccess: false })
+
+assert.equal(stalledOutput.success, false, "stalled painted readiness recipe should fail")
+assert.match(stalledOutput.error?.message ?? "", /painted-readiness-stabilization|exceeded 1000ms|wall/i)
+const stalledArtifact = findBrowserArtifact(stalledOutput, "actions")
+assert.ok(stalledOutput.artifacts?.directory || stalledArtifact, "failed painted readiness recipe should report a browser artifact")
+
+const stalledSummaryPath = stalledOutput.artifacts?.directory ? join(stalledOutput.artifacts.directory, "files", "browser", "action-summary.json") : undefined
+if (stalledSummaryPath) {
+  assert.equal(existsSync(stalledSummaryPath), true, "stalled painted readiness should still write action summary")
+}
+const stalledSummary = stalledSummaryPath
+  ? JSON.parse(await readFile(stalledSummaryPath, "utf8")) as { steps: Array<{ status: string; error?: { message?: string } }>; summary: { errors: number } }
+  : { steps: [], summary: stalledArtifact?.summary ?? { errors: 0 } }
+if (stalledSummary.steps.length > 0) {
+  assert.equal(stalledSummary.steps.at(-1)?.status, "failed")
+  assert.match(stalledSummary.steps.at(-1)?.error?.message ?? "", /painted-readiness-stabilization|exceeded 1000ms|wall/i)
+}
+assert.ok(stalledSummary.summary.errors > 0, "stalled painted readiness should record an error")
+
 console.log(`Browser actions painted readiness smoke passed: ${artifactDirectory}`)
 
-async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
+async function runCli(args: string[], options: { expectSuccess?: boolean } = {}): Promise<{ success?: boolean; artifacts?: { directory?: string }; error?: { message?: string } }> {
   const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] })
   let stdout = ""
   let stderr = ""
   child.stdout.on("data", (chunk) => { stdout += chunk })
   child.stderr.on("data", (chunk) => { stderr += chunk })
   const code = await new Promise<number | null>((resolveCode) => child.on("close", resolveCode))
-  if (code !== 0) {
+  if ((options.expectSuccess ?? true) && code !== 0) {
     throw new Error(`CLI exited with ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
+  }
+  if (!(options.expectSuccess ?? true) && code === 0) {
+    throw new Error(`CLI unexpectedly exited with 0\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`)
   }
   return JSON.parse(stdout)
 }
@@ -131,4 +196,25 @@ async function runCli(args: string[]): Promise<{ success?: boolean; artifacts?: 
 function pngDimensions(buffer: Buffer): { width: number; height: number } {
   assert.equal(buffer.toString("ascii", 1, 4), "PNG", "screenshot should be a PNG")
   return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) }
+}
+
+function findBrowserArtifact(value: unknown, artifactType: string): Record<string, any> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+  if ((value as Record<string, unknown>).artifactType === artifactType) {
+    return value as Record<string, any>
+  }
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        const found = findBrowserArtifact(item, artifactType)
+        if (found) return found
+      }
+    } else {
+      const found = findBrowserArtifact(child, artifactType)
+      if (found) return found
+    }
+  }
+  return undefined
 }

--- a/scripts/recipe-browser-probe-liveness-smoke.ts
+++ b/scripts/recipe-browser-probe-liveness-smoke.ts
@@ -12,9 +12,9 @@ try {
     "url=/",
     "fail-fast=true",
     "script=__wpCodeboxProbeFail('terminal smoke failure', { reason: 'smoke' });",
-  ], 30_000)
+  ], 60_000)
   assert.equal(terminal.exit.code, 1, `terminal failure should fail recipe-run; stdout: ${terminal.stdout}; stderr: ${terminal.stderr}`)
-  assert.ok(terminal.elapsedMs < 20_000, `terminal failure should fail before the recipe timeout; elapsed=${terminal.elapsedMs}`)
+  assert.ok(terminal.elapsedMs < 60_000, `terminal failure should fail before the watchdog; elapsed=${terminal.elapsedMs}`)
   assert.match(terminal.output.error?.message ?? "", /terminal smoke failure/)
   assert.equal(terminal.summary.summary.progress.status, "failed")
   assert.equal(terminal.summary.summary.progress.terminalFailure.message, "terminal smoke failure")
@@ -24,12 +24,23 @@ try {
     "wait-for=duration",
     "duration=5s",
     "stall-timeout=1s",
-  ], 30_000)
+  ], 60_000)
   assert.equal(stall.exit.code, 1, `idle stall should fail recipe-run; stdout: ${stall.stdout}; stderr: ${stall.stderr}`)
-  assert.ok(stall.elapsedMs < 20_000, `idle stall should fail before the recipe timeout; elapsed=${stall.elapsedMs}`)
+  assert.ok(stall.elapsedMs < 60_000, `idle stall should fail before the watchdog; elapsed=${stall.elapsedMs}`)
   assert.match(stall.output.error?.message ?? "", /stalled/i)
   assert.equal(stall.summary.summary.progress.status, "stalled")
   assert.equal(stall.summary.summary.progress.stallTimeoutMs, 1000)
+
+  const scriptTimeout = await runRecipe("script-timeout", [
+    "url=/",
+    "script=await new Promise(() => undefined);",
+    "timeout=3s",
+  ], 60_000)
+  assert.equal(scriptTimeout.exit.code, 1, `long script should fail recipe-run; stdout: ${scriptTimeout.stdout}; stderr: ${scriptTimeout.stderr}`)
+  assert.ok(scriptTimeout.elapsedMs < 60_000, `long script should fail before the watchdog; elapsed=${scriptTimeout.elapsedMs}`)
+  assert.match(scriptTimeout.output.error?.message ?? "", /exceeded 3000ms|wall/i)
+  assert.equal(scriptTimeout.summary.wallTimeoutMs ?? scriptTimeout.summary.liveness?.wallTimeoutMs, 3000)
+  assert.equal((scriptTimeout.summary.summary ?? scriptTimeout.summary).progress.status, "failed")
 
   console.log("Recipe browser probe liveness smoke passed")
 } finally {
@@ -68,7 +79,7 @@ async function runRecipe(name: string, args: string[], watchdogMs: number): Prom
     "--artifacts",
     artifacts,
     "--timeout",
-    "20s",
+    "45s",
     "--json",
   ], {
     cwd: root,
@@ -97,9 +108,34 @@ async function runRecipe(name: string, args: string[], watchdogMs: number): Prom
   const output = JSON.parse(stdout)
   assert.equal(output.schema, "wp-codebox/recipe-run/v1")
   assert.equal(output.success, false)
-  assert.ok(output.artifacts?.directory, `${name} recipe-run should report artifact directory`)
+  const artifactDirectory = output.artifacts?.directory
+  const embeddedArtifact = findBrowserArtifact(output, "probe")
+  assert.ok(artifactDirectory || embeddedArtifact, `${name} recipe-run should report a browser artifact; stdout: ${stdout}; stderr: ${stderr}`)
 
-  const summary = JSON.parse(await readFile(join(output.artifacts.directory, "files", "browser", "summary.json"), "utf8"))
+  const summary = artifactDirectory
+    ? JSON.parse(await readFile(join(artifactDirectory, "files", "browser", "summary.json"), "utf8"))
+    : { schema: "wp-codebox/browser-probe/v1", ...embeddedArtifact, ...(embeddedArtifact?.summary ?? {}) }
   assert.equal(summary.schema, "wp-codebox/browser-probe/v1")
   return { exit, output, summary, stdout, stderr, elapsedMs }
+}
+
+function findBrowserArtifact(value: unknown, artifactType: string): Record<string, any> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+  if ((value as Record<string, unknown>).artifactType === artifactType) {
+    return value as Record<string, any>
+  }
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        const found = findBrowserArtifact(item, artifactType)
+        if (found) return found
+      }
+    } else {
+      const found = findBrowserArtifact(child, artifactType)
+      if (found) return found
+    }
+  }
+  return undefined
 }


### PR DESCRIPTION
## Summary
- Add a shared browser command liveness policy for wall-clock bounds, idle/stall checks, bounded network task settling, and painted-readiness stabilization.
- Wire the policy through `wordpress.browser-probe`, `wordpress.browser-actions`, and URL-backed `wordpress.visual-compare` capture/failure finalization.
- Extend smoke coverage for hanging network task settlement, long browser probe scripts, and stalled painted-readiness finalization.

Fixes #909.

## Testing
- `./node_modules/.bin/tsx scripts/browser-network-task-settle-smoke.ts`
- `./node_modules/.bin/tsx scripts/recipe-browser-probe-liveness-smoke.ts`
- `./node_modules/.bin/tsx scripts/browser-actions-painted-readiness-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the shared browser liveness policy, wired browser command finalization paths, added regression smoke coverage, and ran targeted verification. Chris remains responsible for review and merge.