### PR TITLE
Forward preview options through agent task runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,7 +1349,12 @@ Caller-owned runtime components can provide workspace, file, GitHub, or other to
 Parent orchestrators that already own task state can call the same API instead of generating a low-level WP Codebox recipe. The stable CLI entry point is:
 
 ```bash
-wp-codebox agent-task-run --input-file=/path/to/request.json --json
+wp-codebox agent-task-run --input-file=/path/to/request.json --json \
+  --preview-hold-seconds 300 \
+  --preview-hold-blocking \
+  --preview-port 4173 \
+  --preview-bind 127.0.0.1 \
+  --preview-public-url https://preview.example.test
 ```
 
 Generic caller-owned `request.json` payloads may use this shape:

--- a/docs/agent-runtime-contract.md
+++ b/docs/agent-runtime-contract.md
@@ -7,7 +7,12 @@ WP Codebox exposes a stable, product-neutral sandbox runtime boundary. External 
 The stable orchestrator-facing CLI entry point is:
 
 ```bash
-wp-codebox agent-task-run --input-file=/path/to/request.json --json
+wp-codebox agent-task-run --input-file=/path/to/request.json --json \
+  --preview-hold-seconds 300 \
+  --preview-hold-blocking \
+  --preview-port 4173 \
+  --preview-bind 127.0.0.1 \
+  --preview-public-url https://preview.example.test
 ```
 
 The command reads one JSON request from `--input-file`, writes a single JSON envelope to stdout, and exits non-zero when the normalized result is not successful. Orchestrators should treat stdout JSON as the contract and stderr as diagnostic text only.

--- a/packages/cli/src/agent-fanout.ts
+++ b/packages/cli/src/agent-fanout.ts
@@ -11,6 +11,9 @@ export interface AgentFanoutExecutionOptions {
   recipeDirectory: string
   previewHoldSeconds?: string
   previewPublicUrl?: string
+  previewPort?: string
+  previewBind?: string
+  previewHoldBlocking?: boolean
   sessionId?: string
   clock?: RunPlanClock
   runWorker?: (input: AgentTaskRunInput, options: AgentTaskRunOptions) => Promise<AgentFanoutWorkerOutput>
@@ -178,6 +181,9 @@ function agentTaskFanoutWorkerAdapter(request: FanoutRequestContract, options: A
           json: true,
           previewHoldSeconds: options.previewHoldSeconds ?? "",
           previewPublicUrl: options.previewPublicUrl ?? "",
+          previewPort: options.previewPort ?? "",
+          previewBind: options.previewBind ?? "",
+          previewHoldBlocking: options.previewHoldBlocking ?? false,
         })
         const status = normalizeAgentTaskStatus({ status: output.status, success: output.success })
         const success = agentTaskStatusSucceeded(status)

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -10,8 +10,11 @@ export type { AgentTaskRunInput } from "@automattic/wp-codebox-core"
 export interface AgentTaskRunOptions {
   inputPath: string
   json: boolean
-  previewHoldSeconds: string
-  previewPublicUrl: string
+  previewHoldSeconds?: string
+  previewPublicUrl?: string
+  previewPort?: string
+  previewBind?: string
+  previewHoldBlocking?: boolean
 }
 
 interface AgentTaskRunOutput {
@@ -106,6 +109,15 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     const recipeRunArgs = ["--recipe", recipePath, "--artifacts", artifacts, "--json"]
     if (options.previewHoldSeconds) {
       recipeRunArgs.push("--preview-hold-seconds", options.previewHoldSeconds)
+    }
+    if (options.previewPort) {
+      recipeRunArgs.push("--preview-port", options.previewPort)
+    }
+    if (options.previewBind) {
+      recipeRunArgs.push("--preview-bind", options.previewBind)
+    }
+    if (options.previewHoldBlocking) {
+      recipeRunArgs.push("--preview-hold-blocking")
     }
     if (options.previewPublicUrl) {
       recipeRunArgs.push("--preview-public-url", options.previewPublicUrl)
@@ -331,12 +343,12 @@ export async function buildAgentRuntimeDiagnostics(run: Record<string, unknown>,
 }
 
 function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
-  const { options, positionals } = parseCommandOptions(args, new Set(["--json"]))
+  const { options, positionals } = parseCommandOptions(args, new Set(["--json", "--preview-hold-blocking"]))
   if (positionals.length > 0) {
     throw new Error(`Unknown agent-task-run option: ${positionals[0]}`)
   }
   for (const name of options.keys()) {
-    if (!["--input-file", "--json", "--format", "--preview-hold-seconds", "--preview-public-url"].includes(name)) {
+    if (!["--input-file", "--json", "--format", "--preview-hold-seconds", "--preview-public-url", "--preview-port", "--preview-bind", "--preview-hold-blocking"].includes(name)) {
       throw new Error(`Unknown agent-task-run option: ${name}`)
     }
   }
@@ -349,6 +361,9 @@ function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
     json: options.get("--json") === true || stringOption(options, "--format") === "json",
     previewHoldSeconds: stringOption(options, "--preview-hold-seconds"),
     previewPublicUrl: stringOption(options, "--preview-public-url"),
+    previewPort: stringOption(options, "--preview-port"),
+    previewBind: stringOption(options, "--preview-bind"),
+    previewHoldBlocking: options.get("--preview-hold-blocking") === true,
   }
 }
 

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -134,6 +134,9 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
         recipeDirectory,
         previewHoldSeconds: options?.previewHoldSeconds === undefined ? "" : String(options.previewHoldSeconds),
         previewPublicUrl: options?.previewPublicUrl,
+        previewPort: options?.previewPort === undefined ? "" : String(options.previewPort),
+        previewBind: options?.previewBind,
+        previewHoldBlocking: options?.previewHoldBlocking,
       })
       const finishedAt = new Date().toISOString()
       return {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -313,8 +313,8 @@ export function printHelp(): void {
   wp-codebox runs artifacts --registry <dir> --run-id <id> [--json]
   wp-codebox runs cancel --registry <dir> --run-id <id> [--reason <text>] [--json]
   wp-codebox target provision [--id <id>] [--kind <kind>] [--workspace-root <dir>] [--json]
-  wp-codebox run-agent-task --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
-  wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-public-url <url>]
+  wp-codebox run-agent-task --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>]
+  wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>]
   wp-codebox validate-blueprint --blueprint <json|file> [options]
   wp-codebox materialize-replay-package --snapshot <path> --output <dir> [--snapshot-ref <ref>] [--json]
   wp-codebox recipe-run --recipe <path> [options]
@@ -328,6 +328,12 @@ Options:
   --input-file <path> Agent task input JSON for run-agent-task/agent-task-run.
   --preview-hold-seconds <n>
                     Keep preview runtimes alive after run-agent-task/agent-task-run/recipe-run.
+  --preview-hold-blocking
+                    Block before releasing held previews after run-agent-task/agent-task-run/recipe-run.
+  --preview-port <port>
+                    Fixed local preview proxy port for run-agent-task/agent-task-run/recipe-run.
+  --preview-bind <host>
+                    Bind host or IP for a fixed preview proxy port. Requires --preview-port.
   --preview-public-url <url>
                     Public preview URL passed through to run-agent-task/agent-task-run/recipe-run.
   --bundle <dir>      Artifact bundle directory for artifact verification/probe commands.


### PR DESCRIPTION
## Summary
- expose full preview options on agent-task-run/run-agent-task
- forward preview options through fanout-backed agent runs
- document preview option usage for agent task execution

## Testing
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing preview option forwarding and drafting this PR description.