### PR TITLE
Add typed recipe artifact materialization

### DIFF
--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -1,4 +1,4 @@
-import type { ArtifactBundle, BenchResults, ExecutionResult, RuntimeInfo, RuntimeRunRecord } from "@automattic/wp-codebox-core"
+import type { ArtifactBundle, BenchResults, ExecutionResult, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef } from "@automattic/wp-codebox-core"
 import type { RecipeDryRunOutput, RecipeDryRunSiteSeed, RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import type { AgentSandboxResultSummary, AgentTaskSingleResult, RecipeReplayStatusSummary, SandboxCompletionOutcome } from "../recipe-evidence.js"
 import type { RecipeValidationIssue, RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -252,6 +252,7 @@ export interface RecipeRunDeclaredArtifact {
   size?: number
   sha256?: string
   parsedJson?: unknown
+  materialized?: TypedArtifactRef
   metadata?: Record<string, unknown>
   error?: RunOutput["error"]
 }

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, artifactBundleRunRef, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -10,7 +10,7 @@ import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex, recipeDryRunSiteSeeds, siteSeedScopesAreBounded } from "../recipe-dry-run.js"
-import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
+import { appendRecipeRuntimeEvidence, appendRecipeRuntimeEvidenceFiles, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, installMuPluginsCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspaces, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -422,6 +422,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       artifacts = await awaitRecipe("runtime.collect-artifacts", collectRecipeRuntimeArtifacts(runtime!, { includeLogs: true, includeObservations: true }, { snapshotTimeoutMs: SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS }))
       browserEvidence = await recipeBrowserEvidence(artifacts, executions)
       await artifactPointer.update({ runtime: await runtime!.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
+      await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
       await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts))
       if (declaredArtifactFailure) {
         throw declaredArtifactFailure
@@ -444,6 +445,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       artifacts = await awaitRecipe("runtime.collect-artifacts.preview-hold", collectRecipeRuntimeArtifacts(runtime, { includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds }, { snapshotTimeoutMs: SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS }))
       browserEvidence = await recipeBrowserEvidence(artifacts, executions)
       await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
+      declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, runtime)
+      await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
+      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts))
       evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)
       const previewAgentEvidence = await finalizeAgentSandboxEvidence(artifacts, executions)
       Object.assign(evidence, previewAgentEvidence)
@@ -575,6 +579,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
           if (declaredArtifacts.length === 0) {
             declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, activeRuntime)
           }
+          await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
           const evidenceFiles = await appendRecipeRuntimeEvidence(artifacts, [
             ...recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts),
             failureDiagnostics,
@@ -1503,6 +1508,10 @@ async function collectRecipeDeclaredArtifacts(recipe: WorkspaceRecipe, runtime: 
   for (const [index, artifact] of (recipe.artifacts?.paths ?? []).entries()) {
     results.push(await collectRecipeDeclaredArtifact(runtime, artifact, index))
   }
+  const offset = results.length
+  for (const [index, artifact] of (recipe.artifacts?.typed ?? []).entries()) {
+    results.push(await collectRecipeTypedArtifact(runtime, artifact, offset + index))
+  }
   return results
 }
 
@@ -1542,6 +1551,135 @@ async function collectRecipeDeclaredArtifact(runtime: Runtime, artifact: Workspa
       metadata: artifact.metadata,
     }) as RecipeRunDeclaredArtifact
   }
+}
+
+async function collectRecipeTypedArtifact(runtime: Runtime, artifact: WorkspaceRecipeTypedArtifact, index: number): Promise<RecipeRunDeclaredArtifact> {
+  const result = await collectRecipeDeclaredArtifact(runtime, {
+    name: artifact.name,
+    path: artifact.path,
+    required: artifact.required,
+    parseJson: artifact.parseJson,
+    metadata: artifact.metadata,
+  }, index)
+  if (result.status !== "collected") {
+    return result
+  }
+
+  try {
+    const execution = await runtime.execute({
+      command: "wordpress.run-php",
+      args: [`code=${declaredArtifactContentsCode(artifact.path)}`],
+    })
+    const collected = JSON.parse(execution.stdout.trim() || "{}") as Record<string, unknown>
+    return stripUndefined({
+      ...result,
+      typedArtifact: {
+        name: artifact.name,
+        type: artifact.type,
+        payloadSchema: artifact.payloadSchema,
+        contentType: artifact.contentType ?? typedArtifactContentType(artifact),
+      },
+      contentBase64: typeof collected.contentBase64 === "string" ? collected.contentBase64 : undefined,
+    }) as RecipeRunDeclaredArtifact
+  } catch (error) {
+    return stripUndefined({
+      ...result,
+      status: "failed" as const,
+      exists: false,
+      error: serializeRecipeRunError(error),
+    }) as RecipeRunDeclaredArtifact
+  }
+}
+
+async function materializeTypedRecipeDeclaredArtifacts(artifacts: ArtifactBundle, declaredArtifacts: RecipeRunDeclaredArtifact[]): Promise<void> {
+  const refs: TypedArtifactRef[] = []
+  const files = []
+  for (const artifact of declaredArtifacts) {
+    const typedArtifact = recipeRunTypedArtifactDeclaration(artifact)
+    const contentBase64 = recipeRunArtifactContentBase64(artifact)
+    if (!typedArtifact || artifact.status !== "collected" || !contentBase64) {
+      continue
+    }
+
+    const contents = Buffer.from(contentBase64, "base64")
+    const filename = `typed-artifacts/${safeTypedArtifactName(typedArtifact.name)}-${artifact.index + 1}${typedArtifactExtension(typedArtifact.contentType)}`
+    const sha256 = artifactFileDigest(contents).value
+    const ref: TypedArtifactRef = stripUndefined({
+      schema: STRUCTURED_ARTIFACT_SCHEMA,
+      name: typedArtifact.name,
+      type: typedArtifact.type,
+      payload_schema: typedArtifact.payloadSchema,
+      payload: artifact.parsedJson,
+      metadata: artifact.metadata ?? {},
+      provenance: {
+        direction: "output",
+        source: artifact.path,
+      },
+      artifact: {
+        path: `files/runtime-evidence/${filename}`,
+        kind: "typed-artifact",
+        contentType: typedArtifact.contentType,
+        sha256,
+      },
+    }) as TypedArtifactRef
+    refs.push(ref)
+    artifact.materialized = ref
+    delete (artifact as RecipeRunDeclaredArtifact & { contentBase64?: string }).contentBase64
+    delete (artifact as RecipeRunDeclaredArtifact & { typedArtifact?: unknown }).typedArtifact
+    files.push({ filename, kind: "typed-artifact", contentType: typedArtifact.contentType, contents })
+  }
+
+  if (refs.length === 0) {
+    return
+  }
+
+  const index: TypedArtifactIndex = {
+    schema: TYPED_ARTIFACT_INDEX_SCHEMA,
+    direction: "output",
+    artifacts: refs,
+  }
+  files.push({ filename: "typed-artifacts/index.json", kind: "typed-artifacts-index", contentType: "application/json", contents: `${JSON.stringify(index, null, 2)}\n` })
+  await appendRecipeRuntimeEvidenceFiles(artifacts, files)
+}
+
+function recipeRunTypedArtifactDeclaration(artifact: RecipeRunDeclaredArtifact): { name: string; type: string; contentType: string; payloadSchema?: string | Record<string, unknown> } | undefined {
+  const typedArtifact = (artifact as RecipeRunDeclaredArtifact & { typedArtifact?: unknown }).typedArtifact
+  if (!typedArtifact || typeof typedArtifact !== "object") {
+    return undefined
+  }
+  const record = typedArtifact as Record<string, unknown>
+  if (typeof record.name !== "string" || typeof record.type !== "string" || typeof record.contentType !== "string") {
+    return undefined
+  }
+  return stripUndefined({
+    name: record.name,
+    type: record.type,
+    contentType: record.contentType,
+    payloadSchema: typeof record.payloadSchema === "string" || isRecordValue(record.payloadSchema) ? record.payloadSchema : undefined,
+  })
+}
+
+function recipeRunArtifactContentBase64(artifact: RecipeRunDeclaredArtifact): string | undefined {
+  const contentBase64 = (artifact as RecipeRunDeclaredArtifact & { contentBase64?: unknown }).contentBase64
+  return typeof contentBase64 === "string" && contentBase64.length > 0 ? contentBase64 : undefined
+}
+
+function typedArtifactContentType(artifact: WorkspaceRecipeTypedArtifact): string {
+  return artifact.parseJson === true ? "application/json" : "application/octet-stream"
+}
+
+function typedArtifactExtension(contentType: string): string {
+  if (contentType === "application/json") return ".json"
+  if (contentType.startsWith("text/")) return ".txt"
+  return ".bin"
+}
+
+function safeTypedArtifactName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "artifact"
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
 }
 
 function recipeProbeFailure(probes: RecipeRunProbe[]): RecipeProbeFailureError | undefined {
@@ -1726,6 +1864,20 @@ if (is_file($path)) {
     $result['sha256'] = hash('sha256', wp_json_encode($entries));
 }
 echo wp_json_encode($result);`
+}
+
+function declaredArtifactContentsCode(path: string): string {
+  const encodedPath = JSON.stringify(path)
+  return `
+$path = ${encodedPath};
+if (!is_file($path)) {
+    throw new RuntimeException('Typed artifact path is not a file: ' . $path);
+}
+$contents = file_get_contents($path);
+if (false === $contents) {
+    throw new RuntimeException('Unable to read typed artifact path: ' . $path);
+}
+echo wp_json_encode(array('contentBase64' => base64_encode($contents)));`
 }
 
 function activateExtraPluginCode(pluginFile: string): string {

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -25,7 +25,7 @@ export interface RecipeRuntimeEvidenceFileInput {
   filename: string
   kind: string
   contentType: string
-  contents: string
+  contents: string | Buffer
 }
 
 export interface RecipeArtifactEvidenceResult {

--- a/packages/runtime-core/src/artifact-bundle-verifier.ts
+++ b/packages/runtime-core/src/artifact-bundle-verifier.ts
@@ -5,6 +5,7 @@ import type { ArtifactContentDigest, ArtifactFileDigest, ArtifactManifest, Artif
 import { isPlainObject as isRecord } from "./object-utils.js"
 import { RUNTIME_EPISODE_TRACE_SCHEMA, validateRuntimeEpisodeTrace } from "./runtime-episode.js"
 import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest } from "./runtime-reference.js"
+import { TYPED_ARTIFACT_INDEX_SCHEMA } from "./structured-artifacts.js"
 import type { RuntimeReferenceManifest, RuntimeReferenceManifestArtifactBundleRef, RuntimeReferenceManifestFileRef, RuntimeReferenceManifestSnapshotRef, RuntimeReplayReferenceIndex, RuntimeReplayReferenceIndexActionRef, RuntimeReplayReferenceIndexObservationRef } from "./runtime-reference.js"
 import type { RuntimeEpisodeContentDigest, RuntimeEpisodeTraceRef } from "./index.js"
 
@@ -161,6 +162,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   await verifyRuntimeEpisodeTraceArtifacts(bundleDirectory, manifest, violations)
   await verifyRuntimeReferenceManifestArtifacts(bundleDirectory, manifest, manifestFiles, violations)
   await verifyRuntimeReplayReferenceIndexArtifacts(bundleDirectory, manifest, manifestFiles, violations)
+  await verifyTypedArtifactIndexArtifacts(bundleDirectory, manifest, manifestFiles, violations)
 
   return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
 }
@@ -836,6 +838,46 @@ async function verifyChangedFileEvidence(directory: string, changedFilesPath: st
     }
   } catch (error) {
     violations.push({ code: "review-evidence-mismatch", path: "files/review.json:evidence.changedFiles", file: changedFilesPath, message: `Unable to read changed-file evidence: ${errorMessage(error)}` })
+  }
+}
+
+async function verifyTypedArtifactIndexArtifacts(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  for (const file of manifest.files.filter((entry) => entry.kind === "typed-artifacts-index")) {
+    let index: unknown
+    try {
+      index = JSON.parse(await readFile(join(directory, file.path), "utf8"))
+    } catch (error) {
+      violations.push({ code: "malformed-reference", path: file.path, file: file.path, message: `Unable to read typed artifact index: ${errorMessage(error)}` })
+      continue
+    }
+
+    if (!isRecord(index) || index.schema !== TYPED_ARTIFACT_INDEX_SCHEMA || !Array.isArray(index.artifacts)) {
+      violations.push({ code: "malformed-reference", path: file.path, file: file.path, message: "Typed artifact index must include schema wp-codebox/typed-artifacts-index/v1 and an artifacts array." })
+      continue
+    }
+
+    for (const [indexPosition, artifact] of index.artifacts.entries()) {
+      const fieldPath = `${file.path}:artifacts[${indexPosition}]`
+      if (!isRecord(artifact) || !isRecord(artifact.artifact) || typeof artifact.artifact.path !== "string") {
+        violations.push({ code: "malformed-reference", path: fieldPath, file: file.path, message: "Typed artifact entries must include artifact.path." })
+        continue
+      }
+      validateArtifactReference(artifact.artifact.path, `${fieldPath}.artifact.path`, manifestFiles, violations)
+      if (typeof artifact.artifact.sha256 === "string") {
+        await verifyTypedArtifactFileDigest(directory, artifact.artifact.path, artifact.artifact.sha256, `${fieldPath}.artifact.sha256`, violations)
+      }
+    }
+  }
+}
+
+async function verifyTypedArtifactFileDigest(directory: string, path: string, expectedSha256: string, fieldPath: string, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  try {
+    const actualSha256 = artifactFileDigest(await readFile(join(directory, path))).value
+    if (actualSha256 !== expectedSha256) {
+      violations.push({ code: "file-hash-mismatch", path: fieldPath, file: path, message: `Typed artifact digest mismatch for ${path}: expected ${expectedSha256}, got ${actualSha256}` })
+    }
+  } catch (error) {
+    violations.push({ code: "missing-file", path: fieldPath, file: path, message: `Unable to read typed artifact file: ${errorMessage(error)}` })
   }
 }
 

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -134,6 +134,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             description: "Sandbox artifact paths declared by the recipe for structured post-run collection.",
             items: { $ref: "#/$defs/declaredArtifact" },
           },
+          typed: {
+            type: "array",
+            description: "Typed sandbox output artifacts materialized into the artifact bundle and indexed by name/type.",
+            items: { $ref: "#/$defs/typedArtifact" },
+          },
         },
       },
       probes: {
@@ -547,6 +552,26 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           path: { type: "string", pattern: "^/" },
           required: { type: "boolean" },
           parseJson: { type: "boolean" },
+          metadata: { $ref: "#/$defs/metadata" },
+        },
+      },
+      typedArtifact: {
+        type: "object",
+        additionalProperties: false,
+        required: ["name", "type", "path"],
+        properties: {
+          name: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*$" },
+          type: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.:/-]*$" },
+          path: { type: "string", pattern: "^/" },
+          required: { type: "boolean" },
+          contentType: { type: "string" },
+          parseJson: { type: "boolean" },
+          payloadSchema: {
+            oneOf: [
+              { type: "string" },
+              { type: "object" },
+            ],
+          },
           metadata: { $ref: "#/$defs/metadata" },
         },
       },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -215,6 +215,17 @@ export interface WorkspaceRecipeDeclaredArtifact {
   metadata?: Record<string, unknown>
 }
 
+export interface WorkspaceRecipeTypedArtifact {
+  name: string
+  type: string
+  path: string
+  required?: boolean
+  contentType?: string
+  parseJson?: boolean
+  payloadSchema?: string | Record<string, unknown>
+  metadata?: Record<string, unknown>
+}
+
 export interface WorkspaceRecipePluginRuntimePhp {
   memoryLimit?: string
   maxExecutionTime?: number
@@ -374,6 +385,7 @@ export interface WorkspaceRecipe {
     verify?: boolean | WorkspaceRecipeArtifactVerifier
     workspacePolicy?: boolean | WorkspaceRecipeWorkspacePolicyArtifact
     paths?: WorkspaceRecipeDeclaredArtifact[]
+    typed?: WorkspaceRecipeTypedArtifact[]
   }
   probes?: WorkspaceRecipeProbe[]
 }

--- a/packages/runtime-core/src/structured-artifacts.ts
+++ b/packages/runtime-core/src/structured-artifacts.ts
@@ -2,6 +2,7 @@ import { isPlainObject } from "./object-utils.js"
 
 export const STRUCTURED_ARTIFACT_SCHEMA = "wp-codebox/structured-artifact/v1" as const
 export const STRUCTURED_ARTIFACT_INDEX_SCHEMA = "wp-codebox/structured-artifacts-index/v1" as const
+export const TYPED_ARTIFACT_INDEX_SCHEMA = "wp-codebox/typed-artifacts-index/v1" as const
 
 export type StructuredArtifactDirection = "input" | "output"
 
@@ -31,6 +32,31 @@ export interface StructuredArtifactIndex {
   schema: typeof STRUCTURED_ARTIFACT_INDEX_SCHEMA
   direction: StructuredArtifactDirection
   artifacts: StructuredArtifactRef[]
+}
+
+export interface TypedArtifactRef {
+  schema: typeof STRUCTURED_ARTIFACT_SCHEMA
+  name: string
+  type: string
+  payload_schema?: string | Record<string, unknown>
+  payload?: unknown
+  metadata: Record<string, unknown>
+  provenance: {
+    direction: "output"
+    source: string
+  }
+  artifact: {
+    path: string
+    kind: "typed-artifact"
+    contentType: string
+    sha256: string
+  }
+}
+
+export interface TypedArtifactIndex {
+  schema: typeof TYPED_ARTIFACT_INDEX_SCHEMA
+  direction: "output"
+  artifacts: TypedArtifactRef[]
 }
 
 export function normalizeStructuredArtifacts(value: unknown, direction: StructuredArtifactDirection): StructuredArtifactPayload[] {

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -59,6 +59,7 @@ export const smokeGroups = {
       tsxSmoke("artifact-patch-git-apply-smoke"),
       tsxSmoke("artifact-reference-normalization-smoke"),
       tsxSmoke("artifact-diagnostics-normalizer-smoke"),
+      tsxSmoke("typed-artifacts-smoke"),
       tsxSmoke("partial-artifact-discovery-smoke"),
       tsxSmoke("mounted-workspace-diff-smoke"),
       tsxSmoke("replay-export-blueprint-smoke"),
@@ -76,6 +77,12 @@ export const smokeGroups = {
       tsxSmoke("composer-backed-source-hydration-smoke"),
       tsxSmoke("recipe-run-composer-autoload-extra-plugin-smoke"),
       tsxSmoke("runtime-component-lifecycle-replay-smoke"),
+    ],
+  },
+  package: {
+    description: "Package build contract smoke checks.",
+    commands: [
+      npmScript("build"),
     ],
   },
   agent: {
@@ -101,7 +108,7 @@ export const smokeGroups = {
 export const smokeManifest = {
   groups: smokeGroups,
   aggregateGroups: {
-    check: ["core", "policy", "artifact", "runtime", "agent"],
+    check: ["core", "policy", "artifact", "runtime", "package", "agent"],
   },
 } as const
 

--- a/scripts/typed-artifacts-smoke.ts
+++ b/scripts/typed-artifacts-smoke.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Ajv2020 } from "ajv/dist/2020.js"
+import {
+  STRUCTURED_ARTIFACT_SCHEMA,
+  TYPED_ARTIFACT_INDEX_SCHEMA,
+  artifactFileDigest,
+  calculateArtifactContentDigest,
+  calculateArtifactManifestFileSha256,
+  createWorkspaceRecipeJsonSchema,
+  normalizeStructuredArtifacts,
+  type ArtifactManifest,
+  type TypedArtifactIndex,
+} from "@automattic/wp-codebox-core"
+import { verifyArtifactBundle } from "@automattic/wp-codebox-core/artifacts"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-typed-artifacts-"))
+
+try {
+  const recipeSchema = createWorkspaceRecipeJsonSchema()
+  const validateRecipe = new Ajv2020({ strict: false }).compile(recipeSchema)
+  assert.equal(validateRecipe({
+    schema: "wp-codebox/workspace-recipe/v1",
+    workflow: { steps: [{ command: "host/example" }] },
+    artifacts: {
+      typed: [{ name: "summary", type: "example.summary", path: "/tmp/summary.json", required: true, parseJson: true, payloadSchema: "example/summary/v1" }],
+    },
+  }), true)
+
+  const structured = normalizeStructuredArtifacts([{ name: "summary", type: "example.summary", payload: { ok: true } }], "output")
+  assert.equal(structured[0]?.schema, STRUCTURED_ARTIFACT_SCHEMA)
+  assert.equal(structured[0]?.provenance.direction, "output")
+
+  const validBundle = join(workspace, "valid")
+  await writeTypedArtifactBundle(validBundle)
+  const valid = await verifyArtifactBundle(validBundle)
+  assert.equal(valid.valid, true)
+
+  const missingTypedArtifact = join(workspace, "missing-typed-artifact")
+  await writeTypedArtifactBundle(missingTypedArtifact, { omitTypedArtifactManifestEntry: true })
+  const missing = await verifyArtifactBundle(missingTypedArtifact, { allowOrphanedFiles: true })
+  assert.equal(missing.valid, false)
+  assert.equal(missing.violations.some((violation) => violation.code === "malformed-reference" && violation.file === "files/runtime-evidence/typed-artifacts/summary-1.json"), true)
+
+  const digestMismatch = join(workspace, "typed-digest-mismatch")
+  await writeTypedArtifactBundle(digestMismatch, { badTypedArtifactDigest: true })
+  const mismatch = await verifyArtifactBundle(digestMismatch)
+  assert.equal(mismatch.valid, false)
+  assert.equal(mismatch.violations.some((violation) => violation.code === "file-hash-mismatch" && violation.file === "files/runtime-evidence/typed-artifacts/summary-1.json"), true)
+
+  console.log("Typed artifacts smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+async function writeTypedArtifactBundle(directory: string, options: { omitTypedArtifactManifestEntry?: boolean; badTypedArtifactDigest?: boolean } = {}): Promise<void> {
+  await mkdir(join(directory, "files/runtime-evidence/typed-artifacts"), { recursive: true })
+  await writeFile(join(directory, "metadata.json"), "{}\n")
+
+  const typedPayload = `${JSON.stringify({ ok: true }, null, 2)}\n`
+  const typedPath = "files/runtime-evidence/typed-artifacts/summary-1.json"
+  await writeFile(join(directory, typedPath), typedPayload)
+  const typedDigest = artifactFileDigest(typedPayload).value
+  const index: TypedArtifactIndex = {
+    schema: TYPED_ARTIFACT_INDEX_SCHEMA,
+    direction: "output",
+    artifacts: [{
+      schema: STRUCTURED_ARTIFACT_SCHEMA,
+      name: "summary",
+      type: "example.summary",
+      payload_schema: "example/summary/v1",
+      payload: { ok: true },
+      metadata: {},
+      provenance: { direction: "output", source: "/tmp/summary.json" },
+      artifact: {
+        path: typedPath,
+        kind: "typed-artifact",
+        contentType: "application/json",
+        sha256: options.badTypedArtifactDigest ? "0".repeat(64) : typedDigest,
+      },
+    }],
+  }
+  await writeFile(join(directory, "files/runtime-evidence/typed-artifacts/index.json"), `${JSON.stringify(index, null, 2)}\n`)
+
+  const digest = await calculateArtifactContentDigest(directory, [typedPath])
+  const manifest: ArtifactManifest = {
+    id: `artifact-bundle-sha256-${digest}`,
+    contentDigest: { algorithm: "sha256", inputs: [typedPath], value: digest },
+    createdAt: "2026-06-16T00:00:00.000Z",
+    runtime: {
+      id: "runtime-fixture",
+      backend: "wordpress-playground",
+      status: "destroyed",
+      environment: { kind: "wordpress", version: "latest" },
+      createdAt: "2026-06-16T00:00:00.000Z",
+    },
+    files: [
+      manifestFile("manifest.json", "manifest", "application/json"),
+      manifestFile("metadata.json", "metadata", "application/json"),
+      manifestFile("files/runtime-evidence/typed-artifacts/index.json", "typed-artifacts-index", "application/json"),
+      ...(options.omitTypedArtifactManifestEntry ? [] : [manifestFile(typedPath, "typed-artifact", "application/json")]),
+    ],
+  }
+  for (const file of manifest.files) {
+    if (file.path !== "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
+    }
+  }
+  for (const file of manifest.files) {
+    if (file.path === "manifest.json") {
+      file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
+    }
+  }
+  await writeFile(join(directory, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+function manifestFile(path: string, kind: string, contentType: string): ArtifactManifest["files"][number] {
+  return { path, kind, contentType, sha256: { algorithm: "sha256", value: "0".repeat(64) } }
+}


### PR DESCRIPTION
## Summary
- Add generic `artifacts.typed` recipe declarations for named/type output files.
- Materialize collected typed files into artifact bundles and index them with `typed-artifacts/index.json` while preserving existing `artifacts.paths` and `recipe-declared-artifacts.json` behavior.
- Verify typed artifact index references and file digests during artifact bundle verification.
- Add typed artifact smoke coverage and restore the declared `package` smoke group used by Homeboy tests.

Fixes #1029

## Verification
- `npm run build`
- `npx tsx scripts/typed-artifacts-smoke.ts`
- `npm run smoke -- --group package`
- `homeboy review --changed-since origin/main --summary` passed, run id `54f25942-0e30-4587-bfb4-11906563faca`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the typed artifact declaration/materialization primitive, focused smoke coverage, and verification workflow; Chris remains responsible for review and acceptance.
