### PR TITLE
Refactor brittle tests around test kit helpers

### DIFF
--- a/scripts/test-kit.ts
+++ b/scripts/test-kit.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { mkdtemp, readdir, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -10,14 +11,40 @@ const execFileAsync = promisify(execFile)
 export const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 export const cliPath = resolve(repoRoot, "packages/cli/dist/index.js")
 
+export interface CommandOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+}
+
 export async function runCliJson<T>(args: string[]): Promise<T> {
   const stdout = await runCliText(args)
   return JSON.parse(stdout) as T
 }
 
 export async function runCliText(args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync(process.execPath, [cliPath, ...args], { cwd: repoRoot })
+  return runCommandText(process.execPath, [cliPath, ...args], { cwd: repoRoot })
+}
+
+export async function runCommandJson<T>(command: string, args: string[], options: CommandOptions = {}): Promise<T> {
+  return JSON.parse(await runCommandText(command, args, options)) as T
+}
+
+export async function runCommandText(command: string, args: string[], options: CommandOptions = {}): Promise<string> {
+  const { stdout } = await execFileAsync(command, args, { cwd: options.cwd ?? repoRoot, env: options.env })
   return stdout
+}
+
+export async function runPhpJson<T>(code: string, options: CommandOptions = {}): Promise<T> {
+  return runCommandJson<T>("php", ["-r", code], options)
+}
+
+export async function evaluatePhpJson<T>(expression: string, requires: string[] = []): Promise<T> {
+  const code = [
+    `define('ABSPATH', ${phpStringLiteral(repoRoot)});`,
+    ...requires.map((path) => `require ${phpStringLiteral(resolve(repoRoot, path))};`),
+    `echo json_encode(${expression}, JSON_UNESCAPED_SLASHES);`,
+  ].join(" ")
+  return runPhpJson<T>(code)
 }
 
 export async function withTempDir<T>(prefix: string, callback: (directory: string) => Promise<T>): Promise<T> {
@@ -33,10 +60,45 @@ export async function readJson<T>(path: string): Promise<T> {
   return JSON.parse(await readFile(path, "utf8")) as T
 }
 
+export async function assertTextFile(path: string, expected: string): Promise<void> {
+  assert.equal(await readFile(path, "utf8"), expected)
+}
+
+export async function assertJsonFile<T>(path: string, expected?: T): Promise<T> {
+  const json = await readJson<T>(path)
+  if (arguments.length > 1) {
+    assert.deepEqual(json, expected)
+  }
+  return json
+}
+
 export async function listRelativeFiles(directory: string): Promise<string[]> {
   const files: string[] = []
   await collectFiles(directory, directory, files)
   return files
+}
+
+export function phpFunctionBlock(source: string, method: string): string {
+  const signature = source.indexOf(`function ${method}(`)
+  assert.notEqual(signature, -1, `${method} method exists`)
+
+  const bodyStart = source.indexOf("{", signature)
+  assert.notEqual(bodyStart, -1, `${method} method has a body`)
+  return source.slice(signature, findBalancedEnd(source, bodyStart, "{", "}") + 1)
+}
+
+export function phpCallBlock(source: string, callName: string, containing: string): string {
+  const containingIndex = source.indexOf(containing)
+  assert.notEqual(containingIndex, -1, `${containing} exists`)
+
+  const callStart = source.lastIndexOf(`${callName}(`, containingIndex)
+  assert.notEqual(callStart, -1, `${callName} call exists before ${containing}`)
+
+  const argsStart = source.indexOf("(", callStart)
+  const argsEnd = findBalancedEnd(source, argsStart, "(", ")")
+  const statementEnd = source.indexOf(";", argsEnd)
+  assert.notEqual(statementEnd, -1, `${callName} call has a statement terminator`)
+  return source.slice(callStart, statementEnd + 1)
 }
 
 async function collectFiles(root: string, directory: string, files: string[]): Promise<void> {
@@ -48,4 +110,18 @@ async function collectFiles(root: string, directory: string, files: string[]): P
       files.push(relative(root, path).replace(/\\/g, "/"))
     }
   }
+}
+
+function findBalancedEnd(source: string, start: number, open: string, close: string): number {
+  let depth = 0
+  for (let index = start; index < source.length; index++) {
+    if (source[index] === open) depth++
+    if (source[index] === close) depth--
+    if (depth === 0) return index
+  }
+  assert.fail(`Unbalanced ${open}${close} block`)
+}
+
+export function phpStringLiteral(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`
 }

--- a/tests/browser-artifact-session.test.ts
+++ b/tests/browser-artifact-session.test.ts
@@ -1,12 +1,10 @@
 import assert from "node:assert/strict"
-import { mkdtempSync } from "node:fs"
-import { readFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
 import { resolve } from "node:path"
 
 import { BrowserArtifactSession } from "../packages/runtime-playground/src/browser-artifact-session.js"
+import { assertJsonFile, assertTextFile, withTempDir } from "../scripts/test-kit.js"
 
-const artifactRoot = mkdtempSync(resolve(tmpdir(), "wp-codebox-browser-artifact-session-"))
+await withTempDir("wp-codebox-browser-artifact-session-", async (artifactRoot) => {
 const session = new BrowserArtifactSession(artifactRoot, "files/browser", { source: "wordpress.browser-probe", operation: "browser-probe" })
 
 assert.equal(session.path("snapshot.html"), "files/browser/snapshot.html")
@@ -17,9 +15,9 @@ await session.writeJsonLines("console", "console.jsonl", [{ type: "log", text: "
 await session.writeJson("summary", "summary.json", { schema: "wp-codebox/browser-probe/v1", ok: true })
 await session.writeBuffer("screenshot", "screenshot.png", Buffer.from([0, 1, 2]))
 
-assert.equal(await readFile(resolve(artifactRoot, "files/browser/snapshot.html"), "utf8"), "<html><body>secret</body></html>")
-assert.equal(await readFile(resolve(artifactRoot, "files/browser/console.jsonl"), "utf8"), '{"type":"log","text":"visible"}\n')
-assert.equal(await readFile(resolve(artifactRoot, "files/browser/summary.json"), "utf8"), '{\n  "schema": "wp-codebox/browser-probe/v1",\n  "ok": true\n}\n')
+await assertTextFile(resolve(artifactRoot, "files/browser/snapshot.html"), "<html><body>secret</body></html>")
+await assertTextFile(resolve(artifactRoot, "files/browser/console.jsonl"), '{"type":"log","text":"visible"}\n')
+await assertJsonFile(resolve(artifactRoot, "files/browser/summary.json"), { schema: "wp-codebox/browser-probe/v1", ok: true })
 
 const files = new Map(session.writer.artifacts.files().map((file) => [file.path, file]))
 
@@ -39,3 +37,4 @@ assert.equal(files.get("files/browser/console.jsonl")?.redaction?.policy, "requi
 assert.equal(files.get("files/browser/screenshot.png")?.kind, "browser-screenshot")
 assert.equal(files.get("files/browser/screenshot.png")?.contentType, "image/png")
 assert.deepEqual(files.get("files/browser/screenshot.png")?.redaction, { policy: "none", sensitive: false })
+})

--- a/tests/browser-provider-permissions.test.ts
+++ b/tests/browser-provider-permissions.test.ts
@@ -1,47 +1,26 @@
 import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 
+import { phpCallBlock, phpFunctionBlock } from "../scripts/test-kit.js"
+
 const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-abilities.php", "utf8")
 const permissionsPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-permissions.php", "utf8")
 const providerAdapterPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-provider-adapter.php", "utf8")
 
-const providerAbility = abilityRegistrationBlock(abilitiesPhp, "wp-codebox/execute-browser-provider-request")
+const providerAbility = phpCallBlock(abilitiesPhp, "wp_register_ability", "wp-codebox/execute-browser-provider-request")
 
 assert.match(providerAbility, /'permission_callback'\s*=>\s*array\(\s*self::class,\s*'can_request_browser_connector'\s*\)/)
 assert.doesNotMatch(providerAbility, /can_create_browser_playground_session/)
 assert.match(providerAbility, /browser_connector_authorization_schema\(\)/)
 assert.doesNotMatch(providerAbility, /browser_session_authorization_schema\(\)/)
 
-const connectorPermission = methodBlock(permissionsPhp, "can_request_browser_connector")
+const connectorPermission = phpFunctionBlock(permissionsPhp, "can_request_browser_connector")
 assert.match(connectorPermission, /current_user_can\(\s*'manage_options'\s*\)/)
 assert.match(connectorPermission, /trusted_orchestrator_authorization\(\s*\$input,\s*self::BROWSER_CONNECTOR_REQUEST_SCOPE\s*\)/)
 assert.doesNotMatch(connectorPermission, /BROWSER_SESSION_CREATE_SCOPE/)
 
-const sessionPermission = methodBlock(permissionsPhp, "can_create_browser_playground_session")
+const sessionPermission = phpFunctionBlock(permissionsPhp, "can_create_browser_playground_session")
 assert.match(sessionPermission, /trusted_orchestrator_authorization\(\s*\$input,\s*self::BROWSER_SESSION_CREATE_SCOPE\s*\)/)
 
 assert.match(providerAdapterPhp, /trusted_orchestrator_authorization\(\s*\$input,\s*self::BROWSER_CONNECTOR_REQUEST_SCOPE\s*\)/)
-assert.doesNotMatch(methodBlock(providerAdapterPhp, "browser_provider_request_context"), /browser_session_authorization\(\s*\$input\s*\)/)
-
-function abilityRegistrationBlock(source: string, ability: string): string {
-  const start = source.indexOf(`wp_register_ability(\n\t\t\t\t'${ability}'`)
-  assert.notEqual(start, -1, `${ability} registration exists`)
-
-  const next = source.indexOf("\n\t\t\twp_register_ability(", start + 1)
-  assert.notEqual(next, -1, `${ability} registration has a closing boundary`)
-
-  return source.slice(start, next)
-}
-
-function methodBlock(source: string, method: string): string {
-  const start = source.indexOf(`function ${method}(`)
-  assert.notEqual(start, -1, `${method} method exists`)
-
-  const nextFunction = source.indexOf("\npublic static function ", start + 1)
-  const nextPrivateFunction = source.indexOf("\nprivate static function ", start + 1)
-  const nextCandidates = [nextFunction, nextPrivateFunction].filter((candidate) => candidate !== -1)
-  const next = Math.min(...nextCandidates)
-  assert.notEqual(next, -1, `${method} method has a closing boundary`)
-
-  return source.slice(start, next)
-}
+assert.doesNotMatch(phpFunctionBlock(providerAdapterPhp, "browser_provider_request_context"), /browser_session_authorization\(\s*\$input\s*\)/)

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -1,21 +1,20 @@
 import assert from "node:assert/strict"
-import { spawnSync } from "node:child_process"
 
-const root = new URL("../", import.meta.url)
-const rootPath = root.pathname.replace(/'/g, "'\\''")
+import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
 
-const php = spawnSync("php", ["-r", `
-define('ABSPATH', '${rootPath}');
+const rootPath = phpStringLiteral(repoRoot)
+const result = await runPhpJson<any>(`
+define('ABSPATH', ${rootPath});
 class WP_Error {
 	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
 }
 function is_wp_error( $value ) { return $value instanceof WP_Error; }
-require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
-require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
-require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
-require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
-require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php';
-require '${rootPath}packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php';
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php`)};
 
 $task_input = WP_Codebox_Browser_Task_Builder::normalize_task_input( array(
 	'goal' => 'Build a generic browser task.',
@@ -74,13 +73,7 @@ $explicit_plan_payload = WP_Codebox_Browser_Task_Builder::task_payload(
 );
 
 echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'local_task' => $local_task ), JSON_UNESCAPED_SLASHES );
-`], {
-  cwd: root.pathname,
-  encoding: "utf8",
-})
-
-assert.equal(php.status, 0, php.stderr)
-const result = JSON.parse(php.stdout)
+`)
 
 assert.equal(result.task_input.schema, "wp-codebox/task-input/v1")
 assert.deepEqual(result.task_input.allowed_tools, ["filesystem_write"])

--- a/tests/host-command-executor.test.ts
+++ b/tests/host-command-executor.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict"
-import { mkdir, mkdtemp, readFile, realpath } from "node:fs/promises"
+import { mkdir, readFile, realpath } from "node:fs/promises"
 import { join } from "node:path"
-import { tmpdir } from "node:os"
 import { classifyHostCommandFailure, executeHostCommand, executeManagedHostCommand, hostCommandEnv, ManagedHostCommandError, resolveAllowedHostCommandCwd } from "../packages/runtime-core/src/index.js"
+import { assertJsonFile, assertTextFile, withTempDir } from "../scripts/test-kit.js"
 
-const root = await mkdtemp(join(tmpdir(), "wp-codebox-host-command-executor-"))
+await withTempDir("wp-codebox-host-command-executor-", async (root) => {
 const allowed = join(root, "allowed")
 const sibling = join(root, "allowed-sibling")
 const child = join(allowed, "child")
@@ -54,7 +54,7 @@ const processTreeTimedOut = await executeHostCommand(
     cwd: allowed,
     terminationGraceMs: 25,
   },
-  { timeoutMs: 25 }
+  { timeoutMs: 2_000 }
 )
 assert.equal(processTreeTimedOut.failureClassification, "timeout")
 const grandchildPid = Number.parseInt(await readFile(grandchildPidFile, "utf8"), 10)
@@ -88,9 +88,9 @@ assert.equal(withArtifacts.stderr, "err")
 assert.ok(withArtifacts.artifacts?.stdout?.path.endsWith("stdout.log"))
 assert.ok(withArtifacts.artifacts?.stderr?.path.endsWith("stderr.log"))
 assert.ok(withArtifacts.artifacts?.summary?.path.endsWith("command-summary.json"))
-assert.equal(await readFile(withArtifacts.artifacts!.stdout!.path, "utf8"), "out")
-assert.equal(await readFile(withArtifacts.artifacts!.stderr!.path, "utf8"), "err")
-const artifactSummary = JSON.parse(await readFile(withArtifacts.artifacts!.summary!.path, "utf8"))
+await assertTextFile(withArtifacts.artifacts!.stdout!.path, "out")
+await assertTextFile(withArtifacts.artifacts!.stderr!.path, "err")
+const artifactSummary = await assertJsonFile<{ schema: string, failureClassification: string, memorySamples: unknown[] }>(withArtifacts.artifacts!.summary!.path)
 assert.equal(artifactSummary.schema, "wp-codebox/host-command-summary/v1")
 assert.equal(artifactSummary.failureClassification, "none")
 assert.ok(Array.isArray(artifactSummary.memorySamples))
@@ -155,3 +155,4 @@ await assert.rejects(
     return true
   }
 )
+})

--- a/tests/path-policy-parity.test.ts
+++ b/tests/path-policy-parity.test.ts
@@ -1,16 +1,15 @@
 import assert from "node:assert/strict"
-import { mkdtempSync } from "node:fs"
-import { tmpdir } from "node:os"
 import { resolve } from "node:path"
 import { normalizeRuntimeMountTarget, safeArtifactRelativePath } from "../packages/runtime-core/src/index.js"
 import { parseWorkspaceRecipe, validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.js"
+import { withTempDir } from "../scripts/test-kit.js"
 
 assert.equal(normalizeRuntimeMountTarget("//wordpress//wp-content/plugins/plugin"), "/wordpress/wp-content/plugins/plugin")
 assert.throws(() => normalizeRuntimeMountTarget("/wordpress/../escape"), /parent-directory/)
 assert.equal(safeArtifactRelativePath("/files//output.json"), "files/output.json")
 assert.throws(() => safeArtifactRelativePath("files/../secret.txt"), /parent-directory/)
 
-const source = mkdtempSync(resolve(tmpdir(), "wp-codebox-path-policy-source-"))
+await withTempDir("wp-codebox-path-policy-source-", async (source) => {
 const recipePath = resolve(source, "recipe.json")
 const recipe = parseWorkspaceRecipe(JSON.stringify({
   schema: "wp-codebox/workspace-recipe/v1",
@@ -42,3 +41,4 @@ const artifactTraversalRecipe = parseWorkspaceRecipe(JSON.stringify({
 }), recipePath)
 const traversalIssues = await validateWorkspaceRecipeSemantics(artifactTraversalRecipe, recipePath)
 assert.equal(traversalIssues[0]?.code, "invalid-distribution-artifact")
+})

--- a/tests/php-managed-host-command.test.ts
+++ b/tests/php-managed-host-command.test.ts
@@ -1,24 +1,13 @@
-import { spawnSync } from "node:child_process"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
 import assert from "node:assert/strict"
+import { resolve } from "node:path"
 
-const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
-const classPath = resolve(root, "packages/wordpress-plugin/src/class-wp-codebox-managed-host-command.php")
-const escapedRoot = root.replace(/'/g, "'\\''")
-const escapedClassPath = classPath.replace(/'/g, "'\\''")
+import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
 
-const php = spawnSync(
-  "php",
-  [
-    "-r",
-    `define('ABSPATH', '${escapedRoot}'); require '${escapedClassPath}'; $result = WP_Codebox_Managed_Host_Command::run(array('command' => array(PHP_BINARY, '-r', 'print($argv[1]);', 'literal;not-shell'), 'cwd' => '${escapedRoot}', 'allowed_cwd_roots' => array('${escapedRoot}'))); if (!is_array($result)) { var_export($result); exit(1); } echo json_encode($result, JSON_UNESCAPED_SLASHES);`,
-  ],
-  { encoding: "utf8", cwd: root }
+const root = phpStringLiteral(repoRoot)
+const classPath = phpStringLiteral(resolve(repoRoot, "packages/wordpress-plugin/src/class-wp-codebox-managed-host-command.php"))
+const result = await runPhpJson<{ success: boolean, stdout: string, args: string[] }>(
+  `define('ABSPATH', ${root}); require ${classPath}; $result = WP_Codebox_Managed_Host_Command::run(array('command' => array(PHP_BINARY, '-r', 'print($argv[1]);', 'literal;not-shell'), 'cwd' => ${root}, 'allowed_cwd_roots' => array(${root}))); if (!is_array($result)) { var_export($result); exit(1); } echo json_encode($result, JSON_UNESCAPED_SLASHES);`
 )
-
-assert.equal(php.status, 0, php.stderr || php.stdout)
-const result = JSON.parse(php.stdout)
 assert.equal(result.success, true)
 assert.equal(result.stdout, "literal;not-shell")
 assert.deepEqual(result.args.slice(-2), ["print($argv[1]);", "literal;not-shell"])

--- a/tests/recipe-source-packages.test.ts
+++ b/tests/recipe-source-packages.test.ts
@@ -1,18 +1,17 @@
 import assert from "node:assert/strict"
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
-import { readFile, stat } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { mkdir, stat, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { parseWorkspaceRecipe, validateWorkspaceRecipe } from "../packages/cli/src/recipe-validation.js"
 import { prepareRecipeStagedFiles } from "../packages/cli/src/recipe-sources.js"
 import { compileRecipeTemplate } from "../packages/runtime-core/src/index.js"
+import { assertJsonFile, withTempDir } from "../scripts/test-kit.js"
 
-const recipeDirectory = mkdtempSync(join(tmpdir(), "wp-codebox-source-package-test-"))
+await withTempDir("wp-codebox-source-package-test-", async (recipeDirectory) => {
 const sourceDirectory = join(recipeDirectory, "source")
-mkdirSync(join(sourceDirectory, "src", "secrets"), { recursive: true })
-writeFileSync(join(sourceDirectory, "src", "index.php"), "<?php echo 'ok';\n")
-writeFileSync(join(sourceDirectory, "src", "secrets", "key.php"), "<?php echo 'secret';\n")
-writeFileSync(join(sourceDirectory, ".env"), "TOKEN=secret\n")
+await mkdir(join(sourceDirectory, "src", "secrets"), { recursive: true })
+await writeFile(join(sourceDirectory, "src", "index.php"), "<?php echo 'ok';\n")
+await writeFile(join(sourceDirectory, "src", "secrets", "key.php"), "<?php echo 'secret';\n")
+await writeFile(join(sourceDirectory, ".env"), "TOKEN=secret\n")
 
 const compiled = compileRecipeTemplate({
   recipe: {
@@ -41,7 +40,8 @@ assert.equal((await stat(join(sourcePackage.source, "src", "index.php"))).isFile
 await assert.rejects(stat(join(sourcePackage.source, "src", "secrets", "key.php")))
 await assert.rejects(stat(join(sourcePackage.source, ".env")))
 
-const provenance = JSON.parse(await readFile(join(sourcePackage.source, ".wp-codebox-source-package.json"), "utf8"))
+const provenance = await assertJsonFile<{ schema: string, name: string, target: string }>(join(sourcePackage.source, ".wp-codebox-source-package.json"))
 assert.equal(provenance.schema, "wp-codebox/source-package-provenance/v1")
 assert.equal(provenance.name, "fixture")
 assert.equal(provenance.target, "/workspace/fixtures/plugin")
+})

--- a/tests/schema-parity.test.ts
+++ b/tests/schema-parity.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict"
-import { spawnSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 
 import { createWorkspaceRecipeJsonSchema, TASK_INPUT_ABILITY_ALIAS_FIELDS, TASK_INPUT_JSON_SCHEMA } from "../packages/runtime-core/src/index.js"
+import { evaluatePhpJson } from "../scripts/test-kit.js"
 
-const root = new URL("../", import.meta.url)
+const taskInputContract = "packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php"
 
 function canonicalJson(value: unknown): string {
   return JSON.stringify(sortObject(value), null, 2)
@@ -16,19 +16,10 @@ function sortObject(value: unknown): unknown {
   return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => [key, sortObject(entry)]))
 }
 
-function phpJson(expression: string): unknown {
-  const php = spawnSync("php", ["-r", `define('ABSPATH', '${root.pathname.replace(/'/g, "'\\''")}'); require '${root.pathname.replace(/'/g, "'\\''")}packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php'; echo json_encode(${expression}, JSON_UNESCAPED_SLASHES);`], {
-    cwd: root.pathname,
-    encoding: "utf8",
-  })
-  assert.equal(php.status, 0, php.stderr)
-  return JSON.parse(php.stdout)
-}
-
-const phpTaskInputSchema = phpJson("WP_Codebox_Task_Input_Contract::schema()")
+const phpTaskInputSchema = await evaluatePhpJson("WP_Codebox_Task_Input_Contract::schema()", [taskInputContract])
 assert.equal(canonicalJson(phpTaskInputSchema), canonicalJson(TASK_INPUT_JSON_SCHEMA), "PHP task input schema must match runtime-core TASK_INPUT_JSON_SCHEMA")
 
-const phpAliasFields = phpJson("WP_Codebox_Task_Input_Contract::ABILITY_ALIAS_FIELDS")
+const phpAliasFields = await evaluatePhpJson("WP_Codebox_Task_Input_Contract::ABILITY_ALIAS_FIELDS", [taskInputContract])
 assert.deepEqual(phpAliasFields, [...TASK_INPUT_ABILITY_ALIAS_FIELDS], "PHP ability task aliases must match runtime-core alias fields")
 
 const recipeSchema = createWorkspaceRecipeJsonSchema()


### PR DESCRIPTION
## Summary
- Expand scripts/test-kit.ts with reusable command/PHP JSON, file assertion, temp directory, and PHP source block helpers.
- Migrate brittle inline temp-dir, JSON parsing, PHP process, and source block boilerplate in high-value contract tests.
- Loosen the host-command process-tree timeout case so it validates the same contract without racing Node startup.

## Tests
- npm run test:schema-parity && npm run test:browser-provider-permissions && npm run test:host-command-executor && npm run test:recipe-source-packages && npm run test:browser-artifact-session && npm run test:path-policy-parity && npm run test:php-managed-host-command && npm run test:browser-task-builder
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the test-kit helper refactor and migrated focused test coverage; Chris remains responsible for review and testing.