### PR TITLE
Add artifact postprocess workload step

### DIFF
--- a/packages/runtime-core/src/benchmark-contracts.ts
+++ b/packages/runtime-core/src/benchmark-contracts.ts
@@ -105,7 +105,7 @@ export interface BenchResults {
 }
 
 export interface BenchmarkDefinitionWorkloadStep {
-  type: "php" | "wp-cli" | "rest-request" | "rest-db-query-profiler" | "db-inventory" | "external-http-guardrail" | "ability" | (string & {})
+  type: "php" | "wp-cli" | "rest-request" | "rest-db-query-profiler" | "db-inventory" | "external-http-guardrail" | "artifact-postprocess" | "ability" | (string & {})
   action?: "install" | "collect" | "reset" | (string & {})
   code?: string
   file?: string
@@ -117,6 +117,27 @@ export interface BenchmarkDefinitionWorkloadStep {
   blockResponse?: { code?: number; message?: string; body?: string }
   sampleLimit?: number
   queryLengthLimit?: number
+  helper?: string
+  helperPath?: string
+  script?: string
+  scriptPath?: string
+  args?: string[]
+  env?: Record<string, unknown>
+  inputArtifactRoot?: string
+  "input-artifact-root"?: string
+  artifactRoot?: string
+  "artifact-root"?: string
+  outputArtifactPath?: string
+  "output-artifact-path"?: string
+  maxInputBytes?: number
+  "max-input-bytes"?: number
+  maxArtifacts?: number
+  "max-artifacts"?: number
+  expectedOutputSchema?: string
+  "expected-output-schema"?: string
+  artifactName?: string
+  artifactKind?: string
+  semantic?: string
   metadata?: Record<string, unknown>
   [key: string]: unknown
 }
@@ -439,6 +460,27 @@ function benchmarkSchemaDefs(): Record<string, unknown> {
         },
         sampleLimit: { type: "integer", minimum: 0 },
         queryLengthLimit: { type: "integer", minimum: 80 },
+        helper: { type: "string", minLength: 1 },
+        helperPath: { type: "string", minLength: 1 },
+        script: { type: "string", minLength: 1 },
+        scriptPath: { type: "string", minLength: 1 },
+        args: { type: "array", items: { type: "string" } },
+        env: { type: "object", additionalProperties: true },
+        inputArtifactRoot: { type: "string", minLength: 1 },
+        "input-artifact-root": { type: "string", minLength: 1 },
+        artifactRoot: { type: "string", minLength: 1 },
+        "artifact-root": { type: "string", minLength: 1 },
+        outputArtifactPath: { type: "string", minLength: 1 },
+        "output-artifact-path": { type: "string", minLength: 1 },
+        maxInputBytes: { type: "integer", minimum: 0 },
+        "max-input-bytes": { type: "integer", minimum: 0 },
+        maxArtifacts: { type: "integer", minimum: 0 },
+        "max-artifacts": { type: "integer", minimum: 0 },
+        expectedOutputSchema: { type: "string", minLength: 1 },
+        "expected-output-schema": { type: "string", minLength: 1 },
+        artifactName: { type: "string", minLength: 1 },
+        artifactKind: { type: "string", minLength: 1 },
+        semantic: { type: "string", minLength: 1 },
         metadata: { type: "object", additionalProperties: true },
       },
     },

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -618,7 +618,7 @@ export const commandRegistry = [
       { name: "dependency-slugs", description: "Comma-separated plugin dependency slugs to load.", format: "comma-separated slugs" },
       { name: "env-json", description: "Benchmark environment object.", format: "JSON object" },
       { name: "bootstrap-files-json", description: "Component-relative bootstrap file fallbacks; the first existing file is loaded before workloads execute.", format: "JSON array" },
-      { name: "workloads-json", description: "Explicit workload list. Configured workload steps support php, ability, wp-cli, rest-request, rest-db-query-profiler, db-inventory, and external-http-guardrail mechanics.", format: "JSON array" },
+      { name: "workloads-json", description: "Explicit workload list. Configured workload steps support php, ability, wp-cli, rest-request, rest-db-query-profiler, db-inventory, external-http-guardrail, and artifact-postprocess mechanics.", format: "JSON array" },
       { name: "scenario-ids-json", description: "Optional selected benchmark scenario ids. Filters both discovered tests/bench workloads and explicit workloads by id.", format: "JSON array" },
       { name: "lifecycle-json", description: "Generic benchmark lifecycle hooks keyed by setup, prepare, warmup, measure, or teardown. Hook entries use the same php/ability/wp-cli step format as configured workloads.", format: "JSON object" },
       { name: "reset-policy-json", description: "Explicit benchmark reset policy. Supports betweenIterations and betweenScenarios modes: none or object-cache.", format: "JSON object" },

--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -325,6 +325,204 @@ function wp_codebox_bench_command_step_payload(array $execution, string $prefix,
     return $payload;
 }
 
+function wp_codebox_bench_safe_relative_path($value, string $label): string {
+    if (!is_string($value) || trim($value) === '') {
+        throw new RuntimeException($label . ' is required.');
+    }
+    $path = str_replace(chr(92), '/', trim($value));
+    if (str_starts_with($path, '/') || preg_match('#^[A-Za-z]:/#', $path)) {
+        throw new RuntimeException($label . ' must be a relative path.');
+    }
+    $parts = array();
+    foreach (explode('/', $path) as $part) {
+        if ($part === '' || $part === '.') {
+            continue;
+        }
+        if ($part === '..') {
+            throw new RuntimeException($label . ' must not contain parent traversal.');
+        }
+        $parts[] = $part;
+    }
+    if (empty($parts)) {
+        throw new RuntimeException($label . ' must not resolve to the root directory.');
+    }
+    return implode('/', $parts);
+}
+
+function wp_codebox_bench_resolve_contained_path(string $root, string $relative_path, string $label): string {
+    $root = rtrim(str_replace(chr(92), '/', $root), '/');
+    $resolved = $root . '/' . wp_codebox_bench_safe_relative_path($relative_path, $label);
+    $parent = dirname($resolved);
+    $real_root = realpath($root);
+    $real_parent = realpath($parent);
+    if (!is_string($real_root) || !is_string($real_parent) || ($real_parent !== $real_root && !str_starts_with($real_parent, $real_root . DIRECTORY_SEPARATOR))) {
+        throw new RuntimeException($label . ' must resolve inside its approved root.');
+    }
+    return $resolved;
+}
+
+function wp_codebox_bench_artifact_postprocess_helper_path(array $step, string $plugin_path): string {
+    $helper = $step['helperPath'] ?? ($step['helper'] ?? ($step['scriptPath'] ?? ($step['script'] ?? null)));
+    $helper_path = wp_codebox_bench_resolve_contained_path($plugin_path, wp_codebox_bench_safe_relative_path($helper, 'artifact-postprocess helper path'), 'artifact-postprocess helper path');
+    if (!str_ends_with($helper_path, '.mjs')) {
+        throw new RuntimeException('artifact-postprocess helper path must reference a .mjs file.');
+    }
+    if (!is_file($helper_path)) {
+        throw new RuntimeException('artifact-postprocess helper file does not exist: ' . basename($helper_path));
+    }
+    return $helper_path;
+}
+
+function wp_codebox_bench_artifact_postprocess_scan_input(string $root, int $max_input_bytes, int $max_artifacts): array {
+    $real_root = realpath($root);
+    if (!is_string($real_root) || !is_dir($real_root)) {
+        throw new RuntimeException('artifact-postprocess input artifact root must exist.');
+    }
+    $bytes = 0;
+    $artifacts = 0;
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($real_root, FilesystemIterator::SKIP_DOTS));
+    foreach ($iterator as $file) {
+        if (!$file->isFile() || $file->isLink()) {
+            continue;
+        }
+        ++$artifacts;
+        $bytes += (int) $file->getSize();
+        if ($artifacts > $max_artifacts) {
+            throw new RuntimeException('artifact-postprocess input artifact count exceeds maxArtifacts.');
+        }
+        if ($bytes > $max_input_bytes) {
+            throw new RuntimeException('artifact-postprocess input bytes exceed maxInputBytes.');
+        }
+    }
+    return array('artifact_count' => $artifacts, 'bytes' => $bytes);
+}
+
+function wp_codebox_bench_artifact_postprocess_expand_value($value, array $placeholders) {
+    if (is_string($value)) {
+        return strtr($value, $placeholders);
+    }
+    if (is_array($value)) {
+        $expanded = array();
+        foreach ($value as $key => $item) {
+            $expanded[$key] = wp_codebox_bench_artifact_postprocess_expand_value($item, $placeholders);
+        }
+        return $expanded;
+    }
+    return $value;
+}
+
+function wp_codebox_bench_artifact_postprocess_content_type(string $path): string {
+    $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+    if ($extension === 'json') {
+        return 'application/json';
+    }
+    if ($extension === 'jsonl') {
+        return 'application/x-ndjson';
+    }
+    if ($extension === 'md') {
+        return 'text/markdown';
+    }
+    if ($extension === 'html') {
+        return 'text/html';
+    }
+    return 'application/octet-stream';
+}
+
+function wp_codebox_bench_run_artifact_postprocess_step(array $step, string $plugin_path): array {
+    $command = isset($step['command']) && is_string($step['command']) ? trim($step['command']) : 'node';
+    if ($command !== 'node') {
+        throw new RuntimeException('artifact-postprocess workload steps only support the node command.');
+    }
+    $helper_path = wp_codebox_bench_artifact_postprocess_helper_path($step, $plugin_path);
+    $input_root_value = $step['inputArtifactRoot'] ?? ($step['input-artifact-root'] ?? ($step['artifactRoot'] ?? ($step['artifact-root'] ?? '')));
+    if (!is_string($input_root_value) || trim($input_root_value) === '') {
+        throw new RuntimeException('artifact-postprocess inputArtifactRoot is required.');
+    }
+    $input_root = realpath($input_root_value);
+    if (!is_string($input_root) || !is_dir($input_root)) {
+        throw new RuntimeException('artifact-postprocess input artifact root must exist.');
+    }
+    $output_relative = wp_codebox_bench_safe_relative_path($step['outputArtifactPath'] ?? ($step['output-artifact-path'] ?? ''), 'artifact-postprocess outputArtifactPath');
+    $output_path = rtrim($input_root, '/') . '/' . $output_relative;
+    $max_input_bytes = isset($step['maxInputBytes']) && is_numeric($step['maxInputBytes']) ? max(0, (int) $step['maxInputBytes']) : (isset($step['max-input-bytes']) && is_numeric($step['max-input-bytes']) ? max(0, (int) $step['max-input-bytes']) : 10485760);
+    $max_artifacts = isset($step['maxArtifacts']) && is_numeric($step['maxArtifacts']) ? max(0, (int) $step['maxArtifacts']) : (isset($step['max-artifacts']) && is_numeric($step['max-artifacts']) ? max(0, (int) $step['max-artifacts']) : 1000);
+    $input_summary = wp_codebox_bench_artifact_postprocess_scan_input($input_root, $max_input_bytes, $max_artifacts);
+    if (!is_dir(dirname($output_path)) && !mkdir(dirname($output_path), 0777, true) && !is_dir(dirname($output_path))) {
+        throw new RuntimeException('artifact-postprocess could not create output artifact directory.');
+    }
+    $placeholders = array(
+        '\${helperPath}' => $helper_path,
+        '\${inputArtifactRoot}' => $input_root,
+        '\${outputArtifactPath}' => $output_path,
+        '\${outputArtifactRelativePath}' => $output_relative,
+        '\${expectedOutputSchema}' => isset($step['expectedOutputSchema']) && is_string($step['expectedOutputSchema']) ? $step['expectedOutputSchema'] : (isset($step['expected-output-schema']) && is_string($step['expected-output-schema']) ? $step['expected-output-schema'] : ''),
+    );
+    $args = isset($step['args']) && is_array($step['args']) ? array_values($step['args']) : array('\${helperPath}', '\${inputArtifactRoot}', '\${outputArtifactPath}');
+    $expanded_args = array_map(static fn($arg) => is_scalar($arg) ? (string) wp_codebox_bench_artifact_postprocess_expand_value((string) $arg, $placeholders) : '', $args);
+    if (!in_array($helper_path, $expanded_args, true)) {
+        array_unshift($expanded_args, $helper_path);
+    }
+    $env = getenv();
+    $env = is_array($env) ? $env : array();
+    $env['WP_CODEBOX_ARTIFACT_INPUT_ROOT'] = $input_root;
+    $env['WP_CODEBOX_ARTIFACT_OUTPUT_PATH'] = $output_path;
+    $env['WP_CODEBOX_ARTIFACT_OUTPUT_RELATIVE_PATH'] = $output_relative;
+    foreach (is_array($step['env'] ?? null) ? $step['env'] : array() as $name => $value) {
+        if (is_string($name) && preg_match('/^[A-Z_][A-Z0-9_]*$/', $name)) {
+            $env[$name] = is_scalar($value) ? (string) wp_codebox_bench_artifact_postprocess_expand_value((string) $value, $placeholders) : '';
+        }
+    }
+
+    $execution = wp_codebox_bench_run_command_step($step, 'artifact-postprocess', static function () use ($command, $expanded_args, $env): array {
+        $pipes = array();
+        $process = proc_open(array_merge(array($command), $expanded_args), array(1 => array('pipe', 'w'), 2 => array('pipe', 'w')), $pipes, null, $env);
+        if (!is_resource($process)) {
+            throw new RuntimeException('artifact-postprocess helper process could not be started.');
+        }
+        $stdout = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+        $exit_code = proc_close($process);
+        if ($exit_code !== 0) {
+            throw new RuntimeException('artifact-postprocess helper failed with exit code ' . $exit_code . ': ' . trim((string) $stderr));
+        }
+        return array('stdout' => (string) $stdout, 'stderr' => (string) $stderr, 'exit_code' => $exit_code);
+    });
+    if (!is_file($output_path)) {
+        throw new RuntimeException('artifact-postprocess helper did not create the expected output artifact.');
+    }
+    $bytes = filesize($output_path);
+    $bytes = is_int($bytes) ? $bytes : 0;
+    $expected_schema = isset($step['expectedOutputSchema']) && is_string($step['expectedOutputSchema']) ? $step['expectedOutputSchema'] : (isset($step['expected-output-schema']) && is_string($step['expected-output-schema']) ? $step['expected-output-schema'] : '');
+    $artifact_name = isset($step['artifactName']) && is_string($step['artifactName']) && trim($step['artifactName']) !== '' ? trim($step['artifactName']) : (isset($step['name']) && is_string($step['name']) && trim($step['name']) !== '' ? trim($step['name']) : preg_replace('/\.[^.]+$/', '', basename($output_relative)));
+    $metadata = is_array($step['metadata'] ?? null) ? $step['metadata'] : array();
+    $metadata = array_merge($metadata, array(
+        'schema' => $expected_schema,
+        'semantic' => isset($step['semantic']) && is_string($step['semantic']) ? $step['semantic'] : 'artifact-postprocess',
+        'inputArtifactRoot' => $input_root,
+        'input' => $input_summary,
+    ));
+    $artifact = array(
+        'path' => $output_relative,
+        'kind' => isset($step['artifactKind']) && is_string($step['artifactKind']) && trim($step['artifactKind']) !== '' ? trim($step['artifactKind']) : 'artifact-postprocess',
+        'contentType' => wp_codebox_bench_artifact_postprocess_content_type($output_relative),
+        'sha256' => hash_file('sha256', $output_path),
+        'bytes' => $bytes,
+        'source' => 'artifact-postprocess',
+        'name' => $artifact_name,
+        'metadata' => $metadata,
+    );
+    $payload = wp_codebox_bench_command_step_payload($execution, wp_codebox_bench_metric_prefix($step, 'artifact_postprocess'), array(
+        'artifact_postprocess_input_bytes' => (float) $input_summary['bytes'],
+        'artifact_postprocess_input_artifacts_count' => (float) $input_summary['artifact_count'],
+        'artifact_postprocess_output_bytes' => (float) $bytes,
+    ), array('outputArtifactPath' => $output_relative, 'helper' => basename($helper_path)));
+    $payload['artifacts'][$artifact_name] = $artifact;
+    $payload['metadata']['artifact_postprocess_schema'] = $expected_schema;
+    return $payload;
+}
+
 function wp_codebox_bench_run_rest_request_step(array $step): array {
     if (!class_exists('WP_REST_Request') || !function_exists('rest_do_request')) {
         throw new RuntimeException('The WordPress REST API is not available in this runtime.');
@@ -1237,6 +1435,8 @@ function wp_codebox_bench_run_configured_workload(array $workload, string $plugi
 			$result = wp_codebox_bench_run_rest_db_query_profiler_step($step);
 		} elseif ($type === 'external-http-guardrail') {
 			$result = wp_codebox_bench_run_external_http_guardrail_step($step);
+		} elseif ($type === 'artifact-postprocess') {
+			$result = wp_codebox_bench_run_artifact_postprocess_step($step, $plugin_path);
 		} else {
             throw new RuntimeException('Unsupported bench workload step type: ' . $type);
         }

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { phpFunctionBlock, runPhpFileJson, withTempDir } from "../scripts/test-kit.js"
 import { benchRunCode } from "../packages/runtime-playground/src/bench-command-handlers.js"
@@ -22,6 +22,7 @@ const runAbilityStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_abili
 const runDbInventoryStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_db_inventory_step")
 const runRestDbQueryProfilerStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_rest_db_query_profiler_step")
 const runExternalHttpGuardrailStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_external_http_guardrail_step")
+const runArtifactPostprocessStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_artifact_postprocess_step")
 const commandStepRecord = phpFunctionBlock(benchRunner, "wp_codebox_bench_command_step_record")
 assert.match(runCommandStep, /function wp_codebox_bench_run_command_step\(array \$step, string \$type, callable \$runner\): array/)
 assert.match(runAbilityStep, /wp_codebox_bench_run_command_step\(\$step, 'ability'/)
@@ -35,6 +36,8 @@ assert.match(runRestDbQueryProfilerStep, /\$wpdb->save_queries = true/)
 assert.match(runRestDbQueryProfilerStep, /\$payload\['artifacts'\]\['rest-db-query-profile'\] = \$artifact/)
 assert.match(runExternalHttpGuardrailStep, /wp-codebox\/wordpress-external-http-guardrail\/v1/)
 assert.match(runExternalHttpGuardrailStep, /wp_codebox_bench_install_external_http_guardrail/)
+assert.match(runArtifactPostprocessStep, /artifact-postprocess workload steps only support the node command/)
+assert.match(runArtifactPostprocessStep, /WP_CODEBOX_ARTIFACT_INPUT_ROOT/)
 assert.match(commandStepRecord, /'schema' => 'wp-codebox\/bench-command-step\/v1'/)
 assert.doesNotMatch(runCommandStep, /\$type === 'ability'/)
 assert.ok(
@@ -62,6 +65,20 @@ const externalHttpGuardrailHelpers = [
   "wp_codebox_bench_external_http_guardrail_summary",
   "wp_codebox_bench_install_external_http_guardrail",
   "wp_codebox_bench_run_external_http_guardrail_step",
+].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
+
+const artifactPostprocessHelpers = [
+  "wp_codebox_bench_metric_prefix",
+  "wp_codebox_bench_command_step_record",
+  "wp_codebox_bench_run_command_step",
+  "wp_codebox_bench_command_step_payload",
+  "wp_codebox_bench_safe_relative_path",
+  "wp_codebox_bench_resolve_contained_path",
+  "wp_codebox_bench_artifact_postprocess_helper_path",
+  "wp_codebox_bench_artifact_postprocess_scan_input",
+  "wp_codebox_bench_artifact_postprocess_expand_value",
+  "wp_codebox_bench_artifact_postprocess_content_type",
+  "wp_codebox_bench_run_artifact_postprocess_step",
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
 const restDbQueryProfilerHelpers = [
@@ -144,6 +161,95 @@ assert.equal(externalHttpGuardrailPayload.artifacts["external-http-guardrail"].e
 assert.equal(externalHttpGuardrailPayload.metrics.external_http_guardrail_event_count, 2)
 assert.equal(externalHttpGuardrailPayload.steps[0].type, "external-http-guardrail")
 assert.equal(externalHttpGuardrailPayload.steps[0].action, "collect")
+
+const artifactPostprocessPayload = await withTempDir("wp-codebox-artifact-postprocess-", async (directory) => {
+  const pluginDirectory = join(directory, "plugin")
+  const helperDirectory = join(pluginDirectory, "helpers")
+  const artifactDirectory = join(directory, "artifacts")
+  await mkdir(helperDirectory, { recursive: true })
+  await mkdir(join(artifactDirectory, "source"), { recursive: true })
+  await writeFile(join(artifactDirectory, "source", "coverage.json"), JSON.stringify({ uncovered: ["GET /wc/v3/orders"] }))
+  await writeFile(join(helperDirectory, "postprocess.mjs"), `import { readFile, writeFile } from "node:fs/promises";\nimport { join } from "node:path";\nconst inputRoot = process.argv[2];\nconst outputPath = process.argv[3];\nconst source = JSON.parse(await readFile(join(inputRoot, "source", "coverage.json"), "utf8"));\nawait writeFile(outputPath, JSON.stringify({ schema: process.env.EXPECTED_SCHEMA, inputRoot: process.env.WP_CODEBOX_ARTIFACT_INPUT_ROOT, gaps: source.uncovered }, null, 2));\n`)
+  const phpTestFile = join(directory, "artifact-postprocess.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+${artifactPostprocessHelpers}
+$plugin_path = ${JSON.stringify(pluginDirectory)};
+$payload = wp_codebox_bench_run_artifact_postprocess_step(array(
+    'type' => 'artifact-postprocess',
+    'helperPath' => 'helpers/postprocess.mjs',
+    'inputArtifactRoot' => ${JSON.stringify(artifactDirectory)},
+    'outputArtifactPath' => 'derived/coverage-gaps.json',
+    'maxInputBytes' => 4096,
+    'maxArtifacts' => 4,
+    'expectedOutputSchema' => 'example/coverage-gaps/v1',
+    'artifactName' => 'coverage-gaps',
+    'artifactKind' => 'coverage-gap-report',
+    'semantic' => 'coverage-gap-report',
+    'args' => array('\${helperPath}', '\${inputArtifactRoot}', '\${outputArtifactPath}'),
+    'env' => array('EXPECTED_SCHEMA' => '\${expectedOutputSchema}', 'IGNORED_lower' => 'nope'),
+), $plugin_path);
+echo json_encode($payload, JSON_UNESCAPED_SLASHES);
+`,
+  )
+  const payload = await runPhpFileJson<{ metrics: Record<string, number>; metadata: Record<string, string>; artifacts: Record<string, { path: string; kind: string; contentType: string; sha256: string; bytes: number; source: string; name: string; metadata: { schema: string; semantic: string; input: { artifact_count: number; bytes: number } } }>; steps: Array<{ type: string; helper: string; outputArtifactPath: string }> }>(phpTestFile)
+  const output = JSON.parse(await readFile(join(artifactDirectory, "derived", "coverage-gaps.json"), "utf8")) as { schema: string; gaps: string[] }
+  assert.equal(output.schema, "example/coverage-gaps/v1")
+  assert.deepEqual(output.gaps, ["GET /wc/v3/orders"])
+  return payload
+})
+assert.equal(artifactPostprocessPayload.artifacts["coverage-gaps"].path, "derived/coverage-gaps.json")
+assert.equal(artifactPostprocessPayload.artifacts["coverage-gaps"].kind, "coverage-gap-report")
+assert.equal(artifactPostprocessPayload.artifacts["coverage-gaps"].contentType, "application/json")
+assert.match(artifactPostprocessPayload.artifacts["coverage-gaps"].sha256, /^[a-f0-9]{64}$/)
+assert.equal(artifactPostprocessPayload.artifacts["coverage-gaps"].source, "artifact-postprocess")
+assert.equal(artifactPostprocessPayload.artifacts["coverage-gaps"].metadata.schema, "example/coverage-gaps/v1")
+assert.equal(artifactPostprocessPayload.artifacts["coverage-gaps"].metadata.semantic, "coverage-gap-report")
+assert.equal(artifactPostprocessPayload.artifacts["coverage-gaps"].metadata.input.artifact_count, 1)
+assert.equal(artifactPostprocessPayload.metadata.artifact_postprocess_schema, "example/coverage-gaps/v1")
+assert.equal(artifactPostprocessPayload.metrics.artifact_postprocess_input_artifacts_count, 1)
+assert.equal(artifactPostprocessPayload.steps[0].type, "artifact-postprocess")
+assert.equal(artifactPostprocessPayload.steps[0].helper, "postprocess.mjs")
+
+const artifactPostprocessFailures = await withTempDir("wp-codebox-artifact-postprocess-failures-", async (directory) => {
+  const pluginDirectory = join(directory, "plugin")
+  const helperDirectory = join(pluginDirectory, "helpers")
+  const artifactDirectory = join(directory, "artifacts")
+  await mkdir(helperDirectory, { recursive: true })
+  await mkdir(artifactDirectory, { recursive: true })
+  await writeFile(join(artifactDirectory, "input.json"), "{}")
+  await writeFile(join(helperDirectory, "noop.mjs"), `process.exit(0);\n`)
+  const phpTestFile = join(directory, "artifact-postprocess-failures.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+${artifactPostprocessHelpers}
+$plugin_path = ${JSON.stringify(pluginDirectory)};
+$artifact_root = ${JSON.stringify(artifactDirectory)};
+$messages = array();
+foreach (array(
+    array('helperPath' => '../outside.mjs', 'outputArtifactPath' => 'out.json'),
+    array('helperPath' => '/tmp/outside.mjs', 'outputArtifactPath' => 'out.json'),
+    array('helperPath' => 'helpers/noop.mjs', 'outputArtifactPath' => 'missing/out.json'),
+    array('helperPath' => 'helpers/noop.mjs', 'command' => 'sh', 'outputArtifactPath' => 'out.json'),
+) as $step) {
+    try {
+        wp_codebox_bench_run_artifact_postprocess_step(array_merge(array('type' => 'artifact-postprocess', 'inputArtifactRoot' => $artifact_root), $step), $plugin_path);
+        $messages[] = 'ok';
+    } catch (Throwable $e) {
+        $messages[] = $e->getMessage();
+    }
+}
+echo json_encode($messages, JSON_UNESCAPED_SLASHES);
+`,
+  )
+  return runPhpFileJson<string[]>(phpTestFile)
+})
+assert.match(artifactPostprocessFailures[0], /parent traversal/)
+assert.match(artifactPostprocessFailures[1], /relative path/)
+assert.match(artifactPostprocessFailures[2], /did not create the expected output artifact/)
+assert.match(artifactPostprocessFailures[3], /only support the node command/)
 
 const restDbQueryProfilerPayload = await withTempDir("wp-codebox-rest-db-query-profiler-", async (directory) => {
   const phpTestFile = join(directory, "rest-db-query-profiler.php")

--- a/tests/benchmark-contracts.test.ts
+++ b/tests/benchmark-contracts.test.ts
@@ -46,6 +46,7 @@ const routeMatrixDefinition = {
 
 const schema = createBenchmarkDefinitionJsonSchema()
 const workloadDefinition = (schema.$defs as Record<string, { properties?: Record<string, unknown> }>).workload
+const workloadStepDefinition = (schema.$defs as Record<string, { properties?: Record<string, unknown> }>).workloadStep
 const routeDefinition = (schema.$defs as Record<string, { anyOf?: unknown; properties?: Record<string, unknown> }>).restRouteMatrixEntry
 const restCaseDefinition = (schema.$defs as Record<string, { anyOf?: unknown; properties?: Record<string, unknown> }>).restRequestCaseEntry
 
@@ -55,6 +56,10 @@ assert.ok(workloadDefinition.properties?.rest_request_cases, "benchmark definiti
 assert.ok(workloadDefinition.properties?.request_cases, "benchmark definition schema should expose workload request_cases")
 assert.ok(routeDefinition.properties?.["capture-response"], "route_matrix entries should expose REST response capture")
 assert.ok(restCaseDefinition.properties?.case_id, "REST request case entries should expose case_id")
+assert.ok(workloadStepDefinition.properties?.helperPath, "workload steps should expose artifact-postprocess helperPath")
+assert.ok(workloadStepDefinition.properties?.inputArtifactRoot, "workload steps should expose artifact-postprocess inputArtifactRoot")
+assert.ok(workloadStepDefinition.properties?.outputArtifactPath, "workload steps should expose artifact-postprocess outputArtifactPath")
+assert.ok(workloadStepDefinition.properties?.expectedOutputSchema, "workload steps should expose artifact-postprocess expectedOutputSchema")
 assert.deepEqual(routeDefinition.anyOf, [{ required: ["path"] }, { required: ["route"] }])
 assert.deepEqual(restCaseDefinition.anyOf, [{ required: ["path"] }, { required: ["route"] }])
 


### PR DESCRIPTION
## Summary
- add a generic artifact-postprocess workload step for derived artifact generation
- execute explicit relative .mjs helpers through node without arbitrary shell strings
- enforce bounded input artifact reads and required output artifact creation
- record derived artifacts with schema and semantic metadata

## Stack
- Depends on #1496

## Testing
- npm run build
- npm run test:bench-command-step-behavior
- npx tsx tests/benchmark-contracts.test.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafting/stabilizing the artifact-postprocess workload primitive and targeted verification.