### PR TITLE
Decouple runtime task execution providers

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php
@@ -18,45 +18,20 @@ final class WP_Codebox_Runtime_Task_Runner {
 			return $this->public_error( 'wp_codebox_runtime_task_request_invalid', 'Runtime task requests require a task.', 400 );
 		}
 
-		$upstream = $this->execute_upstream_runtime_task( $input );
-		if ( ! is_wp_error( $upstream ) ) {
-			return $this->result_envelope( $input, $upstream, 'runtime-task' );
+		foreach ( $this->runtime_task_providers( $input ) as $provider ) {
+			if ( ! $this->provider_matches( $provider, $input ) ) {
+				continue;
+			}
+
+			$result = $this->execute_provider( $provider, $input );
+			if ( is_wp_error( $result ) ) {
+				return $this->public_error_from_private_error( $result );
+			}
+
+			return $this->result_envelope( $input, $result, $this->provider_id( $provider ) );
 		}
 
-		if ( 'wp_codebox_runtime_task_upstream_unavailable' !== $upstream->get_error_code() ) {
-			return $this->public_error( 'wp_codebox_runtime_task_failed', 'Runtime task execution failed.', $this->error_status( $upstream, 500 ) );
-		}
-
-		$fallback = $this->execute_codebox_runtime_task( $input );
-		if ( is_wp_error( $fallback ) ) {
-			return $this->public_error( 'wp_codebox_runtime_task_unavailable', 'Runtime task execution is unavailable.', $this->error_status( $fallback, 501 ) );
-		}
-
-		return $this->result_envelope( $input, $fallback, 'wp-codebox-runtime' );
-	}
-
-	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed>|WP_Error */
-	private function execute_upstream_runtime_task( array $input ): array|WP_Error {
-		$ability_name = $this->upstream_runtime_task_ability_name();
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			return new WP_Error( 'wp_codebox_runtime_task_upstream_unavailable', 'Runtime task ability registry unavailable.', array( 'status' => 501 ) );
-		}
-
-		$ability = wp_get_ability( $ability_name );
-		if ( ! $ability || ! method_exists( $ability, 'execute' ) ) {
-			return new WP_Error( 'wp_codebox_runtime_task_upstream_unavailable', 'Runtime task ability unavailable.', array( 'status' => 501 ) );
-		}
-
-		$result = $ability->execute( $this->upstream_request( $input ) );
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		if ( ! is_array( $result ) ) {
-			return new WP_Error( 'wp_codebox_runtime_task_invalid_result', 'Runtime task ability returned an invalid result.', array( 'status' => 502 ) );
-		}
-
-		return $result;
+		return $this->public_error( 'wp_codebox_runtime_task_unavailable', 'Runtime task execution is unavailable.', 501 );
 	}
 
 	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed>|WP_Error */
@@ -71,18 +46,60 @@ final class WP_Codebox_Runtime_Task_Runner {
 		return WP_Codebox_Abilities::run_agent_task( $task_input );
 	}
 
-	private function upstream_runtime_task_ability_name(): string {
-		return 'data' . 'machine/run-runtime-task';
-	}
+	/** @param array<string,mixed> $input Runtime task request. @return array<int,array<string,mixed>> */
+	private function runtime_task_providers( array $input ): array {
+		$providers = array(
+			array(
+				'id'       => 'wp-codebox-runtime',
+				'callback' => fn( array $request ): array|WP_Error => $this->execute_codebox_runtime_task( $request ),
+			),
+		);
 
-	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed> */
-	private function upstream_request( array $input ): array {
-		$request = $input;
-		if ( isset( $request['schema'] ) ) {
-			$request['schema'] = 'data' . 'machine/runtime-task-request/v1';
+		if ( function_exists( 'apply_filters' ) ) {
+			$providers = apply_filters( 'wp_codebox_runtime_task_providers', $providers, $input );
 		}
 
-		return $request;
+		if ( ! is_array( $providers ) ) {
+			return array();
+		}
+
+		return array_values( array_filter( $providers, 'is_array' ) );
+	}
+
+	/** @param array<string,mixed> $provider Runtime task provider. @param array<string,mixed> $input Runtime task request. */
+	private function provider_matches( array $provider, array $input ): bool {
+		$matches = $provider['matches'] ?? null;
+		if ( is_callable( $matches ) ) {
+			return true === $matches( $input );
+		}
+
+		return true;
+	}
+
+	/** @param array<string,mixed> $provider Runtime task provider. @param array<string,mixed> $input Runtime task request. @return array<string,mixed>|WP_Error */
+	private function execute_provider( array $provider, array $input ): array|WP_Error {
+		$callback = $provider['callback'] ?? null;
+		if ( ! is_callable( $callback ) ) {
+			return new WP_Error( 'wp_codebox_runtime_task_provider_invalid', 'Runtime task provider is invalid.', array( 'status' => 500 ) );
+		}
+
+		$result = $callback( $input, $provider );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( ! is_array( $result ) ) {
+			return new WP_Error( 'wp_codebox_runtime_task_provider_invalid_result', 'Runtime task provider returned an invalid result.', array( 'status' => 502 ) );
+		}
+
+		return $result;
+	}
+
+	/** @param array<string,mixed> $provider Runtime task provider. */
+	private function provider_id( array $provider ): string {
+		$id = trim( (string) ( $provider['id'] ?? '' ) );
+
+		return '' === $id ? 'runtime-task-provider' : $id;
 	}
 
 	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed> */
@@ -122,6 +139,7 @@ final class WP_Codebox_Runtime_Task_Runner {
 	/** @param array<string,mixed> $input Runtime task request. @param array<string,mixed> $result Runtime result. @return array<string,mixed> */
 	private function result_envelope( array $input, array $result, string $execution ): array {
 		$success = true === ( $result['success'] ?? true ) && ! in_array( (string) ( $result['status'] ?? '' ), array( 'failed', 'error' ), true );
+		$public  = is_array( $result['public'] ?? null ) ? $result['public'] : $result;
 
 		return array_filter(
 			array(
@@ -130,12 +148,12 @@ final class WP_Codebox_Runtime_Task_Runner {
 				'status'        => (string) ( $result['status'] ?? ( $success ? 'completed' : 'failed' ) ),
 				'execution'     => $execution,
 				'task'          => $input['task'] ?? null,
-				'result'        => $this->sanitize_public_value( $result ),
-				'events'        => is_array( $result['events'] ?? null ) ? $this->sanitize_public_value( $result['events'] ) : array(),
-				'artifacts'     => $this->sanitize_public_value( $result['artifacts'] ?? null ),
-				'run'           => is_array( $result['run'] ?? null ) ? $this->sanitize_public_value( $result['run'] ) : array(),
+				'result'        => $public,
+				'events'        => is_array( $public['events'] ?? null ) ? $public['events'] : array(),
+				'artifacts'     => $public['artifacts'] ?? null,
+				'run'           => is_array( $public['run'] ?? null ) ? $public['run'] : array(),
 				'metadata'      => is_array( $input['metadata'] ?? null ) ? $input['metadata'] : array(),
-				'upstream_refs' => $this->upstream_refs( $result ),
+				'upstream_refs' => $this->upstream_refs( $public ),
 			),
 			static fn( mixed $value ): bool => null !== $value && '' !== $value && array() !== $value
 		);
@@ -165,6 +183,17 @@ final class WP_Codebox_Runtime_Task_Runner {
 		);
 	}
 
+	private function public_error_from_private_error( WP_Error $error ): WP_Error {
+		$data   = $error->get_error_data();
+		$public = is_array( $data ) && is_array( $data['public'] ?? null ) ? $data['public'] : array();
+
+		return $this->public_error(
+			(string) ( $public['code'] ?? 'wp_codebox_runtime_task_failed' ),
+			(string) ( $public['message'] ?? 'Runtime task execution failed.' ),
+			(int) ( $public['status'] ?? $this->error_status( $error, 500 ) )
+		);
+	}
+
 	private function error_status( WP_Error $error, int $default ): int {
 		$data = $error->get_error_data();
 		if ( is_array( $data ) && isset( $data['status'] ) ) {
@@ -174,23 +203,4 @@ final class WP_Codebox_Runtime_Task_Runner {
 		return $default;
 	}
 
-	private function sanitize_public_value( mixed $value ): mixed {
-		if ( is_array( $value ) ) {
-			$sanitized = array();
-			foreach ( $value as $key => $item ) {
-				$sanitized[ $key ] = $this->sanitize_public_value( $item );
-			}
-
-			return $sanitized;
-		}
-
-		if ( is_string( $value ) ) {
-			$normalized_value = preg_replace( '/\s+/', '', strtolower( $value ) ) ?? '';
-			if ( str_contains( $normalized_value, 'data' . 'machine' ) ) {
-				return 'internal-runtime';
-			}
-		}
-
-		return $value;
-	}
 }

--- a/scripts/php-runtime-task-runner-smoke.php
+++ b/scripts/php-runtime-task-runner-smoke.php
@@ -3,14 +3,33 @@ declare(strict_types=1);
 
 define( 'ABSPATH', __DIR__ );
 
-$GLOBALS['wp_codebox_test_abilities'] = array();
+$GLOBALS['wp_codebox_test_filters'] = array();
 
 function is_wp_error( mixed $value ): bool {
 	return $value instanceof WP_Error;
 }
 
-function wp_get_ability( string $name ): ?WP_Ability {
-	return $GLOBALS['wp_codebox_test_abilities'][ $name ] ?? null;
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['wp_codebox_test_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function remove_all_filters( string $hook ): void {
+	unset( $GLOBALS['wp_codebox_test_filters'][ $hook ] );
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	if ( empty( $GLOBALS['wp_codebox_test_filters'][ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $GLOBALS['wp_codebox_test_filters'][ $hook ] );
+	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] as $callbacks ) {
+		foreach ( $callbacks as [ $callback, $accepted_args ] ) {
+			$value = $callback( ...array_slice( array_merge( array( $value ), $args ), 0, $accepted_args ) );
+		}
+	}
+
+	return $value;
 }
 
 final class WP_Error {
@@ -18,15 +37,6 @@ final class WP_Error {
 	public function get_error_code(): string { return $this->code; }
 	public function get_error_message(): string { return $this->message; }
 	public function get_error_data(): array { return $this->data; }
-}
-
-final class WP_Ability {
-	/** @param callable(array<string,mixed>):mixed $callback */
-	public function __construct( private $callback ) {}
-	/** @param array<string,mixed> $input */
-	public function execute( array $input ): mixed {
-		return ( $this->callback )( $input );
-	}
 }
 
 final class WP_Codebox_Abilities {
@@ -66,30 +76,50 @@ $missing_task = $runner->run( array( 'schema' => 'wp-codebox/runtime-task-reques
 assert_same_contract( true, is_wp_error( $missing_task ), 'missing task returns error' );
 assert_same_contract( 'wp-codebox/runtime-task-error/v1', $missing_task->get_error_data()['schema'] ?? null, 'missing task error schema' );
 
-$GLOBALS['wp_codebox_test_abilities']['datamachine/run-runtime-task'] = new WP_Ability(
-	static function ( array $input ): array {
-		return array(
-			'success' => true,
-			'schema'  => 'datamachine/runtime-task-result/v1',
-			'status'  => 'completed',
-			'run_id'  => 'run-1',
-			'echo'    => $input,
+add_filter(
+	'wp_codebox_runtime_task_providers',
+	static function ( array $providers ): array {
+		array_unshift(
+			$providers,
+			array(
+				'id'       => 'example-runtime',
+				'matches'  => static fn( array $input ): bool => 'example-runtime' === ( $input['target_id'] ?? '' ),
+				'callback' => static function ( array $input ): array {
+					return array(
+						'success' => true,
+						'status'  => 'completed',
+						'public'  => array(
+							'run_id' => 'run-1',
+							'echo'   => $input,
+						),
+						'private' => array(
+							'token' => 'secret-token',
+						),
+					);
+				},
+			)
 		);
-	}
+
+		return $providers;
+	},
+	10,
+	1
 );
 
-$upstream = $runner->run(
+$provided = $runner->run(
 	array(
-		'schema' => 'wp-codebox/runtime-task-request/v1',
-		'task'   => 'Ship it',
+		'schema'    => 'wp-codebox/runtime-task-request/v1',
+		'task'      => 'Ship it',
+		'target_id' => 'example-runtime',
 	)
 );
-assert_same_contract( 'wp-codebox/runtime-task-result/v1', $upstream['schema'] ?? null, 'upstream result schema' );
-assert_same_contract( 'runtime-task', $upstream['execution'] ?? null, 'upstream execution label' );
-assert_same_contract( 'internal-runtime', $upstream['result']['schema'] ?? null, 'upstream schema sanitized' );
-assert_same_contract( 'run-1', $upstream['upstream_refs']['run_id'] ?? null, 'upstream run id preserved' );
+assert_same_contract( 'wp-codebox/runtime-task-result/v1', $provided['schema'] ?? null, 'provider result schema' );
+assert_same_contract( 'example-runtime', $provided['execution'] ?? null, 'provider execution label' );
+assert_same_contract( 'wp-codebox/runtime-task-request/v1', $provided['result']['echo']['schema'] ?? null, 'provider receives public schema unchanged' );
+assert_same_contract( 'run-1', $provided['upstream_refs']['run_id'] ?? null, 'provider run id preserved' );
+assert_same_contract( false, str_contains( json_encode( $provided ), 'secret-token' ), 'private provider result omitted' );
 
-$GLOBALS['wp_codebox_test_abilities'] = array();
+remove_all_filters( 'wp_codebox_runtime_task_providers' );
 $fallback = $runner->run(
 	array(
 		'schema'    => 'wp-codebox/runtime-task-request/v1',
@@ -101,8 +131,28 @@ assert_same_contract( 'wp-codebox/runtime-task-result/v1', $fallback['schema'] ?
 assert_same_contract( 'wp-codebox-runtime', $fallback['execution'] ?? null, 'fallback execution label' );
 assert_same_contract( 'wp-codebox/browser-task-contract/v1', $fallback['result']['schema'] ?? null, 'fallback uses browser target' );
 
-$GLOBALS['wp_codebox_test_abilities']['datamachine/run-runtime-task'] = new WP_Ability(
-	static fn( array $input ): WP_Error => new WP_Error( 'datamachine_failure', 'datamachine blew up', array( 'status' => 502, 'ability' => 'datamachine/run-runtime-task' ) )
+add_filter(
+	'wp_codebox_runtime_task_providers',
+	static fn( array $providers ): array => array(
+		array(
+			'id'       => 'example-runtime',
+			'callback' => static fn( array $input ): WP_Error => new WP_Error(
+				'private_runtime_failure',
+				'private runtime blew up',
+				array(
+					'status'  => 502,
+					'private' => array( 'adapter' => 'secret-adapter' ),
+					'public'  => array(
+						'code'    => 'wp_codebox_runtime_task_failed_publicly',
+						'message' => 'The selected runtime failed.',
+						'status'  => 503,
+					),
+				)
+			),
+		),
+	),
+	10,
+	1
 );
 $failed = $runner->run(
 	array(
@@ -110,9 +160,10 @@ $failed = $runner->run(
 		'task'   => 'Fail safely',
 	)
 );
-assert_same_contract( true, is_wp_error( $failed ), 'upstream failure is public error' );
-assert_same_contract( 'wp_codebox_runtime_task_failed', $failed->get_error_code(), 'public error code' );
-assert_same_contract( 'Runtime task execution failed.', $failed->get_error_message(), 'public error message' );
-assert_same_contract( false, str_contains( json_encode( $failed->get_error_data() ), 'datamachine' ), 'public error data sanitized' );
+assert_same_contract( true, is_wp_error( $failed ), 'provider failure is public error' );
+assert_same_contract( 'wp_codebox_runtime_task_failed_publicly', $failed->get_error_code(), 'provider public error code' );
+assert_same_contract( 'The selected runtime failed.', $failed->get_error_message(), 'provider public error message' );
+assert_same_contract( 503, $failed->get_error_data()['status'] ?? null, 'provider public error status' );
+assert_same_contract( false, str_contains( json_encode( $failed ), 'secret-adapter' ), 'private provider error omitted' );
 
 fwrite( STDOUT, "PHP runtime task runner smoke passed\n" );


### PR DESCRIPTION
## Summary
- Replace the runtime task runner hard-coded upstream adapter call with a neutral `wp_codebox_runtime_task_providers` registry filter.
- Keep Codebox core generic by shipping only the built-in Codebox runtime provider fallback.
- Add public/private result and error handling so provider internals stay out of public task responses.
- Update the focused PHP smoke test to use a fake provider and verify provider selection, schema pass-through, private data isolation, public error mapping, and fallback behavior.

## Tests
- `npm run test:php-runtime-task-runner`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php`
- `php -l scripts/php-runtime-task-runner-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the runtime task runner, implementing the provider registry contract, updating focused behavior tests, and preparing this PR description.