### PR TITLE
Handle disposed routed Playwright fetches

### DIFF
--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -188,6 +188,9 @@ async function routeBrowserPreviewNetwork(routePattern: (url: string, handler: (
 
     stat.routed += 1
     const response = await fetchBrowserPreviewRoutedHost(route, requestUrl, policy.routeHosts, localOrigin)
+    if (!response) {
+      return
+    }
     await route.fulfill({ response })
   })
 }
@@ -222,7 +225,7 @@ function normalizeBrowserPreviewHost(host: string): string {
   return host.trim().toLowerCase().replace(/:\d+$/, "")
 }
 
-async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, routedHosts: Set<string>, localOrigin: URL): Promise<Awaited<ReturnType<Route["fetch"]>>> {
+async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, routedHosts: Set<string>, localOrigin: URL): Promise<Awaited<ReturnType<Route["fetch"]>> | undefined> {
   let currentUrl = requestUrl
   for (let redirectCount = 0; redirectCount < 10; redirectCount++) {
     const routedUrl = new URL(currentUrl.toString())
@@ -230,17 +233,27 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, rout
     routedUrl.hostname = localOrigin.hostname
     routedUrl.port = localOrigin.port
 
-    const response = await route.fetch({
-      url: routedUrl.toString(),
-      headers: {
-        ...route.request().headers(),
-        host: currentUrl.host,
-        "x-forwarded-host": currentUrl.host,
-        "x-forwarded-port": currentUrl.port || (currentUrl.protocol === "https:" ? "443" : "80"),
-        "x-forwarded-proto": currentUrl.protocol.replace(":", ""),
-      },
-      maxRedirects: 0,
-    })
+    let response: Awaited<ReturnType<Route["fetch"]>>
+    try {
+      response = await route.fetch({
+        url: routedUrl.toString(),
+        headers: {
+          ...route.request().headers(),
+          host: currentUrl.host,
+          "x-forwarded-host": currentUrl.host,
+          "x-forwarded-port": currentUrl.port || (currentUrl.protocol === "https:" ? "443" : "80"),
+          "x-forwarded-proto": currentUrl.protocol.replace(":", ""),
+        },
+        maxRedirects: 0,
+      })
+    } catch (error) {
+      if (!isBrowserPreviewRouteFetchRequestContextDisposedError(error)) {
+        throw error
+      }
+
+      await route.abort("failed").catch(() => undefined)
+      return undefined
+    }
 
     const location = response.headers().location
     if (!location || response.status() < 300 || response.status() >= 400) {
@@ -256,6 +269,10 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, rout
   }
 
   throw new Error(`wordpress.browser-probe route-host exceeded redirect limit for ${requestUrl.href}`)
+}
+
+export function isBrowserPreviewRouteFetchRequestContextDisposedError(error: unknown): boolean {
+  return error instanceof Error && /\broute\.fetch:\s*Request context disposed\.?/i.test(error.message)
 }
 
 function urlProtocol(url: string): string | undefined {

--- a/scripts/browser-probe-routed-fetch-disposed-smoke.ts
+++ b/scripts/browser-probe-routed-fetch-disposed-smoke.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict"
+import type { Page, Route } from "playwright"
+import { routeBrowserPreviewPageNetwork, type BrowserPreviewNetworkPolicy } from "../packages/runtime-playground/src/browser-preview-routing.js"
+
+const policy = createPolicy()
+let handler: ((route: Route) => Promise<void>) | undefined
+const page = {
+  async route(_pattern: string, routeHandler: (route: Route) => Promise<void>) {
+    handler = routeHandler
+  },
+} as Pick<Page, "route">
+
+await routeBrowserPreviewPageNetwork(page as Page, policy, "http://127.0.0.1:9400/")
+assert.ok(handler, "route handler should be registered")
+
+const disposedRoute = createRoute(new Error("route.fetch: Request context disposed."))
+await handler(disposedRoute as Route)
+assert.equal(disposedRoute.abortCalls, 1, "disposed request context should abort the routed request")
+assert.equal(disposedRoute.fulfillCalls, 0, "disposed request context should not fulfill")
+assert.equal(disposedRoute.continueCalls, 0, "disposed request context should not continue")
+assert.equal(policy.stats.get("wordpress.com")?.routed, 1)
+
+const otherFetchError = new Error("route.fetch: socket hang up")
+const failingRoute = createRoute(otherFetchError)
+await assert.rejects(handler(failingRoute as Route), otherFetchError, "other route.fetch errors should still surface")
+assert.equal(failingRoute.abortCalls, 0, "non-disposed route.fetch errors should not be converted to aborts")
+
+console.log("Browser probe routed fetch disposed smoke passed")
+
+function createPolicy(): BrowserPreviewNetworkPolicy {
+  return {
+    mode: "record",
+    allowHosts: new Set(),
+    blockHosts: new Set(),
+    routeHosts: new Set(["wordpress.com"]),
+    firstPartyHosts: new Set(["127.0.0.1"]),
+    recordExternal: false,
+    stats: new Map(),
+  }
+}
+
+function createRoute(fetchError: Error) {
+  return {
+    abortCalls: 0,
+    continueCalls: 0,
+    fulfillCalls: 0,
+    request() {
+      return {
+        url: () => "https://wordpress.com/wp-admin/admin-ajax.php",
+        headers: () => ({ referer: "https://wordpress.com/wp-admin/site-editor.php" }),
+      }
+    },
+    async fetch() {
+      throw fetchError
+    },
+    async abort(reason?: string) {
+      assert.equal(reason, "failed")
+      this.abortCalls += 1
+    },
+    async continue() {
+      this.continueCalls += 1
+    },
+    async fulfill() {
+      this.fulfillCalls += 1
+    },
+  }
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -198,6 +198,7 @@ export const smokeGroups = {
       tsxSmoke("browser-probe-context-smoke"),
       tsxSmoke("browser-probe-public-url-routing-smoke"),
       tsxSmoke("browser-probe-route-host-smoke"),
+      tsxSmoke("browser-probe-routed-fetch-disposed-smoke"),
       tsxSmoke("browser-probe-routed-admin-auth-smoke"),
       tsxSmoke("browser-probe-network-policy-smoke"),
       tsxSmoke("browser-probe-profile-matrix-smoke"),


### PR DESCRIPTION
## Summary
- Treat only Playwright `route.fetch: Request context disposed` failures as non-fatal routed-request cancellation.
- Preserve failure behavior for other routed `route.fetch` errors.
- Add a focused smoke covering disposed-context cancellation and ordinary fetch failure propagation.

Fixes #928.

## Testing
- `npx tsx scripts/browser-probe-routed-fetch-disposed-smoke.ts`
- `npm run build`
- `npm run smoke -- --command=browser-probe-routed-fetch-disposed-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the targeted routed-fetch disposal handling, added focused smoke coverage, and ran verification; Chris remains responsible for review and merge.