### PR TITLE
Hydrate source packages with existing vendors

### DIFF
--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -294,7 +294,7 @@ function inferredSourceSubpath(source: string, originalSource: string): string {
 }
 
 function installComposerDependenciesForSourcePackageSync(source: string, slug: string, allowedRoot: string, composerInstallArgs?: string[]): string {
-  if (!pathExists(join(source, "composer.json")) || pathExists(join(source, "vendor", "autoload.php"))) {
+  if (!pathExists(join(source, "composer.json"))) {
     return source
   }
 


### PR DESCRIPTION
## Summary
- run Composer hydration for staged source packages whenever composer.json exists
- avoid treating a copied vendor/autoload.php as proof that monorepo path packages are installed

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing stale source-package vendor hydration, implementing the fix, and running focused verification.