### PR TITLE
Add safe database inspection

### DIFF
--- a/docs/wordpress-crud-db-contracts.md
+++ b/docs/wordpress-crud-db-contracts.md
@@ -30,6 +30,7 @@ Foundational supported operations:
 
 - `schema` lists discovered prefixed WordPress tables using `SHOW TABLES`, classifies tables as `core`, `prefixed`, or `external` where observable, and includes bounded column, index, and table-status metadata when available.
 - `read` performs bounded reads against discovered prefixed WordPress table names or base names, allowlists selected and filtered columns against `DESCRIBE`, supports scalar equality filters, and caps results at 100 rows.
+- `inspect` returns read-only inventory metadata for discovered prefixed WordPress table names or base names, including row counts and index metadata from `SHOW INDEX`.
 - `query-summary` summarizes the current `$wpdb` query count or runs bounded read-only `SELECT`, `SHOW`, `DESCRIBE`, or `EXPLAIN` SQL.
 
 DB write guardrails:

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "test:production-boundary-enforcement": "tsx tests/production-boundary-enforcement.test.ts",
     "test:public-api-contract": "tsx tests/public-api-contract.test.ts",
     "test:wordpress-runtime-actions": "tsx tests/wordpress-runtime-actions.test.ts",
+    "test:wordpress-db-contracts": "tsx tests/wordpress-db-contracts.test.ts",
     "test:browser-sdk-facade": "tsx tests/browser-sdk-facade.test.ts",
     "check": "npm run test:production-boundary-enforcement && npm run smoke -- --group=check"
   },

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -533,9 +533,9 @@ export const commandRegistry = [
   },
   {
     id: "wordpress.db-operation",
-    description: "Execute a bounded generic WordPress database operation envelope for schema inspection, safe reads, and query summaries across discovered prefixed WordPress tables. Generic writes are explicitly rejected by the foundational contract.",
+    description: "Execute a bounded generic WordPress database operation envelope for schema/table inspection, safe reads, and query summaries across discovered prefixed WordPress tables. Generic writes are explicitly rejected by the foundational contract.",
     acceptedArgs: [
-      { name: "operation-json", description: "Inline wp-codebox/wordpress-db-operation/v1 operation envelope. Supports schema, read, query-summary, and guarded write operations. Reads require a discovered prefixed table and described table columns.", required: true, format: "JSON object" },
+      { name: "operation-json", description: "Inline wp-codebox/wordpress-db-operation/v1 operation envelope. Supports schema, read, inspect, query-summary, and guarded write operations. Reads and inspections require a discovered prefixed table and described table columns.", required: true, format: "JSON object" },
     ],
     outputShape: "wp-codebox/wordpress-db-result/v1 JSON with command, status, normalized operation, optional item/items, diagnostics, errors, artifactRefs, and metadata. Schema results classify tables as core, prefixed, or external where observable and may include bounded columns, indexes, and status metadata. Generic DB writes return status=error with db-write-unsupported.",
     outputSchema: {

--- a/packages/runtime-core/src/wordpress-db-contracts.ts
+++ b/packages/runtime-core/src/wordpress-db-contracts.ts
@@ -3,7 +3,7 @@ import type { BackendNeutralArtifactRef } from "./runtime-neutral-contracts.js"
 export const WORDPRESS_DB_OPERATION_SCHEMA = "wp-codebox/wordpress-db-operation/v1" as const
 export const WORDPRESS_DB_RESULT_SCHEMA = "wp-codebox/wordpress-db-result/v1" as const
 
-export type WordPressDbVerb = "schema" | "read" | "query-summary" | "write"
+export type WordPressDbVerb = "schema" | "read" | "inspect" | "query-summary" | "write"
 export type WordPressDbResultStatus = "ok" | "unsupported" | "error"
 
 export interface WordPressDbResourceRef {
@@ -56,7 +56,7 @@ export const WORDPRESS_DB_OPERATION_JSON_SCHEMA = {
   required: ["schema", "operation"],
   properties: {
     schema: { const: WORDPRESS_DB_OPERATION_SCHEMA },
-    operation: { enum: ["schema", "read", "query-summary", "write"] },
+    operation: { enum: ["schema", "read", "inspect", "query-summary", "write"] },
     resource: {
       type: "object",
       additionalProperties: false,
@@ -107,7 +107,7 @@ export function normalizeWordPressDbOperation(input: unknown): WordPressDbOperat
   const value = requireObject(input, "wordpress.db-operation") as Partial<WordPressDbOperation>
   const operation = requiredString(value.operation, "wordpress.db-operation.operation")
   if (!isWordPressDbVerb(operation)) {
-    throw new Error("wordpress.db-operation.operation must be schema, read, query-summary, or write.")
+    throw new Error("wordpress.db-operation.operation must be schema, read, inspect, query-summary, or write.")
   }
 
   return stripUndefined({
@@ -189,7 +189,7 @@ function normalizeOptionalLimit(input: unknown): number | undefined {
 }
 
 function isWordPressDbVerb(value: string): value is WordPressDbVerb {
-  return value === "schema" || value === "read" || value === "query-summary" || value === "write"
+  return value === "schema" || value === "read" || value === "inspect" || value === "query-summary" || value === "write"
 }
 
 function normalizeOptionalObject(value: unknown, label: string): Record<string, unknown> | undefined {

--- a/packages/runtime-core/src/wordpress-runtime-actions.ts
+++ b/packages/runtime-core/src/wordpress-runtime-actions.ts
@@ -39,7 +39,7 @@ export type WordPressCrudOperationOptions = Omit<WordPressCrudOperation, "schema
   schema?: typeof WORDPRESS_CRUD_OPERATION_SCHEMA
 }
 
-export type WordPressDatabaseReadOperation = Extract<WordPressDbVerb, "schema" | "read" | "query-summary">
+export type WordPressDatabaseReadOperation = Extract<WordPressDbVerb, "schema" | "read" | "inspect" | "query-summary">
 
 export type WordPressDatabaseReadOptions = Omit<WordPressDbOperation, "schema" | "operation"> & {
   schema?: typeof WORDPRESS_DB_OPERATION_SCHEMA

--- a/packages/runtime-playground/src/wordpress-crud-command-handlers.ts
+++ b/packages/runtime-playground/src/wordpress-crud-command-handlers.ts
@@ -344,6 +344,38 @@ function wp_codebox_emit_db_result( $operation ) {
             return;
         }
 
+        if ( $verb === 'inspect' ) {
+            $requested = wp_codebox_db_resolve_table( $operation );
+            if ( isset( $operation['resource']['table'] ) && ! $requested ) {
+                wp_codebox_db_emit_result( wp_codebox_db_error( $operation, 'unsafe-table', 'DB inspection requires a discovered prefixed WordPress table name or base name.' ) );
+                return;
+            }
+
+            $table_infos = array();
+            if ( $requested ) {
+                $table_infos[] = $requested;
+            } else {
+                $table_infos = array_values( array_filter( wp_codebox_db_discovered_tables(), static function ( $table, $key ) { return $table['name'] === $key; }, ARRAY_FILTER_USE_BOTH ) );
+            }
+
+            $tables = array();
+            foreach ( $table_infos as $table ) {
+                $quoted = wp_codebox_db_quote_identifier( $table['name'] );
+                $row_count = $wpdb->get_var( 'SELECT COUNT(*) FROM ' . $quoted );
+                $indexes = $wpdb->get_results( 'SHOW INDEX FROM ' . $quoted, ARRAY_A );
+                $tables[] = array(
+                    'name' => $table['name'],
+                    'baseName' => $table['baseName'],
+                    'classification' => $table['classification'],
+                    'rowCount' => $row_count === null ? null : (int) $row_count,
+                    'indexes' => is_array( $indexes ) ? $indexes : array(),
+                );
+            }
+
+            wp_codebox_db_emit_result( wp_codebox_db_result( $operation, 'ok', array( 'items' => $tables, 'metadata' => array( 'tableCount' => count( $tables ), 'attribution' => array( 'command' => 'wordpress.db-operation', 'operation' => 'inspect' ) ) ) ) );
+            return;
+        }
+
         if ( $verb === 'query-summary' ) {
             $sql = isset( $query['sql'] ) ? trim( (string) $query['sql'] ) : '';
             if ( $sql === '' ) {

--- a/tests/wordpress-db-contracts.test.ts
+++ b/tests/wordpress-db-contracts.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict"
+import { normalizeWordPressDbOperation } from "../packages/runtime-core/src/wordpress-db-contracts.js"
+import { wordpressDbOperationPhpCode } from "../packages/runtime-playground/src/wordpress-crud-command-handlers.js"
+
+const inspectOperation = normalizeWordPressDbOperation({
+  schema: "wp-codebox/wordpress-db-operation/v1",
+  operation: "inspect",
+  resource: { table: "posts" },
+})
+
+assert.equal(inspectOperation.operation, "inspect")
+assert.equal(inspectOperation.resource?.table, "posts")
+
+assert.throws(() => normalizeWordPressDbOperation({
+  schema: "wp-codebox/wordpress-db-operation/v1",
+  operation: "drop",
+}), /must be schema, read, inspect, query-summary, or write/)
+
+const php = wordpressDbOperationPhpCode(inspectOperation)
+
+assert.match(php, /\$verb === 'inspect'/)
+assert.match(php, /wp_codebox_db_discovered_tables/)
+assert.match(php, /wp_codebox_db_resolve_table/)
+assert.match(php, /SELECT COUNT\(\*\) FROM/)
+assert.match(php, /SHOW INDEX FROM/)
+assert.match(php, /unsafe-table/)
+assert.match(php, /db-write-unsupported/)
+
+console.log("wordpress db contracts ok")


### PR DESCRIPTION
## Summary
- Adds a read-only `inspect` DB operation for discovered prefixed WordPress tables.
- Includes row counts, index metadata, command registry docs, and focused tests.

## Base
- Stacked on `expand-crud-contracts` because both PRs update the CRUD/DB docs and command handler.

## Verification
- `npm run test:wordpress-db-contracts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the fuzz infrastructure changes described above.