### PR TITLE
Execute runtime workload fuzz targets

### DIFF
--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -12,6 +12,7 @@ export interface FuzzSuiteCommandExecutor {
 export interface FuzzSuiteRunOptions {
   executor?: FuzzSuiteCommandExecutor | ((spec: ExecutionSpec) => Promise<ExecutionResult>)
   runtimeActionExecutor?: FuzzSuiteRuntimeActionExecutor | ((input: FuzzSuiteRuntimeActionExecutionInput) => Promise<RuntimeActionObservation>)
+  runtimeWorkloadExecutor?: FuzzSuiteRuntimeWorkloadExecutor | ((input: FuzzSuiteRuntimeWorkloadExecutionInput) => Promise<ExecutionResult>)
   resetExecutor?: FuzzSuiteResetExecutor | ((input: FuzzSuiteResetExecutionInput) => Promise<FuzzSuiteCaseResetResult>)
   targetAdapters?: FuzzSuiteTargetAdapterRegistry | readonly FuzzSuiteTargetAdapter[]
   supportedTargetKinds?: readonly string[]
@@ -41,6 +42,18 @@ export interface FuzzSuiteRuntimeActionExecutionInput {
 
 export interface FuzzSuiteRuntimeActionExecutor {
   executeRuntimeAction(input: FuzzSuiteRuntimeActionExecutionInput): Promise<RuntimeActionObservation>
+}
+
+export interface FuzzSuiteRuntimeWorkloadExecutionInput {
+  suite: FuzzSuiteContract
+  case: FuzzSuiteCase
+  caseIndex: number
+  target: FuzzSuiteTargetRef
+  workload: Record<string, unknown>
+}
+
+export interface FuzzSuiteRuntimeWorkloadExecutor {
+  executeRuntimeWorkload(input: FuzzSuiteRuntimeWorkloadExecutionInput): Promise<ExecutionResult>
 }
 
 export type FuzzSuiteTargetAdapterStatus = "supported" | "unsupported"
@@ -99,6 +112,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
   const diagnostics: FuzzSuiteDiagnostic[] = []
   const execute = normalizeFuzzSuiteExecutor(options.executor)
   const executeRuntimeAction = normalizeFuzzSuiteRuntimeActionExecutor(options.runtimeActionExecutor)
+  const executeRuntimeWorkload = normalizeFuzzSuiteRuntimeWorkloadExecutor(options.runtimeWorkloadExecutor)
   const executeReset = normalizeFuzzSuiteResetExecutor(options.resetExecutor)
   const adapterRegistry = normalizeFuzzSuiteTargetAdapterRegistry(options.targetAdapters)
   const runnerCapabilities = normalizeFuzzSuiteRunnerCapabilities(options.runnerCapabilities)
@@ -219,6 +233,70 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
           reset,
           diagnostics: [diagnostic],
           metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-action", actionType: runtimeAction.action.type, executorKind: "episode" } }),
+        })
+      }
+      continue
+    }
+
+    const runtimeWorkload = target && isWordPressWorkloadRunTarget(target) ? fuzzSuiteRuntimeWorkloadInput(fuzzCase.input) : undefined
+    if (runtimeWorkload?.status === "invalid") {
+      const diagnostic = target ? unsupportedInputAdapterResolution(fuzzCase, target, runtimeWorkload.message, { adapterKind: "runtime-workload" }).diagnostics?.[0] : undefined
+      if (diagnostic) {
+        diagnostics.push(diagnostic)
+        cases.push({
+          id: fuzzCase.id,
+          status: "skipped",
+          success: false,
+          target,
+          reset,
+          skipReason: diagnostic.code,
+          diagnostics: [diagnostic],
+          metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-workload" } }),
+        })
+        continue
+      }
+    }
+
+    if (runtimeWorkload?.status === "valid" && executeRuntimeWorkload && target) {
+      try {
+        const execution = await executeRuntimeWorkload({ suite, case: fuzzCase, caseIndex: index, target, workload: runtimeWorkload.workload })
+        const status = execution.exitCode === 0 ? "passed" : "failed"
+        const caseDiagnostics = status === "passed" ? [] : [{ severity: "error" as const, code: "fuzz_suite_command_failed", caseId: fuzzCase.id, target, message: `${target.entrypoint ?? target.id} exited with ${execution.exitCode}`, metadata: stripUndefined({ executionId: execution.id, stderr: execution.stderr }) }]
+        diagnostics.push(...caseDiagnostics)
+        cases.push({
+          id: fuzzCase.id,
+          status,
+          success: status === "passed",
+          target,
+          reset,
+          diagnostics: caseDiagnostics,
+          artifactRefs: fuzzSuiteExecutionArtifactRefs(execution),
+          metadata: stripUndefined({
+            input: fuzzCase.input,
+            description: fuzzCase.description,
+            caseMetadata: fuzzCase.metadata,
+            adapter: { adapterKind: "runtime-workload", executorKind: "episode" },
+            replay: { ...replayMetadata, workload: runtimeWorkload.workload },
+            execution: { id: execution.id, command: execution.command, exitCode: execution.exitCode, startedAt: execution.startedAt, finishedAt: execution.finishedAt },
+          }),
+        })
+      } catch (error) {
+        const diagnostic: FuzzSuiteDiagnostic = {
+          severity: "error",
+          code: "fuzz_suite_runtime_workload_execution_error",
+          caseId: fuzzCase.id,
+          target,
+          message: error instanceof Error ? error.message : String(error),
+        }
+        diagnostics.push(diagnostic)
+        cases.push({
+          id: fuzzCase.id,
+          status: "error",
+          success: false,
+          target,
+          reset,
+          diagnostics: [diagnostic],
+          metadata: stripUndefined({ replay: replayMetadata, adapter: { adapterKind: "runtime-workload", executorKind: "episode" } }),
         })
       }
       continue
@@ -411,6 +489,16 @@ function normalizeFuzzSuiteRuntimeActionExecutor(executor: FuzzSuiteRunOptions["
   return (input) => executor.executeRuntimeAction(input)
 }
 
+function normalizeFuzzSuiteRuntimeWorkloadExecutor(executor: FuzzSuiteRunOptions["runtimeWorkloadExecutor"]): ((input: FuzzSuiteRuntimeWorkloadExecutionInput) => Promise<ExecutionResult>) | undefined {
+  if (!executor) {
+    return undefined
+  }
+  if (typeof executor === "function") {
+    return executor
+  }
+  return (input) => executor.executeRuntimeWorkload(input)
+}
+
 export function createFuzzSuiteTargetAdapterRegistry(adapters: readonly FuzzSuiteTargetAdapter[] = defaultFuzzSuiteTargetAdapters()): FuzzSuiteTargetAdapterRegistry {
   const byKind = new Map(adapters.map((adapter) => [adapter.kind, adapter]))
   return {
@@ -453,6 +541,13 @@ function commandFuzzSuiteTargetAdapter(kind: "command" | "runtime"): FuzzSuiteTa
       const input = normalizeFuzzSuiteCaseExecutionInput(fuzzCase.input)
       if (!command) {
         return unsupportedTargetAdapterResolution(fuzzCase, target, `Fuzz suite target ${target.kind} is missing an id or entrypoint.`, { adapterKind: kind })
+      }
+      if (kind === "runtime" && command === "wordpress.run-workload") {
+        const workload = fuzzSuiteRuntimeWorkloadInput(fuzzCase.input)
+        if (workload.status === "invalid") {
+          return unsupportedInputAdapterResolution(fuzzCase, target, workload.message, { adapterKind: "runtime-workload" })
+        }
+        return { status: "supported", spec: { command, args: [`workload-json=${JSON.stringify(workload.workload)}`] } as ExecutionSpec, metadata: { adapterKind: "runtime-workload" } }
       }
       if (!input.valid) {
         return unsupportedInputAdapterResolution(fuzzCase, target, "Expected an args array or an object with args, cwd, timeoutMs, and diagnostics.", { adapterKind: kind })
@@ -736,6 +831,22 @@ function fuzzSuiteTargetCommand(target: FuzzSuiteTargetRef | undefined): string 
     return undefined
   }
   return target.entrypoint ?? target.id
+}
+
+function isWordPressWorkloadRunTarget(target: FuzzSuiteTargetRef): boolean {
+  return target.kind === "runtime" && fuzzSuiteTargetCommand(target) === "wordpress.run-workload"
+}
+
+function fuzzSuiteRuntimeWorkloadInput(input: unknown): { status: "valid"; workload: Record<string, unknown> } | { status: "invalid"; message: string } {
+  const payload = fuzzSuiteCaseRecordInput(input)
+  if (payload.invalid || !isRecord(payload.payload)) {
+    return { status: "invalid", message: "Expected wordpress.run-workload input object." }
+  }
+  const workload = payload.payload.schema === "wp-codebox/wordpress-workload-run/v1" ? payload.payload : isRecord(payload.payload.workload) ? payload.payload.workload : payload.payload
+  if (!isRecord(workload) || !Array.isArray(workload.steps)) {
+    return { status: "invalid", message: "Expected wordpress.run-workload input with a steps array." }
+  }
+  return { status: "valid", workload }
 }
 
 function fuzzSuiteUnsupportedDiagnostic(fuzzCase: FuzzSuiteCase, target: FuzzSuiteTargetRef | undefined): FuzzSuiteDiagnostic {

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -24,6 +24,7 @@ import {
   type FuzzSuiteResetExecutor,
   type FuzzSuiteResultEnvelope,
   type FuzzSuiteRuntimeActionExecutor,
+  type FuzzSuiteRuntimeWorkloadExecutor,
   type FuzzSuiteRunOptions,
   type ObservationSpec,
   type Runtime,
@@ -116,7 +117,7 @@ export interface WordPressPageLoadActionOptions {
   captureDiagnostics?: string[]
 }
 
-export type WordPressFuzzSuiteExecutionOptions = Omit<FuzzSuiteRunOptions, "executor" | "runtimeActionExecutor" | "resetExecutor" | "runnerCapabilities">
+export type WordPressFuzzSuiteExecutionOptions = Omit<FuzzSuiteRunOptions, "executor" | "runtimeActionExecutor" | "runtimeWorkloadExecutor" | "resetExecutor" | "runnerCapabilities">
 
 export async function createWordPressRuntime(spec: WordPressRuntimeSpec, options: PlaygroundRuntimeBackendOptions = {}): Promise<Runtime> {
   return createRuntime(wordPressRuntimeCreateSpec(spec), createPlaygroundRuntimeBackend(options))
@@ -218,6 +219,36 @@ export function createWordPressFuzzSuiteCommandExecutor(episode: Pick<RuntimeEpi
   }
 }
 
+export function createWordPressFuzzSuiteRuntimeWorkloadExecutor(episode: Pick<RuntimeEpisode, "step">): FuzzSuiteRuntimeWorkloadExecutor {
+  return {
+    async executeRuntimeWorkload({ workload, case: fuzzCase }) {
+      const steps = [...workloadSteps(workload.before), ...workloadSteps(workload.steps), ...workloadSteps(workload.after)]
+      const startedAt = new Date().toISOString()
+      const executions: ExecutionResult[] = []
+      for (const step of steps) {
+        const result = await episode.step({ kind: "command", command: step.command, args: step.args, timeoutMs: step.timeoutMs }, { type: "command-result" })
+        executions.push(result.execution)
+        if (result.execution.exitCode !== 0 && !step.allowFailure && !step.advisory) {
+          break
+        }
+      }
+      const failed = executions.find((execution) => execution.exitCode !== 0)
+      const last = executions[executions.length - 1]
+      return {
+        id: `wordpress-run-workload-${fuzzCase.id}`,
+        command: "wordpress.run-workload",
+        args: [`steps=${steps.length}`],
+        exitCode: failed ? failed.exitCode : 0,
+        stdout: JSON.stringify({ schema: "wp-codebox/wordpress-workload-run-result/v1", caseId: fuzzCase.id, steps: executions.length, exitCode: failed ? failed.exitCode : 0 }),
+        stderr: failed?.stderr ?? "",
+        startedAt,
+        finishedAt: last?.finishedAt ?? new Date().toISOString(),
+        artifactRefs: executions.flatMap((execution) => execution.artifactRefs ?? []),
+      }
+    },
+  }
+}
+
 export function createWordPressFuzzSuiteResetExecutor(episode: Pick<RuntimeEpisode, "reset" | "step">): FuzzSuiteResetExecutor {
   let checkpointCreated = false
   return {
@@ -281,6 +312,7 @@ export function executeWordPressFuzzSuite(
     ...options,
     executor: createWordPressFuzzSuiteCommandExecutor(episode),
     runtimeActionExecutor: createWordPressFuzzSuiteRuntimeActionExecutor(episode),
+    runtimeWorkloadExecutor: createWordPressFuzzSuiteRuntimeWorkloadExecutor(episode),
     resetExecutor: createWordPressFuzzSuiteResetExecutor(episode),
     runnerCapabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
     metadata: {
@@ -288,6 +320,28 @@ export function executeWordPressFuzzSuite(
       runnerMode: "runtime-backed",
       runtimeBackend: "wordpress-playground",
     },
+  })
+}
+
+function workloadSteps(value: unknown): Array<{ command: string; args?: string[]; timeoutMs?: number; allowFailure?: boolean; advisory?: boolean }> {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value.flatMap((step) => {
+    if (!step || typeof step !== "object" || Array.isArray(step)) {
+      return []
+    }
+    const record = step as Record<string, unknown>
+    if (typeof record.command !== "string" || record.command.trim() === "") {
+      return []
+    }
+    return [{
+      command: record.command,
+      args: Array.isArray(record.args) ? record.args.map(String) : undefined,
+      timeoutMs: typeof record.timeoutMs === "number" ? record.timeoutMs : typeof record.timeout_ms === "number" ? record.timeout_ms : undefined,
+      allowFailure: record.allowFailure === true || record.allow_failure === true,
+      advisory: record.advisory === true,
+    }]
   })
 }
 

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -92,6 +92,30 @@ assert.equal(plannedEditor.status, "supported")
 assert.deepEqual(plannedEditor.spec, { command: "wordpress.editor-open", args: ["target=site"] })
 assert.equal(plannedEditor.replayMetadata.caseId, "editor")
 
+const workloadExecutions: Record<string, unknown>[] = []
+const runtimeWorkloadResult = await runFuzzSuite(fuzzSuiteContract({
+  id: "suite-runtime-workload",
+  cases: [{
+    id: "rest-db-query-profile:default",
+    target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" },
+    input: {
+      schema: "wp-codebox/wordpress-workload-run/v1",
+      enableQueryCapture: true,
+      steps: [{ command: "wordpress.rest-performance-observation", args: ["path=/wp/v2/types", "capture-queries=1"] }],
+    },
+  }],
+}), {
+  runtimeWorkloadExecutor: async ({ workload }) => {
+    workloadExecutions.push(workload)
+    return { id: "workload-exec-1", command: "wordpress.run-workload", args: ["steps=1"], exitCode: 0, stdout: "ok", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z", artifactRefs: [{ kind: "workload", id: "workload-artifact", path: "files/workload.json" }] }
+  },
+})
+assert.equal(runtimeWorkloadResult.status, "passed")
+assert.equal(runtimeWorkloadResult.cases[0]?.status, "passed")
+assert.equal(runtimeWorkloadResult.cases[0]?.diagnostics[0]?.code, undefined)
+assert.equal(runtimeWorkloadResult.cases[0]?.artifactRefs?.[0]?.path, "files/workload.json")
+assert.deepEqual((workloadExecutions[0]?.steps as Array<{ command: string; args: string[] }> | undefined)?.[0], { command: "wordpress.rest-performance-observation", args: ["path=/wp/v2/types", "capture-queries=1"] })
+
 const noExecutor = await runFuzzSuite(fuzzSuiteContract({
   id: "suite-002",
   target: { kind: "command", id: "inspect-mounted-inputs" },

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -57,6 +57,7 @@ const result = await executeWordPressFuzzSuite(episode, fuzzSuiteContract({
     { id: "rest", target: { kind: "rest", id: "/wp/v2/types" }, input: { method: "GET" } },
     { id: "browser", target: { kind: "runtime-action" }, input: { type: "browser", operation: "navigate", url: "/" } },
     { id: "db", target: { kind: "runtime-action" }, input: { type: "db_operation", operation: "inspect", resource: { table: "posts" } } },
+    { id: "workload", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.rest-performance-observation", args: ["path=/wp/v2/types", "capture-queries=1"] }] } },
   ],
 }), { requireCoverage: true })
 
@@ -65,13 +66,15 @@ assert.equal(result.success, true)
 assert.equal(result.metadata?.runnerMode, "runtime-backed")
 assert.equal(result.metadata?.runtimeBackend, "wordpress-playground")
 assert.equal((result.metadata?.runnerCapabilities as { mode?: string } | undefined)?.mode, "runtime-backed")
-assert.deepEqual(steps.map((step) => step.command), ["wordpress.rest-request", "wp-codebox.checkpoint-create", "wp-codebox.checkpoint-restore", "wordpress.rest-request", "wp-codebox.checkpoint-restore", "wordpress.browser-actions", "wp-codebox.checkpoint-restore", "wordpress.db-operation"])
+assert.deepEqual(steps.map((step) => step.command), ["wordpress.rest-request", "wp-codebox.checkpoint-create", "wp-codebox.checkpoint-restore", "wordpress.rest-request", "wp-codebox.checkpoint-restore", "wordpress.browser-actions", "wp-codebox.checkpoint-restore", "wordpress.db-operation", "wp-codebox.checkpoint-restore", "wordpress.rest-performance-observation"])
 assert.equal(result.cases[0]?.reset?.status, "passed")
 assert.equal(result.cases[0]?.reset?.checkpointName, "fuzz-baseline")
 assert.deepEqual(result.cases[0]?.reset?.fixtureRefs, ["fixtures/store.json"])
 assert.equal(result.cases[1]?.reset?.status, "passed")
 assert.equal(result.cases[2]?.status, "passed")
+assert.equal(result.cases[3]?.status, "passed")
 assert.equal(steps[7]?.args?.[0]?.startsWith("operation-json="), true)
 assert.equal(JSON.parse(steps[7]?.args?.[0]?.replace("operation-json=", "") ?? "{}").resource.table, "posts")
+assert.deepEqual(steps[9]?.args, ["path=/wp/v2/types", "capture-queries=1"])
 
 console.log("playground fuzz suite public ok")


### PR DESCRIPTION
## Summary
- Adds a Codebox-native runtime workload executor hook for fuzz suite cases targeting `runtime:wordpress.run-workload`.
- Wires the public Playground `executeWordPressFuzzSuite` wrapper to execute workload `before`, `steps`, and `after` entries through the existing episode command API.
- Adds regression coverage for the observed `rest-db-query-profile:default` runtime workload target shape and the public wrapper path.

## Root Cause
`runtime` fuzz targets were adapted only as raw command specs. The generated `wordpress.run-workload` target uses a structured Codebox workload payload, so it had no runtime-backed executor path and could be skipped as unavailable instead of executing through the public WordPress workload boundary.

## Testing
- `npm run test:fuzz-suite-runner`
- `npm run test:playground-fuzz-suite-public`
- `npm run test:public-api-contract`
- `npm run build`
- Forbidden downstream-boundary string scan over the diff: clean

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, implementation, regression tests, and PR drafting.