### PR TITLE
Support browser function invocations

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
@@ -364,6 +364,13 @@ if ( empty( $preflight['error'] ) && ! empty( $failed_imports ) ) {
 if ( empty( $preflight['error'] ) && ! $provider_ready ) {
 	$preflight['error'] = new WP_Error( 'wp_codebox_browser_provider_unavailable', 'The browser runtime provider is not ready for sandbox invocation.', array( 'provider' => (string) ( $input['provider'] ?? '' ), 'model' => (string) ( $input['model'] ?? '' ) ) );
 }
+if ( empty( $preflight['error'] ) && 'function' === $invocation_type ) {
+	$function = (string) ( $invocation['name'] ?? '' );
+	$preflight['function'] = $function;
+	if ( '' === $function || ! function_exists( $function ) ) {
+		$preflight['error'] = new WP_Error( 'wp_codebox_browser_function_unavailable', 'The requested function is not available inside the Playground site.', array( 'function' => $function ) );
+	}
+}
 if ( empty( $preflight['error'] ) && 'task' === $invocation_type ) {
 	$hook = (string) ( $invocation['hook'] ?? $invocation['name'] ?? '' );
 	$preflight['hook'] = $hook;
@@ -371,7 +378,7 @@ if ( empty( $preflight['error'] ) && 'task' === $invocation_type ) {
 		$preflight['error'] = new WP_Error( 'wp_codebox_browser_task_unavailable', 'The requested sandbox task hook is not registered inside the Playground site.', array( 'hook' => $hook ) );
 	}
 }
-if ( empty( $preflight['error'] ) && 'task' !== $invocation_type ) {
+if ( empty( $preflight['error'] ) && ! in_array( $invocation_type, array( 'function', 'task' ), true ) ) {
 	$ability_names = wp_codebox_browser_runtime_ability_names();
 	$ability_name = (string) ( $invocation['name'] ?? $ability_names['chat'] ?? '' );
 	$preflight['ability'] = $ability_name;
@@ -400,7 +407,9 @@ if ( null === $response ) {
 		add_filter( $permission_filter_hook, $permission_filter, 999, 3 );
 	}
 	try {
-		if ( 'task' === (string) ( $invocation['type'] ?? 'ability' ) ) {
+		if ( 'function' === (string) ( $invocation['type'] ?? 'ability' ) ) {
+			$response = call_user_func( (string) ( $invocation['name'] ?? '' ), $input );
+		} elseif ( 'task' === (string) ( $invocation['type'] ?? 'ability' ) ) {
 			$response = apply_filters( (string) ( $invocation['hook'] ?? $invocation['name'] ?? '' ), null, $input, $payload );
 		} else {
 			$ability_names = wp_codebox_browser_runtime_ability_names();

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -117,8 +117,8 @@ private static function browser_materialization_contract( array $recipe ): array
 private static function browser_runner_invocation( array $runner ): array|WP_Error {
 	$invocation = is_array( $runner['invocation'] ?? null ) ? $runner['invocation'] : array();
 	$type       = self::safe_key( (string) ( $invocation['type'] ?? 'ability' ) );
-	if ( ! in_array( $type, array( 'ability', 'task' ), true ) ) {
-		return new WP_Error( 'wp_codebox_browser_invocation_type_invalid', 'Browser runner invocation type must be ability or task.', array( 'status' => 400 ) );
+	if ( ! in_array( $type, array( 'ability', 'function', 'task' ), true ) ) {
+		return new WP_Error( 'wp_codebox_browser_invocation_type_invalid', 'Browser runner invocation type must be ability, function, or task.', array( 'status' => 400 ) );
 	}
 
 	$name = trim( (string) ( $invocation['name'] ?? '' ) );
@@ -127,6 +127,10 @@ private static function browser_runner_invocation( array $runner ): array|WP_Err
 		$name = '' !== $name ? $name : ( function_exists( 'apply_filters' ) ? trim( (string) apply_filters( 'wp_codebox_browser_runtime_default_ability', '' ) ) : '' );
 		if ( ! preg_match( '#^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$#', $name ) ) {
 			return new WP_Error( 'wp_codebox_browser_invocation_name_invalid', 'Browser runner ability names must use namespace/name form.', array( 'status' => 400 ) );
+		}
+	} elseif ( 'function' === $type ) {
+		if ( '' === $name || ! preg_match( '#^[A-Za-z_][A-Za-z0-9_]*$#', $name ) ) {
+			return new WP_Error( 'wp_codebox_browser_invocation_function_invalid', 'Browser runner function names must be safe PHP function names.', array( 'status' => 400 ) );
 		}
 	} elseif ( '' === $hook || ! preg_match( '#^[A-Za-z0-9_.:-]+$#', $hook ) ) {
 		return new WP_Error( 'wp_codebox_browser_invocation_hook_invalid', 'Browser runner task hooks must be safe WordPress hook names.', array( 'status' => 400 ) );

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -198,6 +198,32 @@ $recipe_run_php_steps = array_values( array_filter( $recipe_steps, static fn( ar
 expect( count( $recipe_run_php_steps ) >= 1, 'Expected browser recipe Blueprint to include the runner runPHP step.' );
 expect( str_contains( (string) ( $recipe_run_php_steps[0]['code'] ?? '' ), 'static-site-importer/import-website-artifact' ), 'Expected browser recipe Blueprint runPHP step to execute the requested invocation.' );
 
+$function_recipe = $recipe_method->invoke(
+	null,
+	array(
+		'goal'               => 'Import through a direct runtime function.',
+		'target'             => array( 'kind' => 'function-smoke' ),
+		'expected_artifacts' => array( 'preview' ),
+	),
+	'function-smoke-session',
+	array(
+		'task_path'   => '/tmp/function-smoke-task.json',
+		'result_path' => '/tmp/function-smoke-result.json',
+		'invocation'  => array(
+			'type'  => 'function',
+			'name'  => 'static_site_importer_ability_import_website_artifact',
+			'input' => array(),
+		),
+	),
+	array( 'steps' => array() ),
+	array(),
+	array( 'schema' => 'wp-codebox/browser-agent-task-payload/v1' )
+);
+expect( ! is_wp_error( $function_recipe ), 'Expected browser function recipe smoke to build.' );
+$function_code = (string) ( $function_recipe['runtime']['blueprint']['steps'][0]['code'] ?? '' );
+expect( str_contains( $function_code, "'type' => 'function'" ), 'Expected browser recipe to preserve function invocation type.' );
+expect( str_contains( $function_code, 'static_site_importer_ability_import_website_artifact' ), 'Expected browser recipe to preserve direct function invocation name.' );
+
 $status = WP_Codebox_Abilities::get_browser_contained_site_status(
 	array(
 		'cache_key'     => 'studio-native-preview',


### PR DESCRIPTION
## Summary
- add `function` as a browser runner invocation type
- validate safe PHP function names at request time
- preflight callable availability and execute the function directly inside Playground
- add smoke coverage for browser function recipes

## Why
Static Site Importer previews run inside a bare Playground where the Abilities API may not be available. Calling SSI's import function directly avoids requiring `wp_register_ability`/`wp_get_ability` in the runtime while still keeping Codebox's preflight and materialization envelope.

## Testing
- php scripts/php-browser-contained-site-contract-smoke.php
- npm run test:php-browser-contained-site-contract
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing Abilities API runtime dependency, drafting direct function invocation support, and running verification.
