### PR TITLE
Add deterministic fanout artifact refs

### DIFF
--- a/packages/cli/src/agent-fanout.ts
+++ b/packages/cli/src/agent-fanout.ts
@@ -1,6 +1,6 @@
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
-import { join } from "node:path"
-import { commandArgValue, createRunPlanEvent, executeRunPlan, FANOUT_EVENT_SCHEMA, FANOUT_PLAN_SCHEMA, FANOUT_REQUEST_SCHEMA, FANOUT_RESULT_SCHEMA, normalizeRunPlanConcurrency, normalizeRunPlanWorkerDescriptors, parseCommandJsonObject, type FanoutLifecycleEvent, type FanoutRequestContract, type RunPlanWorkerAdapter, type RunPlanWorkerDescriptor } from "@automattic/wp-codebox-core"
+import { isAbsolute, join, relative, sep } from "node:path"
+import { commandArgValue, createRunPlanEvent, executeRunPlan, FANOUT_EVENT_SCHEMA, FANOUT_PLAN_SCHEMA, FANOUT_REQUEST_SCHEMA, FANOUT_RESULT_SCHEMA, normalizeRunPlanConcurrency, normalizeRunPlanWorkerDescriptors, parseCommandJsonObject, type FanoutLifecycleEvent, type FanoutRequestContract, type RunPlanClock, type RunPlanWorkerAdapter, type RunPlanWorkerDescriptor } from "@automattic/wp-codebox-core"
 import { agentTaskStatusSucceeded, aggregateFanoutOutputs, fanoutAggregationInputFromWorkerArtifacts, normalizeAgentTaskStatus, stripUndefined, type FanoutAggregationOutput } from "@automattic/wp-codebox-core/internals"
 import { runAgentTask, type AgentTaskRunInput, type AgentTaskRunOptions } from "./commands/agent-task-run.js"
 
@@ -11,6 +11,8 @@ export interface AgentFanoutExecutionOptions {
   recipeDirectory: string
   previewHoldSeconds?: string
   previewPublicUrl?: string
+  sessionId?: string
+  clock?: RunPlanClock
   runWorker?: (input: AgentTaskRunInput, options: AgentTaskRunOptions) => Promise<AgentFanoutWorkerOutput>
 }
 
@@ -20,7 +22,7 @@ export interface AgentFanoutExecutionResult {
   success: boolean
   session: {
     id: string
-    children: Array<{ id: string; worker_id: string; status: string; artifacts: string }>
+    children: Array<{ id: string; worker_id: string; status: string; artifacts: string; artifact_refs: Array<Record<string, unknown>> }>
   }
   concurrency: number
   plan: Record<string, unknown>
@@ -30,6 +32,7 @@ export interface AgentFanoutExecutionResult {
   counts: { total: number; completed: number; failed: number; cancelled: number }
   events_path: string
   result_path: string
+  diagnostics?: Record<string, unknown>
 }
 
 interface AgentFanoutWorkerResult {
@@ -56,7 +59,8 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
     throw new Error("wp-codebox.agent-fanout requires at least one worker")
   }
 
-  const sessionId = stringValue(request.orchestrator?.session_id) || stringValue(request.orchestrator?.request_id) || `fanout-${Date.now()}`
+  const clock = fanoutClock(request, options.clock)
+  const sessionId = options.sessionId || stringValue(request.session_id) || stringValue(request.orchestrator?.session_id) || stringValue(request.orchestrator?.request_id) || `fanout-${Date.now()}`
   const concurrency = normalizeRunPlanConcurrency(request.concurrency, { maxConcurrency: MAX_FANOUT_CONCURRENCY, concurrencyMode: "clamp" })
   const fanoutRoot = join(options.artifactRoot, "fanout")
   const workersRoot = join(fanoutRoot, "workers")
@@ -83,19 +87,20 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
     })),
   }
   await writeJson(planPath, plan)
-  await emitEvent(eventsPath, { event: "fanout.started", total: workers.length, active: 0, completed: 0, failed: 0, cancelled: 0 })
+  await emitEvent(eventsPath, { event: "fanout.started", total: workers.length, active: 0, completed: 0, failed: 0, cancelled: 0 }, clock)
 
   const execution = await executeRunPlan({ workers: request.workers, concurrency }, {
     adapter: agentTaskFanoutWorkerAdapter(request, { ...options, workersRoot, sessionId }),
     defaultAgent: stringValue(request.agent),
     requireGoal: true,
-    onWorkerStarted: (worker) => emitEvent(eventsPath, { event: "worker.started", worker_id: worker.id }),
-    onWorkerCompleted: (worker, result) => emitEvent(eventsPath, { event: "worker.completed", worker_id: worker.id, status: result.status }),
-    onWorkerFailed: (worker, result) => emitEvent(eventsPath, { event: "worker.failed", worker_id: worker.id, status: result.status }),
+    clock,
+    onWorkerStarted: (worker) => emitEvent(eventsPath, { event: "worker.started", worker_id: worker.id }, clock),
+    onWorkerCompleted: (worker, result) => emitEvent(eventsPath, { event: "worker.completed", worker_id: worker.id, status: result.status }, clock),
+    onWorkerFailed: (worker, result) => emitEvent(eventsPath, { event: "worker.failed", worker_id: worker.id, status: result.status }, clock),
   })
   const workerResults: AgentFanoutWorkerResult[] = execution.workers.map(({ success: _success, workerId: _workerId, ...result }) => result as unknown as AgentFanoutWorkerResult)
 
-  await emitEvent(eventsPath, { event: "aggregation.started", total: workers.length, completed: workerResults.filter((worker) => agentTaskStatusSucceeded(worker.status)).length, failed: workerResults.filter((worker) => !agentTaskStatusSucceeded(worker.status)).length })
+  await emitEvent(eventsPath, { event: "aggregation.started", total: workers.length, completed: workerResults.filter((worker) => agentTaskStatusSucceeded(worker.status)).length, failed: workerResults.filter((worker) => !agentTaskStatusSucceeded(worker.status)).length }, clock)
   const aggregationInput = fanoutAggregationInputFromWorkerArtifacts({
     plan: { id: sessionId, workers: workers.map((worker) => ({ id: worker.id, dependsOn: worker.dependsOn, required: worker.required, artifactNamespace: worker.artifactNamespace })) },
     policy: stringValue(request.aggregation?.policy) || "fail",
@@ -114,7 +119,7 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
   })
   await writeJson(join(aggregateRoot, "result.json"), aggregate)
   await writeJson(join(aggregateFinalRoot, "result.json"), aggregate)
-  await emitEvent(eventsPath, { event: "aggregation.completed", status: aggregate.status })
+  await emitEvent(eventsPath, { event: "aggregation.completed", status: aggregate.status }, clock)
 
   const counts = execution.counts
   const success = aggregate.status === "succeeded"
@@ -124,7 +129,13 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
     success,
     session: {
       id: sessionId,
-      children: workerResults.map((worker) => ({ id: worker.session_id, worker_id: worker.worker_id, status: worker.status, artifacts: join(workersRoot, worker.worker_id, "artifacts") })),
+      children: workerResults.map((worker) => ({
+        id: worker.session_id,
+        worker_id: worker.worker_id,
+        status: worker.status,
+        artifacts: `fanout/workers/${worker.worker_id}/artifacts`,
+        artifact_refs: worker.artifact_refs,
+      })),
     },
     concurrency,
     plan,
@@ -142,9 +153,20 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
     counts,
     events_path: eventsPath,
     result_path: resultPath,
+    diagnostics: {
+      private: {
+        local_paths: {
+          root: fanoutRoot,
+          events: eventsPath,
+          result: resultPath,
+          workers: workersRoot,
+          children: workerResults.map((worker) => ({ worker_id: worker.worker_id, artifacts: join(workersRoot, worker.worker_id, "artifacts") })),
+        },
+      },
+    },
   }
   await writeJson(resultPath, result)
-  await emitEvent(eventsPath, { event: success ? "fanout.completed" : "fanout.failed", total: counts.total, completed: counts.completed, failed: counts.failed, cancelled: counts.cancelled })
+  await emitEvent(eventsPath, { event: success ? "fanout.completed" : "fanout.failed", total: counts.total, completed: counts.completed, failed: counts.failed, cancelled: counts.cancelled }, clock)
   return result
 }
 
@@ -188,7 +210,7 @@ function agentTaskFanoutWorkerAdapter(request: FanoutRequestContract, options: A
           required: descriptor.required,
           session_id: childSessionId,
           result_ref: resultRef,
-          artifact_refs: workerArtifactRefs(descriptor.id, output),
+          artifact_refs: workerArtifactRefs(descriptor.id, output, options.artifactRoot),
           output,
           ...(!success ? { error: { code: "worker-failed", message: stringValue(objectValue(output.error)?.message) || `Fanout worker ${descriptor.id} failed.` } } : {}),
         }) as AgentFanoutWorkerExecutionResult
@@ -262,8 +284,8 @@ function inheritedAgentTaskInput(source: Record<string, unknown>): Record<string
   return result
 }
 
-async function emitEvent(path: string, event: Omit<FanoutLifecycleEvent, "schema" | "time" | "worker_id"> & { worker_id?: string }): Promise<void> {
-  await appendFile(path, `${JSON.stringify(createRunPlanEvent<FanoutLifecycleEvent>(FANOUT_EVENT_SCHEMA, event))}\n`)
+async function emitEvent(path: string, event: Omit<FanoutLifecycleEvent, "schema" | "time" | "worker_id"> & { worker_id?: string }, clock?: RunPlanClock): Promise<void> {
+  await appendFile(path, `${JSON.stringify(createRunPlanEvent<FanoutLifecycleEvent>(FANOUT_EVENT_SCHEMA, event, { clock }))}\n`)
 }
 
 async function writeJson(path: string, value: unknown): Promise<void> {
@@ -271,16 +293,28 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
 }
 
-function workerArtifactRefs(workerId: string, output: Record<string, unknown>): Array<Record<string, unknown>> {
+function workerArtifactRefs(workerId: string, output: Record<string, unknown>, artifactRoot: string): Array<Record<string, unknown>> {
   const refs = Array.isArray(output.evidence_refs) ? output.evidence_refs.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))) : []
   return refs.map((ref, index) => stripUndefined({
     id: `${workerId}:${index}`,
     worker_id: workerId,
     namespace: `workers/${workerId}`,
-    path: stringValue(ref.uri) || stringValue(ref.path),
+    path: bundleRelativeArtifactRef(stringValue(ref.uri) || stringValue(ref.path), artifactRoot),
     kind: stringValue(ref.kind) || "codebox-evidence",
-    metadata: ref,
+    metadata: stripUndefined({ ...ref, private: stripUndefined({ local_path: isAbsolute(stringValue(ref.path)) ? stringValue(ref.path) : undefined }) }),
   }))
+}
+
+function bundleRelativeArtifactRef(path: string, artifactRoot: string): string | undefined {
+  if (!path || !isAbsolute(path)) return path
+  const relativePath = relative(artifactRoot, path).split(sep).join("/")
+  return relativePath.startsWith("../") || relativePath === ".." ? undefined : relativePath
+}
+
+function fanoutClock(request: FanoutRequestContract, fallback?: RunPlanClock): RunPlanClock | undefined {
+  const deterministic = objectValue(request.deterministic) ?? objectValue(request.replay)
+  const fixedTime = stringValue(deterministic?.event_time ?? deterministic?.eventTime ?? request.event_time)
+  return fixedTime ? () => fixedTime : fallback
 }
 
 function objectValue(value: unknown): Record<string, unknown> | undefined {

--- a/packages/runtime-core/src/run-plan.ts
+++ b/packages/runtime-core/src/run-plan.ts
@@ -97,10 +97,13 @@ export interface RunPlanWorkerAdapter<TWorker extends RunPlanWorkerContract = Ru
 
 export interface RunPlanExecutorOptions<TWorker extends RunPlanWorkerContract = RunPlanWorkerContract, TResult extends RunPlanWorkerResultLike = RunPlanWorkerResult> extends RunPlanNormalizationOptions {
   adapter: RunPlanWorkerAdapter<TWorker, TResult>
+  clock?: RunPlanClock
   onWorkerStarted?: (descriptor: RunPlanWorkerDescriptor<TWorker>, index: number) => Promise<void> | void
   onWorkerCompleted?: (descriptor: RunPlanWorkerDescriptor<TWorker>, result: TResult, index: number) => Promise<void> | void
   onWorkerFailed?: (descriptor: RunPlanWorkerDescriptor<TWorker>, result: TResult, index: number) => Promise<void> | void
 }
+
+export type RunPlanClock = () => Date | string
 
 export interface RunPlanExecutorResult<TResult extends RunPlanWorkerResultLike = RunPlanWorkerResult> {
   success: boolean
@@ -193,8 +196,13 @@ export function normalizeRunPlanWorkerDescriptors<TWorker extends RunPlanWorkerC
   })
 }
 
-export function createRunPlanEvent<TEvent>(schema: string, event: Omit<TEvent, "schema" | "time"> & { time?: string }): TEvent {
-  return { schema, time: event.time ?? new Date().toISOString(), ...event } as TEvent
+export function createRunPlanEvent<TEvent>(schema: string, event: Omit<TEvent, "schema" | "time"> & { time?: string }, options: { clock?: RunPlanClock } = {}): TEvent {
+  return { schema, time: event.time ?? runPlanClockIso(options.clock), ...event } as TEvent
+}
+
+export function runPlanClockIso(clock?: RunPlanClock): string {
+  const value = clock ? clock() : new Date()
+  return typeof value === "string" ? value : value.toISOString()
 }
 
 export async function runBoundedConcurrent<T, R>(items: T[], concurrency: number, worker: (item: T, index: number) => Promise<R>): Promise<R[]> {

--- a/packages/runtime-core/src/run-registry.ts
+++ b/packages/runtime-core/src/run-registry.ts
@@ -114,6 +114,11 @@ export interface RuntimeRunRegistryCreateOptions {
   now?: Date
 }
 
+export interface RuntimeRunRegistryDeterminismOptions {
+  clock?: () => Date
+  idFactory?: () => string
+}
+
 export interface RuntimeRunRegistryUpdate {
   status?: RuntimeRunStatus
   runtime?: RuntimeInfo
@@ -162,16 +167,20 @@ const runtimeRunStatusTransitions: Record<RuntimeRunStatus, readonly RuntimeRunS
 
 export class RuntimeRunRegistry {
   readonly directory: string
+  private readonly clock: () => Date
+  private readonly idFactory: () => string
 
-  constructor(directory: string) {
+  constructor(directory: string, options: RuntimeRunRegistryDeterminismOptions = {}) {
     this.directory = resolve(directory)
+    this.clock = options.clock ?? (() => new Date())
+    this.idFactory = options.idFactory ?? createRuntimeRunId
   }
 
   async create(options: RuntimeRunRegistryCreateOptions = {}): Promise<RuntimeRunRecord> {
-    const now = (options.now ?? new Date()).toISOString()
+    const now = (options.now ?? this.clock()).toISOString()
     const record: RuntimeRunRecord = {
       schema: "wp-codebox/run-registry-entry/v1",
-      runId: options.runId ?? createRuntimeRunId(),
+      runId: options.runId ?? this.idFactory(),
       status: options.status ?? "queued",
       lifecycle: buildRuntimeRunLifecycle(options.status ?? "queued", initialRuntimeRunCleanup()),
       createdAt: now,
@@ -197,7 +206,7 @@ export class RuntimeRunRegistry {
 
   async update(runId: string, update: RuntimeRunRegistryUpdate): Promise<RuntimeRunRecord> {
     const current = await this.read(runId)
-    const now = (update.now ?? new Date()).toISOString()
+    const now = (update.now ?? this.clock()).toISOString()
     const status = transitionRuntimeRunStatus(current.status, update.status)
     const cleanup = update.cleanup ? updateRuntimeRunCleanup(current.lifecycle?.cleanup, update.cleanup, now) : current.lifecycle?.cleanup ?? initialRuntimeRunCleanup()
     const cancellation = current.lifecycle?.cancellation
@@ -236,7 +245,7 @@ export class RuntimeRunRegistry {
       }
     }
 
-    const now = (options.now ?? new Date()).toISOString()
+    const now = (options.now ?? this.clock()).toISOString()
     const cancellation = stripUndefined({
       requestedAt: now,
       reason: options.reason,
@@ -258,8 +267,8 @@ export class RuntimeRunRegistry {
     }
   }
 
-  async heartbeat(runId: string, now = new Date()): Promise<RuntimeRunRecord> {
-    return this.update(runId, { now, heartbeat: true })
+  async heartbeat(runId: string, now?: Date): Promise<RuntimeRunRecord> {
+    return this.update(runId, { now: now ?? this.clock(), heartbeat: true })
   }
 
   recordPath(runId: string): string {

--- a/tests/agent-fanout-executor.test.ts
+++ b/tests/agent-fanout-executor.test.ts
@@ -11,7 +11,9 @@ await withTempDir("wp-codebox-agent-fanout-executor-", async (root) => {
     schema: FANOUT_REQUEST_SCHEMA,
     concurrency: 3,
     agent: "sandbox-agent",
-    orchestrator: { session_id: "fanout-test" },
+    session_id: "fanout-test",
+    orchestrator: {},
+    deterministic: { event_time: "2026-01-02T03:04:05.000Z" },
     workers: [
       { id: "one", goal: "Collect first result" },
       { id: "two", goal: "Collect second result" },
@@ -32,8 +34,12 @@ await withTempDir("wp-codebox-agent-fanout-executor-", async (root) => {
   assert.equal(result.concurrency, 3)
   assert.deepEqual(result.counts, { total: 2, completed: 2, failed: 0, cancelled: 0 })
   assert.deepEqual(result.session.children.map((child) => child.id), ["fanout-test:one", "fanout-test:two"])
+  assert.deepEqual(result.session.children.map((child) => child.artifacts), ["fanout/workers/one/artifacts", "fanout/workers/two/artifacts"])
   assert.deepEqual(result.workers.map((worker) => worker.status), ["succeeded", "succeeded"])
   assert.equal(result.workers[0].artifact_refs[0].namespace, "workers/one")
+  assert.equal(result.workers[0].artifact_refs[0].path, "fanout/workers/one/artifacts/result.json")
+  assert.equal((result.workers[0].artifact_refs[0].metadata as Record<string, unknown>).private instanceof Object, true)
+  assert.equal(result.diagnostics?.private instanceof Object, true)
 
   const events = (await readFile(join(root, "fanout", "events.jsonl"), "utf8")).trim().split("\n").map((line) => JSON.parse(line))
   assert.deepEqual(events.map((event) => event.event), [
@@ -46,6 +52,7 @@ await withTempDir("wp-codebox-agent-fanout-executor-", async (root) => {
     "aggregation.completed",
     "fanout.completed",
   ])
+  assert.deepEqual([...new Set(events.map((event) => event.time))], ["2026-01-02T03:04:05.000Z"])
 })
 
 console.log("agent fanout executor ok")

--- a/tests/run-plan-executor.test.ts
+++ b/tests/run-plan-executor.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 
-import { executeRunPlan, type RunPlanWorkerAdapter } from "../packages/runtime-core/src/index.js"
+import { createRunPlanEvent, executeRunPlan, type RunPlanEventContract, type RunPlanWorkerAdapter } from "../packages/runtime-core/src/index.js"
 
 const events: string[] = []
 const adapter: RunPlanWorkerAdapter = {
@@ -42,5 +42,11 @@ assert.deepEqual(events, ["started:one", "started:failed", "completed:one", "fai
 
 await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "missing-goal" }] }, { adapter, requireGoal: true }), /requires goal/)
 await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "duplicate", goal: "one" }, { id: "duplicate", goal: "two" }] }, { adapter }), /must be unique/)
+
+assert.deepEqual(createRunPlanEvent<RunPlanEventContract>("wp-codebox/run-plan-event/v1", { event: "worker.started" }, { clock: () => "2026-03-04T05:06:07.000Z" }), {
+  schema: "wp-codebox/run-plan-event/v1",
+  time: "2026-03-04T05:06:07.000Z",
+  event: "worker.started",
+})
 
 console.log("run plan executor ok")

--- a/tests/run-registry.test.ts
+++ b/tests/run-registry.test.ts
@@ -48,6 +48,22 @@ await withTempDir("wp-codebox-run-registry-", async (directory) => {
   assert.equal(retry.lifecycle.cleanup.attempts, 1)
 })
 
+await withTempDir("wp-codebox-run-registry-deterministic-", async (directory) => {
+  const registry = new RuntimeRunRegistry(directory, {
+    idFactory: () => "run_deterministic",
+    clock: () => new Date("2026-02-03T04:05:06.000Z"),
+  })
+  const run = await registry.create({ status: "running" })
+
+  assert.equal(run.runId, "run_deterministic")
+  assert.equal(run.createdAt, "2026-02-03T04:05:06.000Z")
+  assert.equal(run.updatedAt, "2026-02-03T04:05:06.000Z")
+
+  const updated = await registry.update(run.runId, { metadata: { replay: "stable" } })
+  assert.equal(updated.updatedAt, "2026-02-03T04:05:06.000Z")
+  assert.deepEqual(updated.metadata, { replay: "stable" })
+})
+
 await withTempDir("wp-codebox-run-registry-artifacts-", async (directory) => {
   const registry = new RuntimeRunRegistry(directory)
   const run = await registry.create({ runId: "result-artifacts", status: "running" })


### PR DESCRIPTION
## Summary
- Add deterministic replay controls for fanout session IDs and event timestamps.
- Add run-plan clock plumbing and run-registry clock/id factory hooks for stable replay tests.
- Return bundle-relative fanout session/artifact refs while retaining local paths under private diagnostics metadata.

## Tests
- npm run build
- npm run test:run-plan-executor
- npm run test:run-registry
- npm run test:agent-fanout-executor

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing deterministic replay controls, portable artifact refs, tests, and PR preparation.