### PR TITLE
Fix runtime task ability materialization

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -343,11 +343,20 @@ $ability_name = $runtime_task_run ? (string) ($sandbox_runtime_task['ability'] ?
 $ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability($ability_name) : null;
 $registered_ability_ids = function_exists('wp_get_abilities') ? array_keys(wp_get_abilities()) : array();
 sort($registered_ability_ids);
+$runtime_task_preflight = array(
+    'schema' => 'wp-codebox/runtime-task-ability-preflight/v1',
+    'runtime_task_requested' => $runtime_task_run,
+    'ability' => $ability_name,
+    'registry_available' => function_exists('wp_get_ability'),
+    'available' => null !== $ability && method_exists($ability, 'execute'),
+    'registered_ability_ids' => $registered_ability_ids,
+);
 $sandbox_stack['abilities'] = array(
     'count' => count($registered_ability_ids),
     'ids' => $registered_ability_ids,
     'requested' => $ability_name,
     'requested_available' => null !== $ability,
+    'runtime_task_preflight' => $runtime_task_preflight,
 );
 $agent_input = ${phpStringLiteral(JSON.stringify(input))};
 $decoded_agent_input = json_decode($agent_input, true);
@@ -376,8 +385,9 @@ if (!empty($sandbox_agent_bundle_import_failures)) {
         'agent_runtime' => array(
             'success' => false,
             'error' => array(
-                'code' => $runtime_task_run ? 'runtime_task_ability_unavailable' : 'agents_chat_unavailable',
-                'message' => $runtime_task_run ? 'The requested runtime task ability is not available inside the sandbox.' : 'The canonical agents/chat ability is not available inside the sandbox.',
+                'code' => $runtime_task_run ? 'runtime_task_ability_missing_preflight' : 'agents_chat_unavailable',
+                'message' => $runtime_task_run ? 'The requested runtime task ability failed sandbox readiness preflight.' : 'The canonical agents/chat ability is not available inside the sandbox.',
+                'data' => array('preflight' => $runtime_task_preflight),
             ),
         ),
     );
@@ -534,11 +544,11 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined
 }
 
-export function agentSandboxRunCode(task: string, code: string, providerPlugins: Array<{ slug: string; pluginFile?: string; loadAs?: string }>): string {
+export function agentSandboxRunCode(task: string, code: string, providerPlugins: Array<{ slug: string; pluginFile?: string; loadAs?: string }>, runtimeComponents: Array<{ slug: string; pluginFile?: string; loadAs?: string }> = []): string {
   return `<?php
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-$plugins = array_merge(array(
+$plugins = array_merge(wp_codebox_provider_plugin_entries(json_decode(${phpStringLiteral(JSON.stringify(runtimeComponents))}, true)), array(
     'agents-api/agents-api.php',
 ), wp_codebox_provider_plugin_entries(json_decode(${phpStringLiteral(JSON.stringify(providerPlugins))}, true)));
 

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -147,7 +147,7 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
     return {
       command: "wordpress.run-php",
       args: [
-        `code=${agentSandboxRunCode(task, body, providerPluginContracts(args))}`,
+        `code=${agentSandboxRunCode(task, body, providerPluginContracts(args), runtimeComponentContracts(args))}`,
         "wp-cli-bridge=1",
         ...commandDiagnosticsCaptureArgs(step.diagnostics),
       ],
@@ -604,6 +604,18 @@ function providerPluginContracts(args: string[]): Array<{ slug: string; pluginFi
       .map((plugin) => plugin as { slug: string; pluginFile?: string; loadAs?: ComponentLoadMode })
   }
   return providerPluginSlugs(args).map((slug) => ({ slug }))
+}
+
+function runtimeComponentContracts(args: string[]): Array<{ slug: string; pluginFile?: string; loadAs?: ComponentLoadMode }> {
+  const explicit = commandArgValue(args, "runtime-component-contracts-json")
+  if (!explicit) {
+    return []
+  }
+
+  const parsed = parseCommandJsonArray(explicit, "runtime-component-contracts-json")
+  return parsed
+    .filter((plugin) => plugin && typeof plugin === "object" && !Array.isArray(plugin))
+    .map((plugin) => plugin as { slug: string; pluginFile?: string; loadAs?: ComponentLoadMode })
 }
 
 function pluginTarget(slug: string, loadAs: ComponentLoadMode): string {

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -113,6 +113,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
     `model=${stringValue(input.model)}`,
     `provider-plugin-slugs=${providerSlugs}`,
     `provider-plugin-contracts-json=${JSON.stringify(providerContracts)}`,
+    `runtime-component-contracts-json=${JSON.stringify(componentManifest.components)}`,
     `sandbox-tool-policy-json=${JSON.stringify(sandboxToolPolicy(input, taskInput))}`,
   ]
   if (stringValue(input.session_id)) {
@@ -513,8 +514,10 @@ function prepareComponentPluginSource(source: string, originalSource: string, so
 }
 
 function sandboxToolPolicy(input: AgentTaskRunInput, taskInput: TaskInput): SandboxToolPolicySnapshot {
-  const policy = objectValue(input.sandbox_tool_policy) || objectValue(taskInput.sandbox_tool_policy)
-  if (policy) {
+  const inputPolicy = objectValue(input.sandbox_tool_policy) ?? {}
+  const taskPolicy = objectValue(taskInput.sandbox_tool_policy) ?? {}
+  const policy = Object.keys(inputPolicy).length > 0 ? inputPolicy : taskPolicy
+  if (Object.keys(policy).length > 0) {
     return policy as unknown as SandboxToolPolicySnapshot
   }
   return {

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -40,7 +40,8 @@ final class WP_Codebox_Host_Recipe_Builder {
 		if ( ! $dependency_plan instanceof WP_Codebox_Runtime_Dependency_Plan ) {
 			return new WP_Error( 'wp_codebox_runtime_dependency_plan_invalid', 'Runtime dependency plan resolver must return a WP_Codebox_Runtime_Dependency_Plan.', array( 'status' => 500 ) );
 		}
-		$runtime_task          = $adapters['runtime_task']( $input );
+		$runtime_task       = $adapters['runtime_task']( $input );
+		$component_manifest = self::component_manifest( $dependency_plan->component_plugins(), $dependency_plan->provider_plugins() );
 		$steps          = array();
 		foreach ( $task_prompts as $task_prompt ) {
 			$task_input = $adapters['task_input']( array_merge( $input, array( 'goal' => $task_prompt ) ) );
@@ -55,6 +56,7 @@ final class WP_Codebox_Host_Recipe_Builder {
 				'provider=' . $dependency_plan->provider(),
 				'model=' . $dependency_plan->model(),
 				'provider-plugin-slugs=' . implode( ',', $dependency_plan->provider_plugin_slugs() ),
+				'runtime-component-contracts-json=' . $adapters['json_encode']( $component_manifest['components'] ),
 				'sandbox-tool-policy-json=' . $adapters['json_encode']( $task_input['sandbox_tool_policy'] ),
 			);
 			if ( ! empty( $dependency_plan->agent_bundles() ) ) {
@@ -96,8 +98,6 @@ final class WP_Codebox_Host_Recipe_Builder {
 		if ( is_wp_error( $site_seed_payload ) ) {
 			return $site_seed_payload;
 		}
-
-		$component_manifest = self::component_manifest( $dependency_plan->component_plugins(), $dependency_plan->provider_plugins() );
 
 		$recipe_inputs = array(
 			'mounts'             => $mounts,

--- a/scripts/agent-runtime-task-ability-smoke.ts
+++ b/scripts/agent-runtime-task-ability-smoke.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { chdir, cwd } from "node:process"
+import { buildAgentTaskRecipe } from "../packages/runtime-core/src/agent-task-recipe.js"
+import { normalizeTaskInput } from "../packages/runtime-core/src/task-input.js"
+import { runRecipeRunCommand } from "../packages/cli/src/commands/recipe-run.js"
+
+const root = mkdtempSync(join(tmpdir(), "wp-codebox-runtime-task-ability-smoke-"))
+const originalCwd = cwd()
+
+try {
+  chdir(root)
+  const componentPath = writeRuntimeTaskComponent(root)
+  const available = await runRuntimeTaskRecipe(root, componentPath, "example/runtime-task")
+  const availableRuntime = sandboxAgentRuntime(available)
+  assert.equal(available.success, true, JSON.stringify(availableRuntime, null, 2))
+  assert.equal(availableRuntime.success, true, JSON.stringify(availableRuntime, null, 2))
+  assert.deepEqual(availableRuntime.result, {
+    schema: "example/runtime-task-result/v1",
+    success: true,
+    concept_packet: { title: "Runtime task ability available" },
+  })
+
+  const missing = await runRuntimeTaskRecipe(root, componentPath, "example/missing-runtime-task")
+  const missingRuntime = sandboxAgentRuntime(missing)
+  assert.equal(missingRuntime.success, false)
+  assert.equal(missingRuntime.error?.code, "runtime_task_ability_missing_preflight")
+  assert.equal(missingRuntime.error?.data?.preflight?.schema, "wp-codebox/runtime-task-ability-preflight/v1")
+  assert.equal(missingRuntime.error?.data?.preflight?.ability, "example/missing-runtime-task")
+  assert.equal(missingRuntime.error?.data?.preflight?.available, false)
+  assert.ok(missingRuntime.error?.data?.preflight?.registered_ability_ids.includes("example/runtime-task"))
+
+  console.log("agent-runtime-task-ability-smoke: ok")
+} finally {
+  chdir(originalCwd)
+  rmSync(root, { recursive: true, force: true })
+}
+
+function writeRuntimeTaskComponent(rootPath: string): string {
+  const pluginPath = join(rootPath, "runtime-task-component")
+  mkdirSync(pluginPath, { recursive: true })
+  writeFileSync(join(pluginPath, "runtime-task-component.php"), `<?php
+/**
+ * Plugin Name: Runtime Task Component
+ */
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', static function (): void {
+    wp_register_ability(
+        'example/runtime-task',
+        array(
+            'label' => 'Example Runtime Task',
+            'description' => 'Synthetic runtime task ability for sandbox materialization tests.',
+            'category' => 'wp-codebox',
+            'execute_callback' => static function ( array $input ): array {
+                return array(
+                    'schema' => 'example/runtime-task-result/v1',
+                    'success' => true,
+                    'concept_packet' => array( 'title' => (string) ( $input['title'] ?? '' ) ),
+                );
+            },
+            'permission_callback' => '__return_true',
+            'input_schema' => array( 'type' => 'object' ),
+            'output_schema' => array( 'type' => 'object' ),
+        )
+    );
+} );
+`)
+  return pluginPath
+}
+
+async function runRuntimeTaskRecipe(rootPath: string, componentPath: string, ability: string): Promise<{ success?: boolean; executions?: Array<{ recipeCommand?: string; stdout?: string; parsed?: unknown }> }> {
+  const recipe = buildAgentTaskRecipe({
+    goal: `verify runtime task ability ${ability}`,
+    component_contracts: [
+      { slug: "runtime-task-component", path: componentPath, loadAs: "mu-plugin", activate: false },
+    ],
+    runtime_task: {
+      ability,
+      input: { title: "Runtime task ability available" },
+    },
+  }, normalizeTaskInput({ goal: `verify runtime task ability ${ability}` }), "latest")
+  const recipePath = join(rootPath, `${ability.replace(/[^a-z0-9_-]+/gi, "-")}.json`)
+  writeFileSync(recipePath, JSON.stringify(recipe, null, 2))
+
+  const output = await captureStdout(async () => await runRecipeRunCommand(["--recipe", recipePath, "--json"]))
+  return JSON.parse(output) as { success?: boolean; executions?: Array<{ recipeCommand?: string; stdout?: string; parsed?: unknown }> }
+}
+
+function sandboxAgentRuntime(runOutput: { executions?: Array<{ recipeCommand?: string; stdout?: string; parsed?: unknown }> }): { success?: boolean; result?: unknown; error?: { code?: string; data?: { preflight?: { schema?: string; ability?: string; available?: boolean; registered_ability_ids?: string[] } } } } {
+  const execution = runOutput.executions?.find((item) => item.recipeCommand === "wp-codebox.agent-sandbox-run")
+  assert.ok(execution, "agent sandbox execution should be present")
+  const parsed = typeof execution.parsed === "object" && execution.parsed !== null
+    ? execution.parsed as Record<string, unknown>
+    : JSON.parse(String(execution.stdout ?? "{}")) as Record<string, unknown>
+  const output = typeof parsed.output === "string" ? JSON.parse(parsed.output) as Record<string, unknown> : parsed
+  return output.agent_runtime as { success?: boolean; result?: unknown; error?: { code?: string; data?: { preflight?: { schema?: string; ability?: string; available?: boolean; registered_ability_ids?: string[] } } } }
+}
+
+async function captureStdout(callback: () => Promise<unknown>): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let stdout = ""
+  ;(process.stdout.write as typeof process.stdout.write) = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdout += typeof chunk === "string" ? chunk : chunk.toString()
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback()
+    } else if (callback) {
+      callback()
+    }
+    return true
+  }) as typeof process.stdout.write
+  try {
+    await callback()
+    return stdout
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -239,6 +239,12 @@ try {
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine-code"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code"), true)
+  const genericSandboxStepArgs = genericRecipe.workflow.steps.find((step) => step.command === "wp-codebox.agent-sandbox-run")?.args ?? []
+  const genericRuntimeComponentsArg = genericSandboxStepArgs.find((arg) => arg.startsWith("runtime-component-contracts-json=")) ?? "runtime-component-contracts-json=[]"
+  const genericRuntimeComponents = JSON.parse(genericRuntimeComponentsArg.slice("runtime-component-contracts-json=".length)) as Array<{ slug?: string }>
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "wordpress-plugin"), true)
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine"), true)
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine-code"), true)
 
   const recipe = buildAgentTaskRecipe({
     goal: "Verify extra plugin propagation",

--- a/tests/host-recipe-builder.test.ts
+++ b/tests/host-recipe-builder.test.ts
@@ -5,7 +5,7 @@ const result = await runPhpJson<{
   legacy_adapter_calls: string[]
   recipe: {
     schema: string
-    inputs: { inherit: unknown; secretEnv: string[]; agent_bundles: unknown[]; extra_plugins: unknown[] }
+    inputs: { inherit: unknown; secretEnv: string[]; agent_bundles: unknown[]; extra_plugins: unknown[]; component_manifest: { components: Array<{ slug: string }> } }
     workflow: { steps: Array<{ command: string; args: string[] }> }
     runtime: { overlays: unknown[] }
   }
@@ -146,6 +146,9 @@ assert.ok(result.recipe.workflow.steps[0].args.includes("mode=planned-mode"))
 assert.ok(result.recipe.workflow.steps[0].args.includes("provider=planned-provider"))
 assert.ok(result.recipe.workflow.steps[0].args.includes("model=planned-model"))
 assert.ok(result.recipe.workflow.steps[0].args.includes("provider-plugin-slugs=planned-provider"))
+const runtimeComponentContractsArg = result.recipe.workflow.steps[0].args.find((arg) => arg.startsWith("runtime-component-contracts-json=")) ?? "runtime-component-contracts-json=[]"
+const runtimeComponentContracts = JSON.parse(runtimeComponentContractsArg.slice("runtime-component-contracts-json=".length)) as Array<{ slug?: string }>
+assert.deepEqual(runtimeComponentContracts.map((component) => component.slug), ["demo-plugin"])
 assert.deepEqual(result.recipe.runtime.overlays, [{ kind: "plugin", library: "demo", strategy: "replace", source: "/overlays/demo" }])
 assert.deepEqual(result.preset_recipe.inputs.secretEnv, ["PRESET_SECRET"])
 assert.deepEqual(result.preset_recipe.inputs.runtimeEnv, { PRESET_RUNTIME_ENV: "1", WP_AGENT_RUNTIME: "1" })


### PR DESCRIPTION
## Summary
- Pass runtime component contracts into generated agent sandbox runs so declared sandbox-local runtime task abilities are mounted before execution.
- Add a structured runtime task ability readiness preflight diagnostic for missing abilities, including registry availability and registered ability IDs.
- Preserve the safe default sandbox tool policy when normalized task input contains an empty policy object.
- Add coverage for TypeScript and PHP recipe builders, browser preview access preservation, and runtime task ability success/missing preflight behavior.

## Tests
- npm run test:agent-task-contracts
- npm run test:host-recipe-builder
- npm run test:browser-playground-session-run
- npx tsx scripts/agent-runtime-task-ability-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating the WP Codebox/Homeboy runtime task ability materialization failure, implementing the fix, adding tests, and running verification.