### PR TITLE
Neutralize internal runtime names

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -437,7 +437,7 @@ function sandboxToolContract(policy: SandboxToolPolicySnapshot): Record<string, 
 }
 
 function runtimePrincipal(agent: string | undefined, sessionId: string | undefined, mode: string): Record<string, unknown> {
-  const runtimeId = sessionId?.trim() || "wp-codebox-runtime"
+  const runtimeId = sessionId?.trim() || "contained-runtime"
   return {
     acting_user_id: 0,
     effective_agent_id: agent || "wp-codebox-agent",
@@ -666,7 +666,7 @@ function providerPluginResolutionPhp(): string {
     if (file_exists($normal_path)) {
         return array('path' => $normal_path, 'load_as' => 'plugin');
     }
-    $mu_path = WPMU_PLUGIN_DIR . '/wp-codebox-runtime/' . $plugin;
+    $mu_path = WPMU_PLUGIN_DIR . '/contained-runtime/' . $plugin;
     if (file_exists($mu_path)) {
         return array('path' => $mu_path, 'load_as' => 'mu-plugin');
     }
@@ -743,7 +743,7 @@ function wp_codebox_provider_plugin_entry_by_header(string $slug): ?string {
     // matches the entry file (e.g. a Lab workspace synced under a uniquified
     // <slug>-<hash>-<uuid> directory). Fall back to the single top-level *.php
     // file declaring a WordPress plugin header.
-    foreach (array(WP_PLUGIN_DIR . '/' . $slug, WPMU_PLUGIN_DIR . '/wp-codebox-runtime/' . $slug) as $dir) {
+    foreach (array(WP_PLUGIN_DIR . '/' . $slug, WPMU_PLUGIN_DIR . '/contained-runtime/' . $slug) as $dir) {
         if (!is_dir($dir)) {
             continue;
         }

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -491,7 +491,7 @@ function defaultRuntimeComponents(): AgentRuntimeComponent[] {
 }
 
 function defaultRuntimeComponentPaths(): string[] {
-  return (process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
+  return (process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
     .split(/[,:]/)
     .map((value) => value.trim())
     .filter(Boolean)
@@ -555,7 +555,7 @@ function providerPluginContracts(args: string[]): Array<{ slug: string; pluginFi
 }
 
 function pluginTarget(slug: string, loadAs: ComponentLoadMode): string {
-  return loadAs === "mu-plugin" ? `/wordpress/wp-content/mu-plugins/wp-codebox-runtime/${slug}` : `/wordpress/wp-content/plugins/${slug}`
+  return loadAs === "mu-plugin" ? `/wordpress/wp-content/mu-plugins/contained-runtime/${slug}` : `/wordpress/wp-content/plugins/${slug}`
 }
 
 function parseTaskList(raw: string): string[] {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1329,7 +1329,7 @@ function componentContractFailures(plugin: PreparedExtraPlugin, phases: RecipePh
 }
 
 function pluginTargetForReport(slug: string, loadAs: string): string {
-  return loadAs === "mu-plugin" ? `/wordpress/wp-content/mu-plugins/wp-codebox-runtime/${slug}` : `/wordpress/wp-content/plugins/${slug}`
+  return loadAs === "mu-plugin" ? `/wordpress/wp-content/mu-plugins/contained-runtime/${slug}` : `/wordpress/wp-content/plugins/${slug}`
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -1279,7 +1279,7 @@ export function recipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin): strin
 
 export function pluginTarget(slug: string, loadAs: PreparedExtraPlugin["loadAs"]): string {
   if (loadAs === "mu-plugin") {
-    return `/wordpress/wp-content/mu-plugins/wp-codebox-runtime/${slug}`
+    return `/wordpress/wp-content/mu-plugins/contained-runtime/${slug}`
   }
 
   return `/wordpress/wp-content/plugins/${slug}`
@@ -1332,14 +1332,14 @@ export function installMuPluginsCode(extraPlugins: PreparedExtraPlugin[]): strin
   }
 
   return `$plugins = ${JSON.stringify(muPlugins)};
-$runtime_dir = WPMU_PLUGIN_DIR . '/wp-codebox-runtime';
+$runtime_dir = WPMU_PLUGIN_DIR . '/contained-runtime';
 if (!is_dir(WPMU_PLUGIN_DIR) && !mkdir(WPMU_PLUGIN_DIR, 0777, true) && !is_dir(WPMU_PLUGIN_DIR)) {
     throw new RuntimeException('Could not create mu-plugins directory.');
 }
 if (!is_dir($runtime_dir)) {
     throw new RuntimeException('WP Codebox runtime mu-plugin directory is not mounted.');
 }
-$loader = WPMU_PLUGIN_DIR . '/wp-codebox-runtime-loader.php';
+$loader = WPMU_PLUGIN_DIR . '/contained-runtime-loader.php';
 $lines = array(
     '<?php',
     '/**',
@@ -1358,7 +1358,7 @@ foreach ($plugins as $plugin) {
     if (!file_exists($plugin_file)) {
         throw new RuntimeException(sprintf('WP Codebox runtime mu-plugin is not mounted: %s', $plugin));
     }
-    $lines[] = "require_once WPMU_PLUGIN_DIR . '/wp-codebox-runtime/" . str_replace("'", "\\'", $plugin) . "';";
+    $lines[] = "require_once WPMU_PLUGIN_DIR . '/contained-runtime/" . str_replace("'", "\\'", $plugin) . "';";
 }
 if (false === file_put_contents($loader, implode("\\n", $lines) . "\\n")) {
     throw new RuntimeException('Could not write WP Codebox runtime mu-plugin loader.');

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -182,13 +182,13 @@ function defaultRuntimeComponentPlugins(): WorkspaceRecipeExtraPlugin[] {
       pluginFile: entrypoint.pluginFile,
       activate: false,
       loadAs: "mu-plugin" as const,
-      metadata: { source: "wp-codebox-default-agent-runtime-substrate" },
+      metadata: { source: "contained-runtime-default-agent-substrate" },
     }
   })
 }
 
 function defaultRuntimeComponentPaths(): string[] {
-  return (process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
+  return (process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
     .split(/[,:]/)
     .map((value) => value.trim())
     .filter(Boolean)
@@ -276,7 +276,7 @@ function stripEmptyContractFields(value: Record<string, unknown>): Record<string
 
 function componentMountedPath(slug: string, loadAs: "plugin" | "mu-plugin"): string {
   return loadAs === "mu-plugin"
-    ? `/wordpress/wp-content/mu-plugins/wp-codebox-runtime/${slug}`
+    ? `/wordpress/wp-content/mu-plugins/contained-runtime/${slug}`
     : `/wordpress/wp-content/plugins/${slug}`
 }
 
@@ -441,7 +441,7 @@ function sandboxToolPolicy(input: AgentTaskRunInput, taskInput: TaskInput): Sand
     schema: "wp-codebox/sandbox-tool-policy/v1",
     version: 1,
     tools: [{ id: "deny-all", runtime_tool_id: "deny-all", execution_location: "parent", transport_visibility: "hidden", allowed: false, runtime: { environment: "control_plane", capability_scope: "control_plane" } }],
-    metadata: { source: "wp-codebox.agent-task-run.default-deny" },
+    metadata: { source: "contained-runtime.agent-task-run.default-deny" },
   }
 }
 

--- a/packages/runtime-core/src/runtime-php-snippets.ts
+++ b/packages/runtime-core/src/runtime-php-snippets.ts
@@ -91,7 +91,7 @@ function ${abilityNames}(): array {
     return is_array($abilities) ? array_values(array_map('strval', array_keys($abilities))) : array();
 }
 function ${prepare}(): array {
-    $hooks = array('plugins_loaded', 'init', 'wp_abilities_api_categories_init', 'wp_abilities_api_init', 'wp_codebox_runtime_abilities_ready');
+    $hooks = array('plugins_loaded', 'init', 'wp_abilities_api_categories_init', 'wp_abilities_api_init', 'contained_runtime_abilities_ready');
     $state = array('hooks' => array(), 'abilities_before' => ${abilityNames}());
     foreach ($hooks as $hook_name) {
         $state['hooks'][$hook_name] = array(
@@ -128,14 +128,14 @@ export function phpRuntimeComponentLifecycleActionReplayFunction(functionName: s
     do_action('init');
     do_action('wp_abilities_api_categories_init');
     do_action('wp_abilities_api_init');
-    do_action('wp_codebox_runtime_abilities_ready');
+    do_action('contained_runtime_abilities_ready');
 
     return array(
         'plugins_loaded' => function_exists('did_action') ? did_action('plugins_loaded') : null,
         'init' => function_exists('did_action') ? did_action('init') : null,
         'wp_abilities_api_categories_init' => function_exists('did_action') ? did_action('wp_abilities_api_categories_init') : null,
         'wp_abilities_api_init' => function_exists('did_action') ? did_action('wp_abilities_api_init') : null,
-        'wp_codebox_runtime_abilities_ready' => function_exists('did_action') ? did_action('wp_codebox_runtime_abilities_ready') : null,
+        'contained_runtime_abilities_ready' => function_exists('did_action') ? did_action('contained_runtime_abilities_ready') : null,
     );
 }`
 }

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -939,9 +939,9 @@ function wp_codebox_bench_plugin_file_for_slug(string $plugin_slug, string $role
 }
 
 function wp_codebox_bench_manifest_plugin_file_for_slug(string $plugin_slug, string $role): ?string {
-    $manifest = $GLOBALS['wp_codebox_component_manifest'] ?? null;
+    $manifest = $GLOBALS['contained_runtime_component_manifest'] ?? null;
     if (!is_array($manifest)) {
-        $json = defined('WP_CODEBOX_COMPONENT_MANIFEST_JSON') ? WP_CODEBOX_COMPONENT_MANIFEST_JSON : '';
+        $json = defined('CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON') ? CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON : '';
         $decoded = is_string($json) && $json !== '' ? json_decode($json, true) : null;
         $manifest = is_array($decoded) ? $decoded : null;
     }

--- a/packages/runtime-playground/src/browser-auth-storage-state.ts
+++ b/packages/runtime-playground/src/browser-auth-storage-state.ts
@@ -74,7 +74,7 @@ export function normalizeBrowserStorageStatePayload(payload: unknown, source: "i
   const origins = Array.isArray(stateCandidate.origins) ? stateCandidate.origins : undefined
 
   if (!isRecord(payload)) {
-    diagnostics.push({ code: "storage-state-not-object", severity: "error", message: "storage-state must be a Playwright storageState object or wp-codebox storage-state envelope" })
+    diagnostics.push({ code: "storage-state-not-object", severity: "error", message: "storage-state must be a Playwright storageState object or runtime storage-state envelope" })
   }
   if (!cookies) {
     diagnostics.push({ code: "storage-state-cookies-invalid", severity: "error", message: "storage-state cookies must be an array" })
@@ -163,7 +163,7 @@ if ( ! is_array( $browser_urls ) ) {
     $browser_urls = array();
 }
 $requested_user_id = isset( $fixture_user['userId'] ) ? (int) $fixture_user['userId'] : 0;
-$username = isset( $fixture_user['username'] ) && is_string( $fixture_user['username'] ) && '' !== trim( $fixture_user['username'] ) ? sanitize_user( $fixture_user['username'], true ) : 'wp-codebox-fixture-admin';
+$username = isset( $fixture_user['username'] ) && is_string( $fixture_user['username'] ) && '' !== trim( $fixture_user['username'] ) ? sanitize_user( $fixture_user['username'], true ) : 'sandbox_fixture_admin';
 if ( '' === $username ) {
     throw new RuntimeException( 'Fixture user username is invalid.' );
 }
@@ -172,7 +172,7 @@ if ( ! get_role( $role ) ) {
     throw new RuntimeException( 'Fixture user role does not exist: ' . $role );
 }
 $email = isset( $fixture_user['email'] ) && is_string( $fixture_user['email'] ) && is_email( $fixture_user['email'] ) ? $fixture_user['email'] : $username . '@example.test';
-$display_name = isset( $fixture_user['displayName'] ) && is_string( $fixture_user['displayName'] ) && '' !== trim( $fixture_user['displayName'] ) ? $fixture_user['displayName'] : 'WP Codebox Fixture User';
+$display_name = isset( $fixture_user['displayName'] ) && is_string( $fixture_user['displayName'] ) && '' !== trim( $fixture_user['displayName'] ) ? $fixture_user['displayName'] : 'Sandbox Fixture User';
 $password = isset( $fixture_user['password'] ) && is_string( $fixture_user['password'] ) && '' !== $fixture_user['password'] ? $fixture_user['password'] : wp_generate_password( 32, true, true );
 $created = false;
 $user = $requested_user_id > 0 ? get_user_by( 'id', $requested_user_id ) : get_user_by( 'login', $username );

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -54,16 +54,16 @@ function saveQueriesBootstrapPhp(args: string[]): string {
 
 function phpFatalDiagnosticPhp(): string {
   return `register_shutdown_function(static function (): void {
-    $wp_codebox_fatal = error_get_last();
-    if (!is_array($wp_codebox_fatal) || !in_array($wp_codebox_fatal['type'] ?? 0, array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR), true)) {
+    $contained_runtime_fatal = error_get_last();
+    if (!is_array($contained_runtime_fatal) || !in_array($contained_runtime_fatal['type'] ?? 0, array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR), true)) {
         return;
     }
     echo "\nWP_CODEBOX_PHP_FATAL_DIAGNOSTIC:" . json_encode(array(
         'schema' => 'wp-codebox/php-fatal-diagnostic/v1',
-        'message' => isset($wp_codebox_fatal['message']) ? (string) $wp_codebox_fatal['message'] : '',
-        'file' => isset($wp_codebox_fatal['file']) ? (string) $wp_codebox_fatal['file'] : '',
-        'line' => isset($wp_codebox_fatal['line']) ? (int) $wp_codebox_fatal['line'] : 0,
-        'type' => isset($wp_codebox_fatal['type']) ? (int) $wp_codebox_fatal['type'] : 0,
+        'message' => isset($contained_runtime_fatal['message']) ? (string) $contained_runtime_fatal['message'] : '',
+        'file' => isset($contained_runtime_fatal['file']) ? (string) $contained_runtime_fatal['file'] : '',
+        'line' => isset($contained_runtime_fatal['line']) ? (int) $contained_runtime_fatal['line'] : 0,
+        'type' => isset($contained_runtime_fatal['type']) ? (int) $contained_runtime_fatal['type'] : 0,
     ), JSON_UNESCAPED_SLASHES) . "\n";
 });`
 }
@@ -82,9 +82,9 @@ function recipeActivePluginBootstrapPhp(spec: RuntimeCreateSpec): string {
     return ""
   }
 
-  return `${phpRuntimeComponentLifecycleReplayFunction("wp_codebox_run_php")}
-$wp_codebox_run_php_active_plugins = json_decode(base64_decode('${Buffer.from(JSON.stringify(plugins), "utf8").toString("base64")}'), true);
-function wp_codebox_run_php_plugin_load_diagnostic(array $plugin, string $error = ''): string {
+  return `${phpRuntimeComponentLifecycleReplayFunction("contained_runtime_run_php")}
+$contained_runtime_run_php_active_plugins = json_decode(base64_decode('${Buffer.from(JSON.stringify(plugins), "utf8").toString("base64")}'), true);
+function contained_runtime_run_php_plugin_load_diagnostic(array $plugin, string $error = ''): string {
     $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
     $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
     $real_plugin_file = realpath($absolute_plugin_file);
@@ -105,31 +105,31 @@ function wp_codebox_run_php_plugin_load_diagnostic(array $plugin, string $error 
         'error' => $error,
     ), JSON_UNESCAPED_SLASHES);
 }
-function wp_codebox_run_php_include_active_plugin(array $plugin): void {
+function contained_runtime_run_php_include_active_plugin(array $plugin): void {
     $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
     if ($plugin_file === '' || str_starts_with($plugin_file, '/') || str_contains($plugin_file, '..') || !str_ends_with($plugin_file, '.php')) {
-        throw new RuntimeException('wordpress.run-php cannot include unsafe recipe plugin file "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, 'unsafe plugin file'));
+        throw new RuntimeException('wordpress.run-php cannot include unsafe recipe plugin file "' . $plugin_file . '". ' . contained_runtime_run_php_plugin_load_diagnostic($plugin, 'unsafe plugin file'));
     }
     $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
     if (!is_file($absolute_plugin_file) || !is_readable($absolute_plugin_file)) {
-        throw new RuntimeException('wordpress.run-php cannot include recipe plugin file "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, 'missing or unreadable plugin file'));
+        throw new RuntimeException('wordpress.run-php cannot include recipe plugin file "' . $plugin_file . '". ' . contained_runtime_run_php_plugin_load_diagnostic($plugin, 'missing or unreadable plugin file'));
     }
-    $lifecycle = wp_codebox_run_php_component_lifecycle_replay_prepare();
+    $lifecycle = contained_runtime_run_php_component_lifecycle_replay_prepare();
     try {
         require_once $absolute_plugin_file;
     } catch (Throwable $e) {
-        throw new RuntimeException('wordpress.run-php failed to include recipe plugin "' . $plugin_file . '". ' . wp_codebox_run_php_plugin_load_diagnostic($plugin, $e->getMessage()), 0, $e);
+        throw new RuntimeException('wordpress.run-php failed to include recipe plugin "' . $plugin_file . '". ' . contained_runtime_run_php_plugin_load_diagnostic($plugin, $e->getMessage()), 0, $e);
     } finally {
-        wp_codebox_run_php_component_lifecycle_replay_complete($lifecycle);
+        contained_runtime_run_php_component_lifecycle_replay_complete($lifecycle);
     }
-    $diagnostic = wp_codebox_run_php_plugin_load_diagnostic($plugin, 'plugin file was not included');
+    $diagnostic = contained_runtime_run_php_plugin_load_diagnostic($plugin, 'plugin file was not included');
     if (strpos($diagnostic, '"included":true') === false) {
         throw new RuntimeException('wordpress.run-php failed to verify included recipe plugin "' . $plugin_file . '". ' . $diagnostic);
     }
 }
-foreach (is_array($wp_codebox_run_php_active_plugins) ? $wp_codebox_run_php_active_plugins : array() as $wp_codebox_run_php_active_plugin) {
-    if (is_array($wp_codebox_run_php_active_plugin)) {
-        wp_codebox_run_php_include_active_plugin($wp_codebox_run_php_active_plugin);
+foreach (is_array($contained_runtime_run_php_active_plugins) ? $contained_runtime_run_php_active_plugins : array() as $contained_runtime_run_php_active_plugin) {
+    if (is_array($contained_runtime_run_php_active_plugin)) {
+        contained_runtime_run_php_include_active_plugin($contained_runtime_run_php_active_plugin);
     }
 }
 `
@@ -209,11 +209,11 @@ function componentManifestPhp(spec: RuntimeCreateSpec): string {
   }
 
   const encoded = Buffer.from(JSON.stringify(manifest), "utf8").toString("base64")
-  return `$wp_codebox_component_manifest = json_decode(base64_decode('${encoded}'), true);
-if (is_array($wp_codebox_component_manifest)) {
-    $GLOBALS['wp_codebox_component_manifest'] = $wp_codebox_component_manifest;
-    if (!defined('WP_CODEBOX_COMPONENT_MANIFEST_JSON')) {
-        define('WP_CODEBOX_COMPONENT_MANIFEST_JSON', json_encode($wp_codebox_component_manifest, JSON_UNESCAPED_SLASHES));
+  return `$contained_runtime_component_manifest = json_decode(base64_decode('${encoded}'), true);
+if (is_array($contained_runtime_component_manifest)) {
+    $GLOBALS['contained_runtime_component_manifest'] = $contained_runtime_component_manifest;
+    if (!defined('CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON')) {
+        define('CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON', json_encode($contained_runtime_component_manifest, JSON_UNESCAPED_SLASHES));
     }
 }
 `

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -487,9 +487,9 @@ function pg_fire_runtime_abilities_ready(): void {
     if (!function_exists('do_action')) {
         return;
     }
-    do_action('wp_codebox_runtime_abilities_ready');
+    do_action('contained_runtime_abilities_ready');
     if (function_exists('did_action')) {
-        pg_log('NOTICE:runtime ability lifecycle ready: wp_abilities_api_categories_init=' . did_action('wp_abilities_api_categories_init') . '; wp_abilities_api_init=' . did_action('wp_abilities_api_init') . '; wp_codebox_runtime_abilities_ready=' . did_action('wp_codebox_runtime_abilities_ready'));
+        pg_log('NOTICE:runtime ability lifecycle ready: wp_abilities_api_categories_init=' . did_action('wp_abilities_api_categories_init') . '; wp_abilities_api_init=' . did_action('wp_abilities_api_init') . '; contained_runtime_abilities_ready=' . did_action('contained_runtime_abilities_ready'));
     }
 }
 
@@ -576,9 +576,9 @@ function pg_resolve_runtime_cwd(string $cwd, string $plugin_path): string {
 }
 
 function pg_manifest_component_entry(string $plugin_slug): ?array {
-    $manifest = $GLOBALS['wp_codebox_component_manifest'] ?? null;
+    $manifest = $GLOBALS['contained_runtime_component_manifest'] ?? null;
     if (!is_array($manifest)) {
-        $json = defined('WP_CODEBOX_COMPONENT_MANIFEST_JSON') ? WP_CODEBOX_COMPONENT_MANIFEST_JSON : '';
+        $json = defined('CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON') ? CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON : '';
         $decoded = is_string($json) && $json !== '' ? json_decode($json, true) : null;
         $manifest = is_array($decoded) ? $decoded : null;
     }

--- a/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
+++ b/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
@@ -21,12 +21,12 @@ export function runtimeDiscoverySurfacesFromArgs(args: string[]): RuntimeDiscove
 
 export function runtimeDiscoveryPhpCode(surfaces: RuntimeDiscoverySurface[]): string {
   return `<?php
-$wp_codebox_runtime_discovery_surfaces = json_decode(base64_decode('${Buffer.from(JSON.stringify(surfaces), "utf8").toString("base64")}'), true);
-if (!is_array($wp_codebox_runtime_discovery_surfaces)) {
+$runtime_discovery_surfaces = json_decode(base64_decode('${Buffer.from(JSON.stringify(surfaces), "utf8").toString("base64")}'), true);
+if (!is_array($runtime_discovery_surfaces)) {
     throw new RuntimeException('wordpress.runtime-discovery received invalid surfaces.');
 }
 
-function wp_codebox_runtime_discovery_diagnostic(string $surface, string $code, string $message, $data = null): array {
+function runtime_discovery_diagnostic(string $surface, string $code, string $message, $data = null): array {
     $diagnostic = array('surface' => $surface, 'code' => $code, 'message' => $message);
     if ($data !== null) {
         $diagnostic['data'] = $data;
@@ -34,11 +34,11 @@ function wp_codebox_runtime_discovery_diagnostic(string $surface, string $code, 
     return $diagnostic;
 }
 
-function wp_codebox_runtime_discovery_rest(): array {
+function runtime_discovery_rest(): array {
     if (!function_exists('rest_get_server')) {
         return array(
             'payload' => array('schema' => 'wp-codebox/wordpress-rest-route-discovery/v1', 'routes' => array(), 'namespaces' => array()),
-            'diagnostics' => array(wp_codebox_runtime_discovery_diagnostic('rest', 'rest-api-unavailable', 'The WordPress REST API server is unavailable.')),
+            'diagnostics' => array(runtime_discovery_diagnostic('rest', 'rest-api-unavailable', 'The WordPress REST API server is unavailable.')),
         );
     }
 
@@ -53,16 +53,16 @@ function wp_codebox_runtime_discovery_rest(): array {
             if (!is_array($handler)) {
                 continue;
             }
-            $endpoint_methods = wp_codebox_runtime_discovery_rest_methods($handler['methods'] ?? array());
+            $endpoint_methods = runtime_discovery_rest_methods($handler['methods'] ?? array());
             $endpoint_args = array();
             foreach ((array) ($handler['args'] ?? array()) as $arg_name => $arg_schema) {
                 $arg_names[] = (string) $arg_name;
-                $endpoint_args[] = wp_codebox_runtime_discovery_rest_arg((string) $arg_name, is_array($arg_schema) ? $arg_schema : array());
+                $endpoint_args[] = runtime_discovery_rest_arg((string) $arg_name, is_array($arg_schema) ? $arg_schema : array());
             }
             $methods = array_merge($methods, $endpoint_methods);
             $endpoints[] = array(
                 'methods' => $endpoint_methods,
-                'permission' => wp_codebox_runtime_discovery_rest_permission($handler),
+                'permission' => runtime_discovery_rest_permission($handler),
                 'args' => $endpoint_args,
             );
         }
@@ -71,7 +71,7 @@ function wp_codebox_runtime_discovery_rest(): array {
             $namespaces[] = $namespace;
         }
         $route_item = array('route' => (string) $route, 'namespace' => $namespace, 'methods' => array_values(array_unique($methods)), 'argNames' => array_values(array_unique($arg_names)), 'endpoints' => $endpoints);
-        $route_schema = wp_codebox_runtime_discovery_rest_schema((array) $handlers);
+        $route_schema = runtime_discovery_rest_schema((array) $handlers);
         if (!empty($route_schema)) {
             $route_item['schema'] = $route_schema;
         }
@@ -81,7 +81,7 @@ function wp_codebox_runtime_discovery_rest(): array {
     return array('payload' => array('schema' => 'wp-codebox/wordpress-rest-route-discovery/v1', 'routes' => $items, 'namespaces' => array_values(array_unique($namespaces))), 'diagnostics' => array());
 }
 
-function wp_codebox_runtime_discovery_rest_methods($methods): array {
+function runtime_discovery_rest_methods($methods): array {
     if (is_string($methods)) {
         return array_values(array_filter(array_map('trim', explode(',', strtoupper($methods)))));
     }
@@ -97,7 +97,7 @@ function wp_codebox_runtime_discovery_rest_methods($methods): array {
     return array_values(array_unique($normalized));
 }
 
-function wp_codebox_runtime_discovery_rest_permission(array $handler): array {
+function runtime_discovery_rest_permission(array $handler): array {
     if (!array_key_exists('permission_callback', $handler)) {
         return array('mode' => 'none');
     }
@@ -105,10 +105,10 @@ function wp_codebox_runtime_discovery_rest_permission(array $handler): array {
     if ($callback === '__return_true') {
         return array('mode' => 'public', 'callbackType' => 'function');
     }
-    return array('mode' => 'callback', 'callbackType' => wp_codebox_runtime_discovery_callback_type($callback));
+    return array('mode' => 'callback', 'callbackType' => runtime_discovery_callback_type($callback));
 }
 
-function wp_codebox_runtime_discovery_callback_type($callback): string {
+function runtime_discovery_callback_type($callback): string {
     if (is_string($callback)) {
         return 'function';
     }
@@ -124,7 +124,7 @@ function wp_codebox_runtime_discovery_callback_type($callback): string {
     return is_callable($callback) ? 'callable' : 'unknown';
 }
 
-function wp_codebox_runtime_discovery_rest_arg(string $name, array $schema): array {
+function runtime_discovery_rest_arg(string $name, array $schema): array {
     $arg = array('name' => $name, 'required' => !empty($schema['required']));
     foreach (array('type', 'format') as $key) {
         if (isset($schema[$key]) && (is_string($schema[$key]) || is_array($schema[$key]))) {
@@ -143,7 +143,7 @@ function wp_codebox_runtime_discovery_rest_arg(string $name, array $schema): arr
     return $arg;
 }
 
-function wp_codebox_runtime_discovery_rest_schema(array $handlers): array {
+function runtime_discovery_rest_schema(array $handlers): array {
     foreach ($handlers as $handler) {
         if (!is_array($handler) || !isset($handler['schema']) || !is_array($handler['schema'])) {
             continue;
@@ -163,12 +163,12 @@ function wp_codebox_runtime_discovery_rest_schema(array $handlers): array {
     return array();
 }
 
-function wp_codebox_runtime_discovery_admin(): array {
+function runtime_discovery_admin(): array {
     $pages = array();
     $diagnostics = array();
     $menu_loaded = isset($GLOBALS['menu']) && is_array($GLOBALS['menu']);
     if (!$menu_loaded) {
-        $diagnostics[] = wp_codebox_runtime_discovery_diagnostic('admin', 'admin-menu-not-loaded', 'The admin menu globals are not populated in this request context.');
+        $diagnostics[] = runtime_discovery_diagnostic('admin', 'admin-menu-not-loaded', 'The admin menu globals are not populated in this request context.');
     }
 
     foreach ((array) ($GLOBALS['menu'] ?? array()) as $item) {
@@ -189,7 +189,7 @@ function wp_codebox_runtime_discovery_admin(): array {
     return array('payload' => array('schema' => 'wp-codebox/wordpress-admin-page-discovery/v1', 'adminUrl' => admin_url(), 'menuLoaded' => $menu_loaded, 'pages' => $pages), 'diagnostics' => $diagnostics);
 }
 
-function wp_codebox_runtime_discovery_database(): array {
+function runtime_discovery_database(): array {
     global $wpdb;
     $tables = array();
     $candidates = array_values(array_unique(array_map('strval', $wpdb->tables('all'))));
@@ -205,7 +205,7 @@ function wp_codebox_runtime_discovery_database(): array {
     return array('payload' => array('schema' => 'wp-codebox/wordpress-db-schema-discovery/v1', 'prefix' => $wpdb->prefix, 'tables' => $tables), 'diagnostics' => array());
 }
 
-function wp_codebox_runtime_discovery_frontend(): array {
+function runtime_discovery_frontend(): array {
     global $wp_rewrite, $wp;
     $rules = is_object($wp_rewrite) ? $wp_rewrite->wp_rewrite_rules() : array();
     $items = array();
@@ -215,7 +215,7 @@ function wp_codebox_runtime_discovery_frontend(): array {
     return array('payload' => array('schema' => 'wp-codebox/wordpress-frontend-route-discovery/v1', 'homeUrl' => home_url('/'), 'permalinkStructure' => (string) get_option('permalink_structure', ''), 'rewriteRules' => $items, 'publicQueryVars' => array_values(array_map('strval', (array) ($wp->public_query_vars ?? array())))), 'diagnostics' => array());
 }
 
-function wp_codebox_runtime_discovery_blocks(): array {
+function runtime_discovery_blocks(): array {
     $blocks = array();
     if (class_exists('WP_Block_Type_Registry')) {
         foreach (WP_Block_Type_Registry::get_instance()->get_all_registered() as $name => $block_type) {
@@ -233,65 +233,65 @@ function wp_codebox_runtime_discovery_blocks(): array {
     return array('payload' => array('schema' => 'wp-codebox/wordpress-block-editor-target-discovery/v1', 'blocks' => $blocks, 'editorPostTypes' => $post_types), 'diagnostics' => array());
 }
 
-$wp_codebox_runtime_discovery_result = array(
+$runtime_discovery_result = array(
     'schema' => 'wp-codebox/wordpress-runtime-discovery/v1',
     'command' => 'wordpress.runtime-discovery',
     'status' => 'ok',
-    'surfaces' => array_values($wp_codebox_runtime_discovery_surfaces),
+    'surfaces' => array_values($runtime_discovery_surfaces),
     'diagnostics' => array(),
 );
 
-foreach ($wp_codebox_runtime_discovery_surfaces as $wp_codebox_runtime_discovery_surface) {
-    $collector = 'wp_codebox_runtime_discovery_' . $wp_codebox_runtime_discovery_surface;
+foreach ($runtime_discovery_surfaces as $runtime_discovery_surface) {
+    $collector = 'runtime_discovery_' . $runtime_discovery_surface;
     if (!function_exists($collector)) {
-        $wp_codebox_runtime_discovery_result['diagnostics'][] = wp_codebox_runtime_discovery_diagnostic((string) $wp_codebox_runtime_discovery_surface, 'surface-unsupported', 'The requested discovery surface is not implemented.');
+        $runtime_discovery_result['diagnostics'][] = runtime_discovery_diagnostic((string) $runtime_discovery_surface, 'surface-unsupported', 'The requested discovery surface is not implemented.');
         continue;
     }
     $collected = $collector();
-    $wp_codebox_runtime_discovery_result[$wp_codebox_runtime_discovery_surface] = $collected['payload'];
-    $wp_codebox_runtime_discovery_result['diagnostics'] = array_merge($wp_codebox_runtime_discovery_result['diagnostics'], $collected['diagnostics']);
+    $runtime_discovery_result[$runtime_discovery_surface] = $collected['payload'];
+    $runtime_discovery_result['diagnostics'] = array_merge($runtime_discovery_result['diagnostics'], $collected['diagnostics']);
 }
 
-echo wp_json_encode($wp_codebox_runtime_discovery_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
+echo wp_json_encode($runtime_discovery_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
 }
 
 export function runtimeInventoryPhpCode(surface: RuntimeInventorySurface, command: string, schema: string): string {
   const payloadKey = surface === "rest" ? "rest" : surface
   return `<?php
-${runtimeDiscoveryPhpCode([surface]).replace(/^<\?php\n/, "").replace(/echo wp_json_encode\(\$wp_codebox_runtime_discovery_result, JSON_PRETTY_PRINT \| JSON_UNESCAPED_SLASHES\);$/, "")}
+${runtimeDiscoveryPhpCode([surface]).replace(/^<\?php\n/, "").replace(/echo wp_json_encode\(\$runtime_discovery_result, JSON_PRETTY_PRINT \| JSON_UNESCAPED_SLASHES\);$/, "")}
 
-$wp_codebox_runtime_inventory_payload = $wp_codebox_runtime_discovery_result['${payloadKey}'] ?? null;
-$wp_codebox_runtime_inventory_diagnostics = (array) ($wp_codebox_runtime_discovery_result['diagnostics'] ?? array());
+$runtime_inventory_payload = $runtime_discovery_result['${payloadKey}'] ?? null;
+$runtime_inventory_diagnostics = (array) ($runtime_discovery_result['diagnostics'] ?? array());
 
-if (!is_array($wp_codebox_runtime_inventory_payload)) {
+if (!is_array($runtime_inventory_payload)) {
     echo wp_json_encode(array(
         'schema' => '${schema}',
         'command' => '${command}',
         'status' => 'unsupported',
-        'diagnostics' => array_merge($wp_codebox_runtime_inventory_diagnostics, array(wp_codebox_runtime_discovery_diagnostic('${surface}', 'inventory-unavailable', 'The requested WordPress inventory is unavailable in this runtime context.'))),
+        'diagnostics' => array_merge($runtime_inventory_diagnostics, array(runtime_discovery_diagnostic('${surface}', 'inventory-unavailable', 'The requested WordPress inventory is unavailable in this runtime context.'))),
     ), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     return;
 }
 
-$wp_codebox_runtime_inventory_result = array_merge($wp_codebox_runtime_inventory_payload, array(
+$runtime_inventory_result = array_merge($runtime_inventory_payload, array(
     'schema' => '${schema}',
     'command' => '${command}',
-    'status' => empty($wp_codebox_runtime_inventory_diagnostics) ? 'ok' : 'unsupported',
-    'diagnostics' => $wp_codebox_runtime_inventory_diagnostics,
+    'status' => empty($runtime_inventory_diagnostics) ? 'ok' : 'unsupported',
+    'diagnostics' => $runtime_inventory_diagnostics,
 ));
 
 if ('${surface}' === 'frontend') {
-    $wp_codebox_runtime_inventory_urls = array(array('url' => (string) ($wp_codebox_runtime_inventory_payload['homeUrl'] ?? home_url('/')), 'source' => 'home'));
-    foreach ((array) ($wp_codebox_runtime_inventory_payload['rewriteRules'] ?? array()) as $wp_codebox_runtime_inventory_rule) {
-        $wp_codebox_runtime_inventory_urls[] = array(
-            'url' => home_url('/' . ltrim((string) ($wp_codebox_runtime_inventory_rule['pattern'] ?? ''), '/')),
+    $runtime_inventory_urls = array(array('url' => (string) ($runtime_inventory_payload['homeUrl'] ?? home_url('/')), 'source' => 'home'));
+    foreach ((array) ($runtime_inventory_payload['rewriteRules'] ?? array()) as $runtime_inventory_rule) {
+        $runtime_inventory_urls[] = array(
+            'url' => home_url('/' . ltrim((string) ($runtime_inventory_rule['pattern'] ?? ''), '/')),
             'source' => 'rewrite-rule',
-            'pattern' => (string) ($wp_codebox_runtime_inventory_rule['pattern'] ?? ''),
-            'query' => (string) ($wp_codebox_runtime_inventory_rule['query'] ?? ''),
+            'pattern' => (string) ($runtime_inventory_rule['pattern'] ?? ''),
+            'query' => (string) ($runtime_inventory_rule['query'] ?? ''),
         );
     }
-    $wp_codebox_runtime_inventory_result['urls'] = $wp_codebox_runtime_inventory_urls;
+    $runtime_inventory_result['urls'] = $runtime_inventory_urls;
 }
 
-echo wp_json_encode($wp_codebox_runtime_inventory_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
+echo wp_json_encode($runtime_inventory_result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
 }

--- a/packages/runtime-playground/src/wordpress-user-sessions.ts
+++ b/packages/runtime-playground/src/wordpress-user-sessions.ts
@@ -73,49 +73,47 @@ export function wordpressUserSessionFromCommandArgs(args: string[], runtimeSpec:
 
 export function wordpressFixtureUserPhpCode(user: WordPressFixtureUserSpec): string {
   return `
-$wp_codebox_fixture_user = json_decode( ${JSON.stringify(JSON.stringify(user))}, true );
-if ( ! is_array( $wp_codebox_fixture_user ) ) {
-    $wp_codebox_fixture_user = array();
+$sandbox_fixture_user = json_decode( ${JSON.stringify(JSON.stringify(user))}, true );
+if ( ! is_array( $sandbox_fixture_user ) ) {
+    $sandbox_fixture_user = array();
 }
-$wp_codebox_requested_user_id = isset( $wp_codebox_fixture_user['userId'] ) ? (int) $wp_codebox_fixture_user['userId'] : 0;
-$wp_codebox_username = isset( $wp_codebox_fixture_user['username'] ) && is_string( $wp_codebox_fixture_user['username'] ) && '' !== trim( $wp_codebox_fixture_user['username'] ) ? sanitize_user( $wp_codebox_fixture_user['username'], true ) : sanitize_user( (string) ( $wp_codebox_fixture_user['name'] ?? 'wp-codebox-fixture-user' ), true );
-if ( '' === $wp_codebox_username ) {
+$sandbox_requested_user_id = isset( $sandbox_fixture_user['userId'] ) ? (int) $sandbox_fixture_user['userId'] : 0;
+$sandbox_username = isset( $sandbox_fixture_user['username'] ) && is_string( $sandbox_fixture_user['username'] ) && '' !== trim( $sandbox_fixture_user['username'] ) ? sanitize_user( $sandbox_fixture_user['username'], true ) : sanitize_user( (string) ( $sandbox_fixture_user['name'] ?? 'sandbox_fixture_user' ), true );
+if ( '' === $sandbox_username ) {
     throw new RuntimeException( 'Fixture user username is invalid.' );
 }
-$wp_codebox_role = isset( $wp_codebox_fixture_user['role'] ) && is_string( $wp_codebox_fixture_user['role'] ) && '' !== trim( $wp_codebox_fixture_user['role'] ) ? sanitize_key( $wp_codebox_fixture_user['role'] ) : 'administrator';
-if ( ! get_role( $wp_codebox_role ) ) {
-    throw new RuntimeException( 'Fixture user role does not exist: ' . $wp_codebox_role );
+$sandbox_role = isset( $sandbox_fixture_user['role'] ) && is_string( $sandbox_fixture_user['role'] ) && '' !== trim( $sandbox_fixture_user['role'] ) ? sanitize_key( $sandbox_fixture_user['role'] ) : 'administrator';
+if ( ! get_role( $sandbox_role ) ) {
+    throw new RuntimeException( 'Fixture user role does not exist: ' . $sandbox_role );
 }
-$wp_codebox_email = isset( $wp_codebox_fixture_user['email'] ) && is_string( $wp_codebox_fixture_user['email'] ) && is_email( $wp_codebox_fixture_user['email'] ) ? $wp_codebox_fixture_user['email'] : $wp_codebox_username . '@example.test';
-$wp_codebox_display_name = isset( $wp_codebox_fixture_user['displayName'] ) && is_string( $wp_codebox_fixture_user['displayName'] ) && '' !== trim( $wp_codebox_fixture_user['displayName'] ) ? $wp_codebox_fixture_user['displayName'] : $wp_codebox_username;
-$wp_codebox_password = isset( $wp_codebox_fixture_user['password'] ) && is_string( $wp_codebox_fixture_user['password'] ) && '' !== $wp_codebox_fixture_user['password'] ? $wp_codebox_fixture_user['password'] : wp_generate_password( 32, true, true );
-$wp_codebox_user_created = false;
-$wp_codebox_user = $wp_codebox_requested_user_id > 0 ? get_user_by( 'id', $wp_codebox_requested_user_id ) : get_user_by( 'login', $wp_codebox_username );
-if ( ! $wp_codebox_user && $wp_codebox_requested_user_id <= 0 ) {
-    $wp_codebox_user_id = wp_insert_user(
+$sandbox_email = isset( $sandbox_fixture_user['email'] ) && is_string( $sandbox_fixture_user['email'] ) && is_email( $sandbox_fixture_user['email'] ) ? $sandbox_fixture_user['email'] : $sandbox_username . '@example.test';
+$sandbox_display_name = isset( $sandbox_fixture_user['displayName'] ) && is_string( $sandbox_fixture_user['displayName'] ) && '' !== trim( $sandbox_fixture_user['displayName'] ) ? $sandbox_fixture_user['displayName'] : $sandbox_username;
+$sandbox_password = isset( $sandbox_fixture_user['password'] ) && is_string( $sandbox_fixture_user['password'] ) && '' !== $sandbox_fixture_user['password'] ? $sandbox_fixture_user['password'] : wp_generate_password( 32, true, true );
+$sandbox_user = $sandbox_requested_user_id > 0 ? get_user_by( 'id', $sandbox_requested_user_id ) : get_user_by( 'login', $sandbox_username );
+if ( ! $sandbox_user && $sandbox_requested_user_id <= 0 ) {
+    $sandbox_user_id = wp_insert_user(
         array(
-            'user_login'   => $wp_codebox_username,
-            'user_email'   => $wp_codebox_email,
-            'user_pass'    => $wp_codebox_password,
-            'display_name' => $wp_codebox_display_name,
-            'role'         => $wp_codebox_role,
+            'user_login'   => $sandbox_username,
+            'user_email'   => $sandbox_email,
+            'user_pass'    => $sandbox_password,
+            'display_name' => $sandbox_display_name,
+            'role'         => $sandbox_role,
         )
     );
-    if ( is_wp_error( $wp_codebox_user_id ) ) {
-        throw new RuntimeException( 'Fixture user creation failed: ' . $wp_codebox_user_id->get_error_message() );
+    if ( is_wp_error( $sandbox_user_id ) ) {
+        throw new RuntimeException( 'Fixture user creation failed: ' . $sandbox_user_id->get_error_message() );
     }
-    $wp_codebox_user_created = true;
-    $wp_codebox_user = get_user_by( 'id', (int) $wp_codebox_user_id );
+    $sandbox_user = get_user_by( 'id', (int) $sandbox_user_id );
 }
-if ( ! $wp_codebox_user ) {
+if ( ! $sandbox_user ) {
     throw new RuntimeException( 'Fixture user could not be resolved.' );
 }
-$wp_codebox_user_id = (int) $wp_codebox_user->ID;
-$wp_codebox_wp_user = new WP_User( $wp_codebox_user_id );
-if ( ! in_array( $wp_codebox_role, (array) $wp_codebox_wp_user->roles, true ) ) {
-    $wp_codebox_wp_user->add_role( $wp_codebox_role );
+$sandbox_user_id = (int) $sandbox_user->ID;
+$sandbox_wp_user = new WP_User( $sandbox_user_id );
+if ( ! in_array( $sandbox_role, (array) $sandbox_wp_user->roles, true ) ) {
+    $sandbox_wp_user->add_role( $sandbox_role );
 }
-wp_set_current_user( $wp_codebox_user_id );`
+wp_set_current_user( $sandbox_user_id );`
 }
 
 function wordpressUserSessionResolution(source: "user" | "session", name: string, user: Record<string, unknown>, artifacts: unknown[]): WordPressUserSessionResolution {

--- a/tests/agent-runtime-components.test.ts
+++ b/tests/agent-runtime-components.test.ts
@@ -9,6 +9,7 @@ const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-components-"))
 const originalCwd = cwd()
 const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
 const originalRuntimeComponentPaths = process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
+const originalContainedRuntimeComponentPaths = process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
 
 try {
   const runtimeHost = join(root, "runtime-host")
@@ -32,7 +33,7 @@ try {
   mkdirSync(runtimeTools, { recursive: true })
   writeFileSync(join(runtimeEngine, "runtime-engine.php"), "<?php\n/* Plugin Name: Runtime Engine */\n")
   writeFileSync(join(runtimeTools, "runtime-tools.php"), "<?php\n/* Plugin Name: Runtime Tools */\n")
-  process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = `${runtimeEngine},${runtimeTools}`
+  process.env.CONTAINED_RUNTIME_COMPONENT_PATHS = `${runtimeEngine},${runtimeTools}`
   const workspace = join(root, "workspace")
   mkdirSync(workspace, { recursive: true })
   chdir(workspace)
@@ -61,6 +62,11 @@ try {
     delete process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
   } else {
     process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = originalRuntimeComponentPaths
+  }
+  if (originalContainedRuntimeComponentPaths === undefined) {
+    delete process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
+  } else {
+    process.env.CONTAINED_RUNTIME_COMPONENT_PATHS = originalContainedRuntimeComponentPaths
   }
   rmSync(root, { recursive: true, force: true })
 }

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -115,6 +115,7 @@ assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run")
 const agentRecipeTemp = mkdtempSync(join(tmpdir(), "wp-codebox-agent-recipe-test-"))
 const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
 const originalRuntimeComponentPaths = process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
+const originalContainedRuntimeComponentPaths = process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
 try {
   const agentsApiSource = join(agentRecipeTemp, "agents-api")
   mkdirSync(agentsApiSource)
@@ -123,7 +124,7 @@ try {
   const runtimeEngineSource = join(agentRecipeTemp, "runtime-engine")
   mkdirSync(runtimeEngineSource)
   writeFileSync(join(runtimeEngineSource, "runtime-engine.php"), "<?php\n/* Plugin Name: Runtime Engine */\n")
-  process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = runtimeEngineSource
+  process.env.CONTAINED_RUNTIME_COMPONENT_PATHS = runtimeEngineSource
   const providerSource = join(agentRecipeTemp, "test-provider")
   mkdirSync(providerSource)
   writeFileSync(join(providerSource, "test-provider.php"), "<?php\n/* Plugin Name: Test Provider */\n")
@@ -177,6 +178,9 @@ try {
   assert.equal(agentsApiPlugin?.loadAs, "mu-plugin")
   assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api" && component.loadAs === "mu-plugin"), true)
   assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "runtime-engine" && component.loadAs === "mu-plugin"), true)
+  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => String(component.mountedPath).includes("/contained-runtime/")), true)
+  assert.equal(JSON.stringify(recipe).includes("wp-codebox-default-agent-runtime-substrate"), false)
+  assert.equal(JSON.stringify(recipe).includes("wp-codebox-runtime"), false)
   assert.equal(extraPlugins.some((plugin) => plugin.slug === "test-provider" && plugin.activate === true && plugin.loadAs === "plugin"), true)
   assert.equal(extraPlugins.filter((plugin) => plugin.slug === "test-provider" && plugin.loadAs === "plugin").length, 1)
   assert.deepEqual(extraPlugins.find((plugin) => plugin.slug === "agent-runtime-tool-bridge"), {
@@ -213,6 +217,11 @@ try {
     delete process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
   } else {
     process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS = originalRuntimeComponentPaths
+  }
+  if (originalContainedRuntimeComponentPaths === undefined) {
+    delete process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
+  } else {
+    process.env.CONTAINED_RUNTIME_COMPONENT_PATHS = originalContainedRuntimeComponentPaths
   }
   rmSync(agentRecipeTemp, { recursive: true, force: true })
 }

--- a/tests/fixture-auth-storage-state.test.ts
+++ b/tests/fixture-auth-storage-state.test.ts
@@ -21,7 +21,8 @@ const php = wordpressFixtureUserStorageStatePhpCode({
 })
 
 assert.match(php, /wp-codebox\/browser-auth-storage-state\/v1/)
-assert.match(php, /wp-codebox-fixture-admin/)
+assert.match(php, /sandbox_fixture_admin/)
+assert.doesNotMatch(php, /wp_codebox|WP_CODEBOX|wp-codebox-fixture|WP Codebox Fixture/)
 assert.match(php, /wp_insert_user/)
 assert.match(php, /WP_Session_Tokens::get_instance/)
 assert.match(php, /storageState/)

--- a/tests/recipe-user-session.test.ts
+++ b/tests/recipe-user-session.test.ts
@@ -3,7 +3,7 @@ import { commandRegistry } from "../packages/runtime-core/src/command-registry.j
 import { validateWorkspaceRecipeJsonSchema } from "../packages/runtime-core/src/recipe-schema.js"
 import type { RuntimeCreateSpec } from "../packages/runtime-core/src/runtime-contracts.js"
 import { restRequestPhpCode } from "../packages/runtime-playground/src/rest-request-command-handlers.js"
-import { wordpressUserSessionFromCommandArgs } from "../packages/runtime-playground/src/wordpress-user-sessions.js"
+import { wordpressFixtureUserPhpCode, wordpressUserSessionFromCommandArgs } from "../packages/runtime-playground/src/wordpress-user-sessions.js"
 
 const recipe = {
   schema: "wp-codebox/workspace-recipe/v1",
@@ -44,6 +44,10 @@ assert.equal(resolvedUser?.metadata.redactionRequired, false)
 
 assert.throws(() => wordpressUserSessionFromCommandArgs(["session=missing"], runtimeSpec), /Unknown WordPress recipe user session/)
 assert.throws(() => wordpressUserSessionFromCommandArgs(["user=missing"], runtimeSpec), /Unknown WordPress recipe fixture user/)
+
+const fixtureUserPhp = wordpressFixtureUserPhpCode({ role: "administrator" })
+assert.match(fixtureUserPhp, /sandbox_fixture_user/)
+assert.doesNotMatch(fixtureUserPhp, /wp_codebox|WP_CODEBOX|wp-codebox-fixture/)
 
 const generated = restRequestPhpCode({
   method: "GET",

--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -2,10 +2,12 @@ import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
 import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction } from "../packages/runtime-core/src/index.js"
+import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
 
-const lifecycleReplaySnippet = phpRuntimeComponentLifecycleReplayFunction("wp_codebox_test")
-assert.match(lifecycleReplaySnippet, /function wp_codebox_test_component_lifecycle_replay_prepare\(\): array/)
+const lifecycleReplaySnippet = phpRuntimeComponentLifecycleReplayFunction("contained_runtime_test")
+assert.match(lifecycleReplaySnippet, /function contained_runtime_test_component_lifecycle_replay_prepare\(\): array/)
 assert.match(lifecycleReplaySnippet, /'schema' => 'wp-codebox\/runtime-component-lifecycle-replay\/v1'/)
+assert.doesNotMatch(lifecycleReplaySnippet, /wp_codebox|WP_CODEBOX/)
 
 const replayOutput = execFileSync(
   "php",
@@ -26,9 +28,9 @@ function did_action($hook_name) { return (int) ($GLOBALS['wp_actions'][$hook_nam
 function wp_get_abilities() { return array('before' => true, 'after' => true); }
 
 $GLOBALS['wp_filter']['init']->callbacks[10]['existing'] = array('function' => static function () { $GLOBALS['calls'][] = 'existing'; }, 'accepted_args' => 0);
-$state = wp_codebox_test_component_lifecycle_replay_prepare();
+$state = contained_runtime_test_component_lifecycle_replay_prepare();
 $GLOBALS['wp_filter']['init']->callbacks[20]['new'] = array('function' => static function () { $GLOBALS['calls'][] = 'new'; }, 'accepted_args' => 0);
-$diagnostic = wp_codebox_test_component_lifecycle_replay_complete($state);
+$diagnostic = contained_runtime_test_component_lifecycle_replay_complete($state);
 
 echo json_encode(array(
     'calls' => $GLOBALS['calls'],
@@ -47,8 +49,9 @@ assert.deepEqual(JSON.parse(replayOutput), {
   abilities_added: [],
 })
 
-const actionReplaySnippet = phpRuntimeComponentLifecycleActionReplayFunction("wp_codebox_runtime_replay_component_lifecycle")
-assert.match(actionReplaySnippet, /function wp_codebox_runtime_replay_component_lifecycle\(\): array/)
+const actionReplaySnippet = phpRuntimeComponentLifecycleActionReplayFunction("contained_runtime_replay_component_lifecycle")
+assert.match(actionReplaySnippet, /function contained_runtime_replay_component_lifecycle\(\): array/)
+assert.doesNotMatch(actionReplaySnippet, /wp_codebox|WP_CODEBOX/)
 
 const actionOutput = execFileSync(
   "php",
@@ -60,7 +63,7 @@ $wp_actions = array();
 function do_action($hook_name) { $GLOBALS['wp_actions'][$hook_name] = (int) ($GLOBALS['wp_actions'][$hook_name] ?? 0) + 1; }
 function did_action($hook_name) { return (int) ($GLOBALS['wp_actions'][$hook_name] ?? 0); }
 
-echo json_encode(wp_codebox_runtime_replay_component_lifecycle());`,
+echo json_encode(contained_runtime_replay_component_lifecycle());`,
   ],
   { encoding: "utf8" },
 )
@@ -70,8 +73,22 @@ assert.deepEqual(JSON.parse(actionOutput), {
   init: 1,
   wp_abilities_api_categories_init: 1,
   wp_abilities_api_init: 1,
-  wp_codebox_runtime_abilities_ready: 1,
+  contained_runtime_abilities_ready: 1,
 })
+
+const bootstrappedRunPhp = bootstrapPhpCode({
+  metadata: {
+    recipe: {
+      inputs: {
+        extra_plugins: [{ slug: "example", pluginFile: "example/example.php", activate: true }],
+        component_manifest: { schema: "wp-codebox/component-manifest/v1", components: [], providers: [] },
+      },
+    },
+  },
+} as never, "<?php echo 'ok';", [])
+assert.match(bootstrappedRunPhp, /contained_runtime_run_php_component_lifecycle_replay_prepare/)
+assert.match(bootstrappedRunPhp, /CONTAINED_RUNTIME_COMPONENT_MANIFEST_JSON/)
+assert.doesNotMatch(bootstrappedRunPhp, /wp_codebox_run_php|wp_codebox_component_manifest|WP_CODEBOX_COMPONENT_MANIFEST_JSON/)
 
 const sandboxAgentCode = await resolveSandboxTaskCode({
   task: "Say hello",

--- a/tests/wordpress-runtime-discovery-contracts.test.ts
+++ b/tests/wordpress-runtime-discovery-contracts.test.ts
@@ -101,6 +101,7 @@ assert.equal(runtimeContractManifest().schemas.wordpressRuntimeDiscovery.restMat
 assert.equal(runtimeContractManifest().schemas.wordpressRuntimeDiscovery.restMatrixResult, WORDPRESS_REST_MATRIX_RESULT_SCHEMA)
 
 const discoveryPhp = runtimeDiscoveryPhpCode(["rest"]).replace(/^<\?php\n/, "")
+assert.doesNotMatch(discoveryPhp, /wp_codebox|WP_CODEBOX/)
 const discovered = await runPhpJson<WordPressRuntimeDiscoveryResult>(`
 function wp_strip_all_tags( $text ) { return strip_tags( $text ); }
 function wp_json_encode( $data, $flags = 0 ) { return json_encode( $data, $flags ); }


### PR DESCRIPTION
## Summary
- Rename generated runtime-discovery, inventory, fixture-user, active-plugin bootstrap, component-manifest, and lifecycle replay internals away from Codebox-specific identifiers.
- Add neutral contained-runtime defaults for runtime component env/mount names while retaining legacy env fallback for callers.
- Keep public Codebox schemas, command ids, routes, package names, and fatal diagnostic marker contracts unchanged.

## Tests
- `npm run build`
- `npm run test:runtime-php-snippets`
- `npm run test:wordpress-runtime-discovery-contracts`
- `npm run test:fixture-auth-storage-state`
- `npm run test:recipe-user-session`
- `npm run test:agent-task-contracts`
- `npx tsx tests/agent-runtime-components.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing focused internal runtime-name cleanup, updating tests, and running verification.