### PR TITLE
Accept stable agent task CLI requests

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { artifactResultEnvelope, buildAgentTaskRecipe, DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput, parseCommandJson, parseCommandOptions, resolveEffectiveRuntimeToolPolicy, type AgentTaskRunInput, type AgentTaskRunResultSummary, type AgentTerminalResult, type ArtifactResultEnvelope, type SandboxToolPolicySnapshot } from "@automattic/wp-codebox-core"
+import { AGENT_TASK_RUN_REQUEST_SCHEMA, artifactResultEnvelope, buildAgentTaskRecipe, DEFAULT_WORDPRESS_VERSION, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput, parseCommandJson, parseCommandOptions, resolveEffectiveRuntimeToolPolicy, type AgentTaskRunInput, type AgentTaskRunResultSummary, type AgentTerminalResult, type ArtifactResultEnvelope, type SandboxToolPolicySnapshot } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { runRecipeRunCommand } from "./recipe-run.js"
 
@@ -76,7 +76,7 @@ const FAILURE_SNIPPET_CHARS = 4000
 
 export async function runAgentTaskRunCommand(args: string[]): Promise<number> {
   const options = parseAgentTaskRunOptions(args)
-  const input = JSON.parse(await readFile(options.inputPath, "utf8")) as AgentTaskRunInput
+  const input = normalizeAgentTaskRunCliInput(JSON.parse(await readFile(options.inputPath, "utf8")))
   const output = await runAgentTask(input, options)
 
   if (options.json) {
@@ -86,6 +86,24 @@ export async function runAgentTaskRunCommand(args: string[]): Promise<number> {
 
   process.stdout.write(`${output.status}: ${output.task}\n`)
   return agentTaskRunExitCode(output)
+}
+
+export function normalizeAgentTaskRunCliInput(input: unknown): AgentTaskRunInput {
+  const record = objectRecord(input)
+  if (record?.schema !== AGENT_TASK_RUN_REQUEST_SCHEMA) {
+    return input as AgentTaskRunInput
+  }
+
+  const taskInput = objectRecord(record.task_input)
+  if (!taskInput) {
+    return input as AgentTaskRunInput
+  }
+
+  return stripUndefined({
+    ...taskInput,
+    artifacts_path: record.artifacts_path ?? taskInput.artifacts_path,
+    callback_data: record.callback_data ?? taskInput.callback_data,
+  }) as AgentTaskRunInput
 }
 
 export function agentTaskRunExitCode(output: Pick<AgentTaskRunOutput, "agent_task_run_result" | "success">): number {
@@ -370,6 +388,10 @@ function parseAgentTaskRunOptions(args: string[]): AgentTaskRunOptions {
     previewHoldBlocking: options.get("--preview-hold-blocking") === true,
     previewLeaseJson: stringOption(options, "--preview-lease-json"),
   }
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined
 }
 
 async function captureOutput<T>(callback: () => Promise<T>): Promise<CapturedOutput<T>> {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, buildAgentTaskRecipe, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
+import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, buildAgentTaskRecipe, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
-import { agentTaskRunExitCode } from "../packages/cli/src/commands/agent-task-run.js"
+import { agentTaskRunExitCode, normalizeAgentTaskRunCliInput } from "../packages/cli/src/commands/agent-task-run.js"
 import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
 
@@ -15,6 +15,20 @@ assert.equal(AGENT_TASK_RUN_RESULT_JSON_SCHEMA.properties.schema.const, AGENT_TA
 assert.equal(succeeded.schema, AGENT_TASK_RUN_RESULT_SCHEMA)
 assert.equal(succeeded.status, "succeeded")
 assert.equal(agentTaskRunExitCode({ success: true, agent_task_run_result: succeeded }), 0)
+
+const stableRunRequestInput = normalizeAgentTaskRunCliInput({
+  schema: AGENT_TASK_RUN_REQUEST_SCHEMA,
+  task_id: "stable-run",
+  task_input: {
+    schema: "wp-codebox/task-input/v1",
+    goal: "Run the delegated task.",
+  },
+  artifacts_path: "/tmp/stable-run-artifacts",
+  callback_data: { source: "homeboy" },
+})
+assert.equal(stableRunRequestInput.goal, "Run the delegated task.")
+assert.equal(stableRunRequestInput.artifacts_path, "/tmp/stable-run-artifacts")
+assert.deepEqual(stableRunRequestInput.callback_data, { source: "homeboy" })
 
 const noOp = normalizeAgentTaskRunResult({ success: true, no_op: true }, { exitStatus: 0 })
 assert.equal(noOp.status, "no_op")


### PR DESCRIPTION
## Summary
- Unwrap stable `wp-codebox/agent-task-run-request/v1` inputs at the CLI boundary before running the existing agent task handler.
- Carry wrapper-level `artifacts_path` and `callback_data` into the legacy task input shape.
- Add focused coverage for the stable request wrapper.

## Verification
- `node --import tsx tests/agent-task-contracts.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy fuzz fallback failure, implementing the CLI request unwrapping, and adding regression coverage.