### PR TITLE
Preload Composer autoloaders for plugin activation

### DIFF
--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -2,7 +2,7 @@ import { cp, mkdtemp, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { phpRuntimeComponentLifecycleReplayFunction, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe } from "@automattic/wp-codebox-core"
-import { installMuPluginsCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspacePreloads, prepareRecipeWorkspaces, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
+import { installMuPluginsCode, installPluginComposerAutoloadersCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspacePreloads, prepareRecipeWorkspaces, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { pluginRuntimeHealthProbeStep, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex } from "../recipe-dry-run.js"
 import { prepareRecipeRuntimeBackendPackage, type PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
@@ -172,11 +172,16 @@ export async function applyRecipeRuntimeSetup(args: {
     executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${muPluginInstallCode}`] }), "setup", -2, "extra-plugin.install-mu-loader"))
   }
 
+  const composerAutoloaderInstallCode = installPluginComposerAutoloadersCode(extraPlugins)
+  if (composerAutoloaderInstallCode) {
+    executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${composerAutoloaderInstallCode}`] }), "setup", -2, "extra-plugin.install-composer-autoloaders"))
+  }
+
   const activatedPlugins = extraPlugins.filter((plugin) => plugin.loadAs === "plugin" && plugin.activate !== false)
   if (activatedPlugins.length > 0) {
     const activePluginsAfterActivation = await phaseTracker.run("activate_plugins", phasePluginActivationData(activatedPlugins), async () => {
       for (const plugin of activatedPlugins) {
-        executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${activateExtraPluginCode(plugin.pluginFile)}`] }), "setup", -1, `extra-plugin.activate:${plugin.pluginFile}`))
+        executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${activateExtraPluginCode(plugin)}`] }), "setup", -1, `extra-plugin.activate:${plugin.pluginFile}`))
         interruption?.throwIfInterrupted()
       }
       return await activePlugins(runtime)
@@ -385,10 +390,16 @@ function shouldCopyInputMountBaselineEntry(sourceRoot: string, entry: string): b
   return firstSegment !== ".git" && firstSegment !== "node_modules"
 }
 
-function activateExtraPluginCode(pluginFile: string): string {
+function activateExtraPluginCode(plugin: PreparedExtraPlugin): string {
+  const pluginFile = plugin.pluginFile
   return `${phpRuntimeComponentLifecycleReplayFunction("wp_codebox_activate_plugin")}
 $plugin_file = ${JSON.stringify(pluginFile)};
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
+$plugin_dir = dirname($plugin_file);
+$plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
+if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
+    require_once $plugin_autoload;
+}
 if (is_plugin_active($plugin_file)) {
     deactivate_plugins($plugin_file, true, false);
 }

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -1397,3 +1397,46 @@ if (false === file_put_contents($loader, implode("\\n", $lines) . "\\n")) {
 }
 echo wp_json_encode(array('command' => 'install-mu-plugins', 'plugins' => $plugins, 'loader' => $loader), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
 }
+
+export function installPluginComposerAutoloadersCode(extraPlugins: PreparedExtraPlugin[]): string | null {
+  const plugins = extraPlugins
+    .filter((plugin) => plugin.loadAs === "plugin")
+    .map((plugin) => plugin.pluginFile)
+
+  if (plugins.length === 0) {
+    return null
+  }
+
+  return `$plugins = ${JSON.stringify(plugins)};
+if (!is_dir(WPMU_PLUGIN_DIR) && !mkdir(WPMU_PLUGIN_DIR, 0777, true) && !is_dir(WPMU_PLUGIN_DIR)) {
+    throw new RuntimeException('Could not create mu-plugins directory.');
+}
+$loader = WPMU_PLUGIN_DIR . '/wp-codebox-composer-autoloaders.php';
+$lines = array(
+    '<?php',
+    '/**',
+    ' * Plugin Name: WP Codebox Composer Autoloaders',
+    ' * Description: Preloads Composer autoloaders for mounted WP Codebox plugins.',
+    ' */',
+    '',
+    "defined( 'ABSPATH' ) || exit;",
+    '',
+);
+foreach ($plugins as $plugin) {
+    if ('' === $plugin || str_starts_with($plugin, '/') || str_contains($plugin, '..') || !str_ends_with($plugin, '.php')) {
+        throw new RuntimeException('Unsafe WP Codebox Composer autoloader plugin entry.');
+    }
+    $plugin_dir = dirname($plugin);
+    if ('.' === $plugin_dir || '' === $plugin_dir) {
+        throw new RuntimeException('WP Codebox Composer autoloader plugin entry must include a directory.');
+    }
+    $autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
+    if (is_file($autoload)) {
+        $lines[] = "require_once WP_PLUGIN_DIR . '/" . str_replace("'", "\\'", $plugin_dir) . "/vendor/autoload.php';";
+    }
+}
+if (false === file_put_contents($loader, implode("\n", $lines) . "\n")) {
+    throw new RuntimeException('Could not write WP Codebox Composer autoloader loader.');
+}
+echo wp_json_encode(array('command' => 'install-composer-autoloaders', 'plugins' => $plugins, 'loader' => $loader), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);`
+}

--- a/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
+++ b/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
@@ -33,11 +33,6 @@ writeFileSync(resolve(pluginSource, "composer-autoload-smoke.php"), `<?php
 
 defined( 'ABSPATH' ) || exit;
 
-$autoload = __DIR__ . '/vendor/autoload.php';
-if ( is_file( $autoload ) ) {
-	require_once $autoload;
-}
-
 register_activation_hook( __FILE__, static function (): void {
 	if ( ! class_exists( \\WpCodeboxComposerSmoke\\Fixture::class ) ) {
 		throw new RuntimeException( 'Composer classmap fixture was not autoloaded.' );


### PR DESCRIPTION
## Summary
- install a runtime mu-plugin that preloads mounted plugin Composer autoloaders
- require mounted plugin Composer autoloaders before activation hooks run
- tighten the Composer autoload smoke so activation depends on runtime preloading

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Debugging the WP Codebox plugin activation Composer autoload path, implementing the runtime preloader change, and running focused verification.