### PR TITLE
Align PHP tool policy descriptor resolution

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Runtime tool policy descriptor resolution.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Runtime_Tool_Policy_Descriptor {
+
+	private const AGENTS_API_RUNTIME_ENVIRONMENT = 'environment';
+	private const AGENTS_API_RUNTIME_CAPABILITY_SCOPE = 'capability_scope';
+	private const AGENTS_API_RUNTIME_LOCAL = 'runtime_local';
+
+	/** @param array<string,mixed> $policy @return array<string,mixed> */
+	public function resolve_effective_runtime_tool_policy( array $policy ): array {
+		$tools = array_map(
+			fn( array $tool ): array => $this->runtime_tool_descriptor( $tool ),
+			array_values( array_filter( is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array(), 'is_array' ) )
+		);
+
+		return array(
+			'schema'                   => (string) ( $policy['schema'] ?? '' ),
+			'version'                  => (int) ( $policy['version'] ?? 0 ),
+			'tools'                    => $tools,
+			'allowedRuntimeToolIds'    => $this->string_list( array_map( static fn( array $tool ): string => $tool['allowed'] && $tool['visible'] ? $tool['runtimeToolId'] : '', $tools ) ),
+			'visibleRuntimeToolIds'    => $this->string_list( array_map( static fn( array $tool ): string => $tool['visible'] ? $tool['runtimeToolId'] : '', $tools ) ),
+			'parentOnlyRuntimeToolIds' => $this->string_list( array_map( static fn( array $tool ): string => $tool['parentOnly'] ? $tool['runtimeToolId'] : '', $tools ) ),
+			'hiddenRuntimeToolIds'     => $this->string_list( array_map( static fn( array $tool ): string => $tool['hidden'] ? $tool['runtimeToolId'] : '', $tools ) ),
+			'metadata'                 => is_array( $policy['metadata'] ?? null ) ? $policy['metadata'] : array(),
+		);
+	}
+
+	/** @param array<string,mixed> $policy_or_effective */
+	public function resolve_runtime_tool_alias( array $policy_or_effective, string $value ): array|null {
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return null;
+		}
+
+		$effective = array_key_exists( 'allowedRuntimeToolIds', $policy_or_effective )
+			? $policy_or_effective
+			: $this->resolve_effective_runtime_tool_policy( $policy_or_effective );
+
+		foreach ( is_array( $effective['tools'] ?? null ) ? $effective['tools'] : array() as $tool ) {
+			if ( ! is_array( $tool ) ) {
+				continue;
+			}
+			if ( $value === (string) ( $tool['id'] ?? '' ) || $value === (string) ( $tool['runtimeToolId'] ?? '' ) || in_array( $value, $this->string_list( $tool['aliases'] ?? array() ), true ) ) {
+				return $tool;
+			}
+		}
+
+		return null;
+	}
+
+	/** @param array<string,mixed>|null $descriptor */
+	public function denial_reason( array|null $descriptor ): string|null {
+		if ( null === $descriptor ) {
+			return 'not-in-policy';
+		}
+		if ( ! empty( $descriptor['parentOnly'] ) ) {
+			return 'parent-only';
+		}
+		if ( ! empty( $descriptor['hidden'] ) ) {
+			return 'hidden';
+		}
+		if ( empty( $descriptor['visible'] ) ) {
+			return 'not-visible-in-sandbox';
+		}
+		if ( true !== ( $descriptor['allowed'] ?? false ) ) {
+			return 'not-allowed';
+		}
+
+		return null;
+	}
+
+	/** @param array<string,mixed> $tool @return array<string,mixed> */
+	private function runtime_tool_descriptor( array $tool ): array {
+		$runtime          = $this->runtime_metadata( $tool );
+		$metadata         = is_array( $tool['metadata'] ?? null ) ? $tool['metadata'] : array();
+		$transport        = (string) ( $tool['transport_visibility'] ?? '' );
+		$parent_only      = self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] || self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ];
+		$hidden           = 'hidden' === $transport;
+		$visible          = ! $parent_only && ! $hidden && in_array( $transport, array( 'sandbox', 'both' ), true );
+		$runtime_tool_id  = (string) ( $tool['runtime_tool_id'] ?? '' );
+		$metadata_aliases = is_array( $metadata['aliases'] ?? null ) ? $metadata['aliases'] : array();
+
+		$descriptor = array(
+			'id'                  => (string) ( $tool['id'] ?? '' ),
+			'runtimeToolId'       => $runtime_tool_id,
+			'aliases'             => $this->string_list( array_merge( array( (string) ( $tool['id'] ?? '' ), $runtime_tool_id ), is_array( $tool['aliases'] ?? null ) ? $tool['aliases'] : array(), $metadata_aliases ) ),
+			'allowed'             => true === ( $tool['allowed'] ?? false ),
+			'executionLocation'   => (string) ( $tool['execution_location'] ?? '' ),
+			'transportVisibility' => $transport,
+			'visible'             => $visible,
+			'parentOnly'          => $parent_only,
+			'hidden'              => $hidden,
+			'runtime'             => $runtime,
+		);
+
+		if ( isset( $metadata['schema'] ) && is_string( $metadata['schema'] ) ) {
+			$descriptor['schema'] = $metadata['schema'];
+		}
+		if ( isset( $metadata['policy'] ) && is_array( $metadata['policy'] ) ) {
+			$descriptor['policy'] = $metadata['policy'];
+		}
+		if ( ! empty( $metadata ) ) {
+			$descriptor['metadata'] = $metadata;
+		}
+
+		return $descriptor;
+	}
+
+	/** @param array<string,mixed> $tool @return array{environment:string,capability_scope:string} */
+	private function runtime_metadata( array $tool ): array {
+		$runtime = is_array( $tool['runtime'] ?? null ) ? $tool['runtime'] : array();
+
+		return array(
+			self::AGENTS_API_RUNTIME_ENVIRONMENT => isset( $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
+				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
+				: '',
+			self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE => isset( $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
+				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
+				: '',
+		);
+	}
+
+	/** @return string[] */
+	private function string_list( mixed $values ): array {
+		if ( ! is_array( $values ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map(
+						static fn( $value ): string => trim( (string) $value ),
+						$values
+					),
+					static fn( string $value ): bool => '' !== $value
+				)
+			)
+		);
+	}
+}

--- a/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
@@ -17,6 +17,12 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 	private const AGENTS_API_RUNTIME_CAPABILITY_SCOPE = 'capability_scope';
 	private const AGENTS_API_RUNTIME_LOCAL = 'runtime_local';
 
+	private WP_Codebox_Runtime_Tool_Policy_Descriptor $descriptor_resolver;
+
+	public function __construct() {
+		$this->descriptor_resolver = new WP_Codebox_Runtime_Tool_Policy_Descriptor();
+	}
+
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public function normalize_for_task_input( array $input ): array|WP_Error {
 		$policy = is_array( $input['sandbox_tool_policy'] ?? null ) ? $input['sandbox_tool_policy'] : array();
@@ -52,8 +58,8 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 
 		$denied = array();
 		foreach ( $this->string_list( $tools ) as $tool ) {
-			$policy_tool = $this->policy_tool( $policy, $tool );
-			$reason      = null === $policy_tool ? 'not-in-policy' : $this->policy_denial_reason( $policy_tool );
+			$descriptor = $this->descriptor_resolver->resolve_runtime_tool_alias( $policy, $tool );
+			$reason     = $this->descriptor_resolver->denial_reason( $descriptor );
 			if ( null !== $reason ) {
 				$denied[] = array(
 					'tool'   => $tool,
@@ -111,9 +117,10 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 
 	/** @return string[] */
 	public function allowed_tools( array $policy ): array {
+		$effective = $this->descriptor_resolver->resolve_effective_runtime_tool_policy( $policy );
 		$allowed = array();
-		foreach ( is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array() as $tool ) {
-			if ( is_array( $tool ) && null === $this->policy_denial_reason( $tool ) ) {
+		foreach ( is_array( $effective['tools'] ?? null ) ? $effective['tools'] : array() as $tool ) {
+			if ( is_array( $tool ) && null === $this->descriptor_resolver->denial_reason( $tool ) ) {
 				$allowed[] = (string) $tool['id'];
 			}
 		}
@@ -217,45 +224,4 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 		);
 	}
 
-	/** @param array<string,mixed> $policy @return array<string,mixed>|null */
-	private function policy_tool( array $policy, string $tool_id ): array|null {
-		foreach ( is_array( $policy['tools'] ?? null ) ? $policy['tools'] : array() as $tool ) {
-			if ( is_array( $tool ) && $tool_id === (string) ( $tool['id'] ?? '' ) ) {
-				return $tool;
-			}
-		}
-
-		return null;
-	}
-
-	/** @param array<string,mixed> $tool */
-	private function policy_denial_reason( array $tool ): string|null {
-		$runtime = $this->runtime_metadata( $tool );
-
-		if ( self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] ) {
-			return 'parent-only';
-		}
-		if ( self::AGENTS_API_RUNTIME_LOCAL !== $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] ) {
-			return 'not-visible-in-sandbox';
-		}
-		if ( true !== ( $tool['allowed'] ?? false ) ) {
-			return 'not-allowed';
-		}
-
-		return null;
-	}
-
-	/** @param array<string,mixed> $tool @return array{environment:string,capability_scope:string} */
-	private function runtime_metadata( array $tool ): array {
-		$runtime = is_array( $tool['runtime'] ?? null ) ? $tool['runtime'] : array();
-
-		return array(
-			self::AGENTS_API_RUNTIME_ENVIRONMENT => isset( $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
-				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_ENVIRONMENT ] )
-				: '',
-			self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE => isset( $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] ) && '' !== trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
-				? trim( (string) $runtime[ self::AGENTS_API_RUNTIME_CAPABILITY_SCOPE ] )
-				: '',
-		);
-	}
 }

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -20,6 +20,7 @@ define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
 require_once __DIR__ . '/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-path-policy.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';

--- a/scripts/php-tool-policy-normalization-smoke.php
+++ b/scripts/php-tool-policy-normalization-smoke.php
@@ -29,6 +29,7 @@ function is_wp_error( mixed $value ): bool {
 }
 
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-tool-policy-validator.php';
@@ -63,6 +64,7 @@ assert_same( 'runtime_local', $task_input['sandbox_tool_policy']['tools'][0]['ru
 
 $validator = new WP_Codebox_Host_Tool_Policy_Validator();
 assert_same( null, $validator->validate_task_tools( $task_input ), 'validator accepts normalized semantic policy' );
+assert_same( null, $validator->validate_allowed_tools( array( 'filesystem_write' ), $task_input ), 'validator accepts generated runtime tool id alias' );
 
 $explicit_policy = WP_Codebox_Agent_Task::normalize_input(
 	array(
@@ -90,5 +92,65 @@ $explicit_policy = WP_Codebox_Agent_Task::normalize_input(
 
 assert_not_error( $explicit_policy, 'explicit policy remains accepted' );
 assert_same( 'custom_filesystem_write', $explicit_policy['sandbox_tool_policy']['tools'][0]['runtime_tool_id'], 'explicit runtime id preserved' );
+assert_same( null, $validator->validate_allowed_tools( array( 'custom_filesystem_write' ), $explicit_policy ), 'validator accepts explicit runtime tool id alias' );
+
+$descriptor_policy = array(
+	'schema'  => 'wp-codebox/sandbox-tool-policy/v1',
+	'version' => 1,
+	'tools'   => array(
+		array(
+			'id'                   => 'filesystem-write',
+			'runtime_tool_id'      => 'client/filesystem-write',
+			'aliases'              => array( 'filesystem_write' ),
+			'execution_location'   => 'sandbox',
+			'transport_visibility' => 'sandbox',
+			'allowed'              => true,
+			'runtime'              => array(
+				'environment'      => 'runtime_local',
+				'capability_scope' => 'runtime_local',
+			),
+			'metadata'             => array(
+				'aliases' => array( 'write_file' ),
+				'schema'  => 'example/input/v1',
+				'policy'  => array( 'permission' => 'write' ),
+			),
+		),
+		array(
+			'id'                   => 'browser-review',
+			'runtime_tool_id'      => 'client/browser-review',
+			'execution_location'   => 'parent',
+			'transport_visibility' => 'parent',
+			'allowed'              => true,
+			'runtime'              => array(
+				'environment'      => 'control_plane',
+				'capability_scope' => 'control_plane',
+			),
+		),
+		array(
+			'id'                   => 'internal-token',
+			'runtime_tool_id'      => 'client/internal-token',
+			'execution_location'   => 'sandbox',
+			'transport_visibility' => 'hidden',
+			'allowed'              => true,
+			'runtime'              => array(
+				'environment'      => 'runtime_local',
+				'capability_scope' => 'runtime_local',
+			),
+		),
+	),
+	'metadata' => array( 'source' => 'php-tool-policy-normalization-smoke' ),
+);
+
+$resolver = new WP_Codebox_Runtime_Tool_Policy_Descriptor();
+$effective = $resolver->resolve_effective_runtime_tool_policy( $descriptor_policy );
+assert_same( array( 'client/filesystem-write' ), $effective['allowedRuntimeToolIds'], 'effective allowed runtime ids match runtime-core' );
+assert_same( array( 'client/filesystem-write' ), $effective['visibleRuntimeToolIds'], 'effective visible runtime ids match runtime-core' );
+assert_same( array( 'client/browser-review' ), $effective['parentOnlyRuntimeToolIds'], 'effective parent runtime ids match runtime-core' );
+assert_same( array( 'client/internal-token' ), $effective['hiddenRuntimeToolIds'], 'effective hidden runtime ids match runtime-core' );
+assert_same( 'client/filesystem-write', $resolver->resolve_runtime_tool_alias( $descriptor_policy, 'write_file' )['runtimeToolId'], 'metadata alias resolves' );
+assert_same( 'example/input/v1', $resolver->resolve_runtime_tool_alias( $descriptor_policy, 'filesystem_write' )['schema'], 'metadata schema mirrors descriptor' );
+assert_same( array( 'permission' => 'write' ), $resolver->resolve_runtime_tool_alias( $descriptor_policy, 'filesystem_write' )['policy'], 'metadata policy mirrors descriptor' );
+assert_same( 'parent-only', $resolver->denial_reason( $resolver->resolve_runtime_tool_alias( $descriptor_policy, 'client/browser-review' ) ), 'parent-only tool denied by descriptor' );
+assert_same( 'hidden', $resolver->denial_reason( $resolver->resolve_runtime_tool_alias( $descriptor_policy, 'client/internal-token' ) ), 'hidden tool denied by descriptor' );
 
 fwrite( STDOUT, "PHP tool policy normalization smoke passed\n" );

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -11,6 +11,7 @@ class WP_Error {
 }
 function is_wp_error( $value ) { return $value instanceof WP_Error; }
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php';


### PR DESCRIPTION
## Summary
- Add a PHP runtime tool policy descriptor resolver mirroring the runtime-core effective policy contract.
- Route host-side tool validation and allowed-tool diagnostics through descriptor alias/visibility resolution.
- Extend parity coverage for runtime IDs, declared aliases, metadata aliases, parent-only tools, and hidden tools.

## Tests
- npm run test:php-tool-policy-normalization
- npm run test:runtime-tool-policy
- npm run test:browser-task-builder
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the PHP descriptor resolver, validation migration, and parity test updates; Chris remains responsible for review and merge.