### PR TITLE
Centralize generated PHP snippets

### DIFF
--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -1,3 +1,5 @@
+import { phpEnvAssignmentFunction } from "./php-snippets.js"
+
 export interface BenchRunCodeOptions {
   componentId: string
   pluginSlug: string
@@ -15,6 +17,7 @@ export interface BenchRunCodeOptions {
 
 export function benchRunCode(options: BenchRunCodeOptions): string {
   return `require_once ABSPATH . 'wp-admin/includes/plugin.php';
+${phpEnvAssignmentFunction("wp_codebox_bench_apply_env", "wp_json_encode")}
 
 $component_id = ${JSON.stringify(options.componentId)};
 $plugin_slug = ${JSON.stringify(options.pluginSlug)};
@@ -31,15 +34,7 @@ $bench_reset_policy = ${phpJsonDecodeExpression(options.resetPolicy)};
 $wp_cli_bridge_url = ${JSON.stringify(options.wpCliBridge?.url ?? null)};
 $wp_cli_bridge_token = ${JSON.stringify(options.wpCliBridge?.token ?? null)};
 
-if (is_array($bench_env)) {
-    foreach ($bench_env as $name => $value) {
-        if (is_string($name) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
-            $string_value = is_scalar($value) ? (string) $value : wp_json_encode($value);
-            putenv($name . '=' . $string_value);
-            $_ENV[$name] = $string_value;
-        }
-    }
-}
+wp_codebox_bench_apply_env($bench_env);
 
 function wp_codebox_bench_percentile(array $samples, float $percentile): float {
     if (empty($samples)) {

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
-import { argValue, isSafeEnvName, normalizePhpCode, phpBody } from "./commands.js"
+import { argValue, normalizePhpCode, phpBody } from "./commands.js"
+import { phpEnvAssignments, phpWpConfigDefineAssignments } from "./php-snippets.js"
 import type { RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 
 interface PhpBootstrapBridge {
@@ -303,44 +304,18 @@ function pluginRuntimeBootstrapPhp(spec: RuntimeCreateSpec): string {
   if (Number.isInteger(maxExecutionTime) && typeof maxExecutionTime === "number" && maxExecutionTime >= 0 && maxExecutionTime <= 3600) {
     lines.push(`@set_time_limit(${maxExecutionTime});`)
   }
-  for (const [name, value] of Object.entries(runtime.wpConfigDefines ?? {})) {
-    if (!/^[A-Z_][A-Z0-9_]*$/i.test(name) || (!["string", "number", "boolean"].includes(typeof value) && value !== null)) {
-      continue
-    }
-    lines.push(`if (!defined(${JSON.stringify(name)})) { define(${JSON.stringify(name)}, ${phpLiteral(value as string | number | boolean | null)}); }`)
+  const wpConfigDefines = phpWpConfigDefineAssignments(runtime.wpConfigDefines ?? {}).trim()
+  if (wpConfigDefines) {
+    lines.push(wpConfigDefines)
   }
 
   return lines.length > 0 ? `${lines.join("\n")}\n` : ""
 }
 
 function secretEnvPhp(spec: RuntimeCreateSpec): string {
-  const entries = Object.entries(spec.secretEnv ?? {}).filter(([name]) => isSafeEnvName(name))
-  if (entries.length === 0) {
-    return ""
-  }
-
-  return `${entries
-    .map(([name, value]) => `putenv(${JSON.stringify(`${name}=${value}`)});`)
-    .join("\n")}\n`
+  return phpEnvAssignments(spec.secretEnv ?? {})
 }
 
 function runtimeEnvPhp(spec: RuntimeCreateSpec): string {
-  const entries = Object.entries(spec.runtimeEnv ?? {}).filter(([name]) => isSafeEnvName(name))
-  if (entries.length === 0) {
-    return ""
-  }
-
-  return `${entries
-    .map(([name, value]) => `putenv(${JSON.stringify(`${name}=${value}`)});`)
-    .join("\n")}\n`
-}
-
-function phpLiteral(value: string | number | boolean | null): string {
-  if (typeof value === "string") {
-    return JSON.stringify(value)
-  }
-  if (value === null) {
-    return "null"
-  }
-  return String(value)
+  return phpEnvAssignments(spec.runtimeEnv ?? {})
 }

--- a/packages/runtime-playground/src/php-snippets.ts
+++ b/packages/runtime-playground/src/php-snippets.ts
@@ -1,0 +1,79 @@
+import { isSafeEnvName } from "./commands.js"
+
+export type PhpScalar = string | number | boolean | null
+
+export function phpEnvAssignments(env: Record<string, unknown>): string {
+  const lines = Object.entries(env)
+    .filter(([name]) => isSafeEnvName(name))
+    .map(([name, value]) => `putenv(${JSON.stringify(`${name}=${String(value)}`)});`)
+
+  return lines.length > 0 ? `${lines.join("\n")}\n` : ""
+}
+
+export function phpWpConfigDefineAssignments(defines: Record<string, unknown>): string {
+  const lines = Object.entries(defines)
+    .filter((entry): entry is [string, PhpScalar] => isPhpConstantName(entry[0]) && isPhpScalar(entry[1]))
+    .map(([name, value]) => phpWpConfigDefineAssignment(name, value))
+
+  return lines.length > 0 ? `${lines.join("\n")}\n` : ""
+}
+
+export function phpWpConfigDefineAssignment(name: string, value: PhpScalar): string {
+  if (!isPhpConstantName(name)) {
+    throw new Error(`Invalid PHP constant name: ${name}`)
+  }
+
+  return `if (!defined(${JSON.stringify(name)})) { define(${JSON.stringify(name)}, ${phpLiteral(value)}); }`
+}
+
+export function phpLiteral(value: PhpScalar): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value)
+  }
+  if (value === null) {
+    return "null"
+  }
+  return String(value)
+}
+
+export function isPhpConstantName(name: string): boolean {
+  return /^[A-Z_][A-Z0-9_]*$/i.test(name)
+}
+
+export function isPhpScalar(value: unknown): value is PhpScalar {
+  return value === null || ["string", "number", "boolean"].includes(typeof value)
+}
+
+export function phpEnvAssignmentFunction(functionName: string, jsonFunction = "json_encode", invalidKeyLogExpression?: string): string {
+  return `function ${functionName}($env): void {
+    if (!is_array($env)) {
+        return;
+    }
+    foreach ($env as $name => $value) {
+        if (is_string($name) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+            $string_value = is_scalar($value) ? (string) $value : ${jsonFunction}($value);
+            putenv($name . '=' . $string_value);
+            $_ENV[$name] = $string_value;
+        }${invalidKeyLogExpression ? ` else {
+            ${invalidKeyLogExpression}
+        }` : ""}
+    }
+}`
+}
+
+export function phpWpConfigDefineAppenderFunction(functionName: string, invalidKeyLogExpression?: string, includeComment = true): string {
+  return `function ${functionName}(string &$config, $extra_defines): void {
+    if (empty($extra_defines) || !is_array($extra_defines)) {
+        return;
+    }${includeComment ? `
+    $config .= "\n// Recipe-declared wp-config defines.\n";
+` : ""}
+    foreach ($extra_defines as $name => $value) {
+        if (!is_string($name) || !preg_match('/^[A-Z_][A-Z0-9_]*$/i', $name)) {${invalidKeyLogExpression ? `
+            ${invalidKeyLogExpression}` : ""}
+            continue;
+        }
+        $config .= sprintf("if (!defined('%s')) { define('%s', %s); }\n", $name, $name, var_export($value, true));
+    }
+}`
+}

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -1,3 +1,5 @@
+import { phpEnvAssignmentFunction, phpWpConfigDefineAppenderFunction } from "./php-snippets.js"
+
 export interface PhpunitRunCodeOptions {
   pluginSlug: string
   cwd: string
@@ -309,6 +311,10 @@ function pg_log($msg) {
     file_put_contents($result_file, $msg . "\n", FILE_APPEND);
 }
 
+${phpEnvAssignmentFunction("pg_apply_env", "json_encode", "pg_log('NOTICE: skipping invalid bench_env key: ' . var_export($name, true));")}
+
+${phpWpConfigDefineAppenderFunction("pg_append_wp_config_defines", "pg_log('NOTICE: skipping invalid wp_config_defines key: ' . var_export($name, true));")}
+
 function pg_diagnostic_context(): string {
     global $current_stage;
     $hook = function_exists('current_filter') ? current_filter() : null;
@@ -522,16 +528,7 @@ function pg_run_boot_stage(array $cfg = []): ?string {
         $table_prefix = isset($cfg['table_prefix']) && is_string($cfg['table_prefix']) && $cfg['table_prefix'] !== '' ? $cfg['table_prefix'] : 'wptests_';
         $config_path = '/tmp/wp-tests-config.php';
         $config = "<?php\n";
-        if (!empty($extra_defines) && is_array($extra_defines)) {
-            $config .= "\n// Recipe-declared wp-config defines.\n";
-            foreach ($extra_defines as $name => $value) {
-                if (!is_string($name) || !preg_match('/^[A-Z_][A-Z0-9_]*$/i', $name)) {
-                    pg_log('NOTICE: skipping invalid wp_config_defines key: ' . var_export($name, true));
-                    continue;
-                }
-                $config .= sprintf("if (!defined('%s')) { define('%s', %s); }\n", $name, $name, var_export($value, true));
-            }
-        }
+        pg_append_wp_config_defines($config, $extra_defines);
         $config .= '$table_prefix = ' . var_export($table_prefix, true) . ";\n";
         $config .= <<<'CONFIG'
 define('DB_NAME', ':memory:');
@@ -821,17 +818,7 @@ try {
     exit(1);
 }
 
-if (is_array($bench_env)) {
-    foreach ($bench_env as $name => $value) {
-        if (is_string($name) && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
-            $string_value = is_scalar($value) ? (string) $value : json_encode($value);
-            putenv($name . '=' . $string_value);
-            $_ENV[$name] = $string_value;
-        } else {
-            pg_log('NOTICE: skipping invalid bench_env key: ' . var_export($name, true));
-        }
-    }
-}
+pg_apply_env($bench_env);
 
 if (!is_array($wp_config_defines)) {
     $wp_config_defines = array();
@@ -1089,6 +1076,8 @@ function core_pg_log($msg) {
     file_put_contents($result_file, $msg . "\n", FILE_APPEND);
 }
 
+${phpWpConfigDefineAppenderFunction("core_pg_append_wp_config_defines", undefined, false)}
+
 function core_pg_stage_begin($stage) {
     global $current_stage;
     $current_stage = $stage;
@@ -1186,11 +1175,7 @@ function core_pg_write_tests_config(string $core_root, array $extra_defines): st
     }
 
     $config = "<?php\n";
-    foreach ($extra_defines as $name => $value) {
-        if (is_string($name) && preg_match('/^[A-Z_][A-Z0-9_]*$/i', $name)) {
-            $config .= sprintf("if (!defined('%s')) { define('%s', %s); }\n", $name, $name, var_export($value, true));
-        }
-    }
+    core_pg_append_wp_config_defines($config, $extra_defines);
     $config .= "\n";
     $config .= "define('DB_NAME', ':memory:');\n";
     $config .= "define('DB_USER', 'root');\n";

--- a/scripts/php-snippets-smoke.ts
+++ b/scripts/php-snippets-smoke.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  phpEnvAssignmentFunction,
+  phpEnvAssignments,
+  phpLiteral,
+  phpWpConfigDefineAppenderFunction,
+  phpWpConfigDefineAssignment,
+  phpWpConfigDefineAssignments,
+} from "../packages/runtime-playground/src/php-snippets.js"
+
+assert.equal(phpLiteral("quote' double\" newline\n"), '"quote\' double\\" newline\\n"')
+assert.equal(phpLiteral(true), "true")
+assert.equal(phpLiteral(false), "false")
+assert.equal(phpLiteral(12.5), "12.5")
+assert.equal(phpLiteral(null), "null")
+
+assert.equal(phpEnvAssignments({ VALID_ENV: "secret\nvalue", "INVALID-NAME": "nope" }), 'putenv("VALID_ENV=secret\\nvalue");\n')
+assert.equal(
+  phpWpConfigDefineAssignments({ VALID_DEFINE: "value", FLAG: true, COUNT: 3, NULL_VALUE: null, "INVALID-NAME": "nope", ARRAY_VALUE: [] }),
+  'if (!defined("VALID_DEFINE")) { define("VALID_DEFINE", "value"); }\n'
+    + 'if (!defined("FLAG")) { define("FLAG", true); }\n'
+    + 'if (!defined("COUNT")) { define("COUNT", 3); }\n'
+    + 'if (!defined("NULL_VALUE")) { define("NULL_VALUE", null); }\n',
+)
+assert.throws(() => phpWpConfigDefineAssignment("INVALID-NAME", "value"), /Invalid PHP constant name/)
+
+const dir = mkdtempSync(join(tmpdir(), "wp-codebox-php-snippets-"))
+
+const staticPhp = join(dir, "static.php")
+writeFileSync(staticPhp, `<?php
+${phpEnvAssignments({ VALID_ENV: "value" })}
+${phpWpConfigDefineAssignments({ VALID_DEFINE: "value", FLAG: true, COUNT: 3, NULL_VALUE: null })}`)
+execFileSync("php", ["-l", staticPhp], { stdio: "pipe" })
+
+const runtimePhp = join(dir, "runtime.php")
+writeFileSync(runtimePhp, `<?php
+${phpEnvAssignmentFunction("apply_env", "json_encode", "$GLOBALS['invalid_env'][] = $name;")}
+${phpWpConfigDefineAppenderFunction("append_defines", "$GLOBALS['invalid_define'][] = $name;")}
+
+$invalid_env = array();
+apply_env(array('SCALAR_INT' => 12, 'SCALAR_BOOL' => true, 'ARRAY_VALUE' => array('a' => 1), 'INVALID-NAME' => 'nope'));
+assert(getenv('SCALAR_INT') === '12');
+assert($_ENV['SCALAR_BOOL'] === '1');
+assert(getenv('ARRAY_VALUE') === '{"a":1}');
+assert($invalid_env === array('INVALID-NAME'));
+
+$invalid_define = array();
+$config = "<?php\n";
+append_defines($config, array('VALID_DEFINE' => "quote' value", 'INVALID-NAME' => 'nope'));
+assert(strpos($config, "define('VALID_DEFINE', 'quote\\' value')") !== false);
+assert($invalid_define === array('INVALID-NAME'));
+`)
+execFileSync("php", ["-l", runtimePhp], { stdio: "pipe" })
+execFileSync("php", [runtimePhp], { stdio: "pipe" })

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -39,6 +39,7 @@ export const smokeGroups = {
       tsxSmoke("doctor-command-smoke"),
       tsxSmoke("source-checkout-entrypoint-smoke"),
       tsxSmoke("cli-unsettled-command-smoke"),
+      tsxSmoke("php-snippets-smoke"),
       tsxSmoke("agent-runtime-failure-smoke"),
       tsxSmoke("recipe-run-terminal-phase-failure-smoke"),
     ],


### PR DESCRIPTION
## Summary
- Add shared runtime-playground PHP snippet helpers for generated env assignments and wp-config defines.
- Convert bootstrap, bench, and phpunit generated PHP call sites to use the helpers while preserving existing validation/conversion behavior.
- Add a focused smoke test for escaping, invalid names, scalar conversion, and generated PHP syntax.

## Testing
- npm exec -- tsx scripts/php-snippets-smoke.ts
- npm run build
- npm run smoke -- --group=core

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by agent, reviewed via targeted verification.