### PR TITLE
Stabilize public Codebox envelopes

### DIFF
--- a/packages/runtime-core/src/fanout-aggregation.ts
+++ b/packages/runtime-core/src/fanout-aggregation.ts
@@ -203,6 +203,32 @@ export function aggregateFanoutOutputs(input: FanoutAggregationInputRequest, opt
   }
 }
 
+export function validateFanoutAggregationOutput(input: unknown): FanoutAggregationOutput {
+  const output = input && typeof input === "object" && !Array.isArray(input) ? input as Partial<FanoutAggregationOutput> : undefined
+  if (output?.schema !== FANOUT_AGGREGATION_OUTPUT_SCHEMA) {
+    throw new Error("Fanout aggregation output must use wp-codebox/agent-fanout-aggregation-output/v1.")
+  }
+  if (!Array.isArray(output.workerResultRefs)) {
+    throw new Error("Fanout aggregation output requires workerResultRefs.")
+  }
+  if (!Array.isArray(output.rawWorkerArtifactRefs)) {
+    throw new Error("Fanout aggregation output requires rawWorkerArtifactRefs.")
+  }
+  if (!Array.isArray(output.finalArtifactRefs)) {
+    throw new Error("Fanout aggregation output requires finalArtifactRefs.")
+  }
+
+  for (const worker of output.workerResultRefs) {
+    if (!worker.workerId) throw new Error("Fanout worker result refs require workerId.")
+    if (!Array.isArray(worker.artifactRefs)) throw new Error(`Fanout worker ${worker.workerId} requires artifactRefs.`)
+    for (const artifact of worker.artifactRefs) validateFanoutArtifactRef(artifact, `Fanout worker ${worker.workerId}`)
+  }
+  for (const artifact of output.rawWorkerArtifactRefs) validateFanoutArtifactRef(artifact, "Fanout raw worker artifact")
+  for (const artifact of output.finalArtifactRefs) validateFanoutArtifactRef(artifact, "Fanout final artifact")
+
+  return output as FanoutAggregationOutput
+}
+
 export function defaultFanoutAggregationOutputPath(input: FanoutAggregationInputRequest, outputNamespace?: string): string {
   const normalized = normalizeFanoutAggregationInput(input)
   return `${normalizeOutputNamespace(outputNamespace ?? normalized.aggregator?.outputNamespace)}/result.json`
@@ -292,6 +318,11 @@ function resolveAggregationStatus(policy: FanoutAggregationPolicy, conflicts: Fa
   if (policy === "repair") return "repair_required"
   if (policy === "caller-review-required") return "caller_review_required"
   return "failed"
+}
+
+function validateFanoutArtifactRef(artifact: FanoutArtifactRef, label: string): void {
+  if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) throw new Error(`${label} ref must be an object.`)
+  if (!artifact.path) throw new Error(`${label} ref requires path.`)
 }
 
 function normalizePlan(plan: FanoutAggregationInputRequest["plan"]): FanoutPlan {

--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -2,7 +2,7 @@ import { AGENT_TASK_RUN_RESULT_SCHEMA, normalizeAgentTaskRunResult, type AgentTa
 import { HEADLESS_AGENT_TASK_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_RESULT_SCHEMA } from "./headless-agent-task-contracts.js"
 import { AGENT_RUNTIME_WORKLOAD_SCHEMA } from "./agent-runtime-workload.js"
 import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, normalizeArtifactResultEnvelope, type ArtifactResultEnvelope } from "./artifact-result-envelope.js"
-import { FANOUT_AGGREGATION_INPUT_SCHEMA, FANOUT_AGGREGATION_OUTPUT_SCHEMA, aggregateFanoutOutputs, normalizeFanoutAggregationInput, type FanoutAggregationInput, type FanoutAggregationInputRequest, type FanoutAggregationOutput } from "./fanout-aggregation.js"
+import { FANOUT_AGGREGATION_INPUT_SCHEMA, FANOUT_AGGREGATION_OUTPUT_SCHEMA, aggregateFanoutOutputs, normalizeFanoutAggregationInput, validateFanoutAggregationOutput, type FanoutAggregationInput, type FanoutAggregationInputRequest, type FanoutAggregationOutput } from "./fanout-aggregation.js"
 import { FUZZ_COVERAGE_PLAN_SCHEMA } from "./fuzz-coverage-plan-contracts.js"
 import { FUZZ_SUITE_RESULT_SCHEMA, FUZZ_SUITE_SCHEMA } from "./fuzz-suite-contracts.js"
 import { HOST_DELEGATION_EVENT_SCHEMA, HOST_DELEGATION_REQUEST_SCHEMA, HOST_DELEGATION_RESULT_SCHEMA } from "./fanout-contracts.js"
@@ -205,6 +205,7 @@ export const RUNTIME_CONTRACT_NORMALIZERS = {
   artifactResultEnvelope: normalizeArtifactResultEnvelope,
   fanoutAggregationInput: normalizeFanoutAggregationInput,
   fanoutAggregationOutput: aggregateFanoutOutputs,
+  fanoutAggregationOutputEnvelope: validateFanoutAggregationOutput,
   runtimeProfile: normalizeRuntimeProfile,
   runtimeAccess: normalizeRuntimeAccess,
   previewReviewerAccess: normalizePreviewReviewerAccess,
@@ -215,6 +216,7 @@ export const RUNTIME_CONTRACT_NORMALIZERS = {
   artifactResultEnvelope: (input: unknown) => ArtifactResultEnvelope
   fanoutAggregationInput: (input: FanoutAggregationInputRequest) => FanoutAggregationInput
   fanoutAggregationOutput: (input: FanoutAggregationInputRequest) => FanoutAggregationOutput
+  fanoutAggregationOutputEnvelope: (input: unknown) => FanoutAggregationOutput
   runtimeProfile: (input: unknown) => RuntimeProfile
   runtimeAccess: (input: unknown) => RuntimeAccess
   previewReviewerAccess: typeof normalizePreviewReviewerAccess

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php
@@ -18,6 +18,11 @@ final class WP_Codebox_Runtime_Task_Runner {
 			return $this->public_error( 'wp_codebox_runtime_task_request_invalid', 'Runtime task requests require a task.', 400 );
 		}
 
+		$target_id = $this->target_id( $input );
+		if ( '' === $target_id ) {
+			return $this->public_error( 'wp_codebox_runtime_task_target_required', 'Runtime task requests require an explicit target_id.', 400, array( 'reason' => 'target_id_required' ) );
+		}
+
 		foreach ( $this->runtime_task_providers( $input ) as $provider ) {
 			if ( ! $this->provider_matches( $provider, $input ) ) {
 				continue;
@@ -31,7 +36,7 @@ final class WP_Codebox_Runtime_Task_Runner {
 			return $this->result_envelope( $input, $result, $this->provider_id( $provider ) );
 		}
 
-		return $this->public_error( 'wp_codebox_runtime_task_unavailable', 'Runtime task execution is unavailable.', 501 );
+		return $this->public_error( 'wp_codebox_runtime_task_unsupported_target', 'Runtime task target is not supported.', 422, array( 'reason' => 'unsupported-target', 'target_id' => $target_id ) );
 	}
 
 	/** @param array<string,mixed> $input Runtime task request. @return array<string,mixed>|WP_Error */
@@ -50,8 +55,9 @@ final class WP_Codebox_Runtime_Task_Runner {
 	private function runtime_task_providers( array $input ): array {
 		$providers = array(
 			array(
-				'id'       => 'wp-codebox-runtime',
-				'callback' => fn( array $request ): array|WP_Error => $this->execute_codebox_runtime_task( $request ),
+				'id'         => 'wp-codebox-runtime',
+				'target_ids' => array( 'wp-codebox/host-playground', 'wp-codebox/browser-playground' ),
+				'callback'   => fn( array $request ): array|WP_Error => $this->execute_codebox_runtime_task( $request ),
 			),
 		);
 
@@ -71,6 +77,11 @@ final class WP_Codebox_Runtime_Task_Runner {
 		$matches = $provider['matches'] ?? null;
 		if ( is_callable( $matches ) ) {
 			return true === $matches( $input );
+		}
+
+		$target_ids = $provider['target_ids'] ?? array();
+		if ( is_array( $target_ids ) && ! empty( $target_ids ) ) {
+			return in_array( $this->target_id( $input ), array_values( array_filter( $target_ids, 'is_string' ) ), true );
 		}
 
 		return true;
@@ -120,20 +131,12 @@ final class WP_Codebox_Runtime_Task_Runner {
 
 	/** @param array<string,mixed> $input Runtime task request. */
 	private function target_id( array $input ): string {
-		foreach ( array( 'target_id', 'executor_id', 'target', 'executor' ) as $field ) {
-			$value = $input[ $field ] ?? null;
-			if ( is_string( $value ) && '' !== trim( $value ) ) {
-				return trim( $value );
-			}
-			if ( is_array( $value ) ) {
-				$id = trim( (string) ( $value['id'] ?? $value['target'] ?? '' ) );
-				if ( '' !== $id ) {
-					return $id;
-				}
-			}
+		$value = $input['target_id'] ?? null;
+		if ( is_string( $value ) && '' !== trim( $value ) ) {
+			return trim( $value );
 		}
 
-		return 'wp-codebox/host-playground';
+		return '';
 	}
 
 	/** @param array<string,mixed> $input Runtime task request. @param array<string,mixed> $result Runtime result. @return array<string,mixed> */
@@ -172,13 +175,19 @@ final class WP_Codebox_Runtime_Task_Runner {
 	}
 
 	/** @return WP_Error */
-	private function public_error( string $code, string $message, int $status ): WP_Error {
+	private function public_error( string $code, string $message, int $status, array $extra = array() ): WP_Error {
 		return new WP_Error(
 			$code,
 			$message,
-			array(
-				'status' => $status,
-				'schema' => 'wp-codebox/runtime-task-error/v1',
+			array_filter(
+				array_merge(
+					$extra,
+					array(
+						'status' => $status,
+						'schema' => 'wp-codebox/runtime-task-error/v1',
+					)
+				),
+				static fn( mixed $value ): bool => null !== $value && '' !== $value
 			)
 		);
 	}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -2586,7 +2586,7 @@ public static function hydrate_browser_blueprint_ref( array $input ): array|WP_E
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function create_browser_materializer_contract( array $input ): array|WP_Error {
 	$return_raw = self::include_raw_browser_contract( $input, 'materializer' );
-	$input['include_raw_browser_session'] = true;
+	$input['include_internal_browser_session'] = true;
 	$session = self::create_browser_playground_session( $input );
 	if ( is_wp_error( $session ) ) {
 		return $session;
@@ -2662,28 +2662,17 @@ public static function create_browser_task_contract( array $input ): array|WP_Er
 
 /** @param array<string,mixed> $input Ability input. */
 private static function include_raw_browser_contract( array $input, string $contract ): bool {
-	if ( true === ( $input['include_internal_browser_contract'] ?? false ) || true === ( $input['include_raw_browser_contract'] ?? false ) ) {
-		return true;
+	$include = true === ( $input['include_internal_browser_contract'] ?? false );
+	if ( function_exists( 'apply_filters' ) ) {
+		$include = (bool) apply_filters( 'wp_codebox_include_internal_browser_contract', $include, $input, $contract );
 	}
 
-	if ( 'materializer' === $contract && true === ( $input['include_raw_browser_materializer_contract'] ?? false ) ) {
-		return true;
-	}
-
-	if ( 'task' === $contract && true === ( $input['include_raw_browser_task_contract'] ?? false ) ) {
-		return true;
-	}
-
-	$debug = is_array( $input['debug'] ?? null ) ? $input['debug'] : array();
-	return true === ( $debug['include_internal_browser_contract'] ?? false )
-		|| true === ( $debug['include_raw_browser_contract'] ?? false )
-		|| ( 'materializer' === $contract && true === ( $debug['include_raw_browser_materializer_contract'] ?? false ) )
-		|| ( 'task' === $contract && true === ( $debug['include_raw_browser_task_contract'] ?? false ) );
+	return $include;
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 private static function prepare_browser_task_contract( array $input ): array|WP_Error {
-	$input['include_raw_browser_session'] = true;
+	$input['include_internal_browser_session'] = true;
 	$primary = self::create_browser_playground_session( $input );
 	if ( is_wp_error( $primary ) ) {
 		return $primary;
@@ -3485,7 +3474,7 @@ private static function browser_session_response_for_input( array $session, arra
 	if ( ! empty( $evidence_ref ) ) {
 		$product_dto['evidence_ref'] = $evidence_ref;
 	}
-	if ( self::include_raw_browser_session_contract( $input ) ) {
+	if ( self::include_raw_browser_session_contract( $input, $session, $product_dto ) ) {
 		$session['product'] = $product_dto;
 		return $session;
 	}
@@ -3531,14 +3520,14 @@ private static function browser_session_evidence_store( array $product_dto, arra
 	);
 }
 
-/** @param array<string,mixed> $input Ability input. */
-private static function include_raw_browser_session_contract( array $input ): bool {
-	if ( true === ( $input['include_raw_browser_session'] ?? false ) || true === ( $input['include_internal_browser_session'] ?? false ) ) {
-		return true;
+/** @param array<string,mixed> $input Ability input. @param array<string,mixed> $session Raw browser session contract. @param array<string,mixed> $product_dto Product DTO. */
+private static function include_raw_browser_session_contract( array $input, array $session, array $product_dto ): bool {
+	$include = true === ( $input['include_internal_browser_session'] ?? false );
+	if ( function_exists( 'apply_filters' ) ) {
+		$include = (bool) apply_filters( 'wp_codebox_include_internal_browser_session_contract', $include, $input, $session, $product_dto );
 	}
 
-	$debug = is_array( $input['debug'] ?? null ) ? $input['debug'] : array();
-	return true === ( $debug['include_raw_browser_session'] ?? false );
+	return $include;
 }
 
 /** @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php
@@ -653,16 +653,16 @@ private static function artifact_apply_input_properties( string $approved_files_
 private static function runtime_task_request_schema(): array {
 	return array(
 		'type'       => 'object',
-		'required'   => array( 'task' ),
+		'required'   => array( 'task', 'target_id' ),
 		'properties' => array(
 			'schema'             => array( 'type' => 'string', 'const' => 'wp-codebox/runtime-task-request/v1' ),
 			'task'               => array( 'type' => array( 'string', 'object' ) ),
 			'input'              => array( 'type' => 'object' ),
 			'task_input'         => self::task_input_schema(),
-			'executor'           => array( 'type' => array( 'string', 'object' ) ),
-			'target'             => array( 'type' => array( 'string', 'object' ) ),
-			'target_id'          => array( 'type' => 'string' ),
-			'executor_id'        => array( 'type' => 'string' ),
+			'target_id'          => array(
+				'type'        => 'string',
+				'description' => 'Explicit runtime target id. Built-in targets are wp-codebox/host-playground and wp-codebox/browser-playground; extension providers may register additional target ids.',
+			),
 			'mode'               => self::string_property_schema(),
 			'agent'              => self::string_property_schema(),
 			'provider'           => self::string_property_schema(),
@@ -993,14 +993,9 @@ private static function browser_task_input_properties( array $task_input_schema,
 		'blueprint'               => self::object_property_schema( $detailed ? 'Optional WordPress Playground blueprint for the browser to compile and run.' : '' ),
 		'site_blueprint_artifact' => $detailed ? self::site_blueprint_artifact_input_schema() : self::object_property_schema(),
 		'artifact_files'          => $detailed ? self::artifact_files_input_schema() : array( 'type' => 'array' ),
-		'include_raw_browser_session' => array(
-			'type'        => 'boolean',
-			'description' => 'Internal/debug escape hatch for materializers that need the raw browser Playground contract. Public callers should use the default product DTO.',
-			'default'     => false,
-		),
 		'debug'                   => array(
 			'type'        => 'object',
-			'description' => 'Optional debug flags. Set debug.include_raw_browser_session only for internal materializer/debug tooling that needs the raw Playground contract.',
+			'description' => 'Optional debug fields for diagnostics. Public callers receive the stable product DTO envelope.',
 		),
 	);
 }

--- a/scripts/php-runtime-task-runner-smoke.php
+++ b/scripts/php-runtime-task-runner-smoke.php
@@ -76,6 +76,16 @@ $missing_task = $runner->run( array( 'schema' => 'wp-codebox/runtime-task-reques
 assert_same_contract( true, is_wp_error( $missing_task ), 'missing task returns error' );
 assert_same_contract( 'wp-codebox/runtime-task-error/v1', $missing_task->get_error_data()['schema'] ?? null, 'missing task error schema' );
 
+$missing_target = $runner->run( array( 'schema' => 'wp-codebox/runtime-task-request/v1', 'task' => 'No target' ) );
+assert_same_contract( true, is_wp_error( $missing_target ), 'missing target returns error' );
+assert_same_contract( 'wp_codebox_runtime_task_target_required', $missing_target->get_error_code(), 'missing target error code' );
+assert_same_contract( 'target_id_required', $missing_target->get_error_data()['reason'] ?? null, 'missing target reason' );
+
+$unsupported_target = $runner->run( array( 'schema' => 'wp-codebox/runtime-task-request/v1', 'task' => 'Bad target', 'target_id' => 'example/unsupported' ) );
+assert_same_contract( true, is_wp_error( $unsupported_target ), 'unsupported target returns error' );
+assert_same_contract( 'wp_codebox_runtime_task_unsupported_target', $unsupported_target->get_error_code(), 'unsupported target error code' );
+assert_same_contract( 'unsupported-target', $unsupported_target->get_error_data()['reason'] ?? null, 'unsupported target reason' );
+
 add_filter(
 	'wp_codebox_runtime_task_providers',
 	static function ( array $providers ): array {
@@ -156,8 +166,9 @@ add_filter(
 );
 $failed = $runner->run(
 	array(
-		'schema' => 'wp-codebox/runtime-task-request/v1',
-		'task'   => 'Fail safely',
+		'schema'    => 'wp-codebox/runtime-task-request/v1',
+		'task'      => 'Fail safely',
+		'target_id' => 'example-runtime',
 	)
 );
 assert_same_contract( true, is_wp_error( $failed ), 'provider failure is public error' );

--- a/tests/browser-session-public-dto.test.ts
+++ b/tests/browser-session-public-dto.test.ts
@@ -67,27 +67,42 @@ $input = array(
 );
 
 $public = WP_Codebox_Abilities::create_browser_playground_session( $input );
-$raw = WP_Codebox_Abilities::create_browser_playground_session( $input + array( 'include_raw_browser_session' => true ) );
+$raw_requested_public = WP_Codebox_Abilities::create_browser_playground_session( $input + array( 'include_raw_browser_session' => true ) );
+$raw_internal = WP_Codebox_Abilities::create_browser_playground_session( $input + array( 'include_internal_browser_session' => true ) );
 $materializer = WP_Codebox_Abilities::create_browser_materializer_contract( $input );
-$raw_materializer = WP_Codebox_Abilities::create_browser_materializer_contract( $input + array( 'include_raw_browser_materializer_contract' => true ) );
+$raw_materializer_requested_public = WP_Codebox_Abilities::create_browser_materializer_contract( $input + array( 'include_raw_browser_materializer_contract' => true ) );
+$raw_materializer = WP_Codebox_Abilities::create_browser_materializer_contract( $input + array( 'include_internal_browser_contract' => true ) );
 $task_contract = WP_Codebox_Abilities::create_browser_task_contract( $input );
-$raw_task_contract = WP_Codebox_Abilities::create_browser_task_contract( $input + array( 'include_raw_browser_task_contract' => true ) );
+$raw_task_contract_requested_public = WP_Codebox_Abilities::create_browser_task_contract( $input + array( 'include_raw_browser_task_contract' => true ) );
+$raw_task_contract = WP_Codebox_Abilities::create_browser_task_contract( $input + array( 'include_internal_browser_contract' => true ) );
 
 echo json_encode( array(
 	'public' => $public,
-	'raw' => array(
-		'schema' => $raw['schema'] ?? null,
-		'product' => $raw['product'] ?? null,
-		'playground_blueprint_steps_is_array' => is_array( $raw['playground']['blueprint']['steps'] ?? null ),
-		'recipe_runtime_backend' => $raw['recipe']['runtime']['backend'] ?? null,
+	'raw_requested_public' => array(
+		'schema' => $raw_requested_public['schema'] ?? null,
+		'has_playground' => isset( $raw_requested_public['playground'] ),
+	),
+	'raw_internal' => array(
+		'schema' => $raw_internal['schema'] ?? null,
+		'product' => $raw_internal['product'] ?? null,
+		'playground_blueprint_steps_is_array' => is_array( $raw_internal['playground']['blueprint']['steps'] ?? null ),
+		'recipe_runtime_backend' => $raw_internal['recipe']['runtime']['backend'] ?? null,
 	),
 	'materializer' => $materializer,
+	'raw_materializer_requested_public' => array(
+		'schema' => $raw_materializer_requested_public['schema'] ?? null,
+		'has_playground' => isset( $raw_materializer_requested_public['playground'] ),
+	),
 	'raw_materializer' => array(
 		'schema' => $raw_materializer['schema'] ?? null,
 		'compact' => $raw_materializer['compact'] ?? null,
 		'playground_blueprint_steps_is_array' => is_array( $raw_materializer['playground']['blueprint']['steps'] ?? null ),
 	),
 	'task_contract' => $task_contract,
+	'raw_task_contract_requested_public' => array(
+		'schema' => $raw_task_contract_requested_public['schema'] ?? null,
+		'has_primary' => isset( $raw_task_contract_requested_public['primary'] ),
+	),
 	'raw_task_contract' => array(
 		'schema' => $raw_task_contract['schema'] ?? null,
 		'compact' => $raw_task_contract['compact'] ?? null,
@@ -157,10 +172,12 @@ assert.equal(result.public.preview_boot.runtime_access.preview_url, "/preview/in
 assertPublicDtoDoesNotExposeInternals(result.public)
 assertPublicDtoDoesNotExposeInternals(result.public.executable_session)
 
-assert.equal(result.raw.schema, "wp-codebox/browser-playground-session/v1")
-assert.equal(result.raw.product.schema, "wp-codebox/browser-session-product-dto/v1")
-assert.equal(result.raw.playground_blueprint_steps_is_array, true)
-assert.equal(result.raw.recipe_runtime_backend, "wordpress-playground")
+assert.equal(result.raw_requested_public.schema, "wp-codebox/browser-session-product-dto/v1")
+assert.equal(result.raw_requested_public.has_playground, false)
+assert.equal(result.raw_internal.schema, "wp-codebox/browser-playground-session/v1")
+assert.equal(result.raw_internal.product.schema, "wp-codebox/browser-session-product-dto/v1")
+assert.equal(result.raw_internal.playground_blueprint_steps_is_array, true)
+assert.equal(result.raw_internal.recipe_runtime_backend, "wordpress-playground")
 
 assert.equal(result.materializer.schema, "wp-codebox/browser-materializer-product-dto/v1")
 assert.equal(result.materializer.source_schema, "wp-codebox/browser-materializer-contract/v1")
@@ -168,6 +185,8 @@ assert.equal(result.materializer.preview_ref.schema, "wp-codebox/browser-preview
 assert.deepEqual(result.materializer.artifact_refs, result.public.artifact_refs)
 assertPublicDtoDoesNotExposeInternals(result.materializer)
 
+assert.equal(result.raw_materializer_requested_public.schema, "wp-codebox/browser-materializer-product-dto/v1")
+assert.equal(result.raw_materializer_requested_public.has_playground, false)
 assert.equal(result.raw_materializer.schema, "wp-codebox/browser-materializer-contract/v1")
 assert.equal(result.raw_materializer.playground_blueprint_steps_is_array, true)
 assert.equal(result.raw_materializer.compact.schema, "wp-codebox/browser-materializer-product-dto/v1")
@@ -176,6 +195,8 @@ assert.equal(result.task_contract.schema, "wp-codebox/browser-task-product-dto/v
 assert.equal(result.task_contract.primary.schema, "wp-codebox/browser-session-product-dto/v1")
 assertPublicDtoDoesNotExposeInternals(result.task_contract)
 
+assert.equal(result.raw_task_contract_requested_public.schema, "wp-codebox/browser-task-product-dto/v1")
+assert.equal(result.raw_task_contract_requested_public.has_primary, true)
 assert.equal(result.raw_task_contract.schema, "wp-codebox/browser-task-contract/v1")
 assert.equal(result.raw_task_contract.compact.schema, "wp-codebox/browser-task-product-dto/v1")
 assert.equal(result.raw_task_contract.primary_playground_blueprint_steps_is_array, true)

--- a/tests/fanout-aggregation-contract-parity.test.ts
+++ b/tests/fanout-aggregation-contract-parity.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 import vm from "node:vm"
 
-import { aggregateFanoutOutputs, fanoutAggregationInputFromWorkerArtifacts } from "../packages/runtime-core/src/index.js"
+import { aggregateFanoutOutputs, fanoutAggregationInputFromWorkerArtifacts, validateFanoutAggregationOutput } from "../packages/runtime-core/src/index.js"
 import { executeAgentFanoutRequest } from "../packages/cli/src/agent-fanout.js"
 import { FANOUT_REQUEST_SCHEMA } from "../packages/runtime-core/src/index.js"
 import { withTempDir } from "../scripts/test-kit.js"
@@ -12,7 +12,10 @@ const fixture = JSON.parse(await readFile(new URL("fixtures/fanout-aggregation-c
 const plain = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
 const runtimeOutput = plain(aggregateFanoutOutputs(fixture.input))
+assert.deepEqual(plain(validateFanoutAggregationOutput(runtimeOutput)), fixture.expectedOutput, "canonical fanout output fixture must validate")
 assert.deepEqual(runtimeOutput, fixture.expectedOutput, "runtime-core aggregation output must match the canonical fixture")
+assert.throws(() => validateFanoutAggregationOutput({ ...runtimeOutput, workerResultRefs: undefined }), /workerResultRefs/, "canonical fanout output requires worker result refs")
+assert.throws(() => validateFanoutAggregationOutput({ ...runtimeOutput, rawWorkerArtifactRefs: [{ kind: "worker-report" }] }), /requires path/, "canonical fanout output requires artifact ref paths")
 
 const normalizedFromArtifacts = plain(fanoutAggregationInputFromWorkerArtifacts({
   plan: fixture.input.plan,

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -154,6 +154,7 @@ assert.equal(RUNTIME_CONTRACT_NORMALIZERS.typedArtifact({ name: "report", type: 
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.typedArtifactIndex({ artifacts: [{ name: "report", type: "json", path: "files/report.json", sha256: "a".repeat(64) }] }).artifacts.length, 1)
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationInput({ plan: { workers: [] } }).schema, FANOUT_AGGREGATION_INPUT_SCHEMA)
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationOutput({ plan: { workers: [] } }).schema, FANOUT_AGGREGATION_OUTPUT_SCHEMA)
+assert.equal(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationOutputEnvelope(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationOutput({ plan: { workers: [] } })).schema, FANOUT_AGGREGATION_OUTPUT_SCHEMA)
 
 assert.doesNotMatch(JSON.stringify(manifest), /datamachine|data machine|homeboy|wpsg|wp-site-generator|wp site generator/i)
 assert.doesNotMatch(JSON.stringify(manifest), /agents\/run-runtime-package|wp_codebox_runner_workspace_backend|workspace_worktree_add/i)

--- a/tests/wordpress-plugin-public-runtime-abilities.test.ts
+++ b/tests/wordpress-plugin-public-runtime-abilities.test.ts
@@ -19,6 +19,10 @@ assert.match(schemasPhp, /'const'\s*=>\s*'wp-codebox\/wordpress-workload-run-res
 assert.match(schemasPhp, /'const'\s*=>\s*'wp-codebox\/fuzz-suite\/v1'/)
 assert.match(schemasPhp, /'const'\s*=>\s*'wp-codebox\/fuzz-suite-result\/v1'/)
 assert.match(schemasPhp, /'kind'\s*=>\s*array\( 'type' => 'string', 'enum' => array\( 'ability', 'command', 'http', 'rest', 'runtime', 'runtime-action' \) \)/)
+assert.doesNotMatch(schemasPhp, /include_raw_browser_session/, "public browser session input schema must not expose raw browser session escape hatches")
+assert.match(schemasPhp, /'required'\s*=>\s*array\( 'task', 'target_id' \)/, "runtime task requests must require explicit target_id")
+const runtimeTaskSchema = schemasPhp.slice(schemasPhp.indexOf("private static function runtime_task_request_schema"), schemasPhp.indexOf("private static function runtime_task_result_schema"))
+assert.doesNotMatch(runtimeTaskSchema, /'executor_id'\s*=>|\s'executor'\s*=>|\s'target'\s*=>/, "runtime task public schema must not advertise implicit target aliases")
 
 assert.match(executionPhp, /function run_wordpress_workload\( array \$input \)/)
 assert.match(executionPhp, /function run_fuzz_suite\( array \$input \)/)


### PR DESCRIPTION
## Summary
- remove the public raw browser session request flag from ability schemas and gate raw browser/session contracts behind internal-only flags plus filters
- require explicit runtime task target_id and return typed unsupported-target errors instead of falling through to implicit host execution
- publish a fanout aggregation output validator and extend fixture/golden tests for workerResultRefs and artifact refs

## Verification
- npm run test:browser-session-public-dto
- npm run test:php-runtime-task-runner
- npm run test:fanout-aggregation-contract-parity
- npm run test:runtime-contract-manifest
- npm run test:wordpress-plugin-public-runtime-abilities
- npm run test:browser-sdk-facade && npm run test:browser-playground-session-run
- npm run build
- php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php && php -l packages/wordpress-plugin/src/class-wp-codebox-runtime-task-runner.php && php -l scripts/php-runtime-task-runner-smoke.php

## Known blocker
- npm run check currently fails in test:browser-runner-template on an unrelated generated runner template hash mismatch. This PR does not touch the files loaded by that test: class-wp-codebox-browser-runner-template.php, class-wp-codebox-agent-runtime-invoker.php, or trait-wp-codebox-abilities-browser-runner.php.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the contract changes, adding/updating tests, running verification, and drafting this PR.