### PR TITLE
Capture REST DB profiler queries through query filter

### DIFF
--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -442,6 +442,11 @@ function wp_codebox_bench_rest_db_query_profile_case_step(array $request_case, i
     return $step;
 }
 
+function wp_codebox_bench_rest_db_query_profile_filter_query($query, array &$captured_queries) {
+    $captured_queries[] = array((string) $query, 0.0, 'query filter');
+    return $query;
+}
+
 function wp_codebox_bench_run_rest_db_query_profiler_step(array $step): array {
     global $wpdb;
 
@@ -480,9 +485,25 @@ function wp_codebox_bench_run_rest_db_query_profiler_step(array $step): array {
                 continue;
             }
             $case_step = wp_codebox_bench_rest_db_query_profile_case_step($request_case, $index);
+            $captured_queries = array();
+            $query_filter = static function ($query) use (&$captured_queries) {
+                return wp_codebox_bench_rest_db_query_profile_filter_query($query, $captured_queries);
+            };
             $before = is_array($wpdb->queries ?? null) ? count($wpdb->queries) : 0;
-            $payload = wp_codebox_bench_run_rest_request_step($case_step);
+            if (function_exists('add_filter')) {
+                add_filter('query', $query_filter, PHP_INT_MAX, 1);
+            }
+            try {
+                $payload = wp_codebox_bench_run_rest_request_step($case_step);
+            } finally {
+                if (function_exists('remove_filter')) {
+                    remove_filter('query', $query_filter, PHP_INT_MAX);
+                }
+            }
             $after_queries = is_array($wpdb->queries ?? null) ? array_slice($wpdb->queries, $before) : array();
+            if (empty($after_queries) && !empty($captured_queries)) {
+                $after_queries = $captured_queries;
+            }
             $summary = wp_codebox_bench_rest_db_query_profile_summary($after_queries);
             $samples = array();
             foreach (array_slice($after_queries, 0, $sample_limit) as $query) {

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -76,6 +76,7 @@ const restDbQueryProfilerHelpers = [
   "wp_codebox_bench_redact_sql_query",
   "wp_codebox_bench_rest_db_query_profile_summary",
   "wp_codebox_bench_rest_db_query_profile_case_step",
+  "wp_codebox_bench_rest_db_query_profile_filter_query",
   "wp_codebox_bench_run_rest_db_query_profiler_step",
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
@@ -158,15 +159,19 @@ class WP_REST_Request {
     public function set_body($body) {}
 }
 class WP_Codebox_Test_REST_Response { public function get_status() { return 200; } }
+define('SAVEQUERIES', false);
+$wp_codebox_test_filters = array();
+function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) { global $wp_codebox_test_filters; $wp_codebox_test_filters[$hook][$priority][] = $callback; }
+function remove_filter($hook, $callback, $priority = 10) { global $wp_codebox_test_filters; foreach ($wp_codebox_test_filters[$hook][$priority] ?? array() as $index => $registered_callback) { if ($registered_callback === $callback) { unset($wp_codebox_test_filters[$hook][$priority][$index]); } } }
+function apply_filters($hook, $value) { global $wp_codebox_test_filters; foreach ($wp_codebox_test_filters[$hook] ?? array() as $callbacks) { foreach ($callbacks as $callback) { $value = $callback($value); } } return $value; }
 function is_wp_error($value) { return false; }
 function rest_do_request($request) {
-    global $wpdb;
-    $wpdb->queries[] = array("SELECT * FROM wp_posts WHERE post_title = 'private title' AND ID = 123", 0.002, 'wpdb->get_results');
-    $wpdb->queries[] = array("UPDATE wp_options SET option_value = 'secret' WHERE option_id = 45", 0.003, 'wpdb->query');
+    apply_filters('query', "SELECT * FROM wp_posts WHERE post_title = 'private title' AND ID = 123");
+    apply_filters('query', "UPDATE wp_options SET option_value = 'secret' WHERE option_id = 45");
     return new WP_Codebox_Test_REST_Response();
 }
 function rest_get_server() { return new class { public function response_to_data($response, $embed) { return array('ok' => true); } }; }
-$wpdb = (object) array('queries' => array(), 'save_queries' => false);
+$wpdb = (object) array('save_queries' => false);
 ${restDbQueryProfilerHelpers}
 $payload = wp_codebox_bench_run_rest_db_query_profiler_step(array(
     'type' => 'rest-db-query-profiler',


### PR DESCRIPTION
## Summary
- Capture profiled REST SQL through a temporary WordPress query filter.
- Keep using $wpdb->queries when SAVEQUERIES is active so timings remain available.
- Cover the fallback path where SAVEQUERIES is already defined false.

## Testing
- npm run test:bench-command-step-behavior
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the profiler attribution gap, drafting the runtime fix, and updating targeted tests.