### PR TITLE
Hydrate missing Composer vendor directories during source prep

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -396,8 +396,9 @@ async function preparePhpAiClientOverlay(overlay: WorkspaceRecipeRuntimeOverlay,
   await mkdir(srcTarget, { recursive: true })
   await mkdir(thirdPartyTarget, { recursive: true })
 
-  const scopedRoot = await scopePhpAiClientSource(source, stagingRoot)
-  const packages = await composerInstalledPackagesFromSource(source)
+  const preparedSource = await preparePhpAiClientOverlaySource(source, stagingRoot)
+  const scopedRoot = await scopePhpAiClientSource(preparedSource, stagingRoot)
+  const packages = await composerInstalledPackagesFromSource(preparedSource)
   const namespacePrefixes = dependencyNamespacePrefixes(packages)
   await scopePhpAiClientSourceDependencyReferences(join(scopedRoot, "src"), namespacePrefixes)
   await cp(join(scopedRoot, "src"), srcTarget, { recursive: true })
@@ -426,6 +427,65 @@ async function preparePhpAiClientOverlay(overlay: WorkspaceRecipeRuntimeOverlay,
       digest: { sha256: digest },
       ...(overlay.metadata ? { userMetadata: overlay.metadata } : {}),
     },
+  }
+}
+
+async function preparePhpAiClientOverlaySource(source: string, stagingRoot: string): Promise<string> {
+  if (await pathIsDirectory(join(source, "vendor"))) {
+    return source
+  }
+
+  if (!await pathIsFile(join(source, "composer.json"))) {
+    throw new Error(`php-ai-client runtime overlay source has no vendor directory and no composer.json for dependency hydration: ${source}`)
+  }
+
+  const composer = await resolveComposerCommand()
+  if (!composer) {
+    throw new Error(`php-ai-client runtime overlay source has no vendor directory, and Composer is not available to hydrate dependencies. Run composer install in ${source}, or install Composer on PATH before running WP Codebox.`)
+  }
+
+  const hydratedSource = join(stagingRoot, "source")
+  await cp(source, hydratedSource, {
+    recursive: true,
+    filter: (entry) => !workspaceSeedExcludeMatches(relative(source, entry), "vendor"),
+  })
+
+  try {
+    await execFileAsync(composer, ["install", "--working-dir", hydratedSource, "--no-dev", "--no-interaction", "--no-progress", "--prefer-dist", "--classmap-authoritative"])
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`php-ai-client runtime overlay dependency hydration failed for ${source}. Run composer install in that checkout or inspect Composer output. ${message}`)
+  }
+
+  if (!await pathIsFile(join(hydratedSource, "vendor", "composer", "installed.json"))) {
+    throw new Error(`php-ai-client runtime overlay dependency hydration completed without vendor/composer/installed.json: ${source}`)
+  }
+
+  return hydratedSource
+}
+
+async function pathIsDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+async function pathIsFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+async function resolveComposerCommand(): Promise<string> {
+  try {
+    await execFileAsync("composer", ["--version"])
+    return "composer"
+  } catch {
+    return ""
   }
 }
 

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -318,18 +318,20 @@ async function prepareRecipeDependencyOverlay(overlay: WorkspaceRecipeDependency
 
   const source = resolve(recipeDirectory, overlay.source)
   await validateExistingDirectoryForOverlay(source, overlay.source)
+  const stagingRoot = await mkdtemp(join(tmpdir(), "wp-codebox-dependency-overlay-"))
+  const preparedSource = await prepareComposerBackedSource(source, stagingRoot, `dependency overlay ${overlay.package}`)
   const target = `${consumer.target}/vendor/${composerPackageVendorPath(overlay.package)}`
-  const digest = await directoryContentDigest(source)
+  const digest = await directoryContentDigest(preparedSource)
 
   return {
-    source,
+    source: preparedSource,
     sourceRef: overlay.source,
     target,
     package: overlay.package,
     consumer: overlay.consumer,
     type: "directory",
     mode: "readonly",
-    cleanupPaths: [],
+    cleanupPaths: [stagingRoot],
     metadata: {
       kind: "dependency-overlay",
       index,
@@ -396,7 +398,7 @@ async function preparePhpAiClientOverlay(overlay: WorkspaceRecipeRuntimeOverlay,
   await mkdir(srcTarget, { recursive: true })
   await mkdir(thirdPartyTarget, { recursive: true })
 
-  const preparedSource = await preparePhpAiClientOverlaySource(source, stagingRoot)
+  const preparedSource = await prepareComposerBackedSource(source, stagingRoot, `runtime overlay ${overlay.kind}/${overlay.library}/${overlay.strategy}`)
   const scopedRoot = await scopePhpAiClientSource(preparedSource, stagingRoot)
   const packages = await composerInstalledPackagesFromSource(preparedSource)
   const namespacePrefixes = dependencyNamespacePrefixes(packages)
@@ -430,21 +432,21 @@ async function preparePhpAiClientOverlay(overlay: WorkspaceRecipeRuntimeOverlay,
   }
 }
 
-async function preparePhpAiClientOverlaySource(source: string, stagingRoot: string): Promise<string> {
+async function prepareComposerBackedSource(source: string, stagingRoot: string, label: string): Promise<string> {
   if (await pathIsDirectory(join(source, "vendor"))) {
     return source
   }
 
   if (!await pathIsFile(join(source, "composer.json"))) {
-    throw new Error(`php-ai-client runtime overlay source has no vendor directory and no composer.json for dependency hydration: ${source}`)
+    throw new Error(`Composer-backed ${label} source has no vendor directory and no composer.json for dependency hydration: ${source}`)
   }
 
   const composer = await resolveComposerCommand()
   if (!composer) {
-    throw new Error(`php-ai-client runtime overlay source has no vendor directory, and Composer is not available to hydrate dependencies. Run composer install in ${source}, or install Composer on PATH before running WP Codebox.`)
+    throw new Error(`Composer-backed ${label} source has no vendor directory, and Composer is not available to hydrate dependencies. Run composer install in ${source}, or install Composer on PATH before running WP Codebox.`)
   }
 
-  const hydratedSource = join(stagingRoot, "source")
+  const hydratedSource = join(stagingRoot, "composer-source")
   await cp(source, hydratedSource, {
     recursive: true,
     filter: (entry) => !workspaceSeedExcludeMatches(relative(source, entry), "vendor"),
@@ -454,11 +456,11 @@ async function preparePhpAiClientOverlaySource(source: string, stagingRoot: stri
     await execFileAsync(composer, ["install", "--working-dir", hydratedSource, "--no-dev", "--no-interaction", "--no-progress", "--prefer-dist", "--classmap-authoritative"])
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`php-ai-client runtime overlay dependency hydration failed for ${source}. Run composer install in that checkout or inspect Composer output. ${message}`)
+    throw new Error(`Composer-backed ${label} dependency hydration failed for ${source}. Run composer install in that checkout or inspect Composer output. ${message}`)
   }
 
   if (!await pathIsFile(join(hydratedSource, "vendor", "composer", "installed.json"))) {
-    throw new Error(`php-ai-client runtime overlay dependency hydration completed without vendor/composer/installed.json: ${source}`)
+    throw new Error(`Composer-backed ${label} dependency hydration completed without vendor/composer/installed.json: ${source}`)
   }
 
   return hydratedSource

--- a/scripts/composer-backed-source-hydration-smoke.ts
+++ b/scripts/composer-backed-source-hydration-smoke.ts
@@ -2,11 +2,13 @@ import assert from "node:assert/strict"
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { prepareRecipeRuntimeOverlays } from "../packages/cli/src/recipe-sources.js"
+import { prepareRecipeDependencyOverlays, prepareRecipeRuntimeOverlays } from "../packages/cli/src/recipe-sources.js"
+import type { PreparedExtraPlugin } from "../packages/cli/src/recipe-sources.js"
 import type { WorkspaceRecipe } from "../packages/runtime-core/src/runtime-contracts.js"
 
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-runtime-overlay-hydration-"))
 const overlaySource = join(root, "php-ai-client")
+const dependencySource = join(root, "generic-composer-package")
 const binDir = join(root, "bin")
 const scoperPath = join(root, "php-scoper.phar")
 const originalPath = process.env.PATH
@@ -35,6 +37,18 @@ final class Client {
 await writeFile(join(overlaySource, "composer.json"), JSON.stringify({
   name: "wordpress/php-ai-client",
   autoload: { "psr-4": { "WordPress\\AiClient\\": "src/" } },
+  require: { "psr/log": "^3.0" },
+}, null, 2))
+
+await mkdir(join(dependencySource, "src"), { recursive: true })
+await writeFile(join(dependencySource, "src", "Package.php"), String.raw`<?php
+namespace Acme\Package;
+
+final class Package {}
+`)
+await writeFile(join(dependencySource, "composer.json"), JSON.stringify({
+  name: "acme/package",
+  autoload: { "psr-4": { "Acme\\Package\\": "src/" } },
   require: { "psr/log": "^3.0" },
 }, null, 2))
 
@@ -102,15 +116,38 @@ const recipe: WorkspaceRecipe = {
 }
 
 const overlays = await prepareRecipeRuntimeOverlays(recipe, root)
+const dependencyOverlays = await prepareRecipeDependencyOverlays({
+  inputs: {
+    dependency_overlays: [{
+      kind: "composer-package",
+      package: "acme/package",
+      source: dependencySource,
+      consumer: "consumer-plugin",
+    }],
+  },
+}, root, [{
+  source: join(root, "consumer-plugin"),
+  slug: "consumer-plugin",
+  target: "/wordpress/wp-content/plugins/consumer-plugin",
+  pluginFile: "consumer-plugin.php",
+  activate: true,
+  loadAs: "plugin",
+  cleanupPaths: [],
+  provenance: { kind: "local", original: join(root, "consumer-plugin") },
+}] satisfies PreparedExtraPlugin[])
 try {
   assert.equal(overlays.length, 1)
+  assert.equal(dependencyOverlays.length, 1)
   assert.equal(await exists(join(overlaySource, "vendor")), false, "overlay source checkout must not be mutated")
+  assert.equal(await exists(join(dependencySource, "vendor")), false, "dependency overlay source checkout must not be mutated")
   assert.equal(await exists(join(overlays[0].source, "autoload.php")), true)
   assert.equal(await exists(join(overlays[0].source, "src", "Client.php")), true)
   assert.equal(await exists(join(overlays[0].source, "third-party", "Psr", "Log", "LoggerInterface.php")), true)
+  assert.equal(await exists(join(dependencyOverlays[0].source, "vendor", "composer", "installed.json")), true)
+  assert.equal(dependencyOverlays[0].target, "/wordpress/wp-content/plugins/consumer-plugin/vendor/acme/package")
   assert.match(await readFile(join(overlays[0].source, "src", "Client.php"), "utf8"), /WordPress\\AiClientDependencies\\Psr\\Log\\LoggerInterface/)
 } finally {
-  await Promise.all(overlays.flatMap((overlay) => overlay.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })))
+  await Promise.all([...overlays, ...dependencyOverlays].flatMap((overlay) => overlay.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })))
   process.env.PATH = originalPath
   if (originalScoper === undefined) {
     delete process.env.WP_CODEBOX_PHP_SCOPER_PHAR
@@ -120,4 +157,4 @@ try {
   await rm(root, { recursive: true, force: true })
 }
 
-console.log("runtime-overlay-composer-hydration-smoke: ok")
+console.log("composer-backed-source-hydration-smoke: ok")

--- a/scripts/runtime-overlay-composer-hydration-smoke.ts
+++ b/scripts/runtime-overlay-composer-hydration-smoke.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict"
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { prepareRecipeRuntimeOverlays } from "../packages/cli/src/recipe-sources.js"
+import type { WorkspaceRecipe } from "../packages/runtime-core/src/runtime-contracts.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-runtime-overlay-hydration-"))
+const overlaySource = join(root, "php-ai-client")
+const binDir = join(root, "bin")
+const scoperPath = join(root, "php-scoper.phar")
+const originalPath = process.env.PATH
+const originalScoper = process.env.WP_CODEBOX_PHP_SCOPER_PHAR
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+await rm(overlaySource, { recursive: true, force: true })
+await mkdir(join(overlaySource, "src"), { recursive: true })
+await writeFile(join(overlaySource, "src", "Client.php"), String.raw`<?php
+namespace WordPress\AiClient;
+
+use Psr\Log\LoggerInterface;
+
+final class Client {
+	public function __construct( private LoggerInterface $logger ) {}
+}
+`)
+await writeFile(join(overlaySource, "composer.json"), JSON.stringify({
+  name: "wordpress/php-ai-client",
+  autoload: { "psr-4": { "WordPress\\AiClient\\": "src/" } },
+  require: { "psr/log": "^3.0" },
+}, null, 2))
+
+await writeFile(scoperPath, `<?php
+$workingDir = '';
+$outputDir = '';
+foreach ($argv as $index => $arg) {
+	if ('--working-dir' === $arg) { $workingDir = $argv[$index + 1] ?? ''; }
+	if ('--output-dir' === $arg) { $outputDir = $argv[$index + 1] ?? ''; }
+}
+if ('' === $workingDir || '' === $outputDir) { fwrite(STDERR, 'missing scoper args'); exit(1); }
+function copy_tree(string $source, string $target): void {
+	if (is_dir($source)) {
+		@mkdir($target, 0777, true);
+		foreach (scandir($source) ?: array() as $entry) {
+			if ('.' === $entry || '..' === $entry) { continue; }
+			copy_tree($source . DIRECTORY_SEPARATOR . $entry, $target . DIRECTORY_SEPARATOR . $entry);
+		}
+		return;
+	}
+	@mkdir(dirname($target), 0777, true);
+	copy($source, $target);
+}
+copy_tree($workingDir, $outputDir);
+`)
+
+await rm(binDir, { recursive: true, force: true })
+await mkdir(binDir, { recursive: true })
+await writeFile(join(binDir, "composer"), String.raw`#!/bin/sh
+set -eu
+working_dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --working-dir) working_dir="$2"; shift 2 ;;
+    --working-dir=*) working_dir="\${1#--working-dir=}"; shift ;;
+    *) shift ;;
+  esac
+done
+if [ -z "$working_dir" ]; then working_dir="$PWD"; fi
+mkdir -p "$working_dir/vendor/composer" "$working_dir/vendor/psr/log/src"
+cat > "$working_dir/vendor/composer/installed.json" <<'JSON'
+{"packages":[{"name":"wordpress/php-ai-client","autoload":{"psr-4":{"WordPress\\AiClient\\":"src/"}}},{"name":"psr/log","autoload":{"psr-4":{"Psr\\Log\\":"src/"}}}]}
+JSON
+cat > "$working_dir/vendor/psr/log/src/LoggerInterface.php" <<'PHP'
+<?php
+namespace Psr\Log;
+interface LoggerInterface {}
+PHP
+`)
+await chmod(join(binDir, "composer"), 0o755)
+
+process.env.PATH = `${binDir}:${originalPath ?? ""}`
+process.env.WP_CODEBOX_PHP_SCOPER_PHAR = scoperPath
+
+const recipe: WorkspaceRecipe = {
+  runtime: {
+    wp: "latest",
+    overlays: [{
+      kind: "bundled-library",
+      library: "php-ai-client",
+      source: overlaySource,
+      strategy: "wordpress-scoped-bundle",
+    }],
+  },
+}
+
+const overlays = await prepareRecipeRuntimeOverlays(recipe, root)
+try {
+  assert.equal(overlays.length, 1)
+  assert.equal(await exists(join(overlaySource, "vendor")), false, "overlay source checkout must not be mutated")
+  assert.equal(await exists(join(overlays[0].source, "autoload.php")), true)
+  assert.equal(await exists(join(overlays[0].source, "src", "Client.php")), true)
+  assert.equal(await exists(join(overlays[0].source, "third-party", "Psr", "Log", "LoggerInterface.php")), true)
+  assert.match(await readFile(join(overlays[0].source, "src", "Client.php"), "utf8"), /WordPress\\AiClientDependencies\\Psr\\Log\\LoggerInterface/)
+} finally {
+  await Promise.all(overlays.flatMap((overlay) => overlay.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })))
+  process.env.PATH = originalPath
+  if (originalScoper === undefined) {
+    delete process.env.WP_CODEBOX_PHP_SCOPER_PHAR
+  } else {
+    process.env.WP_CODEBOX_PHP_SCOPER_PHAR = originalScoper
+  }
+  await rm(root, { recursive: true, force: true })
+}
+
+console.log("runtime-overlay-composer-hydration-smoke: ok")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -69,6 +69,7 @@ export const smokeGroups = {
       tsxSmoke("run-registry-smoke"),
       tsxSmoke("wordpress-state-contract-smoke"),
       tsxSmoke("playground-command-errors-smoke"),
+      tsxSmoke("runtime-overlay-composer-hydration-smoke"),
     ],
   },
   agent: {

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -69,7 +69,7 @@ export const smokeGroups = {
       tsxSmoke("run-registry-smoke"),
       tsxSmoke("wordpress-state-contract-smoke"),
       tsxSmoke("playground-command-errors-smoke"),
-      tsxSmoke("runtime-overlay-composer-hydration-smoke"),
+      tsxSmoke("composer-backed-source-hydration-smoke"),
     ],
   },
   agent: {


### PR DESCRIPTION
## Summary
- Adds generic Composer-backed source hydration for prepared sources that have `composer.json` but no `vendor/`.
- Applies the self-heal to runtime overlays and Composer package dependency overlays without mutating the original checkout.
- Fails early with direct remediation when `composer.json` or Composer is unavailable.

## Verification
- `npx tsx scripts/composer-backed-source-hydration-smoke.ts` passed
- `npm run build` passed
- Earlier `npm run smoke -- --group=runtime` completed 3/4 smokes, then was externally aborted before the hydration smoke was renamed and generalized

## Related
- Diagnoses Extra-Chill/homeboy#4609 as WP Codebox source preparation behavior.
- The self-heal is intentionally generic; WP AI Client being in WordPress core as of 7.0 is separate from the broader missing-vendor preflight/remediation behavior.