### PR TITLE
Fail closed for runtime-backed fuzz suites

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -78,11 +78,16 @@ filters.
 `wp-codebox/run-fuzz-suite` accepts public target kinds `rest`, `http`,
 `ability`, `command`, `runtime`, and `runtime-action`. The WordPress plugin
 ability runs safe in-process `rest`, same-site `http`, and WordPress `ability`
-targets directly. Targets that require the runtime command, browser, editor, or
+targets directly. Requests may set `runnerMode` / `runner_mode` to `auto`,
+`php-in-process`, or `runtime-backed`; the WordPress plugin ability only provides
+`php-in-process`, so `runtime-backed` fails closed with `status: "error"` before
+case execution. Targets that require the runtime command, browser, editor, or
 page-load executors return `status: "skipped"`, a case-level `skipReason`, and a
-warning diagnostic rather than silently passing without exercising the target.
-Public suite builders declare `metadata.requiredRunnerCapabilities` so callers
-can choose between PHP in-process mode and runtime-backed mode before execution.
+warning diagnostic in permissive PHP mode rather than silently passing without
+exercising the target. Public suite builders declare
+`metadata.requiredRunnerCapabilities`, and the PHP ability also infers required
+target/runtime-action capabilities from suite targets, so callers can choose
+between PHP in-process mode and runtime-backed mode before execution.
 The public core exports `PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES` and
 `RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES` for readiness checks. Runtime-backed
 mode supports `runtime`, browser/editor/page-load action targets, and the

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -58,24 +58,26 @@ public static function run_fuzz_suite( array $input ): array|WP_Error {
 	$cases = is_array( $input['cases'] ?? null ) ? $input['cases'] : array();
 	$runner_capabilities = self::fuzz_suite_php_runner_capabilities( $input );
 	$missing_capabilities = self::fuzz_suite_missing_required_capabilities( $input, $runner_capabilities );
+	$requested_runner_mode = self::fuzz_suite_requested_runner_mode( $input );
+	if ( 'php-in-process' !== $requested_runner_mode ) {
+		return self::fuzz_suite_runner_capability_error_result(
+			$input,
+			$cases,
+			$runner_capabilities,
+			self::fuzz_suite_diagnostic(
+				'error',
+				'wp_codebox_fuzz_suite_runner_mode_unavailable',
+				'wp-codebox/run-fuzz-suite runs PHP in-process mode only; use the runtime-backed Codebox runner for browser, editor, page, CRUD, runtime, or runtime-action coverage.',
+				array( 'requested_runner_mode' => $requested_runner_mode, 'available_runner_mode' => $runner_capabilities['mode'], 'missing_capabilities' => $missing_capabilities )
+			)
+		);
+	}
 	if ( self::fuzz_suite_require_coverage( $input ) && ! empty( $missing_capabilities ) ) {
-		$diagnostic = self::fuzz_suite_diagnostic( 'error', 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported', 'Fuzz suite requires runner capabilities that are not available in PHP in-process mode.', array( 'missing_capabilities' => $missing_capabilities, 'runner_mode' => $runner_capabilities['mode'] ) );
-		$results = array();
-		foreach ( $cases as $index => $case ) {
-			$case_id = is_array( $case ) ? (string) ( $case['id'] ?? $case['case_id'] ?? ( 'case-' . (string) $index ) ) : ( 'case-' . (string) $index );
-			$results[] = self::fuzz_suite_case_result( $case_id, 'skipped', array( $diagnostic ) );
-		}
-
-		return array(
-			'success'      => false,
-			'schema'       => 'wp-codebox/fuzz-suite-result/v1',
-			'status'       => 'error',
-			'suite'        => array_filter( array( 'id' => (string) ( $input['id'] ?? '' ), 'version' => (string) ( $input['version'] ?? '' ) ), static fn( mixed $value ): bool => '' !== $value ),
-			'summary'      => self::fuzz_suite_summary( $results ),
-			'cases'        => $results,
-			'diagnostics'  => array( $diagnostic ),
-			'artifactRefs' => array(),
-			'metadata'     => array( 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'runner' => 'wp-codebox/fuzz-suite-runner/v1', 'runnerCapabilities' => $runner_capabilities ),
+		return self::fuzz_suite_runner_capability_error_result(
+			$input,
+			$cases,
+			$runner_capabilities,
+			self::fuzz_suite_diagnostic( 'error', 'wp_codebox_fuzz_suite_required_runner_capabilities_unsupported', 'Fuzz suite requires runner capabilities that are not available in PHP in-process mode.', array( 'missing_capabilities' => $missing_capabilities, 'runner_mode' => $runner_capabilities['mode'] ) )
 		);
 	}
 	$results = array();
@@ -122,6 +124,27 @@ public static function run_fuzz_suite( array $input ): array|WP_Error {
 	);
 }
 
+/** @param array<string,mixed> $suite Suite input. @param array<int,mixed> $cases Suite cases. @param array<string,mixed> $runner_capabilities Runner capabilities. @param array<string,mixed> $diagnostic Diagnostic. @return array<string,mixed> */
+private static function fuzz_suite_runner_capability_error_result( array $suite, array $cases, array $runner_capabilities, array $diagnostic ): array {
+	$results = array();
+	foreach ( $cases as $index => $case ) {
+		$case_id = is_array( $case ) ? (string) ( $case['id'] ?? $case['case_id'] ?? ( 'case-' . (string) $index ) ) : ( 'case-' . (string) $index );
+		$results[] = self::fuzz_suite_case_result( $case_id, 'skipped', array( $diagnostic ) );
+	}
+
+	return array(
+		'success'      => false,
+		'schema'       => 'wp-codebox/fuzz-suite-result/v1',
+		'status'       => 'error',
+		'suite'        => array_filter( array( 'id' => (string) ( $suite['id'] ?? '' ), 'version' => (string) ( $suite['version'] ?? '' ) ), static fn( mixed $value ): bool => '' !== $value ),
+		'summary'      => self::fuzz_suite_summary( $results ),
+		'cases'        => $results,
+		'diagnostics'  => array( $diagnostic ),
+		'artifactRefs' => array(),
+		'metadata'     => array( 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'runner' => 'wp-codebox/fuzz-suite-runner/v1', 'runnerCapabilities' => $runner_capabilities ),
+	);
+}
+
 /** @param array<string,mixed> $suite Optional suite input. @return array<string,mixed> */
 private static function fuzz_suite_php_runner_capabilities( array $suite = array() ): array {
 	return self::fuzz_suite_runner_capabilities_contract( $suite );
@@ -153,6 +176,13 @@ private static function fuzz_suite_require_coverage( array $suite ): bool {
 	return true === ( $suite['requireCoverage'] ?? $suite['require_coverage'] ?? false );
 }
 
+/** @param array<string,mixed> $suite Suite input. */
+private static function fuzz_suite_requested_runner_mode( array $suite ): string {
+	$metadata = is_array( $suite['metadata'] ?? null ) ? $suite['metadata'] : array();
+	$mode = (string) ( $suite['runnerMode'] ?? $suite['runner_mode'] ?? $metadata['runnerMode'] ?? $metadata['runner_mode'] ?? 'php-in-process' );
+	return '' === $mode || 'auto' === $mode ? 'php-in-process' : $mode;
+}
+
 /** @param array<string,mixed> $suite Suite input. @param array<string,mixed> $runner_capabilities Runner capabilities. @return string[] */
 private static function fuzz_suite_missing_required_capabilities( array $suite, array $runner_capabilities ): array {
 	$required = self::fuzz_suite_required_capabilities( $suite );
@@ -174,6 +204,7 @@ private static function fuzz_suite_required_capabilities( array $suite ): array 
 	$metadata = is_array( $suite['metadata'] ?? null ) ? $suite['metadata'] : array();
 	$required = is_array( $metadata['requiredRunnerCapabilities'] ?? null ) ? $metadata['requiredRunnerCapabilities'] : ( is_array( $metadata['required_runner_capabilities'] ?? null ) ? $metadata['required_runner_capabilities'] : array() );
 	$capabilities = array_map( 'strval', is_array( $required['capabilities'] ?? null ) ? $required['capabilities'] : array() );
+	$capabilities = array_merge( $capabilities, self::fuzz_suite_declared_target_capabilities( $suite ) );
 	foreach ( is_array( $required['targetKinds'] ?? null ) ? $required['targetKinds'] : ( is_array( $required['target_kinds'] ?? null ) ? $required['target_kinds'] : array() ) as $kind ) {
 		$capabilities[] = 'target:' . (string) $kind;
 	}
@@ -183,6 +214,44 @@ private static function fuzz_suite_required_capabilities( array $suite ): array 
 	foreach ( ( is_array( $required['commands'] ?? null ) ? $required['commands'] : array() ) as $command ) {
 		$capabilities[] = 'command:' . (string) $command;
 	}
+	return array_values( array_unique( array_filter( $capabilities, static fn( string $capability ): bool => '' !== $capability ) ) );
+}
+
+/** @param array<string,mixed> $suite Suite input. @return string[] */
+private static function fuzz_suite_declared_target_capabilities( array $suite ): array {
+	$capabilities = array();
+	$targets = array();
+	if ( is_array( $suite['target'] ?? null ) ) {
+		$targets[] = $suite['target'];
+	}
+	foreach ( is_array( $suite['cases'] ?? null ) ? $suite['cases'] : array() as $case ) {
+		if ( is_array( $case ) && is_array( $case['target'] ?? null ) ) {
+			$targets[] = $case['target'];
+		}
+	}
+
+	foreach ( $targets as $target ) {
+		$kind = (string) ( $target['kind'] ?? '' );
+		if ( '' !== $kind ) {
+			$capabilities[] = 'target:' . $kind;
+		}
+	}
+
+	foreach ( is_array( $suite['cases'] ?? null ) ? $suite['cases'] : array() as $case ) {
+		if ( ! is_array( $case ) ) {
+			continue;
+		}
+		$target = is_array( $case['target'] ?? null ) ? $case['target'] : ( is_array( $suite['target'] ?? null ) ? $suite['target'] : array() );
+		if ( 'runtime-action' !== (string) ( $target['kind'] ?? '' ) ) {
+			continue;
+		}
+		$input = is_array( $case['input'] ?? null ) ? $case['input'] : array();
+		$type = (string) ( $input['type'] ?? '' );
+		if ( '' !== $type ) {
+			$capabilities[] = 'runtime-action:' . $type;
+		}
+	}
+
 	return array_values( array_unique( array_filter( $capabilities, static fn( string $capability ): bool => '' !== $capability ) ) );
 }
 

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -720,11 +720,15 @@ private static function fuzz_suite_request_schema(): array {
 		'type'       => 'object',
 		'required'   => array( 'schema', 'id', 'cases' ),
 		'properties' => array(
-			'schema'   => array( 'type' => 'string', 'const' => 'wp-codebox/fuzz-suite/v1' ),
-			'id'       => array( 'type' => 'string' ),
-			'version'  => array( 'type' => 'string' ),
-			'target'   => self::fuzz_suite_target_schema(),
-			'cases'    => array(
+			'schema'          => array( 'type' => 'string', 'const' => 'wp-codebox/fuzz-suite/v1' ),
+			'id'              => array( 'type' => 'string' ),
+			'version'         => array( 'type' => 'string' ),
+			'runnerMode'      => array( 'type' => 'string', 'enum' => array( 'auto', 'php-in-process', 'runtime-backed' ) ),
+			'runner_mode'     => array( 'type' => 'string', 'enum' => array( 'auto', 'php-in-process', 'runtime-backed' ) ),
+			'requireCoverage' => array( 'type' => 'boolean' ),
+			'require_coverage' => array( 'type' => 'boolean' ),
+			'target'          => self::fuzz_suite_target_schema(),
+			'cases'           => array(
 				'type'  => 'array',
 				'items' => array(
 					'type'       => 'object',

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -519,7 +519,26 @@ assert( str_contains( $result['cases'][22]['metadata']['observations'][1]['paylo
 assert( 'wp-codebox/fuzz-runner-capabilities/v1' === $result['metadata']['runnerCapabilities']['schema'] );
 assert( 'php-in-process' === $result['metadata']['runnerCapabilities']['mode'] );
 assert( in_array( 'target:rest', $result['metadata']['runnerCapabilities']['capabilities'], true ) );
-assert( array() === $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'] );
+assert( in_array( 'target:runtime-action', $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'], true ) );
+assert( in_array( 'target:runtime', $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'], true ) );
+assert( in_array( 'runtime-action:browser', $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'], true ) );
+
+$runtime_backed_request = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
+	array(
+		'schema'     => 'wp-codebox/fuzz-suite/v1',
+		'id'         => 'runtime-backed-request-suite',
+		'runnerMode' => 'runtime-backed',
+		'target'     => array( 'kind' => 'runtime-action' ),
+		'cases'      => array( array( 'id' => 'browser-page', 'input' => array( 'type' => 'browser', 'url' => '/sample-page/' ) ) ),
+	)
+);
+assert( is_array( $runtime_backed_request ) );
+assert( false === $runtime_backed_request['success'] );
+assert( 'error' === $runtime_backed_request['status'] );
+assert( 'wp_codebox_fuzz_suite_runner_mode_unavailable' === $runtime_backed_request['diagnostics'][0]['code'] );
+assert( 'wp_codebox_fuzz_suite_runner_mode_unavailable' === $runtime_backed_request['cases'][0]['skipReason'] );
+assert( 'runtime-backed' === $runtime_backed_request['diagnostics'][0]['metadata']['requested_runner_mode'] );
+assert( in_array( 'runtime-action:browser', $runtime_backed_request['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'], true ) );
 
 $required_runtime = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 	array(


### PR DESCRIPTION
## Summary
- make the public PHP fuzz-suite ability fail closed when `runnerMode: "runtime-backed"` is requested
- infer required target/runtime-action capabilities from suite targets, not only metadata
- update the PHP fuzz suite smoke and public API docs for the runner boundary

## Tests
- `npm run test:php-fuzz-suite-runner`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementing the public fuzz-suite runner capability boundary, updating docs/tests, and running focused verification.
