### PR TITLE
Document runtime provider CLI selection

### DIFF
--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -279,7 +279,7 @@ by Abilities:
 - `wp codebox run-runtime-task --input-json='{"goal":"Run the caller-owned runtime task"}' --format=json`
 - `wp codebox run-wordpress-workload --input-file=/path/to/workload.json --format=json`
 - `wp codebox run-runtime-package --input-file=/path/to/runtime-package.json --format=json`
-- `wp codebox resolve-runtime-requirements --runtime='{"provider":"local"}' --format=json`
+- `wp codebox resolve-runtime-requirements --runtime-provider=local --format=json`
 - `wp codebox run-fuzz-suite --input-file=/path/to/fuzz-suite.json --format=json`
 
 Complex task payloads can be passed with `--input-json='{"goal":"..."}'` or

--- a/scripts/php-cli-command-smoke.php
+++ b/scripts/php-cli-command-smoke.php
@@ -139,8 +139,9 @@ expect( 'run_fuzz_suite' === $fuzz_suite['call']['method'], 'Fuzz suite command 
 expect( 'php-in-process-suite' === $fuzz_suite['call']['input']['suite']['id'], 'suite flag should decode as JSON object.' );
 expect( 'rest-status' === $fuzz_suite['call']['input']['cases'][0]['id'], 'cases flag should decode as JSON array.' );
 
-$requirements = run_cli_command( 'codebox resolve-runtime-requirements', array(), array( 'runtime' => '{"provider":"local"}', 'capabilities' => 'php-in-process,rest' ) );
+$requirements = run_cli_command( 'codebox resolve-runtime-requirements', array(), array( 'runtime-provider' => 'local', 'capabilities' => 'php-in-process,rest' ) );
 expect( 'resolve_runtime_requirements' === $requirements['call']['method'], 'Requirements command must dispatch through public API.' );
+expect( 'local' === $requirements['call']['input']['runtime_provider'], 'runtime-provider flag should select the runtime provider.' );
 expect( array( 'php-in-process', 'rest' ) === $requirements['call']['input']['capabilities'], 'capabilities flag should parse as a list.' );
 
 $agent_task = run_cli_command( 'codebox run-agent-task', array(), array( 'goal' => 'public facade task' ) );


### PR DESCRIPTION
## Summary
- Document `--runtime-provider=local` for `wp codebox resolve-runtime-requirements`.
- Assert the CLI parser forwards `runtime_provider` for provider selection.

## Tests
- `npm run test:php-cli-command`
- `npm run test:php-runtime-provider-registry`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the focused documentation/test fix and running verification.