### PR TITLE
Add public browser runtime contract

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -280,10 +280,14 @@ final class WP_Codebox_Browser_Task_Builder {
 		$preview_boot     = self::browser_preview_boot_config( $session );
 		$blueprint_ref    = self::browser_blueprint_ref( self::browser_prepared_runtime_from_envelope( $session, $preview_boot ), $session );
 		$preview_lease    = self::preview_lease_from_session( $session );
+		$runtime_access   = self::runtime_access_from_session( $session );
+		$runtime_readiness = self::browser_runtime_readiness_dto( $session );
+		$runtime_capabilities = self::browser_runtime_capabilities_dto( $session );
 
 		$dto = array_filter(
 			array(
 				'schema'           => 'wp-codebox/browser-session-product-dto/v1',
+				'dto_schema'       => 'wp-codebox/browser-executable-session/v1',
 				'source_schema'    => (string) ( $session['schema'] ?? '' ),
 				'success'          => (bool) ( $session['success'] ?? false ),
 				'status'           => (string) ( $session['status'] ?? ( true === ( $session['success'] ?? false ) ? 'ready' : '' ) ),
@@ -291,6 +295,7 @@ final class WP_Codebox_Browser_Task_Builder {
 				'execution_scope'  => (string) ( $session['execution_scope'] ?? '' ),
 				'permission_model' => (string) ( $session['permission_model'] ?? '' ),
 				'session_id'       => (string) ( $session_envelope['id'] ?? $session['session_id'] ?? '' ),
+				'executable_session' => self::browser_executable_session_dto( $session, $preview_boot, $preview_lease, $blueprint_ref, $runtime_access, $runtime_readiness, $runtime_capabilities ),
 				'contained_site'   => is_array( $session['contained_site'] ?? null ) ? self::compact_public_value( $session['contained_site'] ) : array(),
 				'task'             => (string) ( $session['task'] ?? $task_input['goal'] ?? '' ),
 				'target'           => is_array( $task_input['target'] ?? null ) ? self::compact_public_value( $task_input['target'] ) : array(),
@@ -301,7 +306,9 @@ final class WP_Codebox_Browser_Task_Builder {
 				'preview_lease'    => $preview_lease,
 				'blueprint_ref'    => $blueprint_ref,
 				'preview_reference' => self::browser_product_preview_reference( $session, $preview_boot, $preview_lease, $blueprint_ref ),
-				'runtime_access'   => self::runtime_access_from_session( $session ),
+				'runtime_access'   => $runtime_access,
+				'runtime_capabilities' => $runtime_capabilities,
+				'runtime_readiness' => $runtime_readiness,
 				'preview_ref'      => self::browser_preview_ref( $session ),
 				'signals'          => self::compact_public_value( $signals ),
 				'artifact_refs'    => self::browser_artifact_refs( $session ),
@@ -320,6 +327,91 @@ final class WP_Codebox_Browser_Task_Builder {
 		 * @param array<string,mixed> $session Source browser session contract.
 		 */
 		return function_exists( 'apply_filters' ) ? apply_filters( 'wp_codebox_browser_session_product_dto', $dto, $session ) : $dto;
+	}
+
+	/** @param array<string,mixed> $session Browser session contract. @param array<string,mixed> $preview_boot Preview boot DTO. @param array<string,mixed> $preview_lease Preview lease DTO. @param array<string,mixed> $blueprint_ref Blueprint ref DTO. @param array<string,mixed> $runtime_access Runtime access DTO. @param array<string,mixed> $runtime_readiness Runtime readiness DTO. @param array<string,mixed> $runtime_capabilities Runtime capabilities DTO. @return array<string,mixed> */
+	private static function browser_executable_session_dto( array $session, array $preview_boot, array $preview_lease, array $blueprint_ref, array $runtime_access, array $runtime_readiness, array $runtime_capabilities ): array {
+		$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
+		$contained_site   = is_array( $session['contained_site'] ?? null ) ? self::compact_public_value( $session['contained_site'] ) : array();
+
+		return array_filter(
+			array(
+				'schema'               => 'wp-codebox/browser-executable-session/v1',
+				'success'              => (bool) ( $session['success'] ?? false ),
+				'session_id'           => (string) ( $session_envelope['id'] ?? $session['session_id'] ?? '' ),
+				'status'               => (string) ( $session['status'] ?? ( true === ( $session['success'] ?? false ) ? 'ready' : '' ) ),
+				'execution'            => (string) ( $session['execution'] ?? '' ),
+				'execution_scope'      => (string) ( $session['execution_scope'] ?? '' ),
+				'permission_model'     => (string) ( $session['permission_model'] ?? '' ),
+				'preview'              => $preview_lease,
+				'preview_ref'          => self::browser_preview_ref( $session ),
+				'preview_boot'         => $preview_boot,
+				'blueprint_ref'        => $blueprint_ref,
+				'runtime_access'       => $runtime_access,
+				'runtime_capabilities' => $runtime_capabilities,
+				'runtime_readiness'    => $runtime_readiness,
+				'contained_site'       => $contained_site,
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */
+	private static function browser_runtime_capabilities_dto( array $session ): array {
+		$playground = is_array( $session['playground'] ?? null ) ? $session['playground'] : array();
+		$runtime    = is_array( $session['runtime'] ?? null ) ? $session['runtime'] : array();
+		$task_input = is_array( $session['task_input'] ?? null ) ? $session['task_input'] : array();
+		$profile    = is_array( $task_input['runtime_profile'] ?? null ) ? $task_input['runtime_profile'] : array();
+		$capabilities = array();
+
+		foreach ( is_array( $playground['capabilities'] ?? null ) ? $playground['capabilities'] : array() as $name => $enabled ) {
+			if ( true === (bool) $enabled && is_string( $name ) && '' !== $name ) {
+				$capabilities[] = 'browser:' . $name;
+			}
+		}
+		foreach ( array( $session['runtime_capabilities'] ?? array(), $runtime['capabilities'] ?? array(), $profile['capabilities'] ?? array(), $task_input['runtime_capabilities'] ?? array() ) as $items ) {
+			foreach ( is_array( $items ) ? $items : array() as $item ) {
+				if ( is_scalar( $item ) && '' !== trim( (string) $item ) ) {
+					$capabilities[] = trim( (string) $item );
+				}
+			}
+		}
+
+		$capabilities = array_values( array_unique( array_filter( $capabilities ) ) );
+		return array_filter(
+			array(
+				'schema'       => 'wp-codebox/browser-runtime-capabilities/v1',
+				'capabilities' => $capabilities,
+			),
+			static fn( mixed $value ): bool => array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */
+	private static function browser_runtime_readiness_dto( array $session ): array {
+		$signals = is_array( $session['signals'] ?? null ) ? $session['signals'] : array();
+		$ready_to_code = is_array( $signals['ready_to_code'] ?? null ) ? $signals['ready_to_code'] : array();
+		$requirements = array();
+		foreach ( is_array( $ready_to_code['requirements'] ?? null ) ? $ready_to_code['requirements'] : array() as $name => $ready ) {
+			if ( is_string( $name ) && '' !== $name ) {
+				$requirements[ $name ] = (bool) $ready;
+			}
+		}
+
+		$missing = array_values( array_filter( array_map( 'strval', is_array( $ready_to_code['missing'] ?? null ) ? $ready_to_code['missing'] : array() ), static fn( string $value ): bool => '' !== $value ) );
+		$status  = true === ( $ready_to_code['emitted'] ?? false ) ? 'ready' : ( empty( $ready_to_code ) ? 'unknown' : 'blocked' );
+
+		return array_filter(
+			array(
+				'schema'       => 'wp-codebox/browser-runtime-readiness/v1',
+				'status'       => $status,
+				'ready'        => 'ready' === $status,
+				'requirements' => $requirements,
+				'missing'      => $missing,
+				'message'      => (string) ( $ready_to_code['message'] ?? '' ),
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
 	}
 
 	/** @param array<string,mixed> $session Browser session contract. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -2002,6 +2002,17 @@ public static function create_browser_playground_session( array $input ): array|
 		'contained_site' => $contained_site,
 		'site_blueprint_artifact' => $site_blueprint_artifact,
 		'materialization' => $materialization,
+		'runtime_capabilities' => array_values(
+			array_unique(
+				array_filter(
+					array_merge(
+						array_map( 'strval', is_array( $input['runtime_capabilities'] ?? null ) ? $input['runtime_capabilities'] : array() ),
+						array_map( 'strval', is_array( $input['runtime']['capabilities'] ?? null ) ? $input['runtime']['capabilities'] : array() ),
+						array_map( 'strval', is_array( $runtime['capabilities'] ?? null ) ? $runtime['capabilities'] : array() )
+					)
+				)
+			)
+		),
 		'playground' => array(
 			'client_module_url'  => $playground['client_module_url'],
 			'remote_url'         => $playground['remote_url'],

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -427,6 +427,7 @@ private static function browser_product_dto_schema(): array {
 			'permission_model' => array( 'type' => 'string' ),
 			'status'           => array( 'type' => 'string' ),
 			'session_id'       => array( 'type' => 'string' ),
+			'executable_session' => self::browser_executable_session_schema(),
 			'session'          => array( 'type' => 'object' ),
 			'contained_site'   => self::browser_contained_site_schema(),
 			'primary'          => array( 'type' => 'object' ),
@@ -438,6 +439,8 @@ private static function browser_product_dto_schema(): array {
 			'model'            => array( 'type' => 'string' ),
 			'preview_boot'     => array( 'type' => 'object' ),
 			'runtime_access'   => array( 'type' => 'object' ),
+			'runtime_capabilities' => self::browser_runtime_capabilities_schema(),
+			'runtime_readiness' => self::browser_runtime_readiness_schema(),
 			'preview_ref'      => array( 'type' => 'object' ),
 			'artifact_refs'    => array( 'type' => 'array', 'items' => array( 'type' => 'object' ) ),
 			'signals'          => array( 'type' => 'object' ),
@@ -445,6 +448,59 @@ private static function browser_product_dto_schema(): array {
 			'diagnostics'      => array( 'type' => 'object' ),
 			'execution_metrics' => array( 'type' => 'object' ),
 			'provenance'       => array( 'type' => 'object' ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function browser_executable_session_schema(): array {
+	return array(
+		'type'        => 'object',
+		'description' => 'Codebox-owned public executable browser session DTO. Hosts can store and hand this to browser clients without raw Playground blueprints, package internals, runtime recipes, sandbox paths, or downstream implementation names.',
+		'properties'  => array(
+			'success'              => array( 'type' => 'boolean' ),
+			'schema'               => array( 'type' => 'string', 'const' => 'wp-codebox/browser-executable-session/v1' ),
+			'session_id'           => array( 'type' => 'string' ),
+			'status'               => array( 'type' => 'string' ),
+			'execution'            => array( 'type' => 'string' ),
+			'execution_scope'      => array( 'type' => 'string' ),
+			'permission_model'     => array( 'type' => 'string' ),
+			'preview'              => array( 'type' => 'object' ),
+			'preview_ref'          => array( 'type' => 'object' ),
+			'preview_boot'         => array( 'type' => 'object' ),
+			'blueprint_ref'        => array( 'type' => 'object' ),
+			'runtime_access'       => array( 'type' => 'object' ),
+			'runtime_capabilities' => self::browser_runtime_capabilities_schema(),
+			'runtime_readiness'    => self::browser_runtime_readiness_schema(),
+			'contained_site'       => self::browser_contained_site_schema(),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function browser_runtime_capabilities_schema(): array {
+	return array(
+		'type'        => 'object',
+		'description' => 'Product-safe browser runtime capability summary. Values name portable capabilities only and omit package, plugin, provider, and source implementation details.',
+		'properties'  => array(
+			'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/browser-runtime-capabilities/v1' ),
+			'capabilities' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+		),
+	);
+}
+
+/** @return array<string,mixed> */
+private static function browser_runtime_readiness_schema(): array {
+	return array(
+		'type'        => 'object',
+		'description' => 'Product-safe browser runtime readiness summary. It exposes readiness booleans and missing portable requirements without raw dependency plans or implementation diagnostics.',
+		'properties'  => array(
+			'schema'       => array( 'type' => 'string', 'const' => 'wp-codebox/browser-runtime-readiness/v1' ),
+			'status'       => array( 'type' => 'string', 'enum' => array( 'ready', 'blocked', 'unknown' ) ),
+			'ready'        => array( 'type' => 'boolean' ),
+			'requirements' => array( 'type' => 'object' ),
+			'missing'      => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'message'      => array( 'type' => 'string' ),
 		),
 	);
 }

--- a/tests/browser-session-public-dto.test.ts
+++ b/tests/browser-session-public-dto.test.ts
@@ -34,7 +34,9 @@ $input = array(
 		'artifact_base_path' => '/wordpress/wp-content/uploads/wp-codebox/artifacts/session-public-dto',
 		'artifact_base_url' => '/wp-content/uploads/wp-codebox/artifacts/session-public-dto',
 	),
+	'runtime_capabilities' => array( 'browser:preview' ),
 	'runtime' => array(
+		'capabilities' => array( 'browser:materialize' ),
 		'prepared' => array(
 			'enabled' => true,
 			'cache' => false,
@@ -56,27 +58,64 @@ $raw_materializer = WP_Codebox_Abilities::create_browser_materializer_contract( 
 $task_contract = WP_Codebox_Abilities::create_browser_task_contract( $input );
 $raw_task_contract = WP_Codebox_Abilities::create_browser_task_contract( $input + array( 'include_raw_browser_task_contract' => true ) );
 
-echo json_encode( array( 'public' => $public, 'raw' => $raw, 'materializer' => $materializer, 'raw_materializer' => $raw_materializer, 'task_contract' => $task_contract, 'raw_task_contract' => $raw_task_contract ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array(
+	'public' => $public,
+	'raw' => array(
+		'schema' => $raw['schema'] ?? null,
+		'product' => $raw['product'] ?? null,
+		'playground_blueprint_steps_is_array' => is_array( $raw['playground']['blueprint']['steps'] ?? null ),
+		'recipe_runtime_backend' => $raw['recipe']['runtime']['backend'] ?? null,
+	),
+	'materializer' => $materializer,
+	'raw_materializer' => array(
+		'schema' => $raw_materializer['schema'] ?? null,
+		'compact' => $raw_materializer['compact'] ?? null,
+		'playground_blueprint_steps_is_array' => is_array( $raw_materializer['playground']['blueprint']['steps'] ?? null ),
+	),
+	'task_contract' => $task_contract,
+	'raw_task_contract' => array(
+		'schema' => $raw_task_contract['schema'] ?? null,
+		'compact' => $raw_task_contract['compact'] ?? null,
+		'primary_playground_blueprint_steps_is_array' => is_array( $raw_task_contract['primary']['playground']['blueprint']['steps'] ?? null ),
+	),
+), JSON_UNESCAPED_SLASHES );
 `)
 
 function assertPublicDtoDoesNotExposeInternals(value: unknown) {
   const encoded = JSON.stringify(value)
   assert.equal(encoded.includes("must-not-leak"), false)
   assert.equal(encoded.includes("/wordpress/"), false, encoded)
-  for (const key of ["playground", "runtime", "recipe", "task_payload", "executable", "materialization"]) {
+  for (const key of ["playground", "runtime", "recipe", "task_payload", "materialization"]) {
     assert.equal(Object.prototype.hasOwnProperty.call(value as Record<string, unknown>, key), false, `${key} must not be exposed`)
   }
 }
 
 assert.equal(result.public.schema, "wp-codebox/browser-session-product-dto/v1")
+assert.equal(result.public.dto_schema, "wp-codebox/browser-executable-session/v1")
 assert.equal(result.public.source_schema, "wp-codebox/browser-playground-session/v1")
 assert.equal(result.public.session_id, "session-public-dto")
+assert.equal(result.public.executable_session.schema, "wp-codebox/browser-executable-session/v1")
+assert.equal(result.public.executable_session.session_id, "session-public-dto")
+assert.equal(result.public.executable_session.status, "ready")
+assert.equal(result.public.executable_session.preview_ref.schema, "wp-codebox/browser-preview-ref/v1")
+assert.equal(result.public.executable_session.preview.schema, "wp-codebox/preview-lease/v1")
+assert.equal(result.public.executable_session.preview_boot.blueprint_ref, result.public.preview_boot.blueprint_ref)
+assert.equal(result.public.executable_session.blueprint_ref.ref, result.public.blueprint_ref.ref)
+assert.equal(result.public.executable_session.runtime_access.schema, "wp-codebox/runtime-access/v1")
 assert.equal(result.public.preview_ref.schema, "wp-codebox/browser-preview-ref/v1")
 assert.equal(result.public.preview_ref.preview_id.startsWith("preview-"), true)
 assert.equal(result.public.preview_ref.site_id, "public-dto-site")
 assert.equal(result.public.runtime_access.schema, "wp-codebox/runtime-access/v1")
 assert.equal(result.public.runtime_access.preview_url, "/preview/index.html")
 assert.equal(result.public.runtime_access.lease.schema, "wp-codebox/preview-lease/v1")
+assert.equal(result.public.runtime_capabilities.schema, "wp-codebox/browser-runtime-capabilities/v1")
+assert.deepEqual([...result.public.runtime_capabilities.capabilities].sort(), ["browser:compile_blueprint", "browser:materialize", "browser:preview", "browser:run_blueprint", "browser:run_php", "browser:write_file"].sort())
+assert.deepEqual(result.public.executable_session.runtime_capabilities, result.public.runtime_capabilities)
+assert.equal(result.public.runtime_readiness.schema, "wp-codebox/browser-runtime-readiness/v1")
+assert.equal(result.public.runtime_readiness.status, "ready")
+assert.equal(result.public.runtime_readiness.ready, true)
+assert.deepEqual(result.public.runtime_readiness.missing, undefined)
+assert.deepEqual(result.public.executable_session.runtime_readiness, result.public.runtime_readiness)
 assert.match(result.public.preview_boot.blueprint_ref, /^prepared:public-dto-site:[a-f0-9]{64}$/)
 assert.equal(result.public.preview_boot.blueprint_ref_dto.hydrator_ability, "wp-codebox/hydrate-browser-blueprint-ref")
 assert.equal(result.public.preview_ref.boot_ref, result.public.preview_boot.blueprint_ref)
@@ -94,11 +133,12 @@ assert.equal(JSON.stringify(result.public).includes("must-not-leak"), false)
 assert.equal(result.public.preview_boot.artifacts.base_path, undefined)
 assert.equal(result.public.preview_boot.runtime_access.preview_url, "/preview/index.html")
 assertPublicDtoDoesNotExposeInternals(result.public)
+assertPublicDtoDoesNotExposeInternals(result.public.executable_session)
 
 assert.equal(result.raw.schema, "wp-codebox/browser-playground-session/v1")
 assert.equal(result.raw.product.schema, "wp-codebox/browser-session-product-dto/v1")
-assert.equal(Array.isArray(result.raw.playground.blueprint.steps), true)
-assert.equal(result.raw.recipe.runtime.backend, "wordpress-playground")
+assert.equal(result.raw.playground_blueprint_steps_is_array, true)
+assert.equal(result.raw.recipe_runtime_backend, "wordpress-playground")
 
 assert.equal(result.materializer.schema, "wp-codebox/browser-materializer-product-dto/v1")
 assert.equal(result.materializer.source_schema, "wp-codebox/browser-materializer-contract/v1")
@@ -107,7 +147,7 @@ assert.deepEqual(result.materializer.artifact_refs, result.public.artifact_refs)
 assertPublicDtoDoesNotExposeInternals(result.materializer)
 
 assert.equal(result.raw_materializer.schema, "wp-codebox/browser-materializer-contract/v1")
-assert.equal(Array.isArray(result.raw_materializer.playground.blueprint.steps), true)
+assert.equal(result.raw_materializer.playground_blueprint_steps_is_array, true)
 assert.equal(result.raw_materializer.compact.schema, "wp-codebox/browser-materializer-product-dto/v1")
 
 assert.equal(result.task_contract.schema, "wp-codebox/browser-task-product-dto/v1")
@@ -116,6 +156,6 @@ assertPublicDtoDoesNotExposeInternals(result.task_contract)
 
 assert.equal(result.raw_task_contract.schema, "wp-codebox/browser-task-contract/v1")
 assert.equal(result.raw_task_contract.compact.schema, "wp-codebox/browser-task-product-dto/v1")
-assert.equal(Array.isArray(result.raw_task_contract.primary.playground.blueprint.steps), true)
+assert.equal(result.raw_task_contract.primary_playground_blueprint_steps_is_array, true)
 
 console.log("browser session public dto ok")

--- a/tests/browser-task-contract-product-dto.test.ts
+++ b/tests/browser-task-contract-product-dto.test.ts
@@ -16,7 +16,11 @@ assert.doesNotMatch(descriptors, /'source_digest'\s*=>\s*array\(\s*'description'
 assert.match(descriptors, /'source_digest'\s*=>\s*array\(\s*'type'\s*=>\s*array\(\s*'string',\s*'object'\s*\)/)
 assert.match(schemas, /private static function browser_materializer_contract_schema\(\): array \{\s*return self::browser_product_dto_schema\(\);\s*\}/)
 assert.match(schemas, /private static function browser_task_contract_schema\(\): array \{\s*return self::browser_product_dto_schema\(\);\s*\}/)
+assert.match(schemas, /private static function browser_executable_session_schema\(\): array \{[\s\S]*'const'\s*=>\s*'wp-codebox\/browser-executable-session\/v1'/)
+assert.match(schemas, /'runtime_capabilities'\s*=>\s*self::browser_runtime_capabilities_schema\(\)/)
+assert.match(schemas, /'runtime_readiness'\s*=>\s*self::browser_runtime_readiness_schema\(\)/)
 assert.match(schemas, /private static function browser_internal_materializer_contract_schema\(\): array \{[\s\S]*'task_payload'\s*=>\s*array\( 'type' => 'object' \)/)
 assert.doesNotMatch(schemas.match(/private static function browser_product_dto_schema\(\): array \{[\s\S]*?\n\}/)?.[0] ?? "", /'task_payload'|'playground'|'runtime'|'recipe'|'materialization'/)
+assert.doesNotMatch(schemas.match(/private static function browser_executable_session_schema\(\): array \{[\s\S]*?\n\}/)?.[0] ?? "", /'task_payload'|'playground'|'runtime'|'recipe'|'materialization'/)
 
 console.log("browser task contract product dto ok")


### PR DESCRIPTION
## Summary
- Add a public executable browser session DTO for host-to-browser handoff.
- Expose product-safe runtime capabilities and readiness fields.
- Keep raw runtime internals out of the public browser session DTO.

## Testing
- npm ci
- npm run test:browser-session-public-dto
- npx tsx tests/browser-task-contract-product-dto.test.ts
- npm run test:browser-task-builder
- npm run test:schema-parity
- php -l on edited PHP files

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the code changes.