### PR TITLE
Preload plugin package autoloaders

### DIFF
--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -404,6 +404,10 @@ $plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
 if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
     require_once $plugin_autoload;
 }
+$plugin_package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
+if ('.' !== $plugin_dir && is_file($plugin_package_autoload)) {
+    require_once $plugin_package_autoload;
+}
 if (is_plugin_active($plugin_file)) {
     deactivate_plugins($plugin_file, true, false);
 }

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -1434,6 +1434,10 @@ foreach ($plugins as $plugin) {
     if (is_file($autoload)) {
         $lines[] = "require_once WP_PLUGIN_DIR . '/" . str_replace("'", "\\'", $plugin_dir) . "/vendor/autoload.php';";
     }
+    $package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
+    if (is_file($package_autoload)) {
+        $lines[] = "require_once WP_PLUGIN_DIR . '/" . str_replace("'", "\\'", $plugin_dir) . "/vendor/autoload_packages.php';";
+    }
 }
 if (false === file_put_contents($loader, implode("\n", $lines) . "\n")) {
     throw new RuntimeException('Could not write WP Codebox Composer autoloader loader.');

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -123,6 +123,10 @@ function contained_runtime_run_php_include_active_plugin(array $plugin): void {
     if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
         require_once $plugin_autoload;
     }
+    $plugin_package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
+    if ('.' !== $plugin_dir && is_file($plugin_package_autoload)) {
+        require_once $plugin_package_autoload;
+    }
     $lifecycle = contained_runtime_run_php_component_lifecycle_replay_prepare();
     try {
         require_once $absolute_plugin_file;


### PR DESCRIPTION
## Summary
- preload mounted plugin vendor/autoload_packages.php alongside vendor/autoload.php
- apply the same package-autoloader preload for activation, run-php active plugin replay, and generated runtime MU loader

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing plugin package autoloader preload gaps, implementing the preload change, and running focused verification.