### PR TITLE
Preserve generated package autoloaders

### DIFF
--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process"
-import { existsSync, mkdirSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync } from "node:fs"
 import { homedir } from "node:os"
 import { isAbsolute, join, relative, resolve } from "node:path"
 import { safeArtifactRelativePath } from "./artifact-paths.js"
@@ -207,10 +207,26 @@ export function prepareRecipeSourcePackageSync(options: PreparedRecipeSourcePack
     } else {
       mkdirSync(preparedSource, { recursive: true })
     }
-    return installComposerDependenciesForSourcePackageSync(preparedPluginSource, options.slug, preparedRoot, options.composerInstallArgs)
+    const installedSource = installComposerDependenciesForSourcePackageSync(preparedPluginSource, options.slug, preparedRoot, options.composerInstallArgs)
+    preserveGeneratedPackageAutoloaders(join(copySource, sourceSubpath), installedSource)
+    return installedSource
   }
 
   return prepareRecipeSourcePackageWithoutArtifacts(source, source, options.slug, "")
+}
+
+function preserveGeneratedPackageAutoloaders(originalPluginSource: string, preparedPluginSource: string): void {
+  const originalVendor = join(originalPluginSource, "vendor")
+  const preparedVendor = join(preparedPluginSource, "vendor")
+  preserveGeneratedPackageAutoloaderPath(originalVendor, preparedVendor, "autoload_packages.php")
+  preserveGeneratedPackageAutoloaderPath(originalVendor, preparedVendor, "jetpack-autoloader")
+}
+
+function preserveGeneratedPackageAutoloaderPath(originalVendor: string, preparedVendor: string, relativePath: string): void {
+  const source = join(originalVendor, relativePath)
+  if (!pathExists(source)) return
+  mkdirSync(preparedVendor, { recursive: true })
+  cpSync(source, join(preparedVendor, relativePath), { recursive: true })
 }
 
 export function composerManagedHostEnv(): Record<string, string> {

--- a/scripts/component-contracts-agent-task-smoke.ts
+++ b/scripts/component-contracts-agent-task-smoke.ts
@@ -74,6 +74,8 @@ try {
   assert.equal(monorepoComponent?.metadata?.componentContract?.sourceSubpath, monorepo.sourceSubpath)
   assert.equal(existsSync(join(String(monorepoComponent?.source), "monorepo-component.php")), true)
   assert.equal(existsSync(join(String(monorepoComponent?.source), "..", "..", "packages", "php", "shared", "composer.json")), true)
+  assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "autoload_packages.php")), true)
+  assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "jetpack-autoloader", "class-autoloader.php")), true)
 
   const missingComponentSource = "https://example.com/missing-component.zip"
   const invalidRecipePath = join(root, "invalid-component-recipe.json")
@@ -138,8 +140,11 @@ function writeMonorepoPlugin(rootPath: string, slug: string, name: string): { ro
   const sourceSubpath = join("plugins", slug)
   const pluginPath = join(monorepoRoot, sourceSubpath)
   mkdirSync(pluginPath, { recursive: true })
+  mkdirSync(join(pluginPath, "vendor", "jetpack-autoloader"), { recursive: true })
   mkdirSync(join(monorepoRoot, "packages", "php", "shared"), { recursive: true })
   writeFileSync(join(monorepoRoot, "packages", "php", "shared", "composer.json"), "{}\n")
+  writeFileSync(join(pluginPath, "vendor", "autoload_packages.php"), "<?php // generated package autoloader\n")
+  writeFileSync(join(pluginPath, "vendor", "jetpack-autoloader", "class-autoloader.php"), "<?php // package autoloader runtime\n")
   writeFileSync(join(pluginPath, `${slug}.php`), `<?php
 /**
  * Plugin Name: ${name}


### PR DESCRIPTION
## Summary
- Preserve generated package-autoloader artifacts when staging local source packages.
- Carry over vendor/autoload_packages.php and the jetpack-autoloader runtime if present in the original plugin source.
- Cover monorepo component contracts that need generated package autoloaders after safe Composer hydration.

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing WooCommerce package-autoloader staging gaps, implementing preservation of generated autoload artifacts, and adding regression assertions.