### PR TITLE
Trust mounted component manifest entrypoints

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -6,7 +6,7 @@ import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import type { StructuredArtifactPayload } from "./structured-artifacts.js"
 import type { TaskInput } from "./task-input.js"
 import { isPlainObject, stringList, stripUndefined } from "./object-utils.js"
-import type { WorkspaceRecipe, WorkspaceRecipeMount, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
+import type { WorkspaceRecipe, WorkspaceRecipeComponentManifest, WorkspaceRecipeComponentManifestEntry, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
 import { resolvePluginEntrypointContract, sanitizePluginSlug } from "./component-contracts.js"
 import { prepareLocalSourceStageSync, preparedSourcePath, preparedSourceRoot } from "./prepared-source-staging.js"
 
@@ -67,7 +67,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   const runtimeMounts = runtimeStateMounts(input)
   const agentBundleStagedFiles = stagedAgentBundleSources(input.agent_bundles)
   const stagedFiles = [...(Array.isArray(input.stagedFiles) ? input.stagedFiles : []), ...agentBundleStagedFiles]
-  const providerPlugins = stringList(input.provider_plugin_paths)
+  const providerPlugins: WorkspaceRecipeExtraPlugin[] = stringList(input.provider_plugin_paths)
     .map((plugin) => {
       const slug = slugFromComposerPackage(plugin) || slugFromPath(plugin)
       const preparedSource = prepareComposerPluginSource(plugin, slug, artifacts)
@@ -76,6 +76,12 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
     })
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
   const providerContracts = providerPlugins.map((plugin) => ({ slug: plugin.slug, pluginFile: plugin.pluginFile, loadAs: plugin.loadAs ?? "plugin" }))
+  const componentPluginEntries = componentPlugins(input.component_contracts, artifacts)
+  const extraPlugins = [
+    ...componentPluginEntries,
+    ...providerPlugins,
+  ].filter(Boolean)
+  const componentManifest = componentManifestForPlugins(componentPluginEntries, providerPlugins)
   const workflowArgs = [
     `task=${taskInput.goal}`,
     `agent=${stringValue(input.agent) || "wp-codebox-sandbox"}`,
@@ -118,10 +124,8 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
       mounts: Array.isArray(input.mounts) ? input.mounts : [],
       workspaces: Array.isArray(input.workspaces) ? input.workspaces : [],
       dependency_overlays: Array.isArray(input.dependency_overlays) ? input.dependency_overlays : undefined,
-      extra_plugins: [
-        ...componentPlugins(input.component_contracts, artifacts),
-        ...providerPlugins,
-      ].filter(Boolean),
+      extra_plugins: extraPlugins,
+      component_manifest: componentManifest,
       runtimeEnv: { ...runtimeEnv(input), ...AGENT_RUNTIME_ENV },
       secretEnv: stringList(input.secret_env),
       stagedFiles: stagedFiles.length > 0 ? stagedFiles : undefined,
@@ -132,6 +136,40 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
       after: Array.isArray(input.verify_steps) && input.verify_steps.length > 0 ? input.verify_steps : undefined,
     }),
   }) as WorkspaceRecipe
+}
+
+function componentManifestForPlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], providerPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeComponentManifest {
+  return {
+    schema: "wp-codebox/component-manifest/v1",
+    components: componentPlugins.map(componentManifestEntry),
+    providers: providerPlugins.map(componentManifestEntry),
+  }
+}
+
+function componentManifestEntry(plugin: WorkspaceRecipeExtraPlugin): WorkspaceRecipeComponentManifestEntry {
+  const metadata = plugin.metadata && typeof plugin.metadata === "object" && !Array.isArray(plugin.metadata) ? plugin.metadata : {}
+  const contract = metadata.componentContract && typeof metadata.componentContract === "object" && !Array.isArray(metadata.componentContract)
+    ? metadata.componentContract as Record<string, unknown>
+    : {}
+  const pluginFile = stringValue(plugin.pluginFile)
+  return stripUndefined({
+    slug: stringValue(plugin.slug),
+    source: stringValue(plugin.source),
+    mountedPath: componentMountedPath(stringValue(plugin.slug), plugin.loadAs === "mu-plugin" ? "mu-plugin" : "plugin"),
+    entrypoint: pluginFile,
+    pluginFile,
+    loadAs: plugin.loadAs,
+    activate: plugin.activate,
+    contractIndex: typeof contract.index === "number" ? contract.index : undefined,
+    requestedPath: stringValue(contract.requestedPath) || undefined,
+    provenance: Object.keys(metadata).length > 0 ? metadata : undefined,
+  })
+}
+
+function componentMountedPath(slug: string, loadAs: "plugin" | "mu-plugin"): string {
+  return loadAs === "mu-plugin"
+    ? `/wordpress/wp-content/mu-plugins/wp-codebox-runtime/${slug}`
+    : `/wordpress/wp-content/plugins/${slug}`
 }
 
 function stagedAgentBundleSources(agentBundles: AgentTaskRunInput["agent_bundles"]): WorkspaceRecipeStagedFile[] {
@@ -206,7 +244,7 @@ function runtimeMountList(value: unknown): WorkspaceRecipeMount[] {
   return value.filter((entry): entry is WorkspaceRecipeMount => Boolean(objectValue(entry)))
 }
 
-function componentPlugins(contracts: Array<Record<string, unknown>> | undefined, artifactsRoot: string): Array<{ source: string; slug: string; pluginFile: string; activate: boolean; loadAs: string; metadata: Record<string, unknown> }> {
+function componentPlugins(contracts: Array<Record<string, unknown>> | undefined, artifactsRoot: string): WorkspaceRecipeExtraPlugin[] {
   if (!Array.isArray(contracts)) return []
   return contracts.flatMap((contract, index) => {
     const slug = slugFromPath(stringValue(contract.slug || contract.component || contract.name))
@@ -220,12 +258,13 @@ function componentPlugins(contracts: Array<Record<string, unknown>> | undefined,
       pluginFile: stringValue(contract.pluginFile),
       loadAs: stringValue(contract.loadAs) === "plugin" ? "plugin" : "mu-plugin",
     })
+    const loadAs = stringValue(contract.loadAs) === "plugin" ? "plugin" : "mu-plugin"
     return [{
       source: preparedSource,
       slug,
       pluginFile: entrypoint.pluginFile,
       activate: Boolean(contract.activate),
-      loadAs: stringValue(contract.loadAs) || "mu-plugin",
+      loadAs,
       metadata: stripUndefined({
         componentContract: {
           index,
@@ -235,7 +274,7 @@ function componentPlugins(contracts: Array<Record<string, unknown>> | undefined,
           preparedPath: preparedSource,
           pluginFile: entrypoint.pluginFile,
           pluginEntrypointFallback: entrypoint.fallback,
-          loadAs: stringValue(contract.loadAs) || "mu-plugin",
+          loadAs,
           activate: Boolean(contract.activate),
         },
       }),

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -280,11 +280,14 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
         properties: {
           slug: { type: "string" },
           source: { type: "string" },
+          mountedPath: { type: "string" },
+          entrypoint: { type: "string" },
           pluginFile: { type: "string" },
           loadAs: { enum: ["plugin", "mu-plugin"] },
           activate: { type: "boolean" },
           contractIndex: { type: "integer", minimum: 0 },
           requestedPath: { type: "string" },
+          provenance: { $ref: "#/$defs/metadata" },
         },
       },
       distribution: {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -269,11 +269,14 @@ export interface WorkspaceRecipeExtraPlugin {
 export interface WorkspaceRecipeComponentManifestEntry {
   slug?: string
   source?: string
+  mountedPath?: string
+  entrypoint?: string
   pluginFile?: string
   loadAs?: "plugin" | "mu-plugin"
   activate?: boolean
   contractIndex?: number
   requestedPath?: string
+  provenance?: Record<string, unknown>
 }
 
 export interface WorkspaceRecipeComponentManifest {

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -376,6 +376,11 @@ function wp_codebox_bench_plugin_file_for_slug(string $plugin_slug, string $role
         throw new RuntimeException('wordpress.bench received an empty ' . $role . ' plugin slug. ' . wp_codebox_bench_plugin_slug_diagnostic($plugin_slug, $role, 'empty plugin slug'));
     }
 
+    $manifest_file = wp_codebox_bench_manifest_plugin_file_for_slug($plugin_slug, $role);
+    if ($manifest_file !== null) {
+        return $manifest_file;
+    }
+
     $plugin_dir = WP_PLUGIN_DIR . '/' . $plugin_slug;
     if (!is_dir($plugin_dir)) {
         throw new RuntimeException('wordpress.bench could not find ' . $role . ' plugin directory for slug "' . $plugin_slug . '". ' . wp_codebox_bench_plugin_slug_diagnostic($plugin_slug, $role, 'missing plugin directory'));
@@ -401,6 +406,43 @@ function wp_codebox_bench_plugin_file_for_slug(string $plugin_slug, string $role
     }
 
     throw new RuntimeException('wordpress.bench could not locate a readable plugin header for ' . $role . ' slug "' . $plugin_slug . '". ' . wp_codebox_bench_plugin_slug_diagnostic($plugin_slug, $role, 'missing readable plugin header', $checked_files));
+}
+
+function wp_codebox_bench_manifest_plugin_file_for_slug(string $plugin_slug, string $role): ?string {
+    $manifest = $GLOBALS['wp_codebox_component_manifest'] ?? null;
+    if (!is_array($manifest)) {
+        $json = defined('WP_CODEBOX_COMPONENT_MANIFEST_JSON') ? WP_CODEBOX_COMPONENT_MANIFEST_JSON : '';
+        $decoded = is_string($json) && $json !== '' ? json_decode($json, true) : null;
+        $manifest = is_array($decoded) ? $decoded : null;
+    }
+    if (!is_array($manifest)) {
+        return null;
+    }
+
+    foreach (array('components', 'providers') as $section) {
+        foreach (is_array($manifest[$section] ?? null) ? $manifest[$section] : array() as $entry) {
+            if (!is_array($entry) || (string) ($entry['slug'] ?? '') !== $plugin_slug) {
+                continue;
+            }
+
+            $entrypoint = trim(str_replace('\\\\', '/', (string) ($entry['entrypoint'] ?? $entry['pluginFile'] ?? '')));
+            if ($entrypoint === '' || str_starts_with($entrypoint, '/') || str_contains($entrypoint, '..') || !str_ends_with($entrypoint, '.php')) {
+                throw new RuntimeException('wordpress.bench manifest contains unsafe ' . $role . ' entrypoint for slug "' . $plugin_slug . '". ' . wp_codebox_bench_plugin_slug_diagnostic($plugin_slug, $role, 'unsafe manifest entrypoint'));
+            }
+            if (!str_starts_with($entrypoint, $plugin_slug . '/')) {
+                throw new RuntimeException('wordpress.bench manifest entrypoint for ' . $role . ' slug "' . $plugin_slug . '" must be relative to the mounted plugin slug. ' . wp_codebox_bench_plugin_slug_diagnostic($plugin_slug, $role, 'manifest entrypoint slug mismatch'));
+            }
+
+            $absolute = WP_PLUGIN_DIR . '/' . $entrypoint;
+            if (!is_file($absolute) || !is_readable($absolute)) {
+                throw new RuntimeException('wordpress.bench manifest entrypoint for ' . $role . ' slug "' . $plugin_slug . '" is not readable. ' . wp_codebox_bench_plugin_slug_diagnostic($plugin_slug, $role, 'manifest entrypoint missing', array($absolute)));
+            }
+
+            return $entrypoint;
+        }
+    }
+
+    return null;
 }
 
 function wp_codebox_bench_plugin_slug_diagnostic(string $plugin_slug, string $role, string $error, array $checked_files = array()): string {

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -575,6 +575,53 @@ function pg_resolve_runtime_cwd(string $cwd, string $plugin_path): string {
     return $real;
 }
 
+function pg_manifest_component_entry(string $plugin_slug): ?array {
+    $manifest = $GLOBALS['wp_codebox_component_manifest'] ?? null;
+    if (!is_array($manifest)) {
+        $json = defined('WP_CODEBOX_COMPONENT_MANIFEST_JSON') ? WP_CODEBOX_COMPONENT_MANIFEST_JSON : '';
+        $decoded = is_string($json) && $json !== '' ? json_decode($json, true) : null;
+        $manifest = is_array($decoded) ? $decoded : null;
+    }
+    if (!is_array($manifest)) {
+        return null;
+    }
+
+    foreach (array('components', 'providers') as $section) {
+        foreach (is_array($manifest[$section] ?? null) ? $manifest[$section] : array() as $entry) {
+            if (is_array($entry) && (string) ($entry['slug'] ?? '') === $plugin_slug) {
+                return $entry;
+            }
+        }
+    }
+
+    return null;
+}
+
+function pg_manifest_component_plugin_file(string $plugin_slug, string $plugin_path): ?string {
+    $entry = pg_manifest_component_entry($plugin_slug);
+    if ($entry === null) {
+        return null;
+    }
+
+    $entrypoint = trim(str_replace('\\\\', '/', (string) ($entry['entrypoint'] ?? $entry['pluginFile'] ?? '')));
+    if ($entrypoint === '' || str_starts_with($entrypoint, '/') || str_contains($entrypoint, '..') || !str_ends_with($entrypoint, '.php')) {
+        throw new RuntimeException('manifest contains unsafe component entrypoint for slug ' . $plugin_slug);
+    }
+    if (!str_starts_with($entrypoint, $plugin_slug . '/')) {
+        throw new RuntimeException('manifest component entrypoint must be relative to the mounted plugin slug: ' . $entrypoint);
+    }
+
+    $relative = substr($entrypoint, strlen($plugin_slug) + 1);
+    $file = rtrim($plugin_path, '/') . '/' . $relative;
+    $real = realpath($file);
+    $plugin_real = realpath($plugin_path);
+    if ($real === false || $plugin_real === false || strpos($real, rtrim($plugin_real, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR) !== 0 || !is_file($real) || !is_readable($real)) {
+        throw new RuntimeException('manifest component entrypoint is not readable under mounted plugin path: ' . $entrypoint);
+    }
+
+    return $real;
+}
+
 function pg_plugin_real_path(string $relative_path, string $kind): ?string {
     global $plugin_path;
     $relative_path = trim(str_replace('\\\\', '/', $relative_path));
@@ -717,6 +764,7 @@ function pg_run_load_component_stage(array $cfg): ?string {
     pg_stage_begin('load_component');
     try {
         $plugin_path = $cfg['plugin_path'];
+        $plugin_slug = (string) ($cfg['plugin_slug'] ?? basename($plugin_path));
         $loaded_file = null;
         $style_css = $plugin_path . '/style.css';
         if (file_exists($style_css) && strpos(file_get_contents($style_css), 'Theme Name:') !== false) {
@@ -725,11 +773,12 @@ function pg_run_load_component_stage(array $cfg): ?string {
                 require_once $plugin_path . '/functions.php';
             }
         } else {
-            foreach (glob($plugin_path . '/*.php') ?: array() as $main_file) {
+            $manifest_file = pg_manifest_component_plugin_file($plugin_slug, $plugin_path);
+            foreach ($manifest_file !== null ? array($manifest_file) : (glob($plugin_path . '/*.php') ?: array()) as $main_file) {
                 if (basename($main_file) === 'db.php') {
                     continue;
                 }
-                if (strpos(file_get_contents($main_file), 'Plugin Name:') !== false) {
+                if ($manifest_file !== null || strpos(file_get_contents($main_file), 'Plugin Name:') !== false) {
                     pg_log('PLUGIN_DETECTED ' . basename($main_file));
                     pg_log('PLUGIN_LOAD_CONTEXT ' . basename($main_file) . ' activate=false ' . pg_diagnostic_context());
                     require_once $main_file;
@@ -855,9 +904,9 @@ $loaded_dep_files = array();
 $loaded_component_file = null;
 
 require_once $tests_dir . '/includes/functions.php';
-tests_add_filter('muplugins_loaded', function () use ($plugin_path, $dep_mounts, $pre_component_plugins_loaded_callbacks, $pre_component_init_callbacks, &$deferred_install_plugins_loaded_callbacks, &$deferred_install_init_callbacks, &$loaded_dep_files, &$loaded_component_file) {
+tests_add_filter('muplugins_loaded', function () use ($plugin_slug, $plugin_path, $dep_mounts, $pre_component_plugins_loaded_callbacks, $pre_component_init_callbacks, &$deferred_install_plugins_loaded_callbacks, &$deferred_install_init_callbacks, &$loaded_dep_files, &$loaded_component_file) {
     $loaded_dep_files = pg_run_load_deps_stage(array('dep_mounts' => $dep_mounts));
-    $loaded_component_file = pg_run_load_component_stage(array('plugin_path' => $plugin_path, 'activate' => false));
+    $loaded_component_file = pg_run_load_component_stage(array('plugin_slug' => $plugin_slug, 'plugin_path' => $plugin_path, 'activate' => false));
     $deferred_install_plugins_loaded_callbacks = pg_defer_new_wordpress_hook_callbacks('plugins_loaded', $pre_component_plugins_loaded_callbacks);
     $deferred_install_init_callbacks = pg_defer_new_wordpress_hook_callbacks('init', $pre_component_init_callbacks);
 });

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -162,13 +162,28 @@ final class WP_Codebox_Host_Recipe_Builder {
 			array(
 				'slug'          => (string) ( $plugin['slug'] ?? '' ),
 				'source'        => (string) ( $plugin['source'] ?? '' ),
+				'mountedPath'   => self::component_manifest_mounted_path( $plugin ),
+				'entrypoint'    => (string) ( $plugin['pluginFile'] ?? '' ),
 				'pluginFile'    => (string) ( $plugin['pluginFile'] ?? '' ),
 				'loadAs'        => (string) ( $plugin['loadAs'] ?? '' ),
 				'activate'      => isset( $plugin['activate'] ) ? (bool) $plugin['activate'] : null,
 				'contractIndex' => isset( $contract['index'] ) ? (int) $contract['index'] : null,
 				'requestedPath' => (string) ( $contract['requestedPath'] ?? '' ),
+				'provenance'    => ! empty( $metadata ) ? $metadata : null,
 			),
 			static fn( mixed $value ): bool => null !== $value && '' !== $value
 		);
+	}
+
+	/** @param array<string,mixed> $plugin Prepared plugin entry. */
+	private static function component_manifest_mounted_path( array $plugin ): string {
+		$slug = (string) ( $plugin['slug'] ?? '' );
+		if ( '' === $slug ) {
+			return '';
+		}
+
+		return 'mu-plugin' === (string) ( $plugin['loadAs'] ?? '' )
+			? '/wordpress/wp-content/mu-plugins/wp-codebox-runtime/' . $slug
+			: '/wordpress/wp-content/plugins/' . $slug;
 	}
 }

--- a/scripts/component-plugin-entrypoint-contract-smoke.ts
+++ b/scripts/component-plugin-entrypoint-contract-smoke.ts
@@ -43,6 +43,23 @@ throw new RuntimeException('explicit pluginFile resolution must not read plugin 
   assert.ok(providerPlugin, "provider plugin should be staged from provider_plugin_paths")
   assert.equal(providerPlugin?.pluginFile, "ai-provider-for-opencode/ai-provider-for-opencode.php")
 
+  const providerManifest = recipe.inputs?.component_manifest?.providers?.find((plugin) => plugin.slug === "ai-provider-for-opencode")
+  assert.ok(providerManifest, "provider plugin should be present in the authoritative component manifest")
+  assert.equal(providerManifest?.entrypoint, "ai-provider-for-opencode/ai-provider-for-opencode.php")
+  assert.equal(providerManifest?.pluginFile, "ai-provider-for-opencode/ai-provider-for-opencode.php")
+  assert.equal(providerManifest?.mountedPath, "/wordpress/wp-content/plugins/ai-provider-for-opencode")
+
+  const componentRecipe = buildAgentTaskRecipe({
+    goal: "verify explicit component entrypoint",
+    component_contracts: [{ slug: "explicit-component", path: explicitSource, pluginFile: "explicit-component/custom-entry.php", loadAs: "plugin", activate: true }],
+    artifacts_path: join(root, "component-artifacts"),
+  }, normalizeTaskInput({ goal: "verify explicit component entrypoint" }), "latest")
+  const componentManifest = componentRecipe.inputs?.component_manifest?.components?.find((plugin) => plugin.slug === "explicit-component")
+  assert.ok(componentManifest, "component plugin should be present in the authoritative component manifest")
+  assert.equal(componentManifest?.entrypoint, "explicit-component/custom-entry.php")
+  assert.equal(componentManifest?.mountedPath, "/wordpress/wp-content/plugins/explicit-component")
+  assert.equal(componentManifest?.activate, true)
+
   const sandboxStep = recipe.workflow.steps.find((step) => step.command === "wp-codebox.agent-sandbox-run")
   const contractsArg = sandboxStep?.args?.find((arg) => arg.startsWith("provider-plugin-contracts-json="))
   assert.ok(contractsArg, "agent sandbox step should receive provider plugin contracts")


### PR DESCRIPTION
## Summary
- Adds authoritative mounted component manifest fields for source, mounted path, entrypoint, load mode, activation, and provenance.
- Emits the manifest from agent-task recipe construction for component and provider plugins.
- Updates PHP bench/PHPUnit runtime loading to trust and verify manifest entrypoints before falling back to legacy discovery.

## Tests
- `npx tsx scripts/component-plugin-entrypoint-contract-smoke.ts`
- `npm run test:schema-parity`
- `npm run build`
- `npm run test:agent-task-contracts`
- `npm run test:generic-primitives`
- `npm run smoke -- --group=check` reached `recipe-run-composer-autoload-extra-plugin-smoke` and failed on the existing Composer environment precondition: Composer reports `The HOME or COMPOSER_HOME environment variable must be set`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the manifest contract/runtime loading change and drafted test updates; Chris remains responsible for review and merge.