### PR TITLE
Normalize runtime local preview access

### DIFF
--- a/packages/runtime-core/src/agent-task-run-result.ts
+++ b/packages/runtime-core/src/agent-task-run-result.ts
@@ -146,15 +146,23 @@ export function normalizeAgentTaskRunResult(raw: unknown, options: AgentTaskRunR
 function agentTaskRuntimeAccess(result: Record<string, unknown>): RuntimeAccess | undefined {
   const explicit = objectValue(result.runtime_access)
   const outputs = objectValue(result.outputs)
+  const preview = objectValue(result.preview)
   const source = Object.keys(explicit).length > 0 ? explicit : outputs
+  const reviewerAccess = objectValue(source.reviewer_access ?? source.reviewerAccess ?? preview.reviewerAccess ?? preview.reviewer_access)
+  const reviewerUrl = stringValue(reviewerAccess.openUrl) || stringValue(reviewerAccess.targetUrl)
+  const publicUrl = stringValue(source.public_url ?? source.publicUrl ?? source.preview_public_url ?? source.previewPublicUrl) || stringValue(preview.publicUrl ?? preview.public_url ?? preview.previewPublicUrl ?? preview.preview_public_url)
+  const siteUrl = stringValue(source.site_url ?? source.siteUrl) || stringValue(preview.siteUrl ?? preview.site_url)
+  const directPreviewUrl = stringValue(source.preview_url ?? source.previewUrl) || stringValue(preview.preview_url ?? preview.previewUrl)
+  const fallbackPreviewUrl = directPreviewUrl || (publicUrl || siteUrl || reviewerUrl ? "" : stringValue(preview.url))
   const candidate = stripUndefined({
     schema: RUNTIME_ACCESS_SCHEMA,
-    preview_url: stringValue(source.preview_url ?? source.previewUrl),
-    public_url: stringValue(source.public_url ?? source.publicUrl ?? source.preview_public_url ?? source.previewPublicUrl),
-    site_url: stringValue(source.site_url ?? source.siteUrl),
+    preview_url: fallbackPreviewUrl,
+    public_url: publicUrl,
+    site_url: siteUrl,
+    local_url: stringValue(source.local_url ?? source.localUrl) || stringValue(preview.localUrl ?? preview.local_url),
     admin_url: stringValue(source.admin_url ?? source.adminUrl),
-    lease: source.lease,
-    reviewer_access: Object.keys(objectValue(source.reviewer_access ?? source.reviewerAccess)).length > 0 ? objectValue(source.reviewer_access ?? source.reviewerAccess) : undefined,
+    lease: source.lease ?? preview.lease,
+    reviewer_access: Object.keys(reviewerAccess).length > 0 ? reviewerAccess : undefined,
     metadata: Object.keys(objectValue(source.metadata)).length > 0 ? objectValue(source.metadata) : undefined,
   })
 

--- a/packages/runtime-core/src/artifact-references.ts
+++ b/packages/runtime-core/src/artifact-references.ts
@@ -266,14 +266,21 @@ function browserSessionRuntimeAccess(session: Record<string, unknown>): RuntimeA
   const previewBoot = asRecord(session.preview_boot)
   const preview = asRecord(previewBoot?.preview)
   if (!preview) return undefined
+  const reviewerAccess = asRecord(preview.reviewer_access) ?? asRecord(preview.reviewerAccess)
+  const reviewerUrl = stringValue(reviewerAccess?.openUrl) || stringValue(reviewerAccess?.targetUrl)
+  const publicUrl = stringValue(preview.public_url ?? preview.publicUrl ?? preview.preview_public_url ?? preview.previewPublicUrl)
+  const siteUrl = stringValue(preview.site_url ?? preview.siteUrl)
+  const directPreviewUrl = stringValue(preview.preview_url ?? preview.previewUrl)
+  const fallbackPreviewUrl = directPreviewUrl || (publicUrl || siteUrl || reviewerUrl ? "" : stringValue(preview.url))
 
   try {
     return normalizeRuntimeAccess({
-      preview_url: preview.preview_url ?? preview.previewUrl ?? preview.public_url ?? preview.publicUrl ?? preview.preview_public_url ?? preview.previewPublicUrl,
-      public_url: preview.public_url ?? preview.publicUrl ?? preview.preview_public_url ?? preview.previewPublicUrl,
-      site_url: preview.site_url ?? preview.siteUrl,
+      preview_url: fallbackPreviewUrl,
+      public_url: publicUrl,
+      site_url: siteUrl,
+      local_url: preview.local_url ?? preview.localUrl,
       lease: preview.schema === "wp-codebox/preview-lease/v1" ? preview : undefined,
-      reviewer_access: preview.reviewer_access ?? preview.reviewerAccess,
+      reviewer_access: reviewerAccess,
     })
   } catch {
     return undefined

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -248,11 +248,17 @@ function recipeRunRuntimeAccess(result: Record<string, unknown>): RuntimeAccess 
   const previewAccess = objectValue(preview.runtime_access ?? preview.runtimeAccess)
   const value = Object.keys(explicit).length > 0 ? explicit : Object.keys(artifactAccess).length > 0 ? artifactAccess : previewAccess
   const reviewerAccess = objectValue(value.reviewer_access ?? value.reviewerAccess ?? preview.reviewerAccess)
+  const reviewerUrl = stringValue(reviewerAccess.openUrl) || stringValue(reviewerAccess.targetUrl)
+  const publicUrl = stringValue(value.public_url ?? value.publicUrl ?? value.preview_public_url ?? value.previewPublicUrl) || stringValue(outputs.public_url ?? outputs.publicUrl ?? outputs.preview_public_url ?? outputs.previewPublicUrl) || stringValue(preview.publicUrl ?? preview.public_url ?? preview.previewPublicUrl ?? preview.preview_public_url)
+  const siteUrl = stringValue(value.site_url ?? value.siteUrl) || stringValue(outputs.site_url ?? outputs.siteUrl) || stringValue(preview.siteUrl ?? preview.site_url)
+  const directPreviewUrl = stringValue(value.preview_url ?? value.previewUrl) || stringValue(outputs.preview_url ?? outputs.previewUrl) || stringValue(preview.preview_url ?? preview.previewUrl)
+  const fallbackPreviewUrl = directPreviewUrl || (publicUrl || siteUrl || reviewerUrl ? "" : stringValue(preview.url))
   const candidate = stripUndefined({
     schema: RUNTIME_ACCESS_SCHEMA,
-    preview_url: stringValue(value.preview_url ?? value.previewUrl) || stringValue(outputs.preview_url ?? outputs.previewUrl) || stringValue(reviewerAccess.openUrl) || stringValue(reviewerAccess.targetUrl),
-    public_url: stringValue(value.public_url ?? value.publicUrl ?? value.preview_public_url ?? value.previewPublicUrl) || stringValue(outputs.public_url ?? outputs.publicUrl ?? outputs.preview_public_url ?? outputs.previewPublicUrl),
-    site_url: stringValue(value.site_url ?? value.siteUrl) || stringValue(outputs.site_url ?? outputs.siteUrl),
+    preview_url: fallbackPreviewUrl,
+    public_url: publicUrl,
+    site_url: siteUrl,
+    local_url: stringValue(value.local_url ?? value.localUrl) || stringValue(outputs.local_url ?? outputs.localUrl) || stringValue(preview.localUrl ?? preview.local_url),
     admin_url: stringValue(value.admin_url ?? value.adminUrl) || stringValue(outputs.admin_url ?? outputs.adminUrl),
     lease: value.lease ?? preview.lease,
     reviewer_access: Object.keys(reviewerAccess).length > 0 ? reviewerAccess : undefined,

--- a/packages/runtime-core/src/runtime-boundary-contracts.ts
+++ b/packages/runtime-core/src/runtime-boundary-contracts.ts
@@ -119,6 +119,7 @@ export interface RuntimeAccess {
   preview_url?: string
   public_url?: string
   site_url?: string
+  local_url?: string
   admin_url?: string
   lease?: PreviewLease
   reviewer_access?: Record<string, unknown>
@@ -290,24 +291,28 @@ export function runtimeAccess(input: unknown): RuntimeAccess {
     ?? lease?.public_url
     ?? lease?.preview_public_url
     ?? lease?.site_url
+    ?? optionalString(value.local_url ?? value.localUrl, "runtime_access.local_url")
+    ?? lease?.local_url
   const publicUrl = optionalString(value.public_url ?? value.publicUrl, "runtime_access.public_url")
     ?? optionalString(value.preview_public_url ?? value.previewPublicUrl, "runtime_access.preview_public_url")
     ?? lease?.public_url
     ?? lease?.preview_public_url
   const siteUrl = optionalString(value.site_url ?? value.siteUrl, "runtime_access.site_url") ?? lease?.site_url
+  const localUrl = optionalString(value.local_url ?? value.localUrl, "runtime_access.local_url") ?? lease?.local_url
 
   const access = {
     schema: RUNTIME_ACCESS_SCHEMA,
     preview_url: previewUrl,
     public_url: publicUrl,
     site_url: siteUrl,
+    local_url: localUrl,
     admin_url: optionalString(value.admin_url ?? value.adminUrl, "runtime_access.admin_url"),
     lease,
     reviewer_access: reviewerAccess,
     metadata: normalizeOptionalObject(value.metadata, "runtime_access.metadata"),
   }
-  if (!access.preview_url && !access.public_url && !access.site_url && !access.admin_url && !access.lease && !access.reviewer_access) {
-    throw new Error("Runtime access must include preview_url, public_url, site_url, admin_url, lease, or reviewer_access.")
+  if (!access.preview_url && !access.public_url && !access.site_url && !access.local_url && !access.admin_url && !access.lease && !access.reviewer_access) {
+    throw new Error("Runtime access must include preview_url, public_url, site_url, local_url, admin_url, lease, or reviewer_access.")
   }
   return stripUndefined(access) as RuntimeAccess
 }

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, buildAgentTaskRecipe, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
+import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, PREVIEW_LEASE_SCHEMA, buildAgentTaskRecipe, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeRecipeRunSummary, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
 import { agentTaskRunExitCode, normalizeAgentTaskRunCliInput } from "../packages/cli/src/commands/agent-task-run.js"
@@ -20,6 +20,50 @@ const succeededWithAccess = normalizeAgentTaskRunResult({ success: true, status:
 assert.equal(succeededWithAccess.runtime_access?.schema, "wp-codebox/runtime-access/v1")
 assert.equal(succeededWithAccess.runtime_access?.preview_url, "https://preview.example.test")
 assert.equal(succeededWithAccess.runtime_access?.site_url, "https://site.example.test")
+
+const previewLease = {
+  schema: PREVIEW_LEASE_SCHEMA,
+  local_url: "http://127.0.0.1:9400/",
+  lease: { status: "active", provider: "preview-runtime" },
+}
+
+const agentPreviewAccess = normalizeAgentTaskRunResult({
+  success: true,
+  status: "completed",
+  preview: {
+    url: "https://preview.example.test/",
+    localUrl: "http://127.0.0.1:9400/",
+    lease: previewLease,
+  },
+}, { exitStatus: 0 })
+assert.equal(agentPreviewAccess.runtime_access?.preview_url, "https://preview.example.test/")
+assert.equal(agentPreviewAccess.runtime_access?.local_url, "http://127.0.0.1:9400/")
+assert.equal(agentPreviewAccess.runtime_access?.lease?.local_url, "http://127.0.0.1:9400/")
+
+const agentLocalLeaseAccess = normalizeAgentTaskRunResult({
+  success: true,
+  status: "completed",
+  preview: { localUrl: "http://127.0.0.1:9400/", lease: previewLease },
+}, { exitStatus: 0 })
+assert.equal(agentLocalLeaseAccess.runtime_access?.preview_url, "http://127.0.0.1:9400/")
+assert.equal(agentLocalLeaseAccess.runtime_access?.local_url, "http://127.0.0.1:9400/")
+
+const recipePreviewAccess = normalizeRecipeRunSummary({
+  success: true,
+  status: "completed",
+  run: {
+    preview: {
+      url: "https://preview.example.test/",
+      localUrl: "http://127.0.0.1:9400/",
+      publicUrl: "https://review.example.test/",
+      lease: previewLease,
+    },
+  },
+}, { exitStatus: 0 })
+assert.equal(recipePreviewAccess.runtime_access?.preview_url, "https://review.example.test/")
+assert.equal(recipePreviewAccess.runtime_access?.public_url, "https://review.example.test/")
+assert.equal(recipePreviewAccess.runtime_access?.local_url, "http://127.0.0.1:9400/")
+assert.equal(recipePreviewAccess.preview?.runtime_access?.lease?.local_url, "http://127.0.0.1:9400/")
 
 const stableRunRequestInput = normalizeAgentTaskRunCliInput({
   schema: AGENT_TASK_RUN_REQUEST_SCHEMA,

--- a/tests/runtime-boundary-contracts.test.ts
+++ b/tests/runtime-boundary-contracts.test.ts
@@ -103,8 +103,31 @@ const runtimeAccess = normalizeRuntimeAccess({
 assert.equal(runtimeAccess.schema, "wp-codebox/runtime-access/v1")
 assert.equal(runtimeAccess.preview_url, "https://preview.example.test")
 assert.equal(runtimeAccess.site_url, "https://site.example.test")
+assert.equal(runtimeAccess.local_url, "http://127.0.0.1:8881")
 assert.equal(runtimeAccess.lease?.preview_public_url, "https://preview.example.test")
 assert.equal(runtimeAccess.reviewer_access?.openUrl, "https://preview.example.test")
+
+const localOnlyRuntimeAccess = normalizeRuntimeAccess({
+  schema: RUNTIME_ACCESS_SCHEMA,
+  lease: {
+    schema: PREVIEW_LEASE_SCHEMA,
+    local_url: "http://127.0.0.1:9400/",
+    lease: { status: "active", provider: "local-preview" },
+  },
+})
+assert.equal(localOnlyRuntimeAccess.preview_url, "http://127.0.0.1:9400/")
+assert.equal(localOnlyRuntimeAccess.local_url, "http://127.0.0.1:9400/")
+
+const publicRuntimeAccess = normalizeRuntimeAccess({
+  schema: RUNTIME_ACCESS_SCHEMA,
+  public_url: "https://review.example.test/",
+  lease: {
+    schema: PREVIEW_LEASE_SCHEMA,
+    local_url: "http://127.0.0.1:9400/",
+  },
+})
+assert.equal(publicRuntimeAccess.preview_url, "https://review.example.test/")
+assert.equal(publicRuntimeAccess.local_url, "http://127.0.0.1:9400/")
 
 const containedSiteStatus = browserContainedSiteStatus({
   schema: BROWSER_CONTAINED_SITE_STATUS_SCHEMA,


### PR DESCRIPTION
## Summary
- Add canonical `runtime_access.local_url` support and derive `preview_url` from local preview leases only when no public, site, or reviewer URL is available.
- Preserve `preview.url`, `preview.localUrl`, and preview lease data through browser session, recipe run, and agent task summaries.
- Add behavior coverage for canonical runtime access results, including local-only fallback and public URL precedence.

## Tests
- `npx tsx tests/runtime-boundary-contracts.test.ts`
- `npm run test:agent-task-contracts`
- `npm run test:browser-session-public-dto`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime access normalization fix, adding behavior tests, and preparing this PR.