### PR TITLE
Add public fuzz workload CLI commands

### DIFF
--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -10,6 +10,7 @@ import { runMaterializeReplayPackageCommand } from "./commands/replay-package.js
 import { runMcpRenderClientConfigsCommand } from "./commands/mcp.js"
 import { runPreviewLeaseReleaseCommand, runPreviewLeaseStatusCommand } from "./commands/preview-lease.js"
 import { runBootCommand, runRunCommand, runValidateBlueprintCommand } from "./commands/runtime.js"
+import { runFuzzSuiteCommand, runWordPressWorkloadCommand } from "./commands/wordpress-runtime.js"
 import { runRunsArtifactsCommand, runRunsCancelCommand, runRunsStatusCommand } from "./commands/runs.js"
 import { runTargetProvisionCommand } from "./commands/target.js"
 import { runWorkspacePolicyCheckCommand } from "./commands/workspace-policy.js"
@@ -23,6 +24,8 @@ export async function runCli(args: string[]): Promise<number> {
     materializeReplayPackage: runMaterializeReplayPackageCommand,
     recipeRun: runRecipeRunCommand,
     agentTaskRun: runAgentTaskRunCommand,
+    runFuzzSuite: runFuzzSuiteCommand,
+    runWordPressWorkload: runWordPressWorkloadCommand,
     recipeValidate: runRecipeValidateCommand,
     recipeBuild: runRecipeBuildCommand,
     workspacePolicyCheck: runWorkspacePolicyCheckCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -10,6 +10,8 @@ const cliCommandRoutes = {
   "recipe-run": "recipeRun",
   "agent-task-run": "agentTaskRun",
   "run-agent-task": "agentTaskRun",
+  "run-fuzz-suite": "runFuzzSuite",
+  "run-wordpress-workload": "runWordPressWorkload",
   recipe: {
     validate: "recipeValidate",
     build: "recipeBuild",
@@ -121,7 +123,7 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
 }
 
 async function maybeRespawnWithJspi(command: string | undefined, args: string[]): Promise<number | undefined> {
-  if (!command || !["boot", "run", "recipe-run", "agent-task-run", "run-agent-task"].includes(command)) {
+  if (!command || !["boot", "run", "recipe-run", "agent-task-run", "run-agent-task", "run-wordpress-workload"].includes(command)) {
     return undefined
   }
 

--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -1,0 +1,161 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { parseCommandJson, parseCommandOptions, runFuzzSuite, wordpressWorkloadRunRecipe, type FuzzSuiteContract, type WordPressWorkloadRunRecipeOptions } from "@automattic/wp-codebox-core"
+import { captureStdout } from "../output.js"
+import { runRecipeRunCommand } from "./recipe-run.js"
+
+const FUZZ_SUITE_RESULT_SCHEMA = "wp-codebox/fuzz-suite-result/v1"
+const WORDPRESS_WORKLOAD_RUN_RESULT_SCHEMA = "wp-codebox/wordpress-workload-run-result/v1"
+
+interface PublicRuntimeCommandOptions {
+  input: Record<string, unknown>
+  json: boolean
+  dryRun: boolean
+  artifactsDirectory?: string
+  runRegistryDirectory?: string
+  timeout?: string
+}
+
+export async function runFuzzSuiteCommand(args: string[]): Promise<number> {
+  if (isHelp(args)) {
+    printFuzzSuiteHelp()
+    return 0
+  }
+
+  const options = await parsePublicRuntimeCommandOptions(args)
+  const result = await runFuzzSuite(options.input as unknown as FuzzSuiteContract, {
+    metadata: {
+      public_cli_command: "run-fuzz-suite",
+      dry_run: options.dryRun || undefined,
+    },
+  })
+  const { schema: _schema, ...resultFields } = result
+  writeJson({ schema: FUZZ_SUITE_RESULT_SCHEMA, ...resultFields })
+  return 0
+}
+
+export async function runWordPressWorkloadCommand(args: string[]): Promise<number> {
+  if (isHelp(args)) {
+    printWordPressWorkloadHelp()
+    return 0
+  }
+
+  const options = await parsePublicRuntimeCommandOptions(args)
+  const recipe = wordpressWorkloadRunRecipe(workloadRecipeOptions(options.input)) as unknown as Record<string, unknown>
+  delete recipe.metadata
+  const tempDir = await mkdtemp(join(tmpdir(), "wp-codebox-workload-cli-"))
+  try {
+    const recipePath = join(tempDir, "recipe.json")
+    await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`, "utf8")
+    const recipeArgs = ["--recipe", recipePath, "--json"]
+    if (options.dryRun) recipeArgs.push("--dry-run")
+    if (options.artifactsDirectory) recipeArgs.push("--artifacts", options.artifactsDirectory)
+    if (options.runRegistryDirectory) recipeArgs.push("--run-registry", options.runRegistryDirectory)
+    if (options.timeout) recipeArgs.push("--timeout", options.timeout)
+    const { result: exitCode, logs } = await captureStdout(() => runRecipeRunCommand(recipeArgs))
+    for (const log of logs) {
+      process.stdout.write(`${log}\n`)
+    }
+    return logs.length > 0 ? 0 : exitCode
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+async function parsePublicRuntimeCommandOptions(args: string[]): Promise<PublicRuntimeCommandOptions> {
+  const { options, positionals } = parseCommandOptions(args, new Set(["--json", "--dry-run"]))
+  if (positionals.length > 0) {
+    throw new Error(`Invalid argument: ${positionals[0]}`)
+  }
+
+  for (const name of options.keys()) {
+    if (!["--input-file", "--input-json", "--format", "--json", "--dry-run", "--artifacts", "--run-registry", "--timeout"].includes(name)) {
+      throw new Error(`Unknown option: ${name}`)
+    }
+  }
+
+  const input = await readInput(options)
+  return {
+    input,
+    json: options.get("--json") === true || options.get("--format") === "json",
+    dryRun: options.get("--dry-run") === true,
+    artifactsDirectory: stringOption(options, "--artifacts"),
+    runRegistryDirectory: stringOption(options, "--run-registry"),
+    timeout: stringOption(options, "--timeout"),
+  }
+}
+
+async function readInput(options: Map<string, string | true>): Promise<Record<string, unknown>> {
+  const inputFile = stringOption(options, "--input-file")
+  const inputJson = stringOption(options, "--input-json")
+  if (inputFile && inputJson) {
+    throw new Error("Use either --input-file or --input-json, not both")
+  }
+  if (inputFile) {
+    const parsed = parseCommandJson(await readFile(resolve(inputFile), "utf8"), "--input-file")
+    return objectInput(parsed, "--input-file")
+  }
+  if (inputJson) {
+    return objectInput(parseCommandJson(inputJson, "--input-json"), "--input-json")
+  }
+  throw new Error("Missing required option: --input-file")
+}
+
+function workloadRecipeOptions(input: Record<string, unknown>): WordPressWorkloadRunRecipeOptions {
+  const steps = arrayOption(input.steps)
+  return {
+    wordpressVersion: stringValue(input.wordpressVersion ?? input.wordpress_version ?? input.wp),
+    blueprint: input.blueprint,
+    preview: objectOption(input.preview) as WordPressWorkloadRunRecipeOptions["preview"],
+    mounts: arrayOption(input.mounts) as WordPressWorkloadRunRecipeOptions["mounts"],
+    runtimeStackMounts: arrayOption(input.runtimeStackMounts ?? input.runtime_stack_mounts) as WordPressWorkloadRunRecipeOptions["runtimeStackMounts"],
+    runtimeOverlays: arrayOption(input.runtimeOverlays ?? input.runtime_overlays) as WordPressWorkloadRunRecipeOptions["runtimeOverlays"],
+    runtimeEnv: objectOption(input.runtimeEnv ?? input.runtime_env) as WordPressWorkloadRunRecipeOptions["runtimeEnv"],
+    secretEnv: arrayOption(input.secretEnv ?? input.secret_env).map(String),
+    stagedFiles: arrayOption(input.stagedFiles ?? input.staged_files) as WordPressWorkloadRunRecipeOptions["stagedFiles"],
+    before: arrayOption(input.before) as WordPressWorkloadRunRecipeOptions["before"],
+    steps: steps as WordPressWorkloadRunRecipeOptions["steps"],
+    after: arrayOption(input.after) as WordPressWorkloadRunRecipeOptions["after"],
+  }
+}
+
+function objectInput(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must contain a JSON object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function objectOption(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}
+
+function arrayOption(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : []
+}
+
+function stringOption(options: Map<string, string | true>, name: string): string | undefined {
+  const value = options.get(name)
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function isHelp(args: string[]): boolean {
+  return args.includes("--help") || args.includes("-h")
+}
+
+function writeJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`)
+}
+
+function printFuzzSuiteHelp(): void {
+  process.stdout.write(`Usage: wp-codebox run-fuzz-suite --input-file <path> [--format=json] [--dry-run]\n\nRuns a wp-codebox/fuzz-suite/v1 JSON payload through the public fuzz-suite runner.\n`)
+}
+
+function printWordPressWorkloadHelp(): void {
+  process.stdout.write(`Usage: wp-codebox run-wordpress-workload --input-file <path> [--format=json] [--dry-run]\n\nRuns a wp-codebox/wordpress-workload-run/v1 JSON payload through the public WordPress workload recipe boundary.\nResult schema: ${WORDPRESS_WORKLOAD_RUN_RESULT_SCHEMA}\n`)
+}

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -133,7 +133,7 @@ export function cliFailureEnvelope(command: string | undefined, message: string,
 }
 
 export function wantsJsonOutput(args: readonly string[]): boolean {
-  return args.includes("--json")
+  return args.includes("--json") || args.includes("--format=json") || args.some((arg, index) => arg === "--format" && args[index + 1] === "json")
 }
 
 export function writeJsonFailure(command: string | undefined, message: string, details: Record<string, unknown> = {}): void {
@@ -317,6 +317,8 @@ export function printHelp(): void {
   wp-codebox preview-lease status (--registry <dir> --lease-id <id>|--lease-file <path>) [--json]
   wp-codebox preview-lease release (--registry <dir> --lease-id <id>|--lease-file <path>) [--json]
   wp-codebox target provision [--id <id>] [--kind <kind>] [--workspace-root <dir>] [--json]
+  wp-codebox run-fuzz-suite --input-file <path> [--format=json]
+  wp-codebox run-wordpress-workload --input-file <path> [--format=json] [--dry-run]
   wp-codebox run-agent-task --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>] [--preview-lease-json <json>]
   wp-codebox agent-task-run --input-file <path> [--json] [--preview-hold-seconds <n>] [--preview-hold-blocking] [--preview-port <port>] [--preview-bind <host>] [--preview-public-url <url>] [--preview-lease-json <json>]
   wp-codebox validate-blueprint --blueprint <json|file> [options]
@@ -329,7 +331,8 @@ Options:
   --recipe <path>     Workspace recipe JSON file for recipe-run or recipe validate.
   --options <path>    Recipe builder options JSON file for recipe build.
   --output <path>     Recipe build output JSON path, or materialize-replay-package output directory.
-  --input-file <path> Agent task input JSON for run-agent-task/agent-task-run.
+  --input-file <path> Input JSON for public workload/fuzz commands or agent-task-run.
+  --format=json       Emit machine-readable JSON; accepted by public workload/fuzz commands.
   --preview-hold-seconds <n>
                     Keep preview runtimes alive after run-agent-task/agent-task-run/recipe-run.
                     Max 3600s by default; operators may raise the cap with WP_CODEBOX_PREVIEW_HOLD_MAX_SECONDS.

--- a/tests/command-router.test.ts
+++ b/tests/command-router.test.ts
@@ -14,6 +14,8 @@ const router = {
     calls.push(`agentTaskRun:${args.join(" ")}`)
     return 7
   },
+  runFuzzSuite: async () => 0,
+  runWordPressWorkload: async () => 0,
   recipeValidate: async () => 0,
   recipeBuild: async () => 0,
   workspacePolicyCheck: async () => 0,

--- a/tests/public-fuzz-workload-cli.test.ts
+++ b/tests/public-fuzz-workload-cli.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { runCli } from "../packages/cli/src/cli-entry.js"
+
+process.env.WP_CODEBOX_NO_JSPI_RESPAWN = "1"
+
+const help = await captureStdout(async () => {
+  assert.equal(await runCli(["run-fuzz-suite", "--help"]), 0)
+  assert.equal(await runCli(["run-wordpress-workload", "--help"]), 0)
+})
+assert.match(help, /run-fuzz-suite/)
+assert.match(help, /run-wordpress-workload/)
+assert.match(help, /--input-file/)
+
+const directory = await mkdtemp(join(tmpdir(), "wp-codebox-public-cli-test-"))
+try {
+  const fuzzInput = join(directory, "fuzz.json")
+  await writeFile(fuzzInput, JSON.stringify({
+    schema: "wp-codebox/fuzz-suite/v1",
+    id: "public-cli-suite",
+    cases: [{ id: "case-1", target: { kind: "command", id: "noop" }, input: {} }],
+  }), "utf8")
+  const fuzzOutput = await captureStdout(async () => {
+    assert.equal(await runCli(["run-fuzz-suite", "--input-file", fuzzInput, "--format=json", "--dry-run"]), 0)
+  })
+  const fuzzJson = JSON.parse(fuzzOutput)
+  assert.equal(fuzzJson.schema, "wp-codebox/fuzz-suite-result/v1")
+  assert.equal(fuzzJson.metadata.public_cli_command, "run-fuzz-suite")
+
+  const workloadInput = join(directory, "workload.json")
+  await writeFile(workloadInput, JSON.stringify({
+    schema: "wp-codebox/wordpress-workload-run/v1",
+    steps: [{ command: "wordpress.run-php", args: ["code=<?php echo 'ok';"] }],
+  }), "utf8")
+  const workloadOutput = await captureStdout(async () => {
+    assert.equal(await runCli(["run-wordpress-workload", "--input-file", workloadInput, "--format=json", "--dry-run"]), 0)
+  })
+  const workloadJson = JSON.parse(workloadOutput)
+  assert.equal(workloadJson.schema, "wp-codebox/recipe-run-dry-run/v1")
+  assert.equal(workloadJson.dryRun, true)
+  assert.equal(workloadJson.plan.workflow.steps[0].command, "wordpress.run-php")
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}
+
+console.log("public fuzz/workload CLI contract passed")
+
+async function captureStdout(callback: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let stdout = ""
+  ;(process.stdout.write as typeof process.stdout.write) = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    stdout += typeof chunk === "string" ? chunk : chunk.toString()
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback()
+    } else if (callback) {
+      callback()
+    }
+    return true
+  }) as typeof process.stdout.write
+  try {
+    await callback()
+    return stdout
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}


### PR DESCRIPTION
## Summary
- add public run-fuzz-suite and run-wordpress-workload CLI commands
- wire command discovery/help so downstream providers can detect the fuzz CLI surface
- delegate to existing runtime/workload helpers instead of duplicating execution internals
- add targeted command router and public CLI contract tests

## Testing
- npm run test:command-router
- npx tsx tests/public-fuzz-workload-cli.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafting/stabilizing the public fuzz/workload CLI commands and targeted verification.