### PR TITLE
Fix routed preview host handling

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -498,7 +498,7 @@ async function runSingleBrowserProbeCommand({
       await context.grantPermissions(requestedContext.permissions)
     }
     if (context && browserPreviewNeedsContextRouting(networkPolicy)) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin, routeTracker)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin, routeTracker)
     }
     page = context ? await context.newPage() : await browser.newPage()
     if (onProgress) {
@@ -521,7 +521,7 @@ async function runSingleBrowserProbeCommand({
       await applyBrowserProbeThrottleProfile(page, throttleProfile)
     }
     if (!context && browserPreviewNeedsContextRouting(networkPolicy)) {
-      await routeBrowserPreviewPageNetwork(page, networkPolicy, preview.localOrigin, routeTracker)
+      await routeBrowserPreviewPageNetwork(page, networkPolicy, preview.effectiveOrigin, routeTracker)
     }
     await page.addInitScript(BROWSER_PROBE_STATE_INIT_SCRIPT)
     if (lifecycleSelectors.length > 0) {
@@ -2310,7 +2310,7 @@ export async function runBrowserActionsCommand({
   try {
     const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
     if (context) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
     if (onProgress) {
@@ -3025,7 +3025,7 @@ export async function runEditorOpenCommand({
   try {
     const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
     if (context) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
     authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-open", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
@@ -3234,7 +3234,7 @@ export async function runEditorActionsCommand({
   try {
     const context = browserPreviewNeedsContextRouting(networkPolicy) ? await browser.newContext() : null
     if (context) {
-      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.localOrigin)
+      await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
     authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-actions", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })

--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -148,12 +148,12 @@ export function browserPreviewNetworkPolicySummary(policy: BrowserPreviewNetwork
   }
 }
 
-export async function routeBrowserPreviewPageNetwork(page: Page, policy: BrowserPreviewNetworkPolicy, localPreviewOrigin: string, tracker?: BrowserPreviewRouteTracker): Promise<void> {
-  await routeBrowserPreviewNetwork(page.route.bind(page), policy, localPreviewOrigin, tracker)
+export async function routeBrowserPreviewPageNetwork(page: Page, policy: BrowserPreviewNetworkPolicy, previewOrigin: string, tracker?: BrowserPreviewRouteTracker): Promise<void> {
+  await routeBrowserPreviewNetwork(page.route.bind(page), policy, previewOrigin, tracker)
 }
 
-export async function routeBrowserPreviewContextNetwork(context: import("playwright").BrowserContext, policy: BrowserPreviewNetworkPolicy, localPreviewOrigin: string, tracker?: BrowserPreviewRouteTracker): Promise<void> {
-  await routeBrowserPreviewNetwork(context.route.bind(context), policy, localPreviewOrigin, tracker)
+export async function routeBrowserPreviewContextNetwork(context: import("playwright").BrowserContext, policy: BrowserPreviewNetworkPolicy, previewOrigin: string, tracker?: BrowserPreviewRouteTracker): Promise<void> {
+  await routeBrowserPreviewNetwork(context.route.bind(context), policy, previewOrigin, tracker)
 }
 
 export async function drainBrowserPreviewRouteTracker(tracker: BrowserPreviewRouteTracker, timeoutMs = BROWSER_PREVIEW_ROUTE_DRAIN_TIMEOUT_MS): Promise<void> {
@@ -188,12 +188,12 @@ function browserPreviewMode(args: string[], publicOrigin: string | undefined): B
   throw new Error(`wordpress.browser-probe preview-mode supports local, public, secure: ${raw}`)
 }
 
-async function routeBrowserPreviewNetwork(routePattern: (url: string, handler: (route: Route) => Promise<void>) => Promise<unknown>, policy: BrowserPreviewNetworkPolicy, localPreviewOrigin: string, tracker?: BrowserPreviewRouteTracker): Promise<void> {
+async function routeBrowserPreviewNetwork(routePattern: (url: string, handler: (route: Route) => Promise<void>) => Promise<unknown>, policy: BrowserPreviewNetworkPolicy, previewOrigin: string, tracker?: BrowserPreviewRouteTracker): Promise<void> {
   if (!browserPreviewNeedsContextRouting(policy)) {
     return
   }
 
-  const localOrigin = new URL(localPreviewOrigin)
+  const origin = new URL(previewOrigin)
   await routePattern("**/*", async (route) => {
     const request = route.request()
     let requestUrl: URL
@@ -221,7 +221,7 @@ async function routeBrowserPreviewNetwork(routePattern: (url: string, handler: (
     }
 
     stat.routed += 1
-    const task = fulfillBrowserPreviewRoutedHost(route, requestUrl, policy.routeHosts, localOrigin)
+    const task = fulfillBrowserPreviewRoutedHost(route, requestUrl, policy.routeHosts, origin)
     tracker?.pending.add(task)
     try {
       await task
@@ -276,13 +276,13 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, routedHosts: Set<string>, localOrigin: URL): Promise<Awaited<ReturnType<Route["fetch"]>> | undefined> {
+async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, routedHosts: Set<string>, origin: URL): Promise<Awaited<ReturnType<Route["fetch"]>> | undefined> {
   let currentUrl = requestUrl
   for (let redirectCount = 0; redirectCount < 10; redirectCount++) {
     const routedUrl = new URL(currentUrl.toString())
-    routedUrl.protocol = localOrigin.protocol
-    routedUrl.hostname = localOrigin.hostname
-    routedUrl.port = localOrigin.port
+    routedUrl.protocol = origin.protocol
+    routedUrl.hostname = origin.hostname
+    routedUrl.port = origin.port
 
     let response: Awaited<ReturnType<Route["fetch"]>>
     try {
@@ -317,6 +317,11 @@ async function fetchBrowserPreviewRoutedHost(route: Route, requestUrl: URL, rout
     }
 
     currentUrl = redirectedUrl
+  }
+
+  if (route.request().resourceType() !== "document") {
+    await route.abort("failed").catch(() => undefined)
+    return undefined
   }
 
   throw new Error(`wordpress.browser-probe route-host exceeded redirect limit for ${requestUrl.href}`)


### PR DESCRIPTION
## Summary
- Route preview host requests through the effective preview origin instead of always using the local origin.
- Keep route-host redirect-limit failures fatal for document navigations.
- Abort looping non-document routed subresources instead of failing the entire browser command.

## Evidence
- Local build: `npm run build`
- Lab WP Codebox rebuild: `runner-exec-homeboy-lab-76b4a685-a6cf-49ca-ad62-f85f558ef30c`
- WPCOM proof after fix: `runner-exec-homeboy-lab-7fcf9956-e016-472a-bbcd-eba6d8f79e69`
- Proof artifact: `artifacts/issue250-routehost-subresource-abort-proof`
- Result: public `/ai` browser probe reached `https://wordpress.com/ai/` instead of the previous typo/private-site redirect path; remaining blocker moved to editor browser actions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the WPCOM proof failure, drafted the route-host runtime patch, and ran focused build/lab verification for Chris to review.