### PR TITLE
Fix SQL fingerprint string redaction

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -1445,11 +1445,11 @@ private static function normalize_fuzz_suite_query_sample( mixed $query, int $qu
 
 private static function normalize_fuzz_suite_query_sql( string $sql ): string {
 	$redacted = preg_replace( '/\/\*.*?\*\//s', '/* ? */', $sql );
-	$redacted = preg_replace( '/--[^\r\n]*/', '-- ?', is_string( $redacted ) ? $redacted : $sql );
-	$redacted = preg_replace( '/#[^\r\n]*/', '# ?', is_string( $redacted ) ? $redacted : $sql );
 	$redacted = preg_replace( "/\\b(?:x|b)'(?:''|[^'])*'/i", "'?'", is_string( $redacted ) ? $redacted : $sql );
 	$redacted = preg_replace( "/'(?:''|[^'])*'/", "'?'", is_string( $redacted ) ? $redacted : $sql );
 	$redacted = preg_replace( '/"(?:""|[^"])*"/', '"?"', is_string( $redacted ) ? $redacted : $sql );
+	$redacted = preg_replace( '/--[^\r\n]*/', '-- ?', is_string( $redacted ) ? $redacted : $sql );
+	$redacted = preg_replace( '/#[^\r\n]*/', '# ?', is_string( $redacted ) ? $redacted : $sql );
 	$redacted = preg_replace( '/\b0x[0-9a-f]+\b/i', '?', is_string( $redacted ) ? $redacted : $sql );
 	$redacted = preg_replace( '/\b[-+]?\d+(?:\.\d+)?(?:e[-+]?\d+)?\b/i', '?', is_string( $redacted ) ? $redacted : $sql );
 	$redacted = preg_replace( '/\s+/', ' ', is_string( $redacted ) ? $redacted : $sql );

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -139,6 +139,7 @@ class WP_Codebox_Test_REST_Response {
 function rest_do_request( WP_REST_Request $request ): WP_Codebox_Test_REST_Response {
 	apply_filters( 'query', "SELECT * FROM wp_posts WHERE post_type = 'secret-post-type' AND ID IN (123, 456)" );
 	apply_filters( 'query', "SELECT * FROM wp_posts WHERE post_type = 'another-secret-post-type' AND ID IN (789, 101112)" );
+	apply_filters( 'query', "INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('session_key', 'Ef# secret-fragment', 'no')" );
 	apply_filters( 'query', 'SELECT option_value FROM wp_options WHERE option_name = "blogname"' );
 	return new WP_Codebox_Test_REST_Response( '/wp/v2/status' === $request->path ? 200 : 404 );
 }
@@ -526,21 +527,25 @@ assert( 'array' !== ( $result['cases'][21]['metadata']['observations'][0]['retur
 assert( is_file( WP_CONTENT_DIR . '/uploads/workloads/rest-db-query-profile.json' ) );
 $workload_report = json_decode( file_get_contents( WP_CONTENT_DIR . '/uploads/workloads/rest-db-query-profile.json' ), true );
 assert( 'wp-codebox/json-workload-result/v1' === $workload_report['schema'] );
-assert( 3 === $workload_report['steps'][1]['observation']['queryCount'] );
-assert( 2 === $workload_report['steps'][1]['observation']['fingerprintCount'] );
-assert( 3 === $workload_report['steps'][1]['requests'][0]['queryCount'] );
+assert( 4 === $workload_report['steps'][1]['observation']['queryCount'] );
+assert( 3 === $workload_report['steps'][1]['observation']['fingerprintCount'] );
+assert( 4 === $workload_report['steps'][1]['requests'][0]['queryCount'] );
 assert( "SELECT * FROM wp_posts WHERE post_type = '?' AND ID IN (?)" === $workload_report['steps'][1]['requests'][0]['sampledQueries'][0]['sql'] );
 assert( 2 === $workload_report['steps'][1]['queryFingerprints'][0]['count'] );
 assert( "select * from wp_posts where post_type = '?' and id in (?)" === $workload_report['steps'][1]['queryFingerprints'][0]['fingerprint'] );
 assert( array( "SELECT * FROM wp_posts WHERE post_type = '?' AND ID IN (?)" ) === $workload_report['steps'][1]['queryFingerprints'][0]['examples'] );
 assert( 2 === $workload_report['steps'][1]['requests'][0]['queryFingerprints'][0]['count'] );
 assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['requests'][0]['sampledQueries'] ), 'secret-post-type' ) );
+assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['requests'][0]['sampledQueries'] ), 'secret-fragment' ) );
+assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['requests'][0]['sampledQueries'] ), 'Ef#' ) );
 assert( 'hook-hotspot-sampler' === $workload_report['steps'][2]['type'] );
-assert( 3 === $workload_report['steps'][2]['observation']['hookCount'] );
+assert( 4 === $workload_report['steps'][2]['observation']['hookCount'] );
 assert( 'query' === $workload_report['steps'][2]['requests'][0]['hookHotspots'][0]['hook'] );
 assert( isset( $workload_report['steps'][2]['requests'][0]['totalElapsedMs'] ) );
 assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['queryFingerprints'] ), 'another-secret-post-type' ) );
 assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['queryFingerprints'] ), '101112' ) );
+assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['queryFingerprints'] ), 'secret-fragment' ) );
+assert( ! str_contains( wp_json_encode( $workload_report['steps'][1]['queryFingerprints'] ), 'Ef#' ) );
 assert( 'closure-external-http-guardrail' === $result['cases'][22]['id'] );
 assert( 'passed' === $result['cases'][22]['status'] );
 assert( 'array' === $result['cases'][22]['metadata']['observations'][1]['return_type'] );


### PR DESCRIPTION
## Summary
- Redact quoted SQL literals before stripping comment syntax while normalizing query samples and fingerprints.
- Add regression coverage for `#` inside a SQL string literal so fingerprint examples do not leak literal fragments.

## Testing
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- php -l scripts/php-fuzz-suite-runner-smoke.php
- npm run test:php-fuzz-suite-runner

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the fuzz artifact redaction leak and applying the focused redaction-order fix.
