### PR TITLE
fix: accept suite path for nested fuzz command

### DIFF
--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -230,7 +230,7 @@ async function fuzzSuiteFromRecipeCommandArgs(args: string[], recipeDirectory: s
   if (inline) {
     return parseCommandJson(inline, "input-json") as FuzzSuiteContract
   }
-  const file = commandArgValue(args, "input-file") ?? commandArgValue(args, "suite-file")
+  const file = commandArgValue(args, "input-file") ?? commandArgValue(args, "suite-file") ?? commandArgValue(args, "suite")
   if (file) {
     return parseCommandJson(await readFile(resolve(recipeDirectory, file), "utf8"), file) as FuzzSuiteContract
   }

--- a/tests/nested-fuzz-suite-recipe-command.test.ts
+++ b/tests/nested-fuzz-suite-recipe-command.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 
 import { assertWorkspaceRecipeJsonSchema, fuzzSuiteContract, type ExecutionResult, type ExecutionSpec, type Runtime, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
 import { executeRecipeWorkflowStep } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
@@ -49,5 +52,22 @@ assert.equal(execution.exitCode, 0)
 assert.equal(result.schema, "wp-codebox/fuzz-suite-result/v1")
 assert.equal(result.status, "passed")
 assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.run-php"])
+
+const suiteAliasDir = await mkdtemp(join(tmpdir(), "wp-codebox-nested-fuzz-suite-alias-"))
+await writeFile(join(suiteAliasDir, "suite.json"), JSON.stringify(suite), "utf8")
+const suiteAliasRecipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [{ command: "wp-codebox/run-fuzz-suite", args: ["suite=suite.json"] }],
+  },
+}
+assertWorkspaceRecipeJsonSchema(suiteAliasRecipe, { recipeCommandIds: ["wp-codebox/run-fuzz-suite", "wordpress.run-php"] })
+const aliasExecution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: suiteAliasRecipe.workflow.steps[0]! }, suiteAliasDir)
+const aliasResult = JSON.parse(aliasExecution.stdout)
+
+assert.equal(aliasExecution.command, "wp-codebox/run-fuzz-suite")
+assert.equal(aliasExecution.exitCode, 0)
+assert.equal(aliasResult.schema, "wp-codebox/fuzz-suite-result/v1")
+assert.equal(aliasResult.status, "passed")
 
 console.log("nested fuzz suite recipe command ok")


### PR DESCRIPTION
## Summary
- Accept `suite=<path>` as a file alias for nested `wp-codebox/run-fuzz-suite` recipe commands.
- Keep existing `input-json`, `input-file`, `suite-json`, and `suite-file` support.
- Add focused regression coverage for the alias emitted by Woo fuzz workloads.

## Evidence
Offloaded Woo fuzz run `wc-db-api-codebox-suite-20260626T0130Z` reached nested fuzz-suite execution and failed with `wp-codebox/run-fuzz-suite requires input-json=<suite> or input-file=<path>` because the generated command used `suite=${package.root}/manifests/codebox-fuzz-suite-smoke.json`.

## Verification
- `npm ci` (also ran build)
- `npm run test:nested-fuzz-suite-recipe-command`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Diagnosing the offloaded fuzz failure, drafting the alias fix, adding focused test coverage, and preparing the PR.
