### PR TITLE
Clean up reviewer access auth planning

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "smoke": "tsx scripts/run-smoke.ts",
     "test:redaction": "tsx tests/redaction.test.ts",
     "test:generic-primitives": "tsx tests/generic-primitives.test.ts",
+    "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "check": "npm run smoke -- --group=check"
   },
   "workspaces": [

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -753,6 +753,7 @@ export interface ArtifactPreview {
 export interface ArtifactPreviewReviewerAccess {
   schema: "wp-codebox/preview-reviewer-access/v1"
   status: "ready" | "blocked" | "unavailable"
+  outcome: "public" | "local" | "bootstrap" | "blocked" | "auth-required"
   mode: "direct-url" | "auth-bootstrap" | "none"
   reviewerSafe: boolean
   openUrl?: string

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -41,6 +41,7 @@ import {
 } from "@automattic/wp-codebox-core"
 import { normalizeJsonValue, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import type { BrowserArtifact } from "./browser-artifacts.js"
+import { firstCommandWordPressAdminAuthRequirement } from "./command-auth-requirements.js"
 import {
   ArtifactRedactor,
   artifactContentDigest,
@@ -814,8 +815,8 @@ export function heldPreviewWithExternalAccessBlockers(preview: ArtifactPreview |
     return preview
   }
 
-  const authCommand = commands.find((command) => browserCommandRequestsWordPressAdminAuth(command))
-  if (!authCommand) {
+  const authRequirement = firstCommandWordPressAdminAuthRequirement(commands)
+  if (!authRequirement) {
     return preview
   }
 
@@ -834,7 +835,7 @@ export function heldPreviewWithExternalAccessBlockers(preview: ArtifactPreview |
     retryable: false,
     reviewerSafe: false,
     evidence: {
-      command: authCommand.command,
+      command: authRequirement.command.command,
       auth: "wordpress-admin",
     },
   }
@@ -844,30 +845,6 @@ export function heldPreviewWithExternalAccessBlockers(preview: ArtifactPreview |
     blockers: [...(preview.blockers ?? []), blocker],
     reviewerAccess: previewReviewerAccess({ ...preview, blockers: [...(preview.blockers ?? []), blocker] }),
   }
-}
-
-function browserCommandRequestsWordPressAdminAuth(command: ExecutionResult): boolean {
-  if (!["wordpress.browser-actions", "wordpress.browser-probe", "wordpress.browser-scenario", "wordpress.visual-compare"].includes(command.command)) {
-    return false
-  }
-
-  return command.args.some((arg) => argRequestsWordPressAdminAuth(arg))
-}
-
-function argRequestsWordPressAdminAuth(arg: string): boolean {
-  const separator = arg.indexOf("=")
-  if (separator > 0) {
-    const key = arg.slice(0, separator).trim()
-    const value = arg.slice(separator + 1).trim()
-    if (key === "auth" && value === "wordpress-admin") {
-      return true
-    }
-    if ((key === "scenario" || key === "scenario-json") && /"auth"\s*:\s*"wordpress-admin"/.test(value)) {
-      return true
-    }
-  }
-
-  return /"auth"\s*:\s*"wordpress-admin"/.test(arg)
 }
 
 function evidenceRef(path: string, kind: string, contentType = "application/json"): ArtifactEvidenceRef {

--- a/packages/runtime-playground/src/command-auth-requirements.ts
+++ b/packages/runtime-playground/src/command-auth-requirements.ts
@@ -1,0 +1,86 @@
+import type { ExecutionResult } from "@automattic/wp-codebox-core"
+
+export interface WordPressAdminAuthCommandRequirement {
+  command: ExecutionResult
+  userId: number
+  redirectUrl?: string
+}
+
+const WORDPRESS_ADMIN_AUTH_ARG_COMMANDS = new Set([
+  "wordpress.browser-actions",
+  "wordpress.browser-probe",
+  "wordpress.browser-scenario",
+  "wordpress.visual-compare",
+])
+
+const WORDPRESS_ADMIN_AUTH_REQUIRED_COMMANDS = new Set([
+  "wordpress.editor-open",
+  "wordpress.editor-actions",
+])
+
+export function commandWordPressAdminAuthRequirement(command: ExecutionResult): WordPressAdminAuthCommandRequirement | undefined {
+  if (WORDPRESS_ADMIN_AUTH_REQUIRED_COMMANDS.has(command.command)) {
+    return {
+      command,
+      userId: commandWordPressAdminAuthUserId(command),
+      redirectUrl: commandRedirectUrl(command),
+    }
+  }
+
+  if (!WORDPRESS_ADMIN_AUTH_ARG_COMMANDS.has(command.command) || !command.args.some((arg) => argRequestsWordPressAdminAuth(arg))) {
+    return undefined
+  }
+
+  return {
+    command,
+    userId: commandWordPressAdminAuthUserId(command),
+    redirectUrl: commandRedirectUrl(command),
+  }
+}
+
+export function firstCommandWordPressAdminAuthRequirement(commands: ExecutionResult[]): WordPressAdminAuthCommandRequirement | undefined {
+  for (const command of commands) {
+    const requirement = commandWordPressAdminAuthRequirement(command)
+    if (requirement) {
+      return requirement
+    }
+  }
+  return undefined
+}
+
+function commandWordPressAdminAuthUserId(command: ExecutionResult): number {
+  const raw = command.args.map((arg) => argKeyValue(arg)).find((entry) => entry?.key === "auth-user-id")?.value
+  const userId = raw ? Number.parseInt(raw, 10) : 1
+  return Number.isInteger(userId) && userId > 0 ? userId : 1
+}
+
+function commandRedirectUrl(command: ExecutionResult): string | undefined {
+  return command.args.map((arg) => argKeyValue(arg)).find((entry) => entry?.key === "url")?.value
+}
+
+function argRequestsWordPressAdminAuth(arg: string): boolean {
+  const separator = arg.indexOf("=")
+  if (separator > 0) {
+    const key = arg.slice(0, separator).trim()
+    const value = arg.slice(separator + 1).trim()
+    if (key === "auth" && value === "wordpress-admin") {
+      return true
+    }
+    if ((key === "scenario" || key === "scenario-json") && /"auth"\s*:\s*"wordpress-admin"/.test(value)) {
+      return true
+    }
+  }
+
+  return /"auth"\s*:\s*"wordpress-admin"/.test(arg)
+}
+
+function argKeyValue(arg: string): { key: string; value: string } | undefined {
+  const separator = arg.indexOf("=")
+  if (separator <= 0) {
+    return undefined
+  }
+  return {
+    key: arg.slice(0, separator).trim(),
+    value: arg.slice(separator + 1).trim(),
+  }
+}

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -8,6 +8,7 @@ import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtif
 import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand, wordpressAdminAuthCookiePhpCode } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
+import { firstCommandWordPressAdminAuthRequirement } from "./command-auth-requirements.js"
 import { cleanWpCliOutput, shellArgv, wpCliCommandFromArgs, wpCliPhpScript } from "./commands.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { observeHttpResponse as observeHttpResponseArtifact, observeWordPressState as observeWordPressStateArtifact } from "./observation-artifacts.js"
@@ -70,38 +71,7 @@ interface ReviewerAuthBootstrapRecord {
   userId: number
 }
 
-function browserCommandRequestsWordPressAdminAuth(command: ExecutionResult): boolean {
-  if (!["wordpress.browser-actions", "wordpress.browser-probe", "wordpress.browser-scenario", "wordpress.visual-compare"].includes(command.command)) {
-    return false
-  }
-
-  return command.args.some((arg) => argRequestsWordPressAdminAuth(arg))
-}
-
-function argRequestsWordPressAdminAuth(arg: string): boolean {
-  const separator = arg.indexOf("=")
-  if (separator > 0) {
-    const key = arg.slice(0, separator).trim()
-    const value = arg.slice(separator + 1).trim()
-    if (key === "auth" && value === "wordpress-admin") {
-      return true
-    }
-    if ((key === "scenario" || key === "scenario-json") && /"auth"\s*:\s*"wordpress-admin"/.test(value)) {
-      return true
-    }
-  }
-
-  return /"auth"\s*:\s*"wordpress-admin"/.test(arg)
-}
-
-function browserCommandWordPressAdminAuthUserId(command: ExecutionResult): number {
-  const raw = command.args.map((arg) => argKeyValue(arg)).find((entry) => entry?.key === "auth-user-id")?.value
-  const userId = raw ? Number.parseInt(raw, 10) : 1
-  return Number.isInteger(userId) && userId > 0 ? userId : 1
-}
-
-function reviewerAuthRedirectUrl(command: ExecutionResult, serverUrl: string): string | undefined {
-  const url = command.args.map((arg) => argKeyValue(arg)).find((entry) => entry?.key === "url")?.value
+function reviewerAuthRedirectUrl(url: string | undefined, serverUrl: string): string | undefined {
   if (!url) {
     return undefined
   }
@@ -110,17 +80,6 @@ function reviewerAuthRedirectUrl(command: ExecutionResult, serverUrl: string): s
     return new URL(url, serverUrl).toString()
   } catch {
     return undefined
-  }
-}
-
-function argKeyValue(arg: string): { key: string; value: string } | undefined {
-  const separator = arg.indexOf("=")
-  if (separator <= 0) {
-    return undefined
-  }
-  return {
-    key: arg.slice(0, separator).trim(),
-    value: arg.slice(separator + 1).trim(),
   }
 }
 
@@ -566,15 +525,15 @@ class PlaygroundRuntime implements Runtime {
   }
 
   private createReviewerAuthBootstrap(server: PlaygroundCliServer, preview: ArtifactPreview, expiresAt: string, commands: ExecutionResult[]): ArtifactReviewerAuthBootstrap | undefined {
-    const authCommand = commands.find((command) => browserCommandRequestsWordPressAdminAuth(command))
-    if (!authCommand || !server.previewRoutes || !isLocalPreviewUrl(preview.localUrl ?? preview.url)) {
+    const authRequirement = firstCommandWordPressAdminAuthRequirement(commands)
+    if (!authRequirement || !server.previewRoutes || !isLocalPreviewUrl(preview.localUrl ?? preview.url)) {
       return undefined
     }
 
     this.registerReviewerAuthBootstrapRoute(server)
     const token = randomBytes(24).toString("base64url")
-    const userId = browserCommandWordPressAdminAuthUserId(authCommand)
-    const redirectUrl = reviewerAuthRedirectUrl(authCommand, server.serverUrl) ?? server.serverUrl
+    const userId = authRequirement.userId
+    const redirectUrl = reviewerAuthRedirectUrl(authRequirement.redirectUrl, server.serverUrl) ?? server.serverUrl
     this.reviewerAuthBootstraps.set(token, {
       expiresAt,
       redirectUrl,
@@ -592,7 +551,7 @@ class PlaygroundRuntime implements Runtime {
       redirectUrl,
       expiresAt,
       evidence: {
-        command: authCommand.command,
+        command: authRequirement.command.command,
         auth: "wordpress-admin",
         userId,
       },

--- a/packages/runtime-playground/src/preview-reviewer-access.ts
+++ b/packages/runtime-playground/src/preview-reviewer-access.ts
@@ -5,6 +5,7 @@ export function previewReviewerAccess(preview: ArtifactPreview | undefined): Art
     return {
       schema: "wp-codebox/preview-reviewer-access/v1",
       status: "unavailable",
+      outcome: "blocked",
       mode: "none",
       reviewerSafe: false,
       reason: "preview-not-held",
@@ -15,6 +16,7 @@ export function previewReviewerAccess(preview: ArtifactPreview | undefined): Art
     return {
       schema: "wp-codebox/preview-reviewer-access/v1",
       status: "ready",
+      outcome: "bootstrap",
       mode: "auth-bootstrap",
       reviewerSafe: true,
       openUrl: preview.reviewerAuthBootstrap.bootstrapUrl,
@@ -28,6 +30,7 @@ export function previewReviewerAccess(preview: ArtifactPreview | undefined): Art
     return {
       schema: "wp-codebox/preview-reviewer-access/v1",
       status: "blocked",
+      outcome: preview.blockers.some((blocker) => blocker.code === "external-wordpress-admin-auth-unavailable") ? "auth-required" : "blocked",
       mode: "none",
       reviewerSafe: false,
       blockers: preview.blockers,
@@ -41,6 +44,7 @@ export function previewReviewerAccess(preview: ArtifactPreview | undefined): Art
     return {
       schema: "wp-codebox/preview-reviewer-access/v1",
       status: "ready",
+      outcome: "public",
       mode: "direct-url",
       reviewerSafe: true,
       openUrl: safeUrl,
@@ -52,6 +56,7 @@ export function previewReviewerAccess(preview: ArtifactPreview | undefined): Art
   return {
     schema: "wp-codebox/preview-reviewer-access/v1",
     status: "blocked",
+    outcome: "local",
     mode: "none",
     reviewerSafe: false,
     expiresAt: preview.expiresAt,

--- a/tests/reviewer-access.test.ts
+++ b/tests/reviewer-access.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import type { ArtifactPreview, ExecutionResult } from "../packages/runtime-core/src/index.js"
+import { firstCommandWordPressAdminAuthRequirement } from "../packages/runtime-playground/src/command-auth-requirements.js"
+import { heldPreviewWithExternalAccessBlockers } from "../packages/runtime-playground/src/artifact-bundle-builder.js"
+import { previewReviewerAccess } from "../packages/runtime-playground/src/preview-reviewer-access.js"
+
+const heldPreview: ArtifactPreview = {
+  url: "http://127.0.0.1:9400/",
+  localUrl: "http://127.0.0.1:9400/",
+  status: "available",
+  lifecycle: "held-after-run",
+  source: "live-playground",
+  createdAt: "2026-06-17T00:00:00.000Z",
+  expiresAt: "2026-06-17T00:05:00.000Z",
+  holdSeconds: 300,
+}
+
+assert.equal(firstCommandWordPressAdminAuthRequirement([command("wordpress.browser-probe", ["url=/", "auth=wordpress-admin", "auth-user-id=2"])])?.userId, 2)
+assert.equal(firstCommandWordPressAdminAuthRequirement([command("wordpress.editor-open", ["target=site"])])?.userId, 1)
+assert.equal(firstCommandWordPressAdminAuthRequirement([command("wordpress.editor-actions", ["url=/wp-admin/site-editor.php", "steps-json=[]"])])?.redirectUrl, "/wp-admin/site-editor.php")
+assert.equal(firstCommandWordPressAdminAuthRequirement([command("wordpress.browser-probe", ["url=/"])])?.command.command, undefined)
+
+const blockedEditorPreview = heldPreviewWithExternalAccessBlockers(heldPreview, [command("wordpress.editor-open", ["target=site"])])
+assert.equal(blockedEditorPreview?.blockers?.[0]?.code, "external-wordpress-admin-auth-unavailable")
+assert.equal(blockedEditorPreview?.reviewerAccess?.status, "blocked")
+assert.equal(blockedEditorPreview?.reviewerAccess?.outcome, "auth-required")
+
+const directPublicPreview = heldPreviewWithExternalAccessBlockers({ ...heldPreview, url: "https://preview.example.test/", publicUrl: "https://preview.example.test/" }, [])
+assert.equal(directPublicPreview?.reviewerAccess?.outcome, undefined)
+assert.equal(previewReviewerAccess(directPublicPreview).outcome, "public")
+assert.equal(previewReviewerAccess(heldPreview).outcome, "local")
+
+function command(command: string, args: string[]): ExecutionResult {
+  return {
+    id: `command-${command}`,
+    command,
+    args,
+    startedAt: "2026-06-17T00:00:00.000Z",
+    completedAt: "2026-06-17T00:00:01.000Z",
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared runtime-playground helper for WordPress admin auth requirements across browser/editor commands.
- Include `wordpress.editor-open` and `wordpress.editor-actions` in reviewer-access auth planning.
- Express preview reviewer access outcomes explicitly as public, local, bootstrap, blocked, or auth-required.
- Replace duplicated auth command parsing in the playground runtime and artifact bundle builder.

## Testing
- `npm run build`
- `npm run test:generic-primitives`
- `npm run test:redaction`
- `npm run test:reviewer-access`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Drafted the implementation and focused tests; Chris remains responsible for review and validation.