### PR TITLE
Mount Data Machine runtime substrate by default

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -138,6 +138,28 @@ function wp_codebox_ensure_sandbox_default_agent(string $agent_slug, array $agen
         return array('success' => true, 'agent' => $agent_slug, 'existing' => true);
     }
 
+    if (class_exists('DataMachine\\Core\\Database\\Agents\\Agents')) {
+        $owner_id = function_exists('get_current_user_id') ? (int) get_current_user_id() : 0;
+        if ($owner_id <= 0) {
+            $owner_id = 1;
+        }
+        $default_config = array_filter(array(
+            'default_provider' => (string) ($agent_input['provider'] ?? ''),
+            'default_model' => (string) ($agent_input['model'] ?? ''),
+        ), static fn($value): bool => '' !== $value);
+        try {
+            $agent_id = (new DataMachine\\Core\\Database\\Agents\\Agents())->create_if_missing(
+                $agent_slug,
+                'WP Codebox Sandbox',
+                $owner_id,
+                $default_config
+            );
+            return array('success' => $agent_id > 0, 'agent' => $agent_slug, 'agent_id' => $agent_id, 'created' => $agent_id > 0, 'runtime' => 'data-machine');
+        } catch (Throwable $e) {
+            return array('success' => false, 'agent' => $agent_slug, 'reason' => 'data_machine_agent_create_failed', 'message' => $e->getMessage());
+        }
+    }
+
     if (!class_exists('WP_Agents_Registry')) {
         return array('success' => false, 'agent' => $agent_slug, 'reason' => 'agent_registry_unavailable');
     }

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
+import { dirname, resolve } from "node:path"
 import { commandArgValue, commandDiagnosticsCaptureArgs, normalizeSandboxToolPolicySnapshot, normalizeStructuredArtifacts, parseCommandJson, parseCommandJsonArray, parseCommandJsonObject, type ExecutionSpec, type MountSpec, type RuntimePolicy, type SandboxToolPolicySnapshot, type SandboxWorkspaceContract, type SandboxWorkspaceMode, type StructuredArtifactPayload, type WorkspaceRecipe } from "@automattic/wp-codebox-core"
 import { resolvePluginEntrypointContract, type ComponentLoadMode } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
@@ -486,12 +486,25 @@ function agentRuntimeComponents(options: AgentRuntimeProbeOptions): AgentRuntime
 }
 
 function defaultRuntimeComponents(): AgentRuntimeComponent[] {
-  return defaultRuntimeComponentPaths()
-    .map((source) => componentFromPath(source, undefined, undefined, "mu-plugin", "component"))
+  return defaultRuntimeComponentSources()
+    .map((component) => componentFromPath(component.source, component.slug, undefined, "mu-plugin", "component"))
 }
 
-function defaultRuntimeComponentPaths(): string[] {
-  return [process.env.WP_CODEBOX_AGENTS_API_PATH, process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? ""]
+function defaultRuntimeComponentSources(): Array<{ source: string; slug?: string }> {
+  const dataMachine = defaultSiblingComponentPath("data-machine", "data-machine.php", process.env.WP_CODEBOX_DATA_MACHINE_PATH)
+  const dataMachineCode = defaultSiblingComponentPath("data-machine-code", "data-machine-code.php", process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH)
+  const agentsApi = defaultAgentsApiPath(dataMachine)
+
+  return uniqueComponentSources([
+    dataMachine ? { source: dataMachine, slug: "data-machine" } : undefined,
+    dataMachineCode ? { source: dataMachineCode, slug: "data-machine-code" } : undefined,
+    agentsApi ? { source: agentsApi, slug: "agents-api" } : undefined,
+    ...configuredRuntimeComponentPaths().map((source) => ({ source })),
+  ])
+}
+
+function configuredRuntimeComponentPaths(): string[] {
+  return [process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? ""]
     .filter(Boolean)
     .join(",")
     .split(/[,:]/)
@@ -499,6 +512,43 @@ function defaultRuntimeComponentPaths(): string[] {
     .filter(Boolean)
     .map((value) => resolve(value))
     .filter((source) => existsSync(source))
+}
+
+function defaultAgentsApiPath(dataMachinePath = ""): string {
+  const explicit = process.env.WP_CODEBOX_AGENTS_API_PATH?.trim()
+  if (explicit) {
+    return explicit
+  }
+  if (dataMachinePath) {
+    return ""
+  }
+
+  return defaultSiblingComponentPath("agents-api", "agents-api.php")
+}
+
+function defaultSiblingComponentPath(slug: string, pluginFile: string, explicit = ""): string {
+  if (explicit.trim()) {
+    return explicit.trim()
+  }
+  return [
+    resolve(process.cwd(), "..", slug),
+    resolve(dirname(process.cwd()), slug),
+  ].find((source) => existsSync(resolve(source, pluginFile))) ?? ""
+}
+
+function uniqueComponentSources(components: Array<{ source: string; slug?: string } | undefined>): Array<{ source: string; slug?: string }> {
+  const seen = new Set<string>()
+  return components.filter((component): component is { source: string; slug?: string } => {
+    if (!component?.source) {
+      return false
+    }
+    const source = resolve(component.source)
+    if (seen.has(source)) {
+      return false
+    }
+    seen.add(source)
+    return true
+  })
 }
 
 function providerPluginSlugs(args: string[]): string[] {

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -175,10 +175,10 @@ function defaultAgentRuntimeComponentPlugins(componentPlugins: WorkspaceRecipeEx
 }
 
 function defaultRuntimeComponentPlugins(): WorkspaceRecipeExtraPlugin[] {
-  return defaultRuntimeComponentPaths().map((source) => {
-    const entrypoint = resolvePluginEntrypointContract({ source, loadAs: "mu-plugin" })
+  return defaultRuntimeComponentSources().map((component) => {
+    const entrypoint = resolvePluginEntrypointContract({ source: component.source, slug: component.slug, loadAs: "mu-plugin" })
     return {
-      source,
+      source: component.source,
       slug: entrypoint.slug,
       pluginFile: entrypoint.pluginFile,
       activate: false,
@@ -188,24 +188,67 @@ function defaultRuntimeComponentPlugins(): WorkspaceRecipeExtraPlugin[] {
   })
 }
 
-function defaultRuntimeComponentPaths(): string[] {
-  return [
-    ...(process.env.WP_CODEBOX_AGENTS_API_PATH ?? "")
-    .split(/[,:]/)
-    .map((value) => value.trim())
-    .filter(Boolean),
-    ...(process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
-    .split(/[,:]/)
-    .map((value) => value.trim())
-    .filter(Boolean),
-    ...bundledRuntimeComponentPaths(),
-  ]
-    .map((value) => resolve(value))
-    .filter((source, index, sources) => existsSync(source) && sources.indexOf(source) === index)
+function defaultRuntimeComponentSources(): Array<{ source: string; slug?: string }> {
+  const dataMachine = defaultSiblingComponentPath("data-machine", "data-machine.php", process.env.WP_CODEBOX_DATA_MACHINE_PATH)
+  const dataMachineCode = defaultSiblingComponentPath("data-machine-code", "data-machine-code.php", process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH)
+  const agentsApi = defaultAgentsApiPath(dataMachine)
+
+  return uniqueComponentSources([
+    dataMachine ? { source: dataMachine, slug: "data-machine" } : undefined,
+    dataMachineCode ? { source: dataMachineCode, slug: "data-machine-code" } : undefined,
+    agentsApi ? { source: agentsApi, slug: "agents-api" } : undefined,
+    ...configuredRuntimeComponentPaths().map((source) => ({ source })),
+    ...bundledRuntimeComponentPaths().map((source) => ({ source, slug: "wordpress-plugin" })),
+  ])
 }
 
 function bundledRuntimeComponentPaths(): string[] {
   return [resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "wordpress-plugin")]
+}
+
+function configuredRuntimeComponentPaths(): string[] {
+  return (process.env.CONTAINED_RUNTIME_COMPONENT_PATHS ?? process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS ?? "")
+    .split(/[,:]/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+function defaultAgentsApiPath(dataMachinePath = ""): string {
+  const explicit = process.env.WP_CODEBOX_AGENTS_API_PATH?.trim()
+  if (explicit) {
+    return explicit
+  }
+  if (dataMachinePath) {
+    return ""
+  }
+
+  return defaultSiblingComponentPath("agents-api", "agents-api.php")
+}
+
+function defaultSiblingComponentPath(slug: string, pluginFile: string, explicit = ""): string {
+  if (explicit.trim()) {
+    return explicit.trim()
+  }
+  return [
+    resolve(process.cwd(), "..", slug),
+    resolve(dirname(process.cwd()), slug),
+  ].find((source) => existsSync(resolve(source, pluginFile))) ?? ""
+}
+
+function uniqueComponentSources(components: Array<{ source: string; slug?: string } | undefined>): Array<{ source: string; slug?: string }> {
+  const seen = new Set<string>()
+  return components.filter((component): component is { source: string; slug?: string } => {
+    if (!component?.source) {
+      return false
+    }
+    const source = resolve(component.source)
+    if (!existsSync(source) || seen.has(source)) {
+      return false
+    }
+    component.source = source
+    seen.add(source)
+    return true
+  })
 }
 
 export function componentManifestForRuntimePlugins(componentPlugins: WorkspaceRecipeExtraPlugin[], providerPlugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeComponentManifest {

--- a/tests/agent-runtime-components.test.ts
+++ b/tests/agent-runtime-components.test.ts
@@ -8,10 +8,14 @@ import { agentRuntimeMounts, parseAgentRuntimeProbeOptions, type AgentRuntimeMou
 const root = mkdtempSync(join(tmpdir(), "wp-codebox-agent-runtime-components-"))
 const originalCwd = cwd()
 const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
+const originalDataMachinePath = process.env.WP_CODEBOX_DATA_MACHINE_PATH
+const originalDataMachineCodePath = process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH
 const originalRuntimeComponentPaths = process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
 const originalContainedRuntimeComponentPaths = process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
 
 try {
+  chdir(root)
+
   const runtimeHost = join(root, "runtime-host")
   const agentsApi = join(runtimeHost, "vendor", "wordpress", "agents-api")
   mkdirSync(agentsApi, { recursive: true })
@@ -24,25 +28,28 @@ try {
 
   assert.equal(agentsApiMount, undefined)
 
-  const defaultAgentsApi = join(root, "agents-api")
-  mkdirSync(defaultAgentsApi, { recursive: true })
-  writeFileSync(join(defaultAgentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
-  const runtimeEngine = join(root, "runtime-engine")
-  const runtimeTools = join(root, "runtime-tools")
-  mkdirSync(runtimeEngine, { recursive: true })
-  mkdirSync(runtimeTools, { recursive: true })
-  writeFileSync(join(runtimeEngine, "runtime-engine.php"), "<?php\n/* Plugin Name: Runtime Engine */\n")
-  writeFileSync(join(runtimeTools, "runtime-tools.php"), "<?php\n/* Plugin Name: Runtime Tools */\n")
-  process.env.CONTAINED_RUNTIME_COMPONENT_PATHS = `${runtimeEngine},${runtimeTools}`
+  const dataMachine = join(root, "data-machine")
+  const bundledAgentsApi = join(dataMachine, "vendor", "wordpress", "agents-api")
+  const dataMachineCode = join(root, "data-machine-code")
+  mkdirSync(bundledAgentsApi, { recursive: true })
+  mkdirSync(dataMachineCode, { recursive: true })
+  writeFileSync(join(dataMachine, "data-machine.php"), "<?php\n/* Plugin Name: Data Machine */\n")
+  writeFileSync(join(bundledAgentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+  writeFileSync(join(dataMachineCode, "data-machine-code.php"), "<?php\n/* Plugin Name: Data Machine Code */\n")
   const workspace = join(root, "workspace")
   mkdirSync(workspace, { recursive: true })
   chdir(workspace)
   const defaultMounts = agentRuntimeMounts(parseAgentRuntimeProbeOptions([], parseMount))
-  const defaultMount = defaultMounts
-    .find((mount) => mount.metadata?.slug === "agents-api")
-  assert.equal(defaultMount, undefined)
-  assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "runtime-engine")?.source, runtimeEngine)
-  assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "runtime-tools")?.source, runtimeTools)
+  assert.equal(defaultMounts.find((mount) => mount.metadata?.slug === "agents-api"), undefined)
+  assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "data-machine")?.source, dataMachine)
+  assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "data-machine-code")?.source, dataMachineCode)
+
+  rmSync(dataMachine, { recursive: true, force: true })
+  const defaultAgentsApi = join(root, "agents-api")
+  mkdirSync(defaultAgentsApi, { recursive: true })
+  writeFileSync(join(defaultAgentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+  const fallbackMounts = agentRuntimeMounts(parseAgentRuntimeProbeOptions([], parseMount))
+  assertSamePath(fallbackMounts.find((mount) => mount.metadata?.slug === "agents-api")?.source, defaultAgentsApi)
 
   const explicitAgentsApi = join(root, "explicit-agents-api")
   mkdirSync(explicitAgentsApi, { recursive: true })
@@ -57,6 +64,16 @@ try {
     delete process.env.WP_CODEBOX_AGENTS_API_PATH
   } else {
     process.env.WP_CODEBOX_AGENTS_API_PATH = originalAgentsApiPath
+  }
+  if (originalDataMachinePath === undefined) {
+    delete process.env.WP_CODEBOX_DATA_MACHINE_PATH
+  } else {
+    process.env.WP_CODEBOX_DATA_MACHINE_PATH = originalDataMachinePath
+  }
+  if (originalDataMachineCodePath === undefined) {
+    delete process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH
+  } else {
+    process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH = originalDataMachineCodePath
   }
   if (originalRuntimeComponentPaths === undefined) {
     delete process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { chdir, cwd } from "node:process"
 import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, PREVIEW_LEASE_SCHEMA, buildAgentTaskRecipe, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeRecipeRunSummary, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
@@ -191,18 +192,28 @@ assert.equal(agentRecipePolicy.commands.includes("wordpress.wp-cli"), true)
 assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run"), false)
 
 const agentRecipeTemp = mkdtempSync(join(tmpdir(), "wp-codebox-agent-recipe-test-"))
+const originalCwd = cwd()
 const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
+const originalDataMachinePath = process.env.WP_CODEBOX_DATA_MACHINE_PATH
+const originalDataMachineCodePath = process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH
 const originalRuntimeComponentPaths = process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
 const originalContainedRuntimeComponentPaths = process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
 try {
+  const workspaceRoot = join(agentRecipeTemp, "workspace")
+  mkdirSync(workspaceRoot)
+  chdir(workspaceRoot)
+
   const agentsApiSource = join(agentRecipeTemp, "agents-api")
   mkdirSync(agentsApiSource)
   writeFileSync(join(agentsApiSource, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
-  process.env.WP_CODEBOX_AGENTS_API_PATH = agentsApiSource
-  const runtimeEngineSource = join(agentRecipeTemp, "runtime-engine")
-  mkdirSync(runtimeEngineSource)
-  writeFileSync(join(runtimeEngineSource, "runtime-engine.php"), "<?php\n/* Plugin Name: Runtime Engine */\n")
-  process.env.CONTAINED_RUNTIME_COMPONENT_PATHS = runtimeEngineSource
+  const dataMachineSource = join(agentRecipeTemp, "data-machine")
+  const bundledAgentsApiSource = join(dataMachineSource, "vendor", "wordpress", "agents-api")
+  mkdirSync(bundledAgentsApiSource, { recursive: true })
+  writeFileSync(join(dataMachineSource, "data-machine.php"), "<?php\n/* Plugin Name: Data Machine */\n")
+  writeFileSync(join(bundledAgentsApiSource, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
+  const dataMachineCodeSource = join(agentRecipeTemp, "data-machine-code")
+  mkdirSync(dataMachineCodeSource)
+  writeFileSync(join(dataMachineCodeSource, "data-machine-code.php"), "<?php\n/* Plugin Name: Data Machine Code */\n")
   const providerSource = join(agentRecipeTemp, "test-provider")
   mkdirSync(providerSource)
   writeFileSync(join(providerSource, "test-provider.php"), "<?php\n/* Plugin Name: Test Provider */\n")
@@ -222,8 +233,12 @@ try {
   }, normalizeTaskInput({ goal: "Verify generic runtime propagation" }), "latest")
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
-  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), true)
-  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), true)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), false)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), false)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine"), true)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine-code"), true)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), true)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code"), true)
 
   const recipe = buildAgentTaskRecipe({
     goal: "Verify extra plugin propagation",
@@ -257,7 +272,8 @@ try {
   assert.equal(agentsApiPlugin?.activate, false)
   assert.equal(agentsApiPlugin?.loadAs, "mu-plugin")
   assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api" && component.loadAs === "mu-plugin"), true)
-  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "runtime-engine" && component.loadAs === "mu-plugin"), true)
+  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine" && component.loadAs === "mu-plugin"), true)
+  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code" && component.loadAs === "mu-plugin"), true)
   assert.equal(recipe.inputs?.component_manifest?.components.some((component) => String(component.mountedPath).includes("/contained-runtime/")), true)
   assert.equal(JSON.stringify(recipe).includes("wp-codebox-default-agent-runtime-substrate"), false)
   assert.equal(JSON.stringify(recipe).includes("wp-codebox-runtime"), false)
@@ -288,10 +304,21 @@ try {
   assert.equal(dryRun.success, true)
   assert.deepEqual(dryRun.plan?.runtime.blueprint, { steps: [] })
 } finally {
+  chdir(originalCwd)
   if (originalAgentsApiPath === undefined) {
     delete process.env.WP_CODEBOX_AGENTS_API_PATH
   } else {
     process.env.WP_CODEBOX_AGENTS_API_PATH = originalAgentsApiPath
+  }
+  if (originalDataMachinePath === undefined) {
+    delete process.env.WP_CODEBOX_DATA_MACHINE_PATH
+  } else {
+    process.env.WP_CODEBOX_DATA_MACHINE_PATH = originalDataMachinePath
+  }
+  if (originalDataMachineCodePath === undefined) {
+    delete process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH
+  } else {
+    process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH = originalDataMachineCodePath
   }
   if (originalRuntimeComponentPaths === undefined) {
     delete process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS


### PR DESCRIPTION
## Summary
- mount Data Machine and Data Machine Code as Codebox-owned default runtime substrate when sibling checkouts are available
- prefer Data Machine's bundled Agents API instead of mounting standalone Agents API separately
- keep standalone/explicit Agents API support as fallback or override

## Testing
- `npx tsx tests/agent-runtime-components.test.ts`
- `git diff --check`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing sandbox agents/chat substrate, drafting the runtime component discovery change, updating the focused substrate test, and running verification.
