### PR TITLE
Add generic materialization result envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,7 @@ wp-codebox materialize-replay-package \
   --json
 ```
 
-The materializer writes `blueprint.after.json`, `blueprint.zip`, `files/runtime-snapshot.json`, `blueprint.after-notes.json`, and `manifest.json`. The generated notes and manifest record source metadata, including the resolved input snapshot path, optional `--snapshot-ref`, and the `wp-codebox materialize-replay-package` command.
+The materializer writes `blueprint.after.json`, `blueprint.zip`, `files/runtime-snapshot.json`, `blueprint.after-notes.json`, and `manifest.json`. With `--json`, stdout is a generic `wp-codebox/materialization-result/v1` envelope; the replay-package-specific `wp-codebox/wordpress-replay-export/v1` data is carried as a projection. The generated notes and manifest record source metadata, including the resolved input snapshot path, optional `--snapshot-ref`, and the `wp-codebox materialize-replay-package` command.
 
 Replay packages use a bundled resource for `files/runtime-snapshot.json` so the blueprint and snapshot travel together as one local artifact directory. `blueprint.after.json` is the local/package validation artifact. Public WordPress Playground viewer links must use `blueprint.zip`, because Playground resolves bundled resources from a bundle archive with a root `blueprint.json` entry; a plain JSON URL cannot resolve `files/runtime-snapshot.json`. The manifest therefore records `replayableWordPressSite.publicViewerArtifactPath: "blueprint.zip"`. Use URL resources only when the snapshot is already hosted at a stable, browser-fetchable URL; this avoids shipping the snapshot beside the blueprint, but replay then depends on network access, CORS, URL lifetime, and the full snapshot download at restore time.
 

--- a/docs/generic-runtime-primitives.md
+++ b/docs/generic-runtime-primitives.md
@@ -37,6 +37,13 @@ only for loopback hosts.
 references produced while converting runtime output into durable artifacts. These
 refs can be folded into run records as `materialization:<kind>` artifact refs.
 
+`wp-codebox/materialization-result/v1` is the generic materialization envelope.
+It records `status` (`completed`, `failed`, or `skipped`), ordered `phases`,
+artifact refs, diagnostics, and optional caller projections. Product-specific
+views such as browser artifact persistence or WordPress replay packages belong in
+`projections[]`; the core envelope stays caller-neutral and represents failures
+without requiring callers to recover information from thrown errors.
+
 ## Evidence Artifact Envelopes
 
 `wp-codebox/evidence-artifact-envelope/v1` is a caller-neutral envelope for

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:editor-actions": "tsx tests/editor-actions.test.ts",
     "test:artifact-path-primitives": "tsx tests/artifact-path-primitives.test.ts",
     "test:browser-callback-materialization-contracts": "tsx tests/browser-callback-materialization-contracts.test.ts",
+    "test:materialize-replay-package-command": "tsx tests/materialize-replay-package-command.test.ts",
     "test:source-package-compiler-primitives": "tsx tests/source-package-compiler-primitives.test.ts",
     "test:source-root-preparation": "tsx tests/source-root-preparation.test.ts",
     "test:bench-command-step-behavior": "tsx tests/bench-command-step-behavior.test.ts",

--- a/packages/cli/src/commands/replay-package.ts
+++ b/packages/cli/src/commands/replay-package.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
+import { materializationPhaseResult, materializationResultEnvelope, type MaterializationArtifactRef, type MaterializationResultEnvelope } from "@automattic/wp-codebox-core"
 import { writeReplayExportPackage, type ReplayExportPackage, type RuntimeSnapshotArtifact } from "@automattic/wp-codebox-playground"
 import { captureStdout } from "../output.js"
 
@@ -23,10 +24,10 @@ export async function runMaterializeReplayPackageCommand(args: string[]): Promis
     return 0
   }
 
-  const { result, logs } = await captureStdout(execute)
+  const { result, logs } = await captureStdout(() => materializeReplayPackageEnvelope(options))
   const output = logs.length > 0 ? { ...result, logs } : result
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
-  return 0
+  return result.status === "completed" ? 0 : 1
 }
 
 async function materializeReplayPackage(options: MaterializeReplayPackageOptions): Promise<ReplayExportPackage> {
@@ -49,6 +50,46 @@ async function materializeReplayPackage(options: MaterializeReplayPackageOptions
       materializerCommand: "wp-codebox materialize-replay-package",
     },
   })
+}
+
+async function materializeReplayPackageEnvelope(options: MaterializeReplayPackageOptions): Promise<MaterializationResultEnvelope> {
+  const startedAtMs = Date.now()
+  try {
+    const result = await materializeReplayPackage(options)
+    const phase = materializationPhaseResult({
+      phase: "wordpress-replay-package-materialization",
+      status: "completed",
+      artifactRefs: replayPackageArtifactRefs(result),
+      metadata: result.metrics,
+    })
+
+    return materializationResultEnvelope({
+      task: "materialize-replay-package",
+      phases: [phase],
+      result: result as unknown as Record<string, unknown>,
+      projections: [{ kind: "wordpress-replay-package", schema: "wp-codebox/wordpress-replay-export/v1", package: result }],
+      metadata: { durationMs: Date.now() - startedAtMs },
+    })
+  } catch (error) {
+    const serialized = serializeMaterializationError(error)
+    return materializationResultEnvelope({
+      task: "materialize-replay-package",
+      status: "failed",
+      phases: [materializationPhaseResult({
+        phase: "wordpress-replay-package-materialization",
+        status: "failed",
+        error: serialized,
+      })],
+      diagnostics: [{
+        code: serialized.code ?? "replay-package-materialization-failed",
+        message: serialized.message,
+        severity: "error",
+        phase: "wordpress-replay-package-materialization",
+      }],
+      error: serialized,
+      metadata: { durationMs: Date.now() - startedAtMs },
+    })
+  }
 }
 
 function parseMaterializeReplayPackageOptions(args: string[]): MaterializeReplayPackageOptions {
@@ -111,6 +152,27 @@ function printMaterializeReplayPackageHumanOutput(output: ReplayExportPackage): 
   console.log(`Snapshot: ${output.artifacts.snapshot}`)
   console.log(`Notes: ${output.artifacts.notes}`)
   console.log(`Manifest: ${output.artifacts.manifest}`)
+}
+
+function replayPackageArtifactRefs(result: ReplayExportPackage): MaterializationArtifactRef[] {
+  return [
+    { kind: "replay-package-manifest", path: result.artifacts.manifest, digest: result.manifest.contentDigest },
+    { kind: "replay-package-blueprint", path: result.artifacts.blueprint },
+    { kind: "replay-package-bundle", path: result.artifacts.playgroundBundle },
+    { kind: "runtime-snapshot", path: result.artifacts.snapshot },
+    { kind: "replay-package-notes", path: result.artifacts.notes },
+  ]
+}
+
+function serializeMaterializationError(error: unknown): { name: string; message: string; code?: string } {
+  if (error instanceof Error) {
+    return {
+      name: error.name || "Error",
+      message: error.message,
+      ...("code" in error && typeof error.code === "string" ? { code: error.code } : {}),
+    }
+  }
+  return { name: "Error", message: String(error) }
 }
 
 function isRuntimeSnapshotArtifact(value: unknown): value is RuntimeSnapshotArtifact {

--- a/packages/runtime-core/src/materialization-contracts.ts
+++ b/packages/runtime-core/src/materialization-contracts.ts
@@ -25,15 +25,61 @@ export interface MaterializationPhaseResult {
   }
 }
 
-export interface MaterializationResultEnvelope {
-  schema: typeof MATERIALIZATION_RESULT_SCHEMA
-  success: true
-  task: string
-  result: Record<string, unknown>
-  report: Record<string, unknown> | null
-  response: Record<string, unknown>
-  codeboxMaterialization: unknown
+export type MaterializationResultStatus = "completed" | "failed" | "skipped"
+
+export interface MaterializationDiagnostic {
+  code: string
+  message: string
+  severity?: "info" | "warning" | "error"
+  phase?: string
+  metadata?: Record<string, unknown>
 }
+
+export interface MaterializationProjection {
+  kind: string
+  schema?: string
+  [key: string]: unknown
+}
+
+export interface MaterializationResultEnvelopeBase {
+  schema: typeof MATERIALIZATION_RESULT_SCHEMA
+  status: MaterializationResultStatus
+  success: boolean
+  task?: string
+  phases: MaterializationPhaseResult[]
+  artifactRefs: MaterializationArtifactRef[]
+  diagnostics: MaterializationDiagnostic[]
+  projections?: MaterializationProjection[]
+  metadata?: Record<string, unknown>
+  result?: Record<string, unknown>
+  report: Record<string, unknown> | null
+  response?: Record<string, unknown>
+  codeboxMaterialization?: unknown
+}
+
+export interface CompletedMaterializationResultEnvelope extends MaterializationResultEnvelopeBase {
+  status: "completed"
+  success: true
+  result: Record<string, unknown>
+}
+
+export interface FailedMaterializationResultEnvelope extends MaterializationResultEnvelopeBase {
+  status: "failed"
+  success: false
+  error: {
+    name: string
+    message: string
+    code?: string
+  }
+}
+
+export interface SkippedMaterializationResultEnvelope extends MaterializationResultEnvelopeBase {
+  status: "skipped"
+  success: false
+  reason?: string
+}
+
+export type MaterializationResultEnvelope = CompletedMaterializationResultEnvelope | FailedMaterializationResultEnvelope | SkippedMaterializationResultEnvelope
 
 export interface BrowserArtifactProjectionInput {
   artifact?: Record<string, unknown> | null
@@ -61,7 +107,68 @@ export function materializationPhaseResult(input: Omit<MaterializationPhaseResul
   })
 }
 
-export function normalizeMaterializationResultEnvelope(materialization: unknown, fallbackMessage = "Materialization failed."): MaterializationResultEnvelope {
+export function materializationResultEnvelope(input: {
+  task?: string
+  status?: MaterializationResultStatus
+  phases?: MaterializationPhaseResult[]
+  artifactRefs?: MaterializationArtifactRef[]
+  diagnostics?: MaterializationDiagnostic[]
+  projections?: MaterializationProjection[]
+  metadata?: Record<string, unknown>
+  result?: Record<string, unknown>
+  report?: Record<string, unknown> | null
+  response?: Record<string, unknown>
+  error?: { name?: string; message?: string; code?: string } | Error | string
+  reason?: string
+  codeboxMaterialization?: unknown
+}): MaterializationResultEnvelope {
+  const phases = input.phases ?? []
+  const status = input.status ?? (input.error || phases.some((phase) => phase.status === "failed") ? "failed" : "completed")
+  const artifactRefs = [...(input.artifactRefs ?? []), ...phases.flatMap((phase) => phase.artifactRefs)]
+  const diagnostics = input.diagnostics ?? phases.flatMap(phaseDiagnostics)
+  const base = stripUndefined({
+    schema: MATERIALIZATION_RESULT_SCHEMA,
+    status,
+    success: status === "completed",
+    task: input.task,
+    phases,
+    artifactRefs,
+    diagnostics,
+    projections: input.projections,
+    metadata: input.metadata,
+    result: input.result,
+    report: input.report ?? null,
+    response: input.response,
+    codeboxMaterialization: input.codeboxMaterialization,
+  })
+
+  if (status === "failed") {
+    return stripUndefined({
+      ...base,
+      status,
+      success: false as const,
+      error: normalizeError(input.error, diagnostics[0]?.message ?? "Materialization failed."),
+    })
+  }
+
+  if (status === "skipped") {
+    return stripUndefined({
+      ...base,
+      status,
+      success: false as const,
+      reason: input.reason,
+    })
+  }
+
+  return {
+    ...base,
+    status,
+    success: true as const,
+    result: input.result ?? {},
+  }
+}
+
+export function normalizeMaterializationResultEnvelope(materialization: unknown, fallbackMessage = "Materialization failed."): CompletedMaterializationResultEnvelope {
   const materializationRecord = asRecord(materialization)
   const raw = asRecord(materializationRecord?.response) ?? materializationRecord
   const report = raw?.schema === MATERIALIZATION_RESULT_SCHEMA || typeof raw?.schema === "string"
@@ -69,7 +176,14 @@ export function normalizeMaterializationResultEnvelope(materialization: unknown,
     : undefined
   const response = asRecord(report?.response) ?? raw
   if (response?.success !== true) {
-    throw new Error(errorMessage(response) ?? errorMessage(report) ?? fallbackMessage)
+    return requireCompletedMaterializationResultEnvelope(materializationResultEnvelope({
+      task: stringValue(response?.task) || stringValue(report?.task),
+      status: "failed",
+      report: report ?? null,
+      response,
+      error: errorObject(response) ?? errorObject(report) ?? fallbackMessage,
+      codeboxMaterialization: materialization,
+    }))
   }
 
   const canonicalResult = firstRecord(
@@ -81,18 +195,31 @@ export function normalizeMaterializationResultEnvelope(materialization: unknown,
     response.response,
   )
   if (canonicalResult?.success === false) {
-    throw new Error(errorMessage(canonicalResult) ?? fallbackMessage)
+    return requireCompletedMaterializationResultEnvelope(materializationResultEnvelope({
+      task: stringValue(response.task) || stringValue(report?.task),
+      status: "failed",
+      result: canonicalResult,
+      report: report ?? null,
+      response,
+      error: errorObject(canonicalResult) ?? fallbackMessage,
+      codeboxMaterialization: materialization,
+    }))
   }
 
-  return {
-    schema: MATERIALIZATION_RESULT_SCHEMA,
-    success: true,
+  return requireCompletedMaterializationResultEnvelope(materializationResultEnvelope({
     task: stringValue(response.task) || stringValue(report?.task),
     result: canonicalResult ?? response,
     report: report ?? null,
     response,
     codeboxMaterialization: materialization,
+  }))
+}
+
+export function requireCompletedMaterializationResultEnvelope(envelope: MaterializationResultEnvelope): CompletedMaterializationResultEnvelope {
+  if (envelope.status !== "completed") {
+    throw new Error(envelope.status === "failed" ? envelope.error.message : envelope.reason ?? "Materialization did not complete.")
   }
+  return envelope
 }
 
 export function browserArtifactPersistenceProjection(input: BrowserArtifactProjectionInput | MaterializationResultEnvelope | unknown): BrowserArtifactPersistenceProjection {
@@ -190,6 +317,38 @@ function normalizeDigest(input: unknown): MaterializationArtifactRef["digest"] |
   return value ? { algorithm, value } : normalizeDigest(input.sha256) ?? normalizeDigest(input.digest) ?? normalizeDigest(input.contentDigest)
 }
 
+function phaseDiagnostics(phase: MaterializationPhaseResult): MaterializationDiagnostic[] {
+  if (phase.status !== "failed" || !phase.error) {
+    return []
+  }
+  return [{
+    code: phase.error.code ?? "materialization-phase-failed",
+    message: phase.error.message,
+    severity: "error",
+    phase: phase.phase,
+  }]
+}
+
+function normalizeError(input: { name?: string; message?: string; code?: string } | Error | string | undefined, fallbackMessage: string): FailedMaterializationResultEnvelope["error"] {
+  if (input instanceof Error) {
+    return stripUndefined({ name: input.name || "Error", message: input.message || fallbackMessage, code: "code" in input && typeof input.code === "string" ? input.code : undefined })
+  }
+  if (typeof input === "string") {
+    return { name: "Error", message: input || fallbackMessage }
+  }
+  return stripUndefined({
+    name: stringValue(input?.name) || "Error",
+    message: stringValue(input?.message) || fallbackMessage,
+    code: stringValue(input?.code) || undefined,
+  })
+}
+
+function errorObject(value: Record<string, unknown> | undefined): FailedMaterializationResultEnvelope["error"] | undefined {
+  const error = asRecord(value?.error)
+  const message = stringValue(error?.message) || stringValue(value?.message)
+  return message ? normalizeError({ name: stringValue(error?.name) || "Error", message, code: stringValue(error?.code) || undefined }, message) : undefined
+}
+
 function firstRecord(...values: unknown[]): Record<string, unknown> | undefined {
   return values.find(isRecord)
 }
@@ -204,9 +363,4 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value : ""
-}
-
-function errorMessage(value: Record<string, unknown> | undefined): string | undefined {
-  const error = asRecord(value?.error)
-  return stringValue(error?.message) || stringValue(value?.message) || undefined
 }

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -7,6 +7,7 @@ import {
   browserCallbackCapability,
   browserCallbackResultEnvelope,
   browserCallbackSignature,
+  materializationResultEnvelope,
   materializationPhaseResult,
   materializationRunArtifactRefs,
   normalizeMaterializationResultEnvelope,
@@ -153,6 +154,28 @@ assert.deepEqual(materializationRunArtifactRefs([phase]), [
     digest: { algorithm: "sha256", value: "abc" },
   },
 ])
+
+const failedMaterializationEnvelope = materializationResultEnvelope({
+  task: "package-runtime-replay",
+  status: "failed",
+  phases: [materializationPhaseResult({
+    phase: "snapshot-validation",
+    status: "failed",
+    error: { name: "Error", message: "invalid snapshot", code: "invalid-snapshot" },
+  })],
+  projections: [{ kind: "browser-artifacts", schema: "wp-codebox/browser-artifact-persistence-projection/v1", artifacts: [] }],
+})
+assert.equal(failedMaterializationEnvelope.schema, "wp-codebox/materialization-result/v1")
+assert.equal(failedMaterializationEnvelope.status, "failed")
+assert.equal(failedMaterializationEnvelope.success, false)
+assert.equal(failedMaterializationEnvelope.error.message, "invalid snapshot")
+assert.deepEqual(failedMaterializationEnvelope.diagnostics, [{
+  code: "invalid-snapshot",
+  message: "invalid snapshot",
+  severity: "error",
+  phase: "snapshot-validation",
+}])
+assert.equal(failedMaterializationEnvelope.projections?.[0]?.kind, "browser-artifacts")
 
 const materializationEnvelope = normalizeMaterializationResultEnvelope({
   success: true,

--- a/tests/materialize-replay-package-command.test.ts
+++ b/tests/materialize-replay-package-command.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { runMaterializeReplayPackageCommand } from "../packages/cli/src/commands/replay-package.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-materialization-result-"))
+
+try {
+  const snapshotPath = join(root, "not-a-snapshot.json")
+  await writeFile(snapshotPath, JSON.stringify({ schema: "example/not-runtime-snapshot" }))
+
+  const { code, stdout } = await captureStdout(() => runMaterializeReplayPackageCommand([
+    "--snapshot",
+    snapshotPath,
+    "--output",
+    join(root, "package"),
+    "--json",
+  ]))
+  const envelope = JSON.parse(stdout)
+
+  assert.equal(code, 1)
+  assert.equal(envelope.schema, "wp-codebox/materialization-result/v1")
+  assert.equal(envelope.task, "materialize-replay-package")
+  assert.equal(envelope.status, "failed")
+  assert.equal(envelope.success, false)
+  assert.equal(envelope.phases[0].phase, "wordpress-replay-package-materialization")
+  assert.equal(envelope.phases[0].status, "failed")
+  assert.match(envelope.error.message, /not a wp-codebox\/wordpress-runtime-snapshot\/v1/)
+  assert.equal(envelope.diagnostics[0].severity, "error")
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+async function captureStdout(callback: () => Promise<number>): Promise<{ code: number; stdout: string }> {
+  let stdout = ""
+  const write = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdout += typeof chunk === "string" ? chunk : chunk.toString()
+
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback()
+    } else if (callback) {
+      callback()
+    }
+
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    return { code: await callback(), stdout }
+  } finally {
+    process.stdout.write = write
+  }
+}


### PR DESCRIPTION
## Summary
- Add a generic materialization result envelope with completed/failed/skipped status, phases, artifact refs, diagnostics, and optional projections.
- Keep browser artifact persistence as a projection and preserve the existing completed-only browser callback adapter.
- Emit deterministic materialization envelopes from the replay package JSON command, including failed materializations.

## Tests
- npm run build
- npm run test:browser-callback-materialization-contracts
- npm run test:materialize-replay-package-command
- npm exec -- tsx scripts/materialize-replay-package-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested generic materialization result envelope.