### PR TITLE
Hide internal agent runtime substrate from public contracts

### DIFF
--- a/packages/runtime-core/src/public.ts
+++ b/packages/runtime-core/src/public.ts
@@ -5,7 +5,6 @@
  */
 export * from "./agent-runtime-workload.js"
 export * from "./agent-workload.js"
-export * from "./agent-task-recipe.js"
 export * from "./agent-task-run-result.js"
 export * from "./agent-terminal-result.js"
 export * from "./artifact-capture-policy.js"

--- a/packages/runtime-core/src/task-input.ts
+++ b/packages/runtime-core/src/task-input.ts
@@ -75,7 +75,7 @@ export type TaskInputRequest = Partial<Omit<TaskInput, "schema" | "version" | "g
 export const TASK_INPUT_JSON_SCHEMA = {
   $id: TASK_INPUT_SCHEMA,
   type: "object",
-  required: ["schema", "version", "goal", "target", "allowed_tools", "expected_artifacts", "structured_artifacts", "agent_bundles", "tool_bridge", "parent_tool_bridge", "sandbox_tool_policy", "policy", "context"],
+  required: ["schema", "version", "goal", "target", "allowed_tools", "expected_artifacts", "structured_artifacts", "tool_bridge", "parent_tool_bridge", "sandbox_tool_policy", "policy", "context"],
   properties: {
     schema: { type: "string", const: TASK_INPUT_SCHEMA, description: "Task input contract schema id." },
     version: { type: "integer", const: TASK_INPUT_VERSION, description: "Task input contract version." },

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -164,7 +164,10 @@ final class WP_Codebox_Agents_API_Adapter {
 			array(
 				'label'        => 'Agents API runtime adapter',
 				'kind'         => 'ability-adapter',
-				'capabilities' => array( 'runtime-package' ),
+				'public_id'    => 'codebox-agent-runtime',
+				'public_label' => 'Codebox agent runtime',
+				'public_kind'  => 'runtime-profile',
+				'capabilities' => array( 'codebox.runtime-package' ),
 				'default'      => true,
 			)
 		);

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-provider-registry.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-provider-registry.php
@@ -225,11 +225,13 @@ final class WP_Codebox_Runtime_Provider_Registry {
 
 	/** @param array<string,mixed> $metadata Provider metadata. @return array<string,mixed> */
 	private static function public_metadata( string $id, array $metadata ): array {
+		$public_id = is_string( $metadata['public_id'] ?? null ) ? self::normalize_provider_id( $metadata['public_id'] ) : $id;
+
 		return array_filter(
 			array(
-				'id' => $id,
-				'label' => is_string( $metadata['label'] ?? null ) ? $metadata['label'] : $id,
-				'kind' => is_string( $metadata['kind'] ?? null ) ? $metadata['kind'] : 'adapter',
+				'id' => '' !== $public_id ? $public_id : $id,
+				'label' => is_string( $metadata['public_label'] ?? null ) ? $metadata['public_label'] : ( is_string( $metadata['label'] ?? null ) ? $metadata['label'] : $id ),
+				'kind' => is_string( $metadata['public_kind'] ?? null ) ? $metadata['public_kind'] : ( is_string( $metadata['kind'] ?? null ) ? $metadata['kind'] : 'adapter' ),
 				'capabilities' => is_array( $metadata['capabilities'] ?? null ) ? array_values( $metadata['capabilities'] ) : array(),
 			),
 			static fn( mixed $value ): bool => array() !== $value && '' !== $value

--- a/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
@@ -18,7 +18,7 @@ final class WP_Codebox_Task_Input_Contract {
 		return array(
 			'$id'        => self::SCHEMA,
 			'type'       => 'object',
-			'required'   => array( 'schema', 'version', 'goal', 'target', 'allowed_tools', 'expected_artifacts', 'structured_artifacts', 'agent_bundles', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'policy', 'context' ),
+			'required'   => array( 'schema', 'version', 'goal', 'target', 'allowed_tools', 'expected_artifacts', 'structured_artifacts', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'policy', 'context' ),
 			'properties' => array(
 				'schema'             => array(
 					'type'        => 'string',

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -66,6 +66,10 @@ assert( false === $adapter->is_available( WP_Codebox_Agents_API_Adapter::default
 WP_Codebox_Agents_API_Adapter::register_runtime_provider();
 $early_providers = WP_Codebox_Runtime_Provider_Registry::providers();
 assert( isset( $early_providers['agents-api-adapter'] ) );
+assert( 'codebox-agent-runtime' === $early_providers['agents-api-adapter']['id'] );
+assert( 'Codebox agent runtime' === $early_providers['agents-api-adapter']['label'] );
+assert( 'runtime-profile' === $early_providers['agents-api-adapter']['kind'] );
+assert( array( 'codebox.runtime-package' ) === $early_providers['agents-api-adapter']['capabilities'] );
 assert( 'agents-api-adapter' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
 $early_runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
 assert( is_wp_error( $early_runtime_package ) );
@@ -126,23 +130,25 @@ assert( 'wp_codebox_agents_api_ability_unavailable' === $missing->get_error_code
 WP_Codebox_Agents_API_Adapter::register_runtime_provider();
 $providers = WP_Codebox_Runtime_Provider_Registry::providers();
 assert( isset( $providers['agents-api-adapter'] ) );
+assert( 'codebox-agent-runtime' === $providers['agents-api-adapter']['id'] );
 assert( 'agents-api-adapter' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
 
 $default_registered_runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
 assert( ! is_wp_error( $default_registered_runtime_package ) );
-assert( 'agents-api-adapter' === $default_registered_runtime_package['runtime_provider']['id'] );
+assert( 'codebox-agent-runtime' === $default_registered_runtime_package['runtime_provider']['id'] );
+assert( false === str_contains( json_encode( $default_registered_runtime_package['runtime_provider'] ), 'agents-api' ) );
 
 $runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'runtime_provider_id' => 'agents-api-adapter', 'package' => array( 'id' => 'example' ) ) );
 assert( ! is_wp_error( $runtime_package ) );
 assert( 'wp-codebox/runtime-package-result/v1' === $runtime_package['schema'] );
-assert( 'agents-api-adapter' === $runtime_package['runtime_provider']['id'] );
+assert( 'codebox-agent-runtime' === $runtime_package['runtime_provider']['id'] );
 assert_no_agents_api_schema_leaks( $runtime_package, 'runtime-package-registry' );
 
 $GLOBALS['wp_codebox_test_filters']['wp_codebox_default_runtime_provider'] = 'agents-api-adapter';
 assert( 'agents-api-adapter' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
 $default_runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
 assert( ! is_wp_error( $default_runtime_package ) );
-assert( 'agents-api-adapter' === $default_runtime_package['runtime_provider']['id'] );
+assert( 'codebox-agent-runtime' === $default_runtime_package['runtime_provider']['id'] );
 
 WP_Codebox_Runtime_Provider_Registry::register(
 	'Example Runtime',

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -38,6 +38,7 @@ import {
   RUNNER_WORKSPACE_BACKEND_ABILITY_KEYS,
   RUNNER_WORKSPACE_BACKEND_FILTER,
   fuzzCoveragePlanContract,
+  TASK_INPUT_JSON_SCHEMA,
 } from "../packages/runtime-core/src/public.js"
 import * as publicApi from "../packages/runtime-core/src/public.js"
 import * as runResultsApi from "../packages/runtime-core/src/run-results.js"
@@ -112,7 +113,6 @@ const runnerWorkspaceAdapter = await readFile(new URL("packages/wordpress-plugin
 assert.deepEqual(barrelExportModules(publicBarrel), [
   "./agent-runtime-workload.js",
   "./agent-workload.js",
-  "./agent-task-recipe.js",
   "./agent-task-run-result.js",
   "./agent-terminal-result.js",
   "./artifact-capture-policy.js",
@@ -261,6 +261,7 @@ for (const publicModule of [
 }
 
 for (const internalModule of [
+  "./agent-task-recipe.js",
   "./benchmark-substrate.js",
   "./fanout-aggregation.js",
   "./generic-ability-runtime-run.js",
@@ -273,6 +274,20 @@ for (const internalModule of [
   assert.ok(!publicBarrel.includes(`export * from "${internalModule}"`), `public barrel must not export ${internalModule}`)
   assert.ok(!contractsBarrel.includes(`export * from "${internalModule}"`), `contracts barrel must not export ${internalModule}`)
 }
+
+for (const internalRequestField of [
+  "provider_plugin_paths",
+  "runtime_stack_mounts",
+  "runtime_overlays",
+  "runtime_state_mounts",
+  "runtime_config_mounts",
+  "secret_env",
+  "wp_codebox_bin",
+]) {
+  assert.equal(JSON.stringify(TASK_INPUT_JSON_SCHEMA).includes(internalRequestField), false, `public task input schema must not expose ${internalRequestField}`)
+}
+
+assert.equal(TASK_INPUT_JSON_SCHEMA.required.includes("agent_bundles"), false, "agent_bundles must not be required by the public task input schema")
 
 assert.ok(!contractsBarrel.includes(`export * from "./index.js"`), "contracts barrel must not re-export the root package barrel")
 


### PR DESCRIPTION
## Summary
- Keep the default internal agent runtime provider wired to the existing Agents API adapter while presenting it publicly as the generic Codebox agent runtime profile.
- Remove agent-task recipe assembly from the curated public facade and keep task input schemas free of backend runtime knobs.
- Make agent bundles optional in TypeScript and PHP task input schemas to match normalization behavior.

## Testing
- npm run test:public-api-contract
- npm run test:php-agents-api-adapter-contract
- npm run test:agent-task-contracts
- npm run test:runtime-profile-resolver
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting, editing, and verifying the boundary contract changes.