### PR TITLE
Cover deterministic fanout dependency execution

### DIFF
--- a/docs/agent-fanout-contract.md
+++ b/docs/agent-fanout-contract.md
@@ -89,6 +89,7 @@ The parent writes JSONL lifecycle events with schema
 - `worker.started`
 - `worker.completed`
 - `worker.failed`
+- `worker.skipped`
 - `aggregation.started`
 - `aggregation.completed`
 - `fanout.completed`
@@ -97,6 +98,11 @@ The parent writes JSONL lifecycle events with schema
 Product UIs should render these events as progress only. Durable decisions must
 use the final `wp-codebox/agent-fanout-result/v1` envelope and referenced worker
 artifacts.
+
+Browser hosts do not need a product-specific progress API. The generic polling
+contract is the parent artifact envelope: read `fanout/events.jsonl` for live
+progress snapshots, then read `fanout/result.json` and referenced worker or
+aggregate artifacts for durable status and review decisions.
 
 ## Artifact Layout
 

--- a/tests/fanout-execution.test.ts
+++ b/tests/fanout-execution.test.ts
@@ -85,4 +85,44 @@ assert.deepEqual(failure.aggregate.rawWorkerArtifactRefs.map((ref) => ref.path),
 assert.deepEqual(failure.aggregate.finalArtifactRefs, [])
 assert.deepEqual(failure.aggregate.conflicts.map((conflict) => conflict.type), ["failed-worker", "failed-worker", "failed-worker-dependency"])
 
+const released: Array<() => void> = []
+const orderedEvents: string[] = []
+const ordered = await executeFanoutRequest({
+  schema: FANOUT_REQUEST_SCHEMA,
+  concurrency: 3,
+  orchestrator: { session_id: "generic-ordered" },
+  workers: [
+    { id: "slow-root", goal: "Run slow root" },
+    { id: "independent", goal: "Run independent worker" },
+    { id: "after-root", goal: "Run after root", dependsOn: ["slow-root"] },
+  ],
+}, {
+  adapter: {
+    async run({ descriptor }) {
+      orderedEvents.push(`run:${descriptor.id}`)
+      if (descriptor.id === "slow-root") {
+        await new Promise<void>((resolve) => released.push(resolve))
+      }
+      if (descriptor.id === "independent") {
+        released.splice(0).forEach((release) => release())
+      }
+      orderedEvents.push(`done:${descriptor.id}`)
+      return {
+        workerId: descriptor.id,
+        success: true,
+        status: "succeeded",
+        resultRef: `workers/${descriptor.id}/result.json`,
+      }
+    },
+  },
+  requireGoal: true,
+  onWorkerStarted: (descriptor) => orderedEvents.push(`start:${descriptor.id}`),
+  onWorkerCompleted: (descriptor) => orderedEvents.push(`complete:${descriptor.id}`),
+})
+
+assert.deepEqual(ordered.workers.map((worker) => worker.workerId), ["slow-root", "independent", "after-root"])
+assert.deepEqual(ordered.counts, { total: 3, completed: 3, failed: 0, skipped: 0, cancelled: 0, timed_out: 0 })
+assert.ok(orderedEvents.indexOf("start:after-root") > orderedEvents.indexOf("complete:slow-root"), "dependent worker must not start until its dependency completes")
+assert.ok(orderedEvents.indexOf("start:independent") < orderedEvents.indexOf("complete:slow-root"), "independent worker should run while the dependency root is still active")
+
 console.log("fanout execution ok")


### PR DESCRIPTION
## Summary
- Document the emitted worker.skipped lifecycle event.
- Document the generic artifact polling contract for browser/fanout progress.
- Add regression coverage proving independent fanout workers can run while dependents wait, with deterministic result order.

## Testing
- npm run test:fanout-execution && npm run test:agent-fanout-executor && npm run test:fanout-aggregation-contract-parity
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the doc/test changes, regression verification, and PR preparation.