### PR TITLE
Add contained-site sync browser SDK

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -12,6 +12,7 @@
 		'browser-runtime:normalize-result',
 		'browser-runtime:normalize-browser-run-result',
 		'browser-preview:start',
+		'browser-contained-site-sync:consume',
 		'browser-runtime:boot-executable-session',
 		'browser-runtime:parent-tool-bridge',
 		'browser-runtime:aggregate-fanout-outputs',
@@ -334,6 +335,113 @@
 		},
 	} );
 
+	const containedSiteSyncRoute = ( delegation, name ) => {
+		const route = String( delegation?.routes?.[ name ] || '' );
+		if ( ! route.startsWith( '/' ) || route.startsWith( '//' ) ) {
+			throw runtimeError( 'browser_contained_site_sync_consume', 'browser_contained_site_sync_route_invalid', `Contained-site sync route is missing or invalid: ${ name }` );
+		}
+
+		return route;
+	};
+
+	const fetchContainedSiteSyncRoute = async ( route, method = 'GET', body = null ) => {
+		if ( typeof fetch !== 'function' ) {
+			throw runtimeError( 'browser_contained_site_sync_consume', 'browser_contained_site_sync_fetch_unavailable', 'Browser fetch is required to consume contained-site sync DTOs.' );
+		}
+
+		const response = await fetch( route, {
+			method,
+			credentials: 'same-origin',
+			headers: body ? { 'Content-Type': 'application/json' } : {},
+			body: body ? JSON.stringify( body ) : undefined,
+		} );
+		const data = await response.json().catch( () => null );
+		if ( ! response.ok ) {
+			throw runtimeError( 'browser_contained_site_sync_consume', 'browser_contained_site_sync_request_failed', data?.message || `Contained-site sync ${ method } ${ route } failed.`, { status: response.status, route } );
+		}
+
+		return data;
+	};
+
+	const consumeContainedSiteSync = async ( client, delegation, options = {} ) => {
+		void client;
+		const projectId = Number( options.projectId || options.project_id || 0 );
+		const schema = String( delegation?.schema || '' );
+		if ( schema !== 'wp-codebox/browser-contained-site-sync-delegation/v1' && schema !== 'studio-native/codebox-contained-site-sync-delegation/v1' ) {
+			return {
+				schema: 'wp-codebox/browser-contained-site-sync-consumption/v1',
+				status: 'unavailable',
+				project_id: projectId,
+				manifest: null,
+				resources: null,
+				package: null,
+				apply_plan: null,
+				validation: null,
+				validation_hash: '',
+				hydration: {
+					status: 'not_attempted',
+					reason: 'No contained-site sync delegation descriptor was provided.',
+				},
+			};
+		}
+
+		const evidence = {
+			schema: 'wp-codebox/browser-contained-site-sync-consumption/v1',
+			status: 'running',
+			project_id: projectId,
+			manifest: delegation.manifest || null,
+			resources: null,
+			package: null,
+			apply_plan: null,
+			validation: null,
+			validation_hash: '',
+			hydration: { status: 'not_attempted' },
+		};
+
+		try {
+			const manifestRoute = containedSiteSyncRoute( delegation, 'manifest' );
+			const resourcesRoute = containedSiteSyncRoute( delegation, 'resources' );
+			const exportRoute = containedSiteSyncRoute( delegation, 'export' );
+			evidence.manifest = await fetchContainedSiteSyncRoute( manifestRoute );
+			evidence.resources = await fetchContainedSiteSyncRoute( resourcesRoute );
+			evidence.package = await fetchContainedSiteSyncRoute( exportRoute, 'POST', {} );
+
+			if ( delegation.routes?.apply_plan_generate && delegation.routes?.apply_plan_validate ) {
+				try {
+					evidence.apply_plan = await fetchContainedSiteSyncRoute( containedSiteSyncRoute( delegation, 'apply_plan_generate' ), 'POST', {
+						mode: 'content_only',
+						package: evidence.package,
+						resources: evidence.resources,
+					} );
+					evidence.validation = await fetchContainedSiteSyncRoute( containedSiteSyncRoute( delegation, 'apply_plan_validate' ), 'POST', {
+						mode: 'content_only',
+						apply_plan: evidence.apply_plan?.apply_plan || evidence.apply_plan,
+						base_snapshot: evidence.package?.base_snapshot || null,
+					} );
+					evidence.validation_hash = evidence.validation?.validation_hash || evidence.validation?.hash || '';
+				} catch ( error ) {
+					evidence.validation = {
+						status: 'unavailable',
+						reason: error?.message || 'Contained-site sync apply-plan validation is unavailable.',
+					};
+				}
+			}
+
+			evidence.hydration = evidence.package?.schema === 'playground-site-sync/playground-package/v1' && evidence.package?.descriptor?.bootable === true && evidence.package?.blueprint && typeof evidence.package.blueprint === 'object'
+				? { status: 'ready', mode: 'blueprint_descriptor', base_snapshot: evidence.package.base_snapshot || null, descriptor: evidence.package.descriptor || null }
+				: { status: 'unsupported', reason: 'Contained-site sync export did not include a bootable package descriptor.' };
+			evidence.status = evidence.hydration.status === 'ready' ? 'success' : 'unsupported';
+		} catch ( error ) {
+			evidence.status = 'failed';
+			evidence.hydration = {
+				status: 'failed',
+				reason: error?.message || 'Contained-site sync consumption failed.',
+			};
+		}
+
+		return evidence;
+	};
+
 	const browserPreviewBootConfig = ( input ) => {
 		const boot = input?.schema === 'wp-codebox/browser-preview-boot-config/v1'
 			? input
@@ -463,6 +571,7 @@
 		normalizeError: normalizeBrowserSdkError,
 		normalizeBrowserRunResult,
 		browserArtifactPersistenceRef,
+		consumeContainedSiteSync: ( client, delegation, options = {} ) => api.consumeContainedSiteSync( client, delegation, options ),
 		startBrowserPreview: ( input, options = {} ) => api.startBrowserPreview( input, options ),
 		aggregateFanoutOutputs: ( input ) => api.aggregateFanoutOutputs( input ),
 		validateBrowserRuntimeMaterialization: ( client, session, options = {} ) => api.validateBrowserRuntimeMaterialization( client, session, options ),
@@ -477,6 +586,7 @@
 		methods: Object.freeze( {
 			activateTheme: api.activateTheme,
 			browserSessionRecipe: api.browserSessionRecipe,
+			consumeContainedSiteSync: api.consumeContainedSiteSync,
 			startBrowserPreview: api.startBrowserPreview,
 			bootExecutableBrowserSession: api.bootExecutableBrowserSession,
 			createParentToolRequest: api.createParentToolRequest,
@@ -2371,6 +2481,7 @@ echo wp_json_encode( array(
 		aggregateFanoutOutputs,
 		browserSessionRecipe,
 		bootExecutableBrowserSession,
+		consumeContainedSiteSync,
 		createParentToolRequest,
 		dispatchParentTool,
 		ensureDirectory,

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -33,6 +33,7 @@ assert.deepEqual(plain(api.v1.info()), {
     "browser-runtime:normalize-result",
     "browser-runtime:normalize-browser-run-result",
     "browser-preview:start",
+    "browser-contained-site-sync:consume",
     "browser-runtime:boot-executable-session",
     "browser-runtime:parent-tool-bridge",
     "browser-runtime:aggregate-fanout-outputs",
@@ -57,6 +58,7 @@ assert.equal(api.v1.methods.writeFile, api.writeFile)
 assert.equal(api.v1.methods.validateBrowserRuntimeMaterialization, api.validateBrowserRuntimeMaterialization)
 assert.equal(typeof api.v1.runBrowserSessionRecipe, "function")
 assert.equal(typeof api.v1.startBrowserPreview, "function")
+assert.equal(typeof api.v1.consumeContainedSiteSync, "function")
 assert.equal(typeof api.v1.bootExecutableBrowserSession, "function")
 assert.equal(typeof api.v1.createParentToolRequest, "function")
 assert.equal(typeof api.v1.validateBrowserRuntimeMaterialization, "function")
@@ -101,6 +103,52 @@ assert.deepEqual(plain(browserRun.artifactRefs), [
   { kind: "browser-html", path: "files/browser/index.html", digest: { algorithm: "sha256", value: "def" } },
 ])
 assert.equal(api.v1.browserArtifactPersistenceRef(browserRun.result).schema, "wp-codebox/browser-artifact-persistence/ref/v1")
+
+const previousFetch = (sandbox as any).fetch
+const requestedRoutes: Array<{ route: string, method: string, body?: string }> = []
+;(sandbox as any).fetch = async (route: string, request: { method?: string, body?: string } = {}) => {
+  requestedRoutes.push({ route, method: request.method || "GET", body: request.body })
+  const payloadByRoute: Record<string, unknown> = {
+    "/playground-site-sync/v1/manifest": { schema: "playground-site-sync/manifest/v1" },
+    "/playground-site-sync/v1/resources": { schema: "playground-site-sync/resources/v1" },
+    "/playground-site-sync/v1/export": {
+      schema: "playground-site-sync/playground-package/v1",
+      descriptor: { bootable: true },
+      blueprint: { steps: [] },
+      base_snapshot: "snapshot-1",
+    },
+    "/playground-site-sync/v1/apply-plan/generate": { schema: "playground-site-sync/apply-plan/v1", apply_plan: { steps: [] } },
+    "/playground-site-sync/v1/apply-plan/validate": { schema: "playground-site-sync/validation/v1", validation_hash: "validation-1" },
+  }
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payloadByRoute[route],
+  }
+}
+const syncConsumption = await api.v1.consumeContainedSiteSync(null, {
+  schema: "wp-codebox/browser-contained-site-sync-delegation/v1",
+  routes: {
+    manifest: "/playground-site-sync/v1/manifest",
+    resources: "/playground-site-sync/v1/resources",
+    export: "/playground-site-sync/v1/export",
+    apply_plan_generate: "/playground-site-sync/v1/apply-plan/generate",
+    apply_plan_validate: "/playground-site-sync/v1/apply-plan/validate",
+  },
+}, { projectId: 123 })
+assert.equal(syncConsumption.schema, "wp-codebox/browser-contained-site-sync-consumption/v1")
+assert.equal(syncConsumption.status, "success")
+assert.equal(syncConsumption.project_id, 123)
+assert.equal(syncConsumption.hydration.status, "ready")
+assert.equal(syncConsumption.validation_hash, "validation-1")
+assert.deepEqual(requestedRoutes.map(({ route, method }) => `${method} ${route}`), [
+  "GET /playground-site-sync/v1/manifest",
+  "GET /playground-site-sync/v1/resources",
+  "POST /playground-site-sync/v1/export",
+  "POST /playground-site-sync/v1/apply-plan/generate",
+  "POST /playground-site-sync/v1/apply-plan/validate",
+])
+;(sandbox as any).fetch = previousFetch
 
 const runtimeSession = {
   runtime: {


### PR DESCRIPTION
## Summary
- Add a WP Codebox browser SDK v1 capability for consuming contained-site sync delegation DTOs.
- Expose the capability through the stable v1 facade and methods bag.
- Cover the facade contract with a DTO-level test.

## Testing
- npm run test:browser-sdk-facade

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5/OpenCode
- **Used for:** Drafting and applying the browser SDK boundary change and focused contract test.