### PR TITLE
Read preview boot config from primary playground

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -512,7 +512,8 @@ final class WP_Codebox_Browser_Task_Builder {
 
 	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */
 	public static function browser_preview_boot_config( array $session ): array {
-		$playground             = is_array( $session['playground'] ?? null ) ? $session['playground'] : array();
+		$primary                = is_array( $session['primary'] ?? null ) ? $session['primary'] : array();
+		$playground             = is_array( $session['playground'] ?? null ) ? $session['playground'] : ( is_array( $primary['playground'] ?? null ) ? $primary['playground'] : array() );
 		$prepared_runtime       = self::browser_prepared_runtime_from_envelope( $session, $playground );
 		$site_blueprint_artifact = is_array( $session['site_blueprint_artifact'] ?? null ) ? $session['site_blueprint_artifact'] : array();
 		$session_envelope       = is_array( $session['session'] ?? null ) ? $session['session'] : array();

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -178,6 +178,20 @@ $product_session = WP_Codebox_Browser_Task_Builder::product_browser_session_dto(
 	),
 	'artifacts' => array( 'preview_url' => '/?preview=1' ),
 ) );
+$nested_primary_product_session = WP_Codebox_Browser_Task_Builder::product_browser_session_dto( array(
+	'success' => true,
+	'schema' => 'wp-codebox/browser-task-contract/v1',
+	'session' => array( 'id' => 'nested-session-123' ),
+	'primary' => array(
+		'playground' => array(
+			'client_module_url' => 'https://example.test/nested-client.js',
+			'remote_url' => 'https://playground.wordpress.net/nested-remote.html',
+			'scope' => 'nested-session-123',
+			'preview_url' => '/?nested-preview=1',
+			'prepared_runtime' => array( 'cache_key' => 'nested-cache-key', 'input_hash' => str_repeat( 'c', 64 ), 'status' => 'hit' ),
+		),
+	),
+) );
 $preview_lease_status = WP_Codebox_Browser_Task_Builder::preview_lease_status( $product_session );
 
 $blueprint_ref = WP_Codebox_Browser_Task_Builder::browser_blueprint_ref( array( 'cache_key' => 'runtime-cache-key', 'input_hash' => str_repeat( 'b', 64 ), 'status' => 'hit' ) );
@@ -218,7 +232,7 @@ $recipe_dto = WP_Codebox_Browser_Task_Builder::browser_recipe_dto( array(
 	),
 ) );
 
-echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'plan_contract' => $plan_contract, 'plan_plugin_specs' => $plan_plugin_specs, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request, 'product_session' => $product_session, 'preview_lease_status' => $preview_lease_status, 'blueprint_ref' => $blueprint_ref, 'hydrated_blueprint' => $hydrated_blueprint, 'recipe_dto' => $recipe_dto ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'plan_contract' => $plan_contract, 'plan_plugin_specs' => $plan_plugin_specs, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request, 'product_session' => $product_session, 'nested_primary_product_session' => $nested_primary_product_session, 'preview_lease_status' => $preview_lease_status, 'blueprint_ref' => $blueprint_ref, 'hydrated_blueprint' => $hydrated_blueprint, 'recipe_dto' => $recipe_dto ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.task_input.schema, "wp-codebox/task-input/v1")
@@ -290,6 +304,12 @@ assert.equal(result.product_session.preview_boot.blueprint_ref_dto.hydrator_abil
 assert.equal(result.product_session.preview_boot.preview.schema, "wp-codebox/preview-lease/v1")
 assert.equal(result.product_session.preview_boot.preview.preview_public_url, "https://preview.example.test")
 assert.equal(result.product_session.preview_boot.preview.local_url, "/?preview=1")
+assert.equal(result.nested_primary_product_session.schema, "wp-codebox/browser-session-product-dto/v1")
+assert.equal(result.nested_primary_product_session.preview_boot.scope, "nested-session-123")
+assert.equal(result.nested_primary_product_session.preview_boot.client_module_url, "https://example.test/nested-client.js")
+assert.equal(result.nested_primary_product_session.preview_boot.remote_url, "https://playground.wordpress.net/nested-remote.html")
+assert.equal(result.nested_primary_product_session.preview_boot.artifacts.preview_url, "/?nested-preview=1")
+assert.equal(result.nested_primary_product_session.preview_boot.blueprint_ref, `prepared:nested-cache-key:${"c".repeat(64)}`)
 assert.equal(result.preview_lease_status, "active")
 assert.equal(JSON.stringify(result.product_session).includes("must-not-leak"), false)
 assert.equal(JSON.stringify(result.product_session).includes('"blueprint":'), false)


### PR DESCRIPTION
## Summary
- read preview boot config fields from nested primary.playground when top-level playground is absent
- add regression coverage for product DTOs built from browser task contracts with nested primary playground data

## Testing
- npm run test:browser-task-builder

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Studio Web launch failure, implemented the WP Codebox boot config fix, and added regression coverage; Chris reviewed and directed the release workflow.