### PR TITLE
Normalize replay export PHP versions

### DIFF
--- a/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
+++ b/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
@@ -228,7 +228,7 @@ export function buildReplayableWordPressSiteBlueprint(
     $schema: "https://playground.wordpress.net/blueprint-schema.json",
     preferredVersions: {
       wp: snapshot.compatibility.wordpressVersion,
-      php: snapshot.compatibility.phpVersion,
+      php: playgroundBlueprintPhpVersion(snapshot.compatibility.phpVersion),
     },
     landingPage: options.landingPage ?? "/",
     steps: [
@@ -249,7 +249,7 @@ export function buildReplayExportBlueprint(
     $schema: "https://playground.wordpress.net/blueprint-schema.json",
     preferredVersions: {
       wp: snapshot.compatibility.wordpressVersion,
-      php: snapshot.compatibility.phpVersion,
+      php: playgroundBlueprintPhpVersion(snapshot.compatibility.phpVersion),
     },
     landingPage: options.landingPage ?? "/",
     steps: [
@@ -317,6 +317,10 @@ function runtimeInfoForReplayableWordPressSite(
       blueprint,
     },
   }
+}
+
+function playgroundBlueprintPhpVersion(version: string): string {
+  return version.replace(/^(\d+\.\d+)\.\d+$/, "$1")
 }
 
 async function writeJson(path: string, value: unknown): Promise<void> {

--- a/scripts/replay-export-blueprint-smoke.ts
+++ b/scripts/replay-export-blueprint-smoke.ts
@@ -10,7 +10,7 @@ const snapshot: RuntimeSnapshotArtifact = {
   compatibility: {
     backend: "wordpress-playground",
     wordpressVersion: "latest",
-    phpVersion: "8.3",
+    phpVersion: "8.3.31",
   },
   metadata: {
     runtime: {
@@ -51,6 +51,11 @@ const validation = validateBlueprint(blueprint)
 
 if (!validation.valid) {
   throw new Error(`Replay export blueprint is not schema-valid: ${JSON.stringify(validation.errors, null, 2)}`)
+}
+
+const preferredVersions = blueprint.preferredVersions as Record<string, unknown> | undefined
+if (preferredVersions?.php !== "8.3") {
+  throw new Error(`Replay export blueprint must normalize patch-level PHP versions, got ${JSON.stringify(preferredVersions?.php)}`)
 }
 
 if ("x-wp-codebox" in blueprint) {


### PR DESCRIPTION
## Summary
- Normalize patch-level PHP runtime versions before writing Playground `preferredVersions.php`.
- Extend the replay export blueprint smoke so `phpVersion: \"8.3.31\"` emits schema-valid `preferredVersions.php: \"8.3\"`.

## Validation
- `npm run smoke -- --command=replay-export-blueprint-smoke`
- `npm run build`
- Generated a temp replay package with `phpVersion: \"8.3.31\"` and ran `node packages/cli/dist/index.js validate-blueprint --blueprint <tmp-package>/blueprint.after.json --json`; it printed `preferredVersions.php=8.3` and returned `success: true`.

Fixes #1000