### PR TITLE
Use canonical sandbox agent runtime

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -84,6 +84,7 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
     const toolPolicy = { mode: "allow", tools: runtimeToolIds }
     input.tool_policy = toolPolicy
     input.allow_only = runtimeToolIds
+    input.completion_assertions = { required_tool_names: runtimeToolIds }
   }
 
   const timeoutSeconds = Number.parseInt(options.timeoutSeconds ?? '', 10)
@@ -127,50 +128,6 @@ $sandbox_stack['default_agent'] = wp_codebox_ensure_sandbox_default_agent(
     $sandbox_default_agent,
     json_decode(${JSON.stringify(JSON.stringify(input))}, true)
 );
-wp_codebox_register_sandbox_chat_handler();
-
-function wp_codebox_register_sandbox_chat_handler(): void {
-    add_filter('wp_agent_chat_handler', static function ($handler, array $input) {
-        if (null !== $handler) {
-            return $handler;
-        }
-        return static function (array $chat_input) {
-            return wp_codebox_execute_sandbox_chat_turn($chat_input);
-        };
-    }, 100, 2);
-}
-
-function wp_codebox_execute_sandbox_chat_turn(array $chat_input) {
-    if (!class_exists('\\WordPress\\AiClient\\AiClient')) {
-        return new WP_Error('wp_codebox_ai_client_unavailable', 'PHP AI Client is unavailable inside the sandbox.');
-    }
-
-    $provider = trim((string) ($chat_input['provider'] ?? ''));
-    $model = trim((string) ($chat_input['model'] ?? ''));
-    $message = trim((string) ($chat_input['message'] ?? ''));
-    if ('' === $provider || '' === $model) {
-        return new WP_Error('wp_codebox_provider_model_required', 'WP Codebox sandbox chat requires provider and model.');
-    }
-    if ('' === $message) {
-        return new WP_Error('wp_codebox_message_required', 'WP Codebox sandbox chat requires a message.');
-    }
-
-    try {
-        $provider_class = \\WordPress\\AiClient\\AiClient::defaultRegistry()->getProviderClassName($provider);
-        $prompt_builder = \\WordPress\\AiClient\\AiClient::prompt($message)->usingModel($provider_class::model($model));
-        $result = $prompt_builder->generateTextResult();
-        $reply = method_exists($result, 'toText') ? (string) $result->toText() : '';
-        if ('' === $reply) {
-            return new WP_Error('wp_codebox_empty_reply', 'WP Codebox sandbox chat returned an empty reply.');
-        }
-        return array(
-            'session_id' => (string) ($chat_input['session_id'] ?? $chat_input['client_context']['codebox_session_id'] ?? 'wp-codebox-sandbox'),
-            'reply' => $reply,
-        );
-    } catch (Throwable $throwable) {
-        return new WP_Error('wp_codebox_sandbox_chat_failed', $throwable->getMessage(), array('type' => get_class($throwable)));
-    }
-}
 
 function wp_codebox_ensure_sandbox_default_agent(string $agent_slug, array $agent_input): array {
     if ('' === $agent_slug) {

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -476,6 +476,11 @@ function agentRuntimeComponents(options: AgentRuntimeProbeOptions): AgentRuntime
   for (const component of options.components) {
     bySlug.set(component.slug, component)
   }
+  for (const component of defaultRuntimeComponents()) {
+    if (!bySlug.has(component.slug)) {
+      bySlug.set(component.slug, component)
+    }
+  }
   for (const component of options.components) {
     if (bySlug.has("agents-api")) {
       break
@@ -494,6 +499,20 @@ function agentRuntimeComponents(options: AgentRuntimeProbeOptions): AgentRuntime
     }
   }
   return [...bySlug.values()]
+}
+
+function defaultRuntimeComponents(): AgentRuntimeComponent[] {
+  return defaultRuntimeComponentPaths()
+    .map((source) => componentFromPath(source, undefined, undefined, "mu-plugin", "component"))
+}
+
+function defaultRuntimeComponentPaths(): string[] {
+  return (process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
+    .split(/[,:]/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => resolve(value))
+    .filter((source) => existsSync(source))
 }
 
 function defaultAgentsApiPath(): string {

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -160,23 +160,64 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
 }
 
 function defaultAgentRuntimeComponentPlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], callerExtraPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeExtraPlugin[] {
-  if ([...componentPlugins, ...callerExtraPlugins].some((plugin) => plugin.slug === "agents-api")) {
-    return []
+  const existingSlugs = new Set([...componentPlugins, ...callerExtraPlugins].map((plugin) => plugin.slug))
+  const defaults: WorkspaceRecipeExtraPlugin[] = []
+
+  for (const component of defaultRuntimeComponentPlugins()) {
+    if (!existingSlugs.has(component.slug)) {
+      defaults.push(component)
+      existingSlugs.add(component.slug)
+    }
   }
 
-  const agentsApiPath = defaultAgentsApiPath()
-  if (!agentsApiPath) {
-    return []
+  if (!existingSlugs.has("agents-api")) {
+    const bundledAgentsApiPath = [...componentPlugins, ...callerExtraPlugins, ...defaults]
+      .map((component) => agentsApiPathFromRuntimeComponent(component))
+      .find(Boolean)
+    const agentsApiPath = bundledAgentsApiPath || defaultAgentsApiPath()
+    if (agentsApiPath) {
+      defaults.push({
+        source: agentsApiPath,
+        slug: "agents-api",
+        pluginFile: "agents-api/agents-api.php",
+        activate: false,
+        loadAs: "mu-plugin",
+        metadata: { source: "wp-codebox-default-agent-runtime-substrate" },
+      })
+    }
   }
 
-  return [{
-    source: agentsApiPath,
-    slug: "agents-api",
-    pluginFile: "agents-api/agents-api.php",
-    activate: false,
-    loadAs: "mu-plugin",
-    metadata: { source: "wp-codebox-default-agent-runtime-substrate" },
-  }]
+  return defaults
+}
+
+function defaultRuntimeComponentPlugins(): WorkspaceRecipeExtraPlugin[] {
+  return defaultRuntimeComponentPaths().map((source) => {
+    const entrypoint = resolvePluginEntrypointContract({ source, loadAs: "mu-plugin" })
+    return {
+      source,
+      slug: entrypoint.slug,
+      pluginFile: entrypoint.pluginFile,
+      activate: false,
+      loadAs: "mu-plugin" as const,
+      metadata: { source: "wp-codebox-default-agent-runtime-substrate" },
+    }
+  })
+}
+
+function defaultRuntimeComponentPaths(): string[] {
+  return (process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
+    .split(/[,:]/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => resolve(value))
+    .filter((source) => existsSync(source))
+}
+
+function agentsApiPathFromRuntimeComponent(component: WorkspaceRecipeExtraPlugin): string {
+  return [
+    join(component.source, "vendor", "wordpress", "agents-api"),
+    join(component.source, "vendor", "automattic", "agents-api"),
+  ].find((candidate) => existsSync(join(candidate, "agents-api.php"))) ?? ""
 }
 
 function defaultAgentsApiPath(): string {

--- a/tests/agent-runtime-components.test.ts
+++ b/tests/agent-runtime-components.test.ts
@@ -8,6 +8,7 @@ import { agentRuntimeMounts, parseAgentRuntimeProbeOptions, type AgentRuntimeMou
 const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-components-"))
 const originalCwd = cwd()
 const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
+const originalRuntimeComponentPaths = process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
 
 try {
   const dataMachine = join(root, "data-machine")
@@ -28,13 +29,23 @@ try {
   const defaultAgentsApi = join(root, "agents-api")
   mkdirSync(defaultAgentsApi, { recursive: true })
   writeFileSync(join(defaultAgentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+  const runtimeEngine = join(root, "runtime-engine")
+  const runtimeTools = join(root, "runtime-tools")
+  mkdirSync(runtimeEngine, { recursive: true })
+  mkdirSync(runtimeTools, { recursive: true })
+  writeFileSync(join(runtimeEngine, "runtime-engine.php"), "<?php\n/* Plugin Name: Runtime Engine */\n")
+  writeFileSync(join(runtimeTools, "runtime-tools.php"), "<?php\n/* Plugin Name: Runtime Tools */\n")
+  process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = `${runtimeEngine},${runtimeTools}`
   const workspace = join(root, "workspace")
   mkdirSync(workspace, { recursive: true })
   chdir(workspace)
-  const defaultMount = agentRuntimeMounts(parseAgentRuntimeProbeOptions([], parseMount))
+  const defaultMounts = agentRuntimeMounts(parseAgentRuntimeProbeOptions([], parseMount))
+  const defaultMount = defaultMounts
     .find((mount) => mount.metadata?.slug === "agents-api")
   assertSamePath(defaultMount?.source, defaultAgentsApi)
   assert.equal(defaultMount?.target, "/wordpress/wp-content/mu-plugins/wp-codebox-runtime/agents-api")
+  assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "runtime-engine")?.source, runtimeEngine)
+  assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "runtime-tools")?.source, runtimeTools)
 
   const explicitAgentsApi = join(root, "explicit-agents-api")
   mkdirSync(explicitAgentsApi, { recursive: true })
@@ -49,6 +60,11 @@ try {
     delete process.env.WP_CODEBOX_AGENTS_API_PATH
   } else {
     process.env.WP_CODEBOX_AGENTS_API_PATH = originalAgentsApiPath
+  }
+  if (originalRuntimeComponentPaths === undefined) {
+    delete process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
+  } else {
+    process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = originalRuntimeComponentPaths
   }
   rmSync(root, { recursive: true, force: true })
 }

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -106,11 +106,16 @@ assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run")
 
 const agentRecipeTemp = mkdtempSync(join(tmpdir(), "wp-codebox-agent-recipe-test-"))
 const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
+const originalRuntimeComponentPaths = process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
 try {
   const agentsApiSource = join(agentRecipeTemp, "agents-api")
   mkdirSync(agentsApiSource)
   writeFileSync(join(agentsApiSource, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
   process.env.WP_CODEBOX_AGENTS_API_PATH = agentsApiSource
+  const runtimeEngineSource = join(agentRecipeTemp, "runtime-engine")
+  mkdirSync(runtimeEngineSource)
+  writeFileSync(join(runtimeEngineSource, "runtime-engine.php"), "<?php\n/* Plugin Name: Runtime Engine */\n")
+  process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = runtimeEngineSource
   const providerSource = join(agentRecipeTemp, "test-provider")
   mkdirSync(providerSource)
   writeFileSync(join(providerSource, "test-provider.php"), "<?php\n/* Plugin Name: Test Provider */\n")
@@ -158,6 +163,7 @@ try {
     metadata: { source: "wp-codebox-default-agent-runtime-substrate" },
   })
   assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api" && component.loadAs === "mu-plugin"), true)
+  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "runtime-engine" && component.loadAs === "mu-plugin"), true)
   assert.equal(extraPlugins.some((plugin) => plugin.slug === "test-provider" && plugin.activate === true && plugin.loadAs === "plugin"), true)
   assert.equal(extraPlugins.filter((plugin) => plugin.slug === "test-provider" && plugin.loadAs === "plugin").length, 1)
   assert.deepEqual(extraPlugins.find((plugin) => plugin.slug === "agent-runtime-tool-bridge"), {
@@ -189,6 +195,11 @@ try {
     delete process.env.WP_CODEBOX_AGENTS_API_PATH
   } else {
     process.env.WP_CODEBOX_AGENTS_API_PATH = originalAgentsApiPath
+  }
+  if (originalRuntimeComponentPaths === undefined) {
+    delete process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
+  } else {
+    process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = originalRuntimeComponentPaths
   }
   rmSync(agentRecipeTemp, { recursive: true, force: true })
 }

--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -80,6 +80,33 @@ const sandboxAgentCode = await resolveSandboxTaskCode({
   model: "gpt-5.5",
   sandboxToolPolicy: { schema: "wp-codebox/sandbox-tool-policy/v1", version: 1, tools: [] },
 })
-assert.match(sandboxAgentCode, /wp_codebox_register_sandbox_chat_handler\(\)/)
-assert.match(sandboxAgentCode, /wp_agent_chat_handler/)
-assert.match(sandboxAgentCode, /wp_codebox_execute_sandbox_chat_turn/)
+assert.doesNotMatch(sandboxAgentCode, /wp_codebox_register_sandbox_chat_handler\(\)/)
+assert.doesNotMatch(sandboxAgentCode, /wp_agent_chat_handler/)
+assert.doesNotMatch(sandboxAgentCode, /wp_codebox_execute_sandbox_chat_turn/)
+
+const sandboxAgentCodeWithTools = await resolveSandboxTaskCode({
+  task: "Inspect workspace",
+  agent: "wp-codebox-sandbox",
+  provider: "codex",
+  model: "gpt-5.5",
+  sandboxToolPolicy: {
+    schema: "wp-codebox/sandbox-tool-policy/v1",
+    version: 1,
+    metadata: {},
+    tools: [
+      {
+        id: "workspace_ls",
+        runtime_tool_id: "workspace_ls",
+        execution_location: "sandbox",
+        transport_visibility: "sandbox",
+        allowed: true,
+        runtime: {
+          environment: "runtime_local",
+          capability_scope: "runtime_local",
+        },
+      },
+    ],
+  },
+})
+assert.match(sandboxAgentCodeWithTools, /\\"allow_only\\":\[\\"workspace_ls\\"\]/)
+assert.match(sandboxAgentCodeWithTools, /\\"completion_assertions\\":\{\\"required_tool_names\\":\[\\"workspace_ls\\"\]\}/)


### PR DESCRIPTION
## Summary
- remove WP Codebox's CLI sandbox-owned agents/chat fallback handler
- preserve sandbox runtime tool requirements through completion assertions
- allow internal runtime components to be mounted from a generic component-path env list without exposing downstream plugin APIs

## Testing
- npm run test:runtime-php-snippets
- npm run test:agent-task-contracts
- npm run test:production-boundary-enforcement
- npx tsx tests/agent-runtime-components.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosing the text-only sandbox tool fallback, removing the fallback path, wiring generic internal runtime component mounting, and adding regression coverage.