### PR TITLE
Improve admin discovery fuzz targets

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -148,6 +148,12 @@ The stable public surface is grouped by lifecycle area rather than by product:
   in-process WordPress load path; browser-heavy probes remain available through
   browser commands and `openWordPressAdminPage()` when a caller explicitly needs
   DOM, screenshot, console, or network evidence.
+- **WordPress admin discovery:** `wordpress.runtime-discovery` and
+  `wordpress.admin-page-inventory` expose admin pages with canonical admin URLs,
+  declared capabilities, current-user access checks, and current-user role context
+  for authenticated runtime fuzzing. When the request context has not populated
+  WordPress admin menu globals yet, discovery performs the standard admin menu
+  bootstrap before reporting an unsupported empty menu.
 - **Fuzz suite:** `wp-codebox/fuzz-suite/v1` describes a generic suite of
   boundary cases against a Codebox-owned target such as an ability, command, HTTP
   endpoint, REST route, or runtime action. Canonical target kinds are `ability`,

--- a/packages/runtime-core/src/wordpress-runtime-discovery-contracts.ts
+++ b/packages/runtime-core/src/wordpress-runtime-discovery-contracts.ts
@@ -87,6 +87,7 @@ export interface WordPressAdminPageDiscovery {
   schema: "wp-codebox/wordpress-admin-page-discovery/v1"
   adminUrl: string
   menuLoaded: boolean
+  user?: WordPressAdminDiscoveryUserContext
   pages: WordPressAdminPageDescriptor[]
 }
 
@@ -96,8 +97,15 @@ export interface WordPressAdminPageInventory {
   status: "ok" | "unsupported"
   adminUrl: string
   menuLoaded: boolean
+  user?: WordPressAdminDiscoveryUserContext
   pages: WordPressAdminPageDescriptor[]
   diagnostics: WordPressRuntimeDiscoveryDiagnostic[]
+}
+
+export interface WordPressAdminDiscoveryUserContext {
+  isLoggedIn: boolean
+  id: number
+  roles: string[]
 }
 
 export interface WordPressAdminPageDescriptor {
@@ -105,6 +113,8 @@ export interface WordPressAdminPageDescriptor {
   pageTitle: string
   menuTitle: string
   capability: string
+  canAccess?: boolean | null
+  canonicalUrl?: string
   parentSlug?: string
 }
 

--- a/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
+++ b/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
@@ -166,27 +166,73 @@ function runtime_discovery_rest_schema(array $handlers): array {
 function runtime_discovery_admin(): array {
     $pages = array();
     $diagnostics = array();
+    if ((!isset($GLOBALS['menu']) || !is_array($GLOBALS['menu'])) && is_user_logged_in()) {
+        if (!defined('WP_ADMIN')) {
+            define('WP_ADMIN', true);
+        }
+        if (defined('ABSPATH') && file_exists(ABSPATH . 'wp-admin/includes/admin.php')) {
+            require_once ABSPATH . 'wp-admin/includes/admin.php';
+        }
+        if (defined('ABSPATH') && file_exists(ABSPATH . 'wp-admin/menu.php')) {
+            require_once ABSPATH . 'wp-admin/menu.php';
+        }
+    }
     $menu_loaded = isset($GLOBALS['menu']) && is_array($GLOBALS['menu']);
     if (!$menu_loaded) {
         $diagnostics[] = runtime_discovery_diagnostic('admin', 'admin-menu-not-loaded', 'The admin menu globals are not populated in this request context.');
     }
 
+    $current_user = function_exists('wp_get_current_user') ? wp_get_current_user() : null;
+    $user_context = array(
+        'isLoggedIn' => function_exists('is_user_logged_in') ? is_user_logged_in() : false,
+        'id' => is_object($current_user) && isset($current_user->ID) ? (int) $current_user->ID : 0,
+        'roles' => is_object($current_user) && isset($current_user->roles) ? array_values(array_map('strval', (array) $current_user->roles)) : array(),
+    );
+
     foreach ((array) ($GLOBALS['menu'] ?? array()) as $item) {
         if (!is_array($item)) {
             continue;
         }
-        $pages[] = array('menuSlug' => (string) ($item[2] ?? ''), 'pageTitle' => wp_strip_all_tags((string) ($item[0] ?? '')), 'menuTitle' => wp_strip_all_tags((string) ($item[0] ?? '')), 'capability' => (string) ($item[1] ?? ''));
+        $pages[] = runtime_discovery_admin_page((string) ($item[2] ?? ''), (string) ($item[0] ?? ''), (string) ($item[1] ?? ''));
     }
     foreach ((array) ($GLOBALS['submenu'] ?? array()) as $parent_slug => $items) {
         foreach ((array) $items as $item) {
             if (!is_array($item)) {
                 continue;
             }
-            $pages[] = array('menuSlug' => (string) ($item[2] ?? ''), 'pageTitle' => wp_strip_all_tags((string) ($item[0] ?? '')), 'menuTitle' => wp_strip_all_tags((string) ($item[0] ?? '')), 'capability' => (string) ($item[1] ?? ''), 'parentSlug' => (string) $parent_slug);
+            $pages[] = runtime_discovery_admin_page((string) ($item[2] ?? ''), (string) ($item[0] ?? ''), (string) ($item[1] ?? ''), (string) $parent_slug);
         }
     }
 
-    return array('payload' => array('schema' => 'wp-codebox/wordpress-admin-page-discovery/v1', 'adminUrl' => admin_url(), 'menuLoaded' => $menu_loaded, 'pages' => $pages), 'diagnostics' => $diagnostics);
+    return array('payload' => array('schema' => 'wp-codebox/wordpress-admin-page-discovery/v1', 'adminUrl' => admin_url(), 'menuLoaded' => $menu_loaded, 'user' => $user_context, 'pages' => $pages), 'diagnostics' => $diagnostics);
+}
+
+function runtime_discovery_admin_page(string $menu_slug, string $title, string $capability, string $parent_slug = ''): array {
+    $page = array(
+        'menuSlug' => $menu_slug,
+        'pageTitle' => wp_strip_all_tags($title),
+        'menuTitle' => wp_strip_all_tags($title),
+        'capability' => $capability,
+        'canAccess' => $capability === '' ? null : current_user_can($capability),
+        'canonicalUrl' => runtime_discovery_admin_page_url($menu_slug, $parent_slug),
+    );
+    if ($parent_slug !== '') {
+        $page['parentSlug'] = $parent_slug;
+    }
+    return $page;
+}
+
+function runtime_discovery_admin_page_url(string $menu_slug, string $parent_slug = ''): string {
+    if ($menu_slug === '') {
+        return admin_url();
+    }
+    if (strpos($menu_slug, '.php') !== false) {
+        return admin_url($menu_slug);
+    }
+    if ($parent_slug !== '' && strpos($parent_slug, '.php') !== false) {
+        return admin_url($parent_slug . '?page=' . rawurlencode($menu_slug));
+    }
+    return admin_url('admin.php?page=' . rawurlencode($menu_slug));
 }
 
 function runtime_discovery_database(): array {

--- a/tests/wordpress-runtime-discovery-contracts.test.ts
+++ b/tests/wordpress-runtime-discovery-contracts.test.ts
@@ -61,6 +61,7 @@ const adminInventory: WordPressAdminPageInventory = {
   status: "unsupported",
   adminUrl: "https://example.com/wp-admin/",
   menuLoaded: false,
+  user: { isLoggedIn: false, id: 0, roles: [] },
   pages: [],
   diagnostics: [],
 }
@@ -158,5 +159,43 @@ assert.equal(route?.endpoints?.[0]?.args[0]?.description, "Item id")
 assert.deepEqual(route?.endpoints?.[0]?.args[1]?.enum, ["view", "edit"])
 assert.equal(route?.endpoints?.[0]?.args[1]?.defaultPresent, true)
 assert.deepEqual(route?.schema?.properties, ["id", "name"])
+
+const adminDiscoveryPhp = runtimeDiscoveryPhpCode(["admin"]).replace(/^<\?php\n/, "")
+assert.match(adminDiscoveryPhp, /wp-admin\/menu\.php/)
+const adminDiscovered = await runPhpJson<WordPressRuntimeDiscoveryResult>(`
+class WP_User {
+    public $ID = 7;
+    public $roles = array( 'administrator' );
+}
+function is_user_logged_in() { return true; }
+function wp_get_current_user() { return new WP_User(); }
+function current_user_can( $capability ) { return in_array( $capability, array( 'read', 'manage_options' ), true ); }
+function admin_url( $path = '' ) { return 'https://example.com/wp-admin/' . ltrim( $path, '/' ); }
+function wp_strip_all_tags( $text ) { return strip_tags( $text ); }
+function wp_json_encode( $data, $flags = 0 ) { return json_encode( $data, $flags ); }
+$GLOBALS['menu'] = array(
+    array( 'Dashboard', 'read', 'index.php' ),
+    array( 'Demo Plugin', 'manage_options', 'demo-plugin' ),
+);
+$GLOBALS['submenu'] = array(
+    'tools.php' => array(
+        array( 'Import Demo', 'import', 'demo-import' ),
+    ),
+);
+${adminDiscoveryPhp}
+`)
+
+assert.equal(adminDiscovered.admin?.menuLoaded, true)
+assert.equal(adminDiscovered.admin?.user?.id, 7)
+assert.deepEqual(adminDiscovered.admin?.user?.roles, ["administrator"])
+const dashboardPage = adminDiscovered.admin?.pages.find((page) => page.menuSlug === "index.php")
+assert.equal(dashboardPage?.canonicalUrl, "https://example.com/wp-admin/index.php")
+assert.equal(dashboardPage?.canAccess, true)
+const pluginPage = adminDiscovered.admin?.pages.find((page) => page.menuSlug === "demo-plugin")
+assert.equal(pluginPage?.canonicalUrl, "https://example.com/wp-admin/admin.php?page=demo-plugin")
+assert.equal(pluginPage?.canAccess, true)
+const importPage = adminDiscovered.admin?.pages.find((page) => page.menuSlug === "demo-import")
+assert.equal(importPage?.canonicalUrl, "https://example.com/wp-admin/tools.php?page=demo-import")
+assert.equal(importPage?.canAccess, false)
 
 console.log("wordpress runtime discovery contracts ok")


### PR DESCRIPTION
## Summary
- Enriches admin page discovery with canonical URLs, current-user role context, and access checks.
- Bootstraps admin menus when possible for authenticated runtime fuzz discovery.

## Verification
- `npm run test:wordpress-runtime-discovery-contracts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and testing the fuzz infrastructure changes described above.