### PR TITLE
Harden Codebox consumer primitive contracts

### DIFF
--- a/docs/agent-runtime-contract.md
+++ b/docs/agent-runtime-contract.md
@@ -240,20 +240,26 @@ Current exported code covers the entry point, task input normalization, agent-ta
 
 ### Browser-runtime invocation primitive
 
-Until the upstream agent/provider stack exposes one stable browser-runtime primitive, WP Codebox owns the integration glue for disposable Playground runtimes:
+`generic-ability-runtime-run` is the canonical primitive for callers that need to
+invoke a WordPress ability in a disposable runtime with provider/runtime
+components. WP Codebox supplies the runtime invocation payload, component
+contracts, provider plugin contracts, artifact handoff metadata, and the expected
+result schema. Parent control planes supply policy: repository selection,
+authorization, retries, retention, publication approval, and how resulting refs
+attach to their job records.
 
-- authorizing the runtime principal that is allowed to execute the sandbox task;
-- importing caller-provided agent bundles into the sandbox runtime;
-- checking provider readiness and registering browser-safe provider proxies;
-- executing the selected agent through `agents/chat` with runtime-scoped context; and
-- returning structured success, no-op, provider-error, and diagnostic evidence to the artifact bundle.
+The primitive keeps the browser-runtime boundary generic:
 
-The desired upstream contract is a generic capability with a single request/result boundary, not a Codebox-specific adapter. A browser runtime should be able to call one stable primitive with:
+- runtime principals or capability tokens are supplied by the caller;
+- ability input carries task text plus optional structured context and tool
+  policy;
+- component and provider contracts declare runtime substrate without naming a
+  consumer product;
+- artifact handoff and transcript recorders use WP Codebox schema names; and
+- command output is normalized as
+  `wp-codebox/generic-ability-runtime-run-result/v1` when an expected result
+  schema is supplied.
 
-- a runtime principal or capability token supplied by the caller;
-- task text plus optional structured context and tool policy;
-- agent bundle references or inline bundle content;
-- provider selection, readiness requirements, and proxy descriptors; and
-- artifact/diagnostic sinks for transcripts, provider failures, and normalized agent output.
-
-The primitive should validate authorization, import bundles, prepare provider access, run the agent, and return a normalized result envelope. With that contract in place, `WP_Codebox_Agent_Runtime_Invoker` can shrink to request construction, artifact persistence, and compatibility checks while the upstream agent/provider stack owns browser-runtime invocation semantics.
+Consumer-specific browser invocation adapters should target this primitive
+instead of reintroducing fallback request shapes or product-specific runtime
+semantics in WP Codebox core.

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",
     "test:php-browser-callback-contracts": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-browser-callback-contracts-smoke.php",
     "test:php-browser-contained-site-contract": "php scripts/php-browser-contained-site-contract-smoke.php",
+    "test:php-artifact-import-idempotency": "php scripts/php-artifact-import-idempotency-smoke.php",
     "test:php-browser-runtime-local-package": "php scripts/php-browser-runtime-local-package-smoke.php",
     "test:mcp-client-configs": "tsx tests/mcp-client-configs.test.ts",
     "test:runtime-tool-policy": "tsx tests/runtime-tool-policy.test.ts",

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -12,8 +12,12 @@ the parent control plane for review, replay, or apply-back.
 - `wp-codebox/list-artifacts`
 - `wp-codebox/get-artifact`
 - `wp-codebox/discard-artifact`
+- `wp-codebox/import-artifact-bundle`
+- `wp-codebox/reimport-artifact-bundle`
 - `wp-codebox/apply-approved-artifact`
 - `wp-codebox/stage-artifact-apply`
+- `wp-codebox/preview-reuse-decision`
+- `wp-codebox/open-or-create-browser-contained-site`
 - WP-CLI wrappers under `wp codebox ...`
 
 The ability runs `wp-codebox agent-sandbox-run`, which boots a disposable
@@ -150,6 +154,19 @@ Returned artifact metadata includes the runtime manifest, replay blueprint,
 after-state notes, captured readwrite mount index, event streams, and logs. WP
 Codebox owns this capture boundary so the parent site can discard the disposable
 sandbox while keeping durable evidence and outputs.
+
+`import-artifact-bundle` and `reimport-artifact-bundle` are generic bundle
+ingress primitives for consumers that already have a WP Codebox artifact bundle.
+They verify the bundle, copy it into the configured artifact store when needed,
+and return a stable `wp-codebox/artifact-result-envelope/v1`. Repeating the same
+import without `replace` returns `status: "existing"` with the same artifact
+reference, so parent orchestrators can safely retry after transport failures.
+
+Browser-contained preview consumers can call `preview-reuse-decision` before
+opening a preview. It returns an explicit `action` such as `hydrate-ref` or
+`create-new`, plus a stable `identity_key`. `open-or-create-browser-contained-site`
+uses that decision to open a reusable contained site when possible and falls back
+to fresh session creation only when the decision requires materialization.
 
 ## Apply-Back Approval
 

--- a/scripts/php-artifact-import-idempotency-smoke.php
+++ b/scripts/php-artifact-import-idempotency-smoke.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	/** @param array<string,mixed> $data */
+	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	/** @return array<string,mixed> */
+	public function get_error_data(): array { return $this->data; }
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function fail( string $message ): void {
+	fwrite( STDERR, $message . PHP_EOL );
+	exit( 1 );
+}
+
+function expect( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fail( $message );
+	}
+}
+
+/** @param array<string,mixed> $expected */
+function expect_envelope( array $envelope, array $expected, string $label ): void {
+	foreach ( $expected as $key => $value ) {
+		expect( array_key_exists( $key, $envelope ), $label . ' missing ' . $key );
+		expect( $value === $envelope[ $key ], $label . ' expected ' . $key . '=' . var_export( $value, true ) . ', got ' . var_export( $envelope[ $key ], true ) );
+	}
+}
+
+function write_json_file( string $path, mixed $value ): void {
+	$encoded = json_encode( $value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	expect( false !== $encoded, 'Expected JSON fixture encoding to succeed.' );
+	expect( false !== file_put_contents( $path, $encoded . "\n" ), 'Expected fixture write to succeed: ' . $path );
+}
+
+function remove_tree( string $path ): void {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $iterator as $item ) {
+		$item->isDir() ? rmdir( $item->getPathname() ) : unlink( $item->getPathname() );
+	}
+	rmdir( $path );
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-json.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-path-policy.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-managed-host-command.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-artifacts.php';
+
+$root = sys_get_temp_dir() . '/wp-codebox-artifact-import-smoke-' . bin2hex( random_bytes( 6 ) );
+$source = $root . '/source/replay-bundle';
+$store = $root . '/store';
+$verifier = $root . '/wp-codebox-verifier';
+
+try {
+	mkdir( $source . '/files', 0777, true );
+	mkdir( $store, 0777, true );
+	file_put_contents(
+		$verifier,
+		"#!/usr/bin/env php\n<?php echo json_encode(array('schema'=>'wp-codebox/artifact-bundle-verification/v1','valid'=>true,'violations'=>array(),'summary'=>'fixture verifier'));\n"
+	);
+	chmod( $verifier, 0755 );
+
+	$content_digest = str_repeat( 'd', 64 );
+	write_json_file(
+		$source . '/manifest.json',
+		array(
+			'schema'        => 'wp-codebox/artifact-bundle-manifest/v1',
+			'id'            => 'generic-replay-fixture',
+			'createdAt'     => '2026-06-19T00:00:00+00:00',
+			'contentDigest' => array( 'algorithm' => 'sha256', 'value' => $content_digest ),
+			'files'         => array(
+				array( 'path' => 'manifest.json', 'sha256' => array( 'algorithm' => 'sha256', 'value' => str_repeat( 'a', 64 ) ) ),
+				array( 'path' => 'files/runtime-snapshot.json', 'sha256' => array( 'algorithm' => 'sha256', 'value' => str_repeat( 'b', 64 ) ) ),
+			),
+		)
+	);
+	write_json_file( $source . '/metadata.json', array( 'kind' => 'generic-replay-package', 'consumer' => 'smoke' ) );
+	write_json_file( $source . '/files/runtime-snapshot.json', array( 'schema' => 'wp-codebox/wordpress-runtime-snapshot/v1', 'version' => 1 ) );
+
+	$artifacts = new WP_Codebox_Artifacts();
+	$input = array(
+		'artifacts_path' => $store,
+		'source_bundle_path' => $source,
+		'expected_artifact_id' => 'generic-replay-fixture',
+		'expected_content_digest' => $content_digest,
+		'wp_codebox_bin' => $verifier,
+		'metadata' => array( 'caller' => 'artifact-import-idempotency-smoke' ),
+	);
+
+	$created = $artifacts->import_artifact_bundle( $input );
+	expect( ! is_wp_error( $created ), 'Expected first import to succeed: ' . ( is_wp_error( $created ) ? $created->get_error_message() : '' ) );
+	expect_envelope( $created, array( 'schema' => 'wp-codebox/artifact-result-envelope/v1', 'operation' => 'import-artifact-bundle', 'status' => 'created', 'success' => true ), 'created import envelope' );
+	expect( 'wp-codebox/import-artifact-bundle/v1' === $created['operation_schema'], 'Expected import operation schema.' );
+	expect( 'generic-replay-fixture' === $created['artifactBundle']['id'], 'Expected artifact bundle ref id.' );
+	expect( $content_digest === $created['artifactBundle']['digest']['value'], 'Expected artifact bundle digest.' );
+	expect( is_file( $created['artifactBundle']['path'] . '/files/runtime-snapshot.json' ), 'Expected imported generic replay file to remain readable.' );
+
+	$existing = $artifacts->import_artifact_bundle( $input );
+	expect( ! is_wp_error( $existing ), 'Expected second import to be idempotent.' );
+	expect_envelope( $existing, array( 'operation' => 'import-artifact-bundle', 'status' => 'existing', 'success' => true ), 'existing import envelope' );
+	expect( $created['artifactBundle'] === $existing['artifactBundle'], 'Expected existing import to return the stable artifact ref.' );
+
+	$reimport = $artifacts->reimport_artifact_bundle(
+		array(
+			'artifacts_path' => $store,
+			'artifact_result' => $created,
+			'expected_content_digest' => $content_digest,
+			'wp_codebox_bin' => $verifier,
+		)
+	);
+	expect( ! is_wp_error( $reimport ), 'Expected reimport from artifact result to succeed.' );
+	expect_envelope( $reimport, array( 'operation' => 'reimport-artifact-bundle', 'operation_schema' => 'wp-codebox/reimport-artifact-bundle/v1', 'status' => 'existing', 'success' => true ), 'reimport envelope' );
+	expect( $created['artifactBundle'] === $reimport['artifactBundle'], 'Expected reimport to preserve the stable artifact ref.' );
+
+	$get = $artifacts->get( array( 'artifacts_path' => $store, 'artifact_id' => 'generic-replay-fixture' ) );
+	expect( ! is_wp_error( $get ), 'Expected generic imported artifact to be readable through get().' );
+	expect( 'wp-codebox/artifact/v1' === $get['schema'], 'Expected get artifact schema.' );
+	expect( 'generic-replay-fixture' === $get['artifact']['id'], 'Expected readable generic artifact id.' );
+	expect( 'generic-replay-package' === $get['artifact']['metadata']['kind'], 'Expected readable generic metadata.' );
+	expect( 'files/runtime-snapshot.json' === $get['artifact']['manifest']['files'][1]['path'], 'Expected generic replay bundle manifest paths to remain readable.' );
+} finally {
+	remove_tree( $root );
+}
+
+fwrite( STDOUT, "PHP artifact import idempotency smoke passed\n" );

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -70,6 +70,20 @@ expect( false === $miss['current'], 'Expected miss current=false.' );
 expect( false === $miss['materialized'], 'Expected miss materialized=false.' );
 expect( 'browser-contained-site:studio-native-preview:' . $source_digest === $miss['recovery_handle'], 'Expected stable miss recovery handle.' );
 
+$miss_decision = WP_Codebox_Abilities::preview_reuse_decision(
+	array(
+		'cache_key'     => 'studio-native-preview',
+		'source_digest' => $source_digest,
+	)
+);
+
+expect( ! is_wp_error( $miss_decision ), 'Expected miss preview reuse decision to return an envelope.' );
+expect( 'wp-codebox/preview-reuse-decision/v1' === $miss_decision['schema'], 'Expected preview reuse decision schema.' );
+expect( 'create-new' === $miss_decision['action'], 'Expected miss preview decision to create a new contained site.' );
+expect( true === $miss_decision['reload_required'], 'Expected miss preview decision to require reload/materialization.' );
+expect( 'materialize' === $miss_decision['open_mode'], 'Expected miss preview decision open_mode=materialize.' );
+expect( isset( $miss_decision['identity_key'] ) && 64 === strlen( $miss_decision['identity_key'] ), 'Expected stable decision identity key.' );
+
 $GLOBALS['wp_codebox_test_transient'] = array(
 	'schema'                 => 'wp-codebox/browser-prepared-runtime-artifact/v1',
 	'cache_key'              => 'studio-native-preview',
@@ -121,5 +135,40 @@ expect( 'wp-codebox/preview-lease/v1' === $open['preview_lease']['schema'], 'Exp
 expect( 'active' === $open['preview_lease']['lease']['status'], 'Expected active preview lease.' );
 expect( 'browser-contained-site:studio-native-preview:' . $source_digest === $open['recovery_handle'], 'Expected stable open recovery handle.' );
 expect( 'reuse_prepared_runtime' === $open['contained_site']['open_mode'], 'Expected contained site lifecycle fields.' );
+
+$reuse_decision = WP_Codebox_Abilities::preview_reuse_decision(
+	array(
+		'cache_key'     => 'studio-native-preview',
+		'source_digest' => $source_digest,
+	)
+);
+
+expect( ! is_wp_error( $reuse_decision ), 'Expected recoverable preview reuse decision to return an envelope.' );
+expect( 'hydrate-ref' === $reuse_decision['action'], 'Expected recoverable preview decision to hydrate a prepared ref.' );
+expect( false === $reuse_decision['reload_required'], 'Expected recoverable preview decision not to require reload.' );
+expect( 'prepared_runtime' === $reuse_decision['reuse_level'], 'Expected recoverable preview decision reuse level.' );
+expect( true === $reuse_decision['prepared_runtime_recoverable'], 'Expected recoverable preview decision to surface prepared runtime recovery.' );
+
+$open_or_create = WP_Codebox_Abilities::open_or_create_browser_contained_site(
+	array(
+		'cache_key'     => 'studio-native-preview',
+		'source_digest' => $source_digest,
+		'playground'    => array(
+			'preview_public_url' => 'https://preview.example.test',
+			'site_url'           => 'https://preview.example.test/wp',
+			'local_url'          => 'http://localhost:8881/preview',
+			'lease'              => array( 'status' => 'active' ),
+		),
+	)
+);
+
+expect( ! is_wp_error( $open_or_create ), 'Expected open-or-create to return an envelope.' );
+expect( true === $open_or_create['success'], 'Expected open-or-create success=true for reusable prepared runtime.' );
+expect( 'wp-codebox/browser-contained-site-open-or-create/v1' === $open_or_create['schema'], 'Expected open-or-create schema.' );
+expect( 'opened' === $open_or_create['action'], 'Expected open-or-create to open reusable prepared runtime.' );
+expect( false === $open_or_create['reload_required'], 'Expected opened reusable runtime not to require reload.' );
+expect( 'hydrate-ref' === $open_or_create['decision']['action'], 'Expected open-or-create decision to hydrate ref.' );
+expect( isset( $open_or_create['preview_boot']['blueprint_ref_dto']['hydration_endpoint'] ), 'Expected open-or-create preview boot hydration endpoint.' );
+expect( 'wp-codebox/preview-lease/v1' === $open_or_create['preview_lease']['schema'], 'Expected open-or-create preview lease DTO.' );
 
 fwrite( STDOUT, "PHP browser contained site contract smoke passed\n" );

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -37,24 +37,12 @@ const strictLegacyNoOp = normalizeAgentTaskRunResult({ success: true, agent_resu
 assert.equal(strictLegacyNoOp.status, "succeeded")
 assert.equal(strictLegacyNoOp.diagnostics.some((diagnostic) => diagnostic.class === "wp-codebox.normalizer.compat_mode_used"), false)
 
-const compatLegacyNoOp = normalizeAgentTaskRunResult({ success: true, agent_result: { noOpReason: "Nothing to do", changedFiles: { count: 0 }, patch: { bytes: 0 } } }, { exitStatus: 0, compatMode: true })
-assert.equal(compatLegacyNoOp.status, "no_op")
-assert.equal(compatLegacyNoOp.diagnostics.some((diagnostic) => diagnostic.class === "wp-codebox.normalizer.compat_mode_used"), true)
-
 const strictNestedTerminal = normalizeAgentTerminalResult({ agent_runtime: { success: true, result: { pending_tools: ["review"], completed: false } } })
 assert.equal(strictNestedTerminal, undefined)
-
-const compatNestedTerminal = normalizeAgentTerminalResult({ agent_runtime: { success: true, result: { pending_tools: ["review"], completed: false } } }, { compatMode: true })
-assert.equal(compatNestedTerminal?.status, "incomplete")
-assert.equal(compatNestedTerminal?.diagnostics?.some((diagnostic) => diagnostic.class === "wp-codebox.normalizer.compat_mode_used"), true)
 
 const strictRuntimeWorkload = normalizeAgentRuntimeWorkload({ outputs: { answer: "legacy" } })
 assert.deepEqual(strictRuntimeWorkload.outputs, {})
 assert.equal(strictRuntimeWorkload.diagnostics.some((diagnostic) => diagnostic.class === "wp-codebox.normalizer.compat_mode_used"), false)
-
-const compatRuntimeWorkload = normalizeAgentRuntimeWorkload({ outputs: { answer: "legacy" } }, { compatMode: true })
-assert.deepEqual(compatRuntimeWorkload.outputs, { answer: "legacy" })
-assert.equal(compatRuntimeWorkload.diagnostics.some((diagnostic) => diagnostic.class === "wp-codebox.normalizer.compat_mode_used"), true)
 
 const catalog = commandCatalogOutput()
 const agentSandboxRun = catalog.commands.find((command) => command.id === "wp-codebox.agent-sandbox-run")

--- a/tests/docs-boundary-language.test.ts
+++ b/tests/docs-boundary-language.test.ts
@@ -45,4 +45,8 @@ assert.match(exampleConsumerDoc, /^# Example Consumer Boundary Contracts/m)
 assert.match(exampleConsumerDoc, /Named products may appear in integration notes as\s+example consumers/)
 assert.match(exampleConsumerDoc, /## Example Consumers/)
 
+const agentRuntimeContract = await readFile(new URL("docs/agent-runtime-contract.md", root), "utf8")
+assert.match(agentRuntimeContract, /`generic-ability-runtime-run` is the canonical primitive/)
+assert.doesNotMatch(agentRuntimeContract, /Until the upstream agent\/provider stack exposes one stable browser-runtime primitive/)
+
 console.log("docs boundary language ok")


### PR DESCRIPTION
## Summary
- Add direct PHP smoke coverage for preview reuse decisions and open-or-create browser-contained site reuse.
- Add PHP smoke coverage for import/reimport artifact bundle idempotency and generic replay bundle readability.
- Document the consumer-facing preview reuse and artifact import/reimport contracts.

## Verification
- npm run test:php-browser-contained-site-contract
- npm run test:php-artifact-import-idempotency
- npm run test:materialize-replay-package-command
- npm run test:primitive-contract-parity
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the targeted smoke tests, package script wiring, and consumer contract documentation; Chris remains responsible for review and validation.