### PR TITLE
Derive recipe policy command dependencies

### DIFF
--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS, commandArgValue, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { effectivePolicyCommandsFor } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
 import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandIds, listCliRuntimeBackendKinds } from "./runtime-backends.js"
@@ -22,6 +23,7 @@ export const defaultPolicy: RuntimePolicy = {
 }
 
 const cliRuntimeRecipePolicy = cliRuntimeBackendRecipePolicy()
+const cliRecipeCommandDefinitions = cliRuntimeRecipePolicy.recipeCommands
 const supportedRecipeCommands = new Set(listCliRecipeCommandIds())
 const hostRecipeCommandPattern = /^host\/[A-Za-z0-9._/-]+$/
 const supportedRuntimeOverlayKinds = uniqueRuntimeOverlayDescriptorValues("kind")
@@ -763,13 +765,10 @@ export function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
     ...(recipe.inputs?.pluginRuntime?.healthProbes ?? []).map(pluginRuntimeHealthProbeStep),
   ].map((step) => step.command)
   const commands = [
-    ...recipeWorkflowSteps(recipe).map(({ step }) => step.command.startsWith("wp-codebox.agent-") ? "wordpress.run-php" : step.command),
-    ...pluginRuntimeCommands,
-    ...(recipe.probes ?? []).map((probe) => probe.step.command),
+    ...effectivePolicyCommandsFor(recipeWorkflowSteps(recipe).map(({ step }) => step.command), cliRecipeCommandDefinitions),
+    ...effectivePolicyCommandsFor(pluginRuntimeCommands, cliRecipeCommandDefinitions),
+    ...effectivePolicyCommandsFor((recipe.probes ?? []).map((probe) => probe.step.command), cliRecipeCommandDefinitions),
   ]
-  if (recipeWorkflowSteps(recipe).some(({ step }) => step.command === "wp-codebox.agent-sandbox-run")) {
-    commands.unshift("wordpress.wp-cli")
-  }
   if (recipeWorkflowSteps(recipe).some(({ step }) => step.command === "wordpress.bench" && recipeBenchStepUsesWpCli(step))) {
     commands.unshift("wordpress.wp-cli")
   }

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -24,6 +24,7 @@ export interface CommandDefinition {
   outputShape: string
   outputSchema?: CommandOutputSchemaContract
   policyRequirement: string
+  requiresPolicyCommands?: readonly string[]
   recipe: boolean
   handler: CommandHandlerBinding
 }
@@ -426,6 +427,7 @@ export const commandRegistry = [
     ],
     outputShape: "JSON probe result emitted by the sandbox PHP runner.",
     policyRequirement: "Recipe policy maps this helper to wordpress.run-php.",
+    requiresPolicyCommands: ["wordpress.run-php"],
     recipe: true,
     handler: { kind: "recipe-alias", command: "wordpress.run-php" },
   },
@@ -448,7 +450,8 @@ export const commandRegistry = [
       { name: "code-file", description: "Path to PHP runner override for operator/debug use.", format: "path" },
     ],
     outputShape: "JSON agent run result emitted by the sandbox PHP runner.",
-    policyRequirement: "Recipe policy maps this helper to wordpress.run-php.",
+    policyRequirement: "Recipe policy maps this helper to wordpress.run-php and wordpress.wp-cli.",
+    requiresPolicyCommands: ["wordpress.run-php", "wordpress.wp-cli"],
     recipe: true,
     handler: { kind: "recipe-alias", command: "wordpress.run-php" },
   },
@@ -477,6 +480,36 @@ export type PlaygroundRuntimeCommandId = PlaygroundRuntimeCommandDefinition["id"
 
 export function getCommandDefinition(command: string): CommandDefinition | undefined {
   return commandRegistry.find((definition) => definition.id === command)
+}
+
+export function effectivePolicyCommands(command: string, definitions: readonly CommandDefinition[] = commandRegistry): string[] {
+  const byId = new Map(definitions.map((definition) => [definition.id, definition]))
+  const commands: string[] = []
+  const visiting = new Set<string>()
+
+  const collect = (id: string): void => {
+    if (visiting.has(id)) return
+    visiting.add(id)
+
+    const definition = byId.get(id)
+    const requirements = definition?.requiresPolicyCommands
+    if (requirements) {
+      for (const requiredCommand of requirements) {
+        collect(requiredCommand)
+      }
+    } else if (!commands.includes(id)) {
+      commands.push(id)
+    }
+
+    visiting.delete(id)
+  }
+
+  collect(command)
+  return commands
+}
+
+export function effectivePolicyCommandsFor(commands: readonly string[], definitions: readonly CommandDefinition[] = commandRegistry): string[] {
+  return [...new Set(commands.flatMap((command) => effectivePolicyCommands(command, definitions)))]
 }
 
 export function runtimeCommandDefinitions(): CommandDefinition[] {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict"
 import { normalizeAgentTaskRunResult } from "../packages/runtime-core/src/index.js"
+import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
 import { agentTaskRunExitCode } from "../packages/cli/src/commands/agent-task-run.js"
+import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
 
 const succeeded = normalizeAgentTaskRunResult({ success: true, status: "completed" }, { exitStatus: 0 })
 assert.equal(succeeded.status, "succeeded")
@@ -32,5 +34,42 @@ const agentSandboxRun = catalog.commands.find((command) => command.id === "wp-co
 assert.ok(agentSandboxRun, "catalog includes wp-codebox.agent-sandbox-run")
 assert.equal(agentSandboxRun.acceptedArgs.some((arg) => arg.name === "code"), false)
 assert.equal(agentSandboxRun.acceptedArgs.some((arg) => arg.name === "code-file"), false)
+assert.deepEqual(agentSandboxRun.requiresPolicyCommands, ["wordpress.run-php", "wordpress.wp-cli"])
+
+assert.deepEqual(effectivePolicyCommands("wp-codebox.agent-sandbox-run"), ["wordpress.run-php", "wordpress.wp-cli"])
+assert.deepEqual(effectivePolicyCommands("custom.wrapper", [
+  {
+    id: "custom.wrapper",
+    description: "test wrapper",
+    acceptedArgs: [],
+    outputShape: "test",
+    policyRequirement: "test",
+    requiresPolicyCommands: ["custom.inner"],
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "custom.inner" },
+  },
+  {
+    id: "custom.inner",
+    description: "test inner",
+    acceptedArgs: [],
+    outputShape: "test",
+    policyRequirement: "test",
+    requiresPolicyCommands: ["wordpress.run-php"],
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "wordpress.run-php" },
+  },
+]), ["wordpress.run-php"])
+
+const agentRecipePolicy = recipePolicy({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [
+      { command: "wp-codebox.agent-sandbox-run", args: ["task=Verify policy dependencies"] },
+    ],
+  },
+} as never)
+assert.equal(agentRecipePolicy.commands.includes("wordpress.run-php"), true)
+assert.equal(agentRecipePolicy.commands.includes("wordpress.wp-cli"), true)
+assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run"), false)
 
 console.log("agent task contracts passed")


### PR DESCRIPTION
## Summary
- Add registry metadata for command policy dependencies and a transitive effective policy command resolver.
- Teach recipe policy generation to derive workflow, plugin runtime, and probe command requirements from command registry metadata.
- Declare agent helper policy requirements for `wp-codebox.agent-runtime-probe` and `wp-codebox.agent-sandbox-run`, including the sandbox WP-CLI bridge requirement.

## Testing
- `npm run build`
- `npm run test:agent-task-contracts`
- `npm run test:path-policy-parity`
- `npm run test:schema-parity`
- `npx tsx scripts/command-registry-smoke.ts`
- `npm run wp-codebox -- recipe validate --recipe examples/recipes/wp-cli.json --json`
- `npm run wp-codebox -- recipe validate --recipe examples/recipes/cookbook/headless-browser-agent-task.json --json`
- `npm run wp-codebox -- recipe-run --recipe examples/recipes/cookbook/headless-browser-agent-task.json --dry-run --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, focused tests, verification commands, and PR description for Chris to review.