### PR TITLE
Apply distribution runtime setup subset

### DIFF
--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -220,7 +220,7 @@ export interface RecipeDiagnosticArtifactRef {
   sha256?: string
 }
 
-export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "import_fixture_databases" | "run_distribution_setup_artifacts" | "run_distribution_startup_probes" | "run_workloads" | "run_probes" | "collect_artifacts"
+export type RecipePhaseName = "runtime_startup" | "mount_plugins" | "activate_plugins" | "run_blueprint_steps" | "apply_distribution" | "import_fixture_databases" | "run_distribution_setup_artifacts" | "run_distribution_startup_probes" | "run_workloads" | "run_probes" | "collect_artifacts"
 
 export interface RecipePhaseEvidence {
   schema: "wp-codebox/recipe-phase-evidence/v1"

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -99,7 +99,10 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
 
   const plan = await planWorkspaceRecipe(recipe, recipeDirectory, { recipePath, artifactsDirectory: configuredArtifactsDirectory }, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec })
   const { valid: _policyValid, issues: _policyIssues, ...policy } = plan.policy
-  const runtimeEnv = normalizeRuntimeEnv(recipe.inputs?.runtimeEnv ?? {})
+  const runtimeEnv = {
+    ...distributionRuntimeEnv(recipe),
+    ...normalizeRuntimeEnv(recipe.inputs?.runtimeEnv ?? {}),
+  }
   const secretEnvResolution = resolveRecipeSecretEnv(recipe.inputs?.secretEnv ?? [], { field: "--secret-env name" })
   const secretEnv = secretEnvResolution.values
   const effectivePolicy = Object.keys(secretEnv).length > 0 ? { ...policy, secrets: "connector-scoped" as const } : policy
@@ -560,6 +563,17 @@ async function validateRecipe(options: RecipeValidateOptions): Promise<RecipeVal
 
 function normalizeRuntimeEnv(values: Record<string, unknown>): Record<string, string> {
   return normalizeRuntimeEnvRecord(values, { field: "inputs.runtimeEnv", invalid: "omit" })
+}
+
+function distributionRuntimeEnv(recipe: WorkspaceRecipe): Record<string, string> {
+  const values: Record<string, string> = {}
+  for (const [name, value] of Object.entries(recipe.distribution?.env ?? {})) {
+    if (value === null || ["string", "number", "boolean"].includes(typeof value)) {
+      values[name] = value === null ? "" : String(value)
+    }
+  }
+
+  return normalizeRuntimeEnvRecord(values, { field: "distribution.env", invalid: "omit" })
 }
 
 function parseRecipeRunOptions(args: string[]): RecipeRunOptions {

--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -71,6 +71,28 @@ export async function applyRecipeRuntimeSetup(args: {
     interruption?.throwIfInterrupted()
   }
 
+  for (const [index, mount] of (recipe.distribution?.sourceMounts ?? []).entries()) {
+    const source = resolve(recipeDirectory, mount.source)
+    await awaitRecipe(`distribution.source-mount[${index}]:${mount.target}`, runtime.mount({
+      type: await recipeMountType(source, mount.type),
+      source,
+      target: mount.target,
+      mode: mount.mode ?? "readonly",
+      metadata: {
+        kind: "distribution-source-mount",
+        index,
+        ...(mount.role ? { role: mount.role } : {}),
+        ...(mount.ref ? { ref: mount.ref } : {}),
+        ...(mount.metadata ?? {}),
+      },
+    }))
+    interruption?.throwIfInterrupted()
+  }
+
+  if (recipe.distribution) {
+    phaseTracker.complete("apply_distribution", distributionRuntimeData(recipe))
+  }
+
   for (const overlay of overlays) {
     await awaitRecipe(`runtime.overlay.mount:${overlay.target}`, runtime.mount({
       type: overlay.type,
@@ -280,6 +302,38 @@ function phasePluginActivationData(activatedPlugins: PreparedExtraPlugin[]): Rec
   return {
     count: activatedPlugins.length,
     plugins: activatedPlugins.map((plugin) => ({ slug: plugin.slug, pluginFile: plugin.pluginFile })),
+  }
+}
+
+function distributionRuntimeData(recipe: WorkspaceRecipe): Record<string, unknown> {
+  const distribution = recipe.distribution
+  if (!distribution) {
+    return { applied: [], unsupported: [] }
+  }
+
+  const applied = [
+    ...(Object.keys(distribution.env ?? {}).length > 0 ? [{ field: "env", action: "runtimeEnv+bootstrap", count: Object.keys(distribution.env ?? {}).length }] : []),
+    ...(Object.keys(distribution.constants ?? {}).length > 0 ? [{ field: "constants", action: "bootstrap", count: Object.keys(distribution.constants ?? {}).length }] : []),
+    ...((distribution.sourceMounts ?? []).map((mount, index) => ({ field: `sourceMounts[${index}]`, action: "mounted", target: mount.target, mode: mount.mode ?? "readonly" }))),
+    ...((distribution.setupArtifacts ?? []).map((artifact, index) => ({ field: `setupArtifacts[${index}]`, action: "applied-by-run_distribution_setup_artifacts", name: artifact.name, type: artifact.type }))),
+    ...((distribution.startupProbes ?? []).map((probe, index) => ({ field: `startupProbes[${index}]`, action: "applied-by-run_distribution_startup_probes", name: probe.name, type: probe.type }))),
+  ]
+  const unsupported = [
+    ...(distribution.wordpress.root ? [{ field: "wordpress.root", reason: "runtime WordPress root selection is still controlled by runtime.assets.wordpressDirectory" }] : []),
+    ...(distribution.wordpress.config ? [{ field: "wordpress.config", reason: "custom wp-config file declarations are not applied by this runtime subset" }] : []),
+    ...(distribution.wordpress.bootstrap && distribution.wordpress.bootstrap !== "standard" ? [{ field: "wordpress.bootstrap", reason: "custom/external bootstrap modes are not applied by this runtime subset" }] : []),
+    ...(distribution.wordpress.bootstrapFile ? [{ field: "wordpress.bootstrapFile", reason: "custom bootstrap files are not applied by this runtime subset" }] : []),
+    ...((distribution.serviceFakes ?? []).map((fake, index) => ({ field: `serviceFakes[${index}]`, reason: `service fake '${fake.name}' is declaration-only` }))),
+    ...((distribution.routeAliases ?? []).map((alias, index) => ({ field: `routeAliases[${index}]`, reason: `route alias '${alias.name ?? alias.path ?? alias.host ?? index}' is declaration-only` }))),
+    ...((distribution.artifacts ?? []).map((artifact, index) => ({ field: `artifacts[${index}]`, reason: `distribution artifact '${artifact.path}' is not collected by this runtime subset` }))),
+    ...((distribution.safety?.allowedHosts ?? []).map((host, index) => ({ field: `safety.allowedHosts[${index}]`, reason: `network host '${host}' is not enforced by this runtime subset` }))),
+    ...((distribution.safety?.secretEnv ?? []).map((name, index) => ({ field: `safety.secretEnv[${index}]`, reason: `distribution secret env '${name}' is not resolved by this runtime subset` }))),
+  ]
+
+  return {
+    name: distribution.name,
+    applied,
+    unsupported,
   }
 }
 

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -12,6 +12,7 @@ import { basename, dirname, join } from "node:path"
 import { createServer as createNetServer } from "node:net"
 import * as PlaygroundStorage from "@wp-playground/storage"
 import { resolveWordPressRelease } from "@wp-playground/wordpress"
+import { phpEnvAssignments, phpWpConfigDefineAssignments } from "./php-snippets.js"
 
 export interface PlaygroundCliModule {
   runCLI(options: {
@@ -68,7 +69,7 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
     })
     const wordpressDirectory = spec.environment.assets?.wordpressDirectory
     const wordpressInstallMode = spec.environment.wordpressInstallMode ?? "install-from-existing-files"
-    const bootstrapIniEntries = pluginRuntimeBootstrapPhpIniEntries(spec)
+    const bootstrapIniEntries = runtimeBootstrapPhpIniEntries(spec)
     const useProgrammaticRunner = shouldUseProgrammaticPlaygroundRunner(spec, options)
     const wordpressStartupAsset = wordpressDirectory ? undefined : await resolvePlaygroundWordPressStartupAsset(spec.environment.version, spec.environment.assets?.wordpressZip)
     const cacheValidation = wordpressStartupAsset?.cacheValidation ?? {
@@ -164,11 +165,11 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
 }
 
 export function shouldUseProgrammaticPlaygroundRunner(spec: RuntimeCreateSpec, options: PlaygroundCliStartupOptions = {}): boolean {
-  return !options.cliModule && Boolean(spec.environment.assets?.wordpressDirectory) && Boolean(pluginRuntimeBootstrapPhpIniEntries(spec))
+  return !options.cliModule && Boolean(spec.environment.assets?.wordpressDirectory) && Boolean(runtimeBootstrapPhpIniEntries(spec))
 }
 
 async function pluginRuntimeBootstrapSharedMount(spec: RuntimeCreateSpec): Promise<{ hostPath: string; vfsPath: string } | undefined> {
-  const iniEntries = pluginRuntimeBootstrapPhpIniEntries(spec)
+  const iniEntries = runtimeBootstrapPhpIniEntries(spec)
   if (!iniEntries) {
     return undefined
   }
@@ -178,9 +179,18 @@ async function pluginRuntimeBootstrapSharedMount(spec: RuntimeCreateSpec): Promi
   await mkdir(join(directory, "mu-plugins"), { recursive: true })
   await mkdir(join(directory, "preload"), { recursive: true })
   await writeFile(join(directory, "php.ini"), phpIniContent(iniEntries), "utf8")
-  await writeFile(join(directory, "auto_prepend_file.php"), "<?php\n", "utf8")
+  await writeFile(join(directory, "auto_prepend_file.php"), runtimeAutoPrependPhp(spec), "utf8")
 
   return { hostPath: directory, vfsPath: "/internal/shared" }
+}
+
+function runtimeBootstrapPhpIniEntries(spec: RuntimeCreateSpec): Record<string, string> | undefined {
+  const entries = pluginRuntimeBootstrapPhpIniEntries(spec) ?? {}
+  if (Object.keys(entries).length === 0 && !distributionBootstrapPhp(spec)) {
+    return undefined
+  }
+
+  return entries
 }
 
 function pluginRuntimeBootstrapPhpIniEntries(spec: RuntimeCreateSpec): Record<string, string> | undefined {
@@ -239,6 +249,45 @@ function phpIniContent(entries: Record<string, string>): string {
   }
 
   return `${lines.join("\n")}\n`
+}
+
+function runtimeAutoPrependPhp(spec: RuntimeCreateSpec): string {
+  return `<?php\n${distributionBootstrapPhp(spec)}`
+}
+
+function distributionBootstrapPhp(spec: RuntimeCreateSpec): string {
+  const distribution = recipeDistribution(spec)
+  if (!distribution) {
+    return ""
+  }
+
+  const lines = [
+    phpEnvAssignments(distributionEnv(distribution.env)),
+    phpWpConfigDefineAssignments(distribution.constants ?? {}),
+  ].filter(Boolean)
+
+  return lines.length > 0 ? `${lines.join("")}\n` : ""
+}
+
+function recipeDistribution(spec: RuntimeCreateSpec): { env?: Record<string, unknown>; constants?: Record<string, unknown> } | undefined {
+  const recipe = spec.metadata?.recipe
+  if (!recipe || typeof recipe !== "object" || Array.isArray(recipe)) {
+    return undefined
+  }
+
+  const distribution = (recipe as { distribution?: unknown }).distribution
+  return distribution && typeof distribution === "object" && !Array.isArray(distribution) ? distribution as { env?: Record<string, unknown>; constants?: Record<string, unknown> } : undefined
+}
+
+function distributionEnv(values: Record<string, unknown> | undefined): Record<string, unknown> {
+  const env: Record<string, unknown> = {}
+  for (const [name, value] of Object.entries(values ?? {})) {
+    if (value === null || ["string", "number", "boolean"].includes(typeof value)) {
+      env[name] = value === null ? "" : String(value)
+    }
+  }
+
+  return env
 }
 
 function playgroundCliBlueprint(spec: RuntimeCreateSpec): unknown {

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -58,7 +58,7 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
     phpIniEntries,
     createFiles: {
       "/internal/shared/php.ini": options.sharedPhpIniContent,
-      "/internal/shared/auto_prepend_file.php": "<?php\n",
+      "/internal/shared/auto_prepend_file.php": autoPrependPhp(spec),
       "/internal/shared/mu-plugins/.keep": "",
       "/internal/shared/preload/.keep": "",
     },
@@ -99,6 +99,48 @@ export async function startProgrammaticPlaygroundServer(spec: RuntimeCreateSpec,
       await requestHandler[Symbol.asyncDispose]()
     },
   }
+}
+
+function autoPrependPhp(spec: RuntimeCreateSpec): string {
+  const recipe = spec.metadata?.recipe
+  if (!recipe || typeof recipe !== "object" || Array.isArray(recipe)) {
+    return "<?php\n"
+  }
+
+  const distribution = (recipe as { distribution?: unknown }).distribution
+  if (!distribution || typeof distribution !== "object" || Array.isArray(distribution)) {
+    return "<?php\n"
+  }
+
+  const env = (distribution as { env?: unknown }).env
+  const constants = (distribution as { constants?: unknown }).constants
+  const lines: string[] = []
+  if (env && typeof env === "object" && !Array.isArray(env)) {
+    for (const [name, value] of Object.entries(env)) {
+      if (/^[A-Z_][A-Z0-9_]*$/.test(name) && (value === null || ["string", "number", "boolean"].includes(typeof value))) {
+        lines.push(`putenv(${JSON.stringify(`${name}=${value === null ? "" : String(value)}`)});`)
+      }
+    }
+  }
+  if (constants && typeof constants === "object" && !Array.isArray(constants)) {
+    for (const [name, value] of Object.entries(constants)) {
+      if (/^[A-Z_][A-Z0-9_]*$/i.test(name) && (value === null || ["string", "number", "boolean"].includes(typeof value))) {
+        lines.push(`if (!defined(${JSON.stringify(name)})) { define(${JSON.stringify(name)}, ${phpLiteral(value)}); }`)
+      }
+    }
+  }
+
+  return `<?php\n${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`
+}
+
+function phpLiteral(value: string | number | boolean | null): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value)
+  }
+  if (value === null) {
+    return "null"
+  }
+  return String(value)
 }
 
 async function mountHostDirectory(php: ProgrammaticPHP, vfsPath: string, hostPath: string): Promise<void> {

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -74,6 +74,34 @@ try {
   assert.match(await readFile(join(sharedMount as string, "auto_prepend_file.php"), "utf8"), /<\?php/)
   assert.equal((await stat(join(sharedMount as string, "mu-plugins"))).isDirectory(), true)
   assert.equal((await stat(join(sharedMount as string, "preload"))).isDirectory(), true)
+
+  calls.length = 0
+  const distributionOnlySpec: RuntimeCreateSpec = {
+    ...spec,
+    metadata: {
+      recipe: {
+        distribution: {
+          name: "branch-preview",
+          wordpress: { root: "/wordpress" },
+          env: { WPCOM_BRANCH: "feature/example", FEATURE_ENABLED: true, EMPTY_VALUE: null },
+          constants: { WPCOM_IS_BRANCH_PREVIEW: true, WPCOM_BRANCH_ID: 123 },
+        },
+      },
+    },
+  }
+
+  const distributionOnlyServer = await startPlaygroundCliServer(distributionOnlySpec, [], { cliModule })
+  await distributionOnlyServer[Symbol.asyncDispose]()
+
+  assert.equal(calls.length, 1)
+  const distributionSharedMount = calls[0]["mount-before-install"]?.[0]?.hostPath
+  assert.equal(typeof distributionSharedMount, "string")
+  const distributionAutoPrepend = await readFile(join(distributionSharedMount as string, "auto_prepend_file.php"), "utf8")
+  assert.match(distributionAutoPrepend, /putenv\("WPCOM_BRANCH=feature\/example"\);/)
+  assert.match(distributionAutoPrepend, /putenv\("FEATURE_ENABLED=true"\);/)
+  assert.match(distributionAutoPrepend, /putenv\("EMPTY_VALUE="\);/)
+  assert.match(distributionAutoPrepend, /define\("WPCOM_IS_BRANCH_PREVIEW", true\)/)
+  assert.match(distributionAutoPrepend, /define\("WPCOM_BRANCH_ID", 123\)/)
 } finally {
   await rm(wordpressDirectory, { recursive: true, force: true })
   await rm(artifactsDirectory, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- apply distribution env values as runtime env additions
- apply distribution constants through Playground bootstrap
- mount declared distribution sourceMounts and report unsupported distribution features

## Testing
- npm run build
- Homeboy Lab attempted targeted test run: runner-exec-homeboy-lab-b76385b2-e2c6-4085-a78c-5c56a817eb04

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing runtime distribution setup and drafting this PR description.