### PR TITLE
Normalize runtime package task outcomes

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -161,7 +161,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     const recipeSuccess = Boolean(run.success) && (!hasAgentBundle || workload.success)
     const agentTaskResult = objectValue(run.agentTaskResult) || objectValue(runRecord.agentTaskResult) || objectValue(artifactsRecord.agentTaskResult) || {}
     const terminalResult = terminalResultFromRun(run, agentTaskResult)
-    const completionOutcome = objectValue(run.completionOutcome) || objectValue(artifactsRecord.completionOutcome) || {}
+    const completionOutcome = objectValue(run.completionOutcome) || objectValue(run.completion_outcome) || objectValue(artifactsRecord.completionOutcome) || objectValue(artifactsRecord.completion_outcome) || {}
     const agentResult = objectValue(run.agentResult) || objectValue(runRecord.agentResult) || objectValue(artifactsRecord.agentResult) || {}
     const normalizedRunResult = normalizeAgentTaskRunResult({
       ...run,

--- a/packages/runtime-core/src/agent-task-run-result.ts
+++ b/packages/runtime-core/src/agent-task-run-result.ts
@@ -98,11 +98,16 @@ export function normalizeAgentTaskRunResult(raw: unknown, options: AgentTaskRunR
   const completionOutcome = completionOutcomeRecord(result, compatMode, compatibilityDiagnostics)
   const runMetadata = objectValue(result.run_metadata)
   const patch = objectValue(agentResult.patch)
-  const terminalResult = terminalResultRecord(result, agentResult, compatMode, compatibilityDiagnostics)
+  const terminalResult = terminalResultForCompletion(
+    terminalResultRecord(result, agentResult, compatMode, compatibilityDiagnostics),
+    completionOutcome,
+  )
   const status = normalizeStatus(result, agentResult, exitStatus, terminalResult)
   const artifacts = normalizeArtifacts(result, agentResult, completionOutcome, compatMode, compatibilityDiagnostics)
   const noOp = noOpMetadata(result, agentResult)
-  const failureClassification = stringValue(result.failure_classification) || terminalResult?.failure_classification || failureClassificationForStatus(status)
+  const failureClassification = status === "succeeded" || status === "no_op"
+    ? ""
+    : stringValue(result.failure_classification) || terminalResult?.failure_classification || failureClassificationForStatus(status)
 
   return stripUndefined({
     schema: AGENT_TASK_RUN_RESULT_SCHEMA,
@@ -174,14 +179,16 @@ function agentTaskRuntimeAccess(result: Record<string, unknown>): RuntimeAccess 
 }
 
 function normalizeStatus(result: Record<string, unknown>, agentResult: Record<string, unknown>, exitStatus: number, terminalResult?: AgentTerminalResult): AgentTaskRunStatus {
+  const noOp = noOpMetadata(result, agentResult)
   if (terminalResult) {
     if (terminalResult.status === "max_turns") return "timeout"
+    if (terminalResult.status === "incomplete" && noOp.detected) return "no_op"
     if (terminalResult.status === "incomplete") return "failed"
     const terminalStatus = normalizeAgentTaskStatus({ status: terminalResult.status, success: terminalResult.success })
     if (terminalStatus === "succeeded" || terminalStatus === "failed" || terminalStatus === "no_op" || terminalStatus === "timeout" || terminalStatus === "provider_error" || terminalStatus === "unable_to_remediate") return terminalStatus
   }
 
-  if (noOpMetadata(result, agentResult).detected) return "no_op"
+  if (noOp.detected) return "no_op"
   return normalizeAgentTaskStatus({
     status: result.status,
     success: result.success,
@@ -273,11 +280,17 @@ function artifactFromAgentResult(id: string, kind: string, root: string, metadat
 }
 
 function noOpMetadata(result: Record<string, unknown>, agentResult: Record<string, unknown>): AgentTaskRunResultSummary["no_op"] {
+  const explicitNoOp = objectValue(result.no_op)
   const changedFilesCount = numberValue(objectValue(agentResult.changedFiles).count)
+    ?? numberValue(explicitNoOp.changed_files_count)
+    ?? numberValue(explicitNoOp.changedFilesCount)
   const patchBytes = numberValue(objectValue(agentResult.patch).bytes)
-  const reason = stringValue(agentResult.noOpReason) || stringValue(result.no_op_reason)
+    ?? numberValue(explicitNoOp.patch_bytes)
+    ?? numberValue(explicitNoOp.patchBytes)
+  const reason = stringValue(agentResult.noOpReason) || stringValue(result.no_op_reason) || stringValue(explicitNoOp.reason)
   const detected = result.outcome === "no_op"
     || result.no_op === true
+    || explicitNoOp.detected === true
     || (result.success === true && Boolean(reason) && changedFilesCount === 0 && patchBytes === 0)
 
   return stripUndefined({ detected, reason, changed_files_count: changedFilesCount, patch_bytes: patchBytes })
@@ -328,6 +341,21 @@ function terminalResultRecord(result: Record<string, unknown>, agentResult: Reco
     }
   }
   return undefined
+}
+
+function terminalResultForCompletion(terminalResult: AgentTerminalResult | undefined, completionOutcome: Record<string, unknown>): AgentTerminalResult | undefined {
+  if (stringValue(completionOutcome.status) !== "succeeded") return terminalResult
+  if (terminalResult?.success === true && terminalResult.status === "succeeded") return terminalResult
+  if (terminalResult && terminalResult.status !== "incomplete" && terminalResult.status !== "unknown") return terminalResult
+
+  return {
+    schema: "wp-codebox/agent-terminal-result/v1",
+    terminal: true,
+    status: "succeeded",
+    success: true,
+    source: terminalResult?.source ?? "canonical",
+    evidence_refs: terminalResult?.evidence_refs ?? [],
+  }
 }
 
 function failureClassificationForStatus(status: AgentTaskRunStatus): AgentTaskRunFailureClassification | "" {

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -165,6 +165,7 @@ final class WP_Codebox_Agents_API_Adapter {
 				'label'        => 'Agents API runtime adapter',
 				'kind'         => 'ability-adapter',
 				'capabilities' => array( 'runtime-package' ),
+				'default'      => true,
 			)
 		);
 	}
@@ -423,6 +424,11 @@ final class WP_Codebox_Agents_API_Adapter {
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 	public function run_runtime_package( array $input ): array|WP_Error {
+		if ( ! isset( $input['package'] ) && isset( $input['runtime_package'] ) ) {
+			$metadata         = is_array( $input['metadata'] ?? null ) ? $input['metadata'] : array();
+			$descriptor       = is_array( $metadata['runtime_package_descriptor'] ?? null ) ? $metadata['runtime_package_descriptor'] : array();
+			$input['package'] = ! empty( $descriptor ) ? $descriptor : array( 'slug' => (string) $input['runtime_package'] );
+		}
 		return $this->execute( self::RUN_RUNTIME_PACKAGE, $input );
 	}
 

--- a/scripts/agent-terminal-result-contract-smoke.ts
+++ b/scripts/agent-terminal-result-contract-smoke.ts
@@ -107,4 +107,58 @@ assert.equal(runResult.terminal_result?.status, "succeeded")
 assert.equal(runResult.status, "succeeded")
 assert.equal(runResult.success, true)
 
+const completionSucceededRunResult = normalizeAgentTaskRunResult({
+  schema: "wp-codebox/agent-task-run/v1",
+  success: false,
+  status: "failed",
+  terminal_result: {
+    schema: "wp-codebox/agent-terminal-result/v1",
+    terminal: true,
+    status: "incomplete",
+    success: false,
+    evidence_refs: [],
+  },
+  completion_outcome: {
+    schema: "wp-codebox/sandbox-completion-outcome/v1",
+    status: "succeeded",
+    summary: "Agent sandbox produced artifacts.",
+  },
+}, { compatMode: true })
+assert.equal(completionSucceededRunResult.terminal_result?.status, "succeeded")
+assert.equal(completionSucceededRunResult.status, "succeeded")
+assert.equal(completionSucceededRunResult.success, true)
+
+const partialNoOpRunResult = normalizeAgentTaskRunResult({
+  schema: "wp-codebox/agent-task-run/v1",
+  success: false,
+  status: "failed",
+  terminal_result: {
+    schema: "wp-codebox/agent-terminal-result/v1",
+    terminal: true,
+    status: "incomplete",
+    success: false,
+    failure_classification: "incomplete",
+    evidence_refs: [],
+  },
+  agentResult: {
+    summary: "Agent sandbox completed successfully without actionable file changes.",
+  },
+  no_op: {
+    detected: true,
+    reason: "no_file_changes",
+    changed_files_count: 0,
+    patch_bytes: 0,
+  },
+  completion_outcome: {
+    schema: "wp-codebox/sandbox-completion-outcome/v1",
+    status: "partial",
+    summary: "Agent sandbox completed successfully without actionable file changes.",
+    blockers: [],
+    riskNotes: ["no_file_changes"],
+  },
+}, { compatMode: true })
+assert.equal(partialNoOpRunResult.status, "no_op")
+assert.equal(partialNoOpRunResult.success, true)
+assert.equal(partialNoOpRunResult.failure_classification, undefined)
+
 console.log("agent terminal result contract smoke passed")

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -72,10 +72,19 @@ $GLOBALS['wp_codebox_test_abilities'][ $names['get_chat_run'] ]        = new WP_
 assert( true === $adapter->is_available( WP_Codebox_Agents_API_Adapter::default_chat_ability() ) );
 $chat = $adapter->chat( array( 'message' => 'hello' ) );
 $task = $adapter->run_task( array( 'goal' => 'ship' ) );
-$package = $adapter->run_runtime_package( array( 'package' => array() ) );
+$package = $adapter->run_runtime_package( array( 'runtime_package' => 'example-agent' ) );
 assert( 'wp-codebox/agent-chat-result/v1' === $chat['schema'] );
 assert( 'wp-codebox/agent-task-result/v1' === $task['schema'] );
 assert( 'wp-codebox/runtime-package-result/v1' === $package['schema'] );
+assert( array( 'slug' => 'example-agent' ) === $package['received']['package'] );
+
+$package_with_descriptor = $adapter->run_runtime_package(
+	array(
+		'runtime_package' => 'example-agent',
+		'metadata'        => array( 'runtime_package_descriptor' => array( 'slug' => 'example-agent', 'source' => 'bundles/example-agent' ) ),
+	)
+);
+assert( array( 'slug' => 'example-agent', 'source' => 'bundles/example-agent' ) === $package_with_descriptor['received']['package'] );
 assert( 'running' === $adapter->get_task_run( array( 'run_id' => 'task-run', 'session_id' => 'session' ) )['status'] );
 assert( 'running' === $adapter->get_chat_run( array( 'run_id' => 'chat-run', 'session_id' => 'session' ) )['status'] );
 assert_no_agents_api_schema_leaks( $chat, 'chat' );
@@ -89,10 +98,11 @@ assert( 'wp_codebox_agents_api_ability_unavailable' === $missing->get_error_code
 WP_Codebox_Agents_API_Adapter::register_runtime_provider();
 $providers = WP_Codebox_Runtime_Provider_Registry::providers();
 assert( isset( $providers['agents-api-adapter'] ) );
+assert( 'agents-api-adapter' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
 
-$missing_default = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
-assert( is_wp_error( $missing_default ) );
-assert( 'wp_codebox_runtime_provider_default_missing' === $missing_default->get_error_code() );
+$default_registered_runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
+assert( ! is_wp_error( $default_registered_runtime_package ) );
+assert( 'agents-api-adapter' === $default_registered_runtime_package['runtime_provider']['id'] );
 
 $runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'runtime_provider_id' => 'agents-api-adapter', 'package' => array( 'id' => 'example' ) ) );
 assert( ! is_wp_error( $runtime_package ) );


### PR DESCRIPTION
## Summary
- Treat successful completion outcomes as terminal success when stale terminal metadata reports incomplete.
- Preserve no-op classification for successful no-change runtime package runs.
- Make the Agents API adapter the default runtime provider and translate `runtime_package` inputs into canonical package descriptors.

## Verification
- `npm run build`
- `npx tsx scripts/agent-terminal-result-contract-smoke.ts`
- `npm run test:php-agents-api-adapter-contract`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing runtime package outcome normalization, implementing focused fixes, and running contract validation.