### PR TITLE
Preserve bench extra plugin source roots

### DIFF
--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -161,6 +161,15 @@ function normalizeExtraPlugins(plugins: readonly WorkspaceRecipeExtraPlugin[] = 
     if (plugin.slug !== undefined) {
       normalized.slug = plugin.slug
     }
+    if (plugin.sourceRoot !== undefined) {
+      normalized.sourceRoot = plugin.sourceRoot
+    }
+    if (plugin.sourceSubpath !== undefined) {
+      normalized.sourceSubpath = plugin.sourceSubpath
+    }
+    if (plugin.originalSource !== undefined) {
+      normalized.originalSource = plugin.originalSource
+    }
     if (plugin.pluginFile !== undefined) {
       normalized.pluginFile = plugin.pluginFile
     }

--- a/tests/recipe-builder-bench-steps.test.ts
+++ b/tests/recipe-builder-bench-steps.test.ts
@@ -3,6 +3,13 @@ import { buildWordPressBenchRecipe } from "../packages/runtime-core/src/recipe-b
 
 const recipe = buildWordPressBenchRecipe({
   pluginSlug: "fixture-plugin",
+  extra_plugins: [{
+    source: "/tmp/monorepo",
+    sourceRoot: "/tmp/monorepo",
+    sourceSubpath: "plugins/fixture-plugin",
+    originalSource: "/tmp/monorepo/plugins/fixture-plugin",
+    slug: "fixture-plugin",
+  }],
   prepareSteps: [{ command: "wordpress.wp-cli", args: ["command=option update fixture_prepare yes"] }],
   postSteps: [{ command: "wordpress.browser-probe", args: ["url=/", "capture=html,screenshot"] }],
 })
@@ -17,6 +24,13 @@ assert.deepEqual(recipe.workflow.steps.map((step) => step.command), [
 assert.deepEqual(recipe.workflow.steps[1], {
   command: "wordpress.browser-probe",
   args: ["url=/", "capture=html,screenshot"],
+})
+assert.deepEqual(recipe.inputs.extra_plugins?.[0], {
+  source: "/tmp/monorepo",
+  sourceRoot: "/tmp/monorepo",
+  sourceSubpath: "plugins/fixture-plugin",
+  originalSource: "/tmp/monorepo/plugins/fixture-plugin",
+  slug: "fixture-plugin",
 })
 
 console.log("recipe builder bench steps ok")


### PR DESCRIPTION
## Summary
- Preserve sourceRoot, sourceSubpath, and originalSource when buildWordPressBenchRecipe normalizes extra_plugins.
- Add targeted coverage so monorepo component plugin recipe inputs retain the root/subpath needed for Composer path repositories.

## Tests
- npx tsx tests/recipe-builder-bench-steps.test.ts
- npm run build
- npm run build && npx tsx scripts/recipe-run-composer-autoload-extra-plugin-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Homeboy issue path, implementing the recipe-builder field preservation, and drafting tests/PR text.

Related: Extra-Chill/homeboy#6472