### PR TITLE
Bridge package autoloaders to Composer autoload

### DIFF
--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process"
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { isAbsolute, join, relative, resolve } from "node:path"
 import { safeArtifactRelativePath } from "./artifact-paths.js"
@@ -212,7 +212,9 @@ export function prepareRecipeSourcePackageSync(options: PreparedRecipeSourcePack
       preserveExistingComposerVendor(originalPluginSource, preparedPluginSource)
       return preparedPluginSource
     }
-    return installComposerDependenciesForSourcePackageSync(preparedPluginSource, options.slug, preparedRoot, options.composerInstallArgs)
+    const installedSource = installComposerDependenciesForSourcePackageSync(preparedPluginSource, options.slug, preparedRoot, options.composerInstallArgs)
+    bridgePackageAutoloaderToComposerAutoload(installedSource)
+    return installedSource
   }
 
   return prepareRecipeSourcePackageWithoutArtifacts(source, source, options.slug, "")
@@ -225,6 +227,17 @@ function preserveExistingComposerVendor(originalPluginSource: string, preparedPl
   rmSync(preparedVendor, { recursive: true, force: true })
   mkdirSync(preparedPluginSource, { recursive: true })
   cpSync(originalVendor, preparedVendor, { recursive: true })
+}
+
+export function bridgePackageAutoloaderToComposerAutoload(pluginSource: string): void {
+  const packageAutoloader = join(pluginSource, "vendor", "autoload_packages.php")
+  const composerAutoloader = join(pluginSource, "vendor", "autoload.php")
+  if (!pathExists(packageAutoloader) || !pathExists(composerAutoloader)) return
+
+  const bridge = "require_once __DIR__ . '/autoload.php';"
+  const contents = readFileSync(packageAutoloader, "utf8")
+  if (contents.includes(bridge)) return
+  writeFileSync(packageAutoloader, `${contents.trimEnd()}\n${bridge}\n`)
 }
 
 export function composerManagedHostEnv(): Record<string, string> {

--- a/scripts/source-package-autoload-packages-bridge-smoke.ts
+++ b/scripts/source-package-autoload-packages-bridge-smoke.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+import { prepareRecipeSourcePackageSync } from "../packages/runtime-core/src/recipe-source-packages.js"
+
+const root = mkdtempSync(join(tmpdir(), "wp-codebox-source-package-autoload-packages-"))
+const originalPath = process.env.PATH ?? ""
+
+try {
+  const bin = join(root, "bin")
+  const sourceRoot = join(root, "source")
+  const pluginSource = join(sourceRoot, "plugins", "woocommerce")
+  const artifactsRoot = join(root, "artifacts")
+  mkdirSync(bin, { recursive: true })
+  mkdirSync(pluginSource, { recursive: true })
+
+  writeFileSync(join(pluginSource, "composer.json"), `${JSON.stringify({ name: "wp-codebox/source-package-autoload-packages-smoke" }, null, 2)}\n`)
+  writeFileSync(join(bin, "composer"), `#!/bin/sh
+mkdir -p vendor
+printf "%s\n" "<?php // composer autoload" > vendor/autoload.php
+printf "%s\n" "<?php" "namespace WpCodeboxSmoke;" "require_once __DIR__ . '/jetpack-autoloader/class-autoloader.php';" > vendor/autoload_packages.php
+mkdir -p vendor/jetpack-autoloader
+printf "%s\n" "<?php // package autoloader" > vendor/jetpack-autoloader/class-autoloader.php
+`, { mode: 0o755 })
+
+  process.env.PATH = `${bin}${delimiter}${originalPath}`
+  const prepared = prepareRecipeSourcePackageSync({
+    source: sourceRoot,
+    originalSource: sourceRoot,
+    sourceSubpath: "plugins/woocommerce",
+    slug: "woocommerce",
+    artifactsRoot,
+    packageRootName: "prepared-plugins",
+  })
+
+  const packageAutoloader = join(prepared, "vendor", "autoload_packages.php")
+  assert.equal(existsSync(packageAutoloader), true)
+  assert.match(readFileSync(packageAutoloader, "utf8"), /require_once __DIR__ \. '\/autoload\.php';/)
+  assert.equal(existsSync(join(pluginSource, "vendor", "autoload_packages.php")), false, "source checkout must not be mutated")
+
+  console.log("source-package-autoload-packages-bridge-smoke: ok")
+} finally {
+  process.env.PATH = originalPath
+  rmSync(root, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- When source-package hydration creates both vendor/autoload.php and vendor/autoload_packages.php, patch the package autoloader to load Composer's autoloader too.
- Keep the caller checkout untouched while making prepared package-autoloader boot paths see Composer-installed classmaps.
- Add a focused source-package smoke using a fake Composer binary for deterministic coverage.

## Testing
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the package-autoloader/classmap bridge failure, drafting the fix, and running focused verification.