### PR TITLE
Clear REST route context during fuzz route refresh

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1058,8 +1058,29 @@ private static function ensure_fuzz_suite_rest_routes_registered(): void {
 private static function refresh_fuzz_suite_rest_server(): void {
 	if ( function_exists( 'rest_get_server' ) ) {
 		global $wp_rest_server;
+		$wp_rest_route_was_set  = isset( $GLOBALS['wp'] )
+			&& is_object( $GLOBALS['wp'] )
+			&& isset( $GLOBALS['wp']->query_vars )
+			&& is_array( $GLOBALS['wp']->query_vars )
+			&& array_key_exists( 'rest_route', $GLOBALS['wp']->query_vars );
+		$wp_rest_route          = $wp_rest_route_was_set ? $GLOBALS['wp']->query_vars['rest_route'] : null;
+		$get_rest_route_was_set = array_key_exists( 'rest_route', $_GET );
+		$get_rest_route         = $get_rest_route_was_set ? $_GET['rest_route'] : null;
+		if ( $wp_rest_route_was_set ) {
+			unset( $GLOBALS['wp']->query_vars['rest_route'] );
+		}
+		unset( $_GET['rest_route'] );
 		$wp_rest_server = null;
-		rest_get_server();
+		try {
+			rest_get_server();
+		} finally {
+			if ( $wp_rest_route_was_set ) {
+				$GLOBALS['wp']->query_vars['rest_route'] = $wp_rest_route;
+			}
+			if ( $get_rest_route_was_set ) {
+				$_GET['rest_route'] = $get_rest_route;
+			}
+		}
 	}
 }
 

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -110,6 +110,10 @@ class WP_Codebox_Test_REST_Server {
 }
 
 function rest_get_server(): WP_Codebox_Test_REST_Server {
+	$GLOBALS['wp_codebox_rest_server_route_contexts'][] = array(
+		'wp_rest_route'  => $GLOBALS['wp']->query_vars['rest_route'] ?? null,
+		'get_rest_route' => $_GET['rest_route'] ?? null,
+	);
 	return new WP_Codebox_Test_REST_Server();
 }
 
@@ -174,6 +178,9 @@ class WP_Codebox_Test_WPDB {
 }
 
 $GLOBALS['wpdb'] = new WP_Codebox_Test_WPDB();
+$GLOBALS['wp'] = (object) array( 'query_vars' => array( 'rest_route' => '/wc/store/v1/products' ) );
+$_GET['rest_route'] = '/wc/store/v1/products';
+$GLOBALS['wp_codebox_rest_server_route_contexts'] = array();
 
 require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php';
 
@@ -368,6 +375,10 @@ assert( is_array( $result ) );
 assert( 'wp-codebox/fuzz-suite-result/v1' === $result['schema'] );
 assert( true === $result['success'] );
 assert( 'passed' === $result['status'] );
+assert( '/wc/store/v1/products' === $GLOBALS['wp']->query_vars['rest_route'] );
+assert( '/wc/store/v1/products' === $_GET['rest_route'] );
+assert( null === $GLOBALS['wp_codebox_rest_server_route_contexts'][0]['wp_rest_route'] );
+assert( null === $GLOBALS['wp_codebox_rest_server_route_contexts'][0]['get_rest_route'] );
 assert( 21 === $result['summary']['total'] );
 assert( 10 === $result['summary']['passed'] );
 assert( 11 === $result['summary']['skipped'] );


### PR DESCRIPTION
## Summary
- Clear active REST route context while fuzz workloads rebuild the REST server.
- Restore the original request context after rebuild so subsequent handling is unchanged.
- Cover the Woo-style namespace gating case in the PHP fuzz suite smoke.

## Testing
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- php -l scripts/php-fuzz-suite-runner-smoke.php
- npm run test:php-fuzz-suite-runner

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Woo REST route registration issue, implementing the focused WP Codebox fix, and updating focused smoke coverage.