### PR TITLE
Add reviewer auth bootstrap for held admin previews

### DIFF
--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -658,6 +658,7 @@ export interface ArtifactPreviewSessionEvidence {
     createdAt: string
     expiresAt?: string
     holdSeconds?: number
+    reviewerAuth?: Omit<ArtifactPreviewReviewerAuth, "url">
     hasPublicUrl: boolean
     hasSiteUrl: boolean
     blockers?: ArtifactPreviewBlocker[]
@@ -691,7 +692,24 @@ export interface ArtifactPreview {
   createdAt: string
   expiresAt?: string
   holdSeconds?: number
+  reviewerAuth?: ArtifactPreviewReviewerAuth
   blockers?: ArtifactPreviewBlocker[]
+}
+
+export interface ArtifactPreviewReviewerAuth {
+  schema: "wp-codebox/preview-reviewer-auth/v1"
+  kind: "reviewer-auth-bootstrap"
+  auth: "wordpress-admin" | (string & {})
+  reviewerSafe: true
+  url: string
+  targetPath: string
+  expiresAt: string
+  holdSeconds: number
+  userId: number
+  scope: {
+    runtimeId: string
+    origin: string
+  }
 }
 
 export interface ArtifactPreviewBlocker {
@@ -753,6 +771,7 @@ export interface ArtifactPreviewEvidence {
     createdAt?: string
     expiresAt?: string
     holdSeconds?: number
+    reviewerAuth?: ArtifactPreviewReviewerAuth
     url: ArtifactPreviewUrlRef
     publicUrl?: ArtifactPreviewUrlRef
     localUrl?: ArtifactPreviewUrlRef

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -635,6 +635,7 @@ function buildPreviewEvidence({
       createdAt: preview?.createdAt,
       expiresAt: preview?.expiresAt,
       holdSeconds: preview?.holdSeconds,
+      ...(preview?.reviewerAuth ? { reviewerAuth: preview.reviewerAuth } : {}),
       ...(preview?.blockers ? { blockers: preview.blockers } : {}),
       url: safePreviewUrlRef(preview?.url),
       ...(preview?.publicUrl ? { publicUrl: safePreviewUrlRef(preview.publicUrl) } : {}),
@@ -769,6 +770,17 @@ function buildPreviewSessionEvidence({
       createdAt: preview.createdAt,
       expiresAt: preview.expiresAt,
       holdSeconds: preview.holdSeconds,
+      reviewerAuth: preview.reviewerAuth ? {
+        schema: preview.reviewerAuth.schema,
+        kind: preview.reviewerAuth.kind,
+        auth: preview.reviewerAuth.auth,
+        reviewerSafe: preview.reviewerAuth.reviewerSafe,
+        targetPath: preview.reviewerAuth.targetPath,
+        expiresAt: preview.reviewerAuth.expiresAt,
+        holdSeconds: preview.reviewerAuth.holdSeconds,
+        userId: preview.reviewerAuth.userId,
+        scope: preview.reviewerAuth.scope,
+      } : undefined,
       hasPublicUrl: Boolean(preview.publicUrl),
       hasSiteUrl: Boolean(preview.siteUrl),
       blockers: preview.blockers,
@@ -799,6 +811,10 @@ export function heldPreviewWithExternalAccessBlockers(preview: ArtifactPreview |
 
   const authCommand = commands.find((command) => browserCommandRequestsWordPressAdminAuth(command))
   if (!authCommand) {
+    return preview
+  }
+
+  if (preview.reviewerAuth?.reviewerSafe) {
     return preview
   }
 

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -13,11 +13,12 @@ import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collect
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserError } from "./browser-metrics.js"
 import { browserPreviewNetworkPolicy, browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
 import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
-import { argValue, cleanWpCliOutput, commaListArg, durationArg, jsonArrayArg, strictBooleanArg, viewportArg } from "./commands.js"
+import { argValue, commaListArg, durationArg, jsonArrayArg, strictBooleanArg, viewportArg } from "./commands.js"
 import { editorActionStepsFromArgs, editorOpenTargetFromArgs, type EditorActionStep } from "./editor-actions.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
+import { browserAuthCookieHostSummary, parseWordPressAdminAuthCookies, wordpressAdminAuthCookiePhpCode } from "./wordpress-admin-auth.js"
 import type { Page } from "playwright"
 
 const BROWSER_STEP_DEFAULT_TIMEOUT_MS = 15_000
@@ -5226,7 +5227,7 @@ async function installWordPressAdminAuthCookies({
   const urls = uniqueBrowserAuthCookieUrls(cookieUrls ?? [server.serverUrl])
   const response = await runPlaygroundCommand(authCommand, server, { code: bootstrapPhpCode(runtimeSpec, wordpressAdminAuthCookiePhpCode(urls, userId), []) })
   assertPlaygroundResponseOk(authCommand, response)
-  const cookies = JSON.parse(cleanWpCliOutput(response.text)) as Array<{ name?: string; value?: string; domain?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: "Lax" }>
+  const cookies = parseWordPressAdminAuthCookies(response.text)
   await page.context().addCookies(cookies.map((cookie) => ({
     name: String(cookie.name ?? ""),
     value: String(cookie.value ?? ""),
@@ -5239,59 +5240,6 @@ async function installWordPressAdminAuthCookies({
   })))
 
   return { mode: "wordpress-admin", userId, cookieCount: cookies.length, cookieHosts: browserAuthCookieHostSummary(cookies) }
-}
-
-function wordpressAdminAuthCookiePhpCode(browserUrls: string[], userId: number): string {
-  return `
-$user_id = ${JSON.stringify(userId)};
-$user = get_user_by( 'id', $user_id );
-if ( ! $user ) {
-    throw new RuntimeException( 'Browser auth requires the requested WordPress user to exist.' );
-}
-wp_set_current_user( $user_id );
-$expiration = time() + HOUR_IN_SECONDS;
-$token = '';
-if ( class_exists( 'WP_Session_Tokens' ) ) {
-    $token = WP_Session_Tokens::get_instance( $user_id )->create( $expiration );
-}
-$browser_urls = ${JSON.stringify(browserUrls)};
-$cookies = array();
-foreach ( $browser_urls as $browser_url ) {
-    $browser_host = wp_parse_url( $browser_url, PHP_URL_HOST );
-    if ( ! $browser_host ) {
-        continue;
-    }
-    $secure = 'https' === wp_parse_url( $browser_url, PHP_URL_SCHEME );
-    foreach ( array( array( AUTH_COOKIE, 'auth', false ), array( SECURE_AUTH_COOKIE, 'secure_auth', true ) ) as $admin_cookie ) {
-        $cookies[] = array(
-            'name'     => $admin_cookie[0],
-            'value'    => wp_generate_auth_cookie( $user_id, $expiration, $admin_cookie[1], $token ),
-            'domain'   => $browser_host,
-            'path'     => defined( 'ADMIN_COOKIE_PATH' ) && ADMIN_COOKIE_PATH ? ADMIN_COOKIE_PATH : '/wp-admin',
-            'expires'  => $expiration,
-            'httpOnly' => true,
-            'secure'   => $admin_cookie[2],
-            'sameSite' => 'Lax',
-        );
-    }
-    $logged_in_cookie = array(
-        'name'     => LOGGED_IN_COOKIE,
-        'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in', $token ),
-        'domain'   => $browser_host,
-        'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
-        'expires'  => $expiration,
-        'httpOnly' => true,
-        'secure'   => $secure,
-        'sameSite' => 'Lax',
-    );
-    $cookies[] = $logged_in_cookie;
-    if ( defined( 'SITECOOKIEPATH' ) && SITECOOKIEPATH && SITECOOKIEPATH !== COOKIEPATH ) {
-        $logged_in_cookie['path'] = SITECOOKIEPATH;
-        $cookies[] = $logged_in_cookie;
-    }
-}
-echo wp_json_encode( $cookies );
-`
 }
 
 function browserAuthCookieUrls(serverUrl: string, routedHosts: string[], targetUrls: string[]): string[] {
@@ -5345,16 +5293,6 @@ function browserUrlHostname(url: string): string | undefined {
 
 function normalizeBrowserCookieHost(host: string): string {
   return host.trim().toLowerCase().replace(/:\d+$/, "")
-}
-
-function browserAuthCookieHostSummary(cookies: Array<{ domain?: string }>): Array<{ host: string; cookieCount: number }> {
-  const counts = new Map<string, number>()
-  for (const cookie of cookies) {
-    const host = normalizeBrowserCookieHost(String(cookie.domain ?? ""))
-    if (!host) continue
-    counts.set(host, (counts.get(host) ?? 0) + 1)
-  }
-  return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([host, cookieCount]) => ({ host, cookieCount }))
 }
 
 function browserAuthRequest(args: string[]): { userId: number } | undefined {

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -123,7 +123,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       return server
     }
 
-    const proxiedServer = await withPreviewProxy(server, spec.preview.port, spec.preview.bind)
+    const proxiedServer = await withPreviewProxy(server, spec.preview.port, spec.preview.bind, spec)
     emitProgress("preview:ready", "complete", "Preview ready", {
       localUrl: proxiedServer.serverUrl,
       upstreamUrl: server.serverUrl,

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -433,6 +433,16 @@ class PlaygroundRuntime implements Runtime {
     const expiresAt = normalizedHoldSeconds > 0 ? new Date(Date.now() + normalizedHoldSeconds * 1000).toISOString() : undefined
     const publicUrl = this.spec.preview?.publicUrl
     const siteUrl = this.spec.preview?.siteUrl
+    const reviewerAuthRequest = this.reviewerAuthRequest(server.serverUrl)
+    const reviewerAuth = reviewerAuthRequest && server.createReviewerAuthBootstrap && expiresAt
+      ? await server.createReviewerAuthBootstrap({
+          runtimeId: this.runtimeId,
+          targetPath: reviewerAuthRequest.targetPath,
+          expiresAt,
+          holdSeconds: normalizedHoldSeconds,
+          userId: reviewerAuthRequest.userId,
+        })
+      : undefined
 
     return {
       url: publicUrl ?? server.serverUrl,
@@ -442,8 +452,19 @@ class PlaygroundRuntime implements Runtime {
       lifecycle: normalizedHoldSeconds > 0 ? "held-after-run" : "destroyed-on-completion",
       source: publicUrl ? "public-url-override" : "live-playground",
       createdAt,
+      ...(reviewerAuth ? { reviewerAuth } : {}),
       ...(expiresAt ? { expiresAt, holdSeconds: normalizedHoldSeconds } : {}),
     }
+  }
+
+  private reviewerAuthRequest(previewUrl: string): { targetPath: string; userId: number } | undefined {
+    const command = this.commands.find((candidate) => candidate.exitCode === 0 && browserCommandRequestsWordPressAdminAuth(candidate))
+    if (!command) {
+      return undefined
+    }
+
+    const targetPath = browserCommandTargetPath(command, previewUrl)
+    return targetPath ? { targetPath, userId: authUserId(command.args ?? []) } : undefined
   }
 
   private recordEvent(type: LifecycleEvent["type"], data?: Record<string, unknown>): LifecycleEvent {
@@ -876,6 +897,54 @@ function stringArg(args: string[], name: string): string | undefined {
   const prefix = `${name}=`
   const value = args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length).trim()
   return value && value.length > 0 ? value : undefined
+}
+
+function browserCommandRequestsWordPressAdminAuth(command: ExecutionResult): boolean {
+  if (!["wordpress.browser-actions", "wordpress.browser-probe", "wordpress.browser-scenario", "wordpress.visual-compare"].includes(command.command)) {
+    return false
+  }
+
+  return command.args.some((arg) => argRequestsWordPressAdminAuth(arg))
+}
+
+function argRequestsWordPressAdminAuth(arg: string): boolean {
+  const separator = arg.indexOf("=")
+  if (separator > 0) {
+    const key = arg.slice(0, separator).trim()
+    const value = arg.slice(separator + 1).trim()
+    if (key === "auth" && value === "wordpress-admin") {
+      return true
+    }
+    if ((key === "scenario" || key === "scenario-json") && /"auth"\s*:\s*"wordpress-admin"/.test(value)) {
+      return true
+    }
+  }
+
+  return /"auth"\s*:\s*"wordpress-admin"/.test(arg)
+}
+
+function browserCommandTargetPath(command: ExecutionResult, previewUrl: string): string | undefined {
+  const rawUrl = stringArg(command.args ?? [], "url")
+  if (!rawUrl) {
+    return undefined
+  }
+
+  try {
+    const parsed = new URL(rawUrl, previewUrl)
+    const preview = new URL(previewUrl)
+    if (parsed.origin !== preview.origin) {
+      return undefined
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return undefined
+  }
+}
+
+function authUserId(args: string[]): number {
+  const raw = stringArg(args, "auth-user-id")
+  const parsed = raw ? Number.parseInt(raw, 10) : 1
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1
 }
 
 function wpContentRelativePath(path: string): string | undefined {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -1,5 +1,10 @@
+import { randomBytes } from "node:crypto"
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
+import { bootstrapPhpCode } from "./php-bootstrap.js"
+import { assertPlaygroundResponseOk } from "./playground-command-errors.js"
+import { parseWordPressAdminAuthCookies, wordpressAdminAuthCookiePhpCode, type WordPressAdminAuthCookie } from "./wordpress-admin-auth.js"
+import type { ArtifactPreviewReviewerAuth, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 
 export interface PlaygroundServerRunResponse {
   exitCode?: number
@@ -15,11 +20,21 @@ export interface PlaygroundCliServer {
     writeFile?(path: string, contents: string): Promise<void>
   }
   serverUrl: string
+  createReviewerAuthBootstrap?(options: ReviewerAuthBootstrapOptions): Promise<ArtifactPreviewReviewerAuth>
   [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface ReviewerAuthBootstrapOptions {
+  runtimeId: string
+  targetPath: string
+  expiresAt: string
+  holdSeconds: number
+  userId: number
 }
 
 interface PlaygroundPreviewProxy {
   serverUrl: string
+  createReviewerAuthBootstrap?: PlaygroundCliServer["createReviewerAuthBootstrap"]
   dispose(): Promise<void>
 }
 
@@ -34,10 +49,10 @@ export class PlaygroundPreviewPortUnavailableError extends Error {
   }
 }
 
-export async function withPreviewProxy(server: PlaygroundCliServer, port: number, bind = "127.0.0.1"): Promise<PlaygroundCliServer> {
+export async function withPreviewProxy(server: PlaygroundCliServer, port: number, bind = "127.0.0.1", runtimeSpec?: RuntimeCreateSpec): Promise<PlaygroundCliServer> {
   let proxy: PlaygroundPreviewProxy | undefined
   try {
-    proxy = await startPreviewProxy(server.serverUrl, port, bind)
+    proxy = await startPreviewProxy(server, port, bind, runtimeSpec)
   } catch (error) {
     await server[Symbol.asyncDispose]()
     throw error
@@ -46,6 +61,7 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
   return {
     ...server,
     serverUrl: proxy.serverUrl,
+    ...(proxy.createReviewerAuthBootstrap ? { createReviewerAuthBootstrap: proxy.createReviewerAuthBootstrap } : {}),
     async [Symbol.asyncDispose]() {
       await proxy.dispose()
       await server[Symbol.asyncDispose]()
@@ -53,15 +69,16 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
   }
 }
 
-async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
-  const target = new URL(targetUrl)
-  const proxy = previewProxyServer(target)
+async function startPreviewProxy(server: PlaygroundCliServer, port: number, bind: string, runtimeSpec: RuntimeCreateSpec | undefined): Promise<PlaygroundPreviewProxy> {
+  const target = new URL(server.serverUrl)
+  const reviewerAuth = runtimeSpec ? createReviewerAuthBootstrapStore(server, runtimeSpec) : undefined
+  const proxy = previewProxyServer(target, reviewerAuth)
   const servers = [proxy]
 
   await listenPreviewProxy(proxy, port, bind)
 
   if (bind === "127.0.0.1") {
-    const ipv6Proxy = previewProxyServer(target)
+    const ipv6Proxy = previewProxyServer(target, reviewerAuth)
     try {
       await listenPreviewProxy(ipv6Proxy, port, "::1")
       servers.push(ipv6Proxy)
@@ -79,18 +96,133 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
 
   return {
     serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
+    ...(reviewerAuth ? { createReviewerAuthBootstrap: (options) => reviewerAuth.createBootstrap(`http://${formatPreviewHost(reportedHost)}:${resolvedPort}`, options) } : {}),
     async dispose() {
       await closePreviewProxyServers(servers)
     },
   }
 }
 
-function previewProxyServer(target: URL): PreviewProxyServer {
+function previewProxyServer(target: URL, reviewerAuth?: ReviewerAuthBootstrapStore): PreviewProxyServer {
   const upstreamQueue = createPreviewProxyQueue()
 
   return createHttpServer((incoming, outgoing) => {
+    if (reviewerAuth?.canHandle(incoming)) {
+      reviewerAuth.handle(incoming, outgoing).catch((error: Error) => writeProxyError(outgoing, error))
+      return
+    }
+
     upstreamQueue(() => proxyPreviewRequest(target, incoming, outgoing)).catch((error: Error) => writeProxyError(outgoing, error))
   })
+}
+
+interface ReviewerAuthBootstrapEntry extends ReviewerAuthBootstrapOptions {
+  token: string
+  origin: string
+}
+
+interface ReviewerAuthBootstrapStore {
+  canHandle(incoming: IncomingMessage): boolean
+  createBootstrap(origin: string, options: ReviewerAuthBootstrapOptions): Promise<ArtifactPreviewReviewerAuth>
+  handle(incoming: IncomingMessage, outgoing: ServerResponse): Promise<void>
+}
+
+function createReviewerAuthBootstrapStore(server: PlaygroundCliServer, runtimeSpec: RuntimeCreateSpec): ReviewerAuthBootstrapStore {
+  const entries = new Map<string, ReviewerAuthBootstrapEntry>()
+  const bootstrapPath = "/_wp-codebox/reviewer-auth/bootstrap"
+
+  return {
+    canHandle(incoming) {
+      return requestPath(incoming) === bootstrapPath
+    },
+    async createBootstrap(origin, options) {
+      const token = randomBytes(24).toString("base64url")
+      entries.set(token, { ...options, token, origin })
+      const url = new URL(bootstrapPath, origin)
+      url.searchParams.set("token", token)
+      return {
+        schema: "wp-codebox/preview-reviewer-auth/v1",
+        kind: "reviewer-auth-bootstrap",
+        auth: "wordpress-admin",
+        reviewerSafe: true,
+        url: url.toString(),
+        targetPath: options.targetPath,
+        expiresAt: options.expiresAt,
+        holdSeconds: options.holdSeconds,
+        userId: options.userId,
+        scope: {
+          runtimeId: options.runtimeId,
+          origin,
+        },
+      }
+    },
+    async handle(incoming, outgoing) {
+      if (incoming.method && incoming.method !== "GET" && incoming.method !== "HEAD") {
+        writeText(outgoing, 405, "Reviewer auth bootstrap only supports GET.\n")
+        return
+      }
+      const token = requestUrl(incoming)?.searchParams.get("token") ?? ""
+      const entry = entries.get(token)
+      if (!entry || Date.now() >= Date.parse(entry.expiresAt)) {
+        writeText(outgoing, 410, "Reviewer auth bootstrap is expired or unavailable.\n")
+        return
+      }
+
+      const response = await server.playground.run({ code: bootstrapPhpCode(runtimeSpec, wordpressAdminAuthCookiePhpCode([entry.origin], entry.userId), []) })
+      assertPlaygroundResponseOk("preview.reviewer-auth-bootstrap", response)
+      const cookies = parseWordPressAdminAuthCookies(response.text)
+      outgoing.writeHead(302, {
+        "cache-control": "no-store",
+        "location": entry.targetPath,
+        "set-cookie": cookies.map(cookieToSetCookieHeader).filter((cookie): cookie is string => Boolean(cookie)),
+      })
+      outgoing.end()
+    },
+  }
+}
+
+function cookieToSetCookieHeader(cookie: WordPressAdminAuthCookie): string | undefined {
+  const name = String(cookie.name ?? "")
+  const value = String(cookie.value ?? "")
+  if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(name) || !value) {
+    return undefined
+  }
+
+  const parts = [`${name}=${value}`]
+  parts.push(`Path=${typeof cookie.path === "string" && cookie.path.length > 0 ? cookie.path : "/"}`)
+  if (typeof cookie.expires === "number") {
+    parts.push(`Expires=${new Date(cookie.expires * 1000).toUTCString()}`)
+  }
+  if (cookie.httpOnly !== false) {
+    parts.push("HttpOnly")
+  }
+  if (cookie.secure === true) {
+    parts.push("Secure")
+  }
+  parts.push(`SameSite=${cookie.sameSite ?? "Lax"}`)
+  return parts.join("; ")
+}
+
+function requestPath(incoming: IncomingMessage): string | undefined {
+  return requestUrl(incoming)?.pathname
+}
+
+function requestUrl(incoming: IncomingMessage): URL | undefined {
+  try {
+    return new URL(incoming.url ?? "/", "http://127.0.0.1")
+  } catch {
+    return undefined
+  }
+}
+
+function writeText(outgoing: ServerResponse, statusCode: number, body: string): void {
+  const buffer = Buffer.from(body, "utf8")
+  outgoing.writeHead(statusCode, {
+    "cache-control": "no-store",
+    "content-type": "text/plain; charset=utf-8",
+    "content-length": String(buffer.byteLength),
+  })
+  outgoing.end(buffer)
 }
 
 function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {

--- a/packages/runtime-playground/src/wordpress-admin-auth.ts
+++ b/packages/runtime-playground/src/wordpress-admin-auth.ts
@@ -1,0 +1,83 @@
+import { cleanWpCliOutput } from "./commands.js"
+
+export interface WordPressAdminAuthCookie {
+  name?: string
+  value?: string
+  domain?: string
+  path?: string
+  expires?: number
+  httpOnly?: boolean
+  secure?: boolean
+  sameSite?: "Lax"
+}
+
+export function parseWordPressAdminAuthCookies(output: string): WordPressAdminAuthCookie[] {
+  return JSON.parse(cleanWpCliOutput(output)) as WordPressAdminAuthCookie[]
+}
+
+export function wordpressAdminAuthCookiePhpCode(browserUrls: string[], userId: number): string {
+  return `
+$user_id = ${JSON.stringify(userId)};
+$user = get_user_by( 'id', $user_id );
+if ( ! $user ) {
+    throw new RuntimeException( 'Browser auth requires the requested WordPress user to exist.' );
+}
+wp_set_current_user( $user_id );
+$expiration = time() + HOUR_IN_SECONDS;
+$token = '';
+if ( class_exists( 'WP_Session_Tokens' ) ) {
+    $token = WP_Session_Tokens::get_instance( $user_id )->create( $expiration );
+}
+$browser_urls = ${JSON.stringify(browserUrls)};
+$cookies = array();
+foreach ( $browser_urls as $browser_url ) {
+    $browser_host = wp_parse_url( $browser_url, PHP_URL_HOST );
+    if ( ! $browser_host ) {
+        continue;
+    }
+    $secure = 'https' === wp_parse_url( $browser_url, PHP_URL_SCHEME );
+    foreach ( array( array( AUTH_COOKIE, 'auth', false ), array( SECURE_AUTH_COOKIE, 'secure_auth', true ) ) as $admin_cookie ) {
+        $cookies[] = array(
+            'name'     => $admin_cookie[0],
+            'value'    => wp_generate_auth_cookie( $user_id, $expiration, $admin_cookie[1], $token ),
+            'domain'   => $browser_host,
+            'path'     => defined( 'ADMIN_COOKIE_PATH' ) && ADMIN_COOKIE_PATH ? ADMIN_COOKIE_PATH : '/wp-admin',
+            'expires'  => $expiration,
+            'httpOnly' => true,
+            'secure'   => $admin_cookie[2],
+            'sameSite' => 'Lax',
+        );
+    }
+    $logged_in_cookie = array(
+        'name'     => LOGGED_IN_COOKIE,
+        'value'    => wp_generate_auth_cookie( $user_id, $expiration, 'logged_in', $token ),
+        'domain'   => $browser_host,
+        'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
+        'expires'  => $expiration,
+        'httpOnly' => true,
+        'secure'   => $secure,
+        'sameSite' => 'Lax',
+    );
+    $cookies[] = $logged_in_cookie;
+    if ( defined( 'SITECOOKIEPATH' ) && SITECOOKIEPATH && SITECOOKIEPATH !== COOKIEPATH ) {
+        $logged_in_cookie['path'] = SITECOOKIEPATH;
+        $cookies[] = $logged_in_cookie;
+    }
+}
+echo wp_json_encode( $cookies );
+`
+}
+
+export function browserAuthCookieHostSummary(cookies: Array<{ domain?: string }>): Array<{ host: string; cookieCount: number }> {
+  const counts = new Map<string, number>()
+  for (const cookie of cookies) {
+    const host = normalizeBrowserCookieHost(String(cookie.domain ?? ""))
+    if (!host) continue
+    counts.set(host, (counts.get(host) ?? 0) + 1)
+  }
+  return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([host, cookieCount]) => ({ host, cookieCount }))
+}
+
+function normalizeBrowserCookieHost(host: string): string {
+  return host.trim().toLowerCase().replace(/:\d+$/, "")
+}

--- a/scripts/held-admin-preview-blocker-smoke.ts
+++ b/scripts/held-admin-preview-blocker-smoke.ts
@@ -36,10 +36,32 @@ assert.equal(blockedPreview.blockers[0].reviewerSafe, false)
 assert.equal(blockedPreview.blockers[0].retryable, false)
 assert.deepEqual(blockedPreview.blockers[0].evidence, { command: "wordpress.browser-actions", auth: "wordpress-admin" })
 
+const bootstrapPreview = heldPreviewWithExternalAccessBlockers({
+  ...heldPreview,
+  reviewerAuth: {
+    schema: "wp-codebox/preview-reviewer-auth/v1",
+    kind: "reviewer-auth-bootstrap",
+    auth: "wordpress-admin",
+    reviewerSafe: true,
+    url: "http://127.0.0.1:48631/_wp-codebox/reviewer-auth/bootstrap?token=redacted-smoke-token",
+    targetPath: "/wp-admin/post.php?post=24117035&action=edit",
+    expiresAt: "2026-06-15T00:15:00.000Z",
+    holdSeconds: 900,
+    userId: 1,
+    scope: {
+      runtimeId: "runtime-smoke",
+      origin: "http://127.0.0.1:48631",
+    },
+  },
+}, [command])
+assert.equal(bootstrapPreview?.blockers, undefined)
+assert.equal(bootstrapPreview?.reviewerAuth?.reviewerSafe, true)
+assert.equal(bootstrapPreview?.reviewerAuth?.targetPath, "/wp-admin/post.php?post=24117035&action=edit")
+
 const publicPreview = heldPreviewWithExternalAccessBlockers(heldPreview, [{ ...command, args: ["url=/"] }])
 assert.equal(publicPreview?.blockers, undefined)
 
 const expiredPreview = heldPreviewWithExternalAccessBlockers({ ...heldPreview, lifecycle: "destroyed-on-completion", status: "expired-on-completion", holdSeconds: undefined }, [command])
 assert.equal(expiredPreview?.blockers, undefined)
 
-console.log("Held admin preview blocker smoke passed")
+console.log("Held admin preview blocker/bootstrap smoke passed")

--- a/scripts/preview-reviewer-auth-bootstrap-smoke.ts
+++ b/scripts/preview-reviewer-auth-bootstrap-smoke.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict"
+import { createServer } from "node:http"
+import { createServer as createNetServer } from "node:net"
+import { withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+
+const target = createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "text/plain" })
+  response.end("target ok")
+})
+await listen(target, 0)
+const targetAddress = target.address()
+assert.ok(targetAddress && typeof targetAddress === "object")
+
+const fakeServer: PlaygroundCliServer = {
+  playground: {
+    async run() {
+      return {
+        text: JSON.stringify([
+          {
+            name: "wordpress_logged_in_smoke",
+            value: "fixture-cookie-value",
+            path: "/",
+            expires: Math.floor(Date.now() / 1000) + 60,
+            httpOnly: true,
+            secure: false,
+            sameSite: "Lax",
+          },
+        ]),
+      }
+    },
+  },
+  serverUrl: `http://127.0.0.1:${targetAddress.port}`,
+  async [Symbol.asyncDispose]() {},
+}
+
+const proxyPort = await reserveFreePort()
+const runtimeSpec = { backend: "wordpress-playground", environment: { kind: "wordpress" }, policy: {} } as RuntimeCreateSpec
+const proxy = await withPreviewProxy(fakeServer, proxyPort, "127.0.0.1", runtimeSpec)
+
+try {
+  assert.equal(typeof proxy.createReviewerAuthBootstrap, "function")
+  const reviewerAuth = await proxy.createReviewerAuthBootstrap?.({
+    runtimeId: "runtime-smoke",
+    targetPath: "/wp-admin/post.php?post=1&action=edit",
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    holdSeconds: 60,
+    userId: 1,
+  })
+
+  assert.equal(reviewerAuth?.schema, "wp-codebox/preview-reviewer-auth/v1")
+  assert.equal(reviewerAuth?.reviewerSafe, true)
+  assert.equal(reviewerAuth?.scope.origin, `http://127.0.0.1:${proxyPort}`)
+  assert.ok(reviewerAuth?.url.includes("/_wp-codebox/reviewer-auth/bootstrap?token="))
+
+  const response = await fetch(reviewerAuth!.url, { redirect: "manual" })
+  assert.equal(response.status, 302)
+  assert.equal(response.headers.get("location"), "/wp-admin/post.php?post=1&action=edit")
+  assert.match(response.headers.get("set-cookie") ?? "", /wordpress_logged_in_smoke=fixture-cookie-value/)
+  assert.match(response.headers.get("cache-control") ?? "", /no-store/)
+} finally {
+  await proxy[Symbol.asyncDispose]()
+  await close(target)
+}
+
+console.log("Preview reviewer auth bootstrap smoke passed")
+
+async function reserveFreePort(): Promise<number> {
+  const server = createNetServer()
+  await listen(server, 0)
+  const address = server.address()
+  assert.ok(address && typeof address === "object")
+  const port = address.port
+  await close(server)
+  return port
+}
+
+function listen(server: ReturnType<typeof createServer> | ReturnType<typeof createNetServer>, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(port, "127.0.0.1", () => resolve())
+  })
+}
+
+function close(server: ReturnType<typeof createServer> | ReturnType<typeof createNetServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -185,6 +185,7 @@ export const smokeGroups = {
       tsxSmoke("preview-response-body-smoke"),
       tsxSmoke("browser-startup-progress-smoke"),
       tsxSmoke("held-admin-preview-blocker-smoke"),
+      tsxSmoke("preview-reviewer-auth-bootstrap-smoke"),
       tsxSmoke("recipe-browser-probe-liveness-smoke"),
       tsxSmoke("boot-preview-smoke"),
       tsxSmoke("blueprint-validation-smoke"),


### PR DESCRIPTION
## Summary
- Adds a local preview proxy bootstrap endpoint for held `auth=wordpress-admin` reviewer flows.
- Emits a structured `reviewerAuth` preview artifact only when the bootstrap URL is available and reviewer-safe.
- Preserves `external-wordpress-admin-auth-unavailable` blockers for unsupported held admin preview cases.

## Verification
- `npx tsx scripts/held-admin-preview-blocker-smoke.ts`
- `npx tsx scripts/preview-reviewer-auth-bootstrap-smoke.ts`
- `npm run smoke -- --group=preview`
- `npm run build`

## Downstream rerun
After this lands and `wpcom-codebox` consumes the updated `wp-codebox`, rerun the `/ai` held-preview proof with a proxied local preview port so the artifact can expose `preview.reviewerAuth.url`:

```bash
homeboy agent-task run wpcom-codebox --prompt 'Rerun the wordpress.com/ai held-preview proof for Automattic/wpcom-codebox#237 against the wp-codebox reviewer auth bootstrap build. Use auth=wordpress-admin, --preview-hold, --preview-hold-blocking, and a local --preview-port so the reviewer bootstrap URL can be emitted. Verify artifacts suppress misleading editor URLs only when reviewerAuth is absent, and report the reviewerAuth URL shape without printing token values.'
```

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementation and verification of the reviewer bootstrap auth contract and focused smoke coverage; Chris remains responsible for review and merge.