### PR TITLE
Support staged PHP workload files

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -381,6 +381,8 @@ final class WP_Codebox_Agents_API_Adapter {
 			'workspaces',
 			'runtime_stack_mounts',
 			'runtime_overlays',
+			'staged_files',
+			'stagedFiles',
 			'inherit',
 			'secret_env',
 			'sandbox_session_id',
@@ -432,10 +434,113 @@ final class WP_Codebox_Agents_API_Adapter {
 		if ( is_array( $input['package'] ?? null ) ) {
 			$input['package'] = self::package_descriptor_for_runtime( $input['package'], $input );
 		}
+		$input = self::stage_runtime_package_wordpress_workload_files( $input );
 
 		$input = self::runtime_package_options_for_agents_api( $input );
 
 		return $this->execute( self::RUN_RUNTIME_PACKAGE, $input );
+	}
+
+	/** @param array<string,mixed> $input Runtime input. @return array<string,mixed> */
+	private static function stage_runtime_package_wordpress_workload_files( array $input ): array {
+		$workflow_input = is_array( $input['input'] ?? null ) ? $input['input'] : array();
+		if ( 'wp-codebox/wordpress-workload-run/v1' !== (string) ( $workflow_input['schema'] ?? '' ) ) {
+			return $input;
+		}
+
+		$package_root = self::runtime_package_root( is_array( $input['package'] ?? null ) ? $input['package'] : array() );
+		$staged_files = is_array( $workflow_input['staged_files'] ?? null ) ? $workflow_input['staged_files'] : ( is_array( $workflow_input['stagedFiles'] ?? null ) ? $workflow_input['stagedFiles'] : array() );
+		foreach ( array( 'before', 'steps', 'after' ) as $phase ) {
+			$steps = is_array( $workflow_input[ $phase ] ?? null ) ? $workflow_input[ $phase ] : array();
+			foreach ( $steps as $index => $step ) {
+				if ( ! is_array( $step ) || 'wordpress.run-workload' !== (string) ( $step['command'] ?? '' ) ) {
+					continue;
+				}
+				$args = self::parse_step_args( is_array( $step['args'] ?? null ) ? $step['args'] : array() );
+				if ( 'php' !== strtolower( (string) ( $args['type'] ?? '' ) ) ) {
+					continue;
+				}
+				$source = self::resolve_runtime_package_file_path( (string) ( $args['path'] ?? $args['file'] ?? '' ), $package_root );
+				if ( '' === $source ) {
+					continue;
+				}
+
+				$target = '/tmp/wp-codebox-workloads/' . substr( hash( 'sha256', $source ), 0, 16 ) . '-' . basename( $source );
+				$staged_files[] = array(
+					'source'   => $source,
+					'target'   => $target,
+					'metadata' => array( 'kind' => 'wordpress-php-workload' ),
+				);
+				$args['path'] = $target;
+				unset( $args['file'] );
+				$step['args'] = self::step_args_from_map( $args );
+				$steps[ $index ] = $step;
+			}
+			$workflow_input[ $phase ] = $steps;
+		}
+
+		if ( ! empty( $staged_files ) ) {
+			$workflow_input['staged_files'] = array_values( $staged_files );
+		}
+		$input['input'] = $workflow_input;
+
+		return $input;
+	}
+
+	/** @param array<string,mixed> $package Package descriptor. */
+	private static function runtime_package_root( array $package ): string {
+		$source = isset( $package['source'] ) ? (string) $package['source'] : '';
+		if ( '' === $source ) {
+			return '';
+		}
+		if ( is_file( $source ) ) {
+			return dirname( $source );
+		}
+
+		return is_dir( $source ) ? rtrim( $source, '/\\' ) : '';
+	}
+
+	private static function resolve_runtime_package_file_path( string $path, string $package_root ): string {
+		$path = trim( $path );
+		if ( '' === $path ) {
+			return '';
+		}
+		if ( '' !== $package_root ) {
+			$path = str_replace( array( '${package.root}', '{{package.root}}' ), $package_root, $path );
+		}
+		$candidates = array( $path );
+		if ( '' !== $package_root && ! self::is_absolute_package_source( $path ) ) {
+			$candidates[] = rtrim( $package_root, '/\\' ) . '/' . ltrim( $path, '/\\' );
+		}
+		foreach ( $candidates as $candidate ) {
+			if ( is_file( $candidate ) && is_readable( $candidate ) ) {
+				$real = realpath( $candidate );
+				return false !== $real ? $real : $candidate;
+			}
+		}
+
+		return '';
+	}
+
+	/** @param array<int,mixed> $args @return array<string,string> */
+	private static function parse_step_args( array $args ): array {
+		$parsed = array();
+		foreach ( $args as $arg ) {
+			$parts = explode( '=', (string) $arg, 2 );
+			$parsed[ $parts[0] ] = $parts[1] ?? '';
+		}
+
+		return $parsed;
+	}
+
+	/** @param array<string,string> $args @return array<int,string> */
+	private static function step_args_from_map( array $args ): array {
+		$out = array();
+		foreach ( $args as $key => $value ) {
+			$out[] = (string) $key . '=' . (string) $value;
+		}
+
+		return $out;
 	}
 
 	/** @param array<string,mixed> $input Runtime input. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -102,6 +102,7 @@ final class WP_Codebox_Host_Recipe_Builder {
 		$recipe_inputs = array(
 			'mounts'             => $mounts,
 			'workspaces'         => $workspaces,
+			'stagedFiles'        => self::staged_files( $input ),
 			'inherit'            => $dependency_plan->inheritance_request(),
 			'inheritance'        => $dependency_plan->inheritance(),
 			'extra_plugins'      => array_merge( $dependency_plan->component_plugins(), $dependency_plan->provider_plugins() ),
@@ -144,6 +145,32 @@ final class WP_Codebox_Host_Recipe_Builder {
 			'readiness'       => is_array( $input['runtime_profile']['readiness'] ?? null ) ? $input['runtime_profile']['readiness'] : array(),
 			'diagnostics'     => is_array( $input['runtime_profile']['diagnostics'] ?? null ) ? $input['runtime_profile']['diagnostics'] : array(),
 		);
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<int,array<string,mixed>> */
+	private static function staged_files( array $input ): array {
+		$files = is_array( $input['staged_files'] ?? null ) ? $input['staged_files'] : ( is_array( $input['stagedFiles'] ?? null ) ? $input['stagedFiles'] : array() );
+		$normalized = array();
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+			$source = trim( (string) ( $file['source'] ?? '' ) );
+			$target = trim( (string) ( $file['target'] ?? '' ) );
+			if ( '' === $source || '' === $target ) {
+				continue;
+			}
+			$entry = array(
+				'source' => $source,
+				'target' => $target,
+			);
+			if ( isset( $file['metadata'] ) && is_array( $file['metadata'] ) ) {
+				$entry['metadata'] = $file['metadata'];
+			}
+			$normalized[] = $entry;
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php
@@ -11,7 +11,7 @@ final class WP_Codebox_Task_Input_Contract {
 
 	public const SCHEMA  = 'wp-codebox/task-input/v1';
 	public const VERSION = 1;
-	public const ABILITY_ALIAS_FIELDS = array( 'goal', 'target', 'allowed_tools', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'expected_artifacts', 'structured_artifacts', 'policy', 'context' );
+	public const ABILITY_ALIAS_FIELDS = array( 'goal', 'target', 'allowed_tools', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'expected_artifacts', 'structured_artifacts', 'staged_files', 'policy', 'context' );
 
 	/** @return array<string,mixed> */
 	public static function schema(): array {
@@ -70,6 +70,11 @@ final class WP_Codebox_Task_Input_Contract {
 							'provenance'     => array( 'type' => 'object' ),
 						),
 					),
+				),
+				'staged_files'       => array(
+					'type'        => 'array',
+					'description' => 'Host-resolved files to stage into the disposable runtime before task invocation.',
+					'items'       => array( 'type' => 'object' ),
 				),
 				'agent_bundles'      => array(
 					'type'        => 'array',
@@ -139,6 +144,7 @@ final class WP_Codebox_Task_Input_Contract {
 			'allowed_tools'      => self::string_list( $input['allowed_tools'] ?? array() ),
 			'expected_artifacts' => self::string_list( $input['expected_artifacts'] ?? array() ),
 			'structured_artifacts' => self::structured_artifacts( $input['structured_artifacts'] ?? array() ),
+			'staged_files'       => self::staged_files( $input['staged_files'] ?? $input['stagedFiles'] ?? array() ),
 			'agent_bundles'      => self::agent_bundles( $input['agent_bundles'] ?? array() ),
 			'tool_bridge'        => is_array( $input['tool_bridge'] ?? null ) ? $input['tool_bridge'] : array(),
 			'parent_tool_bridge' => is_array( $input['parent_tool_bridge'] ?? null ) ? $input['parent_tool_bridge'] : array(),
@@ -200,6 +206,31 @@ final class WP_Codebox_Task_Input_Contract {
 		}
 
 		return is_array( $value ) ? $value : null;
+	}
+
+	/** @return array<int,array<string,mixed>> */
+	private static function staged_files( mixed $value ): array {
+		$files = array();
+		foreach ( is_array( $value ) ? $value : array() as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$source = trim( (string) ( $entry['source'] ?? '' ) );
+			$target = trim( (string) ( $entry['target'] ?? '' ) );
+			if ( '' === $source || '' === $target ) {
+				continue;
+			}
+			$file = array(
+				'source' => $source,
+				'target' => $target,
+			);
+			if ( isset( $entry['metadata'] ) && is_array( $entry['metadata'] ) ) {
+				$file['metadata'] = $entry['metadata'];
+			}
+			$files[] = $file;
+		}
+
+		return $files;
 	}
 
 	/** @return array<int,array<string,mixed>> */

--- a/packages/wordpress-plugin/src/class-wp-codebox-wordpress-workload-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-wordpress-workload-runner.php
@@ -128,7 +128,8 @@ final class WP_Codebox_WordPress_Workload_Runner {
 			$result = match ( $command ) {
 				'wordpress.rest-request'             => $this->execute_rest_request( $args, $index ),
 				'wordpress.collect-workload-result'  => $this->collect_artifact( $args, $input ),
-				'wordpress.run-workload', 'wordpress.run-declarative-fuzz' => $this->acknowledge_recipe_step( $command ),
+				'wordpress.run-workload'             => 'php' === strtolower( (string) ( $args['type'] ?? '' ) ) ? $this->execute_php_workload( $args, $input, $index ) : $this->acknowledge_recipe_step( $command ),
+				'wordpress.run-declarative-fuzz'     => $this->acknowledge_recipe_step( $command ),
 				default                              => $this->unsupported_step( $command, $index ),
 			};
 		} catch ( Throwable $throwable ) {
@@ -156,6 +157,50 @@ final class WP_Codebox_WordPress_Workload_Runner {
 			),
 			static fn( mixed $value ): bool => ! ( is_array( $value ) && empty( $value ) ) && '' !== $value
 		);
+	}
+
+	/** @param array<string,string> $args Step args. @param array<string,mixed> $input Workload request. @return array<string,mixed> */
+	private function execute_php_workload( array $args, array $input, int $index ): array {
+		$path = (string) ( $args['path'] ?? $args['file'] ?? '' );
+		if ( '' === $path || ! is_file( $path ) || ! is_readable( $path ) ) {
+			return array( 'status' => 'error', 'diagnostics' => array( $this->diagnostic( 'error', 'wp_codebox_wordpress_workload_php_file_unavailable', 'PHP workload file is not available inside this runtime.', array( 'step_index' => $index, 'path' => $path ) ) ) );
+		}
+
+		ob_start();
+		try {
+			$callable = require $path;
+		} finally {
+			$output = ob_get_clean();
+		}
+		if ( ! is_callable( $callable ) ) {
+			return array( 'status' => 'error', 'observation' => array( 'path' => $path, 'output_bytes' => strlen( (string) $output ), 'return_type' => gettype( $callable ) ), 'diagnostics' => array( $this->diagnostic( 'error', 'wp_codebox_wordpress_workload_php_not_callable', 'PHP workload files must return a callable.', array( 'step_index' => $index, 'path' => $path ) ) ) );
+		}
+
+		ob_start();
+		try {
+			$result = $callable( $input, $args );
+		} finally {
+			$output .= ob_get_clean();
+		}
+
+		if ( is_array( $result ) ) {
+			$status = (string) ( $result['status'] ?? ( false === ( $result['success'] ?? true ) ? 'failed' : 'passed' ) );
+			if ( 'completed' === $status ) {
+				$status = 'passed';
+			}
+
+			return array_filter(
+				array(
+					'status'       => '' === $status ? 'passed' : $status,
+					'observation'  => array_merge( array( 'path' => $path, 'output_bytes' => strlen( (string) $output ), 'return_type' => 'array' ), is_array( $result['observation'] ?? null ) ? $result['observation'] : array() ),
+					'diagnostics'  => is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array(),
+					'artifactRefs' => is_array( $result['artifactRefs'] ?? null ) ? $result['artifactRefs'] : ( is_array( $result['artifacts'] ?? null ) ? $result['artifacts'] : array() ),
+				),
+				static fn( mixed $value ): bool => ! ( is_array( $value ) && empty( $value ) )
+			);
+		}
+
+		return array( 'status' => false === $result ? 'failed' : 'passed', 'observation' => array( 'path' => $path, 'output_bytes' => strlen( (string) $output ), 'return_type' => gettype( $result ) ) );
 	}
 
 	/** @param array<string,string> $args Step args. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php
@@ -48,6 +48,16 @@ trait WP_Codebox_Abilities_Browser_Runner {
 	);
 	$runtime_blueprint['steps'] = $runtime_steps;
 
+	$staged_files = array(
+		array(
+			'source' => 'task-payload',
+			'target' => $task_path,
+		),
+	);
+	foreach ( self::browser_runner_staged_files( $task_input ) as $staged_file ) {
+		$staged_files[] = $staged_file;
+	}
+
 	return array(
 		'schema'   => 'wp-codebox/workspace-recipe/v1',
 		'runtime'  => array(
@@ -57,12 +67,7 @@ trait WP_Codebox_Abilities_Browser_Runner {
 			'blueprint' => $runtime_blueprint,
 		),
 		'inputs'   => array(
-			'stagedFiles' => array(
-				array(
-					'source' => 'task-payload',
-					'target' => $task_path,
-				),
-			),
+			'stagedFiles' => $staged_files,
 			'agent_bundles' => is_array( $task_payload['agent_bundles'] ?? null ) ? $task_payload['agent_bundles'] : array(),
 		),
 		'workflow' => array(
@@ -88,6 +93,32 @@ trait WP_Codebox_Abilities_Browser_Runner {
 			'runner_contract' => $runner_contract,
 		),
 	);
+}
+
+/** @param array<string,mixed> $task_input Normalized task input. @return array<int,array<string,mixed>> */
+private static function browser_runner_staged_files( array $task_input ): array {
+	$files      = is_array( $task_input['staged_files'] ?? null ) ? $task_input['staged_files'] : ( is_array( $task_input['stagedFiles'] ?? null ) ? $task_input['stagedFiles'] : array() );
+	$normalized = array();
+	foreach ( $files as $file ) {
+		if ( ! is_array( $file ) ) {
+			continue;
+		}
+		$source = trim( (string) ( $file['source'] ?? '' ) );
+		$target = trim( (string) ( $file['target'] ?? '' ) );
+		if ( '' === $source || '' === $target ) {
+			continue;
+		}
+		$entry = array(
+			'source' => $source,
+			'target' => $target,
+		);
+		if ( isset( $file['metadata'] ) && is_array( $file['metadata'] ) ) {
+			$entry['metadata'] = $file['metadata'];
+		}
+		$normalized[] = $entry;
+	}
+
+	return $normalized;
 }
 
 /** @param array<string,mixed> $recipe Browser recipe. @return array<string,mixed> */

--- a/scripts/php-wordpress-workload-runner-smoke.php
+++ b/scripts/php-wordpress-workload-runner-smoke.php
@@ -34,6 +34,7 @@ function rest_do_request( WP_REST_Request $request ): WP_Codebox_Test_REST_Respo
 }
 
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-wordpress-workload-runner.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php';
 
 class WP_Codebox_WordPress_Workload_Runner_Smoke {
@@ -63,6 +64,90 @@ assert( 200 === $result['steps'][0]['observation']['status'] );
 assert( 'workload/report.json' === $result['artifacts'][0]['path'] );
 assert( 'skipped' === $result['steps'][2]['status'] );
 assert( 'wp_codebox_wordpress_workload_step_unsupported' === $result['steps'][2]['diagnostics'][0]['code'] );
+
+$php_workload_path = tempnam( sys_get_temp_dir(), 'wp-codebox-workload-' );
+assert( is_string( $php_workload_path ) );
+file_put_contents(
+	$php_workload_path,
+	<<<'PHP'
+<?php
+return static function ( array $input, array $args ): array {
+	return array(
+		'status' => 'passed',
+		'observation' => array(
+			'input_schema' => $input['schema'] ?? '',
+			'arg_type' => $args['type'] ?? '',
+		),
+		'artifactRefs' => array(
+			array( 'name' => 'php-report', 'path' => 'workload/php-report.json' ),
+		),
+	);
+};
+PHP
+);
+
+$php_result = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
+	array(
+		'schema' => 'wp-codebox/wordpress-workload-run/v1',
+		'steps'  => array(
+			array( 'command' => 'wordpress.run-workload', 'args' => array( 'type=php', 'path=' . $php_workload_path ) ),
+		),
+	)
+);
+
+assert( is_array( $php_result ) );
+assert( true === $php_result['success'] );
+assert( 'completed' === $php_result['status'] );
+assert( 'passed' === $php_result['steps'][0]['status'] );
+assert( 'wp-codebox/wordpress-workload-run/v1' === $php_result['steps'][0]['observation']['input_schema'] );
+assert( 'php' === $php_result['steps'][0]['observation']['arg_type'] );
+assert( 'workload/php-report.json' === $php_result['artifacts'][0]['path'] );
+@unlink( $php_workload_path );
+
+$not_callable_path = tempnam( sys_get_temp_dir(), 'wp-codebox-workload-' );
+assert( is_string( $not_callable_path ) );
+file_put_contents( $not_callable_path, "<?php\nreturn array();\n" );
+$not_callable = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
+	array(
+		'schema' => 'wp-codebox/wordpress-workload-run/v1',
+		'steps'  => array(
+			array( 'command' => 'wordpress.run-workload', 'args' => array( 'type=php', 'path=' . $not_callable_path ) ),
+		),
+	)
+);
+
+assert( is_array( $not_callable ) );
+assert( false === $not_callable['success'] );
+assert( 'failed' === $not_callable['status'] );
+assert( 'wp_codebox_wordpress_workload_php_not_callable' === $not_callable['diagnostics'][0]['code'] );
+@unlink( $not_callable_path );
+
+$package_root = sys_get_temp_dir() . '/wp-codebox-workload-package-' . bin2hex( random_bytes( 4 ) );
+mkdir( $package_root );
+$package_workload = $package_root . '/bench.php';
+file_put_contents( $package_workload, "<?php\nreturn static function (): array { return array( 'status' => 'passed' ); };\n" );
+$package_workload_real = realpath( $package_workload );
+assert( is_string( $package_workload_real ) );
+$stage_method = new ReflectionMethod( WP_Codebox_Agents_API_Adapter::class, 'stage_runtime_package_wordpress_workload_files' );
+$staged_input = $stage_method->invoke(
+	null,
+	array(
+		'package' => array( 'source' => $package_root ),
+		'input'   => array(
+			'schema' => 'wp-codebox/wordpress-workload-run/v1',
+			'steps'  => array(
+				array( 'command' => 'wordpress.run-workload', 'args' => array( 'type=php', 'path=${package.root}/bench.php' ) ),
+			),
+		),
+	)
+);
+
+assert( is_array( $staged_input ) );
+assert( str_starts_with( $staged_input['input']['steps'][0]['args'][1], 'path=/tmp/wp-codebox-workloads/' ) );
+assert( $package_workload_real === $staged_input['input']['staged_files'][0]['source'] );
+assert( 'wordpress-php-workload' === $staged_input['input']['staged_files'][0]['metadata']['kind'] );
+@unlink( $package_workload );
+@rmdir( $package_root );
 
 $unsafe = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
 	array(


### PR DESCRIPTION
## Summary
- Add `wordpress.run-workload type=php path=...` execution support to the WordPress workload runner.
- Resolve runtime package PHP workload paths from `${package.root}` or package-relative paths before entering Playground.
- Stage resolved PHP workload files into sandbox-visible paths and propagate staged files through task/recipe inputs.

## Testing
- `php -l packages/wordpress-plugin/src/class-wp-codebox-wordpress-workload-runner.php`
- `php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runner.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-task-input-contract.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php`
- `php -l scripts/php-wordpress-workload-runner-smoke.php`
- `php scripts/php-wordpress-workload-runner-smoke.php`
- `php scripts/php-fuzz-suite-runner-smoke.php`
- `php scripts/php-browser-contained-site-contract-smoke.php`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode, plus delegated coding agent
- **Used for:** Implementation, test updates, and verification command selection.
