### PR TITLE
Centralize artifact redaction writes

### DIFF
--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -51,6 +51,7 @@ import { buildRuntimeReferenceIndex } from "./runtime-reference-index.js"
 import { buildReplayableWordPressSiteBlueprint, buildReplayableWordPressSiteLimitations } from "./replayable-wordpress-site-bundle.js"
 import { runtimeSnapshotPayload, type RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
 import { previewReviewerAccess } from "./preview-reviewer-access.js"
+import { artifactJsonLines, writeRedactedArtifactFile } from "./artifact-bundle-writer.js"
 
 export interface ArtifactBundleBuilderSource {
   artifactRoot: string
@@ -718,15 +719,11 @@ function isLocalPreviewHost(hostname: string): boolean {
 }
 
 async function writeJsonLines(path: string, records: unknown[], redactor: ArtifactRedactor, artifactRoot: string): Promise<void> {
-  await writeRedactedArtifact(redactor, path, artifactRoot, records.length > 0 ? `${records.map((record) => artifactJsonLine(record)).join("\n")}\n` : "")
+  await writeRedactedArtifact(redactor, path, artifactRoot, artifactJsonLines(records.map((record) => normalizeJsonValue(record))))
 }
 
 function artifactJson(value: unknown): string {
   return `${JSON.stringify(normalizeJsonValue(value), null, 2)}\n`
-}
-
-function artifactJsonLine(value: unknown): string {
-  return JSON.stringify(normalizeJsonValue(value))
 }
 
 function buildPreviewSessionEvidence({
@@ -1150,5 +1147,5 @@ function stringValue(value: unknown): string | undefined {
 }
 
 async function writeRedactedArtifact(redactor: ArtifactRedactor, path: string, artifactRoot: string, contents: string): Promise<void> {
-  await writeFile(path, redactor.redact(relative(artifactRoot, path), contents))
+  await writeRedactedArtifactFile(artifactRoot, path, contents, redactor)
 }

--- a/packages/runtime-playground/src/artifact-bundle-writer.ts
+++ b/packages/runtime-playground/src/artifact-bundle-writer.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises"
-import { dirname, join } from "node:path"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, join, relative } from "node:path"
 
 import {
   artifactManifestFile,
@@ -8,12 +8,17 @@ import {
   type ArtifactManifestFile,
   type ArtifactViewerMetadata,
 } from "@automattic/wp-codebox-core"
+import type { ArtifactRedactor } from "./artifacts.js"
 
 export interface ManifestedArtifactFileInput {
   path: string
   kind: ArtifactManifestFile["kind"]
   contentType: string
   viewer?: ArtifactViewerMetadata
+}
+
+export interface RedactArtifactFilesOptions {
+  tolerateMissing?: boolean
 }
 
 export class ManifestedArtifactSet {
@@ -42,6 +47,10 @@ export class ArtifactBundleWriter {
     return join(this.directory, path)
   }
 
+  relativePath(path: string): string {
+    return artifactManifestRelativePath(this.directory, path)
+  }
+
   async write(path: string, contents: string | Buffer, manifest: Omit<ManifestedArtifactFileInput, "path">): Promise<void> {
     this.artifacts.add({ path, ...manifest })
     await mkdir(dirname(this.path(path)), { recursive: true })
@@ -49,7 +58,25 @@ export class ArtifactBundleWriter {
   }
 
   async writeJson(path: string, value: unknown, manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
-    await this.write(path, `${JSON.stringify(value, null, 2)}\n`, {
+    await this.write(path, artifactJson(value), {
+      ...manifest,
+      contentType: manifest.contentType ?? "application/json",
+    })
+  }
+
+  async writeJsonLines(path: string, records: unknown[], manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
+    await this.write(path, artifactJsonLines(records), {
+      ...manifest,
+      contentType: manifest.contentType ?? "application/x-ndjson",
+    })
+  }
+
+  async writeRedacted(path: string, contents: string, redactor: ArtifactRedactor, manifest: Omit<ManifestedArtifactFileInput, "path">): Promise<void> {
+    await this.write(path, redactor.redact(path, contents), manifest)
+  }
+
+  async writeRedactedJson(path: string, value: unknown, redactor: ArtifactRedactor, manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
+    await this.writeRedacted(path, artifactJson(value), redactor, {
       ...manifest,
       contentType: manifest.contentType ?? "application/json",
     })
@@ -73,6 +100,37 @@ export class ArtifactBundleWriter {
 
   private async writeManifestJson(manifest: ArtifactManifest): Promise<void> {
     await mkdir(dirname(this.path(this.manifestPath)), { recursive: true })
-    await writeFile(this.path(this.manifestPath), `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(this.path(this.manifestPath), artifactJson(manifest))
+  }
+}
+
+export function artifactJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+export function artifactJsonLines(records: unknown[]): string {
+  return records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : ""
+}
+
+export function artifactManifestRelativePath(artifactRoot: string, path: string): string {
+  return relative(artifactRoot, path).replace(/\\/g, "/")
+}
+
+export async function writeRedactedArtifactFile(artifactRoot: string, path: string, contents: string, redactor: ArtifactRedactor): Promise<void> {
+  await writeFile(path, redactor.redact(artifactManifestRelativePath(artifactRoot, path), contents))
+}
+
+export async function redactArtifactFiles(artifactRoot: string, paths: string[], redactor: ArtifactRedactor, options: RedactArtifactFilesOptions = {}): Promise<void> {
+  const tolerateMissing = options.tolerateMissing ?? true
+
+  for (const path of paths) {
+    const absolutePath = join(artifactRoot, path)
+    try {
+      await writeRedactedArtifactFile(artifactRoot, absolutePath, await readFile(absolutePath, "utf8"), redactor)
+    } catch (error) {
+      if (!tolerateMissing) {
+        throw error
+      }
+    }
   }
 }

--- a/packages/runtime-playground/src/check-artifacts.ts
+++ b/packages/runtime-playground/src/check-artifacts.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { mkdir, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { artifactManifestFile, type ArtifactManifestFile } from "@automattic/wp-codebox-core"
+import { redactArtifactFiles } from "./artifact-bundle-writer.js"
 import type { ArtifactRedactor } from "./artifacts.js"
 import type { normalizePluginCheckOutput, normalizeThemeCheckOutput } from "./commands.js"
 
@@ -97,26 +98,12 @@ export function themeCheckManifestFiles(artifactRoot: string, themeChecks: Theme
 
 export async function redactPluginCheckArtifacts(artifactRoot: string, pluginChecks: PluginCheckArtifact[], redactor: ArtifactRedactor): Promise<void> {
   for (const check of pluginChecks) {
-    for (const path of [check.files.raw, check.files.normalized]) {
-      const absolutePath = join(artifactRoot, path)
-      try {
-        await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
-      } catch {
-        // Plugin Check artifacts are generated before bundle collection; tolerate missing files.
-      }
-    }
+    await redactArtifactFiles(artifactRoot, [check.files.raw, check.files.normalized], redactor)
   }
 }
 
 export async function redactThemeCheckArtifacts(artifactRoot: string, themeChecks: ThemeCheckArtifact[], redactor: ArtifactRedactor): Promise<void> {
   for (const check of themeChecks) {
-    for (const path of [check.files.raw, check.files.normalized]) {
-      const absolutePath = join(artifactRoot, path)
-      try {
-        await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
-      } catch {
-        // Theme Check capture is best-effort; preserve artifact collection if a file vanished.
-      }
-    }
+    await redactArtifactFiles(artifactRoot, [check.files.raw, check.files.normalized], redactor)
   }
 }

--- a/packages/runtime-playground/src/runtime-artifact-helpers.ts
+++ b/packages/runtime-playground/src/runtime-artifact-helpers.ts
@@ -1,4 +1,3 @@
-import { readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { artifactManifestFile } from "@automattic/wp-codebox-core"
 import { normalizeJsonValue } from "@automattic/wp-codebox-core/internals"
@@ -17,6 +16,7 @@ import type {
   Snapshot,
 } from "@automattic/wp-codebox-core"
 import { ArtifactBundleBuilder } from "./artifact-bundle-builder.js"
+import { redactArtifactFiles } from "./artifact-bundle-writer.js"
 import type { ArtifactRedactor } from "./artifacts.js"
 import { browserManifestFiles as browserArtifactManifestFiles, browserRedactionPaths, browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
 import { pluginCheckManifestFiles, redactPluginCheckArtifacts, redactThemeCheckArtifacts, themeCheckManifestFiles, type PluginCheckArtifact, type ThemeCheckArtifact } from "./check-artifacts.js"
@@ -112,13 +112,6 @@ function observationManifestFiles(artifactRoot: string, observations: Observatio
 
 async function redactBrowserArtifacts(artifactRoot: string, browserProbes: BrowserArtifact[], redactor: ArtifactRedactor): Promise<void> {
   for (const probe of browserProbes) {
-    for (const path of browserRedactionPaths(probe)) {
-      const absolutePath = join(artifactRoot, path)
-      try {
-        await writeFile(absolutePath, redactor.redact(path, await readFile(absolutePath, "utf8")))
-      } catch {
-        // Browser capture is best-effort; preserve artifact collection if a file vanished.
-      }
-    }
+    await redactArtifactFiles(artifactRoot, browserRedactionPaths(probe), redactor)
   }
 }

--- a/scripts/artifact-redaction-smoke.ts
+++ b/scripts/artifact-redaction-smoke.ts
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { artifactJsonLines, redactArtifactFiles, writeRedactedArtifactFile } from "../packages/runtime-playground/src/artifact-bundle-writer.js"
 import { ArtifactRedactor } from "../packages/runtime-playground/src/artifacts.js"
 
 const redactor = new ArtifactRedactor({
@@ -42,3 +46,22 @@ assert.match(largeRedacted, /\[REDACTED:openai-api-key\]/)
 assert.match(largeRedacted, /\[REDACTED:configured-secret-value\]/)
 assert.match(largeRedacted, /\[REDACTED:jwt\]/)
 assert.equal(largeRedactor.summary().total, 3)
+
+const directory = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-redaction-"))
+try {
+  const artifactRoot = directory
+  const commandPath = join(artifactRoot, "commands.jsonl")
+  const logPath = join(artifactRoot, "logs/runtime.log")
+  const fileRedactor = new ArtifactRedactor({ WP_CODEBOX_SECRET: "super-secret-value" })
+
+  await writeRedactedArtifactFile(artifactRoot, commandPath, artifactJsonLines([{ token: "super-secret-value" }]), fileRedactor)
+  assert.deepEqual(JSON.parse(await readFile(commandPath, "utf8")), { token: "[REDACTED:configured-secret-value]" })
+
+  await mkdir(join(artifactRoot, "logs"), { recursive: true })
+  await writeFile(logPath, "secret=super-secret-value\n")
+  await redactArtifactFiles(artifactRoot, ["logs/runtime.log", "missing.log"], fileRedactor)
+  assert.equal(await readFile(logPath, "utf8"), "secret=[REDACTED:configured-secret-value]\n")
+  assert.deepEqual(fileRedactor.summary().artifacts.map((artifact) => artifact.path).sort(), ["commands.jsonl", "logs/runtime.log"])
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- extend `ArtifactBundleWriter` with shared JSON/JSONL serialization, redacted writes, and manifest-relative artifact paths
- add a shared best-effort artifact file redaction loop for browser/check artifacts
- migrate artifact bundle builder, check artifacts, and runtime browser artifact helpers to the shared primitives without changing artifact formats
- extend the existing artifact redaction smoke coverage for shared redacted file writes and missing-file tolerance

## Tests
- `npx tsx scripts/artifact-redaction-smoke.ts`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the shared artifact writer/redaction primitives, migrated scoped runtime-playground call sites, and added targeted smoke coverage for Chris to review.