### PR TITLE
Support programmatic Playground runtime gaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3949,9 +3949,13 @@
       "version": "0.8.3",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
+        "@php-wasm/node": "^3.1.35",
+        "@php-wasm/universal": "^3.1.35",
         "@types/pngjs": "^6.0.5",
+        "@wp-playground/blueprints": "^3.1.35",
         "@wp-playground/cli": "^3.1.35",
         "@wp-playground/storage": "^3.1.35",
+        "@wp-playground/wordpress": "^3.1.35",
         "@wp-playground/wordpress-builds": "^0.9.4",
         "pixelmatch": "^7.2.0",
         "playwright": "^1.60.0",

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -934,6 +934,24 @@ async function validateRecipePluginRuntime(pluginRuntime: WorkspaceRecipePluginR
     addIssue("invalid-plugin-runtime-max-execution-time", "$.inputs.pluginRuntime.php.maxExecutionTime", "Plugin runtime maxExecutionTime must be an integer from 0 through 3600.")
   }
 
+  for (const [name, value] of Object.entries(pluginRuntime.php?.iniEntries ?? {})) {
+    if (!/^[a-zA-Z0-9_.-]+$/.test(name)) {
+      addIssue("invalid-plugin-runtime-php-ini-entry", `$.inputs.pluginRuntime.php.iniEntries.${name}`, "PHP ini entry names may contain only letters, numbers, dots, underscores, and hyphens.")
+    }
+    if (!["string", "number", "boolean"].includes(typeof value) && value !== null) {
+      addIssue("invalid-plugin-runtime-php-ini-entry-value", `$.inputs.pluginRuntime.php.iniEntries.${name}`, "PHP ini entry values must be string, number, boolean, or null.")
+    }
+  }
+
+  for (const [name, value] of Object.entries(pluginRuntime.php?.bootstrapIniEntries ?? {})) {
+    if (!/^[a-zA-Z0-9_.-]+$/.test(name)) {
+      addIssue("invalid-plugin-runtime-bootstrap-php-ini-entry", `$.inputs.pluginRuntime.php.bootstrapIniEntries.${name}`, "Bootstrap PHP ini entry names may contain only letters, numbers, dots, underscores, and hyphens.")
+    }
+    if (!["string", "number", "boolean"].includes(typeof value) && value !== null) {
+      addIssue("invalid-plugin-runtime-bootstrap-php-ini-entry-value", `$.inputs.pluginRuntime.php.bootstrapIniEntries.${name}`, "Bootstrap PHP ini entry values must be string, number, boolean, or null.")
+    }
+  }
+
   for (const [name, value] of Object.entries(pluginRuntime.wpConfigDefines ?? {})) {
     if (!/^[A-Z_][A-Z0-9_]*$/i.test(name)) {
       addIssue("invalid-plugin-runtime-wp-config-define", `$.inputs.pluginRuntime.wpConfigDefines.${name}`, "wpConfigDefines keys must be valid PHP constant names.")

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -745,6 +745,19 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             properties: {
               memoryLimit: { type: "string", pattern: "^[0-9]+[KMG]?$" },
               maxExecutionTime: { type: "integer", minimum: 0, maximum: 3600 },
+              iniEntries: {
+                type: "object",
+                additionalProperties: {
+                  type: ["string", "number", "boolean", "null"],
+                },
+              },
+              bootstrapIniEntries: {
+                type: "object",
+                description: "PHP.ini entries written before PHP WASM initializes. Use this for settings that must override PHP WASM's generated default php.ini, such as opcache file-cache behavior.",
+                additionalProperties: {
+                  type: ["string", "number", "boolean", "null"],
+                },
+              },
             },
           },
           wpConfigDefines: {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -244,6 +244,8 @@ export interface WorkspaceRecipeTypedArtifact {
 export interface WorkspaceRecipePluginRuntimePhp {
   memoryLimit?: string
   maxExecutionTime?: number
+  iniEntries?: Record<string, string | number | boolean | null>
+  bootstrapIniEntries?: Record<string, string | number | boolean | null>
 }
 
 export interface WorkspaceRecipePluginRuntimeHealthProbe {

--- a/packages/runtime-playground/package.json
+++ b/packages/runtime-playground/package.json
@@ -18,8 +18,12 @@
   },
   "dependencies": {
     "@automattic/wp-codebox-core": "file:../runtime-core",
+    "@php-wasm/node": "^3.1.35",
+    "@php-wasm/universal": "^3.1.35",
+    "@wp-playground/blueprints": "^3.1.35",
     "@wp-playground/cli": "^3.1.35",
     "@wp-playground/storage": "^3.1.35",
+    "@wp-playground/wordpress": "^3.1.35",
     "@wp-playground/wordpress-builds": "^0.9.4",
     "@types/pngjs": "^6.0.5",
     "pixelmatch": "^7.2.0",

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -1,6 +1,7 @@
 import { playgroundBlueprint } from "./blueprint.js"
 import { PlaygroundCliExitError, type PlaygroundCliBufferedOutput } from "./playground-command-errors.js"
 import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
+import { startProgrammaticPlaygroundServer } from "./programmatic-playground-runner.js"
 import type { BrowserStartupProgressEvent, BrowserStartupProgressPhase, BrowserStartupProgressStatus, MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { randomInt } from "node:crypto"
 import { existsSync } from "node:fs"
@@ -24,8 +25,10 @@ export interface PlaygroundCliModule {
     blueprint?: unknown
     wp?: string
     php?: string
+    workers?: number | "auto"
     wordpressInstallMode?: "install-from-existing-files" | "install-from-existing-files-if-needed" | "do-not-attempt-installing"
     "site-url"?: string
+    phpIniEntries?: Record<string, string>
   }): Promise<PlaygroundCliServer>
 }
 
@@ -56,7 +59,6 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
   })
   emitProgress("preview:loading-client", "running", "Loading preview")
   try {
-    const { runCLI } = options.cliModule ?? (await import("@wp-playground/cli")) as unknown as PlaygroundCliModule
     if (spec.preview?.port) {
       await assertPreviewPortAvailable(spec.preview.port)
     }
@@ -66,6 +68,8 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
     })
     const wordpressDirectory = spec.environment.assets?.wordpressDirectory
     const wordpressInstallMode = spec.environment.wordpressInstallMode ?? "install-from-existing-files"
+    const bootstrapIniEntries = pluginRuntimeBootstrapPhpIniEntries(spec)
+    const useProgrammaticRunner = shouldUseProgrammaticPlaygroundRunner(spec, options)
     const wordpressStartupAsset = wordpressDirectory ? undefined : await resolvePlaygroundWordPressStartupAsset(spec.environment.version, spec.environment.assets?.wordpressZip)
     const cacheValidation = wordpressStartupAsset?.cacheValidation ?? {
       version: spec.environment.version ?? "mounted-wordpress-source",
@@ -84,8 +88,24 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       emitProgress("preview:activating-dependencies", "running", "Activating site features", blueprintSummary)
     }
 
-    const server = await startPlaygroundCliWithDynamicPortRetry(async (port) => {
+    const server = useProgrammaticRunner ? await startPlaygroundCliWithDynamicPortRetry(async (port) => {
+      return startProgrammaticPlaygroundServer({
+        ...spec,
+        preview: {
+          ...spec.preview,
+          port,
+        },
+      }, mounts, {
+        bootstrapIniEntries: bootstrapIniEntries!,
+        phpIniEntries: pluginRuntimePhpIniEntries(spec),
+        wordpressDirectory: wordpressDirectory!,
+        wordpressInstallMode,
+        sharedPhpIniContent: phpIniContent(bootstrapIniEntries!),
+      })
+    }, Boolean(spec.preview?.port)) : await startPlaygroundCliWithDynamicPortRetry(async (port) => {
+      const { runCLI } = options.cliModule ?? (await import("@wp-playground/cli")) as unknown as PlaygroundCliModule
       const localAssetServer = wordpressStartupAsset?.localPath ? await serveLocalStartupAsset(wordpressStartupAsset.localPath) : undefined
+      const bootstrapSharedMount = await pluginRuntimeBootstrapSharedMount(spec)
       try {
         return await runCLI({
           command: "server",
@@ -93,16 +113,23 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
           quiet: true,
           verbosity: "quiet",
           skipBrowser: true,
-          mount: mounts.map((mount) => ({
-            hostPath: mount.source,
-            vfsPath: mount.target,
-          })),
-          ...(wordpressDirectory ? {
-            "mount-before-install": [{ hostPath: wordpressDirectory, vfsPath: "/wordpress" }],
+          workers: 6,
+          mount: [
+            ...mounts.map((mount) => ({
+              hostPath: mount.source,
+              vfsPath: mount.target,
+            })),
+          ],
+          ...(wordpressDirectory || bootstrapSharedMount ? {
+            "mount-before-install": [
+              ...(bootstrapSharedMount ? [bootstrapSharedMount] : []),
+              ...(wordpressDirectory ? [{ hostPath: wordpressDirectory, vfsPath: "/wordpress" }] : []),
+            ],
             wordpressInstallMode,
           } : {}),
           wp: localAssetServer?.url ?? wordpressStartupAsset?.wp,
           php: spec.environment.phpVersion,
+          phpIniEntries: pluginRuntimePhpIniEntries(spec),
           "site-url": spec.preview?.siteUrl,
           blueprint: playgroundCliBlueprint(spec),
         })
@@ -134,6 +161,84 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
 
     throw error
   }
+}
+
+export function shouldUseProgrammaticPlaygroundRunner(spec: RuntimeCreateSpec, options: PlaygroundCliStartupOptions = {}): boolean {
+  return !options.cliModule && Boolean(spec.environment.assets?.wordpressDirectory) && Boolean(pluginRuntimeBootstrapPhpIniEntries(spec))
+}
+
+async function pluginRuntimeBootstrapSharedMount(spec: RuntimeCreateSpec): Promise<{ hostPath: string; vfsPath: string } | undefined> {
+  const iniEntries = pluginRuntimeBootstrapPhpIniEntries(spec)
+  if (!iniEntries) {
+    return undefined
+  }
+
+  const directory = join(spec.artifactsDirectory ?? "artifacts", "playground-internal-shared")
+  await mkdir(directory, { recursive: true })
+  await mkdir(join(directory, "mu-plugins"), { recursive: true })
+  await mkdir(join(directory, "preload"), { recursive: true })
+  await writeFile(join(directory, "php.ini"), phpIniContent(iniEntries), "utf8")
+  await writeFile(join(directory, "auto_prepend_file.php"), "<?php\n", "utf8")
+
+  return { hostPath: directory, vfsPath: "/internal/shared" }
+}
+
+function pluginRuntimeBootstrapPhpIniEntries(spec: RuntimeCreateSpec): Record<string, string> | undefined {
+  return pluginRuntimePhpEntries(spec, "bootstrapIniEntries")
+}
+
+function pluginRuntimePhpIniEntries(spec: RuntimeCreateSpec): Record<string, string> | undefined {
+  return pluginRuntimePhpEntries(spec, "iniEntries")
+}
+
+function pluginRuntimePhpEntries(spec: RuntimeCreateSpec, key: "iniEntries" | "bootstrapIniEntries"): Record<string, string> | undefined {
+  const pluginRuntime = spec.metadata?.recipe && typeof spec.metadata.recipe === "object" && !Array.isArray(spec.metadata.recipe)
+    ? (spec.metadata.recipe as { inputs?: { pluginRuntime?: unknown } }).inputs?.pluginRuntime
+    : undefined
+  const php = pluginRuntime && typeof pluginRuntime === "object" && !Array.isArray(pluginRuntime)
+    ? (pluginRuntime as { php?: Record<string, unknown> }).php
+    : undefined
+  const iniEntries = php && typeof php === "object" && !Array.isArray(php) ? php[key] : undefined
+  if (!iniEntries || typeof iniEntries !== "object" || Array.isArray(iniEntries)) {
+    return undefined
+  }
+
+  const entries: Record<string, string> = {}
+  for (const [name, value] of Object.entries(iniEntries)) {
+    if (/^[a-zA-Z0-9_.-]+$/.test(name) && (["string", "number", "boolean"].includes(typeof value) || value === null)) {
+      entries[name] = value === null ? "" : String(value)
+    }
+  }
+
+  return Object.keys(entries).length > 0 ? entries : undefined
+}
+
+function phpIniContent(entries: Record<string, string>): string {
+  const lines = [
+    "auto_prepend_file=/internal/shared/auto_prepend_file.php",
+    "memory_limit=256M",
+    "ignore_repeated_errors = 1",
+    "error_reporting = E_ALL",
+    "display_errors = 1",
+    "html_errors = 1",
+    "display_startup_errors = On",
+    "log_errors = 1",
+    "always_populate_raw_post_data = -1",
+    "upload_max_filesize = 2000M",
+    "post_max_size = 2000M",
+    "allow_url_fopen = On",
+    "allow_url_include = Off",
+    "session.save_path = /home/web_user",
+    "implicit_flush = 1",
+    "output_buffering = 0",
+    "max_execution_time = 0",
+    "max_input_time = -1",
+  ]
+  for (const [name, value] of Object.entries(entries)) {
+    lines.push(`${name} = ${value}`)
+  }
+
+  return `${lines.join("\n")}\n`
 }
 
 function playgroundCliBlueprint(spec: RuntimeCreateSpec): unknown {

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -1,0 +1,183 @@
+import * as PHPWasmNode from "@php-wasm/node"
+import { compileBlueprint } from "@wp-playground/blueprints"
+import { bootWordPressAndRequestHandler } from "@wp-playground/wordpress"
+import type { MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { createServer as createHttpServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http"
+import { dirname } from "node:path"
+import { playgroundBlueprint } from "./blueprint.js"
+import type { PlaygroundCliServer, PlaygroundServerRunResponse } from "./preview-server.js"
+
+const { createNodeFsMountHandler, loadNodeRuntime } = PHPWasmNode as unknown as {
+  createNodeFsMountHandler(localPath: string): unknown
+  loadNodeRuntime(phpVersion: AllPHPVersion, options?: { followSymlinks?: boolean; emscriptenOptions?: { processId?: number } }): Promise<number>
+}
+
+type AllPHPVersion = "8.5" | "8.4" | "8.3" | "8.2" | "8.1" | "8.0" | "7.4" | "5.2"
+
+interface ProgrammaticPHP {
+  fileExists(path: string): boolean
+  mkdir(path: string): void
+  mount(vfsPath: string, mountHandler: unknown): Promise<unknown>
+  onMessage(listener: (data: string) => Promise<string | void> | string | void): () => Promise<void>
+  readFileAsText(path: string): string
+  run(options: { code: string } | { scriptPath: string }): Promise<ProgrammaticPHPResponse>
+  writeFile(path: string, contents: string): void
+}
+
+interface ProgrammaticPHPResponse {
+  exitCode: number
+  errors: string
+  text: string
+}
+
+export interface ProgrammaticPlaygroundStartupOptions {
+  bootstrapIniEntries: Record<string, string>
+  phpIniEntries?: Record<string, string>
+  wordpressDirectory: string
+  wordpressInstallMode?: "install-from-existing-files" | "install-from-existing-files-if-needed" | "do-not-attempt-installing"
+  sharedPhpIniContent: string
+}
+
+export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec, mounts: MountSpec[], options: ProgrammaticPlaygroundStartupOptions): Promise<PlaygroundCliServer> {
+  const phpVersion = (spec.environment.phpVersion ?? "8.4") as AllPHPVersion
+  let nextProcessId = 1
+  const phpIniEntries = {
+    ...options.bootstrapIniEntries,
+    ...options.phpIniEntries,
+  }
+  const requestHandler = await bootWordPressAndRequestHandler({
+    createPhpRuntime: () => loadNodeRuntime(phpVersion, {
+      followSymlinks: true,
+      emscriptenOptions: { processId: nextProcessId++ },
+    }),
+    phpVersion,
+    siteUrl: spec.preview?.siteUrl ?? "http://127.0.0.1",
+    documentRoot: "/wordpress",
+    sapiName: "cli",
+    wordpressInstallMode: options.wordpressInstallMode ?? "install-from-existing-files",
+    phpIniEntries,
+    createFiles: {
+      "/internal/shared/php.ini": options.sharedPhpIniContent,
+      "/internal/shared/auto_prepend_file.php": "<?php\n",
+      "/internal/shared/mu-plugins/.keep": "",
+      "/internal/shared/preload/.keep": "",
+    },
+    async onPHPInstanceCreated(php: unknown) {
+      const programmaticPhp = php as ProgrammaticPHP
+      await mountHostDirectory(programmaticPhp, "/wordpress", options.wordpressDirectory)
+      for (const mount of mounts) {
+        await mountHostDirectory(programmaticPhp, mount.target, mount.source)
+      }
+    },
+  })
+
+  const primaryPhp = await requestHandler.getPrimaryPhp() as ProgrammaticPHP
+  await applyBlueprint(primaryPhp, spec)
+
+  const httpServer = createHttpServer((incoming, outgoing) => {
+    handleRequest(requestHandler, incoming, outgoing).catch((error: Error) => {
+      if (!outgoing.headersSent) {
+        outgoing.statusCode = 500
+      }
+      outgoing.end(error.message)
+    })
+  })
+  const serverUrl = await listenHttpServer(httpServer, 0, "127.0.0.1")
+
+  return {
+    serverUrl,
+    playground: {
+      run: (runOptions) => runPhp(primaryPhp, runOptions),
+      onMessage: (listener) => primaryPhp.onMessage(listener),
+      readFileAsText: (path) => primaryPhp.readFileAsText(path),
+      async writeFile(path, contents) {
+        primaryPhp.writeFile(path, contents)
+      },
+    },
+    async [Symbol.asyncDispose]() {
+      await closeHttpServer(httpServer)
+      await requestHandler[Symbol.asyncDispose]()
+    },
+  }
+}
+
+async function mountHostDirectory(php: ProgrammaticPHP, vfsPath: string, hostPath: string): Promise<void> {
+  ensureVfsParentDirectory(php, vfsPath)
+  await php.mount(vfsPath, createNodeFsMountHandler(hostPath))
+}
+
+function ensureVfsParentDirectory(php: ProgrammaticPHP, vfsPath: string): void {
+  const parent = dirname(vfsPath.replace(/\/+$/, ""))
+  if (parent && parent !== "." && parent !== "/" && !php.fileExists(parent)) {
+    php.mkdir(parent)
+  }
+}
+
+async function applyBlueprint(php: ProgrammaticPHP, spec: RuntimeCreateSpec): Promise<void> {
+  const blueprint = playgroundBlueprint(spec.environment.blueprint, spec.policy, spec.preview?.siteUrl)
+  if (!blueprint || typeof blueprint !== "object" || !("steps" in blueprint) || !Array.isArray(blueprint.steps) || blueprint.steps.length === 0) {
+    return
+  }
+
+  const compiled = await compileBlueprint(blueprint)
+  await compiled.run(php as never)
+}
+
+async function runPhp(php: ProgrammaticPHP, options: { code: string } | { scriptPath: string }): Promise<PlaygroundServerRunResponse> {
+  const response = await php.run(options)
+  return normalizePhpResponse(response)
+}
+
+function normalizePhpResponse(response: ProgrammaticPHPResponse): PlaygroundServerRunResponse {
+  return {
+    exitCode: response.exitCode,
+    errors: response.errors,
+    text: response.text,
+  }
+}
+
+async function handleRequest(requestHandler: Awaited<ReturnType<typeof bootWordPressAndRequestHandler>>, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {
+  const response = await requestHandler.request({
+    url: incoming.url ?? "/",
+    method: incoming.method ?? "GET",
+    headers: incoming.headers as Record<string, string | string[]>,
+    body: await readRequestBody(incoming),
+  })
+
+  outgoing.statusCode = response.httpStatusCode
+  for (const [name, values] of Object.entries(response.headers)) {
+    outgoing.setHeader(name, values as string[])
+  }
+  outgoing.end(response.bytes)
+}
+
+function readRequestBody(incoming: IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    incoming.on("data", (chunk: Buffer | string) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+    incoming.on("end", () => resolve(Buffer.concat(chunks)))
+    incoming.on("error", reject)
+  })
+}
+
+function listenHttpServer(server: HttpServer, port: number, bind: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    server.listen(port, bind, () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        reject(new Error("Programmatic Playground server address is unavailable"))
+        return
+      }
+      const host = bind === "0.0.0.0" ? "127.0.0.1" : bind
+      resolve(`http://${host.includes(":") ? `[${host}]` : host}:${address.port}`)
+    })
+    server.once("error", reject)
+  })
+}
+
+function closeHttpServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+    server.closeAllConnections()
+  })
+}

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { startPlaygroundCliServer, type PlaygroundCliModule } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import type { RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
+
+const wordpressDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-wordpress-source-"))
+const artifactsDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-artifacts-"))
+const calls: Parameters<PlaygroundCliModule["runCLI"]>[0][] = []
+
+const cliModule: PlaygroundCliModule = {
+  async runCLI(options) {
+    calls.push(options)
+    return {
+      serverUrl: "http://127.0.0.1:65535",
+      playground: {
+        async run() {
+          return { text: "" }
+        },
+      },
+      async [Symbol.asyncDispose]() {},
+    }
+  },
+}
+
+try {
+  const spec: RuntimeCreateSpec = {
+    backend: "wordpress-playground",
+    environment: {
+      version: "mounted-wordpress-source",
+      phpVersion: "8.4",
+      wordpressInstallMode: "do-not-attempt-installing",
+      assets: { wordpressDirectory },
+      blueprint: {},
+    },
+    policy: {
+      network: "deny",
+      filesystem: "readwrite-mounts",
+      commands: ["wordpress.run-php"],
+      secrets: "none",
+      approvals: "never",
+    },
+    metadata: {
+      recipe: {
+        inputs: {
+          pluginRuntime: {
+            php: {
+              iniEntries: { memory_limit: "512M" },
+              bootstrapIniEntries: { "opcache.file_cache": "/tmp/opcache" },
+            },
+          },
+        },
+      },
+    },
+    artifactsDirectory,
+  }
+
+  const server = await startPlaygroundCliServer(spec, [], { cliModule })
+  await server[Symbol.asyncDispose]()
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]["mount-before-install"]?.length, 2)
+  assert.equal(calls[0]["mount-before-install"]?.[0]?.vfsPath, "/internal/shared")
+  assert.deepEqual(calls[0]["mount-before-install"]?.[1], { hostPath: wordpressDirectory, vfsPath: "/wordpress" })
+  assert.deepEqual(calls[0].mount, [])
+  assert.equal(calls[0].workers, 6)
+  assert.equal(calls[0].wordpressInstallMode, "do-not-attempt-installing")
+  assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
+  const sharedMount = calls[0]["mount-before-install"]?.[0]?.hostPath
+  assert.equal(typeof sharedMount, "string")
+  assert.match(await readFile(join(sharedMount as string, "php.ini"), "utf8"), /opcache\.file_cache = \/tmp\/opcache/)
+  assert.match(await readFile(join(sharedMount as string, "auto_prepend_file.php"), "utf8"), /<\?php/)
+  assert.equal((await stat(join(sharedMount as string, "mu-plugins"))).isDirectory(), true)
+  assert.equal((await stat(join(sharedMount as string, "preload"))).isDirectory(), true)
+} finally {
+  await rm(wordpressDirectory, { recursive: true, force: true })
+  await rm(artifactsDirectory, { recursive: true, force: true })
+}
+
+console.log("playground cli runner bootstrap ini ok")

--- a/tests/programmatic-playground-runner.test.ts
+++ b/tests/programmatic-playground-runner.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import { shouldUseProgrammaticPlaygroundRunner } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import type { RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
+
+const spec: RuntimeCreateSpec = {
+  backend: "wordpress-playground",
+  environment: {
+    version: "mounted-wordpress-source",
+    phpVersion: "8.4",
+    wordpressInstallMode: "do-not-attempt-installing",
+    assets: { wordpressDirectory: "/tmp/wordpress" },
+    blueprint: {},
+  },
+  policy: {
+    network: "deny",
+    filesystem: "readwrite-mounts",
+    commands: ["wordpress.run-php", "wordpress.wp-cli"],
+    secrets: "none",
+    approvals: "never",
+  },
+  metadata: {
+    recipe: {
+      inputs: {
+        pluginRuntime: {
+          php: {
+            bootstrapIniEntries: { memory_limit: "384M" },
+          },
+        },
+      },
+    },
+  },
+}
+
+assert.equal(shouldUseProgrammaticPlaygroundRunner(spec), true)
+assert.equal(shouldUseProgrammaticPlaygroundRunner({ ...spec, environment: { ...spec.environment, assets: {} } }), false)
+assert.equal(shouldUseProgrammaticPlaygroundRunner({ ...spec, metadata: {} }), false)
+assert.equal(shouldUseProgrammaticPlaygroundRunner(spec, {
+  cliModule: {
+    async runCLI() {
+      throw new Error("not called")
+    },
+  },
+}), false)
+
+console.log("programmatic playground runner opt-in boundary ok")


### PR DESCRIPTION
## Summary
- add recipe schema/types/validation for `pluginRuntime.php.iniEntries` and `bootstrapIniEntries`
- seed bootstrap PHP ini via a shared mount for Playground runs that need pre-init PHP settings
- add an opt-in programmatic Playground runner for mounted WordPress source plus bootstrap ini cases
- cover the bootstrap mount and programmatic-runner boundary with targeted tests

## Validation
- `git diff --check`
- `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts`
- `npx tsx tests/programmatic-playground-runner.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing bootstrap ini support, the programmatic Playground runner path, tests, and validation.