### PR TITLE
Handle noisy wordpress.bench result output

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -836,16 +836,94 @@ async function validateRecipe(options: RecipeValidateOptions): Promise<RecipeVal
 }
 
 function parseBenchResults(raw: string, manifestFiles: Map<string, ArtifactManifestFile>): BenchResults {
-  const parsed = JSON.parse(raw) as unknown
+  const { parsed, prefix, suffix } = parseBenchResultsJson(raw)
   if (!validateBenchResultsSchema(parsed)) {
     throw new Error(`Bench command did not emit a wp-codebox/bench-results/v1 envelope: ${benchResultsAjv.errorsText(validateBenchResultsSchema.errors)}`)
   }
 
   const results = parsed as BenchResults
+  const diagnostics = [...results.diagnostics]
+  if (prefix.trim()) {
+    diagnostics.push(benchOutputDiagnostic("bench-output-prefix", "before", prefix))
+  }
+  if (suffix.trim()) {
+    diagnostics.push(benchOutputDiagnostic("bench-output-suffix", "after", suffix))
+  }
+
   return {
     ...results,
+    diagnostics,
     scenarios: results.scenarios.map((scenario) => enrichBenchScenarioArtifactRefs(scenario, manifestFiles)),
   }
+}
+
+function parseBenchResultsJson(raw: string): { parsed: unknown; prefix: string; suffix: string } {
+  try {
+    return { parsed: JSON.parse(raw) as unknown, prefix: "", suffix: "" }
+  } catch (error) {
+    const extracted = extractFirstJsonObject(raw)
+    if (!extracted) {
+      throw error
+    }
+
+    try {
+      return { parsed: JSON.parse(extracted.json) as unknown, prefix: extracted.prefix, suffix: extracted.suffix }
+    } catch {
+      throw error
+    }
+  }
+}
+
+function extractFirstJsonObject(raw: string): { json: string; prefix: string; suffix: string } | undefined {
+  for (let start = raw.indexOf("{"); start !== -1; start = raw.indexOf("{", start + 1)) {
+    let depth = 0
+    let inString = false
+    let escaped = false
+
+    for (let index = start; index < raw.length; index++) {
+      const character = raw[index]
+      if (inString) {
+        if (escaped) {
+          escaped = false
+        } else if (character === "\\") {
+          escaped = true
+        } else if (character === '"') {
+          inString = false
+        }
+        continue
+      }
+
+      if (character === '"') {
+        inString = true
+      } else if (character === "{") {
+        depth++
+      } else if (character === "}") {
+        depth--
+        if (depth === 0) {
+          return { json: raw.slice(start, index + 1), prefix: raw.slice(0, start), suffix: raw.slice(index + 1) }
+        }
+      }
+    }
+  }
+
+  return undefined
+}
+
+function benchOutputDiagnostic(code: string, position: "before" | "after", output: string): BenchResults["diagnostics"][number] {
+  return {
+    severity: "warning",
+    code,
+    source: "wordpress.bench/stdout",
+    message: `wordpress.bench emitted non-JSON stdout ${position} the bench-results envelope.`,
+    details: {
+      output: boundDiagnosticText(output),
+    },
+  }
+}
+
+function boundDiagnosticText(output: string): string {
+  const normalized = output.trim()
+  return normalized.length > 4000 ? `${normalized.slice(0, 4000)}...` : normalized
 }
 
 function enrichBenchScenarioArtifactRefs(scenario: BenchResults["scenarios"][number], manifestFiles: Map<string, ArtifactManifestFile>): BenchScenarioWithArtifactRefs {

--- a/scripts/recipe-bench-smoke.ts
+++ b/scripts/recipe-bench-smoke.ts
@@ -64,7 +64,7 @@ writeFileSync(recipePath, `${JSON.stringify({
                 { type: "rest-request", method: "GET", path: "/wp/v2/types", "metric-prefix": "rest_types" },
                 {
                   type: "php",
-                  code: "return array('metrics' => array('env_value' => (int) getenv('BENCH_FIXTURE_ENV'), 'define_visible' => defined('BENCH_FIXTURE_DEFINE') && BENCH_FIXTURE_DEFINE === 'defined-value' ? 1 : 0, 'wp_cli_option_visible' => get_option('wp_codebox_bench_wp_cli') === 'yes' ? 1 : 0, 'lifecycle_setup_visible' => get_option('wp_codebox_bench_lifecycle_setup') === 'yes' ? 1 : 0, 'lifecycle_prepare_visible' => get_option('wp_codebox_bench_lifecycle_prepare') === 'yes' ? 1 : 0, 'cache_was_empty' => wp_cache_get('wp_codebox_bench_cache_flag', 'wp-codebox-bench') === false ? (wp_cache_set('wp_codebox_bench_cache_flag', 'set', 'wp-codebox-bench') ? 1 : 1) : (wp_cache_set('wp_codebox_bench_cache_flag', 'set', 'wp-codebox-bench') ? 0 : 0)), 'metadata' => array('kind' => 'configured'));",
+                  code: "print '<br />\\n<b>Warning</b>: Fixture warning before bench JSON in <b>/tmp/wp-codebox-warning-fixture.php</b> on line <b>1</b><br />\\n'; return array('metrics' => array('env_value' => (int) getenv('BENCH_FIXTURE_ENV'), 'define_visible' => defined('BENCH_FIXTURE_DEFINE') && BENCH_FIXTURE_DEFINE === 'defined-value' ? 1 : 0, 'wp_cli_option_visible' => get_option('wp_codebox_bench_wp_cli') === 'yes' ? 1 : 0, 'lifecycle_setup_visible' => get_option('wp_codebox_bench_lifecycle_setup') === 'yes' ? 1 : 0, 'lifecycle_prepare_visible' => get_option('wp_codebox_bench_lifecycle_prepare') === 'yes' ? 1 : 0, 'cache_was_empty' => wp_cache_get('wp_codebox_bench_cache_flag', 'wp-codebox-bench') === false ? (wp_cache_set('wp_codebox_bench_cache_flag', 'set', 'wp-codebox-bench') ? 1 : 1) : (wp_cache_set('wp_codebox_bench_cache_flag', 'set', 'wp-codebox-bench') ? 0 : 0)), 'metadata' => array('kind' => 'configured'));",
                 },
               ],
               artifacts: { report: { path: "workloads/report.json", kind: "json" } },
@@ -106,9 +106,13 @@ assert.deepEqual(output.benchResults.lifecycle.diagnostics, [])
 assert.equal(output.benchResults.reset_policy.betweenIterations, "object-cache")
 assert.equal(output.benchResults.reset_policy.betweenScenarios, "none")
 assert.equal(output.benchResults.scenarios.length, 2)
-assert.equal(output.benchResults.diagnostics.length, 0)
+assert.equal(output.benchResults.diagnostics.length, 1)
 assert.equal(output.benchResults.provenance.command, "wordpress.bench")
 assert.equal(output.benchResults.provenance.definition.schema, "wp-codebox/benchmark-definition/v1")
+const benchOutputPrefixDiagnostic = output.benchResults.diagnostics.find((diagnostic: { code?: string }) => diagnostic.code === "bench-output-prefix")
+assert.ok(benchOutputPrefixDiagnostic, "warning-like stdout before bench JSON should be captured as a bench diagnostic")
+assert.match(benchOutputPrefixDiagnostic.details.output, /Fixture warning before bench JSON/)
+assert.match(output.executions.at(-1).stdout, /^<br \/>/)
 
 const scenario = output.benchResults.scenarios[0]
 assert.equal(scenario.id, "noop")


### PR DESCRIPTION
## Summary
- Recover `wp-codebox/bench-results/v1` JSON from successful `wordpress.bench` stdout when PHP/WordPress warning text is printed before or after the structured envelope.
- Preserve the non-JSON output as `benchResults.diagnostics` so warnings remain visible without corrupting recipe-run parsing.
- Extend `recipe-bench-smoke` with a fixture workload that emits warning-like HTML before valid bench JSON.

Fixes #959.

## Validation
- `npm run build`
- `npx tsx scripts/recipe-bench-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the `wordpress.bench` recipe-run parsing path, drafted the parser fix and targeted smoke coverage, and ran validation commands. Chris remains responsible for review and merge.