### PR TITLE
Fix browser probe navigation timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "package-installed-binary-smoke": "tsx scripts/package-installed-binary-smoke.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "artifact-export-links-smoke": "tsx scripts/artifact-export-links-smoke.ts",
+    "browser-probe-navigation-timeout-smoke": "tsx scripts/browser-probe-navigation-timeout-smoke.ts",
     "browser-visual-compare-dimension-drift-smoke": "tsx scripts/browser-visual-compare-dimension-drift-smoke.ts",
     "browser-visual-compare-matrix-smoke": "tsx scripts/browser-visual-compare-matrix-smoke.ts",
     "wp-codebox": "node packages/cli/dist/index.js",

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -555,7 +555,7 @@ async function runSingleBrowserProbeCommand({
       throw previewReadinessError
     }
 
-    await withBrowserProbeLiveness(page, progress, failFast, navigateBrowserProbe(page, targetUrl, waitFor, durationMs), livenessPolicy, "navigation")
+    await withBrowserProbeLiveness(page, progress, failFast, navigateBrowserProbe(page, targetUrl, waitFor, durationMs, wallTimeoutMs), livenessPolicy, "navigation")
     progress.mark("navigation")
     const browserLocation = await page.evaluate(() => ({ origin: window.location.origin, secureContext: window.isSecureContext })).catch(() => undefined)
     windowLocationOrigin = browserLocation?.origin

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -212,24 +212,24 @@ function now(): string {
   return new Date().toISOString()
 }
 
-export async function navigateBrowserProbe(page: Page, url: string, waitFor: string, durationMs: number): Promise<void> {
+export async function navigateBrowserProbe(page: Page, url: string, waitFor: string, durationMs: number, navigationTimeoutMs = 30_000): Promise<void> {
   if (["domcontentloaded", "load", "networkidle"].includes(waitFor)) {
-    await page.goto(url, { waitUntil: waitFor as "domcontentloaded" | "load" | "networkidle", timeout: 30_000 })
+    await page.goto(url, { waitUntil: waitFor as "domcontentloaded" | "load" | "networkidle", timeout: navigationTimeoutMs })
     return
   }
 
   if (waitFor.startsWith("selector:")) {
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: navigationTimeoutMs })
     const selector = waitFor.slice("selector:".length).trim()
     if (!selector) {
       throw new Error("wordpress.browser-probe wait-for=selector:<selector> requires a selector")
     }
-    await page.locator(selector).first().waitFor({ timeout: 30_000 })
+    await page.locator(selector).first().waitFor({ timeout: navigationTimeoutMs })
     return
   }
 
   if (waitFor === "duration") {
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 })
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: navigationTimeoutMs })
     await page.waitForTimeout(durationMs > 0 ? durationMs : 1000)
     return
   }

--- a/scripts/browser-probe-navigation-timeout-smoke.ts
+++ b/scripts/browser-probe-navigation-timeout-smoke.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+
+import { navigateBrowserProbe } from "../packages/runtime-playground/src/browser-probe.js"
+
+type GotoCall = {
+  readonly url: string
+  readonly options: { readonly waitUntil: string; readonly timeout: number }
+}
+
+function fakePage() {
+  const gotoCalls: GotoCall[] = []
+  const waitForCalls: { readonly timeout: number }[] = []
+
+  return {
+    page: {
+      async goto(url: string, options: GotoCall["options"]) {
+        gotoCalls.push({ url, options })
+      },
+      locator(selector: string) {
+        assert.equal(selector, ".ready")
+        return {
+          first() {
+            return {
+              async waitFor(options: { readonly timeout: number }) {
+                waitForCalls.push(options)
+              },
+            }
+          },
+        }
+      },
+      async waitForTimeout() {},
+    },
+    gotoCalls,
+    waitForCalls,
+  }
+}
+
+const navigationTimeoutMs = 180_000
+
+{
+  const { page, gotoCalls } = fakePage()
+  await navigateBrowserProbe(page as never, "http://example.test/", "domcontentloaded", 0, navigationTimeoutMs)
+  assert.equal(gotoCalls[0]?.options.timeout, navigationTimeoutMs)
+}
+
+{
+  const { page, gotoCalls, waitForCalls } = fakePage()
+  await navigateBrowserProbe(page as never, "http://example.test/", "selector:.ready", 0, navigationTimeoutMs)
+  assert.equal(gotoCalls[0]?.options.timeout, navigationTimeoutMs)
+  assert.equal(waitForCalls[0]?.timeout, navigationTimeoutMs)
+}
+
+console.log("browser-probe navigation timeout smoke passed")


### PR DESCRIPTION
## Summary
- Pass the caller-declared `wordpress.browser-probe timeout=` budget into Playwright navigation.
- Apply the same timeout to selector waits so slow-but-valid pages are governed by the probe budget.
- Add a focused smoke proving a 180s timeout reaches navigation and selector waits.

Fixes #939.

## Verification
- `npm run browser-probe-navigation-timeout-smoke`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the timeout propagation fix, added focused smoke coverage, and ran verification commands for Chris to review.