### PR TITLE
docs: clarify public Codebox boundary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,8 @@ unless this index says otherwise.
   artifacts, runner workspace publication, lifecycle metadata, provider
   overlays, and default sandbox bootstrap expectations.
 - [Public API contract](./public-api-contract.md) defines stable package
-  entrypoints, lifecycle contract areas, inspectable surfaces, and the limited
-  role of `./internals`.
+  entrypoints, lifecycle contract areas, inspectable surfaces, Codebox's wrapper
+  role around upstream runtime systems, and the limited role of `./internals`.
 - [Generic runtime primitives](./generic-runtime-primitives.md) documents the
   caller-neutral artifact storage, trusted browser origin, materialization, and
   target-context envelopes shared by runtime integrations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,12 @@ WordPress Playground runtime, mount the target code and agent stack, collect
 reviewable artifacts, and return those artifacts to the caller for apply or
 discard.
 
+WP Codebox is also the portable integration surface for the current agent runtime
+stack. Data Machine, Agents API, Data Machine Code, and WordPress Playground are
+implementation inputs that Codebox can wrap internally. Consumers should call
+Codebox ability ids, schemas, package entrypoints, browser SDK facades, and CLI
+commands instead of assembling workflows from those upstream APIs directly.
+
 ```text
 Parent control plane
   owns users, auth, durable jobs, review UX, and apply-back policy
@@ -96,8 +102,8 @@ backend or host adapter. The important modules are:
   episode contracts, and `createRuntime()`.
 - [`src/index.ts`](../packages/runtime-core/src/index.ts): the stable package
   root for runtime, recipe, policy, artifact metadata, task, browser, host-tool,
-  fanout contract, and result-envelope types. Keep implementation helpers out of
-  this barrel.
+  fanout contract, and result-envelope types. Keep implementation helpers and
+  upstream adapter vocabulary out of this barrel.
 - [`docs/public-api-contract.md`](./public-api-contract.md): the maintained
   contract map for stable package entrypoints, inspectable surfaces, lifecycle
   contract areas, and the limited role of `./internals`.
@@ -108,7 +114,8 @@ backend or host adapter. The important modules are:
   export-link, diagnostics, and partial-discovery helpers.
 - `@automattic/wp-codebox-core/internals`: implementation helpers used inside
   this monorepo. External consumers should not rely on this path as a stable
-  compatibility surface.
+  compatibility surface; it is private/unstable even though the package exports it
+  for workspace package reuse.
 - [`src/runtime-policy.ts`](../packages/runtime-core/src/runtime-policy.ts):
   `RuntimePolicy`, policy validation, and command allow-list enforcement.
 - [`src/command-registry.ts`](../packages/runtime-core/src/command-registry.ts):

--- a/docs/parent-tool-bridge-contract.md
+++ b/docs/parent-tool-bridge-contract.md
@@ -131,6 +131,7 @@ Minimal integration points:
   `parent_request` into the sandbox run input.
 - CLI input accepts `--parent-tool-bridge='<json>'` as an object-valued field.
 
-Homeboy Extensions and Data Machine can later inject their specific endpoint or
-command metadata behind this contract without adding their product semantics to
-WP Codebox core.
+Host adapters can later map their endpoint or command metadata into this Codebox
+contract without adding product semantics to WP Codebox core. Upstream systems
+such as Data Machine should provide generic tool/run inputs; Codebox performs any
+WP Codebox schema mapping at its boundary.

--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -2,7 +2,9 @@
 
 WP Codebox has two kinds of API surface: stable public entrypoints for host
 integrations, and monorepo internals for implementation reuse. This document is
-the maintained contract map for package consumers.
+the maintained contract map for package consumers. Consumers use Codebox APIs;
+they do not couple to the upstream systems that Codebox uses to assemble or run a
+sandbox.
 
 ## Stable Entry Points
 
@@ -82,9 +84,32 @@ The stable public surface is grouped by lifecycle area rather than by product:
   `commands` output, and recipe validation descriptors.
 
 Implementation backends are intentionally not public namespaces. References to
-Agents API, Data Machine Code, or WordPress Playground describe the current
-upstream/runtime adapter behind WP Codebox; consumers should depend on the
-Codebox ability ids, schemas, package entrypoints, and browser SDK facades above.
+Data Machine, Agents API, Data Machine Code, or WordPress Playground describe the
+current upstream/runtime adapters behind WP Codebox; consumers should depend on
+the Codebox ability ids, schemas, package entrypoints, and browser SDK facades
+above.
+
+## Integration Boundary
+
+WP Codebox is the portable integration surface around the current WordPress agent
+runtime stack:
+
+- Data Machine concepts such as jobs, artifacts, flows, and pending approvals map
+  to Codebox run, artifact, approval, and session contracts before they reach a
+  consumer.
+- Agents API execution targets, principals, and provider mechanics map to Codebox
+  task, permission, provider, and runtime-session contracts.
+- Data Machine Code workspace lifecycle, GitHub workflow, evidence, and apply-back
+  details map to Codebox source, workspace, artifact, and apply contracts.
+- WordPress Playground boot, filesystem, preview, PHP, and WP-CLI details map to
+  Codebox runtime, mount, command, preview, and browser-session contracts.
+
+The dependency direction is one-way: Codebox may adapt those upstream systems into
+generic Codebox inputs internally. Data Machine must not parse, validate, or emit
+WP Codebox-specific schemas as a compatibility requirement. If a Data Machine
+workflow needs to launch a sandbox, the Codebox adapter translates from generic
+Data Machine inputs into the Codebox task/recipe/runtime contracts at the
+boundary.
 
 When adding a new public type or helper, place it in the focused owner module and
 export it through `@automattic/wp-codebox-core/public` or the narrowest stable

--- a/docs/transfer-readiness-checklist.md
+++ b/docs/transfer-readiness-checklist.md
@@ -52,7 +52,7 @@ Current workspace packages:
 
 - `packages/runtime-core` owns backend-agnostic contracts: runtime policy,
   command registry, task input, workspace policy, recipe schemas, artifact
-  verification, sandbox Data Machine tool policy, and shared types.
+  verification, generic sandbox tool policy, and shared types.
 - `packages/runtime-playground` owns the WordPress Playground backend adapter:
   Playground boot, command routing, WP-CLI/PHP/browser command runners,
   snapshots, observations, mounted-file capture, diagnostics, and artifact bundle
@@ -80,7 +80,8 @@ Transfer checklist:
   review UX, or model-evaluation scoring.
 - Keep the WordPress plugin as a parent-site adapter; it should expose abilities
   and host configuration without depending on a specific product database, queue,
-  UI, or Data Machine install beyond optional integration filters.
+  UI, or Data Machine install. Codebox adapters map generic Data Machine inputs to
+  Codebox contracts internally when that integration is present.
 - Track helper deduplication through issue #344 so shared object/hash/artifact
   helpers move to stable package homes without creating dependency cycles.
 
@@ -207,9 +208,9 @@ Transfer checklist:
   validation versus runtime enforcement.
 - Workspace policy must keep sandbox writes inside declared writable roots and
   hide configured paths from artifact capture or tool access.
-- Sandbox Data Machine tools must stay on the explicit safe allow-list; parent
-  worktree lifecycle, GitSync, PR mutation, issue mutation, comments, deploys,
-  cleanup, and apply-back operations remain parent-only.
+- Sandbox tools mapped from a parent system must stay on the explicit safe
+  allow-list; parent worktree lifecycle, GitSync, PR mutation, issue mutation,
+  comments, deploys, cleanup, and apply-back operations remain parent-only.
 - Artifact access must resolve paths under the configured artifact root and reject
   outside-root traversal.
 - Apply-back must require reviewed `approved_files[]` and digest-verified bundle

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,6 +3,11 @@
 CLI entrypoint for running disposable WP Codebox sandboxes and collecting
 reviewable artifact bundles. **Secure coding environments inside WordPress** — every command runs against a fresh WordPress Playground instance that can't touch your host site.
 
+The CLI is a public Codebox surface. Consumers should use its documented commands
+and JSON outputs rather than importing package internals or depending on Data
+Machine, Agents API, Data Machine Code, or raw WordPress Playground details used
+behind the runner.
+
 ## Install
 
 The public `@automattic/wp-codebox-cli` npm package is not published yet. Until

--- a/packages/runtime-core/src/artifacts.ts
+++ b/packages/runtime-core/src/artifacts.ts
@@ -1,3 +1,4 @@
+/** Public artifact helpers for Codebox-produced bundles and apply adapters. */
 export * from "./artifact-manifest.js"
 export * from "./artifact-paths.js"
 export * from "./artifact-capture-policy.js"

--- a/packages/runtime-core/src/contracts.ts
+++ b/packages/runtime-core/src/contracts.ts
@@ -1,2 +1,3 @@
+/** Inspectable Codebox contract metadata for CLI and orchestrator consumers. */
 export * from "./index.js"
 export * from "./command-registry.js"

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Stable root package barrel kept for existing consumers. New integrations should
+ * prefer the curated `@automattic/wp-codebox-core/public` facade or narrower
+ * lifecycle subpaths documented in docs/public-api-contract.md.
+ */
 export * from "./artifact-manifest.js"
 export * from "./artifact-paths.js"
 export * from "./artifact-capture-policy.js"

--- a/packages/runtime-core/src/public.ts
+++ b/packages/runtime-core/src/public.ts
@@ -1,3 +1,8 @@
+/**
+ * Curated public facade for external Codebox integrations. This surface exposes
+ * Codebox-owned contracts, not Data Machine, Agents API, Data Machine Code, or
+ * raw WordPress Playground implementation APIs.
+ */
 export * from "./agent-runtime-workload.js"
 export * from "./agent-task-recipe.js"
 export * from "./agent-task-run-result.js"

--- a/packages/runtime-playground/src/index.ts
+++ b/packages/runtime-playground/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Public WordPress Playground backend adapter for Codebox runtimes. Consumers
+ * should call Codebox runtime contracts rather than raw Playground internals.
+ */
 export { playgroundRuntimeCommandIds } from "./command-router.js"
 export { ArtifactBundleWriter, ManifestedArtifactSet, type ManifestedArtifactFileInput } from "./artifact-bundle-writer.js"
 export { buildArtifactDiagnostics } from "./artifacts.js"

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -36,8 +36,10 @@ metadata exposes `meta.canonical_ability` for aliases.
 The host task abilities build a private Codebox recipe, boot a disposable
 sandbox runtime, mount the requested runtime components, invoke the configured
 sandbox-local task, and return artifact metadata. `wp-codebox agent-sandbox-run`,
-WordPress Playground, and upstream task runtimes are implementation details of
-the current runner, not consumer-facing API names.
+Data Machine, Agents API, Data Machine Code, WordPress Playground, and upstream
+task runtimes are implementation details of the current runner, not
+consumer-facing API names. The plugin maps those internals to Codebox task,
+runtime, artifact, and apply contracts before returning results to consumers.
 
 The task ability accepts `wp-codebox/task-input/v1` fields: `goal`, `target`,
 `allowed_tools`, `expected_artifacts`, `policy`, and `context`. Raw PHP `code`

--- a/tests/docs-boundary-language.test.ts
+++ b/tests/docs-boundary-language.test.ts
@@ -22,6 +22,14 @@ const genericContractDocs = [
   "docs/benchmark-contract.md",
 ]
 
+const publicBoundaryDocs = [
+  "docs/public-api-contract.md",
+  "docs/architecture.md",
+  "docs/parent-tool-bridge-contract.md",
+  "packages/cli/README.md",
+  "packages/wordpress-plugin/README.md",
+]
+
 const root = new URL("..", import.meta.url)
 const violations: string[] = []
 
@@ -53,6 +61,14 @@ assert.match(exampleConsumerDoc, /WordPress Playground boot, filesystem, preview
 assert.match(exampleConsumerDoc, /Public schema names, top-level DTO fields, package entrypoints, and docs intended\s+for consumers use Codebox vocabulary\./)
 assert.match(exampleConsumerDoc, /Named products may appear in integration notes as\s+example consumers/)
 assert.match(exampleConsumerDoc, /## Example Consumers/)
+
+const publicBoundaryText = (await Promise.all(publicBoundaryDocs.map((doc) => readFile(new URL(doc, root), "utf8")))).join("\n")
+assert.match(publicBoundaryText, /Consumers should call\s+Codebox ability ids, schemas, package entrypoints, browser SDK facades, and CLI\s+commands/)
+assert.match(publicBoundaryText, /Data Machine must not parse, validate, or emit\s+WP Codebox-specific schemas as a compatibility requirement/)
+assert.match(publicBoundaryText, /Codebox performs any\s+WP Codebox schema mapping at its boundary/)
+assert.match(publicBoundaryText, /The CLI is a public Codebox surface/)
+assert.match(publicBoundaryText, /Data Machine, Agents API, Data Machine Code, WordPress Playground, and upstream\s+task runtimes are implementation details/)
+assert.doesNotMatch(publicBoundaryText, /Data Machine (?:must|should) (?:understand|parse|validate|emit) (?:WP )?Codebox/)
 
 const agentRuntimeContract = await readFile(new URL("docs/agent-runtime-contract.md", root), "utf8")
 assert.match(agentRuntimeContract, /`generic-ability-runtime-run` is the canonical primitive/)

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -110,6 +110,10 @@ for (const internalModule of [
 assert.match(docs, /@automattic\/wp-codebox-core\/internals` exists for this monorepo's package split/)
 assert.match(docs, /not a stable compatibility surface for external integrations/)
 assert.match(docs, /New external TypeScript\s+consumers should prefer/)
+assert.match(docs, /## Integration Boundary/)
+assert.match(docs, /Codebox may adapt those upstream systems into\s+generic Codebox inputs internally/)
+assert.match(docs, /Data Machine must not parse, validate, or emit\s+WP Codebox-specific schemas as a compatibility requirement/)
+assert.match(docs, /Codebox adapter translates from generic\s+Data Machine inputs into the Codebox task\/recipe\/runtime contracts/)
 
 assert.equal(typeof normalizeBrowserRunResult, "function")
 assert.equal(typeof browserRunResultEnvelope, "function")


### PR DESCRIPTION
## Summary
- Document WP Codebox as the public integration surface around runtime internals
- Clarify that consumers should use Codebox APIs rather than Data Machine, Agents API, Data Machine Code, or raw Playground internals
- Add tests that lock boundary language and the one-way Data Machine dependency rule

## Testing
- npm run test:public-api-contract
- npx tsx tests/docs-boundary-language.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting documentation and boundary-language test updates