### PR TITLE
Preserve recipe-run activation failure diagnostics

### DIFF
--- a/packages/cli/src/commands/recipe-run-artifact-pointers.ts
+++ b/packages/cli/src/commands/recipe-run-artifact-pointers.ts
@@ -3,7 +3,7 @@ import { join, relative } from "node:path"
 import type { ArtifactBundle, RuntimeInfo } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import type { RunOutput } from "../runtime-command-wrappers.js"
-import type { RecipeArtifactPointerCommandStatus, RecipeArtifactPointerState, RecipeBrowserEvidence, RecipePhaseEvidence } from "./recipe-run-types.js"
+import type { RecipeArtifactPointerCommandStatus, RecipeArtifactPointerState, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipePhaseEvidence } from "./recipe-run-types.js"
 
 export class RecipeArtifactPointerTracker {
   private command: string | undefined
@@ -13,6 +13,7 @@ export class RecipeArtifactPointerTracker {
   private failure: RunOutput["error"] | undefined
   private phases: RecipePhaseEvidence[] = []
   private browserEvidence: RecipeBrowserEvidence[] = []
+  private diagnosticArtifacts: RecipeDiagnosticArtifactRef[] = []
 
   constructor(private readonly directory: string | undefined, private readonly runId: string, private readonly recipePath: string, private readonly startedAt: string) {}
 
@@ -28,6 +29,7 @@ export class RecipeArtifactPointerTracker {
     this.failure = state.failure ?? (state.commandStatus === "completed" || state.commandStatus === "running" ? undefined : this.failure)
     this.phases = state.phases ?? this.phases
     this.browserEvidence = state.browserEvidence ?? this.browserEvidence
+    this.diagnosticArtifacts = state.diagnosticArtifacts ?? this.diagnosticArtifacts
 
     const pointer = stripUndefined({
       schema: "wp-codebox/recipe-run-artifact-pointer/v1",
@@ -43,6 +45,7 @@ export class RecipeArtifactPointerTracker {
       failure: this.failure,
       failurePhase: recipeArtifactPointerFailurePhase(this.failure, this.phases),
       browserEvidence: this.browserEvidence.length > 0 ? this.browserEvidence : undefined,
+      diagnosticArtifacts: this.diagnosticArtifacts.length > 0 ? this.diagnosticArtifacts : undefined,
       ...await recipeArtifactPointerArtifactState(this.directory, this.runtime, this.artifacts),
     })
 

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -119,6 +119,14 @@ export interface RecipeArtifactPointerState {
   failure?: RunOutput["error"]
   phases?: RecipePhaseEvidence[]
   browserEvidence?: RecipeBrowserEvidence[]
+  diagnosticArtifacts?: RecipeDiagnosticArtifactRef[]
+}
+
+export interface RecipeDiagnosticArtifactRef {
+  path: string
+  kind: string
+  contentType: string
+  sha256?: string
 }
 
 export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "import_fixture_databases" | "run_workloads" | "run_probes" | "collect_artifacts"

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { cp, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
 import { DEFAULT_WORDPRESS_VERSION, artifactBundleRunRef, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
@@ -20,7 +20,7 @@ import { createRecipeRunContext } from "./recipe-run-context.js"
 import { createRecipeInterruptionController, interruptedRecipeOutput, markRecipeArtifactsFinalized, recipeInterruptionSerializedError } from "./recipe-run-interruption.js"
 import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, isRecipeRunTimeoutError, printJsonFailureDiagnostic, recipeRunFailureStatus, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError, RecipeRunTimeoutError, RecipeRuntimeCreateError, remainingRecipeTimeoutMs, serializeRecipeRunError, watchRecipeOperation, writeRecipeJsonOutput } from "./recipe-run-output.js"
 import { RecipePhaseError, RecipePhaseTracker } from "./recipe-run-phases.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
@@ -532,6 +532,24 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       run: runRecord,
     }
   } catch (error) {
+    const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
+    const failureDiagnostics = recipeFailureRuntimeEvidenceFile({
+      recipe,
+      recipePath,
+      extraPlugins,
+      dependencyOverlays,
+      workspaceMounts,
+      stagedFiles,
+      overlays,
+      executions,
+      fixtureDatabases,
+      probes,
+      declaredArtifacts,
+      phaseEvidence: phaseTracker.list(),
+      diagnostics: recipeRuntimeDiagnostics(recipe, executions, error) ?? [],
+      error: serializedError,
+    })
+    let diagnosticArtifacts: RecipeDiagnosticArtifactRef[] = []
     if (runtime) {
       const activeRuntime = runtime
       artifacts = await phaseTracker.run("collect_artifacts", { failureRecovery: true, includeLogs: true, includeObservations: true }, async () => await collectAndFinalizeFailedRecipeArtifacts({
@@ -546,13 +564,20 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         interruption,
       }))
       if (artifacts) {
+        const collectedArtifacts = artifacts
         browserEvidence = await recipeBrowserEvidence(artifacts, executions)
         await artifactPointer.update({ runtime: await activeRuntime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
         try {
           if (declaredArtifacts.length === 0) {
             declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, activeRuntime)
           }
-          await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts))
+          const evidenceFiles = await appendRecipeRuntimeEvidence(artifacts, [
+            ...recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts),
+            failureDiagnostics,
+          ])
+          diagnosticArtifacts = evidenceFiles
+            .filter((file) => file.kind === failureDiagnostics.kind)
+            .map((file) => ({ path: join(basename(collectedArtifacts.directory), file.path), kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
         } catch {
           // Preserve the original recipe failure; failure recovery already kept the base artifact bundle.
         }
@@ -572,12 +597,16 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       }
     }
 
+    if (diagnosticArtifacts.length === 0) {
+      const fallbackDiagnostic = await writeRecipeFailureDiagnosticArtifact(configuredArtifactsDirectory, failureDiagnostics.value)
+      diagnosticArtifacts = fallbackDiagnostic ? [fallbackDiagnostic] : []
+    }
+
     cleanupEvidence = await runRecipeCleanup(runRegistry, runRecord, async () => {
       await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays, dependencyOverlays)
       await cleanupInputMountBaselines(inputMountBaselinePaths)
     })
     runRecord = await runRegistry.read(runRecord.runId)
-    const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
     runRecord = await runRegistry.update(runRecord.runId, {
       status: recipeRunFailureStatus(error, interruption),
       ...(runtime ? { runtime: await runtime.info() } : {}),
@@ -585,7 +614,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: recipeRunFailureStatus(error, interruption), startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: serializedError, phaseEvidence: phaseTracker.list() }) },
       error: serializedError,
     })
-    await artifactPointer.update({ commandStatus: "failed", ...(runtime ? { runtime: await runtime.info() } : {}), ...(artifacts ? { artifacts } : {}), failure: serializedError, phases: phaseTracker.list(), browserEvidence })
+    await artifactPointer.update({ commandStatus: "failed", ...(runtime ? { runtime: await runtime.info() } : {}), ...(artifacts ? { artifacts } : {}), failure: serializedError, phases: phaseTracker.list(), browserEvidence, diagnosticArtifacts })
 
     return {
       success: false,
@@ -1524,6 +1553,72 @@ function recipeRuntimeEvidenceFiles(fixtureDatabases: RecipeRunFixtureDatabase[]
     ...(probes.length > 0 ? [{ filename: "recipe-probes.json", kind: "recipe-probe-results", value: { schema: "wp-codebox/recipe-probe-results/v1", passed: !recipeProbeFailure(probes), probes } }] : []),
     ...(declaredArtifacts.length > 0 ? [{ filename: "recipe-declared-artifacts.json", kind: "recipe-declared-artifact-results", value: { schema: "wp-codebox/recipe-declared-artifact-results/v1", passed: !recipeDeclaredArtifactFailure(declaredArtifacts), artifacts: declaredArtifacts } }] : []),
   ]
+}
+
+function recipeFailureRuntimeEvidenceFile(args: {
+  recipe: WorkspaceRecipe
+  recipePath: string
+  extraPlugins: PreparedExtraPlugin[]
+  dependencyOverlays: PreparedDependencyOverlay[]
+  workspaceMounts: PreparedWorkspaceMount[]
+  stagedFiles: PreparedStagedFile[]
+  overlays: PreparedRuntimeOverlay[]
+  executions: RecipeExecutionResult[]
+  fixtureDatabases: RecipeRunFixtureDatabase[]
+  probes: RecipeRunProbe[]
+  declaredArtifacts: RecipeRunDeclaredArtifact[]
+  phaseEvidence: RecipePhaseEvidence[]
+  diagnostics: RecipeRuntimeDiagnostic[]
+  error: RunOutput["error"]
+}): { filename: string; kind: string; value: unknown } {
+  return {
+    filename: "recipe-run-failure-diagnostics.json",
+    kind: "recipe-run-failure-diagnostics",
+    value: stripUndefined({
+      schema: "wp-codebox/recipe-run-failure-diagnostics/v1",
+      createdAt: new Date().toISOString(),
+      recipe: {
+        path: args.recipePath,
+        schema: args.recipe.schema,
+        runtime: args.recipe.runtime ?? {},
+        workflow: recipeWorkflowMetadata(args.recipe),
+        inputs: {
+          extra_plugins: args.extraPlugins.map(recipeRunExtraPlugin),
+          dependency_overlays: args.dependencyOverlays.map(recipeRunDependencyOverlay),
+          workspaces: args.workspaceMounts.map((workspace) => ({ target: workspace.target, mode: workspace.mode, metadata: workspace.metadata })),
+          stagedFiles: args.stagedFiles.map(recipeRunStagedFile),
+          secretEnv: args.recipe.inputs?.secretEnv ?? [],
+        },
+        artifacts: args.recipe.artifacts ?? {},
+      },
+      preparedRuntimeOverlays: args.overlays.map((overlay) => ({ target: overlay.target, type: overlay.type, mode: overlay.mode, metadata: overlay.metadata })),
+      executions: args.executions,
+      fixtureDatabases: args.fixtureDatabases,
+      probes: args.probes,
+      declaredArtifacts: args.declaredArtifacts,
+      phaseEvidence: args.phaseEvidence,
+      diagnostics: args.diagnostics,
+      error: args.error,
+    }),
+  }
+}
+
+async function writeRecipeFailureDiagnosticArtifact(artifactsDirectory: string | undefined, value: unknown): Promise<RecipeDiagnosticArtifactRef | undefined> {
+  if (!artifactsDirectory) {
+    return undefined
+  }
+
+  const directory = resolve(artifactsDirectory)
+  const path = join(directory, "recipe-run-failure-diagnostics.json")
+  const contents = `${JSON.stringify(value, null, 2)}\n`
+  await mkdir(directory, { recursive: true })
+  await writeFile(path, contents)
+  return {
+    path: "recipe-run-failure-diagnostics.json",
+    kind: "recipe-run-failure-diagnostics",
+    contentType: "application/json",
+    sha256: createHash("sha256").update(contents).digest("hex"),
+  }
 }
 
 function parseFixtureDatabaseImportResult(stdout: string): { counts: Record<string, number> } {

--- a/scripts/recipe-run-activation-failure-artifacts-smoke.ts
+++ b/scripts/recipe-run-activation-failure-artifacts-smoke.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-activation-failure-artifacts-"))
+
+try {
+  const pluginSource = join(workspace, "failing-plugin")
+  const artifacts = join(workspace, "artifacts")
+  const recipePath = join(workspace, "recipe.json")
+  await mkdir(pluginSource, { recursive: true })
+  await writeFile(join(pluginSource, "failing-plugin.php"), `<?php
+/**
+ * Plugin Name: WP Codebox Activation Failure Smoke
+ */
+register_activation_hook(__FILE__, function () {
+    throw new RuntimeException('activation failure smoke sentinel');
+});
+`)
+  await writeFile(recipePath, `${JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: {
+      backend: "wordpress-playground",
+      name: "recipe-run-activation-failure-artifacts-smoke",
+      wp: "7.0",
+      blueprint: { steps: [] },
+    },
+    inputs: {
+      extra_plugins: [
+        {
+          source: pluginSource,
+          slug: "failing-plugin",
+          pluginFile: "failing-plugin/failing-plugin.php",
+        },
+      ],
+    },
+    workflow: {
+      steps: [
+        {
+          command: "wordpress.run-php",
+          args: ["code=<?php echo 'unreachable';"],
+        },
+      ],
+    },
+  }, null, 2)}\n`)
+
+  const result = spawnSync(process.execPath, [
+    cli,
+    "recipe-run",
+    "--recipe",
+    recipePath,
+    "--artifacts",
+    artifacts,
+    "--json",
+  ], { cwd: root, encoding: "utf8" })
+
+  assert.equal(result.status, 1, `recipe-run should fail activation; stdout: ${result.stdout}; stderr: ${result.stderr}`)
+  assert.ok(result.stdout.trim(), `recipe-run should emit JSON output; stderr: ${result.stderr}`)
+  const output = JSON.parse(result.stdout)
+  assert.equal(output.schema, "wp-codebox/recipe-run/v1")
+  assert.equal(output.success, false)
+  assert.match(JSON.stringify(output.error), /activation failure smoke sentinel|Failed to activate extra plugin/i)
+  assert.ok(output.artifacts?.directory, "activation failure should report a runtime artifact directory")
+
+  const pointer = JSON.parse(await readFile(join(artifacts, "manifest.json"), "utf8"))
+  assert.equal(pointer.schema, "wp-codebox/recipe-run-artifact-pointer/v1")
+  assert.equal(pointer.commandStatus, "failed")
+  assert.equal(pointer.failurePhase, "activate_plugins")
+  assert.ok(pointer.paths?.runtimeManifest, "pointer should expose the failed runtime manifest")
+  assert.ok(Array.isArray(pointer.diagnosticArtifacts), "pointer should expose diagnostic artifact refs")
+
+  const failureDiagnostic = pointer.diagnosticArtifacts.find((artifact: { kind?: string }) => artifact.kind === "recipe-run-failure-diagnostics")
+  assert.ok(failureDiagnostic, "pointer should expose recipe-run failure diagnostics")
+
+  const diagnostics = JSON.parse(await readFile(join(artifacts, failureDiagnostic.path), "utf8"))
+  assert.equal(diagnostics.schema, "wp-codebox/recipe-run-failure-diagnostics/v1")
+  assert.equal(diagnostics.recipe.path, recipePath)
+  assert.equal(diagnostics.recipe.inputs.extra_plugins[0].pluginFile, "failing-plugin/failing-plugin.php")
+  assert.equal(diagnostics.recipe.inputs.secretEnv.length, 0)
+  assert.equal(diagnostics.phaseEvidence.some((phase: { name: string; status: string }) => phase.name === "activate_plugins" && phase.status === "failed"), true)
+
+  const runtimeManifest = JSON.parse(await readFile(join(artifacts, pointer.paths.runtimeManifest), "utf8"))
+  const runtimeDiagnosticPath = failureDiagnostic.path.split("/").slice(1).join("/")
+  assert.equal(runtimeManifest.files.some((file: { kind?: string; path?: string }) => file.kind === "recipe-run-failure-diagnostics" && file.path === runtimeDiagnosticPath), true)
+
+  console.log("recipe run activation failure artifact smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Preserve durable recipe-run failure diagnostics as artifact evidence and expose them from the top-level artifact pointer manifest.
- Include prepared extra plugin provenance, phase evidence, executions, diagnostics, and redacted secret-env names for activation/setup failures.
- Add smoke coverage for an extra plugin that fails during activation.

## Testing
- npm run build
- node --import tsx scripts/recipe-run-activation-failure-artifacts-smoke.ts
- node --import tsx scripts/recipe-run-summary-smoke.ts

Fixes #991