### PR TITLE
Propagate agent task extra plugins

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -35,6 +35,8 @@ export interface AgentTaskRunInput {
   mounts?: NonNullable<WorkspaceRecipe["inputs"]>["mounts"]
   workspaces?: NonNullable<WorkspaceRecipe["inputs"]>["workspaces"]
   dependency_overlays?: NonNullable<WorkspaceRecipe["inputs"]>["dependency_overlays"]
+  extra_plugins?: WorkspaceRecipeExtraPlugin[]
+  extraPlugins?: WorkspaceRecipeExtraPlugin[]
   runtime_stack_mounts?: WorkspaceRecipeMount[]
   runtime_overlays?: Array<Record<string, unknown>>
   agent_bundles?: Array<Record<string, unknown>>
@@ -89,9 +91,11 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
   const providerContracts = providerPlugins.map((plugin) => ({ slug: plugin.slug, pluginFile: plugin.pluginFile, loadAs: plugin.loadAs ?? "plugin" }))
   const componentPluginEntries = componentPlugins(input.component_contracts, artifacts)
+  const callerExtraPlugins = agentTaskExtraPlugins(input)
   const extraPlugins = [
     ...componentPluginEntries,
     ...providerPlugins,
+    ...callerExtraPlugins,
   ].filter(Boolean)
   const componentManifest = componentManifestForRuntimePlugins(componentPluginEntries, providerPlugins)
   const workflowArgs = [
@@ -304,6 +308,32 @@ function runtimeStateMounts(input: AgentTaskRunInput): WorkspaceRecipeMount[] {
 function runtimeMountList(value: unknown): WorkspaceRecipeMount[] {
   if (!Array.isArray(value)) return []
   return value.filter((entry): entry is WorkspaceRecipeMount => Boolean(objectValue(entry)))
+}
+
+function agentTaskExtraPlugins(input: AgentTaskRunInput): WorkspaceRecipeExtraPlugin[] {
+  return [
+    ...normalizeAgentTaskExtraPlugins(input.extra_plugins),
+    ...normalizeAgentTaskExtraPlugins(input.extraPlugins),
+  ]
+}
+
+function normalizeAgentTaskExtraPlugins(value: unknown): WorkspaceRecipeExtraPlugin[] {
+  if (!Array.isArray(value)) return []
+
+  return value.flatMap((entry) => {
+    if (!isPlainObject(entry)) return []
+    const source = stringValue(entry.source)
+    if (!source) return []
+    return [stripUndefined({
+      source,
+      slug: stringValue(entry.slug) || undefined,
+      pluginFile: stringValue(entry.pluginFile) || undefined,
+      activate: typeof entry.activate === "boolean" ? entry.activate : undefined,
+      sha256: stringValue(entry.sha256) || undefined,
+      loadAs: entry.loadAs === "plugin" || entry.loadAs === "mu-plugin" ? entry.loadAs : undefined,
+      metadata: isPlainObject(entry.metadata) ? entry.metadata : undefined,
+    }) as WorkspaceRecipeExtraPlugin]
+  })
 }
 
 function componentPlugins(contracts: Array<Record<string, unknown>> | undefined, artifactsRoot: string): WorkspaceRecipeExtraPlugin[] {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict"
-import { normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult } from "../packages/runtime-core/src/index.js"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { buildAgentTaskRecipe, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
 import { agentTaskRunExitCode } from "../packages/cli/src/commands/agent-task-run.js"
@@ -94,5 +97,54 @@ const agentRecipePolicy = recipePolicy({
 assert.equal(agentRecipePolicy.commands.includes("wordpress.run-php"), true)
 assert.equal(agentRecipePolicy.commands.includes("wordpress.wp-cli"), true)
 assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run"), false)
+
+const agentRecipeTemp = mkdtempSync(join(tmpdir(), "wp-codebox-agent-recipe-test-"))
+try {
+  const providerSource = join(agentRecipeTemp, "test-provider")
+  mkdirSync(providerSource)
+  writeFileSync(join(providerSource, "test-provider.php"), "<?php\n/* Plugin Name: Test Provider */\n")
+  const artifactsPath = join(agentRecipeTemp, "artifacts")
+  mkdirSync(artifactsPath)
+
+  const recipe = buildAgentTaskRecipe({
+    goal: "Verify extra plugin propagation",
+    artifacts_path: artifactsPath,
+    provider_plugin_paths: [providerSource],
+    extra_plugins: [{
+      source: "/workspace/runtime-tools/agent-runtime-tool-bridge",
+      slug: "agent-runtime-tool-bridge",
+      loadAs: "mu-plugin",
+      activate: false,
+      pluginFile: "agent-runtime-tool-bridge/agent-runtime-tool-bridge.php",
+      metadata: { source: "agent-task-input" },
+    }],
+    extraPlugins: [{
+      source: "/workspace/runtime-tools/agent-runtime-helper",
+      slug: "agent-runtime-helper",
+      loadAs: "plugin",
+      activate: true,
+      pluginFile: "agent-runtime-helper/agent-runtime-helper.php",
+    }],
+  }, normalizeTaskInput({ goal: "Verify extra plugin propagation" }), "latest")
+  const extraPlugins = recipe.inputs?.extra_plugins ?? []
+  assert.equal(extraPlugins.some((plugin) => plugin.slug === "test-provider" && plugin.activate === true && plugin.loadAs === "plugin"), true)
+  assert.deepEqual(extraPlugins.find((plugin) => plugin.slug === "agent-runtime-tool-bridge"), {
+    source: "/workspace/runtime-tools/agent-runtime-tool-bridge",
+    slug: "agent-runtime-tool-bridge",
+    pluginFile: "agent-runtime-tool-bridge/agent-runtime-tool-bridge.php",
+    activate: false,
+    loadAs: "mu-plugin",
+    metadata: { source: "agent-task-input" },
+  })
+  assert.deepEqual(extraPlugins.find((plugin) => plugin.slug === "agent-runtime-helper"), {
+    source: "/workspace/runtime-tools/agent-runtime-helper",
+    slug: "agent-runtime-helper",
+    pluginFile: "agent-runtime-helper/agent-runtime-helper.php",
+    activate: true,
+    loadAs: "plugin",
+  })
+} finally {
+  rmSync(agentRecipeTemp, { recursive: true, force: true })
+}
 
 console.log("agent task contracts passed")


### PR DESCRIPTION
## Summary
- include caller-provided `extra_plugins` / `extraPlugins` entries when building agent-task recipes
- preserve extra plugin load metadata including `pluginFile`, `loadAs`, activation, checksum, and metadata fields
- add contract coverage for provider plugins plus snake_case and camelCase extra plugin inputs

## Tests
- `npm run test:agent-task-contracts`
- `npm run build --workspace=@automattic/wp-codebox-core`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused agent-task recipe propagation change and contract test; Chris remains responsible for review and validation.