### PR TITLE
Guard runtime contract schema parity

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -66,6 +66,9 @@ top-level fields:
 - `mounts`
 - `workspaces`
 - `extra_plugins`
+- `component_manifest`
+- `dependency_overlays`
+- `runtimeEnv`
 - `secretEnv`
 - `pluginRuntime`
 - `fixtureDatabases`

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:generic-primitives": "tsx tests/generic-primitives.test.ts",
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
+    "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "check": "npm run smoke -- --group=check"
   },
   "workspaces": [

--- a/packages/runtime-core/src/task-input.ts
+++ b/packages/runtime-core/src/task-input.ts
@@ -6,6 +6,16 @@ export type TaskTargetKind = "repo" | "site" | "plugin" | "theme" | (string & {}
 
 export const TASK_INPUT_SCHEMA = "wp-codebox/task-input/v1" as const
 export const TASK_INPUT_VERSION = 1 as const
+export const TASK_INPUT_ABILITY_ALIAS_FIELDS = [
+  "goal",
+  "target",
+  "allowed_tools",
+  "sandbox_tool_policy",
+  "expected_artifacts",
+  "structured_artifacts",
+  "policy",
+  "context",
+] as const
 
 export interface TaskTarget {
   kind: TaskTargetKind
@@ -62,8 +72,8 @@ export const TASK_INPUT_JSON_SCHEMA = {
   type: "object",
   required: ["schema", "version", "goal", "target", "allowed_tools", "expected_artifacts", "structured_artifacts", "agent_bundles", "sandbox_tool_policy", "policy", "context"],
   properties: {
-    schema: { const: TASK_INPUT_SCHEMA, description: "Task input contract schema id." },
-    version: { const: TASK_INPUT_VERSION, description: "Task input contract version." },
+    schema: { type: "string", const: TASK_INPUT_SCHEMA, description: "Task input contract schema id." },
+    version: { type: "integer", const: TASK_INPUT_VERSION, description: "Task input contract version." },
     goal: { type: "string", description: "User-facing outcome the sandboxed coding agent should accomplish." },
     target: {
       type: "object",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -305,16 +305,10 @@ final class WP_Codebox_Abilities {
 									'properties' => array(
 										'schema'             => array( 'type' => 'string', 'const' => 'wp-codebox/agent-fanout-worker/v1' ),
 										'id'                 => array( 'type' => 'string' ),
-										'goal'               => $task_input_schema['properties']['goal'],
 										'task'               => array( 'type' => 'string' ),
 										'agent'              => array( 'type' => 'string' ),
-										'context'            => $task_input_schema['properties']['context'],
-										'expected_artifacts' => $task_input_schema['properties']['expected_artifacts'],
-										'allowed_tools'      => $task_input_schema['properties']['allowed_tools'],
-										'sandbox_tool_policy' => $task_input_schema['properties']['sandbox_tool_policy'],
-										'policy'             => $task_input_schema['properties']['policy'],
 										'timeout_seconds'    => array( 'type' => 'integer' ),
-									),
+									) + self::task_input_alias_properties( $task_input_schema ),
 								),
 							),
 							'concurrency'           => array(
@@ -366,11 +360,7 @@ final class WP_Codebox_Abilities {
 						'properties' => array(
 							'schema'             => array( 'type' => 'string', 'const' => 'wp-codebox/host-delegation-request/v1' ),
 							'request_id'         => array( 'type' => 'string' ),
-							'goal'               => $task_input_schema['properties']['goal'],
 							'task'               => array( 'type' => 'string' ),
-							'target'             => $task_input_schema['properties']['target'],
-							'context'            => $task_input_schema['properties']['context'],
-							'expected_artifacts' => $task_input_schema['properties']['expected_artifacts'],
 							'execution'          => array(
 								'type'        => 'object',
 								'description' => 'Product-neutral host execution preferences or requirements. WP Codebox preserves this for the host provider without interpreting product policy.',
@@ -378,7 +368,7 @@ final class WP_Codebox_Abilities {
 							'orchestrator'       => $session_input['orchestrator'],
 							'sandbox_session_id' => $session_input['sandbox_session_id'],
 							'metadata'           => array( 'type' => 'object' ),
-						),
+						) + self::task_input_alias_properties( $task_input_schema ),
 					),
 					'output_schema'       => array(
 						'type'       => 'object',

--- a/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
@@ -11,6 +11,7 @@ final class WP_Codebox_Task_Input_Contract {
 
 	public const SCHEMA  = 'wp-codebox/task-input/v1';
 	public const VERSION = 1;
+	public const ABILITY_ALIAS_FIELDS = array( 'goal', 'target', 'allowed_tools', 'sandbox_tool_policy', 'expected_artifacts', 'structured_artifacts', 'policy', 'context' );
 
 	/** @return array<string,mixed> */
 	public static function schema(): array {
@@ -64,7 +65,7 @@ final class WP_Codebox_Task_Input_Contract {
 							'name'           => array( 'type' => 'string' ),
 							'type'           => array( 'type' => 'string' ),
 							'payload_schema' => array( 'anyOf' => array( array( 'type' => 'string' ), array( 'type' => 'object' ) ) ),
-							'payload'        => array(),
+							'payload'        => (object) array(),
 							'metadata'       => array( 'type' => 'object' ),
 							'provenance'     => array( 'type' => 'object' ),
 						),
@@ -83,10 +84,19 @@ final class WP_Codebox_Task_Input_Contract {
 							'source'      => array( 'type' => 'string' ),
 							'bundle'      => array( 'type' => 'object' ),
 							'slug'        => array( 'type' => 'string' ),
-							'on_conflict' => array( 'type' => 'string', 'enum' => array( 'error', 'skip', 'upgrade' ) ),
-							'owner_id'    => array( 'type' => 'integer' ),
+							'on_conflict' => array( 'enum' => array( 'error', 'skip', 'upgrade' ) ),
+							'owner_id'    => array( 'type' => 'integer', 'minimum' => 1 ),
 							'token_env'   => array( 'type' => 'string' ),
-							'import_principal' => array( 'type' => 'object' ),
+							'import_principal' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'agent_id'      => array( 'type' => 'integer', 'minimum' => 1 ),
+									'owner_id'      => array( 'type' => 'integer', 'minimum' => 1 ),
+									'token_id'      => array( 'type' => 'integer', 'minimum' => 1 ),
+									'capabilities'  => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+									'scope'         => array( 'type' => 'object' ),
+								),
+							),
 						),
 					),
 				),

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -574,15 +574,7 @@ private static function host_agent_task_input_properties( array $task_input_sche
 	);
 
 	if ( ! empty( $options['task_fields'] ) ) {
-		$properties = array(
-			'goal'                => $task_input_schema['properties']['goal'],
-			'target'              => $task_input_schema['properties']['target'],
-			'allowed_tools'       => $task_input_schema['properties']['allowed_tools'],
-			'sandbox_tool_policy' => $task_input_schema['properties']['sandbox_tool_policy'],
-			'expected_artifacts'  => $task_input_schema['properties']['expected_artifacts'],
-			'policy'              => $task_input_schema['properties']['policy'],
-			'context'             => $task_input_schema['properties']['context'],
-		) + $properties;
+		$properties = self::task_input_alias_properties( $task_input_schema ) + $properties;
 	}
 
 	if ( ! empty( $options['site_seeds'] ) ) {
@@ -647,14 +639,7 @@ private static function component_contracts_schema( string $description = '' ): 
  * @return array<string,mixed>
  */
 private static function browser_task_input_properties( array $task_input_schema, array $inherit_schema, array $session_input, bool $detailed = false ): array {
-	return array(
-		'goal'                    => $task_input_schema['properties']['goal'],
-		'target'                  => $task_input_schema['properties']['target'],
-		'allowed_tools'           => $task_input_schema['properties']['allowed_tools'],
-		'sandbox_tool_policy'     => $task_input_schema['properties']['sandbox_tool_policy'],
-		'expected_artifacts'      => $task_input_schema['properties']['expected_artifacts'],
-		'policy'                  => $task_input_schema['properties']['policy'],
-		'context'                 => $task_input_schema['properties']['context'],
+	return self::task_input_alias_properties( $task_input_schema ) + array(
 		'agent'                   => self::string_property_schema( $detailed ? 'Sandbox agent slug to invoke through agents/chat inside the browser Playground.' : '' ),
 		'provider'                => self::string_property_schema( $detailed ? 'AI provider id to seed into the browser Playground agent invocation.' : '' ),
 		'model'                   => self::string_property_schema( $detailed ? 'AI model id to seed into the browser Playground agent invocation.' : '' ),
@@ -674,6 +659,16 @@ private static function browser_task_input_properties( array $task_input_schema,
 		'site_blueprint_artifact' => $detailed ? self::site_blueprint_artifact_input_schema() : self::object_property_schema(),
 		'artifact_files'          => $detailed ? self::artifact_files_input_schema() : array( 'type' => 'array' ),
 	);
+}
+
+/** @return array<string,mixed> */
+private static function task_input_alias_properties( array $task_input_schema ): array {
+	$properties = array();
+	foreach ( WP_Codebox_Task_Input_Contract::ABILITY_ALIAS_FIELDS as $field ) {
+		$properties[ $field ] = $task_input_schema['properties'][ $field ];
+	}
+
+	return $properties;
 }
 
 /** @return array<string,mixed> */

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -41,6 +41,7 @@ export const smokeGroups = {
       tsxSmoke("host-command-tool-smoke"),
       tsxSmoke("runtime-env-smoke"),
       tsxSmoke("task-input-contract-smoke"),
+      npmScript("test:schema-parity"),
       tsxSmoke("discovery-command-smoke"),
       tsxSmoke("doctor-command-smoke"),
       tsxSmoke("cli-json-failure-smoke"),

--- a/tests/schema-parity.test.ts
+++ b/tests/schema-parity.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+
+import { createWorkspaceRecipeJsonSchema, TASK_INPUT_ABILITY_ALIAS_FIELDS, TASK_INPUT_JSON_SCHEMA } from "../packages/runtime-core/src/index.js"
+
+const root = new URL("../", import.meta.url)
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortObject(value), null, 2)
+}
+
+function sortObject(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortObject)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => [key, sortObject(entry)]))
+}
+
+function phpJson(expression: string): unknown {
+  const php = spawnSync("php", ["-r", `define('ABSPATH', '${root.pathname.replace(/'/g, "'\\''")}'); require '${root.pathname.replace(/'/g, "'\\''")}packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php'; echo json_encode(${expression}, JSON_UNESCAPED_SLASHES);`], {
+    cwd: root.pathname,
+    encoding: "utf8",
+  })
+  assert.equal(php.status, 0, php.stderr)
+  return JSON.parse(php.stdout)
+}
+
+const phpTaskInputSchema = phpJson("WP_Codebox_Task_Input_Contract::schema()")
+assert.equal(canonicalJson(phpTaskInputSchema), canonicalJson(TASK_INPUT_JSON_SCHEMA), "PHP task input schema must match runtime-core TASK_INPUT_JSON_SCHEMA")
+
+const phpAliasFields = phpJson("WP_Codebox_Task_Input_Contract::ABILITY_ALIAS_FIELDS")
+assert.deepEqual(phpAliasFields, [...TASK_INPUT_ABILITY_ALIAS_FIELDS], "PHP ability task aliases must match runtime-core alias fields")
+
+const recipeSchema = createWorkspaceRecipeJsonSchema()
+const recipeProperties = recipeSchema.properties as Record<string, { properties?: Record<string, unknown> }>
+const docs = readFileSync(new URL("../docs/recipe-contract.md", import.meta.url), "utf8")
+
+function documentedFields(section: string): string[] {
+  const lines = docs.split("\n")
+  const start = lines.findIndex((line) => line.includes(section))
+  assert.notEqual(start, -1, `Missing docs field section: ${section}`)
+  const fields: string[] = []
+  for (const line of lines.slice(start + 1)) {
+    const match = line.match(/^- `([^`]+)`/)
+    if (match) {
+      fields.push(match[1])
+      continue
+    }
+    if (fields.length > 0 && line.trim() === "") break
+  }
+  return fields
+}
+
+assert.deepEqual(documentedFields("top-level fields"), Object.keys(recipeProperties), "Recipe docs top-level field list must match runtime-core schema")
+assert.deepEqual(documentedFields("`inputs` accepts these fields"), Object.keys(recipeProperties.inputs.properties ?? {}), "Recipe docs inputs field list must match runtime-core schema")
+
+console.log("schema parity ok")


### PR DESCRIPTION
## Summary
- add a runtime-core task input alias field list and reuse it for PHP parent ability input aliases
- align the PHP wp-codebox/task-input/v1 schema with runtime-core TASK_INPUT_JSON_SCHEMA
- add a schema parity guard covering TS/PHP task input schema, ability aliases, and recipe docs stable-field lists
- update recipe docs for runtime-core input fields that had drifted from the generated recipe schema

## Verification
- npm run test:schema-parity
- npm run build
- php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification