### PR TITLE
Prepare local recipe plugins with Composer autoload

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -39,7 +39,7 @@ export interface RecipeSourceProvenance {
     maxExtractedFiles: number
     sha256Required: boolean
   }
-  localPathCategory?: "recipe-relative" | "temporary-download"
+  localPathCategory?: "recipe-relative" | "temporary-download" | "temporary-composer-autoload"
 }
 
 interface PreparedExternalSource {
@@ -279,21 +279,70 @@ export async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeD
     const resolved = await prepareRecipeSource(plugin.source, recipeDirectory, slug, plugin.sha256)
     const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
     const loadAs = plugin.loadAs ?? "plugin"
-    await assertPreparedPluginFileExists(resolved.source, pluginFile.slice(slug.length + 1), plugin.source)
+    const prepared = await prepareComposerAutoloadForPlugin(resolved, slug, plugin.source)
+    await assertPreparedPluginFileExists(prepared.source, pluginFile.slice(slug.length + 1), plugin.source)
     plugins.push({
-      source: resolved.source,
+      source: prepared.source,
       slug,
       target: pluginTarget(slug, loadAs),
       pluginFile,
       activate: plugin.activate !== false,
       loadAs,
-      cleanupPaths: resolved.cleanupPaths,
-      provenance: resolved.provenance,
+      cleanupPaths: prepared.cleanupPaths,
+      provenance: prepared.provenance,
       metadata: plugin.metadata ?? {},
     })
   }
 
   return plugins
+}
+
+async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource, slug: string, sourceRef: string): Promise<PreparedExternalSource> {
+  if (prepared.provenance.kind !== "local") {
+    return prepared
+  }
+
+  try {
+    const composerJson = await stat(join(prepared.source, "composer.json"))
+    if (!composerJson.isFile()) {
+      return prepared
+    }
+  } catch {
+    return prepared
+  }
+
+  try {
+    const autoload = await stat(join(prepared.source, "vendor", "autoload.php"))
+    if (autoload.isFile()) {
+      return prepared
+    }
+  } catch {
+    // Prepare a temporary copy below.
+  }
+
+  const stagingRoot = await mkdtemp(join(tmpdir(), `wp-codebox-plugin-${slug}-`))
+  const stagedSource = join(stagingRoot, slug)
+  await cp(prepared.source, stagedSource, { recursive: true })
+  try {
+    await execFileAsync("composer", ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts", "--no-plugins"], {
+      cwd: stagedSource,
+      maxBuffer: 1024 * 1024 * 10,
+    })
+  } catch (error) {
+    await rm(stagingRoot, { recursive: true, force: true })
+    const detail = error instanceof Error && "stderr" in error && typeof error.stderr === "string" && error.stderr.trim() ? error.stderr.trim() : error instanceof Error ? error.message : String(error)
+    throw new Error(`Recipe extra plugin source requires Composer autoload but could not be prepared: ${sourceRef}: ${detail}`)
+  }
+
+  return {
+    ...prepared,
+    source: stagedSource,
+    cleanupPaths: [...prepared.cleanupPaths, stagingRoot],
+    provenance: {
+      ...prepared.provenance,
+      localPathCategory: "temporary-composer-autoload",
+    },
+  }
 }
 
 export async function prepareRecipeDependencyOverlays(recipe: WorkspaceRecipe, recipeDirectory: string, extraPlugins: PreparedExtraPlugin[]): Promise<PreparedDependencyOverlay[]> {

--- a/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
+++ b/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const cli = resolve(root, "packages/cli/dist/index.js")
+const artifacts = resolve(root, "artifacts/recipe-run-composer-autoload-extra-plugin-smoke")
+const pluginSource = resolve(artifacts, "source-plugin")
+const recipePath = resolve(artifacts, "recipe.json")
+
+rmSync(artifacts, { recursive: true, force: true })
+mkdirSync(resolve(pluginSource, "src"), { recursive: true })
+
+writeFileSync(resolve(pluginSource, "composer.json"), `${JSON.stringify({
+  name: "wp-codebox/composer-autoload-smoke",
+  autoload: { classmap: ["src/"] },
+  config: { "allow-plugins": false },
+}, null, 2)}\n`)
+
+writeFileSync(resolve(pluginSource, "composer-autoload-smoke.php"), `<?php
+/**
+ * Plugin Name: WP Codebox Composer Autoload Smoke
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$autoload = __DIR__ . '/vendor/autoload.php';
+if ( is_file( $autoload ) ) {
+	require_once $autoload;
+}
+
+register_activation_hook( __FILE__, static function (): void {
+	if ( ! class_exists( \\WpCodeboxComposerSmoke\\Fixture::class ) ) {
+		throw new RuntimeException( 'Composer classmap fixture was not autoloaded.' );
+	}
+
+	update_option( 'wp_codebox_composer_smoke_value', \\WpCodeboxComposerSmoke\\Fixture::value() );
+} );
+`)
+
+writeFileSync(resolve(pluginSource, "src", "Fixture.php"), `<?php
+
+namespace WpCodeboxComposerSmoke;
+
+final class Fixture {
+	public static function value(): int {
+		return 992;
+	}
+}
+`)
+
+writeFileSync(recipePath, `${JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: {
+    backend: "wordpress-playground",
+    name: "recipe-run-composer-autoload-extra-plugin-smoke",
+    wp: "7.0",
+    blueprint: { steps: [] },
+  },
+  inputs: {
+    extra_plugins: [
+      {
+        source: pluginSource,
+        slug: "composer-autoload-smoke",
+        pluginFile: "composer-autoload-smoke/composer-autoload-smoke.php",
+      },
+    ],
+  },
+  workflow: {
+    steps: [
+      {
+        command: "wordpress.run-php",
+        args: [
+          "code=if (!class_exists('WpCodeboxComposerSmoke\\\\Fixture')) { throw new RuntimeException('autoloaded class missing after plugin boot'); } echo wp_json_encode(array('value' => get_option('wp_codebox_composer_smoke_value'), 'active' => is_plugin_active('composer-autoload-smoke/composer-autoload-smoke.php')));",
+        ],
+      },
+    ],
+  },
+}, null, 2)}\n`)
+
+assert.equal(existsSync(resolve(pluginSource, "vendor", "autoload.php")), false, "fixture source should start without Composer vendor/autoload.php")
+
+const result = spawnSync(process.execPath, [
+  cli,
+  "recipe-run",
+  "--recipe",
+  recipePath,
+  "--artifacts",
+  artifacts,
+  "--json",
+], { cwd: root, encoding: "utf8" })
+
+assert.equal(result.status, 0, result.stderr || result.stdout)
+const output = JSON.parse(result.stdout)
+assert.equal(output.success, true)
+
+const workflowExecution = output.executions.find((execution: { command: string; recipePhase?: string }) => execution.command === "wordpress.run-php" && execution.recipePhase === "steps")
+assert.ok(workflowExecution)
+
+const workflowResult = JSON.parse(workflowExecution.stdout)
+assert.equal(workflowResult.value, "992")
+assert.equal(workflowResult.active, true)
+assert.equal(existsSync(resolve(pluginSource, "vendor", "autoload.php")), false, "recipe-run must not mutate the caller plugin checkout")
+assert.equal(existsSync(resolve(pluginSource, "composer.lock")), false, "recipe-run must not write Composer lockfiles into the caller plugin checkout")
+
+console.log("recipe run Composer autoload extra plugin smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -70,6 +70,7 @@ export const smokeGroups = {
       tsxSmoke("wordpress-state-contract-smoke"),
       tsxSmoke("playground-command-errors-smoke"),
       tsxSmoke("composer-backed-source-hydration-smoke"),
+      tsxSmoke("recipe-run-composer-autoload-extra-plugin-smoke"),
     ],
   },
   agent: {


### PR DESCRIPTION
## Summary
- Prepare local `recipe-run` `inputs.extra_plugins` sources with Composer autoload when they have `composer.json` but no `vendor/autoload.php`.
- Stage the plugin in a temporary copy and run Composer with `--no-dev --prefer-dist --no-interaction --no-progress --no-scripts --no-plugins`, leaving caller checkouts unchanged.
- Add a recipe-run smoke that activates a plugin whose activation hook requires a Composer classmap autoloaded class and asserts the source checkout remains unmodified.

Fixes #992.

## Verification
- `npm install` in isolated issue worktree (ran package prepare/build)
- `npm run build`
- `npm run smoke -- --command=recipe-run-composer-autoload-extra-plugin-smoke`
- `npm run smoke -- --group=runtime` was started; `run-registry-smoke`, `wordpress-state-contract-smoke`, and `playground-command-errors-smoke` passed before the command was interrupted by the caller.