### PR TITLE
Expose stable recipe builder entrypoint

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -206,6 +206,37 @@ npm run wp-codebox -- recipe build phpunit --options ./phpunit-options.json --ou
 npm run wp-codebox -- recipe-run --recipe ./phpunit.recipe.json --artifacts ./artifacts/phpunit --json
 ```
 
+## Stable Recipe-Builder API
+
+Tools that need to generate WordPress bench or PHPUnit recipes without shelling
+out to the CLI may import the supported recipe-builder module:
+
+```js
+import {
+  buildWordPressBenchRecipe,
+  buildWordPressPhpunitRecipe,
+} from "@automattic/wp-codebox-core/recipe-builders"
+```
+
+The same subpath is exported by the root release package as
+`wp-codebox-workspace/recipe-builders`, so callers can use one documented module
+name for npm package installs and release-tarball installs without probing
+`packages/runtime-core/dist/index.js` or other internal build paths. Local
+checkout consumers should run `npm run build` first, then import the same
+workspace package subpath through normal Node package resolution.
+
+The CLI surface remains the stable process boundary for hosts that prefer JSON
+over an in-process import:
+
+```bash
+wp-codebox recipe build phpunit --options ./phpunit-options.json --output ./phpunit.recipe.json
+wp-codebox recipe build bench --options ./bench-options.json --output ./bench.recipe.json
+```
+
+Both builders return `wp-codebox/workspace-recipe/v1` recipes. The generated
+recipes should still be validated with `wp-codebox recipe validate` or
+`wp-codebox recipe-run --dry-run` before execution in CI.
+
 For monorepos such as WooCommerce, set `pluginSource` to the directory that
 should appear as `wp-content/plugins/<plugin-slug>` and set `cwd` to the same
 sandbox directory a `wp-env --env-cwd` command would use. Relative `cwd` values

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
       "types": "./packages/runtime-core/dist/index.d.ts",
       "import": "./packages/runtime-core/dist/index.js"
     },
+    "./recipe-builders": {
+      "types": "./packages/runtime-core/dist/recipe-builders.d.ts",
+      "import": "./packages/runtime-core/dist/recipe-builders.js"
+    },
     "./playground": {
       "types": "./packages/runtime-playground/dist/index.d.ts",
       "import": "./packages/runtime-playground/dist/index.js"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,6 +47,22 @@ descriptions, accepted args, known output shape, and policy requirements.
 the canonical `createWorkspaceRecipeJsonSchema()` contract exported by
 `@automattic/wp-codebox-core`.
 
+## Recipe Builders
+
+Hosts that generate WordPress bench or PHPUnit recipes can use either stable
+surface:
+
+- Import `buildWordPressBenchRecipe` and `buildWordPressPhpunitRecipe` from
+  `@automattic/wp-codebox-core/recipe-builders` when the core package is
+  installed through npm or a local checkout.
+- Import the same builders from `wp-codebox-workspace/recipe-builders` when the
+  root release tarball is installed.
+- Shell out to `wp-codebox recipe build phpunit|bench --options <json>` when the
+  host wants a process boundary instead of a Node import.
+
+These are the supported recipe-builder entrypoints. Callers should not resolve
+`packages/runtime-core/dist/index.js` or other internal build paths.
+
 ## Recipe Planning
 
 - `wp-codebox validate-blueprint --blueprint <json|file> [--json]` boots a raw WordPress Playground blueprint through WP Codebox and captures the normal artifact bundle.

--- a/packages/cli/src/commands/recipe-build.ts
+++ b/packages/cli/src/commands/recipe-build.ts
@@ -43,6 +43,9 @@ interface WordPressBenchBuilderOptions {
   wpConfigDefines?: Record<string, unknown>
   bootstrapFiles?: string[]
   workloads?: unknown[]
+  scenarioIds?: string[]
+  lifecycle?: Record<string, unknown>
+  resetPolicy?: Record<string, unknown>
 }
 
 export async function runRecipeBuildCommand(args: string[]): Promise<number> {
@@ -99,6 +102,9 @@ function buildRecipe(recipeType: RecipeBuildOptions["recipeType"], options: Word
         wpConfigDefines: plainObject(options.wpConfigDefines),
         bootstrapFiles: Array.isArray((options as WordPressBenchBuilderOptions).bootstrapFiles) ? (options as WordPressBenchBuilderOptions).bootstrapFiles : [],
         workloads: Array.isArray((options as WordPressBenchBuilderOptions).workloads) ? (options as WordPressBenchBuilderOptions).workloads : [],
+        scenarioIds: Array.isArray((options as WordPressBenchBuilderOptions).scenarioIds) ? (options as WordPressBenchBuilderOptions).scenarioIds : [],
+        lifecycle: plainObject((options as WordPressBenchBuilderOptions).lifecycle),
+        resetPolicy: plainObject((options as WordPressBenchBuilderOptions).resetPolicy),
       })
   }
 }

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./recipe-builders": {
+      "types": "./dist/recipe-builders.d.ts",
+      "import": "./dist/recipe-builders.js"
     }
   },
   "files": [

--- a/scripts/package-distribution-smoke.ts
+++ b/scripts/package-distribution-smoke.ts
@@ -11,6 +11,10 @@ const rootPackage = JSON.parse(await readFile(resolve(repoRoot, "package.json"),
   bin?: Record<string, string>
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  exports?: Record<string, { types?: string; import?: string }>
+}
+const corePackage = JSON.parse(await readFile(resolve(repoRoot, "packages", "runtime-core", "package.json"), "utf8")) as {
+  exports?: Record<string, { types?: string; import?: string }>
 }
 
 assert.ok(
@@ -30,6 +34,14 @@ const { stdout: packStdout } = await execFileAsync(
 const [pack] = JSON.parse(packStdout) as Array<{ files: Array<{ path: string }>; entryCount: number }>
 const packedFiles = new Set(pack.files.map((file) => file.path))
 
+const { stdout: corePackStdout } = await execFileAsync(
+  "npm",
+  ["pack", "--workspace", "@automattic/wp-codebox-core", "--dry-run", "--json"],
+  { cwd: repoRoot, maxBuffer: 1024 * 1024 * 10 },
+)
+const [corePack] = JSON.parse(corePackStdout) as Array<{ files: Array<{ path: string }> }>
+const corePackedFiles = new Set(corePack.files.map((file) => file.path))
+
 const { stdout: rootPackStdout } = await execFileAsync(
   "npm",
   ["pack", "--dry-run", "--json"],
@@ -44,9 +56,21 @@ assert.ok(packedFiles.has("dist/index.js"), "CLI package should include compiled
 assert.ok(packedFiles.has("dist/index.d.ts"), "CLI package should include generated types")
 assert.equal(packedFiles.has("src/index.ts"), false, "CLI package should not ship TypeScript source")
 assert.ok(pack.entryCount >= 4, "CLI package should contain expected publish files")
+assert.deepEqual(
+  corePackage.exports?.["./recipe-builders"],
+  { types: "./dist/recipe-builders.d.ts", import: "./dist/recipe-builders.js" },
+  "Core package should expose a stable recipe-builder subpath",
+)
+assert.ok(corePackedFiles.has("dist/recipe-builders.js"), "Core package should ship compiled recipe-builder entrypoint")
+assert.ok(corePackedFiles.has("dist/recipe-builders.d.ts"), "Core package should ship recipe-builder types")
 assert.ok(
   rootPackedFiles.has("scripts/normalize-playground-sqlite-package.mjs"),
   "Root package should ship the Playground SQLite package normalizer for clean installs",
+)
+assert.deepEqual(
+  rootPackage.exports?.["./recipe-builders"],
+  { types: "./packages/runtime-core/dist/recipe-builders.d.ts", import: "./packages/runtime-core/dist/recipe-builders.js" },
+  "Root release package should expose the stable recipe-builder subpath",
 )
 assert.equal(
   rootPackage.bin?.["wp-codebox"],
@@ -54,6 +78,8 @@ assert.equal(
   "Root release tarball should install the stable wp-codebox binary",
 )
 assert.ok(rootPackedFiles.has("packages/cli/dist/index.js"), "Root package should ship the compiled CLI binary target")
+assert.ok(rootPackedFiles.has("packages/runtime-core/dist/recipe-builders.js"), "Root package should ship compiled recipe builders")
+assert.ok(rootPackedFiles.has("packages/runtime-core/dist/recipe-builders.d.ts"), "Root package should ship recipe-builder types")
 
 await execFileAsync("npm", ["run", "package:wordpress-plugin"], { cwd: repoRoot, maxBuffer: 1024 * 1024 * 10 })
 const pluginZip = resolve(repoRoot, "packages", "wordpress-plugin", "dist", "wp-codebox.zip")

--- a/scripts/recipe-build-cli-smoke.ts
+++ b/scripts/recipe-build-cli-smoke.ts
@@ -38,6 +38,7 @@ assert.equal(recipe.workflow.steps[0].command, "wordpress.phpunit")
 assert.deepEqual(recipe.inputs.mounts, [{ source: "/repo/plugin", target: "/wordpress/wp-content/plugins/demo", mode: "readwrite" }])
 assert.deepEqual(recipe.workflow.steps[0].args, [
   "plugin-slug=demo",
+  "cwd=/wordpress/wp-content/plugins/demo",
   "test-file=tests/DemoTest.php",
   'changed-tests-json=["tests/DemoTest.php"]',
   'env-json={"HOMEBOY_FLAG":"yes"}',
@@ -66,6 +67,9 @@ await writeFile(benchOptionsPath, JSON.stringify({
   wpConfigDefines: { SAVEQUERIES: true },
   bootstrapFiles: ["bench/bootstrap.php"],
   workloads: [{ id: "homepage", path: "/" }],
+  scenarioIds: ["homepage", " ", "homepage"],
+  lifecycle: { setup: [{ type: "php", code: "update_option('bench_setup', 'yes');" }] },
+  resetPolicy: { betweenIterations: "object-cache" },
 }, null, 2))
 
 const benchExitCode = await runCli(["recipe", "build", "bench", "--options", benchOptionsPath, "--output", benchOutputPath])
@@ -92,8 +96,9 @@ assert.deepEqual(benchRecipe.workflow.steps[0].args, [
   'env-json={"BENCH_FLAG":"yes"}',
   'bootstrap-files-json=["bench/bootstrap.php"]',
   'workloads-json=[{"id":"homepage","path":"/"}]',
-  'lifecycle-json={}',
-  'reset-policy-json={}',
+  'scenario-ids-json=["homepage"]',
+  'lifecycle-json={"setup":[{"type":"php","code":"update_option(\'bench_setup\', \'yes\');"}]}',
+  'reset-policy-json={"betweenIterations":"object-cache"}',
 ])
 
 console.log("recipe build cli smoke passed")

--- a/scripts/wordpress-recipe-builders-smoke.ts
+++ b/scripts/wordpress-recipe-builders-smoke.ts
@@ -4,7 +4,8 @@ import { mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { DEFAULT_WORDPRESS_VERSION, buildWordPressBenchRecipe, buildWordPressPhpunitRecipe, createBenchmarkDefinitionJsonSchema, createBenchResultsJsonSchema, createWorkspaceRecipeJsonSchema, recipeCommandDefinitions } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createBenchmarkDefinitionJsonSchema, createBenchResultsJsonSchema, createWorkspaceRecipeJsonSchema, recipeCommandDefinitions } from "@automattic/wp-codebox-core"
+import { buildWordPressBenchRecipe, buildWordPressPhpunitRecipe } from "@automattic/wp-codebox-core/recipe-builders"
 import Ajv2020 from "ajv/dist/2020.js"
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")


### PR DESCRIPTION
## Summary
- Exposes `@automattic/wp-codebox-core/recipe-builders` and the root release-package `wp-codebox-workspace/recipe-builders` subpath as supported recipe-builder imports.
- Documents the stable import and CLI recipe-builder surfaces so callers do not need to resolve `packages/runtime-core/dist/index.js` or package-layout internals.
- Passes bench `scenarioIds`, `lifecycle`, and `resetPolicy` through `wp-codebox recipe build bench`, with smoke coverage for the supported entrypoints.

Fixes #925.
Related downstream cleanup: Extra-Chill/homeboy-extensions#1327.
Related existing issue: #633.

## Verification
- `npm run build`
- `npx tsx scripts/wordpress-recipe-builders-smoke.ts`
- `npx tsx scripts/recipe-build-cli-smoke.ts`
- `npx tsx scripts/package-distribution-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the existing package/CLI recipe-builder surface, drafted the minimal export/docs/tests changes, ran targeted verification, and prepared this PR for Chris to review.