### PR TITLE
Tighten primitive parity fixtures

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -69,6 +69,8 @@ export interface RuntimeDependencyPlanContractInput {
   inheritance?: { connectors?: unknown; settings?: unknown }
   agent_bundles?: unknown
   secret_env?: unknown
+  runtime_env?: unknown
+  runtimeEnv?: unknown
 }
 
 export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskInput, wpVersion: string): WorkspaceRecipe {
@@ -176,7 +178,22 @@ export function runtimeDependencyPlanContract(input: RuntimeDependencyPlanContra
     },
     agent_bundles: objectList(input.agent_bundles),
     secret_env: stringList(input.secret_env).filter((name) => /^[A-Z_][A-Z0-9_]*$/.test(name)),
+    runtime_env: runtimeEnvMap(input.runtime_env ?? input.runtimeEnv),
   })
+}
+
+function runtimeEnvMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([name, entry]) => /^[A-Z_][A-Z0-9_]*$/.test(name) && (typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean"))
+      .map(([name, entry]) => [name, runtimeEnvString(entry)]),
+  )
+}
+
+function runtimeEnvString(value: string | number | boolean): string {
+  return typeof value === "boolean" ? (value ? "1" : "") : String(value)
 }
 
 function componentManifestEntry(plugin: WorkspaceRecipeExtraPlugin): WorkspaceRecipeComponentManifestEntry {

--- a/scripts/php-primitive-contract-parity-smoke.php
+++ b/scripts/php-primitive-contract-parity-smoke.php
@@ -39,6 +39,7 @@ require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-redac
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-run-plan.php';
 
 $fixture = json_decode( file_get_contents( __DIR__ . '/../tests/fixtures/primitive-contracts.json' ), true );
 if ( ! is_array( $fixture ) ) {
@@ -117,7 +118,8 @@ $plan          = new WP_Codebox_Runtime_Dependency_Plan(
     $runtime_input['inheritance'],
     $runtime_input['inheritance_request'],
     $runtime_input['agent_bundles'],
-    $runtime_input['secret_env']
+    $runtime_input['secret_env'],
+    $runtime_input['runtime_env']
 );
 assert_same_contract( $fixture['runtimeDependencyPlan']['expected'], $plan->to_contract(), 'runtime dependency plan contract' );
 
@@ -127,5 +129,11 @@ assert_same_contract(
     $component_manifest->invoke( null, $fixture['componentManifest']['components'], $fixture['componentManifest']['providers'] ),
     'component manifest contract'
 );
+
+$run_plan = new WP_Codebox_Run_Plan();
+assert_same_contract( $fixture['runPlan']['counts'], $run_plan->result_counts( $fixture['runPlan']['children'] ), 'run-plan result counts' );
+assert_same_contract( $fixture['runPlan']['succeeded'], $run_plan->succeeded( $fixture['runPlan']['counts'] ), 'run-plan succeeded contract' );
+assert_same_contract( $fixture['runPlan']['concurrency']['defaulted'], $run_plan->normalize_concurrency( '', array( 'default_concurrency' => 3, 'max_concurrency' => 5 ) ), 'run-plan default concurrency' );
+assert_same_contract( $fixture['runPlan']['concurrency']['clamped'], $run_plan->normalize_concurrency( 99, array( 'max_concurrency' => 2 ) ), 'run-plan clamped concurrency' );
 
 fwrite( STDOUT, "PHP primitive contract parity smoke passed\n" );

--- a/scripts/primitive-contract-fixture.ts
+++ b/scripts/primitive-contract-fixture.ts
@@ -1,0 +1,198 @@
+import { writeFile } from "node:fs/promises"
+
+import {
+  componentManifestForRuntimePlugins,
+  countRunPlanChildResults,
+  normalizeRunPlanConcurrency,
+  normalizeRuntimeMountTarget,
+  redactJsonValue,
+  resolveEffectiveRuntimeToolPolicy,
+  resolveRuntimeToolAlias,
+  runPlanSucceeded,
+  runtimeDependencyPlanContract,
+  RUN_PLAN_EVENT_SCHEMA,
+  RUN_PLAN_RESULT_SCHEMA,
+  RUN_PLAN_SCHEMA,
+  safeArtifactRelativePath,
+  type SandboxToolPolicySnapshot,
+  type WorkspaceRecipeExtraPlugin,
+} from "../packages/runtime-core/src/index.js"
+
+type PathContract = { input: string; expected?: string; error?: boolean }
+
+const redactionProfiles = {
+  provider_proxy: {
+    input: {
+      provider: "generic",
+      request: {
+        authorization: "Bearer abc",
+        model: "example",
+        messages: [{ role: "user", content: "visible" }],
+      },
+    },
+  },
+}
+
+const mountTargetCases: PathContract[] = [
+  { input: "//wordpress//wp-content/plugins/plugin" },
+  { input: " \\wordpress\\wp-content\\mu-plugins\\runtime " },
+  { input: "/" },
+  { input: "/wordpress/../escape", error: true },
+  { input: "relative/runtime", error: true },
+]
+
+const artifactPathCases: PathContract[] = [
+  { input: "/files//output.json" },
+  { input: " logs\\run.json " },
+  { input: "files/../secret.txt", error: true },
+  { input: "C:/secret.txt", error: true },
+]
+
+const toolPolicySnapshot: SandboxToolPolicySnapshot = {
+  schema: "wp-codebox/sandbox-tool-policy/v1",
+  version: 1,
+  tools: [
+    {
+      id: "filesystem-write",
+      runtime_tool_id: "client/filesystem-write",
+      aliases: ["filesystem_write"],
+      execution_location: "sandbox",
+      transport_visibility: "sandbox",
+      allowed: true,
+      runtime: { environment: "runtime_local", capability_scope: "runtime_local" },
+      metadata: { schema: "example/input/v1", aliases: ["write_file"], policy: { permission: "write" } },
+    },
+    {
+      id: "browser-review",
+      runtime_tool_id: "client/browser-review",
+      execution_location: "parent",
+      transport_visibility: "parent",
+      allowed: true,
+      runtime: { environment: "control_plane", capability_scope: "control_plane" },
+    },
+    {
+      id: "internal-token",
+      runtime_tool_id: "client/internal-token",
+      execution_location: "sandbox",
+      transport_visibility: "hidden",
+      allowed: true,
+      runtime: { environment: "runtime_local", capability_scope: "runtime_local" },
+    },
+  ],
+  metadata: { source: "primitive-contracts" },
+}
+
+const statusTaxonomy = [
+  { input: { status: "succeeded" }, command: "completed", phase: "succeeded", agentTask: "succeeded", check: "passed" },
+  { input: { status: "timed_out" }, command: "timed_out", phase: "failed", agentTask: "timeout", check: "failed" },
+  { input: { status: "blocked" }, command: "failed", phase: "blocked", agentTask: "unable_to_remediate", check: "warning" },
+]
+
+const runtimeDependencyPlanInput = {
+  selection: { agent: "wp-codebox-sandbox", mode: "sandbox", provider: "openai", model: "gpt-test", empty: "" },
+  provider_plugin_paths: ["/runtime/providers/openai", "/runtime/providers/openai", ""],
+  provider_plugins: [{ source: "/runtime/providers/openai", slug: "ai-provider-for-openai", activate: false }],
+  component_plugins: [
+    {
+      source: "/workspace/plugin",
+      slug: "demo-plugin",
+      pluginFile: "demo-plugin/demo.php",
+      loadAs: "plugin",
+      activate: true,
+      metadata: { componentContract: { index: 2, requestedPath: "/workspace/plugin" } },
+    },
+  ],
+  runtime_overlays: [{ kind: "composer-package", source: "/runtime/overlays/pkg" }],
+  inheritance_request: { connectors: ["openai", "openai", ""], settings: ["model"] },
+  inheritance: { connectors: [{ id: "openai", status: "available" }], settings: [{ name: "model", status: "resolved" }] },
+  agent_bundles: [{ source: "/workspace/agent-bundle" }],
+  secret_env: ["OPENAI_API_KEY", "bad-name", "OPENAI_API_KEY"],
+  runtime_env: { WP_ENVIRONMENT_TYPE: "local", badName: "ignored", WP_DEBUG: true },
+}
+
+const componentManifestComponents: WorkspaceRecipeExtraPlugin[] = [
+  {
+    source: "/workspace/plugin",
+    slug: "demo-plugin",
+    pluginFile: "demo-plugin/demo.php",
+    loadAs: "plugin",
+    activate: true,
+    metadata: { componentContract: { index: 2, requestedPath: "/workspace/plugin" }, sourceKind: "local" },
+  },
+  { source: "/workspace/mu", slug: "demo-mu", pluginFile: "demo-mu/demo-mu.php", loadAs: "mu-plugin", activate: false },
+]
+
+const componentManifestProviders: WorkspaceRecipeExtraPlugin[] = [
+  { source: "/runtime/providers/openai", slug: "ai-provider-for-openai", pluginFile: "ai-provider-for-openai/provider.php", loadAs: "plugin", activate: false },
+]
+
+const runPlanChildren = [
+  { success: true, status: "succeeded" },
+  { success: false, status: "failed" },
+  { success: false, status: "cancelled" },
+]
+
+export function primitiveContractsFixture(): Record<string, unknown> {
+  const effectiveToolPolicy = resolveEffectiveRuntimeToolPolicy(toolPolicySnapshot)
+  const runPlanCounts = countRunPlanChildResults(runPlanChildren)
+
+  return {
+    generatedBy: "scripts/primitive-contract-fixture.ts",
+    redaction: {
+      profiles: Object.fromEntries(Object.entries(redactionProfiles).map(([profile, contract]) => [
+        profile,
+        { ...contract, expected: redactJsonValue(contract.input, { profile: profile as never, redactStrings: false }) },
+      ])),
+    },
+    pathPolicy: {
+      mountTargets: mountTargetCases.map((contract) => contract.error ? contract : { ...contract, expected: normalizeRuntimeMountTarget(contract.input) }),
+      artifactPaths: artifactPathCases.map((contract) => contract.error ? contract : { ...contract, expected: safeArtifactRelativePath(contract.input) }),
+    },
+    toolPolicy: {
+      snapshot: toolPolicySnapshot,
+      effective: {
+        schema: effectiveToolPolicy.schema,
+        version: effectiveToolPolicy.version,
+        allowedRuntimeToolIds: effectiveToolPolicy.allowedRuntimeToolIds,
+        visibleRuntimeToolIds: effectiveToolPolicy.visibleRuntimeToolIds,
+        parentOnlyRuntimeToolIds: effectiveToolPolicy.parentOnlyRuntimeToolIds,
+        hiddenRuntimeToolIds: effectiveToolPolicy.hiddenRuntimeToolIds,
+        metadata: effectiveToolPolicy.metadata,
+      },
+      aliases: Object.fromEntries(["filesystem_write", "write_file", "client/browser-review"].map((alias) => [alias, resolveRuntimeToolAlias(effectiveToolPolicy, alias)?.runtimeToolId])),
+    },
+    statusTaxonomy,
+    jsonCodec: {
+      prettyValue: { path: "files/result.json" },
+      prettyExpected: '{\n    "path": "files/result.json"\n}',
+      object: '{"ok":true}',
+      list: '["a","b"]',
+      trailing: 'warning\n{"status":"ok"}',
+      fragment: 'prefix {"result":{"ok":true}} suffix',
+      expected: { object: { ok: true }, list: ["a", "b"], trailing: { status: "ok" }, fragment: { result: { ok: true } } },
+    },
+    runtimeDependencyPlan: {
+      input: runtimeDependencyPlanInput,
+      expected: runtimeDependencyPlanContract(runtimeDependencyPlanInput),
+    },
+    componentManifest: {
+      components: componentManifestComponents,
+      providers: componentManifestProviders,
+      expected: componentManifestForRuntimePlugins(componentManifestComponents, componentManifestProviders),
+    },
+    runPlan: {
+      children: runPlanChildren,
+      counts: runPlanCounts,
+      succeeded: runPlanSucceeded(runPlanCounts),
+      concurrency: {
+        defaulted: normalizeRunPlanConcurrency("", { defaultConcurrency: 3, maxConcurrency: 5 }),
+        clamped: normalizeRunPlanConcurrency(99, { maxConcurrency: 2 }),
+      },
+      schemas: { plan: RUN_PLAN_SCHEMA, event: RUN_PLAN_EVENT_SCHEMA, result: RUN_PLAN_RESULT_SCHEMA },
+    },
+  }
+}
+
+if (process.argv.includes("--write")) {
+  await writeFile(new URL("../tests/fixtures/primitive-contracts.json", import.meta.url), `${JSON.stringify(primitiveContractsFixture(), null, 2)}\n`)
+}

--- a/tests/fixtures/primitive-contracts.json
+++ b/tests/fixtures/primitive-contracts.json
@@ -1,4 +1,5 @@
 {
+  "generatedBy": "scripts/primitive-contract-fixture.ts",
   "redaction": {
     "profiles": {
       "provider_proxy": {
@@ -38,7 +39,19 @@
         "expected": "/wordpress/wp-content/plugins/plugin"
       },
       {
+        "input": " \\wordpress\\wp-content\\mu-plugins\\runtime ",
+        "expected": "/wordpress/wp-content/mu-plugins/runtime"
+      },
+      {
+        "input": "/",
+        "expected": "/"
+      },
+      {
         "input": "/wordpress/../escape",
+        "error": true
+      },
+      {
+        "input": "relative/runtime",
         "error": true
       }
     ],
@@ -48,7 +61,15 @@
         "expected": "files/output.json"
       },
       {
+        "input": " logs\\run.json ",
+        "expected": "logs/run.json"
+      },
+      {
         "input": "files/../secret.txt",
+        "error": true
+      },
+      {
+        "input": "C:/secret.txt",
         "error": true
       }
     ]
@@ -61,7 +82,9 @@
         {
           "id": "filesystem-write",
           "runtime_tool_id": "client/filesystem-write",
-          "aliases": ["filesystem_write"],
+          "aliases": [
+            "filesystem_write"
+          ],
           "execution_location": "sandbox",
           "transport_visibility": "sandbox",
           "allowed": true,
@@ -71,7 +94,9 @@
           },
           "metadata": {
             "schema": "example/input/v1",
-            "aliases": ["write_file"],
+            "aliases": [
+              "write_file"
+            ],
             "policy": {
               "permission": "write"
             }
@@ -107,10 +132,18 @@
     "effective": {
       "schema": "wp-codebox/sandbox-tool-policy/v1",
       "version": 1,
-      "allowedRuntimeToolIds": ["client/filesystem-write"],
-      "visibleRuntimeToolIds": ["client/filesystem-write"],
-      "parentOnlyRuntimeToolIds": ["client/browser-review"],
-      "hiddenRuntimeToolIds": ["client/internal-token"],
+      "allowedRuntimeToolIds": [
+        "client/filesystem-write"
+      ],
+      "visibleRuntimeToolIds": [
+        "client/filesystem-write"
+      ],
+      "parentOnlyRuntimeToolIds": [
+        "client/browser-review"
+      ],
+      "hiddenRuntimeToolIds": [
+        "client/internal-token"
+      ],
       "metadata": {
         "source": "primitive-contracts"
       }
@@ -123,21 +156,27 @@
   },
   "statusTaxonomy": [
     {
-      "input": { "status": "succeeded" },
+      "input": {
+        "status": "succeeded"
+      },
       "command": "completed",
       "phase": "succeeded",
       "agentTask": "succeeded",
       "check": "passed"
     },
     {
-      "input": { "status": "timed_out" },
+      "input": {
+        "status": "timed_out"
+      },
       "command": "timed_out",
       "phase": "failed",
       "agentTask": "timeout",
       "check": "failed"
     },
     {
-      "input": { "status": "blocked" },
+      "input": {
+        "status": "blocked"
+      },
       "command": "failed",
       "phase": "blocked",
       "agentTask": "unable_to_remediate",
@@ -145,17 +184,30 @@
     }
   ],
   "jsonCodec": {
-    "prettyValue": { "path": "files/result.json" },
+    "prettyValue": {
+      "path": "files/result.json"
+    },
     "prettyExpected": "{\n    \"path\": \"files/result.json\"\n}",
     "object": "{\"ok\":true}",
     "list": "[\"a\",\"b\"]",
     "trailing": "warning\n{\"status\":\"ok\"}",
     "fragment": "prefix {\"result\":{\"ok\":true}} suffix",
     "expected": {
-      "object": { "ok": true },
-      "list": ["a", "b"],
-      "trailing": { "status": "ok" },
-      "fragment": { "result": { "ok": true } }
+      "object": {
+        "ok": true
+      },
+      "list": [
+        "a",
+        "b"
+      ],
+      "trailing": {
+        "status": "ok"
+      },
+      "fragment": {
+        "result": {
+          "ok": true
+        }
+      }
     }
   },
   "runtimeDependencyPlan": {
@@ -167,7 +219,11 @@
         "model": "gpt-test",
         "empty": ""
       },
-      "provider_plugin_paths": ["/runtime/providers/openai", "/runtime/providers/openai", ""],
+      "provider_plugin_paths": [
+        "/runtime/providers/openai",
+        "/runtime/providers/openai",
+        ""
+      ],
       "provider_plugins": [
         {
           "source": "/runtime/providers/openai",
@@ -197,15 +253,44 @@
         }
       ],
       "inheritance_request": {
-        "connectors": ["openai", "openai", ""],
-        "settings": ["model"]
+        "connectors": [
+          "openai",
+          "openai",
+          ""
+        ],
+        "settings": [
+          "model"
+        ]
       },
       "inheritance": {
-        "connectors": [{ "id": "openai", "status": "available" }],
-        "settings": [{ "name": "model", "status": "resolved" }]
+        "connectors": [
+          {
+            "id": "openai",
+            "status": "available"
+          }
+        ],
+        "settings": [
+          {
+            "name": "model",
+            "status": "resolved"
+          }
+        ]
       },
-      "agent_bundles": [{ "source": "/workspace/agent-bundle" }],
-      "secret_env": ["OPENAI_API_KEY", "bad-name", "OPENAI_API_KEY"]
+      "agent_bundles": [
+        {
+          "source": "/workspace/agent-bundle"
+        }
+      ],
+      "secret_env": [
+        "OPENAI_API_KEY",
+        "bad-name",
+        "OPENAI_API_KEY"
+      ],
+      "runtime_env": {
+        "WP_ENVIRONMENT_TYPE": "local",
+        "badName": "ignored",
+        "WP_DEBUG": true
+      }
     },
     "expected": {
       "schema": "wp-codebox/runtime-dependency-plan/v1",
@@ -215,7 +300,9 @@
         "provider": "openai",
         "model": "gpt-test"
       },
-      "provider_plugin_paths": ["/runtime/providers/openai"],
+      "provider_plugin_paths": [
+        "/runtime/providers/openai"
+      ],
       "provider_plugins": [
         {
           "source": "/runtime/providers/openai",
@@ -245,15 +332,39 @@
         }
       ],
       "inheritance_request": {
-        "connectors": ["openai"],
-        "settings": ["model"]
+        "connectors": [
+          "openai"
+        ],
+        "settings": [
+          "model"
+        ]
       },
       "inheritance": {
-        "connectors": [{ "id": "openai", "status": "available" }],
-        "settings": [{ "name": "model", "status": "resolved" }]
+        "connectors": [
+          {
+            "id": "openai",
+            "status": "available"
+          }
+        ],
+        "settings": [
+          {
+            "name": "model",
+            "status": "resolved"
+          }
+        ]
       },
-      "agent_bundles": [{ "source": "/workspace/agent-bundle" }],
-      "secret_env": ["OPENAI_API_KEY"]
+      "agent_bundles": [
+        {
+          "source": "/workspace/agent-bundle"
+        }
+      ],
+      "secret_env": [
+        "OPENAI_API_KEY"
+      ],
+      "runtime_env": {
+        "WP_ENVIRONMENT_TYPE": "local",
+        "WP_DEBUG": "1"
+      }
     }
   },
   "componentManifest": {
@@ -335,9 +446,18 @@
   },
   "runPlan": {
     "children": [
-      { "success": true, "status": "succeeded" },
-      { "success": false, "status": "failed" },
-      { "success": false, "status": "cancelled" }
+      {
+        "success": true,
+        "status": "succeeded"
+      },
+      {
+        "success": false,
+        "status": "failed"
+      },
+      {
+        "success": false,
+        "status": "cancelled"
+      }
     ],
     "counts": {
       "total": 3,
@@ -346,6 +466,10 @@
       "cancelled": 1
     },
     "succeeded": false,
+    "concurrency": {
+      "defaulted": 3,
+      "clamped": 2
+    },
     "schemas": {
       "plan": "wp-codebox/run-plan/v1",
       "event": "wp-codebox/run-plan-event/v1",

--- a/tests/primitive-contract-parity.test.ts
+++ b/tests/primitive-contract-parity.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeCheckStatus,
   normalizeCommandEnvelopeStatus,
   normalizePhaseRecipeStatus,
+  normalizeRunPlanConcurrency,
   normalizeRuntimeMountTarget,
   redactJsonValue,
   resolveEffectiveRuntimeToolPolicy,
@@ -20,8 +21,10 @@ import {
   type SandboxToolPolicySnapshot,
   type WorkspaceRecipeExtraPlugin,
 } from "../packages/runtime-core/src/index.js"
+import { primitiveContractsFixture } from "../scripts/primitive-contract-fixture.js"
 
 const fixture = JSON.parse(await readFile(new URL("./fixtures/primitive-contracts.json", import.meta.url), "utf8"))
+assert.deepEqual(fixture, primitiveContractsFixture(), "primitive contracts fixture must match generated TS contracts")
 
 for (const [profile, contract] of Object.entries(fixture.redaction.profiles) as Array<[string, { input: unknown; expected: unknown }]>) {
   assert.deepEqual(redactJsonValue(contract.input, { profile: profile as never, redactStrings: false }), contract.expected, `${profile} redaction contract`)
@@ -29,7 +32,7 @@ for (const [profile, contract] of Object.entries(fixture.redaction.profiles) as 
 
 for (const contract of fixture.pathPolicy.mountTargets as Array<{ input: string; expected?: string; error?: boolean }>) {
   if (contract.error) {
-    assert.throws(() => normalizeRuntimeMountTarget(contract.input), /directory/)
+    assert.throws(() => normalizeRuntimeMountTarget(contract.input), /absolute|directory/)
   } else {
     assert.equal(normalizeRuntimeMountTarget(contract.input), contract.expected)
   }
@@ -37,7 +40,7 @@ for (const contract of fixture.pathPolicy.mountTargets as Array<{ input: string;
 
 for (const contract of fixture.pathPolicy.artifactPaths as Array<{ input: string; expected?: string; error?: boolean }>) {
   if (contract.error) {
-    assert.throws(() => safeArtifactRelativePath(contract.input), /directory/)
+    assert.throws(() => safeArtifactRelativePath(contract.input), /relative|directory/)
   } else {
     assert.equal(safeArtifactRelativePath(contract.input), contract.expected)
   }
@@ -76,6 +79,8 @@ assert.deepEqual(
 
 assert.deepEqual(countRunPlanChildResults(fixture.runPlan.children), fixture.runPlan.counts)
 assert.equal(runPlanSucceeded(fixture.runPlan.counts), fixture.runPlan.succeeded)
+assert.equal(normalizeRunPlanConcurrency("", { defaultConcurrency: 3, maxConcurrency: 5 }), fixture.runPlan.concurrency.defaulted)
+assert.equal(normalizeRunPlanConcurrency(99, { maxConcurrency: 2 }), fixture.runPlan.concurrency.clamped)
 assert.deepEqual(fixture.runPlan.schemas, {
   plan: RUN_PLAN_SCHEMA,
   event: RUN_PLAN_EVENT_SCHEMA,


### PR DESCRIPTION
## Summary
- Add a TS-generated primitive contract fixture builder and assert the committed fixture stays in sync with TS primitives.
- Extend shared parity coverage for path-policy edge cases, runtime dependency `runtime_env`, and run-plan result/concurrency primitives.
- Align `runtimeDependencyPlanContract()` with the PHP mirror by normalizing `runtime_env` into the shared contract.

## Tests
- `npm run test:primitive-contract-parity`
- `npm run test:php-primitive-contract-parity`
- `npm run test:schema-parity`
- `npm run test:path-policy-parity`
- `npm run test:php-path-policy-parity`
- `npm run test:php-run-plan-contract`
- `npm run build`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the parity fixture generator, contract alignment, test updates, and verification commands; Chris remains responsible for review and merge.