### PR TITLE
Remove consumer defaults from plugin substrate

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1292,10 +1292,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private function remediation_outcome( array $run, int $exit_code, string $output ): array {
 		$run_outcome = $this->agents_api_run_outcome( $run );
 		$has_run_outcome = ! empty( $run_outcome );
-		$datamachine = $has_run_outcome ? array() : $this->first_datamachine_metadata( $run );
 		$run_status = (string) ( $run_outcome['status'] ?? '' );
 		$stop_reason = (string) ( $run_outcome['stop_reason'] ?? '' );
-		$max_turns_reached = $has_run_outcome ? 'max_turns' === $stop_reason : ( $this->recursive_truthy_key( $run, 'max_turns_reached' ) || true === ( $datamachine['max_turns_reached'] ?? false ) );
+		$max_turns_reached = $has_run_outcome ? 'max_turns' === $stop_reason : $this->recursive_truthy_key( $run, 'max_turns_reached' );
 		$pending_runtime_tool = $has_run_outcome && ( 'runtime_tool_pending' === $run_status || 'runtime_tool_pending' === $stop_reason );
 		$provider_error = $has_run_outcome ? $this->agents_api_provider_error_details( $run_outcome ) : $this->provider_error_details( $run, $output );
 		$pr_url = $this->first_url_for_keys( $run, array( 'pr_url', 'pull_request_url', 'pullRequestUrl' ) );
@@ -1317,7 +1316,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 					'agents_api_stop_reason' => $has_run_outcome ? $stop_reason : null,
 					'agents_api_completed'   => $has_run_outcome && array_key_exists( 'completed', $run_outcome ) ? (bool) $run_outcome['completed'] : null,
 					'pending_runtime_tool'   => $has_run_outcome ? $pending_runtime_tool : null,
-					'datamachine_completed' => array_key_exists( 'completed', $datamachine ) ? (bool) $datamachine['completed'] : null,
 					'max_turns_reached'     => $max_turns_reached,
 				),
 				static fn( mixed $value ): bool => null !== $value
@@ -1326,8 +1324,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		if ( $has_run_outcome ) {
 			$outcome['metadata'] = array( 'agents_api' => array( 'run_outcome' => $run_outcome ) );
-		} elseif ( ! empty( $datamachine ) ) {
-			$outcome['metadata'] = array( 'datamachine' => $datamachine );
 		}
 
 		if ( $has_artifact_changes && $false_positive ) {
@@ -1489,20 +1485,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
 		);
-	}
-
-	/** @param array<string,mixed> $run Decoded CLI run output. @return array<string,mixed> */
-	private function first_datamachine_metadata( array $run ): array {
-		$payloads = array_merge( array( $run ), $this->agent_payloads( $run ) );
-		foreach ( $payloads as $payload ) {
-			$metadata = is_array( $payload['metadata'] ?? null ) ? $payload['metadata'] : array();
-			$datamachine = is_array( $metadata['datamachine'] ?? null ) ? $metadata['datamachine'] : array();
-			if ( ! empty( $datamachine ) ) {
-				return $datamachine;
-			}
-		}
-
-		return array();
 	}
 
 	/** @param array<string,mixed> $run Decoded CLI run output. @return array<int,array<string,mixed>> */

--- a/packages/wordpress-plugin/src/class-wp-codebox-pending-artifact-apply.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-pending-artifact-apply.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * Optional Data Machine pending-action integration for artifact apply-back.
+ * Pending artifact apply integration seam for WP Codebox.
  *
  * @package WPCodebox
  */
 
 defined( 'ABSPATH' ) || exit;
 
-final class WP_Codebox_Data_Machine_Pending_Actions {
+final class WP_Codebox_Pending_Artifact_Apply {
 
 	public const KIND = 'wp_codebox_apply_back';
 
 	public function __construct() {
-		add_filter( 'datamachine_pending_action_handlers', array( self::class, 'register_handler' ) );
+		add_filter( 'wp_codebox_pending_apply_artifact_handlers', array( self::class, 'register_handler' ) );
 	}
 
-	/** @param array<string,mixed> $handlers Current Data Machine pending-action handlers. */
+	/** @param array<string,mixed> $handlers Current pending artifact apply handlers. */
 	public static function register_handler( array $handlers ): array {
 		$handlers[ self::KIND ] = array(
 			'apply'       => array( self::class, 'apply' ),
@@ -26,7 +26,7 @@ final class WP_Codebox_Data_Machine_Pending_Actions {
 	}
 
 	/**
-	 * Stage an artifact apply request through Data Machine pending actions.
+	 * Stage an artifact apply request through a consumer-owned pending action layer.
 	 *
 	 * @param array<string,mixed> $input Ability/helper input.
 	 * @return array<string,mixed>|WP_Error
@@ -70,19 +70,15 @@ final class WP_Codebox_Data_Machine_Pending_Actions {
 			return $filtered;
 		}
 
-		if ( ! class_exists( '\\DataMachine\\Engine\\AI\\Actions\\PendingActionHelper' ) ) {
-			return new WP_Error( 'wp_codebox_datamachine_pending_actions_missing', 'Data Machine pending actions are not available.', array( 'status' => 501 ) );
-		}
-
-		return \DataMachine\Engine\AI\Actions\PendingActionHelper::stage( $stage_args );
+		return new WP_Error( 'wp_codebox_pending_apply_unavailable', 'No pending artifact apply staging handler is registered.', array( 'status' => 501 ) );
 	}
 
-	/** @param array<string,mixed> $apply_input Stored Data Machine apply input. */
+	/** @param array<string,mixed> $apply_input Stored apply input. */
 	public static function apply( array $apply_input ): array|WP_Error {
 		return ( new WP_Codebox_Artifacts() )->apply_approved( $apply_input );
 	}
 
-	/** @param array<string,mixed> $payload Stored Data Machine pending-action payload. */
+	/** @param array<string,mixed> $payload Stored pending-action payload. */
 	public static function can_resolve( array $payload, string $decision, int $user_id ): bool|WP_Error {
 		$allowed = function_exists( 'current_user_can' ) ? current_user_can( 'manage_options' ) : true;
 
@@ -118,21 +114,21 @@ final class WP_Codebox_Data_Machine_Pending_Actions {
 		return $apply_input;
 	}
 
-	/** @param array<string,mixed> $input Ability/helper input. @return string[] */
+	/** @return array<int,string> */
 	private static function approved_files( array $input ): array {
 		$files = is_array( $input['approved_files'] ?? null ) ? $input['approved_files'] : array();
 
 		return array_values(
 			array_unique(
 				array_filter(
-					array_map( static fn( $path ): string => trim( (string) $path ), $files ),
-					static fn( string $path ): bool => '' !== $path
+					array_map( static fn( mixed $file ): string => trim( (string) $file ), $files ),
+					static fn( string $file ): bool => '' !== $file
 				)
 			)
 		);
 	}
 
-	/** @param array<string,mixed> $bundle Artifact bundle. @param array<string,mixed> $apply_input Stored apply input. */
+	/** @param array<string,mixed> $bundle Artifact bundle. @param array<string,mixed> $apply_input Apply input. @param array<string,mixed> $verification Verification result. @return array<string,mixed> */
 	private static function preview_data( array $bundle, array $apply_input, array $verification ): array {
 		return array(
 			'schema'         => 'wp-codebox/pending-apply-preview/v1',
@@ -140,7 +136,7 @@ final class WP_Codebox_Data_Machine_Pending_Actions {
 			'content_digest' => (string) ( $bundle['content_digest'] ?? '' ),
 			'created_at'     => (string) ( $bundle['created_at'] ?? '' ),
 			'verification'   => $verification,
-			'approved_files' => $apply_input['approved_files'] ?? array(),
+			'approved_files' => is_array( $apply_input['approved_files'] ?? null ) ? $apply_input['approved_files'] : array(),
 			'changed_files'  => is_array( $bundle['changed_files'] ?? null ) ? $bundle['changed_files'] : array(),
 			'test_results'   => is_array( $bundle['test_results'] ?? null ) ? $bundle['test_results'] : array(),
 			'review'         => is_array( $bundle['review'] ?? null ) ? $bundle['review'] : array(),

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -332,8 +332,8 @@ foreach ( $payload as $key => $value ) {
 return $sanitized;
 }
 
-if ( interface_exists( "\\DataMachine\\Engine\\AI\\LoopEventSinkInterface" ) && ! class_exists( "WP_Codebox_Browser_Event_File_Sink" ) ) {
-class WP_Codebox_Browser_Event_File_Sink implements \\DataMachine\\Engine\\AI\\LoopEventSinkInterface {
+if ( ! class_exists( "WP_Codebox_Browser_Event_File_Sink" ) ) {
+class WP_Codebox_Browser_Event_File_Sink {
 	private string $path;
 
 	public function __construct( string $path ) {
@@ -353,6 +353,15 @@ class WP_Codebox_Browser_Event_File_Sink implements \\DataMachine\\Engine\\AI\\L
 		}
 	}
 }
+}
+
+function wp_codebox_browser_runtime_event_sink( string $event_path, array $input, array $payload ) {
+$sink = null;
+if ( function_exists( "apply_filters" ) ) {
+	$sink = apply_filters( "wp_codebox_browser_runtime_event_sink", $sink, $event_path, $input, $payload );
+}
+
+return is_object( $sink ) && method_exists( $sink, "emit" ) ? $sink : null;
 }
 
 function wp_codebox_browser_install_provider_proxy( array $payload ): array {
@@ -896,7 +905,7 @@ $artifact_metrics = wp_codebox_browser_artifact_metrics( $artifact_bundle );
 $elapsed_ms = max( 0, (int) round( ( microtime( true ) - $started_monotonic ) * 1000 ) );
 
 return array_filter( array(
-    "schema" => "agents-api/execution-metrics/v1",
+    "schema" => "wp-codebox/execution-metrics/v1",
     "executor" => "wp-codebox/browser-playground",
     "phase" => "execution",
     "status" => $failed ? "error" : "completed",
@@ -1236,9 +1245,11 @@ if ( ! empty( $sandbox_tool_ids ) ) {
 }
 $input = array_replace_recursive( $base_input, is_array( $invocation[\'input\'] ?? null ) ? $invocation[\'input\'] : array() );
 $event_sink_attached = false;
-if ( interface_exists( "\\DataMachine\\Engine\\AI\\LoopEventSinkInterface" ) && class_exists( "WP_Codebox_Browser_Event_File_Sink" ) ) {
+
+$event_sink = wp_codebox_browser_runtime_event_sink( $event_path, $input, $payload );
+if ( null !== $event_sink ) {
 	file_put_contents( $event_path, "" );
-	$input[\'event_sink\'] = new WP_Codebox_Browser_Event_File_Sink( $event_path );
+	$input[\'event_sink\'] = $event_sink;
 	$event_sink_attached = true;
 }
 $invocation_type = (string) ( $invocation[\'type\'] ?? \'ability\' );

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -380,7 +380,7 @@ private static function browser_contract_execution_metrics( array $primary, arra
 
 	return array_filter(
 		array(
-			'schema'           => 'agents-api/execution-metrics/v1',
+			'schema'           => 'wp-codebox/execution-metrics/v1',
 			'executor'         => 'wp-codebox/browser-playground',
 			'phase'            => 'contract',
 			'status'           => true === ( $primary['success'] ?? false ) ? 'pending' : (string) ( $primary['status'] ?? 'blocked' ),
@@ -1046,6 +1046,6 @@ public static function apply_approved_artifact( array $input ): array|WP_Error {
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function stage_artifact_apply( array $input ): array|WP_Error {
-	return WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact( $input );
+	return WP_Codebox_Pending_Artifact_Apply::stage_apply_artifact( $input );
 }
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -197,15 +197,23 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		if ( is_array( $normalized['error'] ?? null ) ) {
 			return self::runner_workspace_prepare_failure( 'invalid_request', $normalized['error'], 'failed', $normalized );
 		}
+		$backend       = self::runner_workspace_backend_config();
+		$backend_id    = (string) ( $backend['id'] ?? '' );
+		$abilities     = is_array( $backend['abilities'] ?? null ) ? $backend['abilities'] : array();
+		$adopt_ability = (string) ( $abilities['workspace_adopt'] ?? '' );
+		$show_ability  = (string) ( $abilities['workspace_show'] ?? '' );
+		$clone_ability = (string) ( $abilities['workspace_clone'] ?? '' );
+		$add_ability   = (string) ( $abilities['workspace_worktree_add'] ?? '' );
 
 		$checkout_path = (string) $normalized['checkout_path'];
-		if ( '' !== $checkout_path && ! defined( 'DATAMACHINE_WORKSPACE_PATH' ) ) {
-			define( 'DATAMACHINE_WORKSPACE_PATH', rtrim( dirname( $checkout_path ), '/' ) );
+		$workspace_path_constant = (string) ( $backend['workspace_path_constant'] ?? '' );
+		if ( '' !== $checkout_path && '' !== $workspace_path_constant && ! defined( $workspace_path_constant ) ) {
+			define( $workspace_path_constant, rtrim( dirname( $checkout_path ), '/' ) );
 		}
 
 		$required = '' !== $checkout_path
-			? array( 'datamachine-code/workspace-adopt' )
-			: array( 'datamachine-code/workspace-show', 'datamachine-code/workspace-clone', 'datamachine-code/workspace-worktree-add' );
+			? array( $adopt_ability )
+			: array( $show_ability, $clone_ability, $add_ability );
 
 		foreach ( $required as $ability_name ) {
 			$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
@@ -220,7 +228,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		}
 
 		if ( '' !== $checkout_path ) {
-			$adopt = wp_get_ability( 'datamachine-code/workspace-adopt' )->execute( array( 'path' => $checkout_path, 'name' => $normalized['repo'] ) );
+			$adopt = wp_get_ability( $adopt_ability )->execute( array( 'path' => $checkout_path, 'name' => $normalized['repo'] ) );
 			if ( is_wp_error( $adopt ) ) {
 				return self::runner_workspace_prepare_failure( 'backend_error', array( 'code' => $adopt->get_error_code(), 'message' => $adopt->get_error_message(), 'data' => $adopt->get_error_data() ), 'failed', $normalized );
 			}
@@ -233,7 +241,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 					'success'      => true,
 					'schema'       => 'wp-codebox/runner-workspace-prepare-result/v1',
 					'status'       => 'prepared',
-					'backend'      => 'datamachine-code',
+					'backend'      => $backend_id,
 					'repo'         => $normalized['repo'],
 					'branch'       => $normalized['branch'],
 					'handle'       => (string) ( $adopt['handle'] ?? $adopt['name'] ?? $normalized['repo'] ),
@@ -246,7 +254,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			);
 		}
 
-		$show = wp_get_ability( 'datamachine-code/workspace-show' )->execute( array( 'name' => $normalized['repo'] ) );
+		$show = wp_get_ability( $show_ability )->execute( array( 'name' => $normalized['repo'] ) );
 		if ( is_wp_error( $show ) ) {
 			if ( '' === $normalized['clone_url'] ) {
 				return self::runner_workspace_prepare_failure( 'clone_url_required', array( 'code' => 'wp_codebox_runner_workspace_prepare_clone_url_required', 'message' => 'Runner workspace primary is missing and clone_url is empty.' ), 'failed', $normalized );
@@ -257,7 +265,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				$clone_input['auth_token_env'] = $normalized['github_token_env'];
 			}
 
-			$clone = wp_get_ability( 'datamachine-code/workspace-clone' )->execute( array_filter( $clone_input, static fn( mixed $value ): bool => '' !== $value ) );
+			$clone = wp_get_ability( $clone_ability )->execute( array_filter( $clone_input, static fn( mixed $value ): bool => '' !== $value ) );
 			if ( is_wp_error( $clone ) ) {
 				return self::runner_workspace_prepare_failure( 'backend_error', array( 'code' => $clone->get_error_code(), 'message' => $clone->get_error_message(), 'data' => $clone->get_error_data() ), 'failed', $normalized );
 			}
@@ -277,7 +285,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			static fn( mixed $value ): bool => '' !== $value && null !== $value
 		);
 
-		$worktree = wp_get_ability( 'datamachine-code/workspace-worktree-add' )->execute( $worktree_input );
+		$worktree = wp_get_ability( $add_ability )->execute( $worktree_input );
 		if ( is_wp_error( $worktree ) ) {
 			return self::runner_workspace_prepare_failure( 'backend_error', array( 'code' => $worktree->get_error_code(), 'message' => $worktree->get_error_message(), 'data' => $worktree->get_error_data() ), 'failed', $normalized );
 		}
@@ -290,7 +298,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'success'      => true,
 				'schema'       => 'wp-codebox/runner-workspace-prepare-result/v1',
 				'status'       => 'prepared',
-				'backend'      => 'datamachine-code',
+				'backend'      => $backend_id,
 				'repo'         => $normalized['repo'],
 				'branch'       => (string) ( $worktree['branch'] ?? $normalized['branch'] ),
 				'handle'       => (string) ( $worktree['handle'] ?? '' ),
@@ -310,7 +318,10 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			return self::runner_workspace_publication_failure( 'invalid_request', $normalized['error'], 'write_without_pr', $normalized );
 		}
 
-		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine-code/publish-runner-workspace' ) : null;
+		$backend         = self::runner_workspace_backend_config();
+		$abilities       = is_array( $backend['abilities'] ?? null ) ? $backend['abilities'] : array();
+		$publish_ability = (string) ( $abilities['publish_runner_workspace'] ?? '' );
+		$ability         = '' !== $publish_ability && function_exists( 'wp_get_ability' ) ? wp_get_ability( $publish_ability ) : null;
 		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
 			return self::runner_workspace_publication_failure(
 				'publication_unavailable',
@@ -364,7 +375,9 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			return self::runner_workspace_operation_failure( 'capture', 'invalid_request', $normalized['error'], 'failed', $normalized );
 		}
 
-		$status = self::execute_runner_workspace_backend_ability( 'datamachine-code/workspace-git-status', array( 'name' => $normalized['workspace'] ) );
+		$backend_config = self::runner_workspace_backend_config();
+		$abilities      = is_array( $backend_config['abilities'] ?? null ) ? $backend_config['abilities'] : array();
+		$status = self::execute_runner_workspace_backend_ability( (string) ( $abilities['workspace_git_status'] ?? '' ), array( 'name' => $normalized['workspace'] ) );
 		if ( is_array( $status['error'] ?? null ) ) {
 			return self::runner_workspace_operation_failure( 'capture', (string) $status['failure_type'], $status['error'], 'unavailable', $normalized );
 		}
@@ -373,7 +386,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		$exclude_paths = self::runner_publication_string_list( $input['exclude_paths'] ?? array() );
 		$files         = self::filter_runner_workspace_capture_files( self::runner_publication_string_list( $status_result['files'] ?? array() ), $exclude_paths );
 		$dirty         = count( $files );
-		$backend       = (string) ( $status_result['backend'] ?? $normalized['workspace_backend'] ?? 'datamachine-code' );
+		$backend       = (string) ( $status_result['backend'] ?? $normalized['workspace_backend'] ?? $backend_config['id'] ?? '' );
 		$diff_result   = array();
 		$include_diff  = false !== ( $input['include_diff'] ?? true );
 
@@ -387,7 +400,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				),
 				static fn( mixed $value ): bool => '' !== $value
 			);
-			$diff = self::execute_runner_workspace_backend_ability( 'datamachine-code/workspace-git-diff', $diff_input );
+			$diff = self::execute_runner_workspace_backend_ability( (string) ( $abilities['workspace_git_diff'] ?? '' ), $diff_input );
 			if ( is_array( $diff['error'] ?? null ) ) {
 				return self::runner_workspace_operation_failure( 'capture', (string) $diff['failure_type'], $diff['error'], 'unavailable', $normalized, array( 'status' => $status_result ) );
 			}
@@ -467,10 +480,12 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value && null !== $value
 		);
 
-		$backend = self::execute_runner_workspace_backend_ability( 'datamachine-code/run-runner-workspace-command', $backend_input );
+		$backend_config = self::runner_workspace_backend_config();
+		$abilities      = is_array( $backend_config['abilities'] ?? null ) ? $backend_config['abilities'] : array();
+		$backend = self::execute_runner_workspace_backend_ability( (string) ( $abilities['run_runner_workspace_command'] ?? '' ), $backend_input );
 		if ( ! is_array( $backend['error'] ?? null ) ) {
 			$result = is_array( $backend['result'] ?? null ) ? $backend['result'] : array();
-			return self::normalize_runner_workspace_command_result( $result, $normalized, $backend_input, (string) ( $result['backend'] ?? 'datamachine-code' ) );
+			return self::normalize_runner_workspace_command_result( $result, $normalized, $backend_input, (string) ( $result['backend'] ?? $backend_config['id'] ?? '' ) );
 		}
 
 		if ( false !== ( $input['allow_local_fallback'] ?? true ) && '' !== $normalized['workspace_path'] && is_dir( $normalized['workspace_path'] ) ) {
@@ -547,6 +562,12 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		return trim( $slug, '-' );
 	}
 
+	/** @return array<string,mixed> */
+	private static function runner_workspace_backend_config(): array {
+		$config = function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_runner_workspace_backend', array() ) : array();
+		return is_array( $config ) ? $config : array();
+	}
+
 	/** @param array<string,mixed> $error Error shape. @param array<string,mixed> $input Normalized input. @return array<string,mixed> */
 	private static function runner_workspace_prepare_failure( string $failure_type, array $error, string $status, array $input ): array {
 		return array_filter(
@@ -556,7 +577,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'status'       => $status,
 				'failure_type' => $failure_type,
 				'error'        => $error,
-				'backend'      => 'datamachine-code',
+				'backend'      => (string) ( self::runner_workspace_backend_config()['id'] ?? '' ),
 				'repo'         => (string) ( $input['repo'] ?? '' ),
 				'branch'       => (string) ( $input['branch'] ?? '' ),
 				'capabilities' => array( 'capture' => false, 'command' => false, 'publish' => false ),

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -29,7 +29,7 @@ require_once __DIR__ . '/src/class-wp-codebox-host-run-result-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-parent-site-seed-exporter.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
-require_once __DIR__ . '/src/class-wp-codebox-data-machine-pending-actions.php';
+require_once __DIR__ . '/src/class-wp-codebox-pending-artifact-apply.php';
 require_once __DIR__ . '/src/class-wp-codebox-preview-options.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 
@@ -44,7 +44,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 add_action( 'plugins_loaded', static function (): void {
-	new WP_Codebox_Data_Machine_Pending_Actions();
+	new WP_Codebox_Pending_Artifact_Apply();
 }, 20 );
 
 add_action(

--- a/tests/smoke-wordpress-plugin.php
+++ b/tests/smoke-wordpress-plugin.php
@@ -205,7 +205,7 @@ require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-run-r
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-parent-site-seed-exporter.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
-require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-data-machine-pending-actions.php';
+require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-pending-artifact-apply.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-preview-options.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
 require __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-cli-command.php';
@@ -347,7 +347,7 @@ $violation_codes = static function ( WP_Error $error ): array {
 
 echo "WP Codebox WordPress plugin - smoke\n";
 
-new WP_Codebox_Data_Machine_Pending_Actions();
+new WP_Codebox_Pending_Artifact_Apply();
 new WP_Codebox_Abilities();
 WP_Codebox_CLI_Command::register();
 
@@ -432,6 +432,21 @@ $assert( 'runner workspace prepare ability exposes Codebox request/result schema
 $assert( 'runner workspace prepare accepts checkout path and runner config', isset( $prepare_ability['input_schema']['properties']['checkout_path'] ) && isset( $prepare_ability['input_schema']['properties']['runner_workspace_config'] ) );
 $prepare_unavailable = call_user_func( $prepare_ability['execute_callback'], array( 'repo' => 'Automattic/wp-codebox', 'branch' => 'runner/docs' ) );
 $assert( 'runner workspace prepare returns typed unavailable without backend', ! is_wp_error( $prepare_unavailable ) && false === ( $prepare_unavailable['success'] ?? true ) && 'unavailable' === ( $prepare_unavailable['status'] ?? '' ) && 'backend_unavailable' === ( $prepare_unavailable['failure_type'] ?? '' ) );
+
+$GLOBALS['wp_codebox_filters']['wp_codebox_runner_workspace_backend'] = array(
+	'id'                      => 'datamachine-code',
+	'workspace_path_constant' => 'DATAMACHINE_WORKSPACE_PATH',
+	'abilities'               => array(
+		'workspace_adopt'              => 'datamachine-code/workspace-adopt',
+		'workspace_show'               => 'datamachine-code/workspace-show',
+		'workspace_clone'              => 'datamachine-code/workspace-clone',
+		'workspace_worktree_add'       => 'datamachine-code/workspace-worktree-add',
+		'publish_runner_workspace'     => 'datamachine-code/publish-runner-workspace',
+		'workspace_git_status'         => 'datamachine-code/workspace-git-status',
+		'workspace_git_diff'           => 'datamachine-code/workspace-git-diff',
+		'run_runner_workspace_command' => 'datamachine-code/run-runner-workspace-command',
+	),
+);
 
 $dmc_prepare_show_ability     = new WP_Codebox_Smoke_Ability( array( 'success' => true, 'name' => 'wp-codebox' ) );
 $dmc_prepare_clone_ability    = new WP_Codebox_Smoke_Ability( array( 'success' => true ) );
@@ -1375,7 +1390,7 @@ $agents_api_browser_executor_result = apply_filters(
 );
 $assert( 'Agents API browser executor returns the browser task contract shape', ! is_wp_error( $agents_api_browser_executor_result ) && ( $browser_task_contract['schema'] ?? '' ) === ( $agents_api_browser_executor_result['schema'] ?? '' ) && ( $browser_task_contract['session']['id'] ?? '' ) === ( $agents_api_browser_executor_result['session']['id'] ?? '' ) && ( $browser_task_contract['compact']['schema'] ?? '' ) === ( $agents_api_browser_executor_result['compact']['schema'] ?? '' ) );
 $agents_api_browser_executor_metrics_encoded = wp_json_encode( $agents_api_browser_executor_result['execution_metrics'] ?? array() );
-$assert( 'Agents API browser executor exposes normalized execution metrics', ! is_wp_error( $agents_api_browser_executor_result ) && 'agents-api/execution-metrics/v1' === ( $agents_api_browser_executor_result['execution_metrics']['schema'] ?? '' ) && 'wp-codebox/browser-playground' === ( $agents_api_browser_executor_result['execution_metrics']['executor'] ?? '' ) && 'contract' === ( $agents_api_browser_executor_result['execution_metrics']['phase'] ?? '' ) && 'pending' === ( $agents_api_browser_executor_result['execution_metrics']['status'] ?? '' ) && isset( $agents_api_browser_executor_result['execution_metrics']['payload_bytes']['task_payload'] ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $agents_api_browser_executor_result['execution_metrics']['diagnostics_refs']['event_stream_path'] ?? '' ) );
+$assert( 'Agents API browser executor exposes normalized execution metrics', ! is_wp_error( $agents_api_browser_executor_result ) && 'wp-codebox/execution-metrics/v1' === ( $agents_api_browser_executor_result['execution_metrics']['schema'] ?? '' ) && 'wp-codebox/browser-playground' === ( $agents_api_browser_executor_result['execution_metrics']['executor'] ?? '' ) && 'contract' === ( $agents_api_browser_executor_result['execution_metrics']['phase'] ?? '' ) && 'pending' === ( $agents_api_browser_executor_result['execution_metrics']['status'] ?? '' ) && isset( $agents_api_browser_executor_result['execution_metrics']['payload_bytes']['task_payload'] ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $agents_api_browser_executor_result['execution_metrics']['diagnostics_refs']['event_stream_path'] ?? '' ) );
 $assert( 'Agents API browser executor metrics are secret-safe summaries', is_string( $agents_api_browser_executor_metrics_encoded ) && ! str_contains( $agents_api_browser_executor_metrics_encoded, 'sk-browser-provider-secret' ) && ! str_contains( $agents_api_browser_executor_metrics_encoded, 'data:application/zip;base64' ) && ! str_contains( $agents_api_browser_executor_metrics_encoded, 'pluginData' ) );
 
 $wp_agent_browser_task_handler_result = apply_filters(
@@ -1405,23 +1420,25 @@ $assert( 'browser task contract rejects unsupported phase kinds', is_wp_error( $
 
 $runner_report_path = $root . '/browser-materialization-report.json';
 add_filter(
+	'wp_codebox_browser_runtime_event_sink',
+	static function ( $sink, string $event_path ) {
+		return new WP_Codebox_Browser_Event_File_Sink( $event_path );
+	},
+	10
+);
+add_filter(
 	'caller_runtime_task',
 	static function ( $result, array $input, array $payload ) use ( $runner_report_path ): array {
-		file_put_contents(
-			'/tmp/wp-codebox-agent-events.jsonl',
-			wp_json_encode(
+		if ( is_object( $input['event_sink'] ?? null ) && method_exists( $input['event_sink'], 'emit' ) ) {
+			$input['event_sink']->emit(
+				'tool.completed',
 				array(
-					'schema'     => 'wp-codebox/browser-agent-event/v1',
-					'event'      => 'tool.completed',
-					'payload'    => array(
-						'tool_name'   => 'client/filesystem-write',
-						'duration_ms' => 37,
-						'success'     => true,
-					),
-					'emitted_at' => gmdate( 'c' ),
+					'tool_name'   => 'client/filesystem-write',
+					'duration_ms' => 37,
+					'success'     => true,
 				)
-			) . "\n"
-		);
+			);
+		}
 		file_put_contents(
 			$runner_report_path,
 			wp_json_encode(
@@ -1518,9 +1535,9 @@ $assert( 'browser Playground generated runner invokes caller task hook', is_arra
 $assert( 'browser Playground generated runner captures normalized materialization evidence', is_array( $runner_result ) && 'wp-codebox/browser-materialization/v1' === ( $runner_result['schema'] ?? '' ) && 'wp-codebox/browser-capture/v1' === ( $runner_result['captures'][0]['schema'] ?? '' ) && true === ( $runner_result['captures'][0]['exists'] ?? false ) && 'caller/materialization-report/v1' === ( $runner_result['captures'][0]['json']['schema'] ?? '' ) );
 $assert( 'browser Playground generated runner writes result evidence file', is_array( $runner_result_file ) && $runner_result === $runner_result_file );
 $assert( 'browser Playground generated runner records diagnostics and provenance', is_array( $runner_result ) && array() === ( $runner_result['errors'] ?? null ) && 'wp-codebox/browser-runner' === ( $runner_result['provenance']['generated_by'] ?? '' ) && '/tmp/wp-codebox-agent-result.json' === ( $runner_result['provenance']['result_path'] ?? '' ) );
-$assert( 'browser Playground generated runner captures agent event stream diagnostics', is_array( $runner_result ) && 2 === ( $runner_result['diagnostics']['capture_count'] ?? 0 ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $runner_result['diagnostics']['event_stream']['path'] ?? '' ) && false === ( $runner_result['diagnostics']['event_stream']['sink_attached'] ?? true ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $runner_result['captures'][1]['path'] ?? '' ) && 'events' === ( $runner_result['captures'][1]['kind'] ?? '' ) );
+$assert( 'browser Playground generated runner captures consumer-registered event stream diagnostics', is_array( $runner_result ) && 2 === ( $runner_result['diagnostics']['capture_count'] ?? 0 ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $runner_result['diagnostics']['event_stream']['path'] ?? '' ) && true === ( $runner_result['diagnostics']['event_stream']['sink_attached'] ?? false ) && '/tmp/wp-codebox-agent-events.jsonl' === ( $runner_result['captures'][1]['path'] ?? '' ) && 'events' === ( $runner_result['captures'][1]['kind'] ?? '' ) );
 $runner_metrics_encoded = wp_json_encode( $runner_result['execution_metrics'] ?? array() );
-$assert( 'browser Playground generated runner emits normalized execution metrics', is_array( $runner_result ) && 'agents-api/execution-metrics/v1' === ( $runner_result['execution_metrics']['schema'] ?? '' ) && 'wp-codebox/browser-playground' === ( $runner_result['execution_metrics']['executor'] ?? '' ) && 'execution' === ( $runner_result['execution_metrics']['phase'] ?? '' ) && 'completed' === ( $runner_result['execution_metrics']['status'] ?? '' ) && 1 === ( $runner_result['execution_metrics']['tool_calls']['count'] ?? 0 ) && 37 === ( $runner_result['execution_metrics']['tool_calls']['duration_ms'] ?? 0 ) && 2 === ( $runner_result['execution_metrics']['artifacts']['capture_count'] ?? 0 ) );
+$assert( 'browser Playground generated runner emits normalized execution metrics', is_array( $runner_result ) && 'wp-codebox/execution-metrics/v1' === ( $runner_result['execution_metrics']['schema'] ?? '' ) && 'wp-codebox/browser-playground' === ( $runner_result['execution_metrics']['executor'] ?? '' ) && 'execution' === ( $runner_result['execution_metrics']['phase'] ?? '' ) && 'completed' === ( $runner_result['execution_metrics']['status'] ?? '' ) && 1 === ( $runner_result['execution_metrics']['tool_calls']['count'] ?? 0 ) && 37 === ( $runner_result['execution_metrics']['tool_calls']['duration_ms'] ?? 0 ) && 2 === ( $runner_result['execution_metrics']['artifacts']['capture_count'] ?? 0 ) );
 $assert( 'browser Playground execution metrics summarize artifacts without raw payloads or secrets', is_string( $runner_metrics_encoded ) && isset( $runner_result['execution_metrics']['artifact_bytes']['captures'] ) && ! str_contains( $runner_metrics_encoded, 'sk-browser-provider-secret' ) && ! str_contains( $runner_metrics_encoded, '<main>Generic caller artifact</main>' ) && ! str_contains( $runner_metrics_encoded, 'RIFFfixtureWEBP' ) );
 $assert( 'browser Playground generated runner captures caller-owned artifact schema', is_array( $runner_result ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['artifact_bundle']['schema'] ?? '' ) && 'caller/generic-browser-artifact-bundle/v1' === ( $runner_result['response']['artifact_bundle']['schema'] ?? '' ) );
 $assert( 'browser Playground generated runner preserves caller artifact metadata and roles', is_array( $runner_result ) && array( 'non-studio-web' ) === ( $runner_result['artifact_bundle']['metadata']['labels'] ?? array() ) && array( 'preview' => 'generic-output/index.html' ) === ( $runner_result['artifact_bundle']['roles'] ?? array() ) && array( 'preview' ) === ( $runner_result['artifact_bundle']['files'][0]['roles'] ?? array() ) && 'entrypoint' === ( $runner_result['artifact_bundle']['files'][0]['metadata']['opaque'] ?? '' ) );
@@ -1563,7 +1580,7 @@ $assert( 'browser Playground session exposes canonical task string', ! is_wp_err
 $assert( 'browser Playground agents/chat runner exposes sandbox tools through runtime declarations', str_contains( $runner_php, "wp_codebox_browser_runtime_tool_declarations" ) && str_contains( $runner_php, "filesystem_write" ) && str_contains( $runner_php, "WP_Codebox_Browser_Filesystem_Write_Tool" ) );
 $assert( 'browser Playground agents/chat runner requires model-visible runtime tool names', str_contains( $runner_php, "'runtime_tools' => \$runtime_tool_declarations" ) && str_contains( $runner_php, "'runtime_tool_callback' => 'wp_codebox_browser_runtime_tool_callback'" ) && str_contains( $runner_php, "'tool_policy'" ) && str_contains( $runner_php, "'allow_only'" ) && str_contains( $runner_php, "'completion_assertions'" ) && str_contains( $runner_php, "'required_tool_names'" ) && str_contains( $runner_php, '$sandbox_tool_ids' ) );
 $browser_capture_paths = array_map( static fn( array $capture ): string => (string) ( $capture['path'] ?? '' ), $browser_session['recipe']['browser']['captures'] ?? array() );
-$assert( 'browser Playground agents/chat runner wires loop events into a captured JSONL file', str_contains( $runner_php, 'LoopEventSinkInterface' ) && str_contains( $runner_php, 'WP_Codebox_Browser_Event_File_Sink' ) && str_contains( $runner_php, 'event_sink' ) && str_contains( $runner_php, '/tmp/wp-codebox-agent-events.jsonl' ) && in_array( '/tmp/wp-codebox-agent-events.jsonl', $browser_capture_paths, true ) );
+$assert( 'browser Playground agents/chat runner exposes filterable loop events captured as JSONL', ! str_contains( $runner_php, 'LoopEventSinkInterface' ) && str_contains( $runner_php, 'wp_codebox_browser_runtime_event_sink' ) && str_contains( $runner_php, 'WP_Codebox_Browser_Event_File_Sink' ) && str_contains( $runner_php, 'event_sink' ) && str_contains( $runner_php, '/tmp/wp-codebox-agent-events.jsonl' ) && in_array( '/tmp/wp-codebox-agent-events.jsonl', $browser_capture_paths, true ) );
 
 $normalize_browser_bundle_ability = $GLOBALS['wp_codebox_registered_abilities']['wp-codebox/normalize-browser-artifact-bundle'] ?? null;
 $browser_bundle_input            = array(
@@ -1882,7 +1899,7 @@ $assert( 'browser provider proxy binds provider-compatible placeholder authentic
 $assert( 'browser provider proxy derives connector scope from generic inheritance', ! is_wp_error( $browser_inherited_session ) && str_contains( $provider_proxy_code, "\$payload['inheritance']['connectors']" ) && str_contains( $provider_proxy_code, "'inherit'            => \$this->inherit" ) );
 $assert( 'browser provider proxy consumes bounded adapter HTTP envelope', ! is_wp_error( $browser_inherited_session ) && str_contains( $provider_proxy_code, "\$response['response']" ) && str_contains( $provider_proxy_code, '$status < 100 || $status > 599' ) );
 $assert( 'browser provider proxy source is independent of Data Machine', ! is_wp_error( $browser_inherited_session ) && ! str_contains( $provider_proxy_code, 'datamachine_' ) && ! str_contains( $provider_proxy_code, 'DataMachine' ) );
-$assert( 'generated browser runner only references Data Machine for the existing loop event sink interface', ! is_wp_error( $browser_inherited_session ) && ! str_contains( $browser_runner_code, 'datamachine_' ) && str_contains( $browser_runner_code, '\\DataMachine\\Engine\\AI\\LoopEventSinkInterface' ) && substr_count( $browser_runner_code, 'DataMachine' ) === substr_count( $browser_runner_code, '\\DataMachine\\Engine\\AI\\LoopEventSinkInterface' ) );
+$assert( 'generated browser runner does not reference Data Machine runtime contracts', ! is_wp_error( $browser_inherited_session ) && ! str_contains( $browser_runner_code, 'datamachine_' ) && ! str_contains( $browser_runner_code, 'DataMachine' ) && str_contains( $browser_runner_code, 'wp_codebox_browser_runtime_event_sink' ) );
 $assert( 'browser Playground recipe preserves and imports multiple runtime agent bundles before agents chat', ! is_wp_error( $browser_inherited_session ) && 2 === count( $browser_inherited_session['recipe']['inputs']['agent_bundles'] ?? array() ) && 2 === count( $browser_inherited_session['task_payload']['agent_bundles'] ?? array() ) && str_contains( $browser_runner_code, 'wp_codebox_browser_import_agent_bundles' ) && str_contains( $browser_runner_code, 'wp_agent_import_runtime_bundles' ) && str_contains( $browser_runner_code, 'wp_agent_runtime_import_bundle' ) && strpos( $browser_runner_code, 'wp_codebox_browser_import_agent_bundles' ) < strpos( $browser_runner_code, 'wp_get_ability( $ability_name )' ) );
 $assert( 'browser Playground recipe preserves non-secret runtime import principal', ! is_wp_error( $browser_inherited_session ) && 123 === ( $browser_inherited_session['task_payload']['agent_bundles'][0]['import_principal']['agent_id'] ?? null ) && array( 'runtime/import-agent' ) === ( $browser_inherited_session['task_payload']['agent_bundles'][0]['import_principal']['scope']['ability_allow'] ?? array() ) );
 $assert( 'browser Playground recipe delegates runtime bundle imports through generic helper', ! is_wp_error( $browser_inherited_session ) && str_contains( $browser_runner_code, "wp_agent_import_runtime_bundles" ) && str_contains( $browser_runner_code, "apply_filters( 'wp_agent_runtime_import_bundle'" ) && ! str_contains( $browser_runner_code, '\\DataMachine\\Abilities\\PermissionHelper' ) && ! str_contains( $browser_runner_code, "wp_get_ability( 'datamachine/import-agent' )" ) );
@@ -2925,16 +2942,14 @@ $assert( 'strict remediation outcome preserves pending runtime tools', ! is_wp_e
 
 $text_false_positive_result = $remediation_run(
 	array(
-		'answer'   => 'This looks like a false positive; no code changes are needed.',
-		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
+		'answer' => 'This looks like a false positive; no code changes are needed.',
 	)
 );
 $assert( 'strict remediation outcome returns noop artifact for text-only false-positive conclusions without artifact', ! is_wp_error( $text_false_positive_result ) && true === ( $text_false_positive_result['success'] ?? false ) && 'noop_artifact' === ( $text_false_positive_result['outcome']['kind'] ?? '' ) && true === ( $text_false_positive_result['outcome']['false_positive'] ?? false ) );
 
 $normal_no_pr_result = $remediation_run(
 	array(
-		'answer'   => 'Done.',
-		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
+		'answer' => 'Done.',
 	)
 );
 $assert( 'strict remediation outcome returns unable-to-remediate terminal outcome without artifact', ! is_wp_error( $normal_no_pr_result ) && true === ( $normal_no_pr_result['success'] ?? false ) && 'unable_to_remediate' === ( $normal_no_pr_result['outcome']['kind'] ?? '' ) );
@@ -2955,9 +2970,7 @@ $completed_run_outcome_result = $remediation_run(
 $assert( 'strict remediation outcome preserves completed Agents API outcome', ! is_wp_error( $completed_run_outcome_result ) && true === ( $completed_run_outcome_result['success'] ?? false ) && 'unable_to_remediate' === ( $completed_run_outcome_result['outcome']['kind'] ?? '' ) && true === ( $completed_run_outcome_result['outcome']['diagnostics']['agents_api_completed'] ?? false ) && 'natural' === ( $completed_run_outcome_result['outcome']['diagnostics']['agents_api_stop_reason'] ?? '' ) );
 
 $fix_artifact_result = $remediation_run(
-	array(
-		'metadata' => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
-	),
+	array(),
 	0,
 	$remediation_artifact_run( 'fix', array( array( 'path' => '/wordpress/wp-content/plugins/example/example.php', 'relativePath' => 'example.php', 'status' => 'modified' ) ) )
 );
@@ -2966,7 +2979,6 @@ $assert( 'strict remediation outcome accepts changed fix artifact', ! is_wp_erro
 $false_positive_artifact_result = $remediation_run(
 	array(
 		'false_positive' => true,
-		'metadata'       => array( 'datamachine' => array( 'completed' => true, 'max_turns_reached' => false ) ),
 	),
 	0,
 	$remediation_artifact_run( 'false-positive', array( array( 'path' => '/wordpress/wp-content/plugins/example/tests/audit.php', 'relativePath' => 'tests/audit.php', 'status' => 'modified' ) ) )
@@ -3235,10 +3247,10 @@ $invalid_concurrency = $fanout_runner->run_fanout(
 );
 $assert( 'fanout runner rejects unsafe concurrency bounds', is_wp_error( $invalid_concurrency ) && 'wp_codebox_fanout_concurrency_invalid' === $invalid_concurrency->get_error_code() );
 
-$pending_action_handlers_filter     = $GLOBALS['wp_codebox_filters']['datamachine_pending_action_handlers'] ?? null;
+$pending_action_handlers_filter     = $GLOBALS['wp_codebox_filters']['wp_codebox_pending_apply_artifact_handlers'] ?? null;
 $GLOBALS['wp_codebox_is_multisite'] = true;
 $GLOBALS['wp_codebox_filters']      = array_filter(
-	array( 'datamachine_pending_action_handlers' => $pending_action_handlers_filter ),
+	array( 'wp_codebox_pending_apply_artifact_handlers' => $pending_action_handlers_filter ),
 	static fn( mixed $filter ): bool => null !== $filter
 );
 $GLOBALS['wp_codebox_site_options'] = array(
@@ -3259,7 +3271,7 @@ $GLOBALS['wp_codebox_filters']      = array_filter(
 		'wp_codebox_default_provider'           => 'openai',
 		'wp_codebox_default_model'              => 'gpt-5.5',
 		'wp_codebox_default_secret_env'         => array( 'OPENAI_API_KEY' ),
-		'datamachine_pending_action_handlers'   => $pending_action_handlers_filter,
+		'wp_codebox_pending_apply_artifact_handlers' => $pending_action_handlers_filter,
 	),
 	static fn( mixed $filter ): bool => null !== $filter
 );
@@ -3482,7 +3494,7 @@ $reference_metadata = $metadata;
 $reference_metadata['artifacts']['patch'] = 'files/missing.diff';
 file_put_contents( $reference_fixture_root . '/runtime-test/metadata.json', json_encode( $reference_metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n" );
 $refresh_manifest_hashes( $reference_fixture_root . '/runtime-test' );
-$reference_failure = WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact(
+$reference_failure = WP_Codebox_Pending_Artifact_Apply::stage_apply_artifact(
 	array(
 		'artifacts_path' => $reference_fixture_root,
 		'artifact_id'    => $artifact_id,
@@ -3603,7 +3615,7 @@ $GLOBALS['wp_codebox_filters']['wp_codebox_stage_pending_apply_artifact'] = func
 		),
 	);
 };
-$staged = WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact(
+$staged = WP_Codebox_Pending_Artifact_Apply::stage_apply_artifact(
 	array(
 		'artifacts_path'  => $artifact_root,
 		'artifact_id'     => $artifact_id,
@@ -3613,15 +3625,15 @@ $staged = WP_Codebox_Data_Machine_Pending_Actions::stage_apply_artifact(
 		'context'         => array( 'session_id' => 'chat-123' ),
 	)
 );
-$assert( 'pending artifact apply can be staged', ! is_wp_error( $staged ) && true === ( $staged['staged'] ?? false ) && WP_Codebox_Data_Machine_Pending_Actions::KIND === ( $captured_stage_args['kind'] ?? '' ) );
+$assert( 'pending artifact apply can be staged', ! is_wp_error( $staged ) && true === ( $staged['staged'] ?? false ) && WP_Codebox_Pending_Artifact_Apply::KIND === ( $captured_stage_args['kind'] ?? '' ) );
 $assert( 'pending artifact apply stores exact apply input', $artifact_id === ( $captured_stage_args['apply_input']['artifact_id'] ?? '' ) && array( '/wordpress/wp-content/plugins/example/generated.txt' ) === ( $captured_stage_args['apply_input']['approved_files'] ?? array() ) && array( 'repo' => 'Automattic/wp-codebox' ) === ( $captured_stage_args['apply_input']['apply_target'] ?? array() ) );
 $assert( 'pending artifact apply preview includes review and changed files', 'wp-codebox/pending-apply-preview/v1' === ( $captured_stage_args['preview_data']['schema'] ?? '' ) && 'wp-codebox/artifact-review/v1' === ( $captured_stage_args['preview_data']['review']['schema'] ?? '' ) && 'wp-codebox/changed-files/v1' === ( $captured_stage_args['preview_data']['changed_files']['schema'] ?? '' ) );
 $assert( 'pending artifact apply preview includes successful bundle verification', true === ( $captured_stage_args['preview_data']['verification']['valid'] ?? false ) && 'wp-codebox/artifact-bundle-verification/v1' === ( $captured_stage_args['preview_data']['verification']['schema'] ?? '' ) );
 
-$handlers = apply_filters( 'datamachine_pending_action_handlers', array() );
-$assert( 'pending artifact apply handler registers with Data Machine', isset( $handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'] ) && is_callable( $handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'] ) );
+$handlers = apply_filters( 'wp_codebox_pending_apply_artifact_handlers', array() );
+$assert( 'pending artifact apply handler registers generically', isset( $handlers[ WP_Codebox_Pending_Artifact_Apply::KIND ]['apply'] ) && is_callable( $handlers[ WP_Codebox_Pending_Artifact_Apply::KIND ]['apply'] ) );
 $pending_handler_result = call_user_func(
-	$handlers[ WP_Codebox_Data_Machine_Pending_Actions::KIND ]['apply'],
+	$handlers[ WP_Codebox_Pending_Artifact_Apply::KIND ]['apply'],
 	array(
 		'artifacts_path'  => $artifact_root,
 		'artifact_id'     => $artifact_id,


### PR DESCRIPTION
## Summary
- Remove Data Machine / Extra-Chill substrate defaults from the generic WordPress plugin source by moving runtime event sinks, workspace backend abilities, and pending apply staging behind WP Codebox-owned filter seams.
- Rename the pending artifact apply integration to a generic WP Codebox class while preserving the existing staged payload contract for consumers.
- Use a WP Codebox-owned execution metrics schema and keep browser runtime component registration consumer-owned.

Fixes #633.

## Verification
- `php tests/smoke-wordpress-plugin.php` passed: `OK (512 assertions)`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-pending-artifact-apply.php`
- `git diff --check`
- Purity grep over `packages/wordpress-plugin/*.php` and `packages/wordpress-plugin/src/*.php` found no matches for `data-machine|datamachine|DataMachine|Extra-Chill|LoopEventSinkInterface|agents-api/execution-metrics|agents-api.*latest/download|data-machine.*latest/download`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and verified the substrate decoupling patch, smoke test updates, and PR description; Chris remains responsible for review and merge.