### PR TITLE
Capture browser document 5xx diagnostics

### DIFF
--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -768,6 +768,9 @@ export interface BrowserProbeNetworkRecord {
   bodySize?: number
   requestBodySize?: number
   responseBodySize?: number
+  responseTextPreview?: string
+  responseTextSha256?: string
+  responseTextTruncated?: boolean
   failure?: ReturnType<Request["failure"]>
 }
 

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -1367,12 +1367,16 @@ function sanitizeBrowserRedirectMessage(message: string): string {
 
 interface BrowserWordPressDiagnosticRecord {
   schema: "wp-codebox/browser-wordpress-diagnostic-record/v1"
-  classification: "php-fatal"
+  classification: "php-fatal" | "http-5xx-status" | "http-response-code-5xx"
   severity: "error"
-  errorType: number
+  errorType?: number
   message: string
-  file: string
-  line: number
+  file?: string
+  line?: number
+  status?: number
+  statusHeader?: string
+  requestUri?: string
+  backtrace?: Array<{ file?: string; line?: number; function?: string; class?: string; type?: string }>
   capturedAt: string
 }
 
@@ -1381,7 +1385,7 @@ interface BrowserWordPressDiagnosticsArtifact {
   version: 1
   capturedAt: string
   status: BrowserWordPressDiagnosticsSummary["status"]
-  document5xxResponses: Array<{ url: string; status: number; statusText?: string }>
+  document5xxResponses: Array<{ url: string; status: number; statusText?: string; responseTextPreview?: string; responseTextSha256?: string; responseTextTruncated?: boolean }>
   diagnostics: BrowserWordPressDiagnosticRecord[]
   summary: BrowserWordPressDiagnosticsSummary
 }
@@ -1397,30 +1401,90 @@ if ( ! defined( 'WPINC' ) ) {
     return;
 }
 
+function wp_codebox_browser_diagnostics_write( array $record ): void {
+    file_put_contents( WP_CONTENT_DIR . '/wp-codebox-browser-diagnostics.jsonl', wp_json_encode( $record ) . "\n", FILE_APPEND | LOCK_EX );
+}
+
+function wp_codebox_browser_diagnostics_backtrace(): array {
+    $frames = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 12 );
+    $frames = array_slice( $frames, 2 );
+
+    return array_map(
+        static function ( array $frame ): array {
+            return array_filter(
+                array(
+                    'file'     => isset( $frame['file'] ) ? (string) $frame['file'] : null,
+                    'line'     => isset( $frame['line'] ) ? (int) $frame['line'] : null,
+                    'function' => isset( $frame['function'] ) ? (string) $frame['function'] : null,
+                    'class'    => isset( $frame['class'] ) ? (string) $frame['class'] : null,
+                    'type'     => isset( $frame['type'] ) ? (string) $frame['type'] : null,
+                ),
+                static fn ( $value ) => null !== $value && '' !== $value
+            );
+        },
+        $frames
+    );
+}
+
+add_filter(
+    'status_header',
+    static function ( string $status_header, int $code ): string {
+        if ( $code >= 500 && $code < 600 ) {
+            wp_codebox_browser_diagnostics_write(
+                array(
+                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
+                    'classification' => 'http-5xx-status',
+                    'severity'       => 'error',
+                    'status'         => $code,
+                    'statusHeader'   => $status_header,
+                    'requestUri'     => isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '',
+                    'message'        => 'WordPress emitted a 5xx status header during browser navigation.',
+                    'backtrace'      => wp_codebox_browser_diagnostics_backtrace(),
+                    'capturedAt'     => gmdate( 'c' ),
+                )
+            );
+        }
+
+        return $status_header;
+    },
+    10,
+    2
+);
+
 register_shutdown_function(
     static function (): void {
         $error = error_get_last();
-        if ( ! is_array( $error ) ) {
-            return;
-        }
-
         $fatal_types = array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR );
-        if ( ! in_array( $error['type'] ?? null, $fatal_types, true ) ) {
+        if ( is_array( $error ) && in_array( $error['type'] ?? null, $fatal_types, true ) ) {
+            wp_codebox_browser_diagnostics_write(
+                array(
+                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
+                    'classification' => 'php-fatal',
+                    'severity'       => 'error',
+                    'errorType'      => (int) ( $error['type'] ?? 0 ),
+                    'message'        => (string) ( $error['message'] ?? '' ),
+                    'file'           => (string) ( $error['file'] ?? '' ),
+                    'line'           => (int) ( $error['line'] ?? 0 ),
+                    'capturedAt'     => gmdate( 'c' ),
+                )
+            );
             return;
         }
 
-        $record = array(
-            'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
-            'classification' => 'php-fatal',
-            'severity'       => 'error',
-            'errorType'      => (int) ( $error['type'] ?? 0 ),
-            'message'        => (string) ( $error['message'] ?? '' ),
-            'file'           => (string) ( $error['file'] ?? '' ),
-            'line'           => (int) ( $error['line'] ?? 0 ),
-            'capturedAt'     => gmdate( 'c' ),
-        );
-
-        file_put_contents( WP_CONTENT_DIR . '/wp-codebox-browser-diagnostics.jsonl', wp_json_encode( $record ) . "\n", FILE_APPEND | LOCK_EX );
+        $status = http_response_code();
+        if ( is_int( $status ) && $status >= 500 && $status < 600 ) {
+            wp_codebox_browser_diagnostics_write(
+                array(
+                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
+                    'classification' => 'http-response-code-5xx',
+                    'severity'       => 'error',
+                    'status'         => $status,
+                    'requestUri'     => isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '',
+                    'message'        => 'Browser navigation finished with a 5xx HTTP response code and no PHP fatal.',
+                    'capturedAt'     => gmdate( 'c' ),
+                )
+            );
+        }
     }
 );
 `
@@ -1475,9 +1539,12 @@ async function browserWordPressDiagnosticsArtifact({
   const document5xxResponses = network
     .filter((record) => record.type === "response" && record.resourceType === "document" && typeof record.status === "number" && record.status >= 500 && record.status < 600)
     .map((record) => ({
-      url: safeBrowserProbeUrl(record.url) ?? record.url,
+      url: browserRedirectSafeUrl(safeBrowserProbeUrl(record.url) ?? record.url),
       status: record.status as number,
       ...(record.statusText ? { statusText: record.statusText } : {}),
+      ...(record.responseTextPreview ? { responseTextPreview: record.responseTextPreview } : {}),
+      ...(record.responseTextSha256 ? { responseTextSha256: record.responseTextSha256 } : {}),
+      ...(typeof record.responseTextTruncated === "boolean" ? { responseTextTruncated: record.responseTextTruncated } : {}),
     }))
 
   if (document5xxResponses.length === 0) {
@@ -1543,20 +1610,64 @@ function parseBrowserWordPressDiagnosticRecord(line: string): BrowserWordPressDi
   }
 
   const record = parsed as Record<string, unknown>
-  if (record.schema !== "wp-codebox/browser-wordpress-diagnostic-record/v1" || record.classification !== "php-fatal") {
+  if (record.schema !== "wp-codebox/browser-wordpress-diagnostic-record/v1" || !isBrowserWordPressDiagnosticClassification(record.classification)) {
     return undefined
   }
 
+  const classification = record.classification
+
   return {
     schema: "wp-codebox/browser-wordpress-diagnostic-record/v1",
-    classification: "php-fatal",
+    classification,
     severity: "error",
-    errorType: typeof record.errorType === "number" && Number.isFinite(record.errorType) ? record.errorType : 0,
-    message: typeof record.message === "string" ? record.message : "",
-    file: typeof record.file === "string" ? record.file : "",
-    line: typeof record.line === "number" && Number.isFinite(record.line) ? record.line : 0,
+    ...(typeof record.errorType === "number" && Number.isFinite(record.errorType) ? { errorType: record.errorType } : {}),
+    message: sanitizeBrowserWordPressDiagnosticString(typeof record.message === "string" ? record.message : ""),
+    ...(typeof record.file === "string" && record.file.length > 0 ? { file: sanitizeBrowserWordPressDiagnosticString(record.file) } : {}),
+    ...(typeof record.line === "number" && Number.isFinite(record.line) ? { line: record.line } : {}),
+    ...(typeof record.status === "number" && Number.isFinite(record.status) ? { status: record.status } : {}),
+    ...(typeof record.statusHeader === "string" && record.statusHeader.length > 0 ? { statusHeader: sanitizeBrowserWordPressDiagnosticString(record.statusHeader) } : {}),
+    ...(typeof record.requestUri === "string" && record.requestUri.length > 0 ? { requestUri: sanitizeBrowserWordPressDiagnosticRequestUri(record.requestUri) } : {}),
+    ...(Array.isArray(record.backtrace) ? { backtrace: sanitizeBrowserWordPressDiagnosticBacktrace(record.backtrace) } : {}),
     capturedAt: typeof record.capturedAt === "string" ? record.capturedAt : now(),
   }
+}
+
+function isBrowserWordPressDiagnosticClassification(value: unknown): value is BrowserWordPressDiagnosticRecord["classification"] {
+  return value === "php-fatal" || value === "http-5xx-status" || value === "http-response-code-5xx"
+}
+
+function sanitizeBrowserWordPressDiagnosticString(value: string): string {
+  return value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, (url) => browserRedirectSafeUrl(url))
+    .replace(/([?&][^=&#\s"'<>]+)=([^&#\s"'<>]+)/g, "$1=[redacted]")
+    .replace(/((?:access[_-]?token|auth|bearer|code|cookie|credential|key|login|nonce|pass|password|secret|session|state|token)["'\s:=]+)[^\s"'<>]+/gi, "$1[redacted]")
+}
+
+function sanitizeBrowserWordPressDiagnosticRequestUri(value: string): string {
+  try {
+    const parsed = new URL(value, "http://wp-codebox.local")
+    const queryKeys = [...new Set([...parsed.searchParams.keys()])].sort()
+    const query = queryKeys.length > 0 ? `?${queryKeys.map((key) => `${encodeURIComponent(key)}=[redacted]`).join("&")}` : ""
+    return `${parsed.pathname || "/"}${query}${parsed.hash ? "#[redacted]" : ""}`
+  } catch {
+    return sanitizeBrowserWordPressDiagnosticString(value)
+  }
+}
+
+function sanitizeBrowserWordPressDiagnosticBacktrace(value: unknown[]): BrowserWordPressDiagnosticRecord["backtrace"] {
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return []
+    }
+    const frame = entry as Record<string, unknown>
+    return [{
+      ...(typeof frame.file === "string" && frame.file.length > 0 ? { file: sanitizeBrowserWordPressDiagnosticString(frame.file) } : {}),
+      ...(typeof frame.line === "number" && Number.isFinite(frame.line) ? { line: frame.line } : {}),
+      ...(typeof frame.function === "string" && frame.function.length > 0 ? { function: sanitizeBrowserWordPressDiagnosticString(frame.function) } : {}),
+      ...(typeof frame.class === "string" && frame.class.length > 0 ? { class: sanitizeBrowserWordPressDiagnosticString(frame.class) } : {}),
+      ...(typeof frame.type === "string" && frame.type.length > 0 ? { type: sanitizeBrowserWordPressDiagnosticString(frame.type) } : {}),
+    }]
+  }).slice(0, 12)
 }
 
 export async function runHtmlCaptureCommand(input: {

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { access, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import type { ArtifactManifest } from "@automattic/wp-codebox-core"
@@ -546,6 +547,7 @@ export async function serializeBrowserResponse(response: Response, timestamp = n
   const request = response.request()
   const sizes = await browserRequestSizes(request)
   const transferSize = sizes ? sizes.responseHeadersSize + sizes.responseBodySize : undefined
+  const responseTextPreview = await browserDocument5xxResponsePreview(response)
   return {
     type: "response",
     url: response.url(),
@@ -561,7 +563,54 @@ export async function serializeBrowserResponse(response: Response, timestamp = n
     ...(sizes ? { bodySize: sizes.responseBodySize } : {}),
     ...(sizes ? { requestBodySize: sizes.requestBodySize } : {}),
     ...(sizes ? { responseBodySize: sizes.responseBodySize } : {}),
+    ...responseTextPreview,
     timestamp,
+  }
+}
+
+async function browserDocument5xxResponsePreview(response: Response): Promise<Pick<BrowserProbeNetworkRecord, "responseTextPreview" | "responseTextSha256" | "responseTextTruncated">> {
+  if (response.request().resourceType() !== "document" || response.status() < 500 || response.status() >= 600) {
+    return {}
+  }
+
+  const contentType = response.headers()["content-type"] ?? ""
+  if (contentType && !/\b(?:html|json|javascript|text|xml)\b/i.test(contentType)) {
+    return {}
+  }
+
+  let body = ""
+  try {
+    body = await response.text()
+  } catch {
+    return {}
+  }
+
+  const maxPreviewLength = 4096
+  const sanitized = redactBrowserResponseText(body)
+  const preview = sanitized.length > maxPreviewLength ? sanitized.slice(0, maxPreviewLength) : sanitized
+
+  return {
+    responseTextPreview: preview,
+    responseTextSha256: createHash("sha256").update(sanitized).digest("hex"),
+    responseTextTruncated: preview !== sanitized,
+  }
+}
+
+function redactBrowserResponseText(body: string): string {
+  return body
+    .replace(/https?:\/\/[^\s"'<>]+/gi, (match) => redactBrowserUrlQueryValues(match))
+    .replace(/([?&][^=&#\s"'<>]+)=([^&#\s"'<>]+)/g, "$1=[redacted]")
+    .replace(/((?:access[_-]?token|auth|bearer|code|cookie|credential|key|login|nonce|pass|password|secret|session|state|token)["'\s:=]+)[^\s"'<>]+/gi, "$1[redacted]")
+}
+
+function redactBrowserUrlQueryValues(value: string): string {
+  try {
+    const url = new URL(value)
+    const queryKeys = [...new Set([...url.searchParams.keys()])].sort()
+    const query = queryKeys.length > 0 ? `?${queryKeys.map((key) => `${encodeURIComponent(key)}=[redacted]`).join("&")}` : ""
+    return `${url.origin}${url.pathname}${query}${url.hash ? "#[redacted]" : ""}`
+  } catch {
+    return value
   }
 }
 

--- a/scripts/browser-wordpress-500-diagnostics-smoke.ts
+++ b/scripts/browser-wordpress-500-diagnostics-smoke.ts
@@ -8,7 +8,9 @@ const repoRoot = resolve(import.meta.dirname, "..")
 const workspace = resolve(repoRoot, "artifacts", "browser-wordpress-500-diagnostics-smoke")
 const pluginDir = join(workspace, "fatal-fixture")
 const recipePath = join(workspace, "recipe.json")
+const actionRecipePath = join(workspace, "action-recipe.json")
 const artifactsRoot = join(workspace, "artifacts")
+const actionArtifactsRoot = join(workspace, "action-artifacts")
 
 await rm(workspace, { recursive: true, force: true })
 await mkdir(pluginDir, { recursive: true })
@@ -22,6 +24,15 @@ add_action( 'init', static function (): void {
     if ( isset( $_GET['wp_codebox_browser_fatal'] ) ) {
         status_header( 500 );
         wp_codebox_missing_browser_diagnostics_fixture_function();
+    }
+} );
+
+add_action( 'template_redirect', static function (): void {
+    if ( isset( $_GET['wp_codebox_browser_status'] ) ) {
+        status_header( 500 );
+        header( 'Content-Type: text/html; charset=utf-8' );
+        echo '<!doctype html><title>Fixture 500</title><main>status body https://example.test/callback?token=super-secret-token&safe=visible password=super-secret-password</main>';
+        exit;
     }
 } );
 `)
@@ -41,12 +52,40 @@ await writeFile(recipePath, `${JSON.stringify({
     steps: [
       {
         command: "wordpress.capture-html",
-        args: ["url=/?wp_codebox_browser_fatal=1"],
+        args: ["url=/?wp_codebox_browser_fatal=1&token=super-secret-token"],
       },
     ],
   },
   artifacts: {
     directory: artifactsRoot,
+  },
+}, null, 2)}\n`)
+
+await writeFile(actionRecipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    extra_plugins: [
+      {
+        source: "./fatal-fixture",
+        plugin_file: "fatal-fixture/fatal-fixture.php",
+        activate: true,
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.browser-actions",
+        args: [
+          "url=/",
+          `steps-json=${JSON.stringify([{ kind: "navigate", url: "/?wp_codebox_browser_status=1&token=super-secret-token&safe=visible" }])}`,
+          "capture=steps,network,html",
+        ],
+      },
+    ],
+  },
+  artifacts: {
+    directory: actionArtifactsRoot,
   },
 }, null, 2)}\n`)
 
@@ -72,22 +111,29 @@ assert.equal(existsSync(diagnosticsPath), true, "wordpress-diagnostics.json shou
 const diagnostics = JSON.parse(await readFile(diagnosticsPath, "utf8")) as {
   schema: string
   status: string
-  document5xxResponses: Array<{ status: number }>
-  diagnostics: Array<{ classification: string; message: string; file: string; line: number }>
+  document5xxResponses: Array<{ url: string; status: number; responseTextPreview?: string; responseTextSha256?: string; responseTextTruncated?: boolean }>
+  diagnostics: Array<{ classification: string; message: string; file?: string; line?: number; status?: number; requestUri?: string }>
   summary: { artifact?: string; document5xxResponses: number; diagnostics: number; fatalErrors: number; classifications: string[] }
 }
 assert.equal(diagnostics.schema, "wp-codebox/browser-wordpress-diagnostics/v1")
 assert.equal(diagnostics.status, "captured")
 assert.equal(diagnostics.document5xxResponses[0]?.status, 500)
+assert.equal(diagnostics.document5xxResponses[0]?.url.includes("token=[redacted]"), true)
+assert.equal(typeof diagnostics.document5xxResponses[0]?.responseTextSha256, "string")
+assert.equal(diagnostics.document5xxResponses[0]?.responseTextTruncated, false)
 assert.equal(diagnostics.summary.artifact, "files/browser/wordpress-diagnostics.json")
 assert.equal(diagnostics.summary.document5xxResponses, 1)
-assert.equal(diagnostics.summary.diagnostics, 1)
+assert.equal(diagnostics.summary.diagnostics, 2)
 assert.equal(diagnostics.summary.fatalErrors, 1)
-assert.deepEqual(diagnostics.summary.classifications, ["php-fatal"])
-assert.equal(diagnostics.diagnostics[0]?.classification, "php-fatal")
-assert.match(diagnostics.diagnostics[0]?.message ?? "", /wp_codebox_missing_browser_diagnostics_fixture_function/)
-assert.match(diagnostics.diagnostics[0]?.file ?? "", /fatal-fixture\.php$/)
-assert.ok((diagnostics.diagnostics[0]?.line ?? 0) > 0, "diagnostic should include a line number")
+assert.deepEqual(diagnostics.summary.classifications, ["http-5xx-status", "php-fatal"])
+const fatalDiagnostic = diagnostics.diagnostics.find((diagnostic) => diagnostic.classification === "php-fatal")
+const statusDiagnostic = diagnostics.diagnostics.find((diagnostic) => diagnostic.classification === "http-5xx-status")
+assert.match(fatalDiagnostic?.message ?? "", /wp_codebox_missing_browser_diagnostics_fixture_function/)
+assert.match(fatalDiagnostic?.file ?? "", /fatal-fixture\.php$/)
+assert.ok((fatalDiagnostic?.line ?? 0) > 0, "fatal diagnostic should include a line number")
+assert.equal(statusDiagnostic?.status, 500)
+assert.equal(statusDiagnostic?.requestUri?.includes("token=[redacted]"), true)
+assert.doesNotMatch(JSON.stringify(diagnostics), /super-secret-token|super-secret-password/, "diagnostics artifact must not expose fixture secrets")
 
 const summary = JSON.parse(await readFile(summaryPath, "utf8")) as {
   files: { wordpressDiagnostics?: string }
@@ -98,7 +144,7 @@ assert.equal(summary.files.wordpressDiagnostics, "files/browser/wordpress-diagno
 assert.equal(summary.summary.wordpressDiagnostics?.artifact, "files/browser/wordpress-diagnostics.json")
 assert.equal(summary.summary.wordpressDiagnostics?.document5xxResponses, 1)
 assert.equal(summary.summary.wordpressDiagnostics?.fatalErrors, 1)
-assert.deepEqual(summary.summary.wordpressDiagnostics?.classifications, ["php-fatal"])
+assert.deepEqual(summary.summary.wordpressDiagnostics?.classifications, ["http-5xx-status", "php-fatal"])
 
 const review = JSON.parse(await readFile(reviewPath, "utf8")) as { browser?: { probes?: Array<{ wordpressDiagnostics?: { artifact?: string; fatalErrors: number } }> } }
 assert.equal(review.browser?.probes?.[0]?.wordpressDiagnostics?.artifact, "files/browser/wordpress-diagnostics.json")
@@ -106,6 +152,45 @@ assert.equal(review.browser?.probes?.[0]?.wordpressDiagnostics?.fatalErrors, 1)
 
 const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { files: Array<{ path: string; kind: string }> }
 assert.ok(manifest.files.some((file) => file.path === "files/browser/wordpress-diagnostics.json" && file.kind === "browser-wordpress-diagnostics"))
+
+const actionOutput = await runCli([
+  "packages/cli/dist/index.js",
+  "recipe-run",
+  "--recipe",
+  actionRecipePath,
+  "--json",
+], 0)
+
+assert.equal(actionOutput.success, true, actionOutput.error?.message ?? "browser-actions recipe-run failed")
+assert.ok(actionOutput.artifacts?.directory, "browser-actions recipe-run should return an artifact directory")
+
+const actionArtifactDirectory = actionOutput.artifacts.directory
+const actionDiagnosticsPath = join(actionArtifactDirectory, "files", "browser", "wordpress-diagnostics.json")
+const actionSummaryPath = join(actionArtifactDirectory, "files", "browser", "action-summary.json")
+
+assert.equal(existsSync(actionDiagnosticsPath), true, "browser-actions should capture wordpress-diagnostics.json for document 5xx")
+const actionDiagnostics = JSON.parse(await readFile(actionDiagnosticsPath, "utf8")) as typeof diagnostics
+assert.equal(actionDiagnostics.status, "captured")
+assert.equal(actionDiagnostics.document5xxResponses[0]?.status, 500)
+assert.equal(actionDiagnostics.document5xxResponses[0]?.url.includes("token=[redacted]"), true)
+assert.match(actionDiagnostics.document5xxResponses[0]?.responseTextPreview ?? "", /status body/)
+assert.match(actionDiagnostics.document5xxResponses[0]?.responseTextPreview ?? "", /token=\[redacted\]/)
+assert.match(actionDiagnostics.document5xxResponses[0]?.responseTextPreview ?? "", /password=\[redacted\]/)
+assert.equal(typeof actionDiagnostics.document5xxResponses[0]?.responseTextSha256, "string")
+assert.equal(actionDiagnostics.summary.document5xxResponses, 1)
+assert.equal(actionDiagnostics.summary.fatalErrors, 0)
+assert.deepEqual(actionDiagnostics.summary.classifications, ["http-5xx-status", "http-response-code-5xx"])
+assert.equal(actionDiagnostics.diagnostics.some((diagnostic) => diagnostic.classification === "http-5xx-status" && diagnostic.status === 500), true)
+assert.equal(actionDiagnostics.diagnostics.some((diagnostic) => diagnostic.classification === "http-response-code-5xx" && diagnostic.status === 500), true)
+assert.doesNotMatch(JSON.stringify(actionDiagnostics), /super-secret-token|super-secret-password/, "browser-actions diagnostics must not expose fixture secrets")
+
+const actionSummary = JSON.parse(await readFile(actionSummaryPath, "utf8")) as {
+  files: { wordpressDiagnostics?: string }
+  summary: { wordpressDiagnostics?: { artifact?: string; document5xxResponses: number; fatalErrors: number; classifications: string[] } }
+}
+assert.equal(actionSummary.files.wordpressDiagnostics, "files/browser/wordpress-diagnostics.json")
+assert.equal(actionSummary.summary.wordpressDiagnostics?.document5xxResponses, 1)
+assert.deepEqual(actionSummary.summary.wordpressDiagnostics?.classifications, ["http-5xx-status", "http-response-code-5xx"])
 
 console.log(`Browser WordPress 500 diagnostics smoke passed: ${artifactDirectory}`)
 


### PR DESCRIPTION
## Summary
- Captures reviewer-safe `wordpress-diagnostics.json` artifacts for document 5xx responses in `wordpress.browser-probe` and `wordpress.browser-actions`.
- Adds sanitized response previews and sanitized-body hashes for safe text-like document 5xx responses.
- Extends the browser-installed WordPress MU diagnostics plugin to report PHP fatals, status-header 5xx records, shutdown 5xx records, and summary classifications.

Fixes #914.

## Verification
- `npm run build`
- `npx tsx scripts/browser-wordpress-500-diagnostics-smoke.ts`
- `npx tsx scripts/browser-redirect-chain-diagnostics-smoke.ts`
- `npx tsx scripts/browser-probe-routed-admin-auth-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the browser diagnostics update, expanded smoke coverage, and ran the verification commands. Chris remains responsible for review and merge.