### PR TITLE
Honor runtime requirement extra plugins in task recipes

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -55,6 +55,8 @@ export interface AgentTaskRunInput {
   artifacts_path?: string
   wp?: string
   component_contracts?: Array<Record<string, unknown>>
+  runtime_requirements?: Record<string, unknown>
+  runtimeRequirements?: Record<string, unknown>
   verify_steps?: WorkspaceRecipe["workflow"]["after"]
   parent_request?: Record<string, unknown>
   orchestrator?: Record<string, unknown>
@@ -408,9 +410,12 @@ function runtimeMountList(value: unknown): WorkspaceRecipeMount[] {
 }
 
 function agentTaskExtraPlugins(input: AgentTaskRunInput): WorkspaceRecipeExtraPlugin[] {
+  const runtimeRequirements = objectValue(input.runtime_requirements) || objectValue(input.runtimeRequirements)
   return [
     ...normalizeAgentTaskExtraPlugins(input.extra_plugins),
     ...normalizeAgentTaskExtraPlugins(input.extraPlugins),
+    ...normalizeAgentTaskExtraPlugins(runtimeRequirements?.extra_plugins),
+    ...normalizeAgentTaskExtraPlugins(runtimeRequirements?.extraPlugins),
   ]
 }
 

--- a/scripts/component-contracts-agent-task-smoke.ts
+++ b/scripts/component-contracts-agent-task-smoke.ts
@@ -11,6 +11,7 @@ const root = mkdtempSync(join(tmpdir(), "wp-codebox-component-contracts-smoke-")
 try {
   const domainPlugin = writePlugin(root, "domain-component", "Domain Component")
   const runtimePlugin = writePlugin(root, "runtime-component", "Runtime Component")
+  const requirementsPlugin = writePlugin(root, "requirements-component", "Requirements Component")
   const artifacts = join(root, "artifacts")
   mkdirSync(artifacts, { recursive: true })
 
@@ -21,6 +22,11 @@ try {
       { slug: "domain-component", path: domainPlugin, loadAs: "plugin", activate: true },
       { slug: "runtime-component", path: runtimePlugin, loadAs: "mu-plugin", activate: false },
     ],
+    runtime_requirements: {
+      extra_plugins: [
+        { slug: "requirements-component", source: requirementsPlugin, pluginFile: "requirements-component/requirements-component.php", loadAs: "plugin", activate: true },
+      ],
+    },
   }, normalizeTaskInput({ goal: "verify component contract staging" }), "latest")
 
   const plugins = recipe.inputs?.extra_plugins ?? []
@@ -29,12 +35,17 @@ try {
 
   const domain = componentPlugins.find((plugin) => plugin.slug === "domain-component")
   const runtime = componentPlugins.find((plugin) => plugin.slug === "runtime-component")
+  const requirements = plugins.find((plugin) => plugin.slug === "requirements-component")
   assert.ok(domain, "explicit domain component should be staged")
   assert.ok(runtime, "runtime component should coexist with explicit domain component")
+  assert.ok(requirements, "runtime_requirements.extra_plugins should become recipe extra plugins")
   assert.equal(domain?.loadAs, "plugin")
   assert.equal(domain?.activate, true)
   assert.equal(runtime?.loadAs, "mu-plugin")
   assert.equal(runtime?.activate, false)
+  assert.equal(requirements?.loadAs, "plugin")
+  assert.equal(requirements?.activate, true)
+  assert.equal(requirements?.pluginFile, "requirements-component/requirements-component.php")
   assert.match(String(domain?.source), /prepared-plugins\/domain-component$/)
   assert.match(String(runtime?.source), /prepared-plugins\/runtime-component$/)
   assert.equal(domain?.metadata?.componentContract?.requestedPath, domainPlugin)


### PR DESCRIPTION
## Summary
- Include nested runtime_requirements.extra_plugins when building agent task recipes.
- Preserve the standardized runtime requirements contract as the source for sandbox plugin activation.
- Cover runtime requirement extra plugins in the component-contract smoke.

## Testing
- npm run build
- npm run test:php-fuzz-suite-runner
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing missing WooCommerce runtime activation, implementing the WP Codebox recipe-builder fix, and updating focused smoke coverage.