### PR TITLE
Add RuntimeRunResult to run registry

### DIFF
--- a/packages/cli/src/commands/recipe-run-finalizer.ts
+++ b/packages/cli/src/commands/recipe-run-finalizer.ts
@@ -1,6 +1,6 @@
 import { readdir, stat } from "node:fs/promises"
 import { resolve } from "node:path"
-import { artifactBundleRunRef, normalizeRecipeRunSummary, type ArtifactBundle, type RuntimeInfo, type RuntimeRunRecord, type RuntimeRunRegistry } from "@automattic/wp-codebox-core"
+import { artifactBundleRunRef, normalizeRecipeRunSummary, runtimeRunResultFromRecipeSummary, type ArtifactBundle, type RuntimeInfo, type RuntimeRunRecord, type RuntimeRunRegistry } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { serializeError } from "../output.js"
 import { finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultOutput, recipeAgentTaskResultOutput, recipeCompletionOutcomeOutput, recipeReplayStatusOutput, recipeTerminalResultOutput } from "../recipe-evidence.js"
@@ -127,7 +127,7 @@ export function completedRecipeOutputFields(args: {
 }
 
 export async function finalizeRecipeValidationFailure(args: RecipeRunFinalizerBase & { failure: RunOutput["error"]; componentContracts?: RecipeRunComponentContract[]; validation: RecipeRunOutput["validation"] }): Promise<RecipeRunOutput> {
-  const runRecord = await args.runRegistry.update(args.runRecord.runId, {
+  let runRecord = await args.runRegistry.update(args.runRecord.runId, {
     status: "failed",
     metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs: args.startedAtMs, status: "failed", failure: args.failure }) },
     error: args.failure,
@@ -142,13 +142,15 @@ export async function finalizeRecipeValidationFailure(args: RecipeRunFinalizerBa
     run: runRecord,
     error: args.failure,
   })
+  runRecord = await args.runRegistry.update(args.runRecord.runId, { result: runtimeRunResultFromRecipeSummary(output.result!) })
+  output.run = runRecord
   await args.artifactPointer.update({ command: "recipe.validate", commandStatus: "failed", failure: args.failure, result: output.result })
   return output
 }
 
 export async function finalizeCompletedRecipeRun(args: FinalizeCompletedRecipeRunOptions): Promise<RecipeRunOutput> {
   const status = args.success ? "succeeded" : "failed"
-  const runRecord = await args.runRegistry.update(args.runRecord.runId, {
+  let runRecord = await args.runRegistry.update(args.runRecord.runId, {
     status,
     runtime: args.runtime,
     preview: args.artifacts.preview,
@@ -169,13 +171,15 @@ export async function finalizeCompletedRecipeRun(args: FinalizeCompletedRecipeRu
     run: runRecord,
     error: args.failure,
   }) as RecipeRunOutput)
+  runRecord = await args.runRegistry.update(args.runRecord.runId, { result: runtimeRunResultFromRecipeSummary(output.result!) })
+  output.run = runRecord
   await args.artifactPointer.update({ commandStatus: args.success ? "completed" : "failed", runtime: args.runtime, artifacts: args.artifacts, failure: args.failure, phases: args.phaseEvidence, browserEvidence: args.browserEvidence, result: output.result })
   return output
 }
 
 export async function finalizeRecoveredRecipeFailure(args: FinalizeRecoveredRecipeFailureOptions): Promise<RecipeRunOutput> {
   const status = recipeRunFailureStatus(args.originalError, args.interruption)
-  const runRecord = await args.runRegistry.update(args.runRecord.runId, {
+  let runRecord = await args.runRegistry.update(args.runRecord.runId, {
     status,
     ...(args.runtime ? { runtime: args.runtime } : {}),
     ...(args.artifacts ? { preview: args.artifacts.preview, artifactRefs: artifactBundleRunRef(args.artifacts) } : {}),
@@ -193,6 +197,8 @@ export async function finalizeRecoveredRecipeFailure(args: FinalizeRecoveredReci
     ...(args.interruption?.metadata ? { interruption: args.interruption.metadata } : {}),
     error: args.serializedError,
   }) as RecipeRunOutput)
+  runRecord = await args.runRegistry.update(args.runRecord.runId, { result: runtimeRunResultFromRecipeSummary(output.result!) })
+  output.run = runRecord
   await args.artifactPointer.update({ commandStatus: "failed", ...(args.runtime ? { runtime: args.runtime } : {}), ...(args.artifacts ? { artifacts: args.artifacts } : {}), failure: args.serializedError, phases: args.phaseEvidence, browserEvidence: args.browserEvidence, diagnosticArtifacts: args.diagnosticArtifacts, result: output.result })
   return output
 }

--- a/packages/cli/src/commands/runs.ts
+++ b/packages/cli/src/commands/runs.ts
@@ -29,11 +29,18 @@ export async function runRunsArtifactsCommand(args: string[]): Promise<number> {
     schema: "wp-codebox/run-artifacts/v1",
     runId: record.runId,
     status: record.status,
+    result: record.result,
+    resultArtifacts: record.result?.artifacts ?? [],
+    resultRefs: record.result?.refs,
     artifactRefs: record.artifactRefs,
   }
   if (!options.json) {
     console.log(`WP Codebox run artifacts: ${record.runId}`)
     console.log(`Status: ${record.status}`)
+    if (record.result) {
+      console.log(`Result: ${record.result.status} (${record.result.success ? "succeeded" : "failed"})`)
+      console.log(`Result artifacts: ${record.result.artifacts.length}`)
+    }
     for (const artifact of record.artifactRefs) {
       console.log(`${artifact.kind}: ${artifact.directory ?? artifact.path ?? artifact.id ?? "unknown"}`)
     }
@@ -166,6 +173,9 @@ function printRunStatusHumanOutput(record: RuntimeRunRecord): void {
   console.log(`Cancellable: ${record.lifecycle.cancellable ? "yes" : "no"}`)
   console.log(`Cleanup: ${record.lifecycle.cleanup.status} (${record.lifecycle.cleanup.attempts} attempts)`)
   console.log(`Heartbeat: ${record.heartbeatAt}`)
+  if (record.result) {
+    console.log(`Result: ${record.result.status} (${record.result.success ? "succeeded" : "failed"})`)
+  }
   console.log(`Artifacts: ${record.artifactRefs.length}`)
   if (record.preview?.reviewerAccess?.openUrl) {
     console.log(`Preview: ${record.preview.reviewerAccess.openUrl} (${record.preview.reviewerAccess.status}, ${record.preview.reviewerAccess.mode})`)

--- a/packages/runtime-core/src/run-registry.ts
+++ b/packages/runtime-core/src/run-registry.ts
@@ -3,11 +3,13 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import type { ArtifactBundle, ArtifactPreview, RuntimeInfo } from "./runtime-contracts.js"
+import type { RecipeRunSummary } from "./recipe-run-summary.js"
 import { normalizeArtifactDigest } from "./artifact-references.js"
 import { stripUndefined } from "./object-utils.js"
 import { redactJsonValue } from "./redaction.js"
 
 export type RuntimeRunStatus = "queued" | "booting" | "running" | "collecting_artifacts" | "succeeded" | "failed" | "timed_out" | "cancelled"
+export const RUNTIME_RUN_RESULT_SCHEMA = "wp-codebox/runtime-run-result/v1" as const
 
 export type RuntimeRunLifecyclePhase = "pending" | "active" | "finalizing" | "terminal"
 export type RuntimeRunLifecycleOutcome = "succeeded" | "failed" | "timed_out" | "cancelled"
@@ -66,6 +68,17 @@ export interface RuntimeRunReplay {
   ref?: string
 }
 
+export interface RuntimeRunResult {
+  schema: typeof RUNTIME_RUN_RESULT_SCHEMA
+  kind: "recipe-run" | (string & {})
+  success: boolean
+  status: string
+  summary?: RecipeRunSummary
+  artifacts: RecipeRunSummary["artifacts"]
+  refs?: RecipeRunSummary["refs"]
+  metadata: Record<string, unknown>
+}
+
 export interface RuntimeRunRecord {
   schema: "wp-codebox/run-registry-entry/v1"
   runId: string
@@ -77,6 +90,7 @@ export interface RuntimeRunRecord {
   runtime?: RuntimeInfo
   preview?: ArtifactPreview
   metadata?: Record<string, unknown>
+  result?: RuntimeRunResult
   artifactRefs: RuntimeRunArtifactRef[]
   retention?: RuntimeRunRetention
   replay?: RuntimeRunReplay
@@ -93,6 +107,7 @@ export interface RuntimeRunRegistryCreateOptions {
   runtime?: RuntimeInfo
   preview?: ArtifactPreview
   metadata?: Record<string, unknown>
+  result?: RuntimeRunResult
   retention?: RuntimeRunRetention
   replay?: RuntimeRunReplay
   artifactRefs?: RuntimeRunArtifactRef[]
@@ -104,6 +119,7 @@ export interface RuntimeRunRegistryUpdate {
   runtime?: RuntimeInfo
   preview?: ArtifactPreview
   metadata?: Record<string, unknown>
+  result?: RuntimeRunResult
   retention?: RuntimeRunRetention
   replay?: RuntimeRunReplay
   artifactRefs?: RuntimeRunArtifactRef[]
@@ -166,6 +182,7 @@ export class RuntimeRunRegistry {
         runtime: options.runtime,
         preview: options.preview,
         metadata: sanitizeRunMetadata(options.metadata),
+        result: options.result,
         retention: options.retention,
         replay: options.replay,
       }),
@@ -191,6 +208,7 @@ export class RuntimeRunRegistry {
       ...(update.runtime ? { runtime: update.runtime } : {}),
       ...(update.preview ? { preview: update.preview } : {}),
       ...(update.metadata ? { metadata: sanitizeRunMetadata({ ...(current.metadata ?? {}), ...update.metadata }) } : {}),
+      ...(update.result ? { result: update.result } : {}),
       ...(update.retention ? { retention: update.retention } : {}),
       ...(update.replay ? { replay: update.replay } : {}),
       ...(update.artifactRefs ? { artifactRefs: update.artifactRefs } : {}),
@@ -356,6 +374,19 @@ export function artifactBundleRunRef(bundle: ArtifactBundle | undefined): Runtim
       digest: normalizeArtifactDigest(bundle.previewSessionEvidenceRef.sha256),
     })] : []),
   ]
+}
+
+export function runtimeRunResultFromRecipeSummary(summary: RecipeRunSummary): RuntimeRunResult {
+  return {
+    schema: RUNTIME_RUN_RESULT_SCHEMA,
+    kind: "recipe-run",
+    success: summary.success,
+    status: summary.status,
+    summary,
+    artifacts: summary.artifacts,
+    refs: summary.refs,
+    metadata: summary.metadata,
+  }
 }
 
 export function defaultRunRegistryDirectory(artifactsDirectory: string | undefined, cwd = process.cwd()): string {

--- a/tests/run-registry.test.ts
+++ b/tests/run-registry.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict"
 
 import { withTempDir } from "../scripts/test-kit.js"
-import { RuntimeRunRegistry, transitionRuntimeRunStatus } from "../packages/runtime-core/src/index.js"
+import { RuntimeRunRegistry, runtimeRunResultFromRecipeSummary, transitionRuntimeRunStatus, type RecipeRunSummary } from "../packages/runtime-core/src/index.js"
+import { finalizeRecipeValidationFailure } from "../packages/cli/src/commands/recipe-run-finalizer.js"
+import { runRunsArtifactsCommand } from "../packages/cli/src/commands/runs.js"
 
 assert.equal(transitionRuntimeRunStatus("queued", "running"), "running")
 assert.equal(transitionRuntimeRunStatus("queued", "collecting_artifacts"), "collecting_artifacts")
@@ -23,10 +25,14 @@ await withTempDir("wp-codebox-run-registry-", async (directory) => {
   const succeeded = await registry.update(run.runId, {
     status: "succeeded",
     artifactRefs: [{ kind: "artifact-bundle", path: "artifacts/run.json" }],
+    result: runtimeRunResultFromRecipeSummary(recipeRunSummaryFixture()),
     now: new Date("2026-01-02T03:04:08.000Z"),
   })
   assert.equal(succeeded.lifecycle.terminal, true)
   assert.equal(succeeded.lifecycle.outcome, "succeeded")
+  assert.equal(succeeded.result?.schema, "wp-codebox/runtime-run-result/v1")
+  assert.equal(succeeded.result?.status, "succeeded")
+  assert.equal(succeeded.result?.artifacts[0]?.path, "files/summary.json")
 
   await assert.rejects(registry.update(run.runId, { status: "failed", now: new Date("2026-01-02T03:04:09.000Z") }), /terminal runtime run status/)
 
@@ -40,6 +46,43 @@ await withTempDir("wp-codebox-run-registry-", async (directory) => {
   assert.deepEqual(retry.artifactRefs, [{ kind: "artifact-bundle", path: "artifacts/retry.json" }])
   assert.equal(retry.lifecycle.cleanup.status, "running")
   assert.equal(retry.lifecycle.cleanup.attempts, 1)
+})
+
+await withTempDir("wp-codebox-run-registry-artifacts-", async (directory) => {
+  const registry = new RuntimeRunRegistry(directory)
+  const run = await registry.create({ runId: "result-artifacts", status: "running" })
+  await registry.update(run.runId, {
+    status: "succeeded",
+    artifactRefs: [{ kind: "artifact-bundle", path: "artifacts/run.json" }],
+    result: runtimeRunResultFromRecipeSummary(recipeRunSummaryFixture()),
+  })
+
+  const { code, stdout } = await captureStdout(() => runRunsArtifactsCommand(["--registry", directory, "--run-id", run.runId, "--json"]))
+  const output = JSON.parse(stdout)
+
+  assert.equal(code, 0)
+  assert.equal(output.result.schema, "wp-codebox/runtime-run-result/v1")
+  assert.equal(output.resultArtifacts[0].path, "files/summary.json")
+  assert.equal(output.resultRefs.logs[0].path, "files/summary.json")
+})
+
+await withTempDir("wp-codebox-run-registry-finalizer-", async (directory) => {
+  const registry = new RuntimeRunRegistry(directory)
+  const run = await registry.create({ runId: "finalizer-result", status: "running" })
+  const output = await finalizeRecipeValidationFailure({
+    recipePath: "recipe.json",
+    runRegistry: registry,
+    runRecord: run,
+    artifactPointer: { update: async () => {} },
+    startedAtMs: Date.now(),
+    failure: { name: "RecipeValidationError", message: "recipe failed validation" },
+    validation: { issues: [{ code: "invalid", path: "$.workflow", message: "invalid workflow" }] },
+  })
+  const record = await registry.read(run.runId)
+
+  assert.equal(output.run?.result?.schema, "wp-codebox/runtime-run-result/v1")
+  assert.equal(record.result?.schema, "wp-codebox/runtime-run-result/v1")
+  assert.equal(record.result?.summary?.failure_summary, "recipe failed validation")
 })
 
 await withTempDir("wp-codebox-run-registry-cancel-", async (directory) => {
@@ -80,3 +123,48 @@ await withTempDir("wp-codebox-run-registry-cancel-", async (directory) => {
   assert.equal(cancelled.lifecycle.cancelled, true)
   assert.equal(cancelled.lifecycle.outcome, "cancelled")
 })
+
+function recipeRunSummaryFixture(): RecipeRunSummary {
+  return {
+    schema: "wp-codebox/recipe-run-summary/v1",
+    success: true,
+    status: "succeeded",
+    diagnostics: [],
+    artifacts: [{ id: "summary", kind: "codebox-command-log", path: "files/summary.json" }],
+    commands: [],
+    refs: {
+      startup_logs: [],
+      probe_json: [],
+      screenshots: [],
+      side_effects: [],
+      declared_artifacts: [],
+      artifact_bundles: [],
+      changed_files: [],
+      patches: [],
+      transcripts: [],
+      logs: [{ id: "summary", kind: "codebox-command-log", path: "files/summary.json" }],
+      runtimes: [],
+    },
+    metadata: { run_id: "result-artifacts" },
+  }
+}
+
+async function captureStdout(callback: () => Promise<number>): Promise<{ code: number; stdout: string }> {
+  let stdout = ""
+  const write = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdout += chunk.toString()
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback()
+    } else if (callback) {
+      callback()
+    }
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    return { code: await callback(), stdout }
+  } finally {
+    process.stdout.write = write
+  }
+}


### PR DESCRIPTION
## Summary
- add a first-class RuntimeRunResult schema on RuntimeRunRecord
- persist normalized recipe run summaries into the registry during finalization
- expose result artifacts/refs through runs artifacts and show result status in run status output

## Tests
- npm run test:run-registry
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the implementation, tests, and PR description; Chris remains responsible for review and validation.