### PR TITLE
Preserve CLI JSON output before exit

### DIFF
--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -6,7 +6,7 @@ export type CliExit = (code: number) => never
 
 const UNSETTLED_COMMAND_MESSAGE = "WP Codebox CLI command did not settle before the Node.js event loop drained."
 
-export function runCliEntrypoint(args: string[], runner: CliRunner = runCli, exit: CliExit = process.exit): void {
+export function runCliEntrypoint(args: string[], runner: CliRunner = runCli, exit: CliExit = naturalExit): void {
   let settled = false
   const writeStderr = process.stderr.write.bind(process.stderr)
   const handleBeforeExit = () => {
@@ -43,6 +43,11 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli, exi
       exitAfterOutputDrains(1, exit)
     },
   )
+}
+
+function naturalExit(code: number): never {
+  process.exitCode = code
+  return undefined as never
 }
 
 function exitAfterOutputDrains(code: number, exit: CliExit): void {

--- a/tests/cli-main-output-drain.test.ts
+++ b/tests/cli-main-output-drain.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+
+const payload = "x".repeat(1024 * 1024)
+const script = `
+  import { runCliEntrypoint } from ${JSON.stringify(new URL("../packages/cli/src/cli-main.ts", import.meta.url).href)};
+  runCliEntrypoint(["run-agent-task", "--json"], async () => {
+    process.stdout.write("x".repeat(${payload.length}));
+    return 1;
+  });
+`
+
+const result = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+  encoding: "utf8",
+  maxBuffer: payload.length * 20,
+})
+
+assert.equal(result.error, undefined)
+assert.equal(result.signal, null)
+assert.equal(result.status, 1, result.stderr)
+assert.equal(result.stdout.length, payload.length)
+assert.equal(result.stdout, payload)


### PR DESCRIPTION
## Summary
- Let the WP Codebox CLI set `process.exitCode` and exit naturally instead of forcing `process.exit()` immediately after command output.
- Add a regression test that writes a large JSON-sized payload through `runCliEntrypoint` and verifies stdout is preserved on a non-zero exit.

## Tests
- `npx tsx tests/cli-main-output-drain.test.ts`
- `npm run build`
- `npm run test:fuzz-suite-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing dropped CLI JSON output during WP Codebox fuzz dispatch, implementing the exit-path fix, and adding regression coverage.
