### PR TITLE
Clarify runner workspace backend API boundary

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -66,7 +66,10 @@ The stable public surface is grouped by lifecycle area rather than by product:
   `runWordPressEpisodeActions()` from `@automattic/wp-codebox-playground/public`
   instead of composing core runtime internals directly.
 - **Runner workspace:** workspace policy, preload artifact, source-root
-  preparation, mount primitive, and runner workspace publication contracts.
+  preparation, mount primitive, runner workspace publication contracts, and the
+  backend adapter config shape named by `RUNNER_WORKSPACE_BACKEND_FILTER`,
+  `RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS`, and
+  `RunnerWorkspaceBackendConfig`.
 - **Tool bridge:** host tool registry, managed host command, host command
   executor, sandbox tool policy, and tool-call artifact contracts.
 - **Browser task and contained site:** browser interaction, callback, probe,
@@ -134,6 +137,14 @@ Runtime package callers use `wp-codebox/run-runtime-package` or
 `wp-codebox/runtime-package-output-projection/v1`. These contracts are generic
 Codebox runtime/package shapes and do not require consumers to know backend
 ability ids.
+
+Runner workspace backends are installed by integration code and discovered via
+the `wp_codebox_runner_workspace_backend` filter. The stable backend config is
+`RunnerWorkspaceBackendConfig`: an optional backend `id`, an optional
+`workspace_root_constant`, and an `abilities` map keyed by
+`RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS`. Public callers still use the Codebox
+ability ids and request/result schemas; backend ability names stay behind this
+adapter config and are not part of the consumer-facing surface.
 
 ## Internal Entry Point
 

--- a/packages/runtime-core/src/runner-workspace-publication.ts
+++ b/packages/runtime-core/src/runner-workspace-publication.ts
@@ -6,6 +6,26 @@ export const RUNNER_WORKSPACE_CAPTURE_REQUEST_SCHEMA = "wp-codebox/runner-worksp
 export const RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA = "wp-codebox/runner-workspace-capture-result/v1" as const
 export const RUNNER_WORKSPACE_COMMAND_REQUEST_SCHEMA = "wp-codebox/runner-workspace-command-request/v1" as const
 export const RUNNER_WORKSPACE_COMMAND_RESULT_SCHEMA = "wp-codebox/runner-workspace-command-result/v1" as const
+export const RUNNER_WORKSPACE_BACKEND_FILTER = "wp_codebox_runner_workspace_backend" as const
+
+export const RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS = [
+  "workspace_adopt",
+  "workspace_show",
+  "workspace_clone",
+  "workspace_worktree_add",
+  "workspace_git_status",
+  "workspace_git_diff",
+  "run_runner_workspace_command",
+  "publish_runner_workspace",
+] as const
+
+export type RunnerWorkspaceBackendAbilityKey = typeof RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS[number]
+
+export interface RunnerWorkspaceBackendConfig {
+  id?: string
+  workspace_root_constant?: string
+  abilities: Partial<Record<RunnerWorkspaceBackendAbilityKey, string>>
+}
 
 export type RunnerWorkspacePublicationRequest = {
   schema?: typeof RUNNER_WORKSPACE_PUBLICATION_REQUEST_SCHEMA

--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -7,6 +7,8 @@ import { BROWSER_CONTAINED_SITE_OPEN_SCHEMA, BROWSER_CONTAINED_SITE_STATUS_SCHEM
 import {
   RUNNER_WORKSPACE_CAPTURE_REQUEST_SCHEMA,
   RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA,
+  RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS,
+  RUNNER_WORKSPACE_BACKEND_FILTER,
   RUNNER_WORKSPACE_COMMAND_REQUEST_SCHEMA,
   RUNNER_WORKSPACE_COMMAND_RESULT_SCHEMA,
   RUNNER_WORKSPACE_PREPARE_REQUEST_SCHEMA,
@@ -71,6 +73,10 @@ export interface RuntimeContractManifest {
     runRuntimePackage: typeof CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY
   }
   providerRuntime: ProviderRuntimeInvocationContract
+  runnerWorkspaceBackend: {
+    filter: typeof RUNNER_WORKSPACE_BACKEND_FILTER
+    abilityKeys: typeof RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS
+  }
 }
 
 export function runtimeContractManifest(): RuntimeContractManifest {
@@ -82,6 +88,10 @@ export function runtimeContractManifest(): RuntimeContractManifest {
       runRuntimePackage: CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY,
     },
     providerRuntime: providerRuntimeInvocationContract(),
+    runnerWorkspaceBackend: {
+      filter: RUNNER_WORKSPACE_BACKEND_FILTER,
+      abilityKeys: RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS,
+    },
   }
 }
 

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -8,6 +8,8 @@ import {
   normalizeBrowserRunResult,
   runtimePackageExecutionInput,
   persistedBrowserArtifactRefs,
+  RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS,
+  RUNNER_WORKSPACE_BACKEND_FILTER,
 } from "../packages/runtime-core/src/public.js"
 
 const root = new URL("..", import.meta.url)
@@ -60,6 +62,7 @@ assert.deepEqual(exportKeys(playgroundPackage), [".", "./public"])
 
 const docs = await readFile(new URL("docs/public-api-contract.md", root), "utf8")
 const publicBarrel = await readFile(new URL("packages/runtime-core/src/public.ts", root), "utf8")
+const runnerWorkspaceAdapter = await readFile(new URL("packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php", root), "utf8")
 
 for (const publicEntry of [
   "@automattic/wp-codebox-core",
@@ -121,6 +124,9 @@ assert.match(docs, /## Integration Boundary/)
 assert.match(docs, /Codebox may adapt those upstream systems into\s+generic Codebox inputs internally/)
 assert.match(docs, /Data Machine must not parse, validate, or emit\s+WP Codebox-specific schemas as a compatibility requirement/)
 assert.match(docs, /Codebox adapter translates from generic\s+Data Machine inputs into the Codebox task\/recipe\/runtime contracts/)
+assert.match(docs, /RUNNER_WORKSPACE_BACKEND_FILTER/)
+assert.match(docs, /RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS/)
+assert.match(docs, /RunnerWorkspaceBackendConfig/)
 
 assert.equal(typeof normalizeBrowserRunResult, "function")
 assert.equal(typeof browserRunResultEnvelope, "function")
@@ -129,5 +135,11 @@ assert.equal(typeof persistedBrowserArtifactRefs, "function")
 assert.equal(typeof artifactBundleFileManifest, "function")
 assert.equal(typeof buildRuntimePackageRunRecipe, "function")
 assert.equal(typeof runtimePackageExecutionInput, "function")
+assert.equal(RUNNER_WORKSPACE_BACKEND_FILTER, "wp_codebox_runner_workspace_backend")
+assert.ok(RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS.includes("publish_runner_workspace"))
+assert.match(runnerWorkspaceAdapter, new RegExp(escapeRegExp(RUNNER_WORKSPACE_BACKEND_FILTER)))
+for (const key of RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS) {
+  assert.match(runnerWorkspaceAdapter, new RegExp(escapeRegExp(key)), `PHP adapter must recognize backend ability key ${key}`)
+}
 
 console.log("public API contract ok")

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -18,6 +18,8 @@ import {
   RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA,
   RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA,
   RUNTIME_PROFILE_SCHEMA,
+  RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS,
+  RUNNER_WORKSPACE_BACKEND_FILTER,
   RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA,
   RUNNER_WORKSPACE_COMMAND_RESULT_SCHEMA,
   RUNNER_WORKSPACE_PREPARE_RESULT_SCHEMA,
@@ -36,6 +38,10 @@ assert.equal(manifest.version, 1)
 assert.deepEqual(manifest.schemas, RUNTIME_CONTRACT_SCHEMAS)
 assert.deepEqual(manifest.abilities, { runRuntimePackage: CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY })
 assert.deepEqual(manifest.providerRuntime, providerRuntimeInvocationContract())
+assert.deepEqual(manifest.runnerWorkspaceBackend, {
+  filter: RUNNER_WORKSPACE_BACKEND_FILTER,
+  abilityKeys: RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS,
+})
 
 assert.equal(manifest.schemas.providerRuntime.invocation, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
 assert.equal(manifest.schemas.providerRuntime.credentialRequirements, PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA)
@@ -52,6 +58,17 @@ assert.equal(manifest.schemas.runnerWorkspace.prepareResult, RUNNER_WORKSPACE_PR
 assert.equal(manifest.schemas.runnerWorkspace.captureResult, RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA)
 assert.equal(manifest.schemas.runnerWorkspace.commandResult, RUNNER_WORKSPACE_COMMAND_RESULT_SCHEMA)
 assert.equal(manifest.schemas.runnerWorkspace.publicationResult, RUNNER_WORKSPACE_PUBLICATION_RESULT_SCHEMA)
+assert.equal(RUNNER_WORKSPACE_BACKEND_FILTER, "wp_codebox_runner_workspace_backend")
+assert.deepEqual(RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS, [
+  "workspace_adopt",
+  "workspace_show",
+  "workspace_clone",
+  "workspace_worktree_add",
+  "workspace_git_status",
+  "workspace_git_diff",
+  "run_runner_workspace_command",
+  "publish_runner_workspace",
+])
 assert.equal(manifest.schemas.fanoutAggregation.input, FANOUT_AGGREGATION_INPUT_SCHEMA)
 assert.equal(manifest.schemas.fanoutAggregation.output, FANOUT_AGGREGATION_OUTPUT_SCHEMA)
 


### PR DESCRIPTION
## Summary
- Export stable runner workspace backend filter and ability-key contract values from runtime core.
- Include the backend adapter contract in the runtime contract manifest.
- Document the backend adapter config boundary and pin docs/PHP adapter alignment in tests.

## Verification
- npm run test:public-api-contract
- npm run test:runtime-contract-manifest
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented contract docs/types/tests and opened this PR.