### PR TITLE
Capture hidden Playground crash diagnostics

### DIFF
--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -172,19 +172,67 @@ function diagnosticRecords(value: unknown, seen = new Set<unknown>()): Record<st
   }
   seen.add(value)
 
-  const record = value as Record<string, unknown>
+  const record = diagnosticRecord(value)
   return [
     record,
     ...["cause", "response", "result", "data", "output"].flatMap((key) => diagnosticRecords(record[key], seen)),
   ]
 }
 
+function diagnosticRecord(value: object): Record<string, unknown> {
+  const record: Record<string, unknown> = {}
+  for (const key of diagnosticPropertyNames(value)) {
+    const descriptor = getPropertyDescriptor(value, key)
+    if (!descriptor || !("value" in descriptor || descriptor.get)) {
+      continue
+    }
+
+    try {
+      record[key] = "value" in descriptor ? descriptor.value : descriptor.get?.call(value)
+    } catch {
+      // Ignore throwing diagnostic accessors; they are not useful crash context.
+    }
+  }
+
+  return record
+}
+
+function diagnosticPropertyNames(value: object): string[] {
+  const names = new Set<string>()
+  let current: object | null = value
+  while (current && current !== Object.prototype) {
+    for (const name of Object.getOwnPropertyNames(current)) {
+      names.add(name)
+    }
+    current = Object.getPrototypeOf(current) as object | null
+  }
+  return [...names]
+}
+
+function getPropertyDescriptor(value: object, key: string): PropertyDescriptor | undefined {
+  let current: object | null = value
+  while (current && current !== Object.prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, key)
+    if (descriptor) {
+      return descriptor
+    }
+    current = Object.getPrototypeOf(current) as object | null
+  }
+  return undefined
+}
+
 function diagnosticText(value: unknown): string | undefined {
   if (typeof value === "string") {
     return playgroundOutputDiagnostic(value.trim())
   }
+  if (value instanceof ArrayBuffer) {
+    return playgroundOutputDiagnostic(new TextDecoder().decode(value).trim())
+  }
   if (value instanceof Uint8Array) {
     return playgroundOutputDiagnostic(new TextDecoder().decode(value).trim())
+  }
+  if (ArrayBuffer.isView(value)) {
+    return playgroundOutputDiagnostic(new TextDecoder().decode(new Uint8Array(value.buffer, value.byteOffset, value.byteLength)).trim())
   }
   if (!value || typeof value !== "object" || typeof value === "function") {
     return undefined

--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -76,6 +76,28 @@ assert.match(nestedResponseMessage, /status=500/)
 assert.match(nestedResponseMessage, /--- Playground response text ---/)
 assert.match(nestedResponseMessage, /wp_codebox_missing_fixture/)
 
+const nonEnumerableFatal = new Error("PHP.run() failed with exit code 255")
+Object.defineProperties(nonEnumerableFatal, {
+  httpStatusCode: { value: 500 },
+  exitCode: { value: 255 },
+  response: {
+    value: Object.defineProperties({}, {
+      body: { value: new TextEncoder().encode("Fatal error: Uncaught Error: Call to undefined function wp_codebox_hidden_fixture()") },
+      headers: { value: { "content-type": "text/html; charset=UTF-8", authorization: "secret" } },
+    }),
+  },
+})
+
+const nonEnumerableFatalMessage = new PlaygroundCommandCrashError("wordpress.run-php", nonEnumerableFatal).message
+
+assert.match(nonEnumerableFatalMessage, /httpStatusCode=500/)
+assert.match(nonEnumerableFatalMessage, /exitCode=255/)
+assert.match(nonEnumerableFatalMessage, /--- Playground response body ---/)
+assert.match(nonEnumerableFatalMessage, /wp_codebox_hidden_fixture/)
+assert.doesNotMatch(nonEnumerableFatalMessage, /No Playground stdout, stderr, or response body was captured/)
+assert.doesNotMatch(nonEnumerableFatalMessage, /authorization/)
+assert.doesNotMatch(nonEnumerableFatalMessage, /secret/)
+
 const htmlFatal = "<br />\n<b>Fatal error</b>:  Uncaught Error: Call to a member function is_sandbox() on null in <b>/wordpress/wp-content/plugins/woocommerce-square/includes/Gateway/Cash_App_Pay_Gateway.php</b>:283\nStack trace:\n#0 {main}\n  thrown in <b>/wordpress/wp-content/plugins/woocommerce-square/includes/Gateway/Cash_App_Pay_Gateway.php</b> on line <b>283</b><br />"
 const byteMap = Object.fromEntries(Array.from(Buffer.from(htmlFatal, "utf8")).map((byte, index) => [String(index), byte]))
 const byteMapMessage = new PlaygroundCommandError("wordpress.bench", {


### PR DESCRIPTION
## Summary
- Capture non-enumerable Playground crash diagnostics when `wordpress.run-php` fails before returning a structured response.
- Decode binary response body payloads so PHP fatal messages attached as bytes are surfaced in the crash message.
- Extend the existing focused playground-command-errors smoke to cover hidden HTTP 500 / exit 255 response diagnostics and header redaction.

Fixes #1024.

## Evidence
- Source evidence: latest WPCOM proof artifact root reported in #1024: `/home/chubes/Developer/_lab_workspaces/wpcom-codebox-final-20260616T0120/artifacts/edit-page/wordpress-com-ai-2026-06-16T02-58-26-517Z`.
- Offloaded verification on Homeboy Lab runner `homeboy-lab`: `npm run smoke -- --command playground-command-errors-smoke && npm run build`.
- Homeboy run id: `runner-exec-homeboy-lab-1ea495a1-8dc2-4ca0-a1a8-70f514caadeb`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the diagnostic handling change, focused regression coverage, and offloaded verification commands; Chris remains responsible for review and final submission.
