### PR TITLE
Use generic provider plugin identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,22 +1310,9 @@ WP Codebox normalizes the task input, writes the private temporary recipe, runs 
 
 Failed `agent-task-run` responses also include `failure_evidence` with `schema: "wp-codebox/agent-task-run-failure-evidence/v1"`. This block is intentionally safe for parent orchestrators to persist alongside their own task failure record. It includes the best available `phase`, `command`, `exit_code`, message, stdout/stderr snippets, runtime and sandbox identifiers, artifact directory or bundle identifiers, recipe-run status/run ID, diagnostics, phase evidence, and the serialized error. If recipe-run fails before normal runtime artifacts exist or returns malformed output, `agent-task-run` still emits this fallback evidence block in the CLI JSON payload and references it from `evidence_refs` with kind `codebox-agent-task-failure-evidence`.
 
-`runtime_overlay_profiles` is a convenience layer for reusable runtime stack examples. The raw primitives remain `provider_plugin_paths`, `component_contracts`, `runtime_stack_mounts`, `runtime_overlays`, and `secret_env`; profiles only expand those fields before the private recipe is written.
+Provider stacks are assembled from generic primitives: `provider_plugin_paths`, `component_contracts`, `runtime_stack_mounts`, `runtime_overlays`, and `secret_env`. A provider plugin path may point at any prepared checkout; when the checkout has a Composer package name, WP Codebox uses the package basename as the mounted plugin slug so branch/worktree directory names do not become WordPress plugin identities.
 
-The built-in `codex-subscription` profile is an example of packaging a provider plugin plus a scoped bundled-library overlay for subscription-backed model access. It expands to:
-
-- `provider_plugin_paths`: the OpenAI/Codex provider plugin checkout from `WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH`
-- `runtime_overlays`: a `php-ai-client` bundled-library overlay from `WP_CODEBOX_PHP_AI_CLIENT_PATH` using `strategy: "wordpress-scoped-bundle"`
-
-Prepare the profile checkouts before running it:
-
-```bash
-export WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH=/path/to/ai-provider-for-openai
-export WP_CODEBOX_PHP_AI_CLIENT_PATH=/path/to/php-ai-client
-composer install --working-dir "$WP_CODEBOX_PHP_AI_CLIENT_PATH"
-```
-
-Callers can skip the profile and pass the expanded fields directly when they own a different provider/library stack. Parent orchestrators select profiles through the generic `runtime_overlay_profiles` field; WP Codebox still owns only recipe expansion, sandbox lifecycle, and artifact capture.
+Use explicit `runtime_overlays` for bundled libraries or scoped runtime replacements. The cookbook recipe at `examples/recipes/cookbook/codex-agent-smoke.json` shows one concrete provider setup using these primitives without adding provider-specific behavior to WP Codebox itself.
 
 Consumers that need a stable interpretation layer can import `normalizeAgentTaskRunResult()` from `@automattic/wp-codebox-core`. It accepts the current `agent-task-run` response and compatibility aliases from older orchestrator integrations, including `agentResult`, `agent_result`, `completionOutcome`, `completion_outcome`, and nested `metadata.recipe_run` records. The returned `wp-codebox/agent-task-run-result/v1` envelope normalizes `completed`/`success` into `succeeded` or `failed`, exposes terminal statuses such as `no_op`, `timeout`, `provider_error`, and `unable_to_remediate`, groups artifact bundle, changed-files, patch, transcript, log, and runtime refs, and includes no-op/failure metadata for parent schedulers.
 

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -209,8 +209,14 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
 export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: ReturnType<typeof normalizeTaskInput>, wpVersion: string): WorkspaceRecipe {
   const artifacts = stringValue(input.artifacts_path)
   const profile = runtimeOverlayProfileDefaults(input)
-  const providerPlugins = uniqueStrings([...profile.providerPluginPaths, ...stringList(input.provider_plugin_paths)])
-    .map((source) => ({ source: prepareComposerPluginSource(source, slugFromPath(source), artifacts), slug: slugFromPath(source), activate: true }))
+  const providerPlugins = uniqueProviderPlugins([
+    ...profile.providerPlugins,
+    ...stringList(input.provider_plugin_paths).map((source) => ({ source })),
+  ])
+    .map((plugin) => {
+      const slug = plugin.slug || slugFromPath(plugin.source)
+      return { source: prepareComposerPluginSource(plugin.source, slug, artifacts), slug, activate: true }
+    })
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
   const workflowArgs = [
     `task=${taskInput.goal}`,
@@ -272,7 +278,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
 }
 
 interface RuntimeOverlayProfileDefaults {
-  providerPluginPaths: string[]
+  providerPlugins: Array<{ source: string; slug?: string }>
   runtimeOverlays: Array<Record<string, unknown>>
 }
 
@@ -282,15 +288,18 @@ const CODEX_PHP_AI_CLIENT_ENV = "WP_CODEBOX_PHP_AI_CLIENT_PATH"
 
 function runtimeOverlayProfileDefaults(input: AgentTaskRunInput): RuntimeOverlayProfileDefaults {
   const profiles = stringList(input.runtime_overlay_profiles)
-  if (profiles.length === 0) return { providerPluginPaths: [], runtimeOverlays: [] }
+  if (profiles.length === 0) return { providerPlugins: [], runtimeOverlays: [] }
 
-  const defaults: RuntimeOverlayProfileDefaults = { providerPluginPaths: [], runtimeOverlays: [] }
+  const defaults: RuntimeOverlayProfileDefaults = { providerPlugins: [], runtimeOverlays: [] }
   for (const profile of profiles) {
     if (profile === CODEX_SUBSCRIPTION_PROFILE) {
-      defaults.providerPluginPaths.push(requiredProfilePath(CODEX_SUBSCRIPTION_PROFILE, CODEX_PROVIDER_PLUGIN_ENV, [
-        "~/Developer/ai-provider-for-openai@codex-oauth-provider",
-        "~/Developer/ai-provider-for-openai",
-      ], hasComposerPackage))
+      defaults.providerPlugins.push({
+        source: requiredProfilePath(CODEX_SUBSCRIPTION_PROFILE, CODEX_PROVIDER_PLUGIN_ENV, [
+          "~/Developer/ai-provider-for-openai@codex-oauth-provider",
+          "~/Developer/ai-provider-for-openai",
+        ], hasComposerPackage),
+        slug: "ai-provider-for-openai",
+      })
       defaults.runtimeOverlays.push({
         kind: "bundled-library",
         library: "php-ai-client",
@@ -338,8 +347,14 @@ function runtimeOverlays(input: AgentTaskRunInput, profile: RuntimeOverlayProfil
   return overlays.length > 0 ? overlays : undefined
 }
 
-function uniqueStrings(values: string[]): string[] {
-  return Array.from(new Set(values.filter(Boolean)))
+function uniqueProviderPlugins(plugins: Array<{ source: string; slug?: string }>): Array<{ source: string; slug?: string }> {
+  const seen = new Set<string>()
+  return plugins.filter((plugin) => {
+    const source = stringValue(plugin.source)
+    if (!source || seen.has(source)) return false
+    seen.add(source)
+    return true
+  })
 }
 
 function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
@@ -209,13 +209,10 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
 export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: ReturnType<typeof normalizeTaskInput>, wpVersion: string): WorkspaceRecipe {
   const artifacts = stringValue(input.artifacts_path)
   const profile = runtimeOverlayProfileDefaults(input)
-  const providerPlugins = uniqueProviderPlugins([
-    ...profile.providerPlugins,
-    ...stringList(input.provider_plugin_paths).map((source) => ({ source })),
-  ])
+  const providerPlugins = uniqueStrings(stringList(input.provider_plugin_paths))
     .map((plugin) => {
-      const slug = plugin.slug || slugFromPath(plugin.source)
-      return { source: prepareComposerPluginSource(plugin.source, slug, artifacts), slug, activate: true }
+      const slug = slugFromComposerPackage(plugin) || slugFromPath(plugin)
+      return { source: prepareComposerPluginSource(plugin, slug, artifacts), slug, activate: true }
     })
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
   const workflowArgs = [
@@ -278,68 +275,17 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
 }
 
 interface RuntimeOverlayProfileDefaults {
-  providerPlugins: Array<{ source: string; slug?: string }>
   runtimeOverlays: Array<Record<string, unknown>>
 }
 
-const CODEX_SUBSCRIPTION_PROFILE = "codex-subscription"
-const CODEX_PROVIDER_PLUGIN_ENV = "WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH"
-const CODEX_PHP_AI_CLIENT_ENV = "WP_CODEBOX_PHP_AI_CLIENT_PATH"
-
 function runtimeOverlayProfileDefaults(input: AgentTaskRunInput): RuntimeOverlayProfileDefaults {
   const profiles = stringList(input.runtime_overlay_profiles)
-  if (profiles.length === 0) return { providerPlugins: [], runtimeOverlays: [] }
+  if (profiles.length === 0) return { runtimeOverlays: [] }
 
-  const defaults: RuntimeOverlayProfileDefaults = { providerPlugins: [], runtimeOverlays: [] }
   for (const profile of profiles) {
-    if (profile === CODEX_SUBSCRIPTION_PROFILE) {
-      defaults.providerPlugins.push({
-        source: requiredProfilePath(CODEX_SUBSCRIPTION_PROFILE, CODEX_PROVIDER_PLUGIN_ENV, [
-          "~/Developer/ai-provider-for-openai@codex-oauth-provider",
-          "~/Developer/ai-provider-for-openai",
-        ], hasComposerPackage),
-        slug: "ai-provider-for-openai",
-      })
-      defaults.runtimeOverlays.push({
-        kind: "bundled-library",
-        library: "php-ai-client",
-        source: requiredProfilePath(CODEX_SUBSCRIPTION_PROFILE, CODEX_PHP_AI_CLIENT_ENV, [
-          "~/Developer/php-ai-client@custom-provider-auth",
-          "~/Developer/php-ai-client",
-        ], hasInstalledComposerPackage),
-        target: "/wordpress/wp-includes/php-ai-client",
-        strategy: "wordpress-scoped-bundle",
-        metadata: { profile, component: "php-ai-client", ref: "custom-provider-auth" },
-      })
-      continue
-    }
     throw new Error(`Unknown runtime overlay profile: ${profile}`)
   }
-  return defaults
-}
-
-function requiredProfilePath(profile: string, envName: string, candidates: string[], isUsablePath: (path: string) => boolean = existsSync): string {
-  const explicit = stringValue(process.env[envName])
-  const resolved = explicit || candidates.map(resolveProfilePathCandidate).find((candidate) => isUsablePath(candidate)) || ""
-  if (!resolved) {
-    throw new Error(`${profile} runtime overlay profile requires ${envName} or one of: ${candidates.join(", ")}`)
-  }
-  if (!isUsablePath(resolved)) {
-    throw new Error(`${profile} runtime overlay profile path from ${envName} is not prepared: ${resolved}`)
-  }
-  return resolved
-}
-
-function resolveProfilePathCandidate(candidate: string): string {
-  return candidate.startsWith("~/") ? join(process.env.HOME || "", candidate.slice(2)) : candidate
-}
-
-function hasComposerPackage(candidate: string): boolean {
-  return existsSync(join(candidate, "composer.json"))
-}
-
-function hasInstalledComposerPackage(candidate: string): boolean {
-  return hasComposerPackage(candidate) && existsSync(join(candidate, "vendor"))
+  return { runtimeOverlays: [] }
 }
 
 function runtimeOverlays(input: AgentTaskRunInput, profile: RuntimeOverlayProfileDefaults): Array<Record<string, unknown>> | undefined {
@@ -347,14 +293,8 @@ function runtimeOverlays(input: AgentTaskRunInput, profile: RuntimeOverlayProfil
   return overlays.length > 0 ? overlays : undefined
 }
 
-function uniqueProviderPlugins(plugins: Array<{ source: string; slug?: string }>): Array<{ source: string; slug?: string }> {
-  const seen = new Set<string>()
-  return plugins.filter((plugin) => {
-    const source = stringValue(plugin.source)
-    if (!source || seen.has(source)) return false
-    seen.add(source)
-    return true
-  })
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)))
 }
 
 function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
@@ -652,6 +592,17 @@ function sandboxToolPolicy(input: AgentTaskRunInput, taskInput: ReturnType<typeo
 function slugFromPath(source: string): string {
   const base = source.replace(/\/$/, "").split("/").pop() || "provider"
   return base.replace(/[^A-Za-z0-9_-]/g, "-")
+}
+
+function slugFromComposerPackage(source: string): string {
+  try {
+    const composer = JSON.parse(readFileSync(join(source, "composer.json"), "utf8")) as { name?: unknown }
+    const name = stringValue(composer.name)
+    if (!name) return ""
+    return slugFromPath(name.split("/").pop() || name)
+  } catch {
+    return ""
+  }
 }
 
 function stringList(value: unknown): string[] {

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -320,10 +320,14 @@ const codexProfileInput = {
 const codexProfileRecipe = buildAgentTaskRecipe(codexProfileInput, normalizeTaskInput(codexProfileInput), "trunk")
 const codexPlugins = codexProfileRecipe.inputs?.extra_plugins ?? []
 const codexOverlays = codexProfileRecipe.runtime?.overlays ?? []
+const codexWorkflowArgs = codexProfileRecipe.workflow?.steps?.[0]?.args ?? []
 
-const codexProviderPlugin = codexPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai-codex-oauth-provider")
-assert.equal(codexProviderPlugin?.source, "/tmp/wp-codebox-artifacts/prepared-plugins/ai-provider-for-openai-codex-oauth-provider")
+const codexProviderPlugin = codexPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai")
+assert.equal(codexProviderPlugin?.source, "/tmp/wp-codebox-artifacts/prepared-plugins/ai-provider-for-openai")
 assert.equal(codexProviderPlugin?.activate, true, "codex profile provider plugin must activate before provider preflight")
+assert.ok(!codexPlugins.some((plugin) => plugin?.slug === "ai-provider-for-openai-codex-oauth-provider"))
+assert.ok(codexWorkflowArgs.includes("provider-plugin-slugs=ai-provider-for-openai"))
+assert.ok(!codexWorkflowArgs.includes("provider-plugin-slugs=ai-provider-for-openai-codex-oauth-provider"))
 assert.equal(codexOverlays[0]?.kind, "bundled-library")
 assert.equal(codexOverlays[0]?.library, "php-ai-client")
 assert.equal(codexOverlays[0]?.source, phpAiClientPath)

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -300,42 +300,48 @@ const structuredIndex = JSON.parse(readFileSync(join(filesRoot, "structured-arti
 assert.equal(structuredIndex.schema, "wp-codebox/structured-artifacts-index/v1")
 assert.equal(structuredIndex.artifacts[0]?.payload?.theme, "warm editorial")
 
-const profileRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-profile-"))
-const codexProviderPath = join(profileRoot, "ai-provider-for-openai@codex-oauth-provider")
-const phpAiClientPath = join(profileRoot, "php-ai-client@custom-provider-auth")
-mkdirSync(codexProviderPath, { recursive: true })
-mkdirSync(join(phpAiClientPath, "vendor"), { recursive: true })
-writeFileSync(join(codexProviderPath, "composer.json"), "{}\n")
-writeFileSync(join(phpAiClientPath, "composer.json"), "{}\n")
-process.env.WP_CODEBOX_CODEX_PROVIDER_PLUGIN_PATH = codexProviderPath
-process.env.WP_CODEBOX_PHP_AI_CLIENT_PATH = phpAiClientPath
+const providerRoot = mkdtempSync(join(tmpdir(), "wp-codebox-agent-task-provider-"))
+const customProviderPath = join(providerRoot, "custom-provider-branch-checkout")
+const bundledLibraryPath = join(providerRoot, "custom-library-checkout")
+mkdirSync(customProviderPath, { recursive: true })
+mkdirSync(bundledLibraryPath, { recursive: true })
+writeFileSync(join(customProviderPath, "composer.json"), JSON.stringify({ name: "example/canonical-provider-plugin" }))
 
-const codexProfileInput = {
-  goal: "Run a Codex subscription-backed agent",
-  provider: "codex",
-  model: "gpt-5.5",
-  runtime_overlay_profiles: ["codex-subscription"],
+const providerIdentityInput = {
+  goal: "Run a provider-backed agent",
+  provider: "example-provider",
+  model: "example-model",
+  provider_plugin_paths: [customProviderPath],
+  runtime_overlays: [{
+    kind: "bundled-library",
+    library: "example-library",
+    source: bundledLibraryPath,
+    target: "/wordpress/wp-includes/example-library",
+    strategy: "wordpress-scoped-bundle",
+  }],
   artifacts_path: "/tmp/wp-codebox-artifacts",
 }
-const codexProfileRecipe = buildAgentTaskRecipe(codexProfileInput, normalizeTaskInput(codexProfileInput), "trunk")
-const codexPlugins = codexProfileRecipe.inputs?.extra_plugins ?? []
-const codexOverlays = codexProfileRecipe.runtime?.overlays ?? []
-const codexWorkflowArgs = codexProfileRecipe.workflow?.steps?.[0]?.args ?? []
+const providerIdentityRecipe = buildAgentTaskRecipe(providerIdentityInput, normalizeTaskInput(providerIdentityInput), "trunk")
+const providerIdentityPlugins = providerIdentityRecipe.inputs?.extra_plugins ?? []
+const providerIdentityOverlays = providerIdentityRecipe.runtime?.overlays ?? []
+const providerIdentityWorkflowArgs = providerIdentityRecipe.workflow?.steps?.[0]?.args ?? []
 
-const codexProviderPlugin = codexPlugins.find((plugin) => plugin?.slug === "ai-provider-for-openai")
-assert.equal(codexProviderPlugin?.source, "/tmp/wp-codebox-artifacts/prepared-plugins/ai-provider-for-openai")
-assert.equal(codexProviderPlugin?.activate, true, "codex profile provider plugin must activate before provider preflight")
-assert.ok(!codexPlugins.some((plugin) => plugin?.slug === "ai-provider-for-openai-codex-oauth-provider"))
-assert.ok(codexWorkflowArgs.includes("provider-plugin-slugs=ai-provider-for-openai"))
-assert.ok(!codexWorkflowArgs.includes("provider-plugin-slugs=ai-provider-for-openai-codex-oauth-provider"))
-assert.equal(codexOverlays[0]?.kind, "bundled-library")
-assert.equal(codexOverlays[0]?.library, "php-ai-client")
-assert.equal(codexOverlays[0]?.source, phpAiClientPath)
-assert.equal(codexOverlays[0]?.strategy, "wordpress-scoped-bundle")
+const providerIdentityPlugin = providerIdentityPlugins.find((plugin) => plugin?.slug === "canonical-provider-plugin")
+assert.equal(providerIdentityPlugin?.source, "/tmp/wp-codebox-artifacts/prepared-plugins/canonical-provider-plugin")
+assert.equal(providerIdentityPlugin?.activate, true, "provider plugin must activate before provider preflight")
+assert.ok(!providerIdentityPlugins.some((plugin) => plugin?.slug === "custom-provider-branch-checkout"))
+assert.ok(providerIdentityWorkflowArgs.includes("provider-plugin-slugs=canonical-provider-plugin"))
+assert.ok(!providerIdentityWorkflowArgs.includes("provider-plugin-slugs=custom-provider-branch-checkout"))
+assert.equal(providerIdentityOverlays[0]?.kind, "bundled-library")
+assert.equal(providerIdentityOverlays[0]?.library, "example-library")
+assert.equal(providerIdentityOverlays[0]?.source, bundledLibraryPath)
+assert.equal(providerIdentityOverlays[0]?.strategy, "wordpress-scoped-bundle")
 assert.ok(agentCodeSource.includes("wp_codebox_validate_requested_provider"))
 assert.ok(agentCodeSource.includes("WordPress\\\\AiClient\\\\Providers\\\\ProviderRegistry"))
 assert.ok(agentCodeSource.includes("wp_codebox_provider_not_registered"))
 assert.ok(!agentTaskRunSource.includes("CodexProvider"))
+assert.ok(!agentTaskRunSource.includes("codex-subscription"))
+assert.ok(!agentTaskRunSource.includes("WP_CODEBOX_CODEX"))
 
 async function promiseMustSettle<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timeout: NodeJS.Timeout | undefined


### PR DESCRIPTION
## Summary
- Removes the built-in Codex runtime overlay profile so WP Codebox does not encode provider-specific setup, local checkout fallbacks, or Codex environment variables.
- Keeps provider stacks composable through generic primitives: `provider_plugin_paths`, explicit `runtime_overlays`, and `secret_env`.
- Uses a provider checkout's Composer package basename as the mounted plugin slug when available, so arbitrary branch/worktree directory names do not become WordPress plugin identities.
- Updates smoke coverage to verify generic identity discovery and guard against reintroducing Codex-specific profile code.
- Documents the generic provider stack primitives and keeps Codex as a cookbook recipe example only.

Fixes #923.

## Testing
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic provider plugin identity fix, removed provider-specific profile behavior, updated smoke coverage and docs, and ran local verification. Chris remains responsible for review and merge.