### PR TITLE
Register sandbox chat handler for agent runs

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -127,6 +127,50 @@ $sandbox_stack['default_agent'] = wp_codebox_ensure_sandbox_default_agent(
     $sandbox_default_agent,
     json_decode(${JSON.stringify(JSON.stringify(input))}, true)
 );
+wp_codebox_register_sandbox_chat_handler();
+
+function wp_codebox_register_sandbox_chat_handler(): void {
+    add_filter('wp_agent_chat_handler', static function ($handler, array $input) {
+        if (null !== $handler) {
+            return $handler;
+        }
+        return static function (array $chat_input) {
+            return wp_codebox_execute_sandbox_chat_turn($chat_input);
+        };
+    }, 100, 2);
+}
+
+function wp_codebox_execute_sandbox_chat_turn(array $chat_input) {
+    if (!class_exists('\\WordPress\\AiClient\\AiClient')) {
+        return new WP_Error('wp_codebox_ai_client_unavailable', 'PHP AI Client is unavailable inside the sandbox.');
+    }
+
+    $provider = trim((string) ($chat_input['provider'] ?? ''));
+    $model = trim((string) ($chat_input['model'] ?? ''));
+    $message = trim((string) ($chat_input['message'] ?? ''));
+    if ('' === $provider || '' === $model) {
+        return new WP_Error('wp_codebox_provider_model_required', 'WP Codebox sandbox chat requires provider and model.');
+    }
+    if ('' === $message) {
+        return new WP_Error('wp_codebox_message_required', 'WP Codebox sandbox chat requires a message.');
+    }
+
+    try {
+        $provider_class = \\WordPress\\AiClient\\AiClient::defaultRegistry()->getProviderClassName($provider);
+        $prompt_builder = \\WordPress\\AiClient\\AiClient::prompt($message)->usingModel($provider_class::model($model));
+        $result = $prompt_builder->generateTextResult();
+        $reply = method_exists($result, 'toText') ? (string) $result->toText() : '';
+        if ('' === $reply) {
+            return new WP_Error('wp_codebox_empty_reply', 'WP Codebox sandbox chat returned an empty reply.');
+        }
+        return array(
+            'session_id' => (string) ($chat_input['session_id'] ?? $chat_input['client_context']['codebox_session_id'] ?? 'wp-codebox-sandbox'),
+            'reply' => $reply,
+        );
+    } catch (Throwable $throwable) {
+        return new WP_Error('wp_codebox_sandbox_chat_failed', $throwable->getMessage(), array('type' => get_class($throwable)));
+    }
+}
 
 function wp_codebox_ensure_sandbox_default_agent(string $agent_slug, array $agent_input): array {
     if ('' === $agent_slug) {

--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
+import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction } from "../packages/runtime-core/src/index.js"
 
 const lifecycleReplaySnippet = phpRuntimeComponentLifecycleReplayFunction("wp_codebox_test")
@@ -71,3 +72,14 @@ assert.deepEqual(JSON.parse(actionOutput), {
   wp_abilities_api_init: 1,
   wp_codebox_runtime_abilities_ready: 1,
 })
+
+const sandboxAgentCode = await resolveSandboxTaskCode({
+  task: "Say hello",
+  agent: "wp-codebox-sandbox",
+  provider: "codex",
+  model: "gpt-5.5",
+  sandboxToolPolicy: { schema: "wp-codebox/sandbox-tool-policy/v1", version: 1, tools: [] },
+})
+assert.match(sandboxAgentCode, /wp_codebox_register_sandbox_chat_handler\(\)/)
+assert.match(sandboxAgentCode, /wp_agent_chat_handler/)
+assert.match(sandboxAgentCode, /wp_codebox_execute_sandbox_chat_turn/)


### PR DESCRIPTION
## Summary
- register a sandbox-only agents/chat handler when WP Codebox executes agent sandbox runs and no prior handler exists
- dispatch the chat turn through PHP AI Client using the requested provider/model
- assert generated sandbox PHP contains the handler registration

## Testing
- npm exec tsx tests/runtime-php-snippets.test.ts
- npm exec tsx tests/agent-task-contracts.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the sandbox chat-handler wiring and generated-code assertion; Chris requested the continued proof run and remains responsible for review and merge.