### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -95,6 +95,13 @@ final class WP_Codebox_Abilities {
 		}
 
 		$register_category = static function (): void {
+			// Core's `wp_abilities_api_categories_init` action can fire more than
+			// once per request (e.g. on multisite), so guard against re-registering
+			// an already-registered category to avoid a `_doing_it_wrong` notice.
+			if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'wp-codebox' ) ) {
+				return;
+			}
+
 			wp_register_ability_category(
 				'wp-codebox',
 				array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "wp-codebox" is already registered.
```

## Root cause

On WordPress multisite, core's `wp_abilities_api_categories_init` action fires more than once per request. wp-codebox registered its `wp-codebox` ability category unconditionally inside that callback, so on the second fire it re-registered an already-registered category and tripped core's `_doing_it_wrong` notice.

## The fix

Guard the `wp_register_ability_category( 'wp-codebox', ... )` call with core's idempotency check `wp_has_ability_category( 'wp-codebox' )` (itself guarded with `function_exists` since it ships with the same 6.9 API). A repeat hook fire is now a clean no-op. Slug, label, description, and the registration hook are unchanged.