### PR TITLE
Preserve caller cwd in source CLI entrypoint

### DIFF
--- a/bin/wp-codebox-source.mjs
+++ b/bin/wp-codebox-source.mjs
@@ -9,10 +9,11 @@ const repoRoot = dirname(scriptDirectory)
 const distEntrypoint = join(repoRoot, "packages/cli/dist/index.js")
 const nodeModules = join(repoRoot, "node_modules")
 const packageLock = join(repoRoot, "package-lock.json")
+const callerCwd = process.cwd()
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
-    cwd: repoRoot,
+    cwd: options.cwd ?? repoRoot,
     stdio: options.delegate ? "inherit" : ["inherit", "pipe", "pipe"],
     encoding: options.delegate ? undefined : "utf8",
     env: process.env,
@@ -48,4 +49,4 @@ if (!existsSync(distEntrypoint)) {
   run("npm", ["run", "build"])
 }
 
-run(process.execPath, [distEntrypoint, ...process.argv.slice(2)], { delegate: true })
+run(process.execPath, [distEntrypoint, ...process.argv.slice(2)], { cwd: callerCwd, delegate: true })

--- a/scripts/source-checkout-entrypoint-smoke.ts
+++ b/scripts/source-checkout-entrypoint-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
-import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { copyFile, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { promisify } from "node:util"
@@ -8,6 +8,7 @@ import { promisify } from "node:util"
 const execFileAsync = promisify(execFile)
 const root = new URL("..", import.meta.url).pathname
 const fixture = await mkdtemp(join(tmpdir(), "wp-codebox-source-entrypoint-"))
+const consumerWorkspace = await mkdtemp(join(tmpdir(), "wp-codebox-source-entrypoint-consumer-"))
 
 try {
   await mkdir(join(fixture, "bin"), { recursive: true })
@@ -30,18 +31,20 @@ try {
     `import { mkdir, writeFile } from "node:fs/promises"\n` +
       `await mkdir("packages/cli/dist", { recursive: true })\n` +
       `await writeFile("build-ran.txt", "yes")\n` +
-      `await writeFile("packages/cli/dist/index.js", "console.log(JSON.stringify({ built: true, args: process.argv.slice(2) }))\\n")\n`,
+      `await writeFile("packages/cli/dist/index.js", "console.log(JSON.stringify({ built: true, args: process.argv.slice(2), cwd: process.cwd() }))\\n")\n`,
   )
 
-  const { stdout, stderr } = await execFileAsync(process.execPath, ["bin/wp-codebox-source.mjs", "commands", "--json"], { cwd: fixture })
+  const { stdout, stderr } = await execFileAsync(process.execPath, [join(fixture, "bin/wp-codebox-source.mjs"), "commands", "--json"], { cwd: consumerWorkspace })
   const output = JSON.parse(stdout)
 
   assert.match(stderr, /dist entrypoint is absent/)
   assert.match(stderr, /> build/)
   assert.equal(output.built, true)
   assert.deepEqual(output.args, ["commands", "--json"])
+  assert.equal(await realpath(output.cwd), await realpath(consumerWorkspace))
 
   console.log("Source checkout entrypoint smoke passed")
 } finally {
   await rm(fixture, { recursive: true, force: true })
+  await rm(consumerWorkspace, { recursive: true, force: true })
 }


### PR DESCRIPTION
## Summary
- Preserve the caller cwd before source-checkout bootstrap work starts.
- Keep npm install/build bootstrap commands running from the WP Codebox source root.
- Delegate the compiled CLI from the original caller cwd so consumer-relative paths resolve in the consumer workspace.

Fixes #1039.

## Testing
- npm run build
- npm run smoke -- --command=source-checkout-entrypoint-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the source entrypoint cwd fix, extended focused smoke coverage, and ran local verification for Chris to review.