### PR TITLE
Mount default Agents API substrate

### DIFF
--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { commandArgValue, normalizeSandboxToolPolicySnapshot, normalizeStructuredArtifacts, parseCommandJson, parseCommandJsonArray, parseCommandJsonObject, type MountSpec, type RuntimePolicy, type SandboxToolPolicySnapshot, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type StructuredArtifactPayload, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { resolvePluginEntrypointContract, type ComponentLoadMode } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
@@ -486,7 +486,42 @@ function agentRuntimeComponents(options: AgentRuntimeProbeOptions): AgentRuntime
       bySlug.set(agentsApi.slug, agentsApi)
     }
   }
+  if (!bySlug.has("agents-api")) {
+    const agentsApiPath = defaultAgentsApiPath()
+    if (agentsApiPath) {
+      const agentsApi = componentFromPath(agentsApiPath, "agents-api", undefined, "mu-plugin", "component")
+      bySlug.set(agentsApi.slug, agentsApi)
+    }
+  }
   return [...bySlug.values()]
+}
+
+function defaultAgentsApiPath(): string {
+  const explicit = [process.env.WP_CODEBOX_AGENTS_API_PATH, process.env.AGENTS_API_PATH]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .map((value) => resolve(value))
+    .find(isAgentsApiPluginRoot)
+
+  if (explicit) {
+    return explicit
+  }
+
+  const candidates: string[] = []
+  let current = resolve(process.cwd())
+  for (let depth = 0; depth < 6; depth++) {
+    candidates.push(join(current, "agents-api"), join(dirname(current), "agents-api"))
+    const parent = dirname(current)
+    if (parent === current) {
+      break
+    }
+    current = parent
+  }
+
+  return candidates.find(isAgentsApiPluginRoot) ?? ""
+}
+
+function isAgentsApiPluginRoot(candidate: string): boolean {
+  return existsSync(join(candidate, "agents-api.php"))
 }
 
 function agentsApiPathFromRuntimeComponent(component: AgentRuntimeComponent): string {

--- a/tests/agent-runtime-components.test.ts
+++ b/tests/agent-runtime-components.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict"
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { chdir, cwd } from "node:process"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { agentRuntimeMounts, parseAgentRuntimeProbeOptions, type AgentRuntimeMount } from "../packages/cli/src/agent-sandbox.js"
 
 const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-components-"))
+const originalCwd = cwd()
+const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
 
 try {
   const dataMachine = join(root, "data-machine")
@@ -21,7 +24,32 @@ try {
   assert.equal(agentsApiMount?.target, "/wordpress/wp-content/mu-plugins/wp-codebox-runtime/agents-api")
   assert.equal(agentsApiMount?.metadata?.pluginFile, "agents-api/agents-api.php")
   assert.equal(agentsApiMount?.metadata?.loadAs, "mu-plugin")
+
+  const defaultAgentsApi = join(root, "agents-api")
+  mkdirSync(defaultAgentsApi, { recursive: true })
+  writeFileSync(join(defaultAgentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+  const workspace = join(root, "workspace")
+  mkdirSync(workspace, { recursive: true })
+  chdir(workspace)
+  const defaultMount = agentRuntimeMounts(parseAgentRuntimeProbeOptions([], parseMount))
+    .find((mount) => mount.metadata?.slug === "agents-api")
+  assertSamePath(defaultMount?.source, defaultAgentsApi)
+  assert.equal(defaultMount?.target, "/wordpress/wp-content/mu-plugins/wp-codebox-runtime/agents-api")
+
+  const explicitAgentsApi = join(root, "explicit-agents-api")
+  mkdirSync(explicitAgentsApi, { recursive: true })
+  writeFileSync(join(explicitAgentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+  process.env.WP_CODEBOX_AGENTS_API_PATH = defaultAgentsApi
+  const explicitMount = agentRuntimeMounts(parseAgentRuntimeProbeOptions(["--agents-api", explicitAgentsApi], parseMount))
+    .find((mount) => mount.metadata?.slug === "agents-api")
+  assertSamePath(explicitMount?.source, explicitAgentsApi)
 } finally {
+  chdir(originalCwd)
+  if (originalAgentsApiPath === undefined) {
+    delete process.env.WP_CODEBOX_AGENTS_API_PATH
+  } else {
+    process.env.WP_CODEBOX_AGENTS_API_PATH = originalAgentsApiPath
+  }
   rmSync(root, { recursive: true, force: true })
 }
 
@@ -31,4 +59,8 @@ function parseMount(value: string): AgentRuntimeMount {
     throw new Error(`Invalid mount mode: ${mode}`)
   }
   return { source, target, mode }
+}
+
+function assertSamePath(actual: string | undefined, expected: string): void {
+  assert.equal(actual ? realpathSync(actual) : actual, realpathSync(expected))
 }


### PR DESCRIPTION
## Summary
- mount a default Agents API substrate for agent sandboxes when no explicit or inferred agents-api component is provided
- resolve the default from WP_CODEBOX_AGENTS_API_PATH / AGENTS_API_PATH or a nearby sibling agents-api checkout
- keep explicit --agents-api and runtime-vendored agents-api components authoritative

## Testing
- npm exec tsx tests/agent-runtime-components.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WP Codebox CLI fallback substrate mount and targeted tests; Chris requested the PR and remains responsible for review and merge.