### PR TITLE
Support admin page fuzz primitive

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -286,6 +286,8 @@ private static function execute_fuzz_suite_step( array $step, array $case, array
 		return match ( $command ) {
 			'wordpress.ensure-plugin-active' => self::execute_fuzz_suite_plugin_activation( $args, $observation, $case_id ),
 			'wordpress.inventory-rest-routes', 'wordpress.rest-route-inventory' => self::execute_fuzz_suite_rest_route_inventory( $args, $observation, $case_id ),
+			'wordpress.admin-page-inventory' => self::execute_fuzz_suite_admin_page_inventory( $args, $observation ),
+			'wordpress.fuzz-admin-pages' => self::execute_fuzz_suite_admin_page_fuzz( $args, $observation ),
 			'wordpress.rest-request' => self::execute_fuzz_suite_rest_request( $args, $observation, $case_id ),
 			'wordpress.http-request' => self::execute_fuzz_suite_http_request( $args, $observation, $case_id ),
 			'wordpress.ability' => self::execute_fuzz_suite_ability( $args, $observation, $case_id ),
@@ -359,6 +361,160 @@ private static function execute_fuzz_suite_rest_route_inventory( array $args, ar
 		'namespaces' => $observation['namespaces'],
 	);
 	return array( 'status' => 'passed', 'observation' => $observation );
+}
+
+/** @param array<string,string> $args Args. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
+private static function execute_fuzz_suite_admin_page_inventory( array $args, array $observation ): array {
+	$inventory = self::fuzz_suite_admin_page_inventory( $args );
+	$observation['page_count'] = count( $inventory['pages'] );
+	$observation['menu_loaded'] = (bool) $inventory['menuLoaded'];
+	$observation['payload'] = $inventory;
+	return array( 'status' => 'passed', 'observation' => $observation );
+}
+
+/** @param array<string,string> $args Args. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
+private static function execute_fuzz_suite_admin_page_fuzz( array $args, array $observation ): array {
+	$inventory = self::fuzz_suite_admin_page_inventory( $args );
+	$max_pages = max( 1, (int) ( $args['max_pages'] ?? 80 ) );
+	$targets = array_slice( $inventory['pages'], 0, $max_pages );
+	$visits = array();
+	$skipped = array();
+	foreach ( $targets as $target ) {
+		$url = (string) ( $target['canonicalUrl'] ?? '' );
+		$skip_reason = self::fuzz_suite_admin_page_skip_reason( $target, $url );
+		if ( null !== $skip_reason ) {
+			$skipped[] = array( 'target' => $target, 'reason' => $skip_reason );
+			continue;
+		}
+		$visits[] = array(
+			'target' => $target,
+			'method' => 'GET',
+			'status' => 'planned',
+			'reason' => 'public PHP fuzz runner records safe admin coverage without issuing browser requests.',
+		);
+	}
+	$payload = array(
+		'schema' => 'wp-codebox/wordpress-admin-page-coverage/v1',
+		'contract' => array(
+			'safety_class' => 'read_only',
+			'command' => 'wordpress.fuzz-admin-pages',
+			'admin_inventory_schema' => $inventory['schema'],
+		),
+		'targets' => $targets,
+		'visits' => $visits,
+		'skipped' => $skipped,
+		'request_logs' => array(),
+		'query_attribution' => array(),
+		'metrics' => array(
+			'target_count' => count( $targets ),
+			'visit_count' => count( $visits ),
+			'skipped_count' => count( $skipped ),
+			'menu_loaded' => (bool) $inventory['menuLoaded'],
+		),
+		'inventory' => $inventory,
+	);
+	$observation['artifact'] = (string) ( $args['artifact'] ?? 'admin_page_coverage' );
+	$observation['target_count'] = count( $targets );
+	$observation['visit_count'] = count( $visits );
+	$observation['skipped_count'] = count( $skipped );
+	$observation['payload'] = $payload;
+	return array( 'status' => 'passed', 'observation' => $observation );
+}
+
+/** @param array<string,string> $args Args. @return array<string,mixed> */
+private static function fuzz_suite_admin_page_inventory( array $args ): array {
+	$diagnostics = array();
+	if ( ( ! isset( $GLOBALS['menu'] ) || ! is_array( $GLOBALS['menu'] ) ) && function_exists( 'is_user_logged_in' ) && is_user_logged_in() ) {
+		if ( ! defined( 'WP_ADMIN' ) ) {
+			define( 'WP_ADMIN', true );
+		}
+		if ( defined( 'ABSPATH' ) && file_exists( ABSPATH . 'wp-admin/includes/admin.php' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/admin.php';
+		}
+		if ( defined( 'ABSPATH' ) && file_exists( ABSPATH . 'wp-admin/menu.php' ) ) {
+			require_once ABSPATH . 'wp-admin/menu.php';
+		}
+	}
+	$menu_loaded = isset( $GLOBALS['menu'] ) && is_array( $GLOBALS['menu'] );
+	if ( ! $menu_loaded ) {
+		$diagnostics[] = array( 'surface' => 'admin', 'code' => 'admin-menu-not-loaded', 'message' => 'The admin menu globals are not populated in this request context.' );
+	}
+	$pages = array();
+	foreach ( (array) ( $GLOBALS['menu'] ?? array() ) as $item ) {
+		if ( is_array( $item ) ) {
+			$pages[] = self::fuzz_suite_admin_page_descriptor( (string) ( $item[2] ?? '' ), (string) ( $item[0] ?? '' ), (string) ( $item[1] ?? '' ) );
+		}
+	}
+	foreach ( (array) ( $GLOBALS['submenu'] ?? array() ) as $parent_slug => $items ) {
+		foreach ( (array) $items as $item ) {
+			if ( is_array( $item ) ) {
+				$pages[] = self::fuzz_suite_admin_page_descriptor( (string) ( $item[2] ?? '' ), (string) ( $item[0] ?? '' ), (string) ( $item[1] ?? '' ), (string) $parent_slug );
+			}
+		}
+	}
+	return array(
+		'schema' => 'wp-codebox/wordpress-admin-page-inventory/v1',
+		'command' => 'wordpress.admin-page-inventory',
+		'status' => $menu_loaded ? 'ok' : 'unsupported',
+		'adminUrl' => function_exists( 'admin_url' ) ? admin_url() : '',
+		'menuLoaded' => $menu_loaded,
+		'user' => self::fuzz_suite_admin_user_context(),
+		'pages' => array_values( array_filter( $pages, static fn( array $page ): bool => '' !== ( $page['menuSlug'] ?? '' ) ) ),
+		'diagnostics' => $diagnostics,
+	);
+}
+
+private static function fuzz_suite_admin_page_descriptor( string $menu_slug, string $title, string $capability, string $parent_slug = '' ): array {
+	$page = array(
+		'menuSlug' => $menu_slug,
+		'pageTitle' => self::fuzz_suite_strip_tags( $title ),
+		'menuTitle' => self::fuzz_suite_strip_tags( $title ),
+		'capability' => $capability,
+		'canAccess' => '' === $capability || ! function_exists( 'current_user_can' ) ? null : current_user_can( $capability ),
+		'canonicalUrl' => self::fuzz_suite_admin_page_url( $menu_slug, $parent_slug ),
+	);
+	if ( '' !== $parent_slug ) {
+		$page['parentSlug'] = $parent_slug;
+	}
+	return $page;
+}
+
+private static function fuzz_suite_admin_page_url( string $menu_slug, string $parent_slug = '' ): string {
+	if ( str_ends_with( $menu_slug, '.php' ) ) {
+		$path = $menu_slug;
+	} elseif ( '' !== $parent_slug && str_ends_with( $parent_slug, '.php' ) ) {
+		$path = add_query_arg( 'page', $menu_slug, $parent_slug );
+	} else {
+		$path = add_query_arg( 'page', $menu_slug, 'admin.php' );
+	}
+	return function_exists( 'admin_url' ) ? admin_url( $path ) : $path;
+}
+
+/** @param array<string,mixed> $target Target. */
+private static function fuzz_suite_admin_page_skip_reason( array $target, string $url ): ?array {
+	if ( false === ( $target['canAccess'] ?? null ) ) {
+		return array( 'code' => 'capability_denied', 'message' => 'The current runtime user cannot access this admin page.', 'capability' => $target['capability'] ?? '' );
+	}
+	foreach ( array( 'action=delete', 'action=install', 'action=update', 'action=activate', 'action=deactivate', '_wpnonce=' ) as $pattern ) {
+		if ( str_contains( $url, $pattern ) ) {
+			return array( 'code' => 'destructive_or_nonce_action', 'message' => 'The admin page URL looks like a mutation or nonce-protected action.', 'pattern' => $pattern );
+		}
+	}
+	return null;
+}
+
+/** @return array<string,mixed> */
+private static function fuzz_suite_admin_user_context(): array {
+	$user = function_exists( 'wp_get_current_user' ) ? wp_get_current_user() : null;
+	return array(
+		'isLoggedIn' => function_exists( 'is_user_logged_in' ) ? is_user_logged_in() : false,
+		'id' => is_object( $user ) && isset( $user->ID ) ? (int) $user->ID : 0,
+		'roles' => is_object( $user ) && isset( $user->roles ) ? array_values( array_map( 'strval', (array) $user->roles ) ) : array(),
+	);
+}
+
+private static function fuzz_suite_strip_tags( string $value ): string {
+	return function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( $value ) : strip_tags( $value );
 }
 
 /** @param string[] $namespace_filter Namespace filters. */

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -67,6 +67,31 @@ function wp_remote_retrieve_response_code( array $response ): int {
 	return (int) ( $response['response']['code'] ?? 0 );
 }
 
+function admin_url( string $path = '' ): string {
+	return 'https://example.test/wp-admin/' . ltrim( $path, '/' );
+}
+
+function add_query_arg( string $key, string $value, string $url ): string {
+	$separator = str_contains( $url, '?' ) ? '&' : '?';
+	return $url . $separator . rawurlencode( $key ) . '=' . rawurlencode( $value );
+}
+
+function current_user_can( string $capability ): bool {
+	return 'denied_cap' !== $capability;
+}
+
+function is_user_logged_in(): bool {
+	return true;
+}
+
+function wp_get_current_user(): object {
+	return (object) array( 'ID' => 1, 'roles' => array( 'administrator' ) );
+}
+
+function wp_strip_all_tags( string $value ): string {
+	return strip_tags( $value );
+}
+
 function wp_has_ability( string $name ): bool {
 	return 'example/echo' === $name;
 }
@@ -80,6 +105,17 @@ require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abili
 class WP_Codebox_Fuzz_Suite_Runner_Smoke {
 	use WP_Codebox_Abilities_Execution;
 }
+
+$GLOBALS['menu'] = array(
+	array( 'Dashboard', 'read', 'index.php' ),
+	array( 'Products', 'manage_woocommerce', 'edit.php?post_type=product' ),
+	array( 'Denied', 'denied_cap', 'denied.php' ),
+);
+$GLOBALS['submenu'] = array(
+	'edit.php?post_type=product' => array(
+		array( 'Add New', 'manage_woocommerce', 'post-new.php?post_type=product' ),
+	),
+);
 
 $result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 	array(
@@ -120,6 +156,14 @@ $result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 				'phases' => array(
 					'action' => array(
 						array( 'command' => 'wordpress.inventory-rest-routes', 'args' => array( 'namespaces=sample/v1', 'artifact=route_inventory' ) ),
+					),
+				),
+			),
+			array(
+				'id'     => 'admin-page-coverage',
+				'phases' => array(
+					'action' => array(
+						array( 'command' => 'wordpress.fuzz-admin-pages', 'args' => array( 'max_pages=3' ) ),
 					),
 				),
 			),
@@ -191,8 +235,8 @@ assert( is_array( $result ) );
 assert( 'wp-codebox/fuzz-suite-result/v1' === $result['schema'] );
 assert( true === $result['success'] );
 assert( 'passed' === $result['status'] );
-assert( 17 === $result['summary']['total'] );
-assert( 6 === $result['summary']['passed'] );
+assert( 18 === $result['summary']['total'] );
+assert( 7 === $result['summary']['passed'] );
 assert( 11 === $result['summary']['skipped'] );
 assert( 'collect-artifact' === $result['cases'][0]['id'] );
 assert( 'passed' === $result['cases'][0]['status'] );
@@ -207,21 +251,26 @@ assert( 'rest-route-inventory' === $result['cases'][4]['id'] );
 assert( 1 === $result['cases'][4]['metadata']['observations'][0]['route_count'] );
 assert( 'sample' === $result['cases'][4]['metadata']['observations'][0]['namespaces'][0] );
 assert( 'passed' === $result['cases'][5]['status'] );
+assert( 'admin-page-coverage' === $result['cases'][5]['id'] );
+assert( 3 === $result['cases'][5]['metadata']['observations'][0]['target_count'] );
+assert( 1 === $result['cases'][5]['metadata']['observations'][0]['skipped_count'] );
+assert( 'wp-codebox/wordpress-admin-page-coverage/v1' === $result['cases'][5]['metadata']['observations'][0]['payload']['schema'] );
 assert( 'passed' === $result['cases'][6]['status'] );
-assert( 'command-target' === $result['cases'][7]['id'] );
-assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][7]['skipReason'] );
-assert( 'runtime-target' === $result['cases'][8]['id'] );
+assert( 'passed' === $result['cases'][7]['status'] );
+assert( 'command-target' === $result['cases'][8]['id'] );
 assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][8]['skipReason'] );
-assert( 'runtime-action-wp-cli' === $result['cases'][9]['id'] );
-assert( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported' === $result['cases'][9]['skipReason'] );
-assert( 'wordpress.wp-cli' === $result['cases'][9]['metadata']['observations'][0]['command'] );
-assert( 'wp_codebox_fuzz_runtime_action_php_unsupported' === $result['cases'][10]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_browser_unsupported' === $result['cases'][11]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported' === $result['cases'][12]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported' === $result['cases'][13]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported' === $result['cases'][14]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_page_unsupported' === $result['cases'][15]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_unsupported' === $result['cases'][16]['skipReason'] );
+assert( 'runtime-target' === $result['cases'][9]['id'] );
+assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][9]['skipReason'] );
+assert( 'runtime-action-wp-cli' === $result['cases'][10]['id'] );
+assert( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported' === $result['cases'][10]['skipReason'] );
+assert( 'wordpress.wp-cli' === $result['cases'][10]['metadata']['observations'][0]['command'] );
+assert( 'wp_codebox_fuzz_runtime_action_php_unsupported' === $result['cases'][11]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_unsupported' === $result['cases'][12]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported' === $result['cases'][13]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported' === $result['cases'][14]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported' === $result['cases'][15]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_page_unsupported' === $result['cases'][16]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_unsupported' === $result['cases'][17]['skipReason'] );
 
 $unsafe = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 	array(


### PR DESCRIPTION
## Summary
- support wordpress.admin-page-inventory in the public PHP fuzz-suite runner
- support wordpress.fuzz-admin-pages as a read-only admin coverage primitive
- include bounded admin targets, planned safe visits, skip classifications, and coverage metrics in the observation payload
- cover the admin primitive in the PHP fuzz-suite smoke test

## Tests
- npm run test:php-fuzz-suite-runner
- npm run test:php-primitive-contract-parity
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Implementing the PHP admin fuzz primitive, updating smoke coverage, and running verification.