### PR TITLE
Complete runtime contract manifest aliases

### DIFF
--- a/packages/runtime-core/src/provider-runtime-contracts.ts
+++ b/packages/runtime-core/src/provider-runtime-contracts.ts
@@ -35,6 +35,7 @@ export interface ProviderRuntimeInvocationContract {
     workspace_publication: "wp-codebox/runner-workspace-publication-result/v1"
     tool_call_transcript: "wp-codebox/tool-call-transcript/v1"
     evidence_artifact_envelope: "wp-codebox/evidence-artifact-envelope/v1"
+    artifact_result_envelope: "wp-codebox/artifact-result-envelope/v1"
   }
 }
 
@@ -89,6 +90,7 @@ export function providerRuntimeInvocationContract(): ProviderRuntimeInvocationCo
       workspace_publication: "wp-codebox/runner-workspace-publication-result/v1",
       tool_call_transcript: "wp-codebox/tool-call-transcript/v1",
       evidence_artifact_envelope: "wp-codebox/evidence-artifact-envelope/v1",
+      artifact_result_envelope: "wp-codebox/artifact-result-envelope/v1",
     },
   }
 }

--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -62,6 +62,7 @@ export const RUNTIME_CONTRACT_SCHEMAS = {
   agentTask: {
     runRequest: AGENT_TASK_RUN_REQUEST_SCHEMA,
     runResult: AGENT_TASK_RUN_RESULT_SCHEMA,
+    legacyRunResponse: AGENT_TASK_RUN_RESULT_SCHEMA,
   },
   runtimeBoundary: {
     profile: RUNTIME_PROFILE_SCHEMA,
@@ -107,6 +108,7 @@ export const RUNTIME_CONTRACT_SCHEMAS = {
     credentialResolution: PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA,
   },
   providerRuntime: {
+    invocation: PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
     invocationContract: PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA,
     credentialRequirements: PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA,
     credentialPreflight: PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA,

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -69,6 +69,7 @@ assert.deepEqual(manifest.abilities, CODEBOX_PUBLIC_RUNTIME_ABILITIES)
 
 assert.equal(manifest.schemas.agentTask.runRequest, AGENT_TASK_RUN_REQUEST_SCHEMA)
 assert.equal(manifest.schemas.agentTask.runResult, AGENT_TASK_RUN_RESULT_SCHEMA)
+assert.equal(manifest.schemas.agentTask.legacyRunResponse, AGENT_TASK_RUN_RESULT_SCHEMA)
 assert.equal(manifest.schemas.runtimeBoundary.profile, RUNTIME_PROFILE_SCHEMA)
 assert.equal(manifest.schemas.runtimeBoundary.previewLease, PREVIEW_LEASE_SCHEMA)
 assert.equal(manifest.schemas.runtimeBoundary.browserSessionProductDto, BROWSER_SESSION_PRODUCT_DTO_SCHEMA)
@@ -96,6 +97,7 @@ assert.equal(manifest.schemas.runtimeProvider.credentialRequirements, PROVIDER_C
 assert.equal(manifest.schemas.runtimeProvider.credentialPreflight, PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA)
 assert.equal(manifest.schemas.runtimeProvider.credentialResolution, PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA)
 assert.equal(manifest.schemas.providerRuntime.invocationContract, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
+assert.equal(manifest.schemas.providerRuntime.invocation, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
 assert.equal(manifest.schemas.providerRuntime.credentialRequirements, PROVIDER_CREDENTIAL_REQUIREMENTS_SCHEMA)
 assert.equal(manifest.schemas.providerRuntime.credentialPreflight, PROVIDER_CREDENTIAL_PREFLIGHT_SCHEMA)
 assert.equal(manifest.schemas.providerRuntime.credentialResolution, PROVIDER_CREDENTIAL_RESOLUTION_SCHEMA)
@@ -131,6 +133,7 @@ assert.equal(manifest.abilities.wordpressRuntime.runFuzzSuite, CODEBOX_RUN_FUZZ_
 assert.equal(manifest.providerRuntime.schema, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
 assert.deepEqual(manifest.providerRuntime.tasks, PROVIDER_RUNTIME_TASK_NAMES)
 assert.equal(manifest.providerRuntime.tasks.workspaceCommand, "wp-codebox.runner-workspace.command")
+assert.equal(manifest.providerRuntime.result_schemas.artifact_result_envelope, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
 
 const values = runtimeContractSchemaValues()
 assert.equal(new Set(values).size, values.length, "runtime contract schema constants must be unique")


### PR DESCRIPTION
## Summary
- Adds compatibility schema aliases expected by existing WP Codebox agent-runtime consumers.
- Includes `artifact_result_envelope` in the provider-runtime result schema contract.
- Keeps the canonical manifest data in WP Codebox so downstream validators do not need to relax their contract.

## Testing
- npm run build
- npm run test:runtime-contract-manifest
- npm run test:runtime-contract-package-exports
- `HOMEBOY_WP_CODEBOX_CORE_MODULE=/Users/chubes/Developer/wp-codebox@fix-complete-runtime-contract-manifest/packages/runtime-core/dist/index.js node .../agent-runtimes/wp-codebox/lib/wp-codebox-runtime-contract-source.js` validator check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the HBX runtime contract validation failure, adding compatibility aliases, and running verification.