### PR TITLE
Run fuzz cases through runtime actions

### DIFF
--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -1,5 +1,6 @@
 import { stripUndefined } from "./object-utils.js"
 import { fuzzSuiteResultEnvelope, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
+import type { RuntimeAction, RuntimeActionObservation } from "./runtime-action-adapter.js"
 import type { ExecutionResult, ExecutionSpec, RuntimeCommandDiagnosticsCaptureSpec, RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
 
 export interface FuzzSuiteCommandExecutor {
@@ -8,9 +9,22 @@ export interface FuzzSuiteCommandExecutor {
 
 export interface FuzzSuiteRunOptions {
   executor?: FuzzSuiteCommandExecutor | ((spec: ExecutionSpec) => Promise<ExecutionResult>)
+  runtimeActionExecutor?: FuzzSuiteRuntimeActionExecutor | ((input: FuzzSuiteRuntimeActionExecutionInput) => Promise<RuntimeActionObservation>)
   targetAdapters?: FuzzSuiteTargetAdapterRegistry | readonly FuzzSuiteTargetAdapter[]
   supportedTargetKinds?: readonly string[]
   metadata?: Record<string, unknown>
+}
+
+export interface FuzzSuiteRuntimeActionExecutionInput {
+  suite: FuzzSuiteContract
+  case: FuzzSuiteCase
+  caseIndex: number
+  target: FuzzSuiteTargetRef
+  action: RuntimeAction
+}
+
+export interface FuzzSuiteRuntimeActionExecutor {
+  executeRuntimeAction(input: FuzzSuiteRuntimeActionExecutionInput): Promise<RuntimeActionObservation>
 }
 
 export type FuzzSuiteTargetAdapterStatus = "supported" | "unsupported"
@@ -68,6 +82,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
   const cases: FuzzSuiteCaseResult[] = []
   const diagnostics: FuzzSuiteDiagnostic[] = []
   const execute = normalizeFuzzSuiteExecutor(options.executor)
+  const executeRuntimeAction = normalizeFuzzSuiteRuntimeActionExecutor(options.runtimeActionExecutor)
   const adapterRegistry = normalizeFuzzSuiteTargetAdapterRegistry(options.targetAdapters)
   const supportedTargetKinds = new Set(options.supportedTargetKinds ?? DEFAULT_SUPPORTED_TARGET_KINDS)
 
@@ -87,6 +102,69 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         diagnostics: planDiagnostics,
         metadata: stripUndefined({ replay: replayMetadata, adapter: plan.metadata }),
       })
+      continue
+    }
+
+    const runtimeAction = target.kind === "runtime-action" && executeRuntimeAction ? fuzzSuiteRuntimeActionInput(fuzzCase.input) : undefined
+    if (runtimeAction?.status === "invalid") {
+      const diagnostic = unsupportedInputAdapterResolution(fuzzCase, target, runtimeAction.message, { adapterKind: "runtime-action" }).diagnostics?.[0]
+      if (diagnostic) {
+        diagnostics.push(diagnostic)
+        cases.push({
+          id: fuzzCase.id,
+          status: "skipped",
+          success: false,
+          target,
+          skipReason: diagnostic.code,
+          diagnostics: [diagnostic],
+          metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-action" } }),
+        })
+        continue
+      }
+    }
+
+    if (runtimeAction?.status === "valid" && executeRuntimeAction) {
+      try {
+        const observation = await executeRuntimeAction({ suite, case: fuzzCase, caseIndex: index, target, action: runtimeAction.action })
+        cases.push({
+          id: fuzzCase.id,
+          status: "passed",
+          success: true,
+          target,
+          diagnostics: [],
+          artifactRefs: fuzzSuiteRuntimeActionArtifactRefs(observation),
+          metadata: stripUndefined({
+            input: fuzzCase.input,
+            description: fuzzCase.description,
+            caseMetadata: fuzzCase.metadata,
+            adapter: { adapterKind: "runtime-action", actionType: runtimeAction.action.type, executorKind: "episode" },
+            replay: { ...replayMetadata, runtimeAction: runtimeAction.action },
+            observation: {
+              type: observation.type,
+              status: observation.status,
+              observedAt: observation.observedAt,
+              digest: observation.digest,
+            },
+          }),
+        })
+      } catch (error) {
+        const diagnostic: FuzzSuiteDiagnostic = {
+          severity: "error",
+          code: "fuzz_suite_runtime_action_execution_error",
+          caseId: fuzzCase.id,
+          target,
+          message: error instanceof Error ? error.message : String(error),
+        }
+        diagnostics.push(diagnostic)
+        cases.push({
+          id: fuzzCase.id,
+          status: "error",
+          success: false,
+          target,
+          diagnostics: [diagnostic],
+          metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-action", actionType: runtimeAction.action.type, executorKind: "episode" } }),
+        })
+      }
       continue
     }
 
@@ -201,6 +279,16 @@ function normalizeFuzzSuiteExecutor(executor: FuzzSuiteRunOptions["executor"]): 
     return executor
   }
   return (spec) => executor.execute(spec)
+}
+
+function normalizeFuzzSuiteRuntimeActionExecutor(executor: FuzzSuiteRunOptions["runtimeActionExecutor"]): ((input: FuzzSuiteRuntimeActionExecutionInput) => Promise<RuntimeActionObservation>) | undefined {
+  if (!executor) {
+    return undefined
+  }
+  if (typeof executor === "function") {
+    return executor
+  }
+  return (input) => executor.executeRuntimeAction(input)
 }
 
 export function createFuzzSuiteTargetAdapterRegistry(adapters: readonly FuzzSuiteTargetAdapter[] = defaultFuzzSuiteTargetAdapters()): FuzzSuiteTargetAdapterRegistry {
@@ -574,6 +662,14 @@ function fuzzSuiteCaseRecordInput(input: unknown): { invalid?: false; payload: u
   }
 }
 
+function fuzzSuiteRuntimeActionInput(input: unknown): { status: "valid"; action: RuntimeAction } | { status: "invalid"; message: string } {
+  const normalized = fuzzSuiteCaseRecordInput(input)
+  if (normalized.invalid || !isRecord(normalized.payload) || typeof normalized.payload.type !== "string") {
+    return { status: "invalid", message: "Expected runtime-action input object with a type field." }
+  }
+  return { status: "valid", action: normalized.payload as unknown as RuntimeAction }
+}
+
 function isRecord(input: unknown): input is Record<string, unknown> {
   return Boolean(input) && typeof input === "object" && !Array.isArray(input)
 }
@@ -657,6 +753,11 @@ function jsonArg(name: string, value: unknown): string | undefined {
 
 function fuzzSuiteExecutionArtifactRefs(execution: ExecutionResult): FuzzSuiteArtifactRef[] | undefined {
   const refs = [...(execution.artifactRefs ?? []), ...(execution.result?.artifactRefs ?? [])].map(fuzzSuiteArtifactRefFromTrace).filter((ref): ref is FuzzSuiteArtifactRef => Boolean(ref))
+  return refs.length > 0 ? refs : undefined
+}
+
+function fuzzSuiteRuntimeActionArtifactRefs(observation: RuntimeActionObservation): FuzzSuiteArtifactRef[] | undefined {
+  const refs = (observation.artifactRefs ?? []).map(fuzzSuiteArtifactRefFromTrace).filter((ref): ref is FuzzSuiteArtifactRef => Boolean(ref))
   return refs.length > 0 ? refs : undefined
 }
 

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -105,9 +105,9 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
       continue
     }
 
-    const runtimeAction = target.kind === "runtime-action" && executeRuntimeAction ? fuzzSuiteRuntimeActionInput(fuzzCase.input) : undefined
+    const runtimeAction = target?.kind === "runtime-action" && executeRuntimeAction ? fuzzSuiteRuntimeActionInput(fuzzCase.input) : undefined
     if (runtimeAction?.status === "invalid") {
-      const diagnostic = unsupportedInputAdapterResolution(fuzzCase, target, runtimeAction.message, { adapterKind: "runtime-action" }).diagnostics?.[0]
+      const diagnostic = target ? unsupportedInputAdapterResolution(fuzzCase, target, runtimeAction.message, { adapterKind: "runtime-action" }).diagnostics?.[0] : undefined
       if (diagnostic) {
         diagnostics.push(diagnostic)
         cases.push({
@@ -123,7 +123,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
       }
     }
 
-    if (runtimeAction?.status === "valid" && executeRuntimeAction) {
+    if (runtimeAction?.status === "valid" && executeRuntimeAction && target) {
       try {
         const observation = await executeRuntimeAction({ suite, case: fuzzCase, caseIndex: index, target, action: runtimeAction.action })
         cases.push({

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -1,8 +1,17 @@
 import {
   createRuntime,
   createRuntimeEpisode,
+  openWordPressAdminPage,
+  openWordPressEditor,
+  probeWordPressBrowser,
+  requestWordPressRest,
+  runWordPressBrowserAction,
+  runWordPressPhp,
+  runWordPressWpCli,
+  visitWordPressPage,
   type ArtifactBundle,
   type ArtifactSpec,
+  type FuzzSuiteRuntimeActionExecutor,
   type ObservationSpec,
   type Runtime,
   type RuntimeCreateSpec,
@@ -34,6 +43,9 @@ export {
   setupWordPressPlugin,
   setupWordPressTheme,
   visitWordPressPage,
+}
+export {
+  collectWordPressArtifacts,
   type RuntimeActionObservation,
   type WordPressAdminPageOptions,
   type WordPressBrowserActionOptions,
@@ -109,6 +121,38 @@ export async function runWordPressEpisodeActions(
   }
 
   return results
+}
+
+export function createWordPressFuzzSuiteRuntimeActionExecutor(episode: Pick<RuntimeEpisode, "step">): FuzzSuiteRuntimeActionExecutor {
+  return {
+    async executeRuntimeAction({ action }) {
+      if (action.type === "wp_cli") {
+        return runWordPressWpCli(episode, action)
+      }
+      if (action.type === "php") {
+        return runWordPressPhp(episode, action)
+      }
+      if (action.type === "rest_request") {
+        return requestWordPressRest(episode, action)
+      }
+      if (action.type === "browser") {
+        return runWordPressBrowserAction(episode, action)
+      }
+      if (action.type === "browser_probe") {
+        return probeWordPressBrowser(episode, action)
+      }
+      if (action.type === "editor_open") {
+        return openWordPressEditor(episode, action)
+      }
+      if (action.type === "admin_page") {
+        return openWordPressAdminPage(episode, action)
+      }
+      if (action.type === "page") {
+        return visitWordPressPage(episode, action)
+      }
+      throw new Error(`Unsupported WordPress fuzz runtime-action type: ${action.type}`)
+    },
+  }
 }
 
 export async function collectWordPressRuntimeArtifacts(runtime: Pick<Runtime, "collectArtifacts">, spec?: ArtifactSpec): Promise<ArtifactBundle> {

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -43,9 +43,6 @@ export {
   setupWordPressPlugin,
   setupWordPressTheme,
   visitWordPressPage,
-}
-export {
-  collectWordPressArtifacts,
   type RuntimeActionObservation,
   type WordPressAdminPageOptions,
   type WordPressBrowserActionOptions,

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -89,6 +89,35 @@ assert.equal(noExecutor.status, "skipped")
 assert.deepEqual(noExecutor.coverageSummary?.skippedReasons, [{ reason: "fuzz_suite_executor_unavailable", count: 1, caseIds: ["case-skipped"] }])
 assert.equal(noExecutor.cases[0]?.diagnostics[0]?.code, "fuzz_suite_executor_unavailable")
 
+const runtimeActions: string[] = []
+const runtimeActionResult = await runFuzzSuite(fuzzSuiteContract({
+  id: "suite-episode-actions",
+  target: { kind: "runtime-action" },
+  cases: [
+    { id: "browser-capture", input: { type: "browser", operation: "capture", capture: ["html"] } },
+    { id: "admin-page", input: { type: "admin_page", path: "plugins.php", capture: ["html"] } },
+  ],
+}), {
+  runtimeActionExecutor: async ({ action }) => {
+    runtimeActions.push(action.type)
+    return {
+      schema: "wp-codebox/runtime-action-observation/v1",
+      type: action.type,
+      status: "ok",
+      action,
+      data: { actionType: action.type },
+      observedAt: "2026-01-01T00:00:00.000Z",
+      artifactRefs: [{ kind: "runtime-action", id: `${action.type}-artifact`, path: `files/${action.type}.json`, digest: { algorithm: "sha256", value: `sha-${action.type}` } }],
+      digest: { algorithm: "sha256", value: `digest-${action.type}` },
+    }
+  },
+})
+assert.equal(runtimeActionResult.status, "passed")
+assert.deepEqual(runtimeActionResult.summary, { total: 2, passed: 2, failed: 0, error: 0, skipped: 0 })
+assert.deepEqual(runtimeActions, ["browser", "admin_page"])
+assert.equal(runtimeActionResult.cases[0]?.artifactRefs?.[0]?.path, "files/browser.json")
+assert.equal((runtimeActionResult.cases[0]?.metadata?.adapter as Record<string, unknown> | undefined)?.executorKind, "episode")
+
 const restMatrix = wordpressRestMatrixContract({
   id: "rest-matrix-001",
   cases: [{ id: "get-posts", method: "GET", path: "/wp/v2/posts", params: { per_page: 1 }, headers: { accept: "application/json" }, session: "admin" }],

--- a/tests/wordpress-runtime-actions.test.ts
+++ b/tests/wordpress-runtime-actions.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict"
+import { fuzzSuiteContract, runFuzzSuite } from "../packages/runtime-core/src/index.js"
 import {
   collectWordPressArtifacts,
+  createWordPressFuzzSuiteRuntimeActionExecutor,
   discoverWordPressRuntime,
   executeFuzzSuite,
   executeWordPressRestMatrix,
@@ -153,5 +155,27 @@ assert.equal(restMatrixResult.success, true)
 
 const artifactBundle = { id: "bundle", directory: "artifacts/runtime", contentDigest: "digest", createdAt: "2026-01-01T00:00:00.000Z" }
 assert.equal(await collectWordPressArtifacts({ async collectArtifacts() { return artifactBundle } }), artifactBundle)
+
+const beforeFuzzCalls = calls.length
+const fuzzResult = await runFuzzSuite(fuzzSuiteContract({
+  id: "wordpress-episode-runtime-actions",
+  target: { kind: "runtime-action" },
+  cases: [
+    { id: "browser", input: { type: "browser", operation: "capture", capture: ["html"] } },
+    { id: "editor", input: { type: "editor_open", target: "post-new", post_type: "page" } },
+    { id: "admin", input: { type: "admin_page", path: "plugins.php" } },
+    { id: "page", input: { type: "page", path: "/sample-page/" } },
+  ],
+}), {
+  runtimeActionExecutor: createWordPressFuzzSuiteRuntimeActionExecutor(fakeEpisode),
+})
+assert.equal(fuzzResult.status, "passed")
+assert.deepEqual(fuzzResult.summary, { total: 4, passed: 4, failed: 0, error: 0, skipped: 0 })
+assert.deepEqual(calls.slice(beforeFuzzCalls).map((call) => call.command), [
+  "wordpress.browser-actions",
+  "wordpress.editor-open",
+  "wordpress.browser-probe",
+  "wordpress.browser-probe",
+])
 
 console.log("wordpress runtime actions ok")

--- a/tests/wordpress-runtime-actions.test.ts
+++ b/tests/wordpress-runtime-actions.test.ts
@@ -157,7 +157,7 @@ const artifactBundle = { id: "bundle", directory: "artifacts/runtime", contentDi
 assert.equal(await collectWordPressArtifacts({ async collectArtifacts() { return artifactBundle } }), artifactBundle)
 
 const beforeFuzzCalls = calls.length
-const fuzzResult = await runFuzzSuite(fuzzSuiteContract({
+const runtimeActionFuzzResult = await runFuzzSuite(fuzzSuiteContract({
   id: "wordpress-episode-runtime-actions",
   target: { kind: "runtime-action" },
   cases: [
@@ -169,8 +169,8 @@ const fuzzResult = await runFuzzSuite(fuzzSuiteContract({
 }), {
   runtimeActionExecutor: createWordPressFuzzSuiteRuntimeActionExecutor(fakeEpisode),
 })
-assert.equal(fuzzResult.status, "passed")
-assert.deepEqual(fuzzResult.summary, { total: 4, passed: 4, failed: 0, error: 0, skipped: 0 })
+assert.equal(runtimeActionFuzzResult.status, "passed")
+assert.deepEqual(runtimeActionFuzzResult.summary, { total: 4, passed: 4, failed: 0, error: 0, skipped: 0 })
 assert.deepEqual(calls.slice(beforeFuzzCalls).map((call) => call.command), [
   "wordpress.browser-actions",
   "wordpress.editor-open",


### PR DESCRIPTION
## Summary
- Adds a runtime-action executor path for fuzz suite cases.
- Exposes a WordPress episode-backed runtime-action fuzz executor from the playground public facade.

## Base
- Stacked on `fix/fuzz-coverage-summary-envelope` because both PRs touch fuzz suite runner contracts/tests.

## Verification
- `npm run build && npm run test:fuzz-suite-runner && npm run test:wordpress-runtime-actions`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the fuzz infrastructure changes described above.