### PR TITLE
Add recipe secret env provider hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     "./cli": {
       "types": "./packages/cli/dist/index.d.ts",
       "import": "./packages/cli/dist/index.js"
+    },
+    "./cli/recipe-secret-env": {
+      "types": "./packages/cli/dist/recipe-secret-env.d.ts",
+      "import": "./packages/cli/dist/recipe-secret-env.js"
     }
   },
   "bin": {
@@ -110,6 +114,7 @@
     "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
+    "test:recipe-secret-env": "tsx tests/recipe-secret-env.test.ts",
     "test:evidence-bundle-digest-and-recipe-artifact": "tsx tests/evidence-bundle-digest-and-recipe-artifact.test.ts",
     "test:runtime-overlay-descriptors": "tsx tests/runtime-overlay-descriptors.test.ts",
     "test:runtime-preset-registry": "tsx tests/runtime-preset-registry.test.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./recipe-secret-env": {
+      "types": "./dist/recipe-secret-env.d.ts",
+      "import": "./dist/recipe-secret-env.js"
     }
   },
   "files": [

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,13 +1,14 @@
 import { createHash } from "node:crypto"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, resolveSecretEnvNames, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, recipeDryRunSiteSeeds } from "../recipe-dry-run.js"
 import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeArtifactEvidenceFailure, recipeReplayStatusOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
+import { resolveRecipeSecretEnv } from "../recipe-secret-env.js"
 import type { PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { loadWorkspaceRecipe, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -99,7 +100,8 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   const plan = await planWorkspaceRecipe(recipe, recipeDirectory, { recipePath, artifactsDirectory: configuredArtifactsDirectory }, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec })
   const { valid: _policyValid, issues: _policyIssues, ...policy } = plan.policy
   const runtimeEnv = normalizeRuntimeEnv(recipe.inputs?.runtimeEnv ?? {})
-  const secretEnv = resolveSecretEnvNames(recipe.inputs?.secretEnv ?? [], { field: "--secret-env name" })
+  const secretEnvResolution = resolveRecipeSecretEnv(recipe.inputs?.secretEnv ?? [], { field: "--secret-env name" })
+  const secretEnv = secretEnvResolution.values
   const effectivePolicy = Object.keys(secretEnv).length > 0 ? { ...policy, secrets: "connector-scoped" as const } : policy
   let workspaceMounts: PreparedWorkspaceMount[] = []
   let extraPlugins: PreparedExtraPlugin[] = []
@@ -270,7 +272,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       if (declaredArtifactFailure) {
         throw declaredArtifactFailure
       }
-      const recipeEvidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)
+      const recipeEvidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnvResolution.summary)
       const agentEvidence = await finalizeAgentSandboxEvidence(artifacts, executions)
       Object.assign(recipeEvidence, agentEvidence)
       markRecipeArtifactsFinalized(interruption, true)
@@ -291,7 +293,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, runtime)
       await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
       await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts))
-      evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnv)
+      evidence = await finalizeRecipeArtifactEvidence(artifacts, recipe, workspaceMounts, stagedFiles, effectivePolicy, secretEnvResolution.summary)
       const previewAgentEvidence = await finalizeAgentSandboxEvidence(artifacts, executions)
       Object.assign(evidence, previewAgentEvidence)
     }
@@ -381,7 +383,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         workspaceMounts,
         stagedFiles,
         policy: effectivePolicy,
-        secretEnv,
+        secretEnv: secretEnvResolution.summary,
         executions,
         interruption,
       }))

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -2,6 +2,7 @@ import { basename, dirname, resolve } from "node:path"
 import { fixtureImportDeterministicIdPlan, validateRuntimePolicy, type FixtureImportDeterministicIdPlan, type MountSpec, type RuntimePolicy, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeSiteSeedBootstrap, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { serializeError } from "./output.js"
+import { resolveRecipeSecretEnv, type RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
 import { composerPackageVendorPath, defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
 import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
 import { runtimeOverlayTarget } from "./runtime-overlay-registry.js"
@@ -65,7 +66,7 @@ export interface RecipePlan {
   siteSeeds: RecipeDryRunSiteSeed[]
   stagedFiles: RecipeDryRunStagedFile[]
   probes: RecipeDryRunProbe[]
-  secretEnv: Array<{ name: string; available: boolean }>
+  secretEnv: Array<{ name: string; available: boolean; status: RecipeSecretEnvSummaryEntry["status"]; source?: string }>
   policy: RuntimePolicy & {
     valid: boolean
     issues: ReturnType<typeof validateRuntimePolicy>["issues"]
@@ -93,7 +94,7 @@ interface RecipeDryRunDistribution {
   safety: {
     network: "deny" | "declared"
     allowedHosts: string[]
-    secretEnv: Array<{ name: string; available: boolean }>
+    secretEnv: Array<{ name: string; available: boolean; status: RecipeSecretEnvSummaryEntry["status"]; source?: string }>
     ambientSecrets: false
   }
 }
@@ -307,6 +308,7 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
   const siteSeeds = recipeDryRunSiteSeeds(recipe, recipeDirectory)
   const stagedFiles = await recipeDryRunStagedFiles(recipe, recipeDirectory)
   const workflowSteps = await recipeDryRunSteps(recipe, recipeDirectory, policy, context)
+  const secretEnvSummary = resolveRecipeSecretEnv(recipe.inputs?.secretEnv ?? []).summary
   const probes = await recipeDryRunProbes(recipe, recipeDirectory, policy, context)
   const recipeMounts = await Promise.all((recipe.inputs?.mounts ?? []).map(async (mount) => {
     const source = resolve(recipeDirectory, mount.source)
@@ -430,10 +432,7 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
     siteSeeds,
     stagedFiles,
     probes,
-    secretEnv: (recipe.inputs?.secretEnv ?? []).map((name) => ({
-      name,
-      available: process.env[name] !== undefined,
-    })),
+    secretEnv: secretEnvSummary.map(recipeDryRunSecretEnvEntry),
     policy: {
       ...policy,
       valid: policyValidation.valid,
@@ -526,12 +525,18 @@ async function recipeDryRunDistribution(distribution: WorkspaceRecipeDistributio
     safety: {
       network: distribution.safety?.network ?? "deny",
       allowedHosts: distribution.safety?.allowedHosts ?? [],
-      secretEnv: (distribution.safety?.secretEnv ?? []).map((name) => ({
-        name,
-        available: process.env[name] !== undefined,
-      })),
+      secretEnv: resolveRecipeSecretEnv(distribution.safety?.secretEnv ?? []).summary.map(recipeDryRunSecretEnvEntry),
       ambientSecrets: false,
     },
+  }
+}
+
+function recipeDryRunSecretEnvEntry(entry: RecipeSecretEnvSummaryEntry): { name: string; available: boolean; status: RecipeSecretEnvSummaryEntry["status"]; source?: string } {
+  return {
+    name: entry.name,
+    available: entry.status === "available",
+    status: entry.status,
+    ...(entry.source ? { source: entry.source } : {}),
   }
 }
 

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util"
 import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, captureArtifactFile, checkWorkspacePolicy, materializeStructuredArtifactFiles, normalizeAgentTerminalResult, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core/artifacts"
 import { isPlainObject as isRecord, sha256StableJson, stripUndefined } from "@automattic/wp-codebox-core/internals"
+import type { RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
 
 export interface RecipeArtifactEvidenceFile {
   path: string
@@ -224,7 +225,7 @@ export interface RecipeRunAttestation {
     schema: "wp-codebox/redacted-secret-envelope/v1"
     provided: boolean
     count: number
-    secrets: Array<{ name: string; status: "available"; source: "recipe-secret-env" }>
+    secrets: Array<{ name: string; status: RecipeSecretEnvSummaryEntry["status"]; source?: string }>
     redaction: "names-only"
   }
   evidenceRefs: {
@@ -307,7 +308,7 @@ export async function collectAndFinalizeFailedRecipeArtifacts(args: {
   workspaceMounts: RecipeEvidenceWorkspaceMount[]
   stagedFiles: RecipeEvidenceStagedFile[]
   policy: RuntimePolicy
-  secretEnv: Record<string, string>
+  secretEnv: RecipeSecretEnvSummaryEntry[]
   executions: RecipeEvidenceExecutionResult[]
   interruption?: RecipeArtifactsFinalizationController
 }): Promise<ArtifactBundle | undefined> {
@@ -399,7 +400,7 @@ export async function finalizeRecipeArtifactEvidence(
   workspaceMounts: RecipeEvidenceWorkspaceMount[],
   stagedFiles: RecipeEvidenceStagedFile[],
   policy: RuntimePolicy,
-  secretEnv: Record<string, string>,
+  secretEnv: RecipeSecretEnvSummaryEntry[],
 ): Promise<RecipeArtifactEvidenceResult> {
   const result: RecipeArtifactEvidenceResult = {}
   const verifier = normalizeArtifactToggle(recipe.artifacts?.verify)
@@ -1230,7 +1231,7 @@ async function buildRecipeRunAttestation(args: {
   artifacts: ArtifactBundle
   recipe: WorkspaceRecipe
   policy: RuntimePolicy
-  secretEnv: Record<string, string>
+  secretEnv: RecipeSecretEnvSummaryEntry[]
   workspacePolicy: { enabled: boolean; strict: boolean }
   verifier: { enabled: boolean; strict: boolean }
   workspacePolicyFile?: RecipeArtifactEvidenceFile
@@ -1310,9 +1311,9 @@ async function buildRecipeRunAttestation(args: {
     },
     secretEnvelope: {
       schema: "wp-codebox/redacted-secret-envelope/v1",
-      provided: Object.keys(args.secretEnv).length > 0,
-      count: Object.keys(args.secretEnv).length,
-      secrets: Object.keys(args.secretEnv).sort().map((name) => ({ name, status: "available", source: "recipe-secret-env" })),
+      provided: args.secretEnv.some((entry) => entry.status === "available"),
+      count: args.secretEnv.filter((entry) => entry.status === "available").length,
+      secrets: [...args.secretEnv].sort((a, b) => a.name.localeCompare(b.name)),
       redaction: "names-only",
     },
     evidenceRefs: stripUndefined({

--- a/packages/cli/src/recipe-secret-env.ts
+++ b/packages/cli/src/recipe-secret-env.ts
@@ -1,0 +1,113 @@
+import { assertRuntimeEnvName } from "@automattic/wp-codebox-core"
+
+export const SECRET_ENV_PROJECTIONS_ENV = "WP_CODEBOX_SECRET_ENV_PROJECTIONS"
+
+export interface RecipeSecretEnvProviderContext {
+  readonly source: Record<string, string | undefined>
+}
+
+export interface RecipeSecretEnvProviderResult {
+  readonly value?: string
+  readonly source: string
+}
+
+export type RecipeSecretEnvProvider = (name: string, context: RecipeSecretEnvProviderContext) => RecipeSecretEnvProviderResult | undefined
+
+export interface RecipeSecretEnvSummaryEntry {
+  name: string
+  status: "available" | "missing"
+  source?: string
+}
+
+export interface RecipeSecretEnvResolution {
+  values: Record<string, string>
+  summary: RecipeSecretEnvSummaryEntry[]
+}
+
+export interface ResolveRecipeSecretEnvOptions {
+  source?: Record<string, string | undefined>
+  providers?: readonly RecipeSecretEnvProvider[]
+  field?: string
+}
+
+type SecretEnvProjectionSpec = Record<string, string> | Array<{ name?: unknown; from?: unknown }>
+
+export function resolveRecipeSecretEnv(names: readonly string[], options: ResolveRecipeSecretEnvOptions = {}): RecipeSecretEnvResolution {
+  const source = options.source ?? process.env
+  const providers = options.providers ?? defaultRecipeSecretEnvProviders(source)
+  const field = options.field ?? "secretEnv"
+  const values: Record<string, string> = {}
+  const summary: RecipeSecretEnvSummaryEntry[] = []
+
+  for (const rawName of names) {
+    const name = rawName.trim()
+    assertRuntimeEnvName(name, field)
+    const result = resolveFromProviders(name, providers, { source })
+    if (result?.value !== undefined) {
+      values[name] = result.value
+      summary.push({ name, status: "available", source: result.source })
+      continue
+    }
+    summary.push({ name, status: "missing" })
+  }
+
+  return { values, summary }
+}
+
+export function defaultRecipeSecretEnvProviders(source: Record<string, string | undefined> = process.env): RecipeSecretEnvProvider[] {
+  return [
+    directProcessEnvSecretProvider,
+    projectionSecretEnvProvider(parseSecretEnvProjections(source[SECRET_ENV_PROJECTIONS_ENV])),
+  ]
+}
+
+export const directProcessEnvSecretProvider: RecipeSecretEnvProvider = (name, context) => {
+  const value = context.source[name]
+  return value === undefined ? undefined : { value, source: "process-env" }
+}
+
+export function projectionSecretEnvProvider(projections: ReadonlyMap<string, string>): RecipeSecretEnvProvider {
+  return (name, context) => {
+    const sourceName = projections.get(name)
+    if (!sourceName) {
+      return undefined
+    }
+    const value = context.source[sourceName]
+    return value === undefined ? undefined : { value, source: "env-projection" }
+  }
+}
+
+export function parseSecretEnvProjections(raw: string | undefined): ReadonlyMap<string, string> {
+  if (!raw?.trim()) {
+    return new Map()
+  }
+
+  const parsed = JSON.parse(raw) as SecretEnvProjectionSpec
+  const entries = Array.isArray(parsed)
+    ? parsed.map((entry) => [entry.name, entry.from])
+    : Object.entries(parsed)
+  const projections = new Map<string, string>()
+
+  for (const [rawName, rawFrom] of entries) {
+    if (typeof rawName !== "string" || typeof rawFrom !== "string") {
+      throw new Error(`${SECRET_ENV_PROJECTIONS_ENV} entries must map secret env names to source env names`)
+    }
+    const name = rawName.trim()
+    const from = rawFrom.trim()
+    assertRuntimeEnvName(name, SECRET_ENV_PROJECTIONS_ENV)
+    assertRuntimeEnvName(from, SECRET_ENV_PROJECTIONS_ENV)
+    projections.set(name, from)
+  }
+
+  return projections
+}
+
+function resolveFromProviders(name: string, providers: readonly RecipeSecretEnvProvider[], context: RecipeSecretEnvProviderContext): RecipeSecretEnvProviderResult | undefined {
+  for (const provider of providers) {
+    const result = provider(name, context)
+    if (result?.value !== undefined) {
+      return result
+    }
+  }
+  return undefined
+}

--- a/tests/recipe-secret-env.test.ts
+++ b/tests/recipe-secret-env.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict"
+
+import {
+  SECRET_ENV_PROJECTIONS_ENV,
+  defaultRecipeSecretEnvProviders,
+  parseSecretEnvProjections,
+  resolveRecipeSecretEnv,
+  type RecipeSecretEnvProvider,
+} from "../packages/cli/src/recipe-secret-env.js"
+import { planWorkspaceRecipe } from "../packages/cli/src/recipe-dry-run.js"
+
+const source = {
+  DIRECT_SECRET: "direct-value-123",
+  RUNNER_PROJECTED_SECRET: "projected-value-456",
+  [SECRET_ENV_PROJECTIONS_ENV]: JSON.stringify({ PROJECTED_SECRET: "RUNNER_PROJECTED_SECRET" }),
+}
+
+const resolved = resolveRecipeSecretEnv(["DIRECT_SECRET", "PROJECTED_SECRET", "MISSING_SECRET"], { source })
+
+assert.deepEqual(resolved.values, {
+  DIRECT_SECRET: "direct-value-123",
+  PROJECTED_SECRET: "projected-value-456",
+})
+assert.deepEqual(resolved.summary, [
+  { name: "DIRECT_SECRET", status: "available", source: "process-env" },
+  { name: "PROJECTED_SECRET", status: "available", source: "env-projection" },
+  { name: "MISSING_SECRET", status: "missing" },
+])
+assert.doesNotMatch(JSON.stringify(resolved.summary), /direct-value-123|projected-value-456/)
+
+const customProvider: RecipeSecretEnvProvider = (name) => name === "DERIVED_SECRET"
+  ? { value: `derived:${name.toLowerCase()}`, source: "test-provider" }
+  : undefined
+const customResolved = resolveRecipeSecretEnv(["DERIVED_SECRET"], { source: {}, providers: [customProvider] })
+assert.deepEqual(customResolved.values, { DERIVED_SECRET: "derived:derived_secret" })
+assert.deepEqual(customResolved.summary, [{ name: "DERIVED_SECRET", status: "available", source: "test-provider" }])
+
+assert.deepEqual([...parseSecretEnvProjections(JSON.stringify([
+  { name: "ARRAY_PROJECTED_SECRET", from: "RUNNER_PROJECTED_SECRET" },
+]))], [["ARRAY_PROJECTED_SECRET", "RUNNER_PROJECTED_SECRET"]])
+
+assert.equal(defaultRecipeSecretEnvProviders(source).length, 2)
+assert.throws(() => parseSecretEnvProjections(JSON.stringify({ bad: "RUNNER_PROJECTED_SECRET" })), /WP_CODEBOX_SECRET_ENV_PROJECTIONS/)
+
+const previousProjection = process.env[SECRET_ENV_PROJECTIONS_ENV]
+const previousRunnerSecret = process.env.RUNNER_DRY_RUN_SECRET
+try {
+  process.env[SECRET_ENV_PROJECTIONS_ENV] = JSON.stringify({ DRY_RUN_SECRET: "RUNNER_DRY_RUN_SECRET" })
+  process.env.RUNNER_DRY_RUN_SECRET = "dry-run-secret-value-789"
+  const plan = await planWorkspaceRecipe({
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: { secretEnv: ["DRY_RUN_SECRET"] },
+    workflow: { steps: [{ command: "wordpress.run-php", args: ["code=<?php echo 'ok';"] }] },
+  }, process.cwd(), { recipePath: "recipe.json" }, {
+    defaultWordPressVersion: "latest",
+    resolveExecutionSpec: async (step) => ({ command: step.command, args: step.args ?? [] }),
+  })
+
+  assert.deepEqual(plan.secretEnv, [{ name: "DRY_RUN_SECRET", available: true, status: "available", source: "env-projection" }])
+  assert.doesNotMatch(JSON.stringify(plan.secretEnv), /dry-run-secret-value-789/)
+} finally {
+  if (previousProjection === undefined) {
+    delete process.env[SECRET_ENV_PROJECTIONS_ENV]
+  } else {
+    process.env[SECRET_ENV_PROJECTIONS_ENV] = previousProjection
+  }
+  if (previousRunnerSecret === undefined) {
+    delete process.env.RUNNER_DRY_RUN_SECRET
+  } else {
+    process.env.RUNNER_DRY_RUN_SECRET = previousRunnerSecret
+  }
+}


### PR DESCRIPTION
## Summary
- Add generic recipe-run secret env resolver/provider hooks
- Support direct env lookup and JSON projections via `WP_CODEBOX_SECRET_ENV_PROJECTIONS`
- Keep artifacts/evidence limited to names/status/source, never secret values
- Add focused tests for resolution and evidence behavior

## Verification
- `npm run test:recipe-secret-env`
- `npm run build`
- `npm run test:generic-ability-runtime-run`
- `node -e "import('@automattic/wp-codebox-cli/recipe-secret-env').then((m)=>{ if (typeof m.resolveRecipeSecretEnv !== 'function') process.exit(1) })"`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing provider hooks and targeted tests.