### PR TITLE
Add agent runtime diagnostics summary

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -326,6 +326,14 @@ function wp_codebox_registered_provider_ids(object $registry): array {
 $runtime_task_run = is_array($sandbox_runtime_task) && !empty($sandbox_runtime_task);
 $ability_name = $runtime_task_run ? (string) ($sandbox_runtime_task['ability'] ?? '') : 'agents/chat';
 $ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability($ability_name) : null;
+$registered_ability_ids = function_exists('wp_get_abilities') ? array_keys(wp_get_abilities()) : array();
+sort($registered_ability_ids);
+$sandbox_stack['abilities'] = array(
+    'count' => count($registered_ability_ids),
+    'ids' => $registered_ability_ids,
+    'requested' => $ability_name,
+    'requested_available' => null !== $ability,
+);
 $agent_input = ${JSON.stringify(JSON.stringify(input))};
 $decoded_agent_input = json_decode($agent_input, true);
 $provider_validation_error = wp_codebox_validate_requested_provider(is_array($decoded_agent_input) ? $decoded_agent_input : array(), $sandbox_stack);

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -30,6 +30,7 @@ interface AgentTaskRunOutput {
   structured_artifacts: Array<Record<string, unknown>>
   run: Record<string, unknown>
   diagnostics: Array<Record<string, unknown>>
+  agent_runtime_diagnostics: Record<string, unknown>
   evidence_refs: Array<Record<string, unknown>>
   failure_evidence?: Record<string, unknown>
   run_metadata: Record<string, unknown>
@@ -120,6 +121,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       structured_artifacts: structuredArtifactRefs(agentTaskResult),
       run,
       diagnostics: [...diagnostics(run, success ? 0 : capture.exitCode, success, failureEvidence), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])],
+      agent_runtime_diagnostics: await buildAgentRuntimeDiagnostics(run, input),
       evidence_refs: evidenceRefs(run, artifacts, failureEvidence),
       failure_evidence: failureEvidence,
       run_metadata: stripUndefined({
@@ -158,6 +160,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       structured_artifacts: [],
       run,
       diagnostics: failureDiagnostics,
+      agent_runtime_diagnostics: await buildAgentRuntimeDiagnostics(run, input),
       evidence_refs: evidenceRefs(run, artifacts, failureEvidence),
       failure_evidence: failureEvidence,
       run_metadata: stripUndefined({
@@ -177,6 +180,40 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
   } finally {
     await rm(recipeDirectory, { recursive: true, force: true })
   }
+}
+
+export async function buildAgentRuntimeDiagnostics(run: Record<string, unknown>, input: AgentTaskRunInput = {}): Promise<Record<string, unknown>> {
+  const artifactsRecord = objectValue(run.artifacts) || {}
+  const metadata = await readJsonRecord(stringValue(artifactsRecord.metadataPath))
+  const context = objectValue(metadata?.context) || {}
+  const recipe = objectValue(context.recipe) || {}
+  const task = objectValue(context.task) || {}
+  const recipeInputs = objectValue(recipe.inputs) || {}
+  const taskInputs = objectValue(task.inputs) || {}
+  const componentContracts = componentContractReport(run)
+  const executions = arrayRecords(run.executions)
+  const phaseEvidence = arrayRecords(run.phaseEvidence)
+  const sandboxRuntime = agentSandboxRuntime(run)
+  const sandboxInput = objectValue(sandboxRuntime?.input) || {}
+  const sandboxStack = objectValue(sandboxRuntime?.stack) || {}
+  const stackSignals = objectValue(sandboxStack.signals) || {}
+  const toolPolicy = objectValue(input.sandbox_tool_policy)
+  const requestedTools = sandboxToolIdsBeforeFiltering(toolPolicy)
+  const runtimeTools = stringArray(sandboxInput.allow_only).length > 0 ? stringArray(sandboxInput.allow_only) : stringArray(objectValue(sandboxInput.tool_policy)?.tools)
+
+  return stripUndefined({
+    schema: "wp-codebox/agent-runtime-diagnostics/v1",
+    component_contracts: componentContracts.map((contract) => compactRecord(contract, ["slug", "requestedPath", "preparedPath", "pluginFile", "loadAs", "activate", "status", "activationStatus", "failures"])),
+    prepared_paths: compactPreparedPaths(context, recipeInputs, taskInputs),
+    loader_entries: compactLoaderEntries(run, context, stackSignals),
+    loaded_entrypoints: compactLoadedEntrypoints(executions, sandboxStack, stackSignals),
+    lifecycle_actions: compactLifecycleActions(phaseEvidence, executions),
+    registered_abilities: compactRegisteredAbilities(sandboxRuntime, sandboxStack),
+    resolved_tool_ids: stripUndefined({
+      before_filtering: requestedTools.length > 0 ? requestedTools : undefined,
+      after_filtering: runtimeTools.length > 0 ? runtimeTools : undefined,
+    }),
+  })
 }
 
 function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
@@ -396,6 +433,117 @@ function structuredArtifactRefs(agentTaskResult: Record<string, unknown>): Array
   const outputs = objectValue(agentTaskResult.outputs) || {}
   const fromOutputs = Array.isArray(outputs.structured_artifacts) ? outputs.structured_artifacts : []
   return fromOutputs.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry)))
+}
+
+async function readJsonRecord(path: string): Promise<Record<string, unknown> | undefined> {
+  if (!path) return undefined
+  try {
+    return objectValue(JSON.parse(await readFile(path, "utf8")))
+  } catch {
+    return undefined
+  }
+}
+
+function compactPreparedPaths(context: Record<string, unknown>, recipeInputs: Record<string, unknown>, taskInputs: Record<string, unknown>): Record<string, unknown> {
+  return stripUndefined({
+    component_contracts: arrayRecords(context.preparedComponentContracts).map((contract) => compactRecord(contract, ["slug", "requestedPath", "preparedPath", "pluginFile", "loadAs", "activate", "status"])),
+    workspaces: arrayRecords(context.preparedWorkspaces).map((workspace) => compactRecord(workspace, ["target", "mode", "metadata"])),
+    staged_files: arrayRecords(context.preparedStagedFiles).map((file) => compactRecord(file, ["sourceRef", "target", "type", "provenance", "metadata"])),
+    dependency_overlays: arrayRecords(context.preparedDependencyOverlays).map((overlay) => compactRecord(overlay, ["package", "target", "type", "mode", "metadata"])),
+    runtime_overlays: arrayRecords(context.preparedRuntimeOverlays).map((overlay) => compactRecord(overlay, ["target", "type", "mode", "metadata"])),
+    requested_component_contracts: arrayRecords(recipeInputs.component_contracts ?? taskInputs.component_contracts).map((contract) => compactRecord(contract, ["slug", "path", "loadAs", "activate"])),
+  })
+}
+
+function compactLoaderEntries(run: Record<string, unknown>, context: Record<string, unknown>, stackSignals: Record<string, unknown>): Array<Record<string, unknown>> {
+  const componentEntries = componentContractReport(run)
+    .map((contract) => compactRecord(contract, ["slug", "pluginFile", "preparedPath", "loadAs", "activationStatus", "status"]))
+  const preparedEntries = arrayRecords(context.preparedComponentContracts)
+    .map((contract) => compactRecord(contract, ["slug", "pluginFile", "preparedPath", "loadAs", "activate", "status"]))
+  const providerEntries = arrayRecords(stackSignals.provider_plugin_files)
+    .map((plugin) => compactRecord(plugin, ["slug", "source", "plugin_file", "mounted_path", "load_as", "mounted"]))
+  return dedupeRecords([...componentEntries, ...preparedEntries, ...providerEntries])
+}
+
+function compactLoadedEntrypoints(executions: Array<Record<string, unknown>>, sandboxStack: Record<string, unknown>, stackSignals: Record<string, unknown>): Array<Record<string, unknown>> {
+  const activationExecutions = executions
+    .filter((execution) => stringValue(execution.recipeCommand).startsWith("extra-plugin.activate:"))
+    .map((execution) => stripUndefined({ entrypoint: stringValue(execution.recipeCommand).replace("extra-plugin.activate:", ""), load_as: "plugin", exit_code: numberValue(execution.exitCode) }))
+  const pluginActivations = Object.entries(objectValue(sandboxStack.plugins) || {})
+    .map(([entrypoint, value]) => stripUndefined({ entrypoint, active: objectValue(value)?.active, load_as: stringValue(objectValue(value)?.load_as), error: stringValue(objectValue(value)?.error) || undefined }))
+  const providerPlugins = stringArray(stackSignals.provider_plugins)
+    .map((entrypoint) => ({ entrypoint, source: "provider_plugins" }))
+  return dedupeRecords([...activationExecutions, ...pluginActivations, ...providerPlugins])
+}
+
+function compactLifecycleActions(phaseEvidence: Array<Record<string, unknown>>, executions: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const phases = phaseEvidence.map((phase) => compactRecord(phase, ["name", "status", "durationMs", "data", "error"]))
+  const commands = executions.map((execution) => stripUndefined({ phase: stringValue(execution.recipePhase), command: stringValue(execution.recipeCommand) || stringValue(execution.command), exit_code: numberValue(execution.exitCode) }))
+  return dedupeRecords([...phases, ...commands])
+}
+
+function compactRegisteredAbilities(sandboxRuntime: Record<string, unknown> | undefined, sandboxStack: Record<string, unknown>): Record<string, unknown> | undefined {
+  const stackAbilities = objectValue(sandboxStack.abilities)
+  const runtimeAbilities = objectValue(sandboxRuntime?.abilities)
+  const source = stackAbilities || runtimeAbilities
+  if (!source) return undefined
+  return stripUndefined({
+    count: numberValue(source.count),
+    ids: stringArray(source.ids),
+    requested: stringValue(source.requested) || undefined,
+    requested_available: typeof source.requested_available === "boolean" ? source.requested_available : undefined,
+  })
+}
+
+function agentSandboxRuntime(run: Record<string, unknown>): Record<string, unknown> | undefined {
+  const agentTaskResult = objectValue(run.agentTaskResult)
+  const raw = objectValue(agentTaskResult?.raw)
+  const direct = objectValue(raw?.agent_runtime)
+  if (direct) return direct
+
+  for (const execution of [...arrayRecords(run.executions)].reverse()) {
+    if (stringValue(execution.recipeCommand) !== "wp-codebox.agent-sandbox-run") continue
+    const parsed = parseJsonObject(stringValue(execution.stdout)) || parseJsonObject(stringValue(execution.stderr))
+    const runtime = objectValue(parsed?.agent_runtime)
+    if (runtime) return runtime
+  }
+  return undefined
+}
+
+function sandboxToolIdsBeforeFiltering(policy: Record<string, unknown> | undefined): string[] {
+  return stringArray(arrayRecords(policy?.tools).map((tool) => stringValue(tool.runtime_tool_id) || stringValue(tool.id)))
+}
+
+function parseJsonObject(value: string): Record<string, unknown> | undefined {
+  if (!value) return undefined
+  try {
+    return objectValue(JSON.parse(value))
+  } catch {
+    return undefined
+  }
+}
+
+function compactRecord(record: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  return stripUndefined(Object.fromEntries(keys.map((key) => [key, record[key]])))
+}
+
+function dedupeRecords(records: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const seen = new Set<string>()
+  return records.filter((record) => {
+    if (Object.keys(record).length === 0) return false
+    const key = JSON.stringify(record)
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function arrayRecords(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? [...new Set(value.map((entry) => stringValue(entry)).filter(Boolean))].sort() : []
 }
 
 function objectValue(value: unknown): Record<string, unknown> | undefined {

--- a/scripts/agent-runtime-diagnostics-summary-smoke.ts
+++ b/scripts/agent-runtime-diagnostics-summary-smoke.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildAgentRuntimeDiagnostics } from "../packages/cli/src/commands/agent-task-run.js"
+
+const directory = await mkdtemp(join(tmpdir(), "wp-codebox-agent-runtime-diagnostics-"))
+
+try {
+  const metadataPath = join(directory, "metadata.json")
+  await writeFile(metadataPath, `${JSON.stringify({
+    context: {
+      preparedComponentContracts: [{ slug: "wp-site-generator", requestedPath: "/host/wpsg", preparedPath: "/tmp/prepared-plugins/wp-site-generator", pluginFile: "wp-site-generator/wp-site-generator.php", loadAs: "mu-plugin", activate: true, status: "prepared" }],
+      preparedWorkspaces: [{ target: "/workspace/wp-site-generator", mode: "readwrite", metadata: { repo: "wp-site-generator" } }],
+      preparedStagedFiles: [{ sourceRef: "bundle.json", target: "/workspace/bundle.json", type: "file" }],
+      preparedRuntimeOverlays: [{ target: "/wordpress/wp-content/mu-plugins/runtime.php", type: "file", mode: "readonly" }],
+      recipe: { inputs: { component_contracts: [{ slug: "wp-site-generator", path: "/host/wpsg", loadAs: "mu-plugin", activate: true }] } },
+    },
+  }, null, 2)}\n`)
+
+  const sandboxPayload = {
+    agent_runtime: {
+      success: false,
+      input: {
+        allow_only: ["workspace.read", "workspace.grep"],
+        tool_policy: { mode: "allow", tools: ["workspace.grep", "workspace.read"] },
+      },
+      stack: {
+        plugins: {
+          "wp-site-generator/wp-site-generator.php": { active: true, load_as: "mu-plugin", error: null },
+        },
+        signals: {
+          provider_plugins: ["ai-provider-for-opencode/ai-provider-for-opencode.php"],
+          provider_plugin_files: [{ slug: "ai-provider-for-opencode", plugin_file: "ai-provider-for-opencode/ai-provider-for-opencode.php", mounted_path: "/wordpress/wp-content/mu-plugins/wp-codebox-runtime/ai-provider-for-opencode/ai-provider-for-opencode.php", load_as: "mu-plugin", mounted: true }],
+        },
+        abilities: { count: 2, ids: ["agents/chat", "wp-site-generator/run"], requested: "agents/chat", requested_available: true },
+      },
+      error: { code: "expected-test-error", message: "synthetic" },
+    },
+  }
+
+  const summary = await buildAgentRuntimeDiagnostics({
+    artifacts: { metadataPath },
+    componentContracts: [{ slug: "wp-site-generator", requestedPath: "/host/wpsg", preparedPath: "/tmp/prepared-plugins/wp-site-generator", pluginFile: "wp-site-generator/wp-site-generator.php", loadAs: "mu-plugin", activationStatus: "loaded", status: "loaded" }],
+    phaseEvidence: [{ name: "mount_plugins", status: "completed", data: { count: 2 } }, { name: "activate_plugins", status: "completed" }],
+    executions: [
+      { recipePhase: "setup", recipeCommand: "extra-plugin.install-mu-loader", command: "wordpress.run-php", exitCode: 0 },
+      { recipePhase: "run", recipeCommand: "wp-codebox.agent-sandbox-run", command: "wordpress.run-php", exitCode: 1, stdout: JSON.stringify(sandboxPayload) },
+    ],
+  }, {
+    sandbox_tool_policy: {
+      schema: "wp-codebox/sandbox-tool-policy/v1",
+      version: 1,
+      metadata: {},
+      tools: [
+        { id: "read", runtime_tool_id: "workspace.read", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true, runtime: { environment: "runtime_local", capability_scope: "runtime_local" } },
+        { id: "grep", runtime_tool_id: "workspace.grep", execution_location: "sandbox", transport_visibility: "sandbox", allowed: true, runtime: { environment: "runtime_local", capability_scope: "runtime_local" } },
+        { id: "write", runtime_tool_id: "workspace.write", execution_location: "sandbox", transport_visibility: "sandbox", allowed: false, runtime: { environment: "runtime_local", capability_scope: "runtime_local" } },
+      ],
+    },
+  })
+
+  assert.equal(summary.schema, "wp-codebox/agent-runtime-diagnostics/v1")
+  assert.match(JSON.stringify(summary.component_contracts), /wp-site-generator/)
+  assert.match(JSON.stringify(summary.prepared_paths), /prepared-plugins/)
+  assert.match(JSON.stringify(summary.loader_entries), /ai-provider-for-opencode/)
+  assert.match(JSON.stringify(summary.loaded_entrypoints), /wp-site-generator.php/)
+  assert.match(JSON.stringify(summary.lifecycle_actions), /mount_plugins/)
+  assert.deepEqual(summary.registered_abilities, { count: 2, ids: ["agents/chat", "wp-site-generator/run"], requested: "agents/chat", requested_available: true })
+  assert.deepEqual(summary.resolved_tool_ids, { before_filtering: ["workspace.grep", "workspace.read", "workspace.write"], after_filtering: ["workspace.grep", "workspace.read"] })
+
+  console.log("agent-runtime-diagnostics-summary-smoke: ok")
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Add a compact `agent_runtime_diagnostics` summary to agent-task output covering component contracts, prepared paths, loader entries, loaded entrypoints, lifecycle actions, registered abilities, and resolved tool IDs.
- Include runtime ability inventory in sandbox stack output so callers can confirm whether expected abilities were registered and requested ability resolution succeeded.
- Add a focused smoke test for the generic summary shape using synthetic metadata and sandbox runtime output.

## Verification
- `npm run build`
- `npx tsx scripts/agent-runtime-diagnostics-summary-smoke.ts`

Fixes #1013