### PR TITLE
Expand canonical live progress counts

### DIFF
--- a/packages/runtime-core/src/live-progress.ts
+++ b/packages/runtime-core/src/live-progress.ts
@@ -6,6 +6,7 @@ export const LIVE_PROGRESS_EVENT_SCHEMA = "wp-codebox/live-progress-event/v1" as
 export type LiveProgressStatus = "queued" | "running" | "succeeded" | "failed" | "skipped" | "cancelled" | "timed_out"
 
 export interface LiveProgressCounts {
+  current?: number
   total?: number
   active?: number
   completed?: number
@@ -13,6 +14,8 @@ export interface LiveProgressCounts {
   skipped?: number
   cancelled?: number
   timed_out?: number
+  percent?: number
+  unit?: string
 }
 
 export interface LiveProgressEvent {
@@ -81,15 +84,26 @@ function liveProgressStatus(input: Partial<FanoutLifecycleEvent> | BrowserStartu
 }
 
 function liveProgressCounts(input: Partial<FanoutLifecycleEvent>): LiveProgressCounts {
+  const current = numberValue((input as Record<string, unknown>).current) ?? numberValue(input.completed)
+  const total = numberValue(input.total)
   return stripUndefined({
-    total: numberValue(input.total),
+    current,
+    total,
     active: numberValue(input.active),
     completed: numberValue(input.completed),
     failed: numberValue(input.failed),
     skipped: numberValue(input.skipped),
     cancelled: numberValue(input.cancelled),
     timed_out: numberValue(input.timed_out),
+    percent: normalizePercent(numberValue((input as Record<string, unknown>).percent) ?? (current !== undefined && total ? (current / total) * 100 : undefined)),
+    unit: stringValue((input as Record<string, unknown>).unit) || undefined,
   })
+}
+
+function normalizePercent(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined
+  const percent = value > 0 && value <= 1 ? value * 100 : value
+  return Math.max(0, Math.min(100, percent))
 }
 
 function liveProgressLabel(phase: string, status: LiveProgressStatus): string {

--- a/tests/live-progress.test.ts
+++ b/tests/live-progress.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+import { normalizeLiveProgressEvent } from "../packages/runtime-core/src/live-progress.js"
+
+const event = normalizeLiveProgressEvent({
+  schema: "wp-codebox/fanout-event/v1",
+  event: "worker.completed",
+  fanout_id: "fanout-1",
+  worker_id: "worker-2",
+  completed: 2,
+  total: 4,
+  status: "completed",
+  artifacts: { result: "fanout/worker-2/result.json" },
+  diagnostics: { counts: { failed: 0 } },
+  time: "2026-06-26T00:00:00.000Z",
+})
+
+assert.equal(event.schema, "wp-codebox/live-progress-event/v1")
+assert.equal(event.phase, "worker.completed")
+assert.equal(event.status, "succeeded")
+assert.equal(event.progress?.current, 2)
+assert.equal(event.progress?.total, 4)
+assert.equal(event.progress?.percent, 50)
+assert.deepEqual(event.artifacts, { result: "fanout/worker-2/result.json" })
+assert.deepEqual(event.diagnostics, { counts: { failed: 0 } })


### PR DESCRIPTION
## Summary
- Extend the canonical live progress event count payload with current, percent, and unit.
- Derive percent from current/completed and total when possible.
- Add a focused live progress normalization test.

## Testing
- npx tsx tests/live-progress.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the canonical progress count extension, added focused tests, and ran targeted verification.