### PR TITLE
Skip active recipe plugin replay during setup

### DIFF
--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -169,19 +169,19 @@ export async function applyRecipeRuntimeSetup(args: {
 
   const muPluginInstallCode = installMuPluginsCode(extraPlugins)
   if (muPluginInstallCode) {
-    executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${muPluginInstallCode}`] }), "setup", -2, "extra-plugin.install-mu-loader"))
+    executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: setupPhpArgs(muPluginInstallCode) }), "setup", -2, "extra-plugin.install-mu-loader"))
   }
 
   const composerAutoloaderInstallCode = installPluginComposerAutoloadersCode(extraPlugins)
   if (composerAutoloaderInstallCode) {
-    executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${composerAutoloaderInstallCode}`] }), "setup", -2, "extra-plugin.install-composer-autoloaders"))
+    executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: setupPhpArgs(composerAutoloaderInstallCode) }), "setup", -2, "extra-plugin.install-composer-autoloaders"))
   }
 
   const activatedPlugins = extraPlugins.filter((plugin) => plugin.loadAs === "plugin" && plugin.activate !== false)
   if (activatedPlugins.length > 0) {
     const activePluginsAfterActivation = await phaseTracker.run("activate_plugins", phasePluginActivationData(activatedPlugins), async () => {
       for (const plugin of activatedPlugins) {
-        executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: [`code=${activateExtraPluginCode(plugin)}`] }), "setup", -1, `extra-plugin.activate:${plugin.pluginFile}`))
+        executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: setupPhpArgs(activateExtraPluginCode(plugin)) }), "setup", -1, `extra-plugin.activate:${plugin.pluginFile}`))
         interruption?.throwIfInterrupted()
       }
       return await activePlugins(runtime)
@@ -290,10 +290,14 @@ async function executeRecipePluginRuntimeHealthProbe(runtime: Runtime, probe: Wo
 async function activePlugins(runtime: Runtime): Promise<string[]> {
   const execution = await runtime.execute({
     command: "wordpress.run-php",
-    args: ["code=echo wp_json_encode(array_values((array) get_option('active_plugins', array())));"],
+    args: setupPhpArgs("echo wp_json_encode(array_values((array) get_option('active_plugins', array())));"),
   })
   const parsed = JSON.parse(execution.stdout.trim() || "[]") as unknown
   return Array.isArray(parsed) ? parsed.filter((plugin): plugin is string => typeof plugin === "string") : []
+}
+
+function setupPhpArgs(code: string): string[] {
+  return ["recipe-active-plugins=none", `code=${code}`]
 }
 
 function phasePluginMountData(extraPlugins: PreparedExtraPlugin[]): Record<string, unknown> {

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -33,7 +33,7 @@ ${runtimeEnvPhp(spec)}
 ${secretEnvPhp(spec)}
 ${componentManifestPhp(spec)}
 require_once '/wordpress/wp-load.php';
-${recipeActivePluginBootstrapPhp(spec)}
+${recipeActivePluginBootstrapPhp(spec, args)}
 ${wpCliBridge ? `putenv(${JSON.stringify(`WP_CODEBOX_TERMINAL_ACTION_URL=${wpCliBridge.url}`)});
 putenv(${JSON.stringify(`WP_CODEBOX_TERMINAL_ACTION_TOKEN=${wpCliBridge.token}`)});
 ` : ""}
@@ -76,7 +76,11 @@ interface RecipePluginMetadata {
   loadAs?: unknown
 }
 
-function recipeActivePluginBootstrapPhp(spec: RuntimeCreateSpec): string {
+function recipeActivePluginBootstrapPhp(spec: RuntimeCreateSpec, args: string[]): string {
+  if (argValue(args, "recipe-active-plugins") === "none") {
+    return ""
+  }
+
   const plugins = recipeActivePluginMetadata(spec)
   if (plugins.length === 0) {
     return ""


### PR DESCRIPTION
## Summary
- add a narrow wordpress.run-php bootstrap flag to skip active recipe plugin replay
- use it for WP Codebox internal setup, activation, and active-plugin bookkeeping commands
- preserves normal active plugin replay for workload/runtime commands after setup

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing setup-phase active plugin replay, implementing the bootstrap opt-out, and running focused verification.