### PR TITLE
Consolidate smoke test harness helpers

### DIFF
--- a/scripts/artifact-browser-error-collection-smoke.ts
+++ b/scripts/artifact-browser-error-collection-smoke.ts
@@ -1,14 +1,12 @@
 import assert from "node:assert/strict"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import type { BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.ts"
 import { BrowserCommandArtifactError } from "../packages/runtime-playground/src/browser-command-runners.ts"
 import { collectPlaygroundArtifacts } from "../packages/runtime-playground/src/runtime-artifact-helpers.ts"
+import { readJson, withTempDir } from "./test-kit.ts"
 
-const workspace = await mkdtemp(join(tmpdir(), "wp-codebox-browser-error-artifacts-"))
-
-try {
+await withTempDir("wp-codebox-browser-error-artifacts-", async (workspace) => {
   const artifactRoot = join(workspace, "artifacts")
   await mkdir(join(artifactRoot, "files/browser"), { recursive: true })
   await writeFile(join(artifactRoot, "files/browser/summary.json"), "{\"status\":\"failed\"}\n")
@@ -65,13 +63,11 @@ try {
   const commandsLog = await readFile(bundle.commandsLogPath, "utf8")
   assert.equal(commandsLog, "\n")
 
-  const manifest = JSON.parse(await readFile(bundle.manifestPath, "utf8"))
+  const manifest = await readJson<{ files: Array<{ path?: string }> }>(bundle.manifestPath)
   assert.equal(manifest.files.some((file: { path?: string }) => file.path === "files/browser/summary.json"), true)
 
   console.log("Artifact browser error collection smoke passed")
-} finally {
-  await rm(workspace, { recursive: true, force: true })
-}
+})
 
 function browserArtifactFixture(): BrowserArtifact {
   return {

--- a/scripts/artifact-layout-writer-smoke.ts
+++ b/scripts/artifact-layout-writer-smoke.ts
@@ -1,7 +1,5 @@
 import assert from "node:assert/strict"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { join } from "node:path"
-import { tmpdir } from "node:os"
 
 import {
   ARTIFACT_MANIFEST_PATH,
@@ -15,10 +13,9 @@ import {
   runtimeReplayReferenceIndexArtifactFiles,
   type ArtifactManifest,
 } from "@automattic/wp-codebox-core"
+import { readJson, withTempDir } from "./test-kit.ts"
 
-const directory = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-layout-"))
-
-try {
+await withTempDir("wp-codebox-artifact-layout-", async (directory) => {
   const writer = new ArtifactBundleWriter(directory)
   await writer.writeJson("files/example.json", { ok: true }, { kind: "example" })
 
@@ -41,7 +38,7 @@ try {
 
   await writer.writeManifest(manifest)
 
-  const written = JSON.parse(await readFile(join(directory, ARTIFACT_MANIFEST_PATH), "utf8")) as ArtifactManifest
+  const written = await readJson<ArtifactManifest>(join(directory, ARTIFACT_MANIFEST_PATH))
   assert.deepEqual(written.files.map((file) => file.path), ["files/example.json", ARTIFACT_MANIFEST_PATH])
   assert.notEqual(written.files.find((file) => file.path === ARTIFACT_MANIFEST_PATH)?.sha256.value, "0".repeat(64))
   assert.equal(writer.relativePath(join(directory, "files", "example.json")), "files/example.json")
@@ -57,8 +54,6 @@ try {
 
   assert.deepEqual(runtimeReferenceManifestArtifactFiles(files).map((file) => file.path), ["files/example.json"])
   assert.deepEqual(runtimeReplayReferenceIndexArtifactFiles(files).map((file) => file.path), [METADATA_ARTIFACT_PATH, REVIEW_ARTIFACT_PATH, RUNTIME_REFERENCE_MANIFEST_ARTIFACT_PATH, "files/example.json"])
-} finally {
-  await rm(directory, { recursive: true, force: true })
-}
+})
 
 console.log("Artifact layout writer smoke passed")

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -1,16 +1,9 @@
-import { execFile } from "node:child_process"
-import { readFile } from "node:fs/promises"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
-import { promisify } from "node:util"
+import { resolve } from "node:path"
 import { createWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { commandRegistry, recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import Ajv2020 from "ajv/dist/2020.js"
 import { listCliRuntimeBackendKinds } from "../packages/cli/src/runtime-backends.js"
-
-const execFileAsync = promisify(execFile)
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
-const cliPath = resolve(repoRoot, "packages/cli/dist/index.js")
+import { readJson, repoRoot, runCliJson, runCliText } from "./test-kit.ts"
 
 interface CommandCatalogOutput {
   schema: "wp-codebox/command-catalog/v1"
@@ -68,16 +61,6 @@ const representativeRecipes = [
   },
 ] satisfies WorkspaceRecipe[]
 
-async function cliJson<T>(args: string[]): Promise<T> {
-  const { stdout } = await execFileAsync(process.execPath, [cliPath, ...args], { cwd: repoRoot })
-  return JSON.parse(stdout) as T
-}
-
-async function cliText(args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync(process.execPath, [cliPath, ...args], { cwd: repoRoot })
-  return stdout
-}
-
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message)
@@ -85,7 +68,7 @@ function assert(condition: unknown, message: string): asserts condition {
 }
 
 async function main(): Promise<void> {
-  const catalog = await cliJson<CommandCatalogOutput>(["commands", "--json"])
+  const catalog = await runCliJson<CommandCatalogOutput>(["commands", "--json"])
   assert(catalog.schema === "wp-codebox/command-catalog/v1", "Unexpected command catalog schema")
   assert(JSON.stringify(catalog.commands.map((command) => command.id)) === JSON.stringify(expectedCatalogCommandIds), "Command ids changed unexpectedly")
 
@@ -104,14 +87,14 @@ async function main(): Promise<void> {
   const pluginCheck = catalog.commands.find((command) => command.id === "wordpress.plugin-check")
   assert(pluginCheck?.acceptedArgs.some((arg) => arg.name === "plugin-slug" && arg.required), "wordpress.plugin-check must document required plugin-slug arg")
 
-  const help = await cliText(["--help"])
+  const help = await runCliText(["--help"])
   const recipeHelp = help.slice(help.indexOf("Recipe commands:"))
   assert(recipeHelp.startsWith("Recipe commands:"), "Help output must include generated recipe command section")
   for (const commandId of expectedCommandIds) {
     assert(recipeHelp.includes(`  ${commandId}\n`) || recipeHelp.includes(`  ${commandId}`), `Help output is missing recipe command: ${commandId}`)
   }
 
-  const schemaOutput = await cliJson<RecipeSchemaOutput>(["schema", "recipe", "--json"])
+  const schemaOutput = await runCliJson<RecipeSchemaOutput>(["schema", "recipe", "--json"])
   assert(schemaOutput.schema === "wp-codebox/json-schema/v1", "Unexpected recipe schema envelope")
   assert(schemaOutput.id === "wp-codebox/workspace-recipe/v1", "Unexpected recipe schema id")
   assert(
@@ -127,7 +110,7 @@ async function main(): Promise<void> {
     "examples/recipes/bench-plugin.json",
     "examples/recipes/cookbook/seeded-content.json",
   ]) {
-    const recipe = JSON.parse(await readFile(resolve(repoRoot, recipePath), "utf8"))
+    const recipe = await readJson(resolve(repoRoot, recipePath))
     assert(validate(recipe), `${recipePath} does not validate against discovery schema: ${ajv.errorsText(validate.errors)}`)
   }
 

--- a/scripts/replay-export-manifest-integrity-smoke.ts
+++ b/scripts/replay-export-manifest-integrity-smoke.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict"
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join, relative } from "node:path"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 
 import { writeReplayExportPackage } from "../packages/runtime-playground/src/replayable-wordpress-site-bundle.ts"
 import type { RuntimeSnapshotArtifact } from "../packages/runtime-playground/src/runtime-snapshot.ts"
+import { listRelativeFiles, readJson, withTempDir } from "./test-kit.ts"
 
 const snapshot: RuntimeSnapshotArtifact = {
   schema: "wp-codebox/wordpress-runtime-snapshot/v1",
@@ -50,18 +50,16 @@ const snapshot: RuntimeSnapshotArtifact = {
   },
 }
 
-const directory = await mkdtemp(join(tmpdir(), "wp-codebox-replay-export-manifest-"))
-
-try {
+await withTempDir("wp-codebox-replay-export-manifest-", async (directory) => {
   await writeReplayExportPackage(snapshot, {
     directory,
     createdAt: "2026-06-15T00:00:00.000Z",
     id: "replay-export-manifest-integrity-smoke",
   })
 
-  const manifest = JSON.parse(await readFile(join(directory, "manifest.json"), "utf8")) as { files: Array<{ path: string }> }
+  const manifest = await readJson<{ files: Array<{ path: string }> }>(join(directory, "manifest.json"))
   const manifestPaths = manifest.files.map((file) => file.path).sort()
-  const writtenPaths = (await listFiles(directory)).sort()
+  const writtenPaths = (await listRelativeFiles(directory)).sort()
 
   assert.deepEqual(writtenPaths, manifestPaths)
   assert.deepEqual(new Set(manifestPaths).size, manifestPaths.length)
@@ -71,23 +69,4 @@ try {
   }
 
   console.log("replay-export-manifest-integrity-smoke passed")
-} finally {
-  await rm(directory, { recursive: true, force: true })
-}
-
-async function listFiles(directory: string): Promise<string[]> {
-  const files: string[] = []
-  await collectFiles(directory, directory, files)
-  return files
-}
-
-async function collectFiles(root: string, directory: string, files: string[]): Promise<void> {
-  for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const path = join(directory, entry.name)
-    if (entry.isDirectory()) {
-      await collectFiles(root, path, files)
-    } else if (entry.isFile()) {
-      files.push(relative(root, path).replace(/\\/g, "/"))
-    }
-  }
-}
+})

--- a/scripts/test-kit.ts
+++ b/scripts/test-kit.ts
@@ -1,0 +1,51 @@
+import { execFile } from "node:child_process"
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+export const cliPath = resolve(repoRoot, "packages/cli/dist/index.js")
+
+export async function runCliJson<T>(args: string[]): Promise<T> {
+  const stdout = await runCliText(args)
+  return JSON.parse(stdout) as T
+}
+
+export async function runCliText(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(process.execPath, [cliPath, ...args], { cwd: repoRoot })
+  return stdout
+}
+
+export async function withTempDir<T>(prefix: string, callback: (directory: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), prefix))
+  try {
+    return await callback(directory)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+export async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T
+}
+
+export async function listRelativeFiles(directory: string): Promise<string[]> {
+  const files: string[] = []
+  await collectFiles(directory, directory, files)
+  return files
+}
+
+async function collectFiles(root: string, directory: string, files: string[]): Promise<void> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      await collectFiles(root, path, files)
+    } else if (entry.isFile()) {
+      files.push(relative(root, path).replace(/\\/g, "/"))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add scripts/test-kit.ts with shared repoRoot, cliPath, runCliJson, runCliText, withTempDir, readJson, and listRelativeFiles helpers.
- Convert representative smoke scripts to use the shared helper while preserving assertions and output behavior.
- Covered CLI discovery, temp-dir cleanup, JSON reads, and recursive artifact file listing patterns.

## Testing
- npm run smoke -- --command=discovery-command-smoke
- npm run smoke -- --command=artifact-layout-writer-smoke
- npm run smoke -- --command=replay-export-manifest-integrity-smoke
- npm run smoke -- --command=artifact-browser-error-collection-smoke
- npm run build
- npm run check

## Risks
- Low: test infrastructure refactor only; smoke assertions and expected behavior are unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shared smoke test helper extraction and representative smoke script conversions; Chris remains responsible for review and testing.