### PR TITLE
Gate fuzz suites on runner capabilities

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -79,6 +79,15 @@ ability runs safe in-process `rest`, same-site `http`, and WordPress `ability`
 targets directly. Targets that require the runtime command, browser, editor, or
 page-load executors return `status: "skipped"`, a case-level `skipReason`, and a
 warning diagnostic rather than silently passing without exercising the target.
+Public suite builders declare `metadata.requiredRunnerCapabilities` so callers
+can choose between PHP in-process mode and runtime-backed mode before execution.
+The public core exports `PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES` and
+`RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES` for readiness checks. Runtime-backed
+mode supports `runtime`, browser/editor/page-load action targets, and the
+`crud_operation` runtime action mapped to `wordpress.crud-operation`. When a
+caller requests required coverage, pass `requireCoverage: true`; unsupported
+required capabilities fail closed with `status: "error"` instead of looking like a
+successful structured skip.
 Documented skip reason codes are:
 
 - `wp_codebox_fuzz_target_command_unsupported`

--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -6,6 +6,7 @@ export const FUZZ_SUITE_RESULT_SCHEMA = "wp-codebox/fuzz-suite-result/v1" as con
 export type FuzzSuiteTargetKind = "ability" | "command" | "http" | "rest" | "runtime" | "runtime-action" | (string & {})
 export type FuzzSuiteCaseStatus = "passed" | "failed" | "error" | "skipped"
 export type FuzzSuiteDiagnosticSeverity = "error" | "warning" | "info"
+export type FuzzSuiteRunnerMode = "php-in-process" | "runtime-backed" | (string & {})
 
 export interface FuzzSuiteTargetRef {
   kind: FuzzSuiteTargetKind
@@ -30,6 +31,45 @@ export interface FuzzSuiteContract {
   target?: FuzzSuiteTargetRef
   cases: FuzzSuiteCase[]
   metadata?: Record<string, unknown>
+}
+
+export interface FuzzSuiteRunnerCapabilities {
+  mode: FuzzSuiteRunnerMode
+  capabilities: string[]
+  targetKinds: string[]
+  runtimeActionTypes?: string[]
+  commands?: string[]
+}
+
+export const PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES: FuzzSuiteRunnerCapabilities = {
+  mode: "php-in-process",
+  capabilities: ["target:ability", "target:http", "target:rest"],
+  targetKinds: ["ability", "http", "rest"],
+}
+
+export const RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES: FuzzSuiteRunnerCapabilities = {
+  mode: "runtime-backed",
+  capabilities: [
+    "target:ability",
+    "target:command",
+    "target:http",
+    "target:rest",
+    "target:runtime",
+    "target:runtime-action",
+    "runtime",
+    "runtime-action:admin_page",
+    "runtime-action:browser",
+    "runtime-action:browser_probe",
+    "runtime-action:crud_operation",
+    "runtime-action:editor_open",
+    "runtime-action:page",
+    "runtime-action:php",
+    "runtime-action:rest_request",
+    "runtime-action:wp_cli",
+  ],
+  targetKinds: ["ability", "command", "http", "rest", "runtime", "runtime-action"],
+  runtimeActionTypes: ["admin_page", "browser", "browser_probe", "crud_operation", "editor_open", "page", "php", "rest_request", "wp_cli"],
+  commands: ["wordpress.ability", "wordpress.admin-page-load", "wordpress.browser-actions", "wordpress.browser-probe", "wordpress.crud-operation", "wordpress.editor-open", "wordpress.frontend-page-load", "wordpress.http-request", "wordpress.rest-request", "wordpress.run-php", "wordpress.wp-cli"],
 }
 
 export interface FuzzSuiteDiagnostic {
@@ -133,7 +173,8 @@ export function fuzzSuiteResultEnvelope(input: {
   const coverageSummary = input.coverageSummary ?? summarizeFuzzCoverage({ discovered: fuzzSuiteDiscoveredCount(input.suite, cases.length), cases })
   const contractDiagnostics = fuzzSuiteContractDiagnostics({ suite: input.suite, cases, artifactRefs, coverageSummary })
   diagnostics.push(...contractDiagnostics)
-  const status: FuzzSuiteCaseStatus = summary.error > 0 || contractDiagnostics.length > 0 ? "error" : summary.failed > 0 ? "failed" : summary.skipped === summary.total && summary.total > 0 ? "skipped" : "passed"
+  const hasRequiredCoverageError = diagnostics.some((diagnostic) => diagnostic.code === "fuzz_suite_required_runner_capabilities_unsupported" || diagnostic.code === "fuzz_suite_required_coverage_unsupported")
+  const status: FuzzSuiteCaseStatus = summary.error > 0 || hasRequiredCoverageError || contractDiagnostics.length > 0 ? "error" : summary.failed > 0 ? "failed" : summary.skipped === summary.total && summary.total > 0 ? "skipped" : "passed"
 
   return stripUndefined({
     schema: FUZZ_SUITE_RESULT_SCHEMA,
@@ -147,6 +188,20 @@ export function fuzzSuiteResultEnvelope(input: {
     artifactRefs,
     metadata: input.metadata,
   })
+}
+
+export function fuzzSuiteRequiredRunnerCapabilities(suite: FuzzSuiteContract): string[] {
+  const metadata = fuzzSuiteMetadata(suite)
+  const required = recordField(metadata, "requiredRunnerCapabilities") ?? recordField(metadata, "required_runner_capabilities")
+  return dedupeStrings([
+    ...stringArrayField(required, "capabilities"),
+    ...stringArrayField(required, "targetKinds").map((kind) => `target:${kind}`),
+    ...stringArrayField(required, "target_kinds").map((kind) => `target:${kind}`),
+    ...stringArrayField(required, "runtimeActionTypes").map((type) => `runtime-action:${type}`),
+    ...stringArrayField(required, "runtime_action_types").map((type) => `runtime-action:${type}`),
+    ...stringArrayField(metadata, "requiredCapabilities"),
+    ...stringArrayField(metadata, "required_capabilities"),
+  ])
 }
 
 export function summarizeFuzzCases(cases: readonly Pick<FuzzSuiteCaseResult, "status">[]): FuzzSuiteSummary {
@@ -303,6 +358,14 @@ function arrayField(source: Record<string, unknown> | undefined, key: string): u
 
 function nonEmptyArrayField(source: Record<string, unknown> | undefined, key: string): boolean {
   return arrayField(source, key).length > 0
+}
+
+function stringArrayField(source: Record<string, unknown> | undefined, key: string): string[] {
+  return arrayField(source, key).filter((item): item is string => typeof item === "string" && item.length > 0)
+}
+
+function dedupeStrings(values: readonly string[]): string[] {
+  return [...new Set(values)]
 }
 
 function booleanField(source: Record<string, unknown> | undefined, key: string): boolean | undefined {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -1,7 +1,8 @@
 import { stripUndefined } from "./object-utils.js"
-import { fuzzSuiteResultEnvelope, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
+import { RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteRequiredRunnerCapabilities, fuzzSuiteResultEnvelope, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteRunnerCapabilities, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
 import type { RuntimeAction, RuntimeActionObservation } from "./runtime-action-adapter.js"
 import type { ExecutionResult, ExecutionSpec, RuntimeCommandDiagnosticsCaptureSpec, RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
+import { WORDPRESS_CRUD_OPERATION_SCHEMA, normalizeWordPressCrudOperation } from "./wordpress-crud-contracts.js"
 
 export interface FuzzSuiteCommandExecutor {
   execute(spec: ExecutionSpec): Promise<ExecutionResult>
@@ -12,6 +13,8 @@ export interface FuzzSuiteRunOptions {
   runtimeActionExecutor?: FuzzSuiteRuntimeActionExecutor | ((input: FuzzSuiteRuntimeActionExecutionInput) => Promise<RuntimeActionObservation>)
   targetAdapters?: FuzzSuiteTargetAdapterRegistry | readonly FuzzSuiteTargetAdapter[]
   supportedTargetKinds?: readonly string[]
+  runnerCapabilities?: FuzzSuiteRunnerCapabilities | readonly string[]
+  requireCoverage?: boolean
   metadata?: Record<string, unknown>
 }
 
@@ -84,7 +87,24 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
   const execute = normalizeFuzzSuiteExecutor(options.executor)
   const executeRuntimeAction = normalizeFuzzSuiteRuntimeActionExecutor(options.runtimeActionExecutor)
   const adapterRegistry = normalizeFuzzSuiteTargetAdapterRegistry(options.targetAdapters)
-  const supportedTargetKinds = new Set(options.supportedTargetKinds ?? DEFAULT_SUPPORTED_TARGET_KINDS)
+  const runnerCapabilities = normalizeFuzzSuiteRunnerCapabilities(options.runnerCapabilities)
+  const supportedTargetKinds = new Set(options.supportedTargetKinds ?? runnerCapabilities.targetKinds ?? DEFAULT_SUPPORTED_TARGET_KINDS)
+  const missingCapabilities = missingRequiredFuzzSuiteCapabilities(suite, runnerCapabilities)
+
+  if (options.requireCoverage && missingCapabilities.length > 0) {
+    const diagnostic: FuzzSuiteDiagnostic = {
+      severity: "error",
+      code: "fuzz_suite_required_runner_capabilities_unsupported",
+      message: `Fuzz suite ${suite.id} requires runner capabilities that are not available: ${missingCapabilities.join(", ")}.`,
+      metadata: { requiredCapabilities: fuzzSuiteRequiredRunnerCapabilities(suite), availableCapabilities: runnerCapabilities.capabilities, missingCapabilities, runnerMode: runnerCapabilities.mode },
+    }
+    return fuzzSuiteResultEnvelope({
+      suite,
+      cases: suite.cases.map((fuzzCase) => ({ id: fuzzCase.id, status: "skipped", success: false, target: fuzzCase.target ?? suite.target, skipReason: diagnostic.code, diagnostics: [diagnostic] })),
+      diagnostics: [diagnostic],
+      metadata: stripUndefined({ ...options.metadata, sourceSchema: suite.schema, runner: "wp-codebox/fuzz-suite-runner/v1", runnerCapabilities }),
+    })
+  }
 
   for (const [index, fuzzCase] of suite.cases.entries()) {
     const plan = planFuzzSuiteCaseExecutionSpec({ suite, case: fuzzCase, caseIndex: index, targetAdapters: adapterRegistry, supportedTargetKinds: [...supportedTargetKinds] })
@@ -92,14 +112,15 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
     const replayMetadata = plan.replayMetadata
     if (plan.status === "unsupported" || !plan.spec) {
       const planDiagnostics = plan.diagnostics ?? []
-      diagnostics.push(...planDiagnostics)
+      const caseDiagnostics = requiredCoverageDiagnostics(options.requireCoverage, suite, fuzzCase, planDiagnostics)
+      diagnostics.push(...caseDiagnostics)
       cases.push({
         id: fuzzCase.id,
         status: "skipped",
         success: false,
         target,
         skipReason: fuzzSuiteSkipReason(planDiagnostics),
-        diagnostics: planDiagnostics,
+        diagnostics: caseDiagnostics,
         metadata: stripUndefined({ replay: replayMetadata, adapter: plan.metadata }),
       })
       continue
@@ -176,14 +197,15 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         target,
         message: `No executor was provided for fuzz suite case ${fuzzCase.id}.`,
       }
-      diagnostics.push(diagnostic)
+      const caseDiagnostics = requiredCoverageDiagnostics(options.requireCoverage, suite, fuzzCase, [diagnostic])
+      diagnostics.push(...caseDiagnostics)
       cases.push({
         id: fuzzCase.id,
         status: "skipped",
         success: false,
         target,
         skipReason: diagnostic.code,
-        diagnostics: [diagnostic],
+        diagnostics: caseDiagnostics,
         metadata: stripUndefined({ replay: replayMetadata }),
       })
       continue
@@ -253,6 +275,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
       ...options.metadata,
       sourceSchema: suite.schema,
       runner: "wp-codebox/fuzz-suite-runner/v1",
+      runnerCapabilities,
     }),
   })
 }
@@ -509,6 +532,27 @@ function runtimeActionFuzzSuiteTargetAdapter(): FuzzSuiteTargetAdapter {
         }
       }
 
+      if (input.payload.type === "crud_operation") {
+        try {
+          const operation = normalizeWordPressCrudOperation({ schema: WORDPRESS_CRUD_OPERATION_SCHEMA, ...input.payload })
+          return {
+            status: "supported",
+            spec: stripUndefined({
+              command: "wordpress.crud-operation",
+              args: [`operation-json=${JSON.stringify(operation)}`],
+              timeoutMs: runtimeActionTimeoutMs(input.payload, input.timeoutMs),
+            }) as ExecutionSpec,
+            metadata: { adapterKind: "runtime-action", actionType: input.payload.type, mappedCommand: "wordpress.crud-operation" },
+          }
+        } catch (error) {
+          return unsupportedInputAdapterResolution(fuzzCase, target, error instanceof Error ? error.message : String(error), { adapterKind: "runtime-action", actionType: input.payload.type })
+        }
+      }
+
+      if (input.payload.type === "wordpress_crud_operation") {
+        return unsupportedTargetAdapterResolution(fuzzCase, target, "Runtime-action type wordpress_crud_operation has been renamed to crud_operation.", { adapterKind: "runtime-action", actionType: input.payload.type })
+      }
+
       if (input.payload.type === "browser") {
         return {
           status: "supported",
@@ -608,6 +652,39 @@ function unsupportedInputAdapterResolution(fuzzCase: FuzzSuiteCase, target: Fuzz
 
 function fuzzSuiteSkipReason(diagnostics: readonly FuzzSuiteDiagnostic[]): string | undefined {
   return diagnostics[0]?.code ?? diagnostics[0]?.message
+}
+
+function normalizeFuzzSuiteRunnerCapabilities(input: FuzzSuiteRunOptions["runnerCapabilities"]): FuzzSuiteRunnerCapabilities {
+  if (!input) {
+    return RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES
+  }
+  if (Array.isArray(input)) {
+    return { mode: "runtime-backed", capabilities: [...input], targetKinds: DEFAULT_SUPPORTED_TARGET_KINDS }
+  }
+  return input as FuzzSuiteRunnerCapabilities
+}
+
+function missingRequiredFuzzSuiteCapabilities(suite: FuzzSuiteContract, runnerCapabilities: FuzzSuiteRunnerCapabilities): string[] {
+  const available = new Set([...runnerCapabilities.capabilities, ...runnerCapabilities.targetKinds.map((kind) => `target:${kind}`), ...(runnerCapabilities.runtimeActionTypes ?? []).map((type) => `runtime-action:${type}`)])
+  return fuzzSuiteRequiredRunnerCapabilities(suite).filter((capability) => !available.has(capability))
+}
+
+function requiredCoverageDiagnostics(requireCoverage: boolean | undefined, suite: FuzzSuiteContract, fuzzCase: FuzzSuiteCase, diagnostics: readonly FuzzSuiteDiagnostic[]): FuzzSuiteDiagnostic[] {
+  if (!requireCoverage) {
+    return [...diagnostics]
+  }
+  const unsupported = diagnostics.find((diagnostic) => diagnostic.code === "fuzz_suite_case_unsupported" || diagnostic.code === "fuzz_suite_target_adapter_unsupported" || diagnostic.code === "fuzz_suite_executor_unavailable")
+  if (!unsupported) {
+    return [...diagnostics]
+  }
+  return [...diagnostics, {
+    severity: "error",
+    code: "fuzz_suite_required_coverage_unsupported",
+    caseId: fuzzCase.id,
+    target: fuzzCase.target ?? suite.target,
+    message: `Fuzz suite ${suite.id} requires coverage for case ${fuzzCase.id}, but the selected runner skipped an unsupported target.`,
+    metadata: { skippedCode: unsupported.code },
+  }]
 }
 
 function normalizeFuzzSuiteCaseExecutionInput(input: unknown): { valid: true; value: FuzzSuiteCaseExecutionInput } | { valid: false } {

--- a/packages/runtime-core/src/runtime-action-adapter.ts
+++ b/packages/runtime-core/src/runtime-action-adapter.ts
@@ -5,12 +5,13 @@ import { performanceObservation, type PerformanceObservation } from "./performan
 import { runtimeEpisodeDigest } from "./runtime-episode.js"
 import type { RuntimePolicy } from "./runtime-policy.js"
 import type { MountSpec, RuntimeCommandDiagnosticsCaptureSpec, RuntimeEpisode, RuntimeEpisodeContentDigest, RuntimeEpisodeStepResult, RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
+import { WORDPRESS_CRUD_OPERATION_SCHEMA, normalizeWordPressCrudOperation, type WordPressCrudOperation } from "./wordpress-crud-contracts.js"
 
 export const RUNTIME_ACTION_OBSERVATION_SCHEMA = "wp-codebox/runtime-action-observation/v1" as const
 
 export const SANDBOX_WORKSPACE_ROOT = "/workspace"
 
-export type RuntimeAction = RuntimeWpCliAction | RuntimePhpAction | RuntimeRestRequestAction | RuntimeFilesystemAction | RuntimeBrowserAction | RuntimeBrowserProbeAction | RuntimeEditorOpenAction | RuntimeAdminPageAction | RuntimePageAction | RuntimeWordPressPluginSetupAction | RuntimeWordPressPluginStateAction | RuntimeWordPressThemeSetupAction
+export type RuntimeAction = RuntimeWpCliAction | RuntimePhpAction | RuntimeRestRequestAction | RuntimeWordPressCrudOperationAction | RuntimeFilesystemAction | RuntimeBrowserAction | RuntimeBrowserProbeAction | RuntimeEditorOpenAction | RuntimeAdminPageAction | RuntimePageAction | RuntimeWordPressPluginSetupAction | RuntimeWordPressPluginStateAction | RuntimeWordPressThemeSetupAction
 
 export interface RuntimeWpCliAction {
   type: "wp_cli"
@@ -34,6 +35,11 @@ export interface RuntimeRestRequestAction {
   params?: Record<string, unknown>
   body?: string
   body_json?: unknown
+  timeout_ms?: number
+}
+
+export interface RuntimeWordPressCrudOperationAction extends Omit<WordPressCrudOperation, "schema"> {
+  type: "crud_operation"
   timeout_ms?: number
 }
 
@@ -169,6 +175,10 @@ export async function runRuntimeAction(
 
   if (action.type === "rest_request") {
     return runRuntimeRestRequestAction(episode, action)
+  }
+
+  if (action.type === "crud_operation") {
+    return runRuntimeWordPressCrudOperationAction(episode, action)
   }
 
   if (action.type === "browser") {
@@ -349,6 +359,36 @@ async function runRuntimeRestRequestAction(episode: RuntimeEpisode, action: Runt
     action,
     step,
     data: normalized,
+    artifactRefs: step.observation?.artifactRefs,
+  })
+}
+
+async function runRuntimeWordPressCrudOperationAction(episode: RuntimeEpisode, action: RuntimeWordPressCrudOperationAction): Promise<RuntimeActionObservation> {
+  const operation = normalizeWordPressCrudOperation({ schema: WORDPRESS_CRUD_OPERATION_SCHEMA, ...action })
+  const step = await episode.step(
+    {
+      kind: "command",
+      command: "wordpress.crud-operation",
+      args: [`operation-json=${JSON.stringify(operation)}`],
+      ...(action.timeout_ms !== undefined ? { timeoutMs: action.timeout_ms } : {}),
+    },
+    { type: "command-result" },
+  )
+
+  return runtimeActionObservation({
+    type: action.type,
+    action,
+    step,
+    data: {
+      operation,
+      mappedCommand: step.execution.command,
+      args: step.execution.args,
+      exitCode: step.execution.exitCode,
+      stdout: step.execution.stdout,
+      stderr: step.execution.stderr,
+      executionId: step.execution.id,
+      stepId: step.id,
+    },
     artifactRefs: step.observation?.artifactRefs,
   })
 }

--- a/packages/runtime-core/src/wordpress-block-fuzz-suite.ts
+++ b/packages/runtime-core/src/wordpress-block-fuzz-suite.ts
@@ -13,6 +13,8 @@ export interface WordPressBlockFuzzSuiteOptions {
 
 const DEFAULT_BLOCK_FUZZ_SUITE_ID = "wordpress-block-discovery"
 const DEFAULT_EDITOR_CAPTURE = ["editor-state", "errors"] as const
+const BLOCK_SERVER_RENDER_CAPABILITIES = ["target:runtime", "runtime"] as const
+const BLOCK_EDITOR_INSERT_CAPABILITIES = ["target:runtime", "runtime", "runtime-action:editor_open"] as const
 
 export function wordpressBlockDiscoveryToFuzzSuite(discovery: WordPressBlockEditorTargetDiscovery, options: WordPressBlockFuzzSuiteOptions = {}): FuzzSuiteContract {
   const includeServerRender = options.includeServerRender ?? true
@@ -44,6 +46,18 @@ export function wordpressBlockDiscoveryToFuzzSuite(discovery: WordPressBlockEdit
         includeServerRender ? "server-render" : undefined,
         includeEditorInsert ? "editor-insert" : undefined,
       ].filter((operation): operation is string => Boolean(operation)),
+      requiredRunnerCapabilities: stripUndefined({
+        capabilities: [...new Set([
+          ...(includeServerRender ? BLOCK_SERVER_RENDER_CAPABILITIES : []),
+          ...(includeEditorInsert ? BLOCK_EDITOR_INSERT_CAPABILITIES : []),
+        ])],
+        targetKinds: ["runtime"],
+        runtimeActionTypes: includeEditorInsert ? ["editor_open"] : undefined,
+        commands: [
+          includeServerRender ? "wordpress.run-php" : undefined,
+          includeEditorInsert ? "wordpress.editor-open" : undefined,
+        ].filter((command): command is string => Boolean(command)),
+      }),
     }),
   })
 }

--- a/packages/runtime-core/src/wordpress-fuzz-suite-builders.ts
+++ b/packages/runtime-core/src/wordpress-fuzz-suite-builders.ts
@@ -41,6 +41,23 @@ const FRONTEND_PAGE_LOAD_TARGET: FuzzSuiteTargetRef = {
   label: "WordPress frontend page load",
 }
 
+const REST_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES = {
+  capabilities: ["target:rest"],
+  targetKinds: ["rest"],
+}
+
+const ADMIN_PAGE_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES = {
+  capabilities: ["target:runtime", "runtime"],
+  targetKinds: ["runtime"],
+  commands: ["wordpress.admin-page-load"],
+}
+
+const FRONTEND_PAGE_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES = {
+  capabilities: ["target:runtime", "runtime"],
+  targetKinds: ["runtime"],
+  commands: ["wordpress.frontend-page-load"],
+}
+
 const REST_PARAMETER_GENERATION_HOOK: FuzzCoveragePlanParameterGenerationHook = {
   id: "wordpress.rest-route-parameters",
   label: "WordPress REST route parameter generator",
@@ -59,7 +76,7 @@ export function restRouteInventoryToFuzzSuite(inventory: WordPressRestRouteInven
     version: options.version,
     target: REST_REQUEST_TARGET,
     cases: inventory.routes.flatMap((route) => restRouteFuzzSuiteCases(route, options)),
-    metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status }),
+    metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, requiredRunnerCapabilities: REST_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES }),
   })
 }
 
@@ -69,7 +86,7 @@ export function adminPageInventoryToFuzzSuite(inventory: WordPressAdminPageInven
     version: options.version,
     target: ADMIN_PAGE_LOAD_TARGET,
     cases: inventory.pages.map((page) => adminPageFuzzSuiteCase(page, options)),
-    metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, adminUrl: inventory.adminUrl, menuLoaded: inventory.menuLoaded }),
+    metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, adminUrl: inventory.adminUrl, menuLoaded: inventory.menuLoaded, requiredRunnerCapabilities: ADMIN_PAGE_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES }),
   })
 }
 
@@ -79,7 +96,7 @@ export function frontendUrlInventoryToFuzzSuite(inventory: WordPressFrontendUrlI
     version: options.version,
     target: FRONTEND_PAGE_LOAD_TARGET,
     cases: inventory.urls.map((url) => frontendUrlFuzzSuiteCase(url, inventory.homeUrl, options)),
-    metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, homeUrl: inventory.homeUrl, permalinkStructure: inventory.permalinkStructure }),
+    metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, homeUrl: inventory.homeUrl, permalinkStructure: inventory.permalinkStructure, requiredRunnerCapabilities: FRONTEND_PAGE_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES }),
   })
 }
 

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -5,6 +5,7 @@ import {
   openWordPressEditor,
   probeWordPressBrowser,
   requestWordPressRest,
+  runWordPressCrudOperation,
   runWordPressBrowserAction,
   runWordPressPhp,
   runWordPressWpCli,
@@ -131,6 +132,20 @@ export function createWordPressFuzzSuiteRuntimeActionExecutor(episode: Pick<Runt
       }
       if (action.type === "rest_request") {
         return requestWordPressRest(episode, action)
+      }
+      if (action.type === "crud_operation") {
+        const step = await runWordPressCrudOperation(episode, action, action.timeout_ms)
+        return {
+          schema: "wp-codebox/runtime-action-observation/v1",
+          type: action.type,
+          status: "ok",
+          action,
+          data: { stepId: step.id, executionId: step.execution.id, mappedCommand: step.execution.command, args: step.execution.args, exitCode: step.execution.exitCode },
+          observedAt: new Date().toISOString(),
+          step,
+          artifactRefs: step.observation?.artifactRefs,
+          digest: { algorithm: "sha256", value: step.execution.command },
+        }
       }
       if (action.type === "browser") {
         return runWordPressBrowserAction(episode, action)

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -51,6 +51,28 @@ public static function run_fuzz_suite( array $input ): array|WP_Error {
 	}
 
 	$cases = is_array( $input['cases'] ?? null ) ? $input['cases'] : array();
+	$runner_capabilities = self::fuzz_suite_php_runner_capabilities();
+	$missing_capabilities = self::fuzz_suite_missing_required_capabilities( $input, $runner_capabilities );
+	if ( self::fuzz_suite_require_coverage( $input ) && ! empty( $missing_capabilities ) ) {
+		$diagnostic = self::fuzz_suite_diagnostic( 'error', 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported', 'Fuzz suite requires runner capabilities that are not available in PHP in-process mode.', array( 'missing_capabilities' => $missing_capabilities, 'runner_mode' => $runner_capabilities['mode'] ) );
+		$results = array();
+		foreach ( $cases as $index => $case ) {
+			$case_id = is_array( $case ) ? (string) ( $case['id'] ?? $case['case_id'] ?? ( 'case-' . (string) $index ) ) : ( 'case-' . (string) $index );
+			$results[] = self::fuzz_suite_case_result( $case_id, 'skipped', array( $diagnostic ) );
+		}
+
+		return array(
+			'success'      => false,
+			'schema'       => 'wp-codebox/fuzz-suite-result/v1',
+			'status'       => 'error',
+			'suite'        => array_filter( array( 'id' => (string) ( $input['id'] ?? '' ), 'version' => (string) ( $input['version'] ?? '' ) ), static fn( mixed $value ): bool => '' !== $value ),
+			'summary'      => self::fuzz_suite_summary( $results ),
+			'cases'        => $results,
+			'diagnostics'  => array( $diagnostic ),
+			'artifactRefs' => array(),
+			'metadata'     => array( 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'runner' => 'wp-codebox/fuzz-suite-runner/v1', 'runnerCapabilities' => $runner_capabilities ),
+		);
+	}
 	$results = array();
 	$diagnostics = array();
 	$artifact_refs = array();
@@ -91,8 +113,46 @@ public static function run_fuzz_suite( array $input ): array|WP_Error {
 		'cases'        => $results,
 		'diagnostics'  => $diagnostics,
 		'artifactRefs' => self::dedupe_fuzz_suite_artifact_refs( $artifact_refs ),
-		'metadata'     => array( 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'runner' => 'wp-codebox/fuzz-suite-runner/v1' ),
+		'metadata'     => array( 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'runner' => 'wp-codebox/fuzz-suite-runner/v1', 'runnerCapabilities' => $runner_capabilities ),
 	);
+}
+
+/** @return array<string,mixed> */
+private static function fuzz_suite_php_runner_capabilities(): array {
+	return array(
+		'mode'         => 'php-in-process',
+		'capabilities' => array( 'target:ability', 'target:http', 'target:rest' ),
+		'targetKinds'  => array( 'ability', 'http', 'rest' ),
+	);
+}
+
+/** @param array<string,mixed> $suite Suite input. */
+private static function fuzz_suite_require_coverage( array $suite ): bool {
+	return true === ( $suite['requireCoverage'] ?? $suite['require_coverage'] ?? false );
+}
+
+/** @param array<string,mixed> $suite Suite input. @param array<string,mixed> $runner_capabilities Runner capabilities. @return string[] */
+private static function fuzz_suite_missing_required_capabilities( array $suite, array $runner_capabilities ): array {
+	$required = self::fuzz_suite_required_capabilities( $suite );
+	$available = array_fill_keys( array_map( 'strval', $runner_capabilities['capabilities'] ?? array() ), true );
+	foreach ( (array) ( $runner_capabilities['targetKinds'] ?? array() ) as $kind ) {
+		$available[ 'target:' . (string) $kind ] = true;
+	}
+	return array_values( array_filter( $required, static fn( string $capability ): bool => ! isset( $available[ $capability ] ) ) );
+}
+
+/** @param array<string,mixed> $suite Suite input. @return string[] */
+private static function fuzz_suite_required_capabilities( array $suite ): array {
+	$metadata = is_array( $suite['metadata'] ?? null ) ? $suite['metadata'] : array();
+	$required = is_array( $metadata['requiredRunnerCapabilities'] ?? null ) ? $metadata['requiredRunnerCapabilities'] : ( is_array( $metadata['required_runner_capabilities'] ?? null ) ? $metadata['required_runner_capabilities'] : array() );
+	$capabilities = array_map( 'strval', is_array( $required['capabilities'] ?? null ) ? $required['capabilities'] : array() );
+	foreach ( is_array( $required['targetKinds'] ?? null ) ? $required['targetKinds'] : ( is_array( $required['target_kinds'] ?? null ) ? $required['target_kinds'] : array() ) as $kind ) {
+		$capabilities[] = 'target:' . (string) $kind;
+	}
+	foreach ( is_array( $required['runtimeActionTypes'] ?? null ) ? $required['runtimeActionTypes'] : ( is_array( $required['runtime_action_types'] ?? null ) ? $required['runtime_action_types'] : array() ) as $type ) {
+		$capabilities[] = 'runtime-action:' . (string) $type;
+	}
+	return array_values( array_unique( array_filter( $capabilities, static fn( string $capability ): bool => '' !== $capability ) ) );
 }
 
 /** @param array<string,mixed> $case Fuzz case. @param array<string,mixed> $suite Suite input. @return array<string,mixed> */

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -427,6 +427,24 @@ assert( 'wp-codebox/json-workload-result/v1' === $workload_report['schema'] );
 assert( 2 === $workload_report['steps'][1]['observation']['queryCount'] );
 assert( 2 === $workload_report['steps'][1]['requests'][0]['queryCount'] );
 assert( 'SELECT * FROM wp_posts WHERE post_type = "post"' === $workload_report['steps'][1]['requests'][0]['sampledQueries'][0]['sql'] );
+assert( 'php-in-process' === $result['metadata']['runnerCapabilities']['mode'] );
+assert( in_array( 'target:rest', $result['metadata']['runnerCapabilities']['capabilities'], true ) );
+
+$required_runtime = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
+	array(
+		'schema'          => 'wp-codebox/fuzz-suite/v1',
+		'id'              => 'required-runtime-suite',
+		'requireCoverage' => true,
+		'target'          => array( 'kind' => 'runtime', 'entrypoint' => 'wordpress.admin-page-load' ),
+		'metadata'        => array( 'requiredRunnerCapabilities' => array( 'capabilities' => array( 'target:runtime', 'runtime' ), 'targetKinds' => array( 'runtime' ) ) ),
+		'cases'           => array( array( 'id' => 'admin-page', 'input' => array( 'args' => array( 'path=plugins.php' ) ) ) ),
+	)
+);
+assert( is_array( $required_runtime ) );
+assert( false === $required_runtime['success'] );
+assert( 'error' === $required_runtime['status'] );
+assert( 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported' === $required_runtime['diagnostics'][0]['code'] );
+assert( 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported' === $required_runtime['cases'][0]['skipReason'] );
 
 $GLOBALS['menu'] = null;
 $GLOBALS['submenu'] = null;

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 
-import { fuzzSuiteContract, planFuzzSuiteCaseExecutionSpec, runFuzzSuite, runWordPressRestMatrix, wordpressRestMatrixContract, wordpressRestMatrixToFuzzSuite, type ExecutionResult, type ExecutionSpec } from "../packages/runtime-core/src/index.js"
+import { PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteContract, planFuzzSuiteCaseExecutionSpec, runFuzzSuite, runWordPressRestMatrix, wordpressRestMatrixContract, wordpressRestMatrixToFuzzSuite, type ExecutionResult, type ExecutionSpec } from "../packages/runtime-core/src/index.js"
 
 const executed: ExecutionSpec[] = []
 const result = await runFuzzSuite(fuzzSuiteContract({
@@ -18,6 +18,7 @@ const result = await runFuzzSuite(fuzzSuiteContract({
     { id: "case-runtime-action-admin", target: { kind: "runtime-action" }, input: { type: "admin_page", path: "plugins.php", capture_diagnostics: ["php-notices"] } },
     { id: "case-runtime-action-page", target: { kind: "runtime-action" }, input: { type: "page", path: "/sample-page/", query: { preview: true } } },
     { id: "case-runtime-action-editor", target: { kind: "runtime-action" }, input: { type: "editor_open", target: "post-new", post_type: "page", capture: ["editor-state"] } },
+    { id: "case-runtime-action-crud", target: { kind: "runtime-action" }, input: { type: "crud_operation", operation: "read", resource: { kind: "post", type: "page", id: 42 } } },
     { id: "case-runtime-action-unsupported", target: { kind: "runtime-action" }, input: { type: "filesystem", operation: "list" } },
   ],
 }), {
@@ -42,16 +43,16 @@ assert.equal(result.schema, "wp-codebox/fuzz-suite-result/v1")
 assert.equal(result.suite.id, "suite-001")
 assert.equal(result.status, "failed")
 assert.equal(result.success, false)
-assert.deepEqual(result.summary, { total: 11, passed: 9, failed: 1, error: 0, skipped: 1 })
+assert.deepEqual(result.summary, { total: 12, passed: 10, failed: 1, error: 0, skipped: 1 })
 assert.deepEqual(result.coverageSummary, {
-  discovered: 11,
-  generated: 11,
-  executed: 10,
+  discovered: 12,
+  generated: 12,
+  executed: 11,
   skipped: 1,
   untested: 0,
   skippedReasons: [{ reason: "fuzz_suite_target_adapter_unsupported", count: 1, caseIds: ["case-runtime-action-unsupported"] }],
 })
-assert.deepEqual(executed.map((spec) => spec.command), ["inspect-mounted-inputs", "wordpress.run-php", "wordpress.http-request", "wordpress.rest-request", "wordpress.ability", "wordpress.rest-request", "wordpress.browser-actions", "wordpress.admin-page-load", "wordpress.frontend-page-load", "wordpress.editor-open"])
+assert.deepEqual(executed.map((spec) => spec.command), ["inspect-mounted-inputs", "wordpress.run-php", "wordpress.http-request", "wordpress.rest-request", "wordpress.ability", "wordpress.rest-request", "wordpress.browser-actions", "wordpress.admin-page-load", "wordpress.frontend-page-load", "wordpress.editor-open", "wordpress.crud-operation"])
 assert.deepEqual(executed[0], { command: "inspect-mounted-inputs", args: ["--json"], cwd: "/workspace", timeoutMs: 1000 })
 assert.deepEqual(executed[2], { command: "wordpress.http-request", args: ["url=/", "method=GET", "expect-status=200"], method: "GET", path: "/" })
 assert.deepEqual(executed[3], { command: "wordpress.rest-request", args: ["path=/wp/v2/types", "method=GET", "params-json={\"context\":\"view\"}"], method: "GET", path: "/wp/v2/types" })
@@ -61,14 +62,15 @@ assert.deepEqual(executed[6], { command: "wordpress.browser-actions", args: ['st
 assert.deepEqual(executed[7], { command: "wordpress.admin-page-load", args: ["path=plugins.php", "capture-diagnostics=php-notices"] })
 assert.deepEqual(executed[8], { command: "wordpress.frontend-page-load", args: ["path=/sample-page/", "query-json={\"preview\":true}"] })
 assert.deepEqual(executed[9], { command: "wordpress.editor-open", args: ["target=post-new", "post-type=page", "capture=editor-state"] })
+assert.equal(JSON.parse(executed[10]?.args?.[0]?.replace("operation-json=", "") ?? "{}").schema, "wp-codebox/wordpress-crud-operation/v1")
 assert.equal(result.cases[0]?.status, "passed")
 assert.equal(result.cases[0]?.artifactRefs?.[0]?.path, "/artifacts/exec-1.json")
 assert.equal(result.cases[1]?.status, "failed")
 assert.equal(result.cases[1]?.diagnostics[0]?.code, "fuzz_suite_command_failed")
-assert.equal(result.cases[10]?.status, "skipped")
-assert.equal(result.cases[10]?.skipReason, "fuzz_suite_target_adapter_unsupported")
-assert.equal(result.cases[10]?.diagnostics[0]?.code, "fuzz_suite_target_adapter_unsupported")
-assert.equal(result.artifactRefs.length, 10)
+assert.equal(result.cases[11]?.status, "skipped")
+assert.equal(result.cases[11]?.skipReason, "fuzz_suite_target_adapter_unsupported")
+assert.equal(result.cases[11]?.diagnostics[0]?.code, "fuzz_suite_target_adapter_unsupported")
+assert.equal(result.artifactRefs.length, 11)
 assert.equal((result.cases[0]?.metadata?.replay as Record<string, unknown> | undefined)?.caseId, "case-pass")
 
 const plannedEditor = planFuzzSuiteCaseExecutionSpec({
@@ -88,6 +90,28 @@ const noExecutor = await runFuzzSuite(fuzzSuiteContract({
 assert.equal(noExecutor.status, "skipped")
 assert.deepEqual(noExecutor.coverageSummary?.skippedReasons, [{ reason: "fuzz_suite_executor_unavailable", count: 1, caseIds: ["case-skipped"] }])
 assert.equal(noExecutor.cases[0]?.diagnostics[0]?.code, "fuzz_suite_executor_unavailable")
+
+const requiredRuntimeOnPhpRunner = await runFuzzSuite(fuzzSuiteContract({
+  id: "suite-runtime-required-on-php-runner",
+  target: { kind: "runtime", entrypoint: "wordpress.admin-page-load" },
+  cases: [{ id: "admin-page", input: { args: ["path=plugins.php"] } }],
+  metadata: { requiredRunnerCapabilities: { capabilities: ["target:runtime", "runtime"], targetKinds: ["runtime"], commands: ["wordpress.admin-page-load"] } },
+}), {
+  requireCoverage: true,
+  runnerCapabilities: PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES,
+})
+assert.equal(requiredRuntimeOnPhpRunner.status, "error")
+assert.equal(requiredRuntimeOnPhpRunner.success, false)
+assert.equal(requiredRuntimeOnPhpRunner.diagnostics[0]?.code, "fuzz_suite_required_runner_capabilities_unsupported")
+assert.equal(requiredRuntimeOnPhpRunner.cases[0]?.skipReason, "fuzz_suite_required_runner_capabilities_unsupported")
+
+const skippedCoverageRequired = await runFuzzSuite(fuzzSuiteContract({
+  id: "suite-required-coverage-skipped",
+  target: { kind: "command", id: "inspect-mounted-inputs" },
+  cases: [{ id: "case-skipped" }],
+}), { requireCoverage: true })
+assert.equal(skippedCoverageRequired.status, "error")
+assert.equal(skippedCoverageRequired.diagnostics.some((diagnostic) => diagnostic.code === "fuzz_suite_required_coverage_unsupported"), true)
 
 const emptyRequiredArtifacts = await runFuzzSuite(fuzzSuiteContract({
   id: "suite-empty-required-artifacts",

--- a/tests/wordpress-block-fuzz-suite.test.ts
+++ b/tests/wordpress-block-fuzz-suite.test.ts
@@ -25,6 +25,12 @@ assert.deepEqual(suite.cases.map((fuzzCase) => fuzzCase.id), [
 ])
 assert.equal(suite.metadata?.sourceSchema, "wp-codebox/wordpress-block-editor-target-discovery/v1")
 assert.equal(suite.metadata?.editorPostType, "page")
+assert.deepEqual(suite.metadata?.requiredRunnerCapabilities, {
+  capabilities: ["target:runtime", "runtime", "runtime-action:editor_open"],
+  targetKinds: ["runtime"],
+  runtimeActionTypes: ["editor_open"],
+  commands: ["wordpress.run-php", "wordpress.editor-open"],
+})
 
 const renderCase = suite.cases[0]
 assert.deepEqual(renderCase?.target, { kind: "runtime", entrypoint: "wordpress.run-php" })
@@ -47,6 +53,11 @@ assert.deepEqual(renderOnly.cases.map((fuzzCase) => fuzzCase.id), [
   "block-core-paragraph-server-render-empty-attributes",
   "block-core-template-part-server-render-empty-attributes",
 ])
+assert.deepEqual(renderOnly.metadata?.requiredRunnerCapabilities, {
+  capabilities: ["target:runtime", "runtime"],
+  targetKinds: ["runtime"],
+  commands: ["wordpress.run-php"],
+})
 
 const noEditorTargets = wordpressBlockDiscoveryToFuzzSuite({ ...discovery, editorPostTypes: [] })
 assert.deepEqual(noEditorTargets.cases.map((fuzzCase) => fuzzCase.id), [

--- a/tests/wordpress-fuzz-suite-builders.test.ts
+++ b/tests/wordpress-fuzz-suite-builders.test.ts
@@ -30,6 +30,7 @@ const restInventory: WordPressRestRouteInventory = {
 const restSuite = restRouteInventoryToFuzzSuite(restInventory, { session: "admin" })
 assert.equal(restSuite.schema, "wp-codebox/fuzz-suite/v1")
 assert.equal(restSuite.metadata?.sourceSchema, WORDPRESS_REST_ROUTE_INVENTORY_SCHEMA)
+assert.deepEqual(restSuite.metadata?.requiredRunnerCapabilities, { capabilities: ["target:rest"], targetKinds: ["rest"] })
 assert.equal(restSuite.cases.length, 3)
 assert.equal(restSuite.cases[0]?.target?.kind, "rest")
 assert.deepEqual(restSuite.cases[0]?.input, { method: "GET", path: "/wp/v2/posts", session: "admin" })
@@ -61,6 +62,7 @@ const adminInventory: WordPressAdminPageInventory = {
 
 const adminSuite = adminPageInventoryToFuzzSuite(adminInventory, { user: "admin" })
 assert.equal(adminSuite.target?.entrypoint, "wordpress.admin-page-load")
+assert.deepEqual(adminSuite.metadata?.requiredRunnerCapabilities, { capabilities: ["target:runtime", "runtime"], targetKinds: ["runtime"], commands: ["wordpress.admin-page-load"] })
 assert.deepEqual(adminSuite.cases[0]?.input, { args: ["path=tools.php", "user=admin"] })
 assert.deepEqual(adminSuite.cases[1]?.input, { args: ["path=admin.php?page=demo-settings", "user=admin"] })
 
@@ -82,6 +84,7 @@ const frontendInventory: WordPressFrontendUrlInventory = {
 
 const frontendSuite = frontendUrlInventoryToFuzzSuite(frontendInventory)
 assert.equal(frontendSuite.target?.entrypoint, "wordpress.frontend-page-load")
+assert.deepEqual(frontendSuite.metadata?.requiredRunnerCapabilities, { capabilities: ["target:runtime", "runtime"], targetKinds: ["runtime"], commands: ["wordpress.frontend-page-load"] })
 assert.deepEqual(frontendSuite.cases[0]?.input, { args: ["path=/hello-world/?preview=true"] })
 assert.equal((frontendSuite.cases[0]?.metadata?.safety as Record<string, unknown>).executable, true)
 

--- a/tests/wordpress-runtime-actions.test.ts
+++ b/tests/wordpress-runtime-actions.test.ts
@@ -165,17 +165,19 @@ const runtimeActionFuzzResult = await runFuzzSuite(fuzzSuiteContract({
     { id: "editor", input: { type: "editor_open", target: "post-new", post_type: "page" } },
     { id: "admin", input: { type: "admin_page", path: "plugins.php" } },
     { id: "page", input: { type: "page", path: "/sample-page/" } },
+    { id: "crud", input: { type: "crud_operation", operation: "read", resource: { kind: "post", type: "page", id: 42 } } },
   ],
 }), {
   runtimeActionExecutor: createWordPressFuzzSuiteRuntimeActionExecutor(fakeEpisode),
 })
 assert.equal(runtimeActionFuzzResult.status, "passed")
-assert.deepEqual(runtimeActionFuzzResult.summary, { total: 4, passed: 4, failed: 0, error: 0, skipped: 0 })
+assert.deepEqual(runtimeActionFuzzResult.summary, { total: 5, passed: 5, failed: 0, error: 0, skipped: 0 })
 assert.deepEqual(calls.slice(beforeFuzzCalls).map((call) => call.command), [
   "wordpress.browser-actions",
   "wordpress.editor-open",
   "wordpress.browser-probe",
   "wordpress.browser-probe",
+  "wordpress.crud-operation",
 ])
 
 console.log("wordpress runtime actions ok")


### PR DESCRIPTION
## Summary
- Add public fuzz runner capability profiles for PHP in-process and runtime-backed execution.
- Have public fuzz-suite builders emit required runner capability metadata.
- Fail closed when `requireCoverage` is requested but required runner capabilities are unavailable.
- Add runtime-backed `crud_operation` fuzz action support mapped to `wordpress.crud-operation`.

## Testing
- `npm run build`
- `npm run test:fuzz-suite-runner`
- `npm run test:wordpress-fuzz-suite-builders`
- `npm run test:wordpress-block-fuzz-suite`
- `npm run test:wordpress-runtime-actions`
- `npm run test:php-fuzz-suite-runner`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, rebase conflict resolution, test updates, and PR description drafting.
