### PR TITLE
Tighten public boundary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ explicitly allow each registered canonical tool name before a sandbox can invoke
 it.
 
 ```ts
-import { createHostToolRegistry, createRuntime } from "@automattic/wp-codebox-core"
-import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
+import { createHostToolRegistry } from "@automattic/wp-codebox-core"
+import { createWordPressRuntime } from "@automattic/wp-codebox-playground/public"
 
 const hostTools = createHostToolRegistry([
   {
@@ -132,8 +132,7 @@ const hostTools = createHostToolRegistry([
   },
 ])
 
-const runtime = await createRuntime({
-  backend: "wordpress-playground",
+const runtime = await createWordPressRuntime({
   environment: { kind: "wordpress", version: "latest" },
   policy: {
     network: "deny",
@@ -143,7 +142,7 @@ const runtime = await createRuntime({
     approvals: "never",
   },
   hostTools,
-}, createPlaygroundRuntimeBackend())
+})
 
 const result = await runtime.execute({
   command: "client/echo",
@@ -395,7 +394,7 @@ Expected shape:
 {
   "success": true,
   "runtime": {
-    "backend": "wordpress-playground",
+    "backend": "wordpress",
     "status": "destroyed"
   },
   "execution": {
@@ -510,7 +509,7 @@ kimaki tunnel -- sh -c 'npm run wp-codebox -- run \
 
 When a caller exposes the local Playground through a tunnel or proxy, pass `--preview-public-url <url>` to report that public URL in `artifacts.preview.url`, `metadata.json`, and `files/review.json`. WP Codebox also passes the same URL to Playground as `site-url` and defines `WP_HOME` / `WP_SITEURL` in the sandbox config, so WordPress-generated links and canonical redirects align with the public preview URL. The local proxy URL remains recorded as `preview.localUrl`. If the fixed port is already occupied, WP Codebox fails clearly with `EADDRINUSE` and the requested `--preview-port` value.
 
-Remote-host previews can opt into `--preview-bind <host>` with `--preview-port`. The flag changes the WP Codebox preview proxy bind address only; the upstream Playground server remains loopback-bound because `@wp-playground/cli` does not expose host/bind control yet. The default stays `127.0.0.1`. Use `--preview-bind 0.0.0.0` only behind trusted firewall, tunnel, or reverse-proxy controls because the sandbox preview is reachable for the hold duration. Track the upstream Playground bind-host API gap in https://github.com/WordPress/wordpress-playground/issues/3681.
+Remote-host previews can opt into `--preview-bind <host>` with `--preview-port`. The flag changes the WP Codebox preview proxy bind address only; the upstream runtime server remains loopback-bound until backend bind-host control is available. The default stays `127.0.0.1`. Use `--preview-bind 0.0.0.0` only behind trusted firewall, tunnel, or reverse-proxy controls because the sandbox preview is reachable for the hold duration.
 
 ## Runtime Episodes
 
@@ -520,26 +519,21 @@ observations, step executions, optional per-step observations, snapshots, and
 artifact bundles without knowing benchmark, reward, or scenario semantics.
 
 ```ts
-import { createRuntimeEpisode } from "@automattic/wp-codebox-core"
-import { createPlaygroundRuntimeBackend } from "@automattic/wp-codebox-playground"
+import { createWordPressEpisode } from "@automattic/wp-codebox-playground/public"
 
-const episode = await createRuntimeEpisode(
-  {
-    runtime: {
-      backend: "wordpress-playground",
-      environment: { kind: "wordpress", version: "7.0", blueprint: { steps: [] } },
-      policy: {
-        network: "deny",
-        filesystem: "readwrite-mounts",
-        commands: ["wordpress.wp-cli", "wordpress.run-php"],
-        secrets: "none",
-        approvals: "never",
-      },
+const episode = await createWordPressEpisode({
+  runtime: {
+    environment: { kind: "wordpress", version: "7.0", blueprint: { steps: [] } },
+    policy: {
+      network: "deny",
+      filesystem: "readwrite-mounts",
+      commands: ["wordpress.wp-cli", "wordpress.run-php"],
+      secrets: "none",
+      approvals: "never",
     },
-    stepObservation: { type: "runtime-info" },
   },
-  createPlaygroundRuntimeBackend(),
-)
+  stepObservation: { type: "runtime-info" },
+})
 
 await episode.step({ command: "wordpress.wp-cli", args: ["command=post list"] })
 const artifacts = await episode.collectArtifacts({ includeLogs: true })
@@ -911,9 +905,9 @@ External sources are explicit and CI-safe. WP Codebox validates URL-shaped sourc
         "pluginFile": "acme-helper/acme-helper.php"
       },
       {
-        "source": "../agents-api",
-        "slug": "agents-api",
-        "pluginFile": "agents-api/agents-api.php",
+        "source": "../caller-runtime-substrate",
+        "slug": "caller-runtime-substrate",
+        "pluginFile": "caller-runtime-substrate/caller-runtime-substrate.php",
         "activate": false,
         "loadAs": "mu-plugin"
       }
@@ -1222,7 +1216,7 @@ runtime-reference payload are best-effort diagnostics for failure enrichment.
   "provenance": {
     "task": { "kind": "agent-sandbox-run", "input": "Add a Dry Rub filter..." },
     "runtime": {
-      "backend": "wordpress-playground",
+      "backend": "wordpress",
       "version": "0.0.0",
       "wordpressVersion": "7.0"
     },
@@ -1367,7 +1361,7 @@ Generic caller-owned `request.json` payloads may use this shape:
   "model": "example-model",
   "provider_plugin_paths": ["/srv/runtime/ai-provider-example"],
   "component_contracts": [
-    { "slug": "agents-api", "path": "/srv/runtime/agents-api", "pluginFile": "agents-api/agents-api.php", "loadAs": "mu-plugin" },
+    { "slug": "caller-runtime-substrate", "path": "/srv/runtime/caller-runtime-substrate", "pluginFile": "caller-runtime-substrate/caller-runtime-substrate.php", "loadAs": "mu-plugin" },
     { "slug": "caller-runtime", "path": "/srv/runtime/caller-runtime", "pluginFile": "caller-runtime/caller-runtime.php", "loadAs": "mu-plugin" },
     { "slug": "caller-runtime-tools", "path": "/srv/runtime/caller-runtime-tools", "pluginFile": "caller-runtime-tools/caller-runtime-tools.php", "loadAs": "mu-plugin" }
   ],
@@ -1381,7 +1375,7 @@ Generic caller-owned `request.json` payloads may use this shape:
     }
   ],
   "runtime_stack_mounts": [
-    { "source": "/srv/runtime/agents-api", "target": "/runtime/agents-api", "mode": "readonly" }
+    { "source": "/srv/runtime/caller-runtime-substrate", "target": "/runtime/caller-runtime-substrate", "mode": "readonly" }
   ],
   "runtime_overlays": [
     { "id": "caller-runtime-overlay", "source": "/srv/runtime/caller-runtime-overlay" }

--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -119,9 +119,9 @@ run. Each entry requires `source` and may include `slug`, `pluginFile`,
         "activate": false
       },
       {
-        "source": "../agents-api",
-        "slug": "agents-api",
-        "pluginFile": "agents-api/agents-api.php",
+        "source": "../caller-runtime-substrate",
+        "slug": "caller-runtime-substrate",
+        "pluginFile": "caller-runtime-substrate/caller-runtime-substrate.php",
         "activate": false,
         "loadAs": "mu-plugin"
       }

--- a/docs/sandbox-session-contract.md
+++ b/docs/sandbox-session-contract.md
@@ -14,7 +14,7 @@ Parent control plane
       -> WP Codebox shells out to the CLI and captures artifacts
     <- returns wp-codebox/sandbox-session/v1 for correlation
 
-Disposable Playground sandbox
+Disposable browser sandbox
   may mount agent runtimes, coding tools, and provider plugins
   owns in-sandbox agent behavior only
 ```
@@ -22,7 +22,7 @@ Disposable Playground sandbox
 The host WP Codebox plugin receives parent job context through this session contract.
 External orchestrators consume the same abilities and artifact contracts.
 
-## Browser Playground Permission Model
+## Browser Runtime Permission Model
 
 `wp-codebox/create-browser-playground-session` returns an explicit browser
 session boundary:
@@ -40,14 +40,14 @@ session boundary:
 ```
 
 The `runtime-principal` permission model means the generated browser runner
-authorizes Agents API calls with a scoped runtime principal inside the disposable
-Playground site. The principal binds the call to the WP Codebox client,
+authorizes sandbox runtime calls with a scoped runtime principal inside the
+disposable WordPress site. The principal binds the call to the WP Codebox client,
 workspace, runtime type, and browser session instead of inheriting host-site user
 state. This is safe only because the browser runner executes in PHP-WASM inside
-the caller-owned Playground filesystem and cannot grant permissions on the host
+the caller-owned sandbox filesystem and cannot grant permissions on the host
 WordPress site.
 
-The generated PHP runner validates the expected Playground environment before it
+The generated PHP runner validates the expected disposable runtime before it
 registers runtime-principal authorization. If the runner is copied into a normal
 host WordPress install, it fails with `wp_codebox_browser_runner_not_playground`
 instead of executing the requested sandbox invocation.

--- a/examples/agent-runtime/README.md
+++ b/examples/agent-runtime/README.md
@@ -1,16 +1,16 @@
 # Agent Runtime Stack Probe
 
-This example proves the intended guest application surface: a WordPress Playground sandbox with caller-supplied agent runtime components mounted and activated.
+This example proves the intended guest application surface: a contained WordPress sandbox with caller-supplied agent runtime components mounted and activated.
 
 Set local checkout paths, then run the preset:
 
 ```bash
-AGENTS_API_PATH=/path/to/agents-api \
+RUNTIME_SUBSTRATE_PATH=/path/to/runtime-substrate \
 RUNTIME_ENGINE_PATH=/path/to/runtime-engine \
 RUNTIME_TOOLS_PATH=/path/to/runtime-tools \
 PROVIDER_PLUGIN_PATH=/path/to/ai-provider-plugin \
 npm run wp-codebox -- agent-runtime-probe \
-  --component agents-api="$AGENTS_API_PATH" \
+  --component runtime-substrate="$RUNTIME_SUBSTRATE_PATH" \
   --component runtime-engine="$RUNTIME_ENGINE_PATH" \
   --component runtime-tools="$RUNTIME_TOOLS_PATH" \
   --provider-plugin "$PROVIDER_PLUGIN_PATH" \

--- a/examples/recipes/cookbook/README.md
+++ b/examples/recipes/cookbook/README.md
@@ -6,7 +6,7 @@ against bbPress" or "drive my theme against seeded content."
 
 These are not internal correctness fixtures (the recipes in
 `examples/recipes/*.json` cover that). They are product fixtures: each one
-mounts a target plugin or theme, seeds a realistic host context via Playground
+mounts a target plugin or theme, seeds a realistic host context via contained-runtime
 blueprint steps, and is intended to be paired with `--preview-hold-seconds` for visual
 smoke testing.
 
@@ -25,7 +25,7 @@ files plus dry-run evidence limited to shareable metadata.
 
 ### `codex-agent-smoke.json`
 
-Runs a headless agent runtime inside a disposable WordPress Playground
+Runs a headless agent runtime inside a disposable contained WordPress
 sandbox using the Codex provider. This is the smallest end-to-end recipe for
 proving that WP Codebox can mount the agent runtime stack, overlay a
 `php-ai-client` branch with provider-supplied request auth, activate a Codex
@@ -35,7 +35,7 @@ provider plugin branch, and execute `agents/chat` through `wp-codebox.agent-sand
 uses explicit placeholder input paths so callers can see the full contract shape
 and replace each path with their prepared local checkout or artifact:
 
-- `/sample/prepared-component-stack/agents-api`
+- `/sample/prepared-component-stack/runtime-substrate`
 - `/sample/prepared-component-stack/runtime-engine`
 - `/sample/prepared-component-stack/runtime-tools`
 - `/sample/prepared-provider-stack/php-ai-client`
@@ -49,7 +49,7 @@ a dry-run plan with the sandbox backend, overlays, extra plugins, secret
 environment names, and resolved agent command arguments.
 
 - The component stack provides the WordPress plugins needed by the sandbox agent
-  runtime: `agents-api`, `runtime-engine`, and `runtime-tools`.
+  runtime: `runtime-substrate`, `runtime-engine`, and `runtime-tools`.
 - The provider stack provides the `php-ai-client` overlay and provider plugin
   selected by `provider=codex` and
   `provider-plugin-slugs=ai-provider-for-openai`.

--- a/examples/recipes/cookbook/claude-code-agent-smoke.json
+++ b/examples/recipes/cookbook/claude-code-agent-smoke.json
@@ -24,8 +24,8 @@
   "inputs": {
     "extra_plugins": [
       {
-        "source": "/sample/prepared-component-stack/agents-api",
-        "slug": "agents-api",
+        "source": "/sample/prepared-component-stack/runtime-substrate",
+        "slug": "runtime-substrate",
         "activate": true
       },
       {

--- a/examples/recipes/cookbook/codex-agent-smoke.json
+++ b/examples/recipes/cookbook/codex-agent-smoke.json
@@ -24,8 +24,8 @@
   "inputs": {
     "extra_plugins": [
       {
-        "source": "/sample/prepared-component-stack/agents-api",
-        "slug": "agents-api",
+        "source": "/sample/prepared-component-stack/runtime-substrate",
+        "slug": "runtime-substrate",
         "activate": true
       },
       {

--- a/examples/simple-plugin/README.md
+++ b/examples/simple-plugin/README.md
@@ -2,7 +2,7 @@
 
 Tiny WordPress plugin fixture for `wp-codebox run`.
 
-The demo mounts this directory into a disposable WordPress Playground-shaped runtime at:
+The demo mounts this directory into a disposable contained WordPress runtime at:
 
 ```text
 /wordpress/wp-content/plugins/simple-plugin

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "test:wordpress-plugin-public-runtime-abilities": "tsx tests/wordpress-plugin-public-runtime-abilities.test.ts",
     "test:recipe-source-packages": "tsx tests/recipe-source-packages.test.ts",
     "test:distribution-startup-probes": "tsx tests/distribution-startup-probes.test.ts",
+    "test:docs-boundary-language": "tsx tests/docs-boundary-language.test.ts",
     "test:path-policy-parity": "tsx tests/path-policy-parity.test.ts",
     "test:php-path-policy-parity": "php scripts/php-path-policy-parity-smoke.php",
     "test:php-provider-credential-boundary": "php scripts/php-provider-credential-boundary-smoke.php",

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
@@ -27,7 +27,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 		$descriptors = array(
 			'wp-codebox/hydrate-browser-blueprint-ref'      => array(
 				'label'               => 'Hydrate Browser Blueprint Ref',
-				'description'         => 'Resolve a product-safe prepared browser blueprint ref into an executable WordPress Playground blueprint without requiring consumers to store blueprint files.',
+				'description'         => 'Resolve a product-safe prepared browser blueprint ref into an executable contained WordPress runtime blueprint without requiring consumers to store blueprint files.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -52,8 +52,8 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 				'meta'                => array( 'show_in_rest' => true ),
 			),
 			'wp-codebox/create-browser-playground-session'    => array(
-				'label'               => 'Create Browser Playground Session',
-				'description'         => 'Prepare a WP Codebox browser sandbox session without requiring the host to run the WP Codebox CLI or Node. WordPress Playground is the current implementation runtime, not a caller-owned API namespace.',
+				'label'               => 'Create Browser Sandbox Session',
+				'description'         => 'Prepare a WP Codebox browser sandbox session without requiring the host to run the WP Codebox CLI or Node.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -67,7 +67,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/create-browser-materializer-contract' => array(
 				'label'               => 'Create Browser Materializer Contract',
-				'description'         => 'Prepare the WP Codebox browser materialization contract for an already-created parent browser session. The executable Playground recipe is an implementation detail of the current runtime backend.',
+				'description'         => 'Prepare the WP Codebox browser materialization contract for an already-created parent browser session. The executable runtime recipe is an implementation detail of the current backend.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -122,7 +122,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/get-browser-contained-site-status'    => array(
 				'label'               => 'Get Browser Contained Site Status',
-				'description'         => 'Resolve a durable browser-contained site handle into explicit prepared-runtime recoverability or live/current/materialized availability without creating a new Playground session.',
+				'description'         => 'Resolve a durable browser-contained site handle into explicit prepared-runtime recoverability or live/current/materialized availability without creating a new browser sandbox session.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -164,7 +164,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/preview-reuse-decision'              => array(
 				'label'               => 'Preview Reuse Decision',
-				'description'         => 'Return an explicit reuse/create/reload decision for a browser-contained preview site without creating a new Playground session.',
+				'description'         => 'Return an explicit reuse/create/reload decision for a browser-contained preview site without creating a new browser sandbox session.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -215,7 +215,6 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 						'input_hash'    => array( 'type' => 'string' ),
 						'runtime_profile' => array( 'type' => 'object' ),
 						'recovery'      => array( 'type' => 'object' ),
-						'playground'    => array( 'type' => 'object' ),
 						'preview_lease' => array( 'type' => 'object' ),
 						'session_id'    => array( 'type' => 'string' ),
 					),
@@ -255,7 +254,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/open-or-create-browser-contained-site' => array(
 				'label'               => 'Open or Create Browser Contained Site',
-				'description'         => 'Open a reusable browser-contained preview site when possible, otherwise create a fresh browser Playground session from the same task input.',
+				'description'         => 'Open a reusable browser-contained preview site when possible, otherwise create a fresh browser sandbox session from the same task input.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -297,7 +296,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/create-browser-contained-site-session' => array(
 				'label'               => 'Create Browser Contained Site Session',
-				'description'         => 'Create a browser-contained preview session and return a product-safe boot descriptor, preview lease, and startup diagnostics. Raw Playground boot internals remain available through legacy session envelopes and explicit hydration refs only.',
+				'description'         => 'Create a browser-contained preview session and return a product-safe boot descriptor, preview lease, and startup diagnostics. Runtime boot internals remain available through legacy session envelopes and explicit hydration refs only.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -333,7 +332,6 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 						'cache_key'     => array( 'type' => 'string' ),
 						'source_digest' => array( 'type' => array( 'string', 'object' ), 'description' => '64-character source digest string, or an object with a value field.' ),
 						'input_hash'    => array( 'type' => 'string' ),
-						'playground'    => array( 'type' => 'object' ),
 						'preview_lease' => array( 'type' => 'object' ),
 						'session_id'    => array( 'type' => 'string' ),
 					),
@@ -356,7 +354,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/preview-boot-ref' => array(
 				'label'               => 'Get Preview Boot Ref',
-				'description'         => 'Return the stable consumer preview boot ref DTO. The DTO exposes a blueprint hydration ref instead of inline Playground blueprint data.',
+				'description'         => 'Return the stable consumer preview boot ref DTO. The DTO exposes a blueprint hydration ref instead of inline runtime blueprint data.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -366,7 +364,6 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 						'cache_key'     => array( 'type' => 'string' ),
 						'source_digest' => array( 'type' => array( 'string', 'object' ), 'description' => '64-character source digest string, or an object with a value field.' ),
 						'input_hash'    => array( 'type' => 'string' ),
-						'playground'    => array( 'type' => 'object' ),
 						'preview_lease' => array( 'type' => 'object' ),
 					),
 				),
@@ -573,7 +570,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/persist-browser-artifact'            => array(
 				'label'               => 'Persist Browser Artifact',
-				'description'         => 'Persist browser-produced files from a disposable Playground session as a canonical WP Codebox artifact bundle.',
+				'description'         => 'Persist browser-produced files from a disposable browser sandbox session as a canonical WP Codebox artifact bundle.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
@@ -583,7 +580,7 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 						'authorization'    => $context['trusted_artifact_authorization_schema'],
 						'session_id'       => array(
 							'type'        => 'string',
-							'description' => 'Optional browser Playground session id that produced the artifact files.',
+							'description' => 'Optional browser sandbox session id that produced the artifact files.',
 						),
 						'session'          => array(
 							'type'        => 'object',

--- a/tests/docs-boundary-language.test.ts
+++ b/tests/docs-boundary-language.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { readFile } from "node:fs/promises"
+import { readdir, readFile } from "node:fs/promises"
 
 const forbiddenConsumerTerms = [
   /\bStudio Web\b/,
@@ -12,12 +12,27 @@ const forbiddenPublicImplementationTerms = [
   /\bData Machine\b/,
   /\bData Machine Code\b/,
   /\bAgents API\b/,
-  /\bWordPress Playground\b/,
   /\bgeneric Data Machine inputs\b/,
   /\bWP_Codebox_Agents_API_Adapter\b/,
   /\bagents\/[a-z0-9._/-]+/i,
   /\bGitSync\b/,
   /\bwp_agent_[a-z0-9_]+\b/,
+]
+
+const forbiddenPublicConsumerGuidanceTerms = [
+  /\bData Machine\b/i,
+  /\bData Machine Code\b/i,
+  /\bAgents API\b/i,
+  /\bagents-api\b/i,
+  /\bdatamachine\b/i,
+  /\bwp-coding-agents\b/i,
+]
+
+const forbiddenRawRuntimeGuidanceTerms = [
+  /createPlaygroundRuntimeBackend/,
+  /@wp-playground\//,
+  /\braw Playground\b/i,
+  /\bPlayground-shaped\b/i,
 ]
 
 const genericContractDocs = [
@@ -46,8 +61,27 @@ const publicBoundaryDocs = [
   "packages/wordpress-plugin/README.md",
 ]
 
+const publicConsumerRoots = ["README.md", "docs", "examples"]
+const publicDescriptorFiles = [
+  "packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php",
+]
+
 const root = new URL("..", import.meta.url)
 const violations: string[] = []
+
+async function collectTextFiles(path: string): Promise<string[]> {
+  if (!path.includes(".")) {
+    const entries = await readdir(new URL(`${path}/`, root), { withFileTypes: true })
+    const nested = await Promise.all(entries.map((entry) => collectTextFiles(`${path}/${entry.name}`)))
+    return nested.flat()
+  }
+
+  if (/\.(md|json|ts|js|ya?ml)$/.test(path)) {
+    return [path]
+  }
+
+  return []
+}
 
 for (const doc of genericContractDocs) {
   const source = await readFile(new URL(doc, root), "utf8")
@@ -89,6 +123,24 @@ assert.match(publicBoundaryText, /adapter config maps each operation to its\s+in
 assert.match(publicBoundaryText, /not mirror the monorepo-only\s+`\.\/internals` helper entrypoint/)
 for (const term of forbiddenPublicImplementationTerms) {
   assert.doesNotMatch(publicBoundaryText, term)
+}
+
+const publicConsumerFiles = (await Promise.all(publicConsumerRoots.map(collectTextFiles))).flat()
+for (const file of [...publicConsumerFiles, ...publicDescriptorFiles]) {
+  const source = await readFile(new URL(file, root), "utf8")
+  if (file === "docs/browser-runtime-dependency-audit.md" || file === "docs/portable-wp-codebox.md" || file === "docs/transfer-namespace-plan.md") {
+    continue
+  }
+
+  for (const term of forbiddenPublicConsumerGuidanceTerms) {
+    assert.doesNotMatch(source, term, `${file} must not teach public consumers host implementation names`)
+  }
+
+  if (file === "packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php" || file.endsWith("README.md")) {
+    for (const term of forbiddenRawRuntimeGuidanceTerms) {
+      assert.doesNotMatch(source, term, `${file} must not teach raw runtime internals`)
+    }
+  }
 }
 
 const runnerWorkspaceBackendContract = await readFile(new URL("docs/runner-workspace-backend-contract.md", root), "utf8")


### PR DESCRIPTION
## Summary
- Update public docs and examples to describe Codebox contracts instead of implementation substrates.
- Keep consumer-facing browser ability language backend-neutral.
- Add a docs boundary language test across README, docs, examples, and ability descriptors.

## Testing
- npm ci
- npm run build
- npm run test:docs-boundary-language
- npm run test:public-ability-aliases
- npm run test:wordpress-plugin-public-runtime-abilities

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the code changes.