### PR TITLE
Make agent workload normalization pluggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "smoke": "tsx scripts/run-smoke.ts",
     "test:redaction": "tsx tests/redaction.test.ts",
     "test:agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",
+    "test:agent-runtime-workload-normalizers": "tsx tests/agent-runtime-workload-normalizers.test.ts",
     "test:browser-task-builder": "tsx tests/browser-task-builder.test.ts",
     "test:browser-contained-site-status": "tsx tests/browser-contained-site-status.test.ts",
     "test:host-recipe-builder": "tsx tests/host-recipe-builder.test.ts",

--- a/packages/runtime-core/src/agent-runtime-workload.ts
+++ b/packages/runtime-core/src/agent-runtime-workload.ts
@@ -101,16 +101,30 @@ export interface AgentRuntimeWorkloadOptions {
   requiredOutputs?: Record<string, string> | string[]
   toolRecorders?: unknown
   workloadId?: string
+  normalizerAdapters?: AgentRuntimeWorkloadNormalizerAdapter[]
+  /** @deprecated Pass `legacyAgentRuntimeWorkloadNormalizerAdapters` as `normalizerAdapters` instead. */
   compatMode?: boolean
 }
 
-type WorkloadDraft = Omit<AgentRuntimeWorkload, "schema" | "success"> & { success?: boolean }
+export type AgentRuntimeWorkloadDraft = Omit<AgentRuntimeWorkload, "schema" | "success"> & { success?: boolean }
+
+export interface AgentRuntimeWorkloadNormalizerContext {
+  options: AgentRuntimeWorkloadOptions
+  normalizeRaw(raw: unknown): AgentRuntimeWorkloadDraft | undefined
+}
+
+export interface AgentRuntimeWorkloadNormalizerAdapter {
+  name: string
+  normalize(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): AgentRuntimeWorkloadDraft | undefined
+}
+
+type WorkloadDraft = AgentRuntimeWorkloadDraft
 
 export function normalizeAgentRuntimeWorkload(raw: unknown, options: AgentRuntimeWorkloadOptions = {}): AgentRuntimeWorkload {
   const canonicalWorkload = canonicalWorkloadFromRaw(raw, options)
-  const compatMode = options.compatMode === true
   const compatibilityDiagnostics: AgentRuntimeWorkloadDiagnostic[] = []
-  const workload = canonicalWorkload ?? (compatMode ? workloadFromRawCompat(raw, options, compatibilityDiagnostics) : undefined) ?? emptyWorkload(options)
+  const adapters = workloadNormalizerAdapters(options)
+  const workload = canonicalWorkload ?? workloadFromNormalizerAdapters(raw, options, adapters, compatibilityDiagnostics) ?? emptyWorkload(options)
   const toolRecorderOutputs = outputsFromToolRecorders(workload, options.toolRecorders)
   const outputs = { ...workload.outputs, ...toolRecorderOutputs }
   const diagnostics = [...workload.diagnostics, ...compatibilityDiagnostics, ...diagnosticsFromWorkload({ ...workload, outputs }, options)]
@@ -131,67 +145,133 @@ export function normalizeAgentRuntimeWorkload(raw: unknown, options: AgentRuntim
   }
 }
 
-function canonicalWorkloadFromRaw(raw: unknown, options: AgentRuntimeWorkloadOptions): WorkloadDraft | undefined {
-  const parsed = parseJsonEnvelope(raw)
-  const record = objectValue(parsed)
-  if (!record) return undefined
+export const legacyAgentRuntimeWorkloadNormalizerAdapters: AgentRuntimeWorkloadNormalizerAdapter[] = [
+  { name: "runtime-workload-explicit-envelope", normalize: normalizeExplicitEnvelopeField },
+  { name: "runtime-workload-stdout-json", normalize: normalizeStdoutJsonEnvelope },
+  { name: "runtime-workload-nested-canonical", normalize: normalizeNestedCanonicalEnvelope },
+  { name: "runtime-workload-agent-bundle-run", normalize: normalizeLegacyAgentBundleRun },
+  { name: "runtime-workload-scenario-shape", normalize: normalizeScenarioShape },
+  { name: "runtime-workload-single-result-shape", normalize: normalizeSingleResultShape },
+  { name: "runtime-workload-recipe-run-nested-agent-task-result", normalize: normalizeRecipeRunNestedAgentTaskResult },
+  { name: "runtime-workload-execution-stdout", normalize: normalizeExecutionStdout },
+  { name: "runtime-workload-metadata-shape", normalize: normalizeMetadataShape },
+]
 
-  return parseAgentRuntimeWorkloadEnvelope(record, options) ?? workloadFromExplicitEnvelopeField(record, options)
+function canonicalWorkloadFromRaw(raw: unknown, options: AgentRuntimeWorkloadOptions): WorkloadDraft | undefined {
+  return parseAgentRuntimeWorkloadEnvelope(raw, options)
 }
 
-function workloadFromRawCompat(raw: unknown, options: AgentRuntimeWorkloadOptions, diagnostics: AgentRuntimeWorkloadDiagnostic[]): WorkloadDraft | undefined {
-  const parsed = parseJsonEnvelope(raw)
-  const record = objectValue(parsed)
-  if (!record) return undefined
+function workloadNormalizerAdapters(options: AgentRuntimeWorkloadOptions): AgentRuntimeWorkloadNormalizerAdapter[] {
+  return Array.isArray(options.normalizerAdapters)
+    ? options.normalizerAdapters
+    : options.compatMode === true
+      ? legacyAgentRuntimeWorkloadNormalizerAdapters
+      : []
+}
 
-  const canonical = parseAgentRuntimeWorkloadEnvelope(record, options)
-  if (canonical) return canonical
+function workloadFromNormalizerAdapters(raw: unknown, options: AgentRuntimeWorkloadOptions, adapters: AgentRuntimeWorkloadNormalizerAdapter[], diagnostics: AgentRuntimeWorkloadDiagnostic[]): WorkloadDraft | undefined {
+  if (adapters.length === 0) return undefined
 
-  const explicitEnvelope = workloadFromExplicitEnvelopeField(record, options)
-  if (explicitEnvelope) return withCompatibilityDiagnostic(explicitEnvelope, diagnostics, "runtime-workload-explicit-envelope")
-
-  const stdout = stringValue(record.stdout)
-  if (stdout) {
-    const stdoutWorkload = workloadFromRawCompat(stdout, options, diagnostics)
-    if (stdoutWorkload && hasSemanticWorkload(stdoutWorkload)) return withCompatibilityDiagnostic(stdoutWorkload, diagnostics, "runtime-workload-stdout-json")
+  const context: AgentRuntimeWorkloadNormalizerContext = {
+    options,
+    normalizeRaw: (candidate) => canonicalWorkloadFromRaw(candidate, options) ?? workloadFromNormalizerAdapters(candidate, options, adapters, diagnostics),
   }
 
-  const direct = objectValue(record.agent_runtime)?.result ?? record.result ?? record
-  const candidate = parseJsonEnvelope(direct)
-  const candidateRecord = objectValue(candidate)
-  if (!candidateRecord) return undefined
-
-  const canonicalCandidate = parseAgentRuntimeWorkloadEnvelope(candidateRecord, options)
-  if (canonicalCandidate) return withCompatibilityDiagnostic(canonicalCandidate, diagnostics, "runtime-workload-nested-canonical")
-
-  if (isLegacyAgentBundleRun(candidateRecord)) return withCompatibilityDiagnostic(workloadFromLegacyAgentBundleRun(candidateRecord, options), diagnostics, "runtime-workload-agent-bundle-run")
-  if (Array.isArray(candidateRecord.scenarios)) return withCompatibilityDiagnostic(workloadFromScenarioWorkload(candidateRecord, options), diagnostics, "runtime-workload-scenario-shape")
-  if (isSingleResultWorkload(candidateRecord)) return withCompatibilityDiagnostic(workloadFromSingleResult(candidateRecord, options), diagnostics, "runtime-workload-single-result-shape")
-
-  const recipeRun = objectValue(candidateRecord.run)
-  const agentTaskResult = objectValue(candidateRecord.agentTaskResult) ?? objectValue(recipeRun?.agentTaskResult) ?? objectValue(candidateRecord.agent_task_result)
-  const nestedRuntime = objectValue(agentTaskResult?.raw)?.agent_runtime
-  const nestedRuntimeRecord = objectValue(nestedRuntime)
-  if (nestedRuntimeRecord?.result) return workloadFromRawCompat({ agent_runtime: nestedRuntimeRecord }, options, diagnostics)
-
-  const executionWorkload = workloadFromExecutions(candidateRecord, options, diagnostics)
-  if (executionWorkload) return withCompatibilityDiagnostic(executionWorkload, diagnostics, "runtime-workload-execution-stdout")
-
-  if (candidateRecord.metadata || candidateRecord.metrics) {
-    return withCompatibilityDiagnostic({
-      outputs: {},
-      scenarios: [scenarioFromRecord(candidateRecord, options)],
-      diagnostics: diagnosticsFromRaw(candidateRecord.diagnostics),
-      artifacts: artifactsFromRaw(candidateRecord.artifacts),
-      metadata: objectValue(candidateRecord.metadata) ?? {},
-    }, diagnostics, "runtime-workload-metadata-shape")
+  for (const adapter of adapters) {
+    const workload = adapter.normalize(raw, context)
+    if (hasSemanticWorkload(workload)) return withCompatibilityDiagnostic(workload, diagnostics, adapter.name)
   }
 
   return undefined
 }
 
-function parseAgentRuntimeWorkloadEnvelope(raw: unknown, options: AgentRuntimeWorkloadOptions): WorkloadDraft | undefined {
+function normalizeExplicitEnvelopeField(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const parsed = parseJsonEnvelope(raw)
+  const record = objectValue(parsed)
+  if (!record) return undefined
+
+  return workloadFromExplicitEnvelopeField(record, context.options)
+}
+
+function normalizeStdoutJsonEnvelope(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
   const record = objectValue(parseJsonEnvelope(raw))
+  if (!record) return undefined
+  const stdout = stringValue(record.stdout)
+  if (stdout) {
+    return context.normalizeRaw(stdout)
+  }
+  return undefined
+}
+
+function normalizeNestedCanonicalEnvelope(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const record = objectValue(parseJsonEnvelope(raw))
+  if (!record) return undefined
+  const direct = objectValue(record.agent_runtime)?.result ?? record.result ?? record
+  const candidate = parseJsonEnvelope(direct)
+  const candidateRecord = objectValue(candidate)
+  if (!candidateRecord) return undefined
+
+  return parseAgentRuntimeWorkloadEnvelope(candidateRecord, context.options)
+}
+
+function normalizeLegacyAgentBundleRun(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const record = candidateRecordFromRaw(raw)
+  return record && isLegacyAgentBundleRun(record) ? workloadFromLegacyAgentBundleRun(record, context.options) : undefined
+}
+
+function normalizeScenarioShape(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const record = candidateRecordFromRaw(raw)
+  return record && Array.isArray(record.scenarios) ? workloadFromScenarioWorkload(record, context.options) : undefined
+}
+
+function normalizeSingleResultShape(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const record = candidateRecordFromRaw(raw)
+  return record && isSingleResultWorkload(record) ? workloadFromSingleResult(record, context.options) : undefined
+}
+
+function normalizeRecipeRunNestedAgentTaskResult(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const candidateRecord = candidateRecordFromRaw(raw)
+  if (!candidateRecord) return undefined
+
+  const recipeRun = objectValue(candidateRecord.run)
+  const agentTaskResult = objectValue(candidateRecord.agentTaskResult) ?? objectValue(recipeRun?.agentTaskResult) ?? objectValue(candidateRecord.agent_task_result)
+  const nestedRuntime = objectValue(agentTaskResult?.raw)?.agent_runtime
+  const nestedRuntimeRecord = objectValue(nestedRuntime)
+  if (nestedRuntimeRecord?.result) return context.normalizeRaw({ agent_runtime: nestedRuntimeRecord })
+  return undefined
+}
+
+function normalizeExecutionStdout(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const candidateRecord = candidateRecordFromRaw(raw)
+  return candidateRecord ? workloadFromExecutions(candidateRecord, context) : undefined
+}
+
+function normalizeMetadataShape(raw: unknown, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
+  const candidateRecord = candidateRecordFromRaw(raw)
+  if (!candidateRecord) return undefined
+  if (candidateRecord.metadata || candidateRecord.metrics) {
+    return {
+      outputs: {},
+      scenarios: [scenarioFromRecord(candidateRecord, context.options)],
+      diagnostics: diagnosticsFromRaw(candidateRecord.diagnostics),
+      artifacts: artifactsFromRaw(candidateRecord.artifacts),
+      metadata: objectValue(candidateRecord.metadata) ?? {},
+    }
+  }
+
+  return undefined
+}
+
+function candidateRecordFromRaw(raw: unknown): Record<string, unknown> | undefined {
+  const record = objectValue(parseJsonEnvelope(raw))
+  if (!record) return undefined
+
+  const direct = objectValue(record.agent_runtime)?.result ?? record.result ?? record
+  return objectValue(parseJsonEnvelope(direct))
+}
+
+function parseAgentRuntimeWorkloadEnvelope(raw: unknown, options: AgentRuntimeWorkloadOptions): WorkloadDraft | undefined {
+  const record = objectValue(parseStrictJsonEnvelope(raw))
   if (!record || stringValue(record.schema) !== AGENT_RUNTIME_WORKLOAD_SCHEMA) return undefined
 
   const scenarios = arrayObjects(record.scenarios).map((scenario) => normalizeScenario(scenario, options))
@@ -223,12 +303,12 @@ function workloadFromExplicitEnvelopeField(record: Record<string, unknown>, opti
   return undefined
 }
 
-function workloadFromExecutions(record: Record<string, unknown>, options: AgentRuntimeWorkloadOptions, diagnostics: AgentRuntimeWorkloadDiagnostic[]): WorkloadDraft | undefined {
+function workloadFromExecutions(record: Record<string, unknown>, context: AgentRuntimeWorkloadNormalizerContext): WorkloadDraft | undefined {
   const executions = arrayObjects(record.executions).length > 0 ? arrayObjects(record.executions) : arrayObjects(objectValue(record.run)?.executions)
   for (const execution of executions) {
     const stdout = stringValue(execution.stdout)
     if (!stdout) continue
-    const workload = workloadFromRawCompat(stdout, options, diagnostics)
+    const workload = context.normalizeRaw(stdout)
     if (hasSemanticWorkload(workload)) return workload
   }
   return undefined
@@ -471,6 +551,23 @@ function parseJsonEnvelope(value: unknown): unknown {
   return typeof wrapperOutput === "string" ? parseJson(wrapperOutput) ?? parsed : parsed
 }
 
+function parseStrictJsonEnvelope(value: unknown): unknown {
+  if (typeof value !== "string") return value
+  const parsed = parseStrictJson(value)
+  const wrapperOutput = objectValue(parsed)?.output
+  return typeof wrapperOutput === "string" ? parseStrictJson(wrapperOutput) ?? parsed : parsed
+}
+
+function parseStrictJson(value: string): unknown {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return undefined
+  }
+}
+
 function parseJson(value: string): unknown {
   const trimmed = value.trim()
   if (!trimmed) return undefined
@@ -496,7 +593,7 @@ function isSingleResultWorkload(record: Record<string, unknown>): boolean {
   return Boolean(objectValue(record.outputs) || objectValue(record.output) || Array.isArray(record.diagnostics) || stringValue(record.summary))
 }
 
-function hasSemanticWorkload(workload: WorkloadDraft | undefined): boolean {
+function hasSemanticWorkload(workload: WorkloadDraft | undefined): workload is WorkloadDraft {
   return Boolean(workload && (workload.scenarios.length > 0 || Object.keys(workload.outputs).length > 0))
 }
 

--- a/scripts/agent-runtime-workload-normalizer-smoke.ts
+++ b/scripts/agent-runtime-workload-normalizer-smoke.ts
@@ -1,4 +1,4 @@
-import { normalizeAgentRuntimeWorkload } from "@automattic/wp-codebox-core"
+import { legacyAgentRuntimeWorkloadNormalizerAdapters, normalizeAgentRuntimeWorkload } from "@automattic/wp-codebox-core"
 
 const canonicalEnvelope = normalizeAgentRuntimeWorkload({
   schema: "wp-codebox/agent-runtime-workload/v1",
@@ -23,7 +23,7 @@ const explicitEnvelope = normalizeAgentRuntimeWorkload({
     scenarios: [{ id: "explicit" }],
   },
   stdout: JSON.stringify({ success: false, outputs: { report_path: "legacy/report.json" } }),
-})
+}, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters })
 assertEqual(explicitEnvelope.success, true, "explicit envelope wins over legacy extraction")
 assertEqual(explicitEnvelope.outputs.report_path, "runtime/report.json", "explicit envelope output is used")
 assertEqual(explicitEnvelope.scenarios[0]?.id, "explicit", "explicit envelope scenario is used")
@@ -34,7 +34,7 @@ const legacyBundleRun = normalizeAgentRuntimeWorkload({
   bundle: { bundle_slug: "site-build" },
   outputs: { preview_url: "https://example.test/preview" },
   workflow: { steps: [{ id: "generate" }, { id: "verify" }] },
-}, { compatMode: true, requiredOutputs: { preview_url: "outputs.preview_url" } })
+}, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters, requiredOutputs: { preview_url: "outputs.preview_url" } })
 assertEqual(legacyBundleRun.schema, "wp-codebox/agent-runtime-workload/v1", "legacy bundle run emits canonical schema")
 assertEqual(legacyBundleRun.success, true, "legacy bundle run succeeds")
 assertEqual(legacyBundleRun.outputs.preview_url, "https://example.test/preview", "legacy bundle outputs are preserved")
@@ -53,7 +53,7 @@ const stdoutWrapper = normalizeAgentRuntimeWorkload({
       },
     }),
   }),
-}, { compatMode: true, workloadId: "stdout-agent", toolRecorders: [{ name: "pull_request_url", path: "outputs.pull_request_url" }] })
+}, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters, workloadId: "stdout-agent", toolRecorders: [{ name: "pull_request_url", path: "outputs.pull_request_url" }] })
 assertEqual(stdoutWrapper.success, true, "stdout wrapper succeeds")
 assertEqual(stdoutWrapper.outputs.pull_request_url, "https://github.com/Automattic/wp-codebox/pull/1", "stdout wrapper output is normalized")
 assertEqual(stdoutWrapper.scenarios[0]?.id, "stdout-agent", "stdout wrapper workload id is used")
@@ -77,13 +77,13 @@ const recipeRun = normalizeAgentRuntimeWorkload({
       },
     },
   },
-}, { compatMode: true })
+}, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters })
 assertEqual(recipeRun.success, true, "recipe-run nested agent task result succeeds")
 assertEqual(recipeRun.outputs.report_path, "runtime-evidence/report.json", "recipe-run nested outputs are normalized")
 
 const failedScenario = normalizeAgentRuntimeWorkload({
   scenarios: [{ id: "failed", metadata: { error: "runtime adapter failed" } }],
-}, { compatMode: true })
+}, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters })
 assertEqual(failedScenario.success, false, "scenario metadata error fails workload")
 assertEqual(failedScenario.diagnostics.some((diagnostic) => diagnostic.message === "runtime adapter failed"), true, "scenario metadata error is surfaced")
 

--- a/tests/agent-runtime-workload-normalizers.test.ts
+++ b/tests/agent-runtime-workload-normalizers.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict"
+import {
+  AGENT_RUNTIME_WORKLOAD_SCHEMA,
+  legacyAgentRuntimeWorkloadNormalizerAdapters,
+  normalizeAgentRuntimeWorkload,
+  type AgentRuntimeWorkloadNormalizerAdapter,
+} from "../packages/runtime-core/src/agent-runtime-workload.js"
+
+const canonical = normalizeAgentRuntimeWorkload({
+  schema: AGENT_RUNTIME_WORKLOAD_SCHEMA,
+  success: true,
+  outputs: { preview_url: "https://example.test/canonical" },
+  scenarios: [{ id: "canonical", status: "completed" }],
+})
+
+assert.equal(canonical.success, true)
+assert.equal(canonical.outputs.preview_url, "https://example.test/canonical")
+assert.equal(canonical.scenarios[0]?.id, "canonical")
+assert.deepEqual(canonical.diagnostics, [])
+
+const legacyBundleRun = {
+  schema: "example/agent-bundle-run/v1",
+  success: true,
+  job_id: "caller-job-123",
+  flow_slug: "downstream-flow",
+  engine_data: { provider: "downstream" },
+  bundle: { flow_slug: "bundle-flow", bundle_slug: "site-build" },
+  outputs: { preview_url: "https://example.test/legacy" },
+  workflow: { steps: [{ id: "generate" }, { id: "verify" }] },
+}
+
+const strictBundleRun = normalizeAgentRuntimeWorkload(legacyBundleRun, { requiredOutputs: ["preview_url"] })
+assert.equal(strictBundleRun.success, false)
+assert.deepEqual(strictBundleRun.outputs, {})
+assert.deepEqual(strictBundleRun.scenarios, [])
+assert.equal(strictBundleRun.diagnostics[0]?.data?.reason, "missing_required_outputs")
+
+const adaptedBundleRun = normalizeAgentRuntimeWorkload(legacyBundleRun, {
+  normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters,
+  requiredOutputs: ["preview_url"],
+})
+assert.equal(adaptedBundleRun.success, true)
+assert.equal(adaptedBundleRun.outputs.preview_url, "https://example.test/legacy")
+assert.equal(adaptedBundleRun.scenarios[0]?.id, "bundle-flow")
+assert.equal(adaptedBundleRun.scenarios[0]?.metrics?.workflow_step_count, 2)
+assert.equal(adaptedBundleRun.scenarios[0]?.metadata?.job_id, "caller-job-123")
+assert.deepEqual(adaptedBundleRun.scenarios[0]?.metadata?.engine_data, { provider: "downstream" })
+assert.equal(adaptedBundleRun.diagnostics.some((diagnostic) => diagnostic.data?.adapter === "runtime-workload-agent-bundle-run"), true)
+
+const scenarioShape = {
+  success: true,
+  outputs: { report_path: "runtime/report.json" },
+  scenarios: [{ id: "legacy-scenario", outputs: { report_path: "runtime/report.json" } }],
+}
+
+const strictScenarioShape = normalizeAgentRuntimeWorkload(scenarioShape)
+assert.equal(strictScenarioShape.success, false)
+assert.deepEqual(strictScenarioShape.scenarios, [])
+assert.equal(strictScenarioShape.diagnostics[0]?.data?.reason, "missing_semantic_outputs")
+
+const adaptedScenarioShape = normalizeAgentRuntimeWorkload(scenarioShape, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters })
+assert.equal(adaptedScenarioShape.success, true)
+assert.equal(adaptedScenarioShape.scenarios[0]?.id, "legacy-scenario")
+assert.equal(adaptedScenarioShape.outputs.report_path, "runtime/report.json")
+
+const executionStdout = {
+  executions: [{
+    stdout: JSON.stringify({
+      schema: AGENT_RUNTIME_WORKLOAD_SCHEMA,
+      success: true,
+      outputs: { artifact_url: "https://example.test/artifact" },
+      scenarios: [{ id: "execution" }],
+    }),
+  }],
+}
+
+const strictExecutionStdout = normalizeAgentRuntimeWorkload(executionStdout)
+assert.equal(strictExecutionStdout.success, false)
+assert.deepEqual(strictExecutionStdout.outputs, {})
+
+const adaptedExecutionStdout = normalizeAgentRuntimeWorkload(executionStdout, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters })
+assert.equal(adaptedExecutionStdout.success, true)
+assert.equal(adaptedExecutionStdout.outputs.artifact_url, "https://example.test/artifact")
+assert.equal(adaptedExecutionStdout.scenarios[0]?.id, "execution")
+
+const customAdapter: AgentRuntimeWorkloadNormalizerAdapter = {
+  name: "test-custom-downstream-shape",
+  normalize(raw) {
+    const record = raw && typeof raw === "object" && !Array.isArray(raw) ? raw as Record<string, unknown> : undefined
+    const customOutput = record?.custom_output
+    if (typeof customOutput !== "string") return undefined
+    return {
+      outputs: { custom_output: customOutput },
+      scenarios: [{ id: "custom-adapter", outputs: { custom_output: customOutput } }],
+      diagnostics: [],
+      artifacts: [],
+      metadata: {},
+    }
+  },
+}
+
+const adaptedCustomShape = normalizeAgentRuntimeWorkload({ custom_output: "owned-by-caller" }, { normalizerAdapters: [customAdapter] })
+assert.equal(adaptedCustomShape.success, true)
+assert.equal(adaptedCustomShape.outputs.custom_output, "owned-by-caller")
+assert.equal(adaptedCustomShape.diagnostics.some((diagnostic) => diagnostic.data?.adapter === "test-custom-downstream-shape"), true)
+
+console.log("agent runtime workload normalizer adapters ok")


### PR DESCRIPTION
## Summary
- Keep canonical wp-codebox/agent-runtime-workload/v1 parsing strict by default.
- Add pluggable workload normalizer adapters and expose legacy adapters as explicit opt-in compatibility.
- Move legacy agent-bundle-run, scenario shape, execution stdout, nested job/flow/engine-data compatibility behind registered adapters.
- Add coverage for strict default parsing, legacy adapter normalization, and caller-owned custom adapters.

## Tests
- npm run build
- npm run test:agent-runtime-workload-normalizers
- npx tsx scripts/agent-runtime-workload-normalizer-smoke.ts
- npm run test:public-api-contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the adapter-based workload normalizer split, adding tests, running verification, and preparing this PR.