### PR TITLE
Return browser session product DTO by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",
     "test:agent-runtime-workload-normalizers": "tsx tests/agent-runtime-workload-normalizers.test.ts",
     "test:browser-task-builder": "tsx tests/browser-task-builder.test.ts",
+    "test:browser-session-public-dto": "tsx tests/browser-session-public-dto.test.ts",
     "test:browser-contained-site-status": "tsx tests/browser-contained-site-status.test.ts",
     "test:host-recipe-builder": "tsx tests/host-recipe-builder.test.ts",
     "test:runtime-recipe-resolver": "tsx tests/runtime-recipe-resolver.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -194,7 +194,7 @@ final class WP_Codebox_Abilities {
 			$site_seed_schema  = self::site_seed_schema();
 			$inherit_schema    = self::inherit_schema();
 			$session_schema    = self::sandbox_session_schema();
-			$browser_session_schema = self::browser_playground_session_schema();
+			$browser_session_schema = self::browser_product_dto_schema();
 			$session_input     = self::sandbox_session_input_schema();
 			$preview_schema    = self::preview_input_schema();
 			$outcome_schema    = self::remediation_outcome_schema();

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -295,8 +295,10 @@ final class WP_Codebox_Browser_Task_Builder {
 				'provider'         => (string) ( $session['provider'] ?? '' ),
 				'model'            => (string) ( $session['model'] ?? '' ),
 				'preview_boot'     => self::browser_preview_boot_config( $session ),
+				'preview_ref'      => self::browser_preview_ref( $session ),
 				'signals'          => self::compact_public_value( $signals ),
 				'artifacts'        => is_array( $session['artifacts'] ?? null ) ? self::compact_public_value( $session['artifacts'] ) : array(),
+				'artifact_refs'    => self::browser_artifact_refs( $session ),
 				'error'            => is_array( $session['error'] ?? null ) ? self::compact_public_value( $session['error'] ) : array(),
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
@@ -322,6 +324,61 @@ final class WP_Codebox_Browser_Task_Builder {
 	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */
 	public static function safe_browser_session_dto( array $session ): array {
 		return self::product_browser_session_dto( $session );
+	}
+
+	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */
+	public static function browser_preview_ref( array $session ): array {
+		$contained_site = is_array( $session['contained_site'] ?? null ) ? $session['contained_site'] : array();
+		$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
+		$preview_boot = self::browser_preview_boot_config( $session );
+		$preview = is_array( $preview_boot['preview'] ?? null ) ? $preview_boot['preview'] : array();
+
+		return array_filter(
+			array(
+				'schema'     => 'wp-codebox/browser-preview-ref/v1',
+				'id'         => (string) ( $contained_site['preview_id'] ?? '' ),
+				'preview_id' => (string) ( $contained_site['preview_id'] ?? '' ),
+				'session_id' => (string) ( $session_envelope['id'] ?? $session['session_id'] ?? $contained_site['session_id'] ?? '' ),
+				'site_id'    => (string) ( $contained_site['site_id'] ?? '' ),
+				'scope'      => (string) ( $preview_boot['scope'] ?? $contained_site['session_id'] ?? '' ),
+				'url'        => (string) ( $preview['preview_public_url'] ?? $preview['local_url'] ?? '' ),
+				'boot_ref'   => (string) ( $preview_boot['blueprint_ref'] ?? '' ),
+			),
+			static fn( string $value ): bool => '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $session Browser session contract. @return array<int,array<string,mixed>> */
+	public static function browser_artifact_refs( array $session ): array {
+		$artifacts = is_array( $session['artifacts'] ?? null ) ? $session['artifacts'] : array();
+		$files = is_array( $artifacts['files'] ?? null ) ? $artifacts['files'] : array();
+		$refs = array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$path = trim( (string) ( $file['path'] ?? '' ) );
+			$refs[] = array_filter(
+				array(
+					'schema' => 'wp-codebox/browser-artifact-ref/v1',
+					'kind'   => (string) ( $file['kind'] ?? 'browser-artifact' ),
+					'path'   => '' !== $path ? 'files/browser/' . ltrim( $path, '/' ) : '',
+					'digest' => self::browser_artifact_digest_ref( $file['sha256'] ?? null ),
+					'size'   => isset( $file['size'] ) ? (int) $file['size'] : null,
+				),
+				static fn( mixed $value ): bool => null !== $value && '' !== $value && array() !== $value
+			);
+		}
+
+		return array_values( array_filter( $refs ) );
+	}
+
+	private static function browser_artifact_digest_ref( mixed $digest ): array {
+		$value = is_array( $digest ) ? (string) ( $digest['value'] ?? '' ) : (string) $digest;
+		$value = trim( $value );
+
+		return '' !== $value ? array( 'algorithm' => is_array( $digest ) ? (string) ( $digest['algorithm'] ?? 'sha256' ) : 'sha256', 'value' => $value ) : array();
 	}
 
 	/** @param array<string,mixed> $profile Runtime profile input. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -194,7 +194,8 @@ public static function create_browser_playground_session( array $input ): array|
 	}
 	$ready_to_code = self::browser_ready_to_code_signal( $input, $runtime );
 	if ( false === ( $ready_to_code['emitted'] ?? false ) ) {
-		return self::blocked_browser_playground_session( $session_id, $input, $task_input, $ready_to_code, $browser_plugins, $runtime, $artifacts, $playground, $blueprint, $site_blueprint_artifact );
+		$blocked_session = self::blocked_browser_playground_session( $session_id, $input, $task_input, $ready_to_code, $browser_plugins, $runtime, $artifacts, $playground, $blueprint, $site_blueprint_artifact );
+		return self::browser_session_response_for_input( $blocked_session, $input );
 	}
 
 	$task_payload = self::browser_task_payload( $input, $task_input, $session_id, $artifacts, $inheritance_payload['inheritance'], $dependency_plan );
@@ -204,7 +205,7 @@ public static function create_browser_playground_session( array $input ): array|
 	}
 	$materialization = self::browser_materialization_contract( $recipe );
 
-	return array(
+	$session = array(
 		'success'          => true,
 		'schema'           => 'wp-codebox/browser-playground-session/v1',
 		'execution'        => 'browser-playground',
@@ -253,6 +254,8 @@ public static function create_browser_playground_session( array $input ): array|
 			'expected_artifacts' => $task_input['expected_artifacts'],
 		),
 	);
+
+	return self::browser_session_response_for_input( $session, $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
@@ -601,6 +604,7 @@ public static function hydrate_browser_blueprint_ref( array $input ): array|WP_E
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function create_browser_materializer_contract( array $input ): array|WP_Error {
+	$input['include_raw_browser_session'] = true;
 	$session = self::create_browser_playground_session( $input );
 	if ( is_wp_error( $session ) ) {
 		return $session;
@@ -669,6 +673,7 @@ public static function create_browser_task_contract( array $input ): array|WP_Er
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 private static function prepare_browser_task_contract( array $input ): array|WP_Error {
+	$input['include_raw_browser_session'] = true;
 	$primary = self::create_browser_playground_session( $input );
 	if ( is_wp_error( $primary ) ) {
 		return $primary;
@@ -1350,6 +1355,27 @@ private static function blocked_browser_playground_session( string $session_id, 
 			'expected_artifacts' => $task_input['expected_artifacts'],
 		),
 	);
+}
+
+/** @param array<string,mixed> $session Browser session contract. @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+private static function browser_session_response_for_input( array $session, array $input ): array {
+	$product_dto = WP_Codebox_Browser_Task_Builder::product_browser_session_dto( $session );
+	if ( self::include_raw_browser_session_contract( $input ) ) {
+		$session['product'] = $product_dto;
+		return $session;
+	}
+
+	return $product_dto;
+}
+
+/** @param array<string,mixed> $input Ability input. */
+private static function include_raw_browser_session_contract( array $input ): bool {
+	if ( true === ( $input['include_raw_browser_session'] ?? false ) || true === ( $input['include_internal_browser_session'] ?? false ) ) {
+		return true;
+	}
+
+	$debug = is_array( $input['debug'] ?? null ) ? $input['debug'] : array();
+	return true === ( $debug['include_raw_browser_session'] ?? false );
 }
 
 /** @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -304,19 +304,13 @@ private static function browser_playground_session_schema(): array {
 				'description' => 'The generated browser runner authorizes Agents API calls through a scoped runtime principal inside the disposable Playground sandbox.',
 			),
 			'session'    => array( 'type' => 'object' ),
+			'preview_boot' => array( 'type' => 'object' ),
+			'preview_ref'  => array( 'type' => 'object' ),
+			'artifact_refs' => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
 			'contained_site' => self::browser_contained_site_schema(),
-			'task_input' => self::task_input_schema(),
-			'task_payload' => array( 'type' => 'object' ),
-			'playground' => array( 'type' => 'object' ),
-			'runtime'    => array( 'type' => 'object' ),
-			'site_blueprint_artifact' => array( 'type' => 'object' ),
-			'materialization' => array(
-				'type'        => 'object',
-				'description' => 'Generic browser materialization invocation contract and result capture shape produced by the generated Playground runner.',
-			),
-			'recipe'     => array( 'type' => 'object' ),
 			'signals'    => array( 'type' => 'object' ),
 			'artifacts'  => array( 'type' => 'object' ),
+			'product'    => self::browser_product_dto_schema(),
 		),
 	);
 }
@@ -883,6 +877,15 @@ private static function browser_task_input_properties( array $task_input_schema,
 		'blueprint'               => self::object_property_schema( $detailed ? 'Optional WordPress Playground blueprint for the browser to compile and run.' : '' ),
 		'site_blueprint_artifact' => $detailed ? self::site_blueprint_artifact_input_schema() : self::object_property_schema(),
 		'artifact_files'          => $detailed ? self::artifact_files_input_schema() : array( 'type' => 'array' ),
+		'include_raw_browser_session' => array(
+			'type'        => 'boolean',
+			'description' => 'Internal/debug escape hatch for materializers that need the raw browser Playground contract. Public callers should use the default product DTO.',
+			'default'     => false,
+		),
+		'debug'                   => array(
+			'type'        => 'object',
+			'description' => 'Optional debug flags. Set debug.include_raw_browser_session only for internal materializer/debug tooling that needs the raw Playground contract.',
+		),
 	);
 }
 

--- a/tests/browser-session-public-dto.test.ts
+++ b/tests/browser-session-public-dto.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict"
+
+import { phpStringLiteral, repoRoot, runPhpJson } from "../scripts/test-kit.js"
+
+const result = await runPhpJson<any>(`
+define('ABSPATH', ${phpStringLiteral(repoRoot)});
+define('WPINC', 'wp-includes');
+
+class WP_Error {
+	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+}
+function is_wp_error( $value ) { return $value instanceof WP_Error; }
+function plugin_dir_path( $file ) { return rtrim( dirname( $file ), '/' ) . '/'; }
+function plugin_dir_url( $file ) { return 'https://example.test/wp-content/plugins/wp-codebox/'; }
+function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {}
+function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {}
+function apply_filters( $hook, $value, ...$args ) { return $value; }
+function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', (string) $value ) ); }
+function sanitize_text_field( $value ) { return trim( (string) $value ); }
+function wp_json_encode( $value, $flags = 0 ) { return json_encode( $value, $flags ); }
+function wp_parse_url( $url ) { return parse_url( $url ); }
+function wp_create_nonce( $action = -1 ) { return 'test-rest-nonce'; }
+function wp_normalize_path( $path ) { return str_replace( chr( 92 ), '/', (string) $path ); }
+
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/wp-codebox.php`)};
+
+$input = array(
+	'goal' => 'Build a product-safe browser artifact.',
+	'sandbox_session_id' => 'session-public-dto',
+	'orchestrator' => array( 'id' => 'studio-web' ),
+	'runtime_requirements' => array( 'requires_provider' => false ),
+	'playground' => array(
+		'preview_url' => '/preview/index.html',
+		'artifact_base_path' => '/wordpress/wp-content/uploads/wp-codebox/artifacts/session-public-dto',
+		'artifact_base_url' => '/wp-content/uploads/wp-codebox/artifacts/session-public-dto',
+	),
+	'runtime' => array(
+		'prepared' => array(
+			'enabled' => true,
+			'cache' => false,
+			'cache_key' => 'public-dto-site',
+			'input_hash' => str_repeat( 'a', 64 ),
+			'blueprint' => array( 'steps' => array( array( 'step' => 'runPHP', 'code' => 'must-not-leak' ) ) ),
+		),
+	),
+	'artifact_files' => array(
+		array( 'path' => 'index.html', 'kind' => 'browser-html', 'content' => '<h1>Preview</h1>' ),
+	),
+	'blueprint' => array( 'steps' => array( array( 'step' => 'runPHP', 'code' => 'must-not-leak' ) ) ),
+);
+
+$public = WP_Codebox_Abilities::create_browser_playground_session( $input );
+$raw = WP_Codebox_Abilities::create_browser_playground_session( $input + array( 'include_raw_browser_session' => true ) );
+$materializer = WP_Codebox_Abilities::create_browser_materializer_contract( $input );
+
+echo json_encode( array( 'public' => $public, 'raw' => $raw, 'materializer' => $materializer ), JSON_UNESCAPED_SLASHES );
+`)
+
+assert.equal(result.public.schema, "wp-codebox/browser-session-product-dto/v1")
+assert.equal(result.public.source_schema, "wp-codebox/browser-playground-session/v1")
+assert.equal(result.public.session_id, "session-public-dto")
+assert.equal(result.public.preview_ref.schema, "wp-codebox/browser-preview-ref/v1")
+assert.equal(result.public.preview_ref.preview_id.startsWith("preview-"), true)
+assert.equal(result.public.preview_ref.site_id, "public-dto-site")
+assert.match(result.public.preview_boot.blueprint_ref, /^prepared:public-dto-site:[a-f0-9]{64}$/)
+assert.equal(result.public.preview_boot.blueprint_ref_dto.hydrator_ability, "wp-codebox/hydrate-browser-blueprint-ref")
+assert.equal(result.public.preview_ref.boot_ref, result.public.preview_boot.blueprint_ref)
+assert.deepEqual(result.public.artifact_refs, [{
+  schema: "wp-codebox/browser-artifact-ref/v1",
+  kind: "browser-html",
+  path: "files/browser/index.html",
+  digest: { algorithm: "sha256", value: "f6197bb99270f103a24a4556bca591ddfb76fdf471755f078390af2f5e605ba0" },
+  size: 16,
+}])
+assert.equal(result.public.playground, undefined)
+assert.equal(result.public.recipe, undefined)
+assert.equal(result.public.task_payload, undefined)
+assert.equal(JSON.stringify(result.public).includes("must-not-leak"), false)
+
+assert.equal(result.raw.schema, "wp-codebox/browser-playground-session/v1")
+assert.equal(result.raw.product.schema, "wp-codebox/browser-session-product-dto/v1")
+assert.equal(Array.isArray(result.raw.playground.blueprint.steps), true)
+assert.equal(result.raw.recipe.runtime.backend, "wordpress-playground")
+
+assert.equal(result.materializer.schema, "wp-codebox/browser-materializer-contract/v1")
+assert.equal(Array.isArray(result.materializer.playground.blueprint.steps), true)
+assert.equal(result.materializer.compact.schema, "wp-codebox/browser-materializer-product-dto/v1")
+
+console.log("browser session public dto ok")

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -180,7 +180,12 @@ $product_session = WP_Codebox_Browser_Task_Builder::product_browser_session_dto(
 		'status' => 'ready',
 		'source_digest' => array( 'algorithm' => 'sha256', 'value' => str_repeat( 'a', 64 ) ),
 	),
-	'artifacts' => array( 'preview_url' => '/?preview=1' ),
+	'artifacts' => array(
+		'preview_url' => '/?preview=1',
+		'files' => array(
+			array( 'path' => 'index.html', 'kind' => 'browser-html', 'sha256' => str_repeat( 'd', 64 ), 'size' => 42, 'content' => 'must-not-leak' ),
+		),
+	),
 ) );
 $nested_primary_product_session = WP_Codebox_Browser_Task_Builder::product_browser_session_dto( array(
 	'success' => true,
@@ -309,6 +314,17 @@ assert.equal(result.product_session.preview_boot.blueprint_ref_dto.hydrator_abil
 assert.equal(result.product_session.preview_boot.preview.schema, "wp-codebox/preview-lease/v1")
 assert.equal(result.product_session.preview_boot.preview.preview_public_url, "https://preview.example.test")
 assert.equal(result.product_session.preview_boot.preview.local_url, "/?preview=1")
+assert.equal(result.product_session.preview_ref.schema, "wp-codebox/browser-preview-ref/v1")
+assert.equal(result.product_session.preview_ref.preview_id, "preview-123")
+assert.equal(result.product_session.preview_ref.session_id, "session-123")
+assert.equal(result.product_session.preview_ref.boot_ref, `prepared:runtime-cache-key:${"a".repeat(64)}`)
+assert.deepEqual(result.product_session.artifact_refs, [{
+  schema: "wp-codebox/browser-artifact-ref/v1",
+  kind: "browser-html",
+  path: "files/browser/index.html",
+  digest: { algorithm: "sha256", value: "d".repeat(64) },
+  size: 42,
+}])
 assert.equal(result.nested_primary_product_session.schema, "wp-codebox/browser-session-product-dto/v1")
 assert.equal(result.nested_primary_product_session.preview_boot.scope, "nested-session-123")
 assert.equal(result.nested_primary_product_session.preview_boot.client_module_url, "https://example.test/nested-client.js")


### PR DESCRIPTION
## Summary
- Return the public browser playground session ability response as the compact browser session product DTO by default.
- Preserve the raw browser Playground session contract for internal materializer/debug paths via an explicit include flag.
- Add preview/artifact reference fields and coverage for product-safe browser session output.

## Testing
- npm run test:browser-session-public-dto
- npm run test:browser-task-builder
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code review, implementation finalization, targeted verification, commit, push, and PR preparation.