### PR TITLE
Add provider credential boundary

### DIFF
--- a/docs/provider-credential-boundary.md
+++ b/docs/provider-credential-boundary.md
@@ -1,0 +1,81 @@
+# Provider Credential Boundary
+
+WP Codebox exposes a generic provider credential lane so products can ask for a
+provider/model without knowing the provider's raw credential storage, token
+shape, refresh policy, or scoped authorization rules.
+
+Provider-owned code declares requirements with
+`wp_codebox_provider_credential_requirements` and resolves availability with
+`wp_codebox_resolve_provider_credentials`. Both contracts are redacted. WP
+Codebox accepts env var names and status diagnostics only; it never accepts,
+prints, persists, or serializes secret values through these contracts.
+
+```php
+add_filter( 'wp_codebox_provider_credential_requirements', function ( $requirements, $selection ) {
+	if ( 'example-provider' !== ( $selection['provider'] ?? '' ) ) {
+		return $requirements;
+	}
+
+	$requirements['requirements'][] = array(
+		'name'       => 'primary_api_token',
+		'kind'       => 'api-token',
+		'scope'      => 'sandbox-agent',
+		'required'   => true,
+		'secret_env' => array( 'EXAMPLE_PROVIDER_TOKEN' ),
+	);
+
+	return $requirements;
+}, 10, 2 );
+
+add_filter( 'wp_codebox_resolve_provider_credentials', function ( $preflight, $requirements ) {
+	if ( 'example-provider' !== ( $requirements['provider'] ?? '' ) ) {
+		return $preflight;
+	}
+
+	$preflight['status']     = getenv( 'EXAMPLE_PROVIDER_TOKEN' ) ? 'available' : 'missing';
+	$preflight['secret_env'] = array( 'EXAMPLE_PROVIDER_TOKEN' );
+	$preflight['diagnostics'][] = array(
+		'code'     => 'example-token-env',
+		'severity' => 'info',
+		'message'  => 'Credential resolved through provider-owned env mapping.',
+	);
+
+	return $preflight;
+}, 10, 2 );
+```
+
+Resolved runtime metadata uses `wp-codebox/provider-credential-resolution/v1`:
+
+```json
+{
+  "schema": "wp-codebox/provider-credential-resolution/v1",
+  "requirements": {
+    "schema": "wp-codebox/provider-credential-requirements/v1",
+    "provider": "example-provider",
+    "requirements": [
+      { "name": "primary_api_token", "required": true, "kind": "api-token", "scope": "sandbox-agent", "secretEnv": ["EXAMPLE_PROVIDER_TOKEN"] }
+    ],
+    "redacted": true
+  },
+  "preflight": {
+    "schema": "wp-codebox/provider-credential-preflight/v1",
+    "provider": "example-provider",
+    "status": "available",
+    "secret_env": ["EXAMPLE_PROVIDER_TOKEN"],
+    "diagnostics": [],
+    "redacted": true
+  },
+  "secret_env": ["EXAMPLE_PROVIDER_TOKEN"],
+  "redacted": true
+}
+```
+
+Contract rules:
+
+- `available` allows the sandbox to proceed and merges declared env names into
+  the sandbox secret-env allowlist.
+- `missing` and `denied` fail closed before sandbox launch.
+- `not-required` is the default when no provider requirement hook participates.
+- Diagnostics should describe requirement names, scopes, and safe status only.
+- Raw values stay in provider-owned storage or process env and are never part of
+  requirement, preflight, runtime plan, artifact, or log output.

--- a/package.json
+++ b/package.json
@@ -131,9 +131,9 @@
     "test:distribution-startup-probes": "tsx tests/distribution-startup-probes.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",
     "test:php-path-policy-parity": "php scripts/php-path-policy-parity-smoke.php",
+    "test:php-provider-credential-boundary": "php scripts/php-provider-credential-boundary-smoke.php",
     "test:production-boundary-enforcement": "tsx tests/production-boundary-enforcement.test.ts",
     "test:public-api-contract": "tsx tests/public-api-contract.test.ts",
-    "test:parent-tool-bridge-contract": "tsx tests/parent-tool-bridge-contract.test.ts",
     "test:browser-sdk-facade": "tsx tests/browser-sdk-facade.test.ts",
     "check": "npm run test:production-boundary-enforcement && npm run smoke -- --group=check"
   },

--- a/packages/runtime-core/src/provider-runtime-contracts.ts
+++ b/packages/runtime-core/src/provider-runtime-contracts.ts
@@ -1,4 +1,7 @@
 export const PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA = "wp-codebox/provider-runtime-invocation-contract/v1" as const
+export const PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA = "wp-codebox/provider-credential-requirements/v1" as const
+export const PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA = "wp-codebox/provider-credential-preflight/v1" as const
+export const PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA = "wp-codebox/provider-credential-resolution/v1" as const
 
 export const PROVIDER_RUNTIME_TASK_NAMES = {
   workspacePrepare: "wp-codebox.runner-workspace.prepare",
@@ -33,6 +36,44 @@ export interface ProviderRuntimeInvocationContract {
     tool_call_transcript: "wp-codebox/tool-call-transcript/v1"
     evidence_artifact_envelope: "wp-codebox/evidence-artifact-envelope/v1"
   }
+}
+
+export type ProviderCredentialStatus = "available" | "missing" | "denied" | "not-required"
+
+export interface ProviderCredentialRequirement {
+  name: string
+  required: boolean
+  kind?: string
+  scope?: string
+  source?: string
+  secretEnv?: string[]
+}
+
+export interface ProviderCredentialRequirementsContract {
+  schema: typeof PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA
+  provider: string
+  model?: string
+  requirements: ProviderCredentialRequirement[]
+  redacted: true
+}
+
+export interface ProviderCredentialPreflightContract {
+  schema: typeof PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA
+  provider: string
+  model?: string
+  status: ProviderCredentialStatus
+  requirements: ProviderCredentialRequirement[]
+  secret_env: string[]
+  diagnostics: Array<{ code?: string; severity?: "info" | "warning" | "error"; message?: string }>
+  redacted: true
+}
+
+export interface ProviderCredentialResolutionContract {
+  schema: typeof PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA
+  requirements: ProviderCredentialRequirementsContract
+  preflight: ProviderCredentialPreflightContract
+  secret_env: string[]
+  redacted: true
 }
 
 export function providerRuntimeInvocationContract(): ProviderRuntimeInvocationContract {

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -105,6 +105,17 @@ environment and are not accepted in the ability payload. For example, pass
 `"secret_env": ["GITHUB_TOKEN"]` after the host process has `GITHUB_TOKEN` in
 its environment; do not pass token values through ability input.
 
+Provider plugins can also own their credential boundary through the generic
+credential hooks. `wp_codebox_provider_credential_requirements` returns a
+redacted `wp-codebox/provider-credential-requirements/v1` declaration for the
+selected provider/model, and `wp_codebox_resolve_provider_credentials` returns a
+redacted `wp-codebox/provider-credential-preflight/v1` status plus the env var
+names WP Codebox may expose. WP Codebox fails closed on `missing` or `denied`,
+merges only allowed env names into `secret_env`, and records only redacted
+requirements/preflight diagnostics in the runtime dependency plan. Hook results
+must not include raw token values; fields such as `secret_env_values`,
+`credentials`, or provider-specific token payloads are ignored by this boundary.
+
 Callers may also pass an `inherit` declaration to request parent-environment
 connectors or settings by name:
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-provider-credentials.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-provider-credentials.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Generic provider credential boundary contracts.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Provider_Credentials {
+	public const REQUIREMENTS_SCHEMA = 'wp-codebox/provider-credential-requirements/v1';
+	public const PREFLIGHT_SCHEMA    = 'wp-codebox/provider-credential-preflight/v1';
+
+	/** @param array<string,mixed> $selection Provider/model/runtime selection metadata. @param array<string,mixed> $input Ability input. @param array<string,mixed> $inheritance Sanitized inheritance metadata. @return array<string,mixed>|WP_Error */
+	public static function resolve( array $selection, array $input = array(), array $inheritance = array() ): array|WP_Error {
+		$requirements = self::requirements( $selection, $input, $inheritance );
+		$preflight    = self::preflight( $requirements, $selection, $input, $inheritance );
+		if ( in_array( (string) ( $preflight['status'] ?? '' ), array( 'missing', 'denied' ), true ) ) {
+			return new WP_Error( 'wp_codebox_provider_credentials_unavailable', 'Provider credentials are missing or denied for this sandbox scope.', array( 'status' => 403, 'schema' => self::PREFLIGHT_SCHEMA, 'preflight' => $preflight ) );
+		}
+
+		return array(
+			'requirements' => $requirements,
+			'preflight'    => $preflight,
+			'secret_env'   => self::secret_env_names( $preflight ),
+		);
+	}
+
+	/** @param array<string,mixed> $selection Provider/model/runtime selection metadata. @param array<string,mixed> $input Ability input. @param array<string,mixed> $inheritance Sanitized inheritance metadata. @return array<string,mixed> */
+	public static function requirements( array $selection, array $input = array(), array $inheritance = array() ): array {
+		$requirements = array(
+			'schema'       => self::REQUIREMENTS_SCHEMA,
+			'provider'     => self::safe_slug( $selection['provider'] ?? '' ),
+			'model'        => self::safe_label( $selection['model'] ?? '' ),
+			'requirements' => array(),
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'wp_codebox_provider_credential_requirements', $requirements, $selection, $input, $inheritance );
+			if ( is_array( $filtered ) ) {
+				$requirements = $filtered;
+			}
+		}
+
+		return self::sanitize_requirements( $requirements, $selection );
+	}
+
+	/** @param array<string,mixed> $requirements Redacted requirement contract. @param array<string,mixed> $selection Provider/model/runtime selection metadata. @param array<string,mixed> $input Ability input. @param array<string,mixed> $inheritance Sanitized inheritance metadata. @return array<string,mixed> */
+	public static function preflight( array $requirements, array $selection, array $input = array(), array $inheritance = array() ): array {
+		$preflight = array(
+			'schema'       => self::PREFLIGHT_SCHEMA,
+			'provider'     => self::safe_slug( $selection['provider'] ?? $requirements['provider'] ?? '' ),
+			'model'        => self::safe_label( $selection['model'] ?? $requirements['model'] ?? '' ),
+			'status'       => self::has_required_requirements( $requirements ) ? 'missing' : 'not-required',
+			'requirements' => $requirements['requirements'] ?? array(),
+			'secret_env'   => array(),
+			'diagnostics'  => array(),
+			'redacted'     => true,
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'wp_codebox_resolve_provider_credentials', $preflight, $requirements, $selection, $input, $inheritance );
+			if ( is_array( $filtered ) ) {
+				$preflight = $filtered;
+			}
+		}
+
+		return self::sanitize_preflight( $preflight, $requirements, $selection );
+	}
+
+	/** @param array<string,mixed> $preflight Sanitized preflight contract. @return string[] */
+	public static function secret_env_names( array $preflight ): array {
+		return self::env_names( $preflight['secret_env'] ?? array() );
+	}
+
+	/** @param array<string,mixed> $requirements Raw requirements. @param array<string,mixed> $selection Provider/model/runtime selection metadata. @return array<string,mixed> */
+	private static function sanitize_requirements( array $requirements, array $selection ): array {
+		$entries = array();
+		foreach ( is_array( $requirements['requirements'] ?? null ) ? $requirements['requirements'] : array() as $requirement ) {
+			if ( ! is_array( $requirement ) ) {
+				continue;
+			}
+			$name = self::safe_key( $requirement['name'] ?? '' );
+			if ( '' === $name ) {
+				continue;
+			}
+
+			$entry = array(
+				'name'     => $name,
+				'required' => array_key_exists( 'required', $requirement ) ? (bool) $requirement['required'] : true,
+			);
+			foreach ( array( 'kind', 'scope', 'source' ) as $field ) {
+				$value = self::safe_label( $requirement[ $field ] ?? '' );
+				if ( '' !== $value ) {
+					$entry[ $field ] = $value;
+				}
+			}
+			$env = self::env_names( $requirement['secret_env'] ?? $requirement['secretEnv'] ?? array() );
+			if ( ! empty( $env ) ) {
+				$entry['secretEnv'] = $env;
+			}
+
+			$entries[] = $entry;
+		}
+
+		return array(
+			'schema'       => self::REQUIREMENTS_SCHEMA,
+			'provider'     => self::safe_slug( $selection['provider'] ?? $requirements['provider'] ?? '' ),
+			'model'        => self::safe_label( $selection['model'] ?? $requirements['model'] ?? '' ),
+			'requirements' => $entries,
+			'redacted'     => true,
+		);
+	}
+
+	/** @param array<string,mixed> $preflight Raw preflight. @param array<string,mixed> $requirements Sanitized requirements. @param array<string,mixed> $selection Provider/model/runtime selection metadata. @return array<string,mixed> */
+	private static function sanitize_preflight( array $preflight, array $requirements, array $selection ): array {
+		$status = self::status( (string) ( $preflight['status'] ?? '' ), ! self::has_required_requirements( $requirements ) );
+		return array(
+			'schema'       => self::PREFLIGHT_SCHEMA,
+			'provider'     => self::safe_slug( $selection['provider'] ?? $preflight['provider'] ?? $requirements['provider'] ?? '' ),
+			'model'        => self::safe_label( $selection['model'] ?? $preflight['model'] ?? $requirements['model'] ?? '' ),
+			'status'       => $status,
+			'requirements' => is_array( $requirements['requirements'] ?? null ) ? $requirements['requirements'] : array(),
+			'secret_env'   => self::env_names( $preflight['secret_env'] ?? $preflight['secretEnv'] ?? array() ),
+			'diagnostics'  => self::diagnostics( $preflight['diagnostics'] ?? array() ),
+			'redacted'     => true,
+		);
+	}
+
+	private static function status( string $status, bool $empty_requirements ): string {
+		if ( in_array( $status, array( 'available', 'missing', 'denied', 'not-required' ), true ) ) {
+			return $status;
+		}
+
+		return $empty_requirements ? 'not-required' : 'missing';
+	}
+
+	/** @param array<string,mixed> $requirements Sanitized requirements. */
+	private static function has_required_requirements( array $requirements ): bool {
+		foreach ( is_array( $requirements['requirements'] ?? null ) ? $requirements['requirements'] : array() as $requirement ) {
+			if ( is_array( $requirement ) && (bool) ( $requirement['required'] ?? true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/** @return array<int,array<string,string>> */
+	private static function diagnostics( mixed $diagnostics ): array {
+		$entries = array();
+		foreach ( is_array( $diagnostics ) ? $diagnostics : array() as $diagnostic ) {
+			if ( ! is_array( $diagnostic ) ) {
+				continue;
+			}
+			$code    = self::safe_key( $diagnostic['code'] ?? '' );
+			$message = self::safe_reason( $diagnostic['message'] ?? '' );
+			if ( '' === $code && '' === $message ) {
+				continue;
+			}
+
+			$entry = array();
+			if ( '' !== $code ) {
+				$entry['code'] = $code;
+			}
+			if ( '' !== $message ) {
+				$entry['message'] = $message;
+			}
+			$severity = self::safe_key( $diagnostic['severity'] ?? '' );
+			if ( in_array( $severity, array( 'info', 'warning', 'error' ), true ) ) {
+				$entry['severity'] = $severity;
+			}
+			$entries[] = $entry;
+		}
+
+		return $entries;
+	}
+
+	/** @return string[] */
+	private static function env_names( mixed $value ): array {
+		$names = array();
+		foreach ( WP_Codebox_Agent_Task::string_list( $value ) as $name ) {
+			if ( 1 === preg_match( '/^[A-Z_][A-Z0-9_]*$/', $name ) ) {
+				$names[] = $name;
+			}
+		}
+
+		return array_values( array_unique( $names ) );
+	}
+
+	private static function safe_slug( mixed $value ): string {
+		return substr( preg_replace( '/[^A-Za-z0-9_.:-]/', '', trim( (string) $value ) ) ?? '', 0, 120 );
+	}
+
+	private static function safe_key( mixed $value ): string {
+		return substr( preg_replace( '/[^A-Za-z0-9_.:-]/', '', trim( (string) $value ) ) ?? '', 0, 120 );
+	}
+
+	private static function safe_label( mixed $value ): string {
+		return substr( preg_replace( '/[^A-Za-z0-9 ._:@\/-]/', '', trim( (string) $value ) ) ?? '', 0, 160 );
+	}
+
+	private static function safe_reason( mixed $value ): string {
+		return substr( preg_replace( '/[^A-Za-z0-9 .,:_@\/-]/', '', trim( (string) $value ) ) ?? '', 0, 240 );
+	}
+}

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
@@ -225,13 +225,19 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 			return array();
 		}
 
-		$preflight = is_array( $value['preflight'] ?? null ) ? $value['preflight'] : array();
+		$requirements = is_array( $value['requirements'] ?? null ) ? $value['requirements'] : array();
+		$preflight    = is_array( $value['preflight'] ?? null ) ? $value['preflight'] : array();
+		$secret_env   = self::secret_env_list( $value['secret_env'] ?? $preflight['secret_env'] ?? array() );
+		if ( empty( $requirements ) && empty( $preflight ) && empty( $secret_env ) ) {
+			return array();
+		}
+
 		return array_filter(
 			array(
 				'schema'       => 'wp-codebox/provider-credential-resolution/v1',
-				'requirements' => is_array( $value['requirements'] ?? null ) ? $value['requirements'] : array(),
+				'requirements' => $requirements,
 				'preflight'    => $preflight,
-				'secret_env'   => self::secret_env_list( $value['secret_env'] ?? $preflight['secret_env'] ?? array() ),
+				'secret_env'   => $secret_env,
 				'redacted'     => true,
 			),
 			static fn( mixed $entry ): bool => array() !== $entry && '' !== $entry

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
@@ -39,6 +39,9 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 	/** @var array<string,string> */
 	private array $runtime_env;
 
+	/** @var array<string,mixed> */
+	private array $provider_credentials;
+
 	/**
 	 * @param array<string,mixed> $selection Provider/model/runtime selection metadata.
 	 * @param string[] $provider_plugin_paths Resolved provider plugin paths.
@@ -50,8 +53,9 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 	 * @param array<int,array<string,mixed>> $agent_bundles Agent bundle import specs.
 	 * @param string[] $secret_env_names Required secret env names.
 	 * @param array<string,mixed> $runtime_env Non-secret runtime environment values.
+	 * @param array<string,mixed> $provider_credentials Redacted provider credential resolution metadata.
 	 */
-	public function __construct( array $selection, array $provider_plugin_paths, array $provider_plugins, array $component_plugins, array $runtime_overlays, array $inheritance, array $inheritance_request, array $agent_bundles, array $secret_env_names, array $runtime_env = array() ) {
+	public function __construct( array $selection, array $provider_plugin_paths, array $provider_plugins, array $component_plugins, array $runtime_overlays, array $inheritance, array $inheritance_request, array $agent_bundles, array $secret_env_names, array $runtime_env = array(), array $provider_credentials = array() ) {
 		$this->selection             = $selection;
 		$this->provider_plugin_paths = self::string_list( $provider_plugin_paths );
 		$this->provider_plugins      = array_values( array_filter( $provider_plugins, 'is_array' ) );
@@ -68,6 +72,7 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 		$this->agent_bundles         = array_values( array_filter( $agent_bundles, 'is_array' ) );
 		$this->secret_env_names      = self::secret_env_list( $secret_env_names );
 		$this->runtime_env           = self::runtime_env_map( $runtime_env );
+		$this->provider_credentials  = self::normalize_provider_credentials( $provider_credentials );
 	}
 
 	/** @return array<string,mixed> */
@@ -133,6 +138,11 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 		return $this->runtime_env;
 	}
 
+	/** @return array<string,mixed> */
+	public function provider_credentials(): array {
+		return $this->provider_credentials;
+	}
+
 	/** @param array<string,string> $defaults @return array<string,string> */
 	public function runtime_env_with_defaults( array $defaults ): array {
 		return array_merge( $this->runtime_env, self::runtime_env_map( $defaults ) );
@@ -168,6 +178,7 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 				'agent_bundles'         => $this->agent_bundles,
 				'secret_env'            => $this->secret_env_names,
 				'runtime_env'           => $this->runtime_env,
+				'provider_credentials'  => $this->provider_credentials,
 			),
 			static fn( mixed $value ): bool => array() !== $value && '' !== $value
 		);
@@ -206,5 +217,24 @@ final class WP_Codebox_Runtime_Dependency_Plan {
 		}
 
 		return $env;
+	}
+
+	/** @return array<string,mixed> */
+	private static function normalize_provider_credentials( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$preflight = is_array( $value['preflight'] ?? null ) ? $value['preflight'] : array();
+		return array_filter(
+			array(
+				'schema'       => 'wp-codebox/provider-credential-resolution/v1',
+				'requirements' => is_array( $value['requirements'] ?? null ) ? $value['requirements'] : array(),
+				'preflight'    => $preflight,
+				'secret_env'   => self::secret_env_list( $value['secret_env'] ?? $preflight['secret_env'] ?? array() ),
+				'redacted'     => true,
+			),
+			static fn( mixed $entry ): bool => array() !== $entry && '' !== $entry
+		);
 	}
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -32,8 +32,16 @@ private static function browser_inheritance_resolution_payload( array $input ): 
 
 /** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed>|WP_Error */
 private static function browser_input_with_inheritance( array $input, array $inheritance ): array|WP_Error {
+	$provider_credentials = self::browser_provider_credentials( $input, $inheritance );
+	if ( is_wp_error( $provider_credentials ) ) {
+		return $provider_credentials;
+	}
+
 	$input['provider_plugin_paths'] = array_values( array_unique( array_merge( self::browser_provider_plugin_paths( $input ), self::browser_inheritance_provider_plugin_paths( $inheritance ) ) ) );
-	$input['secret_env']            = array_values( array_unique( array_merge( self::browser_secret_env_names( $input ), self::browser_inheritance_secret_env_names( $inheritance ) ) ) );
+	$input['secret_env']            = array_values( array_unique( array_merge( self::browser_secret_env_names( $input ), self::browser_inheritance_secret_env_names( $inheritance ), self::string_list( $provider_credentials['secret_env'] ?? array() ) ) ) );
+	if ( ! empty( $provider_credentials ) ) {
+		$input['_wp_codebox_provider_credentials'] = $provider_credentials;
+	}
 	if ( class_exists( 'WP_Codebox_Runtime_Profile_Resolver' ) ) {
 		$resolved = WP_Codebox_Runtime_Profile_Resolver::apply_to_input( $input, $inheritance );
 		if ( is_wp_error( $resolved ) ) {
@@ -86,8 +94,29 @@ private static function browser_runtime_dependency_plan( array $input, array $in
 		self::browser_inheritance_request( $input ),
 		self::normalize_agent_bundles( $input['agent_bundles'] ?? array() ),
 		self::browser_secret_env_names( $input ),
-		self::browser_runtime_env( $input )
+		self::browser_runtime_env( $input ),
+		is_array( $input['_wp_codebox_provider_credentials'] ?? null ) ? $input['_wp_codebox_provider_credentials'] : self::browser_provider_credentials_fallback( $input, $inheritance )
 	);
+}
+
+/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed>|WP_Error */
+private static function browser_provider_credentials( array $input, array $inheritance ): array|WP_Error {
+	return WP_Codebox_Provider_Credentials::resolve(
+		array(
+			'agent'    => self::browser_agent_slug( $input ),
+			'mode'     => self::browser_mode( $input ),
+			'provider' => self::browser_provider( $input, $inheritance ),
+			'model'    => self::browser_model( $input, $inheritance ),
+		),
+		$input,
+		$inheritance
+	);
+}
+
+/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed> */
+private static function browser_provider_credentials_fallback( array $input, array $inheritance ): array {
+	$resolved = self::browser_provider_credentials( $input, $inheritance );
+	return is_wp_error( $resolved ) ? array() : $resolved;
 }
 
 /** @param array<string,mixed> $input Ability input. */

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -20,11 +20,11 @@ define( 'WP_CODEBOX_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WP_CODEBOX_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 require_once __DIR__ . '/src/class-wp-codebox-task-input-contract.php';
-require_once __DIR__ . '/src/class-wp-codebox-parent-tool-bridge-contract.php';
 require_once __DIR__ . '/src/class-wp-codebox-runtime-tool-policy-descriptor.php';
 require_once __DIR__ . '/src/class-wp-codebox-sandbox-tool-policy-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-path-policy.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-task.php';
+require_once __DIR__ . '/src/class-wp-codebox-provider-credentials.php';
 require_once __DIR__ . '/src/class-wp-codebox-runtime-dependency-plan.php';
 require_once __DIR__ . '/src/class-wp-codebox-runtime-profile-resolver.php';
 require_once __DIR__ . '/src/class-wp-codebox-runtime-recipe-resolver.php';

--- a/scripts/php-provider-credential-boundary-smoke.php
+++ b/scripts/php-provider-credential-boundary-smoke.php
@@ -1,0 +1,106 @@
+<?php
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	private string $code;
+	private mixed $data;
+
+	public function __construct( string $code, string $message = '', mixed $data = null ) {
+		$this->code = $code;
+		$this->data = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+$GLOBALS['wp_codebox_test_filters'] = array();
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['wp_codebox_test_filters'][ $hook ][] = array( $callback, $accepted_args );
+}
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array() as $entry ) {
+		$value = $entry[0]( ...array_slice( array_merge( array( $value ), $args ), 0, $entry[1] ) );
+	}
+	return $value;
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-provider-credentials.php';
+
+add_filter(
+	'wp_codebox_provider_credential_requirements',
+	static function ( array $requirements ): array {
+		$requirements['provider']       = 'example-provider';
+		$requirements['requirements'][] = array(
+			'name'              => 'primary token',
+			'kind'              => 'api-token',
+			'scope'             => 'sandbox',
+			'required'          => true,
+			'secret_env_values' => array( 'EXAMPLE_PROVIDER_TOKEN' => 'do-not-serialize' ),
+			'secret_env'        => array( 'EXAMPLE_PROVIDER_TOKEN', 'bad-name' ),
+		);
+		return $requirements;
+	},
+	10,
+	1
+);
+
+add_filter(
+	'wp_codebox_resolve_provider_credentials',
+	static function ( array $preflight ): array {
+		$preflight['status']            = 'available';
+		$preflight['secret_env']        = array( 'EXAMPLE_PROVIDER_TOKEN' );
+		$preflight['secret_env_values'] = array( 'EXAMPLE_PROVIDER_TOKEN' => 'do-not-serialize' );
+		$preflight['credentials']       = array( 'token' => 'do-not-serialize' );
+		$preflight['diagnostics'][]     = array( 'code' => 'ok', 'severity' => 'info', 'message' => 'Resolved through provider-owned mapping.' );
+		return $preflight;
+	},
+	10,
+	1
+);
+
+$resolved = WP_Codebox_Provider_Credentials::resolve( array( 'provider' => 'example-provider', 'model' => 'example-model' ) );
+if ( is_wp_error( $resolved ) ) {
+	fwrite( STDERR, "Expected provider credentials to resolve.\n" );
+	exit( 1 );
+}
+
+$serialized = json_encode( $resolved );
+if ( ! is_string( $serialized ) || str_contains( $serialized, 'do-not-serialize' ) || str_contains( $serialized, 'secret_env_values' ) || str_contains( $serialized, 'credentials' ) ) {
+	fwrite( STDERR, "Provider credential contract leaked secret-shaped fields.\n" );
+	exit( 1 );
+}
+
+if ( array( 'EXAMPLE_PROVIDER_TOKEN' ) !== ( $resolved['secret_env'] ?? null ) ) {
+	fwrite( STDERR, "Provider credential env name resolution failed.\n" );
+	exit( 1 );
+}
+
+$GLOBALS['wp_codebox_test_filters'] = array();
+add_filter(
+	'wp_codebox_provider_credential_requirements',
+	static function ( array $requirements ): array {
+		$requirements['requirements'][] = array( 'name' => 'primary_token', 'required' => true );
+		return $requirements;
+	},
+	10,
+	1
+);
+
+$missing = WP_Codebox_Provider_Credentials::resolve( array( 'provider' => 'example-provider' ) );
+if ( ! is_wp_error( $missing ) || 'wp_codebox_provider_credentials_unavailable' !== $missing->get_error_code() ) {
+	fwrite( STDERR, "Expected provider credential preflight to fail closed.\n" );
+	exit( 1 );
+}
+
+echo "provider credential boundary ok\n";

--- a/tests/provider-runtime-contracts.test.ts
+++ b/tests/provider-runtime-contracts.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 
 import {
+  PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA,
+  PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA,
+  PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA,
   PROVIDER_RUNTIME_ABILITY_NAMES,
   PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
   PROVIDER_RUNTIME_TASK_NAMES,
@@ -27,9 +30,35 @@ assert.equal(contract.result_schemas.workspace_command, "wp-codebox/runner-works
 assert.equal(contract.result_schemas.workspace_publication, "wp-codebox/runner-workspace-publication-result/v1")
 assert.equal(contract.result_schemas.tool_call_transcript, "wp-codebox/tool-call-transcript/v1")
 assert.equal(contract.result_schemas.evidence_artifact_envelope, "wp-codebox/evidence-artifact-envelope/v1")
+assert.equal(PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA, "wp-codebox/provider-credential-requirements/v1")
+assert.equal(PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA, "wp-codebox/provider-credential-preflight/v1")
+assert.equal(PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA, "wp-codebox/provider-credential-resolution/v1")
+
+const credentialResolution = {
+  schema: PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA,
+  requirements: {
+    schema: PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA,
+    provider: "example-provider",
+    requirements: [{ name: "primary_api_token", required: true, kind: "api-token", secretEnv: ["EXAMPLE_PROVIDER_TOKEN"] }],
+    redacted: true,
+  },
+  preflight: {
+    schema: PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA,
+    provider: "example-provider",
+    status: "available",
+    requirements: [{ name: "primary_api_token", required: true, kind: "api-token", secretEnv: ["EXAMPLE_PROVIDER_TOKEN"] }],
+    secret_env: ["EXAMPLE_PROVIDER_TOKEN"],
+    diagnostics: [{ code: "resolved", severity: "info", message: "Credential resolved by provider-owned boundary." }],
+    redacted: true,
+  },
+  secret_env: ["EXAMPLE_PROVIDER_TOKEN"],
+  redacted: true,
+}
+assert.doesNotMatch(JSON.stringify(credentialResolution), /token-value|secret_env_values|credentials/i)
 
 const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-abilities.php", "utf8")
 const runnerWorkspacePhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php", "utf8")
+const providerCredentialsPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-provider-credentials.php", "utf8")
 const registeredAbilityIds = [
   contract.abilities.workspacePrepare,
   contract.abilities.workspaceCapture,
@@ -53,6 +82,9 @@ assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilitie
 assert.match(phpCallBlock(abilitiesPhp, "wp_register_ability", contract.abilities.workspacePublish), /'permission_callback'\s*=>\s*array\(\s*self::class,\s*'can_run_agent_task'\s*\)/)
 
 assert.match(runnerWorkspacePhp, /apply_filters\(\s*'wp_codebox_runner_workspace_backend'/)
+assert.match(providerCredentialsPhp, /wp_codebox_provider_credential_requirements/)
+assert.match(providerCredentialsPhp, /wp_codebox_resolve_provider_credentials/)
+assert.doesNotMatch(providerCredentialsPhp, /secret_env_values|access_token|refresh_token/i)
 assert.doesNotMatch(runnerWorkspacePhp, /datamachine|data machine|homeboy|wpsg|wp-site-generator|wp site generator/i)
 
 const serialized = JSON.stringify(contract)


### PR DESCRIPTION
## Summary
- Add generic provider credential requirement, preflight, and resolution contracts.
- Resolve provider-owned credential availability through redacted hooks and merge only allowed env var names into `secret_env`.
- Fail closed for missing or denied required credentials and omit empty credential metadata from runtime dependency plans.

## Stack
- Stacked on #1278 because full production-boundary checks rely on the parent-tool-bridge cleanup that moves Data Machine-specific runtime profiles out of Codebox core defaults.

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-provider-credentials.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
- npm run test:php-provider-credential-boundary
- npm run test:provider-runtime-contracts
- npm run build
- npm run check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the code, tests, and documentation changes.