### PR TITLE
Add fuzz runner capability contract

### DIFF
--- a/packages/runtime-core/src/contracts.ts
+++ b/packages/runtime-core/src/contracts.ts
@@ -1,5 +1,6 @@
 /** Inspectable Codebox contract metadata for CLI and orchestrator consumers. */
 export * from "./browser-probe-contract.js"
 export * from "./command-registry.js"
+export * from "./fuzz-suite-contracts.js"
 export * from "./runtime-contract-manifest.js"
 export * from "./wordpress-page-load-contracts.js"

--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -2,6 +2,7 @@ import { stripUndefined } from "./object-utils.js"
 
 export const FUZZ_SUITE_SCHEMA = "wp-codebox/fuzz-suite/v1" as const
 export const FUZZ_SUITE_RESULT_SCHEMA = "wp-codebox/fuzz-suite-result/v1" as const
+export const FUZZ_RUNNER_CAPABILITIES_SCHEMA = "wp-codebox/fuzz-runner-capabilities/v1" as const
 
 export type FuzzSuiteTargetKind = "ability" | "command" | "http" | "rest" | "runtime" | "runtime-action" | (string & {})
 export type FuzzSuiteCaseStatus = "passed" | "failed" | "error" | "skipped"
@@ -62,20 +63,40 @@ export interface FuzzSuiteContract {
 }
 
 export interface FuzzSuiteRunnerCapabilities {
+  schema?: typeof FUZZ_RUNNER_CAPABILITIES_SCHEMA
   mode: FuzzSuiteRunnerMode
   capabilities: string[]
   targetKinds: string[]
   runtimeActionTypes?: string[]
   commands?: string[]
+  unsupportedRequiredCapabilities?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface FuzzRunnerCapabilitiesContract extends FuzzSuiteRunnerCapabilities {
+  schema: typeof FUZZ_RUNNER_CAPABILITIES_SCHEMA
+  unsupportedRequiredCapabilities: string[]
+}
+
+export interface FuzzRunnerRequiredCapabilities {
+  capabilities?: readonly string[]
+  targetKinds?: readonly string[]
+  target_kinds?: readonly string[]
+  runtimeActionTypes?: readonly string[]
+  runtime_action_types?: readonly string[]
+  commands?: readonly string[]
 }
 
 export const PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES: FuzzSuiteRunnerCapabilities = {
+  schema: FUZZ_RUNNER_CAPABILITIES_SCHEMA,
   mode: "php-in-process",
   capabilities: ["target:ability", "target:http", "target:rest"],
   targetKinds: ["ability", "http", "rest"],
+  unsupportedRequiredCapabilities: [],
 }
 
 export const RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES: FuzzSuiteRunnerCapabilities = {
+  schema: FUZZ_RUNNER_CAPABILITIES_SCHEMA,
   mode: "runtime-backed",
   capabilities: [
     "target:ability",
@@ -98,6 +119,7 @@ export const RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES: FuzzSuiteRunnerCapab
   targetKinds: ["ability", "command", "http", "rest", "runtime", "runtime-action"],
   runtimeActionTypes: ["admin_page", "browser", "browser_probe", "crud_operation", "editor_open", "page", "php", "rest_request", "wp_cli"],
   commands: ["wordpress.ability", "wordpress.admin-page-load", "wordpress.browser-actions", "wordpress.browser-probe", "wordpress.crud-operation", "wordpress.editor-open", "wordpress.frontend-page-load", "wordpress.http-request", "wordpress.rest-request", "wordpress.run-php", "wordpress.wp-cli"],
+  unsupportedRequiredCapabilities: [],
 }
 
 export interface FuzzSuiteDiagnostic {
@@ -226,12 +248,52 @@ export function fuzzSuiteResultEnvelope(input: {
 export function fuzzSuiteRequiredRunnerCapabilities(suite: FuzzSuiteContract): string[] {
   const metadata = fuzzSuiteMetadata(suite)
   const required = recordField(metadata, "requiredRunnerCapabilities") ?? recordField(metadata, "required_runner_capabilities")
+  return fuzzRunnerRequiredCapabilities(required, metadata)
+}
+
+export function fuzzRunnerCapabilitiesContract(input: FuzzSuiteRunnerCapabilities, required?: FuzzSuiteContract | FuzzRunnerRequiredCapabilities | readonly string[]): FuzzRunnerCapabilitiesContract {
+  const requiredCapabilities = Array.isArray(required)
+    ? [...required]
+    : isFuzzSuiteContract(required)
+      ? fuzzSuiteRequiredRunnerCapabilities(required)
+      : fuzzRunnerRequiredCapabilities(required)
+
+  return stripUndefined({
+    schema: FUZZ_RUNNER_CAPABILITIES_SCHEMA,
+    mode: input.mode,
+    capabilities: dedupeStrings(input.capabilities),
+    targetKinds: dedupeStrings(input.targetKinds),
+    runtimeActionTypes: input.runtimeActionTypes ? dedupeStrings(input.runtimeActionTypes) : undefined,
+    commands: input.commands ? dedupeStrings(input.commands) : undefined,
+    unsupportedRequiredCapabilities: unsupportedRequiredFuzzRunnerCapabilities(requiredCapabilities, input),
+    metadata: input.metadata,
+  })
+}
+
+export function unsupportedRequiredFuzzRunnerCapabilities(required: FuzzSuiteContract | FuzzRunnerRequiredCapabilities | readonly string[] | undefined, runnerCapabilities: FuzzSuiteRunnerCapabilities): string[] {
+  const requiredCapabilities = Array.isArray(required)
+    ? [...required]
+    : isFuzzSuiteContract(required)
+      ? fuzzSuiteRequiredRunnerCapabilities(required)
+      : fuzzRunnerRequiredCapabilities(required)
+  const available = new Set([
+    ...runnerCapabilities.capabilities,
+    ...runnerCapabilities.targetKinds.map((kind) => `target:${kind}`),
+    ...(runnerCapabilities.runtimeActionTypes ?? []).map((type) => `runtime-action:${type}`),
+    ...(runnerCapabilities.commands ?? []).map((command) => `command:${command}`),
+  ])
+  return requiredCapabilities.filter((capability) => !available.has(capability))
+}
+
+function fuzzRunnerRequiredCapabilities(required?: FuzzRunnerRequiredCapabilities | unknown, metadata?: Record<string, unknown>): string[] {
+  const requiredRecord = isRecord(required) ? required : undefined
   return dedupeStrings([
-    ...stringArrayField(required, "capabilities"),
-    ...stringArrayField(required, "targetKinds").map((kind) => `target:${kind}`),
-    ...stringArrayField(required, "target_kinds").map((kind) => `target:${kind}`),
-    ...stringArrayField(required, "runtimeActionTypes").map((type) => `runtime-action:${type}`),
-    ...stringArrayField(required, "runtime_action_types").map((type) => `runtime-action:${type}`),
+    ...stringArrayField(requiredRecord, "capabilities"),
+    ...stringArrayField(requiredRecord, "targetKinds").map((kind) => `target:${kind}`),
+    ...stringArrayField(requiredRecord, "target_kinds").map((kind) => `target:${kind}`),
+    ...stringArrayField(requiredRecord, "runtimeActionTypes").map((type) => `runtime-action:${type}`),
+    ...stringArrayField(requiredRecord, "runtime_action_types").map((type) => `runtime-action:${type}`),
+    ...stringArrayField(requiredRecord, "commands").map((command) => `command:${command}`),
     ...stringArrayField(metadata, "requiredCapabilities"),
     ...stringArrayField(metadata, "required_capabilities"),
   ])
@@ -273,6 +335,10 @@ export function fuzzSuiteResetPolicyDiagnostics(input: unknown, caseId?: string)
     })
   }
   return diagnostics
+}
+
+function isFuzzSuiteContract(value: unknown): value is FuzzSuiteContract {
+  return isRecord(value) && value.schema === FUZZ_SUITE_SCHEMA
 }
 
 export function summarizeFuzzCases(cases: readonly Pick<FuzzSuiteCaseResult, "status">[]): FuzzSuiteSummary {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -1,5 +1,5 @@
 import { stripUndefined } from "./object-utils.js"
-import { RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteCaseResetPolicy, fuzzSuiteRequiredRunnerCapabilities, fuzzSuiteResetPolicyDiagnostics, fuzzSuiteResultEnvelope, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResetResult, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteResetPolicy, type FuzzSuiteRunnerCapabilities, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
+import { FUZZ_RUNNER_CAPABILITIES_SCHEMA, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzRunnerCapabilitiesContract, fuzzSuiteCaseResetPolicy, fuzzSuiteRequiredRunnerCapabilities, fuzzSuiteResetPolicyDiagnostics, fuzzSuiteResultEnvelope, unsupportedRequiredFuzzRunnerCapabilities, type FuzzSuiteArtifactRef, type FuzzSuiteCase, type FuzzSuiteCaseResetResult, type FuzzSuiteCaseResult, type FuzzSuiteContract, type FuzzSuiteDiagnostic, type FuzzSuiteResetPolicy, type FuzzSuiteRunnerCapabilities, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
 import type { RuntimeAction, RuntimeActionObservation } from "./runtime-action-adapter.js"
 import type { ExecutionResult, ExecutionSpec, RuntimeCommandDiagnosticsCaptureSpec, RuntimeEpisodeTraceRef } from "./runtime-contracts.js"
 import { WORDPRESS_CRUD_OPERATION_SCHEMA, normalizeWordPressCrudOperation } from "./wordpress-crud-contracts.js"
@@ -115,7 +115,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
       suite,
       cases: suite.cases.map((fuzzCase) => ({ id: fuzzCase.id, status: "skipped", success: false, target: fuzzCase.target ?? suite.target, skipReason: diagnostic.code, diagnostics: [diagnostic] })),
       diagnostics: [diagnostic],
-      metadata: stripUndefined({ ...options.metadata, sourceSchema: suite.schema, runner: "wp-codebox/fuzz-suite-runner/v1", runnerCapabilities }),
+      metadata: stripUndefined({ ...options.metadata, sourceSchema: suite.schema, runner: "wp-codebox/fuzz-suite-runner/v1", runnerCapabilities: fuzzRunnerCapabilitiesContract(runnerCapabilities, suite) }),
     })
   }
 
@@ -312,7 +312,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
       ...options.metadata,
       sourceSchema: suite.schema,
       runner: "wp-codebox/fuzz-suite-runner/v1",
-      runnerCapabilities,
+      runnerCapabilities: fuzzRunnerCapabilitiesContract(runnerCapabilities, suite),
     }),
   })
 }
@@ -755,14 +755,13 @@ function normalizeFuzzSuiteRunnerCapabilities(input: FuzzSuiteRunOptions["runner
     return RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES
   }
   if (Array.isArray(input)) {
-    return { mode: "runtime-backed", capabilities: [...input], targetKinds: DEFAULT_SUPPORTED_TARGET_KINDS }
+    return { schema: FUZZ_RUNNER_CAPABILITIES_SCHEMA, mode: "runtime-backed", capabilities: [...input], targetKinds: DEFAULT_SUPPORTED_TARGET_KINDS, unsupportedRequiredCapabilities: [] }
   }
   return input as FuzzSuiteRunnerCapabilities
 }
 
 function missingRequiredFuzzSuiteCapabilities(suite: FuzzSuiteContract, runnerCapabilities: FuzzSuiteRunnerCapabilities): string[] {
-  const available = new Set([...runnerCapabilities.capabilities, ...runnerCapabilities.targetKinds.map((kind) => `target:${kind}`), ...(runnerCapabilities.runtimeActionTypes ?? []).map((type) => `runtime-action:${type}`)])
-  return fuzzSuiteRequiredRunnerCapabilities(suite).filter((capability) => !available.has(capability))
+  return unsupportedRequiredFuzzRunnerCapabilities(suite, runnerCapabilities)
 }
 
 function requiredCoverageDiagnostics(requireCoverage: boolean | undefined, suite: FuzzSuiteContract, fuzzCase: FuzzSuiteCase, diagnostics: readonly FuzzSuiteDiagnostic[]): FuzzSuiteDiagnostic[] {

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -371,7 +371,7 @@ final class WP_Codebox_Abilities {
 					'output_schema'       => self::fuzz_suite_result_schema(),
 					'execute_callback'    => array( self::class, 'run_fuzz_suite' ),
 					'permission_callback' => array( self::class, 'can_run_agent_task' ),
-					'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-fuzz-suite' ),
+					'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'runner_capabilities' => self::fuzz_suite_runner_capabilities_contract(), 'runner_capabilities_schema' => self::fuzz_runner_capabilities_schema() ),
 				)
 			);
 

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -56,7 +56,7 @@ public static function run_fuzz_suite( array $input ): array|WP_Error {
 	}
 
 	$cases = is_array( $input['cases'] ?? null ) ? $input['cases'] : array();
-	$runner_capabilities = self::fuzz_suite_php_runner_capabilities();
+	$runner_capabilities = self::fuzz_suite_php_runner_capabilities( $input );
 	$missing_capabilities = self::fuzz_suite_missing_required_capabilities( $input, $runner_capabilities );
 	if ( self::fuzz_suite_require_coverage( $input ) && ! empty( $missing_capabilities ) ) {
 		$diagnostic = self::fuzz_suite_diagnostic( 'error', 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported', 'Fuzz suite requires runner capabilities that are not available in PHP in-process mode.', array( 'missing_capabilities' => $missing_capabilities, 'runner_mode' => $runner_capabilities['mode'] ) );
@@ -122,12 +122,29 @@ public static function run_fuzz_suite( array $input ): array|WP_Error {
 	);
 }
 
-/** @return array<string,mixed> */
-private static function fuzz_suite_php_runner_capabilities(): array {
+/** @param array<string,mixed> $suite Optional suite input. @return array<string,mixed> */
+private static function fuzz_suite_php_runner_capabilities( array $suite = array() ): array {
+	return self::fuzz_suite_runner_capabilities_contract( $suite );
+}
+
+/** @param array<string,mixed> $suite Optional suite input. @return array<string,mixed> */
+private static function fuzz_suite_runner_capabilities_contract( array $suite = array() ): array {
+	$capabilities = array(
+		'schema'                          => 'wp-codebox/fuzz-runner-capabilities/v1',
+		'mode'                            => 'php-in-process',
+		'capabilities'                    => array( 'target:ability', 'target:http', 'target:rest' ),
+		'targetKinds'                     => array( 'ability', 'http', 'rest' ),
+		'unsupportedRequiredCapabilities' => array(),
+	);
+	if ( ! empty( $suite ) ) {
+		$capabilities['unsupportedRequiredCapabilities'] = self::fuzz_suite_missing_required_capabilities( $suite, $capabilities );
+	}
 	return array(
-		'mode'         => 'php-in-process',
-		'capabilities' => array( 'target:ability', 'target:http', 'target:rest' ),
-		'targetKinds'  => array( 'ability', 'http', 'rest' ),
+		'schema'                          => $capabilities['schema'],
+		'mode'                            => $capabilities['mode'],
+		'capabilities'                    => $capabilities['capabilities'],
+		'targetKinds'                     => $capabilities['targetKinds'],
+		'unsupportedRequiredCapabilities' => $capabilities['unsupportedRequiredCapabilities'],
 	);
 }
 
@@ -143,6 +160,12 @@ private static function fuzz_suite_missing_required_capabilities( array $suite, 
 	foreach ( (array) ( $runner_capabilities['targetKinds'] ?? array() ) as $kind ) {
 		$available[ 'target:' . (string) $kind ] = true;
 	}
+	foreach ( (array) ( $runner_capabilities['runtimeActionTypes'] ?? array() ) as $type ) {
+		$available[ 'runtime-action:' . (string) $type ] = true;
+	}
+	foreach ( (array) ( $runner_capabilities['commands'] ?? array() ) as $command ) {
+		$available[ 'command:' . (string) $command ] = true;
+	}
 	return array_values( array_filter( $required, static fn( string $capability ): bool => ! isset( $available[ $capability ] ) ) );
 }
 
@@ -156,6 +179,9 @@ private static function fuzz_suite_required_capabilities( array $suite ): array 
 	}
 	foreach ( is_array( $required['runtimeActionTypes'] ?? null ) ? $required['runtimeActionTypes'] : ( is_array( $required['runtime_action_types'] ?? null ) ? $required['runtime_action_types'] : array() ) as $type ) {
 		$capabilities[] = 'runtime-action:' . (string) $type;
+	}
+	foreach ( ( is_array( $required['commands'] ?? null ) ? $required['commands'] : array() ) as $command ) {
+		$capabilities[] = 'command:' . (string) $command;
 	}
 	return array_values( array_unique( array_filter( $capabilities, static fn( string $capability ): bool => '' !== $capability ) ) );
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -698,6 +698,23 @@ private static function wordpress_workload_run_result_schema(): array {
 }
 
 /** @return array<string,mixed> */
+private static function fuzz_runner_capabilities_schema(): array {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'schema'                          => array( 'type' => 'string', 'const' => 'wp-codebox/fuzz-runner-capabilities/v1' ),
+			'mode'                            => array( 'type' => 'string', 'enum' => array( 'php-in-process', 'runtime-backed' ) ),
+			'capabilities'                    => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'targetKinds'                     => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'runtimeActionTypes'              => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'commands'                        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'unsupportedRequiredCapabilities' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'metadata'                        => self::object_property_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
 private static function fuzz_suite_request_schema(): array {
 	return array(
 		'type'       => 'object',

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -508,8 +508,10 @@ assert( 'array' === $result['cases'][22]['metadata']['observations'][1]['return_
 assert( 'wp-codebox/external-http-guardrail/v1' === $result['cases'][22]['metadata']['observations'][1]['payload']['schema'] );
 assert( 1 === $result['cases'][22]['metadata']['observations'][1]['payload']['summary']['blocked'] );
 assert( str_contains( $result['cases'][22]['metadata']['observations'][1]['payload']['requests'][0]['url'], 'token=[redacted]' ) );
+assert( 'wp-codebox/fuzz-runner-capabilities/v1' === $result['metadata']['runnerCapabilities']['schema'] );
 assert( 'php-in-process' === $result['metadata']['runnerCapabilities']['mode'] );
 assert( in_array( 'target:rest', $result['metadata']['runnerCapabilities']['capabilities'], true ) );
+assert( array() === $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'] );
 
 $required_runtime = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 	array(
@@ -517,7 +519,7 @@ $required_runtime = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 		'id'              => 'required-runtime-suite',
 		'requireCoverage' => true,
 		'target'          => array( 'kind' => 'runtime', 'entrypoint' => 'wordpress.admin-page-load' ),
-		'metadata'        => array( 'requiredRunnerCapabilities' => array( 'capabilities' => array( 'target:runtime', 'runtime' ), 'targetKinds' => array( 'runtime' ) ) ),
+		'metadata'        => array( 'requiredRunnerCapabilities' => array( 'capabilities' => array( 'target:runtime', 'runtime' ), 'targetKinds' => array( 'runtime' ), 'commands' => array( 'wordpress.admin-page-load' ) ) ),
 		'cases'           => array( array( 'id' => 'admin-page', 'input' => array( 'args' => array( 'path=plugins.php' ) ) ) ),
 	)
 );
@@ -526,6 +528,7 @@ assert( false === $required_runtime['success'] );
 assert( 'error' === $required_runtime['status'] );
 assert( 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported' === $required_runtime['diagnostics'][0]['code'] );
 assert( 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported' === $required_runtime['cases'][0]['skipReason'] );
+assert( array( 'target:runtime', 'runtime', 'command:wordpress.admin-page-load' ) === $required_runtime['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'] );
 
 $GLOBALS['menu'] = null;
 $GLOBALS['submenu'] = null;

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 
-import { PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzSuiteContract, fuzzSuiteResetPolicyDiagnostics, normalizeFuzzSuiteResetPolicy, planFuzzSuiteCaseExecutionSpec, runFuzzSuite, runWordPressRestMatrix, wordpressRestMatrixContract, wordpressRestMatrixToFuzzSuite, type ExecutionResult, type ExecutionSpec } from "../packages/runtime-core/src/index.js"
+import { PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzRunnerCapabilitiesContract, fuzzSuiteContract, fuzzSuiteResetPolicyDiagnostics, normalizeFuzzSuiteResetPolicy, planFuzzSuiteCaseExecutionSpec, runFuzzSuite, runWordPressRestMatrix, wordpressRestMatrixContract, wordpressRestMatrixToFuzzSuite, type ExecutionResult, type ExecutionSpec } from "../packages/runtime-core/src/index.js"
 
 const executed: ExecutionSpec[] = []
 const result = await runFuzzSuite(fuzzSuiteContract({
@@ -104,6 +104,18 @@ assert.equal(requiredRuntimeOnPhpRunner.status, "error")
 assert.equal(requiredRuntimeOnPhpRunner.success, false)
 assert.equal(requiredRuntimeOnPhpRunner.diagnostics[0]?.code, "fuzz_suite_required_runner_capabilities_unsupported")
 assert.equal(requiredRuntimeOnPhpRunner.cases[0]?.skipReason, "fuzz_suite_required_runner_capabilities_unsupported")
+assert.deepEqual((requiredRuntimeOnPhpRunner.metadata?.runnerCapabilities as { unsupportedRequiredCapabilities?: string[] } | undefined)?.unsupportedRequiredCapabilities, ["target:runtime", "runtime", "command:wordpress.admin-page-load"])
+
+const phpCapabilities = fuzzRunnerCapabilitiesContract(PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, {
+  capabilities: ["target:rest", "runtime"],
+  targetKinds: ["rest", "runtime"],
+  runtimeActionTypes: ["browser"],
+  commands: ["wordpress.rest-request"],
+})
+assert.equal(phpCapabilities.schema, "wp-codebox/fuzz-runner-capabilities/v1")
+assert.equal(phpCapabilities.mode, "php-in-process")
+assert.deepEqual(phpCapabilities.targetKinds, ["ability", "http", "rest"])
+assert.deepEqual(phpCapabilities.unsupportedRequiredCapabilities, ["runtime", "target:runtime", "runtime-action:browser", "command:wordpress.rest-request"])
 
 const skippedCoverageRequired = await runFuzzSuite(fuzzSuiteContract({
   id: "suite-required-coverage-skipped",


### PR DESCRIPTION
## Summary
- Add a public `wp-codebox/fuzz-runner-capabilities/v1` DTO for fuzz runner discovery/readiness.
- Include runner mode, supported target kinds, runtime action types, runtime commands, and unsupported required capabilities in TypeScript APIs and PHP ability metadata.
- Reuse existing fuzz-suite required capability metadata and include command requirements in missing-capability checks.

## Tests
- `npm run test:fuzz-suite-runner`
- `npm run test:playground-fuzz-suite-public`
- `npm run test:php-fuzz-suite-runner`
- `npm run build`

## Notes
- Did not run benchmarks.
- `npm run test:wordpress-plugin-public-runtime-abilities` currently fails on an existing expectation that `wp-codebox/run-wordpress-workload` contains `safe_stub => true`; this PR does not modify that ability.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fuzz runner capability/readiness contract, PHP ability metadata wiring, tests, and PR preparation.