### PR TITLE
Ensure CLI build output is executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "node ./node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli",
+    "build": "node ./node_modules/typescript/bin/tsc -b packages/runtime-core packages/runtime-playground packages/cli && node scripts/ensure-cli-bin-executable.mjs",
     "prepare": "npm run build",
     "package:wordpress-plugin": "tsx scripts/build-wordpress-plugin-zip.ts",
     "release:package": "tsx scripts/package-release-artifact.ts",

--- a/scripts/ensure-cli-bin-executable.mjs
+++ b/scripts/ensure-cli-bin-executable.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { chmodSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, resolve } from "node:path"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+chmodSync(resolve(root, "packages/cli/dist/index.js"), 0o755)


### PR DESCRIPTION
## Summary
- Run a post-build chmod step for the generated CLI bin entrypoint.
- Keep direct spawns of packages/cli/dist/index.js working after fresh builds and cache syncs.

## Testing
- npm run build
- npm run test:bench-command-step-behavior
- Verified packages/cli/dist/index.js is executable after build.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runner EACCES failure, drafting the build-mode fix, and verifying the packaging behavior.