### PR TITLE
Preserve vendors in prepared source staging

### DIFF
--- a/packages/runtime-core/src/file-tree-policy.ts
+++ b/packages/runtime-core/src/file-tree-policy.ts
@@ -3,7 +3,7 @@ import { isAbsolute, normalize, relative, sep } from "node:path"
 export type NamedFileTreeSkipPolicy = "prepared-source" | "captured-mount"
 
 const FILE_TREE_SKIP_POLICIES = {
-  "prepared-source": [".git", "node_modules", "vendor"],
+  "prepared-source": [".git", "node_modules"],
   "captured-mount": [".git", "node_modules", "target"],
 } as const satisfies Record<NamedFileTreeSkipPolicy, readonly string[]>
 


### PR DESCRIPTION
## Summary
- keep vendor directories when staging prepared source packages
- lets Composer-hydrated prepared plugin sources mount with generated autoloaders

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing missing hydrated vendor mounts, implementing the staging policy fix, and running focused verification.