### PR TITLE
Validate browser preview boot contracts

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -553,6 +553,37 @@ final class WP_Codebox_Browser_Task_Builder {
 		return function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_browser_preview_boot_config', $config, $session ) : $config;
 	}
 
+	/**
+	 * @param array<string,mixed> $preview_boot Browser preview boot config.
+	 * @param array<string,mixed> $blueprint_ref Browser blueprint ref DTO.
+	 * @return array{valid:bool,reason:string}
+	 */
+	public static function validate_browser_preview_boot_contract( array $preview_boot, array $blueprint_ref = array() ): array {
+		$boot_ref           = trim( (string) ( $preview_boot['blueprint_ref'] ?? '' ) );
+		$boot_ref_dto       = is_array( $preview_boot['blueprint_ref_dto'] ?? null ) ? $preview_boot['blueprint_ref_dto'] : array();
+		$boot_dto_ref       = trim( (string) ( $boot_ref_dto['ref'] ?? $boot_ref_dto['id'] ?? '' ) );
+		$contract_ref       = trim( (string) ( $blueprint_ref['ref'] ?? $blueprint_ref['id'] ?? '' ) );
+		$hydration_endpoint = trim( (string) ( $boot_ref_dto['hydration_endpoint'] ?? $boot_ref_dto['endpoint'] ?? '' ) );
+
+		if ( '' === $boot_ref || 'inline-session-blueprint' === $boot_ref ) {
+			return array( 'valid' => false, 'reason' => 'preview-boot-blueprint-ref-missing' );
+		}
+
+		if ( '' === $boot_dto_ref ) {
+			return array( 'valid' => false, 'reason' => 'preview-boot-blueprint-ref-dto-missing' );
+		}
+
+		if ( $boot_ref !== $boot_dto_ref || ( '' !== $contract_ref && $boot_ref !== $contract_ref ) ) {
+			return array( 'valid' => false, 'reason' => 'preview-boot-blueprint-ref-mismatch' );
+		}
+
+		if ( '' === $hydration_endpoint ) {
+			return array( 'valid' => false, 'reason' => 'preview-boot-hydration-endpoint-missing' );
+		}
+
+		return array( 'valid' => true, 'reason' => 'preview-boot-contract-hydratable' );
+	}
+
 	/** @param array<string,mixed> $recipe Browser workspace recipe. @return array<string,mixed> */
 	public static function browser_recipe_dto( array $recipe ): array {
 		$runtime = is_array( $recipe['runtime'] ?? null ) ? $recipe['runtime'] : array();

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -180,11 +180,19 @@ public static function open_browser_contained_site( array $input ): array|WP_Err
 	$preview_boot   = WP_Codebox_Browser_Task_Builder::preview_boot_config( $session );
 	$preview_lease  = WP_Codebox_Browser_Task_Builder::preview_lease( $session );
 	$blueprint_ref  = is_array( $status['blueprint_ref'] ?? null ) ? $status['blueprint_ref'] : array();
+	$boot_contract  = true === ( $status['success'] ?? false ) ? WP_Codebox_Browser_Task_Builder::validate_browser_preview_boot_contract( $preview_boot, $blueprint_ref ) : array( 'valid' => false, 'reason' => '' );
 	$site_id        = (string) ( $status['site_id'] ?? $contained_site['site_id'] ?? $input['site_id'] ?? '' );
 	$session_id     = (string) ( $session['session']['id'] ?? '' );
 	$preview_id     = (string) ( $contained_site['preview_id'] ?? $input['preview_id'] ?? '' );
 	$scope          = (string) ( $preview_boot['scope'] ?? $contained_site['preview']['scope'] ?? '' );
 	$resolution     = is_array( $status['resolution'] ?? null ) ? $status['resolution'] : array();
+	$open_status    = (string) ( $status['status'] ?? 'miss' );
+	$open_success   = true === ( $status['success'] ?? false );
+	if ( $open_success && true !== ( $boot_contract['valid'] ?? false ) ) {
+		$open_success = false;
+		$open_status  = 'unusable';
+		$resolution   = self::browser_contained_site_resolution( $open_status, array( 'invalidation' => array( 'reason' => (string) ( $boot_contract['reason'] ?? 'preview-boot-contract-unusable' ) ) ) );
+	}
 
 	$opened_site = array_filter(
 		array_merge(
@@ -194,7 +202,7 @@ public static function open_browser_contained_site( array $input ): array|WP_Err
 				'site_id'          => $site_id,
 				'preview_id'       => $preview_id,
 				'session_id'       => $session_id,
-				'status'           => (string) ( $status['status'] ?? 'miss' ),
+				'status'           => $open_status,
 				'resolution'       => $resolution,
 				'persistence'      => 'browser-contained',
 				'source_digest'    => is_array( $status['source_digest'] ?? null ) ? $status['source_digest'] : array(),
@@ -211,10 +219,10 @@ public static function open_browser_contained_site( array $input ): array|WP_Err
 
 	return array_filter(
 		array(
-			'success'       => true === ( $status['success'] ?? false ),
+			'success'       => $open_success,
 			'schema'        => 'wp-codebox/browser-contained-site-open/v1',
 			'site_id'       => $site_id,
-			'status'        => (string) ( $status['status'] ?? 'miss' ),
+			'status'        => $open_status,
 			'resolution'    => $resolution,
 			'contained_site' => $opened_site,
 			'source_digest' => is_array( $status['source_digest'] ?? null ) ? $status['source_digest'] : array(),

--- a/tests/browser-contained-site-status.test.ts
+++ b/tests/browser-contained-site-status.test.ts
@@ -11,6 +11,12 @@ class WP_Error {
 function is_wp_error( $value ) { return $value instanceof WP_Error; }
 function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', (string) $value ) ); }
 function wp_create_nonce( $action = -1 ) { return 'test-rest-nonce'; }
+function apply_filters( $tag, $value, ...$args ) {
+	if ( 'wp_codebox_browser_preview_boot_config' === $tag && ! empty( $GLOBALS['wp_codebox_test_strip_preview_boot_ref'] ) && is_array( $value ) ) {
+		unset( $value['blueprint_ref_dto'] );
+	}
+	return $value;
+}
 
 $GLOBALS['wp_codebox_test_transients'] = array();
 function get_transient( $key ) { return $GLOBALS['wp_codebox_test_transients'][ $key ] ?? false; }
@@ -85,8 +91,17 @@ $open_miss = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browser_cont
 	'site_id' => $cache_key,
 	'input_hash' => str_repeat( 'd', 64 ),
 ) );
+$GLOBALS['wp_codebox_test_strip_preview_boot_ref'] = true;
+$open_unbootable = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browser_contained_site( array(
+	'contained_site' => array(
+		'schema' => 'wp-codebox/browser-contained-site/v1',
+		'site_id' => $cache_key,
+		'source_digest' => array( 'algorithm' => 'sha256', 'value' => $input_hash ),
+		'recovery' => array( 'input' => array( 'cache_key' => $cache_key, 'input_hash' => $input_hash ) ),
+	),
+) );
 
-echo json_encode( array( 'hit' => $hit, 'miss' => $miss, 'incompatible' => $incompatible, 'open_hit' => $open_hit, 'open_miss' => $open_miss ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'hit' => $hit, 'miss' => $miss, 'incompatible' => $incompatible, 'open_hit' => $open_hit, 'open_miss' => $open_miss, 'open_unbootable' => $open_unbootable ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.hit.schema, "wp-codebox/browser-contained-site-status/v1")
@@ -122,6 +137,8 @@ assert.equal(result.open_hit.blueprint_ref.hydrator_ability, "wp-codebox/hydrate
 assert.equal(result.open_hit.blueprint_ref.hydration_endpoint.includes("/wp-codebox/v1/browser-blueprint-ref"), true)
 assert.equal(result.open_hit.preview_boot.schema, "wp-codebox/browser-preview-boot-config/v1")
 assert.equal(result.open_hit.preview_boot.blueprint_ref, `prepared:browser-site-proof:${"c".repeat(64)}`)
+assert.equal(result.open_hit.preview_boot.blueprint_ref_dto.ref, `prepared:browser-site-proof:${"c".repeat(64)}`)
+assert.equal(result.open_hit.preview_boot.blueprint_ref_dto.hydration_endpoint.includes("/wp-codebox/v1/browser-blueprint-ref"), true)
 assert.equal(result.open_hit.preview_boot.preview.preview_public_url, "https://preview.example.test")
 assert.equal(result.open_hit.preview_lease.schema, "wp-codebox/preview-lease/v1")
 assert.equal(result.open_hit.preview_lease.lease.status, "active")
@@ -134,5 +151,13 @@ assert.equal(result.open_miss.success, false)
 assert.equal(result.open_miss.status, "miss")
 assert.equal(result.open_miss.resolution.miss, true)
 assert.equal(result.open_miss.blueprint_ref, undefined)
+assert.equal(result.open_unbootable.success, false)
+assert.equal(result.open_unbootable.status, "unusable")
+assert.equal(result.open_unbootable.resolution.outcome, "unusable")
+assert.equal(result.open_unbootable.resolution.reused, false)
+assert.equal(result.open_unbootable.resolution.reason, "preview-boot-blueprint-ref-dto-missing")
+assert.equal(result.open_unbootable.contained_site.status, "unusable")
+assert.equal(result.open_unbootable.preview_boot.blueprint_ref, `prepared:browser-site-proof:${"c".repeat(64)}`)
+assert.equal(result.open_unbootable.preview_boot.blueprint_ref_dto, undefined)
 
 console.log("browser contained site status ok")


### PR DESCRIPTION
## Summary
- Add a generic browser preview boot contract validator.
- Treat contained-site open responses without hydratable preview boot data as unusable instead of reusable success.
- Cover successful hydratable boot contracts and malformed boot configs in browser-contained-site tests.

## Testing
- `npm ci`
- `npm run test:browser-contained-site-status`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the generic boot-contract validation and focused tests; Chris remains responsible for review and verification.