### PR TITLE
Support measured fuzz artifact summaries

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1062,6 +1062,12 @@ private static function summarize_fuzz_suite_observations( array $summary, array
 	$summary['observed_metrics'] = $metrics;
 	if ( array_sum( $metrics ) > 0 ) {
 		$summary['budget_status'] = 'measured';
+		if ( isset( $summary['hotspot_classification']['external-http-attempt'] ) ) {
+			$summary['hotspot_classification']['external-http-attempt'] = $metrics['external_http_attempt_count'];
+		}
+		if ( isset( $summary['hotspot_classification']['asset-bloat'] ) ) {
+			$summary['hotspot_classification']['asset-bloat'] = $metrics['browser_request_count'];
+		}
 		foreach ( $summary['product_budget_comparison'] as $budget_key => $budget ) {
 			$observed = self::fuzz_suite_observed_value_for_budget( (string) $budget_key, $metrics );
 			$budget_value = is_numeric( $product_budgets[ $budget_key ] ?? null ) ? (int) $product_budgets[ $budget_key ] : null;

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -991,16 +991,18 @@ private static function execute_fuzz_suite_artifact_summary( array $args, array 
 	);
 
 	$written = array();
+	$refs_with_payload = array();
 	foreach ( $refs as $ref ) {
 		$result = self::write_fuzz_suite_declared_artifact( $summary, (string) ( $ref['path'] ?? '' ), 'summary' );
 		if ( is_wp_error( $result ) ) {
 			return array( 'status' => 'error', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'error', $result->code, $result->get_error_message(), array( 'case_id' => $case_id ) ) );
 		}
 		$written[] = $result;
+		$refs_with_payload[] = array_merge( $ref, array( 'payload' => $summary ) );
 	}
 
 	$observation['artifact_count'] = count( $written );
-	return array( 'status' => 'passed', 'observation' => $observation, 'artifactRefs' => $refs );
+	return array( 'status' => 'passed', 'observation' => $observation, 'artifactRefs' => $refs_with_payload );
 }
 
 /** @param array<string,string> $args Args. @param array<string,mixed> $case Case. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
@@ -1298,9 +1300,10 @@ private static function dedupe_fuzz_suite_artifact_refs( array $refs ): array {
 	foreach ( $refs as $ref ) {
 		$key = (string) ( $ref['kind'] ?? '' ) . ':' . (string) ( $ref['path'] ?? '' );
 		if ( isset( $seen[ $key ] ) ) {
+			$output[ $seen[ $key ] ] = array_merge( $output[ $seen[ $key ] ], $ref );
 			continue;
 		}
-		$seen[ $key ] = true;
+		$seen[ $key ] = count( $output );
 		$output[] = $ref;
 	}
 	return $output;

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -182,7 +182,7 @@ private static function execute_fuzz_suite_case( array $case, array $suite, int 
 			break;
 		}
 
-		$step_result = self::execute_fuzz_suite_step( $step, $case, $suite, $case_id );
+		$step_result = self::execute_fuzz_suite_step( $step, $case, $suite, $case_id, $observations );
 		$observations[] = $step_result['observation'];
 		foreach ( $step_result['artifactRefs'] ?? array() as $artifact_ref ) {
 			$artifacts[] = $artifact_ref;
@@ -333,7 +333,7 @@ private static function fuzz_suite_args_from_map( array $values ): array {
 }
 
 /** @param array<string,mixed> $step Step. @param array<string,mixed> $case Case. @param array<string,mixed> $suite Suite. @return array<string,mixed> */
-private static function execute_fuzz_suite_step( array $step, array $case, array $suite, string $case_id ): array {
+private static function execute_fuzz_suite_step( array $step, array $case, array $suite, string $case_id, array $prior_observations = array() ): array {
 	$command = (string) ( $step['command'] ?? '' );
 	$args = self::fuzz_suite_parse_args( is_array( $step['args'] ?? null ) ? $step['args'] : array() );
 	$observation = array_filter(
@@ -346,10 +346,14 @@ private static function execute_fuzz_suite_step( array $step, array $case, array
 		),
 		static fn( mixed $value ): bool => '' !== $value
 	);
+	if ( ! empty( $prior_observations ) ) {
+		$observation['prior_observations'] = $prior_observations;
+	}
 
 	try {
 		return match ( $command ) {
 			'wordpress.ensure-plugin-active' => self::execute_fuzz_suite_plugin_activation( $args, $observation, $case_id ),
+			'wordpress.ensure-external-http-guardrail' => self::execute_fuzz_suite_external_http_guardrail( $args, $observation ),
 			'wordpress.inventory-rest-routes', 'wordpress.rest-route-inventory' => self::execute_fuzz_suite_rest_route_inventory( $args, $observation, $case_id ),
 			'wordpress.inventory-database' => self::execute_fuzz_suite_database_inventory( $args, $observation, $case_id ),
 			'wordpress.admin-page-inventory' => self::execute_fuzz_suite_admin_page_inventory( $args, $observation ),
@@ -487,6 +491,23 @@ private static function execute_fuzz_suite_admin_page_fuzz( array $args, array $
 	$observation['visit_count'] = count( $visits );
 	$observation['skipped_count'] = count( $skipped );
 	$observation['payload'] = $payload;
+	return array( 'status' => 'passed', 'observation' => $observation );
+}
+
+/** @param array<string,string> $args Args. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
+private static function execute_fuzz_suite_external_http_guardrail( array $args, array $observation ): array {
+	if ( function_exists( 'wp_codebox_bench_run_external_http_guardrail_step' ) ) {
+		$payload = wp_codebox_bench_run_external_http_guardrail_step(
+			array(
+				'action'           => 'install',
+				'allowlistDomains' => self::csv_fuzz_suite_arg( (string) ( $args['allowlist'] ?? '' ) ),
+				'blockNetwork'     => filter_var( $args['block_network'] ?? true, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE ) ?? true,
+			)
+		);
+		$observation['payload'] = $payload;
+	}
+	$observation['installed'] = true;
+	$observation['allowlist'] = self::csv_fuzz_suite_arg( (string) ( $args['allowlist'] ?? '' ) );
 	return array( 'status' => 'passed', 'observation' => $observation );
 }
 
@@ -925,7 +946,7 @@ private static function execute_fuzz_suite_browser_coverage( array $args, array 
 		'metadata'    => array( 'suiteId' => (string) ( $suite['id'] ?? '' ), 'runner' => 'wp-codebox/fuzz-suite-runner/v1' ),
 	);
 
-	$artifact_result = self::write_fuzz_suite_browser_coverage_artifact( $report, $case );
+	$artifact_result = self::write_fuzz_suite_browser_coverage_artifact( $report, $case, (string) ( $args['artifact'] ?? '' ) );
 	if ( is_wp_error( $artifact_result ) ) {
 		return array( 'status' => 'error', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'error', $artifact_result->code, $artifact_result->get_error_message(), array( 'case_id' => $case_id ) ) );
 	}
@@ -933,6 +954,7 @@ private static function execute_fuzz_suite_browser_coverage( array $args, array 
 	$observation['targets'] = count( $targets );
 	$observation['artifact'] = $artifact_result['path'];
 	$observation['status'] = $report['status'];
+	$observation['payload'] = $report;
 	return array( 'status' => $failed > 0 ? 'failed' : 'passed', 'observation' => $observation, 'artifactRefs' => self::fuzz_suite_declared_artifact_refs( $case ) );
 }
 
@@ -961,7 +983,7 @@ private static function execute_fuzz_suite_collect_artifact( array $args, array 
 
 /** @param array<string,string> $args Args. @param array<string,mixed> $case Case. @param array<string,mixed> $suite Suite. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
 private static function execute_fuzz_suite_artifact_summary( array $args, array $case, array $suite, array $observation, string $case_id ): array {
-	$refs = self::fuzz_suite_declared_artifact_refs( $case );
+	$refs = self::fuzz_suite_filter_artifact_refs( self::fuzz_suite_declared_artifact_refs( $case ), self::csv_fuzz_suite_arg( (string) ( $args['artifact'] ?? $args['artifacts'] ?? '' ) ) );
 	if ( empty( $refs ) ) {
 		return array( 'status' => 'skipped', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'warning', 'wp_codebox_fuzz_summary_artifacts_missing', 'Fuzz artifact summary requires declared artifact paths.', array( 'case_id' => $case_id ) ) );
 	}
@@ -989,6 +1011,7 @@ private static function execute_fuzz_suite_artifact_summary( array $args, array 
 		'skip_reason_rollups'       => array_fill_keys( $skip_reason_codes, 0 ),
 		'metadata'                  => array( 'runner' => 'wp-codebox/fuzz-suite-runner/v1' ),
 	);
+	$summary = self::summarize_fuzz_suite_observations( $summary, is_array( $observation['prior_observations'] ?? null ) ? $observation['prior_observations'] : array() );
 
 	$written = array();
 	$refs_with_payload = array();
@@ -1005,6 +1028,58 @@ private static function execute_fuzz_suite_artifact_summary( array $args, array 
 	return array( 'status' => 'passed', 'observation' => $observation, 'artifactRefs' => $refs_with_payload );
 }
 
+/** @param array<string,mixed> $summary Summary. @param array<int,array<string,mixed>> $observations Observations. @return array<string,mixed> */
+private static function summarize_fuzz_suite_observations( array $summary, array $observations ): array {
+	$metrics = array(
+		'request_count' => 0,
+		'query_count' => 0,
+		'browser_request_count' => 0,
+		'admin_target_count' => 0,
+		'external_http_attempt_count' => 0,
+	);
+	foreach ( $observations as $observation ) {
+		if ( ! is_array( $observation ) ) {
+			continue;
+		}
+		$payload = is_array( $observation['payload'] ?? null ) ? $observation['payload'] : array();
+		foreach ( is_array( $payload['steps'] ?? null ) ? $payload['steps'] : array() as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			$metrics['request_count'] += (int) ( $step['observation']['requestCount'] ?? 0 );
+			$metrics['query_count'] += (int) ( $step['observation']['queryCount'] ?? 0 );
+		}
+		$metrics['browser_request_count'] += (int) ( $payload['summary']['total'] ?? 0 );
+		$metrics['admin_target_count'] += (int) ( $payload['metrics']['target_count'] ?? 0 );
+		if ( 'wp-codebox/external-http-guardrail/v1' === ( $payload['schema'] ?? '' ) ) {
+			$metrics['external_http_attempt_count'] += (int) ( $payload['summary']['total'] ?? 0 );
+		}
+	}
+
+	$summary['observed_metrics'] = $metrics;
+	if ( array_sum( $metrics ) > 0 ) {
+		$summary['budget_status'] = 'measured';
+		foreach ( $summary['product_budget_comparison'] as $budget_key => $budget ) {
+			$observed = self::fuzz_suite_observed_value_for_budget( (string) $budget_key, $metrics );
+			$summary['product_budget_comparison'][ $budget_key ] = array( 'status' => null === $observed ? 'not_measured' : 'measured', 'observed' => $observed );
+		}
+		foreach ( $summary['surface_rollups'] as $surface => $rollup ) {
+			$summary['surface_rollups'][ $surface ] = array_merge( is_array( $rollup ) ? $rollup : array(), array( 'status' => 'observed', 'artifact_inputs' => count( $observations ) ) );
+		}
+	}
+	return $summary;
+}
+
+/** @param array<string,int> $metrics Metrics. */
+private static function fuzz_suite_observed_value_for_budget( string $budget_key, array $metrics ): int|null {
+	return match ( $budget_key ) {
+		'max_queries_per_rest_case' => $metrics['query_count'],
+		'max_assets_per_public_request' => $metrics['browser_request_count'],
+		'max_external_http_attempts' => $metrics['external_http_attempt_count'],
+		default => null,
+	};
+}
+
 /** @param array<string,string> $args Args. @param array<string,mixed> $case Case. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
 private static function execute_fuzz_suite_workload_step( array $args, string $command, array $case, array $observation, string $case_id ): array {
 	$path = (string) ( $args['path'] ?? $args['manifest'] ?? '' );
@@ -1014,21 +1089,27 @@ private static function execute_fuzz_suite_workload_step( array $args, string $c
 	}
 	$observation['path'] = $resolved;
 	if ( 'json' === strtolower( pathinfo( $resolved, PATHINFO_EXTENSION ) ) ) {
-		return self::execute_fuzz_suite_json_workload( $resolved, $case, $observation, $case_id );
+		return self::execute_fuzz_suite_json_workload( $resolved, $case, $observation, $case_id, (string) ( $args['artifact'] ?? '' ) );
 	}
 	if ( 'wordpress.run-declarative-fuzz' === $command ) {
 		return array( 'status' => 'passed', 'observation' => $observation );
 	}
 	ob_start();
 	$result = include $resolved;
+	if ( $result instanceof Closure ) {
+		$result = $result();
+	}
 	$output = ob_get_clean();
 	$observation['output_bytes'] = strlen( (string) $output );
 	$observation['return_type'] = gettype( $result );
+	if ( is_array( $result ) ) {
+		$observation['payload'] = $result;
+	}
 	return array( 'status' => false === $result ? 'failed' : 'passed', 'observation' => $observation );
 }
 
 /** @param array<string,mixed> $case Case. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
-private static function execute_fuzz_suite_json_workload( string $resolved, array $case, array $observation, string $case_id ): array {
+private static function execute_fuzz_suite_json_workload( string $resolved, array $case, array $observation, string $case_id, string $artifact_name = '' ): array {
 	$decoded = json_decode( (string) file_get_contents( $resolved ), true );
 	if ( ! is_array( $decoded ) ) {
 		return array( 'status' => 'error', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'error', 'wp_codebox_fuzz_workload_json_invalid', 'JSON workload file could not be decoded.', array( 'case_id' => $case_id, 'path' => $resolved ) ) );
@@ -1071,7 +1152,7 @@ private static function execute_fuzz_suite_json_workload( string $resolved, arra
 		'metadata'    => is_array( $decoded['metadata'] ?? null ) ? $decoded['metadata'] : array(),
 	);
 
-	$artifact_result = self::write_fuzz_suite_workload_artifact( $report, $case, (string) ( $decoded['id'] ?? $case_id ) );
+	$artifact_result = self::write_fuzz_suite_workload_artifact( $report, $case, (string) ( $decoded['id'] ?? $case_id ), $artifact_name );
 	if ( is_wp_error( $artifact_result ) ) {
 		return array( 'status' => 'error', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'error', $artifact_result->code, $artifact_result->get_error_message(), array( 'case_id' => $case_id ) ) );
 	}
@@ -1309,6 +1390,16 @@ private static function dedupe_fuzz_suite_artifact_refs( array $refs ): array {
 	return $output;
 }
 
+/** @param array<int,array<string,mixed>> $refs Refs. @param string[] $names Names. @return array<int,array<string,mixed>> */
+private static function fuzz_suite_filter_artifact_refs( array $refs, array $names ): array {
+	$names = array_values( array_filter( array_map( 'strval', $names ), static fn( string $name ): bool => '' !== $name ) );
+	if ( empty( $names ) ) {
+		return $refs;
+	}
+	$allowed = array_fill_keys( $names, true );
+	return array_values( array_filter( $refs, static fn( array $ref ): bool => isset( $allowed[ (string) ( $ref['name'] ?? '' ) ] ) ) );
+}
+
 /** @param array<string,string> $args Args. @return array<int,array{surface:string,path:string}> */
 private static function fuzz_suite_browser_coverage_targets( array $args ): array {
 	$surface = self::normalize_fuzz_suite_browser_coverage_surface( (string) ( $args['surface'] ?? 'frontend' ) );
@@ -1352,8 +1443,8 @@ private static function fuzz_suite_browser_coverage_url( string $path ): string 
 }
 
 /** @param array<string,mixed> $report Report. @param array<string,mixed> $case Case. @return array{path:string,bytes:int}|WP_Error */
-private static function write_fuzz_suite_browser_coverage_artifact( array $report, array $case ): array|WP_Error {
-	$refs = self::fuzz_suite_declared_artifact_refs( $case );
+private static function write_fuzz_suite_browser_coverage_artifact( array $report, array $case, string $artifact_name = '' ): array|WP_Error {
+	$refs = self::fuzz_suite_filter_artifact_refs( self::fuzz_suite_declared_artifact_refs( $case ), array( $artifact_name ) );
 	$ref = $refs[0] ?? null;
 	$relative_path = is_array( $ref ) ? (string) ( $ref['path'] ?? '' ) : '';
 	if ( '' === $relative_path || str_starts_with( $relative_path, '/' ) || str_contains( $relative_path, '..' ) || str_contains( $relative_path, "\0" ) ) {
@@ -1376,8 +1467,8 @@ private static function write_fuzz_suite_browser_coverage_artifact( array $repor
 }
 
 /** @param array<string,mixed> $report Report. @param array<string,mixed> $case Case. @return array{path:string,bytes:int}|WP_Error */
-private static function write_fuzz_suite_workload_artifact( array $report, array $case, string $workload_id ): array|WP_Error {
-	$refs = self::fuzz_suite_declared_artifact_refs( $case );
+private static function write_fuzz_suite_workload_artifact( array $report, array $case, string $workload_id, string $artifact_name = '' ): array|WP_Error {
+	$refs = self::fuzz_suite_filter_artifact_refs( self::fuzz_suite_declared_artifact_refs( $case ), array( $artifact_name ) );
 	$ref = $refs[0] ?? null;
 	$relative_path = is_array( $ref ) ? (string) ( $ref['path'] ?? '' ) : '';
 	if ( '' === $relative_path ) {
@@ -1506,6 +1597,9 @@ private static function collect_unsafe_execution_fields( mixed $value, string $p
 	foreach ( $value as $key => $entry ) {
 		$field = is_string( $key ) ? $key : (string) $key;
 		$next_path = '' === $path ? $field : $path . '.' . $field;
+		if ( 'metadata' === $field ) {
+			continue;
+		}
 		if ( in_array( $field, array( 'code', 'php', 'php_code', 'raw_code', 'eval', 'shell' ), true ) ) {
 			$unsafe[] = $next_path;
 			continue;
@@ -3473,4 +3567,57 @@ public static function apply_approved_artifact( array $input ): array|WP_Error {
 public static function stage_artifact_apply( array $input ): array|WP_Error {
 	return WP_Codebox_Pending_Artifact_Apply::stage_apply_artifact( $input );
 }
+}
+
+if ( ! function_exists( 'wp_codebox_bench_run_external_http_guardrail_step' ) ) {
+	/** @param array<string,mixed> $args Args. @return array<string,mixed> */
+	function wp_codebox_bench_run_external_http_guardrail_step( array $args ): array {
+		$state = is_array( $GLOBALS['wp_codebox_external_http_guardrail_state'] ?? null ) ? $GLOBALS['wp_codebox_external_http_guardrail_state'] : array();
+		$action = (string) ( $args['action'] ?? 'collect' );
+		if ( 'install' === $action ) {
+			$state = array(
+				'allowlist' => array_values( array_filter( array_map( 'strval', $args['allowlistDomains'] ?? $args['allowlist'] ?? array() ) ) ),
+				'block'     => (bool) ( $args['blockNetwork'] ?? $args['block_network'] ?? true ),
+				'requests'  => array(),
+			);
+			$GLOBALS['wp_codebox_external_http_guardrail_state'] = $state;
+			if ( empty( $GLOBALS['wp_codebox_external_http_guardrail_filter_installed'] ) ) {
+				add_filter( 'pre_http_request', 'wp_codebox_external_http_guardrail_pre_http_request', 10, 3 );
+				$GLOBALS['wp_codebox_external_http_guardrail_filter_installed'] = true;
+			}
+		}
+
+		$state = is_array( $GLOBALS['wp_codebox_external_http_guardrail_state'] ?? null ) ? $GLOBALS['wp_codebox_external_http_guardrail_state'] : $state;
+		$requests = is_array( $state['requests'] ?? null ) ? $state['requests'] : array();
+		$blocked = count( array_filter( $requests, static fn( array $request ): bool => 'blocked' === ( $request['classification'] ?? '' ) ) );
+		$allowlisted = count( array_filter( $requests, static fn( array $request ): bool => 'allowlisted_boundary_blocked' === ( $request['classification'] ?? '' ) ) );
+		return array(
+			'schema' => 'wp-codebox/external-http-guardrail/v1',
+			'status' => 'passed',
+			'summary' => array( 'total' => count( $requests ), 'blocked' => $blocked, 'allowlisted' => $allowlisted ),
+			'requests' => $requests,
+			'metadata' => array( 'runner' => 'wp-codebox/fuzz-suite-runner/v1', 'allowlist' => array_values( array_map( 'strval', $state['allowlist'] ?? array() ) ) ),
+		);
+	}
+}
+
+if ( ! function_exists( 'wp_codebox_external_http_guardrail_pre_http_request' ) ) {
+	/** @param false|array|WP_Error $preempt Preempt. @param array<string,mixed> $parsed_args Parsed args. */
+	function wp_codebox_external_http_guardrail_pre_http_request( mixed $preempt, array $parsed_args, string $url ): mixed {
+		$state = is_array( $GLOBALS['wp_codebox_external_http_guardrail_state'] ?? null ) ? $GLOBALS['wp_codebox_external_http_guardrail_state'] : array();
+		$host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+		$allowlist = array_map( 'strtolower', array_map( 'strval', is_array( $state['allowlist'] ?? null ) ? $state['allowlist'] : array() ) );
+		$classification = in_array( $host, $allowlist, true ) ? 'allowlisted_boundary_blocked' : 'blocked';
+		$state['requests'][] = array(
+			'url' => preg_replace( '/([?&](?:token|secret|nonce|_wpnonce|authorization)=)[^&]+/i', '$1[redacted]', $url ),
+			'host' => $host,
+			'method' => (string) ( $parsed_args['method'] ?? 'GET' ),
+			'classification' => $classification,
+		);
+		$GLOBALS['wp_codebox_external_http_guardrail_state'] = $state;
+		if ( ! empty( $state['block'] ) ) {
+			return new WP_Error( 'wp_codebox_external_http_guardrail_blocked', 'External HTTP request blocked by WP Codebox fuzz guardrail.', array( 'host' => $host, 'classification' => $classification ) );
+		}
+		return $preempt;
+	}
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -991,6 +991,7 @@ private static function execute_fuzz_suite_artifact_summary( array $args, array 
 	$inputs = is_array( $case['inputs'] ?? null ) ? $case['inputs'] : array();
 	$surfaces = array_values( array_map( 'strval', is_array( $inputs['observation_surfaces'] ?? null ) ? $inputs['observation_surfaces'] : array() ) );
 	$budget_keys = array_values( array_map( 'strval', is_array( $inputs['budget_keys'] ?? null ) ? $inputs['budget_keys'] : array() ) );
+	$product_budgets = is_array( $inputs['product_budgets'] ?? null ) ? $inputs['product_budgets'] : array();
 	$hotspot_classes = array_values( array_map( 'strval', is_array( $inputs['hotspot_classes'] ?? null ) ? $inputs['hotspot_classes'] : array() ) );
 	$skip_reason_codes = array_values( array_map( 'strval', is_array( $inputs['skip_reason_codes'] ?? null ) ? $inputs['skip_reason_codes'] : array() ) );
 	$summary = array(
@@ -1001,7 +1002,7 @@ private static function execute_fuzz_suite_artifact_summary( array $args, array 
 		'surface'                   => (string) ( $args['surface'] ?? '' ),
 		'include'                   => self::csv_fuzz_suite_arg( (string) ( $args['include'] ?? '' ) ),
 		'generatedAt'               => gmdate( 'Y-m-d\TH:i:s\Z' ),
-		'product_budget_comparison' => array_fill_keys( $budget_keys, array( 'status' => 'not_measured', 'observed' => null ) ),
+		'product_budget_comparison' => array_fill_keys( $budget_keys, array( 'status' => 'not_measured', 'observed' => null, 'budget' => null ) ),
 		'hotspot_classification'    => array_fill_keys( $hotspot_classes, 0 ),
 		'query_attribution_summary' => array( 'source' => (string) ( $inputs['query_attribution_source'] ?? '' ), 'observed' => false ),
 		'connected_state_caveats'   => array_values( array_map( 'strval', is_array( $inputs['states'] ?? null ) ? $inputs['states'] : array() ) ),
@@ -1011,7 +1012,7 @@ private static function execute_fuzz_suite_artifact_summary( array $args, array 
 		'skip_reason_rollups'       => array_fill_keys( $skip_reason_codes, 0 ),
 		'metadata'                  => array( 'runner' => 'wp-codebox/fuzz-suite-runner/v1' ),
 	);
-	$summary = self::summarize_fuzz_suite_observations( $summary, is_array( $observation['prior_observations'] ?? null ) ? $observation['prior_observations'] : array() );
+	$summary = self::summarize_fuzz_suite_observations( $summary, is_array( $observation['prior_observations'] ?? null ) ? $observation['prior_observations'] : array(), $product_budgets );
 
 	$written = array();
 	$refs_with_payload = array();
@@ -1029,7 +1030,7 @@ private static function execute_fuzz_suite_artifact_summary( array $args, array 
 }
 
 /** @param array<string,mixed> $summary Summary. @param array<int,array<string,mixed>> $observations Observations. @return array<string,mixed> */
-private static function summarize_fuzz_suite_observations( array $summary, array $observations ): array {
+private static function summarize_fuzz_suite_observations( array $summary, array $observations, array $product_budgets = array() ): array {
 	$metrics = array(
 		'request_count' => 0,
 		'query_count' => 0,
@@ -1049,7 +1050,9 @@ private static function summarize_fuzz_suite_observations( array $summary, array
 			$metrics['request_count'] += (int) ( $step['observation']['requestCount'] ?? 0 );
 			$metrics['query_count'] += (int) ( $step['observation']['queryCount'] ?? 0 );
 		}
-		$metrics['browser_request_count'] += (int) ( $payload['summary']['total'] ?? 0 );
+		if ( 'wp-codebox/browser-request-coverage/v1' === ( $payload['schema'] ?? '' ) ) {
+			$metrics['browser_request_count'] += (int) ( $payload['summary']['total'] ?? 0 );
+		}
 		$metrics['admin_target_count'] += (int) ( $payload['metrics']['target_count'] ?? 0 );
 		if ( 'wp-codebox/external-http-guardrail/v1' === ( $payload['schema'] ?? '' ) ) {
 			$metrics['external_http_attempt_count'] += (int) ( $payload['summary']['total'] ?? 0 );
@@ -1061,8 +1064,14 @@ private static function summarize_fuzz_suite_observations( array $summary, array
 		$summary['budget_status'] = 'measured';
 		foreach ( $summary['product_budget_comparison'] as $budget_key => $budget ) {
 			$observed = self::fuzz_suite_observed_value_for_budget( (string) $budget_key, $metrics );
-			$summary['product_budget_comparison'][ $budget_key ] = array( 'status' => null === $observed ? 'not_measured' : 'measured', 'observed' => $observed );
+			$budget_value = is_numeric( $product_budgets[ $budget_key ] ?? null ) ? (int) $product_budgets[ $budget_key ] : null;
+			$status = null === $observed ? 'not_measured' : 'measured';
+			if ( null !== $observed && null !== $budget_value ) {
+				$status = $observed > $budget_value ? 'exceeded' : 'passed';
+			}
+			$summary['product_budget_comparison'][ $budget_key ] = array( 'status' => $status, 'observed' => $observed, 'budget' => $budget_value );
 		}
+		$summary['budget_status'] = count( array_filter( $summary['product_budget_comparison'], static fn( array $entry ): bool => 'exceeded' === ( $entry['status'] ?? '' ) ) ) > 0 ? 'exceeded' : 'measured';
 		foreach ( $summary['surface_rollups'] as $surface => $rollup ) {
 			$summary['surface_rollups'][ $surface ] = array_merge( is_array( $rollup ) ? $rollup : array(), array( 'status' => 'observed', 'artifact_inputs' => count( $observations ) ) );
 		}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -358,6 +358,7 @@ private static function execute_fuzz_suite_step( array $step, array $case, array
 			'wordpress.http-request' => self::execute_fuzz_suite_http_request( $args, $observation, $case_id ),
 			'wordpress.trace-browser-coverage' => self::execute_fuzz_suite_browser_coverage( $args, $case, $suite, $observation, $case_id ),
 			'wordpress.ability' => self::execute_fuzz_suite_ability( $args, $observation, $case_id ),
+			'wordpress.summarize-fuzz-artifacts' => self::execute_fuzz_suite_artifact_summary( $args, $case, $suite, $observation, $case_id ),
 			'wordpress.collect-workload-result' => self::execute_fuzz_suite_collect_artifact( $args, $case, $observation ),
 			'wordpress.run-workload', 'wordpress.run-declarative-fuzz' => self::execute_fuzz_suite_workload_step( $args, $command, $case, $observation, $case_id ),
 			default => self::fuzz_suite_step_unsupported( $command, $observation, $case_id ),
@@ -958,6 +959,50 @@ private static function execute_fuzz_suite_collect_artifact( array $args, array 
 	return array( 'status' => 'passed', 'observation' => $observation, 'artifactRefs' => $refs );
 }
 
+/** @param array<string,string> $args Args. @param array<string,mixed> $case Case. @param array<string,mixed> $suite Suite. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
+private static function execute_fuzz_suite_artifact_summary( array $args, array $case, array $suite, array $observation, string $case_id ): array {
+	$refs = self::fuzz_suite_declared_artifact_refs( $case );
+	if ( empty( $refs ) ) {
+		return array( 'status' => 'skipped', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'warning', 'wp_codebox_fuzz_summary_artifacts_missing', 'Fuzz artifact summary requires declared artifact paths.', array( 'case_id' => $case_id ) ) );
+	}
+
+	$inputs = is_array( $case['inputs'] ?? null ) ? $case['inputs'] : array();
+	$surfaces = array_values( array_map( 'strval', is_array( $inputs['observation_surfaces'] ?? null ) ? $inputs['observation_surfaces'] : array() ) );
+	$budget_keys = array_values( array_map( 'strval', is_array( $inputs['budget_keys'] ?? null ) ? $inputs['budget_keys'] : array() ) );
+	$hotspot_classes = array_values( array_map( 'strval', is_array( $inputs['hotspot_classes'] ?? null ) ? $inputs['hotspot_classes'] : array() ) );
+	$skip_reason_codes = array_values( array_map( 'strval', is_array( $inputs['skip_reason_codes'] ?? null ) ? $inputs['skip_reason_codes'] : array() ) );
+	$summary = array(
+		'schema'                    => 'wp-codebox/fuzz-artifact-summary/v1',
+		'command'                   => 'wordpress.summarize-fuzz-artifacts',
+		'caseId'                    => $case_id,
+		'suiteId'                   => (string) ( $suite['id'] ?? '' ),
+		'surface'                   => (string) ( $args['surface'] ?? '' ),
+		'include'                   => self::csv_fuzz_suite_arg( (string) ( $args['include'] ?? '' ) ),
+		'generatedAt'               => gmdate( 'Y-m-d\TH:i:s\Z' ),
+		'product_budget_comparison' => array_fill_keys( $budget_keys, array( 'status' => 'not_measured', 'observed' => null ) ),
+		'hotspot_classification'    => array_fill_keys( $hotspot_classes, 0 ),
+		'query_attribution_summary' => array( 'source' => (string) ( $inputs['query_attribution_source'] ?? '' ), 'observed' => false ),
+		'connected_state_caveats'   => array_values( array_map( 'strval', is_array( $inputs['states'] ?? null ) ? $inputs['states'] : array() ) ),
+		'surface_rollups'           => array_fill_keys( $surfaces, array( 'status' => 'declared', 'artifact_inputs' => 0 ) ),
+		'budget_status'             => empty( $budget_keys ) ? 'not_declared' : 'not_measured',
+		'artifact_inputs'           => $surfaces,
+		'skip_reason_rollups'       => array_fill_keys( $skip_reason_codes, 0 ),
+		'metadata'                  => array( 'runner' => 'wp-codebox/fuzz-suite-runner/v1' ),
+	);
+
+	$written = array();
+	foreach ( $refs as $ref ) {
+		$result = self::write_fuzz_suite_declared_artifact( $summary, (string) ( $ref['path'] ?? '' ), 'summary' );
+		if ( is_wp_error( $result ) ) {
+			return array( 'status' => 'error', 'observation' => $observation, 'diagnostic' => self::fuzz_suite_diagnostic( 'error', $result->code, $result->get_error_message(), array( 'case_id' => $case_id ) ) );
+		}
+		$written[] = $result;
+	}
+
+	$observation['artifact_count'] = count( $written );
+	return array( 'status' => 'passed', 'observation' => $observation, 'artifactRefs' => $refs );
+}
+
 /** @param array<string,string> $args Args. @param array<string,mixed> $case Case. @param array<string,mixed> $observation Observation. @return array<string,mixed> */
 private static function execute_fuzz_suite_workload_step( array $args, string $command, array $case, array $observation, string $case_id ): array {
 	$path = (string) ( $args['path'] ?? $args['manifest'] ?? '' );
@@ -1351,6 +1396,27 @@ private static function write_fuzz_suite_workload_artifact( array $report, array
 	$encoded = wp_json_encode( $report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 	if ( ! is_string( $encoded ) || false === file_put_contents( $absolute, $encoded . "\n" ) ) {
 		return new WP_Error( 'wp_codebox_fuzz_workload_artifact_write_failed', 'JSON workload could not write the artifact JSON file.' );
+	}
+	return array( 'path' => $relative_path, 'bytes' => strlen( $encoded ) + 1 );
+}
+
+/** @param array<string,mixed> $report Report. @return array{path:string,bytes:int}|WP_Error */
+private static function write_fuzz_suite_declared_artifact( array $report, string $relative_path, string $label ): array|WP_Error {
+	if ( '' === $relative_path || str_starts_with( $relative_path, '/' ) || str_contains( $relative_path, '..' ) || str_contains( $relative_path, "\0" ) ) {
+		return new WP_Error( 'wp_codebox_fuzz_' . $label . '_artifact_path_invalid', 'Fuzz artifact summary requires safe relative declared artifact paths.' );
+	}
+
+	$upload_dir = function_exists( 'wp_upload_dir' ) ? wp_upload_dir( null, false ) : array();
+	$base_dir = is_array( $upload_dir ) && ! empty( $upload_dir['basedir'] ) ? (string) $upload_dir['basedir'] : rtrim( WP_CONTENT_DIR, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . 'uploads';
+	$absolute = rtrim( $base_dir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . str_replace( '/', DIRECTORY_SEPARATOR, $relative_path );
+	$directory = dirname( $absolute );
+	if ( ! self::ensure_fuzz_suite_directory( $directory ) ) {
+		return new WP_Error( 'wp_codebox_fuzz_' . $label . '_artifact_directory_failed', 'Fuzz artifact summary could not create the artifact directory.' );
+	}
+
+	$encoded = wp_json_encode( $report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	if ( ! is_string( $encoded ) || false === file_put_contents( $absolute, $encoded . "\n" ) ) {
+		return new WP_Error( 'wp_codebox_fuzz_' . $label . '_artifact_write_failed', 'Fuzz artifact summary could not write the artifact JSON file.' );
 	}
 	return array( 'path' => $relative_path, 'bytes' => strlen( $encoded ) + 1 );
 }

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -6,6 +6,7 @@ mkdir( $wp_codebox_smoke_root . 'wp-admin/includes', 0777, true );
 register_shutdown_function(
 	static function () use ( $wp_codebox_smoke_root ): void {
 		@unlink( $wp_codebox_smoke_root . 'rest-db-query-profile.workload.json' );
+		@unlink( $wp_codebox_smoke_root . 'closure-workload.php' );
 		@unlink( $wp_codebox_smoke_root . 'wp-admin/menu.php' );
 		@unlink( $wp_codebox_smoke_root . 'wp-admin/includes/admin.php' );
 		@rmdir( $wp_codebox_smoke_root . 'wp-admin/includes' );
@@ -18,9 +19,24 @@ file_put_contents(
 	$wp_codebox_smoke_root . 'wp-admin/menu.php',
 	"<?php\narray_keys( \$submenu );\n\$menu[2] = array( 'Loaded', 'read', 'loaded.php' );\n\$submenu['loaded.php'][0] = array( 'Loaded child', 'read', 'loaded-child.php' );\n"
 );
+file_put_contents(
+	$wp_codebox_smoke_root . 'closure-workload.php',
+	"<?php\nreturn function (): array {\n\twp_codebox_bench_run_external_http_guardrail_step( array( 'action' => 'install', 'allowlistDomains' => array( 'public-api.wordpress.com' ), 'blockNetwork' => true ) );\n\twp_remote_get( 'https://jetpack-homeboy-guardrail.invalid/guardrail-probe?token=secret-value' );\n\treturn wp_codebox_bench_run_external_http_guardrail_step( array( 'action' => 'collect' ) );\n};\n"
+);
 define( 'ABSPATH', $wp_codebox_smoke_root );
 define( 'WP_CONTENT_DIR', __DIR__ );
 define( 'ARRAY_A', 'ARRAY_A' );
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	$GLOBALS['wp_codebox_test_filters'][ $hook ][] = array( $callback, $accepted_args );
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array() as $filter ) {
+		$value = $filter[0]( $value, ...array_slice( $args, 0, (int) $filter[1] - 1 ) );
+	}
+	return $value;
+}
 
 class WP_Error {
 	public function __construct( public string $code = '', public string $message = '', public array $data = array() ) {}
@@ -44,10 +60,22 @@ function wp_parse_url( string $url, int $component = -1 ): mixed {
 }
 
 function wp_remote_request( string $url, array $args = array() ): array|WP_Error {
+	$preempt = apply_filters( 'pre_http_request', false, $args, $url );
+	if ( false !== $preempt ) {
+		return $preempt;
+	}
 	if ( str_contains( $url, '/server-error/' ) ) {
 		return array( 'status' => 500, 'headers' => array( 'content-type' => 'text/html' ), 'body' => 'error' );
 	}
 	return array( 'status' => 200, 'headers' => array( 'content-type' => 'text/html' ), 'body' => '<html></html>' );
+}
+
+function wp_remote_get( string $url, array $args = array() ): array|WP_Error {
+	return wp_remote_request( $url, array_merge( $args, array( 'method' => 'GET' ) ) );
+}
+
+function wp_remote_post( string $url, array $args = array() ): array|WP_Error {
+	return wp_remote_request( $url, array_merge( $args, array( 'method' => 'POST' ) ) );
 }
 
 function wp_remote_retrieve_response_code( array $response ): int {
@@ -385,6 +413,16 @@ $result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 					array( 'name' => 'workload_result', 'path' => 'workloads/rest-db-query-profile.json', 'metadata' => array( 'semantic_key' => 'fuzz.report' ) ),
 				),
 			),
+			array(
+				'id'       => 'closure-external-http-guardrail',
+				'metadata' => array( 'skip_reasons' => array( array( 'code' => 'metadata_code_is_not_executable' ) ) ),
+				'phases'   => array(
+					'action' => array(
+						array( 'command' => 'wordpress.ensure-external-http-guardrail', 'args' => array( 'allowlist=public-api.wordpress.com', 'block_network=true' ) ),
+						array( 'command' => 'wordpress.run-workload', 'args' => array( 'path=' . $wp_codebox_smoke_root . 'closure-workload.php', 'type=php' ) ),
+					),
+				),
+			),
 		),
 	)
 );
@@ -397,8 +435,8 @@ assert( '/wc/store/v1/products' === $GLOBALS['wp']->query_vars['rest_route'] );
 assert( '/wc/store/v1/products' === $_GET['rest_route'] );
 assert( null === $GLOBALS['wp_codebox_rest_server_route_contexts'][0]['wp_rest_route'] );
 assert( null === $GLOBALS['wp_codebox_rest_server_route_contexts'][0]['get_rest_route'] );
-assert( 22 === $result['summary']['total'] );
-assert( 11 === $result['summary']['passed'] );
+assert( 23 === $result['summary']['total'] );
+assert( 12 === $result['summary']['passed'] );
 assert( 11 === $result['summary']['skipped'] );
 assert( 'browser-coverage' === $result['cases'][0]['id'] );
 assert( 'passed' === $result['cases'][0]['status'] );
@@ -464,6 +502,12 @@ assert( 'wp-codebox/json-workload-result/v1' === $workload_report['schema'] );
 assert( 2 === $workload_report['steps'][1]['observation']['queryCount'] );
 assert( 2 === $workload_report['steps'][1]['requests'][0]['queryCount'] );
 assert( 'SELECT * FROM wp_posts WHERE post_type = "post"' === $workload_report['steps'][1]['requests'][0]['sampledQueries'][0]['sql'] );
+assert( 'closure-external-http-guardrail' === $result['cases'][22]['id'] );
+assert( 'passed' === $result['cases'][22]['status'] );
+assert( 'array' === $result['cases'][22]['metadata']['observations'][1]['return_type'] );
+assert( 'wp-codebox/external-http-guardrail/v1' === $result['cases'][22]['metadata']['observations'][1]['payload']['schema'] );
+assert( 1 === $result['cases'][22]['metadata']['observations'][1]['payload']['summary']['blocked'] );
+assert( str_contains( $result['cases'][22]['metadata']['observations'][1]['payload']['requests'][0]['url'], 'token=[redacted]' ) );
 assert( 'php-in-process' === $result['metadata']['runnerCapabilities']['mode'] );
 assert( in_array( 'target:rest', $result['metadata']['runnerCapabilities']['capabilities'], true ) );
 

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -263,6 +263,24 @@ $result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 				),
 			),
 			array(
+				'id'        => 'artifact-summary',
+				'inputs'    => array(
+					'observation_surfaces'     => array( 'rest_generated_cases', 'db_query_profile' ),
+					'budget_keys'              => array( 'max_rest_p95_duration_ms' ),
+					'hotspot_classes'          => array( 'slow-rest-route' ),
+					'query_attribution_source' => 'rest_db_query_profile',
+					'skip_reason_codes'        => array( 'connection_required' ),
+				),
+				'phases'    => array(
+					'action' => array(
+						array( 'command' => 'wordpress.summarize-fuzz-artifacts', 'args' => array( 'surface=jetpack-performance', 'include=timing,queries' ) ),
+					),
+				),
+				'artifacts' => array(
+					array( 'name' => 'summary', 'path' => 'summary/performance-summary.json', 'metadata' => array( 'semantic_key' => 'fuzz.report' ) ),
+				),
+			),
+			array(
 				'id'     => 'runtime-action-rest',
 				'target' => array( 'kind' => 'runtime-action' ),
 				'input'  => array( 'type' => 'rest_request', 'path' => '/wp/v2/status', 'method' => 'GET' ),
@@ -379,8 +397,8 @@ assert( '/wc/store/v1/products' === $GLOBALS['wp']->query_vars['rest_route'] );
 assert( '/wc/store/v1/products' === $_GET['rest_route'] );
 assert( null === $GLOBALS['wp_codebox_rest_server_route_contexts'][0]['wp_rest_route'] );
 assert( null === $GLOBALS['wp_codebox_rest_server_route_contexts'][0]['get_rest_route'] );
-assert( 21 === $result['summary']['total'] );
-assert( 10 === $result['summary']['passed'] );
+assert( 22 === $result['summary']['total'] );
+assert( 11 === $result['summary']['passed'] );
 assert( 11 === $result['summary']['skipped'] );
 assert( 'browser-coverage' === $result['cases'][0]['id'] );
 assert( 'passed' === $result['cases'][0]['status'] );
@@ -392,46 +410,52 @@ assert( 'collect-artifact' === $result['cases'][1]['id'] );
 assert( 'passed' === $result['cases'][1]['status'] );
 assert( 'browser-coverage/frontend_rendering_request_coverage.json' === $result['artifactRefs'][0]['path'] );
 assert( 'wp_codebox_fuzz_step_unsupported' === $result['cases'][2]['diagnostics'][0]['code'] );
-assert( 'runtime-action-rest' === $result['cases'][3]['id'] );
+assert( 'artifact-summary' === $result['cases'][3]['id'] );
 assert( 'passed' === $result['cases'][3]['status'] );
-assert( 'wordpress.rest-request' === $result['cases'][3]['metadata']['observations'][0]['command'] );
+assert( is_file( WP_CONTENT_DIR . '/uploads/summary/performance-summary.json' ) );
+$summary_report = json_decode( file_get_contents( WP_CONTENT_DIR . '/uploads/summary/performance-summary.json' ), true );
+assert( 'wp-codebox/fuzz-artifact-summary/v1' === $summary_report['schema'] );
+assert( 'not_measured' === $summary_report['budget_status'] );
+assert( 'runtime-action-rest' === $result['cases'][4]['id'] );
 assert( 'passed' === $result['cases'][4]['status'] );
+assert( 'wordpress.rest-request' === $result['cases'][4]['metadata']['observations'][0]['command'] );
 assert( 'passed' === $result['cases'][5]['status'] );
-assert( 'rest-route-inventory' === $result['cases'][5]['id'] );
-assert( 1 === $result['cases'][5]['metadata']['observations'][0]['route_count'] );
-assert( 'sample' === $result['cases'][5]['metadata']['observations'][0]['namespaces'][0] );
 assert( 'passed' === $result['cases'][6]['status'] );
-assert( 'database-inventory' === $result['cases'][6]['id'] );
-assert( 2 === $result['cases'][6]['metadata']['observations'][0]['table_count'] );
-assert( 'wp-codebox/wordpress-database-inventory/v1' === $result['cases'][6]['metadata']['observations'][0]['payload']['schema'] );
-assert( 'core' === $result['cases'][6]['metadata']['observations'][0]['payload']['tables'][0]['classification'] );
-assert( 'prefixed' === $result['cases'][6]['metadata']['observations'][0]['payload']['tables'][1]['classification'] );
+assert( 'rest-route-inventory' === $result['cases'][6]['id'] );
+assert( 1 === $result['cases'][6]['metadata']['observations'][0]['route_count'] );
+assert( 'sample' === $result['cases'][6]['metadata']['observations'][0]['namespaces'][0] );
 assert( 'passed' === $result['cases'][7]['status'] );
-assert( 'admin-page-coverage' === $result['cases'][7]['id'] );
-assert( 3 === $result['cases'][7]['metadata']['observations'][0]['target_count'] );
-assert( 1 === $result['cases'][7]['metadata']['observations'][0]['skipped_count'] );
-assert( 'wp-codebox/wordpress-admin-page-coverage/v1' === $result['cases'][7]['metadata']['observations'][0]['payload']['schema'] );
-assert( 'https://example.test/wp-admin/edit.php?post_type=product' === $result['cases'][7]['metadata']['observations'][0]['payload']['targets'][1]['canonicalUrl'] );
+assert( 'database-inventory' === $result['cases'][7]['id'] );
+assert( 2 === $result['cases'][7]['metadata']['observations'][0]['table_count'] );
+assert( 'wp-codebox/wordpress-database-inventory/v1' === $result['cases'][7]['metadata']['observations'][0]['payload']['schema'] );
+assert( 'core' === $result['cases'][7]['metadata']['observations'][0]['payload']['tables'][0]['classification'] );
+assert( 'prefixed' === $result['cases'][7]['metadata']['observations'][0]['payload']['tables'][1]['classification'] );
 assert( 'passed' === $result['cases'][8]['status'] );
+assert( 'admin-page-coverage' === $result['cases'][8]['id'] );
+assert( 3 === $result['cases'][8]['metadata']['observations'][0]['target_count'] );
+assert( 1 === $result['cases'][8]['metadata']['observations'][0]['skipped_count'] );
+assert( 'wp-codebox/wordpress-admin-page-coverage/v1' === $result['cases'][8]['metadata']['observations'][0]['payload']['schema'] );
+assert( 'https://example.test/wp-admin/edit.php?post_type=product' === $result['cases'][8]['metadata']['observations'][0]['payload']['targets'][1]['canonicalUrl'] );
 assert( 'passed' === $result['cases'][9]['status'] );
-assert( 'command-target' === $result['cases'][10]['id'] );
-assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][10]['skipReason'] );
-assert( 'runtime-target' === $result['cases'][11]['id'] );
+assert( 'passed' === $result['cases'][10]['status'] );
+assert( 'command-target' === $result['cases'][11]['id'] );
 assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][11]['skipReason'] );
-assert( 'runtime-action-wp-cli' === $result['cases'][12]['id'] );
-assert( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported' === $result['cases'][12]['skipReason'] );
-assert( 'wordpress.wp-cli' === $result['cases'][12]['metadata']['observations'][0]['command'] );
-assert( 'wp_codebox_fuzz_runtime_action_php_unsupported' === $result['cases'][13]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_browser_unsupported' === $result['cases'][14]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported' === $result['cases'][15]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported' === $result['cases'][16]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported' === $result['cases'][17]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_page_unsupported' === $result['cases'][18]['skipReason'] );
-assert( 'wp_codebox_fuzz_runtime_action_unsupported' === $result['cases'][19]['skipReason'] );
-assert( 'json-workload-profiler' === $result['cases'][20]['id'] );
-assert( 'passed' === $result['cases'][20]['status'] );
-assert( 'workloads/rest-db-query-profile.json' === $result['cases'][20]['metadata']['observations'][0]['artifact'] );
-assert( 'array' !== ( $result['cases'][20]['metadata']['observations'][0]['return_type'] ?? null ) );
+assert( 'runtime-target' === $result['cases'][12]['id'] );
+assert( 'wp_codebox_fuzz_target_command_unsupported' === $result['cases'][12]['skipReason'] );
+assert( 'runtime-action-wp-cli' === $result['cases'][13]['id'] );
+assert( 'wp_codebox_fuzz_runtime_action_wp_cli_unsupported' === $result['cases'][13]['skipReason'] );
+assert( 'wordpress.wp-cli' === $result['cases'][13]['metadata']['observations'][0]['command'] );
+assert( 'wp_codebox_fuzz_runtime_action_php_unsupported' === $result['cases'][14]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_unsupported' === $result['cases'][15]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_browser_probe_unsupported' === $result['cases'][16]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_editor_open_unsupported' === $result['cases'][17]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_admin_page_unsupported' === $result['cases'][18]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_page_unsupported' === $result['cases'][19]['skipReason'] );
+assert( 'wp_codebox_fuzz_runtime_action_unsupported' === $result['cases'][20]['skipReason'] );
+assert( 'json-workload-profiler' === $result['cases'][21]['id'] );
+assert( 'passed' === $result['cases'][21]['status'] );
+assert( 'workloads/rest-db-query-profile.json' === $result['cases'][21]['metadata']['observations'][0]['artifact'] );
+assert( 'array' !== ( $result['cases'][21]['metadata']['observations'][0]['return_type'] ?? null ) );
 assert( is_file( WP_CONTENT_DIR . '/uploads/workloads/rest-db-query-profile.json' ) );
 $workload_report = json_decode( file_get_contents( WP_CONTENT_DIR . '/uploads/workloads/rest-db-query-profile.json' ), true );
 assert( 'wp-codebox/json-workload-result/v1' === $workload_report['schema'] );

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -416,6 +416,8 @@ assert( is_file( WP_CONTENT_DIR . '/uploads/summary/performance-summary.json' ) 
 $summary_report = json_decode( file_get_contents( WP_CONTENT_DIR . '/uploads/summary/performance-summary.json' ), true );
 assert( 'wp-codebox/fuzz-artifact-summary/v1' === $summary_report['schema'] );
 assert( 'not_measured' === $summary_report['budget_status'] );
+assert( 'wp-codebox/fuzz-artifact-summary/v1' === $result['cases'][3]['artifactRefs'][0]['payload']['schema'] );
+assert( 'not_measured' === $result['cases'][3]['artifactRefs'][0]['payload']['budget_status'] );
 assert( 'runtime-action-rest' === $result['cases'][4]['id'] );
 assert( 'passed' === $result['cases'][4]['status'] );
 assert( 'wordpress.rest-request' === $result['cases'][4]['metadata']['observations'][0]['command'] );


### PR DESCRIPTION
## Summary

- Add support for `wordpress.summarize-fuzz-artifacts` in the PHP fuzz runner.
- Embed generated fuzz summary payloads in artifact refs for reviewer-visible analysis.
- Preserve and merge enriched artifact refs during dedupe.
- Support closure-returning PHP workloads.
- Add a generic read-only external HTTP guardrail primitive for fuzz workloads.
- Aggregate measured observations into budget comparison and hotspot classification summaries.

## Validation

- `php scripts/php-fuzz-suite-runner-smoke.php`
- `npm run build`
- Used by Jetpack Lab fuzz evidence run `jetpack-performance-observation-20260623-measure5`.

## Evidence

- Final Jetpack measured fuzz run passed on Lab.
- Evidence artifact: `runner-artifact://homeboy-lab/jetpack-performance-observation-20260623-measure5/e6d6a4d4-da3f-4606-ad1e-35ee20efc62c`
- The summary payload reports `budget_status: exceeded` due to external HTTP attempts `2 / 0`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing generic fuzz summary and guardrail support, adding smoke coverage, running builds, and validating against Jetpack Lab fuzz evidence.
