### PR TITLE
Make browser artifact persistence idempotent

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -246,7 +246,20 @@ final class WP_Codebox_Artifacts {
 		$destination    = $root . DIRECTORY_SEPARATOR . $bundle_id;
 		if ( file_exists( $destination ) ) {
 			$this->remove_directory( $tmp );
-			return new WP_Error( 'wp_codebox_artifact_already_exists', 'Artifact bundle already exists for this browser artifact content digest.', array( 'status' => 409, 'artifact_id' => $bundle_id ) );
+			$bundle = $this->read_bundle_at_manifest( $destination . DIRECTORY_SEPARATOR . 'manifest.json', true );
+			if ( is_wp_error( $bundle ) ) {
+				return $bundle;
+			}
+
+			return array(
+				'success'        => true,
+				'schema'         => self::BROWSER_PERSIST_SCHEMA,
+				'status'         => 'existing',
+				'artifact_id'    => $bundle_id,
+				'content_digest' => $content_digest,
+				'directory'      => $destination,
+				'artifact'       => $bundle,
+			);
 		}
 
 		$provenance = is_array( $input['provenance'] ?? null ) ? $input['provenance'] : array();
@@ -329,6 +342,7 @@ final class WP_Codebox_Artifacts {
 		return array(
 			'success'        => true,
 			'schema'         => self::BROWSER_PERSIST_SCHEMA,
+			'status'         => 'created',
 			'artifact_id'    => $bundle_id,
 			'content_digest' => $content_digest,
 			'directory'      => $destination,

--- a/scripts/browser-artifact-persistence-idempotency-smoke.ts
+++ b/scripts/browser-artifact-persistence-idempotency-smoke.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const dir = mkdtempSync(join(tmpdir(), "wp-codebox-browser-artifact-idempotency-"))
+const smokePhp = join(dir, "smoke.php")
+const classPath = new URL("../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php", import.meta.url).pathname
+
+writeFileSync(smokePhp, `<?php
+define('ABSPATH', __DIR__);
+
+class WP_Error {
+	private string $code;
+	private string $message;
+	private mixed $data;
+
+	public function __construct(string $code = '', string $message = '', mixed $data = '') {
+		$this->code = $code;
+		$this->message = $message;
+		$this->data = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error(mixed $value): bool {
+	return $value instanceof WP_Error;
+}
+
+function smoke_assert(bool $condition, string $message): void {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function smoke_remove_tree(string $path): void {
+	if (!is_dir($path)) {
+		return;
+	}
+
+	$items = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ($items as $item) {
+		$item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+	}
+	rmdir($path);
+}
+
+require ${JSON.stringify(classPath)};
+
+$root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'wp-codebox-artifacts-' . bin2hex(random_bytes(8));
+$input = array(
+	'artifacts_path' => $root,
+	'schema_id' => 'smoke/browser-artifact/v1',
+	'root' => 'website',
+	'entrypoint' => 'website/index.html',
+	'session' => array('id' => 'smoke-session'),
+	'files' => array(
+		array(
+			'path' => 'website/index.html',
+			'content' => '<!doctype html><title>Smoke</title>',
+			'encoding' => 'utf-8',
+		),
+	),
+);
+
+try {
+	$artifacts = new WP_Codebox_Artifacts();
+	$created = $artifacts->persist_browser_bundle($input);
+	smoke_assert(!is_wp_error($created), 'first persistence should not return WP_Error');
+	smoke_assert('created' === ($created['status'] ?? ''), 'first persistence should return status=created');
+	smoke_assert('' !== (string) ($created['artifact_id'] ?? ''), 'first persistence should return artifact_id');
+	smoke_assert('' !== (string) ($created['content_digest'] ?? ''), 'first persistence should return content_digest');
+
+	$existing = $artifacts->persist_browser_bundle($input);
+	smoke_assert(!is_wp_error($existing), 'duplicate persistence should not return WP_Error');
+	smoke_assert('existing' === ($existing['status'] ?? ''), 'duplicate persistence should return status=existing');
+	smoke_assert($created['artifact_id'] === $existing['artifact_id'], 'duplicate persistence should return stable artifact_id');
+	smoke_assert($created['content_digest'] === $existing['content_digest'], 'duplicate persistence should return stable content_digest');
+	smoke_assert(is_array($existing['artifact'] ?? null), 'duplicate persistence should return existing artifact payload');
+} finally {
+	smoke_remove_tree($root);
+}
+`)
+
+execFileSync("php", ["-l", smokePhp], { stdio: "pipe" })
+execFileSync("php", [smokePhp], { stdio: "pipe" })
+
+console.log("Browser artifact persistence idempotency smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -70,6 +70,7 @@ export const smokeGroups = {
       tsxSmoke("artifact-diagnostics-normalizer-smoke"),
       tsxSmoke("typed-artifacts-smoke"),
       tsxSmoke("artifact-browser-error-collection-smoke"),
+      tsxSmoke("browser-artifact-persistence-idempotency-smoke"),
       tsxSmoke("partial-artifact-discovery-smoke"),
       tsxSmoke("mounted-workspace-diff-smoke"),
       tsxSmoke("replay-export-blueprint-smoke"),


### PR DESCRIPTION
## Summary
- Return a normal browser artifact persistence result for duplicate content instead of WP_Error control flow.
- Add status: created|existing to the persistence DTO while preserving stable artifact_id, content_digest, and artifact payload.
- Add a browser artifact persistence idempotency smoke regression to the artifact smoke group.

## Tests
- npm run smoke -- --command=browser-artifact-persistence-idempotency-smoke
- npm run smoke -- --group=artifact
- php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Drafted the idempotent persistence implementation and regression smoke test; Chris remains responsible for review and validation.