### PR TITLE
Fix agent task prepared component plugins

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,7 +1,7 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { basename, join } from "node:path"
+import { basename, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeTaskInput, stripUndefined, type SandboxToolPolicySnapshot, type StructuredArtifactPayload, type WorkspaceRecipe, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
 import { runRecipeRunCommand } from "./recipe-run.js"
@@ -549,9 +549,10 @@ function componentPlugins(contracts: Array<Record<string, unknown>> | undefined,
   return contracts.flatMap((contract) => {
     const slug = slugFromPath(stringValue(contract.slug || contract.component || contract.name))
     const source = stringValue(contract.path || contract.source)
+    const originalSource = stringValue(contract.original_source || contract.originalSource || contract.original_path || contract.originalPath)
     if (!slug || !source) return []
     return [{
-      source: prepareComposerPluginSource(source, slug, artifactsRoot),
+      source: prepareComponentPluginSource(source, originalSource, slug, artifactsRoot),
       slug,
       activate: Boolean(contract.activate),
       loadAs: stringValue(contract.loadAs) || "mu-plugin",
@@ -559,31 +560,84 @@ function componentPlugins(contracts: Array<Record<string, unknown>> | undefined,
   })
 }
 
+function prepareComponentPluginSource(source: string, originalSource: string, slug: string, artifactsRoot: string): string {
+  if (!artifactsRoot) {
+    return prepareComposerPluginSource(originalSource || source, slug, artifactsRoot)
+  }
+
+  const preparedSource = preparedPluginSource(artifactsRoot, slug)
+  const copySource = localSourcePath(originalSource || source)
+  if (!pathExists(copySource)) {
+    return prepareComposerPluginSource(source, slug, artifactsRoot)
+  }
+
+  if (resolve(copySource) !== resolve(preparedSource)) {
+    rmSyncSafe(preparedSource)
+    mkdirSyncSafe(preparedPluginRoot(artifactsRoot))
+    cpSyncFiltered(copySource, preparedSource)
+  } else {
+    mkdirSyncSafe(preparedSource)
+  }
+
+  return installComposerDependenciesIfNeeded(preparedSource, slug)
+}
+
 function prepareComposerPluginSource(source: string, slug: string, artifactsRoot: string): string {
-  if (!source || !pathExists(join(source, "composer.json")) || pathExists(join(source, "vendor", "autoload.php"))) {
-    return source
+  if (!source) return source
+
+  const localSource = localSourcePath(source)
+  if (!pathExists(join(localSource, "composer.json"))) {
+    return pathExists(localSource) ? localSource : source
+  }
+  if (pathExists(join(localSource, "vendor", "autoload.php"))) {
+    return localSource
   }
   if (!artifactsRoot) {
     throw new Error(`Plugin ${slug} requires Composer dependencies but no artifacts directory is available for staging.`)
   }
 
-  const preparedRoot = join(artifactsRoot, "prepared-plugins")
-  const preparedSource = join(preparedRoot, slug)
-  rmSyncSafe(preparedSource)
-  mkdirSyncSafe(preparedRoot)
-  cpSyncFiltered(source, preparedSource)
+  const preparedRoot = preparedPluginRoot(artifactsRoot)
+  const preparedSource = preparedPluginSource(artifactsRoot, slug)
+  if (resolve(localSource) !== resolve(preparedSource)) {
+    rmSyncSafe(preparedSource)
+    mkdirSyncSafe(preparedRoot)
+    cpSyncFiltered(localSource, preparedSource)
+  } else {
+    mkdirSyncSafe(preparedSource)
+  }
+
+  return installComposerDependenciesIfNeeded(preparedSource, slug)
+}
+
+function installComposerDependenciesIfNeeded(source: string, slug: string): string {
+  if (!pathExists(join(source, "composer.json")) || pathExists(join(source, "vendor", "autoload.php"))) {
+    return source
+  }
+
   const result = spawnSync("composer", ["install", "--no-interaction", "--prefer-dist", "--no-progress"], {
-    cwd: preparedSource,
+    cwd: source,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   })
   if (result.status !== 0) {
     throw new Error(`Composer install failed for plugin ${slug}: ${result.stderr || result.stdout || `exit ${result.status}`}`)
   }
-  if (!pathExists(join(preparedSource, "vendor", "autoload.php"))) {
+  if (!pathExists(join(source, "vendor", "autoload.php"))) {
     throw new Error(`Composer install for plugin ${slug} did not create vendor/autoload.php.`)
   }
-  return preparedSource
+  return source
+}
+
+function preparedPluginRoot(artifactsRoot: string): string {
+  return resolve(artifactsRoot, "prepared-plugins")
+}
+
+function preparedPluginSource(artifactsRoot: string, slug: string): string {
+  return join(preparedPluginRoot(artifactsRoot), slug)
+}
+
+function localSourcePath(source: string): string {
+  return pathExists(source) ? resolve(source) : source
 }
 
 function pathExists(filePath: string): boolean {

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { artifactManifestFile, normalizeTaskInput, type ArtifactBundle, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
@@ -9,6 +9,7 @@ import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src
 import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
 import { installMuPluginsCode } from "../packages/cli/src/recipe-sources.js"
 import { buildAgentTaskSingleResult, finalizeAgentSandboxEvidence } from "../packages/cli/src/recipe-evidence.js"
+import { validateWorkspaceRecipe } from "../packages/cli/src/recipe-validation.js"
 
 const input = {
   goal: "Run a caller runtime bundle",
@@ -103,6 +104,42 @@ const verifyRecipe = buildAgentTaskRecipe(verifyInput, normalizeTaskInput(verify
 assert.equal(verifyRecipe.workflow.steps[0]?.command, "wp-codebox.agent-sandbox-run", "agent run remains the primary workflow step")
 assert.equal(verifyRecipe.workflow.after?.length, 1, "verify_steps should be emitted as workflow.after")
 assert.equal(verifyRecipe.workflow.after?.[0]?.command, "wordpress.phpunit", "after step should be the supplied verify command")
+
+const preparedComponentRoot = mkdtempSync(join(tmpdir(), "wp-codebox-prepared-component-smoke-"))
+const preparedComponentArtifacts = join(preparedComponentRoot, "artifacts")
+const preparedComponentOriginals = join(preparedComponentRoot, "originals")
+const preparedComponentSlugs = ["agents-api", "data-machine", "data-machine-code"]
+const preparedComponentContracts = preparedComponentSlugs.map((slug) => {
+  const original = join(preparedComponentOriginals, slug)
+  mkdirSync(original, { recursive: true })
+  writeFileSync(join(original, `${slug}.php`), `<?php\n/**\n * Plugin Name: ${slug}\n */\n`)
+  writeFileSync(join(original, "composer.json"), `${JSON.stringify({ name: `acme/${slug}`, autoload: { files: [`${slug}.php`] } }, null, 2)}\n`)
+  return {
+    slug,
+    path: join(preparedComponentArtifacts, "prepared-plugins", slug),
+    original_source: original,
+    loadAs: "mu-plugin",
+  }
+})
+const preparedComponentInput = {
+  goal: "Run prepared runtime components",
+  provider: "opencode",
+  model: "opencode-go/kimi-k2.6",
+  artifacts_path: preparedComponentArtifacts,
+  component_contracts: preparedComponentContracts,
+}
+const preparedComponentRecipe = buildAgentTaskRecipe(preparedComponentInput, normalizeTaskInput(preparedComponentInput), "trunk")
+for (const slug of preparedComponentSlugs) {
+  const plugin = preparedComponentRecipe.inputs?.extra_plugins?.find((entry) => entry.slug === slug)
+  const preparedSource = join(preparedComponentArtifacts, "prepared-plugins", slug)
+  assert.equal(plugin?.source, preparedSource, `${slug} should reference the prepared plugin copy`)
+  assert.equal(existsSync(join(preparedSource, `${slug}.php`)), true, `${slug} plugin file should exist before recipe validation`)
+  assert.equal(existsSync(join(preparedSource, "composer.json")), true, `${slug} composer file should exist before recipe validation`)
+  assert.equal(existsSync(join(preparedSource, "vendor", "autoload.php")), true, `${slug} Composer autoload should exist before recipe validation`)
+}
+const preparedComponentRecipePath = join(mkdtempSync(join(tmpdir(), "wp-codebox-prepared-component-recipe-")), "recipe.json")
+writeFileSync(preparedComponentRecipePath, `${JSON.stringify(preparedComponentRecipe, null, 2)}\n`)
+assert.deepEqual(await validateWorkspaceRecipe(preparedComponentRecipe, preparedComponentRecipePath), [], "prepared runtime component recipe should validate after staging plugins")
 
 // Without verify_steps, no after phase is emitted (back-compat with current runs).
 const noVerifyRecipe = buildAgentTaskRecipe(input, normalizeTaskInput(input), "trunk")

--- a/tests/fixtures/artifact-package-provenance-shape.json
+++ b/tests/fixtures/artifact-package-provenance-shape.json
@@ -2,15 +2,15 @@
   "schema": "wp-codebox/package-provenance/v1",
   "wpCodebox": {
     "name": "wp-codebox-workspace",
-    "version": "0.8.1"
+    "version": "0.8.2"
   },
   "runtimeCore": {
     "name": "@automattic/wp-codebox-core",
-    "version": "0.8.1"
+    "version": "0.8.2"
   },
   "runtimePlayground": {
     "name": "@automattic/wp-codebox-playground",
-    "version": "0.8.1"
+    "version": "0.8.2"
   },
   "playground": {
     "cli": {


### PR DESCRIPTION
## Summary
- Stage component plugin contracts into `artifacts/prepared-plugins/<slug>` from their original local source when one is available.
- Avoid deleting an already-prepared component/plugin source before Composer dependency installation.
- Cover prepared `agents-api`, `data-machine`, and `data-machine-code` runtime component contracts before recipe validation.
- Refresh the package provenance fixture to match the current `0.8.2` package manifests so the check smoke can progress past the artifact contract gate.

Fixes #945

## Verification
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`
- `npm run build`
- `npm run check` progressed through the new runtime component smoke, but the aggregate run repeatedly timed out while running `scripts/recipe-interruption-artifacts-smoke.ts`.
- `npx tsx scripts/recipe-interruption-artifacts-smoke.ts` also timed out after 3 minutes with no output.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the WP Codebox CLI component plugin staging fix, added regression smoke coverage, ran verification, and drafted this PR description; Chris to review before merge.