### PR TITLE
Add core artifact capture policy

### DIFF
--- a/packages/runtime-core/src/artifact-capture-policy.ts
+++ b/packages/runtime-core/src/artifact-capture-policy.ts
@@ -1,0 +1,50 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join, relative } from "node:path"
+
+import { artifactFileDigest, artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions } from "./artifact-manifest.js"
+
+export interface ArtifactPartInput {
+  root: string
+  path: string
+  kind: ArtifactManifestFile["kind"]
+  contentType: string
+  contents: string | Buffer
+  redaction?: ArtifactManifestFileOptions["redaction"]
+  provenance?: ArtifactManifestFileOptions["provenance"]
+}
+
+export interface ArtifactPart {
+  path: string
+  absolutePath: string
+  bytes: number
+  manifestFile: ArtifactManifestFile
+}
+
+export async function writeArtifactPart(input: ArtifactPartInput): Promise<ArtifactPart> {
+  const relativePath = normalizeArtifactPartPath(input.path)
+  const contents = typeof input.contents === "string" ? input.contents : Buffer.from(input.contents)
+  const absolutePath = join(input.root, relativePath)
+
+  await mkdir(dirname(absolutePath), { recursive: true })
+  await writeFile(absolutePath, contents)
+
+  const manifestFile = artifactManifestFile(absolutePath, input.kind, input.contentType, artifactFileDigest(contents), {
+    redaction: input.redaction,
+    provenance: input.provenance,
+  })
+
+  return {
+    path: relative(input.root, absolutePath).replace(/\\/g, "/"),
+    absolutePath,
+    bytes: Buffer.byteLength(contents),
+    manifestFile,
+  }
+}
+
+export function normalizeArtifactPartPath(path: string): string {
+  const segments = path.replace(/\\/g, "/").split("/").filter(Boolean)
+  if (segments.length === 0 || segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("Artifact part path must be a relative path without current-directory or parent-directory segments")
+  }
+  return segments.join("/")
+}

--- a/packages/runtime-core/src/artifact-manifest.ts
+++ b/packages/runtime-core/src/artifact-manifest.ts
@@ -31,7 +31,22 @@ export interface ArtifactManifestFile {
     | (string & {})
   contentType: string
   sha256: ArtifactFileDigest
+  redaction?: ArtifactRedactionMetadata
+  provenance?: ArtifactProvenanceMetadata
   viewer?: ArtifactViewerMetadata
+}
+
+export interface ArtifactRedactionMetadata {
+  policy: "none" | "required" | "applied" | (string & {})
+  reason?: string
+  sensitive?: boolean
+}
+
+export interface ArtifactProvenanceMetadata {
+  source: string
+  operation?: string
+  id?: string
+  metadata?: Record<string, unknown>
 }
 
 export interface ArtifactViewerMetadata {
@@ -79,8 +94,15 @@ export function artifactFileDigest(contents: string | Buffer): ArtifactFileDiges
   return { algorithm: "sha256", value: createHash("sha256").update(contents).digest("hex") }
 }
 
-export function artifactManifestFile(path: string, kind: ArtifactManifestFile["kind"], contentType: string, sha256: ArtifactFileDigest = placeholderArtifactFileDigest(), viewer?: ArtifactViewerMetadata): ArtifactManifestFile {
-  return stripUndefined({ path, kind, contentType, sha256, viewer })
+export interface ArtifactManifestFileOptions {
+  viewer?: ArtifactViewerMetadata
+  redaction?: ArtifactRedactionMetadata
+  provenance?: ArtifactProvenanceMetadata
+}
+
+export function artifactManifestFile(path: string, kind: ArtifactManifestFile["kind"], contentType: string, sha256: ArtifactFileDigest = placeholderArtifactFileDigest(), viewerOrOptions?: ArtifactViewerMetadata | ArtifactManifestFileOptions): ArtifactManifestFile {
+  const options = artifactManifestFileOptions(viewerOrOptions)
+  return stripUndefined({ path, kind, contentType, sha256, ...options })
 }
 
 export function artifactManifestFileWithSha256(path: string, kind: ArtifactManifestFile["kind"], contentType: string, sha256: string): ArtifactManifestFile {
@@ -155,4 +177,14 @@ function manifestWithPlaceholderSelfHash(manifest: ArtifactManifest, manifestFil
 
 function stripUndefined<T extends object>(value: T): T {
   return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T
+}
+
+function artifactManifestFileOptions(viewerOrOptions: ArtifactViewerMetadata | ArtifactManifestFileOptions | undefined): ArtifactManifestFileOptions {
+  if (!viewerOrOptions) {
+    return {}
+  }
+  if ("base" in viewerOrOptions && "query" in viewerOrOptions && "replay" in viewerOrOptions) {
+    return { viewer: viewerOrOptions }
+  }
+  return viewerOrOptions
 }

--- a/packages/runtime-core/src/artifacts.ts
+++ b/packages/runtime-core/src/artifacts.ts
@@ -1,4 +1,5 @@
 export * from "./artifact-manifest.js"
+export * from "./artifact-capture-policy.js"
 export * from "./artifact-layout.js"
 export * from "./artifact-references.js"
 export * from "./artifact-review.js"

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./artifact-manifest.js"
+export * from "./artifact-capture-policy.js"
 export * from "./artifact-layout.js"
 export * from "./artifact-references.js"
 export * from "./file-tree-policy.js"

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -1,7 +1,7 @@
 import { assertRuntimePolicy } from "./runtime-policy.js"
 import type { RuntimePolicy } from "./runtime-policy.js"
 import { SANDBOX_WORKSPACE_ROOT } from "./runtime-action-adapter.js"
-import type { ArtifactFileDigest, ArtifactSpec, ArtifactViewerMetadata } from "./artifact-manifest.js"
+import type { ArtifactFileDigest, ArtifactManifestFile, ArtifactSpec, ArtifactViewerMetadata } from "./artifact-manifest.js"
 import type { HostToolDefinition, HostToolRegistry } from "./host-tool-registry.js"
 import type {
   RUNTIME_EPISODE_ACTION_SCHEMA,
@@ -599,6 +599,7 @@ export interface ObservationResult {
   data: unknown
   observedAt: string
   artifactRefs?: RuntimeEpisodeTraceRef[]
+  artifactManifestFiles?: ArtifactManifestFile[]
   digest?: RuntimeEpisodeContentDigest
 }
 

--- a/packages/runtime-playground/src/check-artifacts.ts
+++ b/packages/runtime-playground/src/check-artifacts.ts
@@ -1,6 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises"
-import { join, relative } from "node:path"
-import { artifactManifestFile, type ArtifactManifestFile } from "@automattic/wp-codebox-core"
+import { join } from "node:path"
+import { writeArtifactPart, type ArtifactManifestFile } from "@automattic/wp-codebox-core"
 import { redactArtifactFiles } from "./artifact-bundle-writer.js"
 import type { ArtifactRedactor } from "./artifacts.js"
 import type { normalizePluginCheckOutput, normalizeThemeCheckOutput } from "./commands.js"
@@ -11,6 +10,7 @@ export interface PluginCheckArtifact {
     raw: string
     normalized: string
   }
+  manifestFiles: ArtifactManifestFile[]
   summary: ReturnType<typeof normalizePluginCheckOutput>["summary"]
 }
 
@@ -20,6 +20,7 @@ export interface ThemeCheckArtifact {
     raw: string
     normalized: string
   }
+  manifestFiles: ArtifactManifestFile[]
   summary: ReturnType<typeof normalizeThemeCheckOutput>["summary"]
   status: ReturnType<typeof normalizeThemeCheckOutput>["status"]
   exitCode: number
@@ -31,20 +32,33 @@ export async function writePluginCheckArtifacts(
   rawOutput: string,
   normalized: ReturnType<typeof normalizePluginCheckOutput>,
 ): Promise<PluginCheckArtifact> {
-  const pluginCheckDirectory = join(artifactRoot, "files", "plugin-check")
-  await mkdir(pluginCheckDirectory, { recursive: true })
   const safeSlug = pluginSlug.replace(/[^a-z0-9_-]/gi, "-")
-  const rawPath = join(pluginCheckDirectory, `${safeSlug}.raw.json`)
-  const normalizedPath = join(pluginCheckDirectory, `${safeSlug}.json`)
-  await writeFile(rawPath, rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`)
-  await writeFile(normalizedPath, `${JSON.stringify(normalized, null, 2)}\n`)
+  const raw = await writeArtifactPart({
+    root: artifactRoot,
+    path: join("files", "plugin-check", `${safeSlug}.raw.json`),
+    kind: "plugin-check-raw",
+    contentType: "application/json",
+    contents: rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`,
+    redaction: { policy: "required", sensitive: true, reason: "Plugin check raw output may include local paths or captured diagnostics." },
+    provenance: { source: "runtime-playground", operation: "plugin-check", id: pluginSlug },
+  })
+  const normalizedArtifact = await writeArtifactPart({
+    root: artifactRoot,
+    path: join("files", "plugin-check", `${safeSlug}.json`),
+    kind: "plugin-check",
+    contentType: "application/json",
+    contents: `${JSON.stringify(normalized, null, 2)}\n`,
+    redaction: { policy: "required", sensitive: true, reason: "Plugin check normalized output may include local paths or captured diagnostics." },
+    provenance: { source: "runtime-playground", operation: "plugin-check", id: pluginSlug },
+  })
 
   return {
     targetPlugin: pluginSlug,
     files: {
-      raw: relative(artifactRoot, rawPath),
-      normalized: relative(artifactRoot, normalizedPath),
+      raw: raw.path,
+      normalized: normalizedArtifact.path,
     },
+    manifestFiles: [raw.manifestFile, normalizedArtifact.manifestFile],
     summary: normalized.summary,
   }
 }
@@ -56,44 +70,44 @@ export async function writeThemeCheckArtifacts(
   normalized: ReturnType<typeof normalizeThemeCheckOutput>,
 ): Promise<ThemeCheckArtifact> {
   const safeTheme = theme.replace(/[^a-z0-9_-]/gi, "-") || "theme"
-  const directory = join(artifactRoot, "files", "theme-check")
-  await mkdir(directory, { recursive: true })
-  const rawPath = join(directory, `${safeTheme}.raw.txt`)
-  const normalizedPath = join(directory, `${safeTheme}.normalized.json`)
-  await writeFile(rawPath, raw.endsWith("\n") ? raw : `${raw}\n`)
-  await writeFile(normalizedPath, `${JSON.stringify(normalized, null, 2)}\n`)
+  const rawArtifact = await writeArtifactPart({
+    root: artifactRoot,
+    path: join("files", "theme-check", `${safeTheme}.raw.txt`),
+    kind: "theme-check-raw",
+    contentType: "text/plain",
+    contents: raw.endsWith("\n") ? raw : `${raw}\n`,
+    redaction: { policy: "required", sensitive: true, reason: "Theme check raw output may include local paths or captured diagnostics." },
+    provenance: { source: "runtime-playground", operation: "theme-check", id: theme },
+  })
+  const normalizedArtifact = await writeArtifactPart({
+    root: artifactRoot,
+    path: join("files", "theme-check", `${safeTheme}.normalized.json`),
+    kind: "theme-check-normalized",
+    contentType: "application/json",
+    contents: `${JSON.stringify(normalized, null, 2)}\n`,
+    redaction: { policy: "required", sensitive: true, reason: "Theme check normalized output may include local paths or captured diagnostics." },
+    provenance: { source: "runtime-playground", operation: "theme-check", id: theme },
+  })
 
   return {
     theme,
     files: {
-      raw: relative(artifactRoot, rawPath),
-      normalized: relative(artifactRoot, normalizedPath),
+      raw: rawArtifact.path,
+      normalized: normalizedArtifact.path,
     },
+    manifestFiles: [rawArtifact.manifestFile, normalizedArtifact.manifestFile],
     summary: normalized.summary,
     status: normalized.status,
     exitCode: normalized.exitCode,
   }
 }
 
-export function pluginCheckManifestFiles(artifactRoot: string, pluginChecks: PluginCheckArtifact[]): ArtifactManifestFile[] {
-  return pluginChecks.flatMap((check) => [
-    artifactManifestFile(join(artifactRoot, check.files.raw), "plugin-check-raw", "application/json"),
-    artifactManifestFile(join(artifactRoot, check.files.normalized), "plugin-check", "application/json"),
-  ])
+export function pluginCheckManifestFiles(_artifactRoot: string, pluginChecks: PluginCheckArtifact[]): ArtifactManifestFile[] {
+  return pluginChecks.flatMap((check) => check.manifestFiles)
 }
 
-export function themeCheckManifestFiles(artifactRoot: string, themeChecks: ThemeCheckArtifact[]): ArtifactManifestFile[] {
-  if (themeChecks.length === 0) {
-    return []
-  }
-
-  const files = new Map<string, { kind: string; contentType: string }>()
-  for (const check of themeChecks) {
-    files.set(check.files.raw, { kind: "theme-check-raw", contentType: "text/plain" })
-    files.set(check.files.normalized, { kind: "theme-check-normalized", contentType: "application/json" })
-  }
-
-  return [...files.entries()].map(([path, entry]) => artifactManifestFile(join(artifactRoot, path), entry.kind, entry.contentType))
+export function themeCheckManifestFiles(_artifactRoot: string, themeChecks: ThemeCheckArtifact[]): ArtifactManifestFile[] {
+  return themeChecks.flatMap((check) => check.manifestFiles)
 }
 
 export async function redactPluginCheckArtifacts(artifactRoot: string, pluginChecks: PluginCheckArtifact[], redactor: ArtifactRedactor): Promise<void> {

--- a/packages/runtime-playground/src/observation-artifacts.ts
+++ b/packages/runtime-playground/src/observation-artifacts.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto"
-import { mkdir, writeFile } from "node:fs/promises"
-import { dirname, join } from "node:path"
-import type { ObservationSpec, RuntimeCreateSpec, RuntimeEpisodeTraceRef } from "@automattic/wp-codebox-core"
+import type { ArtifactManifestFile, ObservationSpec, RuntimeCreateSpec, RuntimeEpisodeTraceRef } from "@automattic/wp-codebox-core"
+import { writeArtifactPart } from "@automattic/wp-codebox-core"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { assertPlaygroundResponseOk } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
@@ -18,7 +17,7 @@ export async function observeWordPressState({
   server: PlaygroundCliServer
   spec: ObservationSpec
   runtimeSpec: RuntimeCreateSpec
-}): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {
+}): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[]; artifactManifestFiles: ArtifactManifestFile[] }> {
   const config = {
     sections: spec.sections,
     redaction: spec.redaction ?? "safe",
@@ -37,20 +36,28 @@ export async function observeWordPressState({
   }
   const sectionArtifacts: Record<string, { artifact: string; sha256: string; bytes: number }> = {}
   const artifactRefs: RuntimeEpisodeTraceRef[] = []
+  const manifestFiles: ArtifactManifestFile[] = []
   const sections = stateExport.sections ?? {}
 
   for (const [section, contents] of Object.entries(sections)) {
     const serialized = `${JSON.stringify({ schema: "wp-codebox/wordpress-state-section/v1", version: 1, section, data: contents }, null, 2)}\n`
-    const digest = createHash("sha256").update(serialized).digest("hex")
     const relativePath = `files/observations/${observationId}-wordpress-state-${safeArtifactSegment(section)}.json`
-    await mkdir(dirname(join(artifactRoot, relativePath)), { recursive: true })
-    await writeFile(join(artifactRoot, relativePath), serialized)
-    sectionArtifacts[section] = { artifact: relativePath, sha256: digest, bytes: Buffer.byteLength(serialized) }
+    const part = await writeArtifactPart({
+      root: artifactRoot,
+      path: relativePath,
+      kind: "wordpress-state-section",
+      contentType: "application/json",
+      contents: serialized,
+      redaction: { policy: "required", sensitive: true, reason: "WordPress state sections can include site content, users, options, or route data depending on observation config." },
+      provenance: { source: "runtime-playground", operation: "observe-wordpress-state", id: `${observationId}:${section}` },
+    })
+    sectionArtifacts[section] = { artifact: part.path, sha256: part.manifestFile.sha256.value, bytes: part.bytes }
+    manifestFiles.push(part.manifestFile)
     artifactRefs.push({
       kind: "wordpress-state-section",
       id: `${observationId}:${section}`,
-      path: relativePath,
-      digest: { algorithm: "sha256", value: digest },
+      path: part.path,
+      digest: part.manifestFile.sha256,
     })
   }
 
@@ -64,6 +71,7 @@ export async function observeWordPressState({
       artifacts: sectionArtifacts,
     },
     artifactRefs,
+    artifactManifestFiles: manifestFiles,
   }
 }
 
@@ -77,7 +85,7 @@ export async function observeHttpResponse({
   observationId: string
   spec: ObservationSpec
   url: string
-}): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {
+}): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[]; artifactManifestFiles: ArtifactManifestFile[] }> {
   const response = await fetch(url, {
     method: spec.method ?? "GET",
     headers: spec.headers,
@@ -86,6 +94,7 @@ export async function observeHttpResponse({
   const body = await response.text()
   const bodyDigest = createHash("sha256").update(body).digest("hex")
   const artifactRefs: RuntimeEpisodeTraceRef[] = []
+  const manifestFiles: ArtifactManifestFile[] = []
   const data: Record<string, unknown> = {
     url,
     method: spec.method ?? "GET",
@@ -100,17 +109,25 @@ export async function observeHttpResponse({
     data.body = body
   } else if (body.length > 0) {
     const relativePath = `files/observations/${observationId}-body.txt`
-    await mkdir(dirname(join(artifactRoot, relativePath)), { recursive: true })
-    await writeFile(join(artifactRoot, relativePath), body)
+    const part = await writeArtifactPart({
+      root: artifactRoot,
+      path: relativePath,
+      kind: "observation-artifact",
+      contentType: response.headers.get("content-type") ?? "text/plain",
+      contents: body,
+      redaction: { policy: "required", sensitive: true, reason: "Observed HTTP responses can include private content, headers, or credentials." },
+      provenance: { source: "runtime-playground", operation: "observe-http-response", id: observationId, metadata: { url, method: spec.method ?? "GET", status: response.status } },
+    })
+    manifestFiles.push(part.manifestFile)
     artifactRefs.push({
       kind: "observation-artifact",
       id: `${observationId}:body`,
-      path: relativePath,
-      digest: { algorithm: "sha256", value: bodyDigest },
+      path: part.path,
+      digest: part.manifestFile.sha256,
     })
   }
 
-  return { data, artifactRefs }
+  return { data, artifactRefs, artifactManifestFiles: manifestFiles }
 }
 
 function wordpressStateExportPhp(config: Record<string, unknown>): string {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -25,6 +25,7 @@ import { preflightPhpWasmRuntimeAssets } from "./php-wasm-preflight.js"
 import { previewReviewerAccess } from "./preview-reviewer-access.js"
 import type {
   ArtifactBundle,
+  ArtifactManifestFile,
   ArtifactPreview,
   ArtifactReviewerAuthBootstrap,
   ArtifactSpec,
@@ -302,6 +303,7 @@ class PlaygroundRuntime implements Runtime {
       data: observed.data,
       observedAt,
       ...(observed.artifactRefs.length > 0 ? { artifactRefs: observed.artifactRefs } : {}),
+      ...(observed.artifactManifestFiles.length > 0 ? { artifactManifestFiles: observed.artifactManifestFiles } : {}),
     }
     observation.digest = runtimeEpisodeDigest({
       schema: RUNTIME_EPISODE_OBSERVATION_SCHEMA,
@@ -1023,8 +1025,9 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     void Promise.resolve(this.spec.onBrowserStartupProgress?.(event)).catch(() => undefined)
   }
 
-  private async observeData(spec: ObservationSpec, observationId: string): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[] }> {
+  private async observeData(spec: ObservationSpec, observationId: string): Promise<{ data: unknown; artifactRefs: RuntimeEpisodeTraceRef[]; artifactManifestFiles: ArtifactManifestFile[] }> {
     const artifactRefs: RuntimeEpisodeTraceRef[] = []
+    const artifactManifestFiles: ArtifactManifestFile[] = []
 
     if (spec.type === "command-result") {
       const command = spec.commandId ? this.commands.find((candidate) => candidate.id === spec.commandId) : this.commands.at(-1)
@@ -1043,6 +1046,7 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
             }
           : { commandId: spec.commandId ?? null, found: false },
         artifactRefs,
+        artifactManifestFiles,
       }
     }
 
@@ -1055,14 +1059,14 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     }
 
     if (spec.type === "browser-result") {
-      return { data: browserArtifactReviewSummary(this.browserProbes) ?? { probes: [] }, artifactRefs }
+      return { data: browserArtifactReviewSummary(this.browserProbes) ?? { probes: [] }, artifactRefs, artifactManifestFiles }
     }
 
     if (spec.type === "runtime-events" || spec.type === "runtime-logs") {
-      return { data: this.events, artifactRefs }
+      return { data: this.events, artifactRefs, artifactManifestFiles }
     }
 
-    return { data: await this.observeStub(spec), artifactRefs }
+    return { data: await this.observeStub(spec), artifactRefs, artifactManifestFiles }
   }
 
   private async observeStub(spec: ObservationSpec): Promise<unknown> {

--- a/packages/runtime-playground/src/runtime-artifact-helpers.ts
+++ b/packages/runtime-playground/src/runtime-artifact-helpers.ts
@@ -103,7 +103,7 @@ export function formatCommandsLog(commands: ExecutionResult[]): string {
 }
 
 function observationManifestFiles(artifactRoot: string, observations: ObservationResult[]): ArtifactManifestFile[] {
-  return observations.flatMap((observation) =>
+  return observations.flatMap((observation) => observation.artifactManifestFiles ??
     (observation.artifactRefs ?? [])
       .filter((ref): ref is RuntimeEpisodeTraceRef & { path: string } => typeof ref.path === "string" && ref.path.length > 0)
       .map((ref) => artifactManifestFile(join(artifactRoot, ref.path), ref.kind, ref.path.endsWith(".json") ? "application/json" : "text/plain")),

--- a/tests/generic-primitives.test.ts
+++ b/tests/generic-primitives.test.ts
@@ -1,13 +1,19 @@
 import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { resolve } from "node:path"
+import { mkdtempSync } from "node:fs"
 import {
+  artifactFileDigest,
   artifactStoragePath,
   artifactStoragePublicUrl,
   materializationPhaseResult,
   materializationRunArtifactRefs,
+  normalizeArtifactPartPath,
   runtimeArtifactStorageDescriptor,
   trustedBrowserSessionOrigin,
   trustedBrowserSessionOrigins,
+  writeArtifactPart,
 } from "../packages/runtime-core/src/index.js"
 
 const storage = runtimeArtifactStorageDescriptor({
@@ -48,3 +54,22 @@ assert.deepEqual(materializationRunArtifactRefs([phase]), [
     digest: { algorithm: "sha256", value: "abc" },
   },
 ])
+
+const artifactRoot = mkdtempSync(resolve(tmpdir(), "wp-codebox-artifact-part-"))
+const part = await writeArtifactPart({
+  root: artifactRoot,
+  path: "files/check/result.json",
+  kind: "check-result",
+  contentType: "application/json",
+  contents: "{\"ok\":true}\n",
+  redaction: { policy: "required", sensitive: true, reason: "test sensitive artifact" },
+  provenance: { source: "test", operation: "write-artifact-part", id: "result" },
+})
+
+assert.equal(part.path, "files/check/result.json")
+assert.equal(await readFile(part.absolutePath, "utf8"), "{\"ok\":true}\n")
+assert.deepEqual(part.manifestFile.sha256, artifactFileDigest("{\"ok\":true}\n"))
+assert.deepEqual(part.manifestFile.redaction, { policy: "required", sensitive: true, reason: "test sensitive artifact" })
+assert.deepEqual(part.manifestFile.provenance, { source: "test", operation: "write-artifact-part", id: "result" })
+assert.equal(normalizeArtifactPartPath("/files//check/result.json"), "files/check/result.json")
+assert.throws(() => normalizeArtifactPartPath("files/../secret.txt"), /relative path/)


### PR DESCRIPTION
## Summary
- Add a generic runtime-core ArtifactPart writer that normalizes artifact paths, writes content, computes SHA-256 manifests, and carries redaction/provenance metadata.
- Extend manifest file metadata with redaction/provenance fields while preserving existing viewer metadata call sites.
- Migrate focused playground bypasses for WordPress/HTTP observations and plugin/theme check artifacts to produce manifest entries at capture time.

## Testing
- npm run test:generic-primitives
- npm run test:redaction
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Drafted the artifact capture primitive, migrated focused artifact writers, added behavior coverage, and ran local verification. Chris remains responsible for review and acceptance.