### PR TITLE
Fix interrupted recipe artifact pointers

### DIFF
--- a/packages/cli/src/commands/recipe-run-artifact-pointers.ts
+++ b/packages/cli/src/commands/recipe-run-artifact-pointers.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, stat, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { stripUndefined, type ArtifactBundle, type RuntimeInfo } from "@automattic/wp-codebox-core"
 import type { RunOutput } from "../runtime-command-wrappers.js"
@@ -42,7 +42,7 @@ export class RecipeArtifactPointerTracker {
       failure: this.failure,
       failurePhase: recipeArtifactPointerFailurePhase(this.failure, this.phases),
       browserEvidence: this.browserEvidence.length > 0 ? this.browserEvidence : undefined,
-      paths: recipeArtifactPointerPaths(this.directory, this.runtime, this.artifacts),
+      ...await recipeArtifactPointerArtifactState(this.directory, this.runtime, this.artifacts),
     })
 
     await mkdir(this.directory, { recursive: true })
@@ -65,28 +65,44 @@ function recipeArtifactPointerFailurePhase(error: RunOutput["error"] | undefined
   return undefined
 }
 
-function recipeArtifactPointerPaths(directory: string, runtime: RuntimeInfo | undefined, artifacts: ArtifactBundle | undefined): Record<string, string> {
+async function recipeArtifactPointerArtifactState(directory: string, runtime: RuntimeInfo | undefined, artifacts: ArtifactBundle | undefined): Promise<Record<string, unknown>> {
   const paths: Record<string, string | undefined> = {}
+  const artifactMissing: Record<string, { path: string; reason: "runtime-artifact-not-created" }> = {}
   if (runtime) {
     const runtimeDirectory = join(directory, runtime.id)
-    paths.runtimeDirectory = relative(directory, runtimeDirectory) || "."
-    paths.eventLog = relative(directory, join(runtimeDirectory, "events.jsonl"))
-    paths.commandLog = relative(directory, join(runtimeDirectory, "logs", "commands.log"))
-    paths.runtimeLog = relative(directory, join(runtimeDirectory, "logs", "runtime.log"))
-    paths.runtimeMetadata = relative(directory, join(runtimeDirectory, "metadata.json"))
-    paths.runtimeManifest = relative(directory, join(runtimeDirectory, "manifest.json"))
-    paths.browserArtifacts = relative(directory, join(runtimeDirectory, "files", "browser"))
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeDirectory", runtimeDirectory)
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "eventLog", join(runtimeDirectory, "events.jsonl"))
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "commandLog", join(runtimeDirectory, "logs", "commands.log"))
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeLog", join(runtimeDirectory, "logs", "runtime.log"))
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeMetadata", join(runtimeDirectory, "metadata.json"))
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeManifest", join(runtimeDirectory, "manifest.json"))
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "browserArtifacts", join(runtimeDirectory, "files", "browser"))
   }
 
   if (artifacts) {
-    paths.runtimeDirectory = relative(directory, artifacts.directory) || "."
-    paths.eventLog = relative(directory, artifacts.eventsPath)
-    paths.commandLog = relative(directory, artifacts.commandsLogPath)
-    paths.runtimeLog = relative(directory, artifacts.runtimeLogPath)
-    paths.runtimeMetadata = relative(directory, artifacts.metadataPath)
-    paths.runtimeManifest = relative(directory, artifacts.manifestPath)
-    paths.browserArtifacts = relative(directory, join(artifacts.directory, "files", "browser"))
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeDirectory", artifacts.directory)
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "eventLog", artifacts.eventsPath)
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "commandLog", artifacts.commandsLogPath)
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeLog", artifacts.runtimeLogPath)
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeMetadata", artifacts.metadataPath)
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "runtimeManifest", artifacts.manifestPath)
+    await appendExistingArtifactPath(directory, paths, artifactMissing, "browserArtifacts", join(artifacts.directory, "files", "browser"))
   }
 
-  return stripUndefined(paths) as Record<string, string>
+  return stripUndefined({
+    paths: stripUndefined(paths),
+    artifactMissing: Object.keys(artifactMissing).length > 0 ? artifactMissing : undefined,
+  })
+}
+
+async function appendExistingArtifactPath(directory: string, paths: Record<string, string | undefined>, artifactMissing: Record<string, { path: string; reason: "runtime-artifact-not-created" }>, key: string, absolutePath: string): Promise<void> {
+  const path = relative(directory, absolutePath) || "."
+  try {
+    await stat(absolutePath)
+    paths[key] = path
+    delete artifactMissing[key]
+  } catch {
+    delete paths[key]
+    artifactMissing[key] = { path, reason: "runtime-artifact-not-created" }
+  }
 }

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -539,7 +539,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       }
 
       if (error instanceof RecipeRunTimeoutError) {
-        void activeRuntime.destroy().catch(() => undefined)
+        await bestEffortTimeout(activeRuntime.destroy(), 2_000)
       } else {
         await runRecipeCleanup(runRegistry, runRecord, async () => {
           try {

--- a/scripts/recipe-interruption-artifacts-smoke.ts
+++ b/scripts/recipe-interruption-artifacts-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { spawn } from "node:child_process"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
@@ -88,12 +88,12 @@ try {
   assert.equal(latestRuntime.runtimeId, output.runtime.id)
   assert.equal(latestRuntime.commandStatus, "failed")
   assert.equal(latestRuntime.failure.code, "recipe-interrupted")
-  assert.equal(latestRuntime.paths.runtimeManifest, `${output.runtime.id}/manifest.json`)
-  assert.equal(latestRuntime.paths.commandLog, `${output.runtime.id}/logs/commands.log`)
-  assert.equal(latestRuntime.paths.runtimeLog, `${output.runtime.id}/logs/runtime.log`)
-  assert.equal(latestRuntime.paths.eventLog, `${output.runtime.id}/events.jsonl`)
-  assert.equal(latestRuntime.paths.runtimeMetadata, `${output.runtime.id}/metadata.json`)
-  assert.equal(latestRuntime.paths.browserArtifacts, `${output.runtime.id}/files/browser`)
+  await assertPointerArtifact(latestRuntime, artifacts, "runtimeManifest", `${output.runtime.id}/manifest.json`)
+  await assertPointerArtifact(latestRuntime, artifacts, "commandLog", `${output.runtime.id}/logs/commands.log`)
+  await assertPointerArtifact(latestRuntime, artifacts, "runtimeLog", `${output.runtime.id}/logs/runtime.log`)
+  await assertPointerArtifact(latestRuntime, artifacts, "eventLog", `${output.runtime.id}/events.jsonl`)
+  await assertPointerArtifact(latestRuntime, artifacts, "runtimeMetadata", `${output.runtime.id}/metadata.json`)
+  await assertPointerArtifact(latestRuntime, artifacts, "browserArtifacts", `${output.runtime.id}/files/browser`)
 
   const manifest = JSON.parse(await readFile(join(output.artifacts.directory, "manifest.json"), "utf8"))
   assertManifestFile(manifest, "files/runtime-evidence/run-attestation.json", "run-attestation")
@@ -246,7 +246,7 @@ try {
   assert.equal(disconnectLatestRuntime.schema, "wp-codebox/recipe-run-artifact-pointer/v1")
   assert.equal(disconnectLatestRuntime.commandStatus, "failed")
   assert.equal(disconnectLatestRuntime.failure.code, "recipe-interrupted")
-  assert.equal(disconnectLatestRuntime.paths.runtimeManifest, `${disconnectOutput.runtime.id}/manifest.json`)
+  await assertPointerArtifact(disconnectLatestRuntime, disconnectArtifacts, "runtimeManifest", `${disconnectOutput.runtime.id}/manifest.json`)
 
   console.log("Recipe interruption artifact smoke passed")
 } finally {
@@ -272,4 +272,16 @@ async function waitForPointerCommand(directory: string, command: string, timeout
 
 function assertManifestFile(manifest: { files: Array<{ path: string; kind: string }> }, path: string, kind: string): void {
   assert.ok(manifest.files.some((file) => file.path === path && file.kind === kind), `Expected manifest entry ${kind} at ${path}`)
+}
+
+async function assertPointerArtifact(pointer: { paths?: Record<string, string>; artifactMissing?: Record<string, { path: string; reason: string }> }, artifactRoot: string, key: string, expectedPath: string): Promise<void> {
+  const path = pointer.paths?.[key]
+  if (path) {
+    assert.equal(path, expectedPath)
+    await stat(join(artifactRoot, path))
+    return
+  }
+
+  assert.equal(pointer.artifactMissing?.[key]?.path, expectedPath, `Expected ${key} to have an artifact-missing path`)
+  assert.equal(pointer.artifactMissing?.[key]?.reason, "runtime-artifact-not-created")
 }

--- a/scripts/recipe-run-timeout-smoke.ts
+++ b/scripts/recipe-run-timeout-smoke.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { promisify } from "node:util"
 import { execFile } from "node:child_process"
 import { spawn } from "node:child_process"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -90,12 +90,12 @@ try {
   assert.equal(latestRuntime.commandStatus, "failed")
   assert.equal(latestRuntime.failure.code, "recipe-run-timeout")
   assert.equal(latestRuntime.failurePhase, "run_workloads")
-  assert.equal(latestRuntime.paths.runtimeManifest, `${output.runtime.id}/manifest.json`)
-  assert.equal(latestRuntime.paths.commandLog, `${output.runtime.id}/logs/commands.log`)
-  assert.equal(latestRuntime.paths.runtimeLog, `${output.runtime.id}/logs/runtime.log`)
-  assert.equal(latestRuntime.paths.eventLog, `${output.runtime.id}/events.jsonl`)
-  assert.equal(latestRuntime.paths.runtimeMetadata, `${output.runtime.id}/metadata.json`)
-  assert.equal(latestRuntime.paths.browserArtifacts, `${output.runtime.id}/files/browser`)
+  await assertPointerArtifact(latestRuntime, artifacts, "runtimeManifest", `${output.runtime.id}/manifest.json`)
+  await assertPointerArtifact(latestRuntime, artifacts, "commandLog", `${output.runtime.id}/logs/commands.log`)
+  await assertPointerArtifact(latestRuntime, artifacts, "runtimeLog", `${output.runtime.id}/logs/runtime.log`)
+  await assertPointerArtifact(latestRuntime, artifacts, "eventLog", `${output.runtime.id}/events.jsonl`)
+  await assertPointerArtifact(latestRuntime, artifacts, "runtimeMetadata", `${output.runtime.id}/metadata.json`)
+  await assertPointerArtifact(latestRuntime, artifacts, "browserArtifacts", `${output.runtime.id}/files/browser`)
   assert.equal(await recipeRunProcessCount(recipePath), 0, "Timed-out recipe should not leave recipe-run child processes behind")
 
   console.log("Recipe run timeout smoke passed")
@@ -109,4 +109,16 @@ async function recipeRunProcessCount(recipePath: string): Promise<number> {
     .split("\n")
     .filter((line) => line.includes("recipe-run") && line.includes(recipePath))
     .length
+}
+
+async function assertPointerArtifact(pointer: { paths?: Record<string, string>; artifactMissing?: Record<string, { path: string; reason: string }> }, artifactRoot: string, key: string, expectedPath: string): Promise<void> {
+  const path = pointer.paths?.[key]
+  if (path) {
+    assert.equal(path, expectedPath)
+    await stat(join(artifactRoot, path))
+    return
+  }
+
+  assert.equal(pointer.artifactMissing?.[key]?.path, expectedPath, `Expected ${key} to have an artifact-missing path`)
+  assert.equal(pointer.artifactMissing?.[key]?.reason, "runtime-artifact-not-created")
 }


### PR DESCRIPTION
## Summary
- Make recipe-run artifact pointers existence-aware so interrupted or timed-out runs only advertise readable artifact paths.
- Add explicit `artifactMissing` entries for missing runtime logs, manifests, and browser artifact directories using relative paths and reviewer-safe reasons.
- Await bounded runtime destruction after recipe timeouts so the CLI can emit terminal run state instead of lingering behind an internal `wordpress.run-php` command.

Fixes #919.

Related downstream tracker: https://github.a8c.com/Automattic/wpcom-codebox/issues/135

## Verification
- `npm run build`
- `npx tsx scripts/recipe-run-timeout-smoke.ts`
- `npx tsx scripts/recipe-interruption-artifacts-smoke.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the artifact pointer diagnostics fix, updated focused smoke coverage, and ran build/smoke verification. Chris remains responsible for review and merge.