### PR TITLE
Enforce Codebox public boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ What you can build on top of WP Codebox:
 - **Agentic coding against a WordPress site.** Let users describe a change in chat — from any host: a WordPress plugin, a mobile app, a desktop tool, a Slack/Discord bot. Dispatch a sandbox with the target site's stack mounted, capture an artifact with a live Playground preview URL, then let the parent control plane review, apply, and open any PR. The contributor never needs shell access.
 - **Agent training and evaluation.** Run the same WordPress task side by side across multiple models in isolated Playground workspaces. Capture each model's output, grade against hidden quality checks, and produce per-model review artifacts. Example implementation: [wp-gym](https://github.com/Automattic/wp-gym).
 - **Long-running terrariums.** Boot a Playground that an agent evolves over time — software, content, configuration — with day-cycle automation driven from CI. See [world-of-wordpress](https://github.com/chubes4/world-of-wordpress).
-- **Static-site / WordPress-import factories.** Generate raw HTML/CSS sites in CI, validate them via Playground + WordPress import, post Playground preview links as PR evidence. See [wp-site-generator](https://github.com/chubes4/wp-site-generator).
+- **Static-site / WordPress-import factories.** Generate raw HTML/CSS sites in CI, validate them via Playground + WordPress import, and post Playground preview links as PR evidence.
 - **Untrusted patch evaluation.** Plugin and theme authors can accept community-submitted patches, run them in a sandbox, capture artifacts (diffs, test results, screenshots), and review before merging. The reviewing tool can be anything.
 - **"Try it in a sandbox first."** Before installing a plugin, theme, or update on a production site, run it in a disposable Playground and see what happens.
 - **Reproduction harness for bug reports.** Ship a recipe with an issue so any contributor can replay the bug deterministically in a clean WordPress instance. The replay can be triggered from a CLI, a CI job, or a maintainer's IDE plugin.
@@ -87,9 +87,9 @@ result outside the sandbox.
 ## Host Tool Registry
 
 `HostToolRegistry` is a WP Codebox transport adapter, not a generic tool
-contract. Agents API owns canonical tool declarations, tool calls, execution
-results, pending external-tool states, and product-neutral runtime metadata.
-The caller owns the concrete tool sources and product policy.
+contract. The caller owns the canonical tool declarations, concrete tool
+sources, execution result semantics, pending external-tool states, runtime
+metadata, and product policy.
 WP Codebox only exposes caller-provided per-run tool declarations to sandbox
 agents, routes allowed calls across the browser/host boundary, and records
 transport diagnostics.
@@ -154,12 +154,13 @@ const result = await runtime.execute({
 Host tool output is a Codebox transport diagnostic envelope with schema
 `wp-codebox/host-tool-result/v1`. Successful calls return `status: "ok"`, an
 `output` value validated against the transport output schema, and `toolResult`
-using the canonical Agents API result shape: `success`, `tool_name`, `result`,
-`metadata`, and optional `runtime`. Invalid input, invalid output, malformed
-JSON, and handler failures return `status: "error"` with a stable transport error
-code while `toolResult` maps the same failure to a canonical tool error. The
-`diagnostics` object is the Codebox-owned portion of the envelope and preserves
-the transport, policy command, validation schemas, and resolved policy metadata.
+using the caller's canonical tool result shape: `success`, `tool_name`,
+`result`, `metadata`, and optional `runtime`. Invalid input, invalid output,
+malformed JSON, and handler failures return `status: "error"` with a stable
+transport error code while `toolResult` maps the same failure to a canonical
+tool error. The `diagnostics` object is the Codebox-owned portion of the
+envelope and preserves the transport, policy command, validation schemas, and
+resolved policy metadata.
 
 Product-specific tools such as evidence commands should live in product
 extensions that provide canonical tool declarations and handlers through this

--- a/docs/portable-wp-codebox.md
+++ b/docs/portable-wp-codebox.md
@@ -17,7 +17,7 @@ WordPress Playground is the first backend because it provides a cheap, portable,
 ## Boundary
 
 - **Parent control planes** own operator, CI, and evidence workflows.
-- **Agents API** owns agent identity, sessions, tools, and run loops.
+- **Caller agent layers** own agent identity, sessions, tools, and run loops.
 - **WP AI Client** owns model/provider prompt execution.
 - **Connectors API** owns external service auth and credential configuration.
 - **WP Codebox** owns isolated environments, mounts, execution policy, observations, snapshots, and artifacts.

--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -319,10 +319,8 @@ drive your own UI: `click`/`hover`/`fill`/`type`/`select`/`drag` to interact,
 Keep `steps-json` inline (not `@file`) if it contains an `evaluate` step so the
 recipe auto-grants the `wordpress.browser-actions.evaluate` policy capability.
 
-A worked, plugin-specific consumer of this capability — driving the
-[data-machine-socials](https://github.com/Extra-Chill/data-machine-socials)
-`react-easy-crop` modal under React 19 — lives in that plugin's own repository,
-where the recipe sits next to the code it guards.
+A worked plugin-specific consumer of this capability can live in the target
+plugin's own repository, where the recipe sits next to the code it guards.
 
 ### `woocommerce-store.json`
 

--- a/packages/cli/src/recipe-backend-package.ts
+++ b/packages/cli/src/recipe-backend-package.ts
@@ -3,7 +3,6 @@ import { readFile, stat } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import type { RuntimeBackendFactoryContext, RuntimeBackendKind, WorkspaceRecipe, WorkspaceRecipeRuntimeBackendPackage } from "@automattic/wp-codebox-core"
-import type { PlaygroundCliModule } from "@automattic/wp-codebox-playground"
 
 export interface RuntimeBackendPackageProvenance {
   schema: "wp-codebox/runtime-backend-package/v1"
@@ -43,6 +42,10 @@ interface PreparedRuntimeBackendPackageAdapterResult {
 interface RuntimeBackendPackageAdapter {
   readonly backendKind: RuntimeBackendKind
   prepare(loadedPackage: LoadedRuntimeBackendPackage): PreparedRuntimeBackendPackageAdapterResult
+}
+
+interface RuntimeCliEntrypointModule {
+  runCLI(args: string[]): unknown
 }
 
 class RuntimeBackendPackageAdapterRegistry {
@@ -85,7 +88,7 @@ const playgroundRuntimeBackendPackageAdapter: RuntimeBackendPackageAdapter = {
     }
 
     return {
-      runtimeBackendContext: { cliModule: module as PlaygroundCliModule },
+      runtimeBackendContext: { cliModule: module as RuntimeCliEntrypointModule },
       diagnostics: [{ status: "passed", message: "Entrypoint exports runCLI" }],
     }
   },
@@ -216,7 +219,7 @@ async function importBackendEntrypoint(backendPackage: WorkspaceRecipeRuntimeBac
   }
 }
 
-function isPlaygroundCliModule(value: unknown): value is PlaygroundCliModule {
+function isPlaygroundCliModule(value: unknown): value is RuntimeCliEntrypointModule {
   return Boolean(value && typeof value === "object" && "runCLI" in value && typeof (value as { runCLI?: unknown }).runCLI === "function")
 }
 

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -7,8 +7,6 @@ export { createHostCommandTool, type HostCommandToolConfig } from "./host-comman
 export { PlaygroundRuntimeBackend, createPlaygroundRuntimeBackend, playgroundRuntimeBackendProvider } from "./playground-runtime.js"
 export { preflightPhpWasmRuntimeAssets, PhpWasmRuntimeAssetIntegrityError, type PhpWasmRuntimeAssetPreflight, type PhpWasmRuntimeAssetPreflightOptions } from "./php-wasm-preflight.js"
 export { browserPreviewAuthCookieUrls, browserPreviewNetworkPolicySummary, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, browserPreviewTopology, browserPreviewOrigins, resolveBrowserPreviewUrl, type BrowserPreviewNetworkPolicy, type BrowserPreviewTopology } from "./browser-preview-routing.js"
-export { assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer, type PlaygroundPreviewProxyDiagnostics, type PlaygroundPreviewRouteHandler, type PlaygroundPreviewRouteRegistry } from "./preview-server.js"
 export { applyVfsMountSnapshots, materializePlaygroundMountsFromVfs, type HostMountSnapshot, type MountMaterializationResult, type VfsMountSnapshot } from "./mount-materialization.js"
 export { buildReplayExportBlueprint, buildReplayableWordPressSiteBlueprint, buildReplayableWordPressSiteLimitations, writeReplayExportPackage, writeReplayableWordPressSiteBundle, type ReplayExportPackage, type ReplayExportPackageOptions, type ReplayableWordPressSiteBundle, type ReplayableWordPressSiteBundleManifest, type ReplayableWordPressSiteBundleOptions } from "./replayable-wordpress-site-bundle.js"
 export type { RuntimeSnapshotArtifact } from "./runtime-snapshot.js"
-export type { PlaygroundCliModule } from "./playground-cli-runner.js"

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -270,9 +270,8 @@ plane.
 
 Sandbox-safe tool abilities should be an explicit allow-list:
 
-- Workspace read/list/search/edit primitives: `datamachine/workspace-read`,
-  `datamachine/workspace-ls`, `datamachine/workspace-grep`,
-  `datamachine/workspace-write`, and `datamachine/workspace-edit`.
+- Workspace read/list/search/edit primitives supplied by the mounted coding
+  tools component.
 - Read-only GitHub context primitives: issue, PR, PR file, check/status, tree,
   file, and repo list/get abilities.
 

--- a/tests/production-boundary-enforcement.test.ts
+++ b/tests/production-boundary-enforcement.test.ts
@@ -5,6 +5,16 @@ import { join, relative } from "node:path"
 const root = new URL("..", import.meta.url)
 const packagesDir = new URL("../packages/", import.meta.url)
 const productionExtensions = new Set([".cjs", ".js", ".json", ".jsx", ".mjs", ".php", ".ts", ".tsx"])
+const publicDocPaths = [
+  "README.md",
+  "docs/README.md",
+  "docs/portable-wp-codebox.md",
+  "packages/cli/README.md",
+  "packages/wordpress-plugin/README.md",
+  "examples/simple-plugin/README.md",
+  "examples/agent-runtime/README.md",
+  "examples/recipes/cookbook/README.md",
+]
 const forbiddenTerms = [
   /datamachine/i,
   /data machine/i,
@@ -14,6 +24,18 @@ const forbiddenTerms = [
   /\bwpsg\b/i,
   /wp-site-generator/i,
   /wp site generator/i,
+]
+const forbiddenPublicSurfaceTerms = [
+  ...forbiddenTerms,
+  /agents api/i,
+  /data machine code/i,
+]
+const forbiddenPublicExportTargets = [
+  /preview-server\.js$/,
+  /playground-cli-runner\.js$/,
+]
+const forbiddenPublicImportSpecifiers = [
+  /@wp-playground\//,
 ]
 
 async function productionFiles(dir: URL): Promise<string[]> {
@@ -51,6 +73,45 @@ for (const file of await productionFiles(packagesDir)) {
   }
 }
 
+for (const rel of publicDocPaths) {
+  const source = await readFile(new URL(`../${rel}`, import.meta.url), "utf8")
+  for (const term of forbiddenPublicSurfaceTerms) {
+    if (term.test(source)) {
+      violations.push(`${rel} exposes ${term} in public documentation`)
+    }
+  }
+}
+
+for (const manifest of await packageManifests(packagesDir)) {
+  const source = JSON.parse(await readFile(manifest, "utf8")) as { name?: string; exports?: unknown; dependencies?: Record<string, string> }
+  const rel = relative(root.pathname, manifest)
+
+  for (const target of exportTargets(source.exports)) {
+    for (const forbidden of forbiddenPublicExportTargets) {
+      if (forbidden.test(target)) {
+        violations.push(`${rel} exports internal runtime target ${target}`)
+      }
+    }
+  }
+
+  for (const dependency of Object.keys(source.dependencies ?? {})) {
+    if (source.name !== "@automattic/wp-codebox-playground" && forbiddenPublicImportSpecifiers.some((forbidden) => forbidden.test(dependency))) {
+      violations.push(`${rel} depends on backend-internal package ${dependency}`)
+    }
+  }
+}
+
+for (const rel of ["packages/runtime-core/src/index.ts", "packages/runtime-playground/src/index.ts", "packages/cli/src/index.ts"]) {
+  const source = await readFile(new URL(`../${rel}`, import.meta.url), "utf8")
+  for (const target of exportedModuleSpecifiers(source)) {
+    for (const forbidden of forbiddenPublicExportTargets) {
+      if (forbidden.test(target)) {
+        violations.push(`${rel} re-exports backend-internal module ${target}`)
+      }
+    }
+  }
+}
+
 assert.deepEqual(
   violations,
   [],
@@ -58,3 +119,26 @@ assert.deepEqual(
 )
 
 console.log("production boundary enforcement passed")
+
+async function packageManifests(dir: URL): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const manifests: string[] = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    manifests.push(new URL(`${entry.name}/package.json`, dir).pathname)
+  }
+
+  return manifests
+}
+
+function exportTargets(exportsField: unknown): string[] {
+  if (typeof exportsField === "string") return [exportsField]
+  if (!exportsField || typeof exportsField !== "object") return []
+
+  return Object.values(exportsField as Record<string, unknown>).flatMap(exportTargets)
+}
+
+function exportedModuleSpecifiers(source: string): string[] {
+  return [...source.matchAll(/export\s+(?:type\s+)?(?:\{[^}]*\}|\*)\s+from\s+["']([^"']+)["']/g)].map((match) => match[1] ?? "")
+}


### PR DESCRIPTION
## Summary
- Extend production boundary enforcement to cover public docs, package export targets, public barrel re-exports, and backend-internal dependencies.
- Remove existing consumer-facing references to downstream/internal products from public docs.
- Stop re-exporting Playground preview-server/playground-cli-runner internals from the public playground package barrel and replace the CLI structural type import with a local shape.

## Tests
- `npm run test:production-boundary-enforcement`
- `npm run build`
- `npm run check` fails in existing `scripts/agent-runtime-signal-smoke.ts` with `undefined !== '1'` after earlier checks pass; rerunning that smoke directly reproduces the same failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing boundary enforcement tests/docs, local verification, and PR preparation.