### PR TITLE
Add addressable run cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,9 +420,12 @@ WP Codebox boots Playground lazily on the first command, captures artifacts afte
 
 Recipe runs also write a registry entry under the run registry directory
 (`artifacts/runs` by default, or `--run-registry <dir>`). Poll it with
-`wp-codebox runs status --registry <dir> --run-id <id> --json`. The returned
-record keeps the existing flat `status` field and adds `lifecycle`, a concise
-machine contract for orchestrators:
+`wp-codebox runs status --registry <dir> --run-id <id> --json`, inspect
+artifacts with `wp-codebox runs artifacts --registry <dir> --run-id <id>
+--json`, and request cancellation with `wp-codebox runs cancel --registry <dir>
+--run-id <id> --reason <text> --json`. The returned record keeps the existing
+flat `status` field and adds `lifecycle`, a concise machine contract for
+orchestrators:
 
 ```json
 {
@@ -432,6 +435,7 @@ machine contract for orchestrators:
     "phase": "terminal",
     "terminal": true,
     "cancellable": false,
+    "cancelRequested": false,
     "successful": true,
     "failed": false,
     "cancelled": false,
@@ -447,6 +451,9 @@ machine contract for orchestrators:
 Orchestrators should use `lifecycle.terminal`, `lifecycle.outcome`, and
 `lifecycle.cleanup.status` instead of scraping human logs. Timeout and signal
 interruptions settle as `timed_out` and `cancelled` outcomes respectively.
+Cancellation requests are idempotent: repeated `runs cancel` calls preserve the
+first `lifecycle.cancellation.requestedAt`/`reason`, and active recipe runs
+observe the request through the registry before settling as `cancelled`.
 
 ## Runtime Evidence
 

--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -9,7 +9,7 @@ import { runRecipeRunCommand, runRecipeValidateCommand } from "./commands/recipe
 import { runMaterializeReplayPackageCommand } from "./commands/replay-package.js"
 import { runMcpRenderClientConfigsCommand } from "./commands/mcp.js"
 import { runBootCommand, runRunCommand, runValidateBlueprintCommand } from "./commands/runtime.js"
-import { runRunsArtifactsCommand, runRunsStatusCommand } from "./commands/runs.js"
+import { runRunsArtifactsCommand, runRunsCancelCommand, runRunsStatusCommand } from "./commands/runs.js"
 import { runTargetProvisionCommand } from "./commands/target.js"
 import { runWorkspacePolicyCheckCommand } from "./commands/workspace-policy.js"
 import { printHelp } from "./output.js"
@@ -41,6 +41,7 @@ export async function runCli(args: string[]): Promise<number> {
     benchCompare: runBenchCompareCommand,
     runsStatus: runRunsStatusCommand,
     runsArtifacts: runRunsArtifactsCommand,
+    runsCancel: runRunsCancelCommand,
     targetProvision: runTargetProvisionCommand,
     mcpRenderClientConfigs: runMcpRenderClientConfigsCommand,
     commands: runCommandsCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -37,6 +37,7 @@ const cliCommandRoutes = {
   runs: {
     status: "runsStatus",
     artifacts: "runsArtifacts",
+    cancel: "runsCancel",
   },
   target: {
     provision: "targetProvision",

--- a/packages/cli/src/commands/recipe-run-interruption.ts
+++ b/packages/cli/src/commands/recipe-run-interruption.ts
@@ -118,6 +118,9 @@ export function createRecipeInterruptionController(): RecipeInterruptionControll
         rejectInterrupted = undefined
       }
     },
+    requestCancellation() {
+      interrupt("SIGTERM", "run-cancellation-request")
+    },
     throwIfInterrupted() {
       if (metadata) {
         throw new RecipeInterruptedError(metadata.signal, metadata.reason, metadata.receivedAt)
@@ -184,6 +187,9 @@ function recipeInterruptionMessage(metadata: Pick<RecipeInterruptionMetadata, "s
   }
   if (metadata.reason === "stdio-closed") {
     return "Recipe run interrupted after stdio closed"
+  }
+  if (metadata.reason === "run-cancellation-request") {
+    return "Recipe run interrupted by cancellation request"
   }
   return `Recipe run interrupted by ${metadata.signal}`
 }

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -262,7 +262,7 @@ export interface RecipeRunDeclaredArtifact {
 }
 
 export type RecipeInterruptionSignal = "SIGINT" | "SIGTERM" | "SIGHUP"
-export type RecipeInterruptionReason = "signal" | "parent-disconnect" | "stdio-closed"
+export type RecipeInterruptionReason = "signal" | "parent-disconnect" | "stdio-closed" | "run-cancellation-request"
 
 export interface RecipeInterruptionMetadata {
   signal: RecipeInterruptionSignal
@@ -276,6 +276,7 @@ export interface RecipeInterruptionController {
   install(): void
   dispose(): void
   interruptible<T>(promise: Promise<T>): Promise<T>
+  requestCancellation(): void
   throwIfInterrupted(): void
   propagateIfInterrupted(): void
   clear(): void

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, resolveSecretEnvNames, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, resolveSecretEnvNames, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
@@ -130,6 +130,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   const phaseExecutor = new RecipeRunPhaseExecutor({ context, timeoutMs: options.timeoutMs, interruption, destroyActiveRuntime })
   const phaseTracker = phaseExecutor.tracker
   const awaitRecipe = <T>(operation: string, promiseOrFactory: Promise<T> | (() => Promise<T>), timeoutMs?: number): Promise<T> => phaseExecutor.operation(operation, promiseOrFactory, timeoutMs)
+  const cancellationWatcher = interruption ? watchRunCancellationRequests(runRegistry, runRecord.runId, interruption) : undefined
 
   try {
     const preparedRuntimeSetup = await prepareRecipeRuntimeSetup(recipe, recipeDirectory, plan.runtime.backend)
@@ -448,6 +449,40 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         diagnostics: recipeRuntimeDiagnostics(recipe, executions, error),
       },
     })
+  } finally {
+    cancellationWatcher?.dispose()
+  }
+}
+
+function watchRunCancellationRequests(runRegistry: RuntimeRunRegistry, runId: string, interruption: RecipeInterruptionController): { dispose(): void } {
+  let disposed = false
+  let checking = false
+  const check = async (): Promise<void> => {
+    if (disposed || checking || interruption.metadata) {
+      return
+    }
+    checking = true
+    try {
+      const record = await runRegistry.read(runId)
+      if (record.lifecycle.cancelRequested && !record.lifecycle.terminal) {
+        interruption.requestCancellation()
+      }
+    } catch {
+      // Cancellation polling must not replace the primary recipe-run failure.
+    } finally {
+      checking = false
+    }
+  }
+  const timer = setInterval(() => {
+    void check()
+  }, 1_000)
+  timer.unref()
+  void check()
+  return {
+    dispose() {
+      disposed = true
+      clearInterval(timer)
+    },
   }
 }
 

--- a/packages/cli/src/commands/runs.ts
+++ b/packages/cli/src/commands/runs.ts
@@ -6,6 +6,10 @@ interface RunLookupOptions {
   json: boolean
 }
 
+interface RunCancelOptions extends RunLookupOptions {
+  reason?: string
+}
+
 export async function runRunsStatusCommand(args: string[]): Promise<number> {
   const options = parseRunLookupOptions(args)
   const record = await new RuntimeRunRegistry(options.registryDirectory).read(options.runId)
@@ -37,6 +41,22 @@ export async function runRunsArtifactsCommand(args: string[]): Promise<number> {
   }
 
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+  return 0
+}
+
+export async function runRunsCancelCommand(args: string[]): Promise<number> {
+  const options = parseRunCancelOptions(args)
+  const result = await new RuntimeRunRegistry(options.registryDirectory).requestCancellation(options.runId, { reason: options.reason })
+  if (!options.json) {
+    console.log(`WP Codebox run cancellation: ${result.runId}`)
+    console.log(`Status: ${result.status}`)
+    console.log(`Cancellation requested: ${result.cancellationRequested ? "yes" : "no"}`)
+    console.log(`Already requested: ${result.alreadyRequested ? "yes" : "no"}`)
+    console.log(`Terminal: ${result.terminal ? "yes" : "no"}`)
+    return 0
+  }
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
   return 0
 }
 
@@ -80,6 +100,63 @@ function parseRunLookupOptions(args: string[]): RunLookupOptions {
   }
 
   return options as RunLookupOptions
+}
+
+function parseRunCancelOptions(args: string[]): RunCancelOptions {
+  const options = parseRunLookupOptionsWithExtra(args, (name, value, parsed) => {
+    if (name === "--reason") {
+      parsed.reason = value
+      return true
+    }
+
+    return false
+  })
+
+  return options as RunCancelOptions
+}
+
+function parseRunLookupOptionsWithExtra(args: string[], extra: (name: string, value: string, options: Partial<RunCancelOptions>) => boolean): Partial<RunCancelOptions> {
+  const options: Partial<RunCancelOptions> = { json: false }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+
+    switch (name) {
+      case "--registry":
+      case "--run-registry":
+        options.registryDirectory = value
+        break
+      case "--run-id":
+        options.runId = value
+        break
+      default:
+        if (!extra(name, value, options)) {
+          throw new Error(`Unknown option: ${name}`)
+        }
+    }
+  }
+
+  if (!options.registryDirectory) {
+    throw new Error("Missing required option: --registry")
+  }
+
+  if (!options.runId) {
+    throw new Error("Missing required option: --run-id")
+  }
+
+  return options
 }
 
 function printRunStatusHumanOutput(record: RuntimeRunRecord): void {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -311,6 +311,7 @@ export function printHelp(): void {
   wp-codebox artifacts bench-compare --baseline-bundle <dir> --candidate-bundle <dir> [--json]
   wp-codebox runs status --registry <dir> --run-id <id> [--json]
   wp-codebox runs artifacts --registry <dir> --run-id <id> [--json]
+  wp-codebox runs cancel --registry <dir> --run-id <id> [--reason <text>] [--json]
   wp-codebox target provision [--id <id>] [--kind <kind>] [--workspace-root <dir>] [--json]
   wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
   wp-codebox validate-blueprint --blueprint <json|file> [options]

--- a/packages/runtime-core/src/run-registry.ts
+++ b/packages/runtime-core/src/run-registry.ts
@@ -28,11 +28,18 @@ export interface RuntimeRunLifecycle {
   phase: RuntimeRunLifecyclePhase
   terminal: boolean
   cancellable: boolean
+  cancelRequested: boolean
+  cancellation?: RuntimeRunCancellationState
   successful: boolean
   failed: boolean
   cancelled: boolean
   outcome?: RuntimeRunLifecycleOutcome
   cleanup: RuntimeRunCleanupState
+}
+
+export interface RuntimeRunCancellationState {
+  requestedAt: string
+  reason?: string
 }
 
 export interface RuntimeRunArtifactRef {
@@ -106,6 +113,21 @@ export interface RuntimeRunRegistryUpdate {
   now?: Date
 }
 
+export interface RuntimeRunCancellationRequestOptions {
+  reason?: string
+  now?: Date
+}
+
+export interface RuntimeRunCancellationRequestResult {
+  schema: "wp-codebox/run-cancellation-request/v1"
+  runId: string
+  status: RuntimeRunStatus
+  cancellationRequested: boolean
+  alreadyRequested: boolean
+  terminal: boolean
+  record: RuntimeRunRecord
+}
+
 export interface RuntimeRunCleanupUpdate {
   status: RuntimeRunCleanupStatus
   error?: RuntimeRunRecord["error"]
@@ -161,10 +183,11 @@ export class RuntimeRunRegistry {
     const now = (update.now ?? new Date()).toISOString()
     const status = transitionRuntimeRunStatus(current.status, update.status)
     const cleanup = update.cleanup ? updateRuntimeRunCleanup(current.lifecycle?.cleanup, update.cleanup, now) : current.lifecycle?.cleanup ?? initialRuntimeRunCleanup()
+    const cancellation = current.lifecycle?.cancellation
     const next: RuntimeRunRecord = {
       ...current,
       status,
-      lifecycle: buildRuntimeRunLifecycle(status, cleanup),
+      lifecycle: buildRuntimeRunLifecycle(status, cleanup, cancellation),
       ...(update.runtime ? { runtime: update.runtime } : {}),
       ...(update.preview ? { preview: update.preview } : {}),
       ...(update.metadata ? { metadata: sanitizeRunMetadata({ ...(current.metadata ?? {}), ...update.metadata }) } : {}),
@@ -177,6 +200,44 @@ export class RuntimeRunRegistry {
     }
     await this.write(next)
     return next
+  }
+
+  async requestCancellation(runId: string, options: RuntimeRunCancellationRequestOptions = {}): Promise<RuntimeRunCancellationRequestResult> {
+    const current = await this.read(runId)
+    const terminal = isTerminalRuntimeRunStatus(current.status)
+    const existingCancellation = current.lifecycle?.cancellation
+    if (terminal || existingCancellation) {
+      return {
+        schema: "wp-codebox/run-cancellation-request/v1",
+        runId: current.runId,
+        status: current.status,
+        cancellationRequested: Boolean(existingCancellation),
+        alreadyRequested: Boolean(existingCancellation),
+        terminal,
+        record: current,
+      }
+    }
+
+    const now = (options.now ?? new Date()).toISOString()
+    const cancellation = stripUndefined({
+      requestedAt: now,
+      reason: options.reason,
+    }) as RuntimeRunCancellationState
+    const next: RuntimeRunRecord = {
+      ...current,
+      lifecycle: buildRuntimeRunLifecycle(current.status, current.lifecycle?.cleanup ?? initialRuntimeRunCleanup(), cancellation),
+      updatedAt: now,
+    }
+    await this.write(next)
+    return {
+      schema: "wp-codebox/run-cancellation-request/v1",
+      runId: next.runId,
+      status: next.status,
+      cancellationRequested: true,
+      alreadyRequested: false,
+      terminal: false,
+      record: next,
+    }
   }
 
   async heartbeat(runId: string, now = new Date()): Promise<RuntimeRunRecord> {
@@ -197,7 +258,7 @@ export class RuntimeRunRegistry {
   }
 }
 
-export function buildRuntimeRunLifecycle(status: RuntimeRunStatus, cleanup: RuntimeRunCleanupState = initialRuntimeRunCleanup()): RuntimeRunLifecycle {
+export function buildRuntimeRunLifecycle(status: RuntimeRunStatus, cleanup: RuntimeRunCleanupState = initialRuntimeRunCleanup(), cancellation?: RuntimeRunCancellationState): RuntimeRunLifecycle {
   const terminal = isTerminalRuntimeRunStatus(status)
   return {
     schema: "wp-codebox/run-lifecycle/v1",
@@ -205,6 +266,8 @@ export function buildRuntimeRunLifecycle(status: RuntimeRunStatus, cleanup: Runt
     phase: runtimeRunLifecyclePhase(status),
     terminal,
     cancellable: !terminal,
+    cancelRequested: Boolean(cancellation),
+    ...(cancellation ? { cancellation } : {}),
     successful: status === "succeeded",
     failed: status === "failed" || status === "timed_out",
     cancelled: status === "cancelled",

--- a/scripts/run-registry-smoke.ts
+++ b/scripts/run-registry-smoke.ts
@@ -82,6 +82,15 @@ try {
   assert.equal(timedOut.lifecycle.outcome, "timed_out")
   assert.equal(timedOut.lifecycle.cancellable, false)
 
+  const cancellable = await registry.create({ runId: "run_cancel", status: "running" })
+  const { stdout: cancelStdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "runs", "cancel", "--registry", registryDirectory, "--run-id", cancellable.runId, "--reason", "smoke requested", "--json"], { cwd: root })
+  const cancellation = JSON.parse(cancelStdout)
+  assert.equal(cancellation.schema, "wp-codebox/run-cancellation-request/v1")
+  assert.equal(cancellation.cancellationRequested, true)
+  assert.equal(cancellation.alreadyRequested, false)
+  assert.equal(cancellation.record.lifecycle.cancelRequested, true)
+  assert.equal(cancellation.record.lifecycle.cancellation.reason, "smoke requested")
+
   const { stdout: artifactsStdout } = await execFileAsync(process.execPath, ["packages/cli/dist/index.js", "runs", "artifacts", "--registry", registryDirectory, "--run-id", run.runId, "--json"], { cwd: root })
   const artifacts = JSON.parse(artifactsStdout)
   assert.equal(artifacts.schema, "wp-codebox/run-artifacts/v1")

--- a/tests/run-registry.test.ts
+++ b/tests/run-registry.test.ts
@@ -41,3 +41,42 @@ await withTempDir("wp-codebox-run-registry-", async (directory) => {
   assert.equal(retry.lifecycle.cleanup.status, "running")
   assert.equal(retry.lifecycle.cleanup.attempts, 1)
 })
+
+await withTempDir("wp-codebox-run-registry-cancel-", async (directory) => {
+  const registry = new RuntimeRunRegistry(directory)
+  const run = await registry.create({ runId: "cancel-active", status: "running", now: new Date("2026-01-02T03:04:05.000Z") })
+
+  assert.equal(run.lifecycle.cancellable, true)
+  assert.equal(run.lifecycle.cancelRequested, false)
+
+  const requested = await registry.requestCancellation(run.runId, {
+    reason: "caller stopped",
+    now: new Date("2026-01-02T03:04:06.000Z"),
+  })
+  assert.equal(requested.schema, "wp-codebox/run-cancellation-request/v1")
+  assert.equal(requested.cancellationRequested, true)
+  assert.equal(requested.alreadyRequested, false)
+  assert.equal(requested.terminal, false)
+  assert.equal(requested.record.status, "running")
+  assert.equal(requested.record.lifecycle.cancelRequested, true)
+  assert.deepEqual(requested.record.lifecycle.cancellation, {
+    requestedAt: "2026-01-02T03:04:06.000Z",
+    reason: "caller stopped",
+  })
+
+  const repeated = await registry.requestCancellation(run.runId, {
+    reason: "ignored duplicate",
+    now: new Date("2026-01-02T03:04:07.000Z"),
+  })
+  assert.equal(repeated.cancellationRequested, true)
+  assert.equal(repeated.alreadyRequested, true)
+  assert.deepEqual(repeated.record.lifecycle.cancellation, requested.record.lifecycle.cancellation)
+
+  const cancelled = await registry.update(run.runId, {
+    status: "cancelled",
+    now: new Date("2026-01-02T03:04:08.000Z"),
+  })
+  assert.equal(cancelled.lifecycle.terminal, true)
+  assert.equal(cancelled.lifecycle.cancelled, true)
+  assert.equal(cancelled.lifecycle.outcome, "cancelled")
+})


### PR DESCRIPTION
## Summary
- Add a generic run-registry cancellation request primitive keyed by run id.
- Add `wp-codebox runs cancel --registry <dir> --run-id <id>` and document the lifecycle fields.
- Have active recipe runs observe registry cancellation requests and reuse the existing interruption/finalization path.

## Testing
- `npm run build`
- `npm run test:run-registry`
- `npm run smoke -- --group=check`
- `npm exec -- tsx scripts/run-registry-smoke.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implemented and tested addressable Codebox run cancellation.