### PR TITLE
Add runtime run status transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:browser-task-builder": "tsx tests/browser-task-builder.test.ts",
     "test:host-recipe-builder": "tsx tests/host-recipe-builder.test.ts",
     "test:runtime-recipe-resolver": "tsx tests/runtime-recipe-resolver.test.ts",
+    "test:run-registry": "tsx tests/run-registry.test.ts",
     "test:runtime-php-snippets": "tsx tests/runtime-php-snippets.test.ts",
     "test:browser-runner-template": "tsx tests/browser-runner-template.test.ts",
     "test:editor-actions": "tsx tests/editor-actions.test.ts",

--- a/packages/runtime-core/src/run-registry.ts
+++ b/packages/runtime-core/src/run-registry.ts
@@ -111,6 +111,17 @@ export interface RuntimeRunCleanupUpdate {
   error?: RuntimeRunRecord["error"]
 }
 
+const runtimeRunStatusTransitions: Record<RuntimeRunStatus, readonly RuntimeRunStatus[]> = {
+  queued: ["booting", "running", "cancelled", "failed", "timed_out"],
+  booting: ["running", "collecting_artifacts", "cancelled", "failed", "timed_out"],
+  running: ["collecting_artifacts", "succeeded", "cancelled", "failed", "timed_out"],
+  collecting_artifacts: ["succeeded", "cancelled", "failed", "timed_out"],
+  succeeded: [],
+  failed: [],
+  timed_out: [],
+  cancelled: [],
+}
+
 export class RuntimeRunRegistry {
   readonly directory: string
 
@@ -148,7 +159,7 @@ export class RuntimeRunRegistry {
   async update(runId: string, update: RuntimeRunRegistryUpdate): Promise<RuntimeRunRecord> {
     const current = await this.read(runId)
     const now = (update.now ?? new Date()).toISOString()
-    const status = update.status ?? current.status
+    const status = transitionRuntimeRunStatus(current.status, update.status)
     const cleanup = update.cleanup ? updateRuntimeRunCleanup(current.lifecycle?.cleanup, update.cleanup, now) : current.lifecycle?.cleanup ?? initialRuntimeRunCleanup()
     const next: RuntimeRunRecord = {
       ...current,
@@ -200,6 +211,22 @@ export function buildRuntimeRunLifecycle(status: RuntimeRunStatus, cleanup: Runt
     ...(terminal ? { outcome: status as RuntimeRunLifecycleOutcome } : {}),
     cleanup,
   }
+}
+
+export function transitionRuntimeRunStatus(current: RuntimeRunStatus, next = current): RuntimeRunStatus {
+  if (current === next) {
+    return current
+  }
+
+  if (isTerminalRuntimeRunStatus(current)) {
+    throw new Error(`Cannot transition terminal runtime run status from ${current} to ${next}`)
+  }
+
+  if (!runtimeRunStatusTransitions[current].includes(next)) {
+    throw new Error(`Invalid runtime run status transition from ${current} to ${next}`)
+  }
+
+  return next
 }
 
 function initialRuntimeRunCleanup(): RuntimeRunCleanupState {

--- a/tests/run-registry.test.ts
+++ b/tests/run-registry.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+
+import { withTempDir } from "../scripts/test-kit.js"
+import { RuntimeRunRegistry, transitionRuntimeRunStatus } from "../packages/runtime-core/src/index.js"
+
+assert.equal(transitionRuntimeRunStatus("queued", "running"), "running")
+assert.equal(transitionRuntimeRunStatus("succeeded", "succeeded"), "succeeded")
+assert.throws(() => transitionRuntimeRunStatus("queued", "succeeded"), /Invalid runtime run status transition/)
+assert.throws(() => transitionRuntimeRunStatus("failed", "running"), /terminal runtime run status/)
+
+await withTempDir("wp-codebox-run-registry-", async (directory) => {
+  const registry = new RuntimeRunRegistry(directory)
+  const run = await registry.create({ runId: "retry-safe", status: "running", now: new Date("2026-01-02T03:04:05.000Z") })
+
+  assert.equal(run.status, "running")
+
+  await assert.rejects(registry.update(run.runId, { status: "queued", now: new Date("2026-01-02T03:04:06.000Z") }), /Invalid runtime run status transition/)
+
+  const finalizing = await registry.update(run.runId, { status: "collecting_artifacts", now: new Date("2026-01-02T03:04:07.000Z") })
+  assert.equal(finalizing.lifecycle.phase, "finalizing")
+
+  const succeeded = await registry.update(run.runId, {
+    status: "succeeded",
+    artifactRefs: [{ kind: "artifact-bundle", path: "artifacts/run.json" }],
+    now: new Date("2026-01-02T03:04:08.000Z"),
+  })
+  assert.equal(succeeded.lifecycle.terminal, true)
+  assert.equal(succeeded.lifecycle.outcome, "succeeded")
+
+  await assert.rejects(registry.update(run.runId, { status: "failed", now: new Date("2026-01-02T03:04:09.000Z") }), /terminal runtime run status/)
+
+  const retry = await registry.update(run.runId, {
+    status: "succeeded",
+    artifactRefs: [{ kind: "artifact-bundle", path: "artifacts/retry.json" }],
+    cleanup: { status: "running" },
+    now: new Date("2026-01-02T03:04:10.000Z"),
+  })
+  assert.equal(retry.status, "succeeded")
+  assert.deepEqual(retry.artifactRefs, [{ kind: "artifact-bundle", path: "artifacts/retry.json" }])
+  assert.equal(retry.lifecycle.cleanup.status, "running")
+  assert.equal(retry.lifecycle.cleanup.attempts, 1)
+})


### PR DESCRIPTION
## Summary
- Add a generic runtime run status transition primitive in runtime-core.
- Validate registry status updates against allowed transitions and protect terminal statuses from being overwritten.
- Allow idempotent re-application of the same terminal status for retry/finalization-safe metadata, artifact, and cleanup updates.

## Tests
- npm run test:run-registry
- npm --workspace @automattic/wp-codebox-core run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the runtime-core transition primitive, targeted tests, and PR description; Chris remains responsible for review and validation.