### PR TITLE
Document public handoff abilities

### DIFF
--- a/docs/agent-fanout-contract.md
+++ b/docs/agent-fanout-contract.md
@@ -116,8 +116,10 @@ fanout/
 
 The parent result includes `session.children`, aggregate counts, the requested
 concurrency, worker run summaries, failure summaries, and artifact references.
-Parent products remain responsible for review, apply, PR creation, deployment,
-or any other mutation outside the sandbox.
+WP Codebox owns this parent result envelope and the referenced child artifact
+layout. Parent hosts own durable job/result records, callback delivery,
+placement/ranking policy, review, apply, PR creation, deployment, or any other
+mutation outside the sandbox.
 
 ## Host Delegation
 

--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -61,6 +61,34 @@ Consumer-facing WordPress abilities use the `wp-codebox/*` namespace. Public
 docs and schemas describe the canonical Codebox-owned names that integrations
 should call directly.
 
+## Public Handoff Abilities
+
+Native hosts and other external orchestrators should treat these abilities as
+the public handoff/fanout boundary:
+
+- `wp-codebox/create-browser-task-contract` prepares a product-facing browser
+  task contract. WP Codebox owns the contract envelope, session descriptors,
+  callback capability shape, phase structure, and artifact references; the host
+  owns durable job state, UI state, review decisions, and any callback endpoint
+  implementation that receives or forwards the result.
+- `wp-codebox/normalize-browser-artifact-bundle` validates caller-provided
+  browser files, safe paths, entrypoint, roles, provenance, and metadata into a
+  product-neutral bundle description without interpreting product-specific
+  meaning.
+- `wp-codebox/persist-browser-artifact` stores browser-produced files as a
+  canonical WP Codebox artifact bundle and returns artifact bundle references for
+  review, replay, import, or apply-back.
+- `wp-codebox/import-artifact-bundle` and
+  `wp-codebox/reimport-artifact-bundle` are the durable ingress path for an
+  existing bundle. They verify bundle identity/digest and return
+  `wp-codebox/artifact-result-envelope/v1`; callers own when to retry,
+  replace, review, or apply returned artifacts.
+- `wp-codebox/run-agent-task-fanout` runs a bounded, product-neutral fanout
+  request and returns the parent `wp-codebox/agent-fanout-result/v1` envelope.
+  WP Codebox owns isolated worker execution, lifecycle events, aggregation
+  envelope shape, and artifact layout; the host owns placement, ranking,
+  durable orchestration state, callback delivery, and final result decisions.
+
 The public runtime contract manifest currently publishes these Codebox-owned
 ability identifiers:
 

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -81,6 +81,10 @@ DTOs by default. Those DTOs expose stable session ids, contained-site and previe
 refs, preview URLs, artifact refs, status, and compact diagnostics. Raw
 Playground/runtime contracts, recipes, task payloads, sandbox paths, and
 implementation diagnostics stay behind explicit internal/debug raw-contract flags.
+`wp-codebox/create-browser-task-contract` is the public browser handoff surface:
+WP Codebox owns the contract envelope, phase descriptors, callback capability
+shape, and artifact refs; callers own durable job state, callback transport,
+review decisions, and final result handling.
 
 Runtime orchestrators can pass `agent_bundles` plus a generic `runtime_task`
 payload to run caller-owned bundle logic without injecting PHP code. WP Codebox
@@ -229,6 +233,14 @@ They verify the bundle, copy it into the configured artifact store when needed,
 and return a stable `wp-codebox/artifact-result-envelope/v1`. Repeating the same
 import without `replace` returns `status: "existing"` with the same artifact
 reference, so parent orchestrators can safely retry after transport failures.
+Browser hosts that produce files outside the sandbox should use
+`normalize-browser-artifact-bundle` to validate the caller-owned bundle shape,
+`persist-browser-artifact` to store browser-produced files as a canonical WP
+Codebox artifact bundle, and `import-artifact-bundle` or
+`reimport-artifact-bundle` to rehydrate an existing bundle into the configured
+artifact store. WP Codebox preserves caller metadata and returns artifact result
+envelopes; the caller owns product interpretation, review state, and apply
+decisions.
 
 Browser-contained preview consumers can call `preview-reuse-decision` before
 opening a preview. It returns an explicit `action` such as `hydrate-ref` or

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -302,6 +302,21 @@ assert.match(rootBarrel, /Stable root package barrel kept for existing consumers
 assert.match(rootBarrel, /prefer the curated `@automattic\/wp-codebox-core\/public` facade or narrower/)
 assert.match(docs, /WordPress consumers should prefer `WP_Codebox_API`/)
 assert.match(docs, /`wp-codebox\/\*` ability ids/)
+for (const handoffAbility of [
+  "wp-codebox/create-browser-task-contract",
+  "wp-codebox/normalize-browser-artifact-bundle",
+  "wp-codebox/persist-browser-artifact",
+  "wp-codebox/import-artifact-bundle",
+  "wp-codebox/reimport-artifact-bundle",
+  "wp-codebox/run-agent-task-fanout",
+]) {
+  assert.match(docs, new RegExp(escapeRegExp(handoffAbility)), `public docs must cover ${handoffAbility}`)
+  assert.match(pluginReadme, new RegExp(escapeRegExp(handoffAbility.replace("wp-codebox/", "")) + "|" + escapeRegExp(handoffAbility)), `plugin README must cover ${handoffAbility}`)
+}
+assert.match(docs + pluginReadme, /WP Codebox owns the contract envelope/)
+assert.match(docs + pluginReadme, /callers? own durable job state|host owns durable job state/)
+assert.match(docs + pluginReadme, /normalize-browser-artifact-bundle[\s\S]*persist-browser-artifact[\s\S]*reimport-artifact-bundle/)
+assert.doesNotMatch(docs + pluginReadme, /Studio Native/i)
 assert.match(docs, /`@automattic\/wp-codebox-playground`: advanced runtime backend entrypoint/)
 assert.match(docs, /New consumers should prefer\s+`@automattic\/wp-codebox-playground\/public`/)
 assert.match(docs, /## Integration Boundary/)


### PR DESCRIPTION
## Summary
- document the public host handoff abilities for browser contracts, artifact bundles, reimport, and fanout
- clarify WP Codebox ownership versus host ownership at the boundary
- add contract test coverage so docs keep naming the public surfaces

## Testing
- npm run test:public-api-contract
- npm run test:docs-boundary-language
- npm run test:browser-callback-materialization-contracts
- npm run test:fanout-aggregation-contract-parity

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting documentation/test updates and PR description.