### PR TITLE
Document public fuzz suite target skips

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -73,6 +73,25 @@ manifest intentionally excludes backend handler bindings such as agent execution
 substrate ability names, runtime command handlers, and integration-specific
 filters.
 
+`wp-codebox/run-fuzz-suite` accepts public target kinds `rest`, `http`,
+`ability`, `command`, `runtime`, and `runtime-action`. The WordPress plugin
+ability runs safe in-process `rest`, same-site `http`, and WordPress `ability`
+targets directly. Targets that require the runtime command, browser, editor, or
+page-load executors return `status: "skipped"`, a case-level `skipReason`, and a
+warning diagnostic rather than silently passing without exercising the target.
+Documented skip reason codes are:
+
+- `wp_codebox_fuzz_target_command_unsupported`
+- `wp_codebox_fuzz_runtime_action_wp_cli_unsupported`
+- `wp_codebox_fuzz_runtime_action_php_unsupported`
+- `wp_codebox_fuzz_runtime_action_browser_unsupported`
+- `wp_codebox_fuzz_runtime_action_browser_probe_unsupported`
+- `wp_codebox_fuzz_runtime_action_editor_open_unsupported`
+- `wp_codebox_fuzz_runtime_action_admin_page_unsupported`
+- `wp_codebox_fuzz_runtime_action_page_unsupported`
+- `wp_codebox_fuzz_runtime_action_unsupported`
+- `wp_codebox_fuzz_step_unsupported`
+
 WordPress consumers should prefer `WP_Codebox_API` for PHP calls and
 `wp-codebox/*` ability ids for ability-oriented calls. Runtime adapters may use
 backend systems internally, while public docs and schemas present Codebox-owned

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -174,7 +174,7 @@ private static function fuzz_suite_target_step( array $case, array $target ): ar
 		'ability' => 'wordpress.ability',
 		default => $entrypoint,
 	};
-	return array( 'command' => $command, 'args' => $args );
+	return array_filter( array( 'command' => $command, 'args' => $args, 'targetKind' => $kind, 'targetId' => $entrypoint ), static fn( mixed $value ): bool => '' !== $value && ! ( is_array( $value ) && empty( $value ) ) );
 }
 
 /** @param array<string,mixed> $input Runtime action input. @return array<string,mixed> */
@@ -190,33 +190,44 @@ private static function fuzz_suite_runtime_action_step( array $input ): array {
 		return array(
 			'command' => 'wordpress.wp-cli',
 			'args'    => self::fuzz_suite_args_from_map( array( 'command' => $input['command'] ?? null ) ),
+			'action'  => $type,
+		);
+	}
+	if ( 'php' === $type ) {
+		return array(
+			'command' => 'wordpress.run-php',
+			'action'  => $type,
 		);
 	}
 	if ( 'browser' === $type ) {
 		return array(
 			'command' => 'wordpress.browser-actions',
 			'args'    => self::fuzz_suite_browser_action_args( $input ),
+			'action'  => $type,
 		);
 	}
 	if ( 'browser_probe' === $type ) {
 		return array(
 			'command' => 'wordpress.browser-probe',
 			'args'    => self::fuzz_suite_args_from_map( array( 'url' => $input['url'] ?? null, 'wait-for' => $input['wait_for'] ?? $input['waitFor'] ?? null, 'duration' => $input['duration'] ?? null, 'capture' => self::fuzz_suite_csv_arg( $input['capture'] ?? null ), 'viewport' => $input['viewport'] ?? null ) ),
+			'action'  => $type,
 		);
 	}
 	if ( 'editor_open' === $type ) {
 		return array(
 			'command' => 'wordpress.editor-open',
 			'args'    => self::fuzz_suite_args_from_map( array( 'target' => $input['target'] ?? null, 'post-id' => $input['post_id'] ?? $input['postId'] ?? null, 'post-type' => $input['post_type'] ?? $input['postType'] ?? null, 'url' => $input['url'] ?? null, 'wait-selector' => $input['wait_selector'] ?? $input['waitSelector'] ?? null, 'wait-timeout' => isset( $input['timeout_ms'] ) ? ( (string) $input['timeout_ms'] . 'ms' ) : ( isset( $input['timeoutMs'] ) ? ( (string) $input['timeoutMs'] . 'ms' ) : null ), 'capture' => self::fuzz_suite_csv_arg( $input['capture'] ?? null ) ) ),
+			'action'  => $type,
 		);
 	}
 	if ( 'admin_page' === $type || 'page' === $type ) {
 		return array(
 			'command' => 'admin_page' === $type ? 'wordpress.admin-page-load' : 'wordpress.frontend-page-load',
 			'args'    => self::fuzz_suite_args_from_map( array( 'path' => $input['path'] ?? null, 'url' => $input['url'] ?? null, 'method' => $input['method'] ?? null, 'query-json' => $input['query'] ?? null, 'body-json' => $input['body'] ?? null, 'user' => $input['user'] ?? null, 'session' => $input['session'] ?? null, 'capture-diagnostics' => self::fuzz_suite_csv_arg( $input['capture_diagnostics'] ?? $input['captureDiagnostics'] ?? null ) ) ),
+			'action'  => $type,
 		);
 	}
-	return array( 'command' => 'wordpress.runtime-action', 'args' => self::fuzz_suite_args_from_map( array( 'type' => $type ) ) );
+	return array( 'command' => 'wordpress.runtime-action', 'args' => self::fuzz_suite_args_from_map( array( 'type' => $type ) ), 'action' => $type );
 }
 
 /** @param array<string,mixed> $input Runtime browser action input. @return string[] */
@@ -260,7 +271,16 @@ private static function fuzz_suite_args_from_map( array $values ): array {
 private static function execute_fuzz_suite_step( array $step, array $case, array $suite, string $case_id ): array {
 	$command = (string) ( $step['command'] ?? '' );
 	$args = self::fuzz_suite_parse_args( is_array( $step['args'] ?? null ) ? $step['args'] : array() );
-	$observation = array( 'command' => $command, 'phase' => (string) ( $step['phase'] ?? '' ) );
+	$observation = array_filter(
+		array(
+			'command'    => $command,
+			'phase'      => (string) ( $step['phase'] ?? '' ),
+			'targetKind' => (string) ( $step['targetKind'] ?? '' ),
+			'targetId'   => (string) ( $step['targetId'] ?? '' ),
+			'action'     => (string) ( $step['action'] ?? '' ),
+		),
+		static fn( mixed $value ): bool => '' !== $value
+	);
 
 	try {
 		return match ( $command ) {
@@ -391,21 +411,48 @@ private static function execute_fuzz_suite_workload_step( array $args, string $c
 
 /** @param array<string,mixed> $observation Observation. @return array<string,mixed> */
 private static function fuzz_suite_step_unsupported( string $command, array $observation, string $case_id ): array {
-	return array( 'status' => 'skipped', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'warning', 'wp_codebox_fuzz_step_unsupported', 'Fuzz suite step is not supported by this runner.', array( 'case_id' => $case_id, 'command' => $command ) ) );
+	$reason = self::fuzz_suite_unsupported_step_reason( $command, $observation );
+	return array( 'status' => 'skipped', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'warning', $reason['code'], $reason['message'], array_filter( array( 'case_id' => $case_id, 'command' => $command, 'target_kind' => $observation['targetKind'] ?? null, 'target_id' => $observation['targetId'] ?? null, 'action' => $observation['action'] ?? null, 'reason' => $reason['reason'] ) ) ) );
+}
+
+/** @param array<string,mixed> $observation Observation. @return array{code:string,message:string,reason:string} */
+private static function fuzz_suite_unsupported_step_reason( string $command, array $observation ): array {
+	if ( in_array( $observation['targetKind'] ?? '', array( 'command', 'runtime' ), true ) ) {
+		return array( 'code' => 'wp_codebox_fuzz_target_command_unsupported', 'reason' => 'target_command_unsupported', 'message' => 'Command and runtime fuzz-suite targets require the runtime command executor; the public PHP fuzz-suite ability records a structured skip.' );
+	}
+
+	$runtime_commands = array(
+		'wordpress.wp-cli'             => array( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported', 'runtime_action_wp_cli_unsupported', 'Runtime-action type wp_cli requires the runtime command executor; the public PHP fuzz-suite ability records a structured skip.' ),
+		'wordpress.run-php'            => array( 'wp_codebox_fuzz_runtime_action_php_unsupported', 'runtime_action_php_unsupported', 'Runtime-action type php requires raw PHP execution and is not accepted by the public PHP fuzz-suite ability.' ),
+		'wordpress.browser-actions'    => array( 'wp_codebox_fuzz_runtime_action_browser_unsupported', 'runtime_action_browser_unsupported', 'Runtime-action type browser requires the browser runtime executor; the public PHP fuzz-suite ability records a structured skip.' ),
+		'wordpress.browser-probe'      => array( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported', 'runtime_action_browser_probe_unsupported', 'Runtime-action type browser_probe requires the browser runtime executor; the public PHP fuzz-suite ability records a structured skip.' ),
+		'wordpress.editor-open'        => array( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported', 'runtime_action_editor_open_unsupported', 'Runtime-action type editor_open requires the browser/editor runtime executor; the public PHP fuzz-suite ability records a structured skip.' ),
+		'wordpress.admin-page-load'    => array( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported', 'runtime_action_admin_page_unsupported', 'Runtime-action type admin_page requires the page-load runtime executor; the public PHP fuzz-suite ability records a structured skip.' ),
+		'wordpress.frontend-page-load' => array( 'wp_codebox_fuzz_runtime_action_page_unsupported', 'runtime_action_page_unsupported', 'Runtime-action type page requires the page-load runtime executor; the public PHP fuzz-suite ability records a structured skip.' ),
+		'wordpress.runtime-action'     => array( 'wp_codebox_fuzz_runtime_action_unsupported', 'runtime_action_unsupported', 'Runtime-action type is not supported by the public PHP fuzz-suite ability.' ),
+	);
+
+	if ( isset( $runtime_commands[ $command ] ) ) {
+		return array( 'code' => $runtime_commands[ $command ][0], 'reason' => $runtime_commands[ $command ][1], 'message' => $runtime_commands[ $command ][2] );
+	}
+
+	return array( 'code' => 'wp_codebox_fuzz_step_unsupported', 'reason' => 'step_unsupported', 'message' => 'Fuzz suite step is not supported by this runner.' );
 }
 
 /** @return array<string,mixed> */
 private static function fuzz_suite_case_result( string $id, string $status, array $diagnostics, array $artifact_refs = array(), array $metadata = array() ): array {
-	return array_filter(
-		array(
+	$result = array(
 			'id'           => $id,
 			'status'       => $status,
 			'success'      => 'passed' === $status,
+			'skipReason'   => 'skipped' === $status ? (string) ( $diagnostics[0]['code'] ?? '' ) : null,
 			'diagnostics'  => $diagnostics,
 			'artifactRefs' => self::dedupe_fuzz_suite_artifact_refs( $artifact_refs ),
 			'metadata'     => $metadata,
-		),
-		static fn( mixed $value ): bool => ! ( is_array( $value ) && empty( $value ) )
+		);
+	return array_filter(
+		$result,
+		static fn( mixed $value ): bool => null !== $value && ! ( is_array( $value ) && empty( $value ) )
 	);
 }
 

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -38,6 +38,26 @@ function rest_do_request( WP_REST_Request $request ): WP_Codebox_Test_REST_Respo
 	return new WP_Codebox_Test_REST_Response( '/wp/v2/status' === $request->path ? 200 : 404 );
 }
 
+function home_url( string $path = '' ): string {
+	return 'https://example.test' . $path;
+}
+
+function wp_remote_request( string $url, array $args = array() ): array {
+	return array( 'response' => array( 'code' => str_contains( $url, '/healthy' ) ? 200 : 404 ) );
+}
+
+function wp_remote_retrieve_response_code( array $response ): int {
+	return (int) ( $response['response']['code'] ?? 0 );
+}
+
+function wp_has_ability( string $name ): bool {
+	return 'example/echo' === $name;
+}
+
+function wp_call_ability( string $name, array $input ): array|WP_Error {
+	return 'example/echo' === $name ? array( 'echo' => $input ) : new WP_Error( 'missing_ability', 'Ability missing.' );
+}
+
 require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php';
 
 class WP_Codebox_Fuzz_Suite_Runner_Smoke {
@@ -74,9 +94,69 @@ $result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 				'input'  => array( 'type' => 'rest_request', 'path' => '/wp/v2/status', 'method' => 'GET' ),
 			),
 			array(
+				'id'     => 'rest-target',
+				'target' => array( 'kind' => 'rest', 'id' => '/wp/v2/status' ),
+				'input'  => array( 'method' => 'GET' ),
+			),
+			array(
+				'id'     => 'http-target',
+				'target' => array( 'kind' => 'http', 'id' => '/healthy' ),
+				'input'  => array( 'method' => 'GET' ),
+			),
+			array(
+				'id'     => 'ability-target',
+				'target' => array( 'kind' => 'ability', 'id' => 'example/echo' ),
+				'input'  => array( 'input' => array( 'message' => 'hello' ) ),
+			),
+			array(
+				'id'     => 'command-target',
+				'target' => array( 'kind' => 'command', 'id' => 'inspect-mounted-inputs' ),
+				'input'  => array( 'args' => array( '--json' ) ),
+			),
+			array(
+				'id'     => 'runtime-target',
+				'target' => array( 'kind' => 'runtime', 'entrypoint' => 'wordpress.run-php' ),
+				'input'  => array( 'args' => array( 'bootstrap=none' ) ),
+			),
+			array(
 				'id'     => 'runtime-action-wp-cli',
 				'target' => array( 'kind' => 'runtime-action' ),
 				'input'  => array( 'type' => 'wp_cli', 'command' => 'option get blogname' ),
+			),
+			array(
+				'id'     => 'runtime-action-php',
+				'target' => array( 'kind' => 'runtime-action' ),
+				'input'  => array( 'type' => 'php' ),
+			),
+			array(
+				'id'     => 'runtime-action-browser',
+				'target' => array( 'kind' => 'runtime-action' ),
+				'input'  => array( 'type' => 'browser', 'operation' => 'navigate', 'url' => '/sample-page/' ),
+			),
+			array(
+				'id'     => 'runtime-action-browser-probe',
+				'target' => array( 'kind' => 'runtime-action' ),
+				'input'  => array( 'type' => 'browser_probe', 'url' => '/sample-page/' ),
+			),
+			array(
+				'id'     => 'runtime-action-editor',
+				'target' => array( 'kind' => 'runtime-action' ),
+				'input'  => array( 'type' => 'editor_open', 'target' => 'post-new', 'post_type' => 'page' ),
+			),
+			array(
+				'id'     => 'runtime-action-admin-page',
+				'target' => array( 'kind' => 'runtime-action' ),
+				'input'  => array( 'type' => 'admin_page', 'path' => 'plugins.php' ),
+			),
+			array(
+				'id'     => 'runtime-action-page',
+				'target' => array( 'kind' => 'runtime-action' ),
+				'input'  => array( 'type' => 'page', 'path' => '/sample-page/' ),
+			),
+			array(
+				'id'     => 'runtime-action-unknown',
+				'target' => array( 'kind' => 'runtime-action' ),
+				'input'  => array( 'type' => 'filesystem' ),
 			),
 		),
 	)
@@ -86,9 +166,9 @@ assert( is_array( $result ) );
 assert( 'wp-codebox/fuzz-suite-result/v1' === $result['schema'] );
 assert( true === $result['success'] );
 assert( 'passed' === $result['status'] );
-assert( 4 === $result['summary']['total'] );
-assert( 2 === $result['summary']['passed'] );
-assert( 2 === $result['summary']['skipped'] );
+assert( 16 === $result['summary']['total'] );
+assert( 5 === $result['summary']['passed'] );
+assert( 11 === $result['summary']['skipped'] );
 assert( 'collect-artifact' === $result['cases'][0]['id'] );
 assert( 'passed' === $result['cases'][0]['status'] );
 assert( 'php-smoke/report.json' === $result['artifactRefs'][0]['path'] );
@@ -96,9 +176,23 @@ assert( 'wp_codebox_fuzz_step_unsupported' === $result['cases'][1]['diagnostics'
 assert( 'runtime-action-rest' === $result['cases'][2]['id'] );
 assert( 'passed' === $result['cases'][2]['status'] );
 assert( 'wordpress.rest-request' === $result['cases'][2]['metadata']['observations'][0]['command'] );
-assert( 'runtime-action-wp-cli' === $result['cases'][3]['id'] );
-assert( 'skipped' === $result['cases'][3]['status'] );
-assert( 'wordpress.wp-cli' === $result['cases'][3]['metadata']['observations'][0]['command'] );
+assert( 'passed' === $result['cases'][3]['status'] );
+assert( 'passed' === $result['cases'][4]['status'] );
+assert( 'passed' === $result['cases'][5]['status'] );
+assert( 'command-target' === $result['cases'][6]['id'] );
+assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][6]['skipReason'] );
+assert( 'runtime-target' === $result['cases'][7]['id'] );
+assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][7]['skipReason'] );
+assert( 'runtime-action-wp-cli' === $result['cases'][8]['id'] );
+assert( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported' === $result['cases'][8]['skipReason'] );
+assert( 'wordpress.wp-cli' === $result['cases'][8]['metadata']['observations'][0]['command'] );
+assert( 'wp_codebox_fuzz_runtime_action_php_unsupported' === $result['cases'][9]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_unsupported' === $result['cases'][10]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported' === $result['cases'][11]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported' === $result['cases'][12]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported' === $result['cases'][13]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_page_unsupported' === $result['cases'][14]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_unsupported' === $result['cases'][15]['skipReason'] );
 
 $unsafe = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 	array(


### PR DESCRIPTION
## Summary
- Add structured skip output for public fuzz-suite target kinds that the PHP in-process runner cannot execute.
- Preserve execution for safe PHP-supported REST, same-site HTTP, and ability targets.
- Document public target behavior and skip reason codes.

## Testing
- npm run test:php-fuzz-suite-runner
- npm run test:fuzz-suite-runner
- npm run test:public-api-contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the structured skip contract, tests, docs, and PR preparation.