### PR TITLE
Run distribution setup artifacts

### DIFF
--- a/packages/cli/src/commands/recipe-declared-artifacts.ts
+++ b/packages/cli/src/commands/recipe-declared-artifacts.ts
@@ -3,7 +3,7 @@ import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, STRUCTURED_ARTIFACT_SCHEMA, TYPED_
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { appendRecipeRuntimeEvidenceFiles } from "../recipe-evidence.js"
 import { serializeRecipeRunError, RecipeDeclaredArtifactFailureError, RecipeProbeFailureError } from "./recipe-run-output.js"
-import type { RecipeRunDeclaredArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunProbe } from "./recipe-run-types.js"
+import type { RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunProbe } from "./recipe-run-types.js"
 
 const DECLARED_ARTIFACT_CAPTURE_MAX_BYTES = DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES
 const declaredArtifactContents = new WeakMap<RecipeRunDeclaredArtifact, Buffer>()
@@ -208,9 +208,10 @@ export function recipeDeclaredArtifactFailure(declaredArtifacts: RecipeRunDeclar
   return declaredArtifacts.some((artifact) => artifact.required && artifact.status !== "collected") ? new RecipeDeclaredArtifactFailureError(declaredArtifacts) : undefined
 }
 
-export function recipeRuntimeEvidenceFiles(fixtureDatabases: RecipeRunFixtureDatabase[], distributionStartupProbes: RecipeRunDistributionStartupProbe[], probes: RecipeRunProbe[], declaredArtifacts: RecipeRunDeclaredArtifact[]): Array<{ filename: string; kind: string; value: unknown }> {
+export function recipeRuntimeEvidenceFiles(fixtureDatabases: RecipeRunFixtureDatabase[], distributionSetupArtifacts: RecipeRunDistributionSetupArtifact[], distributionStartupProbes: RecipeRunDistributionStartupProbe[], probes: RecipeRunProbe[], declaredArtifacts: RecipeRunDeclaredArtifact[]): Array<{ filename: string; kind: string; value: unknown }> {
   return [
     ...(fixtureDatabases.length > 0 ? [{ filename: "fixture-databases.json", kind: "fixture-database-results", value: { schema: "wp-codebox/fixture-database-results/v1", fixtures: fixtureDatabases } }] : []),
+    ...(distributionSetupArtifacts.length > 0 ? [{ filename: "distribution-setup-artifacts.json", kind: "distribution-setup-artifact-results", value: { schema: "wp-codebox/distribution-setup-artifact-results/v1", artifacts: distributionSetupArtifacts } }] : []),
     ...(distributionStartupProbes.length > 0 ? [{ filename: "distribution-startup-probes.json", kind: "distribution-startup-probe-results", value: { schema: "wp-codebox/distribution-startup-probe-results/v1", passed: !distributionStartupProbeFailure(distributionStartupProbes), probes: distributionStartupProbes } }] : []),
     ...(probes.length > 0 ? [{ filename: "recipe-probes.json", kind: "recipe-probe-results", value: { schema: "wp-codebox/recipe-probe-results/v1", passed: !recipeProbeFailure(probes), probes } }] : []),
     ...(declaredArtifacts.length > 0 ? [{ filename: "recipe-declared-artifacts.json", kind: "recipe-declared-artifact-results", value: { schema: "wp-codebox/recipe-declared-artifact-results/v1", passed: !recipeDeclaredArtifactFailure(declaredArtifacts), artifacts: declaredArtifacts } }] : []),

--- a/packages/cli/src/commands/recipe-run-finalizer.ts
+++ b/packages/cli/src/commands/recipe-run-finalizer.ts
@@ -42,6 +42,7 @@ interface RecipeRunCommonOutputFields {
   stagedFiles?: RecipeRunStagedFile[]
   fixtureDatabases?: RecipeRunFixtureDatabase[]
   siteSeeds?: RecipeRunSiteSeed[]
+  distributionSetupArtifacts?: RecipeRunOutput["distributionSetupArtifacts"]
   distributionStartupProbes?: RecipeRunOutput["distributionStartupProbes"]
   probes?: RecipeRunProbe[]
   declaredArtifacts?: RecipeRunDeclaredArtifact[]
@@ -98,6 +99,7 @@ export function completedRecipeOutputFields(args: {
   stagedFiles: RecipeRunStagedFile[]
   fixtureDatabases: RecipeRunFixtureDatabase[]
   siteSeeds: RecipeRunOutput["siteSeeds"]
+  distributionSetupArtifacts: NonNullable<RecipeRunOutput["distributionSetupArtifacts"]>
   distributionStartupProbes: NonNullable<RecipeRunOutput["distributionStartupProbes"]>
   probes: RecipeRunProbe[]
   declaredArtifacts: RecipeRunDeclaredArtifact[]
@@ -113,6 +115,7 @@ export function completedRecipeOutputFields(args: {
     stagedFiles: args.stagedFiles,
     fixtureDatabases: args.fixtureDatabases,
     siteSeeds: args.siteSeeds,
+    ...(args.distributionSetupArtifacts.length > 0 ? { distributionSetupArtifacts: args.distributionSetupArtifacts } : {}),
     ...(args.distributionStartupProbes.length > 0 ? { distributionStartupProbes: args.distributionStartupProbes } : {}),
     probes: args.probes,
     declaredArtifacts: args.declaredArtifacts,

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -49,6 +49,7 @@ export interface RecipeRunOutput {
   stagedFiles?: RecipeRunStagedFile[]
   fixtureDatabases?: RecipeRunFixtureDatabase[]
   siteSeeds?: RecipeRunSiteSeed[]
+  distributionSetupArtifacts?: RecipeRunDistributionSetupArtifact[]
   distributionStartupProbes?: RecipeRunDistributionStartupProbe[]
   probes?: RecipeRunProbe[]
   declaredArtifacts?: RecipeRunDeclaredArtifact[]
@@ -150,7 +151,7 @@ export interface RecipeDiagnosticArtifactRef {
   sha256?: string
 }
 
-export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "import_fixture_databases" | "run_distribution_startup_probes" | "run_workloads" | "run_probes" | "collect_artifacts"
+export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "import_fixture_databases" | "run_distribution_setup_artifacts" | "run_distribution_startup_probes" | "run_workloads" | "run_probes" | "collect_artifacts"
 
 export interface RecipePhaseEvidence {
   schema: "wp-codebox/recipe-phase-evidence/v1"
@@ -223,6 +224,26 @@ export interface RecipeRunFixtureDatabase {
   identity: {
     name: string
     version: string
+    sourceSha256: string
+  }
+  counts?: Record<string, number>
+  metadata?: Record<string, unknown>
+}
+
+export interface RecipeRunDistributionSetupArtifact {
+  schema: "wp-codebox/distribution-setup-artifact-result/v1"
+  index: number
+  name: string
+  type: "sql"
+  source: string
+  action: "applied"
+  command: string
+  args: string[]
+  exitCode: number
+  stdout: string
+  stderr: string
+  identity: {
+    name: string
     sourceSha256: string
   }
   counts?: Record<string, number>

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -1,11 +1,14 @@
-import { type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
+import { createHash } from "node:crypto"
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeDistributionSetupArtifact, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { recipeWorkflowSteps, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { artifactManifestFilesByPath } from "./recipe-run-benchmark-artifacts.js"
 import { serializeRecipeRunError } from "./recipe-run-output.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe } from "./recipe-run-types.js"
 
 export function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number, recipeCommand?: string): RecipeExecutionResult {
   return {
@@ -208,6 +211,50 @@ export async function runDistributionStartupProbes(recipe: WorkspaceRecipe, runt
   return results
 }
 
+export async function runDistributionSetupArtifacts(recipe: WorkspaceRecipe, recipeDirectory: string, runtime: Runtime, executions: RecipeExecutionResult[]): Promise<RecipeRunDistributionSetupArtifact[]> {
+  const results: RecipeRunDistributionSetupArtifact[] = []
+  for (const [index, artifact] of (recipe.distribution?.setupArtifacts ?? []).entries()) {
+    const source = resolve(recipeDirectory, artifact.source)
+    const sql = await readFile(source, "utf8")
+    const execution = await executeDistributionSetupArtifact(runtime, artifact, sql, index)
+    executions.push(execution)
+    const applied = parseDistributionSetupArtifactResult(execution.stdout)
+    results.push(stripUndefined({
+      schema: "wp-codebox/distribution-setup-artifact-result/v1" as const,
+      index,
+      name: artifact.name,
+      type: artifact.type,
+      source,
+      action: "applied" as const,
+      command: execution.command,
+      args: execution.args,
+      exitCode: execution.exitCode,
+      stdout: execution.stdout,
+      stderr: execution.stderr,
+      identity: {
+        name: artifact.name,
+        sourceSha256: createHash("sha256").update(sql).digest("hex"),
+      },
+      counts: applied.counts,
+      metadata: artifact.metadata,
+    }))
+  }
+  return results
+}
+
+async function executeDistributionSetupArtifact(runtime: Runtime, artifact: WorkspaceRecipeDistributionSetupArtifact, sql: string, index: number): Promise<RecipeExecutionResult> {
+  try {
+    const execution = await runtime.execute({
+      command: "wordpress.run-php",
+      args: [`code=${distributionSetupSqlArtifactCode(artifact, sql)}`],
+    })
+    return withRecipeExecutionPhase(execution, "setup", index, `distribution.setupArtifact:${artifact.name}`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Distribution setup artifact "${artifact.name}" failed before producing a result: ${message}`, { cause: error })
+  }
+}
+
 export function distributionStartupProbeFailure(probes: RecipeRunDistributionStartupProbe[]): Error | undefined {
   const failed = probes.find((probe) => probe.status === "failed")
   return failed ? new Error(`Distribution startup probe "${failed.name}" failed with exit code ${failed.exitCode ?? "unknown"}.`) : undefined
@@ -245,6 +292,40 @@ function distributionStartupProbeExecutionSpec(probe: WorkspaceRecipeDistributio
     return { command: "wordpress.http-request", args: [`url=${probe.url ?? ""}`, probe.expectStatus === undefined ? undefined : `expect-status=${probe.expectStatus}`].filter((arg): arg is string => Boolean(arg)) }
   }
   return { command: "wordpress.browser-probe", args: [`url=${probe.url ?? ""}`] }
+}
+
+function parseDistributionSetupArtifactResult(stdout: string): { counts: Record<string, number> } {
+  const parsed = JSON.parse(stdout.trim() || "{}") as { counts?: Record<string, unknown> }
+  const counts: Record<string, number> = {}
+  for (const [key, value] of Object.entries(parsed.counts ?? {})) {
+    if (typeof value === "number") {
+      counts[key] = value
+    }
+  }
+  return { counts }
+}
+
+function distributionSetupSqlArtifactCode(artifact: WorkspaceRecipeDistributionSetupArtifact, sql: string): string {
+  const encodedName = JSON.stringify(artifact.name)
+  const encodedSql = JSON.stringify(sql)
+  return `
+global $wpdb;
+$artifact_name = ${encodedName};
+$sql = ${encodedSql};
+$counts = array('statements' => 0);
+$statements = preg_split('/;\s*(?:\r?\n|$)/', $sql);
+foreach ($statements as $statement) {
+    $statement = trim($statement);
+    if ('' === $statement || str_starts_with($statement, '--')) {
+        continue;
+    }
+    $result = $wpdb->query($statement);
+    if (false === $result) {
+        throw new RuntimeException('Distribution setup artifact failed for ' . $artifact_name . ': ' . $wpdb->last_error);
+    }
+    $counts['statements']++;
+}
+echo wp_json_encode(array('counts' => $counts));`
 }
 
 function distributionStartupHttpProbeSkipped(probe: WorkspaceRecipeDistributionStartupProbe, index: number): RecipeRunDistributionStartupProbe {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -23,8 +23,8 @@ import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRu
 import { RecipePhaseError } from "./recipe-run-phases.js"
 import { importRecipeSiteSeeds } from "./recipe-site-seeds.js"
 import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRuntimeSetup, recipeRunDependencyOverlay, recipeRunExtraPlugin, recipeRunStagedFile } from "./recipe-runtime-setup.js"
-import { distributionStartupProbeFailure, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowStepIsAdvisory, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
+import { distributionStartupProbeFailure, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowStepIsAdvisory, runDistributionSetupArtifacts, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
@@ -111,6 +111,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
   const executions: RecipeExecutionResult[] = []
   let fixtureDatabases: RecipeRunFixtureDatabase[] = []
+  let distributionSetupArtifacts: RecipeRunDistributionSetupArtifact[] = []
   let distributionStartupProbes: RecipeRunDistributionStartupProbe[] = []
   let probes: RecipeRunProbe[] = []
   let declaredArtifacts: RecipeRunDeclaredArtifact[] = []
@@ -222,6 +223,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
 
     fixtureDatabases = await phaseTracker.run("import_fixture_databases", phaseFixtureDatabaseData(recipe), async () => await awaitRecipe("fixture-databases.import", importRecipeFixtureDatabases(recipe, recipeDirectory, runtime!, executions)))
     const siteSeeds = await awaitRecipe("site-seeds.import", importRecipeSiteSeeds(recipe, recipeDirectory, runtime!, executions))
+    distributionSetupArtifacts = await phaseTracker.run("run_distribution_setup_artifacts", phaseDistributionSetupArtifactData(recipe), async () => await awaitRecipe("distribution.setup-artifacts.run", runDistributionSetupArtifacts(recipe, recipeDirectory, runtime!, executions)))
     interruption?.throwIfInterrupted()
 
     const sandboxWorkspace = sandboxWorkspaceContract(workspaceMounts, recipe.inputs?.mounts ?? [])
@@ -264,7 +266,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       browserEvidence = await recipeBrowserEvidence(artifacts, executions)
       await artifactPointer.update({ runtime: await runtime!.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
-      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionStartupProbes, probes, declaredArtifacts))
+      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts))
       if (declaredArtifactFailure) {
         throw declaredArtifactFailure
       }
@@ -288,7 +290,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, runtime)
       await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
-      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionStartupProbes, probes, declaredArtifacts))
+      await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts))
       evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)
       const previewAgentEvidence = await finalizeAgentSandboxEvidence(artifacts, executions)
       Object.assign(evidence, previewAgentEvidence)
@@ -328,7 +330,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         browserEvidence,
         replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
         failure: recipeFailure,
-        output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
+        output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
       })
     }
 
@@ -347,7 +349,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       phaseEvidence: phaseTracker.list(),
       browserEvidence,
       replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
-      output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
+      output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, evidence }),
     })
   } catch (error) {
     const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
@@ -361,6 +363,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       overlays,
       executions,
       fixtureDatabases,
+      distributionSetupArtifacts,
       distributionStartupProbes,
       probes,
       declaredArtifacts,
@@ -392,7 +395,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
           }
           await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
           const evidenceFiles = await appendRecipeRuntimeEvidence(artifacts, [
-            ...recipeRuntimeEvidenceFiles(fixtureDatabases, distributionStartupProbes, probes, declaredArtifacts),
+            ...recipeRuntimeEvidenceFiles(fixtureDatabases, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts),
             failureDiagnostics,
           ])
           diagnosticArtifacts = evidenceFiles
@@ -448,6 +451,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions, error),
         stagedFiles: stagedFiles.map(recipeRunStagedFile),
         fixtureDatabases,
+        distributionSetupArtifacts,
         distributionStartupProbes,
         probes,
         declaredArtifacts,
@@ -695,6 +699,7 @@ function recipeFailureRuntimeEvidenceFile(args: {
   overlays: PreparedRuntimeOverlay[]
   executions: RecipeExecutionResult[]
   fixtureDatabases: RecipeRunFixtureDatabase[]
+  distributionSetupArtifacts: RecipeRunDistributionSetupArtifact[]
   distributionStartupProbes: RecipeRunDistributionStartupProbe[]
   probes: RecipeRunProbe[]
   declaredArtifacts: RecipeRunDeclaredArtifact[]
@@ -725,6 +730,7 @@ function recipeFailureRuntimeEvidenceFile(args: {
       preparedRuntimeOverlays: args.overlays.map((overlay) => ({ target: overlay.target, type: overlay.type, mode: overlay.mode, metadata: overlay.metadata })),
       executions: args.executions,
       fixtureDatabases: args.fixtureDatabases,
+      distributionSetupArtifacts: args.distributionSetupArtifacts,
       distributionStartupProbes: args.distributionStartupProbes,
       probes: args.probes,
       declaredArtifacts: args.declaredArtifacts,
@@ -840,6 +846,18 @@ function phaseDistributionStartupProbeData(recipe: WorkspaceRecipe): Record<stri
       name: probe.name,
       type: probe.type,
       executable: probe.type === "wp-cli" || probe.type === "php" || probe.type === "browser",
+    })),
+  }
+}
+
+function phaseDistributionSetupArtifactData(recipe: WorkspaceRecipe): Record<string, unknown> {
+  const artifacts = recipe.distribution?.setupArtifacts ?? []
+  return {
+    count: artifacts.length,
+    artifacts: artifacts.map((artifact, index) => ({
+      index,
+      name: artifact.name,
+      type: artifact.type,
     })),
   }
 }

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -87,6 +87,7 @@ interface RecipeDryRunDistribution {
   constants: Record<string, string | number | boolean | null>
   serviceFakes: RecipeDryRunDistributionServiceFake[]
   routeAliases: NonNullable<WorkspaceRecipeDistribution["routeAliases"]>
+  setupArtifacts: Array<NonNullable<WorkspaceRecipeDistribution["setupArtifacts"]>[number] & { source: string; planned: "local-artifact" }>
   startupProbes: RecipeDryRunDistributionStartupProbe[]
   artifacts: NonNullable<WorkspaceRecipeDistribution["artifacts"]>
   safety: {
@@ -515,6 +516,11 @@ async function recipeDryRunDistribution(distribution: WorkspaceRecipeDistributio
       ...(fake.metadata ? { metadata: fake.metadata } : {}),
     })),
     routeAliases: distribution.routeAliases ?? [],
+    setupArtifacts: (distribution.setupArtifacts ?? []).map((artifact) => ({
+      ...artifact,
+      source: resolve(recipeDirectory, artifact.source),
+      planned: "local-artifact" as const,
+    })),
     startupProbes: (distribution.startupProbes ?? []).map(distributionStartupProbePlan),
     artifacts: distribution.artifacts ?? [],
     safety: {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -103,7 +103,7 @@ export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath
     if (!recipe.distribution.wordpress.root || typeof recipe.distribution.wordpress.root !== "string") {
       throw new Error(`Recipe distribution wordpress requires root: ${recipePath}`)
     }
-    for (const field of ["sourceMounts", "serviceFakes", "routeAliases", "startupProbes", "artifacts"] as const) {
+    for (const field of ["sourceMounts", "serviceFakes", "routeAliases", "setupArtifacts", "startupProbes", "artifacts"] as const) {
       if (recipe.distribution[field] !== undefined && !Array.isArray(recipe.distribution[field])) {
         throw new Error(`Recipe distribution ${field} must be an array: ${recipePath}`)
       }
@@ -683,6 +683,17 @@ async function validateRecipeDistribution(distribution: WorkspaceRecipeDistribut
     validateDistributionStartupProbe(probe, `$.distribution.startupProbes[${index}]`, addIssue)
   }
 
+  for (const [index, artifact] of (distribution.setupArtifacts ?? []).entries()) {
+    const path = `$.distribution.setupArtifacts[${index}]`
+    if (!/^[a-z0-9][a-z0-9_.-]*$/i.test(artifact.name)) {
+      addIssue("invalid-distribution-setup-artifact-name", `${path}.name`, `Distribution setup artifact names must be stable identifiers: ${artifact.name}`)
+    }
+    if (artifact.type !== "sql") {
+      addIssue("invalid-distribution-setup-artifact-type", `${path}.type`, "Distribution setup artifacts currently support sql only.")
+    }
+    await validateExistingFile(resolve(recipeDirectory, artifact.source), `${path}.source`, addIssue)
+  }
+
   for (const [index, artifact] of (distribution.artifacts ?? []).entries()) {
     if (!artifact.path || !isRelativeArtifactPath(artifact.path)) {
       addIssue("invalid-distribution-artifact", `$.distribution.artifacts[${index}].path`, "Distribution artifact paths must be relative artifact paths.")
@@ -785,6 +796,9 @@ export function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
     commands.unshift("wordpress.run-php")
   }
   if ((recipe.inputs?.fixtureDatabases ?? []).length > 0 || workspaceRecipeRuntimeCollectedArtifacts(recipe).length > 0) {
+    commands.unshift("wordpress.run-php")
+  }
+  if ((recipe.distribution?.setupArtifacts ?? []).length > 0) {
     commands.unshift("wordpress.run-php")
   }
   // Auto-grant the evaluate capability when a browser-actions step opts into the

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -174,6 +174,15 @@ function normalizeRecipeRunArtifacts(result: Record<string, unknown>, agentTaskA
     }))
   }
 
+  for (const artifact of arrayObjects(result.distributionSetupArtifacts)) {
+    appendUniqueArtifact(artifacts, stripUndefined({
+      id: stringValue(artifact.name) || `distribution-setup-artifact-${numberValue(artifact.index) ?? artifacts.length + 1}`,
+      kind: "distribution-setup-artifact-result",
+      path: stringValue(artifact.source),
+      metadata: artifact,
+    }))
+  }
+
   for (const artifact of arrayObjects(result.declaredArtifacts)) {
     appendUniqueArtifact(artifacts, stripUndefined({
       id: stringValue(artifact.name) || stringValue(artifact.path),

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -328,6 +328,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "array",
             items: { $ref: "#/$defs/distributionRouteAlias" },
           },
+          setupArtifacts: {
+            type: "array",
+            description: "Recipe-local setup artifacts applied inside the local sandbox before distribution startup probes.",
+            items: { $ref: "#/$defs/distributionSetupArtifact" },
+          },
           startupProbes: {
             type: "array",
             items: { $ref: "#/$defs/distributionStartupProbe" },
@@ -406,6 +411,17 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           command: { type: "string" },
           code: { type: "string" },
           expectStatus: { type: "integer", minimum: 100, maximum: 599 },
+          metadata: { $ref: "#/$defs/metadata" },
+        },
+      },
+      distributionSetupArtifact: {
+        type: "object",
+        additionalProperties: false,
+        required: ["name", "type", "source"],
+        properties: {
+          name: { type: "string" },
+          type: { enum: ["sql"] },
+          source: { type: "string" },
           metadata: { $ref: "#/$defs/metadata" },
         },
       },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -139,6 +139,13 @@ export interface WorkspaceRecipeDistributionStartupProbe {
   metadata?: Record<string, unknown>
 }
 
+export interface WorkspaceRecipeDistributionSetupArtifact {
+  name: string
+  type: "sql"
+  source: string
+  metadata?: Record<string, unknown>
+}
+
 export interface WorkspaceRecipeDistributionArtifact {
   path: string
   kind?: "logs" | "probe-results" | "fake-side-effects" | "runtime" | (string & {})
@@ -159,6 +166,7 @@ export interface WorkspaceRecipeDistribution {
   constants?: Record<string, string | number | boolean | null>
   serviceFakes?: WorkspaceRecipeDistributionServiceFake[]
   routeAliases?: WorkspaceRecipeDistributionRouteAlias[]
+  setupArtifacts?: WorkspaceRecipeDistributionSetupArtifact[]
   startupProbes?: WorkspaceRecipeDistributionStartupProbe[]
   artifacts?: WorkspaceRecipeDistributionArtifact[]
   safety?: WorkspaceRecipeDistributionSafety

--- a/tests/distribution-startup-probes.test.ts
+++ b/tests/distribution-startup-probes.test.ts
@@ -1,16 +1,26 @@
 import assert from "node:assert/strict"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 
 import type { Runtime, WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { validateWorkspaceRecipeJsonSchema } from "../packages/runtime-core/src/recipe-schema.js"
 import { normalizeRecipeRunSummary } from "../packages/runtime-core/src/recipe-run-summary.js"
 import { httpRequestInputFromArgs, runHttpRequest } from "../packages/runtime-playground/src/commands.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
-import { distributionStartupProbeFailure, runDistributionStartupProbes } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+import { distributionStartupProbeFailure, runDistributionSetupArtifacts, runDistributionStartupProbes } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+
+const recipeDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-distribution-setup-"))
+await writeFile(join(recipeDirectory, "setup.sql"), "INSERT INTO wp_options (option_name, option_value) VALUES ('codebox_ready', '1');\n", "utf8")
 
 const recipe: WorkspaceRecipe = {
   schema: "wp-codebox/workspace-recipe/v1",
   distribution: {
     name: "custom-distribution",
     wordpress: { root: "/wordpress" },
+    setupArtifacts: [
+      { name: "local-options", type: "sql", source: "setup.sql", metadata: { role: "local-runtime-setup" } },
+    ],
     startupProbes: [
       { name: "database", type: "wp-cli", command: "option get siteurl", metadata: { role: "readiness" } },
       { name: "bootstrap", type: "php", code: "echo 'ready';" },
@@ -21,7 +31,10 @@ const recipe: WorkspaceRecipe = {
   workflow: { steps: [{ command: "wordpress.run-php", args: ["code=echo 'workload';"] }] },
 }
 
+assert.equal(validateWorkspaceRecipeJsonSchema(recipe).valid, true)
+
 const policy = recipePolicy(recipe)
+assert.ok(policy.commands.includes("wordpress.run-php"), "setup artifacts are policy-visible")
 assert.ok(policy.commands.includes("wordpress.wp-cli"), "wp-cli startup probes are policy-visible")
 assert.ok(policy.commands.includes("wordpress.run-php"), "php startup probes are policy-visible")
 assert.ok(policy.commands.includes("wordpress.browser-probe"), "browser startup probes are policy-visible")
@@ -36,7 +49,7 @@ const runtime = {
       command: spec.command,
       args: spec.args ?? [],
       exitCode: 0,
-      stdout: spec.command === "wordpress.wp-cli" ? "http://example.test\n" : "ready",
+      stdout: spec.args?.some((arg) => arg.includes("Distribution setup artifact failed")) ? '{"counts":{"statements":1}}\n' : spec.command === "wordpress.wp-cli" ? "http://example.test\n" : "ready",
       stderr: "",
       startedAt: "2026-01-01T00:00:00.000Z",
       finishedAt: "2026-01-01T00:00:00.001Z",
@@ -45,15 +58,23 @@ const runtime = {
 } as Runtime
 
 const executions = []
+const setupResults = await runDistributionSetupArtifacts(recipe, recipeDirectory, runtime, executions)
 const results = await runDistributionStartupProbes(recipe, runtime, executions)
 
 assert.deepEqual(executed, [
+  { command: "wordpress.run-php", args: [executed[0]?.args[0] ?? ""] },
   { command: "wordpress.wp-cli", args: ["command=option get siteurl"] },
   { command: "wordpress.run-php", args: ["code=echo 'ready';"] },
   { command: "wordpress.browser-probe", args: ["url=/"] },
   { command: "wordpress.http-request", args: ["url=/wp-json/", "expect-status=200"] },
 ])
-assert.equal(executions.length, 4)
+assert.equal(executed[0]?.args[0]?.startsWith("code="), true)
+assert.equal(setupResults[0]?.name, "local-options")
+assert.equal(setupResults[0]?.action, "applied")
+assert.equal(setupResults[0]?.counts?.statements, 1)
+assert.equal(setupResults[0]?.metadata?.role, "local-runtime-setup")
+assert.match(setupResults[0]?.identity.sourceSha256 ?? "", /^[a-f0-9]{64}$/)
+assert.equal(executions.length, 5)
 assert.deepEqual(results.map((result) => [result.name, result.type, result.status]), [
   ["database", "wp-cli", "passed"],
   ["bootstrap", "php", "passed"],
@@ -84,9 +105,11 @@ assert.deepEqual(skippedResults[3]?.availableCommands, ["wordpress.rest-request"
 const summary = normalizeRecipeRunSummary({
   success: true,
   executions,
+  distributionSetupArtifacts: setupResults,
   distributionStartupProbes: results,
   artifacts: { directory: "/tmp/artifacts" },
 })
+assert.ok(summary.artifacts.some((artifact) => artifact.kind === "distribution-setup-artifact-result" && artifact.id === "local-options"))
 assert.ok(summary.artifacts.some((artifact) => artifact.kind === "distribution-startup-probe-result" && artifact.id === "database"))
 
 const originalFetch = globalThis.fetch


### PR DESCRIPTION
## Summary
- add generic `distribution.setupArtifacts[]` support for explicit local setup artifacts
- execute declared SQL setup artifacts inside the disposable runtime before startup probes
- record setup artifact evidence, hashes, output, failure diagnostics, and summary refs

## Testing
- `npm run test:distribution-startup-probes`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the generic setup artifact phase and tests; Chris remains responsible for review and testing.