### PR TITLE
Centralize sandbox PHP template fragments

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -519,110 +519,7 @@ $plugins = array_merge(array(
     'agents-api/agents-api.php',
 ), wp_codebox_provider_plugin_entries(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)));
 
-function wp_codebox_plugin_entry_path(string $plugin): ?array {
-    $plugin = ltrim($plugin, '/');
-    if ('' === $plugin || str_contains($plugin, '..') || !str_ends_with($plugin, '.php')) {
-        return null;
-    }
-    $normal_path = WP_PLUGIN_DIR . '/' . $plugin;
-    if (file_exists($normal_path)) {
-        return array('path' => $normal_path, 'load_as' => 'plugin');
-    }
-    $mu_path = WPMU_PLUGIN_DIR . '/wp-codebox-runtime/' . $plugin;
-    if (file_exists($mu_path)) {
-        return array('path' => $mu_path, 'load_as' => 'mu-plugin');
-    }
-    return null;
-}
-
-function wp_codebox_provider_plugin_entries(array $provider_plugins): array {
-    $entries = array();
-    foreach ($provider_plugins as $plugin) {
-        $slug = isset($plugin['slug']) ? sanitize_key((string) $plugin['slug']) : '';
-        if ('' === $slug) {
-            continue;
-        }
-        $matched = wp_codebox_resolve_provider_plugin_entry($plugin, $slug);
-        if (null !== $matched) {
-            $entries[] = $matched;
-        }
-    }
-    return $entries;
-}
-
-function wp_codebox_provider_plugin_file_diagnostics(array $provider_plugins): array {
-    $diagnostics = array();
-    foreach ($provider_plugins as $plugin) {
-        $slug = isset($plugin['slug']) ? sanitize_key((string) $plugin['slug']) : '';
-        if ('' === $slug) {
-            continue;
-        }
-
-        $entry = null;
-        $entry_path = null;
-        $load_as = null;
-        foreach (wp_codebox_provider_plugin_entries(array($plugin)) as $candidate) {
-            $candidate_entry = wp_codebox_plugin_entry_path($candidate);
-            if ($candidate_entry) {
-                $entry = $candidate;
-                $entry_path = $candidate_entry['path'];
-                $load_as = $candidate_entry['load_as'];
-                break;
-            }
-        }
-
-        $diagnostics[] = array(
-            'slug' => $slug,
-            'source' => isset($plugin['source']) ? (string) $plugin['source'] : '',
-            'plugin_file' => $entry,
-            'mounted_path' => $entry_path,
-            'load_as' => $load_as,
-            'mounted' => null !== $entry_path,
-        );
-    }
-    return $diagnostics;
-}
-
-function wp_codebox_resolve_provider_plugin_entry(array $plugin, string $slug): ?string {
-    $explicit = isset($plugin['pluginFile']) ? ltrim((string) $plugin['pluginFile'], '/') : '';
-    if ('' !== $explicit && wp_codebox_plugin_entry_path($explicit)) {
-        return $explicit;
-    }
-
-    $candidates = array($slug . '/' . $slug . '.php', $slug . '/plugin.php');
-    foreach ($candidates as $candidate) {
-        if (wp_codebox_plugin_entry_path($candidate)) {
-            return $candidate;
-        }
-    }
-
-    return wp_codebox_provider_plugin_entry_by_header($slug);
-}
-
-function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
-    // The conventional entries (<slug>/plugin.php, <slug>/<slug>.php) are absent.
-    // This happens when the plugin directory was renamed so its name no longer
-    // matches the entry file (e.g. a Lab workspace synced under a uniquified
-    // <slug>-<hash>-<uuid> directory). Fall back to the single top-level *.php
-    // file declaring a WordPress plugin header.
-    foreach (array(WP_PLUGIN_DIR . '/' . $slug, WPMU_PLUGIN_DIR . '/wp-codebox-runtime/' . $slug) as $dir) {
-        if (!is_dir($dir)) {
-            continue;
-        }
-        $files = glob($dir . '/*.php') ?: array();
-        sort($files);
-        foreach ($files as $file) {
-            $header = @file_get_contents($file, false, null, 0, 8192);
-            if (false !== $header && preg_match('/Plugin Name:[ \\t]*[^ \\t\\r\\n]/', $header)) {
-                $candidate = $slug . '/' . basename($file);
-                if (wp_codebox_plugin_entry_path($candidate)) {
-                    return $candidate;
-                }
-            }
-        }
-    }
-    return null;
-}
+${providerPluginResolutionPhp()}
 
 function wp_codebox_json_encode_sandbox_payload($value): string {
     $json = wp_json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
@@ -643,21 +540,7 @@ function wp_codebox_json_encode_sandbox_payload($value): string {
     return (string) wp_json_encode($fallback, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
 }
 
-function wp_codebox_runtime_replay_component_lifecycle(): array {
-    do_action('plugins_loaded');
-    do_action('init');
-    do_action('wp_abilities_api_categories_init');
-    do_action('wp_abilities_api_init');
-    do_action('wp_codebox_runtime_abilities_ready');
-
-    return array(
-        'plugins_loaded' => function_exists('did_action') ? did_action('plugins_loaded') : null,
-        'init' => function_exists('did_action') ? did_action('init') : null,
-        'wp_abilities_api_categories_init' => function_exists('did_action') ? did_action('wp_abilities_api_categories_init') : null,
-        'wp_abilities_api_init' => function_exists('did_action') ? did_action('wp_abilities_api_init') : null,
-        'wp_codebox_runtime_abilities_ready' => function_exists('did_action') ? did_action('wp_codebox_runtime_abilities_ready') : null,
-    );
-}
+${runtimeLifecycleReplayPhp()}
 
 $activation_results = array();
 
@@ -727,7 +610,53 @@ $plugins = array_merge(array(
     'agents-api/agents-api.php',
 ), wp_codebox_provider_plugin_entries(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)));
 
-function wp_codebox_plugin_entry_path(string $plugin): ?array {
+${providerPluginResolutionPhp()}
+
+${runtimeLifecycleReplayPhp()}
+
+$activation_results = array();
+
+foreach ($plugins as $plugin) {
+    $entry = wp_codebox_plugin_entry_path($plugin);
+    if (!$entry) {
+        $activation_results[$plugin] = array('active' => false, 'error' => 'Plugin is not mounted.');
+        continue;
+    }
+    $result = null;
+    if ('mu-plugin' === $entry['load_as']) {
+        require_once $entry['path'];
+    } else {
+        $result = activate_plugin($plugin);
+    }
+    $activation_results[$plugin] = array(
+        'active' => 'mu-plugin' === $entry['load_as'] ? true : is_plugin_active($plugin),
+        'load_as' => $entry['load_as'],
+        'error' => is_wp_error($result) ? $result->get_error_message() : null,
+    );
+}
+
+$runtime_lifecycle = wp_codebox_runtime_replay_component_lifecycle();
+
+echo json_encode(
+    array(
+        'command' => 'agent-runtime.probe',
+        'wp_loaded' => function_exists('wp_insert_post'),
+        'plugins' => $activation_results,
+        'signals' => array(
+            'agents_api_loaded' => defined('AGENTS_API_LOADED'),
+            'agents_registry_class' => class_exists('WP_Agents_Registry'),
+            'runtime_lifecycle' => $runtime_lifecycle,
+            'provider_plugins' => wp_codebox_provider_plugin_entries(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
+            'provider_plugin_files' => wp_codebox_provider_plugin_file_diagnostics(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
+        ),
+    ),
+    JSON_PRETTY_PRINT
+);
+`
+}
+
+function providerPluginResolutionPhp(): string {
+  return `function wp_codebox_plugin_entry_path(string $plugin): ?array {
     $plugin = ltrim($plugin, '/');
     if ('' === $plugin || str_contains($plugin, '..') || !str_ends_with($plugin, '.php')) {
         return null;
@@ -830,9 +759,11 @@ function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
         }
     }
     return null;
+}`
 }
 
-function wp_codebox_runtime_replay_component_lifecycle(): array {
+function runtimeLifecycleReplayPhp(): string {
+  return `function wp_codebox_runtime_replay_component_lifecycle(): array {
     do_action('plugins_loaded');
     do_action('init');
     do_action('wp_abilities_api_categories_init');
@@ -846,45 +777,5 @@ function wp_codebox_runtime_replay_component_lifecycle(): array {
         'wp_abilities_api_init' => function_exists('did_action') ? did_action('wp_abilities_api_init') : null,
         'wp_codebox_runtime_abilities_ready' => function_exists('did_action') ? did_action('wp_codebox_runtime_abilities_ready') : null,
     );
-}
-
-$activation_results = array();
-
-foreach ($plugins as $plugin) {
-    $entry = wp_codebox_plugin_entry_path($plugin);
-    if (!$entry) {
-        $activation_results[$plugin] = array('active' => false, 'error' => 'Plugin is not mounted.');
-        continue;
-    }
-    $result = null;
-    if ('mu-plugin' === $entry['load_as']) {
-        require_once $entry['path'];
-    } else {
-        $result = activate_plugin($plugin);
-    }
-    $activation_results[$plugin] = array(
-        'active' => 'mu-plugin' === $entry['load_as'] ? true : is_plugin_active($plugin),
-        'load_as' => $entry['load_as'],
-        'error' => is_wp_error($result) ? $result->get_error_message() : null,
-    );
-}
-
-$runtime_lifecycle = wp_codebox_runtime_replay_component_lifecycle();
-
-echo json_encode(
-    array(
-        'command' => 'agent-runtime.probe',
-        'wp_loaded' => function_exists('wp_insert_post'),
-        'plugins' => $activation_results,
-        'signals' => array(
-            'agents_api_loaded' => defined('AGENTS_API_LOADED'),
-            'agents_registry_class' => class_exists('WP_Agents_Registry'),
-            'runtime_lifecycle' => $runtime_lifecycle,
-            'provider_plugins' => wp_codebox_provider_plugin_entries(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
-            'provider_plugin_files' => wp_codebox_provider_plugin_file_diagnostics(json_decode(${JSON.stringify(JSON.stringify(providerPlugins))}, true)),
-        ),
-    ),
-    JSON_PRETTY_PRINT
-);
-`
+}`
 }

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -16,6 +16,7 @@ import { BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BR
 import { argValue, cleanWpCliOutput, commaListArg, durationArg, jsonArrayArg, strictBooleanArg, viewportArg } from "./commands.js"
 import { editorActionStepsFromArgs, editorOpenTargetFromArgs, type EditorActionStep } from "./editor-actions.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
+import { phpBrowserWordPressDiagnosticsPlugin } from "./php-snippets.js"
 import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import type { Page } from "playwright"
@@ -1464,102 +1465,7 @@ interface BrowserWordPressDiagnosticsArtifact {
 
 const BROWSER_WORDPRESS_DIAGNOSTICS_LOG = "/wordpress/wp-content/wp-codebox-browser-diagnostics.jsonl"
 const BROWSER_WORDPRESS_DIAGNOSTICS_MU_PLUGIN = "/wordpress/wp-content/mu-plugins/000-wp-codebox-browser-diagnostics.php"
-const BROWSER_WORDPRESS_DIAGNOSTICS_PLUGIN = `<?php
-/**
- * Plugin Name: WP Codebox Browser Diagnostics
- */
-
-if ( ! defined( 'WPINC' ) ) {
-    return;
-}
-
-function wp_codebox_browser_diagnostics_write( array $record ): void {
-    file_put_contents( WP_CONTENT_DIR . '/wp-codebox-browser-diagnostics.jsonl', wp_json_encode( $record ) . "\n", FILE_APPEND | LOCK_EX );
-}
-
-function wp_codebox_browser_diagnostics_backtrace(): array {
-    $frames = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 12 );
-    $frames = array_slice( $frames, 2 );
-
-    return array_map(
-        static function ( array $frame ): array {
-            return array_filter(
-                array(
-                    'file'     => isset( $frame['file'] ) ? (string) $frame['file'] : null,
-                    'line'     => isset( $frame['line'] ) ? (int) $frame['line'] : null,
-                    'function' => isset( $frame['function'] ) ? (string) $frame['function'] : null,
-                    'class'    => isset( $frame['class'] ) ? (string) $frame['class'] : null,
-                    'type'     => isset( $frame['type'] ) ? (string) $frame['type'] : null,
-                ),
-                static fn ( $value ) => null !== $value && '' !== $value
-            );
-        },
-        $frames
-    );
-}
-
-add_filter(
-    'status_header',
-    static function ( string $status_header, int $code ): string {
-        if ( $code >= 500 && $code < 600 ) {
-            wp_codebox_browser_diagnostics_write(
-                array(
-                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
-                    'classification' => 'http-5xx-status',
-                    'severity'       => 'error',
-                    'status'         => $code,
-                    'statusHeader'   => $status_header,
-                    'requestUri'     => isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '',
-                    'message'        => 'WordPress emitted a 5xx status header during browser navigation.',
-                    'backtrace'      => wp_codebox_browser_diagnostics_backtrace(),
-                    'capturedAt'     => gmdate( 'c' ),
-                )
-            );
-        }
-
-        return $status_header;
-    },
-    10,
-    2
-);
-
-register_shutdown_function(
-    static function (): void {
-        $error = error_get_last();
-        $fatal_types = array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR );
-        if ( is_array( $error ) && in_array( $error['type'] ?? null, $fatal_types, true ) ) {
-            wp_codebox_browser_diagnostics_write(
-                array(
-                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
-                    'classification' => 'php-fatal',
-                    'severity'       => 'error',
-                    'errorType'      => (int) ( $error['type'] ?? 0 ),
-                    'message'        => (string) ( $error['message'] ?? '' ),
-                    'file'           => (string) ( $error['file'] ?? '' ),
-                    'line'           => (int) ( $error['line'] ?? 0 ),
-                    'capturedAt'     => gmdate( 'c' ),
-                )
-            );
-            return;
-        }
-
-        $status = http_response_code();
-        if ( is_int( $status ) && $status >= 500 && $status < 600 ) {
-            wp_codebox_browser_diagnostics_write(
-                array(
-                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
-                    'classification' => 'http-response-code-5xx',
-                    'severity'       => 'error',
-                    'status'         => $status,
-                    'requestUri'     => isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '',
-                    'message'        => 'Browser navigation finished with a 5xx HTTP response code and no PHP fatal.',
-                    'capturedAt'     => gmdate( 'c' ),
-                )
-            );
-        }
-    }
-);
-`
+const BROWSER_WORDPRESS_DIAGNOSTICS_PLUGIN = phpBrowserWordPressDiagnosticsPlugin()
 
 async function installBrowserWordPressDiagnostics(
   runPlaygroundCommand: ((command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>) | undefined,

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { argValue, normalizePhpCode, phpBody } from "./commands.js"
-import { phpEnvAssignments, phpWpConfigDefineAssignments } from "./php-snippets.js"
+import { phpEnvAssignments, phpRuntimeComponentLifecycleReplayFunction, phpWpConfigDefineAssignments } from "./php-snippets.js"
 import { normalizeRuntimeEnvRecord, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 
 interface PhpBootstrapBridge {
@@ -68,7 +68,7 @@ function recipeActivePluginBootstrapPhp(spec: RuntimeCreateSpec): string {
     return ""
   }
 
-  return `${runtimeComponentLifecycleReplayPhp("wp_codebox_run_php")}
+  return `${phpRuntimeComponentLifecycleReplayFunction("wp_codebox_run_php")}
 $wp_codebox_run_php_active_plugins = json_decode(base64_decode('${Buffer.from(JSON.stringify(plugins), "utf8").toString("base64")}'), true);
 function wp_codebox_run_php_plugin_load_diagnostic(array $plugin, string $error = ''): string {
     $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
@@ -119,130 +119,6 @@ foreach (is_array($wp_codebox_run_php_active_plugins) ? $wp_codebox_run_php_acti
     }
 }
 `
-}
-
-function runtimeComponentLifecycleReplayPhp(prefix: string): string {
-  const snapshot = `${prefix}_component_lifecycle_snapshot_hook_callbacks`
-  const defer = `${prefix}_component_lifecycle_defer_new_hook_callbacks`
-  const run = `${prefix}_component_lifecycle_run_deferred_hook_callbacks`
-  const reopen = `${prefix}_component_lifecycle_reopen_action`
-  const restore = `${prefix}_component_lifecycle_restore_action`
-  const abilityNames = `${prefix}_component_lifecycle_ability_names`
-  const prepare = `${prefix}_component_lifecycle_replay_prepare`
-  const complete = `${prefix}_component_lifecycle_replay_complete`
-
-  return `if (!function_exists('${prepare}')) {
-function ${snapshot}(string $hook_name): array {
-    global $wp_filter;
-    $snapshot = array();
-    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
-        return $snapshot;
-    }
-    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
-        foreach (array_keys($callbacks) as $callback_id) {
-            $snapshot[$priority . ':' . $callback_id] = true;
-        }
-    }
-    return $snapshot;
-}
-function ${defer}(string $hook_name, array $before): array {
-    global $wp_filter;
-    $deferred = array();
-    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
-        return $deferred;
-    }
-    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
-        foreach ($callbacks as $callback_id => $callback) {
-            if (isset($before[$priority . ':' . $callback_id])) {
-                continue;
-            }
-            $deferred[] = array('priority' => (int) $priority, 'callback' => $callback);
-            unset($wp_filter[$hook_name]->callbacks[$priority][$callback_id]);
-        }
-        if (empty($wp_filter[$hook_name]->callbacks[$priority])) {
-            unset($wp_filter[$hook_name]->callbacks[$priority]);
-        }
-    }
-    usort($deferred, static function (array $left, array $right): int { return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10); });
-    return $deferred;
-}
-function ${run}(array $deferred, string $hook_name, array $args = array()): void {
-    global $wp_current_filter;
-    if (!is_array($wp_current_filter)) {
-        $wp_current_filter = array();
-    }
-    $wp_current_filter[] = $hook_name;
-    try {
-        foreach ($deferred as $entry) {
-            $callback = $entry['callback'] ?? null;
-            if (!is_array($callback) || !isset($callback['function'])) {
-                continue;
-            }
-            $accepted_args = isset($callback['accepted_args']) ? (int) $callback['accepted_args'] : count($args);
-            call_user_func_array($callback['function'], array_slice($args, 0, $accepted_args));
-        }
-    } finally {
-        array_pop($wp_current_filter);
-    }
-}
-function ${reopen}(string $hook_name): int {
-    global $wp_actions;
-    $count = function_exists('did_action') ? (int) did_action($hook_name) : 0;
-    if ($count > 0) {
-        if (!is_array($wp_actions)) {
-            $wp_actions = array();
-        }
-        $wp_actions[$hook_name] = 0;
-    }
-    return $count;
-}
-function ${restore}(string $hook_name, int $count): void {
-    global $wp_actions;
-    if ($count <= 0) {
-        return;
-    }
-    if (!is_array($wp_actions)) {
-        $wp_actions = array();
-    }
-    $wp_actions[$hook_name] = max($count, (int) ($wp_actions[$hook_name] ?? 0), 1);
-}
-function ${abilityNames}(): array {
-    if (!function_exists('wp_get_abilities')) {
-        return array();
-    }
-    $abilities = wp_get_abilities();
-    return is_array($abilities) ? array_values(array_map('strval', array_keys($abilities))) : array();
-}
-function ${prepare}(): array {
-    $hooks = array('plugins_loaded', 'init', 'wp_abilities_api_categories_init', 'wp_abilities_api_init', 'wp_codebox_runtime_abilities_ready');
-    $state = array('hooks' => array(), 'abilities_before' => ${abilityNames}());
-    foreach ($hooks as $hook_name) {
-        $state['hooks'][$hook_name] = array(
-            'callbacks' => ${snapshot}($hook_name),
-            'did_action' => ${reopen}($hook_name),
-        );
-    }
-    return $state;
-}
-function ${complete}(array $state): array {
-    $diagnostic = array(
-        'schema' => 'wp-codebox/runtime-component-lifecycle-replay/v1',
-        'hooks' => array(),
-        'abilities_before' => $state['abilities_before'] ?? array(),
-        'abilities_after' => array(),
-        'abilities_added' => array(),
-    );
-    foreach (($state['hooks'] ?? array()) as $hook_name => $hook_state) {
-        $deferred = ${defer}((string) $hook_name, is_array($hook_state['callbacks'] ?? null) ? $hook_state['callbacks'] : array());
-        ${run}($deferred, (string) $hook_name);
-        ${restore}((string) $hook_name, (int) ($hook_state['did_action'] ?? 0));
-        $diagnostic['hooks'][(string) $hook_name] = array('replayed_callbacks' => count($deferred), 'previous_did_action' => (int) ($hook_state['did_action'] ?? 0));
-    }
-    $diagnostic['abilities_after'] = ${abilityNames}();
-    $diagnostic['abilities_added'] = array_values(array_diff($diagnostic['abilities_after'], is_array($diagnostic['abilities_before']) ? $diagnostic['abilities_before'] : array()));
-    return $diagnostic;
-}
-}`
 }
 
 function recipeActivePluginMetadata(spec: RuntimeCreateSpec): RecipePluginMetadata[] {

--- a/packages/runtime-playground/src/php-snippets.ts
+++ b/packages/runtime-playground/src/php-snippets.ts
@@ -77,3 +77,226 @@ export function phpWpConfigDefineAppenderFunction(functionName: string, invalidK
     }
 }`
 }
+
+export function phpRuntimeComponentLifecycleReplayFunction(prefix: string): string {
+  const snapshot = `${prefix}_component_lifecycle_snapshot_hook_callbacks`
+  const defer = `${prefix}_component_lifecycle_defer_new_hook_callbacks`
+  const run = `${prefix}_component_lifecycle_run_deferred_hook_callbacks`
+  const reopen = `${prefix}_component_lifecycle_reopen_action`
+  const restore = `${prefix}_component_lifecycle_restore_action`
+  const abilityNames = `${prefix}_component_lifecycle_ability_names`
+  const prepare = `${prefix}_component_lifecycle_replay_prepare`
+  const complete = `${prefix}_component_lifecycle_replay_complete`
+
+  return `if (!function_exists('${prepare}')) {
+function ${snapshot}(string $hook_name): array {
+    global $wp_filter;
+    $snapshot = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $snapshot;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach (array_keys($callbacks) as $callback_id) {
+            $snapshot[$priority . ':' . $callback_id] = true;
+        }
+    }
+    return $snapshot;
+}
+function ${defer}(string $hook_name, array $before): array {
+    global $wp_filter;
+    $deferred = array();
+    if (!isset($wp_filter[$hook_name]) || !isset($wp_filter[$hook_name]->callbacks)) {
+        return $deferred;
+    }
+    foreach ($wp_filter[$hook_name]->callbacks as $priority => $callbacks) {
+        foreach ($callbacks as $callback_id => $callback) {
+            if (isset($before[$priority . ':' . $callback_id])) {
+                continue;
+            }
+            $deferred[] = array('priority' => (int) $priority, 'callback' => $callback);
+            unset($wp_filter[$hook_name]->callbacks[$priority][$callback_id]);
+        }
+        if (empty($wp_filter[$hook_name]->callbacks[$priority])) {
+            unset($wp_filter[$hook_name]->callbacks[$priority]);
+        }
+    }
+    usort($deferred, static function (array $left, array $right): int { return ($left['priority'] ?? 10) <=> ($right['priority'] ?? 10); });
+    return $deferred;
+}
+function ${run}(array $deferred, string $hook_name, array $args = array()): void {
+    global $wp_current_filter;
+    if (!is_array($wp_current_filter)) {
+        $wp_current_filter = array();
+    }
+    $wp_current_filter[] = $hook_name;
+    try {
+        foreach ($deferred as $entry) {
+            $callback = $entry['callback'] ?? null;
+            if (!is_array($callback) || !isset($callback['function'])) {
+                continue;
+            }
+            $accepted_args = isset($callback['accepted_args']) ? (int) $callback['accepted_args'] : count($args);
+            call_user_func_array($callback['function'], array_slice($args, 0, $accepted_args));
+        }
+    } finally {
+        array_pop($wp_current_filter);
+    }
+}
+function ${reopen}(string $hook_name): int {
+    global $wp_actions;
+    $count = function_exists('did_action') ? (int) did_action($hook_name) : 0;
+    if ($count > 0) {
+        if (!is_array($wp_actions)) {
+            $wp_actions = array();
+        }
+        $wp_actions[$hook_name] = 0;
+    }
+    return $count;
+}
+function ${restore}(string $hook_name, int $count): void {
+    global $wp_actions;
+    if ($count <= 0) {
+        return;
+    }
+    if (!is_array($wp_actions)) {
+        $wp_actions = array();
+    }
+    $wp_actions[$hook_name] = max($count, (int) ($wp_actions[$hook_name] ?? 0), 1);
+}
+function ${abilityNames}(): array {
+    if (!function_exists('wp_get_abilities')) {
+        return array();
+    }
+    $abilities = wp_get_abilities();
+    return is_array($abilities) ? array_values(array_map('strval', array_keys($abilities))) : array();
+}
+function ${prepare}(): array {
+    $hooks = array('plugins_loaded', 'init', 'wp_abilities_api_categories_init', 'wp_abilities_api_init', 'wp_codebox_runtime_abilities_ready');
+    $state = array('hooks' => array(), 'abilities_before' => ${abilityNames}());
+    foreach ($hooks as $hook_name) {
+        $state['hooks'][$hook_name] = array(
+            'callbacks' => ${snapshot}($hook_name),
+            'did_action' => ${reopen}($hook_name),
+        );
+    }
+    return $state;
+}
+function ${complete}(array $state): array {
+    $diagnostic = array(
+        'schema' => 'wp-codebox/runtime-component-lifecycle-replay/v1',
+        'hooks' => array(),
+        'abilities_before' => $state['abilities_before'] ?? array(),
+        'abilities_after' => array(),
+        'abilities_added' => array(),
+    );
+    foreach (($state['hooks'] ?? array()) as $hook_name => $hook_state) {
+        $deferred = ${defer}((string) $hook_name, is_array($hook_state['callbacks'] ?? null) ? $hook_state['callbacks'] : array());
+        ${run}($deferred, (string) $hook_name);
+        ${restore}((string) $hook_name, (int) ($hook_state['did_action'] ?? 0));
+        $diagnostic['hooks'][(string) $hook_name] = array('replayed_callbacks' => count($deferred), 'previous_did_action' => (int) ($hook_state['did_action'] ?? 0));
+    }
+    $diagnostic['abilities_after'] = ${abilityNames}();
+    $diagnostic['abilities_added'] = array_values(array_diff($diagnostic['abilities_after'], is_array($diagnostic['abilities_before']) ? $diagnostic['abilities_before'] : array()));
+    return $diagnostic;
+}
+}`
+}
+
+export function phpBrowserWordPressDiagnosticsPlugin(): string {
+  return `<?php
+/**
+ * Plugin Name: WP Codebox Browser Diagnostics
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+    return;
+}
+
+function wp_codebox_browser_diagnostics_write( array $record ): void {
+    file_put_contents( WP_CONTENT_DIR . '/wp-codebox-browser-diagnostics.jsonl', wp_json_encode( $record ) . "\n", FILE_APPEND | LOCK_EX );
+}
+
+function wp_codebox_browser_diagnostics_backtrace(): array {
+    $frames = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 12 );
+    $frames = array_slice( $frames, 2 );
+
+    return array_map(
+        static function ( array $frame ): array {
+            return array_filter(
+                array(
+                    'file'     => isset( $frame['file'] ) ? (string) $frame['file'] : null,
+                    'line'     => isset( $frame['line'] ) ? (int) $frame['line'] : null,
+                    'function' => isset( $frame['function'] ) ? (string) $frame['function'] : null,
+                    'class'    => isset( $frame['class'] ) ? (string) $frame['class'] : null,
+                    'type'     => isset( $frame['type'] ) ? (string) $frame['type'] : null,
+                ),
+                static fn ( $value ) => null !== $value && '' !== $value
+            );
+        },
+        $frames
+    );
+}
+
+add_filter(
+    'status_header',
+    static function ( string $status_header, int $code ): string {
+        if ( $code >= 500 && $code < 600 ) {
+            wp_codebox_browser_diagnostics_write(
+                array(
+                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
+                    'classification' => 'http-5xx-status',
+                    'severity'       => 'error',
+                    'status'         => $code,
+                    'statusHeader'   => $status_header,
+                    'requestUri'     => isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '',
+                    'message'        => 'WordPress emitted a 5xx status header during browser navigation.',
+                    'backtrace'      => wp_codebox_browser_diagnostics_backtrace(),
+                    'capturedAt'     => gmdate( 'c' ),
+                )
+            );
+        }
+
+        return $status_header;
+    },
+    10,
+    2
+);
+
+register_shutdown_function(
+    static function (): void {
+        $error = error_get_last();
+        $fatal_types = array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR );
+        if ( is_array( $error ) && in_array( $error['type'] ?? null, $fatal_types, true ) ) {
+            wp_codebox_browser_diagnostics_write(
+                array(
+                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
+                    'classification' => 'php-fatal',
+                    'severity'       => 'error',
+                    'errorType'      => (int) ( $error['type'] ?? 0 ),
+                    'message'        => (string) ( $error['message'] ?? '' ),
+                    'file'           => (string) ( $error['file'] ?? '' ),
+                    'line'           => (int) ( $error['line'] ?? 0 ),
+                    'capturedAt'     => gmdate( 'c' ),
+                )
+            );
+            return;
+        }
+
+        $status = http_response_code();
+        if ( is_int( $status ) && $status >= 500 && $status < 600 ) {
+            wp_codebox_browser_diagnostics_write(
+                array(
+                    'schema'         => 'wp-codebox/browser-wordpress-diagnostic-record/v1',
+                    'classification' => 'http-response-code-5xx',
+                    'severity'       => 'error',
+                    'status'         => $status,
+                    'requestUri'     => isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '',
+                    'message'        => 'Browser navigation finished with a 5xx HTTP response code and no PHP fatal.',
+                    'capturedAt'     => gmdate( 'c' ),
+                )
+            );
+        }
+    }
+);
+`
+}

--- a/scripts/php-snippets-smoke.ts
+++ b/scripts/php-snippets-smoke.ts
@@ -6,7 +6,9 @@ import { join } from "node:path"
 import {
   phpEnvAssignmentFunction,
   phpEnvAssignments,
+  phpBrowserWordPressDiagnosticsPlugin,
   phpLiteral,
+  phpRuntimeComponentLifecycleReplayFunction,
   phpWpConfigDefineAppenderFunction,
   phpWpConfigDefineAssignment,
   phpWpConfigDefineAssignments,
@@ -56,3 +58,13 @@ assert($invalid_define === array('INVALID-NAME'));
 `)
 execFileSync("php", ["-l", runtimePhp], { stdio: "pipe" })
 execFileSync("php", [runtimePhp], { stdio: "pipe" })
+
+const lifecyclePhp = join(dir, "lifecycle.php")
+writeFileSync(lifecyclePhp, `<?php
+${phpRuntimeComponentLifecycleReplayFunction("wp_codebox_smoke")}
+`)
+execFileSync("php", ["-l", lifecyclePhp], { stdio: "pipe" })
+
+const browserDiagnosticsPhp = join(dir, "browser-diagnostics.php")
+writeFileSync(browserDiagnosticsPhp, phpBrowserWordPressDiagnosticsPlugin())
+execFileSync("php", ["-l", browserDiagnosticsPhp], { stdio: "pipe" })


### PR DESCRIPTION
## Summary
- Extract provider plugin resolution and runtime lifecycle replay PHP fragments used by sandbox agent templates into reusable TS fragment helpers.
- Move runtime component lifecycle replay and browser WordPress diagnostics PHP bodies into shared runtime playground snippet functions.
- Extend the PHP snippets smoke test to lint the extracted lifecycle and browser diagnostics PHP fragments.

## Testing
- npm run build
- npm run smoke -- --command=php-snippets-smoke
- npm run smoke -- --command=runtime-component-lifecycle-replay-smoke
- npm run smoke -- --command=agent-runtime-ability-lifecycle-smoke

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the refactor and targeted smoke coverage; Chris remains responsible for review and validation.