### PR TITLE
Stage agent task recipes in artifacts

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -122,7 +122,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
   let generatedRecipeArtifact: GeneratedRecipeArtifactRef | undefined
 
   try {
-    const recipe = buildAgentTaskRecipe(input, taskInput, wpVersion)
+    const recipe = buildAgentTaskRecipe({ ...input, artifacts_path: artifacts }, taskInput, wpVersion)
     recipeJson = `${JSON.stringify(recipe, null, 2)}\n`
     await writeFile(recipePath, recipeJson)
     const recipeRunArgs = ["--recipe", recipePath, "--artifacts", artifacts, "--json"]


### PR DESCRIPTION
## Summary
- Pass the resolved agent-task artifacts directory into recipe generation.
- Allow generated agent-task recipes to stage local source packages before recipe-run executes.
- Unblocks component_contracts sourceRoot/sourceSubpath staging for WP Codebox agent-task runs.

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing why generated agent-task recipes skipped source staging, implementing the call-site fix, and verifying focused smoke coverage.