### PR TITLE
Fix browser local package target folders

### DIFF
--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -493,12 +493,13 @@ private static function browser_runtime_plugin_specs( array $plugins ): array|WP
 			$resolved[] = array_merge(
 				$plugin,
 				array(
-					'slug'          => $slug,
-					'url'           => $package['url'],
+					'slug'                    => $slug,
+					'url'                     => $package['url'],
 					'local_package_fetch_url' => $package['fetch_url'],
-					'sha256'        => $package['sha256'],
-					'local_package' => true,
-					'provenance'    => array(
+					'targetFolderName'        => self::safe_key( (string) ( $plugin['targetFolderName'] ?? $slug ) ),
+					'sha256'                  => $package['sha256'],
+					'local_package'           => true,
+					'provenance'              => array(
 						'schema' => 'wp-codebox/browser-plugin-provenance/v1',
 						'source' => 'runtime-plugin-remote-package',
 						'url'    => (string) ( $plugin['url'] ?? '' ),
@@ -533,6 +534,7 @@ private static function browser_runtime_plugin_specs( array $plugins ): array|WP
 				'slug'                    => $slug,
 				'url'                     => $package['url'],
 				'local_package_fetch_url' => $package['fetch_url'],
+				'targetFolderName'        => self::safe_key( (string) ( $plugin['targetFolderName'] ?? $slug ) ),
 				'sha256'                  => $package['sha256'],
 				'local_package'           => true,
 				'provenance'              => array(
@@ -588,6 +590,7 @@ private static function browser_component_plugins( array $input, array $declared
 				'activate'                => (bool) ( $contract['activate'] ?? true ),
 				'local_package'           => true,
 				'local_package_fetch_url' => $package['fetch_url'],
+				'targetFolderName'        => $slug,
 				'sha256'                  => $package['sha256'],
 				'provenance'              => array(
 					'schema' => 'wp-codebox/browser-component-plugin-provenance/v1',
@@ -613,6 +616,7 @@ private static function browser_component_plugins( array $input, array $declared
 			$component['url']                     = $package['url'];
 			$component['local_package']           = true;
 			$component['local_package_fetch_url'] = $package['fetch_url'];
+			$component['targetFolderName']        = self::safe_key( (string) ( $component['targetFolderName'] ?? $slug ) );
 			$component['sha256']                  = $package['sha256'];
 		}
 
@@ -1168,7 +1172,7 @@ private static function normalize_browser_plugins( array $plugins, string $field
 			'ref'              => sanitize_text_field( (string) ( $plugin['ref'] ?? '' ) ),
 			'refType'          => sanitize_key( (string) ( $plugin['refType'] ?? '' ) ),
 			'path'             => 'git:directory' === $resource ? ltrim( str_replace( '\\', '/', (string) ( $plugin['path'] ?? '' ) ), '/' ) : '',
-			'targetFolderName' => sanitize_key( (string) ( $plugin['targetFolderName'] ?? '' ) ),
+			'targetFolderName' => sanitize_key( (string) ( $plugin['targetFolderName'] ?? ( ! empty( $plugin['local_package'] ) ? $slug : '' ) ) ),
 			'provenance'       => array_filter(
 				array(
 					'schema' => 'wp-codebox/browser-plugin-provenance/v1',

--- a/scripts/php-browser-contained-site-contract-smoke.php
+++ b/scripts/php-browser-contained-site-contract-smoke.php
@@ -225,6 +225,7 @@ $local_package_install_plugin_steps = array_values( array_filter( $local_package
 expect( 1 === count( $local_package_run_php_steps ), 'Expected local package data URL to use a runPHP installer step.' );
 expect( 0 === count( $local_package_install_plugin_steps ), 'Expected local package data URL to avoid installPlugin.' );
 expect( str_contains( (string) ( $local_package_run_php_steps[0]['code'] ?? '' ), 'activate_plugin' ), 'Expected local package runPHP installer to activate the plugin.' );
+expect( str_contains( (string) ( $local_package_run_php_steps[0]['code'] ?? '' ), '$target_folder = \'runtime-smoke\'' ), 'Expected local package runPHP installer to scan the plugin slug folder.' );
 
 $function_recipe = $recipe_method->invoke(
 	null,


### PR DESCRIPTION
## Summary
- Preserve `targetFolderName` for packaged local runtime plugins and component plugins.
- Fall back local packaged plugin target folders to the sanitized plugin slug during normalization.
- Cover the generated installer target folder in the contained-site smoke test.

## Verification
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php`
- `npm run test:php-browser-contained-site-contract`
- `npm run test:php-browser-runtime-local-package`
- Built the WordPress plugin zip with `npm run package:wordpress-plugin`, installed it on the local `wordpress-importer-test` Studio site, regenerated the Static Site Importer Figma preview blueprint, confirmed the installer uses `$target_folder = 'static-site-importer'`, and ran the full blueprint successfully with `npx --yes @wp-playground/cli run-blueprint`.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 via OpenCode\n- **Used for:** Diagnosing the Playground blueprint failure, implementing the target folder propagation fix, adding smoke coverage, and running verification.