### PR TITLE
Align PHP fanout aggregation contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "test:primitive-contract-parity": "tsx tests/primitive-contract-parity.test.ts",
     "test:php-primitive-contract-parity": "php scripts/php-primitive-contract-parity-smoke.php",
     "test:php-run-plan-contract": "php scripts/php-run-plan-contract-smoke.php",
+    "test:php-fanout-aggregation-contract": "php scripts/php-fanout-aggregation-contract-smoke.php",
     "test:php-agents-api-execution-targets": "php scripts/php-agents-api-execution-targets-smoke.php",
     "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -414,6 +414,7 @@ final class WP_Codebox_Abilities {
 									'events' => array( 'type' => 'string' ),
 								),
 							),
+							'aggregate'   => array( 'type' => 'object' ),
 							'orchestrator' => array( 'type' => 'object' ),
 							'runs'        => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
 							'failures'    => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -14,7 +14,6 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private const FANOUT_PLAN_SCHEMA = 'wp-codebox/agent-fanout-plan/v1';
 	private const FANOUT_EVENT_SCHEMA = 'wp-codebox/agent-fanout-event/v1';
 	private const FANOUT_SCHEMA = 'wp-codebox/agent-fanout-result/v1';
-	private const FANOUT_AGGREGATE_SCHEMA = 'wp-codebox/agent-fanout-aggregate/v1';
 	private const FANOUT_ARTIFACTS_SCHEMA = 'wp-codebox/agent-fanout-artifacts/v1';
 	private const DEFAULT_WORDPRESS_VERSION = 'latest';
 	private const FANOUT_MAX_CONCURRENCY = 8;
@@ -38,6 +37,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	private WP_Codebox_Run_Plan $run_plan;
 	private WP_Codebox_Agent_Process_Runner $process_runner;
 	private WP_Codebox_Agent_Outcome_Classifier $outcome_classifier;
+	private WP_Codebox_Fanout_Aggregation $fanout_aggregation;
 
 	/**
 	 * @param array<string, callable> $callbacks Test seams for pure-PHP smoke coverage.
@@ -54,6 +54,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$this->process_runner          = new WP_Codebox_Agent_Process_Runner( $callbacks );
 		$this->result_builder          = new WP_Codebox_Agent_Run_Result_Builder( $this->run_plan );
 		$this->outcome_classifier      = new WP_Codebox_Agent_Outcome_Classifier();
+		$this->fanout_aggregation      = new WP_Codebox_Fanout_Aggregation();
 	}
 
 	/**
@@ -100,7 +101,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		$parent_session_id = $this->sandbox_session_id( $input );
 		$paths = $this->run_plan_paths( $this->clean_path( (string) ( $input['artifacts_path'] ?? $this->default_artifacts_path() ) ) );
-		foreach ( array( $paths['workers'], $paths['aggregate_artifacts'] ) as $path ) {
+		foreach ( array( $paths['workers'], $paths['aggregate_artifacts'], dirname( $paths['aggregate_final_result'] ) ) as $path ) {
 			if ( ! $this->ensure_directory( $path ) ) {
 				return new WP_Error( 'wp_codebox_fanout_artifacts_unwritable', 'Could not create fanout artifact directories.', array( 'status' => 500, 'path' => $path ) );
 			}
@@ -145,10 +146,31 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$runs = array_values( $runs );
 
 		$counts = $this->result_builder->status_counts( $runs );
-		$success = $this->run_plan->succeeded( $counts );
-		$status  = $success ? 'completed' : 'failed';
 		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.started', 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'skipped' => $counts['skipped'], 'cancelled' => $counts['cancelled'], 'timed_out' => $counts['timed_out'] ) );
 
+		$aggregate = $this->fanout_aggregation->aggregate(
+			$this->fanout_aggregation->input_from_worker_artifacts(
+				array(
+					'plan'             => $this->fanout_aggregation_plan( $parent_session_id, $workers ),
+					'policy'           => is_array( $input['aggregation'] ?? null ) && is_string( $input['aggregation']['policy'] ?? null ) ? $input['aggregation']['policy'] : 'fail',
+					'aggregator'       => is_array( $input['aggregation'] ?? null ) ? $input['aggregation'] : null,
+					'workerResultRefs' => $this->fanout_worker_result_refs( $runs, $workers ),
+				)
+			),
+			array(
+				'finalArtifactRefs' => array(
+					array(
+						'path'        => 'aggregate/final/result.json',
+						'kind'        => 'fanout-aggregate-output',
+						'namespace'   => 'aggregate/final',
+						'contentType' => 'application/json',
+					),
+				),
+			)
+		);
+
+		$success = 'succeeded' === (string) $aggregate['status'];
+		$status  = $success ? 'completed' : 'failed';
 		$result = $this->result_builder->fanout_result(
 			self::FANOUT_SCHEMA,
 			self::FANOUT_ARTIFACTS_SCHEMA,
@@ -163,9 +185,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$plan,
 			$runs
 		);
+		$result['aggregate'] = $aggregate;
 
-		$this->write_json_file( $paths['aggregate_result'], $this->run_plan->aggregate_result( self::FANOUT_AGGREGATE_SCHEMA, $status, $counts ) );
-		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.completed', 'status' => $status ) );
+		$this->write_json_file( $paths['aggregate_result'], $aggregate );
+		$this->write_json_file( $paths['aggregate_final_result'], $aggregate );
+		$this->append_fanout_event( $paths['root'], array( 'event' => 'aggregation.completed', 'status' => (string) $aggregate['status'] ) );
 		$this->write_json_file( $paths['result'], $result );
 		$this->append_fanout_event( $paths['root'], array( 'event' => $success ? 'fanout.completed' : 'fanout.failed', 'status' => $status, 'completed' => $counts['completed'], 'failed' => $counts['failed'], 'skipped' => $counts['skipped'], 'cancelled' => $counts['cancelled'], 'timed_out' => $counts['timed_out'] ) );
 
@@ -352,6 +376,69 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$descriptors = array_map( static fn( array $worker ): array => $worker['_run_plan_descriptor'], $workers );
 
 		return $this->run_plan->plan( $schema, $session_id, $concurrency, is_array( $input['orchestrator'] ?? null ) ? $input['orchestrator'] : array(), $descriptors );
+	}
+
+	/** @param array<int,array<string,mixed>> $workers Workers. @return array<string,mixed> */
+	private function fanout_aggregation_plan( string $session_id, array $workers ): array {
+		return array(
+			'id'      => $session_id,
+			'workers' => array_map(
+				static function ( array $worker ): array {
+					$descriptor = is_array( $worker['_run_plan_descriptor'] ?? null ) ? $worker['_run_plan_descriptor'] : array();
+					return array(
+						'id'                => (string) $worker['id'],
+						'dependsOn'         => is_array( $descriptor['depends_on'] ?? null ) ? $descriptor['depends_on'] : array(),
+						'required'          => false !== ( $descriptor['required'] ?? true ),
+						'artifactNamespace' => (string) ( $descriptor['artifact_namespace'] ?? $worker['id'] ),
+					);
+				},
+				$workers
+			),
+		);
+	}
+
+	/** @param array<int,array<string,mixed>> $runs Runs. @param array<int,array<string,mixed>> $workers Workers. @return array<int,array<string,mixed>> */
+	private function fanout_worker_result_refs( array $runs, array $workers ): array {
+		$required_by_id = array();
+		foreach ( $workers as $worker ) {
+			$descriptor = is_array( $worker['_run_plan_descriptor'] ?? null ) ? $worker['_run_plan_descriptor'] : array();
+			$required_by_id[ (string) $worker['id'] ] = false !== ( $descriptor['required'] ?? true );
+		}
+
+		return array_map(
+			fn( array $run ): array => array(
+				'worker_id'     => (string) ( $run['worker_id'] ?? '' ),
+				'status'        => (string) ( $run['status'] ?? '' ),
+				'success'       => true === ( $run['success'] ?? false ),
+				'required'      => $required_by_id[ (string) ( $run['worker_id'] ?? '' ) ] ?? true,
+				'result_ref'    => 'fanout/workers/' . (string) ( $run['worker_id'] ?? '' ) . '/result.json',
+				'artifact_refs' => $this->fanout_worker_artifact_refs( $run ),
+				'error'         => is_array( $run['error'] ?? null ) ? $run['error'] : null,
+			),
+			$runs
+		);
+	}
+
+	/** @param array<string,mixed> $run Worker run. @return array<int,array<string,mixed>> */
+	private function fanout_worker_artifact_refs( array $run ): array {
+		if ( is_array( $run['artifact_refs'] ?? null ) ) {
+			return $run['artifact_refs'];
+		}
+
+		$worker_id = (string) ( $run['worker_id'] ?? '' );
+		$refs      = array();
+		$evidence  = is_array( $run['evidence_refs'] ?? null ) ? $run['evidence_refs'] : array();
+		foreach ( array( 'agent_task_result', 'completion_outcome', 'transcript' ) as $key ) {
+			if ( is_string( $evidence[ $key ] ?? null ) && '' !== $evidence[ $key ] ) {
+				$refs[] = array(
+					'path'     => 'fanout/workers/' . $worker_id . '/artifacts/' . $evidence[ $key ],
+					'kind'     => 'codebox-' . str_replace( '_', '-', $key ),
+					'workerId' => $worker_id,
+				);
+			}
+		}
+
+		return $refs;
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * Shared fanout aggregation contract helpers for PHP host fanout.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Fanout_Aggregation {
+
+	public const INPUT_SCHEMA  = 'wp-codebox/agent-fanout-aggregation-input/v1';
+	public const OUTPUT_SCHEMA = 'wp-codebox/agent-fanout-aggregation-output/v1';
+
+	/** @param array<string,mixed> $options Aggregation input options. @return array<string,mixed> */
+	public function input_from_worker_artifacts( array $options ): array {
+		return $this->normalize_input(
+			array(
+				'plan'               => $options['plan'] ?? array(),
+				'policy'             => $options['policy'] ?? 'fail',
+				'aggregator'         => $options['aggregator'] ?? null,
+				'workerResultRefs'   => $options['workerResultRefs'] ?? array(),
+				'artifactRefs'       => $options['workerArtifacts'] ?? array(),
+				'conflictCandidates' => $options['conflictCandidates'] ?? array(),
+				'metadata'           => $options['metadata'] ?? null,
+			)
+		);
+	}
+
+	/** @param array<string,mixed> $input Aggregation input. @return array<string,mixed> */
+	public function aggregate( array $input, array $options = array() ): array {
+		$normalized = $this->normalize_input( $input );
+		$conflicts  = array_merge(
+			$this->normalize_conflict_records( $normalized['conflictCandidates'] ?? array() ),
+			$this->duplicate_final_artifact_path_conflicts( $normalized['artifactRefs'] ?? array() ),
+			$this->worker_dependency_conflicts( $normalized['plan'] ?? array(), $normalized['workerResultRefs'] ?? array() )
+		);
+
+		if ( is_array( $options['aggregationError'] ?? null ) ) {
+			$error       = $options['aggregationError'];
+			$conflicts[] = array_filter(
+				array(
+					'type'     => 'aggregation-failure',
+					'severity' => 'error',
+					'message'  => (string) ( $error['message'] ?? 'Fanout aggregation failed.' ),
+					'details'  => array_filter(
+						array_merge(
+							array( 'code' => $error['code'] ?? null ),
+							is_array( $error['details'] ?? null ) ? $error['details'] : array()
+						),
+						static fn( mixed $value ): bool => null !== $value && '' !== $value
+					),
+				),
+				static fn( mixed $value ): bool => array() !== $value
+			);
+		}
+
+		$has_error = ! empty( array_filter( $conflicts, static fn( array $conflict ): bool => 'error' === (string) ( $conflict['severity'] ?? '' ) ) );
+
+		return array_filter(
+			array(
+				'schema'                => self::OUTPUT_SCHEMA,
+				'status'                => $this->resolve_status( (string) $normalized['policy'], $conflicts ),
+				'policy'                => (string) $normalized['policy'],
+				'plan'                  => $normalized['plan'],
+				'aggregator'            => $normalized['aggregator'] ?? null,
+				'workerResultRefs'      => $normalized['workerResultRefs'],
+				'rawWorkerArtifactRefs' => $normalized['artifactRefs'],
+				'finalArtifactRefs'     => $has_error ? array() : ( $options['finalArtifactRefs'] ?? $this->default_final_artifact_refs( $normalized, $options['outputNamespace'] ?? null ) ),
+				'conflicts'             => $conflicts,
+				'metadata'              => $options['metadata'] ?? $normalized['metadata'] ?? null,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Aggregation input. @return array<string,mixed> */
+	public function normalize_input( array $input ): array {
+		$worker_results      = $this->normalize_worker_result_refs( $input['workerResultRefs'] ?? $input['worker_results'] ?? $input['workerResults'] ?? array() );
+		$input_artifact_refs = $this->normalize_artifact_refs( $input['artifactRefs'] ?? $input['artifact_refs'] ?? array() );
+		$artifact_refs       = self::INPUT_SCHEMA === (string) ( $input['schema'] ?? '' ) ? $input_artifact_refs : array_merge( $input_artifact_refs, ...array_map( static fn( array $worker ): array => $worker['artifactRefs'] ?? array(), $worker_results ) );
+
+		return array_filter(
+			array(
+				'schema'             => self::INPUT_SCHEMA,
+				'plan'               => $this->normalize_plan( is_array( $input['plan'] ?? null ) ? $input['plan'] : array() ),
+				'policy'             => (string) ( $input['policy'] ?? 'fail' ),
+				'aggregator'         => is_array( $input['aggregator'] ?? null ) ? $input['aggregator'] : ( is_array( $input['aggregation'] ?? null ) ? $input['aggregation'] : null ),
+				'workerResultRefs'   => $worker_results,
+				'artifactRefs'       => $artifact_refs,
+				'conflictCandidates' => $this->normalize_conflict_records( $input['conflictCandidates'] ?? $input['conflict_candidates'] ?? array() ),
+				'metadata'           => is_array( $input['metadata'] ?? null ) ? $input['metadata'] : null,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Aggregation input. @return array<int,array<string,mixed>> */
+	public function default_final_artifact_refs( array $input, mixed $output_namespace = null ): array {
+		return array(
+			array(
+				'path'        => $this->default_output_path( $input, $output_namespace ),
+				'kind'        => 'fanout-aggregate-output',
+				'contentType' => 'application/json',
+			),
+		);
+	}
+
+	/** @param array<string,mixed> $input Aggregation input. */
+	public function default_output_path( array $input, mixed $output_namespace = null ): string {
+		$normalized = $this->normalize_input( $input );
+		$aggregator = is_array( $normalized['aggregator'] ?? null ) ? $normalized['aggregator'] : array();
+		return $this->normalize_output_namespace( $output_namespace ?? $aggregator['outputNamespace'] ?? null ) . '/result.json';
+	}
+
+	/** @param array<int,array<string,mixed>> $conflicts Conflicts. */
+	private function resolve_status( string $policy, array $conflicts ): string {
+		$has_error = ! empty( array_filter( $conflicts, static fn( array $conflict ): bool => 'error' === (string) ( $conflict['severity'] ?? '' ) ) );
+		if ( ! $has_error ) {
+			return 'succeeded';
+		}
+		if ( 'partial' === $policy ) {
+			return 'partial';
+		}
+		if ( 'repair' === $policy ) {
+			return 'repair_required';
+		}
+		if ( 'caller-review-required' === $policy ) {
+			return 'caller_review_required';
+		}
+		return 'failed';
+	}
+
+	/** @param array<string,mixed> $plan Plan. @return array<string,mixed> */
+	private function normalize_plan( array $plan ): array {
+		$workers = is_array( $plan['workers'] ?? null ) ? array_map( fn( mixed $worker ): array => $this->normalize_worker_plan( is_array( $worker ) ? $worker : array() ), $plan['workers'] ) : array();
+		$plan['id'] = is_string( $plan['id'] ?? null ) && '' !== $plan['id'] ? $plan['id'] : null;
+		$plan['workers'] = $workers;
+		$plan['metadata'] = is_array( $plan['metadata'] ?? null ) ? $plan['metadata'] : null;
+
+		return array_filter( $plan, static fn( mixed $value ): bool => null !== $value );
+	}
+
+	/** @param array<string,mixed> $worker Worker plan. @return array<string,mixed> */
+	private function normalize_worker_plan( array $worker ): array {
+		$depends_on = $worker['dependsOn'] ?? $worker['depends_on'] ?? array();
+		$worker['id'] = is_string( $worker['id'] ?? null ) ? $worker['id'] : '';
+		$worker['dependsOn'] = is_array( $depends_on ) ? array_values( array_filter( $depends_on, 'is_string' ) ) : array();
+		$worker['required'] = false !== ( $worker['required'] ?? true );
+		$worker['artifactNamespace'] = is_string( $worker['artifactNamespace'] ?? null ) ? $worker['artifactNamespace'] : ( is_string( $worker['artifact_namespace'] ?? null ) ? $worker['artifact_namespace'] : null );
+		$worker['metadata'] = is_array( $worker['metadata'] ?? null ) ? $worker['metadata'] : null;
+
+		return array_filter( $worker, static fn( mixed $value ): bool => null !== $value );
+	}
+
+	/** @param mixed $worker_results Worker results. @return array<int,array<string,mixed>> */
+	private function normalize_worker_result_refs( mixed $worker_results ): array {
+		if ( ! is_array( $worker_results ) ) {
+			return array();
+		}
+
+		return array_map( fn( mixed $worker ): array => $this->normalize_worker_result_ref( is_array( $worker ) ? $worker : array() ), $worker_results );
+	}
+
+	/** @param array<string,mixed> $worker Worker result. @return array<string,mixed> */
+	private function normalize_worker_result_ref( array $worker ): array {
+		$worker_id = is_string( $worker['workerId'] ?? null ) && '' !== $worker['workerId'] ? $worker['workerId'] : ( is_string( $worker['worker_id'] ?? null ) ? $worker['worker_id'] : '' );
+		$artifacts = $worker['artifactRefs'] ?? $worker['artifact_refs'] ?? array();
+
+		return array_filter(
+			array(
+				'workerId'     => $worker_id,
+				'status'       => WP_Codebox_Status_Taxonomy::agent_task_status( array( 'status' => $worker['status'] ?? '', 'success' => $worker['success'] ?? null ) ),
+				'required'     => false !== ( $worker['required'] ?? true ),
+				'resultRef'    => is_string( $worker['resultRef'] ?? null ) ? $worker['resultRef'] : ( is_string( $worker['result_ref'] ?? null ) ? $worker['result_ref'] : null ),
+				'artifactRefs' => $this->normalize_artifact_refs( $artifacts, $worker_id ),
+				'error'        => $this->normalize_error( $worker['error'] ?? null ),
+				'metadata'     => is_array( $worker['metadata'] ?? null ) ? $worker['metadata'] : null,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	/** @param mixed $artifacts Artifact refs. @return array<int,array<string,mixed>> */
+	private function normalize_artifact_refs( mixed $artifacts, mixed $fallback_worker_id = null ): array {
+		if ( ! is_array( $artifacts ) ) {
+			return array();
+		}
+
+		return array_map( fn( mixed $artifact ): array => $this->normalize_artifact_ref( is_array( $artifact ) ? $artifact : array(), $fallback_worker_id ), $artifacts );
+	}
+
+	/** @param array<string,mixed> $artifact Artifact ref. @return array<string,mixed> */
+	private function normalize_artifact_ref( array $artifact, mixed $fallback_worker_id = null ): array {
+		return array_filter(
+			array(
+				'id'          => is_string( $artifact['id'] ?? null ) ? $artifact['id'] : null,
+				'path'        => is_string( $artifact['path'] ?? null ) ? $artifact['path'] : '',
+				'kind'        => is_string( $artifact['kind'] ?? null ) ? $artifact['kind'] : null,
+				'workerId'    => is_string( $artifact['workerId'] ?? null ) ? $artifact['workerId'] : ( is_string( $artifact['worker_id'] ?? null ) ? $artifact['worker_id'] : ( is_string( $fallback_worker_id ) ? $fallback_worker_id : null ) ),
+				'namespace'   => is_string( $artifact['namespace'] ?? null ) ? $artifact['namespace'] : null,
+				'finalPath'   => is_string( $artifact['finalPath'] ?? null ) ? $artifact['finalPath'] : ( is_string( $artifact['final_path'] ?? null ) ? $artifact['final_path'] : null ),
+				'contentType' => is_string( $artifact['contentType'] ?? null ) ? $artifact['contentType'] : ( is_string( $artifact['content_type'] ?? null ) ? $artifact['content_type'] : null ),
+				'sha256'      => is_string( $artifact['sha256'] ?? null ) ? $artifact['sha256'] : null,
+				'bytes'       => is_int( $artifact['bytes'] ?? null ) || is_float( $artifact['bytes'] ?? null ) ? $artifact['bytes'] : null,
+				'metadata'    => is_array( $artifact['metadata'] ?? null ) ? $artifact['metadata'] : null,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	/** @param mixed $conflicts Conflict records. @return array<int,array<string,mixed>> */
+	private function normalize_conflict_records( mixed $conflicts ): array {
+		if ( ! is_array( $conflicts ) ) {
+			return array();
+		}
+
+		return array_map( fn( mixed $conflict ): array => $this->normalize_conflict_record( is_array( $conflict ) ? $conflict : array() ), $conflicts );
+	}
+
+	/** @param array<string,mixed> $conflict Conflict record. @return array<string,mixed> */
+	private function normalize_conflict_record( array $conflict ): array {
+		$worker_ids = $conflict['workerIds'] ?? $conflict['worker_ids'] ?? null;
+		$artifacts  = $conflict['artifactRefs'] ?? $conflict['artifact_refs'] ?? null;
+
+		return array_filter(
+			array(
+				'type'         => is_string( $conflict['type'] ?? null ) ? $conflict['type'] : 'partial-output',
+				'severity'     => is_string( $conflict['severity'] ?? null ) ? $conflict['severity'] : 'error',
+				'message'      => is_string( $conflict['message'] ?? null ) ? $conflict['message'] : 'Fanout aggregation conflict candidate.',
+				'workerIds'    => is_array( $worker_ids ) ? array_values( array_filter( $worker_ids, 'is_string' ) ) : null,
+				'path'         => is_string( $conflict['path'] ?? null ) ? $conflict['path'] : null,
+				'artifactRefs' => is_array( $artifacts ) ? $this->normalize_artifact_refs( $artifacts ) : null,
+				'dependencyId' => is_string( $conflict['dependencyId'] ?? null ) ? $conflict['dependencyId'] : ( is_string( $conflict['dependency_id'] ?? null ) ? $conflict['dependency_id'] : null ),
+				'details'      => is_array( $conflict['details'] ?? null ) ? $conflict['details'] : null,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	/** @param array<int,array<string,mixed>> $artifact_refs Artifact refs. @return array<int,array<string,mixed>> */
+	private function duplicate_final_artifact_path_conflicts( array $artifact_refs ): array {
+		$by_path = array();
+		foreach ( $artifact_refs as $artifact ) {
+			$final_path = (string) ( $artifact['finalPath'] ?? '' );
+			if ( '' === $final_path ) {
+				continue;
+			}
+			$by_path[ $final_path ][] = $artifact;
+		}
+
+		$conflicts = array();
+		foreach ( $by_path as $path => $refs ) {
+			if ( count( $refs ) < 2 ) {
+				continue;
+			}
+			$conflicts[] = array(
+				'type'         => 'duplicate-final-artifact-path',
+				'severity'     => 'error',
+				'message'      => 'Multiple fanout worker artifacts target final path ' . $path . '.',
+				'path'         => $path,
+				'workerIds'    => array_values( array_unique( array_filter( array_map( static fn( array $ref ): string => (string) ( $ref['workerId'] ?? '' ), $refs ) ) ) ),
+				'artifactRefs' => $refs,
+			);
+		}
+
+		return $conflicts;
+	}
+
+	/** @param array<string,mixed> $plan Plan. @param array<int,array<string,mixed>> $worker_results Worker results. @return array<int,array<string,mixed>> */
+	private function worker_dependency_conflicts( array $plan, array $worker_results ): array {
+		$conflicts = array();
+		$by_worker = array();
+		foreach ( $worker_results as $result ) {
+			$by_worker[ (string) ( $result['workerId'] ?? '' ) ] = $result;
+			if ( false !== ( $result['required'] ?? true ) && 'succeeded' !== (string) ( $result['status'] ?? '' ) ) {
+				$conflicts[] = array_filter(
+					array(
+						'type'         => 'failed-worker',
+						'severity'     => 'error',
+						'message'      => 'Required fanout worker ' . (string) ( $result['workerId'] ?? '' ) . ' ended with status ' . (string) ( $result['status'] ?? '' ) . '.',
+						'workerIds'    => array( (string) ( $result['workerId'] ?? '' ) ),
+						'artifactRefs' => $result['artifactRefs'] ?? array(),
+						'details'      => is_array( $result['error'] ?? null ) ? array( 'error' => $result['error'] ) : null,
+					),
+					static fn( mixed $value ): bool => null !== $value
+				);
+			}
+		}
+
+		foreach ( $plan['workers'] ?? array() as $worker ) {
+			foreach ( $worker['dependsOn'] ?? array() as $dependency_id ) {
+				if ( ! isset( $by_worker[ $dependency_id ] ) ) {
+					$conflicts[] = array(
+						'type'         => 'missing-worker-dependency',
+						'severity'     => 'error',
+						'message'      => 'Fanout worker ' . (string) ( $worker['id'] ?? '' ) . ' depends on missing worker ' . $dependency_id . '.',
+						'workerIds'    => array( (string) ( $worker['id'] ?? '' ) ),
+						'dependencyId' => $dependency_id,
+					);
+					continue;
+				}
+
+				$dependency = $by_worker[ $dependency_id ];
+				if ( 'succeeded' !== (string) ( $dependency['status'] ?? '' ) ) {
+					$conflicts[] = array(
+						'type'         => 'failed-worker-dependency',
+						'severity'     => 'error',
+						'message'      => 'Fanout worker ' . (string) ( $worker['id'] ?? '' ) . ' depends on ' . $dependency_id . ', which ended with status ' . (string) ( $dependency['status'] ?? '' ) . '.',
+						'workerIds'    => array( (string) ( $worker['id'] ?? '' ), $dependency_id ),
+						'dependencyId' => $dependency_id,
+						'artifactRefs' => $dependency['artifactRefs'] ?? array(),
+					);
+				}
+			}
+		}
+
+		return $conflicts;
+	}
+
+	private function normalize_error( mixed $error ): ?array {
+		if ( ! is_array( $error ) ) {
+			return null;
+		}
+
+		return array_filter(
+			array(
+				'code'    => is_string( $error['code'] ?? null ) ? $error['code'] : null,
+				'message' => is_string( $error['message'] ?? null ) ? $error['message'] : 'Fanout worker failed.',
+				'details' => is_array( $error['details'] ?? null ) ? $error['details'] : null,
+			),
+			static fn( mixed $value ): bool => null !== $value
+		);
+	}
+
+	private function normalize_output_namespace( mixed $output_namespace ): string {
+		$raw      = is_string( $output_namespace ) && '' !== $output_namespace ? $output_namespace : 'aggregate/final';
+		$segments = array_filter(
+			array_map(
+				static fn( string $segment ): string => trim( preg_replace( '/[^a-zA-Z0-9._-]+/', '-', $segment ) ?? '', '-' ),
+				explode( '/', $raw )
+			),
+			static fn( string $segment ): bool => '' !== $segment
+		);
+
+		return empty( $segments ) ? 'aggregate/final' : implode( '/', $segments );
+	}
+}

--- a/packages/wordpress-plugin/src/class-wp-codebox-run-plan.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-run-plan.php
@@ -190,14 +190,16 @@ final class WP_Codebox_Run_Plan {
 		$aggregate = $root . DIRECTORY_SEPARATOR . 'aggregate';
 
 		return array(
-			'root'                => $root,
-			'workers'             => $workers,
-			'aggregate'           => $aggregate,
-			'aggregate_artifacts' => $aggregate . DIRECTORY_SEPARATOR . 'artifacts',
-			'plan'                => $root . DIRECTORY_SEPARATOR . 'plan.json',
-			'events'              => $root . DIRECTORY_SEPARATOR . 'events.jsonl',
-			'result'              => $root . DIRECTORY_SEPARATOR . 'result.json',
-			'aggregate_result'    => $aggregate . DIRECTORY_SEPARATOR . 'result.json',
+			'root'                   => $root,
+			'workers'                => $workers,
+			'aggregate'              => $aggregate,
+			'aggregate_artifacts'    => $aggregate . DIRECTORY_SEPARATOR . 'artifacts',
+			'aggregate_final'        => dirname( $root ) . DIRECTORY_SEPARATOR . 'aggregate' . DIRECTORY_SEPARATOR . 'final',
+			'plan'                   => $root . DIRECTORY_SEPARATOR . 'plan.json',
+			'events'                 => $root . DIRECTORY_SEPARATOR . 'events.jsonl',
+			'result'                 => $root . DIRECTORY_SEPARATOR . 'result.json',
+			'aggregate_result'       => $aggregate . DIRECTORY_SEPARATOR . 'result.json',
+			'aggregate_final_result' => dirname( $root ) . DIRECTORY_SEPARATOR . 'aggregate' . DIRECTORY_SEPARATOR . 'final' . DIRECTORY_SEPARATOR . 'result.json',
 		);
 	}
 

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -46,6 +46,7 @@ require_once __DIR__ . '/src/class-wp-codebox-runner-workspace-adapter.php';
 require_once __DIR__ . '/src/class-wp-codebox-parent-site-seed-exporter.php';
 require_once __DIR__ . '/src/class-wp-codebox-json.php';
 require_once __DIR__ . '/src/class-wp-codebox-run-plan.php';
+require_once __DIR__ . '/src/class-wp-codebox-fanout-aggregation.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-process-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-run-result-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-outcome-classifier.php';

--- a/scripts/php-fanout-aggregation-contract-smoke.php
+++ b/scripts/php-fanout-aggregation-contract-smoke.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+require_once dirname( __DIR__ ) . '/packages/wordpress-plugin/src/class-wp-codebox-status-taxonomy.php';
+require_once dirname( __DIR__ ) . '/packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php';
+
+function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $label . " failed.\nExpected: " . json_encode( $expected, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\nActual: " . json_encode( $actual, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n" );
+		exit( 1 );
+	}
+}
+
+$fixture = json_decode( file_get_contents( dirname( __DIR__ ) . '/tests/fixtures/fanout-aggregation-contract.json' ) ?: '', true );
+if ( ! is_array( $fixture ) ) {
+	fwrite( STDERR, "Could not read fanout aggregation contract fixture.\n" );
+	exit( 1 );
+}
+
+$aggregation = new WP_Codebox_Fanout_Aggregation();
+$output      = $aggregation->aggregate( $fixture['input'] );
+assert_same_contract( $fixture['expectedOutput'], $output, 'PHP fanout aggregation output' );
+
+$duplicate_output = $aggregation->aggregate(
+	array(
+		'plan'           => array(
+			'id'      => 'duplicate-final-path',
+			'workers' => array(
+				array( 'id' => 'one' ),
+				array( 'id' => 'two' ),
+			),
+		),
+		'policy'         => 'partial',
+		'worker_results' => array(
+			array( 'worker_id' => 'one', 'status' => 'succeeded', 'artifact_refs' => array( array( 'path' => 'one.json', 'final_path' => 'same.json' ) ) ),
+			array( 'worker_id' => 'two', 'status' => 'succeeded', 'artifact_refs' => array( array( 'path' => 'two.json', 'final_path' => 'same.json' ) ) ),
+		),
+	)
+);
+assert_same_contract( 'partial', $duplicate_output['status'], 'partial policy conflict status' );
+assert_same_contract( 'duplicate-final-artifact-path', $duplicate_output['conflicts'][0]['type'], 'duplicate final-path conflict' );
+assert_same_contract( array(), $duplicate_output['finalArtifactRefs'], 'conflicted aggregation final refs' );
+
+echo "PHP fanout aggregation contract smoke passed\n";


### PR DESCRIPTION
## Summary
- Add a PHP fanout aggregation helper that normalizes and emits the shared `wp-codebox/agent-fanout-aggregation-output/v1` schema.
- Wire host-side fanout to include the canonical aggregate in the returned result and write it to both `fanout/aggregate/result.json` and `aggregate/final/result.json`.
- Add PHP smoke coverage against the existing canonical TS fanout aggregation fixture.

## Verification
- `php -l packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php && php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php && php -l packages/wordpress-plugin/src/class-wp-codebox-run-plan.php`
- `npm run test:php-fanout-aggregation-contract`
- `npm run test:php-run-plan-contract`
- `npm run test:fanout-aggregation-contract-parity`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the TS/runtime-core contract, implementing PHP contract parity, adding focused smoke coverage, and running lightweight verification.