### PR TITLE
Pass provider runtime contract to generic runs

### DIFF
--- a/docs/generic-runtime-primitives.md
+++ b/docs/generic-runtime-primitives.md
@@ -10,6 +10,7 @@ product or job system.
   `packages/runtime-core/src/materialization-contracts.ts`, and
   `packages/runtime-core/src/evidence-artifact-envelope.ts`, and
   `packages/runtime-core/src/runtime-overlay-bundle.ts`, and
+  `packages/runtime-core/src/provider-runtime-contracts.ts`, and
   `packages/runtime-core/src/command-agent-run.ts`.
 - Coverage lives in `tests/generic-primitives.test.ts` and
   `tests/command-agent-run.test.ts`.
@@ -162,3 +163,20 @@ Example recipe step:
   ]
 }
 ```
+
+## Provider Runtime Invocation Contract
+
+`buildGenericAbilityRuntimeRunRecipe()` includes
+`runtime_invocation.provider_runtime_contract` in the ability input. The contract
+is the generic runtime-provider handshake introduced by PR #1205: workspace
+capture, workspace command execution, workspace publication, tool-call transcript
+recording, artifact handoff, and runtime evidence result schemas.
+
+WP Codebox owns the names and schemas. Callers own policy: repository selection,
+authorization, retries, retention, publication approval, and how resulting refs
+are attached to their job records.
+
+The contract intentionally uses `wp-codebox.runner-workspace.*`,
+`wp-codebox.tool-call-transcript.record`, and `wp-codebox.artifact-handoff`
+names. Downstream product names and orchestration policy stay outside the
+runtime invocation payload.

--- a/packages/runtime-core/src/generic-ability-runtime-run.ts
+++ b/packages/runtime-core/src/generic-ability-runtime-run.ts
@@ -1,6 +1,7 @@
 import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import { commandArg, commandJsonArg } from "./command-codecs.js"
 import { resolvePluginEntrypointContract, sanitizePluginSlug, type ComponentLoadMode } from "./component-contracts.js"
+import { providerRuntimeInvocationContract } from "./provider-runtime-contracts.js"
 import { DEFAULT_WORDPRESS_VERSION } from "./runtime-defaults.js"
 import type { WorkspaceRecipe, WorkspaceRecipeExtraPlugin, WorkspaceRecipeMount, WorkspaceRecipeRuntimeOverlay, WorkspaceRecipeStagedFile } from "./runtime-contracts.js"
 import { componentManifestForRuntimePlugins, runtimeDependencyPlanContract } from "./agent-task-recipe.js"
@@ -59,6 +60,7 @@ export function buildGenericAbilityRuntimeRunRecipe(options: GenericAbilityRunti
       schema: GENERIC_ABILITY_RUNTIME_RUN_RESULT_SCHEMA,
       ability_id: abilityId,
       expected_result_schema: expectedResultSchema,
+      provider_runtime_contract: providerRuntimeInvocationContract(),
       component_manifest: componentManifest,
       dependency_plan: runtimeDependencyPlanContract({
         provider_plugin_paths: options.providerPluginPaths,

--- a/tests/generic-ability-runtime-run.test.ts
+++ b/tests/generic-ability-runtime-run.test.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { runRecipeBuildCommand } from "../packages/cli/src/commands/recipe-build.js"
-import { buildGenericAbilityRuntimeRunRecipe, GENERIC_ABILITY_RUNTIME_RUN_RESULT_SCHEMA } from "../packages/runtime-core/src/index.js"
+import { buildGenericAbilityRuntimeRunRecipe, GENERIC_ABILITY_RUNTIME_RUN_RESULT_SCHEMA, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA } from "../packages/runtime-core/src/index.js"
 import { buildGenericAbilityRuntimeRunRecipe as buildGenericAbilityRuntimeRunRecipeFromStableSubpath } from "../packages/runtime-core/src/recipe-builders.js"
 import { abilityResponseToCommandEnvelope, expectedAbilityResultSchemaFromArgs } from "../packages/runtime-playground/src/commands.js"
 import { withTempDir } from "../scripts/test-kit.js"
@@ -48,7 +48,19 @@ await withTempDir("wp-codebox-generic-ability-runtime-run-", async (root) => {
   assert.equal(input.runtime_invocation.schema, GENERIC_ABILITY_RUNTIME_RUN_RESULT_SCHEMA)
   assert.equal(input.runtime_invocation.ability_id, "example/runtime-run")
   assert.equal(input.runtime_invocation.expected_result_schema, "example/result/v1")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.schema, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
+  assert.equal(input.runtime_invocation.provider_runtime_contract.tasks.workspaceCapture, "wp-codebox.runner-workspace.capture")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.tasks.workspaceCommand, "wp-codebox.runner-workspace.command")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.tasks.workspacePublish, "wp-codebox.runner-workspace.publish")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.tasks.toolCallTranscriptRecord, "wp-codebox.tool-call-transcript.record")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.tasks.artifactHandoff, "wp-codebox.artifact-handoff")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.result_schemas.workspace_capture, "wp-codebox/runner-workspace-capture-result/v1")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.result_schemas.workspace_command, "wp-codebox/runner-workspace-command-result/v1")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.result_schemas.workspace_publication, "wp-codebox/runner-workspace-publication-result/v1")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.result_schemas.tool_call_transcript, "wp-codebox/tool-call-transcript/v1")
+  assert.equal(input.runtime_invocation.provider_runtime_contract.result_schemas.evidence_artifact_envelope, "wp-codebox/evidence-artifact-envelope/v1")
   assert.equal(input.runtime_invocation.component_manifest.components[0].slug, "example-component")
+  assert.doesNotMatch(JSON.stringify(input.runtime_invocation), /datamachine|data machine|homeboy|wpsg|wp-site-generator|wp site generator/i)
 
   const cliOptionsPath = join(root, "generic-ability-runtime-options.json")
   const cliRecipePath = join(root, "generic-ability-runtime.recipe.json")


### PR DESCRIPTION
## Summary
- Include the provider runtime invocation contract inside generic ability runtime invocation payloads.
- Document the in-band generic provider handshake for workspace operations, publication, transcript recording, artifact handoff, and evidence schemas.
- Extend tests to enforce generic names and product-boundary vocabulary.

## Verification
- npm run test:generic-ability-runtime-run
- npm run test:provider-runtime-contracts
- npm run test:production-boundary-enforcement
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected PR #1205 and the current WP Codebox runtime contracts, drafted the small generic invocation wiring, docs, and tests; Chris remains responsible for review and merge.