### PR TITLE
Harden redacted artifact capture

### DIFF
--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -247,7 +247,7 @@ export interface RecipeRunDeclaredArtifact {
   name: string
   path: string
   required: boolean
-  status: "collected" | "missing" | "failed"
+  status: "collected" | "missing" | "failed" | "oversized" | "sensitive" | "skipped"
   exists: boolean
   type?: "file" | "directory" | "other"
   size?: number
@@ -256,6 +256,7 @@ export interface RecipeRunDeclaredArtifact {
   materialized?: TypedArtifactRef
   metadata?: Record<string, unknown>
   error?: RunOutput["error"]
+  diagnostics?: Record<string, unknown>
 }
 
 export type RecipeInterruptionSignal = "SIGINT" | "SIGTERM" | "SIGHUP"

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, refreshArtifactManifestFileSha256s, resolveSecretEnvNames, upsertArtifactManifestFiles, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, redactJsonValue, refreshArtifactManifestFileSha256s, resolveSecretEnvNames, upsertArtifactManifestFiles, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -24,6 +24,8 @@ import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenc
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
+const DECLARED_ARTIFACT_CAPTURE_MAX_BYTES = DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES
+const declaredArtifactContents = new WeakMap<RecipeRunDeclaredArtifact, Buffer>()
 
 interface BenchmarkArtifactOutput {
   schema: "wp-codebox/benchmark-artifacts/v1"
@@ -1472,7 +1474,7 @@ async function collectRecipeDeclaredArtifact(runtime: Runtime, artifact: Workspa
   try {
     const execution = await runtime.execute({
       command: "wordpress.run-php",
-      args: [`code=${declaredArtifactReadCode(artifact.path, artifact.parseJson === true)}`],
+      args: [`code=${declaredArtifactReadCode(artifact.path, artifact.parseJson === true, false)}`],
     })
     const collected = JSON.parse(execution.stdout.trim() || "{}") as Record<string, unknown>
     const exists = collected.exists === true
@@ -1482,13 +1484,14 @@ async function collectRecipeDeclaredArtifact(runtime: Runtime, artifact: Workspa
       name: artifact.name,
       path: artifact.path,
       required,
-      status: exists ? "collected" as const : "missing" as const,
+      status: declaredArtifactCollectionStatus(collected, exists),
       exists,
       type: collected.type,
       size: collected.size,
       sha256: collected.sha256,
-      parsedJson: collected.parsedJson,
+      parsedJson: collected.parsedJson === undefined ? undefined : redactJsonValue(collected.parsedJson),
       metadata: artifact.metadata,
+      diagnostics: declaredArtifactDiagnostics(collected),
     }) as RecipeRunDeclaredArtifact
   } catch (error) {
     return stripUndefined({
@@ -1506,38 +1509,48 @@ async function collectRecipeDeclaredArtifact(runtime: Runtime, artifact: Workspa
 }
 
 async function collectRecipeTypedArtifact(runtime: Runtime, artifact: WorkspaceRecipeTypedArtifact, index: number): Promise<RecipeRunDeclaredArtifact> {
-  const result = await collectRecipeDeclaredArtifact(runtime, {
-    name: artifact.name,
-    path: artifact.path,
-    required: artifact.required,
-    parseJson: artifact.parseJson,
-    metadata: artifact.metadata,
-  }, index)
-  if (result.status !== "collected") {
-    return result
-  }
-
   try {
     const execution = await runtime.execute({
       command: "wordpress.run-php",
-      args: [`code=${declaredArtifactContentsCode(artifact.path)}`],
+      args: [`code=${declaredArtifactReadCode(artifact.path, artifact.parseJson === true, true)}`],
     })
     const collected = JSON.parse(execution.stdout.trim() || "{}") as Record<string, unknown>
-    return stripUndefined({
-      ...result,
+    const exists = collected.exists === true
+    const result = stripUndefined({
+      schema: "wp-codebox/recipe-declared-artifact-result/v1" as const,
+      index,
+      name: artifact.name,
+      path: artifact.path,
+      required: artifact.required !== false,
+      status: declaredArtifactCollectionStatus(collected, exists),
+      exists,
+      type: collected.type,
+      size: collected.size,
+      sha256: collected.sha256,
+      parsedJson: collected.parsedJson === undefined ? undefined : redactJsonValue(collected.parsedJson),
       typedArtifact: {
         name: artifact.name,
         type: artifact.type,
         payloadSchema: artifact.payloadSchema,
         contentType: artifact.contentType ?? typedArtifactContentType(artifact),
       },
-      contentBase64: typeof collected.contentBase64 === "string" ? collected.contentBase64 : undefined,
+      metadata: artifact.metadata,
+      diagnostics: declaredArtifactDiagnostics(collected),
     }) as RecipeRunDeclaredArtifact
+    if (result.status === "collected" && typeof collected.contentBase64 === "string" && collected.contentBase64.length > 0) {
+      declaredArtifactContents.set(result, Buffer.from(collected.contentBase64, "base64"))
+    }
+    return result
   } catch (error) {
     return stripUndefined({
-      ...result,
+      schema: "wp-codebox/recipe-declared-artifact-result/v1" as const,
+      index,
+      name: artifact.name,
+      path: artifact.path,
+      required: artifact.required !== false,
       status: "failed" as const,
       exists: false,
+      metadata: artifact.metadata,
       error: serializeRecipeRunError(error),
     }) as RecipeRunDeclaredArtifact
   }
@@ -1548,12 +1561,11 @@ async function materializeTypedRecipeDeclaredArtifacts(artifacts: ArtifactBundle
   const files = []
   for (const artifact of declaredArtifacts) {
     const typedArtifact = recipeRunTypedArtifactDeclaration(artifact)
-    const contentBase64 = recipeRunArtifactContentBase64(artifact)
-    if (!typedArtifact || artifact.status !== "collected" || !contentBase64) {
+    const contents = declaredArtifactContents.get(artifact)
+    if (!typedArtifact || artifact.status !== "collected" || !contents) {
       continue
     }
 
-    const contents = Buffer.from(contentBase64, "base64")
     const filename = `typed-artifacts/${safeTypedArtifactName(typedArtifact.name)}-${artifact.index + 1}${typedArtifactExtension(typedArtifact.contentType)}`
     const sha256 = artifactFileDigest(contents).value
     const ref: TypedArtifactRef = stripUndefined({
@@ -1576,9 +1588,8 @@ async function materializeTypedRecipeDeclaredArtifacts(artifacts: ArtifactBundle
     }) as TypedArtifactRef
     refs.push(ref)
     artifact.materialized = ref
-    delete (artifact as RecipeRunDeclaredArtifact & { contentBase64?: string }).contentBase64
     delete (artifact as RecipeRunDeclaredArtifact & { typedArtifact?: unknown }).typedArtifact
-    files.push({ filename, kind: "typed-artifact", contentType: typedArtifact.contentType, contents })
+    files.push({ filename, kind: "typed-artifact", contentType: typedArtifact.contentType, contents, maxBytes: DECLARED_ARTIFACT_CAPTURE_MAX_BYTES })
   }
 
   if (refs.length === 0) {
@@ -1611,11 +1622,6 @@ function recipeRunTypedArtifactDeclaration(artifact: RecipeRunDeclaredArtifact):
   })
 }
 
-function recipeRunArtifactContentBase64(artifact: RecipeRunDeclaredArtifact): string | undefined {
-  const contentBase64 = (artifact as RecipeRunDeclaredArtifact & { contentBase64?: unknown }).contentBase64
-  return typeof contentBase64 === "string" && contentBase64.length > 0 ? contentBase64 : undefined
-}
-
 function typedArtifactContentType(artifact: WorkspaceRecipeTypedArtifact): string {
   return artifact.parseJson === true ? "application/json" : "application/octet-stream"
 }
@@ -1632,6 +1638,28 @@ function safeTypedArtifactName(name: string): string {
 
 function isRecordValue(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function declaredArtifactCollectionStatus(collected: Record<string, unknown>, exists: boolean): RecipeRunDeclaredArtifact["status"] {
+  if (!exists) return "missing"
+  if (collected.oversized === true) return "oversized"
+  if (collected.sensitive === true) return "sensitive"
+  if (collected.skipped === true) return "skipped"
+  return "collected"
+}
+
+function declaredArtifactDiagnostics(collected: Record<string, unknown>): Record<string, unknown> | undefined {
+  const diagnostics = stripUndefined({
+    capture: {
+      schema: "wp-codebox/declared-artifact-capture-diagnostics/v1",
+      status: collected.oversized === true ? "oversized" : collected.sensitive === true ? "sensitive" : collected.skipped === true ? "skipped" : collected.exists === true ? "captured" : "missing",
+      reason: typeof collected.reason === "string" ? collected.reason : undefined,
+      maxBytes: typeof collected.maxBytes === "number" ? collected.maxBytes : undefined,
+      binary: typeof collected.binary === "boolean" ? collected.binary : undefined,
+      redacted: collected.redacted === true,
+    },
+  })
+  return Object.keys(diagnostics.capture).length > 1 ? diagnostics : undefined
 }
 
 function recipeProbeFailure(probes: RecipeRunProbe[]): RecipeProbeFailureError | undefined {
@@ -1784,11 +1812,14 @@ foreach ($statements as $statement) {
 echo wp_json_encode(array('counts' => $counts));`
 }
 
-function declaredArtifactReadCode(path: string, parseJson: boolean): string {
+function declaredArtifactReadCode(path: string, parseJson: boolean, includeContents: boolean): string {
   const encodedPath = JSON.stringify(path)
+  const maxBytes = DECLARED_ARTIFACT_CAPTURE_MAX_BYTES
   return `
 $path = ${encodedPath};
 $parse_json = ${parseJson ? "true" : "false"};
+$include_contents = ${includeContents ? "true" : "false"};
+$max_bytes = ${maxBytes};
 $result = array('exists' => file_exists($path));
 if (!$result['exists']) {
     echo wp_json_encode($result);
@@ -1796,18 +1827,39 @@ if (!$result['exists']) {
 }
 $result['type'] = is_dir($path) ? 'directory' : (is_file($path) ? 'file' : 'other');
 if (is_file($path)) {
+    $file_size = filesize($path);
+    if (false === $file_size) {
+        throw new RuntimeException('Unable to stat declared artifact path: ' . $path);
+    }
+    $result['size'] = $file_size;
+    $result['maxBytes'] = $max_bytes;
+    if ($file_size > $max_bytes) {
+        $result['oversized'] = true;
+        $result['reason'] = 'max-bytes-exceeded';
+        echo wp_json_encode($result);
+        return;
+    }
     $contents = file_get_contents($path);
     if (false === $contents) {
         throw new RuntimeException('Unable to read declared artifact path: ' . $path);
     }
-    $result['size'] = strlen($contents);
     $result['sha256'] = hash('sha256', $contents);
+    $result['binary'] = 1 !== preg_match('//u', $contents);
+    if (preg_match('/\\b(?:sk-[A-Za-z0-9_-]{20,}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16})\\b/', $contents)) {
+        $result['sensitive'] = true;
+        $result['reason'] = 'secret-like-value';
+        echo wp_json_encode($result);
+        return;
+    }
     if ($parse_json) {
         $decoded = json_decode($contents, true);
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new RuntimeException('Declared artifact JSON parse failed for ' . $path . ': ' . json_last_error_msg());
         }
         $result['parsedJson'] = $decoded;
+    }
+    if ($include_contents) {
+        $result['contentBase64'] = base64_encode($contents);
     }
 } elseif (is_dir($path)) {
     $entries = array_values(array_diff(scandir($path) ?: array(), array('.', '..')));
@@ -1816,20 +1868,6 @@ if (is_file($path)) {
     $result['sha256'] = hash('sha256', wp_json_encode($entries));
 }
 echo wp_json_encode($result);`
-}
-
-function declaredArtifactContentsCode(path: string): string {
-  const encodedPath = JSON.stringify(path)
-  return `
-$path = ${encodedPath};
-if (!is_file($path)) {
-    throw new RuntimeException('Typed artifact path is not a file: ' . $path);
-}
-$contents = file_get_contents($path);
-if (false === $contents) {
-    throw new RuntimeException('Unable to read typed artifact path: ' . $path);
-}
-echo wp_json_encode(array('contentBase64' => base64_encode($contents)));`
 }
 
 function activateExtraPluginCode(pluginFile: string): string {

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, checkWorkspacePolicy, normalizeAgentTerminalResult, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactIndex, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, captureArtifactFile, checkWorkspacePolicy, normalizeAgentTerminalResult, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactIndex, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core/artifacts"
 import { isPlainObject as isRecord, sha256StableJson, stripUndefined } from "@automattic/wp-codebox-core/internals"
 
@@ -26,6 +26,8 @@ export interface RecipeRuntimeEvidenceFileInput {
   kind: string
   contentType: string
   contents: string | Buffer
+  maxBytes?: number
+  skipSensitiveText?: boolean
 }
 
 export interface RecipeArtifactEvidenceResult {
@@ -594,11 +596,23 @@ export async function appendRecipeRuntimeEvidenceFiles(artifacts: ArtifactBundle
   const evidenceFiles: RecipeArtifactEvidenceFile[] = []
   for (const file of files) {
     const path = join(evidenceDirectory, file.filename)
-    await mkdir(dirname(path), { recursive: true })
-    await writeFile(path, file.contents)
+    const captured = await captureArtifactFile({
+      root: artifacts.directory,
+      path: relative(artifacts.directory, path),
+      kind: file.kind,
+      contentType: file.contentType,
+      contents: file.contents,
+      maxBytes: file.maxBytes ?? DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES,
+      skipSensitiveText: file.skipSensitiveText,
+      redaction: { policy: "applied", sensitive: file.skipSensitiveText === true, reason: "Runtime evidence files are redacted and bounded before capture." },
+      provenance: { source: "recipe-run", operation: "append-runtime-evidence-file", id: file.filename },
+    })
+    if (captured.status !== "captured" || !captured.sha256) {
+      continue
+    }
     evidenceFiles.push({
       path: relative(artifacts.directory, path),
-      sha256: artifactFileDigest(file.contents).value,
+      sha256: captured.sha256,
       kind: file.kind,
       contentType: file.contentType,
     })

--- a/packages/runtime-core/src/artifact-capture-policy.ts
+++ b/packages/runtime-core/src/artifact-capture-policy.ts
@@ -1,7 +1,8 @@
-import { mkdir, writeFile } from "node:fs/promises"
-import { dirname, join, relative } from "node:path"
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
 
 import { artifactFileDigest, artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions } from "./artifact-manifest.js"
+import { containsSecretLikeValue, redactString } from "./redaction.js"
 
 export interface ArtifactPartInput {
   root: string
@@ -19,6 +20,45 @@ export interface ArtifactPart {
   bytes: number
   manifestFile: ArtifactManifestFile
 }
+
+export interface CapturedArtifactFileInput {
+  sourcePath?: string
+  root: string
+  path: string
+  kind: ArtifactManifestFile["kind"]
+  contentType?: string
+  contents?: string | Buffer
+  allowedRoots?: string[]
+  maxBytes?: number
+  redact?: (path: string, contents: string) => string
+  skipSensitiveText?: boolean
+  redaction?: ArtifactManifestFileOptions["redaction"]
+  provenance?: ArtifactManifestFileOptions["provenance"]
+}
+
+export type CapturedArtifactFileStatus = "captured" | "skipped" | "oversized" | "sensitive" | "failed"
+
+export interface CapturedArtifactFile {
+  schema: "wp-codebox/captured-artifact-file/v1"
+  status: CapturedArtifactFileStatus
+  path: string
+  absolutePath?: string
+  sourcePath?: string
+  bytes?: number
+  originalBytes?: number
+  sha256?: string
+  contentType?: string
+  binary?: boolean
+  reason?: string
+  error?: string
+  limit?: {
+    maxBytes?: number
+    allowedRoots?: string[]
+  }
+  manifestFile?: ArtifactManifestFile
+}
+
+export const DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES = 1024 * 1024
 
 export async function writeArtifactPart(input: ArtifactPartInput): Promise<ArtifactPart> {
   const relativePath = normalizeArtifactPartPath(input.path)
@@ -41,10 +81,99 @@ export async function writeArtifactPart(input: ArtifactPartInput): Promise<Artif
   }
 }
 
+export async function captureArtifactFile(input: CapturedArtifactFileInput): Promise<CapturedArtifactFile> {
+  const relativePath = normalizeArtifactPartPath(input.path)
+  const maxBytes = input.maxBytes ?? DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES
+  const allowedRoots = await Promise.all((input.allowedRoots ?? [input.root]).map((root) => realpath(root).catch(() => resolve(root))))
+  const destination = join(input.root, relativePath)
+
+  try {
+    const contents = input.contents === undefined ? await readAllowedSource(input.sourcePath, allowedRoots, maxBytes) : Buffer.isBuffer(input.contents) ? input.contents : Buffer.from(input.contents, "utf8")
+    if (contents.byteLength > maxBytes) {
+      return captureSkipped(input, relativePath, "oversized", "max-bytes-exceeded", { originalBytes: contents.byteLength, maxBytes, allowedRoots })
+    }
+
+    const text = contents.toString("utf8")
+    const binary = !isReplayableUtf8(contents, text)
+    if (!binary && input.skipSensitiveText === true && containsSecretLikeValue(text)) {
+      return captureSkipped(input, relativePath, "sensitive", "secret-like-value", { originalBytes: contents.byteLength, maxBytes, allowedRoots })
+    }
+
+    const capturedContents = binary ? contents : Buffer.from(input.redact ? input.redact(relativePath, text) : redactString(text), "utf8")
+    await mkdir(dirname(destination), { recursive: true })
+    await writeFile(destination, capturedContents)
+    const manifestFile = artifactManifestFile(relativePath, input.kind, input.contentType ?? (binary ? "application/octet-stream" : "text/plain; charset=utf-8"), artifactFileDigest(capturedContents), {
+      redaction: input.redaction,
+      provenance: input.provenance,
+    })
+
+    return {
+      schema: "wp-codebox/captured-artifact-file/v1",
+      status: "captured",
+      path: relativePath,
+      absolutePath: destination,
+      ...(input.sourcePath ? { sourcePath: input.sourcePath } : {}),
+      bytes: capturedContents.byteLength,
+      originalBytes: contents.byteLength,
+      sha256: manifestFile.sha256.value,
+      contentType: manifestFile.contentType,
+      binary,
+      manifestFile,
+      limit: { maxBytes, allowedRoots },
+    }
+  } catch (error) {
+    if (error instanceof OversizedArtifactError) {
+      return captureSkipped(input, relativePath, "oversized", "max-bytes-exceeded", { originalBytes: error.bytes, maxBytes, allowedRoots })
+    }
+    return captureSkipped(input, relativePath, "failed", "capture-failed", { maxBytes, allowedRoots, error: error instanceof Error ? error.message : String(error) })
+  }
+}
+
 export function normalizeArtifactPartPath(path: string): string {
   const segments = path.replace(/\\/g, "/").split("/").filter(Boolean)
   if (segments.length === 0 || segments.some((segment) => segment === "." || segment === "..")) {
     throw new Error("Artifact part path must be a relative path without current-directory or parent-directory segments")
   }
   return segments.join("/")
+}
+
+async function readAllowedSource(sourcePath: string | undefined, allowedRoots: string[], maxBytes: number): Promise<Buffer> {
+  if (!sourcePath) {
+    throw new Error("Captured artifact sourcePath is required when contents are not provided")
+  }
+  const resolvedSource = await realpath(sourcePath)
+  if (!allowedRoots.some((root) => resolvedSource === root || resolvedSource.startsWith(`${root}/`))) {
+    throw new Error(`Captured artifact source path is outside allowed roots: ${sourcePath}`)
+  }
+  const sourceStats = await stat(resolvedSource)
+  if (!sourceStats.isFile()) {
+    throw new Error(`Captured artifact source path is not a file: ${sourcePath}`)
+  }
+  if (sourceStats.size > maxBytes) {
+    throw new OversizedArtifactError(sourceStats.size)
+  }
+  return readFile(resolvedSource)
+}
+
+class OversizedArtifactError extends Error {
+  constructor(readonly bytes: number) {
+    super("Captured artifact source exceeds max bytes")
+  }
+}
+
+function captureSkipped(input: CapturedArtifactFileInput, path: string, status: CapturedArtifactFileStatus, reason: string, extra: { originalBytes?: number; maxBytes?: number; allowedRoots?: string[]; error?: string }): CapturedArtifactFile {
+  return {
+    schema: "wp-codebox/captured-artifact-file/v1",
+    status,
+    path,
+    ...(input.sourcePath ? { sourcePath: input.sourcePath } : {}),
+    ...(extra.originalBytes !== undefined ? { originalBytes: extra.originalBytes } : {}),
+    reason,
+    ...(extra.error ? { error: extra.error } : {}),
+    limit: { maxBytes: extra.maxBytes, allowedRoots: extra.allowedRoots },
+  }
+}
+
+function isReplayableUtf8(buffer: Buffer, text: string): boolean {
+  return !text.includes("\uFFFD") && Buffer.from(text, "utf8").equals(buffer)
 }

--- a/packages/runtime-core/src/redaction.ts
+++ b/packages/runtime-core/src/redaction.ts
@@ -17,6 +17,7 @@ export interface RedactStringOptions extends SensitiveKeyOptions {
 
 const SENSITIVE_KEY_PATTERN = /(?:secret|token|credential|password|pass|api[_-]?key|private[_-]?key|authorization|auth|cookie|bearer|nonce|session|state|code|login)/i
 const SECRET_LIKE_VALUE_PATTERN = /\b(?:sk-[A-Za-z0-9_-]{20,}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16})\b/
+const SECRET_LIKE_VALUE_GLOBAL_PATTERN = /\b(?:sk-[A-Za-z0-9_-]{20,}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16})\b/g
 
 export function isSensitiveKey(key: string, options: SensitiveKeyOptions = {}): boolean {
   return (options.pattern ?? SENSITIVE_KEY_PATTERN).test(key) || Boolean(options.extraPattern?.test(key))
@@ -49,6 +50,7 @@ export function redactJsonValue(value: unknown, options: RedactJsonOptions = {},
 export function redactString(value: string, options: RedactStringOptions = {}): string {
   return value
     .replace(/https?:\/\/[^\s"'<>]+/gi, (match) => redactUrl(match, options))
+    .replace(SECRET_LIKE_VALUE_GLOBAL_PATTERN, REDACTED_VALUE)
     .replace(/([?&][^=&#\s"'<>]+)=([^&#\s"'<>]+)/g, options.redactQueryAssignments ? `$1=${REDACTED_VALUE}` : "$&")
     .replace(/((?:[A-Za-z0-9_-]*)(?:access[_-]?token|auth|bearer|code|cookie|credential|key|login|nonce|pass|password|secret|session|state|token)(?:[A-Za-z0-9_-]*)(?:["'\s:=]+))[^&#\s"'<>]+/gi, `$1${REDACTED_VALUE}`)
 }

--- a/packages/runtime-playground/src/runtime-diagnostics.ts
+++ b/packages/runtime-playground/src/runtime-diagnostics.ts
@@ -1,6 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises"
-import { dirname, join } from "node:path"
-import type { MountSpec } from "@automattic/wp-codebox-core"
+import { basename, dirname, join } from "node:path"
+import { captureArtifactFile, type MountSpec } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { extractPhpunitFailureMessage } from "./playground-command-errors.js"
 
@@ -19,8 +18,15 @@ export async function persistPhpunitResult(server: PlaygroundCliServer, vfsPath:
 
   try {
     const contents = await server.playground.readFileAsText(vfsPath)
-    await mkdir(dirname(hostPath), { recursive: true })
-    await writeFile(hostPath, contents)
+    await captureArtifactFile({
+      root: dirname(hostPath),
+      path: basename(hostPath),
+      kind: "test-results",
+      contentType: "text/plain; charset=utf-8",
+      contents,
+      redaction: { policy: "applied", sensitive: true, reason: "PHPUnit failure diagnostics are redacted before artifact capture." },
+      provenance: { source: "wordpress-playground", operation: "persist-phpunit-result", id: vfsPath },
+    })
   } catch {
     // The structured result is best-effort; preserve the command outcome if copying fails.
   }
@@ -65,8 +71,15 @@ export async function persistVfsDiagnosticFileToHost(server: PlaygroundCliServer
 
   try {
     const contents = await server.playground.readFileAsText(sourceVfsPath)
-    await mkdir(dirname(hostPath), { recursive: true })
-    await writeFile(hostPath, contents)
+    await captureArtifactFile({
+      root: dirname(hostPath),
+      path: basename(hostPath),
+      kind: "diagnostics",
+      contentType: "text/plain; charset=utf-8",
+      contents,
+      redaction: { policy: "applied", sensitive: true, reason: "Failure diagnostics are redacted before host capture." },
+      provenance: { source: "wordpress-playground", operation: "persist-vfs-diagnostic", id: sourceVfsPath, metadata: { hostVfsPath } },
+    })
   } catch {
     // The structured result is best-effort; preserve the command failure if copying fails.
   }

--- a/tests/generic-primitives.test.ts
+++ b/tests/generic-primitives.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict"
-import { readFile } from "node:fs/promises"
+import { readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { resolve } from "node:path"
+import { join, resolve } from "node:path"
 import { mkdtempSync } from "node:fs"
 import {
   artifactFileDigest,
   artifactStoragePath,
   artifactStoragePublicUrl,
+  captureArtifactFile,
   materializationPhaseResult,
   materializationRunArtifactRefs,
   normalizeArtifactPartPath,
@@ -73,3 +74,43 @@ assert.deepEqual(part.manifestFile.redaction, { policy: "required", sensitive: t
 assert.deepEqual(part.manifestFile.provenance, { source: "test", operation: "write-artifact-part", id: "result" })
 assert.equal(normalizeArtifactPartPath("/files//check/result.json"), "files/check/result.json")
 assert.throws(() => normalizeArtifactPartPath("files/../secret.txt"), /relative path/)
+
+const captureRoot = mkdtempSync(resolve(tmpdir(), "wp-codebox-capture-"))
+const redactedCapture = await captureArtifactFile({
+  root: captureRoot,
+  path: "files/diagnostics/failure.txt",
+  kind: "diagnostics",
+  contents: "Authorization: bearer-secret\ntoken sk-abcdefghijklmnopqrstuvwxyz\n",
+  contentType: "text/plain; charset=utf-8",
+  redaction: { policy: "applied", sensitive: true },
+  provenance: { source: "test", operation: "capture" },
+})
+assert.equal(redactedCapture.status, "captured")
+assert.equal(await readFile(join(captureRoot, "files/diagnostics/failure.txt"), "utf8"), "Authorization: [redacted]\ntoken [redacted]\n")
+assert.equal(redactedCapture.manifestFile?.redaction?.policy, "applied")
+
+const sourceRoot = mkdtempSync(resolve(tmpdir(), "wp-codebox-capture-source-"))
+const largeSource = join(sourceRoot, "large.txt")
+await writeFile(largeSource, "0123456789")
+const oversizedCapture = await captureArtifactFile({
+  sourcePath: largeSource,
+  root: captureRoot,
+  path: "files/large.txt",
+  kind: "file",
+  allowedRoots: [sourceRoot],
+  maxBytes: 4,
+})
+assert.equal(oversizedCapture.status, "oversized")
+assert.equal(oversizedCapture.reason, "max-bytes-exceeded")
+assert.equal(oversizedCapture.originalBytes, 10)
+
+const sensitiveCapture = await captureArtifactFile({
+  root: captureRoot,
+  path: "files/sensitive.txt",
+  kind: "file",
+  contents: "token sk-abcdefghijklmnopqrstuvwxyz\n",
+  maxBytes: 1024,
+  skipSensitiveText: true,
+})
+assert.equal(sensitiveCapture.status, "sensitive")
+assert.equal(sensitiveCapture.reason, "secret-like-value")

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -26,6 +26,7 @@ for (const [value, expected] of redactedValueCases) {
 
 assert.equal(containsSecretLikeValue("token sk-abcdefghijklmnopqrstuvwxyz"), true)
 assert.equal(containsSecretLikeValue("token [redacted]"), false)
+assert.equal(redactString("token sk-abcdefghijklmnopqrstuvwxyz"), "token [redacted]")
 
 assert.deepEqual(
   redactJsonValue({ token: "abc", nested: { api_key: "def", visible: "ok" }, list: [{ password: "secret" }] }, { redactStrings: false }),


### PR DESCRIPTION
## Summary
- Add a shared bounded artifact capture primitive with allowed roots, size limits, binary/text handling, redaction, skipped/oversized/sensitive statuses, and manifest metadata.
- Route runtime failure diagnostic writes and runtime evidence file writes through the shared capture primitive.
- Bound declared/typed artifact collection, redact parsed JSON, avoid persisting raw base64 in declared artifact results, and surface oversized/sensitive diagnostics.

## Testing
- npm run test:redaction
- npm run test:generic-primitives
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification