### PR TITLE
Expand WP Codebox API facade coverage

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-api.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-api.php
@@ -17,16 +17,26 @@ final class WP_Codebox_API {
 		'wp-codebox/run-agent-task'                         => 'run_agent_task',
 		'wp-codebox/run-agent-task-batch'                   => 'run_agent_task_batch',
 		'wp-codebox/run-agent-task-fanout'                  => 'run_agent_task_fanout',
+		'wp-codebox/run-runtime-task'                       => 'run_runtime_task',
+		'wp-codebox/run-runtime-package'                    => 'run_runtime_package',
 		'wp-codebox/create-browser-playground-session'      => 'create_browser_session',
 		'wp-codebox/create-sandbox-session'                 => 'create_browser_session',
+		'wp-codebox/create-browser-task-contract'           => 'create_browser_task_contract',
+		'wp-codebox/create-task-contract'                   => 'create_browser_task_contract',
+		'wp-codebox/create-browser-materializer-contract'   => 'create_browser_materializer_contract',
 		'wp-codebox/create-browser-contained-site-session'  => 'create_browser_contained_site_session',
-		'wp-codebox/get-browser-contained-site-status'      => 'get_browser_session_status',
+		'wp-codebox/get-browser-contained-site-status'      => 'browser_contained_site_status',
 		'wp-codebox/preview-reuse-decision'                 => 'preview_reuse_decision',
 		'wp-codebox/open-browser-contained-site'            => 'open_browser_session',
-		'wp-codebox/open-or-create-browser-contained-site'  => 'open_or_create_browser_session',
-		'wp-codebox/open-contained-runtime'                 => 'open_or_create_browser_session',
+		'wp-codebox/open-or-create-browser-contained-site'  => 'open_or_create_browser_contained_site',
+		'wp-codebox/open-contained-runtime'                 => 'open_or_create_browser_contained_site',
+		'wp-codebox/request-host-delegation'                => 'request_host_delegation',
 		'wp-codebox/list-artifacts'                         => 'list_artifacts',
 		'wp-codebox/get-artifact'                           => 'get_artifact',
+		'wp-codebox/normalize-browser-artifact-bundle'      => 'normalize_artifact_bundle',
+		'wp-codebox/persist-browser-artifact'               => 'persist_artifact',
+		'wp-codebox/import-artifact-bundle'                 => 'import_artifact',
+		'wp-codebox/reimport-artifact-bundle'               => 'reimport_artifact',
 		'wp-codebox/apply-artifact-preflight'               => 'preflight_artifact_apply',
 		'wp-codebox/stage-artifact-apply'                   => 'stage_artifact_apply',
 		'wp-codebox/apply-approved-artifact'                => 'apply_approved_artifact',
@@ -70,9 +80,29 @@ final class WP_Codebox_API {
 		return WP_Codebox_Abilities::run_agent_task_fanout( $input );
 	}
 
+	/** @param array<string,mixed> $input Runtime task input. @return array<string,mixed>|WP_Error */
+	public static function run_runtime_task( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_runtime_task( $input );
+	}
+
+	/** @param array<string,mixed> $input Runtime package input. @return array<string,mixed>|WP_Error */
+	public static function run_runtime_package( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_runtime_package( $input );
+	}
+
 	/** @param array<string,mixed> $input Browser session input. @return array<string,mixed>|WP_Error */
 	public static function create_browser_session( array $input ): array|WP_Error {
 		return WP_Codebox_Abilities::create_browser_playground_session( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser task contract input. @return array<string,mixed>|WP_Error */
+	public static function create_browser_task_contract( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::create_browser_task_contract( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser materializer contract input. @return array<string,mixed>|WP_Error */
+	public static function create_browser_materializer_contract( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::create_browser_materializer_contract( $input );
 	}
 
 	/** @param array<string,mixed> $input Browser contained-site session input. @return array<string,mixed>|WP_Error */
@@ -82,6 +112,11 @@ final class WP_Codebox_API {
 
 	/** @param array<string,mixed> $input Browser session lookup input. @return array<string,mixed>|WP_Error */
 	public static function get_browser_session_status( array $input ): array|WP_Error {
+		return self::browser_contained_site_status( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser contained-site status input. @return array<string,mixed>|WP_Error */
+	public static function browser_contained_site_status( array $input ): array|WP_Error {
 		return WP_Codebox_Abilities::get_browser_contained_site_status( $input );
 	}
 
@@ -97,7 +132,17 @@ final class WP_Codebox_API {
 
 	/** @param array<string,mixed> $input Browser session input. @return array<string,mixed>|WP_Error */
 	public static function open_or_create_browser_session( array $input ): array|WP_Error {
+		return self::open_or_create_browser_contained_site( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser contained-site input. @return array<string,mixed>|WP_Error */
+	public static function open_or_create_browser_contained_site( array $input ): array|WP_Error {
 		return WP_Codebox_Abilities::open_or_create_browser_contained_site( $input );
+	}
+
+	/** @param array<string,mixed> $input Host delegation input. @return array<string,mixed>|WP_Error */
+	public static function request_host_delegation( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::request_host_delegation( $input );
 	}
 
 	/** @param array<string,mixed> $input Artifact list input. @return array<string,mixed>|WP_Error */
@@ -108,6 +153,26 @@ final class WP_Codebox_API {
 	/** @param array<string,mixed> $input Artifact lookup input. @return array<string,mixed>|WP_Error */
 	public static function get_artifact( array $input ): array|WP_Error {
 		return WP_Codebox_Abilities::get_artifact( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact bundle normalization input. @return array<string,mixed>|WP_Error */
+	public static function normalize_artifact_bundle( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::normalize_browser_artifact_bundle( $input );
+	}
+
+	/** @param array<string,mixed> $input Browser artifact persistence input. @return array<string,mixed>|WP_Error */
+	public static function persist_artifact( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::persist_browser_artifact( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact bundle import input. @return array<string,mixed>|WP_Error */
+	public static function import_artifact( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::import_artifact_bundle( $input );
+	}
+
+	/** @param array<string,mixed> $input Artifact bundle reimport input. @return array<string,mixed>|WP_Error */
+	public static function reimport_artifact( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::reimport_artifact_bundle( $input );
 	}
 
 	/** @param array<string,mixed> $input Artifact apply input. @return array<string,mixed>|WP_Error */

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -38,6 +38,61 @@ final class WP_Codebox_Abilities {
 	}
 
 	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_runtime_task( array $input ): array {
+		return self::record( 'run_runtime_task', 'wp-codebox/runtime-task-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_runtime_package( array $input ): array {
+		return self::record( 'run_runtime_package', 'wp-codebox/runtime-package-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function create_browser_task_contract( array $input ): array {
+		return self::record( 'create_browser_task_contract', 'wp-codebox/browser-task-contract/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function create_browser_materializer_contract( array $input ): array {
+		return self::record( 'create_browser_materializer_contract', 'wp-codebox/browser-materializer-contract/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function get_browser_contained_site_status( array $input ): array {
+		return self::record( 'get_browser_contained_site_status', 'wp-codebox/browser-contained-site-status/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function open_or_create_browser_contained_site( array $input ): array {
+		return self::record( 'open_or_create_browser_contained_site', 'wp-codebox/browser-contained-site-open-or-create/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function request_host_delegation( array $input ): array {
+		return self::record( 'request_host_delegation', 'wp-codebox/host-delegation-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function normalize_browser_artifact_bundle( array $input ): array {
+		return self::record( 'normalize_browser_artifact_bundle', 'wp-codebox/browser-artifact-bundle/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function persist_browser_artifact( array $input ): array {
+		return self::record( 'persist_browser_artifact', 'wp-codebox/artifact-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function import_artifact_bundle( array $input ): array {
+		return self::record( 'import_artifact_bundle', 'wp-codebox/import-artifact-bundle/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function reimport_artifact_bundle( array $input ): array {
+		return self::record( 'reimport_artifact_bundle', 'wp-codebox/reimport-artifact-bundle/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
 	private static function record( string $method, string $schema, array $input ): array {
 		self::$calls[] = array( 'method' => $method, 'input' => $input );
 		return array( 'success' => true, 'schema' => $schema, 'method' => $method );
@@ -56,14 +111,25 @@ $expected_methods = array(
 	'run_agent_task',
 	'run_agent_task_batch',
 	'run_agent_task_fanout',
+	'run_runtime_task',
+	'run_runtime_package',
 	'create_browser_session',
+	'create_browser_task_contract',
+	'create_browser_materializer_contract',
 	'create_browser_contained_site_session',
 	'get_browser_session_status',
+	'browser_contained_site_status',
 	'preview_reuse_decision',
 	'open_browser_session',
 	'open_or_create_browser_session',
+	'open_or_create_browser_contained_site',
+	'request_host_delegation',
 	'list_artifacts',
 	'get_artifact',
+	'normalize_artifact_bundle',
+	'persist_artifact',
+	'import_artifact',
+	'reimport_artifact',
 	'preflight_artifact_apply',
 	'stage_artifact_apply',
 	'apply_approved_artifact',
@@ -84,6 +150,11 @@ expect( $blocked instanceof WP_Error, 'Expected non-wp-codebox ability names to 
 expect( 'wp_codebox_api_ability_not_supported' === $blocked->get_error_code(), 'Expected unsupported ability error code.' );
 expect( ! str_contains( json_encode( $blocked->get_error_data(), JSON_UNESCAPED_SLASHES ) ?: '', 'external-backend' ), 'Unsupported ability errors must not echo backend ability names.' );
 
+foreach ( array( 'agents/run-runtime-package', 'datamachine/jobs-list', 'playground/run-blueprint' ) as $raw_ability ) {
+	$blocked = WP_Codebox_API::execute_ability( $raw_ability, array() );
+	expect( $blocked instanceof WP_Error, 'Expected raw backend ability name to be rejected: ' . $raw_ability );
+}
+
 $runner_workspace_abilities = array(
 	'wp-codebox/runner-workspace-prepare' => array( 'method' => 'prepare_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-prepare-result/v1' ),
 	'wp-codebox/runner-workspace-capture' => array( 'method' => 'capture_runner_workspace', 'schema' => 'wp-codebox/runner-workspace-capture-result/v1' ),
@@ -100,6 +171,40 @@ foreach ( $runner_workspace_abilities as $ability_name => $expected ) {
 	expect( is_array( $result ), 'Expected runner workspace facade result for ' . $ability_name );
 	expect( $expected['method'] === $result['method'], 'Expected runner workspace facade method for ' . $ability_name );
 	expect( $expected['schema'] === $result['schema'], 'Expected runner workspace facade schema for ' . $ability_name );
+}
+
+$public_abilities = array(
+	'wp-codebox/run-runtime-task' => array( 'method' => 'run_runtime_task', 'schema' => 'wp-codebox/runtime-task-result/v1' ),
+	'wp-codebox/run-runtime-package' => array( 'method' => 'run_runtime_package', 'schema' => 'wp-codebox/runtime-package-result/v1' ),
+	'wp-codebox/create-browser-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),
+	'wp-codebox/create-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),
+	'wp-codebox/create-browser-materializer-contract' => array( 'method' => 'create_browser_materializer_contract', 'schema' => 'wp-codebox/browser-materializer-contract/v1' ),
+	'wp-codebox/open-or-create-browser-contained-site' => array( 'method' => 'open_or_create_browser_contained_site', 'schema' => 'wp-codebox/browser-contained-site-open-or-create/v1' ),
+	'wp-codebox/open-contained-runtime' => array( 'method' => 'open_or_create_browser_contained_site', 'schema' => 'wp-codebox/browser-contained-site-open-or-create/v1' ),
+	'wp-codebox/get-browser-contained-site-status' => array( 'method' => 'get_browser_contained_site_status', 'schema' => 'wp-codebox/browser-contained-site-status/v1' ),
+	'wp-codebox/normalize-browser-artifact-bundle' => array( 'method' => 'normalize_browser_artifact_bundle', 'schema' => 'wp-codebox/browser-artifact-bundle/v1' ),
+	'wp-codebox/persist-browser-artifact' => array( 'method' => 'persist_browser_artifact', 'schema' => 'wp-codebox/artifact-result/v1' ),
+	'wp-codebox/import-artifact-bundle' => array( 'method' => 'import_artifact_bundle', 'schema' => 'wp-codebox/import-artifact-bundle/v1' ),
+	'wp-codebox/reimport-artifact-bundle' => array( 'method' => 'reimport_artifact_bundle', 'schema' => 'wp-codebox/reimport-artifact-bundle/v1' ),
+	'wp-codebox/request-host-delegation' => array( 'method' => 'request_host_delegation', 'schema' => 'wp-codebox/host-delegation-result/v1' ),
+);
+
+foreach ( $public_abilities as $ability_name => $expected ) {
+	$result = WP_Codebox_API::execute_ability( $ability_name, array( 'goal' => 'Exercise public facade dispatch.' ) );
+	expect( is_array( $result ), 'Expected public facade result for ' . $ability_name );
+	expect( $expected['method'] === $result['method'], 'Expected public facade method for ' . $ability_name );
+	expect( $expected['schema'] === $result['schema'], 'Expected public facade schema for ' . $ability_name );
+}
+
+foreach ( array(
+	'wp-codebox/browser-contained-site-status',
+	'wp-codebox/normalize-artifact-bundle',
+	'wp-codebox/persist-artifact',
+	'wp-codebox/import-artifact',
+	'wp-codebox/reimport-artifact',
+) as $unregistered_short_name ) {
+	$blocked = WP_Codebox_API::execute_ability( $unregistered_short_name, array() );
+	expect( $blocked instanceof WP_Error, 'Expected unregistered shorthand ability to be rejected: ' . $unregistered_short_name );
 }
 
 fwrite( STDOUT, "PHP public API facade smoke passed\n" );


### PR DESCRIPTION
## Summary
- Add direct `WP_Codebox_API` facade methods for runtime task/package execution, browser task/materializer contracts, contained-site open/status, artifact bundle lifecycle, and host delegation.
- Wire `execute_ability()` to dispatch the existing canonical `wp-codebox/*` ability names plus existing aliases, without accepting raw backend namespaces or new shorthand ability aliases.
- Extend the PHP public facade smoke test to assert public dispatch targets and backend/raw ability rejection.

## Tests
- `npm run test:php-public-api-facade`
- `npm run test:public-ability-aliases`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the focused facade coverage change, updating targeted tests, and preparing this PR description.
