### PR TITLE
Add reusable PHP worker JSON helpers

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
@@ -30,12 +30,9 @@ $capture_paths = ' . var_export( $captures, true ) . ';
 $started_at = gmdate( \'c\' );
 $started_monotonic = microtime( true );
 
-if ( is_readable( $task_path ) ) {
-	$raw_payload = json_decode( (string) file_get_contents( $task_path ), true );
-	if ( is_array( $raw_payload ) ) {
-		$payload = array_replace_recursive( $payload, $raw_payload );
-	}
-}
+' . self::worker_json_fragment() . '
+
+$payload = wp_codebox_worker_json_merge_file( $task_path, $payload );
 
 $wp_codebox_component_manifest = is_array( $payload[\'component_manifest\'] ?? null ) ? $payload[\'component_manifest\'] : array();
 if ( ! empty( $wp_codebox_component_manifest ) ) {
@@ -51,6 +48,50 @@ if ( function_exists( \'get_current_user_id\' ) && function_exists( \'wp_set_cur
 	wp_set_current_user( 1 );
 }
 ';
+	}
+
+	/** Builds generic JSON helpers for generated PHP workers. */
+	public static function worker_json_fragment(): string {
+		return <<<'PHP'
+function wp_codebox_worker_json_decode_array( string $json ): ?array {
+	$decoded = json_decode( $json, true );
+	return is_array( $decoded ) ? $decoded : null;
+}
+
+function wp_codebox_worker_json_read_array_file( string $path ): ?array {
+	if ( '' === $path || ! is_readable( $path ) ) {
+		return null;
+	}
+	$contents = file_get_contents( $path );
+	return is_string( $contents ) ? wp_codebox_worker_json_decode_array( $contents ) : null;
+}
+
+function wp_codebox_worker_json_merge_file( string $path, array $defaults ): array {
+	$overrides = wp_codebox_worker_json_read_array_file( $path );
+	return is_array( $overrides ) ? array_replace_recursive( $defaults, $overrides ) : $defaults;
+}
+
+function wp_codebox_worker_json_encode( $value ): ?string {
+	if ( function_exists( 'wp_json_encode' ) ) {
+		$encoded = wp_json_encode( $value, JSON_UNESCAPED_SLASHES );
+	} else {
+		$encoded = json_encode( $value, JSON_UNESCAPED_SLASHES );
+	}
+	return is_string( $encoded ) ? $encoded : null;
+}
+
+function wp_codebox_worker_json_write_file( string $path, $value ): bool {
+	$encoded = wp_codebox_worker_json_encode( $value );
+	if ( null === $encoded ) {
+		return false;
+	}
+	$directory = dirname( $path );
+	if ( '' !== $directory && '.' !== $directory && ! is_dir( $directory ) && ! mkdir( $directory, 0777, true ) && ! is_dir( $directory ) ) {
+		return false;
+	}
+	return false !== file_put_contents( $path, $encoded );
+}
+PHP;
 	}
 
 	/** Builds the generated PHP error normalization fragment. */
@@ -844,8 +885,8 @@ if ( ! empty( \$artifact_bundle ) ) {
 }
 }
 
-file_put_contents( \$result_path, wp_json_encode( \$result ) );
-echo wp_json_encode( \$result );
+wp_codebox_worker_json_write_file( \$result_path, \$result );
+echo wp_codebox_worker_json_encode( \$result );
 PHP;
 	}
 

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -244,12 +244,7 @@ $wp_codebox_is_playground = \'/wordpress/\' === $wp_codebox_playground_root && (
 
 $runtime_lifecycle = wp_codebox_browser_runtime_replay_ability_lifecycle();
 
-if ( is_readable( $task_path ) ) {
-$raw_payload = json_decode( (string) file_get_contents( $task_path ), true );
-if ( is_array( $raw_payload ) ) {
-	$payload = array_replace_recursive( $payload, $raw_payload );
-}
-}
+$payload = wp_codebox_worker_json_merge_file( $task_path, $payload );
 
 $wp_codebox_browser_artifact_environment = wp_codebox_browser_artifact_environment( $payload );
 $provider_proxy_diagnostics = wp_codebox_browser_install_provider_proxy( $payload );

--- a/scripts/php-worker-json-smoke.php
+++ b/scripts/php-worker-json-smoke.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+require_once dirname( __DIR__ ) . '/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php';
+
+function smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+$temp_dir = sys_get_temp_dir() . '/wp-codebox-worker-json-' . bin2hex( random_bytes( 4 ) );
+$task_path = $temp_dir . '/nested/task.json';
+$result_path = $temp_dir . '/nested/result.json';
+
+eval( WP_Codebox_Browser_Runner_Template::worker_json_fragment() );
+
+smoke_assert( null === wp_codebox_worker_json_read_array_file( $task_path ), 'missing task file returns null' );
+smoke_assert( wp_codebox_worker_json_write_file( $task_path, array( 'goal' => 'Override', 'nested' => array( 'right' => true ) ) ), 'task file writes JSON' );
+
+$merged = wp_codebox_worker_json_merge_file( $task_path, array( 'goal' => 'Default', 'nested' => array( 'left' => true ) ) );
+smoke_assert( 'Override' === $merged['goal'], 'task file overrides defaults' );
+smoke_assert( true === $merged['nested']['left'], 'recursive merge keeps defaults' );
+smoke_assert( true === $merged['nested']['right'], 'recursive merge applies overrides' );
+
+smoke_assert( wp_codebox_worker_json_write_file( $result_path, array( 'success' => true, 'schema' => 'example/v1' ) ), 'result file writes JSON' );
+$result = wp_codebox_worker_json_read_array_file( $result_path );
+smoke_assert( is_array( $result ) && true === $result['success'], 'result file reads JSON' );
+
+file_put_contents( $task_path, '{not-json' );
+$fallback = wp_codebox_worker_json_merge_file( $task_path, array( 'goal' => 'Fallback' ) );
+smoke_assert( array( 'goal' => 'Fallback' ) === $fallback, 'invalid JSON preserves defaults' );
+
+echo "worker JSON smoke passed\n";

--- a/tests/browser-runner-template.test.ts
+++ b/tests/browser-runner-template.test.ts
@@ -76,7 +76,7 @@ echo json_encode( array(
 assert.equal(php.status, 0, php.stderr)
 const result = JSON.parse(php.stdout)
 
-assert.equal(result.sha256, "6fb6aa5b9b9bb8dac1a247ca038c24376e0755caa5350121aa49ed6a301a910b")
+assert.equal(result.sha256, "acfadba3cee573c68ea65b6a9c5853388ab333eeecf7880ef0177e66b07fe866")
 assert.deepEqual(result.function_counts, {
   event_sink: 1,
   capture_file: 1,

--- a/tests/browser-runner-template.test.ts
+++ b/tests/browser-runner-template.test.ts
@@ -76,7 +76,7 @@ echo json_encode( array(
 assert.equal(php.status, 0, php.stderr)
 const result = JSON.parse(php.stdout)
 
-assert.equal(result.sha256, "8c7698406f3ce17c23ef8b7ec61a1af9a19a7f2ffd45ce5b1d4fa1f277b91264")
+assert.equal(result.sha256, "6fb6aa5b9b9bb8dac1a247ca038c24376e0755caa5350121aa49ed6a301a910b")
 assert.deepEqual(result.function_counts, {
   event_sink: 1,
   capture_file: 1,


### PR DESCRIPTION
## Summary
- Add reusable PHP worker JSON helper fragments to the browser runner template
- Reuse the helper for browser task payload/result JSON handling
- Add a PHP smoke script for the worker JSON fragment
- Update the browser runner template contract hash

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php`
- `php -l scripts/php-worker-json-smoke.php`
- `php scripts/php-worker-json-smoke.php`
- `npm run test:browser-runner-template`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the helper extraction and targeted validation.