### PR TITLE
Improve runtime overlay validation diagnostics

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -22,6 +22,9 @@ export const defaultPolicy: RuntimePolicy = {
 
 const supportedRecipeCommands = new Set(recipeCommandDefinitions().map((command) => command.id))
 const hostRecipeCommandPattern = /^host\/[A-Za-z0-9._/-]+$/
+const supportedRuntimeOverlayKinds = ["bundled-library"] as const
+const supportedRuntimeOverlayLibraries = ["php-ai-client"] as const
+const supportedRuntimeOverlayStrategies = ["wordpress-scoped-bundle"] as const
 
 export async function loadWorkspaceRecipe(recipePath: string): Promise<WorkspaceRecipe> {
   return parseWorkspaceRecipe(await readFile(recipePath, "utf8"), recipePath)
@@ -347,26 +350,34 @@ function validateRecipeRuntimeOverlays(overlays: WorkspaceRecipeRuntimeOverlay[]
     throw new Error(`Recipe runtime overlays must be an array: ${recipePath}`)
   }
 
-  for (const overlay of overlays ?? []) {
-    if (overlay.kind !== "bundled-library") {
-      throw new Error(`Recipe runtime overlay kind is unsupported: ${recipePath}`)
+  for (const [index, overlay] of (overlays ?? []).entries()) {
+    const path = `runtime_overlays[${index}] ($.runtime.overlays[${index}])`
+    if (!overlay || typeof overlay !== "object" || Array.isArray(overlay)) {
+      throw new Error(runtimeOverlayValidationMessage(path, "entry", "must be an object", recipePath))
     }
-    if (overlay.library !== "php-ai-client") {
-      throw new Error(`Recipe runtime overlay library is unsupported: ${recipePath}`)
+    if (!supportedRuntimeOverlayKinds.includes(overlay.kind)) {
+      throw new Error(runtimeOverlayValidationMessage(path, "kind", `must be one of: ${supportedRuntimeOverlayKinds.join(", ")}`, recipePath))
     }
-    if (overlay.strategy !== "wordpress-scoped-bundle") {
-      throw new Error(`Recipe runtime overlay strategy is unsupported: ${recipePath}`)
+    if (!supportedRuntimeOverlayLibraries.includes(overlay.library)) {
+      throw new Error(runtimeOverlayValidationMessage(path, "library", `must be one of: ${supportedRuntimeOverlayLibraries.join(", ")}`, recipePath))
+    }
+    if (!supportedRuntimeOverlayStrategies.includes(overlay.strategy)) {
+      throw new Error(runtimeOverlayValidationMessage(path, "strategy", `must be one of: ${supportedRuntimeOverlayStrategies.join(", ")}`, recipePath))
     }
     if (!overlay.source || typeof overlay.source !== "string") {
-      throw new Error(`Recipe runtime overlays must include source: ${recipePath}`)
+      throw new Error(runtimeOverlayValidationMessage(path, "source", "must be a non-empty string", recipePath))
     }
     if (overlay.target !== undefined && typeof overlay.target !== "string") {
-      throw new Error(`Recipe runtime overlay target must be a string when provided: ${recipePath}`)
+      throw new Error(runtimeOverlayValidationMessage(path, "target", "must be a string when provided", recipePath))
     }
     if (overlay.metadata !== undefined && (!overlay.metadata || typeof overlay.metadata !== "object" || Array.isArray(overlay.metadata))) {
-      throw new Error(`Recipe runtime overlay metadata must be an object when provided: ${recipePath}`)
+      throw new Error(runtimeOverlayValidationMessage(path, "metadata", "must be an object when provided", recipePath))
     }
   }
+}
+
+function runtimeOverlayValidationMessage(path: string, field: string, problem: string, recipePath: string): string {
+  return `Recipe runtime overlay is unsupported at ${path}; field ${field} ${problem}; accepted canonical kind values: ${supportedRuntimeOverlayKinds.join(", ")}; recipe: ${recipePath}`
 }
 
 function validateRecipeDependencyOverlays(overlays: WorkspaceRecipeDependencyOverlay[] | undefined, recipePath: string): void {

--- a/scripts/runtime-overlay-validation-smoke.ts
+++ b/scripts/runtime-overlay-validation-smoke.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict"
+import { parseWorkspaceRecipe } from "../packages/cli/src/recipe-validation.js"
+
+const recipePath = "/tmp/wp-codebox-runtime-overlay-recipe.json"
+
+function recipeWithOverlay(overlay: Record<string, unknown>): string {
+  return JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    runtime: {
+      overlays: [overlay],
+    },
+    workflow: {
+      steps: [
+        {
+          command: "inspect-mounted-inputs",
+        },
+      ],
+    },
+  })
+}
+
+assert.throws(
+  () => parseWorkspaceRecipe(recipeWithOverlay({
+    type: "bundled-library",
+    library: "php-ai-client",
+    source: "./vendor/php-ai-client",
+    strategy: "wordpress-scoped-bundle",
+  }), recipePath),
+  (error) => {
+    assert.ok(error instanceof Error)
+    assert.match(error.message, /runtime_overlays\[0\]/)
+    assert.match(error.message, /\$\.runtime\.overlays\[0\]/)
+    assert.match(error.message, /field kind must be one of: bundled-library/)
+    assert.match(error.message, /accepted canonical kind values: bundled-library/)
+    assert.match(error.message, new RegExp(recipePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+    return true
+  },
+)
+
+assert.throws(
+  () => parseWorkspaceRecipe(recipeWithOverlay({
+    kind: "provider-plugin",
+    library: "php-ai-client",
+    source: "./vendor/php-ai-client",
+    strategy: "wordpress-scoped-bundle",
+  }), recipePath),
+  (error) => {
+    assert.ok(error instanceof Error)
+    assert.match(error.message, /runtime_overlays\[0\]/)
+    assert.match(error.message, /field kind must be one of: bundled-library/)
+    assert.match(error.message, /accepted canonical kind values: bundled-library/)
+    assert.match(error.message, /recipe: \/tmp\/wp-codebox-runtime-overlay-recipe\.json/)
+    return true
+  },
+)
+
+console.log("Runtime overlay validation smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -72,6 +72,7 @@ export const smokeGroups = {
       tsxSmoke("wordpress-state-contract-smoke"),
       tsxSmoke("playground-command-errors-smoke"),
       tsxSmoke("replay-export-snapshot-scoping-smoke"),
+      tsxSmoke("runtime-overlay-validation-smoke"),
       tsxSmoke("composer-backed-source-hydration-smoke"),
       tsxSmoke("recipe-run-composer-autoload-extra-plugin-smoke"),
       tsxSmoke("runtime-component-lifecycle-replay-smoke"),


### PR DESCRIPTION
## Summary
- Report unsupported runtime overlay entries with the offending `runtime_overlays[N]` / `$.runtime.overlays[N]` path.
- Include the failing field, accepted canonical `kind` values, and recipe path evidence in validation errors.
- Keep the contract canonical-only: legacy `type` remains unsupported and is reported as a missing/invalid `kind`.

Fixes #1025.

## Testing
- `npm exec tsx -- scripts/runtime-overlay-validation-smoke.ts`
- `npm run build`
- `npm run smoke -- --command=runtime-overlay-validation-smoke`

No local Cargo was run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the validation diagnostic changes, focused smoke coverage, and verification notes for Chris to review.
