### PR TITLE
Add browser task builder primitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "smoke": "tsx scripts/run-smoke.ts",
     "test:redaction": "tsx tests/redaction.test.ts",
     "test:agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",
+    "test:browser-task-builder": "tsx tests/browser-task-builder.test.ts",
     "test:generic-primitives": "tsx tests/generic-primitives.test.ts",
     "test:browser-provider-permissions": "tsx tests/browser-provider-permissions.test.ts",
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -243,6 +243,7 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
       args: ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts", "--no-plugins"],
       cwd: stagedSource,
       allowedCwdRoots: [stagingRoot],
+      inheritedEnv: ["HOME", "COMPOSER_HOME"],
       maxOutputBytes: 1024 * 1024 * 10,
       label: "prepare Composer autoload for recipe extra plugin",
     })
@@ -444,6 +445,7 @@ async function prepareComposerBackedSource(source: string, stagingRoot: string, 
       args: ["install", "--working-dir", hydratedSource, "--no-dev", "--no-interaction", "--no-progress", "--prefer-dist", "--classmap-authoritative"],
       cwd: hydratedSource,
       allowedCwdRoots: [stagingRoot],
+      inheritedEnv: ["HOME", "COMPOSER_HOME"],
       maxOutputBytes: 1024 * 1024 * 10,
       label: `hydrate Composer-backed ${label}`,
     })

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Generic browser task input and payload builder.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Browser_Task_Builder {
+
+	/**
+	 * Normalizes caller input into the canonical WP Codebox task input contract.
+	 *
+	 * @param array<string,mixed> $input Ability or caller input.
+	 * @param callable|null       $allowed_tools_validator Optional validator: fn( array $tools, array $task_input ): WP_Error|null.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function normalize_task_input( array $input, ?callable $allowed_tools_validator = null ): array|WP_Error {
+		return WP_Codebox_Agent_Task::normalize_input( $input, $allowed_tools_validator, true );
+	}
+
+	/**
+	 * Builds the generic browser agent task payload sent into the sandbox.
+	 *
+	 * Product-specific task data remains in task_input.context, target, policy,
+	 * and structured_artifacts. This method only owns the WP Codebox envelope.
+	 *
+	 * @param array<string,mixed> $input       Ability or caller input.
+	 * @param array<string,mixed> $task_input  Normalized task input.
+	 * @param string              $session_id  Browser sandbox session id.
+	 * @param array<int,array<string,mixed>> $artifacts Browser artifact specs.
+	 * @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance Resolved inheritance.
+	 * @param array<string,callable> $resolvers Optional field resolvers for agent, mode, provider, model, secret_env, and agent_bundles.
+	 * @return array<string,mixed>
+	 */
+	public static function task_payload( array $input, array $task_input, string $session_id, array $artifacts, array $inheritance, array $resolvers = array() ): array {
+		$resolve = static function ( string $name, mixed $fallback ) use ( $input, $task_input, $inheritance, $resolvers ): mixed {
+			if ( isset( $resolvers[ $name ] ) && is_callable( $resolvers[ $name ] ) ) {
+				return $resolvers[ $name ]( $input, $task_input, $inheritance );
+			}
+
+			return $fallback;
+		};
+
+		return array_filter(
+			array(
+				'schema'        => 'wp-codebox/browser-agent-task-payload/v1',
+				'agent'         => (string) $resolve( 'agent', self::agent_slug( $input ) ),
+				'mode'          => (string) $resolve( 'mode', self::mode( $input ) ),
+				'provider'      => (string) $resolve( 'provider', self::provider( $input, $inheritance ) ),
+				'model'         => (string) $resolve( 'model', self::model( $input, $inheritance ) ),
+				'message'       => (string) $task_input['goal'],
+				'session_id'    => $session_id,
+				'task_input'    => $task_input,
+				'agent_bundles' => self::array_resolver_value( $resolve( 'agent_bundles', $task_input['agent_bundles'] ?? array() ) ),
+				'inheritance'   => $inheritance,
+				'secret_env'    => self::string_list( $resolve( 'secret_env', $input['secret_env'] ?? array() ) ),
+				'artifacts'     => array(
+					'schema' => 'wp-codebox/browser-artifacts/v1',
+					'files'  => $artifacts,
+				),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability or caller input. */
+	private static function agent_slug( array $input ): string {
+		$agent = trim( (string) ( $input['agent'] ?? '' ) );
+		return '' !== $agent ? $agent : 'wp-codebox-sandbox';
+	}
+
+	/** @param array<string,mixed> $input Ability or caller input. */
+	private static function mode( array $input ): string {
+		$mode = trim( (string) ( $input['mode'] ?? '' ) );
+		return '' !== $mode ? $mode : 'sandbox';
+	}
+
+	/** @param array<string,mixed> $input Ability or caller input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
+	private static function provider( array $input, array $inheritance ): string {
+		$provider = trim( (string) ( $input['provider'] ?? '' ) );
+		if ( '' !== $provider ) {
+			return $provider;
+		}
+
+		foreach ( is_array( $inheritance['connectors'] ?? null ) ? $inheritance['connectors'] : array() as $connector ) {
+			$provider = trim( (string) ( $connector['provider'] ?? '' ) );
+			if ( '' !== $provider ) {
+				return $provider;
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $input Ability or caller input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
+	private static function model( array $input, array $inheritance ): string {
+		$model = trim( (string) ( $input['model'] ?? '' ) );
+		if ( '' !== $model ) {
+			return $model;
+		}
+
+		foreach ( is_array( $inheritance['connectors'] ?? null ) ? $inheritance['connectors'] : array() as $connector ) {
+			$model = trim( (string) ( $connector['model'] ?? '' ) );
+			if ( '' !== $model ) {
+				return $model;
+			}
+		}
+
+		return '';
+	}
+
+	/** @return array<int,mixed> */
+	private static function array_resolver_value( mixed $value ): array {
+		return is_array( $value ) ? $value : array();
+	}
+
+	/** @return string[] */
+	private static function string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item && 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $item ) && ! in_array( $item, $items, true ) ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 trait WP_Codebox_Abilities_Inheritance {
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 private static function normalize_task_input( array $input ): array|WP_Error {
-	return WP_Codebox_Agent_Task::normalize_input( $input, fn( array $tools, array $task_input ): WP_Error|null => ( new WP_Codebox_Agent_Sandbox_Runner() )->validate_allowed_tools( $tools, $task_input ), true );
+	return WP_Codebox_Browser_Task_Builder::normalize_task_input( $input, fn( array $tools, array $task_input ): WP_Error|null => ( new WP_Codebox_Agent_Sandbox_Runner() )->validate_allowed_tools( $tools, $task_input ) );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array{connectors:string[],settings:string[]} */
@@ -40,25 +40,20 @@ private static function browser_input_with_inheritance( array $input, array $inh
 
 /** @param array<string,mixed> $input Ability input. @param array<string,mixed> $task_input Normalized task input. @param array<int,array<string,mixed>> $artifacts Browser artifact specs. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed> */
 private static function browser_task_payload( array $input, array $task_input, string $session_id, array $artifacts, array $inheritance ): array {
-	return array_filter(
+	return WP_Codebox_Browser_Task_Builder::task_payload(
+		$input,
+		$task_input,
+		$session_id,
+		$artifacts,
+		$inheritance,
 		array(
-			'schema'      => 'wp-codebox/browser-agent-task-payload/v1',
-			'agent'       => self::browser_agent_slug( $input ),
-			'mode'        => self::browser_mode( $input ),
-			'provider'    => self::browser_provider( $input, $inheritance ),
-			'model'       => self::browser_model( $input, $inheritance ),
-			'message'     => (string) $task_input['goal'],
-			'session_id'  => $session_id,
-			'task_input'  => $task_input,
-			'agent_bundles' => self::normalize_agent_bundles( $input['agent_bundles'] ?? array() ),
-			'inheritance' => $inheritance,
-			'secret_env'  => self::browser_secret_env_names( $input ),
-			'artifacts'   => array(
-				'schema' => 'wp-codebox/browser-artifacts/v1',
-				'files'  => $artifacts,
-			),
-		),
-		static fn( mixed $value ): bool => '' !== $value && array() !== $value
+			'agent'         => static fn( array $input ): string => self::browser_agent_slug( $input ),
+			'mode'          => static fn( array $input ): string => self::browser_mode( $input ),
+			'provider'      => static fn( array $input, array $task_input, array $inheritance ): string => self::browser_provider( $input, $inheritance ),
+			'model'         => static fn( array $input, array $task_input, array $inheritance ): string => self::browser_model( $input, $inheritance ),
+			'agent_bundles' => static fn( array $input ): array => self::normalize_agent_bundles( $input['agent_bundles'] ?? array() ),
+			'secret_env'    => static fn( array $input ): array => self::browser_secret_env_names( $input ),
+		)
 	);
 }
 

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -21,6 +21,7 @@ define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
+require_once __DIR__ . '/src/class-wp-codebox-browser-task-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-inheritance.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-request-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-tool-policy-validator.php';

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -31,6 +31,7 @@ export const smokeGroups = {
     commands: [
       npmScript("build"),
       npmScript("test:generic-primitives"),
+      npmScript("test:browser-task-builder"),
       tsxSmoke("runtime-backend-registry-smoke"),
       tsxSmoke("backend-package-adapter-registry-smoke"),
       tsxSmoke("command-registry-smoke"),

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+
+const root = new URL("../", import.meta.url)
+const rootPath = root.pathname.replace(/'/g, "'\\''")
+
+const php = spawnSync("php", ["-r", `
+define('ABSPATH', '${rootPath}');
+class WP_Error {
+	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+}
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php';
+
+$task_input = WP_Codebox_Browser_Task_Builder::normalize_task_input( array(
+	'goal' => 'Build a generic browser task.',
+	'target' => array( 'kind' => 'site', 'ref' => 'demo' ),
+	'allowed_tools' => array( 'filesystem_write', 'filesystem_write', '' ),
+	'expected_artifacts' => array( 'patch', 'preview' ),
+	'context' => array( 'caller' => 'test' ),
+	'agent_bundles' => array(
+		array( 'source' => '/tmp/agent-bundle.zip', 'on_conflict' => 'skip' ),
+	),
+) );
+
+$payload = WP_Codebox_Browser_Task_Builder::task_payload(
+	array(
+		'agent' => 'custom-agent',
+		'mode' => 'sandbox',
+		'secret_env' => array( 'OPENAI_API_KEY', 'OPENAI_API_KEY', 'bad-name' ),
+	),
+	$task_input,
+	'session-123',
+	array( array( 'path' => '/tmp/result.json', 'name' => 'result' ) ),
+	array(
+		'connectors' => array( array( 'provider' => 'provider-from-inheritance', 'model' => 'model-from-inheritance' ) ),
+		'settings' => array(),
+	)
+);
+
+echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload ), JSON_UNESCAPED_SLASHES );
+`], {
+  cwd: root.pathname,
+  encoding: "utf8",
+})
+
+assert.equal(php.status, 0, php.stderr)
+const result = JSON.parse(php.stdout)
+
+assert.equal(result.task_input.schema, "wp-codebox/task-input/v1")
+assert.deepEqual(result.task_input.allowed_tools, ["filesystem_write"])
+assert.equal(result.payload.schema, "wp-codebox/browser-agent-task-payload/v1")
+assert.equal(result.payload.message, "Build a generic browser task.")
+assert.equal(result.payload.session_id, "session-123")
+assert.equal(result.payload.provider, "provider-from-inheritance")
+assert.equal(result.payload.model, "model-from-inheritance")
+assert.deepEqual(result.payload.secret_env, ["OPENAI_API_KEY"])
+assert.deepEqual(result.payload.task_input.context, { caller: "test" })
+assert.deepEqual(result.payload.agent_bundles, [{ source: "/tmp/agent-bundle.zip", on_conflict: "skip" }])
+
+console.log("browser task builder ok")


### PR DESCRIPTION
## Summary
- Add a generic PHP browser task builder for normalized task input and browser agent payload envelopes.
- Route the existing browser task ability through the shared builder while keeping product-specific context caller-owned.
- Add focused coverage and wire it into the check smoke group.
- Inherit HOME/COMPOSER_HOME for managed Composer hydration commands so the existing check suite can run in minimal-env command execution.

## Verification
- npm run test:browser-task-builder
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
- HOME=/Users/chubes COMPOSER_HOME=/Users/chubes/.composer npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the generic browser task builder primitive, focused tests, verification, and PR preparation under Chris's direction.