### PR TITLE
Align task input agent bundle contract

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -1,17 +1,9 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
-import { sandboxAllowedRuntimeToolIds, type SandboxToolPolicySnapshot, type SandboxWorkspaceContract, type StructuredArtifactPayload } from "@automattic/wp-codebox-core"
+import { normalizeAgentBundles, sandboxAllowedRuntimeToolIds, type SandboxToolPolicySnapshot, type SandboxWorkspaceContract, type StructuredArtifactPayload, type TaskInputAgentBundle } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT } from "@automattic/wp-codebox-core/internals"
 
-export interface AgentBundleSpec {
-  source?: string
-  bundle?: Record<string, unknown>
-  slug?: string
-  on_conflict?: "error" | "skip" | "upgrade"
-  owner_id?: number
-  token_env?: string
-  import_principal?: Record<string, unknown>
-}
+export type AgentBundleSpec = TaskInputAgentBundle
 
 export interface AgentSandboxCodeOptions {
   task: string
@@ -96,7 +88,7 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
 
   const timeoutSeconds = Number.parseInt(options.timeoutSeconds ?? '', 10)
   const timeoutLimit = Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 0
-  const agentBundles = normalizeAgentBundleSpecs(options.agentBundles ?? [])
+  const agentBundles = normalizeAgentBundles(options.agentBundles ?? [])
   const runtimeTask = normalizeRuntimeTask(options.runtimeTask, input)
   return `
 if (function_exists('wp_set_current_user')) {
@@ -475,25 +467,6 @@ function defaultSandboxWorkspace(workspace: SandboxWorkspaceContract | undefined
   if (!workspace?.mounts.length) return null
   const mount = workspace.mounts.find((entry) => entry.mode === "readwrite" && entry.target.startsWith(SANDBOX_WORKSPACE_ROOT)) ?? workspace.mounts[0]
   return mount ? { ...mount } : null
-}
-
-function normalizeAgentBundleSpecs(specs: AgentBundleSpec[]): AgentBundleSpec[] {
-  return specs.flatMap((spec) => {
-    if (!spec || typeof spec !== "object") return []
-    const source = typeof spec.source === "string" ? spec.source.trim() : ""
-    const bundle = spec.bundle && typeof spec.bundle === "object" && !Array.isArray(spec.bundle) ? spec.bundle : undefined
-    if (!source && !bundle) return []
-
-    const normalized: AgentBundleSpec = {}
-    if (source) normalized.source = source
-    if (bundle) normalized.bundle = bundle
-    if (typeof spec.slug === "string" && spec.slug.trim()) normalized.slug = spec.slug.trim()
-    normalized.on_conflict = spec.on_conflict && ["error", "skip", "upgrade"].includes(spec.on_conflict) ? spec.on_conflict : "upgrade"
-    if (Number.isSafeInteger(spec.owner_id) && Number(spec.owner_id) > 0) normalized.owner_id = Number(spec.owner_id)
-    if (typeof spec.token_env === "string" && spec.token_env.trim()) normalized.token_env = spec.token_env.trim()
-    if (spec.import_principal && typeof spec.import_principal === "object" && !Array.isArray(spec.import_principal)) normalized.import_principal = spec.import_principal
-    return [normalized]
-  })
 }
 
 function normalizeRuntimeTask(config: Record<string, unknown> | undefined, agentInput: Record<string, unknown>): Record<string, unknown> | null {

--- a/packages/runtime-core/src/task-input.ts
+++ b/packages/runtime-core/src/task-input.ts
@@ -28,6 +28,15 @@ export interface TaskInputAgentBundle {
   on_conflict?: "error" | "skip" | "upgrade"
   owner_id?: number
   token_env?: string
+  import_principal?: TaskInputAgentBundleImportPrincipal
+}
+
+export interface TaskInputAgentBundleImportPrincipal {
+  agent_id?: number
+  owner_id?: number
+  token_id?: number
+  capabilities?: string[]
+  scope?: Record<string, unknown>
 }
 
 export interface TaskInput {
@@ -106,6 +115,16 @@ export const TASK_INPUT_JSON_SCHEMA = {
           on_conflict: { enum: ["error", "skip", "upgrade"] },
           owner_id: { type: "integer", minimum: 1 },
           token_env: { type: "string" },
+          import_principal: {
+            type: "object",
+            properties: {
+              agent_id: { type: "integer", minimum: 1 },
+              owner_id: { type: "integer", minimum: 1 },
+              token_id: { type: "integer", minimum: 1 },
+              capabilities: { type: "array", items: { type: "string" } },
+              scope: { type: "object" },
+            },
+          },
         },
       },
     },
@@ -143,7 +162,7 @@ export function normalizeTaskInput(input: TaskInputRequest): TaskInput {
   }
 }
 
-function normalizeAgentBundles(value: unknown): TaskInputAgentBundle[] {
+export function normalizeAgentBundles(value: unknown): TaskInputAgentBundle[] {
   if (!Array.isArray(value)) return []
 
   return value.flatMap((entry): TaskInputAgentBundle[] => {
@@ -159,6 +178,24 @@ function normalizeAgentBundles(value: unknown): TaskInputAgentBundle[] {
     normalized.on_conflict = ["error", "skip", "upgrade"].includes(String(entry.on_conflict)) ? entry.on_conflict as TaskInputAgentBundle["on_conflict"] : "upgrade"
     if (Number.isSafeInteger(entry.owner_id) && Number(entry.owner_id) > 0) normalized.owner_id = Number(entry.owner_id)
     if (typeof entry.token_env === "string" && entry.token_env.trim()) normalized.token_env = entry.token_env.trim()
+    const importPrincipal = normalizeAgentBundleImportPrincipal(entry.import_principal)
+    if (importPrincipal) normalized.import_principal = importPrincipal
     return [normalized]
   })
+}
+
+function normalizeAgentBundleImportPrincipal(value: unknown): TaskInputAgentBundleImportPrincipal | undefined {
+  if (!isPlainObject(value)) return undefined
+
+  const normalized: TaskInputAgentBundleImportPrincipal = {}
+  for (const field of ["agent_id", "owner_id", "token_id"] as const) {
+    const numericValue = Number(value[field])
+    if (Number.isSafeInteger(numericValue) && numericValue > 0) normalized[field] = numericValue
+  }
+
+  const capabilities = stringList(value.capabilities)
+  if (capabilities.length) normalized.capabilities = capabilities
+  if (isPlainObject(value.scope)) normalized.scope = value.scope
+
+  return Object.keys(normalized).length ? normalized : undefined
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
@@ -17,7 +17,7 @@ final class WP_Codebox_Task_Input_Contract {
 		return array(
 			'$id'        => self::SCHEMA,
 			'type'       => 'object',
-			'required'   => array( 'schema', 'version', 'goal', 'target', 'allowed_tools', 'expected_artifacts', 'agent_bundles', 'sandbox_tool_policy', 'policy', 'context' ),
+			'required'   => array( 'schema', 'version', 'goal', 'target', 'allowed_tools', 'expected_artifacts', 'structured_artifacts', 'agent_bundles', 'sandbox_tool_policy', 'policy', 'context' ),
 			'properties' => array(
 				'schema'             => array(
 					'type'        => 'string',
@@ -52,6 +52,23 @@ final class WP_Codebox_Task_Input_Contract {
 					'type'        => 'array',
 					'description' => 'Artifact kinds the caller wants back, such as patch, review, tests, preview, or package.',
 					'items'       => array( 'type' => 'string' ),
+				),
+				'structured_artifacts' => array(
+					'type'        => 'array',
+					'description' => 'Named JSON artifacts supplied by the caller as typed task inputs.',
+					'items'       => array(
+						'type'       => 'object',
+						'required'   => array( 'schema', 'name', 'type', 'payload', 'metadata', 'provenance' ),
+						'properties' => array(
+							'schema'         => array( 'const' => 'wp-codebox/structured-artifact/v1' ),
+							'name'           => array( 'type' => 'string' ),
+							'type'           => array( 'type' => 'string' ),
+							'payload_schema' => array( 'anyOf' => array( array( 'type' => 'string' ), array( 'type' => 'object' ) ) ),
+							'payload'        => array(),
+							'metadata'       => array( 'type' => 'object' ),
+							'provenance'     => array( 'type' => 'object' ),
+						),
+					),
 				),
 				'agent_bundles'      => array(
 					'type'        => 'array',
@@ -103,11 +120,66 @@ final class WP_Codebox_Task_Input_Contract {
 			'target'             => is_array( $input['target'] ?? null ) ? $input['target'] : array(),
 			'allowed_tools'      => self::string_list( $input['allowed_tools'] ?? array() ),
 			'expected_artifacts' => self::string_list( $input['expected_artifacts'] ?? array() ),
+			'structured_artifacts' => self::structured_artifacts( $input['structured_artifacts'] ?? array() ),
 			'agent_bundles'      => self::agent_bundles( $input['agent_bundles'] ?? array() ),
 			'sandbox_tool_policy' => is_array( $input['sandbox_tool_policy'] ?? null ) ? $input['sandbox_tool_policy'] : array(),
 			'policy'             => is_array( $input['policy'] ?? null ) ? $input['policy'] : array(),
 			'context'            => is_array( $input['context'] ?? null ) ? $input['context'] : array(),
 		);
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function structured_artifacts( mixed $value ): array {
+		$artifacts = array();
+		foreach ( is_array( $value ) ? $value : array() as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$name = isset( $entry['name'] ) ? trim( (string) $entry['name'] ) : '';
+			$type = isset( $entry['type'] ) ? trim( (string) $entry['type'] ) : '';
+			if ( '' === $name || '' === $type ) {
+				continue;
+			}
+
+			$artifact = array(
+				'schema'     => 'wp-codebox/structured-artifact/v1',
+				'name'       => $name,
+				'type'       => $type,
+				'payload'    => $entry['payload'] ?? null,
+				'metadata'   => is_array( $entry['metadata'] ?? null ) ? $entry['metadata'] : array(),
+				'provenance' => array_merge(
+					is_array( $entry['provenance'] ?? null ) ? $entry['provenance'] : array(),
+					array( 'direction' => 'input' )
+				),
+			);
+
+			$payload_schema = self::structured_payload_schema( $entry['payload_schema'] ?? $entry['payloadSchema'] ?? $entry['artifact_schema'] ?? $entry['artifactSchema'] ?? null );
+			if ( null !== $payload_schema ) {
+				$artifact['payload_schema'] = $payload_schema;
+			}
+			if ( isset( $artifact['provenance']['source'] ) ) {
+				$source = trim( (string) $artifact['provenance']['source'] );
+				if ( '' !== $source ) {
+					$artifact['provenance']['source'] = $source;
+				} else {
+					unset( $artifact['provenance']['source'] );
+				}
+			}
+
+			$artifacts[] = $artifact;
+		}
+
+		return $artifacts;
+	}
+
+	private static function structured_payload_schema( mixed $value ): mixed {
+		if ( is_string( $value ) ) {
+			$value = trim( $value );
+			return '' !== $value ? $value : null;
+		}
+
+		return is_array( $value ) ? $value : null;
 	}
 
 	/** @return array<int,array<string,mixed>> */

--- a/scripts/task-input-contract-smoke.ts
+++ b/scripts/task-input-contract-smoke.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { spawnSync } from "node:child_process"
 import { normalizeTaskInput, TASK_INPUT_JSON_SCHEMA, TASK_INPUT_SCHEMA, TASK_INPUT_VERSION } from "@automattic/wp-codebox-core"
 
 interface Fixture {
@@ -9,8 +10,17 @@ interface Fixture {
 
 const fixtures = JSON.parse(await readFile(new URL("../tests/fixtures/task-input-normalization.json", import.meta.url), "utf8")) as Fixture[]
 
-if (TASK_INPUT_JSON_SCHEMA.$id !== TASK_INPUT_SCHEMA) throw new Error("Task input schema id drifted.")
-if (TASK_INPUT_JSON_SCHEMA.properties.version.const !== TASK_INPUT_VERSION) throw new Error("Task input schema version drifted.")
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
+assert(TASK_INPUT_JSON_SCHEMA.$id === TASK_INPUT_SCHEMA, "Task input schema id drifted.")
+assert(TASK_INPUT_JSON_SCHEMA.properties.version.const === TASK_INPUT_VERSION, "Task input schema version drifted.")
+assert(TASK_INPUT_JSON_SCHEMA.required.includes("structured_artifacts"), "TS task input schema must require structured_artifacts.")
+assert(
+  "import_principal" in TASK_INPUT_JSON_SCHEMA.properties.agent_bundles.items.properties,
+  "TS agent bundle schema must include import_principal.",
+)
 
 for (const fixture of fixtures) {
   const normalized = normalizeTaskInput(fixture.input)
@@ -18,5 +28,36 @@ for (const fixture of fixtures) {
     throw new Error(`Task input fixture failed: ${fixture.name}`)
   }
 }
+
+const contractPath = new URL("../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php", import.meta.url)
+const fixturePath = new URL("../tests/fixtures/task-input-normalization.json", import.meta.url)
+const php = spawnSync("php", ["-r", `
+define('ABSPATH', __DIR__);
+require ${JSON.stringify(contractPath.pathname)};
+$fixtures = json_decode(file_get_contents(${JSON.stringify(fixturePath.pathname)}), true, 512, JSON_THROW_ON_ERROR);
+$schema = WP_Codebox_Task_Input_Contract::schema();
+$normalized = WP_Codebox_Task_Input_Contract::normalize($fixtures[0]['input']);
+echo json_encode(array(
+    'required' => $schema['required'],
+    'agent_bundle_properties' => array_keys($schema['properties']['agent_bundles']['items']['properties']),
+    'has_structured_artifacts_schema' => isset($schema['properties']['structured_artifacts']),
+    'normalized' => $normalized,
+), JSON_THROW_ON_ERROR);
+`], { encoding: "utf8" })
+
+assert(php.status === 0, `PHP task input contract smoke failed: ${php.stderr || php.stdout}`)
+
+const phpContract = JSON.parse(php.stdout) as {
+  required: string[]
+  agent_bundle_properties: string[]
+  has_structured_artifacts_schema: boolean
+  normalized: ReturnType<typeof normalizeTaskInput>
+}
+
+assert(phpContract.required.includes("structured_artifacts"), "PHP task input schema must require structured_artifacts.")
+assert(phpContract.agent_bundle_properties.includes("import_principal"), "PHP agent bundle schema must include import_principal.")
+assert(phpContract.has_structured_artifacts_schema, "PHP task input schema must define structured_artifacts.")
+assert(phpContract.normalized.structured_artifacts[0]?.provenance?.direction === "input", "PHP must normalize input structured_artifacts.")
+assert(phpContract.normalized.agent_bundles[0]?.import_principal?.agent_id === 12, "PHP must normalize agent bundle import_principal.")
 
 console.log(`task input contract smoke ok (${fixtures.length} fixtures)`)

--- a/tests/fixtures/task-input-normalization.json
+++ b/tests/fixtures/task-input-normalization.json
@@ -31,7 +31,16 @@
           "source": "/tmp/site-generator-agent.json",
           "slug": "site-generator",
           "on_conflict": "upgrade",
-          "owner_id": 1
+          "owner_id": 1,
+          "import_principal": {
+            "agent_id": "12",
+            "owner_id": 7,
+            "token_id": 3,
+            "capabilities": ["agents.import", "", "agents.import"],
+            "scope": {
+              "runtime": "sandbox"
+            }
+          }
         },
         {
           "bundle": {
@@ -86,7 +95,16 @@
           "source": "/tmp/site-generator-agent.json",
           "slug": "site-generator",
           "on_conflict": "upgrade",
-          "owner_id": 1
+          "owner_id": 1,
+          "import_principal": {
+            "agent_id": 12,
+            "owner_id": 7,
+            "token_id": 3,
+            "capabilities": ["agents.import"],
+            "scope": {
+              "runtime": "sandbox"
+            }
+          }
         },
         {
           "bundle": {


### PR DESCRIPTION
## Summary
- Add `import_principal` to the TS task input agent bundle contract/schema and normalize it in core.
- Reuse the core agent bundle normalizer from TS CLI agent sandbox code instead of a duplicate local implementation.
- Add `structured_artifacts` to the PHP task input contract schema/normalizer and extend the shared smoke fixture to prove TS/PHP parity for `structured_artifacts` and `import_principal`.

## Tests
- `npx tsx scripts/task-input-contract-smoke.ts`
- `npm run build`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by agent, reviewed via targeted verification.