### PR TITLE
Lazy-load package classmaps

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -365,27 +365,25 @@ async function writeComposerInstalledPackageAutoloader(pluginSource: string): Pr
   }
   const installed = JSON.parse(await readFile(installedPath, "utf8")) as unknown
   const classmapPaths = composerInstalledPackages(installed).flatMap((pkg) => composerInstalledPackageClassmapPaths(pkg))
-  const classmapFiles = (await Promise.all(classmapPaths.map((path) => composerInstalledPackageClassmapFiles(pluginSource, path)))).flat()
-  if (classmapFiles.length === 0) {
+  if (classmapPaths.length === 0 || !await pathIsFile(join(pluginSource, "vendor", "composer", "autoload_classmap.php"))) {
     return
   }
 
-  const uniqueFiles = [...new Set(classmapFiles)]
-  const fileLines = uniqueFiles.map((path) => `    __DIR__ . ${JSON.stringify(`/composer/${path}`)},`).join("\n")
   const classmapLoader = `
-$wp_codebox_composer_package_classmap_files = array(
-${fileLines}
-);
-
-foreach ($wp_codebox_composer_package_classmap_files as $file) {
-    if (is_file($file)) {
-        require_once $file;
-    }
+$wp_codebox_composer_package_classmap = __DIR__ . '/composer/autoload_classmap.php';
+if (is_file($wp_codebox_composer_package_classmap)) {
+    spl_autoload_register(static function (string $class) use ($wp_codebox_composer_package_classmap): void {
+        $classmap = require $wp_codebox_composer_package_classmap;
+        if (!is_array($classmap) || !isset($classmap[$class]) || !is_file($classmap[$class])) {
+            return;
+        }
+        require $classmap[$class];
+    }, true, true);
 }
 `
   if (existingPackageAutoloader) {
     const contents = await readFile(packageAutoloader, "utf8")
-    if (!contents.includes("$wp_codebox_composer_package_classmap_files")) {
+    if (!contents.includes("$wp_codebox_composer_package_classmap")) {
       await writeFile(packageAutoloader, `${contents.trimEnd()}\n${classmapLoader}`)
     }
     return
@@ -395,33 +393,6 @@ foreach ($wp_codebox_composer_package_classmap_files as $file) {
 defined( 'ABSPATH' ) || exit;
 ${classmapLoader}
 `)
-}
-
-async function composerInstalledPackageClassmapFiles(pluginSource: string, classmapPath: string): Promise<string[]> {
-  const absolutePath = join(pluginSource, "vendor", "composer", classmapPath)
-  if (await pathIsFile(absolutePath)) {
-    return [classmapPath]
-  }
-  if (!await pathIsDirectory(absolutePath)) {
-    return []
-  }
-  const files: string[] = []
-  await collectPhpFiles(absolutePath, classmapPath.replace(/\/+$/, ""), files)
-  return files
-}
-
-async function collectPhpFiles(directory: string, relativeDirectory: string, files: string[]): Promise<void> {
-  for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const absolutePath = join(directory, entry.name)
-    const relativePath = `${relativeDirectory}/${entry.name}`.replace(/^\/+/, "")
-    if (entry.isDirectory()) {
-      await collectPhpFiles(absolutePath, relativePath, files)
-      continue
-    }
-    if (entry.isFile() && entry.name.endsWith(".php")) {
-      files.push(relativePath)
-    }
-  }
 }
 
 async function bridgePackageAutoloaderToComposerAutoload(packageAutoloader: string): Promise<void> {

--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process"
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, rmSync, writeFileSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, statSync, rmSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { isAbsolute, join, relative, resolve } from "node:path"
 import { safeArtifactRelativePath } from "./artifact-paths.js"
@@ -239,7 +239,7 @@ export function bridgePackageAutoloaderToComposerAutoload(pluginSource: string):
   const initCall = "Autoloader::init();"
   let bridged = contents.includes(bridge) ? contents : contents.includes(initCall) ? contents.replace(initCall, `${bridge}\n${initCall}`) : `${contents.trimEnd()}\n${bridge}\n`
   const classmapLoader = composerInstalledPackageClassmapLoader(pluginSource)
-  if (classmapLoader && !bridged.includes("$wp_codebox_composer_package_classmap_files")) {
+  if (classmapLoader && !bridged.includes("$wp_codebox_composer_package_classmap")) {
     bridged = `${bridged.trimEnd()}\n${classmapLoader}`
   }
   if (bridged !== contents) {
@@ -258,20 +258,27 @@ function composerInstalledPackageClassmapLoader(pluginSource: string): string {
   if (!pathExists(installedPath)) return ""
   const installed = JSON.parse(readFileSync(installedPath, "utf8")) as unknown
   const classmapPaths = composerInstalledPackages(installed).flatMap((pkg) => composerInstalledPackageClassmapPaths(pkg))
-  const classmapFiles = classmapPaths.flatMap((path) => composerInstalledPackageClassmapFiles(pluginSource, path))
-  if (classmapFiles.length === 0) return ""
-  const fileLines = [...new Set(classmapFiles)].map((path) => `    __DIR__ . ${JSON.stringify(`/composer/${path}`)},`).join("\n")
+  if (classmapPaths.length === 0 || !pathIsFile(join(pluginSource, "vendor", "composer", "autoload_classmap.php"))) return ""
   return `
-$wp_codebox_composer_package_classmap_files = array(
-${fileLines}
-);
-
-foreach ($wp_codebox_composer_package_classmap_files as $file) {
-    if (is_file($file)) {
-        require_once $file;
-    }
+$wp_codebox_composer_package_classmap = __DIR__ . '/composer/autoload_classmap.php';
+if (is_file($wp_codebox_composer_package_classmap)) {
+    spl_autoload_register(static function (string $class) use ($wp_codebox_composer_package_classmap): void {
+        $classmap = require $wp_codebox_composer_package_classmap;
+        if (!is_array($classmap) || !isset($classmap[$class]) || !is_file($classmap[$class])) {
+            return;
+        }
+        require $classmap[$class];
+    }, true, true);
 }
 `
+}
+
+function pathIsFile(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile()
+  } catch {
+    return false
+  }
 }
 
 function composerInstalledPackages(installed: unknown): ComposerInstalledPackage[] {
@@ -293,44 +300,6 @@ function composerInstalledPackageClassmapPaths(pkg: ComposerInstalledPackage): s
   return entries
     .filter((entry): entry is string => typeof entry === "string" && entry.length > 0 && !isAbsolute(entry) && !entry.includes(".."))
     .map((entry) => `${pkg["install-path"]!.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "")}/${entry.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "")}`)
-}
-
-function composerInstalledPackageClassmapFiles(pluginSource: string, classmapPath: string): string[] {
-  const absolutePath = join(pluginSource, "vendor", "composer", classmapPath)
-  if (pathIsFile(absolutePath)) return [classmapPath]
-  if (!pathIsDirectory(absolutePath)) return []
-  const files: string[] = []
-  collectPhpFiles(absolutePath, classmapPath.replace(/\/+$/, ""), files)
-  return files
-}
-
-function collectPhpFiles(directory: string, relativeDirectory: string, files: string[]): void {
-  for (const entry of readdirSync(directory, { withFileTypes: true })) {
-    const relativePath = `${relativeDirectory}/${entry.name}`.replace(/^\/+/, "")
-    if (entry.isDirectory()) {
-      collectPhpFiles(join(directory, entry.name), relativePath, files)
-      continue
-    }
-    if (entry.isFile() && entry.name.endsWith(".php")) {
-      files.push(relativePath)
-    }
-  }
-}
-
-function pathIsFile(filePath: string): boolean {
-  try {
-    return statSync(filePath).isFile()
-  } catch {
-    return false
-  }
-}
-
-function pathIsDirectory(filePath: string): boolean {
-  try {
-    return statSync(filePath).isDirectory()
-  } catch {
-    return false
-  }
 }
 
 export function composerManagedHostEnv(): Record<string, string> {

--- a/scripts/source-package-autoload-packages-bridge-smoke.ts
+++ b/scripts/source-package-autoload-packages-bridge-smoke.ts
@@ -22,6 +22,11 @@ printf "%s\n" "<?php // composer autoload" > vendor/autoload.php
 printf "%s\n" "<?php" "namespace WpCodeboxSmoke;" "require_once __DIR__ . '/jetpack-autoloader/class-autoloader.php';" "Autoloader::init();" > vendor/autoload_packages.php
 mkdir -p vendor/jetpack-autoloader
 printf "%s\n" "<?php // package autoloader" > vendor/jetpack-autoloader/class-autoloader.php
+mkdir -p vendor/composer packages/email-editor/src/Engine/Renderer packages/email-editor/src
+printf "%s\n" '{"packages":[{"name":"woocommerce/email-editor","install-path":"../../packages/email-editor","autoload":{"classmap":["src/"]}}]}' > vendor/composer/installed.json
+printf "%s\n" "<?php" "return array(" "    'Automattic\\\\WooCommerce\\\\EmailEditor\\\\Package' => __DIR__ . '/../../packages/email-editor/src/class-package.php'," ");" > vendor/composer/autoload_classmap.php
+printf "%s\n" "<?php namespace Automattic\\WooCommerce\\EmailEditor; class Package {}" > packages/email-editor/src/class-package.php
+printf "%s\n" "<?php throw new RuntimeException('template files must not be eagerly required');" > packages/email-editor/src/Engine/Renderer/template-canvas.php
 `, { mode: 0o755 })
 
   process.env.PATH = `${bin}${delimiter}${originalPath}`
@@ -39,6 +44,8 @@ printf "%s\n" "<?php // package autoloader" > vendor/jetpack-autoloader/class-au
   const bridgedPackageAutoloader = readFileSync(packageAutoloader, "utf8")
   assert.match(bridgedPackageAutoloader, /require_once __DIR__ \. '\/autoload\.php';/)
   assert.ok(bridgedPackageAutoloader.indexOf("require_once __DIR__ . '/autoload.php';") < bridgedPackageAutoloader.indexOf("Autoloader::init();"))
+  assert.match(bridgedPackageAutoloader, /spl_autoload_register/)
+  assert.doesNotMatch(bridgedPackageAutoloader, /template-canvas/)
   assert.equal(existsSync(join(pluginSource, "vendor", "autoload_packages.php")), false, "source checkout must not be mutated")
 
   console.log("source-package-autoload-packages-bridge-smoke: ok")


### PR DESCRIPTION
## Summary
- replace eager package classmap file requiring with a lazy classmap autoloader
- avoid bootstrapping non-class PHP files from installed package classmaps
- extend the source-package bridge smoke to guard against eager template loading

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the package classmap bootstrap fatal, implementing the lazy loader, and updating regression coverage.