### PR TITLE
Consolidate utility primitives

### DIFF
--- a/packages/runtime-core/src/agent-task-run-result.ts
+++ b/packages/runtime-core/src/agent-task-run-result.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, stripUndefined } from "./object-utils.js"
+import { isPlainObject, numberValue, objectValue, stringValue, stripUndefined } from "./object-utils.js"
 import { normalizeAgentTerminalResult, type AgentTerminalResult } from "./agent-terminal-result.js"
 import { normalizeAgentTaskStatus } from "./status-taxonomy.js"
 
@@ -269,10 +269,6 @@ function artifactPath(root: string, relativePath: string): string {
   return `${root.replace(/\/$/, "")}/${relativePath.replace(/^\//, "")}`
 }
 
-function objectValue(value: unknown): Record<string, unknown> {
-  return isPlainObject(value) ? value : {}
-}
-
 function firstObject(...values: unknown[]): Record<string, unknown> {
   for (const value of values) {
     if (isPlainObject(value) && Object.keys(value).length > 0) return value
@@ -282,12 +278,4 @@ function firstObject(...values: unknown[]): Record<string, unknown> {
 
 function arrayObjects(value: unknown): Array<Record<string, unknown>> {
   return Array.isArray(value) ? value.filter(isPlainObject) : []
-}
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value.trim() : ""
-}
-
-function numberValue(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined
 }

--- a/packages/runtime-core/src/browser-result-shapes.ts
+++ b/packages/runtime-core/src/browser-result-shapes.ts
@@ -1,3 +1,5 @@
+import { isPlainObject as isRecord, stringValue } from "./object-utils.js"
+
 export const BROWSER_RESULT_SCHEMA_VERSION = 1 as const
 
 const VALID_TRACE_ENVELOPE_STATUSES = new Set(["pass", "fail", "error", "skip", "unknown"])
@@ -381,10 +383,6 @@ function roundNumber(value: number): number {
   return Math.round(value * 1000) / 1000
 }
 
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value.trim() : ""
-}
-
 function normalizePhaseName(name: unknown, options: BrowserResultShapeOptions): string {
   if (options.normalizePhaseName) {
     return options.normalizePhaseName(name)
@@ -394,10 +392,6 @@ function normalizePhaseName(name: unknown, options: BrowserResultShapeOptions): 
 
 function comparePhaseMarks(a: BrowserPhaseMark, b: BrowserPhaseMark): number {
   return a.start_time_ms - b.start_time_ms || a.name.localeCompare(b.name)
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function stripUndefined<T extends object>(value: T): T {

--- a/packages/runtime-core/src/object-utils.ts
+++ b/packages/runtime-core/src/object-utils.ts
@@ -4,6 +4,42 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+export function objectValue(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {}
+}
+
+export function optionalObjectValue(value: unknown): Record<string, unknown> | undefined {
+  return isPlainObject(value) ? value : undefined
+}
+
+export function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+export function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function parseJsonObject(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return undefined
+  }
+}
+
+export function now(): string {
+  return new Date().toISOString()
+}
+
+export function sha256(contents: string | Buffer): string {
+  return createHash("sha256").update(contents).digest("hex")
+}
+
 export function stableJson(value: unknown): string {
   return stableJsonValue(value, new WeakSet(), 0)
 }

--- a/packages/runtime-core/src/status-taxonomy.ts
+++ b/packages/runtime-core/src/status-taxonomy.ts
@@ -1,3 +1,5 @@
+import { stringValue } from "./object-utils.js"
+
 export type CommandEnvelopeStatus = "completed" | "failed" | "timed_out" | "cancelled" | "running" | "queued" | (string & {})
 export type PhaseRecipeStatus = "succeeded" | "failed" | "partial" | "blocked" | "skipped" | "running" | (string & {})
 export type AgentTaskStatus = "succeeded" | "failed" | "no_op" | "timeout" | "provider_error" | "unable_to_remediate" | (string & {})
@@ -69,8 +71,4 @@ export function agentTaskStatusFailed(status: unknown): boolean {
 
 function numericExitStatus(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0
-}
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value.trim() : ""
 }

--- a/packages/runtime-playground/src/browser-auth-storage-state.ts
+++ b/packages/runtime-playground/src/browser-auth-storage-state.ts
@@ -1,3 +1,5 @@
+import { isPlainObject as isRecord } from "@automattic/wp-codebox-core/internals"
+
 export interface WordPressFixtureUserSpec {
   userId?: number
   username?: string
@@ -148,10 +150,6 @@ function normalizeBrowserStorageStateOrigin(origin: unknown): BrowserAuthStorage
       return { name: String(item.name ?? ""), value: String(item.value ?? "") }
     }),
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 export function wordpressFixtureUserStorageStatePhpCode({

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -1,7 +1,7 @@
-import { createHash } from "node:crypto"
 import { access, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative } from "node:path"
 import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, redactString, resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
 import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
@@ -3738,16 +3738,8 @@ class BrowserStorageStateImportError extends Error {
   }
 }
 
-function now(): string {
-  return new Date().toISOString()
-}
-
 async function fileSha256(path: string): Promise<string> {
   return sha256(await readFile(path))
-}
-
-function sha256(contents: Buffer): string {
-  return createHash("sha256").update(contents).digest("hex")
 }
 
 type BrowserProbeProgressSource = "navigation" | "network" | "console" | "pageerror" | "checkpoint" | "script" | "duration" | "probe-error"

--- a/packages/runtime-playground/src/browser-interactions.ts
+++ b/packages/runtime-playground/src/browser-interactions.ts
@@ -1,4 +1,5 @@
 import type { BrowserInteractionStep } from "@automattic/wp-codebox-core"
+import { now } from "@automattic/wp-codebox-core/internals"
 import type { Frame, Page } from "playwright"
 import { browserActionLoadState, browserDeepEqual, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import type { BrowserProbeErrorRecord, BrowserStepAssertion, BrowserStepReadiness, BrowserStepRecord } from "./browser-artifacts.js"
@@ -29,10 +30,6 @@ interface BrowserPaintedReadinessTarget {
   frame: Page | Frame
   selector?: string
   urlFragment?: string
-}
-
-function now(): string {
-  return new Date().toISOString()
 }
 
 export async function executeBrowserInteractionStep(

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto"
 import { access, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { redactString, type ArtifactManifest } from "@automattic/wp-codebox-core"
+import { isPlainObject as isRecord, now } from "@automattic/wp-codebox-core/internals"
 import type { ConsoleMessage, Request, Response } from "playwright"
 import type {
   BrowserArtifact,
@@ -25,14 +26,6 @@ export interface BrowserArtifactMetricsResult {
   hasBrowserMetrics: boolean
   metrics: Record<string, number>
   artifacts: Record<string, { path: string; kind: "json" | "jsonl" }>
-}
-
-function now(): string {
-  return new Date().toISOString()
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 export function browserProbeMemorySummary(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbeMemorySummary {

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -1,5 +1,6 @@
 import type { Frame, Page } from "playwright"
 import { BROWSER_PROBE_CAPTURE_VALUES } from "@automattic/wp-codebox-core"
+import { now } from "@automattic/wp-codebox-core/internals"
 import type {
   BrowserProbeCheckpointRecord,
   BrowserProbeErrorRecord,
@@ -206,10 +207,6 @@ export const BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT = `
   }
 })();
 `
-
-function now(): string {
-  return new Date().toISOString()
-}
 
 export async function navigateBrowserProbe(page: Page, url: string, waitFor: string, durationMs: number, navigationTimeoutMs = 30_000): Promise<void> {
   if (["domcontentloaded", "load", "networkidle"].includes(waitFor)) {

--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -1,7 +1,7 @@
-import { createHash } from "node:crypto"
 import { access, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative } from "node:path"
 import type { ExecutionSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { errorMessage, now, sha256 } from "@automattic/wp-codebox-core/internals"
 import pixelmatch from "pixelmatch"
 import { PNG } from "pngjs"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
@@ -883,10 +883,6 @@ function visualCompareMatrixOptions(args: string[]): Record<string, unknown> {
   }
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
-}
-
 interface VisualComparePairSummary {
   status: string
   source: Record<string, unknown>
@@ -1753,16 +1749,8 @@ function visualCompareDiffPixel(diff: PNG, x: number, y: number): boolean {
   return diff.data[offset] > 0 || diff.data[offset + 1] > 0 || diff.data[offset + 2] > 0
 }
 
-function now(): string {
-  return new Date().toISOString()
-}
-
 async function fileSha256(path: string): Promise<string> {
   return sha256(await readFile(path))
-}
-
-function sha256(contents: Buffer): string {
-  return createHash("sha256").update(contents).digest("hex")
 }
 
 function numberArg(args: string[], name: string, fallback: number): number {

--- a/packages/runtime-playground/src/playground-command-errors.ts
+++ b/packages/runtime-playground/src/playground-command-errors.ts
@@ -1,4 +1,7 @@
 import { isSensitiveKey } from "@automattic/wp-codebox-core"
+import { errorMessage, parseJsonObject } from "@automattic/wp-codebox-core/internals"
+
+export { errorMessage }
 
 export interface PlaygroundRunResponse {
   bytes?: unknown
@@ -47,10 +50,6 @@ export function assertPlaygroundResponseOk(command: string, response: Playground
   if (typeof response.exitCode === "number" && response.exitCode !== 0) {
     throw new PlaygroundCommandError(command, response)
   }
-}
-
-export function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
 }
 
 /**
@@ -409,14 +408,6 @@ function decodeByteMapText(text: string): string | undefined {
   }
 
   return new TextDecoder().decode(Uint8Array.from(bytes)).trim()
-}
-
-function parseJsonObject(text: string): unknown {
-  try {
-    return JSON.parse(text)
-  } catch {
-    return undefined
-  }
 }
 
 function findByteMap(value: unknown, seen = new Set<unknown>()): number[] | undefined {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1,8 +1,9 @@
-import { createHash, randomBytes } from "node:crypto"
+import { randomBytes } from "node:crypto"
 import { mkdir, realpath, writeFile } from "node:fs/promises"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { dirname, join, resolve } from "node:path"
 import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, createHostToolRegistry, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
+import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
 import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand, wordpressAdminAuthCookiePhpCode } from "./browser-command-runners.js"
@@ -46,10 +47,6 @@ import type {
   RuntimeCommandResultEnvelope,
   Snapshot,
 } from "@automattic/wp-codebox-core"
-function now(): string {
-  return new Date().toISOString()
-}
-
 function id(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
@@ -1109,10 +1106,6 @@ export const playgroundRuntimeBackendProvider: RuntimeBackendProvider = {
   createBackend(context = {}) {
     return createPlaygroundRuntimeBackend({ cliModule: context.cliModule as PlaygroundCliModule | undefined })
   },
-}
-
-function sha256(contents: Buffer): string {
-  return createHash("sha256").update(contents).digest("hex")
 }
 
 function stringArg(args: string[], name: string): string | undefined {

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -1177,21 +1177,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @return string[] */
 	private function string_list( mixed $values ): array {
-		if ( ! is_array( $values ) ) {
-			return array();
-		}
-
-		return array_values(
-			array_unique(
-				array_filter(
-					array_map(
-						static fn( $value ): string => trim( (string) $value ),
-						$values
-					),
-					static fn( string $value ): bool => '' !== $value
-				)
-			)
-		);
+		return WP_Codebox_Agent_Task::string_list( $values );
 	}
 
 	/** @return string[] */

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-request-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-request-normalizer.php
@@ -74,21 +74,7 @@ final class WP_Codebox_Host_Request_Normalizer {
 
 	/** @return string[] */
 	private function string_list( mixed $values ): array {
-		if ( ! is_array( $values ) ) {
-			return array();
-		}
-
-		return array_values(
-			array_unique(
-				array_filter(
-					array_map(
-						static fn( $value ): string => trim( (string) $value ),
-						$values
-					),
-					static fn( string $value ): bool => '' !== $value
-				)
-			)
-		);
+		return WP_Codebox_Agent_Task::string_list( $values );
 	}
 
 	/** @return string[] */

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-tool-policy-validator.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-tool-policy-validator.php
@@ -22,25 +22,6 @@ final class WP_Codebox_Host_Tool_Policy_Validator {
 
 	/** @param array<string,mixed> $task_input Normalized task input. */
 	public function validate_task_tools( array $task_input ): WP_Error|null {
-		return $this->normalizer->validate_task_tools( $this->string_list( $task_input['allowed_tools'] ?? array() ), $task_input );
-	}
-
-	/** @return string[] */
-	private function string_list( mixed $values ): array {
-		if ( ! is_array( $values ) ) {
-			return array();
-		}
-
-		return array_values(
-			array_unique(
-				array_filter(
-					array_map(
-						static fn( $value ): string => trim( (string) $value ),
-						$values
-					),
-					static fn( string $value ): bool => '' !== $value
-				)
-			)
-		);
+		return $this->normalizer->validate_task_tools( WP_Codebox_Agent_Task::string_list( $task_input['allowed_tools'] ?? array() ), $task_input );
 	}
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-sandbox-tool-policy-normalizer.php
@@ -27,7 +27,7 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 	public function normalize_for_task_input( array $input ): array|WP_Error {
 		$policy = is_array( $input['sandbox_tool_policy'] ?? null ) ? $input['sandbox_tool_policy'] : array();
 		if ( empty( $policy ) ) {
-			$policy = $this->from_allowed_tools( $this->string_list( $input['allowed_tools'] ?? array() ), $input );
+			$policy = $this->from_allowed_tools( WP_Codebox_Agent_Task::string_list( $input['allowed_tools'] ?? array() ), $input );
 		}
 		if ( empty( $policy ) && function_exists( 'apply_filters' ) ) {
 			$policy = apply_filters( 'wp_codebox_resolved_sandbox_tool_policy', $policy, $input );
@@ -57,7 +57,7 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 		}
 
 		$denied = array();
-		foreach ( $this->string_list( $tools ) as $tool ) {
+		foreach ( WP_Codebox_Agent_Task::string_list( $tools ) as $tool ) {
 			$descriptor = $this->descriptor_resolver->resolve_runtime_tool_alias( $policy, $tool );
 			$reason     = $this->descriptor_resolver->denial_reason( $descriptor );
 			if ( null !== $reason ) {
@@ -88,7 +88,7 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 	/** @param string[] $allowed_tools @param array<string,mixed> $context @return array<string,mixed> */
 	public function from_allowed_tools( array $allowed_tools, array $context = array() ): array {
 		$policy_tools = array();
-		foreach ( $this->string_list( $allowed_tools ) as $tool_id ) {
+		foreach ( WP_Codebox_Agent_Task::string_list( $allowed_tools ) as $tool_id ) {
 			$tool = $this->tool_policy_entry( $tool_id, $context );
 			if ( ! empty( $tool ) ) {
 				$policy_tools[] = $tool;
@@ -203,25 +203,6 @@ final class WP_Codebox_Sandbox_Tool_Policy_Normalizer {
 
 	private function provider_safe_runtime_tool_id( string $tool_id ): string {
 		return trim( preg_replace( '/[^A-Za-z0-9_]+/', '_', $tool_id ) ?? '', '_' );
-	}
-
-	/** @return string[] */
-	private function string_list( mixed $values ): array {
-		if ( ! is_array( $values ) ) {
-			return array();
-		}
-
-		return array_values(
-			array_unique(
-				array_filter(
-					array_map(
-						static fn( $value ): string => trim( (string) $value ),
-						$values
-					),
-					static fn( string $value ): bool => '' !== $value
-				)
-			)
-		);
 	}
 
 }


### PR DESCRIPTION
## Summary
- add shared runtime-core utility primitives for record/string/number parsing, JSON parsing, error messages, timestamps, and sha256 hashing
- replace matching duplicated TypeScript helpers in runtime-core and runtime-playground with shared imports
- route PHP task tool-policy list normalization through the existing shared task helper where the dependency is safe

## Testing
- npm run build
- npm run test:agent-task-contracts
- npm run test:php-tool-policy-normalization
- npm run test:primitive-contract-parity
- npm run test:php-primitive-contract-parity
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted and verified the utility consolidation changes; Chris remains responsible for review and merge.