### PR TITLE
Fix runtime component ability lifecycle replay

### DIFF
--- a/docs/runtime-component-lifecycle.md
+++ b/docs/runtime-component-lifecycle.md
@@ -1,0 +1,13 @@
+# Runtime Component Lifecycle
+
+WP Codebox runtime tasks may load component entries after WordPress has already booted. To keep component behavior deterministic, Codebox replays the runtime component lifecycle before agent execution:
+
+1. `plugins_loaded`
+2. `init`
+3. `wp_abilities_api_categories_init`
+4. `wp_abilities_api_init`
+5. `wp_codebox_runtime_abilities_ready`
+
+Components should use WordPress' ability hooks to register ability categories and abilities. Components that expose model-facing tools derived from registered abilities should attach that projection to `wp_codebox_runtime_abilities_ready` so all ability registration has completed first.
+
+Runtime diagnostics include the observed `did_action()` counts for these hooks where the runtime surface returns structured lifecycle diagnostics.

--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -656,6 +656,22 @@ function wp_codebox_json_encode_sandbox_payload($value): string {
     return (string) wp_json_encode($fallback, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
 }
 
+function wp_codebox_runtime_replay_component_lifecycle(): array {
+    do_action('plugins_loaded');
+    do_action('init');
+    do_action('wp_abilities_api_categories_init');
+    do_action('wp_abilities_api_init');
+    do_action('wp_codebox_runtime_abilities_ready');
+
+    return array(
+        'plugins_loaded' => function_exists('did_action') ? did_action('plugins_loaded') : null,
+        'init' => function_exists('did_action') ? did_action('init') : null,
+        'wp_abilities_api_categories_init' => function_exists('did_action') ? did_action('wp_abilities_api_categories_init') : null,
+        'wp_abilities_api_init' => function_exists('did_action') ? did_action('wp_abilities_api_init') : null,
+        'wp_codebox_runtime_abilities_ready' => function_exists('did_action') ? did_action('wp_codebox_runtime_abilities_ready') : null,
+    );
+}
+
 $activation_results = array();
 
 foreach ($plugins as $plugin) {
@@ -677,10 +693,7 @@ foreach ($plugins as $plugin) {
     );
 }
 
-do_action('plugins_loaded');
-do_action('init');
-do_action('wp_abilities_api_categories_init');
-do_action('wp_abilities_api_init');
+$runtime_lifecycle = wp_codebox_runtime_replay_component_lifecycle();
 
 $sandbox_task = ${phpStringLiteral(task)};
 $sandbox_stack = array(
@@ -688,6 +701,7 @@ $sandbox_stack = array(
         'signals' => array(
             'agents_api_loaded' => defined('AGENTS_API_LOADED'),
             'agents_registry_class' => class_exists('WP_Agents_Registry'),
+            'runtime_lifecycle' => $runtime_lifecycle,
             'provider_plugins' => wp_codebox_provider_plugin_entries(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
             'provider_plugin_files' => wp_codebox_provider_plugin_file_diagnostics(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
         ),
@@ -825,6 +839,22 @@ function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
     return null;
 }
 
+function wp_codebox_runtime_replay_component_lifecycle(): array {
+    do_action('plugins_loaded');
+    do_action('init');
+    do_action('wp_abilities_api_categories_init');
+    do_action('wp_abilities_api_init');
+    do_action('wp_codebox_runtime_abilities_ready');
+
+    return array(
+        'plugins_loaded' => function_exists('did_action') ? did_action('plugins_loaded') : null,
+        'init' => function_exists('did_action') ? did_action('init') : null,
+        'wp_abilities_api_categories_init' => function_exists('did_action') ? did_action('wp_abilities_api_categories_init') : null,
+        'wp_abilities_api_init' => function_exists('did_action') ? did_action('wp_abilities_api_init') : null,
+        'wp_codebox_runtime_abilities_ready' => function_exists('did_action') ? did_action('wp_codebox_runtime_abilities_ready') : null,
+    );
+}
+
 $activation_results = array();
 
 foreach ($plugins as $plugin) {
@@ -846,10 +876,7 @@ foreach ($plugins as $plugin) {
     );
 }
 
-do_action('plugins_loaded');
-do_action('init');
-do_action('wp_abilities_api_categories_init');
-do_action('wp_abilities_api_init');
+$runtime_lifecycle = wp_codebox_runtime_replay_component_lifecycle();
 
 echo json_encode(
     array(
@@ -859,6 +886,7 @@ echo json_encode(
         'signals' => array(
             'agents_api_loaded' => defined('AGENTS_API_LOADED'),
             'agents_registry_class' => class_exists('WP_Agents_Registry'),
+            'runtime_lifecycle' => $runtime_lifecycle,
             'provider_plugins' => wp_codebox_provider_plugin_entries(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
             'provider_plugin_files' => wp_codebox_provider_plugin_file_diagnostics(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
         ),

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1729,17 +1729,144 @@ echo wp_json_encode($result);`
 }
 
 function activateExtraPluginCode(pluginFile: string): string {
-  return `$plugin_file = ${JSON.stringify(pluginFile)};
+  return `${runtimeComponentLifecycleReplayPhp("wp_codebox_activate_plugin")}
+$plugin_file = ${JSON.stringify(pluginFile)};
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 if (is_plugin_active($plugin_file)) {
     deactivate_plugins($plugin_file, true, false);
 }
+$lifecycle = wp_codebox_activate_plugin_component_lifecycle_replay_prepare();
 $result = activate_plugin($plugin_file, '', false, false);
+wp_codebox_activate_plugin_component_lifecycle_replay_complete($lifecycle);
 if (is_wp_error($result)) {
     throw new RuntimeException('Failed to activate extra plugin ' . $plugin_file . ': ' . $result->get_error_message());
 }
 do_action('wp_codebox_runtime_plugin_activated', $plugin_file);
 echo wp_json_encode(array('activated' => $plugin_file));`
+}
+
+function runtimeComponentLifecycleReplayPhp(prefix: string): string {
+  const snapshot = `${prefix}_component_lifecycle_snapshot_hook_callbacks`
+  const defer = `${prefix}_component_lifecycle_defer_new_hook_callbacks`
+  const run = `${prefix}_component_lifecycle_run_deferred_hook_callbacks`
+  const reopen = `${prefix}_component_lifecycle_reopen_action`
+  const restore = `${prefix}_component_lifecycle_restore_action`
+  const abilityNames = `${prefix}_component_lifecycle_ability_names`
+  const prepare = `${prefix}_component_lifecycle_replay_prepare`
+  const complete = `${prefix}_component_lifecycle_replay_complete`
+
+  return `if (!function_exists('${prepare}')) {
+function ${snapshot}(string $hook_name): array {
+    global $wp_filter;
+    $snapshot = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $snapshot;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach (array_keys($callbacks) as $callback_id) {
+            $snapshot[$priority . ':' . $callback_id] = true;
+        }
+    }
+    return $snapshot;
+}
+function ${defer}(string $hook_name, array $before): array {
+    global $wp_filter;
+    $deferred = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $deferred;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach ($callbacks as $callback_id => $callback) {
+            if (isset($before[$priority . ':' . $callback_id])) {
+                continue;
+            }
+            $deferred[] = array('priority' => (int) $priority, 'callback' => $callback);
+            unset($wp_filter[$hook_name]->callbacks[$priority][$callback_id]);
+        }
+        if (empty($wp_filter[$hook_name]->callbacks[$priority])) {
+            unset($wp_filter[$hook_name]->callbacks[$priority]);
+        }
+    }
+    usort($deferred, static function (array $left, array $right): int { return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10); });
+    return $deferred;
+}
+function ${run}(array $deferred, string $hook_name, array $args = array()): void {
+    global $wp_current_filter;
+    if (!is_array($wp_current_filter)) {
+        $wp_current_filter = array();
+    }
+    $wp_current_filter[] = $hook_name;
+    try {
+        foreach ($deferred as $entry) {
+            $callback = $entry['callback'] ?? null;
+            if (!is_array($callback) || !isset($callback['function'])) {
+                continue;
+            }
+            $accepted_args = isset($callback['accepted_args']) ? (int) $callback['accepted_args'] : count($args);
+            call_user_func_array($callback['function'], array_slice($args, 0, $accepted_args));
+        }
+    } finally {
+        array_pop($wp_current_filter);
+    }
+}
+function ${reopen}(string $hook_name): int {
+    global $wp_actions;
+    $count = function_exists('did_action') ? (int) did_action($hook_name) : 0;
+    if ($count > 0) {
+        if (!is_array($wp_actions)) {
+            $wp_actions = array();
+        }
+        $wp_actions[$hook_name] = 0;
+    }
+    return $count;
+}
+function ${restore}(string $hook_name, int $count): void {
+    global $wp_actions;
+    if ($count <= 0) {
+        return;
+    }
+    if (!is_array($wp_actions)) {
+        $wp_actions = array();
+    }
+    $wp_actions[$hook_name] = max($count, (int) ($wp_actions[$hook_name] ?? 0), 1);
+}
+function ${abilityNames}(): array {
+    if (!function_exists('wp_get_abilities')) {
+        return array();
+    }
+    $abilities = wp_get_abilities();
+    return is_array($abilities) ? array_values(array_map('strval', array_keys($abilities))) : array();
+}
+function ${prepare}(): array {
+    $hooks = array('plugins_loaded', 'init', 'wp_abilities_api_categories_init', 'wp_abilities_api_init', 'wp_codebox_runtime_abilities_ready');
+    $state = array('hooks' => array(), 'abilities_before' => ${abilityNames}());
+    foreach ($hooks as $hook_name) {
+        $state['hooks'][$hook_name] = array(
+            'callbacks' => ${snapshot}($hook_name),
+            'did_action' => ${reopen}($hook_name),
+        );
+    }
+    return $state;
+}
+function ${complete}(array $state): array {
+    $diagnostic = array(
+        'schema' => 'wp-codebox/runtime-component-lifecycle-replay/v1',
+        'hooks' => array(),
+        'abilities_before' => $state['abilities_before'] ?? array(),
+        'abilities_after' => array(),
+        'abilities_added' => array(),
+    );
+    foreach (($state['hooks'] ?? array()) as $hook_name => $hook_state) {
+        $deferred = ${defer}((string) $hook_name, is_array($hook_state['callbacks'] ?? null) ? $hook_state['callbacks'] : array());
+        ${run}($deferred, (string) $hook_name);
+        ${restore}((string) $hook_name, (int) ($hook_state['did_action'] ?? 0));
+        $diagnostic['hooks'][(string) $hook_name] = array('replayed_callbacks' => count($deferred), 'previous_did_action' => (int) ($hook_state['did_action'] ?? 0));
+    }
+    $diagnostic['abilities_after'] = ${abilityNames}();
+    $diagnostic['abilities_added'] = array_values(array_diff($diagnostic['abilities_after'], is_array($diagnostic['abilities_before']) ? $diagnostic['abilities_before'] : array()));
+    return $diagnostic;
+}
+}`
 }
 
 async function activePlugins(runtime: Runtime): Promise<string[]> {

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -49,7 +49,8 @@ function recipeActivePluginBootstrapPhp(spec: RuntimeCreateSpec): string {
     return ""
   }
 
-  return `$wp_codebox_run_php_active_plugins = json_decode(base64_decode('${Buffer.from(JSON.stringify(plugins), "utf8").toString("base64")}'), true);
+  return `${runtimeComponentLifecycleReplayPhp("wp_codebox_run_php")}
+$wp_codebox_run_php_active_plugins = json_decode(base64_decode('${Buffer.from(JSON.stringify(plugins), "utf8").toString("base64")}'), true);
 function wp_codebox_run_php_plugin_load_diagnostic(array $plugin, string $error = ''): string {
     $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
     $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
@@ -80,10 +81,13 @@ function wp_codebox_run_php_include_active_plugin(array $plugin): void {
     if (!is_file($absolute_plugin_file) || !is_readable($absolute_plugin_file)) {
         throw new RuntimeException('wordpress.run-php cannot include recipe plugin file "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, 'missing or unreadable plugin file'));
     }
+    $lifecycle = wp_codebox_run_php_component_lifecycle_replay_prepare();
     try {
         require_once $absolute_plugin_file;
     } catch (Throwable $e) {
         throw new RuntimeException('wordpress.run-php failed to include recipe plugin "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, $e->getMessage()), 0, $e);
+    } finally {
+        wp_codebox_run_php_component_lifecycle_replay_complete($lifecycle);
     }
     $diagnostic = wp_codebox_run_php_plugin_load_diagnostic($plugin, 'plugin file was not included');
     if (strpos($diagnostic, '"included":true') === false) {
@@ -96,6 +100,130 @@ foreach (is_array($wp_codebox_run_php_active_plugins) ? $wp_codebox_run_php_acti
     }
 }
 `
+}
+
+function runtimeComponentLifecycleReplayPhp(prefix: string): string {
+  const snapshot = `${prefix}_component_lifecycle_snapshot_hook_callbacks`
+  const defer = `${prefix}_component_lifecycle_defer_new_hook_callbacks`
+  const run = `${prefix}_component_lifecycle_run_deferred_hook_callbacks`
+  const reopen = `${prefix}_component_lifecycle_reopen_action`
+  const restore = `${prefix}_component_lifecycle_restore_action`
+  const abilityNames = `${prefix}_component_lifecycle_ability_names`
+  const prepare = `${prefix}_component_lifecycle_replay_prepare`
+  const complete = `${prefix}_component_lifecycle_replay_complete`
+
+  return `if (!function_exists('${prepare}')) {
+function ${snapshot}(string $hook_name): array {
+    global $wp_filter;
+    $snapshot = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $snapshot;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach (array_keys($callbacks) as $callback_id) {
+            $snapshot[$priority . ':' . $callback_id] = true;
+        }
+    }
+    return $snapshot;
+}
+function ${defer}(string $hook_name, array $before): array {
+    global $wp_filter;
+    $deferred = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $deferred;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach ($callbacks as $callback_id => $callback) {
+            if (isset($before[$priority . ':' . $callback_id])) {
+                continue;
+            }
+            $deferred[] = array('priority' => (int) $priority, 'callback' => $callback);
+            unset($wp_filter[$hook_name]->callbacks[$priority][$callback_id]);
+        }
+        if (empty($wp_filter[$hook_name]->callbacks[$priority])) {
+            unset($wp_filter[$hook_name]->callbacks[$priority]);
+        }
+    }
+    usort($deferred, static function (array $left, array $right): int { return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10); });
+    return $deferred;
+}
+function ${run}(array $deferred, string $hook_name, array $args = array()): void {
+    global $wp_current_filter;
+    if (!is_array($wp_current_filter)) {
+        $wp_current_filter = array();
+    }
+    $wp_current_filter[] = $hook_name;
+    try {
+        foreach ($deferred as $entry) {
+            $callback = $entry['callback'] ?? null;
+            if (!is_array($callback) || !isset($callback['function'])) {
+                continue;
+            }
+            $accepted_args = isset($callback['accepted_args']) ? (int) $callback['accepted_args'] : count($args);
+            call_user_func_array($callback['function'], array_slice($args, 0, $accepted_args));
+        }
+    } finally {
+        array_pop($wp_current_filter);
+    }
+}
+function ${reopen}(string $hook_name): int {
+    global $wp_actions;
+    $count = function_exists('did_action') ? (int) did_action($hook_name) : 0;
+    if ($count > 0) {
+        if (!is_array($wp_actions)) {
+            $wp_actions = array();
+        }
+        $wp_actions[$hook_name] = 0;
+    }
+    return $count;
+}
+function ${restore}(string $hook_name, int $count): void {
+    global $wp_actions;
+    if ($count <= 0) {
+        return;
+    }
+    if (!is_array($wp_actions)) {
+        $wp_actions = array();
+    }
+    $wp_actions[$hook_name] = max($count, (int) ($wp_actions[$hook_name] ?? 0), 1);
+}
+function ${abilityNames}(): array {
+    if (!function_exists('wp_get_abilities')) {
+        return array();
+    }
+    $abilities = wp_get_abilities();
+    return is_array($abilities) ? array_values(array_map('strval', array_keys($abilities))) : array();
+}
+function ${prepare}(): array {
+    $hooks = array('plugins_loaded', 'init', 'wp_abilities_api_categories_init', 'wp_abilities_api_init', 'wp_codebox_runtime_abilities_ready');
+    $state = array('hooks' => array(), 'abilities_before' => ${abilityNames}());
+    foreach ($hooks as $hook_name) {
+        $state['hooks'][$hook_name] = array(
+            'callbacks' => ${snapshot}($hook_name),
+            'did_action' => ${reopen}($hook_name),
+        );
+    }
+    return $state;
+}
+function ${complete}(array $state): array {
+    $diagnostic = array(
+        'schema' => 'wp-codebox/runtime-component-lifecycle-replay/v1',
+        'hooks' => array(),
+        'abilities_before' => $state['abilities_before'] ?? array(),
+        'abilities_after' => array(),
+        'abilities_added' => array(),
+    );
+    foreach (($state['hooks'] ?? array()) as $hook_name => $hook_state) {
+        $deferred = ${defer}((string) $hook_name, is_array($hook_state['callbacks'] ?? null) ? $hook_state['callbacks'] : array());
+        ${run}($deferred, (string) $hook_name);
+        ${restore}((string) $hook_name, (int) ($hook_state['did_action'] ?? 0));
+        $diagnostic['hooks'][(string) $hook_name] = array('replayed_callbacks' => count($deferred), 'previous_did_action' => (int) ($hook_state['did_action'] ?? 0));
+    }
+    $diagnostic['abilities_after'] = ${abilityNames}();
+    $diagnostic['abilities_added'] = array_values(array_diff($diagnostic['abilities_after'], is_array($diagnostic['abilities_before']) ? $diagnostic['abilities_before'] : array()));
+    return $diagnostic;
+}
+}`
 }
 
 function recipeActivePluginMetadata(spec: RuntimeCreateSpec): RecipePluginMetadata[] {

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -477,6 +477,16 @@ function pg_fire_reopened_wordpress_action(string $hook_name, bool $reopened): v
     }
 }
 
+function pg_fire_runtime_abilities_ready(): void {
+    if (!function_exists('do_action')) {
+        return;
+    }
+    do_action('wp_codebox_runtime_abilities_ready');
+    if (function_exists('did_action')) {
+        pg_log('NOTICE:runtime ability lifecycle ready: wp_abilities_api_categories_init=' . did_action('wp_abilities_api_categories_init') . '; wp_abilities_api_init=' . did_action('wp_abilities_api_init') . '; wp_codebox_runtime_abilities_ready=' . did_action('wp_codebox_runtime_abilities_ready'));
+    }
+}
+
 function pg_preload_wp_cli_namespaced_functions(): void {
     global $autoload_file;
     $vendor_dir = dirname($autoload_file);
@@ -884,6 +894,7 @@ usort($deferred_install_init_callbacks, static function (array $left, array $rig
 pg_run_deferred_wordpress_hook_callbacks($deferred_install_init_callbacks, array(), 'init');
 pg_fire_reopened_wordpress_action('wp_abilities_api_categories_init', $reopened_ability_categories_init);
 pg_fire_reopened_wordpress_action('wp_abilities_api_init', $reopened_ability_init);
+pg_fire_runtime_abilities_ready();
 
 pg_stage_begin('load_fixtures');
 try {

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -1082,6 +1082,25 @@ $declarations[\'filesystem_write\'] = array(
 return $declarations;
 }
 
+function wp_codebox_browser_runtime_replay_ability_lifecycle(): array {
+if ( function_exists( \'wp_register_ability\' ) ) {
+if ( ! did_action( \'wp_abilities_api_categories_init\' ) ) {
+	do_action( \'wp_abilities_api_categories_init\' );
+}
+if ( ! did_action( \'wp_abilities_api_init\' ) ) {
+	do_action( \'wp_abilities_api_init\' );
+}
+}
+
+do_action( \'wp_codebox_runtime_abilities_ready\' );
+
+return array(
+	\'wp_abilities_api_categories_init\' => function_exists( \'did_action\' ) ? did_action( \'wp_abilities_api_categories_init\' ) : null,
+	\'wp_abilities_api_init\' => function_exists( \'did_action\' ) ? did_action( \'wp_abilities_api_init\' ) : null,
+	\'wp_codebox_runtime_abilities_ready\' => function_exists( \'did_action\' ) ? did_action( \'wp_codebox_runtime_abilities_ready\' ) : null,
+);
+}
+
 function wp_codebox_browser_runtime_tool_callback( array $request, array $payload ) {
 unset( $payload );
 
@@ -1123,14 +1142,7 @@ add_filter( \'wp_agent_runtime_resolved_tools\', function ( array $tools, $mode,
 $wp_codebox_playground_root = defined( \'ABSPATH\' ) ? wp_normalize_path( ABSPATH ) : \'\';
 $wp_codebox_is_playground = \'/wordpress/\' === $wp_codebox_playground_root && ( \'Emscripten\' === PHP_OS_FAMILY || ( defined( \'WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER\' ) && WP_CODEBOX_BROWSER_PLAYGROUND_RUNNER ) );
 
-if ( function_exists( \'wp_register_ability\' ) ) {
-if ( ! did_action( \'wp_abilities_api_categories_init\' ) ) {
-	do_action( \'wp_abilities_api_categories_init\' );
-}
-if ( ! did_action( \'wp_abilities_api_init\' ) ) {
-	do_action( \'wp_abilities_api_init\' );
-}
-}
+$runtime_lifecycle = wp_codebox_browser_runtime_replay_ability_lifecycle();
 
 if ( is_readable( $task_path ) ) {
 $raw_payload = json_decode( (string) file_get_contents( $task_path ), true );
@@ -1330,6 +1342,7 @@ $diagnostics = array(
 ),
 \'provider_proxy\' => $provider_proxy_diagnostics,
 \'sandbox_tool_ids\' => $sandbox_tool_ids,
+\'runtime_lifecycle\' => $runtime_lifecycle,
 \'input_controls\' => wp_codebox_browser_input_control_diagnostics( is_array( $input ?? null ) ? $input : array() ),
 \'artifact_capture\' => wp_codebox_browser_artifact_capture_diagnostics( $payload, $artifact_bundle ),
 \'response\' => wp_codebox_browser_response_diagnostics( $response ?? null ),

--- a/scripts/agent-runtime-ability-lifecycle-smoke.ts
+++ b/scripts/agent-runtime-ability-lifecycle-smoke.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildAgentTaskRecipe } from "../packages/runtime-core/src/agent-task-recipe.js"
+import { normalizeTaskInput } from "../packages/runtime-core/src/task-input.js"
+import { runRecipeRunCommand } from "../packages/cli/src/commands/recipe-run.js"
+
+const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-ability-lifecycle-smoke-"))
+
+try {
+  const componentPath = writeAbilityLifecycleComponent(root)
+  const recipe = buildAgentTaskRecipe({
+    goal: "verify ability-backed tool lifecycle",
+    component_contracts: [
+      { slug: "ability-lifecycle-component", path: componentPath, loadAs: "mu-plugin", activate: false },
+    ],
+  }, normalizeTaskInput({ goal: "verify ability-backed tool lifecycle" }), "latest")
+
+  recipe.workflow.steps = [{
+    command: "wp-codebox.agent-sandbox-run",
+    args: [
+      "task=verify ability-backed tool lifecycle",
+      `code=${agentSandboxProbeCode()}`,
+    ],
+  }]
+
+  const recipePath = join(root, "agent-runtime-ability-lifecycle-recipe.json")
+  writeFileSync(recipePath, JSON.stringify(recipe, null, 2))
+
+  const runOutput = await runRecipe(recipePath)
+  assert.equal(runOutput.success, true)
+
+  const sandboxPayload = JSON.parse(String(runOutput.executions?.[0]?.stdout ?? "{}")) as { output?: string; stack?: { signals?: { runtime_lifecycle?: Record<string, number> } } }
+  const lifecycle = sandboxPayload.stack?.signals?.runtime_lifecycle ?? {}
+  assert.equal(lifecycle.wp_codebox_runtime_abilities_ready, 1)
+
+  const probe = JSON.parse(String(sandboxPayload.output ?? "{}")) as {
+    hasProbeTool?: boolean
+    abilityInitCount?: number
+    readyCount?: number
+    readySawAbilityInit?: number
+  }
+  assert.equal(probe.hasProbeTool, true, "tool projection registered on wp_codebox_runtime_abilities_ready should be visible")
+  assert.equal(probe.abilityInitCount, 1)
+  assert.equal(probe.readyCount, 1)
+  assert.equal(probe.readySawAbilityInit, 1)
+
+  console.log("agent-runtime-ability-lifecycle-smoke: ok")
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
+
+function writeAbilityLifecycleComponent(rootPath: string): string {
+  const pluginPath = join(rootPath, "ability-lifecycle-component")
+  mkdirSync(pluginPath, { recursive: true })
+  writeFileSync(join(pluginPath, "ability-lifecycle-component.php"), `<?php
+/**
+ * Plugin Name: Ability Lifecycle Component
+ */
+defined( 'ABSPATH' ) || exit;
+
+$GLOBALS['wp_codebox_ability_lifecycle_probe'] = array(
+    'ability_init_count' => 0,
+    'ready_count' => 0,
+    'ready_saw_ability_init' => 0,
+);
+
+add_action( 'wp_abilities_api_init', static function (): void {
+    $GLOBALS['wp_codebox_ability_lifecycle_probe']['ability_init_count'] = did_action( 'wp_abilities_api_init' );
+} );
+
+add_action( 'wp_codebox_runtime_abilities_ready', static function (): void {
+    $GLOBALS['wp_codebox_ability_lifecycle_probe']['ready_count'] = did_action( 'wp_codebox_runtime_abilities_ready' );
+    $GLOBALS['wp_codebox_ability_lifecycle_probe']['ready_saw_ability_init'] = did_action( 'wp_abilities_api_init' );
+    add_filter( 'wp_agent_runtime_resolved_tools', static function ( array $tools ): array {
+        $tools['probe-tool'] = array(
+            'name' => 'probe-tool',
+            'description' => 'Synthetic lifecycle probe tool.',
+        );
+        return $tools;
+    }, 10, 3 );
+} );
+`)
+  return pluginPath
+}
+
+function agentSandboxProbeCode(): string {
+  return `
+$tools = apply_filters( 'wp_agent_runtime_resolved_tools', array(), 'agent', array() );
+$probe = is_array( $GLOBALS['wp_codebox_ability_lifecycle_probe'] ?? null ) ? $GLOBALS['wp_codebox_ability_lifecycle_probe'] : array();
+echo wp_json_encode( array(
+    'hasProbeTool' => isset( $tools['probe-tool'] ),
+    'abilityInitCount' => (int) ( $probe['ability_init_count'] ?? 0 ),
+    'readyCount' => (int) ( $probe['ready_count'] ?? 0 ),
+    'readySawAbilityInit' => (int) ( $probe['ready_saw_ability_init'] ?? 0 ),
+) );
+`
+}
+
+async function runRecipe(recipePath: string): Promise<{ success?: boolean; executions?: Array<{ stdout?: string }> }> {
+  const output = await captureStdout(async () => await runRecipeRunCommand(["--recipe", recipePath, "--json"]))
+  return JSON.parse(output) as { success?: boolean; executions?: Array<{ stdout?: string }> }
+}
+
+async function captureStdout(callback: () => Promise<unknown>): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let stdout = ""
+  ;(process.stdout.write as typeof process.stdout.write) = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdout += typeof chunk === "string" ? chunk : chunk.toString()
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback()
+    } else if (callback) {
+      callback()
+    }
+    return true
+  }) as typeof process.stdout.write
+  try {
+    await callback()
+    return stdout
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}

--- a/scripts/runtime-component-lifecycle-replay-smoke.ts
+++ b/scripts/runtime-component-lifecycle-replay-smoke.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
+
+const runtimeSpec = {
+  backend: "wordpress-playground",
+  environment: { kind: "wordpress", phpVersion: "8.3" },
+  policy: { filesystem: "readwrite", network: "deny", commands: [] },
+  metadata: {
+    recipe: {
+      inputs: {
+        extra_plugins: [
+          {
+            slug: "late-ability-component",
+            pluginFile: "late-ability-component/late-ability-component.php",
+            target: "/wordpress/wp-content/plugins/late-ability-component",
+            loadAs: "plugin",
+            activate: true,
+          },
+        ],
+      },
+    },
+  },
+} as const
+
+const bootstrap = bootstrapPhpCode(runtimeSpec, "echo 'ok';", [])
+
+assert.match(bootstrap, /wp-codebox\/runtime-component-lifecycle-replay\/v1/, "late include bootstrap should expose lifecycle replay diagnostics")
+assert.match(bootstrap, /wp_codebox_runtime_abilities_ready/, "late include bootstrap should replay the post-abilities contract hook")
+assert.ok(
+  bootstrap.indexOf("$lifecycle = wp_codebox_run_php_component_lifecycle_replay_prepare();") < bootstrap.indexOf("require_once $absolute_plugin_file;"),
+  "late include bootstrap should reopen lifecycle before including plugin code",
+)
+assert.ok(
+  bootstrap.indexOf("wp_codebox_run_php_component_lifecycle_replay_complete($lifecycle);") > bootstrap.indexOf("require_once $absolute_plugin_file;"),
+  "late include bootstrap should replay newly registered callbacks after including plugin code",
+)
+
+const recipeRunSource = readFileSync(join(process.cwd(), "packages/cli/src/commands/recipe-run.ts"), "utf8")
+const activateFunction = recipeRunSource.slice(recipeRunSource.indexOf("function activateExtraPluginCode"), recipeRunSource.indexOf("async function activePlugins"))
+
+assert.match(activateFunction, /wp-codebox\/runtime-component-lifecycle-replay\/v1/, "activation setup should expose lifecycle replay diagnostics")
+assert.match(activateFunction, /wp_codebox_runtime_abilities_ready/, "activation setup should replay the post-abilities contract hook")
+assert.ok(
+  activateFunction.indexOf("$lifecycle = wp_codebox_activate_plugin_component_lifecycle_replay_prepare();") < activateFunction.indexOf("activate_plugin($plugin_file"),
+  "activation setup should reopen lifecycle before activate_plugin loads plugin code",
+)
+assert.ok(
+  activateFunction.indexOf("wp_codebox_activate_plugin_component_lifecycle_replay_complete($lifecycle);") > activateFunction.indexOf("activate_plugin($plugin_file"),
+  "activation setup should replay newly registered callbacks after activate_plugin loads plugin code",
+)
+
+console.log("runtime-component-lifecycle-replay-smoke: ok")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -74,6 +74,7 @@ export const smokeGroups = {
       tsxSmoke("replay-export-snapshot-scoping-smoke"),
       tsxSmoke("composer-backed-source-hydration-smoke"),
       tsxSmoke("recipe-run-composer-autoload-extra-plugin-smoke"),
+      tsxSmoke("runtime-component-lifecycle-replay-smoke"),
     ],
   },
   agent: {
@@ -81,6 +82,7 @@ export const smokeGroups = {
     commands: [
       tsxSmoke("agent-runtime-workload-normalizer-smoke"),
       tsxSmoke("agent-runtime-signal-smoke"),
+      tsxSmoke("agent-runtime-ability-lifecycle-smoke"),
       tsxSmoke("agent-sandbox-incomplete-scope-smoke"),
       tsxSmoke("recipe-run-summary-smoke"),
       tsxSmoke("fanout-contract-smoke"),


### PR DESCRIPTION
## Summary
- Replays late-loaded runtime component lifecycle hooks deterministically so ability callbacks registered after WordPress bootstrap are run before ability execution.
- Adds generic post-abilities readiness diagnostics and documents the runtime component lifecycle contract.
- Covers the setup/bootstrap contract with focused lifecycle smoke tests.

## Verification
- npm run build
- npm exec -- tsx scripts/runtime-component-lifecycle-replay-smoke.ts
- npm run smoke -- --group=runtime (aborted manually after initial checks; run-registry, wordpress-state-contract, and playground-command-errors passed before abort)

Fixes #1012