### PR TITLE
Support local browser runtime packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:php-managed-host-command": "tsx tests/php-managed-host-command.test.ts",
     "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",
     "test:php-browser-callback-contracts": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-browser-callback-contracts-smoke.php",
+    "test:php-browser-runtime-local-package": "php scripts/php-browser-runtime-local-package-smoke.php",
     "test:mcp-client-configs": "tsx tests/mcp-client-configs.test.ts",
     "test:runtime-tool-policy": "tsx tests/runtime-tool-policy.test.ts",
     "test:primitive-contract-parity": "tsx tests/primitive-contract-parity.test.ts",

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -32,16 +32,25 @@ private static function normalize_browser_mu_plugins( array $mu_plugins ): array
 			}
 
 			if ( '' !== $source_path ) {
-				if ( ! is_dir( $source_path ) ) {
-					return new WP_Error( 'wp_codebox_browser_mu_plugin_path_missing', 'Browser mu-plugin path does not exist.', array( 'status' => 400, 'index' => $index, 'slug' => $slug ) );
-				}
+				if ( is_file( $source_path ) && str_ends_with( strtolower( $source_path ), '.zip' ) ) {
+					$package    = self::browser_package_local_archive( $slug, $source_path, $index, (string) ( $mu_plugin['sha256'] ?? '' ), 'plugin' );
+					$provenance = array(
+						'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
+						'source' => 'runtime-mu-plugin-package-path',
+						'path'   => $source_path,
+					);
+				} else {
+					if ( ! is_dir( $source_path ) ) {
+						return new WP_Error( 'wp_codebox_browser_mu_plugin_path_missing', 'Browser mu-plugin path does not exist.', array( 'status' => 400, 'index' => $index, 'slug' => $slug ) );
+					}
 
-				$package    = self::browser_package_component_plugin( $slug, $source_path );
-				$provenance = array(
-					'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
-					'source' => 'runtime-mu-plugin-path',
-					'path'   => $source_path,
-				);
+					$package    = self::browser_package_component_plugin( $slug, $source_path );
+					$provenance = array(
+						'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
+						'source' => 'runtime-mu-plugin-path',
+						'path'   => $source_path,
+					);
+				}
 			} else {
 				$package    = self::browser_remote_mu_plugin_package( $slug, $source_url, $index, (string) ( $mu_plugin['sha256'] ?? '' ) );
 				$provenance = array(
@@ -824,6 +833,63 @@ private static function browser_package_remote_plugin( string $slug, string $url
 	}
 
 	return self::browser_package_remote_archive( $slug, $source['url'], $index, $expected_sha256, 'plugin' );
+}
+
+/** @return array{url:string,fetch_url:string,path:string,sha256:string}|WP_Error */
+private static function browser_package_local_archive( string $slug, string $source_path, int $index, string $expected_sha256, string $kind ): array|WP_Error {
+	if ( ! is_file( $source_path ) || ! is_readable( $source_path ) ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_package_path_missing', 'Browser runtime package path does not exist.', array( 'status' => 400, 'index' => $index, 'slug' => $slug ) );
+	}
+
+	$source_sha256 = hash_file( 'sha256', $source_path );
+	if ( ! is_string( $source_sha256 ) ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_package_hash_failed', 'Could not hash browser runtime package.', array( 'status' => 500, 'slug' => $slug ) );
+	}
+
+	$expected_sha256 = strtolower( trim( $expected_sha256 ) );
+	if ( '' !== $expected_sha256 && ! preg_match( '/^[a-f0-9]{64}$/', $expected_sha256 ) ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_sha256_invalid', 'Browser runtime package sha256 must be a 64-character hex digest.', array( 'status' => 400, 'index' => $index, 'slug' => $slug ) );
+	}
+
+	if ( '' !== $expected_sha256 && ! hash_equals( $expected_sha256, $source_sha256 ) ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_package_hash_mismatch', 'Browser runtime package does not match the expected sha256.', array( 'status' => 400, 'slug' => $slug ) );
+	}
+
+	$upload = function_exists( 'wp_upload_dir' ) ? wp_upload_dir() : array( 'basedir' => sys_get_temp_dir(), 'baseurl' => '' );
+	if ( ! is_array( $upload ) || empty( $upload['basedir'] ) ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_upload_dir_missing', 'Browser runtime packaging requires an upload directory.', array( 'status' => 500, 'slug' => $slug ) );
+	}
+
+	$directory = 'theme' === $kind ? 'browser-runtime-themes' : 'browser-runtime-plugins';
+	$base_dir  = rtrim( (string) $upload['basedir'], '/\\' ) . DIRECTORY_SEPARATOR . 'wp-codebox' . DIRECTORY_SEPARATOR . $directory;
+	if ( ! is_dir( $base_dir ) && ! mkdir( $base_dir, 0777, true ) ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_package_dir_failed', 'Could not create browser runtime package directory.', array( 'status' => 500, 'slug' => $slug ) );
+	}
+
+	$package_id = substr( hash( 'sha256', $slug . "\n" . $source_path . "\n" . $source_sha256 ), 0, 16 );
+	$zip_path   = $base_dir . DIRECTORY_SEPARATOR . $slug . '-' . $package_id . '.zip';
+	if ( ! is_file( $zip_path ) && ! copy( $source_path, $zip_path ) ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_package_write_failed', 'Could not write browser runtime package.', array( 'status' => 500, 'slug' => $slug ) );
+	}
+
+	$base_url = is_array( $upload ) && ! empty( $upload['baseurl'] ) ? rtrim( (string) $upload['baseurl'], '/' ) : '';
+	$url      = '' !== $base_url ? $base_url . '/wp-codebox/' . $directory . '/' . rawurlencode( basename( $zip_path ) ) : '';
+	if ( '' === $url ) {
+		return new WP_Error( 'wp_codebox_browser_' . $kind . '_package_url_missing', 'Browser runtime package URL is missing.', array( 'status' => 500, 'slug' => $slug ) );
+	}
+
+	$safe_url     = self::browser_safe_local_package_url( $url );
+	$delivery_url = self::browser_plugin_delivery_url( $zip_path, $safe_url, $slug );
+	if ( is_wp_error( $delivery_url ) ) {
+		return $delivery_url;
+	}
+
+	return array(
+		'url'       => $delivery_url,
+		'fetch_url' => $safe_url,
+		'path'      => $zip_path,
+		'sha256'    => $source_sha256,
+	);
 }
 
 /** @return array{url:string,fetch_url:string,path:string,sha256:string}|WP_Error */

--- a/scripts/php-browser-runtime-local-package-smoke.php
+++ b/scripts/php-browser-runtime-local-package-smoke.php
@@ -1,0 +1,148 @@
+<?php
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	/** @var array<string,mixed> */
+	private array $data;
+
+	/** @param array<string,mixed> $data */
+	public function __construct( string $code = '', string $message = '', array $data = array() ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	/** @return array<string,mixed> */
+	public function get_error_data(): array {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+/** @return array{basedir:string,baseurl:string} */
+function wp_upload_dir(): array {
+	return array(
+		'basedir' => sys_get_temp_dir() . '/wp-codebox-local-package-smoke/uploads',
+		'baseurl' => 'https://example.test/wp-content/uploads',
+	);
+}
+
+/** @return array<string,mixed>|false */
+function wp_parse_url( string $url ): array|false {
+	return parse_url( $url );
+}
+
+function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+	return $value;
+}
+
+function sanitize_key( string $key ): string {
+	return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', $key ) ?? '' );
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-path-policy.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php';
+
+final class WP_Codebox_Browser_Runtime_Local_Package_Smoke {
+	use WP_Codebox_Abilities_Browser_Runtime;
+
+	/** @param array<int,mixed> $mu_plugins @return array<int,array<string,mixed>>|WP_Error */
+	public static function normalize( array $mu_plugins ): array|WP_Error {
+		$method = new ReflectionMethod( self::class, 'normalize_browser_mu_plugins' );
+		return $method->invoke( null, $mu_plugins );
+	}
+}
+
+function fail( string $message ): void {
+	fwrite( STDERR, $message . PHP_EOL );
+	exit( 1 );
+}
+
+function remove_tree( string $path ): void {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
+
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $iterator as $item ) {
+		if ( $item instanceof SplFileInfo && $item->isDir() ) {
+			rmdir( $item->getPathname() );
+		} elseif ( $item instanceof SplFileInfo ) {
+			unlink( $item->getPathname() );
+		}
+	}
+	rmdir( $path );
+}
+
+$root = sys_get_temp_dir() . '/wp-codebox-local-package-smoke';
+remove_tree( $root );
+mkdir( $root . '/source', 0777, true );
+
+$zip_path = $root . '/source/runtime.zip';
+file_put_contents( $zip_path, "PK\x03\x04local-package-smoke" );
+$sha256 = hash_file( 'sha256', $zip_path );
+if ( ! is_string( $sha256 ) ) {
+	fail( 'Could not hash test package.' );
+}
+
+$normalized = WP_Codebox_Browser_Runtime_Local_Package_Smoke::normalize(
+	array(
+		array(
+			'slug'   => 'runtime-smoke',
+			'file'   => 'runtime-smoke.php',
+			'path'   => $zip_path,
+			'sha256' => $sha256,
+			'entry'  => 'runtime-smoke/runtime-smoke.php',
+		),
+	)
+);
+
+if ( is_wp_error( $normalized ) ) {
+	fail( 'Expected local package normalization to succeed, got ' . $normalized->get_error_code() . ': ' . $normalized->get_error_message() );
+}
+
+$entry = $normalized[0] ?? array();
+if ( ( $entry['sha256'] ?? '' ) !== $sha256 ) {
+	fail( 'Expected normalized package sha256 to match source package.' );
+}
+if ( ! str_starts_with( (string) ( $entry['url'] ?? '' ), 'data:application/zip;base64,' ) ) {
+	fail( 'Expected local package to use data URL delivery.' );
+}
+if ( ( $entry['provenance']['source'] ?? '' ) !== 'runtime-mu-plugin-package-path' ) {
+	fail( 'Expected local package path provenance.' );
+}
+
+$mismatch = WP_Codebox_Browser_Runtime_Local_Package_Smoke::normalize(
+	array(
+		array(
+			'slug'   => 'runtime-smoke',
+			'file'   => 'runtime-smoke.php',
+			'path'   => $zip_path,
+			'sha256' => str_repeat( '0', 64 ),
+			'entry'  => 'runtime-smoke/runtime-smoke.php',
+		),
+	)
+);
+if ( ! is_wp_error( $mismatch ) || 'wp_codebox_browser_plugin_package_hash_mismatch' !== $mismatch->get_error_code() ) {
+	fail( 'Expected sha256 mismatch to fail.' );
+}
+
+remove_tree( $root );
+fwrite( STDOUT, "PHP browser runtime local package smoke passed\n" );


### PR DESCRIPTION
## Summary
- Allow browser runtime mu-plugin specs to use a local `.zip` package path.
- Copy local packages into the existing WP Codebox browser runtime package cache.
- Validate optional package sha256 and reuse the existing local/data URL delivery flow.
- Add a PHP smoke test for local package success and hash mismatch failure.

## Testing
- `npm run test:php-browser-runtime-local-package`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the PHP implementation and smoke coverage; Chris remains responsible for review and validation.