### PR TITLE
Add neutral agent runtime execution signal

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -7,6 +7,8 @@ import type { TaskInput } from "./task-input.js"
 import { isPlainObject, stringList, stripUndefined } from "./object-utils.js"
 import type { WorkspaceRecipe, WorkspaceRecipeMount, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
 
+const AGENT_RUNTIME_ENV = { WP_CODEBOX_AGENT_RUNTIME: "1" }
+
 /**
  * Consumer-facing agent-task request fields accepted by the reusable recipe builder.
  *
@@ -113,7 +115,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
         ...componentPlugins(input.component_contracts, artifacts),
         ...providerPlugins,
       ].filter(Boolean),
-      runtimeEnv: runtimeEnv(input),
+      runtimeEnv: { ...runtimeEnv(input), ...AGENT_RUNTIME_ENV },
       secretEnv: stringList(input.secret_env),
       stagedFiles: stagedFiles.length > 0 ? stagedFiles : undefined,
       agent_bundles: Array.isArray(input.agent_bundles) && input.agent_bundles.length > 0 ? input.agent_bundles : undefined,

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -9,6 +9,8 @@ defined( 'ABSPATH' ) || exit;
 
 final class WP_Codebox_Host_Recipe_Builder {
 
+	private const AGENT_RUNTIME_ENV = array( 'WP_CODEBOX_AGENT_RUNTIME' => '1' );
+
 	/**
 	 * @param array<int,array<string,mixed>> $paths Component contracts.
 	 * @param array<string,mixed> $input Ability input.
@@ -97,7 +99,7 @@ final class WP_Codebox_Host_Recipe_Builder {
 			'inherit'       => $adapters['inheritance_request']( $input ),
 			'inheritance'   => $inheritance,
 			'extra_plugins' => array_merge( $adapters['component_plugins']( $paths ), $provider_plugins ),
-			'runtimeEnv'    => $adapters['runtime_env']( $input ),
+			'runtimeEnv'    => array_merge( $adapters['runtime_env']( $input ), self::AGENT_RUNTIME_ENV ),
 			'secretEnv'     => $adapters['secret_env_names']( $input, $inheritance ),
 		);
 		if ( ! empty( $agent_bundles ) ) {

--- a/scripts/agent-runtime-signal-smoke.ts
+++ b/scripts/agent-runtime-signal-smoke.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildAgentTaskRecipe } from "../packages/runtime-core/src/agent-task-recipe.js"
+import { normalizeTaskInput } from "../packages/runtime-core/src/task-input.js"
+import { runRecipeRunCommand } from "../packages/cli/src/commands/recipe-run.js"
+
+const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-signal-smoke-"))
+
+try {
+  const agentRecipe = buildAgentTaskRecipe({
+    goal: "report agent runtime signal",
+    runtime_env: { EXISTING_RUNTIME_ENV: "preserved", WP_CODEBOX_AGENT_RUNTIME: "caller-value" },
+  }, normalizeTaskInput({ goal: "report agent runtime signal" }), "latest")
+  assert.equal(agentRecipe.inputs?.runtimeEnv?.WP_CODEBOX_AGENT_RUNTIME, "1")
+  assert.equal(agentRecipe.inputs?.runtimeEnv?.EXISTING_RUNTIME_ENV, "preserved")
+  assert.ok(!agentRecipe.inputs?.secretEnv?.includes("WP_CODEBOX_AGENT_RUNTIME"))
+
+  agentRecipe.workflow.steps = [{
+    command: "wp-codebox.agent-sandbox-run",
+    args: [
+      "task=report agent runtime signal",
+      "code=echo getenv('WP_CODEBOX_AGENT_RUNTIME') ?: 'unset';",
+    ],
+  }]
+  const agentRecipePath = join(root, "agent-runtime-recipe.json")
+  writeFileSync(agentRecipePath, JSON.stringify(agentRecipe, null, 2))
+
+  const agentOutput = await runRecipe(agentRecipePath)
+  assert.equal(agentOutput.success, true)
+  const agentPayload = JSON.parse(String(agentOutput.executions?.[0]?.stdout ?? "{}")) as { output?: string }
+  assert.equal(agentPayload.output, "1")
+
+  const frontendRecipePath = join(root, "frontend-run-php-recipe.json")
+  writeFileSync(frontendRecipePath, JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: { backend: "wordpress-playground", wp: "latest", blueprint: { steps: [] } },
+    inputs: {},
+    workflow: {
+      steps: [{
+        command: "wordpress.run-php",
+        args: ["code=echo getenv('WP_CODEBOX_AGENT_RUNTIME') ?: 'unset';"],
+      }],
+    },
+  }, null, 2))
+
+  const frontendOutput = await runRecipe(frontendRecipePath)
+  assert.equal(frontendOutput.success, true)
+  assert.equal(frontendOutput.executions?.[0]?.stdout, "unset")
+
+  console.log("agent-runtime-signal-smoke: ok")
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
+
+async function runRecipe(recipePath: string): Promise<{ success?: boolean; executions?: Array<{ stdout?: string }> }> {
+  const output = await captureStdout(async () => await runRecipeRunCommand(["--recipe", recipePath, "--json"]))
+  return JSON.parse(output) as { success?: boolean; executions?: Array<{ stdout?: string }> }
+}
+
+async function captureStdout(callback: () => Promise<unknown>): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let stdout = ""
+  ;(process.stdout.write as typeof process.stdout.write) = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdout += typeof chunk === "string" ? chunk : chunk.toString()
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback()
+    } else if (callback) {
+      callback()
+    }
+    return true
+  }) as typeof process.stdout.write
+  try {
+    await callback()
+    return stdout
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -78,6 +78,7 @@ export const smokeGroups = {
     description: "Agent task, fanout, and delegation contract smoke checks.",
     commands: [
       tsxSmoke("agent-runtime-workload-normalizer-smoke"),
+      tsxSmoke("agent-runtime-signal-smoke"),
       tsxSmoke("agent-sandbox-incomplete-scope-smoke"),
       tsxSmoke("recipe-run-summary-smoke"),
       tsxSmoke("fanout-contract-smoke"),


### PR DESCRIPTION
## Summary
- Add host-agnostic `WP_AGENT_RUNTIME=1` as a non-secret runtime env signal for agent runtime recipe execution.
- Apply the signal in both the WordPress host recipe builder and reusable runtime-core agent task recipe builder.
- Add smoke coverage proving agent runtime `wordpress.run-php` sees the signal while a normal `wordpress.run-php` recipe does not get it by default.

Fixes #1002.

## Testing
- `npm exec -- tsx scripts/agent-runtime-signal-smoke.ts`
- `npm run build`
- `npm run smoke -- --group=agent`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php`