### PR TITLE
Generate concrete REST and block fuzz samples

### DIFF
--- a/docs/wordpress-runtime-discovery-contract.md
+++ b/docs/wordpress-runtime-discovery-contract.md
@@ -27,12 +27,18 @@ The inventory commands expose narrower public contracts for fuzzing target disco
 - `wordpress.inventory-database` returns `wp-codebox/wordpress-db-inventory/v1` with the database prefix, table descriptors, bounded column descriptors, indexes, row/byte totals, and best-effort table status. It does not read row data.
 - `wordpress.frontend-url-inventory` returns `wp-codebox/wordpress-frontend-url-inventory/v1` with home URL, rewrite-rule URL seeds, rewrite rules, and public query vars. This is a seed list, not a crawler result.
 
+Block descriptors include registered block name, title, category, inserter support, bounded generic attribute schema descriptors, and optional example attributes. Attribute descriptors expose only product-neutral JSON-schema-like fields used for conservative fuzz sample generation: `name`, `type`, `enum` capped to 25 values, `defaultPresent`, and `default`.
+
+`wordpressBlockDiscoveryToFuzzSuite()` generates small valid attribute samples from block attribute defaults, enum values, example attributes, and simple primitive types (`string`, `integer`, `number`, `boolean`, `array`, and `object`). Server-render and editor-insert cases use generated attributes when available and fall back to empty attributes when no safe sample can be derived.
+
 REST route descriptors keep route selection product-neutral. Each route includes:
 
 - `route`, `namespace`, `methods`, and `argNames` for compact target selection.
 - `endpoints[]` with `methods`, `permission`, and `args` descriptors. Permission descriptors report only `public`, `callback`, or `none` plus a callback type such as `function`, `method`, `closure`, or `invokable`; callback names are not part of the public contract.
 - `args[]` with bounded JSON-schema-like fields: `name`, `required`, `type`, `format`, `enum` capped to 25 values, stripped/truncated `description`, `defaultPresent`, `validateCallback`, and `sanitizeCallback`.
 - optional route `schema` with bounded `title`, `type`, and up to 100 property names.
+
+`restRouteInventoryToFuzzSuite()` and `restRouteInventoryToCoveragePlan()` generate concrete executable cases for safe REST methods (`GET`, `HEAD`, and `OPTIONS`) when required route arguments can be represented from the discovered descriptors. Path tokens such as `(?P<id>[\d]+)` are replaced with conservative samples, and required non-path args are passed as request params using enum or type-derived samples. Mutating methods remain planned and require an explicit safe-fixture opt-in before execution.
 
 ## REST Matrix Contract
 

--- a/packages/runtime-core/src/wordpress-block-fuzz-suite.ts
+++ b/packages/runtime-core/src/wordpress-block-fuzz-suite.ts
@@ -1,7 +1,7 @@
 import { fuzzCoveragePlanContract, type FuzzCoveragePlanContract, type FuzzCoveragePlanItem, type FuzzCoveragePlanParameterGenerationHook } from "./fuzz-coverage-plan-contracts.js"
 import { fuzzSuiteContract, type FuzzSuiteCase, type FuzzSuiteContract } from "./fuzz-suite-contracts.js"
 import { stripUndefined } from "./object-utils.js"
-import type { WordPressBlockEditorTargetDiscovery, WordPressBlockTypeDescriptor, WordPressEditorPostTypeDescriptor } from "./wordpress-runtime-discovery-contracts.js"
+import type { WordPressBlockAttributeDescriptor, WordPressBlockEditorTargetDiscovery, WordPressBlockTypeDescriptor, WordPressEditorPostTypeDescriptor } from "./wordpress-runtime-discovery-contracts.js"
 
 export interface WordPressBlockFuzzSuiteOptions {
   id?: string
@@ -96,34 +96,40 @@ export function wordpressBlockDiscoveryToCoveragePlan(discovery: WordPressBlockE
 }
 
 function serverRenderCase(block: WordPressBlockTypeDescriptor): FuzzSuiteCase {
+  const attributes = blockAttributeSamples(block)
+  const sampleKind = Object.keys(attributes).length ? "sample-attributes" : "empty-attributes"
+
   return {
-    id: `block-${caseIdPart(block.name)}-server-render-empty-attributes`,
+    id: `block-${caseIdPart(block.name)}-server-render-${sampleKind}`,
     target: { kind: "runtime", entrypoint: "wordpress.run-php" },
     input: {
       args: [
-        `code=${serverRenderPhp(block.name)}`,
+        `code=${serverRenderPhp(block.name, attributes)}`,
         "bootstrap=wordpress",
       ],
     },
-    description: `Render ${block.name} through render_block with empty attributes.`,
-    metadata: blockCaseMetadata(block, "server-render", { emptyAttributes: {} }),
+    description: `Render ${block.name} through render_block with ${sampleKind.replace("-", " ")}.`,
+    metadata: blockCaseMetadata(block, "server-render", { attributes }),
   }
 }
 
 function editorInsertCase(block: WordPressBlockTypeDescriptor, postType: WordPressEditorPostTypeDescriptor, capture: readonly string[]): FuzzSuiteCase {
+  const attributes = blockAttributeSamples(block)
+  const sampleKind = Object.keys(attributes).length ? "sample-attributes" : "empty-attributes"
+
   return {
-    id: `block-${caseIdPart(block.name)}-editor-insert-${caseIdPart(postType.name)}-empty-attributes`,
+    id: `block-${caseIdPart(block.name)}-editor-insert-${caseIdPart(postType.name)}-${sampleKind}`,
     target: { kind: "runtime", entrypoint: "wordpress.editor-actions" },
     input: {
       args: [
         "target=post-new",
         `post-type=${postType.name}`,
-        `steps-json=${JSON.stringify([{ kind: "insertBlock", name: block.name, attributes: {} }, { kind: "inspectState" }])}`,
+        `steps-json=${JSON.stringify([{ kind: "insertBlock", name: block.name, attributes }, { kind: "inspectState" }])}`,
         `capture=${capture.join(",")}`,
       ],
     },
-    description: `Insert ${block.name} into a new ${postType.name} editor canvas with empty attributes.`,
-    metadata: blockCaseMetadata(block, "editor-insert", { emptyAttributes: {}, editorPostType: postType.name }),
+    description: `Insert ${block.name} into a new ${postType.name} editor canvas with ${sampleKind.replace("-", " ")}.`,
+    metadata: blockCaseMetadata(block, "editor-insert", { attributes, editorPostType: postType.name }),
   }
 }
 
@@ -185,8 +191,46 @@ function selectEditorPostType(postTypes: readonly WordPressEditorPostTypeDescrip
   return postTypes.find((postType) => postType.name === "post") ?? postTypes[0]
 }
 
-function serverRenderPhp(blockName: string): string {
-  return `$block = array('blockName' => ${JSON.stringify(blockName)}, 'attrs' => array(), 'innerBlocks' => array(), 'innerHTML' => '', 'innerContent' => array()); $rendered = render_block($block); if (!is_string($rendered)) { exit(1); }`
+function blockAttributeSamples(block: WordPressBlockTypeDescriptor): Record<string, unknown> {
+  return Object.fromEntries(block.attributes.flatMap((attribute) => {
+    const sample = blockAttributeSample(attribute, block.exampleAttributes?.[attribute.name])
+    return sample === undefined ? [] : [[attribute.name, sample]]
+  }))
+}
+
+function blockAttributeSample(attribute: WordPressBlockAttributeDescriptor, example: unknown): unknown {
+  if (attribute.defaultPresent) {
+    return attribute.default
+  }
+  if (attribute.enum?.length) {
+    return attribute.enum[0]
+  }
+  if (example !== undefined) {
+    return example
+  }
+
+  const type = Array.isArray(attribute.type) ? attribute.type.find((candidate) => candidate !== "null") : attribute.type
+  if (type === "string") {
+    return "sample"
+  }
+  if (type === "integer" || type === "number") {
+    return 1
+  }
+  if (type === "boolean") {
+    return true
+  }
+  if (type === "array") {
+    return []
+  }
+  if (type === "object") {
+    return {}
+  }
+
+  return undefined
+}
+
+function serverRenderPhp(blockName: string, attributes: Record<string, unknown>): string {
+  return `$attributes = json_decode(${JSON.stringify(JSON.stringify(attributes))}, true); if (!is_array($attributes)) { exit(1); } $block = array('blockName' => ${JSON.stringify(blockName)}, 'attrs' => $attributes, 'innerBlocks' => array(), 'innerHTML' => '', 'innerContent' => array()); $rendered = render_block($block); if (!is_string($rendered)) { exit(1); }`
 }
 
 function caseIdPart(value: string): string {

--- a/packages/runtime-core/src/wordpress-fuzz-suite-builders.ts
+++ b/packages/runtime-core/src/wordpress-fuzz-suite-builders.ts
@@ -1,7 +1,7 @@
 import { fuzzCoveragePlanContract, type FuzzCoveragePlanContract, type FuzzCoveragePlanItem, type FuzzCoveragePlanParameterGenerationHook, type FuzzCoveragePlanReason } from "./fuzz-coverage-plan-contracts.js"
 import { fuzzSuiteContract, type FuzzSuiteCase, type FuzzSuiteContract, type FuzzSuiteTargetRef } from "./fuzz-suite-contracts.js"
 import { stripUndefined } from "./object-utils.js"
-import type { WordPressAdminPageDescriptor, WordPressAdminPageInventory, WordPressFrontendUrlDescriptor, WordPressFrontendUrlInventory, WordPressRestRouteDescriptor, WordPressRestRouteEndpointDescriptor, WordPressRestRouteInventory } from "./wordpress-runtime-discovery-contracts.js"
+import type { WordPressAdminPageDescriptor, WordPressAdminPageInventory, WordPressFrontendUrlDescriptor, WordPressFrontendUrlInventory, WordPressRestRouteArgDescriptor, WordPressRestRouteDescriptor, WordPressRestRouteEndpointDescriptor, WordPressRestRouteInventory } from "./wordpress-runtime-discovery-contracts.js"
 
 export interface WordPressInventoryFuzzSuiteOptions {
   id?: string
@@ -61,7 +61,7 @@ const FRONTEND_PAGE_FUZZ_SUITE_REQUIRED_RUNNER_CAPABILITIES = {
 const REST_PARAMETER_GENERATION_HOOK: FuzzCoveragePlanParameterGenerationHook = {
   id: "wordpress.rest-route-parameters",
   label: "WordPress REST route parameter generator",
-  description: "Placeholder hook for consumers that can generate concrete REST path/query/body parameters from discovered route args.",
+  description: "Generates conservative concrete REST path and query parameters from discovered safe-method route args.",
 }
 
 const REST_MUTATING_OPT_IN_HOOK: FuzzCoveragePlanParameterGenerationHook = {
@@ -160,22 +160,23 @@ function restRouteFuzzSuiteCases(route: WordPressRestRouteDescriptor, options: W
 function restRouteFuzzSuiteCase(route: WordPressRestRouteDescriptor, method: string, options: WordPressInventoryFuzzSuiteOptions, endpoint?: WordPressRestRouteEndpointDescriptor, endpointIndex?: number): FuzzSuiteCase {
   const normalizedMethod = method.toUpperCase()
   const requiredArgs = endpoint?.args.filter((arg) => arg.required).map((arg) => arg.name) ?? []
-  const concreteRoute = !route.route.includes("(?P<") && requiredArgs.length === 0
   const safeMethod = SAFE_REST_METHODS.has(normalizedMethod)
-  const executable = safeMethod && concreteRoute
+  const concreteInput = safeMethod ? concreteRestInput(route, normalizedMethod, options, endpoint) : undefined
+  const executable = concreteInput !== undefined
   const safety = stripUndefined({
     executable,
     safeMethod,
     planned: !executable,
     reason: executable ? undefined : safeMethod ? "route_requires_discovered_parameters" : "mutating_rest_method_requires_explicit_opt_in",
     requiredArgs: requiredArgs.length ? requiredArgs : undefined,
+    generatedParameters: concreteInput?.generatedParameters,
   })
 
   return stripUndefined({
     id: `rest-${slugify(normalizedMethod)}-${slugify(route.route)}${endpointIndex === undefined ? "" : `-${endpointIndex}`}`,
     target: executable ? REST_REQUEST_TARGET : PLANNED_REST_REQUEST_TARGET,
     description: `${normalizedMethod} ${route.route}`,
-    input: executable ? stripUndefined({ method: normalizedMethod, path: route.route, user: options.user, session: options.session }) : undefined,
+    input: concreteInput ? restInputForCase(concreteInput) : undefined,
     metadata: stripUndefined({
       source: "wordpress.rest-route-inventory",
       route: route.route,
@@ -199,9 +200,9 @@ function restRouteCoveragePlanItems(route: WordPressRestRouteDescriptor, options
 function restRouteCoveragePlanItem(route: WordPressRestRouteDescriptor, method: string, options: WordPressInventoryFuzzSuiteOptions, endpoint?: WordPressRestRouteEndpointDescriptor, endpointIndex?: number): FuzzCoveragePlanItem {
   const normalizedMethod = method.toUpperCase()
   const requiredArgs = endpoint?.args.filter((arg) => arg.required).map((arg) => arg.name) ?? []
-  const concreteRoute = !route.route.includes("(?P<") && requiredArgs.length === 0
   const safeMethod = SAFE_REST_METHODS.has(normalizedMethod)
-  const executable = safeMethod && concreteRoute
+  const concreteInput = safeMethod ? concreteRestInput(route, normalizedMethod, options, endpoint) : undefined
+  const executable = concreteInput !== undefined
   const reason = executable ? undefined : restRouteUntestedReason(safeMethod, requiredArgs)
   const parameterGeneration = executable ? undefined : stripUndefined({
     hook: safeMethod ? REST_PARAMETER_GENERATION_HOOK.id : REST_MUTATING_OPT_IN_HOOK.id,
@@ -212,7 +213,7 @@ function restRouteCoveragePlanItem(route: WordPressRestRouteDescriptor, method: 
     id: restRouteCaseId(route.route, normalizedMethod, endpointIndex),
     target: executable ? REST_REQUEST_TARGET : PLANNED_REST_REQUEST_TARGET,
     description: `${normalizedMethod} ${route.route}`,
-    input: executable ? stripUndefined({ method: normalizedMethod, path: route.route, user: options.user, session: options.session }) : undefined,
+    input: concreteInput ? restInputForCase(concreteInput) : undefined,
     reason,
     parameterGeneration,
     metadata: stripUndefined({
@@ -222,8 +223,120 @@ function restRouteCoveragePlanItem(route: WordPressRestRouteDescriptor, method: 
       method: normalizedMethod,
       permission: endpoint?.permission,
       argNames: route.argNames,
+      generatedParameters: concreteInput?.generatedParameters,
     }),
   })
+}
+
+interface ConcreteRestInput {
+  method: string
+  path: string
+  params?: Record<string, unknown>
+  user?: string
+  session?: string
+  generatedParameters?: Record<string, unknown>
+}
+
+function concreteRestInput(route: WordPressRestRouteDescriptor, method: string, options: WordPressInventoryFuzzSuiteOptions, endpoint?: WordPressRestRouteEndpointDescriptor): ConcreteRestInput | undefined {
+  const args = endpoint?.args ?? []
+  const pathArgNames = restRoutePathArgNames(route.route)
+  const pathSamples: Record<string, unknown> = {}
+  const querySamples: Record<string, unknown> = {}
+  let path = route.route
+
+  for (const name of pathArgNames) {
+    const arg = args.find((candidate) => candidate.name === name)
+    const sample = restArgSample(arg, restRoutePathPattern(route.route, name))
+    if (sample === undefined || typeof sample === "object") {
+      return undefined
+    }
+    pathSamples[name] = sample
+    path = path.replace(restRoutePathTokenPattern(name), encodeURIComponent(String(sample)))
+  }
+
+  for (const arg of args) {
+    if (!arg.required || pathArgNames.includes(arg.name)) {
+      continue
+    }
+    const sample = restArgSample(arg)
+    if (sample === undefined) {
+      return undefined
+    }
+    querySamples[arg.name] = sample
+  }
+
+  const generatedParameters = stripUndefined({
+    path: Object.keys(pathSamples).length ? pathSamples : undefined,
+    params: Object.keys(querySamples).length ? querySamples : undefined,
+  })
+
+  return stripUndefined({
+    method,
+    path,
+    params: Object.keys(querySamples).length ? querySamples : undefined,
+    user: options.user,
+    session: options.session,
+    generatedParameters: Object.keys(generatedParameters).length ? generatedParameters : undefined,
+  })
+}
+
+function restInputForCase(input: ConcreteRestInput): Record<string, unknown> {
+  return stripUndefined({ method: input.method, path: input.path, params: input.params, user: input.user, session: input.session })
+}
+
+function restRoutePathArgNames(route: string): string[] {
+  return [...route.matchAll(/\(\?P<([^>]+)>[^)]+\)/g)].map((match) => match[1]).filter((name): name is string => Boolean(name))
+}
+
+function restRoutePathPattern(route: string, name: string): string | undefined {
+  return route.match(restRoutePathTokenPattern(name))?.[1]
+}
+
+function restRoutePathTokenPattern(name: string): RegExp {
+  return new RegExp(`\\(\\?P<${escapeRegExp(name)}>([^)]+)\\)`)
+}
+
+function restArgSample(arg: WordPressRestRouteArgDescriptor | undefined, pathPattern?: string): unknown {
+  if (arg?.enum?.length) {
+    return arg.enum[0]
+  }
+
+  const type = Array.isArray(arg?.type) ? arg?.type.find((candidate) => candidate !== "null") : arg?.type
+  if (type === "integer") {
+    return 1
+  }
+  if (type === "number") {
+    return 1
+  }
+  if (type === "boolean") {
+    return true
+  }
+  if (type === "array") {
+    return []
+  }
+  if (type === "object") {
+    return {}
+  }
+
+  if (arg?.format === "date-time") {
+    return "2000-01-01T00:00:00"
+  }
+  if (arg?.format === "date") {
+    return "2000-01-01"
+  }
+  if (arg?.format === "email") {
+    return "sample@example.com"
+  }
+
+  if (pathPattern && /\\d|\[0-9]|\[\\d]/.test(pathPattern)) {
+    return 1
+  }
+
+  return "sample"
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 function restRouteUntestedReason(safeMethod: boolean, requiredArgs: string[]): FuzzCoveragePlanReason {

--- a/packages/runtime-core/src/wordpress-runtime-discovery-contracts.ts
+++ b/packages/runtime-core/src/wordpress-runtime-discovery-contracts.ts
@@ -229,7 +229,16 @@ export interface WordPressBlockTypeDescriptor {
   title: string
   category: string
   supportsInserter: boolean
-  attributes: string[]
+  attributes: WordPressBlockAttributeDescriptor[]
+  exampleAttributes?: Record<string, unknown>
+}
+
+export interface WordPressBlockAttributeDescriptor {
+  name: string
+  type?: string | string[]
+  enum?: Array<string | number | boolean | null>
+  defaultPresent?: boolean
+  default?: unknown
 }
 
 export interface WordPressEditorPostTypeDescriptor {

--- a/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
+++ b/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
@@ -283,7 +283,33 @@ function runtime_discovery_blocks(): array {
     if (class_exists('WP_Block_Type_Registry')) {
         foreach (WP_Block_Type_Registry::get_instance()->get_all_registered() as $name => $block_type) {
             $supports = is_object($block_type) && is_array($block_type->supports ?? null) ? $block_type->supports : array();
-            $blocks[] = array('name' => (string) $name, 'title' => (string) ($block_type->title ?? ''), 'category' => (string) ($block_type->category ?? ''), 'supportsInserter' => !isset($supports['inserter']) || $supports['inserter'] !== false, 'attributes' => array_values(array_map('strval', array_keys((array) ($block_type->attributes ?? array())))));
+            $attributes = array();
+            foreach ((array) ($block_type->attributes ?? array()) as $attribute_name => $attribute_schema) {
+                $attribute_schema = is_array($attribute_schema) ? $attribute_schema : array();
+                $descriptor = array('name' => (string) $attribute_name);
+                if (isset($attribute_schema['type'])) {
+                    $descriptor['type'] = is_array($attribute_schema['type']) ? array_values(array_map('strval', $attribute_schema['type'])) : (string) $attribute_schema['type'];
+                }
+                if (isset($attribute_schema['enum']) && is_array($attribute_schema['enum'])) {
+                    $descriptor['enum'] = array_map('runtime_discovery_block_attribute_value', array_slice(array_values($attribute_schema['enum']), 0, 25));
+                }
+                if (array_key_exists('default', $attribute_schema)) {
+                    $descriptor['defaultPresent'] = true;
+                    $descriptor['default'] = runtime_discovery_block_attribute_value($attribute_schema['default']);
+                }
+                $attributes[] = $descriptor;
+            }
+
+            $example_attributes = null;
+            if (isset($block_type->example) && is_array($block_type->example) && isset($block_type->example['attributes']) && is_array($block_type->example['attributes'])) {
+                $example_attributes = $block_type->example['attributes'];
+            }
+
+            $descriptor = array('name' => (string) $name, 'title' => (string) ($block_type->title ?? ''), 'category' => (string) ($block_type->category ?? ''), 'supportsInserter' => !isset($supports['inserter']) || $supports['inserter'] !== false, 'attributes' => $attributes);
+            if ($example_attributes !== null) {
+                $descriptor['exampleAttributes'] = runtime_discovery_block_attribute_value($example_attributes);
+            }
+            $blocks[] = $descriptor;
         }
     }
 
@@ -294,6 +320,24 @@ function runtime_discovery_blocks(): array {
     }
 
     return array('payload' => array('schema' => 'wp-codebox/wordpress-block-editor-target-discovery/v1', 'blocks' => $blocks, 'editorPostTypes' => $post_types), 'diagnostics' => array());
+}
+
+function runtime_discovery_block_attribute_value($value, int $depth = 0) {
+    if (is_string($value)) {
+        return substr($value, 0, 200);
+    }
+    if (is_int($value) || is_float($value) || is_bool($value) || $value === null) {
+        return $value;
+    }
+    if (!is_array($value) || $depth >= 2) {
+        return null;
+    }
+
+    $bounded = array();
+    foreach (array_slice($value, 0, 20, true) as $key => $item) {
+        $bounded[$key] = runtime_discovery_block_attribute_value($item, $depth + 1);
+    }
+    return $bounded;
 }
 
 $runtime_discovery_result = array(

--- a/tests/wordpress-block-fuzz-suite.test.ts
+++ b/tests/wordpress-block-fuzz-suite.test.ts
@@ -5,8 +5,9 @@ import { wordpressBlockDiscoveryToCoveragePlan, wordpressBlockDiscoveryToFuzzSui
 const discovery: WordPressBlockEditorTargetDiscovery = {
   schema: "wp-codebox/wordpress-block-editor-target-discovery/v1",
   blocks: [
-    { name: "core/paragraph", title: "Paragraph", category: "text", supportsInserter: true, attributes: ["content", "dropCap"] },
-    { name: "core/template-part", title: "Template Part", category: "theme", supportsInserter: false, attributes: ["slug"] },
+    { name: "core/paragraph", title: "Paragraph", category: "text", supportsInserter: true, attributes: [{ name: "content", type: "string", defaultPresent: true, default: "Hello" }, { name: "dropCap", type: "boolean" }, { name: "align", type: "string", enum: ["wide", "full"] }] },
+    { name: "core/image", title: "Image", category: "media", supportsInserter: true, attributes: [{ name: "id", type: "integer" }, { name: "caption", type: "string" }, { name: "url" }], exampleAttributes: { url: "https://example.com/image.jpg" } },
+    { name: "core/template-part", title: "Template Part", category: "theme", supportsInserter: false, attributes: [{ name: "slug" }] },
   ],
   editorPostTypes: [
     { name: "page", label: "Pages", restBase: "pages", editorUrl: "https://example.com/wp-admin/post-new.php?post_type=page" },
@@ -19,15 +20,19 @@ const suite = wordpressBlockDiscoveryToFuzzSuite(discovery, { id: "blocks", edit
 assert.equal(suite.schema, "wp-codebox/fuzz-suite/v1")
 assert.equal(suite.id, "blocks")
 assert.deepEqual(suite.cases.map((fuzzCase) => fuzzCase.id), [
-  "block-core-paragraph-server-render-empty-attributes",
-  "block-core-paragraph-editor-insert-page-empty-attributes",
+  "block-core-paragraph-server-render-sample-attributes",
+  "block-core-paragraph-editor-insert-page-sample-attributes",
+  "block-core-image-server-render-sample-attributes",
+  "block-core-image-editor-insert-page-sample-attributes",
   "block-core-template-part-server-render-empty-attributes",
 ])
 assert.equal(suite.metadata?.sourceSchema, "wp-codebox/wordpress-block-editor-target-discovery/v1")
 assert.equal(suite.coveragePlan?.schema, "wp-codebox/fuzz-coverage-plan/v1")
 assert.deepEqual(suite.coveragePlan?.summary.caseIds, [
-  "block-core-paragraph-server-render-empty-attributes",
-  "block-core-paragraph-editor-insert-page-empty-attributes",
+  "block-core-paragraph-server-render-sample-attributes",
+  "block-core-paragraph-editor-insert-page-sample-attributes",
+  "block-core-image-server-render-sample-attributes",
+  "block-core-image-editor-insert-page-sample-attributes",
   "block-core-template-part-server-render-empty-attributes",
   "block-core-template-part-editor-insert-page-empty-attributes",
 ])
@@ -43,21 +48,25 @@ const renderCase = suite.cases[0]
 assert.deepEqual(renderCase?.target, { kind: "runtime", entrypoint: "wordpress.run-php" })
 assert.deepEqual((renderCase?.input as { args: string[] }).args[1], "bootstrap=wordpress")
 assert.match((renderCase?.input as { args: string[] }).args[0] ?? "", /render_block/)
-assert.deepEqual(renderCase?.metadata?.samples, { emptyAttributes: {} })
+assert.match((renderCase?.input as { args: string[] }).args[0] ?? "", /Hello/)
+assert.deepEqual(renderCase?.metadata?.samples, { attributes: { content: "Hello", dropCap: true, align: "wide" } })
 
 const editorCase = suite.cases[1]
 assert.deepEqual(editorCase?.target, { kind: "runtime", entrypoint: "wordpress.editor-actions" })
 assert.deepEqual((editorCase?.input as { args: string[] }).args, [
   "target=post-new",
   "post-type=page",
-  'steps-json=[{"kind":"insertBlock","name":"core/paragraph","attributes":{}},{"kind":"inspectState"}]',
+  'steps-json=[{"kind":"insertBlock","name":"core/paragraph","attributes":{"content":"Hello","dropCap":true,"align":"wide"}},{"kind":"inspectState"}]',
   "capture=editor-state,errors",
 ])
-assert.deepEqual(editorCase?.metadata?.samples, { emptyAttributes: {}, editorPostType: "page" })
+assert.deepEqual(editorCase?.metadata?.samples, { attributes: { content: "Hello", dropCap: true, align: "wide" }, editorPostType: "page" })
+
+assert.deepEqual(suite.cases[2]?.metadata?.samples, { attributes: { id: 1, caption: "sample", url: "https://example.com/image.jpg" } })
 
 const renderOnly = wordpressBlockDiscoveryToFuzzSuite(discovery, { includeEditorInsert: false })
 assert.deepEqual(renderOnly.cases.map((fuzzCase) => fuzzCase.id), [
-  "block-core-paragraph-server-render-empty-attributes",
+  "block-core-paragraph-server-render-sample-attributes",
+  "block-core-image-server-render-sample-attributes",
   "block-core-template-part-server-render-empty-attributes",
 ])
 assert.deepEqual(renderOnly.metadata?.requiredRunnerCapabilities, {
@@ -68,13 +77,14 @@ assert.deepEqual(renderOnly.metadata?.requiredRunnerCapabilities, {
 
 const noEditorTargets = wordpressBlockDiscoveryToFuzzSuite({ ...discovery, editorPostTypes: [] })
 assert.deepEqual(noEditorTargets.cases.map((fuzzCase) => fuzzCase.id), [
-  "block-core-paragraph-server-render-empty-attributes",
+  "block-core-paragraph-server-render-sample-attributes",
+  "block-core-image-server-render-sample-attributes",
   "block-core-template-part-server-render-empty-attributes",
 ])
 
 const coveragePlan = wordpressBlockDiscoveryToCoveragePlan(discovery, { id: "blocks", editorPostType: "page" })
 assert.equal(coveragePlan.schema, "wp-codebox/fuzz-coverage-plan/v1")
-assert.deepEqual({ discovered: coveragePlan.summary.discovered, generated: coveragePlan.summary.generated, executable: coveragePlan.summary.executable, executed: coveragePlan.summary.executed, skipped: coveragePlan.summary.skipped, untested: coveragePlan.summary.untested }, { discovered: 4, generated: 4, executable: 3, executed: 0, skipped: 0, untested: 1 })
+assert.deepEqual({ discovered: coveragePlan.summary.discovered, generated: coveragePlan.summary.generated, executable: coveragePlan.summary.executable, executed: coveragePlan.summary.executed, skipped: coveragePlan.summary.skipped, untested: coveragePlan.summary.untested }, { discovered: 6, generated: 6, executable: 5, executed: 0, skipped: 0, untested: 1 })
 assert.equal(coveragePlan.untested[0]?.reason?.code, "block_inserter_unsupported")
 assert.deepEqual(coveragePlan.untested[0]?.reason?.data?.unsupportedCapabilities, ["block:inserter"])
 assert.equal(coveragePlan.parameterGenerationHooks?.[0]?.id, "wordpress.block-attribute-samples")

--- a/tests/wordpress-fuzz-suite-builders.test.ts
+++ b/tests/wordpress-fuzz-suite-builders.test.ts
@@ -22,6 +22,7 @@ const restInventory: WordPressRestRouteInventory = {
   routes: [
     { route: "/wp/v2/posts", namespace: "wp/v2", methods: ["GET", "POST"], argNames: [], endpoints: [{ methods: ["GET", "POST"], permission: { mode: "public" }, args: [] }] },
     { route: "/wp/v2/posts/(?P<id>[\\d]+)", namespace: "wp/v2", methods: ["GET"], argNames: ["id"], endpoints: [{ methods: ["GET"], permission: { mode: "callback", callbackType: "method" }, args: [{ name: "id", required: true, type: "integer" }] }] },
+    { route: "/demo/v1/search", namespace: "demo/v1", methods: ["GET"], argNames: ["kind"], endpoints: [{ methods: ["GET"], permission: { mode: "public" }, args: [{ name: "kind", required: true, type: "string", enum: ["post", "page"] }] }] },
   ],
   namespaces: ["wp/v2"],
   diagnostics: [],
@@ -32,25 +33,28 @@ assert.equal(restSuite.schema, "wp-codebox/fuzz-suite/v1")
 assert.equal(restSuite.metadata?.sourceSchema, WORDPRESS_REST_ROUTE_INVENTORY_SCHEMA)
 assert.deepEqual(restSuite.metadata?.requiredRunnerCapabilities, { capabilities: ["target:rest"], targetKinds: ["rest"] })
 assert.equal(restSuite.coveragePlan?.schema, "wp-codebox/fuzz-coverage-plan/v1")
-assert.deepEqual(restSuite.coveragePlan?.summary.caseIds, ["rest-get-wp-v2-posts-0", "rest-post-wp-v2-posts-0", "rest-get-wp-v2-posts-p-id-d-0"])
-assert.equal(restSuite.cases.length, 3)
+assert.deepEqual(restSuite.coveragePlan?.summary.caseIds, ["rest-get-wp-v2-posts-0", "rest-post-wp-v2-posts-0", "rest-get-wp-v2-posts-p-id-d-0", "rest-get-demo-v1-search-0"])
+assert.equal(restSuite.cases.length, 4)
 assert.equal(restSuite.cases[0]?.target?.kind, "rest")
 assert.deepEqual(restSuite.cases[0]?.input, { method: "GET", path: "/wp/v2/posts", session: "admin" })
 assert.equal((restSuite.cases[0]?.metadata?.safety as Record<string, unknown>).executable, true)
 assert.equal(restSuite.cases[1]?.target?.kind, "rest-planned")
 assert.equal((restSuite.cases[1]?.metadata?.safety as Record<string, unknown>).reason, "mutating_rest_method_requires_explicit_opt_in")
-assert.equal(restSuite.cases[2]?.target?.kind, "rest-planned")
-assert.deepEqual((restSuite.cases[2]?.metadata?.safety as Record<string, unknown>).requiredArgs, ["id"])
+assert.equal(restSuite.cases[2]?.target?.kind, "rest")
+assert.deepEqual(restSuite.cases[2]?.input, { method: "GET", path: "/wp/v2/posts/1", session: "admin" })
+assert.deepEqual((restSuite.cases[2]?.metadata?.safety as Record<string, unknown>).generatedParameters, { path: { id: 1 } })
+assert.equal(restSuite.cases[3]?.target?.kind, "rest")
+assert.deepEqual(restSuite.cases[3]?.input, { method: "GET", path: "/demo/v1/search", params: { kind: "post" }, session: "admin" })
 
 const restCoveragePlan = restRouteInventoryToCoveragePlan(restInventory, { session: "admin" })
 assert.equal(restCoveragePlan.schema, "wp-codebox/fuzz-coverage-plan/v1")
-assert.deepEqual({ discovered: restCoveragePlan.summary.discovered, generated: restCoveragePlan.summary.generated, executable: restCoveragePlan.summary.executable, executed: restCoveragePlan.summary.executed, skipped: restCoveragePlan.summary.skipped, untested: restCoveragePlan.summary.untested }, { discovered: 3, generated: 3, executable: 1, executed: 0, skipped: 0, untested: 2 })
+assert.deepEqual({ discovered: restCoveragePlan.summary.discovered, generated: restCoveragePlan.summary.generated, executable: restCoveragePlan.summary.executable, executed: restCoveragePlan.summary.executed, skipped: restCoveragePlan.summary.skipped, untested: restCoveragePlan.summary.untested }, { discovered: 4, generated: 4, executable: 3, executed: 0, skipped: 0, untested: 1 })
 assert.deepEqual(restCoveragePlan.summary.targetIds, ["wordpress.rest-request"])
 assert.deepEqual(restCoveragePlan.executable[0]?.input, { method: "GET", path: "/wp/v2/posts", session: "admin" })
+assert.deepEqual(restCoveragePlan.executable[1]?.input, { method: "GET", path: "/wp/v2/posts/1", session: "admin" })
+assert.deepEqual(restCoveragePlan.executable[2]?.input, { method: "GET", path: "/demo/v1/search", params: { kind: "post" }, session: "admin" })
 assert.equal(restCoveragePlan.untested[0]?.reason?.code, "mutating_rest_method_requires_explicit_opt_in")
 assert.equal(restCoveragePlan.untested[0]?.parameterGeneration?.hook, "wordpress.rest-mutating-route-opt-in")
-assert.equal(restCoveragePlan.untested[1]?.reason?.code, "route_requires_discovered_parameters")
-assert.deepEqual(restCoveragePlan.untested[1]?.parameterGeneration?.requiredInputs, ["id"])
 assert.equal(restCoveragePlan.parameterGenerationHooks?.length, 2)
 
 const adminInventory: WordPressAdminPageInventory = {

--- a/tests/wordpress-runtime-discovery-contracts.test.ts
+++ b/tests/wordpress-runtime-discovery-contracts.test.ts
@@ -295,4 +295,37 @@ const importPage = adminDiscovered.admin?.pages.find((page) => page.menuSlug ===
 assert.equal(importPage?.canonicalUrl, "https://example.com/wp-admin/tools.php?page=demo-import")
 assert.equal(importPage?.canAccess, false)
 
+const blockDiscoveryPhp = runtimeDiscoveryPhpCode(["blocks"]).replace(/^<\?php\n/, "")
+const blocksDiscovered = await runPhpJson<WordPressRuntimeDiscoveryResult>(`
+function wp_json_encode( $data, $flags = 0 ) { return json_encode( $data, $flags ); }
+function admin_url( $path = '' ) { return 'https://example.com/wp-admin/' . ltrim( $path, '/' ); }
+function get_post_types( $args, $output ) {
+    return array( 'post' => (object) array( 'label' => 'Posts', 'rest_base' => 'posts' ) );
+}
+class WP_Block_Type_Registry {
+    public static function get_instance() { return new self(); }
+    public function get_all_registered() {
+        return array(
+            'demo/card' => (object) array(
+                'title' => 'Card',
+                'category' => 'widgets',
+                'supports' => array( 'inserter' => true ),
+                'attributes' => array(
+                    'title' => array( 'type' => 'string', 'default' => 'Hello' ),
+                    'tone' => array( 'type' => 'string', 'enum' => array( 'light', 'dark' ) ),
+                ),
+                'example' => array( 'attributes' => array( 'title' => 'Example title' ) ),
+            ),
+        );
+    }
+}
+${blockDiscoveryPhp}
+`)
+
+const block = blocksDiscovered.blocks?.blocks[0]
+assert.equal(block?.name, "demo/card")
+assert.deepEqual(block?.attributes[0], { name: "title", type: "string", defaultPresent: true, default: "Hello" })
+assert.deepEqual(block?.attributes[1], { name: "tone", type: "string", enum: ["light", "dark"] })
+assert.deepEqual(block?.exampleAttributes, { title: "Example title" })
+
 console.log("wordpress runtime discovery contracts ok")


### PR DESCRIPTION
## Summary
- generate concrete executable REST cases for safe routes with required path/query params
- keep mutating REST methods planned until an explicit fixture policy exists
- expose bounded block attribute descriptors during discovery and use conservative samples in block render/editor fuzz cases

## Tests
- `npm run test:wordpress-fuzz-suite-builders`
- `npm run test:fuzz-suite-runner`
- `node ./node_modules/typescript/bin/tsc -b packages/runtime-core`
- `npm run test:wordpress-block-fuzz-suite`
- `npm run test:wordpress-runtime-discovery-contracts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementing generic REST parameter and block attribute sample generation, updating discovery contracts/docs/tests, and running focused verification.
