### PR TITLE
Add generic preview lease provider contract

### DIFF
--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -10,7 +10,7 @@ import type {
   RUNTIME_EPISODE_SNAPSHOT_SCHEMA,
   RUNTIME_EPISODE_TRACE_SCHEMA,
 } from "./runtime-episode-contracts.js"
-import type { PreviewLease, PreviewLeaseLifecycleStatus } from "./runtime-boundary-contracts.js"
+import type { PreviewLease, PreviewLeaseLifecycleStatus, PreviewReachabilityEvidence } from "./runtime-boundary-contracts.js"
 
 export type RuntimeBackendKind = "wordpress-playground" | (string & {})
 
@@ -66,6 +66,41 @@ export interface RuntimePreviewSpec {
   port?: number
   bind?: string
   lease?: PreviewLease
+  leaseProvider?: RuntimePreviewLeaseProvider
+}
+
+export interface RuntimePreviewLeaseProvider {
+  acquire(request: RuntimePreviewLeaseAcquireRequest): Promise<PreviewLease> | PreviewLease
+  probe?(lease: PreviewLease): Promise<RuntimePreviewLeaseProbeResult> | RuntimePreviewLeaseProbeResult
+  release?(lease: PreviewLease, request: RuntimePreviewLeaseReleaseRequest): Promise<RuntimePreviewLeaseReleaseResult | void> | RuntimePreviewLeaseReleaseResult | void
+}
+
+export interface RuntimePreviewLeaseAcquireRequest {
+  localUrl: string
+  requestedPublicUrl?: string
+  requestedSiteUrl?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface RuntimePreviewLeaseProbeResult {
+  status: PreviewReachabilityEvidence["status"]
+  lease?: PreviewLease
+  reachability?: PreviewReachabilityEvidence
+  evidence_refs?: Record<string, unknown>[]
+  metadata?: Record<string, unknown>
+}
+
+export interface RuntimePreviewLeaseReleaseRequest {
+  status: Extract<PreviewLeaseLifecycleStatus, "released"> | "failed"
+  reason: "runtime-dispose" | "acquire-failed" | "probe-failed" | "startup-failed" | (string & {})
+  error?: Record<string, unknown>
+}
+
+export interface RuntimePreviewLeaseReleaseResult {
+  status: Extract<PreviewLeaseLifecycleStatus, "released"> | "unknown"
+  released_at?: string
+  evidence_refs?: Record<string, unknown>[]
+  metadata?: Record<string, unknown>
 }
 
 export interface WorkspaceRecipeMount {

--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -2,7 +2,7 @@ import { playgroundBlueprint } from "./blueprint.js"
 import { PlaygroundCliExitError, type PlaygroundCliBufferedOutput } from "./playground-command-errors.js"
 import { PlaygroundPreviewPortUnavailableError, assertPreviewPortAvailable, errorHasCode, withPreviewProxy, type PlaygroundCliServer } from "./preview-server.js"
 import { startProgrammaticPlaygroundServer } from "./programmatic-playground-runner.js"
-import type { BrowserStartupProgressEvent, BrowserStartupProgressPhase, BrowserStartupProgressStatus, MountSpec, RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { previewLease, type BrowserStartupProgressEvent, type BrowserStartupProgressPhase, type BrowserStartupProgressStatus, type MountSpec, type PreviewLease, type RuntimeCreateSpec, type RuntimePreviewLeaseProvider } from "@automattic/wp-codebox-core"
 import { randomInt } from "node:crypto"
 import { existsSync } from "node:fs"
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http"
@@ -145,10 +145,11 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
       fixedPreviewPort: spec.preview?.port ?? null,
     })
 
-    const proxiedServer = await withPreviewProxy(server, spec.preview?.port ?? 0, spec.preview?.bind)
+    const proxiedServer = await withPreviewLeaseProvider(await withPreviewProxy(server, spec.preview?.port ?? 0, spec.preview?.bind), spec)
     emitProgress("preview:ready", "complete", "Preview ready", {
       localUrl: proxiedServer.serverUrl,
       upstreamUrl: server.serverUrl,
+      lease: proxiedServer.previewLease ? previewLeaseDetail(proxiedServer.previewLease) : undefined,
     })
     return proxiedServer
   } catch (error) {
@@ -161,6 +162,85 @@ export async function startPlaygroundCliServer(spec: RuntimeCreateSpec, mounts: 
     }
 
     throw error
+  }
+}
+
+async function withPreviewLeaseProvider(server: PlaygroundCliServer, spec: RuntimeCreateSpec): Promise<PlaygroundCliServer> {
+  const provider = spec.preview?.leaseProvider
+  if (!provider) {
+    return server
+  }
+
+  let lease: PreviewLease | undefined
+  try {
+    lease = previewLease(await provider.acquire({
+      localUrl: server.serverUrl,
+      requestedPublicUrl: spec.preview?.publicUrl,
+      requestedSiteUrl: spec.preview?.siteUrl,
+      metadata: { backend: spec.backend },
+    }))
+    lease = await probePreviewLease(provider, lease)
+  } catch (error) {
+    if (lease) {
+      await safeReleasePreviewLease(provider, lease, "probe-failed", error)
+    }
+    await server[Symbol.asyncDispose]()
+    throw error
+  }
+
+  return {
+    ...server,
+    previewLease: lease,
+    async [Symbol.asyncDispose]() {
+      try {
+        await safeReleasePreviewLease(provider, lease, "runtime-dispose")
+      } finally {
+        await server[Symbol.asyncDispose]()
+      }
+    },
+  }
+}
+
+async function probePreviewLease(provider: RuntimePreviewLeaseProvider, lease: PreviewLease): Promise<PreviewLease> {
+  const result = await provider.probe?.(lease)
+  if (!result) {
+    return lease
+  }
+
+  const probedLease = previewLease({
+    ...lease,
+    ...(result.lease ?? {}),
+    reachability: result.reachability ?? result.lease?.reachability ?? {
+      status: result.status,
+      checked_at: new Date().toISOString(),
+      ...(result.evidence_refs ? { evidence_refs: result.evidence_refs } : {}),
+      ...(result.metadata ? { metadata: result.metadata } : {}),
+    },
+    evidence_refs: result.evidence_refs ?? result.lease?.evidence_refs ?? lease.evidence_refs,
+  })
+  if (result.status === "unreachable") {
+    throw new PreviewLeaseProbeError(probedLease)
+  }
+
+  return probedLease
+}
+
+async function safeReleasePreviewLease(provider: RuntimePreviewLeaseProvider, lease: PreviewLease, reason: "runtime-dispose" | "probe-failed", error?: unknown): Promise<void> {
+  try {
+    await provider.release?.(lease, {
+      status: error ? "failed" : "released",
+      reason,
+      ...(error ? { error: errorDetail(error) } : {}),
+    })
+  } catch {
+    // Local runtime cleanup must still proceed even if an external lease provider fails release.
+  }
+}
+
+class PreviewLeaseProbeError extends Error {
+  constructor(readonly lease: PreviewLease) {
+    super("Preview lease probe reported unreachable preview.")
+    this.name = "PreviewLeaseProbeError"
   }
 }
 
@@ -357,6 +437,16 @@ function previewDetail(spec: RuntimeCreateSpec): Record<string, unknown> {
     hasSiteUrl: Boolean(spec.preview?.siteUrl),
     hasFixedPort: spec.preview?.port !== undefined,
     bind: spec.preview?.bind ?? null,
+    hasLeaseProvider: Boolean(spec.preview?.leaseProvider),
+  }
+}
+
+function previewLeaseDetail(lease: PreviewLease): Record<string, unknown> {
+  return {
+    provider: lease.lease?.provider ?? null,
+    status: lease.lease?.status ?? null,
+    reachability: lease.reachability?.status ?? null,
+    hasPublicUrl: Boolean(lease.public_url ?? lease.preview_public_url),
   }
 }
 

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -574,7 +574,7 @@ class PlaygroundRuntime implements Runtime {
 
     try {
       const server = await this.cliServerPromise
-      return this.spec.preview?.publicUrl ?? this.spec.preview?.lease?.public_url ?? this.spec.preview?.lease?.preview_public_url ?? server.serverUrl
+      return this.spec.preview?.publicUrl ?? server.previewLease?.public_url ?? server.previewLease?.preview_public_url ?? this.spec.preview?.lease?.public_url ?? this.spec.preview?.lease?.preview_public_url ?? server.serverUrl
     } catch {
       return undefined
     }
@@ -588,9 +588,10 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     const normalizedHoldSeconds = Math.max(0, Math.floor(holdSeconds))
     const expiresAt = normalizedHoldSeconds > 0 ? new Date(Date.now() + normalizedHoldSeconds * 1000).toISOString() : undefined
-    const publicUrl = this.spec.preview?.publicUrl ?? this.spec.preview?.lease?.public_url ?? this.spec.preview?.lease?.preview_public_url
-    const siteUrl = this.spec.preview?.siteUrl ?? this.spec.preview?.lease?.site_url ?? publicUrl
-    const lease = this.previewLease(server.serverUrl, publicUrl, siteUrl, createdAt, expiresAt)
+    const activeLease = server.previewLease ?? this.spec.preview?.lease
+    const publicUrl = this.spec.preview?.publicUrl ?? activeLease?.public_url ?? activeLease?.preview_public_url
+    const siteUrl = this.spec.preview?.siteUrl ?? activeLease?.site_url ?? publicUrl
+    const lease = this.previewLease(server.serverUrl, publicUrl, siteUrl, createdAt, expiresAt, activeLease)
 
     const preview: ArtifactPreview = {
       url: publicUrl ?? server.serverUrl,
@@ -616,8 +617,7 @@ class PlaygroundRuntime implements Runtime {
     }
   }
 
-  private previewLease(localUrl: string, publicUrl: string | undefined, siteUrl: string | undefined, createdAt: string, expiresAt: string | undefined): PreviewLease {
-    const supplied = this.spec.preview?.lease
+  private previewLease(localUrl: string, publicUrl: string | undefined, siteUrl: string | undefined, createdAt: string, expiresAt: string | undefined, supplied = this.spec.preview?.lease): PreviewLease {
     const previewPublicUrl = publicUrl ?? supplied?.public_url ?? supplied?.preview_public_url
     const leaseStatus = expiresAt ? "active" : "expired"
 

--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -1,5 +1,6 @@
 import { createServer as createHttpServer, request as httpRequest, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from "node:http"
 import { createServer as createNetServer } from "node:net"
+import type { PreviewLease } from "@automattic/wp-codebox-core"
 
 export interface PlaygroundServerRunResponse {
   exitCode?: number
@@ -15,6 +16,7 @@ export interface PlaygroundCliServer {
     writeFile?(path: string, contents: string): Promise<void>
   }
   serverUrl: string
+  previewLease?: PreviewLease
   previewRoutes?: PlaygroundPreviewRouteRegistry
   previewProxyDiagnostics?: PlaygroundPreviewProxyDiagnostics
   [Symbol.asyncDispose](): Promise<void>

--- a/tests/preview-lease-provider.test.ts
+++ b/tests/preview-lease-provider.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict"
+import { startPlaygroundCliServer } from "../packages/runtime-playground/src/playground-cli-runner.js"
+import type { PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
+import type { RuntimeCreateSpec, RuntimePreviewLeaseProvider } from "../packages/runtime-core/src/index.js"
+
+const baseSpec: RuntimeCreateSpec = {
+  backend: "wordpress-playground",
+  environment: {
+    version: "mounted-wordpress-source",
+    wordpressInstallMode: "do-not-attempt-installing",
+    assets: { wordpressDirectory: "/tmp/wordpress" },
+    blueprint: {},
+  },
+  policy: {
+    network: "deny",
+    filesystem: "readwrite-mounts",
+    commands: [],
+    secrets: "none",
+    approvals: "never",
+  },
+}
+
+function cliModule(disposed: { value: boolean }) {
+  return {
+    async runCLI(): Promise<PlaygroundCliServer> {
+      return {
+        playground: {
+          async run() {
+            return { text: "" }
+          },
+        },
+        serverUrl: "http://127.0.0.1:65535",
+        async [Symbol.asyncDispose]() {
+          disposed.value = true
+        },
+      }
+    },
+  }
+}
+
+{
+  const calls: string[] = []
+  const disposed = { value: false }
+  let acquiredLocalUrl = ""
+  let releasedStatus = ""
+  const provider: RuntimePreviewLeaseProvider = {
+    acquire(request) {
+      calls.push("acquire")
+      acquiredLocalUrl = request.localUrl
+      return {
+        schema: "wp-codebox/preview-lease/v1",
+        public_url: "https://preview.example.test/site",
+        local_url: request.localUrl,
+        lease: { id: "lease-1", status: "active", provider: "test-provider" },
+      }
+    },
+    probe(lease) {
+      calls.push("probe")
+      return {
+        status: "reachable",
+        lease: {
+          ...lease,
+          reachability: { status: "reachable", checked_at: "2026-06-22T00:00:00.000Z" },
+        },
+      }
+    },
+    release(_lease, request) {
+      calls.push("release")
+      releasedStatus = request.status
+    },
+  }
+
+  const server = await startPlaygroundCliServer({ ...baseSpec, preview: { leaseProvider: provider } }, [], { cliModule: cliModule(disposed) })
+  assert.deepEqual(calls, ["acquire", "probe"])
+  assert.equal(server.previewLease?.public_url, "https://preview.example.test/site")
+  assert.equal(server.previewLease?.reachability?.status, "reachable")
+  assert.match(acquiredLocalUrl, /^http:\/\/127\.0\.0\.1:/)
+
+  await server[Symbol.asyncDispose]()
+  assert.deepEqual(calls, ["acquire", "probe", "release"])
+  assert.equal(releasedStatus, "released")
+  assert.equal(disposed.value, true)
+}
+
+{
+  const calls: string[] = []
+  const disposed = { value: false }
+  const provider: RuntimePreviewLeaseProvider = {
+    acquire(request) {
+      calls.push("acquire")
+      return {
+        schema: "wp-codebox/preview-lease/v1",
+        public_url: "https://preview.example.test/site",
+        local_url: request.localUrl,
+        lease: { id: "lease-2", status: "active", provider: "test-provider" },
+      }
+    },
+    probe() {
+      calls.push("probe")
+      return { status: "unreachable" }
+    },
+    release(_lease, request) {
+      calls.push(`release:${request.status}:${request.reason}`)
+    },
+  }
+
+  await assert.rejects(
+    startPlaygroundCliServer({ ...baseSpec, preview: { leaseProvider: provider } }, [], { cliModule: cliModule(disposed) }),
+    /Preview lease probe reported unreachable preview/,
+  )
+  assert.deepEqual(calls, ["acquire", "probe", "release:failed:probe-failed"])
+  assert.equal(disposed.value, true)
+}
+
+console.log("preview lease provider lifecycle ok")


### PR DESCRIPTION
## Summary
- Adds a runtime-agnostic preview lease provider callback contract on RuntimePreviewSpec.
- Invokes acquire/probe after the local Playground preview proxy is live and releases leases during cleanup.
- Preserves provider-owned implementation outside core and carries acquired/probed lease evidence into preview artifacts.
- Adds behavior coverage for acquisition, probe, release, and probe-failure cleanup.

## Tests
- npx tsx tests/preview-lease-provider.test.ts
- npm run build
- npm run test:runtime-contract-manifest

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Implementing the preview lease provider contract, runtime-playground lifecycle wiring, tests, and verification.