### PR TITLE
Extract materialization envelope helper

### DIFF
--- a/packages/runtime-core/src/materialization-contracts.ts
+++ b/packages/runtime-core/src/materialization-contracts.ts
@@ -83,6 +83,15 @@ export interface SkippedMaterializationResultEnvelope extends MaterializationRes
 
 export type MaterializationResultEnvelope = CompletedMaterializationResultEnvelope | FailedMaterializationResultEnvelope | SkippedMaterializationResultEnvelope
 
+export interface MaterializationResultEnvelopeExtraction {
+  report?: Record<string, unknown>
+  response?: Record<string, unknown>
+  result?: Record<string, unknown>
+  task?: string
+  error?: FailedMaterializationResultEnvelope["error"]
+  malformed?: boolean
+}
+
 export interface BrowserArtifactProjectionInput {
   artifact?: Record<string, unknown> | null
   artifacts?: unknown
@@ -178,34 +187,23 @@ export function materializationResultEnvelope(input: {
 }
 
 export function normalizeMaterializationResultEnvelope(materialization: unknown, fallbackMessage = "Materialization failed."): MaterializationResultEnvelope {
-  const materializationRecord = asRecord(materialization)
-  const raw = asRecord(materializationRecord?.response) ?? materializationRecord
-  const report = raw?.schema === MATERIALIZATION_RESULT_SCHEMA || typeof raw?.schema === "string"
-    ? raw
-    : undefined
-  const response = asRecord(report?.response) ?? raw
+  const extracted = extractMaterializationResultEnvelope(materialization, fallbackMessage)
+  const { report, response } = extracted
   if (response?.success !== true) {
     return materializationResultEnvelope({
-      task: stringValue(response?.task) || stringValue(report?.task),
+      task: extracted.task,
       status: "failed",
       report: report ?? null,
       response,
-      error: errorObject(response) ?? errorObject(report) ?? fallbackMessage,
+      error: extracted.error ?? fallbackMessage,
       codeboxMaterialization: materialization,
     })
   }
 
-  const canonicalResult = firstRecord(
-    asRecord(response.result)?.result,
-    asRecord(response.result)?.data,
-    asRecord(response.result)?.response,
-    response.result,
-    response.data,
-    response.response,
-  )
+  const canonicalResult = extracted.result
   if (canonicalResult?.success === false) {
     return materializationResultEnvelope({
-      task: stringValue(response.task) || stringValue(report?.task),
+      task: extracted.task,
       status: "failed",
       result: canonicalResult,
       report: report ?? null,
@@ -214,14 +212,46 @@ export function normalizeMaterializationResultEnvelope(materialization: unknown,
       codeboxMaterialization: materialization,
     })
   }
+  if (extracted.malformed) {
+    return materializationResultEnvelope({
+      task: extracted.task,
+      status: "failed",
+      report: report ?? null,
+      response,
+      error: extracted.error ?? fallbackMessage,
+      codeboxMaterialization: materialization,
+    })
+  }
 
   return requireCompletedMaterializationResultEnvelope(materializationResultEnvelope({
-    task: stringValue(response.task) || stringValue(report?.task),
+    task: extracted.task,
     result: canonicalResult ?? response,
     report: report ?? null,
     response,
     codeboxMaterialization: materialization,
   }))
+}
+
+export function extractMaterializationResultEnvelope(materialization: unknown, fallbackMessage = "Materialization failed."): MaterializationResultEnvelopeExtraction {
+  const materializationRecord = asRecord(materialization)
+  const raw = asRecord(materializationRecord?.response) ?? materializationRecord
+  const report = raw?.schema === MATERIALIZATION_RESULT_SCHEMA || typeof raw?.schema === "string"
+    ? raw
+    : undefined
+  const response = asRecord(report?.response) ?? raw
+  const result = canonicalMaterializationResult(response) ?? capturedMaterializationResult(response) ?? capturedMaterializationResult(report)
+  const task = stringValue(response?.task) || stringValue(report?.task) || undefined
+  const error = errorObject(response) ?? errorObject(report)
+  const malformed = response?.success === true && response.schema === MATERIALIZATION_RESULT_SCHEMA && !result
+
+  return stripUndefined({
+    report,
+    response,
+    result,
+    task,
+    error: malformed ? error ?? normalizeError(fallbackMessage, fallbackMessage) : error,
+    malformed: malformed || undefined,
+  })
 }
 
 export function requireCompletedMaterializationResultEnvelope(envelope: MaterializationResultEnvelope): CompletedMaterializationResultEnvelope {
@@ -402,6 +432,42 @@ function errorObject(value: Record<string, unknown> | undefined): FailedMaterial
   const error = asRecord(value?.error)
   const message = stringValue(error?.message) || stringValue(value?.message)
   return message ? normalizeError({ name: stringValue(error?.name) || "Error", message, code: stringValue(error?.code) || undefined }, message) : undefined
+}
+
+function canonicalMaterializationResult(response: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  return firstRecord(
+    asRecord(response?.result)?.result,
+    asRecord(response?.result)?.data,
+    asRecord(response?.result)?.response,
+    response?.result,
+    response?.data,
+    response?.response,
+  )
+}
+
+function capturedMaterializationResult(source: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  const captures = Array.isArray(source?.captures) ? source.captures : []
+  for (const capture of captures) {
+    const captureRecord = asRecord(capture)
+    const json = asRecord(captureRecord?.json) ?? parseJsonRecord(captureRecord?.content)
+    const nestedResponse = asRecord(json?.response) ?? json
+    const result = canonicalMaterializationResult(nestedResponse)
+    if (result) {
+      return result
+    }
+  }
+  return undefined
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined
+  }
+  try {
+    return asRecord(JSON.parse(value))
+  } catch {
+    return undefined
+  }
 }
 
 function firstRecord(...values: unknown[]): Record<string, unknown> | undefined {

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -8,6 +8,7 @@ import {
   browserCallbackCapability,
   browserCallbackResultEnvelope,
   browserCallbackSignature,
+  extractMaterializationResultEnvelope,
   materializationResultEnvelope,
   materializationPhaseResult,
   materializationRunArtifactRefs,
@@ -220,6 +221,64 @@ assert.deepEqual(projection.artifactRefs, [
 ])
 assert.deepEqual(persistedBrowserArtifactRefs(projection), projection.artifactRefs)
 assert.deepEqual(browserArtifactPersistenceProjection(projection).artifactRefs, projection.artifactRefs)
+
+const canonicalMaterialization = extractMaterializationResultEnvelope({
+  schema: "wp-codebox/materialization-result/v1",
+  task: "generic-materialization",
+  success: true,
+  result: { artifact: { path: "files/output.json", kind: "generic-json", sha256: "abc" } },
+})
+assert.equal(canonicalMaterialization.task, "generic-materialization")
+assert.deepEqual(canonicalMaterialization.result, { artifact: { path: "files/output.json", kind: "generic-json", sha256: "abc" } })
+
+const nestedCaptureMaterialization = normalizeMaterializationResultEnvelope({
+  response: {
+    schema: "wp-codebox/browser-materialization/v1",
+    success: true,
+    task: "capture-materialization",
+    captures: [{
+      schema: "wp-codebox/browser-capture/v1",
+      path: "/tmp/materialization.json",
+      json: { success: true, result: { artifact: { path: "files/captured.json", kind: "generic-json", sha256: "123" } } },
+    }],
+  },
+})
+assert.equal(nestedCaptureMaterialization.status, "completed")
+assert.deepEqual(nestedCaptureMaterialization.result, { artifact: { path: "files/captured.json", kind: "generic-json", sha256: "123" } })
+
+const nestedCaptureContentMaterialization = normalizeMaterializationResultEnvelope({
+  response: {
+    schema: "wp-codebox/browser-materialization/v1",
+    success: true,
+    task: "capture-content-materialization",
+    captures: [{
+      schema: "wp-codebox/browser-capture/v1",
+      path: "/tmp/materialization.json",
+      content: JSON.stringify({ success: true, result: { artifact: { path: "files/captured-content.json", kind: "generic-json", sha256: "456" } } }),
+    }],
+  },
+})
+assert.equal(nestedCaptureContentMaterialization.status, "completed")
+assert.deepEqual(nestedCaptureContentMaterialization.result, { artifact: { path: "files/captured-content.json", kind: "generic-json", sha256: "456" } })
+
+const explicitFailureMaterialization = normalizeMaterializationResultEnvelope({
+  schema: "wp-codebox/materialization-result/v1",
+  task: "generic-materialization",
+  success: false,
+  error: { name: "Error", message: "explicit materialization failure", code: "explicit-failure" },
+})
+assert.equal(explicitFailureMaterialization.status, "failed")
+assert.equal(explicitFailureMaterialization.error.message, "explicit materialization failure")
+assert.equal(explicitFailureMaterialization.error.code, "explicit-failure")
+
+const missingResultMaterialization = normalizeMaterializationResultEnvelope({
+  schema: "wp-codebox/materialization-result/v1",
+  task: "generic-materialization",
+  success: true,
+})
+assert.equal(missingResultMaterialization.status, "failed")
+assert.equal(missingResultMaterialization.error.message, "Materialization failed.")
+
 assert.deepEqual(normalizeMaterializationArtifactRefs([
   { kind: "browser-html", path: "files/browser/index.html", sha256: "def" },
   { role: "browser-html", path: "files/browser/index.html", content_digest: "def" },


### PR DESCRIPTION
## Summary
- Add a reusable generic materialization envelope extraction helper.
- Reuse it from materialization envelope normalization.
- Cover canonical success, nested capture JSON, explicit failure, and malformed/missing-result cases.

## Verification
- `npm ci`
- `npm run test:browser-callback-materialization-contracts`
- `npm run test:materialize-replay-package-command`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode plus delegated coding agent
- **Used for:** Implementing the generic materialization envelope helper, extending tests, and running focused verification.
