### PR TITLE
Execute runtime command fuzz cases

### DIFF
--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -3,7 +3,7 @@ import { existsSync, realpathSync, statSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, isAbsolute, join, resolve } from "node:path"
-import { parseCommandJson, parseCommandOptions, runFuzzSuite, wordpressWorkloadRunRecipe, type ExecutionResult, type FuzzSuiteContract, type FuzzSuiteRuntimeWorkloadExecutionInput, type WordPressWorkloadRunRecipeOptions, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
+import { parseCommandJson, parseCommandOptions, runFuzzSuite, wordpressWorkloadRunRecipe, type ExecutionResult, type ExecutionSpec, type FuzzSuiteContract, type FuzzSuiteRuntimeWorkloadExecutionInput, type WordPressWorkloadRunRecipeOptions, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
 import { captureStdout } from "../output.js"
 import { runRecipeRunCommand } from "./recipe-run.js"
 
@@ -27,7 +27,9 @@ export async function runFuzzSuiteCommand(args: string[]): Promise<number> {
 
   const options = await parsePublicRuntimeCommandOptions(args)
   const result = await runFuzzSuite(options.input as unknown as FuzzSuiteContract, {
+    executor: (spec) => runWordPressFuzzCommand(spec, options),
     runtimeWorkloadExecutor: (input) => runWordPressWorkloadFuzzCase(input, options),
+    supportedTargetKinds: ["runtime"],
     metadata: {
       public_cli_command: "run-fuzz-suite",
       dry_run: options.dryRun || undefined,
@@ -36,6 +38,42 @@ export async function runFuzzSuiteCommand(args: string[]): Promise<number> {
   const { schema: _schema, ...resultFields } = result
   writeJson({ schema: FUZZ_SUITE_RESULT_SCHEMA, ...resultFields })
   return 0
+}
+
+async function runWordPressFuzzCommand(spec: ExecutionSpec, options: PublicRuntimeCommandOptions): Promise<ExecutionResult> {
+  const startedAt = new Date().toISOString()
+  const requirements = fuzzSuiteRuntimeRequirements(options.input)
+  const step = { command: spec.command, args: spec.args ?? [], ...(spec.timeoutMs !== undefined ? { timeoutMs: spec.timeoutMs } : {}) }
+  const recipe = wordpressWorkloadRunRecipe(workloadRecipeOptions({ steps: [step] }, requirements)) as WorkspaceRecipe
+  applyFuzzSuiteRuntimeRequirements(recipe, requirements)
+  const tempDir = await mkdtemp(join(tmpdir(), "wp-codebox-fuzz-command-"))
+  try {
+    const recipePath = join(tempDir, "recipe.json")
+    await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`, "utf8")
+    const recipeArgs = ["--recipe", recipePath, "--json"]
+    if (options.dryRun) recipeArgs.push("--dry-run")
+    if (options.artifactsDirectory) recipeArgs.push("--artifacts", options.artifactsDirectory)
+    if (options.runRegistryDirectory) recipeArgs.push("--run-registry", options.runRegistryDirectory)
+    if (options.timeout) recipeArgs.push("--timeout", options.timeout)
+    const { result: exitCode, logs } = await captureStdout(() => runRecipeRunCommand(recipeArgs))
+    const stdout = logs.join("")
+    const recipeResult = parseRecipeRunOutput(stdout)
+    const stderr = recipeResult?.error && typeof recipeResult.error === "object" && "message" in recipeResult.error ? String(recipeResult.error.message) : ""
+    return {
+      id: `wordpress-fuzz-command-${createHash("sha256").update(`${spec.command}\0${JSON.stringify(spec.args ?? [])}`).digest("hex").slice(0, 12)}`,
+      command: spec.command,
+      args: spec.args ?? [],
+      exitCode,
+      stdout,
+      stderr,
+      result: { schema: "wp-codebox/runtime-command-result/v1", status: exitCode === 0 ? "ok" : "error", stdout, stderr, json: recipeResult },
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      artifactRefs: recipeArtifactRefs(recipeResult),
+    }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
 }
 
 export async function runWordPressWorkloadCommand(args: string[]): Promise<number> {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -359,7 +359,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
             exitCode: execution.exitCode,
             startedAt: execution.startedAt,
             finishedAt: execution.finishedAt,
-            result: execution.result,
+            result: fuzzSuiteExecutionMetadataResult(execution.result),
           },
         }),
       })
@@ -395,6 +395,12 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
       runnerCapabilities: fuzzRunnerCapabilitiesContract(runnerCapabilities, suite),
     }),
   })
+}
+
+function fuzzSuiteExecutionMetadataResult(result: ExecutionResult["result"]): ExecutionResult["result"] | undefined {
+  if (!result) return undefined
+  const { stdout: _stdout, stderr: _stderr, ...metadataResult } = result
+  return stripUndefined(metadataResult) as ExecutionResult["result"]
 }
 
 function normalizeFuzzSuiteResetExecutor(executor: FuzzSuiteRunOptions["resetExecutor"]): ((input: FuzzSuiteResetExecutionInput) => Promise<FuzzSuiteCaseResetResult>) | undefined {

--- a/packages/runtime-core/src/fuzz-suite-runner.ts
+++ b/packages/runtime-core/src/fuzz-suite-runner.ts
@@ -359,6 +359,7 @@ export async function runFuzzSuite(suite: FuzzSuiteContract, options: FuzzSuiteR
             exitCode: execution.exitCode,
             startedAt: execution.startedAt,
             finishedAt: execution.finishedAt,
+            result: execution.result,
           },
         }),
       })

--- a/tests/public-fuzz-workload-cli.test.ts
+++ b/tests/public-fuzz-workload-cli.test.ts
@@ -81,6 +81,28 @@ return static function ( array $input, array $args ): array {
   assert.equal(runtimeFuzzJson.cases[0].metadata.adapter.adapterKind, "runtime-workload")
   assert.equal(runtimeFuzzJson.metadata.runnerCapabilities.mode, "runtime-backed")
 
+  const runtimeCommandFuzzInput = join(directory, "runtime-command-fuzz.json")
+  await writeFile(runtimeCommandFuzzInput, JSON.stringify({
+    schema: "wp-codebox/fuzz-suite/v1",
+    id: "public-cli-runtime-command-suite",
+    cases: [{
+      id: "rest-route-inventory",
+      target: { kind: "runtime", id: "wordpress.inventory-rest-routes", entrypoint: "wordpress.inventory-rest-routes" },
+      input: { args: [] },
+    }],
+  }), "utf8")
+  const runtimeCommandFuzzOutput = await captureStdout(async () => {
+    assert.equal(await runCli(["run-fuzz-suite", "--input-file", runtimeCommandFuzzInput, "--format=json", "--dry-run"]), 0)
+  })
+  const runtimeCommandFuzzJson = JSON.parse(runtimeCommandFuzzOutput)
+  assert.equal(runtimeCommandFuzzJson.schema, "wp-codebox/fuzz-suite-result/v1")
+  assert.equal(runtimeCommandFuzzJson.status, "passed")
+  assert.equal(runtimeCommandFuzzJson.cases[0].status, "passed")
+  assert.notEqual(runtimeCommandFuzzJson.cases[0].skipReason, "fuzz_suite_executor_unavailable")
+  assert.equal(runtimeCommandFuzzJson.cases[0].metadata.adapter.adapterKind, "runtime")
+  assert.equal(runtimeCommandFuzzJson.cases[0].metadata.execution.result.json.schema, "wp-codebox/recipe-run-dry-run/v1")
+  assert.equal(runtimeCommandFuzzJson.cases[0].metadata.execution.result.json.plan.workflow.steps[0].command, "wordpress.inventory-rest-routes")
+
   const phpRuntimeFuzzInput = join(directory, "runtime-php-workload-fuzz.json")
   await writeFile(phpRuntimeFuzzInput, JSON.stringify({
     schema: "wp-codebox/fuzz-suite/v1",


### PR DESCRIPTION
## Summary
- Execute direct runtime command targets in `wp-codebox run-fuzz-suite` by wrapping each command in a temporary one-step WordPress recipe.
- Keep the public CLI scoped to runtime targets so generic command targets remain unsupported rather than accidentally executed.
- Preserve command execution results in fuzz-suite case metadata for artifact inspection.

## Testing
- `npm run build`
- `./node_modules/.bin/tsx tests/public-fuzz-workload-cli.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Root cause analysis, implementation, and focused test updates.