### PR TITLE
Add non-blocking preview leases

### DIFF
--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -8,6 +8,7 @@ import { runRecipeBuildCommand } from "./commands/recipe-build.js"
 import { runRecipeRunCommand, runRecipeValidateCommand } from "./commands/recipe-run.js"
 import { runMaterializeReplayPackageCommand } from "./commands/replay-package.js"
 import { runMcpRenderClientConfigsCommand } from "./commands/mcp.js"
+import { runPreviewLeaseReleaseCommand, runPreviewLeaseStatusCommand } from "./commands/preview-lease.js"
 import { runBootCommand, runRunCommand, runValidateBlueprintCommand } from "./commands/runtime.js"
 import { runRunsArtifactsCommand, runRunsCancelCommand, runRunsStatusCommand } from "./commands/runs.js"
 import { runTargetProvisionCommand } from "./commands/target.js"
@@ -42,6 +43,8 @@ export async function runCli(args: string[]): Promise<number> {
     runsStatus: runRunsStatusCommand,
     runsArtifacts: runRunsArtifactsCommand,
     runsCancel: runRunsCancelCommand,
+    previewLeaseStatus: runPreviewLeaseStatusCommand,
+    previewLeaseRelease: runPreviewLeaseReleaseCommand,
     targetProvision: runTargetProvisionCommand,
     mcpRenderClientConfigs: runMcpRenderClientConfigsCommand,
     commands: runCommandsCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -17,6 +17,10 @@ const cliCommandRoutes = {
   "workspace-policy": {
     check: "workspacePolicyCheck",
   },
+  "preview-lease": {
+    status: "previewLeaseStatus",
+    release: "previewLeaseRelease",
+  },
   artifacts: {
     verify: "artifactsVerify",
     "apply-preflight": "artifactsApplyPreflight",

--- a/packages/cli/src/commands/preview-lease.ts
+++ b/packages/cli/src/commands/preview-lease.ts
@@ -1,0 +1,308 @@
+import { spawn } from "node:child_process"
+import { randomUUID } from "node:crypto"
+import { closeSync, openSync } from "node:fs"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+import { defaultRunRegistryDirectory, RuntimeRunRegistry, type ArtifactPreview } from "@automattic/wp-codebox-core"
+import { stripUndefined } from "@automattic/wp-codebox-core/internals"
+import { loadWorkspaceRecipe } from "../recipe-validation.js"
+
+export interface PreviewLeaseMetadata {
+  schema: "wp-codebox/preview-lease/v1"
+  leaseId: string
+  runId?: string
+  registryDirectory: string
+  leaseFile: string
+  status: "starting" | "available" | "release_requested" | "released" | "expired" | "failed"
+  pid?: number
+  createdAt: string
+  updatedAt: string
+  expiresAt?: string
+  holdSeconds?: number
+  preview?: ArtifactPreview
+  releaseCommand: string[]
+  statusCommand: string[]
+  outputFile?: string
+  error?: { name: string; message: string; code?: string }
+}
+
+interface PreviewLeaseStartOptions {
+  args: string[]
+  json: boolean
+  recipePath: string
+  artifactsDirectory?: string
+  runRegistryDirectory?: string
+  previewHoldSeconds?: number
+}
+
+interface PreviewLeaseLookupOptions {
+  leaseId?: string
+  leaseFile?: string
+  registryDirectory?: string
+  json: boolean
+}
+
+const PREVIEW_LEASE_READY_TIMEOUT_MS = 30 * 60 * 1000
+
+export async function startPreviewLeaseRecipeRun(options: PreviewLeaseStartOptions): Promise<number> {
+  if (!options.previewHoldSeconds || options.previewHoldSeconds <= 0) {
+    throw new Error("--preview-lease requires --preview-hold-seconds so the detached runtime has a bounded lifetime")
+  }
+
+  const leaseId = createPreviewLeaseId()
+  const registryDirectory = await resolvePreviewLeaseRegistryDirectory(options)
+  const leaseFile = previewLeaseFile(registryDirectory, leaseId)
+  const outputFile = join(dirname(leaseFile), `${leaseId}.recipe-run.json`)
+  const now = new Date().toISOString()
+  await writePreviewLease({
+    schema: "wp-codebox/preview-lease/v1",
+    leaseId,
+    registryDirectory,
+    leaseFile,
+    status: "starting",
+    createdAt: now,
+    updatedAt: now,
+    holdSeconds: options.previewHoldSeconds,
+    outputFile,
+    releaseCommand: previewLeaseReleaseCommand(registryDirectory, leaseId),
+    statusCommand: previewLeaseStatusCommand(registryDirectory, leaseId),
+  })
+
+  const executable = process.argv[1]
+  if (!executable) {
+    throw new Error("Unable to resolve wp-codebox CLI entrypoint for preview lease child")
+  }
+  await mkdir(dirname(outputFile), { recursive: true })
+  const stdoutFd = openSync(outputFile, "a")
+  const stderrFd = openSync(`${outputFile}.stderr`, "a")
+
+  const child = spawn(process.execPath, [...process.execArgv, executable, "recipe-run", ...withoutPreviewLeaseFlag(options.args), "--json", "--preview-hold-blocking", "--preview-lease-child", "--preview-lease-id", leaseId, "--preview-lease-file", leaseFile], {
+    detached: true,
+    stdio: ["ignore", stdoutFd, stderrFd],
+    env: {
+      ...process.env,
+      WP_CODEBOX_PREVIEW_LEASE_CHILD: "1",
+    },
+  })
+  closeSync(stdoutFd)
+  closeSync(stderrFd)
+  child.unref()
+
+  await updatePreviewLease(leaseFile, { pid: child.pid })
+  const lease = await waitForPreviewLease(leaseFile, child.pid)
+  printPreviewLeaseOutput(lease, options.json)
+  return lease.status === "available" ? 0 : 1
+}
+
+export async function markPreviewLeaseAvailable(leaseFile: string, update: { runId: string; preview?: ArtifactPreview; holdSeconds?: number }): Promise<PreviewLeaseMetadata | undefined> {
+  const existing = await readPreviewLeaseOptional(leaseFile)
+  if (!existing) {
+    return undefined
+  }
+
+  return updatePreviewLease(leaseFile, {
+    runId: update.runId,
+    status: "available",
+    preview: update.preview,
+    expiresAt: update.preview?.expiresAt,
+    holdSeconds: update.holdSeconds ?? update.preview?.holdSeconds,
+  })
+}
+
+export async function markPreviewLeaseReleased(leaseFile: string | undefined, status: "released" | "expired" = "released"): Promise<void> {
+  if (!leaseFile) {
+    return
+  }
+  const existing = await readPreviewLeaseOptional(leaseFile)
+  if (!existing) {
+    return
+  }
+  await updatePreviewLease(leaseFile, { status })
+}
+
+export async function markPreviewLeaseFailed(leaseFile: string | undefined, error: unknown): Promise<void> {
+  if (!leaseFile) {
+    return
+  }
+  const existing = await readPreviewLeaseOptional(leaseFile)
+  if (!existing) {
+    return
+  }
+  await updatePreviewLease(leaseFile, { status: "failed", error: serializeLeaseError(error) })
+}
+
+export async function runPreviewLeaseStatusCommand(args: string[]): Promise<number> {
+  const options = parsePreviewLeaseLookupOptions(args)
+  const lease = await readPreviewLease(await resolvePreviewLeaseFileFromLookup(options))
+  printPreviewLeaseOutput(await refreshPreviewLeaseStatus(lease), options.json)
+  return 0
+}
+
+export async function runPreviewLeaseReleaseCommand(args: string[]): Promise<number> {
+  const options = parsePreviewLeaseLookupOptions(args)
+  const leaseFile = await resolvePreviewLeaseFileFromLookup(options)
+  const lease = await readPreviewLease(leaseFile)
+  if (lease.runId) {
+    await new RuntimeRunRegistry(lease.registryDirectory).requestCancellation(lease.runId, { reason: `preview lease ${lease.leaseId} released` })
+  }
+  const released = await updatePreviewLease(leaseFile, { status: "release_requested" })
+  printPreviewLeaseOutput(released, options.json)
+  return 0
+}
+
+function withoutPreviewLeaseFlag(args: string[]): string[] {
+  return args.filter((arg) => arg !== "--preview-lease")
+}
+
+async function waitForPreviewLease(leaseFile: string, pid: number | undefined): Promise<PreviewLeaseMetadata> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < PREVIEW_LEASE_READY_TIMEOUT_MS) {
+    const lease = await readPreviewLease(leaseFile)
+    if (lease.status !== "starting") {
+      return refreshPreviewLeaseStatus(lease)
+    }
+    if (pid && !isProcessAlive(pid)) {
+      return updatePreviewLease(leaseFile, { status: "failed", error: { name: "PreviewLeaseChildExited", message: "Preview lease child exited before publishing a preview URL." } })
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+  return updatePreviewLease(leaseFile, { status: "failed", error: { name: "PreviewLeaseTimeout", message: "Timed out waiting for preview lease child to publish a preview URL." } })
+}
+
+async function refreshPreviewLeaseStatus(lease: PreviewLeaseMetadata): Promise<PreviewLeaseMetadata> {
+  if (lease.status !== "available" || !lease.expiresAt) {
+    return lease
+  }
+  if (Date.parse(lease.expiresAt) <= Date.now()) {
+    return updatePreviewLease(lease.leaseFile, { status: "expired" })
+  }
+  return lease
+}
+
+async function resolvePreviewLeaseRegistryDirectory(options: PreviewLeaseStartOptions): Promise<string> {
+  if (options.runRegistryDirectory) {
+    return resolve(options.runRegistryDirectory)
+  }
+  if (options.artifactsDirectory) {
+    return defaultRunRegistryDirectory(options.artifactsDirectory)
+  }
+  const recipe = await loadWorkspaceRecipe(resolve(options.recipePath))
+  return defaultRunRegistryDirectory(recipe.artifacts?.directory)
+}
+
+function previewLeaseFile(registryDirectory: string, leaseId: string): string {
+  return join(resolve(registryDirectory), "preview-leases", `${leaseId}.json`)
+}
+
+async function resolvePreviewLeaseFileFromLookup(options: PreviewLeaseLookupOptions): Promise<string> {
+  if (options.leaseFile) {
+    return resolve(options.leaseFile)
+  }
+  if (!options.registryDirectory || !options.leaseId) {
+    throw new Error("Missing required preview lease lookup options: pass --lease-file or both --registry and --lease-id")
+  }
+  return previewLeaseFile(options.registryDirectory, options.leaseId)
+}
+
+async function readPreviewLease(file: string): Promise<PreviewLeaseMetadata> {
+  return JSON.parse(await readFile(file, "utf8")) as PreviewLeaseMetadata
+}
+
+async function readPreviewLeaseOptional(file: string): Promise<PreviewLeaseMetadata | undefined> {
+  try {
+    return await readPreviewLease(file)
+  } catch {
+    return undefined
+  }
+}
+
+async function updatePreviewLease(file: string, update: Partial<PreviewLeaseMetadata>): Promise<PreviewLeaseMetadata> {
+  const current = await readPreviewLease(file)
+  return writePreviewLease({ ...current, ...stripUndefined(update), updatedAt: new Date().toISOString() })
+}
+
+async function writePreviewLease(lease: PreviewLeaseMetadata): Promise<PreviewLeaseMetadata> {
+  await mkdir(dirname(lease.leaseFile), { recursive: true })
+  const temp = join(dirname(lease.leaseFile), `.${lease.leaseId}.${process.pid}.tmp`)
+  await writeFile(temp, `${JSON.stringify(lease, null, 2)}\n`)
+  await rename(temp, lease.leaseFile)
+  return lease
+}
+
+function parsePreviewLeaseLookupOptions(args: string[]): PreviewLeaseLookupOptions {
+  const options: Partial<PreviewLeaseLookupOptions> = { json: false }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === "--json") {
+      options.json = true
+      continue
+    }
+    const [name, inlineValue] = arg.split("=", 2)
+    const value = inlineValue ?? args[++index]
+    if (!name.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument: ${arg}`)
+    }
+    switch (name) {
+      case "--lease-id":
+        options.leaseId = value
+        break
+      case "--lease-file":
+        options.leaseFile = value
+        break
+      case "--registry":
+      case "--run-registry":
+        options.registryDirectory = value
+        break
+      default:
+        throw new Error(`Unknown option: ${name}`)
+    }
+  }
+  return options as PreviewLeaseLookupOptions
+}
+
+function printPreviewLeaseOutput(lease: PreviewLeaseMetadata, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(lease, null, 2)}\n`)
+    return
+  }
+  console.log(`WP Codebox preview lease: ${lease.leaseId}`)
+  console.log(`Status: ${lease.status}`)
+  if (lease.preview?.reviewerAccess?.openUrl) {
+    console.log(`Preview URL: ${lease.preview.reviewerAccess.openUrl}`)
+  } else if (lease.preview?.url) {
+    console.log(`Preview URL: ${lease.preview.url}`)
+  }
+  if (lease.expiresAt) {
+    console.log(`Expires at: ${lease.expiresAt}`)
+  }
+  console.log(`Status command: ${lease.statusCommand.join(" ")}`)
+  console.log(`Release command: ${lease.releaseCommand.join(" ")}`)
+}
+
+function previewLeaseReleaseCommand(registryDirectory: string, leaseId: string): string[] {
+  return ["wp-codebox", "preview-lease", "release", "--registry", registryDirectory, "--lease-id", leaseId]
+}
+
+function previewLeaseStatusCommand(registryDirectory: string, leaseId: string): string[] {
+  return ["wp-codebox", "preview-lease", "status", "--registry", registryDirectory, "--lease-id", leaseId]
+}
+
+function createPreviewLeaseId(): string {
+  return `lease_${randomUUID().replaceAll("-", "")}`
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function serializeLeaseError(error: unknown): PreviewLeaseMetadata["error"] {
+  if (error instanceof Error) {
+    return stripUndefined({ name: error.name, message: error.message, code: (error as Error & { code?: string }).code })
+  }
+  return { name: "Error", message: String(error) }
+}

--- a/packages/cli/src/commands/recipe-run-interruption.ts
+++ b/packages/cli/src/commands/recipe-run-interruption.ts
@@ -52,7 +52,7 @@ export function createRecipeInterruptionController(): RecipeInterruptionControll
       for (const signal of signals) {
         process.on(signal, handler)
       }
-      if (initialParentPid > 1) {
+      if (initialParentPid > 1 && process.env.WP_CODEBOX_PREVIEW_LEASE_CHILD !== "1") {
         parentWatcher = setInterval(() => {
           if (process.ppid === 1 || process.ppid !== initialParentPid) {
             parentDisconnectHandler()

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -13,6 +13,10 @@ export interface RecipeRunOptions {
   previewPort?: number
   previewBind?: string
   previewHoldBlocking: boolean
+  previewLease: boolean
+  previewLeaseChild: boolean
+  previewLeaseId?: string
+  previewLeaseFile?: string
   timeoutMs: number
   json: boolean
   dryRun: boolean

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -22,6 +22,7 @@ import { RecipeRunPhaseExecutor } from "./recipe-run-phase-executor.js"
 import { createRecipeInterruptionController, interruptedRecipeOutput, markRecipeArtifactsFinalized, recipeInterruptionSerializedError } from "./recipe-run-interruption.js"
 import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, printJsonFailureDiagnostic, RecipeRunTimeoutError, RecipeRuntimeCreateError, serializeRecipeRunError, writeRecipeJsonOutput } from "./recipe-run-output.js"
 import { RecipePhaseError } from "./recipe-run-phases.js"
+import { markPreviewLeaseAvailable, markPreviewLeaseFailed, markPreviewLeaseReleased, startPreviewLeaseRecipeRun } from "./preview-lease.js"
 import { importRecipeSiteSeeds } from "./recipe-site-seeds.js"
 import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRuntimeSetup, recipeRunDependencyOverlay, recipeRunExtraPlugin, recipeRunStagedFile } from "./recipe-runtime-setup.js"
 import { distributionStartupProbeFailure, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowStepIsAdvisory, runDistributionSetupArtifacts, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
@@ -31,6 +32,9 @@ const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
 export async function runRecipeRunCommand(args: string[]): Promise<number> {
   const options = parseRecipeRunOptions(args)
+  if (options.previewLease && !options.previewLeaseChild) {
+    return startPreviewLeaseRecipeRun({ args, json: options.json, recipePath: options.recipePath, artifactsDirectory: options.artifactsDirectory, runRegistryDirectory: options.runRegistryDirectory, previewHoldSeconds: options.previewHoldSeconds })
+  }
   const interruption = options.dryRun ? undefined : createRecipeInterruptionController()
   interruption?.install()
   const execute = (): Promise<RecipeRunCommandOutput> => options.dryRun ? dryRunRecipe(options, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec }) : runRecipe(options, interruption)
@@ -298,9 +302,24 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       Object.assign(evidence, previewAgentEvidence)
     }
     const runtimeInfo = successfulRecipe && options.previewHoldSeconds ? await runtime.info() : undefined
+    if (successfulRecipe && options.previewLeaseChild && options.previewLeaseFile) {
+      await markPreviewLeaseAvailable(options.previewLeaseFile, { runId: runRecord.runId, preview: artifacts.preview, holdSeconds: options.previewHoldSeconds })
+    }
     const activeRuntime = runtime
     cleanupEvidence = await runRecipeCleanup(runRegistry, runRecord, async () => {
-      await awaitRecipe("runtime.release", releaseRuntime(activeRuntime, successfulRecipe && options.previewHoldBlocking ? options.previewHoldSeconds : 0))
+      await awaitRecipe("runtime.release", async () => {
+        try {
+          await releaseRuntime(activeRuntime, successfulRecipe && options.previewHoldBlocking ? options.previewHoldSeconds : 0, async () => {
+            await markPreviewLeaseReleased(options.previewLeaseFile)
+          }, interruption)
+        } catch (error) {
+          if (!options.previewLeaseChild || interruption?.metadata?.reason !== "run-cancellation-request") {
+            throw error
+          }
+          await markPreviewLeaseReleased(options.previewLeaseFile)
+          interruption.clear()
+        }
+      })
       await cleanupRecipePreparedSources(workspaceMounts, extraPlugins, stagedFiles, overlays, dependencyOverlays)
       await cleanupInputMountBaselines(inputMountBaselinePaths)
     })
@@ -355,6 +374,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }),
     })
   } catch (error) {
+    await markPreviewLeaseFailed(options.previewLeaseFile, error)
     const serializedError = interruption?.metadata ? recipeInterruptionSerializedError(interruption.metadata) : serializeRecipeRunError(error)
     const failureDiagnostics = recipeFailureRuntimeEvidenceFile({
       recipe,
@@ -563,7 +583,7 @@ function normalizeRuntimeEnv(values: Record<string, unknown>): Record<string, st
 }
 
 function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
-  const parsed = parseCommandOptions(args, new Set(["--json", "--dry-run", "--preview-hold-blocking"]))
+  const parsed = parseCommandOptions(args, new Set(["--json", "--dry-run", "--preview-hold-blocking", "--preview-lease", "--preview-lease-child"]))
   if (parsed.positionals.length > 0) {
     throw new Error(`Invalid argument: ${parsed.positionals[0]}`)
   }
@@ -571,6 +591,8 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
     json: parsed.options.get("--json") === true,
     dryRun: parsed.options.get("--dry-run") === true,
     previewHoldBlocking: parsed.options.get("--preview-hold-blocking") === true,
+    previewLease: parsed.options.get("--preview-lease") === true,
+    previewLeaseChild: parsed.options.get("--preview-lease-child") === true,
     timeoutMs: DEFAULT_RECIPE_RUN_TIMEOUT_MS,
   }
   for (const [name, value] of parsed.options) {
@@ -598,6 +620,12 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
         break
       case "--preview-bind":
         options.previewBind = parsePreviewBind(value)
+        break
+      case "--preview-lease-id":
+        options.previewLeaseId = value
+        break
+      case "--preview-lease-file":
+        options.previewLeaseFile = value
         break
       case "--timeout":
         options.timeoutMs = parseRecipeRunTimeoutMs(value)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -312,6 +312,8 @@ export function printHelp(): void {
   wp-codebox runs status --registry <dir> --run-id <id> [--json]
   wp-codebox runs artifacts --registry <dir> --run-id <id> [--json]
   wp-codebox runs cancel --registry <dir> --run-id <id> [--reason <text>] [--json]
+  wp-codebox preview-lease status (--registry <dir> --lease-id <id>|--lease-file <path>) [--json]
+  wp-codebox preview-lease release (--registry <dir> --lease-id <id>|--lease-file <path>) [--json]
   wp-codebox target provision [--id <id>] [--kind <kind>] [--workspace-root <dir>] [--json]
   wp-codebox run-agent-task --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
   wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
@@ -368,6 +370,8 @@ Options:
                        Durable run registry directory for recipe-run.
   --registry <dir>    Durable run registry directory for runs lookup commands.
   --run-id <id>       Run ID for runs lookup commands.
+  --lease-id <id>     Preview lease ID for preview-lease status/release.
+  --lease-file <path> Preview lease metadata file for preview-lease status/release.
   --id <id>           Target id for target provision. Defaults to default.
   --kind <kind>       Target kind for target provision. Defaults to generic.
   --artifact-public-url-root <url>
@@ -387,6 +391,7 @@ Options:
   --artifacts <dir>    Artifact root directory.
   --preview-hold-seconds <n>
                        Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
+  --preview-lease     Return after the preview is available while a detached child keeps the runtime alive until released or expired.
   --preview-port <n>   Start Playground on a fixed local port. Defaults to a random available port.
   --preview-bind <host>
                        Host/IP for the fixed-port WP Codebox preview proxy. Requires --preview-port.


### PR DESCRIPTION
## Summary
- add a non-blocking preview lease mode for recipe runs
- add preview-lease status and release commands
- persist lease metadata with preview URL, expiry, and release/status commands

## Testing
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the preview lease CLI/runtime changes and drafting this PR description.