### PR TITLE
Preserve source package vendor trees

### DIFF
--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process"
-import { cpSync, existsSync, mkdirSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs"
 import { homedir } from "node:os"
 import { isAbsolute, join, relative, resolve } from "node:path"
 import { safeArtifactRelativePath } from "./artifact-paths.js"
@@ -208,25 +208,20 @@ export function prepareRecipeSourcePackageSync(options: PreparedRecipeSourcePack
       mkdirSync(preparedSource, { recursive: true })
     }
     const installedSource = installComposerDependenciesForSourcePackageSync(preparedPluginSource, options.slug, preparedRoot, options.composerInstallArgs)
-    preserveGeneratedPackageAutoloaders(join(copySource, sourceSubpath), installedSource)
+    preserveExistingComposerVendor(join(copySource, sourceSubpath), installedSource)
     return installedSource
   }
 
   return prepareRecipeSourcePackageWithoutArtifacts(source, source, options.slug, "")
 }
 
-function preserveGeneratedPackageAutoloaders(originalPluginSource: string, preparedPluginSource: string): void {
+function preserveExistingComposerVendor(originalPluginSource: string, preparedPluginSource: string): void {
   const originalVendor = join(originalPluginSource, "vendor")
   const preparedVendor = join(preparedPluginSource, "vendor")
-  preserveGeneratedPackageAutoloaderPath(originalVendor, preparedVendor, "autoload_packages.php")
-  preserveGeneratedPackageAutoloaderPath(originalVendor, preparedVendor, "jetpack-autoloader")
-}
-
-function preserveGeneratedPackageAutoloaderPath(originalVendor: string, preparedVendor: string, relativePath: string): void {
-  const source = join(originalVendor, relativePath)
-  if (!pathExists(source)) return
-  mkdirSync(preparedVendor, { recursive: true })
-  cpSync(source, join(preparedVendor, relativePath), { recursive: true })
+  if (!pathExists(originalVendor)) return
+  rmSync(preparedVendor, { recursive: true, force: true })
+  mkdirSync(preparedPluginSource, { recursive: true })
+  cpSync(originalVendor, preparedVendor, { recursive: true })
 }
 
 export function composerManagedHostEnv(): Record<string, string> {

--- a/scripts/component-contracts-agent-task-smoke.ts
+++ b/scripts/component-contracts-agent-task-smoke.ts
@@ -64,7 +64,7 @@ try {
   assert.equal(domain?.metadata?.componentContract?.pluginFile, "domain-component/domain-component.php")
   assert.equal(existsSync(join(String(domain?.source), ".git")), false, "prepared component source should exclude VCS metadata")
   assert.equal(existsSync(join(String(domain?.source), "node_modules")), false, "prepared component source should exclude Node dependencies")
-  assert.equal(existsSync(join(String(domain?.source), "vendor")), false, "prepared component source should exclude Composer dependencies before hydration")
+  assert.equal(existsSync(join(String(domain?.source), "vendor")), true, "prepared component source should preserve existing Composer dependencies")
   assert.equal(runtime?.metadata?.componentContract?.requestedPath, runtimePlugin)
   assert.equal(runtime?.metadata?.componentContract?.preparedPath, runtime?.source)
   assert.equal(runtime?.metadata?.componentContract?.pluginFile, "runtime-component/runtime-component.php")
@@ -76,6 +76,7 @@ try {
   assert.equal(existsSync(join(String(monorepoComponent?.source), "..", "..", "packages", "php", "shared", "composer.json")), true)
   assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "autoload_packages.php")), true)
   assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "jetpack-autoloader", "class-autoloader.php")), true)
+  assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "woocommerce", "email-editor", "src", "class-package.php")), true)
 
   const missingComponentSource = "https://example.com/missing-component.zip"
   const invalidRecipePath = join(root, "invalid-component-recipe.json")
@@ -141,10 +142,12 @@ function writeMonorepoPlugin(rootPath: string, slug: string, name: string): { ro
   const pluginPath = join(monorepoRoot, sourceSubpath)
   mkdirSync(pluginPath, { recursive: true })
   mkdirSync(join(pluginPath, "vendor", "jetpack-autoloader"), { recursive: true })
+  mkdirSync(join(pluginPath, "vendor", "woocommerce", "email-editor", "src"), { recursive: true })
   mkdirSync(join(monorepoRoot, "packages", "php", "shared"), { recursive: true })
   writeFileSync(join(monorepoRoot, "packages", "php", "shared", "composer.json"), "{}\n")
   writeFileSync(join(pluginPath, "vendor", "autoload_packages.php"), "<?php // generated package autoloader\n")
   writeFileSync(join(pluginPath, "vendor", "jetpack-autoloader", "class-autoloader.php"), "<?php // package autoloader runtime\n")
+  writeFileSync(join(pluginPath, "vendor", "woocommerce", "email-editor", "src", "class-package.php"), "<?php // package source\n")
   writeFileSync(join(pluginPath, `${slug}.php`), `<?php
 /**
  * Plugin Name: ${name}


### PR DESCRIPTION
## Summary
- Preserve existing Composer vendor trees when staging source packages.
- Keep generated package autoloader metadata intact for monorepo plugins that ship built vendor contents.
- Update component-contract smoke coverage for preserved package vendor files.

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the source-package staging gap, drafting the patch, and running focused verification.