### PR TITLE
Extract patch approval filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "test:primitive-contract-parity": "tsx tests/primitive-contract-parity.test.ts",
     "test:php-primitive-contract-parity": "php scripts/php-primitive-contract-parity-smoke.php",
     "test:php-run-plan-contract": "php scripts/php-run-plan-contract-smoke.php",
+    "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -751,7 +751,7 @@ final class WP_Codebox_Artifacts {
 			return new WP_Error( 'wp_codebox_patch_missing', 'Artifact patch.diff is missing or empty.', array( 'status' => 400 ) );
 		}
 
-		$patch = $this->filter_patch_to_approved_files( $patch, $changed_files, $approved_files );
+		$patch = ( new WP_Codebox_Patch_Approval_Filter() )->filter_patch_to_approved_files( $patch, $changed_files, $approved_files );
 		if ( is_wp_error( $patch ) ) {
 			return $patch;
 		}
@@ -1471,134 +1471,6 @@ final class WP_Codebox_Artifacts {
 				)
 			)
 		);
-	}
-
-	/**
-	 * @param array<int,mixed> $changed_files Artifact changed file entries.
-	 * @param string[]         $approved_files Approved sandbox paths.
-	 */
-	private function filter_patch_to_approved_files( string $patch, array $changed_files, array $approved_files ): string|WP_Error {
-		$approved_lookup             = array_fill_keys( $approved_files, true );
-		$approved_patch_path_sets    = array();
-		$approved_patch_paths_lookup = array();
-
-		foreach ( $changed_files as $file ) {
-			if ( ! is_array( $file ) ) {
-				continue;
-			}
-
-			$path = trim( (string) ( $file['path'] ?? '' ) );
-			if ( '' === $path || ! isset( $approved_lookup[ $path ] ) ) {
-				continue;
-			}
-
-			foreach ( array( $path, (string) ( $file['relativePath'] ?? '' ) ) as $patch_path ) {
-				$normalized = $this->normalize_patch_path( $patch_path );
-				if ( '' !== $normalized ) {
-					$approved_patch_path_sets[ $path ][ $normalized ] = true;
-					$approved_patch_paths_lookup[ $normalized ] = true;
-				}
-			}
-		}
-
-		if ( empty( $approved_patch_paths_lookup ) ) {
-			return new WP_Error( 'wp_codebox_approved_patch_paths_missing', 'Approved files could not be mapped to patch paths.', array( 'status' => 400 ) );
-		}
-
-		$blocks = $this->split_git_patch_blocks( $patch );
-		if ( empty( $blocks ) ) {
-			return new WP_Error( 'wp_codebox_patch_unfilterable', 'Artifact patch.diff could not be split into file patches.', array( 'status' => 400 ) );
-		}
-
-		$matched_approved_files = array();
-		$filtered_blocks = array();
-		foreach ( $blocks as $block ) {
-			$block_paths = $this->git_patch_block_paths( $block );
-			$matches     = array_intersect_key( $block_paths, $approved_patch_paths_lookup );
-			if ( empty( $matches ) ) {
-				continue;
-			}
-
-			foreach ( $approved_patch_path_sets as $approved_file => $candidate_paths ) {
-				if ( ! empty( array_intersect_key( $matches, $candidate_paths ) ) ) {
-					$matched_approved_files[ $approved_file ] = true;
-				}
-			}
-
-			$filtered_blocks[] = $block;
-		}
-
-		$missing_files = array_values( array_diff( $approved_files, array_keys( $matched_approved_files ) ) );
-		if ( ! empty( $missing_files ) ) {
-			return new WP_Error(
-				'wp_codebox_approved_patch_missing',
-				'Artifact patch.diff does not contain every approved file, so the partial approval cannot be applied safely.',
-				array(
-					'status' => 400,
-					'files'  => $missing_files,
-				)
-			);
-		}
-
-		$filtered_patch = implode( '', $filtered_blocks );
-		if ( '' === trim( $filtered_patch ) ) {
-			return new WP_Error( 'wp_codebox_approved_patch_empty', 'Approved files produced an empty patch.', array( 'status' => 400 ) );
-		}
-
-		return $filtered_patch;
-	}
-
-	/** @return string[] */
-	private function split_git_patch_blocks( string $patch ): array {
-		$lines = preg_split( "/(?<=\n)(?=diff --git )/", $patch );
-		if ( false === $lines ) {
-			return array();
-		}
-
-		return array_values(
-			array_filter(
-				$lines,
-				static fn( string $block ): bool => str_starts_with( $block, 'diff --git ' )
-			)
-		);
-	}
-
-	/** @return array<string,bool> */
-	private function git_patch_block_paths( string $block ): array {
-		$paths = array();
-		if ( preg_match( '/^diff --git\s+a\/(.+?)\s+b\/(.+)$/m', $block, $matches ) ) {
-			foreach ( array( $matches[1], $matches[2] ) as $path ) {
-				$normalized = $this->normalize_patch_path( $path );
-				if ( '' !== $normalized ) {
-					$paths[ $normalized ] = true;
-				}
-			}
-		}
-
-		foreach ( array( '---', '+++' ) as $prefix ) {
-			if ( preg_match( '/^' . preg_quote( $prefix, '/' ) . '\s+(.+)$/m', $block, $matches ) ) {
-				$normalized = $this->normalize_patch_path( $matches[1] );
-				if ( '' !== $normalized ) {
-					$paths[ $normalized ] = true;
-				}
-			}
-		}
-
-		return $paths;
-	}
-
-	private function normalize_patch_path( string $path ): string {
-		$path = trim( $path );
-		if ( '' === $path || '/dev/null' === $path ) {
-			return '';
-		}
-
-		$path = preg_replace( '/\s+.*$/', '', $path ) ?? $path;
-		$path = str_replace( '\\', '/', $path );
-		$path = preg_replace( '#^(?:a|b)/#', '', $path ) ?? $path;
-		$path = ltrim( $path, '/' );
-
-		return $path;
 	}
 
 	/**

--- a/packages/wordpress-plugin/src/class-wp-codebox-patch-approval-filter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-patch-approval-filter.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Filters artifact patches down to approved sandbox files.
+ *
+ * @package WP_Codebox
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class WP_Codebox_Patch_Approval_Filter {
+	/**
+	 * @param array<int,mixed> $changed_files Artifact changed file entries.
+	 * @param string[]         $approved_files Approved sandbox paths.
+	 */
+	public function filter_patch_to_approved_files( string $patch, array $changed_files, array $approved_files ): string|WP_Error {
+		$approved_lookup             = array_fill_keys( $approved_files, true );
+		$approved_patch_path_sets    = array();
+		$approved_patch_paths_lookup = array();
+
+		foreach ( $changed_files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = trim( (string) ( $file['path'] ?? '' ) );
+			if ( '' === $path || ! isset( $approved_lookup[ $path ] ) ) {
+				continue;
+			}
+
+			foreach ( array( $path, (string) ( $file['relativePath'] ?? '' ) ) as $patch_path ) {
+				$normalized = $this->normalize_patch_path( $patch_path );
+				if ( '' !== $normalized ) {
+					$approved_patch_path_sets[ $path ][ $normalized ] = true;
+					$approved_patch_paths_lookup[ $normalized ] = true;
+				}
+			}
+		}
+
+		if ( empty( $approved_patch_paths_lookup ) ) {
+			return new WP_Error( 'wp_codebox_approved_patch_paths_missing', 'Approved files could not be mapped to patch paths.', array( 'status' => 400 ) );
+		}
+
+		$blocks = $this->split_git_patch_blocks( $patch );
+		if ( empty( $blocks ) ) {
+			return new WP_Error( 'wp_codebox_patch_unfilterable', 'Artifact patch.diff could not be split into file patches.', array( 'status' => 400 ) );
+		}
+
+		$matched_approved_files = array();
+		$filtered_blocks        = array();
+		foreach ( $blocks as $block ) {
+			$block_paths = $this->git_patch_block_paths( $block );
+			$matches     = array_intersect_key( $block_paths, $approved_patch_paths_lookup );
+			if ( empty( $matches ) ) {
+				continue;
+			}
+
+			foreach ( $approved_patch_path_sets as $approved_file => $candidate_paths ) {
+				if ( ! empty( array_intersect_key( $matches, $candidate_paths ) ) ) {
+					$matched_approved_files[ $approved_file ] = true;
+				}
+			}
+
+			$filtered_blocks[] = $block;
+		}
+
+		$missing_files = array_values( array_diff( $approved_files, array_keys( $matched_approved_files ) ) );
+		if ( ! empty( $missing_files ) ) {
+			return new WP_Error(
+				'wp_codebox_approved_patch_missing',
+				'Artifact patch.diff does not contain every approved file, so the partial approval cannot be applied safely.',
+				array(
+					'status' => 400,
+					'files'  => $missing_files,
+				)
+			);
+		}
+
+		$filtered_patch = implode( '', $filtered_blocks );
+		if ( '' === trim( $filtered_patch ) ) {
+			return new WP_Error( 'wp_codebox_approved_patch_empty', 'Approved files produced an empty patch.', array( 'status' => 400 ) );
+		}
+
+		return $filtered_patch;
+	}
+
+	/** @return string[] */
+	private function split_git_patch_blocks( string $patch ): array {
+		$lines = preg_split( "/(?<=\n)(?=diff --git )/", $patch );
+		if ( false === $lines ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$lines,
+				static fn( string $block ): bool => str_starts_with( $block, 'diff --git ' )
+			)
+		);
+	}
+
+	/** @return array<string,bool> */
+	private function git_patch_block_paths( string $block ): array {
+		$paths = array();
+		if ( preg_match( '/^diff --git\s+a\/(.+?)\s+b\/(.+)$/m', $block, $matches ) ) {
+			foreach ( array( $matches[1], $matches[2] ) as $path ) {
+				$normalized = $this->normalize_patch_path( $path );
+				if ( '' !== $normalized ) {
+					$paths[ $normalized ] = true;
+				}
+			}
+		}
+
+		foreach ( array( '---', '+++' ) as $prefix ) {
+			if ( preg_match( '/^' . preg_quote( $prefix, '/' ) . '\s+(.+)$/m', $block, $matches ) ) {
+				$normalized = $this->normalize_patch_path( $matches[1] );
+				if ( '' !== $normalized ) {
+					$paths[ $normalized ] = true;
+				}
+			}
+		}
+
+		return $paths;
+	}
+
+	private function normalize_patch_path( string $path ): string {
+		$path = trim( $path );
+		if ( '' === $path || '/dev/null' === $path ) {
+			return '';
+		}
+
+		$path = preg_replace( '/\s+.*$/', '', $path ) ?? $path;
+		$path = str_replace( '\\', '/', $path );
+		$path = preg_replace( '#^(?:a|b)/#', '', $path ) ?? $path;
+		$path = ltrim( $path, '/' );
+
+		return $path;
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -47,6 +47,7 @@ require_once __DIR__ . '/src/class-wp-codebox-agent-runtime-invoker.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-provider-bridge.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
+require_once __DIR__ . '/src/class-wp-codebox-patch-approval-filter.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-pending-artifact-apply.php';
 require_once __DIR__ . '/src/class-wp-codebox-preview-options.php';

--- a/scripts/php-patch-approval-filter-smoke.php
+++ b/scripts/php-patch-approval-filter-smoke.php
@@ -1,0 +1,189 @@
+<?php
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	/** @var mixed */
+	private mixed $data;
+
+	/** @param mixed $data */
+	public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-patch-approval-filter.php';
+
+function assert_same_patch_filter( mixed $expected, mixed $actual, string $label ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $label . " failed.\nExpected: " . var_export( $expected, true ) . "\nActual: " . var_export( $actual, true ) . "\n" );
+		exit( 1 );
+	}
+}
+
+function assert_error_code_patch_filter( string $expected_code, mixed $actual, string $label ): void {
+	if ( ! is_wp_error( $actual ) ) {
+		fwrite( STDERR, $label . ' failed: expected WP_Error, got ' . var_export( $actual, true ) . PHP_EOL );
+		exit( 1 );
+	}
+
+	assert_same_patch_filter( $expected_code, $actual->get_error_code(), $label . ' code' );
+}
+
+$patch = implode(
+	'',
+	array(
+		"diff --git a/wp-content/plugins/demo/demo.php b/wp-content/plugins/demo/demo.php\n",
+		"index 1111111..2222222 100644\n",
+		"--- a/wp-content/plugins/demo/demo.php\n",
+		"+++ b/wp-content/plugins/demo/demo.php\n",
+		"@@ -1 +1 @@\n",
+		"-old\n",
+		"+new\n",
+		"diff --git a/wp-content/plugins/demo/readme.txt b/wp-content/plugins/demo/readme.txt\n",
+		"index 3333333..4444444 100644\n",
+		"--- a/wp-content/plugins/demo/readme.txt\n",
+		"+++ b/wp-content/plugins/demo/readme.txt\n",
+		"@@ -1 +1 @@\n",
+		"-readme\n",
+		"+updated readme\n",
+	)
+);
+
+$changed_files = array(
+	array(
+		'path'         => '/wordpress/wp-content/plugins/demo/demo.php',
+		'relativePath' => 'wp-content/plugins/demo/demo.php',
+	),
+	array(
+		'path'         => '/wordpress/wp-content/plugins/demo/readme.txt',
+		'relativePath' => 'wp-content/plugins/demo/readme.txt',
+	),
+);
+
+$filter = new WP_Codebox_Patch_Approval_Filter();
+
+$filtered = $filter->filter_patch_to_approved_files(
+	$patch,
+	$changed_files,
+	array( '/wordpress/wp-content/plugins/demo/demo.php' )
+);
+
+assert_same_patch_filter(
+	implode(
+		'',
+		array(
+			"diff --git a/wp-content/plugins/demo/demo.php b/wp-content/plugins/demo/demo.php\n",
+			"index 1111111..2222222 100644\n",
+			"--- a/wp-content/plugins/demo/demo.php\n",
+			"+++ b/wp-content/plugins/demo/demo.php\n",
+			"@@ -1 +1 @@\n",
+			"-old\n",
+			"+new\n",
+		)
+	),
+	$filtered,
+	'filters to only the approved file block'
+);
+
+$filtered = $filter->filter_patch_to_approved_files(
+	$patch,
+	$changed_files,
+	array(
+		'/wordpress/wp-content/plugins/demo/demo.php',
+		'/wordpress/wp-content/plugins/demo/readme.txt',
+	)
+);
+assert_same_patch_filter( $patch, $filtered, 'preserves all blocks when all changed files are approved' );
+
+$renamed_patch = implode(
+	'',
+	array(
+		"diff --git a/wp-content/plugins/demo/old.php b/wp-content/plugins/demo/new.php\n",
+		"similarity index 88%\n",
+		"rename from wp-content/plugins/demo/old.php\n",
+		"rename to wp-content/plugins/demo/new.php\n",
+		"--- a/wp-content/plugins/demo/old.php\n",
+		"+++ b/wp-content/plugins/demo/new.php\n",
+		"@@ -1 +1 @@\n",
+		"-old\n",
+		"+new\n",
+	)
+);
+
+$filtered = $filter->filter_patch_to_approved_files(
+	$renamed_patch,
+	array(
+		array(
+			'path'         => '/wordpress/wp-content/plugins/demo/new.php',
+			'relativePath' => 'wp-content/plugins/demo/new.php',
+		),
+	),
+	array( '/wordpress/wp-content/plugins/demo/new.php' )
+);
+assert_same_patch_filter( $renamed_patch, $filtered, 'matches approved renamed destination path' );
+
+$filtered = $filter->filter_patch_to_approved_files(
+	"diff --git a/wp-content/plugins/demo/windows.php b/wp-content/plugins/demo/windows.php\n--- a/wp-content/plugins/demo/windows.php\t2026-06-17\n+++ b/wp-content/plugins/demo/windows.php\t2026-06-17\n@@ -1 +1 @@\n-old\n+new\n",
+	array(
+		array(
+			'path'         => '/wordpress/wp-content/plugins/demo/windows.php',
+			'relativePath' => 'wp-content\\plugins\\demo\\windows.php',
+		),
+	),
+	array( '/wordpress/wp-content/plugins/demo/windows.php' )
+);
+assert_same_patch_filter( true, is_string( $filtered ), 'normalizes backslashes and metadata-suffixed patch paths' );
+
+$missing = $filter->filter_patch_to_approved_files(
+	$patch,
+	$changed_files,
+	array( '/wordpress/wp-content/plugins/demo/missing.php' )
+);
+assert_error_code_patch_filter( 'wp_codebox_approved_patch_paths_missing', $missing, 'rejects approved file without changed-file mapping' );
+
+$missing_patch = $filter->filter_patch_to_approved_files(
+	$patch,
+	array(
+		array(
+			'path'         => '/wordpress/wp-content/plugins/demo/missing.php',
+			'relativePath' => 'wp-content/plugins/demo/missing.php',
+		),
+	),
+	array( '/wordpress/wp-content/plugins/demo/missing.php' )
+);
+assert_error_code_patch_filter( 'wp_codebox_approved_patch_missing', $missing_patch, 'rejects approved changed file missing from patch' );
+
+$unfilterable = $filter->filter_patch_to_approved_files(
+	"not a git patch\n",
+	array(
+		array(
+			'path'         => '/wordpress/wp-content/plugins/demo/demo.php',
+			'relativePath' => 'wp-content/plugins/demo/demo.php',
+		),
+	),
+	array( '/wordpress/wp-content/plugins/demo/demo.php' )
+);
+assert_error_code_patch_filter( 'wp_codebox_patch_unfilterable', $unfilterable, 'rejects patches without git blocks' );
+
+fwrite( STDOUT, "PHP patch approval filter smoke passed\n" );


### PR DESCRIPTION
## Summary
- Extract approved-file patch filtering from `WP_Codebox_Artifacts` into `WP_Codebox_Patch_Approval_Filter`.
- Keep artifact apply preflight behavior delegating through the extracted filter.
- Add focused PHP smoke coverage for partial approvals, relative path matching, rename destination matching, path normalization, and safety failures.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-patch-approval-filter.php && php -l packages/wordpress-plugin/src/class-wp-codebox-artifacts.php && php -l packages/wordpress-plugin/wp-codebox.php && php -l scripts/php-patch-approval-filter-smoke.php`
- `npm run test:php-patch-approval-filter`
- `npm run test:artifact-path-primitives`
- `npm run test:browser-artifact-session`
- `npm run test:php-path-policy-parity`
- `npm run build`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the extraction, smoke coverage, and local verification commands; Chris remains responsible for review and testing.
