### PR TITLE
Decouple WordPress browser diagnostics from generic probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:bench-command-step-behavior": "tsx tests/bench-command-step-behavior.test.ts",
     "test:generic-primitives": "npm run test:artifact-path-primitives && npm run test:browser-callback-materialization-contracts && npm run test:source-package-compiler-primitives && npm run test:bench-command-step-behavior && npm run test:generic-ability-runtime-run",
     "test:browser-artifact-session": "tsx tests/browser-artifact-session.test.ts",
+    "test:browser-diagnostic-providers": "tsx tests/browser-diagnostic-providers.test.ts",
     "test:browser-provider-permissions": "tsx tests/browser-provider-permissions.test.ts",
     "test:browser-provider-bridge-inheritance": "tsx tests/browser-provider-bridge-inheritance.test.ts",
     "test:fixture-auth-storage-state": "tsx tests/fixture-auth-storage-state.test.ts",

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -1,5 +1,6 @@
 import { type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import type { BrowserArtifact } from "./browser-artifacts.js"
+import { browserWordPressDiagnosticProvider } from "./browser-wordpress-diagnostic-provider.js"
 import { BrowserCommandArtifactError, isBrowserCommandArtifactError } from "./browser-command-artifact-error.js"
 import { runBrowserProbeCommand, runSingleBrowserProbeCommand, type BrowserProbeRunPlan } from "./browser-probe-runner.js"
 import type { PlaygroundRunResponse } from "./playground-command-errors.js"
@@ -9,6 +10,7 @@ export { BrowserCommandArtifactError, isBrowserCommandArtifactError }
 export { runBrowserActionsCommand, runBrowserScenarioCommand, type BrowserActionsRunPlan } from "./browser-actions-runner.js"
 export { runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand } from "./editor-command-runners.js"
 export { runBrowserProbeCommand, runSingleBrowserProbeCommand, type BrowserProbeRunPlan } from "./browser-probe-runner.js"
+export { browserWordPressDiagnosticProvider } from "./browser-wordpress-diagnostic-provider.js"
 export { wordpressAdminAuthCookiePhpCode } from "./browser-probe-support.js"
 export { runVisualCompareCommand } from "./browser-visual-compare.js"
 
@@ -27,6 +29,7 @@ export async function runHtmlCaptureCommand(input: {
   return runBrowserProbeCommand({
     ...input,
     command: "wordpress.capture-html",
+    diagnosticProviders: [browserWordPressDiagnosticProvider()],
     spec: { ...input.spec, args },
   })
 }

--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -1,7 +1,7 @@
 import { BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js"
-import type { BrowserProbeArtifact, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport } from "./browser-artifacts.js"
+import type { BrowserArtifactFiles, BrowserProbeArtifact, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
@@ -11,7 +11,7 @@ import { BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT,
 import { argValue, commaListArg, durationArg, strictBooleanArg, viewportArg } from "./commands.js"
 import type { PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
-import { browserAuthRequest, browserProbeWaterfallArtifact, browserRedirectDiagnosticsArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, browserWordPressDiagnosticsArtifact, createBrowserProbeProgressTracker, fileSha256, installBrowserWordPressDiagnostics, installWordPressAdminAuthCookies, now, sha256, withBrowserProbeLiveness, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserProbeScriptCheckpoint, type BrowserStorageStateImport } from "./browser-probe-support.js"
+import { browserAuthRequest, browserProbeWaterfallArtifact, browserRedirectDiagnosticsArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, createBrowserProbeProgressTracker, fileSha256, installWordPressAdminAuthCookies, now, sha256, withBrowserProbeLiveness, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserProbeScriptCheckpoint, type BrowserStorageStateImport } from "./browser-probe-support.js"
 import { BrowserProbeSessionResultBuilder, browserProbeCaptureSelection } from "./browser-probe-session-result-builder.js"
 
 const BROWSER_PROBE_PROFILE_OVERRIDES = new Set(["browser", "device", "locale", "permissions", "throttle", "timezone", "user-agent", "viewport"])
@@ -34,6 +34,32 @@ export interface BrowserProbeRunPlan {
   wallTimeoutMs: number
   lifecycleSelectors: string[]
   assertions: ReturnType<typeof browserProbeAssertionsFromArgs>
+  diagnosticProviders?: BrowserProbeDiagnosticProvider[]
+}
+
+export interface BrowserProbeDiagnosticProvider {
+  id: string
+  setup(input: BrowserProbeDiagnosticSetupInput): Promise<unknown>
+  collect(input: BrowserProbeDiagnosticCollectInput): Promise<BrowserProbeCollectedDiagnostic | undefined>
+}
+
+export interface BrowserProbeDiagnosticSetupInput {
+  command: string
+  runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>
+  server: PlaygroundCliServer
+}
+
+export interface BrowserProbeDiagnosticCollectInput extends BrowserProbeDiagnosticSetupInput {
+  artifactPath: string
+  network: BrowserProbeNetworkRecord[]
+  setupResult: unknown
+}
+
+export interface BrowserProbeCollectedDiagnostic {
+  key: keyof BrowserArtifactFiles
+  fileName: string
+  artifact: unknown
+  summary: unknown
 }
 
 interface BrowserProbeThrottleProfileDefinition {
@@ -70,6 +96,7 @@ export async function runBrowserProbeCommand({
   server,
   spec,
   onProgress,
+  diagnosticProviders,
 }: {
   abortSignal?: AbortSignal
   artifactRoot: string
@@ -80,9 +107,10 @@ export async function runBrowserProbeCommand({
   server: PlaygroundCliServer
   spec: ExecutionSpec
   onProgress?: (event: BrowserCommandProgressEvent) => void
+  diagnosticProviders?: BrowserProbeDiagnosticProvider[]
 }): Promise<{ artifact: BrowserProbeArtifact; artifacts?: BrowserProbeArtifact[]; output: string }> {
   if (plan) {
-    return runSingleBrowserProbeCommand({ abortSignal, artifactRoot, command, plan, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser", onProgress })
+    return runSingleBrowserProbeCommand({ abortSignal, artifactRoot, command, plan, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser", onProgress, diagnosticProviders })
   }
 
   const profileIds = browserProbeProfileIds(spec.args ?? [])
@@ -101,9 +129,10 @@ export async function runBrowserProbeCommand({
         browserFilesDirectory: "files/browser",
         profileId: profile.id,
         onProgress,
+        diagnosticProviders,
       })
     }
-    return runSingleBrowserProbeCommand({ abortSignal, artifactRoot, command, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser", onProgress })
+    return runSingleBrowserProbeCommand({ abortSignal, artifactRoot, command, runtimeSpec, runPlaygroundCommand, server, spec, browserFilesDirectory: "files/browser", onProgress, diagnosticProviders })
   }
 
   const profiles = profileIds.map((profileId) => browserProbeProfile(profileId))
@@ -124,6 +153,7 @@ export async function runBrowserProbeCommand({
       browserFilesDirectory: `files/browser/${profile.id}`,
       profileId: profile.id,
       onProgress,
+      diagnosticProviders,
     })
     artifacts.push(result.artifact)
     outputs.push(JSON.parse(result.output))
@@ -157,6 +187,7 @@ export async function runSingleBrowserProbeCommand({
   browserFilesDirectory,
   profileId,
   onProgress,
+  diagnosticProviders,
 }: {
   abortSignal?: AbortSignal
   artifactRoot: string
@@ -169,6 +200,7 @@ export async function runSingleBrowserProbeCommand({
   browserFilesDirectory: string
   profileId?: string
   onProgress?: (event: BrowserCommandProgressEvent) => void
+  diagnosticProviders?: BrowserProbeDiagnosticProvider[]
 }): Promise<{ artifact: BrowserProbeArtifact; output: string }> {
   const args = spec.args ?? []
   const runPlan = plan ?? await browserProbeRunPlanFromArgs(args, profileId, artifactRoot)
@@ -202,6 +234,7 @@ export async function runSingleBrowserProbeCommand({
   const livenessPolicy = browserCommandLivenessPolicy({ wallTimeoutMs, idleTimeoutMs: stallTimeoutMs })
   const lifecycleSelectors = runPlan.lifecycleSelectors
   const assertions = runPlan.assertions
+  const activeDiagnosticProviders = runPlan.diagnosticProviders ?? diagnosticProviders ?? []
   const captureSelection = browserProbeCaptureSelection(capture, assertions)
   const prePageScriptMetadata = prePageScript ? browserProbeScriptMetadata(prePageScript) : undefined
   const topology = browserPreviewTopology(args, runtimeSpec, server.serverUrl)
@@ -247,7 +280,7 @@ export async function runSingleBrowserProbeCommand({
   let pendingError: Error | undefined
   let artifact: BrowserProbeArtifact | undefined
   let output: string | undefined
-  let wordpressDiagnosticsReady = false
+  const diagnosticSetupResults = new Map<string, unknown>()
   const abortHandler = () => {
     pendingError = pendingError ?? new Error("Browser command aborted during runtime cleanup")
     void page?.close().catch(() => undefined)
@@ -312,7 +345,9 @@ export async function runSingleBrowserProbeCommand({
     if (prePageScript) {
       await page.addInitScript(prePageScript)
     }
-    wordpressDiagnosticsReady = await installBrowserWordPressDiagnostics(runPlaygroundCommand, server)
+    for (const provider of activeDiagnosticProviders) {
+      diagnosticSetupResults.set(provider.id, await provider.setup({ command, runPlaygroundCommand, server }))
+    }
     viewport = await browserProbeViewport(page)
     contextDetails = await browserProbeContextDetails(page, requestedContext, viewport)
     capabilityDiagnostics = await browserProbeCapabilityDiagnostics(page, viewport)
@@ -478,15 +513,22 @@ export async function runSingleBrowserProbeCommand({
     if (redirectDiagnostics) {
       await artifactSession.writeJson("redirectDiagnostics", "redirect-diagnostics.json", redirectDiagnostics)
     }
-    const wordpressDiagnostics = await browserWordPressDiagnosticsArtifact({
-      artifactPath: `${browserFilesDirectory}/wordpress-diagnostics.json`,
-      network,
-      ready: wordpressDiagnosticsReady,
-      server,
-    })
-    if (wordpressDiagnostics) {
-      await artifactSession.writeJson("wordpressDiagnostics", "wordpress-diagnostics.json", wordpressDiagnostics)
+    const diagnostics: BrowserProbeCollectedDiagnostic[] = []
+    for (const provider of activeDiagnosticProviders) {
+      const diagnostic = await provider.collect({
+        artifactPath: `${browserFilesDirectory}/${provider.id}-diagnostics.json`,
+        command,
+        network,
+        runPlaygroundCommand,
+        server,
+        setupResult: diagnosticSetupResults.get(provider.id),
+      })
+      if (diagnostic) {
+        diagnostics.push(diagnostic)
+        await artifactSession.writeJson(diagnostic.key, diagnostic.fileName, diagnostic.artifact)
+      }
     }
+    const wordpressDiagnostics = diagnostics.find((diagnostic): diagnostic is BrowserProbeCollectedDiagnostic & { key: "wordpressDiagnostics"; summary: BrowserWordPressDiagnosticsSummary } => diagnostic.key === "wordpressDiagnostics")
     const result = new BrowserProbeSessionResultBuilder().compose({
       assertions: assertionResults,
       authSummary,

--- a/packages/runtime-playground/src/browser-wordpress-diagnostic-provider.ts
+++ b/packages/runtime-playground/src/browser-wordpress-diagnostic-provider.ts
@@ -1,0 +1,27 @@
+import { browserWordPressDiagnosticsArtifact, installBrowserWordPressDiagnostics } from "./browser-probe-support.js"
+import type { BrowserProbeDiagnosticProvider } from "./browser-probe-runner.js"
+
+export function browserWordPressDiagnosticProvider(): BrowserProbeDiagnosticProvider {
+  return {
+    id: "wordpress",
+    setup: ({ runPlaygroundCommand, server }) => installBrowserWordPressDiagnostics(runPlaygroundCommand, server),
+    async collect({ artifactPath, network, server, setupResult }) {
+      const artifact = await browserWordPressDiagnosticsArtifact({
+        artifactPath,
+        network,
+        ready: setupResult === true,
+        server,
+      })
+      if (!artifact) {
+        return undefined
+      }
+
+      return {
+        key: "wordpressDiagnostics",
+        fileName: "wordpress-diagnostics.json",
+        artifact,
+        summary: artifact.summary,
+      }
+    },
+  }
+}

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -7,7 +7,7 @@ import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
 import { normalizeBrowserStorageStatePayload, wordpressFixtureUserStorageStatePhpCode, type WordPressFixtureUserSpec } from "./browser-auth-storage-state.js"
-import { isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand, wordpressAdminAuthCookiePhpCode } from "./browser-command-runners.js"
+import { browserWordPressDiagnosticProvider, isBrowserCommandArtifactError, runBrowserActionsCommand, runBrowserProbeCommand, runBrowserScenarioCommand, runEditorActionsCommand, runEditorCanvasProbeCommand, runEditorOpenCommand, runHtmlCaptureCommand, runVisualCompareCommand, wordpressAdminAuthCookiePhpCode } from "./browser-command-runners.js"
 import type { PluginCheckArtifact, ThemeCheckArtifact } from "./check-artifacts.js"
 import { executePlaygroundCommand } from "./command-router.js"
 import { firstCommandWordPressAdminAuthRequirement } from "./command-auth-requirements.js"
@@ -618,7 +618,7 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     let result: Awaited<ReturnType<typeof runBrowserProbeCommand>>
     try {
-      result = await runBrowserProbeCommand({ abortSignal: this.activeExecutionSignal, artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec, onProgress: (event) => this.recordEvent("runtime.browser-command-progress", { ...event, specCommand: spec.command }) })
+      result = await runBrowserProbeCommand({ abortSignal: this.activeExecutionSignal, artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec, onProgress: (event) => this.recordEvent("runtime.browser-command-progress", { ...event, specCommand: spec.command }), diagnosticProviders: [browserWordPressDiagnosticProvider()] })
     } catch (error) {
       if (isBrowserCommandArtifactError(error)) {
         this.browserProbes.push(error.artifact)

--- a/tests/browser-diagnostic-providers.test.ts
+++ b/tests/browser-diagnostic-providers.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict"
+
+import { BrowserProbeSessionResultBuilder } from "../packages/runtime-playground/src/browser-probe-session-result-builder.js"
+import type { BrowserProbeSessionResultInput } from "../packages/runtime-playground/src/browser-probe-session-result-builder.js"
+import type { BrowserWordPressDiagnosticsSummary } from "../packages/runtime-playground/src/browser-artifacts.js"
+import { createBrowserProbeProgressTracker } from "../packages/runtime-playground/src/browser-probe-support.js"
+import { browserWordPressDiagnosticProvider } from "../packages/runtime-playground/src/browser-wordpress-diagnostic-provider.js"
+import type { PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+
+const baseInput = (): BrowserProbeSessionResultInput => ({
+  assertions: [],
+  browser: { name: "chromium", channel: "chromium", version: null },
+  browserFilesDirectory: "files/browser",
+  capture: new Set(["network"]),
+  captureSelection: { console: false, errors: false, network: true, metrics: false, consoleForAssertions: false, errorsForAssertions: false, networkForAssertions: false },
+  checkpoints: [],
+  command: "browser.probe",
+  consoleMessages: [],
+  durationMs: 0,
+  errors: [],
+  failFast: false,
+  finalUrl: "https://example.test/",
+  hashes: {},
+  lifecycleSelectors: [],
+  liveness: { wallTimeoutMs: 30_000, stallTimeoutMs: 0, networkSettleTimeoutMs: 500 },
+  network: [],
+  preview: { requestedMode: "local", effectiveMode: "local", localOrigin: "https://example.test", effectiveOrigin: "https://example.test", diagnostics: [] },
+  progress: createBrowserProbeProgressTracker("2026-01-01T00:00:00.000Z", 0),
+  requestedUrl: "https://example.test/",
+  startedAt: "2026-01-01T00:00:00.000Z",
+  startedAtMs: Date.now(),
+  throttleId: null,
+  topologyOrigins: {},
+  viewport: null,
+  waitFor: "domcontentloaded",
+})
+
+const genericResult = new BrowserProbeSessionResultBuilder().compose(baseInput())
+assert.equal(genericResult.artifact.files.wordpressDiagnostics, undefined)
+assert.equal(genericResult.artifact.summary.wordpressDiagnostics, undefined)
+assert.equal(genericResult.review.wordpressDiagnostics, undefined)
+assert.doesNotMatch(genericResult.output, /wordpressDiagnostics/)
+
+const wordpressSummary: BrowserWordPressDiagnosticsSummary = {
+  status: "captured",
+  artifact: "files/browser/wordpress-diagnostics.json",
+  document5xxResponses: 1,
+  diagnostics: 1,
+  fatalErrors: 1,
+  classifications: ["php-fatal"],
+}
+
+const wordpressResult = new BrowserProbeSessionResultBuilder().compose({
+  ...baseInput(),
+  command: "wordpress.browser-probe",
+  wordpressDiagnostics: { summary: wordpressSummary },
+})
+assert.equal(wordpressResult.artifact.files.wordpressDiagnostics, "files/browser/wordpress-diagnostics.json")
+assert.deepEqual(wordpressResult.artifact.summary.wordpressDiagnostics, wordpressSummary)
+assert.deepEqual(wordpressResult.review.wordpressDiagnostics, wordpressSummary)
+assert.match(wordpressResult.output, /wordpressDiagnostics/)
+
+const server = {
+  serverUrl: "https://example.test",
+  playground: {
+    readFileAsText: async () => `${JSON.stringify({
+      schema: "wp-codebox/browser-wordpress-diagnostic-record/v1",
+      classification: "php-fatal",
+      message: "Fatal error",
+      capturedAt: "2026-01-01T00:00:00.000Z",
+    })}\n`,
+  },
+  async [Symbol.asyncDispose]() {},
+} satisfies PlaygroundCliServer
+const provider = browserWordPressDiagnosticProvider()
+const providerArtifact = await provider.collect({
+  artifactPath: "files/browser/wordpress-diagnostics.json",
+  command: "wordpress.browser-probe",
+  network: [{ type: "response", url: "https://example.test/", method: "GET", resourceType: "document", timestamp: "2026-01-01T00:00:00.000Z", status: 500, statusText: "Internal Server Error" }],
+  server,
+  setupResult: true,
+})
+assert.equal(providerArtifact?.key, "wordpressDiagnostics")
+assert.equal(providerArtifact?.fileName, "wordpress-diagnostics.json")
+assert.equal((providerArtifact?.summary as BrowserWordPressDiagnosticsSummary | undefined)?.status, "captured")
+
+console.log("browser diagnostic providers ok")


### PR DESCRIPTION
## Summary
- Add browser probe diagnostic provider hooks so the generic probe runs without WordPress diagnostics by default.
- Move WordPress diagnostic setup/collection behind an explicit WordPress provider.
- Opt the WordPress runtime browser probe and HTML capture entrypoints into the WordPress provider to preserve existing behavior.
- Add coverage for generic output without WordPress diagnostics and provider-enabled WordPress diagnostic output.

## Verification
- npm run test:browser-diagnostic-providers
- npm run test:browser-artifact-session
- npm run test:fixture-auth-storage-state
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and PR description for Chris to review.