### PR TITLE
Cache package classmap autoloads

### DIFF
--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -373,11 +373,15 @@ async function writeComposerInstalledPackageAutoloader(pluginSource: string): Pr
 $wp_codebox_composer_package_classmap = __DIR__ . '/composer/autoload_classmap.php';
 if (is_file($wp_codebox_composer_package_classmap)) {
     spl_autoload_register(static function (string $class) use ($wp_codebox_composer_package_classmap): void {
-        $classmap = require $wp_codebox_composer_package_classmap;
+        static $classmap = null;
+        if (null === $classmap) {
+            $loaded_classmap = require $wp_codebox_composer_package_classmap;
+            $classmap = is_array($loaded_classmap) ? $loaded_classmap : array();
+        }
         if (!is_array($classmap) || !isset($classmap[$class]) || !is_file($classmap[$class])) {
             return;
         }
-        require $classmap[$class];
+        require_once $classmap[$class];
     }, true, true);
 }
 `

--- a/packages/runtime-core/src/recipe-source-packages.ts
+++ b/packages/runtime-core/src/recipe-source-packages.ts
@@ -263,11 +263,15 @@ function composerInstalledPackageClassmapLoader(pluginSource: string): string {
 $wp_codebox_composer_package_classmap = __DIR__ . '/composer/autoload_classmap.php';
 if (is_file($wp_codebox_composer_package_classmap)) {
     spl_autoload_register(static function (string $class) use ($wp_codebox_composer_package_classmap): void {
-        $classmap = require $wp_codebox_composer_package_classmap;
+        static $classmap = null;
+        if (null === $classmap) {
+            $loaded_classmap = require $wp_codebox_composer_package_classmap;
+            $classmap = is_array($loaded_classmap) ? $loaded_classmap : array();
+        }
         if (!is_array($classmap) || !isset($classmap[$class]) || !is_file($classmap[$class])) {
             return;
         }
-        require $classmap[$class];
+        require_once $classmap[$class];
     }, true, true);
 }
 `


### PR DESCRIPTION
## Summary
- cache generated package classmaps inside the lazy autoload closure
- use require_once when loading classmap entries
- avoid reparsing large Composer classmaps on every autoload attempt during WordPress bootstrap

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm exec -- tsx scripts/source-package-autoload-packages-bridge-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the memory exhaustion in package classmap autoloading and implementing the cached autoload fix.