### PR TITLE
Fix provider registry preflight class reference

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -324,7 +324,8 @@ function wp_codebox_validate_requested_provider(array $agent_input, array $sandb
     if ('' === $provider) {
         return null;
     }
-    if (!class_exists('WordPress\\AiClient\\Providers\\ProviderRegistry')) {
+    $provider_registry_class = \\WordPress\\AiClient\\Providers\\ProviderRegistry::class;
+    if (!class_exists($provider_registry_class)) {
         return array(
             'code' => 'wp_codebox_provider_registry_unavailable',
             'message' => 'The requested provider could not be validated because the wp-ai-client provider registry is unavailable inside the sandbox.',
@@ -336,7 +337,7 @@ function wp_codebox_validate_requested_provider(array $agent_input, array $sandb
         );
     }
 
-    $registry = new WordPress\AiClient\Providers\ProviderRegistry();
+    $registry = new $provider_registry_class();
     if (method_exists($registry, 'isProviderConfigured') && $registry->isProviderConfigured($provider)) {
         return null;
     }

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -168,6 +168,15 @@ const structuredTaskCode = await resolveSandboxTaskCode({
 })
 assert.ok(structuredTaskCode.includes("structured_artifacts"), "sandbox agent input should include structured artifact context")
 assert.ok(structuredTaskCode.includes("ConceptPacket"), "sandbox agent input should preserve structured artifact names")
+const providerRegistryClassReference = String.raw`\WordPress\AiClient\Providers\ProviderRegistry::class`
+assert.ok(
+  structuredTaskCode.includes(providerRegistryClassReference),
+  "generated sandbox PHP should preserve ProviderRegistry namespace separators",
+)
+assert.ok(
+  !structuredTaskCode.includes("WordPressAiClientProvidersProviderRegistry"),
+  "generated sandbox PHP should not flatten ProviderRegistry into an invalid class name",
+)
 
 const outputTaskResult = buildAgentTaskSingleResult({
   schema: "wp-codebox/agent-transcript/v1",


### PR DESCRIPTION
## Summary
- Fixes the generated sandbox provider preflight to reference `\WordPress\AiClient\Providers\ProviderRegistry::class` through escaped TypeScript template output instead of allowing PHP namespace separators to flatten.
- Instantiates the registry through the class-string variable so `class_exists()` and construction use the same generic wp-ai-client provider registry reference.
- Adds smoke coverage against the generated sandbox PHP string to catch `WordPressAiClientProvidersProviderRegistry` regressions.

Fixes #916.

## Testing
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the provider preflight escaping fix, added regression smoke coverage, and ran focused verification. Chris remains responsible for review and merge.