### PR TITLE
Add shared redaction policy profiles

### DIFF
--- a/packages/runtime-core/src/redaction.ts
+++ b/packages/runtime-core/src/redaction.ts
@@ -1,8 +1,18 @@
 export const REDACTED_VALUE = "[redacted]"
 
+export type RedactionPolicyProfileName = "audit_metadata" | "provider_proxy" | "browser_event" | "public_session_dto"
+
+export interface RedactionPolicyProfile {
+  name: RedactionPolicyProfileName
+  exactKeys: readonly string[]
+  sensitiveKeyTokens: readonly string[]
+  allowedKeys?: readonly string[]
+}
+
 export interface SensitiveKeyOptions {
   pattern?: RegExp
   extraPattern?: RegExp
+  profile?: RedactionPolicyProfileName
 }
 
 export interface RedactJsonOptions extends SensitiveKeyOptions {
@@ -19,7 +29,44 @@ const SENSITIVE_KEY_PATTERN = /(?:secret|token|credential|password|pass|api[_-]?
 const SECRET_LIKE_VALUE_PATTERN = /\b(?:sk-[A-Za-z0-9_-]{20,}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16})\b/
 const SECRET_LIKE_VALUE_GLOBAL_PATTERN = /\b(?:sk-[A-Za-z0-9_-]{20,}|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16})\b/g
 
+const REDACTION_POLICY_PROFILES: Record<RedactionPolicyProfileName, RedactionPolicyProfile> = {
+  audit_metadata: {
+    name: "audit_metadata",
+    exactKeys: ["authorization", "key", "value"],
+    sensitiveKeyTokens: ["secret", "token", "password", "credential", "private_key", "api_key"],
+  },
+  provider_proxy: {
+    name: "provider_proxy",
+    exactKeys: ["authorization", "key", "value"],
+    sensitiveKeyTokens: ["secret", "token", "password", "credential", "private_key", "api_key"],
+  },
+  browser_event: {
+    name: "browser_event",
+    exactKeys: ["authorization"],
+    sensitiveKeyTokens: ["secret", "token", "password", "credential", "private_key", "api_key", "cookie"],
+  },
+  public_session_dto: {
+    name: "public_session_dto",
+    exactKeys: [],
+    sensitiveKeyTokens: ["secret", "token", "password", "private_key", "api_key", "credential"],
+    allowedKeys: ["secret_env", "secretenv", "secret_env_names"],
+  },
+}
+
+export function getRedactionPolicyProfile(profile: RedactionPolicyProfileName): RedactionPolicyProfile {
+  return REDACTION_POLICY_PROFILES[profile]
+}
+
 export function isSensitiveKey(key: string, options: SensitiveKeyOptions = {}): boolean {
+  if (options.profile) {
+    const normalizedKey = key.toLowerCase()
+    const profile = getRedactionPolicyProfile(options.profile)
+    if (profile.allowedKeys?.includes(normalizedKey)) {
+      return false
+    }
+    return profile.exactKeys.includes(normalizedKey) || profile.sensitiveKeyTokens.some((token) => normalizedKey.includes(token)) || Boolean(options.extraPattern?.test(key))
+  }
+
   return (options.pattern ?? SENSITIVE_KEY_PATTERN).test(key) || Boolean(options.extraPattern?.test(key))
 }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-redaction-policy.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-redaction-policy.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Shared redaction policy profiles for WordPress-side DTOs and proxies.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class WP_Codebox_Redaction_Policy {
+	public const REDACTED_VALUE = '[redacted]';
+
+	/** @return array<string,array{exact_keys:array<int,string>,sensitive_key_tokens:array<int,string>,allowed_keys?:array<int,string>}> */
+	private static function profiles(): array {
+		return array(
+			'audit_metadata'      => array(
+				'exact_keys'           => array( 'authorization', 'key', 'value' ),
+				'sensitive_key_tokens' => array( 'secret', 'token', 'password', 'credential', 'private_key', 'api_key' ),
+			),
+			'provider_proxy'      => array(
+				'exact_keys'           => array( 'authorization', 'key', 'value' ),
+				'sensitive_key_tokens' => array( 'secret', 'token', 'password', 'credential', 'private_key', 'api_key' ),
+			),
+			'browser_event'       => array(
+				'exact_keys'           => array( 'authorization' ),
+				'sensitive_key_tokens' => array( 'secret', 'token', 'password', 'credential', 'private_key', 'api_key', 'cookie' ),
+			),
+			'public_session_dto' => array(
+				'exact_keys'           => array(),
+				'sensitive_key_tokens' => array( 'secret', 'token', 'password', 'private_key', 'api_key', 'credential' ),
+				'allowed_keys'          => array( 'secret_env', 'secretenv', 'secret_env_names' ),
+			),
+		);
+	}
+
+	public static function key_should_redact( string $profile_name, string $key ): bool {
+		$profile = self::profiles()[ $profile_name ] ?? null;
+		if ( null === $profile ) {
+			return false;
+		}
+
+		$normalized_key = strtolower( $key );
+		if ( in_array( $normalized_key, $profile['allowed_keys'] ?? array(), true ) ) {
+			return false;
+		}
+
+		if ( in_array( $normalized_key, $profile['exact_keys'], true ) ) {
+			return true;
+		}
+
+		foreach ( $profile['sensitive_key_tokens'] as $token ) {
+			if ( str_contains( $normalized_key, $token ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static function redact_array( string $profile_name, mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		$redacted = array();
+		foreach ( $value as $key => $item ) {
+			if ( self::key_should_redact( $profile_name, (string) $key ) ) {
+				$redacted[ $key ] = self::REDACTED_VALUE;
+				continue;
+			}
+
+			$redacted[ $key ] = self::redact_array( $profile_name, $item );
+		}
+
+		return $redacted;
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -293,7 +293,7 @@ if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) || null === $va
 }
 
 $text = is_scalar( $value ) ? (string) $value : "";
-if ( preg_match( "/authorization|secret|token|password|credential|private_key|api_key|cookie/i", $key ) ) {
+if ( wp_codebox_browser_redaction_key_should_redact( "browser_event", $key ) ) {
 	return "[redacted]";
 }
 if ( preg_match( "/content|message|prompt|response|body|data|argument|output|input/i", $key ) ) {
@@ -304,6 +304,29 @@ if ( strlen( $text ) > 160 ) {
 }
 
 return $text;
+}
+
+function wp_codebox_browser_redaction_key_should_redact( string $profile_name, string $key ): bool {
+$profiles = array(
+	"browser_event" => array(
+		"exact_keys" => array( "authorization" ),
+		"sensitive_key_tokens" => array( "secret", "token", "password", "credential", "private_key", "api_key", "cookie" ),
+	),
+);
+$profile = $profiles[ $profile_name ] ?? null;
+if ( ! is_array( $profile ) ) {
+	return false;
+}
+$normalized_key = strtolower( $key );
+if ( in_array( $normalized_key, $profile["exact_keys"], true ) ) {
+	return true;
+}
+foreach ( $profile["sensitive_key_tokens"] as $token ) {
+	if ( str_contains( $normalized_key, $token ) ) {
+		return true;
+	}
+}
+return false;
 }
 
 function wp_codebox_browser_sanitize_event_value( $value, string $key = "" ) {

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -565,18 +565,7 @@ private static function compact_browser_dto_key_should_omit( string $key ): bool
 }
 
 private static function compact_browser_dto_key_should_redact( string $key ): bool {
-	$normalized = strtolower( $key );
-	if ( in_array( $normalized, array( 'secret_env', 'secretenv', 'secret_env_names' ), true ) ) {
-		return false;
-	}
-
-	foreach ( array( 'secret', 'token', 'password', 'private_key', 'api_key', 'credential' ) as $needle ) {
-		if ( str_contains( $normalized, $needle ) ) {
-			return true;
-		}
-	}
-
-	return false;
+	return WP_Codebox_Redaction_Policy::key_should_redact( 'public_session_dto', $key );
 }
 
 /** @param array<string,mixed> $input Ability input. @param array<string,mixed> $session_envelope Primary browser session envelope. @return array<int,array<string,mixed>>|WP_Error */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-provider-adapter.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-provider-adapter.php
@@ -134,35 +134,6 @@ trait WP_Codebox_Abilities_Provider_Adapter {
 	}
 
 	private static function redact_provider_metadata( mixed $value ): mixed {
-		if ( ! is_array( $value ) ) {
-			return $value;
-		}
-
-		$redacted = array();
-		foreach ( $value as $key => $item ) {
-			$normalized_key = strtolower( (string) $key );
-			if ( self::is_sensitive_provider_metadata_key( $normalized_key ) ) {
-				$redacted[ $key ] = '[redacted]';
-				continue;
-			}
-
-			$redacted[ $key ] = self::redact_provider_metadata( $item );
-		}
-
-		return $redacted;
-	}
-
-	private static function is_sensitive_provider_metadata_key( string $key ): bool {
-		if ( in_array( $key, array( 'authorization', 'key', 'value' ), true ) ) {
-			return true;
-		}
-
-		foreach ( array( 'secret', 'token', 'password', 'credential', 'private_key', 'api_key' ) as $needle ) {
-			if ( str_contains( $key, $needle ) ) {
-				return true;
-			}
-		}
-
-		return false;
+		return WP_Codebox_Redaction_Policy::redact_array( 'provider_proxy', $value );
 	}
 }

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -22,6 +22,7 @@ define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/src/class-wp-codebox-inheritance.php';
+require_once __DIR__ . '/src/class-wp-codebox-redaction-policy.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-request-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-tool-policy-validator.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-recipe-builder.php';

--- a/tests/fixtures/redaction-policy-profiles.json
+++ b/tests/fixtures/redaction-policy-profiles.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "audit_metadata": {
+      "redact": ["authorization", "key", "value", "secret", "session_token", "password", "credential_id", "private_key", "api_key"],
+      "preserve": ["display_name", "model", "provider", "status"]
+    },
+    "provider_proxy": {
+      "redact": ["authorization", "key", "value", "secret", "session_token", "password", "credential_id", "private_key", "api_key"],
+      "preserve": ["display_name", "model", "provider", "status"]
+    },
+    "browser_event": {
+      "redact": ["authorization", "secret", "token", "password", "credential", "private_key", "api_key", "cookie"],
+      "preserve": ["display_name", "model", "provider", "status", "value"]
+    },
+    "public_session_dto": {
+      "redact": ["secret", "token", "password", "private_key", "api_key", "credential"],
+      "preserve": ["display_name", "model", "provider", "status", "secret_env", "secretEnv", "secret_env_names", "authorization", "value"]
+    }
+  }
+}

--- a/tests/redaction-policy-parity.php
+++ b/tests/redaction-policy-parity.php
@@ -1,0 +1,42 @@
+<?php
+define( 'ABSPATH', __DIR__ );
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-redaction-policy.php';
+
+$fixture = json_decode( file_get_contents( __DIR__ . '/fixtures/redaction-policy-profiles.json' ), true );
+if ( ! is_array( $fixture ) || ! is_array( $fixture['profiles'] ?? null ) ) {
+	fwrite( STDERR, "Invalid redaction policy fixture.\n" );
+	exit( 1 );
+}
+
+foreach ( $fixture['profiles'] as $profile => $cases ) {
+	foreach ( $cases['redact'] as $key ) {
+		if ( ! WP_Codebox_Redaction_Policy::key_should_redact( $profile, $key ) ) {
+			fwrite( STDERR, "Expected {$profile} to redact {$key}.\n" );
+			exit( 1 );
+		}
+	}
+
+	foreach ( $cases['preserve'] as $key ) {
+		if ( WP_Codebox_Redaction_Policy::key_should_redact( $profile, $key ) ) {
+			fwrite( STDERR, "Expected {$profile} to preserve {$key}.\n" );
+			exit( 1 );
+		}
+	}
+}
+
+$redacted = WP_Codebox_Redaction_Policy::redact_array(
+	'provider_proxy',
+	array(
+		'provider' => 'generic',
+		'request'  => array(
+			'authorization' => 'Bearer abc',
+			'model'         => 'example',
+		),
+	)
+);
+
+if ( '[redacted]' !== ( $redacted['request']['authorization'] ?? null ) || 'example' !== ( $redacted['request']['model'] ?? null ) ) {
+	fwrite( STDERR, "Provider proxy recursive redaction failed.\n" );
+	exit( 1 );
+}

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
-import { containsSecretLikeValue, isRedactedValue, isSensitiveKey, redactJsonValue, redactString, redactUrl } from "../packages/runtime-core/src/redaction.js"
+import { readFile } from "node:fs/promises"
+import { containsSecretLikeValue, isRedactedValue, isSensitiveKey, redactJsonValue, redactString, redactUrl, type RedactionPolicyProfileName } from "../packages/runtime-core/src/redaction.js"
 
 const sensitiveKeyCases: Array<[string, boolean]> = [
   ["token", true],
@@ -47,3 +48,17 @@ assert.equal(
   redactUrl("https://example.com/path?plain=ok&token=abc#frag"),
   "https://example.com/path?plain=ok&token=[redacted]#frag",
 )
+
+const fixture = JSON.parse(await readFile(new URL("./fixtures/redaction-policy-profiles.json", import.meta.url), "utf8")) as {
+  profiles: Record<RedactionPolicyProfileName, { redact: string[]; preserve: string[] }>
+}
+
+for (const [profile, cases] of Object.entries(fixture.profiles) as Array<[RedactionPolicyProfileName, { redact: string[]; preserve: string[] }]>) {
+  for (const key of cases.redact) {
+    assert.equal(isSensitiveKey(key, { profile }), true, `${profile} should redact ${key}`)
+  }
+
+  for (const key of cases.preserve) {
+    assert.equal(isSensitiveKey(key, { profile }), false, `${profile} should preserve ${key}`)
+  }
+}


### PR DESCRIPTION
## Summary
- Add generic named redaction policy profiles for audit metadata, provider proxy payloads, browser events, and public session DTOs.
- Add PHP and TypeScript parity coverage from a shared fixture.
- Migrate high-value PHP redactors for provider proxy metadata, public browser session DTO compaction, and browser runner event sanitization to profile-based checks without changing their public output shape.

## Tests
- npm run test:redaction
- php tests/redaction-policy-parity.php
- php -l packages/wordpress-plugin/wp-codebox.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-redaction-policy.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-provider-adapter.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
- npm run build
- git diff --check

## Residual gaps
- The browser runner still carries its sandbox-local PHP profile copy because that code is emitted into the disposable Playground runtime; broader deduplication can follow if the sandbox gains a shared runtime include.
- This PR intentionally migrates only the highest-value PHP redactors and leaves deeper artifact/body string redactors unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the redaction profile contract, PHP/TypeScript parity fixtures, targeted migrations, and verification commands; Chris remains responsible for review and merge.