### PR TITLE
Allow public prepared blueprint hydration

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -116,8 +116,24 @@ final class WP_Codebox_Abilities {
 		);
 	}
 
-	public static function can_hydrate_browser_blueprint_ref(): bool {
-		return is_user_logged_in() || current_user_can( 'manage_options' );
+	public static function can_hydrate_browser_blueprint_ref( mixed $request = null ): bool {
+		if ( is_user_logged_in() || current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		if ( ! is_object( $request ) || ! is_callable( array( $request, 'get_param' ) ) ) {
+			return false;
+		}
+
+		$ref = trim( (string) $request->get_param( 'ref' ) );
+		if ( preg_match( '/^prepared:[A-Za-z0-9_-]+:[a-f0-9]{64}$/', $ref ) ) {
+			return true;
+		}
+
+		$cache_key  = sanitize_key( (string) $request->get_param( 'cache_key' ) );
+		$input_hash = strtolower( trim( (string) $request->get_param( 'input_hash' ) ) );
+
+		return '' !== $cache_key && (bool) preg_match( '/^[a-f0-9]{64}$/', $input_hash );
 	}
 
 	/** @param WP_REST_Request $request REST request. @return array<string,mixed>|WP_Error */

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -29,6 +29,24 @@ function sanitize_key( string $key ): string {
 	return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', $key ) ?? '' );
 }
 
+function is_user_logged_in(): bool {
+	return false;
+}
+
+function current_user_can( string $capability ): bool {
+	unset( $capability );
+	return false;
+}
+
+final class WP_Codebox_Test_Request {
+	/** @param array<string,mixed> $params */
+	public function __construct( private array $params ) {}
+
+	public function get_param( string $key ): mixed {
+		return $this->params[ $key ] ?? null;
+	}
+}
+
 function get_transient( string $transient ): mixed {
 	if ( array_key_exists( $transient, $GLOBALS['wp_codebox_test_transients'] ) ) {
 		return $GLOBALS['wp_codebox_test_transients'][ $transient ]['value'];
@@ -78,6 +96,10 @@ require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abili
 $source_digest = str_repeat( 'a', 64 );
 $artifact_digest = str_repeat( 'b', 64 );
 $materialization_digest = str_repeat( 'c', 64 );
+
+expect( WP_Codebox_Abilities::can_hydrate_browser_blueprint_ref( new WP_Codebox_Test_Request( array( 'ref' => 'prepared:studio-native-preview:' . $source_digest ) ) ), 'Expected public prepared blueprint refs to be hydratable.' );
+expect( WP_Codebox_Abilities::can_hydrate_browser_blueprint_ref( new WP_Codebox_Test_Request( array( 'cache_key' => 'studio-native-preview', 'input_hash' => $source_digest ) ) ), 'Expected public prepared blueprint cache key and input hash to be hydratable.' );
+expect( ! WP_Codebox_Abilities::can_hydrate_browser_blueprint_ref( new WP_Codebox_Test_Request( array( 'ref' => 'prepared:studio-native-preview:not-a-hash' ) ) ), 'Expected malformed public prepared blueprint refs to remain forbidden.' );
 
 $miss = WP_Codebox_Abilities::get_browser_contained_site_status(
 	array(


### PR DESCRIPTION
## Summary
- allow unauthenticated hydration of well-formed opaque prepared-runtime blueprint refs
- preserve authenticated access and keep malformed public requests forbidden
- add PHP contained-site smoke coverage for public prepared blueprint refs

## Why
Static Site Importer can now ask WP Codebox for prepared preview refs, but Playground loads the blueprint URL without a WordPress login. The hydration endpoint therefore needs to accept opaque prepared refs publicly while still rejecting malformed refs.

## Testing
- php scripts/php-browser-contained-site-contract-smoke.php
- npm run test:php-browser-contained-site-contract
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the SSI-to-Codebox Playground hydration failure, drafting the permission contract change, and running verification.