### PR TITLE
Make preview hold cap configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ more than one hard link. The hard-link check uses the host platform's
 `lstat().nlink` value and fails closed if the link count cannot be determined,
 because a hard-linked file under an allowed root is not independent evidence.
 
-For interactive review, pass `--preview-hold-seconds <duration>` to keep the live preview server available briefly after artifact capture. The command emits `artifacts.preview.url` and `files/review.json` includes a matching top-level `preview` object with lifecycle and expiry details.
+For interactive review, pass `--preview-hold-seconds <duration>` to keep the live preview server available briefly after artifact capture. The command emits `artifacts.preview.url` and `files/review.json` includes a matching top-level `preview` object with lifecycle and expiry details. The hold cap defaults to 3600 seconds; local operators may raise it with `WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS` up to the hard 24-hour ceiling.
 
 ```bash
 npm run wp-codebox -- run \
@@ -785,7 +785,7 @@ npm run wp-codebox -- boot \
   --json
 ```
 
-`boot` accepts the same mount, WordPress version, policy, artifact, fixed preview port, and public preview URL setup used by the runtime commands. `--blueprint` accepts inline JSON or a path to a contained-runtime blueprint JSON file. `--preview-hold-seconds` uses the same duration syntax and 3600-second maximum as `run --preview-hold-seconds`.
+`boot` accepts the same mount, WordPress version, policy, artifact, fixed preview port, and public preview URL setup used by the runtime commands. `--blueprint` accepts inline JSON or a path to a contained-runtime blueprint JSON file. `--preview-hold-seconds` uses the same duration syntax and operator-configurable cap as `run --preview-hold-seconds`.
 
 The JSON output uses `wp-codebox/boot/v1` and includes runtime information plus the collected artifact bundle. The artifact bundle includes preview metadata, mounted-file capture, diffs, review metadata, and lifecycle logs, but no `execution` object and no fake command entry.
 

--- a/contracts/preview-options.fixture.json
+++ b/contracts/preview-options.fixture.json
@@ -5,7 +5,7 @@
       "type": "integer",
       "minimum": 0,
       "maximum": 3600,
-      "description": "Seconds to keep the live Playground preview URL available after capture. Max 3600."
+      "description": "Seconds to keep the live Playground preview URL available after capture. Max 3600 by default; operators may raise the cap with WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS."
     },
     "preview_port": {
       "type": "integer",
@@ -68,6 +68,19 @@
       "name": "hold clamps above maximum",
       "input": {
         "preview_hold_seconds": "7200"
+      },
+      "valid": true,
+      "normalized": {
+        "preview_hold_seconds": 3600,
+        "preview_port": null,
+        "preview_bind": null,
+        "preview_public_url": null
+      }
+    },
+    {
+      "name": "hour preview hold syntax clamps to default cap",
+      "input": {
+        "preview_hold_seconds": "2h"
       },
       "valid": true,
       "normalized": {

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -576,7 +576,9 @@ both files are registered as redaction-required browser artifacts and surfaced
 through `browserEvidence.files`.
 
 `--preview-hold-seconds <duration>` records held-preview lifecycle metadata in the
-artifact bundle and returns after recipe work finishes. Use
+artifact bundle and returns after recipe work finishes. The cap defaults to 3600
+seconds and can be raised by an operator with `WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS`
+up to the hard 24-hour ceiling. Use
 `--preview-hold-blocking` only for operator workflows that need the CLI process
 to keep a live preview server open for the hold duration.
 

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "test:fuzz-suite-runner": "tsx tests/fuzz-suite-runner.test.ts",
     "test:wordpress-fuzz-suite-builders": "tsx tests/wordpress-fuzz-suite-builders.test.ts",
     "test:recipe-secret-env": "tsx tests/recipe-secret-env.test.ts",
+    "test:preview-options": "tsx tests/preview-options.test.ts",
     "test:evidence-bundle-digest-and-recipe-artifact": "tsx tests/evidence-bundle-digest-and-recipe-artifact.test.ts",
     "test:runtime-overlay-descriptors": "tsx tests/runtime-overlay-descriptors.test.ts",
     "test:runtime-preset-registry": "tsx tests/runtime-preset-registry.test.ts",

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -330,6 +330,7 @@ Options:
   --input-file <path> Agent task input JSON for run-agent-task/agent-task-run.
   --preview-hold-seconds <n>
                     Keep preview runtimes alive after run-agent-task/agent-task-run/recipe-run.
+                    Max 3600s by default; operators may raise the cap with WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS.
   --preview-hold-blocking
                     Block before releasing held previews after run-agent-task/agent-task-run/recipe-run.
   --preview-port <port>
@@ -396,7 +397,7 @@ Options:
   --snapshot-ref <ref>  Optional external reference for the input snapshot source metadata.
   --artifacts <dir>    Artifact root directory.
   --preview-hold-seconds <n>
-                       Keep the live Playground preview available after a successful run. Accepts seconds or minutes, e.g. 30s or 15m; max 3600s.
+                       Keep the live Playground preview available after a successful run. Accepts seconds, minutes, or hours, e.g. 30s, 15m, or 2h; max 3600s unless WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS raises the cap.
   --preview-lease     Return after the preview is available while a detached child keeps the runtime alive until released or expired.
   --preview-port <n>   Start Playground on a fixed local port. Defaults to a random available port.
   --preview-bind <host>

--- a/packages/cli/src/preview-options.ts
+++ b/packages/cli/src/preview-options.ts
@@ -1,4 +1,7 @@
-export const PREVIEW_HOLD_MAX_SECONDS = 3600
+export const PREVIEW_HOLD_DEFAULT_MAX_SECONDS = 3600
+export const PREVIEW_HOLD_MAX_SECONDS = PREVIEW_HOLD_DEFAULT_MAX_SECONDS
+export const PREVIEW_HOLD_HARD_MAX_SECONDS = 24 * 60 * 60
+export const PREVIEW_HOLD_MAX_SECONDS_ENV = "WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS"
 export const PREVIEW_PORT_MIN = 1
 export const PREVIEW_PORT_MAX = 65535
 
@@ -27,8 +30,8 @@ export const previewInputSchema = {
   preview_hold_seconds: {
     type: "integer",
     minimum: 0,
-    maximum: PREVIEW_HOLD_MAX_SECONDS,
-    description: "Seconds to keep the live Playground preview URL available after capture. Max 3600.",
+    maximum: PREVIEW_HOLD_DEFAULT_MAX_SECONDS,
+    description: `Seconds to keep the live Playground preview URL available after capture. Max ${PREVIEW_HOLD_DEFAULT_MAX_SECONDS} by default; operators may raise the cap with ${PREVIEW_HOLD_MAX_SECONDS_ENV}.`,
   },
   preview_port: {
     type: "integer",
@@ -68,6 +71,10 @@ export function parsePreviewHoldSeconds(value: unknown): number {
   return parsePreviewHoldSecondsValue(value)
 }
 
+export function previewHoldMaxSeconds(source: Record<string, string | undefined> = process.env): number {
+  return parsePreviewHoldMaxSeconds(source[PREVIEW_HOLD_MAX_SECONDS_ENV])
+}
+
 export function parsePreviewPort(value: unknown): number {
   const port = parsePreviewPortValue(value, "--preview-port")
   if (port === null) {
@@ -93,14 +100,34 @@ export function parsePreviewPublicUrl(value: unknown): string {
 }
 
 function parsePreviewHoldSecondsValue(value: unknown): number {
+  const maxSeconds = previewHoldMaxSeconds()
   const raw = String(value).trim()
-  const match = raw.match(/^(\d+)(s|m)?$/)
-  const seconds = match ? Number.parseInt(match[1], 10) * (match[2] === "m" ? 60 : 1) : Number.parseInt(raw, 10)
+  const match = raw.match(/^(\d+)(s|m|h)?$/)
+  const seconds = match ? Number.parseInt(match[1], 10) * (match[2] === "h" ? 3600 : match[2] === "m" ? 60 : 1) : Number.parseInt(raw, 10)
   if (!Number.isFinite(seconds)) {
     return 0
   }
 
-  return Math.max(0, Math.min(PREVIEW_HOLD_MAX_SECONDS, Math.floor(seconds)))
+  return Math.max(0, Math.min(maxSeconds, Math.floor(seconds)))
+}
+
+function parsePreviewHoldMaxSeconds(value: unknown): number {
+  if (value === undefined || value === null || String(value).trim() === "") {
+    return PREVIEW_HOLD_DEFAULT_MAX_SECONDS
+  }
+
+  const raw = String(value).trim()
+  const match = raw.match(/^(\d+)(s|m|h)?$/)
+  if (!match) {
+    throw new PreviewOptionError("wp_codebox_preview_hold_max_invalid", `${PREVIEW_HOLD_MAX_SECONDS_ENV} must be a duration such as 3600, 60m, or 4h.`)
+  }
+
+  const seconds = Number.parseInt(match[1], 10) * (match[2] === "h" ? 3600 : match[2] === "m" ? 60 : 1)
+  if (!Number.isSafeInteger(seconds) || seconds < PREVIEW_HOLD_DEFAULT_MAX_SECONDS || seconds > PREVIEW_HOLD_HARD_MAX_SECONDS) {
+    throw new PreviewOptionError("wp_codebox_preview_hold_max_invalid", `${PREVIEW_HOLD_MAX_SECONDS_ENV} must be between ${PREVIEW_HOLD_DEFAULT_MAX_SECONDS} and ${PREVIEW_HOLD_HARD_MAX_SECONDS} seconds.`)
+  }
+
+  return seconds
 }
 
 function parsePreviewPortValue(value: unknown, label = "preview_port"): number | null {

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -215,6 +215,8 @@ contained WordPress runtime available after artifact capture. The ability respon
 field point at the same live URL until the hold window expires. Without a hold
 window, the preview field is still recorded as evidence but marked
 `expired-on-completion` because the sandbox is destroyed when the command exits.
+The hold cap defaults to 3600 seconds; operators may raise it with
+`WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS` up to the hard 24-hour ceiling.
 
 Returned artifact metadata includes the runtime manifest, replay blueprint,
 after-state notes, captured readwrite mount index, event streams, and logs. WP

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -921,7 +921,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return WP_Codebox_Path_Policy::clean_host_path( $path );
 	}
 
-	private function preview_hold_seconds( array $input ): int {
+	private function preview_hold_seconds( array $input ): int|WP_Error {
 		return WP_Codebox_Preview_Options::preview_hold_seconds( $input );
 	}
 
@@ -929,8 +929,11 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		return $this->preview_args_builder->build( $input );
 	}
 
-	private function preview_hold_arg( array $input ): string {
+	private function preview_hold_arg( array $input ): string|WP_Error {
 		$seconds = $this->preview_hold_seconds( $input );
+		if ( is_wp_error( $seconds ) ) {
+			return $seconds;
+		}
 
 		return $seconds > 0 ? ' --preview-hold-seconds ' . escapeshellarg( (string) $seconds ) : '';
 	}

--- a/packages/wordpress-plugin/src/class-wp-codebox-preview-options.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-preview-options.php
@@ -12,18 +12,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 final class WP_Codebox_Preview_Options {
-	public const HOLD_MAX_SECONDS = 3600;
-	public const PORT_MIN         = 1;
-	public const PORT_MAX         = 65535;
+	public const HOLD_DEFAULT_MAX_SECONDS = 3600;
+	public const HOLD_MAX_SECONDS         = self::HOLD_DEFAULT_MAX_SECONDS;
+	public const HOLD_HARD_MAX_SECONDS    = 24 * 60 * 60;
+	public const HOLD_MAX_SECONDS_ENV     = 'WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS';
+	public const PORT_MIN                 = 1;
+	public const PORT_MAX                 = 65535;
 
 	/** @return array<string,array<string,mixed>> */
 	public static function input_schema(): array {
+		$hold_max = self::preview_hold_max_seconds();
+		if ( is_wp_error( $hold_max ) ) {
+			$hold_max = self::HOLD_DEFAULT_MAX_SECONDS;
+		}
+
 		return array(
 			'preview_hold_seconds' => array(
 				'type'        => 'integer',
 				'minimum'     => 0,
-				'maximum'     => self::HOLD_MAX_SECONDS,
-				'description' => 'Seconds to keep the live Playground preview URL available after capture. Max 3600.',
+				'maximum'     => $hold_max,
+				'description' => 'Seconds to keep the live Playground preview URL available after capture. Max 3600 by default; operators may raise the cap with WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS.',
 			),
 			'preview_port'         => array(
 				'type'        => 'integer',
@@ -45,11 +53,12 @@ final class WP_Codebox_Preview_Options {
 
 	/** @param array<string,mixed> $input Preview option input. @return array{preview_hold_seconds:int,preview_port:?int,preview_bind:?string,preview_public_url:?string}|WP_Error */
 	public static function normalize( array $input ): array|WP_Error {
+		$hold   = self::preview_hold_seconds( $input );
 		$port   = self::preview_port( $input );
 		$bind   = self::preview_bind( $input );
 		$public = self::preview_public_url( $input );
 
-		foreach ( array( $port, $bind, $public ) as $value ) {
+		foreach ( array( $hold, $port, $bind, $public ) as $value ) {
 			if ( is_wp_error( $value ) ) {
 				return $value;
 			}
@@ -60,26 +69,58 @@ final class WP_Codebox_Preview_Options {
 		}
 
 		return array(
-			'preview_hold_seconds' => self::preview_hold_seconds( $input ),
+			'preview_hold_seconds' => $hold,
 			'preview_port'         => $port,
 			'preview_bind'         => $bind,
 			'preview_public_url'   => $public,
 		);
 	}
 
-	/** @param array<string,mixed> $input Preview option input. */
-	public static function preview_hold_seconds( array $input ): int {
+	/** @param array<string,mixed> $input Preview option input. @return int|WP_Error */
+	public static function preview_hold_seconds( array $input ): int|WP_Error {
+		$max = self::preview_hold_max_seconds();
+		if ( is_wp_error( $max ) ) {
+			return $max;
+		}
+
 		$raw = trim( (string) ( $input['preview_hold_seconds'] ?? 0 ) );
-		if ( preg_match( '/^(\d+)(s|m)?$/', $raw, $matches ) ) {
+		if ( preg_match( '/^(\d+)(s|m|h)?$/', $raw, $matches ) ) {
 			$seconds = (int) $matches[1];
-			if ( 'm' === ( $matches[2] ?? '' ) ) {
+			if ( 'h' === ( $matches[2] ?? '' ) ) {
+				$seconds *= 3600;
+			} elseif ( 'm' === ( $matches[2] ?? '' ) ) {
 				$seconds *= 60;
 			}
 		} else {
 			$seconds = (int) $raw;
 		}
 
-		return max( 0, min( self::HOLD_MAX_SECONDS, $seconds ) );
+		return max( 0, min( $max, $seconds ) );
+	}
+
+	private static function preview_hold_max_seconds(): int|WP_Error {
+		$value = getenv( self::HOLD_MAX_SECONDS_ENV );
+		if ( false === $value || '' === trim( (string) $value ) ) {
+			return self::HOLD_DEFAULT_MAX_SECONDS;
+		}
+
+		$raw = trim( (string) $value );
+		if ( ! preg_match( '/^(\d+)(s|m|h)?$/', $raw, $matches ) ) {
+			return new WP_Error( 'wp_codebox_preview_hold_max_invalid', self::HOLD_MAX_SECONDS_ENV . ' must be a duration such as 3600, 60m, or 4h.', array( 'status' => 400 ) );
+		}
+
+		$seconds = (int) $matches[1];
+		if ( 'h' === ( $matches[2] ?? '' ) ) {
+			$seconds *= 3600;
+		} elseif ( 'm' === ( $matches[2] ?? '' ) ) {
+			$seconds *= 60;
+		}
+
+		if ( $seconds < self::HOLD_DEFAULT_MAX_SECONDS || $seconds > self::HOLD_HARD_MAX_SECONDS ) {
+			return new WP_Error( 'wp_codebox_preview_hold_max_invalid', self::HOLD_MAX_SECONDS_ENV . ' must be between ' . self::HOLD_DEFAULT_MAX_SECONDS . ' and ' . self::HOLD_HARD_MAX_SECONDS . ' seconds.', array( 'status' => 400 ) );
+		}
+
+		return $seconds;
 	}
 
 	/** @param array<string,mixed> $input Preview option input. */

--- a/tests/preview-options.test.ts
+++ b/tests/preview-options.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+
+import { parsePreviewHoldSeconds, PreviewOptionError, previewHoldMaxSeconds } from "../packages/cli/src/preview-options.js"
+
+const originalCap = process.env.WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS
+
+try {
+  delete process.env.WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS
+  assert.equal(parsePreviewHoldSeconds("2h"), 3600, "default cap remains one hour")
+
+  process.env.WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS = "4h"
+  assert.equal(previewHoldMaxSeconds(), 14_400, "operator cap accepts hour syntax")
+  assert.equal(parsePreviewHoldSeconds("3h"), 10_800, "operator cap allows longer holds")
+  assert.equal(parsePreviewHoldSeconds("5h"), 14_400, "requested hold clamps to operator cap")
+
+  process.env.WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS = "25h"
+  assert.throws(() => previewHoldMaxSeconds(), PreviewOptionError, "operator cap cannot exceed hard ceiling")
+} finally {
+  if (originalCap === undefined) {
+    delete process.env.WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS
+  } else {
+    process.env.WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS = originalCap
+  }
+}
+
+console.log("preview options ok")


### PR DESCRIPTION
## Summary
- keep the default preview hold cap at one hour
- allow operator-configured longer holds with a hard 24-hour ceiling
- document the environment override and update preview option fixtures

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-preview-options.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing configurable preview hold limits and drafting this PR description.