### PR TITLE
Tighten bootstrap component manifest boundary

### DIFF
--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, refreshArtifactManifestFileSha256s, resolveSecretEnvNames, upsertArtifactManifestFiles, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, refreshArtifactManifestFileSha256s, resolveSecretEnvNames, upsertArtifactManifestFiles, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -2164,6 +2164,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
     metadata: plugin.metadata,
   }))
   const componentContracts = componentContractResults(recipe, extraPlugins, [], [])
+  const componentManifest = recipeComponentManifest(extraPlugins, recipe.inputs?.component_manifest)
   const siteSeedProvenance = recipeDryRunSiteSeeds(recipe, dirname(recipePath))
   const stagedFileProvenance = stagedFiles.map(recipeRunStagedFile)
   const workflow = recipeWorkflowMetadata(recipe)
@@ -2179,6 +2180,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: extraPluginMetadata,
+        component_manifest: componentManifest,
         component_contracts: componentContracts,
         dependency_overlays: recipe.inputs?.dependency_overlays ?? [],
         pluginRuntime: recipe.inputs?.pluginRuntime ?? {},
@@ -2208,6 +2210,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         workspaces: recipe.inputs?.workspaces ?? [],
         mounts: recipe.inputs?.mounts ?? [],
         extra_plugins: extraPluginMetadata,
+        component_manifest: componentManifest,
         component_contracts: componentContracts,
         dependency_overlays: recipe.inputs?.dependency_overlays ?? [],
         pluginRuntime: recipe.inputs?.pluginRuntime ?? {},
@@ -2245,6 +2248,39 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
     })),
     preparedComponentContracts: componentContracts,
     ...(backendPackage ? { preparedRuntimeBackend: backendPackage.provenance } : {}),
+  }
+}
+
+function recipeComponentManifest(extraPlugins: PreparedExtraPlugin[], fallback: WorkspaceRecipeComponentManifest | undefined): Record<string, unknown> | undefined {
+  if (extraPlugins.length === 0) {
+    return fallback as Record<string, unknown> | undefined
+  }
+
+  const components: Record<string, unknown>[] = []
+  const providers: Record<string, unknown>[] = []
+  for (const plugin of extraPlugins) {
+    const contract = recordValue(plugin.metadata?.componentContract)
+    const entry = stripUndefined({
+      slug: plugin.slug,
+      source: plugin.source,
+      target: plugin.target,
+      pluginFile: plugin.pluginFile,
+      loadAs: plugin.loadAs,
+      activate: plugin.activate,
+      contractIndex: numberValue(contract?.index),
+      requestedPath: stringValue(contract?.requestedPath) || undefined,
+    })
+    if (contract) {
+      components.push(entry)
+    } else {
+      providers.push(entry)
+    }
+  }
+
+  return {
+    schema: "wp-codebox/component-manifest/v1",
+    components,
+    providers,
   }
 }
 

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -136,6 +136,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "array",
             items: { $ref: "#/$defs/extraPlugin" },
           },
+          component_manifest: { $ref: "#/$defs/componentManifest" },
           dependency_overlays: {
             type: "array",
             description: "Typed local dependency overlays mounted into a consumer plugin before setup, activation, and workflow steps.",
@@ -253,6 +254,29 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
       metadata: {
         type: "object",
         additionalProperties: true,
+      },
+      componentManifest: {
+        type: "object",
+        additionalProperties: false,
+        required: ["schema"],
+        properties: {
+          schema: { const: "wp-codebox/component-manifest/v1" },
+          components: { type: "array", items: { $ref: "#/$defs/componentManifestEntry" } },
+          providers: { type: "array", items: { $ref: "#/$defs/componentManifestEntry" } },
+        },
+      },
+      componentManifestEntry: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          slug: { type: "string" },
+          source: { type: "string" },
+          pluginFile: { type: "string" },
+          loadAs: { enum: ["plugin", "mu-plugin"] },
+          activate: { type: "boolean" },
+          contractIndex: { type: "integer", minimum: 0 },
+          requestedPath: { type: "string" },
+        },
       },
       distribution: {
         type: "object",

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -266,6 +266,22 @@ export interface WorkspaceRecipeExtraPlugin {
   metadata?: Record<string, unknown>
 }
 
+export interface WorkspaceRecipeComponentManifestEntry {
+  slug?: string
+  source?: string
+  pluginFile?: string
+  loadAs?: "plugin" | "mu-plugin"
+  activate?: boolean
+  contractIndex?: number
+  requestedPath?: string
+}
+
+export interface WorkspaceRecipeComponentManifest {
+  schema: "wp-codebox/component-manifest/v1"
+  components?: WorkspaceRecipeComponentManifestEntry[]
+  providers?: WorkspaceRecipeComponentManifestEntry[]
+}
+
 export interface WorkspaceRecipeDependencyOverlay {
   kind: "composer-package"
   package: string
@@ -364,6 +380,7 @@ export interface WorkspaceRecipe {
     workspaces?: WorkspaceRecipeWorkspace[]
     mounts?: WorkspaceRecipeMount[]
     extra_plugins?: WorkspaceRecipeExtraPlugin[]
+    component_manifest?: WorkspaceRecipeComponentManifest
     dependency_overlays?: WorkspaceRecipeDependencyOverlay[]
     runtimeEnv?: Record<string, string>
     secretEnv?: string[]

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -15,8 +15,9 @@ ${phpFatalDiagnosticPhp()}
 define( 'REST_REQUEST', true );
 $_SERVER['REQUEST_URI'] = '/wp-json/wp-codebox/ability';
 ${runtimeEnvPhp(spec)}
-require_once '/wordpress/wp-load.php';
 ${secretEnvPhp(spec)}
+${componentManifestPhp(spec)}
+require_once '/wordpress/wp-load.php';
 ${phpBody(code)}`
 }
 
@@ -29,9 +30,10 @@ export function bootstrapPhpCode(spec: RuntimeCreateSpec, code: string, args: st
 ${phpFatalDiagnosticPhp()}
 ${pluginRuntimeBootstrapPhp(spec)}
 ${runtimeEnvPhp(spec)}
+${secretEnvPhp(spec)}
+${componentManifestPhp(spec)}
 require_once '/wordpress/wp-load.php';
 ${recipeActivePluginBootstrapPhp(spec)}
-${secretEnvPhp(spec)}
 ${wpCliBridge ? `putenv(${JSON.stringify(`HOMEBOY_TERMINAL_ACTION_URL=${wpCliBridge.url}`)});
 putenv(${JSON.stringify(`HOMEBOY_TERMINAL_ACTION_TOKEN=${wpCliBridge.token}`)});
 ` : ""}
@@ -186,6 +188,46 @@ function pluginRuntimeBootstrapPhp(spec: RuntimeCreateSpec): string {
   }
 
   return lines.length > 0 ? `${lines.join("\n")}\n` : ""
+}
+
+function componentManifestPhp(spec: RuntimeCreateSpec): string {
+  const manifest = componentManifest(spec)
+  if (!manifest) {
+    return ""
+  }
+
+  const encoded = Buffer.from(JSON.stringify(manifest), "utf8").toString("base64")
+  return `$wp_codebox_component_manifest = json_decode(base64_decode('${encoded}'), true);
+if (is_array($wp_codebox_component_manifest)) {
+    $GLOBALS['wp_codebox_component_manifest'] = $wp_codebox_component_manifest;
+    if (!defined('WP_CODEBOX_COMPONENT_MANIFEST_JSON')) {
+        define('WP_CODEBOX_COMPONENT_MANIFEST_JSON', json_encode($wp_codebox_component_manifest, JSON_UNESCAPED_SLASHES));
+    }
+}
+`
+}
+
+function componentManifest(spec: RuntimeCreateSpec): unknown {
+  const recipeManifest = metadataInputs(spec.metadata?.recipe)?.component_manifest
+  if (recipeManifest && typeof recipeManifest === "object" && !Array.isArray(recipeManifest)) {
+    return recipeManifest
+  }
+
+  const taskManifest = metadataInputs(spec.metadata?.task)?.component_manifest
+  if (taskManifest && typeof taskManifest === "object" && !Array.isArray(taskManifest)) {
+    return taskManifest
+  }
+
+  return undefined
+}
+
+function metadataInputs(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined
+  }
+
+  const inputs = (value as { inputs?: unknown }).inputs
+  return inputs && typeof inputs === "object" && !Array.isArray(inputs) ? inputs as Record<string, unknown> : undefined
 }
 
 function secretEnvPhp(spec: RuntimeCreateSpec): string {

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
@@ -21,12 +21,6 @@ final class WP_Codebox_Browser_Runner_Template {
 	public static function bootstrap_fragment( string $task_path, string $result_path, array $payload, array $invocation, array $captures ): string {
 		return '<?php
 $_GET[\'rest_route\'] = \'/wp-codebox/browser-runner\';
-require_once \'/wordpress/wp-load.php\';
-
-if ( function_exists( \'get_current_user_id\' ) && function_exists( \'wp_set_current_user\' ) && get_current_user_id() <= 0 ) {
-	wp_set_current_user( 1 );
-}
-
 $task_path = ' . var_export( $task_path, true ) . ';
 $result_path = ' . var_export( $result_path, true ) . ';
 $event_path = "/tmp/wp-codebox-agent-events.jsonl";
@@ -35,6 +29,27 @@ $invocation = ' . var_export( $invocation, true ) . ';
 $capture_paths = ' . var_export( $captures, true ) . ';
 $started_at = gmdate( \'c\' );
 $started_monotonic = microtime( true );
+
+if ( is_readable( $task_path ) ) {
+	$raw_payload = json_decode( (string) file_get_contents( $task_path ), true );
+	if ( is_array( $raw_payload ) ) {
+		$payload = array_replace_recursive( $payload, $raw_payload );
+	}
+}
+
+$wp_codebox_component_manifest = is_array( $payload[\'component_manifest\'] ?? null ) ? $payload[\'component_manifest\'] : array();
+if ( ! empty( $wp_codebox_component_manifest ) ) {
+	$GLOBALS[\'wp_codebox_component_manifest\'] = $wp_codebox_component_manifest;
+	if ( ! defined( \'WP_CODEBOX_COMPONENT_MANIFEST_JSON\' ) ) {
+		define( \'WP_CODEBOX_COMPONENT_MANIFEST_JSON\', json_encode( $wp_codebox_component_manifest, JSON_UNESCAPED_SLASHES ) );
+	}
+}
+
+require_once \'/wordpress/wp-load.php\';
+
+if ( function_exists( \'get_current_user_id\' ) && function_exists( \'wp_set_current_user\' ) && get_current_user_id() <= 0 ) {
+	wp_set_current_user( 1 );
+}
 ';
 	}
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -93,14 +93,18 @@ final class WP_Codebox_Host_Recipe_Builder {
 			return $site_seed_payload;
 		}
 
+		$component_plugins  = $adapters['component_plugins']( $paths );
+		$component_manifest = self::component_manifest( $component_plugins, $provider_plugins );
+
 		$recipe_inputs = array(
-			'mounts'        => $mounts,
-			'workspaces'    => $workspaces,
-			'inherit'       => $adapters['inheritance_request']( $input ),
-			'inheritance'   => $inheritance,
-			'extra_plugins' => array_merge( $adapters['component_plugins']( $paths ), $provider_plugins ),
-			'runtimeEnv'    => array_merge( $adapters['runtime_env']( $input ), self::AGENT_RUNTIME_ENV ),
-			'secretEnv'     => $adapters['secret_env_names']( $input, $inheritance ),
+			'mounts'             => $mounts,
+			'workspaces'         => $workspaces,
+			'inherit'            => $adapters['inheritance_request']( $input ),
+			'inheritance'        => $inheritance,
+			'extra_plugins'      => array_merge( $component_plugins, $provider_plugins ),
+			'component_manifest' => $component_manifest,
+			'runtimeEnv'         => array_merge( $adapters['runtime_env']( $input ), self::AGENT_RUNTIME_ENV ),
+			'secretEnv'          => $adapters['secret_env_names']( $input, $inheritance ),
 		);
 		if ( ! empty( $agent_bundles ) ) {
 			$recipe_inputs['agent_bundles'] = $agent_bundles;
@@ -133,6 +137,38 @@ final class WP_Codebox_Host_Recipe_Builder {
 		return array(
 			'path'          => $file,
 			'cleanup_paths' => $site_seed_payload['cleanup_paths'],
+		);
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $component_plugins Prepared runtime component plugin entries.
+	 * @param array<int,array<string,mixed>> $provider_plugins Provider plugin entries.
+	 * @return array<string,mixed>
+	 */
+	private static function component_manifest( array $component_plugins, array $provider_plugins ): array {
+		return array(
+			'schema'     => 'wp-codebox/component-manifest/v1',
+			'components' => array_values( array_map( array( self::class, 'component_manifest_plugin_entry' ), $component_plugins ) ),
+			'providers'  => array_values( array_map( array( self::class, 'component_manifest_plugin_entry' ), $provider_plugins ) ),
+		);
+	}
+
+	/** @param array<string,mixed> $plugin Prepared plugin entry. @return array<string,mixed> */
+	private static function component_manifest_plugin_entry( array $plugin ): array {
+		$metadata = is_array( $plugin['metadata'] ?? null ) ? $plugin['metadata'] : array();
+		$contract = is_array( $metadata['componentContract'] ?? null ) ? $metadata['componentContract'] : array();
+
+		return array_filter(
+			array(
+				'slug'          => (string) ( $plugin['slug'] ?? '' ),
+				'source'        => (string) ( $plugin['source'] ?? '' ),
+				'pluginFile'    => (string) ( $plugin['pluginFile'] ?? '' ),
+				'loadAs'        => (string) ( $plugin['loadAs'] ?? '' ),
+				'activate'      => isset( $plugin['activate'] ) ? (bool) $plugin['activate'] : null,
+				'contractIndex' => isset( $contract['index'] ) ? (int) $contract['index'] : null,
+				'requestedPath' => (string) ( $contract['requestedPath'] ?? '' ),
+			),
+			static fn( mixed $value ): bool => null !== $value && '' !== $value
 		);
 	}
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -177,12 +177,55 @@ private static function browser_runner_invocation_metadata( array $invocation ):
 	);
 }
 
+/** @param array<string,mixed> $task_input Normalized task input. @return array<string,mixed> */
+private static function browser_runner_component_manifest( array $task_input ): array {
+	$providers = array();
+	foreach ( is_array( $task_input['provider_plugin_paths'] ?? null ) ? $task_input['provider_plugin_paths'] : array() as $path ) {
+		$path = (string) $path;
+		if ( '' === $path ) {
+			continue;
+		}
+
+		$providers[] = array(
+			'slug'   => basename( $path ),
+			'source' => $path,
+		);
+	}
+
+	$components = array();
+	foreach ( is_array( $task_input['component_contracts'] ?? null ) ? $task_input['component_contracts'] : array() as $index => $contract ) {
+		if ( ! is_array( $contract ) ) {
+			continue;
+		}
+
+		$path = (string) ( $contract['path'] ?? '' );
+		$components[] = array_filter(
+			array(
+				'slug'          => (string) ( $contract['slug'] ?? ( '' !== $path ? basename( $path ) : '' ) ),
+				'source'        => $path,
+				'loadAs'        => (string) ( $contract['loadAs'] ?? 'mu-plugin' ),
+				'activate'      => isset( $contract['activate'] ) ? (bool) $contract['activate'] : null,
+				'contractIndex' => $index,
+				'requestedPath' => $path,
+			),
+			static fn( mixed $value ): bool => null !== $value && '' !== $value
+		);
+	}
+
+	return array(
+		'schema'     => 'wp-codebox/component-manifest/v1',
+		'components' => $components,
+		'providers'  => $providers,
+	);
+}
+
 private static function browser_agent_runner_php( array $task_input, string $session_id, string $task_path, string $result_path, array $invocation, array $captures ): string {
 	$default_payload = array(
 		'agent'      => 'wp-codebox-sandbox',
 		'message'    => (string) $task_input['goal'],
 		'session_id' => $session_id,
 		'task_input' => $task_input,
+		'component_manifest' => self::browser_runner_component_manifest( $task_input ),
 		'artifacts'  => array(),
 	);
 	$default_invocation = $invocation;


### PR DESCRIPTION
## Summary
- Apply runtime and secret env before injected PHP loads WordPress so provider plugins can see declared env during bootstrap.
- Add a canonical `inputs.component_manifest` recipe contract and carry the prepared component/provider manifest into runtime metadata.
- Preload the browser-runner staged payload manifest before `wp-load.php` so injected PHP and plugins can consume the boundary explicitly.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php`
- `npm run build`
- `npm run test:redaction`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the wp-codebox bootstrap/env/component manifest cleanup and ran local verification; Chris remains responsible for review and acceptance.
