### PR TITLE
Add source checkout CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1276,7 +1276,7 @@ Callers can gate success on post-agent verification through `verify_steps`: an a
 
 Each component contract declares `slug`, `path` or `source`, optional `activate`, optional `loadAs`, and optional `readiness_probe` metadata.
 
-The CLI binary can come from ability input, the `wp_codebox_bin` option, or the `wp_codebox_bin` filter.
+The CLI binary can come from ability input, the `wp_codebox_bin` option, or the `wp_codebox_bin` filter. Source-checkout snapshots that do not include generated `dist/` files should point at `bin/wp-codebox-source.mjs`; it builds WP Codebox when needed before delegating to the compiled CLI.
 
 Caller-owned runtime components can provide workspace, file, GitHub, or other tools to the sandboxed agent. WP Codebox owns the parent-site ability surface, sandbox lifecycle, and artifact capture boundary.
 

--- a/bin/wp-codebox-source.mjs
+++ b/bin/wp-codebox-source.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const repoRoot = dirname(scriptDirectory)
+const distEntrypoint = join(repoRoot, "packages/cli/dist/index.js")
+const nodeModules = join(repoRoot, "node_modules")
+const packageLock = join(repoRoot, "package-lock.json")
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: options.delegate ? "inherit" : ["inherit", "pipe", "pipe"],
+    encoding: options.delegate ? undefined : "utf8",
+    env: process.env,
+    shell: process.platform === "win32",
+  })
+
+  if (!options.delegate) {
+    if (result.stdout) {
+      process.stderr.write(result.stdout)
+    }
+    if (result.stderr) {
+      process.stderr.write(result.stderr)
+    }
+  }
+
+  if (result.error) {
+    console.error(`WP Codebox source entrypoint failed to run ${command}: ${result.error.message}`)
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+if (!existsSync(distEntrypoint)) {
+  console.error("WP Codebox CLI dist entrypoint is absent; bootstrapping the source checkout before running the CLI.")
+
+  if (!existsSync(nodeModules)) {
+    run("npm", [existsSync(packageLock) ? "ci" : "install"])
+  }
+
+  run("npm", ["run", "build"])
+}
+
+run(process.execPath, [distEntrypoint, ...process.argv.slice(2)], { delegate: true })

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
+    "wp-codebox:source": "node bin/wp-codebox-source.mjs",
     "smoke": "tsx scripts/run-smoke.ts",
     "check": "npm run smoke -- --group=check"
   },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,6 +18,22 @@ Release tarball installs expose the `wp-codebox` binary from the compiled
 `packages/cli/dist/` entrypoint. Build from source with `npm run build` before
 running local package validation.
 
+## Source Checkouts
+
+Lab and CI snapshots may carry WP Codebox source without generated `dist/`
+files. For those source checkouts, point orchestration at the committed source
+entrypoint instead of an ignored build artifact:
+
+```bash
+node /path/to/wp-codebox/bin/wp-codebox-source.mjs commands --json
+```
+
+The source entrypoint runs the compiled CLI when `packages/cli/dist/index.js`
+exists. When `dist/` is absent, it installs dependencies if needed, runs
+`npm run build`, then delegates to the compiled CLI. Parent WordPress runners
+also fail early with a diagnostic if `wp_codebox_bin` points at a missing `.js`
+or `.mjs` file.
+
 ## Smoke
 
 ```bash

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -217,7 +217,10 @@ Each contract declares the component instead of relying on product-specific keys
 
 The CLI binary can be supplied by ability input, the `wp_codebox_bin` option,
 or the `wp_codebox_bin` filter. On multisite, WP Codebox reads `wp_codebox_bin`
-from network options because the binary path is host-level configuration.
+from network options because the binary path is host-level configuration. Source
+checkouts without generated `dist/` files should point at
+`bin/wp-codebox-source.mjs`; it builds WP Codebox when needed before delegating
+to the compiled CLI.
 
 The artifact root can be supplied per request with `artifacts_path`, by the
 `wp_codebox_artifacts_root` option, or by the `wp_codebox_artifacts_root`

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1921,13 +1921,29 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	private function command_prefix( string $bin ): string|WP_Error {
-		if ( str_ends_with( $bin, '.js' ) && is_file( $bin ) ) {
+		$is_node_script = 1 === preg_match( '/\.m?js$/', $bin );
+		$is_path_like   = str_contains( $bin, '/' ) || str_contains( $bin, '\\' ) || str_starts_with( $bin, '.' );
+
+		if ( $is_node_script && is_file( $bin ) ) {
 			$node = $this->node_binary();
 			if ( is_wp_error( $node ) ) {
 				return $node;
 			}
 
 			return escapeshellarg( $node ) . ' ' . escapeshellarg( $bin );
+		}
+
+		if ( $is_node_script && $is_path_like ) {
+			return new WP_Error(
+				'wp_codebox_bin_missing',
+				'Configured wp_codebox_bin points at a missing JavaScript file. Build WP Codebox first, point wp_codebox_bin at bin/wp-codebox-source.mjs for source checkouts, or use an installed wp-codebox binary.',
+				array(
+					'status'          => 500,
+					'path'            => $bin,
+					'source_command'  => 'node bin/wp-codebox-source.mjs',
+					'build_command'   => 'npm ci && npm run build',
+				)
+			);
 		}
 
 		if ( $this->is_bundled_cli_wrapper( $bin ) ) {

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -37,6 +37,7 @@ export const smokeGroups = {
       tsxSmoke("task-input-contract-smoke"),
       tsxSmoke("discovery-command-smoke"),
       tsxSmoke("doctor-command-smoke"),
+      tsxSmoke("source-checkout-entrypoint-smoke"),
       tsxSmoke("cli-unsettled-command-smoke"),
       tsxSmoke("agent-runtime-failure-smoke"),
       tsxSmoke("recipe-run-terminal-phase-failure-smoke"),

--- a/scripts/source-checkout-entrypoint-smoke.ts
+++ b/scripts/source-checkout-entrypoint-smoke.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const root = new URL("..", import.meta.url).pathname
+const fixture = await mkdtemp(join(tmpdir(), "wp-codebox-source-entrypoint-"))
+
+try {
+  await mkdir(join(fixture, "bin"), { recursive: true })
+  await mkdir(join(fixture, "node_modules"), { recursive: true })
+  await mkdir(join(fixture, "scripts"), { recursive: true })
+  await copyFile(join(root, "bin/wp-codebox-source.mjs"), join(fixture, "bin/wp-codebox-source.mjs"))
+
+  await writeFile(
+    join(fixture, "package.json"),
+    JSON.stringify({
+      type: "module",
+      scripts: {
+        build: "node scripts/build-fixture.mjs",
+      },
+    }),
+  )
+
+  await writeFile(
+    join(fixture, "scripts/build-fixture.mjs"),
+    `import { mkdir, writeFile } from "node:fs/promises"\n` +
+      `await mkdir("packages/cli/dist", { recursive: true })\n` +
+      `await writeFile("build-ran.txt", "yes")\n` +
+      `await writeFile("packages/cli/dist/index.js", "console.log(JSON.stringify({ built: true, args: process.argv.slice(2) }))\\n")\n`,
+  )
+
+  const { stdout, stderr } = await execFileAsync(process.execPath, ["bin/wp-codebox-source.mjs", "commands", "--json"], { cwd: fixture })
+  const output = JSON.parse(stdout)
+
+  assert.match(stderr, /dist entrypoint is absent/)
+  assert.match(stderr, /> build/)
+  assert.equal(output.built, true)
+  assert.deepEqual(output.args, ["commands", "--json"])
+
+  console.log("Source checkout entrypoint smoke passed")
+} finally {
+  await rm(fixture, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- add a committed `bin/wp-codebox-source.mjs` entrypoint for source checkouts that bootstraps missing `dist/` output before delegating to the CLI
- keep bootstrap/build output on stderr so delegated `--json` stdout stays parseable
- fail early when parent-site `wp_codebox_bin` points at a missing JS path, with generic source/build remediation guidance
- document the source-checkout binary path for CLI and parent-site callers

Closes #1032.

## Testing
- `npx tsx scripts/source-checkout-entrypoint-smoke.ts`
- `npm run build`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php`
- `npm run smoke -- --group core`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the source-checkout entrypoint, focused smoke coverage, docs, and preflight diagnostic; Chris to review and validate before merge.
