### PR TITLE
Adopt shared PHP path policy cleaners

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1776,7 +1776,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	private function clean_path( string $path ): string {
-		return rtrim( trim( $path ), DIRECTORY_SEPARATOR );
+		return WP_Codebox_Path_Policy::clean_host_path( $path );
 	}
 
 	private function preview_hold_seconds( array $input ): int {

--- a/packages/wordpress-plugin/src/class-wp-codebox-path-policy.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-path-policy.php
@@ -9,6 +9,26 @@ defined( 'ABSPATH' ) || exit;
 
 final class WP_Codebox_Path_Policy {
 
+	public static function clean_host_path( string $path ): string {
+		return rtrim( trim( $path ), DIRECTORY_SEPARATOR );
+	}
+
+	public static function clean_browser_runtime_source_path( string $path ): string {
+		$path = trim( $path );
+		if ( '' === $path ) {
+			return '';
+		}
+
+		$real = realpath( $path );
+		return false !== $real ? $real : rtrim( $path, '/\\' );
+	}
+
+	public static function normalize_absolute_browser_path( string $path ): string {
+		$path = '/' . ltrim( trim( $path ), '/' );
+		$path = rtrim( $path, '/' );
+		return '' === $path ? '/' : $path;
+	}
+
 	/** @param array<string,mixed> $data Additional error data. */
 	public static function normalize_sandbox_mount_target( string $target, string $label = 'Sandbox mount', string $error_code = 'wp_codebox_mount_target_invalid', array $data = array() ): string|WP_Error {
 		$normalized = preg_replace( '#/+#', '/', trim( str_replace( '\\', '/', $target ) ) );

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -716,9 +716,7 @@ private static function browser_preview_url( array $artifacts, array $playground
 }
 
 private static function normalize_absolute_browser_path( string $path ): string {
-	$path = '/' . ltrim( trim( $path ), '/' );
-	$path = rtrim( $path, '/' );
-	return '' === $path ? '/' : $path;
+	return WP_Codebox_Path_Policy::normalize_absolute_browser_path( $path );
 }
 
 private static function join_browser_path( string $base, string $path ): string {

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -752,13 +752,7 @@ private static function browser_configured_component_contracts(): array {
 }
 
 private static function browser_clean_path( string $path ): string {
-	$path = trim( $path );
-	if ( '' === $path ) {
-		return '';
-	}
-
-	$real = realpath( $path );
-	return false !== $real ? $real : rtrim( $path, '/\\' );
+	return WP_Codebox_Path_Policy::clean_browser_runtime_source_path( $path );
 }
 
 /** @return array{url:string,fetch_url:string,path:string,sha256:string}|WP_Error */

--- a/scripts/php-path-policy-parity-smoke.php
+++ b/scripts/php-path-policy-parity-smoke.php
@@ -49,6 +49,26 @@ function assert_error( mixed $actual, string $label ): void {
 	}
 }
 
+function old_clean_host_path( string $path ): string {
+	return rtrim( trim( $path ), DIRECTORY_SEPARATOR );
+}
+
+function old_clean_browser_runtime_source_path( string $path ): string {
+	$path = trim( $path );
+	if ( '' === $path ) {
+		return '';
+	}
+
+	$real = realpath( $path );
+	return false !== $real ? $real : rtrim( $path, '/\\' );
+}
+
+function old_normalize_absolute_browser_path( string $path ): string {
+	$path = '/' . ltrim( trim( $path ), '/' );
+	$path = rtrim( $path, '/' );
+	return '' === $path ? '/' : $path;
+}
+
 assert_same( 'files/output.json', WP_Codebox_Path_Policy::normalize_artifact_relative_path( '/files//output.json' ), 'artifact leading slash and slash collapse' );
 assert_same( 'files/windows/path.json', WP_Codebox_Path_Policy::normalize_artifact_relative_path( 'files\\windows/path.json' ), 'artifact backslash normalization' );
 assert_error( WP_Codebox_Path_Policy::normalize_artifact_relative_path( './files/output.json' ), 'artifact current-directory segment' );
@@ -62,5 +82,42 @@ assert_same( '/', WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '///' 
 assert_error( WP_Codebox_Path_Policy::normalize_sandbox_mount_target( 'wordpress/wp-content/plugins/plugin' ), 'mount relative target' );
 assert_error( WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '/wordpress/./plugins/plugin' ), 'mount current-directory segment' );
 assert_error( WP_Codebox_Path_Policy::normalize_sandbox_mount_target( '/wordpress/../escape' ), 'mount parent-directory segment' );
+
+$host_path_cases = array(
+	'',
+	'   ',
+	' /tmp/wp-codebox/ ',
+	"/tmp/wp-codebox//",
+	'C:\\tmp\\wp-codebox\\',
+);
+foreach ( $host_path_cases as $case ) {
+	assert_same( old_clean_host_path( $case ), WP_Codebox_Path_Policy::clean_host_path( $case ), 'host path cleaner parity for ' . var_export( $case, true ) );
+}
+
+$existing_path = __DIR__;
+$browser_source_path_cases = array(
+	'',
+	'   ',
+	' /tmp/wp-codebox/ ',
+	"/tmp/wp-codebox//",
+	'C:\\tmp\\wp-codebox\\',
+	$existing_path,
+	$existing_path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . basename( $existing_path ),
+);
+foreach ( $browser_source_path_cases as $case ) {
+	assert_same( old_clean_browser_runtime_source_path( $case ), WP_Codebox_Path_Policy::clean_browser_runtime_source_path( $case ), 'browser source path cleaner parity for ' . var_export( $case, true ) );
+}
+
+$absolute_browser_path_cases = array(
+	'',
+	'   ',
+	'wp-content/uploads',
+	'/wp-content/uploads/',
+	'//wp-content//uploads//',
+	' /preview/path/ ',
+);
+foreach ( $absolute_browser_path_cases as $case ) {
+	assert_same( old_normalize_absolute_browser_path( $case ), WP_Codebox_Path_Policy::normalize_absolute_browser_path( $case ), 'absolute browser path parity for ' . var_export( $case, true ) );
+}
 
 fwrite( STDOUT, "PHP path policy parity smoke passed\n" );


### PR DESCRIPTION
## Summary
- Move remaining PHP host/browser path cleaners behind WP_Codebox_Path_Policy.
- Keep the existing sandbox runner and browser runtime helper methods as thin compatibility wrappers.
- Extend PHP path policy parity coverage for the adopted cleaner behavior.

## Tests
- npm run test:php-path-policy-parity
- php -l packages/wordpress-plugin/src/class-wp-codebox-path-policy.php && php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php && php -l scripts/php-path-policy-parity-smoke.php
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, parity test additions, and verification commands for Chris to review.
