### PR TITLE
Improve PHP execution failure diagnostics

### DIFF
--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -10,6 +10,7 @@ interface PhpBootstrapBridge {
 
 export function bootstrapAbilityPhpCode(spec: RuntimeCreateSpec, code: string): string {
   return `<?php
+${phpFatalDiagnosticPhp()}
 define( 'REST_REQUEST', true );
 $_SERVER['REQUEST_URI'] = '/wp-json/wp-codebox/ability';
 ${runtimeEnvPhp(spec)}
@@ -24,6 +25,7 @@ export function bootstrapPhpCode(spec: RuntimeCreateSpec, code: string, args: st
   }
 
   return `<?php
+${phpFatalDiagnosticPhp()}
 ${pluginRuntimeBootstrapPhp(spec)}
 ${runtimeEnvPhp(spec)}
 require_once '/wordpress/wp-load.php';
@@ -33,6 +35,22 @@ ${wpCliBridge ? `putenv(${JSON.stringify(`HOMEBOY_TERMINAL_ACTION_URL=${wpCliBri
 putenv(${JSON.stringify(`HOMEBOY_TERMINAL_ACTION_TOKEN=${wpCliBridge.token}`)});
 ` : ""}
 ${phpBody(code)}`
+}
+
+function phpFatalDiagnosticPhp(): string {
+  return `register_shutdown_function(static function (): void {
+    $wp_codebox_fatal = error_get_last();
+    if (!is_array($wp_codebox_fatal) || !in_array($wp_codebox_fatal['type'] ?? 0, array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR), true)) {
+        return;
+    }
+    echo "\nWP_CODEBOX_PHP_FATAL_DIAGNOSTIC:" . json_encode(array(
+        'schema' => 'wp-codebox/php-fatal-diagnostic/v1',
+        'message' => isset($wp_codebox_fatal['message']) ? (string) $wp_codebox_fatal['message'] : '',
+        'file' => isset($wp_codebox_fatal['file']) ? (string) $wp_codebox_fatal['file'] : '',
+        'line' => isset($wp_codebox_fatal['line']) ? (int) $wp_codebox_fatal['line'] : 0,
+        'type' => isset($wp_codebox_fatal['type']) ? (int) $wp_codebox_fatal['type'] : 0,
+    ), JSON_UNESCAPED_SLASHES) . "\n";
+});`
 }
 
 interface RecipePluginMetadata {

--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -1,6 +1,10 @@
 export interface PlaygroundRunResponse {
+  bytes?: unknown
+  cause?: unknown
   exitCode?: number
   errors?: string
+  httpStatusCode?: number
+  originalErrorClassName?: string
   text: string
 }
 
@@ -87,18 +91,48 @@ export function extractPhpunitFailureMessage(log: string): string | undefined {
 
 function playgroundFailureMessage(command: string, response: PlaygroundRunResponse): string {
   const lines = [`${command} failed with exit code ${response.exitCode ?? "unknown"}`]
-  const errors = response.errors?.trim()
-  const text = response.text?.trim()
+  const diagnostics = playgroundResponseDiagnostics(response)
 
-  if (errors) {
-    lines.push("", "--- Playground errors ---", errors)
-  }
-
-  if (text) {
-    lines.push("", "--- Playground output ---", playgroundOutputDiagnostic(text))
+  if (diagnostics.length > 0) {
+    lines.push("", "--- Playground response diagnostics ---", ...diagnostics)
   }
 
   return lines.join("\n")
+}
+
+function playgroundResponseDiagnostics(response: PlaygroundRunResponse): string[] {
+  const metadata: string[] = []
+  const sections: string[] = []
+  let capturedOutput = false
+
+  for (const [value, label] of [
+    [response.originalErrorClassName, "originalErrorClassName"],
+    [response.httpStatusCode, "httpStatusCode"],
+    [response.exitCode, "exitCode"],
+    [diagnosticCauseMessage(response.cause), "cause"],
+  ] as const) {
+    if ((typeof value === "number" || typeof value === "string") && value !== "") {
+      metadata.push(`${label}=${value}`)
+    }
+  }
+
+  for (const [value, label] of [
+    [response.errors, "Playground errors"],
+    [response.text, "Playground output"],
+    [response.bytes, "Playground response bytes"],
+  ] as const) {
+    const text = label === "Playground response bytes" ? diagnosticBytesText(value) : diagnosticText(value)
+    if (text) {
+      capturedOutput = true
+      sections.push(`--- ${label} ---`, text)
+    }
+  }
+
+  if (!capturedOutput && (metadata.length > 0 || hasEmptyByteMap(response.bytes) || response.errors === "" || response.text === "")) {
+    sections.push("No Playground response bytes, errors, or text were captured. The PHP fatal payload was absent from the wordpress.run-php response; inspect runtime command artifacts and Playground server diagnostics for the failing PHP process.")
+  }
+
+  return [...metadata, ...sections]
 }
 
 function playgroundCrashMessage(command: string, cause: unknown): string {
@@ -245,6 +279,24 @@ function diagnosticText(value: unknown): string | undefined {
   }
 }
 
+function diagnosticBytesText(value: unknown): string | undefined {
+  const bytes = byteMapFromUnknown(value)
+  if (!bytes || bytes.length === 0) {
+    return undefined
+  }
+
+  return playgroundOutputDiagnostic(new TextDecoder().decode(Uint8Array.from(bytes)).trim())
+}
+
+function diagnosticCauseMessage(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+
+  const message = (value as { message?: unknown }).message
+  return typeof message === "string" && message.trim() ? message.trim() : undefined
+}
+
 function diagnosticHeaders(value: unknown): string | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined
@@ -299,6 +351,11 @@ function playgroundOutputDiagnostic(raw: string): string {
 
 function phpFatalSummary(text: string): string | undefined {
   const normalized = stripHtml(text).replace(/\s+/g, " ").trim()
+  const diagnostic = wpCodeboxPhpFatalSummary(normalized)
+  if (diagnostic) {
+    return diagnostic
+  }
+
   const fatal = normalized.match(/(?:PHP )?Fatal error:\s+(.+?)(?=(?: Stack trace:| thrown in |$))/)
   if (!fatal) {
     return undefined
@@ -307,6 +364,23 @@ function phpFatalSummary(text: string): string | undefined {
   const thrown = normalized.match(/thrown in ([^\s]+) on line (\d+)/)
   const location = thrown ? `\nLocation: ${thrown[1]}:${thrown[2]}` : ""
   return `PHP fatal: ${fatal[1].trim()}${location}`
+}
+
+function wpCodeboxPhpFatalSummary(text: string): string | undefined {
+  const marker = text.match(/WP_CODEBOX_PHP_FATAL_DIAGNOSTIC:({.+?})(?:\s|$)/)
+  if (!marker) {
+    return undefined
+  }
+
+  const diagnostic = parseJsonObject(marker[1]) as { message?: unknown; file?: unknown; line?: unknown } | undefined
+  if (!diagnostic || typeof diagnostic.message !== "string" || !diagnostic.message.trim()) {
+    return undefined
+  }
+
+  const file = typeof diagnostic.file === "string" ? diagnostic.file : ""
+  const line = typeof diagnostic.line === "number" ? diagnostic.line : 0
+  const location = file && line > 0 ? `\nLocation: ${file}:${line}` : ""
+  return `PHP fatal: ${diagnostic.message.trim()}${location}`
 }
 
 function stripHtml(text: string): string {
@@ -363,6 +437,18 @@ function findByteMap(value: unknown, seen = new Set<unknown>()): number[] | unde
   }
 
   return undefined
+}
+
+function byteMapFromUnknown(value: unknown): number[] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined
+  }
+
+  return byteMapValues(value as Record<string, unknown>)
+}
+
+function hasEmptyByteMap(value: unknown): boolean {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value) && Object.keys(value as Record<string, unknown>).length === 0)
 }
 
 function byteMapValues(record: Record<string, unknown>): number[] | undefined {

--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
 import { createRuntime } from "../packages/runtime-core/src/index.js"
+import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
 import { PlaygroundCommandCrashError, PlaygroundCommandError } from "../packages/runtime-playground/src/playground-command-errors.js"
 import { createPlaygroundRuntimeBackend, type PlaygroundCliModule } from "../packages/runtime-playground/src/index.js"
 
@@ -98,6 +99,36 @@ assert.doesNotMatch(nonEnumerableFatalMessage, /No Playground stdout, stderr, or
 assert.doesNotMatch(nonEnumerableFatalMessage, /authorization/)
 assert.doesNotMatch(nonEnumerableFatalMessage, /secret/)
 
+const emptyPhpExecutionFailureMessage = new PlaygroundCommandError("wordpress.run-php", {
+  originalErrorClassName: "PHPExecutionFailureError",
+  httpStatusCode: 500,
+  exitCode: 255,
+  bytes: {},
+  errors: "",
+  text: "",
+  cause: { message: "Comlink method call failed" },
+}).message
+
+assert.match(emptyPhpExecutionFailureMessage, /wordpress\.run-php failed with exit code 255/)
+assert.match(emptyPhpExecutionFailureMessage, /originalErrorClassName=PHPExecutionFailureError/)
+assert.match(emptyPhpExecutionFailureMessage, /httpStatusCode=500/)
+assert.match(emptyPhpExecutionFailureMessage, /exitCode=255/)
+assert.match(emptyPhpExecutionFailureMessage, /cause=Comlink method call failed/)
+assert.match(emptyPhpExecutionFailureMessage, /No Playground response bytes, errors, or text were captured\./)
+assert.match(emptyPhpExecutionFailureMessage, /PHP fatal payload was absent from the wordpress\.run-php response/)
+assert.doesNotMatch(emptyPhpExecutionFailureMessage, /--- Playground response bytes ---/)
+
+const wpCodeboxFatalDiagnostic = 'WP_CODEBOX_PHP_FATAL_DIAGNOSTIC:{"schema":"wp-codebox/php-fatal-diagnostic/v1","message":"Uncaught RuntimeException: Local wp-admin auth fixture user could not be loaded.","file":"/wordpress/wp-content/plugins/auth-fixture/auth-fixture.php","line":17,"type":1}'
+const wpCodeboxFatalMessage = new PlaygroundCommandError("wordpress.run-php", {
+  exitCode: 255,
+  bytes: Object.fromEntries(Array.from(Buffer.from(wpCodeboxFatalDiagnostic, "utf8")).map((byte, index) => [String(index), byte])),
+  text: "",
+}).message
+
+assert.match(wpCodeboxFatalMessage, /PHP fatal: Uncaught RuntimeException: Local wp-admin auth fixture user could not be loaded\./)
+assert.match(wpCodeboxFatalMessage, /Location: \/wordpress\/wp-content\/plugins\/auth-fixture\/auth-fixture\.php:17/)
+assert.doesNotMatch(wpCodeboxFatalMessage, /WP_CODEBOX_PHP_FATAL_DIAGNOSTIC/)
+
 const htmlFatal = "<br />\n<b>Fatal error</b>:  Uncaught Error: Call to a member function is_sandbox() on null in <b>/wordpress/wp-content/plugins/woocommerce-square/includes/Gateway/Cash_App_Pay_Gateway.php</b>:283\nStack trace:\n#0 {main}\n  thrown in <b>/wordpress/wp-content/plugins/woocommerce-square/includes/Gateway/Cash_App_Pay_Gateway.php</b> on line <b>283</b><br />"
 const byteMap = Object.fromEntries(Array.from(Buffer.from(htmlFatal, "utf8")).map((byte, index) => [String(index), byte]))
 const byteMapMessage = new PlaygroundCommandError("wordpress.bench", {
@@ -156,5 +187,10 @@ await assert.rejects(
 
 assert.match(receivedRunPhpCode, /RuntimeException/)
 await runtime.destroy()
+
+const bootstrappedRunPhp = bootstrapPhpCode({ kind: "wordpress", name: "fatal-diagnostic", version: "7.0", blueprint: { steps: [] } }, "throw new RuntimeException('boom');", [])
+assert.match(bootstrappedRunPhp, /register_shutdown_function/)
+assert.match(bootstrappedRunPhp, /WP_CODEBOX_PHP_FATAL_DIAGNOSTIC/)
+assert.match(bootstrappedRunPhp, /wp-codebox\/php-fatal-diagnostic\/v1/)
 
 console.log("playground command errors smoke passed")

--- a/scripts/playground-command-errors-smoke.ts
+++ b/scripts/playground-command-errors-smoke.ts
@@ -32,7 +32,7 @@ assert.match(hiddenFatalMessage, /Local wp-admin auth fixture user could not be 
 assert.doesNotMatch(hiddenFatalMessage, /--- Playground stdout ---\n\s*---/)
 assert.doesNotMatch(hiddenFatalMessage, /--- Playground stderr ---\n\s*---/)
 
-const emptyWpcomFatal = new Error("PHP.run() failed with exit code 255") as Error & {
+const emptyStructuredFatal = new Error("PHP.run() failed with exit code 255") as Error & {
   httpStatusCode?: number
   exitCode?: number
   stdout?: string
@@ -40,11 +40,11 @@ const emptyWpcomFatal = new Error("PHP.run() failed with exit code 255") as Erro
   response?: { headers?: Record<string, string> }
 }
 
-emptyWpcomFatal.httpStatusCode = 500
-emptyWpcomFatal.exitCode = 255
-emptyWpcomFatal.stdout = ""
-emptyWpcomFatal.stderr = ""
-emptyWpcomFatal.response = {
+emptyStructuredFatal.httpStatusCode = 500
+emptyStructuredFatal.exitCode = 255
+emptyStructuredFatal.stdout = ""
+emptyStructuredFatal.stderr = ""
+emptyStructuredFatal.response = {
   headers: {
     "content-type": "text/html; charset=UTF-8",
     "x-powered-by": "PHP/8.4.21",
@@ -52,16 +52,16 @@ emptyWpcomFatal.response = {
   },
 }
 
-const emptyWpcomFatalMessage = new PlaygroundCommandCrashError("wordpress.run-php", emptyWpcomFatal).message
+const emptyStructuredFatalMessage = new PlaygroundCommandCrashError("wordpress.run-php", emptyStructuredFatal).message
 
-assert.match(emptyWpcomFatalMessage, /wordpress\.run-php crashed before producing a structured response/)
-assert.match(emptyWpcomFatalMessage, /PHP\.run\(\) failed with exit code 255/)
-assert.match(emptyWpcomFatalMessage, /httpStatusCode=500/)
-assert.match(emptyWpcomFatalMessage, /exitCode=255/)
-assert.match(emptyWpcomFatalMessage, /--- Playground response headers ---/)
-assert.match(emptyWpcomFatalMessage, /x-powered-by: PHP\/8\.4\.21/)
-assert.match(emptyWpcomFatalMessage, /No Playground stdout, stderr, or response body was captured\./)
-assert.doesNotMatch(emptyWpcomFatalMessage, /wordpress_test_cookie/)
+assert.match(emptyStructuredFatalMessage, /wordpress\.run-php crashed before producing a structured response/)
+assert.match(emptyStructuredFatalMessage, /PHP\.run\(\) failed with exit code 255/)
+assert.match(emptyStructuredFatalMessage, /httpStatusCode=500/)
+assert.match(emptyStructuredFatalMessage, /exitCode=255/)
+assert.match(emptyStructuredFatalMessage, /--- Playground response headers ---/)
+assert.match(emptyStructuredFatalMessage, /x-powered-by: PHP\/8\.4\.21/)
+assert.match(emptyStructuredFatalMessage, /No Playground stdout, stderr, or response body was captured\./)
+assert.doesNotMatch(emptyStructuredFatalMessage, /wordpress_test_cookie/)
 
 const nestedResponseError = new Error("Playground request failed") as Error & {
   response?: { status?: number; text?: string }


### PR DESCRIPTION
## Summary
- Register a shutdown fatal diagnostic before `wordpress.run-php` / ability bootstrap so PHP fatals can emit a `WP_CODEBOX_PHP_FATAL_DIAGNOSTIC` marker when the runtime returns bytes.
- Decode direct `response.bytes` payloads and the new fatal marker into concise `PHP fatal:` messages.
- For the reported `PHPExecutionFailureError` shape where the runtime returns `httpStatusCode: 500`, `exitCode: 255`, `bytes: {}`, `errors: ""`, and no text, report the metadata and explicitly state that the fatal payload was absent from the response.

Closes #1028.

## Tests / evidence
- `runner-exec-homeboy-lab-55a15e54-ca3d-4cdc-adda-bc9cea42b169`: `npm run smoke -- --command=playground-command-errors-smoke` passed on `homeboy-lab` after the generic naming cleanup.
- `runner-exec-homeboy-lab-710a279c-4a08-465d-ac91-1b5670211bd0`: `npm run build` passed on `homeboy-lab`.
- `runner-exec-homeboy-lab-b0461b98-e390-4542-b848-42ee674fdc34`: Homeboy generic `test` harness reached the lab and built successfully, then failed because it invoked `node --test --command=playground-command-errors-smoke`; the repo smoke command above is the relevant targeted verification.

## What surfaces now
- If the PHP process returns bytes, the error message can surface the fatal as `PHP fatal: <message>` plus `Location: <file>:<line>` from the shutdown marker or existing Playground fatal output.
- If the response payload is genuinely absent, the error message now includes `originalErrorClassName=PHPExecutionFailureError`, `httpStatusCode=500`, `exitCode=255`, `cause=Comlink method call failed`, and `No Playground response bytes, errors, or text were captured.`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the diagnostic implementation and focused smoke coverage; Chris remains responsible for review and validation.