### PR TITLE
Expose agent runtime execution primitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "test:command-agent-run": "tsx tests/command-agent-run.test.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
     "test:php-host-run-result-normalizer": "php scripts/php-host-run-result-normalizer-smoke.php",
+    "test:php-agent-runtime-execution": "php scripts/php-agent-runtime-execution-smoke.php",
     "test:php-json-codec": "tsx tests/php-json-codec.test.ts",
     "test:php-managed-host-command": "tsx tests/php-managed-host-command.test.ts",
     "test:php-worker-runner": "tsx tests/php-worker-runner.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -64,18 +64,59 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public function run( array $input ): array|WP_Error {
+		return $this->run_runtime_execution( $input );
+	}
+
+	/**
+	 * Prepare, execute, and normalize a host-side Codebox runtime execution.
+	 *
+	 * This is the public PHP contract for callers that need the same behavior as
+	 * the host agent task ability without shelling out to `wp-codebox recipe-run`.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function run_runtime_execution( array $input ): array|WP_Error {
 		if ( ! $this->process_runner->shell_available() ) {
 			return new WP_Error( 'wp_codebox_shell_unavailable', 'Shell execution is not available for WP Codebox.', array( 'status' => 500 ) );
 		}
 
-		$prepared = $this->prepare_agent_task_run( $input );
+		$prepared = $this->prepare_runtime_execution( $input );
 		if ( is_wp_error( $prepared ) ) {
 			return $prepared;
 		}
 
-		$result = $this->process_runner->run_command( (string) $prepared['command'], $prepared['process_secret_env'], (int) $prepared['timeout_seconds'] );
+		return $this->run_prepared_runtime_execution( $prepared );
+	}
 
-		return $this->complete_agent_task_run( $prepared, $result );
+	/**
+	 * Execute and normalize a previously prepared Codebox runtime execution.
+	 *
+	 * @param array<string,mixed> $prepared Prepared runtime execution from prepare_runtime_execution().
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function run_prepared_runtime_execution( array $prepared ): array|WP_Error {
+		if ( ! $this->process_runner->shell_available() ) {
+			return new WP_Error( 'wp_codebox_shell_unavailable', 'Shell execution is not available for WP Codebox.', array( 'status' => 500 ) );
+		}
+
+		$result = $this->execute_runtime( $prepared );
+
+		return $this->normalize_runtime_result( $prepared, $result );
+	}
+
+	/**
+	 * Execute a prepared Codebox runtime command.
+	 *
+	 * @param array<string,mixed> $prepared Prepared runtime execution from prepare_runtime_execution().
+	 * @return array<string,mixed>
+	 */
+	public function execute_runtime( array $prepared ): array {
+		return $this->process_runner->run_command(
+			(string) ( $prepared['command'] ?? '' ),
+			is_array( $prepared['process_secret_env'] ?? null ) ? $prepared['process_secret_env'] : array(),
+			(int) ( $prepared['timeout_seconds'] ?? 0 )
+		);
 	}
 
 	/**
@@ -116,7 +157,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$worker_id      = (string) $worker['id'];
 			$worker_path    = $paths['workers'] . DIRECTORY_SEPARATOR . $worker_id;
 			$worker_input   = $this->fanout_worker_input( $input, $worker, $parent_session_id, $worker_path );
-			$worker_prepare = $this->prepare_agent_task_run( $worker_input );
+			$worker_prepare = $this->prepare_runtime_execution( $worker_input );
 			if ( is_wp_error( $worker_prepare ) ) {
 				$prepared_workers[] = array(
 					'id'         => $worker_id,
@@ -197,7 +238,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
-	private function prepare_agent_task_run( array $input ): array|WP_Error {
+	public function prepare_runtime_execution( array $input ): array|WP_Error {
 		$input = $this->normalize_parent_task_request( $input );
 		if ( is_wp_error( $input ) ) {
 			return $input;
@@ -274,7 +315,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 	}
 
 	/** @param array<string,mixed> $prepared Prepared run. @param array<string,mixed> $result Command result. @return array<string,mixed>|WP_Error */
-	private function complete_agent_task_run( array $prepared, array $result ): array|WP_Error {
+	public function normalize_runtime_result( array $prepared, array $result ): array|WP_Error {
 		return $this->run_result_normalizer->normalize(
 			$prepared,
 			$result,
@@ -564,7 +605,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 				$result = $captured['result'];
 
-				$completed = $this->complete_agent_task_run( $worker['prepared'], $result );
+				$completed = $this->normalize_runtime_result( $worker['prepared'], $result );
 				$runs[ (int) $worker['index'] ] = is_wp_error( $completed ) ? $this->result_builder->fanout_worker_error_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) ) : $this->result_builder->fanout_worker_success_result( $worker, $completed, (float) $worker['started_at'], microtime( true ) );
 				$this->write_json_file( (string) $worker['path'] . DIRECTORY_SEPARATOR . 'result.json', $runs[ (int) $worker['index'] ] );
 				$this->append_fanout_event( $fanout_path, array( 'event' => true === ( $runs[ (int) $worker['index'] ]['success'] ?? false ) ? 'worker.completed' : 'worker.failed', 'worker_id' => (string) $worker['id'], 'status' => (string) $runs[ (int) $worker['index'] ]['status'] ) );

--- a/scripts/php-agent-runtime-execution-smoke.php
+++ b/scripts/php-agent-runtime-execution-smoke.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	private string $code;
+	private string $message;
+	private mixed $data;
+
+	public function __construct( string $code, string $message, mixed $data = null ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code(): string {
+		return $this->code;
+	}
+
+	public function get_error_message(): string {
+		return $this->message;
+	}
+
+	public function get_error_data(): mixed {
+		return $this->data;
+	}
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function wp_json_encode( mixed $value, int $flags = 0 ): string|false {
+	return json_encode( $value, $flags );
+}
+
+function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+	unset( $hook_name, $args );
+	return $value;
+}
+
+function smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+$root = dirname( __DIR__ ) . '/packages/wordpress-plugin/src/';
+foreach ( array(
+	'class-wp-codebox-task-input-contract.php',
+	'class-wp-codebox-agent-workload.php',
+	'class-wp-codebox-runtime-tool-policy-descriptor.php',
+	'class-wp-codebox-sandbox-tool-policy-normalizer.php',
+	'class-wp-codebox-path-policy.php',
+	'class-wp-codebox-agent-task.php',
+	'class-wp-codebox-provider-credentials.php',
+	'class-wp-codebox-runtime-dependency-plan.php',
+	'class-wp-codebox-runtime-profile-resolver.php',
+	'class-wp-codebox-runtime-recipe-resolver.php',
+	'class-wp-codebox-browser-task-builder.php',
+	'class-wp-codebox-connector-credential-resolvers.php',
+	'class-wp-codebox-inheritance.php',
+	'class-wp-codebox-redaction-policy.php',
+	'class-wp-codebox-host-request-normalizer.php',
+	'class-wp-codebox-host-tool-policy-validator.php',
+	'class-wp-codebox-host-preview-args-builder.php',
+	'class-wp-codebox-host-runtime-config-builder.php',
+	'class-wp-codebox-agent-runtime-config-resolver.php',
+	'class-wp-codebox-host-recipe-builder.php',
+	'class-wp-codebox-status-taxonomy.php',
+	'class-wp-codebox-host-run-result-normalizer.php',
+	'class-wp-codebox-parent-site-seed-exporter.php',
+	'class-wp-codebox-json.php',
+	'class-wp-codebox-run-plan.php',
+	'class-wp-codebox-fanout-aggregation.php',
+	'class-wp-codebox-agent-process-runner.php',
+	'class-wp-codebox-agent-run-result-builder.php',
+	'class-wp-codebox-agent-outcome-classifier.php',
+	'class-wp-codebox-agent-sandbox-runner.php',
+) as $file ) {
+	require_once $root . $file;
+}
+
+$prepared_base = array(
+	'input'              => array( 'goal' => 'Test task', 'provider' => 'test-provider', 'model' => 'test-model' ),
+	'task_input'         => array( 'goal' => 'Test task' ),
+	'task'               => 'Test task',
+	'session_id'         => 'session-1',
+	'paths'              => array(),
+	'artifacts'          => '/tmp/wp-codebox-artifacts',
+	'wp_version'         => 'latest',
+	'command'            => 'wp-codebox recipe-run --recipe /tmp/recipe.json --json',
+	'process_secret_env' => array(),
+	'timeout_seconds'    => 1,
+	'recipe_file'        => '',
+	'cleanup_paths'      => array(),
+);
+
+$cases = array(
+	'success'      => array(
+		'command_result' => array(
+			'exit_code' => 0,
+			'output'    => '{"agentResult":{"summary":"Changed one file","changedFiles":{"count":1},"patch":{"bytes":10}},"agentTaskResult":{"status":"succeeded"}}',
+		),
+		'assert'         => static function ( array $result ): void {
+			smoke_assert( true === $result['success'], 'success contract succeeds' );
+			smoke_assert( 'succeeded' === $result['agent_task_run_result']['status'], 'success canonical result status is succeeded' );
+		},
+	),
+	'non_zero'     => array(
+		'command_result' => array( 'exit_code' => 2, 'output' => '{"agentResult":{}}' ),
+		'assert'         => static function ( array $result ): void {
+			smoke_assert( false === $result['success'], 'non-zero contract fails' );
+			smoke_assert( 'non_zero_exit' === $result['error']['failure_classification'], 'non-zero classification is preserved' );
+		},
+	),
+	'timeout'      => array(
+		'command_result' => array( 'exit_code' => 124, 'output' => '', 'timed_out' => true, 'timeout_seconds' => 1 ),
+		'assert'         => static function ( array $result ): void {
+			smoke_assert( false === $result['success'], 'timeout contract fails' );
+			smoke_assert( 'timeout' === $result['agent_task_status'], 'timeout maps to agent task timeout' );
+		},
+	),
+	'invalid_json' => array(
+		'command_result' => array( 'exit_code' => 0, 'output' => 'not-json' ),
+		'assert'         => static function ( array $result ): void {
+			smoke_assert( false === $result['success'], 'invalid JSON contract fails' );
+			smoke_assert( 'invalid_json' === $result['error']['failure_classification'], 'invalid JSON classification is preserved' );
+		},
+	),
+);
+
+foreach ( $cases as $name => $case ) {
+	$runner = new WP_Codebox_Agent_Sandbox_Runner(
+		array(
+			'shell_available' => static fn(): bool => true,
+			'command_runner'  => static function ( string $command, array $secret_env, int $timeout_seconds ) use ( $case, $prepared_base ): array {
+				smoke_assert( $prepared_base['command'] === $command, 'prepared command is passed to command runner' );
+				smoke_assert( array() === $secret_env, 'prepared secret env is passed to command runner' );
+				smoke_assert( 1 === $timeout_seconds, 'prepared timeout is passed to command runner' );
+				return $case['command_result'];
+			},
+		)
+	);
+
+	$result = $runner->run_prepared_runtime_execution( $prepared_base );
+	smoke_assert( is_array( $result ) && ! is_wp_error( $result ), $name . ' returns result envelope' );
+	$case['assert']( $result );
+}
+
+echo "agent runtime execution smoke passed\n";


### PR DESCRIPTION
## Summary
- Exposes the host agent sandbox runner's prepare -> execute -> normalize phases as public PHP methods.
- Keeps the existing run() path as an adapter over the new runtime execution contract.
- Adds a PHP smoke test covering success, non-zero exit, timeout, and invalid JSON through the public prepared execution contract.

## Tests
- npm run test:php-agent-runtime-execution
- npm run test:php-host-run-result-normalizer
- php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
- php -l scripts/php-agent-runtime-execution-smoke.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, focused PHP smoke coverage, and PR drafting.