### PR TITLE
Avoid hard exit on recipe phase failure

### DIFF
--- a/packages/cli/src/commands/recipe-run-output.ts
+++ b/packages/cli/src/commands/recipe-run-output.ts
@@ -83,7 +83,7 @@ export function exitAfterTerminalRecipePhaseFailure(output: RecipeRunCommandOutp
     return
   }
 
-  process.exit(1)
+  process.exitCode = 1
 }
 
 function hasTerminalRecipePhaseFailure(output: RecipeRunOutput): boolean {

--- a/tests/recipe-run-output-exit.test.ts
+++ b/tests/recipe-run-output-exit.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { exitAfterTerminalRecipePhaseFailure } from "../packages/cli/src/commands/recipe-run-output.js"
+
+const originalExit = process.exit
+const originalExitCode = process.exitCode
+let exitCalled = false
+
+process.exit = ((code?: string | number | null | undefined) => {
+  exitCalled = true
+  throw new Error(`process.exit called with ${code}`)
+}) as typeof process.exit
+
+try {
+  process.exitCode = undefined
+  exitAfterTerminalRecipePhaseFailure({
+    schema: "wp-codebox/recipe-run/v1",
+    success: false,
+    error: { name: "RecipePhaseError", message: "failed", code: "recipe-phase-failed" },
+  } as never)
+
+  assert.equal(exitCalled, false)
+  assert.equal(process.exitCode, 1)
+} finally {
+  process.exit = originalExit
+  process.exitCode = originalExitCode
+}


### PR DESCRIPTION
## Summary
- Replace the hard `process.exit(1)` used for terminal recipe phase failures with `process.exitCode = 1`.
- Add a regression test proving terminal recipe failure handling does not terminate nested callers before they can restore stdout and emit failure envelopes.

## Tests
- `npx tsx tests/cli-main-output-drain.test.ts`
- `npx tsx tests/recipe-run-output-exit.test.ts`
- `npm run build`
- `npm run test:fuzz-suite-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing empty WP Codebox `run-agent-task` output during fuzz dispatch, implementing the recipe phase exit fix, and adding regression coverage.
