### PR TITLE
Redact fuzz suite REST DB query samples

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1339,7 +1339,11 @@ private static function refresh_fuzz_suite_rest_server(): void {
 private static function normalize_fuzz_suite_query_sample( mixed $query, int $query_length_limit ): array {
 	$sql = is_array( $query ) ? (string) ( $query[0] ?? '' ) : (string) $query;
 	$time = is_array( $query ) ? (float) ( $query[1] ?? 0 ) : 0.0;
-	return array_filter( array( 'sql' => substr( $sql, 0, max( 0, $query_length_limit ) ), 'time' => $time ), static fn( mixed $value ): bool => '' !== $value && 0.0 !== $value );
+	$redacted = preg_replace( "/'(?:''|[^'])*'/", "'?'", $sql );
+	$redacted = preg_replace( '/\\b\\d+(?:\\.\\d+)?\\b/', '?', is_string( $redacted ) ? $redacted : $sql );
+	$redacted = preg_replace( '/\\s+/', ' ', is_string( $redacted ) ? $redacted : $sql );
+	$redacted = trim( (string) $redacted );
+	return array_filter( array( 'sql' => substr( $redacted, 0, max( 0, $query_length_limit ) ), 'time' => $time ), static fn( mixed $value ): bool => '' !== $value && 0.0 !== $value );
 }
 
 /** @param array<string,mixed> $observation Observation. @return array<string,mixed> */

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -126,7 +126,7 @@ class WP_Codebox_Test_REST_Response {
 }
 
 function rest_do_request( WP_REST_Request $request ): WP_Codebox_Test_REST_Response {
-	apply_filters( 'query', 'SELECT * FROM wp_posts WHERE post_type = "post"' );
+	apply_filters( 'query', "SELECT * FROM wp_posts WHERE post_type = 'secret-post-type' AND ID = 123" );
 	apply_filters( 'query', 'SELECT option_value FROM wp_options WHERE option_name = "blogname"' );
 	return new WP_Codebox_Test_REST_Response( '/wp/v2/status' === $request->path ? 200 : 404 );
 }
@@ -508,7 +508,8 @@ $workload_report = json_decode( file_get_contents( WP_CONTENT_DIR . '/uploads/wo
 assert( 'wp-codebox/json-workload-result/v1' === $workload_report['schema'] );
 assert( 2 === $workload_report['steps'][1]['observation']['queryCount'] );
 assert( 2 === $workload_report['steps'][1]['requests'][0]['queryCount'] );
-assert( 'SELECT * FROM wp_posts WHERE post_type = "post"' === $workload_report['steps'][1]['requests'][0]['sampledQueries'][0]['sql'] );
+assert( "SELECT * FROM wp_posts WHERE post_type = '?' AND ID = ?" === $workload_report['steps'][1]['requests'][0]['sampledQueries'][0]['sql'] );
+assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['requests'][0]['sampledQueries'] ), 'secret-post-type' ) );
 assert( 'closure-external-http-guardrail' === $result['cases'][22]['id'] );
 assert( 'passed' === $result['cases'][22]['status'] );
 assert( 'array' === $result['cases'][22]['metadata']['observations'][1]['return_type'] );


### PR DESCRIPTION
## Summary
- Redact quoted strings and numeric literals in PHP fuzz-suite REST DB query samples.
- Keep query counts intact while preventing sampled SQL from exposing generated salts, session keys, IDs, or literal values.
- Extend the PHP fuzz-suite smoke test to prove sampled SQL redaction.

## Testing
- npm run test:php-fuzz-suite-runner
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Identifying raw SQL literal leakage in profiler evidence, drafting the redaction fix, and updating smoke coverage.