### PR TITLE
Extract structured artifact materializer

### DIFF
--- a/packages/cli/src/commands/recipe-declared-artifacts.ts
+++ b/packages/cli/src/commands/recipe-declared-artifacts.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer"
-import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, redactJsonValue, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type Runtime, type TypedArtifactIndex, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, materializeStructuredArtifactFiles, redactJsonValue, workspaceRecipeRuntimeCollectedArtifacts, type ArtifactBundle, type Runtime, type StructuredArtifactPayload, type TypedArtifactRef, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeTypedArtifact } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { appendRecipeRuntimeEvidenceFiles } from "../recipe-evidence.js"
 import { serializeRecipeRunError, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError } from "./recipe-run-output.js"
@@ -106,8 +106,7 @@ async function collectRecipeTypedArtifact(runtime: Runtime, artifact: WorkspaceR
 }
 
 export async function materializeTypedRecipeDeclaredArtifacts(artifacts: ArtifactBundle, declaredArtifacts: RecipeRunDeclaredArtifact[]): Promise<void> {
-  const refs: TypedArtifactRef[] = []
-  const files = []
+  const inputs: Array<{ artifact: RecipeRunDeclaredArtifact; ref: StructuredArtifactPayload; contents: Buffer; contentType: string }> = []
   for (const artifact of declaredArtifacts) {
     const typedArtifact = recipeRunTypedArtifactDeclaration(artifact)
     const contents = declaredArtifactContents.get(artifact)
@@ -115,9 +114,7 @@ export async function materializeTypedRecipeDeclaredArtifacts(artifacts: Artifac
       continue
     }
 
-    const filename = `typed-artifacts/${safeTypedArtifactName(typedArtifact.name)}-${artifact.index + 1}${typedArtifactExtension(typedArtifact.contentType)}`
-    const sha256 = artifactFileDigest(contents).value
-    const ref: TypedArtifactRef = stripUndefined({
+    const ref: StructuredArtifactPayload = stripUndefined({
       schema: STRUCTURED_ARTIFACT_SCHEMA,
       name: typedArtifact.name,
       type: typedArtifact.type,
@@ -125,32 +122,38 @@ export async function materializeTypedRecipeDeclaredArtifacts(artifacts: Artifac
       payload: artifact.parsedJson,
       metadata: artifact.metadata ?? {},
       provenance: {
-        direction: "output",
+        direction: "output" as const,
         source: artifact.path,
       },
-      artifact: {
-        path: `files/runtime-evidence/${filename}`,
-        kind: "typed-artifact",
-        contentType: typedArtifact.contentType,
-        sha256,
-      },
-    }) as TypedArtifactRef
-    refs.push(ref)
-    artifact.materialized = ref
-    delete (artifact as RecipeRunDeclaredArtifact & { typedArtifact?: unknown }).typedArtifact
-    files.push({ filename, kind: "typed-artifact", contentType: typedArtifact.contentType, contents, maxBytes: DECLARED_ARTIFACT_CAPTURE_MAX_BYTES })
+    })
+    inputs.push({ artifact, ref, contents, contentType: typedArtifact.contentType })
   }
 
-  if (refs.length === 0) {
+  if (inputs.length === 0) {
     return
   }
 
-  const index: TypedArtifactIndex = {
-    schema: TYPED_ARTIFACT_INDEX_SCHEMA,
-    direction: "output",
-    artifacts: refs,
+  const materialized = materializeStructuredArtifactFiles<StructuredArtifactPayload, TypedArtifactRef>({
+    artifacts: inputs.map((input) => input.ref),
+    artifactPathPrefix: "files/runtime-evidence/typed-artifacts",
+    artifactKind: "typed-artifact",
+    indexKind: "typed-artifacts-index",
+    indexSchema: TYPED_ARTIFACT_INDEX_SCHEMA,
+    contentType: (_artifact, index) => inputs[index].contentType,
+    contents: (_artifact, index) => inputs[index].contents,
+  })
+  for (const [index, ref] of materialized.refs.entries()) {
+    inputs[index].artifact.materialized = ref
+    delete (inputs[index].artifact as RecipeRunDeclaredArtifact & { typedArtifact?: unknown }).typedArtifact
   }
-  files.push({ filename: "typed-artifacts/index.json", kind: "typed-artifacts-index", contentType: "application/json", contents: `${JSON.stringify(index, null, 2)}\n` })
+
+  const files = materialized.files.map((file) => ({
+    filename: file.path.replace(/^files\/runtime-evidence\//, ""),
+    kind: file.kind,
+    contentType: file.contentType,
+    contents: file.contents,
+    maxBytes: DECLARED_ARTIFACT_CAPTURE_MAX_BYTES,
+  }))
   await appendRecipeRuntimeEvidenceFiles(artifacts, files)
 }
 
@@ -173,16 +176,6 @@ function recipeRunTypedArtifactDeclaration(artifact: RecipeRunDeclaredArtifact):
 
 function typedArtifactContentType(artifact: WorkspaceRecipeTypedArtifact): string {
   return artifact.parseJson === true ? "application/json" : "application/octet-stream"
-}
-
-function typedArtifactExtension(contentType: string): string {
-  if (contentType === "application/json") return ".json"
-  if (contentType.startsWith("text/")) return ".txt"
-  return ".bin"
-}
-
-function safeTypedArtifactName(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "artifact"
 }
 
 function isRecordValue(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, captureArtifactFile, checkWorkspacePolicy, normalizeAgentTerminalResult, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactIndex, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, captureArtifactFile, checkWorkspacePolicy, materializeStructuredArtifactFiles, normalizeAgentTerminalResult, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core/artifacts"
 import { isPlainObject as isRecord, sha256StableJson, stripUndefined } from "@automattic/wp-codebox-core/internals"
 
@@ -813,36 +813,29 @@ async function writeAgentTaskStructuredArtifacts(artifacts: ArtifactBundle, agen
   }
 
   const structuredDirectory = join(dirname(artifacts.reviewPath), "structured-artifacts")
-  await mkdir(structuredDirectory, { recursive: true })
-  const refs: StructuredArtifactRef[] = []
+  const materialized = materializeStructuredArtifactFiles<StructuredArtifactRef, StructuredArtifactRef>({
+    artifacts: outputCandidates,
+    artifactPathPrefix: relative(artifacts.directory, structuredDirectory),
+    artifactKind: "structured-artifact",
+    indexKind: "structured-artifacts-index",
+    indexSchema: STRUCTURED_ARTIFACT_INDEX_SCHEMA,
+  })
   const files: RecipeArtifactEvidenceFile[] = []
 
-  for (const [index, artifact] of outputCandidates.entries()) {
-    const path = join(structuredDirectory, `${safeStructuredArtifactName(artifact.name)}-${index + 1}.json`)
-    const file = await writeRecipeEvidenceJson(artifacts.directory, path, artifact, `structured-artifact:${artifact.name}`)
-    const ref: StructuredArtifactRef = {
-      ...artifact,
-      artifact: {
-        path: file.path,
-        kind: "structured-artifact",
-        contentType: "application/json",
-        sha256: file.sha256,
-      },
-    }
-    refs.push(ref)
-    files.push(file)
+  await mkdir(structuredDirectory, { recursive: true })
+  for (const file of materialized.files) {
+    await writeFile(join(artifacts.directory, file.path), file.contents)
+    files.push({
+      path: file.path,
+      sha256: file.sha256.value,
+      kind: file.artifact ? `structured-artifact:${file.artifact.name}` : file.kind,
+      contentType: file.contentType,
+    })
   }
-
-  const index: StructuredArtifactIndex = {
-    schema: STRUCTURED_ARTIFACT_INDEX_SCHEMA,
-    direction: "output",
-    artifacts: refs,
-  }
-  files.push(await writeRecipeEvidenceJson(artifacts.directory, join(structuredDirectory, "index.json"), index, "structured-artifacts-index"))
-  agentTaskResult.structured_artifacts = refs
+  agentTaskResult.structured_artifacts = materialized.refs
   agentTaskResult.outputs = {
     ...agentTaskResult.outputs,
-    structured_artifacts: refs,
+    structured_artifacts: materialized.refs,
   }
   return files
 }
@@ -860,10 +853,6 @@ function structuredArtifactOutputCandidates(agentTaskResult: AgentTaskSingleResu
           ? rawResult.structuredArtifacts
           : []
   return normalizeStructuredArtifacts(value, "output")
-}
-
-function safeStructuredArtifactName(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "artifact"
 }
 
 function latestAgentRuntime(transcript: AgentSandboxTranscript): Record<string, unknown> | undefined {

--- a/packages/runtime-core/src/structured-artifacts.ts
+++ b/packages/runtime-core/src/structured-artifacts.ts
@@ -1,4 +1,5 @@
 import { isPlainObject } from "./object-utils.js"
+import { artifactFileDigest, type ArtifactFileDigest } from "./artifact-manifest.js"
 
 export const STRUCTURED_ARTIFACT_SCHEMA = "wp-codebox/structured-artifact/v1" as const
 export const STRUCTURED_ARTIFACT_INDEX_SCHEMA = "wp-codebox/structured-artifacts-index/v1" as const
@@ -59,6 +60,83 @@ export interface TypedArtifactIndex {
   artifacts: TypedArtifactRef[]
 }
 
+export interface MaterializedStructuredArtifactRef extends Omit<StructuredArtifactPayload, "payload"> {
+  payload?: unknown
+  artifact?: {
+    path: string
+    kind: string
+    contentType: string
+    sha256: string
+  }
+}
+
+export interface StructuredArtifactMaterializationInput<TArtifact extends StructuredArtifactPayload = StructuredArtifactPayload> {
+  artifacts: TArtifact[]
+  artifactPathPrefix: string
+  artifactKind: string
+  indexKind: string
+  indexSchema: typeof STRUCTURED_ARTIFACT_INDEX_SCHEMA | typeof TYPED_ARTIFACT_INDEX_SCHEMA
+  contentType?: string | ((artifact: TArtifact, index: number) => string)
+  contents?: (artifact: TArtifact, index: number) => string | Buffer
+  extension?: (contentType: string, artifact: TArtifact, index: number) => string
+}
+
+export interface StructuredArtifactMaterializedFile<TArtifact extends StructuredArtifactPayload = StructuredArtifactPayload> {
+  path: string
+  kind: string
+  contentType: string
+  contents: string | Buffer
+  sha256: ArtifactFileDigest
+  artifact?: TArtifact
+}
+
+export interface StructuredArtifactMaterializationResult<TRef extends MaterializedStructuredArtifactRef = MaterializedStructuredArtifactRef> {
+  refs: TRef[]
+  index: StructuredArtifactIndex | TypedArtifactIndex
+  files: StructuredArtifactMaterializedFile[]
+}
+
+export function materializeStructuredArtifactFiles<TArtifact extends StructuredArtifactPayload, TRef extends MaterializedStructuredArtifactRef = MaterializedStructuredArtifactRef>(input: StructuredArtifactMaterializationInput<TArtifact>): StructuredArtifactMaterializationResult<TRef> {
+  const artifactPathPrefix = normalizeArtifactPathPrefix(input.artifactPathPrefix)
+  const refs: MaterializedStructuredArtifactRef[] = []
+  const files: StructuredArtifactMaterializedFile[] = []
+
+  for (const [index, artifact] of input.artifacts.entries()) {
+    const contents = input.contents ? input.contents(artifact, index) : `${JSON.stringify(artifact, null, 2)}\n`
+    const contentType = typeof input.contentType === "function" ? input.contentType(artifact, index) : input.contentType ?? "application/json"
+    const extension = input.extension ? input.extension(contentType, artifact, index) : structuredArtifactExtension(contentType)
+    const path = `${artifactPathPrefix}/${safeStructuredArtifactName(artifact.name)}-${index + 1}${extension}`
+    const sha256 = artifactFileDigest(contents)
+    const ref: MaterializedStructuredArtifactRef = stripUndefined({
+      ...artifact,
+      artifact: {
+        path,
+        kind: input.artifactKind,
+        contentType,
+        sha256: sha256.value,
+      },
+    }) as MaterializedStructuredArtifactRef
+    refs.push(ref)
+    files.push({ path, kind: input.artifactKind, contentType, contents, sha256, artifact })
+  }
+
+  const index: StructuredArtifactIndex | TypedArtifactIndex = {
+    schema: input.indexSchema,
+    direction: "output",
+    artifacts: refs as never,
+  }
+  const indexContents = `${JSON.stringify(index, null, 2)}\n`
+  files.push({
+    path: `${artifactPathPrefix}/index.json`,
+    kind: input.indexKind,
+    contentType: "application/json",
+    contents: indexContents,
+    sha256: artifactFileDigest(indexContents),
+  })
+
+  return { refs: refs as TRef[], index, files }
+}
+
 export function normalizeStructuredArtifacts(value: unknown, direction: StructuredArtifactDirection): StructuredArtifactPayload[] {
   const entries = Array.isArray(value) ? value : []
   return entries.flatMap((entry): StructuredArtifactPayload[] => {
@@ -96,4 +174,22 @@ function structuredPayloadSchema(value: unknown): string | Record<string, unknow
 
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value.trim() : ""
+}
+
+function safeStructuredArtifactName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "artifact"
+}
+
+function structuredArtifactExtension(contentType: string): string {
+  if (contentType === "application/json") return ".json"
+  if (contentType.startsWith("text/")) return ".txt"
+  return ".bin"
+}
+
+function normalizeArtifactPathPrefix(prefix: string): string {
+  return prefix.trim().replace(/\\/g, "/").replace(/^\/+|\/+$/g, "")
+}
+
+function stripUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T
 }

--- a/tests/structured-artifact-materializer.test.ts
+++ b/tests/structured-artifact-materializer.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict"
+import { Buffer } from "node:buffer"
+import {
+  STRUCTURED_ARTIFACT_INDEX_SCHEMA,
+  STRUCTURED_ARTIFACT_SCHEMA,
+  TYPED_ARTIFACT_INDEX_SCHEMA,
+  materializeStructuredArtifactFiles,
+  type StructuredArtifactPayload,
+  type TypedArtifactRef,
+} from "../packages/runtime-core/src/index.js"
+
+const agentArtifact: StructuredArtifactPayload = {
+  schema: STRUCTURED_ARTIFACT_SCHEMA,
+  name: "Summary Report",
+  type: "example.summary",
+  payload: { ok: true },
+  metadata: { source: "agent" },
+  provenance: { direction: "output", source: "agent-runtime" },
+}
+
+const agentMaterialized = materializeStructuredArtifactFiles({
+  artifacts: [agentArtifact],
+  artifactPathPrefix: "files/structured-artifacts",
+  artifactKind: "structured-artifact",
+  indexKind: "structured-artifacts-index",
+  indexSchema: STRUCTURED_ARTIFACT_INDEX_SCHEMA,
+})
+
+assert.equal(agentMaterialized.files[0].path, "files/structured-artifacts/summary-report-1.json")
+assert.equal(agentMaterialized.files[0].kind, "structured-artifact")
+assert.equal(agentMaterialized.files[1].path, "files/structured-artifacts/index.json")
+assert.equal(agentMaterialized.files[1].kind, "structured-artifacts-index")
+assert.deepEqual(agentMaterialized.index, {
+  schema: STRUCTURED_ARTIFACT_INDEX_SCHEMA,
+  direction: "output",
+  artifacts: agentMaterialized.refs,
+})
+assert.deepEqual(agentMaterialized.refs[0].artifact, {
+  path: "files/structured-artifacts/summary-report-1.json",
+  kind: "structured-artifact",
+  contentType: "application/json",
+  sha256: agentMaterialized.files[0].sha256.value,
+})
+
+const typedArtifact: StructuredArtifactPayload = {
+  schema: STRUCTURED_ARTIFACT_SCHEMA,
+  name: "Summary Report",
+  type: "example.summary",
+  payload_schema: "https://example.test/schema.json",
+  payload: { ok: true },
+  metadata: { source: "recipe" },
+  provenance: { direction: "output", source: "/tmp/summary.json" },
+}
+const typedContents = Buffer.from(JSON.stringify({ ok: true }))
+const typedMaterialized = materializeStructuredArtifactFiles<StructuredArtifactPayload, TypedArtifactRef>({
+  artifacts: [typedArtifact],
+  artifactPathPrefix: "files/runtime-evidence/typed-artifacts",
+  artifactKind: "typed-artifact",
+  indexKind: "typed-artifacts-index",
+  indexSchema: TYPED_ARTIFACT_INDEX_SCHEMA,
+  contentType: "application/json",
+  contents: () => typedContents,
+})
+
+assert.equal(typedMaterialized.files[0].path, "files/runtime-evidence/typed-artifacts/summary-report-1.json")
+assert.equal(typedMaterialized.files[0].kind, "typed-artifact")
+assert.equal(typedMaterialized.files[1].path, "files/runtime-evidence/typed-artifacts/index.json")
+assert.equal(typedMaterialized.files[1].kind, "typed-artifacts-index")
+assert.deepEqual(typedMaterialized.index, {
+  schema: TYPED_ARTIFACT_INDEX_SCHEMA,
+  direction: "output",
+  artifacts: typedMaterialized.refs,
+})
+assert.deepEqual(typedMaterialized.refs[0].artifact, {
+  path: "files/runtime-evidence/typed-artifacts/summary-report-1.json",
+  kind: "typed-artifact",
+  contentType: "application/json",
+  sha256: typedMaterialized.files[0].sha256.value,
+})
+
+console.log("structured artifact materializer passed")


### PR DESCRIPTION
## Summary
- Add a generic runtime-core structured artifact materializer for safe names, paths, content hashes, refs, and index files.
- Route recipe-declared typed artifacts through the shared materializer.
- Route agent task structured artifacts through the shared materializer while preserving existing bundle layout and evidence metadata behavior.

## Tests
- `npx tsx tests/structured-artifact-materializer.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the shared materializer, migrated the two duplicate call sites, and added targeted test coverage; Chris remains responsible for review and validation.