### PR TITLE
Centralize Agents API integration behind Codebox adapter

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
@@ -238,17 +238,7 @@ return array(
 }
 
 function wp_codebox_browser_runtime_agents_ability_names(): array {
-return array(
-	'chat' => 'agents/chat',
-	'run_task' => 'agents/run-task',
-	'run_runtime_package' => 'agents/run-runtime-package',
-	'get_task_run' => 'agents/get-task-run',
-	'cancel_task_run' => 'agents/cancel-task-run',
-	'get_chat_run' => 'agents/get-chat-run',
-	'cancel_chat_run' => 'agents/cancel-chat-run',
-	'queue_chat_message' => 'agents/queue-chat-message',
-	'list_chat_run_events' => 'agents/list-chat-run-events',
-);
+return WP_Codebox_Agents_API_Adapter::ability_names();
 }
 
 function wp_codebox_browser_runtime_agents_ability_exists( string $ability_name ): bool {
@@ -325,15 +315,8 @@ if ( empty( $bundle_specs ) ) {
 	return array();
 }
 
-if ( ! function_exists( 'wp_agent_import_runtime_bundles' ) ) {
-	$agents_api_importers = array();
-	if ( defined( 'AGENTS_API_PATH' ) ) {
-		$agents_api_importers[] = trailingslashit( AGENTS_API_PATH ) . 'src/Registry/register-agent-runtime-bundle-importer.php';
-	}
-	if ( defined( 'WP_PLUGIN_DIR' ) ) {
-		$agents_api_importers[] = trailingslashit( WP_PLUGIN_DIR ) . 'agents-api/src/Registry/register-agent-runtime-bundle-importer.php';
-	}
-	foreach ( $agents_api_importers as $agents_api_importer ) {
+if ( ! function_exists( WP_Codebox_Agents_API_Adapter::import_runtime_bundles_function() ) ) {
+	foreach ( WP_Codebox_Agents_API_Adapter::runtime_bundle_importer_paths() as $agents_api_importer ) {
 		if ( is_readable( $agents_api_importer ) ) {
 			require_once $agents_api_importer;
 			break;
@@ -341,8 +324,9 @@ if ( ! function_exists( 'wp_agent_import_runtime_bundles' ) ) {
 	}
 }
 
-if ( function_exists( 'wp_agent_import_runtime_bundles' ) ) {
-	return wp_agent_import_runtime_bundles( $bundle_specs, array( 'owner_id' => get_current_user_id() ?: 1 ) );
+$import_runtime_bundles = WP_Codebox_Agents_API_Adapter::import_runtime_bundles_function();
+if ( function_exists( $import_runtime_bundles ) ) {
+	return $import_runtime_bundles( $bundle_specs, array( 'owner_id' => get_current_user_id() ?: 1 ) );
 }
 
 $imports = array();
@@ -372,7 +356,7 @@ foreach ( $bundle_specs as $index => $spec ) {
 	if ( isset( $spec['import_principal'] ) && is_array( $spec['import_principal'] ) ) {
 		$input['import_principal'] = $spec['import_principal'];
 	}
-	$result = apply_filters( 'wp_agent_runtime_import_bundle', null, $spec, $input, $index );
+	$result = apply_filters( WP_Codebox_Agents_API_Adapter::runtime_bundle_import_filter(), null, $spec, $input, $index );
 	if ( null === $result ) {
 		$result = new WP_Error( 'wp_codebox_agent_bundle_importer_unavailable', 'No browser runtime agent bundle importer handled this bundle spec.', array( 'index' => $index, 'diagnostics' => wp_codebox_browser_runtime_agent_bundle_importer_diagnostics() ) );
 	}
@@ -384,25 +368,20 @@ foreach ( $bundle_specs as $index => $spec ) {
 function wp_codebox_browser_runtime_agent_bundle_importer_diagnostics(): array {
 global $wp_filter;
 $callback_count = 0;
-if ( isset( $wp_filter['wp_agent_runtime_import_bundle'] ) && is_object( $wp_filter['wp_agent_runtime_import_bundle'] ) && isset( $wp_filter['wp_agent_runtime_import_bundle']->callbacks ) && is_array( $wp_filter['wp_agent_runtime_import_bundle']->callbacks ) ) {
-	foreach ( $wp_filter['wp_agent_runtime_import_bundle']->callbacks as $callbacks ) {
+$runtime_bundle_import_filter = WP_Codebox_Agents_API_Adapter::runtime_bundle_import_filter();
+if ( isset( $wp_filter[ $runtime_bundle_import_filter ] ) && is_object( $wp_filter[ $runtime_bundle_import_filter ] ) && isset( $wp_filter[ $runtime_bundle_import_filter ]->callbacks ) && is_array( $wp_filter[ $runtime_bundle_import_filter ]->callbacks ) ) {
+	foreach ( $wp_filter[ $runtime_bundle_import_filter ]->callbacks as $callbacks ) {
 		$callback_count += is_array( $callbacks ) ? count( $callbacks ) : 0;
 	}
 }
 
-$candidates = array();
-if ( defined( 'AGENTS_API_PATH' ) ) {
-	$candidates[] = trailingslashit( AGENTS_API_PATH ) . 'src/Registry/register-agent-runtime-bundle-importer.php';
-}
-if ( defined( 'WP_PLUGIN_DIR' ) ) {
-	$candidates[] = trailingslashit( WP_PLUGIN_DIR ) . 'agents-api/src/Registry/register-agent-runtime-bundle-importer.php';
-}
+$candidates = WP_Codebox_Agents_API_Adapter::runtime_bundle_importer_paths();
 
 return array(
 	'agents_api_path_defined' => defined( 'AGENTS_API_PATH' ),
 	'agents_api_path' => defined( 'AGENTS_API_PATH' ) ? (string) AGENTS_API_PATH : '',
 	'wp_plugin_dir' => defined( 'WP_PLUGIN_DIR' ) ? (string) WP_PLUGIN_DIR : '',
-	'wp_agent_import_runtime_bundles_exists' => function_exists( 'wp_agent_import_runtime_bundles' ),
+	'wp_agent_import_runtime_bundles_exists' => function_exists( WP_Codebox_Agents_API_Adapter::import_runtime_bundles_function() ),
 	'wp_agent_runtime_import_bundle_callback_count' => $callback_count,
 	'candidate_importers' => array_values( array_map( static fn( $path ) => array(
 		'path' => (string) $path,
@@ -489,7 +468,7 @@ $permission_filter = static function ( bool $allowed, $principal, array $permiss
 	return wp_codebox_browser_runtime_principal_permission( $allowed, $principal, $permission_input, $session_id );
 };
 if ( null === $response ) {
-	add_filter( 'agents_chat_runtime_principal_permission', $permission_filter, 999, 3 );
+	add_filter( WP_Codebox_Agents_API_Adapter::chat_runtime_principal_permission_filter(), $permission_filter, 999, 3 );
 	try {
 		if ( 'task' === (string) ( $invocation['type'] ?? 'ability' ) ) {
 			$response = apply_filters( (string) ( $invocation['hook'] ?? $invocation['name'] ?? '' ), null, $input, $payload );
@@ -500,7 +479,7 @@ if ( null === $response ) {
 		$response = $exception;
 	} finally {
 		if ( function_exists( 'remove_filter' ) ) {
-			remove_filter( 'agents_chat_runtime_principal_permission', $permission_filter, 999 );
+			remove_filter( WP_Codebox_Agents_API_Adapter::chat_runtime_principal_permission_filter(), $permission_filter, 999 );
 		}
 	}
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -25,6 +25,27 @@ final class WP_Codebox_Agents_API_Adapter {
 	public const QUEUE_CHAT_MESSAGE   = 'agents/queue-chat-message';
 	public const LIST_CHAT_RUN_EVENTS = 'agents/list-chat-run-events';
 
+	public const TASK_INPUT_SCHEMA      = 'agents-api/task-input/v1';
+	public const EXECUTOR_TARGET_SCHEMA = 'agents-api/executor-target/v1';
+	public const BROWSER_TARGET         = 'wp-codebox/browser-playground';
+	public const HOST_TARGET            = 'wp-codebox/host-playground';
+	public const IMPORT_RUNTIME_BUNDLES_FUNCTION = 'wp_agent_import_runtime_bundles';
+	public const RUNTIME_BUNDLE_IMPORT_FILTER = 'wp_agent_runtime_import_bundle';
+	public const LEGACY_RESOLVED_TOOLS_FILTER = 'agents_api_resolved_tools';
+	public const RUNTIME_RESOLVED_TOOLS_FILTER = 'wp_agent_runtime_resolved_tools';
+	public const CHAT_RUNTIME_PRINCIPAL_PERMISSION_FILTER = 'agents_chat_runtime_principal_permission';
+
+	private const EXECUTOR_TARGET_FILTERS = array(
+		'agents_api_executor_targets',
+		'wp_agent_execution_targets',
+		'wp_agent_executor_targets',
+	);
+
+	private const EXECUTE_TASK_FILTERS = array(
+		'agents_api_execute_task' => 3,
+		'wp_agent_task_handler'   => 2,
+	);
+
 	/** @return array<string,string> */
 	public static function ability_names(): array {
 		return array(
@@ -37,6 +58,191 @@ final class WP_Codebox_Agents_API_Adapter {
 			'cancel_chat_run'      => self::CANCEL_CHAT_RUN,
 			'queue_chat_message'   => self::QUEUE_CHAT_MESSAGE,
 			'list_chat_run_events' => self::LIST_CHAT_RUN_EVENTS,
+		);
+	}
+
+	public static function default_chat_ability(): string {
+		return self::CHAT;
+	}
+
+	public static function import_runtime_bundles_function(): string {
+		return self::IMPORT_RUNTIME_BUNDLES_FUNCTION;
+	}
+
+	public static function runtime_bundle_import_filter(): string {
+		return self::RUNTIME_BUNDLE_IMPORT_FILTER;
+	}
+
+	public static function runtime_resolved_tools_filter(): string {
+		return self::RUNTIME_RESOLVED_TOOLS_FILTER;
+	}
+
+	public static function legacy_resolved_tools_filter(): string {
+		return self::LEGACY_RESOLVED_TOOLS_FILTER;
+	}
+
+	public static function chat_runtime_principal_permission_filter(): string {
+		return self::CHAT_RUNTIME_PRINCIPAL_PERMISSION_FILTER;
+	}
+
+	/** @return array<int,string> */
+	public static function runtime_bundle_importer_paths(): array {
+		$paths = array();
+		if ( defined( 'AGENTS_API_PATH' ) ) {
+			$paths[] = trailingslashit( AGENTS_API_PATH ) . 'src/Registry/register-agent-runtime-bundle-importer.php';
+		}
+		if ( defined( 'WP_PLUGIN_DIR' ) ) {
+			$paths[] = trailingslashit( WP_PLUGIN_DIR ) . 'agents-api/src/Registry/register-agent-runtime-bundle-importer.php';
+		}
+
+		return $paths;
+	}
+
+	public static function register_executor_adapters( callable $target_callback, callable $execute_callback ): void {
+		if ( ! function_exists( 'add_filter' ) ) {
+			return;
+		}
+
+		foreach ( self::EXECUTOR_TARGET_FILTERS as $hook ) {
+			add_filter( $hook, $target_callback );
+		}
+		foreach ( self::EXECUTE_TASK_FILTERS as $hook => $accepted_args ) {
+			add_filter( $hook, $execute_callback, 10, $accepted_args );
+		}
+	}
+
+	/** @param array<string,mixed> $task_input_schema Codebox task input schema. @return array<string,mixed> */
+	public static function task_input_schema( array $task_input_schema ): array {
+		$task_input_schema['$id'] = self::TASK_INPUT_SCHEMA;
+		$task_input_schema['properties']['schema']['const'] = self::TASK_INPUT_SCHEMA;
+		$task_input_schema['properties']['schema']['description'] = 'Generic Agents API task input schema id.';
+
+		return $task_input_schema;
+	}
+
+	/** @param array<string,mixed> $task_input_schema Agents API task input schema. @param array<string,mixed> $browser_output_schema Browser task output schema. @return array<int,array<string,mixed>> */
+	public static function executor_target_declarations( array $task_input_schema, array $browser_output_schema ): array {
+		$browser_output_schema['properties']['schema']['const'] = 'wp-codebox/browser-task-contract/v1';
+
+		return array(
+			array(
+				'schema'        => self::EXECUTOR_TARGET_SCHEMA,
+				'id'            => self::BROWSER_TARGET,
+				'label'         => 'WP Codebox Browser Playground',
+				'description'   => 'Prepare the existing WP Codebox browser task contract for execution inside a browser-owned WordPress Playground.',
+				'provider'      => 'wp-codebox',
+				'kind'          => 'browser-playground',
+				'capabilities'  => array( 'wordpress-playground', 'browser-runtime', 'browser-task-contract' ),
+				'input_schema'  => $task_input_schema,
+				'output_schema' => $browser_output_schema,
+			),
+			array(
+				'schema'        => self::EXECUTOR_TARGET_SCHEMA,
+				'id'            => self::HOST_TARGET,
+				'label'         => 'WP Codebox Host Playground',
+				'description'   => 'Run the existing WP Codebox host sandbox runner and return the wp-codebox/run-agent-task result shape.',
+				'provider'      => 'wp-codebox',
+				'kind'          => 'host-playground',
+				'capabilities'  => array( 'wordpress-playground', 'host-sandbox-runner', 'artifact-capture' ),
+				'input_schema'  => $task_input_schema,
+				'output_schema' => array( 'type' => 'object' ),
+			),
+		);
+	}
+
+	public static function executor_target_id( mixed $target, mixed $request ): string {
+		if ( is_string( $target ) ) {
+			return $target;
+		}
+		if ( is_array( $target ) ) {
+			return trim( (string) ( $target['id'] ?? $target['target'] ?? '' ) );
+		}
+		if ( is_array( $request ) ) {
+			foreach ( array( 'executor_id', 'executor', 'target_id', 'target' ) as $field ) {
+				if ( is_string( $request[ $field ] ?? null ) ) {
+					return trim( (string) $request[ $field ] );
+				}
+				if ( is_array( $request[ $field ] ?? null ) ) {
+					$nested = $request[ $field ];
+					return trim( (string) ( $nested['id'] ?? $nested['target'] ?? '' ) );
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<string,mixed> $request Generic task request. @return array<string,mixed> */
+	public static function task_request_input( array $request ): array {
+		foreach ( array( 'input', 'task_input' ) as $field ) {
+			if ( is_array( $request[ $field ] ?? null ) ) {
+				return self::task_input( $request[ $field ], $request );
+			}
+		}
+
+		return self::task_input( $request, $request );
+	}
+
+	/** @param array<string,mixed> $input Task input. @param array<string,mixed> $request Full request. @return array<string,mixed> */
+	private static function task_input( array $input, array $request ): array {
+		$normalized_workload = WP_Codebox_Agent_Workload::normalize_ability_input( $input );
+		if ( ! is_wp_error( $normalized_workload ) ) {
+			$input = $normalized_workload;
+		}
+
+		if ( self::TASK_INPUT_SCHEMA === (string) ( $input['schema'] ?? '' ) ) {
+			$input['schema'] = WP_Codebox_Task_Input_Contract::SCHEMA;
+		}
+
+		foreach ( self::task_passthrough_fields() as $field ) {
+			if ( ! array_key_exists( $field, $input ) && array_key_exists( $field, $request ) ) {
+				$input[ $field ] = $request[ $field ];
+			}
+		}
+
+		return $input;
+	}
+
+	/** @return array<int,string> */
+	private static function task_passthrough_fields(): array {
+		return array(
+			'agent',
+			'mode',
+			'provider',
+			'model',
+			'provider_plugin_paths',
+			'agent_bundles',
+			'runtime_task',
+			'parent_request',
+			'component_contracts',
+			'mounts',
+			'workspaces',
+			'runtime_stack_mounts',
+			'runtime_overlays',
+			'inherit',
+			'secret_env',
+			'sandbox_session_id',
+			'orchestrator',
+			'session_id',
+			'max_turns',
+			'task_timeout_seconds',
+			'preview_hold_seconds',
+			'preview_port',
+			'preview_bind',
+			'preview_public_url',
+			'wp',
+			'artifacts_path',
+			'wp_codebox_bin',
+			'authorization',
+			'playground',
+			'browser_runner',
+			'browser_plugins',
+			'runtime',
+			'blueprint',
+			'site_blueprint_artifact',
+			'artifact_files',
+			'phases',
+			'materializers',
 		);
 	}
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php
@@ -711,7 +711,7 @@ $elapsed_ms = max( 0, (int) round( ( microtime( true ) - $started_monotonic ) * 
 
 return array_filter( array(
     "schema" => "wp-codebox/execution-metrics/v1",
-    "executor" => "wp-codebox/browser-playground",
+    "executor" => "' . WP_Codebox_Agents_API_Adapter::BROWSER_TARGET . '",
     "phase" => "execution",
     "status" => $failed ? "error" : "completed",
     "execution" => "browser-playground",
@@ -1131,12 +1131,12 @@ $tool_def = is_array( $request[\'tool_def\'] ?? null ) ? $request[\'tool_def\'] 
 return $handler->handle_tool_call( $parameters, $tool_def );
 }
 
-add_filter( \'agents_api_resolved_tools\', function ( array $tools, $mode, array $context ) {
+add_filter( WP_Codebox_Agents_API_Adapter::legacy_resolved_tools_filter(), function ( array $tools, $mode, array $context ) {
 	unset( $context );
 	return wp_codebox_browser_runtime_merge_ability_tools( $tools, $mode );
 }, 20, 3 );
 
-add_filter( \'wp_agent_runtime_resolved_tools\', function ( array $tools, $mode, array $args ) {
+add_filter( WP_Codebox_Agents_API_Adapter::runtime_resolved_tools_filter(), function ( array $tools, $mode, array $args ) {
 	global $wp_codebox_browser_artifact_environment;
 	$environment = is_array( $wp_codebox_browser_artifact_environment ?? null ) ? $wp_codebox_browser_artifact_environment : array();
 	$root = (string) ( $environment[\'root\'] ?? \'wp-codebox-output/\' );

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -156,7 +156,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'result_path' => '/tmp/wp-codebox-browser-result.json',
 				'invocation'  => array(
 					'type' => 'ability',
-					'name' => class_exists( 'WP_Codebox_Agents_API_Adapter' ) ? WP_Codebox_Agents_API_Adapter::CHAT : 'agents/chat',
+					'name' => WP_Codebox_Agents_API_Adapter::default_chat_ability(),
 				),
 			),
 		);

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-agents-api-executors.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Internal Agents API task executor adapters for WP Codebox.
+ * Internal task executor adapters for WP Codebox's Agents API facade.
  *
  * These adapters let the upstream task runtime call Codebox-owned execution
  * targets. Consumer-facing integrations should use the wp-codebox/* abilities
@@ -13,18 +13,11 @@ defined( 'ABSPATH' ) || exit;
 
 trait WP_Codebox_Abilities_Agents_API_Executors {
 
-	private const AGENTS_API_TASK_INPUT_SCHEMA = 'agents-api/task-input/v1';
-
 	private function register_agents_api_executor_adapters(): void {
-		if ( ! function_exists( 'add_filter' ) ) {
-			return;
-		}
-
-		add_filter( 'agents_api_executor_targets', array( self::class, 'register_agents_api_executor_targets' ) );
-		add_filter( 'wp_agent_execution_targets', array( self::class, 'register_agents_api_executor_targets' ) );
-		add_filter( 'wp_agent_executor_targets', array( self::class, 'register_agents_api_executor_targets' ) );
-		add_filter( 'agents_api_execute_task', array( self::class, 'execute_agents_api_task' ), 10, 3 );
-		add_filter( 'wp_agent_task_handler', array( self::class, 'execute_agents_api_task' ), 10, 2 );
+		WP_Codebox_Agents_API_Adapter::register_executor_adapters(
+			array( self::class, 'register_agents_api_executor_targets' ),
+			array( self::class, 'execute_agents_api_task' )
+		);
 	}
 
 	/** @param mixed $targets Existing executor targets. @return array<int|string,mixed> */
@@ -43,8 +36,8 @@ trait WP_Codebox_Abilities_Agents_API_Executors {
 			return $pre;
 		}
 
-		$target_id = self::agents_api_executor_target_id( $target, $request );
-		if ( ! in_array( $target_id, array( 'wp-codebox/browser-playground', 'wp-codebox/host-playground' ), true ) ) {
+		$target_id = WP_Codebox_Agents_API_Adapter::executor_target_id( $target, $request );
+		if ( ! in_array( $target_id, array( WP_Codebox_Agents_API_Adapter::BROWSER_TARGET, WP_Codebox_Agents_API_Adapter::HOST_TARGET ), true ) ) {
 			return $pre;
 		}
 
@@ -52,144 +45,22 @@ trait WP_Codebox_Abilities_Agents_API_Executors {
 			return new WP_Error( 'wp_codebox_agents_api_task_request_invalid', 'Agents API task requests must be objects.', array( 'status' => 400 ) );
 		}
 
-		$input = self::agents_api_task_request_input( $request );
-		return 'wp-codebox/browser-playground' === $target_id
+		$input = WP_Codebox_Agents_API_Adapter::task_request_input( $request );
+		return WP_Codebox_Agents_API_Adapter::BROWSER_TARGET === $target_id
 			? self::create_browser_task_contract( $input )
 			: self::run_agent_task( $input );
 	}
 
 	/** @return array<int,array<string,mixed>> */
 	private static function agents_api_executor_target_declarations(): array {
-		$task_input_schema          = self::agents_api_task_input_schema();
-		$browser_task_output_schema = self::browser_task_contract_schema();
-		$browser_task_output_schema['properties']['schema']['const'] = 'wp-codebox/browser-task-contract/v1';
-
-		return array(
-			array(
-				'schema'       => 'agents-api/executor-target/v1',
-				'id'           => 'wp-codebox/browser-playground',
-				'label'        => 'WP Codebox Browser Playground',
-				'description'  => 'Prepare the existing WP Codebox browser task contract for execution inside a browser-owned WordPress Playground.',
-				'provider'     => 'wp-codebox',
-				'kind'         => 'browser-playground',
-				'capabilities' => array( 'wordpress-playground', 'browser-runtime', 'browser-task-contract' ),
-				'input_schema'      => $task_input_schema,
-				'output_schema'     => $browser_task_output_schema,
-			),
-			array(
-				'schema'       => 'agents-api/executor-target/v1',
-				'id'           => 'wp-codebox/host-playground',
-				'label'        => 'WP Codebox Host Playground',
-				'description'  => 'Run the existing WP Codebox host sandbox runner and return the wp-codebox/run-agent-task result shape.',
-				'provider'     => 'wp-codebox',
-				'kind'         => 'host-playground',
-				'capabilities' => array( 'wordpress-playground', 'host-sandbox-runner', 'artifact-capture' ),
-				'input_schema'      => $task_input_schema,
-				'output_schema'     => array( 'type' => 'object' ),
-			),
+		return WP_Codebox_Agents_API_Adapter::executor_target_declarations(
+			self::agents_api_task_input_schema(),
+			self::browser_task_contract_schema()
 		);
 	}
 
 	/** @return array<string,mixed> */
 	private static function agents_api_task_input_schema(): array {
-		$schema = self::task_input_schema();
-		$schema['$id'] = self::AGENTS_API_TASK_INPUT_SCHEMA;
-		$schema['properties']['schema']['const'] = self::AGENTS_API_TASK_INPUT_SCHEMA;
-		$schema['properties']['schema']['description'] = 'Generic Agents API task input schema id.';
-
-		return $schema;
-	}
-
-	private static function agents_api_executor_target_id( mixed $target, mixed $request ): string {
-		if ( is_string( $target ) ) {
-			return $target;
-		}
-		if ( is_array( $target ) ) {
-			return trim( (string) ( $target['id'] ?? $target['target'] ?? '' ) );
-		}
-		if ( is_array( $request ) ) {
-			foreach ( array( 'executor_id', 'executor', 'target_id', 'target' ) as $field ) {
-				if ( is_string( $request[ $field ] ?? null ) ) {
-					return trim( (string) $request[ $field ] );
-				}
-				if ( is_array( $request[ $field ] ?? null ) ) {
-					$nested = $request[ $field ];
-					return trim( (string) ( $nested['id'] ?? $nested['target'] ?? '' ) );
-				}
-			}
-		}
-
-		return '';
-	}
-
-	/** @param array<string,mixed> $request Generic task request. @return array<string,mixed> */
-	private static function agents_api_task_request_input( array $request ): array {
-		foreach ( array( 'input', 'task_input' ) as $field ) {
-			if ( is_array( $request[ $field ] ?? null ) ) {
-				return self::agents_api_task_input( $request[ $field ], $request );
-			}
-		}
-
-		return self::agents_api_task_input( $request, $request );
-	}
-
-	/** @param array<string,mixed> $input Task input. @param array<string,mixed> $request Full request. @return array<string,mixed> */
-	private static function agents_api_task_input( array $input, array $request ): array {
-		$normalized_workload = WP_Codebox_Agent_Workload::normalize_ability_input( $input );
-		if ( ! is_wp_error( $normalized_workload ) ) {
-			$input = $normalized_workload;
-		}
-
-		if ( self::AGENTS_API_TASK_INPUT_SCHEMA === (string) ( $input['schema'] ?? '' ) ) {
-			$input['schema'] = WP_Codebox_Task_Input_Contract::SCHEMA;
-		}
-
-		$passthrough_fields = array(
-			'agent',
-			'mode',
-			'provider',
-			'model',
-			'provider_plugin_paths',
-			'agent_bundles',
-			'runtime_task',
-			'parent_request',
-			'component_contracts',
-			'mounts',
-			'workspaces',
-			'runtime_stack_mounts',
-			'runtime_overlays',
-			'inherit',
-			'secret_env',
-			'sandbox_session_id',
-			'orchestrator',
-			'session_id',
-			'max_turns',
-			'task_timeout_seconds',
-			'preview_hold_seconds',
-			'preview_port',
-			'preview_bind',
-			'preview_public_url',
-			'wp',
-			'artifacts_path',
-			'wp_codebox_bin',
-			'authorization',
-			'playground',
-			'browser_runner',
-			'browser_plugins',
-			'runtime',
-			'blueprint',
-			'site_blueprint_artifact',
-			'artifact_files',
-			'phases',
-			'materializers',
-		);
-
-		foreach ( $passthrough_fields as $field ) {
-			if ( ! array_key_exists( $field, $input ) && array_key_exists( $field, $request ) ) {
-				$input[ $field ] = $request[ $field ];
-			}
-		}
-
-		return $input;
+		return WP_Codebox_Agents_API_Adapter::task_input_schema( self::task_input_schema() );
 	}
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -117,7 +117,7 @@ private static function browser_runner_invocation( array $runner ): array|WP_Err
 	$name = trim( (string) ( $invocation['name'] ?? '' ) );
 	$hook = trim( (string) ( $invocation['hook'] ?? $name ) );
 	if ( 'ability' === $type ) {
-		$name = '' !== $name ? $name : ( class_exists( 'WP_Codebox_Agents_API_Adapter' ) ? WP_Codebox_Agents_API_Adapter::CHAT : 'agents/chat' );
+		$name = '' !== $name ? $name : WP_Codebox_Agents_API_Adapter::default_chat_ability();
 		if ( ! preg_match( '#^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$#', $name ) ) {
 			return new WP_Error( 'wp_codebox_browser_invocation_name_invalid', 'Browser runner ability names must use namespace/name form.', array( 'status' => 400 ) );
 		}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -695,7 +695,7 @@ private static function browser_contract_execution_metrics( array $primary, arra
 	return array_filter(
 		array(
 			'schema'           => 'wp-codebox/execution-metrics/v1',
-			'executor'         => 'wp-codebox/browser-playground',
+			'executor'         => WP_Codebox_Agents_API_Adapter::BROWSER_TARGET,
 			'phase'            => 'contract',
 			'status'           => true === ( $primary['success'] ?? false ) ? 'pending' : (string) ( $primary['status'] ?? 'blocked' ),
 			'execution'        => 'browser-playground',

--- a/scripts/php-agents-api-execution-targets-smoke.php
+++ b/scripts/php-agents-api-execution-targets-smoke.php
@@ -19,6 +19,8 @@ function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
 }
 
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-workload.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
 
 function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {


### PR DESCRIPTION
## Summary
- Move WP Codebox direct Agents API hook names, ability names, executor target declarations, and task request normalization behind `WP_Codebox_Agents_API_Adapter`.
- Make executor registration, browser runner defaults, runtime bundle import hooks, runtime tool hooks, and runtime-principal permission hooks delegate through the adapter.
- Keep consumer-facing code focused on `wp-codebox/*` APIs and schemas.

## Testing
- `php -l` on changed PHP files
- `php scripts/php-agents-api-adapter-contract-smoke.php`
- `php scripts/php-agents-api-execution-targets-smoke.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Refactor implementation, focused code search, and verification.