### PR TITLE
Extract recipe run result finalization

### DIFF
--- a/packages/cli/src/commands/recipe-run-finalizer.ts
+++ b/packages/cli/src/commands/recipe-run-finalizer.ts
@@ -1,10 +1,12 @@
 import { readdir, stat } from "node:fs/promises"
 import { resolve } from "node:path"
+import { artifactBundleRunRef, normalizeRecipeRunSummary, type ArtifactBundle, type RuntimeInfo, type RuntimeRunRecord, type RuntimeRunRegistry } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
-import type { ArtifactBundle, RuntimeRunRecord, RuntimeRunRegistry } from "@automattic/wp-codebox-core"
 import { serializeError } from "../output.js"
-import { serializeRecipeRunError } from "./recipe-run-output.js"
-import type { RecipePhaseEvidence } from "./recipe-run-types.js"
+import { finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeTerminalResultOutput } from "../recipe-evidence.js"
+import { recipeRunFailureStatus, serializeRecipeRunError } from "./recipe-run-output.js"
+import type { RecipeArtifactPointerTracker } from "./recipe-run-artifact-pointers.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOutput, RecipeRunProbe, RecipeRunSiteSeed, RecipeRunStagedFile } from "./recipe-run-types.js"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 
 export interface RunResourceCleanupEvidence {
@@ -23,6 +25,176 @@ interface RunResourceEvidenceOptions {
   artifacts?: ArtifactBundle
   failure?: RunOutput["error"]
   phaseEvidence?: RecipePhaseEvidence[]
+}
+
+interface RecipeRunFinalizerBase {
+  recipePath: string
+  runRegistry: RuntimeRunRegistry
+  runRecord: RuntimeRunRecord
+  artifactPointer: RecipeArtifactPointerTracker
+  startedAtMs: number
+}
+
+interface RecipeRunCommonOutputFields {
+  runtime?: RuntimeInfo
+  executions: RecipeExecutionResult[]
+  componentContracts?: RecipeRunComponentContract[]
+  stagedFiles?: RecipeRunStagedFile[]
+  fixtureDatabases?: RecipeRunFixtureDatabase[]
+  siteSeeds?: RecipeRunSiteSeed[]
+  probes?: RecipeRunProbe[]
+  declaredArtifacts?: RecipeRunDeclaredArtifact[]
+  phaseEvidence?: RecipePhaseEvidence[]
+  advisoryFailures?: RecipeAdvisoryFailure[]
+  browserEvidence?: RecipeBrowserEvidence[]
+  diagnostics?: RecipeRunOutput["diagnostics"]
+  benchResults?: RecipeRunOutput["benchResults"]
+  benchResultsList?: RecipeRunOutput["benchResultsList"]
+  agentResult?: RecipeRunOutput["agentResult"]
+  agentTaskResult?: RecipeRunOutput["agentTaskResult"]
+  terminalResult?: RecipeRunOutput["terminalResult"]
+  completionOutcome?: RecipeRunOutput["completionOutcome"]
+  replayStatus?: RecipeRunOutput["replayStatus"]
+  artifacts?: ArtifactBundle
+  interruption?: RecipeRunOutput["interruption"]
+}
+
+interface FinalizeCompletedRecipeRunOptions extends RecipeRunFinalizerBase {
+  success: boolean
+  runtime: RuntimeInfo
+  artifacts: ArtifactBundle
+  startupDurationMs?: number
+  cleanup?: RunResourceCleanupEvidence
+  phaseEvidence: RecipePhaseEvidence[]
+  browserEvidence: RecipeBrowserEvidence[]
+  replayStatus?: RecipeRunOutput["replayStatus"]
+  failure?: RunOutput["error"]
+  output: RecipeRunCommonOutputFields
+}
+
+interface FinalizeRecoveredRecipeFailureOptions extends RecipeRunFinalizerBase {
+  originalError: unknown
+  serializedError: RunOutput["error"]
+  runtime?: RuntimeInfo
+  artifacts?: ArtifactBundle
+  startupDurationMs?: number
+  cleanup?: RunResourceCleanupEvidence
+  phaseEvidence: RecipePhaseEvidence[]
+  browserEvidence: RecipeBrowserEvidence[]
+  diagnosticArtifacts: RecipeDiagnosticArtifactRef[]
+  interruption?: RecipeInterruptionController
+  output: RecipeRunCommonOutputFields
+}
+
+export function recipeRunOutputWithResult<T extends RecipeRunOutput>(output: T): T {
+  output.result = normalizeRecipeRunSummary(output)
+  return output
+}
+
+export function completedRecipeOutputFields(args: {
+  executions: RecipeExecutionResult[]
+  componentContracts?: RecipeRunComponentContract[]
+  stagedFiles: RecipeRunStagedFile[]
+  fixtureDatabases: RecipeRunFixtureDatabase[]
+  siteSeeds: RecipeRunOutput["siteSeeds"]
+  probes: RecipeRunProbe[]
+  declaredArtifacts: RecipeRunDeclaredArtifact[]
+  phaseEvidence: RecipePhaseEvidence[]
+  advisoryFailures: RecipeAdvisoryFailure[]
+  browserEvidence: RecipeBrowserEvidence[]
+  benchResultsList: NonNullable<RecipeRunOutput["benchResultsList"]>
+  evidence: Awaited<ReturnType<typeof finalizeRecipeArtifactEvidence>> & Awaited<ReturnType<typeof finalizeAgentSandboxEvidence>>
+}): Pick<RecipeRunOutput, "executions"> & Partial<RecipeRunOutput> {
+  return {
+    executions: args.executions,
+    componentContracts: args.componentContracts,
+    stagedFiles: args.stagedFiles,
+    fixtureDatabases: args.fixtureDatabases,
+    siteSeeds: args.siteSeeds,
+    probes: args.probes,
+    declaredArtifacts: args.declaredArtifacts,
+    phaseEvidence: args.phaseEvidence,
+    ...(args.advisoryFailures.length > 0 ? { advisoryFailures: args.advisoryFailures } : {}),
+    ...(args.browserEvidence.length > 0 ? { browserEvidence: args.browserEvidence } : {}),
+    ...(args.benchResultsList.length === 1 ? { benchResults: args.benchResultsList[0] } : {}),
+    ...(args.benchResultsList.length > 0 ? { benchResultsList: args.benchResultsList } : {}),
+    ...(args.evidence.agentResult ? { agentResult: recipeAgentResultOutput(args.evidence.agentResult) } : {}),
+    ...(args.evidence.agentTaskResult ? { agentTaskResult: recipeAgentTaskResultOutput(args.evidence.agentTaskResult) } : {}),
+    ...(args.evidence.terminalResult ? { terminalResult: recipeTerminalResultOutput(args.evidence.terminalResult) } : {}),
+    ...(args.evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(args.evidence.completionOutcome) } : {}),
+    ...(args.evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(args.evidence.replayStatus) } : {}),
+  }
+}
+
+export async function finalizeRecipeValidationFailure(args: RecipeRunFinalizerBase & { failure: RunOutput["error"]; componentContracts?: RecipeRunComponentContract[]; validation: RecipeRunOutput["validation"] }): Promise<RecipeRunOutput> {
+  const runRecord = await args.runRegistry.update(args.runRecord.runId, {
+    status: "failed",
+    metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs: args.startedAtMs, status: "failed", failure: args.failure }) },
+    error: args.failure,
+  })
+  const output: RecipeRunOutput = recipeRunOutputWithResult({
+    success: false,
+    schema: "wp-codebox/recipe-run/v1",
+    recipePath: args.recipePath,
+    executions: [],
+    componentContracts: args.componentContracts,
+    validation: args.validation,
+    run: runRecord,
+    error: args.failure,
+  })
+  await args.artifactPointer.update({ command: "recipe.validate", commandStatus: "failed", failure: args.failure, result: output.result })
+  return output
+}
+
+export async function finalizeCompletedRecipeRun(args: FinalizeCompletedRecipeRunOptions): Promise<RecipeRunOutput> {
+  const status = args.success ? "succeeded" : "failed"
+  const runRecord = await args.runRegistry.update(args.runRecord.runId, {
+    status,
+    runtime: args.runtime,
+    preview: args.artifacts.preview,
+    artifactRefs: artifactBundleRunRef(args.artifacts),
+    metadata: {
+      runResourceEvidence: await runResourceEvidence({ startedAtMs: args.startedAtMs, status, startupDurationMs: args.startupDurationMs, cleanup: args.cleanup, artifacts: args.artifacts, failure: args.failure, phaseEvidence: args.phaseEvidence }),
+      ...(args.replayStatus ? { replayStatus: args.replayStatus } : {}),
+    },
+    ...(args.failure ? { error: args.failure } : {}),
+  })
+  const output = recipeRunOutputWithResult(stripUndefined({
+    success: args.success,
+    schema: "wp-codebox/recipe-run/v1" as const,
+    recipePath: args.recipePath,
+    ...args.output,
+    runtime: args.runtime,
+    artifacts: args.artifacts,
+    run: runRecord,
+    error: args.failure,
+  }) as RecipeRunOutput)
+  await args.artifactPointer.update({ commandStatus: args.success ? "completed" : "failed", runtime: args.runtime, artifacts: args.artifacts, failure: args.failure, phases: args.phaseEvidence, browserEvidence: args.browserEvidence, result: output.result })
+  return output
+}
+
+export async function finalizeRecoveredRecipeFailure(args: FinalizeRecoveredRecipeFailureOptions): Promise<RecipeRunOutput> {
+  const status = recipeRunFailureStatus(args.originalError, args.interruption)
+  const runRecord = await args.runRegistry.update(args.runRecord.runId, {
+    status,
+    ...(args.runtime ? { runtime: args.runtime } : {}),
+    ...(args.artifacts ? { preview: args.artifacts.preview, artifactRefs: artifactBundleRunRef(args.artifacts) } : {}),
+    metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs: args.startedAtMs, status, startupDurationMs: args.startupDurationMs, cleanup: args.cleanup, artifacts: args.artifacts, failure: args.serializedError, phaseEvidence: args.phaseEvidence }) },
+    error: args.serializedError,
+  })
+  const output = recipeRunOutputWithResult(stripUndefined({
+    success: false,
+    schema: "wp-codebox/recipe-run/v1" as const,
+    recipePath: args.recipePath,
+    ...args.output,
+    ...(args.runtime ? { runtime: args.runtime } : {}),
+    ...(args.artifacts ? { artifacts: args.artifacts } : {}),
+    run: runRecord,
+    ...(args.interruption?.metadata ? { interruption: args.interruption.metadata } : {}),
+    error: args.serializedError,
+  }) as RecipeRunOutput)
+  await args.artifactPointer.update({ commandStatus: "failed", ...(args.runtime ? { runtime: args.runtime } : {}), ...(args.artifacts ? { artifacts: args.artifacts } : {}), failure: args.serializedError, phases: args.phaseEvidence, browserEvidence: args.browserEvidence, diagnosticArtifacts: args.diagnosticArtifacts, result: output.result })
+  return output
 }
 
 export async function runRecipeCleanup(runRegistry: RuntimeRunRegistry, runRecord: RuntimeRunRecord, cleanup: () => Promise<void>): Promise<RunResourceCleanupEvidence> {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,13 +1,13 @@
 import { createHash } from "node:crypto"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, artifactBundleRunRef, createRuntime, normalizeRecipeRunSummary, normalizeRuntimeEnvRecord, parseCommandOptions, resolveSecretEnvNames, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, resolveSecretEnvNames, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, recipeDryRunSiteSeeds } from "../recipe-dry-run.js"
-import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeArtifactEvidenceFailure, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeTerminalResultOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
+import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeArtifactEvidenceFailure, recipeReplayStatusOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
 import type { PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { loadWorkspaceRecipe, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -16,10 +16,10 @@ import { previewSpec, releaseRuntime, runtimeMetadata, type RunOutput } from "..
 import { artifactManifestFilesByPath, parseBenchResults, writeBenchmarkArtifactEvidence } from "./recipe-run-benchmark-artifacts.js"
 import { createRecipeRunContext } from "./recipe-run-context.js"
 import { collectRecipeDeclaredArtifacts, materializeTypedRecipeDeclaredArtifacts, recipeDeclaredArtifactFailure, recipeProbeFailure, recipeRuntimeEvidenceFiles } from "./recipe-declared-artifacts.js"
-import { runRecipeCleanup, runResourceEvidence, type RunResourceCleanupEvidence } from "./recipe-run-finalizer.js"
+import { completedRecipeOutputFields, finalizeCompletedRecipeRun, finalizeRecipeValidationFailure, finalizeRecoveredRecipeFailure, runRecipeCleanup, type RunResourceCleanupEvidence } from "./recipe-run-finalizer.js"
 import { RecipeRunPhaseExecutor } from "./recipe-run-phase-executor.js"
 import { createRecipeInterruptionController, interruptedRecipeOutput, markRecipeArtifactsFinalized, recipeInterruptionSerializedError } from "./recipe-run-interruption.js"
-import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, printJsonFailureDiagnostic, recipeRunFailureStatus, RecipeRunTimeoutError, RecipeRuntimeCreateError, serializeRecipeRunError, writeRecipeJsonOutput } from "./recipe-run-output.js"
+import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, printJsonFailureDiagnostic, RecipeRunTimeoutError, RecipeRuntimeCreateError, serializeRecipeRunError, writeRecipeJsonOutput } from "./recipe-run-output.js"
 import { RecipePhaseError } from "./recipe-run-phases.js"
 import { importRecipeSiteSeeds } from "./recipe-site-seeds.js"
 import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRuntimeSetup, recipeRunDependencyOverlay, recipeRunExtraPlugin, recipeRunStagedFile } from "./recipe-runtime-setup.js"
@@ -84,23 +84,16 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       message: `Recipe validation failed with ${issues.length} issue${issues.length === 1 ? "" : "s"}.`,
       issues,
     }
-    runRecord = await runRegistry.update(runRecord.runId, {
-      status: "failed",
-      metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", failure }) },
-      error: failure,
-    })
-    const output: RecipeRunOutput = recipeRunOutputWithResult({
-      success: false,
-      schema: "wp-codebox/recipe-run/v1",
+    return await finalizeRecipeValidationFailure({
       recipePath,
-      executions: [],
+      runRegistry,
+      runRecord,
+      artifactPointer,
+      startedAtMs,
+      failure,
       componentContracts: componentContractResults(recipe, [], [], [], failure),
       validation: { issues },
-      run: runRecord,
-      error: failure,
     })
-    await artifactPointer.update({ command: "recipe.validate", commandStatus: "failed", failure, result: output.result })
-    return output
   }
 
   const plan = await planWorkspaceRecipe(recipe, recipeDirectory, { recipePath, artifactsDirectory: configuredArtifactsDirectory }, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec })
@@ -312,78 +305,43 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     }
 
     if (recipeFailure) {
-      runRecord = await runRegistry.update(runRecord.runId, {
-        status: "failed",
-        runtime: runtimeInfo ?? await runtime.info(),
-        preview: artifacts.preview,
-        artifactRefs: artifactBundleRunRef(artifacts),
-        metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "failed", startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: recipeFailure, phaseEvidence: phaseTracker.list() }), ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}) },
-        error: recipeFailure,
-      })
-      const output: RecipeRunOutput = recipeRunOutputWithResult({
+      const finalRuntimeInfo = runtimeInfo ?? await runtime.info()
+      return await finalizeCompletedRecipeRun({
         success: false,
-        schema: "wp-codebox/recipe-run/v1",
         recipePath,
-        runtime: runtimeInfo ?? await runtime.info(),
-        executions,
-        componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions),
-        stagedFiles: stagedFiles.map(recipeRunStagedFile),
-        fixtureDatabases,
-        siteSeeds,
-        probes,
-        declaredArtifacts,
-        phaseEvidence: phaseTracker.list(),
-        ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
-        ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
-        ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
-        ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
-        ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
-        ...(evidence.agentTaskResult ? { agentTaskResult: recipeAgentTaskResultOutput(evidence.agentTaskResult) } : {}),
-        ...(evidence.terminalResult ? { terminalResult: recipeTerminalResultOutput(evidence.terminalResult) } : {}),
-        ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
-        ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}),
+        runRegistry,
+        runRecord,
+        artifactPointer,
+        startedAtMs,
+        runtime: finalRuntimeInfo,
         artifacts,
-        run: runRecord,
-        error: recipeFailure,
+        startupDurationMs,
+        cleanup: cleanupEvidence,
+        phaseEvidence: phaseTracker.list(),
+        browserEvidence,
+        replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
+        failure: recipeFailure,
+        output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
       })
-      await artifactPointer.update({ commandStatus: "failed", runtime: runtimeInfo ?? await runtime.info(), artifacts, failure: recipeFailure, phases: phaseTracker.list(), browserEvidence, result: output.result })
-      return output
     }
 
-    runRecord = await runRegistry.update(runRecord.runId, {
-      status: "succeeded",
-      runtime: runtimeInfo ?? await runtime.info(),
-      preview: artifacts.preview,
-      artifactRefs: artifactBundleRunRef(artifacts),
-      metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: "succeeded", startupDurationMs, cleanup: cleanupEvidence, artifacts, phaseEvidence: phaseTracker.list() }), ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}) },
-    })
-    const output: RecipeRunOutput = recipeRunOutputWithResult({
+    const finalRuntimeInfo = runtimeInfo ?? await runtime.info()
+    return await finalizeCompletedRecipeRun({
       success: true,
-      schema: "wp-codebox/recipe-run/v1",
       recipePath,
-      runtime: runtimeInfo ?? await runtime.info(),
-      executions,
-      componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions),
-      stagedFiles: stagedFiles.map(recipeRunStagedFile),
-      fixtureDatabases,
-      siteSeeds,
-      probes,
-      declaredArtifacts,
-      phaseEvidence: phaseTracker.list(),
-      ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
-      ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
-      ...(benchResultsList.length === 1 ? { benchResults: benchResultsList[0] } : {}),
-      ...(benchResultsList.length > 0 ? { benchResultsList } : {}),
-      ...(evidence.agentResult ? { agentResult: recipeAgentResultOutput(evidence.agentResult) } : {}),
-      ...(evidence.agentTaskResult ? { agentTaskResult: recipeAgentTaskResultOutput(evidence.agentTaskResult) } : {}),
-        ...(evidence.terminalResult ? { terminalResult: recipeTerminalResultOutput(evidence.terminalResult) } : {}),
-        ...(evidence.completionOutcome ? { completionOutcome: recipeCompletionOutcomeOutput(evidence.completionOutcome) } : {}),
-      ...(evidence.replayStatus ? { replayStatus: recipeReplayStatusOutput(evidence.replayStatus) } : {}),
+      runRegistry,
+      runRecord,
+      artifactPointer,
+      startedAtMs,
+      runtime: finalRuntimeInfo,
       artifacts,
-      run: runRecord,
+      startupDurationMs,
+      cleanup: cleanupEvidence,
+      phaseEvidence: phaseTracker.list(),
+      browserEvidence,
+      replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
+      output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
     })
-    await artifactPointer.update({ commandStatus: "completed", runtime: runtimeInfo ?? await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence, result: output.result })
-    return output
   } catch (error) {
     const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
     const failureDiagnostics = recipeFailureRuntimeEvidenceFile({
@@ -461,42 +419,36 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       await cleanupInputMountBaselines(inputMountBaselinePaths)
     })
     runRecord = await runRegistry.read(runRecord.runId)
-    runRecord = await runRegistry.update(runRecord.runId, {
-      status: recipeRunFailureStatus(error, interruption),
-      ...(runtime ? { runtime: await runtime.info() } : {}),
-      ...(artifacts ? { preview: artifacts.preview, artifactRefs: artifactBundleRunRef(artifacts) } : {}),
-      metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs, status: recipeRunFailureStatus(error, interruption), startupDurationMs, cleanup: cleanupEvidence, artifacts, failure: serializedError, phaseEvidence: phaseTracker.list() }) },
-      error: serializedError,
-    })
-    const output: RecipeRunOutput = recipeRunOutputWithResult({
-      success: false,
-      schema: "wp-codebox/recipe-run/v1",
+    return await finalizeRecoveredRecipeFailure({
       recipePath,
+      runRegistry,
+      runRecord,
+      artifactPointer,
+      startedAtMs,
+      originalError: error,
+      serializedError,
       ...(runtime ? { runtime: await runtime.info() } : {}),
-      executions,
-      componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions, error),
-      stagedFiles: stagedFiles.map(recipeRunStagedFile),
-      fixtureDatabases,
-      probes,
-      declaredArtifacts,
-      phaseEvidence: phaseTracker.list(),
-      ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
-      ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
-      diagnostics: recipeRuntimeDiagnostics(recipe, executions, error),
       ...(artifacts ? { artifacts } : {}),
-      run: runRecord,
-      ...(interruption?.metadata ? { interruption: interruption.metadata } : {}),
-      error: serializedError,
+      startupDurationMs,
+      cleanup: cleanupEvidence,
+      phaseEvidence: phaseTracker.list(),
+      browserEvidence,
+      diagnosticArtifacts,
+      interruption,
+      output: {
+        executions,
+        componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions, error),
+        stagedFiles: stagedFiles.map(recipeRunStagedFile),
+        fixtureDatabases,
+        probes,
+        declaredArtifacts,
+        phaseEvidence: phaseTracker.list(),
+        ...(advisoryFailures.length > 0 ? { advisoryFailures } : {}),
+        ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
+        diagnostics: recipeRuntimeDiagnostics(recipe, executions, error),
+      },
     })
-    await artifactPointer.update({ commandStatus: "failed", ...(runtime ? { runtime: await runtime.info() } : {}), ...(artifacts ? { artifacts } : {}), failure: serializedError, phases: phaseTracker.list(), browserEvidence, diagnosticArtifacts, result: output.result })
-
-    return output
   }
-}
-
-function recipeRunOutputWithResult<T extends RecipeRunOutput>(output: T): T {
-  output.result = normalizeRecipeRunSummary(output)
-  return output
 }
 
 function resolveRecipeRuntimeAssets(recipe: WorkspaceRecipe, recipeDirectory: string): RuntimeAssetSpec | undefined {


### PR DESCRIPTION
## Summary
- Extract recipe-run validation, success/failure, and recovered-failure finalization into `recipe-run-finalizer.ts`
- Centralize result summary shaping, run registry final status updates, artifact refs, and latest artifact pointer writes
- Keep `runRecipe()` focused on orchestration and phase execution without changing CLI output contracts

## Testing
- `npm run build`
- `npm run smoke -- --command=recipe-run-summary-smoke`
- `npm run smoke -- --command=recipe-run-terminal-phase-failure-smoke`
- `npx tsx scripts/recipe-run-activation-failure-artifacts-smoke.ts`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the structural TypeScript refactor and ran local verification; Chris remains responsible for review and merge.
