### PR TITLE
Add backend package adapter registry

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -181,7 +181,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     dependencyOverlays = await prepareRecipeDependencyOverlays(recipe, recipeDirectory, extraPlugins)
     stagedFiles = await prepareRecipeStagedFiles(recipe, recipeDirectory)
     overlays = await prepareRecipeRuntimeOverlaysForRun(recipe, recipeDirectory)
-    backendPackage = await prepareRecipeRuntimeBackendPackage(recipe, recipeDirectory)
+    backendPackage = await prepareRecipeRuntimeBackendPackage(recipe, recipeDirectory, plan.runtime.backend)
     interruption?.throwIfInterrupted()
 
     runRecord = await runRegistry.update(runRecord.runId, { status: "booting" })
@@ -218,7 +218,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         runtime: runtimeEnvironment,
       }, async () => await awaitRecipe("runtime.create", () => createRuntime(
         runtimeCreateSpec,
-        resolveCliRuntimeBackend(runtimeCreateSpec.backend, { cliModule: backendPackage?.cliModule }),
+        resolveCliRuntimeBackend(runtimeCreateSpec.backend, backendPackage?.runtimeBackendContext),
       )))
       startupDurationMs = Date.now() - startupStartedAtMs
     } catch (error) {

--- a/packages/cli/src/recipe-backend-package.ts
+++ b/packages/cli/src/recipe-backend-package.ts
@@ -2,12 +2,12 @@ import { createHash } from "node:crypto"
 import { readFile, stat } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
-import type { WorkspaceRecipe, WorkspaceRecipeRuntimeBackendPackage } from "@automattic/wp-codebox-core"
+import type { RuntimeBackendFactoryContext, RuntimeBackendKind, WorkspaceRecipe, WorkspaceRecipeRuntimeBackendPackage } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliModule } from "@automattic/wp-codebox-playground"
 
 export interface RuntimeBackendPackageProvenance {
   schema: "wp-codebox/runtime-backend-package/v1"
-  kind: "playground"
+  kind: string
   source: string
   resolvedSource: string
   entrypoint: string
@@ -22,9 +22,76 @@ export interface RuntimeBackendPackageProvenance {
 }
 
 export interface PreparedRuntimeBackendPackage {
-  cliModule: PlaygroundCliModule
+  runtimeBackendContext: RuntimeBackendFactoryContext
   provenance: RuntimeBackendPackageProvenance
 }
+
+interface LoadedRuntimeBackendPackage {
+  backendPackage: WorkspaceRecipeRuntimeBackendPackage
+  resolvedSource: string
+  entrypoint: string
+  entrypointContents: string
+  manifest?: { raw: string; json: Record<string, unknown> }
+  module: unknown
+}
+
+interface PreparedRuntimeBackendPackageAdapterResult {
+  runtimeBackendContext: RuntimeBackendFactoryContext
+  diagnostics: Array<{ status: "passed"; message: string }>
+}
+
+interface RuntimeBackendPackageAdapter {
+  readonly backendKind: RuntimeBackendKind
+  prepare(loadedPackage: LoadedRuntimeBackendPackage): PreparedRuntimeBackendPackageAdapterResult
+}
+
+class RuntimeBackendPackageAdapterRegistry {
+  readonly #adapters = new Map<RuntimeBackendKind, RuntimeBackendPackageAdapter>()
+
+  constructor(adapters: readonly RuntimeBackendPackageAdapter[] = []) {
+    for (const adapter of adapters) {
+      this.register(adapter)
+    }
+  }
+
+  register(adapter: RuntimeBackendPackageAdapter): void {
+    if (this.#adapters.has(adapter.backendKind)) {
+      throw new Error(`Runtime backend package adapter is already registered: ${adapter.backendKind}`)
+    }
+
+    this.#adapters.set(adapter.backendKind, adapter)
+  }
+
+  resolve(backendKind: RuntimeBackendKind): RuntimeBackendPackageAdapter {
+    const adapter = this.#adapters.get(backendKind)
+    if (!adapter) {
+      const known = this.#adapters.size > 0 ? [...this.#adapters.keys()].join(", ") : "none"
+      throw new Error(`Unsupported runtime backend package backend: ${backendKind}; known backend package backends: ${known}`)
+    }
+
+    return adapter
+  }
+}
+
+const playgroundRuntimeBackendPackageAdapter: RuntimeBackendPackageAdapter = {
+  backendKind: "wordpress-playground",
+  prepare(loadedPackage) {
+    const { backendPackage, entrypoint, module } = loadedPackage
+    if (backendPackage.kind !== "playground") {
+      throw backendPackageError(backendPackage, `Unsupported WordPress Playground runtime backend package kind: ${backendPackage.kind}`)
+    }
+    if (!isPlaygroundCliModule(module)) {
+      throw backendPackageError(backendPackage, `Runtime backend package entrypoint must export runCLI(): ${entrypoint}`)
+    }
+
+    return {
+      runtimeBackendContext: { cliModule: module as PlaygroundCliModule },
+      diagnostics: [{ status: "passed", message: "Entrypoint exports runCLI" }],
+    }
+  },
+}
+
+const runtimeBackendPackageAdapterRegistry = new RuntimeBackendPackageAdapterRegistry([playgroundRuntimeBackendPackageAdapter])
 
 export class RecipeRuntimeBackendPackageError extends Error {
   readonly code = "recipe-runtime-backend-package-invalid"
@@ -35,14 +102,10 @@ export class RecipeRuntimeBackendPackageError extends Error {
   }
 }
 
-export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedRuntimeBackendPackage | undefined> {
+export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe, recipeDirectory: string, backendKind: RuntimeBackendKind = recipe.runtime?.backend ?? "wordpress-playground"): Promise<PreparedRuntimeBackendPackage | undefined> {
   const backendPackage = recipe.runtime?.backendPackage
   if (!backendPackage) {
     return undefined
-  }
-
-  if (backendPackage.kind !== "playground") {
-    throw backendPackageError(backendPackage, `Unsupported runtime backend package kind: ${backendPackage.kind}`)
   }
 
   const resolvedSource = resolve(recipeDirectory, backendPackage.source)
@@ -58,15 +121,14 @@ export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe
     : resolvedSource
   const entrypointContents = await readBackendEntrypoint(backendPackage, entrypoint)
   const module = await importBackendEntrypoint(backendPackage, entrypoint)
-  if (!isPlaygroundCliModule(module)) {
-    throw backendPackageError(backendPackage, `Runtime backend package entrypoint must export runCLI(): ${entrypoint}`)
-  }
+  const adapter = runtimeBackendPackageAdapterRegistry.resolve(backendKind)
+  const adapterResult = adapter.prepare({ backendPackage, resolvedSource, entrypoint, entrypointContents, manifest, module })
 
   return {
-    cliModule: module as PlaygroundCliModule,
+    runtimeBackendContext: adapterResult.runtimeBackendContext,
     provenance: {
       schema: "wp-codebox/runtime-backend-package/v1",
-      kind: "playground",
+      kind: backendPackage.kind,
       source: backendPackage.source,
       resolvedSource,
       entrypoint,
@@ -75,7 +137,7 @@ export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe
       diagnostics: [
         { status: "passed", message: "Source exists" },
         { status: "passed", message: "Entrypoint resolved" },
-        { status: "passed", message: "Entrypoint exports runCLI" },
+        ...adapterResult.diagnostics,
       ],
       ...(backendPackage.metadata ? { metadata: backendPackage.metadata } : {}),
     },

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -39,7 +39,7 @@ export interface RecipePlan {
   runtime: {
     backend: string
     backendPackage?: {
-      kind: "playground"
+      kind: string
       source: string
       package?: string
       entrypoint?: string

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -306,8 +306,8 @@ function validateRecipeRuntimeBackendPackage(backendPackage: WorkspaceRecipeRunt
   if (!backendPackage || typeof backendPackage !== "object" || Array.isArray(backendPackage)) {
     throw new Error(`Recipe runtime backendPackage must be an object: ${recipePath}`)
   }
-  if (backendPackage.kind !== "playground") {
-    throw new Error(`Recipe runtime backendPackage kind is unsupported: ${recipePath}`)
+  if (!backendPackage.kind || typeof backendPackage.kind !== "string") {
+    throw new Error(`Recipe runtime backendPackage kind must be a string: ${recipePath}`)
   }
   if (!backendPackage.source || typeof backendPackage.source !== "string") {
     throw new Error(`Recipe runtime backendPackage must include source: ${recipePath}`)

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -441,11 +441,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
       },
       runtimeBackendPackage: {
         type: "object",
-        additionalProperties: false,
+        additionalProperties: true,
         required: ["kind", "source"],
-        description: "Optional local Playground backend package or entrypoint used to boot the runtime. This selects the backend package itself and is separate from /wordpress filesystem overlays.",
+        description: "Optional local backend package or entrypoint used to boot the runtime. This selects the backend package itself and is separate from /wordpress filesystem overlays.",
         properties: {
-          kind: { const: "playground" },
+          kind: { type: "string", minLength: 1 },
           source: { type: "string" },
           package: { type: "string" },
           entrypoint: { type: "string" },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -102,7 +102,7 @@ export interface WorkspaceRecipeRuntimeOverlay {
 }
 
 export interface WorkspaceRecipeRuntimeBackendPackage {
-  kind: "playground"
+  kind: string
   source: string
   package?: string
   entrypoint?: string

--- a/scripts/backend-package-adapter-registry-smoke.ts
+++ b/scripts/backend-package-adapter-registry-smoke.ts
@@ -1,0 +1,73 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { prepareRecipeRuntimeBackendPackage } from "../packages/cli/src/recipe-backend-package.js"
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+async function assertRejects(operation: () => Promise<unknown>, messageIncludes: string): Promise<void> {
+  try {
+    await operation()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    assert(message.includes(messageIncludes), `Expected error to include ${messageIncludes}; got ${message}`)
+    return
+  }
+
+  throw new Error(`Expected operation to reject with ${messageIncludes}`)
+}
+
+async function main(): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "wp-codebox-backend-package-"))
+  try {
+    const packageDirectory = join(root, "playground-backend")
+    await writeFile(join(root, "package.json"), JSON.stringify({ type: "module" }))
+    await writeFile(join(root, "invalid.js"), "export const notRunCLI = true\n")
+    await mkdir(packageDirectory)
+    await writeFile(join(packageDirectory, "package.json"), JSON.stringify({ name: "local-playground-backend", version: "1.2.3", type: "module", exports: "./index.js" }))
+    await writeFile(join(packageDirectory, "index.js"), "export async function runCLI() { return { php: { requestHandler: {} } } }\n")
+
+    const genericSchemaResult = validateWorkspaceRecipeJsonSchema({
+      schema: "wp-codebox/workspace-recipe/v1",
+      runtime: {
+        backendPackage: { kind: "future-backend-package", source: "./future", futureOption: true },
+      },
+      workflow: { steps: [{ command: "wp/version" }] },
+    })
+    assert(genericSchemaResult.valid, `Expected generic backendPackage schema to accept future kinds: ${JSON.stringify(genericSchemaResult.issues)}`)
+
+    const recipe = {
+      schema: "wp-codebox/workspace-recipe/v1",
+      runtime: {
+        backend: "wordpress-playground",
+        backendPackage: { kind: "playground", source: "./playground-backend", package: "local-playground-backend" },
+      },
+    } satisfies WorkspaceRecipe
+    const prepared = await prepareRecipeRuntimeBackendPackage(recipe, root, "wordpress-playground")
+    assert(prepared?.provenance.kind === "playground", "Expected Playground backend package provenance kind")
+    assert(typeof (prepared.runtimeBackendContext.cliModule as { runCLI?: unknown }).runCLI === "function", "Expected Playground adapter to expose cliModule.runCLI")
+    assert(prepared.provenance.diagnostics.some((diagnostic) => diagnostic.message === "Entrypoint exports runCLI"), "Expected Playground runCLI diagnostic")
+
+    await assertRejects(() => prepareRecipeRuntimeBackendPackage({
+      schema: "wp-codebox/workspace-recipe/v1",
+      runtime: { backendPackage: { kind: "playground", source: "./invalid.js" } },
+    }, root, "wordpress-playground"), "must export runCLI")
+
+    await assertRejects(() => prepareRecipeRuntimeBackendPackage({
+      schema: "wp-codebox/workspace-recipe/v1",
+      runtime: { backendPackage: { kind: "future", source: "./invalid.js" } },
+    }, root, "future-runtime"), "Unsupported runtime backend package backend: future-runtime")
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -31,6 +31,7 @@ export const smokeGroups = {
     commands: [
       npmScript("build"),
       tsxSmoke("runtime-backend-registry-smoke"),
+      tsxSmoke("backend-package-adapter-registry-smoke"),
       tsxSmoke("command-registry-smoke"),
       tsxSmoke("command-args-smoke"),
       tsxSmoke("host-tool-registry-smoke"),


### PR DESCRIPTION
## Summary
- Add a backend-package adapter registry keyed by runtime backend kind.
- Keep generic backend package schema/shape validation independent of Playground-specific package kinds.
- Move the Playground runCLI module contract into the WordPress Playground adapter while preserving existing runtime context behavior.
- Add targeted smoke coverage for future package kinds, unsupported backend adapters, and Playground runCLI validation.

## Testing
- npm run build
- npm exec -- tsx scripts/backend-package-adapter-registry-smoke.ts
- npm run smoke -- --command=backend-package-adapter-registry-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the backend package adapter registry implementation, generic validation updates, and targeted smoke coverage; Chris remains responsible for review and verification.