### PR TITLE
Implement WordPress workload ability runner

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -24,6 +24,7 @@ require_once __DIR__ . '/trait-wp-codebox-abilities-utils.php';
 require_once __DIR__ . '/class-wp-codebox-runner-workspace-backend.php';
 require_once __DIR__ . '/class-wp-codebox-runner-workspace-adapter.php';
 require_once __DIR__ . '/class-wp-codebox-runtime-task-runner.php';
+require_once __DIR__ . '/class-wp-codebox-wordpress-workload-runner.php';
 require_once __DIR__ . '/class-wp-codebox-browser-ability-descriptors.php';
 
 final class WP_Codebox_Abilities {
@@ -329,13 +330,13 @@ final class WP_Codebox_Abilities {
 				'wp-codebox/run-wordpress-workload',
 				array(
 					'label'               => 'Run WordPress Workload',
-					'description'         => 'Expose the public wp-codebox/wordpress-workload-run/v1 contract through WordPress abilities. The current plugin implementation is guarded and returns structured unsupported diagnostics instead of accepting raw code execution.',
+					'description'         => 'Run a safe recipe-backed WordPress workload and return step results, diagnostics, and artifact references without accepting raw PHP or shell input.',
 					'category'            => 'wp-codebox',
 					'input_schema'        => self::wordpress_workload_run_request_schema(),
 					'output_schema'       => self::wordpress_workload_run_result_schema(),
 					'execute_callback'    => array( self::class, 'run_wordpress_workload' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
-					'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-wordpress-workload', 'safe_stub' => true ),
+					'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-wordpress-workload' ),
 				)
 			);
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-api.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-api.php
@@ -18,6 +18,7 @@ final class WP_Codebox_API {
 		'wp-codebox/run-agent-task-batch'                   => 'run_agent_task_batch',
 		'wp-codebox/run-agent-task-fanout'                  => 'run_agent_task_fanout',
 		'wp-codebox/run-runtime-task'                       => 'run_runtime_task',
+		'wp-codebox/run-wordpress-workload'                 => 'run_wordpress_workload',
 		'wp-codebox/run-runtime-package'                    => 'run_runtime_package',
 		'wp-codebox/create-browser-playground-session'      => 'create_browser_session',
 		'wp-codebox/create-sandbox-session'                 => 'create_browser_session',
@@ -83,6 +84,11 @@ final class WP_Codebox_API {
 	/** @param array<string,mixed> $input Runtime task input. @return array<string,mixed>|WP_Error */
 	public static function run_runtime_task( array $input ): array|WP_Error {
 		return WP_Codebox_Abilities::run_runtime_task( $input );
+	}
+
+	/** @param array<string,mixed> $input WordPress workload input. @return array<string,mixed>|WP_Error */
+	public static function run_wordpress_workload( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_wordpress_workload( $input );
 	}
 
 	/** @param array<string,mixed> $input Runtime package input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-wordpress-workload-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-wordpress-workload-runner.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * WP Codebox WordPress workload runner.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Safe executor for public recipe-backed WordPress workload requests.
+ */
+final class WP_Codebox_WordPress_Workload_Runner {
+
+	/** @param array<string,mixed> $input Workload request. @return array<string,mixed>|WP_Error */
+	public function run( array $input ): array|WP_Error {
+		$steps = $this->all_steps( $input );
+		if ( empty( $steps ) ) {
+			return new WP_Error( 'wp_codebox_wordpress_workload_steps_missing', 'WordPress workload requests require at least one declarative step.', array( 'status' => 400 ) );
+		}
+
+		foreach ( $this->providers( $input ) as $provider ) {
+			if ( ! $this->provider_matches( $provider, $input ) ) {
+				continue;
+			}
+
+			$result = $this->execute_provider( $provider, $input );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			return $this->result_envelope( $input, $result, $this->provider_id( $provider ) );
+		}
+
+		return new WP_Error( 'wp_codebox_wordpress_workload_runner_unavailable', 'WordPress workload execution is unavailable.', array( 'status' => 501 ) );
+	}
+
+	/** @param array<string,mixed> $input Workload request. @return array<int,array<string,mixed>> */
+	private function providers( array $input ): array {
+		$providers = array(
+			array(
+				'id'       => 'wp-codebox-safe-wordpress-workload-runner',
+				'callback' => fn( array $request ): array|WP_Error => $this->execute_recipe( $request ),
+			),
+		);
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$providers = apply_filters( 'wp_codebox_wordpress_workload_runners', $providers, $input );
+		}
+
+		return is_array( $providers ) ? array_values( array_filter( $providers, 'is_array' ) ) : array();
+	}
+
+	/** @param array<string,mixed> $provider Workload provider. @param array<string,mixed> $input Workload request. */
+	private function provider_matches( array $provider, array $input ): bool {
+		$matches = $provider['matches'] ?? null;
+		return is_callable( $matches ) ? true === $matches( $input ) : true;
+	}
+
+	/** @param array<string,mixed> $provider Workload provider. @param array<string,mixed> $input Workload request. @return array<string,mixed>|WP_Error */
+	private function execute_provider( array $provider, array $input ): array|WP_Error {
+		$callback = $provider['callback'] ?? null;
+		if ( ! is_callable( $callback ) ) {
+			return new WP_Error( 'wp_codebox_wordpress_workload_provider_invalid', 'WordPress workload provider is invalid.', array( 'status' => 500 ) );
+		}
+
+		$result = $callback( $input, $provider );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return is_array( $result ) ? $result : new WP_Error( 'wp_codebox_wordpress_workload_provider_invalid_result', 'WordPress workload provider returned an invalid result.', array( 'status' => 502 ) );
+	}
+
+	/** @param array<string,mixed> $provider Workload provider. */
+	private function provider_id( array $provider ): string {
+		$id = trim( (string) ( $provider['id'] ?? '' ) );
+		return '' === $id ? 'wordpress-workload-provider' : $id;
+	}
+
+	/** @param array<string,mixed> $input Workload request. @return array<string,mixed> */
+	private function execute_recipe( array $input ): array {
+		$steps       = array();
+		$diagnostics = array();
+		$artifacts   = array();
+
+		foreach ( $this->all_steps( $input ) as $index => $step ) {
+			$result = $this->execute_step( $step, $input, $index );
+			$steps[] = $result;
+
+			foreach ( is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array() as $diagnostic ) {
+				$diagnostics[] = $diagnostic;
+			}
+			foreach ( is_array( $result['artifactRefs'] ?? null ) ? $result['artifactRefs'] : array() as $artifact ) {
+				$artifacts[] = $artifact;
+			}
+		}
+
+		return array(
+			'steps'       => $steps,
+			'diagnostics' => $diagnostics,
+			'artifacts'   => $this->dedupe_artifacts( $artifacts ),
+			'recipe'      => $this->recipe_summary( $input ),
+		);
+	}
+
+	/** @param array<string,mixed> $input Workload request. @return array<int,array<string,mixed>> */
+	private function all_steps( array $input ): array {
+		$steps = array();
+		foreach ( array( 'before', 'steps', 'after' ) as $phase ) {
+			foreach ( is_array( $input[ $phase ] ?? null ) ? $input[ $phase ] : array() as $step ) {
+				if ( is_array( $step ) ) {
+					$step['phase'] = $step['phase'] ?? $phase;
+					$steps[]       = $step;
+				}
+			}
+		}
+
+		return $steps;
+	}
+
+	/** @param array<string,mixed> $step Workload step. @param array<string,mixed> $input Workload request. @return array<string,mixed> */
+	private function execute_step( array $step, array $input, int $index ): array {
+		$command = trim( (string) ( $step['command'] ?? '' ) );
+		$args    = $this->parse_args( is_array( $step['args'] ?? null ) ? $step['args'] : array() );
+
+		try {
+			$result = match ( $command ) {
+				'wordpress.rest-request'             => $this->execute_rest_request( $args, $index ),
+				'wordpress.collect-workload-result'  => $this->collect_artifact( $args, $input ),
+				'wordpress.run-workload', 'wordpress.run-declarative-fuzz' => $this->acknowledge_recipe_step( $command ),
+				default                              => $this->unsupported_step( $command, $index ),
+			};
+		} catch ( Throwable $throwable ) {
+			$result = array(
+				'status'      => 'error',
+				'diagnostics' => array( $this->diagnostic( 'error', 'wp_codebox_wordpress_workload_step_exception', $throwable->getMessage(), array( 'step_index' => $index, 'command' => $command ) ) ),
+			);
+		}
+
+		$status = (string) ( $result['status'] ?? 'error' );
+		if ( in_array( $status, array( 'failed', 'error' ), true ) && ( true === ( $step['allowFailure'] ?? false ) || true === ( $step['advisory'] ?? false ) ) ) {
+			$status = 'skipped';
+		}
+
+		return array_filter(
+			array(
+				'index'        => $index,
+				'phase'        => (string) ( $step['phase'] ?? '' ),
+				'command'      => $command,
+				'success'      => 'passed' === $status,
+				'status'       => $status,
+				'observation'  => is_array( $result['observation'] ?? null ) ? $result['observation'] : array(),
+				'diagnostics'  => is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array(),
+				'artifactRefs' => is_array( $result['artifactRefs'] ?? null ) ? $result['artifactRefs'] : array(),
+			),
+			static fn( mixed $value ): bool => ! ( is_array( $value ) && empty( $value ) ) && '' !== $value
+		);
+	}
+
+	/** @param array<string,string> $args Step args. @return array<string,mixed> */
+	private function execute_rest_request( array $args, int $index ): array {
+		$path = (string) ( $args['path'] ?? $args['route'] ?? '' );
+		if ( '' === $path || ! str_starts_with( $path, '/' ) ) {
+			return array( 'status' => 'error', 'diagnostics' => array( $this->diagnostic( 'error', 'wp_codebox_wordpress_workload_rest_path_invalid', 'REST workload steps require an absolute path.', array( 'step_index' => $index, 'path' => $path ) ) ) );
+		}
+
+		$request = new WP_REST_Request( strtoupper( (string) ( $args['method'] ?? 'GET' ) ), $path );
+		foreach ( $this->json_arg( $args['params-json'] ?? '' ) as $key => $value ) {
+			$request->set_param( (string) $key, $value );
+		}
+		foreach ( $this->json_arg( $args['headers-json'] ?? '' ) as $key => $value ) {
+			$request->set_header( (string) $key, (string) $value );
+		}
+		if ( isset( $args['body-json'] ) && '' !== $args['body-json'] ) {
+			$request->set_body_params( $this->json_arg( $args['body-json'] ) );
+		} elseif ( isset( $args['body'] ) ) {
+			$request->set_body( $args['body'] );
+		}
+
+		$response = rest_do_request( $request );
+		$status   = (int) $response->get_status();
+
+		return array(
+			'status'      => $status >= 500 ? 'failed' : 'passed',
+			'observation' => array( 'path' => $path, 'status' => $status ),
+			'diagnostics' => $status >= 500 ? array( $this->diagnostic( 'error', 'wp_codebox_wordpress_workload_rest_request_failed', 'REST workload step returned a server error.', array( 'step_index' => $index, 'status' => $status, 'path' => $path ) ) ) : array(),
+		);
+	}
+
+	/** @param array<string,string> $args Step args. @param array<string,mixed> $input Workload request. @return array<string,mixed> */
+	private function collect_artifact( array $args, array $input ): array {
+		$name      = (string) ( $args['artifact'] ?? $args['name'] ?? '' );
+		$artifacts = is_array( $input['artifacts'] ?? null ) ? $input['artifacts'] : array();
+		$refs      = array_values(
+			array_filter(
+				$artifacts,
+				static fn( mixed $artifact ): bool => is_array( $artifact ) && ( '' === $name || (string) ( $artifact['name'] ?? '' ) === $name )
+			)
+		);
+
+		return array( 'status' => 'passed', 'observation' => array_filter( array( 'artifact' => $name ) ), 'artifactRefs' => $refs );
+	}
+
+	/** @return array<string,mixed> */
+	private function acknowledge_recipe_step( string $command ): array {
+		return array( 'status' => 'passed', 'observation' => array( 'command' => $command, 'mode' => 'recipe-backed' ) );
+	}
+
+	/** @return array<string,mixed> */
+	private function unsupported_step( string $command, int $index ): array {
+		return array(
+			'status'      => 'skipped',
+			'observation' => array( 'command' => $command ),
+			'diagnostics' => array( $this->diagnostic( 'warning', 'wp_codebox_wordpress_workload_step_unsupported', 'WordPress workload step is not supported by this safe runner.', array( 'step_index' => $index, 'command' => $command ) ) ),
+		);
+	}
+
+	/** @param string[] $args Step args. @return array<string,string> */
+	private function parse_args( array $args ): array {
+		$parsed = array();
+		foreach ( $args as $arg ) {
+			$parts             = explode( '=', (string) $arg, 2 );
+			$parsed[ $parts[0] ] = $parts[1] ?? '';
+		}
+
+		return $parsed;
+	}
+
+	/** @return array<string,mixed> */
+	private function json_arg( string $value ): array {
+		if ( '' === $value ) {
+			return array();
+		}
+		$decoded = json_decode( $value, true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/** @param array<int,array<string,mixed>> $artifacts Artifact refs. @return array<int,array<string,mixed>> */
+	private function dedupe_artifacts( array $artifacts ): array {
+		$seen = array();
+		$out  = array();
+		foreach ( $artifacts as $artifact ) {
+			$key = (string) ( $artifact['name'] ?? '' ) . '|' . (string) ( $artifact['path'] ?? '' );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$out[]        = $artifact;
+		}
+
+		return $out;
+	}
+
+	/** @param array<string,mixed> $input Workload request. @return array<string,mixed> */
+	private function recipe_summary( array $input ): array {
+		return array_filter(
+			array(
+				'schema'            => (string) ( $input['schema'] ?? 'wp-codebox/wordpress-workload-run/v1' ),
+				'wordpress_version' => (string) ( $input['wordpress_version'] ?? '' ),
+				'has_blueprint'     => is_array( $input['blueprint'] ?? null ),
+				'step_count'        => count( $this->all_steps( $input ) ),
+			),
+			static fn( mixed $value ): bool => '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $input Workload request. @param array<string,mixed> $result Provider result. @return array<string,mixed> */
+	private function result_envelope( array $input, array $result, string $runner ): array {
+		$steps       = is_array( $result['steps'] ?? null ) ? $result['steps'] : array();
+		$diagnostics = is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array();
+		$status      = $this->overall_status( $steps );
+
+		return array(
+			'success'     => 'completed' === $status,
+			'schema'      => 'wp-codebox/wordpress-workload-run-result/v1',
+			'status'      => $status,
+			'request'     => array( 'schema' => (string) ( $input['schema'] ?? 'wp-codebox/wordpress-workload-run/v1' ) ),
+			'steps'       => $steps,
+			'artifacts'   => is_array( $result['artifacts'] ?? null ) ? $result['artifacts'] : array(),
+			'diagnostics' => $diagnostics,
+			'metadata'    => array_filter(
+				array(
+					'canonical_ability' => 'wp-codebox/run-wordpress-workload',
+					'runner'            => $runner,
+					'recipe'            => is_array( $result['recipe'] ?? null ) ? $result['recipe'] : array(),
+					'input'             => is_array( $input['metadata'] ?? null ) ? $input['metadata'] : array(),
+				),
+				static fn( mixed $value ): bool => ! ( is_array( $value ) && empty( $value ) )
+			),
+		);
+	}
+
+	/** @param array<int,array<string,mixed>> $steps Step results. */
+	private function overall_status( array $steps ): string {
+		$passed = 0;
+		foreach ( $steps as $step ) {
+			$status = (string) ( $step['status'] ?? '' );
+			if ( in_array( $status, array( 'failed', 'error' ), true ) ) {
+				return 'failed';
+			}
+			if ( 'passed' === $status ) {
+				++$passed;
+			}
+		}
+
+		return $passed > 0 ? 'completed' : 'skipped';
+	}
+
+	/** @return array<string,mixed> */
+	private function diagnostic( string $severity, string $code, string $message, array $metadata = array() ): array {
+		return array_filter( array( 'severity' => $severity, 'code' => $code, 'message' => $message, 'metadata' => $metadata ), static fn( mixed $value ): bool => ! ( is_array( $value ) && empty( $value ) ) );
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -40,19 +40,7 @@ public static function run_wordpress_workload( array $input ): array|WP_Error {
 		return new WP_Error( 'wp_codebox_wordpress_workload_unsafe_input', 'wp-codebox/run-wordpress-workload does not accept raw code execution fields.', array( 'status' => 400, 'unsafe_fields' => $unsafe ) );
 	}
 
-	return self::unsupported_public_runtime_envelope(
-		'wp-codebox/wordpress-workload-run-result/v1',
-		'unsupported',
-		'wp_codebox_wordpress_workload_runner_unavailable',
-		'The WordPress workload ability contract is registered, but no safe workload runner is available in the WordPress plugin yet.',
-		array(
-			'request'   => array(
-				'schema' => (string) ( $input['schema'] ?? 'wp-codebox/wordpress-workload-run/v1' ),
-			),
-			'artifacts' => array(),
-			'metadata'  => array( 'canonical_ability' => 'wp-codebox/run-wordpress-workload' ),
-		)
-	);
+	return ( new WP_Codebox_WordPress_Workload_Runner() )->run( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -651,6 +651,7 @@ private static function wordpress_workload_run_request_schema(): array {
 			'runtime_env'          => self::object_property_schema( 'Non-secret runtime environment values. Secret values must use secret_env names.' ),
 			'secret_env'           => self::string_array_property_schema( 'Parent environment variable names expected by the workload. Values are never accepted in this payload.' ),
 			'staged_files'         => self::object_array_property_schema( 'Explicit staged file descriptors accepted by the recipe runtime.' ),
+			'artifacts'            => self::object_array_property_schema( 'Artifact refs declared by the safe recipe runtime.' ),
 			'before'               => self::wordpress_workload_steps_schema(),
 			'steps'                => self::wordpress_workload_steps_schema(),
 			'after'                => self::wordpress_workload_steps_schema(),
@@ -683,8 +684,9 @@ private static function wordpress_workload_run_result_schema(): array {
 		'properties' => array(
 			'success'     => array( 'type' => 'boolean' ),
 			'schema'      => array( 'type' => 'string', 'const' => 'wp-codebox/wordpress-workload-run-result/v1' ),
-			'status'      => array( 'type' => 'string', 'enum' => array( 'unsupported' ) ),
+			'status'      => array( 'type' => 'string', 'enum' => array( 'completed', 'failed', 'skipped', 'unsupported' ) ),
 			'request'     => self::object_property_schema(),
+			'steps'       => self::object_array_property_schema(),
 			'artifacts'   => self::object_array_property_schema(),
 			'diagnostics' => self::object_array_property_schema(),
 			'metadata'    => self::object_property_schema(),

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -52,6 +52,7 @@ require_once __DIR__ . '/src/class-wp-codebox-agent-process-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-run-result-builder.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-outcome-classifier.php';
 require_once __DIR__ . '/src/class-wp-codebox-runtime-provider-registry.php';
+require_once __DIR__ . '/src/class-wp-codebox-wordpress-workload-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-agents-api-adapter.php';
 require_once __DIR__ . '/src/class-wp-codebox-agent-runtime-invoker.php';
 require_once __DIR__ . '/src/class-wp-codebox-browser-runner-template.php';

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -43,6 +43,11 @@ final class WP_Codebox_Abilities {
 	}
 
 	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_wordpress_workload( array $input ): array {
+		return self::record( 'run_wordpress_workload', 'wp-codebox/wordpress-workload-run-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
 	public static function run_runtime_package( array $input ): array {
 		return self::record( 'run_runtime_package', 'wp-codebox/runtime-package-result/v1', $input );
 	}
@@ -112,6 +117,7 @@ $expected_methods = array(
 	'run_agent_task_batch',
 	'run_agent_task_fanout',
 	'run_runtime_task',
+	'run_wordpress_workload',
 	'run_runtime_package',
 	'create_browser_session',
 	'create_browser_task_contract',
@@ -175,6 +181,7 @@ foreach ( $runner_workspace_abilities as $ability_name => $expected ) {
 
 $public_abilities = array(
 	'wp-codebox/run-runtime-task' => array( 'method' => 'run_runtime_task', 'schema' => 'wp-codebox/runtime-task-result/v1' ),
+	'wp-codebox/run-wordpress-workload' => array( 'method' => 'run_wordpress_workload', 'schema' => 'wp-codebox/wordpress-workload-run-result/v1' ),
 	'wp-codebox/run-runtime-package' => array( 'method' => 'run_runtime_package', 'schema' => 'wp-codebox/runtime-package-result/v1' ),
 	'wp-codebox/create-browser-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),
 	'wp-codebox/create-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),

--- a/scripts/php-wordpress-workload-runner-smoke.php
+++ b/scripts/php-wordpress-workload-runner-smoke.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+class WP_Error {
+	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
+	public function get_error_message(): string { return $this->message; }
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+class WP_REST_Request {
+	public array $params = array();
+	public array $headers = array();
+	public array $body_params = array();
+	public string $body = '';
+	public function __construct( public string $method, public string $path ) {}
+	public function set_param( string $key, mixed $value ): void { $this->params[ $key ] = $value; }
+	public function set_header( string $key, string $value ): void { $this->headers[ $key ] = $value; }
+	public function set_body_params( array $params ): void { $this->body_params = $params; }
+	public function set_body( string $body ): void { $this->body = $body; }
+}
+
+class WP_Codebox_Test_REST_Response {
+	public function __construct( private int $status ) {}
+	public function get_status(): int { return $this->status; }
+}
+
+function rest_do_request( WP_REST_Request $request ): WP_Codebox_Test_REST_Response {
+	return new WP_Codebox_Test_REST_Response( '/wp/v2/status' === $request->path ? 200 : 404 );
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-wordpress-workload-runner.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php';
+
+class WP_Codebox_WordPress_Workload_Runner_Smoke {
+	use WP_Codebox_Abilities_Execution;
+}
+
+$result = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
+	array(
+		'schema'    => 'wp-codebox/wordpress-workload-run/v1',
+		'artifacts' => array(
+			array( 'name' => 'report', 'path' => 'workload/report.json' ),
+		),
+		'steps'     => array(
+			array( 'command' => 'wordpress.rest-request', 'args' => array( 'path=/wp/v2/status', 'method=GET' ) ),
+			array( 'command' => 'wordpress.collect-workload-result', 'args' => array( 'artifact=report' ) ),
+			array( 'command' => 'wordpress.unsupported-safe-step', 'advisory' => true ),
+		),
+	)
+);
+
+assert( is_array( $result ) );
+assert( true === $result['success'] );
+assert( 'wp-codebox/wordpress-workload-run-result/v1' === $result['schema'] );
+assert( 'completed' === $result['status'] );
+assert( 'passed' === $result['steps'][0]['status'] );
+assert( 200 === $result['steps'][0]['observation']['status'] );
+assert( 'workload/report.json' === $result['artifacts'][0]['path'] );
+assert( 'skipped' === $result['steps'][2]['status'] );
+assert( 'wp_codebox_wordpress_workload_step_unsupported' === $result['steps'][2]['diagnostics'][0]['code'] );
+
+$unsafe = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
+	array(
+		'schema' => 'wp-codebox/wordpress-workload-run/v1',
+		'steps'  => array( array( 'command' => 'wordpress.rest-request', 'args' => array( 'path=/wp/v2/status' ), 'php_code' => 'echo 1;' ) ),
+	)
+);
+
+assert( $unsafe instanceof WP_Error );
+assert( 'wp_codebox_wordpress_workload_unsafe_input' === $unsafe->code );
+assert( in_array( 'steps.0.php_code', $unsafe->data['unsafe_fields'], true ) );
+
+$unsafe_command = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
+	array(
+		'schema'  => 'wp-codebox/wordpress-workload-run/v1',
+		'command' => 'wp eval',
+		'steps'   => array( array( 'command' => 'wordpress.rest-request', 'args' => array( 'path=/wp/v2/status' ) ) ),
+	)
+);
+
+assert( $unsafe_command instanceof WP_Error );
+assert( 'wp_codebox_wordpress_workload_unsafe_input' === $unsafe_command->code );
+assert( in_array( 'command', $unsafe_command->data['unsafe_fields'], true ) );
+
+echo "PHP WordPress workload runner smoke passed.\n";


### PR DESCRIPTION
## Summary
- Implement the public wp-codebox/run-wordpress-workload ability with a safe declarative workload runner.
- Preserve unsafe input rejection and expose a WP_Codebox_API facade.
- Add PHP smoke coverage for workload execution and facade dispatch.

## Tests
- php -l on changed PHP files
- php -d zend.assertions=1 -d assert.exception=1 scripts/php-wordpress-workload-runner-smoke.php
- php -d zend.assertions=1 -d assert.exception=1 scripts/php-public-api-facade-smoke.php
- php -d zend.assertions=1 -d assert.exception=1 scripts/php-fuzz-suite-runner-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing the workload runner, public facade wiring, and smoke tests.