### PR TITLE
Add browser storage state export command

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -286,9 +286,25 @@ The emitted PHP returns `wp-codebox/browser-auth-storage-state/v1`:
 }
 ```
 
-Callers own when to run the PHP and where to persist the returned storage-state
-JSON. Product policy, production identifiers, and cross-site account mapping stay
-outside WP Codebox.
+Recipes can export that state as an artifact with the generic command:
+
+```json
+{
+  "command": "wordpress.export-browser-storage-state",
+  "args": [
+    "browser-urls=http://127.0.0.1:9400,https://preview.example.test",
+    "user-json={\"username\":\"fixture-admin\",\"role\":\"administrator\"}"
+  ]
+}
+```
+
+The command returns `wp-codebox/browser-storage-state-export/v1` with
+`artifacts.storageState` and `artifacts.summary`. The storage-state artifact is
+the token-bearing Playwright JSON and is marked `redactionRequired` in
+`artifactRefs`; the summary artifact and command output contain only
+reviewer-safe metadata: schema/kind, user id/name/email/role/created flag,
+cookie counts by host, origin count, and diagnostics. Product policy,
+production identifiers, and cross-site account mapping stay outside WP Codebox.
 
 `wordpress.browser-probe` and `wordpress.browser-actions` can import a reusable
 storage state with `storage-state=<json>` or `storage-state=@./state.json`. The

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -298,6 +298,12 @@ Recipes can export that state as an artifact with the generic command:
 }
 ```
 
+The command also accepts caller-produced state with `storage-state=<json>` or
+`storage-state=@./state.json`. That value may be a raw Playwright
+`storageState` object or the `wp-codebox/browser-auth-storage-state/v1` envelope
+shown above, so product-specific PHP bootstrap code can stay outside WP Codebox
+and hand the resulting generic browser state to the exporter.
+
 The command returns `wp-codebox/browser-storage-state-export/v1` with
 `artifacts.storageState` and `artifacts.summary`. The storage-state artifact is
 the token-bearing Playwright JSON and is marked `redactionRequired` in

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -210,6 +210,7 @@ export const commandRegistry = [
     id: "wordpress.export-browser-storage-state",
     description: "Export reusable Playwright browser storageState JSON for a generic WordPress fixture user and record reviewer-safe metadata.",
     acceptedArgs: [
+      { name: "storage-state", description: "Optional Playwright storageState JSON, wp-codebox storage-state envelope, or @<path> to JSON to materialize as a reusable artifact. When omitted, WP Codebox exports a WordPress fixture-user storage state.", format: "JSON object or @path" },
       { name: "browser-urls", description: "Comma-separated browser origins or URLs whose hosts should receive WordPress auth cookies. Defaults to the runtime preview URL.", format: "comma-separated URLs" },
       { name: "user-json", description: "Optional fixture user object with userId, username, email, role, displayName, or password fields.", format: "JSON object" },
       { name: "output-dir", description: "Optional artifact directory relative to the runtime artifact root; defaults to files/browser-storage-state.", format: "relative path" },

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -207,6 +207,23 @@ export const commandRegistry = [
     handler: { kind: "playground", method: "runWpCli" },
   },
   {
+    id: "wordpress.export-browser-storage-state",
+    description: "Export reusable Playwright browser storageState JSON for a generic WordPress fixture user and record reviewer-safe metadata.",
+    acceptedArgs: [
+      { name: "browser-urls", description: "Comma-separated browser origins or URLs whose hosts should receive WordPress auth cookies. Defaults to the runtime preview URL.", format: "comma-separated URLs" },
+      { name: "user-json", description: "Optional fixture user object with userId, username, email, role, displayName, or password fields.", format: "JSON object" },
+      { name: "output-dir", description: "Optional artifact directory relative to the runtime artifact root; defaults to files/browser-storage-state.", format: "relative path" },
+    ],
+    outputShape: "wp-codebox/browser-storage-state-export/v1 JSON with storageState and summary artifact refs plus redacted schema/kind, user, cookie host counts, origin count, and diagnostics.",
+    outputSchema: artifactSummarySchema("wp-codebox/browser-storage-state-export/v1", {
+      storageState: { type: "string" },
+      summary: { type: "string" },
+    }),
+    policyRequirement: "Runtime policy commands must include wordpress.export-browser-storage-state.",
+    recipe: true,
+    handler: { kind: "playground", method: "runExportBrowserStorageState" },
+  },
+  {
     id: "wordpress.capture-state-bundle",
     description: "Capture the current WordPress runtime state as a portable state bundle source for replayable Playground artifacts.",
     acceptedArgs: [

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -9,6 +9,7 @@ interface PlaygroundCommandRuntime {
   runCommandAgent(spec: ExecutionSpec): Promise<PlaygroundCommandOutput>
   runPhp(spec: ExecutionSpec): Promise<string>
   runWpCli(spec: ExecutionSpec): Promise<string>
+  runExportBrowserStorageState(spec: ExecutionSpec): Promise<string>
   runCaptureStateBundle(spec: ExecutionSpec): Promise<string>
   runExportReplayPackage(spec: ExecutionSpec): Promise<string>
   runRestRequest(spec: ExecutionSpec): Promise<string>

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -6,6 +6,7 @@ import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_S
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
+import { normalizeBrowserStorageStatePayload, wordpressFixtureUserStorageStatePhpCode, type WordPressFixtureUserSpec } from "./browser-auth-storage-state.js"
 import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand, wordpressAdminAuthCookiePhpCode } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
@@ -801,6 +802,72 @@ class PlaygroundRuntime implements Runtime {
     return cleanWpCliOutput(response.text)
   }
 
+  async runExportBrowserStorageState(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const browserUrls = stringListArg(spec.args ?? [], "browser-urls") ?? [this.spec.preview?.publicUrl ?? server.serverUrl]
+    const user = jsonObjectStringArg(spec.args ?? [], "user-json") as WordPressFixtureUserSpec
+    const outputDirectory = storageStateOutputDirectory(this.artifactRoot, stringArg(spec.args ?? [], "output-dir"))
+    const code = wordpressFixtureUserStorageStatePhpCode({ browserUrls, user })
+    const response = await this.runPlaygroundCommand("wordpress.export-browser-storage-state", server, {
+      code: bootstrapPhpCode(this.spec, code, spec.args ?? []),
+    })
+    assertPlaygroundResponseOk("wordpress.export-browser-storage-state", response)
+
+    let payload: unknown
+    try {
+      payload = JSON.parse(response.text)
+    } catch (error) {
+      throw new Error(`wordpress.export-browser-storage-state returned invalid JSON: ${errorMessage(error)}`)
+    }
+
+    const normalized = normalizeBrowserStorageStatePayload(payload, "inline")
+    if (normalized.summary.status !== "ready") {
+      throw new Error(`wordpress.export-browser-storage-state returned unsupported storage state: ${JSON.stringify(normalized.summary.diagnostics)}`)
+    }
+
+    const envelope = payload && typeof payload === "object" && !Array.isArray(payload) ? payload as Record<string, unknown> : {}
+    const exportedUser = envelope.user && typeof envelope.user === "object" && !Array.isArray(envelope.user) ? envelope.user as Record<string, unknown> : undefined
+    const storageStatePath = join(outputDirectory, "storage-state.json")
+    const summaryPath = join(outputDirectory, "summary.json")
+    const storageStateArtifactPath = artifactRelativePath(this.artifactRoot, storageStatePath)
+    const summaryArtifactPath = artifactRelativePath(this.artifactRoot, summaryPath)
+    const storageStateJson = `${JSON.stringify(normalized.storageState, null, 2)}\n`
+    const summary = {
+      schema: "wp-codebox/browser-storage-state-export-summary/v1",
+      status: "exported",
+      storageState: normalized.summary,
+      ...(exportedUser ? { user: storageStateUserSummary(exportedUser) } : {}),
+      artifacts: {
+        storageState: storageStateArtifactPath,
+        summary: summaryArtifactPath,
+      },
+    }
+    const summaryJson = `${JSON.stringify(summary, null, 2)}\n`
+
+    await mkdir(outputDirectory, { recursive: true })
+    await writeFile(storageStatePath, storageStateJson)
+    await writeFile(summaryPath, summaryJson)
+
+    const storageStateDigest = { algorithm: "sha256" as const, value: sha256(Buffer.from(storageStateJson, "utf8")) }
+    const summaryDigest = { algorithm: "sha256" as const, value: sha256(Buffer.from(summaryJson, "utf8")) }
+
+    return `${JSON.stringify({
+      schema: "wp-codebox/browser-storage-state-export/v1",
+      status: "exported",
+      command: "wordpress.export-browser-storage-state",
+      storageState: normalized.summary,
+      ...(exportedUser ? { user: storageStateUserSummary(exportedUser) } : {}),
+      artifacts: {
+        storageState: storageStateArtifactPath,
+        summary: summaryArtifactPath,
+      },
+      artifactRefs: [
+        { kind: "browser-storage-state", path: storageStateArtifactPath, digest: storageStateDigest, redactionRequired: true },
+        { kind: "browser-storage-state-summary", path: summaryArtifactPath, digest: summaryDigest },
+      ],
+    }, null, 2)}\n`
+  }
+
   async runCaptureStateBundle(spec: ExecutionSpec): Promise<string> {
     const label = stringArg(spec.args ?? [], "label")
     const snapshotOptions = snapshotOptionsFromArgs(spec.args ?? [])
@@ -1161,6 +1228,42 @@ function stringListArg(args: string[], name: string): string[] | undefined {
 
   const values = value.split(",").map((item) => item.trim()).filter((item) => item.length > 0)
   return values.length > 0 ? values : undefined
+}
+
+function jsonObjectStringArg(args: string[], name: string): Record<string, unknown> {
+  const value = stringArg(args, name)
+  if (!value) {
+    return {}
+  }
+
+  const parsed = JSON.parse(value) as unknown
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${name} must be a JSON object`)
+  }
+  return parsed as Record<string, unknown>
+}
+
+function storageStateOutputDirectory(artifactRoot: string, requested: string | undefined): string {
+  const relativePath = requested?.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "") || "files/browser-storage-state"
+  if (relativePath.length === 0 || relativePath.includes("..")) {
+    throw new Error("wordpress.export-browser-storage-state output-dir must be a relative path inside the runtime artifact root")
+  }
+
+  return join(artifactRoot, relativePath)
+}
+
+function artifactRelativePath(artifactRoot: string, absolutePath: string): string {
+  return absolutePath.replace(artifactRoot, "").replace(/^\/+/, "")
+}
+
+function storageStateUserSummary(user: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: typeof user.id === "number" ? user.id : undefined,
+    username: typeof user.username === "string" ? user.username : undefined,
+    email: typeof user.email === "string" ? user.email : undefined,
+    role: typeof user.role === "string" ? user.role : undefined,
+    created: typeof user.created === "boolean" ? user.created : undefined,
+  }
 }
 
 function snapshotOptionsFromArgs(args: string[]): RuntimeSnapshotExportOptions {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from "node:crypto"
-import { mkdir, realpath, writeFile } from "node:fs/promises"
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { dirname, join, resolve } from "node:path"
-import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, parseCommandAgentRunRequest, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
+import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, parseCommandAgentRunRequest, resolveCommandPath, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
@@ -804,23 +804,10 @@ class PlaygroundRuntime implements Runtime {
 
   async runExportBrowserStorageState(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
-    const browserUrls = stringListArg(spec.args ?? [], "browser-urls") ?? [this.spec.preview?.publicUrl ?? server.serverUrl]
-    const user = jsonObjectStringArg(spec.args ?? [], "user-json") as WordPressFixtureUserSpec
     const outputDirectory = storageStateOutputDirectory(this.artifactRoot, stringArg(spec.args ?? [], "output-dir"))
-    const code = wordpressFixtureUserStorageStatePhpCode({ browserUrls, user })
-    const response = await this.runPlaygroundCommand("wordpress.export-browser-storage-state", server, {
-      code: bootstrapPhpCode(this.spec, code, spec.args ?? []),
-    })
-    assertPlaygroundResponseOk("wordpress.export-browser-storage-state", response)
-
-    let payload: unknown
-    try {
-      payload = JSON.parse(response.text)
-    } catch (error) {
-      throw new Error(`wordpress.export-browser-storage-state returned invalid JSON: ${errorMessage(error)}`)
-    }
-
-    const normalized = normalizeBrowserStorageStatePayload(payload, "inline")
+    const providedStorageState = await storageStatePayloadFromArgs(spec.args ?? [])
+    const payload = providedStorageState?.payload ?? await this.exportWordPressFixtureUserStorageState(spec, server)
+    const normalized = normalizeBrowserStorageStatePayload(payload, providedStorageState?.source ?? "inline")
     if (normalized.summary.status !== "ready") {
       throw new Error(`wordpress.export-browser-storage-state returned unsupported storage state: ${JSON.stringify(normalized.summary.diagnostics)}`)
     }
@@ -866,6 +853,22 @@ class PlaygroundRuntime implements Runtime {
         { kind: "browser-storage-state-summary", path: summaryArtifactPath, digest: summaryDigest },
       ],
     }, null, 2)}\n`
+  }
+
+  private async exportWordPressFixtureUserStorageState(spec: ExecutionSpec, server: PlaygroundCliServer): Promise<unknown> {
+    const browserUrls = stringListArg(spec.args ?? [], "browser-urls") ?? [this.spec.preview?.publicUrl ?? server.serverUrl]
+    const user = jsonObjectStringArg(spec.args ?? [], "user-json") as WordPressFixtureUserSpec
+    const code = wordpressFixtureUserStorageStatePhpCode({ browserUrls, user })
+    const response = await this.runPlaygroundCommand("wordpress.export-browser-storage-state", server, {
+      code: bootstrapPhpCode(this.spec, code, spec.args ?? []),
+    })
+    assertPlaygroundResponseOk("wordpress.export-browser-storage-state", response)
+
+    try {
+      return JSON.parse(response.text)
+    } catch (error) {
+      throw new Error(`wordpress.export-browser-storage-state returned invalid JSON: ${errorMessage(error)}`)
+    }
   }
 
   async runCaptureStateBundle(spec: ExecutionSpec): Promise<string> {
@@ -1241,6 +1244,21 @@ function jsonObjectStringArg(args: string[], name: string): Record<string, unkno
     throw new Error(`${name} must be a JSON object`)
   }
   return parsed as Record<string, unknown>
+}
+
+async function storageStatePayloadFromArgs(args: string[]): Promise<{ payload: unknown; source: "inline" | "file" } | undefined> {
+  const raw = stringArg(args, "storage-state")
+  if (!raw) {
+    return undefined
+  }
+
+  const source = raw.startsWith("@") ? "file" : "inline"
+  const text = source === "file" ? await readFile(resolveCommandPath(raw.slice(1)), "utf8") : raw
+  try {
+    return { payload: JSON.parse(text), source }
+  } catch (error) {
+    throw new Error(`wordpress.export-browser-storage-state storage-state must be valid JSON: ${errorMessage(error)}`)
+  }
 }
 
 function storageStateOutputDirectory(artifactRoot: string, requested: string | undefined): string {

--- a/tests/fixture-auth-storage-state.test.ts
+++ b/tests/fixture-auth-storage-state.test.ts
@@ -50,4 +50,11 @@ for (const commandId of ["wordpress.browser-probe", "wordpress.browser-actions"]
   assert.ok(command?.acceptedArgs.some((arg) => arg.name === "storage-state"), `${commandId} exposes storage-state argument`)
 }
 
+const exportCommand = commandRegistry.find((definition) => definition.id === "wordpress.export-browser-storage-state")
+assert.ok(exportCommand, "storage-state export command is registered")
+assert.equal(exportCommand?.outputSchema?.id, "wp-codebox/browser-storage-state-export/v1")
+assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "browser-urls"), "export command accepts browser URLs")
+assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "user-json"), "export command accepts a fixture user")
+assert.doesNotMatch(JSON.stringify(exportCommand), /wpcom|dolly|blog_id|site_id/i)
+
 console.log("fixture auth storage state ok")

--- a/tests/fixture-auth-storage-state.test.ts
+++ b/tests/fixture-auth-storage-state.test.ts
@@ -55,6 +55,7 @@ assert.ok(exportCommand, "storage-state export command is registered")
 assert.equal(exportCommand?.outputSchema?.id, "wp-codebox/browser-storage-state-export/v1")
 assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "browser-urls"), "export command accepts browser URLs")
 assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "user-json"), "export command accepts a fixture user")
+assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "storage-state"), "export command accepts caller-provided storage state")
 assert.doesNotMatch(JSON.stringify(exportCommand), /wpcom|dolly|blog_id|site_id/i)
 
 console.log("fixture auth storage state ok")


### PR DESCRIPTION
## Summary
- Adds a generic `wordpress.export-browser-storage-state` recipe command that materializes caller-provided Playwright `storageState` JSON or a `wp-codebox/browser-auth-storage-state/v1` envelope into reusable artifacts.
- Keeps a generic WordPress fixture-user convenience export path for disposable sandbox admin auth when `storage-state` is omitted.
- Writes a token-bearing `storage-state.json` artifact plus a redacted `summary.json` artifact with schema/kind, user metadata, cookie host counts, origin count, and diagnostics.
- Documents the generic export/import contract and extends the storage-state contract test.

## Testing
- `npm run test:fixture-auth-storage-state`
- `npm run build`
- `npm run test:schema-parity`
- `npm run test:recipe-validation-descriptors`
- `npm run test:primitive-contract-parity`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Inspected the existing storage-state contract, implemented the generic export command/docs/tests, and ran targeted verification. Chris remains responsible for review and merge.