### PR TITLE
Harden runner workspace facade boundary

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-api.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-api.php
@@ -49,7 +49,7 @@ final class WP_Codebox_API {
 		$ability_name = trim( $ability_name );
 		$method       = self::ABILITY_METHODS[ $ability_name ] ?? '';
 		if ( '' === $method ) {
-			return new WP_Error( 'wp_codebox_api_ability_not_supported', 'WP_Codebox_API only executes supported wp-codebox consumer operations.', array( 'status' => 400, 'ability' => $ability_name ) );
+			return new WP_Error( 'wp_codebox_api_ability_not_supported', 'WP_Codebox_API only executes supported wp-codebox consumer operations.', array( 'status' => 400 ) );
 		}
 
 		return self::{$method}( $input );

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -14,6 +14,36 @@ if ( ! class_exists( 'WP_Error' ) ) {
 
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-api.php';
 
+final class WP_Codebox_Abilities {
+	public static array $calls = array();
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function prepare_runner_workspace( array $input ): array {
+		return self::record( 'prepare_runner_workspace', 'wp-codebox/runner-workspace-prepare-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function capture_runner_workspace( array $input ): array {
+		return self::record( 'capture_runner_workspace', 'wp-codebox/runner-workspace-capture-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_runner_workspace_command( array $input ): array {
+		return self::record( 'run_runner_workspace_command', 'wp-codebox/runner-workspace-command-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function publish_runner_workspace( array $input ): array {
+		return self::record( 'publish_runner_workspace', 'wp-codebox/runner-workspace-publication-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	private static function record( string $method, string $schema, array $input ): array {
+		self::$calls[] = array( 'method' => $method, 'input' => $input );
+		return array( 'success' => true, 'schema' => $schema, 'method' => $method );
+	}
+}
+
 function expect( bool $condition, string $message ): void {
 	if ( ! $condition ) {
 		fwrite( STDERR, $message . PHP_EOL );
@@ -52,5 +82,24 @@ foreach ( $expected_methods as $method ) {
 $blocked = WP_Codebox_API::execute_ability( 'datamachine-code/workspace-show', array() );
 expect( $blocked instanceof WP_Error, 'Expected non-wp-codebox ability names to be rejected.' );
 expect( 'wp_codebox_api_ability_not_supported' === $blocked->get_error_code(), 'Expected unsupported ability error code.' );
+expect( ! str_contains( json_encode( $blocked->get_error_data(), JSON_UNESCAPED_SLASHES ) ?: '', 'datamachine-code' ), 'Unsupported ability errors must not echo backend ability names.' );
+
+$runner_workspace_abilities = array(
+	'wp-codebox/runner-workspace-prepare' => array( 'method' => 'prepare_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-prepare-result/v1' ),
+	'wp-codebox/runner-workspace-capture' => array( 'method' => 'capture_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-capture-result/v1' ),
+	'wp-codebox/runner-workspace-command' => array( 'method' => 'run_runner_workspace_command', 'schema' => 'wp-codebox/runner-workspace-command-result/v1' ),
+	'wp-codebox/runner-workspace-publish' => array( 'method' => 'publish_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-publication-result/v1' ),
+	'wp-codebox/prepare-runner-workspace' => array( 'method' => 'prepare_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-prepare-result/v1' ),
+	'wp-codebox/capture-runner-workspace' => array( 'method' => 'capture_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-capture-result/v1' ),
+	'wp-codebox/run-runner-workspace-command' => array( 'method' => 'run_runner_workspace_command', 'schema' => 'wp-codebox/runner-workspace-command-result/v1' ),
+	'wp-codebox/publish-runner-workspace' => array( 'method' => 'publish_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-publication-result/v1' ),
+);
+
+foreach ( $runner_workspace_abilities as $ability_name => $expected ) {
+	$result = WP_Codebox_API::execute_ability( $ability_name, array( 'workspace' => 'wp-codebox@task', 'repo' => 'wp-codebox', 'command' => 'php -l file.php' ) );
+	expect( is_array( $result ), 'Expected runner workspace facade result for ' . $ability_name );
+	expect( $expected['method'] === $result['method'], 'Expected runner workspace facade method for ' . $ability_name );
+	expect( $expected['schema'] === $result['schema'], 'Expected runner workspace facade schema for ' . $ability_name );
+}
 
 fwrite( STDOUT, "PHP public API facade smoke passed\n" );


### PR DESCRIPTION
## Summary
- Keep runner workspace execution routed through WP Codebox-owned facade ability names.
- Stop echoing unsupported backend ability names from the public PHP facade error data.
- Extend the public facade smoke to cover canonical runner workspace abilities, explicit runner-workspace compatibility aliases, and backend-name redaction.

## Verification
- php scripts/php-public-api-facade-smoke.php
- php scripts/php-runner-workspace-adapter-boundary-smoke.php
- npm run test:public-api-contract
- php -l packages/wordpress-plugin/src/class-wp-codebox-api.php && php -l scripts/php-public-api-facade-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5/OpenCode
- **Used for:** Implementing the facade boundary hardening, focused smoke coverage, and PR preparation.