### PR TITLE
Preserve runtime workload fuzz results

### DIFF
--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -277,7 +277,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
             caseMetadata: fuzzCase.metadata,
             adapter: { adapterKind: "runtime-workload", executorKind: "episode" },
             replay: { ...replayMetadata, workload: runtimeWorkload.workload },
-            execution: { id: execution.id, command: execution.command, exitCode: execution.exitCode, startedAt: execution.startedAt, finishedAt: execution.finishedAt },
+            execution: { id: execution.id, command: execution.command, exitCode: execution.exitCode, startedAt: execution.startedAt, finishedAt: execution.finishedAt, result: execution.result },
           }),
         })
       } catch (error) {

--- a/tests/fuzz-suite-runner.test.ts
+++ b/tests/fuzz-suite-runner.test.ts
@@ -107,13 +107,14 @@ const runtimeWorkloadResult = await runFuzzSuite(fuzzSuiteContract({
 }), {
   runtimeWorkloadExecutor: async ({ workload }) => {
     workloadExecutions.push(workload)
-    return { id: "workload-exec-1", command: "wordpress.run-workload", args: ["steps=1"], exitCode: 0, stdout: "ok", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z", artifactRefs: [{ kind: "workload", id: "workload-artifact", path: "files/workload.json" }] }
+    return { id: "workload-exec-1", command: "wordpress.run-workload", args: ["steps=1"], exitCode: 0, stdout: "ok", stderr: "", startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z", artifactRefs: [{ kind: "workload", id: "workload-artifact", path: "files/workload.json" }], result: { schema: "wp-codebox/runtime-command-result/v1", status: "ok", json: { metrics: { query_count: 7 }, artifacts: { profile: { schema: "example/profile" } } } } }
   },
 })
 assert.equal(runtimeWorkloadResult.status, "passed")
 assert.equal(runtimeWorkloadResult.cases[0]?.status, "passed")
 assert.equal(runtimeWorkloadResult.cases[0]?.diagnostics[0]?.code, undefined)
 assert.equal(runtimeWorkloadResult.cases[0]?.artifactRefs?.[0]?.path, "files/workload.json")
+assert.deepEqual(((runtimeWorkloadResult.cases[0]?.metadata?.execution as { result?: { json?: { metrics?: { query_count?: number } } } } | undefined)?.result?.json?.metrics?.query_count), 7)
 assert.deepEqual((workloadExecutions[0]?.steps as Array<{ command: string; args: string[] }> | undefined)?.[0], { command: "wordpress.rest-performance-observation", args: ["path=/wp/v2/types", "capture-queries=1"] })
 
 const noExecutor = await runFuzzSuite(fuzzSuiteContract({


### PR DESCRIPTION
## Summary
- Preserve structured runtime workload execution results in fuzz suite case metadata.
- Cover runtime workload result JSON preservation in the fuzz suite runner test.

## Testing
- npx tsx tests/fuzz-suite-runner.test.ts
- npx tsx tests/public-fuzz-workload-cli.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, code change, test update, and verification.