### PR TITLE
Add generic runtime recipe resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",
     "test:browser-task-builder": "tsx tests/browser-task-builder.test.ts",
     "test:host-recipe-builder": "tsx tests/host-recipe-builder.test.ts",
+    "test:runtime-recipe-resolver": "tsx tests/runtime-recipe-resolver.test.ts",
     "test:browser-runner-template": "tsx tests/browser-runner-template.test.ts",
     "test:editor-actions": "tsx tests/editor-actions.test.ts",
     "test:generic-primitives": "tsx tests/generic-primitives.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -161,10 +161,17 @@ final class WP_Codebox_Browser_Task_Builder {
 		);
 
 		$merged    = self::merge_defaults( self::merge_defaults( $input, $defaults ), $generic_defaults );
+		if ( class_exists( 'WP_Codebox_Runtime_Recipe_Resolver' ) ) {
+			$resolved = WP_Codebox_Runtime_Recipe_Resolver::apply_to_input( $merged );
+			if ( ! is_wp_error( $resolved ) ) {
+				$merged = $resolved;
+			}
+		}
 		$placement = is_array( $merged['placement'] ?? null ) ? $merged['placement'] : $generic_defaults['placement'];
 		$placement['required_capabilities'] = self::string_list_lower(
 			array_merge(
 				$generic_defaults['placement']['required_capabilities'],
+				is_array( $placement['required_capabilities'] ?? null ) ? $placement['required_capabilities'] : array(),
 				is_array( $defaults['placement']['required_capabilities'] ?? null ) ? $defaults['placement']['required_capabilities'] : array(),
 				is_array( $input['placement']['required_capabilities'] ?? null ) ? $input['placement']['required_capabilities'] : array()
 			)

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-recipe-resolver.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-recipe-resolver.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * Generic runtime recipe/package resolution for WordPress sandboxes.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Runtime_Recipe_Resolver {
+
+	/** @param array<string,mixed> $input Caller task input. @param array<string,mixed> $inheritance Resolved inheritance metadata. @return array<string,mixed>|WP_Error */
+	public static function apply_to_input( array $input, array $inheritance = array() ): array|WP_Error {
+		$request = self::request_from_input( $input );
+		if ( empty( $request['packages'] ) && empty( $request['capabilities'] ) ) {
+			return $input;
+		}
+
+		$resolved = self::resolve( $request, $input, $inheritance );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+
+		$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
+		$input['runtime'] = self::merge_runtime( $runtime, $resolved['runtime'] );
+		$input['runtime']['resolved_recipe'] = $resolved['contract'];
+
+		foreach ( array( 'provider_plugin_paths', 'secret_env', 'agent_bundles' ) as $field ) {
+			if ( ! empty( $resolved[ $field ] ) ) {
+				$input[ $field ] = self::merge_lists( is_array( $input[ $field ] ?? null ) ? $input[ $field ] : array(), $resolved[ $field ] );
+			}
+		}
+
+		if ( ! empty( $resolved['inherit'] ) ) {
+			$input['inherit'] = self::merge_inherit( is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array(), $resolved['inherit'] );
+		}
+
+		if ( ! empty( $resolved['placement_capabilities'] ) ) {
+			$placement = is_array( $input['placement'] ?? null ) ? $input['placement'] : array();
+			$placement['required_capabilities'] = self::merge_string_lists( is_array( $placement['required_capabilities'] ?? null ) ? $placement['required_capabilities'] : array(), $resolved['placement_capabilities'] );
+			$input['placement'] = $placement;
+		}
+
+		return $input;
+	}
+
+	/** @param array<string,mixed> $request Runtime recipe request. @param array<string,mixed> $input Caller task input. @param array<string,mixed> $inheritance Resolved inheritance metadata. @return array<string,mixed>|WP_Error */
+	public static function resolve( array $request, array $input = array(), array $inheritance = array() ): array|WP_Error {
+		$registry = self::package_registry( $input, $inheritance );
+		$package_ids = self::requested_package_ids( $request, $registry );
+		$selected = array();
+		$errors = array();
+
+		foreach ( $package_ids as $package_id ) {
+			self::select_package( $package_id, $registry, $selected, $errors );
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new WP_Error( 'wp_codebox_runtime_recipe_unresolved', 'Runtime recipe packages could not be resolved.', array( 'status' => 400, 'errors' => $errors ) );
+		}
+
+		$resolved = array(
+			'schema'                 => 'wp-codebox/runtime-recipe-resolution/v1',
+			'packages'               => array(),
+			'capabilities'           => array(),
+			'runtime'                => array(),
+			'inherit'                => array(),
+			'provider_plugin_paths'  => array(),
+			'secret_env'             => array(),
+			'agent_bundles'          => array(),
+			'placement_capabilities' => array(),
+		);
+
+		foreach ( $selected as $package ) {
+			$resolved['packages'][] = self::package_public_entry( $package );
+			$resolved['capabilities'] = self::merge_string_lists( $resolved['capabilities'], self::package_capabilities( $package ) );
+			$resolved['runtime'] = self::merge_runtime( $resolved['runtime'], is_array( $package['runtime'] ?? null ) ? $package['runtime'] : array() );
+			$resolved['inherit'] = self::merge_inherit( $resolved['inherit'], is_array( $package['inherit'] ?? null ) ? $package['inherit'] : array() );
+			$resolved['provider_plugin_paths'] = self::merge_string_lists( $resolved['provider_plugin_paths'], $package['provider_plugin_paths'] ?? array() );
+			$resolved['secret_env'] = self::merge_secret_env( $resolved['secret_env'], $package['secret_env'] ?? array() );
+			$resolved['agent_bundles'] = self::merge_lists( $resolved['agent_bundles'], is_array( $package['agent_bundles'] ?? null ) ? $package['agent_bundles'] : array() );
+			$resolved['placement_capabilities'] = self::merge_string_lists( $resolved['placement_capabilities'], $package['placement_capabilities'] ?? array() );
+		}
+
+		$resolved['contract'] = self::contract( $request, $resolved );
+		return $resolved;
+	}
+
+	/** @param array<string,mixed> $input Caller task input. @return array{packages:array<int,mixed>,capabilities:string[]} */
+	private static function request_from_input( array $input ): array {
+		$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
+		$recipe = is_array( $input['runtime_recipe'] ?? null ) ? $input['runtime_recipe'] : ( is_array( $runtime['recipe'] ?? null ) ? $runtime['recipe'] : array() );
+
+		return array(
+			'packages'     => self::merge_lists( is_array( $recipe['packages'] ?? null ) ? $recipe['packages'] : array(), is_array( $runtime['packages'] ?? null ) ? $runtime['packages'] : array(), is_array( $input['runtime_packages'] ?? null ) ? $input['runtime_packages'] : array() ),
+			'capabilities' => self::merge_string_lists( is_array( $recipe['capabilities'] ?? null ) ? $recipe['capabilities'] : array(), is_array( $runtime['capabilities'] ?? null ) ? $runtime['capabilities'] : array(), is_array( $input['runtime_capabilities'] ?? null ) ? $input['runtime_capabilities'] : array() ),
+		);
+	}
+
+	/** @param array<string,mixed> $input Caller task input. @param array<string,mixed> $inheritance Resolved inheritance metadata. @return array<string,array<string,mixed>> */
+	private static function package_registry( array $input, array $inheritance ): array {
+		$registry = array(
+			'wordpress-playground' => array(
+				'id'                     => 'wordpress-playground',
+				'label'                  => 'WordPress Playground sandbox',
+				'provides'               => array( 'wordpress.playground', 'browser.preview' ),
+				'placement_capabilities' => array( 'wordpress.playground', 'browser.preview' ),
+			),
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$registry = apply_filters( 'wp_codebox_runtime_package_registry', $registry, $input, $inheritance );
+		}
+
+		$normalized = array();
+		foreach ( is_array( $registry ) ? $registry : array() as $key => $package ) {
+			if ( ! is_array( $package ) ) {
+				continue;
+			}
+
+			$id = self::safe_key( (string) ( $package['id'] ?? $package['package'] ?? $key ) );
+			if ( '' === $id ) {
+				continue;
+			}
+
+			$package['id'] = $id;
+			$normalized[ $id ] = $package;
+		}
+
+		return $normalized;
+	}
+
+	/** @param array<string,mixed> $request Runtime recipe request. @param array<string,array<string,mixed>> $registry Package registry. @return string[] */
+	private static function requested_package_ids( array $request, array $registry ): array {
+		$ids = array();
+		foreach ( is_array( $request['packages'] ?? null ) ? $request['packages'] : array() as $package ) {
+			$id = is_array( $package ) ? (string) ( $package['id'] ?? $package['package'] ?? $package['name'] ?? '' ) : (string) $package;
+			$id = self::safe_key( $id );
+			if ( '' !== $id ) {
+				$ids[] = $id;
+			}
+		}
+
+		foreach ( self::string_list_lower( $request['capabilities'] ?? array() ) as $capability ) {
+			foreach ( $registry as $id => $package ) {
+				if ( in_array( $capability, self::package_capabilities( $package ), true ) ) {
+					$ids[] = $id;
+				}
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/** @param array<string,array<string,mixed>> $registry Package registry. @param array<string,array<string,mixed>> $selected Selected packages keyed by id. @param array<int,array<string,string>> $errors Resolution errors. */
+	private static function select_package( string $package_id, array $registry, array &$selected, array &$errors ): void {
+		$package_id = self::safe_key( $package_id );
+		if ( '' === $package_id || isset( $selected[ $package_id ] ) ) {
+			return;
+		}
+
+		if ( ! isset( $registry[ $package_id ] ) ) {
+			$errors[] = array( 'code' => 'package_not_registered', 'package' => $package_id );
+			return;
+		}
+
+		$package = $registry[ $package_id ];
+		foreach ( self::string_list_lower( $package['requires'] ?? array() ) as $required ) {
+			$required_id = isset( $registry[ $required ] ) ? $required : self::package_id_for_capability( $required, $registry );
+			if ( '' === $required_id ) {
+				$errors[] = array( 'code' => 'requirement_not_registered', 'package' => $package_id, 'requirement' => $required );
+				continue;
+			}
+
+			self::select_package( $required_id, $registry, $selected, $errors );
+		}
+
+		$selected[ $package_id ] = $package;
+	}
+
+	/** @param array<string,array<string,mixed>> $registry Package registry. */
+	private static function package_id_for_capability( string $capability, array $registry ): string {
+		foreach ( $registry as $id => $package ) {
+			if ( in_array( $capability, self::package_capabilities( $package ), true ) ) {
+				return $id;
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $package Package descriptor. @return string[] */
+	private static function package_capabilities( array $package ): array {
+		return self::merge_string_lists( $package['provides'] ?? array(), $package['capabilities'] ?? array() );
+	}
+
+	/** @param array<string,mixed> $request Runtime recipe request. @param array<string,mixed> $resolved Resolution payload. @return array<string,mixed> */
+	private static function contract( array $request, array $resolved ): array {
+		return array_filter(
+			array(
+				'schema'                 => 'wp-codebox/runtime-recipe-resolution/v1',
+				'request'                => array(
+					'packages'     => is_array( $request['packages'] ?? null ) ? $request['packages'] : array(),
+					'capabilities' => self::string_list_lower( $request['capabilities'] ?? array() ),
+				),
+				'packages'               => $resolved['packages'],
+				'capabilities'           => $resolved['capabilities'],
+				'placement_capabilities' => $resolved['placement_capabilities'],
+				'summary'                => array(
+					'packages'    => count( $resolved['packages'] ),
+					'plugins'     => count( is_array( $resolved['runtime']['plugins'] ?? null ) ? $resolved['runtime']['plugins'] : array() ),
+					'mu_plugins'  => count( is_array( $resolved['runtime']['mu_plugins'] ?? null ) ? $resolved['runtime']['mu_plugins'] : array() ),
+					'themes'      => count( is_array( $resolved['runtime']['themes'] ?? null ) ? $resolved['runtime']['themes'] : array() ),
+					'components'  => count( is_array( $resolved['runtime']['components'] ?? null ) ? $resolved['runtime']['components'] : array() ),
+					'bootstrap'   => count( is_array( $resolved['runtime']['bootstrap'] ?? null ) ? $resolved['runtime']['bootstrap'] : array() ),
+				),
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $package Package descriptor. @return array<string,mixed> */
+	private static function package_public_entry( array $package ): array {
+		return array_filter(
+			array(
+				'id'           => (string) ( $package['id'] ?? '' ),
+				'label'        => (string) ( $package['label'] ?? '' ),
+				'provides'     => self::package_capabilities( $package ),
+				'requires'     => self::string_list_lower( $package['requires'] ?? array() ),
+				'provenance'   => is_array( $package['provenance'] ?? null ) ? $package['provenance'] : array(),
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $base Base runtime. @param array<string,mixed> $extra Extra runtime. @return array<string,mixed> */
+	private static function merge_runtime( array $base, array $extra ): array {
+		foreach ( array( 'components', 'plugins', 'mu_plugins', 'themes', 'bootstrap' ) as $field ) {
+			$base[ $field ] = self::merge_lists( is_array( $base[ $field ] ?? null ) ? $base[ $field ] : array(), is_array( $extra[ $field ] ?? null ) ? $extra[ $field ] : array() );
+		}
+
+		foreach ( array( 'prepared', 'prepared_runtime' ) as $field ) {
+			if ( isset( $extra[ $field ] ) && ! isset( $base[ $field ] ) ) {
+				$base[ $field ] = $extra[ $field ];
+			}
+		}
+
+		return $base;
+	}
+
+	/** @param array<string,mixed> $base Base inherit. @param array<string,mixed> $extra Extra inherit. @return array<string,mixed> */
+	private static function merge_inherit( array $base, array $extra ): array {
+		foreach ( array( 'connectors', 'settings' ) as $field ) {
+			$base[ $field ] = self::merge_string_lists( is_array( $base[ $field ] ?? null ) ? $base[ $field ] : array(), is_array( $extra[ $field ] ?? null ) ? $extra[ $field ] : array() );
+		}
+
+		return array_filter( $base, static fn( mixed $value ): bool => array() !== $value );
+	}
+
+	/** @return array<int,mixed> */
+	private static function merge_lists( mixed ...$lists ): array {
+		$merged = array();
+		$seen = array();
+		foreach ( $lists as $list ) {
+			foreach ( is_array( $list ) ? $list : array() as $item ) {
+				$key = is_array( $item ) ? md5( wp_json_encode( $item ) ?: serialize( $item ) ) : 'scalar:' . (string) $item;
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+				$seen[ $key ] = true;
+				$merged[] = $item;
+			}
+		}
+
+		return $merged;
+	}
+
+	/** @return string[] */
+	private static function merge_string_lists( mixed ...$lists ): array {
+		$merged = array();
+		foreach ( $lists as $list ) {
+			foreach ( self::string_list_lower( $list ) as $item ) {
+				if ( ! in_array( $item, $merged, true ) ) {
+					$merged[] = $item;
+				}
+			}
+		}
+
+		return $merged;
+	}
+
+	/** @return string[] */
+	private static function merge_secret_env( mixed ...$lists ): array {
+		$merged = array();
+		foreach ( $lists as $list ) {
+			foreach ( self::string_list( $list ) as $item ) {
+				if ( 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $item ) && ! in_array( $item, $merged, true ) ) {
+					$merged[] = $item;
+				}
+			}
+		}
+
+		return $merged;
+	}
+
+	/** @return string[] */
+	private static function string_list( mixed $value ): array {
+		$items = array();
+		foreach ( is_array( $value ) ? $value : array() as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+
+	/** @return string[] */
+	private static function string_list_lower( mixed $value ): array {
+		return array_values( array_unique( array_map( 'strtolower', self::string_list( $value ) ) ) );
+	}
+
+	private static function safe_key( string $value ): string {
+		if ( function_exists( 'sanitize_key' ) ) {
+			return sanitize_key( $value );
+		}
+
+		return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', $value ) ?? '' );
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -51,6 +51,9 @@ public static function create_browser_playground_session( array $input ): array|
 		return $inheritance_payload;
 	}
 	$input           = self::browser_input_with_inheritance( $input, $inheritance_payload['inheritance'] );
+	if ( is_wp_error( $input ) ) {
+		return $input;
+	}
 	$browser_runner  = is_array( $input['browser_runner'] ?? null ) ? $input['browser_runner'] : array();
 	$browser_plugins = self::browser_plugins( $input );
 	if ( is_wp_error( $browser_plugins ) ) {

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -30,10 +30,18 @@ private static function browser_inheritance_resolution_payload( array $input ): 
 	return array( 'inheritance' => $inheritance );
 }
 
-/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed> */
-private static function browser_input_with_inheritance( array $input, array $inheritance ): array {
+/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed>|WP_Error */
+private static function browser_input_with_inheritance( array $input, array $inheritance ): array|WP_Error {
 	$input['provider_plugin_paths'] = array_values( array_unique( array_merge( self::browser_provider_plugin_paths( $input ), self::browser_inheritance_provider_plugin_paths( $inheritance ) ) ) );
 	$input['secret_env']            = array_values( array_unique( array_merge( self::browser_secret_env_names( $input ), self::browser_inheritance_secret_env_names( $inheritance ) ) ) );
+	if ( class_exists( 'WP_Codebox_Runtime_Recipe_Resolver' ) ) {
+		$resolved = WP_Codebox_Runtime_Recipe_Resolver::apply_to_input( $input, $inheritance );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+
+		$input = $resolved;
+	}
 
 	return $input;
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -650,6 +650,9 @@ private static function browser_task_input_properties( array $task_input_schema,
 		'model'                   => self::string_property_schema( $detailed ? 'AI model id to seed into the browser Playground agent invocation.' : '' ),
 		'mode'                    => self::string_property_schema( $detailed ? 'Agent execution mode. Defaults to sandbox.' : '' ),
 		'provider_plugin_paths'   => self::string_array_property_schema( $detailed ? 'AI provider plugin directories the browser sandbox should have available before code execution.' : '' ),
+		'runtime_recipe'          => $detailed ? self::runtime_recipe_input_schema() : self::object_property_schema(),
+		'runtime_packages'        => self::string_array_property_schema( $detailed ? 'Portable runtime package ids WP Codebox should resolve through the runtime package registry.' : '' ),
+		'runtime_capabilities'    => self::string_array_property_schema( $detailed ? 'Portable runtime capabilities WP Codebox should satisfy through registered runtime packages.' : '' ),
 		'agent_bundles'           => self::agent_bundle_schema(),
 		'inherit'                 => $inherit_schema,
 		'secret_env'              => self::string_array_property_schema( $detailed ? 'Parent environment variable names expected to be available to the browser sandbox. Values are never accepted in this payload.' : '' ),
@@ -750,6 +753,9 @@ private static function browser_runtime_input_schema(): array {
 		'description' => 'Structured browser Playground runtime dependencies compiled by WP Codebox into the session blueprint.',
 		'properties'  => array(
 			'components' => array( 'type' => 'array' ),
+			'packages'   => array( 'type' => 'array' ),
+			'capabilities' => array( 'type' => 'array' ),
+			'recipe'     => self::runtime_recipe_input_schema(),
 			'plugins'    => array( 'type' => 'array' ),
 			'mu_plugins' => array( 'type' => 'array' ),
 			'themes'     => array( 'type' => 'array' ),
@@ -766,6 +772,18 @@ private static function browser_runtime_input_schema(): array {
 				),
 			),
 			'prepared_runtime' => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function runtime_recipe_input_schema(): array {
+	return array(
+		'type'        => 'object',
+		'description' => 'Portable runtime recipe request. Callers name package ids or capabilities; WP Codebox resolves registered dependencies, package rows, inheritance, and placement details.',
+		'properties'  => array(
+			'packages'     => array( 'type' => 'array' ),
+			'capabilities' => array( 'type' => 'array' ),
 		),
 	);
 }

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -25,6 +25,7 @@ require_once __DIR__ . '/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
 require_once __DIR__ . '/src/class-wp-codebox-path-policy.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/src/class-wp-codebox-runtime-dependency-plan.php';
+require_once __DIR__ . '/src/class-wp-codebox-runtime-recipe-resolver.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-task-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-connector-credential-resolvers.php';
 require_once __DIR__ . '/src/class-wp-codebox-inheritance.php';

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -9,11 +9,14 @@ class WP_Error {
 	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
 }
 function is_wp_error( $value ) { return $value instanceof WP_Error; }
+function wp_json_encode( $value, $flags = 0 ) { return json_encode( $value, $flags ); }
+function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', (string) $value ) ); }
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-recipe-resolver.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php`)};
 
 $task_input = WP_Codebox_Browser_Task_Builder::normalize_task_input( array(

--- a/tests/runtime-recipe-resolver.test.ts
+++ b/tests/runtime-recipe-resolver.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+
+const root = new URL("../", import.meta.url)
+const rootPath = root.pathname.replace(/'/g, "'\\''")
+
+const php = spawnSync("php", ["-r", `
+define('ABSPATH', '${rootPath}');
+class WP_Error {
+	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+}
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+function wp_json_encode( $value, $flags = 0 ) { return json_encode( $value, $flags ); }
+function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', (string) $value ) ); }
+function apply_filters( $hook, $value, ...$args ) {
+	if ( 'wp_codebox_runtime_package_registry' !== $hook ) {
+		return $value;
+	}
+
+	$value['agents'] = array(
+		'id' => 'agents',
+		'label' => 'Agents runtime',
+		'provides' => array( 'agents.runtime' ),
+		'requires' => array( 'wordpress.playground' ),
+		'runtime' => array(
+			'components' => array( 'agents-api' ),
+			'plugins' => array( array( 'slug' => 'agents-api', 'url' => 'https://example.test/agents-api.zip', 'activate' => true ) ),
+		),
+		'placement_capabilities' => array( 'agents.runtime' ),
+	);
+	$value['data-machine'] = array(
+		'id' => 'data-machine',
+		'provides' => array( 'data-machine.runtime' ),
+		'requires' => array( 'agents' ),
+		'runtime' => array(
+			'components' => array( 'data-machine', 'data-machine-code' ),
+			'plugins' => array(
+				array( 'slug' => 'data-machine', 'url' => 'https://example.test/data-machine.zip', 'activate' => true ),
+				array( 'slug' => 'data-machine-code', 'url' => 'https://example.test/data-machine-code.zip', 'activate' => true ),
+			),
+			'bootstrap' => array( array( 'operation' => 'set_option', 'args' => array( 'name' => 'datamachine_runtime', 'value' => 'sandbox' ) ) ),
+		),
+	);
+	$value['provider-connector'] = array(
+		'id' => 'provider-connector',
+		'provides' => array( 'provider.connector' ),
+		'requires' => array( 'agents.runtime' ),
+		'inherit' => array( 'connectors' => array( 'primary-ai' ) ),
+		'provider_plugin_paths' => array( '/opt/provider-plugin' ),
+		'secret_env' => array( 'PROVIDER_TOKEN', 'bad-name' ),
+	);
+
+	return $value;
+}
+
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-runtime-recipe-resolver.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
+require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php';
+
+$input = array(
+	'runtime_recipe' => array(
+		'capabilities' => array( 'data-machine.runtime', 'provider.connector' ),
+	),
+	'runtime' => array(
+		'plugins' => array( array( 'slug' => 'caller-plugin', 'url' => 'https://example.test/caller.zip' ) ),
+	),
+	'inherit' => array( 'connectors' => array( 'existing' ) ),
+	'placement' => array( 'required_capabilities' => array( 'artifact.website-bundle' ) ),
+);
+
+$resolved = WP_Codebox_Runtime_Recipe_Resolver::apply_to_input( $input, array( 'connectors' => array(), 'settings' => array() ) );
+$local_task = WP_Codebox_Browser_Task_Builder::local_browser_task_input( array(
+	'sandbox_session_id' => 'runtime-session',
+	'runtime_capabilities' => array( 'provider.connector' ),
+) );
+
+echo json_encode( array( 'resolved' => $resolved, 'local_task' => $local_task ), JSON_UNESCAPED_SLASHES );
+`], {
+  cwd: root.pathname,
+  encoding: "utf8",
+})
+
+assert.equal(php.status, 0, php.stderr)
+const result = JSON.parse(php.stdout)
+
+assert.deepEqual(result.resolved.runtime.components, ["agents-api", "data-machine", "data-machine-code"])
+assert.deepEqual(result.resolved.runtime.plugins.map((plugin: { slug: string }) => plugin.slug), ["caller-plugin", "agents-api", "data-machine", "data-machine-code"])
+assert.deepEqual(result.resolved.inherit.connectors, ["existing", "primary-ai"])
+assert.deepEqual(result.resolved.provider_plugin_paths, ["/opt/provider-plugin"])
+assert.deepEqual(result.resolved.secret_env, ["PROVIDER_TOKEN"])
+assert.deepEqual(result.resolved.placement.required_capabilities, ["artifact.website-bundle", "wordpress.playground", "browser.preview", "agents.runtime"])
+assert.equal(result.resolved.runtime.resolved_recipe.schema, "wp-codebox/runtime-recipe-resolution/v1")
+assert.equal(result.resolved.runtime.resolved_recipe.summary.packages, 4)
+assert.deepEqual(result.local_task.runtime.components, ["agents-api"])
+assert.deepEqual(result.local_task.inherit.connectors, ["primary-ai"])
+assert.deepEqual(result.local_task.placement.required_capabilities, ["wordpress.playground", "browser.preview", "agents.runtime"])
+
+console.log("runtime recipe resolver ok")


### PR DESCRIPTION
## Summary
- Add a generic WP Codebox runtime recipe resolver that maps portable package IDs and capabilities to registered runtime dependencies.
- Wire browser task/session inputs through the resolver so callers can request packages/capabilities instead of hand-shaping plugin rows, inheritance, placement capabilities, and runtime metadata.
- Add schema fields and tests covering WordPress Playground, agents, Data Machine, and provider connector style package composition without hard-coded provider metadata.

## Tests
- npm run test:browser-task-builder
- npm run test:runtime-recipe-resolver
- npm run build
- php -l packages/wordpress-plugin/src/class-wp-codebox-runtime-recipe-resolver.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and implemented the runtime recipe resolver, integration wiring, and contract tests; Chris to review and validate before merge.