### PR TITLE
Add command artifact schema contracts

### DIFF
--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -1,5 +1,5 @@
 import { runCli } from "./cli-entry.js"
-import { serializeError } from "./output.js"
+import { serializeError, wantsJsonOutput, writeJsonFailure } from "./output.js"
 
 export type CliRunner = (args: string[]) => Promise<number>
 
@@ -10,6 +10,11 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): vo
   const writeStderr = process.stderr.write.bind(process.stderr)
   const handleBeforeExit = () => {
     if (settled) {
+      return
+    }
+    if (wantsJsonOutput(args)) {
+      writeJsonFailure(args[0], UNSETTLED_COMMAND_MESSAGE, { code: "unsettled-command" })
+      process.exitCode = 1
       return
     }
     writeStderr(`${UNSETTLED_COMMAND_MESSAGE}\n`)
@@ -26,7 +31,12 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): vo
     (error) => {
       settled = true
       process.off("beforeExit", handleBeforeExit)
-      writeStderr(`${serializeError(error)?.message ?? String(error)}\n`)
+      const serialized = serializeError(error)
+      if (wantsJsonOutput(args)) {
+        writeJsonFailure(args[0], serialized.message, { code: serialized.code ?? "uncaught-error", error: serialized })
+      } else {
+        writeStderr(`${serialized.message}\n`)
+      }
       process.exitCode = 1
     },
   )

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { wantsJsonOutput, writeJsonFailure } from "./output.js"
 
 type CliCommandHandler = (args: string[]) => Promise<number>
 
@@ -79,6 +80,10 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
 
   const route = routeForCommand(command)
   if (!route) {
+    if (wantsJsonOutput(argv)) {
+      writeJsonFailure(command, `Unknown command: ${command}`, { code: "unknown-command" })
+      return 1
+    }
     console.error(`Unknown command: ${command}`)
     router.printHelp()
     return 1
@@ -91,6 +96,10 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
   const subcommand = args.shift()
   const handlerName = subcommand ? (route as Partial<Record<string, CliCommandHandlerName>>)[subcommand] : undefined
   if (!handlerName) {
+    if (wantsJsonOutput(argv)) {
+      writeJsonFailure(command, `Unknown ${command} command: ${subcommand ?? ""}`, { code: "unknown-subcommand", subcommand: subcommand ?? null })
+      return 1
+    }
     console.error(`Unknown ${command} command: ${subcommand ?? ""}`)
     router.printHelp()
     return 1

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -112,6 +112,34 @@ export function serializeError(error: unknown): CliError {
   return { name: "Error", message: String(error) }
 }
 
+export function cliFailureEnvelope(command: string | undefined, message: string, details: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema: "wp-codebox/cli-failure/v1",
+    success: false,
+    status: "error",
+    ...(command ? { command } : {}),
+    error: {
+      name: "Error",
+      message,
+    },
+    diagnostics: [
+      {
+        code: "cli-error",
+        message,
+        ...details,
+      },
+    ],
+  }
+}
+
+export function wantsJsonOutput(args: readonly string[]): boolean {
+  return args.includes("--json")
+}
+
+export function writeJsonFailure(command: string | undefined, message: string, details: Record<string, unknown> = {}): void {
+  process.stdout.write(`${JSON.stringify(cliFailureEnvelope(command, message, details), null, 2)}\n`)
+}
+
 export function printHumanOutput(output: RunOutputLike): void {
   if (!output.success) {
     console.error(output.error?.message ?? "WP Codebox failed")

--- a/packages/runtime-core/src/artifact-bundle-verifier.ts
+++ b/packages/runtime-core/src/artifact-bundle-verifier.ts
@@ -1,5 +1,6 @@
 import { lstat, readdir, readFile, realpath } from "node:fs/promises"
 import { isAbsolute, join, normalize, relative, sep } from "node:path"
+import { Ajv2020 } from "ajv/dist/2020.js"
 import { artifactFileDigest, calculateArtifactContentDigest, calculateArtifactManifestFileSha256 } from "./artifact-manifest.js"
 import type { ArtifactContentDigest, ArtifactFileDigest, ArtifactManifest, ArtifactManifestFile } from "./artifact-manifest.js"
 import { isPlainObject as isRecord } from "./object-utils.js"
@@ -24,6 +25,7 @@ export type ArtifactBundleVerificationViolationCode =
   | "review-evidence-mismatch"
   | "unsafe-file"
   | "hardlink"
+  | "payload-schema-violation"
 
 export interface ArtifactBundleVerificationViolation {
   code: ArtifactBundleVerificationViolationCode
@@ -866,7 +868,37 @@ async function verifyTypedArtifactIndexArtifacts(directory: string, manifest: Ar
       if (typeof artifact.artifact.sha256 === "string") {
         await verifyTypedArtifactFileDigest(directory, artifact.artifact.path, artifact.artifact.sha256, `${fieldPath}.artifact.sha256`, violations)
       }
+      validateTypedArtifactPayloadSchema(artifact, fieldPath, file.path, violations)
     }
+  }
+}
+
+function validateTypedArtifactPayloadSchema(artifact: Record<string, unknown>, fieldPath: string, indexPath: string, violations: ArtifactBundleVerificationViolation[]): void {
+  const payloadSchema = artifact.payload_schema ?? artifact.payloadSchema
+  if (!isRecord(payloadSchema) || !("payload" in artifact)) {
+    return
+  }
+
+  try {
+    const validate = new Ajv2020({ strict: false, allErrors: true }).compile(payloadSchema)
+    if (validate(artifact.payload)) {
+      return
+    }
+
+    violations.push({
+      code: "payload-schema-violation",
+      path: `${fieldPath}.payload`,
+      file: indexPath,
+      message: `Typed artifact payload does not match payload_schema: ${(validate.errors ?? []).map((error) => `${error.instancePath || "/"} ${error.message ?? "is invalid"}`).join("; ")}`,
+      details: { errors: validate.errors ?? [] },
+    })
+  } catch (error) {
+    violations.push({
+      code: "payload-schema-violation",
+      path: `${fieldPath}.payload_schema`,
+      file: indexPath,
+      message: `Typed artifact payload_schema is not a valid JSON Schema: ${errorMessage(error)}`,
+    })
   }
 }
 

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -2,6 +2,13 @@ export type CommandHandlerBinding =
   | { kind: "playground"; method: string }
   | { kind: "recipe-alias"; command: string }
 
+export type CommandJsonSchema = Record<string, unknown> & { $id?: string }
+
+export interface CommandOutputSchemaContract {
+  id: string
+  jsonSchema?: CommandJsonSchema
+}
+
 export interface CommandDefinition {
   id: string
   description: string
@@ -13,10 +20,34 @@ export interface CommandDefinition {
     format?: string
   }>
   outputShape: string
+  outputSchema?: CommandOutputSchemaContract
   policyRequirement: string
   recipe: boolean
   handler: CommandHandlerBinding
 }
+
+const objectEnvelopeSchema = (id: string, extraProperties: Record<string, unknown> = {}): CommandOutputSchemaContract => ({
+  id,
+  jsonSchema: {
+    $id: id,
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      schema: { const: id },
+      command: { type: "string" },
+      status: { type: "string" },
+      ...extraProperties,
+    },
+  },
+})
+
+const artifactSummarySchema = (id: string, artifactProperties: Record<string, unknown> = {}): CommandOutputSchemaContract => objectEnvelopeSchema(id, {
+  artifacts: {
+    type: "object",
+    additionalProperties: true,
+    properties: artifactProperties,
+  },
+})
 
 const snapshotScopingAcceptedArgs: CommandDefinition["acceptedArgs"] = [
   { name: "snapshot-include-wp-content", description: "Comma-separated wp-content-relative paths to include in the runtime snapshot. Defaults to all non-excluded paths.", format: "string" },
@@ -69,6 +100,10 @@ export const commandRegistry = [
       ...snapshotScopingAcceptedArgs,
     ],
     outputShape: "wp-codebox/wordpress-state-bundle-capture/v1 JSON with runtime snapshot id, artifact refs, replay status, and capture summary.",
+    outputSchema: artifactSummarySchema("wp-codebox/wordpress-state-bundle-capture/v1", {
+      runtimeSnapshot: { type: "string" },
+      manifest: { type: "string" },
+    }),
     policyRequirement: "Runtime policy commands must include wordpress.capture-state-bundle.",
     recipe: true,
     handler: { kind: "playground", method: "runCaptureStateBundle" },
@@ -84,6 +119,11 @@ export const commandRegistry = [
       ...snapshotScopingAcceptedArgs,
     ],
     outputShape: "wp-codebox/wordpress-replay-export/v1 JSON with import/materialization/snapshot/export metrics and manifest, blueprint.after.json, blueprint.after-notes.json, and files/runtime-snapshot.json artifact paths.",
+    outputSchema: artifactSummarySchema("wp-codebox/wordpress-replay-export/v1", {
+      manifest: { type: "string" },
+      blueprint: { type: "string" },
+      runtimeSnapshot: { type: "string" },
+    }),
     policyRequirement: "Runtime policy commands must include wordpress.export-replay-package.",
     recipe: true,
     handler: { kind: "playground", method: "runExportReplayPackage" },
@@ -133,6 +173,12 @@ export const commandRegistry = [
       { name: "reset-policy-json", description: "Explicit benchmark reset policy. Supports betweenIterations and betweenScenarios modes: none or object-cache.", format: "JSON object" },
     ],
     outputShape: "wp-codebox/bench-results/v1 JSON envelope with typed scenarios, metrics, diagnostics, artifacts, and provenance.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/bench-results/v1", {
+      scenarios: { type: "array" },
+      diagnostics: { type: "array" },
+      artifacts: { type: "object" },
+      provenance: { type: "object" },
+    }),
     policyRequirement: "Runtime policy commands must include wordpress.bench.",
     recipe: true,
     handler: { kind: "playground", method: "runBench" },
@@ -172,6 +218,10 @@ export const commandRegistry = [
       { name: "checks", description: "Optional comma-separated official Plugin Check slugs to run; omit to run the default suite.", format: "comma-separated check slugs" },
     ],
     outputShape: "wp-codebox/plugin-check/v1 JSON with command, target plugin, exit code/status, summary counts, and findings; raw and normalized outputs are captured in artifacts.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/plugin-check/v1", {
+      summary: { type: "object" },
+      findings: { type: "array" },
+    }),
     policyRequirement: "Runtime policy commands must include wordpress.plugin-check.",
     recipe: true,
     handler: { kind: "playground", method: "runPluginCheck" },
@@ -324,6 +374,10 @@ export const commandRegistry = [
       { name: "max-regions", description: "Maximum mismatch regions to report; defaults to 8.", format: "positive integer" },
     ],
     outputShape: "wp-codebox/visual-compare/v1 JSON summary plus files/browser/visual-compare/source.png, candidate.png, diff.png, visual-diff.json, visual-explanation.json when DOM/style context is available, and optional baseline delta evidence when a previous visual comparison artifact is supplied. Matrix runs emit wp-codebox/visual-compare-matrix/v1 in files/browser/visual-compare/matrix-summary.json plus per-comparison subdirectories.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/visual-compare/v1", {
+      summary: { type: "object" },
+      artifacts: { type: "object" },
+    }),
     policyRequirement: "Runtime policy commands must include wordpress.visual-compare.",
     recipe: true,
     handler: { kind: "playground", method: "runVisualCompare" },
@@ -418,6 +472,11 @@ export const commandRegistry = [
       { name: "request-file", description: "Recipe-relative path to a wp-codebox/agent-fanout-request/v1 envelope.", format: "path" },
     ],
     outputShape: "JSON wp-codebox/agent-fanout-result/v1 envelope plus fanout/plan.json, fanout/events.jsonl, worker result refs, and aggregate/final refs in runtime evidence artifacts.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/agent-fanout-result/v1", {
+      fanout: { type: "object" },
+      workers: { type: "array" },
+      aggregate: { type: "object" },
+    }),
     policyRequirement: "Host-side recipe helper; it writes generic Codebox artifact envelopes and does not expose product or Data Machine internals.",
     recipe: true,
     handler: { kind: "recipe-alias", command: "wp-codebox.agent-fanout" },

--- a/scripts/cli-json-failure-smoke.ts
+++ b/scripts/cli-json-failure-smoke.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { runCli } from "../packages/cli/src/cli-entry.js"
+
+const originalStdoutWrite = process.stdout.write.bind(process.stdout)
+let stdout = ""
+
+process.stdout.write = ((chunk: unknown, ..._args: unknown[]) => {
+  stdout += String(chunk)
+  return true
+}) as typeof process.stdout.write
+
+try {
+  const exitCode = await runCli(["not-a-command", "--json"])
+  assert.equal(exitCode, 1)
+
+  const output = JSON.parse(stdout)
+  assert.equal(output.schema, "wp-codebox/cli-failure/v1")
+  assert.equal(output.success, false)
+  assert.equal(output.command, "not-a-command")
+  assert.match(output.error.message, /Unknown command/)
+  assert.equal(output.diagnostics[0].code, "unknown-command")
+} finally {
+  process.stdout.write = originalStdoutWrite
+}
+
+console.log("cli-json-failure-smoke: ok")

--- a/scripts/command-registry-smoke.ts
+++ b/scripts/command-registry-smoke.ts
@@ -19,6 +19,13 @@ function main(): void {
     assert(command.id.length > 0, "Command id must be non-empty")
     assert(command.description.length > 0, `${command.id} is missing description`)
     assert(command.outputShape.length > 0, `${command.id} is missing outputShape`)
+    if (command.outputSchema) {
+      assert(command.outputSchema.id.length > 0, `${command.id} outputSchema is missing id`)
+      assert(command.outputShape.includes(command.outputSchema.id), `${command.id} outputShape should mention outputSchema id`)
+      if (command.outputSchema.jsonSchema) {
+        assert(command.outputSchema.jsonSchema.$id === command.outputSchema.id, `${command.id} outputSchema JSON Schema $id must match id`)
+      }
+    }
     assert(command.policyRequirement.length > 0, `${command.id} is missing policyRequirement`)
     assert(Array.isArray(command.acceptedArgs), `${command.id} acceptedArgs must be an array`)
   }
@@ -35,6 +42,8 @@ function main(): void {
     assert(command.handler.kind === "playground", `${command.id} must bind to a Playground handler`)
     assert(command.handler.method.length > 0, `${command.id} must name its Playground handler method`)
   }
+
+  assert(commandRegistry.some((command) => command.outputSchema?.jsonSchema), "Command registry should expose structured output schemas where available")
 }
 
 main()

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -38,6 +38,7 @@ export const smokeGroups = {
       tsxSmoke("task-input-contract-smoke"),
       tsxSmoke("discovery-command-smoke"),
       tsxSmoke("doctor-command-smoke"),
+      tsxSmoke("cli-json-failure-smoke"),
       tsxSmoke("source-checkout-entrypoint-smoke"),
       tsxSmoke("cli-unsettled-command-smoke"),
       tsxSmoke("php-snippets-smoke"),

--- a/scripts/typed-artifacts-smoke.ts
+++ b/scripts/typed-artifacts-smoke.ts
@@ -50,16 +50,23 @@ try {
   assert.equal(mismatch.valid, false)
   assert.equal(mismatch.violations.some((violation) => violation.code === "file-hash-mismatch" && violation.file === "files/runtime-evidence/typed-artifacts/summary-1.json"), true)
 
+  const payloadSchemaMismatch = join(workspace, "typed-payload-schema-mismatch")
+  await writeTypedArtifactBundle(payloadSchemaMismatch, { invalidPayloadForSchema: true })
+  const schemaMismatch = await verifyArtifactBundle(payloadSchemaMismatch)
+  assert.equal(schemaMismatch.valid, false)
+  assert.equal(schemaMismatch.violations.some((violation) => violation.code === "payload-schema-violation" && violation.path === "files/runtime-evidence/typed-artifacts/index.json:artifacts[0].payload"), true)
+
   console.log("Typed artifacts smoke passed")
 } finally {
   await rm(workspace, { recursive: true, force: true })
 }
 
-async function writeTypedArtifactBundle(directory: string, options: { omitTypedArtifactManifestEntry?: boolean; badTypedArtifactDigest?: boolean } = {}): Promise<void> {
+async function writeTypedArtifactBundle(directory: string, options: { omitTypedArtifactManifestEntry?: boolean; badTypedArtifactDigest?: boolean; invalidPayloadForSchema?: boolean } = {}): Promise<void> {
   await mkdir(join(directory, "files/runtime-evidence/typed-artifacts"), { recursive: true })
   await writeFile(join(directory, "metadata.json"), "{}\n")
 
-  const typedPayload = `${JSON.stringify({ ok: true }, null, 2)}\n`
+  const payload = options.invalidPayloadForSchema ? { ok: "yes" } : { ok: true }
+  const typedPayload = `${JSON.stringify(payload, null, 2)}\n`
   const typedPath = "files/runtime-evidence/typed-artifacts/summary-1.json"
   await writeFile(join(directory, typedPath), typedPayload)
   const typedDigest = artifactFileDigest(typedPayload).value
@@ -70,8 +77,8 @@ async function writeTypedArtifactBundle(directory: string, options: { omitTypedA
       schema: STRUCTURED_ARTIFACT_SCHEMA,
       name: "summary",
       type: "example.summary",
-      payload_schema: "example/summary/v1",
-      payload: { ok: true },
+      payload_schema: options.invalidPayloadForSchema ? { $id: "example/summary/v1", type: "object", required: ["ok"], properties: { ok: { type: "boolean" } } } : "example/summary/v1",
+      payload,
       metadata: {},
       provenance: { direction: "output", source: "/tmp/summary.json" },
       artifact: {


### PR DESCRIPTION
## Summary
- Add optional structured output schema contracts to selected command registry entries while preserving existing prose outputShape fields.
- Validate typed artifact payloads against inline payload_schema JSON Schemas during artifact bundle verification.
- Emit JSON-mode CLI failure envelopes for router and entrypoint failures so machine callers can read diagnostics from stdout.

## Tests
- npm run build
- npx tsx scripts/command-registry-smoke.ts
- npx tsx scripts/typed-artifacts-smoke.ts
- npx tsx scripts/cli-json-failure-smoke.ts
- npx tsx scripts/discovery-command-smoke.ts
- npm run smoke -- --group core
- npm run smoke -- --group artifact

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, smoke coverage, and PR description; Chris remains responsible for review and merge.