### PR TITLE
Enforce run-plan execution policy

### DIFF
--- a/packages/runtime-core/src/run-plan.ts
+++ b/packages/runtime-core/src/run-plan.ts
@@ -107,6 +107,8 @@ export interface RunPlanExecutorOptions<TWorker extends RunPlanWorkerContract = 
   onWorkerFailed?: (descriptor: RunPlanWorkerDescriptor<TWorker>, result: TResult, index: number) => Promise<void> | void
   onWorkerSkipped?: (descriptor: RunPlanWorkerDescriptor<TWorker>, result: TResult, index: number) => Promise<void> | void
   createSkippedResult?: (descriptor: RunPlanWorkerDescriptor<TWorker>, dependencies: TResult[]) => TResult
+  createCancelledResult?: (descriptor: RunPlanWorkerDescriptor<TWorker>) => TResult
+  createTimedOutResult?: (descriptor: RunPlanWorkerDescriptor<TWorker>, reason: string) => TResult
 }
 
 export type RunPlanClock = () => Date | string
@@ -143,8 +145,21 @@ export async function executeRunPlan<TWorker extends RunPlanWorkerContract, TRes
   validateRunPlanDependencies(workers)
   const concurrency = normalizeRunPlanConcurrency(plan.concurrency, options)
   const results = await runDependencyAwareConcurrent(workers, concurrency, async (descriptor, index) => {
+    if (descriptor.cancellation.cancelRequested) {
+      const result = options.createCancelledResult?.(descriptor) ?? defaultCancelledRunPlanResult(descriptor) as TResult
+      await options.onWorkerFailed?.(descriptor, result, index)
+      return result
+    }
+
+    const executionTimeoutMs = runPlanWorkerExecutionTimeoutMs(descriptor, options.clock)
+    if (executionTimeoutMs === 0) {
+      const result = options.createTimedOutResult?.(descriptor, "deadline") ?? defaultTimedOutRunPlanResult(descriptor, "deadline") as TResult
+      await options.onWorkerFailed?.(descriptor, result, index)
+      return result
+    }
+
     await options.onWorkerStarted?.(descriptor, index)
-    const result = await options.adapter.run({ descriptor, index })
+    const result = await runPlanWorkerWithTimeout(options.adapter.run({ descriptor, index }), descriptor, executionTimeoutMs, options)
     if (result.success === true) {
       await options.onWorkerCompleted?.(descriptor, result, index)
     } else {
@@ -333,6 +348,22 @@ export function runPlanCancellationMetadata(source: Record<string, unknown>): Ru
   }
 }
 
+export function runPlanWorkerExecutionTimeoutMs(descriptor: RunPlanWorkerDescriptor, clock?: RunPlanClock): number | undefined {
+  const limits: number[] = []
+  if (descriptor.timeoutSeconds) {
+    limits.push(descriptor.timeoutSeconds * 1000)
+  }
+  if (descriptor.cancellation.deadline) {
+    const deadlineMs = Date.parse(descriptor.cancellation.deadline)
+    const nowMs = Date.parse(runPlanClockIso(clock))
+    if (Number.isFinite(deadlineMs) && Number.isFinite(nowMs)) {
+      limits.push(Math.max(0, deadlineMs - nowMs))
+    }
+  }
+
+  return limits.length > 0 ? Math.min(...limits) : undefined
+}
+
 export function safeRunPlanPathSegment(value: unknown): string {
   const segment = stringValue(value)
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment)) {
@@ -365,6 +396,43 @@ function defaultSkippedRunPlanResult<TWorker extends RunPlanWorkerContract, TRes
     status: "skipped",
     error: { code: "dependency-skipped", message: `Run plan worker ${descriptor.id} skipped because a dependency did not complete successfully.` },
     dependencies: dependencies.map((dependency) => ({ workerId: dependency.workerId, status: dependency.status, success: dependency.success })),
+  } as unknown as TResult
+}
+
+function runPlanWorkerWithTimeout<TWorker extends RunPlanWorkerContract, TResult extends RunPlanWorkerResultLike>(operation: Promise<TResult>, descriptor: RunPlanWorkerDescriptor<TWorker>, timeoutMs: number | undefined, options: RunPlanExecutorOptions<TWorker, TResult>): Promise<TResult> {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return operation
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      resolve(options.createTimedOutResult?.(descriptor, "timeout") ?? defaultTimedOutRunPlanResult(descriptor, "timeout") as TResult)
+    }, Math.max(0, Math.round(timeoutMs)))
+    operation.then((result) => {
+      clearTimeout(timeout)
+      resolve(result)
+    }).catch((error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+  })
+}
+
+function defaultCancelledRunPlanResult<TWorker extends RunPlanWorkerContract, TResult extends RunPlanWorkerResultLike>(descriptor: RunPlanWorkerDescriptor<TWorker>): TResult {
+  return {
+    workerId: descriptor.id,
+    success: false,
+    status: "cancelled",
+    error: { code: "worker-cancelled", message: descriptor.cancellation.reason || `Run plan worker ${descriptor.id} was cancelled before execution.` },
+  } as unknown as TResult
+}
+
+function defaultTimedOutRunPlanResult<TWorker extends RunPlanWorkerContract, TResult extends RunPlanWorkerResultLike>(descriptor: RunPlanWorkerDescriptor<TWorker>, reason: string): TResult {
+  return {
+    workerId: descriptor.id,
+    success: false,
+    status: "timed_out",
+    error: { code: "worker-timed-out", message: `Run plan worker ${descriptor.id} exceeded its ${reason}.` },
   } as unknown as TResult
 }
 

--- a/tests/run-plan-executor.test.ts
+++ b/tests/run-plan-executor.test.ts
@@ -52,6 +52,81 @@ assert.ok(events.indexOf("completed:one") < events.indexOf("started:after-one"),
 assert.ok(!events.includes("started:after-failed"), "failed dependency dependent is never started")
 assert.ok(events.indexOf("skipped:after-failed") < events.indexOf("skipped:after-skipped"), "transitive skip is deterministic")
 
+const successfulRun = await executeRunPlan({
+  concurrency: 1,
+  workers: [{ id: "success", goal: "Complete normally" }],
+}, {
+  adapter: {
+    async run({ descriptor }) {
+      return { workerId: descriptor.id, status: "succeeded", success: true }
+    },
+  },
+})
+assert.equal(successfulRun.success, true)
+assert.deepEqual(successfulRun.counts, { total: 1, completed: 1, failed: 0, skipped: 0, cancelled: 0, timed_out: 0 })
+
+const timedOutRuns: string[] = []
+const timedOutRun = await executeRunPlan({
+  concurrency: 1,
+  workers: [
+    { id: "slow", goal: "Time out", timeout_seconds: 1 },
+    { id: "after-slow", goal: "Skip after timeout", dependsOn: ["slow"] },
+  ],
+}, {
+  adapter: {
+    async run({ descriptor }) {
+      timedOutRuns.push(descriptor.id)
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+      return { workerId: descriptor.id, status: "succeeded", success: true }
+    },
+  },
+})
+assert.equal(timedOutRun.success, false)
+assert.deepEqual(timedOutRun.counts, { total: 2, completed: 0, failed: 0, skipped: 1, cancelled: 0, timed_out: 1 })
+assert.equal(timedOutRun.workers[0].status, "timed_out")
+assert.equal(timedOutRun.workers[1].status, "skipped")
+assert.deepEqual(timedOutRuns, ["slow"])
+
+const cancelledRuns: string[] = []
+const cancelledRun = await executeRunPlan({
+  concurrency: 1,
+  workers: [
+    { id: "cancelled", goal: "Do not start", cancel_requested: true, cancel_reason: "operator-requested" },
+    { id: "after-cancelled", goal: "Skip after cancellation", dependsOn: ["cancelled"] },
+  ],
+}, {
+  adapter: {
+    async run({ descriptor }) {
+      cancelledRuns.push(descriptor.id)
+      return { workerId: descriptor.id, status: "succeeded", success: true }
+    },
+  },
+})
+assert.equal(cancelledRun.success, false)
+assert.deepEqual(cancelledRun.counts, { total: 2, completed: 0, failed: 0, skipped: 1, cancelled: 1, timed_out: 0 })
+assert.equal(cancelledRun.workers[0].status, "cancelled")
+assert.equal((cancelledRun.workers[0] as { error?: { message?: string } }).error?.message, "operator-requested")
+assert.equal(cancelledRun.workers[1].status, "skipped")
+assert.deepEqual(cancelledRuns, [])
+
+const deadlineRuns: string[] = []
+const deadlineRun = await executeRunPlan({
+  concurrency: 1,
+  workers: [{ id: "expired", goal: "Do not start after deadline", deadline: "2026-03-04T05:06:06.000Z" }],
+}, {
+  adapter: {
+    async run({ descriptor }) {
+      deadlineRuns.push(descriptor.id)
+      return { workerId: descriptor.id, status: "succeeded", success: true }
+    },
+  },
+  clock: () => "2026-03-04T05:06:07.000Z",
+})
+assert.equal(deadlineRun.success, false)
+assert.deepEqual(deadlineRun.counts, { total: 1, completed: 0, failed: 0, skipped: 0, cancelled: 0, timed_out: 1 })
+assert.equal(deadlineRun.workers[0].status, "timed_out")
+assert.deepEqual(deadlineRuns, [])
+
 await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "missing-goal" }] }, { adapter, requireGoal: true }), /requires goal/)
 await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "duplicate", goal: "one" }, { id: "duplicate", goal: "two" }] }, { adapter }), /must be unique/)
 await assert.rejects(executeRunPlan({ concurrency: 1, workers: [{ id: "unknown", goal: "one", dependsOn: ["missing"] }] }, { adapter }), /unknown worker/)


### PR DESCRIPTION
## Summary
- Enforces cancellation, expired deadlines, and worker timeouts in runtime-core run plans.
- Keeps dependency scheduling deterministic by skipping dependents after non-success dependency results.
- Adds targeted run-plan executor coverage.

## Testing
- npm run test:run-plan-executor
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, tests, and PR preparation.