### PR TITLE
Fix Agents API execution target registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "test:primitive-contract-parity": "tsx tests/primitive-contract-parity.test.ts",
     "test:php-primitive-contract-parity": "php scripts/php-primitive-contract-parity-smoke.php",
     "test:php-run-plan-contract": "php scripts/php-run-plan-contract-smoke.php",
+    "test:php-agents-api-execution-targets": "php scripts/php-agents-api-execution-targets-smoke.php",
     "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php
@@ -17,6 +17,7 @@ trait WP_Codebox_Abilities_Agents_API_Executors {
 		}
 
 		add_filter( 'agents_api_executor_targets', array( self::class, 'register_agents_api_executor_targets' ) );
+		add_filter( 'wp_agent_execution_targets', array( self::class, 'register_agents_api_executor_targets' ) );
 		add_filter( 'wp_agent_executor_targets', array( self::class, 'register_agents_api_executor_targets' ) );
 		add_filter( 'agents_api_execute_task', array( self::class, 'execute_agents_api_task' ), 10, 3 );
 		add_filter( 'wp_agent_task_handler', array( self::class, 'execute_agents_api_task' ), 10, 2 );

--- a/scripts/php-agents-api-execution-targets-smoke.php
+++ b/scripts/php-agents-api-execution-targets-smoke.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['wp_codebox_test_filters'] = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $priority, $accepted_args );
+	$GLOBALS['wp_codebox_test_filters'][ $hook ][] = $callback;
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+
+	return $value;
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
+
+function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $label . " failed.\nExpected: " . json_encode( $expected, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\nActual: " . json_encode( $actual, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n" );
+		exit( 1 );
+	}
+}
+
+$reflection = new ReflectionClass( WP_Codebox_Abilities::class );
+$abilities  = $reflection->newInstanceWithoutConstructor();
+$method     = $reflection->getMethod( 'register_agents_api_executor_adapters' );
+$method->invoke( $abilities );
+
+$targets = apply_filters( 'wp_agent_execution_targets', array() );
+
+assert_same_contract( true, isset( $targets['wp-codebox/browser-playground'] ), 'browser target registered on canonical Agents API hook' );
+assert_same_contract( true, isset( $targets['wp-codebox/host-playground'] ), 'host target registered on canonical Agents API hook' );
+assert_same_contract( 'agents-api/executor-target/v1', $targets['wp-codebox/browser-playground']['schema'] ?? null, 'browser target schema' );
+assert_same_contract( 'agents-api/task-input/v1', $targets['wp-codebox/browser-playground']['input_schema']['$id'] ?? null, 'browser target input schema id' );
+assert_same_contract( 'wp-codebox', $targets['wp-codebox/host-playground']['provider'] ?? null, 'host target provider' );
+
+$legacy_targets = apply_filters( 'wp_agent_executor_targets', array() );
+assert_same_contract( true, isset( $legacy_targets['wp-codebox/browser-playground'] ), 'browser target registered on legacy Codebox hook' );
+
+fwrite( STDOUT, "PHP Agents API execution targets smoke passed\n" );

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -134,6 +134,7 @@ export const smokeGroups = {
       tsxSmoke("agent-sandbox-incomplete-scope-smoke"),
       tsxSmoke("recipe-run-summary-smoke"),
       tsxSmoke("fanout-contract-smoke"),
+      phpSmoke("php-agents-api-execution-targets-smoke"),
       phpSmoke("php-run-plan-contract-smoke"),
       tsxSmoke("host-delegation-contract-smoke"),
       tsxSmoke("codex-agent-recipe-smoke"),


### PR DESCRIPTION
## Summary
- Register WP Codebox executor targets on the canonical Agents API `wp_agent_execution_targets` filter.
- Keep existing Codebox/legacy target filters registered for compatibility.
- Add a PHP smoke test proving Codebox targets are discoverable through the canonical Agents API execution target path and include it in `npm run check`.

## Testing
- `npm run test:php-agents-api-execution-targets`
- `npm run build`
- `npm run check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** aligned WP Codebox executor target registration with Agents API canonical contract.