### PR TITLE
Share recipe plugin preload for activation

### DIFF
--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -1,7 +1,7 @@
 import { cp, mkdtemp, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
-import { phpRuntimeComponentLifecycleReplayFunction, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe } from "@automattic/wp-codebox-core"
+import { phpRuntimeRecipePluginPreloadFunction, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe } from "@automattic/wp-codebox-core"
 import { installMuPluginsCode, installPluginComposerAutoloadersCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspacePreloads, prepareRecipeWorkspaces, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { pluginRuntimeHealthProbeStep, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex } from "../recipe-dry-run.js"
@@ -395,72 +395,47 @@ function shouldCopyInputMountBaselineEntry(sourceRoot: string, entry: string): b
 }
 
 function activateExtraPluginCode(plugin: PreparedExtraPlugin): string {
-  const pluginFile = plugin.pluginFile
-  return `${phpRuntimeComponentLifecycleReplayFunction("wp_codebox_activate_plugin")}
-$plugin_file = ${JSON.stringify(pluginFile)};
+  const pluginMetadata = {
+    slug: plugin.slug,
+    pluginFile: plugin.pluginFile,
+    target: plugin.target,
+  }
+  const encodedPluginMetadata = Buffer.from(JSON.stringify(pluginMetadata), "utf8").toString("base64")
+  return `${phpRuntimeRecipePluginPreloadFunction("wp_codebox_activate_plugin")}
+$plugin = json_decode(base64_decode('${encodedPluginMetadata}'), true);
+if (!is_array($plugin)) {
+    throw new RuntimeException('Could not decode recipe plugin activation metadata.');
+}
+$plugin_file = ${JSON.stringify(plugin.pluginFile)};
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
-$plugin_dir = dirname($plugin_file);
-$plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
-$plugin_package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
-register_shutdown_function(static function () use ($plugin_file, $plugin_dir, $plugin_autoload, $plugin_package_autoload): void {
+register_shutdown_function(static function () use ($plugin, $plugin_file): void {
     $fatal = error_get_last();
     if (!is_array($fatal) || !in_array($fatal['type'] ?? 0, array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR), true)) {
         return;
     }
-
-    $message = isset($fatal['message']) ? (string) $fatal['message'] : '';
-    $missing_class = null;
+    $diagnostic = wp_codebox_activate_plugin_recipe_plugin_preload_diagnostic($plugin, 'activation-recipe-plugin', isset($fatal['message']) ? (string) $fatal['message'] : '');
+    $message = $diagnostic['error'];
     if (preg_match('/Class "([^"]+)" not found/', $message, $matches)) {
-        $missing_class = $matches[1];
-    }
-
-    $classmap = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/composer/autoload_classmap.php';
-    $classmap_entry = null;
-    if (is_string($missing_class) && is_file($classmap)) {
-        $classmap_data = include $classmap;
-        if (is_array($classmap_data) && isset($classmap_data[$missing_class])) {
-            $classmap_entry = (string) $classmap_data[$missing_class];
+        $diagnostic['missing_class'] = $matches[1];
+        $classmap = $diagnostic['classmap']['path'];
+        if (is_string($classmap) && is_file($classmap)) {
+            $classmap_data = include $classmap;
+            if (is_array($classmap_data) && isset($classmap_data[$diagnostic['missing_class']])) {
+                $diagnostic['classmap']['entry'] = (string) $classmap_data[$diagnostic['missing_class']];
+                $diagnostic['classmap']['entry_exists'] = is_file($diagnostic['classmap']['entry']);
+            }
         }
+        $diagnostic['class_exists'] = array(
+            'without_autoload' => class_exists($diagnostic['missing_class'], false),
+            'with_autoload' => class_exists($diagnostic['missing_class'], true),
+        );
     }
-
-    $included_files = array_map(static fn($file) => realpath($file) ?: $file, get_included_files());
-    echo "\nWP_CODEBOX_PLUGIN_AUTOLOAD_DIAGNOSTIC:" . wp_json_encode(array(
-        'schema' => 'wp-codebox/plugin-autoload-diagnostic/v1',
-        'plugin_file' => $plugin_file,
-        'plugin_dir' => $plugin_dir,
+    echo "\nWP_CODEBOX_PLUGIN_PRELOAD_DIAGNOSTIC:" . wp_json_encode(array(
+        ...$diagnostic,
         'fatal_message' => $message,
-        'missing_class' => $missing_class,
-        'autoload' => array(
-            'path' => $plugin_autoload,
-            'exists' => is_file($plugin_autoload),
-            'readable' => is_readable($plugin_autoload),
-            'included' => in_array(realpath($plugin_autoload) ?: $plugin_autoload, $included_files, true),
-        ),
-        'package_autoload' => array(
-            'path' => $plugin_package_autoload,
-            'exists' => is_file($plugin_package_autoload),
-            'readable' => is_readable($plugin_package_autoload),
-            'included' => in_array(realpath($plugin_package_autoload) ?: $plugin_package_autoload, $included_files, true),
-        ),
-        'classmap' => array(
-            'path' => $classmap,
-            'exists' => is_file($classmap),
-            'readable' => is_readable($classmap),
-            'entry' => $classmap_entry,
-            'entry_exists' => is_string($classmap_entry) ? is_file($classmap_entry) : null,
-        ),
-        'class_exists' => is_string($missing_class) ? array(
-            'without_autoload' => class_exists($missing_class, false),
-            'with_autoload' => class_exists($missing_class, true),
-        ) : null,
     ), JSON_UNESCAPED_SLASHES) . "\n";
 });
-if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
-    require_once $plugin_autoload;
-}
-if ('.' !== $plugin_dir && is_file($plugin_package_autoload)) {
-    require_once $plugin_package_autoload;
-}
+wp_codebox_activate_plugin_preload_recipe_plugin($plugin, false, 'activation-recipe-plugin', 'recipe-runtime-setup activate_plugin');
 if (is_plugin_active($plugin_file)) {
     deactivate_plugins($plugin_file, true, false);
 }

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -334,6 +334,7 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
       }),
       cwd: stagedSource,
     })
+    await writeComposerInstalledPackageAutoloader(stagedSource)
   } catch (error) {
     await rm(stagingRoot, { recursive: true, force: true })
     const detail = error instanceof Error && "stderr" in error && typeof error.stderr === "string" && error.stderr.trim() ? error.stderr.trim() : error instanceof Error ? error.message : String(error)
@@ -349,6 +350,90 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
       localPathCategory: "temporary-composer-autoload",
     },
   }
+}
+
+async function writeComposerInstalledPackageAutoloader(pluginSource: string): Promise<void> {
+  const packageAutoloader = join(pluginSource, "vendor", "autoload_packages.php")
+  if (await pathIsFile(packageAutoloader)) {
+    await bridgePackageAutoloaderToComposerAutoload(packageAutoloader)
+    return
+  }
+
+  const installedPath = join(pluginSource, "vendor", "composer", "installed.json")
+  if (!await pathIsFile(installedPath)) {
+    return
+  }
+  const installed = JSON.parse(await readFile(installedPath, "utf8")) as unknown
+  const classmapPaths = composerInstalledPackages(installed).flatMap((pkg) => composerInstalledPackageClassmapPaths(pkg))
+  const classmapFiles = (await Promise.all(classmapPaths.map((path) => composerInstalledPackageClassmapFiles(pluginSource, path)))).flat()
+  if (classmapFiles.length === 0) {
+    return
+  }
+
+  const uniqueFiles = [...new Set(classmapFiles)]
+  const fileLines = uniqueFiles.map((path) => `    __DIR__ . ${JSON.stringify(`/composer/${path}`)},`).join("\n")
+  await writeFile(packageAutoloader, `<?php
+defined( 'ABSPATH' ) || exit;
+
+$wp_codebox_composer_package_classmap_files = array(
+${fileLines}
+);
+
+foreach ($wp_codebox_composer_package_classmap_files as $file) {
+    if (is_file($file)) {
+        require_once $file;
+    }
+}
+`)
+}
+
+async function composerInstalledPackageClassmapFiles(pluginSource: string, classmapPath: string): Promise<string[]> {
+  const absolutePath = join(pluginSource, "vendor", "composer", classmapPath)
+  if (await pathIsFile(absolutePath)) {
+    return [classmapPath]
+  }
+  if (!await pathIsDirectory(absolutePath)) {
+    return []
+  }
+  const files: string[] = []
+  await collectPhpFiles(absolutePath, classmapPath.replace(/\/+$/, ""), files)
+  return files
+}
+
+async function collectPhpFiles(directory: string, relativeDirectory: string, files: string[]): Promise<void> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const absolutePath = join(directory, entry.name)
+    const relativePath = `${relativeDirectory}/${entry.name}`.replace(/^\/+/, "")
+    if (entry.isDirectory()) {
+      await collectPhpFiles(absolutePath, relativePath, files)
+      continue
+    }
+    if (entry.isFile() && entry.name.endsWith(".php")) {
+      files.push(relativePath)
+    }
+  }
+}
+
+async function bridgePackageAutoloaderToComposerAutoload(packageAutoloader: string): Promise<void> {
+  const bridge = "require_once __DIR__ . '/autoload.php';"
+  const contents = await readFile(packageAutoloader, "utf8")
+  if (contents.includes(bridge)) {
+    return
+  }
+  const initCall = "Autoloader::init();"
+  const bridged = contents.includes(initCall) ? contents.replace(initCall, `${bridge}\n${initCall}`) : `${contents.trimEnd()}\n${bridge}\n`
+  await writeFile(packageAutoloader, bridged)
+}
+
+function composerInstalledPackageClassmapPaths(pkg: ComposerInstalledPackage): string[] {
+  if (typeof pkg["install-path"] !== "string") {
+    return []
+  }
+  const classmap = pkg.autoload?.classmap
+  const entries = Array.isArray(classmap) ? classmap : typeof classmap === "string" ? [classmap] : []
+  return entries
+    .filter((entry): entry is string => typeof entry === "string" && entry.length > 0 && !isAbsolute(entry) && !entry.includes(".."))
+    .map((entry) => `${pkg["install-path"]!.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "")}/${entry.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "")}`)
 }
 
 export async function prepareRecipeDependencyOverlays(recipe: WorkspaceRecipe, recipeDirectory: string, extraPlugins: PreparedExtraPlugin[]): Promise<PreparedDependencyOverlay[]> {
@@ -913,7 +998,8 @@ function escapeRegExp(value: string): string {
 
 interface ComposerInstalledPackage {
   name: string
-  autoload?: { "psr-4"?: Record<string, string | string[]> }
+  "install-path"?: string
+  autoload?: { "psr-4"?: Record<string, string | string[]>; classmap?: string | string[] }
 }
 
 function composerInstalledPackages(installed: unknown): ComposerInstalledPackage[] {

--- a/packages/runtime-core/src/runtime-php-snippets.ts
+++ b/packages/runtime-core/src/runtime-php-snippets.ts
@@ -122,6 +122,102 @@ function ${complete}(array $state): array {
 }`
 }
 
+export function phpRuntimeRecipePluginPreloadFunction(prefix: string): string {
+  const diagnostic = `${prefix}_recipe_plugin_preload_diagnostic`
+  const diagnosticString = `${prefix}_recipe_plugin_preload_diagnostic_string`
+  const preload = `${prefix}_preload_recipe_plugin`
+  const prepare = `${prefix}_component_lifecycle_replay_prepare`
+  const complete = `${prefix}_component_lifecycle_replay_complete`
+
+  return `${phpRuntimeComponentLifecycleReplayFunction(prefix)}
+if (!function_exists('${preload}')) {
+function ${diagnostic}(array $plugin, string $role, string $error = ''): array {
+    $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
+    $plugin_dir = dirname($plugin_file);
+    $absolute_plugin_file = defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR . '/' . $plugin_file : $plugin_file;
+    $real_plugin_file = realpath($absolute_plugin_file);
+    $included_files = array_map(static fn($file) => realpath($file) ?: $file, get_included_files());
+    $autoload = defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php' : '';
+    $package_autoload = defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php' : '';
+    $classmap = defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/composer/autoload_classmap.php' : '';
+    return array(
+        'schema' => 'wp-codebox/recipe-plugin-preload-diagnostic/v1',
+        'role' => $role,
+        'plugin_slug' => isset($plugin['slug']) ? (string) $plugin['slug'] : dirname($plugin_file),
+        'plugin_file' => $plugin_file,
+        'plugin_dir' => $plugin_dir,
+        'mounted_path' => isset($plugin['target']) ? (string) $plugin['target'] : (defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR . '/' . dirname($plugin_file) : ''),
+        'expected_file_path' => $absolute_plugin_file,
+        'file_exists' => is_file($absolute_plugin_file),
+        'file_readable' => is_readable($absolute_plugin_file),
+        'active' => function_exists('is_plugin_active') ? is_plugin_active($plugin_file) : null,
+        'included' => in_array($real_plugin_file ?: $absolute_plugin_file, $included_files, true),
+        'wp_plugin_dir' => defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR : null,
+        'autoload' => array(
+            'path' => $autoload,
+            'exists' => $autoload !== '' ? is_file($autoload) : false,
+            'readable' => $autoload !== '' ? is_readable($autoload) : false,
+            'included' => $autoload !== '' ? in_array(realpath($autoload) ?: $autoload, $included_files, true) : false,
+        ),
+        'package_autoload' => array(
+            'path' => $package_autoload,
+            'exists' => $package_autoload !== '' ? is_file($package_autoload) : false,
+            'readable' => $package_autoload !== '' ? is_readable($package_autoload) : false,
+            'size' => ($package_autoload !== '' && is_file($package_autoload)) ? filesize($package_autoload) : null,
+            'sha1' => ($package_autoload !== '' && is_file($package_autoload)) ? sha1_file($package_autoload) : null,
+            'included' => $package_autoload !== '' ? in_array(realpath($package_autoload) ?: $package_autoload, $included_files, true) : false,
+        ),
+        'classmap' => array(
+            'path' => $classmap,
+            'exists' => $classmap !== '' ? is_file($classmap) : false,
+            'readable' => $classmap !== '' ? is_readable($classmap) : false,
+        ),
+        'error' => $error,
+    );
+}
+function ${diagnosticString}(array $plugin, string $role, string $error = ''): string {
+    $diagnostic = ${diagnostic}($plugin, $role, $error);
+    $json = function_exists('wp_json_encode') ? wp_json_encode($diagnostic, JSON_UNESCAPED_SLASHES) : json_encode($diagnostic, JSON_UNESCAPED_SLASHES);
+    return 'diagnostic=' . (is_string($json) ? $json : '{}');
+}
+function ${preload}(array $plugin, bool $include_plugin_file, string $role = 'recipe-plugin', string $command_label = 'wordpress.run-php'): array {
+    $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
+    if ($plugin_file === '' || str_starts_with($plugin_file, '/') || str_contains($plugin_file, '..') || !str_ends_with($plugin_file, '.php')) {
+        throw new RuntimeException($command_label . ' cannot preload unsafe recipe plugin file "' . $plugin_file . '". ' . ${diagnosticString}($plugin, $role, 'unsafe plugin file'));
+    }
+    $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
+    if (!is_file($absolute_plugin_file) || !is_readable($absolute_plugin_file)) {
+        throw new RuntimeException($command_label . ' cannot preload recipe plugin file "' . $plugin_file . '". ' . ${diagnosticString}($plugin, $role, 'missing or unreadable plugin file'));
+    }
+    $plugin_dir = dirname($plugin_file);
+    $plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
+    if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
+        require_once $plugin_autoload;
+    }
+    $plugin_package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
+    if ('.' !== $plugin_dir && is_file($plugin_package_autoload)) {
+        require_once $plugin_package_autoload;
+    }
+    if (!$include_plugin_file) {
+        return ${diagnostic}($plugin, $role);
+    }
+    $lifecycle = ${prepare}();
+    try {
+        require_once $absolute_plugin_file;
+    } catch (Throwable $e) {
+        throw new RuntimeException($command_label . ' failed to include recipe plugin "' . $plugin_file . '". ' . ${diagnosticString}($plugin, $role, $e->getMessage()), 0, $e);
+    } finally {
+        ${complete}($lifecycle);
+    }
+    $diagnostic = ${diagnostic}($plugin, $role, 'plugin file was not included');
+    if (empty($diagnostic['included'])) {
+        throw new RuntimeException($command_label . ' failed to verify included recipe plugin "' . $plugin_file . '". diagnostic=' . (function_exists('wp_json_encode') ? wp_json_encode($diagnostic, JSON_UNESCAPED_SLASHES) : json_encode($diagnostic, JSON_UNESCAPED_SLASHES)));
+    }
+    return ${diagnostic}($plugin, $role);
+}
+}`
+}
+
 export function phpRuntimeComponentLifecycleActionReplayFunction(functionName: string): string {
   return `function ${functionName}(): array {
     do_action('plugins_loaded');

--- a/packages/runtime-playground/src/php-bootstrap.ts
+++ b/packages/runtime-playground/src/php-bootstrap.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises"
 import { argValue, normalizePhpCode, phpBody } from "./commands.js"
-import { phpEnvAssignments, phpRuntimeComponentLifecycleReplayFunction, phpWpConfigDefineAssignments } from "./php-snippets.js"
+import { phpEnvAssignments, phpRuntimeRecipePluginPreloadFunction, phpWpConfigDefineAssignments } from "./php-snippets.js"
 import { normalizeRuntimeEnvRecord, resolveCommandPath, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 
 interface PhpBootstrapBridge {
@@ -86,63 +86,11 @@ function recipeActivePluginBootstrapPhp(spec: RuntimeCreateSpec, args: string[])
     return ""
   }
 
-  return `${phpRuntimeComponentLifecycleReplayFunction("contained_runtime_run_php")}
+  return `${phpRuntimeRecipePluginPreloadFunction("contained_runtime_run_php")}
 $contained_runtime_run_php_active_plugins = json_decode(base64_decode('${Buffer.from(JSON.stringify(plugins), "utf8").toString("base64")}'), true);
-function contained_runtime_run_php_plugin_load_diagnostic(array $plugin, string $error = ''): string {
-    $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
-    $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
-    $real_plugin_file = realpath($absolute_plugin_file);
-    $included_files = array_map(static fn($file) => realpath($file) ?: $file, get_included_files());
-    $included = in_array($real_plugin_file ?: $absolute_plugin_file, $included_files, true);
-    return 'diagnostic=' . wp_json_encode(array(
-        'schema' => 'wp-codebox/run-php-plugin-load-diagnostic/v1',
-        'role' => 'active-recipe-plugin',
-        'plugin_slug' => isset($plugin['slug']) ? (string) $plugin['slug'] : dirname($plugin_file),
-        'plugin_file' => $plugin_file,
-        'mounted_path' => isset($plugin['target']) ? (string) $plugin['target'] : WP_PLUGIN_DIR . '/' . dirname($plugin_file),
-        'expected_file_path' => $absolute_plugin_file,
-        'file_exists' => is_file($absolute_plugin_file),
-        'file_readable' => is_readable($absolute_plugin_file),
-        'active' => function_exists('is_plugin_active') ? is_plugin_active($plugin_file) : null,
-        'included' => $included,
-        'wp_plugin_dir' => WP_PLUGIN_DIR,
-        'error' => $error,
-    ), JSON_UNESCAPED_SLASHES);
-}
-function contained_runtime_run_php_include_active_plugin(array $plugin): void {
-    $plugin_file = isset($plugin['pluginFile']) ? (string) $plugin['pluginFile'] : '';
-    if ($plugin_file === '' || str_starts_with($plugin_file, '/') || str_contains($plugin_file, '..') || !str_ends_with($plugin_file, '.php')) {
-        throw new RuntimeException('wordpress.run-php cannot include unsafe recipe plugin file "' . $plugin_file . '". ' . contained_runtime_run_php_plugin_load_diagnostic($plugin, 'unsafe plugin file'));
-    }
-    $absolute_plugin_file = WP_PLUGIN_DIR . '/' . $plugin_file;
-    if (!is_file($absolute_plugin_file) || !is_readable($absolute_plugin_file)) {
-        throw new RuntimeException('wordpress.run-php cannot include recipe plugin file "' . $plugin_file . '". ' . contained_runtime_run_php_plugin_load_diagnostic($plugin, 'missing or unreadable plugin file'));
-    }
-    $plugin_dir = dirname($plugin_file);
-    $plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
-    if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
-        require_once $plugin_autoload;
-    }
-    $plugin_package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
-    if ('.' !== $plugin_dir && is_file($plugin_package_autoload)) {
-        require_once $plugin_package_autoload;
-    }
-    $lifecycle = contained_runtime_run_php_component_lifecycle_replay_prepare();
-    try {
-        require_once $absolute_plugin_file;
-    } catch (Throwable $e) {
-        throw new RuntimeException('wordpress.run-php failed to include recipe plugin "' . $plugin_file . '". ' . contained_runtime_run_php_plugin_load_diagnostic($plugin, $e->getMessage()), 0, $e);
-    } finally {
-        contained_runtime_run_php_component_lifecycle_replay_complete($lifecycle);
-    }
-    $diagnostic = contained_runtime_run_php_plugin_load_diagnostic($plugin, 'plugin file was not included');
-    if (strpos($diagnostic, '"included":true') === false) {
-        throw new RuntimeException('wordpress.run-php failed to verify included recipe plugin "' . $plugin_file . '". ' . $diagnostic);
-    }
-}
 foreach (is_array($contained_runtime_run_php_active_plugins) ? $contained_runtime_run_php_active_plugins : array() as $contained_runtime_run_php_active_plugin) {
     if (is_array($contained_runtime_run_php_active_plugin)) {
-        contained_runtime_run_php_include_active_plugin($contained_runtime_run_php_active_plugin);
+        contained_runtime_run_php_preload_recipe_plugin($contained_runtime_run_php_active_plugin, true, 'active-recipe-plugin', 'wordpress.run-php');
     }
 }
 `

--- a/packages/runtime-playground/src/php-snippets.ts
+++ b/packages/runtime-playground/src/php-snippets.ts
@@ -1,6 +1,6 @@
 import { isSafeEnvName } from "./commands.js"
 
-export { phpRuntimeComponentLifecycleReplayFunction } from "@automattic/wp-codebox-core"
+export { phpRuntimeComponentLifecycleReplayFunction, phpRuntimeRecipePluginPreloadFunction } from "@automattic/wp-codebox-core"
 
 export type PhpScalar = string | number | boolean | null
 

--- a/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
+++ b/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
@@ -20,8 +20,9 @@ writeFileSync(resolve(pluginSource, "composer.json"), `${JSON.stringify({
   name: "wp-codebox/composer-autoload-smoke",
   autoload: { classmap: ["src/"] },
   repositories: [{ type: "path", url: "../../packages/php/email-editor", options: { symlink: false } }],
-  require: { "wp-codebox/email-editor-smoke": "*" },
-  config: { "allow-plugins": false },
+  require: { "composer/installers": "^1.9", "woocommerce/email-editor": "*" },
+  config: { "allow-plugins": { "composer/installers": true } },
+  extra: { "installer-paths": { "packages/{$name}": ["woocommerce/email-editor"] } },
   "minimum-stability": "dev",
   "prefer-stable": true,
 }, null, 2)}\n`)
@@ -37,16 +38,11 @@ register_activation_hook( __FILE__, static function (): void {
 	if ( ! class_exists( \\WpCodeboxComposerSmoke\\Fixture::class ) ) {
 		throw new RuntimeException( 'Composer classmap fixture was not autoloaded.' );
 	}
-	$sibling_package = __DIR__ . '/vendor/wp-codebox/email-editor-smoke/src/SiblingPackage.php';
+	$sibling_package = __DIR__ . '/packages/email-editor/src/class-package.php';
 	if ( ! is_file( $sibling_package ) ) {
-		throw new RuntimeException( 'Composer path repository sibling package was not installed.' );
+		throw new RuntimeException( 'Composer path repository WordPress package was not installed.' );
 	}
-	require_once $sibling_package;
-	if ( ! class_exists( \\WpCodeboxEmailEditorSmoke\\SiblingPackage::class ) ) {
-		throw new RuntimeException( 'Composer path repository sibling package was not loadable.' );
-	}
-
-	update_option( 'wp_codebox_composer_smoke_value', \\WpCodeboxComposerSmoke\\Fixture::value() + \\WpCodeboxEmailEditorSmoke\\SiblingPackage::value() );
+	update_option( 'wp_codebox_composer_smoke_value', \\WpCodeboxComposerSmoke\\Fixture::value() + \\Automattic\\WooCommerce\\EmailEditor\\Package::value() );
 } );
 `)
 
@@ -62,16 +58,17 @@ final class Fixture {
 `)
 
 writeFileSync(resolve(siblingPackageSource, "composer.json"), `${JSON.stringify({
-  name: "wp-codebox/email-editor-smoke",
-  autoload: { "psr-4": { "WpCodeboxEmailEditorSmoke\\\\": "src/" } },
+  name: "woocommerce/email-editor",
+  type: "wordpress-plugin",
+  autoload: { classmap: ["src/"] },
   version: "dev-main",
 }, null, 2)}\n`)
 
-writeFileSync(resolve(siblingPackageSource, "src", "SiblingPackage.php"), `<?php
+writeFileSync(resolve(siblingPackageSource, "src", "class-package.php"), `<?php
 
-namespace WpCodeboxEmailEditorSmoke;
+namespace Automattic\\WooCommerce\\EmailEditor;
 
-final class SiblingPackage {
+final class Package {
 	public static function value(): int {
 		return 8;
 	}
@@ -102,7 +99,7 @@ writeFileSync(recipePath, `${JSON.stringify({
       {
         command: "wordpress.run-php",
         args: [
-          "code=if (!class_exists('WpCodeboxComposerSmoke\\\\Fixture')) { throw new RuntimeException('autoloaded class missing after plugin boot'); } if (!is_file(WP_PLUGIN_DIR . '/composer-autoload-smoke/vendor/wp-codebox/email-editor-smoke/src/SiblingPackage.php')) { throw new RuntimeException('path repository package missing after plugin boot'); } if (!class_exists('WpCodeboxEmailEditorSmoke\\\\SiblingPackage')) { require_once WP_PLUGIN_DIR . '/composer-autoload-smoke/vendor/wp-codebox/email-editor-smoke/src/SiblingPackage.php'; } echo wp_json_encode(array('value' => get_option('wp_codebox_composer_smoke_value'), 'active' => is_plugin_active('composer-autoload-smoke/composer-autoload-smoke.php')));",
+          "code=if (!class_exists('WpCodeboxComposerSmoke\\\\Fixture')) { throw new RuntimeException('autoloaded class missing after plugin boot'); } if (!is_file(WP_PLUGIN_DIR . '/composer-autoload-smoke/packages/email-editor/src/class-package.php')) { throw new RuntimeException('path repository WordPress package missing after plugin boot'); } if (!class_exists('Automattic\\\\WooCommerce\\\\EmailEditor\\\\Package')) { throw new RuntimeException('path repository WordPress package class missing after plugin boot'); } echo wp_json_encode(array('value' => get_option('wp_codebox_composer_smoke_value'), 'active' => is_plugin_active('composer-autoload-smoke/composer-autoload-smoke.php')));",
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Add a shared PHP primitive for recipe plugin preload diagnostics/loading.
- Use the same primitive for normal wordpress.run-php active plugin bootstrap and built-in setup activation.
- Cover Woo-style Composer path packages installed by composer/installers in the activation smoke.

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the activation bootstrap mismatch, drafting the shared preload refactor, and running verification.