### PR TITLE
Fix admin fuzz page URLs

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -482,10 +482,12 @@ private static function fuzz_suite_admin_page_descriptor( string $menu_slug, str
 private static function fuzz_suite_admin_page_url( string $menu_slug, string $parent_slug = '' ): string {
 	if ( str_ends_with( $menu_slug, '.php' ) ) {
 		$path = $menu_slug;
-	} elseif ( '' !== $parent_slug && str_ends_with( $parent_slug, '.php' ) ) {
-		$path = add_query_arg( 'page', $menu_slug, $parent_slug );
+	} elseif ( str_contains( $menu_slug, '.php' ) ) {
+		$path = $menu_slug;
+	} elseif ( '' !== $parent_slug && str_contains( $parent_slug, '.php' ) ) {
+		$path = $parent_slug . '?page=' . rawurlencode( $menu_slug );
 	} else {
-		$path = add_query_arg( 'page', $menu_slug, 'admin.php' );
+		$path = 'admin.php?page=' . rawurlencode( $menu_slug );
 	}
 	return function_exists( 'admin_url' ) ? admin_url( $path ) : $path;
 }

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -71,11 +71,6 @@ function admin_url( string $path = '' ): string {
 	return 'https://example.test/wp-admin/' . ltrim( $path, '/' );
 }
 
-function add_query_arg( string $key, string $value, string $url ): string {
-	$separator = str_contains( $url, '?' ) ? '&' : '?';
-	return $url . $separator . rawurlencode( $key ) . '=' . rawurlencode( $value );
-}
-
 function current_user_can( string $capability ): bool {
 	return 'denied_cap' !== $capability;
 }
@@ -255,6 +250,7 @@ assert( 'admin-page-coverage' === $result['cases'][5]['id'] );
 assert( 3 === $result['cases'][5]['metadata']['observations'][0]['target_count'] );
 assert( 1 === $result['cases'][5]['metadata']['observations'][0]['skipped_count'] );
 assert( 'wp-codebox/wordpress-admin-page-coverage/v1' === $result['cases'][5]['metadata']['observations'][0]['payload']['schema'] );
+assert( 'https://example.test/wp-admin/edit.php?post_type=product' === $result['cases'][5]['metadata']['observations'][0]['payload']['targets'][1]['canonicalUrl'] );
 assert( 'passed' === $result['cases'][6]['status'] );
 assert( 'passed' === $result['cases'][7]['status'] );
 assert( 'command-target' === $result['cases'][8]['id'] );


### PR DESCRIPTION
## Summary
- stop using add_query_arg() in the PHP admin fuzz URL builder
- align admin page canonical URLs with runtime discovery behavior for .php menu slugs
- extend PHP fuzz-suite smoke coverage for query-string admin slugs

## Tests
- npm run test:php-fuzz-suite-runner
- npm run test:php-primitive-contract-parity
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Fixing the admin URL builder, updating smoke coverage, and running verification.