### PR TITLE
Mount bundled Agents API for agent runtimes

### DIFF
--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -1,5 +1,6 @@
+import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
+import { join, resolve } from "node:path"
 import { commandArgValue, normalizeSandboxToolPolicySnapshot, normalizeStructuredArtifacts, parseCommandJson, parseCommandJsonArray, parseCommandJsonObject, type MountSpec, type RuntimePolicy, type SandboxToolPolicySnapshot, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type StructuredArtifactPayload, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { resolvePluginEntrypointContract, type ComponentLoadMode } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
@@ -475,7 +476,24 @@ function agentRuntimeComponents(options: AgentRuntimeProbeOptions): AgentRuntime
   for (const component of options.components) {
     bySlug.set(component.slug, component)
   }
+  for (const component of options.components) {
+    if (bySlug.has("agents-api")) {
+      break
+    }
+    const agentsApiPath = agentsApiPathFromRuntimeComponent(component)
+    if (agentsApiPath) {
+      const agentsApi = componentFromPath(agentsApiPath, "agents-api", undefined, "mu-plugin", "component")
+      bySlug.set(agentsApi.slug, agentsApi)
+    }
+  }
   return [...bySlug.values()]
+}
+
+function agentsApiPathFromRuntimeComponent(component: AgentRuntimeComponent): string {
+  return [
+    join(component.source, "vendor", "wordpress", "agents-api"),
+    join(component.source, "vendor", "automattic", "agents-api"),
+  ].find((candidate) => existsSync(join(candidate, "agents-api.php"))) ?? ""
 }
 
 function providerPluginSlugs(args: string[]): string[] {

--- a/tests/agent-runtime-components.test.ts
+++ b/tests/agent-runtime-components.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { agentRuntimeMounts, parseAgentRuntimeProbeOptions, type AgentRuntimeMount } from "../packages/cli/src/agent-sandbox.js"
+
+const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-components-"))
+
+try {
+  const dataMachine = join(root, "data-machine")
+  const agentsApi = join(dataMachine, "vendor", "wordpress", "agents-api")
+  mkdirSync(agentsApi, { recursive: true })
+  writeFileSync(join(dataMachine, "data-machine.php"), "<?php\n/* Plugin Name: Data Machine */\n")
+  writeFileSync(join(agentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+
+  const options = parseAgentRuntimeProbeOptions(["--component", dataMachine], parseMount)
+  const mounts = agentRuntimeMounts(options)
+  const agentsApiMount = mounts.find((mount) => mount.metadata?.slug === "agents-api")
+
+  assert.equal(agentsApiMount?.source, agentsApi)
+  assert.equal(agentsApiMount?.target, "/wordpress/wp-content/mu-plugins/wp-codebox-runtime/agents-api")
+  assert.equal(agentsApiMount?.metadata?.pluginFile, "agents-api/agents-api.php")
+  assert.equal(agentsApiMount?.metadata?.loadAs, "mu-plugin")
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
+
+function parseMount(value: string): AgentRuntimeMount {
+  const [source, target, mode = "readonly"] = value.split(":")
+  if (mode !== "readonly" && mode !== "readwrite") {
+    throw new Error(`Invalid mount mode: ${mode}`)
+  }
+  return { source, target, mode }
+}


### PR DESCRIPTION
## Summary
- infer a bundled Agents API copy from agent runtime components when no explicit agents-api component is supplied
- mount the inferred Agents API copy as the canonical agents-api mu-plugin runtime substrate
- preserve explicit agents-api components as the caller-selected source of truth

Agents API is the canonical agentic runtime spine. Richer runtimes such as Data Machine can vendor/extend it, but WP Codebox should ensure the spine is mounted as runtime substrate when present.

## Testing
- `npm run build`
- `npm exec tsx tests/agent-runtime-components.test.ts`
- `npm run test:php-agents-api-execution-targets`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Traced the runtime mounting boundary, drafted the Agents API substrate inference change, and ran targeted verification. Chris clarified the Agents API/Data Machine architecture and that this belongs in WP Codebox.