### PR TITLE
Centralize preview topology diagnostics

### DIFF
--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path"
 import { artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions, type ArtifactReviewBrowserSummary } from "@automattic/wp-codebox-core"
+import type { PlaygroundPreviewProxyDiagnostics } from "./preview-server.js"
 import type { Request } from "playwright"
 
 export type BrowserArtifact = BrowserProbeArtifact | BrowserActionsArtifact | BrowserEditorOpenArtifact | BrowserEditorActionsArtifact | BrowserScenarioArtifact | BrowserVisualCompareArtifact
@@ -11,6 +12,7 @@ export interface BrowserArtifactBase {
   requestedUrl: string
   url: string
   preview: BrowserProbePreviewRouting
+  previewProxy?: PlaygroundPreviewProxyDiagnostics
   networkPolicy?: BrowserProbeNetworkPolicySummary
   localPreviewOrigin?: string
   requestedPreviewOrigin?: string
@@ -133,6 +135,7 @@ export interface BrowserArtifactSummary {
     truncated: boolean
   }>
   networkPolicy?: BrowserProbeNetworkPolicySummary
+  previewProxy?: PlaygroundPreviewProxyDiagnostics
   lifecycle?: BrowserProbeLifecycleSummary
   liveness?: {
     wallTimeoutMs?: number

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -12,7 +12,7 @@ import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionS
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness, type BrowserCommandLivenessPolicy } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, jsonLines, serializeBrowserError } from "./browser-metrics.js"
-import { browserPreviewNetworkPolicy, browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
+import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, browserPreviewTopology, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
 import { BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
 import { argValue, cleanWpCliOutput, commaListArg, durationArg, jsonArrayArg, strictBooleanArg, viewportArg } from "./commands.js"
 import { editorActionStepsFromArgs, editorOpenTargetFromArgs, type EditorActionStep } from "./editor-actions.js"
@@ -368,18 +368,16 @@ async function runSingleBrowserProbeCommand({
   const wallTimeoutMs = runPlan.wallTimeoutMs
   const livenessPolicy = browserCommandLivenessPolicy({ wallTimeoutMs, idleTimeoutMs: stallTimeoutMs })
   const lifecycleSelectors = runPlan.lifecycleSelectors
-  const routedHosts = commaListArg(args, "route-host")
   const assertions = runPlan.assertions
   const capturesConsoleForAssertions = assertions.some((assertion) => assertion.type === "no-console-errors" || assertion.type === "no-errors")
   const capturesErrorsForAssertions = assertions.some((assertion) => assertion.type === "no-page-errors" || assertion.type === "no-errors")
   const capturesNetworkForAssertions = browserProbeAssertionsNeedNetwork(assertions)
   const capturesBrowserMetrics = capture.has("performance") || capture.has("memory") || browserProbeAssertionsNeedMetrics(assertions)
   const prePageScriptMetadata = prePageScript ? browserProbeScriptMetadata(prePageScript) : undefined
-  const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
-  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const { preview, networkPolicy } = topology
   const routeTracker = createBrowserPreviewRouteTracker()
-  const previewOrigins = browserPreviewOrigins(preview)
-  const targetUrl = resolveBrowserPreviewUrl(runPlan.url, preview.effectiveOrigin)
+  const targetUrl = topology.resolveUrl(runPlan.url)
   const artifactSession = new BrowserArtifactSession(artifactRoot, browserFilesDirectory, { source: command, operation: "browser-probe" })
 
   const consoleMessages: Record<string, unknown>[] = []
@@ -458,7 +456,7 @@ async function runSingleBrowserProbeCommand({
       })
     }
     if (authRequest) {
-      authSummary = await installWordPressAdminAuthCookies({ command, cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
+      authSummary = await installWordPressAdminAuthCookies({ command, cookieUrls: topology.authCookieUrls([targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
     }
     if (requestedViewport) {
       await page.setViewportSize(requestedViewport)
@@ -708,8 +706,9 @@ async function runSingleBrowserProbeCommand({
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       ...(prePageScriptMetadata ? { prePageScript: prePageScriptMetadata } : {}),
       files: {
         ...(capture.has("console") || capturesConsoleForAssertions ? { console: `${browserFilesDirectory}/console.jsonl` } : {}),
@@ -733,6 +732,7 @@ async function runSingleBrowserProbeCommand({
         finalUrl,
         ...(windowLocationOrigin ? { windowLocationOrigin } : {}),
         htmlSnapshot: Boolean(htmlSha256),
+        ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(lifecycleArtifact ? { lifecycle: { schema: lifecycleArtifact.schema, version: lifecycleArtifact.version, startedAtMs: lifecycleArtifact.startedAtMs, selectors: lifecycleArtifact.selectors } } : {}),
         liveness: { wallTimeoutMs, stallTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
@@ -758,8 +758,9 @@ async function runSingleBrowserProbeCommand({
       schema: "wp-codebox/browser-probe/v1",
       requestedUrl: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       finalUrl,
       ...(windowLocationOrigin ? { windowLocationOrigin } : {}),
       waitFor,
@@ -804,8 +805,9 @@ async function runSingleBrowserProbeCommand({
       command,
       requestedUrl: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       finalUrl: artifact.summary.finalUrl ?? targetUrl,
       files: artifact.files,
       summary: artifact.summary,
@@ -2121,8 +2123,6 @@ export async function runBrowserActionsCommand({
   const requestedViewport = runPlan.requestedViewport
   const authRequest = runPlan.authRequest
   const maxDomSnapshotElements = runPlan.maxDomSnapshotElements
-  const routedHosts = commaListArg(args, "route-host")
-
   const browserDirectory = join(artifactRoot, "files", "browser")
   await mkdir(browserDirectory, { recursive: true })
 
@@ -2145,10 +2145,9 @@ export async function runBrowserActionsCommand({
   const startedAtMs = Date.now()
   const progress = createBrowserProbeProgressTracker(startedAt, 0)
   const browser = await launchChromiumBrowser()
-  const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
-  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
-  const previewOrigins = browserPreviewOrigins(preview)
-  let requestedUrl = initialUrl ? resolveBrowserPreviewUrl(initialUrl, preview.effectiveOrigin) : preview.effectiveOrigin
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const { preview, networkPolicy } = topology
+  let requestedUrl = initialUrl ? topology.resolveUrl(initialUrl) : preview.effectiveOrigin
   let finalUrl = requestedUrl
   let htmlSha256: string | undefined
   let screenshotSha256: string | undefined
@@ -2177,7 +2176,7 @@ export async function runBrowserActionsCommand({
     }
     await page.addInitScript(BROWSER_PROBE_STATE_INIT_SCRIPT)
     if (authRequest) {
-      authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.browser-actions", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, browserActionTargetUrls(steps, preview.effectiveOrigin, requestedUrl)), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
+      authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.browser-actions", cookieUrls: topology.authCookieUrls(browserActionTargetUrls(steps, preview.effectiveOrigin, requestedUrl)), page, runPlaygroundCommand, runtimeSpec, server, userId: authRequest.userId })
     }
     if (requestedViewport) {
       await page.setViewportSize(requestedViewport)
@@ -2333,8 +2332,9 @@ export async function runBrowserActionsCommand({
       requestedUrl,
       url: requestedUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       files: {
         ...(capture.has("steps") ? { steps: "files/browser/steps.jsonl" } : {}),
         ...(capture.has("console") ? { console: "files/browser/console.jsonl" } : {}),
@@ -2355,6 +2355,7 @@ export async function runBrowserActionsCommand({
         errors: errors.length,
         finalUrl,
         htmlSnapshot: Boolean(htmlSha256),
+        ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots } : {}),
         liveness: { wallTimeoutMs: totalTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
@@ -2371,6 +2372,7 @@ export async function runBrowserActionsCommand({
       schema: "wp-codebox/browser-actions/v1",
       requestedUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       finalUrl,
       capture: [...capture].sort(),
       stepTimeoutMs,
@@ -2411,6 +2413,7 @@ export async function runBrowserActionsCommand({
       command: "wordpress.browser-actions",
       requestedUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       finalUrl: artifact.summary.finalUrl ?? finalUrl,
       files: artifact.files,
       summary: artifact.summary,
@@ -2845,11 +2848,9 @@ export async function runEditorOpenCommand({
   }
 
   const waitTimeoutMs = durationArg(args, "wait-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
-  const routedHosts = commaListArg(args, "route-host")
-  const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
-  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
-  const previewOrigins = browserPreviewOrigins(preview)
-  const targetUrl = resolveBrowserPreviewUrl(target.url, preview.effectiveOrigin)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const { preview, networkPolicy } = topology
+  const targetUrl = topology.resolveUrl(target.url)
   const browserDirectory = join(artifactRoot, "files", "browser")
   await mkdir(browserDirectory, { recursive: true })
 
@@ -2880,7 +2881,7 @@ export async function runEditorOpenCommand({
       await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
-    authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-open", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
+    authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-open", cookieUrls: topology.authCookieUrls([targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
     viewport = await browserProbeViewport(page)
     attachBrowserCaptureListeners({
       captureConsole: capture.has("console"),
@@ -2951,8 +2952,9 @@ export async function runEditorOpenCommand({
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       files: {
         ...(capture.has("steps") ? { steps: "files/browser/editor-steps.jsonl" } : {}),
         ...(capture.has("console") ? { console: "files/browser/editor-console.jsonl" } : {}),
@@ -2968,6 +2970,7 @@ export async function runEditorOpenCommand({
         errors: errors.length,
         finalUrl,
         htmlSnapshot: capture.has("html"),
+        ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
         auth: authSummary,
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         networkEvents: 0,
@@ -2982,8 +2985,9 @@ export async function runEditorOpenCommand({
       target,
       requestedUrl: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       finalUrl,
       capture: [...capture].sort(),
       waitTimeoutMs,
@@ -3011,6 +3015,7 @@ export async function runEditorOpenCommand({
       target,
       requestedUrl: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       finalUrl: artifact.summary.finalUrl ?? finalUrl,
       files: artifact.files,
       summary: artifact.summary,
@@ -3053,11 +3058,9 @@ export async function runEditorActionsCommand({
   const waitTimeoutMs = durationArg(args, "wait-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
   const stepTimeoutMs = durationArg(args, "step-timeout", BROWSER_STEP_DEFAULT_TIMEOUT_MS)
   const totalTimeoutMs = durationArg(args, "timeout", BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS)
-  const routedHosts = commaListArg(args, "route-host")
-  const preview = browserPreviewRouting(args, runtimeSpec, server.serverUrl)
-  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
-  const previewOrigins = browserPreviewOrigins(preview)
-  const targetUrl = resolveBrowserPreviewUrl(target.url, preview.effectiveOrigin)
+  const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
+  const { preview, networkPolicy } = topology
+  const targetUrl = topology.resolveUrl(target.url)
   const browserDirectory = join(artifactRoot, "files", "browser")
   await mkdir(browserDirectory, { recursive: true })
 
@@ -3091,7 +3094,7 @@ export async function runEditorActionsCommand({
       await routeBrowserPreviewContextNetwork(context, networkPolicy, preview.effectiveOrigin)
     }
     const page = context ? await context.newPage() : await browser.newPage()
-    authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-actions", cookieUrls: browserAuthCookieUrls(server.serverUrl, routedHosts, [targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
+    authSummary = await installWordPressAdminAuthCookies({ command: "wordpress.editor-actions", cookieUrls: topology.authCookieUrls([targetUrl]), page, runPlaygroundCommand, runtimeSpec, server, userId: 1 })
     viewport = await browserProbeViewport(page)
     attachBrowserCaptureListeners({
       captureConsole: capture.has("console"),
@@ -3194,8 +3197,9 @@ export async function runEditorActionsCommand({
       requestedUrl: targetUrl,
       url: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       files: {
         ...(capture.has("steps") ? { steps: "files/browser/editor-action-steps.jsonl" } : {}),
         ...(capture.has("console") ? { console: "files/browser/editor-action-console.jsonl" } : {}),
@@ -3212,6 +3216,7 @@ export async function runEditorActionsCommand({
         errors: errors.length,
         finalUrl,
         htmlSnapshot: capture.has("html"),
+        ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
         auth: authSummary,
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         networkEvents: 0,
@@ -3229,8 +3234,9 @@ export async function runEditorActionsCommand({
       actions: actionSteps,
       requestedUrl: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...previewOrigins,
+      ...topology.origins,
       finalUrl,
       capture: [...capture].sort(),
       waitTimeoutMs,
@@ -3261,6 +3267,7 @@ export async function runEditorActionsCommand({
       actions: actionSteps.length,
       requestedUrl: targetUrl,
       preview,
+      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
       finalUrl: artifact.summary.finalUrl ?? finalUrl,
       files: artifact.files,
       summary: artifact.summary,
@@ -5269,16 +5276,6 @@ echo wp_json_encode( $cookies );
 `
 }
 
-function browserAuthCookieUrls(serverUrl: string, routedHosts: string[], targetUrls: string[]): string[] {
-  const urls = [serverUrl]
-  for (const host of routedHosts.map(normalizeBrowserCookieHost).filter(Boolean)) {
-    const matchingTarget = targetUrls.find((targetUrl) => normalizeBrowserCookieHost(browserUrlHostname(targetUrl) ?? "") === host)
-    const protocol = matchingTarget ? new URL(matchingTarget).protocol : browserAuthCookieProtocol(targetUrls)
-    urls.push(`${protocol}//${host}/`)
-  }
-  return uniqueBrowserAuthCookieUrls(urls)
-}
-
 function browserActionTargetUrls(steps: BrowserInteractionStep[], effectiveOrigin: string, fallbackUrl: string): string[] {
   const urls = steps
     .filter((step) => step.kind === "navigate" && typeof step.url === "string" && step.url.trim().length > 0)
@@ -5297,25 +5294,6 @@ function uniqueBrowserAuthCookieUrls(urls: string[]): string[] {
     }
   }
   return [...unique.values()]
-}
-
-function browserAuthCookieProtocol(targetUrls: string[]): string {
-  for (const targetUrl of targetUrls) {
-    try {
-      return new URL(targetUrl).protocol
-    } catch {
-      // Keep looking for a usable target URL.
-    }
-  }
-  return "http:"
-}
-
-function browserUrlHostname(url: string): string | undefined {
-  try {
-    return new URL(url).hostname
-  } catch {
-    return undefined
-  }
 }
 
 function normalizeBrowserCookieHost(host: string): string {

--- a/packages/runtime-playground/src/browser-preview-routing.ts
+++ b/packages/runtime-playground/src/browser-preview-routing.ts
@@ -15,6 +15,15 @@ export interface BrowserPreviewNetworkPolicy {
   stats: Map<string, { requests: number; external: boolean; blocked: number; routed: number }>
 }
 
+export interface BrowserPreviewTopology {
+  preview: BrowserProbePreviewRouting
+  networkPolicy: BrowserPreviewNetworkPolicy
+  routedHosts: string[]
+  origins: { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string }
+  resolveUrl(pathOrUrl: string): string
+  authCookieUrls(targetUrls: string[]): string[]
+}
+
 export interface BrowserPreviewRouteTracker {
   pending: Set<Promise<void>>
   errors: unknown[]
@@ -62,6 +71,25 @@ export function browserPreviewRouting(args: string[], runtimeSpec: RuntimeCreate
   }
 }
 
+export function browserPreviewTopology(args: string[], runtimeSpec: RuntimeCreateSpec | undefined, localPreviewOrigin: string): BrowserPreviewTopology {
+  const preview = browserPreviewRouting(args, runtimeSpec, localPreviewOrigin)
+  const routedHosts = commaListArg(args, "route-host")
+  const networkPolicy = browserPreviewNetworkPolicy(args, routedHosts, preview)
+
+  return {
+    preview,
+    networkPolicy,
+    routedHosts,
+    origins: browserPreviewOrigins(preview),
+    resolveUrl(pathOrUrl) {
+      return resolveBrowserPreviewUrl(pathOrUrl, preview.effectiveOrigin)
+    },
+    authCookieUrls(targetUrls) {
+      return browserPreviewAuthCookieUrls(localPreviewOrigin, routedHosts, targetUrls)
+    },
+  }
+}
+
 export function browserPreviewOrigins(preview: BrowserProbePreviewRouting): { localPreviewOrigin: string; requestedPreviewOrigin?: string; effectivePreviewOrigin: string } {
   return {
     localPreviewOrigin: preview.localOrigin,
@@ -100,6 +128,16 @@ export function resolveBrowserPreviewUrl(pathOrUrl: string, baseUrl: string): st
   } catch {
     return new URL(pathOrUrl, baseUrl).toString()
   }
+}
+
+export function browserPreviewAuthCookieUrls(localPreviewOrigin: string, routedHosts: string[], targetUrls: string[]): string[] {
+  const urls = [localPreviewOrigin]
+  for (const host of routedHosts.map(normalizeBrowserPreviewHost).filter(Boolean)) {
+    const matchingTarget = targetUrls.find((targetUrl) => normalizeBrowserPreviewHost(browserPreviewUrlHostname(targetUrl) ?? "") === host)
+    const protocol = matchingTarget ? new URL(matchingTarget).protocol : browserPreviewAuthCookieProtocol(targetUrls)
+    urls.push(`${protocol}//${host}/`)
+  }
+  return uniqueBrowserPreviewAuthCookieUrls(urls)
 }
 
 export function browserPreviewNetworkPolicy(args: string[], routeHosts: string[], preview: BrowserProbePreviewRouting): BrowserPreviewNetworkPolicy {
@@ -266,6 +304,30 @@ function browserPreviewUrlHostname(url: string): string | undefined {
   } catch {
     return undefined
   }
+}
+
+function uniqueBrowserPreviewAuthCookieUrls(urls: string[]): string[] {
+  const unique = new Map<string, string>()
+  for (const url of urls) {
+    try {
+      const parsed = new URL(url)
+      unique.set(`${parsed.protocol}//${normalizeBrowserPreviewHost(parsed.hostname)}`, `${parsed.protocol}//${parsed.hostname}/`)
+    } catch {
+      // Ignore invalid cookie URL inputs; callers still include the local preview origin.
+    }
+  }
+  return [...unique.values()]
+}
+
+function browserPreviewAuthCookieProtocol(targetUrls: string[]): string {
+  for (const targetUrl of targetUrls) {
+    try {
+      return new URL(targetUrl).protocol
+    } catch {
+      // Keep looking for a usable target URL.
+    }
+  }
+  return "http:"
 }
 
 function normalizeBrowserPreviewHost(host: string): string {

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -16,7 +16,17 @@ export interface PlaygroundCliServer {
   }
   serverUrl: string
   previewRoutes?: PlaygroundPreviewRouteRegistry
+  previewProxyDiagnostics?: PlaygroundPreviewProxyDiagnostics
   [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface PlaygroundPreviewProxyDiagnostics {
+  schema: "wp-codebox/preview-proxy-diagnostics/v1"
+  upstreamConcurrency: "serialized"
+  maxConcurrentUpstreamRequests: 1
+  queue: "fifo"
+  bind: string
+  targetOrigin: string
 }
 
 export interface PlaygroundPreviewRouteRegistry {
@@ -28,6 +38,7 @@ export type PlaygroundPreviewRouteHandler = (incoming: IncomingMessage, outgoing
 interface PlaygroundPreviewProxy {
   serverUrl: string
   previewRoutes: PlaygroundPreviewRouteRegistry
+  diagnostics: PlaygroundPreviewProxyDiagnostics
   dispose(): Promise<void>
 }
 
@@ -55,6 +66,7 @@ export async function withPreviewProxy(server: PlaygroundCliServer, port: number
     ...server,
     serverUrl: proxy.serverUrl,
     previewRoutes: proxy.previewRoutes,
+    previewProxyDiagnostics: proxy.diagnostics,
     async [Symbol.asyncDispose]() {
       await proxy.dispose()
       await server[Symbol.asyncDispose]()
@@ -90,6 +102,14 @@ async function startPreviewProxy(targetUrl: string, port: number, bind: string):
   return {
     serverUrl: `http://${formatPreviewHost(reportedHost)}:${resolvedPort}`,
     previewRoutes: routes,
+    diagnostics: {
+      schema: "wp-codebox/preview-proxy-diagnostics/v1",
+      upstreamConcurrency: "serialized",
+      maxConcurrentUpstreamRequests: 1,
+      queue: "fifo",
+      bind,
+      targetOrigin: target.origin,
+    },
     async dispose() {
       await closePreviewProxyServers(servers)
     },

--- a/tests/generic-primitives.test.ts
+++ b/tests/generic-primitives.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
+import { createServer } from "node:http"
 import { mkdtempSync, writeFileSync } from "node:fs"
 import { readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -25,6 +26,8 @@ import {
   writeArtifactPart,
 } from "../packages/runtime-core/src/index.js"
 import { benchRunCode } from "../packages/runtime-playground/src/bench-command-handlers.js"
+import { browserPreviewAuthCookieUrls, browserPreviewTopology } from "../packages/runtime-playground/src/browser-preview-routing.js"
+import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
 const storage = runtimeArtifactStorageDescriptor({
   root: "./artifacts",
@@ -90,6 +93,63 @@ assert.throws(() => browserArtifactRef({ content_digest: "abc" }), /artifact_id/
 assert.deepEqual(normalizeRecipeMounts([{ source: "/host/plugin", target: "//wordpress//wp-content/plugins/plugin" }]), [{ source: "/host/plugin", target: "/wordpress/wp-content/plugins/plugin", mode: "readwrite" }])
 assert.throws(() => normalizeSharedMounts([{ source: "/host/plugin", target: "wordpress/wp-content/plugins/plugin" }]), /absolute target/)
 assert.throws(() => normalizeSharedMounts([{ source: "/host/plugin", target: "/wordpress/../escape" }]), /parent-directory/)
+
+const topology = browserPreviewTopology(
+  ["preview-mode=secure", "route-host=example.test,static.example.test", "network-policy=block", "allow-host=cdn.example.test"],
+  { preview: { publicUrl: "https://example.test/site" } },
+  "http://127.0.0.1:9400",
+)
+assert.equal(topology.preview.effectiveOrigin, "https://example.test/site")
+assert.equal(topology.resolveUrl("/wp-admin/"), "https://example.test/wp-admin/")
+assert.deepEqual(topology.routedHosts, ["example.test", "static.example.test"])
+assert.deepEqual(topology.origins, {
+  localPreviewOrigin: "http://127.0.0.1:9400",
+  requestedPreviewOrigin: "https://example.test/site",
+  effectivePreviewOrigin: "https://example.test/site",
+})
+assert.deepEqual(topology.authCookieUrls(["https://example.test/wp-admin/"]), [
+  "http://127.0.0.1/",
+  "https://example.test/",
+  "https://static.example.test/",
+])
+assert.equal(topology.networkPolicy.mode, "block")
+assert.deepEqual([...topology.networkPolicy.routeHosts].sort(), ["example.test", "static.example.test"])
+assert.deepEqual(browserPreviewAuthCookieUrls("http://localhost:9400", ["PUBLIC.example.test"], ["https://public.example.test/wp-admin/"]), ["http://localhost/", "https://public.example.test/"])
+
+let activeUpstreamRequests = 0
+let maxActiveUpstreamRequests = 0
+const targetServer = createServer(async (_request, response) => {
+  activeUpstreamRequests += 1
+  maxActiveUpstreamRequests = Math.max(maxActiveUpstreamRequests, activeUpstreamRequests)
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, 25))
+  activeUpstreamRequests -= 1
+  response.end("ok")
+})
+const targetServerUrl = await listenLocalHttpServer(targetServer)
+let disposed = false
+const proxied = await withPreviewProxy({
+  playground: { async run() { return { text: "" } } },
+  serverUrl: targetServerUrl,
+  async [Symbol.asyncDispose]() {
+    disposed = true
+  },
+} satisfies PlaygroundCliServer, 0)
+try {
+  assert.deepEqual(proxied.previewProxyDiagnostics, {
+    schema: "wp-codebox/preview-proxy-diagnostics/v1",
+    upstreamConcurrency: "serialized",
+    maxConcurrentUpstreamRequests: 1,
+    queue: "fifo",
+    bind: "127.0.0.1",
+    targetOrigin: new URL(targetServerUrl).origin,
+  })
+  await Promise.all([fetch(proxied.serverUrl), fetch(proxied.serverUrl)])
+  assert.equal(maxActiveUpstreamRequests, 1)
+} finally {
+  await proxied[Symbol.asyncDispose]()
+  await closeHttpServer(targetServer)
+}
+assert.equal(disposed, true)
 
 const phase = materializationPhaseResult({
   phase: "persist-browser-artifacts",


### PR DESCRIPTION
## Summary
- Add a browser preview topology contract that owns preview routing, network policy, origin reporting, URL resolution, and auth cookie URL derivation.
- Update browser commands to consume the topology contract instead of re-deriving preview pieces per command.
- Surface explicit preview proxy diagnostics documenting the current serialized FIFO upstream mode, and include that metadata in browser artifacts.
- Add focused primitive coverage for topology URL/cookie routing and serialized proxy diagnostics/behavior.

## Tests
- npm run test:generic-primitives
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI GPT-5.5
- **Used for:** Drafted the focused topology/proxy cleanup, tests, and PR description; Chris remains responsible for review and validation.