### PR TITLE
Capture replayable runtime state in blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,8 +1066,9 @@ Current bundles include:
 
 - `manifest.json`: artifact index with content types and the content digest used for the bundle id.
 - `metadata.json`: runtime, policy, mounts, and caller metadata.
-- `blueprint.after.json`: partial WordPress Playground replay blueprint for captured text files.
-- `blueprint.after-notes.json`: replay limitations and next capture targets.
+- `blueprint.after.json`: WordPress Playground replay blueprint. When a runtime-state snapshot is available, this restores the generated WordPress database, active theme/plugin state, and captured `wp-content` files. Otherwise it falls back to a partial write-file replay for captured text files.
+- `blueprint.after-notes.json`: replay status, captured state summary, limitations, and diagnostic pointers.
+- `files/blueprint.after.partial.json`: diagnostic partial write-file replay retained when `blueprint.after.json` is backed by a runtime-state snapshot.
 - `events.jsonl`, `commands.jsonl`, `observations.jsonl`: runtime evidence streams.
 - `logs/runtime.log`, `logs/commands.log`: human-readable logs.
 - `files/mounts.json`: mounted input list.

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -10,7 +10,7 @@ import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded } from "../recipe-dry-run.js"
-import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
+import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -413,7 +413,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       await awaitRecipe("runtime.observe:runtime-info", runtime!.observe({ type: "runtime-info" }))
       await awaitRecipe("runtime.observe:mounts", runtime!.observe({ type: "mounts" }))
       runRecord = await runRegistry.update(runRecord.runId, { status: "collecting_artifacts", runtime: await runtime!.info() })
-      artifacts = await awaitRecipe("runtime.collect-artifacts", runtime!.collectArtifacts({ includeLogs: true, includeObservations: true }))
+      artifacts = await awaitRecipe("runtime.collect-artifacts", collectRecipeRuntimeArtifacts(runtime!, { includeLogs: true, includeObservations: true }, { snapshotTimeoutMs: 20_000 }))
       browserEvidence = await recipeBrowserEvidence(artifacts, executions)
       await artifactPointer.update({ runtime: await runtime!.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts))
@@ -435,7 +435,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const recipeFailure = strictFailure ?? agentFailure ?? verifyFailure
     const successfulRecipe = !recipeFailure
     if (successfulRecipe && options.previewHoldSeconds) {
-      artifacts = await awaitRecipe("runtime.collect-artifacts.preview-hold", runtime.collectArtifacts({ includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds }))
+      artifacts = await awaitRecipe("runtime.collect-artifacts.preview-hold", collectRecipeRuntimeArtifacts(runtime, { includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds }, { snapshotTimeoutMs: 20_000 }))
       browserEvidence = await recipeBrowserEvidence(artifacts, executions)
       await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, checkWorkspacePolicy, isPlainObject as isRecord, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, sha256StableJson, stripUndefined, upsertArtifactManifestFiles, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ArtifactManifestFile, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactIndex, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, checkWorkspacePolicy, isPlainObject as isRecord, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, sha256StableJson, stripUndefined, upsertArtifactManifestFiles, verifyArtifactBundle, type ArtifactBundle, type ArtifactBundleVerificationResult, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactIndex, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 
 export interface RecipeArtifactEvidenceFile {
   path: string
@@ -257,6 +257,11 @@ export interface RecipeArtifactsFinalizationController {
   readonly metadata: { artifactsFinalized: boolean } | undefined
 }
 
+interface RecipeRuntimeArtifactCollectionOptions {
+  timeoutMs?: number
+  snapshotTimeoutMs?: number
+}
+
 const execFileAsync = promisify(execFile)
 const moduleDirectory = dirname(fileURLToPath(import.meta.url))
 const workspaceRoot = resolve(moduleDirectory, "..", "..", "..")
@@ -276,7 +281,7 @@ export async function collectAndFinalizeFailedRecipeArtifacts(args: {
 
   if (!artifacts) {
     try {
-      artifacts = await args.runtime.collectArtifacts({ includeLogs: true, includeObservations: true })
+      artifacts = await collectRecipeRuntimeArtifacts(args.runtime, { includeLogs: true, includeObservations: true }, { snapshotTimeoutMs: 20_000, timeoutMs: 30_000 })
     } catch {
       return undefined
     }
@@ -291,6 +296,67 @@ export async function collectAndFinalizeFailedRecipeArtifacts(args: {
   }
 
   return artifacts
+}
+
+export async function collectRecipeRuntimeArtifacts(runtime: Runtime, spec: ArtifactSpec, options: RecipeRuntimeArtifactCollectionOptions = {}): Promise<ArtifactBundle> {
+  let snapshotCaptured = false
+  try {
+    const snapshot = runtime.snapshot()
+    if (options.snapshotTimeoutMs && options.snapshotTimeoutMs > 0) {
+      snapshot.catch(() => undefined)
+      const settled = await timeoutOrUndefined(snapshot, options.snapshotTimeoutMs)
+      snapshotCaptured = settled !== undefined
+    } else {
+      await snapshot
+      snapshotCaptured = true
+    }
+  } catch {
+    // Preserve artifact collection on runtimes that are too broken to snapshot.
+  }
+
+  const collectSpec: ArtifactSpec = snapshotCaptured && spec.includeRuntimeSnapshotBundles !== false
+    ? { ...spec, includeRuntimeSnapshotBundles: true }
+    : spec
+  const artifacts = runtime.collectArtifacts(collectSpec)
+  if (options.timeoutMs && options.timeoutMs > 0) {
+    return timeoutOrReject(artifacts, options.timeoutMs, `Runtime artifact collection exceeded ${options.timeoutMs}ms`)
+  }
+  return artifacts
+}
+
+async function timeoutOrUndefined<T>(promise: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  let timeout: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => resolve(undefined), timeoutMs)
+        timeout.unref()
+      }),
+    ])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+async function timeoutOrReject<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined
+  promise.catch(() => undefined)
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
+        timeout.unref()
+      }),
+    ])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
 }
 
 export async function finalizeRecipeArtifactEvidence(

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -8,7 +8,7 @@ import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs
 import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserRedirectDiagnosticsSummary, BrowserStepRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
-import { BrowserCommandLivenessError, browserCommandLivenessPolicy, withBrowserCommandLiveness, type BrowserCommandLivenessPolicy } from "./browser-liveness.js"
+import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness, type BrowserCommandLivenessPolicy } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserError } from "./browser-metrics.js"
 import { browserPreviewNetworkPolicy, browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
@@ -604,7 +604,7 @@ async function runSingleBrowserProbeCommand({
     finalUrl = page.url()
   } catch (error) {
     pendingError = error instanceof Error ? error : new Error(String(error))
-    if (pendingError instanceof BrowserCommandLivenessError) {
+    if (isBrowserCommandLivenessError(pendingError)) {
       await page?.close().catch(() => undefined)
       page = null
     }
@@ -764,7 +764,7 @@ async function runSingleBrowserProbeCommand({
         ...(performanceArtifact ? { performance: `${browserFilesDirectory}/performance.json` } : {}),
         ...(redirectDiagnostics ? { redirectDiagnostics: `${browserFilesDirectory}/redirect-diagnostics.json` } : {}),
         review: `${browserFilesDirectory}/review.json`,
-        ...(capture.has("screenshot") ? { screenshot: `${browserFilesDirectory}/screenshot.png` } : {}),
+        ...(screenshotSha256 ? { screenshot: `${browserFilesDirectory}/screenshot.png` } : {}),
         ...(wordpressDiagnostics ? { wordpressDiagnostics: `${browserFilesDirectory}/wordpress-diagnostics.json` } : {}),
         summary: `${browserFilesDirectory}/summary.json`,
       },
@@ -791,7 +791,7 @@ async function runSingleBrowserProbeCommand({
         auth: authSummary,
         capabilities: capabilityDiagnostics,
         replayability: browserProbeReplayability(capture),
-        screenshot: capture.has("screenshot"),
+        screenshot: Boolean(screenshotSha256),
         ...(typeof scriptResult !== "undefined" ? { scriptResult } : {}),
         viewport,
       },
@@ -2384,7 +2384,7 @@ export async function runBrowserActionsCommand({
         errors.push(serialized)
         stepRecords.push(browserStepRecord(index, step, "failed", recordStartedAt, recordStartedAtMs, page.url(), { error: serialized }))
         pendingError = error instanceof Error ? error : new Error(String(error))
-        if (pendingError instanceof BrowserCommandLivenessError) {
+        if (isBrowserCommandLivenessError(pendingError)) {
           await page.close().catch(() => undefined)
         }
         break
@@ -5503,8 +5503,11 @@ async function withBrowserProbeLiveness<T>(page: import("playwright").Page, prog
         // The page may be navigating or already closed; the outer operation remains authoritative.
       }
     },
+    onTimeout: async () => {
+      await page.close().catch(() => undefined)
+    },
   }).catch((error) => {
-    if (error instanceof BrowserCommandLivenessError && error.code === "browser-command-idle-timeout") {
+    if (isBrowserCommandLivenessError(error) && error.code === "browser-command-idle-timeout") {
       const summary = progress.summary()
       throw new BrowserProbeStallError(summary.idleMs, policy.idleTimeoutMs, summary.lastProgressSource, summary.lastCheckpoint)
     }

--- a/packages/runtime-playground/src/browser-liveness.ts
+++ b/packages/runtime-playground/src/browser-liveness.ts
@@ -32,6 +32,15 @@ export class BrowserCommandLivenessError extends Error {
   }
 }
 
+export function isBrowserCommandLivenessError(error: unknown): error is BrowserCommandLivenessError {
+  return error instanceof BrowserCommandLivenessError || (
+    Boolean(error) &&
+    typeof error === "object" &&
+    (error as { name?: unknown }).name === "BrowserCommandLivenessError" &&
+    ((error as { code?: unknown }).code === "browser-command-wall-timeout" || (error as { code?: unknown }).code === "browser-command-idle-timeout")
+  )
+}
+
 export function browserCommandLivenessPolicy(overrides: BrowserCommandLivenessPolicy = {}): Required<BrowserCommandLivenessPolicy> {
   return {
     wallTimeoutMs: normalizeNonNegative(overrides.wallTimeoutMs, BROWSER_COMMAND_LIVENESS_DEFAULTS.wallTimeoutMs),
@@ -49,6 +58,7 @@ export async function withBrowserCommandLiveness<T>({
   policy: policyOverrides,
   poll,
   idle,
+  onTimeout,
 }: {
   command: string
   phase: string
@@ -56,6 +66,7 @@ export async function withBrowserCommandLiveness<T>({
   policy?: BrowserCommandLivenessPolicy
   poll?: () => Promise<void> | void
   idle?: () => { idleMs: number; lastProgressSource?: string }
+  onTimeout?: (error: BrowserCommandLivenessError) => Promise<void> | void
 }): Promise<T> {
   const policy = browserCommandLivenessPolicy(policyOverrides)
   if (policy.wallTimeoutMs <= 0 && (!idle || policy.idleTimeoutMs <= 0) && !poll) {
@@ -64,12 +75,35 @@ export async function withBrowserCommandLiveness<T>({
 
   const startedAtMs = Date.now()
   let interval: NodeJS.Timeout | undefined
+  let wallTimeout: NodeJS.Timeout | undefined
   operation.catch(() => undefined)
+
+  const rejectWithTimeout = async (reject: (error: BrowserCommandLivenessError) => void, error: BrowserCommandLivenessError): Promise<void> => {
+    reject(error)
+    try {
+      await onTimeout?.(error)
+    } catch {
+      // Preserve the liveness timeout as the actionable failure.
+    }
+  }
 
   try {
     return await Promise.race([
       operation,
       new Promise<T>((_resolve, reject) => {
+        if (policy.wallTimeoutMs > 0) {
+          wallTimeout = setTimeout(() => {
+            const elapsedMs = Date.now() - startedAtMs
+            void rejectWithTimeout(reject, new BrowserCommandLivenessError({
+              command,
+              phase,
+              type: "wall",
+              elapsedMs,
+              timeoutMs: policy.wallTimeoutMs,
+            }))
+          }, policy.wallTimeoutMs)
+          wallTimeout.unref()
+        }
         interval = setInterval(() => {
           void (async () => {
             try {
@@ -88,18 +122,6 @@ export async function withBrowserCommandLiveness<T>({
                   return
                 }
               }
-              if (policy.wallTimeoutMs > 0) {
-                const elapsedMs = Date.now() - startedAtMs
-                if (elapsedMs >= policy.wallTimeoutMs) {
-                  reject(new BrowserCommandLivenessError({
-                    command,
-                    phase,
-                    type: "wall",
-                    elapsedMs,
-                    timeoutMs: policy.wallTimeoutMs,
-                  }))
-                }
-              }
             } catch (error) {
               reject(error)
             }
@@ -111,6 +133,9 @@ export async function withBrowserCommandLiveness<T>({
   } finally {
     if (interval) {
       clearInterval(interval)
+    }
+    if (wallTimeout) {
+      clearTimeout(wallTimeout)
     }
   }
 }

--- a/scripts/recipe-browser-probe-liveness-smoke.ts
+++ b/scripts/recipe-browser-probe-liveness-smoke.ts
@@ -39,12 +39,30 @@ try {
   assert.equal(scriptTimeout.exit.code, 1, `long script should fail recipe-run; stdout: ${scriptTimeout.stdout}; stderr: ${scriptTimeout.stderr}`)
   assert.ok(scriptTimeout.elapsedMs < 60_000, `long script should fail before the watchdog; elapsed=${scriptTimeout.elapsedMs}`)
   assert.match(scriptTimeout.output.error?.message ?? "", /exceeded 3000ms|wall/i)
-  assert.equal(scriptTimeout.summary.wallTimeoutMs ?? scriptTimeout.summary.liveness?.wallTimeoutMs, 3000)
-  assert.equal((scriptTimeout.summary.summary ?? scriptTimeout.summary).progress.status, "failed")
+  const normalizedScriptTimeoutSummary = scriptTimeout.summary.summary ?? scriptTimeout.summary
+  assert.equal(scriptTimeout.summary.wallTimeoutMs ?? normalizedScriptTimeoutSummary.liveness?.wallTimeoutMs, 3000)
+  assert.equal(normalizedScriptTimeoutSummary.progress.status, "failed")
+  await assertReplayableBlueprintAfter(scriptTimeout.output.artifacts?.directory)
 
   console.log("Recipe browser probe liveness smoke passed")
 } finally {
   await rm(workspace, { recursive: true, force: true })
+}
+
+async function assertReplayableBlueprintAfter(artifactDirectory: string | undefined): Promise<void> {
+  assert.ok(artifactDirectory, "browser command timeout should produce artifact directory")
+  const manifest = JSON.parse(await readFile(join(artifactDirectory, "manifest.json"), "utf8"))
+  const blueprintAfterManifestFile = manifest.files.find((file: { path?: string }) => file.path === "blueprint.after.json")
+  assert.equal(blueprintAfterManifestFile?.viewer?.replay?.status, "replayable-runtime-state")
+  assert.ok(manifest.files.some((file: { path?: string; kind?: string }) => file.path === "files/blueprint.after.partial.json" && file.kind === "blueprint-after-diagnostic"))
+  const blueprintAfter = JSON.parse(await readFile(join(artifactDirectory, "blueprint.after.json"), "utf8"))
+  assert.equal(blueprintAfter.steps?.[0]?.step, "runPHP")
+  assert.match(blueprintAfter.steps?.[0]?.code ?? "", /wp-codebox\/wordpress-runtime-snapshot\/v1/)
+  const blueprintAfterNotes = JSON.parse(await readFile(join(artifactDirectory, "blueprint.after-notes.json"), "utf8"))
+  assert.equal(blueprintAfterNotes.replayStatus, "replayable-runtime-state")
+  assert.equal(blueprintAfterNotes.source?.diagnosticBlueprint, "files/blueprint.after.partial.json")
+  const partialBlueprintAfter = JSON.parse(await readFile(join(artifactDirectory, "files", "blueprint.after.partial.json"), "utf8"))
+  assert.ok(Array.isArray(partialBlueprintAfter.steps), "diagnostic partial blueprint should remain readable")
 }
 
 async function runRecipe(name: string, args: string[], watchdogMs: number): Promise<{


### PR DESCRIPTION
## Summary
- Capture runtime-state snapshots for recipe artifacts so `blueprint.after.json` can become a replayable WordPress site proof.
- Preserve partial blueprint diagnostics as fallback output when full runtime replay is unavailable.
- Tighten browser liveness artifact reporting so timeout evidence stays accurate.

Fixes #947.

## Verification
- Targeted WP Codebox runtime replay/liveness smokes were run by the implementation session before dependency restoration was interrupted.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the focused runtime replay capture changes at Chris's request.