### PR TITLE
Fix evidence bundle identity and recipe artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
+    "test:evidence-bundle-digest-and-recipe-artifact": "tsx tests/evidence-bundle-digest-and-recipe-artifact.test.ts",
     "test:runtime-overlay-descriptors": "tsx tests/runtime-overlay-descriptors.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { buildAgentTaskRecipe, DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput, parseCommandJson, parseCommandOptions, resolveEffectiveRuntimeToolPolicy, type AgentTaskRunInput, type AgentTaskRunResultSummary, type AgentTerminalResult, type SandboxToolPolicySnapshot } from "@automattic/wp-codebox-core"
@@ -46,15 +46,23 @@ interface CapturedOutput<T> {
   exitCode: number
 }
 
-interface FailureEvidenceInput {
+export interface FailureEvidenceInput {
   input: AgentTaskRunInput
   task: string
   wpVersion: string
   artifacts: string
   recipePath: string
+  generatedRecipeArtifact?: GeneratedRecipeArtifactRef
   run: Record<string, unknown>
   capture?: CapturedOutput<unknown>
   error?: unknown
+}
+
+export interface GeneratedRecipeArtifactRef {
+  path: string
+  absolutePath: string
+  kind: "generated-recipe"
+  contentType: "application/json"
 }
 
 const FAILURE_SNIPPET_CHARS = 4000
@@ -85,10 +93,13 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
   const recipeDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-agent-task-recipe-"))
   const recipePath = join(recipeDirectory, "recipe.json")
   let capture: CapturedOutput<number> | undefined
+  let recipeJson = ""
+  let generatedRecipeArtifact: GeneratedRecipeArtifactRef | undefined
 
   try {
     const recipe = buildAgentTaskRecipe(input, taskInput, wpVersion)
-    await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`)
+    recipeJson = `${JSON.stringify(recipe, null, 2)}\n`
+    await writeFile(recipePath, recipeJson)
     const recipeRunArgs = ["--recipe", recipePath, "--artifacts", artifacts, "--json"]
     if (options.previewHoldSeconds) {
       recipeRunArgs.push("--preview-hold-seconds", options.previewHoldSeconds)
@@ -97,6 +108,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       recipeRunArgs.push("--preview-public-url", options.previewPublicUrl)
     }
     capture = await captureOutput(() => runRecipeRunCommand(recipeRunArgs))
+    generatedRecipeArtifact = await persistGeneratedRecipeArtifact(artifacts, recipeJson)
     const run = parseRecipeRunOutput(capture.stdout)
     const runRecord = objectValue(run.run) || {}
     const artifactsRecord = objectValue(run.artifacts) || {}
@@ -131,7 +143,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
       }),
     }, { exitStatus: capture.exitCode })
     const success = normalizedRunResult.success
-    const failureEvidence = success ? undefined : buildFailureEvidence({ input, task, wpVersion, artifacts, recipePath, run, capture })
+    const failureEvidence = success ? undefined : buildFailureEvidence({ input, task, wpVersion, artifacts, recipePath, generatedRecipeArtifact, run, capture })
     const outputDiagnostics = [...diagnostics(run, success ? 0 : capture.exitCode, success, failureEvidence), ...(hasAgentBundle ? workload.diagnostics.map((diagnostic) => ({ ...diagnostic })) : [])]
     const agentTaskRunResult = success ? normalizedRunResult : withFailureEvidence(normalizedRunResult, failureEvidence, outputDiagnostics)
     const output: AgentTaskRunOutput = {
@@ -173,8 +185,9 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     return output
   } catch (error) {
     const run = { success: false, error: serializeUnknownError(error) }
+    generatedRecipeArtifact = recipeJson ? await persistGeneratedRecipeArtifact(artifacts, recipeJson) : undefined
     const normalizedRunResult = normalizeAgentTaskRunResult(run, { exitStatus: capture?.exitCode ?? 1 })
-    const failureEvidence = buildFailureEvidence({ input, task, wpVersion, artifacts, recipePath, run, capture, error })
+    const failureEvidence = buildFailureEvidence({ input, task, wpVersion, artifacts, recipePath, generatedRecipeArtifact, run, capture, error })
     const failureDiagnostics = diagnostics(run, capture?.exitCode ?? 1, false, failureEvidence)
     const agentTaskRunResult = withFailureEvidence(normalizedRunResult, failureEvidence, failureDiagnostics)
     return {
@@ -327,6 +340,14 @@ function parseRecipeRunOutput(stdout: string): Record<string, unknown> {
   return objectValue(parsed) || { success: false, error: { message: "WP Codebox recipe run returned a non-object JSON value." } }
 }
 
+async function persistGeneratedRecipeArtifact(artifacts: string, contents: string): Promise<GeneratedRecipeArtifactRef> {
+  const path = "files/generated-recipe/recipe.json"
+  const absolutePath = join(artifacts, path)
+  await mkdir(join(artifacts, "files", "generated-recipe"), { recursive: true })
+  await writeFile(absolutePath, contents)
+  return { path, absolutePath, kind: "generated-recipe", contentType: "application/json" }
+}
+
 function stringOption(options: Map<string, string | true>, name: string): string {
   const value = options.get(name)
   return typeof value === "string" ? value : ""
@@ -399,7 +420,7 @@ function componentContractReport(run: Record<string, unknown>): Array<Record<str
   return Array.isArray(run.componentContracts) ? run.componentContracts.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
 }
 
-function buildFailureEvidence(values: FailureEvidenceInput): Record<string, unknown> {
+export function buildFailureEvidence(values: FailureEvidenceInput): Record<string, unknown> {
   const runRecord = objectValue(values.run.run) || {}
   const runtimeRecord = objectValue(values.run.runtime) || objectValue(runRecord.runtime) || {}
   const artifactsRecord = objectValue(values.run.artifacts) || {}
@@ -410,7 +431,12 @@ function buildFailureEvidence(values: FailureEvidenceInput): Record<string, unkn
   const stderr = stringValue(execution?.stderr) || values.capture?.stderr || ""
   const recipeRunEvidence = stripUndefined({
     schema: stringValue(values.run.schema) || undefined,
-    recipe_path: values.recipePath,
+    recipe_path: values.generatedRecipeArtifact?.path ?? values.recipePath,
+    recipe_artifact: values.generatedRecipeArtifact ? {
+      path: values.generatedRecipeArtifact.path,
+      kind: values.generatedRecipeArtifact.kind,
+      content_type: values.generatedRecipeArtifact.contentType,
+    } : undefined,
     status: stringValue(runRecord.status) || stringValue(values.run.status) || undefined,
     run_id: stringValue(runRecord.runId) || undefined,
   })

--- a/packages/runtime-core/src/artifact-bundle-verifier.ts
+++ b/packages/runtime-core/src/artifact-bundle-verifier.ts
@@ -1,7 +1,7 @@
 import { lstat, readdir, readFile, realpath } from "node:fs/promises"
 import { isAbsolute, join, normalize, relative, sep } from "node:path"
 import { Ajv2020 } from "ajv/dist/2020.js"
-import { artifactFileDigest, calculateArtifactContentDigest, calculateArtifactManifestFileSha256 } from "./artifact-manifest.js"
+import { artifactFileDigest, calculateArtifactContentDigest, calculateArtifactManifestFileListDigest, calculateArtifactManifestFileSha256 } from "./artifact-manifest.js"
 import type { ArtifactContentDigest, ArtifactFileDigest, ArtifactManifest, ArtifactManifestFile } from "./artifact-manifest.js"
 import { isPlainObject as isRecord } from "./object-utils.js"
 import { RUNTIME_EPISODE_TRACE_SCHEMA, validateRuntimeEpisodeTrace } from "./runtime-episode.js"
@@ -517,6 +517,9 @@ function artifactPathViolation(path: string, fieldPath: string): ArtifactBundleV
 
 async function verifyContentDigest(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
   for (const [index, input] of manifest.contentDigest.inputs.entries()) {
+    if (input === "manifest.files") {
+      continue
+    }
     const pathViolation = artifactPathViolation(input, `manifest.contentDigest.inputs[${index}]`)
     if (pathViolation) {
       violations.push(pathViolation)
@@ -534,7 +537,9 @@ async function verifyContentDigest(directory: string, manifest: ArtifactManifest
   }
 
   try {
-    const value = await calculateArtifactContentDigest(directory, manifest.contentDigest.inputs)
+    const value = manifest.contentDigest.inputs.length === 1 && manifest.contentDigest.inputs[0] === "manifest.files"
+      ? calculateArtifactManifestFileListDigest(manifest.files)
+      : await calculateArtifactContentDigest(directory, manifest.contentDigest.inputs)
     if (value !== manifest.contentDigest.value) {
       violations.push({
         code: "digest-mismatch",

--- a/packages/runtime-core/src/artifact-manifest.ts
+++ b/packages/runtime-core/src/artifact-manifest.ts
@@ -129,6 +129,13 @@ export async function calculateArtifactContentDigest(directory: string, inputs: 
   return hash.digest("hex")
 }
 
+export function calculateArtifactManifestFileListDigest(files: ArtifactManifestFile[]): string {
+  return createHash("sha256")
+    .update("wp-codebox/artifact-manifest-file-list/v1\n")
+    .update(stableJson(files.map(({ path, kind, contentType, redaction, provenance, viewer }) => stripUndefined({ path, kind, contentType, redaction, provenance, viewer }))))
+    .digest("hex")
+}
+
 export async function calculateArtifactManifestFileSha256(directory: string, manifest: ArtifactManifest, file: ArtifactManifestFile, manifestFileName = "manifest.json"): Promise<string> {
   if (file.path === manifestFileName) {
     return calculateArtifactManifestSelfSha256(manifest, manifestFileName)

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -13,6 +13,7 @@ import {
   artifactManifestFile,
   artifactManifestRelativePath,
   artifactManifestFileWithSha256,
+  calculateArtifactManifestFileListDigest,
   calculateArtifactManifestFileSha256,
   refreshArtifactManifestFileSha256s,
   runtimeReferenceManifestArtifactFiles,
@@ -158,73 +159,13 @@ export class ArtifactBundleBuilder {
     const { mountDiffs, changedFiles, patch, diagnostics: mountDiffDiagnostics } = await source.captureMountDiffs(filesDirectory, redactor)
     const changedFilesJson = redactor.redact(CHANGED_FILES_ARTIFACT_PATH, `${JSON.stringify(changedFiles, null, 2)}\n`)
     const redactedPatch = redactor.redact("files/patch.diff", patch)
-    const contentDigest = artifactContentDigest(changedFilesJson, redactedPatch)
-    const bundleId = `artifact-bundle-sha256-${contentDigest}`
-    const contentDigestMetadata = {
-      algorithm: "sha256",
-      inputs: ["files/changed-files.json", "files/patch.diff"],
-      value: contentDigest,
-    }
+    const patchContentDigest = artifactContentDigest(changedFilesJson, redactedPatch)
     const provenance = buildArtifactProvenance({
       runtime,
       context: source.spec.metadata ?? {},
       mounts: source.mounts,
     })
-    const artifactBundleRef: RuntimeEpisodeTraceRef = {
-      kind: "artifact-bundle",
-      id: bundleId,
-      digest: { algorithm: "sha256", value: contentDigest },
-      path: "manifest.json",
-    }
-    const previewEvidence = buildPreviewEvidence({
-      createdAt,
-      runtime,
-      preview,
-      durablePreview: durablePreview?.preview,
-      events: source.events,
-      packages: provenance.packages,
-      artifactBundleRef,
-    })
     const previewSessionEvidenceRelativePath = relative(source.artifactRoot, previewSessionEvidencePath)
-    const previewSessionEvidence = buildPreviewSessionEvidence({
-      artifactId: bundleId,
-      createdAt,
-      runtime,
-      preview,
-      durablePreview: durablePreview?.preview,
-      contentDigest,
-      packages: provenance.packages,
-      browser,
-      paths: {
-        manifest: relative(source.artifactRoot, manifestPath),
-        review: relative(source.artifactRoot, reviewPath),
-        runtimeEvents: relative(source.artifactRoot, eventsPath),
-        runtimeLog: relative(source.artifactRoot, runtimeLogPath),
-        runtimeReferenceManifest: relative(source.artifactRoot, runtimeReferenceManifestPath),
-        runtimeReplayReferenceIndex: relative(source.artifactRoot, runtimeReplayReferenceIndexPath),
-        durablePreview: durablePreview?.preview.manifest.path,
-        browserSummary: browser ? browser.probes.find((probe) => probe.summaryFile)?.summaryFile ?? "files/browser/summary.json" : undefined,
-      },
-    })
-    const previewSessionEvidenceJson = `${JSON.stringify(previewSessionEvidence, null, 2)}\n`
-    const previewSessionEvidenceRef: ArtifactEvidenceRef = {
-      path: previewSessionEvidenceRelativePath,
-      kind: "preview-session-evidence",
-      contentType: "application/json",
-      sha256: artifactFileDigest(previewSessionEvidenceJson),
-    }
-    const metadata: Record<string, unknown> = {
-      id: bundleId,
-      contentDigest: contentDigestMetadata,
-      createdAt,
-      runtime,
-      provenance,
-      mounts: source.mounts,
-      policy: source.spec.policy,
-      context: source.spec.metadata ?? {},
-      spec,
-    }
-    source.recordArtifactsCollected(bundleId, createdAt, spec)
     const diagnostics = buildArtifactDiagnostics(source.observations)
     diagnostics.diagnostics.push(...mountDiffDiagnostics)
     diagnostics.summary.total = diagnostics.diagnostics.length
@@ -234,28 +175,13 @@ export class ArtifactBundleBuilder {
     diagnostics.summary.info = diagnostics.diagnostics.filter((diagnostic) => diagnostic.severity === "info").length
     diagnostics.status = diagnostics.summary.total > 0 ? "reported" : "clean"
     const testResults = buildTestResults()
-    const review = buildArtifactReview({
-      artifactId: bundleId,
-      createdAt,
-      provenance,
-      changedFiles,
-      patch: redactedPatch,
-      contentDigest,
-      runtimeCreatedAt: source.runtimeCreatedAt,
-      mounts: source.mounts,
-      preview,
-      previewEvidencePath: "files/preview-evidence.json",
-      previewSessionEvidencePath: previewSessionEvidenceRelativePath,
-      browser,
-      diagnosticsPath: "files/diagnostics.json",
-    })
     const workspacePatch = buildWorkspacePatchArtifact({
       createdAt,
       provenance,
       mounts: source.mounts,
       mountDiffs,
       changedFiles,
-      contentDigest,
+      contentDigest: patchContentDigest,
     })
     const artifactFiles = {
       workspacePatch: relative(source.artifactRoot, workspacePatchPath),
@@ -276,7 +202,6 @@ export class ArtifactBundleBuilder {
       ...(source.pluginCheckArtifactPaths().length > 0 ? { pluginChecks: source.pluginCheckArtifactPaths() } : {}),
       ...(source.themeCheckArtifactPaths().length > 0 ? { themeChecks: source.themeCheckArtifactPaths() } : {}),
     }
-    metadata.artifacts = artifactFiles
     const partialBlueprintAfter = buildBlueprintAfter({
       environment: source.spec.environment,
       capturedMounts,
@@ -342,6 +267,88 @@ export class ArtifactBundleBuilder {
       ),
     ]
 
+    const normalizedManifestFiles = manifestFiles.map((file) => ({
+      ...file,
+      path: artifactManifestRelativePath(source.artifactRoot, file.path),
+    }))
+    const contentDigest = calculateArtifactManifestFileListDigest(normalizedManifestFiles)
+    const bundleId = `artifact-bundle-sha256-${contentDigest}`
+    const contentDigestMetadata = {
+      algorithm: "sha256" as const,
+      inputs: ["manifest.files"],
+      value: contentDigest,
+    }
+    const artifactBundleRef: RuntimeEpisodeTraceRef = {
+      kind: "artifact-bundle",
+      id: bundleId,
+      digest: { algorithm: "sha256", value: contentDigest },
+      path: "manifest.json",
+    }
+    const previewEvidence = buildPreviewEvidence({
+      createdAt,
+      runtime,
+      preview,
+      durablePreview: durablePreview?.preview,
+      events: source.events,
+      packages: provenance.packages,
+      artifactBundleRef,
+    })
+    const previewSessionEvidence = buildPreviewSessionEvidence({
+      artifactId: bundleId,
+      createdAt,
+      runtime,
+      preview,
+      durablePreview: durablePreview?.preview,
+      contentDigest,
+      packages: provenance.packages,
+      browser,
+      paths: {
+        manifest: relative(source.artifactRoot, manifestPath),
+        review: relative(source.artifactRoot, reviewPath),
+        runtimeEvents: relative(source.artifactRoot, eventsPath),
+        runtimeLog: relative(source.artifactRoot, runtimeLogPath),
+        runtimeReferenceManifest: relative(source.artifactRoot, runtimeReferenceManifestPath),
+        runtimeReplayReferenceIndex: relative(source.artifactRoot, runtimeReplayReferenceIndexPath),
+        durablePreview: durablePreview?.preview.manifest.path,
+        browserSummary: browser ? browser.probes.find((probe) => probe.summaryFile)?.summaryFile ?? "files/browser/summary.json" : undefined,
+      },
+    })
+    const previewSessionEvidenceJson = `${JSON.stringify(previewSessionEvidence, null, 2)}\n`
+    const previewSessionEvidenceRef: ArtifactEvidenceRef = {
+      path: previewSessionEvidenceRelativePath,
+      kind: "preview-session-evidence",
+      contentType: "application/json",
+      sha256: artifactFileDigest(previewSessionEvidenceJson),
+    }
+    const metadata: Record<string, unknown> = {
+      id: bundleId,
+      contentDigest: contentDigestMetadata,
+      createdAt,
+      runtime,
+      provenance,
+      mounts: source.mounts,
+      policy: source.spec.policy,
+      context: source.spec.metadata ?? {},
+      spec,
+      artifacts: artifactFiles,
+    }
+    source.recordArtifactsCollected(bundleId, createdAt, spec)
+    const review = buildArtifactReview({
+      artifactId: bundleId,
+      createdAt,
+      provenance,
+      changedFiles,
+      patch: redactedPatch,
+      contentDigest,
+      runtimeCreatedAt: source.runtimeCreatedAt,
+      mounts: source.mounts,
+      preview,
+      previewEvidencePath: "files/preview-evidence.json",
+      previewSessionEvidencePath: previewSessionEvidenceRelativePath,
+      browser,
+      diagnosticsPath: "files/diagnostics.json",
+    })
+
     metadata.preview = preview
     if (durablePreview) {
       metadata.durablePreview = durablePreview.preview
@@ -384,15 +391,12 @@ export class ArtifactBundleBuilder {
       id: bundleId,
       contentDigest: {
         algorithm: "sha256",
-        inputs: [CHANGED_FILES_ARTIFACT_PATH, "files/patch.diff"],
+        inputs: ["manifest.files"],
         value: contentDigest,
       },
       createdAt,
       runtime,
-      files: manifestFiles.map((file) => ({
-        ...file,
-        path: artifactManifestRelativePath(source.artifactRoot, file.path),
-      })),
+      files: normalizedManifestFiles,
     }
     await refreshArtifactManifestFileSha256s(source.artifactRoot, manifest)
     const runtimeReferenceIndex = await buildRuntimeReferenceIndex({

--- a/tests/evidence-bundle-digest-and-recipe-artifact.test.ts
+++ b/tests/evidence-bundle-digest-and-recipe-artifact.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { artifactManifestFile, calculateArtifactManifestFileListDigest, refreshArtifactManifestFileSha256s, type ArtifactManifest } from "../packages/runtime-core/src/index.js"
+import { verifyArtifactBundle } from "../packages/runtime-core/src/artifact-bundle-verifier.js"
+import { buildFailureEvidence } from "../packages/cli/src/commands/agent-task-run.js"
+
+const patchOnlyFiles = [
+  artifactManifestFile("manifest.json", "manifest", "application/json"),
+  artifactManifestFile("files/changed-files.json", "changed-files", "application/json"),
+  artifactManifestFile("files/patch.diff", "patch", "text/x-diff"),
+]
+const evidenceFiles = [
+  ...patchOnlyFiles,
+  artifactManifestFile("files/browser/summary.json", "browser-summary", "application/json"),
+]
+
+assert.equal(calculateArtifactManifestFileListDigest(patchOnlyFiles), calculateArtifactManifestFileListDigest([...patchOnlyFiles]))
+assert.notEqual(calculateArtifactManifestFileListDigest(patchOnlyFiles), calculateArtifactManifestFileListDigest(evidenceFiles))
+
+const artifactRoot = await mkdtemp(join(tmpdir(), "wp-codebox-evidence-bundle-digest-"))
+await mkdir(join(artifactRoot, "files"), { recursive: true })
+await writeFile(join(artifactRoot, "files", "changed-files.json"), "{}\n")
+await writeFile(join(artifactRoot, "files", "patch.diff"), "")
+await writeFile(join(artifactRoot, "files", "browser-summary.json"), "{}\n")
+
+const manifestFiles = [
+  artifactManifestFile("manifest.json", "manifest", "application/json"),
+  artifactManifestFile("files/changed-files.json", "changed-files", "application/json"),
+  artifactManifestFile("files/patch.diff", "patch", "text/x-diff"),
+  artifactManifestFile("files/browser-summary.json", "browser-summary", "application/json"),
+]
+const manifest: ArtifactManifest = {
+  id: `artifact-bundle-sha256-${calculateArtifactManifestFileListDigest(manifestFiles)}`,
+  contentDigest: {
+    algorithm: "sha256",
+    inputs: ["manifest.files"],
+    value: calculateArtifactManifestFileListDigest(manifestFiles),
+  },
+  createdAt: "2026-01-01T00:00:00.000Z",
+  runtime: {
+    id: "runtime-1",
+    kind: "wordpress-playground",
+    backend: "playground-cli",
+    status: "ready",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    environment: { kind: "wordpress", version: "latest" },
+  },
+  files: manifestFiles,
+}
+await refreshArtifactManifestFileSha256s(artifactRoot, manifest)
+await writeFile(join(artifactRoot, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+assert.equal((await verifyArtifactBundle(artifactRoot)).valid, true)
+
+const failureEvidence = buildFailureEvidence({
+  input: {},
+  task: "Reproduce a failure",
+  wpVersion: "latest",
+  artifacts: "/tmp/wp-codebox-artifacts",
+  recipePath: "/var/folders/deleted/wp-codebox-agent-task-recipe-123/recipe.json",
+  generatedRecipeArtifact: {
+    path: "files/generated-recipe/recipe.json",
+    absolutePath: "/tmp/wp-codebox-artifacts/files/generated-recipe/recipe.json",
+    kind: "generated-recipe",
+    contentType: "application/json",
+  },
+  run: { success: false, error: { message: "failed" } },
+})
+
+assert.deepEqual(failureEvidence.recipe_run, {
+  recipe_path: "files/generated-recipe/recipe.json",
+  recipe_artifact: {
+    path: "files/generated-recipe/recipe.json",
+    kind: "generated-recipe",
+    content_type: "application/json",
+  },
+})
+
+console.log("evidence bundle digest and recipe artifact passed")


### PR DESCRIPTION
## Summary
- derive artifact bundle identity from the finalized manifest artifact list instead of only patch/apply inputs
- keep workspace patch digest semantics tied to changed files and patch content
- persist generated agent-task recipes under artifact evidence and reference the artifact-relative recipe path in failure evidence

## Tests
- npm run test:evidence-bundle-digest-and-recipe-artifact
- npm run test:artifact-path-primitives
- npx tsx scripts/artifact-bundle-verifier-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested deterministic evidence bundle identity and recipe evidence persistence