### PR TITLE
Fix bench component load before dependencies

### DIFF
--- a/examples/bench-dependency/dependency-main.php
+++ b/examples/bench-dependency/dependency-main.php
@@ -34,6 +34,15 @@ add_action(
 	}
 );
 
+register_activation_hook(
+	__FILE__,
+	static function (): void {
+		if ( ! function_exists( 'wp_codebox_bench_plugin_value' ) ) {
+			wp_die( 'Bench dependency requires the component plugin to be loaded before activation.' );
+		}
+	}
+);
+
 function wp_codebox_bench_dependency_value(): int {
 	return WP_Codebox_Bench_Dependency_Fixture::value();
 }

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -516,7 +516,11 @@ $plugins_to_activate = array_values(array_unique($plugins_to_activate));
 foreach ($plugins_to_activate as $plugin_to_activate) {
     wp_codebox_bench_assert_plugin_autoload_ready($plugin_to_activate);
 }
-foreach ($plugins_to_activate as $plugin_to_activate) {
+
+$pre_plugins_loaded_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('plugins_loaded');
+$pre_init_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('init');
+
+foreach (array($plugin_file) as $plugin_to_activate) {
     if (is_plugin_active($plugin_to_activate)) {
         continue;
     }
@@ -526,10 +530,19 @@ foreach ($plugins_to_activate as $plugin_to_activate) {
     }
     $activated_plugins[] = $plugin_to_activate;
 }
+wp_codebox_bench_include_plugin_file($plugin_file, $plugin_roles[$plugin_file] ?? 'component');
 
-$pre_plugins_loaded_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('plugins_loaded');
-$pre_init_callbacks = wp_codebox_bench_snapshot_wordpress_hook_callbacks('init');
 foreach ($plugins_to_activate as $plugin_to_activate) {
+    if ($plugin_to_activate === $plugin_file) {
+        continue;
+    }
+    if (!is_plugin_active($plugin_to_activate)) {
+        $activation = activate_plugin($plugin_to_activate);
+        if (is_wp_error($activation)) {
+            throw new RuntimeException('wordpress.bench failed to activate plugin "' . $plugin_to_activate . '". ' . wp_codebox_bench_plugin_load_diagnostic($plugin_to_activate, $plugin_roles[$plugin_to_activate] ?? 'plugin', $activation->get_error_message()));
+        }
+        $activated_plugins[] = $plugin_to_activate;
+    }
     wp_codebox_bench_include_plugin_file($plugin_to_activate, $plugin_roles[$plugin_to_activate] ?? 'plugin');
 }
 $loaded_bootstrap_file = '';

--- a/scripts/bench-bootstrap-files-smoke.ts
+++ b/scripts/bench-bootstrap-files-smoke.ts
@@ -42,5 +42,11 @@ assert.ok(
   code.indexOf("require_once $bootstrap_path") < code.indexOf("wp_codebox_bench_run_deferred_wordpress_hook_callbacks($deferred_plugins_loaded_callbacks"),
   "bootstrap files should load before synthetic plugins_loaded/init hooks"
 )
+const componentIncludeIndex = code.indexOf("wp_codebox_bench_include_plugin_file($plugin_file")
+const dependencyActivationLoopIndex = code.indexOf("foreach ($plugins_to_activate as $plugin_to_activate)", componentIncludeIndex)
+assert.ok(
+  componentIncludeIndex < code.indexOf("$activation = activate_plugin($plugin_to_activate)", dependencyActivationLoopIndex),
+  "component plugin should be loaded before dependency activation"
+)
 
 console.log("Bench bootstrap files smoke passed")


### PR DESCRIPTION
## Summary
- load the primary bench component immediately after activating it
- activate dependency plugins only after the component file has been included
- add fixture/smoke coverage for dependency activation paths that need component APIs

Fixes #942

## Testing
- npm run build
- npx tsx scripts/bench-bootstrap-files-smoke.ts
- npx tsx scripts/recipe-bench-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the code change and smoke coverage; Chris remains responsible for review and merge.