### PR TITLE
Use fresh browser recipe blueprints

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1702,7 +1702,6 @@ public static function create_browser_playground_session( array $input ): array|
 	$blueprint      = self::browser_blueprint_with_runtime( $base_blueprint, $runtime, $playground );
 	$prepared_runtime = self::browser_prepared_runtime_with_blueprints( is_array( $runtime['prepared_runtime'] ?? null ) ? $runtime['prepared_runtime'] : array(), $blueprint, $playground );
 	$runtime['prepared_runtime'] = $prepared_runtime;
-	$blueprint       = self::browser_selected_prepared_runtime_blueprint( $prepared_runtime, $blueprint );
 	$contained_site  = self::browser_contained_site_envelope( $input, $session_id, $playground, $runtime, $prepared_runtime, 'ready' );
 	$artifacts       = self::browser_artifact_files( $input );
 	if ( is_wp_error( $artifacts ) ) {


### PR DESCRIPTION
## Summary
- keep browser recipe generation based on the fresh runtime Blueprint instead of a previously hydrated prepared Blueprint
- continue writing the final runnable recipe Blueprint back to the prepared-runtime cache for Playground hydration

## Why
Repeated Figma previews could hydrate a Blueprint with multiple runner steps: the cached prepared Blueprint already contained a runner step, and the new recipe appended another one. The fresh recipe should be built from the current runtime dependencies and current artifact payload, then cached as the final hydrated Blueprint.

## Testing
- php scripts/php-browser-contained-site-contract-smoke.php
- npm run test:php-browser-contained-site-contract
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing stale prepared Blueprint reuse, drafting the fix, and running verification.
