### PR TITLE
Fix artifact collection for cyclic browser errors

### DIFF
--- a/packages/runtime-core/src/object-utils.ts
+++ b/packages/runtime-core/src/object-utils.ts
@@ -5,18 +5,91 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 }
 
 export function stableJson(value: unknown): string {
+  return stableJsonValue(value, new WeakSet(), 0)
+}
+
+function stableJsonValue(value: unknown, seen: WeakSet<object>, depth: number): string {
+  if (depth > 30) {
+    return JSON.stringify("[max-depth]")
+  }
+  if (value instanceof Error) {
+    return stableJsonValue(errorJsonRecord(value), seen, depth + 1)
+  }
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value)
   }
+  if (seen.has(value)) {
+    return JSON.stringify("[circular]")
+  }
+  seen.add(value)
 
   if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJson(item)).join(",")}]`
+    const json = `[${value.slice(0, 2000).map((item) => stableJsonValue(item, seen, depth + 1)).join(",")}]`
+    seen.delete(value)
+    return json
   }
 
-  return `{${Object.keys(value as Record<string, unknown>)
+  const json = `{${Object.keys(value as Record<string, unknown>)
     .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+    .slice(0, 300)
+    .map((key) => {
+      const item = (value as Record<string, unknown>)[key]
+      return typeof item === "function" || typeof item === "symbol" ? undefined : `${JSON.stringify(key)}:${stableJsonValue(item, seen, depth + 1)}`
+    })
+    .filter((item): item is string => Boolean(item))
     .join(",")}}`
+  seen.delete(value)
+  return json
+}
+
+export function normalizeJsonValue(value: unknown, seen = new WeakSet<object>(), depth = 0): unknown {
+  if (depth > 30) {
+    return "[max-depth]"
+  }
+  if (value instanceof Error) {
+    return normalizeJsonValue(errorJsonRecord(value), seen, depth + 1)
+  }
+  if (!value || typeof value !== "object") {
+    return value
+  }
+  if (seen.has(value)) {
+    return "[circular]"
+  }
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    const normalized = value.slice(0, 2000).map((item) => normalizeJsonValue(item, seen, depth + 1))
+    seen.delete(value)
+    return normalized
+  }
+
+  const output: Record<string, unknown> = {}
+  for (const [key, item] of Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).slice(0, 300)) {
+    if (typeof item !== "function" && typeof item !== "symbol") {
+      output[key] = normalizeJsonValue(item, seen, depth + 1)
+    }
+  }
+  seen.delete(value)
+  return output
+}
+
+function errorJsonRecord(error: Error): Record<string, unknown> {
+  const record = error as Error & Record<string, unknown>
+  const output: Record<string, unknown> = {
+    name: error.name,
+    message: error.message,
+  }
+
+  for (const [key, item] of Object.entries(record)) {
+    if (key !== "name" && key !== "message" && key !== "stack" && typeof item !== "function" && typeof item !== "symbol") {
+      output[key] = item
+    }
+  }
+  if (record.cause && !("cause" in output)) {
+    output.cause = record.cause
+  }
+
+  return output
 }
 
 export function sha256StableJson(value: unknown, trailingNewline = false): string {

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -31,7 +31,7 @@ import {
   type RuntimeInfo,
   type Snapshot,
 } from "@automattic/wp-codebox-core"
-import { stripUndefined } from "@automattic/wp-codebox-core/internals"
+import { normalizeJsonValue, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import type { BrowserArtifact } from "./browser-artifacts.js"
 import {
   ArtifactRedactor,
@@ -337,37 +337,37 @@ export class ArtifactBundleBuilder {
     }
     metadata.previewSessionEvidence = previewSessionEvidenceRef
 
-    await writeRedactedArtifact(redactor, blueprintAfterPath, source.artifactRoot, `${JSON.stringify(blueprintAfter, null, 2)}\n`)
-    await writeRedactedArtifact(redactor, blueprintAfterNotesPath, source.artifactRoot, `${JSON.stringify(blueprintAfterNotes, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, blueprintAfterPath, source.artifactRoot, artifactJson(blueprintAfter))
+    await writeRedactedArtifact(redactor, blueprintAfterNotesPath, source.artifactRoot, artifactJson(blueprintAfterNotes))
     if (replaySnapshot) {
-      await writeRedactedArtifact(redactor, partialBlueprintAfterPath, source.artifactRoot, `${JSON.stringify(partialBlueprintAfter, null, 2)}\n`)
+      await writeRedactedArtifact(redactor, partialBlueprintAfterPath, source.artifactRoot, artifactJson(partialBlueprintAfter))
     }
     await writeJsonLines(eventsPath, source.events, redactor, source.artifactRoot)
     await writeJsonLines(commandsPath, source.commands, redactor, source.artifactRoot)
     await writeJsonLines(observationsPath, source.observations, redactor, source.artifactRoot)
     await writeRedactedArtifact(redactor, runtimeLogPath, source.artifactRoot, source.formatRuntimeLog())
     await writeRedactedArtifact(redactor, commandsLogPath, source.artifactRoot, source.formatCommandsLog())
-    await writeRedactedArtifact(redactor, mountsPath, source.artifactRoot, `${JSON.stringify(source.mounts, null, 2)}\n`)
-    await writeRedactedArtifact(redactor, capturedMountsPath, source.artifactRoot, `${JSON.stringify(serializeCapturedMountFiles(capturedMounts), null, 2)}\n`)
-    await writeRedactedArtifact(redactor, diffsPath, source.artifactRoot, `${JSON.stringify(mountDiffs, null, 2)}\n`)
-    await writeRedactedArtifact(redactor, workspacePatchPath, source.artifactRoot, `${JSON.stringify(workspacePatch, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, mountsPath, source.artifactRoot, artifactJson(source.mounts))
+    await writeRedactedArtifact(redactor, capturedMountsPath, source.artifactRoot, artifactJson(serializeCapturedMountFiles(capturedMounts)))
+    await writeRedactedArtifact(redactor, diffsPath, source.artifactRoot, artifactJson(mountDiffs))
+    await writeRedactedArtifact(redactor, workspacePatchPath, source.artifactRoot, artifactJson(workspacePatch))
     await writeFile(changedFilesPath, changedFilesJson)
     await writeFile(patchPath, redactedPatch)
-    await writeRedactedArtifact(redactor, diagnosticsPath, source.artifactRoot, `${JSON.stringify(diagnostics, null, 2)}\n`)
-    await writeRedactedArtifact(redactor, testResultsPath, source.artifactRoot, `${JSON.stringify(testResults, null, 2)}\n`)
-    await writeRedactedArtifact(redactor, previewEvidencePath, source.artifactRoot, `${JSON.stringify(previewEvidence, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, diagnosticsPath, source.artifactRoot, artifactJson(diagnostics))
+    await writeRedactedArtifact(redactor, testResultsPath, source.artifactRoot, artifactJson(testResults))
+    await writeRedactedArtifact(redactor, previewEvidencePath, source.artifactRoot, artifactJson(previewEvidence))
     await writeFile(previewSessionEvidencePath, previewSessionEvidenceJson)
     const redaction = redactor.summary()
     if (redaction.total > 0) {
       review.redaction = redaction
       review.riskFlags.push("secrets-redacted")
     }
-    await writeRedactedArtifact(redactor, reviewPath, source.artifactRoot, `${JSON.stringify(review, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, reviewPath, source.artifactRoot, artifactJson(review))
     await writeFile(runtimeReferenceManifestPath, "{}\n")
     await writeFile(runtimeReferenceIndexPath, "{}\n")
     await writeFile(runtimeReplayReferenceIndexPath, "{}\n")
     metadata.redaction = redactor.summary()
-    await writeRedactedArtifact(redactor, metadataPath, source.artifactRoot, `${JSON.stringify(metadata, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, metadataPath, source.artifactRoot, artifactJson(metadata))
 
     const manifest: ArtifactManifest = {
       id: bundleId,
@@ -391,7 +391,7 @@ export class ArtifactBundleBuilder {
       capturedMounts,
       browserProbes: source.browserArtifacts(),
     })
-    await writeFile(runtimeReferenceIndexPath, `${JSON.stringify(runtimeReferenceIndex, null, 2)}\n`)
+    await writeFile(runtimeReferenceIndexPath, artifactJson(runtimeReferenceIndex))
     await refreshArtifactManifestFileSha256s(source.artifactRoot, manifest)
     const runtimeReferenceManifest = buildRuntimeReferenceManifest({
       createdAt,
@@ -406,7 +406,7 @@ export class ArtifactBundleBuilder {
         .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256, ...(file.viewer ? { viewer: cloneArtifactViewerMetadata(file.viewer) } : {}) })),
       snapshots: runtimeSnapshots,
     })
-    await writeFile(runtimeReferenceManifestPath, `${JSON.stringify(runtimeReferenceManifest, null, 2)}\n`)
+    await writeFile(runtimeReferenceManifestPath, artifactJson(runtimeReferenceManifest))
     const runtimeReferenceManifestRef = artifactManifestFileWithSha256(
       "files/runtime-reference-manifest.json",
       "runtime-reference-manifest",
@@ -427,9 +427,9 @@ export class ArtifactBundleBuilder {
       runtimeReferenceManifest: runtimeReferenceManifestRef,
       snapshots: runtimeSnapshots,
     })
-    await writeFile(runtimeReplayReferenceIndexPath, `${JSON.stringify(runtimeReplayReferenceIndex, null, 2)}\n`)
+    await writeFile(runtimeReplayReferenceIndexPath, artifactJson(runtimeReplayReferenceIndex))
     await refreshArtifactManifestFileSha256s(source.artifactRoot, manifest)
-    await writeRedactedArtifact(redactor, manifestPath, source.artifactRoot, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeRedactedArtifact(redactor, manifestPath, source.artifactRoot, artifactJson(manifest))
 
     return {
       id: bundleId,
@@ -718,7 +718,15 @@ function isLocalPreviewHost(hostname: string): boolean {
 }
 
 async function writeJsonLines(path: string, records: unknown[], redactor: ArtifactRedactor, artifactRoot: string): Promise<void> {
-  await writeRedactedArtifact(redactor, path, artifactRoot, records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : "")
+  await writeRedactedArtifact(redactor, path, artifactRoot, records.length > 0 ? `${records.map((record) => artifactJsonLine(record)).join("\n")}\n` : "")
+}
+
+function artifactJson(value: unknown): string {
+  return `${JSON.stringify(normalizeJsonValue(value), null, 2)}\n`
+}
+
+function artifactJsonLine(value: unknown): string {
+  return JSON.stringify(normalizeJsonValue(value))
 }
 
 function buildPreviewSessionEvidence({

--- a/packages/runtime-playground/src/runtime-artifact-helpers.ts
+++ b/packages/runtime-playground/src/runtime-artifact-helpers.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { artifactManifestFile } from "@automattic/wp-codebox-core"
+import { normalizeJsonValue } from "@automattic/wp-codebox-core/internals"
 import type {
   ArtifactBundle,
   ArtifactManifestFile,
@@ -86,7 +87,7 @@ export async function collectPlaygroundArtifacts({
 }
 
 export function formatRuntimeLog(events: LifecycleEvent[]): string {
-  return events.map((event) => `[${event.timestamp}] ${event.type} ${JSON.stringify(event.data ?? {})}`).join("\n") + "\n"
+  return events.map((event) => `[${event.timestamp}] ${event.type} ${JSON.stringify(normalizeJsonValue(event.data ?? {}))}`).join("\n") + "\n"
 }
 
 export function formatCommandsLog(commands: ExecutionResult[]): string {

--- a/scripts/artifact-browser-error-collection-smoke.ts
+++ b/scripts/artifact-browser-error-collection-smoke.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.ts"
+import { BrowserCommandArtifactError } from "../packages/runtime-playground/src/browser-command-runners.ts"
+import { collectPlaygroundArtifacts } from "../packages/runtime-playground/src/runtime-artifact-helpers.ts"
+
+const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-browser-error-artifacts-"))
+
+try {
+  const artifactRoot = join(workspace, "artifacts")
+  await mkdir(join(artifactRoot, "files/browser"), { recursive: true })
+  await writeFile(join(artifactRoot, "files/browser/summary.json"), "{\"status\":\"failed\"}\n")
+
+  const browserArtifact = browserArtifactFixture()
+  const error = new BrowserCommandArtifactError("painted-readiness-stabilization exceeded 1000ms", browserArtifact)
+  ;(browserArtifact as BrowserArtifact & { self?: unknown }).self = browserArtifact
+  ;(browserArtifact as BrowserArtifact & { advisoryFailure?: unknown }).advisoryFailure = error
+
+  const bundle = await collectPlaygroundArtifacts({
+    artifactRoot,
+    browserProbes: [browserArtifact],
+    commands: [],
+    createdAt: "2026-06-16T00:00:00.000Z",
+    events: [
+      {
+        id: "event-browser-advisory-failed",
+        type: "runtime.browser-command-progress",
+        timestamp: "2026-06-16T00:00:01.000Z",
+        data: {
+          specCommand: "wordpress.browser-actions",
+          error,
+        },
+      },
+    ],
+    info: async () => ({
+      id: "runtime-browser-error-fixture",
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", version: "latest" },
+      createdAt: "2026-06-16T00:00:00.000Z",
+      status: "destroyed",
+    }),
+    mounts: [],
+    observations: [],
+    pluginChecks: [],
+    previewInfo: async () => undefined,
+    recordArtifactsCollected: () => undefined,
+    runtimeId: "runtime-browser-error-fixture",
+    snapshots: [],
+    spec: {
+      backend: "wordpress-playground",
+      environment: { kind: "wordpress", version: "latest" },
+      policy: { network: "deny", filesystem: "readwrite-mounts", commands: [], secrets: "none", approvals: "never" },
+    },
+    themeChecks: [],
+  })
+
+  const runtimeLog = await readFile(bundle.runtimeLogPath, "utf8")
+  assert.match(runtimeLog, /BrowserCommandArtifactError/)
+  assert.match(runtimeLog, /painted-readiness-stabilization exceeded 1000ms/)
+  assert.match(runtimeLog, /"artifactType":"actions"/)
+  assert.match(runtimeLog, /"self":"\[circular\]"/)
+
+  const commandsLog = await readFile(bundle.commandsLogPath, "utf8")
+  assert.equal(commandsLog, "\n")
+
+  const manifest = JSON.parse(await readFile(bundle.manifestPath, "utf8"))
+  assert.equal(manifest.files.some((file: { path?: string }) => file.path === "files/browser/summary.json"), true)
+
+  console.log("Artifact browser error collection smoke passed")
+} finally {
+  await rm(workspace, { recursive: true, force: true })
+}
+
+function browserArtifactFixture(): BrowserArtifact {
+  return {
+    artifactType: "actions",
+    requestedUrl: "http://127.0.0.1:9400/",
+    url: "http://127.0.0.1:9400/",
+    preview: {
+      requestedMode: "local",
+      mode: "local",
+      requestedOrigin: "http://127.0.0.1:9400",
+      localOrigin: "http://127.0.0.1:9400",
+      effectiveOrigin: "http://127.0.0.1:9400",
+      secureContext: false,
+      capabilities: [],
+      fallbacks: [],
+    },
+    files: {
+      summary: "files/browser/summary.json",
+    },
+    summary: {
+      actions: 1,
+      steps: 1,
+      consoleMessages: 0,
+      errors: 1,
+      networkEvents: 0,
+      screenshot: false,
+      finalUrl: "http://127.0.0.1:9400/",
+      windowLocationOrigin: "http://127.0.0.1:9400",
+      viewport: null,
+      capabilities: [],
+      replayability: { status: "not-replayable", reasons: ["advisory failure fixture"] },
+    },
+  }
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -61,6 +61,7 @@ export const smokeGroups = {
       tsxSmoke("artifact-reference-normalization-smoke"),
       tsxSmoke("artifact-diagnostics-normalizer-smoke"),
       tsxSmoke("typed-artifacts-smoke"),
+      tsxSmoke("artifact-browser-error-collection-smoke"),
       tsxSmoke("partial-artifact-discovery-smoke"),
       tsxSmoke("mounted-workspace-diff-smoke"),
       tsxSmoke("replay-export-blueprint-smoke"),


### PR DESCRIPTION
## Summary
- Fix bounded serialization for artifact collection paths that can receive Error objects with attached browser artifacts.
- Preserve BrowserCommandArtifactError diagnostics, including the attached artifact summary, while bounding cycles/depth.
- Add a focused smoke that collects artifacts with a cyclic advisory browser error payload.

Closes #1037.

## Testing
- npm run build
- npx tsx scripts/artifact-browser-error-collection-smoke.ts
- npm run smoke -- --group=artifact
- npm run smoke -- --group=core

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the bounded artifact serialization fix, adding the regression smoke, and running local verification. Chris remains responsible for review and merge.