### PR TITLE
Expose WordPress runtime action facade

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -33,8 +33,10 @@ Use these package entrypoints from external integrations:
   runtime backend.
 - `@automattic/wp-codebox-playground/public`: stable WordPress runtime wrappers
   for creating Playground-backed WordPress runtimes and episodes, running episode
-  actions with lifecycle hooks, collecting runtime/episode artifacts, and reading
-  browser artifact metrics through the published Playground facade.
+  actions with lifecycle hooks, running typed WordPress actions such as WP-CLI,
+  PHP, REST requests, browser probes/actions, and editor opens, collecting
+  runtime/episode artifacts, and reading browser artifact metrics through the
+  published Playground facade.
 - `@automattic/wp-codebox-cli`: the executable CLI surface for schema, command,
   recipe, runtime, and artifact operations.
 - `@automattic/wp-codebox-cli/recipe-secret-env`: recipe secret environment
@@ -83,7 +85,10 @@ The stable public surface is grouped by lifecycle area rather than by product:
   policy, and command result contracts. Playground-backed WordPress consumers can use
   `createWordPressRuntime()`, `createWordPressEpisode()`, and
   `runWordPressEpisodeActions()` from `@automattic/wp-codebox-playground/public`
-  instead of composing core runtime internals directly.
+  instead of composing core runtime internals directly. The same entrypoint also
+  exposes consumer-safe action helpers: `runWordPressWpCli()`,
+  `runWordPressPhp()`, `requestWordPressRest()`, `runWordPressBrowserAction()`,
+  `probeWordPressBrowser()`, and `openWordPressEditor()`.
 - **Runner workspace:** workspace policy, preload artifact, source-root
   preparation, mount primitive, runner workspace publication contracts, and the
   backend adapter config schema `wp-codebox/runner-workspace-backend/v1`.

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -11,6 +11,24 @@ import {
   type RuntimeEpisodeSpec,
   type RuntimeEpisodeStepResult,
 } from "@automattic/wp-codebox-core/public"
+export {
+  collectWordPressArtifacts,
+  openWordPressEditor,
+  probeWordPressBrowser,
+  requestWordPressRest,
+  runWordPressBrowserAction,
+  runWordPressPhp,
+  runWordPressWpCli,
+  type RuntimeActionObservation,
+  type WordPressBrowserActionOptions,
+  type WordPressBrowserProbeOptions,
+  type WordPressEditorOpenOptions,
+  type WordPressPhpOptions,
+  type WordPressRestRequestOptions,
+  type WordPressRuntimeActionEpisode,
+  type WordPressRuntimeArtifactSource,
+  type WordPressWpCliOptions,
+} from "@automattic/wp-codebox-core"
 import { browserArtifactMetrics, type BrowserArtifactMetricsResult } from "./browser-metrics.js"
 import { createPlaygroundRuntimeBackend, type PlaygroundRuntimeBackendOptions } from "./playground-runtime.js"
 

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -30,6 +30,7 @@ import {
   RUNNER_WORKSPACE_BACKEND_FILTER,
 } from "../packages/runtime-core/src/public.js"
 import * as publicApi from "../packages/runtime-core/src/public.js"
+import * as playgroundPublicApi from "../packages/runtime-playground/src/public.js"
 
 const root = new URL("..", import.meta.url)
 
@@ -230,6 +231,13 @@ assert.deepEqual(fuzzSuiteResultEnvelope({
   ],
 }).summary, { total: 2, passed: 1, failed: 1, error: 0, skipped: 0 })
 assert.equal(fuzzSuiteResultEnvelope({ suite: { id: "ability-boundary" } }).schema, FUZZ_SUITE_RESULT_SCHEMA)
+assert.equal(typeof playgroundPublicApi.runWordPressWpCli, "function")
+assert.equal(typeof playgroundPublicApi.runWordPressPhp, "function")
+assert.equal(typeof playgroundPublicApi.requestWordPressRest, "function")
+assert.equal(typeof playgroundPublicApi.runWordPressBrowserAction, "function")
+assert.equal(typeof playgroundPublicApi.probeWordPressBrowser, "function")
+assert.equal(typeof playgroundPublicApi.openWordPressEditor, "function")
+assert.equal(typeof playgroundPublicApi.collectWordPressArtifacts, "function")
 assert.equal(RUNNER_WORKSPACE_BACKEND_FILTER, "wp_codebox_runner_workspace_backend")
 assert.ok(RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS.includes("publish_runner_workspace"))
 assert.match(runnerWorkspaceAdapter, new RegExp(escapeRegExp(RUNNER_WORKSPACE_BACKEND_FILTER)))

--- a/tests/wordpress-runtime-actions.test.ts
+++ b/tests/wordpress-runtime-actions.test.ts
@@ -8,7 +8,7 @@ import {
   runWordPressPhp,
   runWordPressWpCli,
   type WordPressRuntimeActionEpisode,
-} from "../packages/runtime-core/src/public.js"
+} from "../packages/runtime-playground/src/public.js"
 
 const calls: Array<{ command: string; args: string[]; kind?: string; timeoutMs?: number }> = []
 


### PR DESCRIPTION
## Summary
- Export consumer-safe WordPress runtime action helpers from `@automattic/wp-codebox-playground/public`.
- Point the runtime action contract test at the Playground public facade.
- Document the typed WP-CLI, PHP, REST, browser, and editor helpers as part of the stable public runtime entrypoint.

## Tests
- `npm run test:public-api-contract`
- `npm run test:wordpress-runtime-actions`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementing the public runtime facade export, updating docs/tests, and running verification.