### PR TITLE
Summarize Playground PHP fatal output

### DIFF
--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -95,7 +95,7 @@ function playgroundFailureMessage(command: string, response: PlaygroundRunRespon
   }
 
   if (text) {
-    lines.push("", "--- Playground output ---", text)
+    lines.push("", "--- Playground output ---", playgroundOutputDiagnostic(text))
   }
 
   return lines.join("\n")
@@ -166,20 +166,124 @@ function diagnosticRecords(value: unknown, seen = new Set<unknown>()): Record<st
 
 function diagnosticText(value: unknown): string | undefined {
   if (typeof value === "string") {
-    return truncateDiagnostic(value.trim())
+    return playgroundOutputDiagnostic(value.trim())
   }
   if (value instanceof Uint8Array) {
-    return truncateDiagnostic(new TextDecoder().decode(value).trim())
+    return playgroundOutputDiagnostic(new TextDecoder().decode(value).trim())
   }
   if (!value || typeof value !== "object" || typeof value === "function") {
     return undefined
   }
 
   try {
-    return truncateDiagnostic(JSON.stringify(value, null, 2))
+    return playgroundOutputDiagnostic(JSON.stringify(value, null, 2))
   } catch {
     return undefined
   }
+}
+
+function playgroundOutputDiagnostic(raw: string): string {
+  const text = raw.trim()
+  const decoded = decodeByteMapText(text)
+  const fatal = phpFatalSummary(decoded ?? text)
+
+  if (fatal) {
+    const rawBytes = Buffer.byteLength(text, "utf8")
+    const decodedSuffix = decoded ? ` Decoded from serialized response bytes (${rawBytes} bytes).` : ""
+    return `${fatal}\n[Raw Playground output omitted from normal error output.${decodedSuffix} Inspect the thrown PlaygroundCommandError response for full diagnostics.]`
+  }
+
+  if (decoded) {
+    return `${truncateDiagnostic(decoded) ?? ""}\n[Raw serialized response bytes omitted from normal error output. Inspect the thrown PlaygroundCommandError response for full diagnostics.]`
+  }
+
+  return truncateDiagnostic(text) ?? ""
+}
+
+function phpFatalSummary(text: string): string | undefined {
+  const normalized = stripHtml(text).replace(/\s+/g, " ").trim()
+  const fatal = normalized.match(/(?:PHP )?Fatal error:\s+(.+?)(?=(?: Stack trace:| thrown in |$))/)
+  if (!fatal) {
+    return undefined
+  }
+
+  const thrown = normalized.match(/thrown in ([^\s]+) on line (\d+)/)
+  const location = thrown ? `\nLocation: ${thrown[1]}:${thrown[2]}` : ""
+  return `PHP fatal: ${fatal[1].trim()}${location}`
+}
+
+function stripHtml(text: string): string {
+  return text
+    .replace(/<br\s*\/?>(\s*)/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+}
+
+function decodeByteMapText(text: string): string | undefined {
+  const parsed = parseJsonObject(text)
+  if (!parsed) {
+    return undefined
+  }
+
+  const bytes = findByteMap(parsed)
+  if (!bytes) {
+    return undefined
+  }
+
+  return new TextDecoder().decode(Uint8Array.from(bytes)).trim()
+}
+
+function parseJsonObject(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return undefined
+  }
+}
+
+function findByteMap(value: unknown, seen = new Set<unknown>()): number[] | undefined {
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return undefined
+  }
+  seen.add(value)
+
+  const record = value as Record<string, unknown>
+  const bytes = byteMapValues(record)
+  if (bytes) {
+    return bytes
+  }
+
+  for (const item of Object.values(record)) {
+    const nested = findByteMap(item, seen)
+    if (nested) {
+      return nested
+    }
+  }
+
+  return undefined
+}
+
+function byteMapValues(record: Record<string, unknown>): number[] | undefined {
+  const keys = Object.keys(record)
+  if (keys.length === 0 || keys.some((key) => !/^\d+$/.test(key))) {
+    return undefined
+  }
+
+  const bytes = keys
+    .map((key) => Number(key))
+    .sort((left, right) => left - right)
+    .map((key) => record[String(key)])
+
+  if (bytes.some((value) => typeof value !== "number" || value < 0 || value > 255 || !Number.isInteger(value))) {
+    return undefined
+  }
+
+  return bytes as number[]
 }
 
 function truncateDiagnostic(value: string): string | undefined {

--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { createRuntime } from "../packages/runtime-core/src/index.js"
-import { PlaygroundCommandCrashError } from "../packages/runtime-playground/src/playground-command-errors.js"
+import { PlaygroundCommandCrashError, PlaygroundCommandError } from "../packages/runtime-playground/src/playground-command-errors.js"
 import { createPlaygroundRuntimeBackend, type PlaygroundCliModule } from "../packages/runtime-playground/src/index.js"
 
 const hiddenFatal = new Error("PHP.run() failed with exit code 255") as Error & {
@@ -44,6 +44,20 @@ const nestedResponseMessage = new PlaygroundCommandCrashError("wordpress.run-php
 assert.match(nestedResponseMessage, /status=500/)
 assert.match(nestedResponseMessage, /--- Playground response text ---/)
 assert.match(nestedResponseMessage, /wp_codebox_missing_fixture/)
+
+const htmlFatal = "<br />\n<b>Fatal error</b>:  Uncaught Error: Call to a member function is_sandbox() on null in <b>/wordpress/wp-content/plugins/woocommerce-square/includes/Gateway/Cash_App_Pay_Gateway.php</b>:283\nStack trace:\n#0 {main}\n  thrown in <b>/wordpress/wp-content/plugins/woocommerce-square/includes/Gateway/Cash_App_Pay_Gateway.php</b> on line <b>283</b><br />"
+const byteMap = Object.fromEntries(Array.from(Buffer.from(htmlFatal, "utf8")).map((byte, index) => [String(index), byte]))
+const byteMapMessage = new PlaygroundCommandError("wordpress.bench", {
+  exitCode: 255,
+  text: JSON.stringify({ bytes: byteMap }),
+}).message
+
+assert.match(byteMapMessage, /wordpress\.bench failed with exit code 255/)
+assert.match(byteMapMessage, /PHP fatal: Uncaught Error: Call to a member function is_sandbox\(\) on null/)
+assert.match(byteMapMessage, /Location: \/wordpress\/wp-content\/plugins\/woocommerce-square\/includes\/Gateway\/Cash_App_Pay_Gateway\.php:283/)
+assert.match(byteMapMessage, /Raw Playground output omitted/)
+assert.doesNotMatch(byteMapMessage, /"bytes"/)
+assert.doesNotMatch(byteMapMessage, /"0":\s*60/)
 
 let receivedRunPhpCode = ""
 const fakeCliModule: PlaygroundCliModule = {


### PR DESCRIPTION
## Summary
- Summarizes Playground command output when PHP fatal responses are serialized as byte maps, surfacing the fatal message and file:line instead of dumping the raw byte object.
- Applies the same summarization to nested Playground crash diagnostics while preserving the raw response on the thrown error object for deeper debugging.
- Adds smoke coverage for a `wordpress.bench` byte-map fatal matching the Homeboy symptom.

Addresses Extra-Chill/homeboy#4353.

## Testing
- `npm run build`
- `npm run smoke -- --command=playground-command-errors-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Traced the Homeboy bench symptom to WP Codebox Playground error formatting, implemented the formatter change, and added targeted smoke coverage; Chris remains responsible for review and validation.