### PR TITLE
Extract prepared source staging primitive

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -6,7 +6,7 @@ import { basename, dirname, join, relative, resolve } from "node:path"
 import { promisify } from "node:util"
 import type { MountSpec, WorkspaceRecipe, WorkspaceRecipeDependencyOverlay, WorkspaceRecipeExtraPlugin, WorkspaceRecipeRuntimeOverlay, WorkspaceRecipeStagedFile, WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { resolvePluginEntrypointContract } from "@automattic/wp-codebox-core"
-import { SANDBOX_WORKSPACE_ROOT } from "@automattic/wp-codebox-core/internals"
+import { collectPreparedSourceCleanupPaths, localPreparedSourceProvenance, prepareLocalSourceStageSync, SANDBOX_WORKSPACE_ROOT, type PreparedSourceProvenance } from "@automattic/wp-codebox-core/internals"
 
 export interface PreparedWorkspaceMount {
   source: string
@@ -63,11 +63,7 @@ export interface PreparedExtraPlugin {
 
 type BootActivePluginCandidate = Pick<PreparedExtraPlugin, "pluginFile" | "activate" | "loadAs">
 
-export interface RecipeStagedFileProvenance {
-  kind: "local"
-  original: string
-  localPathCategory?: "recipe-relative"
-}
+export type RecipeStagedFileProvenance = PreparedSourceProvenance
 
 export interface PreparedStagedFile {
   source: string
@@ -264,13 +260,8 @@ async function cleanupRecipeWorkspaces(workspaces: PreparedWorkspaceMount[]): Pr
 }
 
 export async function cleanupRecipePreparedSources(workspaces: PreparedWorkspaceMount[], extraPlugins: PreparedExtraPlugin[], stagedFiles: PreparedStagedFile[] = [], overlays: PreparedRuntimeOverlay[] = [], dependencyOverlays: PreparedDependencyOverlay[] = []): Promise<void> {
-  await Promise.all([
-    cleanupRecipeWorkspaces(workspaces),
-    ...extraPlugins.flatMap((plugin) => plugin.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
-    ...stagedFiles.flatMap((stagedFile) => stagedFile.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
-    ...overlays.flatMap((overlay) => overlay.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
-    ...dependencyOverlays.flatMap((overlay) => overlay.cleanupPaths).map((path) => rm(path, { recursive: true, force: true })),
-  ])
+  const cleanupPaths = collectPreparedSourceCleanupPaths(extraPlugins, stagedFiles, overlays, dependencyOverlays)
+  await Promise.all([cleanupRecipeWorkspaces(workspaces), ...cleanupPaths.map((path) => rm(path, { recursive: true, force: true }))])
 }
 
 export async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedExtraPlugin[]> {
@@ -404,16 +395,21 @@ export async function prepareRecipeStagedFiles(recipe: WorkspaceRecipe, recipeDi
     const originalSource = resolve(recipeDirectory, stagedFile.source)
     const type = await stagedFileMountType(originalSource)
     const stagingRoot = await mkdtemp(join(tmpdir(), "wp-codebox-staged-file-"))
-    const stagedSource = join(stagingRoot, basename(originalSource))
-    await cp(originalSource, stagedSource, { recursive: type === "directory" })
+    const staged = prepareLocalSourceStageSync({
+      source: originalSource,
+      sourceRef: stagedFile.source,
+      targetRoot: stagingRoot,
+      recipeDirectory,
+      excludeNames: [],
+    })
     const provenance = stagedFileProvenance(stagedFile, recipeDirectory)
     stagedFiles.push({
-      source: stagedSource,
+      source: staged.source,
       originalSource,
       sourceRef: stagedFile.source,
       target: stagedFile.target,
       type,
-      cleanupPaths: [stagingRoot],
+      cleanupPaths: staged.cleanupPaths,
       provenance,
       metadata: {
         kind: "staged-file",
@@ -498,11 +494,14 @@ async function prepareComposerBackedSource(source: string, stagingRoot: string, 
     throw new Error(`Composer-backed ${label} source has no vendor directory, and Composer is not available to hydrate dependencies. Run composer install in ${source}, or install Composer on PATH before running WP Codebox.`)
   }
 
-  const hydratedSource = join(stagingRoot, "composer-source")
-  await cp(source, hydratedSource, {
-    recursive: true,
-    filter: (entry) => !workspaceSeedExcludeMatches(relative(source, entry), "vendor"),
+  const staged = prepareLocalSourceStageSync({
+    source,
+    targetRoot: stagingRoot,
+    targetName: "composer-source",
+    cleanupRoot: false,
+    excludeNames: ["vendor"],
   })
+  const hydratedSource = staged.source
 
   try {
     await execFileAsync(composer, ["install", "--working-dir", hydratedSource, "--no-dev", "--no-interaction", "--no-progress", "--prefer-dist", "--classmap-authoritative"])
@@ -849,11 +848,7 @@ export async function recipeMountType(source: string, explicitType?: MountSpec["
 }
 
 export function stagedFileProvenance(stagedFile: WorkspaceRecipeStagedFile, recipeDirectory: string): RecipeStagedFileProvenance {
-  return {
-    kind: "local",
-    original: stagedFile.source,
-    localPathCategory: resolve(recipeDirectory, stagedFile.source).startsWith(recipeDirectory) ? "recipe-relative" : undefined,
-  }
+  return localPreparedSourceProvenance(stagedFile.source, recipeDirectory)
 }
 
 async function assertPreparedPluginFileExists(sourceDirectory: string, pluginFileRelativeToSource: string, sourceRef: string): Promise<void> {

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -1,12 +1,13 @@
 import { spawnSync } from "node:child_process"
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs"
-import { basename, join, resolve } from "node:path"
+import { existsSync, mkdirSync, readFileSync } from "node:fs"
+import { join, resolve } from "node:path"
 import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import type { StructuredArtifactPayload } from "./structured-artifacts.js"
 import type { TaskInput } from "./task-input.js"
 import { isPlainObject, stringList, stripUndefined } from "./object-utils.js"
 import type { WorkspaceRecipe, WorkspaceRecipeMount, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
 import { resolvePluginEntrypointContract, sanitizePluginSlug } from "./component-contracts.js"
+import { prepareLocalSourceStageSync, preparedSourcePath, preparedSourceRoot } from "./prepared-source-staging.js"
 
 const AGENT_RUNTIME_ENV = { WP_AGENT_RUNTIME: "1" }
 
@@ -253,9 +254,13 @@ function prepareComponentPluginSource(source: string, originalSource: string, sl
   }
 
   if (resolve(copySource) !== resolve(preparedSource)) {
-    rmSyncSafe(preparedSource)
-    mkdirSyncSafe(preparedPluginRoot(artifactsRoot))
-    cpSyncFiltered(copySource, preparedSource)
+    prepareLocalSourceStageSync({
+      source: copySource,
+      sourceRef: originalSource || source,
+      targetRoot: preparedPluginRoot(artifactsRoot),
+      targetName: slug,
+      cleanupRoot: false,
+    })
   } else {
     mkdirSyncSafe(preparedSource)
   }
@@ -280,9 +285,13 @@ function prepareComposerPluginSource(source: string, slug: string, artifactsRoot
   const preparedRoot = preparedPluginRoot(artifactsRoot)
   const preparedSource = preparedPluginSource(artifactsRoot, slug)
   if (resolve(localSource) !== resolve(preparedSource)) {
-    rmSyncSafe(preparedSource)
-    mkdirSyncSafe(preparedRoot)
-    cpSyncFiltered(localSource, preparedSource)
+    prepareLocalSourceStageSync({
+      source: localSource,
+      sourceRef: source,
+      targetRoot: preparedRoot,
+      targetName: slug,
+      cleanupRoot: false,
+    })
   } else {
     mkdirSyncSafe(preparedSource)
   }
@@ -310,11 +319,11 @@ function installComposerDependenciesIfNeeded(source: string, slug: string): stri
 }
 
 function preparedPluginRoot(artifactsRoot: string): string {
-  return resolve(artifactsRoot, "prepared-plugins")
+  return preparedSourceRoot(artifactsRoot, "prepared-plugins")
 }
 
 function preparedPluginSource(artifactsRoot: string, slug: string): string {
-  return join(preparedPluginRoot(artifactsRoot), slug)
+  return preparedSourcePath(artifactsRoot, "prepared-plugins", slug)
 }
 
 function localSourcePath(source: string): string {
@@ -325,22 +334,8 @@ function pathExists(filePath: string): boolean {
   return existsSync(filePath)
 }
 
-function rmSyncSafe(filePath: string): void {
-  rmSync(filePath, { recursive: true, force: true })
-}
-
 function mkdirSyncSafe(filePath: string): void {
   mkdirSync(filePath, { recursive: true })
-}
-
-function cpSyncFiltered(source: string, target: string): void {
-  cpSync(source, target, {
-    recursive: true,
-    filter: (entry: string) => {
-      const base = basename(entry)
-      return base !== ".git" && base !== "node_modules" && base !== "vendor"
-    },
-  })
 }
 
 function sandboxToolPolicy(input: AgentTaskRunInput, taskInput: TaskInput): SandboxToolPolicySnapshot {

--- a/packages/runtime-core/src/internals.ts
+++ b/packages/runtime-core/src/internals.ts
@@ -1,4 +1,5 @@
 export * from "./benchmark-substrate.js"
 export * from "./fanout-aggregation.js"
 export * from "./object-utils.js"
+export * from "./prepared-source-staging.js"
 export * from "./runtime-action-adapter.js"

--- a/packages/runtime-core/src/prepared-source-staging.ts
+++ b/packages/runtime-core/src/prepared-source-staging.ts
@@ -1,0 +1,81 @@
+import { cpSync, mkdirSync, rmSync } from "node:fs"
+import { basename, join, relative, resolve } from "node:path"
+
+export interface PreparedSourceStage {
+  source: string
+  sourceRef: string
+  originalSource: string
+  root: string
+  cleanupPaths: string[]
+  provenance: PreparedSourceProvenance
+}
+
+export interface PreparedSourceProvenance {
+  kind: "local"
+  original: string
+  localPathCategory?: "recipe-relative" | "temporary-download" | "temporary-composer-autoload" | "prepared-artifact"
+}
+
+export interface PrepareLocalSourceStageOptions {
+  source: string
+  sourceRef?: string
+  targetRoot: string
+  targetName?: string
+  recipeDirectory?: string
+  cleanupRoot?: boolean
+  excludeNames?: string[]
+}
+
+export const DEFAULT_PREPARED_SOURCE_EXCLUDE_NAMES = [".git", "node_modules", "vendor"]
+
+export function prepareLocalSourceStageSync(options: PrepareLocalSourceStageOptions): PreparedSourceStage {
+  const source = resolve(options.source)
+  const sourceRef = options.sourceRef ?? options.source
+  const root = resolve(options.targetRoot)
+  const target = join(root, options.targetName ?? basename(source))
+  if (resolve(source) !== resolve(target)) {
+    rmSync(target, { recursive: true, force: true })
+    mkdirSync(root, { recursive: true })
+    copyPreparedSourceFilteredSync(source, target, options.excludeNames)
+  } else {
+    mkdirSync(target, { recursive: true })
+  }
+
+  return {
+    source: target,
+    sourceRef,
+    originalSource: source,
+    root,
+    cleanupPaths: options.cleanupRoot === false ? [] : [root],
+    provenance: localPreparedSourceProvenance(sourceRef, options.recipeDirectory),
+  }
+}
+
+export function copyPreparedSourceFilteredSync(source: string, target: string, excludeNames: string[] = DEFAULT_PREPARED_SOURCE_EXCLUDE_NAMES): void {
+  const excluded = new Set(excludeNames)
+  cpSync(source, target, {
+    recursive: true,
+    filter: (entry: string) => !excluded.has(basename(entry)),
+  })
+}
+
+export function preparedSourceRoot(artifactsRoot: string, directoryName: string): string {
+  return resolve(artifactsRoot, directoryName)
+}
+
+export function preparedSourcePath(artifactsRoot: string, directoryName: string, slug: string): string {
+  return join(preparedSourceRoot(artifactsRoot, directoryName), slug)
+}
+
+export function localPreparedSourceProvenance(sourceRef: string, recipeDirectory?: string): PreparedSourceProvenance {
+  const relativeSource = recipeDirectory ? relative(resolve(recipeDirectory), resolve(recipeDirectory, sourceRef)) : ""
+  return {
+    kind: "local",
+    original: sourceRef,
+    localPathCategory: recipeDirectory && (relativeSource === "" || !relativeSource.startsWith("..")) ? "recipe-relative" : undefined,
+  }
+}
+
+export function collectPreparedSourceCleanupPaths(...groups: Array<Array<{ cleanupPaths: string[] }>>): string[] {
+  return groups.flatMap((group) => group.flatMap((entry) => entry.cleanupPaths))
+}

--- a/scripts/component-contracts-agent-task-smoke.ts
+++ b/scripts/component-contracts-agent-task-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { buildAgentTaskRecipe } from "../packages/runtime-core/src/agent-task-recipe.js"
@@ -39,6 +39,9 @@ try {
   assert.equal(domain?.metadata?.componentContract?.requestedPath, domainPlugin)
   assert.equal(domain?.metadata?.componentContract?.preparedPath, domain?.source)
   assert.equal(domain?.metadata?.componentContract?.pluginFile, "domain-component/domain-component.php")
+  assert.equal(existsSync(join(String(domain?.source), ".git")), false, "prepared component source should exclude VCS metadata")
+  assert.equal(existsSync(join(String(domain?.source), "node_modules")), false, "prepared component source should exclude Node dependencies")
+  assert.equal(existsSync(join(String(domain?.source), "vendor")), false, "prepared component source should exclude Composer dependencies before hydration")
   assert.equal(runtime?.metadata?.componentContract?.requestedPath, runtimePlugin)
   assert.equal(runtime?.metadata?.componentContract?.preparedPath, runtime?.source)
   assert.equal(runtime?.metadata?.componentContract?.pluginFile, "runtime-component/runtime-component.php")
@@ -89,6 +92,9 @@ try {
 function writePlugin(rootPath: string, slug: string, name: string): string {
   const pluginPath = join(rootPath, slug)
   mkdirSync(pluginPath, { recursive: true })
+  mkdirSync(join(pluginPath, ".git"), { recursive: true })
+  mkdirSync(join(pluginPath, "node_modules"), { recursive: true })
+  mkdirSync(join(pluginPath, "vendor"), { recursive: true })
   writeFileSync(join(pluginPath, `${slug}.php`), `<?php
 /**
  * Plugin Name: ${name}


### PR DESCRIPTION
## Summary
- Add a generic prepared source staging primitive in runtime-core internals for local source copy, prepared paths, provenance, and cleanup path collection.
- Reuse the primitive from agent-task component/provider plugin staging and recipe source preparation while preserving each path's existing filtering semantics.
- Cover the agent-task filtered staging behavior in the component-contract smoke test.

## Tests
- `npm run build`
- `npx tsx scripts/component-contracts-agent-task-smoke.ts`
- `npx tsx scripts/composer-backed-source-hydration-smoke.ts`
- `npx tsx scripts/source-checkout-entrypoint-smoke.ts`

## Follow-up
Host-side component preparation that is specific to Homeboy component workflows should live upstream in Homeboy Extensions. This PR keeps WP Codebox limited to generic prepared-source staging primitives and does not add Homeboy-specific preparation logic.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, targeted smoke-test update, and PR description; Chris remains responsible for review and validation.