### PR TITLE
Resolve browser storage-state refs from artifacts

### DIFF
--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -61,7 +61,7 @@ export async function runBrowserActionsCommand({
   onProgress?: (event: BrowserCommandProgressEvent) => void
 }): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
-  const runPlan = plan ?? await browserActionsRunPlanFromArgs(args)
+  const runPlan = plan ?? await browserActionsRunPlanFromArgs(args, artifactRoot)
   const steps = [...runPlan.steps]
   const initialUrl = runPlan.initialUrl
   if (steps.length === 0 && !initialUrl) {
@@ -396,7 +396,7 @@ export async function runBrowserActionsCommand({
   }
 }
 
-async function browserActionsRunPlanFromArgs(args: string[]): Promise<BrowserActionsRunPlan> {
+async function browserActionsRunPlanFromArgs(args: string[], artifactRoot: string): Promise<BrowserActionsRunPlan> {
   const capture = new Set(commaListArg(args, "capture"))
   if (capture.size === 0) {
     capture.add("steps")
@@ -416,7 +416,7 @@ async function browserActionsRunPlanFromArgs(args: string[]): Promise<BrowserAct
     networkSettleTimeoutMs: durationArg(args, "network-settle-timeout", browserCommandLivenessPolicy().networkSettleTimeoutMs),
     requestedViewport: viewportArg(args, "viewport"),
     authRequest: browserAuthRequest(args),
-    storageStateImport: await browserStorageStateImportFromArgs(args, "wordpress.browser-actions"),
+    storageStateImport: await browserStorageStateImportFromArgs(args, "wordpress.browser-actions", artifactRoot),
     maxDomSnapshotElements: positiveIntegerArg(args, "max-dom-snapshot-elements", 160),
   }
 }

--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -170,7 +170,7 @@ export async function runSingleBrowserProbeCommand({
   onProgress?: (event: BrowserCommandProgressEvent) => void
 }): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
   const args = spec.args ?? []
-  const runPlan = plan ?? await browserProbeRunPlanFromArgs(args, profileId)
+  const runPlan = plan ?? await browserProbeRunPlanFromArgs(args, profileId, artifactRoot)
   if (!runPlan.url) {
     throw new Error("wordpress.browser-probe requires url=<path-or-url>")
   }
@@ -577,7 +577,7 @@ function browserProbeProfile(profileId: string): BrowserProbeProfileDefinition {
   return profile
 }
 
-async function browserProbeRunPlanFromArgs(args: string[], profileId?: string): Promise<BrowserProbeRunPlan> {
+async function browserProbeRunPlanFromArgs(args: string[], profileId: string | undefined, artifactRoot: string): Promise<BrowserProbeRunPlan> {
   const capture = new Set(commaListArg(args, "capture"))
   if (capture.size === 0) {
     capture.add("console")
@@ -599,7 +599,7 @@ async function browserProbeRunPlanFromArgs(args: string[], profileId?: string): 
     prePageScript: argValue(args, "pre-page-script"),
     script: argValue(args, "script"),
     authRequest: browserAuthRequest(args),
-    storageStateImport: await browserStorageStateImportFromArgs(args, "wordpress.browser-probe"),
+    storageStateImport: await browserStorageStateImportFromArgs(args, "wordpress.browser-probe", artifactRoot),
     failFast: strictBooleanArg(args, "fail-fast", false),
     stallTimeoutMs: durationArg(args, "stall-timeout", 0),
     wallTimeoutMs: durationArg(args, "timeout", browserCommandLivenessPolicy().wallTimeoutMs),

--- a/packages/runtime-playground/src/browser-probe-support.ts
+++ b/packages/runtime-playground/src/browser-probe-support.ts
@@ -713,14 +713,14 @@ function positiveIntegerArg(args: string[], name: string, fallback: number): num
   return parsed
 }
 
-export async function browserStorageStateImportFromArgs(args: string[], command: string): Promise<BrowserStorageStateImport | undefined> {
+export async function browserStorageStateImportFromArgs(args: string[], command: string, artifactRoot?: string): Promise<BrowserStorageStateImport | undefined> {
   const raw = argValue(args, "storage-state")?.trim()
   if (!raw) {
     return undefined
   }
 
   const source = raw.startsWith("@") ? "file" : "inline"
-  const text = source === "file" ? await readFile(resolveCommandPath(raw.slice(1)), "utf8") : raw
+  const text = source === "file" ? await readStorageStateFile(raw.slice(1), artifactRoot) : raw
   let payload: unknown
   try {
     payload = JSON.parse(text)
@@ -740,6 +740,18 @@ export async function browserStorageStateImportFromArgs(args: string[], command:
     throw new BrowserStorageStateImportError(`${command} storage-state is unsupported`, normalized.summary)
   }
   return normalized
+}
+
+async function readStorageStateFile(pathValue: string, artifactRoot?: string): Promise<string> {
+  const primaryPath = resolveCommandPath(pathValue)
+  try {
+    return await readFile(primaryPath, "utf8")
+  } catch (error) {
+    if (!artifactRoot) {
+      throw error
+    }
+    return readFile(resolveCommandPath(pathValue, artifactRoot), "utf8")
+  }
 }
 
 export function browserStorageStateAuthSummary(summary: BrowserStorageStateImportSummary): BrowserProbeAuthSummary {

--- a/tests/fixture-auth-storage-state.test.ts
+++ b/tests/fixture-auth-storage-state.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict"
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { commandRegistry } from "../packages/runtime-core/src/command-registry.js"
 import { browserStorageStateFromWordPressAuthCookies, normalizeBrowserStorageStatePayload, wordpressFixtureUserStorageStatePhpCode } from "../packages/runtime-playground/src/browser-auth-storage-state.js"
+import { browserStorageStateImportFromArgs } from "../packages/runtime-playground/src/browser-probe-support.js"
 
 const state = browserStorageStateFromWordPressAuthCookies([
   { name: "wordpress_logged_in", value: "token", domain: "localhost", path: "/", expires: 1_800_000_000, httpOnly: true },
@@ -57,5 +61,15 @@ assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "browser-urls")
 assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "user-json"), "export command accepts a fixture user")
 assert.ok(exportCommand?.acceptedArgs.some((arg) => arg.name === "storage-state"), "export command accepts caller-provided storage state")
 assert.doesNotMatch(JSON.stringify(exportCommand), /wpcom|dolly|blog_id|site_id/i)
+
+const artifactRoot = join(tmpdir(), `wp-codebox-storage-state-${process.pid}`)
+const artifactStatePath = join(artifactRoot, "files/browser-storage-state/storage-state.json")
+await mkdir(join(artifactRoot, "files/browser-storage-state"), { recursive: true })
+await writeFile(artifactStatePath, `${JSON.stringify(imported.storageState)}\n`, "utf8")
+const importedFromArtifactRef = await browserStorageStateImportFromArgs([
+  "storage-state=@files/browser-storage-state/storage-state.json",
+], "wordpress.browser-probe", artifactRoot)
+assert.equal(importedFromArtifactRef?.summary.status, "ready")
+assert.equal(importedFromArtifactRef?.summary.cookieCount, 1)
 
 console.log("fixture auth storage state ok")


### PR DESCRIPTION
## Summary
- Resolve browser storage-state @file imports from the runtime artifact root when the process-cwd path is absent.
- Pass the artifact root into browser-probe and browser-actions storage-state import parsing.
- Cover artifact-relative storage-state refs in the fixture auth storage-state test.

## Tests
- npm run test:fixture-auth-storage-state
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and tested the artifact-relative storage-state import fix; Chris remains responsible for review and merge.