### PR TITLE
Add fuzz coverage plan artifacts

### DIFF
--- a/packages/runtime-core/src/contracts.ts
+++ b/packages/runtime-core/src/contracts.ts
@@ -1,6 +1,7 @@
 /** Inspectable Codebox contract metadata for CLI and orchestrator consumers. */
 export * from "./browser-probe-contract.js"
 export * from "./command-registry.js"
+export * from "./fuzz-coverage-plan-contracts.js"
 export * from "./fuzz-suite-contracts.js"
 export * from "./runtime-contract-manifest.js"
 export * from "./wordpress-page-load-contracts.js"

--- a/packages/runtime-core/src/fuzz-coverage-plan-contracts.ts
+++ b/packages/runtime-core/src/fuzz-coverage-plan-contracts.ts
@@ -37,8 +37,11 @@ export interface FuzzCoveragePlanSummary {
   discovered: number
   generated: number
   executable: number
+  executed: number
   skipped: number
   untested: number
+  caseIds: string[]
+  targetIds: string[]
 }
 
 export interface FuzzCoveragePlanContract {
@@ -48,6 +51,7 @@ export interface FuzzCoveragePlanContract {
   discovered: FuzzCoveragePlanItem[]
   generated: FuzzCoveragePlanItem[]
   executable: FuzzCoveragePlanItem[]
+  executed: FuzzCoveragePlanItem[]
   skipped: FuzzCoveragePlanItem[]
   untested: FuzzCoveragePlanItem[]
   parameterGenerationHooks?: FuzzCoveragePlanParameterGenerationHook[]
@@ -61,6 +65,7 @@ export function fuzzCoveragePlanContract(input: {
   discovered?: FuzzCoveragePlanItem[]
   generated?: FuzzCoveragePlanItem[]
   executable?: FuzzCoveragePlanItem[]
+  executed?: FuzzCoveragePlanItem[]
   skipped?: FuzzCoveragePlanItem[]
   untested?: FuzzCoveragePlanItem[]
   parameterGenerationHooks?: FuzzCoveragePlanParameterGenerationHook[]
@@ -69,8 +74,10 @@ export function fuzzCoveragePlanContract(input: {
   const discovered = input.discovered ?? []
   const generated = input.generated ?? []
   const executable = input.executable ?? []
+  const executed = input.executed ?? []
   const skipped = input.skipped ?? []
   const untested = input.untested ?? []
+  const allItems = [...discovered, ...generated, ...executable, ...executed, ...skipped, ...untested]
 
   return stripUndefined({
     schema: FUZZ_COVERAGE_PLAN_SCHEMA,
@@ -79,6 +86,7 @@ export function fuzzCoveragePlanContract(input: {
     discovered,
     generated,
     executable,
+    executed,
     skipped,
     untested,
     parameterGenerationHooks: input.parameterGenerationHooks?.length ? input.parameterGenerationHooks : undefined,
@@ -86,9 +94,16 @@ export function fuzzCoveragePlanContract(input: {
       discovered: discovered.length,
       generated: generated.length,
       executable: executable.length,
+      executed: executed.length,
       skipped: skipped.length,
       untested: untested.length,
+      caseIds: uniqueStrings(allItems.map((item) => item.id)),
+      targetIds: uniqueStrings(allItems.map((item) => item.target?.id ?? item.target?.entrypoint ?? item.target?.kind)),
     },
     metadata: input.metadata,
   })
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))]
 }

--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -1,4 +1,5 @@
 import { stripUndefined } from "./object-utils.js"
+import { fuzzCoveragePlanContract, type FuzzCoveragePlanContract, type FuzzCoveragePlanItem } from "./fuzz-coverage-plan-contracts.js"
 
 export const FUZZ_SUITE_SCHEMA = "wp-codebox/fuzz-suite/v1" as const
 export const FUZZ_SUITE_RESULT_SCHEMA = "wp-codebox/fuzz-suite-result/v1" as const
@@ -59,6 +60,7 @@ export interface FuzzSuiteContract {
   resetPolicy?: FuzzSuiteResetPolicy
   reset_policy?: FuzzSuiteResetPolicy | string
   cases: FuzzSuiteCase[]
+  coveragePlan?: FuzzCoveragePlanContract
   metadata?: Record<string, unknown>
 }
 
@@ -186,6 +188,7 @@ export interface FuzzSuiteResultEnvelope {
   success: boolean
   summary: FuzzSuiteSummary
   coverageSummary?: FuzzSuiteCoverageSummary
+  coveragePlan?: FuzzCoveragePlanContract
   cases: FuzzSuiteCaseResult[]
   diagnostics: FuzzSuiteDiagnostic[]
   artifactRefs: FuzzSuiteArtifactRef[]
@@ -199,6 +202,7 @@ export function fuzzSuiteContract(input: {
   resetPolicy?: FuzzSuiteResetPolicy
   reset_policy?: FuzzSuiteResetPolicy | string
   cases?: FuzzSuiteCase[]
+  coveragePlan?: FuzzCoveragePlanContract
   metadata?: Record<string, unknown>
 }): FuzzSuiteContract {
   return stripUndefined({
@@ -209,6 +213,7 @@ export function fuzzSuiteContract(input: {
     resetPolicy: input.resetPolicy,
     reset_policy: input.reset_policy,
     cases: input.cases ?? [],
+    coveragePlan: input.coveragePlan,
     metadata: input.metadata,
   })
 }
@@ -219,6 +224,7 @@ export function fuzzSuiteResultEnvelope(input: {
   diagnostics?: FuzzSuiteDiagnostic[]
   artifactRefs?: FuzzSuiteArtifactRef[]
   coverageSummary?: FuzzSuiteCoverageSummary
+  coveragePlan?: FuzzCoveragePlanContract
   metadata?: Record<string, unknown>
 }): FuzzSuiteResultEnvelope {
   const cases = (input.cases ?? []).map(normalizeCaseResult)
@@ -226,6 +232,7 @@ export function fuzzSuiteResultEnvelope(input: {
   const artifactRefs = dedupeArtifactRefs([...(input.artifactRefs ?? []), ...cases.flatMap((item) => [...(item.artifactRefs ?? []), ...(item.reset?.artifactRefs ?? [])])])
   const summary = summarizeFuzzCases(cases)
   const coverageSummary = input.coverageSummary ?? summarizeFuzzCoverage({ discovered: fuzzSuiteDiscoveredCount(input.suite, cases.length), cases })
+  const coveragePlan = input.coveragePlan ?? fuzzSuiteResultCoveragePlan(input.suite, cases)
   const contractDiagnostics = fuzzSuiteContractDiagnostics({ suite: input.suite, cases, artifactRefs, coverageSummary })
   diagnostics.push(...contractDiagnostics)
   const hasRequiredCoverageError = diagnostics.some((diagnostic) => diagnostic.code === "fuzz_suite_required_runner_capabilities_unsupported" || diagnostic.code === "fuzz_suite_required_coverage_unsupported")
@@ -238,6 +245,7 @@ export function fuzzSuiteResultEnvelope(input: {
     success: status === "passed",
     summary,
     coverageSummary,
+    coveragePlan,
     cases,
     diagnostics,
     artifactRefs,
@@ -394,6 +402,50 @@ function normalizeCaseResult(input: FuzzSuiteCaseResult): FuzzSuiteCaseResult {
     diagnostics: input.diagnostics ?? [],
     artifactRefs: input.artifactRefs,
     metadata: input.metadata,
+  })
+}
+
+function fuzzSuiteResultCoveragePlan(suite: { id: string; version?: string } | FuzzSuiteContract, cases: readonly FuzzSuiteCaseResult[]): FuzzCoveragePlanContract | undefined {
+  const basePlan = fuzzSuiteCoveragePlan(suite)
+  const suiteCases = "cases" in suite && Array.isArray(suite.cases) ? suite.cases : []
+  if (basePlan || suiteCases.length > 0 || cases.length > 0) {
+    const baseItems = new Map((basePlan?.generated.length ? basePlan.generated : basePlan?.discovered ?? []).map((item) => [item.id, item]))
+    const generated = basePlan?.generated.length ? basePlan.generated : suiteCases.map(fuzzSuiteCaseCoveragePlanItem)
+    const executed = cases.filter((item) => item.status !== "skipped").map((item) => fuzzSuiteCaseResultCoveragePlanItem(item, baseItems.get(item.id)))
+    const skipped = cases.filter((item) => item.status === "skipped").map((item) => fuzzSuiteCaseResultCoveragePlanItem(item, baseItems.get(item.id)))
+    return fuzzCoveragePlanContract({
+      id: basePlan?.id ?? `${suite.id}-coverage-plan`,
+      version: basePlan?.version ?? suite.version,
+      discovered: basePlan?.discovered ?? generated,
+      generated,
+      executable: basePlan?.executable ?? generated,
+      executed,
+      skipped: [...(basePlan?.skipped ?? []), ...skipped.filter((item) => !basePlan?.skipped.some((baseItem) => baseItem.id === item.id))],
+      untested: basePlan?.untested,
+      parameterGenerationHooks: basePlan?.parameterGenerationHooks,
+      metadata: basePlan?.metadata,
+    })
+  }
+  return undefined
+}
+
+function fuzzSuiteCoveragePlan(suite: { id: string; version?: string } | FuzzSuiteContract): FuzzCoveragePlanContract | undefined {
+  if ("coveragePlan" in suite && suite.coveragePlan?.schema === "wp-codebox/fuzz-coverage-plan/v1") return suite.coveragePlan
+  const metadataCoveragePlan = recordField(fuzzSuiteMetadata(suite), "coveragePlan") ?? recordField(fuzzSuiteMetadata(suite), "coverage_plan")
+  return metadataCoveragePlan?.schema === "wp-codebox/fuzz-coverage-plan/v1" ? metadataCoveragePlan as unknown as FuzzCoveragePlanContract : undefined
+}
+
+function fuzzSuiteCaseCoveragePlanItem(fuzzCase: FuzzSuiteCase): FuzzCoveragePlanItem {
+  return stripUndefined({ id: fuzzCase.id, target: fuzzCase.target, description: fuzzCase.description, input: fuzzCase.input, metadata: fuzzCase.metadata })
+}
+
+function fuzzSuiteCaseResultCoveragePlanItem(result: FuzzSuiteCaseResult, base?: FuzzCoveragePlanItem): FuzzCoveragePlanItem {
+  return stripUndefined({
+    ...base,
+    id: result.id,
+    target: result.target ?? base?.target,
+    reason: result.status === "skipped" ? { code: result.skipReason ?? result.diagnostics[0]?.code ?? "fuzz_suite_case_skipped", message: result.diagnostics[0]?.message ?? `Fuzz suite case ${result.id} was skipped.`, data: result.diagnostics[0]?.metadata } : base?.reason,
+    metadata: stripUndefined({ ...base?.metadata, status: result.status }),
   })
 }
 

--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -2,6 +2,7 @@ import { AGENT_TASK_RUN_RESULT_SCHEMA, normalizeAgentTaskRunResult, type AgentTa
 import { AGENT_RUNTIME_WORKLOAD_SCHEMA } from "./agent-runtime-workload.js"
 import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, normalizeArtifactResultEnvelope, type ArtifactResultEnvelope } from "./artifact-result-envelope.js"
 import { FANOUT_AGGREGATION_INPUT_SCHEMA, FANOUT_AGGREGATION_OUTPUT_SCHEMA, aggregateFanoutOutputs, normalizeFanoutAggregationInput, type FanoutAggregationInput, type FanoutAggregationInputRequest, type FanoutAggregationOutput } from "./fanout-aggregation.js"
+import { FUZZ_COVERAGE_PLAN_SCHEMA } from "./fuzz-coverage-plan-contracts.js"
 import { FUZZ_SUITE_RESULT_SCHEMA, FUZZ_SUITE_SCHEMA } from "./fuzz-suite-contracts.js"
 import { HOST_DELEGATION_EVENT_SCHEMA, HOST_DELEGATION_REQUEST_SCHEMA, HOST_DELEGATION_RESULT_SCHEMA } from "./fanout-contracts.js"
 import { ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA, BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA } from "./materialization-contracts.js"
@@ -159,6 +160,7 @@ export const RUNTIME_CONTRACT_SCHEMAS = {
   },
   wordpressRuntime: {
     workloadRun: WORDPRESS_WORKLOAD_RUN_SCHEMA,
+    fuzzCoveragePlan: FUZZ_COVERAGE_PLAN_SCHEMA,
     fuzzSuite: FUZZ_SUITE_SCHEMA,
     fuzzSuiteResult: FUZZ_SUITE_RESULT_SCHEMA,
   },

--- a/packages/runtime-core/src/wordpress-block-fuzz-suite.ts
+++ b/packages/runtime-core/src/wordpress-block-fuzz-suite.ts
@@ -1,3 +1,4 @@
+import { fuzzCoveragePlanContract, type FuzzCoveragePlanContract, type FuzzCoveragePlanItem, type FuzzCoveragePlanParameterGenerationHook } from "./fuzz-coverage-plan-contracts.js"
 import { fuzzSuiteContract, type FuzzSuiteCase, type FuzzSuiteContract } from "./fuzz-suite-contracts.js"
 import { stripUndefined } from "./object-utils.js"
 import type { WordPressBlockEditorTargetDiscovery, WordPressBlockTypeDescriptor, WordPressEditorPostTypeDescriptor } from "./wordpress-runtime-discovery-contracts.js"
@@ -15,6 +16,11 @@ const DEFAULT_BLOCK_FUZZ_SUITE_ID = "wordpress-block-discovery"
 const DEFAULT_EDITOR_CAPTURE = ["editor-state", "errors"] as const
 const BLOCK_SERVER_RENDER_CAPABILITIES = ["target:runtime", "runtime"] as const
 const BLOCK_EDITOR_INSERT_CAPABILITIES = ["target:runtime", "runtime", "runtime-action:editor_open"] as const
+const BLOCK_ATTRIBUTE_PARAMETER_GENERATION_HOOK: FuzzCoveragePlanParameterGenerationHook = {
+  id: "wordpress.block-attribute-samples",
+  label: "WordPress block attribute sample generator",
+  description: "Placeholder hook for consumers that can generate concrete attribute samples from a discovered block schema.",
+}
 
 export function wordpressBlockDiscoveryToFuzzSuite(discovery: WordPressBlockEditorTargetDiscovery, options: WordPressBlockFuzzSuiteOptions = {}): FuzzSuiteContract {
   const includeServerRender = options.includeServerRender ?? true
@@ -36,6 +42,7 @@ export function wordpressBlockDiscoveryToFuzzSuite(discovery: WordPressBlockEdit
     id: options.id ?? DEFAULT_BLOCK_FUZZ_SUITE_ID,
     version: options.version,
     cases,
+    coveragePlan: wordpressBlockDiscoveryToCoveragePlan(discovery, options),
     metadata: stripUndefined({
       sourceSchema: discovery.schema,
       builder: "wp-codebox/wordpress-block-fuzz-suite-builder/v1",
@@ -58,6 +65,32 @@ export function wordpressBlockDiscoveryToFuzzSuite(discovery: WordPressBlockEdit
           includeEditorInsert ? "wordpress.editor-open" : undefined,
         ].filter((command): command is string => Boolean(command)),
       }),
+    }),
+  })
+}
+
+export function wordpressBlockDiscoveryToCoveragePlan(discovery: WordPressBlockEditorTargetDiscovery, options: WordPressBlockFuzzSuiteOptions = {}): FuzzCoveragePlanContract {
+  const includeServerRender = options.includeServerRender ?? true
+  const includeEditorInsert = options.includeEditorInsert ?? true
+  const editorPostType = selectEditorPostType(discovery.editorPostTypes, options.editorPostType)
+  const discovered = discovery.blocks.flatMap((block) => blockCoveragePlanItems(block, includeServerRender, includeEditorInsert, editorPostType, options.capture ?? DEFAULT_EDITOR_CAPTURE))
+  const executable = discovered.filter((item) => item.input !== undefined && !item.reason)
+  const untested = discovered.filter((item) => item.reason)
+
+  return fuzzCoveragePlanContract({
+    id: `${options.id ?? DEFAULT_BLOCK_FUZZ_SUITE_ID}-coverage-plan`,
+    version: options.version,
+    discovered,
+    generated: discovered,
+    executable,
+    untested,
+    parameterGenerationHooks: [BLOCK_ATTRIBUTE_PARAMETER_GENERATION_HOOK],
+    metadata: stripUndefined({
+      sourceSchema: discovery.schema,
+      builder: "wp-codebox/wordpress-block-fuzz-suite-builder/v1",
+      blocks: discovery.blocks.length,
+      editorPostTypes: discovery.editorPostTypes.map((postType) => postType.name),
+      editorPostType: includeEditorInsert ? editorPostType?.name : undefined,
     }),
   })
 }
@@ -92,6 +125,42 @@ function editorInsertCase(block: WordPressBlockTypeDescriptor, postType: WordPre
     description: `Insert ${block.name} into a new ${postType.name} editor canvas with empty attributes.`,
     metadata: blockCaseMetadata(block, "editor-insert", { emptyAttributes: {}, editorPostType: postType.name }),
   }
+}
+
+function blockCoveragePlanItems(block: WordPressBlockTypeDescriptor, includeServerRender: boolean, includeEditorInsert: boolean, editorPostType: WordPressEditorPostTypeDescriptor | undefined, capture: readonly string[]): FuzzCoveragePlanItem[] {
+  return [
+    includeServerRender ? serverRenderCoveragePlanItem(block) : undefined,
+    includeEditorInsert ? editorInsertCoveragePlanItem(block, editorPostType, capture) : undefined,
+  ].filter((item): item is FuzzCoveragePlanItem => Boolean(item))
+}
+
+function serverRenderCoveragePlanItem(block: WordPressBlockTypeDescriptor): FuzzCoveragePlanItem {
+  const fuzzCase = serverRenderCase(block)
+  return stripUndefined({ ...fuzzCase, parameterGeneration: { hook: BLOCK_ATTRIBUTE_PARAMETER_GENERATION_HOOK.id, metadata: { sample: "emptyAttributes" } } })
+}
+
+function editorInsertCoveragePlanItem(block: WordPressBlockTypeDescriptor, postType: WordPressEditorPostTypeDescriptor | undefined, capture: readonly string[]): FuzzCoveragePlanItem {
+  if (!postType) {
+    return stripUndefined({
+      id: `block-${caseIdPart(block.name)}-editor-insert-untested`,
+      target: { kind: "runtime", entrypoint: "wordpress.editor-actions" },
+      description: `Insert ${block.name} into an editor canvas with empty attributes.`,
+      reason: { code: "block_editor_post_type_unavailable", message: "No discovered editor post type is available for editor-insert fuzz coverage.", data: { unsupportedCapabilities: ["runtime-action:editor_open"] } },
+      parameterGeneration: { hook: BLOCK_ATTRIBUTE_PARAMETER_GENERATION_HOOK.id, metadata: { sample: "emptyAttributes" } },
+      metadata: blockCaseMetadata(block, "editor-insert", { emptyAttributes: {} }),
+    })
+  }
+  if (!block.supportsInserter) {
+    return stripUndefined({
+      id: `block-${caseIdPart(block.name)}-editor-insert-${caseIdPart(postType.name)}-empty-attributes`,
+      target: { kind: "runtime", entrypoint: "wordpress.editor-actions" },
+      description: `Insert ${block.name} into a new ${postType.name} editor canvas with empty attributes.`,
+      reason: { code: "block_inserter_unsupported", message: "The block does not support inserter-based editor coverage.", data: { unsupportedCapabilities: ["block:inserter"] } },
+      parameterGeneration: { hook: BLOCK_ATTRIBUTE_PARAMETER_GENERATION_HOOK.id, metadata: { sample: "emptyAttributes" } },
+      metadata: blockCaseMetadata(block, "editor-insert", { emptyAttributes: {}, editorPostType: postType.name }),
+    })
+  }
+  return stripUndefined({ ...editorInsertCase(block, postType, capture), parameterGeneration: { hook: BLOCK_ATTRIBUTE_PARAMETER_GENERATION_HOOK.id, metadata: { sample: "emptyAttributes" } } })
 }
 
 function blockCaseMetadata(block: WordPressBlockTypeDescriptor, operation: string, extra: Record<string, unknown>): Record<string, unknown> {

--- a/packages/runtime-core/src/wordpress-fuzz-suite-builders.ts
+++ b/packages/runtime-core/src/wordpress-fuzz-suite-builders.ts
@@ -76,6 +76,7 @@ export function restRouteInventoryToFuzzSuite(inventory: WordPressRestRouteInven
     version: options.version,
     target: REST_REQUEST_TARGET,
     cases: inventory.routes.flatMap((route) => restRouteFuzzSuiteCases(route, options)),
+    coveragePlan: restRouteInventoryToCoveragePlan(inventory, options),
     metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, requiredRunnerCapabilities: REST_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES }),
   })
 }
@@ -86,6 +87,7 @@ export function adminPageInventoryToFuzzSuite(inventory: WordPressAdminPageInven
     version: options.version,
     target: ADMIN_PAGE_LOAD_TARGET,
     cases: inventory.pages.map((page) => adminPageFuzzSuiteCase(page, options)),
+    coveragePlan: adminPageInventoryToCoveragePlan(inventory, options),
     metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, adminUrl: inventory.adminUrl, menuLoaded: inventory.menuLoaded, requiredRunnerCapabilities: ADMIN_PAGE_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES }),
   })
 }
@@ -96,6 +98,7 @@ export function frontendUrlInventoryToFuzzSuite(inventory: WordPressFrontendUrlI
     version: options.version,
     target: FRONTEND_PAGE_LOAD_TARGET,
     cases: inventory.urls.map((url) => frontendUrlFuzzSuiteCase(url, inventory.homeUrl, options)),
+    coveragePlan: frontendUrlInventoryToCoveragePlan(inventory, options),
     metadata: stripUndefined({ ...options.metadata, sourceSchema: inventory.schema, sourceCommand: inventory.command, inventoryStatus: inventory.status, homeUrl: inventory.homeUrl, permalinkStructure: inventory.permalinkStructure, requiredRunnerCapabilities: FRONTEND_PAGE_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES }),
   })
 }

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -738,7 +738,8 @@ private static function fuzz_suite_request_schema(): array {
 					),
 				),
 			),
-			'metadata' => self::object_property_schema(),
+			'coveragePlan' => self::object_property_schema(),
+			'metadata'     => self::object_property_schema(),
 		),
 	);
 }
@@ -762,15 +763,17 @@ private static function fuzz_suite_result_schema(): array {
 	return array(
 		'type'       => 'object',
 		'properties' => array(
-			'success'      => array( 'type' => 'boolean' ),
-			'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/fuzz-suite-result/v1' ),
-			'status'       => array( 'type' => 'string', 'enum' => array( 'passed', 'failed', 'error', 'skipped', 'unsupported' ) ),
-			'suite'        => self::object_property_schema(),
-			'summary'      => self::object_property_schema(),
-			'cases'        => self::object_array_property_schema(),
-			'diagnostics'  => self::object_array_property_schema(),
-			'artifactRefs' => self::object_array_property_schema(),
-			'metadata'     => self::object_property_schema(),
+			'success'         => array( 'type' => 'boolean' ),
+			'schema'          => array( 'type' => 'string', 'const' => 'wp-codebox/fuzz-suite-result/v1' ),
+			'status'          => array( 'type' => 'string', 'enum' => array( 'passed', 'failed', 'error', 'skipped', 'unsupported' ) ),
+			'suite'           => self::object_property_schema(),
+			'summary'         => self::object_property_schema(),
+			'coverageSummary' => self::object_property_schema(),
+			'coveragePlan'    => self::object_property_schema(),
+			'cases'           => self::object_array_property_schema(),
+			'diagnostics'     => self::object_array_property_schema(),
+			'artifactRefs'    => self::object_array_property_schema(),
+			'metadata'        => self::object_property_schema(),
 		),
 	);
 }

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -52,6 +52,10 @@ assert.deepEqual(result.coverageSummary, {
   untested: 0,
   skippedReasons: [{ reason: "fuzz_suite_target_adapter_unsupported", count: 1, caseIds: ["case-runtime-action-unsupported"] }],
 })
+assert.equal(result.coveragePlan?.schema, "wp-codebox/fuzz-coverage-plan/v1")
+assert.deepEqual({ discovered: result.coveragePlan?.summary.discovered, generated: result.coveragePlan?.summary.generated, executable: result.coveragePlan?.summary.executable, executed: result.coveragePlan?.summary.executed, skipped: result.coveragePlan?.summary.skipped, untested: result.coveragePlan?.summary.untested }, { discovered: 12, generated: 12, executable: 12, executed: 11, skipped: 1, untested: 0 })
+assert.deepEqual(result.coveragePlan?.executed.map((item) => item.id), result.cases.filter((item) => item.status !== "skipped").map((item) => item.id))
+assert.equal(result.coveragePlan?.skipped[0]?.reason?.code, "fuzz_suite_target_adapter_unsupported")
 assert.deepEqual(executed.map((spec) => spec.command), ["inspect-mounted-inputs", "wordpress.run-php", "wordpress.http-request", "wordpress.rest-request", "wordpress.ability", "wordpress.rest-request", "wordpress.browser-actions", "wordpress.admin-page-load", "wordpress.frontend-page-load", "wordpress.editor-open", "wordpress.crud-operation"])
 assert.deepEqual(executed[0], { command: "inspect-mounted-inputs", args: ["--json"], cwd: "/workspace", timeoutMs: 1000 })
 assert.deepEqual(executed[2], { command: "wordpress.http-request", args: ["url=/", "method=GET", "expect-status=200"], method: "GET", path: "/" })

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -191,6 +191,8 @@ assert.deepEqual(barrelExportModules(publicBarrel), [
 assert.deepEqual(barrelExportModules(contractsBarrel), [
   "./browser-probe-contract.js",
   "./command-registry.js",
+  "./fuzz-coverage-plan-contracts.js",
+  "./fuzz-suite-contracts.js",
   "./runtime-contract-manifest.js",
   "./wordpress-page-load-contracts.js",
 ])
@@ -358,6 +360,7 @@ assert.deepEqual(runtimeContractManifest().abilities, CODEBOX_PUBLIC_RUNTIME_ABI
 assert.equal(runtimeContractManifest().abilities.wordpressRuntime.runWorkload, CODEBOX_RUN_WORDPRESS_WORKLOAD_ABILITY)
 assert.equal(runtimeContractManifest().abilities.wordpressRuntime.runFuzzSuite, CODEBOX_RUN_FUZZ_SUITE_ABILITY)
 assert.equal(runtimeContractManifest().schemas.wordpressRuntime.workloadRun, "wp-codebox/wordpress-workload-run/v1")
+assert.equal(runtimeContractManifest().schemas.wordpressRuntime.fuzzCoveragePlan, FUZZ_COVERAGE_PLAN_SCHEMA)
 assert.equal(runtimeContractManifest().schemas.wordpressRuntime.fuzzSuite, FUZZ_SUITE_SCHEMA)
 assert.equal(runtimeContractManifest().schemas.wordpressRuntime.fuzzSuiteResult, FUZZ_SUITE_RESULT_SCHEMA)
 assert.equal(runtimeContractManifest().schemas.agentTask.runRequest, "wp-codebox/agent-task-run-request/v1")

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -23,6 +23,7 @@ import {
   CODEBOX_RUN_WORDPRESS_WORKLOAD_ABILITY,
   FANOUT_AGGREGATION_INPUT_SCHEMA,
   FANOUT_AGGREGATION_OUTPUT_SCHEMA,
+  FUZZ_COVERAGE_PLAN_SCHEMA,
   FUZZ_SUITE_RESULT_SCHEMA,
   FUZZ_SUITE_SCHEMA,
   HOST_DELEGATION_EVENT_SCHEMA,
@@ -119,6 +120,7 @@ assert.equal(manifest.schemas.wordpressRuntimeDiscovery.result, WORDPRESS_RUNTIM
 assert.equal(manifest.schemas.wordpressRuntimeDiscovery.restMatrix, WORDPRESS_REST_MATRIX_SCHEMA)
 assert.equal(manifest.schemas.wordpressRuntimeDiscovery.restMatrixResult, WORDPRESS_REST_MATRIX_RESULT_SCHEMA)
 assert.equal(manifest.schemas.wordpressRuntime.workloadRun, WORDPRESS_WORKLOAD_RUN_SCHEMA)
+assert.equal(manifest.schemas.wordpressRuntime.fuzzCoveragePlan, FUZZ_COVERAGE_PLAN_SCHEMA)
 assert.equal(manifest.schemas.wordpressRuntime.fuzzSuite, FUZZ_SUITE_SCHEMA)
 assert.equal(manifest.schemas.wordpressRuntime.fuzzSuiteResult, FUZZ_SUITE_RESULT_SCHEMA)
 assert.equal(manifest.abilities.agentTask.run, CODEBOX_RUN_AGENT_TASK_ABILITY)

--- a/tests/wordpress-block-fuzz-suite.test.ts
+++ b/tests/wordpress-block-fuzz-suite.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 
-import { wordpressBlockDiscoveryToFuzzSuite, type WordPressBlockEditorTargetDiscovery } from "../packages/runtime-core/src/index.js"
+import { wordpressBlockDiscoveryToCoveragePlan, wordpressBlockDiscoveryToFuzzSuite, type WordPressBlockEditorTargetDiscovery } from "../packages/runtime-core/src/index.js"
 
 const discovery: WordPressBlockEditorTargetDiscovery = {
   schema: "wp-codebox/wordpress-block-editor-target-discovery/v1",
@@ -24,6 +24,13 @@ assert.deepEqual(suite.cases.map((fuzzCase) => fuzzCase.id), [
   "block-core-template-part-server-render-empty-attributes",
 ])
 assert.equal(suite.metadata?.sourceSchema, "wp-codebox/wordpress-block-editor-target-discovery/v1")
+assert.equal(suite.coveragePlan?.schema, "wp-codebox/fuzz-coverage-plan/v1")
+assert.deepEqual(suite.coveragePlan?.summary.caseIds, [
+  "block-core-paragraph-server-render-empty-attributes",
+  "block-core-paragraph-editor-insert-page-empty-attributes",
+  "block-core-template-part-server-render-empty-attributes",
+  "block-core-template-part-editor-insert-page-empty-attributes",
+])
 assert.equal(suite.metadata?.editorPostType, "page")
 assert.deepEqual(suite.metadata?.requiredRunnerCapabilities, {
   capabilities: ["target:runtime", "runtime", "runtime-action:editor_open"],
@@ -64,5 +71,12 @@ assert.deepEqual(noEditorTargets.cases.map((fuzzCase) => fuzzCase.id), [
   "block-core-paragraph-server-render-empty-attributes",
   "block-core-template-part-server-render-empty-attributes",
 ])
+
+const coveragePlan = wordpressBlockDiscoveryToCoveragePlan(discovery, { id: "blocks", editorPostType: "page" })
+assert.equal(coveragePlan.schema, "wp-codebox/fuzz-coverage-plan/v1")
+assert.deepEqual({ discovered: coveragePlan.summary.discovered, generated: coveragePlan.summary.generated, executable: coveragePlan.summary.executable, executed: coveragePlan.summary.executed, skipped: coveragePlan.summary.skipped, untested: coveragePlan.summary.untested }, { discovered: 4, generated: 4, executable: 3, executed: 0, skipped: 0, untested: 1 })
+assert.equal(coveragePlan.untested[0]?.reason?.code, "block_inserter_unsupported")
+assert.deepEqual(coveragePlan.untested[0]?.reason?.data?.unsupportedCapabilities, ["block:inserter"])
+assert.equal(coveragePlan.parameterGenerationHooks?.[0]?.id, "wordpress.block-attribute-samples")
 
 console.log("wordpress block fuzz suite ok")

--- a/tests/wordpress-fuzz-suite-builders.test.ts
+++ b/tests/wordpress-fuzz-suite-builders.test.ts
@@ -31,6 +31,8 @@ const restSuite = restRouteInventoryToFuzzSuite(restInventory, { session: "admin
 assert.equal(restSuite.schema, "wp-codebox/fuzz-suite/v1")
 assert.equal(restSuite.metadata?.sourceSchema, WORDPRESS_REST_ROUTE_INVENTORY_SCHEMA)
 assert.deepEqual(restSuite.metadata?.requiredRunnerCapabilities, { capabilities: ["target:rest"], targetKinds: ["rest"] })
+assert.equal(restSuite.coveragePlan?.schema, "wp-codebox/fuzz-coverage-plan/v1")
+assert.deepEqual(restSuite.coveragePlan?.summary.caseIds, ["rest-get-wp-v2-posts-0", "rest-post-wp-v2-posts-0", "rest-get-wp-v2-posts-p-id-d-0"])
 assert.equal(restSuite.cases.length, 3)
 assert.equal(restSuite.cases[0]?.target?.kind, "rest")
 assert.deepEqual(restSuite.cases[0]?.input, { method: "GET", path: "/wp/v2/posts", session: "admin" })
@@ -42,7 +44,8 @@ assert.deepEqual((restSuite.cases[2]?.metadata?.safety as Record<string, unknown
 
 const restCoveragePlan = restRouteInventoryToCoveragePlan(restInventory, { session: "admin" })
 assert.equal(restCoveragePlan.schema, "wp-codebox/fuzz-coverage-plan/v1")
-assert.deepEqual(restCoveragePlan.summary, { discovered: 3, generated: 3, executable: 1, skipped: 0, untested: 2 })
+assert.deepEqual({ discovered: restCoveragePlan.summary.discovered, generated: restCoveragePlan.summary.generated, executable: restCoveragePlan.summary.executable, executed: restCoveragePlan.summary.executed, skipped: restCoveragePlan.summary.skipped, untested: restCoveragePlan.summary.untested }, { discovered: 3, generated: 3, executable: 1, executed: 0, skipped: 0, untested: 2 })
+assert.deepEqual(restCoveragePlan.summary.targetIds, ["wordpress.rest-request"])
 assert.deepEqual(restCoveragePlan.executable[0]?.input, { method: "GET", path: "/wp/v2/posts", session: "admin" })
 assert.equal(restCoveragePlan.untested[0]?.reason?.code, "mutating_rest_method_requires_explicit_opt_in")
 assert.equal(restCoveragePlan.untested[0]?.parameterGeneration?.hook, "wordpress.rest-mutating-route-opt-in")
@@ -67,7 +70,7 @@ assert.deepEqual(adminSuite.cases[0]?.input, { args: ["path=tools.php", "user=ad
 assert.deepEqual(adminSuite.cases[1]?.input, { args: ["path=admin.php?page=demo-settings", "user=admin"] })
 
 const adminCoveragePlan = adminPageInventoryToCoveragePlan(adminInventory, { user: "admin" })
-assert.deepEqual(adminCoveragePlan.summary, { discovered: 3, generated: 3, executable: 2, skipped: 1, untested: 0 })
+assert.deepEqual({ discovered: adminCoveragePlan.summary.discovered, generated: adminCoveragePlan.summary.generated, executable: adminCoveragePlan.summary.executable, executed: adminCoveragePlan.summary.executed, skipped: adminCoveragePlan.summary.skipped, untested: adminCoveragePlan.summary.untested }, { discovered: 3, generated: 3, executable: 2, executed: 0, skipped: 1, untested: 0 })
 assert.equal(adminCoveragePlan.skipped[0]?.reason?.code, "admin_page_capability_denied")
 
 const frontendInventory: WordPressFrontendUrlInventory = {
@@ -89,7 +92,7 @@ assert.deepEqual(frontendSuite.cases[0]?.input, { args: ["path=/hello-world/?pre
 assert.equal((frontendSuite.cases[0]?.metadata?.safety as Record<string, unknown>).executable, true)
 
 const frontendCoveragePlan = frontendUrlInventoryToCoveragePlan(frontendInventory)
-assert.deepEqual(frontendCoveragePlan.summary, { discovered: 2, generated: 2, executable: 2, skipped: 0, untested: 0 })
+assert.deepEqual({ discovered: frontendCoveragePlan.summary.discovered, generated: frontendCoveragePlan.summary.generated, executable: frontendCoveragePlan.summary.executable, executed: frontendCoveragePlan.summary.executed, skipped: frontendCoveragePlan.summary.skipped, untested: frontendCoveragePlan.summary.untested }, { discovered: 2, generated: 2, executable: 2, executed: 0, skipped: 0, untested: 0 })
 assert.equal(frontendCoveragePlan.executable[1]?.metadata?.pattern, "^sample-page/?$")
 
 console.log("wordpress fuzz suite builders ok")


### PR DESCRIPTION
## Summary
- Adds the public `wp-codebox/fuzz-coverage-plan/v1` coverage-plan contract to the runtime contract surface and contracts subpath.
- Threads `coveragePlan` through fuzz suite contracts and result envelopes, including discovered/generated/executable/executed/skipped/untested accounting with case IDs, target IDs, skip reasons, unsupported capability notes, and parameter-generation hooks.
- Attaches coverage plans from REST/admin/frontend fuzz suite builders and adds block discovery coverage-plan output for server-render/editor-insert coverage gaps.
- Exposes coverage-plan fields in WordPress plugin fuzz suite request/result schemas.

## Tests
- `npm run test:wordpress-fuzz-suite-builders`
- `npm run test:wordpress-block-fuzz-suite`
- `npm run test:fuzz-suite-runner`
- `npm run test:runtime-contract-manifest`
- `npm run test:public-api-contract`
- `npm run build`

## Blockers
- `npm run test:wordpress-plugin-public-runtime-abilities` currently fails before the fuzz coverage assertions because it expects `wp-codebox/run-wordpress-workload` to include a `safe_stub` marker, but current `origin/main` ability registration has no `safe_stub` marker for that ability.
- No benchmarks run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and applying the coverage-plan contract, builder/result wiring, tests, and PR text.
