### PR TITLE
Add case artifact manifest primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,40 @@ Artifact bundle ids are content-addressed for the apply-back contract. The runti
 
 Every `manifest.files[]` entry also carries `sha256: { "algorithm": "sha256", "value": "..." }`. For regular files, `value` is the SHA-256 of that artifact file's bytes. For `manifest.json`, `value` is a canonical self-hash over the parsed manifest with the manifest entry's own hash replaced by 64 zeroes, using the `wp-codebox/artifact-manifest-self/v1` domain separator. `wp-codebox artifacts verify` rejects missing hashes and mismatched hashes for any declared file, so tampering with replay-critical or supporting artifacts is detected even when the top-level content digest inputs are unchanged.
 
+Scenario and fuzz-style workflows can add optional case-level indexes under
+`manifest.cases[]` without introducing a dedicated runner contract. Each case
+has a stable `id`, optional `hash` or `digest`, `artifacts[]` refs with
+bundle-relative paths and optional SHA-256 values, redaction metadata, and
+verification metadata such as `status`, `verifiedAt`, and `verifier`:
+
+```json
+{
+  "cases": [
+    {
+      "id": "case-1",
+      "hash": { "algorithm": "sha256", "value": "..." },
+      "artifacts": [
+        {
+          "path": "files/cases/case-1.json",
+          "kind": "case-result",
+          "contentType": "application/json",
+          "sha256": { "algorithm": "sha256", "value": "..." },
+          "publicUrl": "https://example.test/artifacts/files/cases/case-1.json",
+          "redaction": { "policy": "none", "sensitive": false }
+        }
+      ],
+      "verification": { "status": "passed", "verifiedAt": "2026-05-27T00:00:00.000Z" }
+    }
+  ]
+}
+```
+
+Case artifact paths must be present in `manifest.files[]`. When a case artifact
+declares `sha256`, `wp-codebox artifacts verify` hashes the referenced file and
+fails on mismatch. Reviewer-facing case `publicUrl` values and manifest viewer
+bases must be absolute HTTP(S) URLs and must not point at loopback or local
+hosts, so public refs do not expose host-local paths as review evidence.
+
 `wp-codebox artifacts verify` also fails closed on unsafe bundle topology: all
 declared file paths must be bundle-relative, non-duplicated, traversal-free,
 listed in `manifest.files[]` when used as digest inputs or evidence refs, and

--- a/packages/runtime-core/src/artifact-bundle-verifier.ts
+++ b/packages/runtime-core/src/artifact-bundle-verifier.ts
@@ -2,7 +2,7 @@ import { lstat, readdir, readFile, realpath } from "node:fs/promises"
 import { isAbsolute, join, normalize, relative, sep } from "node:path"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import { artifactFileDigest, calculateArtifactContentDigest, calculateArtifactManifestFileListDigest, calculateArtifactManifestFileSha256 } from "./artifact-manifest.js"
-import type { ArtifactContentDigest, ArtifactFileDigest, ArtifactManifest, ArtifactManifestFile } from "./artifact-manifest.js"
+import type { ArtifactContentDigest, ArtifactFileDigest, ArtifactManifest, ArtifactManifestCase, ArtifactManifestCaseArtifactRef, ArtifactManifestCaseVerificationMetadata, ArtifactManifestFile } from "./artifact-manifest.js"
 import { isPlainObject as isRecord } from "./object-utils.js"
 import { RUNTIME_EPISODE_TRACE_SCHEMA, validateRuntimeEpisodeTrace } from "./runtime-episode.js"
 import { RUNTIME_REFERENCE_MANIFEST_SCHEMA, RUNTIME_REPLAY_REFERENCE_INDEX_SCHEMA, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest } from "./runtime-reference.js"
@@ -133,6 +133,9 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
       violations.push({ code: "invalid-manifest-shape", path: fieldPath, file: file.path, message: `Manifest file path is duplicated: ${file.path}` })
     }
     manifestFiles.add(file.path)
+    if (file.viewer?.base) {
+      validateReviewerPublicUrl(file.viewer.base, `${fieldPath}.viewer.base`, violations, file.path)
+    }
     try {
       await verifyBundleFileTopology(bundleDirectory, file.path, fieldPath, violations)
     } catch {
@@ -167,6 +170,7 @@ export async function verifyArtifactBundle(directory: string, options: VerifyArt
   await verifyRuntimeReplayReferenceIndexArtifacts(bundleDirectory, manifest, manifestFiles, violations)
   await verifyTypedArtifactIndexArtifacts(bundleDirectory, manifest, manifestFiles, violations)
   await verifyToolCallTranscriptArtifacts(bundleDirectory, manifest, manifestFiles, violations)
+  await verifyManifestCases(bundleDirectory, manifest, manifestFiles, violations)
 
   return artifactBundleVerificationResult(bundleDirectory, violations, manifest)
 }
@@ -372,6 +376,7 @@ function isArtifactManifestShape(value: unknown): value is ArtifactManifest {
     && typeof contentDigest.value === "string"
     && Array.isArray(value.files)
     && value.files.every(isArtifactManifestFileShape)
+    && (value.cases === undefined || (Array.isArray(value.cases) && value.cases.every(isArtifactManifestCaseShape)))
 }
 
 function isArtifactManifestFileShape(value: unknown): value is ArtifactManifestFile {
@@ -379,6 +384,34 @@ function isArtifactManifestFileShape(value: unknown): value is ArtifactManifestF
     && typeof value.path === "string"
     && typeof value.kind === "string"
     && typeof value.contentType === "string"
+}
+
+function isArtifactManifestCaseShape(value: unknown): value is ArtifactManifestCase {
+  return isRecord(value)
+    && typeof value.id === "string"
+    && value.id.trim().length > 0
+    && (value.hash === undefined || isArtifactFileDigestShape(value.hash))
+    && (value.digest === undefined || isArtifactFileDigestShape(value.digest))
+    && Array.isArray(value.artifacts)
+    && value.artifacts.every(isArtifactManifestCaseArtifactRefShape)
+    && (value.verification === undefined || isArtifactManifestCaseVerificationMetadataShape(value.verification))
+}
+
+function isArtifactManifestCaseArtifactRefShape(value: unknown): value is ArtifactManifestCaseArtifactRef {
+  return isRecord(value)
+    && typeof value.path === "string"
+    && typeof value.kind === "string"
+    && (value.contentType === undefined || typeof value.contentType === "string")
+    && (value.sha256 === undefined || isArtifactFileDigestShape(value.sha256))
+    && (value.publicUrl === undefined || typeof value.publicUrl === "string")
+}
+
+function isArtifactManifestCaseVerificationMetadataShape(value: unknown): value is ArtifactManifestCaseVerificationMetadata {
+  return isRecord(value)
+    && typeof value.status === "string"
+    && (value.verifiedAt === undefined || typeof value.verifiedAt === "string")
+    && (value.verifier === undefined || typeof value.verifier === "string")
+    && (value.diagnostics === undefined || (Array.isArray(value.diagnostics) && value.diagnostics.every((diagnostic) => typeof diagnostic === "string")))
 }
 
 function isRuntimeReferenceManifestShape(value: unknown): value is RuntimeReferenceManifest {
@@ -982,6 +1015,67 @@ async function verifyTypedArtifactFileDigest(directory: string, path: string, ex
     }
   } catch (error) {
     violations.push({ code: "missing-file", path: fieldPath, file: path, message: `Unable to read typed artifact file: ${errorMessage(error)}` })
+  }
+}
+
+async function verifyManifestCases(directory: string, manifest: ArtifactManifest, manifestFiles: Set<string>, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  if (!manifest.cases) {
+    return
+  }
+
+  const caseIds = new Set<string>()
+  for (const [caseIndex, manifestCase] of manifest.cases.entries()) {
+    const casePath = `manifest.cases[${caseIndex}]`
+    if (caseIds.has(manifestCase.id)) {
+      violations.push({ code: "invalid-manifest-shape", path: `${casePath}.id`, message: `Case id is duplicated: ${manifestCase.id}` })
+    }
+    caseIds.add(manifestCase.id)
+
+    if (manifestCase.verification?.verifiedAt !== undefined && Number.isNaN(new Date(manifestCase.verification.verifiedAt).valueOf())) {
+      violations.push({ code: "invalid-manifest-shape", path: `${casePath}.verification.verifiedAt`, message: "Case verification verifiedAt must be a valid date string." })
+    }
+
+    for (const [artifactIndex, artifact] of manifestCase.artifacts.entries()) {
+      const artifactPath = `${casePath}.artifacts[${artifactIndex}]`
+      validateArtifactReference(artifact.path, `${artifactPath}.path`, manifestFiles, violations)
+      if (artifact.sha256) {
+        await verifyManifestCaseArtifactDigest(directory, artifact.path, artifact.sha256, `${artifactPath}.sha256`, violations)
+      }
+      if (artifact.publicUrl !== undefined) {
+        validateReviewerPublicUrl(artifact.publicUrl, `${artifactPath}.publicUrl`, violations, artifact.path)
+      }
+    }
+  }
+}
+
+async function verifyManifestCaseArtifactDigest(directory: string, path: string, sha256: ArtifactFileDigest, fieldPath: string, violations: ArtifactBundleVerificationViolation[]): Promise<void> {
+  try {
+    const actualSha256 = artifactFileDigest(await readFile(join(directory, path))).value
+    if (actualSha256 !== sha256.value) {
+      violations.push({ code: "file-hash-mismatch", path: fieldPath, file: path, message: `Case artifact digest mismatch for ${path}: expected ${actualSha256}, got ${sha256.value}` })
+    }
+  } catch (error) {
+    violations.push({ code: "missing-file", path: fieldPath, file: path, message: `Unable to read case artifact file: ${errorMessage(error)}` })
+  }
+}
+
+function validateReviewerPublicUrl(value: string, fieldPath: string, violations: ArtifactBundleVerificationViolation[], file?: string): void {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    violations.push({ code: "malformed-reference", path: fieldPath, file, message: "Reviewer-facing artifact URL must be an absolute http:// or https:// URL." })
+    return
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    violations.push({ code: "unsafe-file", path: fieldPath, file, message: "Reviewer-facing artifact URL must use http:// or https://." })
+    return
+  }
+
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "")
+  if (hostname === "localhost" || hostname === "0.0.0.0" || hostname === "::1" || /^127(?:\.\d{1,3}){3}$/.test(hostname) || hostname.endsWith(".local")) {
+    violations.push({ code: "unsafe-file", path: fieldPath, file, message: "Reviewer-facing artifact URL must not use a loopback or local host." })
   }
 }
 

--- a/packages/runtime-core/src/artifact-manifest.ts
+++ b/packages/runtime-core/src/artifact-manifest.ts
@@ -72,6 +72,35 @@ export interface ArtifactViewerMetadata {
   }
 }
 
+export interface ArtifactManifestCaseArtifactRef {
+  path: string
+  kind: string
+  contentType?: string
+  sha256?: ArtifactFileDigest
+  publicUrl?: string
+  redaction?: ArtifactRedactionMetadata
+  provenance?: ArtifactProvenanceMetadata
+  metadata?: Record<string, unknown>
+}
+
+export interface ArtifactManifestCaseVerificationMetadata {
+  status: "passed" | "failed" | "skipped" | "unknown" | (string & {})
+  verifiedAt?: string
+  verifier?: string
+  diagnostics?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface ArtifactManifestCase {
+  id: string
+  hash?: ArtifactFileDigest
+  digest?: ArtifactFileDigest
+  artifacts: ArtifactManifestCaseArtifactRef[]
+  redaction?: ArtifactRedactionMetadata
+  verification?: ArtifactManifestCaseVerificationMetadata
+  metadata?: Record<string, unknown>
+}
+
 export interface ArtifactFileDigest {
   algorithm: "sha256"
   value: string
@@ -83,6 +112,7 @@ export interface ArtifactManifest {
   createdAt: string
   runtime: RuntimeInfo
   files: ArtifactManifestFile[]
+  cases?: ArtifactManifestCase[]
 }
 
 export interface ArtifactContentDigest {

--- a/scripts/artifact-bundle-verifier-smoke.ts
+++ b/scripts/artifact-bundle-verifier-smoke.ts
@@ -64,6 +64,21 @@ try {
   await writeFile(join(fileHashMismatch, "files/test-results.json"), "{\"tampered\":true}\n")
   assertViolation(await verifyArtifactBundle(fileHashMismatch), "file-hash-mismatch")
 
+  const caseReferenceMissing = await copyBundle(validBundle, join(workspace, "case-reference-missing"))
+  const caseReferenceMissingManifest = manifestFixture(await calculateArtifactContentDigest(caseReferenceMissing, ["files/changed-files.json", "files/patch.diff"]))
+  caseReferenceMissingManifest.cases![0]!.artifacts[0]!.path = "files/cases/missing.json"
+  await attachManifestFileHashes(caseReferenceMissing, caseReferenceMissingManifest)
+  await writeJson(join(caseReferenceMissing, "manifest.json"), caseReferenceMissingManifest)
+  assertViolation(await verifyArtifactBundle(caseReferenceMissing), "malformed-reference")
+
+  const caseLocalPublicUrl = await copyBundle(validBundle, join(workspace, "case-local-public-url"))
+  const caseLocalPublicUrlManifest = manifestFixture(await calculateArtifactContentDigest(caseLocalPublicUrl, ["files/changed-files.json", "files/patch.diff"]))
+  caseLocalPublicUrlManifest.cases![0]!.artifacts[0]!.publicUrl = "http://127.0.0.1:8881/artifacts/case.json"
+  await attachCaseArtifactHashes(caseLocalPublicUrl, caseLocalPublicUrlManifest)
+  await attachManifestFileHashes(caseLocalPublicUrl, caseLocalPublicUrlManifest)
+  await writeJson(join(caseLocalPublicUrl, "manifest.json"), caseLocalPublicUrlManifest)
+  assertViolation(await verifyArtifactBundle(caseLocalPublicUrl), "unsafe-file")
+
   const missingFileHash = await copyBundle(validBundle, join(workspace, "missing-file-hash"))
   const missingHashManifest = manifestFixture(await calculateArtifactContentDigest(missingFileHash, ["files/changed-files.json", "files/patch.diff"]))
   await attachManifestFileHashes(missingFileHash, missingHashManifest)
@@ -116,12 +131,14 @@ try {
 
 async function writeValidBundle(directory: string): Promise<void> {
   await mkdir(join(directory, "files"), { recursive: true })
+  await mkdir(join(directory, "files/cases"), { recursive: true })
   const changedFiles = `${JSON.stringify({ schema: "wp-codebox/changed-files/v1", files: [{ path: "/wordpress/wp-content/plugins/example/file.txt", status: "added", mountIndex: 0, mountTarget: "/wordpress/wp-content/plugins/example", relativePath: "file.txt", patchPath: "files/diffs/0-file.txt.diff" }] }, null, 2)}\n`
   const patch = "diff --git a/wordpress/wp-content/plugins/example/file.txt b/wordpress/wp-content/plugins/example/file.txt\nnew file mode 100644\n--- /dev/null\n+++ b/wordpress/wp-content/plugins/example/file.txt\n@@ -0,0 +1 @@\n+cooked\n"
   await writeFile(join(directory, "files/changed-files.json"), changedFiles)
   await writeFile(join(directory, "files/patch.diff"), patch)
   await writeFile(join(directory, "metadata.json"), "{}\n")
   await writeFile(join(directory, "files/test-results.json"), "{}\n")
+  await writeJson(join(directory, "files/cases/case-1.json"), { schema: "example/case-result/v1", id: "case-1", status: "passed" })
 
   const digest = await calculateArtifactContentDigest(directory, ["files/changed-files.json", "files/patch.diff"])
   await writeJson(join(directory, "files/runtime-episode-trace.json"), runtimeEpisodeTraceFixture(digest))
@@ -139,6 +156,7 @@ async function writeValidBundle(directory: string): Promise<void> {
     },
   })
   const manifest = manifestFixture(digest)
+  await attachCaseArtifactHashes(directory, manifest)
   await attachManifestFileHashes(directory, manifest)
   await writeJson(join(directory, "manifest.json"), manifest)
 }
@@ -166,8 +184,27 @@ function manifestFixture(digest: string): ArtifactManifest {
       fileFixture("files/patch.diff", "patch", "text/x-diff"),
       fileFixture("files/review.json", "review", "application/json"),
       fileFixture("files/test-results.json", "test-results", "application/json"),
+      fileFixture("files/cases/case-1.json", "case-result", "application/json"),
       fileFixture("files/runtime-episode-trace.json", "runtime-episode-trace", "application/json"),
       fileFixture("files/runtime-episode.jsonl", "runtime-episode-events", "application/x-ndjson"),
+    ],
+    cases: [
+      {
+        id: "case-1",
+        hash: { algorithm: "sha256", value: createHash("sha256").update("case-1").digest("hex") },
+        artifacts: [
+          {
+            path: "files/cases/case-1.json",
+            kind: "case-result",
+            contentType: "application/json",
+            sha256: { algorithm: "sha256", value: "0".repeat(64) },
+            publicUrl: "https://artifacts.example.test/runs/fixture/files/cases/case-1.json",
+            redaction: { policy: "none", sensitive: false },
+          },
+        ],
+        redaction: { policy: "none", sensitive: false },
+        verification: { status: "passed", verifiedAt: "2026-05-27T00:00:00.000Z", verifier: "artifact-bundle-verifier-smoke" },
+      },
     ],
   }
 }
@@ -218,6 +255,14 @@ async function attachManifestFileHashes(directory: string, manifest: ArtifactMan
   for (const file of manifest.files) {
     if (file.path === "manifest.json") {
       file.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, file) }
+    }
+  }
+}
+
+async function attachCaseArtifactHashes(directory: string, manifest: ArtifactManifest): Promise<void> {
+  for (const manifestCase of manifest.cases ?? []) {
+    for (const artifact of manifestCase.artifacts) {
+      artifact.sha256 = { algorithm: "sha256", value: await calculateArtifactManifestFileSha256(directory, manifest, { path: artifact.path, kind: artifact.kind, contentType: artifact.contentType ?? "application/octet-stream", sha256: artifact.sha256 ?? { algorithm: "sha256", value: "0".repeat(64) } }) }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add optional `manifest.cases[]` primitives for stable case ids, case hash/digest fields, per-case artifact refs, redaction metadata, and verification metadata.
- Extend artifact bundle verification to validate case artifact refs, declared SHA-256 values, duplicate case ids, verification timestamps, and reviewer-facing URL safety.
- Document the case-level artifact index contract and cover it in the focused artifact bundle verifier smoke.

## Verification
- `npm run build`
- `npm run smoke -- --command=artifact-bundle-verifier-smoke`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the optional case-level artifact manifest contract, verifier checks, docs, and focused tests.