### PR TITLE
Standardize runtime command result envelopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "test:provider-runtime-contracts": "tsx tests/provider-runtime-contracts.test.ts",
     "test:runtime-contract-manifest": "tsx tests/runtime-contract-manifest.test.ts",
     "test:runtime-contract-package-exports": "tsx tests/runtime-contract-package-exports.test.ts",
+    "test:runtime-command-result-envelope": "tsx tests/runtime-command-result-envelope.test.ts",
     "test:wordpress-runtime-discovery-contracts": "tsx tests/wordpress-runtime-discovery-contracts.test.ts",
     "test:wordpress-block-fuzz-suite": "tsx tests/wordpress-block-fuzz-suite.test.ts",
     "test:runtime-package-execution": "tsx tests/runtime-package-execution.test.ts",

--- a/packages/runtime-core/src/runtime-command-result.ts
+++ b/packages/runtime-core/src/runtime-command-result.ts
@@ -1,8 +1,44 @@
-import { RUNTIME_COMMAND_RESULT_SCHEMA, type RuntimeCommandResultEnvelope } from "./runtime-contracts.js"
+import { RUNTIME_COMMAND_RESULT_SCHEMA, type RuntimeCommandResultEnvelope, type RuntimeCommandResultError, type RuntimeCommandResultStatus, type RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
 
 export function createRuntimeCommandResultEnvelope(result: Omit<RuntimeCommandResultEnvelope, "schema">): RuntimeCommandResultEnvelope {
   return {
     schema: RUNTIME_COMMAND_RESULT_SCHEMA,
     ...result,
+  }
+}
+
+export interface RuntimeCommandResultEnvelopeFromOutputInput {
+  status?: RuntimeCommandResultStatus
+  stdout?: string
+  stderr?: string
+  diagnostics?: unknown
+  artifactRefs?: RuntimeEpisodeTraceRef[]
+  error?: RuntimeCommandResultError
+}
+
+export function runtimeCommandResultEnvelopeFromOutput(input: RuntimeCommandResultEnvelopeFromOutputInput): RuntimeCommandResultEnvelope {
+  const stdout = input.stdout ?? ""
+  const json = parseRuntimeCommandJsonStdout(stdout)
+  return createRuntimeCommandResultEnvelope({
+    status: input.status ?? "ok",
+    stdout,
+    stderr: input.stderr ?? "",
+    ...(json === undefined ? {} : { json }),
+    ...(input.diagnostics === undefined ? {} : { diagnostics: input.diagnostics }),
+    ...(input.artifactRefs?.length ? { artifactRefs: input.artifactRefs } : {}),
+    ...(input.error ? { error: input.error } : {}),
+  })
+}
+
+function parseRuntimeCommandJsonStdout(stdout: string): unknown {
+  const trimmed = stdout.trim()
+  if (!trimmed || !(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return undefined
   }
 }

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto"
 import { mkdir, readFile, realpath, writeFile } from "node:fs/promises"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { dirname, join, resolve } from "node:path"
-import { HostToolRegistry, PREVIEW_LEASE_SCHEMA, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, parseCommandAgentRunRequest, previewLease, resolveCommandPath, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
+import { HostToolRegistry, PREVIEW_LEASE_SCHEMA, RUNTIME_EPISODE_OBSERVATION_SCHEMA, RUNTIME_EPISODE_SNAPSHOT_SCHEMA, assertRuntimeCommandAllowed, commandAgentRunResultJson, createCommandAgentRunResult, createHostToolRegistry, createRuntimeCommandResultEnvelope, parseCommandAgentRunRequest, previewLease, resolveCommandPath, runtimeCommandResultEnvelopeFromOutput, runtimeEpisodeDigest } from "@automattic/wp-codebox-core"
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { recipeCommandDefinitions } from "@automattic/wp-codebox-core/contracts"
 import { browserReviewSummary as browserArtifactReviewSummary, type BrowserArtifact } from "./browser-artifacts.js"
@@ -93,6 +93,14 @@ function commandEnvelopeStdout(envelope: RuntimeCommandResultEnvelope): string {
     return envelope.stdout
   }
   return envelope.json === undefined ? "" : `${JSON.stringify(envelope.json, null, 2)}\n`
+}
+
+function runtimeCommandTiming(startedAt: string, finishedAt: string): { startedAt: string; finishedAt: string; durationMs: number } {
+  return {
+    startedAt,
+    finishedAt,
+    durationMs: Math.max(0, new Date(finishedAt).getTime() - new Date(startedAt).getTime()),
+  }
 }
 
 interface ReviewerAuthBootstrapRecord {
@@ -272,19 +280,29 @@ class PlaygroundRuntime implements Runtime {
     this.activeExecutionSignal = abortController.signal
     try {
       const output = await timeoutPlaygroundCommand(executePlaygroundCommand(this, spec, this.hostTools), spec, abortController)
-      const envelope = typeof output === "string" ? undefined : output
+      const finishedAt = now()
+      const envelope = typeof output === "string"
+        ? runtimeCommandResultEnvelopeFromOutput({
+          status: "ok",
+          stdout: output,
+          diagnostics: {
+            command: spec.command,
+            timing: runtimeCommandTiming(startedAt, finishedAt),
+          },
+        })
+        : output
       const result: ExecutionResult = {
         id: commandId,
         command: spec.command,
         args: spec.args ?? [],
         exitCode: commandExitCode(envelope),
-        stdout: typeof output === "string" ? output : commandEnvelopeStdout(output),
+        stdout: commandEnvelopeStdout(envelope),
         stderr: envelope?.stderr ?? "",
-        ...(envelope ? { result: envelope } : {}),
+        result: envelope,
         ...(envelope?.diagnostics !== undefined ? { diagnostics: envelope.diagnostics } : {}),
         ...(envelope?.artifactRefs?.length ? { artifactRefs: envelope.artifactRefs } : {}),
         startedAt,
-        finishedAt: now(),
+        finishedAt,
       }
 
       this.commands.push(result)

--- a/tests/runtime-command-result-envelope.test.ts
+++ b/tests/runtime-command-result-envelope.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+
+import { RUNTIME_COMMAND_RESULT_SCHEMA, runtimeCommandResultEnvelopeFromOutput } from "../packages/runtime-core/src/index.js"
+
+const plain = runtimeCommandResultEnvelopeFromOutput({ stdout: "plain output\n" })
+assert.equal(plain.schema, RUNTIME_COMMAND_RESULT_SCHEMA)
+assert.equal(plain.status, "ok")
+assert.equal(plain.stdout, "plain output\n")
+assert.equal(plain.stderr, "")
+assert.equal(plain.json, undefined)
+
+const parsed = runtimeCommandResultEnvelopeFromOutput({
+  stdout: '{"ok":true,"items":[1,2]}\n',
+  diagnostics: { command: "wordpress.runtime-discovery", timing: { startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:00.125Z", durationMs: 125 } },
+})
+assert.deepEqual(parsed.json, { ok: true, items: [1, 2] })
+assert.deepEqual(parsed.diagnostics, { command: "wordpress.runtime-discovery", timing: { startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:00.125Z", durationMs: 125 } })
+
+const failure = runtimeCommandResultEnvelopeFromOutput({
+  status: "error",
+  stdout: "",
+  stderr: "nope",
+  error: { code: "command-failed", message: "Command failed" },
+  artifactRefs: [{ kind: "command-log", id: "stderr", path: "files/stderr.txt" }],
+})
+assert.equal(failure.status, "error")
+assert.equal(failure.stderr, "nope")
+assert.deepEqual(failure.error, { code: "command-failed", message: "Command failed" })
+assert.deepEqual(failure.artifactRefs, [{ kind: "command-log", id: "stderr", path: "files/stderr.txt" }])
+
+console.log("runtime command result envelope ok")


### PR DESCRIPTION
## Summary
- Normalize raw playground command stdout into RuntimeCommandResultEnvelope at the runtime execution boundary.
- Parse JSON stdout into the envelope `json` field when available while preserving `ExecutionResult.stdout` compatibility.
- Add a generic core helper and behavior coverage for stdout, parsed JSON, diagnostics, stderr, errors, and artifact refs.

## Tests
- `npm run test:runtime-command-result-envelope`
- `npm run build`
- `npm run test:command-agent-run`
- `npm run test:generic-ability-runtime-run`
- `npx tsx tests/command-diagnostics.test.ts`
- `npm run test:runtime-contract-package-exports`
- `npm run test:runtime-package-execution`
- `npm run test:runtime-episode-contracts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 / OpenCode
- **Used for:** Implementing the runtime envelope normalization, behavior test, verification, and PR drafting.