### PR TITLE
Support bench request case artifacts

### DIFF
--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -36,6 +36,15 @@ $wp_cli_bridge_token = ${JSON.stringify(options.wpCliBridge?.token ?? null)};
 
 wp_codebox_bench_apply_env($bench_env);
 
+if (!getenv('WP_CODEBOX_BENCH_SHARED_STATE')) {
+    $wp_codebox_bench_shared_state = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'wp-codebox-bench-shared-state-' . getmypid();
+    if (!is_dir($wp_codebox_bench_shared_state) && !mkdir($wp_codebox_bench_shared_state, 0777, true) && !is_dir($wp_codebox_bench_shared_state)) {
+        throw new RuntimeException('wordpress.bench could not create shared state directory.');
+    }
+    putenv('WP_CODEBOX_BENCH_SHARED_STATE=' . $wp_codebox_bench_shared_state);
+    $_ENV['WP_CODEBOX_BENCH_SHARED_STATE'] = $wp_codebox_bench_shared_state;
+}
+
 function wp_codebox_bench_percentile(array $samples, float $percentile): float {
     if (empty($samples)) {
         return 0.0;
@@ -645,6 +654,60 @@ function wp_codebox_bench_rest_db_query_profile_filter_query($query, array &$cap
     return $query;
 }
 
+function wp_codebox_bench_rest_request_cases_from_source(array $source): array {
+    $type = isset($source['type']) && is_string($source['type']) ? $source['type'] : '';
+    if ($type !== 'artifact') {
+        throw new RuntimeException('rest_request_cases_source only supports artifact sources.');
+    }
+
+    $root = getenv('WP_CODEBOX_BENCH_SHARED_STATE');
+    if (!is_string($root) || $root === '' || !is_dir($root)) {
+        throw new RuntimeException('rest_request_cases_source artifact root is unavailable.');
+    }
+
+    $artifact_globs = isset($source['artifact_globs']) && is_array($source['artifact_globs']) ? $source['artifact_globs'] : array();
+    $max_route_cases = isset($source['maxRouteCases']) && is_numeric($source['maxRouteCases']) ? max(0, (int) $source['maxRouteCases']) : 100;
+    $max_artifact_bytes = isset($source['maxArtifactBytes']) && is_numeric($source['maxArtifactBytes']) ? max(0, (int) $source['maxArtifactBytes']) : 1048576;
+    $expected_schema = isset($source['schema']) && is_string($source['schema']) ? $source['schema'] : '';
+    $cases = array();
+    if ($max_route_cases === 0) {
+        return $cases;
+    }
+
+    foreach ($artifact_globs as $artifact_glob) {
+        if (!is_string($artifact_glob) || $artifact_glob === '' || str_starts_with($artifact_glob, '/') || str_contains($artifact_glob, '..')) {
+            throw new RuntimeException('rest_request_cases_source artifact_globs must be safe relative glob paths.');
+        }
+        foreach (glob(rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $artifact_glob) ?: array() as $artifact_path) {
+            if (!is_file($artifact_path)) {
+                continue;
+            }
+            $bytes = filesize($artifact_path);
+            if ($bytes === false || $bytes > $max_artifact_bytes) {
+                throw new RuntimeException('rest_request_cases_source artifact exceeds maxArtifactBytes.');
+            }
+            $artifact = json_decode((string) file_get_contents($artifact_path), true);
+            if (!is_array($artifact)) {
+                throw new RuntimeException('rest_request_cases_source artifact is not valid JSON.');
+            }
+            if ($expected_schema !== '' && isset($artifact['schema']) && $artifact['schema'] !== $expected_schema) {
+                continue;
+            }
+            foreach (isset($artifact['cases']) && is_array($artifact['cases']) ? $artifact['cases'] : array() as $request_case) {
+                if (!is_array($request_case)) {
+                    continue;
+                }
+                $cases[] = $request_case;
+                if (count($cases) >= $max_route_cases) {
+                    return $cases;
+                }
+            }
+        }
+    }
+
+    return $cases;
+}
+
 function wp_codebox_bench_run_rest_db_query_profiler_step(array $step): array {
     global $wpdb;
 
@@ -664,6 +727,12 @@ function wp_codebox_bench_run_rest_db_query_profiler_step(array $step): array {
     $request_cases = isset($step['rest_request_cases']) && is_array($step['rest_request_cases']) ? $step['rest_request_cases'] : array();
     if (empty($request_cases) && isset($step['request_cases']) && is_array($step['request_cases'])) {
         $request_cases = $step['request_cases'];
+    }
+    if (empty($request_cases) && isset($step['rest_request_cases_source']) && is_array($step['rest_request_cases_source'])) {
+        $request_cases = wp_codebox_bench_rest_request_cases_from_source($step['rest_request_cases_source']);
+        if (empty($request_cases)) {
+            throw new RuntimeException('rest_request_cases_source did not resolve any request cases.');
+        }
     }
     if (empty($request_cases)) {
         $request_cases = array($step);

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -21,6 +21,7 @@ const runCommandStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_comma
 const runAbilityStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_ability_step")
 const runDbInventoryStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_db_inventory_step")
 const runRestDbQueryProfilerStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_rest_db_query_profiler_step")
+const restRequestCasesFromSource = phpFunctionBlock(benchRunner, "wp_codebox_bench_rest_request_cases_from_source")
 const runExternalHttpGuardrailStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_external_http_guardrail_step")
 const runArtifactPostprocessStep = phpFunctionBlock(benchRunner, "wp_codebox_bench_run_artifact_postprocess_step")
 const commandStepRecord = phpFunctionBlock(benchRunner, "wp_codebox_bench_command_step_record")
@@ -32,7 +33,9 @@ assert.match(runDbInventoryStep, /SHOW INDEX FROM/)
 assert.match(runDbInventoryStep, /wp-codebox\/wordpress-db-inventory\/v1/)
 assert.match(runDbInventoryStep, /\$payload\['artifacts'\]\['db-inventory'\] = \$inventory/)
 assert.match(runRestDbQueryProfilerStep, /wp-codebox\/wordpress-rest-db-query-profile\/v1/)
+assert.match(restRequestCasesFromSource, /WP_CODEBOX_BENCH_SHARED_STATE/)
 assert.match(runRestDbQueryProfilerStep, /\$wpdb->save_queries = true/)
+assert.match(runRestDbQueryProfilerStep, /wp_codebox_bench_rest_request_cases_from_source/)
 assert.match(runRestDbQueryProfilerStep, /\$payload\['artifacts'\]\['rest-db-query-profile'\] = \$artifact/)
 assert.match(runExternalHttpGuardrailStep, /wp-codebox\/wordpress-external-http-guardrail\/v1/)
 assert.match(runExternalHttpGuardrailStep, /wp_codebox_bench_install_external_http_guardrail/)
@@ -94,6 +97,7 @@ const restDbQueryProfilerHelpers = [
   "wp_codebox_bench_rest_db_query_profile_summary",
   "wp_codebox_bench_rest_db_query_profile_case_step",
   "wp_codebox_bench_rest_db_query_profile_filter_query",
+  "wp_codebox_bench_rest_request_cases_from_source",
   "wp_codebox_bench_run_rest_db_query_profiler_step",
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
@@ -302,6 +306,60 @@ assert.equal(restDbQueryProfilerPayload.metrics.rest_db_query_profile_cases_coun
 assert.equal(restDbQueryProfilerPayload.metrics.rest_db_query_profile_queries_count, 2)
 assert.equal(restDbQueryProfilerPayload.steps[0].type, "rest-db-query-profiler")
 assert.equal(restDbQueryProfilerPayload.steps[0].queries, 2)
+
+const restDbQueryProfilerArtifactSourcePayload = await withTempDir("wp-codebox-rest-db-query-profiler-source-", async (directory) => {
+  const artifactDirectory = join(directory, "generated-rest-request-cases")
+  await mkdir(artifactDirectory, { recursive: true })
+  await writeFile(join(artifactDirectory, "cases.json"), JSON.stringify({
+    schema: "example/rest-request-cases/v1",
+    cases: [{ id: "artifact-products", method: "GET", path: "/wc/store/v1/products", params: { per_page: 1 } }],
+  }))
+  const phpTestFile = join(directory, "rest-db-query-profiler-source.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+class WP_REST_Request {
+    public string $method;
+    public string $route;
+    public function __construct($method, $route) { $this->method = $method; $this->route = $route; }
+    public function set_header($name, $value) {}
+    public function set_param($name, $value) {}
+    public function set_body($body) {}
+}
+class WP_Codebox_Test_REST_Response { public function get_status() { return 200; } }
+define('SAVEQUERIES', false);
+$wp_codebox_test_filters = array();
+function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) { global $wp_codebox_test_filters; $wp_codebox_test_filters[$hook][$priority][] = $callback; }
+function remove_filter($hook, $callback, $priority = 10) { global $wp_codebox_test_filters; foreach ($wp_codebox_test_filters[$hook][$priority] ?? array() as $index => $registered_callback) { if ($registered_callback === $callback) { unset($wp_codebox_test_filters[$hook][$priority][$index]); } } }
+function apply_filters($hook, $value) { global $wp_codebox_test_filters; foreach ($wp_codebox_test_filters[$hook] ?? array() as $callbacks) { foreach ($callbacks as $callback) { $value = $callback($value); } } return $value; }
+function is_wp_error($value) { return false; }
+function rest_do_request($request) {
+    apply_filters('query', "SELECT * FROM wp_posts WHERE post_type = 'product'");
+    return new WP_Codebox_Test_REST_Response();
+}
+function rest_get_server() { return new class { public function response_to_data($response, $embed) { return array('ok' => true); } }; }
+$wpdb = (object) array('save_queries' => false);
+putenv('WP_CODEBOX_BENCH_SHARED_STATE=' . ${JSON.stringify(directory)});
+${restDbQueryProfilerHelpers}
+$payload = wp_codebox_bench_run_rest_db_query_profiler_step(array(
+    'type' => 'rest-db-query-profiler',
+    'rest_request_cases_source' => array(
+        'type' => 'artifact',
+        'schema' => 'example/rest-request-cases/v1',
+        'artifact_globs' => array('generated-rest-request-cases/*.json'),
+        'maxRouteCases' => 80,
+        'maxArtifactBytes' => 1048576,
+    ),
+));
+echo json_encode($payload, JSON_UNESCAPED_SLASHES);
+`,
+  )
+  return runPhpFileJson<{ artifacts: Record<string, { summary: { case_count: number }; cases: Array<{ case_id: string; path: string }> }>; metrics: Record<string, number> }>(phpTestFile)
+})
+assert.equal(restDbQueryProfilerArtifactSourcePayload.artifacts["rest-db-query-profile"].summary.case_count, 1)
+assert.equal(restDbQueryProfilerArtifactSourcePayload.artifacts["rest-db-query-profile"].cases[0].case_id, "artifact-products")
+assert.equal(restDbQueryProfilerArtifactSourcePayload.artifacts["rest-db-query-profile"].cases[0].path, "/wc/store/v1/products")
+assert.equal(restDbQueryProfilerArtifactSourcePayload.metrics.rest_db_query_profile_cases_count, 1)
 
 const routeMatrixSteps = await withTempDir("wp-codebox-bench-route-matrix-", async (directory) => {
   const phpTestFile = join(directory, "route-matrix.php")


### PR DESCRIPTION
## Summary
- add a Codebox-owned shared state directory for wordpress.bench runs
- let rest-db-query-profiler load request cases from declared artifact globs
- cover artifact-backed request case loading in bench behavior tests

## Testing
- npx tsx tests/bench-command-step-behavior.test.ts
- npx tsx tests/public-fuzz-workload-cli.test.ts
- npx tsx tests/production-boundary-enforcement.test.ts
- npx tsx tests/runtime-boundary-contracts.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime helper, adding focused test coverage, and running validation.