### PR TITLE
Make transfer proof private hosts configurable

### DIFF
--- a/docs/transfer-readiness-checklist.md
+++ b/docs/transfer-readiness-checklist.md
@@ -217,6 +217,11 @@ Transfer checklist:
 - Secrets should be passed by environment-variable name or connector reference,
   redacted from recipes, logs, metadata, patches, and review files, and excluded
   from artifact provenance except for sanitized availability/status metadata.
+- Transfer-proof reviewer evidence treats localhost, private-network, and common
+  internal host suffixes as unsafe by default. Parent control planes with
+  organization-private public DNS names should pass caller-owned private host
+  patterns, for example `WP_CODEBOX_TRANSFER_PROOF_PRIVATE_HOSTS=github.a8c.com`
+  or `wp-codebox artifacts transfer-verify --private-host-pattern github.a8c.com`.
 - Generated browser runners that bypass host permission checks must assert they
   are executing inside a disposable Playground runtime before registering the
   bypass.

--- a/packages/cli/src/commands/artifacts.ts
+++ b/packages/cli/src/commands/artifacts.ts
@@ -8,6 +8,7 @@ import { printArtifactVerifyHumanOutput } from "../output.js"
 interface ArtifactVerifyOptions {
   bundleDirectory: string
   json: boolean
+  privateHostPatterns?: string[]
 }
 
 interface ArtifactApplyPreflightOptions extends ArtifactVerifyOptions {
@@ -186,7 +187,7 @@ async function browserMetrics(options: ArtifactVerifyOptions): Promise<BrowserAr
 }
 
 async function transferVerify(options: ArtifactVerifyOptions): Promise<TransferProofBundleVerificationResult> {
-  return verifyTransferProofBundle(resolve(options.bundleDirectory))
+  return verifyTransferProofBundle(resolve(options.bundleDirectory), { privateHostPatterns: options.privateHostPatterns })
 }
 
 async function transferProbes(options: ArtifactVerifyOptions): Promise<TransferProbeDiagnosticsResult> {
@@ -632,6 +633,14 @@ function parseArtifactVerifyOptions(args: string[]): ArtifactVerifyOptions {
       case "--bundle":
       case "--artifacts":
         options.bundleDirectory = value
+        break
+      case "--private-host-pattern":
+        options.privateHostPatterns ??= []
+        options.privateHostPatterns?.push(value)
+        break
+      case "--private-host-patterns":
+        options.privateHostPatterns ??= []
+        options.privateHostPatterns?.push(...value.split(",").map((pattern) => pattern.trim()).filter(Boolean))
         break
       default:
         throw new Error(`Unknown option: ${name}`)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -272,7 +272,7 @@ export function printHelp(): void {
   wp-codebox artifacts apply-preflight --bundle <dir> --approved-file <path> [--json]
   wp-codebox artifacts browser-metrics --bundle <dir> [--json]
   wp-codebox artifacts diagnostics --input <json> [--source <id>] [--stage <id>] [--observation-type <id>] [--ref <path[:kind]>] [--json]
-  wp-codebox artifacts transfer-verify --bundle <dir> [--json]
+  wp-codebox artifacts transfer-verify --bundle <dir> [--private-host-pattern <host>] [--json]
   wp-codebox artifacts transfer-probes --bundle <dir> [--json]
   wp-codebox artifacts discover-partial --artifacts <dir> [--session-id <id>] [--started-at <iso>] [--finished-at <iso>] [--json]
   wp-codebox artifacts benchmark --bundle <dir> [--scenario-id <id>] [--extract-to <dir>] [--json]
@@ -305,7 +305,11 @@ Options:
   --approved-file <path>
                        Changed file approved for artifacts apply-preflight. Repeatable.
   --approved-files <paths>
-                       Comma-separated changed files approved for artifacts apply-preflight.
+                        Comma-separated changed files approved for artifacts apply-preflight.
+  --private-host-pattern <host>
+                       Host pattern treated as private reviewer evidence for transfer-verify.
+                       Repeatable; supports exact hosts and *.suffix patterns. Can also be set with
+                       WP_CODEBOX_TRANSFER_PROOF_PRIVATE_HOSTS.
   --scenario-id <id>  Filter benchmark artifact refs to one scenario.
   --extract-to <dir>  Copy listed benchmark artifact refs to a directory.
   --input <path>      Saved recipe-run JSON output for benchmark summarization.

--- a/packages/runtime-core/src/transfer-proof.ts
+++ b/packages/runtime-core/src/transfer-proof.ts
@@ -74,6 +74,10 @@ export interface TransferProofBundleVerificationResult {
   diagnostics: TransferProbeDiagnosticsResult
 }
 
+export interface TransferProofVerificationOptions {
+  privateHostPatterns?: string[]
+}
+
 export type TransferProbeDiagnosticCode =
   | "page-unavailable"
   | "broken-link"
@@ -138,8 +142,9 @@ const REVIEWER_EVIDENCE_KINDS = new Set([
   "probe-results",
 ])
 
-export async function verifyTransferProofBundle(directory: string): Promise<TransferProofBundleVerificationResult> {
+export async function verifyTransferProofBundle(directory: string, options: TransferProofVerificationOptions = {}): Promise<TransferProofBundleVerificationResult> {
   const bundleDirectory = normalize(directory)
+  const resolvedOptions = resolveTransferProofVerificationOptions(options)
   const artifactVerification = await verifyArtifactBundle(bundleDirectory)
   const diagnostics = await buildTransferProbeDiagnostics(bundleDirectory, artifactVerification.manifest)
   const violations: TransferProofViolation[] = artifactVerification.valid ? [] : artifactVerification.violations.map(artifactViolationToTransferViolation)
@@ -147,8 +152,8 @@ export async function verifyTransferProofBundle(directory: string): Promise<Tran
   if (artifactVerification.manifest) {
     verifyRequiredTransferArtifacts(artifactVerification.manifest, violations)
     await verifyPreviewSessionEvidenceRef(bundleDirectory, artifactVerification.manifest, violations)
-    await verifyTransferProofMetadata(bundleDirectory, artifactVerification.manifest, violations)
-    await verifyReviewerEvidenceSafety(bundleDirectory, artifactVerification.manifest, violations)
+    await verifyTransferProofMetadata(bundleDirectory, artifactVerification.manifest, violations, resolvedOptions)
+    await verifyReviewerEvidenceSafety(bundleDirectory, artifactVerification.manifest, violations, resolvedOptions)
   }
 
   return {
@@ -242,14 +247,24 @@ function verifyRequiredTransferArtifacts(manifest: ArtifactManifest, violations:
   }
 }
 
-async function verifyTransferProofMetadata(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[]): Promise<void> {
+function resolveTransferProofVerificationOptions(options: TransferProofVerificationOptions): Required<TransferProofVerificationOptions> {
+  return {
+    privateHostPatterns: options.privateHostPatterns ?? parsePrivateHostPatterns(process.env.WP_CODEBOX_TRANSFER_PROOF_PRIVATE_HOSTS),
+  }
+}
+
+function parsePrivateHostPatterns(value: string | undefined): string[] {
+  return value?.split(",").map((pattern) => pattern.trim()).filter(Boolean) ?? []
+}
+
+async function verifyTransferProofMetadata(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[], options: Required<TransferProofVerificationOptions>): Promise<void> {
   const metadata = await readJson(join(directory, "metadata.json"))
   const transferProofBundle = isRecord(metadata) && isRecord(metadata.transferProofBundle) ? metadata.transferProofBundle : undefined
   if (!transferProofBundle) {
     return
   }
 
-  for (const finding of unsafeReviewerEvidenceFindings(`${JSON.stringify(transferProofBundle, null, 2)}\n`, "metadata.json")) {
+  for (const finding of unsafeReviewerEvidenceFindings(`${JSON.stringify(transferProofBundle, null, 2)}\n`, "metadata.json", options)) {
     violations.push(finding)
   }
 
@@ -366,19 +381,19 @@ async function verifyPreviewSessionEvidenceRef(directory: string, manifest: Arti
   }
 }
 
-async function verifyReviewerEvidenceSafety(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[]): Promise<void> {
+async function verifyReviewerEvidenceSafety(directory: string, manifest: ArtifactManifest, violations: TransferProofViolation[], options: Required<TransferProofVerificationOptions>): Promise<void> {
   for (const file of manifest.files) {
     if (!REVIEWER_EVIDENCE_KINDS.has(file.kind)) {
       continue
     }
     const text = await readFile(join(directory, file.path), "utf8")
-    for (const finding of unsafeReviewerEvidenceFindings(text, file.path)) {
+    for (const finding of unsafeReviewerEvidenceFindings(text, file.path, options)) {
       violations.push(finding)
     }
   }
 }
 
-function unsafeReviewerEvidenceFindings(text: string, file: string): TransferProofViolation[] {
+function unsafeReviewerEvidenceFindings(text: string, file: string, options: Required<TransferProofVerificationOptions>): TransferProofViolation[] {
   const findings: TransferProofViolation[] = []
   let parsed: unknown
   try {
@@ -388,36 +403,36 @@ function unsafeReviewerEvidenceFindings(text: string, file: string): TransferPro
   }
 
   if (parsed !== undefined) {
-    walkReviewerEvidence(parsed, [], file, findings)
+    walkReviewerEvidence(parsed, [], file, findings, options)
   } else {
     for (const [index, line] of text.split(/\r?\n/).entries()) {
-      scanReviewerEvidenceString(line, [`line:${index + 1}`], file, findings)
+      scanReviewerEvidenceString(line, [`line:${index + 1}`], file, findings, options)
     }
   }
   return findings
 }
 
-function walkReviewerEvidence(value: unknown, path: JsonPath, file: string, findings: TransferProofViolation[]): void {
+function walkReviewerEvidence(value: unknown, path: JsonPath, file: string, findings: TransferProofViolation[], options: Required<TransferProofVerificationOptions>): void {
   if (typeof value === "string") {
-    scanReviewerEvidenceString(value, path, file, findings)
+    scanReviewerEvidenceString(value, path, file, findings, options)
     if (isSecretKeyPath(path) && !isRedactedSecretValue(value)) {
       findings.push(unsafeFinding(file, path, "secret-shaped value", "Reviewer-facing evidence includes a secret-shaped field value."))
     }
     return
   }
   if (Array.isArray(value)) {
-    value.forEach((item, index) => walkReviewerEvidence(item, [...path, index], file, findings))
+    value.forEach((item, index) => walkReviewerEvidence(item, [...path, index], file, findings, options))
     return
   }
   if (isRecord(value)) {
     for (const [key, item] of Object.entries(value)) {
-      walkReviewerEvidence(item, [...path, key], file, findings)
+      walkReviewerEvidence(item, [...path, key], file, findings, options)
     }
   }
 }
 
-function scanReviewerEvidenceString(value: string, path: JsonPath, file: string, findings: TransferProofViolation[]): void {
-  if (unsafeUrl(value)) {
+function scanReviewerEvidenceString(value: string, path: JsonPath, file: string, findings: TransferProofViolation[], options: Required<TransferProofVerificationOptions>): void {
+  if (unsafeUrl(value, options)) {
     findings.push(unsafeFinding(file, path, "unsafe URL", "Reviewer-facing evidence includes a localhost, local, or private URL."))
   }
   if (unsafeLocalPath(value)) {
@@ -432,7 +447,7 @@ function unsafeFinding(file: string, path: JsonPath, kind: string, message: stri
   return { code: "unsafe-reviewer-evidence", path: `${file}:${formatJsonPath(path)}`, file, message, details: { kind } }
 }
 
-function unsafeUrl(value: string): boolean {
+function unsafeUrl(value: string, options: Required<TransferProofVerificationOptions>): boolean {
   const matches = value.matchAll(/\b(?:https?|file):\/\/[^\s"'<>]+/gi)
   for (const match of matches) {
     try {
@@ -441,11 +456,31 @@ function unsafeUrl(value: string): boolean {
       if (url.protocol === "file:" || host === "localhost" || host === "0.0.0.0" || host === "127.0.0.1" || host === "::1") {
         return true
       }
-      if (/^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host) || host.endsWith(".local") || host.endsWith(".internal") || host.endsWith(".corp") || host.endsWith(".lan") || host === "github.a8c.com") {
+      if (/^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[0-1])\.)/.test(host) || host.endsWith(".local") || host.endsWith(".internal") || host.endsWith(".corp") || host.endsWith(".lan") || privateHostPatternMatches(host, options.privateHostPatterns)) {
         return true
       }
     } catch {
       continue
+    }
+  }
+  return false
+}
+
+function privateHostPatternMatches(host: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    const normalized = pattern.trim().toLowerCase()
+    if (!normalized) {
+      continue
+    }
+    if (normalized.startsWith("*.")) {
+      const suffix = normalized.slice(1)
+      if (host.endsWith(suffix) && host.length > suffix.length) {
+        return true
+      }
+      continue
+    }
+    if (host === normalized) {
+      return true
     }
   }
   return false

--- a/scripts/transfer-proof-smoke.ts
+++ b/scripts/transfer-proof-smoke.ts
@@ -56,6 +56,25 @@ try {
   assert.equal(unsafeResult.valid, false)
   assert.ok(unsafeResult.violations.some((violation) => violation.code === "unsafe-reviewer-evidence"), unsafeResult.violations.map((violation) => violation.code).join(", "))
 
+  const callerPrivateHost = await copyBundle(validBundle, join(workspace, "caller-private-host"))
+  const callerPrivateHostMetadata = JSON.parse(await readText(join(callerPrivateHost, "metadata.json")))
+  callerPrivateHostMetadata.transferProofBundle.summary = "Caller-private proof URL: https://github.a8c.com/Automattic/wp-codebox/pull/1"
+  await writeJson(join(callerPrivateHost, "metadata.json"), callerPrivateHostMetadata)
+  await rewriteManifestHashes(callerPrivateHost)
+  const callerPrivateHostDefaultResult = await verifyTransferProofBundle(callerPrivateHost)
+  assert.equal(callerPrivateHostDefaultResult.valid, true)
+  const callerPrivateHostConfiguredResult = await verifyTransferProofBundle(callerPrivateHost, { privateHostPatterns: ["github.a8c.com"] })
+  assert.equal(callerPrivateHostConfiguredResult.valid, false)
+  assert.ok(callerPrivateHostConfiguredResult.violations.some((violation) => violation.code === "unsafe-reviewer-evidence"), callerPrivateHostConfiguredResult.violations.map((violation) => violation.code).join(", "))
+
+  const unrelatedPublicHost = await copyBundle(validBundle, join(workspace, "unrelated-public-host"))
+  const unrelatedPublicHostMetadata = JSON.parse(await readText(join(unrelatedPublicHost, "metadata.json")))
+  unrelatedPublicHostMetadata.transferProofBundle.summary = "Public proof URL: https://github.com/Automattic/wp-codebox/pull/1"
+  await writeJson(join(unrelatedPublicHost, "metadata.json"), unrelatedPublicHostMetadata)
+  await rewriteManifestHashes(unrelatedPublicHost)
+  const unrelatedPublicHostResult = await verifyTransferProofBundle(unrelatedPublicHost, { privateHostPatterns: ["github.a8c.com"] })
+  assert.equal(unrelatedPublicHostResult.valid, true)
+
   const broken = await copyBundle(validBundle, join(workspace, "broken"))
   await writeFile(join(broken, "files/browser/network.jsonl"), `${JSON.stringify({ type: "response", url: "https://example.com/missing.png", resourceType: "image", status: 404 })}\n`)
   await rewriteManifestHashes(broken)


### PR DESCRIPTION
## Summary
- Removes the Automattic-specific `github.a8c.com` unsafe reviewer-evidence host from runtime-core defaults.
- Adds caller-configurable transfer-proof private host patterns through core options, CLI flags, and `WP_CODEBOX_TRANSFER_PROOF_PRIVATE_HOSTS`.
- Documents `github.a8c.com` as caller-owned example policy and expands transfer-proof smoke coverage.

## Testing
- `npm run build`
- `npx tsx scripts/transfer-proof-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation and tests drafted by agent, reviewed via targeted verification.