### PR TITLE
Run distribution startup probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test:generic-ability-runtime-run": "tsx tests/generic-ability-runtime-run.test.ts",
     "test:provider-runtime-contracts": "tsx tests/provider-runtime-contracts.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
+    "test:distribution-startup-probes": "tsx tests/distribution-startup-probes.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",
     "test:php-path-policy-parity": "php scripts/php-path-policy-parity-smoke.php",
     "test:production-boundary-enforcement": "tsx tests/production-boundary-enforcement.test.ts",

--- a/packages/cli/src/commands/recipe-declared-artifacts.ts
+++ b/packages/cli/src/commands/recipe-declared-artifacts.ts
@@ -3,7 +3,7 @@ import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, STRUCTURED_ARTIFACT_SCHEMA, TYPED_
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { appendRecipeRuntimeEvidenceFiles } from "../recipe-evidence.js"
 import { serializeRecipeRunError, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError } from "./recipe-run-output.js"
-import type { RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunProbe } from "./recipe-run-types.js"
+import type { RecipeRunDeclaredArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunProbe } from "./recipe-run-types.js"
 
 const DECLARED_ARTIFACT_CAPTURE_MAX_BYTES = DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES
 const declaredArtifactContents = new WeakMap<RecipeRunDeclaredArtifact, Buffer>()
@@ -208,12 +208,17 @@ export function recipeDeclaredArtifactFailure(declaredArtifacts: RecipeRunDeclar
   return declaredArtifacts.some((artifact) => artifact.required && artifact.status !== "collected") ? new RecipeDeclaredArtifactFailureError(declaredArtifacts) : undefined
 }
 
-export function recipeRuntimeEvidenceFiles(fixtureDatabases: RecipeRunFixtureDatabase[], probes: RecipeRunProbe[], declaredArtifacts: RecipeRunDeclaredArtifact[]): Array<{ filename: string; kind: string; value: unknown }> {
+export function recipeRuntimeEvidenceFiles(fixtureDatabases: RecipeRunFixtureDatabase[], distributionStartupProbes: RecipeRunDistributionStartupProbe[], probes: RecipeRunProbe[], declaredArtifacts: RecipeRunDeclaredArtifact[]): Array<{ filename: string; kind: string; value: unknown }> {
   return [
     ...(fixtureDatabases.length > 0 ? [{ filename: "fixture-databases.json", kind: "fixture-database-results", value: { schema: "wp-codebox/fixture-database-results/v1", fixtures: fixtureDatabases } }] : []),
+    ...(distributionStartupProbes.length > 0 ? [{ filename: "distribution-startup-probes.json", kind: "distribution-startup-probe-results", value: { schema: "wp-codebox/distribution-startup-probe-results/v1", passed: !distributionStartupProbeFailure(distributionStartupProbes), probes: distributionStartupProbes } }] : []),
     ...(probes.length > 0 ? [{ filename: "recipe-probes.json", kind: "recipe-probe-results", value: { schema: "wp-codebox/recipe-probe-results/v1", passed: !recipeProbeFailure(probes), probes } }] : []),
     ...(declaredArtifacts.length > 0 ? [{ filename: "recipe-declared-artifacts.json", kind: "recipe-declared-artifact-results", value: { schema: "wp-codebox/recipe-declared-artifact-results/v1", passed: !recipeDeclaredArtifactFailure(declaredArtifacts), artifacts: declaredArtifacts } }] : []),
   ]
+}
+
+function distributionStartupProbeFailure(probes: RecipeRunDistributionStartupProbe[]): boolean {
+  return probes.some((probe) => probe.status === "failed")
 }
 
 export function recipeProbeFailure(probes: RecipeRunProbe[]): RecipeProbeFailureError | undefined {

--- a/packages/cli/src/commands/recipe-run-finalizer.ts
+++ b/packages/cli/src/commands/recipe-run-finalizer.ts
@@ -42,6 +42,7 @@ interface RecipeRunCommonOutputFields {
   stagedFiles?: RecipeRunStagedFile[]
   fixtureDatabases?: RecipeRunFixtureDatabase[]
   siteSeeds?: RecipeRunSiteSeed[]
+  distributionStartupProbes?: RecipeRunOutput["distributionStartupProbes"]
   probes?: RecipeRunProbe[]
   declaredArtifacts?: RecipeRunDeclaredArtifact[]
   phaseEvidence?: RecipePhaseEvidence[]
@@ -97,6 +98,7 @@ export function completedRecipeOutputFields(args: {
   stagedFiles: RecipeRunStagedFile[]
   fixtureDatabases: RecipeRunFixtureDatabase[]
   siteSeeds: RecipeRunOutput["siteSeeds"]
+  distributionStartupProbes: NonNullable<RecipeRunOutput["distributionStartupProbes"]>
   probes: RecipeRunProbe[]
   declaredArtifacts: RecipeRunDeclaredArtifact[]
   phaseEvidence: RecipePhaseEvidence[]
@@ -111,6 +113,7 @@ export function completedRecipeOutputFields(args: {
     stagedFiles: args.stagedFiles,
     fixtureDatabases: args.fixtureDatabases,
     siteSeeds: args.siteSeeds,
+    ...(args.distributionStartupProbes.length > 0 ? { distributionStartupProbes: args.distributionStartupProbes } : {}),
     probes: args.probes,
     declaredArtifacts: args.declaredArtifacts,
     phaseEvidence: args.phaseEvidence,

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -49,6 +49,7 @@ export interface RecipeRunOutput {
   stagedFiles?: RecipeRunStagedFile[]
   fixtureDatabases?: RecipeRunFixtureDatabase[]
   siteSeeds?: RecipeRunSiteSeed[]
+  distributionStartupProbes?: RecipeRunDistributionStartupProbe[]
   probes?: RecipeRunProbe[]
   declaredArtifacts?: RecipeRunDeclaredArtifact[]
   phaseEvidence?: RecipePhaseEvidence[]
@@ -149,7 +150,7 @@ export interface RecipeDiagnosticArtifactRef {
   sha256?: string
 }
 
-export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "import_fixture_databases" | "run_workloads" | "run_probes" | "collect_artifacts"
+export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "import_fixture_databases" | "run_distribution_startup_probes" | "run_workloads" | "run_probes" | "collect_artifacts"
 
 export interface RecipePhaseEvidence {
   schema: "wp-codebox/recipe-phase-evidence/v1"
@@ -240,6 +241,21 @@ export interface RecipeRunProbe {
   stderr: string
   parsedJson?: unknown
   allowFailure: boolean
+  metadata?: Record<string, unknown>
+}
+
+export interface RecipeRunDistributionStartupProbe {
+  schema: "wp-codebox/distribution-startup-probe-result/v1"
+  index: number
+  name: string
+  type: "http" | "browser" | "wp-cli" | "php"
+  status: "passed" | "failed" | "skipped"
+  command?: string
+  args?: string[]
+  exitCode?: number
+  stdout?: string
+  stderr?: string
+  reason?: string
   metadata?: Record<string, unknown>
 }
 

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -1,11 +1,11 @@
-import { type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
+import { type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { recipeWorkflowSteps, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { artifactManifestFilesByPath } from "./recipe-run-benchmark-artifacts.js"
 import { serializeRecipeRunError } from "./recipe-run-output.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunOptions, RecipeRunProbe } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe } from "./recipe-run-types.js"
 
 export function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number, recipeCommand?: string): RecipeExecutionResult {
   return {
@@ -177,6 +177,46 @@ export async function runRecipeProbes(recipe: WorkspaceRecipe, recipeDirectory: 
   return results
 }
 
+export async function runDistributionStartupProbes(recipe: WorkspaceRecipe, runtime: Runtime, executions: RecipeExecutionResult[]): Promise<RecipeRunDistributionStartupProbe[]> {
+  const results: RecipeRunDistributionStartupProbe[] = []
+  for (const [index, probe] of (recipe.distribution?.startupProbes ?? []).entries()) {
+    if (probe.type === "http" || probe.type === "browser") {
+      results.push(stripUndefined({
+        schema: "wp-codebox/distribution-startup-probe-result/v1" as const,
+        index,
+        name: probe.name,
+        type: probe.type,
+        status: "skipped" as const,
+        reason: "Distribution startup probe type is planned but not executable by this runtime primitive.",
+        metadata: probe.metadata,
+      }))
+      continue
+    }
+
+    const execution = await executeDistributionStartupProbe(runtime, probe, index)
+    executions.push(execution)
+    results.push(stripUndefined({
+      schema: "wp-codebox/distribution-startup-probe-result/v1" as const,
+      index,
+      name: probe.name,
+      type: probe.type,
+      status: execution.exitCode === 0 ? "passed" as const : "failed" as const,
+      command: execution.command,
+      args: execution.args,
+      exitCode: execution.exitCode,
+      stdout: execution.stdout,
+      stderr: execution.stderr,
+      metadata: probe.metadata,
+    }))
+  }
+  return results
+}
+
+export function distributionStartupProbeFailure(probes: RecipeRunDistributionStartupProbe[]): Error | undefined {
+  const failed = probes.find((probe) => probe.status === "failed")
+  return failed ? new Error(`Distribution startup probe "${failed.name}" failed with exit code ${failed.exitCode ?? "unknown"}.`) : undefined
+}
+
 async function executeRecipeProbe(runtime: Runtime, probe: WorkspaceRecipeProbe, recipeDirectory: string, index: number): Promise<RecipeExecutionResult> {
   try {
     const execution = await runtime.execute(await recipeExecutionSpec(probe.step, recipeDirectory))
@@ -184,6 +224,19 @@ async function executeRecipeProbe(runtime: Runtime, probe: WorkspaceRecipeProbe,
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Recipe probe "${probe.name}" failed before producing a result: ${message}`, { cause: error })
+  }
+}
+
+async function executeDistributionStartupProbe(runtime: Runtime, probe: WorkspaceRecipeDistributionStartupProbe, index: number): Promise<RecipeExecutionResult> {
+  const spec = probe.type === "wp-cli"
+    ? { command: "wordpress.wp-cli", args: [`command=${probe.command ?? ""}`] }
+    : { command: "wordpress.run-php", args: [`code=${probe.code ?? ""}`] }
+  try {
+    const execution = await runtime.execute(spec)
+    return withRecipeExecutionPhase(execution, "setup", index, `distribution.startupProbe:${probe.name}`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Distribution startup probe "${probe.name}" failed before producing a result: ${message}`, { cause: error })
   }
 }
 

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -23,8 +23,8 @@ import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRu
 import { RecipePhaseError } from "./recipe-run-phases.js"
 import { importRecipeSiteSeeds } from "./recipe-site-seeds.js"
 import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRuntimeSetup, recipeRunDependencyOverlay, recipeRunExtraPlugin, recipeRunStagedFile } from "./recipe-runtime-setup.js"
-import { executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowStepIsAdvisory, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
+import { distributionStartupProbeFailure, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowStepIsAdvisory, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
@@ -111,6 +111,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
   const executions: RecipeExecutionResult[] = []
   let fixtureDatabases: RecipeRunFixtureDatabase[] = []
+  let distributionStartupProbes: RecipeRunDistributionStartupProbe[] = []
   let probes: RecipeRunProbe[] = []
   let declaredArtifacts: RecipeRunDeclaredArtifact[] = []
   let advisoryFailures: RecipeAdvisoryFailure[] = []
@@ -225,6 +226,11 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
 
     const sandboxWorkspace = sandboxWorkspaceContract(workspaceMounts, recipe.inputs?.mounts ?? [])
     const workflowSteps = recipeWorkflowSteps(recipe)
+    distributionStartupProbes = await phaseTracker.run("run_distribution_startup_probes", phaseDistributionStartupProbeData(recipe), async () => await awaitRecipe("distribution.startup-probes.run", runDistributionStartupProbes(recipe, runtime!, executions)))
+    const startupProbeFailure = distributionStartupProbeFailure(distributionStartupProbes)
+    if (startupProbeFailure) {
+      throw startupProbeFailure
+    }
     await phaseTracker.run("run_workloads", phaseWorkflowData(workflowSteps), async () => {
       for (const workflowStep of workflowSteps) {
         const operation = `workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`
@@ -258,7 +264,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       browserEvidence = await recipeBrowserEvidence(artifacts, executions)
       await artifactPointer.update({ runtime: await runtime!.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
-      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts))
+      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionStartupProbes, probes, declaredArtifacts))
       if (declaredArtifactFailure) {
         throw declaredArtifactFailure
       }
@@ -282,7 +288,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, runtime)
       await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
-      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts))
+      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionStartupProbes, probes, declaredArtifacts))
       evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)
       const previewAgentEvidence = await finalizeAgentSandboxEvidence(artifacts, executions)
       Object.assign(evidence, previewAgentEvidence)
@@ -322,7 +328,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         browserEvidence,
         replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
         failure: recipeFailure,
-        output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
+        output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
       })
     }
 
@@ -341,7 +347,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       phaseEvidence: phaseTracker.list(),
       browserEvidence,
       replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
-      output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
+      output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
     })
   } catch (error) {
     const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
@@ -355,6 +361,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       overlays,
       executions,
       fixtureDatabases,
+      distributionStartupProbes,
       probes,
       declaredArtifacts,
       phaseEvidence: phaseTracker.list(),
@@ -385,7 +392,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
           }
           await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
           const evidenceFiles = await appendRecipeRuntimeEvidence(artifacts, [
-            ...recipeRuntimeEvidenceFiles(fixtureDatabases, probes, declaredArtifacts),
+            ...recipeRuntimeEvidenceFiles(fixtureDatabases, distributionStartupProbes, probes, declaredArtifacts),
             failureDiagnostics,
           ])
           diagnosticArtifacts = evidenceFiles
@@ -441,6 +448,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions, error),
         stagedFiles: stagedFiles.map(recipeRunStagedFile),
         fixtureDatabases,
+        distributionStartupProbes,
         probes,
         declaredArtifacts,
         phaseEvidence: phaseTracker.list(),
@@ -687,6 +695,7 @@ function recipeFailureRuntimeEvidenceFile(args: {
   overlays: PreparedRuntimeOverlay[]
   executions: RecipeExecutionResult[]
   fixtureDatabases: RecipeRunFixtureDatabase[]
+  distributionStartupProbes: RecipeRunDistributionStartupProbe[]
   probes: RecipeRunProbe[]
   declaredArtifacts: RecipeRunDeclaredArtifact[]
   phaseEvidence: RecipePhaseEvidence[]
@@ -716,6 +725,7 @@ function recipeFailureRuntimeEvidenceFile(args: {
       preparedRuntimeOverlays: args.overlays.map((overlay) => ({ target: overlay.target, type: overlay.type, mode: overlay.mode, metadata: overlay.metadata })),
       executions: args.executions,
       fixtureDatabases: args.fixtureDatabases,
+      distributionStartupProbes: args.distributionStartupProbes,
       probes: args.probes,
       declaredArtifacts: args.declaredArtifacts,
       phaseEvidence: args.phaseEvidence,
@@ -817,6 +827,19 @@ function phaseFixtureDatabaseData(recipe: WorkspaceRecipe): Record<string, unkno
       format: fixture.format ?? "sql",
       resetStrategy: fixture.reset?.strategy ?? "truncate-tables",
       resetTables: fixture.reset?.tables ?? [],
+    })),
+  }
+}
+
+function phaseDistributionStartupProbeData(recipe: WorkspaceRecipe): Record<string, unknown> {
+  const probes = recipe.distribution?.startupProbes ?? []
+  return {
+    count: probes.length,
+    probes: probes.map((probe, index) => ({
+      index,
+      name: probe.name,
+      type: probe.type,
+      executable: probe.type === "wp-cli" || probe.type === "php",
     })),
   }
 }

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -762,9 +762,15 @@ export function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
     ...(recipe.inputs?.pluginRuntime?.setup ?? []),
     ...(recipe.inputs?.pluginRuntime?.healthProbes ?? []).map(pluginRuntimeHealthProbeStep),
   ].map((step) => step.command)
+  const distributionStartupProbeCommands = (recipe.distribution?.startupProbes ?? []).flatMap((probe) => {
+    if (probe.type === "wp-cli") return ["wordpress.wp-cli"]
+    if (probe.type === "php") return ["wordpress.run-php"]
+    return []
+  })
   const commands = [
     ...effectivePolicyCommandsFor(recipeWorkflowSteps(recipe).map(({ step }) => step.command), cliRecipeCommandDefinitions),
     ...effectivePolicyCommandsFor(pluginRuntimeCommands, cliRecipeCommandDefinitions),
+    ...effectivePolicyCommandsFor(distributionStartupProbeCommands, cliRecipeCommandDefinitions),
     ...effectivePolicyCommandsFor((recipe.probes ?? []).map((probe) => probe.step.command), cliRecipeCommandDefinitions),
   ]
   if (recipeWorkflowSteps(recipe).some(({ step }) => step.command === "wordpress.bench" && recipeBenchStepUsesWpCli(step))) {

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -79,7 +79,7 @@ export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummar
     artifacts,
     refs: {
       startup_logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log" || artifact.kind === "codebox-command-events" || artifact.kind === "codebox-event-log" || artifact.kind === "codebox-runtime-metadata"),
-      probe_json: artifacts.filter((artifact) => artifact.kind === "browser-summary" || artifact.kind === "recipe-probe-results"),
+      probe_json: artifacts.filter((artifact) => artifact.kind === "browser-summary" || artifact.kind === "recipe-probe-results" || artifact.kind === "distribution-startup-probe-results"),
       screenshots: artifacts.filter((artifact) => artifact.kind === "browser-screenshot" || artifact.kind === "screenshot"),
       side_effects: artifacts.filter((artifact) => artifact.kind === "recipe-side-effects" || artifact.kind === "runtime-side-effects" || artifact.kind === "codebox-observations"),
       declared_artifacts: artifacts.filter((artifact) => artifact.kind === "recipe-declared-artifact" || artifact.kind === "recipe-declared-artifact-results"),
@@ -162,6 +162,14 @@ function normalizeRecipeRunArtifacts(result: Record<string, unknown>, agentTaskA
     appendUniqueArtifact(artifacts, stripUndefined({
       id: stringValue(probe.name) || `recipe-probe-${numberValue(probe.index) ?? artifacts.length + 1}`,
       kind: "recipe-probe-result",
+      metadata: probe,
+    }))
+  }
+
+  for (const probe of arrayObjects(result.distributionStartupProbes)) {
+    appendUniqueArtifact(artifacts, stripUndefined({
+      id: stringValue(probe.name) || `distribution-startup-probe-${numberValue(probe.index) ?? artifacts.length + 1}`,
+      kind: "distribution-startup-probe-result",
       metadata: probe,
     }))
   }

--- a/tests/distribution-startup-probes.test.ts
+++ b/tests/distribution-startup-probes.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict"
+
+import type { Runtime, WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { normalizeRecipeRunSummary } from "../packages/runtime-core/src/recipe-run-summary.js"
+import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
+import { distributionStartupProbeFailure, runDistributionStartupProbes } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+
+const recipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  distribution: {
+    name: "custom-distribution",
+    wordpress: { root: "/wordpress" },
+    startupProbes: [
+      { name: "database", type: "wp-cli", command: "option get siteurl", metadata: { role: "readiness" } },
+      { name: "bootstrap", type: "php", code: "echo 'ready';" },
+      { name: "homepage", type: "http", url: "/" },
+    ],
+  },
+  workflow: { steps: [{ command: "wordpress.run-php", args: ["code=echo 'workload';"] }] },
+}
+
+const policy = recipePolicy(recipe)
+assert.ok(policy.commands.includes("wordpress.wp-cli"), "wp-cli startup probes are policy-visible")
+assert.ok(policy.commands.includes("wordpress.run-php"), "php startup probes are policy-visible")
+
+const executed: Array<{ command: string; args: string[] }> = []
+const runtime = {
+  async execute(spec: { command: string; args?: string[] }) {
+    executed.push({ command: spec.command, args: spec.args ?? [] })
+    return {
+      id: `execution-${executed.length}`,
+      command: spec.command,
+      args: spec.args ?? [],
+      exitCode: 0,
+      stdout: spec.command === "wordpress.wp-cli" ? "http://example.test\n" : "ready",
+      stderr: "",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:00.001Z",
+    }
+  },
+} as Runtime
+
+const executions = []
+const results = await runDistributionStartupProbes(recipe, runtime, executions)
+
+assert.deepEqual(executed, [
+  { command: "wordpress.wp-cli", args: ["command=option get siteurl"] },
+  { command: "wordpress.run-php", args: ["code=echo 'ready';"] },
+])
+assert.equal(executions.length, 2)
+assert.deepEqual(results.map((result) => [result.name, result.type, result.status]), [
+  ["database", "wp-cli", "passed"],
+  ["bootstrap", "php", "passed"],
+  ["homepage", "http", "skipped"],
+])
+assert.equal(results[0]?.metadata?.role, "readiness")
+assert.equal(distributionStartupProbeFailure(results), undefined)
+
+const summary = normalizeRecipeRunSummary({
+  success: true,
+  executions,
+  distributionStartupProbes: results,
+  artifacts: { directory: "/tmp/artifacts" },
+})
+assert.ok(summary.artifacts.some((artifact) => artifact.kind === "distribution-startup-probe-result" && artifact.id === "database"))
+
+console.log("distribution startup probes passed")


### PR DESCRIPTION
## Summary
- execute generic `distribution.startupProbes` for `wp-cli` and `php` probes through existing runtime commands
- record `http` and `browser` probes as explicit skipped startup probe results for now
- include startup probe results in recipe evidence, declared artifacts, failure diagnostics, and run summaries

## Testing
- `npm run test:distribution-startup-probes`
- `npm run test:recipe-validation-descriptors`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the generic startup probe execution primitive and tests; Chris remains responsible for review and testing.