### PR TITLE
Add DMC runner workspace backend adapter

### DIFF
--- a/docs/agent-runtime-contract.md
+++ b/docs/agent-runtime-contract.md
@@ -174,15 +174,18 @@ Runner workspace publication is a separate exported contract in runtime-core:
 - `wp-codebox/runner-workspace-command-request/v1`
 - `wp-codebox/runner-workspace-command-result/v1`
 
-External orchestrators own the backend that turns a sandbox result into a durable workspace, branch, commit, PR, package, or other publication target. WP Codebox defines the request/result shapes so callers can exchange workspace identity, changed paths, commit/PR metadata, evidence context, and backend failure information without encoding placement policy in the sandbox runtime.
+External orchestrators own policy around repository selection, authorization, retries, retention, and publication approval. WP Codebox owns the runner workspace boundary and adapts the configured backend into `wp-codebox/prepare`, `wp-codebox/capture`, `wp-codebox/command`, and `wp-codebox/publish`, so callers never import backend ability names.
+
+When no custom `wp_codebox_runner_workspace_backend` filter is supplied, WP Codebox uses the Data Machine Code backend adapter. The adapter maps the Codebox surface to `datamachine-code/workspace-adopt`, `datamachine-code/workspace-show`, `datamachine-code/workspace-clone`, `datamachine-code/workspace-worktree-add`, `datamachine-code/workspace-git-status`, `datamachine-code/workspace-git-diff`, `datamachine-code/publish-runner-workspace`, and `datamachine-code/run-runner-workspace-command`; `datamachine-code/workspace-capabilities` is optional backend capability discovery.
 
 ## Provider Runtime Invocation Names
 
 Runtime-core exports `wp-codebox/provider-runtime-invocation-contract/v1` through `providerRuntimeInvocationContract()`. This gives provider bridges and external orchestrators stable WP Codebox-owned names for common generic runtime operations without importing a caller's ability namespace:
 
-- `wp-codebox.runner-workspace.capture` / `wp-codebox/runner-workspace-capture` for runner workspace status and diff capture.
-- `wp-codebox.runner-workspace.command` / `wp-codebox/runner-workspace-command` for bounded runner workspace commands.
-- `wp-codebox.runner-workspace.publish` / `wp-codebox/runner-workspace-publish` for branch, commit, PR, or equivalent publication handoff.
+- `wp-codebox.runner-workspace.prepare` / `wp-codebox/prepare` for runner workspace preparation.
+- `wp-codebox.runner-workspace.capture` / `wp-codebox/capture` for runner workspace status and diff capture.
+- `wp-codebox.runner-workspace.command` / `wp-codebox/command` for bounded runner workspace commands.
+- `wp-codebox.runner-workspace.publish` / `wp-codebox/publish` for branch, commit, PR, or equivalent publication handoff.
 - `wp-codebox.tool-call-transcript.record` / `wp-codebox/record-tool-call-transcript` for product-neutral tool-call transcript evidence.
 - `wp-codebox.artifact-handoff` / `wp-codebox/handoff-artifacts` for artifact envelope handoff across a trust boundary.
 

--- a/docs/generic-runtime-primitives.md
+++ b/docs/generic-runtime-primitives.md
@@ -172,11 +172,12 @@ is the generic runtime-provider handshake introduced by PR #1205: workspace
 capture, workspace command execution, workspace publication, tool-call transcript
 recording, artifact handoff, and runtime evidence result schemas.
 
-WP Codebox owns the names and schemas. Callers own policy: repository selection,
-authorization, retries, retention, publication approval, and how resulting refs
-are attached to their job records.
+WP Codebox owns the names and schemas. The runner workspace ability surface is
+`wp-codebox/prepare`, `wp-codebox/capture`, `wp-codebox/command`, and
+`wp-codebox/publish`. Callers own policy: repository selection, authorization,
+retries, retention, publication approval, and how resulting refs are attached to
+their job records.
 
-The contract intentionally uses `wp-codebox.runner-workspace.*`,
-`wp-codebox.tool-call-transcript.record`, and `wp-codebox.artifact-handoff`
-names. Downstream product names and orchestration policy stay outside the
-runtime invocation payload.
+The contract intentionally uses WP Codebox task names and short WP Codebox
+ability names. Downstream product names, backend ability names, and
+orchestration policy stay outside the runtime invocation payload.

--- a/packages/runtime-core/src/provider-runtime-contracts.ts
+++ b/packages/runtime-core/src/provider-runtime-contracts.ts
@@ -1,6 +1,7 @@
 export const PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = "wp-codebox/provider-runtime-invocation-contract/v1" as const
 
 export const PROVIDER_RUNTIME_TASK_NAMES = {
+  workspacePrepare: "wp-codebox.runner-workspace.prepare",
   workspaceCapture: "wp-codebox.runner-workspace.capture",
   workspaceCommand: "wp-codebox.runner-workspace.command",
   workspacePublish: "wp-codebox.runner-workspace.publish",
@@ -9,9 +10,10 @@ export const PROVIDER_RUNTIME_TASK_NAMES = {
 } as const
 
 export const PROVIDER_RUNTIME_ABILITY_NAMES = {
-  workspaceCapture: "wp-codebox/runner-workspace-capture",
-  workspaceCommand: "wp-codebox/runner-workspace-command",
-  workspacePublish: "wp-codebox/runner-workspace-publish",
+  workspacePrepare: "wp-codebox/prepare",
+  workspaceCapture: "wp-codebox/capture",
+  workspaceCommand: "wp-codebox/command",
+  workspacePublish: "wp-codebox/publish",
   toolCallTranscriptRecord: "wp-codebox/record-tool-call-transcript",
   artifactHandoff: "wp-codebox/handoff-artifacts",
 } as const
@@ -24,6 +26,7 @@ export interface ProviderRuntimeInvocationContract {
   tasks: Record<ProviderRuntimeContractKey, string>
   abilities: Record<ProviderRuntimeContractKey, string>
   result_schemas: {
+    workspace_prepare: "wp-codebox/runner-workspace-prepare-result/v1"
     workspace_capture: "wp-codebox/runner-workspace-capture-result/v1"
     workspace_command: "wp-codebox/runner-workspace-command-result/v1"
     workspace_publication: "wp-codebox/runner-workspace-publication-result/v1"
@@ -39,6 +42,7 @@ export function providerRuntimeInvocationContract(): ProviderRuntimeInvocationCo
     tasks: { ...PROVIDER_RUNTIME_TASK_NAMES },
     abilities: { ...PROVIDER_RUNTIME_ABILITY_NAMES },
     result_schemas: {
+      workspace_prepare: "wp-codebox/runner-workspace-prepare-result/v1",
       workspace_capture: "wp-codebox/runner-workspace-capture-result/v1",
       workspace_command: "wp-codebox/runner-workspace-command-result/v1",
       workspace_publication: "wp-codebox/runner-workspace-publication-result/v1",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -440,6 +440,20 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/prepare',
+				array(
+					'label'               => 'Prepare Runner Workspace',
+					'description'         => 'Prepare a runner-owned workspace through the WP Codebox runner boundary without exposing backend workspace internals to callers.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_prepare_input_schema(),
+					'output_schema'       => self::runner_workspace_prepare_output_schema(),
+					'execute_callback'    => array( self::class, 'prepare_runner_workspace' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/prepare-runner-workspace',
 				array(
 					'label'               => 'Prepare Runner Workspace',
@@ -448,6 +462,20 @@ final class WP_Codebox_Abilities {
 					'input_schema'        => self::runner_workspace_prepare_input_schema(),
 					'output_schema'       => self::runner_workspace_prepare_output_schema(),
 					'execute_callback'    => array( self::class, 'prepare_runner_workspace' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/publish',
+				array(
+					'label'               => 'Publish Runner Workspace',
+					'description'         => 'Publish runner-owned workspace changes through the WP Codebox runner boundary without exposing backend publication internals to callers.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_publication_input_schema(),
+					'output_schema'       => self::runner_workspace_publication_output_schema(),
+					'execute_callback'    => array( self::class, 'publish_runner_workspace' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
@@ -482,6 +510,20 @@ final class WP_Codebox_Abilities {
 			);
 
 			wp_register_ability(
+				'wp-codebox/capture',
+				array(
+					'label'               => 'Capture Runner Workspace',
+					'description'         => 'Capture runner-owned workspace status and diff metadata through the WP Codebox runner boundary without exposing backend workspace internals to callers.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_capture_input_schema(),
+					'output_schema'       => self::runner_workspace_capture_output_schema(),
+					'execute_callback'    => array( self::class, 'capture_runner_workspace' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
 				'wp-codebox/capture-runner-workspace',
 				array(
 					'label'               => 'Capture Runner Workspace',
@@ -490,6 +532,20 @@ final class WP_Codebox_Abilities {
 					'input_schema'        => self::runner_workspace_capture_input_schema(),
 					'output_schema'       => self::runner_workspace_capture_output_schema(),
 					'execute_callback'    => array( self::class, 'capture_runner_workspace' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/command',
+				array(
+					'label'               => 'Run Runner Workspace Command',
+					'description'         => 'Run a bounded verification or drift-check command against a runner-owned workspace through the WP Codebox runner boundary.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runner_workspace_command_input_schema(),
+					'output_schema'       => self::runner_workspace_command_output_schema(),
+					'execute_callback'    => array( self::class, 'run_runner_workspace_command' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
 					'meta'                => array( 'show_in_rest' => true ),
 				)

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -220,7 +220,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
 				return self::runner_workspace_prepare_failure(
 					'backend_unavailable',
-					array( 'code' => 'wp_codebox_runner_workspace_prepare_backend_unavailable', 'message' => 'Runner workspace backend ability is not available for preparation.', 'ability' => $ability_name ),
+					array( 'code' => 'wp_codebox_runner_workspace_prepare_backend_unavailable', 'message' => 'Runner workspace backend is not available for preparation.', 'backend' => $backend_id ),
 					'unavailable',
 					$normalized
 				);
@@ -565,7 +565,25 @@ trait WP_Codebox_Abilities_Runner_Publication {
 	/** @return array<string,mixed> */
 	private static function runner_workspace_backend_config(): array {
 		$config = function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_runner_workspace_backend', array() ) : array();
-		return is_array( $config ) ? $config : array();
+		if ( is_array( $config ) && ! empty( $config ) ) {
+			return $config;
+		}
+
+		return array(
+			'id'                      => 'data-machine-code',
+			'workspace_root_constant' => 'DATAMACHINE_CODE_WORKSPACE_ROOT',
+			'abilities'               => array(
+				'workspace_adopt'               => 'datamachine-code/workspace-adopt',
+				'workspace_show'                => 'datamachine-code/workspace-show',
+				'workspace_clone'               => 'datamachine-code/workspace-clone',
+				'workspace_worktree_add'        => 'datamachine-code/workspace-worktree-add',
+				'workspace_git_status'          => 'datamachine-code/workspace-git-status',
+				'workspace_git_diff'            => 'datamachine-code/workspace-git-diff',
+				'publish_runner_workspace'      => 'datamachine-code/publish-runner-workspace',
+				'run_runner_workspace_command' => 'datamachine-code/run-runner-workspace-command',
+				'workspace_capabilities'        => 'datamachine-code/workspace-capabilities',
+			),
+		);
 	}
 
 	/** @param array<string,mixed> $error Error shape. @param array<string,mixed> $input Normalized input. @return array<string,mixed> */
@@ -783,8 +801,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'failure_type' => 'backend_unavailable',
 				'error'        => array(
 					'code'    => 'wp_codebox_runner_workspace_backend_unavailable',
-					'message' => 'Runner workspace backend ability is not available for this operation.',
-					'ability' => $ability_name,
+					'message' => 'Runner workspace backend is not available for this operation.',
 				),
 			);
 		}
@@ -797,7 +814,6 @@ trait WP_Codebox_Abilities_Runner_Publication {
 					'code'    => $result->get_error_code(),
 					'message' => $result->get_error_message(),
 					'data'    => $result->get_error_data(),
-					'ability' => $ability_name,
 				),
 			);
 		}
@@ -808,7 +824,6 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'error'        => array(
 					'code'    => 'wp_codebox_runner_workspace_backend_invalid_response',
 					'message' => 'Runner workspace backend ability returned an invalid response.',
-					'ability' => $ability_name,
 				),
 			);
 		}
@@ -816,7 +831,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		if ( false === ( $result['success'] ?? true ) ) {
 			return array(
 				'failure_type' => (string) ( $result['failure_type'] ?? 'backend_failed' ),
-				'error'        => is_array( $result['error'] ?? null ) ? $result['error'] : array( 'message' => (string) ( $result['error'] ?? 'Runner workspace backend operation failed.' ), 'ability' => $ability_name ),
+				'error'        => is_array( $result['error'] ?? null ) ? $result['error'] : array( 'message' => (string) ( $result['error'] ?? 'Runner workspace backend operation failed.' ) ),
 			);
 		}
 

--- a/tests/provider-runtime-contracts.test.ts
+++ b/tests/provider-runtime-contracts.test.ts
@@ -15,10 +15,13 @@ assert.equal(contract.schema, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
 assert.equal(contract.version, 1)
 assert.deepEqual(contract.tasks, PROVIDER_RUNTIME_TASK_NAMES)
 assert.deepEqual(contract.abilities, PROVIDER_RUNTIME_ABILITY_NAMES)
+assert.equal(contract.tasks.workspacePrepare, "wp-codebox.runner-workspace.prepare")
 assert.equal(contract.tasks.workspaceCapture, "wp-codebox.runner-workspace.capture")
-assert.equal(contract.abilities.workspaceCapture, "wp-codebox/runner-workspace-capture")
-assert.equal(contract.abilities.workspaceCommand, "wp-codebox/runner-workspace-command")
-assert.equal(contract.abilities.workspacePublish, "wp-codebox/runner-workspace-publish")
+assert.equal(contract.abilities.workspacePrepare, "wp-codebox/prepare")
+assert.equal(contract.abilities.workspaceCapture, "wp-codebox/capture")
+assert.equal(contract.abilities.workspaceCommand, "wp-codebox/command")
+assert.equal(contract.abilities.workspacePublish, "wp-codebox/publish")
+assert.equal(contract.result_schemas.workspace_prepare, "wp-codebox/runner-workspace-prepare-result/v1")
 assert.equal(contract.result_schemas.workspace_capture, "wp-codebox/runner-workspace-capture-result/v1")
 assert.equal(contract.result_schemas.workspace_command, "wp-codebox/runner-workspace-command-result/v1")
 assert.equal(contract.result_schemas.workspace_publication, "wp-codebox/runner-workspace-publication-result/v1")
@@ -26,9 +29,14 @@ assert.equal(contract.result_schemas.tool_call_transcript, "wp-codebox/tool-call
 assert.equal(contract.result_schemas.evidence_artifact_envelope, "wp-codebox/evidence-artifact-envelope/v1")
 
 const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-abilities.php", "utf8")
+const runnerWorkspacePhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php", "utf8")
 const registeredAbilityIds = [
+  contract.abilities.workspacePrepare,
+  contract.abilities.workspaceCapture,
   contract.abilities.workspaceCommand,
   contract.abilities.workspacePublish,
+  "wp-codebox/prepare-runner-workspace",
+  "wp-codebox/capture-runner-workspace",
   "wp-codebox/run-runner-workspace-command",
   "wp-codebox/publish-runner-workspace",
 ]
@@ -37,10 +45,26 @@ for (const abilityId of registeredAbilityIds) {
   assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", abilityId), new RegExp(`'${abilityId}'`))
 }
 
+assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspacePrepare), /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'prepare_runner_workspace'\s*\)/)
+assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspaceCapture), /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'capture_runner_workspace'\s*\)/)
 assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspaceCommand), /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'run_runner_workspace_command'\s*\)/)
 assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspaceCommand), /'permission_callback'\s*=>\s*array\(\s*self::class,\s*'can_run_agent_task'\s*\)/)
 assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspacePublish), /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'publish_runner_workspace'\s*\)/)
 assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspacePublish), /'permission_callback'\s*=>\s*array\(\s*self::class,\s*'can_run_agent_task'\s*\)/)
+
+for (const backendAbility of [
+  "datamachine-code/workspace-adopt",
+  "datamachine-code/workspace-show",
+  "datamachine-code/workspace-clone",
+  "datamachine-code/workspace-worktree-add",
+  "datamachine-code/workspace-git-status",
+  "datamachine-code/workspace-git-diff",
+  "datamachine-code/publish-runner-workspace",
+  "datamachine-code/run-runner-workspace-command",
+  "datamachine-code/workspace-capabilities",
+]) {
+  assert.match(runnerWorkspacePhp, new RegExp(`'${backendAbility}'`))
+}
 
 const serialized = JSON.stringify(contract)
 assert.doesNotMatch(serialized, /datamachine|data machine|homeboy|wpsg|wp-site-generator|wp site generator/i)


### PR DESCRIPTION
## Summary
- Add short WP Codebox runner workspace ability aliases: `wp-codebox/prepare`, `wp-codebox/capture`, `wp-codebox/command`, and `wp-codebox/publish`.
- Make Data Machine Code the default runner workspace backend adapter when no custom backend filter is supplied.
- Update provider runtime contract/docs/tests so consumers use WP Codebox-owned names, not DMC ability names.

## Tests
- `npm run test:provider-runtime-contracts`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php`
- `npm run build`
- `npm run test:schema-parity`
- `npm run test:primitive-contract-parity`
- `npx tsx tests/docs-boundary-language.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the adapter wiring, updating contracts/docs, and running verification.