### PR TITLE
Add generic browser task intent builder

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -10,6 +10,113 @@ defined( 'ABSPATH' ) || exit;
 final class WP_Codebox_Browser_Task_Builder {
 
 	/**
+	 * Builds canonical browser task contract input from product-neutral intent.
+	 *
+	 * Downstream products should describe what they want to accomplish here, then
+	 * pass the returned input to wp-codebox/create-browser-task-contract.
+	 *
+	 * @param array<string,mixed> $spec Product-neutral browser task spec.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function browser_task_input_from_intent( array $spec ): array|WP_Error {
+		$intent = is_array( $spec['product_intent'] ?? null ) ? $spec['product_intent'] : ( is_array( $spec['intent'] ?? null ) ? $spec['intent'] : array() );
+		$goal   = trim( (string) ( $intent['goal'] ?? $spec['goal'] ?? '' ) );
+		if ( '' === $goal ) {
+			return new WP_Error( 'wp_codebox_browser_task_intent_missing', 'Browser task intent requires a goal.', array( 'status' => 400 ) );
+		}
+
+		$session_id = trim( (string) ( $spec['sandbox_session_id'] ?? $spec['session_id'] ?? $intent['session_id'] ?? '' ) );
+		$product    = trim( (string) ( $intent['product'] ?? $spec['product'] ?? '' ) );
+		$context    = self::merge_defaults(
+			is_array( $spec['context'] ?? null ) ? $spec['context'] : array(),
+			array_filter(
+				array(
+					'product'                => $product,
+					'orchestrator'           => trim( (string) ( $intent['orchestrator'] ?? $spec['orchestrator']['id'] ?? '' ) ),
+					'execution'              => trim( (string) ( $intent['execution'] ?? 'wp-codebox-browser-playground' ) ),
+					'active_project_context' => is_array( $spec['active_project_context'] ?? null ) ? $spec['active_project_context'] : array(),
+					'callback_refs'          => is_array( $spec['callback_refs'] ?? null ) ? $spec['callback_refs'] : array(),
+				),
+				static fn( mixed $value ): bool => '' !== $value && array() !== $value
+			)
+		);
+
+		$allowed_tools       = self::string_list_any( $spec['desired_tools'] ?? $spec['tools'] ?? $spec['allowed_tools'] ?? array() );
+		$tool_policy         = is_array( $spec['sandbox_tool_policy'] ?? null ) ? $spec['sandbox_tool_policy'] : ( new WP_Codebox_Sandbox_Tool_Policy_Normalizer() )->from_allowed_tools( $allowed_tools, $spec );
+		$artifact_contract   = is_array( $spec['artifacts'] ?? null ) ? $spec['artifacts'] : array();
+		$playground_defaults = self::playground_defaults_from_artifacts( $artifact_contract, $product );
+		$browser_runner      = self::browser_runner_from_artifacts( $artifact_contract );
+
+		$input = array_filter(
+			array(
+				'authorization'         => $spec['authorization'] ?? null,
+				'placement'             => self::browser_execution_placement( self::string_list_lower( $spec['desired_capabilities'] ?? $spec['capabilities'] ?? array() ) ),
+				'agent'                 => trim( (string) ( $spec['agent'] ?? $intent['agent'] ?? '' ) ),
+				'mode'                  => trim( (string) ( $spec['mode'] ?? 'sandbox' ) ),
+				'provider'              => trim( (string) ( $spec['provider'] ?? '' ) ),
+				'model'                 => trim( (string) ( $spec['model'] ?? '' ) ),
+				'agent_bundles'         => is_array( $spec['agent_bundles'] ?? null ) ? $spec['agent_bundles'] : array(),
+				'provider_plugin_paths' => self::string_list_any( $spec['provider_plugin_paths'] ?? array() ),
+				'inherit'               => is_array( $spec['inherit'] ?? null ) ? $spec['inherit'] : array(),
+				'goal'                  => $goal,
+				'sandbox_session_id'    => $session_id,
+				'target'                => is_array( $spec['target'] ?? null ) ? $spec['target'] : self::target_from_intent( $intent, $session_id ),
+				'allowed_tools'         => $allowed_tools,
+				'expected_artifacts'    => self::string_list_any( $spec['expected_artifacts'] ?? $artifact_contract['expected'] ?? array() ),
+				'structured_artifacts'  => is_array( $spec['structured_artifacts'] ?? null ) ? $spec['structured_artifacts'] : array(),
+				'sandbox_tool_policy'   => $tool_policy,
+				'policy'                => is_array( $spec['policy'] ?? null ) ? $spec['policy'] : array(),
+				'context'               => $context,
+				'orchestrator'          => is_array( $spec['orchestrator'] ?? null ) ? $spec['orchestrator'] : array_filter( array( 'id' => $context['orchestrator'] ?? '' ) ),
+				'playground'            => self::merge_defaults( is_array( $spec['playground'] ?? null ) ? $spec['playground'] : array(), $playground_defaults ),
+				'runtime'               => is_array( $spec['runtime'] ?? null ) ? $spec['runtime'] : array(),
+				'browser_runner'        => self::merge_defaults( is_array( $spec['browser_runner'] ?? null ) ? $spec['browser_runner'] : array(), $browser_runner ),
+				'artifact_files'        => is_array( $artifact_contract['files'] ?? null ) ? $artifact_contract['files'] : ( is_array( $spec['artifact_files'] ?? null ) ? $spec['artifact_files'] : array() ),
+				'callback_refs'         => is_array( $spec['callback_refs'] ?? null ) ? $spec['callback_refs'] : array(),
+				'phases'                => is_array( $spec['phases'] ?? null ) ? $spec['phases'] : array(),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value && null !== $value
+		);
+
+		return self::local_browser_task_input( $input );
+	}
+
+	/** @param array<string,mixed> $worker @return array<string,mixed> */
+	public static function fanout_worker( array $worker ): array {
+		return array_filter(
+			array(
+				'schema'  => 'wp-codebox/agent-fanout-worker/v1',
+				'id'      => self::safe_key( (string) ( $worker['id'] ?? $worker['role'] ?? '' ) ),
+				'agent'   => trim( (string) ( $worker['agent'] ?? '' ) ),
+				'goal'    => trim( (string) ( $worker['goal'] ?? '' ) ),
+				'context' => is_array( $worker['context'] ?? null ) ? $worker['context'] : array(),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $request @return array<string,mixed> */
+	public static function fanout_request( array $request ): array {
+		$workers = array();
+		foreach ( is_array( $request['workers'] ?? null ) ? $request['workers'] : array() as $worker ) {
+			if ( is_array( $worker ) ) {
+				$workers[] = self::fanout_worker( $worker );
+			}
+		}
+
+		return array_filter(
+			array(
+				'schema'      => 'wp-codebox/agent-fanout-request/v1',
+				'concurrency' => max( 1, (int) ( $request['concurrency'] ?? 1 ) ),
+				'workers'     => $workers,
+				'context'     => is_array( $request['context'] ?? null ) ? $request['context'] : array(),
+				'orchestrator' => is_array( $request['orchestrator'] ?? null ) ? $request['orchestrator'] : array(),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	/**
 	 * Applies portable defaults for browser-local Playground tasks.
 	 *
 	 * Callers keep ownership of product-specific context, artifacts, and phases;
@@ -200,6 +307,53 @@ final class WP_Codebox_Browser_Task_Builder {
 		return '';
 	}
 
+	/** @param array<string,mixed> $intent */
+	private static function target_from_intent( array $intent, string $session_id ): array {
+		return array_filter(
+			array(
+				'kind' => trim( (string) ( $intent['target_kind'] ?? $intent['kind'] ?? 'browser-playground' ) ),
+				'ref'  => trim( (string) ( $intent['target_ref'] ?? $intent['ref'] ?? $session_id ) ),
+				'path' => trim( (string) ( $intent['target_path'] ?? $intent['path'] ?? '' ) ),
+				'url'  => trim( (string) ( $intent['target_url'] ?? $intent['url'] ?? '' ) ),
+			),
+			static fn( string $value ): bool => '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $artifacts @return array<string,mixed> */
+	private static function playground_defaults_from_artifacts( array $artifacts, string $product ): array {
+		$base = trim( (string) ( $artifacts['base_path'] ?? $artifacts['artifact_base_path'] ?? '' ) );
+		if ( '' === $base && '' !== $product ) {
+			$base = '/wordpress/wp-content/uploads/' . self::safe_key( $product );
+		}
+
+		return array_filter(
+			array(
+				'artifact_base_path' => $base,
+				'artifact_base_url'  => trim( (string) ( $artifacts['base_url'] ?? $artifacts['artifact_base_url'] ?? ( '' !== $product ? '/wp-content/uploads/' . self::safe_key( $product ) : '' ) ) ),
+				'preview_url'        => trim( (string) ( $artifacts['preview_url'] ?? '' ) ),
+			),
+			static fn( string $value ): bool => '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $artifacts @return array<string,mixed> */
+	private static function browser_runner_from_artifacts( array $artifacts ): array {
+		return array_filter(
+			array(
+				'task_path'     => trim( (string) ( $artifacts['task_path'] ?? '' ) ),
+				'result_path'   => trim( (string) ( $artifacts['result_path'] ?? '' ) ),
+				'invocation'    => is_array( $artifacts['invocation'] ?? null ) ? $artifacts['invocation'] : array(),
+				'capture_paths' => is_array( $artifacts['capture_paths'] ?? null ) ? $artifacts['capture_paths'] : array(),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	private static function safe_key( string $value ): string {
+		return trim( strtolower( preg_replace( '/[^a-zA-Z0-9_\-]+/', '-', $value ) ?? '' ), '-' );
+	}
+
 	/** @return array<int,mixed> */
 	private static function array_resolver_value( mixed $value ): array {
 		return is_array( $value ) ? $value : array();
@@ -215,6 +369,23 @@ final class WP_Codebox_Browser_Task_Builder {
 		foreach ( $value as $item ) {
 			$item = trim( (string) $item );
 			if ( '' !== $item && 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $item ) && ! in_array( $item, $items, true ) ) {
+				$items[] = $item;
+			}
+		}
+
+		return $items;
+	}
+
+	/** @return string[] */
+	private static function string_list_any( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			$item = trim( (string) $item );
+			if ( '' !== $item && ! in_array( $item, $items, true ) ) {
 				$items[] = $item;
 			}
 		}

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -72,7 +72,50 @@ $explicit_plan_payload = WP_Codebox_Browser_Task_Builder::task_payload(
 	)
 );
 
-echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'local_task' => $local_task ), JSON_UNESCAPED_SLASHES );
+$intent_task = WP_Codebox_Browser_Task_Builder::browser_task_input_from_intent( array(
+	'product_intent' => array(
+		'product' => 'demo-product',
+		'orchestrator' => 'demo-orchestrator',
+		'goal' => 'Build from intent.',
+		'target_kind' => 'new-site',
+		'target_ref' => 'project-7',
+	),
+	'active_project_context' => array(
+		'project_id' => 7,
+		'project_kind' => 'static-site',
+	),
+	'desired_capabilities' => array( 'Artifact.Website-Bundle', 'artifact.website-bundle' ),
+	'desired_tools' => array( 'filesystem-write', 'browser.review', 'filesystem-write' ),
+	'artifacts' => array(
+		'expected' => array( 'website-artifact-bundle', 'static-site-importer-report' ),
+		'base_path' => '/wordpress/wp-content/uploads/demo-product',
+		'base_url' => '/wp-content/uploads/demo-product',
+		'preview_url' => '/?preview=1',
+		'task_path' => '/tmp/demo-task.json',
+		'result_path' => '/tmp/demo-result.json',
+		'invocation' => array( 'type' => 'task', 'hook' => 'demo_task' ),
+		'capture_paths' => array( array( 'path' => '/wordpress/wp-content/uploads/demo-product/report.json', 'name' => 'report' ) ),
+	),
+	'callback_refs' => array(
+		'success' => array( 'ability' => 'demo/task-success', 'ref' => 'project-7' ),
+	),
+	'session_id' => 'demo-session',
+) );
+
+$fanout_request = WP_Codebox_Browser_Task_Builder::fanout_request( array(
+	'concurrency' => 2,
+	'workers' => array(
+		array(
+			'id' => 'Planner Worker',
+			'agent' => 'demo-agent',
+			'goal' => 'Plan the artifact.',
+			'context' => array( 'role' => 'planner' ),
+		),
+	),
+	'orchestrator' => array( 'id' => 'demo-orchestrator' ),
+) );
+
+echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.task_input.schema, "wp-codebox/task-input/v1")
@@ -99,5 +142,27 @@ assert.equal(result.local_task.context.caller, "test")
 assert.deepEqual(result.local_task.placement.allowed_targets, ["browser"])
 assert.deepEqual(result.local_task.placement.required_capabilities, ["wordpress.playground", "browser.preview", "artifact.website-bundle"])
 assert.equal(result.local_task.browser_runner.invocation.name, "agents/chat")
+assert.equal(result.intent_task.goal, "Build from intent.")
+assert.equal(result.intent_task.target.kind, "new-site")
+assert.equal(result.intent_task.target.ref, "project-7")
+assert.deepEqual(result.intent_task.placement.required_capabilities, ["wordpress.playground", "browser.preview", "artifact.website-bundle"])
+assert.deepEqual(result.intent_task.allowed_tools, ["filesystem-write", "browser.review"])
+assert.equal(result.intent_task.sandbox_tool_policy.tools[0].id, "filesystem-write")
+assert.equal(result.intent_task.sandbox_tool_policy.tools[0].runtime_tool_id, "filesystem_write")
+assert.equal(result.intent_task.sandbox_tool_policy.tools[1].runtime_tool_id, "browser_review")
+assert.equal(result.intent_task.context.product, "demo-product")
+assert.equal(result.intent_task.context.active_project_context.project_id, 7)
+assert.equal(result.intent_task.context.callback_refs.success.ability, "demo/task-success")
+assert.equal(result.intent_task.playground.scope, "demo-session")
+assert.equal(result.intent_task.playground.artifact_base_path, "/wordpress/wp-content/uploads/demo-product")
+assert.equal(result.intent_task.playground.preview_url, "/?preview=1")
+assert.equal(result.intent_task.browser_runner.task_path, "/tmp/demo-task.json")
+assert.equal(result.intent_task.browser_runner.result_path, "/tmp/demo-result.json")
+assert.equal(result.intent_task.browser_runner.invocation.hook, "demo_task")
+assert.equal(result.intent_task.callback_refs.success.ref, "project-7")
+assert.equal(result.fanout_request.schema, "wp-codebox/agent-fanout-request/v1")
+assert.equal(result.fanout_request.concurrency, 2)
+assert.equal(result.fanout_request.workers[0].schema, "wp-codebox/agent-fanout-worker/v1")
+assert.equal(result.fanout_request.workers[0].id, "planner-worker")
 
 console.log("browser task builder ok")


### PR DESCRIPTION
## Summary
- add a product-neutral browser task intent builder that emits canonical wp-codebox/create-browser-task-contract input
- normalize desired tools through the existing sandbox tool policy normalizer so runtime tool IDs stay provider-safe
- add generic fanout request/worker helpers to avoid downstream schema duplication
- cover intent, placement, callback refs, artifact paths, browser runner paths, and fanout helper output in the browser task builder test

## Tests
- npm run test:browser-task-builder
- npm run test:agent-task-contracts
- npm run test:runtime-tool-policy
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the PHP builder/helper changes and tests; Chris remains responsible for review and validation.