### PR TITLE
Add public API WP-CLI runtime wrappers

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -116,6 +116,13 @@ WordPress consumers should prefer `WP_Codebox_API` for PHP calls and
 backend systems internally, while public docs and schemas present Codebox-owned
 ability names, schemas, and facades to callers.
 
+WordPress-hosted orchestration that shells through WP-CLI can use the matching
+`wp codebox ...` wrappers for these public operations, including
+`run-runtime-task`, `run-wordpress-workload`, `run-runtime-package`,
+`resolve-runtime-requirements`, and `run-fuzz-suite`. The WP-CLI wrappers parse
+JSON payloads from `--input-json` or `--input-file` and delegate through
+`WP_Codebox_API` rather than backend internals.
+
 The workspace package mirrors the core entrypoints as `./core`,
 `./core/public`, `./core/contracts`, `./core/artifacts`, `./core/run-results`,
 `./core/php-snippets`, `./recipe-builders`, `./run-results`, `./agent-task-recipe`,

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "test:php-run-plan-contract": "php scripts/php-run-plan-contract-smoke.php",
     "test:php-fanout-aggregation-contract": "php scripts/php-fanout-aggregation-contract-smoke.php",
     "test:php-agents-api-execution-targets": "php scripts/php-agents-api-execution-targets-smoke.php",
+    "test:php-cli-command": "php scripts/php-cli-command-smoke.php",
     "test:php-patch-approval-filter": "php scripts/php-patch-approval-filter-smoke.php",
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -274,6 +274,13 @@ by Abilities:
 - `wp codebox artifacts apply <artifact_id> --approved-files='/path.php' --format=json`
 - `wp codebox browser-session create --goal='Prepare a browser sandbox' --format=json`
 - `wp codebox run-agent-task --goal='Fix the plugin bug' --format=json`
+- `wp codebox run-agent-task-batch --input-file=/path/to/batch.json --format=json`
+- `wp codebox run-agent-task-fanout --input-file=/path/to/fanout.json --format=json`
+- `wp codebox run-runtime-task --input-json='{"goal":"Run the caller-owned runtime task"}' --format=json`
+- `wp codebox run-wordpress-workload --input-file=/path/to/workload.json --format=json`
+- `wp codebox run-runtime-package --input-file=/path/to/runtime-package.json --format=json`
+- `wp codebox resolve-runtime-requirements --runtime='{"provider":"local"}' --format=json`
+- `wp codebox run-fuzz-suite --input-file=/path/to/fuzz-suite.json --format=json`
 
 Complex task payloads can be passed with `--input-json='{"goal":"..."}'` or
 `--input-file=/path/to/input.json`; command-line flags override fields from the
@@ -285,6 +292,12 @@ permission callbacks; shell/WP-CLI access is the permission boundary. The comman
 methods delegate to the same PHP services as Abilities, so validation, artifact
 digest checks, pending-action staging, apply adapters, and runner errors behave
 the same way.
+
+The `run-fuzz-suite` wrapper exposes the same public fuzz-suite contract as
+`WP_Codebox_API::run_fuzz_suite()`. Its WordPress-plugin execution path reports
+PHP in-process runner capabilities and returns structured skips or errors for
+coverage that requires a runtime-backed runner instead of presenting limited
+in-process execution as full product fuzzing.
 
 See [External Apply Adapter Contract](../../docs/external-apply-adapter-contract.md)
 for the parent-control-plane contract. The documented smoke fixture proves that

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -20,7 +20,13 @@ final class WP_Codebox_CLI_Command {
 		\WP_CLI::add_command( 'codebox artifacts apply', array( $command, 'artifacts_apply' ) );
 		\WP_CLI::add_command( 'codebox browser-session create', array( $command, 'browser_session_create' ) );
 		\WP_CLI::add_command( 'codebox run-agent-task', array( $command, 'run_agent_task' ) );
+		\WP_CLI::add_command( 'codebox run-agent-task-batch', array( $command, 'run_agent_task_batch' ) );
 		\WP_CLI::add_command( 'codebox run-agent-task-fanout', array( $command, 'run_agent_task_fanout' ) );
+		\WP_CLI::add_command( 'codebox run-runtime-task', array( $command, 'run_runtime_task' ) );
+		\WP_CLI::add_command( 'codebox run-wordpress-workload', array( $command, 'run_wordpress_workload' ) );
+		\WP_CLI::add_command( 'codebox run-runtime-package', array( $command, 'run_runtime_package' ) );
+		\WP_CLI::add_command( 'codebox resolve-runtime-requirements', array( $command, 'resolve_runtime_requirements' ) );
+		\WP_CLI::add_command( 'codebox run-fuzz-suite', array( $command, 'run_fuzz_suite' ) );
 	}
 
 	/**
@@ -31,7 +37,7 @@ final class WP_Codebox_CLI_Command {
 	 */
 	public function artifacts_list( array $args, array $assoc_args ): void {
 		unset( $args );
-		$this->emit( WP_Codebox_Abilities::list_artifacts( $this->input_from_args( $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::list_artifacts( $this->input_from_args( $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -41,7 +47,7 @@ final class WP_Codebox_CLI_Command {
 	 * @param array<string,mixed> $assoc_args Associated arguments.
 	 */
 	public function artifacts_get( array $args, array $assoc_args ): void {
-		$this->emit( WP_Codebox_Abilities::get_artifact( $this->artifact_input( $args, $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::get_artifact( $this->artifact_input( $args, $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -51,7 +57,7 @@ final class WP_Codebox_CLI_Command {
 	 * @param array<string,mixed> $assoc_args Associated arguments.
 	 */
 	public function artifacts_preflight_apply( array $args, array $assoc_args ): void {
-		$this->emit( WP_Codebox_Abilities::apply_artifact_preflight( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::preflight_artifact_apply( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -61,7 +67,7 @@ final class WP_Codebox_CLI_Command {
 	 * @param array<string,mixed> $assoc_args Associated arguments.
 	 */
 	public function artifacts_stage_apply( array $args, array $assoc_args ): void {
-		$this->emit( WP_Codebox_Abilities::stage_artifact_apply( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::stage_artifact_apply( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -71,7 +77,7 @@ final class WP_Codebox_CLI_Command {
 	 * @param array<string,mixed> $assoc_args Associated arguments.
 	 */
 	public function artifacts_apply( array $args, array $assoc_args ): void {
-		$this->emit( WP_Codebox_Abilities::apply_approved_artifact( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::apply_approved_artifact( $this->apply_input( $args, $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -82,7 +88,7 @@ final class WP_Codebox_CLI_Command {
 	 */
 	public function browser_session_create( array $args, array $assoc_args ): void {
 		unset( $args );
-		$this->emit( WP_Codebox_Abilities::create_browser_playground_session( $this->input_from_args( $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::create_browser_session( $this->input_from_args( $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -93,7 +99,18 @@ final class WP_Codebox_CLI_Command {
 	 */
 	public function run_agent_task( array $args, array $assoc_args ): void {
 		unset( $args );
-		$this->emit( ( new WP_Codebox_Agent_Runtime_Invoker() )->invoke_host_task( $this->input_from_args( $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::run_agent_task( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Run multiple bounded tasks sequentially through the public API facade.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function run_agent_task_batch( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_API::run_agent_task_batch( $this->input_from_args( $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -104,7 +121,62 @@ final class WP_Codebox_CLI_Command {
 	 */
 	public function run_agent_task_fanout( array $args, array $assoc_args ): void {
 		unset( $args );
-		$this->emit( ( new WP_Codebox_Agent_Runtime_Invoker() )->invoke_host_fanout( $this->input_from_args( $assoc_args ) ), $assoc_args );
+		$this->emit( WP_Codebox_API::run_agent_task_fanout( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Run a public runtime task through the public API facade.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function run_runtime_task( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_API::run_runtime_task( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Run a safe WordPress workload through the public API facade.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function run_wordpress_workload( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_API::run_wordpress_workload( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Run a runtime package through the public API facade.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function run_runtime_package( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_API::run_runtime_package( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Resolve runtime/provider readiness through the public API facade.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function resolve_runtime_requirements( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_API::resolve_runtime_requirements( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Run a public fuzz suite through the public API facade.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function run_fuzz_suite( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_API::run_fuzz_suite( $this->input_from_args( $assoc_args ) ), $assoc_args );
 	}
 
 	/**
@@ -161,11 +233,11 @@ final class WP_Codebox_CLI_Command {
 	}
 
 	private function normalize_value( string $field, mixed $value ): mixed {
-		if ( in_array( $field, array( 'target', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'policy', 'context', 'inherit', 'orchestrator', 'parent_request', 'runtime_task', 'runtime_env', 'playground', 'browser_runner', 'runtime', 'blueprint', 'apply_target', 'aggregation' ), true ) ) {
+		if ( in_array( $field, array( 'target', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'policy', 'context', 'inherit', 'orchestrator', 'parent_request', 'runtime_task', 'runtime_env', 'playground', 'browser_runner', 'runtime', 'blueprint', 'apply_target', 'aggregation', 'suite', 'package', 'requirements', 'runner_capabilities', 'metadata' ), true ) ) {
 			return $this->json_object( (string) $value, $field );
 		}
 
-		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'agent_bundles', 'provider_plugin_paths', 'secret_env', 'mounts', 'workspaces', 'runtime_stack_mounts', 'runtime_state_mounts', 'runtime_config_mounts', 'runtime_overlays', 'browser_plugins', 'artifact_files', 'approved_files', 'workers', 'dependencies' ), true ) ) {
+		if ( in_array( $field, array( 'allowed_tools', 'expected_artifacts', 'agent_bundles', 'provider_plugin_paths', 'secret_env', 'mounts', 'workspaces', 'runtime_stack_mounts', 'runtime_state_mounts', 'runtime_config_mounts', 'runtime_overlays', 'browser_plugins', 'artifact_files', 'approved_files', 'workers', 'dependencies', 'tasks', 'cases', 'coverage', 'capabilities' ), true ) ) {
 			return $this->json_or_list( (string) $value, $field );
 		}
 

--- a/scripts/php-cli-command-smoke.php
+++ b/scripts/php-cli-command-smoke.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	public function __construct( private string $code = '', private string $message = '', private mixed $data = null ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	public function get_error_data(): mixed { return $this->data; }
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+function wp_json_encode( mixed $value, int $flags = 0 ): string|false {
+	return json_encode( $value, $flags );
+}
+
+final class WP_CLI {
+	/** @var array<string,callable> */
+	public static array $commands = array();
+	/** @var string[] */
+	public static array $lines = array();
+
+	public static function add_command( string $name, callable $callable ): void {
+		self::$commands[ $name ] = $callable;
+	}
+
+	public static function line( string $message ): void {
+		self::$lines[] = $message;
+	}
+
+	public static function warning( string $message ): void {
+		self::$lines[] = 'warning: ' . $message;
+	}
+
+	public static function error( string $message ): void {
+		throw new RuntimeException( $message );
+	}
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-json.php';
+
+final class WP_Codebox_Abilities {
+	/** @var array<int,array{method:string,input:array<string,mixed>}> */
+	public static array $calls = array();
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function list_artifacts( array $input ): array { return self::record( 'list_artifacts', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function get_artifact( array $input ): array { return self::record( 'get_artifact', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function apply_artifact_preflight( array $input ): array { return self::record( 'apply_artifact_preflight', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function stage_artifact_apply( array $input ): array { return self::record( 'stage_artifact_apply', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function apply_approved_artifact( array $input ): array { return self::record( 'apply_approved_artifact', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function create_browser_playground_session( array $input ): array { return self::record( 'create_browser_playground_session', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_agent_task( array $input ): array { return self::record( 'run_agent_task', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_agent_task_batch( array $input ): array { return self::record( 'run_agent_task_batch', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_agent_task_fanout( array $input ): array { return self::record( 'run_agent_task_fanout', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_runtime_task( array $input ): array { return self::record( 'run_runtime_task', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_wordpress_workload( array $input ): array { return self::record( 'run_wordpress_workload', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_runtime_package( array $input ): array { return self::record( 'run_runtime_package', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function resolve_runtime_requirements( array $input ): array { return self::record( 'resolve_runtime_requirements', $input ); }
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	public static function run_fuzz_suite( array $input ): array { return self::record( 'run_fuzz_suite', $input ); }
+
+	/** @param array<string,mixed> $input @return array<string,mixed> */
+	private static function record( string $method, array $input ): array {
+		self::$calls[] = array( 'method' => $method, 'input' => $input );
+		return array( 'success' => true, 'method' => $method, 'input' => $input );
+	}
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-api.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-cli-command.php';
+
+function expect( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+WP_Codebox_CLI_Command::register();
+
+$expected_commands = array(
+	'codebox artifacts list',
+	'codebox artifacts get',
+	'codebox artifacts preflight-apply',
+	'codebox artifacts stage-apply',
+	'codebox artifacts apply',
+	'codebox browser-session create',
+	'codebox run-agent-task',
+	'codebox run-agent-task-batch',
+	'codebox run-agent-task-fanout',
+	'codebox run-runtime-task',
+	'codebox run-wordpress-workload',
+	'codebox run-runtime-package',
+	'codebox resolve-runtime-requirements',
+	'codebox run-fuzz-suite',
+);
+
+foreach ( $expected_commands as $command ) {
+	expect( isset( WP_CLI::$commands[ $command ] ), 'Missing WP-CLI command: ' . $command );
+}
+
+function run_cli_command( string $command, array $args = array(), array $assoc_args = array() ): array {
+	WP_CLI::$lines = array();
+	WP_Codebox_Abilities::$calls = array();
+
+	WP_CLI::$commands[ $command ]( $args, $assoc_args );
+
+	$output = json_decode( WP_CLI::$lines[0] ?? '', true );
+	expect( is_array( $output ), 'Expected JSON output for ' . $command );
+	expect( 1 === count( WP_Codebox_Abilities::$calls ), 'Expected one public API dispatch for ' . $command );
+
+	return array( 'output' => $output, 'call' => WP_Codebox_Abilities::$calls[0] );
+}
+
+$runtime_package = run_cli_command( 'codebox run-runtime-package', array(), array( 'input-json' => '{"goal":"package"}', 'package' => '{"schema":"wp-codebox/runtime-package/v1"}' ) );
+expect( 'run_runtime_package' === $runtime_package['call']['method'], 'Runtime package command must dispatch through public API.' );
+expect( 'package' === $runtime_package['call']['input']['goal'], 'input-json payload should be preserved.' );
+expect( 'wp-codebox/runtime-package/v1' === $runtime_package['call']['input']['package']['schema'], 'package flag should decode as JSON object.' );
+
+$fuzz_suite = run_cli_command( 'codebox run-fuzz-suite', array(), array( 'suite' => '{"id":"php-in-process-suite"}', 'cases' => '[{"id":"rest-status"}]' ) );
+expect( 'run_fuzz_suite' === $fuzz_suite['call']['method'], 'Fuzz suite command must dispatch through public API.' );
+expect( 'php-in-process-suite' === $fuzz_suite['call']['input']['suite']['id'], 'suite flag should decode as JSON object.' );
+expect( 'rest-status' === $fuzz_suite['call']['input']['cases'][0]['id'], 'cases flag should decode as JSON array.' );
+
+$requirements = run_cli_command( 'codebox resolve-runtime-requirements', array(), array( 'runtime' => '{"provider":"local"}', 'capabilities' => 'php-in-process,rest' ) );
+expect( 'resolve_runtime_requirements' === $requirements['call']['method'], 'Requirements command must dispatch through public API.' );
+expect( array( 'php-in-process', 'rest' ) === $requirements['call']['input']['capabilities'], 'capabilities flag should parse as a list.' );
+
+$agent_task = run_cli_command( 'codebox run-agent-task', array(), array( 'goal' => 'public facade task' ) );
+expect( 'run_agent_task' === $agent_task['call']['method'], 'Agent task command must dispatch through public API.' );
+
+fwrite( STDOUT, "PHP CLI command smoke passed\n" );


### PR DESCRIPTION
## Summary
- Add public WP-CLI wrappers for runtime task, workload, package, requirement resolution, fuzz suite, batch, and fanout entrypoints.
- Route WP-CLI wrappers through `WP_Codebox_API` instead of backend internals.
- Document wrapper usage and add a PHP CLI command smoke test.

## Testing
- Inspected `git status`, `git diff`, `git log --oneline -10`, remote tracking, and `origin/main...HEAD` diff before push.
- `git diff --check`

## Notes
- Known current-main drift: `wordpress-plugin-public-runtime-abilities` is present in `package.json` on the compared base/current main context and is not changed by this branch beyond the nearby script insertion.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Branch inspection, PR creation, and verification summary.