### PR TITLE
Add fuzz suite reset policy

### DIFF
--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -7,6 +7,8 @@ export type FuzzSuiteTargetKind = "ability" | "command" | "http" | "rest" | "run
 export type FuzzSuiteCaseStatus = "passed" | "failed" | "error" | "skipped"
 export type FuzzSuiteDiagnosticSeverity = "error" | "warning" | "info"
 export type FuzzSuiteRunnerMode = "php-in-process" | "runtime-backed" | (string & {})
+export type FuzzSuiteResetMode = "none" | "checkpoint-per-case" | "restore-snapshot"
+export type FuzzSuiteResetStatus = "not-required" | "passed" | "failed" | "unsupported"
 
 export interface FuzzSuiteTargetRef {
   kind: FuzzSuiteTargetKind
@@ -20,7 +22,31 @@ export interface FuzzSuiteCase {
   id: string
   target?: FuzzSuiteTargetRef
   input?: unknown
+  resetPolicy?: FuzzSuiteResetPolicy
+  reset_policy?: FuzzSuiteResetPolicy | string
   description?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface FuzzSuiteResetPolicy {
+  mode: FuzzSuiteResetMode | (string & {})
+  checkpointName?: string
+  checkpoint_name?: string
+  snapshotRef?: string
+  snapshot_ref?: string
+  fixtureRefs?: string[]
+  fixture_refs?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface FuzzSuiteCaseResetResult {
+  mode: FuzzSuiteResetMode | (string & {})
+  status: FuzzSuiteResetStatus
+  checkpointName?: string
+  snapshotRef?: string
+  fixtureRefs?: string[]
+  artifactRefs?: FuzzSuiteArtifactRef[]
+  diagnostics?: FuzzSuiteDiagnostic[]
   metadata?: Record<string, unknown>
 }
 
@@ -29,6 +55,8 @@ export interface FuzzSuiteContract {
   id: string
   version?: string
   target?: FuzzSuiteTargetRef
+  resetPolicy?: FuzzSuiteResetPolicy
+  reset_policy?: FuzzSuiteResetPolicy | string
   cases: FuzzSuiteCase[]
   metadata?: Record<string, unknown>
 }
@@ -96,6 +124,7 @@ export interface FuzzSuiteCaseResult {
   status: FuzzSuiteCaseStatus
   success: boolean
   target?: FuzzSuiteTargetRef
+  reset?: FuzzSuiteCaseResetResult
   skipReason?: string
   diagnostics: FuzzSuiteDiagnostic[]
   artifactRefs?: FuzzSuiteArtifactRef[]
@@ -145,6 +174,8 @@ export function fuzzSuiteContract(input: {
   id: string
   version?: string
   target?: FuzzSuiteTargetRef
+  resetPolicy?: FuzzSuiteResetPolicy
+  reset_policy?: FuzzSuiteResetPolicy | string
   cases?: FuzzSuiteCase[]
   metadata?: Record<string, unknown>
 }): FuzzSuiteContract {
@@ -153,6 +184,8 @@ export function fuzzSuiteContract(input: {
     id: input.id,
     version: input.version,
     target: input.target,
+    resetPolicy: input.resetPolicy,
+    reset_policy: input.reset_policy,
     cases: input.cases ?? [],
     metadata: input.metadata,
   })
@@ -168,7 +201,7 @@ export function fuzzSuiteResultEnvelope(input: {
 }): FuzzSuiteResultEnvelope {
   const cases = (input.cases ?? []).map(normalizeCaseResult)
   const diagnostics = [...(input.diagnostics ?? [])]
-  const artifactRefs = dedupeArtifactRefs([...(input.artifactRefs ?? []), ...cases.flatMap((item) => item.artifactRefs ?? [])])
+  const artifactRefs = dedupeArtifactRefs([...(input.artifactRefs ?? []), ...cases.flatMap((item) => [...(item.artifactRefs ?? []), ...(item.reset?.artifactRefs ?? [])])])
   const summary = summarizeFuzzCases(cases)
   const coverageSummary = input.coverageSummary ?? summarizeFuzzCoverage({ discovered: fuzzSuiteDiscoveredCount(input.suite, cases.length), cases })
   const contractDiagnostics = fuzzSuiteContractDiagnostics({ suite: input.suite, cases, artifactRefs, coverageSummary })
@@ -202,6 +235,44 @@ export function fuzzSuiteRequiredRunnerCapabilities(suite: FuzzSuiteContract): s
     ...stringArrayField(metadata, "requiredCapabilities"),
     ...stringArrayField(metadata, "required_capabilities"),
   ])
+}
+
+export function fuzzSuiteCaseResetPolicy(suite: FuzzSuiteContract, fuzzCase: FuzzSuiteCase): FuzzSuiteResetPolicy {
+  const candidate = fuzzCase.resetPolicy ?? fuzzCase.reset_policy ?? suite.resetPolicy ?? suite.reset_policy
+  return normalizeFuzzSuiteResetPolicy(candidate)
+}
+
+export function normalizeFuzzSuiteResetPolicy(input: unknown): FuzzSuiteResetPolicy {
+  if (typeof input === "string") {
+    return normalizeFuzzSuiteResetPolicyRecord({ mode: input })
+  }
+  if (isRecord(input)) {
+    return normalizeFuzzSuiteResetPolicyRecord(input)
+  }
+  return { mode: "none" }
+}
+
+export function fuzzSuiteResetPolicyDiagnostics(input: unknown, caseId?: string): FuzzSuiteDiagnostic[] {
+  const diagnostics: FuzzSuiteDiagnostic[] = []
+  const policy = normalizeFuzzSuiteResetPolicy(input)
+  if (!isFuzzSuiteResetMode(policy.mode)) {
+    diagnostics.push({
+      severity: "error",
+      code: "fuzz_suite_reset_policy_invalid_mode",
+      caseId,
+      message: `Fuzz suite reset policy mode is not supported: ${String(policy.mode)}.`,
+      metadata: { supportedModes: ["none", "checkpoint-per-case", "restore-snapshot"] },
+    })
+  }
+  if (policy.mode === "restore-snapshot" && !policy.snapshotRef && !policy.snapshot_ref) {
+    diagnostics.push({
+      severity: "error",
+      code: "fuzz_suite_reset_policy_snapshot_ref_required",
+      caseId,
+      message: "Fuzz suite reset policy mode restore-snapshot requires snapshotRef or snapshot_ref.",
+    })
+  }
+  return diagnostics
 }
 
 export function summarizeFuzzCases(cases: readonly Pick<FuzzSuiteCaseResult, "status">[]): FuzzSuiteSummary {
@@ -252,11 +323,29 @@ function normalizeCaseResult(input: FuzzSuiteCaseResult): FuzzSuiteCaseResult {
     status: input.status,
     success: input.status === "passed",
     target: input.target,
+    reset: input.reset,
     skipReason: input.status === "skipped" ? input.skipReason ?? input.diagnostics?.[0]?.code ?? input.diagnostics?.[0]?.message : undefined,
     diagnostics: input.diagnostics ?? [],
     artifactRefs: input.artifactRefs,
     metadata: input.metadata,
   })
+}
+
+function normalizeFuzzSuiteResetPolicyRecord(input: Record<string, unknown>): FuzzSuiteResetPolicy {
+  const fixtureRefs = [...stringArrayField(input, "fixtureRefs"), ...stringArrayField(input, "fixture_refs")]
+  return stripUndefined({
+    mode: typeof input.mode === "string" ? input.mode : "none",
+    checkpointName: typeof input.checkpointName === "string" ? input.checkpointName : undefined,
+    checkpoint_name: typeof input.checkpoint_name === "string" ? input.checkpoint_name : undefined,
+    snapshotRef: typeof input.snapshotRef === "string" ? input.snapshotRef : undefined,
+    snapshot_ref: typeof input.snapshot_ref === "string" ? input.snapshot_ref : undefined,
+    fixtureRefs: fixtureRefs.length > 0 ? fixtureRefs : undefined,
+    metadata: recordField(input, "metadata"),
+  }) as FuzzSuiteResetPolicy
+}
+
+function isFuzzSuiteResetMode(mode: string): mode is FuzzSuiteResetMode {
+  return mode === "none" || mode === "checkpoint-per-case" || mode === "restore-snapshot"
 }
 
 function fuzzSuiteDiscoveredCount(suite: { id: string; version?: string } | FuzzSuiteContract, fallback: number): number {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -1,5 +1,5 @@
 import { stripUndefined } from "./object-utils.js"
-import { RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteRequiredRunnerCapabilities, fuzzSuiteResultEnvelope, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteRunnerCapabilities, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
+import { RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteCaseResetPolicy, fuzzSuiteRequiredRunnerCapabilities, fuzzSuiteResetPolicyDiagnostics, fuzzSuiteResultEnvelope, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResetResult, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteResetPolicy, type FuzzSuiteRunnerCapabilities, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
 import type { RuntimeAction, RuntimeActionObservation } from "./runtime-action-adapter.js"
 import type { ExecutionResult, ExecutionSpec, RuntimeCommandDiagnosticsCaptureSpec, RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
 import { WORDPRESS_CRUD_OPERATION_SCHEMA, normalizeWordPressCrudOperation } from "./wordpress-crud-contracts.js"
@@ -11,11 +11,23 @@ export interface FuzzSuiteCommandExecutor {
 export interface FuzzSuiteRunOptions {
   executor?: FuzzSuiteCommandExecutor | ((spec: ExecutionSpec) => Promise<ExecutionResult>)
   runtimeActionExecutor?: FuzzSuiteRuntimeActionExecutor | ((input: FuzzSuiteRuntimeActionExecutionInput) => Promise<RuntimeActionObservation>)
+  resetExecutor?: FuzzSuiteResetExecutor | ((input: FuzzSuiteResetExecutionInput) => Promise<FuzzSuiteCaseResetResult>)
   targetAdapters?: FuzzSuiteTargetAdapterRegistry | readonly FuzzSuiteTargetAdapter[]
   supportedTargetKinds?: readonly string[]
   runnerCapabilities?: FuzzSuiteRunnerCapabilities | readonly string[]
   requireCoverage?: boolean
   metadata?: Record<string, unknown>
+}
+
+export interface FuzzSuiteResetExecutionInput {
+  suite: FuzzSuiteContract
+  case: FuzzSuiteCase
+  caseIndex: number
+  policy: FuzzSuiteResetPolicy
+}
+
+export interface FuzzSuiteResetExecutor {
+  resetFuzzSuiteCase(input: FuzzSuiteResetExecutionInput): Promise<FuzzSuiteCaseResetResult>
 }
 
 export interface FuzzSuiteRuntimeActionExecutionInput {
@@ -86,6 +98,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
   const diagnostics: FuzzSuiteDiagnostic[] = []
   const execute = normalizeFuzzSuiteExecutor(options.executor)
   const executeRuntimeAction = normalizeFuzzSuiteRuntimeActionExecutor(options.runtimeActionExecutor)
+  const executeReset = normalizeFuzzSuiteResetExecutor(options.resetExecutor)
   const adapterRegistry = normalizeFuzzSuiteTargetAdapterRegistry(options.targetAdapters)
   const runnerCapabilities = normalizeFuzzSuiteRunnerCapabilities(options.runnerCapabilities)
   const supportedTargetKinds = new Set(options.supportedTargetKinds ?? runnerCapabilities.targetKinds ?? DEFAULT_SUPPORTED_TARGET_KINDS)
@@ -107,6 +120,23 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
   }
 
   for (const [index, fuzzCase] of suite.cases.entries()) {
+    const reset = await executeFuzzSuiteCaseReset({ suite, case: fuzzCase, caseIndex: index, executeReset })
+    if (reset.status === "failed" || reset.status === "unsupported") {
+      const resetDiagnostics = reset.diagnostics ?? []
+      diagnostics.push(...resetDiagnostics)
+      cases.push({
+        id: fuzzCase.id,
+        status: "error",
+        success: false,
+        target: fuzzCase.target ?? suite.target,
+        reset,
+        diagnostics: resetDiagnostics,
+        artifactRefs: reset.artifactRefs,
+        metadata: stripUndefined({ resetPolicy: reset.metadata }),
+      })
+      continue
+    }
+
     const plan = planFuzzSuiteCaseExecutionSpec({ suite, case: fuzzCase, caseIndex: index, targetAdapters: adapterRegistry, supportedTargetKinds: [...supportedTargetKinds] })
     const target = plan.target
     const replayMetadata = plan.replayMetadata
@@ -119,6 +149,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         status: "skipped",
         success: false,
         target,
+        reset,
         skipReason: fuzzSuiteSkipReason(planDiagnostics),
         diagnostics: caseDiagnostics,
         metadata: stripUndefined({ replay: replayMetadata, adapter: plan.metadata }),
@@ -136,6 +167,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
           status: "skipped",
           success: false,
           target,
+          reset,
           skipReason: diagnostic.code,
           diagnostics: [diagnostic],
           metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-action" } }),
@@ -152,6 +184,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
           status: "passed",
           success: true,
           target,
+          reset,
           diagnostics: [],
           artifactRefs: fuzzSuiteRuntimeActionArtifactRefs(observation),
           metadata: stripUndefined({
@@ -182,6 +215,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
           status: "error",
           success: false,
           target,
+          reset,
           diagnostics: [diagnostic],
           metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-action", actionType: runtimeAction.action.type, executorKind: "episode" } }),
         })
@@ -204,6 +238,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         status: "skipped",
         success: false,
         target,
+        reset,
         skipReason: diagnostic.code,
         diagnostics: caseDiagnostics,
         metadata: stripUndefined({ replay: replayMetadata }),
@@ -229,6 +264,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         status,
         success: status === "passed",
         target,
+        reset,
         diagnostics: caseDiagnostics,
         artifactRefs: fuzzSuiteExecutionArtifactRefs(execution),
         metadata: stripUndefined({
@@ -261,6 +297,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
         status: "error",
         success: false,
         target,
+        reset,
         diagnostics: [diagnostic],
         metadata: stripUndefined({ replay: replayMetadata }),
       })
@@ -278,6 +315,65 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
       runnerCapabilities,
     }),
   })
+}
+
+function normalizeFuzzSuiteResetExecutor(executor: FuzzSuiteRunOptions["resetExecutor"]): ((input: FuzzSuiteResetExecutionInput) => Promise<FuzzSuiteCaseResetResult>) | undefined {
+  if (!executor) {
+    return undefined
+  }
+  if (typeof executor === "function") {
+    return executor
+  }
+  return (input) => executor.resetFuzzSuiteCase(input)
+}
+
+async function executeFuzzSuiteCaseReset(input: {
+  suite: FuzzSuiteContract
+  case: FuzzSuiteCase
+  caseIndex: number
+  executeReset?: (input: FuzzSuiteResetExecutionInput) => Promise<FuzzSuiteCaseResetResult>
+}): Promise<FuzzSuiteCaseResetResult> {
+  const rawPolicy = input.case.resetPolicy ?? input.case.reset_policy ?? input.suite.resetPolicy ?? input.suite.reset_policy
+  const policy = fuzzSuiteCaseResetPolicy(input.suite, input.case)
+  const validationDiagnostics = fuzzSuiteResetPolicyDiagnostics(rawPolicy, input.case.id)
+  if (validationDiagnostics.length > 0) {
+    return { mode: policy.mode, status: "failed", diagnostics: validationDiagnostics }
+  }
+  if (policy.mode === "none") {
+    return { mode: "none", status: "not-required" }
+  }
+  if (!input.executeReset) {
+    return {
+      mode: policy.mode,
+      status: "unsupported",
+      checkpointName: policy.checkpointName ?? policy.checkpoint_name,
+      snapshotRef: policy.snapshotRef ?? policy.snapshot_ref,
+      fixtureRefs: policy.fixtureRefs ?? policy.fixture_refs,
+      diagnostics: [{
+        severity: "error",
+        code: "fuzz_suite_reset_executor_unavailable",
+        caseId: input.case.id,
+        message: `Fuzz suite case ${input.case.id} requires reset policy ${policy.mode}, but no reset executor was provided.`,
+      }],
+    }
+  }
+  try {
+    return await input.executeReset({ suite: input.suite, case: input.case, caseIndex: input.caseIndex, policy })
+  } catch (error) {
+    return {
+      mode: policy.mode,
+      status: "failed",
+      checkpointName: policy.checkpointName ?? policy.checkpoint_name,
+      snapshotRef: policy.snapshotRef ?? policy.snapshot_ref,
+      fixtureRefs: policy.fixtureRefs ?? policy.fixture_refs,
+      diagnostics: [{
+        severity: "error",
+        code: "fuzz_suite_reset_execution_error",
+        caseId: input.case.id,
+        message: error instanceof Error ? error.message : String(error),
+      }],
+    }
+  }
 }
 
 export function planFuzzSuiteCaseExecutionSpec(input: FuzzSuiteCaseExecutionSpecPlanInput): FuzzSuiteCaseExecutionSpecPlan {

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -18,6 +18,9 @@ import {
   type ExecutionSpec,
   type FuzzSuiteCommandExecutor,
   type FuzzSuiteContract,
+  type FuzzSuiteArtifactRef,
+  type FuzzSuiteCaseResetResult,
+  type FuzzSuiteResetExecutor,
   type FuzzSuiteResultEnvelope,
   type FuzzSuiteRuntimeActionExecutor,
   type FuzzSuiteRunOptions,
@@ -101,7 +104,7 @@ export interface WordPressPageLoadActionOptions {
   captureDiagnostics?: string[]
 }
 
-export type WordPressFuzzSuiteExecutionOptions = Omit<FuzzSuiteRunOptions, "executor" | "runtimeActionExecutor" | "runnerCapabilities">
+export type WordPressFuzzSuiteExecutionOptions = Omit<FuzzSuiteRunOptions, "executor" | "runtimeActionExecutor" | "resetExecutor" | "runnerCapabilities">
 
 export async function createWordPressRuntime(spec: WordPressRuntimeSpec, options: PlaygroundRuntimeBackendOptions = {}): Promise<Runtime> {
   return createRuntime(wordPressRuntimeCreateSpec(spec), createPlaygroundRuntimeBackend(options))
@@ -186,8 +189,51 @@ export function createWordPressFuzzSuiteCommandExecutor(episode: Pick<RuntimeEpi
   }
 }
 
+export function createWordPressFuzzSuiteResetExecutor(episode: Pick<RuntimeEpisode, "reset" | "step">): FuzzSuiteResetExecutor {
+  let checkpointCreated = false
+  return {
+    async resetFuzzSuiteCase({ suite, case: fuzzCase, caseIndex, policy }): Promise<FuzzSuiteCaseResetResult> {
+      const checkpointName = policy.checkpointName ?? policy.checkpoint_name ?? `${suite.id}-baseline`
+      const fixtureRefs = policy.fixtureRefs ?? policy.fixture_refs
+      if (policy.mode === "checkpoint-per-case") {
+        const artifactRefs: FuzzSuiteArtifactRef[] = []
+        if (!checkpointCreated) {
+          const createStep = await episode.step({
+            kind: "command",
+            command: "wp-codebox.checkpoint-create",
+            args: [
+              `name=${checkpointName}`,
+              `metadata-json=${JSON.stringify({ suiteId: suite.id, caseId: fuzzCase.id, caseIndex, fixtureRefs, ...policy.metadata })}`,
+            ],
+          }, { type: "command-result" })
+          artifactRefs.push(...fuzzSuiteStepArtifactRefs(createStep))
+          checkpointCreated = createStep.execution.exitCode === 0
+          if (!checkpointCreated) {
+            return { mode: policy.mode, status: "failed", checkpointName, fixtureRefs, artifactRefs, diagnostics: [{ severity: "error", code: "fuzz_suite_checkpoint_create_failed", caseId: fuzzCase.id, message: `Checkpoint create failed for fuzz suite ${suite.id}.`, metadata: { executionId: createStep.execution.id, stderr: createStep.execution.stderr } }] }
+          }
+        }
+        const restoreStep = await episode.step({ kind: "command", command: "wp-codebox.checkpoint-restore", args: [`name=${checkpointName}`] }, { type: "command-result" })
+        artifactRefs.push(...fuzzSuiteStepArtifactRefs(restoreStep))
+        return {
+          mode: policy.mode,
+          status: restoreStep.execution.exitCode === 0 ? "passed" : "failed",
+          checkpointName,
+          fixtureRefs,
+          artifactRefs,
+          diagnostics: restoreStep.execution.exitCode === 0 ? [] : [{ severity: "error", code: "fuzz_suite_checkpoint_restore_failed", caseId: fuzzCase.id, message: `Checkpoint restore failed for fuzz suite case ${fuzzCase.id}.`, metadata: { executionId: restoreStep.execution.id, stderr: restoreStep.execution.stderr } }],
+        }
+      }
+      if (policy.mode === "restore-snapshot") {
+        const reset = await episode.reset()
+        return { mode: policy.mode, status: "passed", snapshotRef: policy.snapshotRef ?? policy.snapshot_ref, fixtureRefs, metadata: { resetId: reset.id, runtime: reset.runtime } }
+      }
+      return { mode: "none", status: "not-required" }
+    },
+  }
+}
+
 export function executeWordPressFuzzSuite(
-  episode: Pick<RuntimeEpisode, "step">,
+  episode: Pick<RuntimeEpisode, "reset" | "step">,
   suite: FuzzSuiteContract,
   options: WordPressFuzzSuiteExecutionOptions = {},
 ): Promise<FuzzSuiteResultEnvelope> {
@@ -195,12 +241,25 @@ export function executeWordPressFuzzSuite(
     ...options,
     executor: createWordPressFuzzSuiteCommandExecutor(episode),
     runtimeActionExecutor: createWordPressFuzzSuiteRuntimeActionExecutor(episode),
+    resetExecutor: createWordPressFuzzSuiteResetExecutor(episode),
     runnerCapabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
     metadata: {
       ...options.metadata,
       runnerMode: "runtime-backed",
       runtimeBackend: "wordpress-playground",
     },
+  })
+}
+
+function fuzzSuiteStepArtifactRefs(step: RuntimeEpisodeStepResult): FuzzSuiteArtifactRef[] {
+  return (step.execution.artifactRefs ?? []).flatMap((ref) => {
+    const path = ref.path ?? ref.artifactId ?? ref.id
+    return path ? [{
+      path,
+      kind: ref.kind,
+      sha256: ref.digest?.algorithm === "sha256" ? ref.digest.value : undefined,
+      metadata: { id: ref.id, artifactId: ref.artifactId, digest: ref.digest },
+    }] : []
   })
 }
 

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 
-import { PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteContract, planFuzzSuiteCaseExecutionSpec, runFuzzSuite, runWordPressRestMatrix, wordpressRestMatrixContract, wordpressRestMatrixToFuzzSuite, type ExecutionResult, type ExecutionSpec } from "../packages/runtime-core/src/index.js"
+import { PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteContract, fuzzSuiteResetPolicyDiagnostics, normalizeFuzzSuiteResetPolicy, planFuzzSuiteCaseExecutionSpec, runFuzzSuite, runWordPressRestMatrix, wordpressRestMatrixContract, wordpressRestMatrixToFuzzSuite, type ExecutionResult, type ExecutionSpec } from "../packages/runtime-core/src/index.js"
 
 const executed: ExecutionSpec[] = []
 const result = await runFuzzSuite(fuzzSuiteContract({
@@ -112,6 +112,44 @@ const skippedCoverageRequired = await runFuzzSuite(fuzzSuiteContract({
 }), { requireCoverage: true })
 assert.equal(skippedCoverageRequired.status, "error")
 assert.equal(skippedCoverageRequired.diagnostics.some((diagnostic) => diagnostic.code === "fuzz_suite_required_coverage_unsupported"), true)
+
+assert.deepEqual(normalizeFuzzSuiteResetPolicy("checkpoint-per-case"), { mode: "checkpoint-per-case" })
+assert.deepEqual(normalizeFuzzSuiteResetPolicy({ mode: "restore-snapshot", snapshot_ref: "artifact:baseline/files/runtime-snapshot.json", fixture_refs: ["fixtures/store.json"] }), {
+  mode: "restore-snapshot",
+  snapshot_ref: "artifact:baseline/files/runtime-snapshot.json",
+  fixtureRefs: ["fixtures/store.json"],
+})
+assert.deepEqual(fuzzSuiteResetPolicyDiagnostics({ mode: "restore-snapshot" }).map((diagnostic) => diagnostic.code), ["fuzz_suite_reset_policy_snapshot_ref_required"])
+assert.deepEqual(fuzzSuiteResetPolicyDiagnostics({ mode: "truncate-database" }).map((diagnostic) => diagnostic.code), ["fuzz_suite_reset_policy_invalid_mode"])
+
+const resetAttempts: string[] = []
+const resetResult = await runFuzzSuite(fuzzSuiteContract({
+  id: "suite-reset-required",
+  resetPolicy: { mode: "checkpoint-per-case", checkpointName: "baseline", fixtureRefs: ["fixtures/store.json"] },
+  target: { kind: "command", id: "inspect-mounted-inputs" },
+  cases: [{ id: "case-reset" }],
+}), {
+  resetExecutor: async ({ policy }) => {
+    resetAttempts.push(policy.mode)
+    return { mode: policy.mode, status: "passed", checkpointName: policy.checkpointName, fixtureRefs: policy.fixtureRefs, artifactRefs: [{ kind: "checkpoint", path: "files/checkpoint.json" }] }
+  },
+  executor: async (spec) => ({ id: "exec-reset", command: spec.command, args: spec.args ?? [], exitCode: 0, stdout: "ok", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z" }),
+})
+assert.equal(resetResult.status, "passed")
+assert.deepEqual(resetAttempts, ["checkpoint-per-case"])
+assert.equal(resetResult.cases[0]?.reset?.status, "passed")
+assert.equal(resetResult.cases[0]?.reset?.checkpointName, "baseline")
+assert.equal(resetResult.artifactRefs[0]?.path, "files/checkpoint.json")
+
+const resetExecutorMissing = await runFuzzSuite(fuzzSuiteContract({
+  id: "suite-reset-missing-executor",
+  resetPolicy: { mode: "checkpoint-per-case" },
+  target: { kind: "command", id: "inspect-mounted-inputs" },
+  cases: [{ id: "case-reset-blocked" }],
+}), { executor: async (spec) => ({ id: "exec-skipped", command: spec.command, args: spec.args ?? [], exitCode: 0, stdout: "ok", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z" }) })
+assert.equal(resetExecutorMissing.status, "error")
+assert.equal(resetExecutorMissing.cases[0]?.reset?.status, "unsupported")
+assert.equal(resetExecutorMissing.cases[0]?.diagnostics[0]?.code, "fuzz_suite_reset_executor_unavailable")
 
 const emptyRequiredArtifacts = await runFuzzSuite(fuzzSuiteContract({
   id: "suite-empty-required-artifacts",

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -5,6 +5,14 @@ import { createWordPressFuzzSuiteCommandExecutor, executeWordPressFuzzSuite } fr
 
 const steps: Array<{ command: string; args?: string[]; observation?: unknown }> = []
 const episode = {
+  async reset() {
+    return {
+      id: "reset-1",
+      runtime: { id: "runtime-1", backend: "wordpress-playground", status: "ready", createdAt: "2026-01-01T00:00:00.000Z", environment: { kind: "wordpress", name: "WordPress", version: "6.6" } },
+      observations: [],
+      observationRefs: [],
+    }
+  },
   async step(action: { command: string; args?: string[] }, observation?: unknown): Promise<RuntimeEpisodeStepResult> {
     steps.push({ command: action.command, args: action.args, observation })
     const index = steps.length
@@ -44,6 +52,7 @@ assert.deepEqual(steps[0]?.observation, { type: "command-result" })
 
 const result = await executeWordPressFuzzSuite(episode, fuzzSuiteContract({
   id: "runtime-backed-suite",
+  resetPolicy: { mode: "checkpoint-per-case", checkpointName: "fuzz-baseline", fixtureRefs: ["fixtures/store.json"] },
   cases: [
     { id: "rest", target: { kind: "rest", id: "/wp/v2/types" }, input: { method: "GET" } },
     { id: "browser", target: { kind: "runtime-action" }, input: { type: "browser", operation: "navigate", url: "/" } },
@@ -55,6 +64,10 @@ assert.equal(result.success, true)
 assert.equal(result.metadata?.runnerMode, "runtime-backed")
 assert.equal(result.metadata?.runtimeBackend, "wordpress-playground")
 assert.equal((result.metadata?.runnerCapabilities as { mode?: string } | undefined)?.mode, "runtime-backed")
-assert.deepEqual(steps.map((step) => step.command), ["wordpress.rest-request", "wordpress.rest-request", "wordpress.browser-actions"])
+assert.deepEqual(steps.map((step) => step.command), ["wordpress.rest-request", "wp-codebox.checkpoint-create", "wp-codebox.checkpoint-restore", "wordpress.rest-request", "wp-codebox.checkpoint-restore", "wordpress.browser-actions"])
+assert.equal(result.cases[0]?.reset?.status, "passed")
+assert.equal(result.cases[0]?.reset?.checkpointName, "fuzz-baseline")
+assert.deepEqual(result.cases[0]?.reset?.fixtureRefs, ["fixtures/store.json"])
+assert.equal(result.cases[1]?.reset?.status, "passed")
 
 console.log("playground fuzz suite public ok")


### PR DESCRIPTION
## Summary
- Add public fuzz suite reset policy fields on suites and cases with validation for none, checkpoint-per-case, and restore-snapshot.
- Include per-case reset results, reset diagnostics, and reset artifact refs in fuzz suite result envelopes.
- Wire WordPress Playground fuzz execution through same-run checkpoint create/restore commands for checkpoint-per-case policies and fail closed when reset execution is unavailable.

## Tests
- npm run build
- npm run test:fuzz-suite-runner
- npm run test:playground-fuzz-suite-public

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz suite reset policy contract, runner integration, tests, and PR preparation.