### PR TITLE
Add generic host command runner evidence

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -176,6 +176,25 @@ artifact bundle and returns after recipe work finishes. Use
 `--preview-hold-blocking` only for operator workflows that need the CLI process
 to keep a live preview server open for the hold duration.
 
+## Generic Host Command Primitive
+
+Hosts that expose recipe/task runner commands through WP Codebox should use the
+core `executeHostCommand()` primitive instead of hand-rolled process wrappers. It
+runs one command without shell expansion, enforces allowed working-directory and
+environment policy, times out long-running work, terminates the spawned process
+group, samples process-tree RSS, and returns a structured result with:
+
+- `failureClassification`: `none`, `timeout`, `non_zero_exit`, or `signal`.
+- `commandSummary`: a compact command line for human diagnostics.
+- Bounded `stdout` and `stderr` fields plus `outputTruncated`.
+- `memorySamples` and `peakRssBytes` for runner watchdog evidence.
+- Optional `artifacts.stdout`, `artifacts.stderr`, and `artifacts.summary` refs
+  when `artifactsDirectory` is provided.
+
+The summary artifact uses `wp-codebox/host-command-summary/v1`. Product-specific
+orchestrators can wrap this primitive, but should keep WPCOM, CI-provider, and
+deployment semantics outside the generic runner layer.
+
 ## WordPress PHPUnit Runtime
 
 `wordpress.phpunit` is the lightweight WP Codebox equivalent of plugin PHPUnit

--- a/packages/runtime-core/src/host-command-executor.ts
+++ b/packages/runtime-core/src/host-command-executor.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process"
-import { realpath } from "node:fs/promises"
+import { createWriteStream, type WriteStream } from "node:fs"
+import { mkdir, realpath, stat, writeFile } from "node:fs/promises"
 import { isAbsolute, relative, resolve, sep } from "node:path"
 import { assertRuntimeEnvName, normalizeRuntimeEnvRecord } from "./runtime-env.js"
 import type { JsonObject, JsonValue } from "./host-tool-registry.js"
@@ -11,6 +12,9 @@ export interface HostCommandExecutorConfig {
   allowedCwdRoots?: string[]
   timeoutMs?: number
   maxOutputBytes?: number
+  artifactsDirectory?: string
+  memorySampleIntervalMs?: number
+  terminationGraceMs?: number
   inheritedEnv?: string[]
   allowedInputEnv?: string[]
   env?: Record<string, string>
@@ -21,6 +25,24 @@ export interface HostCommandExecutorInput {
   cwd?: string
   timeoutMs?: number
   env?: Record<string, string>
+}
+
+export type HostCommandFailureClassification = "none" | "timeout" | "non_zero_exit" | "signal"
+
+export type HostCommandMemorySample = JsonObject & {
+  elapsedMs: number
+  rssBytes: number
+}
+
+export type HostCommandArtifact = JsonObject & {
+  path: string
+  bytes: number
+}
+
+export type HostCommandArtifacts = JsonObject & {
+  stdout?: HostCommandArtifact
+  stderr?: HostCommandArtifact
+  summary?: HostCommandArtifact
 }
 
 export type HostCommandExecutorResult = JsonObject & {
@@ -34,18 +56,29 @@ export type HostCommandExecutorResult = JsonObject & {
   durationMs: number
   timedOut: boolean
   outputTruncated: boolean
+  failureClassification: HostCommandFailureClassification
+  commandSummary: string
+  memorySamples: HostCommandMemorySample[]
+  peakRssBytes: number
+  artifacts?: HostCommandArtifacts
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000
 const DEFAULT_MAX_OUTPUT_BYTES = 256 * 1024
+const DEFAULT_MEMORY_SAMPLE_INTERVAL_MS = 1_000
+const DEFAULT_TERMINATION_GRACE_MS = 5_000
 
 export async function executeHostCommand(config: HostCommandExecutorConfig, input: HostCommandExecutorInput = {}): Promise<HostCommandExecutorResult> {
   const started = Date.now()
   const cwd = await resolveAllowedHostCommandCwd(config, input.cwd)
   const timeoutMs = boundedHostCommandPositiveInteger(input.timeoutMs ?? config.timeoutMs ?? DEFAULT_TIMEOUT_MS, "timeoutMs")
   const maxOutputBytes = boundedHostCommandPositiveInteger(config.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES, "maxOutputBytes")
+  const memorySampleIntervalMs = boundedHostCommandPositiveInteger(config.memorySampleIntervalMs ?? DEFAULT_MEMORY_SAMPLE_INTERVAL_MS, "memorySampleIntervalMs")
+  const terminationGraceMs = boundedHostCommandPositiveInteger(config.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS, "terminationGraceMs")
   const args = [...(config.args ?? []), ...(input.args ?? [])]
   const env = hostCommandEnv(config, input.env ?? {})
+  const commandSummary = summarizeHostCommand(config.command, args)
+  const artifactWriters = config.artifactsDirectory ? await createHostCommandArtifactWriters(config.artifactsDirectory) : undefined
 
   return new Promise<HostCommandExecutorResult>((resolveResult, reject) => {
     let stdout = ""
@@ -53,26 +86,42 @@ export async function executeHostCommand(config: HostCommandExecutorConfig, inpu
     let outputTruncated = false
     let timedOut = false
     let settled = false
+    const memorySamples: HostCommandMemorySample[] = []
 
     const child = spawn(config.command, args, {
       cwd,
       env,
+      detached: true,
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
     })
 
     const timer = setTimeout(() => {
       timedOut = true
-      child.kill("SIGTERM")
+      terminateHostCommandProcessTree(child.pid, "SIGTERM")
+      setTimeout(() => terminateHostCommandProcessTree(child.pid, "SIGKILL"), terminationGraceMs).unref()
     }, timeoutMs)
 
+    const memoryTimer = setInterval(() => {
+      if (child.pid === undefined) {
+        return
+      }
+      void sampleHostCommandProcessTreeRssBytes(child.pid).then((rssBytes) => {
+        if (rssBytes !== undefined) {
+          memorySamples.push({ elapsedMs: Date.now() - started, rssBytes })
+        }
+      }).catch(() => undefined)
+    }, memorySampleIntervalMs)
+
     child.stdout?.on("data", (chunk: Buffer) => {
+      artifactWriters?.stdout.write(chunk)
       const captured = appendBoundedHostCommandOutput(stdout, chunk, maxOutputBytes)
       stdout = captured.output
       outputTruncated ||= captured.truncated
     })
 
     child.stderr?.on("data", (chunk: Buffer) => {
+      artifactWriters?.stderr.write(chunk)
       const captured = appendBoundedHostCommandOutput(stderr, chunk, maxOutputBytes)
       stderr = captured.output
       outputTruncated ||= captured.truncated
@@ -84,6 +133,8 @@ export async function executeHostCommand(config: HostCommandExecutorConfig, inpu
       }
       settled = true
       clearTimeout(timer)
+      clearInterval(memoryTimer)
+      void closeHostCommandArtifactWriters(artifactWriters).catch(() => undefined)
       reject(error)
     })
 
@@ -93,7 +144,9 @@ export async function executeHostCommand(config: HostCommandExecutorConfig, inpu
       }
       settled = true
       clearTimeout(timer)
-      resolveResult({
+      clearInterval(memoryTimer)
+      const durationMs = Date.now() - started
+      const result: HostCommandExecutorResult = {
         command: config.command,
         args,
         cwd,
@@ -101,10 +154,17 @@ export async function executeHostCommand(config: HostCommandExecutorConfig, inpu
         signal: signal ?? "",
         stdout,
         stderr,
-        durationMs: Date.now() - started,
+        durationMs,
         timedOut,
         outputTruncated,
-      })
+        failureClassification: classifyHostCommandFailure(exitCode, signal, timedOut),
+        commandSummary,
+        memorySamples,
+        peakRssBytes: memorySamples.reduce((peak, sample) => Math.max(peak, sample.rssBytes), 0),
+      }
+      void finalizeHostCommandArtifacts(artifactWriters, result).then((artifacts) => {
+        resolveResult(artifacts ? { ...result, artifacts } : result)
+      }).catch(reject)
     })
   })
 }
@@ -153,6 +213,130 @@ export function appendBoundedHostCommandOutput(current: string, chunk: Buffer, m
     return { output: next, truncated: false }
   }
   return { output: next.slice(0, maxBytes), truncated: true }
+}
+
+export function classifyHostCommandFailure(exitCode: number | null, signal: NodeJS.Signals | null, timedOut: boolean): HostCommandFailureClassification {
+  if (timedOut) {
+    return "timeout"
+  }
+  if (signal) {
+    return "signal"
+  }
+  if ((exitCode ?? 0) !== 0) {
+    return "non_zero_exit"
+  }
+  return "none"
+}
+
+export function summarizeHostCommand(command: string, args: string[]): string {
+  return [command, ...args].map((part) => /\s/.test(part) ? JSON.stringify(part) : part).join(" ")
+}
+
+function terminateHostCommandProcessTree(pid: number | undefined, signal: NodeJS.Signals): void {
+  if (pid === undefined) {
+    return
+  }
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    try {
+      process.kill(pid, signal)
+    } catch {
+      // The process may already be gone by the time cleanup runs.
+    }
+  }
+}
+
+async function sampleHostCommandProcessTreeRssBytes(pid: number): Promise<number | undefined> {
+  const output = await readProcessOutput("ps", ["-o", "rss=", "-g", String(pid)])
+  const rssKilobytes = output.split(/\s+/).filter(Boolean).reduce((total, value) => {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) ? total + parsed : total
+  }, 0)
+  return rssKilobytes > 0 ? rssKilobytes * 1024 : undefined
+}
+
+async function readProcessOutput(command: string, args: string[]): Promise<string> {
+  return await new Promise<string>((resolveOutput, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "ignore"] })
+    let output = ""
+    child.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8")
+    })
+    child.on("error", reject)
+    child.on("close", () => resolveOutput(output))
+  })
+}
+
+interface HostCommandArtifactWriters {
+  stdout: WriteStream
+  stderr: WriteStream
+  stdoutPath: string
+  stderrPath: string
+  summaryPath: string
+}
+
+async function createHostCommandArtifactWriters(directory: string): Promise<HostCommandArtifactWriters> {
+  await mkdir(directory, { recursive: true })
+  const stdoutPath = resolve(directory, "stdout.log")
+  const stderrPath = resolve(directory, "stderr.log")
+  return {
+    stdout: createWriteStream(stdoutPath),
+    stderr: createWriteStream(stderrPath),
+    stdoutPath,
+    stderrPath,
+    summaryPath: resolve(directory, "command-summary.json"),
+  }
+}
+
+async function finalizeHostCommandArtifacts(writers: HostCommandArtifactWriters | undefined, result: HostCommandExecutorResult): Promise<HostCommandArtifacts | undefined> {
+  if (!writers) {
+    return undefined
+  }
+  await closeHostCommandArtifactWriters(writers)
+  const summary = {
+    schema: "wp-codebox/host-command-summary/v1",
+    command: result.command,
+    args: result.args,
+    cwd: result.cwd,
+    commandSummary: result.commandSummary,
+    exitCode: result.exitCode,
+    signal: result.signal,
+    durationMs: result.durationMs,
+    timedOut: result.timedOut,
+    failureClassification: result.failureClassification,
+    outputTruncated: result.outputTruncated,
+    peakRssBytes: result.peakRssBytes,
+    memorySamples: result.memorySamples,
+  }
+  await writeFile(writers.summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8")
+  const [stdoutStat, stderrStat, summaryStat] = await Promise.all([
+    stat(writers.stdoutPath),
+    stat(writers.stderrPath),
+    stat(writers.summaryPath),
+  ])
+  return {
+    stdout: { path: writers.stdoutPath, bytes: stdoutStat.size },
+    stderr: { path: writers.stderrPath, bytes: stderrStat.size },
+    summary: { path: writers.summaryPath, bytes: summaryStat.size },
+  }
+}
+
+async function closeHostCommandArtifactWriters(writers: HostCommandArtifactWriters | undefined): Promise<void> {
+  if (!writers) {
+    return
+  }
+  await Promise.all([closeWriteStream(writers.stdout), closeWriteStream(writers.stderr)])
+}
+
+async function closeWriteStream(stream: WriteStream): Promise<void> {
+  if (stream.closed) {
+    return
+  }
+  await new Promise<void>((resolveClose, reject) => {
+    stream.on("error", reject)
+    stream.end(resolveClose)
+  })
 }
 
 function boundedHostCommandPositiveInteger(value: JsonValue | number, field: string): number {

--- a/packages/runtime-playground/src/host-command-tool.ts
+++ b/packages/runtime-playground/src/host-command-tool.ts
@@ -37,7 +37,7 @@ export function createHostCommandTool(config: HostCommandToolConfig): HostToolDe
     },
     outputSchema: {
       type: "object",
-      required: ["command", "args", "cwd", "exitCode", "signal", "stdout", "stderr", "durationMs", "timedOut", "outputTruncated"],
+      required: ["command", "args", "cwd", "exitCode", "signal", "stdout", "stderr", "durationMs", "timedOut", "outputTruncated", "failureClassification", "commandSummary", "memorySamples", "peakRssBytes"],
       properties: {
         command: { type: "string" },
         args: { type: "array", items: { type: "string" } },
@@ -49,6 +49,30 @@ export function createHostCommandTool(config: HostCommandToolConfig): HostToolDe
         durationMs: { type: "integer" },
         timedOut: { type: "boolean" },
         outputTruncated: { type: "boolean" },
+        failureClassification: { type: "string" },
+        commandSummary: { type: "string" },
+        memorySamples: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["elapsedMs", "rssBytes"],
+            properties: {
+              elapsedMs: { type: "integer" },
+              rssBytes: { type: "integer" },
+            },
+            additionalProperties: false,
+          },
+        },
+        peakRssBytes: { type: "integer" },
+        artifacts: {
+          type: "object",
+          properties: {
+            stdout: hostCommandArtifactSchema(),
+            stderr: hostCommandArtifactSchema(),
+            summary: hostCommandArtifactSchema(),
+          },
+          additionalProperties: false,
+        },
       },
       additionalProperties: false,
     },
@@ -59,6 +83,18 @@ export function createHostCommandTool(config: HostCommandToolConfig): HostToolDe
       description: "Runs one explicitly registered host command without shell expansion.",
     },
     handler: (input) => executeHostCommand(config, normalizeHostCommandInput(input)),
+  }
+}
+
+function hostCommandArtifactSchema(): JsonObject {
+  return {
+    type: "object",
+    required: ["path", "bytes"],
+    properties: {
+      path: { type: "string" },
+      bytes: { type: "integer" },
+    },
+    additionalProperties: false,
   }
 }
 

--- a/tests/host-command-executor.test.ts
+++ b/tests/host-command-executor.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict"
-import { mkdir, mkdtemp, realpath } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, realpath } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { executeHostCommand, executeManagedHostCommand, hostCommandEnv, ManagedHostCommandError, resolveAllowedHostCommandCwd } from "../packages/runtime-core/src/index.js"
+import { classifyHostCommandFailure, executeHostCommand, executeManagedHostCommand, hostCommandEnv, ManagedHostCommandError, resolveAllowedHostCommandCwd } from "../packages/runtime-core/src/index.js"
 
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-host-command-executor-"))
 const allowed = join(root, "allowed")
@@ -31,6 +31,8 @@ const truncated = await executeHostCommand(
 )
 assert.equal(truncated.stdout, "abc")
 assert.equal(truncated.outputTruncated, true)
+assert.equal(truncated.failureClassification, "none")
+assert.equal(truncated.commandSummary, `${process.execPath} -e process.stdout.write('abcdef')`)
 
 const timedOut = await executeHostCommand(
   {
@@ -42,6 +44,63 @@ const timedOut = await executeHostCommand(
 )
 assert.equal(timedOut.timedOut, true)
 assert.notEqual(timedOut.signal, "")
+assert.equal(timedOut.failureClassification, "timeout")
+
+const grandchildPidFile = join(root, "grandchild.pid")
+const processTreeTimedOut = await executeHostCommand(
+  {
+    command: process.execPath,
+    args: ["-e", `const { spawn } = require("node:child_process"); const fs = require("node:fs"); const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" }); fs.writeFileSync(${JSON.stringify(grandchildPidFile)}, String(child.pid)); setInterval(() => {}, 1000);`],
+    cwd: allowed,
+    terminationGraceMs: 25,
+  },
+  { timeoutMs: 25 }
+)
+assert.equal(processTreeTimedOut.failureClassification, "timeout")
+const grandchildPid = Number.parseInt(await readFile(grandchildPidFile, "utf8"), 10)
+await sleep(150)
+assert.equal(isProcessRunning(grandchildPid), false)
+
+const nonZero = await executeHostCommand(
+  {
+    command: process.execPath,
+    args: ["-e", "process.exit(9)"],
+    cwd: allowed,
+  },
+  {}
+)
+assert.equal(nonZero.exitCode, 9)
+assert.equal(nonZero.failureClassification, "non_zero_exit")
+
+const artifactsDirectory = join(root, "artifacts")
+const withArtifacts = await executeHostCommand(
+  {
+    command: process.execPath,
+    args: ["-e", "process.stdout.write('out'); process.stderr.write('err'); setTimeout(() => {}, 75)"],
+    cwd: allowed,
+    artifactsDirectory,
+    memorySampleIntervalMs: 20,
+  },
+  {}
+)
+assert.equal(withArtifacts.stdout, "out")
+assert.equal(withArtifacts.stderr, "err")
+assert.ok(withArtifacts.artifacts?.stdout?.path.endsWith("stdout.log"))
+assert.ok(withArtifacts.artifacts?.stderr?.path.endsWith("stderr.log"))
+assert.ok(withArtifacts.artifacts?.summary?.path.endsWith("command-summary.json"))
+assert.equal(await readFile(withArtifacts.artifacts!.stdout!.path, "utf8"), "out")
+assert.equal(await readFile(withArtifacts.artifacts!.stderr!.path, "utf8"), "err")
+const artifactSummary = JSON.parse(await readFile(withArtifacts.artifacts!.summary!.path, "utf8"))
+assert.equal(artifactSummary.schema, "wp-codebox/host-command-summary/v1")
+assert.equal(artifactSummary.failureClassification, "none")
+assert.ok(Array.isArray(artifactSummary.memorySamples))
+assert.ok(withArtifacts.memorySamples.length > 0)
+assert.ok(withArtifacts.peakRssBytes > 0)
+
+assert.equal(classifyHostCommandFailure(0, null, false), "none")
+assert.equal(classifyHostCommandFailure(2, null, false), "non_zero_exit")
+assert.equal(classifyHostCommandFailure(null, "SIGTERM", false), "signal")
+assert.equal(classifyHostCommandFailure(null, "SIGTERM", true), "timeout")
 
 const managed = await executeManagedHostCommand({
   command: process.execPath,
@@ -68,6 +127,19 @@ await assert.rejects(
     return true
   }
 )
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
 
 await assert.rejects(
   () => executeManagedHostCommand({


### PR DESCRIPTION
## Summary
- extend the generic host command primitive with process-group timeout cleanup, memory samples, failure classification, and command summaries
- optionally write structured stdout/stderr and command-summary artifacts for recipe/task runner callers
- document the primitive as the generic recipe/task runner layer and keep product-specific semantics out of core

## Tests
- npm run test:host-command-executor
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the generic runner primitive changes, tests, docs, and PR description; Chris remains responsible for review and validation.