### PR TITLE
Stabilize runtime snapshot export boundaries

### DIFF
--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -15,7 +15,7 @@ import type { PlaygroundCliServer } from "./preview-server.js"
 import { collectPlaygroundArtifacts } from "./runtime-artifact-helpers.js"
 import { materializePlaygroundMountsFromVfs } from "./mount-materialization.js"
 import { runAbilityCommand, runBenchCommand, runCorePhpunitCommand, runPhpCommand, runPhpunitCommand, runPluginCheckCommand, runRestRequestCommand, runThemeCheckCommand } from "./wordpress-command-runners.js"
-import { PlaygroundSnapshotRestoreError, contentDigest, mountsFromSnapshot, runtimeSnapshotExportPhp, runtimeSnapshotPayload, runtimeSnapshotRestorePhp, runtimeSpecFromSnapshot, snapshotDigest, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
+import { PlaygroundSnapshotRestoreError, contentDigest, mountsFromSnapshot, runtimeSnapshotExportPayload, runtimeSnapshotExportPhp, runtimeSnapshotPayload, runtimeSnapshotRestorePhp, runtimeSpecFromSnapshot, snapshotDigest, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
 import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
 import { preflightPhpWasmRuntimeAssets } from "./php-wasm-preflight.js"
 import type {
@@ -306,11 +306,12 @@ class PlaygroundRuntime implements Runtime {
   }
 
   private async captureRuntimeSnapshotArtifact(snapshotId: string, createdAt: string): Promise<RuntimeSnapshotArtifact> {
-    const response = await this.runPlaygroundCommand("runtime.snapshot", await this.bootPlayground(), {
+    const server = await this.bootPlayground()
+    const response = await this.runPlaygroundCommand("runtime.snapshot", server, {
       code: bootstrapPhpCode(this.spec, runtimeSnapshotExportPhp({ excludedWpContentPaths: this.snapshotExcludedWpContentPaths() }), []),
     })
     assertPlaygroundResponseOk("runtime.snapshot", response)
-    const captured = JSON.parse(response.text || "{}") as Omit<RuntimeSnapshotArtifact, "schema" | "version" | "id" | "createdAt" | "hashes">
+    const captured = await runtimeSnapshotExportPayload(server, response.text)
     const databaseDigest = contentDigest(captured.database)
     const filesDigest = contentDigest(captured.files.map((file) => ({ path: file.path, sha256: file.sha256, bytes: file.bytes })))
 

--- a/packages/runtime-playground/src/runtime-snapshot.ts
+++ b/packages/runtime-playground/src/runtime-snapshot.ts
@@ -113,6 +113,8 @@ export interface RuntimeSnapshotExportOptions {
   excludedWpContentPaths?: string[]
 }
 
+export type RuntimeSnapshotArtifactBody = Omit<RuntimeSnapshotArtifact, "schema" | "version" | "id" | "createdAt" | "hashes">
+
 interface RuntimeSnapshotExportManifest {
   schema: "wp-codebox/wordpress-runtime-snapshot-export-manifest/v1"
   compatibility: RuntimeSnapshotArtifact["compatibility"]
@@ -130,13 +132,10 @@ interface RuntimeSnapshotExportManifest {
   }
 }
 
-export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, responseText: string): Promise<Omit<RuntimeSnapshotArtifact, "schema" | "version" | "id" | "createdAt" | "hashes">> {
-  const manifest = JSON.parse(responseText || "{}") as RuntimeSnapshotExportManifest
-  if (manifest.schema !== "wp-codebox/wordpress-runtime-snapshot-export-manifest/v1") {
-    throw new PlaygroundSnapshotRestoreError("Runtime snapshot export did not return a supported manifest.")
-  }
-
-  if (!server.playground.readFileAsText) {
+export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, responseText: string): Promise<RuntimeSnapshotArtifactBody> {
+  const manifest = parseRuntimeSnapshotExportManifest(responseText)
+  const readFileAsText = server.playground.readFileAsText
+  if (!readFileAsText) {
     throw new PlaygroundSnapshotRestoreError("Runtime snapshot export requires Playground readFileAsText support.")
   }
 
@@ -144,7 +143,7 @@ export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, 
   for (const table of manifest.database.tables) {
     const rows = []
     for (const chunkPath of table.chunks) {
-      const chunkRows = JSON.parse(await server.playground.readFileAsText(chunkPath))
+      const chunkRows = JSON.parse(await readFileAsText(chunkPath))
       if (Array.isArray(chunkRows)) {
         rows.push(...chunkRows)
       }
@@ -153,7 +152,7 @@ export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, 
   }
 
   const files = []
-  const fileLines = (await server.playground.readFileAsText(manifest.files.ndjsonPath)).split("\n")
+  const fileLines = (await readFileAsText(manifest.files.ndjsonPath)).split("\n")
   for (const line of fileLines) {
     if (line.trim().length === 0) {
       continue
@@ -172,6 +171,36 @@ export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, 
     database: { tables },
     files,
   }
+}
+
+function parseRuntimeSnapshotExportManifest(responseText: string): RuntimeSnapshotExportManifest {
+  const manifest = JSON.parse(responseText || "{}") as RuntimeSnapshotExportManifest
+  if (!isRuntimeSnapshotExportManifest(manifest)) {
+    throw new PlaygroundSnapshotRestoreError("Runtime snapshot export did not return a supported manifest.")
+  }
+
+  return manifest
+}
+
+function isRuntimeSnapshotExportManifest(value: unknown): value is RuntimeSnapshotExportManifest {
+  if (!isRecord(value) || value.schema !== "wp-codebox/wordpress-runtime-snapshot-export-manifest/v1") {
+    return false
+  }
+
+  if (!isRecord(value.compatibility) || value.compatibility.backend !== "wordpress-playground") {
+    return false
+  }
+
+  if (!isRecord(value.metadata) || !isRecord(value.database) || !Array.isArray(value.database.tables) || !isRecord(value.files) || typeof value.files.ndjsonPath !== "string") {
+    return false
+  }
+
+  return value.database.tables.every((table) => isRecord(table)
+    && typeof table.name === "string"
+    && typeof table.createSql === "string"
+    && typeof table.rowCount === "number"
+    && Array.isArray(table.chunks)
+    && table.chunks.every((chunkPath) => typeof chunkPath === "string"))
 }
 
 export function runtimeSnapshotExportPhp(options: RuntimeSnapshotExportOptions = {}): string {
@@ -339,27 +368,7 @@ if ( ! is_array( $payload ) || ( $payload['schema'] ?? '' ) !== 'wp-codebox/word
 
 global $wpdb;
 
-function wp_codebox_snapshot_delete_tree( string $path ): void {
-    if ( ! file_exists( $path ) ) {
-        return;
-    }
-
-    if ( is_file( $path ) || is_link( $path ) ) {
-        unlink( $path );
-        return;
-    }
-
-    $iterator = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
-        RecursiveIteratorIterator::CHILD_FIRST
-    );
-
-    foreach ( $iterator as $item ) {
-        $item->isDir() ? rmdir( $item->getPathname() ) : unlink( $item->getPathname() );
-    }
-}
-
-function wp_codebox_snapshot_relative_path_for_restore( string $base, string $path ): string {
+function wp_codebox_snapshot_restore_relative_path( string $base, string $path ): string {
     $base = rtrim( str_replace( '\\', '/', realpath( $base ) ?: $base ), '/' ) . '/';
     $path = str_replace( '\\', '/', $path );
     return ltrim( substr( $path, strlen( $base ) ), '/' );
@@ -395,7 +404,7 @@ function wp_codebox_snapshot_clear_wp_content( string $root, array $preserved_pa
 
     foreach ( $iterator as $item ) {
         $path = $item->getPathname();
-        $relative = wp_codebox_snapshot_relative_path_for_restore( $root, $path );
+        $relative = wp_codebox_snapshot_restore_relative_path( $root, $path );
         if ( wp_codebox_snapshot_restore_should_preserve_path( $relative, $preserved_paths ) ) {
             continue;
         }

--- a/packages/runtime-playground/src/runtime-snapshot.ts
+++ b/packages/runtime-playground/src/runtime-snapshot.ts
@@ -114,6 +114,8 @@ export interface RuntimeSnapshotExportOptions {
 }
 
 export type RuntimeSnapshotArtifactBody = Omit<RuntimeSnapshotArtifact, "schema" | "version" | "id" | "createdAt" | "hashes">
+type RuntimeSnapshotTable = RuntimeSnapshotArtifact["database"]["tables"][number]
+type RuntimeSnapshotFile = RuntimeSnapshotArtifact["files"][number]
 
 interface RuntimeSnapshotExportManifest {
   schema: "wp-codebox/wordpress-runtime-snapshot-export-manifest/v1"
@@ -139,25 +141,30 @@ export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, 
     throw new PlaygroundSnapshotRestoreError("Runtime snapshot export requires Playground readFileAsText support.")
   }
 
-  const tables = []
+  const tables: RuntimeSnapshotTable[] = []
   for (const table of manifest.database.tables) {
-    const rows = []
+    const rows: RuntimeSnapshotTable["rows"] = []
     for (const chunkPath of table.chunks) {
       const chunkRows = JSON.parse(await readFileAsText(chunkPath))
-      if (Array.isArray(chunkRows)) {
-        rows.push(...chunkRows)
+      if (!Array.isArray(chunkRows)) {
+        throw new PlaygroundSnapshotRestoreError(`Runtime snapshot table chunk is not an array: ${chunkPath}`)
       }
+      rows.push(...chunkRows.filter(isRecord))
     }
     tables.push({ name: table.name, createSql: table.createSql, rows, rowCount: table.rowCount })
   }
 
-  const files = []
+  const files: RuntimeSnapshotFile[] = []
   const fileLines = (await readFileAsText(manifest.files.ndjsonPath)).split("\n")
   for (const line of fileLines) {
     if (line.trim().length === 0) {
       continue
     }
-    files.push(JSON.parse(line))
+    const file = JSON.parse(line)
+    if (!isRuntimeSnapshotFile(file)) {
+      throw new PlaygroundSnapshotRestoreError("Runtime snapshot file manifest contains an invalid file entry.")
+    }
+    files.push(file)
   }
 
   return {
@@ -171,6 +178,15 @@ export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, 
     database: { tables },
     files,
   }
+}
+
+function isRuntimeSnapshotFile(value: unknown): value is RuntimeSnapshotFile {
+  return isRecord(value)
+    && value.scope === "wp-content"
+    && typeof value.path === "string"
+    && typeof value.bytes === "number"
+    && typeof value.sha256 === "string"
+    && typeof value.base64 === "string"
 }
 
 function parseRuntimeSnapshotExportManifest(responseText: string): RuntimeSnapshotExportManifest {
@@ -443,7 +459,13 @@ foreach ( $payload['files'] as $file ) {
     }
     $target = WP_CONTENT_DIR . '/' . $relative;
     wp_mkdir_p( dirname( $target ) );
-    file_put_contents( $target, base64_decode( $file['base64'], true ) );
+    $contents = base64_decode( $file['base64'], true );
+    if ( false === $contents ) {
+        throw new RuntimeException( 'Snapshot file payload is not valid base64: ' . $relative );
+    }
+    if ( false === file_put_contents( $target, $contents ) ) {
+        throw new RuntimeException( 'Failed to restore snapshot file: ' . $relative );
+    }
 }
 
 echo wp_json_encode( array(

--- a/packages/runtime-playground/src/runtime-snapshot.ts
+++ b/packages/runtime-playground/src/runtime-snapshot.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { isPlainObject as isRecord, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, runtimeEpisodeDigest, sha256StableJson, type MountSpec, type RuntimeCreateSpec, type RuntimeInfo, type Snapshot } from "@automattic/wp-codebox-core"
 import { playgroundRuntimeCommandIds } from "./command-router.js"
+import type { PlaygroundCliServer } from "./preview-server.js"
 
 export interface RuntimeSnapshotArtifact {
   schema: "wp-codebox/wordpress-runtime-snapshot/v1"
@@ -112,6 +113,67 @@ export interface RuntimeSnapshotExportOptions {
   excludedWpContentPaths?: string[]
 }
 
+interface RuntimeSnapshotExportManifest {
+  schema: "wp-codebox/wordpress-runtime-snapshot-export-manifest/v1"
+  compatibility: RuntimeSnapshotArtifact["compatibility"]
+  metadata: Omit<RuntimeSnapshotArtifact["metadata"], "runtime" | "mounts" | "mountedInputs">
+  database: {
+    tables: Array<{
+      name: string
+      createSql: string
+      rowCount: number
+      chunks: string[]
+    }>
+  }
+  files: {
+    ndjsonPath: string
+  }
+}
+
+export async function runtimeSnapshotExportPayload(server: PlaygroundCliServer, responseText: string): Promise<Omit<RuntimeSnapshotArtifact, "schema" | "version" | "id" | "createdAt" | "hashes">> {
+  const manifest = JSON.parse(responseText || "{}") as RuntimeSnapshotExportManifest
+  if (manifest.schema !== "wp-codebox/wordpress-runtime-snapshot-export-manifest/v1") {
+    throw new PlaygroundSnapshotRestoreError("Runtime snapshot export did not return a supported manifest.")
+  }
+
+  if (!server.playground.readFileAsText) {
+    throw new PlaygroundSnapshotRestoreError("Runtime snapshot export requires Playground readFileAsText support.")
+  }
+
+  const tables = []
+  for (const table of manifest.database.tables) {
+    const rows = []
+    for (const chunkPath of table.chunks) {
+      const chunkRows = JSON.parse(await server.playground.readFileAsText(chunkPath))
+      if (Array.isArray(chunkRows)) {
+        rows.push(...chunkRows)
+      }
+    }
+    tables.push({ name: table.name, createSql: table.createSql, rows, rowCount: table.rowCount })
+  }
+
+  const files = []
+  const fileLines = (await server.playground.readFileAsText(manifest.files.ndjsonPath)).split("\n")
+  for (const line of fileLines) {
+    if (line.trim().length === 0) {
+      continue
+    }
+    files.push(JSON.parse(line))
+  }
+
+  return {
+    compatibility: manifest.compatibility,
+    metadata: {
+      ...manifest.metadata,
+      runtime: null as never,
+      mounts: [],
+      mountedInputs: [],
+    },
+    database: { tables },
+    files,
+  }
+}
+
 export function runtimeSnapshotExportPhp(options: RuntimeSnapshotExportOptions = {}): string {
   const excludedWpContentPaths = JSON.stringify(normalizeWpContentPathList(["database", ...(options.excludedWpContentPaths ?? [])]))
   return [String.raw`
@@ -127,6 +189,14 @@ if ( ! is_array( $wp_codebox_snapshot_excluded_wp_content_paths ) ) {
 
 function wp_codebox_snapshot_hash_file_contents( string $contents ): string {
     return hash( 'sha256', $contents );
+}
+
+function wp_codebox_snapshot_json_encode( $value ): string {
+    $json = json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE );
+    if ( false === $json ) {
+        throw new RuntimeException( 'Failed to encode runtime snapshot JSON: ' . json_last_error_msg() );
+    }
+    return $json;
 }
 
 function wp_codebox_snapshot_relative_path( string $base, string $path ): string {
@@ -149,62 +219,94 @@ function wp_codebox_snapshot_is_excluded_path( string $relative_path, array $exc
     return false;
 }
 
-function wp_codebox_snapshot_files( string $root, array $excluded_paths ): array {
-    if ( ! is_dir( $root ) ) {
-        return array();
+function wp_codebox_snapshot_write_files( string $root, array $excluded_paths, string $target_path ): void {
+    $handle = fopen( $target_path, 'wb' );
+    if ( false === $handle ) {
+        throw new RuntimeException( 'Failed to create runtime snapshot file manifest.' );
     }
 
-    $files = array();
-    $iterator = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS ),
-        RecursiveIteratorIterator::LEAVES_ONLY
-    );
-
-    foreach ( $iterator as $file ) {
-        if ( ! $file->isFile() ) {
-            continue;
+    try {
+        if ( ! is_dir( $root ) ) {
+            return;
         }
 
-        $path = $file->getPathname();
-        $relative = wp_codebox_snapshot_relative_path( $root, $path );
-        if ( wp_codebox_snapshot_is_excluded_path( $relative, $excluded_paths ) ) {
-            continue;
-        }
-
-        $contents = file_get_contents( $path );
-        if ( false === $contents ) {
-            continue;
-        }
-
-        $files[] = array(
-            'scope' => 'wp-content',
-            'path' => $relative,
-            'bytes' => strlen( $contents ),
-            'sha256' => wp_codebox_snapshot_hash_file_contents( $contents ),
-            'base64' => base64_encode( $contents ),
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS ),
+            RecursiveIteratorIterator::LEAVES_ONLY
         );
-    }
 
-    usort( $files, fn( $left, $right ) => strcmp( $left['path'], $right['path'] ) );
-    return $files;
+        foreach ( $iterator as $file ) {
+            if ( ! $file->isFile() ) {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            $relative = wp_codebox_snapshot_relative_path( $root, $path );
+            if ( wp_codebox_snapshot_is_excluded_path( $relative, $excluded_paths ) ) {
+                continue;
+            }
+
+            $contents = file_get_contents( $path );
+            if ( false === $contents ) {
+                continue;
+            }
+
+            fwrite( $handle, wp_codebox_snapshot_json_encode( array(
+                'scope' => 'wp-content',
+                'path' => $relative,
+                'bytes' => strlen( $contents ),
+                'sha256' => wp_codebox_snapshot_hash_file_contents( $contents ),
+                'base64' => base64_encode( $contents ),
+            ) ) . "\n" );
+            unset( $contents );
+        }
+    } finally {
+        fclose( $handle );
+    }
 }
 
 $tables = array();
+$export_dir = sys_get_temp_dir() . '/wp-codebox-runtime-snapshot-' . bin2hex( random_bytes( 8 ) );
+if ( ! mkdir( $export_dir, 0700, true ) && ! is_dir( $export_dir ) ) {
+    throw new RuntimeException( 'Failed to create runtime snapshot export directory.' );
+}
+
+$table_index = 0;
 foreach ( $wpdb->get_col( 'SHOW TABLES' ) as $table_name ) {
     $quoted_table = chr( 96 ) . str_replace( chr( 96 ), chr( 96 ) . chr( 96 ), $table_name ) . chr( 96 );
     $create_row = $wpdb->get_row( 'SHOW CREATE TABLE ' . $quoted_table, ARRAY_N );
-    $rows = $wpdb->get_results( 'SELECT * FROM ' . $quoted_table, ARRAY_A );
+    $row_count = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $quoted_table );
+    $chunks = array();
+    $offset = 0;
+    $chunk_index = 0;
+    $chunk_size = 100;
+
+    while ( $offset < $row_count ) {
+        $rows = $wpdb->get_results( 'SELECT * FROM ' . $quoted_table . ' LIMIT ' . (int) $chunk_size . ' OFFSET ' . (int) $offset, ARRAY_A );
+        $chunk_path = $export_dir . '/table-' . $table_index . '-chunk-' . $chunk_index . '.json';
+        file_put_contents( $chunk_path, wp_codebox_snapshot_json_encode( $rows ?: array() ) );
+        $chunks[] = $chunk_path;
+        $offset += $chunk_size;
+        ++$chunk_index;
+        unset( $rows );
+    }
+
     $tables[] = array(
         'name' => $table_name,
         'createSql' => $create_row[1] ?? '',
-        'rows' => $rows ?: array(),
-        'rowCount' => count( $rows ?: array() ),
+        'rowCount' => $row_count,
+        'chunks' => $chunks,
     );
+    ++$table_index;
 }
 
 usort( $tables, fn( $left, $right ) => strcmp( $left['name'], $right['name'] ) );
 
-echo wp_json_encode( array(
+$files_path = $export_dir . '/files.ndjson';
+wp_codebox_snapshot_write_files( WP_CONTENT_DIR, $wp_codebox_snapshot_excluded_wp_content_paths, $files_path );
+
+echo wp_codebox_snapshot_json_encode( array(
+    'schema' => 'wp-codebox/wordpress-runtime-snapshot-export-manifest/v1',
     'compatibility' => array(
         'backend' => 'wordpress-playground',
         'wordpressVersion' => get_bloginfo( 'version' ),
@@ -220,8 +322,8 @@ echo wp_json_encode( array(
         'skippedWpContentPaths' => array_values( $wp_codebox_snapshot_excluded_wp_content_paths ),
     ),
     'database' => array( 'tables' => $tables ),
-    'files' => wp_codebox_snapshot_files( WP_CONTENT_DIR, $wp_codebox_snapshot_excluded_wp_content_paths ),
-), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );`].join("")
+    'files' => array( 'ndjsonPath' => $files_path ),
+) );`].join("")
 }
 
 export function runtimeSnapshotRestorePhp(payload: RuntimeSnapshotArtifact): string {
@@ -257,6 +359,50 @@ function wp_codebox_snapshot_delete_tree( string $path ): void {
     }
 }
 
+function wp_codebox_snapshot_relative_path_for_restore( string $base, string $path ): string {
+    $base = rtrim( str_replace( '\\', '/', realpath( $base ) ?: $base ), '/' ) . '/';
+    $path = str_replace( '\\', '/', $path );
+    return ltrim( substr( $path, strlen( $base ) ), '/' );
+}
+
+function wp_codebox_snapshot_restore_should_preserve_path( string $relative_path, array $preserved_paths ): bool {
+    $relative_path = trim( str_replace( '\\', '/', $relative_path ), '/' );
+    foreach ( $preserved_paths as $preserved_path ) {
+        if ( ! is_string( $preserved_path ) || '' === $preserved_path ) {
+            continue;
+        }
+        $preserved_path = trim( str_replace( '\\', '/', $preserved_path ), '/' );
+        if (
+            $relative_path === $preserved_path
+            || str_starts_with( $relative_path, $preserved_path . '/' )
+            || str_starts_with( $preserved_path, $relative_path . '/' )
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function wp_codebox_snapshot_clear_wp_content( string $root, array $preserved_paths ): void {
+    if ( ! file_exists( $root ) ) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator( $root, FilesystemIterator::SKIP_DOTS ),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ( $iterator as $item ) {
+        $path = $item->getPathname();
+        $relative = wp_codebox_snapshot_relative_path_for_restore( $root, $path );
+        if ( wp_codebox_snapshot_restore_should_preserve_path( $relative, $preserved_paths ) ) {
+            continue;
+        }
+        $item->isDir() ? rmdir( $path ) : unlink( $path );
+    }
+}
+
 foreach ( $wpdb->get_col( 'SHOW TABLES' ) as $table_name ) {
     $quoted_table = chr( 96 ) . str_replace( chr( 96 ), chr( 96 ) . chr( 96 ), $table_name ) . chr( 96 );
     $wpdb->query( 'DROP TABLE IF EXISTS ' . $quoted_table );
@@ -271,7 +417,11 @@ foreach ( $payload['database']['tables'] as $table ) {
     }
 }
 
-wp_codebox_snapshot_delete_tree( WP_CONTENT_DIR );
+$preserved_wp_content_paths = array_values( array_unique( array_merge(
+    array( 'database' ),
+    (array) ( $payload['metadata']['skippedWpContentPaths'] ?? array() )
+) ) );
+wp_codebox_snapshot_clear_wp_content( WP_CONTENT_DIR, $preserved_wp_content_paths );
 wp_mkdir_p( WP_CONTENT_DIR );
 
 foreach ( $payload['files'] as $file ) {

--- a/packages/runtime-playground/src/runtime-snapshot.ts
+++ b/packages/runtime-playground/src/runtime-snapshot.ts
@@ -113,7 +113,7 @@ export interface RuntimeSnapshotExportOptions {
 }
 
 export function runtimeSnapshotExportPhp(options: RuntimeSnapshotExportOptions = {}): string {
-  const excludedWpContentPaths = JSON.stringify(normalizeWpContentPathList(options.excludedWpContentPaths ?? []))
+  const excludedWpContentPaths = JSON.stringify(normalizeWpContentPathList(["database", ...(options.excludedWpContentPaths ?? [])]))
   return [String.raw`
 global $wpdb;
 

--- a/scripts/recipe-state-bundle-capture-smoke.ts
+++ b/scripts/recipe-state-bundle-capture-smoke.ts
@@ -67,7 +67,7 @@ try {
     const blueprintAfterNotes = JSON.parse(await readFile(artifacts.blueprintAfterNotesPath, "utf8"))
 
     assert.equal(manifest.files.some((file: { path?: string; kind?: string }) => file.path === captureOutput.snapshot.artifactRefs[0].path && file.kind === "runtime-snapshot"), true)
-    assert.deepEqual(snapshotPayload.metadata.skippedWpContentPaths, ["plugins/runtime-substrate", "themes/runtime-substrate-theme"])
+    assert.deepEqual(snapshotPayload.metadata.skippedWpContentPaths, ["database", "plugins/runtime-substrate", "themes/runtime-substrate-theme"])
     assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path?.startsWith("plugins/runtime-substrate/")), false)
     assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path?.startsWith("themes/runtime-substrate-theme/")), false)
     assert.equal(snapshotPayload.files.some((file: { path?: string }) => file.path === "state-bundle-smoke.txt"), true)


### PR DESCRIPTION
## Summary
- Preserve internal WordPress database files when exporting runtime snapshots while keeping database table export authoritative.
- Stream runtime snapshot export through manifest/chunk files so PHP returns a small response and Node assembles the artifact.
- Add validation around the snapshot export manifest boundary before loading chunk files.

## Testing
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the follow-up cleanup and boundary refactor; Chris directed scope and validation constraints.