### PR TITLE
Add runtime checkpoint recipe primitives

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -192,6 +192,36 @@ Use `allowFailure: true` or `advisory: true` for evidence-only workflow steps.
 Failed advisory steps are reported in `advisoryFailures` and do not make an
 otherwise successful recipe return `success: false`.
 
+## Runtime Checkpoints
+
+Recipes can create named checkpoints and restore them later in the same run.
+Checkpoints are generic runtime isolation primitives for bounded mutation loops;
+they are not a high-volume fuzz runner.
+
+```json
+{
+  "workflow": {
+    "steps": [
+      { "command": "wp-codebox.checkpoint-create", "args": ["name=baseline"] },
+      { "command": "wordpress.run-php", "args": ["code=update_option( 'example_flag', 'mutated' );"] },
+      { "command": "wp-codebox.checkpoint-restore", "args": ["name=baseline"] },
+      { "command": "wp-codebox.checkpoint-list" }
+    ]
+  }
+}
+```
+
+Supported commands:
+
+- `wp-codebox.checkpoint-create` captures the current runtime state under `name`.
+- `wp-codebox.checkpoint-restore` restores a previously created `name`.
+- `wp-codebox.checkpoint-list` emits metadata for checkpoints created in the run.
+
+Checkpoint create accepts the same snapshot scoping arguments as
+`wordpress.capture-state-bundle`, plus optional `metadata-json`. Unsupported
+runtime backends fail closed with a structured
+`wp-codebox/runtime-checkpoint-failure/v1` diagnostic and exit code `1`.
+
 ## REST Benchmark Workloads
 
 Recipes can pass REST profiling workloads to `wordpress.bench` with

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
-import { type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeDistributionSetupArtifact, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
+import { commandArgValue, parseCommandJsonObject, runtimeCheckpointUnsupportedDiagnostic, type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type Runtime, type RuntimeCheckpointFailureDiagnostic, type RuntimeCheckpointOperation, type RuntimeCheckpointResult, type WorkspaceRecipe, type WorkspaceRecipeDistributionSetupArtifact, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
@@ -147,12 +147,103 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
         finishedAt,
       }, workflowStep.phase, workflowStep.index, workflowStep.step.command)
     }
+    if (isRuntimeCheckpointRecipeCommand(workflowStep.step.command)) {
+      return withRecipeExecutionPhase(await executeRuntimeCheckpointRecipeCommand(runtime, workflowStep.step.command, workflowStep.step.args ?? []), workflowStep.phase, workflowStep.index, workflowStep.step.command)
+    }
     const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory, sandboxWorkspace))
     return withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, workflowStep.step.command)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Recipe workflow ${workflowStep.phase}[${workflowStep.index}] failed: ${message}`, { cause: error })
   }
+}
+
+async function executeRuntimeCheckpointRecipeCommand(runtime: Runtime, command: string, args: string[]): Promise<ExecutionResult> {
+  const startedAt = new Date().toISOString()
+  const operation = runtimeCheckpointOperation(command)
+  const finish = (exitCode: number, payload: RuntimeCheckpointResult | RuntimeCheckpointFailureDiagnostic): ExecutionResult => ({
+    id: `${command}:${startedAt}`,
+    command,
+    args,
+    exitCode,
+    stdout: `${JSON.stringify({ command, ...payload }, null, 2)}\n`,
+    stderr: exitCode === 0 ? "" : "message" in payload ? payload.message : "Runtime checkpoint command failed.",
+    startedAt,
+    finishedAt: new Date().toISOString(),
+  })
+
+  try {
+    if (operation === "list") {
+      if (!runtime.listCheckpoints) {
+        return finish(1, runtimeCheckpointUnsupportedDiagnostic(operation, await runtime.info()))
+      }
+      return finish(0, await runtime.listCheckpoints())
+    }
+
+    const name = commandArgValue(args, "name")?.trim()
+    if (!name) {
+      return finish(1, runtimeCheckpointFailure(operation, "invalid-request", "runtime-checkpoint-name-required", "Runtime checkpoint command requires name=<checkpoint>."))
+    }
+
+    if (operation === "create") {
+      if (!runtime.createCheckpoint) {
+        return finish(1, runtimeCheckpointUnsupportedDiagnostic(operation, await runtime.info(), name))
+      }
+      return finish(0, await runtime.createCheckpoint({
+        name,
+        metadata: parseCommandJsonObject(commandArgValue(args, "metadata-json"), "metadata-json"),
+        snapshotOptions: snapshotOptionsFromCheckpointArgs(args),
+      }))
+    }
+
+    if (!runtime.restoreCheckpoint) {
+      return finish(1, runtimeCheckpointUnsupportedDiagnostic(operation, await runtime.info(), name))
+    }
+    return finish(0, await runtime.restoreCheckpoint(name))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return finish(1, runtimeCheckpointFailure(operation, "failed", "runtime-checkpoint-operation-failed", message))
+  }
+}
+
+function isRuntimeCheckpointRecipeCommand(command: string): boolean {
+  return command === "wp-codebox.checkpoint-create" || command === "wp-codebox.checkpoint-restore" || command === "wp-codebox.checkpoint-list"
+}
+
+function runtimeCheckpointOperation(command: string): RuntimeCheckpointOperation {
+  if (command === "wp-codebox.checkpoint-create") {
+    return "create"
+  }
+  if (command === "wp-codebox.checkpoint-restore") {
+    return "restore"
+  }
+  return "list"
+}
+
+function runtimeCheckpointFailure(operation: RuntimeCheckpointOperation, status: RuntimeCheckpointFailureDiagnostic["status"], code: string, message: string): RuntimeCheckpointFailureDiagnostic {
+  return {
+    schema: "wp-codebox/runtime-checkpoint-failure/v1",
+    status,
+    operation,
+    code,
+    message,
+    supported: false,
+  }
+}
+
+function snapshotOptionsFromCheckpointArgs(args: string[]): Record<string, string[]> {
+  return {
+    excludedWpContentPaths: commaListArg(args, "snapshot-exclude-wp-content"),
+    includedWpContentPaths: commaListArg(args, "snapshot-include-wp-content"),
+    includedDatabaseTables: commaListArg(args, "snapshot-database-tables"),
+    excludedDatabaseTables: commaListArg(args, "snapshot-exclude-database-tables"),
+    includedOptionNames: commaListArg(args, "snapshot-option-names"),
+    includedPostTypes: commaListArg(args, "snapshot-post-types"),
+  }
+}
+
+function commaListArg(args: string[], name: string): string[] {
+  return (commandArgValue(args, name) ?? "").split(",").map((entry) => entry.trim()).filter(Boolean)
 }
 
 export async function runRecipeProbes(recipe: WorkspaceRecipe, recipeDirectory: string, runtime: Runtime, executions: RecipeExecutionResult[]): Promise<RecipeRunProbe[]> {

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -261,6 +261,51 @@ export const commandRegistry = [
     handler: { kind: "playground", method: "runExportReplayPackage" },
   },
   {
+    id: "wp-codebox.checkpoint-create",
+    description: "Create a named runtime checkpoint for later restore within the same recipe run.",
+    acceptedArgs: [
+      { name: "name", description: "Checkpoint name. Use letters, numbers, dots, underscores, or hyphens.", required: true, format: "string" },
+      { name: "metadata-json", description: "Optional non-secret JSON object recorded on the checkpoint metadata.", format: "JSON object" },
+      ...snapshotScopingAcceptedArgs,
+    ],
+    outputShape: "wp-codebox/runtime-checkpoint-result/v1 JSON with checkpoint name, snapshot id, created timestamp, summary, and metadata.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/runtime-checkpoint-result/v1", {
+      operation: { const: "create" },
+      checkpoint: { type: "object" },
+    }),
+    policyRequirement: "Host-side recipe helper; supported runtime backends create a same-run checkpoint, unsupported backends fail closed with structured diagnostics.",
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "wp-codebox.checkpoint-create" },
+  },
+  {
+    id: "wp-codebox.checkpoint-restore",
+    description: "Restore a previously created named runtime checkpoint within the same recipe run.",
+    acceptedArgs: [
+      { name: "name", description: "Checkpoint name to restore.", required: true, format: "string" },
+    ],
+    outputShape: "wp-codebox/runtime-checkpoint-result/v1 JSON with restored checkpoint metadata.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/runtime-checkpoint-result/v1", {
+      operation: { const: "restore" },
+      checkpoint: { type: "object" },
+    }),
+    policyRequirement: "Host-side recipe helper; supported runtime backends restore a same-run checkpoint, unsupported backends fail closed with structured diagnostics.",
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "wp-codebox.checkpoint-restore" },
+  },
+  {
+    id: "wp-codebox.checkpoint-list",
+    description: "List named runtime checkpoints created during the current recipe run.",
+    acceptedArgs: [],
+    outputShape: "wp-codebox/runtime-checkpoint-result/v1 JSON with checkpoint metadata entries.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/runtime-checkpoint-result/v1", {
+      operation: { const: "list" },
+      checkpoints: { type: "array" },
+    }),
+    policyRequirement: "Host-side recipe helper; supported runtime backends list same-run checkpoints, unsupported backends fail closed with structured diagnostics.",
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "wp-codebox.checkpoint-list" },
+  },
+  {
     id: "wordpress.ability",
     description: "Execute a registered WordPress Ability in the sandbox.",
     acceptedArgs: [

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -700,6 +700,70 @@ export interface Snapshot {
   digest?: RuntimeEpisodeContentDigest
 }
 
+export type RuntimeCheckpointOperation = "create" | "restore" | "list"
+
+export interface RuntimeCheckpointSpec {
+  name: string
+  metadata?: Record<string, unknown>
+  snapshotOptions?: unknown
+}
+
+export interface RuntimeCheckpointMetadata {
+  name: string
+  snapshotId: string
+  createdAt: string
+  restoredAt?: string
+  metadata?: Record<string, unknown>
+  summary?: Record<string, unknown>
+}
+
+export interface RuntimeCheckpointResult {
+  schema: "wp-codebox/runtime-checkpoint-result/v1"
+  status: "created" | "restored" | "listed"
+  operation: RuntimeCheckpointOperation
+  checkpoint?: RuntimeCheckpointMetadata
+  checkpoints?: RuntimeCheckpointMetadata[]
+}
+
+export interface RuntimeCheckpointFailureDiagnostic {
+  schema: "wp-codebox/runtime-checkpoint-failure/v1"
+  status: "unsupported" | "not-found" | "invalid-request" | "failed"
+  operation: RuntimeCheckpointOperation
+  backend?: RuntimeBackendKind
+  name?: string
+  code: string
+  message: string
+  supported: false
+}
+
+export class RuntimeCheckpointError extends Error {
+  readonly diagnostic: RuntimeCheckpointFailureDiagnostic
+
+  constructor(diagnostic: RuntimeCheckpointFailureDiagnostic) {
+    super(diagnostic.message)
+    this.name = "RuntimeCheckpointError"
+    this.diagnostic = diagnostic
+  }
+
+  toJSON(): RuntimeCheckpointFailureDiagnostic & { name: string } {
+    return { ...this.diagnostic, name: this.name }
+  }
+}
+
+export function runtimeCheckpointUnsupportedDiagnostic(operation: RuntimeCheckpointOperation, runtime?: RuntimeInfo, name?: string): RuntimeCheckpointFailureDiagnostic {
+  const backend = runtime?.backend
+  return {
+    schema: "wp-codebox/runtime-checkpoint-failure/v1",
+    status: "unsupported",
+    operation,
+    ...(backend ? { backend } : {}),
+    ...(name ? { name } : {}),
+    code: "runtime-checkpoints-unsupported",
+    message: backend ? `Runtime backend does not support checkpoints: ${backend}` : "Runtime backend does not support checkpoints.",
+    supported: false,
+  }
+}
+
 export interface RuntimeRestoreSpec {
   runtime?: RuntimeCreateSpec
   mounts?: MountSpec[]
@@ -982,6 +1046,9 @@ export interface Runtime {
   execute(spec: ExecutionSpec): Promise<ExecutionResult>
   observe(spec: ObservationSpec): Promise<ObservationResult>
   snapshot(options?: unknown): Promise<Snapshot>
+  createCheckpoint?(spec: RuntimeCheckpointSpec): Promise<RuntimeCheckpointResult>
+  restoreCheckpoint?(name: string): Promise<RuntimeCheckpointResult>
+  listCheckpoints?(): Promise<RuntimeCheckpointResult>
   collectArtifacts(spec?: ArtifactSpec): Promise<ArtifactBundle>
   destroy(): Promise<void>
 }

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -47,6 +47,9 @@ import type {
   RuntimeInfo,
   RuntimeCommandResultEnvelope,
   Snapshot,
+  RuntimeCheckpointResult,
+  RuntimeCheckpointSpec,
+  RuntimeCheckpointMetadata,
 } from "@automattic/wp-codebox-core"
 function id(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
@@ -134,6 +137,7 @@ class PlaygroundRuntime implements Runtime {
   private readonly commands: ExecutionResult[] = []
   private readonly observations: ObservationResult[] = []
   private readonly snapshots: Snapshot[] = []
+  private readonly checkpoints = new Map<string, { snapshot: Snapshot; metadata: RuntimeCheckpointMetadata }>()
   private readonly events: LifecycleEvent[] = []
   private readonly browserProbes: BrowserArtifact[] = []
   private readonly pluginChecks: PluginCheckArtifact[] = []
@@ -371,6 +375,60 @@ class PlaygroundRuntime implements Runtime {
     this.snapshots.push(snapshot)
 
     return snapshot
+  }
+
+  async createCheckpoint(spec: RuntimeCheckpointSpec): Promise<RuntimeCheckpointResult> {
+    const name = normalizeCheckpointName(spec.name)
+    const snapshot = await this.snapshot(spec.snapshotOptions as RuntimeSnapshotExportOptions | undefined)
+    const summary = snapshot.metadata.summary && typeof snapshot.metadata.summary === "object" && !Array.isArray(snapshot.metadata.summary)
+      ? snapshot.metadata.summary as Record<string, unknown>
+      : undefined
+    const checkpoint: RuntimeCheckpointMetadata = {
+      name,
+      snapshotId: snapshot.id,
+      createdAt: snapshot.createdAt,
+      ...(spec.metadata ? { metadata: spec.metadata } : {}),
+      ...(summary ? { summary } : {}),
+    }
+    this.checkpoints.set(name, { snapshot, metadata: checkpoint })
+    this.recordEvent("runtime.checkpoint.created", { checkpoint })
+    return {
+      schema: "wp-codebox/runtime-checkpoint-result/v1",
+      status: "created",
+      operation: "create",
+      checkpoint,
+    }
+  }
+
+  async restoreCheckpoint(name: string): Promise<RuntimeCheckpointResult> {
+    const checkpointName = normalizeCheckpointName(name)
+    const checkpointRecord = this.checkpoints.get(checkpointName)
+    if (!checkpointRecord) {
+      throw new PlaygroundSnapshotRestoreError(`Runtime checkpoint not found: ${checkpointName}`)
+    }
+
+    await this.restoreSnapshotPayload(await runtimeSnapshotPayload(checkpointRecord.snapshot))
+    const checkpoint: RuntimeCheckpointMetadata = {
+      ...checkpointRecord.metadata,
+      restoredAt: now(),
+    }
+    checkpointRecord.metadata = checkpoint
+    this.recordEvent("runtime.checkpoint.restored", { checkpoint })
+    return {
+      schema: "wp-codebox/runtime-checkpoint-result/v1",
+      status: "restored",
+      operation: "restore",
+      checkpoint,
+    }
+  }
+
+  async listCheckpoints(): Promise<RuntimeCheckpointResult> {
+    return {
+      schema: "wp-codebox/runtime-checkpoint-result/v1",
+      status: "listed",
+      operation: "list",
+      checkpoints: [...this.checkpoints.values()].map((checkpoint) => checkpoint.metadata),
+    }
   }
 
   private async captureRuntimeSnapshotArtifact(snapshotId: string, createdAt: string, options: RuntimeSnapshotExportOptions = {}): Promise<RuntimeSnapshotArtifact> {
@@ -1195,6 +1253,14 @@ echo json_encode(array('command' => 'inspect-mounted-inputs', 'mounts' => $inspe
     return new URL(url, baseUrl).toString()
   }
 
+}
+
+function normalizeCheckpointName(name: string): string {
+  const normalized = name.trim()
+  if (!/^[A-Za-z0-9._-]{1,120}$/.test(normalized)) {
+    throw new Error("Runtime checkpoint names must use 1-120 letters, numbers, dots, underscores, or hyphens.")
+  }
+  return normalized
 }
 
 export function createPlaygroundRuntimeBackend(options: PlaygroundRuntimeBackendOptions = {}): RuntimeBackend {

--- a/tests/runtime-checkpoint-primitives.test.ts
+++ b/tests/runtime-checkpoint-primitives.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+
+import { getCommandDefinition } from "../packages/runtime-core/src/command-registry.js"
+import { runtimeCheckpointUnsupportedDiagnostic, type ArtifactBundle, type ArtifactSpec, type ExecutionResult, type ExecutionSpec, type MountSpec, type ObservationResult, type ObservationSpec, type Runtime, type RuntimeCheckpointResult, type RuntimeInfo, type Snapshot } from "../packages/runtime-core/src/runtime-contracts.js"
+import { executeRecipeWorkflowStep } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+
+class UnsupportedRuntime implements Runtime {
+  async info(): Promise<RuntimeInfo> {
+    return { id: "runtime-unsupported", backend: "test-backend", environment: { kind: "test" }, createdAt: "2026-01-02T03:04:05.000Z", status: "created" }
+  }
+
+  async mount(_spec: MountSpec): Promise<void> {}
+  async execute(_spec: ExecutionSpec): Promise<ExecutionResult> { throw new Error("not used") }
+  async observe(_spec: ObservationSpec): Promise<ObservationResult> { throw new Error("not used") }
+  async snapshot(_options?: unknown): Promise<Snapshot> { throw new Error("not used") }
+  async collectArtifacts(_spec?: ArtifactSpec): Promise<ArtifactBundle> { throw new Error("not used") }
+  async destroy(): Promise<void> {}
+}
+
+class CheckpointRuntime extends UnsupportedRuntime {
+  private readonly checkpoints = new Map<string, RuntimeCheckpointResult["checkpoint"]>()
+
+  async createCheckpoint(spec: { name: string; metadata?: Record<string, unknown> }): Promise<RuntimeCheckpointResult> {
+    const checkpoint = { name: spec.name, snapshotId: `snapshot-${spec.name}`, createdAt: "2026-01-02T03:04:05.000Z", metadata: spec.metadata }
+    this.checkpoints.set(spec.name, checkpoint)
+    return { schema: "wp-codebox/runtime-checkpoint-result/v1", status: "created", operation: "create", checkpoint }
+  }
+
+  async restoreCheckpoint(name: string): Promise<RuntimeCheckpointResult> {
+    const checkpoint = this.checkpoints.get(name)
+    if (!checkpoint) {
+      throw new Error(`missing checkpoint ${name}`)
+    }
+    return { schema: "wp-codebox/runtime-checkpoint-result/v1", status: "restored", operation: "restore", checkpoint: { ...checkpoint, restoredAt: "2026-01-02T03:04:06.000Z" } }
+  }
+
+  async listCheckpoints(): Promise<RuntimeCheckpointResult> {
+    return { schema: "wp-codebox/runtime-checkpoint-result/v1", status: "listed", operation: "list", checkpoints: [...this.checkpoints.values()].filter((checkpoint): checkpoint is NonNullable<typeof checkpoint> => Boolean(checkpoint)) }
+  }
+}
+
+assert.equal(getCommandDefinition("wp-codebox.checkpoint-create")?.recipe, true)
+assert.equal(getCommandDefinition("wp-codebox.checkpoint-restore")?.recipe, true)
+assert.equal(getCommandDefinition("wp-codebox.checkpoint-list")?.recipe, true)
+
+assert.deepEqual(runtimeCheckpointUnsupportedDiagnostic("create", await new UnsupportedRuntime().info(), "baseline"), {
+  schema: "wp-codebox/runtime-checkpoint-failure/v1",
+  status: "unsupported",
+  operation: "create",
+  backend: "test-backend",
+  name: "baseline",
+  code: "runtime-checkpoints-unsupported",
+  message: "Runtime backend does not support checkpoints: test-backend",
+  supported: false,
+})
+
+const unsupported = await executeRecipeWorkflowStep(new UnsupportedRuntime(), { phase: "steps", index: 0, step: { command: "wp-codebox.checkpoint-create", args: ["name=baseline"] } }, process.cwd())
+assert.equal(unsupported.exitCode, 1)
+assert.equal(JSON.parse(unsupported.stdout).schema, "wp-codebox/runtime-checkpoint-failure/v1")
+assert.equal(JSON.parse(unsupported.stdout).status, "unsupported")
+
+const runtime = new CheckpointRuntime()
+const created = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: { command: "wp-codebox.checkpoint-create", args: ["name=baseline", "metadata-json={\"case\":\"one\"}"] } }, process.cwd())
+assert.equal(created.exitCode, 0)
+assert.equal(JSON.parse(created.stdout).checkpoint.name, "baseline")
+
+const listed = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 1, step: { command: "wp-codebox.checkpoint-list" } }, process.cwd())
+assert.equal(listed.exitCode, 0)
+assert.equal(JSON.parse(listed.stdout).checkpoints.length, 1)
+
+const restored = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 2, step: { command: "wp-codebox.checkpoint-restore", args: ["name=baseline"] } }, process.cwd())
+assert.equal(restored.exitCode, 0)
+assert.equal(JSON.parse(restored.stdout).checkpoint.restoredAt, "2026-01-02T03:04:06.000Z")
+
+console.log("runtime checkpoint primitives ok")


### PR DESCRIPTION
## Summary
- Add optional runtime checkpoint create/restore/list primitives with structured unsupported diagnostics.
- Implement same-run named checkpoints for the WordPress Playground backend using existing runtime snapshot/restore payloads.
- Expose recipe helper commands for checkpoint create, restore, and list, plus docs and focused tests.

## Verification
- npm run build
- npx tsx tests/runtime-checkpoint-primitives.test.ts
- npm run test:recipe-validation-descriptors
- npm run test:materialize-replay-package-command
- npm run test:runtime-recipe-resolver
- npm run test:evidence-bundle-digest-and-recipe-artifact
- npm run test:recipe-source-packages
- npm run test:public-api-contract
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing runtime checkpoint primitives, recipe command plumbing, docs, tests, and verification.