### PR TITLE
Add replay package export step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,17 @@ Current bundles include:
 - `files/diffs/<mount>.patch`: unified text diff from the mount baseline (a seeded baseline directory, or the git `HEAD` of a git work-tree mount) to the sandbox output.
 - `files/mounts/<index>/...`: copied file contents from readwrite mounts.
 
+Recipes that import a generated site into a clean runtime can export replay evidence before final artifact collection with a workflow step:
+
+```json
+{
+  "command": "wordpress.export-replay-package",
+  "args": ["label=studio-web-replay", "landing-page=/"]
+}
+```
+
+The step writes `files/replay-package/manifest.json`, `blueprint.after.json`, `blueprint.after-notes.json`, and `files/runtime-snapshot.json` under the runtime artifact root. Its stdout is a `wp-codebox/wordpress-replay-export/v1` envelope with `importMs`, `materializeMs`, `snapshotMs`, `exportMs`, `databaseTables`, `wpContentFiles`, `snapshotBytes`, and `blueprintBytes`. The exported `blueprint.after.json` keeps the runtime snapshot as a referenced package file instead of embedding the full snapshot as one large `runPHP` string.
+
 `metadata.json` points to the canonical changed-files, patch, test-results, review, and mount-diff artifact paths under `artifacts`. It also includes `provenance` derived from data WP Codebox already has: task input/context where available, WP Codebox runtime version, WordPress version, mounted component/mount metadata, and agent/provider/model fields passed to the sandbox runner. `files/diffs/<mount>.patch` remains available for per-mount detail; `files/patch.diff` is the combined review/apply-back patch surface.
 
 ### `files/test-results.json`

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -64,6 +64,20 @@ export const commandRegistry = [
     handler: { kind: "playground", method: "runCaptureStateBundle" },
   },
   {
+    id: "wordpress.export-replay-package",
+    description: "Export the current imported WordPress runtime as a replay package with a compact blueprint, external runtime snapshot, notes, manifest, and metrics.",
+    acceptedArgs: [
+      { name: "label", description: "Optional human-readable export label recorded in the command output and package source metadata.", format: "string" },
+      { name: "output-dir", description: "Optional package directory relative to the runtime artifact root; defaults to files/replay-package.", format: "relative path" },
+      { name: "landing-page", description: "Optional replay landing page recorded in blueprint.after.json.", format: "path" },
+      { name: "import-ms", description: "Optional importer duration supplied by the caller so replay export metrics can include the preceding import phase.", format: "non-negative integer" },
+    ],
+    outputShape: "wp-codebox/wordpress-replay-export/v1 JSON with import/materialization/snapshot/export metrics and manifest, blueprint.after.json, blueprint.after-notes.json, and files/runtime-snapshot.json artifact paths.",
+    policyRequirement: "Runtime policy commands must include wordpress.export-replay-package.",
+    recipe: true,
+    handler: { kind: "playground", method: "runExportReplayPackage" },
+  },
+  {
     id: "wordpress.ability",
     description: "Execute a registered WordPress Ability in the sandbox.",
     acceptedArgs: [

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -142,6 +142,7 @@ export class ArtifactBundleBuilder {
         .filter((ref): ref is typeof ref & { path: string } => typeof ref.path === "string" && ref.path.length > 0)
         .map((ref) => artifactManifestFile(join(source.artifactRoot, ref.path), "runtime-snapshot", "application/json")),
     )
+    const replayExportPackageFiles = replayExportPackageManifestFiles(source.artifactRoot, source.commands)
     const capturedMounts = await source.captureMountedFiles(filesDirectory, redactor)
     const { mountDiffs, changedFiles, patch, diagnostics: mountDiffDiagnostics } = await source.captureMountDiffs(filesDirectory, redactor)
     const changedFilesJson = redactor.redact("files/changed-files.json", `${JSON.stringify(changedFiles, null, 2)}\n`)
@@ -323,6 +324,7 @@ export class ArtifactBundleBuilder {
       ...source.pluginCheckManifestFiles(),
       ...source.themeCheckManifestFiles(),
       ...runtimeSnapshotFiles,
+      ...replayExportPackageFiles,
       ...mountDiffs.map((diff) => artifactManifestFile(join(source.artifactRoot, diff.artifactPath), "diff", "text/x-diff")),
       ...capturedMounts.files.map((file) =>
         artifactManifestFile(join(source.artifactRoot, file.artifactPath), "file", file.contentType),
@@ -1085,6 +1087,50 @@ function artifactPreviewContentType(path: string): string {
   }
 
   return "application/octet-stream"
+}
+
+function replayExportPackageManifestFiles(artifactRoot: string, commands: ExecutionResult[]): ArtifactManifestFile[] {
+  return commands.flatMap((command) => {
+    if (command.command !== "wordpress.export-replay-package" || command.exitCode !== 0) {
+      return []
+    }
+
+    let output: unknown
+    try {
+      output = JSON.parse(command.stdout.trim() || "{}")
+    } catch {
+      return []
+    }
+
+    const envelope = asRecord(output)
+    const artifacts = asRecord(envelope?.artifacts)
+    const directory = stringValue(envelope?.directory)
+    if (envelope?.schema !== "wp-codebox/wordpress-replay-export/v1" || !directory || !artifacts) {
+      return []
+    }
+
+    const refs: Array<{ key: string; kind: string; contentType: string }> = [
+      { key: "manifest", kind: "replay-package-manifest", contentType: "application/json" },
+      { key: "blueprint", kind: "blueprint-after", contentType: "application/json" },
+      { key: "snapshot", kind: "runtime-snapshot", contentType: "application/json" },
+      { key: "notes", kind: "blueprint-after-notes", contentType: "application/json" },
+    ]
+
+    return refs.flatMap((ref) => {
+      const artifactPath = stringValue(artifacts[ref.key])
+      if (!artifactPath) {
+        return []
+      }
+
+      const absolutePath = join(directory, artifactPath)
+      const manifestPath = relative(artifactRoot, absolutePath).replace(/\\/g, "/")
+      if (manifestPath.startsWith("..") || manifestPath.startsWith("/")) {
+        return []
+      }
+
+      return [artifactManifestFile(join(artifactRoot, manifestPath), ref.kind, ref.contentType)]
+    })
+  })
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -8,6 +8,7 @@ interface PlaygroundCommandRuntime {
   runPhp(spec: ExecutionSpec): Promise<string>
   runWpCli(spec: ExecutionSpec): Promise<string>
   runCaptureStateBundle(spec: ExecutionSpec): Promise<string>
+  runExportReplayPackage(spec: ExecutionSpec): Promise<string>
   runRestRequest(spec: ExecutionSpec): Promise<string>
   runAbility(spec: ExecutionSpec): Promise<string>
   runBench(spec: ExecutionSpec): Promise<string>
@@ -30,6 +31,7 @@ const playgroundCommandHandlers = {
   "wordpress.run-php": (runtime, spec) => runtime.runPhp(spec),
   "wordpress.wp-cli": (runtime, spec) => runtime.runWpCli(spec),
   "wordpress.capture-state-bundle": (runtime, spec) => runtime.runCaptureStateBundle(spec),
+  "wordpress.export-replay-package": (runtime, spec) => runtime.runExportReplayPackage(spec),
   "wordpress.rest-request": (runtime, spec) => runtime.runRestRequest(spec),
   "wordpress.ability": (runtime, spec) => runtime.runAbility(spec),
   "wordpress.bench": (runtime, spec) => runtime.runBench(spec),

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -4,6 +4,6 @@ export { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "./bro
 export { createHostCommandTool, type HostCommandToolConfig } from "./host-command-tool.js"
 export { PlaygroundRuntimeBackend, createPlaygroundRuntimeBackend, playgroundRuntimeBackendProvider } from "./playground-runtime.js"
 export { preflightPhpWasmRuntimeAssets, PhpWasmRuntimeAssetIntegrityError, type PhpWasmRuntimeAssetPreflight, type PhpWasmRuntimeAssetPreflightOptions } from "./php-wasm-preflight.js"
-export { buildReplayableWordPressSiteBlueprint, buildReplayableWordPressSiteLimitations, writeReplayableWordPressSiteBundle, type ReplayableWordPressSiteBundle, type ReplayableWordPressSiteBundleManifest, type ReplayableWordPressSiteBundleOptions } from "./replayable-wordpress-site-bundle.js"
+export { buildReplayExportBlueprint, buildReplayableWordPressSiteBlueprint, buildReplayableWordPressSiteLimitations, writeReplayExportPackage, writeReplayableWordPressSiteBundle, type ReplayExportPackage, type ReplayExportPackageOptions, type ReplayableWordPressSiteBundle, type ReplayableWordPressSiteBundleManifest, type ReplayableWordPressSiteBundleOptions } from "./replayable-wordpress-site-bundle.js"
 export type { RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
 export type { PlaygroundCliModule } from "./playground-cli-runner.js"

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -18,6 +18,7 @@ import { materializePlaygroundMountsFromVfs } from "./mount-materialization.js"
 import { runAbilityCommand, runBenchCommand, runCorePhpunitCommand, runPhpCommand, runPhpunitCommand, runPluginCheckCommand, runRestRequestCommand, runThemeCheckCommand } from "./wordpress-command-runners.js"
 import { PlaygroundSnapshotRestoreError, contentDigest, mountsFromSnapshot, runtimeSnapshotExportPayload, runtimeSnapshotExportPhp, runtimeSnapshotPayload, runtimeSnapshotRestorePhp, runtimeSpecFromSnapshot, snapshotDigest, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
 import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
+import { writeReplayExportPackage } from "./replayable-wordpress-site-bundle.js"
 import { preflightPhpWasmRuntimeAssets } from "./php-wasm-preflight.js"
 import { previewReviewerAccess } from "./preview-reviewer-access.js"
 import type {
@@ -823,6 +824,67 @@ class PlaygroundRuntime implements Runtime {
     }, null, 2)}\n`
   }
 
+  async runExportReplayPackage(spec: ExecutionSpec): Promise<string> {
+    const label = stringArg(spec.args ?? [], "label")
+    const landingPage = stringArg(spec.args ?? [], "landing-page")
+    const outputDirectory = replayExportOutputDirectory(this.artifactRoot, stringArg(spec.args ?? [], "output-dir"))
+    const importMs = nonNegativeIntegerStringArg(spec.args ?? [], "import-ms") ?? 0
+
+    const materializeStartedAtMs = Date.now()
+    let materialization: Awaited<ReturnType<typeof materializePlaygroundMountsFromVfs>> | undefined
+    if (this.status !== "destroyed" && this.cliServerPromise) {
+      materialization = await materializePlaygroundMountsFromVfs(await this.cliServerPromise, this.mounts)
+      if (materialization.materialized > 0 || materialization.deleted > 0 || materialization.skipped > 0) {
+        this.recordEvent("runtime.mounts.materialized", { ...materialization, source: "wordpress.export-replay-package" })
+      }
+    }
+    const materializeMs = Date.now() - materializeStartedAtMs
+
+    const snapshotStartedAtMs = Date.now()
+    const snapshot = await this.snapshot()
+    const snapshotMs = Date.now() - snapshotStartedAtMs
+    const payload = await runtimeSnapshotPayload(snapshot)
+
+    const exportStartedAtMs = Date.now()
+    const replayPackage = await writeReplayExportPackage(payload, {
+      directory: outputDirectory,
+      landingPage,
+      importMs,
+      materializeMs,
+      snapshotMs,
+      source: {
+        ...(label ? { label } : {}),
+        command: "wordpress.export-replay-package",
+        runtimeId: this.runtimeId,
+        snapshotId: snapshot.id,
+        artifactRoot: this.artifactRoot,
+        ...(materialization ? { materialization } : {}),
+      },
+    })
+    replayPackage.metrics.exportMs = Date.now() - exportStartedAtMs
+
+    this.recordEvent("runtime.replay-package.exported", {
+      directory: replayPackage.directory,
+      metrics: replayPackage.metrics,
+      artifacts: replayPackage.artifacts,
+    })
+
+    return `${JSON.stringify({
+      schema: "wp-codebox/wordpress-replay-export/v1",
+      status: replayPackage.status,
+      ...(label ? { label } : {}),
+      replayStatus: "replayable-runtime-state",
+      directory: replayPackage.directory,
+      metrics: replayPackage.metrics,
+      artifacts: replayPackage.artifacts,
+      manifest: {
+        id: replayPackage.manifest.id,
+        contentDigest: replayPackage.manifest.contentDigest,
+        createdAt: replayPackage.manifest.createdAt,
+      },
+    }, null, 2)}\n`
+  }
+
   async runPluginCheck(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
     const result = await runPluginCheckCommand({
@@ -1063,6 +1125,25 @@ function stringArg(args: string[], name: string): string | undefined {
   const prefix = `${name}=`
   const value = args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length).trim()
   return value && value.length > 0 ? value : undefined
+}
+
+function nonNegativeIntegerStringArg(args: string[], name: string): number | undefined {
+  const value = stringArg(args, name)
+  if (!value) {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function replayExportOutputDirectory(artifactRoot: string, requested: string | undefined): string {
+  const relativePath = requested?.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "") || "files/replay-package"
+  if (relativePath.length === 0 || relativePath.includes("..")) {
+    throw new Error("wordpress.export-replay-package output-dir must be a relative path inside the runtime artifact root")
+  }
+
+  return join(artifactRoot, relativePath)
 }
 
 function wpContentRelativePath(path: string): string | undefined {

--- a/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
+++ b/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, stat, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import {
   artifactManifestFile,
@@ -21,9 +21,9 @@ export interface ReplayableWordPressSiteBundleManifest extends ArtifactManifest 
   schema: "wp-codebox/replayable-wordpress-site/v1"
   version: 1
   replayableWordPressSite: {
-    blueprintPath: "blueprint.json"
-    snapshotPath: "files/runtime-snapshot.json"
-    limitationsPath: "files/replay-limitations.json"
+    blueprintPath: string
+    snapshotPath: string
+    limitationsPath: string
     replayStatus: "replayable-runtime-state"
     source?: Record<string, unknown>
   }
@@ -39,6 +39,122 @@ export interface ReplayableWordPressSiteBundle {
   contentDigest: string
   createdAt: string
   manifest: ReplayableWordPressSiteBundleManifest
+}
+
+export interface ReplayExportPackageOptions extends ReplayableWordPressSiteBundleOptions {
+  importMs?: number
+  materializeMs?: number
+  snapshotMs?: number
+  exportMs?: number
+}
+
+export interface ReplayExportPackage {
+  status: "passed"
+  directory: string
+  metrics: {
+    importMs: number
+    materializeMs: number
+    snapshotMs: number
+    exportMs: number
+    databaseTables: number
+    wpContentFiles: number
+    snapshotBytes: number
+    blueprintBytes: number
+  }
+  artifacts: {
+    manifest: "manifest.json"
+    blueprint: "blueprint.after.json"
+    snapshot: "files/runtime-snapshot.json"
+    notes: "blueprint.after-notes.json"
+  }
+  manifest: ReplayableWordPressSiteBundleManifest
+}
+
+export async function writeReplayExportPackage(snapshot: RuntimeSnapshotArtifact, options: ReplayExportPackageOptions): Promise<ReplayExportPackage> {
+  const createdAt = options.createdAt ?? new Date().toISOString()
+  const directory = options.directory
+  const filesDirectory = join(directory, "files")
+  await mkdir(filesDirectory, { recursive: true })
+
+  const snapshotPath = join(filesDirectory, "runtime-snapshot.json")
+  const blueprintPath = join(directory, "blueprint.after.json")
+  const notesPath = join(directory, "blueprint.after-notes.json")
+  const manifestPath = join(directory, "manifest.json")
+  const blueprint = buildReplayExportBlueprint(snapshot, options)
+  const notes = buildReplayableWordPressSiteLimitations(snapshot, {
+    source: {
+      kind: "wordpress.export-replay-package",
+      snapshotPath: "files/runtime-snapshot.json",
+      mode: "external-runtime-snapshot",
+      ...(options.source ?? {}),
+    },
+  })
+
+  await writeJson(blueprintPath, blueprint)
+  await writeJson(snapshotPath, snapshot)
+  await writeJson(notesPath, notes)
+
+  const contentInputs = ["blueprint.after.json", "files/runtime-snapshot.json", "blueprint.after-notes.json"]
+  const contentDigest = await calculateArtifactContentDigest(directory, contentInputs)
+  const id = options.id ?? `replay-export-package-sha256-${contentDigest}`
+  const manifest: ReplayableWordPressSiteBundleManifest = {
+    schema: "wp-codebox/replayable-wordpress-site/v1",
+    version: 1,
+    id,
+    contentDigest: {
+      algorithm: "sha256",
+      inputs: contentInputs,
+      value: contentDigest,
+    },
+    createdAt,
+    runtime: runtimeInfoForReplayableWordPressSite(snapshot, id, createdAt, blueprint),
+    files: [
+      artifactManifestFile("manifest.json", "manifest", "application/json"),
+      artifactManifestFile("blueprint.after.json", "blueprint-after", "application/json"),
+      artifactManifestFile("files/runtime-snapshot.json", "runtime-snapshot", "application/json"),
+      artifactManifestFile("blueprint.after-notes.json", "blueprint-after-notes", "application/json"),
+    ],
+    replayableWordPressSite: {
+      blueprintPath: "blueprint.after.json",
+      snapshotPath: "files/runtime-snapshot.json",
+      limitationsPath: "blueprint.after-notes.json",
+      replayStatus: "replayable-runtime-state",
+      source: {
+        kind: "wordpress.export-replay-package",
+        snapshotPath: "files/runtime-snapshot.json",
+        mode: "external-runtime-snapshot",
+        ...(options.source ?? {}),
+      },
+    },
+  }
+
+  await refreshArtifactManifestFileSha256s(directory, manifest)
+  await writeJson(manifestPath, manifest)
+  await refreshArtifactManifestFileSha256s(directory, manifest)
+  await writeJson(manifestPath, manifest)
+
+  const [snapshotStats, blueprintStats] = await Promise.all([stat(snapshotPath), stat(blueprintPath)])
+  return {
+    status: "passed",
+    directory,
+    metrics: {
+      importMs: options.importMs ?? 0,
+      materializeMs: options.materializeMs ?? 0,
+      snapshotMs: options.snapshotMs ?? 0,
+      exportMs: options.exportMs ?? 0,
+      databaseTables: snapshot.database.tables.length,
+      wpContentFiles: snapshot.files.length,
+      snapshotBytes: snapshotStats.size,
+      blueprintBytes: blueprintStats.size,
+    },
+    artifacts: {
+      manifest: "manifest.json",
+      blueprint: "blueprint.after.json",
+      snapshot: "files/runtime-snapshot.json",
+      notes: "blueprint.after-notes.json",
+    },
+    manifest,
+  }
 }
 
 export async function writeReplayableWordPressSiteBundle(
@@ -121,6 +237,29 @@ export function buildReplayableWordPressSiteBlueprint(
         code: runtimeSnapshotRestorePhp(snapshot),
       },
     ],
+  }
+}
+
+export function buildReplayExportBlueprint(
+  snapshot: RuntimeSnapshotArtifact,
+  options: Pick<ReplayableWordPressSiteBundleOptions, "landingPage"> = {},
+): Record<string, unknown> {
+  return {
+    $schema: "https://playground.wordpress.net/blueprint-schema.json",
+    preferredVersions: {
+      wp: snapshot.compatibility.wordpressVersion,
+      php: snapshot.compatibility.phpVersion,
+    },
+    landingPage: options.landingPage ?? "/",
+    steps: [],
+    "x-wp-codebox": {
+      schema: "wp-codebox/replay-export-blueprint/v1",
+      replayStatus: "external-runtime-snapshot",
+      snapshotPath: "files/runtime-snapshot.json",
+      restoreCommand: "wordpress.run-php",
+      restoreCode: "runtimeSnapshotRestorePhp(files/runtime-snapshot.json)",
+      note: "The runtime snapshot is stored beside this blueprint instead of embedded as one large runPHP string.",
+    },
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `wordpress.export-replay-package` as a repeatable recipe/runtime step for exporting replay packages after a site has been imported into Playground.
- Emit replay manifest, compact `blueprint.after.json`, `blueprint.after-notes.json`, external `files/runtime-snapshot.json`, and import/materialization/snapshot/export metrics.
- Index exported replay package files during final artifact collection while keeping replay packaging decoupled from `runtime.collect-artifacts`.

## Verification
- `npm run build`
- Focused `writeReplayExportPackage` smoke with a synthetic runtime snapshot
- `git diff --check`

Closes #994