### PR TITLE
Extract browser runner bootstrap template

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Browser runner generated PHP templates.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** String-only builders for generated browser runner PHP fragments. */
+final class WP_Codebox_Browser_Runner_Template {
+	/**
+	 * Builds the generated PHP bootstrap fragment for the browser runner.
+	 *
+	 * @param string                  $task_path   Absolute Playground path for the staged task payload.
+	 * @param string                  $result_path Absolute Playground path for runner result output.
+	 * @param array<string,mixed>     $payload     Default runner payload.
+	 * @param array<string,mixed>     $invocation  Normalized runner invocation.
+	 * @param array<int,array<string,mixed>> $captures Normalized capture paths.
+	 */
+	public static function bootstrap_fragment( string $task_path, string $result_path, array $payload, array $invocation, array $captures ): string {
+		return '<?php
+$_GET[\'rest_route\'] = \'/wp-codebox/browser-runner\';
+require_once \'/wordpress/wp-load.php\';
+
+if ( function_exists( \'get_current_user_id\' ) && function_exists( \'wp_set_current_user\' ) && get_current_user_id() <= 0 ) {
+	wp_set_current_user( 1 );
+}
+
+$task_path = ' . var_export( $task_path, true ) . ';
+$result_path = ' . var_export( $result_path, true ) . ';
+$event_path = "/tmp/wp-codebox-agent-events.jsonl";
+$payload = ' . var_export( $payload, true ) . ';
+$invocation = ' . var_export( $invocation, true ) . ';
+$capture_paths = ' . var_export( $captures, true ) . ';
+$started_at = gmdate( \'c\' );
+$started_monotonic = microtime( true );
+';
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -188,23 +188,7 @@ private static function browser_agent_runner_php( array $task_input, string $ses
 	$default_invocation = $invocation;
 	$default_captures   = $captures;
 
-	return '<?php
-$_GET[\'rest_route\'] = \'/wp-codebox/browser-runner\';
-require_once \'/wordpress/wp-load.php\';
-
-if ( function_exists( \'get_current_user_id\' ) && function_exists( \'wp_set_current_user\' ) && get_current_user_id() <= 0 ) {
-	wp_set_current_user( 1 );
-}
-
-$task_path = ' . var_export( $task_path, true ) . ';
-$result_path = ' . var_export( $result_path, true ) . ';
-$event_path = "/tmp/wp-codebox-agent-events.jsonl";
-$payload = ' . var_export( $default_payload, true ) . ';
-$invocation = ' . var_export( $default_invocation, true ) . ';
-$capture_paths = ' . var_export( $default_captures, true ) . ';
-$started_at = gmdate( \'c\' );
-$started_monotonic = microtime( true );
-
+		return WP_Codebox_Browser_Runner_Template::bootstrap_fragment( $task_path, $result_path, $default_payload, $default_invocation, $default_captures ) . '
 function wp_codebox_browser_normalize_error( $error ) {
 if ( is_wp_error( $error ) ) {
 	return array(

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/src/class-wp-codebox-host-tool-policy-validator.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-recipe-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-run-result-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-parent-site-seed-exporter.php';
+require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-data-machine-pending-actions.php';

--- a/scripts/package-distribution-smoke.ts
+++ b/scripts/package-distribution-smoke.ts
@@ -92,6 +92,7 @@ assert.ok(zipEntries.has("wp-codebox/wp-codebox.php"), "Plugin zip should includ
 assert.ok(zipEntries.has("wp-codebox/README.md"), "Plugin zip should include README.md")
 assert.ok(zipEntries.has("wp-codebox/assets/browser-runtime.js"), "Plugin zip should include the checked-in browser runtime asset")
 assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-abilities.php"), "Plugin zip should include ability surface")
+assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-browser-runner-template.php"), "Plugin zip should include browser runner templates")
 assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-agent-sandbox-runner.php"), "Plugin zip should include sandbox runner")
 assert.ok(zipEntries.has("wp-codebox/src/class-wp-codebox-artifacts.php"), "Plugin zip should include artifact helpers")
 assert.ok(zipEntries.has("wp-codebox/vendor/wp-codebox-cli/bin/wp-codebox"), "Plugin zip should include packaged CLI wrapper")

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -203,6 +203,7 @@ require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-tool-
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-parent-site-seed-exporter.php';
+require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php';
@@ -1445,6 +1446,25 @@ add_filter(
 $runner_php = (string) ( $browser_session['recipe']['workflow']['steps'][0]['args'][0] ?? '' );
 $assert( 'browser Playground generated runner has no Studio Web-specific artifact paths', ! str_contains( $runner_php, '/wordpress/wp-content/uploads/studio-web' ) && ! str_contains( $runner_php, 'studio-web/website' ) );
 $assert( 'browser Playground generated runner defaults to generic Codebox artifacts path', str_contains( $runner_php, '/wordpress/wp-content/uploads/wp-codebox/artifacts' ) && str_contains( $runner_php, 'wp-codebox-output/' ) );
+$bootstrap_fragment = WP_Codebox_Browser_Runner_Template::bootstrap_fragment(
+	'/tmp/wp-codebox-agent-task.json',
+	'/tmp/wp-codebox-agent-result.json',
+	array(
+		'agent'      => 'wp-codebox-sandbox',
+		'message'    => 'Prepare a browser Playground preview.',
+		'session_id' => 'session-template-smoke',
+	),
+	array(
+		'type' => 'task',
+		'hook' => 'caller_runtime_task',
+	),
+	array(
+		array(
+			'path' => '/wordpress/wp-content/uploads/wp-codebox/artifacts/materialization/report.json',
+		),
+	)
+);
+$assert( 'browser runner bootstrap template emits narrow generated PHP prelude', str_starts_with( $bootstrap_fragment, '<?php' ) && str_contains( $bootstrap_fragment, "\$task_path = '/tmp/wp-codebox-agent-task.json';" ) && str_contains( $bootstrap_fragment, "\$result_path = '/tmp/wp-codebox-agent-result.json';" ) && str_contains( $bootstrap_fragment, "\$event_path = \"/tmp/wp-codebox-agent-events.jsonl\";" ) && str_contains( $bootstrap_fragment, "'session_id' => 'session-template-smoke'" ) );
 $runner_contract = $browser_session['recipe']['browser']['runner_contract'] ?? array();
 $assert( 'browser Playground recipe exposes reusable runner PHP contract prelude', is_array( $runner_contract ) && 'wp-codebox/browser-runner-contract/v1' === ( $runner_contract['schema'] ?? '' ) && str_contains( (string) ( $runner_contract['php_prelude'] ?? '' ), 'function wp_codebox_browser_artifact_environment' ) && str_contains( (string) ( $runner_contract['php_prelude'] ?? '' ), '$wp_codebox_is_playground' ) && str_contains( (string) ( $runner_contract['php_prelude'] ?? '' ), '$capture_paths' ) );
 $assert( 'browser Playground recipe exposes reusable runner PHP contract footer', is_array( $runner_contract ) && str_contains( (string) ( $runner_contract['php_footer'] ?? '' ), 'wp_codebox_browser_artifact_capture_diagnostics' ) && str_contains( (string) ( $runner_contract['php_footer'] ?? '' ), 'file_put_contents( $result_path' ) );


### PR DESCRIPTION
## Summary
- Extracts the generated browser runner bootstrap/payload prelude into `WP_Codebox_Browser_Runner_Template::bootstrap_fragment()` with narrow string-builder inputs.
- Keeps the surrounding browser runner orchestration and generated PHP behavior unchanged.
- Adds smoke coverage for the extracted bootstrap fragment and packaging coverage for the new PHP class.

Closes #814.

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php`
- `php -l packages/wordpress-plugin/wp-codebox.php`
- `php -l tests/smoke-wordpress-plugin.php`
- Focused `php -r` smoke for `WP_Codebox_Browser_Runner_Template::bootstrap_fragment()`
- `php tests/smoke-wordpress-plugin.php` passed through the browser runner/template section, including generated-runner eval, then failed later in artifact apply preflight with `WP Codebox artifact verifier did not return valid JSON`.
- `npm run build` could not run directly because this fresh worktree did not have `node_modules/typescript` installed.
- Retried build with a temporary symlink to the primary checkout's `node_modules`; dependency resolution proceeded, then TypeScript failed on existing `reviewerAccess` errors in `packages/runtime-playground/src/artifact-bundle-builder.ts`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the focused PHP template extraction, smoke assertions, packaging assertion, and verification summary for Chris to review.