### PR TITLE
Add WP Codebox PHP public API facade

### DIFF
--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -33,6 +33,31 @@ metadata exposes `meta.canonical_ability` for aliases.
 - `wp-codebox/open-or-create-browser-contained-site`
 - WP-CLI wrappers under `wp codebox ...`
 
+## PHP Facade
+
+Consumers running inside WordPress can call `WP_Codebox_API` instead of
+depending on ability registration details or lower-level runtime classes. The
+facade only exposes WP Codebox operations and delegates to the same service
+layer as the ability and WP-CLI surfaces:
+
+- `WP_Codebox_API::run_agent_task( $input )`
+- `WP_Codebox_API::create_browser_session( $input )`
+- `WP_Codebox_API::open_or_create_browser_session( $input )`
+- `WP_Codebox_API::list_artifacts( $input )`
+- `WP_Codebox_API::get_artifact( $input )`
+- `WP_Codebox_API::preflight_artifact_apply( $input )`
+- `WP_Codebox_API::stage_artifact_apply( $input )`
+- `WP_Codebox_API::apply_approved_artifact( $input )`
+- `WP_Codebox_API::prepare_runner_workspace( $input )`
+- `WP_Codebox_API::capture_runner_workspace( $input )`
+- `WP_Codebox_API::run_runner_workspace_command( $input )`
+- `WP_Codebox_API::publish_runner_workspace( $input )`
+
+For ability-name-oriented callers, `WP_Codebox_API::execute_ability( $name,
+$input )` accepts supported `wp-codebox/...` ability names and compatibility
+aliases only. Host workspace backends, task runtimes, provider adapters, and
+sandbox implementations remain private implementation details.
+
 The host task abilities build a private Codebox recipe, boot a disposable
 sandbox runtime, mount the requested runtime components, invoke the configured
 sandbox-local task, and return artifact metadata. `wp-codebox agent-sandbox-run`,

--- a/packages/wordpress-plugin/src/class-wp-codebox-api.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-api.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Public PHP facade for WP Codebox consumers.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stable PHP facade over WP Codebox consumer operations.
+ */
+final class WP_Codebox_API {
+
+	/** @var array<string,string> */
+	private const ABILITY_METHODS = array(
+		'wp-codebox/run-agent-task'                         => 'run_agent_task',
+		'wp-codebox/run-agent-task-batch'                   => 'run_agent_task_batch',
+		'wp-codebox/run-agent-task-fanout'                  => 'run_agent_task_fanout',
+		'wp-codebox/create-browser-playground-session'      => 'create_browser_session',
+		'wp-codebox/create-sandbox-session'                 => 'create_browser_session',
+		'wp-codebox/create-browser-contained-site-session'  => 'create_browser_contained_site_session',
+		'wp-codebox/get-browser-contained-site-status'      => 'get_browser_session_status',
+		'wp-codebox/preview-reuse-decision'                 => 'preview_reuse_decision',
+		'wp-codebox/open-browser-contained-site'            => 'open_browser_session',
+		'wp-codebox/open-or-create-browser-contained-site'  => 'open_or_create_browser_session',
+		'wp-codebox/open-contained-runtime'                 => 'open_or_create_browser_session',
+		'wp-codebox/list-artifacts'                         => 'list_artifacts',
+		'wp-codebox/get-artifact'                           => 'get_artifact',
+		'wp-codebox/apply-artifact-preflight'               => 'preflight_artifact_apply',
+		'wp-codebox/stage-artifact-apply'                   => 'stage_artifact_apply',
+		'wp-codebox/apply-approved-artifact'                => 'apply_approved_artifact',
+		'wp-codebox/runner-workspace-prepare'               => 'prepare_runner_workspace',
+		'wp-codebox/prepare-runner-workspace'               => 'prepare_runner_workspace',
+		'wp-codebox/prepare'                                => 'prepare_runner_workspace',
+		'wp-codebox/runner-workspace-capture'               => 'capture_runner_workspace',
+		'wp-codebox/capture-runner-workspace'               => 'capture_runner_workspace',
+		'wp-codebox/capture'                                => 'capture_runner_workspace',
+		'wp-codebox/runner-workspace-command'               => 'run_runner_workspace_command',
+		'wp-codebox/run-runner-workspace-command'           => 'run_runner_workspace_command',
+		'wp-codebox/command'                                => 'run_runner_workspace_command',
+		'wp-codebox/runner-workspace-publish'               => 'publish_runner_workspace',
+		'wp-codebox/publish-runner-workspace'               => 'publish_runner_workspace',
+		'wp-codebox/publish'                                => 'publish_runner_workspace',
+	);
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function execute_ability( string $ability_name, array $input = array() ): array|WP_Error {
+		$ability_name = trim( $ability_name );
+		$method       = self::ABILITY_METHODS[ $ability_name ] ?? '';
+		if ( '' === $method ) {
+			return new WP_Error( 'wp_codebox_api_ability_not_supported', 'WP_Codebox_API only executes supported wp-codebox consumer operations.', array( 'status' => 400, 'ability' => $ability_name ) );
+		}
+
+		return self::{$method}( $input );
+	}
+
+	/** @param array<string,mixed> $input Task input. @return array<string,mixed>|WP_Error */
+	public static function run_agent_task( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_agent_task( $input );
+	}
+
+	/** @param array<string,mixed> $input Batch input. @return array<string,mixed>|WP_Error */
+	public static function run_agent_task_batch( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_agent_task_batch( $input );
+	}
+
+	/** @param array<string,mixed> $input Fanout input. @return array<string,mixed>|WP_Error */
+	public static function run_agent_task_fanout( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_agent_task_fanout( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser session input. @return array<string,mixed>|WP_Error */
+	public static function create_browser_session( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::create_browser_playground_session( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser contained-site session input. @return array<string,mixed>|WP_Error */
+	public static function create_browser_contained_site_session( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::create_browser_contained_site_session( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser session lookup input. @return array<string,mixed>|WP_Error */
+	public static function get_browser_session_status( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::get_browser_contained_site_status( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser session lookup input. @return array<string,mixed>|WP_Error */
+	public static function preview_reuse_decision( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::preview_reuse_decision( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser session input. @return array<string,mixed>|WP_Error */
+	public static function open_browser_session( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::open_browser_contained_site( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser session input. @return array<string,mixed>|WP_Error */
+	public static function open_or_create_browser_session( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::open_or_create_browser_contained_site( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact list input. @return array<string,mixed>|WP_Error */
+	public static function list_artifacts( array $input = array() ): array|WP_Error {
+		return WP_Codebox_Abilities::list_artifacts( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact lookup input. @return array<string,mixed>|WP_Error */
+	public static function get_artifact( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::get_artifact( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact apply input. @return array<string,mixed>|WP_Error */
+	public static function preflight_artifact_apply( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::apply_artifact_preflight( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact apply input. @return array<string,mixed>|WP_Error */
+	public static function stage_artifact_apply( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::stage_artifact_apply( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact apply input. @return array<string,mixed>|WP_Error */
+	public static function apply_approved_artifact( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::apply_approved_artifact( $input );
+	}
+
+	/** @param array<string,mixed> $input Runner workspace input. @return array<string,mixed> */
+	public static function prepare_runner_workspace( array $input ): array {
+		return WP_Codebox_Abilities::prepare_runner_workspace( $input );
+	}
+
+	/** @param array<string,mixed> $input Runner workspace input. @return array<string,mixed> */
+	public static function capture_runner_workspace( array $input ): array {
+		return WP_Codebox_Abilities::capture_runner_workspace( $input );
+	}
+
+	/** @param array<string,mixed> $input Runner workspace command input. @return array<string,mixed> */
+	public static function run_runner_workspace_command( array $input ): array {
+		return WP_Codebox_Abilities::run_runner_workspace_command( $input );
+	}
+
+	/** @param array<string,mixed> $input Runner workspace publication input. @return array<string,mixed> */
+	public static function publish_runner_workspace( array $input ): array {
+		return WP_Codebox_Abilities::publish_runner_workspace( $input );
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -60,6 +60,7 @@ require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-pending-artifact-apply.php';
 require_once __DIR__ . '/src/class-wp-codebox-preview-options.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
+require_once __DIR__ . '/src/class-wp-codebox-api.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/src/class-wp-codebox-cli-command.php';

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	final class WP_Error {
+		public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+		public function get_error_code(): string { return $this->code; }
+		public function get_error_message(): string { return $this->message; }
+		public function get_error_data(): mixed { return $this->data; }
+	}
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-api.php';
+
+function expect( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+$expected_methods = array(
+	'execute_ability',
+	'run_agent_task',
+	'run_agent_task_batch',
+	'run_agent_task_fanout',
+	'create_browser_session',
+	'create_browser_contained_site_session',
+	'get_browser_session_status',
+	'preview_reuse_decision',
+	'open_browser_session',
+	'open_or_create_browser_session',
+	'list_artifacts',
+	'get_artifact',
+	'preflight_artifact_apply',
+	'stage_artifact_apply',
+	'apply_approved_artifact',
+	'prepare_runner_workspace',
+	'capture_runner_workspace',
+	'run_runner_workspace_command',
+	'publish_runner_workspace',
+);
+
+$reflection = new ReflectionClass( WP_Codebox_API::class );
+foreach ( $expected_methods as $method ) {
+	expect( $reflection->hasMethod( $method ), 'Missing public API method: ' . $method );
+	expect( $reflection->getMethod( $method )->isPublic(), 'API method is not public: ' . $method );
+}
+
+$blocked = WP_Codebox_API::execute_ability( 'datamachine-code/workspace-show', array() );
+expect( $blocked instanceof WP_Error, 'Expected non-wp-codebox ability names to be rejected.' );
+expect( 'wp_codebox_api_ability_not_supported' === $blocked->get_error_code(), 'Expected unsupported ability error code.' );
+
+fwrite( STDOUT, "PHP public API facade smoke passed\n" );


### PR DESCRIPTION
## Summary
- Add `WP_Codebox_API` as a stable PHP facade for consumer-facing WP Codebox operations.
- Load the facade from the plugin bootstrap.
- Document the PHP entrypoints and add a lightweight facade contract smoke.

## Testing
- `php -l packages/wordpress-plugin/src/class-wp-codebox-api.php`
- `php -l packages/wordpress-plugin/wp-codebox.php`
- `php -l scripts/php-public-api-facade-smoke.php`
- `php scripts/php-public-api-facade-smoke.php`
- `php scripts/php-runner-workspace-adapter-boundary-smoke.php`
- `php scripts/php-browser-contained-site-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, documentation update, and lightweight verification.