### PR TITLE
Exclude runtime substrate from state bundle snapshots

### DIFF
--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -307,7 +307,7 @@ class PlaygroundRuntime implements Runtime {
 
   private async captureRuntimeSnapshotArtifact(snapshotId: string, createdAt: string): Promise<RuntimeSnapshotArtifact> {
     const response = await this.runPlaygroundCommand("runtime.snapshot", await this.bootPlayground(), {
-      code: bootstrapPhpCode(this.spec, runtimeSnapshotExportPhp(), []),
+      code: bootstrapPhpCode(this.spec, runtimeSnapshotExportPhp({ excludedWpContentPaths: this.snapshotExcludedWpContentPaths() }), []),
     })
     assertPlaygroundResponseOk("runtime.snapshot", response)
     const captured = JSON.parse(response.text || "{}") as Omit<RuntimeSnapshotArtifact, "schema" | "version" | "id" | "createdAt" | "hashes">
@@ -331,6 +331,17 @@ class PlaygroundRuntime implements Runtime {
         files: filesDigest,
       },
     }
+  }
+
+  private snapshotExcludedWpContentPaths(): string[] {
+    return this.mounts.flatMap((mount) => {
+      if (mount.mode !== "readonly") {
+        return []
+      }
+
+      const relativePath = wpContentRelativePath(mount.target)
+      return relativePath && relativePath.startsWith("plugins/") ? [relativePath] : []
+    })
   }
 
   private async restoreSnapshotPayload(payload: RuntimeSnapshotArtifact): Promise<void> {
@@ -864,6 +875,18 @@ function stringArg(args: string[], name: string): string | undefined {
   const prefix = `${name}=`
   const value = args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length).trim()
   return value && value.length > 0 ? value : undefined
+}
+
+function wpContentRelativePath(path: string): string | undefined {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/g, "")
+  const marker = "/wp-content/"
+  const index = normalized.indexOf(marker)
+  if (index < 0) {
+    return undefined
+  }
+
+  const relative = normalized.slice(index + marker.length).replace(/^\/+|\/+$/g, "")
+  return relative.length > 0 && !relative.includes("..") ? relative : undefined
 }
 
 function abortable<T>(operation: Promise<T>, signal: AbortSignal | undefined): Promise<T> {

--- a/packages/runtime-playground/src/runtime-snapshot.ts
+++ b/packages/runtime-playground/src/runtime-snapshot.ts
@@ -19,6 +19,7 @@ export interface RuntimeSnapshotArtifact {
     activeTheme: string
     activePlugins: string[]
     wpContentPath: string
+    skippedWpContentPaths?: string[]
   }
   database: {
     tables: Array<{
@@ -107,9 +108,22 @@ export async function runtimeSnapshotPayload(snapshot: Snapshot): Promise<Runtim
   throw new PlaygroundSnapshotRestoreError("Snapshot does not include a readable runtime snapshot artifact payload.")
 }
 
-export function runtimeSnapshotExportPhp(): string {
-  return String.raw`
+export interface RuntimeSnapshotExportOptions {
+  excludedWpContentPaths?: string[]
+}
+
+export function runtimeSnapshotExportPhp(options: RuntimeSnapshotExportOptions = {}): string {
+  const excludedWpContentPaths = JSON.stringify(normalizeWpContentPathList(options.excludedWpContentPaths ?? []))
+  return [String.raw`
 global $wpdb;
+
+$wp_codebox_snapshot_excluded_wp_content_paths = json_decode(<<<'WP_CODEBOX_EXCLUDED_WP_CONTENT_PATHS'
+`, excludedWpContentPaths, String.raw`
+WP_CODEBOX_EXCLUDED_WP_CONTENT_PATHS
+, true );
+if ( ! is_array( $wp_codebox_snapshot_excluded_wp_content_paths ) ) {
+    $wp_codebox_snapshot_excluded_wp_content_paths = array();
+}
 
 function wp_codebox_snapshot_hash_file_contents( string $contents ): string {
     return hash( 'sha256', $contents );
@@ -121,7 +135,21 @@ function wp_codebox_snapshot_relative_path( string $base, string $path ): string
     return ltrim( substr( $path, strlen( $base ) ), '/' );
 }
 
-function wp_codebox_snapshot_files( string $root ): array {
+function wp_codebox_snapshot_is_excluded_path( string $relative_path, array $excluded_paths ): bool {
+    $relative_path = trim( str_replace( '\\', '/', $relative_path ), '/' );
+    foreach ( $excluded_paths as $excluded_path ) {
+        if ( ! is_string( $excluded_path ) || '' === $excluded_path ) {
+            continue;
+        }
+        $excluded_path = trim( str_replace( '\\', '/', $excluded_path ), '/' );
+        if ( $relative_path === $excluded_path || str_starts_with( $relative_path, $excluded_path . '/' ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function wp_codebox_snapshot_files( string $root, array $excluded_paths ): array {
     if ( ! is_dir( $root ) ) {
         return array();
     }
@@ -138,6 +166,11 @@ function wp_codebox_snapshot_files( string $root ): array {
         }
 
         $path = $file->getPathname();
+        $relative = wp_codebox_snapshot_relative_path( $root, $path );
+        if ( wp_codebox_snapshot_is_excluded_path( $relative, $excluded_paths ) ) {
+            continue;
+        }
+
         $contents = file_get_contents( $path );
         if ( false === $contents ) {
             continue;
@@ -145,7 +178,7 @@ function wp_codebox_snapshot_files( string $root ): array {
 
         $files[] = array(
             'scope' => 'wp-content',
-            'path' => wp_codebox_snapshot_relative_path( $root, $path ),
+            'path' => $relative,
             'bytes' => strlen( $contents ),
             'sha256' => wp_codebox_snapshot_hash_file_contents( $contents ),
             'base64' => base64_encode( $contents ),
@@ -184,10 +217,11 @@ echo wp_json_encode( array(
         'activeTheme' => wp_get_theme()->get_stylesheet(),
         'activePlugins' => array_values( (array) get_option( 'active_plugins', array() ) ),
         'wpContentPath' => WP_CONTENT_DIR,
+        'skippedWpContentPaths' => array_values( $wp_codebox_snapshot_excluded_wp_content_paths ),
     ),
     'database' => array( 'tables' => $tables ),
-    'files' => wp_codebox_snapshot_files( WP_CONTENT_DIR ),
-), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );`
+    'files' => wp_codebox_snapshot_files( WP_CONTENT_DIR, $wp_codebox_snapshot_excluded_wp_content_paths ),
+), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );`].join("")
 }
 
 export function runtimeSnapshotRestorePhp(payload: RuntimeSnapshotArtifact): string {
@@ -283,4 +317,11 @@ function isRuntimeSnapshotArtifact(value: unknown): value is RuntimeSnapshotArti
     && isRecord(value.database)
     && Array.isArray(value.database.tables)
     && Array.isArray(value.files)
+}
+
+function normalizeWpContentPathList(paths: string[]): string[] {
+  return [...new Set(paths
+    .map((path) => path.replace(/\\/g, "/").replace(/^\/+|\/+$/g, ""))
+    .filter((path) => path.length > 0 && !path.includes("..")))]
+    .sort()
 }

--- a/scripts/recipe-state-bundle-capture-smoke.ts
+++ b/scripts/recipe-state-bundle-capture-smoke.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { createRuntime, verifyArtifactBundle } from "@automattic/wp-codebox-core"
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
 
 const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-state-bundle-capture-"))
+const runtimePluginDirectory = join(artifactsDirectory, "runtime-substrate-plugin")
 const backend = createPlaygroundRuntimeBackend()
 
 try {
@@ -26,6 +27,15 @@ try {
   )
 
   try {
+    await mkdir(runtimePluginDirectory, { recursive: true })
+    await writeFile(join(runtimePluginDirectory, "runtime-substrate.php"), "<?php /* runtime substrate, not replay state */\n")
+    await runtime.mount({
+      type: "directory",
+      source: runtimePluginDirectory,
+      target: "/wordpress/wp-content/plugins/runtime-substrate",
+      mode: "readonly",
+    })
+
     await runtime.execute({ command: "wordpress.wp-cli", args: ["command=post create --post_type=page --post_status=publish --post_title='State Bundle Capture Smoke' --porcelain"] })
     await runtime.execute({ command: "wordpress.run-php", args: ["code=file_put_contents(WP_CONTENT_DIR . '/state-bundle-smoke.txt', 'captured state bundle file');"] })
 
@@ -42,10 +52,14 @@ try {
 
     const artifacts = await runtime.collectArtifacts({ includeRuntimeSnapshotBundles: true })
     const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8"))
+    const snapshotPayload = JSON.parse(await readFile(join(artifacts.directory, captureOutput.snapshot.artifactRefs[0].path), "utf8"))
     const blueprintAfter = JSON.parse(await readFile(artifacts.blueprintAfterPath, "utf8"))
     const blueprintAfterNotes = JSON.parse(await readFile(artifacts.blueprintAfterNotesPath, "utf8"))
 
     assert.equal(manifest.files.some((file: { path?: string; kind?: string }) => file.path === captureOutput.snapshot.artifactRefs[0].path && file.kind === "runtime-snapshot"), true)
+    assert.deepEqual(snapshotPayload.metadata.skippedWpContentPaths, ["plugins/runtime-substrate"])
+    assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path?.startsWith("plugins/runtime-substrate/")), false)
+    assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path === "state-bundle-smoke.txt"), true)
     assert.equal(manifest.files.some((file: { path?: string; kind?: string }) => file.path === "files/blueprint.after.partial.json" && file.kind === "blueprint-after-diagnostic"), true)
     assert.equal(blueprintAfter.steps[0].step, "runPHP")
     assert.match(blueprintAfter.steps[0].code, /State Bundle Capture Smoke/)


### PR DESCRIPTION
## Summary
- Exclude readonly `wp-content/plugins/*` mounts from WordPress runtime state snapshots so replay bundles do not embed the Codebox/runtime substrate.
- Keep generated `wp-content` state, including themes/uploads/files, eligible for replay capture.
- Record skipped `wp-content` paths in snapshot metadata and cover the behavior in the state-bundle capture smoke.

## Why
Studio Web Workflow Bench r39 wired `wordpress.capture-state-bundle`, but snapshot export exhausted Playground's 256 MB PHP memory budget while base64-encoding readonly runtime plugins. Those plugins are substrate for the run, not generated site state for the user-viewable replay blueprint.

## Verification
- `npm run build`
- `npx tsx scripts/recipe-state-bundle-capture-smoke.ts`
- `npx tsx scripts/runtime-snapshot-restore-smoke.ts`
- `npx tsx scripts/replayable-wordpress-site-bundle-smoke.ts`
- `npx tsx scripts/recipe-replay-status-smoke.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the r39 snapshot memory failure and implemented the readonly plugin-substrate exclusion with smoke coverage.