### PR TITLE
Stage local agent bundle sources

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
-import { DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeTaskInput, stripUndefined, type SandboxToolPolicySnapshot, type StructuredArtifactPayload, type WorkspaceRecipe, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeTaskInput, stripUndefined, type SandboxToolPolicySnapshot, type StructuredArtifactPayload, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipeStagedFile } from "@automattic/wp-codebox-core"
 import { runRecipeRunCommand } from "./recipe-run.js"
 
 export interface AgentTaskRunOptions {
@@ -34,6 +34,7 @@ export interface AgentTaskRunInput {
   runtime_stack_mounts?: WorkspaceRecipeMount[]
   runtime_overlays?: Array<Record<string, unknown>>
   agent_bundles?: Array<Record<string, unknown>>
+  stagedFiles?: WorkspaceRecipeStagedFile[]
   runtime_task?: Record<string, unknown>
   agent_bundle?: Record<string, unknown>
   sandbox_tool_policy?: SandboxToolPolicySnapshot
@@ -216,6 +217,8 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
   const artifacts = stringValue(input.artifacts_path)
   const profile = runtimeOverlayProfileDefaults(input)
   const runtimeMounts = runtimeStateMounts(input)
+  const agentBundleStagedFiles = stagedAgentBundleSources(input.agent_bundles)
+  const stagedFiles = [...(Array.isArray(input.stagedFiles) ? input.stagedFiles : []), ...agentBundleStagedFiles]
   const providerPlugins = uniqueStrings(stringList(input.provider_plugin_paths))
     .map((plugin) => {
       const slug = slugFromComposerPackage(plugin) || slugFromPath(plugin)
@@ -269,6 +272,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
       ].filter(Boolean),
       runtimeEnv: runtimeEnv(input),
       secretEnv: stringList(input.secret_env),
+      stagedFiles: stagedFiles.length > 0 ? stagedFiles : undefined,
       agent_bundles: Array.isArray(input.agent_bundles) && input.agent_bundles.length > 0 ? input.agent_bundles : undefined,
     }),
     workflow: stripUndefined({
@@ -280,6 +284,39 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: Return
       after: Array.isArray(input.verify_steps) && input.verify_steps.length > 0 ? input.verify_steps : undefined,
     }),
   }) as WorkspaceRecipe
+}
+
+function stagedAgentBundleSources(agentBundles: AgentTaskRunInput["agent_bundles"]): WorkspaceRecipeStagedFile[] {
+  if (!Array.isArray(agentBundles)) return []
+
+  const stagedFiles: WorkspaceRecipeStagedFile[] = []
+  const seenTargets = new Set<string>()
+  for (const bundle of agentBundles) {
+    const source = stringValue(bundle.source)
+    if (!source || bundle.bundle || seenTargets.has(source)) continue
+    const localSource = localAgentBundleSource(source)
+    if (!localSource) continue
+    stagedFiles.push({
+      source: localSource,
+      target: source,
+    })
+    seenTargets.add(source)
+  }
+  return stagedFiles
+}
+
+function localAgentBundleSource(source: string): string {
+  const direct = resolve(source)
+  if (existsSync(direct)) return direct
+
+  const workspacePrefix = "/workspace/"
+  if (!source.startsWith(workspacePrefix)) return ""
+
+  const relativeToWorkspace = source.slice(workspacePrefix.length).split("/").filter(Boolean).slice(1).join("/")
+  if (!relativeToWorkspace) return ""
+
+  const fromCwd = resolve(process.cwd(), relativeToWorkspace)
+  return existsSync(fromCwd) ? fromCwd : ""
 }
 
 interface RuntimeOverlayProfileDefaults {

--- a/scripts/agent-task-run-runtime-components-smoke.ts
+++ b/scripts/agent-task-run-runtime-components-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { artifactManifestFile, normalizeTaskInput, type ArtifactBundle, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
@@ -140,6 +140,27 @@ for (const slug of preparedComponentSlugs) {
 const preparedComponentRecipePath = join(mkdtempSync(join(tmpdir(), "wp-codebox-prepared-component-recipe-")), "recipe.json")
 writeFileSync(preparedComponentRecipePath, `${JSON.stringify(preparedComponentRecipe, null, 2)}\n`)
 assert.deepEqual(await validateWorkspaceRecipe(preparedComponentRecipe, preparedComponentRecipePath), [], "prepared runtime component recipe should validate after staging plugins")
+
+const agentBundleWorkspace = mkdtempSync(join(tmpdir(), "wp-codebox-agent-bundle-workspace-"))
+const agentBundleSource = join(agentBundleWorkspace, "bundles", "website-idea-agent")
+mkdirSync(agentBundleSource, { recursive: true })
+writeFileSync(join(agentBundleSource, "manifest.json"), `${JSON.stringify({ schema_version: 1, bundle_slug: "website-idea-agent" }, null, 2)}\n`)
+const previousCwd = process.cwd()
+process.chdir(agentBundleWorkspace)
+try {
+  const bundleRecipe = buildAgentTaskRecipe({
+    goal: "Import a caller-local bundle into the sandbox",
+    agent_bundles: [{ source: "/workspace/wp-site-generator/bundles/website-idea-agent", slug: "website-idea-agent" }],
+  }, normalizeTaskInput({
+    goal: "Import a caller-local bundle into the sandbox",
+    agent_bundles: [{ source: "/workspace/wp-site-generator/bundles/website-idea-agent", slug: "website-idea-agent" }],
+  }), "trunk")
+  assert.equal(bundleRecipe.inputs?.agent_bundles?.[0]?.source, "/workspace/wp-site-generator/bundles/website-idea-agent", "bundle import keeps the sandbox source contract")
+  assert.equal(bundleRecipe.inputs?.stagedFiles?.[0]?.source, realpathSync(agentBundleSource), "local bundle source should be staged from the caller checkout")
+  assert.equal(bundleRecipe.inputs?.stagedFiles?.[0]?.target, "/workspace/wp-site-generator/bundles/website-idea-agent", "local bundle source should mount at the sandbox import path")
+} finally {
+  process.chdir(previousCwd)
+}
 
 // Without verify_steps, no after phase is emitted (back-compat with current runs).
 const noVerifyRecipe = buildAgentTaskRecipe(input, normalizeTaskInput(input), "trunk")


### PR DESCRIPTION
## Summary
- Stage local `agent_bundles[].source` directories into the sandbox when WP Codebox can resolve them from the caller checkout.
- Preserve the sandbox import source path, so runtime importers still see `/workspace/...` instead of caller-local host paths.
- Add smoke coverage for `/workspace/<repo>/bundles/...` bundle sources being staged from the local checkout.

## Testing
- `npm run build`
- `npx tsx scripts/agent-task-run-runtime-components-smoke.ts`

## Notes
- `npm run check` reaches an existing `artifact-contract-smoke` contract assertion failure unrelated to this change. A clean primary checkout also fails that smoke with a stale contract assertion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosing the sandbox bundle import failure, drafting the WP Codebox fix, adding smoke coverage, and running validation. Chris identified the ownership boundary and rejected the downstream WPSG workaround.