### PR TITLE
Add browser artifact session primitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test:redaction": "tsx tests/redaction.test.ts",
     "test:agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",
     "test:generic-primitives": "tsx tests/generic-primitives.test.ts",
+    "test:browser-artifact-session": "tsx tests/browser-artifact-session.test.ts",
     "test:browser-provider-permissions": "tsx tests/browser-provider-permissions.test.ts",
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",

--- a/packages/runtime-core/src/artifact-layout.ts
+++ b/packages/runtime-core/src/artifact-layout.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, relative, resolve } from "node:path"
 
-import { artifactManifestFile, refreshArtifactManifestFileSha256s, type ArtifactManifest, type ArtifactManifestFile, type ArtifactViewerMetadata } from "./artifact-manifest.js"
+import { artifactManifestFile, refreshArtifactManifestFileSha256s, type ArtifactManifest, type ArtifactManifestFile, type ArtifactManifestFileOptions, type ArtifactViewerMetadata } from "./artifact-manifest.js"
 import { resolveArtifactPath, safeArtifactRelativePath } from "./artifact-paths.js"
 
 export interface ManifestedArtifactFileInput {
@@ -9,13 +9,19 @@ export interface ManifestedArtifactFileInput {
   kind: ArtifactManifestFile["kind"]
   contentType: string
   viewer?: ArtifactViewerMetadata
+  redaction?: ArtifactManifestFileOptions["redaction"]
+  provenance?: ArtifactManifestFileOptions["provenance"]
 }
 
 export class ManifestedArtifactSet {
   private readonly entries = new Map<string, ArtifactManifestFile>()
 
   add(input: ManifestedArtifactFileInput): ArtifactManifestFile {
-    const entry = artifactManifestFile(input.path, input.kind, input.contentType, undefined, input.viewer)
+    const entry = artifactManifestFile(input.path, input.kind, input.contentType, undefined, {
+      viewer: input.viewer,
+      redaction: input.redaction,
+      provenance: input.provenance,
+    })
     this.entries.set(input.path, entry)
     return entry
   }

--- a/packages/runtime-playground/src/browser-artifact-session.ts
+++ b/packages/runtime-playground/src/browser-artifact-session.ts
@@ -1,0 +1,57 @@
+import { basename, join } from "node:path"
+
+import type { ArtifactProvenanceMetadata } from "@automattic/wp-codebox-core"
+import { ArtifactBundleWriter } from "./artifact-bundle-writer.js"
+import { browserArtifactFileManifest, type BrowserArtifactFiles } from "./browser-artifacts.js"
+
+export class BrowserArtifactSession {
+  readonly writer: ArtifactBundleWriter
+
+  constructor(
+    artifactRoot: string,
+    private readonly browserFilesDirectory: string,
+    private readonly provenance: ArtifactProvenanceMetadata = { source: "browser", operation: "capture-browser-artifact" },
+  ) {
+    this.writer = new ArtifactBundleWriter(artifactRoot)
+  }
+
+  path(fileName: string): string {
+    return join(this.browserFilesDirectory, basename(fileName))
+  }
+
+  absolutePath(fileName: string): string {
+    return this.writer.path(this.path(fileName))
+  }
+
+  async writeText(key: keyof BrowserArtifactFiles, fileName: string, contents: string): Promise<void> {
+    await this.writer.write(this.path(fileName), contents, this.manifest(key))
+  }
+
+  async writeBuffer(key: keyof BrowserArtifactFiles, fileName: string, contents: Buffer): Promise<void> {
+    await this.writer.write(this.path(fileName), contents, this.manifest(key))
+  }
+
+  async writeJson(key: keyof BrowserArtifactFiles, fileName: string, value: unknown): Promise<void> {
+    await this.writer.writeJson(this.path(fileName), value, this.manifestWithoutContentType(key))
+  }
+
+  async writeJsonLines(key: keyof BrowserArtifactFiles, fileName: string, records: unknown[]): Promise<void> {
+    await this.writer.writeJsonLines(this.path(fileName), records, this.manifestWithoutContentType(key))
+  }
+
+  async writeGenerated(key: keyof BrowserArtifactFiles, fileName: string, write: (absolutePath: string) => Promise<void>): Promise<void> {
+    await this.writer.writeGenerated(this.path(fileName), this.manifest(key), write)
+  }
+
+  private manifest(key: keyof BrowserArtifactFiles) {
+    return {
+      ...browserArtifactFileManifest(key),
+      provenance: this.provenance,
+    }
+  }
+
+  private manifestWithoutContentType(key: keyof BrowserArtifactFiles) {
+    const { contentType: _contentType, ...manifest } = this.manifest(key)
+    return manifest
+  }
+}

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path"
-import { artifactManifestFile, type ArtifactManifestFile, type ArtifactReviewBrowserSummary } from "@automattic/wp-codebox-core"
+import { artifactManifestFile, type ArtifactManifestFile, type ArtifactManifestFileOptions, type ArtifactReviewBrowserSummary } from "@automattic/wp-codebox-core"
 import type { Request } from "playwright"
 
 export type BrowserArtifact = BrowserProbeArtifact | BrowserActionsArtifact | BrowserEditorOpenArtifact | BrowserEditorActionsArtifact | BrowserScenarioArtifact | BrowserVisualCompareArtifact
@@ -865,6 +865,12 @@ interface BrowserArtifactFileManifestEntry {
   redact: boolean
 }
 
+export interface BrowserArtifactFileManifestMetadata {
+  kind: string
+  contentType: string
+  redaction?: ArtifactManifestFileOptions["redaction"]
+}
+
 const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, BrowserArtifactFileManifestEntry> = {
   actions: { kind: "browser-actions", contentType: "application/x-ndjson", redact: true },
   editorState: { kind: "browser-editor-state", contentType: "application/json", redact: true },
@@ -888,6 +894,15 @@ const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, Browser
   redirectDiagnostics: { kind: "browser-redirect-diagnostics", contentType: "application/json", redact: true },
   wordpressDiagnostics: { kind: "browser-wordpress-diagnostics", contentType: "application/json", redact: true },
   summary: { kind: "browser-summary", contentType: "application/json", redact: true },
+}
+
+export function browserArtifactFileManifest(key: keyof BrowserArtifactFiles): BrowserArtifactFileManifestMetadata {
+  const entry = BROWSER_ARTIFACT_FILE_MANIFEST[key]
+  return {
+    kind: entry.kind,
+    contentType: entry.contentType,
+    ...(entry.redact ? { redaction: { policy: "required", sensitive: true, reason: "Browser artifacts can include page content, URLs, user data, headers, or runtime diagnostics." } } : { redaction: { policy: "none", sensitive: false } }),
+  }
 }
 
 function browserArtifactFileEntries(probe: BrowserArtifact): Array<{ path: string; manifest: BrowserArtifactFileManifestEntry }> {

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -5,6 +5,7 @@ import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, BROW
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
 import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
+import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeDiagnostic, BrowserEditorCanvasProbeSummary, BrowserEditorCanvasSelectorGroupSummary, BrowserEditorCanvasSelectorSummary, BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserRedirectDiagnosticsSummary, BrowserStepRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
@@ -379,27 +380,14 @@ async function runSingleBrowserProbeCommand({
   const routeTracker = createBrowserPreviewRouteTracker()
   const previewOrigins = browserPreviewOrigins(preview)
   const targetUrl = resolveBrowserPreviewUrl(runPlan.url, preview.effectiveOrigin)
-  const browserDirectory = join(artifactRoot, browserFilesDirectory)
-  await mkdir(browserDirectory, { recursive: true })
+  const artifactSession = new BrowserArtifactSession(artifactRoot, browserFilesDirectory, { source: command, operation: "browser-probe" })
 
   const consoleMessages: Record<string, unknown>[] = []
   const errors: BrowserProbeErrorRecord[] = []
   const network: BrowserProbeNetworkRecord[] = []
   const networkTasks: Array<Promise<void>> = []
   const checkpoints: BrowserProbeCheckpointRecord[] = []
-  const consolePath = join(browserDirectory, "console.jsonl")
-  const checkpointsPath = join(browserDirectory, "checkpoints.jsonl")
-  const errorsPath = join(browserDirectory, "errors.jsonl")
-  const htmlPath = join(browserDirectory, "snapshot.html")
-  const memoryPath = join(browserDirectory, "memory.json")
-  const lifecyclePath = join(browserDirectory, "lifecycle.json")
-  const networkPath = join(browserDirectory, "network.jsonl")
-  const performancePath = join(browserDirectory, "performance.json")
-  const reviewPath = join(browserDirectory, "review.json")
-  const screenshotPath = join(browserDirectory, "screenshot.png")
-  const summaryPath = join(browserDirectory, "summary.json")
-  const redirectDiagnosticsPath = join(browserDirectory, "redirect-diagnostics.json")
-  const wordpressDiagnosticsPath = join(browserDirectory, "wordpress-diagnostics.json")
+  const screenshotPath = artifactSession.absolutePath("screenshot.png")
   const startedAt = now()
   const startedAtMs = Date.now()
   const progress = createBrowserProbeProgressTracker(startedAt, stallTimeoutMs)
@@ -605,7 +593,7 @@ async function runSingleBrowserProbeCommand({
       if (capture.has("html")) {
         try {
           const html = await page.content()
-          await writeFile(htmlPath, html)
+          await artifactSession.writeText("html", "snapshot.html", html)
           htmlSha256 = sha256(Buffer.from(html, "utf8"))
         } catch (error) {
           errors.push(serializeBrowserError("probe-error", error))
@@ -614,7 +602,8 @@ async function runSingleBrowserProbeCommand({
 
       if (capture.has("screenshot")) {
         try {
-          await page.screenshot({ path: screenshotPath, fullPage: true })
+          const activePage = page
+          await artifactSession.writeGenerated("screenshot", "screenshot.png", (path) => activePage.screenshot({ path, fullPage: true }).then(() => undefined))
           screenshotSha256 = await fileSha256(screenshotPath)
         } catch (error) {
           errors.push(serializeBrowserError("probe-error", error))
@@ -624,25 +613,25 @@ async function runSingleBrowserProbeCommand({
     await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
     await browser.close()
     if (capture.has("console") || capturesConsoleForAssertions) {
-      await writeFile(consolePath, jsonLines(consoleMessages))
+      await artifactSession.writeJsonLines("console", "console.jsonl", consoleMessages)
     }
     if (capture.has("errors") || capturesErrorsForAssertions) {
-      await writeFile(errorsPath, jsonLines(errors))
+      await artifactSession.writeJsonLines("errors", "errors.jsonl", errors)
     }
     if (capture.has("network") || capturesNetworkForAssertions) {
-      await writeFile(networkPath, jsonLines(network))
+      await artifactSession.writeJsonLines("network", "network.jsonl", network)
     }
     if (checkpoints.length > 0) {
-      await writeFile(checkpointsPath, jsonLines(checkpoints))
+      await artifactSession.writeJsonLines("checkpoints", "checkpoints.jsonl", checkpoints)
     }
     if (memoryArtifact) {
-      await writeFile(memoryPath, `${JSON.stringify(memoryArtifact, null, 2)}\n`)
+      await artifactSession.writeJson("memory", "memory.json", memoryArtifact)
     }
     if (lifecycleArtifact) {
-      await writeFile(lifecyclePath, `${JSON.stringify(lifecycleArtifact, null, 2)}\n`)
+      await artifactSession.writeJson("lifecycle", "lifecycle.json", lifecycleArtifact)
     }
     if (performanceArtifact) {
-      await writeFile(performancePath, `${JSON.stringify(performanceArtifact, null, 2)}\n`)
+      await artifactSession.writeJson("performance", "performance.json", performanceArtifact)
     }
 
     const redirectDiagnostics = browserRedirectDiagnosticsArtifact({
@@ -653,7 +642,7 @@ async function runSingleBrowserProbeCommand({
       requestedUrl: targetUrl,
     })
     if (redirectDiagnostics) {
-      await writeFile(redirectDiagnosticsPath, `${JSON.stringify(redirectDiagnostics, null, 2)}\n`)
+      await artifactSession.writeJson("redirectDiagnostics", "redirect-diagnostics.json", redirectDiagnostics)
     }
     const redirectDiagnosticsSummary = redirectDiagnostics?.summary
 
@@ -664,7 +653,7 @@ async function runSingleBrowserProbeCommand({
       server,
     })
     if (wordpressDiagnostics) {
-      await writeFile(wordpressDiagnosticsPath, `${JSON.stringify(wordpressDiagnostics, null, 2)}\n`)
+      await artifactSession.writeJson("wordpressDiagnostics", "wordpress-diagnostics.json", wordpressDiagnostics)
     }
     const wordpressDiagnosticsSummary = wordpressDiagnostics?.summary
 
@@ -712,7 +701,7 @@ async function runSingleBrowserProbeCommand({
       redirectDiagnostics: redirectDiagnosticsSummary,
       wordpressDiagnostics: wordpressDiagnosticsSummary,
     })
-    await writeFile(reviewPath, `${JSON.stringify(review, null, 2)}\n`)
+    await artifactSession.writeJson("review", "review.json", review)
 
     artifact = {
       artifactType: "probe",
@@ -765,7 +754,7 @@ async function runSingleBrowserProbeCommand({
         viewport,
       },
     }
-    await writeFile(summaryPath, `${JSON.stringify({
+    await artifactSession.writeJson("summary", "summary.json", {
       schema: "wp-codebox/browser-probe/v1",
       requestedUrl: targetUrl,
       preview,
@@ -796,7 +785,7 @@ async function runSingleBrowserProbeCommand({
       ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
       viewport,
       summary: artifact.summary,
-    }, null, 2)}\n`)
+    })
   }
 
   abortSignal?.removeEventListener("abort", abortHandler)

--- a/tests/browser-artifact-session.test.ts
+++ b/tests/browser-artifact-session.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict"
+import { mkdtempSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { resolve } from "node:path"
+
+import { BrowserArtifactSession } from "../packages/runtime-playground/src/browser-artifact-session.js"
+
+const artifactRoot = mkdtempSync(resolve(tmpdir(), "wp-codebox-browser-artifact-session-"))
+const session = new BrowserArtifactSession(artifactRoot, "files/browser", { source: "wordpress.browser-probe", operation: "browser-probe" })
+
+assert.equal(session.path("snapshot.html"), "files/browser/snapshot.html")
+assert.equal(session.path("/tmp/snapshot.html"), "files/browser/snapshot.html")
+
+await session.writeText("html", "snapshot.html", "<html><body>secret</body></html>")
+await session.writeJsonLines("console", "console.jsonl", [{ type: "log", text: "visible" }])
+await session.writeJson("summary", "summary.json", { schema: "wp-codebox/browser-probe/v1", ok: true })
+await session.writeBuffer("screenshot", "screenshot.png", Buffer.from([0, 1, 2]))
+
+assert.equal(await readFile(resolve(artifactRoot, "files/browser/snapshot.html"), "utf8"), "<html><body>secret</body></html>")
+assert.equal(await readFile(resolve(artifactRoot, "files/browser/console.jsonl"), "utf8"), '{"type":"log","text":"visible"}\n')
+assert.equal(await readFile(resolve(artifactRoot, "files/browser/summary.json"), "utf8"), '{\n  "schema": "wp-codebox/browser-probe/v1",\n  "ok": true\n}\n')
+
+const files = new Map(session.writer.artifacts.files().map((file) => [file.path, file]))
+
+assert.equal(files.get("files/browser/snapshot.html")?.kind, "browser-html-snapshot")
+assert.equal(files.get("files/browser/snapshot.html")?.contentType, "text/html; charset=utf-8")
+assert.deepEqual(files.get("files/browser/snapshot.html")?.redaction, {
+  policy: "required",
+  sensitive: true,
+  reason: "Browser artifacts can include page content, URLs, user data, headers, or runtime diagnostics.",
+})
+assert.deepEqual(files.get("files/browser/snapshot.html")?.provenance, { source: "wordpress.browser-probe", operation: "browser-probe" })
+
+assert.equal(files.get("files/browser/console.jsonl")?.kind, "browser-console")
+assert.equal(files.get("files/browser/console.jsonl")?.contentType, "application/x-ndjson")
+assert.equal(files.get("files/browser/console.jsonl")?.redaction?.policy, "required")
+
+assert.equal(files.get("files/browser/screenshot.png")?.kind, "browser-screenshot")
+assert.equal(files.get("files/browser/screenshot.png")?.contentType, "image/png")
+assert.deepEqual(files.get("files/browser/screenshot.png")?.redaction, { policy: "none", sensitive: false })


### PR DESCRIPTION
## Summary
- Add a BrowserArtifactSession wrapper over the browser artifact registry and ArtifactBundleWriter.
- Preserve existing browser-probe artifact paths/schema while routing its writes through the session primitive.
- Carry registry-derived redaction metadata and command provenance into writer manifest entries.
- Add focused coverage for path preservation and browser artifact metadata.

## Tests
- npm run test:browser-artifact-session
- npm run test:generic-primitives
- npm run build

## Residual gaps
- This migrates only wordpress.browser-probe as the first proving slice; browser-actions, editor, scenario, and visual-compare still have direct artifact writes.
- Runtime bundle manifest assembly still uses the existing browser artifact registry path; the new session writer metadata is now available for migrated paths and can be wired into broader manifest assembly in a follow-up.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the first browser artifact session slice, migrated browser-probe writes, and added targeted tests; Chris remains responsible for review and validation.