### PR TITLE
Clarify generic runtime contract authority

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,9 @@ unless this index says otherwise.
   documents the stable orchestrator-facing agent-task CLI, schema boundary,
   artifacts, runner workspace publication, lifecycle metadata, provider
   overlays, and default sandbox bootstrap expectations.
+- [Generic runtime primitives](./generic-runtime-primitives.md) documents the
+  caller-neutral artifact storage, trusted browser origin, materialization, and
+  target-context envelopes shared by runtime integrations.
 - [Portable WP Codebox](./portable-wp-codebox.md) documents portable runtime
   packaging and invocation.
 - [Benchmark contract](./benchmark-contract.md) documents benchmark evidence
@@ -43,4 +46,10 @@ unless this index says otherwise.
 - Command catalog: `npm run wp-codebox -- commands --json`.
 - Runtime TypeScript contracts:
   `packages/runtime-core/src/runtime-contracts.ts`.
+- Generic primitive TypeScript contracts:
+  `packages/runtime-core/src/artifact-storage.ts`,
+  `packages/runtime-core/src/browser-session-origin.ts`, and
+  `packages/runtime-core/src/materialization-contracts.ts`.
 - JSON Schema factory: `packages/runtime-core/src/recipe-schema.ts`.
+- Default check coverage: `npm run check` includes
+  `npm run test:generic-primitives` through the smoke manifest `core` group.

--- a/docs/generic-runtime-primitives.md
+++ b/docs/generic-runtime-primitives.md
@@ -3,6 +3,14 @@
 WP Codebox exposes generic contracts for parent control planes without naming a
 product or job system.
 
+## Contract Authority
+
+- TypeScript implementations live in `packages/runtime-core/src/artifact-storage.ts`,
+  `packages/runtime-core/src/browser-session-origin.ts`, and
+  `packages/runtime-core/src/materialization-contracts.ts`.
+- Coverage lives in `tests/generic-primitives.test.ts`.
+- `npm run check` runs that coverage through the smoke manifest `core` group.
+
 ## Artifact Storage
 
 `wp-codebox/runtime-artifact-storage/v1` describes where runtime artifacts can be

--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -13,15 +13,13 @@ smoke testing.
 ## Site seed planning boundary
 
 Recipe authors can use `inputs.siteSeeds` to describe fixture or parent-site
-content shapes for dry-run review, but the current cookbook recipes still seed
-runtime content through explicit fixture scripts. WP Codebox does not snapshot a
-parent site, read private production rows, copy uploads, or import site seed
-records from `inputs.siteSeeds` in this slice.
+content shapes for dry-run review. The current cookbook recipes seed runtime
+content through explicit fixture scripts so every example is portable and
+reviewable from the recipe directory.
 
-Treat parent-site seed declarations as a reviewable manifest only: opt in to
-bounded scopes, name exact option keys, keep user data anonymized, and keep
-secrets, credentials, private post bodies, raw option values, and upload files
-out of recipe files and dry-run evidence.
+Treat parent-site seed declarations as a reviewable manifest: opt in to bounded
+scopes, name exact option keys, use anonymized fixture data, and keep recipe
+files plus dry-run evidence limited to shareable metadata.
 
 ## Available recipes
 
@@ -33,32 +31,38 @@ proving that WP Codebox can mount the agent runtime stack, overlay a
 `php-ai-client` branch with provider-supplied request auth, activate a Codex
 provider plugin branch, and execute `agents/chat` through `wp-codebox.agent-sandbox-run`.
 
-**Replace** these recipe paths before running. They must be materialized local
-filesystem paths on the host running WP Codebox, not remote refs, repo handles,
-or orchestration-layer aliases:
+**Prepare** the component and provider stack before running. The sample recipe
+uses explicit placeholder input paths so callers can see the full contract shape
+and replace each path with their prepared local checkout or artifact:
 
-- `/path/to/agents-api`
-- `/path/to/data-machine`
-- `/path/to/data-machine-code`
-- `/absolute/path/to/php-ai-client-with-bearer-token-auth-and-vendor`
-- `/absolute/path/to/ai-provider-for-openai-that-registers-codex`
+- `/sample/prepared-component-stack/agents-api`
+- `/sample/prepared-component-stack/data-machine`
+- `/sample/prepared-component-stack/data-machine-code`
+- `/sample/prepared-provider-stack/php-ai-client`
+- `/sample/prepared-provider-stack/ai-provider-for-openai`
 
 #### Codex runtime contract
 
-The Codex smoke requires a matched provider stack. WP Codebox stays generic and
-local-path based; it mounts what the caller provides and does not resolve
-orchestrator references, repository handles, or remote checkout aliases.
+The Codex smoke accepts a prepared provider/component stack. WP Codebox mounts
+the local paths supplied by the caller, validates the recipe contract, and emits
+a dry-run plan with the sandbox backend, overlays, extra plugins, secret
+environment names, and resolved agent command arguments.
 
-- The provider plugin checkout must register the `codex` provider id with
-  `wp-ai-client`. If it does not, the sandbox fails with `Provider codex is not
-  registered in wp-ai-client`.
-- The `php-ai-client` overlay must include bearer-token request authentication
-  support. Older checkouts fail when Codex asks for bearer-token auth.
-- The `php-ai-client` checkout must have Composer dependencies installed before
-  WP Codebox runs. Confirm `vendor/composer/installed.json` exists, for example
-  by running `composer install` in that checkout.
-- Orchestrators should persist or materialize their selected checkouts first,
-  then write those absolute local paths into the recipe passed to WP Codebox.
+- The component stack provides the WordPress plugins needed by the sandbox agent
+  runtime: `agents-api`, `data-machine`, and `data-machine-code`.
+- The provider stack provides the `php-ai-client` overlay and provider plugin
+  selected by `provider=codex` and
+  `provider-plugin-slugs=ai-provider-for-openai`.
+- The provider plugin is mounted with `activate: false` so the sandbox agent task
+  owns provider activation during runtime bootstrap.
+- `provider-plugin-contracts-json` declares the mounted provider plugin entrypoint,
+  and `sandbox-tool-policy-json` supplies a concrete default-deny tool policy for
+  the agent runtime.
+- The recipe references secret environment variable names only. Token values stay
+  in the caller environment and out of recipe files and artifacts.
+- Run `npm run wp-codebox -- recipe validate --recipe <recipe> --json` or
+  `npm run wp-codebox -- recipe-run --recipe <recipe> --dry-run --json` to inspect
+  the contract before starting WordPress.
 
 Export Codex OAuth credentials in the shell that runs WP Codebox. Keep token
 values out of recipe files and artifacts:
@@ -84,17 +88,11 @@ wp-codebox recipe-run \
   --json
 ```
 
-The stable installed path is the GitHub Release workspace tarball from a release
-that includes the root `bin` mapping, not the unpublished npm package:
+Install release builds from the GitHub Release workspace tarball:
 
 ```bash
 npm install -g https://github.com/Automattic/wp-codebox/releases/download/v<VERSION>/wp-codebox-workspace-<VERSION>.tgz
 ```
-
-`v0.4.0` includes the fresh sandbox session fix used by the Codex smoke path, but
-its release asset predates the root `bin` mapping. Release managers should cut a
-new release, attach a new root workspace tarball, and publish the scoped npm
-packages from the same commit once npm publishing is approved.
 
 The expected successful response is a JSON recipe run whose agent runtime
 reports the Playground site title and active theme. Fleet runners should

--- a/examples/recipes/cookbook/claude-code-agent-smoke.json
+++ b/examples/recipes/cookbook/claude-code-agent-smoke.json
@@ -2,7 +2,7 @@
   "schema": "wp-codebox/workspace-recipe/v1",
   "runtime": {
     "backend": "wordpress-playground",
-    "name": "provider-agent-smoke",
+    "name": "claude-code-agent-smoke",
     "wp": "trunk",
     "blueprint": {
       "steps": []
@@ -11,7 +11,7 @@
       {
         "kind": "bundled-library",
         "library": "php-ai-client",
-        "source": "/path/to/php-ai-client-claude-code-compatible-branch",
+        "source": "/sample/prepared-provider-stack/php-ai-client",
         "target": "/wordpress/wp-includes/php-ai-client",
         "strategy": "wordpress-scoped-bundle",
         "metadata": {
@@ -24,22 +24,22 @@
   "inputs": {
     "extra_plugins": [
       {
-        "source": "/path/to/agents-api",
+        "source": "/sample/prepared-component-stack/agents-api",
         "slug": "agents-api",
         "activate": true
       },
       {
-        "source": "/path/to/data-machine",
+        "source": "/sample/prepared-component-stack/data-machine",
         "slug": "data-machine",
         "activate": true
       },
       {
-        "source": "/path/to/data-machine-code",
+        "source": "/sample/prepared-component-stack/data-machine-code",
         "slug": "data-machine-code",
         "activate": true
       },
       {
-        "source": "/path/to/wp-coding-agents/carried-plugins/ai-provider-for-claude-code",
+        "source": "/sample/prepared-provider-stack/ai-provider-for-claude-code",
         "slug": "ai-provider-for-claude-code",
         "activate": false
       }
@@ -55,12 +55,14 @@
       {
         "command": "wp-codebox.agent-sandbox-run",
         "args": [
-          "task=Run a minimal headless WP Codebox smoke. Inspect the WordPress runtime, report the site title and active theme, and do not modify files.",
+          "task=Run a minimal headless WP Codebox smoke. Inspect the WordPress runtime with read-only checks and report the site title plus active theme.",
           "agent=wp-codebox-sandbox",
           "mode=default",
           "provider=claude-code",
           "model=claude-code",
           "provider-plugin-slugs=ai-provider-for-claude-code",
+          "provider-plugin-contracts-json=[{\"slug\":\"ai-provider-for-claude-code\",\"pluginFile\":\"ai-provider-for-claude-code/ai-provider-for-claude-code.php\",\"loadAs\":\"plugin\"}]",
+          "sandbox-tool-policy-json={\"schema\":\"wp-codebox/sandbox-tool-policy/v1\",\"version\":1,\"tools\":[{\"id\":\"deny-all\",\"runtime_tool_id\":\"deny-all\",\"execution_location\":\"parent\",\"transport_visibility\":\"hidden\",\"allowed\":false,\"runtime\":{\"environment\":\"control_plane\",\"capability_scope\":\"control_plane\"}}],\"metadata\":{\"source\":\"cookbook.sample-default-deny\"}}",
           "max-turns=1",
           "timeout-seconds=300"
         ]

--- a/examples/recipes/cookbook/codex-agent-smoke.json
+++ b/examples/recipes/cookbook/codex-agent-smoke.json
@@ -11,12 +11,12 @@
       {
         "kind": "bundled-library",
         "library": "php-ai-client",
-        "source": "/absolute/path/to/php-ai-client-with-bearer-token-auth-and-vendor",
+        "source": "/sample/prepared-provider-stack/php-ai-client",
         "target": "/wordpress/wp-includes/php-ai-client",
         "strategy": "wordpress-scoped-bundle",
         "metadata": {
           "component": "php-ai-client",
-          "purpose": "provider-supplied bearer-token request authentication with Composer vendor installed"
+          "purpose": "provider-supplied request authentication and installed Composer dependencies"
         }
       }
     ]
@@ -24,22 +24,22 @@
   "inputs": {
     "extra_plugins": [
       {
-        "source": "/path/to/agents-api",
+        "source": "/sample/prepared-component-stack/agents-api",
         "slug": "agents-api",
         "activate": true
       },
       {
-        "source": "/path/to/data-machine",
+        "source": "/sample/prepared-component-stack/data-machine",
         "slug": "data-machine",
         "activate": true
       },
       {
-        "source": "/path/to/data-machine-code",
+        "source": "/sample/prepared-component-stack/data-machine-code",
         "slug": "data-machine-code",
         "activate": true
       },
       {
-        "source": "/absolute/path/to/ai-provider-for-openai-that-registers-codex",
+        "source": "/sample/prepared-provider-stack/ai-provider-for-openai",
         "slug": "ai-provider-for-openai",
         "activate": false
       }
@@ -57,12 +57,14 @@
       {
         "command": "wp-codebox.agent-sandbox-run",
         "args": [
-          "task=Run a minimal headless WP Codebox smoke. Inspect the WordPress runtime, report the site title and active theme, and do not modify files.",
+          "task=Run a minimal headless WP Codebox smoke. Inspect the WordPress runtime with read-only checks and report the site title plus active theme.",
           "agent=wp-codebox-sandbox",
           "mode=default",
           "provider=codex",
           "model=gpt-5.5",
           "provider-plugin-slugs=ai-provider-for-openai",
+          "provider-plugin-contracts-json=[{\"slug\":\"ai-provider-for-openai\",\"pluginFile\":\"ai-provider-for-openai/ai-provider-for-openai.php\",\"loadAs\":\"plugin\"}]",
+          "sandbox-tool-policy-json={\"schema\":\"wp-codebox/sandbox-tool-policy/v1\",\"version\":1,\"tools\":[{\"id\":\"deny-all\",\"runtime_tool_id\":\"deny-all\",\"execution_location\":\"parent\",\"transport_visibility\":\"hidden\",\"allowed\":false,\"runtime\":{\"environment\":\"control_plane\",\"capability_scope\":\"control_plane\"}}],\"metadata\":{\"source\":\"cookbook.sample-default-deny\"}}",
           "max-turns=1",
           "timeout-seconds=300"
         ]

--- a/scripts/claude-code-agent-recipe-smoke.ts
+++ b/scripts/claude-code-agent-recipe-smoke.ts
@@ -1,14 +1,18 @@
 import assert from "node:assert/strict"
-import { readFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdir, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { recipeExecutionSpec } from "../packages/cli/src/agent-sandbox.js"
+import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
 
 const claudeRecipe = JSON.parse(readFileSync("examples/recipes/cookbook/claude-code-agent-smoke.json", "utf8"))
 const codexRecipe = JSON.parse(readFileSync("examples/recipes/cookbook/codex-agent-smoke.json", "utf8"))
-const claudeJson = JSON.stringify(claudeRecipe)
 
 assert.equal(claudeRecipe.schema, "wp-codebox/workspace-recipe/v1")
 assert.equal(claudeRecipe.runtime?.backend, "wordpress-playground", "Claude Code example should keep Codebox as the WordPress Playground sandbox substrate")
-assert.notEqual(claudeRecipe.runtime?.backend, "claude-code", "Claude Code must not become a Codebox runtime backend")
-assert.notEqual(claudeRecipe.runtime?.name, "claude-code", "Claude Code must not be modeled as a named Codebox runtime")
+assert.equal(claudeRecipe.runtime?.name, "claude-code-agent-smoke")
 
 const claudeOverlay = claudeRecipe.runtime?.overlays?.find((overlay: Record<string, unknown>) => overlay.library === "php-ai-client")
 const codexOverlay = codexRecipe.runtime?.overlays?.find((overlay: Record<string, unknown>) => overlay.library === "php-ai-client")
@@ -20,7 +24,7 @@ assert.equal(claudeOverlay.strategy, codexOverlay?.strategy, "Claude Code exampl
 const claudeProvider = claudeRecipe.inputs?.extra_plugins?.find((plugin: Record<string, unknown>) => plugin.slug === "ai-provider-for-claude-code")
 assert.ok(claudeProvider, "Claude Code example should use the carried ai-provider-for-claude-code plugin")
 assert.equal(claudeProvider.activate, false, "Claude Code provider plugin activation should follow the Codex example pattern")
-assert.match(String(claudeProvider.source), /wp-coding-agents\/carried-plugins\/ai-provider-for-claude-code/)
+assert.equal(claudeProvider.source, "/sample/prepared-provider-stack/ai-provider-for-claude-code")
 
 const args = claudeRecipe.workflow?.steps?.[0]?.args ?? []
 assert.ok(args.includes("provider=claude-code"), "Claude Code example should select the provider through the sandbox agent task")
@@ -33,10 +37,45 @@ assert.deepEqual(claudeRecipe.inputs?.secretEnv, [
   "AI_PROVIDER_CLAUDE_CODE_EXPIRES_AT",
 ], "Claude Code example should reference env names only, not auth/session values")
 
-assert.ok(!claudeJson.includes("claude_code/run"), "Claude Code example should not use a Codebox host/runtime command")
-assert.ok(!claudeJson.includes("hostTools"), "Claude Code example should not add host tools")
-assert.ok(!claudeJson.includes("Homeboy"), "Claude Code example should not make Homeboy part of the recipe contract")
-assert.ok(!claudeJson.includes("refresh-token-"), "Claude Code example should not contain sample session material")
-assert.ok(!claudeJson.includes("access-token-"), "Claude Code example should not contain sample auth material")
+const root = mkdtempSync(join(tmpdir(), "wp-codebox-claude-recipe-"))
+try {
+  const materializedRecipePath = join(root, "recipe.json")
+  const materializedRecipe = await materializeSampleProviderStack(claudeRecipe, root)
+  writeFileSync(materializedRecipePath, JSON.stringify(materializedRecipe, null, 2))
+
+  const dryRun = await dryRunRecipe({ recipePath: materializedRecipePath }, { defaultWordPressVersion: "trunk", resolveExecutionSpec: recipeExecutionSpec })
+  assert.equal(dryRun.schema, "wp-codebox/recipe-run-dry-run/v1")
+  assert.equal(dryRun.success, true, JSON.stringify(dryRun.validation?.issues ?? dryRun.error, null, 2))
+  assert.equal(dryRun.valid, true, JSON.stringify(dryRun.validation?.issues ?? dryRun.error, null, 2))
+  assert.equal(dryRun.plan?.runtime.backend, "wordpress-playground")
+  assert.equal(dryRun.plan?.extra_plugins.length, 4)
+  assert.equal(dryRun.plan?.secretEnv.map((entry) => entry.name).includes("AI_PROVIDER_CLAUDE_CODE_REFRESH_TOKEN"), true)
+  const agentStep = dryRun.plan?.workflow.steps.find((step) => step.parsedArgs.provider === "claude-code")
+  assert.ok(agentStep, "dry-run plan should include the Claude Code agent step")
+  assert.equal(agentStep.resolvedCommand, "wordpress.run-php")
+  assert.equal(agentStep.parsedArgs["provider-plugin-slugs"], "ai-provider-for-claude-code")
+  assert.equal(agentStep.policy.status, "allowed")
+  assert.equal(agentStep.policy.command, "wordpress.run-php")
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
 
 console.log("Claude Code agent recipe smoke passed")
+
+async function materializeSampleProviderStack(sourceRecipe: Record<string, any>, root: string): Promise<Record<string, any>> {
+  const recipe = structuredClone(sourceRecipe)
+  const plugins = recipe.inputs.extra_plugins as Array<Record<string, any>>
+  for (const plugin of plugins) {
+    const source = join(root, plugin.slug)
+    await mkdir(source, { recursive: true })
+    await writeFile(join(source, `${plugin.slug}.php`), `<?php\n/* Plugin Name: ${plugin.slug} */\n`)
+    plugin.source = source
+    plugin.pluginFile = `${plugin.slug}/${plugin.slug}.php`
+  }
+
+  const overlaySource = join(root, "php-ai-client")
+  await mkdir(join(overlaySource, "vendor", "composer"), { recursive: true })
+  await writeFile(join(overlaySource, "vendor", "composer", "installed.json"), "[]\n")
+  recipe.runtime.overlays[0].source = overlaySource
+  return recipe
+}

--- a/scripts/codex-agent-recipe-smoke.ts
+++ b/scripts/codex-agent-recipe-smoke.ts
@@ -1,32 +1,67 @@
 import assert from "node:assert/strict"
-import { readFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdir, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
+import { recipeExecutionSpec } from "../packages/cli/src/agent-sandbox.js"
 
 const recipe = JSON.parse(readFileSync("examples/recipes/cookbook/codex-agent-smoke.json", "utf8"))
-const readme = readFileSync("examples/recipes/cookbook/README.md", "utf8")
 
 const overlay = recipe.runtime?.overlays?.find((entry: Record<string, unknown>) => entry.library === "php-ai-client")
 assert.ok(overlay, "Codex example should include a php-ai-client overlay")
-assert.match(String(overlay.source), /absolute\/path\/to\/php-ai-client-with-bearer-token-auth-and-vendor/)
-assert.match(String(overlay.metadata?.purpose), /bearer-token/)
-assert.match(String(overlay.metadata?.purpose), /Composer vendor/)
+assert.equal(overlay.kind, "bundled-library")
+assert.equal(overlay.target, "/wordpress/wp-includes/php-ai-client")
+assert.equal(overlay.strategy, "wordpress-scoped-bundle")
 
 const providerPlugin = recipe.inputs?.extra_plugins?.find((entry: Record<string, unknown>) => entry.slug === "ai-provider-for-openai")
 assert.ok(providerPlugin, "Codex example should include the OpenAI provider plugin")
 assert.equal(providerPlugin.activate, false, "Codex provider plugin activation should be handled by the sandbox agent task")
-assert.match(String(providerPlugin.source), /registers-codex/)
 
 const args = recipe.workflow?.steps?.[0]?.args ?? []
 assert.ok(args.includes("provider=codex"), "Codex recipe should select the codex provider id")
 assert.ok(args.includes("provider-plugin-slugs=ai-provider-for-openai"), "Codex recipe should pass the provider plugin slug")
 
-for (const requiredPattern of [
-  /materialized local\s+filesystem paths/,
-  /must register the `codex` provider id/,
-  /bearer-token request authentication/,
-  /vendor\/composer\/installed\.json/,
-  /WP Codebox stays generic and\s+local-path based/,
-]) {
-  assert.match(readme, requiredPattern, `Codex README should document: ${requiredPattern}`)
+const root = mkdtempSync(join(tmpdir(), "wp-codebox-codex-recipe-"))
+try {
+  const materializedRecipePath = join(root, "recipe.json")
+  const materializedRecipe = await materializeSampleProviderStack(recipe, root)
+  writeFileSync(materializedRecipePath, JSON.stringify(materializedRecipe, null, 2))
+
+  const dryRun = await dryRunRecipe({ recipePath: materializedRecipePath }, { defaultWordPressVersion: "trunk", resolveExecutionSpec: recipeExecutionSpec })
+  assert.equal(dryRun.schema, "wp-codebox/recipe-run-dry-run/v1")
+  assert.equal(dryRun.success, true, JSON.stringify(dryRun.validation?.issues ?? dryRun.error, null, 2))
+  assert.equal(dryRun.valid, true, JSON.stringify(dryRun.validation?.issues ?? dryRun.error, null, 2))
+  assert.equal(dryRun.plan?.runtime.backend, "wordpress-playground")
+  assert.equal(dryRun.plan?.extra_plugins.length, 4)
+  assert.equal(dryRun.plan?.secretEnv.map((entry) => entry.name).includes("AI_PROVIDER_OPENAI_CODEX_ACCESS_TOKEN"), true)
+  const agentStep = dryRun.plan?.workflow.steps.find((step) => step.parsedArgs.provider === "codex")
+  assert.ok(agentStep, "dry-run plan should include the Codex agent step")
+  assert.equal(agentStep.resolvedCommand, "wordpress.run-php")
+  assert.equal(agentStep.parsedArgs["provider-plugin-slugs"], "ai-provider-for-openai")
+  assert.equal(agentStep.policy.status, "allowed")
+  assert.equal(agentStep.policy.command, "wordpress.run-php")
+} finally {
+  rmSync(root, { recursive: true, force: true })
 }
 
 console.log("Codex agent recipe smoke passed")
+
+async function materializeSampleProviderStack(sourceRecipe: Record<string, any>, root: string): Promise<Record<string, any>> {
+  const recipe = structuredClone(sourceRecipe)
+  const plugins = recipe.inputs.extra_plugins as Array<Record<string, any>>
+  for (const plugin of plugins) {
+    const source = join(root, plugin.slug)
+    await mkdir(source, { recursive: true })
+    await writeFile(join(source, `${plugin.slug}.php`), `<?php\n/* Plugin Name: ${plugin.slug} */\n`)
+    plugin.source = source
+    plugin.pluginFile = `${plugin.slug}/${plugin.slug}.php`
+  }
+
+  const overlaySource = join(root, "php-ai-client")
+  await mkdir(join(overlaySource, "vendor", "composer"), { recursive: true })
+  await writeFile(join(overlaySource, "vendor", "composer", "installed.json"), "[]\n")
+  recipe.runtime.overlays[0].source = overlaySource
+  return recipe
+}

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -30,6 +30,7 @@ export const smokeGroups = {
     description: "Build and core command contract smoke checks.",
     commands: [
       npmScript("build"),
+      npmScript("test:generic-primitives"),
       tsxSmoke("runtime-backend-registry-smoke"),
       tsxSmoke("backend-package-adapter-registry-smoke"),
       tsxSmoke("command-registry-smoke"),


### PR DESCRIPTION
## Summary
- add generic runtime primitives to the docs index and document their TypeScript/test authority
- include `test:generic-primitives` in the default `check` smoke aggregate
- rewrite agent cookbook recipes around prepared sample provider/component stacks and dry-run validation
- replace brittle recipe smoke prose/string assertions with schema, dry-run envelope, overlay, secret env, and resolved command assertions

## Tests
- `npm run test:generic-primitives`
- `npx tsx scripts/codex-agent-recipe-smoke.ts`
- `npx tsx scripts/claude-code-agent-recipe-smoke.ts`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Drafted the docs/test cleanup and verification commands; Chris remains responsible for review and merge.
