### PR TITLE
Add Codebox Agents API adapter facade

### DIFF
--- a/docs/agent-runtime-contract.md
+++ b/docs/agent-runtime-contract.md
@@ -188,6 +188,18 @@ Runtime-core exports `wp-codebox/provider-runtime-invocation-contract/v1` throug
 
 These names are identifiers and contract anchors, not a queue or policy implementation. The corresponding result schemas remain the existing runner workspace, tool-call transcript, and evidence artifact envelope contracts. External orchestrators still own backend placement, authorization, retries, retention, and publication policy.
 
+## Agents API Adapter Boundary
+
+WordPress-hosted WP Codebox consumers should call `WP_Codebox_Agents_API_Adapter` when they need the public Agents API abilities used by Codebox runtime flows. The adapter owns the ability names and execution wrapper for:
+
+- `chat()` -> `agents/chat`.
+- `run_task()` -> `agents/run-task`.
+- `run_runtime_package()` -> `agents/run-runtime-package`.
+- `get_task_run()` / `cancel_task_run()` -> task run-control abilities.
+- `get_chat_run()`, `cancel_chat_run()`, `queue_chat_message()`, and `list_chat_run_events()` -> chat run-control abilities.
+
+This is the Codebox-facing contract. Callers should not import Agents API PHP constants, call handler filters directly, or construct Agents API execution principal classes. Sandbox runtime internals still include a narrow permission bridge for browser Playground runtime principals; that bridge remains private generated code and should not become a consumer API.
+
 ## Heartbeat And Cleanup Metadata
 
 Recipe execution writes run registry records with schema `wp-codebox/run-registry-entry/v1`. The lifecycle block uses `wp-codebox/run-lifecycle/v1` and carries:

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "test:php-managed-host-command": "tsx tests/php-managed-host-command.test.ts",
     "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",
     "test:php-browser-callback-contracts": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-browser-callback-contracts-smoke.php",
+    "test:php-agents-api-adapter-contract": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-agents-api-adapter-contract-smoke.php",
     "test:php-browser-contained-site-contract": "php scripts/php-browser-contained-site-contract-smoke.php",
     "test:php-artifact-import-idempotency": "php scripts/php-artifact-import-idempotency-smoke.php",
     "test:php-browser-runtime-local-package": "php scripts/php-browser-runtime-local-package-smoke.php",

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
@@ -25,15 +25,11 @@ final class WP_Codebox_Agent_Runtime_Invoker {
 	}
 
 	public function is_agents_api_ready(): bool {
-		return $this->is_ability_available( 'agents/chat' );
+		return $this->is_ability_available( WP_Codebox_Agents_API_Adapter::CHAT );
 	}
 
 	public function is_ability_available( string $name ): bool {
-		if ( '' === $name || ! function_exists( 'wp_get_ability' ) ) {
-			return false;
-		}
-
-		return (bool) wp_get_ability( $name );
+		return ( new WP_Codebox_Agents_API_Adapter() )->is_available( $name );
 	}
 
 	/** @param array{url:string,method:string,headers:array<string,string>,body:string} $prepared Prepared request. @return array{url:string,method:string,headers:array<string,string>,body:string}|WP_Error */
@@ -241,6 +237,33 @@ return array(
 );
 }
 
+function wp_codebox_browser_runtime_agents_ability_names(): array {
+return array(
+	'chat' => 'agents/chat',
+	'run_task' => 'agents/run-task',
+	'run_runtime_package' => 'agents/run-runtime-package',
+	'get_task_run' => 'agents/get-task-run',
+	'cancel_task_run' => 'agents/cancel-task-run',
+	'get_chat_run' => 'agents/get-chat-run',
+	'cancel_chat_run' => 'agents/cancel-chat-run',
+	'queue_chat_message' => 'agents/queue-chat-message',
+	'list_chat_run_events' => 'agents/list-chat-run-events',
+);
+}
+
+function wp_codebox_browser_runtime_agents_ability_exists( string $ability_name ): bool {
+return '' !== $ability_name && function_exists( 'wp_get_ability' ) && wp_get_ability( $ability_name ) instanceof WP_Ability;
+}
+
+function wp_codebox_browser_runtime_execute_agents_ability( string $ability_name, array $input ) {
+if ( ! wp_codebox_browser_runtime_agents_ability_exists( $ability_name ) ) {
+	return new WP_Error( 'wp_codebox_browser_ability_unavailable', 'The requested ability is not available inside the Playground site.', array( 'ability' => $ability_name ) );
+}
+
+$ability = wp_get_ability( $ability_name );
+return $ability->execute( $input );
+}
+
 function wp_codebox_browser_runtime_prepare_input( array $payload, array $invocation, string $session_id, array $runtime_tool_declarations, array $ability_tools, array $allowed_tool_ids, array $sandbox_tool_ids ): array {
 $agent = sanitize_key( (string) ( $payload['agent'] ?? 'wp-codebox-sandbox' ) );
 $message = (string) ( $payload['message'] ?? ( $payload['task_input']['goal'] ?? '' ) );
@@ -429,10 +452,9 @@ if ( empty( $preflight['error'] ) && 'task' === $invocation_type ) {
 	}
 }
 if ( empty( $preflight['error'] ) && 'task' !== $invocation_type ) {
-	$ability_name = (string) ( $invocation['name'] ?? 'agents/chat' );
+	$ability_name = (string) ( $invocation['name'] ?? wp_codebox_browser_runtime_agents_ability_names()['chat'] );
 	$preflight['ability'] = $ability_name;
-	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
-	if ( ! $ability instanceof WP_Ability ) {
+	if ( ! wp_codebox_browser_runtime_agents_ability_exists( $ability_name ) ) {
 		$preflight['error'] = new WP_Error( 'wp_codebox_browser_ability_unavailable', 'The requested ability is not available inside the Playground site.', array( 'ability' => $ability_name ) );
 	}
 }
@@ -472,8 +494,7 @@ if ( null === $response ) {
 		if ( 'task' === (string) ( $invocation['type'] ?? 'ability' ) ) {
 			$response = apply_filters( (string) ( $invocation['hook'] ?? $invocation['name'] ?? '' ), null, $input, $payload );
 		} else {
-			$ability = wp_get_ability( (string) ( $invocation['name'] ?? 'agents/chat' ) );
-			$response = $ability->execute( $input );
+			$response = wp_codebox_browser_runtime_execute_agents_ability( (string) ( $invocation['name'] ?? wp_codebox_browser_runtime_agents_ability_names()['chat'] ), $input );
 		}
 	} catch ( Throwable $exception ) {
 		$response = $exception;

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * WP Codebox facade for the Agents API ability boundary.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Codebox-owned wrapper around the public Agents API abilities.
+ *
+ * Consumers should depend on this class instead of importing Agents API constants,
+ * handler names, or execution principal internals.
+ */
+final class WP_Codebox_Agents_API_Adapter {
+
+	public const CHAT                 = 'agents/chat';
+	public const RUN_TASK             = 'agents/run-task';
+	public const RUN_RUNTIME_PACKAGE  = 'agents/run-runtime-package';
+	public const GET_TASK_RUN         = 'agents/get-task-run';
+	public const CANCEL_TASK_RUN      = 'agents/cancel-task-run';
+	public const GET_CHAT_RUN         = 'agents/get-chat-run';
+	public const CANCEL_CHAT_RUN      = 'agents/cancel-chat-run';
+	public const QUEUE_CHAT_MESSAGE   = 'agents/queue-chat-message';
+	public const LIST_CHAT_RUN_EVENTS = 'agents/list-chat-run-events';
+
+	/** @return array<string,string> */
+	public static function ability_names(): array {
+		return array(
+			'chat'                 => self::CHAT,
+			'run_task'             => self::RUN_TASK,
+			'run_runtime_package'  => self::RUN_RUNTIME_PACKAGE,
+			'get_task_run'         => self::GET_TASK_RUN,
+			'cancel_task_run'      => self::CANCEL_TASK_RUN,
+			'get_chat_run'         => self::GET_CHAT_RUN,
+			'cancel_chat_run'      => self::CANCEL_CHAT_RUN,
+			'queue_chat_message'   => self::QUEUE_CHAT_MESSAGE,
+			'list_chat_run_events' => self::LIST_CHAT_RUN_EVENTS,
+		);
+	}
+
+	public function is_available( string $ability_name ): bool {
+		return '' !== $ability_name && function_exists( 'wp_get_ability' ) && (bool) wp_get_ability( $ability_name );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function chat( array $input ): array|WP_Error {
+		return $this->execute( self::CHAT, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function run_task( array $input ): array|WP_Error {
+		return $this->execute( self::RUN_TASK, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function run_runtime_package( array $input ): array|WP_Error {
+		return $this->execute( self::RUN_RUNTIME_PACKAGE, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function get_task_run( array $input ): array|WP_Error {
+		return $this->execute( self::GET_TASK_RUN, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function cancel_task_run( array $input ): array|WP_Error {
+		return $this->execute( self::CANCEL_TASK_RUN, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function get_chat_run( array $input ): array|WP_Error {
+		return $this->execute( self::GET_CHAT_RUN, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function cancel_chat_run( array $input ): array|WP_Error {
+		return $this->execute( self::CANCEL_CHAT_RUN, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function queue_chat_message( array $input ): array|WP_Error {
+		return $this->execute( self::QUEUE_CHAT_MESSAGE, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function list_chat_run_events( array $input ): array|WP_Error {
+		return $this->execute( self::LIST_CHAT_RUN_EVENTS, $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function execute( string $ability_name, array $input ): array|WP_Error {
+		if ( '' === $ability_name || ! function_exists( 'wp_get_ability' ) ) {
+			return new WP_Error( 'wp_codebox_agents_api_unavailable', 'The Agents API ability registry is unavailable.', array( 'status' => 500, 'ability' => $ability_name ) );
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability || ! method_exists( $ability, 'execute' ) ) {
+			return new WP_Error( 'wp_codebox_agents_api_ability_unavailable', 'The requested Agents API ability is unavailable.', array( 'status' => 500, 'ability' => $ability_name ) );
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( ! is_array( $result ) ) {
+			return new WP_Error( 'wp_codebox_agents_api_invalid_result', 'The requested Agents API ability returned an invalid result.', array( 'status' => 500, 'ability' => $ability_name ) );
+		}
+
+		return $result;
+	}
+}

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -156,7 +156,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'result_path' => '/tmp/wp-codebox-browser-result.json',
 				'invocation'  => array(
 					'type' => 'ability',
-					'name' => 'agents/chat',
+					'name' => class_exists( 'WP_Codebox_Agents_API_Adapter' ) ? WP_Codebox_Agents_API_Adapter::CHAT : 'agents/chat',
 				),
 			),
 		);

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -117,7 +117,7 @@ private static function browser_runner_invocation( array $runner ): array|WP_Err
 	$name = trim( (string) ( $invocation['name'] ?? '' ) );
 	$hook = trim( (string) ( $invocation['hook'] ?? $name ) );
 	if ( 'ability' === $type ) {
-		$name = '' !== $name ? $name : 'agents/chat';
+		$name = '' !== $name ? $name : ( class_exists( 'WP_Codebox_Agents_API_Adapter' ) ? WP_Codebox_Agents_API_Adapter::CHAT : 'agents/chat' );
 		if ( ! preg_match( '#^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$#', $name ) ) {
 			return new WP_Error( 'wp_codebox_browser_invocation_name_invalid', 'Browser runner ability names must use namespace/name form.', array( 'status' => 400 ) );
 		}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -45,6 +45,7 @@ require_once __DIR__ . '/src/class-wp-codebox-run-plan.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-process-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-run-result-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-outcome-classifier.php';
+require_once __DIR__ . '/src/class-wp-codebox-agents-api-adapter.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-runtime-invoker.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-provider-bridge.php';

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['wp_codebox_test_abilities'] = array();
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function wp_get_ability( string $name ): ?WP_Ability {
+	return $GLOBALS['wp_codebox_test_abilities'][ $name ] ?? null;
+}
+
+final class WP_Error {
+	public function __construct( private string $code, private string $message, private array $data = array() ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): array { return $this->data; }
+}
+
+final class WP_Ability {
+	/** @param array<string,mixed> $result */
+	public function __construct( private array $result = array( 'success' => true ) ) {}
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public function execute( array $input ): array {
+		return array_merge( $this->result, array( 'received' => $input ) );
+	}
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php';
+
+$names = WP_Codebox_Agents_API_Adapter::ability_names();
+assert( 'agents/chat' === $names['chat'] );
+assert( 'agents/run-task' === $names['run_task'] );
+assert( 'agents/run-runtime-package' === $names['run_runtime_package'] );
+assert( 'agents/get-task-run' === $names['get_task_run'] );
+assert( 'agents/get-chat-run' === $names['get_chat_run'] );
+
+$adapter = new WP_Codebox_Agents_API_Adapter();
+assert( false === $adapter->is_available( WP_Codebox_Agents_API_Adapter::CHAT ) );
+
+$GLOBALS['wp_codebox_test_abilities'][ WP_Codebox_Agents_API_Adapter::CHAT ]                = new WP_Ability( array( 'schema' => 'agents-api/chat-result/v1' ) );
+$GLOBALS['wp_codebox_test_abilities'][ WP_Codebox_Agents_API_Adapter::RUN_TASK ]            = new WP_Ability( array( 'schema' => 'agents-api/task-result/v1' ) );
+$GLOBALS['wp_codebox_test_abilities'][ WP_Codebox_Agents_API_Adapter::RUN_RUNTIME_PACKAGE ] = new WP_Ability( array( 'schema' => 'agents-api/runtime-package-result/v1' ) );
+$GLOBALS['wp_codebox_test_abilities'][ WP_Codebox_Agents_API_Adapter::GET_TASK_RUN ]        = new WP_Ability( array( 'status' => 'running' ) );
+$GLOBALS['wp_codebox_test_abilities'][ WP_Codebox_Agents_API_Adapter::GET_CHAT_RUN ]        = new WP_Ability( array( 'status' => 'running' ) );
+
+assert( true === $adapter->is_available( WP_Codebox_Agents_API_Adapter::CHAT ) );
+assert( 'agents-api/chat-result/v1' === $adapter->chat( array( 'message' => 'hello' ) )['schema'] );
+assert( 'agents-api/task-result/v1' === $adapter->run_task( array( 'goal' => 'ship' ) )['schema'] );
+assert( 'agents-api/runtime-package-result/v1' === $adapter->run_runtime_package( array( 'package' => array() ) )['schema'] );
+assert( 'running' === $adapter->get_task_run( array( 'run_id' => 'task-run', 'session_id' => 'session' ) )['status'] );
+assert( 'running' === $adapter->get_chat_run( array( 'run_id' => 'chat-run', 'session_id' => 'session' ) )['status'] );
+
+$missing = $adapter->cancel_task_run( array( 'run_id' => 'task-run', 'session_id' => 'session' ) );
+assert( is_wp_error( $missing ) );
+assert( 'wp_codebox_agents_api_ability_unavailable' === $missing->get_error_code() );

--- a/tests/browser-runner-template.test.ts
+++ b/tests/browser-runner-template.test.ts
@@ -65,6 +65,7 @@ echo json_encode( array(
 		'capture_schema' => str_contains( $runner_php, 'wp-codebox/browser-capture/v1' ),
 		'provider_request_schema' => str_contains( $runner_php, 'wp-codebox/browser-provider-proxy-request/v1' ),
 		'result_schema' => str_contains( $runner_php, 'wp-codebox/browser-materialization/v1' ),
+		'agents_adapter_helper' => str_contains( $runner_php, 'function wp_codebox_browser_runtime_execute_agents_ability' ),
 		'contract_markers' => str_contains( $runner_php, 'WP_CODEBOX_BROWSER_RUNNER_BODY_START' ) && str_contains( $runner_php, 'WP_CODEBOX_BROWSER_RUNNER_BODY_END' ),
 	),
 ) );
@@ -76,7 +77,7 @@ echo json_encode( array(
 assert.equal(php.status, 0, php.stderr)
 const result = JSON.parse(php.stdout)
 
-assert.equal(result.sha256, "acfadba3cee573c68ea65b6a9c5853388ab333eeecf7880ef0177e66b07fe866")
+assert.equal(result.sha256, "999e30b8b12ff090afcce235f46625233d2179a540f5fd13d0d34453e0852fda")
 assert.deepEqual(result.function_counts, {
   event_sink: 1,
   capture_file: 1,
@@ -88,6 +89,7 @@ assert.deepEqual(result.contains, {
   capture_schema: true,
   provider_request_schema: true,
   result_schema: true,
+  agents_adapter_helper: true,
   contract_markers: true,
 })
 


### PR DESCRIPTION
## Summary
- Add `WP_Codebox_Agents_API_Adapter` as the Codebox-owned facade for public Agents API abilities: chat, task execution, runtime package execution, and run-control calls.
- Route host readiness checks and generated browser-runtime ability execution through the Codebox boundary helpers instead of scattered direct `wp_get_ability()` calls.
- Document the adapter boundary and add PHP smoke coverage for the facade contract plus generated runner contract coverage for the new helper.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php`
- `npm run test:php-agents-api-adapter-contract`
- `npm run test:browser-task-builder`
- `npm run test:runtime-php-snippets`
- `npm run check` reached `agent-runtime-signal-smoke` and failed before this adapter path while booting WordPress Playground CLI with Node `ERR_INPUT_TYPE_NOT_ALLOWED` from the Playground worker process.

## Notes
- The browser Playground runtime still contains a private runtime-principal permission bridge because removing the Agents API principal internals safely needs a deeper runtime contract change. This PR establishes the public adapter boundary and documents that callers should not consume those internals.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the adapter facade, tests, documentation, verification, and PR preparation.