### PR TITLE
Add artifact bundle writer

### DIFF
--- a/packages/runtime-playground/src/artifact-bundle-writer.ts
+++ b/packages/runtime-playground/src/artifact-bundle-writer.ts
@@ -1,0 +1,78 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+import {
+  artifactManifestFile,
+  refreshArtifactManifestFileSha256s,
+  type ArtifactManifest,
+  type ArtifactManifestFile,
+  type ArtifactViewerMetadata,
+} from "@automattic/wp-codebox-core"
+
+export interface ManifestedArtifactFileInput {
+  path: string
+  kind: ArtifactManifestFile["kind"]
+  contentType: string
+  viewer?: ArtifactViewerMetadata
+}
+
+export class ManifestedArtifactSet {
+  private readonly entries = new Map<string, ArtifactManifestFile>()
+
+  add(input: ManifestedArtifactFileInput): ArtifactManifestFile {
+    const entry = artifactManifestFile(input.path, input.kind, input.contentType, undefined, input.viewer)
+    this.entries.set(input.path, entry)
+    return entry
+  }
+
+  files(): ArtifactManifestFile[] {
+    return [...this.entries.values()]
+  }
+}
+
+export class ArtifactBundleWriter {
+  readonly artifacts = new ManifestedArtifactSet()
+
+  constructor(
+    private readonly directory: string,
+    private readonly manifestPath = "manifest.json",
+  ) {}
+
+  path(path: string): string {
+    return join(this.directory, path)
+  }
+
+  async write(path: string, contents: string | Buffer, manifest: Omit<ManifestedArtifactFileInput, "path">): Promise<void> {
+    this.artifacts.add({ path, ...manifest })
+    await mkdir(dirname(this.path(path)), { recursive: true })
+    await writeFile(this.path(path), contents)
+  }
+
+  async writeJson(path: string, value: unknown, manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
+    await this.write(path, `${JSON.stringify(value, null, 2)}\n`, {
+      ...manifest,
+      contentType: manifest.contentType ?? "application/json",
+    })
+  }
+
+  async writeGenerated(path: string, manifest: Omit<ManifestedArtifactFileInput, "path">, write: (absolutePath: string) => Promise<void>): Promise<void> {
+    this.artifacts.add({ path, ...manifest })
+    await mkdir(dirname(this.path(path)), { recursive: true })
+    await write(this.path(path))
+  }
+
+  async writeManifest<T extends ArtifactManifest>(manifest: T): Promise<T> {
+    this.artifacts.add({ path: this.manifestPath, kind: "manifest", contentType: "application/json" })
+    manifest.files = this.artifacts.files()
+    await refreshArtifactManifestFileSha256s(this.directory, manifest, this.manifestPath)
+    await this.writeManifestJson(manifest)
+    await refreshArtifactManifestFileSha256s(this.directory, manifest, this.manifestPath)
+    await this.writeManifestJson(manifest)
+    return manifest
+  }
+
+  private async writeManifestJson(manifest: ArtifactManifest): Promise<void> {
+    await mkdir(dirname(this.path(this.manifestPath)), { recursive: true })
+    await writeFile(this.path(this.manifestPath), `${JSON.stringify(manifest, null, 2)}\n`)
+  }
+}

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,4 +1,5 @@
 export { playgroundRuntimeCommandIds } from "./command-router.js"
+export { ArtifactBundleWriter, ManifestedArtifactSet, type ManifestedArtifactFileInput } from "./artifact-bundle-writer.js"
 export { buildArtifactDiagnostics } from "./artifacts.js"
 export { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "./browser-metrics.js"
 export { createHostCommandTool, type HostCommandToolConfig } from "./host-command-tool.js"

--- a/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
+++ b/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
@@ -7,6 +7,7 @@ import {
   type ArtifactManifest,
   type RuntimeInfo,
 } from "@automattic/wp-codebox-core"
+import { ArtifactBundleWriter } from "./artifact-bundle-writer.js"
 import { runtimeSnapshotRestorePhp, runtimeSnapshotRestorePhpFromFile, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
 
 export interface ReplayableWordPressSiteBundleOptions {
@@ -76,33 +77,30 @@ export interface ReplayExportPackage {
 export async function writeReplayExportPackage(snapshot: RuntimeSnapshotArtifact, options: ReplayExportPackageOptions): Promise<ReplayExportPackage> {
   const createdAt = options.createdAt ?? new Date().toISOString()
   const directory = options.directory
-  const filesDirectory = join(directory, "files")
-  await mkdir(filesDirectory, { recursive: true })
-
-  const snapshotPath = join(filesDirectory, "runtime-snapshot.json")
-  const blueprintPath = join(directory, "blueprint.after.json")
-  const playgroundBundlePath = join(directory, "blueprint.zip")
-  const notesPath = join(directory, "blueprint.after-notes.json")
-  const manifestPath = join(directory, "manifest.json")
+  const writer = new ArtifactBundleWriter(directory)
+  const snapshotPath = "files/runtime-snapshot.json"
+  const blueprintPath = "blueprint.after.json"
+  const playgroundBundlePath = "blueprint.zip"
+  const notesPath = "blueprint.after-notes.json"
   const blueprint = buildReplayExportBlueprint(snapshot, options)
   const notes = buildReplayableWordPressSiteLimitations(snapshot, {
     source: {
       kind: "wordpress.export-replay-package",
-      snapshotPath: "files/runtime-snapshot.json",
+      snapshotPath,
       mode: "external-runtime-snapshot",
       ...(options.source ?? {}),
     },
   })
 
-  await writeJson(blueprintPath, blueprint)
-  await writeJson(snapshotPath, snapshot)
-  await writeJson(notesPath, notes)
-  await writePlaygroundBlueprintBundle(playgroundBundlePath, [
+  await writer.writeJson(blueprintPath, blueprint, { kind: "blueprint-after" })
+  await writer.writeJson(snapshotPath, snapshot, { kind: "runtime-snapshot" })
+  await writer.writeJson(notesPath, notes, { kind: "blueprint-after-notes" })
+  await writer.writeGenerated(playgroundBundlePath, { kind: "playground-blueprint-bundle", contentType: "application/zip" }, (path) => writePlaygroundBlueprintBundle(path, [
     { path: "blueprint.json", data: `${JSON.stringify(blueprint, null, 2)}\n` },
     { path: "files/runtime-snapshot.json", data: `${JSON.stringify(snapshot, null, 2)}\n` },
-  ])
+  ]))
 
-  const contentInputs = ["blueprint.after.json", "blueprint.zip", "files/runtime-snapshot.json", "blueprint.after-notes.json"]
+  const contentInputs = [blueprintPath, playgroundBundlePath, snapshotPath, notesPath]
   const contentDigest = await calculateArtifactContentDigest(directory, contentInputs)
   const id = options.id ?? `replay-export-package-sha256-${contentDigest}`
   const manifest: ReplayableWordPressSiteBundleManifest = {
@@ -116,35 +114,26 @@ export async function writeReplayExportPackage(snapshot: RuntimeSnapshotArtifact
     },
     createdAt,
     runtime: runtimeInfoForReplayableWordPressSite(snapshot, id, createdAt, blueprint),
-    files: [
-      artifactManifestFile("manifest.json", "manifest", "application/json"),
-      artifactManifestFile("blueprint.after.json", "blueprint-after", "application/json"),
-      artifactManifestFile("blueprint.zip", "playground-blueprint-bundle", "application/zip"),
-      artifactManifestFile("files/runtime-snapshot.json", "runtime-snapshot", "application/json"),
-      artifactManifestFile("blueprint.after-notes.json", "blueprint-after-notes", "application/json"),
-    ],
+    files: [],
     replayableWordPressSite: {
-      blueprintPath: "blueprint.after.json",
-      playgroundBundlePath: "blueprint.zip",
-      publicViewerArtifactPath: "blueprint.zip",
-      snapshotPath: "files/runtime-snapshot.json",
-      limitationsPath: "blueprint.after-notes.json",
+      blueprintPath,
+      playgroundBundlePath,
+      publicViewerArtifactPath: playgroundBundlePath,
+      snapshotPath,
+      limitationsPath: notesPath,
       replayStatus: "replayable-runtime-state",
       source: {
         kind: "wordpress.export-replay-package",
-        snapshotPath: "files/runtime-snapshot.json",
+        snapshotPath,
         mode: "external-runtime-snapshot",
         ...(options.source ?? {}),
       },
     },
   }
 
-  await refreshArtifactManifestFileSha256s(directory, manifest)
-  await writeJson(manifestPath, manifest)
-  await refreshArtifactManifestFileSha256s(directory, manifest)
-  await writeJson(manifestPath, manifest)
+  await writer.writeManifest(manifest)
 
-  const [snapshotStats, blueprintStats] = await Promise.all([stat(snapshotPath), stat(blueprintPath)])
+  const [snapshotStats, blueprintStats] = await Promise.all([stat(writer.path(snapshotPath)), stat(writer.path(blueprintPath))])
   return {
     status: "passed",
     directory,
@@ -160,10 +149,10 @@ export async function writeReplayExportPackage(snapshot: RuntimeSnapshotArtifact
     },
     artifacts: {
       manifest: "manifest.json",
-      blueprint: "blueprint.after.json",
-      playgroundBundle: "blueprint.zip",
-      snapshot: "files/runtime-snapshot.json",
-      notes: "blueprint.after-notes.json",
+      blueprint: blueprintPath,
+      playgroundBundle: playgroundBundlePath,
+      snapshot: snapshotPath,
+      notes: notesPath,
     },
     manifest,
   }

--- a/scripts/replay-export-manifest-integrity-smoke.ts
+++ b/scripts/replay-export-manifest-integrity-smoke.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, relative } from "node:path"
+
+import { writeReplayExportPackage } from "../packages/runtime-playground/src/replayable-wordpress-site-bundle.ts"
+import type { RuntimeSnapshotArtifact } from "../packages/runtime-playground/src/runtime-snapshot.ts"
+
+const snapshot: RuntimeSnapshotArtifact = {
+  schema: "wp-codebox/wordpress-runtime-snapshot/v1",
+  version: 1,
+  id: "snapshot-smoke",
+  createdAt: "2026-06-15T00:00:00.000Z",
+  compatibility: {
+    backend: "wordpress-playground",
+    wordpressVersion: "latest",
+    phpVersion: "8.3.31",
+  },
+  metadata: {
+    runtime: {
+      id: "runtime-smoke",
+      backend: "wordpress-playground",
+      status: "destroyed",
+      createdAt: "2026-06-15T00:00:00.000Z",
+      environment: {
+        kind: "wordpress",
+        name: "runtime-smoke",
+        version: "latest",
+      },
+    },
+    mounts: [],
+    mountedInputs: [],
+    activeTheme: "twentytwentyfour",
+    activePlugins: [],
+    wpContentPath: "/wordpress/wp-content",
+  },
+  database: { tables: [] },
+  files: [
+    {
+      scope: "wp-content",
+      path: "smoke.txt",
+      bytes: 5,
+      sha256: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+      base64: "aGVsbG8=",
+    },
+  ],
+  hashes: {
+    database: { algorithm: "sha256", value: "database-smoke" },
+    files: { algorithm: "sha256", value: "files-smoke" },
+  },
+}
+
+const directory = await mkdtemp(join(tmpdir(), "wp-codebox-replay-export-manifest-"))
+
+try {
+  await writeReplayExportPackage(snapshot, {
+    directory,
+    createdAt: "2026-06-15T00:00:00.000Z",
+    id: "replay-export-manifest-integrity-smoke",
+  })
+
+  const manifest = JSON.parse(await readFile(join(directory, "manifest.json"), "utf8")) as { files: Array<{ path: string }> }
+  const manifestPaths = manifest.files.map((file) => file.path).sort()
+  const writtenPaths = (await listFiles(directory)).sort()
+
+  assert.deepEqual(writtenPaths, manifestPaths)
+  assert.deepEqual(new Set(manifestPaths).size, manifestPaths.length)
+
+  for (const file of manifest.files) {
+    await readFile(join(directory, file.path))
+  }
+
+  console.log("replay-export-manifest-integrity-smoke passed")
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}
+
+async function listFiles(directory: string): Promise<string[]> {
+  const files: string[] = []
+  await collectFiles(directory, directory, files)
+  return files
+}
+
+async function collectFiles(root: string, directory: string, files: string[]): Promise<void> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      await collectFiles(root, path, files)
+    } else if (entry.isFile()) {
+      files.push(relative(root, path).replace(/\\/g, "/"))
+    }
+  }
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -65,6 +65,7 @@ export const smokeGroups = {
       tsxSmoke("partial-artifact-discovery-smoke"),
       tsxSmoke("mounted-workspace-diff-smoke"),
       tsxSmoke("replay-export-blueprint-smoke"),
+      tsxSmoke("replay-export-manifest-integrity-smoke"),
       tsxSmoke("materialize-replay-package-smoke"),
     ],
   },


### PR DESCRIPTION
## Summary
- Add a reusable `ArtifactBundleWriter` / `ManifestedArtifactSet` primitive for writing bundle files and finalizing manifest hashes.
- Convert replay export package writing to register artifacts through the writer instead of manually synchronizing path constants, writes, manifest entries, and hash finalization.
- Add a focused replay export manifest integrity smoke that verifies written files and manifest files match.

## Tests
- `npm run build`
- `npm run smoke -- --command=replay-export-manifest-integrity-smoke`
- `npm run smoke -- --command=replay-export-blueprint-smoke`
- `npm run smoke -- --command=materialize-replay-package-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by agent, reviewed via targeted verification.
