### PR TITLE
Eager-load installed package classmaps

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -354,9 +354,9 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
 
 async function writeComposerInstalledPackageAutoloader(pluginSource: string): Promise<void> {
   const packageAutoloader = join(pluginSource, "vendor", "autoload_packages.php")
+  const existingPackageAutoloader = await pathIsFile(packageAutoloader)
   if (await pathIsFile(packageAutoloader)) {
     await bridgePackageAutoloaderToComposerAutoload(packageAutoloader)
-    return
   }
 
   const installedPath = join(pluginSource, "vendor", "composer", "installed.json")
@@ -372,9 +372,7 @@ async function writeComposerInstalledPackageAutoloader(pluginSource: string): Pr
 
   const uniqueFiles = [...new Set(classmapFiles)]
   const fileLines = uniqueFiles.map((path) => `    __DIR__ . ${JSON.stringify(`/composer/${path}`)},`).join("\n")
-  await writeFile(packageAutoloader, `<?php
-defined( 'ABSPATH' ) || exit;
-
+  const classmapLoader = `
 $wp_codebox_composer_package_classmap_files = array(
 ${fileLines}
 );
@@ -384,6 +382,18 @@ foreach ($wp_codebox_composer_package_classmap_files as $file) {
         require_once $file;
     }
 }
+`
+  if (existingPackageAutoloader) {
+    const contents = await readFile(packageAutoloader, "utf8")
+    if (!contents.includes("$wp_codebox_composer_package_classmap_files")) {
+      await writeFile(packageAutoloader, `${contents.trimEnd()}\n${classmapLoader}`)
+    }
+    return
+  }
+
+  await writeFile(packageAutoloader, `<?php
+defined( 'ABSPATH' ) || exit;
+${classmapLoader}
 `)
 }
 

--- a/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
+++ b/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
@@ -42,7 +42,7 @@ register_activation_hook( __FILE__, static function (): void {
 	if ( ! is_file( $sibling_package ) ) {
 		throw new RuntimeException( 'Composer path repository WordPress package was not installed.' );
 	}
-	update_option( 'wp_codebox_composer_smoke_value', \\WpCodeboxComposerSmoke\\Fixture::value() + \\Automattic\\WooCommerce\\EmailEditor\\Package::value() );
+	update_option( 'wp_codebox_composer_smoke_value', \\WpCodeboxComposerSmoke\\Fixture::value() + \\WpCodeboxComposerSmoke\\InternalEmailPackage::value() );
 } );
 `)
 
@@ -53,6 +53,19 @@ namespace WpCodeboxComposerSmoke;
 final class Fixture {
 	public static function value(): int {
 		return 992;
+	}
+}
+`)
+
+writeFileSync(resolve(pluginSource, "src", "InternalEmailPackage.php"), `<?php
+
+namespace WpCodeboxComposerSmoke;
+
+final class InternalEmailPackage {
+	public const VERSION = \\Automattic\\WooCommerce\\EmailEditor\\Package::VERSION;
+
+	public static function value(): int {
+		return \\Automattic\\WooCommerce\\EmailEditor\\Package::value();
 	}
 }
 `)
@@ -69,6 +82,8 @@ writeFileSync(resolve(siblingPackageSource, "src", "class-package.php"), `<?php
 namespace Automattic\\WooCommerce\\EmailEditor;
 
 final class Package {
+	public const VERSION = '0.1.0';
+
 	public static function value(): int {
 		return 8;
 	}


### PR DESCRIPTION
## Summary
- Append Composer installed package classmap files to prepared plugin package autoloaders even when autoload_packages.php already exists.
- Cover Woo-style class-constant package references during activation.

## Testing
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing Woo package classmap activation failure, drafting the generic classmap bridge, and running verification.