### PR TITLE
Extract PHP agent run result builder

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Host-side WP Codebox agent batch and fanout result envelopes.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Agent_Run_Result_Builder {
+
+	private const SESSION_SCHEMA = WP_Codebox_Agent_Task::SESSION_SCHEMA;
+
+	private WP_Codebox_Run_Plan $run_plan;
+
+	public function __construct( ?WP_Codebox_Run_Plan $run_plan = null ) {
+		$this->run_plan = $run_plan ?? new WP_Codebox_Run_Plan();
+	}
+
+	/** @param array<string,mixed> $task_input Normalized task input. @param array<string,mixed> $task_result Single task run result. @return array<string,mixed> */
+	public function batch_success_run( int $index, array $task_input, array $task_result ): array {
+		return array(
+			'index'              => $index,
+			'task'               => (string) $task_input['goal'],
+			'task_input'         => $task_input,
+			'success'            => true,
+			'status'             => 'completed',
+			'exit_code'          => (int) ( $task_result['exit_code'] ?? 0 ),
+			'session'            => $task_result['session'] ?? array(),
+			'artifact_id'        => (string) ( $task_result['session']['artifacts']['bundle_id'] ?? '' ),
+			'preview_url'        => (string) ( $task_result['session']['artifacts']['preview_url'] ?? '' ),
+			'artifacts'          => $task_result['session']['artifacts'] ?? array(),
+			'agent_result'       => $task_result['agent_result'] ?? array(),
+			'agent_task_result'  => $task_result['agent_task_result'] ?? array(),
+			'completion_outcome' => $task_result['completion_outcome'] ?? array(),
+			'run'                => $task_result['run'] ?? array(),
+		);
+	}
+
+	/** @param array<string,mixed> $task_input Normalized task input. @return array<string,mixed> */
+	public function batch_error_run( int $index, array $task_input, WP_Error $error ): array {
+		return array(
+			'index'      => $index,
+			'task'       => (string) $task_input['goal'],
+			'task_input' => $task_input,
+			'success'    => false,
+			'status'     => 'failed',
+			'error'      => $this->error_payload( $error ),
+		);
+	}
+
+	/** @param array<string,mixed> $session Parent sandbox session. @param array<int,string> $tasks Task labels. @param array<int,array<string,mixed>> $task_inputs Normalized task inputs. @param array<int,array<string,mixed>> $runs Child runs. @param array<int,array<string,mixed>> $paths Component paths. @return array<string,mixed> */
+	public function batch_result( string $schema, array $session, array $tasks, array $task_inputs, string $execution, string $wp_version, array $paths, string $artifacts, array $runs ): array {
+		$completed = count( array_filter( $runs, static fn( array $run ): bool => true === ( $run['success'] ?? false ) ) );
+		$failed    = count( $runs ) - $completed;
+
+		return array(
+			'success'     => 0 === $failed,
+			'schema'      => $schema,
+			'session'     => $session,
+			'tasks'       => $tasks,
+			'task_inputs' => $task_inputs,
+			'execution'   => $execution,
+			'total'       => count( $runs ),
+			'completed'   => $completed,
+			'failed'      => $failed,
+			'wp'          => $wp_version,
+			'paths'       => $paths,
+			'artifacts'   => $artifacts,
+			'runs'        => $runs,
+		);
+	}
+
+	/** @param array<string,mixed> $worker Worker metadata. @param array<string,mixed> $result Worker result. @return array<string,mixed> */
+	public function fanout_worker_success_result( array $worker, array $result, float $started_at, float $ended_at ): array {
+		$session   = is_array( $result['session'] ?? null ) ? $result['session'] : array();
+		$artifacts = is_array( $session['artifacts'] ?? null ) ? $session['artifacts'] : array();
+
+		return array(
+			'worker_id'          => (string) $worker['id'],
+			'index'              => (int) $worker['index'],
+			'success'            => true,
+			'status'             => 'completed',
+			'agent'              => (string) ( $worker['prepared']['input']['agent'] ?? '' ),
+			'exit_code'          => (int) ( $result['exit_code'] ?? 0 ),
+			'session'            => $session,
+			'artifacts'          => array_merge( $artifacts, array( 'namespace' => (string) $worker['id'], 'result' => 'result.json' ) ),
+			'diagnostics'        => is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array(),
+			'evidence_refs'      => is_array( $result['evidence_refs'] ?? null ) ? $result['evidence_refs'] : array(),
+			'completion_outcome' => is_array( $result['completion_outcome'] ?? null ) ? $result['completion_outcome'] : array(),
+			'timings'            => $this->timings( $started_at, $ended_at ),
+		);
+	}
+
+	/** @param array<string,mixed> $worker Worker metadata. @return array<string,mixed> */
+	public function fanout_worker_error_result( array $worker, WP_Error $error, float $started_at, float $ended_at ): array {
+		$prepared  = is_array( $worker['prepared'] ?? null ) ? $worker['prepared'] : array();
+		$input     = is_array( $prepared['input'] ?? null ) ? $prepared['input'] : array();
+		$artifacts = (string) ( $prepared['artifacts'] ?? ( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'artifacts' ) );
+
+		return array(
+			'worker_id' => (string) $worker['id'],
+			'index'     => (int) $worker['index'],
+			'success'   => false,
+			'status'    => 'failed',
+			'agent'     => (string) ( $input['agent'] ?? '' ),
+			'session'   => array_filter(
+				array(
+					'schema' => self::SESSION_SCHEMA,
+					'id'     => (string) ( $prepared['session_id'] ?? '' ),
+					'status' => 'failed',
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			),
+			'artifacts' => array(
+				'path'      => $artifacts,
+				'namespace' => (string) $worker['id'],
+				'result'    => 'result.json',
+			),
+			'error'     => $this->error_payload( $error ),
+			'timings'   => array_filter(
+				array(
+					'started_at'  => $started_at > 0 ? gmdate( 'c', (int) $started_at ) : '',
+					'ended_at'    => $ended_at > 0 ? gmdate( 'c', (int) $ended_at ) : '',
+					'duration_ms' => $started_at > 0 && $ended_at > 0 ? (int) round( ( $ended_at - $started_at ) * 1000 ) : null,
+				),
+				static fn( mixed $value ): bool => null !== $value && '' !== $value
+			),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array<int,array<string,mixed>> $runs Child runs. @return array<string,mixed> */
+	public function fanout_parent_session( string $session_id, string $status, array $input, array $paths, array $runs ): array {
+		$children = array_map(
+			static fn( array $run ): array => array_filter(
+				array(
+					'worker_id'  => (string) ( $run['worker_id'] ?? '' ),
+					'session_id' => (string) ( $run['session']['id'] ?? '' ),
+					'status'     => (string) ( $run['status'] ?? '' ),
+					'artifacts'  => is_array( $run['artifacts'] ?? null ) ? $run['artifacts'] : array(),
+				),
+				static fn( mixed $value ): bool => '' !== $value && array() !== $value
+			),
+			$runs
+		);
+
+		$session = WP_Codebox_Agent_Task::session(
+			$session_id,
+			$status,
+			$input,
+			array(
+				'path'      => $paths['root'],
+				'plan'      => 'plan.json',
+				'events'    => 'events.jsonl',
+				'result'    => 'result.json',
+				'aggregate' => 'aggregate/result.json',
+			)
+		);
+		$session['children'] = $children;
+
+		return $session;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array{total:int,completed:int,failed:int,cancelled:int} $counts Counts. @param array<string,mixed> $plan Plan. @param array<int,array<string,mixed>> $runs Child run results. @return array<string,mixed> */
+	public function fanout_result( string $schema, string $artifact_schema, string $execution, string $session_id, string $status, array $input, array $paths, array $counts, float $started_at, float $ended_at, array $plan, array $runs ): array {
+		$success = $this->run_plan->succeeded( $counts );
+
+		return array(
+			'success'      => $success,
+			'schema'       => $schema,
+			'execution'    => $execution,
+			'session'      => $this->fanout_parent_session( $session_id, $status, $input, $paths, $runs ),
+			'concurrency'  => (int) $plan['concurrency'],
+			'total'        => $counts['total'],
+			'completed'    => $counts['completed'],
+			'failed'       => $counts['failed'],
+			'cancelled'    => $counts['cancelled'],
+			'timings'      => $this->timings( $started_at, $ended_at ),
+			'artifacts'    => $this->run_plan->artifacts( $artifact_schema, $paths ),
+			'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
+			'runs'         => $runs,
+			'failures'     => $this->run_plan->failures( $runs ),
+		);
+	}
+
+	/** @return array{total:int,completed:int,failed:int,cancelled:int} */
+	public function status_counts( array $runs ): array {
+		return $this->run_plan->result_counts( $runs );
+	}
+
+	/** @return array<string,mixed> */
+	private function error_payload( WP_Error $error ): array {
+		return array_filter(
+			array(
+				'code'    => $error->get_error_code(),
+				'message' => $error->get_error_message(),
+				'data'    => $error->get_error_data(),
+			),
+			static fn( mixed $value ): bool => null !== $value && array() !== $value && '' !== $value
+		);
+	}
+
+	/** @return array{started_at:string,ended_at:string,duration_ms:int} */
+	private function timings( float $started_at, float $ended_at ): array {
+		return array(
+			'started_at'  => gmdate( 'c', (int) $started_at ),
+			'ended_at'    => gmdate( 'c', (int) $ended_at ),
+			'duration_ms' => (int) round( ( $ended_at - $started_at ) * 1000 ),
+		);
+	}
+}

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -18,7 +18,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const FANOUT_ARTIFACTS_SCHEMA = 'wp-codebox/agent-fanout-artifacts/v1';
 	private const DEFAULT_WORDPRESS_VERSION = 'latest';
 	private const FANOUT_MAX_CONCURRENCY = 8;
-	private const SESSION_SCHEMA = WP_Codebox_Agent_Task::SESSION_SCHEMA;
 	private const TASK_INPUT_SCHEMA = WP_Codebox_Agent_Task::INPUT_SCHEMA;
 	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
 	private const REMEDIATION_OUTCOME_SCHEMA = 'wp-codebox/agent-sandbox-remediation-outcome/v1';
@@ -36,6 +35,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private WP_Codebox_Host_Tool_Policy_Validator $tool_policy_validator;
 	private WP_Codebox_Host_Recipe_Builder $recipe_builder;
 	private WP_Codebox_Host_Run_Result_Normalizer $run_result_normalizer;
+	private WP_Codebox_Agent_Run_Result_Builder $result_builder;
 	private WP_Codebox_Parent_Site_Seed_Exporter $site_seed_exporter;
 	private WP_Codebox_Run_Plan $run_plan;
 	private WP_Codebox_Agent_Process_Runner $process_runner;
@@ -52,6 +52,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$this->site_seed_exporter    = new WP_Codebox_Parent_Site_Seed_Exporter();
 		$this->run_plan              = new WP_Codebox_Run_Plan();
 		$this->process_runner        = new WP_Codebox_Agent_Process_Runner( $callbacks );
+		$this->result_builder        = new WP_Codebox_Agent_Run_Result_Builder( $this->run_plan );
 	}
 
 	/**
@@ -140,13 +141,14 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		ksort( $runs );
 		$runs = array_values( $runs );
 
-		$counts = $this->run_plan->result_counts( $runs );
+		$counts = $this->result_builder->status_counts( $runs );
 		$success = $this->run_plan->succeeded( $counts );
 		$status  = $success ? 'completed' : 'failed';
 		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.started', 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'cancelled' => $counts['cancelled'] ) );
 
-		$result = $this->run_plan_result(
+		$result = $this->result_builder->fanout_result(
 			self::FANOUT_SCHEMA,
+			self::FANOUT_ARTIFACTS_SCHEMA,
 			'bounded-concurrent-isolated-sandboxes',
 			$parent_session_id,
 			$status,
@@ -317,52 +319,23 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 			$task_result = $this->run( $task_input_request );
 			if ( is_wp_error( $task_result ) ) {
-				$runs[] = array(
-					'index'      => $index,
-					'task'       => (string) $task_input['goal'],
-					'task_input' => $task_input,
-					'success'    => false,
-					'status'     => 'failed',
-					'error'      => $this->error_payload( $task_result ),
-				);
+				$runs[] = $this->result_builder->batch_error_run( $index, $task_input, $task_result );
 				continue;
 			}
 
-			$runs[] = array(
-				'index'       => $index,
-				'task'        => (string) $task_input['goal'],
-				'task_input'  => $task_input,
-				'success'     => true,
-				'status'      => 'completed',
-				'exit_code'   => (int) ( $task_result['exit_code'] ?? 0 ),
-				'session'     => $task_result['session'] ?? array(),
-				'artifact_id' => (string) ( $task_result['session']['artifacts']['bundle_id'] ?? '' ),
-				'preview_url' => (string) ( $task_result['session']['artifacts']['preview_url'] ?? '' ),
-				'artifacts'    => $task_result['session']['artifacts'] ?? array(),
-				'agent_result' => $task_result['agent_result'] ?? array(),
-				'agent_task_result' => $task_result['agent_task_result'] ?? array(),
-				'completion_outcome' => $task_result['completion_outcome'] ?? array(),
-				'run'          => $task_result['run'] ?? array(),
-			);
+			$runs[] = $this->result_builder->batch_success_run( $index, $task_input, $task_result );
 		}
 
-		$completed = count( array_filter( $runs, static fn( array $run ): bool => true === ( $run['success'] ?? false ) ) );
-		$failed    = count( $runs ) - $completed;
-
-		return array(
-			'success'     => 0 === $failed,
-			'schema'      => self::BATCH_SCHEMA,
-			'session'     => $this->sandbox_session( $session_id, 'completed', $input, array(), $artifacts ),
-			'tasks'       => $tasks,
-			'task_inputs' => $task_inputs,
-			'execution'   => 'sequential-isolated-sandboxes',
-			'total'       => count( $runs ),
-			'completed'   => $completed,
-			'failed'      => $failed,
-			'wp'          => $wp_version,
-			'paths'       => $paths,
-			'artifacts'   => $artifacts,
-			'runs'        => $runs,
+		return $this->result_builder->batch_result(
+			self::BATCH_SCHEMA,
+			$this->sandbox_session( $session_id, 'completed', $input, array(), $artifacts ),
+			$tasks,
+			$task_inputs,
+			'sequential-isolated-sandboxes',
+			$wp_version,
+			$paths,
+			$artifacts,
+			$runs
 		);
 	}
 
@@ -376,42 +349,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$descriptors = array_map( static fn( array $worker ): array => $worker['_run_plan_descriptor'], $workers );
 
 		return $this->run_plan->plan( $schema, $session_id, $concurrency, is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(), $descriptors );
-	}
-
-	/** @param array<string,string> $paths Run-plan artifact paths. @return array<string,mixed> */
-	private function run_plan_artifacts( string $schema, array $paths ): array {
-		return $this->run_plan->artifacts( $schema, $paths );
-	}
-
-	/** @param array<int,array<string,mixed>> $runs Child run results. @return array<int,array<string,mixed>> */
-	private function run_plan_failures( array $runs ): array {
-		return $this->run_plan->failures( $runs );
-	}
-
-	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array{total:int,completed:int,failed:int,cancelled:int} $counts Counts. @param array<string,mixed> $plan Plan. @param array<int,array<string,mixed>> $runs Child run results. @return array<string,mixed> */
-	private function run_plan_result( string $schema, string $execution, string $session_id, string $status, array $input, array $paths, array $counts, float $started_at, float $ended_at, array $plan, array $runs ): array {
-		$success = $this->run_plan->succeeded( $counts );
-
-		return array(
-			'success'     => $success,
-			'schema'      => $schema,
-			'execution'   => $execution,
-			'session'     => $this->run_plan_parent_session( $session_id, $status, $input, $paths, $runs ),
-			'concurrency' => (int) $plan['concurrency'],
-			'total'       => $counts['total'],
-			'completed'   => $counts['completed'],
-			'failed'      => $counts['failed'],
-			'cancelled'   => $counts['cancelled'],
-			'timings'     => array(
-				'started_at'  => gmdate( 'c', (int) $started_at ),
-				'ended_at'    => gmdate( 'c', (int) $ended_at ),
-				'duration_ms' => (int) round( ( $ended_at - $started_at ) * 1000 ),
-			),
-			'artifacts'   => $this->run_plan_artifacts( self::FANOUT_ARTIFACTS_SCHEMA, $paths ),
-			'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
-			'runs'        => $runs,
-			'failures'    => $this->run_plan_failures( $runs ),
-		);
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
@@ -486,14 +423,14 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				++$next;
 
 				if ( is_wp_error( $item['error'] ?? null ) ) {
-					$runs[ (int) $item['index'] ] = $this->fanout_worker_error_result( $item, $item['error'], 0, 0 );
+					$runs[ (int) $item['index'] ] = $this->result_builder->fanout_worker_error_result( $item, $item['error'], 0, 0 );
 					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $item['index'] ] );
 					continue;
 				}
 
 				$started = $this->process_runner->start_fanout_worker_process( $item );
 				if ( is_wp_error( $started ) ) {
-					$runs[ (int) $item['index'] ] = $this->fanout_worker_error_result( $item, $started, 0, 0 );
+					$runs[ (int) $item['index'] ] = $this->result_builder->fanout_worker_error_result( $item, $started, 0, 0 );
 					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $item['index'] ] );
 					continue;
 				}
@@ -513,7 +450,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				$result = $captured['result'];
 
 				$completed = $this->complete_agent_task_run( $worker['prepared'], $result );
-				$runs[ (int) $worker['index'] ] = is_wp_error( $completed ) ? $this->fanout_worker_error_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) ) : $this->fanout_worker_success_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) );
+				$runs[ (int) $worker['index'] ] = is_wp_error( $completed ) ? $this->result_builder->fanout_worker_error_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) ) : $this->result_builder->fanout_worker_success_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) );
 				$this->write_json_file( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $worker['index'] ] );
 				$this->append_fanout_event( $fanout_path, array( 'event' => true === ( $runs[ (int) $worker['index'] ]['success'] ?? false ) ? 'worker.completed' : 'worker.failed', 'worker_id' => (string) $worker['id'], 'status' => (string) $runs[ (int) $worker['index'] ]['status'] ) );
 				unset( $active[ $active_index ] );
@@ -527,100 +464,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		}
 
 		return $runs;
-	}
-
-	/** @param array<string,mixed> $worker Worker metadata. @param array<string,mixed> $result Worker result. @return array<string,mixed> */
-	private function fanout_worker_success_result( array $worker, array $result, float $started_at, float $ended_at ): array {
-		$session   = is_array( $result['session'] ?? null ) ? $result['session'] : array();
-		$artifacts = is_array( $session['artifacts'] ?? null ) ? $session['artifacts'] : array();
-
-		return array(
-			'worker_id'   => (string) $worker['id'],
-			'index'       => (int) $worker['index'],
-			'success'     => true,
-			'status'      => 'completed',
-			'agent'       => (string) ( $worker['prepared']['input']['agent'] ?? '' ),
-			'exit_code'   => (int) ( $result['exit_code'] ?? 0 ),
-			'session'     => $session,
-			'artifacts'   => array_merge( $artifacts, array( 'namespace' => (string) $worker['id'], 'result' => 'result.json' ) ),
-			'diagnostics' => is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array(),
-			'evidence_refs' => is_array( $result['evidence_refs'] ?? null ) ? $result['evidence_refs'] : array(),
-			'completion_outcome' => is_array( $result['completion_outcome'] ?? null ) ? $result['completion_outcome'] : array(),
-			'timings'     => array(
-				'started_at'  => gmdate( 'c', (int) $started_at ),
-				'ended_at'    => gmdate( 'c', (int) $ended_at ),
-				'duration_ms' => (int) round( ( $ended_at - $started_at ) * 1000 ),
-			),
-		);
-	}
-
-	/** @param array<string,mixed> $worker Worker metadata. */
-	private function fanout_worker_error_result( array $worker, WP_Error $error, float $started_at, float $ended_at ): array {
-		$prepared  = is_array( $worker['prepared'] ?? null ) ? $worker['prepared'] : array();
-		$input     = is_array( $prepared['input'] ?? null ) ? $prepared['input'] : array();
-		$artifacts = (string) ( $prepared['artifacts'] ?? ( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'artifacts' ) );
-
-		return array(
-			'worker_id' => (string) $worker['id'],
-			'index'     => (int) $worker['index'],
-			'success'   => false,
-			'status'    => 'failed',
-			'agent'     => (string) ( $input['agent'] ?? '' ),
-			'session'   => array_filter(
-				array(
-					'schema' => self::SESSION_SCHEMA,
-					'id'     => (string) ( $prepared['session_id'] ?? '' ),
-					'status' => 'failed',
-				),
-				static fn( mixed $value ): bool => '' !== $value
-			),
-			'artifacts' => array(
-				'path'      => $artifacts,
-				'namespace' => (string) $worker['id'],
-				'result'    => 'result.json',
-			),
-			'error'    => $this->error_payload( $error ),
-			'timings'  => array_filter(
-				array(
-					'started_at'  => $started_at > 0 ? gmdate( 'c', (int) $started_at ) : '',
-					'ended_at'    => $ended_at > 0 ? gmdate( 'c', (int) $ended_at ) : '',
-					'duration_ms' => $started_at > 0 && $ended_at > 0 ? (int) round( ( $ended_at - $started_at ) * 1000 ) : null,
-				),
-				static fn( mixed $value ): bool => null !== $value && '' !== $value
-			),
-		);
-	}
-
-	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array<int,array<string,mixed>> $runs Child runs. */
-	private function run_plan_parent_session( string $session_id, string $status, array $input, array $paths, array $runs ): array {
-		$children = array_map(
-			static fn( array $run ): array => array_filter(
-				array(
-					'worker_id' => (string) ( $run['worker_id'] ?? '' ),
-					'session_id' => (string) ( $run['session']['id'] ?? '' ),
-					'status'    => (string) ( $run['status'] ?? '' ),
-					'artifacts' => is_array( $run['artifacts'] ?? null ) ? $run['artifacts'] : array(),
-				),
-				static fn( mixed $value ): bool => '' !== $value && array() !== $value
-			),
-			$runs
-		);
-
-		$session = WP_Codebox_Agent_Task::session(
-			$session_id,
-			$status,
-			$input,
-			array(
-				'path'      => $paths['root'],
-				'plan'      => 'plan.json',
-				'events'    => 'events.jsonl',
-				'result'    => 'result.json',
-				'aggregate' => 'aggregate/result.json',
-			)
-		);
-		$session['children'] = $children;
-
-		return $session;
 	}
 
 	private function ensure_directory( string $path ): bool {
@@ -2156,17 +1999,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'recipe_run_schema'  => (string) ( $run['schema'] ?? '' ),
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
-		);
-	}
-
-	private function error_payload( WP_Error $error ): array {
-		return array_filter(
-			array(
-				'code'    => $error->get_error_code(),
-				'message' => $error->get_error_message(),
-				'data'    => $error->get_error_data(),
-			),
-			static fn( mixed $value ): bool => null !== $value && array() !== $value && '' !== $value
 		);
 	}
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -18,7 +18,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const FANOUT_ARTIFACTS_SCHEMA = 'wp-codebox/agent-fanout-artifacts/v1';
 	private const DEFAULT_WORDPRESS_VERSION = 'latest';
 	private const FANOUT_MAX_CONCURRENCY = 8;
-	private const SESSION_SCHEMA = WP_Codebox_Agent_Task::SESSION_SCHEMA;
 	private const TASK_INPUT_SCHEMA = WP_Codebox_Agent_Task::INPUT_SCHEMA;
 	private const TOOL_DENIAL_SCHEMA = 'wp-codebox/tool-allowlist-denial/v1';
 	private const REMEDIATION_OUTCOME_SCHEMA = 'wp-codebox/agent-sandbox-remediation-outcome/v1';
@@ -36,6 +35,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private WP_Codebox_Host_Tool_Policy_Validator $tool_policy_validator;
 	private WP_Codebox_Host_Recipe_Builder $recipe_builder;
 	private WP_Codebox_Host_Run_Result_Normalizer $run_result_normalizer;
+	private WP_Codebox_Agent_Run_Result_Builder $result_builder;
 	private WP_Codebox_Parent_Site_Seed_Exporter $site_seed_exporter;
 	private WP_Codebox_Run_Plan $run_plan;
 
@@ -50,6 +50,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$this->run_result_normalizer = new WP_Codebox_Host_Run_Result_Normalizer();
 		$this->site_seed_exporter    = new WP_Codebox_Parent_Site_Seed_Exporter();
 		$this->run_plan              = new WP_Codebox_Run_Plan();
+		$this->result_builder        = new WP_Codebox_Agent_Run_Result_Builder( $this->run_plan );
 	}
 
 	/**
@@ -138,13 +139,14 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		ksort( $runs );
 		$runs = array_values( $runs );
 
-		$counts = $this->run_plan->result_counts( $runs );
+		$counts = $this->result_builder->status_counts( $runs );
 		$success = $this->run_plan->succeeded( $counts );
 		$status  = $success ? 'completed' : 'failed';
 		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.started', 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'cancelled' => $counts['cancelled'] ) );
 
-		$result = $this->run_plan_result(
+		$result = $this->result_builder->fanout_result(
 			self::FANOUT_SCHEMA,
+			self::FANOUT_ARTIFACTS_SCHEMA,
 			'bounded-concurrent-isolated-sandboxes',
 			$parent_session_id,
 			$status,
@@ -315,52 +317,23 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 			$task_result = $this->run( $task_input_request );
 			if ( is_wp_error( $task_result ) ) {
-				$runs[] = array(
-					'index'      => $index,
-					'task'       => (string) $task_input['goal'],
-					'task_input' => $task_input,
-					'success'    => false,
-					'status'     => 'failed',
-					'error'      => $this->error_payload( $task_result ),
-				);
+				$runs[] = $this->result_builder->batch_error_run( $index, $task_input, $task_result );
 				continue;
 			}
 
-			$runs[] = array(
-				'index'       => $index,
-				'task'        => (string) $task_input['goal'],
-				'task_input'  => $task_input,
-				'success'     => true,
-				'status'      => 'completed',
-				'exit_code'   => (int) ( $task_result['exit_code'] ?? 0 ),
-				'session'     => $task_result['session'] ?? array(),
-				'artifact_id' => (string) ( $task_result['session']['artifacts']['bundle_id'] ?? '' ),
-				'preview_url' => (string) ( $task_result['session']['artifacts']['preview_url'] ?? '' ),
-				'artifacts'    => $task_result['session']['artifacts'] ?? array(),
-				'agent_result' => $task_result['agent_result'] ?? array(),
-				'agent_task_result' => $task_result['agent_task_result'] ?? array(),
-				'completion_outcome' => $task_result['completion_outcome'] ?? array(),
-				'run'          => $task_result['run'] ?? array(),
-			);
+			$runs[] = $this->result_builder->batch_success_run( $index, $task_input, $task_result );
 		}
 
-		$completed = count( array_filter( $runs, static fn( array $run ): bool => true === ( $run['success'] ?? false ) ) );
-		$failed    = count( $runs ) - $completed;
-
-		return array(
-			'success'     => 0 === $failed,
-			'schema'      => self::BATCH_SCHEMA,
-			'session'     => $this->sandbox_session( $session_id, 'completed', $input, array(), $artifacts ),
-			'tasks'       => $tasks,
-			'task_inputs' => $task_inputs,
-			'execution'   => 'sequential-isolated-sandboxes',
-			'total'       => count( $runs ),
-			'completed'   => $completed,
-			'failed'      => $failed,
-			'wp'          => $wp_version,
-			'paths'       => $paths,
-			'artifacts'   => $artifacts,
-			'runs'        => $runs,
+		return $this->result_builder->batch_result(
+			self::BATCH_SCHEMA,
+			$this->sandbox_session( $session_id, 'completed', $input, array(), $artifacts ),
+			$tasks,
+			$task_inputs,
+			'sequential-isolated-sandboxes',
+			$wp_version,
+			$paths,
+			$artifacts,
+			$runs
 		);
 	}
 
@@ -374,42 +347,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$descriptors = array_map( static fn( array $worker ): array => $worker['_run_plan_descriptor'], $workers );
 
 		return $this->run_plan->plan( $schema, $session_id, $concurrency, is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(), $descriptors );
-	}
-
-	/** @param array<string,string> $paths Run-plan artifact paths. @return array<string,mixed> */
-	private function run_plan_artifacts( string $schema, array $paths ): array {
-		return $this->run_plan->artifacts( $schema, $paths );
-	}
-
-	/** @param array<int,array<string,mixed>> $runs Child run results. @return array<int,array<string,mixed>> */
-	private function run_plan_failures( array $runs ): array {
-		return $this->run_plan->failures( $runs );
-	}
-
-	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array{total:int,completed:int,failed:int,cancelled:int} $counts Counts. @param array<string,mixed> $plan Plan. @param array<int,array<string,mixed>> $runs Child run results. @return array<string,mixed> */
-	private function run_plan_result( string $schema, string $execution, string $session_id, string $status, array $input, array $paths, array $counts, float $started_at, float $ended_at, array $plan, array $runs ): array {
-		$success = $this->run_plan->succeeded( $counts );
-
-		return array(
-			'success'     => $success,
-			'schema'      => $schema,
-			'execution'   => $execution,
-			'session'     => $this->run_plan_parent_session( $session_id, $status, $input, $paths, $runs ),
-			'concurrency' => (int) $plan['concurrency'],
-			'total'       => $counts['total'],
-			'completed'   => $counts['completed'],
-			'failed'      => $counts['failed'],
-			'cancelled'   => $counts['cancelled'],
-			'timings'     => array(
-				'started_at'  => gmdate( 'c', (int) $started_at ),
-				'ended_at'    => gmdate( 'c', (int) $ended_at ),
-				'duration_ms' => (int) round( ( $ended_at - $started_at ) * 1000 ),
-			),
-			'artifacts'   => $this->run_plan_artifacts( self::FANOUT_ARTIFACTS_SCHEMA, $paths ),
-			'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
-			'runs'        => $runs,
-			'failures'    => $this->run_plan_failures( $runs ),
-		);
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */
@@ -484,14 +421,14 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				++$next;
 
 				if ( is_wp_error( $item['error'] ?? null ) ) {
-					$runs[ (int) $item['index'] ] = $this->fanout_worker_error_result( $item, $item['error'], 0, 0 );
+					$runs[ (int) $item['index'] ] = $this->result_builder->fanout_worker_error_result( $item, $item['error'], 0, 0 );
 					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $item['index'] ] );
 					continue;
 				}
 
 				$started = $this->start_prepared_fanout_worker( $item );
 				if ( is_wp_error( $started ) ) {
-					$runs[ (int) $item['index'] ] = $this->fanout_worker_error_result( $item, $started, 0, 0 );
+					$runs[ (int) $item['index'] ] = $this->result_builder->fanout_worker_error_result( $item, $started, 0, 0 );
 					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $item['index'] ] );
 					continue;
 				}
@@ -537,7 +474,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				}
 
 				$completed = $this->complete_agent_task_run( $worker['prepared'], $result );
-				$runs[ (int) $worker['index'] ] = is_wp_error( $completed ) ? $this->fanout_worker_error_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) ) : $this->fanout_worker_success_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) );
+				$runs[ (int) $worker['index'] ] = is_wp_error( $completed ) ? $this->result_builder->fanout_worker_error_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) ) : $this->result_builder->fanout_worker_success_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) );
 				$this->write_json_file( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $worker['index'] ] );
 				$this->append_fanout_event( $fanout_path, array( 'event' => true === ( $runs[ (int) $worker['index'] ]['success'] ?? false ) ? 'worker.completed' : 'worker.failed', 'worker_id' => (string) $worker['id'], 'status' => (string) $runs[ (int) $worker['index'] ]['status'] ) );
 				unset( $active[ $active_index ] );
@@ -584,100 +521,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'error_output' => '',
 			)
 		);
-	}
-
-	/** @param array<string,mixed> $worker Worker metadata. @param array<string,mixed> $result Worker result. @return array<string,mixed> */
-	private function fanout_worker_success_result( array $worker, array $result, float $started_at, float $ended_at ): array {
-		$session   = is_array( $result['session'] ?? null ) ? $result['session'] : array();
-		$artifacts = is_array( $session['artifacts'] ?? null ) ? $session['artifacts'] : array();
-
-		return array(
-			'worker_id'   => (string) $worker['id'],
-			'index'       => (int) $worker['index'],
-			'success'     => true,
-			'status'      => 'completed',
-			'agent'       => (string) ( $worker['prepared']['input']['agent'] ?? '' ),
-			'exit_code'   => (int) ( $result['exit_code'] ?? 0 ),
-			'session'     => $session,
-			'artifacts'   => array_merge( $artifacts, array( 'namespace' => (string) $worker['id'], 'result' => 'result.json' ) ),
-			'diagnostics' => is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array(),
-			'evidence_refs' => is_array( $result['evidence_refs'] ?? null ) ? $result['evidence_refs'] : array(),
-			'completion_outcome' => is_array( $result['completion_outcome'] ?? null ) ? $result['completion_outcome'] : array(),
-			'timings'     => array(
-				'started_at'  => gmdate( 'c', (int) $started_at ),
-				'ended_at'    => gmdate( 'c', (int) $ended_at ),
-				'duration_ms' => (int) round( ( $ended_at - $started_at ) * 1000 ),
-			),
-		);
-	}
-
-	/** @param array<string,mixed> $worker Worker metadata. */
-	private function fanout_worker_error_result( array $worker, WP_Error $error, float $started_at, float $ended_at ): array {
-		$prepared  = is_array( $worker['prepared'] ?? null ) ? $worker['prepared'] : array();
-		$input     = is_array( $prepared['input'] ?? null ) ? $prepared['input'] : array();
-		$artifacts = (string) ( $prepared['artifacts'] ?? ( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'artifacts' ) );
-
-		return array(
-			'worker_id' => (string) $worker['id'],
-			'index'     => (int) $worker['index'],
-			'success'   => false,
-			'status'    => 'failed',
-			'agent'     => (string) ( $input['agent'] ?? '' ),
-			'session'   => array_filter(
-				array(
-					'schema' => self::SESSION_SCHEMA,
-					'id'     => (string) ( $prepared['session_id'] ?? '' ),
-					'status' => 'failed',
-				),
-				static fn( mixed $value ): bool => '' !== $value
-			),
-			'artifacts' => array(
-				'path'      => $artifacts,
-				'namespace' => (string) $worker['id'],
-				'result'    => 'result.json',
-			),
-			'error'    => $this->error_payload( $error ),
-			'timings'  => array_filter(
-				array(
-					'started_at'  => $started_at > 0 ? gmdate( 'c', (int) $started_at ) : '',
-					'ended_at'    => $ended_at > 0 ? gmdate( 'c', (int) $ended_at ) : '',
-					'duration_ms' => $started_at > 0 && $ended_at > 0 ? (int) round( ( $ended_at - $started_at ) * 1000 ) : null,
-				),
-				static fn( mixed $value ): bool => null !== $value && '' !== $value
-			),
-		);
-	}
-
-	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array<int,array<string,mixed>> $runs Child runs. */
-	private function run_plan_parent_session( string $session_id, string $status, array $input, array $paths, array $runs ): array {
-		$children = array_map(
-			static fn( array $run ): array => array_filter(
-				array(
-					'worker_id' => (string) ( $run['worker_id'] ?? '' ),
-					'session_id' => (string) ( $run['session']['id'] ?? '' ),
-					'status'    => (string) ( $run['status'] ?? '' ),
-					'artifacts' => is_array( $run['artifacts'] ?? null ) ? $run['artifacts'] : array(),
-				),
-				static fn( mixed $value ): bool => '' !== $value && array() !== $value
-			),
-			$runs
-		);
-
-		$session = WP_Codebox_Agent_Task::session(
-			$session_id,
-			$status,
-			$input,
-			array(
-				'path'      => $paths['root'],
-				'plan'      => 'plan.json',
-				'events'    => 'events.jsonl',
-				'result'    => 'result.json',
-				'aggregate' => 'aggregate/result.json',
-			)
-		);
-		$session['children'] = $children;
-
-		return $session;
 	}
 
 	private function ensure_directory( string $path ): bool {
@@ -2221,17 +2064,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 				'recipe_run_schema'  => (string) ( $run['schema'] ?? '' ),
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
-		);
-	}
-
-	private function error_payload( WP_Error $error ): array {
-		return array_filter(
-			array(
-				'code'    => $error->get_error_code(),
-				'message' => $error->get_error_message(),
-				'data'    => $error->get_error_data(),
-			),
-			static fn( mixed $value ): bool => null !== $value && array() !== $value && '' !== $value
 		);
 	}
 

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -40,6 +40,7 @@ require_once __DIR__ . '/src/class-wp-codebox-parent-site-seed-exporter.php';
 require_once __DIR__ . '/src/class-wp-codebox-json.php';
 require_once __DIR__ . '/src/class-wp-codebox-run-plan.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-process-runner.php';
+require_once __DIR__ . '/src/class-wp-codebox-agent-run-result-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-runtime-invoker.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-provider-bridge.php';

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -39,6 +39,7 @@ require_once __DIR__ . '/src/class-wp-codebox-managed-host-command.php';
 require_once __DIR__ . '/src/class-wp-codebox-parent-site-seed-exporter.php';
 require_once __DIR__ . '/src/class-wp-codebox-json.php';
 require_once __DIR__ . '/src/class-wp-codebox-run-plan.php';
+require_once __DIR__ . '/src/class-wp-codebox-agent-run-result-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-runtime-invoker.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-provider-bridge.php';

--- a/scripts/php-run-plan-contract-smoke.php
+++ b/scripts/php-run-plan-contract-smoke.php
@@ -37,7 +37,10 @@ function is_wp_error( mixed $value ): bool {
     return $value instanceof WP_Error;
 }
 
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-run-plan.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php';
 
 function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
     if ( $expected !== $actual ) {
@@ -74,5 +77,67 @@ assert_same_contract( false, $run_plan->succeeded( array( 'failed' => 1, 'cancel
 $event = $run_plan->event( 'wp-codebox/agent-fanout-event/v1', array( 'event' => 'worker.completed', 'worker_id' => 'design', 'status' => 'completed' ) );
 unset( $event['time'] );
 assert_same_contract( array( 'schema' => 'wp-codebox/agent-fanout-event/v1', 'event' => 'worker.completed', 'worker_id' => 'design', 'status' => 'completed' ), $event, 'event envelope' );
+
+$builder = new WP_Codebox_Agent_Run_Result_Builder( $run_plan );
+$worker_result = $builder->fanout_worker_success_result(
+    array(
+        'id'       => 'design',
+        'index'    => 0,
+        'prepared' => array( 'input' => array( 'agent' => 'planner' ) ),
+    ),
+    array(
+        'exit_code' => 0,
+        'session'   => array(
+            'id'        => 'child-1',
+            'artifacts' => array( 'path' => '/tmp/artifacts', 'bundle_id' => 'bundle-1' ),
+        ),
+        'diagnostics'        => array( 'schema' => 'wp-codebox/agent-task-diagnostics/v1' ),
+        'evidence_refs'      => array( 'schema' => 'wp-codebox/agent-task-evidence-refs/v1' ),
+        'completion_outcome' => array( 'schema' => 'wp-codebox/sandbox-completion-outcome/v1' ),
+    ),
+    1000.0,
+    1001.25
+);
+assert_same_contract( 'completed', $worker_result['status'], 'fanout worker success status' );
+assert_same_contract( array( 'path' => '/tmp/artifacts', 'bundle_id' => 'bundle-1', 'namespace' => 'design', 'result' => 'result.json' ), $worker_result['artifacts'], 'fanout artifact result shaping' );
+
+$paths = $run_plan->paths( '/tmp/root', 'fanout' );
+$fanout_result = $builder->fanout_result(
+    'wp-codebox/agent-fanout-result/v1',
+    'wp-codebox/agent-fanout-artifacts/v1',
+    'bounded-concurrent-isolated-sandboxes',
+    'parent-1',
+    'completed',
+    array( 'session_id' => 'agent-session-1' ),
+    $paths,
+    $builder->status_counts( array( $worker_result ) ),
+    1000.0,
+    1001.25,
+    $run_plan->plan( 'wp-codebox/agent-fanout-plan/v1', 'parent-1', 2, array(), $descriptors ),
+    array( $worker_result )
+);
+assert_same_contract( true, $fanout_result['success'], 'fanout result success' );
+assert_same_contract( 'wp-codebox/agent-fanout-artifacts/v1', $fanout_result['artifacts']['schema'], 'fanout artifacts schema' );
+assert_same_contract( 'child-1', $fanout_result['session']['children'][0]['session_id'], 'fanout child session ref' );
+
+$batch_result = $builder->batch_result(
+    'wp-codebox/agent-task-batch/v1',
+    WP_Codebox_Agent_Task::session( 'batch-1', 'completed', array(), array( 'path' => '/tmp/batch' ) ),
+    array( 'Draft design direction.' ),
+    array( array( 'goal' => 'Draft design direction.' ) ),
+    'sequential-isolated-sandboxes',
+    'latest',
+    array(),
+    '/tmp/batch',
+    array(
+        $builder->batch_success_run(
+            0,
+            array( 'goal' => 'Draft design direction.' ),
+            array( 'exit_code' => 0, 'session' => array( 'artifacts' => array( 'bundle_id' => 'batch-bundle' ) ) )
+        ),
+    )
+);
+assert_same_contract( 1, $batch_result['completed'], 'batch completed count' );
+assert_same_contract( 'batch-bundle', $batch_result['runs'][0]['artifact_id'], 'batch artifact id shaping' );
 
 fwrite( STDOUT, "PHP run-plan contract smoke passed\n" );


### PR DESCRIPTION
## Summary
- Extract batch and fanout response-envelope shaping from `WP_Codebox_Agent_Sandbox_Runner` into `WP_Codebox_Agent_Run_Result_Builder`.
- Preserve the existing batch/fanout public response fields while keeping preparation and execution in the sandbox runner.
- Extend the PHP run-plan contract smoke to cover builder status counts, fanout artifact/result shaping, child session refs, and batch artifact shaping.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php && php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l packages/wordpress-plugin/wp-codebox.php && php -l scripts/php-run-plan-contract-smoke.php`
- `npm run test:agent-task-contracts`
- `npm run test:php-run-plan-contract`
- `npx tsx scripts/fanout-aggregation-contract-smoke.ts`
- `npx tsx scripts/agent-fanout-execution-smoke.ts`
- `npm run build`
- `npm run check` started and progressed through the check smoke suite, but the local tool timed out after 20 minutes at `agent-runtime-signal-smoke`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the PHP extraction, smoke coverage updates, and verification commands; Chris remains responsible for review and merge.
