### PR TITLE
Add run plan progress snapshots

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -251,8 +251,8 @@ The stable public surface is grouped by lifecycle area rather than by product:
   diagnostics, test result, export link, storage, result envelope, evidence
   envelope, and materialization contracts.
 - **Run results:** normalized task, terminal, command, browser, recipe summary,
-  artifact handoff, and fuzz result DTOs that orchestrators can import from
-  `@automattic/wp-codebox-core/run-results`.
+  artifact handoff, progress snapshot, and fuzz result DTOs that orchestrators can
+  import from `@automattic/wp-codebox-core/run-results`.
 - **Inspect:** command registry metadata, JSON Schema factories, CLI `schema` and
   `commands` output, and recipe validation descriptors.
 
@@ -307,6 +307,15 @@ plugin path details stay internal/debug inputs rather than product DTO fields.
 Artifact handoff, import, and materialization results normalize to
 `wp-codebox/artifact-result-envelope/v1` through `artifactResultEnvelope()` and
 `normalizeArtifactResultEnvelope()`.
+
+Run-plan progress normalizes to `wp-codebox/run-plan-progress/v1` through
+`normalizeRunPlanProgressSnapshot()`. The snapshot reports `status`, `active`,
+settled `counts`, per-worker status, optional `sessionId`/`runId`, and optional
+`eventsRef`/`resultRef` references. Hosts may stream or persist those snapshots in
+their own job system, but WP Codebox does not require host job ownership, create a
+durable parent queue, or expose artifact-file paths as the only progress contract.
+Cancellation appears as normalized worker/run status when requested or observed;
+host UIs own the button, policy, and durable cancellation request transport.
 
 Fuzzing callers can attach `performanceObservation()` output to case diagnostics
 or evidence artifacts when command behavior needs comparable performance context.

--- a/packages/runtime-core/src/run-plan.ts
+++ b/packages/runtime-core/src/run-plan.ts
@@ -1,5 +1,6 @@
 export const RUN_PLAN_SCHEMA = "wp-codebox/run-plan/v1" as const
 export const RUN_PLAN_EVENT_SCHEMA = "wp-codebox/run-plan-event/v1" as const
+export const RUN_PLAN_PROGRESS_SCHEMA = "wp-codebox/run-plan-progress/v1" as const
 export const RUN_PLAN_RESULT_SCHEMA = "wp-codebox/run-plan-result/v1" as const
 
 export interface RunPlanWorkerContract {
@@ -81,6 +82,32 @@ export interface RunPlanResultCounts {
   timed_out: number
 }
 
+export type RunPlanProgressStatus = "queued" | "running" | "succeeded" | "failed" | "skipped" | "cancelled" | "timed_out"
+
+export interface RunPlanProgressWorkerSnapshot {
+  id: string
+  status: RunPlanProgressStatus
+  required?: boolean
+  artifactNamespace?: string
+  lastEvent?: string
+  startedAt?: string
+  completedAt?: string
+}
+
+export interface RunPlanProgressSnapshot {
+  schema: typeof RUN_PLAN_PROGRESS_SCHEMA
+  time: string
+  status: RunPlanProgressStatus
+  active: number
+  counts: RunPlanResultCounts
+  workers: RunPlanProgressWorkerSnapshot[]
+  sessionId?: string
+  runId?: string
+  eventsRef?: string
+  resultRef?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface RunPlanWorkerExecution<TWorker extends RunPlanWorkerContract = RunPlanWorkerContract> {
   descriptor: RunPlanWorkerDescriptor<TWorker>
   index: number
@@ -138,6 +165,71 @@ export function countRunPlanChildResults(results: RunPlanChildResult[]): RunPlan
 
 export function runPlanSucceeded(counts: Pick<RunPlanResultCounts, "failed" | "skipped" | "cancelled" | "timed_out">): boolean {
   return counts.failed === 0 && counts.skipped === 0 && counts.cancelled === 0 && counts.timed_out === 0
+}
+
+export function normalizeRunPlanProgressSnapshot(input: {
+  plan?: Partial<RunPlanContract>
+  workers?: Array<Partial<RunPlanWorkerDescriptor> | RunPlanWorkerContract>
+  results?: RunPlanWorkerResultLike[]
+  events?: RunPlanEventContract[]
+  sessionId?: string
+  runId?: string
+  eventsRef?: string
+  resultRef?: string
+  time?: string
+  clock?: RunPlanClock
+  metadata?: Record<string, unknown>
+} = {}): RunPlanProgressSnapshot {
+  const workerSources = input.workers ?? input.plan?.workers ?? []
+  const resultByWorker = new Map((input.results ?? []).map((result) => [result.workerId, result]))
+  const workerById = new Map<string, RunPlanProgressWorkerSnapshot>()
+
+  for (const source of workerSources) {
+    const worker = source as Partial<RunPlanWorkerDescriptor> & RunPlanWorkerContract
+    const id = stringValue(worker.id)
+    if (!id || workerById.has(id)) continue
+    workerById.set(id, {
+      id,
+      status: "queued",
+      ...(typeof worker.required === "boolean" ? { required: worker.required } : {}),
+      ...(stringValue(worker.artifactNamespace ?? worker.artifact_namespace) ? { artifactNamespace: stringValue(worker.artifactNamespace ?? worker.artifact_namespace) } : {}),
+    })
+  }
+
+  for (const event of input.events ?? []) {
+    const workerId = stringValue(event.workerId)
+    if (!workerId) continue
+    const current = workerById.get(workerId) ?? { id: workerId, status: "queued" as const }
+    const eventStatus = runPlanProgressStatusFromEvent(event)
+    workerById.set(workerId, {
+      ...current,
+      status: eventStatus ?? current.status,
+      lastEvent: stringValue(event.event) || current.lastEvent,
+      ...(eventStatus === "running" && event.time ? { startedAt: event.time } : {}),
+      ...((eventStatus && eventStatus !== "running" && event.time) ? { completedAt: event.time } : {}),
+    })
+  }
+
+  for (const [workerId, result] of resultByWorker) {
+    const current = workerById.get(workerId) ?? { id: workerId, status: "queued" as const }
+    workerById.set(workerId, { ...current, status: runPlanProgressStatusFromResult(result) })
+  }
+
+  const workers = Array.from(workerById.values())
+  const counts = countRunPlanProgressWorkers(workers)
+  return {
+    schema: RUN_PLAN_PROGRESS_SCHEMA,
+    time: input.time ?? runPlanClockIso(input.clock),
+    status: runPlanProgressStatusFromCounts(counts),
+    active: workers.filter((worker) => worker.status === "running").length,
+    counts,
+    workers,
+    ...(stringValue(input.sessionId ?? input.plan?.sessionId) ? { sessionId: stringValue(input.sessionId ?? input.plan?.sessionId) } : {}),
+    ...(stringValue(input.runId ?? input.plan?.id) ? { runId: stringValue(input.runId ?? input.plan?.id) } : {}),
+    ...(stringValue(input.eventsRef) ? { eventsRef: stringValue(input.eventsRef) } : {}),
+    ...(stringValue(input.resultRef) ? { resultRef: stringValue(input.resultRef) } : {}),
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  }
 }
 
 export async function executeRunPlan<TWorker extends RunPlanWorkerContract, TResult extends RunPlanWorkerResultLike>(plan: Pick<RunPlanContract, "workers" | "concurrency">, options: RunPlanExecutorOptions<TWorker, TResult>): Promise<RunPlanExecutorResult<TResult>> {
@@ -434,6 +526,45 @@ function defaultTimedOutRunPlanResult<TWorker extends RunPlanWorkerContract, TRe
     status: "timed_out",
     error: { code: "worker-timed-out", message: `Run plan worker ${descriptor.id} exceeded its ${reason}.` },
   } as unknown as TResult
+}
+
+function countRunPlanProgressWorkers(workers: RunPlanProgressWorkerSnapshot[]): RunPlanResultCounts {
+  return {
+    total: workers.length,
+    completed: workers.filter((worker) => worker.status === "succeeded").length,
+    failed: workers.filter((worker) => worker.status === "failed").length,
+    skipped: workers.filter((worker) => worker.status === "skipped").length,
+    cancelled: workers.filter((worker) => worker.status === "cancelled").length,
+    timed_out: workers.filter((worker) => worker.status === "timed_out").length,
+  }
+}
+
+function runPlanProgressStatusFromResult(result: RunPlanWorkerResultLike): RunPlanProgressStatus {
+  if (result.success === true) return "succeeded"
+  const status = stringValue(result.status)
+  if (status === "cancelled" || status === "skipped" || status === "timed_out" || status === "timeout") return status === "timeout" ? "timed_out" : status
+  return "failed"
+}
+
+function runPlanProgressStatusFromEvent(event: RunPlanEventContract): RunPlanProgressStatus | undefined {
+  const label = `${stringValue(event.event)} ${stringValue(event.status)}`
+  if (/started|running/.test(label)) return "running"
+  if (/completed|succeeded|success/.test(label)) return "succeeded"
+  if (/cancelled|canceled/.test(label)) return "cancelled"
+  if (/timed[_ -]?out|timeout/.test(label)) return "timed_out"
+  if (/skipped/.test(label)) return "skipped"
+  if (/failed|error/.test(label)) return "failed"
+  return undefined
+}
+
+function runPlanProgressStatusFromCounts(counts: RunPlanResultCounts): RunPlanProgressStatus {
+  const settled = counts.completed + counts.failed + counts.skipped + counts.cancelled + counts.timed_out
+  if (settled < counts.total) return "running"
+  if (counts.timed_out > 0) return "timed_out"
+  if (counts.cancelled > 0) return "cancelled"
+  if (counts.failed > 0) return "failed"
+  if (counts.skipped > 0) return "skipped"
+  return "succeeded"
 }
 
 function stringValue(value: unknown): string {

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -153,6 +153,14 @@ returns a `wp-codebox/sandbox-session/v1` envelope with that id, optional
 create host-site job tables or depend on a specific queue. See
 `docs/sandbox-session-contract.md`.
 
+Host progress consumers can normalize run-plan events and child results to
+`wp-codebox/run-plan-progress/v1`. The public snapshot contains a run status,
+active worker count, settled counts, per-worker status, optional session/run ids,
+and optional event/result refs. Hosts own streaming, persistence, UI polling, and
+cancellation-request transport; WP Codebox owns the generic progress shape and
+maps artifact/event evidence into that shape without requiring durable parent
+ownership.
+
 Both abilities accept optional `provider` and `model` fields. These seed the
 disposable sandbox agent configuration for the selected execution mode. Provider
 plugins are supplied with `provider_plugin_paths`; WP Codebox mounts and

--- a/packages/wordpress-plugin/src/class-wp-codebox-run-plan.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-run-plan.php
@@ -9,9 +9,10 @@ defined( 'ABSPATH' ) || exit;
 
 final class WP_Codebox_Run_Plan {
 
-	public const SCHEMA        = 'wp-codebox/run-plan/v1';
-	public const EVENT_SCHEMA  = 'wp-codebox/run-plan-event/v1';
-	public const RESULT_SCHEMA = 'wp-codebox/run-plan-result/v1';
+	public const SCHEMA          = 'wp-codebox/run-plan/v1';
+	public const EVENT_SCHEMA    = 'wp-codebox/run-plan-event/v1';
+	public const PROGRESS_SCHEMA = 'wp-codebox/run-plan-progress/v1';
+	public const RESULT_SCHEMA   = 'wp-codebox/run-plan-result/v1';
 
 	/** @param array<string,mixed> $options Normalization options. */
 	public function normalize_concurrency( mixed $value, array $options = array() ): int|WP_Error {
@@ -250,6 +251,103 @@ final class WP_Codebox_Run_Plan {
 		return 0 === $counts['failed'] && 0 === $counts['skipped'] && 0 === $counts['cancelled'] && 0 === $counts['timed_out'];
 	}
 
+	/**
+	 * @param array<string,mixed> $input Progress inputs.
+	 * @return array<string,mixed>
+	 */
+	public function progress_snapshot( array $input = array() ): array {
+		$plan    = is_array( $input['plan'] ?? null ) ? $input['plan'] : array();
+		$workers = is_array( $input['workers'] ?? null ) ? $input['workers'] : ( is_array( $plan['workers'] ?? null ) ? $plan['workers'] : array() );
+		$events  = is_array( $input['events'] ?? null ) ? $input['events'] : array();
+		$results = is_array( $input['results'] ?? null ) ? $input['results'] : array();
+
+		$worker_map = array();
+		foreach ( $workers as $worker ) {
+			if ( ! is_array( $worker ) ) {
+				continue;
+			}
+			$id = $this->string_value( $worker['id'] ?? '' );
+			if ( '' === $id || isset( $worker_map[ $id ] ) ) {
+				continue;
+			}
+			$snapshot = array(
+				'id'     => $id,
+				'status' => 'queued',
+			);
+			if ( isset( $worker['required'] ) && is_bool( $worker['required'] ) ) {
+				$snapshot['required'] = $worker['required'];
+			}
+			$artifact_namespace = $this->string_value( $worker['artifactNamespace'] ?? $worker['artifact_namespace'] ?? '' );
+			if ( '' !== $artifact_namespace ) {
+				$snapshot['artifactNamespace'] = $artifact_namespace;
+			}
+			$worker_map[ $id ] = $snapshot;
+		}
+
+		foreach ( $events as $event ) {
+			if ( ! is_array( $event ) ) {
+				continue;
+			}
+			$worker_id = $this->string_value( $event['workerId'] ?? $event['worker_id'] ?? '' );
+			if ( '' === $worker_id ) {
+				continue;
+			}
+			$current = $worker_map[ $worker_id ] ?? array( 'id' => $worker_id, 'status' => 'queued' );
+			$status  = $this->progress_status_from_event( $event );
+			if ( null !== $status ) {
+				$current['status'] = $status;
+			}
+			$event_name = $this->string_value( $event['event'] ?? '' );
+			if ( '' !== $event_name ) {
+				$current['lastEvent'] = $event_name;
+			}
+			$time = $this->string_value( $event['time'] ?? '' );
+			if ( '' !== $time && 'running' === $status ) {
+				$current['startedAt'] = $time;
+			} elseif ( '' !== $time && null !== $status ) {
+				$current['completedAt'] = $time;
+			}
+			$worker_map[ $worker_id ] = $current;
+		}
+
+		foreach ( $results as $result ) {
+			if ( ! is_array( $result ) ) {
+				continue;
+			}
+			$worker_id = $this->string_value( $result['workerId'] ?? $result['worker_id'] ?? '' );
+			if ( '' === $worker_id ) {
+				continue;
+			}
+			$current                 = $worker_map[ $worker_id ] ?? array( 'id' => $worker_id, 'status' => 'queued' );
+			$current['status']       = $this->progress_status_from_result( $result );
+			$worker_map[ $worker_id ] = $current;
+		}
+
+		$workers_snapshot = array_values( $worker_map );
+		$counts           = $this->progress_counts( $workers_snapshot );
+		$snapshot         = array(
+			'schema'  => self::PROGRESS_SCHEMA,
+			'time'    => $this->string_value( $input['time'] ?? '' ) ?: gmdate( 'c' ),
+			'status'  => $this->progress_status_from_counts( $counts ),
+			'active'  => count( array_filter( $workers_snapshot, static fn( array $worker ): bool => 'running' === ( $worker['status'] ?? '' ) ) ),
+			'counts'  => $counts,
+			'workers' => $workers_snapshot,
+		);
+
+		foreach ( array( 'sessionId', 'runId', 'eventsRef', 'resultRef' ) as $key ) {
+			$plan_key = 'runId' === $key ? 'id' : $key;
+			$value    = $this->string_value( $input[ $key ] ?? $plan[ $key ] ?? $plan[ $plan_key ] ?? '' );
+			if ( '' !== $value ) {
+				$snapshot[ $key ] = $value;
+			}
+		}
+		if ( isset( $input['metadata'] ) && is_array( $input['metadata'] ) ) {
+			$snapshot['metadata'] = $input['metadata'];
+		}
+
+		return $snapshot;
+	}
+
 	/** @param array<string,string> $paths Run-plan artifact paths. @return array<string,mixed> */
 	public function artifacts( string $schema, array $paths ): array {
 		return array(
@@ -353,5 +451,68 @@ final class WP_Codebox_Run_Plan {
 
 	private function string_value( mixed $value ): string {
 		return trim( (string) ( $value ?? '' ) );
+	}
+
+	/** @param array<int,array<string,mixed>> $workers Workers. @return array{total:int,completed:int,failed:int,skipped:int,cancelled:int,timed_out:int} */
+	private function progress_counts( array $workers ): array {
+		$status_count = static fn( string $status ): int => count( array_filter( $workers, static fn( array $worker ): bool => $status === ( $worker['status'] ?? '' ) ) );
+		return array(
+			'total'     => count( $workers ),
+			'completed' => $status_count( 'succeeded' ),
+			'failed'    => $status_count( 'failed' ),
+			'skipped'   => $status_count( 'skipped' ),
+			'cancelled' => $status_count( 'cancelled' ),
+			'timed_out' => $status_count( 'timed_out' ),
+		);
+	}
+
+	/** @param array<string,mixed> $result Result. */
+	private function progress_status_from_result( array $result ): string {
+		if ( true === ( $result['success'] ?? false ) ) {
+			return 'succeeded';
+		}
+		$status = $this->string_value( $result['status'] ?? '' );
+		if ( 'timeout' === $status ) {
+			return 'timed_out';
+		}
+		return in_array( $status, array( 'cancelled', 'skipped', 'timed_out' ), true ) ? $status : 'failed';
+	}
+
+	/** @param array<string,mixed> $event Event. */
+	private function progress_status_from_event( array $event ): ?string {
+		$label = $this->string_value( $event['event'] ?? '' ) . ' ' . $this->string_value( $event['status'] ?? '' );
+		if ( preg_match( '/started|running/', $label ) ) {
+			return 'running';
+		}
+		if ( preg_match( '/completed|succeeded|success/', $label ) ) {
+			return 'succeeded';
+		}
+		if ( preg_match( '/cancelled|canceled/', $label ) ) {
+			return 'cancelled';
+		}
+		if ( preg_match( '/timed[_ -]?out|timeout/', $label ) ) {
+			return 'timed_out';
+		}
+		if ( preg_match( '/skipped/', $label ) ) {
+			return 'skipped';
+		}
+		if ( preg_match( '/failed|error/', $label ) ) {
+			return 'failed';
+		}
+		return null;
+	}
+
+	/** @param array{total:int,completed:int,failed:int,skipped:int,cancelled:int,timed_out:int} $counts Counts. */
+	private function progress_status_from_counts( array $counts ): string {
+		$settled = $counts['completed'] + $counts['failed'] + $counts['skipped'] + $counts['cancelled'] + $counts['timed_out'];
+		if ( $settled < $counts['total'] ) {
+			return 'running';
+		}
+		foreach ( array( 'timed_out', 'cancelled', 'failed', 'skipped' ) as $status ) {
+			if ( $counts[ $status ] > 0 ) {
+				return $status;
+			}
+		}
+		return 'succeeded';
 	}
 }

--- a/scripts/php-primitive-contract-parity-smoke.php
+++ b/scripts/php-primitive-contract-parity-smoke.php
@@ -141,5 +141,6 @@ if ( is_wp_error( $dependency_descriptors ) ) {
 assert_same_contract( $fixture['runPlan']['dependencyBatches'], $run_plan->dependency_batches( $dependency_descriptors ), 'run-plan dependency batches' );
 assert_same_contract( $fixture['runPlan']['concurrency']['defaulted'], $run_plan->normalize_concurrency( '', array( 'default_concurrency' => 3, 'max_concurrency' => 5 ) ), 'run-plan default concurrency' );
 assert_same_contract( $fixture['runPlan']['concurrency']['clamped'], $run_plan->normalize_concurrency( 99, array( 'max_concurrency' => 2 ) ), 'run-plan clamped concurrency' );
+assert_same_contract( $fixture['runPlan']['progress'], $run_plan->progress_snapshot( $fixture['runPlan']['progressInput'] ), 'run-plan progress snapshot' );
 
 fwrite( STDOUT, "PHP primitive contract parity smoke passed\n" );

--- a/scripts/primitive-contract-fixture.ts
+++ b/scripts/primitive-contract-fixture.ts
@@ -4,6 +4,7 @@ import {
   componentManifestForRuntimePlugins,
   countRunPlanChildResults,
   normalizeRunPlanConcurrency,
+  normalizeRunPlanProgressSnapshot,
   normalizeRuntimeMountTarget,
   redactJsonValue,
   resolveEffectiveRuntimeToolPolicy,
@@ -11,6 +12,7 @@ import {
   runPlanSucceeded,
   runtimeDependencyPlanContract,
   RUN_PLAN_EVENT_SCHEMA,
+  RUN_PLAN_PROGRESS_SCHEMA,
   RUN_PLAN_RESULT_SCHEMA,
   RUN_PLAN_SCHEMA,
   safeArtifactRelativePath,
@@ -140,6 +142,27 @@ const runPlanDependencyWorkers = [
   { id: "dependent", goal: "Dependent", dependsOn: ["setup", "parallel"] },
 ]
 
+const runPlanProgressInput = {
+  plan: {
+    id: "run-fixture",
+    sessionId: "session-fixture",
+    concurrency: 2,
+    workers: [
+      { id: "setup", artifactNamespace: "workers/setup" },
+      { id: "execute" },
+    ],
+  },
+  events: [
+    { event: "worker.started", workerId: "setup", time: "2026-03-04T05:06:00.000Z" },
+    { event: "worker.completed", workerId: "setup", time: "2026-03-04T05:06:01.000Z" },
+    { event: "worker.started", workerId: "execute", time: "2026-03-04T05:06:02.000Z" },
+  ],
+  results: [{ workerId: "setup", status: "succeeded", success: true }],
+  eventsRef: "events.jsonl",
+  resultRef: "result.json",
+  time: "2026-03-04T05:06:03.000Z",
+}
+
 export function primitiveContractsFixture(): Record<string, unknown> {
   const effectiveToolPolicy = resolveEffectiveRuntimeToolPolicy(toolPolicySnapshot)
   const runPlanCounts = countRunPlanChildResults(runPlanChildren)
@@ -198,7 +221,9 @@ export function primitiveContractsFixture(): Record<string, unknown> {
         defaulted: normalizeRunPlanConcurrency("", { defaultConcurrency: 3, maxConcurrency: 5 }),
         clamped: normalizeRunPlanConcurrency(99, { maxConcurrency: 2 }),
       },
-      schemas: { plan: RUN_PLAN_SCHEMA, event: RUN_PLAN_EVENT_SCHEMA, result: RUN_PLAN_RESULT_SCHEMA },
+      progressInput: runPlanProgressInput,
+      progress: normalizeRunPlanProgressSnapshot(runPlanProgressInput),
+      schemas: { plan: RUN_PLAN_SCHEMA, event: RUN_PLAN_EVENT_SCHEMA, progress: RUN_PLAN_PROGRESS_SCHEMA, result: RUN_PLAN_RESULT_SCHEMA },
     },
   }
 }

--- a/tests/docs-boundary-language.test.ts
+++ b/tests/docs-boundary-language.test.ts
@@ -47,6 +47,9 @@ const publicApiContract = await readFile(new URL("docs/public-api-contract.md", 
 assert.match(publicApiContract, /External integrations should compose the Codebox core facades,\s+WordPress abilities, CLI, or browser SDK/)
 assert.match(publicApiContract, /Product consumers should use the Codebox-owned public surfaces/)
 assert.match(publicApiContract, /manifest intentionally excludes backend handler bindings/)
+assert.match(publicApiContract, /`wp-codebox\/run-plan-progress\/v1`/)
+assert.match(publicApiContract, /Hosts may stream or persist those snapshots in\s+their own job system/)
+assert.match(publicApiContract, /host UIs own the button, policy, and durable cancellation request transport/)
 
 const cookbookReadme = await readFile(new URL("examples/recipes/cookbook/README.md", root), "utf8")
 assert.match(cookbookReadme, /Provider-specific agent compatibility fixtures are kept under\s+`tests\/fixtures\/legacy-compatibility-recipes`/)

--- a/tests/fixtures/primitive-contracts.json
+++ b/tests/fixtures/primitive-contracts.json
@@ -507,9 +507,87 @@
       "defaulted": 3,
       "clamped": 2
     },
+    "progressInput": {
+      "plan": {
+        "id": "run-fixture",
+        "sessionId": "session-fixture",
+        "concurrency": 2,
+        "workers": [
+          {
+            "id": "setup",
+            "artifactNamespace": "workers/setup"
+          },
+          {
+            "id": "execute"
+          }
+        ]
+      },
+      "events": [
+        {
+          "event": "worker.started",
+          "workerId": "setup",
+          "time": "2026-03-04T05:06:00.000Z"
+        },
+        {
+          "event": "worker.completed",
+          "workerId": "setup",
+          "time": "2026-03-04T05:06:01.000Z"
+        },
+        {
+          "event": "worker.started",
+          "workerId": "execute",
+          "time": "2026-03-04T05:06:02.000Z"
+        }
+      ],
+      "results": [
+        {
+          "workerId": "setup",
+          "status": "succeeded",
+          "success": true
+        }
+      ],
+      "eventsRef": "events.jsonl",
+      "resultRef": "result.json",
+      "time": "2026-03-04T05:06:03.000Z"
+    },
+    "progress": {
+      "schema": "wp-codebox/run-plan-progress/v1",
+      "time": "2026-03-04T05:06:03.000Z",
+      "status": "running",
+      "active": 1,
+      "counts": {
+        "total": 2,
+        "completed": 1,
+        "failed": 0,
+        "skipped": 0,
+        "cancelled": 0,
+        "timed_out": 0
+      },
+      "workers": [
+        {
+          "id": "setup",
+          "status": "succeeded",
+          "artifactNamespace": "workers/setup",
+          "lastEvent": "worker.completed",
+          "startedAt": "2026-03-04T05:06:00.000Z",
+          "completedAt": "2026-03-04T05:06:01.000Z"
+        },
+        {
+          "id": "execute",
+          "status": "running",
+          "lastEvent": "worker.started",
+          "startedAt": "2026-03-04T05:06:02.000Z"
+        }
+      ],
+      "sessionId": "session-fixture",
+      "runId": "run-fixture",
+      "eventsRef": "events.jsonl",
+      "resultRef": "result.json"
+    },
     "schemas": {
       "plan": "wp-codebox/run-plan/v1",
       "event": "wp-codebox/run-plan-event/v1",
+      "progress": "wp-codebox/run-plan-progress/v1",
       "result": "wp-codebox/run-plan-result/v1"
     }
   }

--- a/tests/primitive-contract-parity.test.ts
+++ b/tests/primitive-contract-parity.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeCommandEnvelopeStatus,
   normalizePhaseRecipeStatus,
   normalizeRunPlanConcurrency,
+  normalizeRunPlanProgressSnapshot,
   normalizeRunPlanWorkerDescriptors,
   normalizeRuntimeMountTarget,
   redactJsonValue,
@@ -16,6 +17,7 @@ import {
   runPlanSucceeded,
   runtimeDependencyPlanContract,
   RUN_PLAN_EVENT_SCHEMA,
+  RUN_PLAN_PROGRESS_SCHEMA,
   RUN_PLAN_RESULT_SCHEMA,
   RUN_PLAN_SCHEMA,
   safeArtifactRelativePath,
@@ -86,9 +88,11 @@ assert.deepEqual(
 )
 assert.equal(normalizeRunPlanConcurrency("", { defaultConcurrency: 3, maxConcurrency: 5 }), fixture.runPlan.concurrency.defaulted)
 assert.equal(normalizeRunPlanConcurrency(99, { maxConcurrency: 2 }), fixture.runPlan.concurrency.clamped)
+assert.deepEqual(normalizeRunPlanProgressSnapshot(fixture.runPlan.progressInput), fixture.runPlan.progress)
 assert.deepEqual(fixture.runPlan.schemas, {
   plan: RUN_PLAN_SCHEMA,
   event: RUN_PLAN_EVENT_SCHEMA,
+  progress: RUN_PLAN_PROGRESS_SCHEMA,
   result: RUN_PLAN_RESULT_SCHEMA,
 })
 

--- a/tests/run-plan-executor.test.ts
+++ b/tests/run-plan-executor.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 
-import { createRunPlanEvent, executeRunPlan, type RunPlanEventContract, type RunPlanWorkerAdapter } from "../packages/runtime-core/src/index.js"
+import { createRunPlanEvent, executeRunPlan, normalizeRunPlanProgressSnapshot, type RunPlanEventContract, type RunPlanWorkerAdapter } from "../packages/runtime-core/src/index.js"
 
 const events: string[] = []
 const runs: string[] = []
@@ -136,6 +136,43 @@ assert.deepEqual(createRunPlanEvent<RunPlanEventContract>("wp-codebox/run-plan-e
   schema: "wp-codebox/run-plan-event/v1",
   time: "2026-03-04T05:06:07.000Z",
   event: "worker.started",
+})
+
+assert.deepEqual(normalizeRunPlanProgressSnapshot({
+  plan: {
+    id: "run-123",
+    sessionId: "session-123",
+    concurrency: 2,
+    workers: [
+      { id: "one", goal: "Done", artifactNamespace: "workers/one" },
+      { id: "two", goal: "Active" },
+      { id: "three", goal: "Queued" },
+    ],
+  },
+  events: [
+    { event: "worker.started", workerId: "one", time: "2026-03-04T05:06:00.000Z" },
+    { event: "worker.completed", workerId: "one", time: "2026-03-04T05:06:01.000Z" },
+    { event: "worker.started", workerId: "two", time: "2026-03-04T05:06:02.000Z" },
+  ],
+  results: [{ workerId: "one", status: "succeeded", success: true }],
+  eventsRef: "events.jsonl",
+  resultRef: "result.json",
+  time: "2026-03-04T05:06:03.000Z",
+}), {
+  schema: "wp-codebox/run-plan-progress/v1",
+  time: "2026-03-04T05:06:03.000Z",
+  status: "running",
+  active: 1,
+  counts: { total: 3, completed: 1, failed: 0, skipped: 0, cancelled: 0, timed_out: 0 },
+  workers: [
+    { id: "one", status: "succeeded", artifactNamespace: "workers/one", lastEvent: "worker.completed", startedAt: "2026-03-04T05:06:00.000Z", completedAt: "2026-03-04T05:06:01.000Z" },
+    { id: "two", status: "running", lastEvent: "worker.started", startedAt: "2026-03-04T05:06:02.000Z" },
+    { id: "three", status: "queued" },
+  ],
+  sessionId: "session-123",
+  runId: "run-123",
+  eventsRef: "events.jsonl",
+  resultRef: "result.json",
 })
 
 console.log("run plan executor ok")


### PR DESCRIPTION
## Summary
- Add wp-codebox/run-plan-progress/v1.
- Add TypeScript and PHP progress snapshot normalizers.
- Document host-owned persistence, polling, streaming, and cancellation boundaries.

## Verification
- npm run test:run-plan-executor
- npm run test:primitive-contract-parity
- npm run test:php-primitive-contract-parity
- npx tsx tests/docs-boundary-language.test.ts
- php -l packages/wordpress-plugin/src/class-wp-codebox-run-plan.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Auditing progress-contract gaps, drafting implementation changes, resolving merge conflicts, and running targeted verification.