### PR TITLE
Use registry metadata for command dispatch

### DIFF
--- a/packages/runtime-core/src/command-codecs.ts
+++ b/packages/runtime-core/src/command-codecs.ts
@@ -1,3 +1,6 @@
+import { resolve } from "node:path"
+import type { JsonValue } from "./host-tool-registry.js"
+
 export type CommandJsonObject = Record<string, unknown>
 
 export interface CommandOptionParseResult {
@@ -80,6 +83,30 @@ export function parseCommandJson(raw: string, label = "JSON argument"): unknown 
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`${label} must be valid JSON: ${message}`)
   }
+}
+
+export function parseCommandInput(args: readonly string[], explicitName = "input-json"): JsonValue {
+  const explicit = commandArgValue(args, explicitName)
+  if (explicit !== undefined) {
+    return parseCommandJson(explicit, explicitName) as JsonValue
+  }
+
+  const input: Record<string, string> = {}
+  for (const arg of args) {
+    const separator = arg.indexOf("=")
+    if (separator > 0) {
+      input[arg.slice(0, separator)] = arg.slice(separator + 1)
+    }
+  }
+  return input
+}
+
+export function resolveCommandPath(pathValue: string, baseDir = process.cwd()): string {
+  const trimmed = pathValue.trim()
+  if (!trimmed) {
+    throw new Error("Command path must be non-empty")
+  }
+  return resolve(baseDir, trimmed)
 }
 
 export function parseCommandJsonObject(raw: string | undefined, label = "JSON argument", fallback: CommandJsonObject = {}): CommandJsonObject {

--- a/packages/runtime-playground/src/browser-actions.ts
+++ b/packages/runtime-playground/src/browser-actions.ts
@@ -1,6 +1,5 @@
 import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
-import { validateBrowserInteractionScript, type BrowserInteractionStep } from "@automattic/wp-codebox-core"
+import { resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep } from "@automattic/wp-codebox-core"
 import { argValue } from "./commands.js"
 
 export async function browserInteractionStepsFromArgs(args: string[]): Promise<BrowserInteractionStep[]> {
@@ -21,7 +20,7 @@ async function parseBrowserStepsPayload(raw: string, name: string): Promise<unkn
   let text = raw
   if (raw.startsWith("@")) {
     const path = raw.slice(1)
-    text = await readFile(resolve(path), "utf8")
+    text = await readFile(resolveCommandPath(path), "utf8")
   }
   try {
     return JSON.parse(text)

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { access, mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative } from "node:path"
-import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, validateBrowserInteractionScript, type BrowserInteractionStep, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
 import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
@@ -2652,7 +2652,7 @@ async function browserScenarioFromArgs(args: string[]): Promise<BrowserScenarioI
   if (!raw) {
     return {}
   }
-  const text = raw.startsWith("@") ? await readFile(raw.slice(1), "utf8") : raw
+  const text = raw.startsWith("@") ? await readFile(resolveCommandPath(raw.slice(1)), "utf8") : raw
   const parsed = JSON.parse(text) as unknown
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("wordpress.browser-scenario scenario-json must be a JSON object")

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -1,5 +1,5 @@
-import { commandArgValue, createHostToolTransportError, createRuntimeCommandResultEnvelope, executeHostTool, parseCommandJson, type HostToolRegistry, type JsonValue, type RuntimeCommandResultEnvelope } from "@automattic/wp-codebox-core"
-import { getCommandDefinition, type PlaygroundRuntimeCommandId } from "@automattic/wp-codebox-core/contracts"
+import { createHostToolTransportError, createRuntimeCommandResultEnvelope, executeHostTool, parseCommandInput, type HostToolRegistry, type JsonValue, type RuntimeCommandResultEnvelope } from "@automattic/wp-codebox-core"
+import { getCommandDefinition, runtimeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import type { ExecutionSpec } from "@automattic/wp-codebox-core"
 
 export type PlaygroundCommandOutput = string | RuntimeCommandResultEnvelope
@@ -27,31 +27,8 @@ interface PlaygroundCommandRuntime {
   runEditorActions(spec: ExecutionSpec): Promise<string>
 }
 
-const playgroundCommandHandlers = {
-  "inspect-mounted-inputs": (runtime) => runtime.inspectMountedInputs(),
-  "wordpress.run-php": (runtime, spec) => runtime.runPhp(spec),
-  "wordpress.wp-cli": (runtime, spec) => runtime.runWpCli(spec),
-  "wordpress.capture-state-bundle": (runtime, spec) => runtime.runCaptureStateBundle(spec),
-  "wordpress.export-replay-package": (runtime, spec) => runtime.runExportReplayPackage(spec),
-  "wordpress.rest-request": (runtime, spec) => runtime.runRestRequest(spec),
-  "wordpress.ability": (runtime, spec) => runtime.runAbility(spec),
-  "wordpress.bench": (runtime, spec) => runtime.runBench(spec),
-  "wordpress.phpunit": (runtime, spec) => runtime.runPhpunit(spec),
-  "wordpress.plugin-check": (runtime, spec) => runtime.runPluginCheck(spec),
-  "wordpress.core-phpunit": (runtime, spec) => runtime.runCorePhpunit(spec),
-  "wordpress.theme-check": (runtime, spec) => runtime.runThemeCheck(spec),
-  "wordpress.browser-probe": (runtime, spec) => runtime.runBrowserProbe(spec),
-  "wordpress.capture-html": (runtime, spec) => runtime.runHtmlCapture(spec),
-  "wordpress.editor-canvas-probe": (runtime, spec) => runtime.runEditorCanvasProbe(spec),
-  "wordpress.browser-actions": (runtime, spec) => runtime.runBrowserActions(spec),
-  "wordpress.browser-scenario": (runtime, spec) => runtime.runBrowserScenario(spec),
-  "wordpress.visual-compare": (runtime, spec) => runtime.runVisualCompare(spec),
-  "wordpress.editor-open": (runtime, spec) => runtime.runEditorOpen(spec),
-  "wordpress.editor-actions": (runtime, spec) => runtime.runEditorActions(spec),
-} satisfies Record<PlaygroundRuntimeCommandId, (runtime: PlaygroundCommandRuntime, spec: ExecutionSpec) => Promise<PlaygroundCommandOutput>>
-
 export function playgroundRuntimeCommandIds(): string[] {
-  return Object.keys(playgroundCommandHandlers)
+  return runtimeCommandDefinitions().map((definition) => definition.id)
 }
 
 export async function executePlaygroundCommand(runtime: PlaygroundCommandRuntime, spec: ExecutionSpec, hostTools?: HostToolRegistry): Promise<PlaygroundCommandOutput> {
@@ -60,7 +37,7 @@ export async function executePlaygroundCommand(runtime: PlaygroundCommandRuntime
     const startedAt = new Date().toISOString()
     let input: JsonValue
     try {
-      input = hostToolInput(spec.args ?? [])
+      input = parseCommandInput(spec.args ?? [])
     } catch (error) {
       const result = createHostToolTransportError(hostTool, spec.command, startedAt, "host-tool-invalid-input-json", error instanceof Error ? error.message : String(error))
       return createRuntimeCommandResultEnvelope({ status: "error", stdout: `${JSON.stringify(result)}\n`, json: result, error: { code: result.error.code, message: result.error.message }, diagnostics: result.diagnostics })
@@ -76,28 +53,16 @@ export async function executePlaygroundCommand(runtime: PlaygroundCommandRuntime
 
   const definition = getCommandDefinition(spec.command)
   if (definition?.handler.kind === "playground") {
-    const handler = playgroundCommandHandlers[definition.id as PlaygroundRuntimeCommandId]
-    if (handler) {
-      return handler(runtime, spec)
+    const method = definition.handler.method
+    if (isPlaygroundCommandRuntimeMethod(runtime, method)) {
+      return runtime[method](spec)
     }
+    throw new Error(`Playground command handler method is unavailable for ${spec.command}: ${method}`)
   }
 
   throw new Error(`No Playground command handler is registered for: ${spec.command}`)
 }
 
-function hostToolInput(args: string[]): JsonValue {
-  const explicit = commandArgValue(args, "input-json")
-  if (explicit !== undefined) {
-    const parsed = parseCommandJson(explicit, "input-json") as JsonValue
-    return parsed
-  }
-
-  const input: Record<string, string> = {}
-  for (const arg of args) {
-    const separator = arg.indexOf("=")
-    if (separator > 0) {
-      input[arg.slice(0, separator)] = arg.slice(separator + 1)
-    }
-  }
-  return input
+function isPlaygroundCommandRuntimeMethod(runtime: PlaygroundCommandRuntime, method: string): method is keyof PlaygroundCommandRuntime {
+  return method in runtime && typeof runtime[method as keyof PlaygroundCommandRuntime] === "function"
 }

--- a/packages/runtime-playground/src/editor-actions.ts
+++ b/packages/runtime-playground/src/editor-actions.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
+import { resolveCommandPath } from "@automattic/wp-codebox-core"
 import { argValue } from "./commands.js"
 
 export interface EditorOpenTarget {
@@ -59,7 +59,7 @@ export async function editorActionStepsFromArgs(args: string[]): Promise<EditorA
 
   let text = stepsRaw
   if (stepsRaw.startsWith("@")) {
-    text = await readFile(resolve(stepsRaw.slice(1)), "utf8")
+    text = await readFile(resolveCommandPath(stepsRaw.slice(1)), "utf8")
   }
 
   let parsed: unknown

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -1,8 +1,7 @@
 import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
 import { argValue, normalizePhpCode, phpBody } from "./commands.js"
 import { phpEnvAssignments, phpRuntimeComponentLifecycleReplayFunction, phpWpConfigDefineAssignments } from "./php-snippets.js"
-import { normalizeRuntimeEnvRecord, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { normalizeRuntimeEnvRecord, resolveCommandPath, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 
 interface PhpBootstrapBridge {
   url: string
@@ -158,7 +157,7 @@ export async function phpCodeFromArgs(args: string[], command = "wordpress.run-p
 
   const codeFile = argValue(args, "code-file")
   if (codeFile) {
-    return normalizePhpCode(await readFile(resolve(codeFile), "utf8"))
+    return normalizePhpCode(await readFile(resolveCommandPath(codeFile), "utf8"))
   }
 
   throw new Error(`${command} requires code=<php> or code-file=<path>`)

--- a/scripts/command-codecs-smoke.ts
+++ b/scripts/command-codecs-smoke.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
-import { booleanCommandArg, commandArg, commandArgValue, commandJsonArg, commandStringListArg, nonNegativeIntegerCommandArg, parseCommandJsonArray, parseCommandJsonObject, parseCommandOptions, parseCommandStringList, positiveIntegerCommandArg, strictBooleanCommandArg } from "@automattic/wp-codebox-core"
+import { join } from "node:path"
+import { booleanCommandArg, commandArg, commandArgValue, commandJsonArg, commandStringListArg, nonNegativeIntegerCommandArg, parseCommandInput, parseCommandJsonArray, parseCommandJsonObject, parseCommandOptions, parseCommandStringList, positiveIntegerCommandArg, resolveCommandPath, strictBooleanCommandArg } from "@automattic/wp-codebox-core"
 
 assert.equal(commandArg("name", "value=with=equals"), "name=value=with=equals")
 assert.equal(commandArgValue(["name=value=with=equals"], "name"), "value=with=equals")
@@ -22,6 +23,11 @@ assert.deepEqual(parseCommandJsonArray('["x"]', "items-json"), ["x"])
 assert.throws(() => parseCommandJsonObject("[]", "payload-json"), /payload-json must be a JSON object/)
 assert.throws(() => parseCommandJsonArray("{}", "items-json"), /items-json must be a JSON array/)
 assert.throws(() => parseCommandJsonObject("{", "payload-json"), /payload-json must be valid JSON/)
+assert.deepEqual(parseCommandInput(["first=one", "second=two=three"]), { first: "one", second: "two=three" })
+assert.deepEqual(parseCommandInput(["input-json={\"ok\":true}"]), { ok: true })
+assert.throws(() => parseCommandInput(["input-json={"]), /input-json must be valid JSON/)
+assert.equal(resolveCommandPath("child/file.txt", "/tmp/base"), join("/tmp/base", "child/file.txt"))
+assert.throws(() => resolveCommandPath("  "), /Command path must be non-empty/)
 
 const parsed = parseCommandOptions(["--recipe=recipe=a.json", "--json", "--artifacts", "out", "positional"], new Set(["--json"]))
 assert.equal(parsed.options.get("--recipe"), "recipe=a.json")

--- a/scripts/command-registry-smoke.ts
+++ b/scripts/command-registry-smoke.ts
@@ -1,5 +1,6 @@
 import { commandRegistry, runtimeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { playgroundRuntimeCommandIds } from "@automattic/wp-codebox-playground"
+import { executePlaygroundCommand } from "../packages/runtime-playground/src/command-router.js"
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -11,7 +12,7 @@ function sorted(values: Iterable<string>): string[] {
   return [...values].sort((left, right) => left.localeCompare(right))
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const registryIds = commandRegistry.map((command) => command.id)
   assert(new Set(registryIds).size === registryIds.length, "Command registry ids must be unique")
 
@@ -43,7 +44,31 @@ function main(): void {
     assert(command.handler.method.length > 0, `${command.id} must name its Playground handler method`)
   }
 
+  for (const command of runtimeCommandDefinitions()) {
+    const calls: string[] = []
+    const runtime = new Proxy({}, {
+      get(_target, property) {
+        if (typeof property !== "string") {
+          return undefined
+        }
+        return async () => {
+          calls.push(property)
+          return ""
+        }
+      },
+      has(_target, property) {
+        return typeof property === "string"
+      },
+    })
+
+    await executePlaygroundCommand(runtime as Parameters<typeof executePlaygroundCommand>[0], { command: command.id, args: [] })
+    assert(calls[0] === command.handler.method, `${command.id} must dispatch through registry handler method ${command.handler.method}`)
+  }
+
   assert(commandRegistry.some((command) => command.outputSchema?.jsonSchema), "Command registry should expose structured output schemas where available")
 }
 
-main()
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary
- Route Playground command dispatch through `CommandDefinition.handler` metadata instead of a hand-maintained command-id map.
- Move generic host command input parsing and command path resolution helpers into runtime-core codecs.
- Add smoke coverage that verifies registry/router method dispatch consistency and the new generic input/path helpers.

## Testing
- `npm run smoke -- --group=core`
- `npm run check` (rerun with a longer tool timeout after the first full-check attempt was terminated at 120s during `replay-export-snapshot-scoping-smoke`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Implemented the targeted command dispatch cleanup, generic parsing/path helper extraction, and smoke coverage; Chris remains responsible for review and validation.