### PR TITLE
Fix recipe preview lease option type conflict

### DIFF
--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -14,7 +14,7 @@ export interface RecipeRunOptions {
   previewPort?: number
   previewBind?: string
   previewHoldBlocking: boolean
-  previewLease: boolean
+  previewLeaseRequested: boolean
   previewLeaseChild: boolean
   previewLeaseId?: string
   previewLeaseFile?: string

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -32,7 +32,7 @@ const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
 export async function runRecipeRunCommand(args: string[]): Promise<number> {
   const options = parseRecipeRunOptions(args)
-  if (options.previewLease && !options.previewLeaseChild) {
+  if (options.previewLeaseRequested && !options.previewLeaseChild) {
     return startPreviewLeaseRecipeRun({ args, json: options.json, recipePath: options.recipePath, artifactsDirectory: options.artifactsDirectory, runRegistryDirectory: options.runRegistryDirectory, previewHoldSeconds: options.previewHoldSeconds })
   }
   const interruption = options.dryRun ? undefined : createRecipeInterruptionController()
@@ -605,7 +605,7 @@ function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
     json: parsed.options.get("--json") === true,
     dryRun: parsed.options.get("--dry-run") === true,
     previewHoldBlocking: parsed.options.get("--preview-hold-blocking") === true,
-    previewLease: parsed.options.get("--preview-lease") === true,
+    previewLeaseRequested: parsed.options.get("--preview-lease") === true,
     previewLeaseChild: parsed.options.get("--preview-lease-child") === true,
     timeoutMs: DEFAULT_RECIPE_RUN_TIMEOUT_MS,
   }


### PR DESCRIPTION
## Summary
- Renames the boolean recipe run preview lease flag to avoid colliding with the parsed PreviewLease payload.
- Restores TypeScript build compatibility for current main.

## Testing
- npm ci
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the TypeScript build failure, making the small code change, and running verification.