### PR TITLE
fix: support nested fuzz suite recipe command

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "test:fuzz-run-recipe": "tsx tests/fuzz-run-recipe.test.ts",
     "test:fuzz-suite-runner": "tsx tests/fuzz-suite-runner.test.ts",
     "test:playground-fuzz-suite-public": "tsx tests/playground-fuzz-suite-public.test.ts",
+    "test:nested-fuzz-suite-recipe-command": "tsx tests/nested-fuzz-suite-recipe-command.test.ts",
     "test:wordpress-fuzz-suite-builders": "tsx tests/wordpress-fuzz-suite-builders.test.ts",
     "test:recipe-secret-env": "tsx tests/recipe-secret-env.test.ts",
     "test:preview-options": "tsx tests/preview-options.test.ts",

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
-import { commandArgValue, parseCommandJsonObject, runtimeCheckpointUnsupportedDiagnostic, type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type Runtime, type RuntimeCheckpointFailureDiagnostic, type RuntimeCheckpointOperation, type RuntimeCheckpointResult, type WorkspaceRecipe, type WorkspaceRecipeDistributionSetupArtifact, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
+import { commandArgValue, parseCommandJson, parseCommandJsonObject, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, runFuzzSuite, runtimeCheckpointUnsupportedDiagnostic, type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type FuzzSuiteContract, type Runtime, type RuntimeCheckpointFailureDiagnostic, type RuntimeCheckpointOperation, type RuntimeCheckpointResult, type WorkspaceRecipe, type WorkspaceRecipeDistributionSetupArtifact, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
@@ -159,6 +159,9 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
     if (isRuntimeCheckpointRecipeCommand(workflowStep.step.command)) {
       return withRecipeExecutionPhase(await executeRuntimeCheckpointRecipeCommand(runtime, workflowStep.step.command, workflowStep.step.args ?? []), workflowStep.phase, workflowStep.index, workflowStep.step.command)
     }
+    if (workflowStep.step.command === "wp-codebox/run-fuzz-suite") {
+      return withRecipeExecutionPhase(await executeRunFuzzSuiteRecipeCommand(runtime, workflowStep.step.args ?? [], recipeDirectory, sandboxWorkspace), workflowStep.phase, workflowStep.index, workflowStep.step.command)
+    }
     const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory, sandboxWorkspace))
     return {
       ...withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, workflowStep.step.command),
@@ -170,6 +173,88 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Recipe workflow ${workflowStep.phase}[${workflowStep.index}] failed: ${message}`, { cause: error })
+  }
+}
+
+async function executeRunFuzzSuiteRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>): Promise<ExecutionResult> {
+  const startedAt = new Date().toISOString()
+  const suite = await fuzzSuiteFromRecipeCommandArgs(args, recipeDirectory)
+  const result = await runFuzzSuite(suite, {
+    runnerCapabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
+    executor: async (spec) => runtime.execute(await recipeExecutionSpec(workflowStepFromExecutionSpec(spec), recipeDirectory, sandboxWorkspace)),
+    runtimeWorkloadExecutor: async ({ workload, case: fuzzCase }) => {
+      const steps = [...workflowStepsFromWorkloadPhase(workload.before), ...workflowStepsFromWorkloadPhase(workload.steps), ...workflowStepsFromWorkloadPhase(workload.after)]
+      const workloadStartedAt = new Date().toISOString()
+      const executions: ExecutionResult[] = []
+      for (const step of steps) {
+        const execution = await runtime.execute(await recipeExecutionSpec(step, recipeDirectory, sandboxWorkspace))
+        executions.push(execution)
+        if (execution.exitCode !== 0 && !step.allowFailure && !step.advisory) {
+          break
+        }
+      }
+      const failed = executions.find((execution) => execution.exitCode !== 0)
+      const payload = { schema: "wp-codebox/wordpress-workload-run-result/v1", caseId: fuzzCase.id, steps: executions.length, exitCode: failed?.exitCode ?? 0 }
+      return {
+        id: `wordpress-run-workload-${fuzzCase.id}`,
+        command: "wordpress.run-workload",
+        args: [`steps=${steps.length}`],
+        exitCode: failed?.exitCode ?? 0,
+        stdout: `${JSON.stringify(payload)}\n`,
+        stderr: failed?.stderr ?? "",
+        result: { schema: "wp-codebox/runtime-command-result/v1", status: failed ? "error" : "ok", json: payload },
+        startedAt: workloadStartedAt,
+        finishedAt: executions.at(-1)?.finishedAt ?? new Date().toISOString(),
+        artifactRefs: executions.flatMap((execution) => execution.artifactRefs ?? []),
+      }
+    },
+    metadata: { public_recipe_command: "wp-codebox/run-fuzz-suite" },
+  })
+  const stdout = `${JSON.stringify(result, null, 2)}\n`
+  const failed = result.status === "failed" || result.status === "error"
+  return {
+    id: `wp-codebox-run-fuzz-suite:${startedAt}`,
+    command: "wp-codebox/run-fuzz-suite",
+    args,
+    exitCode: failed ? 1 : 0,
+    stdout,
+    stderr: failed ? result.diagnostics.map((diagnostic) => diagnostic.message).filter(Boolean).join("\n") : "",
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    artifactRefs: result.artifactRefs?.map((ref) => ({ id: ref.path, path: ref.path, kind: ref.kind, digest: ref.sha256 ? { algorithm: "sha256", value: ref.sha256 } : undefined, metadata: ref.metadata })) ?? [],
+  }
+}
+
+async function fuzzSuiteFromRecipeCommandArgs(args: string[], recipeDirectory: string): Promise<FuzzSuiteContract> {
+  const inline = commandArgValue(args, "input-json") ?? commandArgValue(args, "suite-json")
+  if (inline) {
+    return parseCommandJson(inline, "input-json") as FuzzSuiteContract
+  }
+  const file = commandArgValue(args, "input-file") ?? commandArgValue(args, "suite-file")
+  if (file) {
+    return parseCommandJson(await readFile(resolve(recipeDirectory, file), "utf8"), file) as FuzzSuiteContract
+  }
+  throw new Error("wp-codebox/run-fuzz-suite requires input-json=<suite> or input-file=<path>")
+}
+
+function workflowStepsFromWorkloadPhase(value: unknown): WorkspaceRecipe["workflow"]["steps"] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value.flatMap((step) => {
+    if (!step || typeof step !== "object" || Array.isArray(step)) {
+      return []
+    }
+    const command = (step as { command?: unknown }).command
+    return typeof command === "string" && command.trim() !== "" ? [step as WorkspaceRecipe["workflow"]["steps"][number]] : []
+  })
+}
+
+function workflowStepFromExecutionSpec(spec: { command: string; args?: string[]; diagnostics?: WorkspaceRecipe["workflow"]["steps"][number]["diagnostics"] }): WorkspaceRecipe["workflow"]["steps"][number] {
+  return {
+    command: spec.command,
+    args: spec.args,
+    diagnostics: spec.diagnostics,
   }
 }
 

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -4,6 +4,7 @@ import { WORDPRESS_DB_RESULT_JSON_SCHEMA, WORDPRESS_DB_RESULT_SCHEMA } from "./w
 import { WORDPRESS_CRUD_RESULT_JSON_SCHEMA, WORDPRESS_CRUD_RESULT_SCHEMA } from "./wordpress-crud-contracts.js"
 import { PERFORMANCE_OBSERVATION_SCHEMA } from "./performance-observation.js"
 import { WORDPRESS_ADMIN_PAGE_INVENTORY_SCHEMA, WORDPRESS_DATABASE_INVENTORY_SCHEMA, WORDPRESS_FRONTEND_URL_INVENTORY_SCHEMA, WORDPRESS_REST_ROUTE_INVENTORY_SCHEMA, WORDPRESS_RUNTIME_DISCOVERY_SCHEMA } from "./wordpress-runtime-discovery-contracts.js"
+import { FUZZ_SUITE_RESULT_SCHEMA, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES } from "./fuzz-suite-contracts.js"
 
 export type CommandHandlerBinding =
   | { kind: "playground"; method: string }
@@ -312,6 +313,27 @@ export const commandRegistry = [
     policyRequirement: "Host-side recipe helper; supported runtime backends list same-run checkpoints, unsupported backends fail closed with structured diagnostics.",
     recipe: true,
     handler: { kind: "recipe-alias", command: "wp-codebox.checkpoint-list" },
+  },
+  {
+    id: "wp-codebox/run-fuzz-suite",
+    description: "Recipe-only public runtime helper that runs a wp-codebox/fuzz-suite/v1 payload against the active WordPress runtime.",
+    acceptedArgs: [
+      { name: "input-json", description: "Inline wp-codebox/fuzz-suite/v1 payload.", format: "JSON object" },
+      { name: "input-file", description: "Recipe-relative path to a wp-codebox/fuzz-suite/v1 payload.", format: "path" },
+      { name: "suite-json", description: "Alias for input-json.", format: "JSON object" },
+      { name: "suite-file", description: "Alias for input-file.", format: "path" },
+    ],
+    outputShape: "wp-codebox/fuzz-suite-result/v1 JSON produced by the public fuzz-suite runner.",
+    outputSchema: objectEnvelopeSchema(FUZZ_SUITE_RESULT_SCHEMA, {
+      suite: { type: "object" },
+      cases: { type: "array" },
+      status: { type: "string" },
+      diagnostics: { type: "array" },
+    }),
+    policyRequirement: "Host-side recipe helper; it executes declared fuzz-suite cases through the active runtime and requires the runtime-backed fuzz-suite command set.",
+    requiresPolicyCommands: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES.commands,
+    recipe: true,
+    handler: { kind: "recipe-alias", command: "wp-codebox/run-fuzz-suite" },
   },
   {
     id: "wordpress.ability",

--- a/tests/nested-fuzz-suite-recipe-command.test.ts
+++ b/tests/nested-fuzz-suite-recipe-command.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+
+import { assertWorkspaceRecipeJsonSchema, fuzzSuiteContract, type ExecutionResult, type ExecutionSpec, type Runtime, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { executeRecipeWorkflowStep } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+
+const suite = fuzzSuiteContract({
+  id: "nested-workload-suite",
+  cases: [{
+    id: "case-one",
+    target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" },
+    input: {
+      schema: "wp-codebox/wordpress-workload-run/v1",
+      steps: [{ command: "wordpress.run-php", args: ["code=echo 'ok';"] }],
+    },
+  }],
+})
+
+const recipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [{ command: "wp-codebox/run-fuzz-suite", args: [`input-json=${JSON.stringify(suite)}`] }],
+  },
+}
+
+assertWorkspaceRecipeJsonSchema(recipe, { recipeCommandIds: ["wp-codebox/run-fuzz-suite", "wordpress.run-php"] })
+
+const executed: ExecutionSpec[] = []
+const runtime = {
+  async execute(spec: ExecutionSpec): Promise<ExecutionResult> {
+    executed.push(spec)
+    return {
+      id: `exec-${executed.length}`,
+      command: spec.command,
+      args: spec.args ?? [],
+      exitCode: 0,
+      stdout: "ok\n",
+      stderr: "",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:01.000Z",
+    }
+  },
+} as Runtime
+
+const execution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: recipe.workflow.steps[0]! }, process.cwd())
+const result = JSON.parse(execution.stdout)
+
+assert.equal(execution.command, "wp-codebox/run-fuzz-suite")
+assert.equal(execution.exitCode, 0)
+assert.equal(result.schema, "wp-codebox/fuzz-suite-result/v1")
+assert.equal(result.status, "passed")
+assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.run-php"])
+
+console.log("nested fuzz suite recipe command ok")


### PR DESCRIPTION
## Summary
- Register `wp-codebox/run-fuzz-suite` as a public recipe command.
- Execute nested fuzz-suite recipe steps through the public fuzz-suite runner.
- Support `input-json`, `input-file`, `suite-json`, and `suite-file` arguments.
- Add focused nested recipe command coverage.

## Evidence
Offloaded Woo fuzz run `wc-db-api-codebox-suite-20260626T0115Z` advanced past plugin activation but failed recipe validation because `workflow.steps[0].command = wp-codebox/run-fuzz-suite` was not accepted by the runtime-backed recipe schema.

## Verification
- `npm ci`
- `npm run build`
- `npm run test:nested-fuzz-suite-recipe-command`
- `npm run test:fuzz-suite-runner`
- `npm run test:playground-fuzz-suite-public`
- `npm run test:recipe-validation-descriptors`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Diagnosing the offloaded fuzz failure, drafting the nested recipe command support, adding focused tests, and preparing the PR.
