### PR TITLE
Allow inline benchmark artifacts before materialization

### DIFF
--- a/packages/runtime-core/src/benchmark-contracts.ts
+++ b/packages/runtime-core/src/benchmark-contracts.ts
@@ -45,6 +45,11 @@ export interface BenchmarkArtifactRef {
   metadata?: Record<string, unknown>
 }
 
+export interface BenchmarkInlineArtifact {
+  schema: string
+  [key: string]: unknown
+}
+
 export interface BenchmarkScenarioRecord {
   id: string
   source: BenchmarkScenarioSource
@@ -57,7 +62,7 @@ export interface BenchmarkScenarioRecord {
   diagnostics: BenchmarkDiagnostic[]
   artifactRefs?: BenchmarkArtifactRef[]
   steps?: Array<Record<string, unknown>>
-  artifacts?: Record<string, BenchmarkArtifactRef>
+  artifacts?: Record<string, BenchmarkArtifactRef | BenchmarkInlineArtifact>
   metadata?: Record<string, unknown>
   provenance?: Record<string, unknown>
 }
@@ -267,7 +272,21 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
     },
     artifactMap: {
       type: "object",
-      additionalProperties: { $ref: "#/$defs/artifactRef" },
+      additionalProperties: { anyOf: [{ $ref: "#/$defs/artifactRef" }, { $ref: "#/$defs/inlineBenchmarkArtifact" }] },
+    },
+    inlineBenchmarkArtifact: {
+      type: "object",
+      required: ["schema"],
+      properties: {
+        schema: {
+          enum: [
+            "wp-codebox/wordpress-db-inventory/v1",
+            "wp-codebox/wordpress-external-http-guardrail/v1",
+            "wp-codebox/wordpress-rest-db-query-profile/v1",
+          ],
+        },
+      },
+      additionalProperties: true,
     },
     lifecycle: {
       type: "object",


### PR DESCRIPTION
## Summary
- Allow typed inline benchmark artifacts in raw scenario results before artifact materialization.
- Keep validation strict for unsupported inline artifact schemas while accepting the benchmark artifact payloads produced by WP Codebox runtime primitives.

## Verification
- `npm run build`
- `npx tsx tests/benchmark-contracts.test.ts`
- Runner WP Codebox runtime rebuilt from this branch and verified with the full-surface WooCommerce benchmark.
- Lab API coverage profile pass: `54f5d1cc-7af7-443b-9ea9-a715a8238581`
- Lab full-surface profile pass: `a1a7dc78-7275-4dba-aee3-fc72d843dfb2`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing benchmark contract validation failures, editing contract validation, running verification, and drafting this PR description.
