### PR TITLE
Hydrate source packages with Composer plugins

### DIFF
--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -207,9 +207,12 @@ export function prepareRecipeSourcePackageSync(options: PreparedRecipeSourcePack
     } else {
       mkdirSync(preparedSource, { recursive: true })
     }
-    const installedSource = installComposerDependenciesForSourcePackageSync(preparedPluginSource, options.slug, preparedRoot, options.composerInstallArgs)
-    preserveExistingComposerVendor(join(copySource, sourceSubpath), installedSource)
-    return installedSource
+    const originalPluginSource = join(copySource, sourceSubpath)
+    if (!pathExists(join(preparedPluginSource, "composer.json"))) {
+      preserveExistingComposerVendor(originalPluginSource, preparedPluginSource)
+      return preparedPluginSource
+    }
+    return installComposerDependenciesForSourcePackageSync(preparedPluginSource, options.slug, preparedRoot, options.composerInstallArgs)
   }
 
   return prepareRecipeSourcePackageWithoutArtifacts(source, source, options.slug, "")
@@ -242,7 +245,7 @@ export function composerManagedHostCommandConfig(options: {
 }): ManagedHostCommandConfig {
   return {
     command: "composer",
-    args: options.args ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts", "--no-plugins"],
+    args: options.args ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts"],
     cwd: options.cwd,
     env: composerManagedHostEnv(),
     allowedCwdRoots: options.allowedCwdRoots,
@@ -283,7 +286,7 @@ function installComposerDependenciesForSourcePackageSync(source: string, slug: s
   const config = composerManagedHostCommandConfig({
     cwd: source,
     allowedCwdRoots: [allowedRoot],
-    args: composerInstallArgs ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts", "--no-plugins"],
+    args: composerInstallArgs ?? ["install", "--no-dev", "--prefer-dist", "--no-interaction", "--no-progress", "--no-scripts"],
     label: `hydrate Composer source package ${slug}`,
   })
   const result = spawnSync(config.command, config.args, {


### PR DESCRIPTION
## Summary
- Hydrate staged source packages with Composer plugins enabled while keeping scripts disabled.
- Preserve an existing vendor tree only for sources without Composer metadata.
- Avoid overwriting newly hydrated Composer dependencies with stale vendor contents.

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WooCommerce package-autoloader hydration failure, drafting the follow-up fix, and running focused verification.