### PR TITLE
Add guarded WordPress runtime ability contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "test:runtime-contract-manifest": "tsx tests/runtime-contract-manifest.test.ts",
     "test:runtime-package-execution": "tsx tests/runtime-package-execution.test.ts",
     "test:public-ability-aliases": "tsx tests/public-ability-aliases.test.ts",
+    "test:wordpress-plugin-public-runtime-abilities": "tsx tests/wordpress-plugin-public-runtime-abilities.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
     "test:distribution-startup-probes": "tsx tests/distribution-startup-probes.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -324,6 +324,34 @@ final class WP_Codebox_Abilities {
 				)
 			);
 
+			wp_register_ability(
+				'wp-codebox/run-wordpress-workload',
+				array(
+					'label'               => 'Run WordPress Workload',
+					'description'         => 'Expose the public wp-codebox/wordpress-workload-run/v1 contract through WordPress abilities. The current plugin implementation is guarded and returns structured unsupported diagnostics instead of accepting raw code execution.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::wordpress_workload_run_request_schema(),
+					'output_schema'       => self::wordpress_workload_run_result_schema(),
+					'execute_callback'    => array( self::class, 'run_wordpress_workload' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-wordpress-workload', 'safe_stub' => true ),
+				)
+			);
+
+			wp_register_ability(
+				'wp-codebox/run-fuzz-suite',
+				array(
+					'label'               => 'Run Fuzz Suite',
+					'description'         => 'Expose the public wp-codebox/fuzz-suite/v1 contract through WordPress abilities. The current plugin implementation is guarded and returns structured unsupported diagnostics instead of accepting raw code execution.',
+					'category'            => 'wp-codebox',
+					'input_schema'        => self::fuzz_suite_request_schema(),
+					'output_schema'       => self::fuzz_suite_result_schema(),
+					'execute_callback'    => array( self::class, 'run_fuzz_suite' ),
+					'permission_callback' => array( self::class, 'can_run_agent_task' ),
+					'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'safe_stub' => true ),
+				)
+			);
+
 			$run_agent_task_batch_ability = array(
 					'label'               => 'Run Agent Sandbox Task Batch',
 					'description'         => 'Run multiple tasks in isolated WP Codebox WordPress agent sandboxes and return artifacts for each run.',

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -34,6 +34,107 @@ public static function run_runtime_task( array $input ): array|WP_Error {
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+public static function run_wordpress_workload( array $input ): array|WP_Error {
+	$unsafe = self::unsafe_execution_fields( $input );
+	if ( ! empty( $unsafe ) ) {
+		return new WP_Error( 'wp_codebox_wordpress_workload_unsafe_input', 'wp-codebox/run-wordpress-workload does not accept raw code execution fields.', array( 'status' => 400, 'unsafe_fields' => $unsafe ) );
+	}
+
+	return self::unsupported_public_runtime_envelope(
+		'wp-codebox/wordpress-workload-run-result/v1',
+		'unsupported',
+		'wp_codebox_wordpress_workload_runner_unavailable',
+		'The WordPress workload ability contract is registered, but no safe workload runner is available in the WordPress plugin yet.',
+		array(
+			'request'   => array(
+				'schema' => (string) ( $input['schema'] ?? 'wp-codebox/wordpress-workload-run/v1' ),
+			),
+			'artifacts' => array(),
+			'metadata'  => array( 'canonical_ability' => 'wp-codebox/run-wordpress-workload' ),
+		)
+	);
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+public static function run_fuzz_suite( array $input ): array|WP_Error {
+	$unsafe = self::unsafe_execution_fields( $input );
+	if ( ! empty( $unsafe ) ) {
+		return new WP_Error( 'wp_codebox_fuzz_suite_unsafe_input', 'wp-codebox/run-fuzz-suite does not accept raw code execution fields.', array( 'status' => 400, 'unsafe_fields' => $unsafe ) );
+	}
+
+	$cases = is_array( $input['cases'] ?? null ) ? $input['cases'] : array();
+	return self::unsupported_public_runtime_envelope(
+		'wp-codebox/fuzz-suite-result/v1',
+		'unsupported',
+		'wp_codebox_fuzz_suite_runner_unavailable',
+		'The fuzz suite ability contract is registered, but no safe fuzz runner is available in the WordPress plugin yet.',
+		array(
+			'suite'        => array_filter(
+				array(
+					'id'      => (string) ( $input['id'] ?? '' ),
+					'version' => (string) ( $input['version'] ?? '' ),
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			),
+			'summary'      => array( 'total' => count( $cases ), 'passed' => 0, 'failed' => 0, 'error' => 0, 'skipped' => count( $cases ) ),
+			'cases'        => array(),
+			'artifactRefs' => array(),
+			'metadata'     => array( 'canonical_ability' => 'wp-codebox/run-fuzz-suite' ),
+		)
+	);
+}
+
+/** @return array<string,mixed> */
+private static function unsupported_public_runtime_envelope( string $schema, string $status, string $code, string $message, array $extra ): array {
+	return array_merge(
+		array(
+			'success'     => false,
+			'schema'      => $schema,
+			'status'      => $status,
+			'diagnostics' => array(
+				array(
+					'code'     => $code,
+					'severity' => 'error',
+					'message'  => $message,
+				),
+			),
+		),
+		$extra
+	);
+}
+
+/** @param array<string,mixed> $input Ability input. @return string[] */
+private static function unsafe_execution_fields( array $input ): array {
+	$unsafe = array();
+	foreach ( array( 'command' ) as $field ) {
+		if ( array_key_exists( $field, $input ) ) {
+			$unsafe[] = $field;
+		}
+	}
+	self::collect_unsafe_execution_fields( $input, '', $unsafe );
+
+	return array_values( array_unique( $unsafe ) );
+}
+
+/** @param mixed $value Input value. @param string $path Current input path. @param string[] $unsafe Unsafe path accumulator. */
+private static function collect_unsafe_execution_fields( mixed $value, string $path, array &$unsafe ): void {
+	if ( ! is_array( $value ) ) {
+		return;
+	}
+
+	foreach ( $value as $key => $entry ) {
+		$field = is_string( $key ) ? $key : (string) $key;
+		$next_path = '' === $path ? $field : $path . '.' . $field;
+		if ( in_array( $field, array( 'code', 'php', 'php_code', 'raw_code', 'eval', 'shell' ), true ) ) {
+			$unsafe[] = $next_path;
+			continue;
+		}
+
+		self::collect_unsafe_execution_fields( $entry, $next_path, $unsafe );
+	}
+}
+
+/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function request_host_delegation( array $input ): array|WP_Error {
 	return self::execute_host_delegation_request( $input );
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -623,6 +623,124 @@ private static function runtime_task_result_schema(): array {
 	);
 }
 
+/** @return array<string,mixed> */
+private static function wordpress_workload_run_request_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'schema', 'steps' ),
+		'properties' => array(
+			'schema'               => array( 'type' => 'string', 'const' => 'wp-codebox/wordpress-workload-run/v1' ),
+			'wordpress_version'    => self::string_property_schema( 'WordPress version requested for the disposable Playground workload.' ),
+			'blueprint'            => self::object_property_schema( 'Optional WordPress Playground blueprint object.' ),
+			'preview'              => self::object_property_schema( 'Optional preview settings for the workload.' ),
+			'mounts'               => self::mount_schema(),
+			'runtime_stack_mounts' => self::object_array_property_schema( 'Runtime stack mounts for the disposable workload.' ),
+			'runtime_overlays'     => self::object_array_property_schema( 'Runtime overlays for the disposable workload.' ),
+			'runtime_env'          => self::object_property_schema( 'Non-secret runtime environment values. Secret values must use secret_env names.' ),
+			'secret_env'           => self::string_array_property_schema( 'Parent environment variable names expected by the workload. Values are never accepted in this payload.' ),
+			'staged_files'         => self::object_array_property_schema( 'Explicit staged file descriptors accepted by the recipe runtime.' ),
+			'before'               => self::wordpress_workload_steps_schema(),
+			'steps'                => self::wordpress_workload_steps_schema(),
+			'after'                => self::wordpress_workload_steps_schema(),
+			'metadata'             => self::object_property_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function wordpress_workload_steps_schema(): array {
+	return array(
+		'type'  => 'array',
+		'items' => array(
+			'type'       => 'object',
+			'required'   => array( 'command' ),
+			'properties' => array(
+				'command'      => array( 'type' => 'string' ),
+				'args'         => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+				'allowFailure' => array( 'type' => 'boolean' ),
+				'advisory'     => array( 'type' => 'boolean' ),
+			),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function wordpress_workload_run_result_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'success'     => array( 'type' => 'boolean' ),
+			'schema'      => array( 'type' => 'string', 'const' => 'wp-codebox/wordpress-workload-run-result/v1' ),
+			'status'      => array( 'type' => 'string', 'enum' => array( 'unsupported' ) ),
+			'request'     => self::object_property_schema(),
+			'artifacts'   => self::object_array_property_schema(),
+			'diagnostics' => self::object_array_property_schema(),
+			'metadata'    => self::object_property_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function fuzz_suite_request_schema(): array {
+	return array(
+		'type'       => 'object',
+		'required'   => array( 'schema', 'id', 'cases' ),
+		'properties' => array(
+			'schema'   => array( 'type' => 'string', 'const' => 'wp-codebox/fuzz-suite/v1' ),
+			'id'       => array( 'type' => 'string' ),
+			'version'  => array( 'type' => 'string' ),
+			'target'   => self::fuzz_suite_target_schema(),
+			'cases'    => array(
+				'type'  => 'array',
+				'items' => array(
+					'type'       => 'object',
+					'required'   => array( 'id' ),
+					'properties' => array(
+						'id'          => array( 'type' => 'string' ),
+						'target'      => self::fuzz_suite_target_schema(),
+						'input'       => array(),
+						'description' => array( 'type' => 'string' ),
+						'metadata'    => self::object_property_schema(),
+					),
+				),
+			),
+			'metadata' => self::object_property_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function fuzz_suite_target_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'kind'       => array( 'type' => 'string', 'enum' => array( 'ability', 'command', 'http', 'rest', 'runtime' ) ),
+			'id'         => array( 'type' => 'string' ),
+			'entrypoint' => array( 'type' => 'string' ),
+			'label'      => array( 'type' => 'string' ),
+			'metadata'   => self::object_property_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function fuzz_suite_result_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'success'      => array( 'type' => 'boolean' ),
+			'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/fuzz-suite-result/v1' ),
+			'status'       => array( 'type' => 'string', 'enum' => array( 'unsupported' ) ),
+			'suite'        => self::object_property_schema(),
+			'summary'      => self::object_property_schema(),
+			'cases'        => self::object_array_property_schema(),
+			'diagnostics'  => self::object_array_property_schema(),
+			'artifactRefs' => self::object_array_property_schema(),
+			'metadata'     => self::object_property_schema(),
+		),
+	);
+}
+
 /**
  * Shared host-side sandbox runner input fields used by task, batch, and fanout abilities.
  *

--- a/tests/wordpress-plugin-public-runtime-abilities.test.ts
+++ b/tests/wordpress-plugin-public-runtime-abilities.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+
+const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-abilities.php", "utf8")
+const schemasPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php", "utf8")
+const executionPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php", "utf8")
+
+for (const ability of ["wp-codebox/run-wordpress-workload", "wp-codebox/run-fuzz-suite"]) {
+  assert.match(abilitiesPhp, new RegExp(`wp_register_ability\\(\\s*'${ability}'`), `${ability} must be registered`)
+  assert.match(abilitiesPhp, new RegExp(`'canonical_ability'\\s*=>\\s*'${ability}'`), `${ability} must mark its canonical id`)
+  assert.match(abilitiesPhp, new RegExp(`'safe_stub'\\s*=>\\s*true`), `${ability} must be guarded until execution is implemented`)
+}
+
+assert.match(schemasPhp, /'const'\s*=>\s*'wp-codebox\/wordpress-workload-run\/v1'/)
+assert.match(schemasPhp, /'const'\s*=>\s*'wp-codebox\/wordpress-workload-run-result\/v1'/)
+assert.match(schemasPhp, /'const'\s*=>\s*'wp-codebox\/fuzz-suite\/v1'/)
+assert.match(schemasPhp, /'const'\s*=>\s*'wp-codebox\/fuzz-suite-result\/v1'/)
+
+assert.match(executionPhp, /function run_wordpress_workload\( array \$input \)/)
+assert.match(executionPhp, /function run_fuzz_suite\( array \$input \)/)
+assert.match(executionPhp, /unsafe_execution_fields/)
+assert.match(executionPhp, /collect_unsafe_execution_fields/)
+assert.match(executionPhp, /'code', 'php', 'php_code', 'raw_code', 'eval', 'shell'/)
+assert.match(executionPhp, /array\( 'command' \)/)
+assert.match(executionPhp, /wp_codebox_wordpress_workload_runner_unavailable/)
+assert.match(executionPhp, /wp_codebox_fuzz_suite_runner_unavailable/)
+
+assert.doesNotMatch(abilitiesPhp + schemasPhp + executionPhp, /WooCommerce|Jetpack|Data Machine/i)
+
+console.log("wordpress plugin public runtime abilities contract ok")


### PR DESCRIPTION
## Summary
- Register public WordPress plugin abilities for `wp-codebox/run-wordpress-workload` and `wp-codebox/run-fuzz-suite`.
- Add versioned input/output schemas for the WordPress workload and fuzz suite contracts.
- Return structured unsupported result envelopes until a safe runner is implemented, while rejecting raw unsafe code execution fields.
- Add a focused contract test for the registered ability surface and guarded behavior.

## Verification
- `npm run test:wordpress-plugin-public-runtime-abilities`
- `npm run test:public-ability-aliases`
- `npm run test:public-api-contract`
- `npm run test:fuzz-run-recipe`
- `npx tsx tests/wordpress-workload-primitives.test.ts`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`
- Direct PHP callback check for unsupported workload envelope and nested unsafe fuzz input rejection

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code inspection, implementation, focused tests, verification, and PR drafting.
