### PR TITLE
Harden runner workspace backend boundary

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php
@@ -8,6 +8,19 @@
 defined( 'ABSPATH' ) || exit;
 
 final class WP_Codebox_Runner_Workspace_Adapter {
+	private const ABILITY_KEYS = array(
+		'workspace_adopt',
+		'workspace_show',
+		'workspace_clone',
+		'workspace_worktree_add',
+		'workspace_git_status',
+		'workspace_git_diff',
+		'run_runner_workspace_command',
+		'publish_runner_workspace',
+	);
+
+	private const ABILITY_NAME_PATTERN = '#^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$#i';
+
 	/** @return array<string,mixed> */
 	public function prepare( array $input ): array {
 		$abilities     = $this->abilities();
@@ -117,15 +130,14 @@ final class WP_Codebox_Runner_Workspace_Adapter {
 
 	/** @return array<string,mixed> */
 	private function config(): array {
-		$config = function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_runner_workspace_backend', array() ) : array();
-		if ( is_array( $config ) && ! empty( $config ) ) {
-			return $config;
-		}
+		$config    = function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_runner_workspace_backend', array() ) : array();
+		$config    = is_array( $config ) ? $config : array();
+		$abilities = $this->normalize_abilities( $config['abilities'] ?? null );
 
 		return array(
-			'id'                      => '',
-			'workspace_root_constant' => '',
-			'abilities'               => array(),
+			'id'                      => is_string( $config['id'] ?? null ) ? trim( $config['id'] ) : '',
+			'workspace_root_constant' => is_string( $config['workspace_root_constant'] ?? null ) ? trim( $config['workspace_root_constant'] ) : '',
+			'abilities'               => $abilities,
 		);
 	}
 
@@ -141,8 +153,34 @@ final class WP_Codebox_Runner_Workspace_Adapter {
 		return $this->execute( (string) ( $abilities[ $key ] ?? '' ), $input );
 	}
 
+	/** @return array<string,string> */
+	private function normalize_abilities( mixed $abilities ): array {
+		if ( ! is_array( $abilities ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( self::ABILITY_KEYS as $key ) {
+			$value = $abilities[ $key ] ?? null;
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+
+			$value = trim( $value );
+			if ( '' !== $value && preg_match( self::ABILITY_NAME_PATTERN, $value ) ) {
+				$normalized[ $key ] = $value;
+			}
+		}
+
+		return $normalized;
+	}
+
 	/** @return array{success:bool,result?:array<string,mixed>,failure_type?:string,error?:array<string,mixed>} */
 	private function execute( string $ability_name, array $input ): array {
+		if ( ! $this->valid_ability_name( $ability_name ) ) {
+			return $this->failure( 'backend_unavailable', 'wp_codebox_runner_workspace_backend_unavailable', 'Runner workspace backend is not available for this operation.' );
+		}
+
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
 		if ( ! $ability || ! is_callable( array( $ability, 'execute' ) ) ) {
 			return $this->failure( 'backend_unavailable', 'wp_codebox_runner_workspace_backend_unavailable', 'Runner workspace backend is not available for this operation.' );
@@ -177,8 +215,16 @@ final class WP_Codebox_Runner_Workspace_Adapter {
 	}
 
 	private function ability_available( string $ability_name ): bool {
+		if ( ! $this->valid_ability_name( $ability_name ) ) {
+			return false;
+		}
+
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability_name ) : null;
 		return $ability && is_callable( array( $ability, 'execute' ) );
+	}
+
+	private function valid_ability_name( string $ability_name ): bool {
+		return '' !== $ability_name && 1 === preg_match( self::ABILITY_NAME_PATTERN, $ability_name );
 	}
 
 	/** @return array{success:bool,failure_type:string,error:array<string,string>} */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -433,7 +433,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'success'      => false,
 				'schema'       => 'wp-codebox/runner-workspace-prepare-result/v1',
 				'status'       => $status,
-				'failure_type' => $failure_type,
+				'failure_type' => self::redact_runner_workspace_backend_slugs( $failure_type ),
 				'error'        => self::sanitize_runner_workspace_public_error( $error ),
 				'repo'         => (string) ( $input['repo'] ?? '' ),
 				'branch'       => (string) ( $input['branch'] ?? '' ),
@@ -615,7 +615,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'success'      => false,
 				'schema'       => 'wp-codebox/runner-workspace-publication-result/v1',
 				'status'       => $status,
-				'failure_type' => $failure_type,
+				'failure_type' => self::redact_runner_workspace_backend_slugs( $failure_type ),
 				'error'        => self::sanitize_runner_workspace_public_error( $error ),
 				'workspace'    => array_filter( array( 'handle' => (string) ( $input['workspace'] ?? '' ), 'path' => (string) ( $input['workspace_path'] ?? '' ) ), static fn( mixed $value ): bool => '' !== $value ),
 				'branch'       => array_filter( array( 'base' => (string) ( $input['base'] ?? '' ), 'head' => (string) ( $input['head'] ?? '' ) ), static fn( mixed $value ): bool => '' !== $value ),
@@ -648,7 +648,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 	}
 
 	private static function redact_runner_workspace_backend_slugs( string $value ): string {
-		return preg_replace( '#\bdatamachine-code/[a-z0-9._/-]+#i', 'runner workspace backend', $value ) ?? $value;
+		return preg_replace( '#\bdatamachine-code(?:/[a-z0-9._/-]+)?#i', 'runner workspace backend', $value ) ?? $value;
 	}
 
 	/** @param array<string,mixed> $input Normalized input. @param array<string,mixed> $extra Extra response fields. @return array<string,mixed> */
@@ -659,7 +659,7 @@ trait WP_Codebox_Abilities_Runner_Publication {
 					'success'      => false,
 					'schema'       => 'command' === $operation ? 'wp-codebox/runner-workspace-command-result/v1' : 'wp-codebox/runner-workspace-capture-result/v1',
 					'status'       => $status,
-					'failure_type' => $failure_type,
+					'failure_type' => self::redact_runner_workspace_backend_slugs( $failure_type ),
 					'error'        => self::sanitize_runner_workspace_public_error( $error ),
 					'workspace'    => self::runner_workspace_identity_result( $input ),
 				),

--- a/scripts/php-runner-workspace-adapter-boundary-smoke.php
+++ b/scripts/php-runner-workspace-adapter-boundary-smoke.php
@@ -34,6 +34,7 @@ function is_wp_error( mixed $value ): bool {
 $GLOBALS['wp_codebox_test_abilities'] = array();
 $GLOBALS['wp_codebox_test_filters']   = array();
 $GLOBALS['wp_codebox_ability_calls']  = array();
+$GLOBALS['wp_codebox_ability_lookups'] = array();
 
 function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
 	unset( $priority, $accepted_args );
@@ -49,6 +50,7 @@ function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 }
 
 function wp_get_ability( string $name ): ?object {
+	$GLOBALS['wp_codebox_ability_lookups'][] = $name;
 	return $GLOBALS['wp_codebox_test_abilities'][ $name ] ?? null;
 }
 
@@ -66,6 +68,14 @@ function register_test_ability( string $name, callable $callback ): void {
 function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
 	if ( $expected !== $actual ) {
 		fwrite( STDERR, $label . " failed.\nExpected: " . json_encode( $expected, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\nActual: " . json_encode( $actual, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n" );
+		exit( 1 );
+	}
+}
+
+function assert_no_backend_leak( mixed $value, string $label ): void {
+	$json = json_encode( $value, JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $json ) || str_contains( $json, 'datamachine-code' ) ) {
+		fwrite( STDERR, $label . " leaked backend identifiers.\nActual: " . json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n" );
 		exit( 1 );
 	}
 }
@@ -138,5 +148,42 @@ $failure = WP_Codebox_Abilities::capture_runner_workspace( array( 'workspace' =>
 assert_same_contract( false, $failure['success'], 'failure success' );
 assert_same_contract( 'runner workspace backend exploded', $failure['error']['message'], 'public error redacts backend ability slug' );
 assert_same_contract( false, array_key_exists( 'ability', $failure['error']['data'] ?? array() ), 'public error removes backend ability key' );
+assert_no_backend_leak( $failure, 'wp error failure' );
+
+$GLOBALS['wp_codebox_test_abilities']['datamachine-code/run-runner-workspace-command'] = new class() {
+	public function execute( array $input ): array {
+		unset( $input );
+		return array(
+			'success'      => false,
+			'failure_type' => 'datamachine-code/run-runner-workspace-command',
+			'error'        => array(
+				'code'    => 'datamachine-code/run-runner-workspace-command',
+				'message' => 'datamachine-code/run-runner-workspace-command failed',
+				'data'    => array( 'backend_ability' => 'datamachine-code/run-runner-workspace-command' ),
+			),
+		);
+	}
+};
+
+$backend_failure = WP_Codebox_Abilities::run_runner_workspace_command( array( 'workspace' => 'wp-codebox@task', 'repo' => 'wp-codebox', 'command' => 'php -l file.php' ) );
+assert_same_contract( false, $backend_failure['success'], 'backend failure success' );
+assert_same_contract( 'runner workspace backend', $backend_failure['failure_type'], 'backend failure type redacted' );
+assert_no_backend_leak( $backend_failure, 'backend failure' );
+
+$GLOBALS['wp_codebox_test_filters']['wp_codebox_runner_workspace_backend'] = array(
+	static fn(): array => array(
+		'id'        => 'datamachine-code',
+		'abilities' => array(
+			'run_runner_workspace_command' => 'datamachine-code',
+		),
+	),
+);
+$GLOBALS['wp_codebox_ability_lookups'] = array();
+
+$invalid_map_failure = WP_Codebox_Abilities::run_runner_workspace_command( array( 'workspace' => 'wp-codebox@task', 'repo' => 'wp-codebox', 'command' => 'php -l file.php' ) );
+assert_same_contract( false, $invalid_map_failure['success'], 'invalid map failure success' );
+assert_same_contract( 'backend_unavailable', $invalid_map_failure['failure_type'], 'invalid map failure type' );
+assert_same_contract( false, in_array( 'datamachine-code', $GLOBALS['wp_codebox_ability_lookups'], true ), 'invalid backend ability is not looked up' );
+assert_no_backend_leak( $invalid_map_failure, 'invalid map failure' );
 
 fwrite( STDOUT, "PHP runner workspace adapter boundary smoke passed\n" );


### PR DESCRIPTION
## Summary
- Normalize and validate the `wp_codebox_runner_workspace_backend` filter response before backend ability lookup/execution.
- Keep malformed backend maps behind generic runner workspace unavailable failures.
- Redact backend ability identifiers from public runner workspace failures.
- Add smoke coverage for invalid maps and backend identifier leakage.

## Testing
- `php scripts/php-runner-workspace-adapter-boundary-smoke.php`
- `npm run test:provider-runtime-contracts`
- `npm run test:public-ability-aliases`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php && php -l scripts/php-runner-workspace-adapter-boundary-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, focused test updates, and local verification.