### PR TITLE
Exclude readonly wp-content mounts from snapshots

### DIFF
--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -340,7 +340,7 @@ class PlaygroundRuntime implements Runtime {
       }
 
       const relativePath = wpContentRelativePath(mount.target)
-      return relativePath && relativePath.startsWith("plugins/") ? [relativePath] : []
+      return relativePath ? [relativePath] : []
     })
   }
 

--- a/scripts/recipe-state-bundle-capture-smoke.ts
+++ b/scripts/recipe-state-bundle-capture-smoke.ts
@@ -7,6 +7,7 @@ import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playgroun
 
 const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-state-bundle-capture-"))
 const runtimePluginDirectory = join(artifactsDirectory, "runtime-substrate-plugin")
+const runtimeThemeDirectory = join(artifactsDirectory, "runtime-substrate-theme")
 const backend = createPlaygroundRuntimeBackend()
 
 try {
@@ -36,6 +37,15 @@ try {
       mode: "readonly",
     })
 
+    await mkdir(runtimeThemeDirectory, { recursive: true })
+    await writeFile(join(runtimeThemeDirectory, "style.css"), "/* runtime substrate theme, not replay state */\n")
+    await runtime.mount({
+      type: "directory",
+      source: runtimeThemeDirectory,
+      target: "/wordpress/wp-content/themes/runtime-substrate-theme",
+      mode: "readonly",
+    })
+
     await runtime.execute({ command: "wordpress.wp-cli", args: ["command=post create --post_type=page --post_status=publish --post_title='State Bundle Capture Smoke' --porcelain"] })
     await runtime.execute({ command: "wordpress.run-php", args: ["code=file_put_contents(WP_CONTENT_DIR . '/state-bundle-smoke.txt', 'captured state bundle file');"] })
 
@@ -57,8 +67,9 @@ try {
     const blueprintAfterNotes = JSON.parse(await readFile(artifacts.blueprintAfterNotesPath, "utf8"))
 
     assert.equal(manifest.files.some((file: { path?: string; kind?: string }) => file.path === captureOutput.snapshot.artifactRefs[0].path && file.kind === "runtime-snapshot"), true)
-    assert.deepEqual(snapshotPayload.metadata.skippedWpContentPaths, ["plugins/runtime-substrate"])
+    assert.deepEqual(snapshotPayload.metadata.skippedWpContentPaths, ["plugins/runtime-substrate", "themes/runtime-substrate-theme"])
     assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path?.startsWith("plugins/runtime-substrate/")), false)
+    assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path?.startsWith("themes/runtime-substrate-theme/")), false)
     assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path === "state-bundle-smoke.txt"), true)
     assert.equal(manifest.files.some((file: { path?: string; kind?: string }) => file.path === "files/blueprint.after.partial.json" && file.kind === "blueprint-after-diagnostic"), true)
     assert.equal(blueprintAfter.steps[0].step, "runPHP")


### PR DESCRIPTION
## Summary
- Exclude every readonly mount under `wp-content` from runtime snapshot file capture, not only readonly plugin mounts.
- Keep writable/generated `wp-content` files eligible for replay capture.
- Extend the state-bundle capture smoke to cover readonly theme substrate alongside readonly plugin substrate.

## Why
Workflow Bench r40 still exhausted Playground's PHP memory budget during `runtime.snapshot` after plugin-substrate exclusion, because the run also mounts readonly theme substrate under `wp-content/themes/studio-web`. Readonly mounts are runtime inputs, not generated site state, and should not be embedded into state bundle snapshots.

## Verification
- Lab `npm install`
- Lab `npm run build`
- Lab `npx tsx scripts/recipe-state-bundle-capture-smoke.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the r40 snapshot memory failure and implemented the readonly `wp-content` mount exclusion with smoke coverage.