### PR TITLE
Fix runtime prepared blueprint refs

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -442,9 +442,35 @@ final class WP_Codebox_Browser_Task_Builder {
 		$session = is_array( $input['session'] ?? null ) ? $input['session'] : $input;
 		$primary = is_array( $session['primary'] ?? null ) ? $session['primary'] : $session;
 		$playground = is_array( $primary['playground'] ?? null ) ? $primary['playground'] : ( is_array( $input['playground'] ?? null ) ? $input['playground'] : array() );
-		$prepared = is_array( $input['prepared_runtime'] ?? null ) ? $input['prepared_runtime'] : ( is_array( $playground['prepared_runtime'] ?? null ) ? $playground['prepared_runtime'] : array() );
+		$prepared = self::browser_prepared_runtime_from_envelope( $input, $session, $primary, $playground );
 
 		return self::browser_blueprint_ref( $prepared, $session );
+	}
+
+	/** @param array<string,mixed> ...$envelopes Candidate session/runtime envelopes. @return array<string,mixed> */
+	private static function browser_prepared_runtime_from_envelope( array ...$envelopes ): array {
+		foreach ( $envelopes as $envelope ) {
+			if ( 'wp-codebox/browser-prepared-runtime/v1' === ( $envelope['schema'] ?? '' ) || ( '' !== (string) ( $envelope['cache_key'] ?? '' ) && '' !== (string) ( $envelope['input_hash'] ?? '' ) ) ) {
+				return $envelope;
+			}
+
+			foreach ( array( 'prepared_runtime', 'prepared' ) as $field ) {
+				if ( is_array( $envelope[ $field ] ?? null ) && ( 'wp-codebox/browser-prepared-runtime/v1' === ( $envelope[ $field ]['schema'] ?? '' ) || ( '' !== (string) ( $envelope[ $field ]['cache_key'] ?? '' ) && '' !== (string) ( $envelope[ $field ]['input_hash'] ?? '' ) ) ) ) {
+					return $envelope[ $field ];
+				}
+			}
+
+			foreach ( array( 'playground', 'runtime', 'contained_site' ) as $field ) {
+				if ( is_array( $envelope[ $field ] ?? null ) ) {
+					$prepared = self::browser_prepared_runtime_from_envelope( $envelope[ $field ] );
+					if ( ! empty( $prepared ) ) {
+						return $prepared;
+					}
+				}
+			}
+		}
+
+		return array();
 	}
 
 	/** @param array<string,mixed> $input Blueprint ref input. @return array<string,mixed>|WP_Error */
@@ -487,7 +513,7 @@ final class WP_Codebox_Browser_Task_Builder {
 	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */
 	public static function browser_preview_boot_config( array $session ): array {
 		$playground             = is_array( $session['playground'] ?? null ) ? $session['playground'] : array();
-		$prepared_runtime       = is_array( $playground['prepared_runtime'] ?? null ) ? $playground['prepared_runtime'] : array();
+		$prepared_runtime       = self::browser_prepared_runtime_from_envelope( $session, $playground );
 		$site_blueprint_artifact = is_array( $session['site_blueprint_artifact'] ?? null ) ? $session['site_blueprint_artifact'] : array();
 		$session_envelope       = is_array( $session['session'] ?? null ) ? $session['session'] : array();
 		$blueprint_ref          = self::browser_blueprint_ref( $prepared_runtime, $session );

--- a/tests/browser-blueprint-ref-endpoint.test.ts
+++ b/tests/browser-blueprint-ref-endpoint.test.ts
@@ -18,11 +18,47 @@ $blueprint_ref = WP_Codebox_Browser_Task_Builder::browser_blueprint_ref(
 	)
 );
 
-echo json_encode( $blueprint_ref, JSON_UNESCAPED_SLASHES );
+$runtime_ref = WP_Codebox_Browser_Task_Builder::executable_blueprint_ref(
+	array(
+		'session' => array(
+			'runtime' => array(
+				'prepared_runtime' => array(
+					'schema'     => 'wp-codebox/browser-prepared-runtime/v1',
+					'cache_key'  => 'runtime-proof',
+					'input_hash' => str_repeat( 'b', 64 ),
+					'status'     => 'ready',
+				),
+			),
+		),
+	)
+);
+
+$boot_config = WP_Codebox_Browser_Task_Builder::browser_preview_boot_config(
+	array(
+		'playground' => array(
+			'scope'             => 'runtime-proof-scope',
+			'client_module_url' => 'https://playground.wordpress.net/client/index.js',
+			'remote_url'        => 'https://playground.wordpress.net/remote.html',
+		),
+		'runtime' => array(
+			'prepared_runtime' => array(
+				'schema'     => 'wp-codebox/browser-prepared-runtime/v1',
+				'cache_key'  => 'boot-runtime-proof',
+				'input_hash' => str_repeat( 'c', 64 ),
+				'status'     => 'ready',
+			),
+		),
+	)
+);
+
+echo json_encode( array( 'blueprint_ref' => $blueprint_ref, 'runtime_ref' => $runtime_ref, 'boot_config' => $boot_config ), JSON_UNESCAPED_SLASHES );
 `)
 
-assert.equal(result.schema, "wp-codebox/browser-blueprint-ref/v1")
-assert.equal(result.ref, "prepared:studio-proof:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-assert.match(result.hydration_endpoint, /\/wp-codebox\/v1\/browser-blueprint-ref\?ref=prepared%3Astudio-proof%3A[a]{64}&_wpnonce=test-rest-nonce$/)
+assert.equal(result.blueprint_ref.schema, "wp-codebox/browser-blueprint-ref/v1")
+assert.equal(result.blueprint_ref.ref, "prepared:studio-proof:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+assert.match(result.blueprint_ref.hydration_endpoint, /\/wp-codebox\/v1\/browser-blueprint-ref\?ref=prepared%3Astudio-proof%3A[a]{64}&_wpnonce=test-rest-nonce$/)
+assert.equal(result.runtime_ref.ref, "prepared:runtime-proof:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+assert.equal(result.boot_config.blueprint_ref_dto.ref, "prepared:boot-runtime-proof:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+assert.match(result.boot_config.blueprint_ref_dto.hydration_endpoint, /\/wp-codebox\/v1\/browser-blueprint-ref\?ref=prepared%3Aboot-runtime-proof%3A[c]{64}&_wpnonce=test-rest-nonce$/)
 
 console.log("browser blueprint ref endpoint ok")


### PR DESCRIPTION
## Summary
- Resolve browser prepared runtime refs from runtime and contained-site envelopes, not only playground envelopes.
- Use the shared resolver for executable blueprint refs and preview boot config.
- Cover runtime-carried prepared refs in the browser blueprint ref endpoint test.

## Testing
- npx tsx tests/browser-blueprint-ref-endpoint.test.ts
- npm run test:browser-task-builder
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Studio Web preview boot failure, drafted the WP Codebox helper/test changes, and ran focused verification. Chris reviewed and directed PR creation.