### PR TITLE
fix: keep runtime profile output public

### DIFF
--- a/docs/runtime-profile-contract.md
+++ b/docs/runtime-profile-contract.md
@@ -4,13 +4,14 @@
 contract for callers that need an agent-capable WordPress sandbox without binding
 to backend plugin names, overlay paths, activation order, or readiness probes.
 
-Callers request profiles by generic capabilities or component selectors. WP
-Codebox resolves those selectors into backend details internally, then returns a
-portable profile envelope with:
+Callers request profiles by generic Codebox capabilities or component selectors.
+WP Codebox resolves those selectors into backend details internally, then returns
+a portable profile envelope with:
 
 - `schema`: `wp-codebox/runtime-profile/v1`.
 - `capabilities`: normalized capability strings provided by the resolved profile.
-- `components`: runtime components selected for the sandbox.
+- `components`: caller-declared portable runtime components that remain part of
+  the public profile.
 - `plugins`, `mu_plugins`, `themes`, `overlays`: optional dependency descriptors
   for backend materialization.
 - `runtime_overlays`, `runtime_state_mounts`, `runtime_config_mounts`: optional
@@ -20,17 +21,19 @@ portable profile envelope with:
 - `diagnostics`: structured, non-secret resolver evidence for operators and UI.
 - `provenance`: Codebox ownership and resolver metadata.
 
-The profile contract is the public lane. Consumers should not depend on provider
-plugin paths, overlay file paths, activation order, or backend readiness
-internals. Those may appear in backend execution plans or diagnostics, but the
-caller-facing request/result remains the generic Codebox profile.
+The profile contract is the public lane. Consumers should not depend on Agents
+API, Data Machine, Data Machine Code, WordPress Playground, provider plugin
+paths, overlay file paths, activation order, or backend readiness internals.
+Those may appear in backend execution plans or `runtime.resolved_profile`
+diagnostics, but the caller-facing request/result remains the generic Codebox
+profile.
 
 Example request fragment:
 
 ```json
 {
   "runtime_profile": {
-    "capabilities": ["agents.runtime", "provider.openai"],
+    "capabilities": ["codebox.agent-runtime", "provider.openai"],
     "components": ["workspace-overlay"]
   }
 }
@@ -41,7 +44,7 @@ Example resolved profile fragment:
 ```json
 {
   "schema": "wp-codebox/runtime-profile/v1",
-  "capabilities": ["wordpress.playground", "browser.preview", "agents.runtime", "provider.openai"],
+  "capabilities": ["wordpress.sandbox", "browser.preview", "codebox.agent-runtime", "provider.openai"],
   "components": [{ "kind": "component", "slug": "workspace-overlay" }],
   "readiness": {
     "status": "ready",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,9 +4,8 @@ CLI entrypoint for running disposable WP Codebox sandboxes and collecting
 reviewable artifact bundles. **Secure coding environments inside WordPress** — every command runs against a fresh WordPress Playground instance that can't touch your host site.
 
 The CLI is a public Codebox surface. Consumers should use its documented commands
-and JSON outputs rather than importing package internals or depending on Data
-Machine, Agents API, Data Machine Code, or raw WordPress Playground details used
-behind the runner.
+and JSON outputs rather than importing package internals or depending on upstream
+runtime, workspace, provider, or sandbox backend details used behind the runner.
 
 ## Install
 

--- a/packages/runtime-core/src/public.ts
+++ b/packages/runtime-core/src/public.ts
@@ -1,7 +1,7 @@
 /**
  * Curated public facade for external Codebox integrations. This surface exposes
- * Codebox-owned contracts, not Data Machine, Agents API, Data Machine Code, or
- * raw WordPress Playground implementation APIs.
+ * Codebox-owned contracts, not upstream runtime, workspace, provider, or
+ * sandbox backend implementation APIs.
  */
 export * from "./agent-runtime-workload.js"
 export * from "./agent-workload.js"

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -36,8 +36,8 @@ metadata exposes `meta.canonical_ability` for aliases.
 The host task abilities build a private Codebox recipe, boot a disposable
 sandbox runtime, mount the requested runtime components, invoke the configured
 sandbox-local task, and return artifact metadata. `wp-codebox agent-sandbox-run`,
-Data Machine, Agents API, Data Machine Code, WordPress Playground, and upstream
-task runtimes are implementation details of the current runner, not
+upstream runtime stacks, workspace adapters, provider plugins, sandbox backends,
+and task runtimes are implementation details of the current runner, not
 consumer-facing API names. The plugin maps those internals to Codebox task,
 runtime, artifact, and apply contracts before returning results to consumers.
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -398,15 +398,14 @@ final class WP_Codebox_Browser_Task_Builder {
 		}
 
 		$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
-		$runtime['plugins'] = array_merge(
-			self::object_list( $profile['plugins'] ?? array() ),
-			self::object_list( $profile['provider_plugins'] ?? array() ),
-			is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array()
-		);
+		$profile_plugins = self::merge_lists( self::object_list( $profile['plugins'] ?? array() ), self::object_list( $profile['provider_plugins'] ?? array() ) );
+		$runtime_plugins = is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array();
+		$runtime['plugins'] = empty( $runtime['resolved_profile'] ) ? self::merge_lists( $profile_plugins, $runtime_plugins ) : self::merge_lists( $runtime_plugins, $profile_plugins );
 		foreach ( array( 'components', 'mu_plugins', 'themes', 'bootstrap', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts' ) as $field ) {
 			$profile_items = self::object_list( $profile[ $field ] ?? array() );
 			if ( ! empty( $profile_items ) ) {
-				$runtime[ $field ] = array_merge( $profile_items, is_array( $runtime[ $field ] ?? null ) ? $runtime[ $field ] : array() );
+				$runtime_items = is_array( $runtime[ $field ] ?? null ) ? $runtime[ $field ] : array();
+				$runtime[ $field ] = empty( $runtime['resolved_profile'] ) ? self::merge_lists( $profile_items, $runtime_items ) : self::merge_lists( $runtime_items, $profile_items );
 			}
 		}
 
@@ -820,6 +819,24 @@ final class WP_Codebox_Browser_Task_Builder {
 		}
 
 		return $list;
+	}
+
+	/** @return array<int,mixed> */
+	private static function merge_lists( mixed ...$lists ): array {
+		$merged = array();
+		$seen   = array();
+		foreach ( $lists as $list ) {
+			foreach ( is_array( $list ) ? $list : array() as $item ) {
+				$key = is_array( $item ) ? md5( wp_json_encode( $item ) ?: serialize( $item ) ) : 'scalar:' . (string) $item;
+				if ( isset( $seen[ $key ] ) ) {
+					continue;
+				}
+				$seen[ $key ] = true;
+				$merged[]     = $item;
+			}
+		}
+
+		return $merged;
 	}
 
 	/** @param mixed $value Provider plugin specs. @return string[] */

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php
@@ -25,11 +25,23 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 		foreach ( array( 'id', 'profile', 'profiles', 'components', 'capabilities' ) as $selector_field ) {
 			unset( $profile[ $selector_field ] );
 		}
-		$profile = self::merge_profile( $resolved['profile'], $profile );
+		$materialization_profile = self::merge_profile( $resolved['profile'], $profile );
+		$profile                 = self::merge_profile( self::public_profile( $resolved ), $profile );
 		$profile['resolved_profile'] = $resolved['contract'];
 
 		$input['runtime_profile'] = $profile;
 		$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
+		$runtime['plugins'] = self::merge_lists(
+			is_array( $materialization_profile['plugins'] ?? null ) ? $materialization_profile['plugins'] : array(),
+			is_array( $materialization_profile['provider_plugins'] ?? null ) ? $materialization_profile['provider_plugins'] : array(),
+			is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array()
+		);
+		foreach ( array( 'components', 'mu_plugins', 'themes', 'bootstrap', 'runtime_overlays', 'runtime_state_mounts', 'runtime_config_mounts' ) as $field ) {
+			$items = is_array( $materialization_profile[ $field ] ?? null ) ? $materialization_profile[ $field ] : array();
+			if ( ! empty( $items ) ) {
+				$runtime[ $field ] = self::merge_lists( $items, is_array( $runtime[ $field ] ?? null ) ? $runtime[ $field ] : array() );
+			}
+		}
 		$runtime['resolved_profile'] = $resolved['contract'];
 		$input['runtime'] = $runtime;
 
@@ -143,6 +155,7 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 				'id'                     => 'wordpress-playground',
 				'label'                  => 'WordPress Playground sandbox',
 				'capabilities'           => array( 'wordpress.playground', 'browser.preview' ),
+				'public_capabilities'    => array( 'wordpress.sandbox', 'browser.preview' ),
 				'placement_capabilities' => array( 'wordpress.playground', 'browser.preview' ),
 			),
 			'agents-api' => array(
@@ -150,6 +163,7 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 				'label'                  => 'Agents API runtime',
 				'aliases'                => array( 'agent-runtime', 'wordpress-agent-runtime' ),
 				'capabilities'           => array( 'agents-api', 'agents.runtime' ),
+				'public_capabilities'    => array( 'codebox.agent-runtime' ),
 				'requires'                => array( 'wordpress-playground' ),
 				'components'              => array( array( 'slug' => 'agents-api' ) ),
 				'placement_capabilities' => array( 'agents.runtime' ),
@@ -282,12 +296,53 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 		return self::merge_string_lists( $profile['provides'] ?? array(), $profile['capabilities'] ?? array() );
 	}
 
+	/** @param array<string,mixed> $profile Profile descriptor. @return string[] */
+	private static function profile_public_capabilities( array $profile ): array {
+		$public = self::merge_string_lists( $profile['public_capabilities'] ?? array(), $profile['public_provides'] ?? array() );
+		return ! empty( $public ) ? $public : self::profile_capabilities( $profile );
+	}
+
+	/** @param array<string,mixed> $resolved Resolution payload. @return array<string,mixed> */
+	private static function public_profile( array $resolved ): array {
+		$components = array();
+		foreach ( is_array( $resolved['unresolved_components'] ?? null ) ? $resolved['unresolved_components'] : array() as $component ) {
+			if ( is_array( $component ) ) {
+				$components[] = $component;
+			}
+		}
+
+		return array_filter(
+			array(
+				'schema'       => 'wp-codebox/runtime-profile/v1',
+				'id'           => (string) ( $resolved['profile']['id'] ?? '' ),
+				'capabilities' => self::public_capabilities( $resolved ),
+				'components'   => $components,
+				'readiness'    => is_array( $resolved['profile']['readiness'] ?? null ) ? $resolved['profile']['readiness'] : array(),
+				'diagnostics'  => is_array( $resolved['profile']['diagnostics'] ?? null ) ? $resolved['profile']['diagnostics'] : array(),
+				'provenance'   => is_array( $resolved['profile']['provenance'] ?? null ) ? $resolved['profile']['provenance'] : array(),
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $resolved Resolution payload. @return string[] */
+	private static function public_capabilities( array $resolved ): array {
+		$capabilities = array();
+		foreach ( is_array( $resolved['profiles'] ?? null ) ? $resolved['profiles'] : array() as $profile ) {
+			if ( is_array( $profile ) ) {
+				$capabilities = self::merge_string_lists( $capabilities, $profile['public_provides'] ?? array(), $profile['provides'] ?? array() );
+			}
+		}
+
+		return $capabilities;
+	}
+
 	/** @param array<string,mixed> $request Runtime profile request. @param array<string,array<string,mixed>> $registry Profile registry. @return array<int,array<string,string>> */
 	private static function unresolved_component_entries( array $request, array $registry ): array {
 		$entries = array();
 		foreach ( self::merge_string_lists( $request['components'] ?? array() ) as $component ) {
 			if ( ! isset( $registry[ $component ] ) ) {
-				$entries[] = array( 'slug' => $component );
+				$entries[] = array( 'kind' => 'component', 'slug' => $component );
 			}
 		}
 
@@ -381,7 +436,13 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 				'id'         => (string) ( $profile['id'] ?? '' ),
 				'label'      => (string) ( $profile['label'] ?? '' ),
 				'aliases'    => self::merge_string_lists( $profile['aliases'] ?? array() ),
-				'provides'   => self::profile_capabilities( $profile ),
+				'provides'   => self::profile_public_capabilities( $profile ),
+				'internal'   => array_filter(
+					array(
+						'provides' => self::profile_capabilities( $profile ),
+					),
+					static fn( mixed $value ): bool => array() !== $value && '' !== $value
+				),
 				'requires'   => self::merge_string_lists( $profile['requires'] ?? array() ),
 				'provenance' => is_array( $profile['provenance'] ?? null ) ? $profile['provenance'] : array(),
 			),

--- a/tests/docs-boundary-language.test.ts
+++ b/tests/docs-boundary-language.test.ts
@@ -68,7 +68,7 @@ assert.match(publicBoundaryText, /Consumers should call\s+Codebox ability ids, s
 assert.match(publicBoundaryText, /Data Machine must not parse, validate, or emit\s+WP Codebox-specific schemas as a compatibility requirement/)
 assert.match(publicBoundaryText, /Codebox performs any\s+WP Codebox schema mapping at its boundary/)
 assert.match(publicBoundaryText, /The CLI is a public Codebox surface/)
-assert.match(publicBoundaryText, /Data Machine, Agents API, Data Machine Code, WordPress Playground, and upstream\s+task runtimes are implementation details/)
+assert.match(publicBoundaryText, /upstream runtime stacks, workspace adapters, provider plugins, sandbox backends,\s+and task runtimes are implementation details/)
 assert.doesNotMatch(publicBoundaryText, /Data Machine (?:must|should) (?:understand|parse|validate|emit) (?:WP )?Codebox/)
 
 const agentRuntimeContract = await readFile(new URL("docs/agent-runtime-contract.md", root), "utf8")

--- a/tests/runtime-profile-resolver.test.ts
+++ b/tests/runtime-profile-resolver.test.ts
@@ -4,11 +4,11 @@ import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
 const result = await runPhpJson<{
   default_error: { code: string; data: { errors: Array<{ code: string; profile: string }> } }
   input: {
-    runtime: { components: Array<{ slug: string }>; plugins: Array<{ slug: string }>; resolved_profile: { schema: string; summary: { profiles: number }; profiles: Array<{ id: string; aliases?: string[] }> } }
+    runtime: { components: Array<{ slug: string }>; plugins: Array<{ slug: string }>; resolved_profile: { schema: string; summary: { profiles: number }; capabilities: string[]; profiles: Array<{ id: string; aliases?: string[]; internal?: { provides?: string[] } }> } }
     runtime_profile: {
       schema: string
       capabilities: string[]
-      provider_plugins: Array<{ slug: string }>
+      provider_plugins?: Array<{ slug: string }>
       runtime_overlays: Array<{ id: string }>
       readiness: { status: string; checks: Record<string, boolean> }
       diagnostics: Array<{ code: string; status: string; severity: string; evidence: Record<string, unknown> }>
@@ -89,16 +89,15 @@ assert.deepEqual(result.input.runtime.components.map((component) => component.sl
 ])
 assert.equal(result.input.runtime_profile.schema, "wp-codebox/runtime-profile/v1")
 assert.deepEqual(result.input.runtime_profile.capabilities, [
-  "wordpress.playground",
+  "wordpress.sandbox",
   "browser.preview",
-  "agents-api",
-  "agents.runtime",
+  "codebox.agent-runtime",
   "content.runtime",
   "workspace.runtime",
   "provider.openai",
 ])
 assert.deepEqual(result.input.runtime.plugins.map((plugin) => plugin.slug), ["ai-provider-for-openai"])
-assert.deepEqual(result.input.runtime_profile.provider_plugins.map((plugin) => plugin.slug), ["ai-provider-for-openai"])
+assert.equal(result.input.runtime_profile.provider_plugins, undefined)
 assert.deepEqual(result.input.runtime_profile.runtime_overlays.map((overlay) => overlay.id), ["codex-runtime-overlay"])
 assert.equal(result.input.runtime_profile.readiness.status, "ready")
 assert.equal(result.input.runtime_profile.readiness.checks.dependencies, true)
@@ -108,7 +107,9 @@ assert.equal(result.input.runtime_profile.provenance.owner, "wp-codebox")
 assert.deepEqual(result.input.placement.required_capabilities, ["wordpress.playground", "browser.preview", "agents.runtime"])
 assert.equal(result.input.runtime.resolved_profile.schema, "wp-codebox/runtime-profile-resolution/v1")
 assert.equal(result.input.runtime.resolved_profile.summary.profiles, 5)
+assert.deepEqual(result.input.runtime.resolved_profile.capabilities, ["wordpress.playground", "browser.preview", "agents-api", "agents.runtime", "content.runtime", "workspace.runtime", "provider.openai"])
 assert.equal(result.input.runtime.resolved_profile.profiles.find((profile) => profile.id === "workspace-runtime")?.aliases?.[0], "coding-agent-runtime")
+assert.deepEqual(result.input.runtime.resolved_profile.profiles.find((profile) => profile.id === "agents-api")?.internal?.provides, ["agents-api", "agents.runtime"])
 assert.deepEqual(result.unresolved.runtime.components.map((component) => component.slug), ["repo-local-component"])
 
 console.log("runtime profile resolver ok")


### PR DESCRIPTION
## Summary
- Split runtime profile resolution into public caller-facing output and internal runtime materialization details
- Keep public runtime profile capabilities Codebox-safe while preserving internal diagnostics for execution/operator evidence
- Fix public package docs to avoid exposing upstream runtime implementation names

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
- npm run test:runtime-profile-resolver
- npm run test:production-boundary-enforcement
- npx --no-install tsx tests/docs-boundary-language.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing runtime profile public/internal separation, resolving rebase conflicts, and updating tests/docs
