### PR TITLE
Preload Composer autoloaders for run-php plugins

### DIFF
--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -114,6 +114,11 @@ function contained_runtime_run_php_include_active_plugin(array $plugin): void {
     if (!is_file($absolute_plugin_file) || !is_readable($absolute_plugin_file)) {
         throw new RuntimeException('wordpress.run-php cannot include recipe plugin file "' . $plugin_file . '". ' . contained_runtime_run_php_plugin_load_diagnostic($plugin, 'missing or unreadable plugin file'));
     }
+    $plugin_dir = dirname($plugin_file);
+    $plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
+    if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
+        require_once $plugin_autoload;
+    }
     $lifecycle = contained_runtime_run_php_component_lifecycle_replay_prepare();
     try {
         require_once $absolute_plugin_file;


### PR DESCRIPTION
## Summary
- preload mounted active plugin Composer autoloaders before wordpress.run-php includes recipe plugin files
- keeps plugin activation and subsequent run-php lifecycle replay on the same generic Composer loading path

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Debugging WooCommerce sandbox Composer autoload failures, implementing the contained run-php preload fix, and running focused verification.