### PR TITLE
Add runtime tool policy resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
     "test:php-managed-host-command": "tsx tests/php-managed-host-command.test.ts",
     "test:mcp-client-configs": "tsx tests/mcp-client-configs.test.ts",
+    "test:runtime-tool-policy": "tsx tests/runtime-tool-policy.test.ts",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",
     "test:php-path-policy-parity": "php scripts/php-path-policy-parity-smoke.php",

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { buildAgentTaskRecipe, DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput, parseCommandJson, parseCommandOptions, type AgentTaskRunInput, type AgentTaskRunResultSummary, type AgentTerminalResult } from "@automattic/wp-codebox-core"
+import { buildAgentTaskRecipe, DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput, parseCommandJson, parseCommandOptions, resolveEffectiveRuntimeToolPolicy, type AgentTaskRunInput, type AgentTaskRunResultSummary, type AgentTerminalResult, type SandboxToolPolicySnapshot } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { runRecipeRunCommand } from "./recipe-run.js"
 
@@ -557,7 +557,8 @@ function agentSandboxRuntime(run: Record<string, unknown>): Record<string, unkno
 }
 
 function sandboxToolIdsBeforeFiltering(policy: Record<string, unknown> | undefined): string[] {
-  return stringArray(arrayRecords(policy?.tools).map((tool) => stringValue(tool.runtime_tool_id) || stringValue(tool.id)))
+  if (!policy || !Array.isArray(policy.tools)) return []
+  return resolveEffectiveRuntimeToolPolicy(policy as unknown as SandboxToolPolicySnapshot).tools.map((tool) => tool.runtimeToolId)
 }
 
 function parseJsonObject(value: string): Record<string, unknown> | undefined {

--- a/packages/runtime-core/src/sandbox-tool-policy.ts
+++ b/packages/runtime-core/src/sandbox-tool-policy.ts
@@ -20,6 +20,7 @@ export interface AgentsApiRuntimeToolMetadata {
 export interface SandboxToolPolicyTool {
   id: string
   runtime_tool_id: string
+  aliases?: string[]
   execution_location: SandboxToolExecutionLocation
   transport_visibility: SandboxToolTransportVisibility
   allowed: boolean
@@ -45,6 +46,33 @@ export interface SandboxToolPolicyIssue {
 export interface SandboxToolPolicyValidationResult {
   valid: boolean
   issues: SandboxToolPolicyIssue[]
+}
+
+export interface RuntimeToolDescriptor {
+  id: string
+  runtimeToolId: string
+  aliases: string[]
+  allowed: boolean
+  executionLocation: SandboxToolExecutionLocation
+  transportVisibility: SandboxToolTransportVisibility
+  visible: boolean
+  parentOnly: boolean
+  hidden: boolean
+  runtime: Required<Pick<AgentsApiRuntimeToolMetadata, typeof AGENTS_API_RUNTIME_ENVIRONMENT | typeof AGENTS_API_RUNTIME_CAPABILITY_SCOPE>>
+  schema?: string
+  policy?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+}
+
+export interface EffectiveRuntimeToolPolicy {
+  schema: typeof SANDBOX_TOOL_POLICY_SCHEMA
+  version: typeof SANDBOX_TOOL_POLICY_VERSION
+  tools: RuntimeToolDescriptor[]
+  allowedRuntimeToolIds: string[]
+  visibleRuntimeToolIds: string[]
+  parentOnlyRuntimeToolIds: string[]
+  hiddenRuntimeToolIds: string[]
+  metadata: Record<string, unknown>
 }
 
 export class SandboxToolPolicyValidationError extends Error {
@@ -132,9 +160,28 @@ export function assertSandboxToolPolicySnapshot(input: unknown): asserts input i
 }
 
 export function sandboxAllowedRuntimeToolIds(policy: SandboxToolPolicySnapshot): string[] {
-  return stringList(policy.tools
-    .filter((tool) => tool.allowed && sandboxToolRuntimeMetadata(tool).environment === AGENTS_API_RUNTIME_LOCAL && sandboxToolRuntimeMetadata(tool).capability_scope === AGENTS_API_RUNTIME_LOCAL)
-    .map((tool) => tool.runtime_tool_id))
+  return resolveEffectiveRuntimeToolPolicy(policy).allowedRuntimeToolIds
+}
+
+export function resolveEffectiveRuntimeToolPolicy(policy: SandboxToolPolicySnapshot): EffectiveRuntimeToolPolicy {
+  const tools = policy.tools.map(runtimeToolDescriptor)
+  return {
+    schema: policy.schema,
+    version: policy.version,
+    tools,
+    allowedRuntimeToolIds: stringList(tools.filter((tool) => tool.allowed && tool.visible).map((tool) => tool.runtimeToolId)),
+    visibleRuntimeToolIds: stringList(tools.filter((tool) => tool.visible).map((tool) => tool.runtimeToolId)),
+    parentOnlyRuntimeToolIds: stringList(tools.filter((tool) => tool.parentOnly).map((tool) => tool.runtimeToolId)),
+    hiddenRuntimeToolIds: stringList(tools.filter((tool) => tool.hidden).map((tool) => tool.runtimeToolId)),
+    metadata: policy.metadata,
+  }
+}
+
+export function resolveRuntimeToolAlias(policy: EffectiveRuntimeToolPolicy | SandboxToolPolicySnapshot, value: string): RuntimeToolDescriptor | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  const effective = "allowedRuntimeToolIds" in policy ? policy : resolveEffectiveRuntimeToolPolicy(policy)
+  return effective.tools.find((tool) => tool.id === trimmed || tool.runtimeToolId === trimmed || tool.aliases.includes(trimmed))
 }
 
 export function sandboxToolRuntimeMetadata(tool: SandboxToolPolicyTool): Required<Pick<AgentsApiRuntimeToolMetadata, typeof AGENTS_API_RUNTIME_ENVIRONMENT | typeof AGENTS_API_RUNTIME_CAPABILITY_SCOPE>> {
@@ -149,5 +196,36 @@ export function sandboxToolRuntimeMetadata(tool: SandboxToolPolicyTool): Require
   return {
     environment,
     capability_scope: capabilityScope,
+  }
+}
+
+function runtimeToolDescriptor(tool: SandboxToolPolicyTool): RuntimeToolDescriptor {
+  const runtime = sandboxToolRuntimeMetadata(tool)
+  const aliases = stringList([
+    tool.id,
+    tool.runtime_tool_id,
+    ...stringList(tool.aliases),
+    ...stringList(isPlainObject(tool.metadata) ? tool.metadata.aliases : undefined),
+  ])
+  const parentOnly = runtime.environment !== AGENTS_API_RUNTIME_LOCAL || runtime.capability_scope !== AGENTS_API_RUNTIME_LOCAL
+  const hidden = tool.transport_visibility === "hidden"
+  const visible = !parentOnly && !hidden && (tool.transport_visibility === "sandbox" || tool.transport_visibility === "both")
+  const schema = typeof tool.metadata?.schema === "string" ? tool.metadata.schema : undefined
+  const policy = isPlainObject(tool.metadata?.policy) ? tool.metadata.policy : undefined
+
+  return {
+    id: tool.id,
+    runtimeToolId: tool.runtime_tool_id,
+    aliases,
+    allowed: tool.allowed,
+    executionLocation: tool.execution_location,
+    transportVisibility: tool.transport_visibility,
+    visible,
+    parentOnly,
+    hidden,
+    runtime,
+    ...(schema ? { schema } : {}),
+    ...(policy ? { policy } : {}),
+    ...(tool.metadata ? { metadata: tool.metadata } : {}),
   }
 }

--- a/tests/runtime-tool-policy.test.ts
+++ b/tests/runtime-tool-policy.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict"
+import { resolveEffectiveRuntimeToolPolicy, resolveRuntimeToolAlias, sandboxAllowedRuntimeToolIds, type SandboxToolPolicySnapshot } from "../packages/runtime-core/src/index.js"
+
+const policy: SandboxToolPolicySnapshot = {
+  schema: "wp-codebox/sandbox-tool-policy/v1",
+  version: 1,
+  tools: [
+    {
+      id: "filesystem-write",
+      runtime_tool_id: "client/filesystem-write",
+      aliases: ["filesystem_write"],
+      execution_location: "sandbox",
+      transport_visibility: "sandbox",
+      allowed: true,
+      runtime: { environment: "runtime_local", capability_scope: "runtime_local" },
+      metadata: {
+        schema: "example/input/v1",
+        aliases: ["write_file"],
+        policy: { permission: "write" },
+      },
+    },
+    {
+      id: "browser-review",
+      runtime_tool_id: "client/browser-review",
+      execution_location: "parent",
+      transport_visibility: "parent",
+      allowed: true,
+      runtime: { environment: "control_plane", capability_scope: "control_plane" },
+    },
+    {
+      id: "internal-token",
+      runtime_tool_id: "client/internal-token",
+      execution_location: "sandbox",
+      transport_visibility: "hidden",
+      allowed: true,
+      runtime: { environment: "runtime_local", capability_scope: "runtime_local" },
+    },
+  ],
+  metadata: { source: "runtime-tool-policy.test" },
+}
+
+const effective = resolveEffectiveRuntimeToolPolicy(policy)
+assert.deepEqual(effective.allowedRuntimeToolIds, ["client/filesystem-write"])
+assert.deepEqual(effective.visibleRuntimeToolIds, ["client/filesystem-write"])
+assert.deepEqual(effective.parentOnlyRuntimeToolIds, ["client/browser-review"])
+assert.deepEqual(effective.hiddenRuntimeToolIds, ["client/internal-token"])
+
+const writeTool = resolveRuntimeToolAlias(effective, "filesystem_write")
+assert.equal(writeTool?.runtimeToolId, "client/filesystem-write")
+assert.equal(writeTool?.schema, "example/input/v1")
+assert.deepEqual(writeTool?.policy, { permission: "write" })
+assert.equal(resolveRuntimeToolAlias(effective, "write_file")?.runtimeToolId, "client/filesystem-write")
+assert.equal(resolveRuntimeToolAlias(policy, "client/browser-review")?.parentOnly, true)
+
+assert.deepEqual(sandboxAllowedRuntimeToolIds(policy), ["client/filesystem-write"])
+
+console.log("runtime tool policy passed")


### PR DESCRIPTION
## Summary
- Add a generic runtime tool descriptor/effective policy resolver for sandbox tool policy snapshots.
- Emit runtime IDs, aliases, visibility, parent-only, hidden, runtime metadata, and schema/policy metadata when present.
- Migrate sandbox allowed-tool ID filtering and agent runtime diagnostics to consume the resolver.
- Add focused coverage for alias translation and effective visibility buckets.

## Tests
- npm run build
- npm run test:runtime-tool-policy
- npm run test:host-command-executor
- npm run test:agent-task-contracts

## Residual gaps
- PHP host-side validation still has its own policy normalization path; this PR keeps that untouched as the safe first slice.
- Browser runner/runtime exposure is not rewritten here; follow-up work can consume the descriptor resolver in those larger surfaces.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the resolver, first callsite migration, focused tests, and PR text for Chris to review.