### PR TITLE
Add artifact diagnostics result helpers

### DIFF
--- a/packages/runtime-core/src/artifact-diagnostics.ts
+++ b/packages/runtime-core/src/artifact-diagnostics.ts
@@ -1,5 +1,7 @@
 import { stripUndefined } from "./object-utils.js"
 
+export const ARTIFACT_DIAGNOSTICS_SCHEMA = "wp-codebox/artifact-diagnostics/v1" as const
+
 export type ArtifactDiagnosticSeverity = "error" | "warning" | "notice" | "info" | (string & {})
 
 export interface ArtifactDiagnosticRef {
@@ -26,7 +28,7 @@ export interface ArtifactDiagnostic {
 }
 
 export interface ArtifactDiagnostics {
-  schema: "wp-codebox/artifact-diagnostics/v1"
+  schema: typeof ARTIFACT_DIAGNOSTICS_SCHEMA
   status: "clean" | "reported"
   summary: {
     total: number
@@ -50,6 +52,26 @@ export interface ArtifactDiagnosticNormalizerOptions {
 export function buildArtifactDiagnostics(input: unknown, options: ArtifactDiagnosticNormalizerOptions = {}): ArtifactDiagnostics {
   const observations = Array.isArray(input) ? input : [input]
   const diagnostics = observations.flatMap((observation, observationIndex) => diagnosticsFromArtifactObservation(observation, observationIndex, options))
+
+  return artifactDiagnosticsEnvelope(diagnostics)
+}
+
+export function normalizeArtifactDiagnostics(input: unknown, options: ArtifactDiagnosticNormalizerOptions = {}): ArtifactDiagnostics {
+  const record = input && typeof input === "object" && !Array.isArray(input) ? input as Record<string, unknown> : undefined
+  if (record?.schema !== ARTIFACT_DIAGNOSTICS_SCHEMA) {
+    return buildArtifactDiagnostics(input, options)
+  }
+
+  return artifactDiagnosticsEnvelope(arrayPayload(record.diagnostics)
+    .map((value, index) => normalizeArtifactDiagnostic(value, record, 0, index, options))
+    .filter((diagnostic): diagnostic is ArtifactDiagnostic => diagnostic !== null))
+}
+
+export function isArtifactDiagnostics(input: unknown): input is ArtifactDiagnostics {
+  return Boolean(input && typeof input === "object" && !Array.isArray(input) && (input as Record<string, unknown>).schema === ARTIFACT_DIAGNOSTICS_SCHEMA)
+}
+
+function artifactDiagnosticsEnvelope(diagnostics: ArtifactDiagnostic[]): ArtifactDiagnostics {
   const summary = {
     total: diagnostics.length,
     error: diagnostics.filter((diagnostic) => diagnostic.severity === "error").length,
@@ -59,7 +81,7 @@ export function buildArtifactDiagnostics(input: unknown, options: ArtifactDiagno
   }
 
   return {
-    schema: "wp-codebox/artifact-diagnostics/v1",
+    schema: ARTIFACT_DIAGNOSTICS_SCHEMA,
     status: diagnostics.length > 0 ? "reported" : "clean",
     summary,
     diagnostics,
@@ -101,7 +123,8 @@ function normalizeArtifactDiagnostic(raw: unknown, observation: Record<string, u
   const value = raw as Record<string, unknown>
   const type = stringField(value.type) || stringField(value.kind) || stringField(value.code) || stringField(value.reason_code) || "diagnostic"
   const message = stringField(value.message) || stringField(value.summary) || stringField(value.reason) || stringField(value.excerpt) || stringField(value.error_message) || type
-  const details = stripUndefined(Object.fromEntries(Object.entries(value).filter(([key]) => ![
+  const explicitDetails = value.details && typeof value.details === "object" && !Array.isArray(value.details) ? value.details as Record<string, unknown> : undefined
+  const extraDetails = stripUndefined(Object.fromEntries(Object.entries(value).filter(([key]) => ![
     "id",
     "diagnostic_id",
     "type",
@@ -123,7 +146,14 @@ function normalizeArtifactDiagnostic(raw: unknown, observation: Record<string, u
     "refs",
     "references",
     "artifactRefs",
+    "provenance",
+    "details",
   ].includes(key))))
+  const details = stripUndefined({
+    ...explicitDetails,
+    ...extraDetails,
+  })
+  const provenance = value.provenance && typeof value.provenance === "object" && !Array.isArray(value.provenance) ? value.provenance as Record<string, unknown> : {}
 
   return stripUndefined({
     id: stringField(value.id) || stringField(value.diagnostic_id) || `${stringField(observation.id) ?? `observation-${observationIndex}`}-diagnostic-${diagnosticIndex + 1}`,
@@ -140,6 +170,7 @@ function normalizeArtifactDiagnostic(raw: unknown, observation: Record<string, u
       observationId: stringField(observation.id),
       observationType: stringField(observation.type) || options.observationType,
       observedAt: stringField(observation.observedAt),
+      ...provenance,
     }),
     refs: artifactDiagnosticRefs(value.refs ?? value.references ?? value.artifactRefs, options.refs),
     details: Object.keys(details).length > 0 ? details : undefined,

--- a/packages/runtime-core/src/artifact-result-envelope.ts
+++ b/packages/runtime-core/src/artifact-result-envelope.ts
@@ -1,4 +1,5 @@
 import type { MaterializationArtifactRef, MaterializationDiagnostic } from "./materialization-contracts.js"
+import { buildArtifactDiagnostics, type ArtifactDiagnosticNormalizerOptions, type ArtifactDiagnostics } from "./artifact-diagnostics.js"
 
 export const ARTIFACT_RESULT_ENVELOPE_SCHEMA = "wp-codebox/artifact-result-envelope/v1" as const
 
@@ -40,6 +41,37 @@ export interface SkippedArtifactResultEnvelope extends ArtifactResultEnvelopeBas
 }
 
 export type ArtifactResultEnvelope = SuccessfulArtifactResultEnvelope | FailedArtifactResultEnvelope | SkippedArtifactResultEnvelope
+
+export function artifactDiagnosticsResultEnvelope(input: {
+  operation: ArtifactResultOperation
+  status?: ArtifactResultStatus
+  diagnosticsInput: unknown
+  diagnosticOptions?: ArtifactDiagnosticNormalizerOptions
+  artifactBundle?: MaterializationArtifactRef
+  artifactRefs?: MaterializationArtifactRef[]
+  verification?: Record<string, unknown>
+  result?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+  error?: { name?: string; message?: string; code?: string } | Error | string
+  reason?: string
+}): ArtifactResultEnvelope {
+  const artifactDiagnostics = buildArtifactDiagnostics(input.diagnosticsInput, input.diagnosticOptions)
+  return artifactResultEnvelope({
+    operation: input.operation,
+    status: input.status,
+    artifactBundle: input.artifactBundle,
+    artifactRefs: input.artifactRefs,
+    verification: input.verification,
+    result: stripUndefined({
+      ...input.result,
+      artifactDiagnostics,
+    }),
+    diagnostics: artifactDiagnosticsResultDiagnostics(artifactDiagnostics),
+    metadata: input.metadata,
+    error: input.error,
+    reason: input.reason,
+  })
+}
 
 export function artifactResultEnvelope(input: {
   operation: ArtifactResultOperation
@@ -133,6 +165,19 @@ function normalizeArtifactRefs(refs: MaterializationArtifactRef[]): Materializat
     normalized.push(ref)
   }
   return normalized
+}
+
+function artifactDiagnosticsResultDiagnostics(artifactDiagnostics: ArtifactDiagnostics): MaterializationDiagnostic[] {
+  if (artifactDiagnostics.summary.total === 0) {
+    return []
+  }
+
+  return [{
+    code: "wp-codebox.artifact-diagnostics.reported",
+    message: `${artifactDiagnostics.summary.total} artifact diagnostic${artifactDiagnostics.summary.total === 1 ? "" : "s"} reported.`,
+    severity: artifactDiagnostics.summary.error > 0 ? "error" : artifactDiagnostics.summary.warning > 0 ? "warning" : "info",
+    metadata: { summary: artifactDiagnostics.summary },
+  }]
 }
 
 function materializationArtifactRef(input: unknown): MaterializationArtifactRef | undefined {

--- a/scripts/artifact-diagnostics-normalizer-smoke.ts
+++ b/scripts/artifact-diagnostics-normalizer-smoke.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
-import { buildArtifactDiagnostics } from "@automattic/wp-codebox-core/artifacts"
+import { ARTIFACT_DIAGNOSTICS_SCHEMA, artifactDiagnosticsResultEnvelope, buildArtifactDiagnostics, isArtifactDiagnostics, normalizeArtifactDiagnostics } from "@automattic/wp-codebox-core/artifacts"
 
 const execFileAsync = promisify(execFile)
 const directory = await mkdtemp(join(tmpdir(), "wp-codebox-artifact-diagnostics-"))
@@ -39,7 +39,8 @@ try {
     refs: [{ path: "import-report.json", kind: "static-site-importer/import-report" }],
   })
 
-  assert.equal(direct.schema, "wp-codebox/artifact-diagnostics/v1")
+  assert.equal(direct.schema, ARTIFACT_DIAGNOSTICS_SCHEMA)
+  assert.equal(isArtifactDiagnostics(direct), true)
   assert.equal(direct.status, "reported")
   assert.deepEqual(direct.summary, { total: 2, error: 0, warning: 1, notice: 1, info: 0 })
   assert.equal(direct.diagnostics[0]?.id, "fallback-1")
@@ -52,6 +53,24 @@ try {
   assert.equal(direct.diagnostics[0]?.details?.blockName, "core/html")
   assert.equal(direct.diagnostics[1]?.message, "Image file is missing.")
   assert.equal(direct.diagnostics[1]?.severity, "warning")
+
+  const renormalized = normalizeArtifactDiagnostics(direct)
+  assert.deepEqual(renormalized.summary, direct.summary)
+  assert.deepEqual(renormalized.diagnostics, direct.diagnostics)
+
+  const resultEnvelope = artifactDiagnosticsResultEnvelope({
+    operation: "static-site-import",
+    diagnosticsInput: importReport,
+    diagnosticOptions: {
+      source: "static-site-importer",
+      stage: "import",
+      refs: [{ path: "import-report.json", kind: "static-site-importer/import-report" }],
+    },
+    artifactRefs: [{ kind: "static-site-importer/import-report", path: "import-report.json" }],
+  })
+  assert.equal(resultEnvelope.success, true)
+  assert.equal(resultEnvelope.result?.artifactDiagnostics?.schema, ARTIFACT_DIAGNOSTICS_SCHEMA)
+  assert.equal(resultEnvelope.diagnostics[0]?.code, "wp-codebox.artifact-diagnostics.reported")
 
   const observation = buildArtifactDiagnostics([
     {


### PR DESCRIPTION
## Summary
- Add a public artifact diagnostics schema constant, type guard, and normalization helper.
- Add an artifact diagnostics result-envelope helper that embeds normalized diagnostics and summarizes them as materialization diagnostics.
- Extend the artifact diagnostics smoke coverage for the public artifacts boundary helpers.

## Tests
- npm run build
- npm run smoke -- --group=artifact
- npm run test:public-api-contract

## Known issues
- Public API contract mismatch observed before rebasing this stale worktree: root package exports included ./cli/recipe-secret-env while the stale test expected list did not. After rebasing onto latest origin/main, npm run test:public-api-contract passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Finalizing the existing worktree, verification, commit, and PR description.