### PR TITLE
Return raw browser blueprints

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -148,13 +148,18 @@ final class WP_Codebox_Abilities {
 
 	/** @param WP_REST_Request $request REST request. @return array<string,mixed>|WP_Error */
 	public static function rest_browser_blueprint_ref( WP_REST_Request $request ): array|WP_Error {
-		return self::hydrate_browser_blueprint_ref(
+		$hydration = self::hydrate_browser_blueprint_ref(
 			array(
 				'ref'        => (string) $request->get_param( 'ref' ),
 				'cache_key'  => (string) $request->get_param( 'cache_key' ),
 				'input_hash' => (string) $request->get_param( 'input_hash' ),
 			)
 		);
+		if ( is_wp_error( $hydration ) ) {
+			return $hydration;
+		}
+
+		return is_array( $hydration['blueprint'] ?? null ) ? $hydration['blueprint'] : array();
 	}
 
 	/** @param WP_REST_Request $request REST request. @return array<string,mixed>|WP_Error */

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -47,6 +47,15 @@ final class WP_Codebox_Test_Request {
 	}
 }
 
+final class WP_REST_Request {
+	/** @param array<string,mixed> $params */
+	public function __construct( private array $params ) {}
+
+	public function get_param( string $key ): mixed {
+		return $this->params[ $key ] ?? null;
+	}
+}
+
 function get_transient( string $transient ): mixed {
 	if ( array_key_exists( $transient, $GLOBALS['wp_codebox_test_transients'] ) ) {
 		return $GLOBALS['wp_codebox_test_transients'][ $transient ]['value'];
@@ -144,6 +153,11 @@ $GLOBALS['wp_codebox_test_transient'] = array(
 	'created_at'             => '2026-01-02T03:04:05+00:00',
 	'blueprint'              => array( 'steps' => array() ),
 );
+
+$rest_blueprint = WP_Codebox_Abilities::rest_browser_blueprint_ref( new WP_REST_Request( array( 'ref' => 'prepared:studio-native-preview:' . $source_digest ) ) );
+expect( ! is_wp_error( $rest_blueprint ), 'Expected REST blueprint ref to return a raw Blueprint.' );
+expect( ! isset( $rest_blueprint['success'] ), 'Expected REST blueprint ref to omit the hydration envelope.' );
+expect( isset( $rest_blueprint['steps'] ) && is_array( $rest_blueprint['steps'] ), 'Expected REST blueprint ref to return the Blueprint root.' );
 
 $status = WP_Codebox_Abilities::get_browser_contained_site_status(
 	array(


### PR DESCRIPTION
## Summary
- make the browser blueprint-ref REST endpoint return the raw Playground Blueprint JSON
- keep the internal hydration ability envelope unchanged
- add smoke coverage that the REST callback omits the hydration envelope and returns the Blueprint root

## Why
Playground consumes `blueprint-url` endpoints as raw Blueprint data. Returning the internal hydration envelope causes Playground validation to fail on the top-level `success` property.

## Testing
- php scripts/php-browser-contained-site-contract-smoke.php
- npm run test:php-browser-contained-site-contract
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Playground Blueprint schema validation failure, drafting the REST response fix, and running verification.
