### PR TITLE
Add browser recipe DTO

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -525,6 +525,108 @@ final class WP_Codebox_Browser_Task_Builder {
 		return function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_browser_preview_boot_config', $config, $session ) : $config;
 	}
 
+	/** @param array<string,mixed> $recipe Browser workspace recipe. @return array<string,mixed> */
+	public static function browser_recipe_dto( array $recipe ): array {
+		$runtime = is_array( $recipe['runtime'] ?? null ) ? $recipe['runtime'] : array();
+		$browser = is_array( $recipe['browser'] ?? null ) ? $recipe['browser'] : array();
+		$workflow_steps = array();
+		foreach ( is_array( $recipe['workflow']['steps'] ?? null ) ? $recipe['workflow']['steps'] : array() as $index => $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+
+			$workflow_steps[] = array_filter(
+				array(
+					'index'   => $index,
+					'command' => (string) ( $step['command'] ?? '' ),
+					'args'    => self::browser_recipe_safe_args( is_array( $step['args'] ?? null ) ? $step['args'] : array(), $browser ),
+				),
+				static fn( mixed $value ): bool => '' !== $value && array() !== $value
+			);
+		}
+
+		$dto = array_filter(
+			array(
+				'schema'        => 'wp-codebox/browser-recipe-dto/v1',
+				'source_schema' => (string) ( $recipe['schema'] ?? '' ),
+				'runtime'       => array_filter(
+					array(
+						'backend'       => (string) ( $runtime['backend'] ?? '' ),
+						'name'          => (string) ( $runtime['name'] ?? '' ),
+						'wp'            => (string) ( $runtime['wp'] ?? '' ),
+						'blueprint_ref' => self::browser_blueprint_ref( is_array( $runtime['prepared_runtime'] ?? null ) ? $runtime['prepared_runtime'] : array() ),
+					),
+					static fn( mixed $value ): bool => '' !== $value && array() !== $value
+				),
+				'inputs'        => is_array( $recipe['inputs'] ?? null ) ? self::compact_public_value( $recipe['inputs'] ) : array(),
+				'workflow'      => array_filter( array( 'steps' => $workflow_steps ), static fn( mixed $value ): bool => array() !== $value ),
+				'artifacts'     => is_array( $recipe['artifacts'] ?? null ) ? self::compact_public_value( $recipe['artifacts'] ) : array(),
+				'browser'       => self::browser_recipe_browser_dto( $browser ),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+
+		return function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_browser_recipe_dto', $dto, $recipe ) : $dto;
+	}
+
+	/** @param array<int,mixed> $args Step args. @param array<string,mixed> $browser Browser recipe metadata. @return array<int,string|array<string,mixed>> */
+	private static function browser_recipe_safe_args( array $args, array $browser ): array {
+		$safe_args = array();
+		foreach ( $args as $arg ) {
+			if ( ! is_scalar( $arg ) ) {
+				continue;
+			}
+
+			$arg = (string) $arg;
+			if ( str_starts_with( $arg, 'code=' ) ) {
+				$safe_args[] = array_filter(
+					array(
+						'kind'            => 'generated-php',
+						'runner_contract' => is_array( $browser['runner_contract'] ?? null ) ? self::browser_recipe_runner_contract_dto( $browser['runner_contract'] ) : array(),
+					),
+					static fn( mixed $value ): bool => array() !== $value && '' !== $value
+				);
+				continue;
+			}
+
+			$safe_args[] = $arg;
+		}
+
+		return $safe_args;
+	}
+
+	/** @param array<string,mixed> $browser Browser recipe metadata. @return array<string,mixed> */
+	private static function browser_recipe_browser_dto( array $browser ): array {
+		return array_filter(
+			array(
+				'execution'       => (string) ( $browser['execution'] ?? '' ),
+				'task_path'       => (string) ( $browser['task_path'] ?? '' ),
+				'result_path'     => (string) ( $browser['result_path'] ?? '' ),
+				'invocation'      => is_array( $browser['invocation'] ?? null ) ? self::compact_public_value( $browser['invocation'] ) : array(),
+				'captures'        => is_array( $browser['captures'] ?? null ) ? self::compact_public_value( $browser['captures'] ) : array(),
+				'runner_contract' => is_array( $browser['runner_contract'] ?? null ) ? self::browser_recipe_runner_contract_dto( $browser['runner_contract'] ) : array(),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $contract Browser runner contract. @return array<string,mixed> */
+	private static function browser_recipe_runner_contract_dto( array $contract ): array {
+		$dto = array( 'schema' => (string) ( $contract['schema'] ?? 'wp-codebox/browser-runner-contract/v1' ) );
+		foreach ( array( 'php_prelude', 'php_footer' ) as $field ) {
+			$value = (string) ( $contract[ $field ] ?? '' );
+			if ( '' !== $value ) {
+				$dto[ $field ] = array(
+					'type'   => 'generated-php-fragment',
+					'bytes'  => strlen( $value ),
+					'sha256' => hash( 'sha256', $value ),
+				);
+			}
+		}
+
+		return $dto;
+	}
+
 	/** @param array<string,mixed> $session Browser session or preview input. @return array<string,mixed> */
 	public static function preview_lease( array $session ): array {
 		return self::preview_lease_from_session( $session );
@@ -820,6 +922,13 @@ if ( ! function_exists( 'wp_codebox_browser_preview_lease_dto' ) ) {
 	/** @param array<string,mixed> $input Browser session or preview input. @return array<string,mixed> */
 	function wp_codebox_browser_preview_lease_dto( array $input ): array {
 		return WP_Codebox_Browser_Task_Builder::preview_lease( $input );
+	}
+}
+
+if ( ! function_exists( 'wp_codebox_browser_recipe_dto' ) ) {
+	/** @param array<string,mixed> $recipe Browser workspace recipe. @return array<string,mixed> */
+	function wp_codebox_browser_recipe_dto( array $recipe ): array {
+		return WP_Codebox_Browser_Task_Builder::browser_recipe_dto( $recipe );
 	}
 }
 

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -569,12 +569,7 @@ private static function compact_browser_playground_dto( array $playground ): arr
 
 /** @param array<string,mixed> $recipe Browser recipe. @return array<string,mixed> */
 private static function compact_browser_recipe_dto( array $recipe ): array {
-	$compact = self::compact_browser_dto_value( $recipe );
-	if ( is_array( $compact ) && isset( $compact['runtime'] ) && is_array( $compact['runtime'] ) ) {
-		unset( $compact['runtime']['blueprint'] );
-	}
-
-	return is_array( $compact ) ? $compact : array();
+	return WP_Codebox_Browser_Task_Builder::browser_recipe_dto( $recipe );
 }
 
 private static function compact_browser_dto_value( mixed $value, string $key = '' ): mixed {

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -180,7 +180,36 @@ $GLOBALS['wp_codebox_test_transients']['wp_codebox_browser_prepared_runtime_' . 
 );
 $hydrated_blueprint = WP_Codebox_Browser_Task_Builder::hydrate_browser_blueprint_ref( array( 'ref' => $blueprint_ref['ref'] ) );
 
-echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'plan_contract' => $plan_contract, 'plan_plugin_specs' => $plan_plugin_specs, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request, 'product_session' => $product_session, 'blueprint_ref' => $blueprint_ref, 'hydrated_blueprint' => $hydrated_blueprint ), JSON_UNESCAPED_SLASHES );
+$recipe_dto = WP_Codebox_Browser_Task_Builder::browser_recipe_dto( array(
+	'schema' => 'wp-codebox/workspace-recipe/v1',
+	'runtime' => array(
+		'backend' => 'wordpress-playground',
+		'name' => 'browser-playground',
+		'wp' => 'latest',
+		'blueprint' => array( 'steps' => array( array( 'step' => 'runPHP', 'code' => 'must-not-leak' ) ) ),
+	),
+	'workflow' => array(
+		'steps' => array(
+			array(
+				'command' => 'wordpress.run-php',
+				'args' => array( 'code=<?php /* WP_CODEBOX_BROWSER_RUNNER_BODY_START */ must-not-leak /* WP_CODEBOX_BROWSER_RUNNER_BODY_END */' ),
+			),
+		),
+	),
+	'browser' => array(
+		'execution' => 'php-wasm',
+		'task_path' => '/tmp/task.json',
+		'result_path' => '/tmp/result.json',
+		'runner_contract' => array(
+			'schema' => 'wp-codebox/browser-runner-contract/v1',
+			'php_prelude' => '<?php function generated_prelude() { return "must-not-leak"; }',
+			'php_footer' => '<?php function generated_footer() { return "must-not-leak"; }',
+		),
+		'task_payload' => array( 'secret' => 'must-not-leak' ),
+	),
+) );
+
+echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'plan_contract' => $plan_contract, 'plan_plugin_specs' => $plan_plugin_specs, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request, 'product_session' => $product_session, 'blueprint_ref' => $blueprint_ref, 'hydrated_blueprint' => $hydrated_blueprint, 'recipe_dto' => $recipe_dto ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.task_input.schema, "wp-codebox/task-input/v1")
@@ -255,5 +284,14 @@ assert.equal(result.blueprint_ref.schema, "wp-codebox/browser-blueprint-ref/v1")
 assert.equal(result.blueprint_ref.ref, `prepared:runtime-cache-key:${"b".repeat(64)}`)
 assert.equal(result.hydrated_blueprint.schema, "wp-codebox/browser-blueprint-hydration/v1")
 assert.equal(result.hydrated_blueprint.blueprint.steps[0].step, "login")
+assert.equal(result.recipe_dto.schema, "wp-codebox/browser-recipe-dto/v1")
+assert.equal(result.recipe_dto.source_schema, "wp-codebox/workspace-recipe/v1")
+assert.equal(result.recipe_dto.runtime.backend, "wordpress-playground")
+assert.equal(result.recipe_dto.workflow.steps[0].args[0].kind, "generated-php")
+assert.equal(result.recipe_dto.workflow.steps[0].args[0].runner_contract.php_prelude.type, "generated-php-fragment")
+assert.equal(result.recipe_dto.browser.runner_contract.php_footer.type, "generated-php-fragment")
+assert.equal(JSON.stringify(result.recipe_dto).includes("must-not-leak"), false)
+assert.equal(JSON.stringify(result.recipe_dto).includes("code="), false)
+assert.equal(JSON.stringify(result.recipe_dto).includes("php_prelude\":\""), false)
 
 console.log("browser task builder ok")


### PR DESCRIPTION
## Summary
- Add a generic `wp-codebox/browser-recipe-dto/v1` representation for browser workspace recipes.
- Replace generated PHP workflow args with structured runner contract descriptors.
- Use the DTO for compact browser recipe output so consumers do not inspect generated PHP internals.

## Verification
- `npm run test:browser-task-builder`
- `npx tsx tests/browser-blueprint-ref-endpoint.test.ts`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and targeted tests; Chris remains responsible for review and validation.