### PR TITLE
Test public Codebox API boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test:php-tool-policy-normalization": "php scripts/php-tool-policy-normalization-smoke.php",
     "test:php-browser-callback-contracts": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-browser-callback-contracts-smoke.php",
     "test:php-agents-api-adapter-contract": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-agents-api-adapter-contract-smoke.php",
+    "test:php-public-api-facade": "php scripts/php-public-api-facade-smoke.php",
     "test:php-runtime-task-runner": "php -d zend.assertions=1 -d assert.exception=1 scripts/php-runtime-task-runner-smoke.php",
     "test:php-browser-contained-site-contract": "php scripts/php-browser-contained-site-contract-smoke.php",
     "test:php-artifact-import-idempotency": "php scripts/php-artifact-import-idempotency-smoke.php",

--- a/scripts/agent-runtime-ability-tools-smoke.ts
+++ b/scripts/agent-runtime-ability-tools-smoke.ts
@@ -10,7 +10,7 @@ const source = [
 const requiredSnippets = [
   "function wp_codebox_browser_runtime_ability_tool_declarations",
   "function wp_codebox_browser_runtime_resolve_ability_tools",
-  "add_filter( \\'agents_api_resolved_tools\\'",
+  "WP_Codebox_Agents_API_Adapter::legacy_resolved_tools_filter()",
   "apply_filters( \\'wp_codebox_browser_runtime_ability_tools\\'",
   "$task_input[\\'ability_tools\\']",
   "array_merge( $sandbox_tool_ids, $ability_tool_ids )",

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -136,6 +136,7 @@ export const smokeGroups = {
       tsxSmoke("agent-runtime-ability-tools-smoke"),
       tsxSmoke("agent-terminal-result-contract-smoke"),
       tsxSmoke("agent-sandbox-incomplete-scope-smoke"),
+      phpSmoke("php-public-api-facade-smoke"),
       tsxSmoke("recipe-run-summary-smoke"),
       tsxSmoke("fanout-contract-smoke"),
       phpSmoke("php-agents-api-execution-targets-smoke"),


### PR DESCRIPTION
## Summary
- Wire the existing PHP public facade smoke into package scripts.
- Include the public facade smoke in the agent smoke manifest so the default smoke path covers the public Codebox API boundary.
- Update the ability-tools smoke to assert the new Codebox-owned Agents API adapter boundary instead of literal upstream hook names.

## Verification
- `php scripts/php-public-api-facade-smoke.php`
- `php -d zend.assertions=1 -d assert.exception=1 scripts/php-agents-api-adapter-contract-smoke.php`
- `php scripts/php-agents-api-execution-targets-smoke.php`
- `npm run test:php-public-api-facade`
- `npm run smoke -- --command=php-public-api-facade-smoke`
- `npm exec -- tsx scripts/agent-runtime-ability-tools-smoke.ts`

## Blockers / notes
- `npm run smoke -- --group=agent` timed out after 300 seconds on `agent-runtime-signal-smoke` during rerun; the newly wired public facade smoke and updated ability-tools smoke pass individually.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting existing worktrees, wiring public API boundary smoke coverage, updating a stale smoke assertion, running verification, and preparing this PR.