### PR TITLE
Add WordPress state bundle capture command

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -53,6 +53,17 @@ export const commandRegistry = [
     handler: { kind: "playground", method: "runWpCli" },
   },
   {
+    id: "wordpress.capture-state-bundle",
+    description: "Capture the current WordPress runtime state as a portable state bundle source for replayable Playground artifacts.",
+    acceptedArgs: [
+      { name: "label", description: "Optional human-readable capture label recorded in the command output.", format: "string" },
+    ],
+    outputShape: "wp-codebox/wordpress-state-bundle-capture/v1 JSON with runtime snapshot id, artifact refs, replay status, and capture summary.",
+    policyRequirement: "Runtime policy commands must include wordpress.capture-state-bundle.",
+    recipe: true,
+    handler: { kind: "playground", method: "runCaptureStateBundle" },
+  },
+  {
     id: "wordpress.ability",
     description: "Execute a registered WordPress Ability in the sandbox.",
     acceptedArgs: [

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -6,6 +6,7 @@ interface PlaygroundCommandRuntime {
   inspectMountedInputs(): Promise<string>
   runPhp(spec: ExecutionSpec): Promise<string>
   runWpCli(spec: ExecutionSpec): Promise<string>
+  runCaptureStateBundle(spec: ExecutionSpec): Promise<string>
   runRestRequest(spec: ExecutionSpec): Promise<string>
   runAbility(spec: ExecutionSpec): Promise<string>
   runBench(spec: ExecutionSpec): Promise<string>
@@ -27,6 +28,7 @@ const playgroundCommandHandlers = {
   "inspect-mounted-inputs": (runtime) => runtime.inspectMountedInputs(),
   "wordpress.run-php": (runtime, spec) => runtime.runPhp(spec),
   "wordpress.wp-cli": (runtime, spec) => runtime.runWpCli(spec),
+  "wordpress.capture-state-bundle": (runtime, spec) => runtime.runCaptureStateBundle(spec),
   "wordpress.rest-request": (runtime, spec) => runtime.runRestRequest(spec),
   "wordpress.ability": (runtime, spec) => runtime.runAbility(spec),
   "wordpress.bench": (runtime, spec) => runtime.runBench(spec),

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -605,6 +605,32 @@ class PlaygroundRuntime implements Runtime {
     return cleanWpCliOutput(response.text)
   }
 
+  async runCaptureStateBundle(spec: ExecutionSpec): Promise<string> {
+    const label = stringArg(spec.args ?? [], "label")
+    const snapshot = await this.snapshot()
+    const summary = snapshot.metadata.summary && typeof snapshot.metadata.summary === "object" && !Array.isArray(snapshot.metadata.summary)
+      ? snapshot.metadata.summary as Record<string, unknown>
+      : {}
+
+    return `${JSON.stringify({
+      schema: "wp-codebox/wordpress-state-bundle-capture/v1",
+      status: "captured",
+      replayStatus: "replayable-runtime-state",
+      ...(label ? { label } : {}),
+      snapshot: {
+        id: snapshot.id,
+        createdAt: snapshot.createdAt,
+        semantics: snapshot.semantics,
+        digest: snapshot.digest,
+        artifactRefs: snapshot.artifactRefs ?? [],
+      },
+      summary: {
+        databaseTables: summary.databaseTables ?? 0,
+        wpContentFiles: summary.wpContentFiles ?? 0,
+      },
+    }, null, 2)}\n`
+  }
+
   async runPluginCheck(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
     const result = await runPluginCheckCommand({
@@ -832,6 +858,12 @@ export function createPlaygroundRuntimeBackend(options: PlaygroundRuntimeBackend
 
 function sha256(contents: Buffer): string {
   return createHash("sha256").update(contents).digest("hex")
+}
+
+function stringArg(args: string[], name: string): string | undefined {
+  const prefix = `${name}=`
+  const value = args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length).trim()
+  return value && value.length > 0 ? value : undefined
 }
 
 function abortable<T>(operation: Promise<T>, signal: AbortSignal | undefined): Promise<T> {

--- a/scripts/recipe-state-bundle-capture-smoke.ts
+++ b/scripts/recipe-state-bundle-capture-smoke.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createRuntime, verifyArtifactBundle } from "@automattic/wp-codebox-core"
+import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
+
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-state-bundle-capture-"))
+const backend = createPlaygroundRuntimeBackend()
+
+try {
+  const runtime = await createRuntime(
+    {
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", name: "state-bundle-capture-smoke", version: "7.0", blueprint: { steps: [] } },
+      policy: {
+        network: "deny",
+        filesystem: "readwrite-mounts",
+        commands: ["wordpress.run-php", "wordpress.wp-cli", "wordpress.capture-state-bundle"],
+        secrets: "none",
+        approvals: "never",
+      },
+      artifactsDirectory,
+    },
+    backend,
+  )
+
+  try {
+    await runtime.execute({ command: "wordpress.wp-cli", args: ["command=post create --post_type=page --post_status=publish --post_title='State Bundle Capture Smoke' --porcelain"] })
+    await runtime.execute({ command: "wordpress.run-php", args: ["code=file_put_contents(WP_CONTENT_DIR . '/state-bundle-smoke.txt', 'captured state bundle file');"] })
+
+    const capture = await runtime.execute({ command: "wordpress.capture-state-bundle", args: ["label=after-generation"] })
+    const captureOutput = JSON.parse(capture.stdout)
+    assert.equal(captureOutput.schema, "wp-codebox/wordpress-state-bundle-capture/v1")
+    assert.equal(captureOutput.status, "captured")
+    assert.equal(captureOutput.replayStatus, "replayable-runtime-state")
+    assert.equal(captureOutput.label, "after-generation")
+    assert.equal(captureOutput.snapshot.semantics, "runtime-state-artifact")
+    assert.equal(captureOutput.snapshot.artifactRefs[0].kind, "runtime-snapshot-artifact")
+    assert.equal(captureOutput.summary.databaseTables > 0, true)
+    assert.equal(captureOutput.summary.wpContentFiles > 0, true)
+
+    const artifacts = await runtime.collectArtifacts({ includeRuntimeSnapshotBundles: true })
+    const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
+    const blueprintAfter = JSON.parse(await readFile(artifacts.blueprintAfterPath, "utf8"))
+    const blueprintAfterNotes = JSON.parse(await readFile(artifacts.blueprintAfterNotesPath, "utf8"))
+
+    assert.equal(manifest.files.some((file: { path?: string; kind?: string }) => file.path === captureOutput.snapshot.artifactRefs[0].path && file.kind === "runtime-snapshot"), true)
+    assert.equal(manifest.files.some((file: { path?: string; kind?: string }) => file.path === "files/blueprint.after.partial.json" && file.kind === "blueprint-after-diagnostic"), true)
+    assert.equal(blueprintAfter.steps[0].step, "runPHP")
+    assert.match(blueprintAfter.steps[0].code, /State Bundle Capture Smoke/)
+    assert.match(blueprintAfter.steps[0].code, /state-bundle-smoke\.txt/)
+    assert.equal(blueprintAfterNotes.replayStatus, "replayable-runtime-state")
+    assert.equal(blueprintAfterNotes.captured.databaseTables > 0, true)
+    assert.equal(blueprintAfterNotes.captured.wpContentFiles > 0, true)
+    assert.equal((await verifyArtifactBundle(artifacts.directory)).valid, true)
+
+    console.log("Recipe state bundle capture smoke passed")
+  } finally {
+    await runtime.destroy()
+  }
+} finally {
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -156,6 +156,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-workspace-vfs-materialization-smoke"),
       tsxSmoke("recipe-runtime-evidence-smoke"),
       tsxSmoke("recipe-replay-status-smoke"),
+      tsxSmoke("recipe-state-bundle-capture-smoke"),
       tsxSmoke("recipe-run-timeout-smoke"),
       tsxSmoke("recipe-playground-boot-failure-smoke"),
       tsxSmoke("recipe-backend-package-smoke"),


### PR DESCRIPTION
## Summary
- Add a generic `wordpress.capture-state-bundle` recipe command that captures the live WordPress runtime through the existing runtime-state snapshot machinery.
- Return a versioned `wp-codebox/wordpress-state-bundle-capture/v1` envelope with snapshot refs, replay status, and capture summary.
- Cover the primitive with a smoke that proves artifact finalization upgrades `blueprint.after.json` to a replayable runtime-state blueprint.

Fixes #956.

## Verification
- `npm run build`
- `npx tsx scripts/recipe-state-bundle-capture-smoke.ts`
- `npx tsx scripts/wordpress-recipe-builders-smoke.ts`
- `npx tsx scripts/recipe-replay-status-smoke.ts`
- `npx tsx scripts/replayable-wordpress-site-bundle-smoke.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and verified the generic state-bundle capture command and focused smoke coverage at Chris's request.