### PR TITLE
Serialize preview proxy asset requests

### DIFF
--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -86,7 +86,24 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
 }
 
 function previewProxyServer(target: URL): PreviewProxyServer {
+  const upstreamQueue = createPreviewProxyQueue()
+
   return createHttpServer((incoming, outgoing) => {
+    upstreamQueue(() => proxyPreviewRequest(target, incoming, outgoing)).catch((error: Error) => writeProxyError(outgoing, error))
+  })
+}
+
+function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+    const settle = () => {
+      if (settled) {
+        return
+      }
+      settled = true
+      resolve()
+    }
+
     const targetRequest = httpRequest(
       {
         protocol: target.protocol,
@@ -98,15 +115,59 @@ function previewProxyServer(target: URL): PreviewProxyServer {
       },
       (targetResponse) => {
         outgoing.writeHead(targetResponse.statusCode ?? 502, targetResponse.statusMessage, proxyResponseHeaders(targetResponse.headers))
-        targetResponse.on("error", (error) => outgoing.destroy(error))
+        targetResponse.on("error", (error) => {
+          outgoing.destroy(error)
+          settle()
+        })
+        outgoing.on("finish", settle)
+        outgoing.on("close", settle)
         targetResponse.pipe(outgoing)
       },
     )
 
-    targetRequest.on("error", (error) => writeProxyError(outgoing, error))
-    incoming.on("error", () => targetRequest.destroy())
+    targetRequest.on("error", (error) => {
+      writeProxyError(outgoing, error)
+      settle()
+    })
+    incoming.on("error", () => {
+      targetRequest.destroy()
+      settle()
+    })
     incoming.pipe(targetRequest)
   })
+}
+
+function createPreviewProxyQueue(): (task: () => Promise<void>) => Promise<void> {
+  let active = false
+  const pending: Array<() => void> = []
+
+  const acquire = async () => {
+    if (!active) {
+      active = true
+      return
+    }
+
+    await new Promise<void>((resolve) => pending.push(resolve))
+  }
+
+  const release = () => {
+    const next = pending.shift()
+    if (next) {
+      next()
+      return
+    }
+
+    active = false
+  }
+
+  return async (task) => {
+    await acquire()
+    try {
+      await task()
+    } finally {
+      release()
+    }
+  }
 }
 
 async function listenPreviewProxy(proxy: PreviewProxyServer, port: number, bind: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Serialize fixed-port preview proxy requests before forwarding them to the Playground server.
- Prevent browser asset fanout from overloading/resetting the Playground preview server during public preview proof runs.
- Keeps mounted plugin asset previews working across IPv4/IPv6 loopback smoke coverage.

## Testing
- npm run build
- npx tsx scripts/preview-mounted-plugin-asset-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Homeboy/WP Codebox preview asset failure, drafted the proxy queue fix, and ran focused verification; Chris remains responsible for review and merge.