### PR TITLE
Consolidate PHP host command callsites

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:browser-provider-permissions": "tsx tests/browser-provider-permissions.test.ts",
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
+    "test:php-managed-host-command": "tsx tests/php-managed-host-command.test.ts",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "check": "npm run smoke -- --group=check"
   },

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -2008,17 +2008,15 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			return is_string( $resolved ) ? $resolved : '';
 		}
 
-		if ( ! function_exists( 'exec' ) ) {
-			return '';
+		$paths = explode( PATH_SEPARATOR, (string) getenv( 'PATH' ) );
+		foreach ( $paths as $path ) {
+			$candidate = rtrim( $path, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . $command;
+			if ( is_file( $candidate ) && is_executable( $candidate ) ) {
+				return $candidate;
+			}
 		}
 
-		$output = array();
-		$exit   = 1;
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Used for executable preflight only.
-		exec( 'command -v ' . escapeshellarg( $command ) . ' 2>/dev/null', $output, $exit );
-		$resolved = 0 === $exit && ! empty( $output[0] ) ? (string) $output[0] : '';
-
-		return '' !== $resolved && is_executable( $resolved ) ? $resolved : '';
+		return '';
 	}
 
 	/**

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -1219,26 +1219,26 @@ final class WP_Codebox_Artifacts {
 			return new WP_Error( 'wp_codebox_artifact_directory_missing', 'Artifact bundle directory is missing.', array( 'status' => 400 ) );
 		}
 
-		if ( ! function_exists( 'exec' ) ) {
-			return $this->artifact_verifier_unavailable( 'Shell execution is not available for WP Codebox artifact verification.' );
-		}
-
 		$bin = trim( (string) ( $input['wp_codebox_bin'] ?? $this->default_bin() ) );
 		if ( '' === $bin || ! preg_match( '#^[A-Za-z0-9_./:@+-]+$#', $bin ) ) {
 			return new WP_Error( 'wp_codebox_bin_invalid', 'wp_codebox_bin must be a command name or path without shell metacharacters.', array( 'status' => 400 ) );
 		}
 
-		$command = sprintf(
-			'%s artifacts verify --bundle %s --json',
-			$this->command_prefix( $bin ),
-			escapeshellarg( $directory )
+		$result = WP_Codebox_Managed_Host_Command::run(
+			array(
+				'command'          => $this->artifact_verifier_command( $bin, $directory ),
+				'cwd'              => $directory,
+				'allowed_cwd_roots' => array( $directory ),
+				'timeout_seconds'  => 60,
+				'max_output_bytes' => 262144,
+			)
 		);
+		if ( is_wp_error( $result ) ) {
+			return $this->artifact_verifier_unavailable( $result->get_error_message(), array( 'error' => $result->get_error_data() ) );
+		}
 
-		$output = array();
-		$exit   = 0;
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- Required to delegate to the packaged generic artifact verifier.
-		exec( $command . ' 2>&1', $output, $exit );
-		$raw     = implode( "\n", $output );
+		$exit    = (int) $result['exit_code'];
+		$raw     = trim( (string) $result['stdout'] . ( '' !== (string) $result['stderr'] ? "\n" . (string) $result['stderr'] : '' ) );
 		$decoded = json_decode( $raw, true );
 
 		if ( ! is_array( $decoded ) ) {
@@ -1298,12 +1298,13 @@ final class WP_Codebox_Artifacts {
 		return $bin;
 	}
 
-	private function command_prefix( string $bin ): string {
+	/** @return string[] */
+	private function artifact_verifier_command( string $bin, string $directory ): array {
 		if ( str_ends_with( $bin, '.js' ) && is_file( $bin ) ) {
-			return 'node ' . escapeshellarg( $bin );
+			return WP_Codebox_Managed_Host_Command::command( 'node', array( $bin, 'artifacts', 'verify', '--bundle', $directory, '--json' ) );
 		}
 
-		return escapeshellarg( $bin );
+		return WP_Codebox_Managed_Host_Command::command( $bin, array( 'artifacts', 'verify', '--bundle', $directory, '--json' ) );
 	}
 
 	private function bound_output( string $output ): string {

--- a/packages/wordpress-plugin/src/class-wp-codebox-managed-host-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-managed-host-command.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Managed host command primitive for PHP callsites.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Managed_Host_Command {
+
+	/** @return array<string,mixed> */
+	public static function run( array $config ): array|WP_Error {
+		$command = self::string_list( $config['command'] ?? array() );
+		if ( empty( $command ) || '' === $command[0] ) {
+			return new WP_Error( 'wp_codebox_managed_host_command_invalid', 'Managed host command requires a command argv list.', array( 'status' => 400 ) );
+		}
+
+		if ( ! function_exists( 'proc_open' ) ) {
+			return new WP_Error( 'wp_codebox_managed_host_command_unavailable', 'Managed host command execution requires proc_open support.', array( 'status' => 500 ) );
+		}
+
+		$cwd = self::resolve_cwd( (string) ( $config['cwd'] ?? getcwd() ), self::string_list( $config['allowed_cwd_roots'] ?? array() ) );
+		if ( $cwd instanceof WP_Error ) {
+			return $cwd;
+		}
+
+		$timeout_seconds  = max( 1, min( 3600, (int) ( $config['timeout_seconds'] ?? 60 ) ) );
+		$max_output_bytes = max( 1024, min( 10485760, (int) ( $config['max_output_bytes'] ?? 262144 ) ) );
+		$env              = self::environment( is_array( $config['env'] ?? null ) ? $config['env'] : array() );
+		$started          = microtime( true );
+		$process          = proc_open(
+			$command,
+			array(
+				1 => array( 'pipe', 'w' ),
+				2 => array( 'pipe', 'w' ),
+			),
+			$pipes,
+			$cwd,
+			$env
+		);
+
+		if ( ! is_resource( $process ) ) {
+			return new WP_Error( 'wp_codebox_managed_host_command_failed', 'Failed to start managed host command.', array( 'status' => 500 ) );
+		}
+
+		foreach ( $pipes as $pipe ) {
+			stream_set_blocking( $pipe, false );
+		}
+
+		$stdout           = '';
+		$stderr           = '';
+		$timed_out        = false;
+		$status_exit_code = null;
+		while ( true ) {
+			$status = proc_get_status( $process );
+			$stdout = self::append_bounded_output( $stdout, stream_get_contents( $pipes[1] ), $max_output_bytes );
+			$stderr = self::append_bounded_output( $stderr, stream_get_contents( $pipes[2] ), $max_output_bytes );
+
+			if ( ! (bool) ( $status['running'] ?? false ) ) {
+				$status_exit_code = is_int( $status['exitcode'] ?? null ) ? (int) $status['exitcode'] : null;
+				break;
+			}
+
+			if ( microtime( true ) - $started >= $timeout_seconds ) {
+				$timed_out = true;
+				proc_terminate( $process );
+				break;
+			}
+
+			usleep( 10000 );
+		}
+
+		$stdout = self::append_bounded_output( $stdout, stream_get_contents( $pipes[1] ), $max_output_bytes );
+		$stderr = self::append_bounded_output( $stderr, stream_get_contents( $pipes[2] ), $max_output_bytes );
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
+		$closed_exit_code = proc_close( $process );
+		$exit_code        = -1 !== $closed_exit_code ? $closed_exit_code : ( $status_exit_code ?? $closed_exit_code );
+
+		return array(
+			'success'          => ! $timed_out && 0 === $exit_code,
+			'command'          => $command[0],
+			'args'             => array_slice( $command, 1 ),
+			'cwd'              => $cwd,
+			'exit_code'        => $exit_code,
+			'stdout'           => trim( $stdout ),
+			'stderr'           => trim( $stderr ),
+			'elapsed_ms'       => ( microtime( true ) - $started ) * 1000,
+			'timed_out'        => $timed_out,
+			'output_truncated' => strlen( $stdout ) >= $max_output_bytes || strlen( $stderr ) >= $max_output_bytes,
+		);
+	}
+
+	/** @return string[] */
+	public static function command( string $executable, array $args = array() ): array {
+		return array_merge( array( $executable ), self::string_list( $args ) );
+	}
+
+	/** @return string[] */
+	public static function split_command_line( string $command ): array {
+		$tokens = str_getcsv( $command, ' ', '"', '\\' );
+
+		return array_values( array_filter( array_map( 'strval', $tokens ), static fn( string $token ): bool => '' !== $token ) );
+	}
+
+	/** @return string[] */
+	private static function string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		return array_values( array_map( 'strval', $value ) );
+	}
+
+	/** @param string[] $allowed_roots */
+	private static function resolve_cwd( string $cwd, array $allowed_roots ): string|WP_Error {
+		$real_cwd = realpath( '' !== $cwd ? $cwd : getcwd() );
+		if ( false === $real_cwd || ! is_dir( $real_cwd ) ) {
+			return new WP_Error( 'wp_codebox_managed_host_command_cwd_invalid', 'Managed host command cwd is invalid.', array( 'status' => 400, 'cwd' => $cwd ) );
+		}
+
+		$roots = empty( $allowed_roots ) ? array( $real_cwd ) : $allowed_roots;
+		foreach ( $roots as $root ) {
+			$real_root = realpath( $root );
+			if ( false !== $real_root && self::path_is_same_or_child( $real_cwd, $real_root ) ) {
+				return $real_cwd;
+			}
+		}
+
+		return new WP_Error( 'wp_codebox_managed_host_command_cwd_denied', 'Managed host command cwd is outside allowed roots.', array( 'status' => 400, 'cwd' => $real_cwd ) );
+	}
+
+	/** @param array<string,mixed> $env */
+	private static function environment( array $env ): array {
+		$merged = array( 'PATH' => (string) getenv( 'PATH' ) );
+		foreach ( $env as $name => $value ) {
+			if ( is_string( $name ) && preg_match( '/^[A-Za-z_][A-Za-z0-9_]*$/', $name ) ) {
+				$merged[ $name ] = (string) $value;
+			}
+		}
+
+		return $merged;
+	}
+
+	private static function append_bounded_output( string $current, string|false $chunk, int $max_bytes ): string {
+		if ( ! is_string( $chunk ) || '' === $chunk || strlen( $current ) >= $max_bytes ) {
+			return $current;
+		}
+
+		return substr( $current . $chunk, 0, $max_bytes );
+	}
+
+	private static function path_is_same_or_child( string $path, string $root ): bool {
+		$root = rtrim( $root, DIRECTORY_SEPARATOR );
+
+		return $path === $root || str_starts_with( $path, $root . DIRECTORY_SEPARATOR );
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -879,52 +879,33 @@ trait WP_Codebox_Abilities_Runner_Publication {
 
 	/** @param array<string,mixed> $input Normalized input. @param array<string,mixed> $command_input Command input. @return array<string,mixed> */
 	private static function run_local_runner_workspace_command( string $command, array $input, array $command_input ): array {
-		if ( ! function_exists( 'proc_open' ) ) {
+		$result = WP_Codebox_Managed_Host_Command::run(
+			array(
+				'command'           => WP_Codebox_Managed_Host_Command::split_command_line( $command ),
+				'cwd'               => (string) $input['workspace_path'],
+				'allowed_cwd_roots' => array( (string) $input['workspace_path'] ),
+				'timeout_seconds'   => max( 1, min( 600, (int) ( $command_input['timeout_seconds'] ?? 120 ) ) ),
+				'env'               => is_array( $command_input['env'] ?? null ) ? $command_input['env'] : array(),
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
 			return self::runner_workspace_operation_failure(
 				'command',
 				'local_command_unavailable',
-				array( 'code' => 'wp_codebox_runner_workspace_local_command_unavailable', 'message' => 'Local command execution is unavailable in this PHP runtime.' ),
+				array( 'code' => $result->get_error_code(), 'message' => $result->get_error_message(), 'data' => $result->get_error_data() ),
 				'unavailable',
 				$input
 			);
 		}
 
-		$started = hrtime( true );
-		$env     = is_array( $command_input['env'] ?? null ) ? array_map( 'strval', $command_input['env'] ) : array();
-		$process = proc_open(
-			$command,
-			array(
-				1 => array( 'pipe', 'w' ),
-				2 => array( 'pipe', 'w' ),
-			),
-			$pipes,
-			(string) $input['workspace_path'],
-			array() === $env ? null : $env
-		);
-
-		if ( ! is_resource( $process ) ) {
-			return self::runner_workspace_operation_failure(
-				'command',
-				'local_command_failed',
-				array( 'code' => 'wp_codebox_runner_workspace_local_command_failed', 'message' => 'Failed to start local runner workspace command.' ),
-				'failed',
-				$input
-			);
-		}
-
-		$stdout    = stream_get_contents( $pipes[1] );
-		$stderr    = stream_get_contents( $pipes[2] );
-		fclose( $pipes[1] );
-		fclose( $pipes[2] );
-		$exit_code = proc_close( $process );
-
 		return self::normalize_runner_workspace_command_result(
 			array(
-				'success'    => 0 === $exit_code,
-				'exit_code'  => $exit_code,
-				'stdout'     => is_string( $stdout ) ? trim( $stdout ) : '',
-				'stderr'     => is_string( $stderr ) ? trim( $stderr ) : '',
-				'elapsed_ms' => ( hrtime( true ) - $started ) / 1000000,
+				'success'    => (bool) $result['success'],
+				'exit_code'  => (int) $result['exit_code'],
+				'stdout'     => (string) $result['stdout'],
+				'stderr'     => (string) $result['stderr'],
+				'elapsed_ms' => (float) $result['elapsed_ms'],
 			),
 			$input,
 			$command_input,

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/src/class-wp-codebox-host-request-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-tool-policy-validator.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-recipe-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-run-result-normalizer.php';
+require_once __DIR__ . '/src/class-wp-codebox-managed-host-command.php';
 require_once __DIR__ . '/src/class-wp-codebox-parent-site-seed-exporter.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';

--- a/tests/php-managed-host-command.test.ts
+++ b/tests/php-managed-host-command.test.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import assert from "node:assert/strict"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const classPath = resolve(root, "packages/wordpress-plugin/src/class-wp-codebox-managed-host-command.php")
+const escapedRoot = root.replace(/'/g, "'\\''")
+const escapedClassPath = classPath.replace(/'/g, "'\\''")
+
+const php = spawnSync(
+  "php",
+  [
+    "-r",
+    `define('ABSPATH', '${escapedRoot}'); require '${escapedClassPath}'; $result = WP_Codebox_Managed_Host_Command::run(array('command' => array(PHP_BINARY, '-r', 'print($argv[1]);', 'literal;not-shell'), 'cwd' => '${escapedRoot}', 'allowed_cwd_roots' => array('${escapedRoot}'))); if (!is_array($result)) { var_export($result); exit(1); } echo json_encode($result, JSON_UNESCAPED_SLASHES);`,
+  ],
+  { encoding: "utf8", cwd: root }
+)
+
+assert.equal(php.status, 0, php.stderr || php.stdout)
+const result = JSON.parse(php.stdout)
+assert.equal(result.success, true)
+assert.equal(result.stdout, "literal;not-shell")
+assert.deepEqual(result.args.slice(-2), ["print($argv[1]);", "literal;not-shell"])
+
+console.log("php managed host command ok")


### PR DESCRIPTION
## Summary
- Add a PHP managed host command primitive that executes argv arrays without shell expansion, constrains cwd, bounds output, supports timeouts, and limits environment inheritance to PATH plus explicit env.
- Route artifact bundle verification through the managed primitive and argv command builder.
- Route local runner workspace command fallback through the managed primitive.
- Replace `command -v` shell preflight with pure PHP PATH resolution.
- Add a focused test proving PHP managed host commands preserve shell metacharacters as literal argv.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-managed-host-command.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php`
- `php -l packages/wordpress-plugin/wp-codebox.php`
- `npm run test:php-managed-host-command`
- `npm run test:host-command-executor`
- `npm run test:schema-parity`
- `npm run build`

## Residual gaps
- Agent sandbox recipe execution still uses the existing string-based process path for main/fanout task runs. I left that out of this PR because it is a broader command-construction migration with preview args, secret env, timeout handling, and concurrent fanout streaming; this PR focuses on the safe residual callsites called out by the finding.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Audited residual PHP host command callsites, drafted the PHP managed command primitive and callsite migrations, added targeted test coverage, and ran verification. Chris remains responsible for review and validation.