### PR TITLE
Extract recipe source boundary helpers

### DIFF
--- a/packages/cli/src/overlay-preparers.ts
+++ b/packages/cli/src/overlay-preparers.ts
@@ -1,0 +1,28 @@
+export interface OverlayPrepareContext<TPrepared> {
+  index: number
+  recipeDirectory: string
+  prepare: () => Promise<TPrepared>
+}
+
+export type OverlayPreparer<TOverlay, TPrepared> = (overlay: TOverlay, context: OverlayPrepareContext<TPrepared>) => Promise<TPrepared>
+
+export class OverlayPreparerRegistry<TOverlay, TPrepared> {
+  private preparers = new Map<string, OverlayPreparer<TOverlay, TPrepared>>()
+
+  register(key: string, preparer: OverlayPreparer<TOverlay, TPrepared>): void {
+    this.preparers.set(key, preparer)
+  }
+
+  async prepare(key: string, overlay: TOverlay, context: OverlayPrepareContext<TPrepared>): Promise<TPrepared> {
+    const preparer = this.preparers.get(key)
+    if (!preparer) {
+      throw new Error(`Unsupported runtime overlay: ${key}`)
+    }
+
+    return preparer(overlay, context)
+  }
+
+  has(key: string): boolean {
+    return this.preparers.has(key)
+  }
+}

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -7,6 +7,11 @@ import { promisify } from "node:util"
 import type { MountSpec, WorkspaceRecipe, WorkspaceRecipeDependencyOverlay, WorkspaceRecipeExtraPlugin, WorkspaceRecipeRuntimeOverlay, WorkspaceRecipeStagedFile, WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { resolvePluginEntrypointContract } from "@automattic/wp-codebox-core"
 import { collectPreparedSourceCleanupPaths, localPreparedSourceProvenance, prepareLocalSourceStageSync, SANDBOX_WORKSPACE_ROOT, type PreparedSourceProvenance } from "@automattic/wp-codebox-core/internals"
+import { OverlayPreparerRegistry } from "./overlay-preparers.js"
+import { evaluateSourcePolicy, sourcePolicySnapshot, type SourcePolicyIssue } from "./source-policy.js"
+import { prepareZipSource } from "./zip-source.js"
+
+export { ALLOW_NETWORK_DOWNLOADS_ENV, ALLOWED_DOWNLOAD_HOSTS_ENV, allowedDownloadHosts, isSha256, maxDownloadBytes, maxExtractedBytes, maxExtractedFiles, MAX_DOWNLOAD_BYTES_ENV, MAX_EXTRACTED_BYTES_ENV, MAX_EXTRACTED_FILES_ENV, REQUIRE_SOURCE_SHA256_ENV, sourceSha256Required } from "./source-policy.js"
 
 export interface PreparedWorkspaceMount {
   source: string
@@ -105,94 +110,16 @@ export interface ParsedRecipeSource {
   wporgSlug?: string
 }
 
-export interface RecipeSourcePolicyIssue {
-  code: string
-  message: string
-}
-
-export const ALLOW_NETWORK_DOWNLOADS_ENV = "WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS"
-export const ALLOWED_DOWNLOAD_HOSTS_ENV = "WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS"
-export const REQUIRE_SOURCE_SHA256_ENV = "WP_CODEBOX_REQUIRE_SOURCE_SHA256"
-export const MAX_DOWNLOAD_BYTES_ENV = "WP_CODEBOX_MAX_DOWNLOAD_BYTES"
-export const MAX_EXTRACTED_BYTES_ENV = "WP_CODEBOX_MAX_EXTRACTED_BYTES"
-export const MAX_EXTRACTED_FILES_ENV = "WP_CODEBOX_MAX_EXTRACTED_FILES"
-
-const DEFAULT_ALLOWED_DOWNLOAD_HOSTS = ["downloads.wordpress.org"]
-const DEFAULT_MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
-const DEFAULT_MAX_EXTRACTED_BYTES = 100 * 1024 * 1024
-const DEFAULT_MAX_EXTRACTED_FILES = 5000
 const execFileAsync = promisify(execFile)
 const PHP_SCOPER_VERSION = "0.18.17"
 const PHP_SCOPER_URL = `https://github.com/humbug/php-scoper/releases/download/${PHP_SCOPER_VERSION}/php-scoper.phar`
+const runtimeOverlayPreparers = new OverlayPreparerRegistry<WorkspaceRecipeRuntimeOverlay, PreparedRuntimeOverlay>()
+const PHP_AI_CLIENT_WORDPRESS_SCOPED_OVERLAY_KEY = "bundled-library/php-ai-client/wordpress-scoped-bundle"
 
-export function isSha256(value: string): boolean {
-  return /^[a-f0-9]{64}$/i.test(value)
-}
+runtimeOverlayPreparers.register(PHP_AI_CLIENT_WORDPRESS_SCOPED_OVERLAY_KEY, (_overlay, context) => context.prepare())
 
-export function evaluateRecipeSourcePolicy(source: ParsedRecipeSource, expectedSha256?: string): RecipeSourcePolicyIssue[] {
-  if (source.type === "local") {
-    return []
-  }
-
-  const issues: RecipeSourcePolicyIssue[] = []
-  if (process.env[ALLOW_NETWORK_DOWNLOADS_ENV] !== "1") {
-    issues.push({
-      code: "network-downloads-disabled",
-      message: `External recipe sources require ${ALLOW_NETWORK_DOWNLOADS_ENV}=1 before WP Codebox downloads anything.`,
-    })
-  }
-
-  if (!allowedDownloadHosts().includes(source.host)) {
-    issues.push({
-      code: "download-host-not-allowed",
-      message: `External recipe source host is not allowed: ${source.host}`,
-    })
-  }
-
-  if (expectedSha256 !== undefined && !isSha256(expectedSha256)) {
-    issues.push({
-      code: "invalid-source-sha256",
-      message: "External recipe source sha256 must be a 64-character hex digest.",
-    })
-  }
-
-  if (sourceSha256Required() && !expectedSha256) {
-    issues.push({
-      code: "missing-source-sha256",
-      message: `External recipe sources require sha256 when ${REQUIRE_SOURCE_SHA256_ENV}=1.`,
-    })
-  }
-
-  return issues
-}
-
-export function sourceSha256Required(): boolean {
-  return process.env[REQUIRE_SOURCE_SHA256_ENV] === "1"
-}
-
-export function allowedDownloadHosts(): string[] {
-  const configured = process.env[ALLOWED_DOWNLOAD_HOSTS_ENV]
-  return (configured ? configured.split(",") : DEFAULT_ALLOWED_DOWNLOAD_HOSTS)
-    .map((host) => host.trim().toLowerCase())
-    .filter(Boolean)
-}
-
-function envPositiveInteger(name: string, fallback: number): number {
-  const value = Number(process.env[name] ?? "")
-  return Number.isSafeInteger(value) && value > 0 ? value : fallback
-}
-
-export function maxDownloadBytes(): number {
-  return envPositiveInteger(MAX_DOWNLOAD_BYTES_ENV, DEFAULT_MAX_DOWNLOAD_BYTES)
-}
-
-export function maxExtractedBytes(): number {
-  return envPositiveInteger(MAX_EXTRACTED_BYTES_ENV, DEFAULT_MAX_EXTRACTED_BYTES)
-}
-
-export function maxExtractedFiles(): number {
-  return envPositiveInteger(MAX_EXTRACTED_FILES_ENV, DEFAULT_MAX_EXTRACTED_FILES)
-}
+export type RecipeSourcePolicyIssue = SourcePolicyIssue
+export const evaluateRecipeSourcePolicy = evaluateSourcePolicy
 
 function normalizedWorkspaceSeedExcludePath(value: string): string {
   return value.replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "").replace(/\/+$/, "")
@@ -425,15 +352,20 @@ export async function prepareRecipeStagedFiles(recipe: WorkspaceRecipe, recipeDi
 export async function prepareRecipeRuntimeOverlays(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedRuntimeOverlay[]> {
   const overlays: PreparedRuntimeOverlay[] = []
   for (const [index, overlay] of (recipe.runtime?.overlays ?? []).entries()) {
-    if (overlay.kind !== "bundled-library" || overlay.library !== "php-ai-client" || overlay.strategy !== "wordpress-scoped-bundle") {
-      throw new Error(`Unsupported runtime overlay: ${overlay.kind}/${overlay.library}/${overlay.strategy}`)
-    }
-
-    const prepared = await preparePhpAiClientOverlay(overlay, recipeDirectory, index)
+    const key = runtimeOverlayPreparerKey(overlay)
+    const prepared = await runtimeOverlayPreparers.prepare(key, overlay, {
+      index,
+      recipeDirectory,
+      prepare: () => preparePhpAiClientOverlay(overlay, recipeDirectory, index),
+    })
     overlays.push(prepared)
   }
 
   return overlays
+}
+
+function runtimeOverlayPreparerKey(overlay: WorkspaceRecipeRuntimeOverlay): string {
+  return `${overlay.kind}/${overlay.library}/${overlay.strategy}`
 }
 
 async function preparePhpAiClientOverlay(overlay: WorkspaceRecipeRuntimeOverlay, recipeDirectory: string, index: number): Promise<PreparedRuntimeOverlay> {
@@ -879,105 +811,18 @@ async function prepareRecipeSource(sourceRef: string, recipeDirectory: string, s
     throw new Error(policyIssue.message)
   }
 
-  const directory = await mkdtemp(join(tmpdir(), `wp-codebox-source-${slug}-`))
-  const zipPath = join(directory, "source.zip")
-  const extractDirectory = join(directory, "extracted")
-  await mkdir(extractDirectory, { recursive: true })
-  const digest = await downloadRecipeSourceZip(source, zipPath)
-  await assertSafeZipEntries(zipPath)
-  await execFileAsync("unzip", ["-q", zipPath, "-d", extractDirectory])
-  await assertExtractedSourceBounds(extractDirectory)
+  const preparedZip = await prepareZipSource(source, slug, recipeRedirectSource)
 
   return {
-    source: await extractedPluginSourceDirectory(extractDirectory, slug),
-    cleanupPaths: [directory],
+    source: await extractedPluginSourceDirectory(preparedZip.extractDirectory, slug),
+    cleanupPaths: [preparedZip.root],
     provenance: {
       ...recipeSourceProvenance(source, recipeDirectory),
-      digest: { sha256: digest, ...(source.expectedSha256 ? { expected: source.expectedSha256, verified: true } : {}) },
-      policy: {
-        host: source.host,
-        maxDownloadBytes: maxDownloadBytes(),
-        maxExtractedBytes: maxExtractedBytes(),
-        maxExtractedFiles: maxExtractedFiles(),
-        sha256Required: sourceSha256Required(),
-      },
+      digest: { sha256: preparedZip.digest, ...(source.expectedSha256 ? { expected: source.expectedSha256, verified: true } : {}) },
+      policy: sourcePolicySnapshot(source.host),
       localPathCategory: "temporary-download",
     },
   }
-}
-
-async function downloadRecipeSourceZip(source: ParsedRecipeSource, targetPath: string): Promise<string> {
-  const response = await fetch(source.resolvedUrl)
-  if (!response.ok || !response.body) {
-    throw new Error(`Failed to download recipe source ${source.resolvedUrl}: HTTP ${response.status}`)
-  }
-
-  const finalSource = recipeRedirectSource(source, response.url || source.resolvedUrl, response.headers)
-
-  if (finalSource.type === "local" || !allowedDownloadHosts().includes(finalSource.host)) {
-    throw new Error(`Recipe source redirected to a host that is not allowed: ${finalSource.host || finalSource.resolvedUrl}`)
-  }
-
-  const contentLength = Number(response.headers.get("content-length") ?? "0")
-  if (contentLength > maxDownloadBytes()) {
-    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${source.resolvedUrl}`)
-  }
-
-  const buffer = Buffer.from(await response.arrayBuffer())
-  if (buffer.byteLength > maxDownloadBytes()) {
-    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${source.resolvedUrl}`)
-  }
-
-  const digest = createHash("sha256").update(buffer).digest("hex")
-  if (source.expectedSha256 && digest !== source.expectedSha256.toLowerCase()) {
-    throw new Error(`Recipe source sha256 mismatch for ${source.resolvedUrl}: expected ${source.expectedSha256.toLowerCase()}, got ${digest}`)
-  }
-
-  await writeFile(targetPath, buffer)
-  return digest
-}
-
-async function assertSafeZipEntries(zipPath: string): Promise<void> {
-  const { stdout } = await execFileAsync("unzip", ["-Z1", zipPath])
-  const entries = stdout.split(/\r?\n/).filter(Boolean)
-  if (entries.length > maxExtractedFiles()) {
-    throw new Error(`Recipe source zip contains too many entries: ${entries.length}`)
-  }
-
-  for (const entry of entries) {
-    const normalized = entry.replace(/\\/g, "/")
-    if (normalized.startsWith("/") || normalized.split("/").includes("..")) {
-      throw new Error(`Recipe source zip contains an unsafe path: ${entry}`)
-    }
-  }
-}
-
-async function assertExtractedSourceBounds(directory: string): Promise<void> {
-  const totals = await directoryTotals(directory)
-  if (totals.files > maxExtractedFiles()) {
-    throw new Error(`Recipe source extraction contains too many files: ${totals.files}`)
-  }
-  if (totals.bytes > maxExtractedBytes()) {
-    throw new Error(`Recipe source extraction exceeds ${maxExtractedBytes()} bytes: ${totals.bytes}`)
-  }
-}
-
-async function directoryTotals(directory: string): Promise<{ files: number; bytes: number }> {
-  let files = 0
-  let bytes = 0
-  for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const path = join(directory, entry.name)
-    if (entry.isDirectory()) {
-      const child = await directoryTotals(path)
-      files += child.files
-      bytes += child.bytes
-    } else if (entry.isFile()) {
-      const result = await stat(path)
-      files += 1
-      bytes += result.size
-    }
-  }
-  return { files, bytes }
 }
 
 async function extractedPluginSourceDirectory(extractDirectory: string, slug: string): Promise<string> {
@@ -1163,13 +1008,7 @@ export function recipeSourceProvenance(source: ParsedRecipeSource, recipeDirecto
     original: source.resolvedUrl,
     resolvedUrl: source.resolvedUrl,
     ...(source.expectedSha256 ? { digest: { sha256: source.expectedSha256, expected: source.expectedSha256, verified: false } } : {}),
-    policy: {
-      host: source.host,
-      maxDownloadBytes: maxDownloadBytes(),
-      maxExtractedBytes: maxExtractedBytes(),
-      maxExtractedFiles: maxExtractedFiles(),
-      sha256Required: sourceSha256Required(),
-    },
+    policy: sourcePolicySnapshot(source.host),
   }
 }
 

--- a/packages/cli/src/source-policy.ts
+++ b/packages/cli/src/source-policy.ts
@@ -1,0 +1,108 @@
+export interface ExternalSourcePolicyInput {
+  type: string
+  host: string
+}
+
+export interface SourcePolicyIssue {
+  code: string
+  message: string
+}
+
+export interface SourcePolicySnapshot {
+  host: string
+  maxDownloadBytes: number
+  maxExtractedBytes: number
+  maxExtractedFiles: number
+  sha256Required: boolean
+}
+
+export const ALLOW_NETWORK_DOWNLOADS_ENV = "WP_CODEBOX_ALLOW_NETWORK_DOWNLOADS"
+export const ALLOWED_DOWNLOAD_HOSTS_ENV = "WP_CODEBOX_ALLOWED_DOWNLOAD_HOSTS"
+export const REQUIRE_SOURCE_SHA256_ENV = "WP_CODEBOX_REQUIRE_SOURCE_SHA256"
+export const MAX_DOWNLOAD_BYTES_ENV = "WP_CODEBOX_MAX_DOWNLOAD_BYTES"
+export const MAX_EXTRACTED_BYTES_ENV = "WP_CODEBOX_MAX_EXTRACTED_BYTES"
+export const MAX_EXTRACTED_FILES_ENV = "WP_CODEBOX_MAX_EXTRACTED_FILES"
+
+const DEFAULT_ALLOWED_DOWNLOAD_HOSTS = ["downloads.wordpress.org"]
+const DEFAULT_MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024
+const DEFAULT_MAX_EXTRACTED_BYTES = 100 * 1024 * 1024
+const DEFAULT_MAX_EXTRACTED_FILES = 5000
+
+export function isSha256(value: string): boolean {
+  return /^[a-f0-9]{64}$/i.test(value)
+}
+
+export function evaluateSourcePolicy(source: ExternalSourcePolicyInput, expectedSha256?: string): SourcePolicyIssue[] {
+  if (source.type === "local") {
+    return []
+  }
+
+  const issues: SourcePolicyIssue[] = []
+  if (process.env[ALLOW_NETWORK_DOWNLOADS_ENV] !== "1") {
+    issues.push({
+      code: "network-downloads-disabled",
+      message: `External recipe sources require ${ALLOW_NETWORK_DOWNLOADS_ENV}=1 before WP Codebox downloads anything.`,
+    })
+  }
+
+  if (!allowedDownloadHosts().includes(source.host)) {
+    issues.push({
+      code: "download-host-not-allowed",
+      message: `External recipe source host is not allowed: ${source.host}`,
+    })
+  }
+
+  if (expectedSha256 !== undefined && !isSha256(expectedSha256)) {
+    issues.push({
+      code: "invalid-source-sha256",
+      message: "External recipe source sha256 must be a 64-character hex digest.",
+    })
+  }
+
+  if (sourceSha256Required() && !expectedSha256) {
+    issues.push({
+      code: "missing-source-sha256",
+      message: `External recipe sources require sha256 when ${REQUIRE_SOURCE_SHA256_ENV}=1.`,
+    })
+  }
+
+  return issues
+}
+
+export function sourceSha256Required(): boolean {
+  return process.env[REQUIRE_SOURCE_SHA256_ENV] === "1"
+}
+
+export function allowedDownloadHosts(): string[] {
+  const configured = process.env[ALLOWED_DOWNLOAD_HOSTS_ENV]
+  return (configured ? configured.split(",") : DEFAULT_ALLOWED_DOWNLOAD_HOSTS)
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+function envPositiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name] ?? "")
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback
+}
+
+export function maxDownloadBytes(): number {
+  return envPositiveInteger(MAX_DOWNLOAD_BYTES_ENV, DEFAULT_MAX_DOWNLOAD_BYTES)
+}
+
+export function maxExtractedBytes(): number {
+  return envPositiveInteger(MAX_EXTRACTED_BYTES_ENV, DEFAULT_MAX_EXTRACTED_BYTES)
+}
+
+export function maxExtractedFiles(): number {
+  return envPositiveInteger(MAX_EXTRACTED_FILES_ENV, DEFAULT_MAX_EXTRACTED_FILES)
+}
+
+export function sourcePolicySnapshot(host: string): SourcePolicySnapshot {
+  return {
+    host,
+    maxDownloadBytes: maxDownloadBytes(),
+    maxExtractedBytes: maxExtractedBytes(),
+    maxExtractedFiles: maxExtractedFiles(),
+    sha256Required: sourceSha256Required(),
+  }
+}

--- a/packages/cli/src/zip-source.ts
+++ b/packages/cli/src/zip-source.ts
@@ -1,0 +1,112 @@
+import { execFile } from "node:child_process"
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, readdir, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+import { allowedDownloadHosts, maxDownloadBytes, maxExtractedBytes, maxExtractedFiles } from "./source-policy.js"
+
+const execFileAsync = promisify(execFile)
+
+export interface ZipSourceReference {
+  type: string
+  resolvedUrl: string
+  host: string
+  expectedSha256?: string
+}
+
+export interface PreparedZipSource {
+  root: string
+  zipPath: string
+  extractDirectory: string
+  digest: string
+}
+
+export type RedirectSourceResolver<TSource extends ZipSourceReference> = (source: TSource, finalSourceRef: string, headers?: Headers) => TSource
+
+export async function prepareZipSource<TSource extends ZipSourceReference>(source: TSource, slug: string, redirectSource: RedirectSourceResolver<TSource>): Promise<PreparedZipSource> {
+  const root = await mkdtemp(join(tmpdir(), `wp-codebox-source-${slug}-`))
+  const zipPath = join(root, "source.zip")
+  const extractDirectory = join(root, "extracted")
+  await mkdir(extractDirectory, { recursive: true })
+  const digest = await downloadZipSource(source, zipPath, redirectSource)
+  await assertSafeZipEntries(zipPath)
+  await execFileAsync("unzip", ["-q", zipPath, "-d", extractDirectory])
+  await assertExtractedSourceBounds(extractDirectory)
+
+  return { root, zipPath, extractDirectory, digest }
+}
+
+async function downloadZipSource<TSource extends ZipSourceReference>(source: TSource, targetPath: string, redirectSource: RedirectSourceResolver<TSource>): Promise<string> {
+  const response = await fetch(source.resolvedUrl)
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download recipe source ${source.resolvedUrl}: HTTP ${response.status}`)
+  }
+
+  const finalSource = redirectSource(source, response.url || source.resolvedUrl, response.headers)
+
+  if (finalSource.type === "local" || !allowedDownloadHosts().includes(finalSource.host)) {
+    throw new Error(`Recipe source redirected to a host that is not allowed: ${finalSource.host || finalSource.resolvedUrl}`)
+  }
+
+  const contentLength = Number(response.headers.get("content-length") ?? "0")
+  if (contentLength > maxDownloadBytes()) {
+    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${source.resolvedUrl}`)
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer())
+  if (buffer.byteLength > maxDownloadBytes()) {
+    throw new Error(`Recipe source download exceeds ${maxDownloadBytes()} bytes: ${source.resolvedUrl}`)
+  }
+
+  const digest = createHash("sha256").update(buffer).digest("hex")
+  if (source.expectedSha256 && digest !== source.expectedSha256.toLowerCase()) {
+    throw new Error(`Recipe source sha256 mismatch for ${source.resolvedUrl}: expected ${source.expectedSha256.toLowerCase()}, got ${digest}`)
+  }
+
+  await writeFile(targetPath, buffer)
+  return digest
+}
+
+async function assertSafeZipEntries(zipPath: string): Promise<void> {
+  const { stdout } = await execFileAsync("unzip", ["-Z1", zipPath])
+  const entries = stdout.split(/\r?\n/).filter(Boolean)
+  if (entries.length > maxExtractedFiles()) {
+    throw new Error(`Recipe source zip contains too many entries: ${entries.length}`)
+  }
+
+  for (const entry of entries) {
+    const normalized = entry.replace(/\\/g, "/")
+    if (normalized.startsWith("/") || normalized.split("/").includes("..")) {
+      throw new Error(`Recipe source zip contains an unsafe path: ${entry}`)
+    }
+  }
+}
+
+async function assertExtractedSourceBounds(directory: string): Promise<void> {
+  const totals = await directoryTotals(directory)
+  if (totals.files > maxExtractedFiles()) {
+    throw new Error(`Recipe source extraction contains too many files: ${totals.files}`)
+  }
+  if (totals.bytes > maxExtractedBytes()) {
+    throw new Error(`Recipe source extraction exceeds ${maxExtractedBytes()} bytes: ${totals.bytes}`)
+  }
+}
+
+async function directoryTotals(directory: string): Promise<{ files: number; bytes: number }> {
+  let files = 0
+  let bytes = 0
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      const child = await directoryTotals(path)
+      files += child.files
+      bytes += child.bytes
+    } else if (entry.isFile()) {
+      const result = await stat(path)
+      files += 1
+      bytes += result.size
+    }
+  }
+  return { files, bytes }
+}

--- a/scripts/overlay-preparer-registry-smoke.ts
+++ b/scripts/overlay-preparer-registry-smoke.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import { OverlayPreparerRegistry } from "../packages/cli/src/overlay-preparers.js"
+
+interface Overlay {
+  kind: string
+}
+
+interface PreparedOverlay {
+  target: string
+}
+
+const registry = new OverlayPreparerRegistry<Overlay, PreparedOverlay>()
+const key = "bundled-library/php-ai-client/wordpress-scoped-bundle"
+
+assert.equal(registry.has(key), false)
+
+registry.register(key, async (overlay, context) => {
+  assert.equal(overlay.kind, "bundled-library")
+  assert.equal(context.index, 0)
+  assert.equal(context.recipeDirectory, "/recipe")
+  return context.prepare()
+})
+
+assert.equal(registry.has(key), true)
+assert.deepEqual(await registry.prepare(key, { kind: "bundled-library" }, {
+  index: 0,
+  recipeDirectory: "/recipe",
+  prepare: async () => ({ target: "/wordpress/wp-includes/php-ai-client" }),
+}), { target: "/wordpress/wp-includes/php-ai-client" })
+
+await assert.rejects(
+  () => registry.prepare("unsupported/library/strategy", { kind: "unsupported" }, {
+    index: 1,
+    recipeDirectory: "/recipe",
+    prepare: async () => ({ target: "/unused" }),
+  }),
+  /Unsupported runtime overlay: unsupported\/library\/strategy/,
+)
+
+console.log("Overlay preparer registry smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -54,6 +54,8 @@ export const smokeGroups = {
     commands: [
       tsxSmoke("policy-validation-smoke"),
       tsxSmoke("workspace-policy-smoke"),
+      tsxSmoke("source-policy-smoke"),
+      tsxSmoke("overlay-preparer-registry-smoke"),
     ],
   },
   artifact: {

--- a/scripts/source-policy-smoke.ts
+++ b/scripts/source-policy-smoke.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+import { ALLOWED_DOWNLOAD_HOSTS_ENV, ALLOW_NETWORK_DOWNLOADS_ENV, evaluateSourcePolicy, REQUIRE_SOURCE_SHA256_ENV, sourcePolicySnapshot } from "../packages/cli/src/source-policy.js"
+
+const originalEnv = {
+  [ALLOW_NETWORK_DOWNLOADS_ENV]: process.env[ALLOW_NETWORK_DOWNLOADS_ENV],
+  [ALLOWED_DOWNLOAD_HOSTS_ENV]: process.env[ALLOWED_DOWNLOAD_HOSTS_ENV],
+  [REQUIRE_SOURCE_SHA256_ENV]: process.env[REQUIRE_SOURCE_SHA256_ENV],
+}
+
+try {
+  delete process.env[ALLOW_NETWORK_DOWNLOADS_ENV]
+  delete process.env[ALLOWED_DOWNLOAD_HOSTS_ENV]
+  delete process.env[REQUIRE_SOURCE_SHA256_ENV]
+
+  assert.deepEqual(evaluateSourcePolicy({ type: "local", host: "" }), [])
+  assert.deepEqual(evaluateSourcePolicy({ type: "https_zip", host: "downloads.wordpress.org" }).map((issue) => issue.code), ["network-downloads-disabled"])
+  assert.deepEqual(evaluateSourcePolicy({ type: "https_zip", host: "example.com" }).map((issue) => issue.code), ["network-downloads-disabled", "download-host-not-allowed"])
+
+  process.env[ALLOW_NETWORK_DOWNLOADS_ENV] = "1"
+  process.env[ALLOWED_DOWNLOAD_HOSTS_ENV] = " Example.com , downloads.wordpress.org "
+  process.env[REQUIRE_SOURCE_SHA256_ENV] = "1"
+
+  assert.deepEqual(evaluateSourcePolicy({ type: "https_zip", host: "example.com" }).map((issue) => issue.code), ["missing-source-sha256"])
+  assert.deepEqual(evaluateSourcePolicy({ type: "https_zip", host: "example.com" }, "not-a-digest").map((issue) => issue.code), ["invalid-source-sha256"])
+  assert.deepEqual(evaluateSourcePolicy({ type: "https_zip", host: "example.com" }, "a".repeat(64)), [])
+  assert.equal(sourcePolicySnapshot("example.com").host, "example.com")
+  assert.equal(sourcePolicySnapshot("example.com").sha256Required, true)
+} finally {
+  for (const [name, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = value
+    }
+  }
+}
+
+console.log("Source policy smoke passed")


### PR DESCRIPTION
## Summary
- Extract generic source policy evaluation and zip source preparation helpers from the CLI recipe source adapter.
- Add a small generic runtime overlay preparer registry while keeping the PHP AI Client WordPress-scoped overlay preparation in adapter-named code.
- Add focused smoke coverage for source policy/allowed hosts and overlay registry behavior.

## Tests
- npm run build
- npm run smoke -- --group=policy
- npx tsx scripts/runtime-overlay-validation-smoke.ts
- npx tsx scripts/composer-backed-source-hydration-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the boundary extraction, targeted smoke tests, and PR description for Chris to review and validate.