### PR TITLE
Report public preview lease metadata

### DIFF
--- a/contracts/preview-options.fixture.json
+++ b/contracts/preview-options.fixture.json
@@ -21,6 +21,10 @@
       "type": "string",
       "format": "uri",
       "description": "Optional public http/https URL reported in preview metadata and passed to the sandbox for site URL alignment."
+    },
+    "preview_lease": {
+      "type": "object",
+      "description": "Optional wp-codebox/preview-lease/v1 envelope for external tunnel/public URL handoff metadata. WP Codebox reports it but does not create the tunnel."
     }
   },
   "cases": [
@@ -32,7 +36,8 @@
         "preview_hold_seconds": 0,
         "preview_port": null,
         "preview_bind": null,
-        "preview_public_url": null
+        "preview_public_url": null,
+        "preview_lease": null
       }
     },
     {
@@ -48,7 +53,48 @@
         "preview_hold_seconds": 30,
         "preview_port": 45678,
         "preview_bind": "127.0.0.1",
-        "preview_public_url": "https://preview.example.test/session-123/"
+        "preview_public_url": "https://preview.example.test/session-123/",
+        "preview_lease": null
+      }
+    },
+    {
+      "name": "valid lease envelope derives public url",
+      "input": {
+        "preview_lease": {
+          "schema": "wp-codebox/preview-lease/v1",
+          "public_url": "https://preview.example.test/session-lease/",
+          "local_url": "http://127.0.0.1:45678/",
+          "lease": {
+            "status": "active",
+            "expires_at": "2026-06-22T13:00:00.000Z",
+            "provider": "example-tunnel"
+          },
+          "alignment": {
+            "status": "aligned"
+          }
+        }
+      },
+      "valid": true,
+      "normalized": {
+        "preview_hold_seconds": 0,
+        "preview_port": null,
+        "preview_bind": null,
+        "preview_public_url": "https://preview.example.test/session-lease/",
+        "preview_lease": {
+          "schema": "wp-codebox/preview-lease/v1",
+          "public_url": "https://preview.example.test/session-lease/",
+          "preview_public_url": "https://preview.example.test/session-lease/",
+          "local_url": "http://127.0.0.1:45678/",
+          "lease": {
+            "status": "active",
+            "expires_at": "2026-06-22T13:00:00.000Z",
+            "provider": "example-tunnel"
+          },
+          "alignment": {
+            "status": "aligned"
+          },
+          "evidence_refs": []
+        }
       }
     },
     {
@@ -61,7 +107,8 @@
         "preview_hold_seconds": 120,
         "preview_port": null,
         "preview_bind": null,
-        "preview_public_url": null
+        "preview_public_url": null,
+        "preview_lease": null
       }
     },
     {
@@ -74,7 +121,8 @@
         "preview_hold_seconds": 3600,
         "preview_port": null,
         "preview_bind": null,
-        "preview_public_url": null
+        "preview_public_url": null,
+        "preview_lease": null
       }
     },
     {
@@ -100,7 +148,8 @@
         "preview_hold_seconds": 0,
         "preview_port": 1,
         "preview_bind": null,
-        "preview_public_url": null
+        "preview_public_url": null,
+        "preview_lease": null
       }
     },
     {
@@ -113,7 +162,8 @@
         "preview_hold_seconds": 0,
         "preview_port": 65535,
         "preview_bind": null,
-        "preview_public_url": null
+        "preview_public_url": null,
+        "preview_lease": null
       }
     },
     {
@@ -128,7 +178,8 @@
         "preview_hold_seconds": 0,
         "preview_port": null,
         "preview_bind": null,
-        "preview_public_url": null
+        "preview_public_url": null,
+        "preview_lease": null
       }
     },
     {
@@ -188,6 +239,17 @@
       },
       "valid": false,
       "code": "wp_codebox_preview_public_url_invalid"
+    },
+    {
+      "name": "invalid lease schema",
+      "input": {
+        "preview_lease": {
+          "schema": "example/preview-lease/v1",
+          "public_url": "https://preview.example.test/session-lease/"
+        }
+      },
+      "valid": false,
+      "code": "wp_codebox_preview_lease_invalid"
     }
   ]
 }

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -15,6 +15,7 @@ export interface AgentTaskRunOptions {
   previewPort?: string
   previewBind?: string
   previewHoldBlocking?: boolean
+  previewLeaseJson?: string
 }
 
 interface AgentTaskRunOutput {
@@ -121,6 +122,9 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     }
     if (options.previewPublicUrl) {
       recipeRunArgs.push("--preview-public-url", options.previewPublicUrl)
+    }
+    if (options.previewLeaseJson) {
+      recipeRunArgs.push("--preview-lease-json", options.previewLeaseJson)
     }
     capture = await captureOutput(() => runRecipeRunCommand(recipeRunArgs))
     generatedRecipeArtifact = await persistGeneratedRecipeArtifact(artifacts, recipeJson)
@@ -348,7 +352,7 @@ function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
     throw new Error(`Unknown agent-task-run option: ${positionals[0]}`)
   }
   for (const name of options.keys()) {
-    if (!["--input-file", "--json", "--format", "--preview-hold-seconds", "--preview-public-url", "--preview-port", "--preview-bind", "--preview-hold-blocking"].includes(name)) {
+    if (!["--input-file", "--json", "--format", "--preview-hold-seconds", "--preview-public-url", "--preview-port", "--preview-bind", "--preview-hold-blocking", "--preview-lease-json"].includes(name)) {
       throw new Error(`Unknown agent-task-run option: ${name}`)
     }
   }
@@ -364,6 +368,7 @@ function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
     previewPort: stringOption(options, "--preview-port"),
     previewBind: stringOption(options, "--preview-bind"),
     previewHoldBlocking: options.get("--preview-hold-blocking") === true,
+    previewLeaseJson: stringOption(options, "--preview-lease-json"),
   }
 }
 

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -1,4 +1,4 @@
-import type { AgentTerminalResult, ArtifactBundle, BenchResults, ExecutionResult, RecipeRunSummary, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef, WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
+import type { AgentTerminalResult, ArtifactBundle, BenchResults, ExecutionResult, PreviewLease, RecipeRunSummary, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef, WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
 import type { RecipeDryRunOutput, RecipeDryRunSiteSeed, RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import type { AgentSandboxResultSummary, AgentTaskSingleResult, RecipeReplayStatusSummary, SandboxCompletionOutcome } from "../recipe-evidence.js"
 import type { RecipeValidationIssue, RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -10,6 +10,7 @@ export interface RecipeRunOptions {
   runRegistryDirectory?: string
   previewHoldSeconds?: number
   previewPublicUrl?: string
+  previewLease?: PreviewLease
   previewPort?: number
   previewBind?: string
   previewHoldBlocking: boolean

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -5,7 +5,7 @@ import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRuntimeEnvRecord, pa
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
-import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
+import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewLease, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, recipeDryRunSiteSeeds } from "../recipe-dry-run.js"
 import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeArtifactEvidenceFailure, recipeReplayStatusOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
 import { resolveRecipeSecretEnv } from "../recipe-secret-env.js"
@@ -171,7 +171,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         run: { runId: runRecord.runId, registryDirectory: runRegistry.directory },
         ...recipeRunMetadata(recipe, recipePath, workspaceMounts, extraPlugins, dependencyOverlays, stagedFiles, overlays, backendPackage, effectivePreview),
       },
-      preview: previewSpec(effectivePreview.publicUrl, effectivePreview.port, effectivePreview.bind, effectivePreview.siteUrl),
+      preview: previewSpec(effectivePreview.publicUrl, effectivePreview.port, effectivePreview.bind, effectivePreview.siteUrl, effectivePreview.lease),
     }
     try {
       const startupStartedAtMs = Date.now()
@@ -628,6 +628,9 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
         break
       case "--preview-public-url":
         options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
+      case "--preview-lease-json":
+        options.previewLease = parsePreviewLease(value)
         break
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)
@@ -1116,10 +1119,11 @@ function recipeStepMetadata(step: WorkspaceRecipe["workflow"]["steps"][number]):
 
 function effectiveRecipePreview(recipePreview: RuntimePreviewSpec | undefined, options: RecipeRunOptions): RuntimePreviewSpec {
   return stripUndefined({
-    publicUrl: options.previewPublicUrl ?? recipePreview?.publicUrl,
-    siteUrl: recipePreview?.siteUrl,
+    publicUrl: options.previewPublicUrl ?? recipePreview?.publicUrl ?? options.previewLease?.public_url ?? options.previewLease?.preview_public_url,
+    siteUrl: recipePreview?.siteUrl ?? options.previewLease?.site_url,
     port: options.previewPort ?? recipePreview?.port,
     bind: options.previewBind ?? recipePreview?.bind,
+    lease: options.previewLease ?? recipePreview?.lease,
   })
 }
 

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { captureStdout, printBlueprintValidateHumanOutput, printBootHumanOutput, printHumanOutput } from "../output.js"
-import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
+import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewLease, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { boot, run, validateBlueprint, type BlueprintValidateOptions, type BootOptions, type RunOptions } from "../runtime-command-wrappers.js"
 import { normalizeSharedMounts, type RuntimePolicy } from "@automattic/wp-codebox-core"
 
@@ -119,6 +119,9 @@ async function parseRunOptions(args: string[]): Promise<RunOptions> {
       case "--preview-public-url":
         options.previewPublicUrl = parsePreviewPublicUrl(value)
         break
+      case "--preview-lease-json":
+        options.previewLease = parsePreviewLease(value)
+        break
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)
         break
@@ -184,6 +187,9 @@ async function parseBootOptions(args: string[]): Promise<BootOptions> {
       case "--preview-public-url":
         options.previewPublicUrl = parsePreviewPublicUrl(value)
         break
+      case "--preview-lease-json":
+        options.previewLease = parsePreviewLease(value)
+        break
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)
         break
@@ -235,6 +241,9 @@ async function parseBlueprintValidateOptions(args: string[]): Promise<BlueprintV
         break
       case "--preview-public-url":
         options.previewPublicUrl = parsePreviewPublicUrl(value)
+        break
+      case "--preview-lease-json":
+        options.previewLease = parsePreviewLease(value)
         break
       case "--preview-port":
         options.previewPort = parsePreviewPort(value)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -213,12 +213,14 @@ function printPreviewAccess(artifacts: ArtifactBundle | undefined): void {
 
   const access = preview.reviewerAccess
   if (access?.openUrl) {
-    console.log(`Preview: ${access.openUrl} (${access.status}, ${access.mode})`)
+    const lease = access.lease ? `, lease=${access.lease.status}, alignment=${access.lease.alignmentStatus ?? "unknown"}, reviewerSafe=${access.lease.reviewerSafe ? "yes" : "no"}` : ""
+    console.log(`Preview: ${access.openUrl} (${access.status}, ${access.mode}${lease})`)
     return
   }
 
   if (access?.reason) {
-    console.log(`Preview: ${access.status} (${access.reason})`)
+    const lease = access.lease ? `, lease=${access.lease.status}, alignment=${access.lease.alignmentStatus ?? "unknown"}, reviewerSafe=${access.lease.reviewerSafe ? "yes" : "no"}` : ""
+    console.log(`Preview: ${access.status} (${access.reason}${lease})`)
     return
   }
 
@@ -315,8 +317,8 @@ export function printHelp(): void {
   wp-codebox preview-lease status (--registry <dir> --lease-id <id>|--lease-file <path>) [--json]
   wp-codebox preview-lease release (--registry <dir> --lease-id <id>|--lease-file <path>) [--json]
   wp-codebox target provision [--id <id>] [--kind <kind>] [--workspace-root <dir>] [--json]
-  wp-codebox run-agent-task --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>]
-  wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>]
+  wp-codebox run-agent-task --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>] [--preview-lease-json <json>]
+  wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>] [--preview-lease-json <json>]
   wp-codebox validate-blueprint --blueprint <json|file> [options]
   wp-codebox materialize-replay-package --snapshot <path> --output <dir> [--snapshot-ref <ref>] [--json]
   wp-codebox recipe-run --recipe <path> [options]
@@ -339,6 +341,8 @@ Options:
                     Bind host or IP for a fixed preview proxy port. Requires --preview-port.
   --preview-public-url <url>
                     Public preview URL passed through to run-agent-task/agent-task-run/recipe-run.
+  --preview-lease-json <json>
+                    wp-codebox/preview-lease/v1 envelope to report for external preview handoff metadata.
   --bundle <dir>      Artifact bundle directory for artifact verification/probe commands.
   --source <id>       Default source for artifacts diagnostics normalization.
   --stage <id>        Default stage for artifacts diagnostics normalization.
@@ -404,8 +408,10 @@ Options:
                        Host/IP for the fixed-port WP Codebox preview proxy. Requires --preview-port.
                        Defaults to 127.0.0.1; use 0.0.0.0 only behind trusted network controls.
   --preview-public-url <url>
-                        Public tunnel/proxy URL to report in preview artifacts and pass to Playground as site-url.
-                        Upstream Playground remains loopback-bound; this only changes the WP Codebox proxy bind.
+                         Public tunnel/proxy URL to report in preview artifacts and pass to Playground as site-url.
+                         Upstream Playground remains loopback-bound; this only changes the WP Codebox proxy bind.
+  --preview-lease-json <json>
+                         wp-codebox/preview-lease/v1 envelope for public/local URL, expiry, alignment, and handoff metadata.
   --timeout <duration>  Maximum live recipe-run duration before emitting a structured timeout failure. Defaults to 25m.
   --policy <json|file> Runtime policy JSON or path to a JSON file.
   --dry-run            Validate recipe-run and emit a resolved JSON plan without booting Playground or writing temp workspaces.

--- a/packages/cli/src/preview-options.ts
+++ b/packages/cli/src/preview-options.ts
@@ -1,3 +1,5 @@
+import { previewLease, type PreviewLease } from "@automattic/wp-codebox-core"
+
 export const PREVIEW_HOLD_DEFAULT_MAX_SECONDS = 3600
 export const PREVIEW_HOLD_MAX_SECONDS = PREVIEW_HOLD_DEFAULT_MAX_SECONDS
 export const PREVIEW_HOLD_HARD_MAX_SECONDS = 24 * 60 * 60
@@ -10,6 +12,7 @@ export interface PreviewOptionsInput {
   preview_port?: unknown
   preview_bind?: unknown
   preview_public_url?: unknown
+  preview_lease?: unknown
 }
 
 export interface PreviewOptions {
@@ -17,6 +20,7 @@ export interface PreviewOptions {
   preview_port: number | null
   preview_bind: string | null
   preview_public_url: string | null
+  preview_lease: PreviewLease | null
 }
 
 export class PreviewOptionError extends Error {
@@ -48,12 +52,17 @@ export const previewInputSchema = {
     format: "uri",
     description: "Optional public http/https URL reported in preview metadata and passed to the sandbox for site URL alignment.",
   },
+  preview_lease: {
+    type: "object",
+    description: "Optional wp-codebox/preview-lease/v1 envelope for external tunnel/public URL handoff metadata. WP Codebox reports it but does not create the tunnel.",
+  },
 } as const
 
 export function normalizePreviewOptions(input: PreviewOptionsInput): PreviewOptions {
   const port = parsePreviewPortValue(input.preview_port)
   const bind = parsePreviewBindValue(input.preview_bind)
-  const publicUrl = parsePreviewPublicUrlValue(input.preview_public_url)
+  const lease = parsePreviewLeaseValue(input.preview_lease)
+  const publicUrl = parsePreviewPublicUrlValue(input.preview_public_url) ?? lease?.public_url ?? lease?.preview_public_url ?? null
 
   if (bind !== null && port === null) {
     throw new PreviewOptionError("wp_codebox_preview_bind_requires_port", "preview_bind requires preview_port.")
@@ -64,6 +73,7 @@ export function normalizePreviewOptions(input: PreviewOptionsInput): PreviewOpti
     preview_port: port,
     preview_bind: bind,
     preview_public_url: publicUrl,
+    preview_lease: lease,
   }
 }
 
@@ -97,6 +107,14 @@ export function parsePreviewPublicUrl(value: unknown): string {
     throw new PreviewOptionError("wp_codebox_preview_public_url_invalid", "--preview-public-url must include a URL")
   }
   return publicUrl
+}
+
+export function parsePreviewLease(value: unknown): PreviewLease {
+  const lease = parsePreviewLeaseValue(value)
+  if (lease === null) {
+    throw new PreviewOptionError("wp_codebox_preview_lease_invalid", "--preview-lease-json must include a wp-codebox/preview-lease/v1 envelope")
+  }
+  return lease
 }
 
 function parsePreviewHoldSecondsValue(value: unknown): number {
@@ -182,4 +200,25 @@ function parsePreviewPublicUrlValue(value: unknown): string | null {
   }
 
   return url.toString()
+}
+
+function parsePreviewLeaseValue(value: unknown): PreviewLease | null {
+  if (value === undefined || value === null || String(value).trim() === "") {
+    return null
+  }
+
+  let payload = value
+  if (typeof value === "string") {
+    try {
+      payload = JSON.parse(value)
+    } catch {
+      throw new PreviewOptionError("wp_codebox_preview_lease_invalid", "preview_lease must be a JSON object using wp-codebox/preview-lease/v1.")
+    }
+  }
+
+  try {
+    return previewLease(payload)
+  } catch (error) {
+    throw new PreviewOptionError("wp_codebox_preview_lease_invalid", error instanceof Error ? error.message : "preview_lease must be a valid wp-codebox/preview-lease/v1 envelope.")
+  }
 }

--- a/packages/cli/src/runtime-command-wrappers.ts
+++ b/packages/cli/src/runtime-command-wrappers.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_WORDPRESS_VERSION, createRuntime, type ArtifactBundle, type ExecutionResult, type MountSpec, type Runtime, type RuntimeInfo, type RuntimePolicy } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, type ArtifactBundle, type ExecutionResult, type MountSpec, type PreviewLease, type Runtime, type RuntimeInfo, type RuntimePolicy } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
 import { serializeError } from "./output.js"
@@ -19,6 +19,7 @@ export interface RunOptions {
   blueprint?: unknown
   previewHoldSeconds?: number
   previewPublicUrl?: string
+  previewLease?: PreviewLease
   previewPort?: number
   previewBind?: string
   json: boolean
@@ -46,6 +47,7 @@ export interface BootOptions {
   blueprint?: unknown
   previewHoldSeconds?: number
   previewPublicUrl?: string
+  previewLease?: PreviewLease
   previewPort?: number
   previewBind?: string
   json: boolean
@@ -68,6 +70,7 @@ export interface BlueprintValidateOptions {
   policy?: RuntimePolicy
   previewHoldSeconds?: number
   previewPublicUrl?: string
+  previewLease?: PreviewLease
   previewPort?: number
   previewBind?: string
   json: boolean
@@ -99,22 +102,24 @@ export function runtimeMetadata(artifactsDirectory: string | undefined, wpVersio
   }
 }
 
-export function previewSpec(publicUrl: string | undefined, port: number | undefined, bind: string | undefined, siteUrl?: string): { publicUrl?: string; siteUrl?: string; port?: number; bind?: string } | undefined {
+export function previewSpec(publicUrl: string | undefined, port: number | undefined, bind: string | undefined, siteUrl?: string, lease?: PreviewLease): { publicUrl?: string; siteUrl?: string; port?: number; bind?: string; lease?: PreviewLease } | undefined {
   if (bind && port === undefined) {
     throw new Error("--preview-bind requires --preview-port because upstream Playground does not expose bind-host control yet")
   }
 
-  if (!publicUrl && !siteUrl && port === undefined && !bind) {
+  if (!publicUrl && !siteUrl && port === undefined && !bind && !lease) {
     return undefined
   }
 
   const localUrl = port === undefined ? undefined : `http://${formatPreviewHost(bind === "0.0.0.0" || !bind ? "127.0.0.1" : bind)}:${port}`
+  const effectivePublicUrl = publicUrl ?? lease?.public_url ?? lease?.preview_public_url
 
   return stripUndefined({
-    publicUrl,
-    siteUrl: siteUrl ?? publicUrl ?? localUrl,
+    publicUrl: effectivePublicUrl,
+    siteUrl: siteUrl ?? lease?.site_url ?? effectivePublicUrl ?? localUrl,
     port,
     bind,
+    lease,
   })
 }
 
@@ -131,6 +136,7 @@ function runMetadata(options: RunOptions): Record<string, unknown> {
       args: options.args,
       artifactsDirectory: options.artifactsDirectory,
       previewPublicUrl: options.previewPublicUrl,
+      previewLease: options.previewLease,
       previewPort: options.previewPort,
       previewBind: options.previewBind,
     }),
@@ -144,6 +150,7 @@ function bootMetadata(options: BootOptions): Record<string, unknown> {
       kind: "cli-boot",
       artifactsDirectory: options.artifactsDirectory,
       previewPublicUrl: options.previewPublicUrl,
+      previewLease: options.previewLease,
       previewPort: options.previewPort,
       previewBind: options.previewBind,
     }),
@@ -158,6 +165,7 @@ function blueprintValidationMetadata(options: BlueprintValidateOptions): Record<
       blueprintPath: options.blueprintPath,
       artifactsDirectory: options.artifactsDirectory,
       previewPublicUrl: options.previewPublicUrl,
+      previewLease: options.previewLease,
       previewPort: options.previewPort,
       previewBind: options.previewBind,
     }),
@@ -183,7 +191,7 @@ export async function run(options: RunOptions): Promise<RunOutput> {
         secretEnv: options.secretEnv,
         artifactsDirectory: options.artifactsDirectory,
         metadata: options.metadata ?? runMetadata(options),
-        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind, undefined, options.previewLease),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -247,7 +255,7 @@ export async function boot(options: BootOptions): Promise<BootOutput> {
         policy: options.policy ?? defaultPolicy,
         artifactsDirectory: options.artifactsDirectory,
         metadata: bootMetadata(options),
-        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind, undefined, options.previewLease),
       },
       createPlaygroundRuntimeBackend(),
     )
@@ -310,7 +318,7 @@ export async function validateBlueprint(options: BlueprintValidateOptions): Prom
         policy: options.policy ?? defaultPolicy,
         artifactsDirectory: options.artifactsDirectory,
         metadata: blueprintValidationMetadata(options),
-        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind),
+        preview: previewSpec(options.previewPublicUrl, options.previewPort, options.previewBind, undefined, options.previewLease),
       },
       createPlaygroundRuntimeBackend(),
     )

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -478,6 +478,10 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "string",
             description: "Optional fixed-port preview proxy bind host or IP. Requires port.",
           },
+          lease: {
+            type: "object",
+            description: "Optional wp-codebox/preview-lease/v1 envelope for external tunnel/public URL handoff metadata. WP Codebox accepts and reports the lease but does not create a tunnel.",
+          },
         },
       },
       runtimeAssets: {

--- a/packages/runtime-core/src/runtime-boundary-contracts.ts
+++ b/packages/runtime-core/src/runtime-boundary-contracts.ts
@@ -283,11 +283,18 @@ export function previewReviewerAccess(preview: {
   status?: unknown
   lifecycle?: unknown
   publicUrl?: unknown
+  localUrl?: unknown
+  siteUrl?: unknown
   url?: unknown
   expiresAt?: unknown
+  lease?: unknown
   reviewerAuthBootstrap?: unknown
   blockers?: unknown
 } | undefined): import("./runtime-contracts.js").ArtifactPreviewReviewerAccess {
+  const lease = normalizedPreviewAccessLease(preview?.lease)
+  const leaseSummary = previewLeaseSummary(lease)
+  const expiresAt = optionalString(preview?.expiresAt, "expiresAt") ?? leaseSummary?.expiresAt
+
   if (!preview || preview.status !== "available" || preview.lifecycle !== "held-after-run") {
     return {
       schema: PREVIEW_REVIEWER_ACCESS_SCHEMA,
@@ -295,6 +302,7 @@ export function previewReviewerAccess(preview: {
       outcome: "blocked",
       mode: "none",
       reviewerSafe: false,
+      ...(leaseSummary ? { lease: { ...leaseSummary, reviewerSafe: false } } : {}),
       reason: "preview-not-held",
     }
   }
@@ -310,6 +318,7 @@ export function previewReviewerAccess(preview: {
       openUrl: reviewerAuthBootstrap.bootstrapUrl,
       targetUrl: reviewerAuthBootstrap.redirectUrl,
       expiresAt: reviewerAuthBootstrap.expiresAt,
+      ...(leaseSummary ? { lease: { ...leaseSummary, reviewerSafe: true } } : {}),
       bootstrap: reviewerAuthBootstrap,
     }
   }
@@ -323,12 +332,13 @@ export function previewReviewerAccess(preview: {
       mode: "none",
       reviewerSafe: false,
       blockers,
-      expiresAt: optionalString(preview.expiresAt, "expiresAt"),
+      ...(expiresAt ? { expiresAt } : {}),
+      ...(leaseSummary ? { lease: { ...leaseSummary, reviewerSafe: false } } : {}),
       reason: blockers[0]?.code,
     }
   }
 
-  const safeUrl = safeNonLocalPreviewUrl(optionalString(preview.publicUrl, "publicUrl")) ?? safeNonLocalPreviewUrl(optionalString(preview.url, "url"))
+  const safeUrl = safeNonLocalPreviewUrl(optionalString(preview.publicUrl, "publicUrl")) ?? safeNonLocalPreviewUrl(lease?.public_url) ?? safeNonLocalPreviewUrl(lease?.preview_public_url) ?? safeNonLocalPreviewUrl(optionalString(preview.url, "url"))
   if (safeUrl) {
     return {
       schema: PREVIEW_REVIEWER_ACCESS_SCHEMA,
@@ -338,7 +348,8 @@ export function previewReviewerAccess(preview: {
       reviewerSafe: true,
       openUrl: safeUrl,
       targetUrl: safeUrl,
-      expiresAt: optionalString(preview.expiresAt, "expiresAt"),
+      ...(expiresAt ? { expiresAt } : {}),
+      ...(leaseSummary ? { lease: { ...leaseSummary, reviewerSafe: true } } : {}),
     }
   }
 
@@ -348,12 +359,41 @@ export function previewReviewerAccess(preview: {
     outcome: "local",
     mode: "none",
     reviewerSafe: false,
-    expiresAt: optionalString(preview.expiresAt, "expiresAt"),
+    ...(expiresAt ? { expiresAt } : {}),
+    ...(leaseSummary ? { lease: { ...leaseSummary, reviewerSafe: false } } : {}),
     reason: "local-preview-requires-auth-bootstrap-or-public-url",
   }
 }
 
 export const normalizePreviewReviewerAccess = previewReviewerAccess
+
+function normalizedPreviewAccessLease(input: unknown): PreviewLease | undefined {
+  if (input === undefined) {
+    return undefined
+  }
+
+  return previewLease(input)
+}
+
+export function previewLeaseSummary(lease: PreviewLease | undefined): import("./runtime-contracts.js").ArtifactPreviewLeaseSummary | undefined {
+  if (!lease) {
+    return undefined
+  }
+
+  return {
+    schema: "wp-codebox/preview-lease-summary/v1",
+    status: previewLeaseStatus(lease),
+    ...(lease.public_url ? { publicUrl: lease.public_url } : {}),
+    ...(lease.local_url ? { localUrl: lease.local_url } : {}),
+    ...(lease.site_url ? { siteUrl: lease.site_url } : {}),
+    ...(lease.lease?.expires_at ? { expiresAt: lease.lease.expires_at } : {}),
+    ...(lease.lease?.owner ? { owner: lease.lease.owner } : {}),
+    ...(lease.lease?.provider ? { provider: lease.lease.provider } : {}),
+    ...(lease.alignment?.status ? { alignmentStatus: lease.alignment.status } : {}),
+    ...(lease.reachability?.status ? { reachabilityStatus: lease.reachability.status } : {}),
+    reviewerSafe: Boolean(safeNonLocalPreviewUrl(lease.public_url) || safeNonLocalPreviewUrl(lease.preview_public_url)),
+  }
+}
 
 export function browserContainedSiteStatus(input: unknown): BrowserContainedSiteStatus {
   const value = requireObject(input, "Browser contained site status") as Partial<BrowserContainedSiteStatus>

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -10,6 +10,7 @@ import type {
   RUNTIME_EPISODE_SNAPSHOT_SCHEMA,
   RUNTIME_EPISODE_TRACE_SCHEMA,
 } from "./runtime-episode-contracts.js"
+import type { PreviewLease, PreviewLeaseLifecycleStatus } from "./runtime-boundary-contracts.js"
 
 export type RuntimeBackendKind = "wordpress-playground" | (string & {})
 
@@ -64,6 +65,7 @@ export interface RuntimePreviewSpec {
   siteUrl?: string
   port?: number
   bind?: string
+  lease?: PreviewLease
 }
 
 export interface WorkspaceRecipeMount {
@@ -916,6 +918,7 @@ export interface ArtifactPreviewSessionEvidence {
     holdSeconds?: number
     hasPublicUrl: boolean
     hasSiteUrl: boolean
+    lease?: ArtifactPreviewLeaseSummary
     hasReviewerAuthBootstrap?: boolean
     reviewerAccess: ArtifactPreviewReviewerAccess
     blockers?: ArtifactPreviewBlocker[]
@@ -943,6 +946,7 @@ export interface ArtifactPreview {
   localUrl?: string
   publicUrl?: string
   siteUrl?: string
+  lease?: PreviewLease
   status: "available" | "expired-on-completion"
   lifecycle: "held-after-run" | "destroyed-on-completion"
   source: "live-playground" | "public-url-override"
@@ -963,9 +967,24 @@ export interface ArtifactPreviewReviewerAccess {
   openUrl?: string
   targetUrl?: string
   expiresAt?: string
+  lease?: ArtifactPreviewLeaseSummary
   bootstrap?: ArtifactReviewerAuthBootstrap
   blockers?: ArtifactPreviewBlocker[]
   reason?: string
+}
+
+export interface ArtifactPreviewLeaseSummary {
+  schema: "wp-codebox/preview-lease-summary/v1"
+  status: PreviewLeaseLifecycleStatus
+  publicUrl?: string
+  localUrl?: string
+  siteUrl?: string
+  expiresAt?: string
+  owner?: string
+  provider?: string
+  alignmentStatus?: string
+  reachabilityStatus?: string
+  reviewerSafe: boolean
 }
 
 export interface ArtifactReviewerAuthBootstrap {
@@ -1041,6 +1060,7 @@ export interface ArtifactPreviewEvidence {
     createdAt?: string
     expiresAt?: string
     holdSeconds?: number
+    lease?: ArtifactPreviewLeaseSummary
     url: ArtifactPreviewUrlRef
     publicUrl?: ArtifactPreviewUrlRef
     localUrl?: ArtifactPreviewUrlRef

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -39,6 +39,7 @@ import {
   type RuntimeCreateSpec,
   type RuntimeEpisodeTraceRef,
   type RuntimeInfo,
+  previewLeaseSummary,
   type Snapshot,
 } from "@automattic/wp-codebox-core"
 import { normalizeJsonValue, stripUndefined } from "@automattic/wp-codebox-core/internals"
@@ -669,6 +670,7 @@ function buildPreviewEvidence({
       createdAt: preview?.createdAt,
       expiresAt: preview?.expiresAt,
       holdSeconds: preview?.holdSeconds,
+      ...(preview?.lease ? { lease: previewLeaseSummary(preview.lease) } : {}),
       ...(preview?.blockers ? { blockers: preview.blockers } : {}),
       url: safePreviewUrlRef(preview?.url),
       ...(preview?.publicUrl ? { publicUrl: safePreviewUrlRef(preview.publicUrl) } : {}),
@@ -810,6 +812,7 @@ function buildPreviewSessionEvidence({
       holdSeconds: preview.holdSeconds,
       hasPublicUrl: Boolean(preview.publicUrl),
       hasSiteUrl: Boolean(preview.siteUrl),
+      lease: preview.lease ? previewLeaseSummary(preview.lease) : undefined,
       hasReviewerAuthBootstrap: Boolean(preview.reviewerAuthBootstrap),
       reviewerAccess: previewReviewerAccess(preview),
       blockers: preview.blockers,

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto"
 import { mkdir, readFile, realpath, writeFile } from "node:fs/promises"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { dirname, join, resolve } from "node:path"
-import { HostToolRegistry, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, parseCommandAgentRunRequest, resolveCommandPath, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
+import { HostToolRegistry, PREVIEW_LEASE_SCHEMA, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, parseCommandAgentRunRequest, previewLease, resolveCommandPath, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
@@ -46,6 +46,7 @@ import type {
   RuntimeEpisodeTraceRef,
   RuntimeInfo,
   RuntimeCommandResultEnvelope,
+  PreviewLease,
   Snapshot,
   RuntimeCheckpointResult,
   RuntimeCheckpointSpec,
@@ -57,6 +58,34 @@ function id(prefix: string): string {
 
 function commandExitCode(envelope: RuntimeCommandResultEnvelope | undefined): number {
   return envelope?.status === "error" ? 1 : 0
+}
+
+function previewAlignment(publicUrl: string | undefined, siteUrl: string | undefined, localUrl: string, checkedAt: string): PreviewLease["alignment"] {
+  const previewMatchesSite = originsMatch(publicUrl, siteUrl)
+  const previewMatchesLocal = originsMatch(publicUrl, localUrl)
+  return {
+    status: previewMatchesSite === undefined ? "unknown" : (previewMatchesSite ? "aligned" : "misaligned"),
+    checked_at: checkedAt,
+    ...(previewMatchesSite === undefined ? {} : { preview_matches_site: previewMatchesSite }),
+    ...(previewMatchesLocal === undefined ? {} : { preview_matches_local: previewMatchesLocal }),
+    evidence: {
+      publicUrlDeclared: Boolean(publicUrl),
+      siteUrlDeclared: Boolean(siteUrl),
+      localUrlDeclared: Boolean(localUrl),
+    },
+  }
+}
+
+function originsMatch(left: string | undefined, right: string | undefined): boolean | undefined {
+  if (!left || !right) {
+    return undefined
+  }
+
+  try {
+    return new URL(left).origin === new URL(right).origin
+  } catch {
+    return false
+  }
 }
 
 function commandEnvelopeStdout(envelope: RuntimeCommandResultEnvelope): string {
@@ -545,7 +574,7 @@ class PlaygroundRuntime implements Runtime {
 
     try {
       const server = await this.cliServerPromise
-      return this.spec.preview?.publicUrl ?? server.serverUrl
+      return this.spec.preview?.publicUrl ?? this.spec.preview?.lease?.public_url ?? this.spec.preview?.lease?.preview_public_url ?? server.serverUrl
     } catch {
       return undefined
     }
@@ -559,13 +588,16 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     const normalizedHoldSeconds = Math.max(0, Math.floor(holdSeconds))
     const expiresAt = normalizedHoldSeconds > 0 ? new Date(Date.now() + normalizedHoldSeconds * 1000).toISOString() : undefined
-    const publicUrl = this.spec.preview?.publicUrl
-    const siteUrl = this.spec.preview?.siteUrl
+    const publicUrl = this.spec.preview?.publicUrl ?? this.spec.preview?.lease?.public_url ?? this.spec.preview?.lease?.preview_public_url
+    const siteUrl = this.spec.preview?.siteUrl ?? this.spec.preview?.lease?.site_url ?? publicUrl
+    const lease = this.previewLease(server.serverUrl, publicUrl, siteUrl, createdAt, expiresAt)
 
     const preview: ArtifactPreview = {
       url: publicUrl ?? server.serverUrl,
-      ...(publicUrl ? { publicUrl, localUrl: server.serverUrl } : {}),
+      localUrl: server.serverUrl,
+      ...(publicUrl ? { publicUrl } : {}),
       ...(siteUrl ? { siteUrl } : {}),
+      lease,
       status: normalizedHoldSeconds > 0 ? "available" : "expired-on-completion",
       lifecycle: normalizedHoldSeconds > 0 ? "held-after-run" : "destroyed-on-completion",
       source: publicUrl ? "public-url-override" : "live-playground",
@@ -582,6 +614,39 @@ class PlaygroundRuntime implements Runtime {
       ...previewWithBootstrap,
       reviewerAccess: previewReviewerAccess(previewWithBootstrap),
     }
+  }
+
+  private previewLease(localUrl: string, publicUrl: string | undefined, siteUrl: string | undefined, createdAt: string, expiresAt: string | undefined): PreviewLease {
+    const supplied = this.spec.preview?.lease
+    const previewPublicUrl = publicUrl ?? supplied?.public_url ?? supplied?.preview_public_url
+    const leaseStatus = expiresAt ? "active" : "expired"
+
+    return previewLease({
+      schema: PREVIEW_LEASE_SCHEMA,
+      ...supplied,
+      public_url: previewPublicUrl,
+      preview_public_url: previewPublicUrl,
+      site_url: siteUrl ?? supplied?.site_url,
+      local_url: localUrl,
+      lease: {
+        ...supplied?.lease,
+        status: supplied?.lease?.status ?? leaseStatus,
+        acquired_at: supplied?.lease?.acquired_at ?? createdAt,
+        expires_at: supplied?.lease?.expires_at ?? expiresAt,
+        provider: supplied?.lease?.provider ?? "wp-codebox-runtime-playground",
+      },
+      alignment: supplied?.alignment ?? previewAlignment(publicUrl, siteUrl, localUrl, createdAt),
+      reachability: supplied?.reachability ?? {
+        status: previewPublicUrl ? "unknown" : "reachable",
+        checked_at: createdAt,
+        metadata: { source: previewPublicUrl ? "external-preview-url-not-probed" : "local-preview-server" },
+      },
+      metadata: {
+        ...supplied?.metadata,
+        handoff: "metadata-only",
+        reviewerAccessSafety: previewPublicUrl ? "public-url-declared" : "local-url-not-reviewer-safe",
+      },
+    })
   }
 
   private createReviewerAuthBootstrap(server: PlaygroundCliServer, preview: ArtifactPreview, expiresAt: string, commands: ExecutionResult[]): ArtifactReviewerAuthBootstrap | undefined {

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-preview-args-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-preview-args-builder.php
@@ -20,6 +20,7 @@ final class WP_Codebox_Host_Preview_Args_Builder {
 		$port   = $options['preview_port'];
 		$bind   = $options['preview_bind'];
 		$public = $options['preview_public_url'];
+		$lease  = $options['preview_lease'];
 
 		if ( null !== $port ) {
 			$args .= ' --preview-port ' . escapeshellarg( (string) $port );
@@ -29,6 +30,9 @@ final class WP_Codebox_Host_Preview_Args_Builder {
 		}
 		if ( null !== $public ) {
 			$args .= ' --preview-public-url ' . escapeshellarg( $public );
+		}
+		if ( null !== $lease ) {
+			$args .= ' --preview-lease-json ' . escapeshellarg( wp_json_encode( $lease ) );
 		}
 
 		return $args;

--- a/packages/wordpress-plugin/src/class-wp-codebox-preview-options.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-preview-options.php
@@ -48,17 +48,22 @@ final class WP_Codebox_Preview_Options {
 				'format'      => 'uri',
 				'description' => 'Optional public http/https URL reported in preview metadata and passed to the sandbox for site URL alignment.',
 			),
+			'preview_lease'        => array(
+				'type'        => 'object',
+				'description' => 'Optional wp-codebox/preview-lease/v1 envelope for external tunnel/public URL handoff metadata. WP Codebox reports it but does not create the tunnel.',
+			),
 		);
 	}
 
-	/** @param array<string,mixed> $input Preview option input. @return array{preview_hold_seconds:int,preview_port:?int,preview_bind:?string,preview_public_url:?string}|WP_Error */
+	/** @param array<string,mixed> $input Preview option input. @return array{preview_hold_seconds:int,preview_port:?int,preview_bind:?string,preview_public_url:?string,preview_lease:?array<string,mixed>}|WP_Error */
 	public static function normalize( array $input ): array|WP_Error {
 		$hold   = self::preview_hold_seconds( $input );
 		$port   = self::preview_port( $input );
 		$bind   = self::preview_bind( $input );
-		$public = self::preview_public_url( $input );
+		$lease  = self::preview_lease( $input );
+		$public = self::preview_public_url( $input, is_array( $lease ) ? $lease : null );
 
-		foreach ( array( $hold, $port, $bind, $public ) as $value ) {
+		foreach ( array( $hold, $port, $bind, $public, $lease ) as $value ) {
 			if ( is_wp_error( $value ) ) {
 				return $value;
 			}
@@ -73,6 +78,7 @@ final class WP_Codebox_Preview_Options {
 			'preview_port'         => $port,
 			'preview_bind'         => $bind,
 			'preview_public_url'   => $public,
+			'preview_lease'        => $lease,
 		);
 	}
 
@@ -156,10 +162,14 @@ final class WP_Codebox_Preview_Options {
 		return $bind;
 	}
 
-	/** @param array<string,mixed> $input Preview option input. */
-	private static function preview_public_url( array $input ): string|WP_Error|null {
+	/**
+	 * @param array<string,mixed>      $input Preview option input.
+	 * @param array<string,mixed>|null $lease Preview lease input.
+	 */
+	private static function preview_public_url( array $input, ?array $lease = null ): string|WP_Error|null {
 		if ( ! array_key_exists( 'preview_public_url', $input ) || '' === trim( (string) $input['preview_public_url'] ) ) {
-			return null;
+			$lease_public = is_array( $lease ) ? ( $lease['public_url'] ?? $lease['preview_public_url'] ?? null ) : null;
+			return is_string( $lease_public ) ? $lease_public : null;
 		}
 
 		$url   = trim( (string) $input['preview_public_url'] );
@@ -169,5 +179,41 @@ final class WP_Codebox_Preview_Options {
 		}
 
 		return $url;
+	}
+
+	/** @param array<string,mixed> $input Preview option input. @return array<string,mixed>|WP_Error|null */
+	private static function preview_lease( array $input ): array|WP_Error|null {
+		if ( ! array_key_exists( 'preview_lease', $input ) || null === $input['preview_lease'] || '' === $input['preview_lease'] ) {
+			return null;
+		}
+
+		$lease = $input['preview_lease'];
+		if ( is_string( $lease ) ) {
+			$decoded = json_decode( $lease, true );
+			if ( ! is_array( $decoded ) ) {
+				return new WP_Error( 'wp_codebox_preview_lease_invalid', 'preview_lease must be a JSON object using wp-codebox/preview-lease/v1.', array( 'status' => 400 ) );
+			}
+			$lease = $decoded;
+		}
+
+		if ( ! is_array( $lease ) || ( $lease['schema'] ?? null ) !== 'wp-codebox/preview-lease/v1' ) {
+			return new WP_Error( 'wp_codebox_preview_lease_invalid', 'preview_lease must use schema wp-codebox/preview-lease/v1.', array( 'status' => 400 ) );
+		}
+
+		$public = $lease['public_url'] ?? $lease['preview_public_url'] ?? null;
+		if ( null !== $public ) {
+			$input['preview_public_url'] = $public;
+			$valid_public = self::preview_public_url( $input );
+			if ( is_wp_error( $valid_public ) ) {
+				return $valid_public;
+			}
+			$lease['public_url']         = $valid_public;
+			$lease['preview_public_url'] = $valid_public;
+		}
+		if ( ! array_key_exists( 'evidence_refs', $lease ) ) {
+			$lease['evidence_refs'] = array();
+		}
+
+		return $lease;
 	}
 }


### PR DESCRIPTION
## Summary
- accept preview lease metadata in CLI, recipe, runtime, and host preview inputs
- include lease summaries in preview/reviewer-access artifacts
- report public/local URL alignment and reachability metadata without implementing a tunnel

## Testing
- git diff --check
- Homeboy Lab lint: runner-exec-homeboy-lab-8298e7d7-ec91-482d-88ca-81934a65baf7
- Homeboy Lab test/build attempted: runner-exec-homeboy-lab-41f5ae3f-08a4-415e-8ff3-ae37bd52e6fe

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing preview lease metadata reporting and drafting this PR description.