### PR TITLE
Load Composer autoload before package init

### DIFF
--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -237,7 +237,9 @@ export function bridgePackageAutoloaderToComposerAutoload(pluginSource: string):
   const bridge = "require_once __DIR__ . '/autoload.php';"
   const contents = readFileSync(packageAutoloader, "utf8")
   if (contents.includes(bridge)) return
-  writeFileSync(packageAutoloader, `${contents.trimEnd()}\n${bridge}\n`)
+  const initCall = "Autoloader::init();"
+  const bridged = contents.includes(initCall) ? contents.replace(initCall, `${bridge}\n${initCall}`) : `${contents.trimEnd()}\n${bridge}\n`
+  writeFileSync(packageAutoloader, bridged)
 }
 
 export function composerManagedHostEnv(): Record<string, string> {

--- a/scripts/source-package-autoload-packages-bridge-smoke.ts
+++ b/scripts/source-package-autoload-packages-bridge-smoke.ts
@@ -19,7 +19,7 @@ try {
   writeFileSync(join(bin, "composer"), `#!/bin/sh
 mkdir -p vendor
 printf "%s\n" "<?php // composer autoload" > vendor/autoload.php
-printf "%s\n" "<?php" "namespace WpCodeboxSmoke;" "require_once __DIR__ . '/jetpack-autoloader/class-autoloader.php';" > vendor/autoload_packages.php
+printf "%s\n" "<?php" "namespace WpCodeboxSmoke;" "require_once __DIR__ . '/jetpack-autoloader/class-autoloader.php';" "Autoloader::init();" > vendor/autoload_packages.php
 mkdir -p vendor/jetpack-autoloader
 printf "%s\n" "<?php // package autoloader" > vendor/jetpack-autoloader/class-autoloader.php
 `, { mode: 0o755 })
@@ -36,7 +36,9 @@ printf "%s\n" "<?php // package autoloader" > vendor/jetpack-autoloader/class-au
 
   const packageAutoloader = join(prepared, "vendor", "autoload_packages.php")
   assert.equal(existsSync(packageAutoloader), true)
-  assert.match(readFileSync(packageAutoloader, "utf8"), /require_once __DIR__ \. '\/autoload\.php';/)
+  const bridgedPackageAutoloader = readFileSync(packageAutoloader, "utf8")
+  assert.match(bridgedPackageAutoloader, /require_once __DIR__ \. '\/autoload\.php';/)
+  assert.ok(bridgedPackageAutoloader.indexOf("require_once __DIR__ . '/autoload.php';") < bridgedPackageAutoloader.indexOf("Autoloader::init();"))
   assert.equal(existsSync(join(pluginSource, "vendor", "autoload_packages.php")), false, "source checkout must not be mutated")
 
   console.log("source-package-autoload-packages-bridge-smoke: ok")


### PR DESCRIPTION
## Summary
- Insert the Composer autoload bridge before package autoloader initialization when patching prepared source-package autoloaders.
- Keep the append fallback for package autoloaders without the standard init call.
- Update the source-package bridge smoke to assert ordering.

## Testing
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing package-autoloader ordering, drafting the fix, and running focused verification.