### PR TITLE
Fix provider preflight registry lookup

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -324,20 +324,33 @@ function wp_codebox_validate_requested_provider(array $agent_input, array $sandb
     if ('' === $provider) {
         return null;
     }
+
+    $registry = null;
+    $ai_client_class = \\WordPress\\AiClient\\AiClient::class;
+    if (class_exists($ai_client_class) && method_exists($ai_client_class, 'defaultRegistry')) {
+        $registry = $ai_client_class::defaultRegistry();
+    }
+
     $provider_registry_class = \\WordPress\\AiClient\\Providers\\ProviderRegistry::class;
-    if (!class_exists($provider_registry_class)) {
+    if (null === $registry && class_exists($provider_registry_class)) {
+        $registry = new $provider_registry_class();
+    }
+
+    if (!is_object($registry)) {
         return array(
             'code' => 'wp_codebox_provider_registry_unavailable',
             'message' => 'The requested provider could not be validated because the wp-ai-client provider registry is unavailable inside the sandbox.',
             'data' => array(
                 'provider' => $provider,
+                'ai_client_available' => class_exists($ai_client_class),
+                'ai_client_default_registry_available' => class_exists($ai_client_class) && method_exists($ai_client_class, 'defaultRegistry'),
+                'provider_registry_available' => class_exists($provider_registry_class),
                 'provider_plugins' => $sandbox_stack['signals']['provider_plugins'] ?? array(),
                 'plugin_activation' => $sandbox_stack['plugins'] ?? array(),
             ),
         );
     }
 
-    $registry = new $provider_registry_class();
     if (method_exists($registry, 'isProviderConfigured') && $registry->isProviderConfigured($provider)) {
         return null;
     }

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
@@ -170,14 +171,70 @@ const structuredTaskCode = await resolveSandboxTaskCode({
 assert.ok(structuredTaskCode.includes("structured_artifacts"), "sandbox agent input should include structured artifact context")
 assert.ok(structuredTaskCode.includes("ConceptPacket"), "sandbox agent input should preserve structured artifact names")
 const providerRegistryClassReference = String.raw`\WordPress\AiClient\Providers\ProviderRegistry::class`
+const aiClientClassReference = String.raw`\WordPress\AiClient\AiClient::class`
 assert.ok(
   structuredTaskCode.includes(providerRegistryClassReference),
   "generated sandbox PHP should preserve ProviderRegistry namespace separators",
 )
 assert.ok(
+  structuredTaskCode.includes(aiClientClassReference),
+  "generated sandbox PHP should inspect the AI Client singleton registry",
+)
+assert.ok(
+  structuredTaskCode.indexOf("defaultRegistry") < structuredTaskCode.indexOf("new $provider_registry_class"),
+  "generated sandbox PHP should prefer AiClient::defaultRegistry() before falling back to a fresh registry",
+)
+assert.ok(
   !structuredTaskCode.includes("WordPressAiClientProvidersProviderRegistry"),
   "generated sandbox PHP should not flatten ProviderRegistry into an invalid class name",
 )
+
+const providerValidationStart = structuredTaskCode.indexOf("function wp_codebox_validate_requested_provider")
+const providerValidationEnd = structuredTaskCode.indexOf("$runtime_task_run", providerValidationStart)
+assert.ok(providerValidationStart >= 0 && providerValidationEnd > providerValidationStart, "generated sandbox PHP should include provider validation function")
+const providerValidationFunction = structuredTaskCode.slice(providerValidationStart, providerValidationEnd)
+const providerValidationSmokePath = join(mkdtempSync(join(tmpdir(), "wp-codebox-provider-registry-")), "provider-registry-smoke.php")
+writeFileSync(
+  providerValidationSmokePath,
+  `<?php
+namespace WordPress\\AiClient\\Providers {
+    class ProviderRegistry {
+        public function isProviderConfigured($provider) {
+            return false;
+        }
+    }
+}
+
+namespace WordPress\\AiClient {
+    class AiClient {
+        public static $registry;
+        public static function defaultRegistry() {
+            return self::$registry;
+        }
+    }
+}
+
+namespace {
+    \\WordPress\\AiClient\\AiClient::$registry = new class {
+        public function isProviderConfigured($provider) {
+            return 'example-provider' === $provider;
+        }
+    };
+
+${providerValidationFunction}
+
+    $error = wp_codebox_validate_requested_provider(
+        array('provider' => 'example-provider'),
+        array('signals' => array('provider_plugins' => array()), 'plugins' => array())
+    );
+    if (null !== $error) {
+        fwrite(STDERR, json_encode($error, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        exit(1);
+    }
+}
+`,
+)
+execFileSync("php", [providerValidationSmokePath], { stdio: "pipe" })
 
 const outputTaskResult = buildAgentTaskSingleResult({
   schema: "wp-codebox/agent-transcript/v1",


### PR DESCRIPTION
## Summary
- Fixes the sandbox provider preflight to prefer `WordPress\AiClient\AiClient::defaultRegistry()` before falling back to a fresh `ProviderRegistry` instance.
- Preserves provider-agnostic validation and adds unavailable-registry diagnostics for the AI Client class, default registry API, and provider registry class.
- Extends the runtime-components smoke with an executable PHP preflight check proving a provider known only to `AiClient::defaultRegistry()` passes validation.

Fixes #927.

## Tests
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the provider preflight fix, focused smoke coverage, and verification commands; Chris remains responsible for review and merge.