### PR TITLE
Allow logged-in blueprint ref hydration

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -98,9 +98,13 @@ final class WP_Codebox_Abilities {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( self::class, 'rest_browser_blueprint_ref' ),
-				'permission_callback' => static fn(): bool => current_user_can( 'manage_options' ),
+				'permission_callback' => array( self::class, 'can_hydrate_browser_blueprint_ref' ),
 			)
 		);
+	}
+
+	public static function can_hydrate_browser_blueprint_ref(): bool {
+		return is_user_logged_in() || current_user_can( 'manage_options' );
 	}
 
 	/** @param WP_REST_Request $request REST request. @return array<string,mixed>|WP_Error */

--- a/tests/browser-blueprint-ref-permission.test.ts
+++ b/tests/browser-blueprint-ref-permission.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { repoRoot } from "../scripts/test-kit.js"
+
+const source = readFileSync(join(repoRoot, "packages/wordpress-plugin/src/class-wp-codebox-abilities.php"), "utf8")
+
+assert.match(source, /'permission_callback'\s*=>\s*array\(\s*self::class,\s*'can_hydrate_browser_blueprint_ref'\s*\)/)
+assert.match(source, /public static function can_hydrate_browser_blueprint_ref\(\): bool/)
+assert.match(source, /is_user_logged_in\(\)\s*\|\|\s*current_user_can\(\s*'manage_options'\s*\)/)
+
+console.log("browser blueprint ref permission ok")


### PR DESCRIPTION
## Summary
- allow logged-in users to hydrate prepared browser blueprint refs through the direct REST endpoint
- keep anonymous requests unauthorized
- add focused permission contract coverage

## Testing
- `npx tsx tests/browser-blueprint-ref-permission.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the browser blueprint hydration permission boundary, drafted the fix/test, and ran focused verification.