### PR TITLE
feat: add generic runtime ability aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "test:runtime-preset-registry": "tsx tests/runtime-preset-registry.test.ts",
     "test:generic-ability-runtime-run": "tsx tests/generic-ability-runtime-run.test.ts",
     "test:provider-runtime-contracts": "tsx tests/provider-runtime-contracts.test.ts",
+    "test:public-ability-aliases": "tsx tests/public-ability-aliases.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
     "test:distribution-startup-probes": "tsx tests/distribution-startup-probes.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -246,9 +246,7 @@ final class WP_Codebox_Abilities {
 				),
 			);
 
-			wp_register_ability(
-				'wp-codebox/run-agent-task',
-				array(
+			$run_agent_task_ability = array(
 					'label'               => 'Run Agent Sandbox Task',
 					'description'         => 'Run a bounded task inside an isolated WP Codebox WordPress agent sandbox and return artifacts.',
 					'category'            => 'wp-codebox',
@@ -282,12 +280,17 @@ final class WP_Codebox_Abilities {
 					'execute_callback'    => array( self::class, 'run_agent_task' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
 					'meta'                => array( 'show_in_rest' => true ),
-				)
 			);
 
-			wp_register_ability(
-				'wp-codebox/run-agent-task-batch',
-				array(
+			wp_register_ability( 'wp-codebox/run-agent-task', $run_agent_task_ability );
+
+			$run_sandbox_task_ability         = $run_agent_task_ability;
+			$run_sandbox_task_ability['label'] = 'Run Sandbox Task';
+			$run_sandbox_task_ability['description'] = 'Run a bounded task inside an isolated WP Codebox WordPress sandbox and return artifacts.';
+			$run_sandbox_task_ability['meta']        = array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-agent-task', 'alias_of' => 'wp-codebox/run-agent-task' );
+			wp_register_ability( 'wp-codebox/run-sandbox-task', $run_sandbox_task_ability );
+
+			$run_agent_task_batch_ability = array(
 					'label'               => 'Run Agent Sandbox Task Batch',
 					'description'         => 'Run multiple tasks in isolated WP Codebox WordPress agent sandboxes and return artifacts for each run.',
 					'category'            => 'wp-codebox',
@@ -346,12 +349,17 @@ final class WP_Codebox_Abilities {
 					'execute_callback'    => array( self::class, 'run_agent_task_batch' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
 					'meta'                => array( 'show_in_rest' => true ),
-				)
 			);
 
-			wp_register_ability(
-				'wp-codebox/run-agent-task-fanout',
-				array(
+			wp_register_ability( 'wp-codebox/run-agent-task-batch', $run_agent_task_batch_ability );
+
+			$run_sandbox_task_batch_ability         = $run_agent_task_batch_ability;
+			$run_sandbox_task_batch_ability['label'] = 'Run Sandbox Task Batch';
+			$run_sandbox_task_batch_ability['description'] = 'Run multiple tasks in isolated WP Codebox WordPress sandboxes and return artifacts for each run.';
+			$run_sandbox_task_batch_ability['meta']        = array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-agent-task-batch', 'alias_of' => 'wp-codebox/run-agent-task-batch' );
+			wp_register_ability( 'wp-codebox/run-sandbox-task-batch', $run_sandbox_task_batch_ability );
+
+			$run_agent_task_fanout_ability = array(
 					'label'               => 'Run Agent Sandbox Task Fanout',
 					'description'         => 'Run multiple agent sandbox workers with bounded host-side concurrency and parent/child artifact envelopes.',
 					'category'            => 'wp-codebox',
@@ -414,8 +422,15 @@ final class WP_Codebox_Abilities {
 					'execute_callback'    => array( self::class, 'run_agent_task_fanout' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
 					'meta'                => array( 'show_in_rest' => true ),
-				)
 			);
+
+			wp_register_ability( 'wp-codebox/run-agent-task-fanout', $run_agent_task_fanout_ability );
+
+			$run_sandbox_task_fanout_ability         = $run_agent_task_fanout_ability;
+			$run_sandbox_task_fanout_ability['label'] = 'Run Sandbox Task Fanout';
+			$run_sandbox_task_fanout_ability['description'] = 'Run multiple sandbox workers with bounded host-side concurrency and parent/child artifact envelopes.';
+			$run_sandbox_task_fanout_ability['meta']        = array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-agent-task-fanout', 'alias_of' => 'wp-codebox/run-agent-task-fanout' );
+			wp_register_ability( 'wp-codebox/run-sandbox-task-fanout', $run_sandbox_task_fanout_ability );
 
 			wp_register_ability(
 				'wp-codebox/request-host-delegation',

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
@@ -24,7 +24,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 		$inherit_schema              = $context['inherit_schema'];
 		$session_input               = $context['session_input'];
 
-		return array(
+		$descriptors = array(
 			'wp-codebox/create-browser-contained-site-session' => array(
 				'label'               => 'Create Browser Contained Site Session',
 				'description'         => 'Create a Codebox-contained browser site session and return product-safe session, preview lease, boot descriptor, and startup diagnostics without requiring consumers to pass Playground boot internals.',
@@ -606,5 +606,43 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 				'meta'                => array( 'show_in_rest' => true ),
 			),
 		);
+
+		$aliases = array(
+			'wp-codebox/create-sandbox-session'  => array(
+				'canonical'   => 'wp-codebox/create-browser-playground-session',
+				'label'       => 'Create Sandbox Session',
+				'description' => 'Prepare a WP Codebox browser sandbox session without exposing the current runtime implementation name to callers.',
+			),
+			'wp-codebox/create-task-contract'    => array(
+				'canonical'   => 'wp-codebox/create-browser-task-contract',
+				'label'       => 'Create Task Contract',
+				'description' => 'Prepare a product-facing multi-phase WP Codebox task contract with a primary sandbox session and optional materializer phases.',
+			),
+			'wp-codebox/open-contained-runtime'  => array(
+				'canonical'   => 'wp-codebox/open-or-create-browser-contained-site',
+				'label'       => 'Open Contained Runtime',
+				'description' => 'Open a reusable contained WP Codebox runtime when possible, otherwise create a fresh sandbox session from the same task input.',
+			),
+		);
+
+		foreach ( $aliases as $ability_id => $alias ) {
+			$canonical = $alias['canonical'];
+			if ( ! isset( $descriptors[ $canonical ] ) ) {
+				continue;
+			}
+
+			$descriptors[ $ability_id ]                = $descriptors[ $canonical ];
+			$descriptors[ $ability_id ]['label']       = $alias['label'];
+			$descriptors[ $ability_id ]['description'] = $alias['description'];
+			$descriptors[ $ability_id ]['meta']        = array_merge(
+				is_array( $descriptors[ $ability_id ]['meta'] ?? null ) ? $descriptors[ $ability_id ]['meta'] : array(),
+				array(
+					'canonical_ability' => $canonical,
+					'alias_of'          => $canonical,
+				)
+			);
+		}
+
+		return $descriptors;
 	}
 }

--- a/tests/public-ability-aliases.test.ts
+++ b/tests/public-ability-aliases.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-abilities.php", "utf8")
+const descriptorsPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php", "utf8")
+
+const taskAliases = new Map([
+  ["wp-codebox/run-sandbox-task", { canonical: "wp-codebox/run-agent-task", canonicalVar: "run_agent_task_ability", aliasVar: "run_sandbox_task_ability", callback: "run_agent_task" }],
+  ["wp-codebox/run-sandbox-task-batch", { canonical: "wp-codebox/run-agent-task-batch", canonicalVar: "run_agent_task_batch_ability", aliasVar: "run_sandbox_task_batch_ability", callback: "run_agent_task_batch" }],
+  ["wp-codebox/run-sandbox-task-fanout", { canonical: "wp-codebox/run-agent-task-fanout", canonicalVar: "run_agent_task_fanout_ability", aliasVar: "run_sandbox_task_fanout_ability", callback: "run_agent_task_fanout" }],
+])
+
+for (const [alias, expectation] of taskAliases) {
+  assert.match(abilitiesPhp, new RegExp(`wp_register_ability\\(\\s*'${alias}',\\s*\\$${expectation.aliasVar}\\s*\\)`))
+  assert.match(abilitiesPhp, new RegExp(`\\$${expectation.aliasVar}\\s*=\\s*\\$${expectation.canonicalVar};`))
+  assert.match(abilitiesPhp, new RegExp(`\\$${expectation.aliasVar}\\['meta'\\]\\s*=\\s*array\\([\\s\\S]*'canonical_ability'\\s*=>\\s*'${expectation.canonical}'[\\s\\S]*'alias_of'\\s*=>\\s*'${expectation.canonical}'[\\s\\S]*\\);`))
+  assert.match(abilitiesPhp, new RegExp(`\\$${expectation.canonicalVar}\\s*=\\s*array\\([\\s\\S]*'execute_callback'\\s*=>\\s*array\\(\\s*self::class,\\s*'${expectation.callback}'\\s*\\)`))
+}
+
+const browserAliases = new Map([
+  ["wp-codebox/create-sandbox-session", "wp-codebox/create-browser-playground-session"],
+  ["wp-codebox/create-task-contract", "wp-codebox/create-browser-task-contract"],
+  ["wp-codebox/open-contained-runtime", "wp-codebox/open-or-create-browser-contained-site"],
+])
+
+for (const [alias, canonical] of browserAliases) {
+  assert.match(descriptorsPhp, new RegExp(`'${alias}'\\s*=>\\s*array\\(`))
+  assert.match(descriptorsPhp, new RegExp(`'canonical'\\s*=>\\s*'${canonical}'`))
+}
+
+assert.match(descriptorsPhp, /\$descriptors\[\s*\$ability_id\s*\]\s*=\s*\$descriptors\[\s*\$canonical\s*\]/)
+assert.match(descriptorsPhp, /'canonical_ability'\s*=>\s*\$canonical/)
+assert.match(descriptorsPhp, /'alias_of'\s*=>\s*\$canonical/)
+assert.doesNotMatch(abilitiesPhp + descriptorsPhp, /datamachine|data machine/i)
+
+console.log("public ability aliases ok")


### PR DESCRIPTION
## Summary
- Add generic sandbox/runtime ability aliases over existing agent/browser-specific abilities
- Preserve canonical handlers, schemas, and permissions while exposing alias metadata
- Add static coverage for public alias registration

## Testing
- npm run test:public-ability-aliases
- npm run test:provider-runtime-contracts
- npm run test:browser-provider-permissions
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing alias registration and focused test coverage