### PR TITLE
Expand WordPress CRUD coverage

### DIFF
--- a/docs/wordpress-crud-db-contracts.md
+++ b/docs/wordpress-crud-db-contracts.md
@@ -10,6 +10,8 @@ Supported resource kinds in the Playground backend:
 
 - `post` through `get_post`, `get_posts`, `wp_insert_post`, `wp_update_post`, and `wp_delete_post`.
 - `term` through `get_term`, `get_terms`, `wp_insert_term`, `wp_update_term`, and `wp_delete_term`.
+- `comment` through `get_comment`, `get_comments`, `wp_insert_comment`, `wp_update_comment`, and `wp_delete_comment`.
+- `attachment` or `media` through attachment posts using `get_post`, `get_posts`, `wp_insert_attachment`, `wp_update_post`, and `wp_delete_attachment`.
 - `user` through `get_user_by`, `get_users`, `wp_insert_user`, `wp_update_user`, and `wp_delete_user`.
 - `option` through `get_option`, bounded option reads, `add_option`, `update_option`, and `delete_option`.
 - `metadata` or `meta` through `get_metadata`, `add_metadata`, `update_metadata`, and `delete_metadata`.

--- a/packages/runtime-playground/src/wordpress-crud-command-handlers.ts
+++ b/packages/runtime-playground/src/wordpress-crud-command-handlers.ts
@@ -133,6 +133,45 @@ function wp_codebox_emit_crud_result( $operation ) {
             return;
         }
 
+        if ( $kind === 'comment' ) {
+            if ( $verb === 'read' ) {
+                $comment = get_comment( (int) $id, ARRAY_A );
+                wp_codebox_crud_emit_result( $comment ? wp_codebox_crud_result( $operation, 'ok', array( 'item' => $comment ) ) : wp_codebox_crud_error( $operation, 'not-found', 'Comment not found.' ) );
+                return;
+            }
+            if ( $verb === 'list' ) {
+                $comments = get_comments( array_merge( $query, array( 'number' => wp_codebox_crud_limit( $operation ) ) ) );
+                wp_codebox_crud_emit_result( wp_codebox_crud_result( $operation, 'ok', array( 'items' => array_map( static function ( $comment ) { return $comment->to_array(); }, $comments ) ) ) );
+                return;
+            }
+            $comment_data = array_merge( $data, $id ? array( 'comment_ID' => (int) $id ) : array() );
+            $result_id = $verb === 'create' ? wp_insert_comment( $comment_data ) : ( $verb === 'update' ? wp_update_comment( $comment_data ) : wp_delete_comment( (int) $id, ! empty( $query['force'] ) ) );
+            if ( ! $result_id ) throw new RuntimeException( 'Comment operation failed.' );
+            $comment_id = $verb === 'create' ? (int) $result_id : (int) $id;
+            wp_codebox_crud_emit_result( wp_codebox_crud_result( $operation, 'ok', array( 'item' => $verb === 'delete' ? array( 'deleted' => (bool) $result_id ) : get_comment( $comment_id, ARRAY_A ), 'effects' => array( array( 'kind' => $verb, 'resource' => $resource ) ) ) ) );
+            return;
+        }
+
+        if ( $kind === 'attachment' || $kind === 'media' ) {
+            if ( $verb === 'read' ) {
+                $attachment = get_post( (int) $id, ARRAY_A );
+                wp_codebox_crud_emit_result( $attachment && $attachment['post_type'] === 'attachment' ? wp_codebox_crud_result( $operation, 'ok', array( 'item' => $attachment ) ) : wp_codebox_crud_error( $operation, 'not-found', 'Attachment not found.' ) );
+                return;
+            }
+            if ( $verb === 'list' ) {
+                $attachments = get_posts( array( 'post_type' => 'attachment', 'post_status' => isset( $query['status'] ) ? $query['status'] : 'any', 'numberposts' => wp_codebox_crud_limit( $operation ), 'suppress_filters' => false ) );
+                wp_codebox_crud_emit_result( wp_codebox_crud_result( $operation, 'ok', array( 'items' => array_map( static function ( $attachment ) { return $attachment->to_array(); }, $attachments ) ) ) );
+                return;
+            }
+            $attachment_data = array_merge( $data, array( 'post_type' => 'attachment' ), $id ? array( 'ID' => (int) $id ) : array() );
+            $file = isset( $data['file'] ) ? (string) $data['file'] : false;
+            $parent_post_id = isset( $data['post_parent'] ) ? (int) $data['post_parent'] : 0;
+            $result_id = $verb === 'create' ? wp_insert_attachment( $attachment_data, $file, $parent_post_id, true ) : ( $verb === 'update' ? wp_update_post( $attachment_data, true ) : wp_delete_attachment( (int) $id, ! empty( $query['force'] ) ) );
+            if ( is_wp_error( $result_id ) ) throw new RuntimeException( $result_id->get_error_message() );
+            wp_codebox_crud_emit_result( wp_codebox_crud_result( $operation, 'ok', array( 'item' => $verb === 'delete' ? array( 'deleted' => (bool) $result_id ) : get_post( (int) $result_id, ARRAY_A ), 'effects' => array( array( 'kind' => $verb, 'resource' => $resource ) ) ) ) );
+            return;
+        }
+
         if ( $kind === 'user' ) {
             if ( $verb === 'read' ) {
                 $user = get_user_by( 'id', (int) $id );

--- a/tests/wordpress-crud-contracts.test.ts
+++ b/tests/wordpress-crud-contracts.test.ts
@@ -63,6 +63,8 @@ const guardedCreate = normalizeWordPressCrudOperation({
 const crudPhp = wordpressCrudOperationPhpCode(guardedCreate)
 assert.match(crudPhp, /wp_insert_post/)
 assert.match(crudPhp, /wp_insert_term/)
+assert.match(crudPhp, /wp_insert_comment/)
+assert.match(crudPhp, /wp_insert_attachment/)
 assert.match(crudPhp, /wp_insert_user/)
 assert.match(crudPhp, /add_option/)
 assert.match(crudPhp, /add_metadata/)


### PR DESCRIPTION
## Summary
- Extends WordPress CRUD command handling for comments and attachments/media.
- Updates CRUD contract docs and normalization coverage.

## Verification
- `./node_modules/.bin/tsx tests/wordpress-crud-contracts.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the fuzz infrastructure changes described above.