### PR TITLE
Fix safe VFS mount materialization

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
-import { dirname, join } from "node:path"
-import { namedFileTreeSkipPolicyNames, phpStringArrayLiteral, type MountSpec } from "@automattic/wp-codebox-core"
+import { dirname, isAbsolute, join, relative, resolve } from "node:path"
+import { materializationPhaseResult, namedFileTreeSkipPolicyNames, phpStringArrayLiteral, type MaterializationPhaseResult, type MountSpec } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { SKIPPED_CAPTURE_DIRECTORIES } from "./artifacts.js"
 
@@ -14,6 +14,7 @@ export interface HostMountSnapshot {
 export interface VfsMountSnapshot {
   mountIndex: number
   target: string
+  authoritative?: boolean
   files: Array<{
     relativePath: string
     sha256: string
@@ -25,6 +26,18 @@ export interface MountMaterializationResult {
   materialized: number
   deleted: number
   skipped: number
+  phaseResult: MaterializationPhaseResult
+}
+
+function mountMaterializationResult(input: Omit<MountMaterializationResult, "phaseResult">): MountMaterializationResult {
+  return {
+    ...input,
+    phaseResult: materializationPhaseResult({
+      phase: "playground-vfs-mount-materialization",
+      status: input.materialized > 0 || input.deleted > 0 ? "completed" : "skipped",
+      metadata: input,
+    }),
+  }
 }
 
 export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliServer, mounts: MountSpec[]): Promise<MountMaterializationResult> {
@@ -32,7 +45,7 @@ export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliSe
     .map((mount, mountIndex) => ({ mount, mountIndex }))
     .filter(({ mount }) => mount.mode === "readwrite" && mount.type !== "file")
   if (writableDirectoryMounts.length === 0) {
-    return { materialized: 0, deleted: 0, skipped: 0 }
+    return mountMaterializationResult({ materialized: 0, deleted: 0, skipped: 0 })
   }
 
   const hostSnapshots: HostMountSnapshot[] = []
@@ -50,23 +63,36 @@ export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliSe
 }
 
 export async function applyVfsMountSnapshots(mounts: MountSpec[], snapshots: VfsMountSnapshot[]): Promise<MountMaterializationResult> {
-  const result: MountMaterializationResult = { materialized: 0, deleted: 0, skipped: 0 }
+  const result = { materialized: 0, deleted: 0, skipped: 0 }
 
   for (const snapshot of snapshots) {
     const mount = mounts[snapshot.mountIndex]
-    if (!mount || mount.mode !== "readwrite" || mount.type === "file") {
+    if (!mount || mount.mode !== "readwrite" || mount.type === "file" || snapshot.authoritative === false) {
       result.skipped++
       continue
     }
 
-    const present = new Set(snapshot.files.map((file) => file.relativePath))
-    const existing = await hostFileHashes(mount.source)
-
+    const present = new Set<string>()
+    const writableFiles: typeof snapshot.files = []
     for (const file of snapshot.files) {
-      if (!file.contentsBase64) {
+      if (!containedHostPath(mount.source, file.relativePath)) {
+        result.skipped++
         continue
       }
-      const hostPath = join(mount.source, file.relativePath)
+      present.add(file.relativePath)
+      writableFiles.push(file)
+    }
+    const existing = await hostFileHashes(mount.source)
+
+    for (const file of writableFiles) {
+      if (file.contentsBase64 === undefined) {
+        continue
+      }
+      const hostPath = containedHostPath(mount.source, file.relativePath)
+      if (!hostPath) {
+        result.skipped++
+        continue
+      }
       await mkdir(dirname(hostPath), { recursive: true })
       await writeFile(hostPath, Buffer.from(file.contentsBase64, "base64"))
       result.materialized++
@@ -76,12 +102,30 @@ export async function applyVfsMountSnapshots(mounts: MountSpec[], snapshots: Vfs
       if (present.has(relativePath)) {
         continue
       }
-      await rm(join(mount.source, relativePath), { force: true })
+      const hostPath = containedHostPath(mount.source, relativePath)
+      if (!hostPath) {
+        result.skipped++
+        continue
+      }
+      await rm(hostPath, { force: true })
       result.deleted++
     }
   }
 
-  return result
+  return mountMaterializationResult(result)
+}
+
+function containedHostPath(root: string, relativePath: string): string | undefined {
+  if (!relativePath || isAbsolute(relativePath)) {
+    return undefined
+  }
+  const rootPath = resolve(root)
+  const hostPath = resolve(rootPath, relativePath)
+  const pathWithinRoot = relative(rootPath, hostPath)
+  if (!pathWithinRoot || pathWithinRoot.startsWith("..") || isAbsolute(pathWithinRoot)) {
+    return undefined
+  }
+  return hostPath
 }
 
 async function hostFileHashes(directory: string, relativeDirectory = ""): Promise<Record<string, string>> {
@@ -168,6 +212,7 @@ foreach (($payload['mounts'] ?? array()) as $mount) {
         $mounts[] = array(
             'mountIndex' => (int) ($mount['mountIndex'] ?? -1),
             'target' => $target,
+            'authoritative' => false,
             'files' => array(),
         );
         continue;
@@ -175,6 +220,7 @@ foreach (($payload['mounts'] ?? array()) as $mount) {
     $mounts[] = array(
         'mountIndex' => (int) ($mount['mountIndex'] ?? -1),
         'target' => $target,
+        'authoritative' => true,
         'files' => wp_codebox_vfs_mount_files($target, is_array($mount['files'] ?? null) ? $mount['files'] : array(), $skip),
     );
 }

--- a/scripts/mounted-workspace-diff-smoke.ts
+++ b/scripts/mounted-workspace-diff-smoke.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
 import { execFile } from "node:child_process"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { promisify } from "node:util"
@@ -185,10 +185,69 @@ try {
   assert.doesNotMatch(rawPhp, /wp_json_encode/)
   await writeFile(rawPhpFile, rawPhp)
   const rawPhpResult = await execFileAsync("php", [rawPhpFile])
-  const rawPhpSnapshot = JSON.parse(rawPhpResult.stdout) as { schema?: string; mounts?: Array<{ files?: Array<{ relativePath?: string; contentsBase64?: string }> }> }
+  const rawPhpSnapshot = JSON.parse(rawPhpResult.stdout) as { schema?: string; mounts?: Array<{ authoritative?: boolean; files?: Array<{ relativePath?: string; contentsBase64?: string }> }> }
   assert.equal(rawPhpSnapshot.schema, "wp-codebox/vfs-mount-snapshot/v1")
+  assert.equal(rawPhpSnapshot.mounts?.[0]?.authoritative, true)
   assert.equal(rawPhpSnapshot.mounts?.[0]?.files?.[0]?.relativePath, "changed.txt")
   assert.equal(Buffer.from(rawPhpSnapshot.mounts?.[0]?.files?.[0]?.contentsBase64 ?? "", "base64").toString("utf8"), "changed inside raw php\n")
+
+  const missingRawPhp = vfsMountSnapshotPhp([{
+    mountIndex: 0,
+    target: join(root, "missing-vfs-target"),
+    files: {
+      "remove-me.txt": createHash("sha256").update("delete this\n").digest("hex"),
+    },
+  }])
+  await writeFile(rawPhpFile, missingRawPhp)
+  const missingRawPhpResult = await execFileAsync("php", [rawPhpFile])
+  const missingRawPhpSnapshot = JSON.parse(missingRawPhpResult.stdout) as { mounts?: Array<{ authoritative?: boolean; files?: unknown[] }> }
+  assert.equal(missingRawPhpSnapshot.mounts?.[0]?.authoritative, false)
+  assert.deepEqual(missingRawPhpSnapshot.mounts?.[0]?.files, [])
+
+  const missingTargetMaterialized = await applyVfsMountSnapshots(vfsMounts, [{
+    mountIndex: 0,
+    target: "/workspace/vfs-backed-repo",
+    authoritative: false,
+    files: [],
+  }])
+  assert.equal(missingTargetMaterialized.materialized, 0)
+  assert.equal(missingTargetMaterialized.deleted, 0)
+  assert.equal(missingTargetMaterialized.skipped, 1)
+  assert.equal(await readFile(join(vfsBackedRepo, "remove-me.txt"), "utf8"), "delete this\n")
+
+  const emptyAndUnsafePathMaterialized = await applyVfsMountSnapshots(vfsMounts, [{
+    mountIndex: 0,
+    target: "/workspace/vfs-backed-repo",
+    files: [
+      {
+        relativePath: "empty.txt",
+        sha256: "unused",
+        contentsBase64: "",
+      },
+      {
+        relativePath: "remove-me.txt",
+        sha256: "unused",
+      },
+      {
+        relativePath: "../escaped.txt",
+        sha256: "unused",
+        contentsBase64: Buffer.from("escaped\n").toString("base64"),
+      },
+      {
+        relativePath: "/absolute.txt",
+        sha256: "unused",
+        contentsBase64: Buffer.from("absolute\n").toString("base64"),
+      },
+    ],
+  }])
+  assert.equal(emptyAndUnsafePathMaterialized.materialized, 1)
+  assert.equal(emptyAndUnsafePathMaterialized.deleted, 1)
+  assert.equal(emptyAndUnsafePathMaterialized.skipped, 2)
+  assert.equal(emptyAndUnsafePathMaterialized.phaseResult.schema, "wp-codebox/materialization-phase-result/v1")
+  assert.equal(emptyAndUnsafePathMaterialized.phaseResult.phase, "playground-vfs-mount-materialization")
+  assert.equal(emptyAndUnsafePathMaterialized.phaseResult.status, "completed")
+  assert.equal((await stat(join(vfsBackedRepo, "empty.txt"))).size, 0)
+  await assert.rejects(() => stat(join(root, "escaped.txt")))
 
   const materialized = await applyVfsMountSnapshots(vfsMounts, [{
     mountIndex: 0,
@@ -207,7 +266,7 @@ try {
     ],
   }])
   assert.equal(materialized.materialized, 2)
-  assert.equal(materialized.deleted, 1)
+  assert.equal(materialized.deleted, 2)
 
   const vfsResult = await captureMountDiffs(artifactRoot, filesDirectory, vfsMounts, new ArtifactRedactor())
   const vfsChanged = new Map(vfsResult.changedFiles.files.map((file) => [file.relativePath, file]))


### PR DESCRIPTION
## Summary
- Treat missing runtime VFS mount targets as non-authoritative so they cannot delete host files.
- Validate runtime-produced relative paths before host writes/deletes and skip paths outside the mount root.
- Preserve empty `contentsBase64` files during materialization.
- Include the documented materialization phase result on mount materialization results.

## Verification
- `npm run build`
- `npx tsx scripts/mounted-workspace-diff-smoke.ts`
- `npm run test:generic-primitives`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Drafted the materialization safety implementation and behavior assertions; Chris remains responsible for review and testing.