### PR TITLE
Prepare generic runtime overlay packs

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -501,15 +501,43 @@ export async function prepareRecipeRuntimeOverlays(recipe: WorkspaceRecipe, reci
     if (!descriptor) {
       throw new Error(`Unsupported runtime overlay: ${overlay.kind}/${overlay.library}/${overlay.strategy}`)
     }
-    if (!descriptor.prepare) {
-      throw new Error(`Runtime overlay descriptor has no CLI preparer: ${overlay.kind}/${overlay.library}/${overlay.strategy}`)
-    }
 
-    const prepared = await descriptor.prepare(overlay, recipeDirectory, index)
+    const prepared = descriptor.prepare
+      ? await descriptor.prepare(overlay, recipeDirectory, index)
+      : await prepareDeclaredRuntimeOverlayPack(overlay, recipeDirectory, index, descriptor.defaultTarget)
     overlays.push(prepared)
   }
 
   return overlays
+}
+
+async function prepareDeclaredRuntimeOverlayPack(overlay: WorkspaceRecipeRuntimeOverlay, recipeDirectory: string, index: number, defaultTarget: string): Promise<PreparedRuntimeOverlay> {
+  const source = resolve(recipeDirectory, overlay.source)
+  await validateExistingDirectoryForOverlay(source, overlay.source)
+  const target = overlay.target ?? defaultTarget
+  const digest = await directoryContentDigest(source)
+
+  return {
+    source,
+    target,
+    type: "directory",
+    mode: "readonly",
+    cleanupPaths: [],
+    metadata: {
+      kind: "runtime-overlay",
+      index,
+      overlayKind: overlay.kind,
+      library: overlay.library,
+      strategy: overlay.strategy,
+      source: overlay.source,
+      target,
+      preparedPath: source,
+      preparedPathKind: "local",
+      digest: { sha256: digest },
+      ...(overlay.bundle ? { bundle: overlay.bundle } : {}),
+      ...(overlay.metadata ? { userMetadata: overlay.metadata } : {}),
+    },
+  }
 }
 
 async function preparePhpAiClientOverlay(overlay: WorkspaceRecipeRuntimeOverlay, recipeDirectory: string, index: number): Promise<PreparedRuntimeOverlay> {

--- a/tests/runtime-overlay-descriptors.test.ts
+++ b/tests/runtime-overlay-descriptors.test.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { parseWorkspaceRecipeJson, validateWorkspaceRecipeShape } from "../packages/cli/src/recipe-validation.js"
+import { prepareRecipeRuntimeOverlays } from "../packages/cli/src/recipe-sources.js"
 import { loadConfiguredRuntimeOverlayDescriptors, registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor } from "../packages/cli/src/runtime-overlay-registry.js"
 import { discoverRuntimeOverlayDescriptorManifests, runtimeOverlayDescriptorManifest } from "../packages/runtime-core/src/index.js"
 import { withTempDir } from "../scripts/test-kit.js"
@@ -31,12 +32,21 @@ await withTempDir("wp-codebox-runtime-overlay-descriptors-", async (root) => {
   loadConfiguredRuntimeOverlayDescriptors(descriptorDirectory)
   assert.ok(registeredRuntimeOverlayDescriptors().some((descriptor) => descriptor.library === "example-provider"))
 
+  await mkdir(join(root, "overlays", "example"), { recursive: true })
+  await writeFile(join(root, "overlays", "example", "runtime.php"), "<?php\n")
+
   const recipe = parseWorkspaceRecipeJson(JSON.stringify({
     schema: "wp-codebox/workspace-recipe/v1",
     runtime: { overlays: [{ kind: "provider-runtime", library: "example-provider", strategy: "provider-owned-bundle", source: "overlays/example" }] },
     workflow: { steps: [{ command: "noop" }] },
   }))
   validateWorkspaceRecipeShape(recipe, join(root, "recipe.json"))
+  const [prepared] = await prepareRecipeRuntimeOverlays(recipe, root)
+  assert.equal(prepared.source, join(root, "overlays", "example"))
+  assert.equal(prepared.target, "/wordpress/wp-content/mu-plugins/example-provider-runtime")
+  assert.equal(prepared.mode, "readonly")
+  assert.equal(prepared.metadata.preparedPathKind, "local")
+  assert.equal(typeof (prepared.metadata.digest as { sha256?: unknown }).sha256, "string")
 
   await writeFile(join(descriptorDirectory, "wp-codebox-runtime-overlays.json"), JSON.stringify({
     schema: "wp-codebox/runtime-overlay-descriptors/v1",


### PR DESCRIPTION
## Summary
- allow validated runtime overlay descriptors without custom CLI preparers to materialize as readonly local directory overlay packs
- keep the existing `php-ai-client` custom preparer unchanged
- record digest/provenance metadata for generic prepared overlay packs

## Testing
- `npm run test:runtime-overlay-descriptors`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the generic overlay preparation change and test coverage; Chris remains responsible for review and testing.