### PR TITLE
Preserve activation when deduping extra plugins

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -420,12 +420,25 @@ function agentTaskExtraPlugins(input: AgentTaskRunInput): WorkspaceRecipeExtraPl
 }
 
 function dedupeExtraPlugins(plugins: WorkspaceRecipeExtraPlugin[]): WorkspaceRecipeExtraPlugin[] {
-  const seen = new Set<string>()
+  const seen = new Map<string, number>()
   const deduped: WorkspaceRecipeExtraPlugin[] = []
   for (const plugin of plugins) {
     const key = `${stringValue(plugin.slug) || slugFromPath(stringValue(plugin.source))}:${plugin.loadAs === "plugin" ? "plugin" : "mu-plugin"}`
-    if (seen.has(key)) continue
-    seen.add(key)
+    const existingIndex = seen.get(key)
+    if (existingIndex !== undefined) {
+      const existing = deduped[existingIndex]
+      deduped[existingIndex] = stripUndefined({
+        ...plugin,
+        ...existing,
+        activate: existing.activate === true || plugin.activate === true ? true : existing.activate ?? plugin.activate,
+        metadata: stripUndefined({
+          ...(isPlainObject(plugin.metadata) ? plugin.metadata : {}),
+          ...(isPlainObject(existing.metadata) ? existing.metadata : {}),
+        }),
+      }) as WorkspaceRecipeExtraPlugin
+      continue
+    }
+    seen.set(key, deduped.length)
     deduped.push(plugin)
   }
   return deduped

--- a/scripts/component-contracts-agent-task-smoke.ts
+++ b/scripts/component-contracts-agent-task-smoke.ts
@@ -11,6 +11,7 @@ const root = mkdtempSync(join(tmpdir(), "wp-codebox-component-contracts-smoke-")
 try {
   const domainPlugin = writePlugin(root, "domain-component", "Domain Component")
   const runtimePlugin = writePlugin(root, "runtime-component", "Runtime Component")
+  const dedupePlugin = writePlugin(root, "dedupe-component", "Dedupe Component")
   const requirementsPlugin = writePlugin(root, "requirements-component", "Requirements Component")
   const artifacts = join(root, "artifacts")
   mkdirSync(artifacts, { recursive: true })
@@ -21,28 +22,34 @@ try {
     component_contracts: [
       { slug: "domain-component", path: domainPlugin, loadAs: "plugin", activate: true },
       { slug: "runtime-component", path: runtimePlugin, loadAs: "mu-plugin", activate: false },
+      { slug: "dedupe-component", path: dedupePlugin, loadAs: "plugin" },
     ],
     runtime_requirements: {
       extra_plugins: [
         { slug: "requirements-component", source: requirementsPlugin, pluginFile: "requirements-component/requirements-component.php", loadAs: "plugin", activate: true },
+        { slug: "dedupe-component", source: dedupePlugin, pluginFile: "dedupe-component/dedupe-component.php", loadAs: "plugin", activate: true },
       ],
     },
   }, normalizeTaskInput({ goal: "verify component contract staging" }), "latest")
 
   const plugins = recipe.inputs?.extra_plugins ?? []
   const componentPlugins = plugins.filter((plugin) => plugin.metadata?.componentContract)
-  assert.equal(componentPlugins.length, 2, "component_contracts should become canonical staged plugin inputs")
+  assert.equal(componentPlugins.length, 3, "component_contracts should become canonical staged plugin inputs")
 
   const domain = componentPlugins.find((plugin) => plugin.slug === "domain-component")
   const runtime = componentPlugins.find((plugin) => plugin.slug === "runtime-component")
+  const dedupe = componentPlugins.find((plugin) => plugin.slug === "dedupe-component")
   const requirements = plugins.find((plugin) => plugin.slug === "requirements-component")
   assert.ok(domain, "explicit domain component should be staged")
   assert.ok(runtime, "runtime component should coexist with explicit domain component")
+  assert.ok(dedupe, "component contract duplicate should remain staged")
   assert.ok(requirements, "runtime_requirements.extra_plugins should become recipe extra plugins")
   assert.equal(domain?.loadAs, "plugin")
   assert.equal(domain?.activate, true)
   assert.equal(runtime?.loadAs, "mu-plugin")
   assert.equal(runtime?.activate, false)
+  assert.equal(dedupe?.loadAs, "plugin")
+  assert.equal(dedupe?.activate, true)
   assert.equal(requirements?.loadAs, "plugin")
   assert.equal(requirements?.activate, true)
   assert.equal(requirements?.pluginFile, "requirements-component/requirements-component.php")


### PR DESCRIPTION
## Summary
- Merge duplicate recipe extra-plugin entries instead of dropping later entries outright.
- Preserve activate: true when any duplicate source requests activation.
- Cover the component-contract plus runtime_requirements.extra_plugins duplicate case.

## Testing
- npm run build
- npm run test:php-fuzz-suite-runner
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing WooCommerce plugin activation loss in WP Codebox recipe construction, implementing the dedupe fix, and updating focused smoke coverage.