### PR TITLE
Add runner workspace adapter boundary

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/trait-wp-codebox-abilities-browser-runner.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-browser-connectors.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-agents-api-executors.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-utils.php';
+require_once __DIR__ . '/class-wp-codebox-runner-workspace-adapter.php';
 require_once __DIR__ . '/class-wp-codebox-browser-ability-descriptors.php';
 
 final class WP_Codebox_Abilities {

--- a/packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Runner workspace backend adapter.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Runner_Workspace_Adapter {
+	/** @return array<string,mixed> */
+	public function prepare( array $input ): array {
+		$abilities     = $this->abilities();
+		$adopt_ability = (string) ( $abilities['workspace_adopt'] ?? '' );
+		$show_ability  = (string) ( $abilities['workspace_show'] ?? '' );
+		$clone_ability = (string) ( $abilities['workspace_clone'] ?? '' );
+		$add_ability   = (string) ( $abilities['workspace_worktree_add'] ?? '' );
+
+		$checkout_path           = (string) $input['checkout_path'];
+		$workspace_root_constant = (string) ( $this->config()['workspace_root_constant'] ?? '' );
+		if ( '' !== $checkout_path && '' !== $workspace_root_constant && ! defined( $workspace_root_constant ) ) {
+			define( $workspace_root_constant, rtrim( dirname( $checkout_path ), '/' ) );
+		}
+
+		$required = '' !== $checkout_path ? array( $adopt_ability ) : array( $show_ability, $clone_ability, $add_ability );
+		foreach ( $required as $ability_name ) {
+			if ( ! $this->ability_available( $ability_name ) ) {
+				return $this->failure( 'backend_unavailable', 'wp_codebox_runner_workspace_prepare_backend_unavailable', 'Runner workspace backend is not available for preparation.' );
+			}
+		}
+
+		if ( '' !== $checkout_path ) {
+			$adopt = $this->execute( $adopt_ability, array( 'path' => $checkout_path, 'name' => $input['repo'] ) );
+			if ( empty( $adopt['success'] ) ) {
+				return $adopt;
+			}
+
+			$result = is_array( $adopt['result'] ?? null ) ? $adopt['result'] : array();
+			return array(
+				'success' => true,
+				'result'  => array(
+					'repo'   => (string) $input['repo'],
+					'branch' => (string) $input['branch'],
+					'handle' => (string) ( $result['handle'] ?? $result['name'] ?? $input['repo'] ),
+					'path'   => (string) ( $result['path'] ?? $checkout_path ),
+				),
+			);
+		}
+
+		$show = $this->execute( $show_ability, array( 'name' => $input['repo'] ) );
+		if ( empty( $show['success'] ) ) {
+			if ( '' === (string) $input['clone_url'] ) {
+				return $this->failure( 'clone_url_required', 'wp_codebox_runner_workspace_prepare_clone_url_required', 'Runner workspace primary is missing and clone_url is empty.' );
+			}
+
+			$clone_input = array( 'url' => $input['clone_url'], 'name' => $input['repo'] );
+			if ( '' !== (string) $input['github_token_env'] && '' !== trim( (string) getenv( (string) $input['github_token_env'] ) ) && preg_match( '#^https://github\.com/#', (string) $input['clone_url'] ) ) {
+				$clone_input['auth_token_env'] = $input['github_token_env'];
+			}
+
+			$clone = $this->execute( $clone_ability, array_filter( $clone_input, static fn( mixed $value ): bool => '' !== $value ) );
+			if ( empty( $clone['success'] ) ) {
+				return $clone;
+			}
+		}
+
+		$worktree_input = array_filter(
+			array(
+				'repo'           => $input['repo'],
+				'branch'         => $input['branch'],
+				'from'           => $input['from'],
+				'inject_context' => $input['inject_context'],
+				'bootstrap'      => $input['bootstrap'],
+				'allow_stale'    => $input['allow_stale'],
+				'rebase_base'    => $input['rebase_base'],
+				'force'          => $input['force'],
+			),
+			static fn( mixed $value ): bool => '' !== $value && null !== $value
+		);
+
+		$worktree = $this->execute( $add_ability, $worktree_input );
+		if ( empty( $worktree['success'] ) ) {
+			return $worktree;
+		}
+
+		$result = is_array( $worktree['result'] ?? null ) ? $worktree['result'] : array();
+		return array(
+			'success' => true,
+			'result'  => array(
+				'repo'   => (string) $input['repo'],
+				'branch' => (string) ( $result['branch'] ?? $input['branch'] ),
+				'handle' => (string) ( $result['handle'] ?? '' ),
+				'path'   => (string) ( $result['path'] ?? '' ),
+			),
+		);
+	}
+
+	/** @return array{success:bool,result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
+	public function publish( array $input ): array {
+		return $this->execute_named( 'publish_runner_workspace', $input );
+	}
+
+	/** @return array{success:bool,result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
+	public function git_status( string $workspace ): array {
+		return $this->execute_named( 'workspace_git_status', array( 'name' => $workspace ) );
+	}
+
+	/** @return array{success:bool,result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
+	public function git_diff( array $input ): array {
+		return $this->execute_named( 'workspace_git_diff', $input );
+	}
+
+	/** @return array{success:bool,result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
+	public function run_command( array $input ): array {
+		return $this->execute_named( 'run_runner_workspace_command', $input );
+	}
+
+	/** @return array<string,mixed> */
+	private function config(): array {
+		$config = function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_runner_workspace_backend', array() ) : array();
+		if ( is_array( $config ) && ! empty( $config ) ) {
+			return $config;
+		}
+
+		return array(
+			'id'                      => '',
+			'workspace_root_constant' => '',
+			'abilities'               => array(),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function abilities(): array {
+		$config = $this->config();
+		return is_array( $config['abilities'] ?? null ) ? $config['abilities'] : array();
+	}
+
+	/** @return array{success:bool,result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
+	private function execute_named( string $key, array $input ): array {
+		$abilities = $this->abilities();
+		return $this->execute( (string) ( $abilities[ $key ] ?? '' ), $input );
+	}
+
+	/** @return array{success:bool,result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
+	private function execute( string $ability_name, array $input ): array {
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
+		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
+			return $this->failure( 'backend_unavailable', 'wp_codebox_runner_workspace_backend_unavailable', 'Runner workspace backend is not available for this operation.' );
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'      => false,
+				'failure_type' => 'backend_error',
+				'error'        => array(
+					'code'    => $result->get_error_code(),
+					'message' => $result->get_error_message(),
+					'data'    => $result->get_error_data(),
+				),
+			);
+		}
+
+		if ( ! is_array( $result ) ) {
+			return $this->failure( 'backend_invalid_response', 'wp_codebox_runner_workspace_backend_invalid_response', 'Runner workspace backend returned an invalid response.' );
+		}
+
+		if ( false === ( $result['success'] ?? true ) ) {
+			return array(
+				'success'      => false,
+				'failure_type' => (string) ( $result['failure_type'] ?? 'backend_failed' ),
+				'error'        => is_array( $result['error'] ?? null ) ? $result['error'] : array( 'message' => (string) ( $result['error'] ?? 'Runner workspace backend operation failed.' ) ),
+			);
+		}
+
+		return array( 'success' => true, 'result' => $result );
+	}
+
+	private function ability_available( string $ability_name ): bool {
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
+		return $ability && is_callable( array( $ability, 'execute' ) );
+	}
+
+	/** @return array{success:bool,failure_type:string,error:array<string,string>} */
+	private function failure( string $failure_type, string $code, string $message ): array {
+		return array(
+			'success'      => false,
+			'failure_type' => $failure_type,
+			'error'        => array(
+				'code'    => $code,
+				'message' => $message,
+			),
+		);
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -192,97 +192,12 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		if ( is_array( $normalized['error'] ?? null ) ) {
 			return self::runner_workspace_prepare_failure( 'invalid_request', $normalized['error'], 'failed', $normalized );
 		}
-		$backend       = self::runner_workspace_backend_config();
-		$abilities     = is_array( $backend['abilities'] ?? null ) ? $backend['abilities'] : array();
-		$adopt_ability = (string) ( $abilities['workspace_adopt'] ?? '' );
-		$show_ability  = (string) ( $abilities['workspace_show'] ?? '' );
-		$clone_ability = (string) ( $abilities['workspace_clone'] ?? '' );
-		$add_ability   = (string) ( $abilities['workspace_worktree_add'] ?? '' );
-
-		$checkout_path = (string) $normalized['checkout_path'];
-		$workspace_root_constant = (string) ( $backend['workspace_root_constant'] ?? '' );
-		if ( '' !== $checkout_path && '' !== $workspace_root_constant && ! defined( $workspace_root_constant ) ) {
-			define( $workspace_root_constant, rtrim( dirname( $checkout_path ), '/' ) );
+		$prepared = self::runner_workspace_adapter()->prepare( $normalized );
+		if ( empty( $prepared['success'] ) ) {
+			return self::runner_workspace_prepare_failure( (string) ( $prepared['failure_type'] ?? 'backend_failed' ), is_array( $prepared['error'] ?? null ) ? $prepared['error'] : array( 'message' => 'Runner workspace preparation failed.' ), 'backend_unavailable' === (string) ( $prepared['failure_type'] ?? '' ) ? 'unavailable' : 'failed', $normalized );
 		}
 
-		$required = '' !== $checkout_path
-			? array( $adopt_ability )
-			: array( $show_ability, $clone_ability, $add_ability );
-
-		foreach ( $required as $ability_name ) {
-			$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
-			if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
-				return self::runner_workspace_prepare_failure(
-					'backend_unavailable',
-					array( 'code' => 'wp_codebox_runner_workspace_prepare_backend_unavailable', 'message' => 'Runner workspace backend is not available for preparation.' ),
-					'unavailable',
-					$normalized
-				);
-			}
-		}
-
-		if ( '' !== $checkout_path ) {
-			$adopt = wp_get_ability( $adopt_ability )->execute( array( 'path' => $checkout_path, 'name' => $normalized['repo'] ) );
-			if ( is_wp_error( $adopt ) ) {
-				return self::runner_workspace_prepare_failure( 'backend_error', array( 'code' => $adopt->get_error_code(), 'message' => $adopt->get_error_message(), 'data' => $adopt->get_error_data() ), 'failed', $normalized );
-			}
-			if ( ! is_array( $adopt ) || empty( $adopt['success'] ) ) {
-				return self::runner_workspace_prepare_failure( 'backend_failed', array( 'code' => 'wp_codebox_runner_workspace_prepare_adopt_failed', 'message' => 'Runner workspace backend could not adopt the mounted checkout.', 'result' => $adopt ), 'failed', $normalized );
-			}
-
-			return array_filter(
-				array(
-					'success'      => true,
-					'schema'       => 'wp-codebox/runner-workspace-prepare-result/v1',
-					'status'       => 'prepared',
-					'repo'         => $normalized['repo'],
-					'branch'       => $normalized['branch'],
-					'handle'       => (string) ( $adopt['handle'] ?? $adopt['name'] ?? $normalized['repo'] ),
-					'path'         => (string) ( $adopt['path'] ?? $checkout_path ),
-					'capabilities' => array( 'capture' => true, 'command' => true, 'publish' => true ),
-				),
-				static fn( mixed $value ): bool => '' !== $value && array() !== $value && null !== $value
-			);
-		}
-
-		$show = wp_get_ability( $show_ability )->execute( array( 'name' => $normalized['repo'] ) );
-		if ( is_wp_error( $show ) ) {
-			if ( '' === $normalized['clone_url'] ) {
-				return self::runner_workspace_prepare_failure( 'clone_url_required', array( 'code' => 'wp_codebox_runner_workspace_prepare_clone_url_required', 'message' => 'Runner workspace primary is missing and clone_url is empty.' ), 'failed', $normalized );
-			}
-
-			$clone_input = array( 'url' => $normalized['clone_url'], 'name' => $normalized['repo'] );
-			if ( '' !== $normalized['github_token_env'] && '' !== trim( (string) getenv( $normalized['github_token_env'] ) ) && preg_match( '#^https://github\.com/#', $normalized['clone_url'] ) ) {
-				$clone_input['auth_token_env'] = $normalized['github_token_env'];
-			}
-
-			$clone = wp_get_ability( $clone_ability )->execute( array_filter( $clone_input, static fn( mixed $value ): bool => '' !== $value ) );
-			if ( is_wp_error( $clone ) ) {
-				return self::runner_workspace_prepare_failure( 'backend_error', array( 'code' => $clone->get_error_code(), 'message' => $clone->get_error_message(), 'data' => $clone->get_error_data() ), 'failed', $normalized );
-			}
-		}
-
-		$worktree_input = array_filter(
-			array(
-				'repo'           => $normalized['repo'],
-				'branch'         => $normalized['branch'],
-				'from'           => $normalized['from'],
-				'inject_context' => $normalized['inject_context'],
-				'bootstrap'      => $normalized['bootstrap'],
-				'allow_stale'    => $normalized['allow_stale'],
-				'rebase_base'    => $normalized['rebase_base'],
-				'force'          => $normalized['force'],
-			),
-			static fn( mixed $value ): bool => '' !== $value && null !== $value
-		);
-
-		$worktree = wp_get_ability( $add_ability )->execute( $worktree_input );
-		if ( is_wp_error( $worktree ) ) {
-			return self::runner_workspace_prepare_failure( 'backend_error', array( 'code' => $worktree->get_error_code(), 'message' => $worktree->get_error_message(), 'data' => $worktree->get_error_data() ), 'failed', $normalized );
-		}
-		if ( ! is_array( $worktree ) || empty( $worktree['success'] ) ) {
-			return self::runner_workspace_prepare_failure( 'backend_failed', array( 'code' => 'wp_codebox_runner_workspace_prepare_worktree_failed', 'message' => 'Runner workspace backend could not create the worktree.', 'result' => $worktree ), 'failed', $normalized );
-		}
+		$worktree = is_array( $prepared['result'] ?? null ) ? $prepared['result'] : array();
 
 		return array_filter(
 			array(
@@ -306,53 +221,13 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			return self::runner_workspace_publication_failure( 'invalid_request', $normalized['error'], 'write_without_pr', $normalized );
 		}
 
-		$backend         = self::runner_workspace_backend_config();
-		$abilities       = is_array( $backend['abilities'] ?? null ) ? $backend['abilities'] : array();
-		$publish_ability = (string) ( $abilities['publish_runner_workspace'] ?? '' );
-		$ability         = '' !== $publish_ability && function_exists( 'wp_get_ability' ) ? wp_get_ability( $publish_ability ) : null;
-		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
-			return self::runner_workspace_publication_failure(
-				'publication_unavailable',
-				array(
-					'code'    => 'wp_codebox_runner_workspace_publication_unavailable',
-					'message' => 'Runner workspace publication is not available in this WP Codebox runtime.',
-				),
-				'write_without_pr',
-				$normalized
-			);
+		$backend = self::runner_workspace_adapter()->publish( self::runner_workspace_publication_backend_input( $normalized ) );
+		if ( empty( $backend['success'] ) ) {
+			$status = 'backend_unavailable' === (string) ( $backend['failure_type'] ?? '' ) ? 'write_without_pr' : 'failed';
+			return self::runner_workspace_publication_failure( (string) ( $backend['failure_type'] ?? 'backend_failed' ), is_array( $backend['error'] ?? null ) ? $backend['error'] : array( 'message' => 'Runner workspace publication failed.' ), $status, $normalized );
 		}
 
-		$result = $ability->execute( self::runner_workspace_publication_backend_input( $normalized ) );
-		if ( is_wp_error( $result ) ) {
-			return self::runner_workspace_publication_failure(
-				'backend_error',
-				array(
-					'code'    => $result->get_error_code(),
-					'message' => $result->get_error_message(),
-					'data'    => $result->get_error_data(),
-				),
-				'failed',
-				$normalized
-			);
-		}
-
-		if ( ! is_array( $result ) ) {
-			return self::runner_workspace_publication_failure(
-				'backend_invalid_response',
-				array(
-					'code'    => 'wp_codebox_runner_workspace_publication_invalid_response',
-					'message' => 'Runner workspace publication backend returned an invalid response.',
-				),
-				'failed',
-				$normalized
-			);
-		}
-
-		if ( false === ( $result['success'] ?? true ) ) {
-			$error = is_array( $result['error'] ?? null ) ? $result['error'] : array( 'message' => (string) ( $result['error'] ?? 'Runner workspace publication failed.' ) );
-			return self::runner_workspace_publication_failure( (string) ( $result['failure_type'] ?? 'backend_failed' ), $error, 'failed', $normalized );
-		}
-
+		$result = is_array( $backend['result'] ?? null ) ? $backend['result'] : array();
 		return self::normalize_runner_workspace_publication_result( $result, $normalized );
 	}
 
@@ -363,10 +238,8 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			return self::runner_workspace_operation_failure( 'capture', 'invalid_request', $normalized['error'], 'failed', $normalized );
 		}
 
-		$backend_config = self::runner_workspace_backend_config();
-		$abilities      = is_array( $backend_config['abilities'] ?? null ) ? $backend_config['abilities'] : array();
-		$status = self::execute_runner_workspace_backend_ability( (string) ( $abilities['workspace_git_status'] ?? '' ), array( 'name' => $normalized['workspace'] ) );
-		if ( is_array( $status['error'] ?? null ) ) {
+		$status = self::runner_workspace_adapter()->git_status( (string) $normalized['workspace'] );
+		if ( empty( $status['success'] ) ) {
 			return self::runner_workspace_operation_failure( 'capture', (string) $status['failure_type'], $status['error'], 'unavailable', $normalized );
 		}
 
@@ -387,8 +260,8 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				),
 				static fn( mixed $value ): bool => '' !== $value
 			);
-			$diff = self::execute_runner_workspace_backend_ability( (string) ( $abilities['workspace_git_diff'] ?? '' ), $diff_input );
-			if ( is_array( $diff['error'] ?? null ) ) {
+			$diff = self::runner_workspace_adapter()->git_diff( $diff_input );
+			if ( empty( $diff['success'] ) ) {
 				return self::runner_workspace_operation_failure( 'capture', (string) $diff['failure_type'], $diff['error'], 'unavailable', $normalized );
 			}
 
@@ -464,10 +337,8 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value && null !== $value
 		);
 
-		$backend_config = self::runner_workspace_backend_config();
-		$abilities      = is_array( $backend_config['abilities'] ?? null ) ? $backend_config['abilities'] : array();
-		$backend = self::execute_runner_workspace_backend_ability( (string) ( $abilities['run_runner_workspace_command'] ?? '' ), $backend_input );
-		if ( ! is_array( $backend['error'] ?? null ) ) {
+		$backend = self::runner_workspace_adapter()->run_command( $backend_input );
+		if ( ! empty( $backend['success'] ) ) {
 			$result = is_array( $backend['result'] ?? null ) ? $backend['result'] : array();
 			return self::normalize_runner_workspace_command_result( $result, $normalized, $backend_input );
 		}
@@ -546,18 +417,13 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		return trim( $slug, '-' );
 	}
 
-	/** @return array<string,mixed> */
-	private static function runner_workspace_backend_config(): array {
-		$config = function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_runner_workspace_backend', array() ) : array();
-		if ( is_array( $config ) && ! empty( $config ) ) {
-			return $config;
+	private static function runner_workspace_adapter(): WP_Codebox_Runner_Workspace_Adapter {
+		static $adapter = null;
+		if ( ! $adapter instanceof WP_Codebox_Runner_Workspace_Adapter ) {
+			$adapter = new WP_Codebox_Runner_Workspace_Adapter();
 		}
 
-		return array(
-			'id'                      => '',
-			'workspace_root_constant' => '',
-			'abilities'               => array(),
-		);
+		return $adapter;
 	}
 
 	/** @param array<string,mixed> $error Error shape. @param array<string,mixed> $input Normalized input. @return array<string,mixed> */
@@ -760,51 +626,6 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			),
 			static fn( mixed $value ): bool => array() !== $value && '' !== $value && null !== $value
 		);
-	}
-
-	/** @param array<string,mixed> $input Ability input. @return array{result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
-	private static function execute_runner_workspace_backend_ability( string $ability_name, array $input ): array {
-		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
-		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
-			return array(
-				'failure_type' => 'backend_unavailable',
-				'error'        => array(
-					'code'    => 'wp_codebox_runner_workspace_backend_unavailable',
-					'message' => 'Runner workspace backend is not available for this operation.',
-				),
-			);
-		}
-
-		$result = $ability->execute( $input );
-		if ( is_wp_error( $result ) ) {
-			return array(
-				'failure_type' => 'backend_error',
-				'error'        => array(
-					'code'    => $result->get_error_code(),
-					'message' => $result->get_error_message(),
-					'data'    => $result->get_error_data(),
-				),
-			);
-		}
-
-		if ( ! is_array( $result ) ) {
-			return array(
-				'failure_type' => 'backend_invalid_response',
-				'error'        => array(
-					'code'    => 'wp_codebox_runner_workspace_backend_invalid_response',
-					'message' => 'Runner workspace backend ability returned an invalid response.',
-				),
-			);
-		}
-
-		if ( false === ( $result['success'] ?? true ) ) {
-			return array(
-				'failure_type' => (string) ( $result['failure_type'] ?? 'backend_failed' ),
-				'error'        => is_array( $result['error'] ?? null ) ? $result['error'] : array( 'message' => (string) ( $result['error'] ?? 'Runner workspace backend operation failed.' ) ),
-			);
-		}
-
-		return array( 'result' => $result );
 	}
 
 	/** @param array<string,mixed> $error Raw backend or adapter error. @return array<string,mixed> */

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -40,6 +40,7 @@ require_once __DIR__ . '/src/class-wp-codebox-host-recipe-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-status-taxonomy.php';
 require_once __DIR__ . '/src/class-wp-codebox-host-run-result-normalizer.php';
 require_once __DIR__ . '/src/class-wp-codebox-managed-host-command.php';
+require_once __DIR__ . '/src/class-wp-codebox-runner-workspace-adapter.php';
 require_once __DIR__ . '/src/class-wp-codebox-parent-site-seed-exporter.php';
 require_once __DIR__ . '/src/class-wp-codebox-json.php';
 require_once __DIR__ . '/src/class-wp-codebox-run-plan.php';

--- a/scripts/php-runner-workspace-adapter-boundary-smoke.php
+++ b/scripts/php-runner-workspace-adapter-boundary-smoke.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	private mixed $data;
+
+	public function __construct( string $code = '', string $message = '', mixed $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+$GLOBALS['wp_codebox_test_abilities'] = array();
+$GLOBALS['wp_codebox_test_filters']   = array();
+$GLOBALS['wp_codebox_ability_calls']  = array();
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $priority, $accepted_args );
+	$GLOBALS['wp_codebox_test_filters'][ $hook ][] = $callback;
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+
+	return $value;
+}
+
+function wp_get_ability( string $name ): ?object {
+	return $GLOBALS['wp_codebox_test_abilities'][ $name ] ?? null;
+}
+
+function register_test_ability( string $name, callable $callback ): void {
+	$GLOBALS['wp_codebox_test_abilities'][ $name ] = new class( $name, $callback ) {
+		public function __construct( private string $name, private mixed $callback ) {}
+
+		public function execute( array $input ): mixed {
+			$GLOBALS['wp_codebox_ability_calls'][] = array( 'name' => $this->name, 'input' => $input );
+			return ( $this->callback )( $input );
+		}
+	};
+}
+
+function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $label . " failed.\nExpected: " . json_encode( $expected, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\nActual: " . json_encode( $actual, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n" );
+		exit( 1 );
+	}
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
+
+add_filter(
+	'wp_codebox_runner_workspace_backend',
+	static fn(): array => array(
+		'id'        => 'datamachine-code',
+		'abilities' => array(
+			'workspace_adopt'                => 'datamachine-code/workspace-adopt',
+			'workspace_show'                 => 'datamachine-code/workspace-show',
+			'workspace_clone'                => 'datamachine-code/workspace-clone',
+			'workspace_worktree_add'         => 'datamachine-code/workspace-worktree-add',
+			'workspace_git_status'           => 'datamachine-code/workspace-git-status',
+			'workspace_git_diff'             => 'datamachine-code/workspace-git-diff',
+			'run_runner_workspace_command'   => 'datamachine-code/run-runner-workspace-command',
+			'publish_runner_workspace'       => 'datamachine-code/publish-runner-workspace',
+		),
+	)
+);
+
+register_test_ability( 'datamachine-code/workspace-adopt', static fn( array $input ): array => array( 'success' => true, 'handle' => 'wp-codebox@task', 'path' => $input['path'] ) );
+register_test_ability( 'datamachine-code/workspace-show', static fn(): WP_Error => new WP_Error( 'missing', 'not found' ) );
+register_test_ability( 'datamachine-code/workspace-clone', static fn(): array => array( 'success' => true ) );
+register_test_ability( 'datamachine-code/workspace-worktree-add', static fn( array $input ): array => array( 'success' => true, 'handle' => 'wp-codebox@task', 'path' => '/tmp/wp-codebox@task', 'branch' => $input['branch'] ) );
+register_test_ability( 'datamachine-code/workspace-git-status', static fn(): array => array( 'success' => true, 'name' => 'wp-codebox@task', 'repo' => 'wp-codebox', 'files' => array( ' M src/keep.php', ' M vendor/skip.php' ) ) );
+register_test_ability( 'datamachine-code/workspace-git-diff', static fn(): array => array( 'success' => true, 'diff' => "diff --git a/src/keep.php b/src/keep.php\n+keep\ndiff --git a/vendor/skip.php b/vendor/skip.php\n+skip\n" ) );
+register_test_ability( 'datamachine-code/run-runner-workspace-command', static fn( array $input ): array => array( 'success' => true, 'command' => $input['command'], 'exit_code' => 0, 'stdout' => 'ok' ) );
+register_test_ability( 'datamachine-code/publish-runner-workspace', static fn( array $input ): array => array( 'success' => true, 'workspace_handle' => $input['workspace_handle'], 'head' => 'agent/change', 'commit_sha' => 'abc123', 'pr_number' => 7, 'pr_url' => 'https://example.test/pr/7' ) );
+
+$prepared = WP_Codebox_Abilities::prepare_runner_workspace( array( 'repo' => 'Automattic/wp-codebox', 'checkout_path' => '/tmp/checkout', 'branch' => 'agent/change' ) );
+assert_same_contract( true, $prepared['success'], 'prepare success' );
+assert_same_contract( 'wp-codebox/runner-workspace-prepare-result/v1', $prepared['schema'], 'prepare schema' );
+assert_same_contract( 'wp-codebox@task', $prepared['handle'], 'prepare handle' );
+
+$captured = WP_Codebox_Abilities::capture_runner_workspace( array( 'workspace' => 'wp-codebox@task', 'repo' => 'wp-codebox', 'exclude_paths' => array( 'vendor/**' ) ) );
+assert_same_contract( true, $captured['success'], 'capture success' );
+assert_same_contract( array( 'src/keep.php' ), $captured['status']['files'], 'capture excludes files' );
+assert_same_contract( false, str_contains( $captured['diff']['diff'], 'vendor/skip.php' ), 'capture excludes diff section' );
+
+$published = WP_Codebox_Abilities::publish_runner_workspace(
+	array(
+		'workspace'      => 'wp-codebox@task',
+		'repo'           => 'wp-codebox',
+		'commit_message' => 'Test change',
+		'title'          => 'Test change',
+		'body'           => 'Body',
+	)
+);
+assert_same_contract( true, $published['success'], 'publish success' );
+assert_same_contract( 7, $published['pull_request']['number'], 'publish PR number' );
+
+$command = WP_Codebox_Abilities::run_runner_workspace_command( array( 'workspace' => 'wp-codebox@task', 'repo' => 'wp-codebox', 'command' => 'php -l file.php' ) );
+assert_same_contract( true, $command['success'], 'command success' );
+assert_same_contract( 'completed', $command['status'], 'command status' );
+
+$GLOBALS['wp_codebox_test_abilities']['datamachine-code/workspace-git-status'] = new class() {
+	public function execute( array $input ): WP_Error {
+		unset( $input );
+		return new WP_Error( 'datamachine-code/workspace-git-status', 'datamachine-code/workspace-git-status exploded', array( 'ability' => 'datamachine-code/workspace-git-status' ) );
+	}
+};
+
+$failure = WP_Codebox_Abilities::capture_runner_workspace( array( 'workspace' => 'wp-codebox@task' ) );
+assert_same_contract( false, $failure['success'], 'failure success' );
+assert_same_contract( 'runner workspace backend exploded', $failure['error']['message'], 'public error redacts backend ability slug' );
+assert_same_contract( false, array_key_exists( 'ability', $failure['error']['data'] ?? array() ), 'public error removes backend ability key' );
+
+fwrite( STDOUT, "PHP runner workspace adapter boundary smoke passed\n" );


### PR DESCRIPTION
## Summary
- Add a first-class WP Codebox runner workspace adapter boundary.
- Route prepare, publish, capture, and command operations through normalized adapter envelopes.
- Add a boundary smoke script for the adapter contract.

## Verification
- php -l packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php
- php -l scripts/php-runner-workspace-adapter-boundary-smoke.php
- php scripts/php-runner-workspace-adapter-boundary-smoke.php
- php scripts/php-agents-api-execution-targets-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing the runner workspace boundary, drafting the adapter implementation/tests, and preparing this PR.