### PR TITLE
Align fanout aggregation contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:run-registry": "tsx tests/run-registry.test.ts",
     "test:run-plan-executor": "tsx tests/run-plan-executor.test.ts",
     "test:agent-fanout-executor": "tsx tests/agent-fanout-executor.test.ts",
+    "test:fanout-aggregation-contract-parity": "tsx tests/fanout-aggregation-contract-parity.test.ts",
     "test:runtime-php-snippets": "tsx tests/runtime-php-snippets.test.ts",
     "test:browser-runner-template": "tsx tests/browser-runner-template.test.ts",
     "test:editor-actions": "tsx tests/editor-actions.test.ts",

--- a/packages/cli/src/agent-fanout.ts
+++ b/packages/cli/src/agent-fanout.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { commandArgValue, createRunPlanEvent, executeRunPlan, FANOUT_EVENT_SCHEMA, FANOUT_PLAN_SCHEMA, FANOUT_REQUEST_SCHEMA, FANOUT_RESULT_SCHEMA, normalizeRunPlanConcurrency, normalizeRunPlanWorkerDescriptors, parseCommandJsonObject, type FanoutLifecycleEvent, type FanoutRequestContract, type RunPlanWorkerAdapter, type RunPlanWorkerDescriptor } from "@automattic/wp-codebox-core"
-import { agentTaskStatusSucceeded, aggregateFanoutOutputs, normalizeAgentTaskStatus, stripUndefined, type FanoutAggregationOutput } from "@automattic/wp-codebox-core/internals"
+import { agentTaskStatusSucceeded, aggregateFanoutOutputs, fanoutAggregationInputFromWorkerArtifacts, normalizeAgentTaskStatus, stripUndefined, type FanoutAggregationOutput } from "@automattic/wp-codebox-core/internals"
 import { runAgentTask, type AgentTaskRunInput, type AgentTaskRunOptions } from "./commands/agent-task-run.js"
 
 const MAX_FANOUT_CONCURRENCY = 8
@@ -96,19 +96,20 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
   const workerResults: AgentFanoutWorkerResult[] = execution.workers.map(({ success: _success, workerId: _workerId, ...result }) => result as unknown as AgentFanoutWorkerResult)
 
   await emitEvent(eventsPath, { event: "aggregation.started", total: workers.length, completed: workerResults.filter((worker) => agentTaskStatusSucceeded(worker.status)).length, failed: workerResults.filter((worker) => !agentTaskStatusSucceeded(worker.status)).length })
-  const aggregate = aggregateFanoutOutputs({
+  const aggregationInput = fanoutAggregationInputFromWorkerArtifacts({
     plan: { id: sessionId, workers: workers.map((worker) => ({ id: worker.id, dependsOn: worker.dependsOn, required: worker.required, artifactNamespace: worker.artifactNamespace })) },
     policy: stringValue(request.aggregation?.policy) || "fail",
-    aggregation: request.aggregation,
-    worker_results: workerResults.map((worker) => ({
-      worker_id: worker.worker_id,
+    aggregator: request.aggregation,
+    workerResultRefs: workerResults.map((worker) => ({
+      workerId: worker.worker_id,
       status: worker.status,
       required: worker.required,
-      result_ref: worker.result_ref,
-      artifact_refs: worker.artifact_refs,
+      resultRef: worker.result_ref,
+      artifactRefs: worker.artifact_refs,
       error: worker.error,
     })),
-  }, {
+  })
+  const aggregate = aggregateFanoutOutputs(aggregationInput, {
     finalArtifactRefs: [{ path: "aggregate/final/result.json", kind: "fanout-aggregate-output", namespace: "aggregate/final", contentType: "application/json" }],
   })
   await writeJson(join(aggregateRoot, "result.json"), aggregate)

--- a/packages/runtime-core/src/fanout-aggregation.ts
+++ b/packages/runtime-core/src/fanout-aggregation.ts
@@ -101,6 +101,16 @@ export interface FanoutAggregationResultOptions {
   metadata?: Record<string, unknown>
 }
 
+export interface FanoutAggregationInputFromWorkerArtifactsOptions {
+  plan: FanoutPlan | FanoutAggregationInputRequest["plan"]
+  policy?: FanoutAggregationPolicy
+  aggregator?: FanoutAggregatorConfig
+  workerResultRefs?: Array<FanoutWorkerResultRef | Record<string, unknown>>
+  workerArtifacts?: Array<FanoutArtifactRef | Record<string, unknown>>
+  conflictCandidates?: Array<FanoutConflictRecord | Record<string, unknown>>
+  metadata?: Record<string, unknown>
+}
+
 export interface FanoutAggregationOutput {
   schema: typeof FANOUT_AGGREGATION_OUTPUT_SCHEMA
   status: FanoutAggregationOutputStatus
@@ -126,12 +136,24 @@ export type FanoutAggregationInputRequest = Partial<Omit<FanoutAggregationInput,
   aggregation?: FanoutAggregatorConfig
 }
 
+export function fanoutAggregationInputFromWorkerArtifacts(options: FanoutAggregationInputFromWorkerArtifactsOptions): FanoutAggregationInput {
+  return normalizeFanoutAggregationInput({
+    plan: options.plan,
+    policy: options.policy ?? "fail",
+    aggregator: options.aggregator,
+    workerResultRefs: options.workerResultRefs,
+    artifactRefs: options.workerArtifacts,
+    conflictCandidates: options.conflictCandidates,
+    metadata: options.metadata,
+  })
+}
+
 export function normalizeFanoutAggregationInput(input: FanoutAggregationInputRequest): FanoutAggregationInput {
   const workerResultRefs = (input.workerResultRefs ?? input.worker_results ?? input.workerResults ?? []).map(normalizeWorkerResultRef)
-  const artifactRefs = [
-    ...(input.artifactRefs ?? input.artifact_refs ?? []).map((artifact) => normalizeArtifactRef(artifact)),
-    ...workerResultRefs.flatMap((worker) => worker.artifactRefs),
-  ]
+  const inputArtifactRefs = (input.artifactRefs ?? input.artifact_refs ?? []).map((artifact) => normalizeArtifactRef(artifact))
+  const artifactRefs = input.schema === FANOUT_AGGREGATION_INPUT_SCHEMA
+    ? inputArtifactRefs
+    : [...inputArtifactRefs, ...workerResultRefs.flatMap((worker) => worker.artifactRefs)]
 
   return {
     schema: FANOUT_AGGREGATION_INPUT_SCHEMA,

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -11,6 +11,7 @@
 		'browser-runtime:normalize-error',
 		'browser-runtime:normalize-result',
 		'browser-runtime:normalize-browser-run-result',
+		'browser-runtime:aggregate-fanout-outputs',
 		'browser-runtime:invoke-result',
 		'playground:run-php',
 		'playground:run-recipe',
@@ -339,6 +340,7 @@
 		normalizeError: normalizeBrowserSdkError,
 		normalizeBrowserRunResult,
 		browserArtifactPersistenceRef,
+		aggregateFanoutOutputs: ( input ) => api.aggregateFanoutOutputs( input ),
 		normalizeResult: normalizeOperationResult,
 		result: browserSdkResult,
 		runBrowserSessionRecipe: async ( client, session, taskPayload, options = {} ) => normalizeBrowserRunResult( await api.runBrowserSessionRecipe( client, session, taskPayload, options ), 'browser-session-recipe' ),
@@ -347,6 +349,7 @@
 			browserSessionRecipe: api.browserSessionRecipe,
 			ensureDirectory: api.ensureDirectory,
 			installTheme: api.installTheme,
+			aggregateFanoutOutputs: api.aggregateFanoutOutputs,
 			preparedBrowserRuntimeContract: api.preparedBrowserRuntimeContract,
 			preparedBrowserRuntimeStatus: api.preparedBrowserRuntimeStatus,
 			runBrowserRuntimeContractProbe: api.runBrowserRuntimeContractProbe,
@@ -1248,9 +1251,10 @@ try {
 	const normalizeFanoutWorkerResultRef = ( worker ) => {
 		const artifactRefs = Array.isArray( worker?.artifactRefs ) ? worker.artifactRefs : Array.isArray( worker?.artifact_refs ) ? worker.artifact_refs : [];
 		const workerId = typeof worker?.workerId === 'string' ? worker.workerId : typeof worker?.worker_id === 'string' ? worker.worker_id : '';
+		const status = typeof worker?.status === 'string' && worker.status.length > 0 ? worker.status : 'missing';
 		return {
 			workerId,
-			status: typeof worker?.status === 'string' ? worker.status : 'missing',
+			status: status === 'completed' && worker?.success === true ? 'succeeded' : status,
 			required: worker?.required !== false,
 			resultRef: typeof worker?.resultRef === 'string' ? worker.resultRef : typeof worker?.result_ref === 'string' ? worker.result_ref : undefined,
 			artifactRefs: artifactRefs.map( ( artifact ) => normalizeFanoutArtifactRef( artifact, workerId ) ),
@@ -1273,6 +1277,7 @@ try {
 		const source = input && typeof input === 'object' ? input : {};
 		const workerResultRefs = ( Array.isArray( source.workerResultRefs ) ? source.workerResultRefs : Array.isArray( source.worker_results ) ? source.worker_results : Array.isArray( source.workerResults ) ? source.workerResults : [] ).map( normalizeFanoutWorkerResultRef );
 		const directArtifactRefs = ( Array.isArray( source.artifactRefs ) ? source.artifactRefs : Array.isArray( source.artifact_refs ) ? source.artifact_refs : [] ).map( ( artifact ) => normalizeFanoutArtifactRef( artifact ) );
+		const artifactRefs = source.schema === fanoutAggregationInputSchema ? directArtifactRefs : [ ...directArtifactRefs, ...workerResultRefs.flatMap( ( worker ) => worker.artifactRefs ) ];
 		return {
 			schema: fanoutAggregationInputSchema,
 			plan: {
@@ -1282,7 +1287,7 @@ try {
 			policy: typeof source.policy === 'string' ? source.policy : 'fail',
 			aggregator: source.aggregator && typeof source.aggregator === 'object' ? source.aggregator : source.aggregation && typeof source.aggregation === 'object' ? source.aggregation : undefined,
 			workerResultRefs,
-			artifactRefs: [ ...directArtifactRefs, ...workerResultRefs.flatMap( ( worker ) => worker.artifactRefs ) ],
+			artifactRefs,
 			conflictCandidates: ( Array.isArray( source.conflictCandidates ) ? source.conflictCandidates : Array.isArray( source.conflict_candidates ) ? source.conflict_candidates : [] ).map( normalizeFanoutConflict ),
 			...( source.metadata && typeof source.metadata === 'object' && ! Array.isArray( source.metadata ) ? { metadata: source.metadata } : {} ),
 		};
@@ -1381,10 +1386,7 @@ try {
 			rawWorkerArtifactRefs: normalized.artifactRefs,
 			finalArtifactRefs: hasErrors ? [] : [ { path: outputPath, kind: 'fanout-aggregate-output', contentType: 'application/json' } ],
 			conflicts,
-			metadata: {
-				...( normalized.metadata || {} ),
-				events: [ 'fanout.started', 'aggregation.started', 'aggregation.completed', hasErrors ? 'fanout.failed' : 'fanout.completed' ].map( ( event ) => ( { schema: 'wp-codebox/agent-fanout-event/v1', event } ) ),
-			},
+			metadata: normalized.metadata,
 		};
 	};
 
@@ -1895,6 +1897,7 @@ echo wp_json_encode( array(
 
 	const wpCodeboxBrowserApi = {
 		activateTheme,
+		aggregateFanoutOutputs,
 		browserSessionRecipe,
 		ensureDirectory,
 		installTheme,

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -31,6 +31,7 @@ assert.deepEqual(plain(api.v1.info()), {
     "browser-runtime:normalize-error",
     "browser-runtime:normalize-result",
     "browser-runtime:normalize-browser-run-result",
+    "browser-runtime:aggregate-fanout-outputs",
     "browser-runtime:invoke-result",
     "playground:run-php",
     "playground:run-recipe",

--- a/tests/fanout-aggregation-contract-parity.test.ts
+++ b/tests/fanout-aggregation-contract-parity.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import vm from "node:vm"
+
+import { aggregateFanoutOutputs, fanoutAggregationInputFromWorkerArtifacts } from "../packages/runtime-core/src/index.js"
+import { executeAgentFanoutRequest } from "../packages/cli/src/agent-fanout.js"
+import { FANOUT_REQUEST_SCHEMA } from "../packages/runtime-core/src/index.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+const root = new URL("../", import.meta.url)
+const fixture = JSON.parse(await readFile(new URL("fixtures/fanout-aggregation-contract.json", import.meta.url), "utf8"))
+const plain = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
+
+const runtimeOutput = plain(aggregateFanoutOutputs(fixture.input))
+assert.deepEqual(runtimeOutput, fixture.expectedOutput, "runtime-core aggregation output must match the canonical fixture")
+
+const normalizedFromArtifacts = plain(fanoutAggregationInputFromWorkerArtifacts({
+  plan: fixture.input.plan,
+  policy: fixture.input.policy,
+  aggregator: fixture.input.aggregation,
+  workerResultRefs: fixture.input.worker_results,
+}))
+assert.equal(normalizedFromArtifacts.schema, "wp-codebox/agent-fanout-aggregation-input/v1")
+assert.deepEqual(plain(aggregateFanoutOutputs(normalizedFromArtifacts)), fixture.expectedOutput, "worker artifact refs must normalize into the same aggregation output")
+
+const runtimeSource = await readFile(new URL("packages/wordpress-plugin/assets/browser-runtime.js", root), "utf8")
+const sandbox = {
+  window: {} as { wpCodeboxBrowser?: { v1?: { aggregateFanoutOutputs?: (input: unknown) => unknown } } },
+  btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+  TextDecoder,
+  TextEncoder,
+  URL,
+}
+vm.runInNewContext(runtimeSource, sandbox, { filename: "browser-runtime.js" })
+const browserAggregate = sandbox.window.wpCodeboxBrowser?.v1?.aggregateFanoutOutputs
+assert.equal(typeof browserAggregate, "function", "browser runtime must expose the aggregation contract helper")
+assert.deepEqual(plain(browserAggregate?.(fixture.input)), fixture.expectedOutput, "WordPress browser runtime aggregation output must match runtime-core")
+
+await withTempDir("wp-codebox-fanout-aggregation-parity-", async (artifactRoot) => {
+  const result = await executeAgentFanoutRequest({
+    schema: FANOUT_REQUEST_SCHEMA,
+    concurrency: 2,
+    orchestrator: { session_id: "fanout-contract-fixture" },
+    aggregation: fixture.input.aggregation,
+    workers: [
+      { id: "alpha", goal: "Collect alpha result" },
+      { id: "beta", goal: "Collect beta result", dependsOn: ["alpha"] },
+    ],
+  }, {
+    artifactRoot,
+    recipeDirectory: artifactRoot,
+    runWorker: async (input) => ({
+      success: true,
+      status: "completed",
+      evidence_refs: [{ path: `${input.artifacts_path}/report.json`, kind: "worker-report" }],
+    }),
+  })
+
+  assert.equal(result.aggregate.schema, "wp-codebox/agent-fanout-aggregation-output/v1")
+  assert.equal(result.aggregate.status, "succeeded")
+  assert.deepEqual(result.aggregate.workerResultRefs.map((worker) => worker.status), ["succeeded", "succeeded"])
+  assert.equal(result.aggregate.rawWorkerArtifactRefs.length, 2)
+  assert.deepEqual(result.aggregate.finalArtifactRefs, [{ path: "aggregate/final/result.json", kind: "fanout-aggregate-output", namespace: "aggregate/final", contentType: "application/json" }])
+})
+
+console.log("fanout aggregation contract parity ok")

--- a/tests/fixtures/fanout-aggregation-contract.json
+++ b/tests/fixtures/fanout-aggregation-contract.json
@@ -1,0 +1,137 @@
+{
+  "input": {
+    "plan": {
+      "id": "fanout-contract-fixture",
+      "workers": [
+        {
+          "id": "alpha",
+          "artifact_namespace": "workers/alpha"
+        },
+        {
+          "id": "beta",
+          "depends_on": [
+            "alpha"
+          ],
+          "artifact_namespace": "workers/beta"
+        }
+      ]
+    },
+    "policy": "fail",
+    "aggregation": {
+      "agent": "generic-aggregator",
+      "outputNamespace": "aggregate/final"
+    },
+    "worker_results": [
+      {
+        "worker_id": "alpha",
+        "status": "completed",
+        "success": true,
+        "result_ref": "fanout/workers/alpha/result.json",
+        "artifact_refs": [
+          {
+            "path": "fanout/workers/alpha/artifacts/report.json",
+            "final_path": "reports/alpha.json",
+            "kind": "worker-report"
+          }
+        ]
+      },
+      {
+        "worker_id": "beta",
+        "status": "succeeded",
+        "result_ref": "fanout/workers/beta/result.json",
+        "artifact_refs": [
+          {
+            "path": "fanout/workers/beta/artifacts/report.json",
+            "final_path": "reports/beta.json",
+            "kind": "worker-report"
+          }
+        ]
+      }
+    ]
+  },
+  "expectedOutput": {
+    "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
+    "status": "succeeded",
+    "policy": "fail",
+    "plan": {
+      "id": "fanout-contract-fixture",
+      "workers": [
+        {
+          "id": "alpha",
+          "artifact_namespace": "workers/alpha",
+          "dependsOn": [],
+          "required": true,
+          "artifactNamespace": "workers/alpha"
+        },
+        {
+          "id": "beta",
+          "depends_on": [
+            "alpha"
+          ],
+          "artifact_namespace": "workers/beta",
+          "dependsOn": [
+            "alpha"
+          ],
+          "required": true,
+          "artifactNamespace": "workers/beta"
+        }
+      ]
+    },
+    "aggregator": {
+      "agent": "generic-aggregator",
+      "outputNamespace": "aggregate/final"
+    },
+    "workerResultRefs": [
+      {
+        "workerId": "alpha",
+        "status": "succeeded",
+        "required": true,
+        "resultRef": "fanout/workers/alpha/result.json",
+        "artifactRefs": [
+          {
+            "path": "fanout/workers/alpha/artifacts/report.json",
+            "kind": "worker-report",
+            "workerId": "alpha",
+            "finalPath": "reports/alpha.json"
+          }
+        ]
+      },
+      {
+        "workerId": "beta",
+        "status": "succeeded",
+        "required": true,
+        "resultRef": "fanout/workers/beta/result.json",
+        "artifactRefs": [
+          {
+            "path": "fanout/workers/beta/artifacts/report.json",
+            "kind": "worker-report",
+            "workerId": "beta",
+            "finalPath": "reports/beta.json"
+          }
+        ]
+      }
+    ],
+    "rawWorkerArtifactRefs": [
+      {
+        "path": "fanout/workers/alpha/artifacts/report.json",
+        "kind": "worker-report",
+        "workerId": "alpha",
+        "finalPath": "reports/alpha.json"
+      },
+      {
+        "path": "fanout/workers/beta/artifacts/report.json",
+        "kind": "worker-report",
+        "workerId": "beta",
+        "finalPath": "reports/beta.json"
+      }
+    ],
+    "finalArtifactRefs": [
+      {
+        "path": "aggregate/final/result.json",
+        "kind": "fanout-aggregate-output",
+        "contentType": "application/json"
+      }
+    ],
+    "conflicts": []
+  }
+}


### PR DESCRIPTION
## Summary
- Add a runtime-core fanout aggregation input primitive that normalizes worker result/artifact refs into the executable aggregation input contract.
- Make CLI fanout aggregation call that primitive before producing the typed wp-codebox/agent-fanout-aggregation-output/v1 output.
- Align the WordPress browser runtime aggregation helper with runtime-core output shape and cover runtime-core, CLI, and browser runtime parity with a fixture test.

## Tests
- npm run build
- npm run test:fanout-aggregation-contract-parity
- npm run test:agent-fanout-executor
- npm run test:browser-sdk-facade
- npm exec -- tsx scripts/fanout-aggregation-contract-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the aggregation contract alignment, adding tests/fixtures, running verification, and drafting this PR description.
