### PR TITLE
Support route matrix benchmark workloads

### DIFF
--- a/docs/benchmark-contract.md
+++ b/docs/benchmark-contract.md
@@ -45,7 +45,53 @@ The command contract is intentionally broad enough for future workload types:
 - **PHP:** direct workload callables and inline configured workload steps.
 - **WP-CLI:** configured workload steps that execute in the same sandbox.
 - **Ability:** future ability-backed workload steps should still return generic numeric metrics and metadata.
+- **REST:** configured `rest-request` steps call `rest_do_request()` in-process. A configured workload may declare `route_matrix` as a compact list of REST routes; WP Codebox expands each route into the existing `rest-request` step type.
 - **Browser:** `wordpress.browser-probe` captures generic browser performance and memory artifacts. When a recipe runs browser probes before `wordpress.bench`, selected numeric `browser_*` metrics are promoted into each benchmark scenario while raw browser artifacts remain in the bundle.
+
+## REST Route Matrices
+
+Route-matrix workloads are for API profiling suites that want one benchmark
+scenario to cover a bounded set of REST routes without writing PHP glue. Each
+entry maps directly to a `rest-request` workload step and supports `method`,
+`path` or `route`, `params`, `headers`, `body`, `body-json`, `capture-response`,
+`metric-prefix`, and `metadata`. When `metric-prefix` is omitted and `id` is
+present, WP Codebox derives a `rest_<id>` prefix and then applies the normal
+metric-prefix sanitization.
+
+```json
+{
+  "id": "rest-catalog",
+  "source": "config",
+  "route_matrix": [
+    {
+      "id": "products-list",
+      "method": "GET",
+      "path": "/wc/v3/products",
+      "params": { "per_page": 10 },
+      "capture-response": true
+    },
+    {
+      "id": "orders-list",
+      "method": "GET",
+      "route": "/wc/v3/orders"
+    }
+  ],
+  "artifacts": {
+    "route-summary": {
+      "path": "bench/rest-route-summary.json",
+      "kind": "json",
+      "source": "scenario-artifact"
+    }
+  }
+}
+```
+
+The route-matrix contract is generic: callers decide which routes represent a
+product suite, how fixtures are installed, whether captured responses are safe to
+persist, and how route-level metrics are scored. WP Codebox only executes the
+requests, records numeric timing/status metrics, carries declared scenario
+artifacts, and exposes the results through the normal benchmark summary and
+artifact extraction commands.
 
 ## Result Shape
 

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -192,6 +192,29 @@ Use `allowFailure: true` or `advisory: true` for evidence-only workflow steps.
 Failed advisory steps are reported in `advisoryFailures` and do not make an
 otherwise successful recipe return `success: false`.
 
+## REST Benchmark Workloads
+
+Recipes can pass REST profiling workloads to `wordpress.bench` with
+`workloads-json`. A workload may use `route_matrix` to declare a bounded set of
+REST requests; the runtime expands each route into the existing `rest-request`
+step and returns normal benchmark scenarios/artifacts.
+
+```json
+{
+  "command": "wordpress.bench",
+  "args": [
+    "plugin-slug=woocommerce",
+    "iterations=3",
+    "warmup-iterations=1",
+    "workloads-json=[{\"id\":\"rest-catalog\",\"source\":\"config\",\"route_matrix\":[{\"id\":\"products-list\",\"method\":\"GET\",\"path\":\"/wc/v3/products\",\"params\":{\"per_page\":10}}],\"artifacts\":{\"route-summary\":{\"path\":\"bench/rest-route-summary.json\",\"kind\":\"json\",\"source\":\"scenario-artifact\"}}}]"
+  ]
+}
+```
+
+Use site seeds, fixture databases, or staged files for product-specific data
+setup. Use `artifacts` on the workload for declared per-scenario outputs that
+downstream lab tooling should extract from `benchResults` or an artifact bundle.
+
 ## Fixture Imports And Bootstrap Declarations
 
 `inputs.siteSeeds` is the generic fixture import primitive. JSON fixture seeds

--- a/packages/runtime-core/src/benchmark-contracts.ts
+++ b/packages/runtime-core/src/benchmark-contracts.ts
@@ -109,11 +109,26 @@ export interface BenchmarkDefinitionWorkloadStep {
   [key: string]: unknown
 }
 
+export interface BenchmarkDefinitionRestRouteMatrixEntry {
+  id?: string
+  method?: string
+  path?: string
+  route?: string
+  params?: Record<string, unknown>
+  headers?: Record<string, unknown>
+  body?: unknown
+  "body-json"?: unknown
+  "capture-response"?: boolean
+  "metric-prefix"?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface BenchmarkDefinitionWorkload {
   id: string
   source?: BenchmarkScenarioSource
   file?: string
   run?: BenchmarkDefinitionWorkloadStep[]
+  route_matrix?: BenchmarkDefinitionRestRouteMatrixEntry[]
   artifacts?: Record<string, BenchmarkArtifactRef>
   metadata?: Record<string, unknown>
 }
@@ -321,9 +336,28 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
         source: { type: "string" },
         file: { type: "string" },
         run: { type: "array", items: { $ref: "#/$defs/workloadStep" } },
+        route_matrix: { type: "array", items: { $ref: "#/$defs/restRouteMatrixEntry" } },
         artifacts: { $ref: "#/$defs/artifactMap" },
         metadata: { type: "object", additionalProperties: true },
       },
+    },
+    restRouteMatrixEntry: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        id: { type: "string", minLength: 1 },
+        method: { type: "string", minLength: 1 },
+        path: { type: "string", minLength: 1 },
+        route: { type: "string", minLength: 1 },
+        params: { type: "object", additionalProperties: true },
+        headers: { type: "object", additionalProperties: true },
+        body: true,
+        "body-json": true,
+        "capture-response": { type: "boolean" },
+        "metric-prefix": { type: "string", minLength: 1 },
+        metadata: { type: "object", additionalProperties: true },
+      },
+      anyOf: [{ required: ["path"] }, { required: ["route"] }],
     },
     workloadStep: {
       type: "object",

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -663,8 +663,30 @@ if (did_action('rest_api_init')) {
     do_action('rest_api_init', rest_get_server());
 }
 
+function wp_codebox_bench_workload_run_steps(array $workload): array {
+    $steps = isset($workload['run']) && is_array($workload['run']) ? $workload['run'] : array();
+    $route_matrix = isset($workload['route_matrix']) && is_array($workload['route_matrix']) ? $workload['route_matrix'] : array();
+
+    foreach ($route_matrix as $index => $route) {
+        if (!is_array($route)) {
+            continue;
+        }
+        $step = array_merge($route, array('type' => 'rest-request'));
+        if (!isset($step['metric-prefix']) && isset($route['id']) && is_string($route['id'])) {
+            $step['metric-prefix'] = 'rest_' . $route['id'];
+        }
+        if (!isset($step['metadata']) || !is_array($step['metadata'])) {
+            $step['metadata'] = array();
+        }
+        $step['metadata'] = array_merge(array('route_matrix_index' => $index), $step['metadata']);
+        $steps[] = $step;
+    }
+
+    return !empty($steps) ? $steps : array($workload);
+}
+
 function wp_codebox_bench_run_configured_workload(array $workload, string $plugin_path) {
-    $steps = isset($workload['run']) && is_array($workload['run']) ? $workload['run'] : array($workload);
+    $steps = wp_codebox_bench_workload_run_steps($workload);
     $payload = array('metrics' => array(), 'metadata' => array(), 'artifacts' => array(), 'steps' => array(), 'diagnostics' => array());
     if (isset($workload['metadata']) && is_array($workload['metadata'])) {
         $payload['metadata'] = array_merge($payload['metadata'], $workload['metadata']);

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -30,6 +30,7 @@ const commandStepHelpers = [
   "wp_codebox_bench_command_step_record",
   "wp_codebox_bench_run_command_step",
   "wp_codebox_bench_command_step_payload",
+  "wp_codebox_bench_workload_run_steps",
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
 const commandStepPayload = await withTempDir("wp-codebox-bench-step-", async (directory) => {
@@ -54,3 +55,30 @@ assert.equal(typeof commandStepPayload.steps[0].timing.duration_ms, "number")
 assert.equal(typeof commandStepPayload.metrics.ability_duration_ms, "number")
 assert.equal(commandStepPayload.metrics.custom_count, 2)
 assert.deepEqual(commandStepPayload.metadata, { called: "example/run" })
+
+const routeMatrixSteps = await withTempDir("wp-codebox-bench-route-matrix-", async (directory) => {
+  const phpTestFile = join(directory, "route-matrix.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+${commandStepHelpers}
+$steps = wp_codebox_bench_workload_run_steps(array(
+    'id' => 'rest-catalog',
+    'route_matrix' => array(
+        array('id' => 'products-list', 'method' => 'GET', 'path' => '/wc/v3/products', 'params' => array('per_page' => 10)),
+        array('method' => 'GET', 'route' => '/wc/v3/orders'),
+    ),
+    'artifacts' => array('route-summary' => array('path' => 'bench/rest-route-summary.json', 'kind' => 'json')),
+));
+echo json_encode($steps, JSON_UNESCAPED_SLASHES);
+`,
+  )
+  return runPhpFileJson<Array<{ type: string; path?: string; route?: string; method: string; "metric-prefix"?: string; metadata: { route_matrix_index: number } }>>(phpTestFile)
+})
+assert.equal(routeMatrixSteps.length, 2)
+assert.equal(routeMatrixSteps[0].type, "rest-request")
+assert.equal(routeMatrixSteps[0].path, "/wc/v3/products")
+assert.equal(routeMatrixSteps[0]["metric-prefix"], "rest_products-list")
+assert.deepEqual(routeMatrixSteps[0].metadata, { route_matrix_index: 0 })
+assert.equal(routeMatrixSteps[1].route, "/wc/v3/orders")
+assert.deepEqual(routeMatrixSteps[1].metadata, { route_matrix_index: 1 })

--- a/tests/benchmark-contracts.test.ts
+++ b/tests/benchmark-contracts.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+
+import { createBenchmarkDefinitionJsonSchema, type BenchmarkDefinition } from "../packages/runtime-core/src/benchmark-contracts.js"
+
+const routeMatrixDefinition = {
+  schema: "wp-codebox/benchmark-definition/v1",
+  component_id: "woocommerce-api",
+  plugin_slug: "woocommerce",
+  workloads: [
+    {
+      id: "rest-catalog",
+      source: "config",
+      route_matrix: [
+        {
+          id: "products-list",
+          method: "GET",
+          path: "/wc/v3/products",
+          params: { per_page: 10 },
+          "capture-response": true,
+          "metric-prefix": "rest_products_list",
+        },
+      ],
+      artifacts: {
+        "route-summary": {
+          path: "bench/rest-route-summary.json",
+          kind: "json",
+          source: "scenario-artifact",
+        },
+      },
+    },
+  ],
+} satisfies BenchmarkDefinition
+
+const schema = createBenchmarkDefinitionJsonSchema()
+const workloadDefinition = (schema.$defs as Record<string, { properties?: Record<string, unknown> }>).workload
+const routeDefinition = (schema.$defs as Record<string, { anyOf?: unknown; properties?: Record<string, unknown> }>).restRouteMatrixEntry
+
+assert.ok(routeMatrixDefinition.workloads[0].route_matrix?.[0].path)
+assert.ok(workloadDefinition.properties?.route_matrix, "benchmark definition schema should expose workload route_matrix")
+assert.ok(routeDefinition.properties?.["capture-response"], "route_matrix entries should expose REST response capture")
+assert.deepEqual(routeDefinition.anyOf, [{ required: ["path"] }, { required: ["route"] }])
+
+console.log("benchmark contracts ok")


### PR DESCRIPTION
## Summary
- Add `route_matrix` support to benchmark workload contracts.
- Expand route matrix entries into existing `rest-request` benchmark steps.
- Document route-matrix workload declarations and add focused contract/runtime tests.

## Testing
- `npm run build`
- `npm run test:bench-command-step-behavior`
- `npx tsx tests/benchmark-contracts.test.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing route-matrix benchmark workload support, docs, tests, and PR preparation under Chris review.
