### PR TITLE
Normalize sandbox tool policies from allowed tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
     "test:php-json-codec": "tsx tests/php-json-codec.test.ts",
     "test:php-managed-host-command": "tsx tests/php-managed-host-command.test.ts",
+    "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",
     "test:mcp-client-configs": "tsx tests/mcp-client-configs.test.ts",
     "test:runtime-tool-policy": "tsx tests/runtime-tool-policy.test.ts",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
@@ -35,6 +35,14 @@ final class WP_Codebox_Agent_Task {
 			}
 		}
 
+		if ( ! empty( $task_input['allowed_tools'] ) ) {
+			$policy = ( new WP_Codebox_Sandbox_Tool_Policy_Normalizer() )->normalize_for_task_input( $task_input );
+			if ( is_wp_error( $policy ) ) {
+				return $policy;
+			}
+			$task_input['sandbox_tool_policy'] = $policy;
+		}
+
 		return $task_input;
 	}
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-tool-policy-validator.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-tool-policy-validator.php
@@ -9,11 +9,11 @@ defined( 'ABSPATH' ) || exit;
 
 final class WP_Codebox_Host_Tool_Policy_Validator {
 
-	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
-	private const SANDBOX_TOOL_POLICY_SCHEMA = 'wp-codebox/sandbox-tool-policy/v1';
-	private const AGENTS_API_RUNTIME_ENVIRONMENT = 'environment';
-	private const AGENTS_API_RUNTIME_CAPABILITY_SCOPE = 'capability_scope';
-	private const AGENTS_API_RUNTIME_LOCAL = 'runtime_local';
+	private WP_Codebox_Sandbox_Tool_Policy_Normalizer $normalizer;
+
+	public function __construct() {
+		$this->normalizer = new WP_Codebox_Sandbox_Tool_Policy_Normalizer();
+	}
 
 	/** @param string[] $tools @param array<string,mixed>|null $task_input Normalized task input. */
 	public function validate_allowed_tools( array $tools, ?array $task_input = null ): WP_Error|null {
@@ -22,41 +22,7 @@ final class WP_Codebox_Host_Tool_Policy_Validator {
 
 	/** @param array<string,mixed> $task_input Normalized task input. */
 	public function validate_task_tools( array $task_input ): WP_Error|null {
-		$tools  = $this->string_list( $task_input['allowed_tools'] ?? array() );
-		$policy = $this->resolved_sandbox_tool_policy( $task_input );
-		if ( is_wp_error( $policy ) ) {
-			return $policy;
-		}
-
-		$allowed = $this->allowed_sandbox_tools( $policy );
-		$denied  = array();
-
-		foreach ( $tools as $tool ) {
-			$policy_tool = $this->sandbox_policy_tool( $policy, $tool );
-			$reason      = null === $policy_tool ? 'not-in-policy' : $this->sandbox_policy_denial_reason( $policy_tool );
-			if ( null !== $reason ) {
-				$denied[] = array(
-					'tool'   => $tool,
-					'reason' => $reason,
-				);
-			}
-		}
-
-		if ( empty( $denied ) ) {
-			return null;
-		}
-
-		return new WP_Error(
-			'wp_codebox_tool_not_allowed',
-			'One or more requested tools are not allowed by the resolved sandbox tool policy.',
-			array(
-				'status'        => 403,
-				'schema'        => self::TOOL_DENIAL_SCHEMA,
-				'denied_tools'  => $denied,
-				'allowed_tools' => $allowed,
-				'policy_schema' => $policy['schema'] ?? '',
-			)
-		);
+		return $this->normalizer->validate_task_tools( $this->string_list( $task_input['allowed_tools'] ?? array() ), $task_input );
 	}
 
 	/** @return string[] */
@@ -75,129 +41,6 @@ final class WP_Codebox_Host_Tool_Policy_Validator {
 					static fn( string $value ): bool => '' !== $value
 				)
 			)
-		);
-	}
-
-	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
-	private function resolved_sandbox_tool_policy( array $input ): array|WP_Error {
-		$policy = is_array( $input['sandbox_tool_policy'] ?? null ) ? $input['sandbox_tool_policy'] : array();
-		if ( empty( $policy ) && function_exists( 'apply_filters' ) ) {
-			$policy = apply_filters( 'wp_codebox_resolved_sandbox_tool_policy', $policy, $input );
-		}
-
-		$issues = $this->sandbox_tool_policy_issues( is_array( $policy ) ? $policy : array() );
-		if ( ! empty( $issues ) ) {
-			return new WP_Error(
-				'wp_codebox_sandbox_tool_policy_invalid',
-				'Allowed tools require a valid resolved sandbox_tool_policy snapshot.',
-				array(
-					'status' => 400,
-					'schema' => 'wp-codebox/sandbox-tool-policy-validation/v1',
-					'issues' => $issues,
-				)
-			);
-		}
-
-		return $policy;
-	}
-
-	/** @param array<string,mixed> $policy @return array<int,array<string,string>> */
-	private function sandbox_tool_policy_issues( array $policy ): array {
-		$issues = array();
-		if ( self::SANDBOX_TOOL_POLICY_SCHEMA !== ( $policy['schema'] ?? '' ) ) {
-			$issues[] = array( 'field' => 'schema', 'message' => 'sandbox_tool_policy.schema must be ' . self::SANDBOX_TOOL_POLICY_SCHEMA . '.' );
-		}
-		if ( 1 !== (int) ( $policy['version'] ?? 0 ) ) {
-			$issues[] = array( 'field' => 'version', 'message' => 'sandbox_tool_policy.version must be 1.' );
-		}
-		if ( empty( $policy['tools'] ) || ! is_array( $policy['tools'] ) ) {
-			$issues[] = array( 'field' => 'tools', 'message' => 'sandbox_tool_policy.tools must be a non-empty array.' );
-			return $issues;
-		}
-
-		$seen = array();
-		foreach ( $policy['tools'] as $index => $tool ) {
-			if ( ! is_array( $tool ) ) {
-				$issues[] = array( 'field' => 'tools[' . $index . ']', 'message' => 'Each sandbox tool policy tool must be an object.' );
-				continue;
-			}
-			$id = trim( (string) ( $tool['id'] ?? '' ) );
-			if ( '' === $id ) {
-				$issues[] = array( 'field' => 'tools[' . $index . '].id', 'message' => 'Tool id must be a non-empty string.' );
-			} elseif ( isset( $seen[ $id ] ) ) {
-				$issues[] = array( 'field' => 'tools[' . $index . '].id', 'message' => 'Duplicate tool id: ' . $id . '.' );
-			}
-			$seen[ $id ] = true;
-			foreach ( array( 'runtime_tool_id' ) as $field ) {
-				if ( '' === trim( (string) ( $tool[ $field ] ?? '' ) ) ) {
-					$issues[] = array( 'field' => 'tools[' . $index . '].' . $field, 'message' => 'Tool ' . $field . ' must be a non-empty string.' );
-				}
-			}
-			$runtime = is_array( $tool['runtime'] ?? null ) ? $tool['runtime'] : array();
-			foreach ( array( self::AGENTS_API_RUNTIME_ENVIRONMENT, self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ) as $field ) {
-				if ( '' === trim( (string) ( $runtime[ $field ] ?? '' ) ) ) {
-					$issues[] = array( 'field' => 'tools[' . $index . '].runtime.' . $field, 'message' => 'Tool runtime.' . $field . ' must be a non-empty string.' );
-				}
-			}
-			if ( ! is_bool( $tool['allowed'] ?? null ) ) {
-				$issues[] = array( 'field' => 'tools[' . $index . '].allowed', 'message' => 'Tool allowed must be boolean.' );
-			}
-		}
-
-		return $issues;
-	}
-
-	/** @param array<string,mixed> $policy @return string[] */
-	private function allowed_sandbox_tools( array $policy ): array {
-		$allowed = array();
-		foreach ( is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array() as $tool ) {
-			if ( is_array( $tool ) && null === $this->sandbox_policy_denial_reason( $tool ) ) {
-				$allowed[] = (string) $tool['id'];
-			}
-		}
-
-		return array_values( array_unique( $allowed ) );
-	}
-
-	/** @param array<string,mixed> $policy @return array<string,mixed>|null */
-	private function sandbox_policy_tool( array $policy, string $tool_id ): array|null {
-		foreach ( is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array() as $tool ) {
-			if ( is_array( $tool ) && $tool_id === (string) ( $tool['id'] ?? '' ) ) {
-				return $tool;
-			}
-		}
-
-		return null;
-	}
-
-	/** @param array<string,mixed> $tool */
-	private function sandbox_policy_denial_reason( array $tool ): string|null {
-		$runtime = $this->sandbox_tool_runtime_metadata( $tool );
-
-		if ( self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] ) {
-			return 'parent-only';
-		}
-		if ( self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] ) {
-			return 'not-visible-in-sandbox';
-		}
-		if ( true !== ( $tool['allowed'] ?? false ) ) {
-			return 'not-allowed';
-		}
-
-		return null;
-	}
-
-	/** @param array<string,mixed> $tool @return array{environment:string,capability_scope:string} */
-	private function sandbox_tool_runtime_metadata( array $tool ): array {
-		$runtime = is_array( $tool['runtime'] ?? null ) ? $tool['runtime'] : array();
-
-		return array(
-			self::AGENTS_API_RUNTIME_ENVIRONMENT => isset( $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
-				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
-				: '',
-			self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE => isset( $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
-				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
-				: '',
 		);
 	}
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Sandbox tool policy normalization.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
+
+	public const SCHEMA  = 'wp-codebox/sandbox-tool-policy/v1';
+	public const VERSION = 1;
+
+	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
+	private const AGENTS_API_RUNTIME_ENVIRONMENT = 'environment';
+	private const AGENTS_API_RUNTIME_CAPABILITY_SCOPE = 'capability_scope';
+	private const AGENTS_API_RUNTIME_LOCAL = 'runtime_local';
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function normalize_for_task_input( array $input ): array|WP_Error {
+		$policy = is_array( $input['sandbox_tool_policy'] ?? null ) ? $input['sandbox_tool_policy'] : array();
+		if ( empty( $policy ) ) {
+			$policy = $this->from_allowed_tools( $this->string_list( $input['allowed_tools'] ?? array() ), $input );
+		}
+		if ( empty( $policy ) && function_exists( 'apply_filters' ) ) {
+			$policy = apply_filters( 'wp_codebox_resolved_sandbox_tool_policy', $policy, $input );
+		}
+
+		$issues = $this->policy_issues( is_array( $policy ) ? $policy : array() );
+		if ( ! empty( $issues ) ) {
+			return new WP_Error(
+				'wp_codebox_sandbox_tool_policy_invalid',
+				'Allowed tools require a valid resolved sandbox_tool_policy snapshot.',
+				array(
+					'status' => 400,
+					'schema' => 'wp-codebox/sandbox-tool-policy-validation/v1',
+					'issues' => $issues,
+				)
+			);
+		}
+
+		return $policy;
+	}
+
+	/** @param string[] $tools @param array<string,mixed> $task_input */
+	public function validate_task_tools( array $tools, array $task_input ): WP_Error|null {
+		$policy = $this->normalize_for_task_input( $task_input );
+		if ( is_wp_error( $policy ) ) {
+			return $policy;
+		}
+
+		$denied = array();
+		foreach ( $this->string_list( $tools ) as $tool ) {
+			$policy_tool = $this->policy_tool( $policy, $tool );
+			$reason      = null === $policy_tool ? 'not-in-policy' : $this->policy_denial_reason( $policy_tool );
+			if ( null !== $reason ) {
+				$denied[] = array(
+					'tool'   => $tool,
+					'reason' => $reason,
+				);
+			}
+		}
+
+		if ( empty( $denied ) ) {
+			return null;
+		}
+
+		return new WP_Error(
+			'wp_codebox_tool_not_allowed',
+			'One or more requested tools are not allowed by the resolved sandbox tool policy.',
+			array(
+				'status'        => 403,
+				'schema'        => self::TOOL_DENIAL_SCHEMA,
+				'denied_tools'  => $denied,
+				'allowed_tools' => $this->allowed_tools( $policy ),
+				'policy_schema' => $policy['schema'] ?? '',
+			)
+		);
+	}
+
+	/** @param string[] $allowed_tools @param array<string,mixed> $context @return array<string,mixed> */
+	public function from_allowed_tools( array $allowed_tools, array $context = array() ): array {
+		$policy_tools = array();
+		foreach ( $this->string_list( $allowed_tools ) as $tool_id ) {
+			$tool = $this->tool_policy_entry( $tool_id, $context );
+			if ( ! empty( $tool ) ) {
+				$policy_tools[] = $tool;
+			}
+		}
+
+		if ( empty( $policy_tools ) ) {
+			return array();
+		}
+
+		$policy = array(
+			'schema'  => self::SCHEMA,
+			'version' => self::VERSION,
+			'tools'   => $policy_tools,
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'wp_codebox_sandbox_tool_policy', $policy, $allowed_tools, $context );
+			if ( is_array( $filtered ) ) {
+				$policy = $filtered;
+			}
+		}
+
+		return $policy;
+	}
+
+	/** @return string[] */
+	public function allowed_tools( array $policy ): array {
+		$allowed = array();
+		foreach ( is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array() as $tool ) {
+			if ( is_array( $tool ) && null === $this->policy_denial_reason( $tool ) ) {
+				$allowed[] = (string) $tool['id'];
+			}
+		}
+
+		return array_values( array_unique( $allowed ) );
+	}
+
+	/** @param array<string,mixed> $policy @return array<int,array<string,string>> */
+	public function policy_issues( array $policy ): array {
+		$issues = array();
+		if ( self::SCHEMA !== ( $policy['schema'] ?? '' ) ) {
+			$issues[] = array( 'field' => 'schema', 'message' => 'sandbox_tool_policy.schema must be ' . self::SCHEMA . '.' );
+		}
+		if ( self::VERSION !== (int) ( $policy['version'] ?? 0 ) ) {
+			$issues[] = array( 'field' => 'version', 'message' => 'sandbox_tool_policy.version must be ' . self::VERSION . '.' );
+		}
+		if ( empty( $policy['tools'] ) || ! is_array( $policy['tools'] ) ) {
+			$issues[] = array( 'field' => 'tools', 'message' => 'sandbox_tool_policy.tools must be a non-empty array.' );
+			return $issues;
+		}
+
+		$seen = array();
+		foreach ( $policy['tools'] as $index => $tool ) {
+			if ( ! is_array( $tool ) ) {
+				$issues[] = array( 'field' => 'tools[' . $index . ']', 'message' => 'Each sandbox tool policy tool must be an object.' );
+				continue;
+			}
+			$id = trim( (string) ( $tool['id'] ?? '' ) );
+			if ( '' === $id ) {
+				$issues[] = array( 'field' => 'tools[' . $index . '].id', 'message' => 'Tool id must be a non-empty string.' );
+			} elseif ( isset( $seen[ $id ] ) ) {
+				$issues[] = array( 'field' => 'tools[' . $index . '].id', 'message' => 'Duplicate tool id: ' . $id . '.' );
+			}
+			$seen[ $id ] = true;
+			if ( '' === trim( (string) ( $tool['runtime_tool_id'] ?? '' ) ) ) {
+				$issues[] = array( 'field' => 'tools[' . $index . '].runtime_tool_id', 'message' => 'Tool runtime_tool_id must be a non-empty string.' );
+			}
+			$runtime = is_array( $tool['runtime'] ?? null ) ? $tool['runtime'] : array();
+			foreach ( array( self::AGENTS_API_RUNTIME_ENVIRONMENT, self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ) as $field ) {
+				if ( '' === trim( (string) ( $runtime[ $field ] ?? '' ) ) ) {
+					$issues[] = array( 'field' => 'tools[' . $index . '].runtime.' . $field, 'message' => 'Tool runtime.' . $field . ' must be a non-empty string.' );
+				}
+			}
+			if ( ! is_bool( $tool['allowed'] ?? null ) ) {
+				$issues[] = array( 'field' => 'tools[' . $index . '].allowed', 'message' => 'Tool allowed must be boolean.' );
+			}
+		}
+
+		return $issues;
+	}
+
+	/** @param array<string,mixed> $context @return array<string,mixed> */
+	private function tool_policy_entry( string $tool_id, array $context ): array {
+		$tool_id = trim( $tool_id );
+		if ( '' === $tool_id ) {
+			return array();
+		}
+
+		$entry = array(
+			'id'                   => $tool_id,
+			'runtime_tool_id'      => $this->provider_safe_runtime_tool_id( $tool_id ),
+			'execution_location'   => 'sandbox',
+			'transport_visibility' => 'sandbox',
+			'allowed'              => true,
+			'runtime'              => array(
+				self::AGENTS_API_RUNTIME_ENVIRONMENT      => self::AGENTS_API_RUNTIME_LOCAL,
+				self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE => self::AGENTS_API_RUNTIME_LOCAL,
+			),
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'wp_codebox_sandbox_tool_policy_tool', $entry, $tool_id, $context );
+			if ( is_array( $filtered ) ) {
+				$entry = $filtered;
+			}
+		}
+
+		return $entry;
+	}
+
+	private function provider_safe_runtime_tool_id( string $tool_id ): string {
+		return trim( preg_replace( '/[^A-Za-z0-9_]+/', '_', $tool_id ) ?? '', '_' );
+	}
+
+	/** @return string[] */
+	private function string_list( mixed $values ): array {
+		if ( ! is_array( $values ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map(
+						static fn( $value ): string => trim( (string) $value ),
+						$values
+					),
+					static fn( string $value ): bool => '' !== $value
+				)
+			)
+		);
+	}
+
+	/** @param array<string,mixed> $policy @return array<string,mixed>|null */
+	private function policy_tool( array $policy, string $tool_id ): array|null {
+		foreach ( is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array() as $tool ) {
+			if ( is_array( $tool ) && $tool_id === (string) ( $tool['id'] ?? '' ) ) {
+				return $tool;
+			}
+		}
+
+		return null;
+	}
+
+	/** @param array<string,mixed> $tool */
+	private function policy_denial_reason( array $tool ): string|null {
+		$runtime = $this->runtime_metadata( $tool );
+
+		if ( self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] ) {
+			return 'parent-only';
+		}
+		if ( self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] ) {
+			return 'not-visible-in-sandbox';
+		}
+		if ( true !== ( $tool['allowed'] ?? false ) ) {
+			return 'not-allowed';
+		}
+
+		return null;
+	}
+
+	/** @param array<string,mixed> $tool @return array{environment:string,capability_scope:string} */
+	private function runtime_metadata( array $tool ): array {
+		$runtime = is_array( $tool['runtime'] ?? null ) ? $tool['runtime'] : array();
+
+		return array(
+			self::AGENTS_API_RUNTIME_ENVIRONMENT => isset( $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
+				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
+				: '',
+			self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE => isset( $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
+				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
+				: '',
+		);
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -1312,7 +1312,8 @@ foreach ( is_array( $sandbox_policy[\'tools\'] ?? null ) ? $sandbox_policy[\'too
 		continue;
 	}
 	$tool_id = trim( (string) ( $tool_policy_entry[\'id\'] ?? \'\' ) );
-	$tool_name = wp_codebox_browser_runtime_tool_name( $tool_id );
+	$runtime_tool_id = trim( (string) ( $tool_policy_entry[\'runtime_tool_id\'] ?? \'\' ) );
+	$tool_name = wp_codebox_browser_runtime_tool_name( \'\' !== $runtime_tool_id ? $runtime_tool_id : $tool_id );
 	if ( \'\' !== $tool_name ) {
 		$sandbox_tool_ids[] = $tool_name;
 	}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -20,6 +20,7 @@ define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-path-policy.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-task-builder.php';

--- a/scripts/php-tool-policy-normalization-smoke.php
+++ b/scripts/php-tool-policy-normalization-smoke.php
@@ -1,0 +1,94 @@
+<?php
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	private string $code;
+	/** @var array<string,mixed> */
+	private array $data;
+
+	/** @param array<string,mixed> $data */
+	public function __construct( string $code = '', string $message = '', array $data = array() ) {
+		unset( $message );
+		$this->code = $code;
+		$this->data = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	/** @return array<string,mixed> */
+	public function get_error_data(): array {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-tool-policy-validator.php';
+
+function assert_same( mixed $expected, mixed $actual, string $label ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $label . ' failed: expected ' . var_export( $expected, true ) . ', got ' . var_export( $actual, true ) . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+function assert_not_error( mixed $actual, string $label ): void {
+	if ( is_wp_error( $actual ) ) {
+		fwrite( STDERR, $label . ' failed: unexpected WP_Error ' . $actual->get_error_code() . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+$task_input = WP_Codebox_Agent_Task::normalize_input(
+	array(
+		'goal'          => 'Create a page',
+		'allowed_tools' => array( 'filesystem-write' ),
+	)
+);
+
+assert_not_error( $task_input, 'semantic allowed tool normalizes' );
+assert_same( 'wp-codebox/sandbox-tool-policy/v1', $task_input['sandbox_tool_policy']['schema'], 'policy schema' );
+assert_same( 'filesystem-write', $task_input['sandbox_tool_policy']['tools'][0]['id'], 'semantic policy id' );
+assert_same( 'filesystem_write', $task_input['sandbox_tool_policy']['tools'][0]['runtime_tool_id'], 'provider-safe runtime tool id' );
+assert_same( 'runtime_local', $task_input['sandbox_tool_policy']['tools'][0]['runtime']['environment'], 'runtime environment' );
+assert_same( 'runtime_local', $task_input['sandbox_tool_policy']['tools'][0]['runtime']['capability_scope'], 'runtime scope' );
+
+$validator = new WP_Codebox_Host_Tool_Policy_Validator();
+assert_same( null, $validator->validate_task_tools( $task_input ), 'validator accepts normalized semantic policy' );
+
+$explicit_policy = WP_Codebox_Agent_Task::normalize_input(
+	array(
+		'goal'                => 'Create a page',
+		'allowed_tools'       => array( 'filesystem-write' ),
+		'sandbox_tool_policy' => array(
+			'schema'  => 'wp-codebox/sandbox-tool-policy/v1',
+			'version' => 1,
+			'tools'   => array(
+				array(
+					'id'                   => 'filesystem-write',
+					'runtime_tool_id'      => 'custom_filesystem_write',
+					'execution_location'   => 'sandbox',
+					'transport_visibility' => 'sandbox',
+					'allowed'              => true,
+					'runtime'              => array(
+						'environment'      => 'runtime_local',
+						'capability_scope' => 'runtime_local',
+					),
+				),
+			),
+		),
+	)
+);
+
+assert_not_error( $explicit_policy, 'explicit policy remains accepted' );
+assert_same( 'custom_filesystem_write', $explicit_policy['sandbox_tool_policy']['tools'][0]['runtime_tool_id'], 'explicit runtime id preserved' );
+
+fwrite( STDOUT, "PHP tool policy normalization smoke passed\n" );


### PR DESCRIPTION
## Summary
- Add a reusable WP Codebox sandbox tool policy normalizer that turns semantic allowed tool IDs into runtime-local policy entries with provider-safe runtime tool IDs.
- Materialize the normalized policy during task input normalization so browser payloads carry the resolved sandbox policy without downstream callers serializing transport details.
- Reuse the normalizer from host validation and have the browser runner honor normalized runtime_tool_id values.

## Tests
- npm run test:php-tool-policy-normalization
- php -l packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-host-tool-policy-validator.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-agent-task.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the normalization primitive, wiring, and targeted smoke coverage; Chris remains responsible for review and validation.