### PR TITLE
Fix contained-site no-fallback opens

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -332,7 +332,7 @@ public static function open_or_create_browser_contained_site( array $input ): ar
 		}
 	}
 
-	if ( 'reload-required' === $action && empty( $input['fallback_create'] ) ) {
+	if ( empty( $input['fallback_create'] ) ) {
 		return array_filter(
 			array(
 				'success'         => false,

--- a/tests/browser-contained-site-status.test.ts
+++ b/tests/browser-contained-site-status.test.ts
@@ -93,6 +93,15 @@ $open_miss = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browser_cont
 	'site_id' => $cache_key,
 	'input_hash' => str_repeat( 'd', 64 ),
 ) );
+$open_or_create_miss_no_fallback = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_or_create_browser_contained_site( array(
+	'contained_site' => array(
+		'schema' => 'wp-codebox/browser-contained-site/v1',
+		'site_id' => $cache_key,
+		'cache_key' => $cache_key,
+		'source_digest' => array( 'algorithm' => 'sha256', 'value' => str_repeat( 'd', 64 ) ),
+	),
+	'fallback_create' => false,
+) );
 $GLOBALS['wp_codebox_test_strip_preview_boot_ref'] = true;
 $open_unbootable = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browser_contained_site( array(
 	'contained_site' => array(
@@ -103,7 +112,7 @@ $open_unbootable = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browse
 	),
 ) );
 
-echo json_encode( array( 'hit' => $hit, 'miss' => $miss, 'incompatible' => $incompatible, 'open_hit' => $open_hit, 'open_miss' => $open_miss, 'open_unbootable' => $open_unbootable ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'hit' => $hit, 'miss' => $miss, 'incompatible' => $incompatible, 'open_hit' => $open_hit, 'open_miss' => $open_miss, 'open_or_create_miss_no_fallback' => $open_or_create_miss_no_fallback, 'open_unbootable' => $open_unbootable ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.hit.schema, "wp-codebox/browser-contained-site-status/v1")
@@ -198,6 +207,13 @@ assert.equal(result.open_miss.resolution.miss, true)
 assert.equal(result.open_miss.open_mode, "materialize")
 assert.equal(result.open_miss.requires_materialization, true)
 assert.equal(result.open_miss.blueprint_ref, undefined)
+assert.equal(result.open_or_create_miss_no_fallback.schema, "wp-codebox/browser-contained-site-open-or-create/v1")
+assert.equal(result.open_or_create_miss_no_fallback.success, false)
+assert.equal(result.open_or_create_miss_no_fallback.action, "unavailable")
+assert.equal(result.open_or_create_miss_no_fallback.reload_required, true)
+assert.equal(result.open_or_create_miss_no_fallback.decision.action, "create-new")
+assert.equal(result.open_or_create_miss_no_fallback.error.code, "wp_codebox_browser_contained_site_unavailable")
+assert.equal(result.open_or_create_miss_no_fallback.created, undefined)
 assert.equal(result.open_unbootable.success, false)
 assert.equal(result.open_unbootable.status, "unusable")
 assert.equal(result.open_unbootable.resolution.outcome, "unusable")


### PR DESCRIPTION
## Summary
- honor `fallback_create: false` before every browser contained-site create path
- return the reusable unavailable response instead of validating empty task input
- add regression coverage for a missing contained site with no fallback create

## Testing
- `npm run test:browser-contained-site-status`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the fallback branch, drafted the code/test change, and ran focused verification.