### PR TITLE
Include bundled runtime plugin in agent tasks

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import type { StructuredArtifactPayload } from "./structured-artifacts.js"
 import type { TaskInput } from "./task-input.js"
@@ -188,12 +189,19 @@ function defaultRuntimeComponentPlugins(): WorkspaceRecipeExtraPlugin[] {
 }
 
 function defaultRuntimeComponentPaths(): string[] {
-  return (process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
+  return [
+    ...(process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
     .split(/[,:]/)
     .map((value) => value.trim())
-    .filter(Boolean)
+    .filter(Boolean),
+    ...bundledRuntimeComponentPaths(),
+  ]
     .map((value) => resolve(value))
-    .filter((source) => existsSync(source))
+    .filter((source, index, sources) => existsSync(source) && sources.indexOf(source) === index)
+}
+
+function bundledRuntimeComponentPaths(): string[] {
+  return [resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "wordpress-plugin")]
 }
 
 export function componentManifestForRuntimePlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], providerPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeComponentManifest {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -171,6 +171,8 @@ try {
     artifacts_path: artifactsPath,
     provider_plugin_paths: [providerSource],
   }, normalizeTaskInput({ goal: "Verify generic runtime propagation" }), "latest")
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), false)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), false)
 


### PR DESCRIPTION
## Summary
- Include the bundled `packages/wordpress-plugin` as a default runtime component for agent-task recipes when present.
- Keep env-provided runtime component paths and dedupe resolved component paths.
- Add coverage that generic agent-task recipes carry the bundled WP Codebox plugin component.

## Verification
- `node --import tsx tests/agent-task-contracts.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing missing sandbox runtime abilities, implementing the bundled plugin fallback, and adding regression coverage.