### PR TITLE
Add recipe replay status summary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -361,6 +361,16 @@ Important artifact files include:
   traces, events, and snapshots.
 - `files/runtime-replay-index.json`: replay-oriented index describing which
   actions, observations, snapshots, and artifact refs are available.
+- `files/runtime-evidence/replay-status.json`: recipe-level replay summary with
+  schema `wp-codebox/recipe-replay-status/v1`. Recipe runs also mirror this
+  object to the top-level JSON output and run metadata as `replayStatus` so
+  orchestrators can consume one stable surface. Status is `replayable` when an
+  executable `blueprint.after.json`, notes, replay index, and runtime snapshot
+  are present; `partial` when a blueprint exists but replay capture is
+  incomplete; and `not_available` when no executable blueprint was captured.
+  Bundle-relative artifact paths are distinct from public access: callers must
+  publish the executable blueprint URL when browser replay needs an external
+  URL.
 
 Apply-back is intentionally outside runtime execution. WP Codebox validates an
 artifact id, content digest, approved file list, and patch/reference integrity;

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -1,6 +1,6 @@
 import type { ArtifactBundle, BenchResults, ExecutionResult, RuntimeInfo, RuntimeRunRecord } from "@automattic/wp-codebox-core"
 import type { RecipeDryRunOutput, RecipeDryRunSiteSeed, RecipeDryRunStagedFile } from "../recipe-dry-run.js"
-import type { AgentSandboxResultSummary, AgentTaskSingleResult, SandboxCompletionOutcome } from "../recipe-evidence.js"
+import type { AgentSandboxResultSummary, AgentTaskSingleResult, RecipeReplayStatusSummary, SandboxCompletionOutcome } from "../recipe-evidence.js"
 import type { RecipeValidationIssue, RecipeWorkflowPhase } from "../recipe-validation.js"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 
@@ -62,6 +62,7 @@ export interface RecipeRunOutput {
   agentResult?: AgentSandboxResultSummary
   agentTaskResult?: AgentTaskSingleResult
   completionOutcome?: SandboxCompletionOutcome
+  replayStatus?: RecipeReplayStatusSummary
   artifacts?: ArtifactBundle
   run?: RuntimeRunRecord
   interruption?: RecipeInterruptionMetadata

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -10,7 +10,7 @@ import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded } from "../recipe-dry-run.js"
-import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
+import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -467,7 +467,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         runtime: runtimeInfo ?? await runtime.info(),
         preview: artifacts.preview,
         artifactRefs: artifactBundleRunRef(artifacts),
-        metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: recipeFailure, phaseEvidence: phaseTracker.list() }) },
+        metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: recipeFailure, phaseEvidence: phaseTracker.list() }), ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}) },
         error: recipeFailure,
       })
       await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: recipeFailure, phases: phaseTracker.list(), browserEvidence })
@@ -490,6 +490,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
         ...(evidence.agentTaskResult ? { agentTaskResult: recipeAgentTaskResultOutput(evidence.agentTaskResult) } : {}),
         ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
+        ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}),
         artifacts,
         run: runRecord,
         error: recipeFailure,
@@ -501,7 +502,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       runtime: runtimeInfo ?? await runtime.info(),
       preview: artifacts.preview,
       artifactRefs: artifactBundleRunRef(artifacts),
-      metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "succeeded", startupDurationMs, cleanup: cleanupEvidence, artifacts, phaseEvidence: phaseTracker.list() }) },
+      metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "succeeded", startupDurationMs, cleanup: cleanupEvidence, artifacts, phaseEvidence: phaseTracker.list() }), ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}) },
     })
     await artifactPointer.update({ commandStatus: "completed", runtime: runtimeInfo ?? await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
     return {
@@ -523,6 +524,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
       ...(evidence.agentTaskResult ? { agentTaskResult: recipeAgentTaskResultOutput(evidence.agentTaskResult) } : {}),
       ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
+      ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}),
       artifacts,
       run: runRecord,
     }

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -50,6 +50,32 @@ export interface RecipeArtifactEvidenceResult {
   transcript?: AgentSandboxTranscript & {
     artifact: RecipeArtifactEvidenceFile
   }
+  replayStatus?: RecipeReplayStatusSummary & {
+    artifact: RecipeArtifactEvidenceFile
+  }
+}
+
+export interface RecipeReplayStatusSummary {
+  schema: "wp-codebox/recipe-replay-status/v1"
+  status: "replayable" | "partial" | "not_available"
+  reasons: string[]
+  artifacts: {
+    executableBlueprint?: RecipeReplayArtifactRef
+    notes?: RecipeReplayArtifactRef
+    runtimeSnapshot?: RecipeReplayArtifactRef
+    runtimeReferenceManifest?: RecipeReplayArtifactRef
+    replayIndex?: RecipeReplayArtifactRef
+  }
+  publicAccess: {
+    status: "not_required" | "caller_must_publish"
+    reason?: string
+  }
+}
+
+export interface RecipeReplayArtifactRef {
+  path: string
+  kind: string
+  contentType?: string
 }
 
 export interface AgentTaskSingleResult {
@@ -432,8 +458,110 @@ export async function finalizeRecipeArtifactEvidence(
     artifact: attestationFile,
   }
 
+  const replayStatusPath = join(evidenceDirectory, "replay-status.json")
+  const replayStatus = await buildRecipeReplayStatusSummary(artifacts)
+  const replayStatusFile = await writeRecipeEvidenceJson(artifacts.directory, replayStatusPath, replayStatus, "replay-status")
+  evidenceFiles.push(replayStatusFile)
+  result.replayStatus = {
+    ...replayStatus,
+    artifact: replayStatusFile,
+  }
+
   await updateRecipeArtifactEvidenceReferences(artifacts, evidenceFiles)
   return result
+}
+
+export async function buildRecipeReplayStatusSummary(artifacts: ArtifactBundle): Promise<RecipeReplayStatusSummary> {
+  const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as ArtifactManifest
+  const filesByKind = new Map(manifest.files.map((file) => [file.kind, file]))
+  const executableBlueprint = replayArtifactRef(filesByKind.get("blueprint-after"))
+  const notes = replayArtifactRef(filesByKind.get("blueprint-after-notes"))
+  const runtimeReferenceManifest = replayArtifactRef(filesByKind.get("runtime-reference-manifest"))
+  const replayIndex = replayArtifactRef(filesByKind.get("runtime-replay-index"))
+  const runtimeSnapshot = replayArtifactRef(manifest.files.find((file) => file.kind === "runtime-snapshot"))
+  const reasons: string[] = []
+
+  if (!executableBlueprint) {
+    reasons.push("missing_executable_blueprint")
+  }
+  if (!notes) {
+    reasons.push("missing_blueprint_notes")
+  }
+  if (!runtimeReferenceManifest) {
+    reasons.push("missing_runtime_reference_manifest")
+  }
+  if (!replayIndex) {
+    reasons.push("missing_runtime_replay_index")
+  }
+  if (!runtimeSnapshot) {
+    reasons.push("missing_runtime_snapshot")
+  }
+
+  const blueprintReplayStatus = executableBlueprint
+    ? await readBlueprintReplayStatus(artifacts.directory, executableBlueprint.path, notes?.path)
+    : undefined
+  if (blueprintReplayStatus === "replayable-runtime-state") {
+    reasons.push("blueprint_after_uses_runtime_state_snapshot")
+  } else if (blueprintReplayStatus === "partial") {
+    reasons.push("blueprint_after_is_partial")
+  } else if (executableBlueprint) {
+    reasons.push("blueprint_after_replay_status_unknown")
+  }
+
+  const status = !executableBlueprint
+    ? "not_available"
+    : runtimeSnapshot && replayIndex && blueprintReplayStatus === "replayable-runtime-state"
+      ? "replayable"
+      : "partial"
+
+  return {
+    schema: "wp-codebox/recipe-replay-status/v1",
+    status,
+    reasons,
+    artifacts: stripUndefined({
+      executableBlueprint,
+      notes,
+      runtimeSnapshot,
+      runtimeReferenceManifest,
+      replayIndex,
+    }) as RecipeReplayStatusSummary["artifacts"],
+    publicAccess: {
+      status: executableBlueprint ? "caller_must_publish" : "not_required",
+      ...(executableBlueprint ? { reason: "WP Codebox writes bundle-relative artifacts; callers must publish the executable blueprint URL when external replay needs browser access." } : {}),
+    },
+  }
+}
+
+function replayArtifactRef(file: ArtifactManifestFile | undefined): RecipeReplayArtifactRef | undefined {
+  if (!file) {
+    return undefined
+  }
+  return stripUndefined({ path: file.path, kind: file.kind, contentType: file.contentType }) as RecipeReplayArtifactRef
+}
+
+async function readBlueprintReplayStatus(artifactRoot: string, blueprintPath: string, notesPath: string | undefined): Promise<string | undefined> {
+  const notesStatus = notesPath ? await readJsonReplayStatus(artifactRoot, notesPath) : undefined
+  if (notesStatus) {
+    return notesStatus
+  }
+
+  return readJsonReplayStatus(artifactRoot, blueprintPath)
+}
+
+async function readJsonReplayStatus(artifactRoot: string, path: string): Promise<string | undefined> {
+  try {
+    const value = JSON.parse(await readFile(join(artifactRoot, path), "utf8")) as Record<string, unknown>
+    if (typeof value.replayStatus === "string") {
+      return value.replayStatus
+    }
+    if (typeof value["wp-codebox/replayStatus"] === "string") {
+      return value["wp-codebox/replayStatus"]
+    }
+    const metadata = isRecord(value.metadata) ? value.metadata : undefined
+    return typeof metadata?.replayStatus === "string" ? metadata.replayStatus : undefined
+  } catch {
+    return undefined
+  }
 }
 
 export async function appendRecipeRuntimeEvidence(artifacts: ArtifactBundle, files: RecipeRuntimeEvidenceInput[]): Promise<RecipeArtifactEvidenceFile[]> {
@@ -1000,6 +1128,15 @@ export function recipeCompletionOutcomeOutput(completionOutcome: RecipeArtifactE
   }
 
   const { artifact: _artifact, ...result } = completionOutcome
+  return result
+}
+
+export function recipeReplayStatusOutput(replayStatus: RecipeArtifactEvidenceResult["replayStatus"]): RecipeReplayStatusSummary | undefined {
+  if (!replayStatus) {
+    return undefined
+  }
+
+  const { artifact: _artifact, ...result } = replayStatus
   return result
 }
 

--- a/scripts/recipe-replay-status-smoke.ts
+++ b/scripts/recipe-replay-status-smoke.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ArtifactBundle, ArtifactManifest, ArtifactManifestFile } from "@automattic/wp-codebox-core"
+import { buildRecipeReplayStatusSummary } from "../packages/cli/src/recipe-evidence.js"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-replay-status-"))
+
+try {
+  const replayable = await fixtureBundle("replayable", [
+    manifestFile("blueprint.after.json", "blueprint-after"),
+    manifestFile("blueprint.after-notes.json", "blueprint-after-notes"),
+    manifestFile("files/runtime-snapshots/runtime-state.json", "runtime-snapshot"),
+    manifestFile("files/runtime-reference-manifest.json", "runtime-reference-manifest"),
+    manifestFile("files/runtime-replay-index.json", "runtime-replay-index"),
+  ], "replayable-runtime-state")
+  const replayableStatus = await buildRecipeReplayStatusSummary(replayable)
+  assert.equal(replayableStatus.status, "replayable")
+  assert.equal(replayableStatus.artifacts.executableBlueprint?.path, "blueprint.after.json")
+  assert.equal(replayableStatus.artifacts.runtimeSnapshot?.path, "files/runtime-snapshots/runtime-state.json")
+  assert.equal(replayableStatus.publicAccess.status, "caller_must_publish")
+
+  const partial = await fixtureBundle("partial", [
+    manifestFile("blueprint.after.json", "blueprint-after"),
+    manifestFile("blueprint.after-notes.json", "blueprint-after-notes"),
+    manifestFile("files/runtime-reference-manifest.json", "runtime-reference-manifest"),
+    manifestFile("files/runtime-replay-index.json", "runtime-replay-index"),
+  ], "partial")
+  const partialStatus = await buildRecipeReplayStatusSummary(partial)
+  assert.equal(partialStatus.status, "partial")
+  assert.ok(partialStatus.reasons.includes("missing_runtime_snapshot"))
+  assert.ok(partialStatus.reasons.includes("blueprint_after_is_partial"))
+
+  const unavailable = await fixtureBundle("not-available", [
+    manifestFile("files/runtime-reference-manifest.json", "runtime-reference-manifest"),
+  ])
+  const unavailableStatus = await buildRecipeReplayStatusSummary(unavailable)
+  assert.equal(unavailableStatus.status, "not_available")
+  assert.ok(unavailableStatus.reasons.includes("missing_executable_blueprint"))
+  assert.equal(unavailableStatus.publicAccess.status, "not_required")
+
+  console.log("Recipe replay status smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function fixtureBundle(name: string, files: ArtifactManifestFile[], replayStatus?: string): Promise<ArtifactBundle> {
+  const directory = join(workspace, name)
+  await mkdir(join(directory, "files", "runtime-snapshots"), { recursive: true })
+  if (files.some((file) => file.path === "blueprint.after.json")) {
+    await writeFile(join(directory, "blueprint.after.json"), `${JSON.stringify({ steps: [] }, null, 2)}\n`)
+  }
+  if (files.some((file) => file.path === "blueprint.after-notes.json")) {
+    await writeFile(join(directory, "blueprint.after-notes.json"), `${JSON.stringify({ replayStatus }, null, 2)}\n`)
+  }
+
+  const manifestPath = join(directory, "manifest.json")
+  const metadataPath = join(directory, "metadata.json")
+  const reviewPath = join(directory, "files", "review.json")
+  const manifest: Pick<ArtifactManifest, "files"> = { files }
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  await writeFile(metadataPath, "{}\n")
+  await writeFile(reviewPath, "{}\n")
+
+  return {
+    id: name,
+    directory,
+    manifestPath,
+    metadataPath,
+    blueprintAfterPath: join(directory, "blueprint.after.json"),
+    blueprintAfterNotesPath: join(directory, "blueprint.after-notes.json"),
+    eventsPath: join(directory, "events.ndjson"),
+    commandsPath: join(directory, "commands.ndjson"),
+    observationsPath: join(directory, "observations.ndjson"),
+    runtimeLogPath: join(directory, "runtime.log"),
+    commandsLogPath: join(directory, "commands.log"),
+    mountsPath: join(directory, "files", "mounts.json"),
+    capturedMountsPath: join(directory, "files", "mounted-files.json"),
+    diffsPath: join(directory, "files", "diffs.json"),
+    workspacePatchPath: join(directory, "files", "workspace-patch.json"),
+    changedFilesPath: join(directory, "files", "changed-files.json"),
+    patchPath: join(directory, "files", "patch.diff"),
+    diagnosticsPath: join(directory, "files", "diagnostics.json"),
+    testResultsPath: join(directory, "files", "test-results.json"),
+    reviewPath,
+    contentDigest: "0".repeat(64),
+    createdAt: "2026-06-14T00:00:00.000Z",
+  }
+}
+
+function manifestFile(path: string, kind: string): ArtifactManifestFile {
+  return {
+    path,
+    kind,
+    contentType: "application/json",
+    sha256: { algorithm: "sha256", value: "0".repeat(64) },
+  }
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -155,6 +155,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-workspace-seed-excludes-smoke"),
       tsxSmoke("recipe-workspace-vfs-materialization-smoke"),
       tsxSmoke("recipe-runtime-evidence-smoke"),
+      tsxSmoke("recipe-replay-status-smoke"),
       tsxSmoke("recipe-run-timeout-smoke"),
       tsxSmoke("recipe-playground-boot-failure-smoke"),
       tsxSmoke("recipe-backend-package-smoke"),


### PR DESCRIPTION
## Summary
- Emit `files/runtime-evidence/replay-status.json` during recipe artifact finalization with `replayable`, `partial`, or `not_available` status, structured reasons, and canonical artifact paths.
- Mirror the replay summary into recipe-run JSON output and run metadata as `replayStatus` so orchestrators can consume one stable surface.
- Document the replay status contract and cover replayable/partial/not_available classification with a focused smoke.

Fixes #951.

## Verification
- `npx tsx scripts/recipe-replay-status-smoke.ts`
- `npm run smoke -- --command=recipe-replay-status-smoke`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and verified the focused replay status summary contract at Chris's request.