### PR TITLE
Add generic runtime provider primitives

### DIFF
--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -1,7 +1,12 @@
 import { AGENT_TASK_RUN_RESULT_SCHEMA, normalizeAgentTaskRunResult, type AgentTaskRunResultSummary } from "./agent-task-run-result.js"
+import { AGENT_RUNTIME_WORKLOAD_SCHEMA } from "./agent-runtime-workload.js"
 import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, normalizeArtifactResultEnvelope, type ArtifactResultEnvelope } from "./artifact-result-envelope.js"
 import { FANOUT_AGGREGATION_INPUT_SCHEMA, FANOUT_AGGREGATION_OUTPUT_SCHEMA, aggregateFanoutOutputs, normalizeFanoutAggregationInput, type FanoutAggregationInput, type FanoutAggregationInputRequest, type FanoutAggregationOutput } from "./fanout-aggregation.js"
+import { HOST_DELEGATION_EVENT_SCHEMA, HOST_DELEGATION_REQUEST_SCHEMA, HOST_DELEGATION_RESULT_SCHEMA } from "./fanout-contracts.js"
+import { ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA, BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA } from "./materialization-contracts.js"
 import { PARENT_TOOL_BRIDGE_SCHEMA, PARENT_TOOL_REQUEST_SCHEMA, PARENT_TOOL_RESULT_SCHEMA } from "./parent-tool-bridge.js"
+import { PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA, PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA, PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA } from "./provider-runtime-contracts.js"
+import { RUNTIME_RUN_RESULT_SCHEMA } from "./run-registry.js"
 import { CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY, RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA, RUNTIME_PACKAGE_EXECUTION_INPUT_SCHEMA, RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA, RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA } from "./runtime-package-execution.js"
 import { WORDPRESS_REST_MATRIX_RESULT_SCHEMA, WORDPRESS_REST_MATRIX_SCHEMA } from "./rest-matrix-contracts.js"
 import { BROWSER_CONTAINED_SITE_OPEN_SCHEMA, BROWSER_CONTAINED_SITE_STATUS_SCHEMA, BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA, BROWSER_SESSION_PRODUCT_DTO_SCHEMA, PREVIEW_LEASE_SCHEMA, RUNTIME_PROFILE_SCHEMA, runtimeProfile, type RuntimeProfile } from "./runtime-boundary-contracts.js"
@@ -54,10 +59,42 @@ export const RUNTIME_CONTRACT_SCHEMAS = {
     browserSessionProductDto: BROWSER_SESSION_PRODUCT_DTO_SCHEMA,
     browserPreviewBootConfig: BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA,
   },
+  browserSession: {
+    productDto: BROWSER_SESSION_PRODUCT_DTO_SCHEMA,
+    containedSiteStatus: BROWSER_CONTAINED_SITE_STATUS_SCHEMA,
+    containedSiteOpen: BROWSER_CONTAINED_SITE_OPEN_SCHEMA,
+    previewBootConfig: BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA,
+  },
+  preview: {
+    lease: PREVIEW_LEASE_SCHEMA,
+  },
   artifact: {
     resultEnvelope: ARTIFACT_RESULT_ENVELOPE_SCHEMA,
     runtimePackageDeclaration: RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA,
     runtimePackageProjection: RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA,
+    bundleFileManifest: ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA,
+    browserArtifactPersistenceRef: BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA,
+  },
+  artifactBundle: {
+    resultEnvelope: ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+    fileManifest: ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA,
+    browserPersistenceRef: BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA,
+  },
+  taskState: {
+    agentTaskRunResult: AGENT_TASK_RUN_RESULT_SCHEMA,
+    runtimeRunResult: RUNTIME_RUN_RESULT_SCHEMA,
+    agentRuntimeWorkload: AGENT_RUNTIME_WORKLOAD_SCHEMA,
+  },
+  runtimeProvider: {
+    invocationContract: PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
+    credentialRequirements: PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA,
+    credentialPreflight: PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA,
+    credentialResolution: PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA,
+  },
+  hostDelegation: {
+    request: HOST_DELEGATION_REQUEST_SCHEMA,
+    result: HOST_DELEGATION_RESULT_SCHEMA,
+    event: HOST_DELEGATION_EVENT_SCHEMA,
   },
   runtimePackage: {
     executionInput: RUNTIME_PACKAGE_EXECUTION_INPUT_SCHEMA,
@@ -112,7 +149,7 @@ export function runtimeContractManifest(): RuntimeContractManifest {
 }
 
 export function runtimeContractSchemaValues(): RuntimeContractSchema[] {
-  return Object.values(RUNTIME_CONTRACT_SCHEMAS).flatMap((group) => Object.values(group)) as RuntimeContractSchema[]
+  return [...new Set(Object.values(RUNTIME_CONTRACT_SCHEMAS).flatMap((group) => Object.values(group)))] as RuntimeContractSchema[]
 }
 
 export function isRuntimeContractSchema(value: unknown): value is RuntimeContractSchema {

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -151,6 +151,23 @@ final class WP_Codebox_Agents_API_Adapter {
 		add_filter( 'wp_codebox_browser_runtime_resolved_tools_filter', array( self::class, 'runtime_resolved_tools_filter' ) );
 	}
 
+	public static function register_runtime_provider(): void {
+		if ( ! class_exists( 'WP_Codebox_Runtime_Provider_Registry' ) ) {
+			return;
+		}
+
+		WP_Codebox_Runtime_Provider_Registry::register(
+			'agents-api-adapter',
+			array( new self(), 'run_runtime_package' ),
+			array(
+				'default'      => true,
+				'label'        => 'Agents API runtime adapter',
+				'kind'         => 'ability-adapter',
+				'capabilities' => array( 'runtime-package' ),
+			)
+		);
+	}
+
 	/** @return array<string,string> */
 	public static function browser_runtime_default_invocation(): array {
 		return array(

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-provider-registry.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-provider-registry.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Runtime provider registry for WP Codebox package execution.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Generic runtime provider registry used by wp-codebox/run-runtime-package.
+ *
+ * Providers are adapters behind the Codebox ability contract. The public ability
+ * remains runtime-neutral and does not expose upstream provider ability names.
+ */
+final class WP_Codebox_Runtime_Provider_Registry {
+
+	/** @var array<string,array{callback:callable,metadata:array<string,mixed>}> */
+	private static array $providers = array();
+
+	private static string $default_provider = '';
+
+	/** @param array<string,mixed> $metadata Provider metadata. */
+	public static function register( string $id, callable $callback, array $metadata = array() ): void {
+		$id = self::normalize_provider_id( $id );
+		if ( '' === $id ) {
+			return;
+		}
+
+		self::$providers[ $id ] = array(
+			'callback' => $callback,
+			'metadata' => self::public_metadata( $id, $metadata ),
+		);
+
+		if ( '' === self::$default_provider || true === ( $metadata['default'] ?? false ) ) {
+			self::$default_provider = $id;
+		}
+	}
+
+	/** @return array<string,array<string,mixed>> */
+	public static function providers(): array {
+		return array_map(
+			static fn( array $provider ): array => $provider['metadata'],
+			self::$providers
+		);
+	}
+
+	public static function default_provider(): string {
+		return self::$default_provider;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public static function invoke( array $input ): array|WP_Error {
+		$provider_id = self::requested_provider_id( $input );
+		if ( '' === $provider_id ) {
+			$provider_id = self::$default_provider;
+		}
+
+		if ( '' === $provider_id || ! isset( self::$providers[ $provider_id ] ) ) {
+			return new WP_Error(
+				'wp_codebox_runtime_provider_unavailable',
+				'The requested runtime provider is unavailable.',
+				array(
+					'status' => 500,
+					'provider' => $provider_id,
+					'available_providers' => array_keys( self::$providers ),
+				)
+			);
+		}
+
+		$result = call_user_func( self::$providers[ $provider_id ]['callback'], $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( ! is_array( $result ) ) {
+			return new WP_Error( 'wp_codebox_runtime_provider_invalid_result', 'The runtime provider returned an invalid result.', array( 'status' => 500, 'provider' => $provider_id ) );
+		}
+
+		$result['runtime_provider'] = self::$providers[ $provider_id ]['metadata'];
+		return $result;
+	}
+
+	/** @param array<string,mixed> $input Ability input. */
+	private static function requested_provider_id( array $input ): string {
+		foreach ( array( 'runtime_provider', 'runtime_provider_id' ) as $field ) {
+			$value = $input[ $field ] ?? null;
+			if ( is_array( $value ) ) {
+				$value = $value['id'] ?? $value['provider'] ?? '';
+			}
+			$id = self::normalize_provider_id( is_string( $value ) ? $value : '' );
+			if ( '' !== $id ) {
+				return $id;
+			}
+		}
+
+		return '';
+	}
+
+	private static function normalize_provider_id( string $id ): string {
+		$id = strtolower( trim( $id ) );
+		return preg_replace( '/[^a-z0-9_-]+/', '-', $id ) ?? '';
+	}
+
+	/** @param array<string,mixed> $metadata Provider metadata. @return array<string,mixed> */
+	private static function public_metadata( string $id, array $metadata ): array {
+		return array_filter(
+			array(
+				'id' => $id,
+				'label' => is_string( $metadata['label'] ?? null ) ? $metadata['label'] : $id,
+				'kind' => is_string( $metadata['kind'] ?? null ) ? $metadata['kind'] : 'adapter',
+				'capabilities' => is_array( $metadata['capabilities'] ?? null ) ? array_values( $metadata['capabilities'] ) : array(),
+			),
+			static fn( mixed $value ): bool => array() !== $value && '' !== $value
+		);
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -25,7 +25,7 @@ public static function run_agent_task_fanout( array $input ): array|WP_Error {
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function run_runtime_package( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Agents_API_Adapter() )->run_runtime_package( $input );
+	return WP_Codebox_Runtime_Provider_Registry::invoke( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -51,6 +51,7 @@ require_once __DIR__ . '/src/class-wp-codebox-fanout-aggregation.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-process-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-run-result-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-outcome-classifier.php';
+require_once __DIR__ . '/src/class-wp-codebox-runtime-provider-registry.php';
 require_once __DIR__ . '/src/class-wp-codebox-agents-api-adapter.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-runtime-invoker.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';
@@ -68,6 +69,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 }
 
 WP_Codebox_Agents_API_Adapter::register_runtime_profiles();
+WP_Codebox_Agents_API_Adapter::register_runtime_provider();
 new WP_Codebox_Abilities();
 WP_Codebox_Browser_Provider_Bridge::register();
 

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -29,6 +29,7 @@ final class WP_Ability {
 	}
 }
 
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-provider-registry.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php';
 
 function assert_no_agents_api_schema_leaks( mixed $value, string $path = '$' ): void {
@@ -78,3 +79,29 @@ assert_no_agents_api_schema_leaks( $package, 'package' );
 $missing = $adapter->cancel_task_run( array( 'run_id' => 'task-run', 'session_id' => 'session' ) );
 assert( is_wp_error( $missing ) );
 assert( 'wp_codebox_agents_api_ability_unavailable' === $missing->get_error_code() );
+
+WP_Codebox_Agents_API_Adapter::register_runtime_provider();
+$providers = WP_Codebox_Runtime_Provider_Registry::providers();
+assert( isset( $providers['agents-api-adapter'] ) );
+assert( 'agents-api-adapter' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
+
+$runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
+assert( ! is_wp_error( $runtime_package ) );
+assert( 'wp-codebox/runtime-package-result/v1' === $runtime_package['schema'] );
+assert( 'agents-api-adapter' === $runtime_package['runtime_provider']['id'] );
+assert_no_agents_api_schema_leaks( $runtime_package, 'runtime-package-registry' );
+
+WP_Codebox_Runtime_Provider_Registry::register(
+	'Example Runtime',
+	static fn( array $input ): array => array( 'schema' => 'wp-codebox/example-runtime-result/v1', 'received' => $input ),
+	array( 'label' => 'Example runtime', 'capabilities' => array( 'runtime-package' ) )
+);
+
+$explicit_runtime = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'runtime_provider' => array( 'id' => 'example-runtime' ) ) );
+assert( ! is_wp_error( $explicit_runtime ) );
+assert( 'example-runtime' === $explicit_runtime['runtime_provider']['id'] );
+assert( 'wp-codebox/example-runtime-result/v1' === $explicit_runtime['schema'] );
+
+$unknown_runtime = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'runtime_provider_id' => 'missing-runtime' ) );
+assert( is_wp_error( $unknown_runtime ) );
+assert( 'wp_codebox_runtime_provider_unavailable' === $unknown_runtime->get_error_code() );

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict"
 
 import {
+  AGENT_RUNTIME_WORKLOAD_SCHEMA,
   AGENT_TASK_RUN_RESULT_SCHEMA,
+  ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA,
   ARTIFACT_RESULT_ENVELOPE_SCHEMA,
+  BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA,
+  BROWSER_CONTAINED_SITE_OPEN_SCHEMA,
+  BROWSER_CONTAINED_SITE_STATUS_SCHEMA,
+  BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA,
+  BROWSER_SESSION_PRODUCT_DTO_SCHEMA,
   CODEBOX_PUBLIC_RUNTIME_ABILITIES,
   CODEBOX_RUN_AGENT_TASK_ABILITY,
   CODEBOX_RUN_AGENT_TASK_BATCH_ABILITY,
@@ -13,9 +20,17 @@ import {
   CODEBOX_RUN_SANDBOX_TASK_FANOUT_ABILITY,
   FANOUT_AGGREGATION_INPUT_SCHEMA,
   FANOUT_AGGREGATION_OUTPUT_SCHEMA,
+  HOST_DELEGATION_EVENT_SCHEMA,
+  HOST_DELEGATION_REQUEST_SCHEMA,
+  HOST_DELEGATION_RESULT_SCHEMA,
   PARENT_TOOL_BRIDGE_SCHEMA,
   PARENT_TOOL_REQUEST_SCHEMA,
   PARENT_TOOL_RESULT_SCHEMA,
+  PREVIEW_LEASE_SCHEMA,
+  PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA,
+  PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA,
+  PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA,
+  PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
   RUNTIME_CONTRACT_MANIFEST_SCHEMA,
   RUNTIME_CONTRACT_NORMALIZERS,
   RUNTIME_CONTRACT_SCHEMAS,
@@ -24,6 +39,7 @@ import {
   RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA,
   RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA,
   RUNTIME_PROFILE_SCHEMA,
+  RUNTIME_RUN_RESULT_SCHEMA,
   WORDPRESS_REST_MATRIX_RESULT_SCHEMA,
   WORDPRESS_REST_MATRIX_SCHEMA,
   RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA,
@@ -46,9 +62,31 @@ assert.deepEqual(manifest.abilities, CODEBOX_PUBLIC_RUNTIME_ABILITIES)
 
 assert.equal(manifest.schemas.agentTask.runResult, AGENT_TASK_RUN_RESULT_SCHEMA)
 assert.equal(manifest.schemas.runtimeBoundary.profile, RUNTIME_PROFILE_SCHEMA)
+assert.equal(manifest.schemas.runtimeBoundary.previewLease, PREVIEW_LEASE_SCHEMA)
+assert.equal(manifest.schemas.runtimeBoundary.browserSessionProductDto, BROWSER_SESSION_PRODUCT_DTO_SCHEMA)
+assert.equal(manifest.schemas.browserSession.productDto, BROWSER_SESSION_PRODUCT_DTO_SCHEMA)
+assert.equal(manifest.schemas.browserSession.containedSiteStatus, BROWSER_CONTAINED_SITE_STATUS_SCHEMA)
+assert.equal(manifest.schemas.browserSession.containedSiteOpen, BROWSER_CONTAINED_SITE_OPEN_SCHEMA)
+assert.equal(manifest.schemas.browserSession.previewBootConfig, BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA)
+assert.equal(manifest.schemas.preview.lease, PREVIEW_LEASE_SCHEMA)
 assert.equal(manifest.schemas.artifact.resultEnvelope, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
 assert.equal(manifest.schemas.artifact.runtimePackageDeclaration, RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA)
 assert.equal(manifest.schemas.artifact.runtimePackageProjection, RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA)
+assert.equal(manifest.schemas.artifact.bundleFileManifest, ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA)
+assert.equal(manifest.schemas.artifact.browserArtifactPersistenceRef, BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA)
+assert.equal(manifest.schemas.artifactBundle.resultEnvelope, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
+assert.equal(manifest.schemas.artifactBundle.fileManifest, ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA)
+assert.equal(manifest.schemas.artifactBundle.browserPersistenceRef, BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA)
+assert.equal(manifest.schemas.taskState.agentTaskRunResult, AGENT_TASK_RUN_RESULT_SCHEMA)
+assert.equal(manifest.schemas.taskState.runtimeRunResult, RUNTIME_RUN_RESULT_SCHEMA)
+assert.equal(manifest.schemas.taskState.agentRuntimeWorkload, AGENT_RUNTIME_WORKLOAD_SCHEMA)
+assert.equal(manifest.schemas.runtimeProvider.invocationContract, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
+assert.equal(manifest.schemas.runtimeProvider.credentialRequirements, PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA)
+assert.equal(manifest.schemas.runtimeProvider.credentialPreflight, PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA)
+assert.equal(manifest.schemas.runtimeProvider.credentialResolution, PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA)
+assert.equal(manifest.schemas.hostDelegation.request, HOST_DELEGATION_REQUEST_SCHEMA)
+assert.equal(manifest.schemas.hostDelegation.result, HOST_DELEGATION_RESULT_SCHEMA)
+assert.equal(manifest.schemas.hostDelegation.event, HOST_DELEGATION_EVENT_SCHEMA)
 assert.equal(manifest.schemas.runtimePackage.executionInput, RUNTIME_PACKAGE_EXECUTION_INPUT_SCHEMA)
 assert.equal(manifest.schemas.runtimePackage.executionResult, RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA)
 assert.equal(manifest.schemas.runnerWorkspace.prepareResult, RUNNER_WORKSPACE_PREPARE_RESULT_SCHEMA)


### PR DESCRIPTION
## Summary
- Route wp-codebox/run-runtime-package through a Codebox-owned runtime provider registry.
- Register the Agents API runtime package adapter behind that generic provider seam.
- Extend the runtime contract manifest with stable generic groups for browser sessions, previews, artifact bundles, task state, runtime providers, and host delegation while preserving existing runtimeBoundary aliases.

## Tests
- npm run test:runtime-contract-manifest
- npm run test:agent-runtime-workload-normalizers
- npm run test:runtime-package-execution
- npm run test:php-agents-api-adapter-contract
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented generic runtime primitive cleanup and tests.