### PR TITLE
Introduce runtime dependency plan contract

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -100,7 +100,7 @@ final class WP_Codebox_Browser_Task_Builder {
 	 * @param string              $session_id  Browser sandbox session id.
 	 * @param array<int,array<string,mixed>> $artifacts Browser artifact specs.
 	 * @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance Resolved inheritance.
-	 * @param array<string,callable> $resolvers Optional field resolvers for agent, mode, provider, model, secret_env, and agent_bundles.
+	 * @param array<string,callable> $resolvers Optional field resolvers for agent, mode, provider, model, secret_env, agent_bundles, and runtime_dependency_plan.
 	 * @return array<string,mixed>
 	 */
 	public static function task_payload( array $input, array $task_input, string $session_id, array $artifacts, array $inheritance, array $resolvers = array() ): array {
@@ -112,19 +112,39 @@ final class WP_Codebox_Browser_Task_Builder {
 			return $fallback;
 		};
 
+		$dependency_plan = $resolve( 'runtime_dependency_plan', null );
+		if ( ! $dependency_plan instanceof WP_Codebox_Runtime_Dependency_Plan ) {
+			$dependency_plan = new WP_Codebox_Runtime_Dependency_Plan(
+				array(
+					'agent'    => self::agent_slug( $input ),
+					'mode'     => self::mode( $input ),
+					'provider' => self::provider( $input, $inheritance ),
+					'model'    => self::model( $input, $inheritance ),
+				),
+				self::string_list( $input['provider_plugin_paths'] ?? array() ),
+				array(),
+				array(),
+				self::array_resolver_value( $input['runtime_overlays'] ?? array() ),
+				$inheritance,
+				array( 'connectors' => array(), 'settings' => array() ),
+				self::array_resolver_value( $task_input['agent_bundles'] ?? array() ),
+				self::string_list( $input['secret_env'] ?? array() )
+			);
+		}
+
 		return array_filter(
 			array(
 				'schema'        => 'wp-codebox/browser-agent-task-payload/v1',
 				'agent'         => (string) $resolve( 'agent', self::agent_slug( $input ) ),
 				'mode'          => (string) $resolve( 'mode', self::mode( $input ) ),
-				'provider'      => (string) $resolve( 'provider', self::provider( $input, $inheritance ) ),
-				'model'         => (string) $resolve( 'model', self::model( $input, $inheritance ) ),
+				'provider'      => (string) $resolve( 'provider', $dependency_plan->provider() ),
+				'model'         => (string) $resolve( 'model', $dependency_plan->model() ),
 				'message'       => (string) $task_input['goal'],
 				'session_id'    => $session_id,
 				'task_input'    => $task_input,
-				'agent_bundles' => self::array_resolver_value( $resolve( 'agent_bundles', $task_input['agent_bundles'] ?? array() ) ),
-				'inheritance'   => $inheritance,
-				'secret_env'    => self::string_list( $resolve( 'secret_env', $input['secret_env'] ?? array() ) ),
+				'agent_bundles' => self::array_resolver_value( $resolve( 'agent_bundles', $dependency_plan->agent_bundles() ) ),
+				'inheritance'   => $dependency_plan->inheritance(),
+				'secret_env'    => self::string_list( $resolve( 'secret_env', $dependency_plan->secret_env_names() ) ),
 				'artifacts'     => array(
 					'schema' => 'wp-codebox/browser-artifacts/v1',
 					'files'  => $artifacts,

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -25,18 +25,33 @@ final class WP_Codebox_Host_Recipe_Builder {
 			return $credential_error;
 		}
 
-		$provider_plugins = array_map(
+		$provider_plugin_paths = $adapters['provider_plugin_paths']( $input, $inheritance );
+		$provider_plugins      = array_map(
 			static fn( string $path ): array => array(
 				'source'   => $path,
 				'slug'     => basename( $path ),
 				'activate' => false,
 			),
-			$adapters['provider_plugin_paths']( $input, $inheritance )
+			$provider_plugin_paths
 		);
-
-		$provider_slugs = array_map( static fn( array $plugin ): string => (string) $plugin['slug'], $provider_plugins );
-		$agent_bundles  = $adapters['agent_bundles']( $input );
-		$runtime_task   = $adapters['runtime_task']( $input );
+		$component_plugins     = $adapters['component_plugins']( $paths );
+		$dependency_plan       = new WP_Codebox_Runtime_Dependency_Plan(
+			array(
+				'agent'    => $adapters['agent_slug']( $input ),
+				'mode'     => $adapters['mode']( $input ),
+				'provider' => $adapters['provider']( $input, $inheritance ),
+				'model'    => $adapters['model']( $input, $inheritance ),
+			),
+			$provider_plugin_paths,
+			$provider_plugins,
+			$component_plugins,
+			is_array( $input['runtime_overlays'] ?? null ) ? $input['runtime_overlays'] : array(),
+			$inheritance,
+			$adapters['inheritance_request']( $input ),
+			$adapters['agent_bundles']( $input ),
+			$adapters['secret_env_names']( $input, $inheritance )
+		);
+		$runtime_task          = $adapters['runtime_task']( $input );
 		$steps          = array();
 		foreach ( $task_prompts as $task_prompt ) {
 			$task_input = $adapters['task_input']( array_merge( $input, array( 'goal' => $task_prompt ) ) );
@@ -46,15 +61,15 @@ final class WP_Codebox_Host_Recipe_Builder {
 
 			$args = array(
 				'task=' . $task_prompt,
-				'agent=' . $adapters['agent_slug']( $input ),
-				'mode=' . $adapters['mode']( $input ),
-				'provider=' . $adapters['provider']( $input, $inheritance ),
-				'model=' . $adapters['model']( $input, $inheritance ),
-				'provider-plugin-slugs=' . implode( ',', $provider_slugs ),
+				'agent=' . (string) ( $dependency_plan->selection()['agent'] ?? '' ),
+				'mode=' . (string) ( $dependency_plan->selection()['mode'] ?? '' ),
+				'provider=' . $dependency_plan->provider(),
+				'model=' . $dependency_plan->model(),
+				'provider-plugin-slugs=' . implode( ',', $dependency_plan->provider_plugin_slugs() ),
 				'sandbox-tool-policy-json=' . $adapters['json_encode']( $task_input['sandbox_tool_policy'] ),
 			);
-			if ( ! empty( $agent_bundles ) ) {
-				$args[] = 'agent-bundles-json=' . $adapters['json_encode']( $agent_bundles );
+			if ( ! empty( $dependency_plan->agent_bundles() ) ) {
+				$args[] = 'agent-bundles-json=' . $adapters['json_encode']( $dependency_plan->agent_bundles() );
 			}
 			if ( ! empty( $runtime_task ) ) {
 				$args[] = 'runtime-task-json=' . $adapters['json_encode']( $runtime_task );
@@ -93,21 +108,20 @@ final class WP_Codebox_Host_Recipe_Builder {
 			return $site_seed_payload;
 		}
 
-		$component_plugins  = $adapters['component_plugins']( $paths );
-		$component_manifest = self::component_manifest( $component_plugins, $provider_plugins );
+		$component_manifest = self::component_manifest( $dependency_plan->component_plugins(), $dependency_plan->provider_plugins() );
 
 		$recipe_inputs = array(
 			'mounts'             => $mounts,
 			'workspaces'         => $workspaces,
-			'inherit'            => $adapters['inheritance_request']( $input ),
-			'inheritance'        => $inheritance,
-			'extra_plugins'      => array_merge( $component_plugins, $provider_plugins ),
+			'inherit'            => $dependency_plan->inheritance_request(),
+			'inheritance'        => $dependency_plan->inheritance(),
+			'extra_plugins'      => array_merge( $dependency_plan->component_plugins(), $dependency_plan->provider_plugins() ),
 			'component_manifest' => $component_manifest,
 			'runtimeEnv'         => array_merge( $adapters['runtime_env']( $input ), self::AGENT_RUNTIME_ENV ),
-			'secretEnv'          => $adapters['secret_env_names']( $input, $inheritance ),
+			'secretEnv'          => $dependency_plan->secret_env_names(),
 		);
-		if ( ! empty( $agent_bundles ) ) {
-			$recipe_inputs['agent_bundles'] = $agent_bundles;
+		if ( ! empty( $dependency_plan->agent_bundles() ) ) {
+			$recipe_inputs['agent_bundles'] = $dependency_plan->agent_bundles();
 		}
 		if ( ! empty( $site_seed_payload['siteSeeds'] ) ) {
 			$recipe_inputs['siteSeeds'] = $site_seed_payload['siteSeeds'];

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Runtime dependency plan contract shared by sandbox builders.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Runtime_Dependency_Plan {
+
+	/** @var array<string,mixed> */
+	private array $selection;
+
+	/** @var string[] */
+	private array $provider_plugin_paths;
+
+	/** @var array<int,array<string,mixed>> */
+	private array $provider_plugins;
+
+	/** @var array<int,array<string,mixed>> */
+	private array $component_plugins;
+
+	/** @var array<int,array<string,mixed>> */
+	private array $runtime_overlays;
+
+	/** @var array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} */
+	private array $inheritance;
+
+	/** @var array{connectors:string[],settings:string[]} */
+	private array $inheritance_request;
+
+	/** @var array<int,array<string,mixed>> */
+	private array $agent_bundles;
+
+	/** @var string[] */
+	private array $secret_env_names;
+
+	/**
+	 * @param array<string,mixed> $selection Provider/model/runtime selection metadata.
+	 * @param string[] $provider_plugin_paths Resolved provider plugin paths.
+	 * @param array<int,array<string,mixed>> $provider_plugins Prepared provider plugin entries.
+	 * @param array<int,array<string,mixed>> $component_plugins Prepared component plugin entries.
+	 * @param array<int,array<string,mixed>> $runtime_overlays Runtime overlay descriptors.
+	 * @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance Resolved inheritance metadata.
+	 * @param array{connectors:string[],settings:string[]} $inheritance_request Requested inheritance metadata.
+	 * @param array<int,array<string,mixed>> $agent_bundles Agent bundle import specs.
+	 * @param string[] $secret_env_names Required secret env names.
+	 */
+	public function __construct( array $selection, array $provider_plugin_paths, array $provider_plugins, array $component_plugins, array $runtime_overlays, array $inheritance, array $inheritance_request, array $agent_bundles, array $secret_env_names ) {
+		$this->selection             = $selection;
+		$this->provider_plugin_paths = self::string_list( $provider_plugin_paths );
+		$this->provider_plugins      = array_values( array_filter( $provider_plugins, 'is_array' ) );
+		$this->component_plugins     = array_values( array_filter( $component_plugins, 'is_array' ) );
+		$this->runtime_overlays      = array_values( array_filter( $runtime_overlays, 'is_array' ) );
+		$this->inheritance           = array(
+			'connectors' => array_values( array_filter( is_array( $inheritance['connectors'] ?? null ) ? $inheritance['connectors'] : array(), 'is_array' ) ),
+			'settings'   => array_values( array_filter( is_array( $inheritance['settings'] ?? null ) ? $inheritance['settings'] : array(), 'is_array' ) ),
+		);
+		$this->inheritance_request   = array(
+			'connectors' => self::string_list( $inheritance_request['connectors'] ?? array() ),
+			'settings'   => self::string_list( $inheritance_request['settings'] ?? array() ),
+		);
+		$this->agent_bundles         = array_values( array_filter( $agent_bundles, 'is_array' ) );
+		$this->secret_env_names      = self::secret_env_list( $secret_env_names );
+	}
+
+	/** @return array<string,mixed> */
+	public function selection(): array {
+		return $this->selection;
+	}
+
+	public function provider(): string {
+		return trim( (string) ( $this->selection['provider'] ?? '' ) );
+	}
+
+	public function model(): string {
+		return trim( (string) ( $this->selection['model'] ?? '' ) );
+	}
+
+	/** @return string[] */
+	public function provider_plugin_paths(): array {
+		return $this->provider_plugin_paths;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function provider_plugins(): array {
+		return $this->provider_plugins;
+	}
+
+	/** @return string[] */
+	public function provider_plugin_slugs(): array {
+		return array_values( array_filter( array_map( static fn( array $plugin ): string => (string) ( $plugin['slug'] ?? '' ), $this->provider_plugins ) ) );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function component_plugins(): array {
+		return $this->component_plugins;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function runtime_overlays(): array {
+		return $this->runtime_overlays;
+	}
+
+	/** @return array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} */
+	public function inheritance(): array {
+		return $this->inheritance;
+	}
+
+	/** @return array{connectors:string[],settings:string[]} */
+	public function inheritance_request(): array {
+		return $this->inheritance_request;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function agent_bundles(): array {
+		return $this->agent_bundles;
+	}
+
+	/** @return string[] */
+	public function secret_env_names(): array {
+		return $this->secret_env_names;
+	}
+
+	/** @return array<string,mixed> */
+	public function to_contract(): array {
+		return array_filter(
+			array(
+				'schema'                => 'wp-codebox/runtime-dependency-plan/v1',
+				'selection'             => array_filter( $this->selection, static fn( mixed $value ): bool => '' !== $value && array() !== $value ),
+				'provider_plugin_paths' => $this->provider_plugin_paths,
+				'provider_plugins'      => $this->provider_plugins,
+				'component_plugins'     => $this->component_plugins,
+				'runtime_overlays'      => $this->runtime_overlays,
+				'inheritance_request'   => $this->inheritance_request,
+				'inheritance'           => $this->inheritance,
+				'agent_bundles'         => $this->agent_bundles,
+				'secret_env'            => $this->secret_env_names,
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+
+	/** @return string[] */
+	private static function string_list( mixed $value ): array {
+		$items = array();
+		foreach ( is_array( $value ) ? $value : array() as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item && ! in_array( $item, $items, true ) ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+
+	/** @return string[] */
+	private static function secret_env_list( mixed $value ): array {
+		return array_values( array_filter( self::string_list( $value ), static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) );
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -47,6 +47,24 @@ private static function browser_task_payload( array $input, array $task_input, s
 		$artifacts,
 		$inheritance,
 		array(
+			'runtime_dependency_plan' => static function ( array $input, array $task_input, array $inheritance ): WP_Codebox_Runtime_Dependency_Plan {
+				return new WP_Codebox_Runtime_Dependency_Plan(
+					array(
+						'agent'    => self::browser_agent_slug( $input ),
+						'mode'     => self::browser_mode( $input ),
+						'provider' => self::browser_provider( $input, $inheritance ),
+						'model'    => self::browser_model( $input, $inheritance ),
+					),
+					self::browser_provider_plugin_paths( $input ),
+					array(),
+					array(),
+					is_array( $input['runtime_overlays'] ?? null ) ? $input['runtime_overlays'] : array(),
+					$inheritance,
+					self::browser_inheritance_request( $input ),
+					self::normalize_agent_bundles( $input['agent_bundles'] ?? array() ),
+					self::browser_secret_env_names( $input )
+				);
+			},
 			'agent'         => static fn( array $input ): string => self::browser_agent_slug( $input ),
 			'mode'          => static fn( array $input ): string => self::browser_mode( $input ),
 			'provider'      => static fn( array $input, array $task_input, array $inheritance ): string => self::browser_provider( $input, $inheritance ),

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
 require_once __DIR__ . '/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-path-policy.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
+require_once __DIR__ . '/src/class-wp-codebox-runtime-dependency-plan.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-task-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-connector-credential-resolvers.php';
 require_once __DIR__ . '/src/class-wp-codebox-inheritance.php';

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -13,6 +13,7 @@ function is_wp_error( $value ) { return $value instanceof WP_Error; }
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php';
 require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php';
 
 $task_input = WP_Codebox_Browser_Task_Builder::normalize_task_input( array(
@@ -50,7 +51,28 @@ $payload = WP_Codebox_Browser_Task_Builder::task_payload(
 	)
 );
 
-echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'local_task' => $local_task ), JSON_UNESCAPED_SLASHES );
+$explicit_plan_payload = WP_Codebox_Browser_Task_Builder::task_payload(
+	array( 'secret_env' => array( 'IGNORED_BY_PLAN' ) ),
+	$task_input,
+	'session-123',
+	array(),
+	array( 'connectors' => array(), 'settings' => array() ),
+	array(
+		'runtime_dependency_plan' => static fn(): WP_Codebox_Runtime_Dependency_Plan => new WP_Codebox_Runtime_Dependency_Plan(
+			array( 'provider' => 'planned-provider', 'model' => 'planned-model' ),
+			array( '/tmp/provider-plugin' ),
+			array( array( 'slug' => 'provider-plugin', 'source' => '/tmp/provider-plugin' ) ),
+			array(),
+			array(),
+			array( 'connectors' => array( array( 'provider' => 'planned-provider', 'model' => 'planned-model' ) ), 'settings' => array() ),
+			array( 'connectors' => array( 'planned-connector' ), 'settings' => array() ),
+			array( array( 'source' => '/tmp/planned-bundle.zip' ) ),
+			array( 'PLANNED_SECRET', 'bad-name' )
+		),
+	)
+);
+
+echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'local_task' => $local_task ), JSON_UNESCAPED_SLASHES );
 `], {
   cwd: root.pathname,
   encoding: "utf8",
@@ -69,6 +91,10 @@ assert.equal(result.payload.model, "model-from-inheritance")
 assert.deepEqual(result.payload.secret_env, ["OPENAI_API_KEY"])
 assert.deepEqual(result.payload.task_input.context, { caller: "test" })
 assert.deepEqual(result.payload.agent_bundles, [{ source: "/tmp/agent-bundle.zip", on_conflict: "skip" }])
+assert.equal(result.explicit_plan_payload.provider, "planned-provider")
+assert.equal(result.explicit_plan_payload.model, "planned-model")
+assert.deepEqual(result.explicit_plan_payload.secret_env, ["PLANNED_SECRET"])
+assert.deepEqual(result.explicit_plan_payload.agent_bundles, [{ source: "/tmp/planned-bundle.zip" }])
 assert.equal(result.local_task.mode, "sandbox")
 assert.equal(result.local_task.target.kind, "browser-playground")
 assert.equal(result.local_task.target.ref, "session-123")


### PR DESCRIPTION
## Summary
- Add a generic `WP_Codebox_Runtime_Dependency_Plan` DTO for provider/model selection, resolved provider plugin paths, runtime overlays, component plugins, inheritance metadata, agent bundle imports, and required secret env names.
- Route the host recipe builder through the plan while preserving the existing recipe input and workflow payload shapes.
- Route browser task payload dependency fields through the plan and cover explicit plan consumption in the PHP-backed task builder test.

## Tests
- `npm run test:browser-task-builder`
- `npm run build`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php && php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php && php -l packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php && php -l packages/wordpress-plugin/wp-codebox.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the DTO/refactor and targeted test updates; Chris remains responsible for review and validation.