### PR TITLE
Capture fuzz suite REST DB queries through query filter

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1273,9 +1273,26 @@ private static function profile_fuzz_suite_rest_request_queries( array $case, in
 	foreach ( is_array( $case['params'] ?? null ) ? $case['params'] : array() as $key => $value ) {
 		$request->set_param( (string) $key, $value );
 	}
+	$captured_queries = array();
+	$query_filter     = static function ( $query ) use ( &$captured_queries ) {
+		$captured_queries[] = array( (string) $query, 0.0, 'query filter' );
+		return $query;
+	};
 	$before = is_object( $wpdb ) && is_array( $wpdb->queries ?? null ) ? count( $wpdb->queries ) : 0;
-	$response = rest_do_request( $request );
+	if ( function_exists( 'add_filter' ) ) {
+		add_filter( 'query', $query_filter, PHP_INT_MAX, 1 );
+	}
+	try {
+		$response = rest_do_request( $request );
+	} finally {
+		if ( function_exists( 'remove_filter' ) ) {
+			remove_filter( 'query', $query_filter, PHP_INT_MAX );
+		}
+	}
 	$after_queries = is_object( $wpdb ) && is_array( $wpdb->queries ?? null ) ? array_slice( $wpdb->queries, $before ) : array();
+	if ( empty( $after_queries ) && ! empty( $captured_queries ) ) {
+		$after_queries = $captured_queries;
+	}
 	$queries = array_slice( array_map( static fn( mixed $query ): array => self::normalize_fuzz_suite_query_sample( $query, $query_length_limit ), $after_queries ), 0, max( 0, $sample_limit ) );
 	return array( 'id' => (string) ( $case['id'] ?? $path ), 'method' => strtoupper( (string) ( $case['method'] ?? 'GET' ) ), 'path' => $path, 'status' => (int) $response->get_status(), 'queryCount' => count( $after_queries ), 'sampledQueries' => $queries );
 }

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -28,12 +28,22 @@ define( 'WP_CONTENT_DIR', __DIR__ );
 define( 'ARRAY_A', 'ARRAY_A' );
 
 function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
-	$GLOBALS['wp_codebox_test_filters'][ $hook ][] = array( $callback, $accepted_args );
+	$GLOBALS['wp_codebox_test_filters'][ $hook ][ $priority ][] = array( $callback, $accepted_args );
+}
+
+function remove_filter( string $hook, callable $callback, int $priority = 10 ): void {
+	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ][ $priority ] ?? array() as $index => $filter ) {
+		if ( $filter[0] === $callback ) {
+			unset( $GLOBALS['wp_codebox_test_filters'][ $hook ][ $priority ][ $index ] );
+		}
+	}
 }
 
 function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
-	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array() as $filter ) {
-		$value = $filter[0]( $value, ...array_slice( $args, 0, (int) $filter[1] - 1 ) );
+	foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array() as $filters ) {
+		foreach ( $filters as $filter ) {
+			$value = $filter[0]( $value, ...array_slice( $args, 0, (int) $filter[1] - 1 ) );
+		}
 	}
 	return $value;
 }
@@ -116,11 +126,8 @@ class WP_Codebox_Test_REST_Response {
 }
 
 function rest_do_request( WP_REST_Request $request ): WP_Codebox_Test_REST_Response {
-	global $wpdb;
-	if ( is_object( $wpdb ) && is_array( $wpdb->queries ?? null ) ) {
-		$wpdb->queries[] = array( 'SELECT * FROM wp_posts WHERE post_type = "post"', 0.002, 'rest_do_request' );
-		$wpdb->queries[] = array( 'SELECT option_value FROM wp_options WHERE option_name = "blogname"', 0.001, 'rest_do_request' );
-	}
+	apply_filters( 'query', 'SELECT * FROM wp_posts WHERE post_type = "post"' );
+	apply_filters( 'query', 'SELECT option_value FROM wp_options WHERE option_name = "blogname"' );
 	return new WP_Codebox_Test_REST_Response( '/wp/v2/status' === $request->path ? 200 : 404 );
 }
 


### PR DESCRIPTION
## Summary
- Capture REST DB profiler SQL through a temporary WordPress query filter in the PHP fuzz-suite ability path.
- Keep using $wpdb->queries when available, with query-filter captures as fallback.
- Update the PHP fuzz-suite smoke fixture to cover the no-$wpdb->queries case used by the active runner path.

## Testing
- npm run test:php-fuzz-suite-runner
- npm run test:bench-command-step-behavior
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the active PHP ability query attribution gap, drafting the fallback, and updating smoke coverage.