### PR TITLE
Fix provider profile plugin activation

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -210,7 +210,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
   const artifacts = stringValue(input.artifacts_path)
   const profile = runtimeOverlayProfileDefaults(input)
   const providerPlugins = uniqueStrings([...profile.providerPluginPaths, ...stringList(input.provider_plugin_paths)])
-    .map((source) => ({ source: prepareComposerPluginSource(source, slugFromPath(source), artifacts), slug: slugFromPath(source), activate: false }))
+    .map((source) => ({ source: prepareComposerPluginSource(source, slugFromPath(source), artifacts), slug: slugFromPath(source), activate: true }))
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
   const workflowArgs = [
     `task=${taskInput.goal}`,

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -36,6 +36,7 @@ assert.equal(extraPlugins.find((plugin) => plugin?.slug === "ai-provider-for-ope
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "agents-api")?.activate, false)
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "caller-runtime")?.activate, false)
 assert.equal(extraPlugins.find((plugin) => plugin?.slug === "caller-runtime-tools")?.activate, false)
+assert.equal(extraPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai")?.activate, true)
 assert.equal(recipe.inputs?.dependency_overlays?.[0]?.consumer, "caller-runtime")
 assert.equal(recipe.inputs?.dependency_overlays?.[0]?.package, "acme/dependency")
 
@@ -322,6 +323,7 @@ const codexOverlays = codexProfileRecipe.runtime?.overlays ?? []
 
 const codexProviderPlugin = codexPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai-codex-oauth-provider")
 assert.equal(codexProviderPlugin?.source, "/tmp/wp-codebox-artifacts/prepared-plugins/ai-provider-for-openai-codex-oauth-provider")
+assert.equal(codexProviderPlugin?.activate, true, "codex profile provider plugin must activate before provider preflight")
 assert.equal(codexOverlays[0]?.kind, "bundled-library")
 assert.equal(codexOverlays[0]?.library, "php-ai-client")
 assert.equal(codexOverlays[0]?.source, phpAiClientPath)


### PR DESCRIPTION
## Summary
- Activates agent task provider plugins prepared from runtime overlay profiles or `provider_plugin_paths` so WordPress loads them before provider preflight and agent execution.
- Extends the agent runtime components smoke to assert generic provider plugins and the `codex-subscription` provider plugin are activation-ready.

Fixes #921.

## Tests
- `npm run build`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npx tsx scripts/runtime-overlay-php-ai-client-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the provider profile activation path, drafted the minimal code/test change, and ran focused verification for Chris to review.