### PR TITLE
Add browser contained site status primitives

### DIFF
--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -52,6 +52,66 @@ registers runtime-principal authorization. If the runner is copied into a normal
 host WordPress install, it fails with `wp_codebox_browser_runner_not_playground`
 instead of executing the requested sandbox invocation.
 
+## Browser Contained Site Handle
+
+Browser session, materializer, and task contracts include an additive durable
+handle for caller-owned preview recovery:
+
+```json
+{
+  "contained_site": {
+    "schema": "wp-codebox/browser-contained-site/v1",
+    "site_id": "prepared-a1b2c3d4e5f6a7b8",
+    "preview_id": "preview-1234abcd5678ef90",
+    "session_id": "browser-session-123",
+    "caller_id": "studio-native",
+    "status": "ready",
+    "persistence": "browser-contained",
+    "source_digest": {
+      "algorithm": "sha256",
+      "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "recovery": {
+      "ability": "wp-codebox/get-browser-contained-site-status",
+      "input": {
+        "cache_key": "prepared-a1b2c3d4e5f6a7b8",
+        "input_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "source_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    }
+  }
+}
+```
+
+The handle is intentionally a primitive, not a parent-product lifecycle table.
+`site_id` is stable for the caller plus normalized runtime/source inputs, and
+`preview_id` is stable for the contained site plus browser session. The
+`source_digest` is the prepared-runtime `input_hash` when available, or a stable
+hash of the browser runtime, blueprint, site blueprint artifact, and Playground
+version inputs.
+
+Call `wp-codebox/get-browser-contained-site-status` with `cache_key` or `site_id`
+plus `input_hash` or `source_digest` to check whether WP Codebox can recover the
+prepared-runtime blueprint from its transient cache:
+
+```json
+{
+  "success": true,
+  "schema": "wp-codebox/browser-contained-site-status/v1",
+  "site_id": "prepared-a1b2c3d4e5f6a7b8",
+  "status": "recoverable",
+  "blueprint_ref": {
+    "schema": "wp-codebox/browser-blueprint-ref/v1",
+    "ref": "prepared:prepared-a1b2c3d4e5f6a7b8:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+}
+```
+
+Status is idempotent and read-only. `recoverable` means the prepared runtime
+transient exists and can hydrate a blueprint ref. `miss` means the caller should
+create a new browser session from the same inputs. Durable ownership, UI state,
+and retry policy still belong to the parent control plane.
+
 ## Browser Provider Adapter Contract
 
 Browser Playground provider calls that need parent-side connector authorization

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:redaction": "tsx tests/redaction.test.ts",
     "test:agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",
     "test:browser-task-builder": "tsx tests/browser-task-builder.test.ts",
+    "test:browser-contained-site-status": "tsx tests/browser-contained-site-status.test.ts",
     "test:host-recipe-builder": "tsx tests/host-recipe-builder.test.ts",
     "test:runtime-recipe-resolver": "tsx tests/runtime-recipe-resolver.test.ts",
     "test:runtime-episode-contracts": "tsx tests/runtime-episode-contracts.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -531,6 +531,7 @@ final class WP_Codebox_Abilities {
 					'browser_connector_request_schema' => self::browser_connector_request_schema(),
 					'browser_connector_response_schema' => self::browser_connector_response_schema(),
 					'browser_materializer_contract_schema' => self::browser_materializer_contract_schema(),
+					'browser_contained_site_schema' => self::browser_contained_site_schema(),
 					'browser_task_contract_schema' => self::browser_task_contract_schema(),
 					'browser_task_phase_kinds'    => self::browser_task_phase_kinds(),
 					'trusted_artifact_authorization_schema' => self::trusted_orchestrator_authorization_schema( self::BROWSER_ARTIFACT_WRITE_SCOPE, 'Explicit trusted orchestrator authorization for browser artifact persistence. Callers must provide a caller id and the artifact:write scope; sites grant trust through wp_codebox_trusted_browser_session_callers.' ),

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
@@ -120,6 +120,36 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 				'permission_callback' => array( WP_Codebox_Abilities::class, 'can_create_browser_playground_session' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			),
+			'wp-codebox/get-browser-contained-site-status'    => array(
+				'label'               => 'Get Browser Contained Site Status',
+				'description'         => 'Resolve a durable browser-contained site handle into recoverable prepared-runtime status without creating a new Playground session.',
+				'category'            => 'wp-codebox',
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'contained_site' => $context['browser_contained_site_schema'],
+						'site_id'       => array( 'type' => 'string' ),
+						'cache_key'     => array( 'type' => 'string' ),
+						'source_digest' => array( 'type' => 'string' ),
+						'input_hash'    => array( 'type' => 'string' ),
+					),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'schema'        => array( 'type' => 'string', 'const' => 'wp-codebox/browser-contained-site-status/v1' ),
+						'site_id'       => array( 'type' => 'string' ),
+						'source_digest' => array( 'type' => 'object' ),
+						'status'        => array( 'type' => 'string' ),
+						'prepared_runtime' => array( 'type' => 'object' ),
+						'blueprint_ref' => array( 'type' => 'object' ),
+					),
+				),
+				'execute_callback'    => array( WP_Codebox_Abilities::class, 'get_browser_contained_site_status' ),
+				'permission_callback' => array( WP_Codebox_Abilities::class, 'can_create_browser_playground_session' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			),
 			'wp-codebox/browser-connector-request'            => array(
 				'label'               => 'Run Browser Connector Request',
 				'description'         => 'Resolve connector credentials server-side and dispatch a generic browser connector request without exposing raw secrets to the browser sandbox.',

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -286,6 +286,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'execution_scope'  => (string) ( $session['execution_scope'] ?? '' ),
 				'permission_model' => (string) ( $session['permission_model'] ?? '' ),
 				'session_id'       => (string) ( $session_envelope['id'] ?? $session['session_id'] ?? '' ),
+				'contained_site'   => is_array( $session['contained_site'] ?? null ) ? self::compact_public_value( $session['contained_site'] ) : array(),
 				'task'             => (string) ( $session['task'] ?? $task_input['goal'] ?? '' ),
 				'target'           => is_array( $task_input['target'] ?? null ) ? self::compact_public_value( $task_input['target'] ) : array(),
 				'agent'            => (string) ( $session['agent'] ?? '' ),
@@ -503,6 +504,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'blueprint_ref'     => '' !== (string) ( $blueprint_ref['ref'] ?? '' ) ? (string) $blueprint_ref['ref'] : ( '' !== $legacy_blueprint_ref ? $legacy_blueprint_ref : 'inline-session-blueprint' ),
 				'blueprint_ref_dto' => '' !== (string) ( $blueprint_ref['ref'] ?? '' ) ? $blueprint_ref : array(),
 				'preview'           => self::preview_lease_from_session( $session ),
+				'contained_site'    => is_array( $session['contained_site'] ?? null ) ? self::compact_public_value( $session['contained_site'] ) : array(),
 				'artifacts'         => array_filter(
 					array(
 						'base_path'   => (string) ( $playground['artifact_base_path'] ?? '' ),

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -75,8 +75,9 @@ public static function create_browser_playground_session( array $input ): array|
 	$blueprint      = self::browser_blueprint_with_runtime( $base_blueprint, $runtime, $playground );
 	$prepared_runtime = self::browser_prepared_runtime_with_blueprints( is_array( $runtime['prepared_runtime'] ?? null ) ? $runtime['prepared_runtime'] : array(), $blueprint, $playground );
 	$runtime['prepared_runtime'] = $prepared_runtime;
-	$blueprint = self::browser_selected_prepared_runtime_blueprint( $prepared_runtime, $blueprint );
-	$artifacts      = self::browser_artifact_files( $input );
+	$blueprint       = self::browser_selected_prepared_runtime_blueprint( $prepared_runtime, $blueprint );
+	$contained_site  = self::browser_contained_site_envelope( $input, $session_id, $playground, $runtime, $prepared_runtime, 'ready' );
+	$artifacts       = self::browser_artifact_files( $input );
 	if ( is_wp_error( $artifacts ) ) {
 		return $artifacts;
 	}
@@ -108,6 +109,7 @@ public static function create_browser_playground_session( array $input ): array|
 		'inheritance' => $inheritance_payload['inheritance'],
 		'plugins'    => $browser_plugins,
 		'runtime'    => $runtime,
+		'contained_site' => $contained_site,
 		'site_blueprint_artifact' => $site_blueprint_artifact,
 		'materialization' => $materialization,
 		'playground' => array(
@@ -120,6 +122,7 @@ public static function create_browser_playground_session( array $input ): array|
 			'preview_url'        => self::browser_preview_url( $artifacts, $playground ),
 			'blueprint'          => self::browser_playground_blueprint( $blueprint, $playground ),
 			'prepared_runtime'   => $prepared_runtime,
+			'contained_site'     => $contained_site,
 			'capabilities'       => array(
 				'compile_blueprint' => true,
 				'run_blueprint'     => true,
@@ -139,6 +142,30 @@ public static function create_browser_playground_session( array $input ): array|
 			'expected_artifacts' => $task_input['expected_artifacts'],
 		),
 	);
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+public static function get_browser_contained_site_status( array $input ): array|WP_Error {
+	$contained_site = is_array( $input['contained_site'] ?? null ) ? $input['contained_site'] : array();
+	$recovery       = is_array( $contained_site['recovery']['input'] ?? null ) ? $contained_site['recovery']['input'] : array();
+	$prepared       = is_array( $contained_site['prepared_runtime'] ?? null ) ? $contained_site['prepared_runtime'] : array();
+	$source_digest  = is_array( $input['source_digest'] ?? null ) ? (string) ( $input['source_digest']['value'] ?? '' ) : (string) ( $input['source_digest'] ?? '' );
+	if ( '' === $source_digest && is_array( $contained_site['source_digest'] ?? null ) ) {
+		$source_digest = (string) ( $contained_site['source_digest']['value'] ?? '' );
+	}
+
+	$cache_key  = self::safe_key( (string) ( $input['cache_key'] ?? $recovery['cache_key'] ?? $prepared['cache_key'] ?? $input['site_id'] ?? $contained_site['site_id'] ?? '' ) );
+	$input_hash = strtolower( trim( (string) ( $input['input_hash'] ?? $recovery['input_hash'] ?? $prepared['input_hash'] ?? $source_digest ) ) );
+	if ( '' === $cache_key || ! preg_match( '/^[a-f0-9]{64}$/', $input_hash ) ) {
+		return new WP_Error( 'wp_codebox_browser_contained_site_ref_invalid', 'Browser contained site status requires cache_key/site_id and a 64-character source digest.', array( 'status' => 400 ) );
+	}
+
+	$prepared_ref = array(
+		'cache_key'  => $cache_key,
+		'input_hash' => $input_hash,
+	);
+	$lookup = self::browser_prepared_runtime_cache_lookup( $prepared_ref );
+	return self::browser_contained_site_status_envelope( $cache_key, $input_hash, $lookup );
 }
 
 /** @param array<string,mixed> $input Blueprint ref input. @return array<string,mixed>|WP_Error */
@@ -165,6 +192,7 @@ public static function create_browser_materializer_contract( array $input ): arr
 				'status'           => (string) ( $session['status'] ?? 'blocked' ),
 				'error'            => is_array( $session['error'] ?? null ) ? $session['error'] : array(),
 				'session_id'       => (string) ( $session_envelope['id'] ?? '' ),
+				'contained_site'   => is_array( $session['contained_site'] ?? null ) ? $session['contained_site'] : array(),
 				'authorization'    => is_array( $session_envelope['authorization'] ?? null ) ? $session_envelope['authorization'] : self::browser_session_authorization( $input ),
 				'signals'          => is_array( $session['signals'] ?? null ) ? $session['signals'] : array(),
 			),
@@ -184,6 +212,7 @@ public static function create_browser_materializer_contract( array $input ): arr
 		'execution_scope'  => 'disposable-playground',
 		'permission_model' => 'runtime-principal',
 		'session_id'       => (string) ( $session_envelope['id'] ?? '' ),
+		'contained_site'   => is_array( $session['contained_site'] ?? null ) ? $session['contained_site'] : array(),
 		'authorization'    => is_array( $session_envelope['authorization'] ?? null ) ? $session_envelope['authorization'] : self::browser_session_authorization( $input ),
 		'task_input'       => is_array( $session['task_input'] ?? null ) ? $session['task_input'] : array(),
 		'task_payload'     => is_array( $session['task_payload'] ?? null ) ? $session['task_payload'] : array(),
@@ -231,6 +260,7 @@ private static function prepare_browser_task_contract( array $input ): array|WP_
 				'status'           => (string) ( $primary['status'] ?? 'blocked' ),
 				'error'            => is_array( $primary['error'] ?? null ) ? $primary['error'] : array(),
 				'session'          => $session_envelope,
+				'contained_site'   => is_array( $primary['contained_site'] ?? null ) ? $primary['contained_site'] : array(),
 				'primary'          => $primary,
 				'phases'           => array(),
 				'execution_metrics' => self::browser_contract_execution_metrics( $primary, array() ),
@@ -254,6 +284,7 @@ private static function prepare_browser_task_contract( array $input ): array|WP_
 		'execution_scope'  => 'disposable-playground',
 		'permission_model' => 'runtime-principal',
 		'session'          => $session_envelope,
+		'contained_site'   => is_array( $primary['contained_site'] ?? null ) ? $primary['contained_site'] : array(),
 		'primary'          => $primary,
 		'phases'           => $phases,
 		'execution_metrics' => self::browser_contract_execution_metrics( $primary, $phases ),
@@ -560,6 +591,7 @@ private static function compact_browser_playground_dto( array $playground ): arr
 			'artifact_base_path' => (string) ( $playground['artifact_base_path'] ?? '' ),
 			'artifact_base_url'  => (string) ( $playground['artifact_base_url'] ?? '' ),
 			'preview_url'        => (string) ( $playground['preview_url'] ?? '' ),
+			'contained_site'     => is_array( $playground['contained_site'] ?? null ) ? self::compact_browser_dto_value( $playground['contained_site'] ) : array(),
 			'capabilities'       => is_array( $playground['capabilities'] ?? null ) ? self::compact_browser_dto_value( $playground['capabilities'] ) : array(),
 			'provenance'         => is_array( $playground['provenance'] ?? null ) ? self::compact_browser_dto_value( $playground['provenance'] ) : array(),
 		),
@@ -829,6 +861,9 @@ private static function host_delegation_result( bool $success, string $status, a
  * @return array<string,mixed>
  */
 private static function blocked_browser_playground_session( string $session_id, array $input, array $task_input, array $ready_to_code, array $browser_plugins, array $runtime, array $artifacts, array $playground, array $blueprint, array $site_blueprint_artifact ): array {
+	$prepared_runtime = is_array( $runtime['prepared_runtime'] ?? null ) ? $runtime['prepared_runtime'] : array();
+	$contained_site   = self::browser_contained_site_envelope( $input, $session_id, $playground, $runtime, $prepared_runtime, 'blocked' );
+
 	return array(
 		'success'          => false,
 		'schema'           => 'wp-codebox/browser-playground-session/v1',
@@ -847,6 +882,7 @@ private static function blocked_browser_playground_session( string $session_id, 
 		'agent'      => (string) ( $input['agent'] ?? 'wp-codebox-sandbox' ),
 		'plugins'    => $browser_plugins,
 		'runtime'    => $runtime,
+		'contained_site' => $contained_site,
 		'site_blueprint_artifact' => $site_blueprint_artifact,
 		'materialization' => array(
 			'schema' => 'wp-codebox/browser-materialization/v1',
@@ -862,6 +898,8 @@ private static function blocked_browser_playground_session( string $session_id, 
 			'artifact_base_url'  => self::browser_artifact_base_url( $playground ),
 			'preview_url'        => self::browser_preview_url( $artifacts, $playground ),
 			'blueprint'          => self::browser_playground_blueprint( $blueprint, $playground ),
+			'prepared_runtime'   => $prepared_runtime,
+			'contained_site'     => $contained_site,
 			'capabilities'       => array(
 				'compile_blueprint' => true,
 				'run_blueprint'     => true,
@@ -880,6 +918,117 @@ private static function blocked_browser_playground_session( string $session_id, 
 			'expected_artifacts' => $task_input['expected_artifacts'],
 		),
 	);
+}
+
+/** @return array<string,mixed> */
+private static function browser_contained_site_envelope( array $input, string $session_id, array $playground, array $runtime, array $prepared_runtime, string $status ): array {
+	$source_digest = self::browser_contained_site_source_digest( $input, $playground, $runtime, $prepared_runtime );
+	$caller_id     = self::browser_contained_site_caller_id( $input );
+	$cache_key     = self::safe_key( (string) ( $prepared_runtime['cache_key'] ?? '' ) );
+	if ( '' === $cache_key ) {
+		$cache_key = 'site-' . substr( hash( 'sha256', $caller_id . ':' . $source_digest ), 0, 16 );
+	}
+	$site_id    = $cache_key;
+	$preview_id = 'preview-' . substr( hash( 'sha256', $site_id . ':' . $session_id ), 0, 16 );
+
+	return array_filter(
+		array(
+			'schema'        => 'wp-codebox/browser-contained-site/v1',
+			'site_id'       => $site_id,
+			'preview_id'    => $preview_id,
+			'session_id'    => $session_id,
+			'caller_id'     => $caller_id,
+			'status'        => $status,
+			'persistence'   => 'browser-contained',
+			'recovery'      => array(
+				'ability' => 'wp-codebox/get-browser-contained-site-status',
+				'input'   => array(
+					'cache_key'     => $cache_key,
+					'input_hash'    => $source_digest,
+					'source_digest' => $source_digest,
+				),
+			),
+			'source_digest' => array(
+				'algorithm' => 'sha256',
+				'value'     => $source_digest,
+			),
+			'preview'       => array_filter(
+				array(
+					'preview_public_url' => (string) ( $playground['preview_public_url'] ?? '' ),
+					'local_url'          => self::browser_preview_url( array(), $playground ),
+					'scope'              => (string) ( $playground['scope'] ?? $session_id ),
+				),
+				static fn( string $value ): bool => '' !== $value
+			),
+			'prepared_runtime' => array_filter(
+				array(
+					'cache_key'  => $cache_key,
+					'input_hash' => $source_digest,
+					'status'     => (string) ( $prepared_runtime['status'] ?? '' ),
+					'selected'   => (string) ( $prepared_runtime['selected'] ?? '' ),
+				),
+				static fn( string $value ): bool => '' !== $value
+			),
+		),
+		static fn( mixed $value ): bool => array() !== $value && '' !== $value
+	);
+}
+
+/** @return array<string,mixed> */
+private static function browser_contained_site_status_envelope( string $cache_key, string $input_hash, array $lookup ): array {
+	$artifact = is_array( $lookup['artifact'] ?? null ) ? $lookup['artifact'] : array();
+	$status   = 'hit' === (string) ( $lookup['status'] ?? '' ) ? 'recoverable' : (string) ( $lookup['status'] ?? 'miss' );
+
+	return array_filter(
+		array(
+			'success'       => 'recoverable' === $status,
+			'schema'        => 'wp-codebox/browser-contained-site-status/v1',
+			'site_id'       => $cache_key,
+			'status'        => $status,
+			'source_digest' => array(
+				'algorithm' => 'sha256',
+				'value'     => $input_hash,
+			),
+			'prepared_runtime' => array_filter(
+				array(
+					'cache_key'  => $cache_key,
+					'input_hash' => $input_hash,
+					'status'     => (string) ( $lookup['status'] ?? '' ),
+					'created_at' => (string) ( $artifact['created_at'] ?? '' ),
+				),
+				static fn( string $value ): bool => '' !== $value
+			),
+			'blueprint_ref' => 'recoverable' === $status ? WP_Codebox_Browser_Task_Builder::browser_blueprint_ref( array( 'cache_key' => $cache_key, 'input_hash' => $input_hash, 'status' => 'recoverable' ) ) : array(),
+		),
+		static fn( mixed $value ): bool => array() !== $value && '' !== $value
+	);
+}
+
+private static function browser_contained_site_source_digest( array $input, array $playground, array $runtime, array $prepared_runtime ): string {
+	$input_hash = strtolower( trim( (string) ( $prepared_runtime['input_hash'] ?? '' ) ) );
+	if ( preg_match( '/^[a-f0-9]{64}$/', $input_hash ) ) {
+		return $input_hash;
+	}
+
+	$hash_input = array(
+		'runtime'    => is_array( $runtime['prepared_runtime'] ?? null ) ? array_diff_key( $runtime, array( 'prepared_runtime' => true ) ) : $runtime,
+		'blueprint'  => is_array( $input['blueprint'] ?? null ) ? $input['blueprint'] : array(),
+		'site_blueprint_artifact' => is_array( $input['site_blueprint_artifact'] ?? null ) ? $input['site_blueprint_artifact'] : array(),
+		'playground' => array(
+			'wp'  => (string) ( $playground['wp'] ?? $input['playground']['wp'] ?? 'latest' ),
+			'php' => (string) ( $playground['php'] ?? $input['playground']['php'] ?? 'latest' ),
+		),
+	);
+
+	return hash( 'sha256', 'wp-codebox/browser-contained-site-source/v1' . "\n" . self::stable_json( $hash_input ) );
+}
+
+private static function browser_contained_site_caller_id( array $input ): string {
+	$authorization = is_array( $input['authorization'] ?? null ) ? $input['authorization'] : array();
+	$orchestrator  = is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array();
+	$caller_id     = self::safe_key( (string) ( $authorization['caller'] ?? $orchestrator['id'] ?? $orchestrator['type'] ?? '' ) );
+
+	return '' !== $caller_id ? $caller_id : 'wp-codebox';
 }
 
 /** @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -304,6 +304,7 @@ private static function browser_playground_session_schema(): array {
 				'description' => 'The generated browser runner authorizes Agents API calls through a scoped runtime principal inside the disposable Playground sandbox.',
 			),
 			'session'    => array( 'type' => 'object' ),
+			'contained_site' => self::browser_contained_site_schema(),
 			'task_input' => self::task_input_schema(),
 			'task_payload' => array( 'type' => 'object' ),
 			'playground' => array( 'type' => 'object' ),
@@ -340,6 +341,7 @@ private static function browser_materializer_contract_schema(): array {
 				'enum' => array( 'runtime-principal' ),
 			),
 			'session_id'       => array( 'type' => 'string' ),
+			'contained_site'   => self::browser_contained_site_schema(),
 			'authorization'    => array( 'type' => 'object' ),
 			'task_input'       => self::task_input_schema(),
 			'task_payload'     => array( 'type' => 'object' ),
@@ -373,6 +375,7 @@ private static function browser_task_contract_schema(): array {
 				'enum' => array( 'runtime-principal' ),
 			),
 			'session'          => array( 'type' => 'object' ),
+			'contained_site'   => self::browser_contained_site_schema(),
 			'primary'          => self::browser_playground_session_schema(),
 			'phases'           => array(
 				'type'        => 'array',
@@ -418,6 +421,7 @@ private static function browser_product_dto_schema(): array {
 			'execution_scope'  => array( 'type' => 'string' ),
 			'permission_model' => array( 'type' => 'string' ),
 			'session'          => array( 'type' => 'object' ),
+			'contained_site'   => self::browser_contained_site_schema(),
 			'primary'          => array( 'type' => 'object' ),
 			'phases'           => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
 			'task_input'       => array( 'type' => 'object' ),
@@ -427,6 +431,27 @@ private static function browser_product_dto_schema(): array {
 			'recipe'           => array( 'type' => 'object' ),
 			'artifacts'        => array( 'type' => 'object' ),
 			'execution_metrics' => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function browser_contained_site_schema(): array {
+	return array(
+		'type'        => 'object',
+		'description' => 'Durable browser-contained WordPress site handle. The parent product stores this envelope and can call the status ability to recover a prepared runtime blueprint when the transient still exists.',
+		'properties'  => array(
+			'schema'        => array( 'type' => 'string', 'const' => 'wp-codebox/browser-contained-site/v1' ),
+			'site_id'       => array( 'type' => 'string' ),
+			'preview_id'    => array( 'type' => 'string' ),
+			'session_id'    => array( 'type' => 'string' ),
+			'caller_id'     => array( 'type' => 'string' ),
+			'status'        => array( 'type' => 'string', 'enum' => array( 'ready', 'blocked', 'recoverable', 'miss', 'disabled' ) ),
+			'persistence'   => array( 'type' => 'string', 'enum' => array( 'browser-contained' ) ),
+			'recovery'      => array( 'type' => 'object' ),
+			'source_digest' => array( 'type' => 'object' ),
+			'preview'       => array( 'type' => 'object' ),
+			'prepared_runtime' => array( 'type' => 'object' ),
 		),
 	);
 }

--- a/tests/browser-contained-site-status.test.ts
+++ b/tests/browser-contained-site-status.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+
+import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
+
+const result = await runPhpJson<any>(`
+define('ABSPATH', ${phpStringLiteral(repoRoot)});
+
+class WP_Error {
+	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+}
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', (string) $value ) ); }
+function wp_create_nonce( $action = -1 ) { return 'test-rest-nonce'; }
+
+$GLOBALS['wp_codebox_test_transients'] = array();
+function get_transient( $key ) { return $GLOBALS['wp_codebox_test_transients'][ $key ] ?? false; }
+
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-blueprint.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`)};
+
+class WP_Codebox_Test_Browser_Contained_Site_Abilities {
+	use WP_Codebox_Abilities_Browser_Runtime;
+	use WP_Codebox_Abilities_Browser_Blueprint;
+	use WP_Codebox_Abilities_Execution;
+}
+
+$cache_key = 'studio-proof';
+$input_hash = str_repeat( 'c', 64 );
+$transient_key = 'wp_codebox_browser_prepared_runtime_' . substr( hash( 'sha256', $cache_key . ':' . $input_hash ), 0, 24 );
+$GLOBALS['wp_codebox_test_transients'][ $transient_key ] = array(
+	'schema' => 'wp-codebox/browser-prepared-runtime-artifact/v1',
+	'cache_key' => $cache_key,
+	'input_hash' => $input_hash,
+	'created_at' => '2026-06-18T00:00:00+00:00',
+	'blueprint' => array( 'steps' => array( array( 'step' => 'login' ) ) ),
+);
+
+$hit = WP_Codebox_Test_Browser_Contained_Site_Abilities::get_browser_contained_site_status( array(
+	'contained_site' => array(
+		'site_id' => $cache_key,
+		'source_digest' => array( 'algorithm' => 'sha256', 'value' => $input_hash ),
+		'recovery' => array( 'input' => array( 'cache_key' => $cache_key, 'input_hash' => $input_hash ) ),
+	),
+) );
+$miss = WP_Codebox_Test_Browser_Contained_Site_Abilities::get_browser_contained_site_status( array(
+	'site_id' => $cache_key,
+	'input_hash' => str_repeat( 'd', 64 ),
+) );
+
+echo json_encode( array( 'hit' => $hit, 'miss' => $miss ), JSON_UNESCAPED_SLASHES );
+`)
+
+assert.equal(result.hit.schema, "wp-codebox/browser-contained-site-status/v1")
+assert.equal(result.hit.success, true)
+assert.equal(result.hit.site_id, "studio-proof")
+assert.equal(result.hit.status, "recoverable")
+assert.equal(result.hit.source_digest.value, "c".repeat(64))
+assert.equal(result.hit.blueprint_ref.ref, `prepared:studio-proof:${"c".repeat(64)}`)
+assert.equal(result.miss.success, false)
+assert.equal(result.miss.status, "miss")
+
+console.log("browser contained site status ok")

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -168,6 +168,14 @@ $product_session = WP_Codebox_Browser_Task_Builder::product_browser_session_dto(
 		'preview_url' => '/?preview=1',
 		'prepared_runtime' => array( 'cache_key' => 'runtime-cache-key', 'input_hash' => str_repeat( 'a', 64 ), 'status' => 'hit', 'blueprint' => array( 'must' => 'not leak' ) ),
 	),
+	'contained_site' => array(
+		'schema' => 'wp-codebox/browser-contained-site/v1',
+		'site_id' => 'runtime-cache-key',
+		'preview_id' => 'preview-123',
+		'session_id' => 'session-123',
+		'status' => 'ready',
+		'source_digest' => array( 'algorithm' => 'sha256', 'value' => str_repeat( 'a', 64 ) ),
+	),
 	'artifacts' => array( 'preview_url' => '/?preview=1' ),
 ) );
 
@@ -270,7 +278,10 @@ assert.equal(result.fanout_request.workers[0].schema, "wp-codebox/agent-fanout-w
 assert.equal(result.fanout_request.workers[0].id, "planner-worker")
 assert.equal(result.product_session.schema, "wp-codebox/browser-session-product-dto/v1")
 assert.equal(result.product_session.session_id, "session-123")
+assert.equal(result.product_session.contained_site.schema, "wp-codebox/browser-contained-site/v1")
+assert.equal(result.product_session.contained_site.site_id, "runtime-cache-key")
 assert.equal(result.product_session.preview_boot.schema, "wp-codebox/browser-preview-boot-config/v1")
+assert.equal(result.product_session.preview_boot.contained_site.site_id, "runtime-cache-key")
 assert.equal(result.product_session.preview_boot.blueprint_ref, `prepared:runtime-cache-key:${"a".repeat(64)}`)
 assert.equal(result.product_session.preview_boot.blueprint_ref_dto.schema, "wp-codebox/browser-blueprint-ref/v1")
 assert.equal(result.product_session.preview_boot.blueprint_ref_dto.ref, `prepared:runtime-cache-key:${"a".repeat(64)}`)


### PR DESCRIPTION
## Summary
- Add a `wp-codebox/browser-contained-site/v1` envelope to browser Playground/materializer/task contracts.
- Add `wp-codebox/get-browser-contained-site-status` for read-only recovery/status checks backed by prepared-runtime cache state.
- Document the contained-site status contract and add focused coverage.

## Testing
- `npm run test:browser-contained-site-status`
- `npm run test:browser-task-builder`
- PHP lint for touched WordPress plugin files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the contained-site primitive implementation, docs, and tests; Chris remains responsible for review and validation.