### PR TITLE
Include browser recipes in blueprints

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -40,6 +40,13 @@ trait WP_Codebox_Abilities_Browser_Runner {
 
 	$runner_php      = self::browser_agent_runner_php( $task_input, $session_id, $task_path, $result_path, $invocation, $captures );
 	$runner_contract = self::browser_agent_runner_contract( $runner_php );
+	$runtime_blueprint = self::browser_playground_blueprint( $blueprint, $playground );
+	$runtime_steps = is_array( $runtime_blueprint['steps'] ?? null ) ? $runtime_blueprint['steps'] : array();
+	$runtime_steps[] = array(
+		'step' => 'runPHP',
+		'code' => $runner_php,
+	);
+	$runtime_blueprint['steps'] = $runtime_steps;
 
 	return array(
 		'schema'   => 'wp-codebox/workspace-recipe/v1',
@@ -47,7 +54,7 @@ trait WP_Codebox_Abilities_Browser_Runner {
 			'backend'   => 'wordpress-playground',
 			'name'      => 'browser-playground',
 			'wp'        => (string) ( $playground['wp'] ?? 'latest' ),
-			'blueprint' => self::browser_playground_blueprint( $blueprint, $playground ),
+			'blueprint' => $runtime_blueprint,
 		),
 		'inputs'   => array(
 			'stagedFiles' => array(

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1693,6 +1693,11 @@ public static function create_browser_playground_session( array $input ): array|
 	if ( is_wp_error( $recipe ) ) {
 		return $recipe;
 	}
+	$recipe_blueprint = is_array( $recipe['runtime']['blueprint'] ?? null ) ? $recipe['runtime']['blueprint'] : $blueprint;
+	if ( is_array( $runtime['prepared_runtime'] ?? null ) ) {
+		self::browser_prepared_runtime_cache_store( $runtime['prepared_runtime'], $recipe_blueprint );
+	}
+	$blueprint = $recipe_blueprint;
 	$materialization = self::browser_materialization_contract( $recipe );
 
 	$session = array(

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -97,8 +97,11 @@ function expect( bool $condition, string $message ): void {
 }
 
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-workload.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-path-policy.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agent-task.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-browser-runner-template.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
 
@@ -158,6 +161,42 @@ $rest_blueprint = WP_Codebox_Abilities::rest_browser_blueprint_ref( new WP_REST_
 expect( ! is_wp_error( $rest_blueprint ), 'Expected REST blueprint ref to return a raw Blueprint.' );
 expect( ! isset( $rest_blueprint['success'] ), 'Expected REST blueprint ref to omit the hydration envelope.' );
 expect( isset( $rest_blueprint['steps'] ) && is_array( $rest_blueprint['steps'] ), 'Expected REST blueprint ref to return the Blueprint root.' );
+
+$recipe_method = new ReflectionMethod( WP_Codebox_Abilities::class, 'browser_agent_recipe' );
+$recipe = $recipe_method->invoke(
+	null,
+	array(
+		'goal'               => 'Import a browser artifact.',
+		'target'             => array( 'kind' => 'recipe-smoke' ),
+		'expected_artifacts' => array( 'preview' ),
+	),
+	'recipe-smoke-session',
+	array(
+		'task_path'   => '/tmp/recipe-smoke-task.json',
+		'result_path' => '/tmp/recipe-smoke-result.json',
+		'invocation'  => array(
+			'type'  => 'ability',
+			'name'  => 'static-site-importer/import-website-artifact',
+			'input' => array(),
+		),
+	),
+	array(
+		'steps' => array(
+			array(
+				'step'     => 'login',
+				'username' => 'admin',
+				'password' => 'password',
+			),
+		),
+	),
+	array(),
+	array( 'schema' => 'wp-codebox/browser-agent-task-payload/v1' )
+);
+expect( ! is_wp_error( $recipe ), 'Expected browser agent recipe smoke to build.' );
+$recipe_steps = is_array( $recipe['runtime']['blueprint']['steps'] ?? null ) ? $recipe['runtime']['blueprint']['steps'] : array();
+$recipe_run_php_steps = array_values( array_filter( $recipe_steps, static fn( array $step ): bool => 'runPHP' === ( $step['step'] ?? '' ) ) );
+expect( count( $recipe_run_php_steps ) >= 1, 'Expected browser recipe Blueprint to include the runner runPHP step.' );
+expect( str_contains( (string) ( $recipe_run_php_steps[0]['code'] ?? '' ), 'static-site-importer/import-website-artifact' ), 'Expected browser recipe Blueprint runPHP step to execute the requested invocation.' );
 
 $status = WP_Codebox_Abilities::get_browser_contained_site_status(
 	array(


### PR DESCRIPTION
## Summary
- include the browser runner recipe's `runPHP` materialization step in the public Playground Blueprint
- update prepared-runtime cache entries with the full runnable recipe Blueprint after recipe generation
- add smoke coverage that browser recipe Blueprints include the requested ability invocation

## Why
Static Site Importer can generate a Playground open URL, but Playground was only hydrating the base runtime Blueprint. That booted a default WordPress site without running the SSI import recipe. The hydrated Blueprint needs the Codebox browser runner step so opening Playground performs the import.

## Testing
- php scripts/php-browser-contained-site-contract-smoke.php
- npm run test:php-browser-contained-site-contract
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing Playground import step, drafting the recipe Blueprint/cache fix, and running verification.
