### PR TITLE
Add executable browser DTO and persisted artifact bundle result

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -13,6 +13,7 @@ final class WP_Codebox_Artifacts {
 	private const GET_SCHEMA   = 'wp-codebox/artifact/v1';
 	private const BROWSER_ARTIFACT_GRANT_SCHEMA = 'wp-codebox/browser-artifact-grant/v1';
 	private const BROWSER_ARTIFACT_REF_SCHEMA = 'wp-codebox/browser-artifact-ref/v1';
+	private const BROWSER_PERSISTED_BUNDLE_SCHEMA = 'wp-codebox/browser-persisted-artifact-bundle/v1';
 	private const APPLY_PREFLIGHT_SCHEMA = 'wp-codebox/artifact-apply-preflight/v1';
 	private const APPLY_SCHEMA = 'wp-codebox/artifact-apply/v1';
 	private const APPLY_RESULT_SCHEMA = 'wp-codebox/apply-result/v1';
@@ -230,7 +231,7 @@ final class WP_Codebox_Artifacts {
 			}
 
 			$file_sha256 = hash( 'sha256', $file['bytes'] );
-			$changed_files['files'][] = array(
+			$changed_file = array(
 				'path'         => $file['path'],
 				'artifactPath' => $artifact_path,
 				'status'       => 'created',
@@ -240,6 +241,12 @@ final class WP_Codebox_Artifacts {
 				'sha256'       => array( 'algorithm' => 'sha256', 'value' => $file_sha256 ),
 				'kind'         => $file['kind'],
 			);
+			foreach ( array( 'roles', 'metadata', 'provenance', 'description' ) as $field ) {
+				if ( ! empty( $file[ $field ] ) ) {
+					$changed_file[ $field ] = $file[ $field ];
+				}
+			}
+			$changed_files['files'][] = $changed_file;
 			$manifest_files[] = $this->manifest_file( $artifact_path, 'browser-artifact', $file['mime_type'], $file_sha256 );
 		}
 
@@ -257,7 +264,8 @@ final class WP_Codebox_Artifacts {
 			if ( is_wp_error( $bundle ) ) {
 				return $bundle;
 			}
-			$artifact_ref = $this->browser_artifact_ref( $input, $bundle_id, $content_digest, $destination, 'existing' );
+			$artifact_ref      = $this->browser_artifact_ref( $input, $bundle_id, $content_digest, $destination, 'existing' );
+			$persisted_bundle = $this->browser_persisted_bundle_result( $input, $bundle, $artifact_ref );
 
 			return array(
 				'success'        => true,
@@ -266,9 +274,10 @@ final class WP_Codebox_Artifacts {
 				'artifact_id'    => $bundle_id,
 				'content_digest' => $content_digest,
 				'directory'      => $destination,
-				'artifact_ref'   => $artifact_ref,
-				'grant'          => $artifact_ref['grant'] ?? null,
-				'artifact'       => $bundle,
+				'artifact_ref'     => $artifact_ref,
+				'persisted_bundle' => $persisted_bundle,
+				'grant'            => $artifact_ref['grant'] ?? null,
+				'artifact'         => $bundle,
 			);
 		}
 
@@ -348,7 +357,8 @@ final class WP_Codebox_Artifacts {
 		if ( is_wp_error( $bundle ) ) {
 			return $bundle;
 		}
-		$artifact_ref = $this->browser_artifact_ref( $input, $bundle_id, $content_digest, $destination, 'created' );
+		$artifact_ref      = $this->browser_artifact_ref( $input, $bundle_id, $content_digest, $destination, 'created' );
+		$persisted_bundle = $this->browser_persisted_bundle_result( $input, $bundle, $artifact_ref );
 
 		return array(
 			'success'        => true,
@@ -357,9 +367,10 @@ final class WP_Codebox_Artifacts {
 			'artifact_id'    => $bundle_id,
 			'content_digest' => $content_digest,
 			'directory'      => $destination,
-			'artifact_ref'   => $artifact_ref,
-			'grant'          => $artifact_ref['grant'] ?? null,
-			'artifact'       => $bundle,
+			'artifact_ref'     => $artifact_ref,
+			'persisted_bundle' => $persisted_bundle,
+			'grant'            => $artifact_ref['grant'] ?? null,
+			'artifact'         => $bundle,
 		);
 	}
 
@@ -890,7 +901,7 @@ final class WP_Codebox_Artifacts {
 				$mime_type = $this->browser_bundle_mime_type( $path );
 			}
 
-			$normalized[] = array(
+			$normalized_file = array(
 				'path'      => $path,
 				'bytes'     => $bytes,
 				'encoding'  => $encoding,
@@ -898,6 +909,17 @@ final class WP_Codebox_Artifacts {
 				'kind'      => trim( (string) ( $file['kind'] ?? 'browser-artifact' ) ),
 				'roles'     => array_values( array_filter( array_map( 'strval', is_array( $file['roles'] ?? null ) ? $file['roles'] : array() ), static fn( string $role ): bool => '' !== trim( $role ) ) ),
 			);
+			foreach ( array( 'metadata', 'provenance' ) as $field ) {
+				if ( is_array( $file[ $field ] ?? null ) ) {
+					$normalized_file[ $field ] = $this->stable_assoc_array( $file[ $field ] );
+				}
+			}
+			$description = trim( (string) ( $file['description'] ?? '' ) );
+			if ( '' !== $description ) {
+				$normalized_file['description'] = $description;
+			}
+
+			$normalized[] = $normalized_file;
 		}
 
 		return $normalized;
@@ -1055,6 +1077,54 @@ final class WP_Codebox_Artifacts {
 		);
 
 		return $this->strip_null_values( $ref );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $bundle Persisted artifact bundle. @param array<string,mixed> $artifact_ref Browser artifact reference. @return array<string,mixed> */
+	private function browser_persisted_bundle_result( array $input, array $bundle, array $artifact_ref ): array {
+		$changed_files = is_array( $bundle['changed_files']['files'] ?? null ) ? $bundle['changed_files']['files'] : array();
+		$files         = array();
+		foreach ( $changed_files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$sha256 = is_array( $file['sha256'] ?? null ) ? (string) ( $file['sha256']['value'] ?? '' ) : (string) ( $file['sha256'] ?? '' );
+			$files[] = $this->strip_null_values(
+				array(
+					'path'          => (string) ( $file['path'] ?? '' ),
+					'artifact_path' => (string) ( $file['artifactPath'] ?? $file['artifact_path'] ?? '' ),
+					'status'        => (string) ( $file['status'] ?? '' ),
+					'encoding'      => (string) ( $file['encoding'] ?? '' ),
+					'mime_type'     => (string) ( $file['mimeType'] ?? $file['mime_type'] ?? '' ),
+					'size'          => isset( $file['size'] ) ? (int) $file['size'] : null,
+					'sha256'        => '' === $sha256 ? null : array( 'algorithm' => 'sha256', 'value' => $sha256 ),
+					'kind'          => (string) ( $file['kind'] ?? '' ),
+					'roles'         => is_array( $file['roles'] ?? null ) ? array_values( $file['roles'] ) : null,
+					'metadata'      => is_array( $file['metadata'] ?? null ) ? $file['metadata'] : null,
+					'provenance'    => is_array( $file['provenance'] ?? null ) ? $file['provenance'] : null,
+					'description'   => (string) ( $file['description'] ?? '' ),
+				)
+			);
+		}
+
+		$metadata = is_array( $bundle['metadata'] ?? null ) ? $bundle['metadata'] : array();
+		$caller   = is_array( $metadata['caller'] ?? null ) ? $metadata['caller'] : $this->browser_caller_metadata( $input );
+
+		return $this->strip_null_values(
+			array(
+				'schema'         => self::BROWSER_PERSISTED_BUNDLE_SCHEMA,
+				'artifact_id'    => (string) ( $bundle['id'] ?? $artifact_ref['artifact_id'] ?? '' ),
+				'content_digest' => (string) ( $bundle['content_digest'] ?? $artifact_ref['content_digest'] ?? '' ),
+				'directory'      => (string) ( $bundle['directory'] ?? $artifact_ref['artifacts_path'] ?? '' ),
+				'status'         => (string) ( $artifact_ref['status'] ?? '' ),
+				'artifact_ref'   => $artifact_ref,
+				'root'           => (string) ( $input['root'] ?? '' ),
+				'entrypoint'     => (string) ( $input['entrypoint'] ?? '' ),
+				'files'          => $files,
+				'provenance'     => is_array( $metadata['provenance'] ?? null ) ? $metadata['provenance'] : null,
+				'caller'         => empty( $caller ) ? null : $caller,
+			)
+		);
 	}
 
 	/** @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -467,6 +467,7 @@ private static function compact_browser_materializer_contract_dto( array $contra
 			'authorization'    => is_array( $contract['authorization'] ?? null ) ? self::compact_browser_dto_value( $contract['authorization'] ) : array(),
 			'task_input'       => is_array( $contract['task_input'] ?? null ) ? self::compact_browser_dto_value( $contract['task_input'] ) : array(),
 			'task_payload'     => is_array( $contract['task_payload'] ?? null ) ? self::compact_browser_dto_value( $contract['task_payload'] ) : array(),
+			'executable'       => self::browser_executable_materializer_contract_dto( $contract ),
 			'materialization'  => is_array( $contract['materialization'] ?? null ) ? self::compact_browser_dto_value( $contract['materialization'] ) : array(),
 			'recipe'           => is_array( $contract['recipe'] ?? null ) ? self::compact_browser_recipe_dto( $contract['recipe'] ) : array(),
 			'playground'       => is_array( $contract['playground'] ?? null ) ? self::compact_browser_playground_dto( $contract['playground'] ) : array(),
@@ -475,6 +476,62 @@ private static function compact_browser_materializer_contract_dto( array $contra
 		),
 		static fn( mixed $value ): bool => array() !== $value && '' !== $value
 	);
+}
+
+/** @param array<string,mixed> $contract Browser materializer contract. @return array<string,mixed> */
+private static function browser_executable_materializer_contract_dto( array $contract ): array {
+	$task_payload = is_array( $contract['task_payload'] ?? null ) ? $contract['task_payload'] : array();
+	$task_input   = is_array( $contract['task_input'] ?? null ) ? $contract['task_input'] : array();
+	$payload_bundles = is_array( $task_payload['agent_bundles'] ?? null ) ? self::normalize_agent_bundles( $task_payload['agent_bundles'] ) : array();
+	$input_bundles   = is_array( $task_input['agent_bundles'] ?? null ) ? self::normalize_agent_bundles( $task_input['agent_bundles'] ) : array();
+	$agent_bundles   = ! empty( $payload_bundles ) ? $payload_bundles : $input_bundles;
+
+	return array_filter(
+		array(
+			'schema'       => 'wp-codebox/browser-materializer-executable-dto/v1',
+			'session_id'   => (string) ( $contract['session_id'] ?? $task_payload['session_id'] ?? '' ),
+			'task_payload' => self::compact_browser_executable_task_payload( $task_payload, $agent_bundles ),
+			'task_input'   => self::compact_browser_executable_task_input( $task_input, $agent_bundles ),
+		),
+		static fn( mixed $value ): bool => array() !== $value && '' !== $value
+	);
+}
+
+/** @param array<string,mixed> $task_payload Browser task payload. @param array<int,array<string,mixed>> $agent_bundles Executable bundle specs. @return array<string,mixed> */
+private static function compact_browser_executable_task_payload( array $task_payload, array $agent_bundles ): array {
+	$compact = array();
+	foreach ( array( 'schema', 'agent', 'mode', 'provider', 'model', 'message', 'session_id' ) as $field ) {
+		$value = isset( $task_payload[ $field ] ) ? (string) $task_payload[ $field ] : '';
+		if ( '' !== $value ) {
+			$compact[ $field ] = $value;
+		}
+	}
+	if ( ! empty( $agent_bundles ) ) {
+		$compact['agent_bundles'] = $agent_bundles;
+	}
+
+	return $compact;
+}
+
+/** @param array<string,mixed> $task_input Browser task input. @param array<int,array<string,mixed>> $agent_bundles Executable bundle specs. @return array<string,mixed> */
+private static function compact_browser_executable_task_input( array $task_input, array $agent_bundles ): array {
+	$compact = array();
+	foreach ( array( 'schema', 'version', 'goal' ) as $field ) {
+		$value = isset( $task_input[ $field ] ) ? (string) $task_input[ $field ] : '';
+		if ( '' !== $value ) {
+			$compact[ $field ] = $value;
+		}
+	}
+	foreach ( array( 'target', 'allowed_tools', 'expected_artifacts', 'structured_artifacts', 'sandbox_tool_policy', 'policy', 'context' ) as $field ) {
+		if ( is_array( $task_input[ $field ] ?? null ) ) {
+			$compact[ $field ] = self::compact_browser_dto_value( $task_input[ $field ] );
+		}
+	}
+	if ( ! empty( $agent_bundles ) ) {
+		$compact['agent_bundles'] = $agent_bundles;
+	}
+
+	return array_filter( $compact, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 }
 
 /** @param array<string,mixed> $session Browser session envelope. @return array<string,mixed> */

--- a/scripts/browser-artifact-persistence-idempotency-smoke.ts
+++ b/scripts/browser-artifact-persistence-idempotency-smoke.ts
@@ -78,6 +78,10 @@ $input = array(
 			'path' => 'website/index.html',
 			'content' => '<!doctype html><title>Smoke</title>',
 			'encoding' => 'utf-8',
+			'roles' => array('entrypoint'),
+			'metadata' => array('label' => 'Home'),
+			'provenance' => array('source' => 'smoke'),
+			'description' => 'Smoke home page',
 		),
 	),
 );
@@ -91,6 +95,13 @@ try {
 	smoke_assert('' !== (string) ($created['content_digest'] ?? ''), 'first persistence should return content_digest');
 	smoke_assert('wp-codebox/browser-artifact-ref/v1' === ($created['artifact_ref']['schema'] ?? ''), 'first persistence should return a normalized artifact_ref');
 	smoke_assert(($created['artifact_id'] ?? '') === ($created['artifact_ref']['artifact_id'] ?? ''), 'artifact_ref should carry the persisted artifact id');
+	smoke_assert('wp-codebox/browser-persisted-artifact-bundle/v1' === ($created['persisted_bundle']['schema'] ?? ''), 'first persistence should return a canonical persisted bundle result');
+	smoke_assert(($created['artifact_id'] ?? '') === ($created['persisted_bundle']['artifact_id'] ?? ''), 'persisted bundle should carry the persisted artifact id');
+	smoke_assert('website/index.html' === ($created['persisted_bundle']['files'][0]['path'] ?? ''), 'persisted bundle should carry browser file paths');
+	smoke_assert('files/browser/website/index.html' === ($created['persisted_bundle']['files'][0]['artifact_path'] ?? ''), 'persisted bundle should carry canonical artifact paths');
+	smoke_assert('Home' === ($created['persisted_bundle']['files'][0]['metadata']['label'] ?? ''), 'persisted bundle should preserve per-file metadata');
+	smoke_assert('smoke' === ($created['persisted_bundle']['files'][0]['provenance']['source'] ?? ''), 'persisted bundle should preserve per-file provenance');
+	smoke_assert('entrypoint' === ($created['persisted_bundle']['files'][0]['roles'][0] ?? ''), 'persisted bundle should preserve per-file roles');
 	smoke_assert('wp-codebox/browser-artifact-grant/v1' === ($created['grant']['schema'] ?? ''), 'first persistence should return a scoped artifact grant');
 	smoke_assert('artifact:write' === ($created['grant']['authorization']['scope'] ?? ''), 'artifact grant should carry artifact write authorization');
 
@@ -100,6 +111,8 @@ try {
 	smoke_assert($created['artifact_id'] === $existing['artifact_id'], 'duplicate persistence should return stable artifact_id');
 	smoke_assert($created['content_digest'] === $existing['content_digest'], 'duplicate persistence should return stable content_digest');
 	smoke_assert($created['artifact_ref']['artifact_id'] === $existing['artifact_ref']['artifact_id'], 'duplicate persistence should return stable artifact_ref');
+	smoke_assert($created['persisted_bundle']['artifact_id'] === $existing['persisted_bundle']['artifact_id'], 'duplicate persistence should return stable persisted bundle result');
+	smoke_assert('smoke' === ($existing['persisted_bundle']['files'][0]['provenance']['source'] ?? ''), 'duplicate persistence should preserve per-file provenance');
 	smoke_assert(is_array($existing['artifact'] ?? null), 'duplicate persistence should return existing artifact payload');
 } finally {
 	smoke_remove_tree($root);

--- a/scripts/executable-browser-dto-smoke.ts
+++ b/scripts/executable-browser-dto-smoke.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const dir = mkdtempSync(join(tmpdir(), "wp-codebox-executable-browser-dto-"))
+const smokePhp = join(dir, "smoke.php")
+const traitPath = new URL("../packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php", import.meta.url).pathname
+
+writeFileSync(smokePhp, `<?php
+define('ABSPATH', __DIR__);
+
+class WP_Codebox_Redaction_Policy {
+	public static function key_should_redact(string $profile, string $key): bool {
+		return false;
+	}
+}
+
+function smoke_assert(bool $condition, string $message): void {
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+require ${JSON.stringify(traitPath)};
+
+class Smoke_Browser_DTO {
+	use WP_Codebox_Abilities_Execution;
+
+	public static function compact(array $contract): array {
+		return self::compact_browser_materializer_contract_dto($contract);
+	}
+
+	private static function normalize_agent_bundles(mixed $bundles): array {
+		$normalized = array();
+		foreach (is_array($bundles) ? $bundles : array() as $bundle) {
+			if (!is_array($bundle)) {
+				continue;
+			}
+			$source = isset($bundle['source']) ? trim((string) $bundle['source']) : '';
+			$inline = is_array($bundle['bundle'] ?? null) ? $bundle['bundle'] : null;
+			if ('' === $source && null === $inline) {
+				continue;
+			}
+			$entry = array('on_conflict' => 'upgrade');
+			if ('' !== $source) {
+				$entry['source'] = $source;
+			}
+			if (null !== $inline) {
+				$entry['bundle'] = $inline;
+			}
+			if (isset($bundle['slug'])) {
+				$entry['slug'] = (string) $bundle['slug'];
+			}
+			$normalized[] = $entry;
+		}
+		return $normalized;
+	}
+}
+
+$contract = array(
+	'success' => true,
+	'schema' => 'wp-codebox/browser-materializer-contract/v1',
+	'session_id' => 'session-123',
+	'task_input' => array(
+		'schema' => 'wp-codebox/agent-task-input/v1',
+		'goal' => 'Build a site',
+		'agent_bundles' => array(
+			array(
+				'source' => 'https://example.test/agent-bundle.json',
+				'slug' => 'example-agent',
+			),
+		),
+	),
+	'task_payload' => array(
+		'schema' => 'wp-codebox/browser-agent-task-payload/v1',
+		'agent' => 'wp-codebox-sandbox',
+		'session_id' => 'session-123',
+		'agent_bundles' => array(
+			array(
+				'bundle' => array('schema' => 'agents/runtime-bundle/v1', 'agent' => array('slug' => 'inline-agent')),
+				'slug' => 'inline-agent',
+			),
+		),
+	),
+);
+
+$compact = Smoke_Browser_DTO::compact($contract);
+
+smoke_assert('wp-codebox/browser-materializer-product-dto/v1' === ($compact['schema'] ?? ''), 'summary DTO schema should remain product DTO');
+smoke_assert(!isset($compact['task_payload']['agent_bundles'][0]['bundle']), 'summary task_payload should not include inline bundle payloads');
+smoke_assert(!isset($compact['task_input']['agent_bundles'][0]['source']), 'summary task_input should not include executable sources');
+smoke_assert('wp-codebox/browser-materializer-executable-dto/v1' === ($compact['executable']['schema'] ?? ''), 'executable DTO should be explicit');
+smoke_assert('session-123' === ($compact['executable']['session_id'] ?? ''), 'executable DTO should carry session id');
+smoke_assert('inline-agent' === ($compact['executable']['task_payload']['agent_bundles'][0]['slug'] ?? ''), 'executable DTO should carry bundle slug');
+smoke_assert('agents/runtime-bundle/v1' === ($compact['executable']['task_payload']['agent_bundles'][0]['bundle']['schema'] ?? ''), 'executable DTO should carry inline bundle payload');
+smoke_assert('agents/runtime-bundle/v1' === ($compact['executable']['task_input']['agent_bundles'][0]['bundle']['schema'] ?? ''), 'executable task input should carry importable bundle payload');
+`)
+
+execFileSync("php", ["-l", smokePhp], { stdio: "pipe" })
+execFileSync("php", [smokePhp], { stdio: "pipe" })
+
+console.log("Executable browser DTO smoke passed")

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -79,6 +79,7 @@ export const smokeGroups = {
       tsxSmoke("typed-artifacts-smoke"),
       tsxSmoke("artifact-browser-error-collection-smoke"),
       tsxSmoke("browser-artifact-persistence-idempotency-smoke"),
+      tsxSmoke("executable-browser-dto-smoke"),
       tsxSmoke("partial-artifact-discovery-smoke"),
       tsxSmoke("mounted-workspace-diff-smoke"),
       tsxSmoke("replay-export-blueprint-smoke"),


### PR DESCRIPTION
## Summary
- add an explicit executable browser materializer DTO so replay callers can use importable agent_bundles without relying on summary compaction
- keep summary DTOs source-free while preserving executable bundle specs under executable.task_payload/task_input
- return a canonical persisted browser artifact bundle result with stable refs and per-file metadata/provenance from browser artifact persistence
- preserve per-file metadata, provenance, roles, and descriptions in canonical changed-files payloads

## Tests
- php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- npx tsx scripts/executable-browser-dto-smoke.ts
- npx tsx scripts/browser-artifact-persistence-idempotency-smoke.ts
- npm run test:browser-task-builder
- npm run test:schema-parity
- npm run smoke -- --group=artifact
- npm run build

## Notes
- npm install completed in the isolated worktree and reported one existing high-severity npm audit item.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the executable DTO and persisted artifact bundle contract changes, added smoke coverage, and ran verification; Chris remains responsible for review and acceptance.
