### PR TITLE
Add recipe run result envelope

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -159,6 +159,13 @@ otherwise successful recipe return `success: false`.
 are promoted into `browserEvidence` so callers can discover stable evidence
 without hardcoding artifact paths or parsing command stdout.
 
+The same output includes `result`, a normalized
+`wp-codebox/recipe-run-summary/v1` envelope for portable callers. It groups
+common artifact refs, command stdout/stderr tails, run/runtime metadata, failure
+phase and summary, and held-preview reviewer access. Consumers should prefer
+`result` before scraping `latest-runtime.json`, `commands.jsonl`, command stdout,
+or preview internals from the artifact bundle.
+
 Each `browserEvidence` entry includes the workflow phase/index, command,
 summary file, artifact file refs, summary payload, and `scriptResult` when the
 browser command produced one. The same browser evidence is mirrored into

--- a/packages/cli/src/commands/recipe-run-artifact-pointers.ts
+++ b/packages/cli/src/commands/recipe-run-artifact-pointers.ts
@@ -1,6 +1,6 @@
 import { mkdir, stat, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
-import type { ArtifactBundle, RuntimeInfo } from "@automattic/wp-codebox-core"
+import type { ArtifactBundle, RecipeRunSummary, RuntimeInfo } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 import type { RecipeArtifactPointerCommandStatus, RecipeArtifactPointerState, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipePhaseEvidence } from "./recipe-run-types.js"
@@ -14,6 +14,7 @@ export class RecipeArtifactPointerTracker {
   private phases: RecipePhaseEvidence[] = []
   private browserEvidence: RecipeBrowserEvidence[] = []
   private diagnosticArtifacts: RecipeDiagnosticArtifactRef[] = []
+  private result: RecipeRunSummary | undefined
 
   constructor(private readonly directory: string | undefined, private readonly runId: string, private readonly recipePath: string, private readonly startedAt: string) {}
 
@@ -30,6 +31,7 @@ export class RecipeArtifactPointerTracker {
     this.phases = state.phases ?? this.phases
     this.browserEvidence = state.browserEvidence ?? this.browserEvidence
     this.diagnosticArtifacts = state.diagnosticArtifacts ?? this.diagnosticArtifacts
+    this.result = state.result ?? this.result
 
     const pointer = stripUndefined({
       schema: "wp-codebox/recipe-run-artifact-pointer/v1",
@@ -44,6 +46,7 @@ export class RecipeArtifactPointerTracker {
       commandStatus: this.commandStatus,
       failure: this.failure,
       failurePhase: recipeArtifactPointerFailurePhase(this.failure, this.phases),
+      result: this.result,
       browserEvidence: this.browserEvidence.length > 0 ? this.browserEvidence : undefined,
       diagnosticArtifacts: this.diagnosticArtifacts.length > 0 ? this.diagnosticArtifacts : undefined,
       ...await recipeArtifactPointerArtifactState(this.directory, this.runtime, this.artifacts),

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -1,4 +1,4 @@
-import type { AgentTerminalResult, ArtifactBundle, BenchResults, ExecutionResult, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef } from "@automattic/wp-codebox-core"
+import type { AgentTerminalResult, ArtifactBundle, BenchResults, ExecutionResult, RecipeRunSummary, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef } from "@automattic/wp-codebox-core"
 import type { RecipeDryRunOutput, RecipeDryRunSiteSeed, RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import type { AgentSandboxResultSummary, AgentTaskSingleResult, RecipeReplayStatusSummary, SandboxCompletionOutcome } from "../recipe-evidence.js"
 import type { RecipeValidationIssue, RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -65,6 +65,7 @@ export interface RecipeRunOutput {
   terminalResult?: AgentTerminalResult
   completionOutcome?: SandboxCompletionOutcome
   replayStatus?: RecipeReplayStatusSummary
+  result?: RecipeRunSummary
   artifacts?: ArtifactBundle
   run?: RuntimeRunRecord
   interruption?: RecipeInterruptionMetadata
@@ -138,6 +139,7 @@ export interface RecipeArtifactPointerState {
   phases?: RecipePhaseEvidence[]
   browserEvidence?: RecipeBrowserEvidence[]
   diagnosticArtifacts?: RecipeDiagnosticArtifactRef[]
+  result?: RecipeRunSummary
 }
 
 export interface RecipeDiagnosticArtifactRef {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, redactJsonValue, refreshArtifactManifestFileSha256s, resolveSecretEnvNames, upsertArtifactManifestFiles, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactBundleRunRef, artifactFileDigest, artifactManifestFile, createBenchResultsJsonSchema, createRuntime, normalizeRecipeRunSummary, normalizeRuntimeEnvRecord, parseCommandOptions, redactJsonValue, refreshArtifactManifestFileSha256s, resolveSecretEnvNames, upsertArtifactManifestFiles, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type BenchmarkArtifactRef, type BenchResults, type ExecutionResult, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRecord, type RuntimeRunRegistry, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
@@ -112,8 +112,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", failure }) },
       error: failure,
     })
-    await artifactPointer.update({ command: "recipe.validate", commandStatus: "failed", failure })
-    return {
+    const output: RecipeRunOutput = recipeRunOutputWithResult({
       success: false,
       schema: "wp-codebox/recipe-run/v1",
       recipePath,
@@ -122,7 +121,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       validation: { issues },
       run: runRecord,
       error: failure,
-    }
+    })
+    await artifactPointer.update({ command: "recipe.validate", commandStatus: "failed", failure, result: output.result })
+    return output
   }
 
   const plan = await planWorkspaceRecipe(recipe, recipeDirectory, { recipePath, artifactsDirectory: configuredArtifactsDirectory }, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec })
@@ -481,8 +482,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: recipeFailure, phaseEvidence: phaseTracker.list() }), ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}) },
         error: recipeFailure,
       })
-      await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: recipeFailure, phases: phaseTracker.list(), browserEvidence })
-      return {
+      const output: RecipeRunOutput = recipeRunOutputWithResult({
         success: false,
         schema: "wp-codebox/recipe-run/v1",
         recipePath,
@@ -507,7 +507,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         artifacts,
         run: runRecord,
         error: recipeFailure,
-      }
+      })
+      await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: recipeFailure, phases: phaseTracker.list(), browserEvidence, result: output.result })
+      return output
     }
 
     runRecord = await runRegistry.update(runRecord.runId, {
@@ -517,8 +519,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       artifactRefs: artifactBundleRunRef(artifacts),
       metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "succeeded", startupDurationMs, cleanup: cleanupEvidence, artifacts, phaseEvidence: phaseTracker.list() }), ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}) },
     })
-    await artifactPointer.update({ commandStatus: "completed", runtime: runtimeInfo ?? await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
-    return {
+    const output: RecipeRunOutput = recipeRunOutputWithResult({
       success: true,
       schema: "wp-codebox/recipe-run/v1",
       recipePath,
@@ -542,7 +543,9 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}),
       artifacts,
       run: runRecord,
-    }
+    })
+    await artifactPointer.update({ commandStatus: "completed", runtime: runtimeInfo ?? await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence, result: output.result })
+    return output
   } catch (error) {
     const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
     const failureDiagnostics = recipeFailureRuntimeEvidenceFile({
@@ -627,9 +630,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: recipeRunFailureStatus(error, interruption), startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: serializedError, phaseEvidence: phaseTracker.list() }) },
       error: serializedError,
     })
-    await artifactPointer.update({ commandStatus: "failed", ...(runtime ? { runtime: await runtime.info() } : {}), ...(artifacts ? { artifacts } : {}), failure: serializedError, phases: phaseTracker.list(), browserEvidence, diagnosticArtifacts })
-
-    return {
+    const output: RecipeRunOutput = recipeRunOutputWithResult({
       success: false,
       schema: "wp-codebox/recipe-run/v1",
       recipePath,
@@ -648,8 +649,16 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       run: runRecord,
       ...(interruption?.metadata ? { interruption: interruption.metadata } : {}),
       error: serializedError,
-    }
+    })
+    await artifactPointer.update({ commandStatus: "failed", ...(runtime ? { runtime: await runtime.info() } : {}), ...(artifacts ? { artifacts } : {}), failure: serializedError, phases: phaseTracker.list(), browserEvidence, diagnosticArtifacts, result: output.result })
+
+    return output
   }
+}
+
+function recipeRunOutputWithResult<T extends RecipeRunOutput>(output: T): T {
+  output.result = normalizeRecipeRunSummary(output)
+  return output
 }
 
 function resolveRecipeRuntimeAssets(recipe: WorkspaceRecipe, recipeDirectory: string): RuntimeAssetSpec | undefined {

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -14,6 +14,8 @@ export interface RecipeRunSummary {
   failure_summary?: string
   diagnostics: Array<Record<string, unknown>>
   artifacts: AgentTaskRunArtifactRef[]
+  commands: RecipeRunCommandSummary[]
+  preview?: RecipeRunPreviewSummary
   refs: {
     startup_logs: AgentTaskRunArtifactRef[]
     probe_json: AgentTaskRunArtifactRef[]
@@ -30,6 +32,28 @@ export interface RecipeRunSummary {
   metadata: Record<string, unknown>
 }
 
+export interface RecipeRunCommandSummary {
+  index: number
+  command: string
+  status: "succeeded" | "failed" | "unknown"
+  exit_code?: number
+  duration_ms?: number
+  recipe_phase?: string
+  recipe_step_index?: number
+  stdout_tail?: string
+  stderr_tail?: string
+}
+
+export interface RecipeRunPreviewSummary {
+  status?: string
+  lifecycle?: string
+  source?: string
+  created_at?: string
+  expires_at?: string
+  hold_seconds?: number
+  reviewer_access?: Record<string, unknown>
+}
+
 export interface RecipeRunSummaryOptions {
   exitStatus?: number
 }
@@ -41,6 +65,8 @@ export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummar
   const failedPhase = failedPhaseFromRecipeRun(result)
   const diagnostics = arrayObjects(result.diagnostics)
   const artifacts = normalizeRecipeRunArtifacts(result, agentTask.artifacts)
+  const commands = recipeRunCommandSummaries(result)
+  const preview = recipeRunPreviewSummary(result)
   const summary = failureSummary(result, diagnostics, failedPhase)
 
   return stripUndefined({
@@ -52,7 +78,7 @@ export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummar
     diagnostics,
     artifacts,
     refs: {
-      startup_logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log" || artifact.kind === "codebox-event-log" || artifact.kind === "codebox-runtime-metadata"),
+      startup_logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log" || artifact.kind === "codebox-command-events" || artifact.kind === "codebox-event-log" || artifact.kind === "codebox-runtime-metadata"),
       probe_json: artifacts.filter((artifact) => artifact.kind === "browser-summary" || artifact.kind === "recipe-probe-results"),
       screenshots: artifacts.filter((artifact) => artifact.kind === "browser-screenshot" || artifact.kind === "screenshot"),
       side_effects: artifacts.filter((artifact) => artifact.kind === "recipe-side-effects" || artifact.kind === "runtime-side-effects" || artifact.kind === "codebox-observations"),
@@ -61,9 +87,11 @@ export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummar
       changed_files: artifacts.filter((artifact) => artifact.kind === "codebox-changed-files"),
       patches: artifacts.filter((artifact) => artifact.kind === "codebox-patch"),
       transcripts: artifacts.filter((artifact) => artifact.kind === "codebox-transcript"),
-      logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log" || artifact.kind === "codebox-event-log"),
+      logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log" || artifact.kind === "codebox-command-events" || artifact.kind === "codebox-event-log"),
       runtimes: agentTask.refs.runtimes,
     },
+    commands,
+    preview,
     metadata: stripUndefined({
       run_id: stringValue(objectValue(result.run).runId) || stringValue(objectValue(result.run_metadata).run_id) || stringValue(agentTask.metadata.run_id),
       run_status: stringValue(objectValue(result.run).status) || stringValue(objectValue(result.run_metadata).run_status) || stringValue(agentTask.metadata.run_status),
@@ -121,6 +149,7 @@ function normalizeRecipeRunArtifacts(result: Record<string, unknown>, agentTaskA
   const bundleDirectory = stringValue(bundle.directory) || stringValue(result.artifacts)
   appendUniqueArtifact(artifacts, stripUndefined({ id: stringValue(bundle.id), kind: "codebox-artifact-bundle", path: bundleDirectory, sha256: stringValue(bundle.contentDigest) }))
   appendPathArtifact(artifacts, "codebox-event-log", bundle.eventsPath)
+  appendPathArtifact(artifacts, "codebox-command-events", bundle.commandsPath)
   appendPathArtifact(artifacts, "codebox-command-log", bundle.commandsLogPath || bundle.commandsPath)
   appendPathArtifact(artifacts, "codebox-runtime-log", bundle.runtimeLogPath)
   appendPathArtifact(artifacts, "codebox-runtime-metadata", bundle.metadataPath)
@@ -151,6 +180,46 @@ function normalizeRecipeRunArtifacts(result: Record<string, unknown>, agentTaskA
   }
 
   return artifacts
+}
+
+function recipeRunCommandSummaries(result: Record<string, unknown>): RecipeRunCommandSummary[] {
+  return arrayObjects(result.executions).map((execution, index) => {
+    const exitCode = numberValue(execution.exitCode)
+    return stripUndefined({
+      index,
+      command: stringValue(execution.command) || `command-${index + 1}`,
+      status: exitCode === undefined ? "unknown" : exitCode === 0 ? "succeeded" : "failed",
+      exit_code: exitCode,
+      duration_ms: numberValue(execution.durationMs),
+      recipe_phase: stringValue(execution.recipePhase),
+      recipe_step_index: numberValue(execution.recipeStepIndex),
+      stdout_tail: textTail(execution.stdout),
+      stderr_tail: textTail(execution.stderr),
+    }) as RecipeRunCommandSummary
+  })
+}
+
+function recipeRunPreviewSummary(result: Record<string, unknown>): RecipeRunPreviewSummary | undefined {
+  const preview = objectValue(objectValue(result.artifacts).preview)
+  const runPreview = objectValue(objectValue(result.run).preview)
+  const value = Object.keys(preview).length > 0 ? preview : runPreview
+  if (Object.keys(value).length === 0) return undefined
+
+  return stripUndefined({
+    status: stringValue(value.status),
+    lifecycle: stringValue(value.lifecycle),
+    source: stringValue(value.source),
+    created_at: stringValue(value.createdAt),
+    expires_at: stringValue(value.expiresAt),
+    hold_seconds: numberValue(value.holdSeconds),
+    reviewer_access: objectValue(value.reviewerAccess),
+  }) as RecipeRunPreviewSummary
+}
+
+function textTail(value: unknown, maxChars = 4_000): string | undefined {
+  const text = stringValue(value)
+  if (!text) return undefined
+  return text.length > maxChars ? text.slice(-maxChars) : text
 }
 
 function appendPathArtifact(artifacts: AgentTaskRunArtifactRef[], kind: string, value: unknown): void {

--- a/scripts/browser-artifact-persistence-idempotency-smoke.ts
+++ b/scripts/browser-artifact-persistence-idempotency-smoke.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 
 const dir = mkdtempSync(join(tmpdir(), "wp-codebox-browser-artifact-idempotency-"))
 const smokePhp = join(dir, "smoke.php")
+const pathPolicyClassPath = new URL("../packages/wordpress-plugin/src/class-wp-codebox-path-policy.php", import.meta.url).pathname
 const classPath = new URL("../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php", import.meta.url).pathname
 
 writeFileSync(smokePhp, `<?php
@@ -59,6 +60,7 @@ function smoke_remove_tree(string $path): void {
 	rmdir($path);
 }
 
+require ${JSON.stringify(pathPolicyClassPath)};
 require ${JSON.stringify(classPath)};
 
 $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'wp-codebox-artifacts-' . bin2hex(random_bytes(8));

--- a/scripts/recipe-run-summary-smoke.ts
+++ b/scripts/recipe-run-summary-smoke.ts
@@ -7,16 +7,38 @@ const success = normalizeRecipeRunSummary({
     id: "bundle-ok",
     directory: "/tmp/codebox/bundle-ok",
     runtimeLogPath: "/tmp/codebox/bundle-ok/logs/runtime.log",
+    commandsPath: "/tmp/codebox/bundle-ok/commands.jsonl",
     commandsLogPath: "/tmp/codebox/bundle-ok/logs/commands.log",
     changedFilesPath: "/tmp/codebox/bundle-ok/files/changed-files.json",
     patchPath: "/tmp/codebox/bundle-ok/files/patch.diff",
+    preview: {
+      status: "available",
+      lifecycle: "held-after-run",
+      source: "public-url-override",
+      createdAt: "2026-06-17T00:00:00.000Z",
+      expiresAt: "2026-06-17T00:05:00.000Z",
+      holdSeconds: 300,
+      reviewerAccess: {
+        schema: "wp-codebox/preview-reviewer-access/v1",
+        status: "ready",
+        outcome: "public",
+        mode: "direct-url",
+        reviewerSafe: true,
+        openUrl: "https://example.com/preview",
+        targetUrl: "https://example.com/preview",
+      },
+    },
   },
+  executions: [{ command: "wordpress.wp-cli", exitCode: 0, stdout: "first\nsecond\n", stderr: "", durationMs: 12, recipePhase: "run_workloads", recipeStepIndex: 0 }],
   run: { runId: "run-ok", status: "succeeded" },
   phaseEvidence: [{ name: "runtime_startup", status: "completed" }],
 })
 assertEqual(success.status, "succeeded", "success normalizes to succeeded")
-assertEqual(success.refs.startup_logs.length, 2, "startup logs are grouped")
+assertEqual(success.refs.startup_logs.length, 3, "startup logs are grouped")
 assertEqual(success.refs.changed_files[0]?.path, "/tmp/codebox/bundle-ok/files/changed-files.json", "changed files path is grouped")
+assertEqual(success.refs.logs.some((ref) => ref.path === "/tmp/codebox/bundle-ok/commands.jsonl"), true, "commands jsonl is grouped")
+assertEqual(success.commands[0]?.stdout_tail, "first\nsecond\n", "command stdout tail is exposed")
+assertEqual(success.preview?.reviewer_access?.openUrl, "https://example.com/preview", "preview reviewer access is exposed")
 assertEqual(success.metadata.run_id, "run-ok", "run metadata is exposed")
 
 const startupFailure = normalizeRecipeRunSummary({


### PR DESCRIPTION
## Summary
- Add a normalized `result` envelope to `recipe-run --json` using `wp-codebox/recipe-run-summary/v1`.
- Mirror the normalized result into `latest-runtime.json` artifact pointers.
- Extend recipe run summaries with command stdout/stderr tails, commands.jsonl refs, and held-preview reviewer access.
- Fix the browser artifact idempotency smoke bootstrap to load the path policy dependency.

## Testing
- `npm run build`
- `npx tsx scripts/recipe-run-summary-smoke.ts`
- `npm run smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the upstream recipe-run result envelope, updated tests/docs, fixed the same-repo smoke bootstrap failure, and ran verification.
