### PR TITLE
Add stable preview boot ref facade

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -102,6 +102,15 @@ final class WP_Codebox_Abilities {
 				'permission_callback' => array( self::class, 'can_hydrate_browser_blueprint_ref' ),
 			)
 		);
+		register_rest_route(
+			'wp-codebox/v1',
+			'/preview-boot-ref',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'rest_preview_boot_ref' ),
+				'permission_callback' => array( self::class, 'can_create_browser_playground_session' ),
+			)
+		);
 	}
 
 	public static function can_hydrate_browser_blueprint_ref(): bool {
@@ -127,6 +136,16 @@ final class WP_Codebox_Abilities {
 				'input_hash' => (string) $request->get_param( 'input_hash' ),
 			)
 		);
+	}
+
+	/** @param WP_REST_Request $request REST request. @return array<string,mixed>|WP_Error */
+	public static function rest_preview_boot_ref( WP_REST_Request $request ): array|WP_Error {
+		$input = $request->get_json_params();
+		if ( ! is_array( $input ) ) {
+			return new WP_Error( 'wp_codebox_preview_boot_ref_payload_invalid', 'Preview boot refs require a JSON object.', array( 'status' => 400 ) );
+		}
+
+		return self::preview_boot_ref( $input );
 	}
 
 	/**

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
@@ -45,6 +45,27 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 				'permission_callback' => array( WP_Codebox_Abilities::class, 'can_create_browser_playground_session' ),
 				'meta'                => array( 'show_in_rest' => true ),
 			),
+			'wp-codebox/preview-boot-ref' => array(
+				'label'               => 'Preview Boot Ref',
+				'description'         => 'Resolve a Codebox-contained preview into a stable Studio-style boot DTO. Consumers should read boot, blueprint_ref, preview_lease, and startup_diagnostics instead of raw Playground URLs, scope, blueprint, or legacy session internals.',
+				'category'            => 'wp-codebox',
+				'input_schema'        => array( 'type' => 'object', 'properties' => array( 'contained_site' => $context['browser_contained_site_schema'], 'site_id' => array( 'type' => 'string' ), 'cache_key' => array( 'type' => 'string' ), 'source_digest' => array( 'type' => array( 'string', 'object' ) ), 'input_hash' => array( 'type' => 'string' ), 'playground' => array( 'type' => 'object' ), 'preview_lease' => array( 'type' => 'object' ) ) ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'             => array( 'type' => 'boolean' ),
+						'schema'              => array( 'type' => 'string', 'const' => 'wp-codebox/preview-boot-ref/v1' ),
+						'boot'                => array( 'type' => 'object' ),
+						'blueprint_ref'       => array( 'type' => 'object' ),
+						'preview_lease'       => array( 'type' => 'object' ),
+						'startup_diagnostics' => array( 'type' => 'object' ),
+						'compatibility'       => array( 'type' => 'object' ),
+					),
+				),
+				'execute_callback'    => array( WP_Codebox_Abilities::class, 'preview_boot_ref' ),
+				'permission_callback' => array( WP_Codebox_Abilities::class, 'can_create_browser_playground_session' ),
+				'meta'                => array( 'show_in_rest' => true ),
+			),
 			'wp-codebox/destroy-browser-contained-site-session' => array(
 				'label'               => 'Destroy Browser Contained Site Session',
 				'description'         => 'Release a Codebox-contained browser site session lease and return a terminal contained-site envelope.',

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -406,6 +406,54 @@ public static function boot_browser_contained_site_session( array $input ): arra
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+public static function preview_boot_ref( array $input ): array|WP_Error {
+	$boot_result = self::boot_browser_contained_site_session( $input );
+	if ( is_wp_error( $boot_result ) ) {
+		return $boot_result;
+	}
+
+	$boot           = is_array( $boot_result['boot'] ?? null ) ? $boot_result['boot'] : array();
+	$contained_site = is_array( $boot_result['contained_site'] ?? null ) ? $boot_result['contained_site'] : array();
+	$preview_lease  = is_array( $boot_result['preview_lease'] ?? null ) ? $boot_result['preview_lease'] : array();
+	$diagnostics    = is_array( $boot_result['startup_diagnostics'] ?? null ) ? $boot_result['startup_diagnostics'] : array();
+	$blueprint_ref  = is_array( $boot['blueprint_ref'] ?? null ) ? $boot['blueprint_ref'] : array();
+	$preview        = is_array( $boot['preview'] ?? null ) ? $boot['preview'] : $preview_lease;
+
+	$stable_boot = array_filter(
+		array(
+			'schema'        => 'wp-codebox/browser-contained-site-boot/v1',
+			'session_id'    => (string) ( $boot['session_id'] ?? '' ),
+			'site_id'       => (string) ( $boot['site_id'] ?? '' ),
+			'status'        => (string) ( $boot['status'] ?? '' ),
+			'preview'       => $preview,
+			'blueprint_ref' => $blueprint_ref,
+		),
+		static fn( mixed $value ): bool => array() !== $value && '' !== $value
+	);
+
+	return array_filter(
+		array(
+			'success'             => true === ( $boot_result['success'] ?? false ),
+			'schema'              => 'wp-codebox/preview-boot-ref/v1',
+			'boot'                => $stable_boot,
+			'blueprint_ref'       => $blueprint_ref,
+			'preview_lease'       => $preview_lease,
+			'startup_diagnostics' => $diagnostics,
+			'compatibility'       => array_filter(
+				array(
+					'contained_site_schema' => (string) ( $contained_site['schema'] ?? '' ),
+					'session_result_schema' => (string) ( $boot_result['schema'] ?? '' ),
+					'legacy_contained_site' => $contained_site,
+					'legacy_session_result' => $boot_result,
+				),
+				static fn( mixed $value ): bool => array() !== $value && '' !== $value
+			),
+		),
+		static fn( mixed $value ): bool => array() !== $value && '' !== $value
+	);
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function destroy_browser_contained_site_session( array $input ): array|WP_Error {
 	$contained_site = self::browser_contained_site_public_input( is_array( $input['contained_site'] ?? null ) ? $input['contained_site'] : array() );
 	$site_id        = (string) ( $input['site_id'] ?? $contained_site['site_id'] ?? '' );

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -195,6 +195,32 @@ expect( isset( $boot['boot']['blueprint_ref']['hydration_endpoint'] ), 'Boot des
 expect( 'wp-codebox/browser-contained-site-startup-diagnostics/v1' === $boot['startup_diagnostics']['schema'], 'Expected startup diagnostics schema.' );
 expect( 'active' === $boot['startup_diagnostics']['preview_lease_status'], 'Expected active lease diagnostics.' );
 
+$preview_boot_ref = WP_Codebox_Abilities::preview_boot_ref(
+	array(
+		'cache_key'     => 'studio-native-preview',
+		'source_digest' => $source_digest,
+		'playground'    => array(
+			'preview_public_url' => 'https://preview.example.test',
+			'site_url'           => 'https://preview.example.test/wp',
+			'local_url'          => 'http://localhost:8881/preview',
+			'lease'              => array( 'status' => 'active' ),
+		),
+	)
+);
+
+expect( ! is_wp_error( $preview_boot_ref ), 'Expected preview boot ref facade to return an envelope.' );
+expect( true === $preview_boot_ref['success'], 'Expected preview boot ref success=true.' );
+expect( 'wp-codebox/preview-boot-ref/v1' === $preview_boot_ref['schema'], 'Expected preview boot ref schema.' );
+expect( 'wp-codebox/browser-contained-site-boot/v1' === $preview_boot_ref['boot']['schema'], 'Expected stable boot descriptor.' );
+expect( isset( $preview_boot_ref['blueprint_ref']['hydration_endpoint'] ), 'Expected stable blueprint ref hydration endpoint.' );
+expect( ! isset( $preview_boot_ref['boot']['client_module_url'] ), 'Stable boot descriptor must not expose client_module_url.' );
+expect( ! isset( $preview_boot_ref['boot']['remote_url'] ), 'Stable boot descriptor must not expose remote_url.' );
+expect( ! isset( $preview_boot_ref['boot']['cors_proxy_url'] ), 'Stable boot descriptor must not expose cors_proxy_url.' );
+expect( ! isset( $preview_boot_ref['boot']['scope'] ), 'Stable boot descriptor must not expose scope.' );
+expect( ! isset( $preview_boot_ref['boot']['blueprint'] ), 'Stable boot descriptor must not expose raw blueprint.' );
+expect( 'wp-codebox/browser-contained-site/v1' === $preview_boot_ref['compatibility']['contained_site_schema'], 'Expected contained-site compatibility schema.' );
+expect( 'wp-codebox/browser-contained-site-boot-result/v1' === $preview_boot_ref['compatibility']['session_result_schema'], 'Expected session result compatibility schema.' );
+
 $destroy = WP_Codebox_Abilities::destroy_browser_contained_site_session(
 	array(
 		'contained_site' => $boot['contained_site'],


### PR DESCRIPTION
## Summary
- Add `wp-codebox/preview-boot-ref` and `POST /wp-codebox/v1/preview-boot-ref`.
- Return a stable `wp-codebox/preview-boot-ref/v1` DTO for Studio-style preview consumers.
- Preserve existing contained-site/session output shapes for compatibility.

## Testing
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php`
- `php scripts/php-browser-contained-site-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the preview boot facade and focused contract coverage.