### PR TITLE
Add stable run-agent-task CLI command

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "test:fixture-auth-storage-state": "tsx tests/fixture-auth-storage-state.test.ts",
     "test:recipe-user-session": "tsx tests/recipe-user-session.test.ts",
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
+    "test:command-router": "tsx tests/command-router.test.ts",
     "test:command-agent-run": "tsx tests/command-agent-run.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
     "test:php-host-run-result-normalizer": "php scripts/php-host-run-result-normalizer-smoke.php",

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -9,6 +9,7 @@ const cliCommandRoutes = {
   "materialize-replay-package": "materializeReplayPackage",
   "recipe-run": "recipeRun",
   "agent-task-run": "agentTaskRun",
+  "run-agent-task": "agentTaskRun",
   recipe: {
     validate: "recipeValidate",
     build: "recipeBuild",
@@ -116,7 +117,7 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
 }
 
 async function maybeRespawnWithJspi(command: string | undefined, args: string[]): Promise<number | undefined> {
-  if (!command || !["boot", "run", "recipe-run", "agent-task-run"].includes(command)) {
+  if (!command || !["boot", "run", "recipe-run", "agent-task-run", "run-agent-task"].includes(command)) {
     return undefined
   }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -313,6 +313,7 @@ export function printHelp(): void {
   wp-codebox runs artifacts --registry <dir> --run-id <id> [--json]
   wp-codebox runs cancel --registry <dir> --run-id <id> [--reason <text>] [--json]
   wp-codebox target provision [--id <id>] [--kind <kind>] [--workspace-root <dir>] [--json]
+  wp-codebox run-agent-task --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
   wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
   wp-codebox validate-blueprint --blueprint <json|file> [options]
   wp-codebox materialize-replay-package --snapshot <path> --output <dir> [--snapshot-ref <ref>] [--json]
@@ -324,11 +325,11 @@ Options:
   --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
   --options <path>    Recipe builder options JSON file for recipe build.
   --output <path>     Recipe build output JSON path, or materialize-replay-package output directory.
-  --input-file <path> Agent task input JSON for agent-task-run.
+  --input-file <path> Agent task input JSON for run-agent-task/agent-task-run.
   --preview-hold-seconds <n>
-                    Keep preview runtimes alive after agent-task-run/recipe-run.
+                    Keep preview runtimes alive after run-agent-task/agent-task-run/recipe-run.
   --preview-public-url <url>
-                    Public preview URL passed through to agent-task-run/recipe-run.
+                    Public preview URL passed through to run-agent-task/agent-task-run/recipe-run.
   --bundle <dir>      Artifact bundle directory for artifact verification/probe commands.
   --source <id>       Default source for artifacts diagnostics normalization.
   --stage <id>        Default stage for artifacts diagnostics normalization.

--- a/tests/command-router.test.ts
+++ b/tests/command-router.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import { routeCliCommand } from "../packages/cli/src/command-router.js"
+
+process.env.WP_CODEBOX_NO_JSPI_RESPAWN = "1"
+
+const calls: string[] = []
+const router = {
+  printHelp: () => calls.push("printHelp"),
+  boot: async () => 0,
+  validateBlueprint: async () => 0,
+  materializeReplayPackage: async () => 0,
+  recipeRun: async () => 0,
+  agentTaskRun: async (args: string[]) => {
+    calls.push(`agentTaskRun:${args.join(" ")}`)
+    return 7
+  },
+  recipeValidate: async () => 0,
+  recipeBuild: async () => 0,
+  workspacePolicyCheck: async () => 0,
+  artifactsVerify: async () => 0,
+  artifactsApplyPreflight: async () => 0,
+  artifactsBrowserMetrics: async () => 0,
+  artifactsDiagnostics: async () => 0,
+  artifactsTransferVerify: async () => 0,
+  artifactsTransferProbes: async () => 0,
+  artifactsExportLinks: async () => 0,
+  artifactsBenchmark: async () => 0,
+  artifactsDiscoverPartial: async () => 0,
+  artifactsBenchResults: async () => 0,
+  artifactsBenchCompare: async () => 0,
+  benchMatrix: async () => 0,
+  benchSummarize: async () => 0,
+  benchCompare: async () => 0,
+  runsStatus: async () => 0,
+  runsArtifacts: async () => 0,
+  runsCancel: async () => 0,
+  targetProvision: async () => 0,
+  mcpRenderClientConfigs: async () => 0,
+  commands: async () => 0,
+  recipeSchema: async () => 0,
+  doctor: async () => 0,
+  cleanup: async () => 0,
+  run: async () => 0,
+}
+
+const exitCode = await routeCliCommand(["run-agent-task", "--input-file", "task.json", "--json"], router)
+
+assert.equal(exitCode, 7)
+assert.deepEqual(calls, ["agentTaskRun:--input-file task.json --json"])
+
+console.log("command-router contract passed")


### PR DESCRIPTION
## Summary
- Add `run-agent-task` as a stable CLI command routed to the existing agent task runner.
- Include `run-agent-task` in the JSPI respawn command allowlist.
- Document the stable command in CLI help and add command-router coverage.

## Verification
- `npm run test:command-router`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the CLI alias, adding focused router coverage, and running verification.