### PR TITLE
Recover browser blueprint refs from contained-site input

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -596,6 +596,13 @@ final class WP_Codebox_Browser_Task_Builder {
 				}
 			}
 
+			if ( is_array( $envelope['recovery']['input'] ?? null ) ) {
+				$prepared = self::browser_prepared_runtime_from_envelope( $envelope['recovery']['input'] );
+				if ( ! empty( $prepared ) ) {
+					return $prepared;
+				}
+			}
+
 			foreach ( array( 'playground', 'runtime', 'contained_site' ) as $field ) {
 				if ( is_array( $envelope[ $field ] ?? null ) ) {
 					$prepared = self::browser_prepared_runtime_from_envelope( $envelope[ $field ] );

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -340,4 +340,31 @@ expect( false === str_contains( wp_json_encode( $evidence ), '<h1>Preview</h1>' 
 $executable_ref = WP_Codebox_Browser_Task_Builder::executable_blueprint_ref( $product_session );
 expect( $product_session['blueprint_ref'] === $executable_ref, 'Expected executable blueprint ref from product DTO.' );
 
+$compact_product_session = array(
+	'success'        => true,
+	'schema'         => 'wp-codebox/browser-session-product-dto/v1',
+	'session_id'     => 'compact-product-smoke-session',
+	'preview_boot'   => array(
+		'schema'        => 'wp-codebox/browser-preview-boot-config/v1',
+		'blueprint_ref' => 'inline-session-blueprint',
+	),
+	'contained_site' => array(
+		'schema'   => 'wp-codebox/browser-contained-site/v1',
+		'site_id'  => 'product-smoke-cache',
+		'status'   => 'ready',
+		'recovery' => array(
+			'input' => array(
+				'schema'     => 'wp-codebox/browser-prepared-runtime/v1',
+				'cache_key'  => 'product-smoke-cache',
+				'input_hash' => $source_digest,
+				'status'     => 'ready',
+			),
+		),
+	),
+);
+
+$compact_executable_ref = WP_Codebox_Browser_Task_Builder::executable_blueprint_ref( $compact_product_session );
+expect( 'prepared:product-smoke-cache:' . $source_digest === $compact_executable_ref['ref'], 'Expected executable blueprint ref from compact contained-site recovery input.' );
+expect( isset( $compact_executable_ref['hydration_endpoint'] ), 'Expected compact executable ref hydration endpoint.' );
+
 fwrite( STDOUT, "PHP browser contained site contract smoke passed\n" );


### PR DESCRIPTION
## Summary
- recover prepared runtime descriptors from contained_site.recovery.input when building executable browser blueprint refs
- cover compact product DTOs that only expose inline-session-blueprint plus contained-site recovery metadata

## Testing
- php scripts/php-browser-contained-site-contract-smoke.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
- php -l scripts/php-browser-contained-site-contract-smoke.php
- npm run test:php-browser-contained-site-contract

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Studio Native/WP Codebox blueprint-ref recovery gap, implementing the minimal PHP fix, and adding focused contract coverage.