### PR TITLE
Neutralize Codebox workflow access token naming

### DIFF
--- a/.github/scripts/run-agent-task/build-codebox-task-request.mjs
+++ b/.github/scripts/run-agent-task/build-codebox-task-request.mjs
@@ -65,8 +65,8 @@ const request = {
     completion_outcomes: parseJson("SUCCESS_COMPLETION_OUTCOMES", [], "array"),
   },
   access: {
-    app_token_repos: process.env.APP_TOKEN_REPOS || process.env.TARGET_REPO || "",
-    require_app_token: booleanEnv("REQUIRE_HOMEBOY_APP_TOKEN"),
+    access_token_repos: process.env.ACCESS_TOKEN_REPOS || process.env.TARGET_REPO || "",
+    require_access_token: booleanEnv("REQUIRE_ACCESS_TOKEN"),
     allowed_repos: parseJson("ALLOWED_REPOS", [], "array"),
   },
   limits: {
@@ -97,5 +97,5 @@ output("job_status", status)
 output("transcript_json", request.artifacts.transcript_name)
 output("transcript_summary", `${request.workload.label}: ${status}`)
 output("engine_data_json", JSON.stringify({}))
-output("credential_mode", request.access.require_app_token ? "app-token" : "default")
+output("credential_mode", request.access.require_access_token ? "app-token" : "default")
 output("declared_artifacts_json", JSON.stringify(artifactDeclarations))

--- a/.github/workflows/run-agent-task.yml
+++ b/.github/workflows/run-agent-task.yml
@@ -79,12 +79,12 @@ name: Run Agent Task (reusable)
         description: JSON array of accepted non-PR completion outcomes.
         type: string
         default: '[]'
-      app_token_repos:
-        description: Comma-separated repositories for app-token scoping.
+      access_token_repos:
+        description: Comma-separated repositories for access-token scoping.
         type: string
         default: ""
-      require_homeboy_app_token:
-        description: Whether the run requires the configured app token.
+      require_access_token:
+        description: Whether the run requires the configured access token.
         type: boolean
         default: false
       allowed_repos:
@@ -216,8 +216,8 @@ jobs:
           ACTIONS_ARTIFACT_DOWNLOADS: ${{ inputs.actions_artifact_downloads }}
           SUCCESS_REQUIRES_PR: ${{ inputs.success_requires_pr }}
           SUCCESS_COMPLETION_OUTCOMES: ${{ inputs.success_completion_outcomes }}
-          APP_TOKEN_REPOS: ${{ inputs.app_token_repos }}
-          REQUIRE_HOMEBOY_APP_TOKEN: ${{ inputs.require_homeboy_app_token }}
+          ACCESS_TOKEN_REPOS: ${{ inputs.access_token_repos }}
+          REQUIRE_ACCESS_TOKEN: ${{ inputs.require_access_token }}
           ALLOWED_REPOS: ${{ inputs.allowed_repos }}
           MAX_TURNS: ${{ inputs.max_turns }}
           STEP_BUDGET: ${{ inputs.step_budget }}

--- a/docs/agent-task-reusable-workflow.md
+++ b/docs/agent-task-reusable-workflow.md
@@ -26,6 +26,8 @@ jobs:
       verification_commands: '[{"command":"npm test","description":"Run checks"}]'
       drift_checks: '[]'
       output_projections: '{"pr_url":"metadata.runner_workspace_publication.url"}'
+      access_token_repos: Automattic/example-target
+      require_access_token: true
       expected_artifacts: '["agent_transcript","agent_change_summary"]'
       artifact_declarations: |
         [
@@ -76,6 +78,8 @@ checkout rules, package internals, or private workflow names.
 - `writable_paths`: comma-separated repository paths the agent may edit.
 - `runner_workspace`: JSON workspace publication request.
 - `validation_dependencies`, `verification_commands`, and `drift_checks`: runner-owned validation inputs.
+- `access_token_repos`: comma-separated repositories for access-token scoping.
+- `require_access_token`: require the configured access token for the run.
 - `artifact_declarations` and `expected_artifacts`: typed review artifact contract.
 - `output_projections`: JSON object mapping workflow output names to result paths.
 - `run_agent`: set to `false` to record a skipped run.

--- a/tests/agent-task-reusable-workflow.test.ts
+++ b/tests/agent-task-reusable-workflow.test.ts
@@ -19,6 +19,9 @@ assert.match(workflow, /artifact_declarations:/)
 assert.match(workflow, /output_projections:/)
 assert.match(workflow, /verification_commands:/)
 assert.match(workflow, /drift_checks:/)
+assert.match(workflow, /access_token_repos:/)
+assert.match(workflow, /require_access_token:/)
+assert.doesNotMatch(workflow, /homeboy|require_app_token|require_homeboy_app_token|REQUIRE_HOMEBOY_APP_TOKEN/i)
 assert.doesNotMatch(workflow, /docs-agent|wp-codebox\/docs-agent-runner-recipe\/v1|recipe_path|recipe_json|wp_codebox_ref/i)
 assert.doesNotMatch(workflow, /datamachine-agent-ci|runtime-agent-full-run|Extra-Chill\/homeboy-extensions/)
 assert.doesNotMatch(publicWorkflowSurface, /datamachine|data machine|data-machine|agents api/i)
@@ -30,8 +33,10 @@ assert.match(docs, /Automattic\/wp-codebox\/.github\/workflows\/run-agent-task.y
 assert.match(docs, /runner_recipe/)
 assert.match(docs, /agent_bundle/)
 assert.match(docs, /runner_workspace/)
+assert.match(docs, /access_token_repos/)
+assert.match(docs, /require_access_token/)
 assert.match(docs, /implementation-specific\s+runtime wiring, workspace adapters, plugins, and model setup stay behind the WP\s+Codebox boundary/)
-assert.doesNotMatch(docs, /docs-agent|wp-codebox\/docs-agent-runner-recipe\/v1|recipe_path|recipe_json|wp_codebox_ref|datamachine|data machine|data-machine|agents api|sandbox mounts|ability ids|provider internals/i)
+assert.doesNotMatch(docs, /docs-agent|wp-codebox\/docs-agent-runner-recipe\/v1|recipe_path|recipe_json|wp_codebox_ref|datamachine|data machine|data-machine|agents api|sandbox mounts|ability ids|provider internals|homeboy|require_app_token/i)
 
 const tmp = await mkdtemp(join(tmpdir(), "wp-codebox-agent-task-workflow-"))
 const outputPath = join(tmp, "github-output.txt")
@@ -63,8 +68,8 @@ await execFileAsync("node", [new URL("../.github/scripts/run-agent-task/build-co
     ACTIONS_ARTIFACT_DOWNLOADS: "[]",
     SUCCESS_REQUIRES_PR: "false",
     SUCCESS_COMPLETION_OUTCOMES: "[]",
-    APP_TOKEN_REPOS: "Automattic/example-target",
-    REQUIRE_HOMEBOY_APP_TOKEN: "true",
+    ACCESS_TOKEN_REPOS: "Automattic/example-target",
+    REQUIRE_ACCESS_TOKEN: "true",
     ALLOWED_REPOS: '["Automattic/example-target"]',
     MAX_TURNS: "12",
     STEP_BUDGET: "16",
@@ -87,8 +92,14 @@ assert.equal(request.runner_recipe, "Automattic/example-runner@abc123:ci/runner-
 assert.equal(request.agent_bundle, "bundles/example-agent")
 assert.equal(request.target_repo, "Automattic/example-target")
 assert.deepEqual(request.verification_commands, [{ command: "npm test", description: "Run checks" }])
+assert.deepEqual(request.access, {
+  access_token_repos: "Automattic/example-target",
+  require_access_token: true,
+  allowed_repos: ["Automattic/example-target"],
+})
 assert.deepEqual(request.outputs.projections, { pr_url: "metadata.runner_workspace_publication.url" })
 assert.deepEqual(request.artifacts.declarations, [{ schema: "wp-codebox/artifact-declaration/v1", name: "agent_transcript" }])
+assert.doesNotMatch(JSON.stringify(request), /homeboy|require_app_token|app_token_repos/i)
 
 const outputs = await readFile(outputPath, "utf8")
 assert.match(outputs, /job_status<<__WP_CODEBOX_OUTPUT__\nskipped\n__WP_CODEBOX_OUTPUT__/)


### PR DESCRIPTION
## Summary
- Rename the reusable Codebox workflow token inputs from Homeboy/app-token-specific names to neutral access-token vocabulary.
- Emit `access.access_token_repos` and `access.require_access_token` in the generated Codebox task request.
- Update workflow docs and focused coverage to assert the leaked names are absent.

## Tests
- `npx tsx tests/agent-task-reusable-workflow.test.ts`
- `npm run test -- tests/agent-task-reusable-workflow.test.ts` failed because this repo has no generic `test` npm script.
- `npm run test:production-boundary-enforcement` fails on existing package source references to `datamachine` / `data-machine` outside this PR scope.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5/OpenCode
- **Used for:** Renaming the workflow/request token vocabulary, updating docs/tests, running verification, and drafting this PR.