### PR TITLE
Normalize canonical runtime failure envelopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "test:command-agent-run": "tsx tests/command-agent-run.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
+    "test:php-host-run-result-normalizer": "php scripts/php-host-run-result-normalizer-smoke.php",
     "test:php-json-codec": "tsx tests/php-json-codec.test.ts",
     "test:php-managed-host-command": "tsx tests/php-managed-host-command.test.ts",
     "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",

--- a/packages/runtime-core/src/command-agent-run.ts
+++ b/packages/runtime-core/src/command-agent-run.ts
@@ -48,6 +48,11 @@ export interface CommandAgentRunDiagnostics {
     stderrBytes: number
     parsedJson: boolean
   }
+  error?: {
+    code: string
+    message: string
+    failureClassification: "timeout" | "non_zero_exit" | "invalid_json" | "runtime" | (string & {})
+  }
 }
 
 export interface CommandAgentRunResult {
@@ -118,7 +123,11 @@ export function createCommandAgentRunResult(input: CreateCommandAgentRunResultIn
   const stdout = input.execution.stdout ?? ""
   const stderr = input.execution.stderr ?? ""
   const exitCode = input.execution.exitCode
-  const json = input.request.parseJson ? parseCommandAgentRunJson(stdout) : undefined
+  const jsonResult = input.request.parseJson ? parseCommandAgentRunJson(stdout) : undefined
+  const json = jsonResult?.json
+  const executionRecord = input.execution.result && typeof input.execution.result === "object" && !Array.isArray(input.execution.result) ? input.execution.result as unknown as Record<string, unknown> : {}
+  const timedOut = executionRecord.timedOut === true || executionRecord.timed_out === true
+  const failure = commandAgentRunFailure(exitCode, timedOut, jsonResult?.error)
   const authContext = input.request.auth?.context ?? {}
   const diagnostics: CommandAgentRunDiagnostics = {
     command: input.request.command,
@@ -134,12 +143,13 @@ export function createCommandAgentRunResult(input: CreateCommandAgentRunResultIn
       stderrBytes: Buffer.byteLength(stderr),
       parsedJson: json !== undefined,
     },
+    ...(failure ? { error: failure } : {}),
   }
 
   return {
     schema: COMMAND_AGENT_RUN_SCHEMA,
     command: "command-agent-run",
-    status: normalizeCommandEnvelopeStatus({ success: exitCode === 0, exitStatus: exitCode }),
+    status: normalizeCommandEnvelopeStatus({ success: !failure, exitStatus: exitCode, timeout: timedOut }),
     target: {
       command: input.request.command,
       args: input.request.args,
@@ -183,17 +193,30 @@ function normalizeCommandAgentRunSession(session: CommandAgentRunSession): Comma
   }
 }
 
-function parseCommandAgentRunJson(stdout: string): unknown {
+function parseCommandAgentRunJson(stdout: string): { json?: unknown; error?: string } {
   const trimmed = stdout.trim()
   if (!trimmed) {
-    throw new Error("command-agent-run parse-json=true requires JSON stdout")
+    return { error: "command-agent-run parse-json=true requires JSON stdout" }
   }
   try {
-    return JSON.parse(trimmed)
+    return { json: JSON.parse(trimmed) }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`command-agent-run stdout must be valid JSON: ${message}`)
+    return { error: `command-agent-run stdout must be valid JSON: ${message}` }
   }
+}
+
+function commandAgentRunFailure(exitCode: number, timedOut: boolean, invalidJsonMessage?: string): CommandAgentRunDiagnostics["error"] | undefined {
+  if (timedOut) {
+    return { code: "command-agent-run-timeout", message: "Target command timed out.", failureClassification: "timeout" }
+  }
+  if (exitCode !== 0) {
+    return { code: "command-agent-run-non-zero-exit", message: `Target command exited with status ${exitCode}.`, failureClassification: "non_zero_exit" }
+  }
+  if (invalidJsonMessage) {
+    return { code: "command-agent-run-invalid-json", message: invalidJsonMessage, failureClassification: "invalid_json" }
+  }
+  return undefined
 }
 
 function normalizeEnvNames(names: readonly string[]): string[] {

--- a/packages/runtime-core/src/materialization-contracts.ts
+++ b/packages/runtime-core/src/materialization-contracts.ts
@@ -168,7 +168,7 @@ export function materializationResultEnvelope(input: {
   }
 }
 
-export function normalizeMaterializationResultEnvelope(materialization: unknown, fallbackMessage = "Materialization failed."): CompletedMaterializationResultEnvelope {
+export function normalizeMaterializationResultEnvelope(materialization: unknown, fallbackMessage = "Materialization failed."): MaterializationResultEnvelope {
   const materializationRecord = asRecord(materialization)
   const raw = asRecord(materializationRecord?.response) ?? materializationRecord
   const report = raw?.schema === MATERIALIZATION_RESULT_SCHEMA || typeof raw?.schema === "string"
@@ -176,14 +176,14 @@ export function normalizeMaterializationResultEnvelope(materialization: unknown,
     : undefined
   const response = asRecord(report?.response) ?? raw
   if (response?.success !== true) {
-    return requireCompletedMaterializationResultEnvelope(materializationResultEnvelope({
+    return materializationResultEnvelope({
       task: stringValue(response?.task) || stringValue(report?.task),
       status: "failed",
       report: report ?? null,
       response,
       error: errorObject(response) ?? errorObject(report) ?? fallbackMessage,
       codeboxMaterialization: materialization,
-    }))
+    })
   }
 
   const canonicalResult = firstRecord(
@@ -195,7 +195,7 @@ export function normalizeMaterializationResultEnvelope(materialization: unknown,
     response.response,
   )
   if (canonicalResult?.success === false) {
-    return requireCompletedMaterializationResultEnvelope(materializationResultEnvelope({
+    return materializationResultEnvelope({
       task: stringValue(response.task) || stringValue(report?.task),
       status: "failed",
       result: canonicalResult,
@@ -203,7 +203,7 @@ export function normalizeMaterializationResultEnvelope(materialization: unknown,
       response,
       error: errorObject(canonicalResult) ?? fallbackMessage,
       codeboxMaterialization: materialization,
-    }))
+    })
   }
 
   return requireCompletedMaterializationResultEnvelope(materializationResultEnvelope({

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php
@@ -34,28 +34,25 @@ final class WP_Codebox_Host_Run_Result_Normalizer {
 		$exit_code = (int) ( $result['exit_code'] ?? 1 );
 		$output    = (string) ( $result['output'] ?? '' );
 		if ( true === ( $result['timed_out'] ?? false ) ) {
-			return new WP_Error(
+			return $this->failed_run_envelope(
+				$prepared,
+				$result,
+				$adapters,
 				'wp_codebox_run_timeout',
 				'WP Codebox agent sandbox run timed out.',
-				array(
-					'status'          => 500,
-					'exit_code'       => $exit_code,
-					'timeout_seconds' => (int) ( $result['timeout_seconds'] ?? 0 ),
-					'output'          => $adapters['bound_output']( $output ),
-				)
+				'timeout'
 			);
 		}
 
 		$decoded = $adapters['decode_json_output']( $output );
 		if ( is_wp_error( $decoded ) ) {
-			return new WP_Error(
+			return $this->failed_run_envelope(
+				$prepared,
+				$result,
+				$adapters,
 				'wp_codebox_json_invalid',
 				'WP Codebox did not return valid JSON: ' . $decoded->get_error_message(),
-				array(
-					'status'    => 500,
-					'exit_code' => $exit_code,
-					'output'    => $adapters['bound_output']( $output ),
-				)
+				'invalid_json'
 			);
 		}
 
@@ -63,15 +60,14 @@ final class WP_Codebox_Host_Run_Result_Normalizer {
 		$outcome                    = $strict_remediation_outcome ? $adapters['remediation_outcome']( $decoded, $exit_code, $output ) : null;
 
 		if ( 0 !== $exit_code && ! $strict_remediation_outcome ) {
-			return new WP_Error(
+			return $this->failed_run_envelope(
+				$prepared,
+				$result,
+				$adapters,
 				'wp_codebox_run_failed',
 				'WP Codebox agent sandbox run failed.',
-				array(
-					'status'    => 500,
-					'exit_code' => $exit_code,
-					'output'    => $adapters['bound_output']( $output ),
-					'run'       => $decoded,
-				)
+				'non_zero_exit',
+				$decoded
 			);
 		}
 
@@ -116,6 +112,72 @@ final class WP_Codebox_Host_Run_Result_Normalizer {
 		$response['diagnostics']   = $adapters['run_diagnostics']( $decoded, $exit_code, $outcome );
 		$response['evidence_refs'] = $adapters['evidence_refs']( $response['session'], $decoded );
 		$response['run_metadata']  = $adapters['run_metadata']( $session_id, $input, $wp_version, $decoded );
+
+		return $response;
+	}
+
+	/**
+	 * @param array<string,mixed> $prepared Prepared run.
+	 * @param array<string,mixed> $result Command result.
+	 * @param array<string,callable> $adapters Focused runner adapters for existing host contracts.
+	 * @param array<string,mixed>|null $run Decoded run payload when available.
+	 * @return array<string,mixed>
+	 */
+	private function failed_run_envelope( array $prepared, array $result, array $adapters, string $code, string $message, string $failure_classification, ?array $run = null ): array {
+		$input      = is_array( $prepared['input'] ?? null ) ? $prepared['input'] : array();
+		$task_input = is_array( $prepared['task_input'] ?? null ) ? $prepared['task_input'] : array();
+		$task       = (string) ( $prepared['task'] ?? '' );
+		$session_id = (string) ( $prepared['session_id'] ?? '' );
+		$paths      = is_array( $prepared['paths'] ?? null ) ? $prepared['paths'] : array();
+		$artifacts  = (string) ( $prepared['artifacts'] ?? '' );
+		$wp_version = (string) ( $prepared['wp_version'] ?? '' );
+		$exit_code  = (int) ( $result['exit_code'] ?? 1 );
+		$output     = (string) ( $result['output'] ?? '' );
+		$run        = is_array( $run ) ? $run : array();
+		$error      = array(
+			'code'                   => $code,
+			'message'                => $message,
+			'failure_classification' => $failure_classification,
+			'exit_code'              => $exit_code,
+			'output'                 => $adapters['bound_output']( $output ),
+		);
+
+		if ( true === ( $result['timed_out'] ?? false ) ) {
+			$error['timeout_seconds'] = (int) ( $result['timeout_seconds'] ?? 0 );
+		}
+
+		$response = array(
+			'success'             => false,
+			'schema'              => self::SCHEMA,
+			'session'             => $adapters['sandbox_session']( $session_id, 'failed', $input, $run, $artifacts ),
+			'task'                => $task,
+			'task_input'          => $task_input,
+			'wp'                  => $wp_version,
+			'paths'               => $paths,
+			'artifacts'           => $artifacts,
+			'exit_code'           => $exit_code,
+			'agent_result'        => is_array( $run['agentResult'] ?? null ) ? $run['agentResult'] : array(),
+			'agent_task_result'   => array(
+				'schema'                 => 'wp-codebox/agent-task-run-result/v1',
+				'success'                => false,
+				'status'                 => 'timeout' === $failure_classification ? 'timeout' : 'failed',
+				'summary'                => $message,
+				'failure_classification' => $failure_classification,
+			),
+			'completion_outcome'  => $adapters['completion_outcome']( $run ),
+			'run'                 => $run,
+			'error'               => $error,
+			'status'              => 'failed',
+			'statuses'            => array(
+				'command'    => WP_Codebox_Status_Taxonomy::command_envelope_status( array( 'status' => 'failed', 'success' => false, 'exit_status' => $exit_code, 'timeout' => true === ( $result['timed_out'] ?? false ) ) ),
+				'phase'      => WP_Codebox_Status_Taxonomy::phase_recipe_status( array( 'status' => 'failed', 'success' => false, 'exit_status' => $exit_code ) ),
+				'agent_task' => 'timeout' === $failure_classification ? 'timeout' : 'failed',
+			),
+			'agent_task_status'   => 'timeout' === $failure_classification ? 'timeout' : 'failed',
+			'diagnostics'         => $adapters['run_diagnostics']( $run, $exit_code, null ),
+			'run_metadata'        => $adapters['run_metadata']( $session_id, $input, $wp_version, $run ),
+		);
+		$response['evidence_refs'] = $adapters['evidence_refs']( $response['session'], $run );
 
 		return $response;
 	}

--- a/scripts/php-host-run-result-normalizer-smoke.php
+++ b/scripts/php-host-run-result-normalizer-smoke.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+require_once dirname( __DIR__ ) . '/packages/wordpress-plugin/src/class-wp-codebox-status-taxonomy.php';
+require_once dirname( __DIR__ ) . '/packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php';
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	private mixed $data;
+
+	public function __construct( string $code, string $message, mixed $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+$normalizer = new WP_Codebox_Host_Run_Result_Normalizer();
+$prepared   = array(
+	'input'       => array( 'goal' => 'Test task' ),
+	'task_input'  => array( 'goal' => 'Test task' ),
+	'task'        => 'Test task',
+	'session_id'  => 'session-1',
+	'paths'       => array(),
+	'artifacts'   => '/tmp/wp-codebox-artifacts',
+	'wp_version'  => 'latest',
+	'recipe_file' => '',
+);
+$adapters   = array(
+	'bound_output'               => static fn( string $output ): string => $output,
+	'decode_json_output'         => static fn( string $output ): array|WP_Error => json_decode( $output, true ) ?: new WP_Error( 'json_invalid', 'Invalid JSON' ),
+	'strict_remediation_outcome' => static fn( array $task_input ): bool => false,
+	'remediation_outcome'        => static fn( array $run, int $exit_code, string $output ): array => array( 'success' => 0 === $exit_code ),
+	'sandbox_session'            => static fn( string $session_id, string $status, array $input, array $run, string $artifacts ): array => array( 'id' => $session_id, 'status' => $status, 'artifacts' => $artifacts ),
+	'completion_outcome'         => static fn( array $run ): array => array(),
+	'run_diagnostics'            => static fn( array $run, int $exit_code, ?array $outcome ): array => array(),
+	'evidence_refs'              => static fn( array $session, array $run ): array => array(),
+	'run_metadata'               => static fn( string $session_id, array $input, string $wp_version, array $run ): array => array( 'session_id' => $session_id, 'wp' => $wp_version ),
+);
+
+$timeout = $normalizer->normalize( $prepared, array( 'exit_code' => 124, 'output' => '', 'timed_out' => true, 'timeout_seconds' => 1 ), $adapters );
+smoke_assert( is_array( $timeout ) && ! is_wp_error( $timeout ), 'timeout returns result envelope' );
+smoke_assert( false === $timeout['success'], 'timeout envelope is unsuccessful' );
+smoke_assert( 'timeout' === $timeout['agent_task_status'], 'timeout maps to agent task timeout' );
+smoke_assert( 'wp_codebox_run_timeout' === $timeout['error']['code'], 'timeout error code is preserved' );
+
+$invalid_json = $normalizer->normalize( $prepared, array( 'exit_code' => 0, 'output' => 'not-json' ), $adapters );
+smoke_assert( is_array( $invalid_json ) && ! is_wp_error( $invalid_json ), 'invalid JSON returns result envelope' );
+smoke_assert( 'wp_codebox_json_invalid' === $invalid_json['error']['code'], 'invalid JSON error code is preserved' );
+smoke_assert( 'invalid_json' === $invalid_json['error']['failure_classification'], 'invalid JSON classification is preserved' );
+
+$non_zero = $normalizer->normalize( $prepared, array( 'exit_code' => 2, 'output' => '{"agentResult":{}}' ), $adapters );
+smoke_assert( is_array( $non_zero ) && ! is_wp_error( $non_zero ), 'non-zero exit returns result envelope' );
+smoke_assert( 'wp_codebox_run_failed' === $non_zero['error']['code'], 'non-zero error code is preserved' );
+smoke_assert( 'non_zero_exit' === $non_zero['error']['failure_classification'], 'non-zero classification is preserved' );
+
+echo "host run result normalizer smoke passed\n";

--- a/tests/command-agent-run.test.ts
+++ b/tests/command-agent-run.test.ts
@@ -31,6 +31,31 @@ assert.equal(result.diagnostics.durationMs, 125)
 assert.deepEqual(result.artifactRefs, [{ kind: "command-log", id: "stdout", path: "files/command/stdout.txt" }])
 assert.equal(JSON.parse(commandAgentRunResultJson(result)).schema, COMMAND_AGENT_RUN_SCHEMA)
 
+const invalidJsonResult = createCommandAgentRunResult({
+  request,
+  execution: { ...fixture.execution, stdout: "not-json", exitCode: 0 } as ExecutionResult,
+  runtime: fixture.runtime as RuntimeInfo,
+})
+assert.equal(invalidJsonResult.status, "failed")
+assert.equal(invalidJsonResult.diagnostics.error?.code, "command-agent-run-invalid-json")
+assert.equal(invalidJsonResult.json, undefined)
+
+const nonZeroResult = createCommandAgentRunResult({
+  request: { ...request, parseJson: false },
+  execution: { ...fixture.execution, exitCode: 2, stderr: "failed" } as ExecutionResult,
+  runtime: fixture.runtime as RuntimeInfo,
+})
+assert.equal(nonZeroResult.status, "failed")
+assert.equal(nonZeroResult.diagnostics.error?.failureClassification, "non_zero_exit")
+
+const timeoutResult = createCommandAgentRunResult({
+  request: { ...request, parseJson: false },
+  execution: { ...fixture.execution, exitCode: 124, result: { timedOut: true } } as ExecutionResult,
+  runtime: fixture.runtime as RuntimeInfo,
+})
+assert.equal(timeoutResult.status, "timed_out")
+assert.equal(timeoutResult.diagnostics.error?.failureClassification, "timeout")
+
 assert.throws(() => parseCommandAgentRunRequest([]), /requires command/)
 assert.throws(() => parseCommandAgentRunRequest(["command=command-agent-run"]), /cannot target itself/)
 assert.throws(() => parseCommandAgentRunRequest(["command=example", "auth-required=true"]), /requires auth-context-json/)

--- a/tests/materialize-replay-package-command.test.ts
+++ b/tests/materialize-replay-package-command.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { normalizeMaterializationResultEnvelope, requireCompletedMaterializationResultEnvelope } from "../packages/runtime-core/src/index.js"
 import { runMaterializeReplayPackageCommand } from "../packages/cli/src/commands/replay-package.js"
 
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-materialization-result-"))
@@ -28,8 +29,55 @@ try {
   assert.equal(envelope.phases[0].status, "failed")
   assert.match(envelope.error.message, /not a wp-codebox\/wordpress-runtime-snapshot\/v1/)
   assert.equal(envelope.diagnostics[0].severity, "error")
+
+  const normalizedFailure = normalizeMaterializationResultEnvelope({ response: { success: false, task: "example", error: { message: "failed" } } })
+  assert.equal(normalizedFailure.status, "failed")
+  assert.throws(() => requireCompletedMaterializationResultEnvelope(normalizedFailure), /failed/)
+
+  const validSnapshotPath = join(root, "runtime-snapshot.json")
+  const outputDirectory = join(root, "valid-package")
+  await writeFile(validSnapshotPath, JSON.stringify(runtimeSnapshotFixture(), null, 2))
+
+  const valid = await captureStdout(() => runMaterializeReplayPackageCommand([
+    "--snapshot",
+    validSnapshotPath,
+    "--output",
+    outputDirectory,
+    "--json",
+  ]))
+  const successEnvelope = JSON.parse(valid.stdout)
+  const manifest = JSON.parse(await readFile(join(outputDirectory, "manifest.json"), "utf8"))
+
+  assert.equal(valid.code, 0)
+  assert.equal(successEnvelope.status, "completed")
+  assert.equal(manifest.files.length, 5)
+  for (const path of ["manifest.json", "blueprint.after.json", "blueprint.zip", "files/runtime-snapshot.json", "blueprint.after-notes.json"]) {
+    const file = manifest.files.find((entry: { path: string }) => entry.path === path)
+    assert.ok(file, `manifest includes ${path}`)
+    assert.match(file.sha256.value, /^[a-f0-9]{64}$/)
+    assert.notEqual(file.sha256.value, "0".repeat(64))
+  }
 } finally {
   await rm(root, { recursive: true, force: true })
+}
+
+function runtimeSnapshotFixture() {
+  return {
+    schema: "wp-codebox/wordpress-runtime-snapshot/v1",
+    version: 1,
+    capturedAt: "2026-01-01T00:00:00.000Z",
+    compatibility: {
+      backend: "wordpress-playground",
+      wordpressVersion: "latest",
+      phpVersion: "8.2",
+    },
+    database: {
+      format: "sqlite-sql",
+      tables: [],
+    },
+    files: [],
+    metadata: {},
+  }
 }
 
 async function captureStdout(callback: () => Promise<number>): Promise<{ code: number; stdout: string }> {


### PR DESCRIPTION
## Summary
- Return materialization failure envelopes from normalization while keeping requireCompletedMaterializationResultEnvelope as the explicit completion gate.
- Normalize command-agent-run invalid JSON, non-zero exit, and timeout-shaped results into terminal command envelopes.
- Normalize host sandbox timeout, non-zero, and invalid JSON failures into failed agent-task run envelopes instead of WP_Error.
- Assert replay package manifests include generated artifact entries with sha256 metadata.

## Verification
- npm run test:command-agent-run
- npm run test:materialize-replay-package-command
- npm run test:php-host-run-result-normalizer
- npm run test:agent-task-contracts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation, tests, and PR description; Chris remains responsible for review and validation.