### PR TITLE
Remove Data Machine runtime tool coupling

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
@@ -990,6 +990,40 @@ return array(
 );
 }
 
+function wp_codebox_browser_runtime_resolve_ability_tools( array $payload, array $resolution ): array {
+$tools = is_array( $resolution[\'tools\'] ?? null ) ? $resolution[\'tools\'] : array();
+if ( function_exists( \'apply_filters\' ) ) {
+	$filtered = apply_filters( \'wp_codebox_browser_runtime_ability_tools\', $tools, $payload, $resolution );
+	if ( is_array( $filtered ) ) {
+		$tools = $filtered;
+	}
+}
+
+return $tools;
+}
+
+function wp_codebox_browser_runtime_ability_tools_for_mode( array $ability_tools, $mode ): array {
+$mode = is_array( $mode ) ? array_values( array_map( \'strval\', $mode ) ) : array( (string) $mode );
+$filtered = array();
+foreach ( $ability_tools as $name => $tool ) {
+	if ( ! is_array( $tool ) ) {
+		continue;
+	}
+	$modes = is_array( $tool[\'modes\'] ?? null ) ? array_values( array_map( \'strval\', $tool[\'modes\'] ) ) : array();
+	if ( empty( $modes ) || array_intersect( $mode, $modes ) ) {
+		$filtered[ (string) $name ] = $tool;
+	}
+}
+
+return $filtered;
+}
+
+function wp_codebox_browser_runtime_merge_ability_tools( array $tools, $mode ): array {
+global $wp_codebox_browser_runtime_ability_tools;
+$ability_tools = is_array( $wp_codebox_browser_runtime_ability_tools ?? null ) ? $wp_codebox_browser_runtime_ability_tools : array();
+return array_merge( $tools, wp_codebox_browser_runtime_ability_tools_for_mode( $ability_tools, $mode ) );
+}
+
 function wp_codebox_browser_runtime_ability_tool_diagnostics( array $ability_tools ): array {
 $registered = array();
 $missing = array();
@@ -1056,6 +1090,11 @@ $tool_def = is_array( $request[\'tool_def\'] ?? null ) ? $request[\'tool_def\'] 
 return $handler->handle_tool_call( $parameters, $tool_def );
 }
 
+add_filter( \'agents_api_resolved_tools\', function ( array $tools, $mode, array $context ) {
+	unset( $context );
+	return wp_codebox_browser_runtime_merge_ability_tools( $tools, $mode );
+}, 20, 3 );
+
 add_filter( \'wp_agent_runtime_resolved_tools\', function ( array $tools, $mode, array $args ) {
 	global $wp_codebox_browser_artifact_environment;
 	$environment = is_array( $wp_codebox_browser_artifact_environment ?? null ) ? $wp_codebox_browser_artifact_environment : array();
@@ -1078,7 +1117,7 @@ add_filter( \'wp_agent_runtime_resolved_tools\', function ( array $tools, $mode,
 		\'access_level\' => \'public\',
 		\'modes\'        => is_array( $mode ) ? $mode : array( (string) $mode ),
 	);
-	return $tools;
+	return wp_codebox_browser_runtime_merge_ability_tools( $tools, $mode );
 }, 20, 3 );
 ';
 	}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -254,10 +254,7 @@ if ( is_array( $raw_payload ) ) {
 $wp_codebox_browser_artifact_environment = wp_codebox_browser_artifact_environment( $payload );
 $provider_proxy_diagnostics = wp_codebox_browser_install_provider_proxy( $payload );
 $ability_tool_resolution = wp_codebox_browser_runtime_ability_tool_declarations( $payload );
-$wp_codebox_browser_runtime_ability_tools = is_array( $ability_tool_resolution[\'tools\'] ?? null ) ? $ability_tool_resolution[\'tools\'] : array();
-add_filter( \'datamachine_ability_tools\', function ( array $tools ) use ( &$wp_codebox_browser_runtime_ability_tools ): array {
-	return array_merge( $tools, $wp_codebox_browser_runtime_ability_tools );
-}, 20, 1 );
+$wp_codebox_browser_runtime_ability_tools = wp_codebox_browser_runtime_resolve_ability_tools( $payload, $ability_tool_resolution );
 $ability_tool_diagnostics = wp_codebox_browser_runtime_ability_tool_diagnostics( $wp_codebox_browser_runtime_ability_tools );
 
 $session_id = (string) ( $payload[\'session_id\'] ?? ' . var_export( $session_id, true ) . ' );

--- a/scripts/agent-runtime-ability-tools-smoke.ts
+++ b/scripts/agent-runtime-ability-tools-smoke.ts
@@ -9,8 +9,10 @@ const source = [
 
 const requiredSnippets = [
   "function wp_codebox_browser_runtime_ability_tool_declarations",
+  "function wp_codebox_browser_runtime_resolve_ability_tools",
+  "add_filter( \\'agents_api_resolved_tools\\'",
+  "apply_filters( \\'wp_codebox_browser_runtime_ability_tools\\'",
   "$task_input[\\'ability_tools\\']",
-  "add_filter( \\'datamachine_ability_tools\\'",
   "array_merge( $sandbox_tool_ids, $ability_tool_ids )",
   "'ability_tools' => \\$ability_tool_diagnostics",
   "'allowed_tool_ids' => \\$allowed_tool_ids",
@@ -20,6 +22,10 @@ for (const snippet of requiredSnippets) {
   if (!source.includes(snippet)) {
     throw new Error(`Missing ability_tools runtime bridge snippet: ${snippet}`)
   }
+}
+
+if (source.includes("datamachine_ability_tools")) {
+  throw new Error("Browser runner must not hard-code Data Machine runtime tool hooks")
 }
 
 const preludeStart = source.indexOf("function wp_codebox_browser_runtime_ability_tool_declarations")

--- a/tests/browser-runner-template.test.ts
+++ b/tests/browser-runner-template.test.ts
@@ -76,7 +76,7 @@ echo json_encode( array(
 assert.equal(php.status, 0, php.stderr)
 const result = JSON.parse(php.stdout)
 
-assert.equal(result.sha256, "5109f53a794c0c3db5c710fa81d2310fa71a92b950762bce4b5a2878843c5432")
+assert.equal(result.sha256, "8c7698406f3ce17c23ef8b7ec61a1af9a19a7f2ffd45ce5b1d4fa1f277b91264")
 assert.deepEqual(result.function_counts, {
   event_sink: 1,
   capture_file: 1,


### PR DESCRIPTION
## Summary
- Remove the browser runner direct `datamachine_ability_tools` registration.
- Route runtime ability tool declarations through the generic `wp_codebox_browser_runtime_ability_tools` filter and Agents API canonical `agents_api_resolved_tools` filter.
- Keep WP Codebox runtime resolved-tools path aligned and add smoke coverage that rejects reintroducing the Data Machine hook.

## Tests
- `npm run build` passed.
- `npm run test:browser-runner-template` passed.
- `npm run smoke -- --command=agent-runtime-ability-tools-smoke` passed.
- `npm run check` failed in existing `test:browser-callback-materialization-contracts`: `AssertionError [ERR_ASSERTION]: Missing expected exception` at `tests/browser-callback-materialization-contracts.test.ts:225`. Re-running `npm run test:browser-callback-materialization-contracts` reproduces the same failure; it is outside the browser runner/runtime-tool coupling path changed here.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** removed Data Machine-specific coupling from WP Codebox core.