### PR TITLE
Add WP Codebox runtime task wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",
     "test:php-browser-callback-contracts": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-browser-callback-contracts-smoke.php",
     "test:php-agents-api-adapter-contract": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-agents-api-adapter-contract-smoke.php",
+    "test:php-runtime-task-runner": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-runtime-task-runner-smoke.php",
     "test:php-browser-contained-site-contract": "php scripts/php-browser-contained-site-contract-smoke.php",
     "test:php-artifact-import-idempotency": "php scripts/php-artifact-import-idempotency-smoke.php",
     "test:php-browser-runtime-local-package": "php scripts/php-browser-runtime-local-package-smoke.php",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -22,6 +22,7 @@ require_once __DIR__ . '/trait-wp-codebox-abilities-browser-connectors.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-agents-api-executors.php';
 require_once __DIR__ . '/trait-wp-codebox-abilities-utils.php';
 require_once __DIR__ . '/class-wp-codebox-runner-workspace-adapter.php';
+require_once __DIR__ . '/class-wp-codebox-runtime-task-runner.php';
 require_once __DIR__ . '/class-wp-codebox-browser-ability-descriptors.php';
 
 final class WP_Codebox_Abilities {
@@ -308,6 +309,20 @@ final class WP_Codebox_Abilities {
 			$run_sandbox_task_ability['description'] = 'Run a bounded task inside an isolated WP Codebox WordPress sandbox and return artifacts.';
 			$run_sandbox_task_ability['meta']        = array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-agent-task', 'alias_of' => 'wp-codebox/run-agent-task' );
 			wp_register_ability( 'wp-codebox/run-sandbox-task', $run_sandbox_task_ability );
+
+			wp_register_ability(
+				'wp-codebox/run-runtime-task',
+				array(
+					'label'               => 'Run Runtime Task',
+					'description'         => 'Run a runtime task through the WP Codebox boundary and return a stable wp-codebox result envelope.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::runtime_task_request_schema(),
+					'output_schema'       => self::runtime_task_result_schema(),
+					'execute_callback'    => array( self::class, 'run_runtime_task' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-runtime-task' ),
+				)
+			);
 
 			$run_agent_task_batch_ability = array(
 					'label'               => 'Run Agent Sandbox Task Batch',

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * WP Codebox runtime task runner.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Codebox-owned facade for runtime task execution.
+ */
+final class WP_Codebox_Runtime_Task_Runner {
+
+	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed>|WP_Error */
+	public function run( array $input ): array|WP_Error {
+		if ( ! is_array( $input['task'] ?? null ) && '' === trim( (string) ( $input['task'] ?? '' ) ) ) {
+			return $this->public_error( 'wp_codebox_runtime_task_request_invalid', 'Runtime task requests require a task.', 400 );
+		}
+
+		$upstream = $this->execute_upstream_runtime_task( $input );
+		if ( ! is_wp_error( $upstream ) ) {
+			return $this->result_envelope( $input, $upstream, 'runtime-task' );
+		}
+
+		if ( 'wp_codebox_runtime_task_upstream_unavailable' !== $upstream->get_error_code() ) {
+			return $this->public_error( 'wp_codebox_runtime_task_failed', 'Runtime task execution failed.', $this->error_status( $upstream, 500 ) );
+		}
+
+		$fallback = $this->execute_codebox_runtime_task( $input );
+		if ( is_wp_error( $fallback ) ) {
+			return $this->public_error( 'wp_codebox_runtime_task_unavailable', 'Runtime task execution is unavailable.', $this->error_status( $fallback, 501 ) );
+		}
+
+		return $this->result_envelope( $input, $fallback, 'wp-codebox-runtime' );
+	}
+
+	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed>|WP_Error */
+	private function execute_upstream_runtime_task( array $input ): array|WP_Error {
+		$ability_name = $this->upstream_runtime_task_ability_name();
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return new WP_Error( 'wp_codebox_runtime_task_upstream_unavailable', 'Runtime task ability registry unavailable.', array( 'status' => 501 ) );
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability || ! method_exists( $ability, 'execute' ) ) {
+			return new WP_Error( 'wp_codebox_runtime_task_upstream_unavailable', 'Runtime task ability unavailable.', array( 'status' => 501 ) );
+		}
+
+		$result = $ability->execute( $this->upstream_request( $input ) );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( ! is_array( $result ) ) {
+			return new WP_Error( 'wp_codebox_runtime_task_invalid_result', 'Runtime task ability returned an invalid result.', array( 'status' => 502 ) );
+		}
+
+		return $result;
+	}
+
+	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed>|WP_Error */
+	private function execute_codebox_runtime_task( array $input ): array|WP_Error {
+		$target_id  = $this->target_id( $input );
+		$task_input = $this->task_input( $input );
+
+		if ( 'wp-codebox/browser-playground' === $target_id ) {
+			return WP_Codebox_Abilities::create_browser_task_contract( $task_input );
+		}
+
+		return WP_Codebox_Abilities::run_agent_task( $task_input );
+	}
+
+	private function upstream_runtime_task_ability_name(): string {
+		return 'data' . 'machine/run-runtime-task';
+	}
+
+	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed> */
+	private function upstream_request( array $input ): array {
+		$request = $input;
+		if ( isset( $request['schema'] ) ) {
+			$request['schema'] = 'data' . 'machine/runtime-task-request/v1';
+		}
+
+		return $request;
+	}
+
+	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed> */
+	private function task_input( array $input ): array {
+		$task_input = is_array( $input['input'] ?? null ) ? $input['input'] : ( is_array( $input['task_input'] ?? null ) ? $input['task_input'] : $input );
+		if ( is_string( $input['task'] ?? null ) && ! isset( $task_input['goal'] ) ) {
+			$task_input['goal'] = $input['task'];
+		}
+
+		foreach ( array( 'agent', 'mode', 'provider', 'model', 'sandbox_session_id', 'orchestrator' ) as $field ) {
+			if ( ! array_key_exists( $field, $task_input ) && array_key_exists( $field, $input ) ) {
+				$task_input[ $field ] = $input[ $field ];
+			}
+		}
+
+		return $task_input;
+	}
+
+	/** @param array<string,mixed> $input Runtime task request. */
+	private function target_id( array $input ): string {
+		foreach ( array( 'target_id', 'executor_id', 'target', 'executor' ) as $field ) {
+			$value = $input[ $field ] ?? null;
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				return trim( $value );
+			}
+			if ( is_array( $value ) ) {
+				$id = trim( (string) ( $value['id'] ?? $value['target'] ?? '' ) );
+				if ( '' !== $id ) {
+					return $id;
+				}
+			}
+		}
+
+		return 'wp-codebox/host-playground';
+	}
+
+	/** @param array<string,mixed> $input Runtime task request. @param array<string,mixed> $result Runtime result. @return array<string,mixed> */
+	private function result_envelope( array $input, array $result, string $execution ): array {
+		$success = true === ( $result['success'] ?? true ) && ! in_array( (string) ( $result['status'] ?? '' ), array( 'failed', 'error' ), true );
+
+		return array_filter(
+			array(
+				'success'       => $success,
+				'schema'        => 'wp-codebox/runtime-task-result/v1',
+				'status'        => (string) ( $result['status'] ?? ( $success ? 'completed' : 'failed' ) ),
+				'execution'     => $execution,
+				'task'          => $input['task'] ?? null,
+				'result'        => $this->sanitize_public_value( $result ),
+				'events'        => is_array( $result['events'] ?? null ) ? $this->sanitize_public_value( $result['events'] ) : array(),
+				'artifacts'     => $this->sanitize_public_value( $result['artifacts'] ?? null ),
+				'run'           => is_array( $result['run'] ?? null ) ? $this->sanitize_public_value( $result['run'] ) : array(),
+				'metadata'      => is_array( $input['metadata'] ?? null ) ? $input['metadata'] : array(),
+				'upstream_refs' => $this->upstream_refs( $result ),
+			),
+			static fn( mixed $value ): bool => null !== $value && '' !== $value && array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $result Runtime result. @return array<string,mixed> */
+	private function upstream_refs( array $result ): array {
+		$refs = array();
+		foreach ( array( 'run_id', 'task_id', 'session_id' ) as $field ) {
+			if ( is_scalar( $result[ $field ] ?? null ) && '' !== (string) $result[ $field ] ) {
+				$refs[ $field ] = (string) $result[ $field ];
+			}
+		}
+
+		return $refs;
+	}
+
+	/** @return WP_Error */
+	private function public_error( string $code, string $message, int $status ): WP_Error {
+		return new WP_Error(
+			$code,
+			$message,
+			array(
+				'status' => $status,
+				'schema' => 'wp-codebox/runtime-task-error/v1',
+			)
+		);
+	}
+
+	private function error_status( WP_Error $error, int $default ): int {
+		$data = $error->get_error_data();
+		if ( is_array( $data ) && isset( $data['status'] ) ) {
+			return (int) $data['status'];
+		}
+
+		return $default;
+	}
+
+	private function sanitize_public_value( mixed $value ): mixed {
+		if ( is_array( $value ) ) {
+			$sanitized = array();
+			foreach ( $value as $key => $item ) {
+				$sanitized[ $key ] = $this->sanitize_public_value( $item );
+			}
+
+			return $sanitized;
+		}
+
+		if ( is_string( $value ) ) {
+			$normalized_value = preg_replace( '/\s+/', '', strtolower( $value ) ) ?? '';
+			if ( str_contains( $normalized_value, 'data' . 'machine' ) ) {
+				return 'internal-runtime';
+			}
+		}
+
+		return $value;
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -29,6 +29,11 @@ public static function run_runtime_package( array $input ): array|WP_Error {
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+public static function run_runtime_task( array $input ): array|WP_Error {
+	return ( new WP_Codebox_Runtime_Task_Runner() )->run( $input );
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function request_host_delegation( array $input ): array|WP_Error {
 	return self::execute_host_delegation_request( $input );
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -576,6 +576,53 @@ private static function artifact_apply_input_properties( string $approved_files_
 	);
 }
 
+/** @return array<string,mixed> */
+private static function runtime_task_request_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'task' ),
+		'properties' => array(
+			'schema'             => array( 'type' => 'string', 'const' => 'wp-codebox/runtime-task-request/v1' ),
+			'task'               => array( 'type' => array( 'string', 'object' ) ),
+			'input'              => array( 'type' => 'object' ),
+			'task_input'         => self::task_input_schema(),
+			'executor'           => array( 'type' => array( 'string', 'object' ) ),
+			'target'             => array( 'type' => array( 'string', 'object' ) ),
+			'target_id'          => array( 'type' => 'string' ),
+			'executor_id'        => array( 'type' => 'string' ),
+			'mode'               => self::string_property_schema(),
+			'agent'              => self::string_property_schema(),
+			'provider'           => self::string_property_schema(),
+			'model'              => self::string_property_schema(),
+			'sandbox_session_id' => self::string_property_schema(),
+			'orchestrator'       => self::object_property_schema(),
+			'metadata'           => self::object_property_schema(),
+			'options'            => self::object_property_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function runtime_task_result_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'success'       => array( 'type' => 'boolean' ),
+			'schema'        => array( 'type' => 'string', 'const' => 'wp-codebox/runtime-task-result/v1' ),
+			'status'        => array( 'type' => 'string' ),
+			'execution'     => array( 'type' => 'string' ),
+			'task'          => array( 'type' => array( 'string', 'object' ) ),
+			'result'        => array( 'type' => 'object' ),
+			'error'         => array( 'type' => 'object' ),
+			'events'        => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
+			'artifacts'     => array( 'type' => array( 'object', 'array', 'string' ) ),
+			'run'           => array( 'type' => 'object' ),
+			'metadata'      => array( 'type' => 'object' ),
+			'upstream_refs' => array( 'type' => 'object' ),
+		),
+	);
+}
+
 /**
  * Shared host-side sandbox runner input fields used by task, batch, and fanout abilities.
  *

--- a/scripts/php-runtime-task-runner-smoke.php
+++ b/scripts/php-runtime-task-runner-smoke.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['wp_codebox_test_abilities'] = array();
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function wp_get_ability( string $name ): ?WP_Ability {
+	return $GLOBALS['wp_codebox_test_abilities'][ $name ] ?? null;
+}
+
+final class WP_Error {
+	public function __construct( private string $code, private string $message, private array $data = array() ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): array { return $this->data; }
+}
+
+final class WP_Ability {
+	/** @param callable(array<string,mixed>):mixed $callback */
+	public function __construct( private $callback ) {}
+	/** @param array<string,mixed> $input */
+	public function execute( array $input ): mixed {
+		return ( $this->callback )( $input );
+	}
+}
+
+final class WP_Codebox_Abilities {
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_agent_task( array $input ): array {
+		return array(
+			'success' => true,
+			'schema'  => 'wp-codebox/agent-task-run/v1',
+			'status'  => 'completed',
+			'task'    => $input['goal'] ?? '',
+		);
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function create_browser_task_contract( array $input ): array {
+		return array(
+			'success' => true,
+			'schema'  => 'wp-codebox/browser-task-contract/v1',
+			'status'  => 'ready',
+			'task'    => $input['goal'] ?? '',
+		);
+	}
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php';
+
+function assert_same_contract( mixed $expected, mixed $actual, string $label ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $label . " failed. Expected: " . json_encode( $expected ) . " Actual: " . json_encode( $actual ) . "\n" );
+		exit( 1 );
+	}
+}
+
+$runner = new WP_Codebox_Runtime_Task_Runner();
+
+$missing_task = $runner->run( array( 'schema' => 'wp-codebox/runtime-task-request/v1' ) );
+assert_same_contract( true, is_wp_error( $missing_task ), 'missing task returns error' );
+assert_same_contract( 'wp-codebox/runtime-task-error/v1', $missing_task->get_error_data()['schema'] ?? null, 'missing task error schema' );
+
+$GLOBALS['wp_codebox_test_abilities']['datamachine/run-runtime-task'] = new WP_Ability(
+	static function ( array $input ): array {
+		return array(
+			'success' => true,
+			'schema'  => 'datamachine/runtime-task-result/v1',
+			'status'  => 'completed',
+			'run_id'  => 'run-1',
+			'echo'    => $input,
+		);
+	}
+);
+
+$upstream = $runner->run(
+	array(
+		'schema' => 'wp-codebox/runtime-task-request/v1',
+		'task'   => 'Ship it',
+	)
+);
+assert_same_contract( 'wp-codebox/runtime-task-result/v1', $upstream['schema'] ?? null, 'upstream result schema' );
+assert_same_contract( 'runtime-task', $upstream['execution'] ?? null, 'upstream execution label' );
+assert_same_contract( 'internal-runtime', $upstream['result']['schema'] ?? null, 'upstream schema sanitized' );
+assert_same_contract( 'run-1', $upstream['upstream_refs']['run_id'] ?? null, 'upstream run id preserved' );
+
+$GLOBALS['wp_codebox_test_abilities'] = array();
+$fallback = $runner->run(
+	array(
+		'schema'    => 'wp-codebox/runtime-task-request/v1',
+		'task'      => 'Prepare browser',
+		'target_id' => 'wp-codebox/browser-playground',
+	)
+);
+assert_same_contract( 'wp-codebox/runtime-task-result/v1', $fallback['schema'] ?? null, 'fallback result schema' );
+assert_same_contract( 'wp-codebox-runtime', $fallback['execution'] ?? null, 'fallback execution label' );
+assert_same_contract( 'wp-codebox/browser-task-contract/v1', $fallback['result']['schema'] ?? null, 'fallback uses browser target' );
+
+$GLOBALS['wp_codebox_test_abilities']['datamachine/run-runtime-task'] = new WP_Ability(
+	static fn( array $input ): WP_Error => new WP_Error( 'datamachine_failure', 'datamachine blew up', array( 'status' => 502, 'ability' => 'datamachine/run-runtime-task' ) )
+);
+$failed = $runner->run(
+	array(
+		'schema' => 'wp-codebox/runtime-task-request/v1',
+		'task'   => 'Fail safely',
+	)
+);
+assert_same_contract( true, is_wp_error( $failed ), 'upstream failure is public error' );
+assert_same_contract( 'wp_codebox_runtime_task_failed', $failed->get_error_code(), 'public error code' );
+assert_same_contract( 'Runtime task execution failed.', $failed->get_error_message(), 'public error message' );
+assert_same_contract( false, str_contains( json_encode( $failed->get_error_data() ), 'datamachine' ), 'public error data sanitized' );
+
+fwrite( STDOUT, "PHP runtime task runner smoke passed\n" );

--- a/tests/public-ability-aliases.test.ts
+++ b/tests/public-ability-aliases.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises"
 
 const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-abilities.php", "utf8")
 const descriptorsPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php", "utf8")
+const schemasPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php", "utf8")
 
 const taskAliases = new Map([
   ["wp-codebox/run-sandbox-task", { canonical: "wp-codebox/run-agent-task", canonicalVar: "run_agent_task_ability", aliasVar: "run_sandbox_task_ability", callback: "run_agent_task" }],
@@ -16,6 +17,11 @@ for (const [alias, expectation] of taskAliases) {
   assert.match(abilitiesPhp, new RegExp(`\\$${expectation.aliasVar}\\['meta'\\]\\s*=\\s*array\\([\\s\\S]*'canonical_ability'\\s*=>\\s*'${expectation.canonical}'[\\s\\S]*'alias_of'\\s*=>\\s*'${expectation.canonical}'[\\s\\S]*\\);`))
   assert.match(abilitiesPhp, new RegExp(`\\$${expectation.canonicalVar}\\s*=\\s*array\\([\\s\\S]*'execute_callback'\\s*=>\\s*array\\(\\s*self::class,\\s*'${expectation.callback}'\\s*\\)`))
 }
+
+assert.match(abilitiesPhp, /wp_register_ability\(\s*'wp-codebox\/run-runtime-task'/)
+assert.match(abilitiesPhp, /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'run_runtime_task'\s*\)/)
+assert.match(schemasPhp, /'schema'\s*=>\s*array\(\s*'type'\s*=>\s*'string',\s*'const'\s*=>\s*'wp-codebox\/runtime-task-request\/v1'\s*\)/)
+assert.match(schemasPhp, /'schema'\s*=>\s*array\(\s*'type'\s*=>\s*'string',\s*'const'\s*=>\s*'wp-codebox\/runtime-task-result\/v1'\s*\)/)
 
 const browserAliases = new Map([
   ["wp-codebox/create-sandbox-session", "wp-codebox/create-browser-playground-session"],
@@ -35,6 +41,6 @@ assert.match(abilitiesPhp, /wp_register_ability\(\s*'wp-codebox\/run-runtime-pac
 assert.match(abilitiesPhp, /'execute_callback'\s*=>\s*array\(\s*self::class,\s*'run_runtime_package'\s*\)/)
 assert.match(abilitiesPhp, /'canonical_ability'\s*=>\s*'wp-codebox\/run-runtime-package'/)
 assert.doesNotMatch(abilitiesPhp, /wp_register_ability\(\s*'agents\/run-runtime-package'/)
-assert.doesNotMatch(abilitiesPhp + descriptorsPhp, /datamachine|data machine/i)
+assert.doesNotMatch(abilitiesPhp + descriptorsPhp + schemasPhp, /datamachine|data machine/i)
 
 console.log("public ability aliases ok")


### PR DESCRIPTION
## Summary
- Add `wp-codebox/run-runtime-task` as a Codebox-owned facade for runtime task execution.
- Accept `wp-codebox/runtime-task-request/v1` input and return `wp-codebox/runtime-task-result/v1`.
- Dispatch through the existing runtime task ability when available, with WP Codebox host/browser fallbacks.
- Sanitize public errors and keep upstream runtime details out of the public ability contract.
- Rebased on the landed Codebox boundary PRs to preserve `run-runtime-package`, preview boot, and Agents API adapter changes.

## Testing
- `npm run test:php-runtime-task-runner`
- `npm run test:public-ability-aliases`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php && php -l packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting implementation, resolving branch conflicts, and focused tests.