### PR TITLE
Keep runtime substrate behind Codebox boundary

### DIFF
--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -138,29 +138,11 @@ function wp_codebox_ensure_sandbox_default_agent(string $agent_slug, array $agen
         return array('success' => true, 'agent' => $agent_slug, 'existing' => true);
     }
 
-    if (class_exists('DataMachine\\Core\\Database\\Agents\\Agents')) {
-        $owner_id = function_exists('get_current_user_id') ? (int) get_current_user_id() : 0;
-        if ($owner_id <= 0) {
-            $owner_id = 1;
-        }
-        $default_config = array_filter(array(
-            'default_provider' => (string) ($agent_input['provider'] ?? ''),
-            'default_model' => (string) ($agent_input['model'] ?? ''),
-        ), static fn($value): bool => '' !== $value);
-        try {
-            $agent_id = (new DataMachine\\Core\\Database\\Agents\\Agents())->create_if_missing(
-                $agent_slug,
-                'WP Codebox Sandbox',
-                $owner_id,
-                $default_config
-            );
-            return array('success' => $agent_id > 0, 'agent' => $agent_slug, 'agent_id' => $agent_id, 'created' => $agent_id > 0, 'runtime' => 'data-machine');
-        } catch (Throwable $e) {
-            return array('success' => false, 'agent' => $agent_slug, 'reason' => 'data_machine_agent_create_failed', 'message' => $e->getMessage());
-        }
-    }
-
     if (!class_exists('WP_Agents_Registry')) {
+        $adapter_result = apply_filters('wp_codebox_runtime_agent_registry_ensure_agent', null, $agent_slug, $agent_input);
+        if (null !== $adapter_result) {
+            return is_array($adapter_result) ? $adapter_result : array('success' => (bool) $adapter_result, 'agent' => $agent_slug, 'created' => (bool) $adapter_result, 'adapter' => 'wp_codebox_runtime_agent_registry_ensure_agent');
+        }
         return array('success' => false, 'agent' => $agent_slug, 'reason' => 'agent_registry_unavailable');
     }
 
@@ -549,7 +531,6 @@ export function agentSandboxRunCode(task: string, code: string, providerPlugins:
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 $plugins = array_merge(wp_codebox_provider_plugin_entries(json_decode(${phpStringLiteral(JSON.stringify(runtimeComponents))}, true)), array(
-    'agents-api/agents-api.php',
 ), wp_codebox_provider_plugin_entries(json_decode(${phpStringLiteral(JSON.stringify(providerPlugins))}, true)));
 
 ${providerPluginResolutionPhp()}
@@ -635,13 +616,11 @@ function phpStringLiteral(value: string): string {
   return `<<<'${marker}'\n${value}\n${marker}`
 }
 
-export function agentRuntimeProbeCode(providerPlugins: Array<{ slug: string; pluginFile?: string; loadAs?: string }>): string {
+export function agentRuntimeProbeCode(providerPlugins: Array<{ slug: string; pluginFile?: string; loadAs?: string }>, runtimeComponents: Array<{ slug: string; pluginFile?: string; loadAs?: string }> = []): string {
   return `<?php
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-$plugins = array_merge(array(
-    'agents-api/agents-api.php',
-), wp_codebox_provider_plugin_entries(json_decode(${phpStringLiteral(JSON.stringify(providerPlugins))}, true)));
+$plugins = array_merge(wp_codebox_provider_plugin_entries(json_decode(${phpStringLiteral(JSON.stringify(runtimeComponents))}, true)), wp_codebox_provider_plugin_entries(json_decode(${phpStringLiteral(JSON.stringify(providerPlugins))}, true)));
 
 ${providerPluginResolutionPhp()}
 

--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -111,7 +111,7 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
   if (step.command === "wp-codebox.agent-runtime-probe") {
     return {
       command: "wordpress.run-php",
-      args: [`code=${agentRuntimeProbeCode(providerPluginContracts(step.args ?? []))}`, ...commandDiagnosticsCaptureArgs(step.diagnostics)],
+      args: [`code=${agentRuntimeProbeCode(providerPluginContracts(step.args ?? []), runtimeComponentContracts(step.args ?? []))}`, ...commandDiagnosticsCaptureArgs(step.diagnostics)],
       diagnostics: step.diagnostics,
     }
   }
@@ -519,8 +519,10 @@ function defaultAgentsApiPath(dataMachinePath = ""): string {
   if (explicit) {
     return explicit
   }
-  if (dataMachinePath) {
-    return ""
+
+  const bundled = dataMachinePath ? resolve(dataMachinePath, "vendor", "wordpress", "agents-api") : ""
+  if (bundled && existsSync(resolve(bundled, "agents-api.php"))) {
+    return bundled
   }
 
   return defaultSiblingComponentPath("agents-api", "agents-api.php")

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -221,8 +221,10 @@ function defaultAgentsApiPath(dataMachinePath = ""): string {
   if (explicit) {
     return explicit
   }
-  if (dataMachinePath) {
-    return ""
+
+  const bundled = dataMachinePath ? resolve(dataMachinePath, "vendor", "wordpress", "agents-api") : ""
+  if (bundled && existsSync(resolve(bundled, "agents-api.php"))) {
+    return bundled
   }
 
   return defaultSiblingComponentPath("agents-api", "agents-api.php")

--- a/tests/agent-runtime-components.test.ts
+++ b/tests/agent-runtime-components.test.ts
@@ -40,9 +40,15 @@ try {
   mkdirSync(workspace, { recursive: true })
   chdir(workspace)
   const defaultMounts = agentRuntimeMounts(parseAgentRuntimeProbeOptions([], parseMount))
-  assert.equal(defaultMounts.find((mount) => mount.metadata?.slug === "agents-api"), undefined)
+  assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "agents-api")?.source, bundledAgentsApi)
   assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "data-machine")?.source, dataMachine)
   assertSamePath(defaultMounts.find((mount) => mount.metadata?.slug === "data-machine-code")?.source, dataMachineCode)
+
+  process.env.CONTAINED_RUNTIME_COMPONENT_PATHS = [dataMachine, dataMachineCode].join(",")
+  const configuredMounts = agentRuntimeMounts(parseAgentRuntimeProbeOptions([], parseMount))
+  assertSamePath(configuredMounts.find((mount) => mount.metadata?.slug === "data-machine")?.source, dataMachine)
+  assertSamePath(configuredMounts.find((mount) => mount.metadata?.slug === "data-machine-code")?.source, dataMachineCode)
+  delete process.env.CONTAINED_RUNTIME_COMPONENT_PATHS
 
   rmSync(dataMachine, { recursive: true, force: true })
   const defaultAgentsApi = join(root, "agents-api")
@@ -54,7 +60,6 @@ try {
   const explicitAgentsApi = join(root, "explicit-agents-api")
   mkdirSync(explicitAgentsApi, { recursive: true })
   writeFileSync(join(explicitAgentsApi, "agents-api.php"), "<?php\n/* Plugin Name: Agents API */\n")
-  process.env.WP_CODEBOX_AGENTS_API_PATH = defaultAgentsApi
   const explicitMount = agentRuntimeMounts(parseAgentRuntimeProbeOptions(["--agents-api", explicitAgentsApi], parseMount))
     .find((mount) => mount.metadata?.slug === "agents-api")
   assertSamePath(explicitMount?.source, explicitAgentsApi)

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -7,6 +7,7 @@ import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
 import { agentTaskRunExitCode, normalizeAgentTaskRunCliInput } from "../packages/cli/src/commands/agent-task-run.js"
+import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
 
@@ -191,6 +192,16 @@ assert.equal(agentRecipePolicy.commands.includes("wordpress.run-php"), true)
 assert.equal(agentRecipePolicy.commands.includes("wordpress.wp-cli"), true)
 assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run"), false)
 
+const generatedAgentSandboxPhp = agentSandboxRunCode("Verify registry adapter", "echo 'ok';", [], [])
+assert.doesNotMatch(generatedAgentSandboxPhp, /DataMachine\\Core\\Database\\Agents\\Agents|data_machine_agent_create_failed|agents-api\/agents-api\.php/)
+const generatedDefaultAgentPhp = await resolveSandboxTaskCode({
+  task: "Verify registry adapter",
+  agent: "wp-codebox-sandbox",
+  sandboxToolPolicy: { schema: "wp-codebox/sandbox-tool-policy/v1", version: 1, tools: [] },
+})
+assert.doesNotMatch(generatedDefaultAgentPhp, /DataMachine\\Core\\Database\\Agents\\Agents|data_machine_agent_create_failed/)
+assert.match(generatedDefaultAgentPhp, /wp_codebox_runtime_agent_registry_ensure_agent/)
+
 const agentRecipeTemp = mkdtempSync(join(tmpdir(), "wp-codebox-agent-recipe-test-"))
 const originalCwd = cwd()
 const originalAgentsApiPath = process.env.WP_CODEBOX_AGENTS_API_PATH
@@ -233,8 +244,8 @@ try {
   }, normalizeTaskInput({ goal: "Verify generic runtime propagation" }), "latest")
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
-  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), false)
-  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), false)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), true)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), true)
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine"), true)
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine-code"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), true)
@@ -243,6 +254,7 @@ try {
   const genericRuntimeComponentsArg = genericSandboxStepArgs.find((arg) => arg.startsWith("runtime-component-contracts-json=")) ?? "runtime-component-contracts-json=[]"
   const genericRuntimeComponents = JSON.parse(genericRuntimeComponentsArg.slice("runtime-component-contracts-json=".length)) as Array<{ slug?: string }>
   assert.equal(genericRuntimeComponents.some((component) => component.slug === "wordpress-plugin"), true)
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "agents-api"), true)
   assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine"), true)
   assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine-code"), true)
 
@@ -250,7 +262,11 @@ try {
     goal: "Verify extra plugin propagation",
     artifacts_path: artifactsPath,
     provider_plugin_paths: [providerSource],
-    component_contracts: [{ slug: "agents-api", source: agentsApiSource, pluginFile: "agents-api/agents-api.php", loadAs: "mu-plugin" }],
+    component_contracts: [
+      { slug: "agents-api", source: agentsApiSource, pluginFile: "agents-api/agents-api.php", loadAs: "mu-plugin" },
+      { slug: "data-machine", source: dataMachineSource, pluginFile: "data-machine/data-machine.php", loadAs: "mu-plugin" },
+      { slug: "data-machine-code", source: dataMachineCodeSource, pluginFile: "data-machine-code/data-machine-code.php", loadAs: "mu-plugin" },
+    ],
     extra_plugins: [{
       source: bridgeSource,
       slug: "agent-runtime-tool-bridge",


### PR DESCRIPTION
## Summary
- Preserve the default internal agentic runtime based on Data Machine, Data Machine Code, and Agents API.
- Keep runtime component discovery internal to Codebox rather than requiring consumers to compose substrate APIs.
- Replace generated sandbox PHP direct agent registry calls with a generic runtime registry filter boundary.

## Testing
- npm run test:agent-task-contracts
- npx tsx tests/agent-runtime-components.test.ts
- npx tsx tests/docs-boundary-language.test.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the code changes.