### PR TITLE
Fix routed preview fetch decode failures

### DIFF
--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -298,7 +298,7 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, rout
         maxRedirects: 0,
       })
     } catch (error) {
-      if (!isBrowserPreviewRouteFetchRequestContextDisposedError(error)) {
+      if (!isBrowserPreviewRouteFetchRecoverableError(error)) {
         throw error
       }
 
@@ -324,6 +324,14 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, rout
 
 export function isBrowserPreviewRouteFetchRequestContextDisposedError(error: unknown): boolean {
   return error instanceof Error && /\broute\.fetch:\s*Request context disposed\.?/i.test(error.message)
+}
+
+export function isBrowserPreviewRouteFetchRecoverableError(error: unknown): boolean {
+  return isBrowserPreviewRouteFetchRequestContextDisposedError(error) || isBrowserPreviewRouteFetchContentDecodingError(error)
+}
+
+export function isBrowserPreviewRouteFetchContentDecodingError(error: unknown): boolean {
+  return error instanceof Error && /\broute\.fetch:\s*failed to decompress\b/i.test(error.message)
 }
 
 function urlProtocol(url: string): string | undefined {

--- a/scripts/browser-probe-routed-fetch-disposed-smoke.ts
+++ b/scripts/browser-probe-routed-fetch-disposed-smoke.ts
@@ -20,6 +20,13 @@ assert.equal(disposedRoute.fulfillCalls, 0, "disposed request context should not
 assert.equal(disposedRoute.continueCalls, 0, "disposed request context should not continue")
 assert.equal(policy.stats.get("wordpress.com")?.routed, 1)
 
+const deflateRoute = createRoute(new Error("route.fetch: failed to decompress 'deflate' encoding: Error: incorrect header check"))
+await handler(deflateRoute as Route)
+assert.equal(deflateRoute.abortCalls, 1, "routed content decoding failures should abort the routed request")
+assert.equal(deflateRoute.fulfillCalls, 0, "routed content decoding failures should not fulfill")
+assert.equal(deflateRoute.continueCalls, 0, "routed content decoding failures should not continue")
+assert.equal(policy.stats.get("wordpress.com")?.routed, 2)
+
 const otherFetchError = new Error("route.fetch: socket hang up")
 const failingRoute = createRoute(otherFetchError)
 await assert.rejects(handler(failingRoute as Route), otherFetchError, "other route.fetch errors should still surface")


### PR DESCRIPTION
## Summary
- Treat Playwright `route.fetch` body decoding failures as recoverable routed preview request failures.
- Abort the affected routed request instead of letting malformed compressed admin AJAX responses crash the Node process.
- Extend the routed-fetch smoke with the downstream `failed to decompress 'deflate' encoding` shape seen while validating `wpcom-codebox#208`.

Follow-up to #954.

## Testing
- `npm run build`
- `npm exec -- tsx scripts/browser-probe-routed-fetch-disposed-smoke.ts`
- `npm exec -- tsx scripts/browser-probe-route-host-smoke.ts`
- `npm exec -- tsx scripts/browser-probe-routed-admin-auth-smoke.ts`
- Downstream local proof: `node /Users/chubes/Developer/wp-codebox/packages/cli/dist/index.js recipe-run --recipe recipes/wpcom-logged-in-dashboard-proof.yml --json` in `wpcom-codebox@issue-208-logged-in-dashboard-proof`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the downstream routed `wp-compression-test` failure, implementing the generic route-host recovery, adding regression coverage, and running upstream/downstream validation. Chris remains responsible for review and final merge.