### PR TITLE
Add reviewer auth bootstrap for held previews

### DIFF
--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -660,6 +660,7 @@ export interface ArtifactPreviewSessionEvidence {
     holdSeconds?: number
     hasPublicUrl: boolean
     hasSiteUrl: boolean
+    hasReviewerAuthBootstrap?: boolean
     blockers?: ArtifactPreviewBlocker[]
   }
   refs: {
@@ -692,6 +693,21 @@ export interface ArtifactPreview {
   expiresAt?: string
   holdSeconds?: number
   blockers?: ArtifactPreviewBlocker[]
+  reviewerAuthBootstrap?: ArtifactReviewerAuthBootstrap
+}
+
+export interface ArtifactReviewerAuthBootstrap {
+  schema: "wp-codebox/reviewer-auth-bootstrap/v1"
+  kind: "local-wordpress-admin-fixture"
+  reviewerSafe: true
+  bootstrapUrl: string
+  redirectUrl: string
+  expiresAt: string
+  evidence: {
+    command: string
+    auth: "wordpress-admin"
+    userId: number
+  }
 }
 
 export interface ArtifactPreviewBlocker {
@@ -758,6 +774,7 @@ export interface ArtifactPreviewEvidence {
     localUrl?: ArtifactPreviewUrlRef
     siteUrl?: ArtifactPreviewUrlRef
     durablePreview?: ArtifactDurablePreviewRef
+    reviewerAuthBootstrap?: ArtifactReviewerAuthBootstrap
     blockers?: ArtifactPreviewBlocker[]
   }
   readiness: {

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -62,7 +62,7 @@ export interface ArtifactBundleBuilderSource {
   snapshots: Snapshot[]
   events: LifecycleEvent[]
   info(): Promise<RuntimeInfo>
-  previewInfo(createdAt: string, previewHoldSeconds?: number): Promise<ArtifactPreview | undefined>
+  previewInfo(createdAt: string, previewHoldSeconds: number | undefined, commands: ExecutionResult[]): Promise<ArtifactPreview | undefined>
   browserReviewSummary(): ArtifactReviewBrowserSummary | undefined
   browserArtifacts(): BrowserArtifact[]
   captureMountedFiles(filesDirectory: string, redactor: ArtifactRedactor): Promise<CapturedMountFiles>
@@ -122,7 +122,7 @@ export class ArtifactBundleBuilder {
     await source.redactPluginCheckArtifacts(redactor)
     await source.redactThemeCheckArtifacts(redactor)
 
-    const preview = heldPreviewWithExternalAccessBlockers(await source.previewInfo(createdAt, spec.previewHoldSeconds), source.commands)
+    const preview = heldPreviewWithExternalAccessBlockers(await source.previewInfo(createdAt, spec.previewHoldSeconds, source.commands), source.commands)
     const browser = source.browserReviewSummary()
     const runtime = await source.info()
     const durablePreview = await buildDurableArtifactPreview({
@@ -641,6 +641,7 @@ function buildPreviewEvidence({
       ...(preview?.localUrl ? { localUrl: safePreviewUrlRef(preview.localUrl) } : {}),
       ...(preview?.siteUrl ? { siteUrl: safePreviewUrlRef(preview.siteUrl) } : {}),
       ...(durablePreview ? { durablePreview } : {}),
+      ...(preview?.reviewerAuthBootstrap ? { reviewerAuthBootstrap: preview.reviewerAuthBootstrap } : {}),
     },
     readiness: {
       ready,
@@ -771,6 +772,7 @@ function buildPreviewSessionEvidence({
       holdSeconds: preview.holdSeconds,
       hasPublicUrl: Boolean(preview.publicUrl),
       hasSiteUrl: Boolean(preview.siteUrl),
+      hasReviewerAuthBootstrap: Boolean(preview.reviewerAuthBootstrap),
       blockers: preview.blockers,
     }) : undefined,
     refs: stripUndefined({
@@ -799,6 +801,10 @@ export function heldPreviewWithExternalAccessBlockers(preview: ArtifactPreview |
 
   const authCommand = commands.find((command) => browserCommandRequestsWordPressAdminAuth(command))
   if (!authCommand) {
+    return preview
+  }
+
+  if (preview.reviewerAuthBootstrap) {
     return preview
   }
 

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -5241,7 +5241,7 @@ async function installWordPressAdminAuthCookies({
   return { mode: "wordpress-admin", userId, cookieCount: cookies.length, cookieHosts: browserAuthCookieHostSummary(cookies) }
 }
 
-function wordpressAdminAuthCookiePhpCode(browserUrls: string[], userId: number): string {
+export function wordpressAdminAuthCookiePhpCode(browserUrls: string[], userId: number): string {
   return `
 $user_id = ${JSON.stringify(userId)};
 $user = get_user_by( 'id', $user_id );

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -116,14 +116,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       fixedPreviewPort: spec.preview?.port ?? null,
     })
 
-    if (!spec.preview?.port) {
-      emitProgress("preview:ready", "complete", "Preview ready", {
-        localUrl: server.serverUrl,
-      })
-      return server
-    }
-
-    const proxiedServer = await withPreviewProxy(server, spec.preview.port, spec.preview.bind)
+    const proxiedServer = await withPreviewProxy(server, spec.preview?.port ?? 0, spec.preview?.bind)
     emitProgress("preview:ready", "complete", "Preview ready", {
       localUrl: proxiedServer.serverUrl,
       upstreamUrl: server.serverUrl,

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1,9 +1,10 @@
-import { createHash } from "node:crypto"
+import { createHash, randomBytes } from "node:crypto"
 import { mkdir, realpath, writeFile } from "node:fs/promises"
+import type { IncomingMessage, ServerResponse } from "node:http"
 import { dirname, join, resolve } from "node:path"
 import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, createHostToolRegistry, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
-import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand } from "./browser-command-runners.js"
+import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand, wordpressAdminAuthCookiePhpCode } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
 import { cleanWpCliOutput, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
@@ -21,6 +22,7 @@ import { preflightPhpWasmRuntimeAssets } from "./php-wasm-preflight.js"
 import type {
   ArtifactBundle,
   ArtifactPreview,
+  ArtifactReviewerAuthBootstrap,
   ArtifactSpec,
   ExecutionResult,
   ExecutionSpec,
@@ -43,6 +45,92 @@ function now(): string {
 
 function id(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+interface ReviewerAuthBootstrapRecord {
+  expiresAt: string
+  redirectUrl: string
+  serverUrl: string
+  userId: number
+}
+
+function browserCommandRequestsWordPressAdminAuth(command: ExecutionResult): boolean {
+  if (!["wordpress.browser-actions", "wordpress.browser-probe", "wordpress.browser-scenario", "wordpress.visual-compare"].includes(command.command)) {
+    return false
+  }
+
+  return command.args.some((arg) => argRequestsWordPressAdminAuth(arg))
+}
+
+function argRequestsWordPressAdminAuth(arg: string): boolean {
+  const separator = arg.indexOf("=")
+  if (separator > 0) {
+    const key = arg.slice(0, separator).trim()
+    const value = arg.slice(separator + 1).trim()
+    if (key === "auth" && value === "wordpress-admin") {
+      return true
+    }
+    if ((key === "scenario" || key === "scenario-json") && /"auth"\s*:\s*"wordpress-admin"/.test(value)) {
+      return true
+    }
+  }
+
+  return /"auth"\s*:\s*"wordpress-admin"/.test(arg)
+}
+
+function browserCommandWordPressAdminAuthUserId(command: ExecutionResult): number {
+  const raw = command.args.map((arg) => argKeyValue(arg)).find((entry) => entry?.key === "auth-user-id")?.value
+  const userId = raw ? Number.parseInt(raw, 10) : 1
+  return Number.isInteger(userId) && userId > 0 ? userId : 1
+}
+
+function reviewerAuthRedirectUrl(command: ExecutionResult, serverUrl: string): string | undefined {
+  const url = command.args.map((arg) => argKeyValue(arg)).find((entry) => entry?.key === "url")?.value
+  if (!url) {
+    return undefined
+  }
+
+  try {
+    return new URL(url, serverUrl).toString()
+  } catch {
+    return undefined
+  }
+}
+
+function argKeyValue(arg: string): { key: string; value: string } | undefined {
+  const separator = arg.indexOf("=")
+  if (separator <= 0) {
+    return undefined
+  }
+  return {
+    key: arg.slice(0, separator).trim(),
+    value: arg.slice(separator + 1).trim(),
+  }
+}
+
+function isLocalPreviewUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, "")
+    return hostname === "localhost" || hostname === "0.0.0.0" || hostname === "127.0.0.1" || hostname === "::1" || hostname.startsWith("127.")
+  } catch {
+    return false
+  }
+}
+
+function reviewerAuthSetCookieHeader(cookie: { name?: string; value?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: "Lax" }): string {
+  const parts = [
+    `${String(cookie.name ?? "")}=${String(cookie.value ?? "")}`,
+    `Path=${typeof cookie.path === "string" && cookie.path.length > 0 ? cookie.path : "/"}`,
+    `Expires=${new Date((typeof cookie.expires === "number" ? cookie.expires : Math.floor(Date.now() / 1000) + 3600) * 1000).toUTCString()}`,
+    "SameSite=Lax",
+  ]
+  if (cookie.httpOnly !== false) {
+    parts.push("HttpOnly")
+  }
+  if (cookie.secure === true) {
+    parts.push("Secure")
+  }
+  return parts.join("; ")
 }
 
 export class PlaygroundRuntimeBackend implements RuntimeBackend {
@@ -81,6 +169,8 @@ class PlaygroundRuntime implements Runtime {
   private cliServerPromise?: Promise<PlaygroundCliServer>
   private readonly activeExecutionAbortControllers = new Set<AbortController>()
   private activeExecutionSignal?: AbortSignal
+  private reviewerAuthBootstrapRouteRegistered = false
+  private readonly reviewerAuthBootstraps = new Map<string, ReviewerAuthBootstrapRecord>()
 
   private constructor(private readonly spec: RuntimeCreateSpec, private readonly backendOptions: PlaygroundRuntimeBackendOptions = {}) {
     this.artifactRoot = resolve(spec.artifactsDirectory ?? "artifacts", this.runtimeId)
@@ -376,7 +466,7 @@ class PlaygroundRuntime implements Runtime {
       snapshots: this.snapshots,
       events: this.events,
       info: () => this.info(),
-      previewInfo: (createdAt, previewHoldSeconds) => this.previewInfo(createdAt, previewHoldSeconds),
+      previewInfo: (createdAt, previewHoldSeconds, commands) => this.previewInfo(createdAt, previewHoldSeconds, commands),
       recordArtifactsCollected: (bundleId, createdAt, artifactSpec) => this.recordEvent("runtime.artifacts.collected", {
         id: bundleId,
         directory: this.artifactRoot,
@@ -423,7 +513,7 @@ class PlaygroundRuntime implements Runtime {
     }
   }
 
-  private async previewInfo(createdAt: string, holdSeconds = 0): Promise<ArtifactPreview | undefined> {
+  private async previewInfo(createdAt: string, holdSeconds = 0, commands: ExecutionResult[] = []): Promise<ArtifactPreview | undefined> {
     if (this.status === "destroyed") {
       return undefined
     }
@@ -434,7 +524,7 @@ class PlaygroundRuntime implements Runtime {
     const publicUrl = this.spec.preview?.publicUrl
     const siteUrl = this.spec.preview?.siteUrl
 
-    return {
+    const preview: ArtifactPreview = {
       url: publicUrl ?? server.serverUrl,
       ...(publicUrl ? { publicUrl, localUrl: server.serverUrl } : {}),
       ...(siteUrl ? { siteUrl } : {}),
@@ -444,6 +534,90 @@ class PlaygroundRuntime implements Runtime {
       createdAt,
       ...(expiresAt ? { expiresAt, holdSeconds: normalizedHoldSeconds } : {}),
     }
+
+    const reviewerAuthBootstrap = expiresAt ? this.createReviewerAuthBootstrap(server, preview, expiresAt, commands) : undefined
+    return {
+      ...preview,
+      ...(reviewerAuthBootstrap ? { reviewerAuthBootstrap } : {}),
+    }
+  }
+
+  private createReviewerAuthBootstrap(server: PlaygroundCliServer, preview: ArtifactPreview, expiresAt: string, commands: ExecutionResult[]): ArtifactReviewerAuthBootstrap | undefined {
+    const authCommand = commands.find((command) => browserCommandRequestsWordPressAdminAuth(command))
+    if (!authCommand || !server.previewRoutes || !isLocalPreviewUrl(preview.localUrl ?? preview.url)) {
+      return undefined
+    }
+
+    this.registerReviewerAuthBootstrapRoute(server)
+    const token = randomBytes(24).toString("base64url")
+    const userId = browserCommandWordPressAdminAuthUserId(authCommand)
+    const redirectUrl = reviewerAuthRedirectUrl(authCommand, server.serverUrl) ?? server.serverUrl
+    this.reviewerAuthBootstraps.set(token, {
+      expiresAt,
+      redirectUrl,
+      serverUrl: server.serverUrl,
+      userId,
+    })
+
+    const bootstrapUrl = new URL("/__wp-codebox/reviewer-auth-bootstrap", server.serverUrl)
+    bootstrapUrl.searchParams.set("token", token)
+    return {
+      schema: "wp-codebox/reviewer-auth-bootstrap/v1",
+      kind: "local-wordpress-admin-fixture",
+      reviewerSafe: true,
+      bootstrapUrl: bootstrapUrl.toString(),
+      redirectUrl,
+      expiresAt,
+      evidence: {
+        command: authCommand.command,
+        auth: "wordpress-admin",
+        userId,
+      },
+    }
+  }
+
+  private registerReviewerAuthBootstrapRoute(server: PlaygroundCliServer): void {
+    if (this.reviewerAuthBootstrapRouteRegistered || !server.previewRoutes) {
+      return
+    }
+
+    this.reviewerAuthBootstrapRouteRegistered = true
+    server.previewRoutes.add((incoming, outgoing) => this.handleReviewerAuthBootstrapRequest(server, incoming, outgoing))
+  }
+
+  private async handleReviewerAuthBootstrapRequest(server: PlaygroundCliServer, incoming: IncomingMessage, outgoing: ServerResponse): Promise<boolean> {
+    const requestUrl = new URL(incoming.url ?? "/", server.serverUrl)
+    if (requestUrl.pathname !== "/__wp-codebox/reviewer-auth-bootstrap") {
+      return false
+    }
+
+    const token = requestUrl.searchParams.get("token") ?? ""
+    const record = this.reviewerAuthBootstraps.get(token)
+    if (!record || Date.parse(record.expiresAt) <= Date.now()) {
+      this.writeReviewerAuthBootstrapResponse(outgoing, 410, "Reviewer auth bootstrap expired or unavailable.\n")
+      return true
+    }
+
+    const response = await this.runPlaygroundCommand("reviewer-auth-bootstrap.auth", server, { code: bootstrapPhpCode(this.spec, wordpressAdminAuthCookiePhpCode([record.serverUrl], record.userId), []) })
+    assertPlaygroundResponseOk("reviewer-auth-bootstrap.auth", response)
+    const cookies = JSON.parse(cleanWpCliOutput(response.text)) as Array<{ name?: string; value?: string; path?: string; expires?: number; httpOnly?: boolean; secure?: boolean; sameSite?: "Lax" }>
+    outgoing.writeHead(302, {
+      "location": record.redirectUrl,
+      "cache-control": "no-store",
+      "set-cookie": cookies.map((cookie) => reviewerAuthSetCookieHeader(cookie)),
+    })
+    outgoing.end()
+    return true
+  }
+
+  private writeReviewerAuthBootstrapResponse(outgoing: ServerResponse, status: number, message: string): void {
+    const body = Buffer.from(message, "utf8")
+    outgoing.writeHead(status, {
+      "content-type": "text/plain; charset=utf-8",
+      "content-length": String(body.byteLength),
+      "cache-control": "no-store",
+    })
+    outgoing.end(body)
   }
 
   private recordEvent(type: LifecycleEvent["type"], data?: Record<string, unknown>): LifecycleEvent {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -15,11 +15,19 @@ export interface PlaygroundCliServer {
     writeFile?(path: string, contents: string): Promise<void>
   }
   serverUrl: string
+  previewRoutes?: PlaygroundPreviewRouteRegistry
   [Symbol.asyncDispose](): Promise<void>
 }
 
+export interface PlaygroundPreviewRouteRegistry {
+  add(handler: PlaygroundPreviewRouteHandler): () => void
+}
+
+export type PlaygroundPreviewRouteHandler = (incoming: IncomingMessage, outgoing: ServerResponse) => Promise<boolean> | boolean
+
 interface PlaygroundPreviewProxy {
   serverUrl: string
+  previewRoutes: PlaygroundPreviewRouteRegistry
   dispose(): Promise<void>
 }
 
@@ -46,6 +54,7 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
   return {
     ...server,
     serverUrl: proxy.serverUrl,
+    previewRoutes: proxy.previewRoutes,
     async [Symbol.asyncDispose]() {
       await proxy.dispose()
       await server[Symbol.asyncDispose]()
@@ -55,13 +64,14 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
 
 async function startPreviewProxy(targetUrl: string, port: number, bind: string): Promise<PlaygroundPreviewProxy> {
   const target = new URL(targetUrl)
-  const proxy = previewProxyServer(target)
+  const routes = createPreviewRouteRegistry()
+  const proxy = previewProxyServer(target, routes)
   const servers = [proxy]
 
   await listenPreviewProxy(proxy, port, bind)
 
   if (bind === "127.0.0.1") {
-    const ipv6Proxy = previewProxyServer(target)
+    const ipv6Proxy = previewProxyServer(target, routes)
     try {
       await listenPreviewProxy(ipv6Proxy, port, "::1")
       servers.push(ipv6Proxy)
@@ -79,18 +89,50 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
 
   return {
     serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
+    previewRoutes: routes,
     async dispose() {
       await closePreviewProxyServers(servers)
     },
   }
 }
 
-function previewProxyServer(target: URL): PreviewProxyServer {
+function previewProxyServer(target: URL, routes: InternalPreviewRouteRegistry): PreviewProxyServer {
   const upstreamQueue = createPreviewProxyQueue()
 
-  return createHttpServer((incoming, outgoing) => {
+  return createHttpServer(async (incoming, outgoing) => {
+    try {
+      if (await routes.handle(incoming, outgoing)) {
+        return
+      }
+    } catch (error) {
+      writeProxyError(outgoing, error instanceof Error ? error : new Error(String(error)))
+      return
+    }
+
     upstreamQueue(() => proxyPreviewRequest(target, incoming, outgoing)).catch((error: Error) => writeProxyError(outgoing, error))
   })
+}
+
+interface InternalPreviewRouteRegistry extends PlaygroundPreviewRouteRegistry {
+  handle(incoming: IncomingMessage, outgoing: ServerResponse): Promise<boolean>
+}
+
+function createPreviewRouteRegistry(): InternalPreviewRouteRegistry {
+  const handlers = new Set<PlaygroundPreviewRouteHandler>()
+  return {
+    add(handler) {
+      handlers.add(handler)
+      return () => handlers.delete(handler)
+    },
+    async handle(incoming, outgoing) {
+      for (const handler of handlers) {
+        if (await handler(incoming, outgoing)) {
+          return true
+        }
+      }
+      return false
+    },
+  }
 }
 
 function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {

--- a/packages/runtime-playground/src/runtime-artifact-helpers.ts
+++ b/packages/runtime-playground/src/runtime-artifact-helpers.ts
@@ -47,7 +47,7 @@ export async function collectPlaygroundArtifacts({
   mounts: MountSpec[]
   observations: ObservationResult[]
   pluginChecks: PluginCheckArtifact[]
-  previewInfo: (createdAt: string, holdSeconds: number) => Promise<ArtifactPreview | undefined>
+  previewInfo: (createdAt: string, holdSeconds: number, commands: ExecutionResult[]) => Promise<ArtifactPreview | undefined>
   recordArtifactsCollected: (bundleId: string, createdAt: string, artifactSpec: ArtifactSpec) => void
   runtimeId: string
   snapshots: Snapshot[]

--- a/scripts/artifact-contract-smoke.ts
+++ b/scripts/artifact-contract-smoke.ts
@@ -110,12 +110,16 @@ try {
   assert.equal(blueprintAfterManifestFile.viewer.query.value.source, "public-artifact-url")
   assert.equal(blueprintAfterManifestFile.viewer.query.value.path, "blueprint.after.json")
   assert.equal(blueprintAfterManifestFile.viewer.query.encoding, "url")
-  assert.equal(blueprintAfterManifestFile.viewer.replay.status, "partial")
-  assert.ok(blueprintAfterManifestFile.viewer.replay.limitations.some((limitation: string) => limitation.includes("does not host public artifact URLs")))
+  assert.equal(blueprintAfterManifestFile.viewer.replay.status, "replayable-runtime-state")
+  assert.ok(blueprintAfterManifestFile.viewer.replay.limitations.some((limitation: string) => limitation.includes("runtime-state snapshot")))
   assert.deepEqual(artifacts.blueprintAfterViewer, blueprintAfterManifestFile.viewer)
   const runtimeEvidence = metadata.artifacts.runtimeEvidence
   assert.match(runtimeEvidence["run-attestation"].sha256, /^[a-f0-9]{64}$/)
-  assert.deepEqual(metadata.artifacts, {
+  assert.ok(Array.isArray(metadata.artifacts.runtimeSnapshots))
+  assert.ok(metadata.artifacts.runtimeSnapshots.length > 0)
+  assert.ok(metadata.artifacts.runtimeSnapshots.every((path: string) => path.startsWith("files/runtime-snapshots/") && path.endsWith(".json")))
+  const { runtimeSnapshots: _runtimeSnapshots, ...metadataArtifactsWithoutRuntimeSnapshots } = metadata.artifacts
+  assert.deepEqual(metadataArtifactsWithoutRuntimeSnapshots, {
     workspacePatch: "files/workspace-patch.json",
     changedFiles: "files/changed-files.json",
     patch: "files/patch.diff",
@@ -262,11 +266,11 @@ try {
   assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.kind, "blueprint-after")
   assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.contentType, "application/json")
   assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.query.value.sha256.value, blueprintAfterManifestFile.sha256.value)
-  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.replay.status, "partial")
+  assert.equal(runtimeReplayReferenceIndex.references.blueprintAfter.viewer.replay.status, "replayable-runtime-state")
   assert.equal(runtimeReplayReferenceIndex.references.changedFiles.path, "files/changed-files.json")
   assert.equal(runtimeReplayReferenceIndex.references.patch.path, "files/patch.diff")
-  assert.equal(runtimeReplayReferenceIndex.replay.status, "partial")
-  assert.equal(runtimeReplayReferenceIndex.snapshots.length, 0)
+  assert.equal(runtimeReplayReferenceIndex.replay.status, "runtime-state-artifact")
+  assert.ok(runtimeReplayReferenceIndex.snapshots.length > 0)
   assert.equal(runtimeReferenceManifest.schema, RUNTIME_REFERENCE_MANIFEST_SCHEMA)
   const runtimeReferenceManifestFile = manifestFile(manifest, "files/runtime-reference-manifest.json")
   assert.equal(runtimeReferenceManifestFile.sha256.value, sha256(await readFile(join(artifacts.directory, "files/runtime-reference-manifest.json"))))
@@ -282,8 +286,8 @@ try {
   assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.kind, "blueprint-after")
   assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.contentType, "application/json")
   assert.equal(runtimeReferenceManifestBlueprintViewer.query.value.sha256.value, blueprintAfterManifestFile.sha256.value)
-  assert.equal(runtimeReferenceManifestBlueprintViewer.replay.status, "partial")
-  assert.equal(runtimeReferenceManifest.snapshots.length, 0)
+  assert.equal(runtimeReferenceManifestBlueprintViewer.replay.status, "replayable-runtime-state")
+  assert.ok(runtimeReferenceManifest.snapshots.length > 0)
   assert.ok(runtimeReferenceManifest.files.some((file: { path: string }) => file.path === "files/runtime-reference-index.json"))
   assert.ok(runtimeReferenceManifest.files.some((file: { path: string }) => file.path === "files/changed-files.json"))
   assert.ok(review.changedFiles.some((file: { path: string; status: string }) =>

--- a/scripts/held-admin-preview-blocker-smoke.ts
+++ b/scripts/held-admin-preview-blocker-smoke.ts
@@ -39,6 +39,22 @@ assert.deepEqual(blockedPreview.blockers[0].evidence, { command: "wordpress.brow
 const publicPreview = heldPreviewWithExternalAccessBlockers(heldPreview, [{ ...command, args: ["url=/"] }])
 assert.equal(publicPreview?.blockers, undefined)
 
+const bootstrapPreview = heldPreviewWithExternalAccessBlockers({
+  ...heldPreview,
+  reviewerAuthBootstrap: {
+    schema: "wp-codebox/reviewer-auth-bootstrap/v1",
+    kind: "local-wordpress-admin-fixture",
+    reviewerSafe: true,
+    bootstrapUrl: "http://127.0.0.1:48631/__wp-codebox/reviewer-auth-bootstrap?token=short-lived",
+    redirectUrl: "http://127.0.0.1:48631/wp-admin/post.php?post=24117035&action=edit",
+    expiresAt: "2026-06-15T00:15:00.000Z",
+    evidence: { command: "wordpress.browser-actions", auth: "wordpress-admin", userId: 1 },
+  },
+}, [command])
+assert.equal(bootstrapPreview?.blockers, undefined)
+assert.equal(bootstrapPreview?.reviewerAuthBootstrap?.schema, "wp-codebox/reviewer-auth-bootstrap/v1")
+assert.equal(bootstrapPreview?.reviewerAuthBootstrap?.reviewerSafe, true)
+
 const expiredPreview = heldPreviewWithExternalAccessBlockers({ ...heldPreview, lifecycle: "destroyed-on-completion", status: "expired-on-completion", holdSeconds: undefined }, [command])
 assert.equal(expiredPreview?.blockers, undefined)
 

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -83,6 +83,7 @@ export const smokeGroups = {
       tsxSmoke("mounted-workspace-diff-smoke"),
       tsxSmoke("artifact-contract-smoke"),
       tsxSmoke("durable-artifact-preview-smoke"),
+      tsxSmoke("held-admin-preview-blocker-smoke"),
       tsxSmoke("replayable-wordpress-site-bundle-smoke"),
       tsxSmoke("external-adapter-contract-smoke"),
     ],


### PR DESCRIPTION
## Summary
- Add a local preview proxy route registry so live Playground previews can expose runtime-scoped helper routes.
- Emit `wp-codebox/reviewer-auth-bootstrap/v1` for held local `auth=wordpress-admin` previews, with a short-lived bootstrap URL that sets local fixture admin cookies and redirects to the intended admin URL.
- Keep unsupported held admin previews on the existing `external-wordpress-admin-auth-unavailable` blocker path, and refresh artifact replay contract smoke assertions.

## Testing
- `npx tsx scripts/held-admin-preview-blocker-smoke.ts`
- `npm run build`
- `npm run smoke -- --group=artifact`

## Downstream rerun
After this lands, rerun the `wpcom-codebox` `/ai` held-preview proof against a WP Codebox build that includes this branch. The downstream proof should inspect `artifacts.preview.reviewerAuthBootstrap` or `files/preview-evidence.json.preview.reviewerAuthBootstrap`, open the `bootstrapUrl` in a normal browser, and verify it redirects to the local `/wp-admin/post.php?post=24117035&action=edit` target as the local fixture admin user. Unsupported/non-local admin previews should still surface `external-wordpress-admin-auth-unavailable`.

Closes #972.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, updated smoke coverage, and ran focused verification. Chris remains responsible for review and final validation.