### PR TITLE
Add browser session evidence refs

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -277,6 +277,9 @@ final class WP_Codebox_Browser_Task_Builder {
 		$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
 		$task_input       = is_array( $session['task_input'] ?? null ) ? $session['task_input'] : array();
 		$signals          = is_array( $session['signals'] ?? null ) ? $session['signals'] : array();
+		$preview_boot     = self::browser_preview_boot_config( $session );
+		$blueprint_ref    = self::browser_blueprint_ref( self::browser_prepared_runtime_from_envelope( $session, $preview_boot ), $session );
+		$preview_lease    = self::preview_lease_from_session( $session );
 
 		$dto = array_filter(
 			array(
@@ -294,7 +297,10 @@ final class WP_Codebox_Browser_Task_Builder {
 				'agent'            => (string) ( $session['agent'] ?? '' ),
 				'provider'         => (string) ( $session['provider'] ?? '' ),
 				'model'            => (string) ( $session['model'] ?? '' ),
-				'preview_boot'     => self::browser_preview_boot_config( $session ),
+				'preview_boot'     => $preview_boot,
+				'preview_lease'    => $preview_lease,
+				'blueprint_ref'    => $blueprint_ref,
+				'preview_reference' => self::browser_product_preview_reference( $session, $preview_boot, $preview_lease, $blueprint_ref ),
 				'runtime_access'   => self::runtime_access_from_session( $session ),
 				'preview_ref'      => self::browser_preview_ref( $session ),
 				'signals'          => self::compact_public_value( $signals ),
@@ -345,6 +351,38 @@ final class WP_Codebox_Browser_Task_Builder {
 				'boot_ref'   => (string) ( $preview_boot['blueprint_ref'] ?? '' ),
 			),
 			static fn( string $value ): bool => '' !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $session Browser session contract. @param array<string,mixed> $preview_boot Preview boot DTO. @param array<string,mixed> $preview_lease Preview lease DTO. @param array<string,mixed> $blueprint_ref Blueprint ref DTO. @return array<string,mixed> */
+	private static function browser_product_preview_reference( array $session, array $preview_boot, array $preview_lease, array $blueprint_ref ): array {
+		$contained_site = is_array( $session['contained_site'] ?? null ) ? self::compact_public_value( $session['contained_site'] ) : array();
+		$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
+		$preview_ref = self::browser_preview_ref( $session );
+		$preview_url = (string) ( $preview_lease['public_url'] ?? $preview_lease['preview_public_url'] ?? $preview_lease['site_url'] ?? $preview_lease['local_url'] ?? $preview_ref['url'] ?? '' );
+
+		return array_filter(
+			array(
+				'schema'             => 'wp-codebox/browser-preview-reference/v1',
+				'kind'               => 'browser-contained-site',
+				'status'             => (string) ( $session['status'] ?? ( true === ( $session['success'] ?? false ) ? 'ready' : '' ) ),
+				'preview_id'         => (string) ( $contained_site['preview_id'] ?? $preview_ref['preview_id'] ?? '' ),
+				'session_id'         => (string) ( $session_envelope['id'] ?? $session['session_id'] ?? $contained_site['session_id'] ?? '' ),
+				'site_id'            => (string) ( $contained_site['site_id'] ?? '' ),
+				'preview_url'        => $preview_url,
+				'preview'            => $preview_lease,
+				'preview_ref'        => $preview_ref,
+				'blueprint_ref'      => $blueprint_ref,
+				'hydration_endpoint' => (string) ( $blueprint_ref['hydration_endpoint'] ?? $blueprint_ref['endpoint'] ?? '' ),
+				'boot'               => array_filter(
+					array(
+						'schema' => 'wp-codebox/browser-contained-site-boot/v1',
+						'ref'    => (string) ( $preview_boot['blueprint_ref'] ?? '' ),
+					)
+				),
+				'contained_site'     => $contained_site,
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
 		);
 	}
 
@@ -527,6 +565,16 @@ final class WP_Codebox_Browser_Task_Builder {
 
 	/** @param array<string,mixed> $input Prepared runtime, full session, or executable ref request. @return array<string,mixed> */
 	public static function executable_blueprint_ref( array $input ): array {
+		if ( is_array( $input['blueprint_ref'] ?? null ) ) {
+			return $input['blueprint_ref'];
+		}
+		if ( is_array( $input['preview_boot']['blueprint_ref_dto'] ?? null ) ) {
+			return $input['preview_boot']['blueprint_ref_dto'];
+		}
+		if ( is_array( $input['preview_reference']['blueprint_ref'] ?? null ) ) {
+			return $input['preview_reference']['blueprint_ref'];
+		}
+
 		$session = is_array( $input['session'] ?? null ) ? $input['session'] : $input;
 		$primary = is_array( $session['primary'] ?? null ) ? $session['primary'] : $session;
 		$playground = is_array( $primary['playground'] ?? null ) ? $primary['playground'] : ( is_array( $input['playground'] ?? null ) ? $input['playground'] : array() );

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -2437,12 +2437,54 @@ private static function blocked_browser_playground_session( string $session_id, 
 /** @param array<string,mixed> $session Browser session contract. @param array<string,mixed> $input Ability input. @return array<string,mixed> */
 private static function browser_session_response_for_input( array $session, array $input ): array {
 	$product_dto = WP_Codebox_Browser_Task_Builder::product_browser_session_dto( $session );
+	$evidence_ref = self::browser_session_evidence_store( $product_dto, $session );
+	if ( ! empty( $evidence_ref ) ) {
+		$product_dto['evidence_ref'] = $evidence_ref;
+	}
 	if ( self::include_raw_browser_session_contract( $input ) ) {
 		$session['product'] = $product_dto;
 		return $session;
 	}
 
 	return $product_dto;
+}
+
+/** @param array<string,mixed> $product_dto Product-safe session DTO. @param array<string,mixed> $session Raw browser session contract. @return array<string,mixed> */
+private static function browser_session_evidence_store( array $product_dto, array $session ): array {
+	if ( ! function_exists( 'set_transient' ) ) {
+		return array();
+	}
+
+	$session_id  = (string) ( $product_dto['session_id'] ?? '' );
+	$evidence_id = 'browser-session-' . substr( hash( 'sha256', $session_id . wp_json_encode( $product_dto ) ), 0, 24 );
+	$ttl         = max( 1, (int) apply_filters( 'wp_codebox_browser_session_evidence_ttl', WEEK_IN_SECONDS, $product_dto, $session ) );
+	$evidence    = array_filter(
+		array(
+			'schema'            => 'wp-codebox/browser-session-evidence/v1',
+			'id'                => $evidence_id,
+			'created_at'        => gmdate( 'c' ),
+			'session_id'        => $session_id,
+			'preview_ref'       => is_array( $product_dto['preview_ref'] ?? null ) ? $product_dto['preview_ref'] : array(),
+			'preview_reference' => is_array( $product_dto['preview_reference'] ?? null ) ? $product_dto['preview_reference'] : array(),
+			'preview_lease'     => is_array( $product_dto['preview_lease'] ?? null ) ? $product_dto['preview_lease'] : array(),
+			'preview_boot'      => is_array( $product_dto['preview_boot'] ?? null ) ? $product_dto['preview_boot'] : array(),
+			'blueprint_ref'     => is_array( $product_dto['blueprint_ref'] ?? null ) ? $product_dto['blueprint_ref'] : array(),
+			'contained_site'    => is_array( $product_dto['contained_site'] ?? null ) ? $product_dto['contained_site'] : array(),
+			'signals'           => is_array( $product_dto['signals'] ?? null ) ? $product_dto['signals'] : array(),
+		),
+		static fn( mixed $value ): bool => '' !== $value && array() !== $value
+	);
+
+	if ( ! set_transient( 'wp_codebox_browser_session_evidence_' . $evidence_id, $evidence, $ttl ) ) {
+		return array();
+	}
+
+	return array(
+		'schema'  => 'wp-codebox/browser-session-evidence-ref/v1',
+		'id'      => $evidence_id,
+		'storage' => 'transient',
+		'ttl'     => $ttl,
+	);
 }
 
 /** @param array<string,mixed> $input Ability input. */

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -2,8 +2,10 @@
 declare(strict_types=1);
 
 define( 'ABSPATH', __DIR__ );
+defined( 'WEEK_IN_SECONDS' ) || define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
 
 $GLOBALS['wp_codebox_test_transient'] = false;
+$GLOBALS['wp_codebox_test_transients'] = array();
 
 final class WP_Error {
 	/** @param array<string,mixed> $data */
@@ -28,8 +30,32 @@ function sanitize_key( string $key ): string {
 }
 
 function get_transient( string $transient ): mixed {
+	if ( array_key_exists( $transient, $GLOBALS['wp_codebox_test_transients'] ) ) {
+		return $GLOBALS['wp_codebox_test_transients'][ $transient ]['value'];
+	}
 	unset( $transient );
 	return $GLOBALS['wp_codebox_test_transient'];
+}
+
+function set_transient( string $transient, mixed $value, int $expiration = 0 ): bool {
+	$GLOBALS['wp_codebox_test_transients'][ $transient ] = array(
+		'value'      => $value,
+		'expiration' => $expiration,
+	);
+
+	return true;
+}
+
+function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+	return json_encode( $value, $flags, $depth );
+}
+
+function wp_generate_uuid4(): string {
+	return '00000000-0000-4000-8000-000000000123';
+}
+
+function wp_parse_url( string $url, int $component = -1 ): mixed {
+	return -1 === $component ? parse_url( $url ) : parse_url( $url, $component );
 }
 
 function fail( string $message ): void {
@@ -43,6 +69,8 @@ function expect( bool $condition, string $message ): void {
 	}
 }
 
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-workload.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
@@ -238,5 +266,78 @@ expect( ! is_wp_error( $destroy ), 'Expected destroy facade to return an envelop
 expect( true === $destroy['success'], 'Expected destroy success=true.' );
 expect( 'wp-codebox/browser-contained-site-destroy/v1' === $destroy['schema'], 'Expected destroy schema.' );
 expect( 'released' === $destroy['preview_lease']['lease']['status'], 'Expected released preview lease.' );
+
+$raw_product_session = array(
+	'success'          => true,
+	'schema'           => 'wp-codebox/browser-playground-session/v1',
+	'execution'        => 'browser-playground',
+	'execution_scope'  => 'disposable-playground',
+	'permission_model' => 'runtime-principal',
+	'session'          => array( 'id' => 'product-smoke-session' ),
+	'task_input'       => array(
+		'goal'               => 'Create a disposable preview for smoke testing.',
+		'target'             => array( 'kind' => 'php-smoke' ),
+		'expected_artifacts' => array( 'preview' ),
+	),
+	'playground'       => array(
+		'scope'              => 'product-smoke-session',
+		'preview_url'        => '/wp-content/uploads/wp-codebox/artifacts/uploaded-site/index.html',
+		'prepared_runtime'   => array(
+			'schema'     => 'wp-codebox/browser-prepared-runtime/v1',
+			'cache_key'  => 'product-smoke-cache',
+			'input_hash' => $source_digest,
+			'status'     => 'ready',
+		),
+	),
+	'contained_site'   => array(
+		'schema'     => 'wp-codebox/browser-contained-site/v1',
+		'site_id'    => 'product-smoke-cache',
+		'preview_id' => 'preview-product-smoke',
+		'session_id' => 'product-smoke-session',
+		'status'     => 'ready',
+	),
+	'artifacts'        => array(
+		'schema' => 'wp-codebox/browser-artifacts/v1',
+		'files'  => array(
+			array(
+				'path'    => 'uploaded-site/index.html',
+				'kind'    => 'html',
+				'size'    => 16,
+				'sha256'  => str_repeat( 'd', 64 ),
+				'content' => '<h1>Preview</h1>',
+			),
+		),
+	),
+	'signals'          => array(
+		'ready_to_code' => array( 'schema' => 'wp-codebox/signal/v1', 'emitted' => true ),
+	),
+);
+$response_method = new ReflectionMethod( WP_Codebox_Abilities::class, 'browser_session_response_for_input' );
+$product_session = $response_method->invoke( null, $raw_product_session, array() );
+
+expect( ! is_wp_error( $product_session ), 'Expected product browser session DTO.' );
+expect( 'wp-codebox/browser-session-product-dto/v1' === $product_session['schema'], 'Expected product session DTO schema.' );
+expect( true === $product_session['success'], 'Expected product session success=true.' );
+expect( isset( $product_session['preview_boot'] ), 'Expected product session preview boot.' );
+expect( isset( $product_session['preview_ref'] ), 'Expected product session preview ref.' );
+expect( isset( $product_session['preview_lease'] ), 'Expected product session preview lease.' );
+expect( isset( $product_session['preview_reference'] ), 'Expected product session preview reference.' );
+expect( 'wp-codebox/browser-preview-reference/v1' === $product_session['preview_reference']['schema'], 'Expected preview reference schema.' );
+expect( isset( $product_session['blueprint_ref'] ), 'Expected product session blueprint ref.' );
+expect( isset( $product_session['evidence_ref'] ), 'Expected product session evidence ref.' );
+expect( 'wp-codebox/browser-session-evidence-ref/v1' === $product_session['evidence_ref']['schema'], 'Expected evidence ref schema.' );
+expect( ! isset( $product_session['playground'] ), 'Product DTO must not expose raw playground.' );
+expect( ! isset( $product_session['task_payload'] ), 'Product DTO must not expose raw task payload.' );
+
+$evidence_key = 'wp_codebox_browser_session_evidence_' . $product_session['evidence_ref']['id'];
+expect( isset( $GLOBALS['wp_codebox_test_transients'][ $evidence_key ] ), 'Expected evidence transient to be stored.' );
+$evidence = $GLOBALS['wp_codebox_test_transients'][ $evidence_key ]['value'];
+expect( 'wp-codebox/browser-session-evidence/v1' === $evidence['schema'], 'Expected evidence schema.' );
+expect( $product_session['session_id'] === $evidence['session_id'], 'Expected evidence session id.' );
+expect( isset( $evidence['preview_reference'] ), 'Expected evidence preview reference.' );
+expect( false === str_contains( wp_json_encode( $evidence ), '<h1>Preview</h1>' ), 'Evidence must not store raw uploaded content.' );
+
+$executable_ref = WP_Codebox_Browser_Task_Builder::executable_blueprint_ref( $product_session );
+expect( $product_session['blueprint_ref'] === $executable_ref, 'Expected executable blueprint ref from product DTO.' );
 
 fwrite( STDOUT, "PHP browser contained site contract smoke passed\n" );


### PR DESCRIPTION
## Summary
- Add product-safe browser preview references, preview leases, and blueprint refs to WP Codebox browser session DTOs.
- Persist sanitized browser-session evidence in a transient and return an evidence_ref.
- Teach executable_blueprint_ref() to consume product DTO refs without raw session internals.

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- php scripts/php-browser-contained-site-contract-smoke.php
- php scripts/php-public-api-facade-smoke.php
- php scripts/php-browser-callback-contracts-smoke.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, and test updates for browser-session evidence/reference contracts.