### PR TITLE
Add public browser preview SDK starter

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -52,6 +52,10 @@ Browser sessions that load the WordPress plugin browser runtime also publish
 `window.wpCodeboxBrowser.v1`. The `v1` facade is the stable browser SDK
 for product consumers running inside the browser. Legacy top-level
 `window.wpCodeboxBrowser` methods remain available for existing callers.
+The Codebox-owned browser preview starter is `window.wpCodebox.startBrowserPreview(...)`
+or `window.wpCodeboxBrowser.v1.startBrowserPreview(...)`; callers pass the
+`wp-codebox/browser-preview-boot-config/v1` DTO plus a blueprint hydrator and do
+not import Playground's raw `startPlaygroundWeb` directly.
 
 Consumer-facing WordPress abilities use the `wp-codebox/*` namespace. Public
 docs and schemas describe the canonical Codebox-owned names that integrations
@@ -182,12 +186,19 @@ The stable public surface is grouped by lifecycle area rather than by product:
   boundary contracts. Public WordPress abilities return compact browser/session
   product DTOs by default; executable Playground recipes, runtime payloads,
   sandbox paths, and implementation diagnostics are internal/debug contracts.
+  `wp-codebox/open-or-create-browser-contained-site` requires an explicit `mode`:
+  `open-only` reuses an existing prepared/live preview and returns unavailable on
+  miss, `open-or-create` reuses when possible and otherwise creates, and
+  `prepare-new` always creates a fresh preview session. The old boolean
+  `fallback_create` input is not part of the public contract.
 - **Browser SDK:** `window.wpCodeboxBrowser.v1.info()` reports SDK version,
   capability strings, and global names; `normalizeError()` returns
   `wp-codebox/browser-sdk-error/v1`; `result()` wraps async browser operations in
   `wp-codebox/browser-sdk-result/v1`; `normalizeBrowserRunResult()` returns the
   product-safe `wp-codebox/browser-run-result/v1` DTO; `browserArtifactPersistenceRef()`
-  returns `wp-codebox/browser-artifact-persistence/ref/v1`; `runBrowserSessionRecipe()`
+  returns `wp-codebox/browser-artifact-persistence/ref/v1`; `startBrowserPreview()`
+  starts a Codebox browser preview from the boot DTO and returns
+  `wp-codebox/browser-preview-start-result/v1`; `runBrowserSessionRecipe()`
   executes the existing runtime helper and returns the stable browser-run DTO;
   `methods` exposes stable references to the existing browser runtime helpers for
   callers that need legacy raw results internally. TypeScript consumers outside

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -11,6 +11,7 @@
 		'browser-runtime:normalize-error',
 		'browser-runtime:normalize-result',
 		'browser-runtime:normalize-browser-run-result',
+		'browser-preview:start',
 		'browser-runtime:boot-executable-session',
 		'browser-runtime:parent-tool-bridge',
 		'browser-runtime:aggregate-fanout-outputs',
@@ -333,6 +334,125 @@
 		},
 	} );
 
+	const browserPreviewBootConfig = ( input ) => {
+		const boot = input?.schema === 'wp-codebox/browser-preview-boot-config/v1'
+			? input
+			: ( input?.preview_boot && typeof input.preview_boot === 'object' ? input.preview_boot : ( input?.boot && typeof input.boot === 'object' ? input.boot : null ) );
+		if ( ! boot || typeof boot !== 'object' ) {
+			throw runtimeError( 'browser_preview_start', 'browser_preview_boot_missing', 'A WP Codebox browser preview boot config is required.' );
+		}
+		if ( boot.schema && boot.schema !== 'wp-codebox/browser-preview-boot-config/v1' && boot.schema !== 'wp-codebox/browser-contained-site-boot/v1' ) {
+			throw runtimeError( 'browser_preview_start', 'browser_preview_boot_schema_unsupported', `Unsupported WP Codebox browser preview boot schema: ${ boot.schema }` );
+		}
+
+		return boot;
+	};
+
+	const hydrateBrowserPreviewBlueprint = async ( boot, options = {} ) => {
+		if ( options.blueprint && typeof options.blueprint === 'object' ) {
+			return options.blueprint;
+		}
+		if ( boot.blueprint && typeof boot.blueprint === 'object' ) {
+			return boot.blueprint;
+		}
+
+		const blueprintRef = boot.blueprint_ref_dto && typeof boot.blueprint_ref_dto === 'object'
+			? boot.blueprint_ref_dto
+			: ( boot.blueprint_ref && typeof boot.blueprint_ref === 'object' ? boot.blueprint_ref : { ref: boot.blueprint_ref || '' } );
+		const ref = String( blueprintRef.ref || blueprintRef.id || boot.blueprint_ref || '' );
+		if ( ! ref || ref === 'inline-session-blueprint' ) {
+			throw runtimeError( 'browser_preview_start', 'browser_preview_blueprint_ref_missing', 'Browser preview boot config is missing a hydratable Codebox blueprint ref.' );
+		}
+
+		const request = {
+			schema: 'wp-codebox/browser-blueprint-ref-hydration-request/v1',
+			ability: blueprintRef.hydrator_ability || boot.hydrator_ability || 'wp-codebox/hydrate-browser-blueprint-ref',
+			ref,
+			blueprint_ref: blueprintRef,
+			session_id: boot.session_id || '',
+		};
+		let hydrated;
+		if ( typeof options.hydrateBlueprintRef === 'function' ) {
+			hydrated = await options.hydrateBlueprintRef( request, boot );
+		} else if ( typeof fetch === 'function' && ( blueprintRef.hydration_endpoint || boot.hydration_endpoint ) ) {
+			const endpoint = new URL( blueprintRef.hydration_endpoint || boot.hydration_endpoint, window.location.href );
+			endpoint.searchParams.set( 'ref', ref );
+			hydrated = await fetch( endpoint.toString(), {
+				method: 'GET',
+				headers: options.nonce ? { 'X-WP-Nonce': String( options.nonce ) } : {},
+			} ).then( async ( response ) => {
+				const data = await response.json();
+				if ( ! response.ok ) {
+					throw runtimeError( 'browser_preview_start', 'browser_preview_blueprint_hydration_failed', data?.message || 'Browser preview blueprint hydration failed.', data );
+				}
+				return data;
+			} );
+		} else {
+			throw runtimeError( 'browser_preview_start', 'browser_preview_blueprint_hydrator_missing', 'Provide hydrateBlueprintRef, an inline blueprint, or a blueprint ref hydration endpoint.' );
+		}
+
+		const blueprint = hydrated?.blueprint && typeof hydrated.blueprint === 'object'
+			? hydrated.blueprint
+			: ( hydrated?.data?.blueprint && typeof hydrated.data.blueprint === 'object' ? hydrated.data.blueprint : hydrated );
+		if ( ! blueprint || typeof blueprint !== 'object' || ! Array.isArray( blueprint.steps ) ) {
+			throw runtimeError( 'browser_preview_start', 'browser_preview_blueprint_invalid', 'Codebox blueprint hydration did not return an executable Playground blueprint.' );
+		}
+
+		return blueprint;
+	};
+
+	const resolveStartPlaygroundWeb = async ( boot, options = {} ) => {
+		if ( typeof options.startPlaygroundWeb === 'function' ) {
+			return options.startPlaygroundWeb;
+		}
+
+		const moduleUrl = String( options.clientModuleUrl || boot.client_module_url || '' );
+		if ( ! moduleUrl ) {
+			throw runtimeError( 'browser_preview_start', 'browser_preview_client_module_missing', 'Browser preview boot config is missing client_module_url; pass startPlaygroundWeb for test or custom hosts.' );
+		}
+
+		const importModule = typeof options.importModule === 'function' ? options.importModule : ( async ( url ) => import( url ) );
+		const module = await importModule( moduleUrl );
+		if ( typeof module?.startPlaygroundWeb !== 'function' ) {
+			throw runtimeError( 'browser_preview_start', 'browser_preview_start_unavailable', 'Codebox browser preview client module does not export startPlaygroundWeb.' );
+		}
+
+		return module.startPlaygroundWeb;
+	};
+
+	const startBrowserPreview = async ( input, options = {} ) => {
+		const boot = browserPreviewBootConfig( input );
+		const startPlaygroundWeb = await resolveStartPlaygroundWeb( boot, options );
+		const blueprint = await hydrateBrowserPreviewBlueprint( boot, options );
+		const iframe = options.iframe || input?.iframe || ( typeof document !== 'undefined' && options.iframeSelector ? document.querySelector( options.iframeSelector ) : null );
+		const request = {
+			...( options.startOptions && typeof options.startOptions === 'object' ? options.startOptions : {} ),
+			...( iframe ? { iframe } : {} ),
+			...( boot.remote_url ? { remoteUrl: boot.remote_url } : {} ),
+			...( boot.cors_proxy_url ? { corsProxyUrl: boot.cors_proxy_url } : {} ),
+			...( boot.scope ? { scope: boot.scope } : {} ),
+			blueprint,
+		};
+		const client = await startPlaygroundWeb( request );
+
+		return {
+			schema: 'wp-codebox/browser-preview-start-result/v1',
+			success: true,
+			status: 'started',
+			session_id: boot.session_id || '',
+			preview: boot.preview || null,
+			boot,
+			request: {
+				remoteUrl: request.remoteUrl || null,
+				corsProxyUrl: request.corsProxyUrl || null,
+				scope: request.scope || null,
+				hasIframe: !! request.iframe,
+				hasBlueprint: !! request.blueprint,
+			},
+			client,
+		};
+	};
+
 	const browserSdkFacade = ( api ) => Object.freeze( {
 		schema: browserSdkSchema,
 		apiVersion: 'v1',
@@ -343,6 +463,7 @@
 		normalizeError: normalizeBrowserSdkError,
 		normalizeBrowserRunResult,
 		browserArtifactPersistenceRef,
+		startBrowserPreview: ( input, options = {} ) => api.startBrowserPreview( input, options ),
 		aggregateFanoutOutputs: ( input ) => api.aggregateFanoutOutputs( input ),
 		validateBrowserRuntimeMaterialization: ( client, session, options = {} ) => api.validateBrowserRuntimeMaterialization( client, session, options ),
 		normalizeResult: normalizeOperationResult,
@@ -356,6 +477,7 @@
 		methods: Object.freeze( {
 			activateTheme: api.activateTheme,
 			browserSessionRecipe: api.browserSessionRecipe,
+			startBrowserPreview: api.startBrowserPreview,
 			bootExecutableBrowserSession: api.bootExecutableBrowserSession,
 			createParentToolRequest: api.createParentToolRequest,
 			dispatchParentTool: api.dispatchParentTool,
@@ -2266,10 +2388,16 @@ echo wp_json_encode( array(
 		runWordPressOperation,
 		selectPreparedBrowserBlueprint,
 		setFrontendAdminBarVisible,
+		startBrowserPreview,
 		validateBrowserRuntimeMaterialization,
 		writeFile,
 		writeReviewFile,
 	};
 	wpCodeboxBrowserApi.v1 = browserSdkFacade( wpCodeboxBrowserApi );
 	window.wpCodeboxBrowser = wpCodeboxBrowserApi;
+	window.wpCodebox = Object.freeze( {
+		...( window.wpCodebox && typeof window.wpCodebox === 'object' ? window.wpCodebox : {} ),
+		startBrowserPreview,
+		browser: wpCodeboxBrowserApi.v1,
+	} );
 } )();

--- a/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-browser-ability-descriptors.php
@@ -254,20 +254,25 @@ final class WP_Codebox_Browser_Ability_Descriptors {
 			),
 			'wp-codebox/open-or-create-browser-contained-site' => array(
 				'label'               => 'Open or Create Browser Contained Site',
-				'description'         => 'Open a reusable browser-contained preview site when possible, otherwise create a fresh browser sandbox session from the same task input.',
+				'description'         => 'Start a browser-contained preview with an explicit mode: open-only, open-or-create, or prepare-new.',
 				'category'            => 'wp-codebox',
 				'input_schema'        => array(
 					'type'       => 'object',
+					'required'   => array( 'mode' ),
 					'properties' => array_merge(
 						$browser_session_properties,
 						array(
+							'mode'            => array(
+								'type'        => 'string',
+								'enum'        => array( 'open-only', 'open-or-create', 'prepare-new' ),
+								'description' => 'Deterministic preview start mode. open-only never creates, open-or-create reuses when possible then creates, prepare-new always creates a fresh session.',
+							),
 							'contained_site'  => $context['browser_contained_site_schema'],
 							'site_id'         => array( 'type' => 'string' ),
 							'cache_key'       => array( 'type' => 'string' ),
 							'source_digest'   => array( 'type' => array( 'string', 'object' ), 'description' => '64-character source digest string, or an object with a value field.' ),
 							'input_hash'      => array( 'type' => 'string' ),
 							'preview_lease'   => array( 'type' => 'object' ),
-							'fallback_create' => array( 'type' => 'boolean' ),
 						)
 					),
 				),

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -2202,10 +2202,20 @@ public static function open_browser_contained_site( array $input ): array|WP_Err
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function open_or_create_browser_contained_site( array $input ): array|WP_Error {
+	$mode = self::browser_contained_site_start_mode( $input );
+	if ( is_wp_error( $mode ) ) {
+		return $mode;
+	}
+
+	if ( 'prepare-new' === $mode ) {
+		return self::create_browser_contained_site_start_result( $input, array(), $mode );
+	}
+
 	$decision = self::preview_reuse_decision( $input );
 	if ( is_wp_error( $decision ) ) {
 		return $decision;
 	}
+	$decision['mode'] = $mode;
 
 	$action = (string) ( $decision['action'] ?? 'create-new' );
 	if ( in_array( $action, array( 'reuse-current', 'hydrate-ref' ), true ) ) {
@@ -2219,6 +2229,7 @@ public static function open_or_create_browser_contained_site( array $input ): ar
 				array(
 					'success'         => true,
 					'schema'          => 'wp-codebox/browser-contained-site-open-or-create/v1',
+					'mode'            => $mode,
 					'action'          => 'opened',
 					'decision'        => $decision,
 					'identity_key'    => (string) ( $decision['identity_key'] ?? '' ),
@@ -2235,11 +2246,12 @@ public static function open_or_create_browser_contained_site( array $input ): ar
 		}
 	}
 
-	if ( empty( $input['fallback_create'] ) ) {
+	if ( 'open-only' === $mode ) {
 		return array_filter(
 			array(
 				'success'         => false,
 				'schema'          => 'wp-codebox/browser-contained-site-open-or-create/v1',
+				'mode'            => $mode,
 				'action'          => 'unavailable',
 				'decision'        => $decision,
 				'identity_key'    => (string) ( $decision['identity_key'] ?? '' ),
@@ -2253,6 +2265,25 @@ public static function open_or_create_browser_contained_site( array $input ): ar
 		);
 	}
 
+	return self::create_browser_contained_site_start_result( $input, $decision, $mode );
+}
+
+/** @param array<string,mixed> $input Ability input. @return string|WP_Error */
+private static function browser_contained_site_start_mode( array $input ): string|WP_Error {
+	$mode = trim( (string) ( $input['mode'] ?? '' ) );
+	if ( '' === $mode ) {
+		return new WP_Error( 'wp_codebox_browser_contained_site_mode_required', 'mode is required and must be one of open-only, open-or-create, or prepare-new.', array( 'status' => 400 ) );
+	}
+
+	if ( ! in_array( $mode, array( 'open-only', 'open-or-create', 'prepare-new' ), true ) ) {
+		return new WP_Error( 'wp_codebox_browser_contained_site_mode_invalid', 'mode must be one of open-only, open-or-create, or prepare-new.', array( 'status' => 400, 'mode' => $mode ) );
+	}
+
+	return $mode;
+}
+
+/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $decision Reuse decision. @return array<string,mixed>|WP_Error */
+private static function create_browser_contained_site_start_result( array $input, array $decision, string $mode ): array|WP_Error {
 	$created = self::create_browser_playground_session( $input );
 	if ( is_wp_error( $created ) ) {
 		return $created;
@@ -2262,6 +2293,7 @@ public static function open_or_create_browser_contained_site( array $input ): ar
 		array(
 			'success'         => true === ( $created['success'] ?? false ),
 			'schema'          => 'wp-codebox/browser-contained-site-open-or-create/v1',
+			'mode'            => $mode,
 			'action'          => true === ( $created['success'] ?? false ) ? 'created' : 'blocked',
 			'decision'        => $decision,
 			'identity_key'    => (string) ( $decision['identity_key'] ?? '' ),

--- a/tests/browser-contained-site-status.test.ts
+++ b/tests/browser-contained-site-status.test.ts
@@ -94,13 +94,26 @@ $open_miss = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browser_cont
 	'input_hash' => str_repeat( 'd', 64 ),
 ) );
 $open_or_create_miss_no_fallback = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_or_create_browser_contained_site( array(
+	'mode' => 'open-only',
 	'contained_site' => array(
 		'schema' => 'wp-codebox/browser-contained-site/v1',
 		'site_id' => $cache_key,
 		'cache_key' => $cache_key,
 		'source_digest' => array( 'algorithm' => 'sha256', 'value' => str_repeat( 'd', 64 ) ),
 	),
-	'fallback_create' => false,
+) );
+$open_or_create_missing_mode = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_or_create_browser_contained_site( array(
+	'contained_site' => array(
+		'schema' => 'wp-codebox/browser-contained-site/v1',
+		'site_id' => $cache_key,
+	),
+) );
+$open_or_create_invalid_mode = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_or_create_browser_contained_site( array(
+	'mode' => 'fallback-create',
+	'contained_site' => array(
+		'schema' => 'wp-codebox/browser-contained-site/v1',
+		'site_id' => $cache_key,
+	),
 ) );
 $GLOBALS['wp_codebox_test_strip_preview_boot_ref'] = true;
 $open_unbootable = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browser_contained_site( array(
@@ -112,7 +125,7 @@ $open_unbootable = WP_Codebox_Test_Browser_Contained_Site_Abilities::open_browse
 	),
 ) );
 
-echo json_encode( array( 'hit' => $hit, 'miss' => $miss, 'incompatible' => $incompatible, 'open_hit' => $open_hit, 'open_miss' => $open_miss, 'open_or_create_miss_no_fallback' => $open_or_create_miss_no_fallback, 'open_unbootable' => $open_unbootable ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'hit' => $hit, 'miss' => $miss, 'incompatible' => $incompatible, 'open_hit' => $open_hit, 'open_miss' => $open_miss, 'open_or_create_miss_no_fallback' => $open_or_create_miss_no_fallback, 'open_or_create_missing_mode' => $open_or_create_missing_mode, 'open_or_create_invalid_mode' => $open_or_create_invalid_mode, 'open_unbootable' => $open_unbootable ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.equal(result.hit.schema, "wp-codebox/browser-contained-site-status/v1")
@@ -209,11 +222,14 @@ assert.equal(result.open_miss.requires_materialization, true)
 assert.equal(result.open_miss.blueprint_ref, undefined)
 assert.equal(result.open_or_create_miss_no_fallback.schema, "wp-codebox/browser-contained-site-open-or-create/v1")
 assert.equal(result.open_or_create_miss_no_fallback.success, false)
+assert.equal(result.open_or_create_miss_no_fallback.mode, "open-only")
 assert.equal(result.open_or_create_miss_no_fallback.action, "unavailable")
 assert.equal(result.open_or_create_miss_no_fallback.reload_required, true)
 assert.equal(result.open_or_create_miss_no_fallback.decision.action, "create-new")
 assert.equal(result.open_or_create_miss_no_fallback.error.code, "wp_codebox_browser_contained_site_unavailable")
 assert.equal(result.open_or_create_miss_no_fallback.created, undefined)
+assert.equal(result.open_or_create_missing_mode.code, "wp_codebox_browser_contained_site_mode_required")
+assert.equal(result.open_or_create_invalid_mode.code, "wp_codebox_browser_contained_site_mode_invalid")
 assert.equal(result.open_unbootable.success, false)
 assert.equal(result.open_unbootable.status, "unusable")
 assert.equal(result.open_unbootable.resolution.outcome, "unusable")

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -6,7 +6,7 @@ const root = new URL("../", import.meta.url)
 const runtimeSource = await readFile(new URL("packages/wordpress-plugin/assets/browser-runtime.js", root), "utf8")
 
 const sandbox = {
-  window: {} as { wpCodeboxBrowser?: Record<string, any> },
+  window: {} as { wpCodebox?: Record<string, any>, wpCodeboxBrowser?: Record<string, any> },
   btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
   TextDecoder,
   TextEncoder,
@@ -19,6 +19,7 @@ const api = sandbox.window.wpCodeboxBrowser
 const plain = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
 assert.ok(api, "browser runtime must publish window.wpCodeboxBrowser")
+assert.equal(typeof sandbox.window.wpCodebox?.startBrowserPreview, "function", "browser runtime must publish window.wpCodebox.startBrowserPreview")
 assert.equal(typeof api.runPhpRequest, "function", "legacy top-level methods remain available")
 assert.equal(typeof api.v1, "object", "browser runtime must expose the stable v1 facade")
 
@@ -31,6 +32,7 @@ assert.deepEqual(plain(api.v1.info()), {
     "browser-runtime:normalize-error",
     "browser-runtime:normalize-result",
     "browser-runtime:normalize-browser-run-result",
+    "browser-preview:start",
     "browser-runtime:boot-executable-session",
     "browser-runtime:parent-tool-bridge",
     "browser-runtime:aggregate-fanout-outputs",
@@ -54,6 +56,7 @@ assert.equal(api.v1.methods.runPhpRequest, api.runPhpRequest)
 assert.equal(api.v1.methods.writeFile, api.writeFile)
 assert.equal(api.v1.methods.validateBrowserRuntimeMaterialization, api.validateBrowserRuntimeMaterialization)
 assert.equal(typeof api.v1.runBrowserSessionRecipe, "function")
+assert.equal(typeof api.v1.startBrowserPreview, "function")
 assert.equal(typeof api.v1.bootExecutableBrowserSession, "function")
 assert.equal(typeof api.v1.createParentToolRequest, "function")
 assert.equal(typeof api.v1.validateBrowserRuntimeMaterialization, "function")
@@ -221,6 +224,34 @@ assert.equal(booted.schema, "wp-codebox/browser-run-result/v1")
 assert.equal(booted.status, "completed")
 assert.equal(booted.success, true)
 assert.deepEqual(plain(blueprintRuns), [{ blueprint: { steps: [{ step: "runPHP", code: "<?php echo 'ok';" }] } }])
+
+const previewStarts: any[] = []
+const previewStart = await sandbox.window.wpCodebox!.startBrowserPreview({
+  schema: "wp-codebox/browser-preview-boot-config/v1",
+  session_id: "preview-session-1",
+  remote_url: "https://playground.wordpress.net/remote.html",
+  cors_proxy_url: "https://playground.wordpress.net/proxy.php",
+  scope: "preview-session-1",
+  blueprint_ref_dto: { schema: "wp-codebox/browser-blueprint-ref/v1", ref: "prepared:preview:abc", hydrator_ability: "wp-codebox/hydrate-browser-blueprint-ref" },
+  preview: { public_url: "https://preview.example.test/" },
+}, {
+  iframe: { tagName: "IFRAME" },
+  hydrateBlueprintRef: async (request: any) => {
+    assert.equal(request.ability, "wp-codebox/hydrate-browser-blueprint-ref")
+    assert.equal(request.ref, "prepared:preview:abc")
+    return { schema: "wp-codebox/browser-blueprint-hydration/v1", blueprint: { steps: [{ step: "login" }] } }
+  },
+  startPlaygroundWeb: async (request: any) => {
+    previewStarts.push(request)
+    return { client: "playground" }
+  },
+})
+assert.equal(previewStart.schema, "wp-codebox/browser-preview-start-result/v1")
+assert.equal(previewStart.success, true)
+assert.equal(previewStart.status, "started")
+assert.equal(previewStart.session_id, "preview-session-1")
+assert.deepEqual(plain(previewStart.request), { remoteUrl: "https://playground.wordpress.net/remote.html", corsProxyUrl: "https://playground.wordpress.net/proxy.php", scope: "preview-session-1", hasIframe: true, hasBlueprint: true })
+assert.deepEqual(plain(previewStarts), [{ iframe: { tagName: "IFRAME" }, remoteUrl: "https://playground.wordpress.net/remote.html", corsProxyUrl: "https://playground.wordpress.net/proxy.php", scope: "preview-session-1", blueprint: { steps: [{ step: "login" }] } }])
 
 const parentRequest = api.v1.createParentToolRequest(executableSession, "workspace.read", "read", { path: "README.md" })
 assert.equal(parentRequest.schema, "wp-codebox/parent-tool-request/v1")


### PR DESCRIPTION
## Summary
- expose a Codebox-owned browser preview starter at `window.wpCodebox.startBrowserPreview(...)` and `window.wpCodeboxBrowser.v1.startBrowserPreview(...)`
- require explicit contained-site start `mode`: `open-only`, `open-or-create`, or `prepare-new`
- document the public browser preview boundary and cover SDK/mode behavior in tests

## Tests
- `npm run test:browser-sdk-facade`
- `npm run test:browser-contained-site-status`
- `npm run test:public-api-contract`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the browser preview SDK/session mode contract, docs, tests, and verification.