### PR TITLE
Mirror Composer path repositories for source packages

### DIFF
--- a/packages/runtime-core/src/file-tree-policy.ts
+++ b/packages/runtime-core/src/file-tree-policy.ts
@@ -3,7 +3,7 @@ import { isAbsolute, normalize, relative, sep } from "node:path"
 export type NamedFileTreeSkipPolicy = "prepared-source" | "captured-mount"
 
 const FILE_TREE_SKIP_POLICIES = {
-  "prepared-source": [".git", "node_modules"],
+  "prepared-source": [".git", "node_modules", "vendor"],
   "captured-mount": [".git", "node_modules", "target"],
 } as const satisfies Record<NamedFileTreeSkipPolicy, readonly string[]>
 

--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -247,6 +247,7 @@ export function composerManagedHostEnv(): Record<string, string> {
   return {
     ...(home ? { HOME: home } : {}),
     ...(process.env.COMPOSER_HOME ? { COMPOSER_HOME: process.env.COMPOSER_HOME } : home ? { COMPOSER_HOME: join(home, ".composer") } : {}),
+    COMPOSER_MIRROR_PATH_REPOS: "1",
   }
 }
 


### PR DESCRIPTION
## Summary
- restore prepared source staging to skip original vendor directories
- set COMPOSER_MIRROR_PATH_REPOS=1 for source-package Composer hydration
- ensures path repository packages are copied into prepared sources instead of symlinked out of sandbox bounds

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing path repository symlink behavior, reverting the staging-policy regression, implementing Composer path-repo mirroring, and running focused verification.