### PR TITLE
Centralize artifact layout writer primitives

### DIFF
--- a/packages/runtime-core/src/artifact-layout.ts
+++ b/packages/runtime-core/src/artifact-layout.ts
@@ -1,0 +1,99 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join, relative } from "node:path"
+
+import { artifactManifestFile, refreshArtifactManifestFileSha256s, type ArtifactManifest, type ArtifactManifestFile, type ArtifactViewerMetadata } from "./artifact-manifest.js"
+
+export interface ManifestedArtifactFileInput {
+  path: string
+  kind: ArtifactManifestFile["kind"]
+  contentType: string
+  viewer?: ArtifactViewerMetadata
+}
+
+export class ManifestedArtifactSet {
+  private readonly entries = new Map<string, ArtifactManifestFile>()
+
+  add(input: ManifestedArtifactFileInput): ArtifactManifestFile {
+    const entry = artifactManifestFile(input.path, input.kind, input.contentType, undefined, input.viewer)
+    this.entries.set(input.path, entry)
+    return entry
+  }
+
+  files(): ArtifactManifestFile[] {
+    return [...this.entries.values()]
+  }
+}
+
+export class ArtifactBundleWriter {
+  readonly artifacts = new ManifestedArtifactSet()
+
+  constructor(
+    private readonly directory: string,
+    private readonly manifestPath = "manifest.json",
+  ) {}
+
+  path(path: string): string {
+    return join(this.directory, path)
+  }
+
+  relativePath(path: string): string {
+    return artifactManifestRelativePath(this.directory, path)
+  }
+
+  async write(path: string, contents: string | Buffer, manifest: Omit<ManifestedArtifactFileInput, "path">): Promise<void> {
+    this.artifacts.add({ path, ...manifest })
+    await mkdir(dirname(this.path(path)), { recursive: true })
+    await writeFile(this.path(path), contents)
+  }
+
+  async writeJson(path: string, value: unknown, manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
+    await this.write(path, artifactJson(value), {
+      ...manifest,
+      contentType: manifest.contentType ?? "application/json",
+    })
+  }
+
+  async writeJsonLines(path: string, records: unknown[], manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
+    await this.write(path, artifactJsonLines(records), {
+      ...manifest,
+      contentType: manifest.contentType ?? "application/x-ndjson",
+    })
+  }
+
+  async writeGenerated(path: string, manifest: Omit<ManifestedArtifactFileInput, "path">, write: (absolutePath: string) => Promise<void>): Promise<void> {
+    this.artifacts.add({ path, ...manifest })
+    await mkdir(dirname(this.path(path)), { recursive: true })
+    await write(this.path(path))
+  }
+
+  async writeManifest<T extends ArtifactManifest>(manifest: T): Promise<T> {
+    this.artifacts.add({ path: this.manifestPath, kind: "manifest", contentType: "application/json" })
+    manifest.files = this.artifacts.files()
+    await writeArtifactManifestJson(this.directory, this.manifestPath, manifest)
+    return manifest
+  }
+}
+
+export function artifactJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+export function artifactJsonLines(records: unknown[]): string {
+  return records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : ""
+}
+
+export function artifactManifestRelativePath(artifactRoot: string, path: string): string {
+  return relative(artifactRoot, path).replace(/\\/g, "/")
+}
+
+export async function writeArtifactJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, artifactJson(value))
+}
+
+export async function writeArtifactManifestJson(directory: string, manifestPath: string, manifest: ArtifactManifest): Promise<void> {
+  await refreshArtifactManifestFileSha256s(directory, manifest, manifestPath)
+  await writeArtifactJson(join(directory, manifestPath), manifest)
+  await refreshArtifactManifestFileSha256s(directory, manifest, manifestPath)
+  await writeArtifactJson(join(directory, manifestPath), manifest)
+}

--- a/packages/runtime-core/src/artifact-references.ts
+++ b/packages/runtime-core/src/artifact-references.ts
@@ -2,12 +2,28 @@ import type { ArtifactBundle, RuntimeEpisodeContentDigest, RuntimeEpisodeTraceRe
 import type { ArtifactFileDigest, ArtifactManifestFile, ArtifactViewerMetadata } from "./artifact-manifest.js"
 import type { RuntimeReferenceManifestArtifactBundleRef, RuntimeReferenceManifestFileRef } from "./runtime-reference.js"
 
+export const METADATA_ARTIFACT_PATH = "metadata.json" as const
+export const REVIEW_ARTIFACT_PATH = "files/review.json" as const
 export const RUNTIME_EPISODE_TRACE_ARTIFACT_PATH = "files/runtime-episode-trace.json" as const
 export const RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH = "files/runtime-episode.jsonl" as const
 export const RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH = "files/runtime-reference-manifest.json" as const
 export const RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH = "files/runtime-replay-index.json" as const
+export const RUNTIME_SNAPSHOT_ARTIFACT_PATH = "files/runtime-snapshot.json" as const
 export const CHANGED_FILES_ARTIFACT_PATH = "files/changed-files.json" as const
 export const ARTIFACT_MANIFEST_PATH = "manifest.json" as const
+
+const RUNTIME_REFERENCE_MANIFEST_EXCLUDED_PATHS = new Set<string>([
+  ARTIFACT_MANIFEST_PATH,
+  METADATA_ARTIFACT_PATH,
+  REVIEW_ARTIFACT_PATH,
+  RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH,
+  RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
+])
+
+const RUNTIME_REPLAY_REFERENCE_INDEX_EXCLUDED_PATHS = new Set<string>([
+  ARTIFACT_MANIFEST_PATH,
+  RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
+])
 
 export interface ArtifactReferenceDigestInput {
   algorithm?: string
@@ -115,6 +131,14 @@ export function normalizeRuntimeReferenceManifestFileRefs(inputs: Array<Artifact
   return inputs
     .map((input) => normalizeRuntimeReferenceManifestFileRef(input))
     .filter((ref): ref is RuntimeReferenceManifestFileRef => ref !== undefined)
+}
+
+export function runtimeReferenceManifestArtifactFiles(files: ArtifactManifestFile[]): ArtifactManifestFile[] {
+  return files.filter((file) => !RUNTIME_REFERENCE_MANIFEST_EXCLUDED_PATHS.has(file.path))
+}
+
+export function runtimeReplayReferenceIndexArtifactFiles(files: ArtifactManifestFile[]): ArtifactManifestFile[] {
+  return files.filter((file) => !RUNTIME_REPLAY_REFERENCE_INDEX_EXCLUDED_PATHS.has(file.path))
 }
 
 export function normalizeRuntimeEpisodeTraceRef(input: ArtifactReferenceTraceInput, defaults: NormalizeRuntimeEpisodeTraceRefDefaults = {}): RuntimeEpisodeTraceRef | undefined {

--- a/packages/runtime-core/src/artifacts.ts
+++ b/packages/runtime-core/src/artifacts.ts
@@ -1,4 +1,5 @@
 export * from "./artifact-manifest.js"
+export * from "./artifact-layout.js"
 export * from "./artifact-references.js"
 export * from "./artifact-review.js"
 export * from "./artifact-diagnostics.js"

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./artifact-manifest.js"
+export * from "./artifact-layout.js"
 export * from "./artifact-references.js"
 export * from "./artifact-review.js"
 export * from "./artifact-diagnostics.js"

--- a/packages/runtime-core/src/runtime-episode.ts
+++ b/packages/runtime-core/src/runtime-episode.ts
@@ -4,13 +4,18 @@ import { join } from "node:path"
 
 import { artifactFileDigest, artifactManifestFile, refreshArtifactManifestFileSha256s, upsertArtifactManifestFiles } from "./artifact-manifest.js"
 import type { ArtifactManifest, ArtifactSpec } from "./artifact-manifest.js"
+import { writeArtifactJson, writeArtifactManifestJson } from "./artifact-layout.js"
 import {
+  ARTIFACT_MANIFEST_PATH,
   RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH,
   RUNTIME_EPISODE_TRACE_ARTIFACT_PATH,
+  RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH,
   RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
   normalizeArtifactBundleTraceRef,
   normalizeRuntimeReferenceArtifactBundleRef,
   normalizeRuntimeReferenceManifestFileRefs,
+  runtimeReferenceManifestArtifactFiles,
+  runtimeReplayReferenceIndexArtifactFiles,
 } from "./artifact-references.js"
 import { isPlainObject as isRecord } from "./object-utils.js"
 import {
@@ -271,8 +276,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
     const snapshotDirectory = join(this.artifacts.directory, "files/runtime-snapshots")
     await mkdir(snapshotDirectory, { recursive: true })
-    const baseRefs = manifest.files
-      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
+    const baseRefs = runtimeReferenceManifestArtifactFiles(manifest.files)
     const snapshotRefs = normalizeRuntimeReferenceManifestFileRefs(baseRefs)
 
     for (const [index, snapshot] of this.snapshots.entries()) {
@@ -305,7 +309,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
         },
         refs: snapshotRefs,
       }
-      await writeFile(join(this.artifacts.directory, relativePath), `${JSON.stringify(bundle, null, 2)}\n`)
+      await writeArtifactJson(join(this.artifacts.directory, relativePath), bundle)
       const digest = artifactFileDigest(await readFile(join(this.artifacts.directory, relativePath)))
       const artifactRef: RuntimeEpisodeTraceRef = {
         kind: "runtime-snapshot-bundle",
@@ -324,8 +328,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       upsertArtifactManifestFiles(manifest, [artifactManifestFile(relativePath, "runtime-snapshot-bundle", "application/json")])
     }
 
-    await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
-    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeArtifactManifestJson(this.artifacts.directory, ARTIFACT_MANIFEST_PATH, manifest)
   }
 
   private async persistRuntimeEpisodeTraceArtifacts(): Promise<void> {
@@ -351,8 +354,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     }
 
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
-    const fileRefs = manifest.files
-      .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
+    const fileRefs = runtimeReferenceManifestArtifactFiles(manifest.files)
     const referenceFiles = normalizeRuntimeReferenceManifestFileRefs(fileRefs)
     const traceRef = referenceFiles.find((file) => file.path === traceRelativePath)
     const eventsRef = referenceFiles.find((file) => file.path === eventsRelativePath)
@@ -369,9 +371,9 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       ...(eventsRef ? { events: eventsRef } : {}),
       snapshots: this.snapshots,
     })
-    await writeFile(this.artifacts.runtimeReferenceManifestPath, `${JSON.stringify(referenceManifest, null, 2)}\n`)
+    await writeArtifactJson(this.artifacts.runtimeReferenceManifestPath, referenceManifest)
     await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
-    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeArtifactJson(this.artifacts.manifestPath, manifest)
   }
 
   private async updateRuntimeReplayReferenceIndexForRuntimeEpisodeTrace(trace: RuntimeEpisodeTrace, traceRelativePath: string, eventsRelativePath: string): Promise<void> {
@@ -380,12 +382,11 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
     }
 
     const manifest = JSON.parse(await readFile(this.artifacts.manifestPath, "utf8")) as ArtifactManifest
-    const fileRefs = manifest.files
-      .filter((file) => file.path !== "manifest.json")
+    const fileRefs = runtimeReplayReferenceIndexArtifactFiles(manifest.files)
     const referenceFiles = normalizeRuntimeReferenceManifestFileRefs(fileRefs)
     const traceRef = referenceFiles.find((file) => file.path === traceRelativePath)
     const eventsRef = referenceFiles.find((file) => file.path === eventsRelativePath)
-    const runtimeReferenceManifestRef = referenceFiles.find((file) => file.path === "files/runtime-reference-manifest.json")
+    const runtimeReferenceManifestRef = referenceFiles.find((file) => file.path === RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH)
     const artifactBundle = normalizeRuntimeReferenceArtifactBundleRef(manifest)
     if (!artifactBundle) {
       return
@@ -401,9 +402,9 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       snapshots: this.snapshots,
       episodeTrace: trace,
     })
-    await writeFile(this.artifacts.runtimeReplayReferenceIndexPath, `${JSON.stringify(replayIndex, null, 2)}\n`)
+    await writeArtifactJson(this.artifacts.runtimeReplayReferenceIndexPath, replayIndex)
     await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
-    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeArtifactJson(this.artifacts.manifestPath, manifest)
   }
 
   private async updateArtifactManifestForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
@@ -418,7 +419,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       artifactManifestFile(RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH, "runtime-replay-index", "application/json"),
     ])
     await refreshArtifactManifestFileSha256s(this.artifacts.directory, manifest)
-    await writeFile(this.artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeArtifactManifestJson(this.artifacts.directory, ARTIFACT_MANIFEST_PATH, manifest)
   }
 
   private async updateArtifactMetadataForRuntimeEpisodeTrace(traceRelativePath: string, eventsRelativePath: string): Promise<void> {
@@ -433,7 +434,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
       runtimeEpisodeEvents: eventsRelativePath,
       runtimeReplayReferenceIndex: RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
     }
-    await writeFile(this.artifacts.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`)
+    await writeArtifactJson(this.artifacts.metadataPath, metadata)
   }
 
   private async updateArtifactReviewForRuntimeEpisodeTrace(traceRelativePath: string): Promise<void> {
@@ -452,7 +453,7 @@ class RuntimeEpisodeRunner implements RuntimeEpisode {
         timestamp: new Date().toISOString(),
       })
     }
-    await writeFile(this.artifacts.reviewPath, `${JSON.stringify(review, null, 2)}\n`)
+    await writeArtifactJson(this.artifacts.reviewPath, review)
   }
 
   async trace(): Promise<RuntimeEpisodeTrace> {

--- a/packages/runtime-core/src/runtime-reference.ts
+++ b/packages/runtime-core/src/runtime-reference.ts
@@ -1,7 +1,13 @@
 import { createHash } from "node:crypto"
 
 import type { ArtifactFileDigest, ArtifactViewerMetadata } from "./artifact-manifest.js"
-import { normalizeObservationArtifactRefs, normalizeRuntimeReferenceManifestFileRef } from "./artifact-references.js"
+import {
+  RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH,
+  RUNTIME_EPISODE_TRACE_ARTIFACT_PATH,
+  RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH,
+  normalizeObservationArtifactRefs,
+  normalizeRuntimeReferenceManifestFileRef,
+} from "./artifact-references.js"
 import { stableJson } from "./object-utils.js"
 import type {
   ObservationResult,
@@ -162,9 +168,9 @@ export function runtimeReferenceManifestDigest(manifest: RuntimeReferenceManifes
 export function buildRuntimeReplayReferenceIndex(input: BuildRuntimeReplayReferenceIndexInput): RuntimeReplayReferenceIndex {
   const filesByPath = new Map(input.files.map((file) => [file.path, runtimeReferenceManifestFileRef(file)]))
   const references = compactUndefined<RuntimeReplayReferenceIndex["references"]>({
-    trace: input.trace ? runtimeReferenceManifestFileRef(input.trace) : filesByPath.get("files/runtime-episode-trace.json"),
-    events: input.events ? runtimeReferenceManifestFileRef(input.events) : filesByPath.get("files/runtime-episode.jsonl"),
-    runtimeReferenceManifest: input.runtimeReferenceManifest ? runtimeReferenceManifestFileRef(input.runtimeReferenceManifest) : filesByPath.get("files/runtime-reference-manifest.json"),
+    trace: input.trace ? runtimeReferenceManifestFileRef(input.trace) : filesByPath.get(RUNTIME_EPISODE_TRACE_ARTIFACT_PATH),
+    events: input.events ? runtimeReferenceManifestFileRef(input.events) : filesByPath.get(RUNTIME_EPISODE_EVENTS_ARTIFACT_PATH),
+    runtimeReferenceManifest: input.runtimeReferenceManifest ? runtimeReferenceManifestFileRef(input.runtimeReferenceManifest) : filesByPath.get(RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH),
     observations: filesByPath.get("observations.jsonl"),
     commands: filesByPath.get("commands.jsonl"),
     runtimeEvents: filesByPath.get("events.jsonl"),

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -1,6 +1,12 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join, relative } from "node:path"
 import {
+  ARTIFACT_MANIFEST_PATH,
+  CHANGED_FILES_ARTIFACT_PATH,
+  METADATA_ARTIFACT_PATH,
+  REVIEW_ARTIFACT_PATH,
+  RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH,
+  RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
   buildRuntimeReferenceManifest,
   buildRuntimeReplayReferenceIndex,
   artifactFileDigest,
@@ -8,6 +14,8 @@ import {
   artifactManifestFileWithSha256,
   calculateArtifactManifestFileSha256,
   refreshArtifactManifestFileSha256s,
+  runtimeReferenceManifestArtifactFiles,
+  runtimeReplayReferenceIndexArtifactFiles,
   type ArtifactEvidenceRef,
   type ArtifactBundle,
   type ArtifactDurablePreviewRef,
@@ -95,8 +103,8 @@ export class ArtifactBundleBuilder {
     await mkdir(filesDirectory, { recursive: true })
 
     const createdAt = new Date().toISOString()
-    const manifestPath = join(source.artifactRoot, "manifest.json")
-    const metadataPath = join(source.artifactRoot, "metadata.json")
+    const manifestPath = join(source.artifactRoot, ARTIFACT_MANIFEST_PATH)
+    const metadataPath = join(source.artifactRoot, METADATA_ARTIFACT_PATH)
     const blueprintAfterPath = join(source.artifactRoot, "blueprint.after.json")
     const blueprintAfterNotesPath = join(source.artifactRoot, "blueprint.after-notes.json")
     const eventsPath = join(source.artifactRoot, "events.jsonl")
@@ -107,15 +115,15 @@ export class ArtifactBundleBuilder {
     const mountsPath = join(filesDirectory, "mounts.json")
     const capturedMountsPath = join(filesDirectory, "mounted-files.json")
     const diffsPath = join(filesDirectory, "diffs.json")
-    const changedFilesPath = join(filesDirectory, "changed-files.json")
+    const changedFilesPath = join(source.artifactRoot, CHANGED_FILES_ARTIFACT_PATH)
     const patchPath = join(filesDirectory, "patch.diff")
     const workspacePatchPath = join(filesDirectory, "workspace-patch.json")
     const diagnosticsPath = join(filesDirectory, "diagnostics.json")
     const testResultsPath = join(filesDirectory, "test-results.json")
-    const reviewPath = join(filesDirectory, "review.json")
-    const runtimeReferenceManifestPath = join(filesDirectory, "runtime-reference-manifest.json")
+    const reviewPath = join(source.artifactRoot, REVIEW_ARTIFACT_PATH)
+    const runtimeReferenceManifestPath = join(source.artifactRoot, RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH)
     const runtimeReferenceIndexPath = join(filesDirectory, "runtime-reference-index.json")
-    const runtimeReplayReferenceIndexPath = join(filesDirectory, "runtime-replay-index.json")
+    const runtimeReplayReferenceIndexPath = join(source.artifactRoot, RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH)
     const previewEvidencePath = join(filesDirectory, "preview-evidence.json")
     const previewSessionEvidencePath = join(filesDirectory, "preview-session-evidence.json")
     const redactor = new ArtifactRedactor(source.spec.secretEnv)
@@ -146,7 +154,7 @@ export class ArtifactBundleBuilder {
     const replayExportPackageFiles = replayExportPackageManifestFiles(source.artifactRoot, source.commands)
     const capturedMounts = await source.captureMountedFiles(filesDirectory, redactor)
     const { mountDiffs, changedFiles, patch, diagnostics: mountDiffDiagnostics } = await source.captureMountDiffs(filesDirectory, redactor)
-    const changedFilesJson = redactor.redact("files/changed-files.json", `${JSON.stringify(changedFiles, null, 2)}\n`)
+    const changedFilesJson = redactor.redact(CHANGED_FILES_ARTIFACT_PATH, `${JSON.stringify(changedFiles, null, 2)}\n`)
     const redactedPatch = redactor.redact("files/patch.diff", patch)
     const contentDigest = artifactContentDigest(changedFilesJson, redactedPatch)
     const bundleId = `artifact-bundle-sha256-${contentDigest}`
@@ -374,7 +382,7 @@ export class ArtifactBundleBuilder {
       id: bundleId,
       contentDigest: {
         algorithm: "sha256",
-        inputs: ["files/changed-files.json", "files/patch.diff"],
+        inputs: [CHANGED_FILES_ARTIFACT_PATH, "files/patch.diff"],
         value: contentDigest,
       },
       createdAt,
@@ -402,17 +410,16 @@ export class ArtifactBundleBuilder {
         id: bundleId,
         digest: { algorithm: "sha256", value: contentDigest },
       },
-      files: manifest.files
-        .filter((file) => !["manifest.json", "metadata.json", "files/review.json", "files/runtime-reference-manifest.json", "files/runtime-replay-index.json"].includes(file.path))
+      files: runtimeReferenceManifestArtifactFiles(manifest.files)
         .map((file) => ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256, ...(file.viewer ? { viewer: cloneArtifactViewerMetadata(file.viewer) } : {}) })),
       snapshots: runtimeSnapshots,
     })
     await writeFile(runtimeReferenceManifestPath, artifactJson(runtimeReferenceManifest))
     const runtimeReferenceManifestRef = artifactManifestFileWithSha256(
-      "files/runtime-reference-manifest.json",
+      RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH,
       "runtime-reference-manifest",
       "application/json",
-      await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, artifactManifestFile("files/runtime-reference-manifest.json", "runtime-reference-manifest", "application/json")),
+      await calculateArtifactManifestFileSha256(source.artifactRoot, manifest, artifactManifestFile(RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH, "runtime-reference-manifest", "application/json")),
     )
     const runtimeReplayReferenceIndex = buildRuntimeReplayReferenceIndex({
       createdAt,
@@ -422,9 +429,8 @@ export class ArtifactBundleBuilder {
         id: bundleId,
         digest: { algorithm: "sha256", value: contentDigest },
       },
-      files: manifest.files
-        .filter((file) => !["manifest.json", "files/runtime-replay-index.json"].includes(file.path))
-        .map((file) => file.path === "files/runtime-reference-manifest.json" ? runtimeReferenceManifestRef : ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256, ...(file.viewer ? { viewer: cloneArtifactViewerMetadata(file.viewer) } : {}) })),
+      files: runtimeReplayReferenceIndexArtifactFiles(manifest.files)
+        .map((file) => file.path === RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH ? runtimeReferenceManifestRef : ({ path: file.path, kind: file.kind, contentType: file.contentType, sha256: file.sha256, ...(file.viewer ? { viewer: cloneArtifactViewerMetadata(file.viewer) } : {}) })),
       runtimeReferenceManifest: runtimeReferenceManifestRef,
       snapshots: runtimeSnapshots,
     })

--- a/packages/runtime-playground/src/artifact-bundle-writer.ts
+++ b/packages/runtime-playground/src/artifact-bundle-writer.ts
@@ -1,119 +1,13 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises"
-import { dirname, join, relative } from "node:path"
+import { readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
 
-import {
-  artifactManifestFile,
-  refreshArtifactManifestFileSha256s,
-  type ArtifactManifest,
-  type ArtifactManifestFile,
-  type ArtifactViewerMetadata,
-} from "@automattic/wp-codebox-core"
+import { artifactManifestRelativePath } from "@automattic/wp-codebox-core"
 import type { ArtifactRedactor } from "./artifacts.js"
 
-export interface ManifestedArtifactFileInput {
-  path: string
-  kind: ArtifactManifestFile["kind"]
-  contentType: string
-  viewer?: ArtifactViewerMetadata
-}
+export { ArtifactBundleWriter, ManifestedArtifactSet, artifactJson, artifactJsonLines, artifactManifestRelativePath, type ManifestedArtifactFileInput } from "@automattic/wp-codebox-core"
 
 export interface RedactArtifactFilesOptions {
   tolerateMissing?: boolean
-}
-
-export class ManifestedArtifactSet {
-  private readonly entries = new Map<string, ArtifactManifestFile>()
-
-  add(input: ManifestedArtifactFileInput): ArtifactManifestFile {
-    const entry = artifactManifestFile(input.path, input.kind, input.contentType, undefined, input.viewer)
-    this.entries.set(input.path, entry)
-    return entry
-  }
-
-  files(): ArtifactManifestFile[] {
-    return [...this.entries.values()]
-  }
-}
-
-export class ArtifactBundleWriter {
-  readonly artifacts = new ManifestedArtifactSet()
-
-  constructor(
-    private readonly directory: string,
-    private readonly manifestPath = "manifest.json",
-  ) {}
-
-  path(path: string): string {
-    return join(this.directory, path)
-  }
-
-  relativePath(path: string): string {
-    return artifactManifestRelativePath(this.directory, path)
-  }
-
-  async write(path: string, contents: string | Buffer, manifest: Omit<ManifestedArtifactFileInput, "path">): Promise<void> {
-    this.artifacts.add({ path, ...manifest })
-    await mkdir(dirname(this.path(path)), { recursive: true })
-    await writeFile(this.path(path), contents)
-  }
-
-  async writeJson(path: string, value: unknown, manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
-    await this.write(path, artifactJson(value), {
-      ...manifest,
-      contentType: manifest.contentType ?? "application/json",
-    })
-  }
-
-  async writeJsonLines(path: string, records: unknown[], manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
-    await this.write(path, artifactJsonLines(records), {
-      ...manifest,
-      contentType: manifest.contentType ?? "application/x-ndjson",
-    })
-  }
-
-  async writeRedacted(path: string, contents: string, redactor: ArtifactRedactor, manifest: Omit<ManifestedArtifactFileInput, "path">): Promise<void> {
-    await this.write(path, redactor.redact(path, contents), manifest)
-  }
-
-  async writeRedactedJson(path: string, value: unknown, redactor: ArtifactRedactor, manifest: Omit<ManifestedArtifactFileInput, "path" | "contentType"> & { contentType?: string }): Promise<void> {
-    await this.writeRedacted(path, artifactJson(value), redactor, {
-      ...manifest,
-      contentType: manifest.contentType ?? "application/json",
-    })
-  }
-
-  async writeGenerated(path: string, manifest: Omit<ManifestedArtifactFileInput, "path">, write: (absolutePath: string) => Promise<void>): Promise<void> {
-    this.artifacts.add({ path, ...manifest })
-    await mkdir(dirname(this.path(path)), { recursive: true })
-    await write(this.path(path))
-  }
-
-  async writeManifest<T extends ArtifactManifest>(manifest: T): Promise<T> {
-    this.artifacts.add({ path: this.manifestPath, kind: "manifest", contentType: "application/json" })
-    manifest.files = this.artifacts.files()
-    await refreshArtifactManifestFileSha256s(this.directory, manifest, this.manifestPath)
-    await this.writeManifestJson(manifest)
-    await refreshArtifactManifestFileSha256s(this.directory, manifest, this.manifestPath)
-    await this.writeManifestJson(manifest)
-    return manifest
-  }
-
-  private async writeManifestJson(manifest: ArtifactManifest): Promise<void> {
-    await mkdir(dirname(this.path(this.manifestPath)), { recursive: true })
-    await writeFile(this.path(this.manifestPath), artifactJson(manifest))
-  }
-}
-
-export function artifactJson(value: unknown): string {
-  return `${JSON.stringify(value, null, 2)}\n`
-}
-
-export function artifactJsonLines(records: unknown[]): string {
-  return records.length > 0 ? `${records.map((record) => JSON.stringify(record)).join("\n")}\n` : ""
-}
-
-export function artifactManifestRelativePath(artifactRoot: string, path: string): string {
-  return relative(artifactRoot, path).replace(/\\/g, "/")
 }
 
 export async function writeRedactedArtifactFile(artifactRoot: string, path: string, contents: string, redactor: ArtifactRedactor): Promise<void> {

--- a/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
+++ b/packages/runtime-playground/src/replayable-wordpress-site-bundle.ts
@@ -1,9 +1,13 @@
-import { mkdir, stat, writeFile } from "node:fs/promises"
+import { stat, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import {
+  ARTIFACT_MANIFEST_PATH,
+  RUNTIME_SNAPSHOT_ARTIFACT_PATH,
+  artifactJson,
   artifactManifestFile,
   calculateArtifactContentDigest,
-  refreshArtifactManifestFileSha256s,
+  writeArtifactJson,
+  writeArtifactManifestJson,
   type ArtifactManifest,
   type RuntimeInfo,
 } from "@automattic/wp-codebox-core"
@@ -78,7 +82,7 @@ export async function writeReplayExportPackage(snapshot: RuntimeSnapshotArtifact
   const createdAt = options.createdAt ?? new Date().toISOString()
   const directory = options.directory
   const writer = new ArtifactBundleWriter(directory)
-  const snapshotPath = "files/runtime-snapshot.json"
+  const snapshotPath = RUNTIME_SNAPSHOT_ARTIFACT_PATH
   const blueprintPath = "blueprint.after.json"
   const playgroundBundlePath = "blueprint.zip"
   const notesPath = "blueprint.after-notes.json"
@@ -96,8 +100,8 @@ export async function writeReplayExportPackage(snapshot: RuntimeSnapshotArtifact
   await writer.writeJson(snapshotPath, snapshot, { kind: "runtime-snapshot" })
   await writer.writeJson(notesPath, notes, { kind: "blueprint-after-notes" })
   await writer.writeGenerated(playgroundBundlePath, { kind: "playground-blueprint-bundle", contentType: "application/zip" }, (path) => writePlaygroundBlueprintBundle(path, [
-    { path: "blueprint.json", data: `${JSON.stringify(blueprint, null, 2)}\n` },
-    { path: "files/runtime-snapshot.json", data: `${JSON.stringify(snapshot, null, 2)}\n` },
+    { path: "blueprint.json", data: artifactJson(blueprint) },
+    { path: RUNTIME_SNAPSHOT_ARTIFACT_PATH, data: artifactJson(snapshot) },
   ]))
 
   const contentInputs = [blueprintPath, playgroundBundlePath, snapshotPath, notesPath]
@@ -148,7 +152,7 @@ export async function writeReplayExportPackage(snapshot: RuntimeSnapshotArtifact
       blueprintBytes: blueprintStats.size,
     },
     artifacts: {
-      manifest: "manifest.json",
+      manifest: ARTIFACT_MANIFEST_PATH,
       blueprint: blueprintPath,
       playgroundBundle: playgroundBundlePath,
       snapshot: snapshotPath,
@@ -165,14 +169,13 @@ export async function writeReplayableWordPressSiteBundle(
   const createdAt = options.createdAt ?? new Date().toISOString()
   const directory = options.directory
   const filesDirectory = join(directory, "files")
-  await mkdir(filesDirectory, { recursive: true })
 
   const blueprint = buildReplayableWordPressSiteBlueprint(snapshot, options)
   const limitations = buildReplayableWordPressSiteLimitations(snapshot, options)
 
-  await writeJson(join(directory, "blueprint.json"), blueprint)
-  await writeJson(join(filesDirectory, "runtime-snapshot.json"), snapshot)
-  await writeJson(join(filesDirectory, "replay-limitations.json"), limitations)
+  await writeArtifactJson(join(directory, "blueprint.json"), blueprint)
+  await writeArtifactJson(join(filesDirectory, "runtime-snapshot.json"), snapshot)
+  await writeArtifactJson(join(filesDirectory, "replay-limitations.json"), limitations)
 
   const contentInputs = ["blueprint.json", "files/runtime-snapshot.json", "files/replay-limitations.json"]
   const contentDigest = await calculateArtifactContentDigest(directory, contentInputs)
@@ -189,7 +192,7 @@ export async function writeReplayableWordPressSiteBundle(
     createdAt,
     runtime: runtimeInfoForReplayableWordPressSite(snapshot, id, createdAt, blueprint),
     files: [
-      artifactManifestFile("manifest.json", "manifest", "application/json"),
+      artifactManifestFile(ARTIFACT_MANIFEST_PATH, "manifest", "application/json"),
       artifactManifestFile("blueprint.json", "playground-blueprint", "application/json"),
       artifactManifestFile("files/runtime-snapshot.json", "runtime-snapshot", "application/json"),
       artifactManifestFile("files/replay-limitations.json", "replay-limitations", "application/json"),
@@ -203,15 +206,12 @@ export async function writeReplayableWordPressSiteBundle(
     },
   }
 
-  await refreshArtifactManifestFileSha256s(directory, manifest)
-  await writeJson(join(directory, "manifest.json"), manifest)
-  await refreshArtifactManifestFileSha256s(directory, manifest)
-  await writeJson(join(directory, "manifest.json"), manifest)
+  await writeArtifactManifestJson(directory, ARTIFACT_MANIFEST_PATH, manifest)
 
   return {
     id,
     directory,
-    manifestPath: join(directory, "manifest.json"),
+    manifestPath: join(directory, ARTIFACT_MANIFEST_PATH),
     blueprintPath: join(directory, "blueprint.json"),
     snapshotPath: join(filesDirectory, "runtime-snapshot.json"),
     limitationsPath: join(filesDirectory, "replay-limitations.json"),
@@ -322,10 +322,6 @@ function runtimeInfoForReplayableWordPressSite(
 
 function playgroundBlueprintPhpVersion(version: string): string {
   return version.replace(/^(\d+\.\d+)\.\d+$/, "$1")
-}
-
-async function writeJson(path: string, value: unknown): Promise<void> {
-  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
 }
 
 async function writePlaygroundBlueprintBundle(path: string, entries: Array<{ path: string; data: string }>): Promise<void> {

--- a/scripts/artifact-layout-writer-smoke.ts
+++ b/scripts/artifact-layout-writer-smoke.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import {
+  ARTIFACT_MANIFEST_PATH,
+  ArtifactBundleWriter,
+  METADATA_ARTIFACT_PATH,
+  REVIEW_ARTIFACT_PATH,
+  RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH,
+  RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH,
+  artifactManifestFile,
+  runtimeReferenceManifestArtifactFiles,
+  runtimeReplayReferenceIndexArtifactFiles,
+  type ArtifactManifest,
+} from "@automattic/wp-codebox-core"
+
+const directory = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-layout-"))
+
+try {
+  const writer = new ArtifactBundleWriter(directory)
+  await writer.writeJson("files/example.json", { ok: true }, { kind: "example" })
+
+  const manifest: ArtifactManifest = {
+    id: "artifact-bundle-sha256-test",
+    contentDigest: {
+      algorithm: "sha256",
+      inputs: ["files/example.json"],
+      value: "1".repeat(64),
+    },
+    createdAt: "2026-06-17T00:00:00.000Z",
+    runtime: {
+      id: "runtime-test",
+      backend: "test",
+      createdAt: "2026-06-17T00:00:00.000Z",
+      environment: {},
+    },
+    files: [],
+  }
+
+  await writer.writeManifest(manifest)
+
+  const written = JSON.parse(await readFile(join(directory, ARTIFACT_MANIFEST_PATH), "utf8")) as ArtifactManifest
+  assert.deepEqual(written.files.map((file) => file.path), ["files/example.json", ARTIFACT_MANIFEST_PATH])
+  assert.notEqual(written.files.find((file) => file.path === ARTIFACT_MANIFEST_PATH)?.sha256.value, "0".repeat(64))
+  assert.equal(writer.relativePath(join(directory, "files", "example.json")), "files/example.json")
+
+  const files = [
+    artifactManifestFile(ARTIFACT_MANIFEST_PATH, "manifest", "application/json"),
+    artifactManifestFile(METADATA_ARTIFACT_PATH, "metadata", "application/json"),
+    artifactManifestFile(REVIEW_ARTIFACT_PATH, "review", "application/json"),
+    artifactManifestFile(RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH, "runtime-reference-manifest", "application/json"),
+    artifactManifestFile(RUNTIME_REPLAY_REFERENCE_INDEX_ARTIFACT_PATH, "runtime-replay-index", "application/json"),
+    artifactManifestFile("files/example.json", "example", "application/json"),
+  ]
+
+  assert.deepEqual(runtimeReferenceManifestArtifactFiles(files).map((file) => file.path), ["files/example.json"])
+  assert.deepEqual(runtimeReplayReferenceIndexArtifactFiles(files).map((file) => file.path), [METADATA_ARTIFACT_PATH, REVIEW_ARTIFACT_PATH, RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH, "files/example.json"])
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}
+
+console.log("Artifact layout writer smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -60,6 +60,7 @@ export const smokeGroups = {
     description: "Artifact contract and normalization smoke checks.",
     commands: [
       tsxSmoke("artifact-bundle-verifier-smoke"),
+      tsxSmoke("artifact-layout-writer-smoke"),
       tsxSmoke("artifact-apply-adapter-smoke"),
       tsxSmoke("transfer-proof-smoke"),
       tsxSmoke("artifact-redaction-smoke"),


### PR DESCRIPTION
## Summary
- Move generic artifact writer/layout helpers into runtime-core and re-export them through the existing artifact surfaces.
- Centralize canonical artifact paths and runtime reference/replay manifest inclusion filters.
- Refactor playground bundle builders and runtime episode/reference updates to use the shared path/filter/write helpers while preserving output shapes.
- Add artifact layout writer smoke coverage and include it in the artifact smoke group.

## Tests
- npm run build
- npx tsx scripts/artifact-layout-writer-smoke.ts
- npm run smoke -- --group=artifact

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the artifact layout/writer refactor, smoke coverage, and local verification; Chris remains responsible for review and acceptance.
