### PR TITLE
Support database inventory fuzz primitive

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -286,6 +286,7 @@ private static function execute_fuzz_suite_step( array $step, array $case, array
 		return match ( $command ) {
 			'wordpress.ensure-plugin-active' => self::execute_fuzz_suite_plugin_activation( $args, $observation, $case_id ),
 			'wordpress.inventory-rest-routes', 'wordpress.rest-route-inventory' => self::execute_fuzz_suite_rest_route_inventory( $args, $observation, $case_id ),
+			'wordpress.inventory-database' => self::execute_fuzz_suite_database_inventory( $args, $observation, $case_id ),
 			'wordpress.admin-page-inventory' => self::execute_fuzz_suite_admin_page_inventory( $args, $observation ),
 			'wordpress.fuzz-admin-pages' => self::execute_fuzz_suite_admin_page_fuzz( $args, $observation ),
 			'wordpress.rest-request' => self::execute_fuzz_suite_rest_request( $args, $observation, $case_id ),
@@ -517,6 +518,116 @@ private static function fuzz_suite_admin_user_context(): array {
 		'id' => is_object( $user ) && isset( $user->ID ) ? (int) $user->ID : 0,
 		'roles' => is_object( $user ) && isset( $user->roles ) ? array_values( array_map( 'strval', (array) $user->roles ) ) : array(),
 	);
+}
+
+/** @param array<string,string> $args Args. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
+private static function execute_fuzz_suite_database_inventory( array $args, array $observation, string $case_id ): array {
+	global $wpdb;
+	if ( ! is_object( $wpdb ) || ! method_exists( $wpdb, 'get_results' ) ) {
+		return array( 'status' => 'skipped', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'warning', 'wp_codebox_fuzz_database_unavailable', 'WordPress database connection is not available.', array( 'case_id' => $case_id ) ) );
+	}
+
+	$prefix = isset( $wpdb->prefix ) ? (string) $wpdb->prefix : '';
+	$tables = self::fuzz_suite_database_tables( $wpdb, $prefix );
+	$totals = array(
+		'tableCount'  => count( $tables ),
+		'rowCount'    => (int) array_sum( array_map( static fn( array $table ): int => (int) ( $table['rowCount'] ?? 0 ), $tables ) ),
+		'columnCount' => (int) array_sum( array_map( static fn( array $table ): int => count( (array) ( $table['columns'] ?? array() ) ), $tables ) ),
+		'indexCount'  => (int) array_sum( array_map( static fn( array $table ): int => count( (array) ( $table['indexes'] ?? array() ) ), $tables ) ),
+		'dataBytes'   => (int) array_sum( array_map( static fn( array $table ): int => (int) ( $table['dataBytes'] ?? 0 ), $tables ) ),
+		'indexBytes'  => (int) array_sum( array_map( static fn( array $table ): int => (int) ( $table['indexBytes'] ?? 0 ), $tables ) ),
+		'totalBytes'  => (int) array_sum( array_map( static fn( array $table ): int => (int) ( $table['totalBytes'] ?? 0 ), $tables ) ),
+	);
+
+	$observation['artifact'] = (string) ( $args['artifact'] ?? 'db_inventory' );
+	$observation['table_count'] = $totals['tableCount'];
+	$observation['payload'] = array(
+		'schema'      => 'wp-codebox/wordpress-database-inventory/v1',
+		'command'     => 'wordpress.inventory-database',
+		'status'      => 'ok',
+		'prefix'      => $prefix,
+		'tables'      => $tables,
+		'totals'      => $totals,
+		'diagnostics' => array(),
+	);
+	return array( 'status' => 'passed', 'observation' => $observation );
+}
+
+/** @return array<int,array<string,mixed>> */
+private static function fuzz_suite_database_tables( object $wpdb, string $prefix ): array {
+	$tables = array();
+	foreach ( self::fuzz_suite_database_query_rows( $wpdb, 'SHOW TABLE STATUS' ) as $status ) {
+		$name = (string) ( $status['Name'] ?? '' );
+		if ( '' === $name ) {
+			continue;
+		}
+		$data_bytes = (int) ( $status['Data_length'] ?? 0 );
+		$index_bytes = (int) ( $status['Index_length'] ?? 0 );
+		$tables[] = array(
+			'name'           => $name,
+			'baseName'       => self::fuzz_suite_database_base_table_name( $name, $prefix ),
+			'classification' => self::fuzz_suite_database_table_classification( $name, $prefix ),
+			'engine'         => (string) ( $status['Engine'] ?? '' ),
+			'rowCount'       => (int) ( $status['Rows'] ?? 0 ),
+			'dataBytes'      => $data_bytes,
+			'indexBytes'     => $index_bytes,
+			'totalBytes'     => $data_bytes + $index_bytes,
+			'columns'        => self::fuzz_suite_database_columns( $wpdb, $name ),
+			'indexes'        => self::fuzz_suite_database_indexes( $wpdb, $name ),
+			'status'         => array(
+				'engine'     => (string) ( $status['Engine'] ?? '' ),
+				'rows'       => isset( $status['Rows'] ) ? (int) $status['Rows'] : null,
+				'collation'  => (string) ( $status['Collation'] ?? '' ),
+				'dataBytes'  => $data_bytes,
+				'indexBytes' => $index_bytes,
+				'totalBytes' => $data_bytes + $index_bytes,
+			),
+		);
+	}
+	return $tables;
+}
+
+/** @return array<int,array<string,mixed>> */
+private static function fuzz_suite_database_columns( object $wpdb, string $table ): array {
+	return array_values( array_map( static fn( array $row ): array => array(
+		'name'     => (string) ( $row['Field'] ?? '' ),
+		'type'     => (string) ( $row['Type'] ?? '' ),
+		'nullable' => 'YES' === strtoupper( (string) ( $row['Null'] ?? '' ) ),
+		'key'      => (string) ( $row['Key'] ?? '' ),
+		'default'  => array_key_exists( 'Default', $row ) && null !== $row['Default'] ? (string) $row['Default'] : null,
+		'extra'    => (string) ( $row['Extra'] ?? '' ),
+	), self::fuzz_suite_database_query_rows( $wpdb, 'DESCRIBE ' . self::fuzz_suite_database_identifier( $table ) ) ) );
+}
+
+/** @return array<int,array<string,mixed>> */
+private static function fuzz_suite_database_indexes( object $wpdb, string $table ): array {
+	return array_values( array_map( static fn( array $row ): array => array(
+		'name'     => (string) ( $row['Key_name'] ?? '' ),
+		'column'   => (string) ( $row['Column_name'] ?? '' ),
+		'unique'   => '0' === (string) ( $row['Non_unique'] ?? '1' ),
+		'sequence' => isset( $row['Seq_in_index'] ) ? (int) $row['Seq_in_index'] : null,
+	), self::fuzz_suite_database_query_rows( $wpdb, 'SHOW INDEX FROM ' . self::fuzz_suite_database_identifier( $table ) ) ) );
+}
+
+/** @return array<int,array<string,mixed>> */
+private static function fuzz_suite_database_query_rows( object $wpdb, string $query ): array {
+	$rows = $wpdb->get_results( $query, defined( 'ARRAY_A' ) ? ARRAY_A : 'ARRAY_A' );
+	return is_array( $rows ) ? array_values( array_filter( $rows, 'is_array' ) ) : array();
+}
+
+private static function fuzz_suite_database_identifier( string $name ): string {
+	return '`' . str_replace( '`', '``', $name ) . '`';
+}
+
+private static function fuzz_suite_database_base_table_name( string $name, string $prefix ): string {
+	return '' !== $prefix && str_starts_with( $name, $prefix ) ? substr( $name, strlen( $prefix ) ) : $name;
+}
+
+private static function fuzz_suite_database_table_classification( string $name, string $prefix ): string {
+	if ( '' !== $prefix && str_starts_with( $name, $prefix ) ) {
+		return in_array( self::fuzz_suite_database_base_table_name( $name, $prefix ), array( 'commentmeta', 'comments', 'links', 'options', 'postmeta', 'posts', 'term_relationships', 'term_taxonomy', 'termmeta', 'terms', 'usermeta', 'users' ), true ) ? 'core' : 'prefixed';
+	}
+	return 'external';
 }
 
 private static function fuzz_suite_strip_tags( string $value ): string {

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -19,6 +19,7 @@ file_put_contents(
 );
 define( 'ABSPATH', $wp_codebox_smoke_root );
 define( 'WP_CONTENT_DIR', __DIR__ );
+define( 'ARRAY_A', 'ARRAY_A' );
 
 class WP_Error {
 	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
@@ -111,6 +112,39 @@ function wp_call_ability( string $name, array $input ): array|WP_Error {
 	return 'example/echo' === $name ? array( 'echo' => $input ) : new WP_Error( 'missing_ability', 'Ability missing.' );
 }
 
+class WP_Codebox_Test_WPDB {
+	public string $prefix = 'wp_';
+
+	public function get_results( string $query, mixed $output = null ): array {
+		if ( 'SHOW TABLE STATUS' === $query ) {
+			return array(
+				array( 'Name' => 'wp_posts', 'Engine' => 'InnoDB', 'Rows' => 3, 'Data_length' => 100, 'Index_length' => 40, 'Collation' => 'utf8mb4_unicode_ci' ),
+				array( 'Name' => 'wp_wc_orders', 'Engine' => 'InnoDB', 'Rows' => 2, 'Data_length' => 80, 'Index_length' => 20, 'Collation' => 'utf8mb4_unicode_ci' ),
+			);
+		}
+		if ( 'DESCRIBE `wp_posts`' === $query ) {
+			return array(
+				array( 'Field' => 'ID', 'Type' => 'bigint unsigned', 'Null' => 'NO', 'Key' => 'PRI', 'Default' => null, 'Extra' => 'auto_increment' ),
+				array( 'Field' => 'post_title', 'Type' => 'text', 'Null' => 'NO', 'Key' => '', 'Default' => null, 'Extra' => '' ),
+			);
+		}
+		if ( 'DESCRIBE `wp_wc_orders`' === $query ) {
+			return array(
+				array( 'Field' => 'id', 'Type' => 'bigint unsigned', 'Null' => 'NO', 'Key' => 'PRI', 'Default' => null, 'Extra' => 'auto_increment' ),
+			);
+		}
+		if ( 'SHOW INDEX FROM `wp_posts`' === $query ) {
+			return array( array( 'Key_name' => 'PRIMARY', 'Column_name' => 'ID', 'Non_unique' => 0, 'Seq_in_index' => 1 ) );
+		}
+		if ( 'SHOW INDEX FROM `wp_wc_orders`' === $query ) {
+			return array( array( 'Key_name' => 'PRIMARY', 'Column_name' => 'id', 'Non_unique' => 0, 'Seq_in_index' => 1 ) );
+		}
+		return array();
+	}
+}
+
+$GLOBALS['wpdb'] = new WP_Codebox_Test_WPDB();
+
 require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php';
 
 class WP_Codebox_Fuzz_Suite_Runner_Smoke {
@@ -167,6 +201,14 @@ $result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 				'phases' => array(
 					'action' => array(
 						array( 'command' => 'wordpress.inventory-rest-routes', 'args' => array( 'namespaces=sample/v1', 'artifact=route_inventory' ) ),
+					),
+				),
+			),
+			array(
+				'id'     => 'database-inventory',
+				'phases' => array(
+					'action' => array(
+						array( 'command' => 'wordpress.inventory-database', 'args' => array( 'artifact=db_inventory' ) ),
 					),
 				),
 			),
@@ -246,8 +288,8 @@ assert( is_array( $result ) );
 assert( 'wp-codebox/fuzz-suite-result/v1' === $result['schema'] );
 assert( true === $result['success'] );
 assert( 'passed' === $result['status'] );
-assert( 18 === $result['summary']['total'] );
-assert( 7 === $result['summary']['passed'] );
+assert( 19 === $result['summary']['total'] );
+assert( 8 === $result['summary']['passed'] );
 assert( 11 === $result['summary']['skipped'] );
 assert( 'collect-artifact' === $result['cases'][0]['id'] );
 assert( 'passed' === $result['cases'][0]['status'] );
@@ -262,27 +304,34 @@ assert( 'rest-route-inventory' === $result['cases'][4]['id'] );
 assert( 1 === $result['cases'][4]['metadata']['observations'][0]['route_count'] );
 assert( 'sample' === $result['cases'][4]['metadata']['observations'][0]['namespaces'][0] );
 assert( 'passed' === $result['cases'][5]['status'] );
-assert( 'admin-page-coverage' === $result['cases'][5]['id'] );
-assert( 3 === $result['cases'][5]['metadata']['observations'][0]['target_count'] );
-assert( 1 === $result['cases'][5]['metadata']['observations'][0]['skipped_count'] );
-assert( 'wp-codebox/wordpress-admin-page-coverage/v1' === $result['cases'][5]['metadata']['observations'][0]['payload']['schema'] );
-assert( 'https://example.test/wp-admin/edit.php?post_type=product' === $result['cases'][5]['metadata']['observations'][0]['payload']['targets'][1]['canonicalUrl'] );
+assert( 'database-inventory' === $result['cases'][5]['id'] );
+assert( 2 === $result['cases'][5]['metadata']['observations'][0]['table_count'] );
+assert( 'wp-codebox/wordpress-database-inventory/v1' === $result['cases'][5]['metadata']['observations'][0]['payload']['schema'] );
+assert( 'core' === $result['cases'][5]['metadata']['observations'][0]['payload']['tables'][0]['classification'] );
+assert( 'prefixed' === $result['cases'][5]['metadata']['observations'][0]['payload']['tables'][1]['classification'] );
+assert( 'passed' === $result['cases'][6]['status'] );
+assert( 'admin-page-coverage' === $result['cases'][6]['id'] );
+assert( 3 === $result['cases'][6]['metadata']['observations'][0]['target_count'] );
+assert( 1 === $result['cases'][6]['metadata']['observations'][0]['skipped_count'] );
+assert( 'wp-codebox/wordpress-admin-page-coverage/v1' === $result['cases'][6]['metadata']['observations'][0]['payload']['schema'] );
+assert( 'https://example.test/wp-admin/edit.php?post_type=product' === $result['cases'][6]['metadata']['observations'][0]['payload']['targets'][1]['canonicalUrl'] );
 assert( 'passed' === $result['cases'][6]['status'] );
 assert( 'passed' === $result['cases'][7]['status'] );
-assert( 'command-target' === $result['cases'][8]['id'] );
-assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][8]['skipReason'] );
-assert( 'runtime-target' === $result['cases'][9]['id'] );
+assert( 'passed' === $result['cases'][8]['status'] );
+assert( 'command-target' === $result['cases'][9]['id'] );
 assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][9]['skipReason'] );
-assert( 'runtime-action-wp-cli' === $result['cases'][10]['id'] );
-assert( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported' === $result['cases'][10]['skipReason'] );
-assert( 'wordpress.wp-cli' === $result['cases'][10]['metadata']['observations'][0]['command'] );
-assert( 'wp_codebox_fuzz_runtime_action_php_unsupported' === $result['cases'][11]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_browser_unsupported' === $result['cases'][12]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported' === $result['cases'][13]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported' === $result['cases'][14]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported' === $result['cases'][15]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_page_unsupported' === $result['cases'][16]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_unsupported' === $result['cases'][17]['skipReason'] );
+assert( 'runtime-target' === $result['cases'][10]['id'] );
+assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][10]['skipReason'] );
+assert( 'runtime-action-wp-cli' === $result['cases'][11]['id'] );
+assert( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported' === $result['cases'][11]['skipReason'] );
+assert( 'wordpress.wp-cli' === $result['cases'][11]['metadata']['observations'][0]['command'] );
+assert( 'wp_codebox_fuzz_runtime_action_php_unsupported' === $result['cases'][12]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_unsupported' === $result['cases'][13]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported' === $result['cases'][14]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported' === $result['cases'][15]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported' === $result['cases'][16]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_page_unsupported' === $result['cases'][17]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_unsupported' === $result['cases'][18]['skipReason'] );
 
 $GLOBALS['menu'] = null;
 $GLOBALS['submenu'] = null;


### PR DESCRIPTION
## Summary
- Add public PHP fuzz-suite support for `wordpress.inventory-database`.
- Emit table, column, index, byte, and classification totals from the active WordPress database connection.
- Extend the PHP fuzz-suite smoke with a `$wpdb` fixture covering the database inventory contract.

## Testing
- `php scripts/php-fuzz-suite-runner-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz primitive, updating smoke coverage, and running verification.
