### PR TITLE
Run generic agent task workflow

### DIFF
--- a/.github/scripts/run-agent-task/build-codebox-task-request.mjs
+++ b/.github/scripts/run-agent-task/build-codebox-task-request.mjs
@@ -89,8 +89,106 @@ const request = {
   dry_run: booleanEnv("DRY_RUN"),
 }
 
+const runId = `${request.workload.id}-${process.env.GITHUB_RUN_ID || "local"}`.replace(/[^A-Za-z0-9._-]+/g, "-")
+const runnerRecipe = parseRunnerRecipe(request.runner_recipe)
+const secretEnv = [
+  request.model.provider === "openai" ? "OPENAI_API_KEY" : "",
+  ...[1, 2, 3, 4, 5]
+    .map((index) => `MODEL_PROVIDER_SECRET_${index}`)
+    .filter((name) => process.env[name]),
+].filter(Boolean)
+
+const homeboyPlan = {
+  schema: "homeboy/agent-task-plan/v1",
+  plan_id: runId,
+  tasks: [
+    stripUndefined({
+      schema: "homeboy/agent-task-request/v1",
+      task_id: runId,
+      executor: {
+        backend: "codebox",
+        secret_env: secretEnv,
+        config: stripUndefined({
+          execution_kind: "agent_bundle",
+          runner_recipe: request.runner_recipe,
+          recipe_repo: runnerRecipe.repository,
+          recipe_ref: runnerRecipe.ref,
+          recipe_path: runnerRecipe.path,
+          bundle_repo: runnerRecipe.repository,
+          bundle_ref: runnerRecipe.ref,
+          bundle_path_in_repo: request.agent_bundle,
+          agent_bundle: {
+            bundle_repo: runnerRecipe.repository,
+            bundle_ref: runnerRecipe.ref,
+            bundle_path_in_repo: request.agent_bundle,
+          },
+          target_repo: request.target_repo,
+          component_id: request.workload.component_id,
+          provider: request.model.provider,
+          model: request.model.name,
+          prompt: request.prompt,
+          writable_paths: request.writable_paths,
+          runner_workspace: request.runner_workspace,
+          context_repositories: request.context_repositories,
+          verification_commands: request.verification_commands,
+          drift_checks: request.drift_checks,
+          workspace_contract_checks: request.workspace_contract_checks,
+          actions_artifact_downloads: request.actions_artifact_downloads,
+          validation_dependencies: request.validation_dependencies,
+          success_requires_pr: request.success.requires_pr,
+          success_completion_outcomes: request.success.completion_outcomes,
+          tool_results_key: request.outputs.tool_results_key,
+          engine_data_outputs: request.outputs.projections,
+          transcript_artifact_name: request.artifacts.transcript_name,
+          replay_bundle_artifact_name: request.artifacts.replay_bundle_name,
+          artifact_declarations: request.artifacts.declarations,
+          expected_artifacts: request.artifacts.expected,
+          callback_data: request.callback_data,
+          max_turns: request.limits.max_turns,
+          step_budget: request.limits.step_budget,
+          time_budget_ms: request.limits.time_budget_ms,
+        }),
+      },
+      instructions: request.prompt,
+      workspace: {
+        mode: "managed",
+        target_repo: request.target_repo,
+        publication: request.runner_workspace,
+      },
+      policy: {
+        read: "allow",
+        write: "patch_only",
+        apply: "reviewed",
+      },
+      limits: {
+        max_turns: request.limits.max_turns,
+        step_budget: request.limits.step_budget,
+        time_budget_ms: request.limits.time_budget_ms,
+      },
+      expected_artifacts: request.artifacts.expected,
+      artifact_declarations: request.artifacts.declarations,
+      metadata: {
+        workflow_request_schema: request.schema,
+        target_repo: request.target_repo,
+        workload: request.workload,
+        callback_data: request.callback_data,
+      },
+    }),
+  ],
+  options: {
+    max_concurrency: 1,
+    max_queue_depth: 1,
+  },
+  metadata: {
+    source_schema: request.schema,
+    runner_recipe: request.runner_recipe,
+    agent_bundle: request.agent_bundle,
+  },
+}
+
 mkdirSync(".codebox", { recursive: true })
 writeFileSync(".codebox/agent-task-request.json", `${JSON.stringify(request, null, 2)}\n`)
+writeFileSync(".codebox/homeboy-agent-task-plan.json", `${JSON.stringify(homeboyPlan, null, 2)}\n`)
 
 const status = request.run_agent && !request.dry_run ? "planned" : "skipped"
 output("job_status", status)
@@ -99,3 +197,24 @@ output("transcript_summary", `${request.workload.label}: ${status}`)
 output("engine_data_json", JSON.stringify({}))
 output("credential_mode", request.access.require_access_token ? "app-token" : "default")
 output("declared_artifacts_json", JSON.stringify(artifactDeclarations))
+output("homeboy_plan_path", ".codebox/homeboy-agent-task-plan.json")
+output("run_id", runId)
+
+function parseRunnerRecipe(descriptor) {
+  const match = String(descriptor || "").match(/^([^@:\s]+\/[^@:\s]+)@([^:\s]+):(.+)$/)
+  if (!match) {
+    throw new Error("RUNNER_RECIPE must use OWNER/REPO@ref:path.")
+  }
+  return {
+    repository: `https://github.com/${match[1]}.git`,
+    ref: match[2],
+    path: match[3],
+  }
+}
+
+function stripUndefined(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value
+  }
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined))
+}

--- a/.github/workflows/run-agent-task.yml
+++ b/.github/workflows/run-agent-task.yml
@@ -174,10 +174,10 @@ jobs:
   run-agent-task:
     runs-on: ubuntu-latest
     outputs:
-      job_status: ${{ steps.plan.outputs.job_status }}
-      transcript_json: ${{ steps.plan.outputs.transcript_json }}
-      transcript_summary: ${{ steps.plan.outputs.transcript_summary }}
-      engine_data_json: ${{ steps.plan.outputs.engine_data_json }}
+      job_status: ${{ steps.execute.outputs.job_status || steps.plan.outputs.job_status }}
+      transcript_json: ${{ steps.execute.outputs.transcript_json || steps.plan.outputs.transcript_json }}
+      transcript_summary: ${{ steps.execute.outputs.transcript_summary || steps.plan.outputs.transcript_summary }}
+      engine_data_json: ${{ steps.execute.outputs.engine_data_json || steps.plan.outputs.engine_data_json }}
       credential_mode: ${{ steps.plan.outputs.credential_mode }}
       declared_artifacts_json: ${{ steps.plan.outputs.declared_artifacts_json }}
     steps:
@@ -231,10 +231,65 @@ jobs:
           CALLBACK_DATA: ${{ inputs.callback_data }}
           RUN_AGENT: ${{ inputs.run_agent }}
           DRY_RUN: ${{ inputs.dry_run }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MODEL_PROVIDER_SECRET_1: ${{ secrets.MODEL_PROVIDER_SECRET_1 }}
+          MODEL_PROVIDER_SECRET_2: ${{ secrets.MODEL_PROVIDER_SECRET_2 }}
+          MODEL_PROVIDER_SECRET_3: ${{ secrets.MODEL_PROVIDER_SECRET_3 }}
+          MODEL_PROVIDER_SECRET_4: ${{ secrets.MODEL_PROVIDER_SECRET_4 }}
+          MODEL_PROVIDER_SECRET_5: ${{ secrets.MODEL_PROVIDER_SECRET_5 }}
         run: node .wp-codebox-workflow/.github/scripts/run-agent-task/build-codebox-task-request.mjs
 
       - name: Upload Codebox task request
         uses: actions/upload-artifact@v4
         with:
           name: codebox-agent-task-request-${{ github.run_id }}
-          path: .codebox/agent-task-request.json
+          path: |
+            .codebox/agent-task-request.json
+            .codebox/homeboy-agent-task-plan.json
+
+      - name: Install Homeboy runner
+        if: inputs.run_agent && !inputs.dry_run
+        uses: Extra-Chill/homeboy-action@v2
+        with:
+          extension: wordpress
+          commands: ','
+          auto-setup: 'false'
+          pr-comment: 'false'
+
+      - name: Run Codebox agent task
+        id: execute
+        if: inputs.run_agent && !inputs.dry_run
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MODEL_PROVIDER_SECRET_1: ${{ secrets.MODEL_PROVIDER_SECRET_1 }}
+          MODEL_PROVIDER_SECRET_2: ${{ secrets.MODEL_PROVIDER_SECRET_2 }}
+          MODEL_PROVIDER_SECRET_3: ${{ secrets.MODEL_PROVIDER_SECRET_3 }}
+          MODEL_PROVIDER_SECRET_4: ${{ secrets.MODEL_PROVIDER_SECRET_4 }}
+          MODEL_PROVIDER_SECRET_5: ${{ secrets.MODEL_PROVIDER_SECRET_5 }}
+        run: |
+          set -euo pipefail
+
+          result_path=".codebox/homeboy-agent-task-result.json"
+          homeboy --output "$result_path" agent-task run-plan \
+            --plan "${{ steps.plan.outputs.homeboy_plan_path }}" \
+            --record-run-id "${{ steps.plan.outputs.run_id }}"
+
+          engine_data_json="{}"
+          if [ -s "$result_path" ]; then
+            engine_data_json="$(jq -c '.' "$result_path")"
+          fi
+
+          {
+            printf 'job_status=succeeded\n'
+            printf 'transcript_json=%s\n' "${{ steps.plan.outputs.transcript_json }}"
+            printf 'transcript_summary=%s\n' "${{ inputs.workload_label }}: succeeded"
+            printf 'engine_data_json<<EOF\n%s\nEOF\n' "$engine_data_json"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload Codebox task result
+        if: always() && inputs.run_agent && !inputs.dry_run
+        uses: actions/upload-artifact@v4
+        with:
+          name: codebox-agent-task-result-${{ github.run_id }}
+          path: .codebox/homeboy-agent-task-result.json
+          if-no-files-found: ignore

--- a/tests/agent-task-reusable-workflow.test.ts
+++ b/tests/agent-task-reusable-workflow.test.ts
@@ -21,7 +21,9 @@ assert.match(workflow, /verification_commands:/)
 assert.match(workflow, /drift_checks:/)
 assert.match(workflow, /access_token_repos:/)
 assert.match(workflow, /require_access_token:/)
-assert.doesNotMatch(workflow, /homeboy|require_app_token|require_homeboy_app_token|REQUIRE_HOMEBOY_APP_TOKEN/i)
+assert.doesNotMatch(publicWorkflowSurface, /homeboy|require_app_token|require_homeboy_app_token|REQUIRE_HOMEBOY_APP_TOKEN/i)
+assert.match(workflow, /Extra-Chill\/homeboy-action@v2/)
+assert.match(workflow, /agent-task run-plan/)
 assert.doesNotMatch(workflow, /docs-agent|wp-codebox\/docs-agent-runner-recipe\/v1|recipe_path|recipe_json|wp_codebox_ref/i)
 assert.doesNotMatch(workflow, /datamachine-agent-ci|runtime-agent-full-run|Extra-Chill\/homeboy-extensions/)
 assert.doesNotMatch(publicWorkflowSurface, /datamachine|data machine|data-machine|agents api/i)
@@ -41,6 +43,7 @@ assert.doesNotMatch(docs, /docs-agent|wp-codebox\/docs-agent-runner-recipe\/v1|r
 const tmp = await mkdtemp(join(tmpdir(), "wp-codebox-agent-task-workflow-"))
 const outputPath = join(tmp, "github-output.txt")
 const requestPath = join(tmp, ".codebox", "agent-task-request.json")
+const homeboyPlanPath = join(tmp, ".codebox", "homeboy-agent-task-plan.json")
 
 await writeFile(outputPath, "")
 
@@ -101,8 +104,19 @@ assert.deepEqual(request.outputs.projections, { pr_url: "metadata.runner_workspa
 assert.deepEqual(request.artifacts.declarations, [{ schema: "wp-codebox/artifact-declaration/v1", name: "agent_transcript" }])
 assert.doesNotMatch(JSON.stringify(request), /homeboy|require_app_token|app_token_repos/i)
 
+const homeboyPlan = JSON.parse(await readFile(homeboyPlanPath, "utf8"))
+assert.equal(homeboyPlan.schema, "homeboy/agent-task-plan/v1")
+assert.equal(homeboyPlan.tasks[0].schema, "homeboy/agent-task-request/v1")
+assert.equal(homeboyPlan.tasks[0].executor.backend, "codebox")
+assert.equal(homeboyPlan.tasks[0].executor.config.execution_kind, "agent_bundle")
+assert.equal(homeboyPlan.tasks[0].executor.config.bundle_repo, "https://github.com/Automattic/example-runner.git")
+assert.equal(homeboyPlan.tasks[0].executor.config.bundle_ref, "abc123")
+assert.equal(homeboyPlan.tasks[0].executor.config.bundle_path_in_repo, "bundles/example-agent")
+assert.equal(homeboyPlan.tasks[0].executor.config.runner_recipe, "Automattic/example-runner@abc123:ci/runner-recipe.json")
+
 const outputs = await readFile(outputPath, "utf8")
 assert.match(outputs, /job_status<<__WP_CODEBOX_OUTPUT__\nskipped\n__WP_CODEBOX_OUTPUT__/)
 assert.match(outputs, /credential_mode<<__WP_CODEBOX_OUTPUT__\napp-token\n__WP_CODEBOX_OUTPUT__/)
+assert.match(outputs, /homeboy_plan_path<<__WP_CODEBOX_OUTPUT__\n\.codebox\/homeboy-agent-task-plan\.json\n__WP_CODEBOX_OUTPUT__/)
 
 console.log("agent task reusable workflow ok")


### PR DESCRIPTION
## Summary
- Convert the generic Codebox agent-task workflow request into a Homeboy agent-task plan.
- Install the Homeboy WordPress runner behind the Codebox workflow boundary and execute `homeboy agent-task run-plan` when `run_agent` is enabled.
- Preserve the public Codebox workflow inputs while keeping Homeboy details out of the caller-facing surface.

## Verification
- `npx tsx tests/agent-task-reusable-workflow.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/run-agent-task.yml"); puts "ok"'`\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** openai/gpt-5.5 and OpenCode\n- **Used for:** Diagnosing the workflow gap, implementing the generic execution handoff, updating tests, and preparing this PR.