### PR TITLE
Validate browser runtime materialization

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -15,6 +15,7 @@
 		'browser-runtime:invoke-result',
 		'playground:run-php',
 		'playground:run-recipe',
+		'browser-runtime:validate-materialization',
 		'wordpress:operation',
 		'filesystem:write-file',
 		'filesystem:ensure-directory',
@@ -341,6 +342,7 @@
 		normalizeBrowserRunResult,
 		browserArtifactPersistenceRef,
 		aggregateFanoutOutputs: ( input ) => api.aggregateFanoutOutputs( input ),
+		validateBrowserRuntimeMaterialization: ( client, session, options = {} ) => api.validateBrowserRuntimeMaterialization( client, session, options ),
 		normalizeResult: normalizeOperationResult,
 		result: browserSdkResult,
 		runBrowserSessionRecipe: async ( client, session, taskPayload, options = {} ) => normalizeBrowserRunResult( await api.runBrowserSessionRecipe( client, session, taskPayload, options ), 'browser-session-recipe' ),
@@ -349,6 +351,7 @@
 			browserSessionRecipe: api.browserSessionRecipe,
 			ensureDirectory: api.ensureDirectory,
 			installTheme: api.installTheme,
+			validateBrowserRuntimeMaterialization: api.validateBrowserRuntimeMaterialization,
 			aggregateFanoutOutputs: api.aggregateFanoutOutputs,
 			preparedBrowserRuntimeContract: api.preparedBrowserRuntimeContract,
 			preparedBrowserRuntimeStatus: api.preparedBrowserRuntimeStatus,
@@ -1486,6 +1489,171 @@ try {
 		};
 	};
 
+	const runtimeDependencySpecs = ( session, field ) => {
+		const runtime = session?.runtime && typeof session.runtime === 'object' ? session.runtime : {};
+		return Array.isArray( runtime[ field ] ) ? runtime[ field ].filter( isPlainObject ) : [];
+	};
+
+	const runtimeMaterializationRequest = ( session ) => ( {
+		schema: 'wp-codebox/browser-runtime-materialization-request/v1',
+		plugins: runtimeDependencySpecs( session, 'plugins' ).map( ( plugin ) => ( {
+			slug: String( plugin.slug || '' ),
+			targetFolderName: String( plugin.targetFolderName || plugin.slug || '' ),
+			activate: plugin.activate !== false,
+			required: plugin.required !== false,
+		} ) ).filter( ( plugin ) => plugin.slug || plugin.targetFolderName ),
+		mu_plugins: runtimeDependencySpecs( session, 'mu_plugins' ).map( ( plugin ) => ( {
+			slug: String( plugin.slug || '' ),
+			file: String( plugin.file || ( plugin.slug ? `${ plugin.slug }.php` : '' ) ),
+			required: plugin.required !== false,
+		} ) ).filter( ( plugin ) => plugin.file || plugin.slug ),
+	} );
+
+	const runtimeMaterializationProbePhp = ( request ) => `<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	require_once '/wordpress/wp-load.php';
+}
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+$request = json_decode( base64_decode( '${ base64Json( request ) }' ), true );
+$request = is_array( $request ) ? $request : array();
+$active_plugins = array_map( 'strval', (array) get_option( 'active_plugins', array() ) );
+$mu_plugin_files = array_map( 'basename', glob( WPMU_PLUGIN_DIR . '/*.php' ) ?: array() );
+$dependencies = array();
+$diagnostics = array();
+
+foreach ( is_array( $request['plugins'] ?? null ) ? $request['plugins'] : array() as $plugin ) {
+	$slug = sanitize_key( (string) ( $plugin['slug'] ?? '' ) );
+	$target_folder = sanitize_key( (string) ( $plugin['targetFolderName'] ?? $slug ) );
+	$activate = false !== ( $plugin['activate'] ?? true );
+	$required = false !== ( $plugin['required'] ?? true );
+	$installed_plugins = '' !== $target_folder ? get_plugins( '/' . $target_folder ) : array();
+	$plugin_file = '';
+	foreach ( array_keys( $installed_plugins ) as $file ) {
+		$plugin_file = $target_folder . '/' . $file;
+		break;
+	}
+	$installed = '' !== $plugin_file;
+	$active = $installed && in_array( $plugin_file, $active_plugins, true );
+	$status = $installed ? ( $activate ? ( $active ? 'active' : 'inactive' ) : 'installed' ) : 'missing';
+	$code = '';
+	if ( $required && ! $installed ) {
+		$code = 'wp_codebox_browser_runtime_plugin_missing';
+	} elseif ( $required && $activate && ! $active ) {
+		$code = 'wp_codebox_browser_runtime_plugin_inactive';
+	}
+	$dependency = array_filter( array(
+		'kind' => 'plugin',
+		'slug' => $slug,
+		'targetFolderName' => $target_folder,
+		'required' => $required,
+		'activate' => $activate,
+		'status' => $status,
+		'pluginFile' => $plugin_file,
+		'evidence' => array(
+			'installed' => $installed,
+			'active' => $active,
+		),
+		'code' => $code,
+	), static fn( $value ) => '' !== $value && null !== $value );
+	$dependencies[] = $dependency;
+	if ( '' !== $code ) {
+		$diagnostics[] = array(
+			'code' => $code,
+			'severity' => 'error',
+			'kind' => 'plugin',
+			'slug' => $slug,
+			'targetFolderName' => $target_folder,
+			'pluginFile' => $plugin_file,
+			'message' => 'Required browser runtime plugin is not active.',
+		);
+	}
+}
+
+foreach ( is_array( $request['mu_plugins'] ?? null ) ? $request['mu_plugins'] : array() as $plugin ) {
+	$slug = sanitize_key( (string) ( $plugin['slug'] ?? '' ) );
+	$file = basename( (string) ( $plugin['file'] ?? ( '' !== $slug ? $slug . '.php' : '' ) ) );
+	$required = false !== ( $plugin['required'] ?? true );
+	$materialized = '' !== $file && in_array( $file, $mu_plugin_files, true );
+	$status = $materialized ? 'materialized' : 'missing';
+	$code = $required && ! $materialized ? 'wp_codebox_browser_runtime_mu_plugin_missing' : '';
+	$dependencies[] = array_filter( array(
+		'kind' => 'mu-plugin',
+		'slug' => $slug,
+		'file' => $file,
+		'required' => $required,
+		'status' => $status,
+		'evidence' => array( 'materialized' => $materialized ),
+		'code' => $code,
+	), static fn( $value ) => '' !== $value && null !== $value );
+	if ( '' !== $code ) {
+		$diagnostics[] = array(
+			'code' => $code,
+			'severity' => 'error',
+			'kind' => 'mu-plugin',
+			'slug' => $slug,
+			'file' => $file,
+			'message' => 'Required browser runtime mu-plugin is not materialized.',
+		);
+	}
+}
+
+$success = empty( $diagnostics );
+echo wp_json_encode( array(
+	'schema' => 'wp-codebox/browser-runtime-materialization-result/v1',
+	'success' => $success,
+	'status' => $success ? 'ready' : 'failed',
+	'dependencies' => $dependencies,
+	'diagnostics' => $diagnostics,
+	'error' => $success ? null : array(
+		'code' => 'wp_codebox_browser_runtime_materialization_failed',
+		'message' => 'Browser runtime dependencies failed to materialize.',
+		'diagnostics' => $diagnostics,
+	),
+) );
+`;
+
+	const validateBrowserRuntimeMaterialization = async ( client, session, options = {} ) => {
+		const request = runtimeMaterializationRequest( session );
+		if ( request.plugins.length === 0 && request.mu_plugins.length === 0 ) {
+			return {
+				schema: 'wp-codebox/browser-runtime-materialization-result/v1',
+				success: true,
+				status: 'skipped',
+				dependencies: [],
+				diagnostics: [],
+				error: null,
+			};
+		}
+
+		const result = await runPhpRequest( client, {
+			...options,
+			code: runtimeMaterializationProbePhp( request ),
+			name: options.name || 'codebox-runtime-materialization-probe',
+			expectJson: true,
+		} );
+
+		if ( result?.schema === 'wp-codebox/browser-runtime-materialization-result/v1' ) {
+			return result;
+		}
+
+		return {
+			schema: 'wp-codebox/browser-runtime-materialization-result/v1',
+			success: false,
+			status: 'failed',
+			dependencies: [],
+			diagnostics: [ {
+				code: 'wp_codebox_browser_runtime_validation_invalid_response',
+				severity: 'error',
+				message: 'Browser runtime materialization probe returned an invalid response.',
+				response: result ?? null,
+			} ],
+			error: {
+				code: 'wp_codebox_browser_runtime_validation_invalid_response',
+				message: 'Browser runtime materialization probe returned an invalid response.',
+			},
+		};
+	};
+
 	const runRecipe = async ( client, recipe, taskPayload, options = {} ) => {
 		const taskPath = recipe?.browser?.task_path;
 		const steps = Array.isArray( recipe?.workflow?.steps ) ? recipe.workflow.steps : [];
@@ -1552,6 +1720,20 @@ try {
 
 	const runBrowserSessionRecipe = async ( client, session, taskPayload, options = {} ) => {
 		const payload = taskPayload === undefined ? ( session.task_payload ?? session.task_input ?? {} ) : taskPayload;
+		if ( options.validateRuntime !== false ) {
+			const materialization = await validateBrowserRuntimeMaterialization( client, session, {
+				...options,
+				name: options.runtimeValidationName || 'codebox-browser-session-runtime',
+			} );
+			if ( ! materialization.success ) {
+				throw runtimeError(
+					'browser_runtime_materialization',
+					materialization?.error?.code || 'wp_codebox_browser_runtime_materialization_failed',
+					materialization?.error?.message || 'Browser runtime dependencies failed to materialize.',
+					materialization
+				);
+			}
+		}
 		const recipe = browserSessionRecipe( session );
 		const executableRecipe = payload?.agent_bundles && Array.isArray( payload.agent_bundles ) && payload.agent_bundles.length
 			? {
@@ -1912,6 +2094,7 @@ echo wp_json_encode( array(
 		runWordPressOperation,
 		selectPreparedBrowserBlueprint,
 		setFrontendAdminBarVisible,
+		validateBrowserRuntimeMaterialization,
 		writeFile,
 		writeReviewFile,
 	};

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -544,6 +544,7 @@ final class WP_Codebox_Browser_Task_Builder {
 		$input_hash = strtolower( trim( (string) ( $prepared['input_hash'] ?? $prepared['hash'] ?? '' ) ) );
 		$ref        = '' !== $cache_key && preg_match( '/^[a-f0-9]{64}$/', $input_hash ) ? 'prepared:' . $cache_key . ':' . $input_hash : '';
 		$endpoint   = '' !== $ref ? self::browser_blueprint_ref_hydration_endpoint( $ref ) : '';
+		$hydration  = self::browser_blueprint_ref_hydration_status( $cache_key, $input_hash );
 
 		return array_filter(
 			array(
@@ -554,12 +555,14 @@ final class WP_Codebox_Browser_Task_Builder {
 				'cache_key'       => $cache_key,
 				'input_hash'      => $input_hash,
 				'status'          => (string) ( $prepared['status'] ?? '' ),
+				'hydration_status' => $hydration['status'],
+				'hydratable'      => $hydration['hydratable'],
 				'hydrator_ability' => 'wp-codebox/hydrate-browser-blueprint-ref',
 				'endpoint'        => $endpoint,
 				'hydration_endpoint' => $endpoint,
 				'session_id'      => (string) ( $session['session']['id'] ?? $session['session_id'] ?? '' ),
 			),
-			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+			static fn( mixed $value ): bool => null !== $value && '' !== $value && array() !== $value
 		);
 	}
 
@@ -633,7 +636,11 @@ final class WP_Codebox_Browser_Task_Builder {
 		$transient_key = self::prepared_runtime_transient_key( $cache_key, $input_hash );
 		$artifact      = function_exists( 'get_transient' ) ? get_transient( $transient_key ) : false;
 		if ( ! is_array( $artifact ) || 'wp-codebox/browser-prepared-runtime-artifact/v1' !== ( $artifact['schema'] ?? '' ) || $input_hash !== (string) ( $artifact['input_hash'] ?? '' ) || ! is_array( $artifact['blueprint'] ?? null ) ) {
-			return new WP_Error( 'wp_codebox_browser_blueprint_ref_not_found', 'Browser blueprint ref could not be hydrated from the prepared runtime cache.', array( 'status' => 404, 'ref' => '' !== $ref ? $ref : 'prepared:' . $cache_key . ':' . $input_hash ) );
+			return new WP_Error(
+				'wp_codebox_browser_blueprint_ref_not_found',
+				'Browser blueprint ref could not be hydrated from the prepared runtime cache. Create a new browser session to materialize the site again.',
+				self::browser_blueprint_ref_miss_contract( $cache_key, $input_hash, '' !== $ref ? $ref : 'prepared:' . $cache_key . ':' . $input_hash )
+			);
 		}
 
 		return array(
@@ -1037,6 +1044,42 @@ final class WP_Codebox_Browser_Task_Builder {
 
 	private static function prepared_runtime_transient_key( string $cache_key, string $input_hash ): string {
 		return 'wp_codebox_browser_prepared_runtime_' . substr( hash( 'sha256', $cache_key . ':' . $input_hash ), 0, 24 );
+	}
+
+	/** @return array{status:string,hydratable:bool} */
+	private static function browser_blueprint_ref_hydration_status( string $cache_key, string $input_hash ): array {
+		if ( '' === $cache_key || ! preg_match( '/^[a-f0-9]{64}$/', $input_hash ) ) {
+			return array( 'status' => 'invalid', 'hydratable' => false );
+		}
+
+		if ( ! function_exists( 'get_transient' ) ) {
+			return array( 'status' => 'unknown', 'hydratable' => true );
+		}
+
+		$artifact = get_transient( self::prepared_runtime_transient_key( $cache_key, $input_hash ) );
+		if ( is_array( $artifact ) && 'wp-codebox/browser-prepared-runtime-artifact/v1' === ( $artifact['schema'] ?? '' ) && $input_hash === (string) ( $artifact['input_hash'] ?? '' ) && is_array( $artifact['blueprint'] ?? null ) ) {
+			return array( 'status' => 'available', 'hydratable' => true );
+		}
+
+		return array( 'status' => 'expired', 'hydratable' => false );
+	}
+
+	/** @return array<string,mixed> */
+	private static function browser_blueprint_ref_miss_contract( string $cache_key, string $input_hash, string $ref ): array {
+		return array(
+			'status'                   => 409,
+			'success'                  => false,
+			'schema'                   => 'wp-codebox/browser-blueprint-ref-miss/v1',
+			'ref'                      => $ref,
+			'cache_key'                => $cache_key,
+			'input_hash'               => $input_hash,
+			'action'                   => 'reload-required',
+			'open_mode'                => 'materialize',
+			'reload_required'          => true,
+			'requires_materialization' => true,
+			'reason'                  => 'prepared-runtime-not-found-or-expired',
+			'blueprint_ref'            => self::browser_blueprint_ref( array( 'cache_key' => $cache_key, 'input_hash' => $input_hash, 'status' => 'expired' ) ),
+		);
 	}
 
 	/** @param array<string,mixed> $input Ability or caller input. */

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -35,6 +35,7 @@ assert.deepEqual(plain(api.v1.info()), {
     "browser-runtime:invoke-result",
     "playground:run-php",
     "playground:run-recipe",
+    "browser-runtime:validate-materialization",
     "wordpress:operation",
     "filesystem:write-file",
     "filesystem:ensure-directory",
@@ -49,7 +50,9 @@ assert.deepEqual(plain(api.v1.info()), {
 
 assert.equal(api.v1.methods.runPhpRequest, api.runPhpRequest)
 assert.equal(api.v1.methods.writeFile, api.writeFile)
+assert.equal(api.v1.methods.validateBrowserRuntimeMaterialization, api.validateBrowserRuntimeMaterialization)
 assert.equal(typeof api.v1.runBrowserSessionRecipe, "function")
+assert.equal(typeof api.v1.validateBrowserRuntimeMaterialization, "function")
 assert.deepEqual(plain(api.v1.normalizeError(Object.assign(new Error("Nope"), { code: "demo_error", phase: "probe", status: 418, data: { demo: true } }))), {
   schema: "wp-codebox/browser-sdk-error/v1",
   code: "demo_error",
@@ -91,6 +94,42 @@ assert.deepEqual(plain(browserRun.artifactRefs), [
   { kind: "browser-html", path: "files/browser/index.html", digest: { algorithm: "sha256", value: "def" } },
 ])
 assert.equal(api.v1.browserArtifactPersistenceRef(browserRun.result).schema, "wp-codebox/browser-artifact-persistence/ref/v1")
+
+const runtimeSession = {
+  runtime: {
+    plugins: [ { slug: "demo-plugin", targetFolderName: "demo-plugin", activate: true } ],
+    mu_plugins: [ { slug: "demo-mu", file: "demo-mu.php" } ],
+  },
+}
+const readyRuntime = {
+  schema: "wp-codebox/browser-runtime-materialization-result/v1",
+  success: true,
+  status: "ready",
+  dependencies: [ { kind: "plugin", slug: "demo-plugin", status: "active" } ],
+  diagnostics: [],
+  error: null,
+}
+const readyClient = { run: async () => JSON.stringify(readyRuntime) }
+assert.deepEqual(plain(await api.v1.validateBrowserRuntimeMaterialization(readyClient, runtimeSession)), readyRuntime)
+
+const failedRuntime = {
+  schema: "wp-codebox/browser-runtime-materialization-result/v1",
+  success: false,
+  status: "failed",
+  dependencies: [ { kind: "plugin", slug: "demo-plugin", status: "missing", code: "wp_codebox_browser_runtime_plugin_missing" } ],
+  diagnostics: [ { code: "wp_codebox_browser_runtime_plugin_missing", severity: "error", slug: "demo-plugin" } ],
+  error: { code: "wp_codebox_browser_runtime_materialization_failed", message: "Browser runtime dependencies failed to materialize." },
+}
+const failedClient = { run: async () => JSON.stringify(failedRuntime) }
+await assert.rejects(
+  () => api.v1.runBrowserSessionRecipe(failedClient, runtimeSession, {}),
+  (error: any) => {
+    assert.equal(error.code, "wp_codebox_browser_runtime_materialization_failed")
+    assert.equal(error.phase, "browser_runtime_materialization")
+    assert.deepEqual(plain(error.data), failedRuntime)
+    return true
+  },
+)
 
 const canonicalBrowserRun = api.v1.normalizeBrowserRunResult({
   schema: "wp-codebox/browser-run-result/v1",

--- a/tests/browser-task-builder.test.ts
+++ b/tests/browser-task-builder.test.ts
@@ -208,7 +208,10 @@ $GLOBALS['wp_codebox_test_transients']['wp_codebox_browser_prepared_runtime_' . 
 	'input_hash' => str_repeat( 'b', 64 ),
 	'blueprint' => array( 'steps' => array( array( 'step' => 'login' ) ) ),
 );
+$available_blueprint_ref = WP_Codebox_Browser_Task_Builder::browser_blueprint_ref( array( 'cache_key' => 'runtime-cache-key', 'input_hash' => str_repeat( 'b', 64 ), 'status' => 'hit' ) );
 $hydrated_blueprint = WP_Codebox_Browser_Task_Builder::hydrate_browser_blueprint_ref( array( 'ref' => $blueprint_ref['ref'] ) );
+$missing_blueprint = WP_Codebox_Browser_Task_Builder::hydrate_browser_blueprint_ref( array( 'ref' => 'prepared:missing-runtime:' . str_repeat( 'e', 64 ) ) );
+$missing_blueprint_data = is_wp_error( $missing_blueprint ) ? $missing_blueprint->data : array();
 
 $recipe_dto = WP_Codebox_Browser_Task_Builder::browser_recipe_dto( array(
 	'schema' => 'wp-codebox/workspace-recipe/v1',
@@ -239,7 +242,7 @@ $recipe_dto = WP_Codebox_Browser_Task_Builder::browser_recipe_dto( array(
 	),
 ) );
 
-echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'plan_contract' => $plan_contract, 'plan_plugin_specs' => $plan_plugin_specs, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request, 'product_session' => $product_session, 'nested_primary_product_session' => $nested_primary_product_session, 'preview_lease_status' => $preview_lease_status, 'blueprint_ref' => $blueprint_ref, 'hydrated_blueprint' => $hydrated_blueprint, 'recipe_dto' => $recipe_dto ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'task_input' => $task_input, 'payload' => $payload, 'explicit_plan_payload' => $explicit_plan_payload, 'plan_contract' => $plan_contract, 'plan_plugin_specs' => $plan_plugin_specs, 'local_task' => $local_task, 'intent_task' => $intent_task, 'fanout_request' => $fanout_request, 'product_session' => $product_session, 'nested_primary_product_session' => $nested_primary_product_session, 'preview_lease_status' => $preview_lease_status, 'blueprint_ref' => $blueprint_ref, 'available_blueprint_ref' => $available_blueprint_ref, 'hydrated_blueprint' => $hydrated_blueprint, 'missing_blueprint_data' => $missing_blueprint_data, 'recipe_dto' => $recipe_dto ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.task_input.schema, "wp-codebox/task-input/v1")
@@ -309,6 +312,8 @@ assert.equal(result.product_session.preview_boot.contained_site.site_id, "runtim
 assert.equal(result.product_session.preview_boot.blueprint_ref, `prepared:runtime-cache-key:${"a".repeat(64)}`)
 assert.equal(result.product_session.preview_boot.blueprint_ref_dto.schema, "wp-codebox/browser-blueprint-ref/v1")
 assert.equal(result.product_session.preview_boot.blueprint_ref_dto.ref, `prepared:runtime-cache-key:${"a".repeat(64)}`)
+assert.equal(result.product_session.preview_boot.blueprint_ref_dto.hydration_status, "expired")
+assert.equal(result.product_session.preview_boot.blueprint_ref_dto.hydratable, false)
 assert.equal(result.product_session.preview_boot.blueprint_ref_dto.hydrator_ability, "wp-codebox/hydrate-browser-blueprint-ref")
 assert.equal(result.product_session.preview_boot.preview.schema, "wp-codebox/preview-lease/v1")
 assert.equal(result.product_session.preview_boot.preview.preview_public_url, "https://preview.example.test")
@@ -335,8 +340,19 @@ assert.equal(JSON.stringify(result.product_session).includes("must-not-leak"), f
 assert.equal(JSON.stringify(result.product_session).includes('"blueprint":'), false)
 assert.equal(result.blueprint_ref.schema, "wp-codebox/browser-blueprint-ref/v1")
 assert.equal(result.blueprint_ref.ref, `prepared:runtime-cache-key:${"b".repeat(64)}`)
+assert.equal(result.blueprint_ref.hydration_status, "expired")
+assert.equal(result.blueprint_ref.hydratable, false)
+assert.equal(result.available_blueprint_ref.hydration_status, "available")
+assert.equal(result.available_blueprint_ref.hydratable, true)
 assert.equal(result.hydrated_blueprint.schema, "wp-codebox/browser-blueprint-hydration/v1")
 assert.equal(result.hydrated_blueprint.blueprint.steps[0].step, "login")
+assert.equal(result.missing_blueprint_data.status, 409)
+assert.equal(result.missing_blueprint_data.schema, "wp-codebox/browser-blueprint-ref-miss/v1")
+assert.equal(result.missing_blueprint_data.action, "reload-required")
+assert.equal(result.missing_blueprint_data.reload_required, true)
+assert.equal(result.missing_blueprint_data.requires_materialization, true)
+assert.equal(result.missing_blueprint_data.blueprint_ref.hydration_status, "expired")
+assert.equal(result.missing_blueprint_data.blueprint_ref.hydratable, false)
 assert.equal(result.recipe_dto.schema, "wp-codebox/browser-recipe-dto/v1")
 assert.equal(result.recipe_dto.source_schema, "wp-codebox/workspace-recipe/v1")
 assert.equal(result.recipe_dto.runtime.backend, "wordpress-playground")


### PR DESCRIPTION
## Summary
- Add a Codebox-owned `validateBrowserRuntimeMaterialization()` browser SDK primitive.
- Validate declared browser runtime plugins and mu-plugins inside the browser WordPress site with a structured `wp-codebox/browser-runtime-materialization-result/v1` envelope.
- Make `runBrowserSessionRecipe()` fail closed before recipe execution when required runtime dependencies are missing or inactive.
- Expose browser blueprint ref hydration availability through `hydration_status` / `hydratable` and return a recoverable `reload-required` contract when prepared refs have expired.

## Testing
- `npm run test:browser-task-builder`
- `npm run test:browser-sdk-facade`
- `npm run test:browser-contained-site-status`
- `npx tsx tests/browser-blueprint-ref-endpoint.test.ts`
- `npm run test:php-browser-contained-site-contract`
- `npm run test:php-browser-runtime-local-package`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Runtime boundary analysis, browser SDK primitive implementation, expired blueprint ref contract handling, focused test coverage, and verification.