### PR TITLE
Mount default Agents API in agent task recipes

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import type { StructuredArtifactPayload } from "./structured-artifacts.js"
 import type { TaskInput } from "./task-input.js"
@@ -94,12 +94,14 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   const providerContracts = providerPlugins.map((plugin) => ({ slug: plugin.slug, pluginFile: plugin.pluginFile, loadAs: plugin.loadAs ?? "plugin" }))
   const componentPluginEntries = componentPlugins(input.component_contracts, artifacts)
   const callerExtraPlugins = agentTaskExtraPlugins(input)
+  const defaultRuntimeComponents = defaultAgentRuntimeComponentPlugins(componentPluginEntries, callerExtraPlugins)
   const extraPlugins = dedupeExtraPlugins([
+    ...defaultRuntimeComponents,
     ...componentPluginEntries,
     ...providerPlugins,
     ...callerExtraPlugins,
   ].filter(Boolean))
-  const componentManifest = componentManifestForRuntimePlugins(componentPluginEntries, providerPlugins)
+  const componentManifest = componentManifestForRuntimePlugins([...defaultRuntimeComponents, ...componentPluginEntries], providerPlugins)
   const workflowArgs = [
     `task=${taskInput.goal}`,
     `agent=${stringValue(input.agent) || "wp-codebox-sandbox"}`,
@@ -155,6 +157,54 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
       after: Array.isArray(input.verify_steps) && input.verify_steps.length > 0 ? input.verify_steps : undefined,
     }),
   }) as WorkspaceRecipe
+}
+
+function defaultAgentRuntimeComponentPlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], callerExtraPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeExtraPlugin[] {
+  if ([...componentPlugins, ...callerExtraPlugins].some((plugin) => plugin.slug === "agents-api")) {
+    return []
+  }
+
+  const agentsApiPath = defaultAgentsApiPath()
+  if (!agentsApiPath) {
+    return []
+  }
+
+  return [{
+    source: agentsApiPath,
+    slug: "agents-api",
+    pluginFile: "agents-api/agents-api.php",
+    activate: false,
+    loadAs: "mu-plugin",
+    metadata: { source: "wp-codebox-default-agent-runtime-substrate" },
+  }]
+}
+
+function defaultAgentsApiPath(): string {
+  const explicit = [process.env.WP_CODEBOX_AGENTS_API_PATH, process.env.AGENTS_API_PATH]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .map((value) => resolve(value))
+    .find(isAgentsApiPluginRoot)
+
+  if (explicit) {
+    return explicit
+  }
+
+  const candidates: string[] = []
+  let current = resolve(process.cwd())
+  for (let depth = 0; depth < 6; depth++) {
+    candidates.push(join(current, "agents-api"), join(dirname(current), "agents-api"))
+    const parent = dirname(current)
+    if (parent === current) {
+      break
+    }
+    current = parent
+  }
+
+  return candidates.find(isAgentsApiPluginRoot) ?? ""
+}
+
+function isAgentsApiPluginRoot(candidate: string): boolean {
+  return existsSync(join(candidate, "agents-api.php"))
 }
 
 export function componentManifestForRuntimePlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], providerPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeComponentManifest {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -100,7 +100,12 @@ assert.equal(agentRecipePolicy.commands.includes("wordpress.wp-cli"), true)
 assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run"), false)
 
 const agentRecipeTemp = mkdtempSync(join(tmpdir(), "wp-codebox-agent-recipe-test-"))
+const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
 try {
+  const agentsApiSource = join(agentRecipeTemp, "agents-api")
+  mkdirSync(agentsApiSource)
+  writeFileSync(join(agentsApiSource, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+  process.env.WP_CODEBOX_AGENTS_API_PATH = agentsApiSource
   const providerSource = join(agentRecipeTemp, "test-provider")
   mkdirSync(providerSource)
   writeFileSync(join(providerSource, "test-provider.php"), "<?php\n/* Plugin Name: Test Provider */\n")
@@ -139,6 +144,15 @@ try {
     }],
   }, normalizeTaskInput({ goal: "Verify extra plugin propagation" }), "latest")
   const extraPlugins = recipe.inputs?.extra_plugins ?? []
+  assert.deepEqual(extraPlugins.find((plugin) => plugin.slug === "agents-api"), {
+    source: agentsApiSource,
+    slug: "agents-api",
+    pluginFile: "agents-api/agents-api.php",
+    activate: false,
+    loadAs: "mu-plugin",
+    metadata: { source: "wp-codebox-default-agent-runtime-substrate" },
+  })
+  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api" && component.loadAs === "mu-plugin"), true)
   assert.equal(extraPlugins.some((plugin) => plugin.slug === "test-provider" && plugin.activate === true && plugin.loadAs === "plugin"), true)
   assert.equal(extraPlugins.filter((plugin) => plugin.slug === "test-provider" && plugin.loadAs === "plugin").length, 1)
   assert.deepEqual(extraPlugins.find((plugin) => plugin.slug === "agent-runtime-tool-bridge"), {
@@ -166,6 +180,11 @@ try {
   assert.equal(dryRun.success, true)
   assert.deepEqual(dryRun.plan?.runtime.blueprint, { steps: [] })
 } finally {
+  if (originalAgentsApiPath === undefined) {
+    delete process.env.WP_CODEBOX_AGENTS_API_PATH
+  } else {
+    process.env.WP_CODEBOX_AGENTS_API_PATH = originalAgentsApiPath
+  }
   rmSync(agentRecipeTemp, { recursive: true, force: true })
 }
 


### PR DESCRIPTION
## Summary
- include the default Agents API substrate in generated agent task recipes when no explicit agents-api component is present
- list the default substrate in the component manifest as a runtime mu-plugin component
- cover agent task recipe construction with the default substrate path

## Testing
- npm exec tsx tests/agent-task-contracts.test.ts
- npm exec tsx tests/agent-runtime-components.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the WP Codebox recipe-builder substrate mount and targeted tests; Chris requested the follow-up fix and remains responsible for review and merge.