### PR TITLE
Support bench recipe evidence steps

### DIFF
--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -51,6 +51,8 @@ export interface WordPressBenchRecipeOptions {
   scenarioIds?: string[]
   lifecycle?: JsonObject
   resetPolicy?: JsonObject
+  prepareSteps?: WorkspaceRecipeStep[]
+  postSteps?: WorkspaceRecipeStep[]
 }
 
 export function normalizeRecipeMounts(mounts: readonly WorkspaceRecipeMount[] = [], options: NormalizeRecipeMountsOptions = {}): WorkspaceRecipeMount[] {
@@ -128,6 +130,7 @@ export function buildWordPressBenchRecipe(options: WordPressBenchRecipeOptions):
       mounts: normalizeRecipeMounts(options.mounts, { defaultMode: "readonly" }),
     },
     workflow: {
+      ...(options.prepareSteps && options.prepareSteps.length > 0 ? { before: normalizeRecipeSteps(options.prepareSteps, "prepareSteps") } : {}),
       steps: [{
         command: "wordpress.bench",
         args: [
@@ -143,7 +146,7 @@ export function buildWordPressBenchRecipe(options: WordPressBenchRecipeOptions):
           commandJsonArg("lifecycle-json", options.lifecycle ?? {}),
           commandJsonArg("reset-policy-json", options.resetPolicy ?? {}),
         ],
-      }],
+      }, ...normalizeRecipeSteps(options.postSteps ?? [], "postSteps")],
     },
   }
 }

--- a/packages/runtime-playground/src/browser-metrics.ts
+++ b/packages/runtime-playground/src/browser-metrics.ts
@@ -25,7 +25,7 @@ export interface BrowserArtifactMetricsResult {
   bundleDirectory: string
   hasBrowserMetrics: boolean
   metrics: Record<string, number>
-  artifacts: Record<string, { path: string; kind: "json" | "jsonl" }>
+  artifacts: Record<string, { path: string; kind: "html" | "json" | "jsonl" | "png" }>
 }
 
 export function browserProbeMemorySummary(checkpoints: BrowserProbeCheckpointRecord[]): BrowserProbeMemorySummary {
@@ -405,6 +405,8 @@ export async function browserArtifactMetrics(bundleDirectory: string): Promise<B
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "memory", "memory.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "performance", "performance.json", "json")
   await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "checkpoints", "checkpoints.jsonl", "jsonl")
+  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "html", "snapshot.html", "html")
+  await addBrowserArtifactIfPresent(artifacts, bundleDirectory, "screenshot", "screenshot.png", "png")
 
   let metrics: Record<string, number> = {}
   for (const summaryPath of summaryPaths) {
@@ -458,7 +460,7 @@ async function browserSummaryArtifactPaths(bundleDirectory: string): Promise<str
   return [...paths]
 }
 
-async function addBrowserArtifactIfPresent(artifacts: BrowserArtifactMetricsResult["artifacts"], bundleDirectory: string, name: string, file: string, kind: "json" | "jsonl"): Promise<void> {
+async function addBrowserArtifactIfPresent(artifacts: BrowserArtifactMetricsResult["artifacts"], bundleDirectory: string, name: string, file: string, kind: "html" | "json" | "jsonl" | "png"): Promise<void> {
   const relativePath = `files/browser/${file}`
   try {
     await access(join(bundleDirectory, relativePath))

--- a/tests/browser-metrics-artifact-refs.test.ts
+++ b/tests/browser-metrics-artifact-refs.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { browserArtifactMetrics } from "../packages/runtime-playground/src/browser-metrics.js"
+
+const bundle = await mkdtemp(join(tmpdir(), "wp-codebox-browser-metrics-"))
+await mkdir(join(bundle, "files", "browser"), { recursive: true })
+await writeFile(join(bundle, "files", "browser", "summary.json"), JSON.stringify({ summary: { metrics: { browser_dom_node_count: 12 } } }))
+await writeFile(join(bundle, "files", "browser", "snapshot.html"), "<!doctype html><title>Fixture</title>")
+await writeFile(join(bundle, "files", "browser", "screenshot.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+
+const result = await browserArtifactMetrics(bundle)
+
+assert.equal(result.metrics.browser_dom_node_count, 12)
+assert.deepEqual(result.artifacts.html, { path: "files/browser/snapshot.html", kind: "html" })
+assert.deepEqual(result.artifacts.screenshot, { path: "files/browser/screenshot.png", kind: "png" })
+
+console.log("browser metrics artifact refs ok")

--- a/tests/recipe-builder-bench-steps.test.ts
+++ b/tests/recipe-builder-bench-steps.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import { buildWordPressBenchRecipe } from "../packages/runtime-core/src/recipe-builders.js"
+
+const recipe = buildWordPressBenchRecipe({
+  pluginSlug: "fixture-plugin",
+  prepareSteps: [{ command: "wordpress.wp-cli", args: ["command=option update fixture_prepare yes"] }],
+  postSteps: [{ command: "wordpress.browser-probe", args: ["url=/", "capture=html,screenshot"] }],
+})
+
+assert.deepEqual(recipe.workflow.before, [
+  { command: "wordpress.wp-cli", args: ["command=option update fixture_prepare yes"] },
+])
+assert.deepEqual(recipe.workflow.steps.map((step) => step.command), [
+  "wordpress.bench",
+  "wordpress.browser-probe",
+])
+assert.deepEqual(recipe.workflow.steps[1], {
+  command: "wordpress.browser-probe",
+  args: ["url=/", "capture=html,screenshot"],
+})
+
+console.log("recipe builder bench steps ok")


### PR DESCRIPTION
## Summary
- Add generic prepareSteps and postSteps support to WordPress bench recipe generation.
- Include browser HTML and screenshot refs in browser metrics artifact output.
- Add focused tests for post-step recipe shape and browser evidence refs.

## Testing
- npm exec tsx tests/recipe-builder-bench-steps.test.ts
- npm exec tsx tests/browser-metrics-artifact-refs.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the generic bench recipe/evidence ref changes and focused tests.