### PR TITLE
Normalize runtime requirement plugins for CLI fuzz runs

### DIFF
--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -122,10 +122,31 @@ function fuzzSuiteRuntimeRequirements(suiteInput: Record<string, unknown>): Reco
 function runtimeRequirementExtraPlugins(requirements: Record<string, unknown>, fallback: WorkspaceRecipeExtraPlugin[] | undefined): WorkspaceRecipeExtraPlugin[] | undefined {
   const extraPlugins = arrayOption(requirements.extra_plugins)
   if (extraPlugins.length > 0) {
-    return extraPlugins as WorkspaceRecipeExtraPlugin[]
+    return normalizeRuntimeRequirementExtraPlugins(extraPlugins, fallback)
   }
   const componentContracts = arrayOption(requirements.component_contracts)
-  return componentContracts.length > 0 ? componentContracts as WorkspaceRecipeExtraPlugin[] : fallback
+  return componentContracts.length > 0 ? normalizeRuntimeRequirementExtraPlugins(componentContracts, fallback) : fallback
+}
+
+function normalizeRuntimeRequirementExtraPlugins(value: unknown[], fallback: WorkspaceRecipeExtraPlugin[] | undefined): WorkspaceRecipeExtraPlugin[] | undefined {
+  const plugins = value.flatMap((entry) => {
+    const plugin = objectOption(entry)
+    const source = stringValue(plugin?.source) ?? stringValue(plugin?.path)
+    if (!plugin || !source) return []
+    return [{
+      source,
+      sourceRoot: stringValue(plugin.sourceRoot ?? plugin.source_root),
+      sourceSubpath: stringValue(plugin.sourceSubpath ?? plugin.source_subpath),
+      originalSource: stringValue(plugin.originalSource ?? plugin.original_source),
+      slug: stringValue(plugin.slug),
+      pluginFile: stringValue(plugin.pluginFile ?? plugin.plugin_file),
+      activate: typeof plugin.activate === "boolean" ? plugin.activate : undefined,
+      loadAs: plugin.loadAs === "plugin" || plugin.loadAs === "mu-plugin" ? plugin.loadAs : plugin.load_as === "plugin" || plugin.load_as === "mu-plugin" ? plugin.load_as : undefined,
+      sha256: stringValue(plugin.sha256),
+      metadata: objectOption(plugin.metadata),
+    } satisfies WorkspaceRecipeExtraPlugin]
+  })
+  return plugins.length > 0 ? plugins : fallback
 }
 
 function runtimeRequirementEnv(base: Record<string, string> | undefined, extra: unknown): Record<string, string> | undefined {

--- a/tests/public-fuzz-workload-cli.test.ts
+++ b/tests/public-fuzz-workload-cli.test.ts
@@ -40,7 +40,7 @@ try {
     id: "public-cli-runtime-suite",
     metadata: {
       runtime_requirements: {
-        extra_plugins: [{ slug: "sample-plugin", source: samplePluginSource, loadAs: "plugin", activate: true }],
+        extra_plugins: [{ slug: "sample-plugin", source: samplePluginSource, path: samplePluginSource, loadAs: "plugin", source_subpath: "sample-plugin", activate: true }],
         component_contracts: [{ slug: "sample-plugin", path: samplePluginSource, loadAs: "plugin" }],
         runtime_env: { SAMPLE_ENV: "1" },
       },


### PR DESCRIPTION
## Summary
- Normalize generic runtime requirement plugin DTOs before placing them into strict recipe `inputs.extra_plugins`.
- Accept richer adapter fields such as `path` and snake_case source metadata without leaking unsupported properties into recipe JSON.
- Extend the public CLI fuzz workload test with a richer plugin requirement DTO.

## Testing
- `npm run build`
- `npx tsx tests/public-fuzz-workload-cli.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the recipe schema validation failure, implementing DTO normalization, and updating focused CLI coverage.
