### PR TITLE
Centralize prepared source package hydration

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto"
 import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
-import { homedir, tmpdir } from "node:os"
+import { tmpdir } from "node:os"
 import { basename, dirname, join, relative, resolve } from "node:path"
-import { compileSourcePackage, sourcePackagePathAllowed, type WorkspaceRecipeSourcePackage } from "@automattic/wp-codebox-core"
+import { compileSourcePackage, composerManagedHostCommandConfig, composerManagedHostEnv, sourcePackagePathAllowed, type WorkspaceRecipeSourcePackage } from "@automattic/wp-codebox-core"
 import type { MountSpec, WorkspaceRecipe, WorkspaceRecipeDependencyOverlay, WorkspaceRecipeExtraPlugin, WorkspaceRecipeRuntimeOverlay, WorkspaceRecipeStagedFile, WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { executeManagedHostCommand, resolvePluginEntrypointContract } from "@automattic/wp-codebox-core"
 import { collectPreparedSourceCleanupPaths, DEFAULT_PREPARED_SOURCE_EXCLUDE_NAMES, localPreparedSourceProvenance, prepareLocalSourceStageSync, SANDBOX_WORKSPACE_ROOT, type PreparedSourceProvenance } from "@automattic/wp-codebox-core/internals"
@@ -251,14 +251,12 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
   await cp(prepared.source, stagedSource, { recursive: true })
   try {
     await executeManagedHostCommand({
-      command: "composer",
-      args: ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts", "--no-plugins"],
+      ...composerManagedHostCommandConfig({
+        cwd: stagedSource,
+        allowedCwdRoots: [stagingRoot],
+        label: "prepare Composer autoload for recipe extra plugin",
+      }),
       cwd: stagedSource,
-      env: composerManagedHostEnv(),
-      allowedCwdRoots: [stagingRoot],
-      inheritedEnv: ["HOME", "COMPOSER_HOME"],
-      maxOutputBytes: 1024 * 1024 * 10,
-      label: "prepare Composer autoload for recipe extra plugin",
     })
   } catch (error) {
     await rm(stagingRoot, { recursive: true, force: true })
@@ -522,14 +520,14 @@ async function prepareComposerBackedSource(source: string, stagingRoot: string, 
 
   try {
     await executeManagedHostCommand({
+      ...composerManagedHostCommandConfig({
+        cwd: hydratedSource,
+        allowedCwdRoots: [stagingRoot],
+        args: ["install", "--working-dir", hydratedSource, "--no-dev", "--no-interaction", "--no-progress", "--prefer-dist", "--classmap-authoritative"],
+        label: `hydrate Composer-backed ${label}`,
+      }),
       command: composer,
-      args: ["install", "--working-dir", hydratedSource, "--no-dev", "--no-interaction", "--no-progress", "--prefer-dist", "--classmap-authoritative"],
       cwd: hydratedSource,
-      env: composerManagedHostEnv(),
-      allowedCwdRoots: [stagingRoot],
-      inheritedEnv: ["HOME", "COMPOSER_HOME"],
-      maxOutputBytes: 1024 * 1024 * 10,
-      label: `hydrate Composer-backed ${label}`,
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -565,14 +563,6 @@ async function resolveComposerCommand(): Promise<string> {
     return "composer"
   } catch {
     return ""
-  }
-}
-
-function composerManagedHostEnv(): Record<string, string> {
-  const home = process.env.HOME || homedir()
-  return {
-    ...(home ? { HOME: home } : {}),
-    ...(process.env.COMPOSER_HOME ? { COMPOSER_HOME: process.env.COMPOSER_HOME } : home ? { COMPOSER_HOME: join(home, ".composer") } : {}),
   }
 }
 

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -1,6 +1,4 @@
-import { spawnSync } from "node:child_process"
-import { existsSync, mkdirSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
+import { existsSync, readFileSync } from "node:fs"
 import { join, resolve } from "node:path"
 import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import type { StructuredArtifactPayload } from "./structured-artifacts.js"
@@ -8,7 +6,7 @@ import type { TaskInput } from "./task-input.js"
 import { isPlainObject, stringList, stripUndefined } from "./object-utils.js"
 import type { WorkspaceRecipe, WorkspaceRecipeComponentManifest, WorkspaceRecipeComponentManifestEntry, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
 import { resolvePluginEntrypointContract, sanitizePluginSlug } from "./component-contracts.js"
-import { prepareLocalSourceStageSync, preparedSourcePath, preparedSourceRoot } from "./prepared-source-staging.js"
+import { prepareRecipeSourcePackageSync } from "./recipe-source-packages.js"
 
 const AGENT_RUNTIME_ENV = { WP_AGENT_RUNTIME: "1" }
 
@@ -70,7 +68,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   const providerPlugins: WorkspaceRecipeExtraPlugin[] = stringList(input.provider_plugin_paths)
     .map((plugin) => {
       const slug = slugFromComposerPackage(plugin) || slugFromPath(plugin)
-      const preparedSource = prepareComposerPluginSource(plugin, slug, artifacts)
+      const preparedSource = prepareRecipeSourcePackageSync({ source: plugin, slug, artifactsRoot: artifacts, packageRootName: "prepared-plugins" })
       const entrypoint = resolvePluginEntrypointContract({ source: preparedSource, slug })
       return { source: preparedSource, slug, pluginFile: entrypoint.pluginFile, activate: true, loadAs: "plugin" }
     })
@@ -283,109 +281,7 @@ function componentPlugins(contracts: Array<Record<string, unknown>> | undefined,
 }
 
 function prepareComponentPluginSource(source: string, originalSource: string, slug: string, artifactsRoot: string): string {
-  if (!artifactsRoot) {
-    return prepareComposerPluginSource(originalSource || source, slug, artifactsRoot)
-  }
-
-  const preparedSource = preparedPluginSource(artifactsRoot, slug)
-  const copySource = localSourcePath(originalSource || source)
-  if (!pathExists(copySource)) {
-    return prepareComposerPluginSource(source, slug, artifactsRoot)
-  }
-
-  if (resolve(copySource) !== resolve(preparedSource)) {
-    prepareLocalSourceStageSync({
-      source: copySource,
-      sourceRef: originalSource || source,
-      targetRoot: preparedPluginRoot(artifactsRoot),
-      targetName: slug,
-      cleanupRoot: false,
-    })
-  } else {
-    mkdirSyncSafe(preparedSource)
-  }
-
-  return installComposerDependenciesIfNeeded(preparedSource, slug)
-}
-
-function prepareComposerPluginSource(source: string, slug: string, artifactsRoot: string): string {
-  if (!source) return source
-
-  const localSource = localSourcePath(source)
-  if (!pathExists(join(localSource, "composer.json"))) {
-    return pathExists(localSource) ? localSource : source
-  }
-  if (pathExists(join(localSource, "vendor", "autoload.php"))) {
-    return localSource
-  }
-  if (!artifactsRoot) {
-    throw new Error(`Plugin ${slug} requires Composer dependencies but no artifacts directory is available for staging.`)
-  }
-
-  const preparedRoot = preparedPluginRoot(artifactsRoot)
-  const preparedSource = preparedPluginSource(artifactsRoot, slug)
-  if (resolve(localSource) !== resolve(preparedSource)) {
-    prepareLocalSourceStageSync({
-      source: localSource,
-      sourceRef: source,
-      targetRoot: preparedRoot,
-      targetName: slug,
-      cleanupRoot: false,
-    })
-  } else {
-    mkdirSyncSafe(preparedSource)
-  }
-
-  return installComposerDependenciesIfNeeded(preparedSource, slug)
-}
-
-function installComposerDependenciesIfNeeded(source: string, slug: string): string {
-  if (!pathExists(join(source, "composer.json")) || pathExists(join(source, "vendor", "autoload.php"))) {
-    return source
-  }
-
-  const result = spawnSync("composer", ["install", "--no-interaction", "--prefer-dist", "--no-progress"], {
-    cwd: source,
-    encoding: "utf8",
-    env: composerChildEnv(),
-    stdio: ["ignore", "pipe", "pipe"],
-  })
-  if (result.status !== 0) {
-    throw new Error(`Composer install failed for plugin ${slug}: ${result.stderr || result.stdout || `exit ${result.status}`}`)
-  }
-  if (!pathExists(join(source, "vendor", "autoload.php"))) {
-    throw new Error(`Composer install for plugin ${slug} did not create vendor/autoload.php.`)
-  }
-  return source
-}
-
-function composerChildEnv(): NodeJS.ProcessEnv {
-  const home = process.env.HOME || homedir()
-  return {
-    ...process.env,
-    ...(home ? { HOME: home } : {}),
-    COMPOSER_HOME: process.env.COMPOSER_HOME || (home ? join(home, ".composer") : undefined),
-  }
-}
-
-function preparedPluginRoot(artifactsRoot: string): string {
-  return preparedSourceRoot(artifactsRoot, "prepared-plugins")
-}
-
-function preparedPluginSource(artifactsRoot: string, slug: string): string {
-  return preparedSourcePath(artifactsRoot, "prepared-plugins", slug)
-}
-
-function localSourcePath(source: string): string {
-  return pathExists(source) ? resolve(source) : source
-}
-
-function pathExists(filePath: string): boolean {
-  return existsSync(filePath)
-}
-
-function mkdirSyncSafe(filePath: string): void {
-  mkdirSync(filePath, { recursive: true })
+  return prepareRecipeSourcePackageSync({ source, originalSource, slug, artifactsRoot, packageRootName: "prepared-plugins" })
 }
 
 function sandboxToolPolicy(input: AgentTaskRunInput, taskInput: TaskInput): SandboxToolPolicySnapshot {

--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -1,5 +1,10 @@
-import { isAbsolute, relative, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync } from "node:fs"
+import { homedir } from "node:os"
+import { isAbsolute, join, relative, resolve } from "node:path"
 import { safeArtifactRelativePath } from "./artifact-paths.js"
+import type { ManagedHostCommandConfig } from "./managed-host-command.js"
+import { prepareLocalSourceStageSync, preparedSourcePath, preparedSourceRoot } from "./prepared-source-staging.js"
 import { SANDBOX_WORKSPACE_ROOT } from "./runtime-action-adapter.js"
 import type { WorkspaceRecipe, WorkspaceRecipeDeclaredArtifact, WorkspaceRecipeSourcePackage, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
 
@@ -18,6 +23,15 @@ export interface CompiledSourcePackage {
 export interface RecipeTemplateInput {
   recipe?: Partial<WorkspaceRecipe>
   sourcePackages?: WorkspaceRecipeSourcePackage[]
+}
+
+export interface PreparedRecipeSourcePackageOptions {
+  source: string
+  slug: string
+  artifactsRoot: string
+  originalSource?: string
+  packageRootName?: string
+  composerInstallArgs?: string[]
 }
 
 export interface CompiledRecipeTemplate {
@@ -163,6 +177,111 @@ export function assertPathInside(root: string, path: string): void {
 
 export function sourcePackageArtifactPath(path: string): string {
   return safeArtifactRelativePath(path)
+}
+
+export function prepareRecipeSourcePackageSync(options: PreparedRecipeSourcePackageOptions): string {
+  const packageRootName = options.packageRootName ?? "prepared-source-packages"
+  const source = options.source
+  const originalSource = options.originalSource || source
+  if (!source) return source
+
+  if (!options.artifactsRoot) {
+    return prepareRecipeSourcePackageWithoutArtifacts(source, originalSource, options.slug)
+  }
+
+  const preparedRoot = preparedSourceRoot(options.artifactsRoot, packageRootName)
+  const preparedSource = preparedSourcePath(options.artifactsRoot, packageRootName, options.slug)
+  const copySource = localSourcePath(originalSource)
+  if (pathExists(copySource)) {
+    if (resolve(copySource) !== resolve(preparedSource)) {
+      prepareLocalSourceStageSync({
+        source: copySource,
+        sourceRef: originalSource,
+        targetRoot: preparedRoot,
+        targetName: options.slug,
+        cleanupRoot: false,
+      })
+    } else {
+      mkdirSync(preparedSource, { recursive: true })
+    }
+    return installComposerDependenciesForSourcePackageSync(preparedSource, options.slug, preparedRoot, options.composerInstallArgs)
+  }
+
+  return prepareRecipeSourcePackageWithoutArtifacts(source, source, options.slug)
+}
+
+export function composerManagedHostEnv(): Record<string, string> {
+  const home = process.env.HOME || homedir()
+  return {
+    ...(home ? { HOME: home } : {}),
+    ...(process.env.COMPOSER_HOME ? { COMPOSER_HOME: process.env.COMPOSER_HOME } : home ? { COMPOSER_HOME: join(home, ".composer") } : {}),
+  }
+}
+
+export function composerManagedHostCommandConfig(options: {
+  cwd: string
+  allowedCwdRoots: string[]
+  args?: string[]
+  label: string
+  timeoutMs?: number
+  maxOutputBytes?: number
+}): ManagedHostCommandConfig {
+  return {
+    command: "composer",
+    args: options.args ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts", "--no-plugins"],
+    cwd: options.cwd,
+    env: composerManagedHostEnv(),
+    allowedCwdRoots: options.allowedCwdRoots,
+    inheritedEnv: ["HOME", "COMPOSER_HOME"],
+    timeoutMs: options.timeoutMs,
+    maxOutputBytes: options.maxOutputBytes ?? 1024 * 1024 * 10,
+    label: options.label,
+  }
+}
+
+function prepareRecipeSourcePackageWithoutArtifacts(source: string, originalSource: string, slug: string): string {
+  const localSource = localSourcePath(originalSource)
+  if (!pathExists(join(localSource, "composer.json"))) {
+    return pathExists(localSource) ? localSource : source
+  }
+  if (pathExists(join(localSource, "vendor", "autoload.php"))) {
+    return localSource
+  }
+  throw new Error(`Plugin ${slug} requires Composer dependencies but no artifacts directory is available for staging.`)
+}
+
+function installComposerDependenciesForSourcePackageSync(source: string, slug: string, allowedRoot: string, composerInstallArgs?: string[]): string {
+  if (!pathExists(join(source, "composer.json")) || pathExists(join(source, "vendor", "autoload.php"))) {
+    return source
+  }
+
+  const config = composerManagedHostCommandConfig({
+    cwd: source,
+    allowedCwdRoots: [allowedRoot],
+    args: composerInstallArgs ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts", "--no-plugins"],
+    label: `hydrate Composer source package ${slug}`,
+  })
+  const result = spawnSync(config.command, config.args, {
+    cwd: source,
+    encoding: "utf8",
+    env: { PATH: process.env.PATH ?? "", ...config.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  if (result.status !== 0) {
+    throw new Error(`Composer install failed for plugin ${slug}: ${result.stderr || result.stdout || `exit ${result.status}`}`)
+  }
+  if (!pathExists(join(source, "vendor", "autoload.php"))) {
+    throw new Error(`Composer install for plugin ${slug} did not create vendor/autoload.php.`)
+  }
+  return source
+}
+
+function localSourcePath(source: string): string {
+  return pathExists(source) ? resolve(source) : source
+}
+
+function pathExists(filePath: string): boolean {
+  return existsSync(filePath)
 }
 
 function errorMessage(error: unknown): string {

--- a/tests/generic-primitives.test.ts
+++ b/tests/generic-primitives.test.ts
@@ -16,6 +16,7 @@ import {
   browserArtifactRef,
   captureArtifactFile,
   browserArtifactPersistenceProjection,
+  composerManagedHostCommandConfig,
   evidenceArtifactEnvelope,
   fixtureImportDeterministicIdPlan,
   normalizeMaterializationResultEnvelope,
@@ -24,6 +25,7 @@ import {
   compileRecipeTemplate,
   normalizeReviewerSafePath,
   normalizeWorkspaceRelativeTarget,
+  prepareRecipeSourcePackageSync,
   reviewerSafeArtifactRef,
   sourcePackagePathAllowed,
   normalizeArtifactPartPath,
@@ -79,6 +81,18 @@ assert.deepEqual(template.sourcePackages[0]?.stagedFile, { source: "./fixture", 
 assert.equal(template.recipe.inputs?.sourcePackages?.[0]?.target, "fixtures/plugin")
 assert.equal(template.recipe.artifacts?.paths?.[0]?.name, "source-package-fixture")
 assert.equal(template.recipe.artifacts?.paths?.[0]?.path, "/workspace/fixtures/plugin/.wp-codebox-source-package.json")
+
+const composerPolicy = composerManagedHostCommandConfig({ cwd: process.cwd(), allowedCwdRoots: [process.cwd()], label: "composer policy test" })
+assert.equal(composerPolicy.command, "composer")
+assert.deepEqual(composerPolicy.inheritedEnv, ["HOME", "COMPOSER_HOME"])
+assert.equal(composerPolicy.allowedCwdRoots?.[0], process.cwd())
+
+const composerSourceRoot = mkdtempSync(join(tmpdir(), "wp-codebox-composer-source-"))
+writeFileSync(join(composerSourceRoot, "composer.json"), JSON.stringify({ name: "example/plugin" }))
+assert.throws(
+  () => prepareRecipeSourcePackageSync({ source: composerSourceRoot, slug: "example-plugin", artifactsRoot: "" }),
+  /requires Composer dependencies but no artifacts directory/,
+)
 
 assert.deepEqual(trustedBrowserSessionOrigin("http://localhost:8881/path?x=1"), {
   schema: "wp-codebox/trusted-browser-session-origin/v1",


### PR DESCRIPTION
## Summary
- Move prepared plugin source staging and Composer hydration into the generic recipe source/package primitive.
- Reuse shared Composer managed-host-command policy for recipe extra plugin autoload and Composer-backed source hydration.
- Migrate agent task provider/component plugin preparation away from local spawn/path helpers.

## Tests
- npm run build
- npm run test:recipe-source-packages
- npm run test:generic-primitives
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/component-plugin-entrypoint-contract-smoke.ts
- npm run check (timed out after 20m while running materialize-replay-package-smoke; preceding check commands passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the source/package primitive consolidation, migrated callsites, and ran local verification; Chris remains responsible for review and landing.