### PR TITLE
Harden generic runtime result contracts

### DIFF
--- a/packages/runtime-core/src/agent-task-run-result.ts
+++ b/packages/runtime-core/src/agent-task-run-result.ts
@@ -22,6 +22,7 @@ export const AGENT_TASK_RUN_RESULT_JSON_SCHEMA = {
         transcripts: { type: "array", items: { type: "object" } },
         logs: { type: "array", items: { type: "object" } },
         runtimes: { type: "array", items: { type: "object" } },
+        evidence_bundles: { type: "array", items: { type: "object" } },
       },
     },
     diagnostics: { type: "array", items: { type: "object" } },
@@ -66,6 +67,7 @@ export interface AgentTaskRunResultSummary {
     transcripts: AgentTaskRunArtifactRef[]
     logs: AgentTaskRunArtifactRef[]
     runtimes: AgentTaskRunArtifactRef[]
+    evidence_bundles: AgentTaskRunArtifactRef[]
   }
   diagnostics: Array<Record<string, unknown>>
   metadata: Record<string, unknown>
@@ -112,6 +114,7 @@ export function normalizeAgentTaskRunResult(raw: unknown, options: AgentTaskRunR
       transcripts: artifacts.filter((artifact) => artifact.kind === "codebox-transcript"),
       logs: artifacts.filter((artifact) => artifact.kind === "codebox-runtime-log" || artifact.kind === "codebox-command-log"),
       runtimes: artifacts.filter((artifact) => artifact.kind === "codebox-runtime"),
+      evidence_bundles: artifacts.filter((artifact) => artifact.kind === "evidence-bundle" || artifact.kind === "codebox-evidence-bundle"),
     },
     diagnostics: [...arrayObjects(result.diagnostics), ...compatibilityDiagnostics, ...(terminalResult?.diagnostics ?? [])],
     metadata: stripUndefined({
@@ -196,6 +199,10 @@ function normalizeArtifacts(result: Record<string, unknown>, agentResult: Record
   appendUniqueArtifact(artifacts, stripUndefined({ id: runtimeLogPath ? "codebox-runtime-log" : "", kind: "codebox-runtime-log", path: runtimeLogPath }))
   const commandsLogPath = stringValue(objectValue(result.artifacts).commandsLogPath)
   appendUniqueArtifact(artifacts, stripUndefined({ id: commandsLogPath ? "codebox-command-log" : "", kind: "codebox-command-log", path: commandsLogPath }))
+
+  for (const evidenceRef of arrayObjects(result.evidence_refs)) {
+    appendUniqueArtifact(artifacts, artifactFromResultArtifact({ kind: "codebox-evidence-bundle", ...evidenceRef }))
+  }
 
   const runtime = runtimeRecord(result, compatMode, diagnostics)
   appendUniqueArtifact(artifacts, stripUndefined({

--- a/packages/runtime-core/src/artifact-result-envelope.ts
+++ b/packages/runtime-core/src/artifact-result-envelope.ts
@@ -13,6 +13,7 @@ export interface ArtifactResultEnvelopeBase {
   success: boolean
   artifactBundle?: MaterializationArtifactRef
   artifactRefs: MaterializationArtifactRef[]
+  evidenceRefs: MaterializationArtifactRef[]
   verification?: Record<string, unknown>
   result?: Record<string, unknown>
   diagnostics: MaterializationDiagnostic[]
@@ -49,6 +50,7 @@ export function artifactDiagnosticsResultEnvelope(input: {
   diagnosticOptions?: ArtifactDiagnosticNormalizerOptions
   artifactBundle?: MaterializationArtifactRef
   artifactRefs?: MaterializationArtifactRef[]
+  evidenceRefs?: MaterializationArtifactRef[]
   verification?: Record<string, unknown>
   result?: Record<string, unknown>
   metadata?: Record<string, unknown>
@@ -61,6 +63,7 @@ export function artifactDiagnosticsResultEnvelope(input: {
     status: input.status,
     artifactBundle: input.artifactBundle,
     artifactRefs: input.artifactRefs,
+    evidenceRefs: input.evidenceRefs,
     verification: input.verification,
     result: stripUndefined({
       ...input.result,
@@ -78,6 +81,7 @@ export function artifactResultEnvelope(input: {
   status?: ArtifactResultStatus
   artifactBundle?: MaterializationArtifactRef
   artifactRefs?: MaterializationArtifactRef[]
+  evidenceRefs?: MaterializationArtifactRef[]
   verification?: Record<string, unknown>
   result?: Record<string, unknown>
   diagnostics?: MaterializationDiagnostic[]
@@ -87,6 +91,7 @@ export function artifactResultEnvelope(input: {
 }): ArtifactResultEnvelope {
   const status = input.status ?? (input.error ? "failed" : "created")
   const artifactRefs = normalizeArtifactRefs([...(input.artifactBundle ? [input.artifactBundle] : []), ...(input.artifactRefs ?? [])])
+  const evidenceRefs = normalizeArtifactRefs(input.evidenceRefs ?? [])
   const diagnostics = input.diagnostics ?? []
   const base = stripUndefined({
     schema: ARTIFACT_RESULT_ENVELOPE_SCHEMA,
@@ -95,6 +100,7 @@ export function artifactResultEnvelope(input: {
     success: status === "created" || status === "existing" || status === "updated",
     artifactBundle: input.artifactBundle,
     artifactRefs,
+    evidenceRefs,
     verification: input.verification,
     result: input.result,
     diagnostics,
@@ -134,6 +140,7 @@ export function normalizeArtifactResultEnvelope(input: unknown, fallbackOperatio
       status: artifactResultStatus(record.status),
       artifactBundle: materializationArtifactRef(record.artifactBundle),
       artifactRefs: Array.isArray(record.artifactRefs) ? record.artifactRefs.map(materializationArtifactRef).filter(isDefined) : [],
+      evidenceRefs: Array.isArray(record.evidenceRefs) ? record.evidenceRefs.map(materializationArtifactRef).filter(isDefined) : [],
       verification: asRecord(record.verification),
       result: asRecord(record.result),
       diagnostics: Array.isArray(record.diagnostics) ? record.diagnostics.map(materializationDiagnostic).filter(isDefined) : [],
@@ -149,6 +156,7 @@ export function normalizeArtifactResultEnvelope(input: unknown, fallbackOperatio
     status: result.success === false ? "failed" : undefined,
     artifactBundle: materializationArtifactRef(result.artifactBundle ?? result.artifact_bundle ?? result.artifact_ref),
     artifactRefs: Array.isArray(result.artifactRefs) ? result.artifactRefs.map(materializationArtifactRef).filter(isDefined) : [],
+    evidenceRefs: Array.isArray(result.evidenceRefs) ? result.evidenceRefs.map(materializationArtifactRef).filter(isDefined) : [],
     verification: asRecord(result.verification),
     result,
     error: result.success === false ? errorObject(result.error) ?? "Artifact operation failed." : undefined,

--- a/packages/runtime-core/src/browser-contained-site-contracts.ts
+++ b/packages/runtime-core/src/browser-contained-site-contracts.ts
@@ -30,14 +30,20 @@ export interface BrowserContainedSite {
 
 export interface BrowserPreviewLease {
   schema: typeof BROWSER_CONTAINED_SITE_PREVIEW_LEASE_SCHEMA
+  public_url?: string
   preview_public_url?: string
   site_url?: string
   local_url?: string
   lease?: {
     status?: "active" | "released" | "expired" | "unknown" | string
     expires_at?: string
+    owner?: string
+    owner_id?: string
   }
+  reachability?: Record<string, unknown>
   alignment?: Record<string, unknown>
+  evidence_refs?: Record<string, unknown>[]
+  provenance?: Record<string, unknown>
 }
 
 export interface BrowserContainedSiteBootDescriptor {

--- a/packages/runtime-core/src/runtime-boundary-contracts.ts
+++ b/packages/runtime-core/src/runtime-boundary-contracts.ts
@@ -74,6 +74,7 @@ export interface PreviewLeaseMetadata {
   acquired_at?: string
   expires_at?: string
   owner?: string
+  owner_id?: string
   provider?: string
   provenance?: Record<string, unknown>
 }
@@ -86,13 +87,25 @@ export interface PreviewAlignmentEvidence {
   evidence?: Record<string, unknown>
 }
 
+export interface PreviewReachabilityEvidence {
+  status: "reachable" | "unreachable" | "unknown" | (string & {})
+  checked_at?: string
+  http_status?: number
+  probes?: Record<string, unknown>[]
+  evidence_refs?: Record<string, unknown>[]
+  metadata?: Record<string, unknown>
+}
+
 export interface PreviewLease {
   schema: typeof PREVIEW_LEASE_SCHEMA
+  public_url?: string
   preview_public_url?: string
   site_url?: string
   local_url?: string
   lease?: PreviewLeaseMetadata
+  reachability?: PreviewReachabilityEvidence
   alignment?: PreviewAlignmentEvidence
+  evidence_refs?: Record<string, unknown>[]
   provenance?: Record<string, unknown>
   metadata?: Record<string, unknown>
 }
@@ -220,19 +233,23 @@ export function runtimeProfile(input: unknown): RuntimeProfile {
 
 export function previewLease(input: unknown): PreviewLease {
   const value = requireObject(input, "Preview lease") as Partial<PreviewLease>
+  const publicUrl = optionalString(value.public_url, "public_url") ?? optionalString(value.preview_public_url, "preview_public_url")
   if (value.schema !== PREVIEW_LEASE_SCHEMA) throw new Error(`Preview lease schema must be ${PREVIEW_LEASE_SCHEMA}.`)
   const lease: PreviewLease = {
     schema: PREVIEW_LEASE_SCHEMA,
-    preview_public_url: optionalString(value.preview_public_url, "preview_public_url"),
+    public_url: publicUrl,
+    preview_public_url: publicUrl,
     site_url: optionalString(value.site_url, "site_url"),
     local_url: optionalString(value.local_url, "local_url"),
     lease: value.lease === undefined ? undefined : (normalizeOptionalObject(value.lease, "Preview lease metadata") as PreviewLeaseMetadata),
+    reachability: value.reachability === undefined ? undefined : normalizeReachability(value.reachability),
     alignment: value.alignment === undefined ? undefined : normalizeAlignment(value.alignment),
+    evidence_refs: normalizeObjectList(value.evidence_refs, "Preview lease evidence_refs"),
     provenance: normalizeOptionalObject(value.provenance, "Preview lease provenance"),
     metadata: normalizeOptionalObject(value.metadata, "Preview lease metadata"),
   }
-  if (!lease.preview_public_url && !lease.site_url && !lease.local_url) {
-    throw new Error("Preview lease must include preview_public_url, site_url, or local_url.")
+  if (!lease.public_url && !lease.site_url && !lease.local_url) {
+    throw new Error("Preview lease must include public_url, preview_public_url, site_url, or local_url.")
   }
   return lease
 }
@@ -248,7 +265,7 @@ export function previewLeaseStatus(input: PreviewLease | unknown, now = new Date
     if (!Number.isNaN(expires) && expires <= now.getTime()) return "expired"
   }
 
-  if (declaredStatus === "active" || lease.preview_public_url || lease.site_url || lease.local_url) return "active"
+  if (declaredStatus === "active" || lease.public_url || lease.preview_public_url || lease.site_url || lease.local_url) return "active"
   if (declaredStatus === "expired") return "expired"
   return "unknown"
 }
@@ -348,6 +365,18 @@ function normalizePreviewBootConfig(input: unknown): BrowserPreviewBootConfig {
     contained_site: normalizeOptionalObject(value.contained_site, "preview_boot.contained_site"),
     artifacts: normalizeOptionalObject(value.artifacts, "preview_boot.artifacts"),
     provenance: normalizeOptionalObject(value.provenance, "preview_boot.provenance"),
+  }
+}
+
+function normalizeReachability(input: unknown): PreviewReachabilityEvidence {
+  const value = requireObject(input, "Preview reachability") as Partial<PreviewReachabilityEvidence>
+  return {
+    status: (optionalString(value.status, "reachability.status") ?? "unknown") as PreviewReachabilityEvidence["status"],
+    checked_at: optionalString(value.checked_at, "reachability.checked_at"),
+    http_status: typeof value.http_status === "number" ? value.http_status : undefined,
+    probes: normalizeObjectList(value.probes, "reachability.probes"),
+    evidence_refs: normalizeObjectList(value.evidence_refs, "reachability.evidence_refs"),
+    metadata: normalizeOptionalObject(value.metadata, "reachability.metadata"),
   }
 }
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifacts.php
@@ -1508,6 +1508,7 @@ final class WP_Codebox_Artifacts {
 				'status'         => $status,
 				'artifactBundle' => $artifact_ref,
 				'artifactRefs'   => array( $artifact_ref ),
+				'evidenceRefs'   => is_array( $input['evidenceRefs'] ?? null ) ? $input['evidenceRefs'] : ( is_array( $input['evidence_refs'] ?? null ) ? $input['evidence_refs'] : array() ),
 				'verification'   => $verification,
 				'result'         => array(
 					'artifact_id'    => (string) $bundle['id'],

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -341,7 +341,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'session_id' => (string) ( $session_envelope['id'] ?? $session['session_id'] ?? $contained_site['session_id'] ?? '' ),
 				'site_id'    => (string) ( $contained_site['site_id'] ?? '' ),
 				'scope'      => (string) ( $preview_boot['scope'] ?? $contained_site['session_id'] ?? '' ),
-				'url'        => (string) ( $preview['preview_public_url'] ?? $preview['local_url'] ?? '' ),
+				'url'        => (string) ( $preview['public_url'] ?? $preview['preview_public_url'] ?? $preview['local_url'] ?? '' ),
 				'boot_ref'   => (string) ( $preview_boot['blueprint_ref'] ?? '' ),
 			),
 			static fn( string $value ): bool => '' !== $value
@@ -796,7 +796,7 @@ final class WP_Codebox_Browser_Task_Builder {
 			}
 		}
 
-		if ( 'active' === $status || ! empty( $lease['preview_public_url'] ) || ! empty( $lease['site_url'] ) || ! empty( $lease['local_url'] ) ) {
+		if ( 'active' === $status || ! empty( $lease['public_url'] ) || ! empty( $lease['preview_public_url'] ) || ! empty( $lease['site_url'] ) || ! empty( $lease['local_url'] ) ) {
 			return 'active';
 		}
 
@@ -806,33 +806,50 @@ final class WP_Codebox_Browser_Task_Builder {
 	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */
 	private static function preview_lease_from_session( array $session ): array {
 		if ( 'wp-codebox/preview-lease/v1' === (string) ( $session['schema'] ?? '' ) ) {
-			return self::compact_public_value( $session );
+			return self::canonical_preview_lease( self::compact_public_value( $session ) );
 		}
 
 		if ( is_array( $session['preview_boot']['preview'] ?? null ) ) {
-			return self::compact_public_value( $session['preview_boot']['preview'] );
+			return self::canonical_preview_lease( self::compact_public_value( $session['preview_boot']['preview'] ) );
 		}
 
 		if ( is_array( $session['preview'] ?? null ) && 'wp-codebox/preview-lease/v1' === (string) ( $session['preview']['schema'] ?? '' ) ) {
-			return self::compact_public_value( $session['preview'] );
+			return self::canonical_preview_lease( self::compact_public_value( $session['preview'] ) );
 		}
 
 		$playground = is_array( $session['playground'] ?? null ) ? $session['playground'] : array();
 		$lease      = is_array( $playground['lease'] ?? null ) ? $playground['lease'] : ( is_array( $session['preview_lease'] ?? null ) ? $session['preview_lease'] : array() );
 		$alignment  = is_array( $playground['alignment'] ?? null ) ? $playground['alignment'] : array( 'status' => 'unknown' );
+		$public_url = (string) ( $playground['public_url'] ?? $playground['preview_public_url'] ?? $session['public_url'] ?? $session['preview_public_url'] ?? '' );
+		$reachability = is_array( $playground['reachability'] ?? null ) ? $playground['reachability'] : ( is_array( $session['reachability'] ?? null ) ? $session['reachability'] : array() );
+		$evidence_refs = is_array( $playground['evidence_refs'] ?? null ) ? $playground['evidence_refs'] : ( is_array( $session['evidence_refs'] ?? null ) ? $session['evidence_refs'] : array() );
 
-		return array_filter(
+		return self::canonical_preview_lease( array_filter(
 			array(
 				'schema'             => 'wp-codebox/preview-lease/v1',
-				'preview_public_url' => (string) ( $playground['preview_public_url'] ?? $session['preview_public_url'] ?? '' ),
+				'public_url'         => $public_url,
+				'preview_public_url' => $public_url,
 				'site_url'           => (string) ( $playground['site_url'] ?? $playground['remote_url'] ?? '' ),
 				'local_url'          => (string) ( $playground['local_url'] ?? $playground['preview_url'] ?? '' ),
 				'lease'              => self::compact_public_value( $lease ),
+				'reachability'       => self::compact_public_value( $reachability ),
 				'alignment'          => self::compact_public_value( $alignment ),
+				'evidence_refs'      => self::compact_public_value( $evidence_refs ),
 				'provenance'         => is_array( $playground['provenance'] ?? null ) ? self::compact_public_value( $playground['provenance'] ) : array(),
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
-		);
+		) );
+	}
+
+	/** @param array<string,mixed> $lease Preview lease DTO. @return array<string,mixed> */
+	private static function canonical_preview_lease( array $lease ): array {
+		$public_url = (string) ( $lease['public_url'] ?? $lease['preview_public_url'] ?? '' );
+		if ( '' !== $public_url ) {
+			$lease['public_url'] = $public_url;
+			$lease['preview_public_url'] = $public_url;
+		}
+
+		return $lease;
 	}
 
 	private static function compact_public_value( mixed $value, string $key = '' ): mixed {

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php
@@ -232,6 +232,7 @@ final class WP_Codebox_Host_Run_Result_Normalizer {
 				'transcripts'      => $this->artifact_refs_by_kind( $artifacts, array( 'codebox-transcript' ) ),
 				'logs'             => $this->artifact_refs_by_kind( $artifacts, array( 'codebox-runtime-log', 'codebox-command-log' ) ),
 				'runtimes'         => $this->artifact_refs_by_kind( $artifacts, array( 'codebox-runtime' ) ),
+				'evidence_bundles' => $this->artifact_refs_by_kind( $artifacts, array( 'evidence-bundle', 'codebox-evidence-bundle' ) ),
 			),
 			'diagnostics' => array_values( array_filter( $diagnostics, 'is_array' ) ),
 			'metadata'    => array_filter(
@@ -273,7 +274,22 @@ final class WP_Codebox_Host_Run_Result_Normalizer {
 	/** @param array<string,mixed> $response @param array<string,mixed> $agent_result @param array<string,mixed> $run @return array<int,array<string,mixed>> */
 	private function agent_task_run_artifacts( array $response, array $agent_result, array $run ): array {
 		$artifacts = array();
-		$root      = (string) ( $agent_result['artifacts']['directory'] ?? $response['artifacts'] ?? '' );
+		foreach ( is_array( $response['artifacts'] ?? null ) ? $response['artifacts'] : array() as $artifact ) {
+			if ( is_array( $artifact ) ) {
+				$this->append_artifact_ref( $artifacts, $artifact );
+			}
+		}
+		foreach ( is_array( $response['evidence_refs'] ?? null ) ? $response['evidence_refs'] : array() as $evidence_ref ) {
+			if ( is_array( $evidence_ref ) ) {
+				$this->append_artifact_ref( $artifacts, array_merge( array( 'kind' => 'codebox-evidence-bundle' ), $evidence_ref ) );
+			}
+		}
+		foreach ( is_array( $run['evidence_refs'] ?? null ) ? $run['evidence_refs'] : array() as $evidence_ref ) {
+			if ( is_array( $evidence_ref ) ) {
+				$this->append_artifact_ref( $artifacts, array_merge( array( 'kind' => 'codebox-evidence-bundle' ), $evidence_ref ) );
+			}
+		}
+		$root      = (string) ( $agent_result['artifacts']['directory'] ?? ( is_string( $response['artifacts'] ?? null ) ? $response['artifacts'] : '' ) );
 		$this->append_artifact_ref( $artifacts, array( 'id' => basename( $root ), 'kind' => 'codebox-artifact-bundle', 'path' => $root ) );
 		$this->append_agent_artifact_ref( $artifacts, 'codebox-changed-files', $root, is_array( $agent_result['changedFiles'] ?? null ) ? $agent_result['changedFiles'] : array() );
 		$this->append_agent_artifact_ref( $artifacts, 'codebox-patch', $root, is_array( $agent_result['patch'] ?? null ) ? $agent_result['patch'] : array() );

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -116,10 +116,12 @@ $open = WP_Codebox_Abilities::open_browser_contained_site(
 		'cache_key'     => 'studio-native-preview',
 		'source_digest' => $source_digest,
 		'playground'    => array(
-			'preview_public_url' => 'https://preview.example.test',
+			'public_url'         => 'https://preview.example.test',
 			'site_url'           => 'https://preview.example.test/wp',
 			'local_url'          => 'http://localhost:8881/preview',
-			'lease'              => array( 'status' => 'active' ),
+			'lease'              => array( 'status' => 'active', 'owner' => 'php-smoke' ),
+			'reachability'       => array( 'status' => 'reachable', 'http_status' => 200, 'probes' => array( array( 'kind' => 'http' ) ) ),
+			'evidence_refs'      => array( array( 'kind' => 'probe-log', 'path' => 'files/probe.json' ) ),
 		),
 	)
 );
@@ -132,7 +134,11 @@ expect( 'prepared_runtime' === $open['reuse_level'], 'Expected open reuse_level=
 expect( false === $open['requires_materialization'], 'Expected open not to require materialization.' );
 expect( isset( $open['preview_boot']['blueprint_ref_dto']['hydration_endpoint'] ), 'Expected preview boot hydration endpoint.' );
 expect( 'wp-codebox/preview-lease/v1' === $open['preview_lease']['schema'], 'Expected preview lease DTO.' );
+expect( 'https://preview.example.test' === $open['preview_lease']['public_url'], 'Expected canonical public preview URL.' );
+expect( 'http://localhost:8881/preview' === $open['preview_lease']['local_url'], 'Expected local preview URL to remain distinct.' );
 expect( 'active' === $open['preview_lease']['lease']['status'], 'Expected active preview lease.' );
+expect( 'php-smoke' === $open['preview_lease']['lease']['owner'], 'Expected lease owner evidence.' );
+expect( 'reachable' === $open['preview_lease']['reachability']['status'], 'Expected reachability evidence.' );
 expect( 'browser-contained-site:studio-native-preview:' . $source_digest === $open['recovery_handle'], 'Expected stable open recovery handle.' );
 expect( 'reuse_prepared_runtime' === $open['contained_site']['open_mode'], 'Expected contained site lifecycle fields.' );
 

--- a/scripts/php-host-run-result-normalizer-smoke.php
+++ b/scripts/php-host-run-result-normalizer-smoke.php
@@ -74,10 +74,13 @@ smoke_assert( false === $timeout['agent_task_run_result']['success'], 'timeout c
 smoke_assert( 'timeout' === $timeout['agent_task_run_result']['status'], 'timeout canonical result status is timeout' );
 smoke_assert( 'wp_codebox_run_timeout' === $timeout['error']['code'], 'timeout error code is preserved' );
 
-$invalid_json = $normalizer->normalize( $prepared, array( 'exit_code' => 0, 'output' => 'not-json' ), $adapters );
+$prepared_without_artifacts = array_merge( $prepared, array( 'artifacts' => '' ) );
+$invalid_json = $normalizer->normalize( $prepared_without_artifacts, array( 'exit_code' => 0, 'output' => 'not-json' ), $adapters );
 smoke_assert( is_array( $invalid_json ) && ! is_wp_error( $invalid_json ), 'invalid JSON returns result envelope' );
 smoke_assert( 'wp_codebox_json_invalid' === $invalid_json['error']['code'], 'invalid JSON error code is preserved' );
 smoke_assert( 'invalid_json' === $invalid_json['error']['failure_classification'], 'invalid JSON classification is preserved' );
+smoke_assert( 'wp-codebox/agent-task-run-result/v1' === $invalid_json['agent_task_run_result']['schema'], 'invalid JSON includes canonical result schema' );
+smoke_assert( array() === $invalid_json['agent_task_run_result']['refs']['artifact_bundles'], 'failure before artifacts has no artifact bundle refs' );
 
 $non_zero = $normalizer->normalize( $prepared, array( 'exit_code' => 2, 'output' => '{"agentResult":{}}' ), $adapters );
 smoke_assert( is_array( $non_zero ) && ! is_wp_error( $non_zero ), 'non-zero exit returns result envelope' );
@@ -88,7 +91,7 @@ $success = $normalizer->normalize(
 	$prepared,
 	array(
 		'exit_code' => 0,
-		'output'    => '{"agentResult":{"artifacts":{"directory":"/tmp/wp-codebox-artifacts"},"summary":"Changed one file","changedFiles":{"artifact":"files/changed-files.json","count":1},"patch":{"artifact":"files/patch.diff","bytes":10},"transcript":{"artifact":"files/transcript.json"}},"runtime":{"id":"runtime-1","status":"destroyed"}}',
+		'output'    => '{"agentResult":{"artifacts":{"directory":"/tmp/wp-codebox-artifacts"},"summary":"Changed one file","changedFiles":{"artifact":"files/changed-files.json","count":1},"patch":{"artifact":"files/patch.diff","bytes":10},"transcript":{"artifact":"files/transcript.json"}},"evidence_refs":[{"id":"evidence-1","path":"/tmp/wp-codebox-artifacts/evidence.json"}],"runtime":{"id":"runtime-1","status":"destroyed"}}',
 	),
 	$adapters
 );
@@ -98,5 +101,6 @@ smoke_assert( 'succeeded' === $success['agent_task_run_result']['status'], 'succ
 smoke_assert( true === $success['agent_task_run_result']['success'], 'success canonical result is successful' );
 smoke_assert( 1 === $success['agent_task_run_result']['metadata']['changed_files_count'], 'success canonical result includes changed file count' );
 smoke_assert( 'codebox-patch' === $success['agent_task_run_result']['refs']['patches'][0]['kind'], 'success canonical result includes patch ref' );
+smoke_assert( 'codebox-evidence-bundle' === $success['agent_task_run_result']['refs']['evidence_bundles'][0]['kind'], 'success canonical result includes evidence bundle ref' );
 
 echo "host run result normalizer smoke passed\n";

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -32,6 +32,15 @@ const timeout = normalizeAgentTaskRunResult({
 assert.equal(timeout.status, "timeout")
 assert.equal(agentTaskRunExitCode({ success: true, agent_task_run_result: timeout }), 1)
 
+const failedBeforeArtifacts = normalizeAgentTaskRunResult({ success: false, status: "failed", summary: "Runtime failed before artifact capture." }, { exitStatus: 1 })
+assert.equal(failedBeforeArtifacts.status, "failed")
+assert.equal(failedBeforeArtifacts.success, false)
+assert.deepEqual(failedBeforeArtifacts.refs.artifact_bundles, [])
+
+const malformedProviderOutput = normalizeAgentTaskRunResult({ success: false, status: "failed", diagnostics: [{ code: "wp-codebox.output.invalid-json", message: "Invalid JSON" }] }, { exitStatus: 0 })
+assert.equal(malformedProviderOutput.status, "failed")
+assert.equal(malformedProviderOutput.diagnostics[0].code, "wp-codebox.output.invalid-json")
+
 const failedExit = normalizeAgentTaskRunResult({ success: true, status: "completed" }, { exitStatus: 1 })
 assert.equal(failedExit.status, "failed")
 assert.equal(agentTaskRunExitCode({ success: true, agent_task_run_result: failedExit }), 1)
@@ -63,6 +72,12 @@ const normalizedWithArtifactEnvelope = normalizeAgentTaskRunResult({
 assert.equal(normalizedWithArtifactEnvelope.refs.artifact_bundles[0].path, "artifacts/run-1")
 assert.equal(normalizedWithArtifactEnvelope.refs.transcripts[0].kind, "codebox-transcript")
 assert.equal(ARTIFACT_RESULT_ENVELOPE_SCHEMA, "wp-codebox/artifact-result-envelope/v1")
+
+const normalizedWithEvidenceBundle = normalizeAgentTaskRunResult({
+  success: true,
+  evidence_refs: [{ id: "evidence-1", path: "artifacts/run-1/evidence.json", sha256: "abc" }],
+}, { exitStatus: 0 })
+assert.equal(normalizedWithEvidenceBundle.refs.evidence_bundles[0].kind, "codebox-evidence-bundle")
 
 const catalog = commandCatalogOutput()
 const agentSandboxRun = catalog.commands.find((command) => command.id === "wp-codebox.agent-sandbox-run")

--- a/tests/artifact-result-envelope.test.ts
+++ b/tests/artifact-result-envelope.test.ts
@@ -6,6 +6,7 @@ const envelope = artifactResultEnvelope({
   status: "created",
   artifactBundle: { kind: "artifact-bundle", path: "artifacts/run-1", digest: { algorithm: "sha256", value: "abc" } },
   artifactRefs: [{ kind: "codebox-patch", path: "files/patch.diff" }],
+  evidenceRefs: [{ kind: "evidence-bundle", path: "files/evidence.json" }],
   result: {
     typed_artifacts: [{ name: "report", artifact_schema: "example/report/v1", payload: { ok: true } }],
     outputs: { answer: 42 },
@@ -18,6 +19,7 @@ assert.equal(envelope.schema, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
 assert.equal(envelope.success, true)
 assert.equal(envelope.artifactBundle?.path, "artifacts/run-1")
 assert.equal(envelope.artifactRefs.length, 2)
+assert.deepEqual(envelope.evidenceRefs, [{ kind: "evidence-bundle", path: "files/evidence.json" }])
 assert.deepEqual(envelope.result?.outputs, { answer: 42 })
 assert.equal(envelope.result?.typed_artifacts?.[0]?.name, "report")
 
@@ -27,11 +29,13 @@ const normalized = normalizeArtifactResultEnvelope({
   status: "created",
   artifactBundle: { kind: "bundle", path: "artifacts/run-2" },
   artifactRefs: [{ kind: "log", path: "files/log.txt" }],
+  evidenceRefs: [{ kind: "probe", path: "files/probe.json" }],
   result: { ok: true },
 })
 
 assert.equal(normalized.artifactBundle?.kind, "bundle")
 assert.equal(normalized.artifactRefs[0].path, "artifacts/run-2")
+assert.equal(normalized.evidenceRefs[0].path, "files/probe.json")
 assert.deepEqual(normalized.result, { ok: true })
 assert.deepEqual(normalized.diagnostics, [])
 

--- a/tests/runtime-boundary-contracts.test.ts
+++ b/tests/runtime-boundary-contracts.test.ts
@@ -71,15 +71,22 @@ assert.deepEqual(runtimeProfilePreflight({ schema: RUNTIME_PROFILE_SCHEMA, compo
 
 const lease = previewLease({
   schema: PREVIEW_LEASE_SCHEMA,
-  preview_public_url: "https://preview.example.test",
+  public_url: "https://preview.example.test",
   site_url: "https://site.example.test",
   local_url: "http://127.0.0.1:8881",
-  lease: { id: "lease-1", status: "active", provider: "preview-service" },
+  lease: { id: "lease-1", status: "active", provider: "preview-service", owner: "runtime-loop" },
+  reachability: { status: "reachable", http_status: 200, probes: [{ kind: "http", status: "passed" }], evidence_refs: [{ kind: "probe-log", path: "files/probe.json" }] },
   alignment: { status: "aligned", preview_matches_site: true, preview_matches_local: true },
+  evidence_refs: [{ kind: "preview-evidence", path: "files/browser/summary.json" }],
 })
 
 assert.equal(lease.schema, "wp-codebox/preview-lease/v1")
+assert.equal(lease.public_url, "https://preview.example.test")
+assert.equal(lease.preview_public_url, "https://preview.example.test")
+assert.equal(lease.local_url, "http://127.0.0.1:8881")
+assert.equal(lease.reachability?.status, "reachable")
 assert.equal(lease.alignment?.status, "aligned")
+assert.equal(lease.lease?.owner, "runtime-loop")
 assert.equal(previewLeaseStatus(lease), "active")
 assert.equal(previewLeaseStatus({ schema: PREVIEW_LEASE_SCHEMA, local_url: "http://127.0.0.1:8881", lease: { status: "active", expires_at: "2020-01-01T00:00:00.000Z" } }), "expired")
 
@@ -119,7 +126,7 @@ assert.equal(containedSiteOpen.schema, "wp-codebox/browser-contained-site-open/v
 assert.equal(containedSiteOpen.preview_session?.status, "recoverable_prepared_runtime")
 
 assert.throws(() => runtimeProfile({ schema: RUNTIME_PROFILE_SCHEMA, components: [{ kind: "component" }] }), /slug/)
-assert.throws(() => previewLease({ schema: PREVIEW_LEASE_SCHEMA }), /preview_public_url/)
+assert.throws(() => previewLease({ schema: PREVIEW_LEASE_SCHEMA }), /public_url/)
 assert.throws(() => browserContainedSiteStatus({ schema: BROWSER_CONTAINED_SITE_STATUS_SCHEMA, success: true, site_id: "site-1", status: "recoverable_prepared_runtime", source_digest: { value: "bad" } }), /source_digest/)
 
 const publicContractEnvelopes = [profile, lease, containedSiteStatus, containedSiteOpen]


### PR DESCRIPTION
## Summary
- Add canonical evidence bundle lanes to agent task run results and artifact result envelopes.
- Harden preview lease contracts to distinguish `public_url`, legacy `preview_public_url`, `site_url`, and `local_url`, with lease owner, reachability/probe evidence, evidence refs, and provenance fields.
- Keep WP Codebox core generic by limiting changes to neutral result/preview DTOs and normalizers; no downstream product, Homeboy policy, Data Machine, WPSG, or Agents API semantics were added.

## Validation
- `npm run test:agent-task-contracts`
- `npm run test:artifact-result-envelope`
- `npx tsx tests/runtime-boundary-contracts.test.ts`
- `npm run test:php-host-run-result-normalizer`
- `npm run test:php-browser-contained-site-contract`
- `npm run test:browser-task-builder`
- `npm run build`

## Follow-ups
- Agents API adapter extraction is intentionally left out of this PR. The current seams are already isolated enough for these DTO hardening changes, and a broader adapter split should happen in a dedicated PR to avoid mixing coupling cleanup with runtime contract changes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the contract/normalizer changes, adding targeted tests, running validation, and drafting this PR description.
