### PR TITLE
Add deterministic fanout DAG scheduling

### DIFF
--- a/packages/cli/src/agent-fanout.ts
+++ b/packages/cli/src/agent-fanout.ts
@@ -27,7 +27,7 @@ export interface AgentFanoutExecutionResult {
   artifacts: Record<string, unknown>
   workers: AgentFanoutWorkerResult[]
   aggregate: FanoutAggregationOutput
-  counts: { total: number; completed: number; failed: number; cancelled: number }
+  counts: { total: number; completed: number; failed: number; skipped: number; cancelled: number; timed_out: number }
   events_path: string
   result_path: string
 }
@@ -80,6 +80,7 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
       agent: descriptor.agent,
       goal: descriptor.goal,
       artifact_namespace: descriptor.artifactNamespace,
+      depends_on: descriptor.dependsOn,
     })),
   }
   await writeJson(planPath, plan)
@@ -92,10 +93,15 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
     onWorkerStarted: (worker) => emitEvent(eventsPath, { event: "worker.started", worker_id: worker.id }),
     onWorkerCompleted: (worker, result) => emitEvent(eventsPath, { event: "worker.completed", worker_id: worker.id, status: result.status }),
     onWorkerFailed: (worker, result) => emitEvent(eventsPath, { event: "worker.failed", worker_id: worker.id, status: result.status }),
+    onWorkerSkipped: async (worker, result) => {
+      await writeJson(join(workersRoot, worker.id, "result.json"), result)
+      await emitEvent(eventsPath, { event: "worker.skipped", worker_id: worker.id, status: result.status })
+    },
+    createSkippedResult: (worker, dependencies) => agentTaskSkippedFanoutWorkerResult(worker, sessionId, dependencies),
   })
   const workerResults: AgentFanoutWorkerResult[] = execution.workers.map(({ success: _success, workerId: _workerId, ...result }) => result as unknown as AgentFanoutWorkerResult)
 
-  await emitEvent(eventsPath, { event: "aggregation.started", total: workers.length, completed: workerResults.filter((worker) => agentTaskStatusSucceeded(worker.status)).length, failed: workerResults.filter((worker) => !agentTaskStatusSucceeded(worker.status)).length })
+  await emitEvent(eventsPath, { event: "aggregation.started", total: workers.length, completed: workerResults.filter((worker) => agentTaskStatusSucceeded(worker.status)).length, failed: workerResults.filter((worker) => !agentTaskStatusSucceeded(worker.status) && worker.status !== "skipped").length, skipped: workerResults.filter((worker) => worker.status === "skipped").length })
   const aggregate = aggregateFanoutOutputs({
     plan: { id: sessionId, workers: workers.map((worker) => ({ id: worker.id, dependsOn: worker.dependsOn, required: worker.required, artifactNamespace: worker.artifactNamespace })) },
     policy: stringValue(request.aggregation?.policy) || "fail",
@@ -143,7 +149,7 @@ export async function executeAgentFanoutRequest(request: FanoutRequestContract, 
     result_path: resultPath,
   }
   await writeJson(resultPath, result)
-  await emitEvent(eventsPath, { event: success ? "fanout.completed" : "fanout.failed", total: counts.total, completed: counts.completed, failed: counts.failed, cancelled: counts.cancelled })
+  await emitEvent(eventsPath, { event: success ? "fanout.completed" : "fanout.failed", total: counts.total, completed: counts.completed, failed: counts.failed, skipped: counts.skipped, cancelled: counts.cancelled, timed_out: counts.timed_out })
   return result
 }
 
@@ -209,6 +215,27 @@ function agentTaskFanoutWorkerAdapter(request: FanoutRequestContract, options: A
         await writeJson(join(options.workersRoot, descriptor.id, "result.json"), workerResult)
         return workerResult
       }
+    },
+  }
+}
+
+function agentTaskSkippedFanoutWorkerResult(descriptor: AgentFanoutWorkerDescriptor, sessionId: string, dependencies: AgentFanoutWorkerExecutionResult[]): AgentFanoutWorkerExecutionResult {
+  const childSessionId = `${sessionId}:${descriptor.id}`
+  return {
+    workerId: descriptor.id,
+    success: false,
+    worker_id: descriptor.id,
+    status: "skipped",
+    required: descriptor.required,
+    session_id: childSessionId,
+    result_ref: `fanout/workers/${descriptor.id}/result.json`,
+    artifact_refs: [],
+    error: {
+      code: "dependency-skipped",
+      message: `Fanout worker ${descriptor.id} skipped because a dependency did not complete successfully.`,
+    },
+    output: {
+      dependencies: dependencies.map((dependency) => ({ worker_id: dependency.worker_id, status: dependency.status, success: dependency.success })),
     },
   }
 }

--- a/packages/runtime-core/src/fanout-contracts.ts
+++ b/packages/runtime-core/src/fanout-contracts.ts
@@ -12,6 +12,7 @@ export const FANOUT_EVENT_TYPES = [
   "worker.started",
   "worker.completed",
   "worker.failed",
+  "worker.skipped",
   "aggregation.started",
   "aggregation.completed",
   "fanout.completed",
@@ -63,6 +64,7 @@ export interface FanoutPlanContract {
     agent: string
     goal: string
     artifact_namespace: string
+    depends_on?: string[]
   }>
 }
 
@@ -76,7 +78,9 @@ export interface FanoutLifecycleEvent {
   total?: number
   completed?: number
   failed?: number
+  skipped?: number
   cancelled?: number
+  timed_out?: number
 }
 
 export interface HostDelegationRequestContract {

--- a/packages/runtime-core/src/run-plan.ts
+++ b/packages/runtime-core/src/run-plan.ts
@@ -7,6 +7,8 @@ export interface RunPlanWorkerContract {
   goal?: string
   artifactNamespace?: string
   artifact_namespace?: string
+  dependsOn?: string[]
+  depends_on?: string[]
   required?: boolean
   metadata?: Record<string, unknown>
   [key: string]: unknown
@@ -74,7 +76,9 @@ export interface RunPlanResultCounts {
   total: number
   completed: number
   failed: number
+  skipped: number
   cancelled: number
+  timed_out: number
 }
 
 export interface RunPlanWorkerExecution<TWorker extends RunPlanWorkerContract = RunPlanWorkerContract> {
@@ -100,6 +104,8 @@ export interface RunPlanExecutorOptions<TWorker extends RunPlanWorkerContract = 
   onWorkerStarted?: (descriptor: RunPlanWorkerDescriptor<TWorker>, index: number) => Promise<void> | void
   onWorkerCompleted?: (descriptor: RunPlanWorkerDescriptor<TWorker>, result: TResult, index: number) => Promise<void> | void
   onWorkerFailed?: (descriptor: RunPlanWorkerDescriptor<TWorker>, result: TResult, index: number) => Promise<void> | void
+  onWorkerSkipped?: (descriptor: RunPlanWorkerDescriptor<TWorker>, result: TResult, index: number) => Promise<void> | void
+  createSkippedResult?: (descriptor: RunPlanWorkerDescriptor<TWorker>, dependencies: TResult[]) => TResult
 }
 
 export interface RunPlanExecutorResult<TResult extends RunPlanWorkerResultLike = RunPlanWorkerResult> {
@@ -111,24 +117,29 @@ export interface RunPlanExecutorResult<TResult extends RunPlanWorkerResultLike =
 
 export function countRunPlanChildResults(results: RunPlanChildResult[]): RunPlanResultCounts {
   const completed = results.filter((result) => result.success === true).length
+  const skipped = results.filter((result) => result.status === "skipped").length
   const cancelled = results.filter((result) => result.status === "cancelled").length
+  const timedOut = results.filter((result) => result.status === "timed_out" || result.status === "timeout").length
 
   return {
     total: results.length,
     completed,
-    failed: results.length - completed - cancelled,
+    failed: results.length - completed - skipped - cancelled - timedOut,
+    skipped,
     cancelled,
+    timed_out: timedOut,
   }
 }
 
-export function runPlanSucceeded(counts: Pick<RunPlanResultCounts, "failed" | "cancelled">): boolean {
-  return counts.failed === 0 && counts.cancelled === 0
+export function runPlanSucceeded(counts: Pick<RunPlanResultCounts, "failed" | "skipped" | "cancelled" | "timed_out">): boolean {
+  return counts.failed === 0 && counts.skipped === 0 && counts.cancelled === 0 && counts.timed_out === 0
 }
 
 export async function executeRunPlan<TWorker extends RunPlanWorkerContract, TResult extends RunPlanWorkerResultLike>(plan: Pick<RunPlanContract, "workers" | "concurrency">, options: RunPlanExecutorOptions<TWorker, TResult>): Promise<RunPlanExecutorResult<TResult>> {
   const workers = normalizeRunPlanWorkerDescriptors(plan.workers as TWorker[], options)
+  validateRunPlanDependencies(workers)
   const concurrency = normalizeRunPlanConcurrency(plan.concurrency, options)
-  const results = await runBoundedConcurrent(workers, concurrency, async (descriptor, index) => {
+  const results = await runDependencyAwareConcurrent(workers, concurrency, async (descriptor, index) => {
     await options.onWorkerStarted?.(descriptor, index)
     const result = await options.adapter.run({ descriptor, index })
     if (result.success === true) {
@@ -136,6 +147,10 @@ export async function executeRunPlan<TWorker extends RunPlanWorkerContract, TRes
     } else {
       await options.onWorkerFailed?.(descriptor, result, index)
     }
+    return result
+  }, async (descriptor, dependencies) => {
+    const result = options.createSkippedResult?.(descriptor, dependencies) ?? defaultSkippedRunPlanResult(descriptor, dependencies) as TResult
+    await options.onWorkerSkipped?.(descriptor, result, descriptor.index)
     return result
   })
   const counts = countRunPlanChildResults(results)
@@ -186,11 +201,42 @@ export function normalizeRunPlanWorkerDescriptors<TWorker extends RunPlanWorkerC
       agent: stringValue(worker.agent) || stringValue(options.defaultAgent),
       artifactNamespace: safeRunPlanNamespace(stringValue(worker.artifactNamespace ?? worker.artifact_namespace) || id),
       required: worker.required !== false,
-      dependsOn: Array.isArray(worker.dependsOn) ? worker.dependsOn.filter((dependency): dependency is string => typeof dependency === "string") : [],
+      dependsOn: stringList(worker.dependsOn ?? worker.depends_on),
       timeoutSeconds: positiveInteger(worker.timeoutSeconds ?? worker.timeout_seconds ?? worker.task_timeout_seconds),
       cancellation: runPlanCancellationMetadata(worker),
     }
   })
+}
+
+export function validateRunPlanDependencies<TWorker extends RunPlanWorkerContract>(workers: Array<RunPlanWorkerDescriptor<TWorker>>): void {
+  const byId = new Map(workers.map((worker) => [worker.id, worker]))
+  for (const worker of workers) {
+    for (const dependency of worker.dependsOn) {
+      if (dependency === worker.id) {
+        throw new Error(`Run plan worker cannot depend on itself: ${worker.id}`)
+      }
+      if (!byId.has(dependency)) {
+        throw new Error(`Run plan worker ${worker.id} depends on unknown worker: ${dependency}`)
+      }
+    }
+  }
+
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const visit = (worker: RunPlanWorkerDescriptor<TWorker>): void => {
+    if (visited.has(worker.id)) return
+    if (visiting.has(worker.id)) {
+      throw new Error(`Run plan dependencies contain a cycle at worker: ${worker.id}`)
+    }
+    visiting.add(worker.id)
+    for (const dependency of worker.dependsOn) {
+      visit(byId.get(dependency) as RunPlanWorkerDescriptor<TWorker>)
+    }
+    visiting.delete(worker.id)
+    visited.add(worker.id)
+  }
+
+  for (const worker of workers) visit(worker)
 }
 
 export function createRunPlanEvent<TEvent>(schema: string, event: Omit<TEvent, "schema" | "time"> & { time?: string }): TEvent {
@@ -209,6 +255,64 @@ export async function runBoundedConcurrent<T, R>(items: T[], concurrency: number
   })
   await Promise.all(runners)
   return results
+}
+
+export async function runDependencyAwareConcurrent<T extends { id: string; index: number; dependsOn: string[] }, R extends { success?: boolean; status?: string }>(items: T[], concurrency: number, worker: (item: T, index: number) => Promise<R>, skipped: (item: T, dependencies: R[]) => Promise<R> | R): Promise<R[]> {
+  const effectiveConcurrency = normalizeRunPlanConcurrency(concurrency, { maxConcurrency: items.length || 1 })
+  const byId = new Map(items.map((item) => [item.id, item]))
+  const results = new Array<R>(items.length)
+  const completed = new Set<string>()
+  const running = new Set<string>()
+  let active = 0
+
+  return new Promise((resolve, reject) => {
+    const pump = (): void => {
+      try {
+        let progressed = false
+        for (const item of items) {
+          if (completed.has(item.id) || running.has(item.id)) continue
+          const dependencyResults = item.dependsOn.map((dependency) => results[(byId.get(dependency) as T).index])
+          if (dependencyResults.length !== item.dependsOn.length || dependencyResults.some((result) => !result)) continue
+          if (dependencyResults.some((result) => result && result.success !== true)) {
+            running.add(item.id)
+            active++
+            progressed = true
+            Promise.resolve(skipped(item, dependencyResults.filter((result): result is R => Boolean(result))))
+              .then((result) => {
+                results[item.index] = result
+                running.delete(item.id)
+                completed.add(item.id)
+                active--
+                pump()
+              })
+              .catch(reject)
+            continue
+          }
+          if (active >= effectiveConcurrency) continue
+          running.add(item.id)
+          active++
+          progressed = true
+          Promise.resolve(worker(item, item.index))
+            .then((result) => {
+              results[item.index] = result
+              running.delete(item.id)
+              completed.add(item.id)
+              active--
+              pump()
+            })
+            .catch(reject)
+        }
+        if (completed.size === items.length && active === 0) {
+          resolve(results)
+        } else if (!progressed && active === 0) {
+          reject(new Error("Run plan dependencies could not be scheduled."))
+        }
+      } catch (error) {
+        reject(error)
+      }
+    }
+    pump()
+  })
 }
 
 export function runPlanCancellationMetadata(source: Record<string, unknown>): RunPlanCancellationMetadata {
@@ -240,6 +344,20 @@ export function safeRunPlanNamespace(value: unknown): string {
 function positiveInteger(value: unknown): number | undefined {
   const number = Math.floor(Number(value) || 0)
   return number > 0 ? number : undefined
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => stringValue(item)).filter(Boolean) : []
+}
+
+function defaultSkippedRunPlanResult<TWorker extends RunPlanWorkerContract, TResult extends RunPlanWorkerResultLike>(descriptor: RunPlanWorkerDescriptor<TWorker>, dependencies: TResult[]): TResult {
+  return {
+    workerId: descriptor.id,
+    success: false,
+    status: "skipped",
+    error: { code: "dependency-skipped", message: `Run plan worker ${descriptor.id} skipped because a dependency did not complete successfully.` },
+    dependencies: dependencies.map((dependency) => ({ workerId: dependency.workerId, status: dependency.status, success: dependency.success })),
+  } as unknown as TResult
 }
 
 function stringValue(value: unknown): string {

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -371,6 +371,8 @@ final class WP_Codebox_Abilities {
 										'id'                 => array( 'type' => 'string' ),
 										'task'               => array( 'type' => 'string' ),
 										'agent'              => array( 'type' => 'string' ),
+										'dependsOn'          => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+										'depends_on'         => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
 										'timeout_seconds'    => array( 'type' => 'integer' ),
 									) + self::task_input_alias_properties( $task_input_schema ),
 								),
@@ -392,7 +394,9 @@ final class WP_Codebox_Abilities {
 							'total'       => array( 'type' => 'integer' ),
 							'completed'   => array( 'type' => 'integer' ),
 							'failed'      => array( 'type' => 'integer' ),
+							'skipped'     => array( 'type' => 'integer' ),
 							'cancelled'   => array( 'type' => 'integer' ),
+							'timed_out'   => array( 'type' => 'integer' ),
 							'timings'     => array( 'type' => 'object' ),
 							'artifacts'   => array(
 								'type'       => 'object',

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-run-result-builder.php
@@ -129,6 +129,48 @@ final class WP_Codebox_Agent_Run_Result_Builder {
 		);
 	}
 
+	/** @param array<string,mixed> $worker Worker metadata. @param array<int,array<string,mixed>> $dependencies Dependency results. @return array<string,mixed> */
+	public function fanout_worker_skipped_result( array $worker, array $dependencies ): array {
+		$prepared  = is_array( $worker['prepared'] ?? null ) ? $worker['prepared'] : array();
+		$input     = is_array( $prepared['input'] ?? null ) ? $prepared['input'] : array();
+		$artifacts = (string) ( $prepared['artifacts'] ?? ( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'artifacts' ) );
+
+		return array(
+			'worker_id' => (string) $worker['id'],
+			'index'     => (int) $worker['index'],
+			'success'   => false,
+			'status'    => 'skipped',
+			'agent'     => (string) ( $input['agent'] ?? '' ),
+			'session'   => array_filter(
+				array(
+					'schema' => self::SESSION_SCHEMA,
+					'id'     => (string) ( $prepared['session_id'] ?? '' ),
+					'status' => 'skipped',
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			),
+			'artifacts' => array(
+				'path'      => $artifacts,
+				'namespace' => (string) $worker['id'],
+				'result'    => 'result.json',
+			),
+			'error'     => array(
+				'code'    => 'dependency-skipped',
+				'message' => 'Fanout worker ' . (string) $worker['id'] . ' skipped because a dependency did not complete successfully.',
+			),
+			'output'    => array(
+				'dependencies' => array_map(
+					static fn( array $dependency ): array => array(
+						'worker_id' => (string) ( $dependency['worker_id'] ?? '' ),
+						'status'    => (string) ( $dependency['status'] ?? '' ),
+						'success'   => true === ( $dependency['success'] ?? false ),
+					),
+					$dependencies
+				),
+			),
+		);
+	}
+
 	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array<int,array<string,mixed>> $runs Child runs. @return array<string,mixed> */
 	public function fanout_parent_session( string $session_id, string $status, array $input, array $paths, array $runs ): array {
 		$children = array_map(
@@ -161,7 +203,7 @@ final class WP_Codebox_Agent_Run_Result_Builder {
 		return $session;
 	}
 
-	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array{total:int,completed:int,failed:int,cancelled:int} $counts Counts. @param array<string,mixed> $plan Plan. @param array<int,array<string,mixed>> $runs Child run results. @return array<string,mixed> */
+	/** @param array<string,mixed> $input Ability input. @param array<string,string> $paths Run-plan artifact paths. @param array{total:int,completed:int,failed:int,skipped:int,cancelled:int,timed_out:int} $counts Counts. @param array<string,mixed> $plan Plan. @param array<int,array<string,mixed>> $runs Child run results. @return array<string,mixed> */
 	public function fanout_result( string $schema, string $artifact_schema, string $execution, string $session_id, string $status, array $input, array $paths, array $counts, float $started_at, float $ended_at, array $plan, array $runs ): array {
 		$success = $this->run_plan->succeeded( $counts );
 
@@ -174,7 +216,9 @@ final class WP_Codebox_Agent_Run_Result_Builder {
 			'total'        => $counts['total'],
 			'completed'    => $counts['completed'],
 			'failed'       => $counts['failed'],
+			'skipped'      => $counts['skipped'],
 			'cancelled'    => $counts['cancelled'],
+			'timed_out'    => $counts['timed_out'],
 			'timings'      => $this->timings( $started_at, $ended_at ),
 			'artifacts'    => $this->run_plan->artifacts( $artifact_schema, $paths ),
 			'orchestrator' => is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(),
@@ -183,7 +227,7 @@ final class WP_Codebox_Agent_Run_Result_Builder {
 		);
 	}
 
-	/** @return array{total:int,completed:int,failed:int,cancelled:int} */
+	/** @return array{total:int,completed:int,failed:int,skipped:int,cancelled:int,timed_out:int} */
 	public function status_counts( array $runs ): array {
 		return $this->run_plan->result_counts( $runs );
 	}

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -118,21 +118,23 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$worker_prepare = $this->prepare_agent_task_run( $worker_input );
 			if ( is_wp_error( $worker_prepare ) ) {
 				$prepared_workers[] = array(
-					'id'       => $worker_id,
-					'index'    => $index,
-					'prepared' => null,
-					'error'    => $worker_prepare,
-					'path'     => $worker_path,
+					'id'         => $worker_id,
+					'index'      => $index,
+					'depends_on' => $worker['_run_plan_descriptor']['depends_on'] ?? array(),
+					'prepared'   => null,
+					'error'      => $worker_prepare,
+					'path'       => $worker_path,
 				);
 				continue;
 			}
 
 			$prepared_workers[] = array(
-				'id'       => $worker_id,
-				'index'    => $index,
-				'prepared' => $worker_prepare,
-				'error'    => null,
-				'path'     => $worker_path,
+				'id'         => $worker_id,
+				'index'      => $index,
+				'depends_on' => $worker['_run_plan_descriptor']['depends_on'] ?? array(),
+				'prepared'   => $worker_prepare,
+				'error'      => null,
+				'path'       => $worker_path,
 			);
 		}
 
@@ -145,7 +147,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$counts = $this->result_builder->status_counts( $runs );
 		$success = $this->run_plan->succeeded( $counts );
 		$status  = $success ? 'completed' : 'failed';
-		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.started', 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'cancelled' => $counts['cancelled'] ) );
+		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.started', 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'skipped' => $counts['skipped'], 'cancelled' => $counts['cancelled'], 'timed_out' => $counts['timed_out'] ) );
 
 		$result = $this->result_builder->fanout_result(
 			self::FANOUT_SCHEMA,
@@ -165,7 +167,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$this->write_json_file( $paths['aggregate_result'], $this->run_plan->aggregate_result( self::FANOUT_AGGREGATE_SCHEMA, $status, $counts ) );
 		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.completed', 'status' => $status ) );
 		$this->write_json_file( $paths['result'], $result );
-		$this->append_fanout_event( $paths['root'], array( 'event' => $success ? 'fanout.completed' : 'fanout.failed', 'status' => $status, 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'cancelled' => $counts['cancelled'] ) );
+		$this->append_fanout_event( $paths['root'], array( 'event' => $success ? 'fanout.completed' : 'fanout.failed', 'status' => $status, 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'skipped' => $counts['skipped'], 'cancelled' => $counts['cancelled'], 'timed_out' => $counts['timed_out'] ) );
 
 		return $result;
 	}
@@ -359,6 +361,10 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		if ( is_wp_error( $descriptors ) ) {
 			return $this->fanout_worker_descriptor_error( $descriptors );
 		}
+		$dependencies = $this->run_plan->validate_dependencies( $descriptors );
+		if ( is_wp_error( $dependencies ) ) {
+			return $this->fanout_worker_descriptor_error( $dependencies );
+		}
 
 		return array_map(
 			static function ( array $descriptor ): array {
@@ -413,30 +419,51 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 	/** @param array<int,array<string,mixed>> $prepared_workers Prepared workers. @return array<int,array<string,mixed>> */
 	private function execute_prepared_fanout_workers( array $prepared_workers, int $concurrency, string $fanout_path ): array {
-		$runs   = array();
-		$active = array();
-		$next   = 0;
-		$total  = count( $prepared_workers );
+		$runs      = array();
+		$active    = array();
+		$remaining = array_fill_keys( array_map( static fn( array $worker ): int => (int) $worker['index'], $prepared_workers ), true );
+		$by_id     = array();
+		foreach ( $prepared_workers as $worker ) {
+			$by_id[ (string) $worker['id'] ] = $worker;
+		}
 
-		while ( $next < $total || ! empty( $active ) ) {
-			while ( count( $active ) < $concurrency && $next < $total ) {
-				$item = $prepared_workers[ $next ];
-				++$next;
+		while ( ! empty( $remaining ) || ! empty( $active ) ) {
+			foreach ( $prepared_workers as $item ) {
+				$index = (int) $item['index'];
+				if ( empty( $remaining[ $index ] ) || count( $active ) >= $concurrency ) {
+					continue;
+				}
+
+				$dependency_results = $this->fanout_dependency_results( $item, $by_id, $runs );
+				if ( count( $dependency_results ) !== count( $item['depends_on'] ?? array() ) ) {
+					continue;
+				}
+
+				if ( ! empty( array_filter( $dependency_results, static fn( array $run ): bool => true !== ( $run['success'] ?? false ) ) ) ) {
+					$runs[ $index ] = $this->result_builder->fanout_worker_skipped_result( $item, $dependency_results );
+					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ $index ] );
+					$this->append_fanout_event( $fanout_path, array( 'event' => 'worker.skipped', 'worker_id' => (string) $item['id'], 'status' => 'skipped' ) );
+					unset( $remaining[ $index ] );
+					continue;
+				}
 
 				if ( is_wp_error( $item['error'] ?? null ) ) {
-					$runs[ (int) $item['index'] ] = $this->result_builder->fanout_worker_error_result( $item, $item['error'], 0, 0 );
-					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $item['index'] ] );
+					$runs[ $index ] = $this->result_builder->fanout_worker_error_result( $item, $item['error'], 0, 0 );
+					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ $index ] );
+					unset( $remaining[ $index ] );
 					continue;
 				}
 
 				$started = $this->process_runner->start_fanout_worker_process( $item );
 				if ( is_wp_error( $started ) ) {
-					$runs[ (int) $item['index'] ] = $this->result_builder->fanout_worker_error_result( $item, $started, 0, 0 );
-					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $item['index'] ] );
+					$runs[ $index ] = $this->result_builder->fanout_worker_error_result( $item, $started, 0, 0 );
+					$this->write_json_file( (string) $item['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ $index ] );
+					unset( $remaining[ $index ] );
 					continue;
 				}
 
 				$active[] = $started;
+				unset( $remaining[ $index ] );
 				$this->append_fanout_event( $fanout_path, array( 'event' => 'worker.started', 'worker_id' => (string) $item['id'], 'active' => count( $active ) ) );
 			}
 
@@ -467,6 +494,20 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return $runs;
 	}
 
+	/** @param array<string,mixed> $worker Worker metadata. @param array<string,array<string,mixed>> $by_id Workers by id. @param array<int,array<string,mixed>> $runs Completed runs. @return array<int,array<string,mixed>> */
+	private function fanout_dependency_results( array $worker, array $by_id, array $runs ): array {
+		$results = array();
+		foreach ( $worker['depends_on'] ?? array() as $dependency ) {
+			$dependency_index = (int) ( $by_id[ (string) $dependency ]['index'] ?? -1 );
+			if ( ! isset( $runs[ $dependency_index ] ) ) {
+				continue;
+			}
+			$results[] = $runs[ $dependency_index ];
+		}
+
+		return $results;
+	}
+
 	private function ensure_directory( string $path ): bool {
 		return is_dir( $path ) || mkdir( $path, 0777, true );
 	}
@@ -494,6 +535,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			'wp_codebox_run_plan_path_segment_invalid' => new WP_Error( 'wp_codebox_fanout_worker_id_invalid', 'Each fanout worker requires a stable alphanumeric id.', $data ),
 			'wp_codebox_run_plan_worker_id_duplicate' => new WP_Error( 'wp_codebox_fanout_worker_id_duplicate', 'Fanout worker ids must be unique.', $data ),
 			'wp_codebox_run_plan_worker_goal_missing' => new WP_Error( 'wp_codebox_fanout_worker_goal_missing', 'Each fanout worker requires goal.', $data ),
+			'wp_codebox_run_plan_dependency_self', 'wp_codebox_run_plan_dependency_unknown', 'wp_codebox_run_plan_dependency_cycle' => new WP_Error( 'wp_codebox_fanout_worker_dependency_invalid', 'Fanout worker dependencies must reference an acyclic set of worker ids.', $data ),
 			default => $error,
 		};
 	}

--- a/packages/wordpress-plugin/src/class-wp-codebox-run-plan.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-run-plan.php
@@ -91,6 +91,81 @@ final class WP_Codebox_Run_Plan {
 		return $descriptors;
 	}
 
+	/**
+	 * @param array<int,array<string,mixed>> $descriptors Worker descriptors.
+	 * @return true|WP_Error
+	 */
+	public function validate_dependencies( array $descriptors ): true|WP_Error {
+		$by_id = array();
+		foreach ( $descriptors as $descriptor ) {
+			$by_id[ (string) $descriptor['id'] ] = $descriptor;
+		}
+
+		foreach ( $descriptors as $descriptor ) {
+			$id = (string) $descriptor['id'];
+			foreach ( $descriptor['depends_on'] ?? array() as $dependency ) {
+				$dependency = (string) $dependency;
+				if ( $dependency === $id ) {
+					return new WP_Error( 'wp_codebox_run_plan_dependency_self', 'Run plan worker cannot depend on itself.', array( 'status' => 400, 'worker_id' => $id ) );
+				}
+				if ( ! isset( $by_id[ $dependency ] ) ) {
+					return new WP_Error( 'wp_codebox_run_plan_dependency_unknown', 'Run plan worker depends on unknown worker.', array( 'status' => 400, 'worker_id' => $id, 'dependency' => $dependency ) );
+				}
+			}
+		}
+
+		$visiting = array();
+		$visited  = array();
+		foreach ( $descriptors as $descriptor ) {
+			$error = $this->visit_dependency( $descriptor, $by_id, $visiting, $visited );
+			if ( is_wp_error( $error ) ) {
+				return $error;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return deterministic dependency batches in worker input order.
+	 *
+	 * @param array<int,array<string,mixed>> $descriptors Worker descriptors.
+	 * @return array<int,array<int,string>>|WP_Error
+	 */
+	public function dependency_batches( array $descriptors ): array|WP_Error {
+		$valid = $this->validate_dependencies( $descriptors );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$remaining = array_fill_keys( array_map( static fn( array $descriptor ): string => (string) $descriptor['id'], $descriptors ), true );
+		$batches   = array();
+		while ( ! empty( $remaining ) ) {
+			$batch = array();
+			foreach ( $descriptors as $descriptor ) {
+				$id = (string) $descriptor['id'];
+				if ( empty( $remaining[ $id ] ) ) {
+					continue;
+				}
+				$dependencies = $descriptor['depends_on'] ?? array();
+				if ( empty( array_filter( $dependencies, static fn( string $dependency ): bool => isset( $remaining[ $dependency ] ) ) ) ) {
+					$batch[] = $id;
+				}
+			}
+
+			if ( empty( $batch ) ) {
+				return new WP_Error( 'wp_codebox_run_plan_dependency_unscheduled', 'Run plan dependencies could not be scheduled.', array( 'status' => 400 ) );
+			}
+
+			foreach ( $batch as $id ) {
+				unset( $remaining[ $id ] );
+			}
+			$batches[] = $batch;
+		}
+
+		return $batches;
+	}
+
 	/** @param array<string,mixed> $source Source. @return array<string,mixed> */
 	public function cancellation_metadata( array $source ): array {
 		$timeout = $this->positive_integer( $source['timeoutSeconds'] ?? $source['timeout_seconds'] ?? $source['task_timeout_seconds'] ?? null );
@@ -151,22 +226,26 @@ final class WP_Codebox_Run_Plan {
 		);
 	}
 
-	/** @param array<int,array<string,mixed>> $runs Child run results. @return array{total:int,completed:int,failed:int,cancelled:int} */
+	/** @param array<int,array<string,mixed>> $runs Child run results. @return array{total:int,completed:int,failed:int,skipped:int,cancelled:int,timed_out:int} */
 	public function result_counts( array $runs ): array {
 		$completed = count( array_filter( $runs, static fn( array $run ): bool => true === ( $run['success'] ?? false ) ) );
+		$skipped   = count( array_filter( $runs, static fn( array $run ): bool => 'skipped' === ( $run['status'] ?? '' ) ) );
 		$cancelled = count( array_filter( $runs, static fn( array $run ): bool => 'cancelled' === ( $run['status'] ?? '' ) ) );
+		$timed_out = count( array_filter( $runs, static fn( array $run ): bool => in_array( (string) ( $run['status'] ?? '' ), array( 'timed_out', 'timeout' ), true ) ) );
 
 		return array(
 			'total'     => count( $runs ),
 			'completed' => $completed,
-			'failed'    => count( $runs ) - $completed - $cancelled,
+			'failed'    => count( $runs ) - $completed - $skipped - $cancelled - $timed_out,
+			'skipped'   => $skipped,
 			'cancelled' => $cancelled,
+			'timed_out' => $timed_out,
 		);
 	}
 
-	/** @param array{failed:int,cancelled:int} $counts Counts. */
+	/** @param array{failed:int,skipped:int,cancelled:int,timed_out:int} $counts Counts. */
 	public function succeeded( array $counts ): bool {
-		return 0 === $counts['failed'] && 0 === $counts['cancelled'];
+		return 0 === $counts['failed'] && 0 === $counts['skipped'] && 0 === $counts['cancelled'] && 0 === $counts['timed_out'];
 	}
 
 	/** @param array<string,string> $paths Run-plan artifact paths. @return array<string,mixed> */
@@ -187,15 +266,44 @@ final class WP_Codebox_Run_Plan {
 		return array_values( array_filter( $runs, static fn( array $run ): bool => true !== ( $run['success'] ?? false ) ) );
 	}
 
-	/** @param array{completed:int,failed:int,cancelled:int} $counts Counts. @return array<string,mixed> */
+	/** @param array{completed:int,failed:int,skipped:int,cancelled:int,timed_out:int} $counts Counts. @return array<string,mixed> */
 	public function aggregate_result( string $schema, string $status, array $counts ): array {
 		return array(
 			'schema'    => $schema,
 			'status'    => $status,
 			'completed' => $counts['completed'],
 			'failed'    => $counts['failed'],
+			'skipped'   => $counts['skipped'],
 			'cancelled' => $counts['cancelled'],
+			'timed_out' => $counts['timed_out'],
 		);
+	}
+
+	/**
+	 * @param array<string,mixed>             $descriptor Worker descriptor.
+	 * @param array<string,array<string,mixed>> $by_id Worker map.
+	 * @param array<string,bool>              $visiting Visiting set.
+	 * @param array<string,bool>              $visited Visited set.
+	 */
+	private function visit_dependency( array $descriptor, array $by_id, array &$visiting, array &$visited ): true|WP_Error {
+		$id = (string) $descriptor['id'];
+		if ( isset( $visited[ $id ] ) ) {
+			return true;
+		}
+		if ( isset( $visiting[ $id ] ) ) {
+			return new WP_Error( 'wp_codebox_run_plan_dependency_cycle', 'Run plan dependencies contain a cycle.', array( 'status' => 400, 'worker_id' => $id ) );
+		}
+		$visiting[ $id ] = true;
+		foreach ( $descriptor['depends_on'] ?? array() as $dependency ) {
+			$error = $this->visit_dependency( $by_id[ (string) $dependency ], $by_id, $visiting, $visited );
+			if ( is_wp_error( $error ) ) {
+				return $error;
+			}
+		}
+		unset( $visiting[ $id ] );
+		$visited[ $id ] = true;
+
+		return true;
 	}
 
 	/** @param array<string,mixed> $event Event data. @return array<string,mixed> */

--- a/scripts/php-primitive-contract-parity-smoke.php
+++ b/scripts/php-primitive-contract-parity-smoke.php
@@ -133,6 +133,12 @@ assert_same_contract(
 $run_plan = new WP_Codebox_Run_Plan();
 assert_same_contract( $fixture['runPlan']['counts'], $run_plan->result_counts( $fixture['runPlan']['children'] ), 'run-plan result counts' );
 assert_same_contract( $fixture['runPlan']['succeeded'], $run_plan->succeeded( $fixture['runPlan']['counts'] ), 'run-plan succeeded contract' );
+$dependency_descriptors = $run_plan->normalize_worker_descriptors( $fixture['runPlan']['dependencyWorkers'] );
+if ( is_wp_error( $dependency_descriptors ) ) {
+    fwrite( STDERR, 'run-plan dependency descriptor normalization failed: ' . $dependency_descriptors->get_error_message() . "\n" );
+    exit( 1 );
+}
+assert_same_contract( $fixture['runPlan']['dependencyBatches'], $run_plan->dependency_batches( $dependency_descriptors ), 'run-plan dependency batches' );
 assert_same_contract( $fixture['runPlan']['concurrency']['defaulted'], $run_plan->normalize_concurrency( '', array( 'default_concurrency' => 3, 'max_concurrency' => 5 ) ), 'run-plan default concurrency' );
 assert_same_contract( $fixture['runPlan']['concurrency']['clamped'], $run_plan->normalize_concurrency( 99, array( 'max_concurrency' => 2 ) ), 'run-plan clamped concurrency' );
 

--- a/scripts/php-run-plan-contract-smoke.php
+++ b/scripts/php-run-plan-contract-smoke.php
@@ -71,8 +71,8 @@ assert_same_contract( array( 'cancel_requested' => false, 'timeout_seconds' => 3
 assert_same_contract( 'copy/final', $descriptors[1]['artifact_namespace'], 'artifact namespace' );
 assert_same_contract( false, $descriptors[1]['required'], 'required flag' );
 assert_same_contract( array( 'cancel_requested' => true, 'reason' => 'caller stopped' ), $descriptors[1]['cancellation'], 'cancel requested metadata' );
-assert_same_contract( array( 'total' => 3, 'completed' => 1, 'failed' => 1, 'cancelled' => 1 ), $run_plan->result_counts( array( array( 'success' => true, 'status' => 'completed' ), array( 'success' => false, 'status' => 'failed' ), array( 'success' => false, 'status' => 'cancelled' ) ) ), 'result counts' );
-assert_same_contract( false, $run_plan->succeeded( array( 'failed' => 1, 'cancelled' => 0 ) ), 'run-plan success' );
+assert_same_contract( array( 'total' => 5, 'completed' => 1, 'failed' => 1, 'skipped' => 1, 'cancelled' => 1, 'timed_out' => 1 ), $run_plan->result_counts( array( array( 'success' => true, 'status' => 'completed' ), array( 'success' => false, 'status' => 'failed' ), array( 'success' => false, 'status' => 'skipped' ), array( 'success' => false, 'status' => 'cancelled' ), array( 'success' => false, 'status' => 'timed_out' ) ) ), 'result counts' );
+assert_same_contract( false, $run_plan->succeeded( array( 'failed' => 1, 'skipped' => 0, 'cancelled' => 0, 'timed_out' => 0 ) ), 'run-plan success' );
 
 $event = $run_plan->event( 'wp-codebox/agent-fanout-event/v1', array( 'event' => 'worker.completed', 'worker_id' => 'design', 'status' => 'completed' ) );
 unset( $event['time'] );

--- a/scripts/primitive-contract-fixture.ts
+++ b/scripts/primitive-contract-fixture.ts
@@ -129,7 +129,15 @@ const componentManifestProviders: WorkspaceRecipeExtraPlugin[] = [
 const runPlanChildren = [
   { success: true, status: "succeeded" },
   { success: false, status: "failed" },
+  { success: false, status: "skipped" },
   { success: false, status: "cancelled" },
+  { success: false, status: "timed_out" },
+]
+
+const runPlanDependencyWorkers = [
+  { id: "setup", goal: "Prepare" },
+  { id: "parallel", goal: "Parallel" },
+  { id: "dependent", goal: "Dependent", dependsOn: ["setup", "parallel"] },
 ]
 
 export function primitiveContractsFixture(): Record<string, unknown> {
@@ -184,6 +192,8 @@ export function primitiveContractsFixture(): Record<string, unknown> {
       children: runPlanChildren,
       counts: runPlanCounts,
       succeeded: runPlanSucceeded(runPlanCounts),
+      dependencyWorkers: runPlanDependencyWorkers,
+      dependencyBatches: [["setup", "parallel"], ["dependent"]],
       concurrency: {
         defaulted: normalizeRunPlanConcurrency("", { defaultConcurrency: 3, maxConcurrency: 5 }),
         clamped: normalizeRunPlanConcurrency(99, { maxConcurrency: 2 }),

--- a/tests/agent-fanout-executor.test.ts
+++ b/tests/agent-fanout-executor.test.ts
@@ -30,7 +30,7 @@ await withTempDir("wp-codebox-agent-fanout-executor-", async (root) => {
 
   assert.equal(result.success, true)
   assert.equal(result.concurrency, 3)
-  assert.deepEqual(result.counts, { total: 2, completed: 2, failed: 0, cancelled: 0 })
+  assert.deepEqual(result.counts, { total: 2, completed: 2, failed: 0, skipped: 0, cancelled: 0, timed_out: 0 })
   assert.deepEqual(result.session.children.map((child) => child.id), ["fanout-test:one", "fanout-test:two"])
   assert.deepEqual(result.workers.map((worker) => worker.status), ["succeeded", "succeeded"])
   assert.equal(result.workers[0].artifact_refs[0].namespace, "workers/one")
@@ -46,6 +46,59 @@ await withTempDir("wp-codebox-agent-fanout-executor-", async (root) => {
     "aggregation.completed",
     "fanout.completed",
   ])
+})
+
+await withTempDir("wp-codebox-agent-fanout-dag-", async (root) => {
+  const invoked: string[] = []
+  const result = await executeAgentFanoutRequest({
+    schema: FANOUT_REQUEST_SCHEMA,
+    concurrency: 4,
+    agent: "sandbox-agent",
+    orchestrator: { session_id: "fanout-dag" },
+    workers: [
+      { id: "setup", goal: "Prepare shared context" },
+      { id: "failing", goal: "Fail this branch" },
+      { id: "after-setup", goal: "Run after setup", dependsOn: ["setup"] },
+      { id: "after-failing", goal: "Skip after failing", depends_on: ["failing"] },
+      { id: "after-skipped", goal: "Skip after skipped", dependsOn: ["after-failing"] },
+    ],
+  }, {
+    artifactRoot: root,
+    recipeDirectory: root,
+    runWorker: async (input) => {
+      const workerId = String((input.orchestrator as Record<string, unknown>).fanout_worker_id)
+      invoked.push(workerId)
+      return {
+        success: workerId !== "failing",
+        status: workerId === "failing" ? "failed" : "succeeded",
+        evidence_refs: [{ path: `${input.artifacts_path}/result.json`, kind: "worker-result" }],
+      }
+    },
+    previewHoldSeconds: "",
+    previewPublicUrl: "",
+  })
+
+  assert.equal(result.success, false)
+  assert.deepEqual(result.counts, { total: 5, completed: 2, failed: 1, skipped: 2, cancelled: 0, timed_out: 0 })
+  assert.deepEqual(result.workers.map((worker) => [worker.worker_id, worker.status]), [
+    ["setup", "succeeded"],
+    ["failing", "failed"],
+    ["after-setup", "succeeded"],
+    ["after-failing", "skipped"],
+    ["after-skipped", "skipped"],
+  ])
+  assert.deepEqual(invoked.sort(), ["after-setup", "failing", "setup"])
+
+  const plan = JSON.parse(await readFile(join(root, "fanout", "plan.json"), "utf8"))
+  assert.deepEqual(plan.workers[2].depends_on, ["setup"])
+
+  const skipped = JSON.parse(await readFile(join(root, "fanout", "workers", "after-failing", "result.json"), "utf8"))
+  assert.equal(skipped.status, "skipped")
+  assert.deepEqual(skipped.output.dependencies, [{ worker_id: "failing", status: "failed", success: false }])
+
+  const events = (await readFile(join(root, "fanout", "events.jsonl"), "utf8")).trim().split("\n").map((line) => JSON.parse(line))
+  assert.ok(events.find((event) => event.event === "worker.skipped" && event.worker_id === "after-failing"))
+  assert.ok(events.findIndex((event) => event.event === "worker.completed" && event.worker_id === "setup") < events.findIndex((event) => event.event === "worker.started" && event.worker_id === "after-setup"))
 })
 
 console.log("agent fanout executor ok")

--- a/tests/fixtures/primitive-contracts.json
+++ b/tests/fixtures/primitive-contracts.json
@@ -456,16 +456,53 @@
       },
       {
         "success": false,
+        "status": "skipped"
+      },
+      {
+        "success": false,
         "status": "cancelled"
+      },
+      {
+        "success": false,
+        "status": "timed_out"
       }
     ],
     "counts": {
-      "total": 3,
+      "total": 5,
       "completed": 1,
       "failed": 1,
-      "cancelled": 1
+      "skipped": 1,
+      "cancelled": 1,
+      "timed_out": 1
     },
     "succeeded": false,
+    "dependencyWorkers": [
+      {
+        "id": "setup",
+        "goal": "Prepare"
+      },
+      {
+        "id": "parallel",
+        "goal": "Parallel"
+      },
+      {
+        "id": "dependent",
+        "goal": "Dependent",
+        "dependsOn": [
+          "setup",
+          "parallel"
+        ]
+      }
+    ],
+    "dependencyBatches": [
+      [
+        "setup",
+        "parallel"
+      ],
+      [
+        "dependent"
+      ]
+    ],
     "concurrency": {
       "defaulted": 3,
       "clamped": 2

--- a/tests/primitive-contract-parity.test.ts
+++ b/tests/primitive-contract-parity.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeCommandEnvelopeStatus,
   normalizePhaseRecipeStatus,
   normalizeRunPlanConcurrency,
+  normalizeRunPlanWorkerDescriptors,
   normalizeRuntimeMountTarget,
   redactJsonValue,
   resolveEffectiveRuntimeToolPolicy,
@@ -79,6 +80,10 @@ assert.deepEqual(
 
 assert.deepEqual(countRunPlanChildResults(fixture.runPlan.children), fixture.runPlan.counts)
 assert.equal(runPlanSucceeded(fixture.runPlan.counts), fixture.runPlan.succeeded)
+assert.deepEqual(
+  runPlanDependencyBatches(normalizeRunPlanWorkerDescriptors(fixture.runPlan.dependencyWorkers)),
+  fixture.runPlan.dependencyBatches,
+)
 assert.equal(normalizeRunPlanConcurrency("", { defaultConcurrency: 3, maxConcurrency: 5 }), fixture.runPlan.concurrency.defaulted)
 assert.equal(normalizeRunPlanConcurrency(99, { maxConcurrency: 2 }), fixture.runPlan.concurrency.clamped)
 assert.deepEqual(fixture.runPlan.schemas, {
@@ -88,3 +93,15 @@ assert.deepEqual(fixture.runPlan.schemas, {
 })
 
 console.log("primitive contract parity passed")
+
+function runPlanDependencyBatches(workers: ReturnType<typeof normalizeRunPlanWorkerDescriptors>): string[][] {
+  const remaining = new Set(workers.map((worker) => worker.id))
+  const batches: string[][] = []
+  while (remaining.size > 0) {
+    const batch = workers.filter((worker) => remaining.has(worker.id) && worker.dependsOn.every((dependency) => !remaining.has(dependency))).map((worker) => worker.id)
+    if (batch.length === 0) throw new Error("Run plan dependencies could not be scheduled.")
+    batch.forEach((worker) => remaining.delete(worker))
+    batches.push(batch)
+  }
+  return batches
+}

--- a/tests/run-plan-executor.test.ts
+++ b/tests/run-plan-executor.test.ts
@@ -3,8 +3,11 @@ import assert from "node:assert/strict"
 import { executeRunPlan, type RunPlanWorkerAdapter } from "../packages/runtime-core/src/index.js"
 
 const events: string[] = []
+const runs: string[] = []
 const adapter: RunPlanWorkerAdapter = {
   async run({ descriptor }) {
+    runs.push(descriptor.id)
+    await new Promise((resolve) => setTimeout(resolve, descriptor.id === "one" ? 20 : 1))
     return {
       workerId: descriptor.id,
       status: descriptor.id === "failed" ? "failed" : "succeeded",
@@ -22,6 +25,9 @@ const result = await executeRunPlan({
   workers: [
     { id: "one", goal: "Collect first result" },
     { id: "failed", goal: "Collect failed result", artifact_namespace: "custom/failed" },
+    { id: "after-one", goal: "Collect dependent result", dependsOn: ["one"] },
+    { id: "after-failed", goal: "Skip after failed result", depends_on: ["failed"] },
+    { id: "after-skipped", goal: "Skip after skipped result", dependsOn: ["after-failed"] },
     { id: "two", goal: "Collect second result" },
   ],
 }, {
@@ -31,16 +37,24 @@ const result = await executeRunPlan({
   onWorkerStarted: (worker) => events.push(`started:${worker.id}`),
   onWorkerCompleted: (worker) => events.push(`completed:${worker.id}`),
   onWorkerFailed: (worker) => events.push(`failed:${worker.id}`),
+  onWorkerSkipped: (worker) => events.push(`skipped:${worker.id}`),
 })
 
 assert.equal(result.success, false)
 assert.equal(result.concurrency, 2)
-assert.deepEqual(result.counts, { total: 3, completed: 2, failed: 1, cancelled: 0 })
-assert.deepEqual(result.workers.map((worker) => worker.workerId), ["one", "failed", "two"])
+assert.deepEqual(result.counts, { total: 6, completed: 3, failed: 1, skipped: 2, cancelled: 0, timed_out: 0 })
+assert.deepEqual(result.workers.map((worker) => worker.workerId), ["one", "failed", "after-one", "after-failed", "after-skipped", "two"])
 assert.equal(result.workers[1].output?.artifactNamespace, "custom/failed")
-assert.deepEqual(events, ["started:one", "started:failed", "completed:one", "failed:failed", "started:two", "completed:two"])
+assert.equal(result.workers[3].status, "skipped")
+assert.equal(result.workers[4].status, "skipped")
+assert.deepEqual(runs.sort(), ["after-one", "failed", "one", "two"])
+assert.ok(events.indexOf("completed:one") < events.indexOf("started:after-one"), "dependent starts after dependency completion")
+assert.ok(!events.includes("started:after-failed"), "failed dependency dependent is never started")
+assert.ok(events.indexOf("skipped:after-failed") < events.indexOf("skipped:after-skipped"), "transitive skip is deterministic")
 
 await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "missing-goal" }] }, { adapter, requireGoal: true }), /requires goal/)
 await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "duplicate", goal: "one" }, { id: "duplicate", goal: "two" }] }, { adapter }), /must be unique/)
+await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "unknown", goal: "one", dependsOn: ["missing"] }] }, { adapter }), /unknown worker/)
+await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "a", goal: "one", dependsOn: ["b"] }, { id: "b", goal: "two", dependsOn: ["a"] }] }, { adapter }), /cycle/)
 
 console.log("run plan executor ok")


### PR DESCRIPTION
## Summary
- Add dependency validation and deterministic DAG/barrier scheduling to runtime-core run plans.
- Skip dependents when dependencies fail, skip, cancel, or time out, while preserving input-order result arrays and bounded concurrency for ready workers.
- Align CLI fanout and WordPress plugin fanout results/events with skipped/timed_out counts and dependency-aware execution.
- Add TypeScript fanout/run-plan coverage and TS/PHP primitive parity coverage for dependency ordering and skip behavior.

## Tests
- npm run build
- npm run test:agent-fanout-executor
- npm run test:run-plan-executor
- npm run test:primitive-contract-parity
- npm run test:php-primitive-contract-parity
- npm run test:php-run-plan-contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the DAG scheduler, aligning CLI/PHP behavior, and adding focused tests.