### PR TITLE
Fix bench component load before dependencies

### DIFF
--- a/examples/bench-dependency/dependency-main.php
+++ b/examples/bench-dependency/dependency-main.php
@@ -40,6 +40,7 @@ register_activation_hook(
 		if ( ! function_exists( 'wp_codebox_bench_plugin_value' ) ) {
 			wp_die( 'Bench dependency requires the component plugin to be loaded before activation.' );
 		}
+		update_option( 'wp_codebox_bench_dependency_activation_saw_component', 'yes' );
 	}
 );
 

--- a/examples/bench-plugin/tests/bench/noop.php
+++ b/examples/bench-plugin/tests/bench/noop.php
@@ -11,6 +11,7 @@ return static function (): array {
 			'dependency_class_visible'      => class_exists( 'WP_Codebox_Bench_Dependency_Fixture' ) ? 1 : 0,
 			'dependency_active'             => is_plugin_active( 'bench-dependency/dependency-main.php' ) ? 1 : 0,
 			'dependency_active_at_include'  => (int) $GLOBALS['wp_codebox_bench_dependency_boot']['active_at_include'],
+			'dependency_activation_saw_component' => 'yes' === get_option( 'wp_codebox_bench_dependency_activation_saw_component' ) ? 1 : 0,
 			'dependency_plugins_loaded_callback_count' => (int) $GLOBALS['wp_codebox_bench_dependency_boot']['plugins_loaded_callbacks'],
 			'dependency_init_callback_count'           => (int) $GLOBALS['wp_codebox_bench_dependency_boot']['init_callbacks'],
 			'rest_route_visible'            => isset( $data['value'] ) && 7 === (int) $data['value'] ? 1 : 0,

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -515,15 +515,12 @@ foreach ($plugins_to_activate as $plugin_to_activate) {
 $pre_plugins_loaded_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('plugins_loaded');
 $pre_init_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('init');
 
-foreach (array($plugin_file) as $plugin_to_activate) {
-    if (is_plugin_active($plugin_to_activate)) {
-        continue;
-    }
-    $activation = activate_plugin($plugin_to_activate);
+if (!is_plugin_active($plugin_file)) {
+    $activation = activate_plugin($plugin_file);
     if (is_wp_error($activation)) {
-        throw new RuntimeException('wordpress.bench failed to activate plugin "' . $plugin_to_activate . '". ' . wp_codebox_bench_plugin_load_diagnostic($plugin_to_activate, $plugin_roles[$plugin_to_activate] ?? 'plugin', $activation->get_error_message()));
+        throw new RuntimeException('wordpress.bench failed to activate plugin "' . $plugin_file . '". ' . wp_codebox_bench_plugin_load_diagnostic($plugin_file, $plugin_roles[$plugin_file] ?? 'plugin', $activation->get_error_message()));
     }
-    $activated_plugins[] = $plugin_to_activate;
+    $activated_plugins[] = $plugin_file;
 }
 wp_codebox_bench_include_plugin_file($plugin_file, $plugin_roles[$plugin_file] ?? 'component');
 
@@ -531,14 +528,16 @@ foreach ($plugins_to_activate as $plugin_to_activate) {
     if ($plugin_to_activate === $plugin_file) {
         continue;
     }
-    if (!is_plugin_active($plugin_to_activate)) {
-        $activation = activate_plugin($plugin_to_activate);
-        if (is_wp_error($activation)) {
-            throw new RuntimeException('wordpress.bench failed to activate plugin "' . $plugin_to_activate . '". ' . wp_codebox_bench_plugin_load_diagnostic($plugin_to_activate, $plugin_roles[$plugin_to_activate] ?? 'plugin', $activation->get_error_message()));
-        }
-        $activated_plugins[] = $plugin_to_activate;
+    if (is_plugin_active($plugin_to_activate)) {
+        wp_codebox_bench_include_plugin_file($plugin_to_activate, $plugin_roles[$plugin_to_activate] ?? 'plugin');
+        continue;
+    }
+    $activation = activate_plugin($plugin_to_activate);
+    if (is_wp_error($activation)) {
+        throw new RuntimeException('wordpress.bench failed to activate plugin "' . $plugin_to_activate . '". ' . wp_codebox_bench_plugin_load_diagnostic($plugin_to_activate, $plugin_roles[$plugin_to_activate] ?? 'plugin', $activation->get_error_message()));
     }
     wp_codebox_bench_include_plugin_file($plugin_to_activate, $plugin_roles[$plugin_to_activate] ?? 'plugin');
+    $activated_plugins[] = $plugin_to_activate;
 }
 $loaded_bootstrap_file = '';
 foreach (is_array($bootstrap_files) ? $bootstrap_files : array() as $bootstrap_file) {


### PR DESCRIPTION
## Summary
- Load/include the primary bench component immediately after ensuring it is active and before activating dependency plugins.
- Keep hook snapshots ahead of component/dependency includes so deferred `plugins_loaded`/`init` callbacks are still replayed.
- Update the bench smoke fixture so the dependency activates inside `wordpress.bench` and fails if it cannot see the primary component API.

Fixes #942.

## Verification
- `npm run build`
- `npx tsx scripts/bench-bootstrap-files-smoke.ts`
- `npx tsx scripts/recipe-bench-smoke.ts`
- `npm run check` progressed through build, bench, recipe, and many smoke checks, but hit the local 10-minute shell timeout during `recipe-interruption-artifacts-smoke` with no assertion failure shown before timeout.
- `npx tsx scripts/recipe-interruption-artifacts-smoke.ts` also hit a local 5-minute shell timeout with no output.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the bench load-order fix, targeted regression fixture updates, smoke verification, and PR description for Chris to review.