### PR TITLE
Document REST DB profiler benchmark support

### DIFF
--- a/docs/benchmark-contract.md
+++ b/docs/benchmark-contract.md
@@ -46,17 +46,58 @@ The command contract is intentionally broad enough for future workload types:
 - **WP-CLI:** configured workload steps that execute in the same sandbox.
 - **Ability:** future ability-backed workload steps should still return generic numeric metrics and metadata.
 - **REST:** configured `rest-request` steps call `rest_do_request()` in-process. A configured workload may declare `route_matrix` as a compact list of REST routes; WP Codebox expands each route into the existing `rest-request` step type.
+- **REST DB query profile:** configured `rest-db-query-profiler` steps run one or more REST request cases, bracket each request with `$wpdb->queries`, and emit bounded, redacted query-profile metrics and artifacts.
 - **Database inventory:** configured `db-inventory` steps collect table, row, column, index, and byte-count inventory through the benchmark artifact path.
 - **Browser:** `wordpress.browser-probe` captures generic browser performance and memory artifacts. When a recipe runs browser probes before `wordpress.bench`, selected numeric `browser_*` metrics are promoted into each benchmark scenario while raw browser artifacts remain in the bundle.
 
-WP Codebox does not currently expose a REST DB query profiler workload step. Full
-REST query profiling needs an upstream runtime hook that brackets each
-`rest_do_request()` call, captures `$wpdb->queries` or an equivalent query log for
-that request only, and emits a bounded artifact with query count, total query
-time, repeated-query summaries, and redacted SQL fingerprints. Until that hook
-exists, caller rigs should use real `rest_request_cases` and `db-inventory`
-workloads separately and leave `rest-db-query-profiler` as a documented missing
-primitive rather than emitting synthetic query-profile artifacts.
+## REST DB Query Profiler
+
+`rest-db-query-profiler` is a configured workload step for API/database profiling
+suites that need per-request query evidence without caller-owned PHP glue. It
+accepts `rest_request_cases` or `request_cases`; when neither is supplied, the
+step itself is treated as a single REST request case. Each case uses the same
+REST request fields as `rest-request`: `id`, `case_id`, `method`, `path` or
+`route`, `params`, `headers`, `body`, `body-json`, `capture-response`,
+`metric-prefix`, and `metadata`.
+
+The profiler enables `$wpdb->save_queries` for the duration of the step, records
+only queries captured after each `rest_do_request()` call starts, then restores
+the previous `$wpdb->save_queries` value. Query samples are bounded by
+`sampleLimit` and redacted/truncated by `queryLengthLimit` before being included
+in the inline `rest-db-query-profile` artifact.
+
+```json
+{
+  "id": "rest-db-profile",
+  "source": "config",
+  "run": [
+    {
+      "type": "rest-db-query-profiler",
+      "rest_request_cases": [
+        {
+          "id": "items-search",
+          "method": "GET",
+          "path": "/example/v1/items",
+          "params": { "search": "hat" }
+        }
+      ],
+      "sampleLimit": 25,
+      "queryLengthLimit": 500
+    }
+  ]
+}
+```
+
+The step emits numeric metrics using the selected metric prefix, including
+`<prefix>_cases_count`, `<prefix>_queries_count`, and
+`<prefix>_query_time_ms`. Its inline artifact uses
+`wp-codebox/wordpress-rest-db-query-profile/v1` with summary counts, per-case
+query summaries, operation breakdowns, and redacted SQL/caller samples. When
+artifact collection is enabled, WP Codebox materializes this into
+`files/bench/<component-id>/<scenario-id>-rest-db-query-profile.json` as
+`wp-codebox/benchmark-rest-db-query-profile/v1` and adds a typed
+`benchmark-rest-db-query-profile` artifact reference named
+`rest-db-query-profile`.
 
 ## REST Route Matrices
 

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -304,6 +304,11 @@ Recipes can pass REST profiling workloads to `wordpress.bench` with
 REST requests; the runtime expands each route into the existing `rest-request`
 step and returns normal benchmark scenarios/artifacts.
 
+Workloads may also use a configured `rest-db-query-profiler` step to run one or
+more `rest_request_cases`, bracket each REST request with `$wpdb->queries`, and
+return bounded, redacted query-profile metrics plus the typed
+`rest-db-query-profile` benchmark artifact.
+
 ## Command Diagnostics
 
 Recipe steps may opt into bounded per-command diagnostics with a `diagnostics`
@@ -335,7 +340,7 @@ runtime callers. Limits are capped at 500 records and 524288 serialized bytes.
     "plugin-slug=woocommerce",
     "iterations=3",
     "warmup-iterations=1",
-    "workloads-json=[{\"id\":\"rest-catalog\",\"source\":\"config\",\"route_matrix\":[{\"id\":\"products-list\",\"method\":\"GET\",\"path\":\"/wc/v3/products\",\"params\":{\"per_page\":10}}],\"artifacts\":{\"route-summary\":{\"path\":\"bench/rest-route-summary.json\",\"kind\":\"json\",\"source\":\"scenario-artifact\"}}}]"
+    "workloads-json=[{\"id\":\"rest-catalog\",\"source\":\"config\",\"route_matrix\":[{\"id\":\"products-list\",\"method\":\"GET\",\"path\":\"/wc/v3/products\",\"params\":{\"per_page\":10}}],\"run\":[{\"type\":\"rest-db-query-profiler\",\"rest_request_cases\":[{\"id\":\"products-list\",\"method\":\"GET\",\"path\":\"/wc/v3/products\",\"params\":{\"per_page\":10}}]}],\"artifacts\":{\"route-summary\":{\"path\":\"bench/rest-route-summary.json\",\"kind\":\"json\",\"source\":\"scenario-artifact\"}}}]"
   ]
 }
 ```

--- a/packages/runtime-core/src/benchmark-contracts.ts
+++ b/packages/runtime-core/src/benchmark-contracts.ts
@@ -105,7 +105,7 @@ export interface BenchResults {
 }
 
 export interface BenchmarkDefinitionWorkloadStep {
-  type: "php" | "wp-cli" | "rest-request" | "ability" | (string & {})
+  type: "php" | "wp-cli" | "rest-request" | "rest-db-query-profiler" | "db-inventory" | "external-http-guardrail" | "ability" | (string & {})
   action?: "install" | "collect" | "reset" | (string & {})
   code?: string
   file?: string

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -385,7 +385,7 @@ export const commandRegistry = [
       { name: "dependency-slugs", description: "Comma-separated plugin dependency slugs to load.", format: "comma-separated slugs" },
       { name: "env-json", description: "Benchmark environment object.", format: "JSON object" },
       { name: "bootstrap-files-json", description: "Component-relative bootstrap file fallbacks; the first existing file is loaded before workloads execute.", format: "JSON array" },
-      { name: "workloads-json", description: "Explicit workload list. Configured workload steps support php, ability, wp-cli, and rest-request mechanics.", format: "JSON array" },
+      { name: "workloads-json", description: "Explicit workload list. Configured workload steps support php, ability, wp-cli, rest-request, rest-db-query-profiler, db-inventory, and external-http-guardrail mechanics.", format: "JSON array" },
       { name: "scenario-ids-json", description: "Optional selected benchmark scenario ids. Filters both discovered tests/bench workloads and explicit workloads by id.", format: "JSON array" },
       { name: "lifecycle-json", description: "Generic benchmark lifecycle hooks keyed by setup, prepare, warmup, measure, or teardown. Hook entries use the same php/ability/wp-cli step format as configured workloads.", format: "JSON object" },
       { name: "reset-policy-json", description: "Explicit benchmark reset policy. Supports betweenIterations and betweenScenarios modes: none or object-cache.", format: "JSON object" },

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -71,6 +71,11 @@ assert.equal(agentSandboxRun.acceptedArgs.some((arg) => arg.name === "code"), fa
 assert.equal(agentSandboxRun.acceptedArgs.some((arg) => arg.name === "code-file"), false)
 assert.deepEqual(agentSandboxRun.requiresPolicyCommands, ["wordpress.run-php", "wordpress.wp-cli"])
 
+const wordpressBench = catalog.commands.find((command) => command.id === "wordpress.bench")
+assert.ok(wordpressBench, "catalog includes wordpress.bench")
+const workloadsJsonArg = wordpressBench.acceptedArgs.find((arg) => arg.name === "workloads-json")
+assert.match(workloadsJsonArg?.description ?? "", /rest-db-query-profiler/)
+
 assert.deepEqual(effectivePolicyCommands("wp-codebox.agent-sandbox-run"), ["wordpress.run-php", "wordpress.wp-cli"])
 assert.deepEqual(effectivePolicyCommands("custom.wrapper", [
   {


### PR DESCRIPTION
## Summary
- Verify and document the existing `rest-db-query-profiler` benchmark workload step as supported public benchmark API surface.
- Update `wordpress.bench` command catalog metadata so `workloads-json` lists `rest-db-query-profiler` alongside the other supported configured workload mechanics.
- Add a catalog assertion covering the profiler description and update benchmark workload step type metadata.

## Verification
- `npm run build`
- `npm run test:agent-task-contracts`
- `npm run test:bench-command-step-behavior`
- `npx tsx tests/benchmark-contracts.test.ts`
- `npx tsx tests/docs-boundary-language.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Auditing the profiler implementation/docs mismatch, updating documentation/catalog/type metadata, running targeted verification, and drafting this PR description.