### PR TITLE
Validate recipe schema during ingestion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "ISC",
       "workspaces": [
         "packages/*"
@@ -3928,7 +3928,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -3939,11 +3939,14 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.8.2"
+      "version": "0.8.3",
+      "dependencies": {
+        "ajv": "^8.20.0"
+      }
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@types/pngjs": "^6.0.5",

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -1505,12 +1505,10 @@ async function executeRecipeProbe(runtime: Runtime, probe: WorkspaceRecipeProbe,
 
 async function collectRecipeDeclaredArtifacts(recipe: WorkspaceRecipe, runtime: Runtime): Promise<RecipeRunDeclaredArtifact[]> {
   const results: RecipeRunDeclaredArtifact[] = []
-  for (const [index, artifact] of (recipe.artifacts?.paths ?? []).entries()) {
-    results.push(await collectRecipeDeclaredArtifact(runtime, artifact, index))
-  }
-  const offset = results.length
-  for (const [index, artifact] of (recipe.artifacts?.typed ?? []).entries()) {
-    results.push(await collectRecipeTypedArtifact(runtime, artifact, offset + index))
+  for (const { kind, index, artifact } of workspaceRecipeRuntimeCollectedArtifacts(recipe)) {
+    results.push(kind === "typed"
+      ? await collectRecipeTypedArtifact(runtime, artifact, index)
+      : await collectRecipeDeclaredArtifact(runtime, artifact, index))
   }
   return results
 }

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { validateBrowserInteractionScript, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { assertWorkspaceRecipeJsonSchema, validateBrowserInteractionScript, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 
@@ -34,6 +34,7 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   const recipe = parseWorkspaceRecipeJson(raw)
   normalizeWorkspaceRecipeCompatibility(recipe)
   validateWorkspaceRecipeShape(recipe, recipePath)
+  assertWorkspaceRecipeJsonSchema(recipe, { recipePath, recipeCommandIds: [...supportedRecipeCommands] })
 
   return recipe
 }
@@ -729,7 +730,7 @@ export function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
   if ((recipe.inputs?.siteSeeds ?? []).some((siteSeed) => siteSeed.type === "fixture")) {
     commands.unshift("wordpress.run-php")
   }
-  if ((recipe.inputs?.fixtureDatabases ?? []).length > 0 || (recipe.artifacts?.paths ?? []).length > 0) {
+  if ((recipe.inputs?.fixtureDatabases ?? []).length > 0 || workspaceRecipeRuntimeCollectedArtifacts(recipe).length > 0) {
     commands.unshift("wordpress.run-php")
   }
   // Auto-grant the evaluate capability when a browser-actions step opts into the

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -35,5 +35,8 @@
   ],
   "scripts": {
     "build": "tsc -b"
+  },
+  "dependencies": {
+    "ajv": "^8.20.0"
   }
 }

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -1,7 +1,79 @@
+import { Ajv2020 } from "ajv/dist/2020.js"
+import type { ErrorObject } from "ajv"
+
+import type { WorkspaceRecipe, WorkspaceRecipeDeclaredArtifact, WorkspaceRecipeTypedArtifact } from "./runtime-contracts.js"
+
 export type WorkspaceRecipeJsonSchema = Record<string, unknown>
 
 export interface WorkspaceRecipeJsonSchemaOptions {
   recipeCommandIds?: readonly string[]
+}
+
+export interface WorkspaceRecipeJsonSchemaValidationIssue {
+  path: string
+  keyword: string
+  message: string
+}
+
+export interface WorkspaceRecipeJsonSchemaValidationResult {
+  valid: boolean
+  issues: WorkspaceRecipeJsonSchemaValidationIssue[]
+}
+
+export interface AssertWorkspaceRecipeJsonSchemaOptions extends WorkspaceRecipeJsonSchemaOptions {
+  recipePath?: string
+}
+
+export type WorkspaceRecipeRuntimeCollectedArtifact =
+  | { kind: "path"; index: number; artifact: WorkspaceRecipeDeclaredArtifact }
+  | { kind: "typed"; index: number; artifact: WorkspaceRecipeTypedArtifact }
+
+export function validateWorkspaceRecipeJsonSchema(recipe: unknown, options: WorkspaceRecipeJsonSchemaOptions = {}): WorkspaceRecipeJsonSchemaValidationResult {
+  const validate = new Ajv2020({ strict: false }).compile(createWorkspaceRecipeJsonSchema(options))
+  const valid = validate(recipe) === true
+  return {
+    valid,
+    issues: valid ? [] : workspaceRecipeJsonSchemaIssues(validate.errors ?? []),
+  }
+}
+
+export function assertWorkspaceRecipeJsonSchema(recipe: unknown, options: AssertWorkspaceRecipeJsonSchemaOptions = {}): asserts recipe is WorkspaceRecipe {
+  const result = validateWorkspaceRecipeJsonSchema(recipe, options)
+  if (result.valid) {
+    return
+  }
+
+  const location = options.recipePath ? ` in ${options.recipePath}` : ""
+  const details = result.issues.map((issue) => `${issue.path} ${issue.message}`).join("; ")
+  throw new Error(`Recipe JSON schema validation failed${location}: ${details}`)
+}
+
+export function workspaceRecipeRuntimeCollectedArtifacts(recipe: WorkspaceRecipe): WorkspaceRecipeRuntimeCollectedArtifact[] {
+  const paths = recipe.artifacts?.paths ?? []
+  return [
+    ...paths.map((artifact, index): WorkspaceRecipeRuntimeCollectedArtifact => ({ kind: "path", index, artifact })),
+    ...(recipe.artifacts?.typed ?? []).map((artifact, index): WorkspaceRecipeRuntimeCollectedArtifact => ({ kind: "typed", index: paths.length + index, artifact })),
+  ]
+}
+
+function workspaceRecipeJsonSchemaIssues(errors: ErrorObject[]): WorkspaceRecipeJsonSchemaValidationIssue[] {
+  return errors.map((error) => ({
+    path: jsonPointerToJsonPath(error.instancePath, error),
+    keyword: error.keyword,
+    message: error.message ?? `failed ${error.keyword} validation`,
+  }))
+}
+
+function jsonPointerToJsonPath(pointer: string, error: ErrorObject): string {
+  const segments = pointer.split("/").filter(Boolean).map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"))
+  if (error.keyword === "required" && typeof error.params.missingProperty === "string") {
+    segments.push(error.params.missingProperty)
+  }
+  let path = "$"
+  for (const segment of segments) {
+    path += /^\d+$/.test(segment) ? `[${segment}]` : `.${segment}`
+  }
+  return path
 }
 
 export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSchemaOptions = {}): WorkspaceRecipeJsonSchema {

--- a/scripts/recipe-artifacts-policy-smoke.ts
+++ b/scripts/recipe-artifacts-policy-smoke.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict"
+import { parseWorkspaceRecipe, recipePolicy } from "../packages/cli/src/recipe-validation.js"
+
+const recipePath = "/tmp/wp-codebox-artifacts-policy-recipe.json"
+
+assert.throws(
+  () => parseWorkspaceRecipe(JSON.stringify({
+    schema: "wp-codebox/workspace-recipe/v1",
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+    artifacts: {
+      typed: [{ name: "summary", path: "/tmp/summary.json" }],
+    },
+  }), recipePath),
+  (error) => {
+    assert.ok(error instanceof Error)
+    assert.match(error.message, /Recipe JSON schema validation failed/)
+    assert.match(error.message, /\$\.artifacts\.typed\[0\]\.type/)
+    return true
+  },
+)
+
+const typedOnlyRecipe = parseWorkspaceRecipe(JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  artifacts: {
+    typed: [{ name: "summary", type: "example.summary", path: "/tmp/summary.json" }],
+  },
+}), recipePath)
+
+assert.equal(recipePolicy(typedOnlyRecipe).commands.includes("wordpress.run-php"), true)
+
+console.log("Recipe artifacts policy smoke passed")


### PR DESCRIPTION
## Summary
- Validate ingested workspace recipes against the shared runtime-core JSON schema.
- Add a shared runtime-collected artifact helper that covers both declared path artifacts and typed artifacts.
- Use that helper for recipe artifact collection and policy granting so typed-only artifacts authorize wordpress.run-php.
- Add focused smoke coverage for malformed artifacts.typed and typed-only policy granting.

## Tests
- npm install --package-lock-only (ran prepare/build)
- npx tsx scripts/recipe-artifacts-policy-smoke.ts
- npx tsx scripts/typed-artifacts-smoke.ts
- npx tsx scripts/runtime-overlay-validation-smoke.ts
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by agent, reviewed via targeted verification