### PR TITLE
Clarify public runtime contract boundary

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -11,12 +11,12 @@ sandbox.
 Use these package entrypoints from external integrations:
 
 - `@automattic/wp-codebox-core`: runtime, task/package, runner workspace, tool
-  bridge, browser task/contained-site, artifact metadata, recipe, policy, and
-  provider contract types and helpers.
+  bridge, parent tool bridge, browser task/contained-site, artifact metadata,
+  recipe, policy, and provider contract types and helpers.
 - `@automattic/wp-codebox-core/public`: curated public facade for runtime,
-  task/package, runner workspace, tool bridge, browser, artifact, recipe,
-  policy, and provider contract types and helpers. New external TypeScript
-  consumers should prefer this facade over the broad root barrel.
+  task/package, runner workspace, tool bridge, parent tool bridge, browser,
+  artifact, recipe, policy, and provider contract types and helpers. New external TypeScript consumers should prefer
+  this facade over the broad root barrel.
 - `@automattic/wp-codebox-core/contracts`: command catalog and inspectable
   contract metadata used by CLI and orchestrator consumers.
 - `@automattic/wp-codebox-core/artifacts`: artifact verification, apply adapter,
@@ -72,6 +72,11 @@ The stable public surface is grouped by lifecycle area rather than by product:
   `RunnerWorkspaceBackendConfig`.
 - **Tool bridge:** host tool registry, managed host command, host command
   executor, sandbox tool policy, and tool-call artifact contracts.
+- **Parent tool bridge:** `wp-codebox/parent-tool-bridge/v1`,
+  `wp-codebox/parent-tool-request/v1`, and `wp-codebox/parent-tool-result/v1`
+  describe allowlisted calls from a sandbox to a host dispatcher. Codebox owns
+  the envelope and authorization shape; host adapters own endpoint, command, and
+  product payload validation.
 - **Browser task and contained site:** browser interaction, callback, probe,
   review bridge, session origin, artifact lifecycle, result shape, and runtime
   boundary contracts.
@@ -137,6 +142,13 @@ Runtime package callers use `wp-codebox/run-runtime-package` or
 `wp-codebox/runtime-package-output-projection/v1`. These contracts are generic
 Codebox runtime/package shapes and do not require consumers to know backend
 ability ids.
+
+Agent task callers use the `wp-codebox/run-agent-task` ability or
+`wp-codebox agent-task-run --json`. Caller-facing results normalize to
+`wp-codebox/agent-task-run-result/v1` through `normalizeAgentTaskRunResult()`.
+Artifact handoff, import, and materialization results normalize to
+`wp-codebox/artifact-result-envelope/v1` through `artifactResultEnvelope()` and
+`normalizeArtifactResultEnvelope()`.
 
 Runner workspace backends are installed by integration code and discovered via
 the `wp_codebox_runner_workspace_backend` filter. The stable backend config is

--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -1,6 +1,7 @@
 import { AGENT_TASK_RUN_RESULT_SCHEMA, normalizeAgentTaskRunResult, type AgentTaskRunResultSummary } from "./agent-task-run-result.js"
 import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, normalizeArtifactResultEnvelope, type ArtifactResultEnvelope } from "./artifact-result-envelope.js"
 import { FANOUT_AGGREGATION_INPUT_SCHEMA, FANOUT_AGGREGATION_OUTPUT_SCHEMA, aggregateFanoutOutputs, normalizeFanoutAggregationInput, type FanoutAggregationInput, type FanoutAggregationInputRequest, type FanoutAggregationOutput } from "./fanout-aggregation.js"
+import { PARENT_TOOL_BRIDGE_SCHEMA, PARENT_TOOL_REQUEST_SCHEMA, PARENT_TOOL_RESULT_SCHEMA } from "./parent-tool-bridge.js"
 import { PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA, PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA, PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA, providerRuntimeInvocationContract, type ProviderRuntimeInvocationContract } from "./provider-runtime-contracts.js"
 import { CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY, RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA, RUNTIME_PACKAGE_EXECUTION_INPUT_SCHEMA, RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA, RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA } from "./runtime-package-execution.js"
 import { BROWSER_CONTAINED_SITE_OPEN_SCHEMA, BROWSER_CONTAINED_SITE_STATUS_SCHEMA, BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA, BROWSER_SESSION_PRODUCT_DTO_SCHEMA, PREVIEW_LEASE_SCHEMA, RUNTIME_PROFILE_SCHEMA, runtimeProfile, type RuntimeProfile } from "./runtime-boundary-contracts.js"
@@ -55,6 +56,11 @@ export const RUNTIME_CONTRACT_SCHEMAS = {
     commandResult: RUNNER_WORKSPACE_COMMAND_RESULT_SCHEMA,
     publicationRequest: RUNNER_WORKSPACE_PUBLICATION_REQUEST_SCHEMA,
     publicationResult: RUNNER_WORKSPACE_PUBLICATION_RESULT_SCHEMA,
+  },
+  parentToolBridge: {
+    bridge: PARENT_TOOL_BRIDGE_SCHEMA,
+    request: PARENT_TOOL_REQUEST_SCHEMA,
+    result: PARENT_TOOL_RESULT_SCHEMA,
   },
   fanoutAggregation: {
     input: FANOUT_AGGREGATION_INPUT_SCHEMA,

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -2,12 +2,21 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 import {
   artifactBundleFileManifest,
+  artifactResultEnvelope,
   buildRuntimePackageRunRecipe,
   browserArtifactPersistenceProjection,
   browserRunResultEnvelope,
+  normalizeAgentTaskRunResult,
+  normalizeArtifactResultEnvelope,
   normalizeBrowserRunResult,
+  parentToolBridgeContract,
   runtimePackageExecutionInput,
+  runtimeProfile,
   persistedBrowserArtifactRefs,
+  AGENT_TASK_RUN_RESULT_SCHEMA,
+  ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+  PARENT_TOOL_BRIDGE_SCHEMA,
+  RUNTIME_PROFILE_SCHEMA,
   RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS,
   RUNNER_WORKSPACE_BACKEND_FILTER,
 } from "../packages/runtime-core/src/public.js"
@@ -85,6 +94,7 @@ for (const contractArea of [
   "Runtime task/package",
   "Runner workspace",
   "Tool bridge",
+  "Parent tool bridge",
   "Browser task and contained site",
   "Browser SDK",
   "Browser metrics",
@@ -96,9 +106,12 @@ for (const contractArea of [
 
 for (const publicModule of [
   "./agent-runtime-workload.js",
+  "./agent-task-run-result.js",
   "./artifact-result-envelope.js",
   "./browser-callback-contracts.js",
+  "./parent-tool-bridge.js",
   "./recipe-builders.js",
+  "./runtime-boundary-contracts.js",
   "./runtime-contracts.js",
   "./runtime-episode.js",
   "./runtime-package-execution.js",
@@ -133,8 +146,18 @@ assert.equal(typeof browserRunResultEnvelope, "function")
 assert.equal(typeof browserArtifactPersistenceProjection, "function")
 assert.equal(typeof persistedBrowserArtifactRefs, "function")
 assert.equal(typeof artifactBundleFileManifest, "function")
+assert.equal(typeof normalizeAgentTaskRunResult, "function")
+assert.equal(typeof artifactResultEnvelope, "function")
+assert.equal(typeof normalizeArtifactResultEnvelope, "function")
+assert.equal(typeof runtimeProfile, "function")
+assert.equal(typeof parentToolBridgeContract, "function")
 assert.equal(typeof buildRuntimePackageRunRecipe, "function")
 assert.equal(typeof runtimePackageExecutionInput, "function")
+assert.equal(normalizeAgentTaskRunResult({ status: "completed", success: true }).schema, AGENT_TASK_RUN_RESULT_SCHEMA)
+assert.equal(artifactResultEnvelope({ operation: "agent-task-run" }).schema, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
+assert.equal(normalizeArtifactResultEnvelope({ success: true }).schema, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
+assert.equal(runtimeProfile({ schema: RUNTIME_PROFILE_SCHEMA, components: [] }).schema, RUNTIME_PROFILE_SCHEMA)
+assert.equal(parentToolBridgeContract({ allowedTools: ["workspace.read"], dispatcher: { mode: "host_command", command: { argv: ["dispatch"] } } }).schema, PARENT_TOOL_BRIDGE_SCHEMA)
 assert.equal(RUNNER_WORKSPACE_BACKEND_FILTER, "wp_codebox_runner_workspace_backend")
 assert.ok(RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS.includes("publish_runner_workspace"))
 assert.match(runnerWorkspaceAdapter, new RegExp(escapeRegExp(RUNNER_WORKSPACE_BACKEND_FILTER)))

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -6,6 +6,9 @@ import {
   CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY,
   FANOUT_AGGREGATION_INPUT_SCHEMA,
   FANOUT_AGGREGATION_OUTPUT_SCHEMA,
+  PARENT_TOOL_BRIDGE_SCHEMA,
+  PARENT_TOOL_REQUEST_SCHEMA,
+  PARENT_TOOL_RESULT_SCHEMA,
   PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA,
   PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA,
   PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA,
@@ -58,6 +61,9 @@ assert.equal(manifest.schemas.runnerWorkspace.prepareResult, RUNNER_WORKSPACE_PR
 assert.equal(manifest.schemas.runnerWorkspace.captureResult, RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA)
 assert.equal(manifest.schemas.runnerWorkspace.commandResult, RUNNER_WORKSPACE_COMMAND_RESULT_SCHEMA)
 assert.equal(manifest.schemas.runnerWorkspace.publicationResult, RUNNER_WORKSPACE_PUBLICATION_RESULT_SCHEMA)
+assert.equal(manifest.schemas.parentToolBridge.bridge, PARENT_TOOL_BRIDGE_SCHEMA)
+assert.equal(manifest.schemas.parentToolBridge.request, PARENT_TOOL_REQUEST_SCHEMA)
+assert.equal(manifest.schemas.parentToolBridge.result, PARENT_TOOL_RESULT_SCHEMA)
 assert.equal(RUNNER_WORKSPACE_BACKEND_FILTER, "wp_codebox_runner_workspace_backend")
 assert.deepEqual(RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS, [
   "workspace_adopt",


### PR DESCRIPTION
## Summary
- Add parent-tool bridge schemas to the inspectable runtime contract manifest.
- Document parent-tool bridge and caller-facing agent task/artifact result envelopes in the public API boundary.
- Strengthen public boundary tests for exported agent task result, artifact envelope, runtime profile, and parent tool bridge helpers.

## Tests
- `npm run test:public-api-contract`
- `npm run test:runtime-contract-manifest`
- `npx tsx tests/parent-tool-bridge-contract.test.ts`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting existing public contract surfaces, implementing the manifest/docs/test updates, and running targeted verification.