### PR TITLE
Harden primitive contract parity guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",
     "test:mcp-client-configs": "tsx tests/mcp-client-configs.test.ts",
     "test:runtime-tool-policy": "tsx tests/runtime-tool-policy.test.ts",
+    "test:primitive-contract-parity": "tsx tests/primitive-contract-parity.test.ts",
+    "test:php-primitive-contract-parity": "php scripts/php-primitive-contract-parity-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -61,6 +61,18 @@ interface RuntimeOverlayProfileDefaults {
   runtimeOverlays: Array<Record<string, unknown>>
 }
 
+export interface RuntimeDependencyPlanContractInput {
+  selection?: Record<string, unknown>
+  provider_plugin_paths?: unknown
+  provider_plugins?: unknown
+  component_plugins?: unknown
+  runtime_overlays?: unknown
+  inheritance_request?: { connectors?: unknown; settings?: unknown }
+  inheritance?: { connectors?: unknown; settings?: unknown }
+  agent_bundles?: unknown
+  secret_env?: unknown
+}
+
 export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskInput, wpVersion: string): WorkspaceRecipe {
   const artifacts = stringValue(input.artifacts_path)
   const profile = runtimeOverlayProfileDefaults(input)
@@ -81,7 +93,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
     ...componentPluginEntries,
     ...providerPlugins,
   ].filter(Boolean)
-  const componentManifest = componentManifestForPlugins(componentPluginEntries, providerPlugins)
+  const componentManifest = componentManifestForRuntimePlugins(componentPluginEntries, providerPlugins)
   const workflowArgs = [
     `task=${taskInput.goal}`,
     `agent=${stringValue(input.agent) || "wp-codebox-sandbox"}`,
@@ -138,12 +150,35 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   }) as WorkspaceRecipe
 }
 
-function componentManifestForPlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], providerPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeComponentManifest {
+export function componentManifestForRuntimePlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], providerPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeComponentManifest {
   return {
     schema: "wp-codebox/component-manifest/v1",
     components: componentPlugins.map(componentManifestEntry),
     providers: providerPlugins.map(componentManifestEntry),
   }
+}
+
+export function runtimeDependencyPlanContract(input: RuntimeDependencyPlanContractInput): Record<string, unknown> {
+  const inheritance = input.inheritance && typeof input.inheritance === "object" ? input.inheritance : {}
+  const inheritanceRequest = input.inheritance_request && typeof input.inheritance_request === "object" ? input.inheritance_request : {}
+  return stripEmptyContractFields({
+    schema: "wp-codebox/runtime-dependency-plan/v1",
+    selection: stripEmptyRecordFields(input.selection ?? {}),
+    provider_plugin_paths: stringList(input.provider_plugin_paths),
+    provider_plugins: objectList(input.provider_plugins),
+    component_plugins: objectList(input.component_plugins),
+    runtime_overlays: objectList(input.runtime_overlays),
+    inheritance_request: {
+      connectors: stringList(inheritanceRequest.connectors),
+      settings: stringList(inheritanceRequest.settings),
+    },
+    inheritance: {
+      connectors: objectList(inheritance.connectors),
+      settings: objectList(inheritance.settings),
+    },
+    agent_bundles: objectList(input.agent_bundles),
+    secret_env: stringList(input.secret_env).filter((name) => /^[A-Z_][A-Z0-9_]*$/.test(name)),
+  })
 }
 
 function componentManifestEntry(plugin: WorkspaceRecipeExtraPlugin): WorkspaceRecipeComponentManifestEntry {
@@ -164,6 +199,18 @@ function componentManifestEntry(plugin: WorkspaceRecipeExtraPlugin): WorkspaceRe
     requestedPath: stringValue(contract.requestedPath) || undefined,
     provenance: Object.keys(metadata).length > 0 ? metadata : undefined,
   })
+}
+
+function objectList(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter(isPlainObject) : []
+}
+
+function stripEmptyRecordFields(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== "" && !(Array.isArray(entry) && entry.length === 0)))
+}
+
+function stripEmptyContractFields(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== "" && !(Array.isArray(entry) && entry.length === 0)))
 }
 
 function componentMountedPath(slug: string, loadAs: "plugin" | "mu-plugin"): string {

--- a/scripts/php-primitive-contract-parity-smoke.php
+++ b/scripts/php-primitive-contract-parity-smoke.php
@@ -1,0 +1,131 @@
+<?php
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+    private string $code;
+    private string $message;
+    /** @var array<string,mixed> */
+    private array $data;
+
+    /** @param array<string,mixed> $data */
+    public function __construct( string $code = '', string $message = '', array $data = array() ) {
+        $this->code    = $code;
+        $this->message = $message;
+        $this->data    = $data;
+    }
+
+    public function get_error_code(): string {
+        return $this->code;
+    }
+
+    public function get_error_message(): string {
+        return $this->message;
+    }
+
+    /** @return array<string,mixed> */
+    public function get_error_data(): array {
+        return $this->data;
+    }
+}
+
+function is_wp_error( mixed $value ): bool {
+    return $value instanceof WP_Error;
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-json.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-path-policy.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-redaction-policy.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php';
+
+$fixture = json_decode( file_get_contents( __DIR__ . '/../tests/fixtures/primitive-contracts.json' ), true );
+if ( ! is_array( $fixture ) ) {
+    fwrite( STDERR, "Invalid primitive contracts fixture.\n" );
+    exit( 1 );
+}
+
+function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
+    if ( $expected !== $actual ) {
+        fwrite( STDERR, $label . " failed.\nExpected: " . json_encode( $expected, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\nActual: " . json_encode( $actual, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n" );
+        exit( 1 );
+    }
+}
+
+foreach ( $fixture['redaction']['profiles'] as $profile => $contract ) {
+    assert_same_contract( $contract['expected'], WP_Codebox_Redaction_Policy::redact_array( $profile, $contract['input'] ), $profile . ' redaction contract' );
+}
+
+foreach ( $fixture['pathPolicy']['mountTargets'] as $contract ) {
+    $actual = WP_Codebox_Path_Policy::normalize_sandbox_mount_target( $contract['input'] );
+    if ( ! empty( $contract['error'] ) ) {
+        if ( ! is_wp_error( $actual ) ) {
+            fwrite( STDERR, 'Expected mount target error for ' . $contract['input'] . "\n" );
+            exit( 1 );
+        }
+    } else {
+        assert_same_contract( $contract['expected'], $actual, 'mount target contract' );
+    }
+}
+
+foreach ( $fixture['pathPolicy']['artifactPaths'] as $contract ) {
+    $actual = WP_Codebox_Path_Policy::normalize_artifact_relative_path( $contract['input'] );
+    if ( ! empty( $contract['error'] ) ) {
+        if ( ! is_wp_error( $actual ) ) {
+            fwrite( STDERR, 'Expected artifact path error for ' . $contract['input'] . "\n" );
+            exit( 1 );
+        }
+    } else {
+        assert_same_contract( $contract['expected'], $actual, 'artifact path contract' );
+    }
+}
+
+$descriptor = new WP_Codebox_Runtime_Tool_Policy_Descriptor();
+$effective  = $descriptor->resolve_effective_runtime_tool_policy( $fixture['toolPolicy']['snapshot'] );
+assert_same_contract(
+    $fixture['toolPolicy']['effective'],
+    array(
+        'schema'                   => $effective['schema'],
+        'version'                  => $effective['version'],
+        'allowedRuntimeToolIds'    => $effective['allowedRuntimeToolIds'],
+        'visibleRuntimeToolIds'    => $effective['visibleRuntimeToolIds'],
+        'parentOnlyRuntimeToolIds' => $effective['parentOnlyRuntimeToolIds'],
+        'hiddenRuntimeToolIds'     => $effective['hiddenRuntimeToolIds'],
+        'metadata'                 => $effective['metadata'],
+    ),
+    'tool policy effective contract'
+);
+foreach ( $fixture['toolPolicy']['aliases'] as $alias => $runtime_tool_id ) {
+    assert_same_contract( $runtime_tool_id, $descriptor->resolve_runtime_tool_alias( $effective, $alias )['runtimeToolId'] ?? null, $alias . ' alias contract' );
+}
+
+$json_codec = $fixture['jsonCodec'];
+assert_same_contract( $json_codec['prettyExpected'], WP_Codebox_Json::encode( $json_codec['prettyValue'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ), 'json pretty encode contract' );
+assert_same_contract( $json_codec['expected']['object'], WP_Codebox_Json::decode_object( $json_codec['object'] ), 'json object decode contract' );
+assert_same_contract( $json_codec['expected']['list'], WP_Codebox_Json::decode_list( $json_codec['list'] ), 'json list decode contract' );
+assert_same_contract( $json_codec['expected']['trailing'], WP_Codebox_Json::decode_trailing_array( $json_codec['trailing'] ), 'json trailing decode contract' );
+assert_same_contract( $json_codec['expected']['fragment'], WP_Codebox_Json::decode_fragment_array( $json_codec['fragment'] ), 'json fragment decode contract' );
+
+$runtime_input = $fixture['runtimeDependencyPlan']['input'];
+$plan          = new WP_Codebox_Runtime_Dependency_Plan(
+    $runtime_input['selection'],
+    $runtime_input['provider_plugin_paths'],
+    $runtime_input['provider_plugins'],
+    $runtime_input['component_plugins'],
+    $runtime_input['runtime_overlays'],
+    $runtime_input['inheritance'],
+    $runtime_input['inheritance_request'],
+    $runtime_input['agent_bundles'],
+    $runtime_input['secret_env']
+);
+assert_same_contract( $fixture['runtimeDependencyPlan']['expected'], $plan->to_contract(), 'runtime dependency plan contract' );
+
+$component_manifest = new ReflectionMethod( WP_Codebox_Host_Recipe_Builder::class, 'component_manifest' );
+assert_same_contract(
+    $fixture['componentManifest']['expected'],
+    $component_manifest->invoke( null, $fixture['componentManifest']['components'], $fixture['componentManifest']['providers'] ),
+    'component manifest contract'
+);
+
+fwrite( STDOUT, "PHP primitive contract parity smoke passed\n" );

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -32,6 +32,8 @@ export const smokeGroups = {
       npmScript("build"),
       npmScript("test:generic-primitives"),
       npmScript("test:php-json-codec"),
+      npmScript("test:primitive-contract-parity"),
+      npmScript("test:php-primitive-contract-parity"),
       npmScript("test:browser-task-builder"),
       npmScript("test:browser-runner-template"),
       tsxSmoke("runtime-backend-registry-smoke"),

--- a/tests/fixtures/primitive-contracts.json
+++ b/tests/fixtures/primitive-contracts.json
@@ -1,0 +1,355 @@
+{
+  "redaction": {
+    "profiles": {
+      "provider_proxy": {
+        "input": {
+          "provider": "generic",
+          "request": {
+            "authorization": "Bearer abc",
+            "model": "example",
+            "messages": [
+              {
+                "role": "user",
+                "content": "visible"
+              }
+            ]
+          }
+        },
+        "expected": {
+          "provider": "generic",
+          "request": {
+            "authorization": "[redacted]",
+            "model": "example",
+            "messages": [
+              {
+                "role": "user",
+                "content": "visible"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "pathPolicy": {
+    "mountTargets": [
+      {
+        "input": "//wordpress//wp-content/plugins/plugin",
+        "expected": "/wordpress/wp-content/plugins/plugin"
+      },
+      {
+        "input": "/wordpress/../escape",
+        "error": true
+      }
+    ],
+    "artifactPaths": [
+      {
+        "input": "/files//output.json",
+        "expected": "files/output.json"
+      },
+      {
+        "input": "files/../secret.txt",
+        "error": true
+      }
+    ]
+  },
+  "toolPolicy": {
+    "snapshot": {
+      "schema": "wp-codebox/sandbox-tool-policy/v1",
+      "version": 1,
+      "tools": [
+        {
+          "id": "filesystem-write",
+          "runtime_tool_id": "client/filesystem-write",
+          "aliases": ["filesystem_write"],
+          "execution_location": "sandbox",
+          "transport_visibility": "sandbox",
+          "allowed": true,
+          "runtime": {
+            "environment": "runtime_local",
+            "capability_scope": "runtime_local"
+          },
+          "metadata": {
+            "schema": "example/input/v1",
+            "aliases": ["write_file"],
+            "policy": {
+              "permission": "write"
+            }
+          }
+        },
+        {
+          "id": "browser-review",
+          "runtime_tool_id": "client/browser-review",
+          "execution_location": "parent",
+          "transport_visibility": "parent",
+          "allowed": true,
+          "runtime": {
+            "environment": "control_plane",
+            "capability_scope": "control_plane"
+          }
+        },
+        {
+          "id": "internal-token",
+          "runtime_tool_id": "client/internal-token",
+          "execution_location": "sandbox",
+          "transport_visibility": "hidden",
+          "allowed": true,
+          "runtime": {
+            "environment": "runtime_local",
+            "capability_scope": "runtime_local"
+          }
+        }
+      ],
+      "metadata": {
+        "source": "primitive-contracts"
+      }
+    },
+    "effective": {
+      "schema": "wp-codebox/sandbox-tool-policy/v1",
+      "version": 1,
+      "allowedRuntimeToolIds": ["client/filesystem-write"],
+      "visibleRuntimeToolIds": ["client/filesystem-write"],
+      "parentOnlyRuntimeToolIds": ["client/browser-review"],
+      "hiddenRuntimeToolIds": ["client/internal-token"],
+      "metadata": {
+        "source": "primitive-contracts"
+      }
+    },
+    "aliases": {
+      "filesystem_write": "client/filesystem-write",
+      "write_file": "client/filesystem-write",
+      "client/browser-review": "client/browser-review"
+    }
+  },
+  "statusTaxonomy": [
+    {
+      "input": { "status": "succeeded" },
+      "command": "completed",
+      "phase": "succeeded",
+      "agentTask": "succeeded",
+      "check": "passed"
+    },
+    {
+      "input": { "status": "timed_out" },
+      "command": "timed_out",
+      "phase": "failed",
+      "agentTask": "timeout",
+      "check": "failed"
+    },
+    {
+      "input": { "status": "blocked" },
+      "command": "failed",
+      "phase": "blocked",
+      "agentTask": "unable_to_remediate",
+      "check": "warning"
+    }
+  ],
+  "jsonCodec": {
+    "prettyValue": { "path": "files/result.json" },
+    "prettyExpected": "{\n    \"path\": \"files/result.json\"\n}",
+    "object": "{\"ok\":true}",
+    "list": "[\"a\",\"b\"]",
+    "trailing": "warning\n{\"status\":\"ok\"}",
+    "fragment": "prefix {\"result\":{\"ok\":true}} suffix",
+    "expected": {
+      "object": { "ok": true },
+      "list": ["a", "b"],
+      "trailing": { "status": "ok" },
+      "fragment": { "result": { "ok": true } }
+    }
+  },
+  "runtimeDependencyPlan": {
+    "input": {
+      "selection": {
+        "agent": "wp-codebox-sandbox",
+        "mode": "sandbox",
+        "provider": "openai",
+        "model": "gpt-test",
+        "empty": ""
+      },
+      "provider_plugin_paths": ["/runtime/providers/openai", "/runtime/providers/openai", ""],
+      "provider_plugins": [
+        {
+          "source": "/runtime/providers/openai",
+          "slug": "ai-provider-for-openai",
+          "activate": false
+        }
+      ],
+      "component_plugins": [
+        {
+          "source": "/workspace/plugin",
+          "slug": "demo-plugin",
+          "pluginFile": "demo-plugin/demo.php",
+          "loadAs": "plugin",
+          "activate": true,
+          "metadata": {
+            "componentContract": {
+              "index": 2,
+              "requestedPath": "/workspace/plugin"
+            }
+          }
+        }
+      ],
+      "runtime_overlays": [
+        {
+          "kind": "composer-package",
+          "source": "/runtime/overlays/pkg"
+        }
+      ],
+      "inheritance_request": {
+        "connectors": ["openai", "openai", ""],
+        "settings": ["model"]
+      },
+      "inheritance": {
+        "connectors": [{ "id": "openai", "status": "available" }],
+        "settings": [{ "name": "model", "status": "resolved" }]
+      },
+      "agent_bundles": [{ "source": "/workspace/agent-bundle" }],
+      "secret_env": ["OPENAI_API_KEY", "bad-name", "OPENAI_API_KEY"]
+    },
+    "expected": {
+      "schema": "wp-codebox/runtime-dependency-plan/v1",
+      "selection": {
+        "agent": "wp-codebox-sandbox",
+        "mode": "sandbox",
+        "provider": "openai",
+        "model": "gpt-test"
+      },
+      "provider_plugin_paths": ["/runtime/providers/openai"],
+      "provider_plugins": [
+        {
+          "source": "/runtime/providers/openai",
+          "slug": "ai-provider-for-openai",
+          "activate": false
+        }
+      ],
+      "component_plugins": [
+        {
+          "source": "/workspace/plugin",
+          "slug": "demo-plugin",
+          "pluginFile": "demo-plugin/demo.php",
+          "loadAs": "plugin",
+          "activate": true,
+          "metadata": {
+            "componentContract": {
+              "index": 2,
+              "requestedPath": "/workspace/plugin"
+            }
+          }
+        }
+      ],
+      "runtime_overlays": [
+        {
+          "kind": "composer-package",
+          "source": "/runtime/overlays/pkg"
+        }
+      ],
+      "inheritance_request": {
+        "connectors": ["openai"],
+        "settings": ["model"]
+      },
+      "inheritance": {
+        "connectors": [{ "id": "openai", "status": "available" }],
+        "settings": [{ "name": "model", "status": "resolved" }]
+      },
+      "agent_bundles": [{ "source": "/workspace/agent-bundle" }],
+      "secret_env": ["OPENAI_API_KEY"]
+    }
+  },
+  "componentManifest": {
+    "components": [
+      {
+        "source": "/workspace/plugin",
+        "slug": "demo-plugin",
+        "pluginFile": "demo-plugin/demo.php",
+        "loadAs": "plugin",
+        "activate": true,
+        "metadata": {
+          "componentContract": {
+            "index": 2,
+            "requestedPath": "/workspace/plugin"
+          },
+          "sourceKind": "local"
+        }
+      },
+      {
+        "source": "/workspace/mu",
+        "slug": "demo-mu",
+        "pluginFile": "demo-mu/demo-mu.php",
+        "loadAs": "mu-plugin",
+        "activate": false
+      }
+    ],
+    "providers": [
+      {
+        "source": "/runtime/providers/openai",
+        "slug": "ai-provider-for-openai",
+        "pluginFile": "ai-provider-for-openai/provider.php",
+        "loadAs": "plugin",
+        "activate": false
+      }
+    ],
+    "expected": {
+      "schema": "wp-codebox/component-manifest/v1",
+      "components": [
+        {
+          "slug": "demo-plugin",
+          "source": "/workspace/plugin",
+          "mountedPath": "/wordpress/wp-content/plugins/demo-plugin",
+          "entrypoint": "demo-plugin/demo.php",
+          "pluginFile": "demo-plugin/demo.php",
+          "loadAs": "plugin",
+          "activate": true,
+          "contractIndex": 2,
+          "requestedPath": "/workspace/plugin",
+          "provenance": {
+            "componentContract": {
+              "index": 2,
+              "requestedPath": "/workspace/plugin"
+            },
+            "sourceKind": "local"
+          }
+        },
+        {
+          "slug": "demo-mu",
+          "source": "/workspace/mu",
+          "mountedPath": "/wordpress/wp-content/mu-plugins/wp-codebox-runtime/demo-mu",
+          "entrypoint": "demo-mu/demo-mu.php",
+          "pluginFile": "demo-mu/demo-mu.php",
+          "loadAs": "mu-plugin",
+          "activate": false
+        }
+      ],
+      "providers": [
+        {
+          "slug": "ai-provider-for-openai",
+          "source": "/runtime/providers/openai",
+          "mountedPath": "/wordpress/wp-content/plugins/ai-provider-for-openai",
+          "entrypoint": "ai-provider-for-openai/provider.php",
+          "pluginFile": "ai-provider-for-openai/provider.php",
+          "loadAs": "plugin",
+          "activate": false
+        }
+      ]
+    }
+  },
+  "runPlan": {
+    "children": [
+      { "success": true, "status": "succeeded" },
+      { "success": false, "status": "failed" },
+      { "success": false, "status": "cancelled" }
+    ],
+    "counts": {
+      "total": 3,
+      "completed": 1,
+      "failed": 1,
+      "cancelled": 1
+    },
+    "succeeded": false,
+    "schemas": {
+      "plan": "wp-codebox/run-plan/v1",
+      "event": "wp-codebox/run-plan-event/v1",
+      "result": "wp-codebox/run-plan-result/v1"
+    }
+  }
+}

--- a/tests/primitive-contract-parity.test.ts
+++ b/tests/primitive-contract-parity.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import {
+  componentManifestForRuntimePlugins,
+  countRunPlanChildResults,
+  normalizeAgentTaskStatus,
+  normalizeCheckStatus,
+  normalizeCommandEnvelopeStatus,
+  normalizePhaseRecipeStatus,
+  normalizeRuntimeMountTarget,
+  redactJsonValue,
+  resolveEffectiveRuntimeToolPolicy,
+  resolveRuntimeToolAlias,
+  runPlanSucceeded,
+  runtimeDependencyPlanContract,
+  RUN_PLAN_EVENT_SCHEMA,
+  RUN_PLAN_RESULT_SCHEMA,
+  RUN_PLAN_SCHEMA,
+  safeArtifactRelativePath,
+  type SandboxToolPolicySnapshot,
+  type WorkspaceRecipeExtraPlugin,
+} from "../packages/runtime-core/src/index.js"
+
+const fixture = JSON.parse(await readFile(new URL("./fixtures/primitive-contracts.json", import.meta.url), "utf8"))
+
+for (const [profile, contract] of Object.entries(fixture.redaction.profiles) as Array<[string, { input: unknown; expected: unknown }]>) {
+  assert.deepEqual(redactJsonValue(contract.input, { profile: profile as never, redactStrings: false }), contract.expected, `${profile} redaction contract`)
+}
+
+for (const contract of fixture.pathPolicy.mountTargets as Array<{ input: string; expected?: string; error?: boolean }>) {
+  if (contract.error) {
+    assert.throws(() => normalizeRuntimeMountTarget(contract.input), /directory/)
+  } else {
+    assert.equal(normalizeRuntimeMountTarget(contract.input), contract.expected)
+  }
+}
+
+for (const contract of fixture.pathPolicy.artifactPaths as Array<{ input: string; expected?: string; error?: boolean }>) {
+  if (contract.error) {
+    assert.throws(() => safeArtifactRelativePath(contract.input), /directory/)
+  } else {
+    assert.equal(safeArtifactRelativePath(contract.input), contract.expected)
+  }
+}
+
+const toolPolicy = fixture.toolPolicy.snapshot as SandboxToolPolicySnapshot
+const effectiveToolPolicy = resolveEffectiveRuntimeToolPolicy(toolPolicy)
+assert.deepEqual(
+  {
+    schema: effectiveToolPolicy.schema,
+    version: effectiveToolPolicy.version,
+    allowedRuntimeToolIds: effectiveToolPolicy.allowedRuntimeToolIds,
+    visibleRuntimeToolIds: effectiveToolPolicy.visibleRuntimeToolIds,
+    parentOnlyRuntimeToolIds: effectiveToolPolicy.parentOnlyRuntimeToolIds,
+    hiddenRuntimeToolIds: effectiveToolPolicy.hiddenRuntimeToolIds,
+    metadata: effectiveToolPolicy.metadata,
+  },
+  fixture.toolPolicy.effective,
+)
+for (const [alias, runtimeToolId] of Object.entries(fixture.toolPolicy.aliases) as Array<[string, string]>) {
+  assert.equal(resolveRuntimeToolAlias(effectiveToolPolicy, alias)?.runtimeToolId, runtimeToolId, `${alias} alias contract`)
+}
+
+for (const contract of fixture.statusTaxonomy as Array<{ input: Record<string, unknown>; command: string; phase: string; agentTask: string; check: string }>) {
+  assert.equal(normalizeCommandEnvelopeStatus(contract.input), contract.command)
+  assert.equal(normalizePhaseRecipeStatus(contract.input), contract.phase)
+  assert.equal(normalizeAgentTaskStatus(contract.input), contract.agentTask)
+  assert.equal(normalizeCheckStatus(contract.input), contract.check)
+}
+
+assert.deepEqual(runtimeDependencyPlanContract(fixture.runtimeDependencyPlan.input), fixture.runtimeDependencyPlan.expected)
+assert.deepEqual(
+  componentManifestForRuntimePlugins(fixture.componentManifest.components as WorkspaceRecipeExtraPlugin[], fixture.componentManifest.providers as WorkspaceRecipeExtraPlugin[]),
+  fixture.componentManifest.expected,
+)
+
+assert.deepEqual(countRunPlanChildResults(fixture.runPlan.children), fixture.runPlan.counts)
+assert.equal(runPlanSucceeded(fixture.runPlan.counts), fixture.runPlan.succeeded)
+assert.deepEqual(fixture.runPlan.schemas, {
+  plan: RUN_PLAN_SCHEMA,
+  event: RUN_PLAN_EVENT_SCHEMA,
+  result: RUN_PLAN_RESULT_SCHEMA,
+})
+
+console.log("primitive contract parity passed")


### PR DESCRIPTION
## Summary
- Add a shared primitive contract fixture covering redaction profiles, path policy, sandbox tool policy descriptors, status taxonomy, JSON codec behavior, runtime dependency plans, mounted component manifests, and run-plan contracts.
- Add TS and PHP parity tests against the shared fixture, then wire both into the check smoke group.
- Export tiny runtime-core helpers for runtime dependency plan and component manifest contract serialization so tests assert DTO output rather than private source shape.

## Tests
- npm run test:primitive-contract-parity
- npm run test:php-primitive-contract-parity
- npm run test:redaction
- npm run test:path-policy-parity
- npm run test:runtime-tool-policy
- npm run test:php-json-codec
- npm run test:schema-parity
- npm run test:agent-task-contracts
- npm run test:php-tool-policy-normalization
- npm run test:php-path-policy-parity
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the contract fixture, parity tests, and helper exports; Chris remains responsible for review and merge.