### PR TITLE
Fall back to remote browser mu-plugin packages

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -31,33 +31,29 @@ private static function normalize_browser_mu_plugins( array $mu_plugins ): array
 				return new WP_Error( 'wp_codebox_browser_mu_plugin_slug_missing', 'Packaged browser mu-plugin specs require a slug.', array( 'status' => 400, 'index' => $index ) );
 			}
 
-			if ( '' !== $source_path ) {
-				if ( is_file( $source_path ) && str_ends_with( strtolower( $source_path ), '.zip' ) ) {
-					$package    = self::browser_package_local_archive( $slug, $source_path, $index, (string) ( $mu_plugin['sha256'] ?? '' ), 'plugin' );
-					$provenance = array(
-						'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
-						'source' => 'runtime-mu-plugin-package-path',
-						'path'   => $source_path,
-					);
-				} else {
-					if ( ! is_dir( $source_path ) ) {
-						return new WP_Error( 'wp_codebox_browser_mu_plugin_path_missing', 'Browser mu-plugin path does not exist.', array( 'status' => 400, 'index' => $index, 'slug' => $slug ) );
-					}
-
-					$package    = self::browser_package_component_plugin( $slug, $source_path );
-					$provenance = array(
-						'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
-						'source' => 'runtime-mu-plugin-path',
-						'path'   => $source_path,
-					);
-				}
-			} else {
+			if ( '' !== $source_path && is_file( $source_path ) && str_ends_with( strtolower( $source_path ), '.zip' ) ) {
+				$package    = self::browser_package_local_archive( $slug, $source_path, $index, (string) ( $mu_plugin['sha256'] ?? '' ), 'plugin' );
+				$provenance = array(
+					'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
+					'source' => 'runtime-mu-plugin-package-path',
+					'path'   => $source_path,
+				);
+			} elseif ( '' !== $source_path && is_dir( $source_path ) ) {
+				$package    = self::browser_package_component_plugin( $slug, $source_path );
+				$provenance = array(
+					'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
+					'source' => 'runtime-mu-plugin-path',
+					'path'   => $source_path,
+				);
+			} elseif ( '' !== $source_url ) {
 				$package    = self::browser_remote_mu_plugin_package( $slug, $source_url, $index, (string) ( $mu_plugin['sha256'] ?? '' ) );
 				$provenance = array(
 					'schema' => 'wp-codebox/browser-mu-plugin-provenance/v1',
 					'source' => 'runtime-mu-plugin-remote-package',
 					'url'    => $source_url,
 				);
+			} else {
+				return new WP_Error( 'wp_codebox_browser_mu_plugin_path_missing', 'Browser mu-plugin path does not exist.', array( 'status' => 400, 'index' => $index, 'slug' => $slug ) );
 			}
 
 			if ( is_wp_error( $package ) ) {

--- a/scripts/php-browser-runtime-local-package-smoke.php
+++ b/scripts/php-browser-runtime-local-package-smoke.php
@@ -47,7 +47,29 @@ function wp_parse_url( string $url ): array|false {
 }
 
 function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+	if ( 'wp_codebox_browser_runtime_plugin_package_allowed_hosts' === $hook_name ) {
+		$value[] = 'example.test';
+	}
+
 	return $value;
+}
+
+/** @param array<string,mixed> $args */
+function wp_safe_remote_get( string $url, array $args = array() ): array {
+	return array(
+		'response' => array( 'code' => 200 ),
+		'body'     => $GLOBALS['wp_codebox_remote_package_body'] ?? '',
+	);
+}
+
+/** @param array<string,mixed> $response */
+function wp_remote_retrieve_response_code( array $response ): int {
+	return (int) ( $response['response']['code'] ?? 0 );
+}
+
+/** @param array<string,mixed> $response */
+function wp_remote_retrieve_body( array $response ): string {
+	return (string) ( $response['body'] ?? '' );
 }
 
 function sanitize_key( string $key ): string {
@@ -64,6 +86,20 @@ final class WP_Codebox_Browser_Runtime_Local_Package_Smoke {
 	public static function normalize( array $mu_plugins ): array|WP_Error {
 		$method = new ReflectionMethod( self::class, 'normalize_browser_mu_plugins' );
 		return $method->invoke( null, $mu_plugins );
+	}
+
+	/** @return array<int,string> */
+	private static function string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				array_map( 'strval', $value ),
+				static fn( string $item ): bool => '' !== trim( $item )
+			)
+		);
 	}
 }
 
@@ -96,7 +132,9 @@ remove_tree( $root );
 mkdir( $root . '/source', 0777, true );
 
 $zip_path = $root . '/source/runtime.zip';
-file_put_contents( $zip_path, "PK\x03\x04local-package-smoke" );
+$package_body = "PK\x03\x04local-package-smoke";
+file_put_contents( $zip_path, $package_body );
+$GLOBALS['wp_codebox_remote_package_body'] = $package_body;
 $sha256 = hash_file( 'sha256', $zip_path );
 if ( ! is_string( $sha256 ) ) {
 	fail( 'Could not hash test package.' );
@@ -142,6 +180,34 @@ $mismatch = WP_Codebox_Browser_Runtime_Local_Package_Smoke::normalize(
 );
 if ( ! is_wp_error( $mismatch ) || 'wp_codebox_browser_plugin_package_hash_mismatch' !== $mismatch->get_error_code() ) {
 	fail( 'Expected sha256 mismatch to fail.' );
+}
+
+$remote_fallback = WP_Codebox_Browser_Runtime_Local_Package_Smoke::normalize(
+	array(
+		array(
+			'slug'   => 'runtime-smoke',
+			'file'   => 'runtime-smoke.php',
+			'path'   => $root . '/missing/runtime.zip',
+			'url'    => 'https://example.test/runtime.zip',
+			'sha256' => $sha256,
+			'entry'  => 'runtime-smoke/runtime-smoke.php',
+		),
+	)
+);
+
+if ( is_wp_error( $remote_fallback ) ) {
+	fail( 'Expected missing local package with URL fallback to succeed, got ' . $remote_fallback->get_error_code() . ': ' . $remote_fallback->get_error_message() );
+}
+
+$remote_entry = $remote_fallback[0] ?? array();
+if ( ! str_starts_with( (string) ( $remote_entry['url'] ?? '' ), 'data:application/zip;base64,' ) ) {
+	fail( 'Expected missing local package with URL fallback to use data URL delivery.' );
+}
+if ( ( $remote_entry['provenance']['source'] ?? '' ) !== 'runtime-mu-plugin-remote-package' ) {
+	fail( 'Expected remote package provenance for missing path fallback.' );
+}
+if ( 'https://example.test/runtime.zip' !== ( $remote_entry['provenance']['url'] ?? '' ) ) {
+	fail( 'Expected remote package provenance to keep the source URL.' );
 }
 
 remove_tree( $root );


### PR DESCRIPTION
## Summary
- Fall back to the remote package URL when a browser mu-plugin spec includes a local path that is unavailable in the active runtime.
- Preserve existing local archive/directory behavior when the local path exists.
- Add regression coverage for missing-path plus URL fallback through the existing PHP browser runtime package smoke.

## Verification
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php`
- `php scripts/php-browser-runtime-local-package-smoke.php`
- `npm run test:php-browser-runtime-local-package`
- `npm run smoke -- --group=runtime`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the merged Studio Web e2e failure, implementing the generic WP Codebox fallback, and adding/running focused regression coverage.
