### PR TITLE
Expose runtime-backed WordPress fuzz suite execution

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -88,6 +88,14 @@ mode supports `runtime`, browser/editor/page-load action targets, and the
 caller requests required coverage, pass `requireCoverage: true`; unsupported
 required capabilities fail closed with `status: "error"` instead of looking like a
 successful structured skip.
+
+TypeScript callers running against a contained WordPress runtime episode should use
+`executeWordPressFuzzSuite()` from `@automattic/wp-codebox-playground/public`.
+That helper wires the public fuzz suite contract to the episode command path,
+runtime-action executor, and `RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES` so
+orchestrators can distinguish runtime-backed coverage from the WordPress plugin's
+safe PHP in-process mode. Use `createWordPressFuzzSuiteCommandExecutor()` only
+when composing a custom fuzz runner around an existing `RuntimeEpisode`.
 Documented skip reason codes are:
 
 - `wp_codebox_fuzz_target_command_unsupported`
@@ -187,7 +195,11 @@ The stable public surface is grouped by lifecycle area rather than by product:
   endpoint, REST route, or runtime action. Canonical target kinds are `ability`,
   `command`, `http`, `rest`, `runtime`, and `runtime-action`. Runtime actions use
   the same public action types as `@automattic/wp-codebox-playground/public` where
-  a runner can execute them directly; command-backed runners map safe
+  a runner can execute them directly. Runtime-backed TypeScript callers can
+  pass an existing `RuntimeEpisode` to `executeWordPressFuzzSuite()` from
+  `@automattic/wp-codebox-playground/public` for runtime-backed coverage;
+  PHP/plugin callers continue to advertise `php-in-process` capabilities for the
+  safe in-process path. Command-backed runners map safe
   `rest_request` actions to `wordpress.rest-request` and `wp_cli` actions to
   `wordpress.wp-cli`, while episode-only/browser actions remain structured
   skips. `wp-codebox/fuzz-suite-result/v1` reports case status, diagnostics,

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "test:recipe-runtime-backend-normalization": "tsx tests/recipe-runtime-backend-normalization.test.ts",
     "test:fuzz-run-recipe": "tsx tests/fuzz-run-recipe.test.ts",
     "test:fuzz-suite-runner": "tsx tests/fuzz-suite-runner.test.ts",
+    "test:playground-fuzz-suite-public": "tsx tests/playground-fuzz-suite-public.test.ts",
     "test:wordpress-fuzz-suite-builders": "tsx tests/wordpress-fuzz-suite-builders.test.ts",
     "test:recipe-secret-env": "tsx tests/recipe-secret-env.test.ts",
     "test:preview-options": "tsx tests/preview-options.test.ts",

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -1,10 +1,12 @@
 import {
   createRuntime,
   createRuntimeEpisode,
+  executeFuzzSuite,
   openWordPressAdminPage,
   openWordPressEditor,
   probeWordPressBrowser,
   requestWordPressRest,
+  RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
   runWordPressCrudOperation,
   runWordPressBrowserAction,
   runWordPressPhp,
@@ -12,7 +14,13 @@ import {
   visitWordPressPage,
   type ArtifactBundle,
   type ArtifactSpec,
+  type ExecutionResult,
+  type ExecutionSpec,
+  type FuzzSuiteCommandExecutor,
+  type FuzzSuiteContract,
+  type FuzzSuiteResultEnvelope,
   type FuzzSuiteRuntimeActionExecutor,
+  type FuzzSuiteRunOptions,
   type ObservationSpec,
   type Runtime,
   type RuntimeCreateSpec,
@@ -93,6 +101,8 @@ export interface WordPressPageLoadActionOptions {
   captureDiagnostics?: string[]
 }
 
+export type WordPressFuzzSuiteExecutionOptions = Omit<FuzzSuiteRunOptions, "executor" | "runtimeActionExecutor" | "runnerCapabilities">
+
 export async function createWordPressRuntime(spec: WordPressRuntimeSpec, options: PlaygroundRuntimeBackendOptions = {}): Promise<Runtime> {
   return createRuntime(wordPressRuntimeCreateSpec(spec), createPlaygroundRuntimeBackend(options))
 }
@@ -165,6 +175,33 @@ export function createWordPressFuzzSuiteRuntimeActionExecutor(episode: Pick<Runt
       throw new Error(`Unsupported WordPress fuzz runtime-action type: ${action.type}`)
     },
   }
+}
+
+export function createWordPressFuzzSuiteCommandExecutor(episode: Pick<RuntimeEpisode, "step">): FuzzSuiteCommandExecutor {
+  return {
+    async execute(spec: ExecutionSpec): Promise<ExecutionResult> {
+      const step = await episode.step({ kind: "command", ...spec }, { type: "command-result" })
+      return step.execution
+    },
+  }
+}
+
+export function executeWordPressFuzzSuite(
+  episode: Pick<RuntimeEpisode, "step">,
+  suite: FuzzSuiteContract,
+  options: WordPressFuzzSuiteExecutionOptions = {},
+): Promise<FuzzSuiteResultEnvelope> {
+  return executeFuzzSuite(suite, {
+    ...options,
+    executor: createWordPressFuzzSuiteCommandExecutor(episode),
+    runtimeActionExecutor: createWordPressFuzzSuiteRuntimeActionExecutor(episode),
+    runnerCapabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
+    metadata: {
+      ...options.metadata,
+      runnerMode: "runtime-backed",
+      runtimeBackend: "wordpress-playground",
+    },
+  })
 }
 
 export async function collectWordPressRuntimeArtifacts(runtime: Pick<Runtime, "collectArtifacts">, spec?: ArtifactSpec): Promise<ArtifactBundle> {

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict"
+
+import { fuzzSuiteContract, type RuntimeEpisodeStepResult } from "../packages/runtime-core/src/public.js"
+import { createWordPressFuzzSuiteCommandExecutor, executeWordPressFuzzSuite } from "../packages/runtime-playground/src/public.js"
+
+const steps: Array<{ command: string; args?: string[]; observation?: unknown }> = []
+const episode = {
+  async step(action: { command: string; args?: string[] }, observation?: unknown): Promise<RuntimeEpisodeStepResult> {
+    steps.push({ command: action.command, args: action.args, observation })
+    const index = steps.length
+    return {
+      id: `step-${index}`,
+      index,
+      action: {
+        schema: "wp-codebox/runtime-episode-action/v1",
+        id: `action-${index}`,
+        kind: "command",
+        command: action.command,
+        args: action.args ?? [],
+        digest: { algorithm: "sha256", value: `action-${index}` },
+      },
+      actionRef: { kind: "action", id: `action-${index}` },
+      execution: {
+        id: `execution-${index}`,
+        command: action.command,
+        args: action.args ?? [],
+        exitCode: 0,
+        stdout: "ok",
+        stderr: "",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:00:01.000Z",
+        artifactRefs: [{ kind: "execution", id: `artifact-${index}`, path: `files/execution-${index}.json` }],
+      },
+      executionRef: { kind: "execution", id: `execution-${index}` },
+    }
+  },
+}
+
+const commandExecutor = createWordPressFuzzSuiteCommandExecutor(episode)
+const execution = await commandExecutor.execute({ command: "wordpress.rest-request", args: ["path=/wp/v2/types"] })
+assert.equal(execution.id, "execution-1")
+assert.equal(steps[0]?.command, "wordpress.rest-request")
+assert.deepEqual(steps[0]?.observation, { type: "command-result" })
+
+const result = await executeWordPressFuzzSuite(episode, fuzzSuiteContract({
+  id: "runtime-backed-suite",
+  cases: [
+    { id: "rest", target: { kind: "rest", id: "/wp/v2/types" }, input: { method: "GET" } },
+    { id: "browser", target: { kind: "runtime-action" }, input: { type: "browser", operation: "navigate", url: "/" } },
+  ],
+}), { requireCoverage: true })
+
+assert.equal(result.status, "passed")
+assert.equal(result.success, true)
+assert.equal(result.metadata?.runnerMode, "runtime-backed")
+assert.equal(result.metadata?.runtimeBackend, "wordpress-playground")
+assert.equal((result.metadata?.runnerCapabilities as { mode?: string } | undefined)?.mode, "runtime-backed")
+assert.deepEqual(steps.map((step) => step.command), ["wordpress.rest-request", "wordpress.rest-request", "wordpress.browser-actions"])
+
+console.log("playground fuzz suite public ok")


### PR DESCRIPTION
## Summary
- add a public TypeScript helper for executing `wp-codebox/fuzz-suite/v1` through a WordPress runtime episode
- add a command executor adapter that routes fuzz execution specs through `RuntimeEpisode.step()`
- tag runtime-backed results with runner metadata and document the public boundary

## Testing
- `npm run test:fuzz-suite-runner`
- `npm run test:playground-fuzz-suite-public`
- `npm run test:public-api-contract`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing the public API gap, drafting the runtime-backed fuzz boundary, and running verification.