### PR TITLE
Align PHP DB inventory schema contract

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -631,7 +631,7 @@ private static function execute_fuzz_suite_database_inventory( array $args, arra
 	$observation['artifact'] = (string) ( $args['artifact'] ?? 'db_inventory' );
 	$observation['table_count'] = $totals['tableCount'];
 	$observation['payload'] = array(
-		'schema'      => 'wp-codebox/wordpress-database-inventory/v1',
+		'schema'      => 'wp-codebox/wordpress-db-inventory/v1',
 		'command'     => 'wordpress.inventory-database',
 		'status'      => 'ok',
 		'prefix'      => $prefix,

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -467,7 +467,7 @@ assert( 'sample' === $result['cases'][6]['metadata']['observations'][0]['namespa
 assert( 'passed' === $result['cases'][7]['status'] );
 assert( 'database-inventory' === $result['cases'][7]['id'] );
 assert( 2 === $result['cases'][7]['metadata']['observations'][0]['table_count'] );
-assert( 'wp-codebox/wordpress-database-inventory/v1' === $result['cases'][7]['metadata']['observations'][0]['payload']['schema'] );
+assert( 'wp-codebox/wordpress-db-inventory/v1' === $result['cases'][7]['metadata']['observations'][0]['payload']['schema'] );
 assert( 'core' === $result['cases'][7]['metadata']['observations'][0]['payload']['tables'][0]['classification'] );
 assert( 'prefixed' === $result['cases'][7]['metadata']['observations'][0]['payload']['tables'][1]['classification'] );
 assert( 'passed' === $result['cases'][8]['status'] );


### PR DESCRIPTION
## Summary
- Align the PHP in-process DB inventory payload schema with the public `wp-codebox/wordpress-db-inventory/v1` contract.
- Update the PHP fuzz suite smoke assertion that covers database inventory output.

## Tests
- `npm run test:php-fuzz-suite-runner`
- `npm run test:wordpress-runtime-discovery-contracts`
- `npm run test:wordpress-db-contracts`
- `npx tsx tests/benchmark-contracts.test.ts`
- `npm run test:bench-command-step-behavior`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the schema cleanup, updating the smoke assertion, running targeted tests, and drafting this PR description.