### PR TITLE
Summarize fuzz suite coverage

### DIFF
--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -56,6 +56,7 @@ export interface FuzzSuiteCaseResult {
   status: FuzzSuiteCaseStatus
   success: boolean
   target?: FuzzSuiteTargetRef
+  skipReason?: string
   diagnostics: FuzzSuiteDiagnostic[]
   artifactRefs?: FuzzSuiteArtifactRef[]
   metadata?: Record<string, unknown>
@@ -69,6 +70,21 @@ export interface FuzzSuiteSummary {
   skipped: number
 }
 
+export interface FuzzSuiteSkippedReasonSummary {
+  reason: string
+  count: number
+  caseIds?: string[]
+}
+
+export interface FuzzSuiteCoverageSummary {
+  discovered: number
+  generated: number
+  executed: number
+  skipped: number
+  untested: number
+  skippedReasons: FuzzSuiteSkippedReasonSummary[]
+}
+
 export interface FuzzSuiteResultEnvelope {
   schema: typeof FUZZ_SUITE_RESULT_SCHEMA
   suite: {
@@ -78,6 +94,7 @@ export interface FuzzSuiteResultEnvelope {
   status: FuzzSuiteCaseStatus
   success: boolean
   summary: FuzzSuiteSummary
+  coverageSummary?: FuzzSuiteCoverageSummary
   cases: FuzzSuiteCaseResult[]
   diagnostics: FuzzSuiteDiagnostic[]
   artifactRefs: FuzzSuiteArtifactRef[]
@@ -106,12 +123,14 @@ export function fuzzSuiteResultEnvelope(input: {
   cases?: FuzzSuiteCaseResult[]
   diagnostics?: FuzzSuiteDiagnostic[]
   artifactRefs?: FuzzSuiteArtifactRef[]
+  coverageSummary?: FuzzSuiteCoverageSummary
   metadata?: Record<string, unknown>
 }): FuzzSuiteResultEnvelope {
   const cases = (input.cases ?? []).map(normalizeCaseResult)
   const diagnostics = input.diagnostics ?? []
   const artifactRefs = dedupeArtifactRefs([...(input.artifactRefs ?? []), ...cases.flatMap((item) => item.artifactRefs ?? [])])
   const summary = summarizeFuzzCases(cases)
+  const coverageSummary = input.coverageSummary ?? summarizeFuzzCoverage({ discovered: fuzzSuiteDiscoveredCount(input.suite, cases.length), cases })
   const status: FuzzSuiteCaseStatus = summary.error > 0 ? "error" : summary.failed > 0 ? "failed" : summary.skipped === summary.total && summary.total > 0 ? "skipped" : "passed"
 
   return stripUndefined({
@@ -120,6 +139,7 @@ export function fuzzSuiteResultEnvelope(input: {
     status,
     success: status === "passed",
     summary,
+    coverageSummary,
     cases,
     diagnostics,
     artifactRefs,
@@ -138,16 +158,52 @@ export function summarizeFuzzCases(cases: readonly Pick<FuzzSuiteCaseResult, "st
   return summary
 }
 
+export function summarizeFuzzCoverage(input: {
+  discovered: number
+  cases: readonly Pick<FuzzSuiteCaseResult, "id" | "status" | "skipReason" | "diagnostics">[]
+}): FuzzSuiteCoverageSummary {
+  const skippedReasons = new Map<string, { count: number; caseIds: string[] }>()
+  let executed = 0
+  let skipped = 0
+
+  for (const item of input.cases) {
+    if (item.status === "skipped") {
+      skipped += 1
+      const reason = item.skipReason ?? item.diagnostics[0]?.code ?? item.diagnostics[0]?.message ?? "unspecified"
+      const existing = skippedReasons.get(reason) ?? { count: 0, caseIds: [] }
+      existing.count += 1
+      existing.caseIds.push(item.id)
+      skippedReasons.set(reason, existing)
+    } else {
+      executed += 1
+    }
+  }
+
+  return {
+    discovered: input.discovered,
+    generated: input.cases.length,
+    executed,
+    skipped,
+    untested: Math.max(input.discovered - input.cases.length, 0),
+    skippedReasons: [...skippedReasons.entries()].map(([reason, value]) => ({ reason, count: value.count, caseIds: value.caseIds })),
+  }
+}
+
 function normalizeCaseResult(input: FuzzSuiteCaseResult): FuzzSuiteCaseResult {
   return stripUndefined({
     id: input.id,
     status: input.status,
     success: input.status === "passed",
     target: input.target,
+    skipReason: input.status === "skipped" ? input.skipReason ?? input.diagnostics?.[0]?.code ?? input.diagnostics?.[0]?.message : undefined,
     diagnostics: input.diagnostics ?? [],
     artifactRefs: input.artifactRefs,
     metadata: input.metadata,
   })
+}
+
+function fuzzSuiteDiscoveredCount(suite: { id: string; version?: string } | FuzzSuiteContract, fallback: number): number {
+  return "cases" in suite && Array.isArray(suite.cases) ? suite.cases.length : fallback
 }
 
 function dedupeArtifactRefs(refs: readonly FuzzSuiteArtifactRef[]): FuzzSuiteArtifactRef[] {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -83,6 +83,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         status: "skipped",
         success: false,
         target,
+        skipReason: fuzzSuiteSkipReason(planDiagnostics),
         diagnostics: planDiagnostics,
         metadata: stripUndefined({ replay: replayMetadata, adapter: plan.metadata }),
       })
@@ -103,6 +104,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         status: "skipped",
         success: false,
         target,
+        skipReason: diagnostic.code,
         diagnostics: [diagnostic],
         metadata: stripUndefined({ replay: replayMetadata }),
       })
@@ -514,6 +516,10 @@ function unsupportedInputAdapterResolution(fuzzCase: FuzzSuiteCase, target: Fuzz
     diagnostics: [{ severity: "error", code: "fuzz_suite_input_unsupported", caseId: fuzzCase.id, target, message: `Fuzz suite case ${fuzzCase.id} has unsupported ${target.kind} input. ${message}`, metadata }],
     metadata,
   }
+}
+
+function fuzzSuiteSkipReason(diagnostics: readonly FuzzSuiteDiagnostic[]): string | undefined {
+  return diagnostics[0]?.code ?? diagnostics[0]?.message
 }
 
 function normalizeFuzzSuiteCaseExecutionInput(input: unknown): { valid: true; value: FuzzSuiteCaseExecutionInput } | { valid: false } {

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -43,6 +43,14 @@ assert.equal(result.suite.id, "suite-001")
 assert.equal(result.status, "failed")
 assert.equal(result.success, false)
 assert.deepEqual(result.summary, { total: 11, passed: 9, failed: 1, error: 0, skipped: 1 })
+assert.deepEqual(result.coverageSummary, {
+  discovered: 11,
+  generated: 11,
+  executed: 10,
+  skipped: 1,
+  untested: 0,
+  skippedReasons: [{ reason: "fuzz_suite_target_adapter_unsupported", count: 1, caseIds: ["case-runtime-action-unsupported"] }],
+})
 assert.deepEqual(executed.map((spec) => spec.command), ["inspect-mounted-inputs", "wordpress.run-php", "wordpress.http-request", "wordpress.rest-request", "wordpress.ability", "wordpress.rest-request", "wordpress.browser-actions", "wordpress.admin-page-load", "wordpress.frontend-page-load", "wordpress.editor-open"])
 assert.deepEqual(executed[0], { command: "inspect-mounted-inputs", args: ["--json"], cwd: "/workspace", timeoutMs: 1000 })
 assert.deepEqual(executed[2], { command: "wordpress.http-request", args: ["url=/", "method=GET", "expect-status=200"], method: "GET", path: "/" })
@@ -58,6 +66,7 @@ assert.equal(result.cases[0]?.artifactRefs?.[0]?.path, "/artifacts/exec-1.json")
 assert.equal(result.cases[1]?.status, "failed")
 assert.equal(result.cases[1]?.diagnostics[0]?.code, "fuzz_suite_command_failed")
 assert.equal(result.cases[10]?.status, "skipped")
+assert.equal(result.cases[10]?.skipReason, "fuzz_suite_target_adapter_unsupported")
 assert.equal(result.cases[10]?.diagnostics[0]?.code, "fuzz_suite_target_adapter_unsupported")
 assert.equal(result.artifactRefs.length, 10)
 assert.equal((result.cases[0]?.metadata?.replay as Record<string, unknown> | undefined)?.caseId, "case-pass")
@@ -77,6 +86,7 @@ const noExecutor = await runFuzzSuite(fuzzSuiteContract({
   cases: [{ id: "case-skipped" }],
 }))
 assert.equal(noExecutor.status, "skipped")
+assert.deepEqual(noExecutor.coverageSummary?.skippedReasons, [{ reason: "fuzz_suite_executor_unavailable", count: 1, caseIds: ["case-skipped"] }])
 assert.equal(noExecutor.cases[0]?.diagnostics[0]?.code, "fuzz_suite_executor_unavailable")
 
 const restMatrix = wordpressRestMatrixContract({


### PR DESCRIPTION
## Summary
- Adds coverage summary fields to fuzz suite result envelopes.
- Tracks skipped case reasons for skipped fuzz cases.

## Verification
- `npm run test:fuzz-suite-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the fuzz infrastructure changes described above.