### PR TITLE
Dedupe agent task extra plugins

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -94,11 +94,11 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   const providerContracts = providerPlugins.map((plugin) => ({ slug: plugin.slug, pluginFile: plugin.pluginFile, loadAs: plugin.loadAs ?? "plugin" }))
   const componentPluginEntries = componentPlugins(input.component_contracts, artifacts)
   const callerExtraPlugins = agentTaskExtraPlugins(input)
-  const extraPlugins = [
+  const extraPlugins = dedupeExtraPlugins([
     ...componentPluginEntries,
     ...providerPlugins,
     ...callerExtraPlugins,
-  ].filter(Boolean)
+  ].filter(Boolean))
   const componentManifest = componentManifestForRuntimePlugins(componentPluginEntries, providerPlugins)
   const workflowArgs = [
     `task=${taskInput.goal}`,
@@ -318,6 +318,18 @@ function agentTaskExtraPlugins(input: AgentTaskRunInput): WorkspaceRecipeExtraPl
     ...normalizeAgentTaskExtraPlugins(input.extra_plugins),
     ...normalizeAgentTaskExtraPlugins(input.extraPlugins),
   ]
+}
+
+function dedupeExtraPlugins(plugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeExtraPlugin[] {
+  const seen = new Set<string>()
+  const deduped: WorkspaceRecipeExtraPlugin[] = []
+  for (const plugin of plugins) {
+    const key = `${stringValue(plugin.slug) || slugFromPath(stringValue(plugin.source))}:${plugin.loadAs === "plugin" ? "plugin" : "mu-plugin"}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(plugin)
+  }
+  return deduped
 }
 
 function normalizeAgentTaskExtraPlugins(value: unknown): WorkspaceRecipeExtraPlugin[] {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -126,6 +126,11 @@ try {
       metadata: { source: "agent-task-input" },
     }],
     extraPlugins: [{
+      source: providerSource,
+      slug: "test-provider",
+      loadAs: "plugin",
+      activate: true,
+    }, {
       source: helperSource,
       slug: "agent-runtime-helper",
       loadAs: "plugin",
@@ -135,6 +140,7 @@ try {
   }, normalizeTaskInput({ goal: "Verify extra plugin propagation" }), "latest")
   const extraPlugins = recipe.inputs?.extra_plugins ?? []
   assert.equal(extraPlugins.some((plugin) => plugin.slug === "test-provider" && plugin.activate === true && plugin.loadAs === "plugin"), true)
+  assert.equal(extraPlugins.filter((plugin) => plugin.slug === "test-provider" && plugin.loadAs === "plugin").length, 1)
   assert.deepEqual(extraPlugins.find((plugin) => plugin.slug === "agent-runtime-tool-bridge"), {
     source: bridgeSource,
     slug: "agent-runtime-tool-bridge",


### PR DESCRIPTION
## Summary
- dedupes generated agent-task recipe extra plugins by slug and load mode
- preserves provider/component plugin entries ahead of duplicate caller-provided entries
- adds contract coverage for duplicate provider plugin propagation

## Testing
- npm run test:agent-task-contracts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed duplicate runtime plugin mounts in Homeboy Lab, drafted the dedupe fix and contract coverage, and ran local verification. Chris remains responsible for review and acceptance.