### PR TITLE
Add benchmark artifact refs for full-surface coverage

### DIFF
--- a/docs/benchmark-contract.md
+++ b/docs/benchmark-contract.md
@@ -46,7 +46,17 @@ The command contract is intentionally broad enough for future workload types:
 - **WP-CLI:** configured workload steps that execute in the same sandbox.
 - **Ability:** future ability-backed workload steps should still return generic numeric metrics and metadata.
 - **REST:** configured `rest-request` steps call `rest_do_request()` in-process. A configured workload may declare `route_matrix` as a compact list of REST routes; WP Codebox expands each route into the existing `rest-request` step type.
+- **Database inventory:** configured `db-inventory` steps collect table, row, column, index, and byte-count inventory through the benchmark artifact path.
 - **Browser:** `wordpress.browser-probe` captures generic browser performance and memory artifacts. When a recipe runs browser probes before `wordpress.bench`, selected numeric `browser_*` metrics are promoted into each benchmark scenario while raw browser artifacts remain in the bundle.
+
+WP Codebox does not currently expose a REST DB query profiler workload step. Full
+REST query profiling needs an upstream runtime hook that brackets each
+`rest_do_request()` call, captures `$wpdb->queries` or an equivalent query log for
+that request only, and emits a bounded artifact with query count, total query
+time, repeated-query summaries, and redacted SQL fingerprints. Until that hook
+exists, caller rigs should use real `rest_request_cases` and `db-inventory`
+workloads separately and leave `rest-db-query-profiler` as a documented missing
+primitive rather than emitting synthetic query-profile artifacts.
 
 ## REST Route Matrices
 

--- a/packages/cli/src/commands/recipe-run-benchmark-artifacts.ts
+++ b/packages/cli/src/commands/recipe-run-benchmark-artifacts.ts
@@ -39,6 +39,27 @@ interface RestRequestCaseSummaryArtifact {
   cases: RestRequestCaseStepSummary[]
 }
 
+interface DbInventoryBenchmarkArtifact {
+  schema: "wp-codebox/benchmark-db-inventory/v1"
+  componentId: string
+  scenarioId: string
+  inventory: unknown
+}
+
+interface ExternalHttpGuardrailBenchmarkArtifact {
+  schema: "wp-codebox/benchmark-external-http-guardrail/v1"
+  componentId: string
+  scenarioId: string
+  guardrail: unknown
+}
+
+interface RestDbQueryProfileBenchmarkArtifact {
+  schema: "wp-codebox/benchmark-rest-db-query-profile/v1"
+  componentId: string
+  scenarioId: string
+  profile: unknown
+}
+
 interface RouteMatrixStepSummary {
   index?: number
   id?: string
@@ -157,7 +178,7 @@ function enrichBenchScenarioArtifactRefs(scenario: BenchResults["scenarios"][num
     ...scenarioArtifactRefs(scenario.artifacts, manifestFiles, "scenario-artifact"),
     ...sampleArtifactRefs((scenario as BenchScenarioWithArtifactRefs).samples, manifestFiles),
     ...metricArtifactRefs(scenario.metrics, manifestFiles),
-    ...browserArtifactRefs(scenario.metrics, manifestFiles),
+    ...browserArtifactRefs(manifestFiles),
   ]
   const existingRefs = Array.isArray((scenario as BenchScenarioWithArtifactRefs).artifactRefs) ? (scenario as BenchScenarioWithArtifactRefs).artifactRefs ?? [] : []
   const dedupedRefs = dedupeBenchmarkArtifactRefs([...existingRefs, ...artifactRefs])
@@ -169,8 +190,13 @@ function enrichBenchScenarioArtifactRefs(scenario: BenchResults["scenarios"][num
 }
 
 export async function writeBenchmarkArtifactEvidence(artifacts: ArtifactBundle, benchResultsList: BenchResults[]): Promise<void> {
-  const materializedBenchResultsList = await materializeRouteMatrixSummaryArtifacts(artifacts, benchResultsList)
-  const scenarios = materializedBenchResultsList.flatMap((result) => result.scenarios.map((scenario) => ({
+  const materializedBenchResultsList = await materializeBenchmarkSummaryArtifacts(artifacts, benchResultsList)
+  const manifestFiles = await artifactManifestFilesByPath(artifacts)
+  const enrichedBenchResultsList = materializedBenchResultsList.map((result) => ({
+    ...result,
+    scenarios: result.scenarios.map((scenario) => enrichBenchScenarioArtifactRefs(scenario, manifestFiles)),
+  }))
+  const scenarios = enrichedBenchResultsList.flatMap((result) => result.scenarios.map((scenario) => ({
     componentId: result.component_id,
     scenarioId: String(scenario.id ?? ""),
     source: typeof scenario.source === "string" ? scenario.source : undefined,
@@ -183,7 +209,7 @@ export async function writeBenchmarkArtifactEvidence(artifacts: ArtifactBundle, 
       directory: artifacts.directory,
       contentDigest: artifacts.contentDigest,
     },
-    results: materializedBenchResultsList,
+    results: enrichedBenchResultsList,
     scenarios,
   }
   const relativePath = "files/bench-results.json"
@@ -194,13 +220,67 @@ export async function writeBenchmarkArtifactEvidence(artifacts: ArtifactBundle, 
   await writeFile(artifacts.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
 }
 
-async function materializeRouteMatrixSummaryArtifacts(artifacts: ArtifactBundle, benchResultsList: BenchResults[]): Promise<BenchResults[]> {
+async function materializeBenchmarkSummaryArtifacts(artifacts: ArtifactBundle, benchResultsList: BenchResults[]): Promise<BenchResults[]> {
   const manifest = JSON.parse(await readFile(artifacts.manifestPath, "utf8")) as ArtifactManifest
-  const writes: Array<{ resultIndex: number; scenarioIndex: number; path: string; artifactName: string; kind: string; operation: string; summary: RouteMatrixSummaryArtifact | RestRequestCaseSummaryArtifact }> = []
+  const writes: Array<{ resultIndex: number; scenarioIndex: number; path: string; artifactName: string; kind: string; operation: string; summary: RouteMatrixSummaryArtifact | RestRequestCaseSummaryArtifact | DbInventoryBenchmarkArtifact | ExternalHttpGuardrailBenchmarkArtifact | RestDbQueryProfileBenchmarkArtifact }> = []
 
   benchResultsList.forEach((result, resultIndex) => {
     const routeMatrixScenarioIds = routeMatrixWorkloadScenarioIds(result)
     result.scenarios.forEach((scenario, scenarioIndex) => {
+      const dbInventory = isRecord(scenario.artifacts) && isRecord(scenario.artifacts["db-inventory"]) && scenario.artifacts["db-inventory"].schema === "wp-codebox/wordpress-db-inventory/v1" ? scenario.artifacts["db-inventory"] : undefined
+      if (dbInventory) {
+        const scenarioId = String(scenario.id ?? "")
+        writes.push({
+          resultIndex,
+          scenarioIndex,
+          path: `files/bench/${safeArtifactSegment(result.component_id)}/${safeArtifactSegment(scenarioId)}-db-inventory.json`,
+          artifactName: "db-inventory",
+          kind: "benchmark-db-inventory",
+          operation: "materialize-db-inventory",
+          summary: {
+            schema: "wp-codebox/benchmark-db-inventory/v1",
+            componentId: result.component_id,
+            scenarioId,
+            inventory: dbInventory,
+          },
+        })
+      }
+      const externalHttpGuardrail = isRecord(scenario.artifacts) && isRecord(scenario.artifacts["external-http-guardrail"]) && scenario.artifacts["external-http-guardrail"].schema === "wp-codebox/wordpress-external-http-guardrail/v1" ? scenario.artifacts["external-http-guardrail"] : undefined
+      if (externalHttpGuardrail) {
+        const scenarioId = String(scenario.id ?? "")
+        writes.push({
+          resultIndex,
+          scenarioIndex,
+          path: `files/bench/${safeArtifactSegment(result.component_id)}/${safeArtifactSegment(scenarioId)}-external-http-guardrail.json`,
+          artifactName: "external-http-guardrail",
+          kind: "benchmark-external-http-guardrail",
+          operation: "materialize-external-http-guardrail",
+          summary: {
+            schema: "wp-codebox/benchmark-external-http-guardrail/v1",
+            componentId: result.component_id,
+            scenarioId,
+            guardrail: externalHttpGuardrail,
+          },
+        })
+      }
+      const restDbQueryProfile = isRecord(scenario.artifacts) && isRecord(scenario.artifacts["rest-db-query-profile"]) && scenario.artifacts["rest-db-query-profile"].schema === "wp-codebox/wordpress-rest-db-query-profile/v1" ? scenario.artifacts["rest-db-query-profile"] : undefined
+      if (restDbQueryProfile) {
+        const scenarioId = String(scenario.id ?? "")
+        writes.push({
+          resultIndex,
+          scenarioIndex,
+          path: `files/bench/${safeArtifactSegment(result.component_id)}/${safeArtifactSegment(scenarioId)}-rest-db-query-profile.json`,
+          artifactName: "rest-db-query-profile",
+          kind: "benchmark-rest-db-query-profile",
+          operation: "materialize-rest-db-query-profile",
+          summary: {
+            schema: "wp-codebox/benchmark-rest-db-query-profile/v1",
+            componentId: result.component_id,
+            scenarioId,
+            profile: restDbQueryProfile,
+          },
+        })
+      }
       if (!routeMatrixScenarioIds.has(String(scenario.id ?? ""))) {
         return
       }
@@ -286,12 +366,13 @@ async function materializeRouteMatrixSummaryArtifacts(artifacts: ArtifactBundle,
       }
       const refs = scenarioWrites.map((write) => benchmarkArtifactRef(write.path, { source: "scenario-artifact", name: write.artifactName, kind: write.kind, contentType: "application/json" }, manifestFiles))
       const existingRefs = Array.isArray((scenario as BenchScenarioWithArtifactRefs).artifactRefs) ? (scenario as BenchScenarioWithArtifactRefs).artifactRefs ?? [] : []
+      const materializedArtifacts = Object.fromEntries(scenarioWrites.map((write, index) => [write.artifactName, refs[index]]))
       return stripUndefined({
         ...scenario,
         steps: redactRestStepResponses((scenario as BenchScenarioWithArtifactRefs).steps),
         artifacts: {
           ...(scenario.artifacts ?? {}),
-          ...Object.fromEntries(scenarioWrites.map((write, index) => [write.artifactName, refs[index]])),
+          ...materializedArtifacts,
         },
         artifactRefs: dedupeBenchmarkArtifactRefs([...existingRefs, ...refs]),
       }) as BenchResults["scenarios"][number]
@@ -459,11 +540,7 @@ function metricArtifactRefs(metrics: BenchResults["scenarios"][number]["metrics"
   return Object.keys(metrics).sort().map((metric) => benchmarkArtifactRef("files/bench-results.json", { source: "metric-source", metric, kind: "benchmark-results", contentType: "application/json" }, manifestFiles))
 }
 
-function browserArtifactRefs(metrics: BenchResults["scenarios"][number]["metrics"], manifestFiles: Map<string, ArtifactManifestFile>): BenchmarkArtifactRef[] {
-  if (!metrics || !Object.keys(metrics).some((metric) => metric.startsWith("browser_"))) {
-    return []
-  }
-
+function browserArtifactRefs(manifestFiles: Map<string, ArtifactManifestFile>): BenchmarkArtifactRef[] {
   return [...manifestFiles.values()]
     .filter((file) => file.path.startsWith("files/browser/"))
     .map((file) => benchmarkArtifactRef(file.path, { source: "browser-artifact", kind: file.kind, contentType: file.contentType }, manifestFiles))

--- a/packages/runtime-core/src/benchmark-contracts.ts
+++ b/packages/runtime-core/src/benchmark-contracts.ts
@@ -101,10 +101,17 @@ export interface BenchResults {
 
 export interface BenchmarkDefinitionWorkloadStep {
   type: "php" | "wp-cli" | "rest-request" | "ability" | (string & {})
+  action?: "install" | "collect" | "reset" | (string & {})
   code?: string
   file?: string
   command?: string
   parse?: "json" | (string & {})
+  allowlistDomains?: string[]
+  blockNetwork?: boolean
+  redactUrls?: boolean
+  blockResponse?: { code?: number; message?: string; body?: string }
+  sampleLimit?: number
+  queryLengthLimit?: number
   metadata?: Record<string, unknown>
   [key: string]: unknown
 }
@@ -398,6 +405,21 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
         file: { type: "string" },
         command: { type: "string" },
         parse: { type: "string" },
+        action: { type: "string" },
+        allowlistDomains: { type: "array", items: { type: "string", minLength: 1 } },
+        blockNetwork: { type: "boolean" },
+        redactUrls: { type: "boolean" },
+        blockResponse: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            code: { type: "integer", minimum: 100, maximum: 599 },
+            message: { type: "string" },
+            body: { type: "string" },
+          },
+        },
+        sampleLimit: { type: "integer", minimum: 0 },
+        queryLengthLimit: { type: "integer", minimum: 80 },
         metadata: { type: "object", additionalProperties: true },
       },
     },

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -396,6 +396,149 @@ function wp_codebox_bench_run_rest_request_step(array $step): array {
     return wp_codebox_bench_command_step_payload($execution, $prefix, array($prefix . '_status' => $status), $record);
 }
 
+function wp_codebox_bench_redact_sql_query(string $sql, int $limit = 500): string {
+    $redacted = preg_replace("/'(?:''|[^'])*'/", "'?'", $sql);
+    $redacted = preg_replace('/\\b\\d+(?:\\.\\d+)?\\b/', '?', is_string($redacted) ? $redacted : $sql);
+    $redacted = preg_replace('/\\s+/', ' ', is_string($redacted) ? $redacted : $sql);
+    $redacted = trim((string) $redacted);
+    return strlen($redacted) > $limit ? substr($redacted, 0, $limit) . '...' : $redacted;
+}
+
+function wp_codebox_bench_rest_db_query_profile_summary(array $queries): array {
+    $total_time = 0.0;
+    $by_operation = array();
+    foreach ($queries as $query) {
+        $sql = isset($query[0]) ? (string) $query[0] : '';
+        $duration = isset($query[1]) && is_numeric($query[1]) ? (float) $query[1] : 0.0;
+        $total_time += $duration;
+        $operation = strtoupper(strtok(ltrim($sql), " \t\n\r") ?: 'UNKNOWN');
+        if (!isset($by_operation[$operation])) {
+            $by_operation[$operation] = array('operation' => $operation, 'count' => 0, 'time_ms' => 0.0);
+        }
+        ++$by_operation[$operation]['count'];
+        $by_operation[$operation]['time_ms'] += $duration * 1000;
+    }
+    $operations = array_values($by_operation);
+    usort($operations, static fn(array $left, array $right): int => ($right['count'] <=> $left['count']) ?: strcmp($left['operation'], $right['operation']));
+    return array('query_count' => count($queries), 'total_time_ms' => $total_time * 1000, 'operations' => $operations);
+}
+
+function wp_codebox_bench_rest_db_query_profile_case_step(array $request_case, int $index): array {
+    $step = array_merge($request_case, array('type' => 'rest-request'));
+    if (!isset($step['path']) && isset($request_case['route'])) {
+        $step['path'] = $request_case['route'];
+    }
+    if (!isset($step['metadata']) || !is_array($step['metadata'])) {
+        $step['metadata'] = array();
+    }
+    $step['metadata'] = array_merge(array('rest_request_case_index' => $index), $step['metadata']);
+    if (!isset($step['case_id']) && isset($request_case['id']) && is_scalar($request_case['id'])) {
+        $step['case_id'] = (string) $request_case['id'];
+    }
+    if (!isset($step['metric-prefix'])) {
+        $case_id = isset($step['case_id']) && is_string($step['case_id']) ? $step['case_id'] : 'case_' . $index;
+        $step['metric-prefix'] = 'rest_profile_' . preg_replace('/[^A-Za-z0-9_]+/', '_', $case_id);
+    }
+    return $step;
+}
+
+function wp_codebox_bench_run_rest_db_query_profiler_step(array $step): array {
+    global $wpdb;
+
+    if (!is_object($wpdb)) {
+        throw new RuntimeException('wordpress.bench rest-db-query-profiler requires wpdb.');
+    }
+    if (!class_exists('WP_REST_Request') || !function_exists('rest_do_request')) {
+        throw new RuntimeException('The WordPress REST API is not available in this runtime.');
+    }
+    if (!defined('SAVEQUERIES')) {
+        define('SAVEQUERIES', true);
+    }
+
+    $prefix = wp_codebox_bench_metric_prefix($step, 'rest_db_query_profile');
+    $sample_limit = isset($step['sampleLimit']) && is_numeric($step['sampleLimit']) ? max(0, (int) $step['sampleLimit']) : 50;
+    $query_length_limit = isset($step['queryLengthLimit']) && is_numeric($step['queryLengthLimit']) ? max(80, (int) $step['queryLengthLimit']) : 500;
+    $request_cases = isset($step['rest_request_cases']) && is_array($step['rest_request_cases']) ? $step['rest_request_cases'] : array();
+    if (empty($request_cases) && isset($step['request_cases']) && is_array($step['request_cases'])) {
+        $request_cases = $step['request_cases'];
+    }
+    if (empty($request_cases)) {
+        $request_cases = array($step);
+    }
+
+    $previous_save_queries = property_exists($wpdb, 'save_queries') ? $wpdb->save_queries : null;
+    $wpdb->save_queries = true;
+    $case_profiles = array();
+    $steps = array();
+    $total_queries = 0;
+    $total_time_ms = 0.0;
+    $profile_started = hrtime(true);
+
+    try {
+        foreach ($request_cases as $index => $request_case) {
+            if (!is_array($request_case)) {
+                continue;
+            }
+            $case_step = wp_codebox_bench_rest_db_query_profile_case_step($request_case, $index);
+            $before = is_array($wpdb->queries ?? null) ? count($wpdb->queries) : 0;
+            $payload = wp_codebox_bench_run_rest_request_step($case_step);
+            $after_queries = is_array($wpdb->queries ?? null) ? array_slice($wpdb->queries, $before) : array();
+            $summary = wp_codebox_bench_rest_db_query_profile_summary($after_queries);
+            $samples = array();
+            foreach (array_slice($after_queries, 0, $sample_limit) as $query) {
+                $samples[] = array(
+                    'sql' => wp_codebox_bench_redact_sql_query(isset($query[0]) ? (string) $query[0] : '', $query_length_limit),
+                    'time_ms' => isset($query[1]) && is_numeric($query[1]) ? (float) $query[1] * 1000 : 0.0,
+                    'caller' => isset($query[2]) ? wp_codebox_bench_redact_sql_query((string) $query[2], $query_length_limit) : '',
+                );
+            }
+            $case_id = isset($case_step['case_id']) ? (string) $case_step['case_id'] : 'case-' . $index;
+            $case_profiles[] = array(
+                'case_id' => $case_id,
+                'method' => isset($case_step['method']) ? strtoupper((string) $case_step['method']) : 'GET',
+                'path' => isset($case_step['path']) ? (string) $case_step['path'] : (isset($case_step['route']) ? (string) $case_step['route'] : ''),
+                'summary' => $summary,
+                'samples' => $samples,
+            );
+            $total_queries += (int) $summary['query_count'];
+            $total_time_ms += (float) $summary['total_time_ms'];
+            if (isset($payload['steps']) && is_array($payload['steps'])) {
+                $steps = array_merge($steps, $payload['steps']);
+            }
+        }
+    } finally {
+        if ($previous_save_queries !== null) {
+            $wpdb->save_queries = $previous_save_queries;
+        }
+    }
+
+    $artifact = array(
+        'schema' => 'wp-codebox/wordpress-rest-db-query-profile/v1',
+        'summary' => array(
+            'case_count' => count($case_profiles),
+            'query_count' => $total_queries,
+            'total_time_ms' => $total_time_ms,
+            'sample_limit' => $sample_limit,
+            'query_length_limit' => $query_length_limit,
+        ),
+        'cases' => $case_profiles,
+    );
+    $duration_ms = (hrtime(true) - $profile_started) / 1000000;
+    $execution = array(
+        'result' => $artifact,
+        'duration_ms' => $duration_ms,
+        'record' => wp_codebox_bench_command_step_record($step, 'rest-db-query-profiler', $duration_ms),
+    );
+    $payload = wp_codebox_bench_command_step_payload($execution, $prefix, array(
+        $prefix . '_cases_count' => count($case_profiles),
+        $prefix . '_queries_count' => $total_queries,
+        $prefix . '_query_time_ms' => $total_time_ms,
+    ), array('cases' => count($case_profiles), 'queries' => $total_queries));
+    $payload['artifacts']['rest-db-query-profile'] = $artifact;
+    $payload['steps'] = array_merge($payload['steps'], $steps);
+    return $payload;
+}
+
 function wp_codebox_bench_run_ability_step(array $step): array {
     if (!function_exists('wp_get_ability')) {
         throw new RuntimeException('The WordPress Abilities API is not available in this runtime.');
@@ -493,6 +636,204 @@ function wp_codebox_bench_run_db_inventory_step(array $step): array {
     ), array('tables' => count($tables), 'columns' => $column_count, 'indexes' => $index_count));
     $payload['artifacts']['db-inventory'] = $inventory;
     return $payload;
+}
+
+function wp_codebox_bench_external_http_guardrail_state(): array {
+    if (!isset($GLOBALS['wp_codebox_external_http_guardrail']) || !is_array($GLOBALS['wp_codebox_external_http_guardrail'])) {
+        $GLOBALS['wp_codebox_external_http_guardrail'] = array(
+            'installed' => false,
+            'events' => array(),
+            'policy' => array(
+                'allowlistDomains' => array(),
+                'blockNetwork' => false,
+                'redactUrls' => true,
+                'blockResponse' => array('code' => 599, 'message' => 'External HTTP blocked by WP Codebox guardrail', 'body' => ''),
+            ),
+        );
+    }
+    return $GLOBALS['wp_codebox_external_http_guardrail'];
+}
+
+function wp_codebox_bench_normalize_external_http_guardrail_policy(array $step): array {
+    $allowlist = array();
+    foreach (is_array($step['allowlistDomains'] ?? null) ? $step['allowlistDomains'] : array() as $domain) {
+        if (is_string($domain) && trim($domain) !== '') {
+            $allowlist[] = strtolower(trim($domain, " \t\n\r\0\x0B."));
+        }
+    }
+    $allowlist = array_values(array_unique($allowlist));
+    $block_response = is_array($step['blockResponse'] ?? null) ? $step['blockResponse'] : array();
+    $code = isset($block_response['code']) && is_numeric($block_response['code']) ? (int) $block_response['code'] : 599;
+    if ($code < 100 || $code > 599) {
+        $code = 599;
+    }
+    return array(
+        'allowlistDomains' => $allowlist,
+        'blockNetwork' => array_key_exists('blockNetwork', $step) ? (bool) $step['blockNetwork'] : !empty($allowlist),
+        'redactUrls' => !array_key_exists('redactUrls', $step) || (bool) $step['redactUrls'],
+        'blockResponse' => array(
+            'code' => $code,
+            'message' => isset($block_response['message']) && is_string($block_response['message']) ? $block_response['message'] : 'External HTTP blocked by WP Codebox guardrail',
+            'body' => isset($block_response['body']) && is_string($block_response['body']) ? $block_response['body'] : '',
+        ),
+    );
+}
+
+function wp_codebox_bench_external_http_guardrail_redact_url(string $url): string {
+    $parts = wp_parse_url($url);
+    if (!is_array($parts) || empty($parts['host'])) {
+        return preg_replace('/([?&][^=&#]+)=([^&#]*)/', '$1=redacted', preg_replace('/#.*/', '', $url));
+    }
+    $redacted = ($parts['scheme'] ?? 'http') . '://';
+    if (!empty($parts['user'])) {
+        $redacted .= 'redacted@';
+    }
+    $redacted .= $parts['host'];
+    if (!empty($parts['port'])) {
+        $redacted .= ':' . $parts['port'];
+    }
+    $redacted .= $parts['path'] ?? '';
+    if (!empty($parts['query'])) {
+        $redacted .= '?redacted=1';
+    }
+    return $redacted;
+}
+
+function wp_codebox_bench_external_http_guardrail_host_allowed(string $host, array $allowlist): bool {
+    $host = strtolower(trim($host, '.'));
+    if ($host === '') {
+        return false;
+    }
+    foreach ($allowlist as $domain) {
+        $domain = strtolower(trim((string) $domain, '.'));
+        if ($domain !== '' && ($host === $domain || str_ends_with($host, '.' . $domain))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function wp_codebox_bench_external_http_guardrail_summary(array $events, int $sample_limit = 20): array {
+    $hosts = array();
+    $allowed_count = 0;
+    $blocked_count = 0;
+    foreach ($events as $event) {
+        $host = isset($event['data']['host']) ? (string) $event['data']['host'] : 'unknown';
+        if (!isset($hosts[$host])) {
+            $hosts[$host] = array('host' => $host, 'count' => 0, 'allowed' => 0, 'blocked' => 0);
+        }
+        ++$hosts[$host]['count'];
+        if (!empty($event['data']['blocked']) || ($event['event'] ?? '') === 'http.blocked') {
+            ++$hosts[$host]['blocked'];
+            ++$blocked_count;
+        } else {
+            ++$hosts[$host]['allowed'];
+            ++$allowed_count;
+        }
+    }
+    $host_values = array_values($hosts);
+    usort($host_values, static fn(array $left, array $right): int => ($right['count'] <=> $left['count']) ?: strcmp($left['host'], $right['host']));
+    return array(
+        'event_count' => count($events),
+        'allowed_count' => $allowed_count,
+        'blocked_count' => $blocked_count,
+        'hosts' => $host_values,
+        'samples' => array_slice($events, 0, max(0, $sample_limit)),
+    );
+}
+
+function wp_codebox_bench_install_external_http_guardrail(array $policy): void {
+    $state = wp_codebox_bench_external_http_guardrail_state();
+    $state['policy'] = $policy;
+    $state['events'] = array();
+    $GLOBALS['wp_codebox_external_http_guardrail'] = $state;
+    if (!empty($state['installed'])) {
+        return;
+    }
+    $GLOBALS['wp_codebox_external_http_guardrail']['installed'] = true;
+    add_filter('pre_http_request', static function ($preempt, $parsed_args, $url) {
+        $state = wp_codebox_bench_external_http_guardrail_state();
+        $policy = is_array($state['policy'] ?? null) ? $state['policy'] : array();
+        $host = strtolower((string) wp_parse_url((string) $url, PHP_URL_HOST));
+        $allowed = wp_codebox_bench_external_http_guardrail_host_allowed($host, is_array($policy['allowlistDomains'] ?? null) ? $policy['allowlistDomains'] : array());
+        $blocked = !empty($policy['blockNetwork']) && !$allowed;
+        $event_url = !array_key_exists('redactUrls', $policy) || !empty($policy['redactUrls']) ? wp_codebox_bench_external_http_guardrail_redact_url((string) $url) : (string) $url;
+        $GLOBALS['wp_codebox_external_http_guardrail']['events'][] = array(
+            'schema' => 'wp-codebox/wordpress-external-http-guardrail-event/v1',
+            'event' => $blocked ? 'http.blocked' : 'http.allowed',
+            'timestamp' => gmdate('c'),
+            'data' => array(
+                'id' => substr(hash('sha256', (string) $url), 0, 16),
+                'url' => $event_url,
+                'host' => $host,
+                'method' => $parsed_args['method'] ?? 'GET',
+                'allowed' => $allowed,
+                'blocked' => $blocked,
+            ),
+        );
+        if (!$blocked) {
+            return $preempt;
+        }
+        $block_response = is_array($policy['blockResponse'] ?? null) ? $policy['blockResponse'] : array();
+        return array(
+            'headers' => array(),
+            'body' => (string) ($block_response['body'] ?? ''),
+            'response' => array(
+                'code' => (int) ($block_response['code'] ?? 599),
+                'message' => (string) ($block_response['message'] ?? 'External HTTP blocked by WP Codebox guardrail'),
+            ),
+            'cookies' => array(),
+            'filename' => null,
+        );
+    }, 10, 3);
+}
+
+function wp_codebox_bench_run_external_http_guardrail_step(array $step): array {
+    $action = isset($step['action']) && is_string($step['action']) ? $step['action'] : 'collect';
+    $prefix = wp_codebox_bench_metric_prefix($step, 'external_http_guardrail');
+    if ($action === 'install') {
+        $policy = wp_codebox_bench_normalize_external_http_guardrail_policy($step);
+        $execution = wp_codebox_bench_run_command_step($step, 'external-http-guardrail', static function () use ($policy): array {
+            wp_codebox_bench_install_external_http_guardrail($policy);
+            return array('metadata' => array('external_http_guardrail_policy' => $policy));
+        });
+        return wp_codebox_bench_command_step_payload($execution, $prefix, array(), array('action' => 'install'));
+    }
+    if ($action === 'reset') {
+        $GLOBALS['wp_codebox_external_http_guardrail']['events'] = array();
+        return array('metrics' => array($prefix . '_event_count' => 0), 'steps' => array(array('schema' => 'wp-codebox/bench-command-step/v1', 'type' => 'external-http-guardrail', 'action' => 'reset')));
+    }
+    if ($action !== 'collect') {
+        throw new RuntimeException('external-http-guardrail bench workload steps support install, collect, or reset actions.');
+    }
+    $execution = wp_codebox_bench_run_command_step($step, 'external-http-guardrail', static function (array $step): array {
+        $state = wp_codebox_bench_external_http_guardrail_state();
+        $events = is_array($state['events'] ?? null) ? $state['events'] : array();
+        $summary = wp_codebox_bench_external_http_guardrail_summary($events, isset($step['sampleLimit']) && is_numeric($step['sampleLimit']) ? (int) $step['sampleLimit'] : 20);
+        $artifact = array(
+            'schema' => 'wp-codebox/wordpress-external-http-guardrail/v1',
+            'policy' => $state['policy'] ?? array(),
+            'summary' => $summary,
+            'events' => $events,
+        );
+        return array(
+            'metrics' => array(
+                'event_count' => $summary['event_count'],
+                'allowed_count' => $summary['allowed_count'],
+                'blocked_count' => $summary['blocked_count'],
+                'host_count' => count($summary['hosts']),
+            ),
+            'artifacts' => array('external-http-guardrail' => $artifact),
+            'metadata' => array('external_http_guardrail_schema' => $artifact['schema']),
+        );
+    });
+    $result = is_array($execution['result'] ?? null) ? $execution['result'] : array();
+    return wp_codebox_bench_command_step_payload($execution, $prefix, array(
+        $prefix . '_event_count' => (float) ($result['metrics']['event_count'] ?? 0),
+        $prefix . '_allowed_count' => (float) ($result['metrics']['allowed_count'] ?? 0),
+        $prefix . '_blocked_count' => (float) ($result['metrics']['blocked_count'] ?? 0),
+        $prefix . '_host_count' => (float) ($result['metrics']['host_count'] ?? 0),
+    ), array('action' => 'collect'));
 }
 
 function wp_codebox_bench_snapshot_wordpress_hook_callbacks(string $hook_name): array {
@@ -886,6 +1227,10 @@ function wp_codebox_bench_run_configured_workload(array $workload, string $plugi
 			$result = wp_codebox_bench_run_rest_request_step($step);
 		} elseif ($type === 'db-inventory') {
 			$result = wp_codebox_bench_run_db_inventory_step($step);
+		} elseif ($type === 'rest-db-query-profiler') {
+			$result = wp_codebox_bench_run_rest_db_query_profiler_step($step);
+		} elseif ($type === 'external-http-guardrail') {
+			$result = wp_codebox_bench_run_external_http_guardrail_step($step);
 		} else {
             throw new RuntimeException('Unsupported bench workload step type: ' . $type);
         }

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -20,6 +20,8 @@ const benchRunner = benchRunCode({
 const runCommandStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_command_step")
 const runAbilityStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_ability_step")
 const runDbInventoryStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_db_inventory_step")
+const runRestDbQueryProfilerStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_rest_db_query_profiler_step")
+const runExternalHttpGuardrailStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_external_http_guardrail_step")
 const commandStepRecord = phpFunctionBlock(benchRunner, "wp_codebox_bench_command_step_record")
 assert.match(runCommandStep, /function wp_codebox_bench_run_command_step\(array \$step, string \$type, callable \$runner\): array/)
 assert.match(runAbilityStep, /wp_codebox_bench_run_command_step\(\$step, 'ability'/)
@@ -28,6 +30,11 @@ assert.match(runDbInventoryStep, /SHOW FULL COLUMNS FROM/)
 assert.match(runDbInventoryStep, /SHOW INDEX FROM/)
 assert.match(runDbInventoryStep, /wp-codebox\/wordpress-db-inventory\/v1/)
 assert.match(runDbInventoryStep, /\$payload\['artifacts'\]\['db-inventory'\] = \$inventory/)
+assert.match(runRestDbQueryProfilerStep, /wp-codebox\/wordpress-rest-db-query-profile\/v1/)
+assert.match(runRestDbQueryProfilerStep, /\$wpdb->save_queries = true/)
+assert.match(runRestDbQueryProfilerStep, /\$payload\['artifacts'\]\['rest-db-query-profile'\] = \$artifact/)
+assert.match(runExternalHttpGuardrailStep, /wp-codebox\/wordpress-external-http-guardrail\/v1/)
+assert.match(runExternalHttpGuardrailStep, /wp_codebox_bench_install_external_http_guardrail/)
 assert.match(commandStepRecord, /'schema' => 'wp-codebox\/bench-command-step\/v1'/)
 assert.doesNotMatch(runCommandStep, /\$type === 'ability'/)
 
@@ -37,6 +44,35 @@ const commandStepHelpers = [
   "wp_codebox_bench_run_command_step",
   "wp_codebox_bench_command_step_payload",
   "wp_codebox_bench_workload_run_steps",
+].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
+
+const externalHttpGuardrailHelpers = [
+  "wp_codebox_bench_metric_prefix",
+  "wp_codebox_bench_command_step_record",
+  "wp_codebox_bench_run_command_step",
+  "wp_codebox_bench_command_step_payload",
+  "wp_codebox_bench_external_http_guardrail_state",
+  "wp_codebox_bench_normalize_external_http_guardrail_policy",
+  "wp_codebox_bench_external_http_guardrail_redact_url",
+  "wp_codebox_bench_external_http_guardrail_host_allowed",
+  "wp_codebox_bench_external_http_guardrail_summary",
+  "wp_codebox_bench_install_external_http_guardrail",
+  "wp_codebox_bench_run_external_http_guardrail_step",
+].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
+
+const restDbQueryProfilerHelpers = [
+  "wp_codebox_bench_percentile",
+  "wp_codebox_bench_metric_prefix",
+  "wp_codebox_bench_response_shape",
+  "wp_codebox_bench_redacted_response_summary",
+  "wp_codebox_bench_command_step_record",
+  "wp_codebox_bench_run_command_step",
+  "wp_codebox_bench_command_step_payload",
+  "wp_codebox_bench_run_rest_request_step",
+  "wp_codebox_bench_redact_sql_query",
+  "wp_codebox_bench_rest_db_query_profile_summary",
+  "wp_codebox_bench_rest_db_query_profile_case_step",
+  "wp_codebox_bench_run_rest_db_query_profiler_step",
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
 const commandStepPayload = await withTempDir("wp-codebox-bench-step-", async (directory) => {
@@ -61,6 +97,96 @@ assert.equal(typeof commandStepPayload.steps[0].timing.duration_ms, "number")
 assert.equal(typeof commandStepPayload.metrics.ability_duration_ms, "number")
 assert.equal(commandStepPayload.metrics.custom_count, 2)
 assert.deepEqual(commandStepPayload.metadata, { called: "example/run" })
+
+const externalHttpGuardrailPayload = await withTempDir("wp-codebox-external-http-guardrail-", async (directory) => {
+  const phpTestFile = join(directory, "external-http-guardrail.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+function wp_parse_url($url, $component = -1) { return parse_url($url, $component); }
+$GLOBALS['wp_codebox_test_filters'] = array();
+function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) { $GLOBALS['wp_codebox_test_filters'][$hook][] = $callback; }
+function wp_remote_get($url, $args = array()) {
+    foreach ($GLOBALS['wp_codebox_test_filters']['pre_http_request'] ?? array() as $callback) {
+        $preempt = $callback(false, array_merge(array('method' => 'GET'), $args), $url);
+        if (false !== $preempt) {
+            return $preempt;
+        }
+    }
+    return array('response' => array('code' => 200, 'message' => 'OK'), 'body' => 'ok');
+}
+${externalHttpGuardrailHelpers}
+wp_codebox_bench_run_external_http_guardrail_step(array(
+    'type' => 'external-http-guardrail',
+    'action' => 'install',
+    'allowlistDomains' => array('api.wordpress.org'),
+    'blockNetwork' => true,
+));
+wp_remote_get('https://api.wordpress.org/core/version-check/1.7/?token=secret');
+wp_remote_get('https://tracker.example.test/pixel?email=a@example.test');
+$payload = wp_codebox_bench_run_external_http_guardrail_step(array('type' => 'external-http-guardrail', 'action' => 'collect'));
+echo json_encode($payload, JSON_UNESCAPED_SLASHES);
+`,
+  )
+  return runPhpFileJson<{ metrics: Record<string, number>; artifacts: Record<string, { schema: string; summary: { event_count: number; allowed_count: number; blocked_count: number; hosts: Array<{ host: string; count: number; blocked: number }> }; events: Array<{ event: string; data: { url: string; blocked: boolean } }> }>; steps: Array<{ type: string; action: string }> }>(phpTestFile)
+})
+assert.equal(externalHttpGuardrailPayload.artifacts["external-http-guardrail"].schema, "wp-codebox/wordpress-external-http-guardrail/v1")
+assert.equal(externalHttpGuardrailPayload.artifacts["external-http-guardrail"].summary.event_count, 2)
+assert.equal(externalHttpGuardrailPayload.artifacts["external-http-guardrail"].summary.allowed_count, 1)
+assert.equal(externalHttpGuardrailPayload.artifacts["external-http-guardrail"].summary.blocked_count, 1)
+assert.equal(externalHttpGuardrailPayload.artifacts["external-http-guardrail"].events[0].data.url, "https://api.wordpress.org/core/version-check/1.7/?redacted=1")
+assert.equal(externalHttpGuardrailPayload.artifacts["external-http-guardrail"].events[1].event, "http.blocked")
+assert.equal(externalHttpGuardrailPayload.metrics.external_http_guardrail_event_count, 2)
+assert.equal(externalHttpGuardrailPayload.steps[0].type, "external-http-guardrail")
+assert.equal(externalHttpGuardrailPayload.steps[0].action, "collect")
+
+const restDbQueryProfilerPayload = await withTempDir("wp-codebox-rest-db-query-profiler-", async (directory) => {
+  const phpTestFile = join(directory, "rest-db-query-profiler.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+class WP_REST_Request {
+    public string $method;
+    public string $route;
+    public function __construct($method, $route) { $this->method = $method; $this->route = $route; }
+    public function set_header($name, $value) {}
+    public function set_param($name, $value) {}
+    public function set_body($body) {}
+}
+class WP_Codebox_Test_REST_Response { public function get_status() { return 200; } }
+function is_wp_error($value) { return false; }
+function rest_do_request($request) {
+    global $wpdb;
+    $wpdb->queries[] = array("SELECT * FROM wp_posts WHERE post_title = 'private title' AND ID = 123", 0.002, 'wpdb->get_results');
+    $wpdb->queries[] = array("UPDATE wp_options SET option_value = 'secret' WHERE option_id = 45", 0.003, 'wpdb->query');
+    return new WP_Codebox_Test_REST_Response();
+}
+function rest_get_server() { return new class { public function response_to_data($response, $embed) { return array('ok' => true); } }; }
+$wpdb = (object) array('queries' => array(), 'save_queries' => false);
+${restDbQueryProfilerHelpers}
+$payload = wp_codebox_bench_run_rest_db_query_profiler_step(array(
+    'type' => 'rest-db-query-profiler',
+    'sampleLimit' => 1,
+    'queryLengthLimit' => 120,
+    'rest_request_cases' => array(array('id' => 'posts-list', 'method' => 'GET', 'path' => '/wp/v2/posts')),
+));
+echo json_encode($payload, JSON_UNESCAPED_SLASHES);
+`,
+  )
+  return runPhpFileJson<{ metrics: Record<string, number>; artifacts: Record<string, { schema: string; summary: { case_count: number; query_count: number; sample_limit: number }; cases: Array<{ case_id: string; summary: { query_count: number; total_time_ms: number }; samples: Array<{ sql: string }> }> }>; steps: Array<{ type: string; queries?: number }> }>(phpTestFile)
+})
+assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].schema, "wp-codebox/wordpress-rest-db-query-profile/v1")
+assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].summary.case_count, 1)
+assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].summary.query_count, 2)
+assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].summary.sample_limit, 1)
+assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].cases[0].case_id, "posts-list")
+assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].cases[0].samples.length, 1)
+assert.equal(restDbQueryProfilerPayload.artifacts["rest-db-query-profile"].cases[0].samples[0].sql, "SELECT * FROM wp_posts WHERE post_title = '?' AND ID = ?")
+assert.doesNotMatch(JSON.stringify(restDbQueryProfilerPayload), /private title|secret|123/)
+assert.equal(restDbQueryProfilerPayload.metrics.rest_db_query_profile_cases_count, 1)
+assert.equal(restDbQueryProfilerPayload.metrics.rest_db_query_profile_queries_count, 2)
+assert.equal(restDbQueryProfilerPayload.steps[0].type, "rest-db-query-profiler")
+assert.equal(restDbQueryProfilerPayload.steps[0].queries, 2)
 
 const routeMatrixSteps = await withTempDir("wp-codebox-bench-route-matrix-", async (directory) => {
   const phpTestFile = join(directory, "route-matrix.php")
@@ -121,3 +247,7 @@ assert.match(phpFunctionBlock(benchRunner, "wp_codebox_bench_run_rest_request_st
 assert.match(phpFunctionBlock(benchRunner, "wp_codebox_bench_run_rest_request_step"), /\$record\['case_id'\] = \(string\) \$step\['case_id'\]/)
 assert.match(benchRunner, /\$type === 'db-inventory'/)
 assert.match(benchRunner, /wp_codebox_bench_run_db_inventory_step\(\$step\)/)
+assert.match(benchRunner, /\$type === 'rest-db-query-profiler'/)
+assert.match(benchRunner, /wp_codebox_bench_run_rest_db_query_profiler_step\(\$step\)/)
+assert.match(benchRunner, /\$type === 'external-http-guardrail'/)
+assert.match(benchRunner, /wp_codebox_bench_run_external_http_guardrail_step\(\$step\)/)

--- a/tests/benchmark-contracts.test.ts
+++ b/tests/benchmark-contracts.test.ts
@@ -60,13 +60,18 @@ assert.deepEqual(restCaseDefinition.anyOf, [{ required: ["path"] }, { required: 
 
 await withTempDir("wp-codebox-route-matrix-artifacts-", async (directory) => {
   await mkdir(join(directory, "files"), { recursive: true })
+  await mkdir(join(directory, "files", "browser"), { recursive: true })
+  await writeFile(join(directory, "files", "browser", "request-coverage.json"), JSON.stringify({
+    schema: "wp-codebox/browser-request-coverage/v1",
+    totals: { requests: 2 },
+  }))
   const manifestPath = join(directory, "manifest.json")
   await writeFile(manifestPath, JSON.stringify({
     id: "artifact-bundle",
     contentDigest: { algorithm: "sha256", inputs: [], value: "0".repeat(64) },
     createdAt: "2026-01-01T00:00:00.000Z",
     runtime: { id: "runtime", backend: "test" },
-    files: [],
+    files: [{ path: "files/browser/request-coverage.json", kind: "browser-request-coverage", contentType: "application/json" }],
   }))
   const result: BenchResults = {
     schema: "wp-codebox/bench-results/v1",
@@ -79,6 +84,23 @@ await withTempDir("wp-codebox-route-matrix-artifacts-", async (directory) => {
       iterations: 1,
       metrics: {},
       diagnostics: [],
+      artifacts: {
+        "db-inventory": {
+          schema: "wp-codebox/wordpress-db-inventory/v1",
+          tables: [{ name: "wp_posts", rowCount: 2, columns: [{ name: "ID", type: "bigint" }], indexes: [{ name: "PRIMARY", column: "ID", unique: true }] }],
+          totals: { tableCount: 1, rowCount: 2, columnCount: 1, indexCount: 1, totalBytes: 512 },
+        },
+        "external-http-guardrail": {
+          schema: "wp-codebox/wordpress-external-http-guardrail/v1",
+          summary: { event_count: 2, allowed_count: 1, blocked_count: 1, hosts: [{ host: "example.test", count: 2 }] },
+          events: [],
+        },
+        "rest-db-query-profile": {
+          schema: "wp-codebox/wordpress-rest-db-query-profile/v1",
+          summary: { case_count: 1, query_count: 1, total_time_ms: 2.5, sample_limit: 1, query_length_limit: 500 },
+          cases: [{ case_id: "items-search", method: "GET", path: "/example/v1/items", summary: { query_count: 1, total_time_ms: 2.5, operations: [{ operation: "SELECT", count: 1, time_ms: 2.5 }] }, samples: [{ sql: "SELECT * FROM wp_posts WHERE post_title = '?'", time_ms: 2.5, caller: "wpdb->get_results" }] }],
+        },
+      },
       steps: [{
         schema: "wp-codebox/bench-command-step/v1",
         type: "rest-request",
@@ -123,9 +145,42 @@ await withTempDir("wp-codebox-route-matrix-artifacts-", async (directory) => {
   assert.deepEqual(caseSummary.cases[0].response?.shape, { type: "object", keys: { id: "number", secret: "string" } })
   assert.doesNotMatch(JSON.stringify(caseSummary), /also not persisted/)
 
+  const dbInventory = JSON.parse(await readFile(join(directory, "files", "bench", "generic-api", "rest-catalog-db-inventory.json"), "utf8")) as { schema: string; inventory: { totals: { tableCount: number } } }
+  assert.equal(dbInventory.schema, "wp-codebox/benchmark-db-inventory/v1")
+  assert.equal(dbInventory.inventory.totals.tableCount, 1)
+
+  const externalHttpGuardrail = JSON.parse(await readFile(join(directory, "files", "bench", "generic-api", "rest-catalog-external-http-guardrail.json"), "utf8")) as { schema: string; guardrail: { summary: { blocked_count: number } } }
+  assert.equal(externalHttpGuardrail.schema, "wp-codebox/benchmark-external-http-guardrail/v1")
+  assert.equal(externalHttpGuardrail.guardrail.summary.blocked_count, 1)
+
+  const restDbQueryProfile = JSON.parse(await readFile(join(directory, "files", "bench", "generic-api", "rest-catalog-rest-db-query-profile.json"), "utf8")) as { schema: string; profile: { summary: { query_count: number } } }
+  assert.equal(restDbQueryProfile.schema, "wp-codebox/benchmark-rest-db-query-profile/v1")
+  assert.equal(restDbQueryProfile.profile.summary.query_count, 1)
+
   const benchArtifacts = JSON.parse(await readFile(join(directory, "files", "bench-results.json"), "utf8")) as { scenarios: Array<{ artifactRefs: Array<{ kind: string; name: string; path: string; contentType?: string; sha256?: string; source?: string }> }> }
   assert.doesNotMatch(JSON.stringify(benchArtifacts), /not persisted/)
   assert.deepEqual(benchArtifacts.scenarios[0].artifactRefs.map((ref) => ({ ...ref, sha256: "sha" })), [{
+    path: "files/bench/generic-api/rest-catalog-db-inventory.json",
+    kind: "benchmark-db-inventory",
+    contentType: "application/json",
+    sha256: "sha",
+    source: "scenario-artifact",
+    name: "db-inventory",
+  }, {
+    path: "files/bench/generic-api/rest-catalog-external-http-guardrail.json",
+    kind: "benchmark-external-http-guardrail",
+    contentType: "application/json",
+    sha256: "sha",
+    source: "scenario-artifact",
+    name: "external-http-guardrail",
+  }, {
+    path: "files/bench/generic-api/rest-catalog-rest-db-query-profile.json",
+    kind: "benchmark-rest-db-query-profile",
+    contentType: "application/json",
+    sha256: "sha",
+    source: "scenario-artifact",
+    name: "rest-db-query-profile",
+  }, {
     path: "files/bench/generic-api/rest-catalog-route-matrix-summary.json",
     kind: "benchmark-route-matrix-summary",
     contentType: "application/json",
@@ -139,6 +194,12 @@ await withTempDir("wp-codebox-route-matrix-artifacts-", async (directory) => {
     sha256: "sha",
     source: "scenario-artifact",
     name: "rest-request-case-summary",
+  }, {
+    path: "files/browser/request-coverage.json",
+    kind: "browser-request-coverage",
+    contentType: "application/json",
+    sha256: "sha",
+    source: "browser-artifact",
   }])
 })
 


### PR DESCRIPTION
## Summary
- Materialize full-surface benchmark artifacts for REST request cases, DB inventory, REST DB query profiles, and external HTTP guardrails.
- Enrich benchmark evidence with browser request coverage refs from artifact manifests.
- Add generic `external-http-guardrail` and `rest-db-query-profiler` benchmark step support.

## Testing
- `npm run test:bench-command-step-behavior`
- `npx tsx tests/benchmark-contracts.test.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted and iterated the benchmark artifact materialization, generic bench-step support, and focused contract tests; Chris directed the workflow and retains review responsibility.
