### PR TITLE
Register provider runtime ability aliases

### DIFF
--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -28,7 +28,7 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli, exi
       settled = true
       process.off("beforeExit", handleBeforeExit)
       process.exitCode = code
-      exit(code)
+      exitAfterOutputDrains(code, exit)
     },
     (error) => {
       settled = true
@@ -40,7 +40,27 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli, exi
         writeStderr(`${serialized.message}\n`)
       }
       process.exitCode = 1
-      exit(1)
+      exitAfterOutputDrains(1, exit)
     },
   )
+}
+
+function exitAfterOutputDrains(code: number, exit: CliExit): void {
+  const streams = [process.stdout, process.stderr].filter((stream) => stream.writableNeedDrain)
+  if (streams.length === 0) {
+    exit(code)
+    return
+  }
+
+  let pending = streams.length
+  const finish = () => {
+    pending -= 1
+    if (pending === 0) {
+      exit(code)
+    }
+  }
+
+  for (const stream of streams) {
+    stream.once("drain", finish)
+  }
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -444,6 +444,20 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/runner-workspace-publish',
+				array(
+					'label'               => 'Publish Runner Workspace',
+					'description'         => 'Publish runner-owned workspace changes through the WP Codebox runner boundary without exposing backend publication internals to callers.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_publication_input_schema(),
+					'output_schema'       => self::runner_workspace_publication_output_schema(),
+					'execute_callback'    => array( self::class, 'publish_runner_workspace' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/capture-runner-workspace',
 				array(
 					'label'               => 'Capture Runner Workspace',
@@ -459,6 +473,20 @@ final class WP_Codebox_Abilities {
 
 			wp_register_ability(
 				'wp-codebox/run-runner-workspace-command',
+				array(
+					'label'               => 'Run Runner Workspace Command',
+					'description'         => 'Run a bounded verification or drift-check command against a runner-owned workspace through the WP Codebox runner boundary.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_command_input_schema(),
+					'output_schema'       => self::runner_workspace_command_output_schema(),
+					'execute_callback'    => array( self::class, 'run_runner_workspace_command' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/runner-workspace-command',
 				array(
 					'label'               => 'Run Runner Workspace Command',
 					'description'         => 'Run a bounded verification or drift-check command against a runner-owned workspace through the WP Codebox runner boundary.',

--- a/scripts/executable-browser-dto-smoke.ts
+++ b/scripts/executable-browser-dto-smoke.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 
 const dir = mkdtempSync(join(tmpdir(), "wp-codebox-executable-browser-dto-"))
 const smokePhp = join(dir, "smoke.php")
+const browserTaskBuilderPath = new URL("../packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php", import.meta.url).pathname
 const traitPath = new URL("../packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php", import.meta.url).pathname
 
 writeFileSync(smokePhp, `<?php
@@ -22,6 +23,7 @@ function smoke_assert(bool $condition, string $message): void {
 	}
 }
 
+require ${JSON.stringify(browserTaskBuilderPath)};
 require ${JSON.stringify(traitPath)};
 
 class Smoke_Browser_DTO {

--- a/tests/provider-runtime-contracts.test.ts
+++ b/tests/provider-runtime-contracts.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
 
 import {
   PROVIDER_RUNTIME_ABILITY_NAMES,
@@ -6,6 +7,7 @@ import {
   PROVIDER_RUNTIME_TASK_NAMES,
   providerRuntimeInvocationContract,
 } from "../packages/runtime-core/src/index.js"
+import { phpCallBlock } from "../scripts/test-kit.js"
 
 const contract = providerRuntimeInvocationContract()
 
@@ -15,11 +17,30 @@ assert.deepEqual(contract.tasks, PROVIDER_RUNTIME_TASK_NAMES)
 assert.deepEqual(contract.abilities, PROVIDER_RUNTIME_ABILITY_NAMES)
 assert.equal(contract.tasks.workspaceCapture, "wp-codebox.runner-workspace.capture")
 assert.equal(contract.abilities.workspaceCapture, "wp-codebox/runner-workspace-capture")
+assert.equal(contract.abilities.workspaceCommand, "wp-codebox/runner-workspace-command")
+assert.equal(contract.abilities.workspacePublish, "wp-codebox/runner-workspace-publish")
 assert.equal(contract.result_schemas.workspace_capture, "wp-codebox/runner-workspace-capture-result/v1")
 assert.equal(contract.result_schemas.workspace_command, "wp-codebox/runner-workspace-command-result/v1")
 assert.equal(contract.result_schemas.workspace_publication, "wp-codebox/runner-workspace-publication-result/v1")
 assert.equal(contract.result_schemas.tool_call_transcript, "wp-codebox/tool-call-transcript/v1")
 assert.equal(contract.result_schemas.evidence_artifact_envelope, "wp-codebox/evidence-artifact-envelope/v1")
+
+const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-abilities.php", "utf8")
+const registeredAbilityIds = [
+  contract.abilities.workspaceCommand,
+  contract.abilities.workspacePublish,
+  "wp-codebox/run-runner-workspace-command",
+  "wp-codebox/publish-runner-workspace",
+]
+
+for (const abilityId of registeredAbilityIds) {
+  assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", abilityId), new RegExp(`'${abilityId}'`))
+}
+
+assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspaceCommand), /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'run_runner_workspace_command'\s*\)/)
+assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspaceCommand), /'permission_callback'\s*=>\s*array\(\s*self::class,\s*'can_run_agent_task'\s*\)/)
+assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspacePublish), /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'publish_runner_workspace'\s*\)/)
+assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspacePublish), /'permission_callback'\s*=>\s*array\(\s*self::class,\s*'can_run_agent_task'\s*\)/)
 
 const serialized = JSON.stringify(contract)
 assert.doesNotMatch(serialized, /datamachine|data machine|homeboy|wpsg|wp-site-generator|wp site generator/i)


### PR DESCRIPTION
## Summary
- Register canonical provider runtime ability aliases for runner workspace command and publish operations.
- Preserve the existing registered ability IDs for compatibility.
- Add provider runtime contract coverage that asserts canonical contract names and legacy IDs are registered with the expected callbacks and permissions.
- Fix two upstream check blockers found while verifying: drain CLI output before explicit exit so large JSON discovery output is not truncated, and load the browser task builder dependency in the executable browser DTO smoke.

## Verification
- npm run test:provider-runtime-contracts
- npm run test:runtime-tool-policy
- npm run test:production-boundary-enforcement
- npm run build
- npm exec -- tsx scripts/discovery-command-smoke.ts
- npm exec -- tsx scripts/cli-unsettled-command-smoke.ts
- npm exec -- tsx scripts/executable-browser-dto-smoke.ts
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the compatibility alias registration, provider runtime contract test coverage, upstream check-blocker fixes, and local verification commands; Chris remains responsible for review and merge.