### PR TITLE
Extract generic run plan scheduler helpers

### DIFF
--- a/packages/cli/src/agent-fanout.ts
+++ b/packages/cli/src/agent-fanout.ts
@@ -1,6 +1,6 @@
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { commandArgValue, countRunPlanChildResults, FANOUT_EVENT_SCHEMA, FANOUT_PLAN_SCHEMA, FANOUT_REQUEST_SCHEMA, FANOUT_RESULT_SCHEMA, parseCommandJsonObject, type FanoutLifecycleEvent, type FanoutRequestContract } from "@automattic/wp-codebox-core"
+import { commandArgValue, countRunPlanChildResults, createRunPlanEvent, FANOUT_EVENT_SCHEMA, FANOUT_PLAN_SCHEMA, FANOUT_REQUEST_SCHEMA, FANOUT_RESULT_SCHEMA, normalizeRunPlanConcurrency, normalizeRunPlanWorkerDescriptors, parseCommandJsonObject, runBoundedConcurrent, type FanoutLifecycleEvent, type FanoutRequestContract, type RunPlanWorkerDescriptor } from "@automattic/wp-codebox-core"
 import { agentTaskStatusSucceeded, aggregateFanoutOutputs, normalizeAgentTaskStatus, stripUndefined, type FanoutAggregationOutput } from "@automattic/wp-codebox-core/internals"
 import { runAgentTask, type AgentTaskRunInput, type AgentTaskRunOptions } from "./commands/agent-task-run.js"
 
@@ -44,6 +44,7 @@ interface AgentFanoutWorkerResult {
 }
 
 type AgentFanoutWorkerOutput = Record<string, unknown> & { success?: boolean; evidence_refs?: unknown[]; error?: unknown }
+type AgentFanoutWorkerDescriptor = RunPlanWorkerDescriptor<FanoutRequestContract["workers"][number]>
 
 export async function executeAgentFanoutRequest(request: FanoutRequestContract, options: AgentFanoutExecutionOptions): Promise<AgentFanoutExecutionResult> {
   if (request.schema && request.schema !== FANOUT_REQUEST_SCHEMA) {
@@ -54,7 +55,7 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
   }
 
   const sessionId = stringValue(request.orchestrator?.session_id) || stringValue(request.orchestrator?.request_id) || `fanout-${Date.now()}`
-  const concurrency = Math.max(1, Math.min(MAX_FANOUT_CONCURRENCY, Math.floor(Number(request.concurrency) || 1)))
+  const concurrency = normalizeRunPlanConcurrency(request.concurrency, { maxConcurrency: MAX_FANOUT_CONCURRENCY, concurrencyMode: "clamp" })
   const fanoutRoot = join(options.artifactRoot, "fanout")
   const workersRoot = join(fanoutRoot, "workers")
   const aggregateRoot = join(fanoutRoot, "aggregate")
@@ -65,38 +66,25 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
   await mkdir(workersRoot, { recursive: true })
   await mkdir(aggregateFinalRoot, { recursive: true })
 
-  const workers = request.workers.map((worker) => {
-    const id = safeWorkerId(worker.id)
-    return {
-      ...worker,
-      id,
-      agent: stringValue(worker.agent) || stringValue(request.agent),
-      artifact_namespace: safeArtifactNamespace(worker.artifactNamespace, id),
-      required: worker.required !== false,
-    }
-  })
-
-  if (new Set(workers.map((worker) => worker.id)).size !== workers.length) {
-    throw new Error("wp-codebox.agent-fanout worker ids must be unique")
-  }
+  const workers = normalizeRunPlanWorkerDescriptors(request.workers, { defaultAgent: stringValue(request.agent), requireGoal: true })
 
   const plan = {
     schema: FANOUT_PLAN_SCHEMA,
     session_id: sessionId,
     concurrency,
     orchestrator: request.orchestrator ?? {},
-    workers: workers.map((worker) => ({
-      id: worker.id,
-      agent: worker.agent,
-      goal: worker.goal,
-      artifact_namespace: worker.artifact_namespace,
+    workers: workers.map((descriptor) => ({
+      id: descriptor.id,
+      agent: descriptor.agent,
+      goal: descriptor.goal,
+      artifact_namespace: descriptor.artifactNamespace,
     })),
   }
   await writeJson(planPath, plan)
   await emitEvent(eventsPath, { event: "fanout.started", total: workers.length, active: 0, completed: 0, failed: 0, cancelled: 0 })
 
   const runWorker = options.runWorker ?? (async (input: AgentTaskRunInput, workerOptions: AgentTaskRunOptions): Promise<AgentFanoutWorkerOutput> => runAgentTask(input, workerOptions) as unknown as AgentFanoutWorkerOutput)
-  const workerResults = await runBounded(workers, concurrency, async (worker): Promise<AgentFanoutWorkerResult> => {
+  const workerResults = await runBoundedConcurrent(workers, concurrency, async (worker): Promise<AgentFanoutWorkerResult> => {
     const workerArtifacts = join(workersRoot, worker.id, "artifacts")
     const childSessionId = `${sessionId}:${worker.id}`
     await mkdir(workerArtifacts, { recursive: true })
@@ -143,7 +131,7 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
 
   await emitEvent(eventsPath, { event: "aggregation.started", total: workers.length, completed: workerResults.filter((worker) => agentTaskStatusSucceeded(worker.status)).length, failed: workerResults.filter((worker) => !agentTaskStatusSucceeded(worker.status)).length })
   const aggregate = aggregateFanoutOutputs({
-    plan: { id: sessionId, workers: workers.map((worker) => ({ id: worker.id, dependsOn: Array.isArray(worker.dependsOn) ? worker.dependsOn.filter((dependency): dependency is string => typeof dependency === "string") : [], required: worker.required, artifactNamespace: worker.artifact_namespace })) },
+    plan: { id: sessionId, workers: workers.map((worker) => ({ id: worker.id, dependsOn: worker.dependsOn, required: worker.required, artifactNamespace: worker.artifactNamespace })) },
     policy: stringValue(request.aggregation?.policy) || "fail",
     aggregation: request.aggregation,
     worker_results: workerResults.map((worker) => ({
@@ -207,7 +195,8 @@ async function fanoutRequestFromArgs(args: string[], recipeDirectory: string): P
   return parseCommandJsonObject(text, "wp-codebox.agent-fanout fanout-json") as FanoutRequestContract
 }
 
-function workerInput(request: FanoutRequestContract, worker: Record<string, unknown>, childSessionId: string, artifactsPath: string): AgentTaskRunInput {
+function workerInput(request: FanoutRequestContract, descriptor: AgentFanoutWorkerDescriptor, childSessionId: string, artifactsPath: string): AgentTaskRunInput {
+  const worker = descriptor.worker
   const parentInput = objectValue(request.task_input) || objectValue(request.taskInput) || {}
   const workerTaskInput = objectValue(worker.task_input) || objectValue(worker.taskInput) || {}
   const inherited = inheritedAgentTaskInput(request)
@@ -217,13 +206,13 @@ function workerInput(request: FanoutRequestContract, worker: Record<string, unkn
     ...parentInput,
     ...workerInherited,
     ...workerTaskInput,
-    goal: stringValue(worker.task) || stringValue(worker.goal),
-    agent: stringValue(worker.agent) || stringValue(parentInput.agent) || stringValue(request.agent),
+    goal: stringValue(worker.task) || descriptor.goal,
+    agent: descriptor.agent || stringValue(parentInput.agent) || stringValue(request.agent),
     artifacts_path: artifactsPath,
     session_id: childSessionId,
     sandbox_session_id: childSessionId,
     parent_request: request as unknown as Record<string, unknown>,
-    orchestrator: stripUndefined({ ...(request.orchestrator ?? {}), fanout_worker_id: worker.id }),
+    orchestrator: stripUndefined({ ...(request.orchestrator ?? {}), fanout_worker_id: descriptor.id }),
   }) as AgentTaskRunInput
 }
 
@@ -254,21 +243,8 @@ function inheritedAgentTaskInput(source: Record<string, unknown>): Record<string
   return result
 }
 
-async function runBounded<T, R>(items: T[], concurrency: number, worker: (item: T) => Promise<R>): Promise<R[]> {
-  const results = new Array<R>(items.length)
-  let next = 0
-  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
-    while (next < items.length) {
-      const index = next++
-      results[index] = await worker(items[index])
-    }
-  })
-  await Promise.all(runners)
-  return results
-}
-
 async function emitEvent(path: string, event: Omit<FanoutLifecycleEvent, "schema" | "time" | "worker_id"> & { worker_id?: string }): Promise<void> {
-  await appendFile(path, `${JSON.stringify({ schema: FANOUT_EVENT_SCHEMA, time: new Date().toISOString(), ...event })}\n`)
+  await appendFile(path, `${JSON.stringify(createRunPlanEvent<FanoutLifecycleEvent>(FANOUT_EVENT_SCHEMA, event))}\n`)
 }
 
 async function writeJson(path: string, value: unknown): Promise<void> {
@@ -286,22 +262,6 @@ function workerArtifactRefs(workerId: string, output: Record<string, unknown>): 
     kind: stringValue(ref.kind) || "codebox-evidence",
     metadata: ref,
   }))
-}
-
-function safeWorkerId(value: unknown): string {
-  const id = stringValue(value)
-  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id)) {
-    throw new Error(`wp-codebox.agent-fanout worker id must be a safe path segment: ${id || "<empty>"}`)
-  }
-  return id
-}
-
-function safeArtifactNamespace(value: unknown, fallback: string): string {
-  const namespace = stringValue(value) || fallback
-  if (namespace.split("/").some((segment) => !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment))) {
-    throw new Error(`wp-codebox.agent-fanout artifact namespace must contain safe path segments: ${namespace}`)
-  }
-  return namespace
 }
 
 function objectValue(value: unknown): Record<string, unknown> | undefined {

--- a/packages/runtime-core/src/run-plan.ts
+++ b/packages/runtime-core/src/run-plan.ts
@@ -6,6 +6,8 @@ export interface RunPlanWorkerContract {
   id: string
   goal?: string
   artifactNamespace?: string
+  artifact_namespace?: string
+  required?: boolean
   metadata?: Record<string, unknown>
   [key: string]: unknown
 }
@@ -40,6 +42,34 @@ export interface RunPlanChildResult {
   [key: string]: unknown
 }
 
+export interface RunPlanWorkerDescriptor<TWorker extends RunPlanWorkerContract = RunPlanWorkerContract> {
+  id: string
+  index: number
+  worker: TWorker
+  goal: string
+  agent: string
+  artifactNamespace: string
+  required: boolean
+  dependsOn: string[]
+  timeoutSeconds?: number
+  cancellation: RunPlanCancellationMetadata
+}
+
+export interface RunPlanNormalizationOptions {
+  defaultAgent?: string
+  defaultConcurrency?: number
+  maxConcurrency?: number
+  requireGoal?: boolean
+  concurrencyMode?: "clamp" | "validate"
+}
+
+export interface RunPlanCancellationMetadata {
+  cancelRequested: boolean
+  reason?: string
+  timeoutSeconds?: number
+  deadline?: string
+}
+
 export interface RunPlanResultCounts {
   total: number
   completed: number
@@ -61,4 +91,102 @@ export function countRunPlanChildResults(results: RunPlanChildResult[]): RunPlan
 
 export function runPlanSucceeded(counts: Pick<RunPlanResultCounts, "failed" | "cancelled">): boolean {
   return counts.failed === 0 && counts.cancelled === 0
+}
+
+export function normalizeRunPlanConcurrency(value: unknown, options: Pick<RunPlanNormalizationOptions, "defaultConcurrency" | "maxConcurrency" | "concurrencyMode"> = {}): number {
+  const defaultConcurrency = Math.max(1, Math.floor(Number(options.defaultConcurrency) || 1))
+  const maxConcurrency = Math.max(1, Math.floor(Number(options.maxConcurrency) || Number.MAX_SAFE_INTEGER))
+  const requested = Math.floor(Number(value) || defaultConcurrency)
+
+  if (options.concurrencyMode === "validate" && (requested < 1 || requested > maxConcurrency)) {
+    throw new Error(`Run plan concurrency must be between 1 and ${maxConcurrency}.`)
+  }
+
+  return Math.max(1, Math.min(maxConcurrency, requested))
+}
+
+export function normalizeRunPlanWorkerDescriptors<TWorker extends RunPlanWorkerContract>(workers: TWorker[], options: RunPlanNormalizationOptions = {}): Array<RunPlanWorkerDescriptor<TWorker>> {
+  if (!Array.isArray(workers) || workers.length === 0) {
+    throw new Error("Run plan requires at least one worker.")
+  }
+
+  const seen = new Set<string>()
+  return workers.map((worker, index) => {
+    const id = safeRunPlanPathSegment(worker.id)
+    if (seen.has(id)) {
+      throw new Error(`Run plan worker ids must be unique: ${id}`)
+    }
+    seen.add(id)
+
+    const goal = stringValue(worker.goal)
+    if (options.requireGoal && !goal) {
+      throw new Error(`Run plan worker requires goal: ${id}`)
+    }
+
+    return {
+      id,
+      index,
+      worker: { ...worker, id },
+      goal,
+      agent: stringValue(worker.agent) || stringValue(options.defaultAgent),
+      artifactNamespace: safeRunPlanNamespace(stringValue(worker.artifactNamespace ?? worker.artifact_namespace) || id),
+      required: worker.required !== false,
+      dependsOn: Array.isArray(worker.dependsOn) ? worker.dependsOn.filter((dependency): dependency is string => typeof dependency === "string") : [],
+      timeoutSeconds: positiveInteger(worker.timeoutSeconds ?? worker.timeout_seconds ?? worker.task_timeout_seconds),
+      cancellation: runPlanCancellationMetadata(worker),
+    }
+  })
+}
+
+export function createRunPlanEvent<TEvent>(schema: string, event: Omit<TEvent, "schema" | "time"> & { time?: string }): TEvent {
+  return { schema, time: event.time ?? new Date().toISOString(), ...event } as TEvent
+}
+
+export async function runBoundedConcurrent<T, R>(items: T[], concurrency: number, worker: (item: T, index: number) => Promise<R>): Promise<R[]> {
+  const effectiveConcurrency = normalizeRunPlanConcurrency(concurrency, { maxConcurrency: items.length || 1 })
+  const results = new Array<R>(items.length)
+  let next = 0
+  const runners = Array.from({ length: Math.min(effectiveConcurrency, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await worker(items[index], index)
+    }
+  })
+  await Promise.all(runners)
+  return results
+}
+
+export function runPlanCancellationMetadata(source: Record<string, unknown>): RunPlanCancellationMetadata {
+  const timeoutSeconds = positiveInteger(source.timeoutSeconds ?? source.timeout_seconds ?? source.task_timeout_seconds)
+  return {
+    cancelRequested: Boolean(source.cancelRequested ?? source.cancel_requested ?? source.cancelled),
+    ...(stringValue(source.cancelReason ?? source.cancel_reason) ? { reason: stringValue(source.cancelReason ?? source.cancel_reason) } : {}),
+    ...(timeoutSeconds ? { timeoutSeconds } : {}),
+    ...(stringValue(source.deadline) ? { deadline: stringValue(source.deadline) } : {}),
+  }
+}
+
+export function safeRunPlanPathSegment(value: unknown): string {
+  const segment = stringValue(value)
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment)) {
+    throw new Error(`Run plan path segment must be safe: ${segment || "<empty>"}`)
+  }
+  return segment
+}
+
+export function safeRunPlanNamespace(value: unknown): string {
+  const namespace = stringValue(value)
+  if (!namespace || namespace.split("/").some((segment) => !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment))) {
+    throw new Error(`Run plan namespace must contain safe path segments: ${namespace || "<empty>"}`)
+  }
+  return namespace
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const number = Math.floor(Number(value) || 0)
+  return number > 0 ? number : undefined
+}
+
+function stringValue(value: unknown): string {
+  return value === undefined || value === null ? "" : String(value).trim()
 }

--- a/scripts/fanout-contract-smoke.ts
+++ b/scripts/fanout-contract-smoke.ts
@@ -10,7 +10,11 @@ import {
   RUN_PLAN_RESULT_SCHEMA,
   RUN_PLAN_SCHEMA,
   countRunPlanChildResults,
+  createRunPlanEvent,
   isFanoutEventType,
+  normalizeRunPlanConcurrency,
+  normalizeRunPlanWorkerDescriptors,
+  runBoundedConcurrent,
   runPlanSucceeded,
   type FanoutExecutionStrategy,
   type FanoutLifecycleEvent,
@@ -66,6 +70,15 @@ const counts = countRunPlanChildResults([
   { success: false, status: "failed" },
   { success: false, status: "cancelled" },
 ])
+const descriptors = normalizeRunPlanWorkerDescriptors(
+  [
+    { id: "design", goal: "Draft design direction.", agent: "planner", timeout_seconds: 30 },
+    { id: "copy", goal: "Draft page copy.", artifactNamespace: "copy/final", required: false, cancel_requested: true, cancel_reason: "caller stopped" },
+  ],
+  { defaultAgent: "default-agent", requireGoal: true },
+)
+const emittedFanoutEvent = createRunPlanEvent<FanoutLifecycleEvent>(FANOUT_EVENT_SCHEMA, { event: "worker.completed", worker_id: "design", status: "completed", time: "2026-06-06T00:00:09Z" })
+const boundedResults = await runBoundedConcurrent(["a", "b", "c"], 2, async (value, index) => `${index}:${value}`)
 
 assert.equal(FANOUT_RESULT_SCHEMA, "wp-codebox/agent-fanout-result/v1")
 assert.equal(RUN_PLAN_RESULT_SCHEMA, "wp-codebox/run-plan-result/v1")
@@ -76,6 +89,15 @@ assert.equal(genericPlan.schema, RUN_PLAN_SCHEMA)
 assert.equal(genericEvent.schema, RUN_PLAN_EVENT_SCHEMA)
 assert.deepEqual(counts, { total: 3, completed: 1, failed: 1, cancelled: 1 })
 assert.equal(runPlanSucceeded(counts), false)
+assert.equal(normalizeRunPlanConcurrency(99, { maxConcurrency: 8, concurrencyMode: "clamp" }), 8)
+assert.throws(() => normalizeRunPlanConcurrency(9, { maxConcurrency: 8, concurrencyMode: "validate" }), /between 1 and 8/)
+assert.equal(descriptors[0].timeoutSeconds, 30)
+assert.deepEqual(descriptors[0].cancellation, { cancelRequested: false, timeoutSeconds: 30 })
+assert.equal(descriptors[1].artifactNamespace, "copy/final")
+assert.equal(descriptors[1].required, false)
+assert.deepEqual(descriptors[1].cancellation, { cancelRequested: true, reason: "caller stopped" })
+assert.deepEqual(emittedFanoutEvent, { schema: FANOUT_EVENT_SCHEMA, time: "2026-06-06T00:00:09Z", event: "worker.completed", worker_id: "design", status: "completed" })
+assert.deepEqual(boundedResults, ["0:a", "1:b", "2:c"])
 assert.ok(events.every((event) => event.schema === FANOUT_EVENT_SCHEMA && isFanoutEventType(event.event)))
 assert.equal(isFanoutEventType("worker_finished"), false)
 assert.equal(isFanoutEventType("worker.completed"), true)


### PR DESCRIPTION
## Summary
- Add generic run-plan helpers for concurrency normalization, worker descriptors, timeout/cancellation metadata, lifecycle event envelopes, and bounded concurrent execution.
- Migrate the CLI agent fanout executor to those helpers while preserving the existing fanout schema, artifact layout, concurrency cap, aggregation behavior, and event file shape.
- Extend the fanout contract smoke to cover the new generic helper surface.

## Tests
- php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
- npm run build
- npm run smoke -- --command=fanout-contract-smoke
- npm run smoke -- --command=fanout-aggregation-contract-smoke
- npm run smoke -- --command=agent-fanout-execution-smoke
- npm run smoke -- --group=agent
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the generic run-plan helper extraction, CLI fanout migration, smoke coverage update, and verification pass for Chris to review/test.
