### PR TITLE
Treat runtime replies as terminal answers

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -1055,7 +1055,7 @@ function reachedMaxTurnsWithoutAnswer(payload: Record<string, unknown>): boolean
 }
 
 function hasTerminalAnswer(payload: Record<string, unknown>): boolean {
-  return ["answer", "final_answer", "finalAnswer", "message", "content"].some((key) => {
+  return ["answer", "final_answer", "finalAnswer", "reply", "message", "content"].some((key) => {
     const value = payload[key]
     return typeof value === "string" && value.trim().length > 0
   })

--- a/scripts/agent-terminal-result-contract-smoke.ts
+++ b/scripts/agent-terminal-result-contract-smoke.ts
@@ -39,6 +39,26 @@ const canonicalExecutionFailure = agentSandboxRuntimeFailure({
 })
 assert.equal(canonicalExecutionFailure, undefined, "canonical terminal_result overrides legacy pending-tool fields")
 
+const replyExecutionFailure = agentSandboxRuntimeFailure({
+  executionIndex: 0,
+  command: "wordpress.run-php",
+  exitCode: 0,
+  recipeCommand: "wp-codebox.agent-sandbox-run",
+  stdout: "",
+  stderr: "",
+  parsed: {
+    agent_runtime: {
+      success: true,
+      result: {
+        reply: "Concept packet produced.",
+        current_turn: 20,
+        max_turns: 20,
+      },
+    },
+  },
+})
+assert.equal(replyExecutionFailure, undefined, "reply is a terminal answer for max-turn compatibility checks")
+
 const legacy = normalizeAgentTerminalResult({
   status: "processing",
   completed: false,


### PR DESCRIPTION
## Summary
- Treat nested runtime reply fields as terminal answers when checking max-turn compatibility fallbacks.
- Prevent successful Data Machine chat results with reply from being classified as incomplete.
- Add terminal-result smoke coverage for the reply-shaped runtime result.

## Testing
- npm install (prepare build passed; generated package-lock version metadata was excluded)
- npx tsx scripts/agent-terminal-result-contract-smoke.ts
- npx tsx tests/agent-task-contracts.test.ts
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, implementation, and regression coverage.