### PR TITLE
Expose fuzz suite PHP API facade

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-api.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-api.php
@@ -20,7 +20,6 @@ final class WP_Codebox_API {
 		'wp-codebox/run-runtime-task'                       => 'run_runtime_task',
 		'wp-codebox/run-wordpress-workload'                 => 'run_wordpress_workload',
 		'wp-codebox/run-runtime-package'                    => 'run_runtime_package',
-		'wp-codebox/run-wordpress-workload'                 => 'run_wordpress_workload',
 		'wp-codebox/run-fuzz-suite'                         => 'run_fuzz_suite',
 		'wp-codebox/create-browser-playground-session'      => 'create_browser_session',
 		'wp-codebox/create-sandbox-session'                 => 'create_browser_session',
@@ -96,11 +95,6 @@ final class WP_Codebox_API {
 	/** @param array<string,mixed> $input Runtime package input. @return array<string,mixed>|WP_Error */
 	public static function run_runtime_package( array $input ): array|WP_Error {
 		return WP_Codebox_Abilities::run_runtime_package( $input );
-	}
-
-	/** @param array<string,mixed> $input WordPress workload input. @return array<string,mixed>|WP_Error */
-	public static function run_wordpress_workload( array $input ): array|WP_Error {
-		return WP_Codebox_Abilities::run_wordpress_workload( $input );
 	}
 
 	/** @param array<string,mixed> $input Fuzz suite input. @return array<string,mixed>|WP_Error */

--- a/packages/wordpress-plugin/src/class-wp-codebox-api.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-api.php
@@ -20,6 +20,8 @@ final class WP_Codebox_API {
 		'wp-codebox/run-runtime-task'                       => 'run_runtime_task',
 		'wp-codebox/run-wordpress-workload'                 => 'run_wordpress_workload',
 		'wp-codebox/run-runtime-package'                    => 'run_runtime_package',
+		'wp-codebox/run-wordpress-workload'                 => 'run_wordpress_workload',
+		'wp-codebox/run-fuzz-suite'                         => 'run_fuzz_suite',
 		'wp-codebox/create-browser-playground-session'      => 'create_browser_session',
 		'wp-codebox/create-sandbox-session'                 => 'create_browser_session',
 		'wp-codebox/create-browser-task-contract'           => 'create_browser_task_contract',
@@ -94,6 +96,16 @@ final class WP_Codebox_API {
 	/** @param array<string,mixed> $input Runtime package input. @return array<string,mixed>|WP_Error */
 	public static function run_runtime_package( array $input ): array|WP_Error {
 		return WP_Codebox_Abilities::run_runtime_package( $input );
+	}
+
+	/** @param array<string,mixed> $input WordPress workload input. @return array<string,mixed>|WP_Error */
+	public static function run_wordpress_workload( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_wordpress_workload( $input );
+	}
+
+	/** @param array<string,mixed> $input Fuzz suite input. @return array<string,mixed>|WP_Error */
+	public static function run_fuzz_suite( array $input ): array|WP_Error {
+		return WP_Codebox_Abilities::run_fuzz_suite( $input );
 	}
 
 	/** @param array<string,mixed> $input Browser session input. @return array<string,mixed>|WP_Error */

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -53,11 +53,6 @@ final class WP_Codebox_Abilities {
 	}
 
 	/** @param array<string,mixed> $input @return array<string,mixed> */
-	public static function run_wordpress_workload( array $input ): array {
-		return self::record( 'run_wordpress_workload', 'wp-codebox/wordpress-workload-run-result/v1', $input );
-	}
-
-	/** @param array<string,mixed> $input @return array<string,mixed> */
 	public static function run_fuzz_suite( array $input ): array {
 		return self::record( 'run_fuzz_suite', 'wp-codebox/fuzz-suite-result/v1', $input );
 	}
@@ -129,7 +124,6 @@ $expected_methods = array(
 	'run_runtime_task',
 	'run_wordpress_workload',
 	'run_runtime_package',
-	'run_wordpress_workload',
 	'run_fuzz_suite',
 	'create_browser_session',
 	'create_browser_task_contract',
@@ -195,7 +189,6 @@ $public_abilities = array(
 	'wp-codebox/run-runtime-task' => array( 'method' => 'run_runtime_task', 'schema' => 'wp-codebox/runtime-task-result/v1' ),
 	'wp-codebox/run-wordpress-workload' => array( 'method' => 'run_wordpress_workload', 'schema' => 'wp-codebox/wordpress-workload-run-result/v1' ),
 	'wp-codebox/run-runtime-package' => array( 'method' => 'run_runtime_package', 'schema' => 'wp-codebox/runtime-package-result/v1' ),
-	'wp-codebox/run-wordpress-workload' => array( 'method' => 'run_wordpress_workload', 'schema' => 'wp-codebox/wordpress-workload-run-result/v1' ),
 	'wp-codebox/run-fuzz-suite' => array( 'method' => 'run_fuzz_suite', 'schema' => 'wp-codebox/fuzz-suite-result/v1' ),
 	'wp-codebox/create-browser-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),
 	'wp-codebox/create-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -53,6 +53,16 @@ final class WP_Codebox_Abilities {
 	}
 
 	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_wordpress_workload( array $input ): array {
+		return self::record( 'run_wordpress_workload', 'wp-codebox/wordpress-workload-run-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_fuzz_suite( array $input ): array {
+		return self::record( 'run_fuzz_suite', 'wp-codebox/fuzz-suite-result/v1', $input );
+	}
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
 	public static function create_browser_task_contract( array $input ): array {
 		return self::record( 'create_browser_task_contract', 'wp-codebox/browser-task-contract/v1', $input );
 	}
@@ -119,6 +129,8 @@ $expected_methods = array(
 	'run_runtime_task',
 	'run_wordpress_workload',
 	'run_runtime_package',
+	'run_wordpress_workload',
+	'run_fuzz_suite',
 	'create_browser_session',
 	'create_browser_task_contract',
 	'create_browser_materializer_contract',
@@ -183,6 +195,8 @@ $public_abilities = array(
 	'wp-codebox/run-runtime-task' => array( 'method' => 'run_runtime_task', 'schema' => 'wp-codebox/runtime-task-result/v1' ),
 	'wp-codebox/run-wordpress-workload' => array( 'method' => 'run_wordpress_workload', 'schema' => 'wp-codebox/wordpress-workload-run-result/v1' ),
 	'wp-codebox/run-runtime-package' => array( 'method' => 'run_runtime_package', 'schema' => 'wp-codebox/runtime-package-result/v1' ),
+	'wp-codebox/run-wordpress-workload' => array( 'method' => 'run_wordpress_workload', 'schema' => 'wp-codebox/wordpress-workload-run-result/v1' ),
+	'wp-codebox/run-fuzz-suite' => array( 'method' => 'run_fuzz_suite', 'schema' => 'wp-codebox/fuzz-suite-result/v1' ),
 	'wp-codebox/create-browser-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),
 	'wp-codebox/create-task-contract' => array( 'method' => 'create_browser_task_contract', 'schema' => 'wp-codebox/browser-task-contract/v1' ),
 	'wp-codebox/create-browser-materializer-contract' => array( 'method' => 'create_browser_materializer_contract', 'schema' => 'wp-codebox/browser-materializer-contract/v1' ),


### PR DESCRIPTION
## Summary
- Exposes the public `wp-codebox/run-fuzz-suite` facade through `WP_Codebox_API`.
- Extends the PHP public facade smoke coverage for the new fuzz-suite ability.

## Verification
- `npm run test:php-public-api-facade`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the fuzz infrastructure changes described above.