### PR TITLE
Use neutral agent runtime signal

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -7,7 +7,7 @@ import type { TaskInput } from "./task-input.js"
 import { isPlainObject, stringList, stripUndefined } from "./object-utils.js"
 import type { WorkspaceRecipe, WorkspaceRecipeMount, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
 
-const AGENT_RUNTIME_ENV = { WP_CODEBOX_AGENT_RUNTIME: "1" }
+const AGENT_RUNTIME_ENV = { WP_AGENT_RUNTIME: "1" }
 
 /**
  * Consumer-facing agent-task request fields accepted by the reusable recipe builder.

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 final class WP_Codebox_Host_Recipe_Builder {
 
-	private const AGENT_RUNTIME_ENV = array( 'WP_CODEBOX_AGENT_RUNTIME' => '1' );
+	private const AGENT_RUNTIME_ENV = array( 'WP_AGENT_RUNTIME' => '1' );
 
 	/**
 	 * @param array<int,array<string,mixed>> $paths Component contracts.

--- a/scripts/agent-runtime-signal-smoke.ts
+++ b/scripts/agent-runtime-signal-smoke.ts
@@ -11,17 +11,17 @@ const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-signal-smoke-"
 try {
   const agentRecipe = buildAgentTaskRecipe({
     goal: "report agent runtime signal",
-    runtime_env: { EXISTING_RUNTIME_ENV: "preserved", WP_CODEBOX_AGENT_RUNTIME: "caller-value" },
+    runtime_env: { EXISTING_RUNTIME_ENV: "preserved", WP_AGENT_RUNTIME: "caller-value" },
   }, normalizeTaskInput({ goal: "report agent runtime signal" }), "latest")
-  assert.equal(agentRecipe.inputs?.runtimeEnv?.WP_CODEBOX_AGENT_RUNTIME, "1")
+  assert.equal(agentRecipe.inputs?.runtimeEnv?.WP_AGENT_RUNTIME, "1")
   assert.equal(agentRecipe.inputs?.runtimeEnv?.EXISTING_RUNTIME_ENV, "preserved")
-  assert.ok(!agentRecipe.inputs?.secretEnv?.includes("WP_CODEBOX_AGENT_RUNTIME"))
+  assert.ok(!agentRecipe.inputs?.secretEnv?.includes("WP_AGENT_RUNTIME"))
 
   agentRecipe.workflow.steps = [{
     command: "wp-codebox.agent-sandbox-run",
     args: [
       "task=report agent runtime signal",
-      "code=echo getenv('WP_CODEBOX_AGENT_RUNTIME') ?: 'unset';",
+      "code=echo getenv('WP_AGENT_RUNTIME') ?: 'unset';",
     ],
   }]
   const agentRecipePath = join(root, "agent-runtime-recipe.json")
@@ -40,7 +40,7 @@ try {
     workflow: {
       steps: [{
         command: "wordpress.run-php",
-        args: ["code=echo getenv('WP_CODEBOX_AGENT_RUNTIME') ?: 'unset';"],
+        args: ["code=echo getenv('WP_AGENT_RUNTIME') ?: 'unset';"],
       }],
     },
   }, null, 2))


### PR DESCRIPTION
## Summary
- Replace merged `WP_CODEBOX_AGENT_RUNTIME=1` with neutral `WP_AGENT_RUNTIME=1`.
- Update runtime-core, WordPress host recipe builder, and smoke coverage to avoid requiring runtime consumers to know about WP Codebox.
- This is a forward-fix for the boundary issue in #1003.

## Testing
- Previously run on this branch before #1003 merged:
- `npm exec -- tsx scripts/agent-runtime-signal-smoke.ts`
- `npm run build`
- `npm run smoke -- --group=agent`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php`

Refs #1002.
Follow-up to #1003.