### PR TITLE
Make public browser sessions executable

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -11,6 +11,8 @@
 		'browser-runtime:normalize-error',
 		'browser-runtime:normalize-result',
 		'browser-runtime:normalize-browser-run-result',
+		'browser-runtime:boot-executable-session',
+		'browser-runtime:parent-tool-bridge',
 		'browser-runtime:aggregate-fanout-outputs',
 		'browser-runtime:invoke-result',
 		'playground:run-php',
@@ -345,12 +347,22 @@
 		validateBrowserRuntimeMaterialization: ( client, session, options = {} ) => api.validateBrowserRuntimeMaterialization( client, session, options ),
 		normalizeResult: normalizeOperationResult,
 		result: browserSdkResult,
+		executableBrowserSession: api.executableBrowserSession,
+		bootExecutableBrowserSession: async ( client, session, options = {} ) => normalizeBrowserRunResult( await api.bootExecutableBrowserSession( client, session, options ), 'browser-executable-session' ),
+		parentToolBridge: api.parentToolBridge,
+		createParentToolRequest: api.createParentToolRequest,
+		dispatchParentTool: api.dispatchParentTool,
 		runBrowserSessionRecipe: async ( client, session, taskPayload, options = {} ) => normalizeBrowserRunResult( await api.runBrowserSessionRecipe( client, session, taskPayload, options ), 'browser-session-recipe' ),
 		methods: Object.freeze( {
 			activateTheme: api.activateTheme,
 			browserSessionRecipe: api.browserSessionRecipe,
+			bootExecutableBrowserSession: api.bootExecutableBrowserSession,
+			createParentToolRequest: api.createParentToolRequest,
+			dispatchParentTool: api.dispatchParentTool,
 			ensureDirectory: api.ensureDirectory,
+			executableBrowserSession: api.executableBrowserSession,
 			installTheme: api.installTheme,
+			parentToolBridge: api.parentToolBridge,
 			validateBrowserRuntimeMaterialization: api.validateBrowserRuntimeMaterialization,
 			aggregateFanoutOutputs: api.aggregateFanoutOutputs,
 			preparedBrowserRuntimeContract: api.preparedBrowserRuntimeContract,
@@ -1489,6 +1501,161 @@ try {
 		};
 	};
 
+	const executableBrowserSession = ( input ) => {
+		const session = input?.schema === 'wp-codebox/browser-session-product-dto/v1'
+			? input.executable_session
+			: input;
+		if ( ! session || typeof session !== 'object' ) {
+			throw runtimeError( 'executable_session_validate', 'browser_executable_session_missing', 'WP Codebox executable browser session is required.' );
+		}
+		if ( session.schema !== 'wp-codebox/browser-executable-session/v1' ) {
+			throw runtimeError( 'executable_session_validate', 'browser_executable_session_schema_unsupported', `Unsupported WP Codebox executable session schema: ${ session.schema || 'missing' }` );
+		}
+		if ( session.success === false || session.status === 'blocked' ) {
+			throw runtimeError( 'executable_session_validate', 'browser_executable_session_not_ready', session?.error?.message || 'WP Codebox executable browser session is not ready.' );
+		}
+
+		return session;
+	};
+
+	const executableBrowserRuntimeHandoff = ( input ) => {
+		const session = executableBrowserSession( input );
+		const handoff = session.runtime_handoff && typeof session.runtime_handoff === 'object' ? session.runtime_handoff : {};
+		if ( handoff.schema && handoff.schema !== 'wp-codebox/browser-runtime-handoff/v1' ) {
+			throw runtimeError( 'runtime_handoff_validate', 'browser_runtime_handoff_schema_unsupported', `Unsupported WP Codebox browser runtime handoff schema: ${ handoff.schema }` );
+		}
+		const blueprintRef = handoff.blueprint_ref && typeof handoff.blueprint_ref === 'object'
+			? handoff.blueprint_ref
+			: ( session.blueprint_ref && typeof session.blueprint_ref === 'object' ? session.blueprint_ref : null );
+		const blueprintRefDto = handoff.blueprint_ref_dto && typeof handoff.blueprint_ref_dto === 'object'
+			? handoff.blueprint_ref_dto
+			: ( session.preview_boot?.blueprint_ref_dto && typeof session.preview_boot.blueprint_ref_dto === 'object' ? session.preview_boot.blueprint_ref_dto : blueprintRef );
+
+		return {
+			schema: 'wp-codebox/browser-runtime-handoff/v1',
+			owner: 'wp-codebox',
+			...handoff,
+			session_id: handoff.session_id || session.session_id || '',
+			blueprint_ref: blueprintRef,
+			blueprint_ref_dto: blueprintRefDto,
+			hydrator_ability: handoff.hydrator_ability || blueprintRef?.hydrator_ability || blueprintRefDto?.hydrator_ability || 'wp-codebox/hydrate-browser-blueprint-ref',
+			parent_tool_bridge: handoff.parent_tool_bridge && typeof handoff.parent_tool_bridge === 'object' ? handoff.parent_tool_bridge : parentToolBridge( session ),
+		};
+	};
+
+	const parentToolBridge = ( input ) => {
+		const source = input?.schema === 'wp-codebox/browser-session-product-dto/v1'
+			? input.executable_session
+			: input;
+		const handoff = source?.runtime_handoff && typeof source.runtime_handoff === 'object' ? source.runtime_handoff : {};
+		const bridge = source?.parent_tool_bridge && typeof source.parent_tool_bridge === 'object'
+			? source.parent_tool_bridge
+			: ( handoff.parent_tool_bridge && typeof handoff.parent_tool_bridge === 'object' ? handoff.parent_tool_bridge : null );
+		return bridge && bridge.schema === 'wp-codebox/parent-tool-bridge/v1' ? bridge : null;
+	};
+
+	const createParentToolRequest = ( sessionInput, tool, operation, input = {}, metadata = {} ) => {
+		const session = executableBrowserSession( sessionInput );
+		const bridge = parentToolBridge( session );
+		if ( ! bridge ) {
+			throw runtimeError( 'parent_tool_bridge', 'parent_tool_bridge_missing', 'WP Codebox parent tool bridge is not available for this executable browser session.' );
+		}
+		const toolName = String( tool || '' );
+		if ( ! toolName || ! Array.isArray( bridge.allowed_tools ) || ! bridge.allowed_tools.includes( toolName ) ) {
+			throw runtimeError( 'parent_tool_bridge', 'parent_tool_denied', `Parent tool is not allowed: ${ toolName || 'missing' }` );
+		}
+
+		return {
+			schema: bridge.dispatcher?.request_schema || 'wp-codebox/parent-tool-request/v1',
+			version: 1,
+			request_id: `ptr-${ Date.now().toString( 36 ) }-${ Math.random().toString( 36 ).slice( 2, 10 ) }`,
+			tool: toolName,
+			operation: String( operation || 'call' ),
+			input,
+			sandbox_session: {
+				sandbox_session_id: String( session.session_id || '' ),
+			},
+			authorization: {
+				allowed_tools: [ ...bridge.allowed_tools ],
+			},
+			metadata: metadata && typeof metadata === 'object' ? metadata : {},
+		};
+	};
+
+	const dispatchParentTool = async ( session, tool, operation, input = {}, options = {} ) => {
+		if ( typeof options.dispatchParentTool !== 'function' ) {
+			throw runtimeError( 'parent_tool_bridge', 'parent_tool_dispatcher_missing', 'A host parent-tool dispatcher callback is required.' );
+		}
+		const request = createParentToolRequest( session, tool, operation, input, options.metadata || {} );
+		const result = await options.dispatchParentTool( request, { bridge: parentToolBridge( session ) } );
+		if ( ! result || typeof result !== 'object' || result.schema !== 'wp-codebox/parent-tool-result/v1' ) {
+			throw runtimeError( 'parent_tool_bridge', 'parent_tool_result_invalid', 'Parent tool dispatcher returned an invalid WP Codebox result envelope.' );
+		}
+		return result;
+	};
+
+	const hydrateExecutableBrowserBlueprint = async ( session, options = {} ) => {
+		const handoff = executableBrowserRuntimeHandoff( session );
+		const blueprintRef = handoff.blueprint_ref_dto || handoff.blueprint_ref;
+		const ref = blueprintRef?.ref || blueprintRef?.id || handoff.blueprint_ref || '';
+		if ( ! ref ) {
+			throw runtimeError( 'blueprint_hydration', 'browser_blueprint_ref_missing', 'Executable browser session is missing a Codebox blueprint ref.' );
+		}
+		if ( typeof options.hydrateBlueprintRef !== 'function' ) {
+			throw runtimeError( 'blueprint_hydration', 'browser_blueprint_hydrator_missing', 'A Codebox blueprint-ref hydrator callback is required.' );
+		}
+
+		const hydrated = await options.hydrateBlueprintRef( {
+			schema: 'wp-codebox/browser-blueprint-ref-hydration-request/v1',
+			ability: handoff.hydrator_ability,
+			ref,
+			blueprint_ref: blueprintRef,
+			session_id: handoff.session_id || '',
+		}, handoff );
+		const blueprint = hydrated?.blueprint && typeof hydrated.blueprint === 'object'
+			? hydrated.blueprint
+			: ( hydrated?.data?.blueprint && typeof hydrated.data.blueprint === 'object' ? hydrated.data.blueprint : hydrated );
+		if ( ! blueprint || typeof blueprint !== 'object' || ! Array.isArray( blueprint.steps ) ) {
+			throw runtimeError( 'blueprint_hydration', 'browser_blueprint_hydration_invalid', 'Codebox blueprint hydrator did not return an executable blueprint.' );
+		}
+
+		return {
+			schema: 'wp-codebox/browser-blueprint-hydration-result/v1',
+			ref,
+			blueprint,
+			hydrated,
+		};
+	};
+
+	const runExecutableBrowserBlueprint = async ( client, blueprint, options = {} ) => {
+		return await invokePlaygroundMethod( 'blueprint_run', 'runBlueprint', [
+			{ label: 'client-run-blueprint-envelope', shape: 'client.run', run: () => client.run( { blueprint } ) },
+			{ label: 'client-run-blueprint', shape: 'client.run', run: () => client.run( blueprint ) },
+			{ label: 'client-runBlueprint', shape: 'client.runBlueprint', run: () => client.runBlueprint( blueprint ) },
+			{ label: 'client-applyBlueprint', shape: 'client.applyBlueprint', run: () => client.applyBlueprint( blueprint ) },
+		] );
+	};
+
+	const bootExecutableBrowserSession = async ( client, sessionInput, options = {} ) => {
+		const session = executableBrowserSession( sessionInput );
+		if ( options.validateReadiness !== false && session.runtime_readiness?.ready === false ) {
+			throw runtimeError( 'executable_session_validate', 'browser_executable_session_not_ready', session.runtime_readiness?.message || 'WP Codebox executable browser session runtime is not ready.', session.runtime_readiness );
+		}
+		const hydration = await hydrateExecutableBrowserBlueprint( session, options );
+		const bootResult = await runExecutableBrowserBlueprint( client, hydration.blueprint, options );
+		return {
+			schema: 'wp-codebox/browser-executable-session-boot-result/v1',
+			success: true,
+			status: 'completed',
+			session_id: session.session_id || '',
+			blueprint_ref: hydration.ref,
+			result: bootResult ?? null,
+			preview: session.preview || session.runtime_access?.lease || null,
+			runtime_access: session.runtime_access || null,
+			parent_tool_bridge: parentToolBridge( session ),
+		};
+	};
+
 	const runtimeDependencySpecs = ( session, field ) => {
 		const runtime = session?.runtime && typeof session.runtime === 'object' ? session.runtime : {};
 		return Array.isArray( runtime[ field ] ) ? runtime[ field ].filter( isPlainObject ) : [];
@@ -2081,9 +2248,14 @@ echo wp_json_encode( array(
 		activateTheme,
 		aggregateFanoutOutputs,
 		browserSessionRecipe,
+		bootExecutableBrowserSession,
+		createParentToolRequest,
+		dispatchParentTool,
 		ensureDirectory,
+		executableBrowserSession,
 		installTheme,
 		normalizeOperationResult,
+		parentToolBridge,
 		parseJsonResponse,
 		preparedBrowserRuntimeContract,
 		preparedBrowserRuntimeStatus,

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
@@ -333,6 +333,8 @@ final class WP_Codebox_Browser_Task_Builder {
 	private static function browser_executable_session_dto( array $session, array $preview_boot, array $preview_lease, array $blueprint_ref, array $runtime_access, array $runtime_readiness, array $runtime_capabilities ): array {
 		$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
 		$contained_site   = is_array( $session['contained_site'] ?? null ) ? self::compact_public_value( $session['contained_site'] ) : array();
+		$task_input       = is_array( $session['task_input'] ?? null ) ? $session['task_input'] : array();
+		$parent_tool_bridge = is_array( $task_input['parent_tool_bridge'] ?? null ) ? self::compact_public_value( $task_input['parent_tool_bridge'] ) : array();
 
 		return array_filter(
 			array(
@@ -351,6 +353,26 @@ final class WP_Codebox_Browser_Task_Builder {
 				'runtime_capabilities' => $runtime_capabilities,
 				'runtime_readiness'    => $runtime_readiness,
 				'contained_site'       => $contained_site,
+				'runtime_handoff'      => self::browser_runtime_handoff_dto( $session, $preview_boot, $blueprint_ref, $parent_tool_bridge ),
+				'parent_tool_bridge'   => $parent_tool_bridge,
+			),
+			static fn( mixed $value ): bool => '' !== $value && array() !== $value
+		);
+	}
+
+	/** @param array<string,mixed> $session Browser session contract. @param array<string,mixed> $preview_boot Preview boot DTO. @param array<string,mixed> $blueprint_ref Blueprint ref DTO. @param array<string,mixed> $parent_tool_bridge Parent tool bridge DTO. @return array<string,mixed> */
+	private static function browser_runtime_handoff_dto( array $session, array $preview_boot, array $blueprint_ref, array $parent_tool_bridge ): array {
+		$session_envelope = is_array( $session['session'] ?? null ) ? $session['session'] : array();
+		return array_filter(
+			array(
+				'schema'            => 'wp-codebox/browser-runtime-handoff/v1',
+				'owner'             => 'wp-codebox',
+				'session_id'        => (string) ( $session_envelope['id'] ?? $session['session_id'] ?? '' ),
+				'boot_schema'       => 'wp-codebox/browser-preview-boot-config/v1',
+				'blueprint_ref'     => $blueprint_ref,
+				'blueprint_ref_dto' => is_array( $preview_boot['blueprint_ref_dto'] ?? null ) ? $preview_boot['blueprint_ref_dto'] : $blueprint_ref,
+				'hydrator_ability'  => (string) ( $blueprint_ref['hydrator_ability'] ?? 'wp-codebox/hydrate-browser-blueprint-ref' ),
+				'parent_tool_bridge' => $parent_tool_bridge,
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
 		);

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -473,6 +473,8 @@ private static function browser_executable_session_schema(): array {
 			'runtime_capabilities' => self::browser_runtime_capabilities_schema(),
 			'runtime_readiness'    => self::browser_runtime_readiness_schema(),
 			'contained_site'       => self::browser_contained_site_schema(),
+			'runtime_handoff'      => array( 'type' => 'object' ),
+			'parent_tool_bridge'   => array( 'type' => 'object' ),
 		),
 	);
 }

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -31,6 +31,8 @@ assert.deepEqual(plain(api.v1.info()), {
     "browser-runtime:normalize-error",
     "browser-runtime:normalize-result",
     "browser-runtime:normalize-browser-run-result",
+    "browser-runtime:boot-executable-session",
+    "browser-runtime:parent-tool-bridge",
     "browser-runtime:aggregate-fanout-outputs",
     "browser-runtime:invoke-result",
     "playground:run-php",
@@ -52,6 +54,8 @@ assert.equal(api.v1.methods.runPhpRequest, api.runPhpRequest)
 assert.equal(api.v1.methods.writeFile, api.writeFile)
 assert.equal(api.v1.methods.validateBrowserRuntimeMaterialization, api.validateBrowserRuntimeMaterialization)
 assert.equal(typeof api.v1.runBrowserSessionRecipe, "function")
+assert.equal(typeof api.v1.bootExecutableBrowserSession, "function")
+assert.equal(typeof api.v1.createParentToolRequest, "function")
 assert.equal(typeof api.v1.validateBrowserRuntimeMaterialization, "function")
 assert.deepEqual(plain(api.v1.normalizeError(Object.assign(new Error("Nope"), { code: "demo_error", phase: "probe", status: 418, data: { demo: true } }))), {
   schema: "wp-codebox/browser-sdk-error/v1",
@@ -170,5 +174,64 @@ assert.deepEqual(plain(api.v1.browserArtifactPersistenceRef({
 }).artifactRefs), [
   { kind: "artifact-bundle", id: "artifact-bundle-sha256-abc", path: "artifacts/run-1", digest: { algorithm: "sha256", value: "abc" } },
 ])
+
+const executableSession = {
+  schema: "wp-codebox/browser-executable-session/v1",
+  success: true,
+  session_id: "executable-session-1",
+  status: "ready",
+  preview: { schema: "wp-codebox/preview-lease/v1", public_url: "https://preview.example.test/" },
+  runtime_readiness: { schema: "wp-codebox/browser-runtime-readiness/v1", ready: true, status: "ready" },
+  runtime_handoff: {
+    schema: "wp-codebox/browser-runtime-handoff/v1",
+    owner: "wp-codebox",
+    session_id: "executable-session-1",
+    hydrator_ability: "wp-codebox/hydrate-browser-blueprint-ref",
+    blueprint_ref: {
+      schema: "wp-codebox/browser-blueprint-ref/v1",
+      ref: "prepared:site:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      hydrator_ability: "wp-codebox/hydrate-browser-blueprint-ref",
+    },
+    parent_tool_bridge: {
+      schema: "wp-codebox/parent-tool-bridge/v1",
+      version: 1,
+      allowed_tools: ["workspace.read"],
+      dispatcher: { owner: "wp-codebox", mode: "host_endpoint", request_schema: "wp-codebox/parent-tool-request/v1", result_schema: "wp-codebox/parent-tool-result/v1" },
+      sandbox_env: { mode: "metadata-only", secret_env: [] },
+      authorization: { mode: "allowlist" },
+      redaction: { transcript_artifact_refs: [] },
+      metadata: {},
+    },
+  },
+}
+const blueprintRuns: any[] = []
+const booted = await api.v1.bootExecutableBrowserSession({
+  run: async (request: any) => {
+    blueprintRuns.push(request)
+    return { success: true, data: { booted: true } }
+  },
+}, executableSession, {
+  hydrateBlueprintRef: async (request: any) => {
+    assert.equal(request.ability, "wp-codebox/hydrate-browser-blueprint-ref")
+    assert.equal(request.ref, executableSession.runtime_handoff.blueprint_ref.ref)
+    return { schema: "wp-codebox/browser-blueprint-hydration/v1", blueprint: { steps: [{ step: "runPHP", code: "<?php echo 'ok';" }] } }
+  },
+})
+assert.equal(booted.schema, "wp-codebox/browser-run-result/v1")
+assert.equal(booted.status, "completed")
+assert.equal(booted.success, true)
+assert.deepEqual(plain(blueprintRuns), [{ blueprint: { steps: [{ step: "runPHP", code: "<?php echo 'ok';" }] } }])
+
+const parentRequest = api.v1.createParentToolRequest(executableSession, "workspace.read", "read", { path: "README.md" })
+assert.equal(parentRequest.schema, "wp-codebox/parent-tool-request/v1")
+assert.equal(parentRequest.sandbox_session.sandbox_session_id, "executable-session-1")
+assert.deepEqual(plain(parentRequest.authorization.allowed_tools), ["workspace.read"])
+await assert.rejects(
+  () => api.v1.dispatchParentTool(executableSession, "workspace.write", "write", {}, { dispatchParentTool: async () => ({}) }),
+  (error: any) => {
+    assert.equal(error.code, "parent_tool_denied")
+    return true
+  },
+)
 
 console.log("browser sdk facade ok")

--- a/tests/browser-session-public-dto.test.ts
+++ b/tests/browser-session-public-dto.test.ts
@@ -28,6 +28,21 @@ $input = array(
 	'goal' => 'Build a product-safe browser artifact.',
 	'sandbox_session_id' => 'session-public-dto',
 	'orchestrator' => array( 'id' => 'studio-web' ),
+	'parent_tool_bridge' => array(
+		'schema' => 'wp-codebox/parent-tool-bridge/v1',
+		'version' => 1,
+		'allowed_tools' => array( 'workspace.read' ),
+		'dispatcher' => array(
+			'owner' => 'wp-codebox',
+			'mode' => 'host_endpoint',
+			'request_schema' => 'wp-codebox/parent-tool-request/v1',
+			'result_schema' => 'wp-codebox/parent-tool-result/v1',
+		),
+		'sandbox_env' => array( 'mode' => 'metadata-only', 'secret_env' => array() ),
+		'authorization' => array( 'mode' => 'allowlist' ),
+		'redaction' => array( 'transcript_artifact_refs' => array() ),
+		'metadata' => array( 'adapter' => 'test' ),
+	),
 	'runtime_requirements' => array( 'requires_provider' => false ),
 	'playground' => array(
 		'preview_url' => '/preview/index.html',
@@ -116,6 +131,12 @@ assert.equal(result.public.runtime_readiness.status, "ready")
 assert.equal(result.public.runtime_readiness.ready, true)
 assert.deepEqual(result.public.runtime_readiness.missing, undefined)
 assert.deepEqual(result.public.executable_session.runtime_readiness, result.public.runtime_readiness)
+assert.equal(result.public.executable_session.runtime_handoff.schema, "wp-codebox/browser-runtime-handoff/v1")
+assert.equal(result.public.executable_session.runtime_handoff.owner, "wp-codebox")
+assert.equal(result.public.executable_session.runtime_handoff.hydrator_ability, "wp-codebox/hydrate-browser-blueprint-ref")
+assert.equal(result.public.executable_session.runtime_handoff.blueprint_ref.ref, result.public.blueprint_ref.ref)
+assert.equal(result.public.executable_session.parent_tool_bridge.schema, "wp-codebox/parent-tool-bridge/v1")
+assert.deepEqual(result.public.executable_session.parent_tool_bridge.allowed_tools, ["workspace.read"])
 assert.match(result.public.preview_boot.blueprint_ref, /^prepared:public-dto-site:[a-f0-9]{64}$/)
 assert.equal(result.public.preview_boot.blueprint_ref_dto.hydrator_ability, "wp-codebox/hydrate-browser-blueprint-ref")
 assert.equal(result.public.preview_ref.boot_ref, result.public.preview_boot.blueprint_ref)
@@ -129,6 +150,7 @@ assert.deepEqual(result.public.artifact_refs, [{
 assert.equal(result.public.playground, undefined)
 assert.equal(result.public.recipe, undefined)
 assert.equal(result.public.task_payload, undefined)
+assert.equal(result.public.parent_tool_bridge, undefined)
 assert.equal(JSON.stringify(result.public).includes("must-not-leak"), false)
 assert.equal(result.public.preview_boot.artifacts.base_path, undefined)
 assert.equal(result.public.preview_boot.runtime_access.preview_url, "/preview/index.html")


### PR DESCRIPTION
## Summary
- Add a Codebox-owned browser runtime handoff descriptor to the executable browser session DTO.
- Teach the browser SDK to boot wp-codebox/browser-executable-session/v1 via a Codebox blueprint-ref hydrator instead of raw recipe/task_payload/Playground internals.
- Carry the public parent-tool bridge descriptor and add SDK helpers for allowlisted parent-tool request/dispatch envelopes.

## Testing
- npm run test:browser-session-public-dto
- npm run test:browser-sdk-facade
- npm run test:browser-playground-session-run
- npm run test:schema-parity
- npx tsx tests/parent-tool-bridge-contract.test.ts
- php -l packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the executable browser session handoff, parent-tool bridge SDK helpers, and behavior-focused tests.