### PR TITLE
Run browser distribution startup probes

### DIFF
--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -256,6 +256,10 @@ export interface RecipeRunDistributionStartupProbe {
   stdout?: string
   stderr?: string
   reason?: string
+  missingCommand?: string
+  url?: string
+  expectStatus?: number
+  availableCommands?: string[]
   metadata?: Record<string, unknown>
 }
 

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -180,14 +180,18 @@ export async function runRecipeProbes(recipe: WorkspaceRecipe, recipeDirectory: 
 export async function runDistributionStartupProbes(recipe: WorkspaceRecipe, runtime: Runtime, executions: RecipeExecutionResult[]): Promise<RecipeRunDistributionStartupProbe[]> {
   const results: RecipeRunDistributionStartupProbe[] = []
   for (const [index, probe] of (recipe.distribution?.startupProbes ?? []).entries()) {
-    if (probe.type === "http" || probe.type === "browser") {
+    if (probe.type === "http") {
       results.push(stripUndefined({
         schema: "wp-codebox/distribution-startup-probe-result/v1" as const,
         index,
         name: probe.name,
         type: probe.type,
         status: "skipped" as const,
-        reason: "Distribution startup probe type is planned but not executable by this runtime primitive.",
+        reason: "Distribution startup http probes require a generic HTTP runtime command, but this runtime only exposes REST and browser primitives.",
+        missingCommand: "wordpress.http-request",
+        url: probe.url,
+        expectStatus: probe.expectStatus,
+        availableCommands: ["wordpress.rest-request", "wordpress.browser-probe"],
         metadata: probe.metadata,
       }))
       continue
@@ -228,9 +232,7 @@ async function executeRecipeProbe(runtime: Runtime, probe: WorkspaceRecipeProbe,
 }
 
 async function executeDistributionStartupProbe(runtime: Runtime, probe: WorkspaceRecipeDistributionStartupProbe, index: number): Promise<RecipeExecutionResult> {
-  const spec = probe.type === "wp-cli"
-    ? { command: "wordpress.wp-cli", args: [`command=${probe.command ?? ""}`] }
-    : { command: "wordpress.run-php", args: [`code=${probe.code ?? ""}`] }
+  const spec = distributionStartupProbeExecutionSpec(probe)
   try {
     const execution = await runtime.execute(spec)
     return withRecipeExecutionPhase(execution, "setup", index, `distribution.startupProbe:${probe.name}`)
@@ -238,6 +240,16 @@ async function executeDistributionStartupProbe(runtime: Runtime, probe: Workspac
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Distribution startup probe "${probe.name}" failed before producing a result: ${message}`, { cause: error })
   }
+}
+
+function distributionStartupProbeExecutionSpec(probe: WorkspaceRecipeDistributionStartupProbe): { command: string; args: string[] } {
+  if (probe.type === "wp-cli") {
+    return { command: "wordpress.wp-cli", args: [`command=${probe.command ?? ""}`] }
+  }
+  if (probe.type === "php") {
+    return { command: "wordpress.run-php", args: [`code=${probe.code ?? ""}`] }
+  }
+  return { command: "wordpress.browser-probe", args: [`url=${probe.url ?? ""}`] }
 }
 
 function parseProbeJson(stdout: string): unknown | undefined {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -839,7 +839,7 @@ function phaseDistributionStartupProbeData(recipe: WorkspaceRecipe): Record<stri
       index,
       name: probe.name,
       type: probe.type,
-      executable: probe.type === "wp-cli" || probe.type === "php",
+      executable: probe.type === "wp-cli" || probe.type === "php" || probe.type === "browser",
     })),
   }
 }

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -765,6 +765,7 @@ export function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
   const distributionStartupProbeCommands = (recipe.distribution?.startupProbes ?? []).flatMap((probe) => {
     if (probe.type === "wp-cli") return ["wordpress.wp-cli"]
     if (probe.type === "php") return ["wordpress.run-php"]
+    if (probe.type === "browser") return ["wordpress.browser-probe"]
     return []
   })
   const commands = [

--- a/tests/distribution-startup-probes.test.ts
+++ b/tests/distribution-startup-probes.test.ts
@@ -13,7 +13,8 @@ const recipe: WorkspaceRecipe = {
     startupProbes: [
       { name: "database", type: "wp-cli", command: "option get siteurl", metadata: { role: "readiness" } },
       { name: "bootstrap", type: "php", code: "echo 'ready';" },
-      { name: "homepage", type: "http", url: "/" },
+      { name: "homepage", type: "browser", url: "/" },
+      { name: "api", type: "http", url: "/wp-json/", expectStatus: 200 },
     ],
   },
   workflow: { steps: [{ command: "wordpress.run-php", args: ["code=echo 'workload';"] }] },
@@ -22,6 +23,7 @@ const recipe: WorkspaceRecipe = {
 const policy = recipePolicy(recipe)
 assert.ok(policy.commands.includes("wordpress.wp-cli"), "wp-cli startup probes are policy-visible")
 assert.ok(policy.commands.includes("wordpress.run-php"), "php startup probes are policy-visible")
+assert.ok(policy.commands.includes("wordpress.browser-probe"), "browser startup probes are policy-visible")
 
 const executed: Array<{ command: string; args: string[] }> = []
 const runtime = {
@@ -46,14 +48,20 @@ const results = await runDistributionStartupProbes(recipe, runtime, executions)
 assert.deepEqual(executed, [
   { command: "wordpress.wp-cli", args: ["command=option get siteurl"] },
   { command: "wordpress.run-php", args: ["code=echo 'ready';"] },
+  { command: "wordpress.browser-probe", args: ["url=/"] },
 ])
-assert.equal(executions.length, 2)
+assert.equal(executions.length, 3)
 assert.deepEqual(results.map((result) => [result.name, result.type, result.status]), [
   ["database", "wp-cli", "passed"],
   ["bootstrap", "php", "passed"],
-  ["homepage", "http", "skipped"],
+  ["homepage", "browser", "passed"],
+  ["api", "http", "skipped"],
 ])
 assert.equal(results[0]?.metadata?.role, "readiness")
+assert.equal(results[3]?.missingCommand, "wordpress.http-request")
+assert.equal(results[3]?.url, "/wp-json/")
+assert.equal(results[3]?.expectStatus, 200)
+assert.deepEqual(results[3]?.availableCommands, ["wordpress.rest-request", "wordpress.browser-probe"])
 assert.equal(distributionStartupProbeFailure(results), undefined)
 
 const summary = normalizeRecipeRunSummary({


### PR DESCRIPTION
## Summary
- execute browser distribution startup probes through the existing `wordpress.browser-probe` command
- include browser startup probes in runtime policy and phase metadata
- keep HTTP probes skipped but add structured missing-command evidence

## Testing
- `npm run test:distribution-startup-probes`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted browser startup probe execution and test updates; Chris remains responsible for review and testing.