### PR TITLE
Make browser readiness task-aware

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -72,6 +72,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'playground'            => self::merge_defaults( is_array( $spec['playground'] ?? null ) ? $spec['playground'] : array(), $playground_defaults ),
 				'runtime_profile'       => is_array( $spec['runtime_profile'] ?? null ) ? $spec['runtime_profile'] : ( is_array( $spec['runtimeProfile'] ?? null ) ? $spec['runtimeProfile'] : array() ),
 				'runtime'               => is_array( $spec['runtime'] ?? null ) ? $spec['runtime'] : array(),
+				'runtime_requirements'  => self::runtime_requirements( is_array( $spec['runtime_requirements'] ?? null ) ? $spec['runtime_requirements'] : ( is_array( $spec['runtimeRequirements'] ?? null ) ? $spec['runtimeRequirements'] : array() ) ),
 				'browser_runner'        => self::merge_defaults( is_array( $spec['browser_runner'] ?? null ) ? $spec['browser_runner'] : array(), $browser_runner ),
 				'artifact_files'        => is_array( $artifact_contract['files'] ?? null ) ? $artifact_contract['files'] : ( is_array( $spec['artifact_files'] ?? null ) ? $spec['artifact_files'] : array() ),
 				'callback_refs'         => is_array( $spec['callback_refs'] ?? null ) ? $spec['callback_refs'] : array(),
@@ -375,6 +376,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'diagnostics'  => self::object_list( $profile['diagnostics'] ?? array() ),
 				'provenance'   => is_array( $profile['provenance'] ?? null ) ? self::compact_public_value( $profile['provenance'] ) : array(),
 				'metadata'     => is_array( $profile['metadata'] ?? null ) ? self::compact_public_value( $profile['metadata'] ) : array(),
+				'runtime_requirements' => self::runtime_requirements( is_array( $profile['runtime_requirements'] ?? null ) ? $profile['runtime_requirements'] : ( is_array( $profile['runtimeRequirements'] ?? null ) ? $profile['runtimeRequirements'] : array() ) ),
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
 		);
@@ -419,8 +421,26 @@ final class WP_Codebox_Browser_Task_Builder {
 		$input['runtime_config_mounts'] = array_merge( self::object_list( $profile['runtime_config_mounts'] ?? array() ), is_array( $input['runtime_config_mounts'] ?? null ) ? $input['runtime_config_mounts'] : array() );
 		$input['runtime_env']         = array_merge( self::string_map( is_array( $profile['env'] ?? null ) ? $profile['env'] : array() ), is_array( $input['runtime_env'] ?? null ) ? $input['runtime_env'] : array() );
 		$input['provider_plugin_paths'] = array_values( array_unique( array_merge( self::provider_plugin_paths_from_specs( $profile['provider_plugins'] ?? array() ), self::string_list_any( $input['provider_plugin_paths'] ?? array() ) ) ) );
+		$runtime_requirements = self::runtime_requirements( array_merge( is_array( $profile['runtime_requirements'] ?? null ) ? $profile['runtime_requirements'] : array(), is_array( $input['runtime_requirements'] ?? null ) ? $input['runtime_requirements'] : array() ) );
+		if ( ! empty( $runtime_requirements ) ) {
+			$input['runtime_requirements'] = $runtime_requirements;
+		} else {
+			unset( $input['runtime_requirements'] );
+		}
 
 		return function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_apply_runtime_profile', $input, $profile ) : $input;
+	}
+
+	/** @param array<string,mixed> $requirements Runtime requirement contract input. @return array<string,mixed> */
+	public static function runtime_requirements( array $requirements ): array {
+		if ( array_key_exists( 'requires_provider', $requirements ) || array_key_exists( 'requiresProvider', $requirements ) ) {
+			return array(
+				'schema'            => 'wp-codebox/runtime-requirements/v1',
+				'requires_provider' => (bool) ( $requirements['requires_provider'] ?? $requirements['requiresProvider'] ),
+			);
+		}
+
+		return array();
 	}
 
 	/** @param array<string,mixed> $prepared Prepared runtime descriptor. @param array<string,mixed> $session Optional source session. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php
@@ -340,6 +340,7 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 				'capabilities' => self::public_capabilities( $resolved ),
 				'components'   => $components,
 				'readiness'    => is_array( $resolved['profile']['readiness'] ?? null ) ? $resolved['profile']['readiness'] : array(),
+				'runtime_requirements' => is_array( $resolved['profile']['runtime_requirements'] ?? null ) ? $resolved['profile']['runtime_requirements'] : array(),
 				'diagnostics'  => is_array( $resolved['profile']['diagnostics'] ?? null ) ? $resolved['profile']['diagnostics'] : array(),
 				'provenance'   => is_array( $resolved['profile']['provenance'] ?? null ) ? $resolved['profile']['provenance'] : array(),
 			),
@@ -479,7 +480,7 @@ final class WP_Codebox_Runtime_Profile_Resolver {
 		}
 		$base['capabilities'] = self::merge_string_lists( $base['capabilities'] ?? array(), $extra['capabilities'] ?? array() );
 
-		foreach ( array( 'env', 'metadata', 'readiness', 'provenance' ) as $field ) {
+		foreach ( array( 'env', 'metadata', 'readiness', 'provenance', 'runtime_requirements' ) as $field ) {
 			$base[ $field ] = array_merge( is_array( $base[ $field ] ?? null ) ? $base[ $field ] : array(), is_array( $extra[ $field ] ?? null ) ? $extra[ $field ] : array() );
 		}
 

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1702,9 +1702,11 @@ private static function browser_ready_to_code_signal( array $input, array $runti
 	$inherit      = is_array( $input['inherit'] ?? null ) ? $input['inherit'] : array();
 	$connectors   = array_values( array_filter( array_map( 'strval', is_array( $inherit['connectors'] ?? null ) ? $inherit['connectors'] : array() ) ) );
 	$secret_env   = array_values( array_filter( array_map( 'strval', is_array( $input['secret_env'] ?? null ) ? $input['secret_env'] : array() ) ) );
+	$runtime_requirements = self::browser_runtime_requirements( $input, array( 'connectors' => array(), 'settings' => array() ) );
+	$requires_provider    = (bool) ( $runtime_requirements['requires_provider'] ?? false );
 	$requirements = array(
-		'provider_plugin'   => ! empty( $provider_plugin_paths ) && self::all_paths_ready( $provider_plugin_paths ),
-		'provider_secret'   => ! empty( $connectors ) || ! empty( $secret_env ),
+		'provider_plugin'   => ! $requires_provider || empty( $provider_plugin_paths ) || self::all_paths_ready( $provider_plugin_paths ),
+		'provider_secret'   => ! $requires_provider || ! empty( $connectors ) || ! empty( $secret_env ),
 		'runtime_dependencies' => true,
 	);
 	foreach ( self::browser_ready_to_code_component_requirements( $input, $runtime ) as $name => $ready ) {
@@ -1729,8 +1731,9 @@ private static function browser_ready_to_code_signal( array $input, array $runti
 		'message'      => $emitted ? 'Browser Playground sandbox is ready to code.' : 'Browser Playground sandbox is not ready to code.',
 		'requirements' => $requirements,
 		'requirement_metadata' => array(
-		'runtime_dependencies' => self::browser_runtime_readiness_metadata( $runtime ),
-		'components'           => self::browser_runtime_component_readiness_metadata( $input, $runtime ),
+			'runtime_requirements'  => $runtime_requirements,
+			'runtime_dependencies' => self::browser_runtime_readiness_metadata( $runtime ),
+			'components'           => self::browser_runtime_component_readiness_metadata( $input, $runtime ),
 		),
 		'missing'      => $missing,
 	);

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php
@@ -32,16 +32,6 @@ private static function browser_inheritance_resolution_payload( array $input ): 
 
 /** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed>|WP_Error */
 private static function browser_input_with_inheritance( array $input, array $inheritance ): array|WP_Error {
-	$provider_credentials = self::browser_provider_credentials( $input, $inheritance );
-	if ( is_wp_error( $provider_credentials ) ) {
-		return $provider_credentials;
-	}
-
-	$input['provider_plugin_paths'] = array_values( array_unique( array_merge( self::browser_provider_plugin_paths( $input ), self::browser_inheritance_provider_plugin_paths( $inheritance ) ) ) );
-	$input['secret_env']            = array_values( array_unique( array_merge( self::browser_secret_env_names( $input ), self::browser_inheritance_secret_env_names( $inheritance ), self::string_list( $provider_credentials['secret_env'] ?? array() ) ) ) );
-	if ( ! empty( $provider_credentials ) ) {
-		$input['_wp_codebox_provider_credentials'] = $provider_credentials;
-	}
 	if ( class_exists( 'WP_Codebox_Runtime_Profile_Resolver' ) ) {
 		$resolved = WP_Codebox_Runtime_Profile_Resolver::apply_to_input( $input, $inheritance );
 		if ( is_wp_error( $resolved ) ) {
@@ -49,6 +39,21 @@ private static function browser_input_with_inheritance( array $input, array $inh
 		}
 
 		$input = WP_Codebox_Browser_Task_Builder::apply_runtime_profile( $resolved );
+	}
+
+	$input['runtime_requirements'] = self::browser_runtime_requirements( $input, $inheritance );
+	$provider_credentials = array();
+	if ( self::browser_requires_provider( $input, $inheritance ) ) {
+		$provider_credentials = self::browser_provider_credentials( $input, $inheritance );
+		if ( is_wp_error( $provider_credentials ) ) {
+			return $provider_credentials;
+		}
+	}
+
+	$input['provider_plugin_paths'] = array_values( array_unique( array_merge( self::browser_provider_plugin_paths( $input ), self::browser_inheritance_provider_plugin_paths( $inheritance ) ) ) );
+	$input['secret_env']            = array_values( array_unique( array_merge( self::browser_secret_env_names( $input ), self::browser_inheritance_secret_env_names( $inheritance ), self::string_list( $provider_credentials['secret_env'] ?? array() ) ) ) );
+	if ( ! empty( $provider_credentials ) ) {
+		$input['_wp_codebox_provider_credentials'] = $provider_credentials;
 	}
 
 	if ( class_exists( 'WP_Codebox_Runtime_Recipe_Resolver' ) ) {
@@ -61,6 +66,38 @@ private static function browser_input_with_inheritance( array $input, array $inh
 	}
 
 	return $input;
+}
+
+/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed> */
+private static function browser_runtime_requirements( array $input, array $inheritance ): array {
+	$requirements = is_array( $input['runtime_requirements'] ?? null ) ? WP_Codebox_Browser_Task_Builder::runtime_requirements( $input['runtime_requirements'] ) : array();
+	if ( array_key_exists( 'requires_provider', $requirements ) ) {
+		return $requirements;
+	}
+
+	return array(
+		'schema'            => 'wp-codebox/runtime-requirements/v1',
+		'requires_provider' => self::browser_has_provider_inputs( $input, $inheritance ),
+	);
+}
+
+/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
+private static function browser_requires_provider( array $input, array $inheritance ): bool {
+	$requirements = self::browser_runtime_requirements( $input, $inheritance );
+	return (bool) ( $requirements['requires_provider'] ?? false );
+}
+
+/** @param array<string,mixed> $input Ability input. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance */
+private static function browser_has_provider_inputs( array $input, array $inheritance ): bool {
+	$runtime_profile = is_array( $input['runtime_profile'] ?? null ) ? $input['runtime_profile'] : array();
+	return '' !== trim( (string) ( $input['provider'] ?? '' ) )
+		|| '' !== trim( (string) ( $input['model'] ?? '' ) )
+		|| ! empty( $runtime_profile['provider_plugins'] ?? array() )
+		|| ! empty( array_filter( self::string_list( $runtime_profile['capabilities'] ?? array() ), static fn( string $capability ): bool => str_starts_with( $capability, 'provider.' ) ) )
+		|| ! empty( self::browser_provider_plugin_paths( $input ) )
+		|| ! empty( self::browser_inheritance_provider_plugin_paths( $inheritance ) )
+		|| ! empty( self::browser_secret_env_names( $input ) )
+		|| ! empty( self::browser_inheritance_secret_env_names( $inheritance ) );
 }
 
 /** @param array<string,mixed> $input Ability input. @param array<string,mixed> $task_input Normalized task input. @param array<int,array<string,mixed>> $artifacts Browser artifact specs. @param array{connectors:array<int,array<string,mixed>>,settings:array<int,array<string,mixed>>} $inheritance @return array<string,mixed> */

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -11,6 +11,9 @@ class WP_Error {
 function is_wp_error( $value ) { return $value instanceof WP_Error; }
 function wp_json_encode( $value, $flags = 0 ) { return json_encode( $value, $flags ); }
 function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', (string) $value ) ); }
+class WP_Codebox_Agents_API_Adapter {
+	public static function default_chat_ability(): string { return 'agents/chat'; }
+}
 $GLOBALS['wp_codebox_test_transients'] = array();
 function get_transient( $key ) { return $GLOBALS['wp_codebox_test_transients'][ $key ] ?? false; }
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php`)};
@@ -267,6 +270,7 @@ assert.equal(result.local_task.component_contracts[0].slug, "profile-component")
 assert.equal(result.local_task.runtime_overlays[0].slug, "profile-overlay")
 assert.deepEqual(result.local_task.provider_plugin_paths, ["/profile/provider", "/existing/provider"])
 assert.deepEqual(result.local_task.runtime_env, { PROFILE_ENV: "1", EXISTING: "1" })
+assert.equal(result.local_task.runtime_requirements, undefined)
 assert.deepEqual(result.local_task.placement.allowed_targets, ["browser"])
 assert.deepEqual(result.local_task.placement.required_capabilities, ["wordpress.playground", "browser.preview", "artifact.website-bundle"])
 assert.equal(result.local_task.browser_runner.invocation.name, "agents/chat")
@@ -327,5 +331,46 @@ assert.equal(result.recipe_dto.browser.runner_contract.php_footer.type, "generat
 assert.equal(JSON.stringify(result.recipe_dto).includes("must-not-leak"), false)
 assert.equal(JSON.stringify(result.recipe_dto).includes("code="), false)
 assert.equal(JSON.stringify(result.recipe_dto).includes("php_prelude\":\""), false)
+
+const readiness = await runPhpJson<any>(`
+define('ABSPATH', ${rootPath});
+class WP_Error {
+	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+}
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+function wp_json_encode( $value, $flags = 0 ) { return json_encode( $value, $flags ); }
+function apply_filters( $hook, $value, ...$args ) { return $value; }
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-agent-task.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-inheritance.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-blueprint.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`)};
+class WP_Codebox_Readiness_Test_Abilities {
+	use WP_Codebox_Abilities_Inheritance;
+	use WP_Codebox_Abilities_Browser_Runtime;
+	use WP_Codebox_Abilities_Browser_Blueprint;
+	use WP_Codebox_Abilities_Execution;
+}
+$method = new ReflectionMethod( WP_Codebox_Readiness_Test_Abilities::class, 'browser_ready_to_code_signal' );
+$generic = $method->invoke( null, array(
+	'goal' => 'Materialize a static artifact.',
+	'runtime_requirements' => array( 'requires_provider' => false ),
+), array( 'plugins' => array(), 'components' => array() ) );
+$provider = $method->invoke( null, array(
+	'goal' => 'Run an AI coding agent.',
+	'runtime_requirements' => array( 'requires_provider' => true ),
+), array( 'plugins' => array(), 'components' => array() ) );
+echo json_encode( array( 'generic' => $generic, 'provider' => $provider ), JSON_UNESCAPED_SLASHES );
+`)
+
+assert.equal(readiness.generic.emitted, true)
+assert.equal(readiness.generic.requirement_metadata.runtime_requirements.requires_provider, false)
+assert.equal(readiness.generic.requirements.provider_plugin, true)
+assert.equal(readiness.generic.requirements.provider_secret, true)
+assert.deepEqual(readiness.generic.missing, [])
+assert.equal(readiness.provider.emitted, false)
+assert.deepEqual(readiness.provider.missing, ["provider_secret"])
 
 console.log("browser task builder ok")

--- a/tests/runtime-profile-resolver.test.ts
+++ b/tests/runtime-profile-resolver.test.ts
@@ -26,6 +26,9 @@ class WP_Error {
 }
 function is_wp_error( $value ) { return $value instanceof WP_Error; }
 function wp_json_encode( $value, $flags = 0 ) { return json_encode( $value, $flags ); }
+class WP_Codebox_Agents_API_Adapter {
+	public static function default_chat_ability(): string { return 'agents/chat'; }
+}
 function apply_filters( $hook, $value, ...$args ) {
 	if ( 'wp_codebox_runtime_profile_registry' === $hook ) {
 		$value['content-runtime'] = array(


### PR DESCRIPTION
## Summary
- Add a neutral runtime_requirements contract with requires_provider for browser runtime inputs/profiles.
- Derive provider requirements from task/runtime inputs and skip provider credential resolution when a task does not require a provider.
- Make ready_to_code provider plugin/secret checks conditional so generic materialization/headless/non-AI tasks can be ready without AI provider inputs.
- Cover generic no-provider readiness and runtime profile behavior in focused tests.

## Tests
- npm run test:browser-task-builder
- npm run test:runtime-profile-resolver

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating readiness/provider coupling, implementing the runtime requirements contract, adding focused tests, and preparing this PR.