### PR TITLE
Adopt runtime dependency plan in materializers

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1040,7 +1040,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$inheritance,
 			$this->inheritance_request( $input ),
 			$this->agent_bundles( $input ),
-			$this->secret_env_names( $input, $inheritance )
+			$this->secret_env_names( $input, $inheritance ),
+			$this->runtime_env( $input )
 		);
 	}
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -98,7 +98,7 @@ final class WP_Codebox_Host_Recipe_Builder {
 			'inheritance'        => $dependency_plan->inheritance(),
 			'extra_plugins'      => array_merge( $dependency_plan->component_plugins(), $dependency_plan->provider_plugins() ),
 			'component_manifest' => $component_manifest,
-			'runtimeEnv'         => array_merge( $adapters['runtime_env']( $input ), self::AGENT_RUNTIME_ENV ),
+			'runtimeEnv'         => $dependency_plan->runtime_env_with_defaults( self::AGENT_RUNTIME_ENV ),
 			'secretEnv'          => $dependency_plan->secret_env_names(),
 		);
 		if ( ! empty( $dependency_plan->agent_bundles() ) ) {
@@ -166,7 +166,8 @@ final class WP_Codebox_Host_Recipe_Builder {
 			$inheritance,
 			$adapters['inheritance_request']( $input ),
 			$adapters['agent_bundles']( $input ),
-			$adapters['secret_env_names']( $input, $inheritance )
+			$adapters['secret_env_names']( $input, $inheritance ),
+			$adapters['runtime_env']( $input )
 		);
 	}
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
@@ -36,6 +36,9 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 	/** @var string[] */
 	private array $secret_env_names;
 
+	/** @var array<string,string> */
+	private array $runtime_env;
+
 	/**
 	 * @param array<string,mixed> $selection Provider/model/runtime selection metadata.
 	 * @param string[] $provider_plugin_paths Resolved provider plugin paths.
@@ -46,8 +49,9 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 	 * @param array{connectors:string[],settings:string[]} $inheritance_request Requested inheritance metadata.
 	 * @param array<int,array<string,mixed>> $agent_bundles Agent bundle import specs.
 	 * @param string[] $secret_env_names Required secret env names.
+	 * @param array<string,mixed> $runtime_env Non-secret runtime environment values.
 	 */
-	public function __construct( array $selection, array $provider_plugin_paths, array $provider_plugins, array $component_plugins, array $runtime_overlays, array $inheritance, array $inheritance_request, array $agent_bundles, array $secret_env_names ) {
+	public function __construct( array $selection, array $provider_plugin_paths, array $provider_plugins, array $component_plugins, array $runtime_overlays, array $inheritance, array $inheritance_request, array $agent_bundles, array $secret_env_names, array $runtime_env = array() ) {
 		$this->selection             = $selection;
 		$this->provider_plugin_paths = self::string_list( $provider_plugin_paths );
 		$this->provider_plugins      = array_values( array_filter( $provider_plugins, 'is_array' ) );
@@ -63,6 +67,7 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 		);
 		$this->agent_bundles         = array_values( array_filter( $agent_bundles, 'is_array' ) );
 		$this->secret_env_names      = self::secret_env_list( $secret_env_names );
+		$this->runtime_env           = self::runtime_env_map( $runtime_env );
 	}
 
 	/** @return array<string,mixed> */
@@ -123,6 +128,31 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 		return $this->secret_env_names;
 	}
 
+	/** @return array<string,string> */
+	public function runtime_env(): array {
+		return $this->runtime_env;
+	}
+
+	/** @param array<string,string> $defaults @return array<string,string> */
+	public function runtime_env_with_defaults( array $defaults ): array {
+		return array_merge( $this->runtime_env, self::runtime_env_map( $defaults ) );
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	public function browser_provider_plugin_specs(): array {
+		return array_map(
+			static fn( string $path ): array => array(
+				'slug'       => self::safe_key( basename( $path ) ),
+				'path'       => $path,
+				'activate'   => true,
+				'provenance' => array(
+					'source' => 'provider-plugin-path',
+				),
+			),
+			$this->provider_plugin_paths
+		);
+	}
+
 	/** @return array<string,mixed> */
 	public function to_contract(): array {
 		return array_filter(
@@ -137,9 +167,14 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 				'inheritance'           => $this->inheritance,
 				'agent_bundles'         => $this->agent_bundles,
 				'secret_env'            => $this->secret_env_names,
+				'runtime_env'           => $this->runtime_env,
 			),
 			static fn( mixed $value ): bool => array() !== $value && '' !== $value
 		);
+	}
+
+	private static function safe_key( string $value ): string {
+		return trim( strtolower( preg_replace( '/[^a-zA-Z0-9_\-]+/', '-', $value ) ?? '' ), '-' );
 	}
 
 	/** @return string[] */
@@ -158,5 +193,18 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 	/** @return string[] */
 	private static function secret_env_list( mixed $value ): array {
 		return array_values( array_filter( self::string_list( $value ), static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) );
+	}
+
+	/** @return array<string,string> */
+	private static function runtime_env_map( mixed $value ): array {
+		$env = array();
+		foreach ( is_array( $value ) ? $value : array() as $name => $env_value ) {
+			$name = trim( (string) $name );
+			if ( 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) && is_scalar( $env_value ) ) {
+				$env[ $name ] = (string) $env_value;
+			}
+		}
+
+		return $env;
 	}
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -322,9 +322,10 @@ private static function browser_plugins( array $input ): array|WP_Error {
 }
 
 /** @param array<string,mixed> $input Ability input. @param array<int,array<string,mixed>> $browser_plugins Browser plugin specs. @return array<string,mixed>|WP_Error */
-private static function browser_runtime_dependencies( array $input, array $browser_plugins ): array|WP_Error {
+private static function browser_runtime_dependencies( array $input, array $browser_plugins, ?WP_Codebox_Runtime_Dependency_Plan $dependency_plan = null ): array|WP_Error {
 	$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
-	$runtime_plugin_specs = self::browser_runtime_plugin_specs( array_merge( self::browser_provider_plugin_specs( $input ), is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array() ) );
+	$provider_plugin_specs = $dependency_plan instanceof WP_Codebox_Runtime_Dependency_Plan ? $dependency_plan->browser_provider_plugin_specs() : self::browser_provider_plugin_specs( $input );
+	$runtime_plugin_specs = self::browser_runtime_plugin_specs( array_merge( $provider_plugin_specs, is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array() ) );
 	if ( is_wp_error( $runtime_plugin_specs ) ) {
 		return $runtime_plugin_specs;
 	}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -54,12 +54,13 @@ public static function create_browser_playground_session( array $input ): array|
 	if ( is_wp_error( $input ) ) {
 		return $input;
 	}
+	$dependency_plan = self::browser_runtime_dependency_plan( $input, $inheritance_payload['inheritance'] );
 	$browser_runner  = is_array( $input['browser_runner'] ?? null ) ? $input['browser_runner'] : array();
 	$browser_plugins = self::browser_plugins( $input );
 	if ( is_wp_error( $browser_plugins ) ) {
 		return $browser_plugins;
 	}
-	$runtime = self::browser_runtime_dependencies( $input, $browser_plugins );
+	$runtime = self::browser_runtime_dependencies( $input, $browser_plugins, $dependency_plan );
 	if ( is_wp_error( $runtime ) ) {
 		return $runtime;
 	}
@@ -84,7 +85,7 @@ public static function create_browser_playground_session( array $input ): array|
 		return self::blocked_browser_playground_session( $session_id, $input, $task_input, $ready_to_code, $browser_plugins, $runtime, $artifacts, $playground, $blueprint, $site_blueprint_artifact );
 	}
 
-	$task_payload = self::browser_task_payload( $input, $task_input, $session_id, $artifacts, $inheritance_payload['inheritance'] );
+	$task_payload = self::browser_task_payload( $input, $task_input, $session_id, $artifacts, $inheritance_payload['inheritance'], $dependency_plan );
 	$recipe = self::browser_agent_recipe( $task_input, $session_id, $browser_runner, $blueprint, $playground, $task_payload );
 	if ( is_wp_error( $recipe ) ) {
 		return $recipe;

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -47,7 +47,7 @@ private static function browser_input_with_inheritance( array $input, array $inh
 }
 
 /** @param array<string,mixed> $input Ability input. @param array<string,mixed> $task_input Normalized task input. @param array<int,array<string,mixed>> $artifacts Browser artifact specs. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed> */
-private static function browser_task_payload( array $input, array $task_input, string $session_id, array $artifacts, array $inheritance ): array {
+private static function browser_task_payload( array $input, array $task_input, string $session_id, array $artifacts, array $inheritance, ?WP_Codebox_Runtime_Dependency_Plan $dependency_plan = null ): array {
 	return WP_Codebox_Browser_Task_Builder::task_payload(
 		$input,
 		$task_input,
@@ -55,25 +55,29 @@ private static function browser_task_payload( array $input, array $task_input, s
 		$artifacts,
 		$inheritance,
 		array(
-			'runtime_dependency_plan' => static function ( array $input, array $task_input, array $inheritance ): WP_Codebox_Runtime_Dependency_Plan {
-				return new WP_Codebox_Runtime_Dependency_Plan(
-					array(
-						'agent'    => self::browser_agent_slug( $input ),
-						'mode'     => self::browser_mode( $input ),
-						'provider' => self::browser_provider( $input, $inheritance ),
-						'model'    => self::browser_model( $input, $inheritance ),
-					),
-					self::browser_provider_plugin_paths( $input ),
-					array(),
-					array(),
-					is_array( $input['runtime_overlays'] ?? null ) ? $input['runtime_overlays'] : array(),
-					$inheritance,
-					self::browser_inheritance_request( $input ),
-					self::normalize_agent_bundles( $input['agent_bundles'] ?? array() ),
-					self::browser_secret_env_names( $input )
-				);
-			},
+			'runtime_dependency_plan' => static fn(): WP_Codebox_Runtime_Dependency_Plan => $dependency_plan ?? self::browser_runtime_dependency_plan( $input, $inheritance ),
 		)
+	);
+}
+
+/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
+private static function browser_runtime_dependency_plan( array $input, array $inheritance ): WP_Codebox_Runtime_Dependency_Plan {
+	return new WP_Codebox_Runtime_Dependency_Plan(
+		array(
+			'agent'    => self::browser_agent_slug( $input ),
+			'mode'     => self::browser_mode( $input ),
+			'provider' => self::browser_provider( $input, $inheritance ),
+			'model'    => self::browser_model( $input, $inheritance ),
+		),
+		self::browser_provider_plugin_paths( $input ),
+		array(),
+		array(),
+		is_array( $input['runtime_overlays'] ?? null ) ? $input['runtime_overlays'] : array(),
+		$inheritance,
+		self::browser_inheritance_request( $input ),
+		self::normalize_agent_bundles( $input['agent_bundles'] ?? array() ),
+		self::browser_secret_env_names( $input ),
+		self::browser_runtime_env( $input )
 	);
 }
 
@@ -135,6 +139,20 @@ private static function browser_provider_plugin_paths( array $input ): array {
 /** @param array<string,mixed> $input Ability input. @return string[] */
 private static function browser_secret_env_names( array $input ): array {
 	return array_values( array_unique( array_filter( self::string_list( $input['secret_env'] ?? array() ), static fn( string $name ): bool => 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) ) );
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,string> */
+private static function browser_runtime_env( array $input ): array {
+	$raw = is_array( $input['runtime_env'] ?? null ) ? $input['runtime_env'] : ( is_array( $input['runtimeEnv'] ?? null ) ? $input['runtimeEnv'] : array() );
+	$env = array();
+	foreach ( $raw as $name => $value ) {
+		$name = trim( (string) $name );
+		if ( 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) && is_scalar( $value ) ) {
+			$env[ $name ] = (string) $value;
+		}
+	}
+
+	return $env;
 }
 
 /** @return array<int,array<string,mixed>> */

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -75,6 +75,21 @@ $explicit_plan_payload = WP_Codebox_Browser_Task_Builder::task_payload(
 	)
 );
 
+$plan = new WP_Codebox_Runtime_Dependency_Plan(
+	array( 'agent' => 'contract-agent', 'mode' => 'sandbox', 'provider' => 'contract-provider', 'model' => 'contract-model' ),
+	array( '/tmp/contract-provider' ),
+	array( array( 'slug' => 'contract-provider', 'source' => '/tmp/contract-provider' ) ),
+	array(),
+	array(),
+	array( 'connectors' => array(), 'settings' => array() ),
+	array( 'connectors' => array(), 'settings' => array() ),
+	array(),
+	array( 'CONTRACT_SECRET' ),
+	array( 'CONTRACT_ENV' => '1', 'bad-name' => 'ignored' )
+);
+$plan_contract = $plan->to_contract();
+$plan_plugin_specs = $plan->browser_provider_plugin_specs();
+
 $intent_task = WP_Codebox_Browser_Task_Builder::browser_task_input_from_intent( array(
 	'product_intent' => array(
 		'product' => 'demo-product',
@@ -118,7 +133,7 @@ $fanout_request = WP_Codebox_Browser_Task_Builder::fanout_request( array(
 	'orchestrator' => array( 'id' => 'demo-orchestrator' ),
 ) );
 
-echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'plan_contract' => $plan_contract, 'plan_plugin_specs' => $plan_plugin_specs, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.task_input.schema, "wp-codebox/task-input/v1")
@@ -137,6 +152,8 @@ assert.equal(result.explicit_plan_payload.provider, "planned-provider")
 assert.equal(result.explicit_plan_payload.model, "planned-model")
 assert.deepEqual(result.explicit_plan_payload.secret_env, ["PLANNED_SECRET"])
 assert.deepEqual(result.explicit_plan_payload.agent_bundles, [{ source: "/tmp/planned-bundle.zip" }])
+assert.deepEqual(result.plan_contract.runtime_env, { CONTRACT_ENV: "1" })
+assert.deepEqual(result.plan_plugin_specs, [{ slug: "contract-provider", path: "/tmp/contract-provider", activate: true, provenance: { source: "provider-plugin-path" } }])
 assert.equal(result.local_task.mode, "sandbox")
 assert.equal(result.local_task.target.kind, "browser-playground")
 assert.equal(result.local_task.target.ref, "session-123")

--- a/tests/host-recipe-builder.test.ts
+++ b/tests/host-recipe-builder.test.ts
@@ -23,7 +23,8 @@ $dependency_plan = new WP_Codebox_Runtime_Dependency_Plan(
 	array( 'connectors' => array( array( 'provider' => 'planned-provider', 'model' => 'planned-model' ) ), 'settings' => array() ),
 	array( 'connectors' => array( 'planned-connector' ), 'settings' => array() ),
 	array( array( 'source' => '/tmp/planned-bundle.zip', 'on_conflict' => 'skip' ) ),
-	array( 'PLANNED_SECRET' )
+	array( 'PLANNED_SECRET' ),
+	array( 'CUSTOM_ENV' => '1', 'bad-name' => 'ignored' )
 );
 
 $builder = new WP_Codebox_Host_Recipe_Builder();
@@ -79,6 +80,7 @@ assert.deepEqual(result.legacy_adapter_calls, [])
 assert.equal(result.recipe.schema, "wp-codebox/workspace-recipe/v1")
 assert.deepEqual(result.recipe.inputs.inherit, { connectors: ["planned-connector"], settings: [] })
 assert.deepEqual(result.recipe.inputs.secretEnv, ["PLANNED_SECRET"])
+assert.deepEqual(result.recipe.inputs.runtimeEnv, { CUSTOM_ENV: "1", WP_AGENT_RUNTIME: "1" })
 assert.deepEqual(result.recipe.inputs.agent_bundles, [{ source: "/tmp/planned-bundle.zip", on_conflict: "skip" }])
 assert.deepEqual(result.recipe.inputs.extra_plugins, [
   { source: "/components/demo-plugin", slug: "demo-plugin", activate: true, loadAs: "plugin" },


### PR DESCRIPTION
## Summary
- Thread a single Runtime_Dependency_Plan through browser runtime materialization and browser task payload assembly.
- Move host runtimeEnv consumption onto the plan alongside secretEnv/plugin/component/overlay data.
- Extend plan contract/helpers and tests so plan-provided env and browser provider plugin specs are consumed without changing emitted payload shapes.

## Tests
- npm run test:browser-task-builder
- npm run test:host-recipe-builder
- npm run test:agent-task-contracts
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation and test updates; Chris remains responsible for review and validation.