### PR TITLE
Document Codex cookbook provider stack

### DIFF
--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -33,13 +33,33 @@ proving that WP Codebox can mount the agent runtime stack, overlay a
 `php-ai-client` branch with provider-supplied request auth, activate a Codex
 provider plugin branch, and execute `agents/chat` through `wp-codebox.agent-sandbox-run`.
 
-**Replace** these recipe paths before running:
+**Replace** these recipe paths before running. They must be materialized local
+filesystem paths on the host running WP Codebox, not remote refs, repo handles,
+or orchestration-layer aliases:
 
 - `/path/to/agents-api`
 - `/path/to/data-machine`
 - `/path/to/data-machine-code`
-- `/path/to/php-ai-client-pr-238-or-newer`
-- `/path/to/ai-provider-for-openai-pr-28-or-newer`
+- `/absolute/path/to/php-ai-client-with-bearer-token-auth-and-vendor`
+- `/absolute/path/to/ai-provider-for-openai-that-registers-codex`
+
+#### Codex runtime contract
+
+The Codex smoke requires a matched provider stack. WP Codebox stays generic and
+local-path based; it mounts what the caller provides and does not resolve
+Homeboy, Data Machine Code, GitHub, or other orchestrator references.
+
+- The provider plugin checkout must register the `codex` provider id with
+  `wp-ai-client`. If it does not, the sandbox fails with `Provider codex is not
+  registered in wp-ai-client`.
+- The `php-ai-client` overlay must include bearer-token request authentication
+  support. Older checkouts fail when Codex asks for bearer-token auth.
+- The `php-ai-client` checkout must have Composer dependencies installed before
+  WP Codebox runs. Confirm `vendor/composer/installed.json` exists, for example
+  by running `composer install` in that checkout.
+- Orchestrators such as Homeboy should persist or materialize their selected
+  checkouts first, then write those absolute local paths into the recipe passed
+  to WP Codebox.
 
 Export Codex OAuth credentials in the shell that runs WP Codebox. Keep token
 values out of recipe files and artifacts:

--- a/examples/recipes/cookbook/codex-agent-smoke.json
+++ b/examples/recipes/cookbook/codex-agent-smoke.json
@@ -11,12 +11,12 @@
       {
         "kind": "bundled-library",
         "library": "php-ai-client",
-        "source": "/path/to/php-ai-client-pr-238-or-newer",
+        "source": "/absolute/path/to/php-ai-client-with-bearer-token-auth-and-vendor",
         "target": "/wordpress/wp-includes/php-ai-client",
         "strategy": "wordpress-scoped-bundle",
         "metadata": {
           "component": "php-ai-client",
-          "purpose": "provider-supplied request authentication"
+          "purpose": "provider-supplied bearer-token request authentication with Composer vendor installed"
         }
       }
     ]
@@ -39,7 +39,7 @@
         "activate": true
       },
       {
-        "source": "/path/to/ai-provider-for-openai-pr-28-or-newer",
+        "source": "/absolute/path/to/ai-provider-for-openai-that-registers-codex",
         "slug": "ai-provider-for-openai",
         "activate": false
       }

--- a/scripts/codex-agent-recipe-smoke.ts
+++ b/scripts/codex-agent-recipe-smoke.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+
+const recipe = JSON.parse(readFileSync("examples/recipes/cookbook/codex-agent-smoke.json", "utf8"))
+const readme = readFileSync("examples/recipes/cookbook/README.md", "utf8")
+
+const overlay = recipe.runtime?.overlays?.find((entry: Record<string, unknown>) => entry.library === "php-ai-client")
+assert.ok(overlay, "Codex example should include a php-ai-client overlay")
+assert.match(String(overlay.source), /absolute\/path\/to\/php-ai-client-with-bearer-token-auth-and-vendor/)
+assert.match(String(overlay.metadata?.purpose), /bearer-token/)
+assert.match(String(overlay.metadata?.purpose), /Composer vendor/)
+
+const providerPlugin = recipe.inputs?.extra_plugins?.find((entry: Record<string, unknown>) => entry.slug === "ai-provider-for-openai")
+assert.ok(providerPlugin, "Codex example should include the OpenAI provider plugin")
+assert.equal(providerPlugin.activate, false, "Codex provider plugin activation should be handled by the sandbox agent task")
+assert.match(String(providerPlugin.source), /registers-codex/)
+
+const args = recipe.workflow?.steps?.[0]?.args ?? []
+assert.ok(args.includes("provider=codex"), "Codex recipe should select the codex provider id")
+assert.ok(args.includes("provider-plugin-slugs=ai-provider-for-openai"), "Codex recipe should pass the provider plugin slug")
+
+for (const requiredPattern of [
+  /materialized local\s+filesystem paths/,
+  /must register the `codex` provider id/,
+  /bearer-token request authentication/,
+  /vendor\/composer\/installed\.json/,
+  /WP Codebox stays generic and\s+local-path based/,
+]) {
+  assert.match(readme, requiredPattern, `Codex README should document: ${requiredPattern}`)
+}
+
+console.log("Codex agent recipe smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -87,6 +87,7 @@ export const smokeGroups = {
       tsxSmoke("recipe-run-summary-smoke"),
       tsxSmoke("fanout-contract-smoke"),
       tsxSmoke("host-delegation-contract-smoke"),
+      tsxSmoke("codex-agent-recipe-smoke"),
       tsxSmoke("claude-code-agent-recipe-smoke"),
       tsxSmoke("component-contracts-agent-task-smoke"),
       tsxSmoke("fanout-aggregation-contract-smoke"),


### PR DESCRIPTION
## Summary
- Clarifies the Codex cookbook recipe requires a provider plugin that registers `codex`, a bearer-token-capable `php-ai-client` overlay, and Composer vendor files.
- Updates Codex example placeholders to require materialized local filesystem paths instead of remote refs or orchestrator aliases.
- Adds a lightweight TSX smoke check to keep the Codex cookbook contract explicit.

## Testing
- `npm run smoke -- --command=codex-agent-recipe-smoke`
- `npm run smoke -- --command=claude-code-agent-recipe-smoke`

Closes #1020