### PR TITLE
Clean runner workspace backend boundaries

### DIFF
--- a/packages/runtime-core/src/runner-workspace-publication.ts
+++ b/packages/runtime-core/src/runner-workspace-publication.ts
@@ -155,7 +155,6 @@ export type RunnerWorkspaceCommandRequest = RunnerWorkspaceIdentity & {
   timeout_seconds?: number
   env?: Record<string, string>
   context?: Record<string, unknown>
-  allow_local_fallback?: boolean
 }
 
 export type RunnerWorkspaceCommandResult = {

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-runner-publication.php
@@ -138,7 +138,6 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'timeout_seconds'     => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 600 ),
 				'env'                 => array( 'type' => 'object' ),
 				'context'             => array( 'type' => 'object' ),
-				'allow_local_fallback' => array( 'type' => 'boolean', 'default' => false ),
 			),
 		);
 	}
@@ -343,10 +342,6 @@ trait WP_Codebox_Abilities_Runner_Publication {
 			return self::normalize_runner_workspace_command_result( $result, $normalized, $backend_input );
 		}
 
-		if ( true === ( $input['allow_local_fallback'] ?? false ) && '' !== $normalized['workspace_path'] && is_dir( $normalized['workspace_path'] ) ) {
-			return self::run_local_runner_workspace_command( $command, $normalized, $backend_input );
-		}
-
 		return self::runner_workspace_operation_failure(
 			'command',
 			(string) $backend['failure_type'],
@@ -433,8 +428,8 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'success'      => false,
 				'schema'       => 'wp-codebox/runner-workspace-prepare-result/v1',
 				'status'       => $status,
-				'failure_type' => self::redact_runner_workspace_backend_slugs( $failure_type ),
-				'error'        => self::sanitize_runner_workspace_public_error( $error ),
+				'failure_type' => $failure_type,
+				'error'        => $error,
 				'repo'         => (string) ( $input['repo'] ?? '' ),
 				'branch'       => (string) ( $input['branch'] ?? '' ),
 				'capabilities' => array( 'capture' => false, 'command' => false, 'publish' => false ),
@@ -615,8 +610,8 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'success'      => false,
 				'schema'       => 'wp-codebox/runner-workspace-publication-result/v1',
 				'status'       => $status,
-				'failure_type' => self::redact_runner_workspace_backend_slugs( $failure_type ),
-				'error'        => self::sanitize_runner_workspace_public_error( $error ),
+				'failure_type' => $failure_type,
+				'error'        => $error,
 				'workspace'    => array_filter( array( 'handle' => (string) ( $input['workspace'] ?? '' ), 'path' => (string) ( $input['workspace_path'] ?? '' ) ), static fn( mixed $value ): bool => '' !== $value ),
 				'branch'       => array_filter( array( 'base' => (string) ( $input['base'] ?? '' ), 'head' => (string) ( $input['head'] ?? '' ) ), static fn( mixed $value ): bool => '' !== $value ),
 				'reused'       => false,
@@ -628,29 +623,6 @@ trait WP_Codebox_Abilities_Runner_Publication {
 		);
 	}
 
-	/** @param array<string,mixed> $error Raw backend or adapter error. @return array<string,mixed> */
-	private static function sanitize_runner_workspace_public_error( array $error ): array {
-		$sanitized = array();
-		foreach ( $error as $key => $value ) {
-			if ( in_array( $key, array( 'result', 'input', 'backend', 'ability', 'ability_name', 'backend_ability' ), true ) ) {
-				continue;
-			}
-
-			if ( is_array( $value ) ) {
-				$sanitized[ $key ] = self::sanitize_runner_workspace_public_error( $value );
-				continue;
-			}
-
-			$sanitized[ $key ] = is_string( $value ) ? self::redact_runner_workspace_backend_slugs( $value ) : $value;
-		}
-
-		return array_filter( $sanitized, static fn( mixed $value ): bool => array() !== $value && null !== $value );
-	}
-
-	private static function redact_runner_workspace_backend_slugs( string $value ): string {
-		return preg_replace( '#\bdatamachine-code(?:/[a-z0-9._/-]+)?#i', 'runner workspace backend', $value ) ?? $value;
-	}
-
 	/** @param array<string,mixed> $input Normalized input. @param array<string,mixed> $extra Extra response fields. @return array<string,mixed> */
 	private static function runner_workspace_operation_failure( string $operation, string $failure_type, array $error, string $status, array $input, array $extra = array() ): array {
 		return array_filter(
@@ -659,8 +631,8 @@ trait WP_Codebox_Abilities_Runner_Publication {
 					'success'      => false,
 					'schema'       => 'command' === $operation ? 'wp-codebox/runner-workspace-command-result/v1' : 'wp-codebox/runner-workspace-capture-result/v1',
 					'status'       => $status,
-					'failure_type' => self::redact_runner_workspace_backend_slugs( $failure_type ),
-					'error'        => self::sanitize_runner_workspace_public_error( $error ),
+					'failure_type' => $failure_type,
+					'error'        => $error,
 					'workspace'    => self::runner_workspace_identity_result( $input ),
 				),
 				$extra
@@ -699,41 +671,6 @@ trait WP_Codebox_Abilities_Runner_Publication {
 				'workspace'   => self::runner_workspace_identity_result( $input ),
 			),
 			static fn( mixed $value ): bool => '' !== $value && null !== $value
-		);
-	}
-
-	/** @param array<string,mixed> $input Normalized input. @param array<string,mixed> $command_input Command input. @return array<string,mixed> */
-	private static function run_local_runner_workspace_command( string $command, array $input, array $command_input ): array {
-		$result = WP_Codebox_Managed_Host_Command::run(
-			array(
-				'command'           => WP_Codebox_Managed_Host_Command::split_command_line( $command ),
-				'cwd'               => (string) $input['workspace_path'],
-				'allowed_cwd_roots' => array( (string) $input['workspace_path'] ),
-				'timeout_seconds'   => max( 1, min( 600, (int) ( $command_input['timeout_seconds'] ?? 120 ) ) ),
-				'env'               => is_array( $command_input['env'] ?? null ) ? $command_input['env'] : array(),
-			)
-		);
-
-		if ( is_wp_error( $result ) ) {
-			return self::runner_workspace_operation_failure(
-				'command',
-				'local_command_unavailable',
-				array( 'code' => $result->get_error_code(), 'message' => $result->get_error_message(), 'data' => $result->get_error_data() ),
-				'unavailable',
-				$input
-			);
-		}
-
-		return self::normalize_runner_workspace_command_result(
-			array(
-				'success'    => (bool) $result['success'],
-				'exit_code'  => (int) $result['exit_code'],
-				'stdout'     => (string) $result['stdout'],
-				'stderr'     => (string) $result['stderr'],
-				'elapsed_ms' => (float) $result['elapsed_ms'],
-			),
-			$input,
-			$command_input
 		);
 	}
 

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -79,10 +79,10 @@ foreach ( $expected_methods as $method ) {
 	expect( $reflection->getMethod( $method )->isPublic(), 'API method is not public: ' . $method );
 }
 
-$blocked = WP_Codebox_API::execute_ability( 'datamachine-code/workspace-show', array() );
+$blocked = WP_Codebox_API::execute_ability( 'external-backend/workspace-show', array() );
 expect( $blocked instanceof WP_Error, 'Expected non-wp-codebox ability names to be rejected.' );
 expect( 'wp_codebox_api_ability_not_supported' === $blocked->get_error_code(), 'Expected unsupported ability error code.' );
-expect( ! str_contains( json_encode( $blocked->get_error_data(), JSON_UNESCAPED_SLASHES ) ?: '', 'datamachine-code' ), 'Unsupported ability errors must not echo backend ability names.' );
+expect( ! str_contains( json_encode( $blocked->get_error_data(), JSON_UNESCAPED_SLASHES ) ?: '', 'external-backend' ), 'Unsupported ability errors must not echo backend ability names.' );
 
 $runner_workspace_abilities = array(
 	'wp-codebox/runner-workspace-prepare' => array( 'method' => 'prepare_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-prepare-result/v1' ),

--- a/scripts/php-runner-workspace-adapter-boundary-smoke.php
+++ b/scripts/php-runner-workspace-adapter-boundary-smoke.php
@@ -88,7 +88,7 @@ function assert_same_contract( mixed $expected, mixed $actual, string $label ): 
 
 function assert_no_backend_leak( mixed $value, string $label ): void {
 	$json = json_encode( $value, JSON_UNESCAPED_SLASHES );
-	if ( ! is_string( $json ) || str_contains( $json, 'datamachine-code' ) ) {
+	if ( ! is_string( $json ) || str_contains( $json, 'private-runner' ) ) {
 		fwrite( STDERR, $label . " leaked backend identifiers.\nActual: " . json_encode( $value, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT ) . "\n" );
 		exit( 1 );
 	}
@@ -167,14 +167,16 @@ assert_same_contract( 'completed', $command['status'], 'command status' );
 $GLOBALS['wp_codebox_test_abilities']['fake-runner-workspace-backend/workspace-git-status'] = new class() {
 	public function execute( array $input ): WP_Error {
 		unset( $input );
-		return new WP_Error( 'datamachine-code/workspace-git-status', 'datamachine-code/workspace-git-status exploded', array( 'ability' => 'datamachine-code/workspace-git-status' ) );
+		return new WP_Error( 'private-runner/workspace-git-status', 'private-runner/workspace-git-status exploded', array( 'ability' => 'private-runner/workspace-git-status' ) );
 	}
 };
 
 $failure = WP_Codebox_Abilities::capture_runner_workspace( array( 'workspace' => 'wp-codebox@task' ) );
 assert_same_contract( false, $failure['success'], 'failure success' );
-assert_same_contract( 'Runner workspace backend operation failed.', $failure['error']['message'], 'public error redacts backend ability slug' );
-assert_same_contract( false, array_key_exists( 'ability', $failure['error']['data'] ?? array() ), 'public error removes backend ability key' );
+assert_same_contract( 'backend_error', $failure['failure_type'], 'wp error failure type' );
+assert_same_contract( 'wp_codebox_runner_workspace_backend_error', $failure['error']['code'], 'wp error code is Codebox-owned' );
+assert_same_contract( 'Runner workspace backend operation failed.', $failure['error']['message'], 'wp error message is stable' );
+assert_same_contract( 'workspace_git_status', $failure['error']['operation'], 'wp error includes public operation' );
 assert_no_backend_leak( $failure, 'wp error failure' );
 
 $GLOBALS['wp_codebox_test_abilities']['fake-runner-workspace-backend/run-runner-workspace-command'] = new class() {
@@ -182,11 +184,11 @@ $GLOBALS['wp_codebox_test_abilities']['fake-runner-workspace-backend/run-runner-
 		unset( $input );
 		return array(
 			'success'      => false,
-			'failure_type' => 'datamachine-code/run-runner-workspace-command',
+			'failure_type' => 'private-runner/run-runner-workspace-command',
 			'error'        => array(
-				'code'    => 'datamachine-code/run-runner-workspace-command',
-				'message' => 'datamachine-code/run-runner-workspace-command failed',
-				'data'    => array( 'backend_ability' => 'datamachine-code/run-runner-workspace-command' ),
+				'code'    => 'private-runner/run-runner-workspace-command',
+				'message' => 'private-runner/run-runner-workspace-command failed',
+				'data'    => array( 'backend_ability' => 'private-runner/run-runner-workspace-command' ),
 			),
 		);
 	}
@@ -195,7 +197,28 @@ $GLOBALS['wp_codebox_test_abilities']['fake-runner-workspace-backend/run-runner-
 $backend_failure = WP_Codebox_Abilities::run_runner_workspace_command( array( 'workspace' => 'wp-codebox@task', 'repo' => 'wp-codebox', 'command' => 'php -l file.php' ) );
 assert_same_contract( false, $backend_failure['success'], 'backend failure success' );
 assert_same_contract( 'backend_failed', $backend_failure['failure_type'], 'backend failure type is generic' );
+assert_same_contract( 'wp_codebox_runner_workspace_backend_error', $backend_failure['error']['code'], 'backend failure code is Codebox-owned' );
+assert_same_contract( 'Runner workspace backend operation failed.', $backend_failure['error']['message'], 'backend failure message is stable' );
+assert_same_contract( 'run_runner_workspace_command', $backend_failure['error']['operation'], 'backend failure includes public operation' );
 assert_no_backend_leak( $backend_failure, 'backend failure' );
+
+$GLOBALS['wp_codebox_test_filters']['wp_codebox_runner_workspace_backend'] = array( static fn(): array => array() );
+$GLOBALS['wp_codebox_ability_lookups'] = array();
+
+$unavailable = WP_Codebox_Abilities::run_runner_workspace_command(
+	array(
+		'workspace'      => 'wp-codebox@task',
+		'workspace_path' => __DIR__,
+		'repo'           => 'wp-codebox',
+		'command'        => 'php -r "exit(7);"',
+	)
+);
+assert_same_contract( false, $unavailable['success'], 'unavailable success' );
+assert_same_contract( 'unavailable', $unavailable['status'], 'unavailable status' );
+assert_same_contract( 'backend_unavailable', $unavailable['failure_type'], 'unavailable failure type' );
+assert_same_contract( 'wp_codebox_runner_workspace_backend_unavailable', $unavailable['error']['code'], 'unavailable error code' );
+assert_same_contract( array(), $GLOBALS['wp_codebox_ability_lookups'], 'missing backend does not execute local fallback or ability lookup' );
+assert_no_backend_leak( $unavailable, 'unavailable failure' );
 
 $GLOBALS['wp_codebox_test_filters']['wp_codebox_runner_workspace_backend'] = array(
 	static fn(): array => array(

--- a/tests/production-boundary-enforcement.test.ts
+++ b/tests/production-boundary-enforcement.test.ts
@@ -76,7 +76,7 @@ async function productionFiles(dir: URL): Promise<string[]> {
 const violations: string[] = []
 
 for (const file of await productionFiles(packagesDir)) {
-  const source = (await readFile(file, "utf8")).replace(/.*preg_replace\(.*datamachine-code.*runner workspace backend.*\n/g, "")
+  const source = await readFile(file, "utf8")
   const rel = relative(root.pathname, file)
 
   for (const term of forbiddenTerms) {

--- a/tests/provider-runtime-contracts.test.ts
+++ b/tests/provider-runtime-contracts.test.ts
@@ -114,6 +114,6 @@ assert.doesNotMatch(phpFunctionBlock(runnerWorkspacePhp, "runner_workspace_prepa
 assert.doesNotMatch(phpFunctionBlock(runnerWorkspacePhp, "runner_workspace_capture_output_schema"), /'backend'/)
 assert.doesNotMatch(phpFunctionBlock(runnerWorkspacePhp, "runner_workspace_command_output_schema"), /'backend'/)
 assert.doesNotMatch(phpFunctionBlock(runnerWorkspacePhp, "runner_workspace_publication_output_schema"), /'backend'/)
-assert.match(runnerWorkspacePhp, /sanitize_runner_workspace_public_error/)
+assert.doesNotMatch(runnerWorkspacePhp, /sanitize_runner_workspace_public_error|redact_runner_workspace_backend_slugs/)
 
 console.log("provider runtime contracts ok")


### PR DESCRIPTION
## Summary
- Remove runner workspace command per-call local fallback from the public schema and implementation.
- Remove downstream-specific backend redaction/sanitization from public runner workspace wrappers; backend adapters now own stable Codebox public errors.
- Tighten boundary tests so production scans no longer exempt named downstream slugs, fake backend failures return Codebox-owned errors, and missing backend command execution returns unavailable.

## Tests
- npm run test:production-boundary-enforcement
- npm run test:provider-runtime-contracts
- php scripts/php-runner-workspace-adapter-boundary-smoke.php
- npm run test:php-runner-workspace-backend-contract
- npm run test:php-public-api-facade

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the runner workspace backend boundary cleanup, updating focused smoke/contract tests, and running verification.