### PR TITLE
Ignore root Composer vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+vendor/
 dist/
 artifacts/
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
- Ignores a root-level `vendor/` directory created by Composer installs in this workspace.

## Verification
- `git status --short --branch` in the follow-up worktree reports only the committed `.gitignore` change before push.

## Context
- Follow-up to #988; the hydration fix was merged before this ignore rule landed on that branch.