### PR TITLE
Preserve prepared runtime profiles

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -465,6 +465,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'runtime_overlays'     => self::object_list( $profile['runtime_overlays'] ?? array() ),
 				'runtime_state_mounts' => self::object_list( $profile['runtime_state_mounts'] ?? array() ),
 				'runtime_config_mounts' => self::object_list( $profile['runtime_config_mounts'] ?? array() ),
+				'prepared'     => is_array( $profile['prepared'] ?? null ) ? self::compact_public_value( $profile['prepared'] ) : array(),
 				'bootstrap'    => is_array( $profile['bootstrap'] ?? null ) ? $profile['bootstrap'] : array(),
 				'env'          => is_array( $profile['env'] ?? null ) ? self::string_map( $profile['env'] ) : array(),
 				'readiness'    => is_array( $profile['readiness'] ?? null ) ? self::compact_public_value( $profile['readiness'] ) : array(),
@@ -505,6 +506,12 @@ final class WP_Codebox_Browser_Task_Builder {
 				$runtime_items = is_array( $runtime[ $field ] ?? null ) ? $runtime[ $field ] : array();
 				$runtime[ $field ] = empty( $runtime['resolved_profile'] ) ? self::merge_lists( $profile_items, $runtime_items ) : self::merge_lists( $runtime_items, $profile_items );
 			}
+		}
+		if ( is_array( $profile['prepared'] ?? null ) && ! empty( $profile['prepared'] ) ) {
+			$runtime['prepared'] = array_merge(
+				$profile['prepared'],
+				is_array( $runtime['prepared'] ?? null ) ? $runtime['prepared'] : array()
+			);
 		}
 
 		$input['runtime']             = $runtime;


### PR DESCRIPTION
## Summary
- Preserve the prepared runtime contract when normalizing runtime profiles.
- Propagate prepared profile options into browser runtime input so downstream callers can opt into prepared runtime refs.

## Testing
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, patch drafting, and verification command selection.