### PR TITLE
Add generic browser provider connector bridge inheritance

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:generic-primitives": "tsx tests/generic-primitives.test.ts",
     "test:browser-artifact-session": "tsx tests/browser-artifact-session.test.ts",
     "test:browser-provider-permissions": "tsx tests/browser-provider-permissions.test.ts",
+    "test:browser-provider-bridge-inheritance": "tsx tests/browser-provider-bridge-inheritance.test.ts",
     "test:fixture-auth-storage-state": "tsx tests/fixture-auth-storage-state.test.ts",
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-provider-bridge.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-provider-bridge.php
@@ -123,7 +123,8 @@ final class WP_Codebox_Browser_Provider_Bridge {
 		 * @param array<string,mixed>     $request  Redacted adapter request.
 		 * @param array<string,mixed>     $input    Original ability input.
 		 */
-		$policy = apply_filters( 'wp_codebox_browser_provider_bridge_policy', null, $provider, $request, $input );
+		$policy = self::default_provider_policy( $provider, $request, $input );
+		$policy = apply_filters( 'wp_codebox_browser_provider_bridge_policy', $policy, $provider, $request, $input );
 		if ( empty( $policy ) ) {
 			return array();
 		}
@@ -140,6 +141,60 @@ final class WP_Codebox_Browser_Provider_Bridge {
 		}
 
 		return $policy;
+	}
+
+	/** @param array<string,mixed> $request Redacted adapter request. @param array<string,mixed> $input Original ability input. @return array<string,mixed> */
+	private static function default_provider_policy( string $provider, array $request, array $input ): array {
+		$connector = is_array( $request['connector'] ?? null ) ? $request['connector'] : array();
+		if ( $provider !== sanitize_key( (string) ( $connector['provider'] ?? $connector['name'] ?? '' ) ) ) {
+			return array();
+		}
+
+		$scope = WP_Codebox_Agent_Task::string_list( $connector['capabilityScope'] ?? $connector['capability_scope'] ?? array() );
+		if ( ! in_array( 'browser-connector:request', $scope, true ) ) {
+			return array();
+		}
+
+		$bridge = is_array( $connector['bridge'] ?? null ) ? $connector['bridge'] : array();
+		if ( empty( $bridge ) ) {
+			return array();
+		}
+
+		$allowed_base_urls = self::allowed_bridge_base_urls( $bridge );
+		if ( empty( $allowed_base_urls ) ) {
+			return array();
+		}
+
+		$timeout = isset( $bridge['timeout'] ) && is_numeric( $bridge['timeout'] ) ? (int) $bridge['timeout'] : 0;
+
+		return array_filter(
+			array(
+				'provider'          => $provider,
+				'allowed_base_urls' => $allowed_base_urls,
+				'authentication'    => (string) ( $bridge['authentication'] ?? 'php-ai-client' ),
+				'timeout'           => $timeout > 0 ? $timeout : null,
+			),
+			static fn( mixed $value ): bool => null !== $value && '' !== $value && array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $bridge Connector bridge metadata. @return string[] */
+	private static function allowed_bridge_base_urls( array $bridge ): array {
+		$base_urls = array();
+		foreach ( is_array( $bridge['baseUrls'] ?? null ) ? $bridge['baseUrls'] : ( is_array( $bridge['base_urls'] ?? null ) ? $bridge['base_urls'] : array() ) as $candidate ) {
+			if ( ! is_scalar( $candidate ) ) {
+				continue;
+			}
+
+			$base_url = trim( (string) $candidate );
+			if ( '' === $base_url || ! in_array( strtolower( (string) wp_parse_url( $base_url, PHP_URL_SCHEME ) ), array( 'http', 'https' ), true ) ) {
+				continue;
+			}
+
+			$base_urls[] = rtrim( $base_url, '/' ) . '/';
+		}
+
+		return array_values( array_unique( $base_urls ) );
 	}
 
 	/** @param array<string,mixed> $policy Provider policy. @param array<string,mixed> $request Redacted adapter request. @param array<string,mixed> $input Original ability input. @return array{url:string,method:string,headers:array<string,string>,body:string}|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-connector-credential-resolvers.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-connector-credential-resolvers.php
@@ -12,7 +12,18 @@ final class WP_Codebox_Connector_Credential_Resolvers {
 	/** @param array<string,mixed> $resolution Existing inheritance resolution. @param array{connectors:string[],settings:string[]} $request Requested inheritance. @param array<string,mixed> $input Ability input. */
 	public static function resolve( array $resolution, array $request, array $input ): array {
 		$requested = array_values( array_unique( array_filter( array_map( 'strval', $request['connectors'] ?? array() ) ) ) );
-		if ( empty( $requested ) || ! function_exists( 'apply_filters' ) ) {
+		if ( empty( $requested ) ) {
+			return $resolution;
+		}
+
+		foreach ( $requested as $connector_name ) {
+			$connector = self::default_connector( $connector_name, $input );
+			if ( ! empty( $connector ) ) {
+				$resolution['connectors'] = self::replace_connector( is_array( $resolution['connectors'] ?? null ) ? $resolution['connectors'] : array(), $connector_name, $connector );
+			}
+		}
+
+		if ( ! function_exists( 'apply_filters' ) ) {
 			return $resolution;
 		}
 
@@ -44,6 +55,146 @@ final class WP_Codebox_Connector_Credential_Resolvers {
 		}
 
 		return $resolution;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private static function default_connector( string $connector_name, array $input ): array {
+		$provider = sanitize_key( $connector_name );
+		if ( '' === $provider || ! self::provider_registered( $provider ) ) {
+			return array();
+		}
+
+		$connector = array(
+			'name'           => $connector_name,
+			'status'         => 'resolved',
+			'provider'       => $provider,
+			'bridge'         => array(
+				'schema'         => 'wp-codebox/browser-provider-bridge-connector/v1',
+				'authentication' => 'php-ai-client',
+				'baseUrls'       => self::provider_base_urls( $provider, $input ),
+			),
+			'capabilityScope' => array(
+				'browser-connector:request',
+			),
+		);
+
+		$model = trim( (string) ( $input['model'] ?? '' ) );
+		if ( '' !== $model ) {
+			$connector['model'] = $model;
+		}
+
+		return $connector;
+	}
+
+	private static function provider_registered( string $provider ): bool {
+		if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
+			return false;
+		}
+
+		try {
+			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+			if ( method_exists( $registry, 'hasProvider' ) && $registry->hasProvider( $provider ) ) {
+				return true;
+			}
+
+			return method_exists( $registry, 'getProviderRequestAuthentication' ) && null !== $registry->getProviderRequestAuthentication( $provider );
+		} catch ( Throwable $throwable ) {
+			unset( $throwable );
+			return false;
+		}
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return string[] */
+	private static function provider_base_urls( string $provider, array $input ): array {
+		$candidates = array();
+		$registry   = null;
+
+		try {
+			$registry = class_exists( '\WordPress\AiClient\AiClient' ) ? \WordPress\AiClient\AiClient::defaultRegistry() : null;
+		} catch ( Throwable $throwable ) {
+			unset( $throwable );
+		}
+
+		foreach ( array( 'getProviderBaseUrl', 'getProviderBaseURL', 'getProviderApiBaseUrl', 'getProviderApiBaseURL' ) as $method ) {
+			if ( is_object( $registry ) && method_exists( $registry, $method ) ) {
+				$candidates[] = $registry->{$method}( $provider );
+			}
+		}
+
+		if ( is_object( $registry ) && method_exists( $registry, 'getProviderClassName' ) ) {
+			try {
+				$class_name = $registry->getProviderClassName( $provider );
+				if ( is_string( $class_name ) && class_exists( $class_name ) && method_exists( $class_name, 'baseUrl' ) ) {
+					$base_url = new ReflectionMethod( $class_name, 'baseUrl' );
+					if ( $base_url->isStatic() && 0 === $base_url->getNumberOfRequiredParameters() ) {
+						$base_url->setAccessible( true );
+						$candidates[] = $base_url->invoke( null );
+					}
+				}
+			} catch ( Throwable $throwable ) {
+				unset( $throwable );
+			}
+		}
+
+		$provider_config = null;
+		foreach ( array( 'getProvider', 'provider' ) as $method ) {
+			if ( is_object( $registry ) && method_exists( $registry, $method ) ) {
+				try {
+					$provider_config = $registry->{$method}( $provider );
+					break;
+				} catch ( Throwable $throwable ) {
+					unset( $throwable );
+				}
+			}
+		}
+
+		foreach ( array( 'getBaseUrl', 'getBaseURL', 'getApiBaseUrl', 'getApiBaseURL', 'baseUrl', 'baseURL', 'apiBaseUrl', 'apiBaseURL' ) as $method ) {
+			if ( is_object( $provider_config ) && method_exists( $provider_config, $method ) ) {
+				$candidates[] = $provider_config->{$method}();
+			}
+		}
+
+		foreach ( array( 'base_url', 'baseUrl', 'api_base_url', 'apiBaseUrl' ) as $field ) {
+			if ( is_array( $provider_config ) && isset( $provider_config[ $field ] ) ) {
+				$candidates[] = $provider_config[ $field ];
+			} elseif ( is_object( $provider_config ) && isset( $provider_config->{$field} ) ) {
+				$candidates[] = $provider_config->{$field};
+			}
+		}
+
+		if ( is_array( $input['provider_base_urls'] ?? null ) ) {
+			$candidates = array_merge( $candidates, $input['provider_base_urls'] );
+		}
+
+		/**
+		 * Filters provider base URLs allowed for generic browser provider forwarding.
+		 *
+		 * Products can add provider-specific endpoints without owning request
+		 * forwarding, authentication, or credential transport.
+		 *
+		 * @param array<int,mixed>     $candidates Candidate base URLs.
+		 * @param string              $provider   Provider ID.
+		 * @param array<string,mixed> $input      Ability input.
+		 */
+		if ( function_exists( 'apply_filters' ) ) {
+			$candidates = apply_filters( 'wp_codebox_browser_provider_base_urls', $candidates, $provider, $input );
+		}
+
+		$base_urls = array();
+		foreach ( is_array( $candidates ) ? $candidates : array() as $candidate ) {
+			if ( ! is_scalar( $candidate ) ) {
+				continue;
+			}
+
+			$base_url = trim( (string) $candidate );
+			if ( '' === $base_url || ! in_array( strtolower( (string) wp_parse_url( $base_url, PHP_URL_SCHEME ) ), array( 'http', 'https' ), true ) ) {
+				continue;
+			}
+
+			$base_urls[] = rtrim( $base_url, '/' ) . '/';
+		}
+
+		return array_values( array_unique( $base_urls ) );
 	}
 
 	/** @param array<string,mixed> $resolvers Resolver registry. @param array{connectors:string[],settings:string[]} $request Requested inheritance. @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error|null */

--- a/packages/wordpress-plugin/src/class-wp-codebox-inheritance.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-inheritance.php
@@ -121,6 +121,16 @@ final class WP_Codebox_Inheritance {
 				$entry['credentials'] = $credentials;
 			}
 
+			$bridge = self::sanitize_connector_bridge( $connector['bridge'] ?? null );
+			if ( ! empty( $bridge ) ) {
+				$entry['bridge'] = $bridge;
+			}
+
+			$capability_scope = array_values( array_filter( self::string_list( $connector['capability_scope'] ?? $connector['capabilityScope'] ?? array() ) ) );
+			if ( ! empty( $capability_scope ) ) {
+				$entry['capabilityScope'] = array_values( array_unique( $capability_scope ) );
+			}
+
 			$sanitized[] = $entry;
 		}
 
@@ -168,6 +178,46 @@ final class WP_Codebox_Inheritance {
 			}
 
 			$entry['secrets'][] = $secret_entry;
+		}
+
+		return $entry;
+	}
+
+	/** @return array<string,mixed> */
+	private static function sanitize_connector_bridge( mixed $bridge ): array {
+		if ( ! is_array( $bridge ) ) {
+			return array();
+		}
+
+		$entry = array(
+			'schema' => 'wp-codebox/browser-provider-bridge-connector/v1',
+		);
+		$authentication = trim( (string) ( $bridge['authentication'] ?? '' ) );
+		if ( '' !== $authentication ) {
+			$entry['authentication'] = $authentication;
+		}
+
+		$base_urls = array();
+		foreach ( is_array( $bridge['base_urls'] ?? null ) ? $bridge['base_urls'] : ( is_array( $bridge['baseUrls'] ?? null ) ? $bridge['baseUrls'] : array() ) as $candidate ) {
+			if ( ! is_scalar( $candidate ) ) {
+				continue;
+			}
+
+			$base_url = trim( (string) $candidate );
+			if ( '' === $base_url || ! in_array( strtolower( (string) wp_parse_url( $base_url, PHP_URL_SCHEME ) ), array( 'http', 'https' ), true ) ) {
+				continue;
+			}
+
+			$base_urls[] = rtrim( $base_url, '/' ) . '/';
+		}
+
+		if ( ! empty( $base_urls ) ) {
+			$entry['baseUrls'] = array_values( array_unique( $base_urls ) );
+		}
+
+		$timeout = isset( $bridge['timeout'] ) && is_numeric( $bridge['timeout'] ) ? (int) $bridge['timeout'] : 0;
+		if ( $timeout > 0 ) {
+			$entry['timeout'] = $timeout;
 		}
 
 		return $entry;

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -34,6 +34,7 @@ export const smokeGroups = {
       npmScript("test:php-json-codec"),
       npmScript("test:browser-task-builder"),
       npmScript("test:browser-runner-template"),
+      npmScript("test:browser-provider-bridge-inheritance"),
       tsxSmoke("runtime-backend-registry-smoke"),
       tsxSmoke("backend-package-adapter-registry-smoke"),
       tsxSmoke("command-registry-smoke"),

--- a/tests/browser-provider-bridge-inheritance.test.ts
+++ b/tests/browser-provider-bridge-inheritance.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const bridgePhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-browser-provider-bridge.php", "utf8")
+const resolversPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-connector-credential-resolvers.php", "utf8")
+const inheritancePhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-inheritance.php", "utf8")
+
+assert.match(bridgePhp, /default_provider_policy/)
+assert.match(bridgePhp, /capabilityScope.*browser-connector:request/s)
+assert.match(bridgePhp, /allowed_bridge_base_urls/)
+assert.match(bridgePhp, /authentication'\s*=>\s*\(string\) \( \$bridge\['authentication'\] \?\? 'php-ai-client' \)/)
+assert.doesNotMatch(methodBlock(bridgePhp, "default_provider_policy"), /OPENAI|openai|Studio|studio_web/)
+assert.doesNotMatch(methodBlock(bridgePhp, "default_provider_policy"), /secret_env|secret_values|api_key/i)
+
+assert.match(resolversPhp, /default_connector/)
+assert.match(resolversPhp, /provider_registered/)
+assert.match(resolversPhp, /getProviderClassName/)
+assert.match(resolversPhp, /new ReflectionMethod\( \$class_name, 'baseUrl' \)/)
+assert.match(resolversPhp, /wp_codebox_browser_provider_base_urls/)
+assert.match(resolversPhp, /browser-provider-bridge-connector\/v1/)
+assert.doesNotMatch(methodBlock(resolversPhp, "default_connector"), /OPENAI|openai|Studio|studio_web/)
+assert.doesNotMatch(methodBlock(resolversPhp, "default_connector"), /secret_env|secret_values|api_key/i)
+
+assert.match(inheritancePhp, /sanitize_connector_bridge/)
+assert.match(inheritancePhp, /capabilityScope/)
+assert.match(inheritancePhp, /baseUrls/)
+
+function methodBlock(source: string, method: string): string {
+  const start = source.indexOf(`function ${method}(`)
+  assert.notEqual(start, -1, `${method} method exists`)
+
+  const nextPublic = source.indexOf("\n\tpublic ", start + 1)
+  const nextPrivate = source.indexOf("\n\tprivate ", start + 1)
+  const nextCandidates = [nextPublic, nextPrivate].filter((candidate) => candidate !== -1)
+  const next = Math.min(...nextCandidates)
+  assert.notEqual(next, -1, `${method} method has a closing boundary`)
+
+  return source.slice(start, next)
+}


### PR DESCRIPTION
## Summary
- Resolve requested browser connector inheritance from registered WP AI Client providers by default, including provider id, optional model, bridge auth strategy, allowed base URL metadata, and browser connector capability scope.
- Let the generic browser provider bridge consume resolved connector metadata as its default forwarding policy, while preserving the existing policy filter as an override point.
- Preserve provider-agnostic behavior: no OpenAI-specific defaults, no Studio paths, and no product-owned credential forwarding in the connector bridge path.
- Sanitize bridge metadata into the browser inheritance payload and add a contract test wired into the smoke manifest.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-browser-provider-bridge.php && php -l packages/wordpress-plugin/src/class-wp-codebox-connector-credential-resolvers.php && php -l packages/wordpress-plugin/src/class-wp-codebox-inheritance.php`
- `npm run test:browser-provider-bridge-inheritance`
- `npm run test:browser-provider-permissions`
- `npm run smoke -- --command=test:browser-provider-bridge-inheritance`
- `npm run check` reached `replay-export-snapshot-scoping-smoke` and hit a local Playground port collision: `EADDRINUSE 127.0.0.1:59433`; rerunning `./node_modules/.bin/tsx scripts/replay-export-snapshot-scoping-smoke.ts` passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, tests, and PR description; Chris remains responsible for review and verification.
