### PR TITLE
Neutralize WordPress runtime backend aliasing

### DIFF
--- a/docs/generic-runtime-primitives.md
+++ b/docs/generic-runtime-primitives.md
@@ -7,6 +7,7 @@ product or job system.
 
 - TypeScript implementations live in `packages/runtime-core/src/artifact-storage.ts`,
   `packages/runtime-core/src/browser-session-origin.ts`, and
+  `packages/runtime-core/src/runtime-neutral-contracts.ts`, and
   `packages/runtime-core/src/materialization-contracts.ts`, and
   `packages/runtime-core/src/evidence-artifact-envelope.ts`, and
   `packages/runtime-core/src/runtime-overlay-bundle.ts`, and
@@ -115,6 +116,28 @@ Recipe schema accepts these bundles through `runtime.overlays[]`:
   }
 }
 ```
+
+## Neutral WordPress Runtime Intent
+
+Recipes can omit `runtime.backend` or set it to `wordpress`. WP Codebox currently
+normalizes that neutral WordPress runtime name to the existing
+`wordpress-playground` backend implementation. The `wordpress-playground` spelling
+is still accepted for existing recipes and low-level compatibility.
+
+`runtime-neutral-contracts.ts` also exports helper-only setup intent types for
+callers that need to describe desired setup before compiling it into recipe
+fields:
+
+- `RuntimeWordPressSetupPlanIntent` groups component and filesystem intent for a
+  WordPress sandbox setup plan.
+- `RuntimeWordPressComponentIntent` describes components such as plugins,
+  mu-plugins, themes, WordPress core, and runtime overlays.
+- `RuntimeWordPressFilesystemIntent` describes intended sandbox filesystem
+  materialization, including target path, mode, and purpose.
+
+These intent types are public documentation helpers. Runtime execution still uses
+the concrete recipe fields such as `inputs.extra_plugins`, `inputs.mounts`,
+`inputs.stagedFiles`, `runtime.stack.mounts`, and `runtime.overlays`.
 
 ## Runtime Profiles
 

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -2,8 +2,8 @@
 
 WP Codebox recipes use the `wp-codebox/workspace-recipe/v1` schema. A recipe is
 a declarative sandbox setup plus ordered workflow steps. The CLI validates the
-recipe before booting WordPress Playground, then returns a structured artifact
-bundle after execution.
+recipe before booting the selected WordPress runtime, then returns a structured
+artifact bundle after execution.
 
 Use the generated schema and command catalog as the source of truth:
 
@@ -25,7 +25,7 @@ npm run wp-codebox -- recipe-run --recipe ./path/to/recipe.json --dry-run --json
 {
   "schema": "wp-codebox/workspace-recipe/v1",
   "runtime": {
-    "backend": "wordpress-playground",
+    "backend": "wordpress",
     "wp": "latest"
   },
   "inputs": {
@@ -47,6 +47,16 @@ npm run wp-codebox -- recipe-run --recipe ./path/to/recipe.json --dry-run --json
   }
 }
 ```
+
+`runtime.backend` may be omitted. When present, `wordpress` is the neutral
+WordPress runtime name and currently resolves to the WordPress Playground backend.
+Existing recipes that specify `wordpress-playground` continue to work as a
+compatibility spelling.
+
+Raw Playground-oriented fields such as `runtime.blueprint`, `runtime.phpVersion`,
+`runtime.wordpressInstallMode`, and Playground backend packages are advanced
+compatibility fields. Prefer the neutral `wordpress` backend and recipe inputs
+for new runtime setup where possible.
 
 ## Stable Field Names
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
+    "test:recipe-runtime-backend-normalization": "tsx tests/recipe-runtime-backend-normalization.test.ts",
     "test:fuzz-run-recipe": "tsx tests/fuzz-run-recipe.test.ts",
     "test:recipe-secret-env": "tsx tests/recipe-secret-env.test.ts",
     "test:evidence-bundle-digest-and-recipe-artifact": "tsx tests/evidence-bundle-digest-and-recipe-artifact.test.ts",

--- a/packages/cli/src/recipe-backend-package.ts
+++ b/packages/cli/src/recipe-backend-package.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { readFile, stat } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
-import type { RuntimeBackendFactoryContext, RuntimeBackendKind, WorkspaceRecipe, WorkspaceRecipeRuntimeBackendPackage } from "@automattic/wp-codebox-core"
+import { normalizeRuntimeBackendKind, type RuntimeBackendFactoryContext, type RuntimeBackendKind, type WorkspaceRecipe, type WorkspaceRecipeRuntimeBackendPackage } from "@automattic/wp-codebox-core"
 
 export interface RuntimeBackendPackageProvenance {
   schema: "wp-codebox/runtime-backend-package/v1"
@@ -105,7 +105,7 @@ export class RecipeRuntimeBackendPackageError extends Error {
   }
 }
 
-export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe, recipeDirectory: string, backendKind: RuntimeBackendKind = recipe.runtime?.backend ?? "wordpress-playground"): Promise<PreparedRuntimeBackendPackage | undefined> {
+export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe, recipeDirectory: string, backendKind: RuntimeBackendKind = normalizeRuntimeBackendKind(recipe.runtime?.backend)): Promise<PreparedRuntimeBackendPackage | undefined> {
   const backendPackage = recipe.runtime?.backendPackage
   if (!backendPackage) {
     return undefined
@@ -124,7 +124,7 @@ export async function prepareRecipeRuntimeBackendPackage(recipe: WorkspaceRecipe
     : resolvedSource
   const entrypointContents = await readBackendEntrypoint(backendPackage, entrypoint)
   const module = await importBackendEntrypoint(backendPackage, entrypoint)
-  const adapter = runtimeBackendPackageAdapterRegistry.resolve(backendKind)
+  const adapter = runtimeBackendPackageAdapterRegistry.resolve(normalizeRuntimeBackendKind(backendKind))
   const adapterResult = adapter.prepare({ backendPackage, resolvedSource, entrypoint, entrypointContents, manifest, module })
 
   return {

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, resolve } from "node:path"
-import { fixtureImportDeterministicIdPlan, validateRuntimePolicy, type FixtureImportDeterministicIdPlan, type MountSpec, type RuntimePolicy, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeSiteSeedBootstrap, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
+import { fixtureImportDeterministicIdPlan, normalizeRuntimeBackendKind, validateRuntimePolicy, type FixtureImportDeterministicIdPlan, type MountSpec, type RuntimePolicy, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeSiteSeedBootstrap, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { serializeError } from "./output.js"
 import { resolveRecipeSecretEnv, type RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
@@ -411,7 +411,7 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
 
   return {
     runtime: {
-      backend: recipe.runtime?.backend ?? "wordpress-playground",
+      backend: normalizeRuntimeBackendKind(recipe.runtime?.backend),
       ...(recipe.runtime?.backendPackage ? { backendPackage: recipe.runtime.backendPackage } : {}),
       name: recipe.runtime?.name ?? "wp-codebox-recipe",
       wp: recipe.runtime?.wp ?? context.defaultWordPressVersion,

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
-import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, captureArtifactFile, checkWorkspacePolicy, materializeStructuredArtifactFiles, normalizeAgentTerminalResult, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
+import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTURED_ARTIFACT_INDEX_SCHEMA, artifactFileDigest, artifactManifestFileWithSha256, captureArtifactFile, checkWorkspacePolicy, materializeStructuredArtifactFiles, normalizeAgentTerminalResult, normalizeRuntimeBackendKind, normalizeStructuredArtifacts, refreshArtifactManifestFileSha256s, runtimeReferenceManifestDigest, runtimeReplayReferenceIndexDigest, upsertArtifactManifestFiles, type AgentTerminalResult, type ArtifactBundle, type ArtifactManifest, type ArtifactManifestFile, type ArtifactSpec, type ExecutionResult, type Runtime, type RuntimeInfo, type RuntimePolicy, type StructuredArtifactRef, type WorkspacePolicyResult, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core/artifacts"
 import { isPlainObject as isRecord, sha256StableJson, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import type { RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
@@ -1240,13 +1240,13 @@ async function buildRecipeRunAttestation(args: {
   const manifest = JSON.parse(await readFile(args.artifacts.manifestPath, "utf8")) as { runtime?: RuntimeInfo }
   const runtime = manifest.runtime ?? {
     id: "unknown",
-    backend: args.recipe.runtime?.backend ?? "wordpress-playground",
-      environment: {
-        kind: "wordpress",
-        name: args.recipe.runtime?.name ?? "wp-codebox-recipe",
-        version: args.recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION,
-        phpVersion: args.recipe.runtime?.phpVersion,
-      },
+    backend: normalizeRuntimeBackendKind(args.recipe.runtime?.backend),
+    environment: {
+      kind: "wordpress",
+      name: args.recipe.runtime?.name ?? "wp-codebox-recipe",
+      version: args.recipe.runtime?.wp ?? DEFAULT_WORDPRESS_VERSION,
+      phpVersion: args.recipe.runtime?.phpVersion,
+    },
     createdAt: args.artifacts.createdAt,
     status: "destroyed" as const,
   }

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, commandArgValue, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
+import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, commandArgValue, normalizeRuntimeBackendKind, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { commandValidationDescriptorFor, effectivePolicyCommandsFor, type CommandArgValidationDescriptor } from "@automattic/wp-codebox-core/contracts"
 import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { loadConfiguredRuntimeOverlayDescriptors, registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
@@ -64,6 +64,10 @@ export function parseWorkspaceRecipeJson(raw: string): WorkspaceRecipe {
 }
 
 export function normalizeWorkspaceRecipeCompatibility(recipe: WorkspaceRecipe): WorkspaceRecipe {
+  if (recipe.runtime) {
+    recipe.runtime.backend = normalizeRuntimeBackendKind(recipe.runtime.backend)
+  }
+
   return recipe
 }
 

--- a/packages/cli/src/runtime-backends.ts
+++ b/packages/cli/src/runtime-backends.ts
@@ -1,11 +1,11 @@
-import { createRuntimeBackendRegistry, type RuntimeBackend, type RuntimeBackendFactoryContext, type RuntimeBackendKind, type RuntimeBackendRecipePolicy } from "@automattic/wp-codebox-core"
+import { createRuntimeBackendRegistry, runtimeBackendRecipeAliases, type RuntimeBackend, type RuntimeBackendFactoryContext, type RuntimeBackendKind, type RuntimeBackendRecipePolicy } from "@automattic/wp-codebox-core"
 import type { CommandDefinition } from "@automattic/wp-codebox-core/contracts"
 import { playgroundRuntimeBackendProvider } from "@automattic/wp-codebox-playground"
 
 const cliRuntimeBackendRegistry = createRuntimeBackendRegistry([playgroundRuntimeBackendProvider])
 
 export function listCliRuntimeBackendKinds(): RuntimeBackendKind[] {
-  return cliRuntimeBackendRegistry.list()
+  return cliRuntimeBackendRegistry.list().flatMap((kind) => [kind, ...runtimeBackendRecipeAliases(kind)])
 }
 
 export function cliRuntimeBackendRecipePolicy(): Required<RuntimeBackendRecipePolicy> {

--- a/packages/runtime-core/src/runtime-backend-resolver.ts
+++ b/packages/runtime-core/src/runtime-backend-resolver.ts
@@ -1,6 +1,9 @@
 import type { CommandDefinition } from "./command-registry.js"
 import type { RuntimeBackend, RuntimeBackendKind } from "./runtime-contracts.js"
 
+export const WORDPRESS_RUNTIME_BACKEND_KIND = "wordpress-playground" as const
+export const WORDPRESS_RUNTIME_BACKEND_ALIAS = "wordpress" as const
+
 /**
  * Runtime-specific dependencies that backend providers may need while creating a backend.
  *
@@ -54,7 +57,7 @@ export class RuntimeBackendRegistry {
   }
 
   resolve(kind: RuntimeBackendKind, context?: RuntimeBackendFactoryContext): RuntimeBackend {
-    const provider = this.#providers.get(kind)
+    const provider = this.#providers.get(normalizeRuntimeBackendKind(kind))
     if (!provider) {
       throw new Error(unsupportedRuntimeBackendMessage(kind, this.list()))
     }
@@ -87,6 +90,19 @@ export function createRuntimeBackendRegistry(providers: readonly RuntimeBackendP
 
 export function resolveRuntimeBackend(kind: RuntimeBackendKind, providers: readonly RuntimeBackendProvider[], context?: RuntimeBackendFactoryContext): RuntimeBackend {
   return createRuntimeBackendRegistry(providers).resolve(kind, context)
+}
+
+export function normalizeRuntimeBackendKind(kind: RuntimeBackendKind | undefined | null): RuntimeBackendKind {
+  const normalized = typeof kind === "string" ? kind.trim() : ""
+  if (!normalized || normalized === WORDPRESS_RUNTIME_BACKEND_ALIAS) {
+    return WORDPRESS_RUNTIME_BACKEND_KIND
+  }
+
+  return normalized as RuntimeBackendKind
+}
+
+export function runtimeBackendRecipeAliases(kind: RuntimeBackendKind): RuntimeBackendKind[] {
+  return kind === WORDPRESS_RUNTIME_BACKEND_KIND ? [WORDPRESS_RUNTIME_BACKEND_ALIAS] : []
 }
 
 function unsupportedRuntimeBackendMessage(kind: RuntimeBackendKind, knownKinds: readonly RuntimeBackendKind[]): string {

--- a/packages/runtime-core/src/runtime-neutral-contracts.ts
+++ b/packages/runtime-core/src/runtime-neutral-contracts.ts
@@ -1,5 +1,36 @@
 export type BackendNeutralRuntimeBackendKind = string & {}
 
+export type RuntimeWordPressComponentIntentKind = "wordpress-core" | "plugin" | "mu-plugin" | "theme" | "runtime-overlay" | (string & {})
+export type RuntimeWordPressFilesystemIntentType = "directory" | "file" | (string & {})
+export type RuntimeWordPressFilesystemIntentMode = "readonly" | "readwrite" | "generated" | (string & {})
+
+export interface RuntimeWordPressComponentIntent {
+  kind: RuntimeWordPressComponentIntentKind
+  slug?: string
+  source?: string
+  target?: string
+  activate?: boolean
+  capabilities?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface RuntimeWordPressFilesystemIntent {
+  type?: RuntimeWordPressFilesystemIntentType
+  source?: string
+  target: string
+  mode?: RuntimeWordPressFilesystemIntentMode
+  purpose?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface RuntimeWordPressSetupPlanIntent {
+  schema: "wp-codebox/wordpress-runtime-setup-plan/v1"
+  backend?: BackendNeutralRuntimeBackendKind
+  components?: RuntimeWordPressComponentIntent[]
+  filesystem?: RuntimeWordPressFilesystemIntent[]
+  metadata?: Record<string, unknown>
+}
+
 export interface BackendNeutralRuntimeAssetSpec {
   directory?: string
   archive?: string

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -59,6 +59,7 @@ export const smokeGroups = {
       tsxSmoke("status-taxonomy-smoke"),
       npmScript("test:schema-parity"),
       npmScript("test:recipe-validation-descriptors"),
+      npmScript("test:recipe-runtime-backend-normalization"),
       npmScript("test:runtime-preset-registry"),
       npmScript("test:provider-runtime-contracts"),
       tsxSmoke("discovery-command-smoke"),

--- a/tests/recipe-runtime-backend-normalization.test.ts
+++ b/tests/recipe-runtime-backend-normalization.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+
+import { normalizeRuntimeBackendKind } from "../packages/runtime-core/src/index.js"
+import { parseWorkspaceRecipe } from "../packages/cli/src/recipe-validation.js"
+
+const recipeWithWordPressAlias = parseWorkspaceRecipe(JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: { backend: "wordpress" },
+  workflow: { steps: [{ command: "wordpress.run-php", args: ["code=<?php echo 'ok';"] }] },
+}), "recipe-wordpress-alias.json")
+
+assert.equal(recipeWithWordPressAlias.runtime?.backend, "wordpress-playground")
+assert.equal(normalizeRuntimeBackendKind("wordpress"), "wordpress-playground")
+assert.equal(normalizeRuntimeBackendKind(undefined), "wordpress-playground")
+
+const recipeWithOmittedBackend = parseWorkspaceRecipe(JSON.stringify({
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: { name: "default-wordpress-runtime" },
+  workflow: { steps: [{ command: "wordpress.run-php", args: ["code=<?php echo 'ok';"] }] },
+}), "recipe-omitted-backend.json")
+
+assert.equal(recipeWithOmittedBackend.runtime?.backend, "wordpress-playground")
+
+console.log("recipe runtime backend normalization ok")


### PR DESCRIPTION
## Summary
- Accept omitted `runtime.backend` and `runtime.backend: "wordpress"` for recipes.
- Normalize neutral WordPress runtime requests to the existing `wordpress-playground` backend.
- Document raw Playground fields as advanced compatibility details.
- Add helper intent types for WordPress setup plans, components, and filesystem setup.

## Testing
- `npm run test:recipe-runtime-backend-normalization`
- `npm run test:recipe-validation-descriptors`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, docs, and focused test coverage.