### PR TITLE
Include Agents API in agent task runtime defaults

### DIFF
--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -491,7 +491,9 @@ function defaultRuntimeComponents(): AgentRuntimeComponent[] {
 }
 
 function defaultRuntimeComponentPaths(): string[] {
-  return (process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
+  return [process.env.WP_CODEBOX_AGENTS_API_PATH, process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? ""]
+    .filter(Boolean)
+    .join(",")
     .split(/[,:]/)
     .map((value) => value.trim())
     .filter(Boolean)

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -190,6 +190,10 @@ function defaultRuntimeComponentPlugins(): WorkspaceRecipeExtraPlugin[] {
 
 function defaultRuntimeComponentPaths(): string[] {
   return [
+    ...(process.env.WP_CODEBOX_AGENTS_API_PATH ?? "")
+    .split(/[,:]/)
+    .map((value) => value.trim())
+    .filter(Boolean),
     ...(process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
     .split(/[,:]/)
     .map((value) => value.trim())

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -222,8 +222,8 @@ try {
   }, normalizeTaskInput({ goal: "Verify generic runtime propagation" }), "latest")
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
-  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), false)
-  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), false)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), true)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), true)
 
   const recipe = buildAgentTaskRecipe({
     goal: "Verify extra plugin propagation",


### PR DESCRIPTION
## Summary
- Include WP_CODEBOX_AGENTS_API_PATH in agent-task recipe default runtime components.
- Include the same explicit Agents API path in the CLI sandbox default component list.
- Update agent-task contract coverage to prove the default recipe mounts the Agents API substrate when configured.

## Verification
- npm run test:agent-task-contracts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigating the upstream runtime composition path, implementing the fix, and drafting focused coverage.