### PR TITLE
Document focused public Codebox entrypoints

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -9,8 +9,9 @@ Codebox APIs to assemble and run sandboxes.
 
 Use these package entrypoints from external integrations:
 
-- `@automattic/wp-codebox-core`: broad compatibility barrel for existing
-  consumers. New integrations should use a focused entrypoint below.
+- `@automattic/wp-codebox-core`: compatibility-only broad barrel for existing
+  consumers. New integrations should use a focused entrypoint below; new helper
+  additions belong in `public` or a lifecycle subpath, not the root barrel.
 - `@automattic/wp-codebox-core/public`: curated public facade for runtime,
   task/package, runner workspace, tool bridge, parent tool bridge, browser,
   artifact, recipe, and policy contract types and helpers. New external TypeScript consumers should prefer
@@ -21,6 +22,9 @@ Use these package entrypoints from external integrations:
   and schema identifiers without importing backend adapter bindings.
 - `@automattic/wp-codebox-core/artifacts`: artifact verification, apply adapter,
   export-link, diagnostics, and partial-discovery helpers.
+- `@automattic/wp-codebox-core/run-results`: task, command, browser, artifact,
+  recipe, and fuzz result DTO helpers for orchestrators that need result shapes
+  without importing the broad root or full public facade.
 - `@automattic/wp-codebox-core/recipe-builders`: typed recipe construction
   helpers.
 - `@automattic/wp-codebox-core/agent-task-recipe`: agent-task recipe assembly
@@ -75,10 +79,11 @@ backend systems internally, while public docs and schemas present Codebox-owned
 ability names, schemas, and facades to callers.
 
 The workspace package mirrors the core entrypoints as `./core`,
-`./core/public`, `./core/contracts`, `./core/artifacts`, `./recipe-builders`,
-`./agent-task-recipe`, `./runtime-presets`, `./playground/public`, and
-`./cli/recipe-secret-env` for local consumers in this repo. It intentionally does
-not mirror the monorepo-only `./internals` helper entrypoint.
+`./core/public`, `./core/contracts`, `./core/artifacts`, `./core/run-results`,
+`./recipe-builders`, `./run-results`, `./agent-task-recipe`,
+`./runtime-presets`, `./playground/public`, and `./cli/recipe-secret-env` for
+local consumers in this repo. It intentionally does not mirror the monorepo-only
+`./internals` helper entrypoint.
 
 ## Contract Areas
 
@@ -151,6 +156,9 @@ The stable public surface is grouped by lifecycle area rather than by product:
 - **Artifacts:** manifest, paths, capture policy, layout, references, review,
   diagnostics, test result, export link, storage, result envelope, evidence
   envelope, and materialization contracts.
+- **Run results:** normalized task, terminal, command, browser, recipe summary,
+  artifact handoff, and fuzz result DTOs that orchestrators can import from
+  `@automattic/wp-codebox-core/run-results`.
 - **Inspect:** command registry metadata, JSON Schema factories, CLI `schema` and
   `commands` output, and recipe validation descriptors.
 
@@ -226,6 +234,26 @@ workspace operation names. Public callers use the Codebox ability ids and
 request/result schemas while the adapter config maps each operation to its
 integration-provided backend ability. See `docs/runner-workspace-backend-contract.md`.
 Those adapter bindings are not part of `runtimeContractManifest()`.
+
+## Homeboy Extensions Migration
+
+Homeboy Extensions and other dist/dynamic package loaders should import the
+narrowest Codebox entrypoint that matches the runtime object they need. This
+keeps packaged helpers stable when the broad root barrel continues to exist for
+compatibility but stops being the place where new public helpers accumulate.
+
+| Current import pressure | Use instead | Notes |
+| --- | --- | --- |
+| Root package import for command names, schema ids, or ability metadata | `@automattic/wp-codebox-core/contracts` | Use `runtimeContractManifest()` and command contract helpers without backend adapter exports. |
+| Root package import for artifact refs, export links, bundle verification, or apply/materialization handoff | `@automattic/wp-codebox-core/artifacts` | Artifact helpers stay grouped by evidence and handoff lifecycle. |
+| Root package import for runtime package, phpunit, or bench recipe assembly | `@automattic/wp-codebox-core/recipe-builders` | Recipe construction helpers are public without pulling the full runtime barrel. |
+| Root package import for task, command, browser, recipe, artifact, or fuzz result DTOs | `@automattic/wp-codebox-core/run-results` | Result projection helpers are stable for orchestrators and dist loaders. |
+| Workspace-local mirror import during package development | `./core/contracts`, `./core/artifacts`, `./recipe-builders`, or `./run-results` | Workspace mirrors exist for this repo's local consumers; published consumers should use package names. |
+
+The root barrel remains published so existing integrations keep working. Treat it
+as compatibility-only: new Homeboy Extensions call sites should choose one of the
+focused entrypoints above, and new Codebox helpers should be added to the focused
+owner module that matches their lifecycle area.
 
 ## Internal Entry Point
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,17 @@
       "types": "./packages/runtime-core/dist/artifacts.d.ts",
       "import": "./packages/runtime-core/dist/artifacts.js"
     },
+    "./core/run-results": {
+      "types": "./packages/runtime-core/dist/run-results.d.ts",
+      "import": "./packages/runtime-core/dist/run-results.js"
+    },
     "./recipe-builders": {
       "types": "./packages/runtime-core/dist/recipe-builders.d.ts",
       "import": "./packages/runtime-core/dist/recipe-builders.js"
+    },
+    "./run-results": {
+      "types": "./packages/runtime-core/dist/run-results.d.ts",
+      "import": "./packages/runtime-core/dist/run-results.js"
     },
     "./agent-task-recipe": {
       "types": "./packages/runtime-core/dist/agent-task-recipe.d.ts",

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/artifacts.d.ts",
       "import": "./dist/artifacts.js"
     },
+    "./run-results": {
+      "types": "./dist/run-results.d.ts",
+      "import": "./dist/run-results.js"
+    },
     "./internals": {
       "types": "./dist/internals.d.ts",
       "import": "./dist/internals.js"

--- a/packages/runtime-core/src/run-results.ts
+++ b/packages/runtime-core/src/run-results.ts
@@ -1,0 +1,8 @@
+/** Public run result DTO helpers for orchestrator consumers. */
+export * from "./agent-task-run-result.js"
+export * from "./agent-terminal-result.js"
+export * from "./artifact-result-envelope.js"
+export * from "./browser-run-result.js"
+export * from "./recipe-run-summary.js"
+export * from "./runtime-command-result.js"
+export { FUZZ_SUITE_RESULT_SCHEMA, fuzzSuiteResultEnvelope, type FuzzSuiteCaseResult, type FuzzSuiteResultEnvelope } from "./fuzz-suite-contracts.js"

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -34,6 +34,7 @@ import {
   RUNNER_WORKSPACE_BACKEND_FILTER,
 } from "../packages/runtime-core/src/public.js"
 import * as publicApi from "../packages/runtime-core/src/public.js"
+import * as runResultsApi from "../packages/runtime-core/src/run-results.js"
 import * as playgroundPublicApi from "../packages/runtime-playground/src/public.js"
 
 const root = new URL("..", import.meta.url)
@@ -65,7 +66,9 @@ assert.deepEqual(exportKeys(rootPackage), [
   "./core/public",
   "./core/contracts",
   "./core/artifacts",
+  "./core/run-results",
   "./recipe-builders",
+  "./run-results",
   "./agent-task-recipe",
   "./runtime-presets",
   "./playground",
@@ -79,6 +82,7 @@ assert.deepEqual(exportKeys(corePackage), [
   "./public",
   "./contracts",
   "./artifacts",
+  "./run-results",
   "./internals",
   "./recipe-builders",
   "./agent-task-recipe",
@@ -94,6 +98,7 @@ const pluginReadme = await readFile(new URL("packages/wordpress-plugin/README.md
 const agentsApiAdapter = await readFile(new URL("packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php", root), "utf8")
 const publicBarrel = await readFile(new URL("packages/runtime-core/src/public.ts", root), "utf8")
 const contractsBarrel = await readFile(new URL("packages/runtime-core/src/contracts.ts", root), "utf8")
+const rootBarrel = await readFile(new URL("packages/runtime-core/src/index.ts", root), "utf8")
 const runnerWorkspaceAdapter = await readFile(new URL("packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-adapter.php", root), "utf8")
 
 assert.deepEqual(barrelExportModules(publicBarrel), [
@@ -183,6 +188,7 @@ for (const publicEntry of [
   "@automattic/wp-codebox-core/public",
   "@automattic/wp-codebox-core/contracts",
   "@automattic/wp-codebox-core/artifacts",
+  "@automattic/wp-codebox-core/run-results",
   "@automattic/wp-codebox-core/recipe-builders",
   "@automattic/wp-codebox-core/agent-task-recipe",
   "@automattic/wp-codebox-core/runtime-presets",
@@ -206,6 +212,7 @@ for (const contractArea of [
   "Performance observation",
   "Fuzz suite",
   "Artifacts",
+  "Run results",
   "Inspect",
 ]) {
   assert.match(docs, new RegExp(`\\*\\*${contractArea}:\\*\\*`), `docs must define ${contractArea}`)
@@ -267,6 +274,9 @@ assert.match(docs, /@automattic\/wp-codebox-core\/internals` exists for this mon
 assert.match(docs, /workspace package does not expose a `\.\/core\/internals` mirror/)
 assert.match(docs, /External\s+integrations use the stable entrypoints listed above/)
 assert.match(docs, /New external TypeScript\s+consumers should prefer/)
+assert.match(docs, /`@automattic\/wp-codebox-core`: compatibility-only broad barrel/)
+assert.match(rootBarrel, /Stable root package barrel kept for existing consumers/)
+assert.match(rootBarrel, /prefer the curated `@automattic\/wp-codebox-core\/public` facade or narrower/)
 assert.match(docs, /WordPress consumers should prefer `WP_Codebox_API`/)
 assert.match(docs, /`wp-codebox\/\*` ability ids/)
 assert.match(docs, /`@automattic\/wp-codebox-playground`: advanced runtime backend entrypoint/)
@@ -278,6 +288,13 @@ assert.match(docs, /wp-codebox\/runner-workspace-backend\/v1/)
 assert.match(docs, /backend adapter config schema/)
 assert.match(docs, /adapter config maps each operation to its\s+integration-provided backend ability/)
 assert.match(docs, /runtimeContractManifest\(\)/)
+assert.match(docs, /## Homeboy Extensions Migration/)
+assert.match(docs, /Root package import for command names, schema ids, or ability metadata \| `@automattic\/wp-codebox-core\/contracts`/)
+assert.match(docs, /Root package import for artifact refs, export links, bundle verification, or apply\/materialization handoff \| `@automattic\/wp-codebox-core\/artifacts`/)
+assert.match(docs, /Root package import for runtime package, phpunit, or bench recipe assembly \| `@automattic\/wp-codebox-core\/recipe-builders`/)
+assert.match(docs, /Root package import for task, command, browser, recipe, artifact, or fuzz result DTOs \| `@automattic\/wp-codebox-core\/run-results`/)
+assert.match(docs, /The root barrel remains published so existing integrations keep working/)
+assert.match(docs, /Treat it\s+as compatibility-only/)
 assert.match(docs, /wp-codebox\/run-agent-task/)
 assert.match(docs, /wp-codebox\/run-runtime-package/)
 assert.match(docs, /wp-codebox\/run-wordpress-workload/)
@@ -302,6 +319,13 @@ assert.equal(typeof artifactBundleFileManifest, "function")
 assert.equal(typeof normalizeAgentTaskRunResult, "function")
 assert.equal(typeof artifactResultEnvelope, "function")
 assert.equal(typeof normalizeArtifactResultEnvelope, "function")
+assert.equal(typeof runResultsApi.normalizeAgentTaskRunResult, "function")
+assert.equal(typeof runResultsApi.artifactResultEnvelope, "function")
+assert.equal(typeof runResultsApi.normalizeArtifactResultEnvelope, "function")
+assert.equal(typeof runResultsApi.browserRunResultEnvelope, "function")
+assert.equal(typeof runResultsApi.createRuntimeCommandResultEnvelope, "function")
+assert.equal(typeof runResultsApi.normalizeRecipeRunSummary, "function")
+assert.equal(typeof runResultsApi.fuzzSuiteResultEnvelope, "function")
 assert.equal(typeof runtimeProfile, "function")
 assert.equal(typeof parentToolBridgeContract, "function")
 assert.equal(typeof fuzzSuiteContract, "function")


### PR DESCRIPTION
## Summary
- Add a narrow run-results entrypoint for orchestrator result DTO helpers.
- Document root barrel imports as compatibility-only.
- Add Homeboy Extensions migration guidance toward focused package entrypoints.

## Tests
- npm ci
- npm run test:public-api-contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the focused package-boundary changes, docs, and tests.