### PR TITLE
Stabilize browser SDK DTO normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,7 @@ Browser run and artifact outputs use one product-safe DTO lane:
 - `wp-codebox/browser-run-result/v1` reports `operation`, `status`, `success`, normalized `result`, `artifactRefs`, `diagnostics`, and an `error` on failure.
 - `wp-codebox/browser-artifact-persistence/ref/v1` reports persisted browser artifact data and canonical `artifactRefs`. Older `wp-codebox/browser-artifact-persistence-projection/v1` inputs are still accepted by helpers for compatibility, but new consumer-facing output uses the `/ref/v1` schema.
 - `window.wpCodeboxBrowser.v1.normalizeBrowserRunResult()` and `browserArtifactPersistenceRef()` normalize legacy browser runner/materialization variants into those DTOs.
+- Non-browser TypeScript consumers should use the equivalent public DTO helpers from `@automattic/wp-codebox-core/public`: `normalizeBrowserRunResult()`, `browserRunResultEnvelope()`, `browserArtifactPersistenceProjection()`, `persistedBrowserArtifactRefs()`, and `artifactBundleFileManifest()`.
 
 `browser_runner.capture_paths` is the generic result-capture layer for browser materialization. Each entry names a sandbox-local file that the generated runner should read after the ability or hook returns. The runner writes `/tmp/wp-codebox-agent-result.json` with `wp-codebox/browser-materialization/v1`, normalized `success`/`status`/`error` fields, invocation metadata, the raw response, and captured files as `wp-codebox/browser-capture/v1` records. JSON files are decoded into `json`, text files into `content`, and binary files into `content_base64`, bounded by `max_bytes`.
 

--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -64,7 +64,11 @@ The stable public surface is grouped by lifecycle area rather than by product:
   returns `wp-codebox/browser-artifact-persistence/ref/v1`; `runBrowserSessionRecipe()`
   executes the existing runtime helper and returns the stable browser-run DTO;
   `methods` exposes stable references to the existing browser runtime helpers for
-  callers that need legacy raw results internally.
+  callers that need legacy raw results internally. TypeScript consumers outside
+  the browser can use the matching DTO helpers exported from
+  `@automattic/wp-codebox-core/public`: `normalizeBrowserRunResult()`,
+  `browserRunResultEnvelope()`, `browserArtifactPersistenceProjection()`,
+  `persistedBrowserArtifactRefs()`, and `artifactBundleFileManifest()`.
 - **Artifacts:** manifest, paths, capture policy, layout, references, review,
   diagnostics, test result, export link, storage, result envelope, evidence
   envelope, and materialization contracts.

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -207,13 +207,33 @@
 		return Object.fromEntries( Object.entries( ref ).filter( ( [ , item ] ) => item !== undefined && item !== null ) );
 	};
 
+	const normalizeBrowserArtifactRefs = ( artifacts ) => {
+		const refs = [];
+		const seen = new Set();
+		for ( const artifact of Array.isArray( artifacts ) ? artifacts : [] ) {
+			const ref = normalizeBrowserArtifactRef( artifact );
+			if ( ! ref ) {
+				continue;
+			}
+			const key = `${ ref.kind }\u0000${ ref.id || '' }\u0000${ ref.path || '' }\u0000${ ref.digest?.algorithm || '' }\u0000${ ref.digest?.value || '' }`;
+			if ( seen.has( key ) ) {
+				continue;
+			}
+			seen.add( key );
+			refs.push( ref );
+		}
+		return refs;
+	};
+
 	const browserArtifactPersistenceRef = ( input ) => {
 		const source = input?.schema === 'wp-codebox/materialization-result/v1' && isPlainObject( input.result ) ? input.result : ( isPlainObject( input?.result ) && ( input.result.artifact || input.result.artifacts || input.result.artifact_bundle || input.result.artifactBundle || input.result.materialization ) ? input.result : input || {} );
 		const artifactBundle = isPlainObject( source.artifact_bundle ) ? source.artifact_bundle : ( isPlainObject( source.artifactBundle ) ? source.artifactBundle : null );
 		const artifact = isPlainObject( source.artifact ) ? source.artifact : null;
 		const artifacts = Array.isArray( source.artifacts ) ? source.artifacts.filter( isPlainObject ) : ( artifact ? [ artifact ] : [] );
 		const materialization = isPlainObject( source.materialization ) ? source.materialization : null;
+		const existingRefs = normalizeBrowserArtifactRefs( source.artifactRefs );
 		const refs = [];
+		refs.push( ...existingRefs );
 		const bundleRef = normalizeBrowserArtifactRef( artifactBundle, { kind: 'artifact-bundle' } );
 		if ( bundleRef ) {
 			refs.push( bundleRef );
@@ -247,9 +267,41 @@
 		};
 	};
 
+	const normalizeBrowserRunStatus = ( value, success ) => {
+		if ( value === 'completed' || value === 'failed' || value === 'skipped' ) {
+			return value;
+		}
+		return success === false ? 'failed' : 'completed';
+	};
+
+	const normalizeBrowserRunDiagnostics = ( diagnostics ) => ( Array.isArray( diagnostics ) ? diagnostics
+		.filter( ( diagnostic ) => isPlainObject( diagnostic ) && typeof diagnostic.code === 'string' && typeof diagnostic.message === 'string' )
+		.map( ( diagnostic ) => Object.fromEntries( Object.entries( {
+			code: diagnostic.code,
+			message: diagnostic.message,
+			severity: [ 'info', 'warning', 'error' ].includes( diagnostic.severity ) ? diagnostic.severity : undefined,
+			phase: typeof diagnostic.phase === 'string' ? diagnostic.phase : undefined,
+			metadata: isPlainObject( diagnostic.metadata ) ? diagnostic.metadata : undefined,
+		} ).filter( ( [ , item ] ) => item !== undefined ) ) ) : [] );
+
 	const normalizeBrowserRunResult = ( result, operation = 'browser-run' ) => {
 		if ( result?.schema === 'wp-codebox/browser-run-result/v1' ) {
-			return result;
+			const status = normalizeBrowserRunStatus( result.status, result.success );
+			const success = status === 'completed';
+			const payload = isPlainObject( result.result ) ? result.result : null;
+			const artifactRefs = normalizeBrowserArtifactRefs( result.artifactRefs );
+			return Object.fromEntries( Object.entries( {
+				schema: 'wp-codebox/browser-run-result/v1',
+				operation: typeof result.operation === 'string' && result.operation ? result.operation : operation,
+				status,
+				success,
+				result: success ? ( payload || {} ) : payload,
+				artifactRefs: artifactRefs.length ? artifactRefs : browserArtifactPersistenceRef( payload || result ).artifactRefs,
+				diagnostics: normalizeBrowserRunDiagnostics( result.diagnostics ),
+				metadata: isPlainObject( result.metadata ) ? result.metadata : undefined,
+				error: status === 'failed' ? normalizeBrowserSdkError( result.error || new Error( 'Browser run failed.' ) ) : undefined,
+				reason: status === 'skipped' && typeof result.reason === 'string' ? result.reason : undefined,
+			} ).filter( ( [ , item ] ) => item !== undefined ) );
 		}
 		const payload = isPlainObject( result?.result ) ? result.result : ( isPlainObject( result?.data ) ? result.data : ( isPlainObject( result?.response ) ? result.response : ( isPlainObject( result ) ? result : null ) ) );
 		const success = result?.success === true || payload?.success === true;

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -91,4 +91,44 @@ assert.deepEqual(plain(browserRun.artifactRefs), [
 ])
 assert.equal(api.v1.browserArtifactPersistenceRef(browserRun.result).schema, "wp-codebox/browser-artifact-persistence/ref/v1")
 
+const canonicalBrowserRun = api.v1.normalizeBrowserRunResult({
+  schema: "wp-codebox/browser-run-result/v1",
+  operation: "legacy-operation",
+  status: "failed",
+  success: true,
+  result: "not-an-object",
+  artifactRefs: [
+    { kind: "browser-html", path: "files/browser/index.html", sha256: "def" },
+    { role: "browser-html", path: "files/browser/index.html", content_digest: "def" },
+  ],
+  diagnostics: [
+    { code: "capture-warning", message: "Captured with fallback.", severity: "notice" },
+    { code: "capture-failed", message: "Capture failed.", severity: "error", metadata: { path: "files/browser/index.html" } },
+  ],
+  error: { message: "failed from canonical input", code: "canonical-failed" },
+}, "browser-run")
+assert.equal(canonicalBrowserRun.schema, "wp-codebox/browser-run-result/v1")
+assert.equal(canonicalBrowserRun.operation, "legacy-operation")
+assert.equal(canonicalBrowserRun.status, "failed")
+assert.equal(canonicalBrowserRun.success, false)
+assert.equal(canonicalBrowserRun.result, null)
+assert.deepEqual(plain(canonicalBrowserRun.artifactRefs), [
+  { kind: "browser-html", path: "files/browser/index.html", digest: { algorithm: "sha256", value: "def" } },
+])
+assert.deepEqual(plain(canonicalBrowserRun.diagnostics), [
+  { code: "capture-warning", message: "Captured with fallback." },
+  { code: "capture-failed", message: "Capture failed.", severity: "error", metadata: { path: "files/browser/index.html" } },
+])
+assert.equal(canonicalBrowserRun.error.schema, "wp-codebox/browser-sdk-error/v1")
+assert.equal(canonicalBrowserRun.error.code, "canonical-failed")
+
+assert.deepEqual(plain(api.v1.browserArtifactPersistenceRef({
+  schema: "wp-codebox/browser-artifact-persistence/ref/v1",
+  artifactRefs: [
+    { kind: "artifact-bundle", id: "artifact-bundle-sha256-abc", directory: "artifacts/run-1", contentDigest: { algorithm: "sha256", value: "abc" } },
+  ],
+}).artifactRefs), [
+  { kind: "artifact-bundle", id: "artifact-bundle-sha256-abc", path: "artifacts/run-1", digest: { algorithm: "sha256", value: "abc" } },
+])
+
 console.log("browser sdk facade ok")

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
+import {
+  artifactBundleFileManifest,
+  browserArtifactPersistenceProjection,
+  browserRunResultEnvelope,
+  normalizeBrowserRunResult,
+  persistedBrowserArtifactRefs,
+} from "../packages/runtime-core/src/public.js"
 
 const root = new URL("..", import.meta.url)
 
@@ -77,5 +84,11 @@ for (const contractArea of [
 assert.match(docs, /@automattic\/wp-codebox-core\/internals` exists for this monorepo's package split/)
 assert.match(docs, /not a stable compatibility surface for external integrations/)
 assert.match(docs, /New external TypeScript\s+consumers should prefer/)
+
+assert.equal(typeof normalizeBrowserRunResult, "function")
+assert.equal(typeof browserRunResultEnvelope, "function")
+assert.equal(typeof browserArtifactPersistenceProjection, "function")
+assert.equal(typeof persistedBrowserArtifactRefs, "function")
+assert.equal(typeof artifactBundleFileManifest, "function")
 
 console.log("public API contract ok")


### PR DESCRIPTION
## Summary
- Document browser DTO helpers for non-browser TypeScript consumers.
- Normalize existing browser-run and artifact-ref DTO inputs through the browser SDK facade.
- Add contract coverage for browser SDK and public API exports.

## Verification
- npm run test:browser-sdk-facade
- npm run test:public-api-contract
- npm run test:browser-callback-materialization-contracts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing browser SDK API gaps, drafting normalization/test updates, and preparing this PR.