### PR TITLE
Exit CLI after settled commands

### DIFF
--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -2,10 +2,11 @@ import { runCli } from "./cli-entry.js"
 import { serializeError, wantsJsonOutput, writeJsonFailure } from "./output.js"
 
 export type CliRunner = (args: string[]) => Promise<number>
+export type CliExit = (code: number) => never
 
 const UNSETTLED_COMMAND_MESSAGE = "WP Codebox CLI command did not settle before the Node.js event loop drained."
 
-export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): void {
+export function runCliEntrypoint(args: string[], runner: CliRunner = runCli, exit: CliExit = process.exit): void {
   let settled = false
   const writeStderr = process.stderr.write.bind(process.stderr)
   const handleBeforeExit = () => {
@@ -27,6 +28,7 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): vo
       settled = true
       process.off("beforeExit", handleBeforeExit)
       process.exitCode = code
+      exit(code)
     },
     (error) => {
       settled = true
@@ -38,6 +40,7 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli): vo
         writeStderr(`${serialized.message}\n`)
       }
       process.exitCode = 1
+      exit(1)
     },
   )
 }

--- a/scripts/cli-unsettled-command-smoke.ts
+++ b/scripts/cli-unsettled-command-smoke.ts
@@ -30,4 +30,37 @@ try {
   process.exitCode = originalExitCode
 }
 
+const exits: number[] = []
+process.exitCode = undefined
+runCliEntrypoint(["doctor"], async () => 7, (code) => {
+  exits.push(code)
+  return undefined as never
+})
+await new Promise((resolve) => setImmediate(resolve))
+assert.deepEqual(exits, [7])
+assert.equal(process.exitCode, 7)
+
+const rejectedExits: number[] = []
+stderr = ""
+process.exitCode = undefined
+;(process.stderr.write as typeof process.stderr.write) = ((chunk: unknown, ..._args: unknown[]) => {
+  stderr += String(chunk)
+  return true
+}) as typeof process.stderr.write
+try {
+  runCliEntrypoint(["doctor"], async () => {
+    throw new Error("boom")
+  }, (code) => {
+    rejectedExits.push(code)
+    return undefined as never
+  })
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.deepEqual(rejectedExits, [1])
+  assert.equal(process.exitCode, 1)
+  assert.match(stderr, /boom/)
+} finally {
+  process.stderr.write = originalStderrWrite
+  process.exitCode = originalExitCode
+}
+
 console.log("cli-unsettled-command-smoke: ok")


### PR DESCRIPTION
## Summary
- explicitly exits the WP Codebox CLI after a command promise settles
- keeps the existing unsettled-command guard for commands that never settle
- adds smoke coverage for settled success and rejection paths

## Testing
- npm exec -- tsx scripts/cli-unsettled-command-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the hanging CLI process during Homeboy Lab validation, drafted the CLI exit fix and smoke coverage, and ran local verification. Chris remains responsible for review and acceptance.