### PR TITLE
Fix bench dependency activation order

### DIFF
--- a/examples/bench-dependency/dependency-main.php
+++ b/examples/bench-dependency/dependency-main.php
@@ -3,6 +3,7 @@
  * Plugin Name: Bench Dependency
  * Description: Fixture dependency for WP Codebox bench command smoke tests.
  * Version: 0.1.0
+ * Requires Plugins: bench-plugin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -504,14 +504,14 @@ function wp_codebox_bench_assert_plugin_autoload_ready(string $plugin_basename):
 $plugins_to_activate = array();
 $plugin_roles = array();
 $activated_plugins = array();
+$plugin_file = wp_codebox_bench_plugin_file_for_slug($plugin_slug, 'component');
+$plugins_to_activate[] = $plugin_file;
+$plugin_roles[$plugin_file] = 'component';
 foreach (is_array($dependency_slugs) ? $dependency_slugs : array() as $dependency_slug) {
     $dependency_file = wp_codebox_bench_plugin_file_for_slug((string) $dependency_slug, 'dependency');
     $plugins_to_activate[] = $dependency_file;
     $plugin_roles[$dependency_file] = 'dependency';
 }
-$plugin_file = wp_codebox_bench_plugin_file_for_slug($plugin_slug, 'component');
-$plugins_to_activate[] = $plugin_file;
-$plugin_roles[$plugin_file] = 'component';
 $plugins_to_activate = array_values(array_unique($plugins_to_activate));
 foreach ($plugins_to_activate as $plugin_to_activate) {
     wp_codebox_bench_assert_plugin_autoload_ready($plugin_to_activate);


### PR DESCRIPTION
## Summary
- Activate the primary bench component plugin before dependency plugins in `wordpress.bench`.
- Extend the bench dependency fixture with a `Requires Plugins` header so activation order regressions fail in smoke coverage.

## Why
Gateway dependencies such as WooPayments can declare WooCommerce as a required plugin. Activating dependency plugins before the component plugin causes WP Codebox bench runs to fail before workloads can classify dependency readiness.

## Testing
- `npm run build`
- `npx tsx scripts/recipe-bench-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the bench activation-order blocker, drafted the minimal code/test change, and ran targeted validation. Chris remains responsible for review and merge.