### PR TITLE
Return workload command results from fuzz executors

### DIFF
--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -87,6 +87,7 @@ async function runWordPressWorkloadFuzzCase(input: FuzzSuiteRuntimeWorkloadExecu
       exitCode,
       stdout,
       stderr: recipeResult?.error && typeof recipeResult.error === "object" && "message" in recipeResult.error ? String(recipeResult.error.message) : "",
+      result: { schema: "wp-codebox/runtime-command-result/v1", status: exitCode === 0 ? "ok" : "error", stdout, stderr: recipeResult?.error && typeof recipeResult.error === "object" && "message" in recipeResult.error ? String(recipeResult.error.message) : "", json: recipeResult },
       startedAt,
       finishedAt: new Date().toISOString(),
       artifactRefs: recipeArtifactRefs(recipeResult),

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -234,13 +234,15 @@ export function createWordPressFuzzSuiteRuntimeWorkloadExecutor(episode: Pick<Ru
       }
       const failed = executions.find((execution) => execution.exitCode !== 0)
       const last = executions[executions.length - 1]
+      const workloadResult = { schema: "wp-codebox/wordpress-workload-run-result/v1", caseId: fuzzCase.id, steps: executions.length, exitCode: failed ? failed.exitCode : 0 }
       return {
         id: `wordpress-run-workload-${fuzzCase.id}`,
         command: "wordpress.run-workload",
         args: [`steps=${steps.length}`],
         exitCode: failed ? failed.exitCode : 0,
-        stdout: JSON.stringify({ schema: "wp-codebox/wordpress-workload-run-result/v1", caseId: fuzzCase.id, steps: executions.length, exitCode: failed ? failed.exitCode : 0 }),
+        stdout: JSON.stringify(workloadResult),
         stderr: failed?.stderr ?? "",
+        result: { schema: "wp-codebox/runtime-command-result/v1", status: failed ? "error" : "ok", json: workloadResult },
         startedAt,
         finishedAt: last?.finishedAt ?? new Date().toISOString(),
         artifactRefs: executions.flatMap((execution) => execution.artifactRefs ?? []),


### PR DESCRIPTION
## Summary
- Return structured runtime command results from WordPress workload fuzz executors.
- Preserve workload result JSON for both CLI and public runtime-backed paths.

## Testing
- npx tsx tests/fuzz-suite-runner.test.ts
- npx tsx tests/public-fuzz-workload-cli.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, code change, test selection, and verification.