### PR TITLE
Fix recipe-run terminal phase exit

### DIFF
--- a/packages/cli/src/commands/recipe-run-output.ts
+++ b/packages/cli/src/commands/recipe-run-output.ts
@@ -3,7 +3,7 @@ import type { RuntimeRunRecord } from "@automattic/wp-codebox-core"
 import { serializeError } from "../output.js"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 import { RecipePhaseError } from "./recipe-run-phases.js"
-import type { RecipeInterruptionController, RecipeRunCommandOutput, RecipeRunDeclaredArtifact, RecipeRunProbe } from "./recipe-run-types.js"
+import type { RecipeInterruptionController, RecipeRunCommandOutput, RecipeRunDeclaredArtifact, RecipeRunOutput, RecipeRunProbe } from "./recipe-run-types.js"
 
 export class RecipeRunTimeoutError extends Error {
   readonly code = "recipe-run-timeout"
@@ -76,6 +76,22 @@ export function exitAfterRecipeRunTimeout(output: RecipeRunCommandOutput): void 
   if (output.schema === "wp-codebox/recipe-run/v1" && output.error?.code === "recipe-run-timeout") {
     process.exitCode = output.success ? 0 : 1
   }
+}
+
+export function exitAfterTerminalRecipePhaseFailure(output: RecipeRunCommandOutput): void {
+  if (output.schema !== "wp-codebox/recipe-run/v1" || output.success || !hasTerminalRecipePhaseFailure(output)) {
+    return
+  }
+
+  process.exit(1)
+}
+
+function hasTerminalRecipePhaseFailure(output: RecipeRunOutput): boolean {
+  if (hasSerializedErrorCode(output.error, "recipe-phase-failed")) {
+    return true
+  }
+
+  return output.phaseEvidence?.some((phase) => phase.status === "failed" && hasSerializedErrorCode(phase.error, "recipe-phase-failed")) ?? false
 }
 
 export async function writeRecipeJsonOutput(output: unknown): Promise<void> {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -18,7 +18,7 @@ import { resolveCliRuntimeBackend } from "../runtime-backends.js"
 import { previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "../runtime-command-wrappers.js"
 import { createRecipeRunContext } from "./recipe-run-context.js"
 import { createRecipeInterruptionController, interruptedRecipeOutput, markRecipeArtifactsFinalized, recipeInterruptionSerializedError } from "./recipe-run-interruption.js"
-import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, isRecipeRunTimeoutError, printJsonFailureDiagnostic, recipeRunFailureStatus, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError, RecipeRunTimeoutError, RecipeRuntimeCreateError, remainingRecipeTimeoutMs, serializeRecipeRunError, watchRecipeOperation, writeRecipeJsonOutput } from "./recipe-run-output.js"
+import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, isRecipeRunTimeoutError, printJsonFailureDiagnostic, recipeRunFailureStatus, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError, RecipeRunTimeoutError, RecipeRuntimeCreateError, remainingRecipeTimeoutMs, serializeRecipeRunError, watchRecipeOperation, writeRecipeJsonOutput } from "./recipe-run-output.js"
 import { RecipePhaseError, RecipePhaseTracker } from "./recipe-run-phases.js"
 import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
@@ -62,6 +62,7 @@ export async function runRecipeRunCommand(args: string[]): Promise<number> {
       interruption?.propagateIfInterrupted()
       exitAfterRecipeRunTimeout(output)
       exitAfterPlaygroundCliBootFailure(output)
+      exitAfterTerminalRecipePhaseFailure(output)
       return output.success ? 0 : 1
     }
 
@@ -73,6 +74,7 @@ export async function runRecipeRunCommand(args: string[]): Promise<number> {
     interruption?.propagateIfInterrupted()
     exitAfterRecipeRunTimeout(output)
     exitAfterPlaygroundCliBootFailure(output)
+    exitAfterTerminalRecipePhaseFailure(output)
     return output.success ? 0 : 1
   } finally {
     interruption?.dispose()

--- a/scripts/recipe-run-terminal-phase-failure-smoke.ts
+++ b/scripts/recipe-run-terminal-phase-failure-smoke.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { exitAfterTerminalRecipePhaseFailure } from "../packages/cli/src/commands/recipe-run-output.js"
+
+const originalExit = process.exit
+let exitCode: string | number | null | undefined
+
+process.exit = ((code?: string | number | null | undefined): never => {
+  exitCode = code
+  throw new Error("process.exit stub")
+}) as typeof process.exit
+
+try {
+  assert.throws(() => exitAfterTerminalRecipePhaseFailure({
+    success: false,
+    schema: "wp-codebox/recipe-run/v1",
+    executions: [],
+    phaseEvidence: [{
+      schema: "wp-codebox/recipe-phase-evidence/v1",
+      name: "activate_plugins",
+      status: "failed",
+      startedAt: "2026-06-15T00:00:00.000Z",
+      endedAt: "2026-06-15T00:00:01.000Z",
+      durationMs: 1000,
+      error: {
+        name: "RecipePhaseError",
+        message: "Recipe phase activate_plugins failed",
+        code: "recipe-phase-failed",
+        phase: "activate_plugins",
+      },
+    }],
+  }), /process\.exit stub/)
+  assert.equal(exitCode, 1)
+
+  exitCode = undefined
+  exitAfterTerminalRecipePhaseFailure({
+    success: false,
+    schema: "wp-codebox/recipe-run/v1",
+    executions: [],
+    error: { name: "Error", message: "plain failure" },
+  })
+  assert.equal(exitCode, undefined)
+} finally {
+  process.exit = originalExit
+}
+
+console.log("recipe-run-terminal-phase-failure-smoke: ok")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -39,6 +39,7 @@ export const smokeGroups = {
       tsxSmoke("doctor-command-smoke"),
       tsxSmoke("cli-unsettled-command-smoke"),
       tsxSmoke("agent-runtime-failure-smoke"),
+      tsxSmoke("recipe-run-terminal-phase-failure-smoke"),
     ],
   },
   policy: {


### PR DESCRIPTION
## Summary
- Force `recipe-run` to terminate nonzero after emitting output for terminal `recipe-phase-failed` failures, so lingering runtime handles cannot keep callers alive.
- Detect terminal phase failures from both top-level serialized errors and failed phase evidence.
- Add a focused smoke test for the `activate_plugins`/`recipe-phase-failed` lifecycle path and wire it into core smoke coverage.

Fixes #986.

## Verification
- `npm exec tsx scripts/recipe-run-terminal-phase-failure-smoke.ts`
- `npm run build`
- `npm run smoke -- --group=core`

Note: `npm run check` was started locally after the commit, but was interrupted before completion when the PR was requested immediately. No heavy local benchmarks were run.