### PR TITLE
Add command validation descriptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "test:php-primitive-contract-parity": "php scripts/php-primitive-contract-parity-smoke.php",
     "test:php-run-plan-contract": "php scripts/php-run-plan-contract-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
+    "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",
     "test:php-path-policy-parity": "php scripts/php-path-policy-parity-smoke.php",

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,7 +1,7 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS, commandArgValue, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
-import { effectivePolicyCommandsFor } from "@automattic/wp-codebox-core/contracts"
+import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, commandArgValue, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { commandValidationDescriptorFor, effectivePolicyCommandsFor, type CommandArgValidationDescriptor } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
 import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandIds, listCliRuntimeBackendKinds } from "./runtime-backends.js"
@@ -40,7 +40,7 @@ export function parseWorkspaceRecipe(raw: string, recipePath: string): Workspace
   validateWorkspaceRecipeShape(recipe, recipePath)
   assertWorkspaceRecipeJsonSchema(recipe, {
     recipePath,
-    recipeCommandIds: [...supportedRecipeCommands],
+    recipeCommands: cliRecipeCommandDefinitions,
     runtimeBackendKinds: listCliRuntimeBackendKinds(),
     runtimeWordPressInstallModes: cliRuntimeRecipePolicy.wordpressInstallModes,
     runtimeOverlayKinds: supportedRuntimeOverlayKinds,
@@ -1065,6 +1065,8 @@ export function hasExplicitSiteSeedSelectors(scope: NonNullable<WorkspaceRecipeS
 }
 
 async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"][number], path: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {
+  validateRecipeStepDescriptorArgs(step, path, addIssue)
+
   if (step.command === "wordpress.run-php" || step.command === "wordpress.phpunit" || step.command === "wordpress.core-phpunit") {
     const code = recipeStepArgValue(step.args ?? [], "code")
     const codeFile = recipeStepArgValue(step.args ?? [], "code-file")
@@ -1110,78 +1112,6 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
   }
 
   if (step.command === "wordpress.browser-probe") {
-    if (!recipeStepArgValue(step.args ?? [], "url")?.trim()) {
-      addIssue("missing-url", `${path}.args`, "wordpress.browser-probe requires url=<path-or-url>.")
-    }
-
-    const waitFor = recipeStepArgValue(step.args ?? [], "wait-for")
-    if (waitFor && !["domcontentloaded", "load", "networkidle", "duration"].includes(waitFor) && !waitFor.startsWith("selector:")) {
-      addIssue("invalid-wait-for", `${path}.args`, "wordpress.browser-probe wait-for must be domcontentloaded, load, networkidle, selector:<selector>, or duration.")
-    }
-
-    const duration = recipeStepArgValue(step.args ?? [], "duration")
-    if (duration && !/^(\d+(?:\.\d+)?)(ms|s)$/.test(duration)) {
-      addIssue("invalid-duration", `${path}.args`, "wordpress.browser-probe duration must look like 500ms or 2s.")
-    }
-
-    const stallTimeout = recipeStepArgValue(step.args ?? [], "stall-timeout")
-    if (stallTimeout && !/^(\d+(?:\.\d+)?)(ms|s)$/.test(stallTimeout)) {
-      addIssue("invalid-stall-timeout", `${path}.args`, "wordpress.browser-probe stall-timeout must look like 500ms or 2s.")
-    }
-
-    const failFast = recipeStepArgValue(step.args ?? [], "fail-fast")
-    if (failFast && !["1", "0", "true", "false", "yes", "no", "on", "off"].includes(failFast.toLowerCase())) {
-      addIssue("invalid-fail-fast", `${path}.args`, "wordpress.browser-probe fail-fast must be true or false.")
-    }
-
-    const repeat = recipeStepArgValue(step.args ?? [], "repeat")
-    if (repeat && !/^[1-9]\d*$/.test(repeat)) {
-      addIssue("invalid-repeat", `${path}.args`, "wordpress.browser-probe repeat must be a positive integer.")
-    }
-
-    const resetBetween = recipeStepArgValue(step.args ?? [], "reset-between")
-    if (resetBetween && !["none", "reload", "new-page"].includes(resetBetween)) {
-      addIssue("invalid-reset-between", `${path}.args`, "wordpress.browser-probe reset-between must be none, reload, or new-page.")
-    }
-
-    const profiles = recipeStepArgValue(step.args ?? [], "profiles")
-    if (profiles) {
-      for (const profile of profiles.split(",").map((value) => value.trim()).filter(Boolean)) {
-        if (!(BROWSER_PROBE_CHROMIUM_PROFILE_IDS as readonly string[]).includes(profile)) {
-          addIssue("invalid-profile", `${path}.args`, `wordpress.browser-probe profile is unsupported: ${profile}`)
-        }
-      }
-    }
-
-    const profile = recipeStepArgValue(step.args ?? [], "profile")
-    if (profile && !(BROWSER_PROBE_CHROMIUM_PROFILE_IDS as readonly string[]).includes(profile)) {
-      addIssue("invalid-profile", `${path}.args`, `wordpress.browser-probe profile is unsupported: ${profile}`)
-    }
-
-    const throttle = recipeStepArgValue(step.args ?? [], "throttle")
-    if (throttle && throttle !== "none" && !(BROWSER_PROBE_THROTTLE_PROFILE_IDS as readonly string[]).includes(throttle)) {
-      addIssue("invalid-throttle", `${path}.args`, `wordpress.browser-probe throttle is unsupported: ${throttle}`)
-    }
-
-    const browser = recipeStepArgValue(step.args ?? [], "browser")
-    if (browser && !(BROWSER_PROBE_BROWSER_VALUES as readonly string[]).includes(browser)) {
-      addIssue("invalid-browser", `${path}.args`, `wordpress.browser-probe browser must be ${BROWSER_PROBE_BROWSER_VALUES.join(" or ")}.`)
-    }
-
-    const viewport = recipeStepArgValue(step.args ?? [], "viewport")
-    if (viewport && !/^\d+x\d+$/i.test(viewport)) {
-      addIssue("invalid-viewport", `${path}.args`, "wordpress.browser-probe viewport must use <width>x<height>, for example 390x844.")
-    }
-
-    const capture = recipeStepArgValue(step.args ?? [], "capture")
-    if (capture) {
-      for (const item of capture.split(",").map((value) => value.trim()).filter(Boolean)) {
-        if (!(BROWSER_PROBE_CAPTURE_VALUES as readonly string[]).includes(item)) {
-          addIssue("invalid-capture", `${path}.args`, `wordpress.browser-probe capture does not support: ${item}`)
-        }
-      }
-    }
-
     for (const assertion of (step.args ?? []).filter((arg) => arg.startsWith("assert=")).map((arg) => arg.slice("assert=".length).trim())) {
       const rawNormalized = assertion.startsWith("advisory:") ? assertion.slice("advisory:".length).trim() : assertion
       const frameSeparator = rawNormalized.startsWith("frame:") || rawNormalized.startsWith("frame-url:") ? rawNormalized.indexOf("|") : -1
@@ -1256,10 +1186,6 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
 
   if (step.command === "wordpress.browser-actions") {
     const stepsJson = recipeStepArgValue(step.args ?? [], "steps-json")
-    const url = recipeStepArgValue(step.args ?? [], "url")?.trim()
-    if (!stepsJson && !url) {
-      addIssue("missing-steps", `${path}.args`, "wordpress.browser-actions requires steps-json=<array> or url=<path-or-url>.")
-    }
 
     if (stepsJson && !stepsJson.startsWith("@")) {
       let parsed: unknown
@@ -1276,31 +1202,11 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
         }
       }
     }
-
-    for (const name of ["step-timeout", "timeout"] as const) {
-      const value = recipeStepArgValue(step.args ?? [], name)
-      if (value && /^(\d+(?:\.\d+)?)(ms|s)$/.test(value) === false) {
-        addIssue("invalid-duration", `${path}.args`, `wordpress.browser-actions ${name} must look like 500ms or 2s.`)
-      }
-    }
-
-    const capture = recipeStepArgValue(step.args ?? [], "capture")
-    if (capture) {
-      for (const item of capture.split(",").map((value) => value.trim()).filter(Boolean)) {
-        if (!["steps", "actions", "console", "errors", "html", "network", "screenshot", "dom-snapshot"].includes(item)) {
-          addIssue("invalid-capture", `${path}.args`, `wordpress.browser-actions capture does not support: ${item}`)
-        }
-      }
-    }
     return
   }
 
   if (step.command === "wordpress.browser-scenario") {
     const scenarioJson = recipeStepArgValue(step.args ?? [], "scenario-json")
-    const url = recipeStepArgValue(step.args ?? [], "url")?.trim()
-    if (!scenarioJson && !url) {
-      addIssue("missing-scenario", `${path}.args`, "wordpress.browser-scenario requires scenario-json=<object> or url=<path-or-url>.")
-    }
 
     if (scenarioJson && !scenarioJson.startsWith("@")) {
       try {
@@ -1336,30 +1242,11 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
         }
       }
     }
-
-    for (const name of ["step-timeout", "timeout"] as const) {
-      const value = recipeStepArgValue(step.args ?? [], name)
-      if (value && /^(\d+(?:\.\d+)?)(ms|s)$/.test(value) === false) {
-        addIssue("invalid-duration", `${path}.args`, `wordpress.browser-scenario ${name} must look like 500ms or 2s.`)
-      }
-    }
-
-    const capture = recipeStepArgValue(step.args ?? [], "capture")
-    if (capture) {
-      for (const item of capture.split(",").map((value) => value.trim()).filter(Boolean)) {
-        if (!["steps", "actions", "console", "errors", "html", "network", "performance", "memory", "screenshot", "dom-snapshot"].includes(item)) {
-          addIssue("invalid-capture", `${path}.args`, `wordpress.browser-scenario capture does not support: ${item}`)
-        }
-      }
-    }
     return
   }
 
   if (step.command === "wordpress.editor-actions") {
     const stepsJson = recipeStepArgValue(step.args ?? [], "steps-json")
-    if (!stepsJson) {
-      addIssue("missing-steps", `${path}.args`, "wordpress.editor-actions requires steps-json=<array>.")
-    }
 
     if (stepsJson && !stepsJson.startsWith("@")) {
       let parsed: unknown
@@ -1371,22 +1258,6 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
       }
       if (parsed !== undefined && !Array.isArray(parsed)) {
         addIssue("invalid-steps-json", `${path}.args`, "wordpress.editor-actions steps-json must be a JSON array.")
-      }
-    }
-
-    for (const name of ["wait-timeout", "step-timeout", "timeout"] as const) {
-      const value = recipeStepArgValue(step.args ?? [], name)
-      if (value && /^\d+(?:\.\d+)?(?:ms|s)$/.test(value) === false) {
-        addIssue("invalid-duration", `${path}.args`, `wordpress.editor-actions ${name} must look like 500ms or 2s.`)
-      }
-    }
-
-    const capture = recipeStepArgValue(step.args ?? [], "capture")
-    if (capture) {
-      for (const item of capture.split(",").map((value) => value.trim()).filter(Boolean)) {
-        if (!["steps", "console", "errors", "html", "screenshot", "editor-state"].includes(item)) {
-          addIssue("invalid-capture", `${path}.args`, `wordpress.editor-actions capture does not support: ${item}`)
-        }
       }
     }
     return
@@ -1406,6 +1277,85 @@ async function validateRecipeStepArgs(step: WorkspaceRecipe["workflow"]["steps"]
       }
     }
   }
+}
+
+function validateRecipeStepDescriptorArgs(step: WorkspaceRecipe["workflow"]["steps"][number], path: string, addIssue: (code: string, path: string, message: string) => void): void {
+  const descriptor = commandValidationDescriptorFor(step.command)
+  if (!descriptor) {
+    return
+  }
+
+  const args = step.args ?? []
+  for (const requirement of descriptor.requiredArgs ?? []) {
+    if (!recipeStepArgValue(args, requirement.name)?.trim()) {
+      addIssue(requirement.code, `${path}.args`, requirement.message)
+    }
+  }
+
+  for (const requirement of descriptor.requiredAnyArgs ?? []) {
+    if (!requirement.names.some((name) => Boolean(recipeStepArgValue(args, name)?.trim()))) {
+      addIssue(requirement.code, `${path}.args`, requirement.message)
+    }
+  }
+
+  for (const rule of descriptor.argRules ?? []) {
+    validateRecipeStepDescriptorArgRule(args, rule, `${path}.args`, addIssue)
+  }
+}
+
+function validateRecipeStepDescriptorArgRule(args: string[], rule: CommandArgValidationDescriptor, issuePath: string, addIssue: (code: string, path: string, message: string) => void): void {
+  const raw = recipeStepArgValue(args, rule.name)
+  if (!raw) {
+    return
+  }
+
+  if (rule.kind === "boolean") {
+    if (!["1", "0", "true", "false", "yes", "no", "on", "off"].includes(raw.toLowerCase())) {
+      addIssue(rule.code, issuePath, rule.message)
+    }
+    return
+  }
+
+  if (rule.kind === "duration") {
+    if (!/^(\d+(?:\.\d+)?)(ms|s)$/.test(raw)) {
+      addIssue(rule.code, issuePath, rule.message)
+    }
+    return
+  }
+
+  if (rule.kind === "positive-integer") {
+    if (!/^[1-9]\d*$/.test(raw)) {
+      addIssue(rule.code, issuePath, rule.message)
+    }
+    return
+  }
+
+  if (rule.kind === "viewport") {
+    if (!/^\d+x\d+$/i.test(raw)) {
+      addIssue(rule.code, issuePath, rule.message)
+    }
+    return
+  }
+
+  if (rule.kind === "enum") {
+    if (!(rule.values as readonly string[]).includes(raw) && !(rule.prefixes ?? []).some((prefix) => raw.startsWith(prefix))) {
+      addIssue(rule.code, issuePath, descriptorValueMessage(rule, raw))
+    }
+    return
+  }
+
+  for (const value of raw.split(",").map((item) => item.trim()).filter(Boolean)) {
+    if (!(rule.values as readonly string[]).includes(value)) {
+      addIssue(rule.code, issuePath, descriptorValueMessage(rule, value))
+    }
+  }
+}
+
+function descriptorValueMessage(rule: Extract<CommandArgValidationDescriptor, { kind: "enum" | "comma-list-enum" }>, value: string): string {
+  if (rule.message.endsWith(".")) {
+    return rule.message
+  }
+  return `${rule.message}: ${value}`
 }
 
 function validateInlineJsonArg(step: WorkspaceRecipe["workflow"]["steps"][number], name: string, shape: "array" | "object", path: string, addIssue: (code: string, path: string, message: string) => void): unknown {

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -1,4 +1,4 @@
-import { BROWSER_PROBE_ACCEPTED_ARGS } from "./browser-probe-contract.js"
+import { BROWSER_PROBE_ACCEPTED_ARGS, BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_THROTTLE_PROFILE_IDS } from "./browser-probe-contract.js"
 
 export type CommandHandlerBinding =
   | { kind: "playground"; method: string }
@@ -25,9 +25,36 @@ export interface CommandDefinition {
   outputSchema?: CommandOutputSchemaContract
   policyRequirement: string
   requiresPolicyCommands?: readonly string[]
+  validation?: CommandValidationDescriptor
   recipe: boolean
   handler: CommandHandlerBinding
 }
+
+export interface CommandValidationDescriptor {
+  requiredArgs?: readonly CommandRequiredArgDescriptor[]
+  requiredAnyArgs?: readonly CommandRequiredAnyArgDescriptor[]
+  argRules?: readonly CommandArgValidationDescriptor[]
+}
+
+export interface CommandRequiredArgDescriptor {
+  name: string
+  code: string
+  message: string
+}
+
+export interface CommandRequiredAnyArgDescriptor {
+  names: readonly string[]
+  code: string
+  message: string
+}
+
+export type CommandArgValidationDescriptor =
+  | { name: string; kind: "boolean"; code: string; message: string }
+  | { name: string; kind: "duration"; code: string; message: string }
+  | { name: string; kind: "positive-integer"; code: string; message: string }
+  | { name: string; kind: "viewport"; code: string; message: string }
+  | { name: string; kind: "enum"; values: readonly string[]; prefixes?: readonly string[]; code: string; message: string }
+  | { name: string; kind: "comma-list-enum"; values: readonly string[]; code: string; message: string }
 
 const objectEnvelopeSchema = (id: string, extraProperties: Record<string, unknown> = {}): CommandOutputSchemaContract => ({
   id,
@@ -60,6 +87,64 @@ const snapshotScopingAcceptedArgs: CommandDefinition["acceptedArgs"] = [
   { name: "snapshot-option-names", description: "Comma-separated option_name values or LIKE patterns using * for the options table.", format: "string" },
   { name: "snapshot-post-types", description: "Comma-separated post types used to scope posts and postmeta table exports.", format: "string" },
 ]
+
+const browserActionCaptureValues = ["steps", "actions", "console", "errors", "html", "network", "screenshot", "dom-snapshot"] as const
+const browserScenarioCaptureValues = ["steps", "actions", "console", "errors", "html", "network", "performance", "memory", "screenshot", "dom-snapshot"] as const
+const editorCaptureValues = ["steps", "console", "errors", "html", "screenshot", "editor-state"] as const
+
+const browserProbeValidation: CommandValidationDescriptor = {
+  requiredArgs: [
+    { name: "url", code: "missing-url", message: "wordpress.browser-probe requires url=<path-or-url>." },
+  ],
+  argRules: [
+    { name: "wait-for", kind: "enum", values: ["domcontentloaded", "load", "networkidle", "duration"], prefixes: ["selector:"], code: "invalid-wait-for", message: "wordpress.browser-probe wait-for must be domcontentloaded, load, networkidle, selector:<selector>, or duration." },
+    { name: "duration", kind: "duration", code: "invalid-duration", message: "wordpress.browser-probe duration must look like 500ms or 2s." },
+    { name: "stall-timeout", kind: "duration", code: "invalid-stall-timeout", message: "wordpress.browser-probe stall-timeout must look like 500ms or 2s." },
+    { name: "fail-fast", kind: "boolean", code: "invalid-fail-fast", message: "wordpress.browser-probe fail-fast must be true or false." },
+    { name: "repeat", kind: "positive-integer", code: "invalid-repeat", message: "wordpress.browser-probe repeat must be a positive integer." },
+    { name: "reset-between", kind: "enum", values: ["none", "reload", "new-page"], code: "invalid-reset-between", message: "wordpress.browser-probe reset-between must be none, reload, or new-page." },
+    { name: "profiles", kind: "comma-list-enum", values: BROWSER_PROBE_CHROMIUM_PROFILE_IDS, code: "invalid-profile", message: "wordpress.browser-probe profile is unsupported" },
+    { name: "profile", kind: "enum", values: BROWSER_PROBE_CHROMIUM_PROFILE_IDS, code: "invalid-profile", message: "wordpress.browser-probe profile is unsupported" },
+    { name: "throttle", kind: "enum", values: ["none", ...BROWSER_PROBE_THROTTLE_PROFILE_IDS], code: "invalid-throttle", message: "wordpress.browser-probe throttle is unsupported" },
+    { name: "browser", kind: "enum", values: BROWSER_PROBE_BROWSER_VALUES, code: "invalid-browser", message: `wordpress.browser-probe browser must be ${BROWSER_PROBE_BROWSER_VALUES.join(" or ")}.` },
+    { name: "viewport", kind: "viewport", code: "invalid-viewport", message: "wordpress.browser-probe viewport must use <width>x<height>, for example 390x844." },
+    { name: "capture", kind: "comma-list-enum", values: BROWSER_PROBE_CAPTURE_VALUES, code: "invalid-capture", message: "wordpress.browser-probe capture does not support" },
+  ],
+}
+
+const browserActionsValidation: CommandValidationDescriptor = {
+  requiredAnyArgs: [
+    { names: ["steps-json", "url"], code: "missing-steps", message: "wordpress.browser-actions requires steps-json=<array> or url=<path-or-url>." },
+  ],
+  argRules: [
+    { name: "step-timeout", kind: "duration", code: "invalid-duration", message: "wordpress.browser-actions step-timeout must look like 500ms or 2s." },
+    { name: "timeout", kind: "duration", code: "invalid-duration", message: "wordpress.browser-actions timeout must look like 500ms or 2s." },
+    { name: "capture", kind: "comma-list-enum", values: browserActionCaptureValues, code: "invalid-capture", message: "wordpress.browser-actions capture does not support" },
+  ],
+}
+
+const browserScenarioValidation: CommandValidationDescriptor = {
+  requiredAnyArgs: [
+    { names: ["scenario-json", "url"], code: "missing-scenario", message: "wordpress.browser-scenario requires scenario-json=<object> or url=<path-or-url>." },
+  ],
+  argRules: [
+    { name: "step-timeout", kind: "duration", code: "invalid-duration", message: "wordpress.browser-scenario step-timeout must look like 500ms or 2s." },
+    { name: "timeout", kind: "duration", code: "invalid-duration", message: "wordpress.browser-scenario timeout must look like 500ms or 2s." },
+    { name: "capture", kind: "comma-list-enum", values: browserScenarioCaptureValues, code: "invalid-capture", message: "wordpress.browser-scenario capture does not support" },
+  ],
+}
+
+const editorActionsValidation: CommandValidationDescriptor = {
+  requiredArgs: [
+    { name: "steps-json", code: "missing-steps", message: "wordpress.editor-actions requires steps-json=<array>." },
+  ],
+  argRules: [
+    { name: "wait-timeout", kind: "duration", code: "invalid-duration", message: "wordpress.editor-actions wait-timeout must look like 500ms or 2s." },
+    { name: "step-timeout", kind: "duration", code: "invalid-duration", message: "wordpress.editor-actions step-timeout must look like 500ms or 2s." },
+    { name: "timeout", kind: "duration", code: "invalid-duration", message: "wordpress.editor-actions timeout must look like 500ms or 2s." },
+    { name: "capture", kind: "comma-list-enum", values: editorCaptureValues, code: "invalid-capture", message: "wordpress.editor-actions capture does not support" },
+  ],
+}
 
 export const commandRegistry = [
   {
@@ -290,6 +375,7 @@ export const commandRegistry = [
     acceptedArgs: BROWSER_PROBE_ACCEPTED_ARGS,
     outputShape: "JSON summary with requested/effective browser context details plus assertion results and files/browser/console.jsonl, errors.jsonl, network.jsonl, performance.json, memory.json, checkpoints.jsonl, snapshot.html, summary.json, and screenshot.png when captured.",
     policyRequirement: "Runtime policy commands must include wordpress.browser-probe.",
+    validation: browserProbeValidation,
     recipe: true,
     handler: { kind: "playground", method: "runBrowserProbe" },
   },
@@ -342,6 +428,7 @@ export const commandRegistry = [
     ],
     outputShape: "JSON summary plus files/browser/steps.jsonl, action-summary.json (with assertions pass/fail), named screenshots, sidecar DOM/style snapshots, and optional console/errors/network/html/screenshot artifacts.",
     policyRequirement: "Runtime policy commands must include wordpress.browser-actions. The evaluate step additionally requires wordpress.browser-actions.evaluate.",
+    validation: browserActionsValidation,
     recipe: true,
     handler: { kind: "playground", method: "runBrowserActions" },
   },
@@ -364,6 +451,7 @@ export const commandRegistry = [
     ],
     outputShape: "JSON scenario summary with requested/effective browser metadata and files/browser/scenario-summary.json, preserving lower-level browser-probe and browser-actions summaries when used.",
     policyRequirement: "Runtime policy commands must include wordpress.browser-scenario. Scenarios using evaluate steps additionally require wordpress.browser-actions.evaluate.",
+    validation: browserScenarioValidation,
     recipe: true,
     handler: { kind: "playground", method: "runBrowserScenario" },
   },
@@ -432,6 +520,7 @@ export const commandRegistry = [
     ],
     outputShape: "JSON summary plus files/browser/editor-action-steps.jsonl, editor-action-summary.json, editor-action-state.json, and optional console/errors/html/screenshot artifacts.",
     policyRequirement: "Runtime policy commands must include wordpress.editor-actions.",
+    validation: editorActionsValidation,
     recipe: true,
     handler: { kind: "playground", method: "runEditorActions" },
   },
@@ -507,6 +596,10 @@ export type PlaygroundRuntimeCommandId = PlaygroundRuntimeCommandDefinition["id"
 
 export function getCommandDefinition(command: string): CommandDefinition | undefined {
   return commandRegistry.find((definition) => definition.id === command)
+}
+
+export function commandValidationDescriptorFor(command: string): CommandValidationDescriptor | undefined {
+  return getCommandDefinition(command)?.validation
 }
 
 export function effectivePolicyCommands(command: string, definitions: readonly CommandDefinition[] = commandRegistry): string[] {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -5,8 +5,13 @@ import type { WorkspaceRecipe, WorkspaceRecipeDeclaredArtifact, WorkspaceRecipeT
 
 export type WorkspaceRecipeJsonSchema = Record<string, unknown>
 
+export interface WorkspaceRecipeCommandJsonSchemaDescriptor {
+  id: string
+}
+
 export interface WorkspaceRecipeJsonSchemaOptions {
   recipeCommandIds?: readonly string[]
+  recipeCommands?: readonly WorkspaceRecipeCommandJsonSchemaDescriptor[]
   runtimeBackendKinds?: readonly string[]
   runtimeWordPressInstallModes?: readonly string[]
   runtimeOverlayKinds?: readonly string[]
@@ -87,8 +92,9 @@ function jsonPointerToJsonPath(pointer: string, error: ErrorObject): string {
 }
 
 export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSchemaOptions = {}): WorkspaceRecipeJsonSchema {
-  const commandSchema = options.recipeCommandIds && options.recipeCommandIds.length > 0
-    ? { anyOf: [{ enum: [...options.recipeCommandIds] }, { type: "string", pattern: "^host/[A-Za-z0-9._/-]+$" }] }
+  const recipeCommandIds = options.recipeCommandIds ?? options.recipeCommands?.map((command) => command.id)
+  const commandSchema = recipeCommandIds && recipeCommandIds.length > 0
+    ? { anyOf: [{ enum: [...recipeCommandIds] }, { type: "string", pattern: "^host/[A-Za-z0-9._/-]+$" }] }
     : { type: "string" }
 
   return {

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -58,6 +58,7 @@ export const smokeGroups = {
       tsxSmoke("task-input-contract-smoke"),
       tsxSmoke("status-taxonomy-smoke"),
       npmScript("test:schema-parity"),
+      npmScript("test:recipe-validation-descriptors"),
       tsxSmoke("discovery-command-smoke"),
       tsxSmoke("doctor-command-smoke"),
       tsxSmoke("cli-json-failure-smoke"),

--- a/tests/recipe-validation-descriptors.test.ts
+++ b/tests/recipe-validation-descriptors.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { join } from "node:path"
+
+import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.js"
+import type { WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+await withTempDir("wp-codebox-recipe-validation-descriptors-", async (recipeDirectory) => {
+  const recipePath = join(recipeDirectory, "recipe.json")
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    workflow: {
+      steps: [
+        { command: "wordpress.browser-probe", args: ["capture=console,bogus", "duration=forever", "profile=desktop-webkit"] },
+        { command: "wordpress.browser-actions", args: ["capture=steps,bogus", "timeout=forever"] },
+        { command: "wordpress.browser-scenario", args: ["capture=performance,bogus", "step-timeout=forever"] },
+        { command: "wordpress.editor-actions", args: ["capture=steps,bogus", "wait-timeout=forever"] },
+      ],
+    },
+  }
+
+  const issues = await validateWorkspaceRecipeSemantics(recipe, recipePath)
+  assert.deepEqual(issues.filter((issue) => issue.path === "$.workflow.steps[0].args"), [
+    { code: "missing-url", path: "$.workflow.steps[0].args", message: "wordpress.browser-probe requires url=<path-or-url>." },
+    { code: "invalid-duration", path: "$.workflow.steps[0].args", message: "wordpress.browser-probe duration must look like 500ms or 2s." },
+    { code: "invalid-profile", path: "$.workflow.steps[0].args", message: "wordpress.browser-probe profile is unsupported: desktop-webkit" },
+    { code: "invalid-capture", path: "$.workflow.steps[0].args", message: "wordpress.browser-probe capture does not support: bogus" },
+  ])
+  assert.deepEqual(issues.filter((issue) => issue.path === "$.workflow.steps[1].args"), [
+    { code: "missing-steps", path: "$.workflow.steps[1].args", message: "wordpress.browser-actions requires steps-json=<array> or url=<path-or-url>." },
+    { code: "invalid-duration", path: "$.workflow.steps[1].args", message: "wordpress.browser-actions timeout must look like 500ms or 2s." },
+    { code: "invalid-capture", path: "$.workflow.steps[1].args", message: "wordpress.browser-actions capture does not support: bogus" },
+  ])
+  assert.deepEqual(issues.filter((issue) => issue.path === "$.workflow.steps[2].args"), [
+    { code: "missing-scenario", path: "$.workflow.steps[2].args", message: "wordpress.browser-scenario requires scenario-json=<object> or url=<path-or-url>." },
+    { code: "invalid-duration", path: "$.workflow.steps[2].args", message: "wordpress.browser-scenario step-timeout must look like 500ms or 2s." },
+    { code: "invalid-capture", path: "$.workflow.steps[2].args", message: "wordpress.browser-scenario capture does not support: bogus" },
+  ])
+  assert.deepEqual(issues.filter((issue) => issue.path === "$.workflow.steps[3].args"), [
+    { code: "missing-steps", path: "$.workflow.steps[3].args", message: "wordpress.editor-actions requires steps-json=<array>." },
+    { code: "invalid-duration", path: "$.workflow.steps[3].args", message: "wordpress.editor-actions wait-timeout must look like 500ms or 2s." },
+    { code: "invalid-capture", path: "$.workflow.steps[3].args", message: "wordpress.editor-actions capture does not support: bogus" },
+  ])
+})
+
+console.log("recipe validation descriptors ok")


### PR DESCRIPTION
## Summary
- Add generic per-command validation descriptor metadata to command definitions.
- Use descriptors from recipe semantic validation for the first browser/editor slice: wordpress.browser-probe, wordpress.browser-actions, wordpress.browser-scenario, and wordpress.editor-actions.
- Thread command definitions into recipe JSON schema command-id generation without changing the step args schema shape, and keep complex JSON/assertion validation in the CLI validator.
- Add a descriptor validation regression test and include it in the check smoke group.

## Testing
- npm run test:recipe-validation-descriptors
- npm run test:browser-task-builder
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the descriptor refactor, regression test, and verification workflow; Chris remains responsible for review and merge.