### PR TITLE
Document WP Codebox public API contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,9 @@ unless this index says otherwise.
   documents the stable orchestrator-facing agent-task CLI, schema boundary,
   artifacts, runner workspace publication, lifecycle metadata, provider
   overlays, and default sandbox bootstrap expectations.
+- [Public API contract](./public-api-contract.md) defines stable package
+  entrypoints, lifecycle contract areas, inspectable surfaces, and the limited
+  role of `./internals`.
 - [Generic runtime primitives](./generic-runtime-primitives.md) documents the
   caller-neutral artifact storage, trusted browser origin, materialization, and
   target-context envelopes shared by runtime integrations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,9 @@ backend or host adapter. The important modules are:
   root for runtime, recipe, policy, artifact metadata, task, browser, host-tool,
   fanout contract, and result-envelope types. Keep implementation helpers out of
   this barrel.
+- [`docs/public-api-contract.md`](./public-api-contract.md): the maintained
+  contract map for stable package entrypoints, inspectable surfaces, lifecycle
+  contract areas, and the limited role of `./internals`.
 - `@automattic/wp-codebox-core/contracts`: command catalog metadata and other
   intentional contract surfaces that are useful to CLI/orchestrator consumers but
   not central enough for the package root.
@@ -240,6 +243,9 @@ Package entrypoints are public surfaces, not implementation buckets:
 
 - `runtime-core/src/index.ts` may define truly central runtime contracts and
   re-export focused contract modules.
+- `runtime-core/src/internals.ts` is exported only for monorepo implementation
+  reuse. Treat it as non-stable unless a helper graduates into a focused public
+  owner module and a stable entrypoint.
 - `runtime-playground/src/index.ts` should stay a thin backend factory/export
   surface.
 - `cli/src/index.ts` may remain the executable command orchestrator, but reusable

--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -1,0 +1,77 @@
+# Public API Contract
+
+WP Codebox has two kinds of API surface: stable public entrypoints for host
+integrations, and monorepo internals for implementation reuse. This document is
+the maintained contract map for package consumers.
+
+## Stable Entry Points
+
+Use these package entrypoints from external integrations:
+
+- `@automattic/wp-codebox-core`: runtime, task/package, runner workspace, tool
+  bridge, browser task/contained-site, artifact metadata, recipe, policy, and
+  provider contract types and helpers.
+- `@automattic/wp-codebox-core/contracts`: command catalog and inspectable
+  contract metadata used by CLI and orchestrator consumers.
+- `@automattic/wp-codebox-core/artifacts`: artifact verification, apply adapter,
+  export-link, diagnostics, and partial-discovery helpers.
+- `@automattic/wp-codebox-core/recipe-builders`: typed recipe construction
+  helpers.
+- `@automattic/wp-codebox-core/agent-task-recipe`: agent-task recipe assembly
+  helpers.
+- `@automattic/wp-codebox-core/runtime-presets`: runtime preset registry helpers.
+- `@automattic/wp-codebox-playground`: the current WordPress Playground runtime
+  backend factory and backend-owned helper types.
+- `@automattic/wp-codebox-cli`: the executable CLI surface for schema, command,
+  recipe, runtime, and artifact operations.
+
+The workspace package mirrors the core entrypoints as `./core`,
+`./core/contracts`, `./core/artifacts`, `./recipe-builders`,
+`./agent-task-recipe`, and `./runtime-presets` for local consumers in this repo.
+
+## Contract Areas
+
+The stable public surface is grouped by lifecycle area rather than by product:
+
+- **Runtime task/package:** task input, agent task recipe, recipe source package,
+  runtime workload, runtime policy, provider runtime, and command result
+  contracts.
+- **Runner workspace:** workspace policy, preload artifact, source-root
+  preparation, mount primitive, and runner workspace publication contracts.
+- **Tool bridge:** host tool registry, managed host command, host command
+  executor, sandbox tool policy, and tool-call artifact contracts.
+- **Browser task and contained site:** browser interaction, callback, probe,
+  review bridge, session origin, artifact lifecycle, result shape, and runtime
+  boundary contracts.
+- **Artifacts:** manifest, paths, capture policy, layout, references, review,
+  diagnostics, test result, export link, storage, result envelope, evidence
+  envelope, and materialization contracts.
+- **Inspect:** command registry metadata, JSON Schema factories, CLI `schema` and
+  `commands` output, and recipe validation descriptors.
+
+When adding a new public type or helper, place it in the focused owner module and
+export it through the narrowest stable entrypoint that matches its lifecycle
+area. Avoid adding implementation helpers to a public barrel only because they
+are convenient for one in-repo caller.
+
+## Internal Entry Point
+
+`@automattic/wp-codebox-core/internals` exists for this monorepo's package split
+and may be used by tests, the CLI, and backend packages in this repository. It is
+not a stable compatibility surface for external integrations. Symbols exported
+only through `./internals` may change or move without a public API migration.
+
+Keep `./internals` intentionally small. If an internal helper becomes useful to
+external consumers, move the consumer-safe contract into the focused public owner
+module, export it from a stable entrypoint, and update this document.
+
+## Stability Rules
+
+- Stable entrypoints may add new exports in minor releases when the names are
+  caller-neutral and match an existing lifecycle area.
+- Existing stable export names, schemas, command ids, and artifact file names need
+  an intentional migration path before incompatible changes.
+- Product-specific orchestration, queues, review UI, deploy policy, scoring, and
+  apply-back decisions remain outside the public runtime contract.
+- The CLI's inspectable outputs (`schema`, `commands`, recipe validation, and
+  artifact verification) are part of the public contract when consumed as JSON.

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",
     "test:php-path-policy-parity": "php scripts/php-path-policy-parity-smoke.php",
     "test:production-boundary-enforcement": "tsx tests/production-boundary-enforcement.test.ts",
+    "test:public-api-contract": "tsx tests/public-api-contract.test.ts",
     "check": "npm run test:production-boundary-enforcement && npm run smoke -- --group=check"
   },
   "workspaces": [

--- a/tests/docs-boundary-language.test.ts
+++ b/tests/docs-boundary-language.test.ts
@@ -15,6 +15,7 @@ const genericContractDocs = [
   "docs/external-apply-adapter-contract.md",
   "docs/agent-fanout-contract.md",
   "docs/agent-runtime-contract.md",
+  "docs/public-api-contract.md",
   "docs/generic-runtime-primitives.md",
   "docs/portable-wp-codebox.md",
   "docs/benchmark-contract.md",

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const root = new URL("..", import.meta.url)
+
+async function readJson(path: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(new URL(path, root), "utf8")) as Record<string, unknown>
+}
+
+function exportKeys(packageJson: Record<string, unknown>): string[] {
+  const exportsField = packageJson.exports
+  assert.ok(exportsField && typeof exportsField === "object" && !Array.isArray(exportsField), "package must declare object exports")
+  return Object.keys(exportsField as Record<string, unknown>)
+}
+
+const rootPackage = await readJson("package.json")
+const corePackage = await readJson("packages/runtime-core/package.json")
+const playgroundPackage = await readJson("packages/runtime-playground/package.json")
+
+assert.deepEqual(exportKeys(rootPackage), [
+  "./core",
+  "./core/contracts",
+  "./core/artifacts",
+  "./core/internals",
+  "./recipe-builders",
+  "./agent-task-recipe",
+  "./runtime-presets",
+  "./playground",
+  "./cli",
+])
+
+assert.deepEqual(exportKeys(corePackage), [
+  ".",
+  "./contracts",
+  "./artifacts",
+  "./internals",
+  "./recipe-builders",
+  "./agent-task-recipe",
+  "./runtime-presets",
+])
+
+assert.deepEqual(exportKeys(playgroundPackage), ["."])
+
+const docs = await readFile(new URL("docs/public-api-contract.md", root), "utf8")
+
+for (const publicEntry of [
+  "@automattic/wp-codebox-core",
+  "@automattic/wp-codebox-core/contracts",
+  "@automattic/wp-codebox-core/artifacts",
+  "@automattic/wp-codebox-core/recipe-builders",
+  "@automattic/wp-codebox-core/agent-task-recipe",
+  "@automattic/wp-codebox-core/runtime-presets",
+  "@automattic/wp-codebox-playground",
+  "@automattic/wp-codebox-cli",
+]) {
+  assert.match(docs, new RegExp(publicEntry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `docs must mention ${publicEntry}`)
+}
+
+for (const contractArea of [
+  "Runtime task/package",
+  "Runner workspace",
+  "Tool bridge",
+  "Browser task and contained site",
+  "Artifacts",
+  "Inspect",
+]) {
+  assert.match(docs, new RegExp(`\\*\\*${contractArea}:\\*\\*`), `docs must define ${contractArea}`)
+}
+
+assert.match(docs, /@automattic\/wp-codebox-core\/internals` exists for this monorepo's package split/)
+assert.match(docs, /not a stable compatibility surface for external integrations/)
+
+console.log("public API contract ok")


### PR DESCRIPTION
## Summary
- Add a public API contract doc defining stable package entrypoints and lifecycle areas for runtime task/package, runner workspace, tool bridge, browser task/contained-site, artifacts, and inspect surfaces.
- Clarify that `@automattic/wp-codebox-core/internals` remains exported for monorepo implementation reuse but is not a stable external compatibility surface.
- Add a focused export/docs guard test and include the new doc in the boundary-language test coverage.

## Tests
- `npm run test:public-api-contract`
- `npm run test:production-boundary-enforcement`
- `npx tsx tests/docs-boundary-language.test.ts`
- `npm run build`
- `npm run check` (fails in existing `scripts/agent-runtime-signal-smoke.ts`: expected `agentPayload.output` to be `"1"`, got `undefined`; reproduced with `npx tsx scripts/agent-runtime-signal-smoke.ts`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the public API contract documentation, adding the focused export-surface test, running verification, and preparing this PR.