### PR TITLE
Extract browser DOM snapshot primitive

### DIFF
--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -12,6 +12,7 @@ import type { BrowserArtifact, BrowserArtifactSummary, BrowserEditorCanvasProbeD
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness, type BrowserCommandLivenessPolicy } from "./browser-liveness.js"
+import { captureBrowserDomSnapshot, type BrowserDomSnapshotArtifact } from "./browser-dom-snapshot.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, serializeBrowserError } from "./browser-metrics.js"
 import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, browserPreviewTopology, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
@@ -23,7 +24,6 @@ import { phpBrowserWordPressDiagnosticsPlugin } from "./php-snippets.js"
 import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import type { Page } from "playwright"
-import { captureVisualCompareDomSnapshot, type VisualCompareDomSnapshotArtifact } from "./browser-visual-compare.js"
 
 const BROWSER_STEP_DEFAULT_TIMEOUT_MS = 15_000
 const BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS = 120_000
@@ -2467,8 +2467,8 @@ async function captureBrowserActionDomSnapshot({
   const sanitizedName = step?.name ? sanitizeScreenshotName(step.name) : undefined
   const relativeSnapshotRef = snapshotRef ?? `files/browser/dom-snapshot-${sanitizedName || `step-${step?.index ?? 0}`}.json`
   const snapshotFileName = relativeSnapshotRef.replace(/^files\/browser\//, "")
-  const snapshot = await captureVisualCompareDomSnapshot(page, maxElements)
-  const artifact: VisualCompareDomSnapshotArtifact = {
+  const snapshot = await captureBrowserDomSnapshot(page, maxElements)
+  const artifact: BrowserDomSnapshotArtifact = {
     schema: "wp-codebox/browser-dom-snapshot/v1",
     command: "wordpress.browser-actions",
     screenshot: screenshotRef,

--- a/packages/runtime-playground/src/browser-dom-snapshot.ts
+++ b/packages/runtime-playground/src/browser-dom-snapshot.ts
@@ -1,0 +1,165 @@
+import type { BrowserProbeViewport } from "./browser-artifacts.js"
+import type { Page } from "playwright"
+
+const BROWSER_DOM_SNAPSHOT_STYLE_PROPERTIES = ["display", "position", "box-sizing", "width", "height", "margin-top", "margin-right", "margin-bottom", "margin-left", "padding-top", "padding-right", "padding-bottom", "padding-left", "font-family", "font-size", "font-weight", "line-height", "letter-spacing", "color", "background-color", "border-top-width", "border-right-width", "border-bottom-width", "border-left-width", "border-top-color", "border-right-color", "border-bottom-color", "border-left-color", "opacity", "transform", "visibility"] as const
+const BROWSER_DOM_SNAPSHOT_ATTRIBUTE_NAMES = ["id", "class", "role", "aria-label", "title", "href", "src", "type", "name"] as const
+
+export interface BrowserDomElementSnapshot {
+  path: string
+  tag: string
+  text: string
+  attributes: Record<string, string>
+  boundingBox: { x: number; y: number; width: number; height: number }
+  styles: Record<string, string>
+}
+
+export interface BrowserDomSelectorSnapshot {
+  selector: string
+  matched: number
+  captured: number
+  paths: string[]
+  error?: string
+}
+
+export interface BrowserDomSnapshot {
+  url: string
+  title: string
+  elementCount: number
+  capturedElements: BrowserDomElementSnapshot[]
+  selectors?: BrowserDomSelectorSnapshot[]
+  truncated: boolean
+}
+
+export interface BrowserDomSnapshotArtifact {
+  schema: "wp-codebox/browser-dom-snapshot/v1"
+  command: "wordpress.browser-actions" | "wordpress.visual-compare"
+  screenshot: string
+  step?: { index: number; name?: string; kind: string }
+  finalUrl: string
+  viewport: BrowserProbeViewport | null
+  capturedAt: string
+  limits: { maxElements: number }
+  summary: { elementCount: number; capturedElements: number; truncated: boolean }
+  snapshot: BrowserDomSnapshot
+}
+
+export async function captureBrowserDomSnapshot(page: Page, maxElements: number, selectors: string[] = []): Promise<BrowserDomSnapshot> {
+  return page.evaluate(({ maxElements: maxElementsInput, styleProperties, attributeNames, selectors: selectorInputs }) => {
+    const maxElements = Math.max(1, Number(maxElementsInput) || 1)
+    const elements = Array.from(document.body?.querySelectorAll("*") ?? [])
+    const visibleElements = elements
+      .map((element) => elementSnapshot(element, styleProperties, attributeNames))
+      .filter((element): element is BrowserDomElementSnapshot => Boolean(element))
+    const capturedByPath = new Map(visibleElements.slice(0, maxElements).map((element) => [element.path, element]))
+    const selectorSnapshots = selectorInputs.map((selector) => selectorSnapshot(selector, capturedByPath, styleProperties, attributeNames))
+
+    return {
+      url: window.location.href,
+      title: document.title || "",
+      elementCount: visibleElements.length,
+      capturedElements: [...capturedByPath.values()],
+      ...(selectorSnapshots.length > 0 ? { selectors: selectorSnapshots } : {}),
+      truncated: visibleElements.length > maxElements,
+    }
+
+    function selectorSnapshot(selector: string, captured: Map<string, BrowserDomElementSnapshot>, styles: string[], attributes: string[]): BrowserDomSelectorSnapshot {
+      try {
+        const matches = Array.from(document.querySelectorAll(selector))
+        const snapshots = matches.map((element) => elementSnapshot(element, styles, attributes)).filter((element): element is BrowserDomElementSnapshot => Boolean(element))
+        for (const snapshot of snapshots) {
+          captured.set(snapshot.path, snapshot)
+        }
+        return { selector, matched: matches.length, captured: snapshots.length, paths: snapshots.map((snapshot) => snapshot.path) }
+      } catch (error) {
+        return { selector, matched: 0, captured: 0, paths: [], error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+
+    function elementSnapshot(element: Element, styles: string[], attributes: string[]): BrowserDomElementSnapshot | null {
+      const rect = element.getBoundingClientRect()
+      const computed = window.getComputedStyle(element)
+      if (rect.width <= 0 || rect.height <= 0 || computed.display === "none" || computed.visibility === "hidden" || computed.opacity === "0") {
+        return null
+      }
+      return {
+        path: elementPath(element),
+        tag: element.tagName.toLowerCase(),
+        text: compactText(element.textContent || "", 180),
+        attributes: Object.fromEntries(attributes.flatMap((name) => {
+          const value = element.getAttribute(name)
+          return value === null ? [] : [[name, compactText(value, 180)]]
+        })),
+        boundingBox: {
+          x: roundNumber(rect.x),
+          y: roundNumber(rect.y),
+          width: roundNumber(rect.width),
+          height: roundNumber(rect.height),
+        },
+        styles: Object.fromEntries(styles.map((name) => [name, computed.getPropertyValue(name)])),
+      }
+    }
+
+    function elementPath(element: Element): string {
+      const parts: string[] = []
+      let current: Element | null = element
+      while (current && current !== document.body && parts.length < 6) {
+        let part = current.tagName.toLowerCase()
+        const id = current.getAttribute("id")
+        if (id) {
+          part += `#${cssEscape(id)}`
+          parts.unshift(part)
+          break
+        }
+        const classes = Array.from(current.classList || []).slice(0, 2).map(cssEscape)
+        if (classes.length > 0) {
+          part += `.${classes.join(".")}`
+        }
+        const parent: Element | null = current.parentElement
+        if (parent) {
+          const sameTagSiblings = Array.from(parent.children).filter((child: Element) => child.tagName === current?.tagName)
+          if (sameTagSiblings.length > 1) {
+            part += `:nth-of-type(${sameTagSiblings.indexOf(current) + 1})`
+          }
+        }
+        parts.unshift(part)
+        current = parent
+      }
+      return parts.length > 0 ? parts.join(" > ") : element.tagName.toLowerCase()
+    }
+
+    function compactText(value: string, maxLength: number): string {
+      const compact = value.replace(/\s+/g, " ").trim()
+      return compact.length > maxLength ? `${compact.slice(0, maxLength - 1)}…` : compact
+    }
+
+    function roundNumber(value: number): number {
+      return Math.round(value * 100) / 100
+    }
+
+    function cssEscape(value: string): string {
+      if (globalThis.CSS && typeof globalThis.CSS.escape === "function") {
+        return globalThis.CSS.escape(String(value))
+      }
+      return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&")
+    }
+  }, { maxElements, styleProperties: [...BROWSER_DOM_SNAPSHOT_STYLE_PROPERTIES], attributeNames: [...BROWSER_DOM_SNAPSHOT_ATTRIBUTE_NAMES], selectors })
+}
+
+export function normalizeBrowserDomSnapshotArtifact(input: unknown, requestedPath: string, label = "Browser DOM snapshot"): BrowserDomSnapshotArtifact {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`${label} must be a JSON object: ${requestedPath}`)
+  }
+  const record = input as Partial<BrowserDomSnapshotArtifact> & { snapshot?: unknown }
+  if (record.schema !== "wp-codebox/browser-dom-snapshot/v1") {
+    throw new Error(`${label} has unsupported schema: ${requestedPath}`)
+  }
+  const snapshot = record.snapshot
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    throw new Error(`${label} is missing snapshot object: ${requestedPath}`)
+  }
+  const typedSnapshot = snapshot as Partial<BrowserDomSnapshot>
+  if (!Array.isArray(typedSnapshot.capturedElements)) {
+    throw new Error(`${label} capturedElements must be an array: ${requestedPath}`)
+  }
+  return record as BrowserDomSnapshotArtifact
+}

--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -7,6 +7,7 @@ import { PNG } from "pngjs"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import type { BrowserArtifact, BrowserProbeViewport } from "./browser-artifacts.js"
 import { launchChromiumBrowser } from "./browser-capture-session.js"
+import { captureBrowserDomSnapshot, normalizeBrowserDomSnapshotArtifact, type BrowserDomElementSnapshot as VisualCompareDomElementSnapshot, type BrowserDomSelectorSnapshot as VisualCompareSelectorSnapshot, type BrowserDomSnapshot as VisualCompareDomSnapshot, type BrowserDomSnapshotArtifact as VisualCompareDomSnapshotArtifact } from "./browser-dom-snapshot.js"
 import { browserCommandLivenessPolicy, withBrowserCommandLiveness } from "./browser-liveness.js"
 import { browserPreviewRouting, resolveBrowserPreviewUrl } from "./browser-preview-routing.js"
 import { browserProbeViewport } from "./browser-probe.js"
@@ -14,48 +15,6 @@ import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js
 import { argValue, durationArg, jsonArrayArg, strictBooleanArg, viewportArg } from "./commands.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import type { Page } from "playwright"
-
-const VISUAL_EXPLANATION_STYLE_PROPERTIES = ["display", "position", "box-sizing", "width", "height", "margin-top", "margin-right", "margin-bottom", "margin-left", "padding-top", "padding-right", "padding-bottom", "padding-left", "font-family", "font-size", "font-weight", "line-height", "letter-spacing", "color", "background-color", "border-top-width", "border-right-width", "border-bottom-width", "border-left-width", "border-top-color", "border-right-color", "border-bottom-color", "border-left-color", "opacity", "transform", "visibility"] as const
-const VISUAL_EXPLANATION_ATTRIBUTE_NAMES = ["id", "class", "role", "aria-label", "title", "href", "src", "type", "name"] as const
-
-interface VisualCompareDomElementSnapshot {
-  path: string
-  tag: string
-  text: string
-  attributes: Record<string, string>
-  boundingBox: { x: number; y: number; width: number; height: number }
-  styles: Record<string, string>
-}
-
-interface VisualCompareSelectorSnapshot {
-  selector: string
-  matched: number
-  captured: number
-  paths: string[]
-  error?: string
-}
-
-interface VisualCompareDomSnapshot {
-  url: string
-  title: string
-  elementCount: number
-  capturedElements: VisualCompareDomElementSnapshot[]
-  selectors?: VisualCompareSelectorSnapshot[]
-  truncated: boolean
-}
-
-export interface VisualCompareDomSnapshotArtifact {
-  schema: "wp-codebox/browser-dom-snapshot/v1"
-  command: "wordpress.browser-actions" | "wordpress.visual-compare"
-  screenshot: string
-  step?: { index: number; name?: string; kind: string }
-  finalUrl: string
-  viewport: BrowserProbeViewport | null
-  capturedAt: string
-  limits: { maxElements: number }
-  summary: { elementCount: number; capturedElements: number; truncated: boolean }
-  snapshot: VisualCompareDomSnapshot
-}
 
 interface VisualCompareElementDelta {
   path: string
@@ -1241,7 +1200,7 @@ function visualCompareEndpoint(input: unknown): VisualCompareComparisonSummary["
 async function readVisualCompareDomSnapshotArtifact(requestedPath: string, artifactRoot: string): Promise<VisualCompareDomSnapshotArtifact> {
   const path = await resolveVisualCompareArtifactPath(requestedPath, artifactRoot, "Visual compare DOM snapshot")
   const parsed = JSON.parse(await readFile(path, "utf8")) as unknown
-  const artifact = normalizeVisualCompareDomSnapshotArtifact(parsed, requestedPath)
+  const artifact = normalizeBrowserDomSnapshotArtifact(parsed, requestedPath, "Visual compare DOM snapshot")
   return artifact
 }
 
@@ -1262,25 +1221,6 @@ async function resolveVisualCompareArtifactPath(requestedPath: string, artifactR
 
     throw new Error(`${label} not found: ${requestedPath}`)
   }
-}
-
-function normalizeVisualCompareDomSnapshotArtifact(input: unknown, requestedPath: string): VisualCompareDomSnapshotArtifact {
-  if (!input || typeof input !== "object" || Array.isArray(input)) {
-    throw new Error(`Visual compare DOM snapshot must be a JSON object: ${requestedPath}`)
-  }
-  const record = input as Partial<VisualCompareDomSnapshotArtifact> & { snapshot?: unknown }
-  if (record.schema !== "wp-codebox/browser-dom-snapshot/v1") {
-    throw new Error(`Visual compare DOM snapshot has unsupported schema: ${requestedPath}`)
-  }
-  const snapshot = record.snapshot
-  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
-    throw new Error(`Visual compare DOM snapshot is missing snapshot object: ${requestedPath}`)
-  }
-  const typedSnapshot = snapshot as Partial<VisualCompareDomSnapshot>
-  if (!Array.isArray(typedSnapshot.capturedElements)) {
-    throw new Error(`Visual compare DOM snapshot capturedElements must be an array: ${requestedPath}`)
-  }
-  return record as VisualCompareDomSnapshotArtifact
 }
 
 function visualCompareExplainSelectors(args: string[]): string[] {
@@ -1326,111 +1266,9 @@ async function captureVisualCompareUrl(page: Page, targetUrl: string, outputPath
   } else {
     throw new Error(`wait-for supports domcontentloaded, load, networkidle, selector:<selector>, or duration: ${waitFor}`)
   }
-  const domSnapshot = await withBrowserCommandLiveness({ command: "wordpress.visual-compare", phase: "dom-snapshot", operation: captureVisualCompareDomSnapshot(page, maxExplanationCandidates, explainSelectors), policy: { wallTimeoutMs: timeoutMs, idleTimeoutMs: 0 } })
+  const domSnapshot = await withBrowserCommandLiveness({ command: "wordpress.visual-compare", phase: "dom-snapshot", operation: captureBrowserDomSnapshot(page, maxExplanationCandidates, explainSelectors), policy: { wallTimeoutMs: timeoutMs, idleTimeoutMs: 0 } })
   await page.screenshot({ path: outputPath, fullPage, timeout: timeoutMs })
   return { finalUrl: page.url(), domSnapshot }
-}
-
-export async function captureVisualCompareDomSnapshot(page: Page, maxElements: number, explainSelectors: string[] = []): Promise<VisualCompareDomSnapshot> {
-  return page.evaluate(({ maxElements: maxElementsInput, styleProperties, attributeNames, selectors }) => {
-    const maxElements = Math.max(1, Number(maxElementsInput) || 1)
-    const elements = Array.from(document.body?.querySelectorAll("*") ?? [])
-    const visibleElements = elements
-      .map((element) => elementSnapshot(element, styleProperties, attributeNames))
-      .filter((element): element is VisualCompareDomElementSnapshot => Boolean(element))
-    const capturedByPath = new Map(visibleElements.slice(0, maxElements).map((element) => [element.path, element]))
-    const selectorSnapshots = selectors.map((selector) => selectorSnapshot(selector, capturedByPath, styleProperties, attributeNames))
-
-    return {
-      url: window.location.href,
-      title: document.title || "",
-      elementCount: visibleElements.length,
-      capturedElements: [...capturedByPath.values()],
-      ...(selectorSnapshots.length > 0 ? { selectors: selectorSnapshots } : {}),
-      truncated: visibleElements.length > maxElements,
-    }
-
-    function selectorSnapshot(selector: string, captured: Map<string, VisualCompareDomElementSnapshot>, styles: string[], attributes: string[]): VisualCompareSelectorSnapshot {
-      try {
-        const matches = Array.from(document.querySelectorAll(selector))
-        const snapshots = matches.map((element) => elementSnapshot(element, styles, attributes)).filter((element): element is VisualCompareDomElementSnapshot => Boolean(element))
-        for (const snapshot of snapshots) {
-          captured.set(snapshot.path, snapshot)
-        }
-        return { selector, matched: matches.length, captured: snapshots.length, paths: snapshots.map((snapshot) => snapshot.path) }
-      } catch (error) {
-        return { selector, matched: 0, captured: 0, paths: [], error: error instanceof Error ? error.message : String(error) }
-      }
-    }
-
-    function elementSnapshot(element: Element, styles: string[], attributes: string[]): VisualCompareDomElementSnapshot | null {
-      const rect = element.getBoundingClientRect()
-      const computed = window.getComputedStyle(element)
-      if (rect.width <= 0 || rect.height <= 0 || computed.display === "none" || computed.visibility === "hidden" || computed.opacity === "0") {
-        return null
-      }
-      return {
-        path: elementPath(element),
-        tag: element.tagName.toLowerCase(),
-        text: compactText(element.textContent || "", 180),
-        attributes: Object.fromEntries(attributes.flatMap((name) => {
-          const value = element.getAttribute(name)
-          return value === null ? [] : [[name, compactText(value, 180)]]
-        })),
-        boundingBox: {
-          x: roundNumber(rect.x),
-          y: roundNumber(rect.y),
-          width: roundNumber(rect.width),
-          height: roundNumber(rect.height),
-        },
-        styles: Object.fromEntries(styles.map((name) => [name, computed.getPropertyValue(name)])),
-      }
-    }
-
-    function elementPath(element: Element): string {
-      const parts: string[] = []
-      let current: Element | null = element
-      while (current && current !== document.body && parts.length < 6) {
-        let part = current.tagName.toLowerCase()
-        const id = current.getAttribute("id")
-        if (id) {
-          part += `#${cssEscape(id)}`
-          parts.unshift(part)
-          break
-        }
-        const classes = Array.from(current.classList || []).slice(0, 2).map(cssEscape)
-        if (classes.length > 0) {
-          part += `.${classes.join(".")}`
-        }
-        const parent: Element | null = current.parentElement
-        if (parent) {
-          const sameTagSiblings = Array.from(parent.children).filter((child: Element) => child.tagName === current?.tagName)
-          if (sameTagSiblings.length > 1) {
-            part += `:nth-of-type(${sameTagSiblings.indexOf(current) + 1})`
-          }
-        }
-        parts.unshift(part)
-        current = parent
-      }
-      return parts.length > 0 ? parts.join(" > ") : element.tagName.toLowerCase()
-    }
-
-    function compactText(value: string, maxLength: number): string {
-      const compact = value.replace(/\s+/g, " ").trim()
-      return compact.length > maxLength ? `${compact.slice(0, maxLength - 1)}…` : compact
-    }
-
-    function roundNumber(value: number): number {
-      return Math.round(value * 100) / 100
-    }
-
-    function cssEscape(value: string): string {
-      if (globalThis.CSS && typeof globalThis.CSS.escape === "function") {
-        return globalThis.CSS.escape(String(value))
-      }
-      return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&")
-    }
-  }, { maxElements, styleProperties: [...VISUAL_EXPLANATION_STYLE_PROPERTIES], attributeNames: [...VISUAL_EXPLANATION_ATTRIBUTE_NAMES], selectors: explainSelectors })
 }
 
 function createVisualCompareExplanation({


### PR DESCRIPTION
## Summary
- Add a neutral browser DOM snapshot primitive module for capture, artifact shape, and validation.
- Migrate browser actions DOM snapshot capture away from visual-compare-specific helpers.
- Keep visual compare on the same browser DOM snapshot schema through the shared primitive.

## Tests
- npm run test:browser-artifact-session
- npm run test:browser-task-builder
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the DOM snapshot primitive extraction, migrated TypeScript callsites, and ran local verification; Chris remains responsible for review and merge.