### PR TITLE
fix: map package.json version targets to artifact paths for deploy verification

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -9,18 +9,22 @@
   "version_targets": [
     {
       "file": "package.json",
+      "artifact_path": "vendor/wp-codebox-cli/package.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
     {
       "file": "packages/runtime-core/package.json",
+      "artifact_path": "vendor/wp-codebox-cli/packages/runtime-core/package.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
     {
       "file": "packages/runtime-playground/package.json",
+      "artifact_path": "vendor/wp-codebox-cli/packages/runtime-playground/package.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
     {
       "file": "packages/cli/package.json",
+      "artifact_path": "vendor/wp-codebox-cli/packages/cli/package.json",
       "pattern": "\"version\":\\s*\"([0-9.]+)\""
     },
     {


### PR DESCRIPTION
## Problem

`homeboy deploy wp-codebox` fails verification (blocks #1008):

```
Artifact 'wp-codebox.zip' does not contain version target 'package.json'
for component 'wp-codebox'. Refusing to deploy unverified content.
```

The plugin zip (`scripts/build-wordpress-plugin-zip.ts`) stages the bundled CLI under `wp-codebox/vendor/wp-codebox-cli/...`, so the npm `package.json` version targets land at:

- `package.json` → `vendor/wp-codebox-cli/package.json`
- `packages/runtime-core/package.json` → `vendor/wp-codebox-cli/packages/runtime-core/package.json`
- `packages/runtime-playground/package.json` → `vendor/wp-codebox-cli/packages/runtime-playground/package.json`
- `packages/cli/package.json` → `vendor/wp-codebox-cli/packages/cli/package.json`

Homeboy's deploy verifier requires **every** `version_target` to be present inside the artifact (matched by full/segment-stripped path or basename). The four `package.json` targets are git-source paths that don't match their in-artifact locations, so verification fails — even though every file carries the correct `0.8.3`.

## Fix

Homeboy supports a per-target `artifact_path` override ("the shipped artifact may carry the bumped version at a different path... verify against that path inside the ZIP" — `src/core/deploy/execution.rs`). This adds `artifact_path` to each `package.json` target pointing at its real location in the plugin zip. The `wp-codebox.php` targets already match by basename and are unchanged.

## Verification

All four bundled `package.json` files in the v0.8.3 artifact carry `"version": "0.8.3"`, matching the released version. JSON validated.

Fixes #1008.