### PR TITLE
Fix runtime ability lifecycle smoke

### DIFF
--- a/scripts/agent-runtime-ability-lifecycle-smoke.ts
+++ b/scripts/agent-runtime-ability-lifecycle-smoke.ts
@@ -31,9 +31,11 @@ try {
   const runOutput = await runRecipe(recipePath)
   assert.equal(runOutput.success, true)
 
-  const sandboxPayload = JSON.parse(String(runOutput.executions?.[0]?.stdout ?? "{}")) as { output?: string; stack?: { signals?: { runtime_lifecycle?: Record<string, number> } } }
+  const sandboxExecution = runOutput.executions?.find((execution) => execution.recipeCommand === "wp-codebox.agent-sandbox-run")
+  assert.ok(sandboxExecution, "agent sandbox execution should be present")
+  const sandboxPayload = JSON.parse(String(sandboxExecution.stdout ?? "{}")) as { output?: string; stack?: { signals?: { runtime_lifecycle?: Record<string, number> } } }
   const lifecycle = sandboxPayload.stack?.signals?.runtime_lifecycle ?? {}
-  assert.equal(lifecycle.wp_codebox_runtime_abilities_ready, 1)
+  assert.equal(lifecycle.wp_codebox_runtime_abilities_ready, 1, JSON.stringify(sandboxPayload).slice(0, 1000))
 
   const probe = JSON.parse(String(sandboxPayload.output ?? "{}")) as {
     hasProbeTool?: boolean
@@ -42,9 +44,9 @@ try {
     readySawAbilityInit?: number
   }
   assert.equal(probe.hasProbeTool, true, "tool projection registered on wp_codebox_runtime_abilities_ready should be visible")
-  assert.equal(probe.abilityInitCount, 1)
+  assert.ok((probe.abilityInitCount ?? 0) >= 1)
   assert.equal(probe.readyCount, 1)
-  assert.equal(probe.readySawAbilityInit, 1)
+  assert.equal(probe.readySawAbilityInit, probe.abilityInitCount)
 
   console.log("agent-runtime-ability-lifecycle-smoke: ok")
 } finally {
@@ -98,9 +100,9 @@ echo wp_json_encode( array(
 `
 }
 
-async function runRecipe(recipePath: string): Promise<{ success?: boolean; executions?: Array<{ stdout?: string }> }> {
+async function runRecipe(recipePath: string): Promise<{ success?: boolean; executions?: Array<{ stdout?: string; recipeCommand?: string }> }> {
   const output = await captureStdout(async () => await runRecipeRunCommand(["--recipe", recipePath, "--json"]))
-  return JSON.parse(output) as { success?: boolean; executions?: Array<{ stdout?: string }> }
+  return JSON.parse(output) as { success?: boolean; executions?: Array<{ stdout?: string; recipeCommand?: string }> }
 }
 
 async function captureStdout(callback: () => Promise<unknown>): Promise<string> {


### PR DESCRIPTION
## Summary
- Select the actual `wp-codebox.agent-sandbox-run` execution in the ability lifecycle smoke instead of the preceding setup execution.
- Keep the assertion generic for repeated `wp_abilities_api_init` counts while still proving `wp_codebox_runtime_abilities_ready` runs after ability registration.

## Testing
- `npm run build`
- `npm exec -- tsx scripts/agent-runtime-ability-lifecycle-smoke.ts`

Fixes follow-up for #1012 after #1016.