### PR TITLE
Narrow public Codebox contract boundary

### DIFF
--- a/packages/runtime-core/src/contracts.ts
+++ b/packages/runtime-core/src/contracts.ts
@@ -1,4 +1,4 @@
 /** Inspectable Codebox contract metadata for CLI and orchestrator consumers. */
-export * from "./public.js"
+export * from "./browser-probe-contract.js"
 export * from "./command-registry.js"
 export * from "./runtime-contract-manifest.js"

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -47,6 +47,10 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
+function barrelExportModules(source: string): string[] {
+  return Array.from(source.matchAll(/^export \* from "(.+)"$/gm), (match) => match[1])
+}
+
 const rootPackage = await readJson("package.json")
 const corePackage = await readJson("packages/runtime-core/package.json")
 const playgroundPackage = await readJson("packages/runtime-playground/package.json")
@@ -85,6 +89,83 @@ const agentsApiAdapter = await readFile(new URL("packages/wordpress-plugin/src/c
 const publicBarrel = await readFile(new URL("packages/runtime-core/src/public.ts", root), "utf8")
 const contractsBarrel = await readFile(new URL("packages/runtime-core/src/contracts.ts", root), "utf8")
 const runnerWorkspaceAdapter = await readFile(new URL("packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php", root), "utf8")
+
+assert.deepEqual(barrelExportModules(publicBarrel), [
+  "./agent-runtime-workload.js",
+  "./agent-workload.js",
+  "./agent-task-recipe.js",
+  "./agent-task-run-result.js",
+  "./agent-terminal-result.js",
+  "./artifact-capture-policy.js",
+  "./artifact-diagnostics.js",
+  "./artifact-export-links.js",
+  "./artifact-layout.js",
+  "./artifact-manifest.js",
+  "./artifact-paths.js",
+  "./artifact-references.js",
+  "./artifact-result-envelope.js",
+  "./artifact-review.js",
+  "./artifact-storage.js",
+  "./artifact-test-results.js",
+  "./browser-artifact-lifecycle.js",
+  "./browser-callback-contracts.js",
+  "./browser-interaction.js",
+  "./browser-probe-contract.js",
+  "./browser-result-shapes.js",
+  "./browser-run-result.js",
+  "./browser-review-bridge.js",
+  "./browser-session-origin.js",
+  "./command-agent-run.js",
+  "./command-codecs.js",
+  "./component-contracts.js",
+  "./evidence-artifact-envelope.js",
+  "./fanout-contracts.js",
+  "./fixture-import-primitives.js",
+  "./fuzz-suite-contracts.js",
+  "./fuzz-suite-runner.js",
+  "./host-command-executor.js",
+  "./host-tool-registry.js",
+  "./managed-host-command.js",
+  "./materialization-contracts.js",
+  "./mcp-client-configs.js",
+  "./mount-primitives.js",
+  "./parent-tool-bridge.js",
+  "./performance-observation.js",
+  "./recipe-builders.js",
+  "./recipe-run-summary.js",
+  "./recipe-schema.js",
+  "./recipe-source-packages.js",
+  "./run-plan.js",
+  "./run-registry.js",
+  "./runner-workspace-publication.js",
+  "./runtime-boundary-contracts.js",
+  "./runtime-contract-manifest.js",
+  "./runtime-command-result.js",
+  "./runtime-contracts.js",
+  "./runtime-episode.js",
+  "./runtime-neutral-contracts.js",
+  "./runtime-overlay-bundle.js",
+  "./runtime-overlay-descriptors.js",
+  "./runtime-package-execution.js",
+  "./runtime-policy.js",
+  "./runtime-preset-registry.js",
+  "./sandbox-tool-policy.js",
+  "./source-root-preparation.js",
+  "./structured-artifacts.js",
+  "./task-input.js",
+  "./tool-call-artifacts.js",
+  "./transfer-proof.js",
+  "./workspace-policy.js",
+  "./workspace-preload-artifacts.js",
+  "./wordpress-crud-contracts.js",
+  "./wordpress-runtime-discovery-contracts.js",
+])
+
+assert.deepEqual(barrelExportModules(contractsBarrel), [
+  "./browser-probe-contract.js",
+  "./command-registry.js",
+  "./runtime-contract-manifest.js",
+])
 
 for (const publicEntry of [
   "@automattic/wp-codebox-core",


### PR DESCRIPTION
## Summary
- Narrow `@automattic/wp-codebox-core/contracts` to contract inspection exports instead of re-exporting the curated public facade.
- Keep command registry/runtime manifest consumers working by explicitly exporting browser probe contract metadata, command registry metadata, and runtime contract manifest helpers.
- Add exact barrel export-list assertions so public and contract barrels cannot expand accidentally.

## Tests
- `npm run test:public-api-contract`
- `npm run test:provider-runtime-contracts`
- `npm run test:php-public-api-facade`
- `npm run test:runtime-contract-manifest`
- `npm run build`
- `npm run test:public-ability-aliases`
- `npm run test:wordpress-plugin-public-runtime-abilities`
- `npm run test:php-runner-workspace-backend-contract`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Codebase inspection, targeted implementation, test updates, and verification.