### PR TITLE
Materialize REST request case summaries

### DIFF
--- a/packages/cli/src/commands/recipe-run-benchmark-artifacts.ts
+++ b/packages/cli/src/commands/recipe-run-benchmark-artifacts.ts
@@ -32,6 +32,13 @@ interface RouteMatrixSummaryArtifact {
   routes: RouteMatrixStepSummary[]
 }
 
+interface RestRequestCaseSummaryArtifact {
+  schema: "wp-codebox/benchmark-rest-request-case-summary/v1"
+  componentId: string
+  scenarioId: string
+  cases: RestRequestCaseStepSummary[]
+}
+
 interface RouteMatrixStepSummary {
   index?: number
   id?: string
@@ -45,6 +52,10 @@ interface RouteMatrixStepSummary {
     bytes: number
     shape: unknown
   }
+}
+
+interface RestRequestCaseStepSummary extends RouteMatrixStepSummary {
+  caseId?: string
 }
 
 const benchResultsAjv = new Ajv2020({ strict: false })
@@ -185,7 +196,7 @@ export async function writeBenchmarkArtifactEvidence(artifacts: ArtifactBundle, 
 
 async function materializeRouteMatrixSummaryArtifacts(artifacts: ArtifactBundle, benchResultsList: BenchResults[]): Promise<BenchResults[]> {
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as ArtifactManifest
-  const writes: Array<{ resultIndex: number; scenarioIndex: number; path: string; summary: RouteMatrixSummaryArtifact }> = []
+  const writes: Array<{ resultIndex: number; scenarioIndex: number; path: string; artifactName: string; kind: string; operation: string; summary: RouteMatrixSummaryArtifact | RestRequestCaseSummaryArtifact }> = []
 
   benchResultsList.forEach((result, resultIndex) => {
     const routeMatrixScenarioIds = routeMatrixWorkloadScenarioIds(result)
@@ -202,11 +213,39 @@ async function materializeRouteMatrixSummaryArtifacts(artifacts: ArtifactBundle,
         resultIndex,
         scenarioIndex,
         path: `files/bench/${safeArtifactSegment(result.component_id)}/${safeArtifactSegment(scenarioId)}-route-matrix-summary.json`,
+        artifactName: "route-matrix-summary",
+        kind: "benchmark-route-matrix-summary",
+        operation: "materialize-route-matrix-summary",
         summary: {
           schema: "wp-codebox/benchmark-route-matrix-summary/v1",
           componentId: result.component_id,
           scenarioId,
           routes,
+        },
+      })
+    })
+    const restCaseScenarioIds = restRequestCaseWorkloadScenarioIds(result)
+    result.scenarios.forEach((scenario, scenarioIndex) => {
+      if (!restCaseScenarioIds.has(String(scenario.id ?? ""))) {
+        return
+      }
+      const cases = restRequestCaseStepSummaries((scenario as BenchScenarioWithArtifactRefs).steps)
+      if (cases.length === 0) {
+        return
+      }
+      const scenarioId = String(scenario.id ?? "")
+      writes.push({
+        resultIndex,
+        scenarioIndex,
+        path: `files/bench/${safeArtifactSegment(result.component_id)}/${safeArtifactSegment(scenarioId)}-rest-request-case-summary.json`,
+        artifactName: "rest-request-case-summary",
+        kind: "benchmark-rest-request-case-summary",
+        operation: "materialize-rest-request-case-summary",
+        summary: {
+          schema: "wp-codebox/benchmark-rest-request-case-summary/v1",
+          componentId: result.component_id,
+          scenarioId,
+          cases,
         },
       })
     })
@@ -223,15 +262,15 @@ async function materializeRouteMatrixSummaryArtifacts(artifacts: ArtifactBundle,
     await writeFile(absolutePath, `${JSON.stringify(write.summary, null, 2)}\n`)
   }
 
-  upsertArtifactManifestFiles(manifest, writes.map((write) => artifactManifestFile(write.path, "benchmark-route-matrix-summary", "application/json", undefined, {
+  upsertArtifactManifestFiles(manifest, writes.map((write) => artifactManifestFile(write.path, write.kind, "application/json", undefined, {
     redaction: {
       policy: "applied",
       sensitive: false,
-      reason: "Route-matrix response bodies are replaced with bounded shape and byte metadata.",
+      reason: "REST response bodies are replaced with bounded shape and byte metadata.",
     },
     provenance: {
       source: "wordpress.bench",
-      operation: "materialize-route-matrix-summary",
+      operation: write.operation,
     },
   })))
   await refreshArtifactManifestFileSha256s(artifacts.directory, manifest)
@@ -241,31 +280,31 @@ async function materializeRouteMatrixSummaryArtifacts(artifacts: ArtifactBundle,
   return benchResultsList.map((result, resultIndex) => ({
     ...result,
     scenarios: result.scenarios.map((scenario, scenarioIndex) => {
-      const write = writes.find((candidate) => candidate.resultIndex === resultIndex && candidate.scenarioIndex === scenarioIndex)
-      if (!write) {
+      const scenarioWrites = writes.filter((candidate) => candidate.resultIndex === resultIndex && candidate.scenarioIndex === scenarioIndex)
+      if (scenarioWrites.length === 0) {
         return scenario
       }
-      const ref = benchmarkArtifactRef(write.path, { source: "scenario-artifact", name: "route-matrix-summary", kind: "benchmark-route-matrix-summary", contentType: "application/json" }, manifestFiles)
+      const refs = scenarioWrites.map((write) => benchmarkArtifactRef(write.path, { source: "scenario-artifact", name: write.artifactName, kind: write.kind, contentType: "application/json" }, manifestFiles))
       const existingRefs = Array.isArray((scenario as BenchScenarioWithArtifactRefs).artifactRefs) ? (scenario as BenchScenarioWithArtifactRefs).artifactRefs ?? [] : []
       return stripUndefined({
         ...scenario,
-        steps: redactRouteMatrixStepResponses((scenario as BenchScenarioWithArtifactRefs).steps),
+        steps: redactRestStepResponses((scenario as BenchScenarioWithArtifactRefs).steps),
         artifacts: {
           ...(scenario.artifacts ?? {}),
-          "route-matrix-summary": ref,
+          ...Object.fromEntries(scenarioWrites.map((write, index) => [write.artifactName, refs[index]])),
         },
-        artifactRefs: dedupeBenchmarkArtifactRefs([...existingRefs, ref]),
+        artifactRefs: dedupeBenchmarkArtifactRefs([...existingRefs, ...refs]),
       }) as BenchResults["scenarios"][number]
     }),
   }))
 }
 
-function redactRouteMatrixStepResponses(steps: unknown): unknown {
+function redactRestStepResponses(steps: unknown): unknown {
   if (!Array.isArray(steps)) {
     return steps
   }
   return steps.map((step) => {
-    if (!isRecord(step) || step.type !== "rest-request" || typeof step.route_matrix_index !== "number" || !Object.hasOwn(step, "response")) {
+    if (!isRecord(step) || step.type !== "rest-request" || (typeof step.route_matrix_index !== "number" && typeof step.rest_request_case_index !== "number") || !Object.hasOwn(step, "response")) {
       return step
     }
     return {
@@ -279,6 +318,13 @@ function routeMatrixWorkloadScenarioIds(result: BenchResults): Set<string> {
   const workloads = isRecord(result.provenance.definition) && Array.isArray(result.provenance.definition.workloads) ? result.provenance.definition.workloads : []
   return new Set(workloads
     .filter((workload) => isRecord(workload) && Array.isArray(workload.route_matrix) && workload.route_matrix.length > 0 && typeof workload.id === "string" && workload.id.length > 0)
+    .map((workload) => String(workload.id)))
+}
+
+function restRequestCaseWorkloadScenarioIds(result: BenchResults): Set<string> {
+  const workloads = isRecord(result.provenance.definition) && Array.isArray(result.provenance.definition.workloads) ? result.provenance.definition.workloads : []
+  return new Set(workloads
+    .filter((workload) => isRecord(workload) && ((Array.isArray(workload.rest_request_cases) && workload.rest_request_cases.length > 0) || (Array.isArray(workload.request_cases) && workload.request_cases.length > 0)) && typeof workload.id === "string" && workload.id.length > 0)
     .map((workload) => String(workload.id)))
 }
 
@@ -298,6 +344,25 @@ function routeMatrixStepSummaries(steps: unknown): RouteMatrixStepSummary[] {
       duration_ms: isRecord(step.timing) && typeof step.timing.duration_ms === "number" ? step.timing.duration_ms : undefined,
       ...(Object.hasOwn(step, "response") ? { response: redactedResponseSummary(step.response) } : {}),
     })) as RouteMatrixStepSummary[]
+}
+
+function restRequestCaseStepSummaries(steps: unknown): RestRequestCaseStepSummary[] {
+  if (!Array.isArray(steps)) {
+    return []
+  }
+  return steps
+    .filter((step): step is Record<string, unknown> => isRecord(step) && step.type === "rest-request" && typeof step.rest_request_case_index === "number")
+    .map((step) => stripUndefined({
+      index: typeof step.rest_request_case_index === "number" ? step.rest_request_case_index : undefined,
+      caseId: typeof step.case_id === "string" ? step.case_id : undefined,
+      id: typeof step.route_id === "string" ? step.route_id : undefined,
+      method: typeof step.method === "string" ? step.method : undefined,
+      path: typeof step.path === "string" ? step.path : undefined,
+      route: typeof step.route === "string" ? step.route : undefined,
+      status: typeof step.status === "number" ? step.status : undefined,
+      duration_ms: isRecord(step.timing) && typeof step.timing.duration_ms === "number" ? step.timing.duration_ms : undefined,
+      ...(Object.hasOwn(step, "response") ? { response: redactedResponseSummary(step.response) } : {}),
+    })) as RestRequestCaseStepSummary[]
 }
 
 function redactedResponseSummary(response: unknown): RouteMatrixStepSummary["response"] {

--- a/packages/runtime-core/src/benchmark-contracts.ts
+++ b/packages/runtime-core/src/benchmark-contracts.ts
@@ -123,13 +123,20 @@ export interface BenchmarkDefinitionRestRouteMatrixEntry {
   metadata?: Record<string, unknown>
 }
 
+export interface BenchmarkDefinitionRestRequestCaseEntry extends BenchmarkDefinitionRestRouteMatrixEntry {
+  case_id?: string
+  caseId?: string
+}
+
 export interface BenchmarkDefinitionWorkload {
   id: string
   source?: BenchmarkScenarioSource
   file?: string
-  run?: BenchmarkDefinitionWorkloadStep[]
-  route_matrix?: BenchmarkDefinitionRestRouteMatrixEntry[]
-  artifacts?: Record<string, BenchmarkArtifactRef>
+	run?: BenchmarkDefinitionWorkloadStep[]
+	route_matrix?: BenchmarkDefinitionRestRouteMatrixEntry[]
+	rest_request_cases?: BenchmarkDefinitionRestRequestCaseEntry[]
+	request_cases?: BenchmarkDefinitionRestRequestCaseEntry[]
+	artifacts?: Record<string, BenchmarkArtifactRef>
   metadata?: Record<string, unknown>
 }
 
@@ -335,13 +342,15 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
         id: { type: "string", minLength: 1 },
         source: { type: "string" },
         file: { type: "string" },
-        run: { type: "array", items: { $ref: "#/$defs/workloadStep" } },
-        route_matrix: { type: "array", items: { $ref: "#/$defs/restRouteMatrixEntry" } },
-        artifacts: { $ref: "#/$defs/artifactMap" },
+		run: { type: "array", items: { $ref: "#/$defs/workloadStep" } },
+		route_matrix: { type: "array", items: { $ref: "#/$defs/restRouteMatrixEntry" } },
+		rest_request_cases: { type: "array", items: { $ref: "#/$defs/restRequestCaseEntry" } },
+		request_cases: { type: "array", items: { $ref: "#/$defs/restRequestCaseEntry" } },
+		artifacts: { $ref: "#/$defs/artifactMap" },
         metadata: { type: "object", additionalProperties: true },
       },
     },
-    restRouteMatrixEntry: {
+	restRouteMatrixEntry: {
       type: "object",
       additionalProperties: false,
       properties: {
@@ -357,8 +366,28 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
         "metric-prefix": { type: "string", minLength: 1 },
         metadata: { type: "object", additionalProperties: true },
       },
-      anyOf: [{ required: ["path"] }, { required: ["route"] }],
-    },
+		anyOf: [{ required: ["path"] }, { required: ["route"] }],
+	},
+	restRequestCaseEntry: {
+		type: "object",
+		additionalProperties: false,
+		properties: {
+			id: { type: "string", minLength: 1 },
+			case_id: { type: "string", minLength: 1 },
+			caseId: { type: "string", minLength: 1 },
+			method: { type: "string", minLength: 1 },
+			path: { type: "string", minLength: 1 },
+			route: { type: "string", minLength: 1 },
+			params: { type: "object", additionalProperties: true },
+			headers: { type: "object", additionalProperties: true },
+			body: true,
+			"body-json": true,
+			"capture-response": { type: "boolean" },
+			"metric-prefix": { type: "string", minLength: 1 },
+			metadata: { type: "object", additionalProperties: true },
+		},
+		anyOf: [{ required: ["path"] }, { required: ["route"] }],
+	},
     workloadStep: {
       type: "object",
       additionalProperties: true,

--- a/tests/benchmark-contracts.test.ts
+++ b/tests/benchmark-contracts.test.ts
@@ -24,6 +24,15 @@ const routeMatrixDefinition = {
           "metric-prefix": "rest_items_list",
         },
       ],
+      rest_request_cases: [
+        {
+          id: "items-search",
+          method: "GET",
+          path: "/example/v1/items",
+          params: { search: "hat" },
+          "capture-response": true,
+        },
+      ],
       artifacts: {
         "route-summary": {
           path: "bench/rest-route-summary.json",
@@ -38,11 +47,16 @@ const routeMatrixDefinition = {
 const schema = createBenchmarkDefinitionJsonSchema()
 const workloadDefinition = (schema.$defs as Record<string, { properties?: Record<string, unknown> }>).workload
 const routeDefinition = (schema.$defs as Record<string, { anyOf?: unknown; properties?: Record<string, unknown> }>).restRouteMatrixEntry
+const restCaseDefinition = (schema.$defs as Record<string, { anyOf?: unknown; properties?: Record<string, unknown> }>).restRequestCaseEntry
 
 assert.ok(routeMatrixDefinition.workloads[0].route_matrix?.[0].path)
 assert.ok(workloadDefinition.properties?.route_matrix, "benchmark definition schema should expose workload route_matrix")
+assert.ok(workloadDefinition.properties?.rest_request_cases, "benchmark definition schema should expose workload rest_request_cases")
+assert.ok(workloadDefinition.properties?.request_cases, "benchmark definition schema should expose workload request_cases")
 assert.ok(routeDefinition.properties?.["capture-response"], "route_matrix entries should expose REST response capture")
+assert.ok(restCaseDefinition.properties?.case_id, "REST request case entries should expose case_id")
 assert.deepEqual(routeDefinition.anyOf, [{ required: ["path"] }, { required: ["route"] }])
+assert.deepEqual(restCaseDefinition.anyOf, [{ required: ["path"] }, { required: ["route"] }])
 
 await withTempDir("wp-codebox-route-matrix-artifacts-", async (directory) => {
   await mkdir(join(directory, "files"), { recursive: true })
@@ -76,6 +90,17 @@ await withTempDir("wp-codebox-route-matrix-artifacts-", async (directory) => {
         status: 200,
         timing: { duration_ms: 12.5 },
         response: [{ id: 123, secret: "not persisted" }],
+      }, {
+        schema: "wp-codebox/bench-command-step/v1",
+        type: "rest-request",
+        rest_request_case_index: 0,
+        case_id: "items-search",
+        method: "GET",
+        path: "/example/v1/items",
+        route: "/example/v1/items",
+        status: 200,
+        timing: { duration_ms: 15.5 },
+        response: { id: 456, secret: "also not persisted" },
       }],
     }],
     diagnostics: [],
@@ -92,16 +117,29 @@ await withTempDir("wp-codebox-route-matrix-artifacts-", async (directory) => {
   assert.deepEqual(summary.routes[0].response?.shape, { type: "array", length: 1, items: { type: "object", keys: { id: "number", secret: "string" } } })
   assert.doesNotMatch(JSON.stringify(summary), /not persisted/)
 
+  const caseSummary = JSON.parse(await readFile(join(directory, "files", "bench", "generic-api", "rest-catalog-rest-request-case-summary.json"), "utf8")) as { schema: string; cases: Array<{ caseId?: string; response?: { bytes: number; shape: unknown } }> }
+  assert.equal(caseSummary.schema, "wp-codebox/benchmark-rest-request-case-summary/v1")
+  assert.equal(caseSummary.cases[0].caseId, "items-search")
+  assert.deepEqual(caseSummary.cases[0].response?.shape, { type: "object", keys: { id: "number", secret: "string" } })
+  assert.doesNotMatch(JSON.stringify(caseSummary), /also not persisted/)
+
   const benchArtifacts = JSON.parse(await readFile(join(directory, "files", "bench-results.json"), "utf8")) as { scenarios: Array<{ artifactRefs: Array<{ kind: string; name: string; path: string; contentType?: string; sha256?: string; source?: string }> }> }
   assert.doesNotMatch(JSON.stringify(benchArtifacts), /not persisted/)
-  assert.deepEqual(benchArtifacts.scenarios[0].artifactRefs[0], {
+  assert.deepEqual(benchArtifacts.scenarios[0].artifactRefs.map((ref) => ({ ...ref, sha256: "sha" })), [{
     path: "files/bench/generic-api/rest-catalog-route-matrix-summary.json",
     kind: "benchmark-route-matrix-summary",
     contentType: "application/json",
-    sha256: benchArtifacts.scenarios[0].artifactRefs[0].sha256,
+    sha256: "sha",
     source: "scenario-artifact",
     name: "route-matrix-summary",
-  })
+  }, {
+    path: "files/bench/generic-api/rest-catalog-rest-request-case-summary.json",
+    kind: "benchmark-rest-request-case-summary",
+    contentType: "application/json",
+    sha256: "sha",
+    source: "scenario-artifact",
+    name: "rest-request-case-summary",
+  }])
 })
 
 console.log("benchmark contracts ok")


### PR DESCRIPTION
## Summary
- Materialize generated REST request case summaries as typed benchmark artifacts.
- Add benchmark definition contract support for `rest_request_cases` and `request_cases`.
- Redact generated-case REST responses using the same bounded shape metadata as route matrix summaries.

## Testing
- `npm install` to restore workspace dependencies; the repo `prepare` build completed successfully.
- `npx tsx tests/benchmark-contracts.test.ts`
- `npm run test:bench-command-step-behavior`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing REST request case summary artifacts, benchmark contract coverage, and PR preparation under Chris review.
