### PR TITLE
Extract browser probe result builder

### DIFF
--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -1,17 +1,18 @@
-import { BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, redactString, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js"
-import type { BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserProbeWaterfallArtifact, BrowserProbeWaterfallEntry, BrowserRedirectDiagnosticsSummary, BrowserStepAssertion, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
+import type { BrowserProbeArtifact, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, serializeBrowserError } from "./browser-metrics.js"
 import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewSecureContextError, browserPreviewTopology, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
-import { BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeReplayability, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
+import { BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeAssertionsFromArgs, browserProbeCheckpoint, browserProbeMemoryArtifact, browserProbePendingCheckpoints, browserProbePerformanceArtifact, browserProbeViewport, executeBrowserProbeAssertions, navigateBrowserProbe } from "./browser-probe.js"
 import { argValue, commaListArg, durationArg, strictBooleanArg, viewportArg } from "./commands.js"
 import type { PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
-import { addBrowserProbeNetworkCount, browserAuthRequest, browserProbeArtifactRefs, browserRedirectDiagnosticsArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, browserWordPressDiagnosticsArtifact, createBrowserProbeProgressTracker, fileSha256, installBrowserWordPressDiagnostics, installWordPressAdminAuthCookies, now, requestHost, safeBrowserProbeUrl, sha256, sortBrowserProbeNetworkCounts, withBrowserProbeLiveness, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserProbeScriptCheckpoint, type BrowserStorageStateImport } from "./browser-probe-support.js"
+import { browserAuthRequest, browserProbeWaterfallArtifact, browserRedirectDiagnosticsArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, browserWordPressDiagnosticsArtifact, createBrowserProbeProgressTracker, fileSha256, installBrowserWordPressDiagnostics, installWordPressAdminAuthCookies, now, sha256, withBrowserProbeLiveness, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserProbeScriptCheckpoint, type BrowserStorageStateImport } from "./browser-probe-support.js"
+import { BrowserProbeSessionResultBuilder, browserProbeCaptureSelection } from "./browser-probe-session-result-builder.js"
 
 const BROWSER_PROBE_PROFILE_OVERRIDES = new Set(["browser", "device", "locale", "permissions", "throttle", "timezone", "user-agent", "viewport"])
 
@@ -200,10 +201,7 @@ export async function runSingleBrowserProbeCommand({
   const livenessPolicy = browserCommandLivenessPolicy({ wallTimeoutMs, idleTimeoutMs: stallTimeoutMs })
   const lifecycleSelectors = runPlan.lifecycleSelectors
   const assertions = runPlan.assertions
-  const capturesConsoleForAssertions = assertions.some((assertion) => assertion.type === "no-console-errors" || assertion.type === "no-errors")
-  const capturesErrorsForAssertions = assertions.some((assertion) => assertion.type === "no-page-errors" || assertion.type === "no-errors")
-  const capturesNetworkForAssertions = browserProbeAssertionsNeedNetwork(assertions)
-  const capturesBrowserMetrics = capture.has("performance") || capture.has("memory") || browserProbeAssertionsNeedMetrics(assertions)
+  const captureSelection = browserProbeCaptureSelection(capture, assertions)
   const prePageScriptMetadata = prePageScript ? browserProbeScriptMetadata(prePageScript) : undefined
   const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
   const { preview, networkPolicy } = topology
@@ -247,6 +245,7 @@ export async function runSingleBrowserProbeCommand({
   let assertionResults: import("./browser-artifacts.js").BrowserStepAssertion[] = []
   let pendingError: Error | undefined
   let artifact: BrowserProbeArtifact | undefined
+  let output: string | undefined
   let wordpressDiagnosticsReady = false
   const abortHandler = () => {
     pendingError = pendingError ?? new Error("Browser command aborted during runtime cleanup")
@@ -306,7 +305,7 @@ export async function runSingleBrowserProbeCommand({
     if (lifecycleSelectors.length > 0) {
       await page.addInitScript(browserProbeLifecycleInitScript(lifecycleSelectors))
     }
-    if (capturesBrowserMetrics) {
+    if (captureSelection.metrics) {
       await page.addInitScript(BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT)
     }
     if (prePageScript) {
@@ -317,8 +316,8 @@ export async function runSingleBrowserProbeCommand({
     contextDetails = await browserProbeContextDetails(page, requestedContext, viewport)
     capabilityDiagnostics = await browserProbeCapabilityDiagnostics(page, viewport)
     attachBrowserCaptureListeners({
-      captureConsole: capture.has("console") || capturesConsoleForAssertions,
-      captureErrors: capture.has("errors") || capturesErrorsForAssertions,
+      captureConsole: captureSelection.console,
+      captureErrors: captureSelection.errors,
       captureNetwork: true,
       consoleMessages,
       errors,
@@ -344,7 +343,7 @@ export async function runSingleBrowserProbeCommand({
     if (secureContextError) {
       throw secureContextError
     }
-    if (capturesBrowserMetrics) {
+    if (captureSelection.metrics) {
       checkpoints.push(await browserProbeCheckpoint(page, "after-navigation"))
     }
     if (script) {
@@ -353,7 +352,7 @@ export async function runSingleBrowserProbeCommand({
         return run()
       }, script), livenessPolicy, "script")
       progress.mark("script")
-      if (capturesBrowserMetrics) {
+      if (captureSelection.metrics) {
         const pendingCheckpoints = await browserProbePendingCheckpoints(page)
         if (pendingCheckpoints.length > 0) {
           progress.mark("checkpoint")
@@ -365,15 +364,15 @@ export async function runSingleBrowserProbeCommand({
     if (durationMs > 0 && waitFor !== "duration") {
       await withBrowserProbeLiveness(page, progress, failFast, page.waitForTimeout(durationMs), livenessPolicy, "duration")
       progress.mark("duration")
-      if (capturesBrowserMetrics) {
+      if (captureSelection.metrics) {
         checkpoints.push(await browserProbeCheckpoint(page, "after-duration"))
       }
     }
     if (assertions.length > 0) {
       await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
-      const assertionMetrics = capturesBrowserMetrics ? browserProbeBenchMetrics(browserProbeMemoryArtifact(checkpoints), browserProbePerformanceArtifact(checkpoints)) : {}
+      const assertionMetrics = captureSelection.metrics ? browserProbeBenchMetrics(browserProbeMemoryArtifact(checkpoints), browserProbePerformanceArtifact(checkpoints)) : {}
       assertionResults = await executeBrowserProbeAssertions(page, assertions, consoleMessages, errors, network, assertionMetrics)
-      if (capturesBrowserMetrics) {
+      if (captureSelection.metrics) {
         checkpoints.push(await browserProbeCheckpoint(page, "after-assertions"))
       }
       const fatalFailures = assertionResults.filter((assertion) => !assertion.passed && !assertion.advisory)
@@ -409,7 +408,7 @@ export async function runSingleBrowserProbeCommand({
     if (page) {
       finalUrl = page.url()
       windowLocationOrigin = windowLocationOrigin ?? await page.evaluate(() => window.location.origin).catch(() => undefined)
-      if (capturesBrowserMetrics) {
+      if (captureSelection.metrics) {
         checkpoints.push(await browserProbeCheckpoint(page, "final"))
         if (capture.has("memory")) {
           memoryArtifact = browserProbeMemoryArtifact(checkpoints)
@@ -445,13 +444,13 @@ export async function runSingleBrowserProbeCommand({
     }
     await settleBrowserNetworkTasks(networkTasks, livenessPolicy.networkSettleTimeoutMs)
     await browser.close()
-    if (capture.has("console") || capturesConsoleForAssertions) {
+    if (captureSelection.console) {
       await artifactSession.writeJsonLines("console", "console.jsonl", consoleMessages)
     }
-    if (capture.has("errors") || capturesErrorsForAssertions) {
+    if (captureSelection.errors) {
       await artifactSession.writeJsonLines("errors", "errors.jsonl", errors)
     }
-    if (capture.has("network") || capturesNetworkForAssertions) {
+    if (captureSelection.network) {
       await artifactSession.writeJsonLines("network", "network.jsonl", network)
       await artifactSession.writeJson("waterfall", "waterfall.json", browserProbeWaterfallArtifact(network, startedAt))
     }
@@ -478,8 +477,6 @@ export async function runSingleBrowserProbeCommand({
     if (redirectDiagnostics) {
       await artifactSession.writeJson("redirectDiagnostics", "redirect-diagnostics.json", redirectDiagnostics)
     }
-    const redirectDiagnosticsSummary = redirectDiagnostics?.summary
-
     const wordpressDiagnostics = await browserWordPressDiagnosticsArtifact({
       artifactPath: `${browserFilesDirectory}/wordpress-diagnostics.json`,
       network,
@@ -489,142 +486,53 @@ export async function runSingleBrowserProbeCommand({
     if (wordpressDiagnostics) {
       await artifactSession.writeJson("wordpressDiagnostics", "wordpress-diagnostics.json", wordpressDiagnostics)
     }
-    const wordpressDiagnosticsSummary = wordpressDiagnostics?.summary
-
-    const assertionPassed = assertionResults.filter((assertion) => assertion.passed).length
-    const assertionFailed = assertionResults.filter((assertion) => !assertion.passed).length
-    const advisoryFailed = assertionResults.filter((assertion) => !assertion.passed && assertion.advisory).length
-    const assertionSummary = {
-      total: assertionResults.length,
-      passed: assertionPassed,
-      failed: assertionFailed,
-      advisoryFailed,
-      fatalFailed: assertionFailed - advisoryFailed,
-      results: assertionResults,
-    }
-
-    const finishedAt = now()
-    const review = browserProbeReviewSummary({
+    const result = new BrowserProbeSessionResultBuilder().compose({
+      assertions: assertionResults,
+      authSummary,
       browser: browserMetadata,
+      browserFilesDirectory,
+      capabilities: capabilityDiagnostics,
       capture,
+      captureSelection,
       checkpoints,
+      command,
       consoleMessages,
+      context: contextDetails,
       durationMs,
       errors,
-      files: browserProbeArtifactRefs(browserFilesDirectory, capture, {
-        checkpoints: checkpoints.length > 0,
-        console: capture.has("console") || capturesConsoleForAssertions,
-        errors: capture.has("errors") || capturesErrorsForAssertions,
-        html: capture.has("html") ? htmlSha256 : undefined,
-        lifecycle: Boolean(lifecycleArtifact),
-        memory: Boolean(memoryArtifact),
-        network: capture.has("network") || capturesNetworkForAssertions,
-        waterfall: capture.has("network") || capturesNetworkForAssertions,
-        performance: Boolean(performanceArtifact),
-        redirectDiagnostics: Boolean(redirectDiagnostics),
-        screenshot: capture.has("screenshot") ? screenshotSha256 : undefined,
-        wordpressDiagnostics: Boolean(wordpressDiagnostics),
-      }),
-      finishedAt,
-      network,
-      performanceArtifact,
-      startedAt,
-      throttle: throttleProfile?.id ?? null,
-      totalDurationMs: Date.now() - startedAtMs,
-      viewport,
-      waitFor,
-      redirectDiagnostics: redirectDiagnosticsSummary,
-      wordpressDiagnostics: wordpressDiagnosticsSummary,
-    })
-    await artifactSession.writeJson("review", "review.json", review)
-
-    artifact = {
-      artifactType: "probe",
-      requestedUrl: targetUrl,
-      url: targetUrl,
-      preview,
-      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
-      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...topology.origins,
-      ...(prePageScriptMetadata ? { prePageScript: prePageScriptMetadata } : {}),
-      files: {
-        ...(capture.has("console") || capturesConsoleForAssertions ? { console: `${browserFilesDirectory}/console.jsonl` } : {}),
-        ...(checkpoints.length > 0 ? { checkpoints: `${browserFilesDirectory}/checkpoints.jsonl` } : {}),
-        ...(capture.has("errors") || capturesErrorsForAssertions ? { errors: `${browserFilesDirectory}/errors.jsonl` } : {}),
-        ...(htmlSha256 ? { html: `${browserFilesDirectory}/snapshot.html` } : {}),
-        ...(lifecycleArtifact ? { lifecycle: `${browserFilesDirectory}/lifecycle.json` } : {}),
-        ...(memoryArtifact ? { memory: `${browserFilesDirectory}/memory.json` } : {}),
-        ...(capture.has("network") || capturesNetworkForAssertions ? { network: `${browserFilesDirectory}/network.jsonl` } : {}),
-        ...(capture.has("network") || capturesNetworkForAssertions ? { waterfall: `${browserFilesDirectory}/waterfall.json` } : {}),
-        ...(performanceArtifact ? { performance: `${browserFilesDirectory}/performance.json` } : {}),
-        ...(redirectDiagnostics ? { redirectDiagnostics: `${browserFilesDirectory}/redirect-diagnostics.json` } : {}),
-        review: `${browserFilesDirectory}/review.json`,
-        ...(screenshotSha256 ? { screenshot: `${browserFilesDirectory}/screenshot.png` } : {}),
-        ...(wordpressDiagnostics ? { wordpressDiagnostics: `${browserFilesDirectory}/wordpress-diagnostics.json` } : {}),
-        summary: `${browserFilesDirectory}/summary.json`,
-      },
-      summary: {
-        ...(assertionSummary.total > 0 ? { assertions: assertionSummary } : {}),
-        consoleMessages: consoleMessages.length,
-        errors: errors.length,
-        finalUrl,
-        ...(windowLocationOrigin ? { windowLocationOrigin } : {}),
-        htmlSnapshot: Boolean(htmlSha256),
-        ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
-        ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-        ...(lifecycleArtifact ? { lifecycle: { schema: lifecycleArtifact.schema, version: lifecycleArtifact.version, startedAtMs: lifecycleArtifact.startedAtMs, selectors: lifecycleArtifact.selectors } } : {}),
-        liveness: { wallTimeoutMs, stallTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
-        ...(memoryArtifact ? { memory: memoryArtifact.peak } : {}),
-        ...(memoryArtifact || performanceArtifact ? { metrics: browserProbeBenchMetrics(memoryArtifact, performanceArtifact) } : {}),
-        networkEvents: network.length,
-        ...(performanceArtifact?.phaseMetrics ? { phaseMetrics: performanceArtifact.phaseMetrics } : {}),
-        ...(performanceArtifact ? { performance: performanceArtifact.peak } : {}),
-        progress: progress.summary(),
-        review,
-        ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
-        ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
-        context: contextDetails,
-        auth: authSummary,
-        capabilities: capabilityDiagnostics,
-        replayability: browserProbeReplayability(capture),
-        screenshot: Boolean(screenshotSha256),
-        ...(typeof scriptResult !== "undefined" ? { scriptResult } : {}),
-        viewport,
-      },
-    }
-    await artifactSession.writeJson("summary", "summary.json", {
-      schema: "wp-codebox/browser-probe/v1",
-      requestedUrl: targetUrl,
-      preview,
-      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
-      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...topology.origins,
-      finalUrl,
-      ...(windowLocationOrigin ? { windowLocationOrigin } : {}),
-      waitFor,
-      durationMs,
-      ...(lifecycleSelectors.length > 0 ? { observe: lifecycleSelectors } : {}),
       failFast,
-      stallTimeoutMs,
-      capture: [...capture].sort(),
-      ...(assertionSummary.total > 0 ? { assertions: assertionSummary } : {}),
-      ...(prePageScriptMetadata ? { prePageScript: prePageScriptMetadata } : {}),
-      startedAt,
-      finishedAt,
-      files: artifact.files,
+      finalUrl,
       hashes: {
-        ...(htmlSha256 ? { html: { algorithm: "sha256", value: htmlSha256 } } : {}),
-        ...(screenshotSha256 ? { screenshot: { algorithm: "sha256", value: screenshotSha256 } } : {}),
+        ...(capture.has("html") ? { htmlSha256 } : {}),
+        ...(capture.has("screenshot") ? { screenshotSha256 } : {}),
       },
-      context: contextDetails,
-      auth: authSummary,
-      capabilities: capabilityDiagnostics,
-      review,
-      ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
-      ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
+      lifecycleArtifact,
+      lifecycleSelectors,
+      liveness: { wallTimeoutMs, stallTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
+      memoryArtifact,
+      network,
+      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicySummary: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
+      performanceArtifact,
+      prePageScriptMetadata,
+      preview,
+      ...(server.previewProxyDiagnostics ? { previewProxyDiagnostics: server.previewProxyDiagnostics } : {}),
+      progress,
+      redirectDiagnostics: redirectDiagnostics ? { summary: redirectDiagnostics.summary } : undefined,
+      requestedUrl: targetUrl,
+      scriptResult,
+      startedAt,
+      startedAtMs,
+      throttleId: throttleProfile?.id ?? null,
+      topologyOrigins: topology.origins,
       viewport,
-      summary: artifact.summary,
+      waitFor,
+      windowLocationOrigin,
+      wordpressDiagnostics: wordpressDiagnostics ? { summary: wordpressDiagnostics.summary } : undefined,
     })
+    await artifactSession.writeJson("review", "review.json", result.review)
+    artifact = result.artifact
+    output = result.output
+    await artifactSession.writeJson("summary", "summary.json", result.summary)
   }
 
   abortSignal?.removeEventListener("abort", abortHandler)
@@ -639,17 +547,7 @@ export async function runSingleBrowserProbeCommand({
   }
   return {
     artifact,
-    output: `${JSON.stringify({
-      command,
-      requestedUrl: targetUrl,
-      preview,
-      ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
-      ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
-      ...topology.origins,
-      finalUrl: artifact.summary.finalUrl ?? targetUrl,
-      files: artifact.files,
-      summary: artifact.summary,
-    }, null, 2)}\n`,
+    output: output ?? "",
   }
 }
 
@@ -867,231 +765,4 @@ function browserProbeCapabilityViewport(viewport: BrowserProbeViewport): Browser
     isMobile: viewport.isMobile,
     hasTouch: viewport.hasTouch,
   }
-}
-
-function browserProbeReviewSummary(input: {
-  browser: BrowserProbeReviewSummary["browser"]
-  capture: Set<string>
-  checkpoints: BrowserProbeCheckpointRecord[]
-  consoleMessages: Record<string, unknown>[]
-  durationMs: number
-  errors: BrowserProbeErrorRecord[]
-  files: Record<string, BrowserProbeArtifactRef>
-  finishedAt: string
-  network: BrowserProbeNetworkRecord[]
-  performanceArtifact?: BrowserProbePerformanceArtifact
-  startedAt: string
-  throttle: string | null
-  totalDurationMs: number
-  viewport: BrowserProbeViewport | null
-  waitFor: string
-  redirectDiagnostics?: BrowserRedirectDiagnosticsSummary
-  wordpressDiagnostics?: BrowserWordPressDiagnosticsSummary
-}): BrowserProbeReviewSummary {
-  const performance = input.performanceArtifact?.final
-  const paint = performance?.paint
-  const navigation = performance?.navigation ?? {
-    type: null,
-    redirectCount: 0,
-    durationMs: null,
-    domContentLoadedMs: null,
-    loadEventMs: null,
-    responseStartMs: null,
-    responseEndMs: null,
-    requestStartMs: null,
-    ttfbMs: null,
-    redirectMs: null,
-  }
-  const missingReason = input.capture.has("performance")
-    ? "metric not reported by browser"
-    : "capture=performance was not requested"
-  const pageErrors = input.errors.filter((error) => error.type === "pageerror")
-  const probeErrors = input.errors.filter((error) => error.type === "probe-error")
-  const consoleErrors = input.consoleMessages.filter((message) => message.type === "error")
-  const lcpUrl = safeBrowserProbeUrl(paint?.largestContentfulPaintUrl ?? undefined)
-
-  return {
-    schema: "wp-codebox/browser-probe-review/v1",
-    version: 1,
-    browser: input.browser,
-    runtime: {
-      node: process.version,
-      platform: process.platform,
-      arch: process.arch,
-    },
-    profile: {
-      viewport: input.viewport,
-      userAgent: input.viewport?.userAgent ?? null,
-      throttle: input.throttle,
-      waitFor: input.waitFor,
-      durationMs: input.durationMs,
-    },
-    timings: {
-      startedAt: input.startedAt,
-      finishedAt: input.finishedAt,
-      totalDurationMs: browserProbeMetric(input.totalDurationMs, "probe wall-clock duration unavailable"),
-      navigation,
-      ttfbMs: browserProbeMetric(navigation.ttfbMs, missingReason),
-      firstContentfulPaintMs: browserProbeMetric(paint?.firstContentfulPaintMs, missingReason),
-      largestContentfulPaintMs: browserProbeMetric(paint?.largestContentfulPaintMs, missingReason),
-      loadEventMs: browserProbeMetric(navigation.loadEventMs, missingReason),
-    },
-    lcp: {
-      status: typeof paint?.largestContentfulPaintMs === "number" ? "available" : "missing",
-      ...(typeof paint?.largestContentfulPaintMs === "number" ? {} : { reason: missingReason }),
-      element: paint?.largestContentfulPaintElement ?? null,
-      size: paint?.largestContentfulPaintSize ?? null,
-      url: lcpUrl ?? null,
-    },
-    errors: {
-      console: browserProbeIssueSummary(consoleErrors.length, Boolean(input.files.console), input.files.console?.path),
-      page: browserProbeIssueSummary(pageErrors.length, Boolean(input.files.errors), input.files.errors?.path),
-      probe: browserProbeIssueSummary(probeErrors.length, Boolean(input.files.errors), input.files.errors?.path),
-    },
-    network: browserProbeNetworkReviewSummary(input.network, input.files.network, input.files.waterfall),
-    ...(input.redirectDiagnostics ? { redirectDiagnostics: input.redirectDiagnostics } : {}),
-    ...(input.wordpressDiagnostics ? { wordpressDiagnostics: input.wordpressDiagnostics } : {}),
-    milestones: {
-      status: input.checkpoints.length > 0 ? "captured" : "not-captured",
-      count: input.checkpoints.length,
-      names: [...new Set(input.checkpoints.map((checkpoint) => checkpoint.name).filter(Boolean))].sort(),
-      ...(input.files.checkpoints ? { artifact: input.files.checkpoints.path } : {}),
-    },
-    artifacts: input.files,
-  }
-}
-
-function browserProbeMetric(value: number | null | undefined, reason: string): BrowserProbeMeasuredMetric {
-  return typeof value === "number" && Number.isFinite(value)
-    ? { status: "available", value, unit: "ms" }
-    : { status: "missing", value: null, unit: "ms", reason }
-}
-
-function browserProbeIssueSummary(count: number, captured: boolean, artifact?: string): BrowserProbeReviewSummary["errors"]["console"] {
-  if (!captured && count === 0) {
-    return { count: 0, status: "not-captured" }
-  }
-  return {
-    count,
-    status: count > 0 ? "issues" : "ok",
-    ...(artifact ? { artifact } : {}),
-  }
-}
-
-function browserProbeNetworkReviewSummary(network: BrowserProbeNetworkRecord[], networkArtifact?: BrowserProbeArtifactRef, waterfallArtifact?: BrowserProbeArtifactRef): BrowserProbeNetworkReviewSummary {
-  if (!networkArtifact) {
-    return { status: "not-captured", events: 0, responses: 0, failures: 0, byHost: {}, byType: {} }
-  }
-
-  const byHost: Record<string, BrowserProbeNetworkCountSummary> = {}
-  const byType: Record<string, BrowserProbeNetworkCountSummary> = {}
-  for (const record of network) {
-    addBrowserProbeNetworkCount(byHost, requestHost(record.url) || "unknown", record)
-    addBrowserProbeNetworkCount(byType, record.resourceType || "unknown", record)
-  }
-
-  return {
-    status: "captured",
-    events: network.length,
-    responses: network.filter((record) => record.type === "response").length,
-    failures: network.filter((record) => record.type === "requestfailed").length,
-    byHost: sortBrowserProbeNetworkCounts(byHost),
-    byType: sortBrowserProbeNetworkCounts(byType),
-    ...(waterfallArtifact ? { waterfall: waterfallArtifact } : {}),
-  }
-}
-
-function browserProbeWaterfallArtifact(network: BrowserProbeNetworkRecord[], startedAt: string): BrowserProbeWaterfallArtifact {
-  return {
-    schema: "wp-codebox/browser-waterfall/v1",
-    version: 1,
-    capturedAt: now(),
-    startedAt,
-    summary: {
-      requests: network.length,
-      responses: network.filter((record) => record.type === "response").length,
-      failures: network.filter((record) => record.type === "requestfailed").length,
-      transferSizeBytes: network.reduce((total, record) => total + finiteNumber(record.transferSize, 0), 0),
-    },
-    log: {
-      version: "1.2",
-      creator: { name: "wp-codebox", version: "1" },
-      entries: network.map(browserProbeWaterfallEntry),
-    },
-  }
-}
-
-function browserProbeWaterfallEntry(record: BrowserProbeNetworkRecord): BrowserProbeWaterfallEntry {
-  const timings = browserProbeWaterfallTimings(record.timing ?? {})
-  const startedDateTime = browserProbeWaterfallStartedDateTime(record)
-  const responseEnd = finiteNumber(record.timing?.responseEnd, 0)
-  const fallbackTime = Math.max(0, Date.parse(record.timestamp) - Date.parse(startedDateTime))
-  const time = responseEnd > 0 ? responseEnd : fallbackTime
-  return {
-    startedDateTime,
-    time,
-    request: {
-      method: record.method,
-      url: redactBrowserArtifactUrl(record.url),
-    },
-    response: {
-      status: record.status ?? 0,
-      statusText: record.statusText ?? (record.type === "requestfailed" ? "Request Failed" : ""),
-      content: { mimeType: record.contentType ?? "" },
-      redirectURL: "",
-    },
-    cache: {},
-    timings,
-    _wpCodebox: {
-      type: record.type,
-      resourceType: record.resourceType,
-      timestamp: record.timestamp,
-      ...(typeof record.ok === "boolean" ? { ok: record.ok } : {}),
-      ...(typeof record.transferSize === "number" ? { transferSize: record.transferSize } : {}),
-      ...(typeof record.requestBodySize === "number" ? { requestBodySize: record.requestBodySize } : {}),
-      ...(typeof record.responseBodySize === "number" ? { responseBodySize: record.responseBodySize } : {}),
-      ...(record.failure ? { failure: record.failure } : {}),
-    },
-  }
-}
-
-function browserProbeWaterfallTimings(timing: Record<string, number>): BrowserProbeWaterfallEntry["timings"] {
-  const requestStart = finiteNumber(timing.requestStart, 0)
-  const responseStart = finiteNumber(timing.responseStart, 0)
-  const responseEnd = finiteNumber(timing.responseEnd, responseStart)
-  const dns = timingDelta(timing.domainLookupStart, timing.domainLookupEnd)
-  const connect = timingDelta(timing.connectStart, timing.connectEnd)
-  const ssl = timingDelta(timing.secureConnectionStart, timing.connectEnd)
-  return {
-    blocked: Math.max(0, requestStart),
-    dns,
-    connect,
-    ssl,
-    send: timingDelta(timing.requestStart, timing.requestStart),
-    wait: responseStart >= requestStart ? responseStart - requestStart : 0,
-    receive: responseEnd >= responseStart ? responseEnd - responseStart : 0,
-  }
-}
-
-function browserProbeWaterfallStartedDateTime(record: BrowserProbeNetworkRecord): string {
-  const startTime = record.timing?.startTime
-  if (typeof startTime === "number" && Number.isFinite(startTime) && startTime > 0) {
-    return new Date(startTime).toISOString()
-  }
-  return record.timestamp
-}
-
-function timingDelta(start: number | undefined, end: number | undefined): number {
-  if (typeof start !== "number" || typeof end !== "number" || !Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < start) {
-    return -1
-  }
-  return end - start
-}
-
-function finiteNumber(value: number | undefined, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback
-}
-
-function redactBrowserArtifactUrl(url: string): string {
-  return redactString(url, { redactAllUrlQueryValues: true, redactUrlHash: true, redactQueryAssignments: true })
 }

--- a/packages/runtime-playground/src/browser-probe-session-result-builder.ts
+++ b/packages/runtime-playground/src/browser-probe-session-result-builder.ts
@@ -1,0 +1,395 @@
+import type { PlaygroundPreviewProxyDiagnostics } from "./preview-server.js"
+import type { BrowserPreviewTopology } from "./browser-preview-routing.js"
+import { addBrowserProbeNetworkCount, browserProbeArtifactRefs, createBrowserProbeProgressTracker, now, requestHost, safeBrowserProbeUrl, sortBrowserProbeNetworkCounts } from "./browser-probe-support.js"
+import { browserProbeBenchMetrics } from "./browser-metrics.js"
+import { browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeReplayability } from "./browser-probe.js"
+import type { BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkPolicySummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserRedirectDiagnosticsSummary, BrowserStepAssertion, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
+
+export interface BrowserProbeCaptureSelection {
+  console: boolean
+  errors: boolean
+  network: boolean
+  metrics: boolean
+  consoleForAssertions: boolean
+  errorsForAssertions: boolean
+  networkForAssertions: boolean
+}
+
+export function browserProbeCaptureSelection(capture: Set<string>, assertions: ReturnType<typeof browserProbeAssertionsFromArgs>): BrowserProbeCaptureSelection {
+  const consoleForAssertions = assertions.some((assertion) => assertion.type === "no-console-errors" || assertion.type === "no-errors")
+  const errorsForAssertions = assertions.some((assertion) => assertion.type === "no-page-errors" || assertion.type === "no-errors")
+  const networkForAssertions = browserProbeAssertionsNeedNetwork(assertions)
+  const metricsForAssertions = browserProbeAssertionsNeedMetrics(assertions)
+  return {
+    console: capture.has("console") || consoleForAssertions,
+    errors: capture.has("errors") || errorsForAssertions,
+    network: capture.has("network") || networkForAssertions,
+    metrics: capture.has("performance") || capture.has("memory") || metricsForAssertions,
+    consoleForAssertions,
+    errorsForAssertions,
+    networkForAssertions,
+  }
+}
+
+export interface BrowserProbeArtifactHashes {
+  htmlSha256?: string
+  screenshotSha256?: string
+}
+
+export interface BrowserProbeSessionResultInput {
+  assertions: BrowserStepAssertion[]
+  authSummary?: BrowserProbeAuthSummary
+  browser: BrowserProbeReviewSummary["browser"]
+  browserFilesDirectory: string
+  capabilities?: BrowserProbeCapabilityDiagnostics
+  capture: Set<string>
+  captureSelection: BrowserProbeCaptureSelection
+  checkpoints: BrowserProbeCheckpointRecord[]
+  command: string
+  consoleMessages: Record<string, unknown>[]
+  context?: BrowserProbeContextDetails
+  durationMs: number
+  errors: BrowserProbeErrorRecord[]
+  failFast: boolean
+  finalUrl: string
+  hashes: BrowserProbeArtifactHashes
+  lifecycleArtifact?: BrowserProbeLifecycleArtifact
+  lifecycleSelectors: string[]
+  liveness: { wallTimeoutMs: number; stallTimeoutMs: number; networkSettleTimeoutMs: number }
+  memoryArtifact?: BrowserProbeMemoryArtifact
+  network: BrowserProbeNetworkRecord[]
+  networkPolicySummary?: BrowserProbeNetworkPolicySummary
+  performanceArtifact?: BrowserProbePerformanceArtifact
+  prePageScriptMetadata?: BrowserProbeScriptMetadata
+  preview: BrowserProbePreviewRouting
+  previewProxyDiagnostics?: PlaygroundPreviewProxyDiagnostics
+  progress: ReturnType<typeof createBrowserProbeProgressTracker>
+  redirectDiagnostics?: { summary: BrowserRedirectDiagnosticsSummary }
+  requestedUrl: string
+  scriptResult?: unknown
+  startedAt: string
+  startedAtMs: number
+  throttleId: string | null
+  topologyOrigins: BrowserPreviewTopology["origins"]
+  viewport: BrowserProbeViewport | null
+  waitFor: string
+  windowLocationOrigin?: string
+  wordpressDiagnostics?: { summary: BrowserWordPressDiagnosticsSummary }
+}
+
+export interface BrowserProbeSessionResult {
+  artifact: BrowserProbeArtifact
+  output: string
+  review: BrowserProbeReviewSummary
+  summary: Record<string, unknown>
+}
+
+export class BrowserProbeSessionResultBuilder {
+  compose(input: BrowserProbeSessionResultInput): BrowserProbeSessionResult {
+    const assertionSummary = browserProbeAssertionSummary(input.assertions)
+    const finishedAt = now()
+    const files = browserProbeArtifactFileMap(input)
+    const review = browserProbeReviewSummary({
+      browser: input.browser,
+      capture: input.capture,
+      checkpoints: input.checkpoints,
+      consoleMessages: input.consoleMessages,
+      durationMs: input.durationMs,
+      errors: input.errors,
+      files: browserProbeArtifactRefs(input.browserFilesDirectory, input.capture, {
+        checkpoints: input.checkpoints.length > 0,
+        console: Boolean(files.console),
+        errors: Boolean(files.errors),
+        html: input.hashes.htmlSha256,
+        lifecycle: Boolean(input.lifecycleArtifact),
+        memory: Boolean(input.memoryArtifact),
+        network: Boolean(files.network),
+        waterfall: Boolean(files.waterfall),
+        performance: Boolean(input.performanceArtifact),
+        redirectDiagnostics: Boolean(input.redirectDiagnostics),
+        screenshot: input.hashes.screenshotSha256,
+        wordpressDiagnostics: Boolean(input.wordpressDiagnostics),
+      }),
+      finishedAt,
+      network: input.network,
+      performanceArtifact: input.performanceArtifact,
+      startedAt: input.startedAt,
+      throttle: input.throttleId,
+      totalDurationMs: Date.now() - input.startedAtMs,
+      viewport: input.viewport,
+      waitFor: input.waitFor,
+      redirectDiagnostics: input.redirectDiagnostics?.summary,
+      wordpressDiagnostics: input.wordpressDiagnostics?.summary,
+    })
+    const summary = browserProbeArtifactSummary(input, assertionSummary, review)
+    const artifact: BrowserProbeArtifact = {
+      artifactType: "probe",
+      requestedUrl: input.requestedUrl,
+      url: input.requestedUrl,
+      preview: input.preview,
+      ...(input.previewProxyDiagnostics ? { previewProxy: input.previewProxyDiagnostics } : {}),
+      ...(input.networkPolicySummary ? { networkPolicy: input.networkPolicySummary } : {}),
+      ...input.topologyOrigins,
+      ...(input.prePageScriptMetadata ? { prePageScript: input.prePageScriptMetadata } : {}),
+      files,
+      summary,
+    }
+    return {
+      artifact,
+      review,
+      summary: browserProbeSummaryArtifact(input, artifact, assertionSummary, review, finishedAt),
+      output: `${JSON.stringify({
+        command: input.command,
+        requestedUrl: input.requestedUrl,
+        preview: input.preview,
+        ...(input.previewProxyDiagnostics ? { previewProxy: input.previewProxyDiagnostics } : {}),
+        ...(input.networkPolicySummary ? { networkPolicy: input.networkPolicySummary } : {}),
+        ...input.topologyOrigins,
+        finalUrl: artifact.summary.finalUrl ?? input.requestedUrl,
+        files: artifact.files,
+        summary: artifact.summary,
+      }, null, 2)}\n`,
+    }
+  }
+}
+
+function browserProbeArtifactFileMap(input: BrowserProbeSessionResultInput): BrowserProbeArtifact["files"] {
+  return {
+    ...(input.capture.has("console") || input.captureSelection?.consoleForAssertions ? { console: `${input.browserFilesDirectory}/console.jsonl` } : {}),
+    ...(input.checkpoints.length > 0 ? { checkpoints: `${input.browserFilesDirectory}/checkpoints.jsonl` } : {}),
+    ...(input.capture.has("errors") || input.captureSelection?.errorsForAssertions ? { errors: `${input.browserFilesDirectory}/errors.jsonl` } : {}),
+    ...(input.hashes.htmlSha256 ? { html: `${input.browserFilesDirectory}/snapshot.html` } : {}),
+    ...(input.lifecycleArtifact ? { lifecycle: `${input.browserFilesDirectory}/lifecycle.json` } : {}),
+    ...(input.memoryArtifact ? { memory: `${input.browserFilesDirectory}/memory.json` } : {}),
+    ...(input.capture.has("network") || input.captureSelection?.networkForAssertions ? { network: `${input.browserFilesDirectory}/network.jsonl` } : {}),
+    ...(input.capture.has("network") || input.captureSelection?.networkForAssertions ? { waterfall: `${input.browserFilesDirectory}/waterfall.json` } : {}),
+    ...(input.performanceArtifact ? { performance: `${input.browserFilesDirectory}/performance.json` } : {}),
+    ...(input.redirectDiagnostics ? { redirectDiagnostics: `${input.browserFilesDirectory}/redirect-diagnostics.json` } : {}),
+    review: `${input.browserFilesDirectory}/review.json`,
+    ...(input.hashes.screenshotSha256 ? { screenshot: `${input.browserFilesDirectory}/screenshot.png` } : {}),
+    ...(input.wordpressDiagnostics ? { wordpressDiagnostics: `${input.browserFilesDirectory}/wordpress-diagnostics.json` } : {}),
+    summary: `${input.browserFilesDirectory}/summary.json`,
+  }
+}
+
+function browserProbeArtifactSummary(input: BrowserProbeSessionResultInput, assertionSummary: BrowserAssertionsSummary, review: BrowserProbeReviewSummary): BrowserProbeArtifact["summary"] {
+  return {
+    ...(assertionSummary.total > 0 ? { assertions: assertionSummary } : {}),
+    consoleMessages: input.consoleMessages.length,
+    errors: input.errors.length,
+    finalUrl: input.finalUrl,
+    ...(input.windowLocationOrigin ? { windowLocationOrigin: input.windowLocationOrigin } : {}),
+    htmlSnapshot: Boolean(input.hashes.htmlSha256),
+    ...(input.previewProxyDiagnostics ? { previewProxy: input.previewProxyDiagnostics } : {}),
+    ...(input.networkPolicySummary ? { networkPolicy: input.networkPolicySummary } : {}),
+    ...(input.lifecycleArtifact ? { lifecycle: { schema: input.lifecycleArtifact.schema, version: input.lifecycleArtifact.version, startedAtMs: input.lifecycleArtifact.startedAtMs, selectors: input.lifecycleArtifact.selectors } } : {}),
+    liveness: input.liveness,
+    ...(input.memoryArtifact ? { memory: input.memoryArtifact.peak } : {}),
+    ...(input.memoryArtifact || input.performanceArtifact ? { metrics: browserProbeBenchMetrics(input.memoryArtifact, input.performanceArtifact) } : {}),
+    networkEvents: input.network.length,
+    ...(input.performanceArtifact?.phaseMetrics ? { phaseMetrics: input.performanceArtifact.phaseMetrics } : {}),
+    ...(input.performanceArtifact ? { performance: input.performanceArtifact.peak } : {}),
+    progress: input.progress.summary(),
+    review,
+    ...(input.redirectDiagnostics ? { redirectDiagnostics: input.redirectDiagnostics.summary } : {}),
+    ...(input.wordpressDiagnostics ? { wordpressDiagnostics: input.wordpressDiagnostics.summary } : {}),
+    context: input.context,
+    auth: input.authSummary,
+    capabilities: input.capabilities,
+    replayability: browserProbeReplayability(input.capture),
+    screenshot: Boolean(input.hashes.screenshotSha256),
+    ...(typeof input.scriptResult !== "undefined" ? { scriptResult: input.scriptResult } : {}),
+    viewport: input.viewport,
+  }
+}
+
+function browserProbeSummaryArtifact(input: BrowserProbeSessionResultInput, artifact: BrowserProbeArtifact, assertionSummary: BrowserAssertionsSummary, review: BrowserProbeReviewSummary, finishedAt: string): Record<string, unknown> {
+  return {
+    schema: "wp-codebox/browser-probe/v1",
+    requestedUrl: input.requestedUrl,
+    preview: input.preview,
+    ...(input.previewProxyDiagnostics ? { previewProxy: input.previewProxyDiagnostics } : {}),
+    ...(input.networkPolicySummary ? { networkPolicy: input.networkPolicySummary } : {}),
+    ...input.topologyOrigins,
+    finalUrl: input.finalUrl,
+    ...(input.windowLocationOrigin ? { windowLocationOrigin: input.windowLocationOrigin } : {}),
+    waitFor: input.waitFor,
+    durationMs: input.durationMs,
+    ...(input.lifecycleSelectors.length > 0 ? { observe: input.lifecycleSelectors } : {}),
+    failFast: input.failFast,
+    stallTimeoutMs: input.liveness.stallTimeoutMs,
+    capture: [...input.capture].sort(),
+    ...(assertionSummary.total > 0 ? { assertions: assertionSummary } : {}),
+    ...(input.prePageScriptMetadata ? { prePageScript: input.prePageScriptMetadata } : {}),
+    startedAt: input.startedAt,
+    finishedAt,
+    files: artifact.files,
+    hashes: {
+      ...(input.hashes.htmlSha256 ? { html: { algorithm: "sha256", value: input.hashes.htmlSha256 } } : {}),
+      ...(input.hashes.screenshotSha256 ? { screenshot: { algorithm: "sha256", value: input.hashes.screenshotSha256 } } : {}),
+    },
+    context: input.context,
+    auth: input.authSummary,
+    capabilities: input.capabilities,
+    review,
+    ...(input.redirectDiagnostics ? { redirectDiagnostics: input.redirectDiagnostics.summary } : {}),
+    ...(input.wordpressDiagnostics ? { wordpressDiagnostics: input.wordpressDiagnostics.summary } : {}),
+    viewport: input.viewport,
+    summary: artifact.summary,
+  }
+}
+
+interface BrowserAssertionsSummary {
+  total: number
+  passed: number
+  failed: number
+  advisoryFailed: number
+  fatalFailed: number
+  results: BrowserStepAssertion[]
+}
+
+function browserProbeAssertionSummary(assertionResults: BrowserStepAssertion[]): BrowserAssertionsSummary {
+  const passed = assertionResults.filter((assertion) => assertion.passed).length
+  const failed = assertionResults.filter((assertion) => !assertion.passed).length
+  const advisoryFailed = assertionResults.filter((assertion) => !assertion.passed && assertion.advisory).length
+  return {
+    total: assertionResults.length,
+    passed,
+    failed,
+    advisoryFailed,
+    fatalFailed: failed - advisoryFailed,
+    results: assertionResults,
+  }
+}
+
+function browserProbeReviewSummary(input: {
+  browser: BrowserProbeReviewSummary["browser"]
+  capture: Set<string>
+  checkpoints: BrowserProbeCheckpointRecord[]
+  consoleMessages: Record<string, unknown>[]
+  durationMs: number
+  errors: BrowserProbeErrorRecord[]
+  files: Record<string, BrowserProbeArtifactRef>
+  finishedAt: string
+  network: BrowserProbeNetworkRecord[]
+  performanceArtifact?: BrowserProbePerformanceArtifact
+  startedAt: string
+  throttle: string | null
+  totalDurationMs: number
+  viewport: BrowserProbeViewport | null
+  waitFor: string
+  redirectDiagnostics?: BrowserRedirectDiagnosticsSummary
+  wordpressDiagnostics?: BrowserWordPressDiagnosticsSummary
+}): BrowserProbeReviewSummary {
+  const performance = input.performanceArtifact?.final
+  const paint = performance?.paint
+  const navigation = performance?.navigation ?? {
+    type: null,
+    redirectCount: 0,
+    durationMs: null,
+    domContentLoadedMs: null,
+    loadEventMs: null,
+    responseStartMs: null,
+    responseEndMs: null,
+    requestStartMs: null,
+    ttfbMs: null,
+    redirectMs: null,
+  }
+  const missingReason = input.capture.has("performance")
+    ? "metric not reported by browser"
+    : "capture=performance was not requested"
+  const pageErrors = input.errors.filter((error) => error.type === "pageerror")
+  const probeErrors = input.errors.filter((error) => error.type === "probe-error")
+  const consoleErrors = input.consoleMessages.filter((message) => message.type === "error")
+  const lcpUrl = safeBrowserProbeUrl(paint?.largestContentfulPaintUrl ?? undefined)
+
+  return {
+    schema: "wp-codebox/browser-probe-review/v1",
+    version: 1,
+    browser: input.browser,
+    runtime: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    profile: {
+      viewport: input.viewport,
+      userAgent: input.viewport?.userAgent ?? null,
+      throttle: input.throttle,
+      waitFor: input.waitFor,
+      durationMs: input.durationMs,
+    },
+    timings: {
+      startedAt: input.startedAt,
+      finishedAt: input.finishedAt,
+      totalDurationMs: browserProbeMetric(input.totalDurationMs, "probe wall-clock duration unavailable"),
+      navigation,
+      ttfbMs: browserProbeMetric(navigation.ttfbMs, missingReason),
+      firstContentfulPaintMs: browserProbeMetric(paint?.firstContentfulPaintMs, missingReason),
+      largestContentfulPaintMs: browserProbeMetric(paint?.largestContentfulPaintMs, missingReason),
+      loadEventMs: browserProbeMetric(navigation.loadEventMs, missingReason),
+    },
+    lcp: {
+      status: typeof paint?.largestContentfulPaintMs === "number" ? "available" : "missing",
+      ...(typeof paint?.largestContentfulPaintMs === "number" ? {} : { reason: missingReason }),
+      element: paint?.largestContentfulPaintElement ?? null,
+      size: paint?.largestContentfulPaintSize ?? null,
+      url: lcpUrl ?? null,
+    },
+    errors: {
+      console: browserProbeIssueSummary(consoleErrors.length, Boolean(input.files.console), input.files.console?.path),
+      page: browserProbeIssueSummary(pageErrors.length, Boolean(input.files.errors), input.files.errors?.path),
+      probe: browserProbeIssueSummary(probeErrors.length, Boolean(input.files.errors), input.files.errors?.path),
+    },
+    network: browserProbeNetworkReviewSummary(input.network, input.files.network, input.files.waterfall),
+    ...(input.redirectDiagnostics ? { redirectDiagnostics: input.redirectDiagnostics } : {}),
+    ...(input.wordpressDiagnostics ? { wordpressDiagnostics: input.wordpressDiagnostics } : {}),
+    milestones: {
+      status: input.checkpoints.length > 0 ? "captured" : "not-captured",
+      count: input.checkpoints.length,
+      names: [...new Set(input.checkpoints.map((checkpoint) => checkpoint.name).filter(Boolean))].sort(),
+      ...(input.files.checkpoints ? { artifact: input.files.checkpoints.path } : {}),
+    },
+    artifacts: input.files,
+  }
+}
+
+function browserProbeMetric(value: number | null | undefined, reason: string): BrowserProbeMeasuredMetric {
+  return typeof value === "number" && Number.isFinite(value)
+    ? { status: "available", value, unit: "ms" }
+    : { status: "missing", value: null, unit: "ms", reason }
+}
+
+function browserProbeIssueSummary(count: number, captured: boolean, artifact?: string): BrowserProbeReviewSummary["errors"]["console"] {
+  if (!captured && count === 0) {
+    return { count: 0, status: "not-captured" }
+  }
+  return {
+    count,
+    status: count > 0 ? "issues" : "ok",
+    ...(artifact ? { artifact } : {}),
+  }
+}
+
+function browserProbeNetworkReviewSummary(network: BrowserProbeNetworkRecord[], networkArtifact?: BrowserProbeArtifactRef, waterfallArtifact?: BrowserProbeArtifactRef): BrowserProbeNetworkReviewSummary {
+  if (!networkArtifact) {
+    return { status: "not-captured", events: 0, responses: 0, failures: 0, byHost: {}, byType: {} }
+  }
+
+  const byHost: Record<string, BrowserProbeNetworkCountSummary> = {}
+  const byType: Record<string, BrowserProbeNetworkCountSummary> = {}
+  for (const record of network) {
+    addBrowserProbeNetworkCount(byHost, requestHost(record.url) || "unknown", record)
+    addBrowserProbeNetworkCount(byType, record.resourceType || "unknown", record)
+  }
+
+  return {
+    status: "captured",
+    events: network.length,
+    responses: network.filter((record) => record.type === "response").length,
+    failures: network.filter((record) => record.type === "requestfailed").length,
+    byHost: sortBrowserProbeNetworkCounts(byHost),
+    byType: sortBrowserProbeNetworkCounts(byType),
+    ...(waterfallArtifact ? { waterfall: waterfallArtifact } : {}),
+  }
+}


### PR DESCRIPTION
## Summary
- Extract browser probe capture/result composition from `browser-probe-runner.ts` into `BrowserProbeSessionResultBuilder`.
- Keep Playwright lifecycle, browser setup, navigation, capture collection, and artifact file writes in the runner.
- Preserve browser probe artifact paths, summary/review schema, command output shape, and waterfall artifact generation.

## Tests
- `npx tsx scripts/browser-probe-contract-smoke.ts`
- `npm run test:browser-artifact-session`
- `npm run test:browser-task-builder`
- `npm run build`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused TypeScript refactor and ran the verification commands; Chris remains responsible for review and merge.
