### PR TITLE
Expose blockers for held admin previews

### DIFF
--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -660,6 +660,7 @@ export interface ArtifactPreviewSessionEvidence {
     holdSeconds?: number
     hasPublicUrl: boolean
     hasSiteUrl: boolean
+    blockers?: ArtifactPreviewBlocker[]
   }
   refs: {
     artifactBundle: {
@@ -690,6 +691,20 @@ export interface ArtifactPreview {
   createdAt: string
   expiresAt?: string
   holdSeconds?: number
+  blockers?: ArtifactPreviewBlocker[]
+}
+
+export interface ArtifactPreviewBlocker {
+  schema: "wp-codebox/preview-blocker/v1"
+  kind: "unsupported-preview"
+  code: "external-wordpress-admin-auth-unavailable" | (string & {})
+  message: string
+  retryable: false
+  reviewerSafe: false
+  evidence: {
+    command: string
+    auth: "wordpress-admin" | (string & {})
+  }
 }
 
 export interface ArtifactPreviewUrlRef {
@@ -743,6 +758,7 @@ export interface ArtifactPreviewEvidence {
     localUrl?: ArtifactPreviewUrlRef
     siteUrl?: ArtifactPreviewUrlRef
     durablePreview?: ArtifactDurablePreviewRef
+    blockers?: ArtifactPreviewBlocker[]
   }
   readiness: {
     ready: boolean

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -16,6 +16,7 @@ import {
   type ArtifactManifestFile,
   type ArtifactViewerMetadata,
   type ArtifactPreview,
+  type ArtifactPreviewBlocker,
   type ArtifactPreviewEvidence,
   type ArtifactPreviewSessionEvidence,
   type ArtifactPackageProvenance,
@@ -121,7 +122,7 @@ export class ArtifactBundleBuilder {
     await source.redactPluginCheckArtifacts(redactor)
     await source.redactThemeCheckArtifacts(redactor)
 
-    const preview = await source.previewInfo(createdAt, spec.previewHoldSeconds)
+    const preview = heldPreviewWithExternalAccessBlockers(await source.previewInfo(createdAt, spec.previewHoldSeconds), source.commands)
     const browser = source.browserReviewSummary()
     const runtime = await source.info()
     const durablePreview = await buildDurableArtifactPreview({
@@ -634,6 +635,7 @@ function buildPreviewEvidence({
       createdAt: preview?.createdAt,
       expiresAt: preview?.expiresAt,
       holdSeconds: preview?.holdSeconds,
+      ...(preview?.blockers ? { blockers: preview.blockers } : {}),
       url: safePreviewUrlRef(preview?.url),
       ...(preview?.publicUrl ? { publicUrl: safePreviewUrlRef(preview.publicUrl) } : {}),
       ...(preview?.localUrl ? { localUrl: safePreviewUrlRef(preview.localUrl) } : {}),
@@ -769,6 +771,7 @@ function buildPreviewSessionEvidence({
       holdSeconds: preview.holdSeconds,
       hasPublicUrl: Boolean(preview.publicUrl),
       hasSiteUrl: Boolean(preview.siteUrl),
+      blockers: preview.blockers,
     }) : undefined,
     refs: stripUndefined({
       artifactBundle: {
@@ -787,6 +790,59 @@ function buildPreviewSessionEvidence({
     }),
     components: packages,
   })
+}
+
+export function heldPreviewWithExternalAccessBlockers(preview: ArtifactPreview | undefined, commands: ExecutionResult[]): ArtifactPreview | undefined {
+  if (!preview || preview.lifecycle !== "held-after-run" || !preview.holdSeconds) {
+    return preview
+  }
+
+  const authCommand = commands.find((command) => browserCommandRequestsWordPressAdminAuth(command))
+  if (!authCommand) {
+    return preview
+  }
+
+  const blocker: ArtifactPreviewBlocker = {
+    schema: "wp-codebox/preview-blocker/v1",
+    kind: "unsupported-preview",
+    code: "external-wordpress-admin-auth-unavailable",
+    message: "This held preview used auth=wordpress-admin inside the controlled automation browser. WP Codebox cannot safely export that in-memory WordPress admin session to an external reviewer browser, so admin URLs may redirect to login outside the automation context.",
+    retryable: false,
+    reviewerSafe: false,
+    evidence: {
+      command: authCommand.command,
+      auth: "wordpress-admin",
+    },
+  }
+
+  return {
+    ...preview,
+    blockers: [...(preview.blockers ?? []), blocker],
+  }
+}
+
+function browserCommandRequestsWordPressAdminAuth(command: ExecutionResult): boolean {
+  if (!["wordpress.browser-actions", "wordpress.browser-probe", "wordpress.browser-scenario", "wordpress.visual-compare"].includes(command.command)) {
+    return false
+  }
+
+  return command.args.some((arg) => argRequestsWordPressAdminAuth(arg))
+}
+
+function argRequestsWordPressAdminAuth(arg: string): boolean {
+  const separator = arg.indexOf("=")
+  if (separator > 0) {
+    const key = arg.slice(0, separator).trim()
+    const value = arg.slice(separator + 1).trim()
+    if (key === "auth" && value === "wordpress-admin") {
+      return true
+    }
+    if ((key === "scenario" || key === "scenario-json") && /"auth"\s*:\s*"wordpress-admin"/.test(value)) {
+      return true
+    }
+  }
+
+  return /"auth"\s*:\s*"wordpress-admin"/.test(arg)
 }
 
 function evidenceRef(path: string, kind: string, contentType = "application/json"): ArtifactEvidenceRef {

--- a/scripts/held-admin-preview-blocker-smoke.ts
+++ b/scripts/held-admin-preview-blocker-smoke.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import type { ArtifactPreview, ExecutionResult } from "@automattic/wp-codebox-core"
+import { heldPreviewWithExternalAccessBlockers } from "../packages/runtime-playground/src/artifact-bundle-builder.js"
+
+const heldPreview: ArtifactPreview = {
+  url: "http://127.0.0.1:48631/wp-admin/post.php?post=24117035&action=edit",
+  status: "available",
+  lifecycle: "held-after-run",
+  source: "live-playground",
+  createdAt: "2026-06-15T00:00:00.000Z",
+  expiresAt: "2026-06-15T00:15:00.000Z",
+  holdSeconds: 900,
+}
+
+const command: ExecutionResult = {
+  id: "execution-1",
+  command: "wordpress.browser-actions",
+  args: [
+    "url=/wp-admin/post.php?post=24117035&action=edit",
+    "auth=wordpress-admin",
+    "steps-json=[]",
+  ],
+  exitCode: 0,
+  stdout: "{}",
+  stderr: "",
+  startedAt: "2026-06-15T00:00:01.000Z",
+  finishedAt: "2026-06-15T00:00:02.000Z",
+}
+
+const blockedPreview = heldPreviewWithExternalAccessBlockers(heldPreview, [command])
+assert.equal(blockedPreview?.blockers?.length, 1)
+assert.equal(blockedPreview.blockers[0].schema, "wp-codebox/preview-blocker/v1")
+assert.equal(blockedPreview.blockers[0].kind, "unsupported-preview")
+assert.equal(blockedPreview.blockers[0].code, "external-wordpress-admin-auth-unavailable")
+assert.equal(blockedPreview.blockers[0].reviewerSafe, false)
+assert.equal(blockedPreview.blockers[0].retryable, false)
+assert.deepEqual(blockedPreview.blockers[0].evidence, { command: "wordpress.browser-actions", auth: "wordpress-admin" })
+
+const publicPreview = heldPreviewWithExternalAccessBlockers(heldPreview, [{ ...command, args: ["url=/"] }])
+assert.equal(publicPreview?.blockers, undefined)
+
+const expiredPreview = heldPreviewWithExternalAccessBlockers({ ...heldPreview, lifecycle: "destroyed-on-completion", status: "expired-on-completion", holdSeconds: undefined }, [command])
+assert.equal(expiredPreview?.blockers, undefined)
+
+console.log("Held admin preview blocker smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -184,6 +184,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-preview-routing-browser-probe-smoke"),
       tsxSmoke("preview-response-body-smoke"),
       tsxSmoke("browser-startup-progress-smoke"),
+      tsxSmoke("held-admin-preview-blocker-smoke"),
       tsxSmoke("recipe-browser-probe-liveness-smoke"),
       tsxSmoke("boot-preview-smoke"),
       tsxSmoke("blueprint-validation-smoke"),


### PR DESCRIPTION
## Summary
- Adds a structured `unsupported-preview` blocker to held preview metadata when browser evidence used `auth=wordpress-admin`.
- Surfaces the blocker through `artifacts.preview`, review metadata, `preview-evidence`, and `preview-session-evidence` so callers can stop presenting admin preview URLs as reviewer-safe.
- Adds a focused smoke test and includes it in the preview smoke group.

Fixes https://github.com/Automattic/wp-codebox/issues/966

## Testing
- `npx tsx scripts/held-admin-preview-blocker-smoke.ts`
- `npm run build`

## Downstream verification
After this branch is installed in the WPCOM proof environment, rerun the held preview proof with the same `wpcom-codebox` recipe and Homeboy hold flags, for example:

```bash
homeboy <wpcom-codebox proof command> --preview-hold 15m --preview-hold-blocking
```

Expected result: the recipe can still pass in the controlled automation browser, but the emitted artifact metadata includes `preview.blockers[0].code = external-wordpress-admin-auth-unavailable` for held `auth=wordpress-admin` admin previews. Orchestration should surface that blocker instead of treating the held local admin URL as reviewer-safe.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the minimal preview blocker contract, implementation, test, and PR description for Chris to review and verify.