### PR TITLE
Fix backend registry schema validation

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "node:path"
 import { assertWorkspaceRecipeJsonSchema, validateBrowserInteractionScript, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
+import { listCliRuntimeBackendKinds } from "./runtime-backends.js"
 
 export interface RecipeValidationIssue {
   code: string
@@ -34,7 +35,7 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   const recipe = parseWorkspaceRecipeJson(raw)
   normalizeWorkspaceRecipeCompatibility(recipe)
   validateWorkspaceRecipeShape(recipe, recipePath)
-  assertWorkspaceRecipeJsonSchema(recipe, { recipePath, recipeCommandIds: [...supportedRecipeCommands] })
+  assertWorkspaceRecipeJsonSchema(recipe, { recipePath, recipeCommandIds: [...supportedRecipeCommands], runtimeBackendKinds: listCliRuntimeBackendKinds() })
 
   return recipe
 }

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util"
 import { createWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { commandRegistry, recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import Ajv2020 from "ajv/dist/2020.js"
+import { listCliRuntimeBackendKinds } from "../packages/cli/src/runtime-backends.js"
 
 const execFileAsync = promisify(execFile)
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")


### PR DESCRIPTION
## Summary
- Import the CLI backend registry helper in the discovery smoke test so the post-merge schema parity check runs.
- Pass CLI runtime backend kinds into recipe schema validation during recipe ingestion, matching the schema exposed by discovery.

## Verification
- npm run build
- npx tsx scripts/discovery-command-smoke.ts
- npx tsx scripts/runtime-backend-registry-smoke.ts
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Post-merge verification, follow-up fix, and targeted test runs drafted by agent; Chris remains responsible for review and merge.