### PR TITLE
Preserve runtime overlay schema library hints

### DIFF
--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -494,6 +494,10 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
         },
       },
       runtimeOverlay: {
+        type: "object",
+        properties: {
+          library: { enum: enumValues(options.runtimeOverlayLibraries, defaultRuntimeOverlayLibraries) },
+        },
         oneOf: [
           {
             type: "object",

--- a/scripts/runtime-backend-registry-smoke.ts
+++ b/scripts/runtime-backend-registry-smoke.ts
@@ -69,6 +69,7 @@ const cliProviderSchema = createWorkspaceRecipeJsonSchema({
   runtimeOverlayStrategies: cliPolicy.runtimeOverlayStrategies,
 })
 assert.deepEqual((cliProviderSchema as any).properties.runtime.properties.wordpressInstallMode.enum, ["install-from-existing-files", "install-from-existing-files-if-needed", "do-not-attempt-installing"])
+assert.deepEqual((cliProviderSchema as any).$defs.runtimeOverlay.properties.library, { enum: ["php-ai-client"] })
 assert.deepEqual((cliProviderSchema as any).$defs.runtimeOverlay.oneOf[0].properties.library, { enum: ["php-ai-client"] })
 
 const customBackendRecipe: WorkspaceRecipe = {


### PR DESCRIPTION
## Summary
- restores the top-level `.runtimeOverlay.properties.library` schema hint for runtime overlay introspection
- keeps the strict `oneOf` branch validation for descriptor overlays and runtime overlay bundles
- adds smoke coverage for the previously failing `cliProviderSchema..runtimeOverlay.properties.library` path

## Tests
- `npm run build && npx tsx scripts/runtime-backend-registry-smoke.ts && npm run test:schema-parity && npm run test:generic-primitives`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Investigated the runtime overlay schema drift, drafted the schema/smoke update, and ran verification; Chris remains responsible for review and merge.