### PR TITLE
Preserve prepared extra plugin sources

### DIFF
--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -564,7 +564,7 @@ async function recipeDryRunSteps(recipe: WorkspaceRecipe, recipeDirectory: strin
   const steps: Array<Promise<RecipeDryRunStep>> = []
   const dryRunExtraPlugins = await Promise.all(recipeExtraPlugins(recipe).map(async (plugin) => {
     const slug = recipeExtraPluginSlug(plugin)
-    const sourceRoot = recipeExtraPluginSourceRoot(plugin)
+    const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
     return {
       source: plugin.source,
       slug,
@@ -657,7 +657,7 @@ function recipeDryRunWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string
 function recipeDryRunExtraPlugins(recipe: WorkspaceRecipe, recipeDirectory: string): RecipeDryRunExtraPlugin[] {
   return recipeExtraPlugins(recipe).map((plugin) => {
     const slug = recipeExtraPluginSlug(plugin)
-    const sourceRoot = recipeExtraPluginSourceRoot(plugin)
+    const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
     const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
     const source = recipeSource(sourceRoot, plugin.sha256)
     const provenance = recipeSourceProvenance(source, recipeDirectory)

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -270,7 +270,7 @@ export async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeD
   const plugins: PreparedExtraPlugin[] = []
   for (const plugin of recipeExtraPlugins(recipe)) {
     const slug = recipeExtraPluginSlug(plugin)
-    const sourceRootRef = recipeExtraPluginSourceRoot(plugin)
+    const sourceRootRef = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
     const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
     const resolved = await prepareRecipeSource(sourceRootRef, recipeDirectory, slug, plugin.sha256)
     const pluginResolved = sourceSubpath ? { ...resolved, source: join(resolved.source, sourceSubpath) } : resolved
@@ -1376,16 +1376,20 @@ export function recipeExtraPluginSlug(plugin: WorkspaceRecipeExtraPlugin): strin
   return basename(resolve(plugin.source))
 }
 
-export function recipeExtraPluginSourceRoot(plugin: WorkspaceRecipeExtraPlugin): string {
-  return plugin.sourceRoot ?? plugin.originalSource ?? plugin.source
+export function recipeExtraPluginSourceRoot(plugin: WorkspaceRecipeExtraPlugin, recipeDirectory = "."): string {
+  if (plugin.sourceRoot && recipeExtraPluginSourceRootContainsSource(plugin, plugin.sourceRoot, recipeDirectory)) {
+    return plugin.sourceRoot
+  }
+
+  return plugin.originalSource ?? plugin.source
 }
 
 export function recipeExtraPluginSourceSubpath(plugin: WorkspaceRecipeExtraPlugin, recipeDirectory: string): string {
-  if (plugin.sourceSubpath) {
+  if (plugin.sourceSubpath && plugin.sourceRoot && recipeExtraPluginSourceRootContainsSource(plugin, plugin.sourceRoot, recipeDirectory)) {
     return normalizeReviewerSafePath(plugin.sourceSubpath)
   }
 
-  const sourceRoot = recipeExtraPluginSourceRoot(plugin)
+  const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
   if (sourceRoot === plugin.source) {
     return ""
   }
@@ -1396,6 +1400,11 @@ export function recipeExtraPluginSourceSubpath(plugin: WorkspaceRecipeExtraPlugi
   }
 
   return normalizeReviewerSafePath(relativePath)
+}
+
+function recipeExtraPluginSourceRootContainsSource(plugin: WorkspaceRecipeExtraPlugin, sourceRoot: string, recipeDirectory: string): boolean {
+  const relativePath = relative(resolve(recipeDirectory, sourceRoot), resolve(recipeDirectory, plugin.source))
+  return Boolean(relativePath) && !relativePath.startsWith("..") && !isAbsolute(relativePath)
 }
 
 export function recipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin): string {
@@ -1431,7 +1440,7 @@ export async function resolveRecipeExtraPluginFile(plugin: WorkspaceRecipeExtraP
 
   const source = recipeSource(plugin.source, plugin.sha256)
   if (source.type === "local") {
-    const sourceRoot = resolve(recipeDirectory, recipeExtraPluginSourceRoot(plugin))
+    const sourceRoot = resolve(recipeDirectory, recipeExtraPluginSourceRoot(plugin, recipeDirectory))
     const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
     const pluginSource = sourceSubpath ? join(sourceRoot, sourceSubpath) : resolve(recipeDirectory, plugin.source)
     return resolvePluginEntrypointContract({ source: pluginSource, slug, loadAs: plugin.loadAs }).pluginFile

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -530,7 +530,7 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
       addIssue("invalid-source", `${path}.source`, error instanceof Error ? error.message : String(error))
       continue
     }
-    const sourceRoot = recipeExtraPluginSourceRoot(plugin)
+    const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
     const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
     const pluginSource = source.type === "local" ? resolve(recipeDirectory, plugin.source) : undefined
     const pluginMountedSource = source.type === "local" ? resolve(recipeDirectory, sourceRoot, sourceSubpath) : undefined

--- a/scripts/component-contracts-agent-task-smoke.ts
+++ b/scripts/component-contracts-agent-task-smoke.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { buildAgentTaskRecipe } from "../packages/runtime-core/src/agent-task-recipe.js"
 import { normalizeTaskInput } from "../packages/runtime-core/src/task-input.js"
+import { prepareRecipeExtraPlugins } from "../packages/cli/src/recipe-sources.js"
 import { runRecipeRunCommand } from "../packages/cli/src/commands/recipe-run.js"
 
 const root = mkdtempSync(join(tmpdir(), "wp-codebox-component-contracts-smoke-"))
@@ -77,6 +78,19 @@ try {
   assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "autoload_packages.php")), true)
   assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "jetpack-autoloader", "class-autoloader.php")), true)
   assert.equal(existsSync(join(String(monorepoComponent?.source), "vendor", "woocommerce", "email-editor", "src", "class-package.php")), true)
+
+  const preparedMonorepoRecipe = {
+    ...recipe,
+    inputs: {
+      ...recipe.inputs,
+      extra_plugins: plugins.map((plugin) => plugin.slug === "monorepo-component"
+        ? { ...plugin, sourceRoot: monorepo.rootPath, sourceSubpath: monorepo.sourceSubpath }
+        : plugin),
+    },
+  }
+  const preparedPlugins = await prepareRecipeExtraPlugins(preparedMonorepoRecipe, root)
+  const preparedMonorepoPlugin = preparedPlugins.find((plugin) => plugin.slug === "monorepo-component")
+  assert.equal(preparedMonorepoPlugin?.source, monorepoComponent?.source, "prepared monorepo plugin sources should remain authoritative")
 
   const missingComponentSource = "https://example.com/missing-component.zip"
   const invalidRecipePath = join(root, "invalid-component-recipe.json")


### PR DESCRIPTION
## Summary
- keep already-prepared extra plugin sources authoritative when sourceRoot/sourceSubpath metadata is present
- align dry-run and validation source resolution with runtime preparation
- add component-contract regression coverage for prepared monorepo plugin sources

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the prepared-source mount mismatch, implementing the fix, and updating focused regression coverage.