### PR TITLE
Harden WP Codebox public API boundary

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -68,13 +68,14 @@ API ability names, Playground command handlers, and integration-specific filters
 
 WordPress consumers should prefer `WP_Codebox_API` for PHP calls and
 `wp-codebox/*` ability ids for ability-oriented calls. Runtime adapters may use
-upstream systems internally, but public docs and schemas should not require
-callers to invoke raw upstream ability names.
+upstream systems internally, while public docs and schemas present Codebox-owned
+ability names, schemas, and facades to callers.
 
 The workspace package mirrors the core entrypoints as `./core`,
 `./core/public`, `./core/contracts`, `./core/artifacts`, `./recipe-builders`,
 `./agent-task-recipe`, `./runtime-presets`, `./playground/public`, and
-`./cli/recipe-secret-env` for local consumers in this repo.
+`./cli/recipe-secret-env` for local consumers in this repo. It intentionally does
+not mirror the monorepo-only `./internals` helper entrypoint.
 
 ## Contract Areas
 
@@ -209,9 +210,10 @@ Those adapter bindings are not part of `runtimeContractManifest()`.
 ## Internal Entry Point
 
 `@automattic/wp-codebox-core/internals` exists for this monorepo's package split
-and may be used by tests, the CLI, and backend packages in this repository.
-External integrations use the stable entrypoints listed above. Symbols exported
-only through `./internals` may change or move between package releases.
+and may be used by tests, the CLI, and backend packages in this repository. The
+workspace package does not expose a `./core/internals` mirror. External
+integrations use the stable entrypoints listed above. Symbols exported only
+through `./internals` may change or move between package releases.
 
 Keep `./internals` intentionally small. If an internal helper becomes useful to
 external consumers, move the consumer-safe contract into the focused public owner

--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
       "types": "./packages/runtime-core/dist/artifacts.d.ts",
       "import": "./packages/runtime-core/dist/artifacts.js"
     },
-    "./core/internals": {
-      "types": "./packages/runtime-core/dist/internals.d.ts",
-      "import": "./packages/runtime-core/dist/internals.js"
-    },
     "./recipe-builders": {
       "types": "./packages/runtime-core/dist/recipe-builders.d.ts",
       "import": "./packages/runtime-core/dist/recipe-builders.js"

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -10,8 +10,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Advanced internal adapter around the upstream Agents API abilities.
  *
- * Consumers should depend on this class instead of importing Agents API constants,
- * handler names, or execution principal internals.
+ * Internal runtime code uses this adapter instead of importing Agents API
+ * constants, handler names, or execution principal internals. Consumers should
+ * call WP_Codebox_API or wp-codebox/* abilities.
  *
  * @internal Adapter boundary for WP Codebox runtime integration.
  */

--- a/tests/docs-boundary-language.test.ts
+++ b/tests/docs-boundary-language.test.ts
@@ -71,6 +71,9 @@ assert.match(publicBoundaryText, /Codebox performs any\s+WP Codebox schema mappi
 assert.match(publicBoundaryText, /The CLI is a public Codebox surface/)
 assert.match(publicBoundaryText, /`wp-codebox\/runner-workspace-backend\/v1`/)
 assert.match(publicBoundaryText, /adapter config maps each operation to its\s+integration-provided backend ability/)
+assert.match(publicBoundaryText, /not mirror the monorepo-only `\.\/internals` helper entrypoint/)
+assert.doesNotMatch(publicBoundaryText, /WP_Codebox_Agents_API_Adapter/)
+assert.doesNotMatch(publicBoundaryText, /agents-api\/[a-z0-9._/-]+|agents\/[a-z0-9._/-]+/i)
 assert.doesNotMatch(publicBoundaryText, /Data Machine (?:must|should) (?:understand|parse|validate|emit) (?:WP )?Codebox/)
 
 const runnerWorkspaceBackendContract = await readFile(new URL("docs/runner-workspace-backend-contract.md", root), "utf8")
@@ -79,6 +82,9 @@ assert.match(runnerWorkspaceBackendContract, /`wp-codebox\/runner-workspace-back
 assert.match(runnerWorkspaceBackendContract, /External callers use WP Codebox runner workspace\s+abilities and result schemas/)
 assert.match(runnerWorkspaceBackendContract, /Those names are adapter inputs\s+for the stable Codebox runner workspace operation ids/)
 assert.match(runnerWorkspaceBackendContract, /`wp-codebox\/runner-workspace-prepare`/)
+assert.match(runnerWorkspaceBackendContract, /`workspace_worktree_add`/)
+assert.match(runnerWorkspaceBackendContract, /`run_runner_workspace_command`/)
+assert.match(runnerWorkspaceBackendContract, /`publish_runner_workspace`/)
 assert.doesNotMatch(runnerWorkspaceBackendContract, /datamachine|data[-_ ]?machine|homeboy/i)
 
 const agentRuntimeContract = await readFile(new URL("docs/agent-runtime-contract.md", root), "utf8")

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -61,7 +61,6 @@ assert.deepEqual(exportKeys(rootPackage), [
   "./core/public",
   "./core/contracts",
   "./core/artifacts",
-  "./core/internals",
   "./recipe-builders",
   "./agent-task-recipe",
   "./runtime-presets",
@@ -81,6 +80,8 @@ assert.deepEqual(exportKeys(corePackage), [
   "./agent-task-recipe",
   "./runtime-presets",
 ])
+assert.equal(exportKeys(rootPackage).some((key) => key.includes("internals")), false, "workspace package must not mirror internal package entrypoints")
+assert.equal(exportKeys(corePackage).filter((key) => key.includes("internals")).length, 1, "core package internals entrypoint must stay quarantined to the package split")
 
 assert.deepEqual(exportKeys(playgroundPackage), [".", "./public"])
 
@@ -257,7 +258,8 @@ for (const internalExport of [
 }
 
 assert.match(docs, /@automattic\/wp-codebox-core\/internals` exists for this monorepo's package split/)
-assert.match(docs, /External integrations use the stable entrypoints listed above/)
+assert.match(docs, /workspace package does not expose a `\.\/core\/internals` mirror/)
+assert.match(docs, /External\s+integrations use the stable entrypoints listed above/)
 assert.match(docs, /New external TypeScript\s+consumers should prefer/)
 assert.match(docs, /WordPress consumers should prefer `WP_Codebox_API`/)
 assert.match(docs, /`wp-codebox\/\*` ability ids/)
@@ -277,7 +279,11 @@ assert.match(pluginReadme, /Consumers running inside WordPress should prefer `WP
 assert.match(pluginReadme, /`wp-codebox\/\*` ability/)
 assert.match(agentsApiAdapter, /Advanced internal adapter around the upstream Agents API abilities/)
 assert.match(agentsApiAdapter, /@internal Adapter boundary for WP Codebox runtime integration/)
-assert.doesNotMatch(docs + pluginReadme, /agents\/[a-z0-9._/-]+|datamachine-code\/[a-z0-9._/-]+/i)
+assert.match(agentsApiAdapter, /Consumers should[\s*]+call WP_Codebox_API or wp-codebox\/\* abilities/)
+assert.doesNotMatch(agentsApiAdapter, /Consumers should depend on this class/)
+assert.doesNotMatch(docs + pluginReadme, /agents\/[a-z0-9._/-]+|agents-api\/[a-z0-9._/-]+|datamachine-code\/[a-z0-9._/-]+/i)
+assert.doesNotMatch(docs + pluginReadme, /WP_Codebox_Agents_API_Adapter/)
+assert.doesNotMatch(docs + pluginReadme, /call raw upstream ability names|invoke raw upstream ability names/)
 
 assert.equal(typeof normalizeBrowserRunResult, "function")
 assert.equal(typeof browserRunResultEnvelope, "function")


### PR DESCRIPTION
## Summary
- Remove the workspace-level `./core/internals` export mirror so internals stay quarantined to the core package split.
- Update the public API contract docs and Agents API adapter PHPDoc so consumers are directed to `WP_Codebox_API` and `wp-codebox/*` abilities.
- Strengthen boundary tests for `internals`, direct Agents API/`agents-api` docs, and runner workspace backend operation keys.

## Tests
- `npm run test:public-api-contract`
- `npm run test:production-boundary-enforcement`
- `npx tsx tests/docs-boundary-language.test.ts`
- `npm run build`

## Follow-ups
- Full removal of `@automattic/wp-codebox-core/internals` remains larger because CLI and Playground packages still import that monorepo package-split surface.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Focused implementation, tests, docs, verification, and PR drafting.
