### PR TITLE
Align PHP path policy with runtime core

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
+    "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",
+    "test:php-path-policy-parity": "php scripts/php-path-policy-parity-smoke.php",
     "check": "npm run smoke -- --group=check"
   },
   "workspaces": [

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { assertWorkspaceRecipeJsonSchema, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS, commandArgValue, parseCommandJson, validateBrowserInteractionScript, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { assertWorkspaceRecipeJsonSchema, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS, commandArgValue, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
 import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandIds, listCliRuntimeBackendKinds } from "./runtime-backends.js"
@@ -340,6 +340,12 @@ function validateRecipeMounts(mounts: WorkspaceRecipeMount[] | undefined, label:
   for (const mount of mounts ?? []) {
     if (!mount.source || !mount.target) {
       throw new Error(`Recipe ${label} mounts must include source and target: ${recipePath}`)
+    }
+
+    try {
+      normalizeRuntimeMountTarget(mount.target, `Recipe ${label} mount`)
+    } catch (error) {
+      throw new Error(`${error instanceof Error ? error.message : String(error)}: ${recipePath}`)
     }
 
     if (mount.type && mount.type !== "directory" && mount.type !== "file") {
@@ -713,7 +719,12 @@ function validateDistributionScalar(value: unknown, path: string, addIssue: (cod
 }
 
 function isRelativeArtifactPath(path: string): boolean {
-  return path.length > 0 && !path.startsWith("/") && !path.includes("..")
+  try {
+    safeArtifactRelativePath(path)
+    return true
+  } catch {
+    return false
+  }
 }
 
 export function recipeWorkflowSteps(recipe: WorkspaceRecipe): Array<{ phase: Exclude<RecipeWorkflowPhase, "setup">; index: number; step: WorkspaceRecipe["workflow"]["steps"][number] }> {
@@ -1413,8 +1424,10 @@ async function validateExistingMountSource(path: string, type: MountSpec["type"]
 }
 
 function validateAbsoluteSandboxPath(path: string, issuePath: string, addIssue: (code: string, path: string, message: string) => void): void {
-  if (!path.startsWith("/")) {
-    addIssue("invalid-sandbox-path", issuePath, `Sandbox paths must be absolute: ${path}`)
+  try {
+    normalizeRuntimeMountTarget(path, "Sandbox path")
+  } catch (error) {
+    addIssue("invalid-sandbox-path", issuePath, error instanceof Error ? error.message : String(error))
   }
 }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1808,13 +1808,13 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			}
 
 			$source = $this->clean_path( (string) ( $mount['source'] ?? '' ) );
-			$target = trim( (string) ( $mount['target'] ?? '' ) );
+			$target = WP_Codebox_Path_Policy::normalize_sandbox_mount_target( (string) ( $mount['target'] ?? '' ), 'WP Codebox mount ' . $index, 'wp_codebox_mount_target_invalid', array( 'index' => $index ) );
 			if ( '' === $source || ( ! is_dir( $source ) && ! is_file( $source ) ) ) {
 				return new WP_Error( 'wp_codebox_mount_source_invalid', 'WP Codebox mount source must be an existing file or directory.', array( 'status' => 400, 'index' => $index ) );
 			}
 
-			if ( '' === $target || ! str_starts_with( $target, '/' ) ) {
-				return new WP_Error( 'wp_codebox_mount_target_invalid', 'WP Codebox mount target must be an absolute sandbox path.', array( 'status' => 400, 'index' => $index ) );
+			if ( is_wp_error( $target ) ) {
+				return $target;
 			}
 
 			$mode = (string) ( $mount['mode'] ?? 'readwrite' );
@@ -1869,6 +1869,9 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		);
 
 		$stack_mounts = $this->runtime_stack_mounts( $input );
+		if ( is_wp_error( $stack_mounts ) ) {
+			return $stack_mounts;
+		}
 		if ( ! empty( $stack_mounts ) ) {
 			$runtime['stack'] = array( 'mounts' => $stack_mounts );
 		}
@@ -1881,8 +1884,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return $runtime;
 	}
 
-	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>> */
-	private function runtime_stack_mounts( array $input ): array {
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
+	private function runtime_stack_mounts( array $input ): array|WP_Error {
 		$mounts = $this->merge_array_lists(
 			$input['runtime_stack_mounts'] ?? array(),
 			$input['runtime_config_mounts'] ?? array(),
@@ -1891,19 +1894,22 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$input['runtimeStateMounts'] ?? array()
 		);
 
-		return array_values(
-			array_map(
-				function ( array $mount ): array {
-					if ( ! isset( $mount['metadata'] ) || ! is_array( $mount['metadata'] ) ) {
-						$mount['metadata'] = array();
-					}
-					$mount['metadata'] = array_merge( array( 'kind' => 'runtime-state-mount' ), $mount['metadata'] );
+		$normalized = array();
+		foreach ( $mounts as $index => $mount ) {
+			$target = WP_Codebox_Path_Policy::normalize_sandbox_mount_target( (string) ( $mount['target'] ?? '' ), 'Runtime stack mount ' . $index, 'wp_codebox_runtime_mount_target_invalid', array( 'index' => $index ) );
+			if ( is_wp_error( $target ) ) {
+				return $target;
+			}
 
-					return $mount;
-				},
-				$mounts
-			)
-		);
+			$mount['target'] = $target;
+			if ( ! isset( $mount['metadata'] ) || ! is_array( $mount['metadata'] ) ) {
+				$mount['metadata'] = array();
+			}
+			$mount['metadata'] = array_merge( array( 'kind' => 'runtime-state-mount' ), $mount['metadata'] );
+			$normalized[] = $mount;
+		}
+
+		return $normalized;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,string> */

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -209,8 +209,13 @@ final class WP_Codebox_Artifacts {
 		$manifest_files = array();
 
 		foreach ( $files as $file ) {
-			$artifact_path = 'files/browser/' . $file['path'];
-			$target_path   = $tmp . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $artifact_path );
+			$artifact_path = WP_Codebox_Path_Policy::normalize_artifact_relative_path( 'files/browser/' . $file['path'], 'Browser artifact file', 'wp_codebox_browser_artifact_path_invalid' );
+			if ( is_wp_error( $artifact_path ) ) {
+				$this->remove_directory( $tmp );
+				return $artifact_path;
+			}
+
+			$target_path   = $this->resolve_artifact_file( $tmp, $artifact_path );
 			$target_dir    = dirname( $target_path );
 			if ( ! is_dir( $target_dir ) && ! $this->mkdir_p( $target_dir ) ) {
 				$this->remove_directory( $tmp );
@@ -891,7 +896,7 @@ final class WP_Codebox_Artifacts {
 	}
 
 	private function normalize_browser_bundle_root( string $root ): string|WP_Error {
-		$root = rtrim( trim( str_replace( '\\', '/', $root ) ), '/' );
+		$root = trim( str_replace( '\\', '/', $root ) );
 		if ( '' === $root ) {
 			return '';
 		}
@@ -919,22 +924,17 @@ final class WP_Codebox_Artifacts {
 	}
 
 	private function validate_browser_bundle_file_path( string $path, int $index ): string|WP_Error {
-		if ( '' === $path || str_starts_with( $path, '/' ) || ! preg_match( '#^[A-Za-z0-9_./-]+$#', $path ) ) {
-			return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must be safe relative paths.', array( 'status' => 400, 'index' => $index, 'path' => $path ) );
+		$normalized = WP_Codebox_Path_Policy::normalize_artifact_relative_path( $path, 'Browser artifact file path', 'wp_codebox_browser_artifact_path_invalid', array( 'index' => $index ) );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
 
-		foreach ( explode( '/', $path ) as $segment ) {
-			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
-				return new WP_Error( 'wp_codebox_browser_artifact_path_invalid', 'Browser artifact file paths must not contain empty, current-directory, or parent-directory segments.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'segment' => $segment ) );
-			}
-		}
-
-		$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+		$extension = strtolower( pathinfo( $normalized, PATHINFO_EXTENSION ) );
 		if ( in_array( $extension, array( 'php', 'phtml', 'phar', 'cgi', 'pl', 'py', 'rb', 'asp', 'aspx', 'jsp' ), true ) ) {
-			return new WP_Error( 'wp_codebox_browser_artifact_extension_blocked', 'Browser artifact files must not use executable server-side extensions.', array( 'status' => 400, 'index' => $index, 'path' => $path, 'extension' => $extension ) );
+			return new WP_Error( 'wp_codebox_browser_artifact_extension_blocked', 'Browser artifact files must not use executable server-side extensions.', array( 'status' => 400, 'index' => $index, 'path' => $normalized, 'extension' => $extension ) );
 		}
 
-		return $path;
+		return $normalized;
 	}
 
 	private function browser_bundle_mime_type( string $path ): string {
@@ -1315,7 +1315,12 @@ final class WP_Codebox_Artifacts {
 	}
 
 	private function resolve_artifact_file( string $directory, string $relative_path ): string {
-		$path = $directory . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $relative_path );
+		$relative_path = WP_Codebox_Path_Policy::normalize_artifact_relative_path( $relative_path );
+		if ( is_wp_error( $relative_path ) ) {
+			return '';
+		}
+
+		$path = rtrim( $directory, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $relative_path );
 		$real = realpath( $path );
 
 		return false !== $real ? $real : $path;

--- a/packages/wordpress-plugin/src/class-wp-codebox-path-policy.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-path-policy.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Shared PHP mirror of runtime-core path policy primitives.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Path_Policy {
+
+	/** @param array<string,mixed> $data Additional error data. */
+	public static function normalize_sandbox_mount_target( string $target, string $label = 'Sandbox mount', string $error_code = 'wp_codebox_mount_target_invalid', array $data = array() ): string|WP_Error {
+		$normalized = preg_replace( '#/+#', '/', trim( str_replace( '\\', '/', $target ) ) );
+		$normalized = is_string( $normalized ) ? $normalized : '';
+		if ( '' === $normalized ) {
+			return self::error( $error_code, $label . ' requires target.', $data + array( 'target' => $target ) );
+		}
+
+		if ( ! str_starts_with( $normalized, '/' ) ) {
+			return self::error( $error_code, $label . ' requires an absolute target.', $data + array( 'target' => $target ) );
+		}
+
+		$segments = array_values( array_filter( explode( '/', $normalized ), static fn( string $segment ): bool => '' !== $segment ) );
+		foreach ( $segments as $segment ) {
+			if ( '.' === $segment || '..' === $segment ) {
+				return self::error( $error_code, $label . ' target must not contain current-directory or parent-directory segments.', $data + array( 'target' => $target, 'segment' => $segment ) );
+			}
+		}
+
+		return empty( $segments ) ? '/' : '/' . implode( '/', $segments );
+	}
+
+	/** @param array<string,mixed> $data Additional error data. */
+	public static function normalize_artifact_relative_path( string $path, string $label = 'Artifact path', string $error_code = 'wp_codebox_artifact_path_invalid', array $data = array() ): string|WP_Error {
+		$normalized = trim( str_replace( '\\', '/', $path ) );
+		if ( '' === $normalized || 1 === preg_match( '/^[A-Za-z]:(?:$|\/)/', $normalized ) ) {
+			return self::error( $error_code, $label . ' must be a relative path inside the artifact root.', $data + array( 'path' => $path ) );
+		}
+
+		$segments = array_values( array_filter( explode( '/', $normalized ), static fn( string $segment ): bool => '' !== $segment ) );
+		if ( empty( $segments ) ) {
+			return self::error( $error_code, $label . ' must be a relative path inside the artifact root.', $data + array( 'path' => $path ) );
+		}
+
+		foreach ( $segments as $segment ) {
+			if ( '.' === $segment || '..' === $segment ) {
+				return self::error( $error_code, $label . ' must be a relative path without current-directory or parent-directory segments.', $data + array( 'path' => $path, 'segment' => $segment ) );
+			}
+		}
+
+		return implode( '/', $segments );
+	}
+
+	/** @param array<string,mixed> $data Error data. */
+	private static function error( string $code, string $message, array $data ): WP_Error {
+		return new WP_Error( $code, $message, array_merge( array( 'status' => 400 ), $data ) );
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -20,6 +20,7 @@ define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/src/class-wp-codebox-path-policy.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/src/class-wp-codebox-inheritance.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-request-normalizer.php';

--- a/scripts/php-path-policy-parity-smoke.php
+++ b/scripts/php-path-policy-parity-smoke.php
@@ -1,0 +1,66 @@
+<?php
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	/** @var array<string,mixed> */
+	private array $data;
+
+	/** @param array<string,mixed> $data */
+	public function __construct( string $code = '', string $message = '', array $data = array() ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	/** @return array<string,mixed> */
+	public function get_error_data(): array {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-path-policy.php';
+
+function assert_same( mixed $expected, mixed $actual, string $label ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $label . ' failed: expected ' . var_export( $expected, true ) . ', got ' . var_export( $actual, true ) . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+function assert_error( mixed $actual, string $label ): void {
+	if ( ! is_wp_error( $actual ) ) {
+		fwrite( STDERR, $label . ' failed: expected WP_Error, got ' . var_export( $actual, true ) . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+assert_same( 'files/output.json', WP_Codebox_Path_Policy::normalize_artifact_relative_path( '/files//output.json' ), 'artifact leading slash and slash collapse' );
+assert_same( 'files/windows/path.json', WP_Codebox_Path_Policy::normalize_artifact_relative_path( 'files\\windows/path.json' ), 'artifact backslash normalization' );
+assert_error( WP_Codebox_Path_Policy::normalize_artifact_relative_path( './files/output.json' ), 'artifact current-directory segment' );
+assert_error( WP_Codebox_Path_Policy::normalize_artifact_relative_path( 'files/../secret.txt' ), 'artifact parent-directory segment' );
+assert_error( WP_Codebox_Path_Policy::normalize_artifact_relative_path( 'C:/tmp/output.json' ), 'artifact drive absolute path' );
+assert_error( WP_Codebox_Path_Policy::normalize_artifact_relative_path( '' ), 'artifact empty path' );
+
+assert_same( '/wordpress/wp-content/plugins/plugin', WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '//wordpress//wp-content/plugins/plugin' ), 'mount slash collapse' );
+assert_same( '/wordpress/wp-content/plugins/plugin', WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '\\wordpress\\wp-content/plugins/plugin' ), 'mount backslash normalization' );
+assert_same( '/', WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '///' ), 'mount root target' );
+assert_error( WP_Codebox_Path_Policy::normalize_sandbox_mount_target( 'wordpress/wp-content/plugins/plugin' ), 'mount relative target' );
+assert_error( WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '/wordpress/./plugins/plugin' ), 'mount current-directory segment' );
+assert_error( WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '/wordpress/../escape' ), 'mount parent-directory segment' );
+
+fwrite( STDOUT, "PHP path policy parity smoke passed\n" );

--- a/tests/path-policy-parity.test.ts
+++ b/tests/path-policy-parity.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { resolve } from "node:path"
+import { normalizeRuntimeMountTarget, safeArtifactRelativePath } from "../packages/runtime-core/src/index.js"
+import { parseWorkspaceRecipe, validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.js"
+
+assert.equal(normalizeRuntimeMountTarget("//wordpress//wp-content/plugins/plugin"), "/wordpress/wp-content/plugins/plugin")
+assert.throws(() => normalizeRuntimeMountTarget("/wordpress/../escape"), /parent-directory/)
+assert.equal(safeArtifactRelativePath("/files//output.json"), "files/output.json")
+assert.throws(() => safeArtifactRelativePath("files/../secret.txt"), /parent-directory/)
+
+const source = mkdtempSync(resolve(tmpdir(), "wp-codebox-path-policy-source-"))
+const recipePath = resolve(source, "recipe.json")
+const recipe = parseWorkspaceRecipe(JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: { stack: { mounts: [{ source, target: "//runtime//state" }] } },
+  inputs: { mounts: [{ source, target: "//wordpress//wp-content/plugins/plugin" }] },
+  distribution: {
+    name: "path-policy",
+    wordpress: { root: "/wordpress" },
+    artifacts: [{ path: "/files//summary.json" }],
+  },
+  workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+}), recipePath)
+
+assert.deepEqual(await validateWorkspaceRecipeSemantics(recipe, recipePath), [])
+assert.throws(() => parseWorkspaceRecipe(JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: { mounts: [{ source, target: "/wordpress/../escape" }] },
+  workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+}), recipePath), /parent-directory/)
+
+const artifactTraversalRecipe = parseWorkspaceRecipe(JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  distribution: {
+    name: "path-policy",
+    wordpress: { root: "/wordpress" },
+    artifacts: [{ path: "files/../secret.json" }],
+  },
+  workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+}), recipePath)
+const traversalIssues = await validateWorkspaceRecipeSemantics(artifactTraversalRecipe, recipePath)
+assert.equal(traversalIssues[0]?.code, "invalid-distribution-artifact")


### PR DESCRIPTION
## Summary
- Add a shared PHP path policy mirror for runtime-core artifact-relative paths and sandbox mount targets.
- Apply the policy to PHP host recipe mounts, runtime stack mounts, browser artifact normalization, and artifact file resolution.
- Align CLI validation with runtime-core primitives for sandbox paths and artifact-relative paths.
- Add TS/PHP parity tests covering slash collapsing, dot segments, absolute/relative artifact paths, and traversal attempts.

## Tests
- `npm run test:path-policy-parity`
- `npm run test:php-path-policy-parity`
- `npm run test:generic-primitives`
- `npm run test:schema-parity`
- `npm run build`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-path-policy.php && php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php && php -l scripts/php-path-policy-parity-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the PHP path policy mirror, migrated scoped validation/callsites, and added parity tests; Chris remains responsible for review and merge.