### PR TITLE
Keep bench command in expanded runtime policy

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -1049,6 +1049,9 @@ export function effectivePolicyCommands(command: string, definitions: readonly C
     const definition = byId.get(id)
     const requirements = definition?.requiresPolicyCommands
     if (requirements) {
+      if (definition?.handler.kind === "playground" && !commands.includes(id)) {
+        commands.push(id)
+      }
       for (const requiredCommand of requirements) {
         collect(requiredCommand)
       }

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -217,6 +217,7 @@ assert.deepEqual(wordpressBench.requiresPolicyCommands, [
 
 assert.deepEqual(effectivePolicyCommands("wp-codebox.agent-sandbox-run"), ["wordpress.run-php", "wordpress.wp-cli"])
 assert.deepEqual(effectivePolicyCommands("wordpress.bench"), [
+  "wordpress.bench",
   "wordpress.run-php",
   "wordpress.wp-cli",
   "wordpress.ability",


### PR DESCRIPTION
## Summary
- keep playground wrapper commands in effective runtime policy when they also declare required policy commands
- ensure `wordpress.bench` policies include both the bench command and its documented workload commands

## Testing
- npm run test:legacy-agent-task-contracts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** implementation, test coverage, and local verification