### PR TITLE
Add runtime backend provider recipe hooks

### DIFF
--- a/packages/cli/src/commands/discovery.ts
+++ b/packages/cli/src/commands/discovery.ts
@@ -1,7 +1,7 @@
 import { createWorkspaceRecipeJsonSchema, type WorkspaceRecipeJsonSchema } from "@automattic/wp-codebox-core"
-import { commandRegistry, recipeCommandDefinitions, type CommandDefinition } from "@automattic/wp-codebox-core/contracts"
+import { commandRegistry, type CommandDefinition } from "@automattic/wp-codebox-core/contracts"
 import { printCommandCatalogHumanOutput, printRecipeSchemaHumanOutput } from "../output.js"
-import { listCliRuntimeBackendKinds } from "../runtime-backends.js"
+import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandDefinitions, listCliRuntimeBackendKinds } from "../runtime-backends.js"
 
 interface CommandCatalogOutput {
   schema: "wp-codebox/command-catalog/v1"
@@ -53,19 +53,32 @@ function parseDiscoveryJsonOption(args: string[]): boolean {
 }
 
 function commandCatalogOutput(): CommandCatalogOutput {
+  const commands = new Map<string, Omit<CommandDefinition, "handler">>()
+  for (const { handler, ...metadata } of commandRegistry.filter((command) => command.recipe === false)) {
+    commands.set(metadata.id, metadata)
+  }
+  for (const { handler, ...metadata } of listCliRecipeCommandDefinitions()) {
+    commands.set(metadata.id, metadata)
+  }
+
   return {
     schema: "wp-codebox/command-catalog/v1",
-    commands: commandRegistry.map(({ handler, ...metadata }) => metadata),
+    commands: [...commands.values()],
   }
 }
 
 function recipeSchemaOutput(): RecipeSchemaOutput {
+  const recipePolicy = cliRuntimeBackendRecipePolicy()
   return {
     schema: "wp-codebox/json-schema/v1",
     id: "wp-codebox/workspace-recipe/v1",
     jsonSchema: createWorkspaceRecipeJsonSchema({
-      recipeCommandIds: recipeCommandDefinitions().map((command) => command.id),
+      recipeCommandIds: listCliRecipeCommandDefinitions().map((command) => command.id),
       runtimeBackendKinds: listCliRuntimeBackendKinds(),
+      runtimeWordPressInstallModes: recipePolicy.wordpressInstallModes,
+      runtimeOverlayKinds: recipePolicy.runtimeOverlayKinds,
+      runtimeOverlayLibraries: recipePolicy.runtimeOverlayLibraries,
+      runtimeOverlayStrategies: recipePolicy.runtimeOverlayStrategies,
     }),
   }
 }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,6 +1,6 @@
 import type { ArtifactBundle, ExecutionResult, RuntimeInfo } from "@automattic/wp-codebox-core"
 import type { ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core/artifacts"
-import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
+import { listCliRecipeCommandDefinitions } from "./runtime-backends.js"
 
 interface CliError {
   name: string
@@ -286,7 +286,7 @@ export function printRecipeSchemaHumanOutput(output: RecipeSchemaOutputLike): vo
 }
 
 export function printHelp(): void {
-  const recipeCommandIds = recipeCommandDefinitions().map((command) => command.id)
+  const recipeCommandIds = listCliRecipeCommandDefinitions().map((command) => command.id)
 
   console.log(`Usage:
   wp-codebox commands [--json]

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,9 +1,8 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { assertWorkspaceRecipeJsonSchema, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS, validateBrowserInteractionScript, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
-import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
-import { listCliRuntimeBackendKinds } from "./runtime-backends.js"
+import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandIds, listCliRuntimeBackendKinds } from "./runtime-backends.js"
 
 export interface RecipeValidationIssue {
   code: string
@@ -21,11 +20,12 @@ export const defaultPolicy: RuntimePolicy = {
   approvals: "never",
 }
 
-const supportedRecipeCommands = new Set(recipeCommandDefinitions().map((command) => command.id))
+const cliRuntimeRecipePolicy = cliRuntimeBackendRecipePolicy()
+const supportedRecipeCommands = new Set(listCliRecipeCommandIds())
 const hostRecipeCommandPattern = /^host\/[A-Za-z0-9._/-]+$/
-const supportedRuntimeOverlayKinds = ["bundled-library"] as const
-const supportedRuntimeOverlayLibraries = ["php-ai-client"] as const
-const supportedRuntimeOverlayStrategies = ["wordpress-scoped-bundle"] as const
+const supportedRuntimeOverlayKinds = cliRuntimeRecipePolicy.runtimeOverlayKinds
+const supportedRuntimeOverlayLibraries = cliRuntimeRecipePolicy.runtimeOverlayLibraries
+const supportedRuntimeOverlayStrategies = cliRuntimeRecipePolicy.runtimeOverlayStrategies
 
 export async function loadWorkspaceRecipe(recipePath: string): Promise<WorkspaceRecipe> {
   return parseWorkspaceRecipe(await readFile(recipePath, "utf8"), recipePath)
@@ -35,7 +35,15 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   const recipe = parseWorkspaceRecipeJson(raw)
   normalizeWorkspaceRecipeCompatibility(recipe)
   validateWorkspaceRecipeShape(recipe, recipePath)
-  assertWorkspaceRecipeJsonSchema(recipe, { recipePath, recipeCommandIds: [...supportedRecipeCommands], runtimeBackendKinds: listCliRuntimeBackendKinds() })
+  assertWorkspaceRecipeJsonSchema(recipe, {
+    recipePath,
+    recipeCommandIds: [...supportedRecipeCommands],
+    runtimeBackendKinds: listCliRuntimeBackendKinds(),
+    runtimeWordPressInstallModes: cliRuntimeRecipePolicy.wordpressInstallModes,
+    runtimeOverlayKinds: supportedRuntimeOverlayKinds,
+    runtimeOverlayLibraries: supportedRuntimeOverlayLibraries,
+    runtimeOverlayStrategies: supportedRuntimeOverlayStrategies,
+  })
 
   return recipe
 }
@@ -293,7 +301,7 @@ function validateRecipeRuntimeWordPressInstallMode(mode: NonNullable<WorkspaceRe
     return
   }
 
-  if (!["install-from-existing-files", "install-from-existing-files-if-needed", "do-not-attempt-installing"].includes(mode)) {
+  if (!(cliRuntimeRecipePolicy.wordpressInstallModes as readonly string[]).includes(mode)) {
     throw new Error(`Recipe runtime wordpressInstallMode is unsupported: ${recipePath}`)
   }
 }

--- a/packages/cli/src/runtime-backends.ts
+++ b/packages/cli/src/runtime-backends.ts
@@ -1,10 +1,23 @@
-import { createRuntimeBackendRegistry, type RuntimeBackend, type RuntimeBackendFactoryContext, type RuntimeBackendKind } from "@automattic/wp-codebox-core"
+import { createRuntimeBackendRegistry, type RuntimeBackend, type RuntimeBackendFactoryContext, type RuntimeBackendKind, type RuntimeBackendRecipePolicy } from "@automattic/wp-codebox-core"
+import type { CommandDefinition } from "@automattic/wp-codebox-core/contracts"
 import { playgroundRuntimeBackendProvider } from "@automattic/wp-codebox-playground"
 
 const cliRuntimeBackendRegistry = createRuntimeBackendRegistry([playgroundRuntimeBackendProvider])
 
 export function listCliRuntimeBackendKinds(): RuntimeBackendKind[] {
   return cliRuntimeBackendRegistry.list()
+}
+
+export function cliRuntimeBackendRecipePolicy(): Required<RuntimeBackendRecipePolicy> {
+  return cliRuntimeBackendRegistry.recipePolicy()
+}
+
+export function listCliRecipeCommandDefinitions(): CommandDefinition[] {
+  return cliRuntimeBackendRegistry.recipeCommands()
+}
+
+export function listCliRecipeCommandIds(): string[] {
+  return listCliRecipeCommandDefinitions().map((command) => command.id)
 }
 
 export function resolveCliRuntimeBackend(kind: RuntimeBackendKind, context?: RuntimeBackendFactoryContext): RuntimeBackend {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -8,6 +8,10 @@ export type WorkspaceRecipeJsonSchema = Record<string, unknown>
 export interface WorkspaceRecipeJsonSchemaOptions {
   recipeCommandIds?: readonly string[]
   runtimeBackendKinds?: readonly string[]
+  runtimeWordPressInstallModes?: readonly string[]
+  runtimeOverlayKinds?: readonly string[]
+  runtimeOverlayLibraries?: readonly string[]
+  runtimeOverlayStrategies?: readonly string[]
 }
 
 export interface WorkspaceRecipeJsonSchemaValidationIssue {
@@ -28,6 +32,11 @@ export interface AssertWorkspaceRecipeJsonSchemaOptions extends WorkspaceRecipeJ
 export type WorkspaceRecipeRuntimeCollectedArtifact =
   | { kind: "path"; index: number; artifact: WorkspaceRecipeDeclaredArtifact }
   | { kind: "typed"; index: number; artifact: WorkspaceRecipeTypedArtifact }
+
+const defaultRuntimeWordPressInstallModes = ["install-from-existing-files", "install-from-existing-files-if-needed", "do-not-attempt-installing"] as const
+const defaultRuntimeOverlayKinds = ["bundled-library"] as const
+const defaultRuntimeOverlayLibraries = ["php-ai-client"] as const
+const defaultRuntimeOverlayStrategies = ["wordpress-scoped-bundle"] as const
 
 export function validateWorkspaceRecipeJsonSchema(recipe: unknown, options: WorkspaceRecipeJsonSchemaOptions = {}): WorkspaceRecipeJsonSchemaValidationResult {
   const validate = new Ajv2020({ strict: false }).compile(createWorkspaceRecipeJsonSchema(options))
@@ -105,7 +114,7 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             description: "PHP runtime version passed to WordPress Playground, for example 8.3 or 8.4.",
           },
           wordpressInstallMode: {
-            enum: ["install-from-existing-files", "install-from-existing-files-if-needed", "do-not-attempt-installing"],
+            enum: enumValues(options.runtimeWordPressInstallModes, defaultRuntimeWordPressInstallModes),
             description: "Controls how Playground prepares a mounted WordPress directory. Use do-not-attempt-installing for custom distributions that own their own boot/readiness probes.",
           },
           blueprint: { type: "object" },
@@ -457,11 +466,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
         additionalProperties: false,
         required: ["kind", "library", "source", "strategy"],
         properties: {
-          kind: { const: "bundled-library" },
-          library: { const: "php-ai-client" },
+          kind: { enum: enumValues(options.runtimeOverlayKinds, defaultRuntimeOverlayKinds) },
+          library: { enum: enumValues(options.runtimeOverlayLibraries, defaultRuntimeOverlayLibraries) },
           source: { type: "string" },
           target: { type: "string", pattern: "^/" },
-          strategy: { const: "wordpress-scoped-bundle" },
+          strategy: { enum: enumValues(options.runtimeOverlayStrategies, defaultRuntimeOverlayStrategies) },
           metadata: { $ref: "#/$defs/metadata" },
         },
       },
@@ -778,6 +787,10 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
       },
     },
   }
+}
+
+function enumValues<T extends string>(values: readonly T[] | undefined, fallback: readonly T[]): T[] {
+  return [...(values && values.length > 0 ? values : fallback)]
 }
 
 function runtimeBackendSchema(runtimeBackendKinds: readonly string[] | undefined): Record<string, unknown> {

--- a/packages/runtime-core/src/runtime-backend-resolver.ts
+++ b/packages/runtime-core/src/runtime-backend-resolver.ts
@@ -1,3 +1,4 @@
+import type { CommandDefinition } from "./command-registry.js"
 import type { RuntimeBackend, RuntimeBackendKind } from "./runtime-contracts.js"
 
 /**
@@ -10,8 +11,17 @@ export interface RuntimeBackendFactoryContext {
   readonly cliModule?: unknown
 }
 
+export interface RuntimeBackendRecipePolicy {
+  readonly recipeCommands?: readonly CommandDefinition[]
+  readonly wordpressInstallModes?: readonly string[]
+  readonly runtimeOverlayKinds?: readonly string[]
+  readonly runtimeOverlayLibraries?: readonly string[]
+  readonly runtimeOverlayStrategies?: readonly string[]
+}
+
 export interface RuntimeBackendProvider {
   readonly kind: RuntimeBackendKind
+  readonly recipePolicy?: RuntimeBackendRecipePolicy
   createBackend(context?: RuntimeBackendFactoryContext): RuntimeBackend
 }
 
@@ -29,6 +39,13 @@ export class RuntimeBackendRegistry {
       throw new Error(`Runtime backend provider is already registered: ${provider.kind}`)
     }
 
+    for (const command of provider.recipePolicy?.recipeCommands ?? []) {
+      const existingProvider = this.providers().find((registeredProvider) => registeredProvider.recipePolicy?.recipeCommands?.some((registeredCommand) => registeredCommand.id === command.id))
+      if (existingProvider) {
+        throw new Error(`Runtime backend recipe command is already registered: ${command.id}`)
+      }
+    }
+
     this.#providers.set(provider.kind, provider)
   }
 
@@ -44,6 +61,24 @@ export class RuntimeBackendRegistry {
 
     return provider.createBackend(context)
   }
+
+  recipeCommands(): CommandDefinition[] {
+    return this.providers().flatMap((provider) => [...(provider.recipePolicy?.recipeCommands ?? [])])
+  }
+
+  recipePolicy(): Required<RuntimeBackendRecipePolicy> {
+    return {
+      recipeCommands: this.recipeCommands(),
+      wordpressInstallModes: uniquePolicyValues(this.providers().flatMap((provider) => provider.recipePolicy?.wordpressInstallModes ?? [])),
+      runtimeOverlayKinds: uniquePolicyValues(this.providers().flatMap((provider) => provider.recipePolicy?.runtimeOverlayKinds ?? [])),
+      runtimeOverlayLibraries: uniquePolicyValues(this.providers().flatMap((provider) => provider.recipePolicy?.runtimeOverlayLibraries ?? [])),
+      runtimeOverlayStrategies: uniquePolicyValues(this.providers().flatMap((provider) => provider.recipePolicy?.runtimeOverlayStrategies ?? [])),
+    }
+  }
+
+  private providers(): RuntimeBackendProvider[] {
+    return [...this.#providers.values()]
+  }
 }
 
 export function createRuntimeBackendRegistry(providers: readonly RuntimeBackendProvider[] = []): RuntimeBackendRegistry {
@@ -57,4 +92,8 @@ export function resolveRuntimeBackend(kind: RuntimeBackendKind, providers: reado
 function unsupportedRuntimeBackendMessage(kind: RuntimeBackendKind, knownKinds: readonly RuntimeBackendKind[]): string {
   const known = knownKinds.length > 0 ? knownKinds.join(", ") : "none"
   return `Unsupported runtime backend: ${kind}; known runtime backends: ${known}`
+}
+
+function uniquePolicyValues<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)]
 }

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -3,6 +3,7 @@ import { mkdir, realpath, writeFile } from "node:fs/promises"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { dirname, join, resolve } from "node:path"
 import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, createHostToolRegistry, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
+import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
 import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand, wordpressAdminAuthCookiePhpCode } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
@@ -1135,6 +1136,13 @@ export function createPlaygroundRuntimeBackend(options: PlaygroundRuntimeBackend
 
 export const playgroundRuntimeBackendProvider: RuntimeBackendProvider = {
   kind: "wordpress-playground",
+  recipePolicy: {
+    recipeCommands: recipeCommandDefinitions(),
+    wordpressInstallModes: ["install-from-existing-files", "install-from-existing-files-if-needed", "do-not-attempt-installing"],
+    runtimeOverlayKinds: ["bundled-library"],
+    runtimeOverlayLibraries: ["php-ai-client"],
+    runtimeOverlayStrategies: ["wordpress-scoped-bundle"],
+  },
   createBackend(context = {}) {
     return createPlaygroundRuntimeBackend({ cliModule: context.cliModule as PlaygroundCliModule | undefined })
   },

--- a/scripts/discovery-command-smoke.ts
+++ b/scripts/discovery-command-smoke.ts
@@ -1,8 +1,8 @@
 import { resolve } from "node:path"
 import { createWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
-import { commandRegistry, recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
+import { commandRegistry } from "@automattic/wp-codebox-core/contracts"
 import Ajv2020 from "ajv/dist/2020.js"
-import { listCliRuntimeBackendKinds } from "../packages/cli/src/runtime-backends.js"
+import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandDefinitions, listCliRuntimeBackendKinds } from "../packages/cli/src/runtime-backends.js"
 import { readJson, repoRoot, runCliJson, runCliText } from "./test-kit.ts"
 
 interface CommandCatalogOutput {
@@ -24,8 +24,11 @@ interface RecipeSchemaOutput {
 }
 
 // Registry metadata is the source of truth for discovery and recipe help.
-const expectedCommandIds = recipeCommandDefinitions().map((command) => command.id)
-const expectedCatalogCommandIds = commandRegistry.map((command) => command.id)
+const expectedCommandIds = listCliRecipeCommandDefinitions().map((command) => command.id)
+const expectedCatalogCommandIds = [
+  ...commandRegistry.filter((command) => command.recipe === false).map((command) => command.id),
+  ...expectedCommandIds,
+]
 
 const representativeRecipes = [
   {
@@ -95,10 +98,18 @@ async function main(): Promise<void> {
   }
 
   const schemaOutput = await runCliJson<RecipeSchemaOutput>(["schema", "recipe", "--json"])
+  const recipePolicy = cliRuntimeBackendRecipePolicy()
   assert(schemaOutput.schema === "wp-codebox/json-schema/v1", "Unexpected recipe schema envelope")
   assert(schemaOutput.id === "wp-codebox/workspace-recipe/v1", "Unexpected recipe schema id")
   assert(
-    JSON.stringify(schemaOutput.jsonSchema) === JSON.stringify(createWorkspaceRecipeJsonSchema({ recipeCommandIds: expectedCommandIds, runtimeBackendKinds: listCliRuntimeBackendKinds() })),
+    JSON.stringify(schemaOutput.jsonSchema) === JSON.stringify(createWorkspaceRecipeJsonSchema({
+      recipeCommandIds: expectedCommandIds,
+      runtimeBackendKinds: listCliRuntimeBackendKinds(),
+      runtimeWordPressInstallModes: recipePolicy.wordpressInstallModes,
+      runtimeOverlayKinds: recipePolicy.runtimeOverlayKinds,
+      runtimeOverlayLibraries: recipePolicy.runtimeOverlayLibraries,
+      runtimeOverlayStrategies: recipePolicy.runtimeOverlayStrategies,
+    })),
     "CLI recipe schema must come from the shared runtime-core schema factory"
   )
 

--- a/scripts/runtime-backend-registry-smoke.ts
+++ b/scripts/runtime-backend-registry-smoke.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { createRuntimeBackendRegistry, createWorkspaceRecipeJsonSchema, type RuntimeBackend, type RuntimeBackendProvider, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
-import { listCliRuntimeBackendKinds, resolveCliRuntimeBackend } from "../packages/cli/src/runtime-backends.ts"
+import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandDefinitions, listCliRuntimeBackendKinds, resolveCliRuntimeBackend } from "../packages/cli/src/runtime-backends.ts"
 import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.ts"
 
 const exampleBackend: RuntimeBackend = {
@@ -12,6 +12,18 @@ const exampleBackend: RuntimeBackend = {
 
 const exampleProvider: RuntimeBackendProvider = {
   kind: "example-backend",
+  recipePolicy: {
+    recipeCommands: [{
+      id: "example.recipe-command",
+      description: "Example provider recipe command.",
+      acceptedArgs: [],
+      outputShape: "Example output.",
+      policyRequirement: "Example policy.",
+      recipe: true,
+      handler: { kind: "recipe-alias", command: "example.recipe-command" },
+    }],
+    wordpressInstallModes: ["do-not-attempt-installing"],
+  },
   createBackend() {
     return exampleBackend
   },
@@ -21,6 +33,8 @@ const registry = createRuntimeBackendRegistry([exampleProvider])
 
 assert.deepEqual(registry.list(), ["example-backend"])
 assert.equal(registry.resolve("example-backend"), exampleBackend)
+assert.deepEqual(registry.recipeCommands().map((command) => command.id), ["example.recipe-command"])
+assert.deepEqual(registry.recipePolicy().wordpressInstallModes, ["do-not-attempt-installing"])
 assert.throws(
   () => registry.register(exampleProvider),
   /Runtime backend provider is already registered: example-backend/,
@@ -32,6 +46,8 @@ assert.throws(
 
 assert.deepEqual(listCliRuntimeBackendKinds(), ["wordpress-playground"])
 assert.equal(resolveCliRuntimeBackend("wordpress-playground").kind, "wordpress-playground")
+assert.equal(listCliRecipeCommandDefinitions().some((command) => command.id === "wordpress.run-php"), true)
+assert.deepEqual(cliRuntimeBackendRecipePolicy().runtimeOverlayLibraries, ["php-ai-client"])
 assert.throws(
   () => resolveCliRuntimeBackend("missing-backend"),
   /Unsupported runtime backend: missing-backend; known runtime backends: wordpress-playground/,
@@ -42,6 +58,18 @@ assert.deepEqual((openSchema as any).properties.runtime.properties.backend, { ty
 
 const cliSchema = createWorkspaceRecipeJsonSchema({ runtimeBackendKinds: listCliRuntimeBackendKinds() })
 assert.deepEqual((cliSchema as any).properties.runtime.properties.backend, { enum: ["wordpress-playground"] })
+
+const cliPolicy = cliRuntimeBackendRecipePolicy()
+const cliProviderSchema = createWorkspaceRecipeJsonSchema({
+  recipeCommandIds: listCliRecipeCommandDefinitions().map((command) => command.id),
+  runtimeBackendKinds: listCliRuntimeBackendKinds(),
+  runtimeWordPressInstallModes: cliPolicy.wordpressInstallModes,
+  runtimeOverlayKinds: cliPolicy.runtimeOverlayKinds,
+  runtimeOverlayLibraries: cliPolicy.runtimeOverlayLibraries,
+  runtimeOverlayStrategies: cliPolicy.runtimeOverlayStrategies,
+})
+assert.deepEqual((cliProviderSchema as any).properties.runtime.properties.wordpressInstallMode.enum, ["install-from-existing-files", "install-from-existing-files-if-needed", "do-not-attempt-installing"])
+assert.deepEqual((cliProviderSchema as any).$defs.runtimeOverlay.properties.library, { enum: ["php-ai-client"] })
 
 const customBackendRecipe: WorkspaceRecipe = {
   schema: "wp-codebox/workspace-recipe/v1",


### PR DESCRIPTION
## Summary
- Add optional recipe policy hooks to runtime backend providers for recipe commands, WordPress install modes, and runtime overlay schema values.
- Wire the built-in WordPress Playground provider to expose the existing command/policy defaults so current CLI behavior remains unchanged.
- Update CLI validation, discovery, schema output, and help output to consume provider-composed metadata instead of reading recipe commands/policy constants directly from core.
- Extend smoke coverage for provider-composed registry policy and discovery schema output.

## Tests
- npm run build
- npm run smoke -- --command runtime-backend-registry-smoke
- npm run smoke -- --command discovery-command-smoke
- npm run check passed before rebase.
- After rebasing onto latest origin/main: npm run build, focused smokes passed; npm run check progressed through core/policy/artifact/runtime/package and hit the shell timeout in the agent group, then npm run smoke -- --group agent passed separately.

## Follow-up
- This PR creates the first safe provider seam. Command-specific recipe argument validation still lives in the CLI; moving that full command catalog/validator surface behind provider-owned metadata should be a follow-up PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the runtime backend provider hook implementation, smoke updates, and PR text for Chris to review and test.