### PR TITLE
Decouple runtime invocation from Agents API

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
@@ -214,40 +214,17 @@ $user_id = (int) ( $payload['user_id'] ?? ( function_exists( 'get_current_user_i
 return $user_id > 0 ? $user_id : 1;
 }
 
-function wp_codebox_browser_runtime_agent_principal( string $agent, string $session_id ): array {
-return array(
-	'acting_user_id' => 0,
-	'effective_agent_id' => $agent,
-	'auth_source' => 'runtime',
-	'request_context' => 'runtime',
-	'token_id' => null,
-	'request_metadata' => array(
-		'source' => 'wp-codebox',
-		'mode' => 'browser-playground',
-		'codebox_session_id' => $session_id,
-	),
-	'workspace_id' => 'wp-codebox',
-	'client_id' => 'wp-codebox-browser-runner',
-	'audience_id' => $session_id,
-	'audience_claims' => array(
-		'runtime_type' => 'wordpress-playground',
-	),
-	'owner_type' => 'runtime',
-	'owner_key' => $session_id,
-);
-}
-
-function wp_codebox_browser_runtime_agents_ability_names(): array {
+function wp_codebox_browser_runtime_ability_names(): array {
 $names = function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_browser_runtime_ability_names', array() ) : array();
 return is_array( $names ) ? $names : array();
 }
 
-function wp_codebox_browser_runtime_agents_ability_exists( string $ability_name ): bool {
+function wp_codebox_browser_runtime_ability_exists( string $ability_name ): bool {
 return '' !== $ability_name && function_exists( 'wp_get_ability' ) && wp_get_ability( $ability_name ) instanceof WP_Ability;
 }
 
-function wp_codebox_browser_runtime_execute_agents_ability( string $ability_name, array $input ) {
-if ( ! wp_codebox_browser_runtime_agents_ability_exists( $ability_name ) ) {
+function wp_codebox_browser_runtime_execute_ability( string $ability_name, array $input ) {
+if ( ! wp_codebox_browser_runtime_ability_exists( $ability_name ) ) {
 	return new WP_Error( 'wp_codebox_browser_ability_unavailable', 'The requested ability is not available inside the Playground site.', array( 'ability' => $ability_name ) );
 }
 
@@ -283,11 +260,9 @@ $base_input = array(
 		'key' => $session_id,
 		'label' => 'WP Codebox Browser Playground',
 	),
-	'principal' => wp_codebox_browser_runtime_agent_principal( $agent, $session_id ),
 	'client_context' => array(
-		'source' => 'peer-agent',
+		'source' => 'wp-codebox-browser-runner',
 		'client_name' => 'wp-codebox-browser-runner',
-		'peer_agent_call' => true,
 		'caller_session_id' => $session_id,
 		'task_input' => $payload['task_input'] ?? array(),
 		'runtime_tools' => $runtime_tool_declarations,
@@ -308,7 +283,8 @@ if ( ! empty( $allowed_tool_ids ) ) {
 	}
 }
 
-return array_replace_recursive( $base_input, is_array( $invocation['input'] ?? null ) ? $invocation['input'] : array() );
+$input = array_replace_recursive( $base_input, is_array( $invocation['input'] ?? null ) ? $invocation['input'] : array() );
+return function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_browser_runtime_invocation_input', $input, $payload, $invocation, $session_id, $runtime_tool_declarations, $ability_tools, $allowed_tool_ids, $sandbox_tool_ids ) : $input;
 }
 
 function wp_codebox_browser_runtime_import_agent_bundles( array $bundle_specs ): array {
@@ -434,10 +410,10 @@ if ( empty( $preflight['error'] ) && 'task' === $invocation_type ) {
 	}
 }
 if ( empty( $preflight['error'] ) && 'task' !== $invocation_type ) {
-	$ability_names = wp_codebox_browser_runtime_agents_ability_names();
+	$ability_names = wp_codebox_browser_runtime_ability_names();
 	$ability_name = (string) ( $invocation['name'] ?? $ability_names['chat'] ?? '' );
 	$preflight['ability'] = $ability_name;
-	if ( ! wp_codebox_browser_runtime_agents_ability_exists( $ability_name ) ) {
+	if ( ! wp_codebox_browser_runtime_ability_exists( $ability_name ) ) {
 		$preflight['error'] = new WP_Error( 'wp_codebox_browser_ability_unavailable', 'The requested ability is not available inside the Playground site.', array( 'ability' => $ability_name ) );
 	}
 }
@@ -446,25 +422,10 @@ return $preflight;
 }
 
 function wp_codebox_browser_runtime_principal_permission( bool $allowed, $principal, array $permission_input, string $session_id ): bool {
-if ( ! $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal ) {
-	return $allowed;
-}
-if ( 'runtime' !== $principal->auth_source || 'runtime' !== $principal->request_context ) {
-	return $allowed;
-}
-if ( 'wp-codebox-browser-runner' !== $principal->client_id || 'wp-codebox' !== $principal->workspace_id || 'runtime' !== $principal->owner_type ) {
-	return $allowed;
-}
-if ( $session_id !== $principal->audience_id || $session_id !== $principal->owner_key ) {
-	return $allowed;
-}
-if ( 'wordpress-playground' !== (string) ( $principal->audience_claims['runtime_type'] ?? '' ) ) {
-	return $allowed;
-}
-return 'wp-codebox' === (string) ( $permission_input['principal']['workspace_id'] ?? '' ) && 'wp-codebox-browser-runner' === (string) ( $permission_input['principal']['client_id'] ?? '' );
+return function_exists( 'apply_filters' ) ? (bool) apply_filters( 'wp_codebox_browser_runtime_principal_permission', $allowed, $principal, $permission_input, $session_id ) : $allowed;
 }
 
-function wp_codebox_browser_runtime_invoke_agent_task( array $payload, array $invocation, array $input, string $session_id, bool $is_playground, string $playground_root ): array {
+function wp_codebox_browser_runtime_invoke( array $payload, array $invocation, array $input, string $session_id, bool $is_playground, string $playground_root ): array {
 $agent_bundle_imports = wp_codebox_browser_runtime_import_agent_bundles( is_array( $payload['agent_bundles'] ?? null ) ? $payload['agent_bundles'] : array() );
 $preflight = wp_codebox_browser_runtime_preflight( $payload, $invocation, $input, $agent_bundle_imports, $is_playground, $playground_root );
 $response = $preflight['error'] ?? null;
@@ -480,8 +441,8 @@ if ( null === $response ) {
 		if ( 'task' === (string) ( $invocation['type'] ?? 'ability' ) ) {
 			$response = apply_filters( (string) ( $invocation['hook'] ?? $invocation['name'] ?? '' ), null, $input, $payload );
 		} else {
-			$ability_names = wp_codebox_browser_runtime_agents_ability_names();
-			$response = wp_codebox_browser_runtime_execute_agents_ability( (string) ( $invocation['name'] ?? $ability_names['chat'] ?? '' ), $input );
+			$ability_names = wp_codebox_browser_runtime_ability_names();
+			$response = wp_codebox_browser_runtime_execute_ability( (string) ( $invocation['name'] ?? $ability_names['chat'] ?? '' ), $input );
 		}
 	} catch ( Throwable $exception ) {
 		$response = $exception;

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -146,6 +146,8 @@ final class WP_Codebox_Agents_API_Adapter {
 		add_filter( 'wp_codebox_browser_runtime_bundle_import_filter', array( self::class, 'runtime_bundle_import_filter' ) );
 		add_filter( 'wp_codebox_browser_runtime_bundle_importer_paths', array( self::class, 'runtime_bundle_importer_paths' ) );
 		add_filter( 'wp_codebox_browser_runtime_principal_permission_filter', array( self::class, 'chat_runtime_principal_permission_filter' ) );
+		add_filter( 'wp_codebox_browser_runtime_invocation_input', array( self::class, 'browser_runtime_invocation_input' ), 10, 4 );
+		add_filter( 'wp_codebox_browser_runtime_principal_permission', array( self::class, 'browser_runtime_principal_permission' ), 10, 4 );
 		add_filter( 'wp_codebox_browser_runtime_executor_target', array( self::class, 'browser_executor_target_id' ) );
 		add_filter( 'wp_codebox_browser_runtime_legacy_resolved_tools_filter', array( self::class, 'legacy_resolved_tools_filter' ) );
 		add_filter( 'wp_codebox_browser_runtime_resolved_tools_filter', array( self::class, 'runtime_resolved_tools_filter' ) );
@@ -174,6 +176,66 @@ final class WP_Codebox_Agents_API_Adapter {
 			'type' => 'ability',
 			'name' => self::default_chat_ability(),
 		);
+	}
+
+	/** @param array<string,mixed> $input Runtime input. @param array<string,mixed> $payload Browser payload. @param array<string,mixed> $invocation Runtime invocation. @return array<string,mixed> */
+	public static function browser_runtime_invocation_input( array $input, array $payload, array $invocation, string $session_id ): array {
+		if ( 'ability' !== (string) ( $invocation['type'] ?? 'ability' ) ) {
+			return $input;
+		}
+
+		$ability_name = (string) ( $invocation['name'] ?? '' );
+		if ( '' === $ability_name || ! in_array( $ability_name, self::ability_names(), true ) ) {
+			return $input;
+		}
+
+		$agent = sanitize_key( (string) ( $payload['agent'] ?? $input['agent'] ?? 'wp-codebox-sandbox' ) );
+		$input['principal'] = array(
+			'acting_user_id'     => 0,
+			'effective_agent_id' => $agent,
+			'auth_source'        => 'runtime',
+			'request_context'    => 'runtime',
+			'token_id'           => null,
+			'request_metadata'   => array(
+				'source'             => 'wp-codebox',
+				'mode'               => 'browser-playground',
+				'codebox_session_id' => $session_id,
+			),
+			'workspace_id'       => 'wp-codebox',
+			'client_id'          => 'wp-codebox-browser-runner',
+			'audience_id'        => $session_id,
+			'audience_claims'    => array(
+				'runtime_type' => 'wordpress-playground',
+			),
+			'owner_type'         => 'runtime',
+			'owner_key'          => $session_id,
+		);
+
+		$input['client_context']['source'] = 'peer-agent';
+		$input['client_context']['peer_agent_call'] = true;
+
+		return $input;
+	}
+
+	/** @param array<string,mixed> $permission_input Permission input. */
+	public static function browser_runtime_principal_permission( bool $allowed, mixed $principal, array $permission_input, string $session_id ): bool {
+		if ( ! class_exists( 'AgentsAPI\\AI\\WP_Agent_Execution_Principal' ) || ! $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+			return $allowed;
+		}
+		if ( 'runtime' !== $principal->auth_source || 'runtime' !== $principal->request_context ) {
+			return $allowed;
+		}
+		if ( 'wp-codebox-browser-runner' !== $principal->client_id || 'wp-codebox' !== $principal->workspace_id || 'runtime' !== $principal->owner_type ) {
+			return $allowed;
+		}
+		if ( $session_id !== $principal->audience_id || $session_id !== $principal->owner_key ) {
+			return $allowed;
+		}
+		if ( 'wordpress-playground' !== (string) ( $principal->audience_claims['runtime_type'] ?? '' ) ) {
+			return $allowed;
+		}
+
+		return 'wp-codebox' === (string) ( $permission_input['principal']['workspace_id'] ?? '' ) && 'wp-codebox-browser-runner' === (string) ( $permission_input['principal']['client_id'] ?? '' );
 	}
 
 	/** @param array<string,array<string,mixed>> $registry Runtime profile registry. @return array<string,array<string,mixed>> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -296,7 +296,7 @@ if ( null !== $event_sink ) {
 $invocation_type = (string) ( $invocation[\'type\'] ?? \'ability\' );
 
 /* WP_CODEBOX_BROWSER_RUNNER_BODY_START */
-$runtime_invocation = wp_codebox_browser_runtime_invoke_agent_task( $payload, $invocation, $input, $session_id, $wp_codebox_is_playground, $wp_codebox_playground_root );
+$runtime_invocation = wp_codebox_browser_runtime_invoke( $payload, $invocation, $input, $session_id, $wp_codebox_is_playground, $wp_codebox_playground_root );
 $response = $runtime_invocation[\'response\'] ?? null;
 $agent_bundle_imports = is_array( $runtime_invocation[\'agent_bundle_imports\'] ?? null ) ? $runtime_invocation[\'agent_bundle_imports\'] : array();
 $runtime_invocation_preflight = is_array( $runtime_invocation[\'preflight\'] ?? null ) ? $runtime_invocation[\'preflight\'] : array();

--- a/tests/browser-runtime-generic-invoker.test.ts
+++ b/tests/browser-runtime-generic-invoker.test.ts
@@ -5,12 +5,16 @@ const result = await runPhpJson<{
   has_agents_api_adapter: boolean
   response: { success: boolean; agent: string; message: string }
   preflight: { invocation_type: string; provider_ready: boolean; hook: string }
-  ability_names: string[]
+  generic_ability_names: string[]
+  adapter_ability_names: { chat: string }
+  has_principal: boolean
+  agents_api_input: { has_principal: boolean; source: string; peer_agent_call: boolean; effective_agent_id: string }
 }>(`
 define('ABSPATH', ${phpStringLiteral(repoRoot)});
 class WP_Error {
 	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
 }
+class WP_Ability {}
 function is_wp_error( $value ) { return $value instanceof WP_Error; }
 function sanitize_key( $value ) { return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', (string) $value ) ); }
 function get_current_user_id() { return 1; }
@@ -43,13 +47,29 @@ add_filter( 'wp_codebox_browser_runtime_task', static function ( $response, arra
 $payload = array( 'agent' => 'generic-agent', 'message' => 'Run generic runtime', 'task_input' => array() );
 $invocation = array( 'type' => 'task', 'hook' => 'wp_codebox_browser_runtime_task' );
 $input = wp_codebox_browser_runtime_prepare_input( $payload, $invocation, 'generic-session', array(), array(), array(), array() );
-$result = wp_codebox_browser_runtime_invoke_agent_task( $payload, $invocation, $input, 'generic-session', true, '/wordpress' );
+$result = wp_codebox_browser_runtime_invoke( $payload, $invocation, $input, 'generic-session', true, '/wordpress' );
+$generic_ability_names = wp_codebox_browser_runtime_ability_names();
+$has_agents_api_adapter = class_exists( 'WP_Codebox_Agents_API_Adapter' );
+
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php`)};
+WP_Codebox_Agents_API_Adapter::register_runtime_profiles();
+$agents_api_payload = array( 'agent' => 'agents-api-agent', 'message' => 'Run adapter runtime', 'task_input' => array() );
+$agents_api_invocation = array( 'type' => 'ability', 'name' => 'agents/chat' );
+$agents_api_input = wp_codebox_browser_runtime_prepare_input( $agents_api_payload, $agents_api_invocation, 'agents-api-session', array(), array(), array(), array() );
 
 echo json_encode( array(
-	'has_agents_api_adapter' => class_exists( 'WP_Codebox_Agents_API_Adapter' ),
+	'has_agents_api_adapter' => $has_agents_api_adapter,
 	'response' => $result['response'],
 	'preflight' => $result['preflight'],
-	'ability_names' => wp_codebox_browser_runtime_agents_ability_names(),
+	'generic_ability_names' => $generic_ability_names,
+	'adapter_ability_names' => wp_codebox_browser_runtime_ability_names(),
+	'has_principal' => isset( $input['principal'] ),
+	'agents_api_input' => array(
+		'has_principal' => isset( $agents_api_input['principal'] ),
+		'source' => (string) ( $agents_api_input['client_context']['source'] ?? '' ),
+		'peer_agent_call' => (bool) ( $agents_api_input['client_context']['peer_agent_call'] ?? false ),
+		'effective_agent_id' => (string) ( $agents_api_input['principal']['effective_agent_id'] ?? '' ),
+	),
 ), JSON_UNESCAPED_SLASHES );
 `)
 
@@ -58,6 +78,9 @@ assert.deepEqual(result.response, { success: true, agent: "generic-agent", messa
 assert.equal(result.preflight.invocation_type, "task")
 assert.equal(result.preflight.provider_ready, true)
 assert.equal(result.preflight.hook, "wp_codebox_browser_runtime_task")
-assert.deepEqual(result.ability_names, [])
+assert.deepEqual(result.generic_ability_names, [])
+assert.equal(result.adapter_ability_names.chat, "agents/chat")
+assert.equal(result.has_principal, false)
+assert.deepEqual(result.agents_api_input, { has_principal: true, source: "peer-agent", peer_agent_call: true, effective_agent_id: "agents-api-agent" })
 
 console.log("browser runtime generic invoker ok")


### PR DESCRIPTION
## Summary
- Introduces a generic browser/runtime invocation seam for Codebox.
- Moves Agents API principal decoration and permission behavior into the Agents API adapter.
- Updates focused browser runtime tests around generic invocation.

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
- npm run test:browser-runtime-generic-invoker
- npm run test:generic-ability-runtime-run
- npm run test:php-agents-api-adapter-contract
- npm run test:browser-task-builder
- npx tsx tests/agent-runtime-components.test.ts
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, and PR preparation.