### PR TITLE
Remove default agent substrate discovery

### DIFF
--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -192,14 +192,7 @@ function defaultRuntimeComponentPlugins(): WorkspaceRecipeExtraPlugin[] {
 }
 
 function defaultRuntimeComponentSources(): Array<{ source: string; slug?: string }> {
-  const dataMachine = defaultSiblingComponentPath("data-machine", "data-machine.php", process.env.WP_CODEBOX_DATA_MACHINE_PATH)
-  const dataMachineCode = defaultSiblingComponentPath("data-machine-code", "data-machine-code.php", process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH)
-  const agentsApi = defaultAgentsApiPath(dataMachine)
-
   return uniqueComponentSources([
-    dataMachine ? { source: dataMachine, slug: "data-machine" } : undefined,
-    dataMachineCode ? { source: dataMachineCode, slug: "data-machine-code" } : undefined,
-    agentsApi ? { source: agentsApi, slug: "agents-api" } : undefined,
     ...configuredRuntimeComponentPaths().map((source) => ({ source })),
     ...bundledRuntimeComponentPaths().map((source) => ({ source, slug: "wordpress-plugin" })),
   ])
@@ -214,28 +207,6 @@ function configuredRuntimeComponentPaths(): string[] {
     .split(/[,:]/)
     .map((value) => value.trim())
     .filter(Boolean)
-}
-
-function defaultAgentsApiPath(dataMachinePath = ""): string {
-  const explicit = process.env.WP_CODEBOX_AGENTS_API_PATH?.trim()
-  if (explicit) {
-    return explicit
-  }
-  if (dataMachinePath) {
-    return ""
-  }
-
-  return defaultSiblingComponentPath("agents-api", "agents-api.php")
-}
-
-function defaultSiblingComponentPath(slug: string, pluginFile: string, explicit = ""): string {
-  if (explicit.trim()) {
-    return explicit.trim()
-  }
-  return [
-    resolve(process.cwd(), "..", slug),
-    resolve(dirname(process.cwd()), slug),
-  ].find((source) => existsSync(resolve(source, pluginFile))) ?? ""
 }
 
 function uniqueComponentSources(components: Array<{ source: string; slug?: string } | undefined>): Array<{ source: string; slug?: string }> {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -202,6 +202,8 @@ try {
   const workspaceRoot = join(agentRecipeTemp, "workspace")
   mkdirSync(workspaceRoot)
   chdir(workspaceRoot)
+  delete process.env.WP_CODEBOX_AGENT_RUNTIME_COMPONENT_PATHS
+  delete process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
 
   const agentsApiSource = join(agentRecipeTemp, "agents-api")
   mkdirSync(agentsApiSource)
@@ -225,6 +227,9 @@ try {
   writeFileSync(join(helperSource, "agent-runtime-helper.php"), "<?php\n/* Plugin Name: Agent Runtime Helper */\n")
   const artifactsPath = join(agentRecipeTemp, "artifacts")
   mkdirSync(artifactsPath)
+  process.env.WP_CODEBOX_AGENTS_API_PATH = agentsApiSource
+  process.env.WP_CODEBOX_DATA_MACHINE_PATH = dataMachineSource
+  process.env.WP_CODEBOX_DATA_MACHINE_CODE_PATH = dataMachineCodeSource
 
   const genericRecipe = buildAgentTaskRecipe({
     goal: "Verify generic runtime propagation",
@@ -235,16 +240,16 @@ try {
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), false)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), false)
-  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine"), true)
-  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine-code"), true)
-  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), true)
-  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code"), true)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine"), false)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine-code"), false)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), false)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code"), false)
   const genericSandboxStepArgs = genericRecipe.workflow.steps.find((step) => step.command === "wp-codebox.agent-sandbox-run")?.args ?? []
   const genericRuntimeComponentsArg = genericSandboxStepArgs.find((arg) => arg.startsWith("runtime-component-contracts-json=")) ?? "runtime-component-contracts-json=[]"
   const genericRuntimeComponents = JSON.parse(genericRuntimeComponentsArg.slice("runtime-component-contracts-json=".length)) as Array<{ slug?: string }>
   assert.equal(genericRuntimeComponents.some((component) => component.slug === "wordpress-plugin"), true)
-  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine"), true)
-  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine-code"), true)
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine"), false)
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine-code"), false)
 
   const recipe = buildAgentTaskRecipe({
     goal: "Verify extra plugin propagation",
@@ -278,8 +283,8 @@ try {
   assert.equal(agentsApiPlugin?.activate, false)
   assert.equal(agentsApiPlugin?.loadAs, "mu-plugin")
   assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api" && component.loadAs === "mu-plugin"), true)
-  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine" && component.loadAs === "mu-plugin"), true)
-  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code" && component.loadAs === "mu-plugin"), true)
+  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), false)
+  assert.equal(recipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code"), false)
   assert.equal(recipe.inputs?.component_manifest?.components.some((component) => String(component.mountedPath).includes("/contained-runtime/")), true)
   assert.equal(JSON.stringify(recipe).includes("wp-codebox-default-agent-runtime-substrate"), false)
   assert.equal(JSON.stringify(recipe).includes("wp-codebox-runtime"), false)


### PR DESCRIPTION
## Summary
- Remove runtime-core default discovery of downstream substrate plugins (`data-machine`, `data-machine-code`, `agents-api`).
- Keep caller-provided component contracts, extra plugins, and generic runtime component paths working.
- Update the focused agent task contract test to prove old substrate env vars are ignored while explicit component contracts still mount.

## Tests
- `npm run test:agent-task-contracts`
- `npm --workspace packages/runtime-core run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5/OpenCode
- **Used for:** Drafting and verifying the scoped runtime-core code/test changes.