### PR TITLE
Improve Playground crash diagnostics

### DIFF
--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -117,6 +117,7 @@ function playgroundCrashDiagnostics(cause: unknown): string[] {
   const metadata: string[] = []
   const sections: string[] = []
   const seenSections = new Set<string>()
+  let capturedOutput = false
 
   for (const record of records) {
     for (const [key, label] of [
@@ -142,10 +143,24 @@ function playgroundCrashDiagnostics(cause: unknown): string[] {
       const value = diagnosticText(record[key])
       const sectionKey = `${label}\n${value}`
       if (value && !seenSections.has(sectionKey)) {
+        capturedOutput = true
         sections.push(`--- ${label} ---`, value)
         seenSections.add(sectionKey)
       }
     }
+
+    const headers = diagnosticHeaders(record.headers)
+    if (headers) {
+      const sectionKey = `Playground response headers\n${headers}`
+      if (!seenSections.has(sectionKey)) {
+        sections.push("--- Playground response headers ---", headers)
+        seenSections.add(sectionKey)
+      }
+    }
+  }
+
+  if (!capturedOutput && metadata.length > 0) {
+    sections.push("No Playground stdout, stderr, or response body was captured.")
   }
 
   return [...metadata, ...sections]
@@ -180,6 +195,40 @@ function diagnosticText(value: unknown): string | undefined {
   } catch {
     return undefined
   }
+}
+
+function diagnosticHeaders(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined
+  }
+
+  const lines: string[] = []
+  for (const [rawName, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    const name = rawName.toLowerCase()
+    if (/cookie|authorization|token|secret|key/.test(name)) {
+      continue
+    }
+    if (!["content-type", "server", "x-powered-by"].includes(name) && !name.startsWith("x-wp-") && !name.startsWith("x-playground-")) {
+      continue
+    }
+    const valueText = headerValueText(rawValue)
+    if (valueText) {
+      lines.push(`${rawName}: ${valueText}`)
+    }
+  }
+
+  return lines.length > 0 ? truncateDiagnostic(lines.join("\n")) : undefined
+}
+
+function headerValueText(value: unknown): string | undefined {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value).slice(0, 500)
+  }
+  if (Array.isArray(value)) {
+    const values = value.filter((item): item is string | number => typeof item === "string" || typeof item === "number")
+    return values.length > 0 ? values.map(String).join(", ").slice(0, 500) : undefined
+  }
+  return undefined
 }
 
 function playgroundOutputDiagnostic(raw: string): string {

--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -31,6 +31,37 @@ assert.match(hiddenFatalMessage, /Local wp-admin auth fixture user could not be 
 assert.doesNotMatch(hiddenFatalMessage, /--- Playground stdout ---\n\s*---/)
 assert.doesNotMatch(hiddenFatalMessage, /--- Playground stderr ---\n\s*---/)
 
+const emptyWpcomFatal = new Error("PHP.run() failed with exit code 255") as Error & {
+  httpStatusCode?: number
+  exitCode?: number
+  stdout?: string
+  stderr?: string
+  response?: { headers?: Record<string, string> }
+}
+
+emptyWpcomFatal.httpStatusCode = 500
+emptyWpcomFatal.exitCode = 255
+emptyWpcomFatal.stdout = ""
+emptyWpcomFatal.stderr = ""
+emptyWpcomFatal.response = {
+  headers: {
+    "content-type": "text/html; charset=UTF-8",
+    "x-powered-by": "PHP/8.4.21",
+    "set-cookie": "wordpress_test_cookie=secret",
+  },
+}
+
+const emptyWpcomFatalMessage = new PlaygroundCommandCrashError("wordpress.run-php", emptyWpcomFatal).message
+
+assert.match(emptyWpcomFatalMessage, /wordpress\.run-php crashed before producing a structured response/)
+assert.match(emptyWpcomFatalMessage, /PHP\.run\(\) failed with exit code 255/)
+assert.match(emptyWpcomFatalMessage, /httpStatusCode=500/)
+assert.match(emptyWpcomFatalMessage, /exitCode=255/)
+assert.match(emptyWpcomFatalMessage, /--- Playground response headers ---/)
+assert.match(emptyWpcomFatalMessage, /x-powered-by: PHP\/8\.4\.21/)
+assert.match(emptyWpcomFatalMessage, /No Playground stdout, stderr, or response body was captured\./)
+assert.doesNotMatch(emptyWpcomFatalMessage, /wordpress_test_cookie/)
+
 const nestedResponseError = new Error("Playground request failed") as Error & {
   response?: { status?: number; text?: string }
 }
@@ -69,7 +100,7 @@ const fakeCliModule: PlaygroundCliModule = {
         throw hiddenFatal
       },
     },
-    close: async () => undefined,
+    [Symbol.asyncDispose]: async () => undefined,
   }),
 }
 
@@ -102,5 +133,6 @@ await assert.rejects(
 )
 
 assert.match(receivedRunPhpCode, /RuntimeException/)
+await runtime.destroy()
 
 console.log("playground command errors smoke passed")


### PR DESCRIPTION
## Summary
- Preserve reviewer-safe Playground response headers when a command crashes without stdout/stderr/body.
- Explicitly report that no Playground output was captured for empty PHP 255 failures.
- Covers the WPCOM local-source `wordpress.run-php` crash shape from #1011.

## Testing
- `npx tsx scripts/playground-command-errors-smoke.ts` printed `playground command errors smoke passed`, but the process did not exit before the 120s command timeout in this environment.

Closes #1011.