### PR TITLE
Accept snake_case component source roots

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -472,9 +472,9 @@ function componentPlugins(contracts: Array<Record<string, unknown>> | undefined,
   return contracts.flatMap((contract, index) => {
     const slug = slugFromPath(stringValue(contract.slug || contract.component || contract.name))
     const source = stringValue(contract.path || contract.source)
-    const sourceRoot = stringValue(contract.sourceRoot)
+    const sourceRoot = stringValue(contract.sourceRoot || contract.source_root)
     const originalSource = stringValue(contract.original_source || contract.originalSource || contract.original_path || contract.originalPath)
-    const sourceSubpath = stringValue(contract.sourceSubpath)
+    const sourceSubpath = stringValue(contract.sourceSubpath || contract.source_subpath)
     if (!slug || !source) return []
     const preparedSource = prepareComponentPluginSource(sourceRoot || source, originalSource || sourceRoot, sourceSubpath, slug, artifactsRoot)
     const entrypoint = resolvePluginEntrypointContract({

--- a/scripts/component-contracts-agent-task-smoke.ts
+++ b/scripts/component-contracts-agent-task-smoke.ts
@@ -25,7 +25,7 @@ try {
       { slug: "domain-component", path: domainPlugin, loadAs: "plugin", activate: true },
       { slug: "runtime-component", path: runtimePlugin, loadAs: "mu-plugin", activate: false },
       { slug: "dedupe-component", path: dedupePlugin, loadAs: "plugin" },
-      { slug: "monorepo-component", path: monorepo.pluginPath, sourceRoot: monorepo.rootPath, sourceSubpath: monorepo.sourceSubpath, loadAs: "plugin" },
+      { slug: "monorepo-component", path: monorepo.pluginPath, source_root: monorepo.rootPath, source_subpath: monorepo.sourceSubpath, loadAs: "plugin" },
     ],
     runtime_requirements: {
       extra_plugins: [

--- a/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
+++ b/scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
@@ -10,19 +10,24 @@ const artifacts = resolve(root, "artifacts/recipe-run-composer-autoload-extra-pl
 const monorepoSource = resolve(artifacts, "source-monorepo")
 const pluginSource = resolve(monorepoSource, "plugins", "woocommerce")
 const siblingPackageSource = resolve(monorepoSource, "packages", "php", "email-editor")
+const secondSiblingPackageSource = resolve(monorepoSource, "packages", "php", "blueprint")
 const recipePath = resolve(artifacts, "recipe.json")
 
 rmSync(artifacts, { recursive: true, force: true })
 mkdirSync(resolve(pluginSource, "src"), { recursive: true })
 mkdirSync(resolve(siblingPackageSource, "src"), { recursive: true })
+mkdirSync(resolve(secondSiblingPackageSource, "src"), { recursive: true })
 
 writeFileSync(resolve(pluginSource, "composer.json"), `${JSON.stringify({
   name: "wp-codebox/composer-autoload-smoke",
   autoload: { classmap: ["src/"] },
-  repositories: [{ type: "path", url: "../../packages/php/email-editor", options: { symlink: false } }],
-  require: { "composer/installers": "^1.9", "woocommerce/email-editor": "*" },
+  repositories: [
+    { type: "path", url: "../../packages/php/email-editor", options: { symlink: false } },
+    { type: "path", url: "../../packages/php/blueprint", options: { symlink: false } },
+  ],
+  require: { "composer/installers": "^1.9", "woocommerce/email-editor": "*", "woocommerce/blueprint": "*" },
   config: { "allow-plugins": { "composer/installers": true } },
-  extra: { "installer-paths": { "packages/{$name}": ["woocommerce/email-editor"] } },
+  extra: { "installer-paths": { "packages/{$name}": ["woocommerce/email-editor", "woocommerce/blueprint"] } },
   "minimum-stability": "dev",
   "prefer-stable": true,
 }, null, 2)}\n`)
@@ -42,7 +47,11 @@ register_activation_hook( __FILE__, static function (): void {
 	if ( ! is_file( $sibling_package ) ) {
 		throw new RuntimeException( 'Composer path repository WordPress package was not installed.' );
 	}
-	update_option( 'wp_codebox_composer_smoke_value', \\WpCodeboxComposerSmoke\\Fixture::value() + \\WpCodeboxComposerSmoke\\InternalEmailPackage::value() );
+	$second_sibling_package = __DIR__ . '/packages/blueprint/src/Package.php';
+	if ( ! is_file( $second_sibling_package ) ) {
+		throw new RuntimeException( 'Second Composer path repository WordPress package was not installed.' );
+	}
+	update_option( 'wp_codebox_composer_smoke_value', \\WpCodeboxComposerSmoke\\Fixture::value() + \\WpCodeboxComposerSmoke\\InternalEmailPackage::value() + \\Automattic\\WooCommerce\\Blueprint\\Package::value() );
 } );
 `)
 
@@ -90,6 +99,24 @@ final class Package {
 }
 `)
 
+writeFileSync(resolve(secondSiblingPackageSource, "composer.json"), `${JSON.stringify({
+  name: "woocommerce/blueprint",
+  type: "wordpress-plugin",
+  autoload: { "psr-4": { "Automattic\\WooCommerce\\Blueprint\\": "src/" } },
+  version: "dev-main",
+}, null, 2)}\n`)
+
+writeFileSync(resolve(secondSiblingPackageSource, "src", "Package.php"), `<?php
+
+namespace Automattic\\WooCommerce\\Blueprint;
+
+final class Package {
+	public static function value(): int {
+		return 4;
+	}
+}
+`)
+
 writeFileSync(recipePath, `${JSON.stringify({
   schema: "wp-codebox/workspace-recipe/v1",
   runtime: {
@@ -114,7 +141,7 @@ writeFileSync(recipePath, `${JSON.stringify({
       {
         command: "wordpress.run-php",
         args: [
-          "code=if (!class_exists('WpCodeboxComposerSmoke\\\\Fixture')) { throw new RuntimeException('autoloaded class missing after plugin boot'); } if (!is_file(WP_PLUGIN_DIR . '/composer-autoload-smoke/packages/email-editor/src/class-package.php')) { throw new RuntimeException('path repository WordPress package missing after plugin boot'); } if (!class_exists('Automattic\\\\WooCommerce\\\\EmailEditor\\\\Package')) { throw new RuntimeException('path repository WordPress package class missing after plugin boot'); } echo wp_json_encode(array('value' => get_option('wp_codebox_composer_smoke_value'), 'active' => is_plugin_active('composer-autoload-smoke/composer-autoload-smoke.php')));",
+          "code=if (!class_exists('WpCodeboxComposerSmoke\\\\Fixture')) { throw new RuntimeException('autoloaded class missing after plugin boot'); } if (!is_file(WP_PLUGIN_DIR . '/composer-autoload-smoke/packages/email-editor/src/class-package.php')) { throw new RuntimeException('path repository WordPress package missing after plugin boot'); } if (!is_file(WP_PLUGIN_DIR . '/composer-autoload-smoke/packages/blueprint/src/Package.php')) { throw new RuntimeException('second path repository WordPress package missing after plugin boot'); } if (!class_exists('Automattic\\\\WooCommerce\\\\EmailEditor\\\\Package')) { throw new RuntimeException('path repository WordPress package class missing after plugin boot'); } if (!class_exists('Automattic\\\\WooCommerce\\\\Blueprint\\\\Package')) { throw new RuntimeException('second path repository WordPress package class missing after plugin boot'); } echo wp_json_encode(array('value' => get_option('wp_codebox_composer_smoke_value'), 'active' => is_plugin_active('composer-autoload-smoke/composer-autoload-smoke.php')));",
         ],
       },
     ],
@@ -141,10 +168,11 @@ const workflowExecution = output.executions.find((execution: { command: string; 
 assert.ok(workflowExecution)
 
 const workflowResult = JSON.parse(workflowExecution.stdout)
-assert.equal(workflowResult.value, "1000")
+assert.equal(workflowResult.value, "1004")
 assert.equal(workflowResult.active, true)
 assert.equal(existsSync(resolve(pluginSource, "vendor", "autoload.php")), false, "recipe-run must not mutate the caller plugin checkout")
 assert.equal(existsSync(resolve(pluginSource, "composer.lock")), false, "recipe-run must not write Composer lockfiles into the caller plugin checkout")
 assert.equal(existsSync(resolve(siblingPackageSource, "vendor")), false, "recipe-run must not mutate sibling package checkouts")
+assert.equal(existsSync(resolve(secondSiblingPackageSource, "vendor")), false, "recipe-run must not mutate second sibling package checkouts")
 
 console.log("recipe run Composer autoload extra plugin smoke passed")


### PR DESCRIPTION
## Summary
- accept snake_case source_root and source_subpath fields in component contracts
- cover snake_case monorepo component contracts in the component-contract smoke
- extend the Composer path repository smoke to cover multiple sibling packages

## Testing
- npm exec -- tsx scripts/component-contracts-agent-task-smoke.ts
- npm exec -- tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the component contract source-root staging gap, implementing the fix, and updating focused smoke coverage.