### PR TITLE
Harden public browser DTO contracts

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -103,7 +103,9 @@ The stable public surface is grouped by lifecycle area rather than by product:
   product payload validation.
 - **Browser task and contained site:** browser interaction, callback, probe,
   review bridge, session origin, artifact lifecycle, result shape, and runtime
-  boundary contracts.
+  boundary contracts. Public WordPress abilities return compact browser/session
+  product DTOs by default; executable Playground recipes, runtime payloads,
+  sandbox paths, and implementation diagnostics are internal/debug contracts.
 - **Browser SDK:** `window.wpCodeboxBrowser.v1.info()` reports SDK version,
   capability strings, and global names; `normalizeError()` returns
   `wp-codebox/browser-sdk-error/v1`; `result()` wraps async browser operations in

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -15,6 +15,8 @@ metadata exposes `meta.canonical_ability` for aliases.
 - `wp-codebox/run-agent-task-batch`
 - `wp-codebox/run-agent-task-fanout`
 - `wp-codebox/create-browser-playground-session`
+- `wp-codebox/create-browser-materializer-contract`
+- `wp-codebox/create-browser-task-contract`
 - `wp-codebox/browser-connector-request`
 - `wp-codebox/prepare`
 - `wp-codebox/capture`
@@ -73,6 +75,12 @@ artifact, and apply contracts before returning results to consumers.
 The task ability accepts `wp-codebox/task-input/v1` fields: `goal`, `target`,
 `allowed_tools`, `expected_artifacts`, `policy`, and `context`. Raw PHP `code`
 and `code_file` fields remain rejected on this product ability path.
+
+Browser session, materializer, and task contract abilities return compact public
+DTOs by default. Those DTOs expose stable session ids, contained-site and preview
+refs, preview URLs, artifact refs, status, and compact diagnostics. Raw
+Playground/runtime contracts, recipes, task payloads, sandbox paths, and
+implementation diagnostics stay behind explicit internal/debug raw-contract flags.
 
 Runtime orchestrators can pass `agent_bundles` plus a generic `runtime_task`
 payload to run caller-owned bundle logic without injecting PHP code. WP Codebox

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -297,7 +297,6 @@ final class WP_Codebox_Browser_Task_Builder {
 				'preview_boot'     => self::browser_preview_boot_config( $session ),
 				'preview_ref'      => self::browser_preview_ref( $session ),
 				'signals'          => self::compact_public_value( $signals ),
-				'artifacts'        => is_array( $session['artifacts'] ?? null ) ? self::compact_public_value( $session['artifacts'] ) : array(),
 				'artifact_refs'    => self::browser_artifact_refs( $session ),
 				'error'            => is_array( $session['error'] ?? null ) ? self::compact_public_value( $session['error'] ) : array(),
 			),
@@ -622,7 +621,6 @@ final class WP_Codebox_Browser_Task_Builder {
 				'contained_site'    => is_array( $session['contained_site'] ?? null ) ? self::compact_public_value( $session['contained_site'] ) : array(),
 				'artifacts'         => array_filter(
 					array(
-						'base_path'   => (string) ( $playground['artifact_base_path'] ?? '' ),
 						'base_url'    => (string) ( $playground['artifact_base_url'] ?? '' ),
 						'preview_url' => (string) ( $playground['preview_url'] ?? '' ),
 					),
@@ -836,7 +834,7 @@ final class WP_Codebox_Browser_Task_Builder {
 	}
 
 	private static function compact_public_value( mixed $value, string $key = '' ): mixed {
-		if ( in_array( $key, array( 'task_payload', 'pluginData', 'source', 'content', 'content_base64', 'bundle', 'blueprint', 'fallback_blueprint', 'runtime', 'prepared_runtime', 'prepared', 'plugins' ), true ) ) {
+		if ( in_array( $key, array( 'task_payload', 'pluginData', 'source', 'content', 'content_base64', 'bundle', 'blueprint', 'fallback_blueprint', 'runtime', 'prepared_runtime', 'prepared', 'plugins', 'artifact_base_path', 'base_path', 'task_path', 'result_path', 'event_stream_path', 'capture_paths', 'materialization_result_path' ), true ) ) {
 			return null;
 		}
 		if ( class_exists( 'WP_Codebox_Redaction_Policy' ) && WP_Codebox_Redaction_Policy::key_should_redact( 'public_session_dto', $key ) ) {

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -956,6 +956,7 @@ public static function hydrate_browser_blueprint_ref( array $input ): array|WP_E
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function create_browser_materializer_contract( array $input ): array|WP_Error {
+	$return_raw = self::include_raw_browser_contract( $input, 'materializer' );
 	$input['include_raw_browser_session'] = true;
 	$session = self::create_browser_playground_session( $input );
 	if ( is_wp_error( $session ) ) {
@@ -982,7 +983,7 @@ public static function create_browser_materializer_contract( array $input ): arr
 		);
 		$contract['compact'] = self::compact_browser_materializer_contract_dto( $contract );
 
-		return $contract;
+		return $return_raw ? $contract : $contract['compact'];
 	}
 
 	$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
@@ -1010,17 +1011,45 @@ public static function create_browser_materializer_contract( array $input ): arr
 	);
 	$contract['compact'] = self::compact_browser_materializer_contract_dto( $contract );
 
-	return $contract;
+	return $return_raw ? $contract : $contract['compact'];
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function create_browser_task_contract( array $input ): array|WP_Error {
+	$return_raw = self::include_raw_browser_contract( $input, 'task' );
 	$contract = self::prepare_browser_task_contract( $input );
-	if ( is_wp_error( $contract ) || true !== ( $input['execute_phases'] ?? false ) ) {
+	if ( is_wp_error( $contract ) ) {
 		return $contract;
 	}
+	if ( true === ( $input['execute_phases'] ?? false ) ) {
+		$contract = self::execute_browser_task_phases( $contract );
+		if ( is_wp_error( $contract ) ) {
+			return $contract;
+		}
+	}
 
-	return self::execute_browser_task_phases( $contract );
+	return $return_raw ? $contract : ( is_array( $contract['compact'] ?? null ) ? $contract['compact'] : self::compact_browser_task_contract_dto( $contract ) );
+}
+
+/** @param array<string,mixed> $input Ability input. */
+private static function include_raw_browser_contract( array $input, string $contract ): bool {
+	if ( true === ( $input['include_internal_browser_contract'] ?? false ) || true === ( $input['include_raw_browser_contract'] ?? false ) ) {
+		return true;
+	}
+
+	if ( 'materializer' === $contract && true === ( $input['include_raw_browser_materializer_contract'] ?? false ) ) {
+		return true;
+	}
+
+	if ( 'task' === $contract && true === ( $input['include_raw_browser_task_contract'] ?? false ) ) {
+		return true;
+	}
+
+	$debug = is_array( $input['debug'] ?? null ) ? $input['debug'] : array();
+	return true === ( $debug['include_internal_browser_contract'] ?? false )
+		|| true === ( $debug['include_raw_browser_contract'] ?? false )
+		|| ( 'materializer' === $contract && true === ( $debug['include_raw_browser_materializer_contract'] ?? false ) )
+		|| ( 'task' === $contract && true === ( $debug['include_raw_browser_task_contract'] ?? false ) );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
@@ -1296,16 +1325,29 @@ private static function compact_browser_materializer_contract_dto( array $contra
 			'session_id'       => (string) ( $contract['session_id'] ?? '' ),
 			'authorization'    => is_array( $contract['authorization'] ?? null ) ? self::compact_browser_dto_value( $contract['authorization'] ) : array(),
 			'task'             => is_array( $contract['task_input'] ?? null ) ? (string) ( $contract['task_input']['goal'] ?? '' ) : '',
-			'executable'       => self::browser_executable_materializer_contract_dto( $contract ),
-			'materialization'  => is_array( $contract['materialization'] ?? null ) ? self::compact_browser_dto_value( $contract['materialization'] ) : array(),
-			'recipe'           => is_array( $contract['recipe'] ?? null ) ? self::compact_browser_recipe_dto( $contract['recipe'] ) : array(),
 			'preview_boot'     => WP_Codebox_Browser_Task_Builder::browser_preview_boot_config( $contract ),
-			'playground'       => is_array( $contract['playground'] ?? null ) ? self::compact_browser_playground_dto( $contract['playground'] ) : array(),
-			'artifacts'        => is_array( $contract['artifacts'] ?? null ) ? self::compact_browser_dto_value( $contract['artifacts'] ) : array(),
+			'preview_ref'      => WP_Codebox_Browser_Task_Builder::browser_preview_ref( $contract ),
+			'artifact_refs'    => WP_Codebox_Browser_Task_Builder::browser_artifact_refs( $contract ),
+			'diagnostics'      => self::compact_browser_contract_diagnostics( $contract ),
 			'provenance'       => is_array( $contract['provenance'] ?? null ) ? self::compact_browser_dto_value( $contract['provenance'] ) : array(),
 		),
 		static fn( mixed $value ): bool => array() !== $value && '' !== $value
 	);
+}
+
+/** @param array<string,mixed> $contract Browser contract. @return array<string,mixed> */
+private static function compact_browser_contract_diagnostics( array $contract ): array {
+	$diagnostics = array();
+	if ( is_array( $contract['signals'] ?? null ) ) {
+		$diagnostics['signals'] = self::compact_browser_dto_value( $contract['signals'] );
+	}
+	if ( is_array( $contract['execution_metrics'] ?? null ) ) {
+		$metrics = self::compact_browser_dto_value( $contract['execution_metrics'] );
+		unset( $metrics['payload_bytes'], $metrics['diagnostics_refs'] );
+		$diagnostics['execution_metrics'] = $metrics;
+	}
+
+	return array_filter( $diagnostics, static fn( mixed $value ): bool => array() !== $value && '' !== $value );
 }
 
 /** @param array<string,mixed> $contract Browser materializer contract. @return array<string,mixed> */
@@ -1419,7 +1461,7 @@ private static function compact_browser_dto_value( mixed $value, string $key = '
 }
 
 private static function compact_browser_dto_key_should_omit( string $key ): bool {
-	return in_array( $key, array( 'pluginData', 'source', 'content', 'content_base64', 'bundle', 'plugins', 'runtime' ), true );
+	return in_array( $key, array( 'pluginData', 'source', 'content', 'content_base64', 'bundle', 'plugins', 'runtime', 'artifact_base_path', 'base_path', 'task_path', 'result_path', 'event_stream_path', 'capture_paths', 'materialization_result_path' ), true );
 }
 
 private static function compact_browser_dto_key_should_redact( string $key ): bool {
@@ -1493,6 +1535,7 @@ private static function prepare_browser_task_contract_phases( array $input, arra
 		if ( empty( $phase_input['sandbox_session_id'] ) && '' !== (string) ( $session_envelope['id'] ?? '' ) ) {
 			$phase_input['sandbox_session_id'] = (string) $session_envelope['id'];
 		}
+		$phase_input['include_internal_browser_contract'] = true;
 
 		$contract = self::create_browser_materializer_contract( $phase_input );
 		if ( is_wp_error( $contract ) ) {

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -317,6 +317,11 @@ private static function browser_playground_session_schema(): array {
 
 /** @return array<string,mixed> */
 private static function browser_materializer_contract_schema(): array {
+	return self::browser_product_dto_schema();
+}
+
+/** @return array<string,mixed> */
+private static function browser_internal_materializer_contract_schema(): array {
 	return array(
 		'type'       => 'object',
 		'properties' => array(
@@ -351,6 +356,11 @@ private static function browser_materializer_contract_schema(): array {
 
 /** @return array<string,mixed> */
 private static function browser_task_contract_schema(): array {
+	return self::browser_product_dto_schema();
+}
+
+/** @return array<string,mixed> */
+private static function browser_internal_task_contract_schema(): array {
 	return array(
 		'type'       => 'object',
 		'properties' => array(
@@ -405,7 +415,7 @@ private static function browser_task_phase_kinds(): array {
 private static function browser_product_dto_schema(): array {
 	return array(
 		'type'        => 'object',
-		'description' => 'Compact product-facing browser task/session DTO for durable product records and REST responses. It preserves runner fields used by runBrowserSessionRecipe while omitting raw runtime plugin payloads, source paths, inline content, and secret values.',
+		'description' => 'Compact product-facing browser task/session DTO for durable product records and REST responses. It exposes stable ids, preview refs, artifact refs, status, and compact diagnostics while omitting raw playground, runtime, recipe, task payload, sandbox path, and implementation diagnostic contracts.',
 		'properties'  => array(
 			'success'          => array( 'type' => 'boolean' ),
 			'schema'           => array( 'type' => 'string' ),
@@ -414,17 +424,25 @@ private static function browser_product_dto_schema(): array {
 			'execution'        => array( 'type' => 'string' ),
 			'execution_scope'  => array( 'type' => 'string' ),
 			'permission_model' => array( 'type' => 'string' ),
+			'status'           => array( 'type' => 'string' ),
+			'session_id'       => array( 'type' => 'string' ),
 			'session'          => array( 'type' => 'object' ),
 			'contained_site'   => self::browser_contained_site_schema(),
 			'primary'          => array( 'type' => 'object' ),
 			'phases'           => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
-			'task_input'       => array( 'type' => 'object' ),
-			'task_payload'     => array( 'type' => 'object' ),
-			'materialization'  => array( 'type' => 'object' ),
-			'playground'       => array( 'type' => 'object' ),
-			'recipe'           => array( 'type' => 'object' ),
-			'artifacts'        => array( 'type' => 'object' ),
+			'task'             => array( 'type' => 'string' ),
+			'target'           => array( 'type' => 'object' ),
+			'agent'            => array( 'type' => 'string' ),
+			'provider'         => array( 'type' => 'string' ),
+			'model'            => array( 'type' => 'string' ),
+			'preview_boot'     => array( 'type' => 'object' ),
+			'preview_ref'      => array( 'type' => 'object' ),
+			'artifact_refs'    => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
+			'signals'          => array( 'type' => 'object' ),
+			'error'            => array( 'type' => 'object' ),
+			'diagnostics'      => array( 'type' => 'object' ),
 			'execution_metrics' => array( 'type' => 'object' ),
+			'provenance'       => array( 'type' => 'object' ),
 		),
 	);
 }

--- a/tests/browser-session-public-dto.test.ts
+++ b/tests/browser-session-public-dto.test.ts
@@ -52,9 +52,21 @@ $input = array(
 $public = WP_Codebox_Abilities::create_browser_playground_session( $input );
 $raw = WP_Codebox_Abilities::create_browser_playground_session( $input + array( 'include_raw_browser_session' => true ) );
 $materializer = WP_Codebox_Abilities::create_browser_materializer_contract( $input );
+$raw_materializer = WP_Codebox_Abilities::create_browser_materializer_contract( $input + array( 'include_raw_browser_materializer_contract' => true ) );
+$task_contract = WP_Codebox_Abilities::create_browser_task_contract( $input );
+$raw_task_contract = WP_Codebox_Abilities::create_browser_task_contract( $input + array( 'include_raw_browser_task_contract' => true ) );
 
-echo json_encode( array( 'public' => $public, 'raw' => $raw, 'materializer' => $materializer ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'public' => $public, 'raw' => $raw, 'materializer' => $materializer, 'raw_materializer' => $raw_materializer, 'task_contract' => $task_contract, 'raw_task_contract' => $raw_task_contract ), JSON_UNESCAPED_SLASHES );
 `)
+
+function assertPublicDtoDoesNotExposeInternals(value: unknown) {
+  const encoded = JSON.stringify(value)
+  assert.equal(encoded.includes("must-not-leak"), false)
+  assert.equal(encoded.includes("/wordpress/"), false, encoded)
+  for (const key of ["playground", "runtime", "recipe", "task_payload", "executable", "materialization"]) {
+    assert.equal(Object.prototype.hasOwnProperty.call(value as Record<string, unknown>, key), false, `${key} must not be exposed`)
+  }
+}
 
 assert.equal(result.public.schema, "wp-codebox/browser-session-product-dto/v1")
 assert.equal(result.public.source_schema, "wp-codebox/browser-playground-session/v1")
@@ -76,14 +88,30 @@ assert.equal(result.public.playground, undefined)
 assert.equal(result.public.recipe, undefined)
 assert.equal(result.public.task_payload, undefined)
 assert.equal(JSON.stringify(result.public).includes("must-not-leak"), false)
+assert.equal(result.public.preview_boot.artifacts.base_path, undefined)
+assertPublicDtoDoesNotExposeInternals(result.public)
 
 assert.equal(result.raw.schema, "wp-codebox/browser-playground-session/v1")
 assert.equal(result.raw.product.schema, "wp-codebox/browser-session-product-dto/v1")
 assert.equal(Array.isArray(result.raw.playground.blueprint.steps), true)
 assert.equal(result.raw.recipe.runtime.backend, "wordpress-playground")
 
-assert.equal(result.materializer.schema, "wp-codebox/browser-materializer-contract/v1")
-assert.equal(Array.isArray(result.materializer.playground.blueprint.steps), true)
-assert.equal(result.materializer.compact.schema, "wp-codebox/browser-materializer-product-dto/v1")
+assert.equal(result.materializer.schema, "wp-codebox/browser-materializer-product-dto/v1")
+assert.equal(result.materializer.source_schema, "wp-codebox/browser-materializer-contract/v1")
+assert.equal(result.materializer.preview_ref.schema, "wp-codebox/browser-preview-ref/v1")
+assert.deepEqual(result.materializer.artifact_refs, result.public.artifact_refs)
+assertPublicDtoDoesNotExposeInternals(result.materializer)
+
+assert.equal(result.raw_materializer.schema, "wp-codebox/browser-materializer-contract/v1")
+assert.equal(Array.isArray(result.raw_materializer.playground.blueprint.steps), true)
+assert.equal(result.raw_materializer.compact.schema, "wp-codebox/browser-materializer-product-dto/v1")
+
+assert.equal(result.task_contract.schema, "wp-codebox/browser-task-product-dto/v1")
+assert.equal(result.task_contract.primary.schema, "wp-codebox/browser-session-product-dto/v1")
+assertPublicDtoDoesNotExposeInternals(result.task_contract)
+
+assert.equal(result.raw_task_contract.schema, "wp-codebox/browser-task-contract/v1")
+assert.equal(result.raw_task_contract.compact.schema, "wp-codebox/browser-task-product-dto/v1")
+assert.equal(Array.isArray(result.raw_task_contract.primary.playground.blueprint.steps), true)
 
 console.log("browser session public dto ok")

--- a/tests/browser-task-contract-product-dto.test.ts
+++ b/tests/browser-task-contract-product-dto.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { repoRoot } from "../scripts/test-kit.js"
 
 const execution = readFileSync(join(repoRoot, "packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php"), "utf8")
+const schemas = readFileSync(join(repoRoot, "packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php"), "utf8")
 const descriptors = readFileSync(join(repoRoot, "packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php"), "utf8")
 
 assert.match(execution, /'authorization'\s*=>\s*is_array\(\s*\$session_envelope\['authorization'\]/)
@@ -13,5 +14,9 @@ assert.match(execution, /'authorization'\s*=>\s*is_array\(\s*\$contract\['author
 assert.match(execution, /'task_input'\s*=>\s*is_array\(\s*\$contract\['task_input'\]/)
 assert.doesNotMatch(descriptors, /'source_digest'\s*=>\s*array\(\s*'description'/)
 assert.match(descriptors, /'source_digest'\s*=>\s*array\(\s*'type'\s*=>\s*array\(\s*'string',\s*'object'\s*\)/)
+assert.match(schemas, /private static function browser_materializer_contract_schema\(\): array \{\s*return self::browser_product_dto_schema\(\);\s*\}/)
+assert.match(schemas, /private static function browser_task_contract_schema\(\): array \{\s*return self::browser_product_dto_schema\(\);\s*\}/)
+assert.match(schemas, /private static function browser_internal_materializer_contract_schema\(\): array \{[\s\S]*'task_payload'\s*=>\s*array\( 'type' => 'object' \)/)
+assert.doesNotMatch(schemas.match(/private static function browser_product_dto_schema\(\): array \{[\s\S]*?\n\}/)?.[0] ?? "", /'task_payload'|'playground'|'runtime'|'recipe'|'materialization'/)
 
 console.log("browser task contract product dto ok")


### PR DESCRIPTION
## Summary
- Return compact browser materializer/task DTOs by default, with raw executable contracts behind explicit internal/debug flags.
- Narrow public browser DTO schemas to stable ids, preview refs/URLs, artifact refs, status, and compact diagnostics.
- Keep internal materializer/task schema helpers available for raw contract consumers and update docs/tests for the public DTO boundary.

## Tests
- npm run test:browser-session-public-dto
- npm run test:browser-task-builder
- npm run test:wordpress-plugin-public-runtime-abilities
- npm exec -- tsx tests/browser-task-contract-product-dto.test.ts
- npm run test:public-api-contract
- npm run test:schema-parity
- npm run build
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the DTO/schema boundary change, updating tests/docs, and running verification.