### PR TITLE
Fix typed artifact recipe-run exits

### DIFF
--- a/packages/cli/src/cli-main.ts
+++ b/packages/cli/src/cli-main.ts
@@ -46,8 +46,7 @@ export function runCliEntrypoint(args: string[], runner: CliRunner = runCli, exi
 }
 
 function naturalExit(code: number): never {
-  process.exitCode = code
-  return undefined as never
+  process.exit(code)
 }
 
 function exitAfterOutputDrains(code: number, exit: CliExit): void {

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -191,7 +191,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     const session = sandboxSession(input, run, artifacts, success ? "completed" : "failed")
     const structuredArtifacts = structuredArtifactRefs(agentTaskResult)
     const outputs = stripUndefined({ ...workload.outputs })
-    const typedArtifacts = typedArtifactRefs(agentTaskResult, outputs)
+    const typedArtifacts = agentTaskRunTypedArtifacts(agentTaskResult, outputs, run)
     const evidence = evidenceRefs(run, artifacts, failureEvidence)
     const artifactResult = artifactResultEnvelope({
       operation: "agent-task-run",
@@ -626,6 +626,11 @@ export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, work
     objectValue(rawRuntimeResult.outputs)?.typed_artifacts,
     objectValue(rawRuntimeResult.engine_data)?.outputs && objectValue(objectValue(rawRuntimeResult.engine_data)?.outputs)?.typed_artifacts,
   ].flatMap(typedArtifactList))
+}
+
+export function agentTaskRunTypedArtifacts(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown>, run: Record<string, unknown>): Array<Record<string, unknown>> {
+  const runtimeOutputs = objectValue(run.outputs) || {}
+  return typedArtifactRefs(agentTaskResult, stripUndefined({ ...runtimeOutputs, ...workloadOutputs }))
 }
 
 function typedArtifactList(value: unknown): Array<Record<string, unknown>> {

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -163,7 +163,7 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     })
     const hasAgentBundle = Object.keys(agentBundle).length > 0
     const recipeSuccess = Boolean(run.success) && (!hasAgentBundle || workload.success)
-    const agentTaskResult = objectValue(run.agentTaskResult) || objectValue(runRecord.agentTaskResult) || objectValue(artifactsRecord.agentTaskResult) || {}
+    const agentTaskResult = agentTaskResultFromRun(run, runRecord, artifactsRecord)
     const terminalResult = terminalResultFromRun(run, agentTaskResult)
     const completionOutcome = objectValue(run.completionOutcome) || objectValue(run.completion_outcome) || objectValue(artifactsRecord.completionOutcome) || objectValue(artifactsRecord.completion_outcome) || {}
     const agentResult = objectValue(run.agentResult) || objectValue(runRecord.agentResult) || objectValue(artifactsRecord.agentResult) || {}
@@ -608,6 +608,7 @@ function structuredArtifactRefs(agentTaskResult: Record<string, unknown>): Array
 
 export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown> = {}): Array<Record<string, unknown>> {
   const outputs = objectValue(agentTaskResult.outputs) || {}
+  const outputsResult = objectValue(outputs.result) || {}
   const result = objectValue(agentTaskResult.result) || {}
   const raw = objectValue(agentTaskResult.raw) || {}
   const rawResult = objectValue(raw.result) || {}
@@ -615,6 +616,8 @@ export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, work
   return dedupeRecords([
     agentTaskResult.typed_artifacts,
     outputs.typed_artifacts,
+    objectValue(outputsResult.outputs)?.typed_artifacts,
+    objectValue(outputsResult.engine_data)?.outputs && objectValue(objectValue(outputsResult.engine_data)?.outputs)?.typed_artifacts,
     workloadOutputs.typed_artifacts,
     result.typed_artifacts,
     objectValue(result.outputs)?.typed_artifacts,
@@ -631,6 +634,16 @@ export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, work
 export function agentTaskRunTypedArtifacts(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown>, run: Record<string, unknown>): Array<Record<string, unknown>> {
   const runtimeOutputs = objectValue(run.outputs) || {}
   return typedArtifactRefs(agentTaskResult, stripUndefined({ ...runtimeOutputs, ...workloadOutputs }))
+}
+
+export function agentTaskResultFromRun(run: Record<string, unknown>, runRecord: Record<string, unknown> = {}, artifactsRecord: Record<string, unknown> = {}): Record<string, unknown> {
+  return objectValue(run.agentTaskResult)
+    || objectValue(run.agent_task_result)
+    || objectValue(runRecord.agentTaskResult)
+    || objectValue(runRecord.agent_task_result)
+    || objectValue(artifactsRecord.agentTaskResult)
+    || objectValue(artifactsRecord.agent_task_result)
+    || {}
 }
 
 function typedArtifactList(value: unknown): Array<Record<string, unknown>> {

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -607,11 +607,21 @@ function structuredArtifactRefs(agentTaskResult: Record<string, unknown>): Array
 }
 
 export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown> = {}): Array<Record<string, unknown>> {
-  const direct = typedArtifactList(agentTaskResult.typed_artifacts)
   const outputs = objectValue(agentTaskResult.outputs) || {}
-  const fromOutputs = typedArtifactList(outputs.typed_artifacts)
-  const fromWorkloadOutputs = typedArtifactList(workloadOutputs.typed_artifacts)
-  return dedupeRecords([...direct, ...fromOutputs, ...fromWorkloadOutputs].filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))))
+  const raw = objectValue(agentTaskResult.raw) || {}
+  const rawResult = objectValue(raw.result) || {}
+  const rawRuntimeResult = objectValue(objectValue(raw.agent_runtime)?.result) || {}
+  return dedupeRecords([
+    agentTaskResult.typed_artifacts,
+    outputs.typed_artifacts,
+    workloadOutputs.typed_artifacts,
+    rawResult.typed_artifacts,
+    objectValue(rawResult.outputs)?.typed_artifacts,
+    objectValue(rawResult.engine_data)?.outputs && objectValue(objectValue(rawResult.engine_data)?.outputs)?.typed_artifacts,
+    rawRuntimeResult.typed_artifacts,
+    objectValue(rawRuntimeResult.outputs)?.typed_artifacts,
+    objectValue(rawRuntimeResult.engine_data)?.outputs && objectValue(objectValue(rawRuntimeResult.engine_data)?.outputs)?.typed_artifacts,
+  ].flatMap(typedArtifactList))
 }
 
 function typedArtifactList(value: unknown): Array<Record<string, unknown>> {

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -608,6 +608,7 @@ function structuredArtifactRefs(agentTaskResult: Record<string, unknown>): Array
 
 export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown> = {}): Array<Record<string, unknown>> {
   const outputs = objectValue(agentTaskResult.outputs) || {}
+  const result = objectValue(agentTaskResult.result) || {}
   const raw = objectValue(agentTaskResult.raw) || {}
   const rawResult = objectValue(raw.result) || {}
   const rawRuntimeResult = objectValue(objectValue(raw.agent_runtime)?.result) || {}
@@ -615,6 +616,9 @@ export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, work
     agentTaskResult.typed_artifacts,
     outputs.typed_artifacts,
     workloadOutputs.typed_artifacts,
+    result.typed_artifacts,
+    objectValue(result.outputs)?.typed_artifacts,
+    objectValue(result.engine_data)?.outputs && objectValue(objectValue(result.engine_data)?.outputs)?.typed_artifacts,
     rawResult.typed_artifacts,
     objectValue(rawResult.outputs)?.typed_artifacts,
     objectValue(rawResult.engine_data)?.outputs && objectValue(objectValue(rawResult.engine_data)?.outputs)?.typed_artifacts,

--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -606,12 +606,40 @@ function structuredArtifactRefs(agentTaskResult: Record<string, unknown>): Array
   return fromOutputs.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry)))
 }
 
-function typedArtifactRefs(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown> = {}): Array<Record<string, unknown>> {
-  const direct = Array.isArray(agentTaskResult.typed_artifacts) ? agentTaskResult.typed_artifacts : []
+export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown> = {}): Array<Record<string, unknown>> {
+  const direct = typedArtifactList(agentTaskResult.typed_artifacts)
   const outputs = objectValue(agentTaskResult.outputs) || {}
-  const fromOutputs = Array.isArray(outputs.typed_artifacts) ? outputs.typed_artifacts : []
-  const fromWorkloadOutputs = Array.isArray(workloadOutputs.typed_artifacts) ? workloadOutputs.typed_artifacts : []
+  const fromOutputs = typedArtifactList(outputs.typed_artifacts)
+  const fromWorkloadOutputs = typedArtifactList(workloadOutputs.typed_artifacts)
   return dedupeRecords([...direct, ...fromOutputs, ...fromWorkloadOutputs].filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))))
+}
+
+function typedArtifactList(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry)))
+  }
+
+  const record = objectValue(value)
+  if (!record) {
+    return []
+  }
+
+  return Object.entries(record)
+    .map(([name, artifact]) => typedArtifactFromMapEntry(name, artifact))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+}
+
+function typedArtifactFromMapEntry(name: string, artifact: unknown): Record<string, unknown> | undefined {
+  const record = objectValue(artifact)
+  if (!record) {
+    return undefined
+  }
+
+  return stripUndefined({
+    ...record,
+    name: stringValue(record.name) || stringValue(record.output_key) || name,
+    artifact_schema: stringValue(record.artifact_schema) || stringValue(record.schema) || undefined,
+  })
 }
 
 function agentReply(agentResult: Record<string, unknown>, terminalResult: AgentTerminalResult | undefined, runResult: AgentTaskRunResultSummary): Record<string, unknown> | undefined {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -825,6 +825,9 @@ export function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
     ...effectivePolicyCommandsFor(distributionStartupProbeCommands, cliRecipeCommandDefinitions),
     ...effectivePolicyCommandsFor((recipe.probes ?? []).map((probe) => probe.step.command), cliRecipeCommandDefinitions),
   ]
+  if (recipeWorkflowSteps(recipe).some(({ step }) => step.command === "wordpress.bench")) {
+    commands.unshift("wordpress.run-php")
+  }
   if (recipeWorkflowSteps(recipe).some(({ step }) => step.command === "wordpress.bench" && recipeBenchStepUsesWpCli(step))) {
     commands.unshift("wordpress.wp-cli")
   }

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -6,7 +6,7 @@ import { chdir, cwd } from "node:process"
 import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_JSON_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_RESULT_JSON_SCHEMA, HEADLESS_AGENT_TASK_RESULT_SCHEMA, PREVIEW_LEASE_SCHEMA, buildAgentTaskRecipe, headlessAgentTaskRequestToRunInput, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeHeadlessAgentTaskRequest, normalizeHeadlessAgentTaskResult, normalizeRecipeRunSummary, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
-import { agentTaskRunExitCode, normalizeAgentTaskRunCliInput, typedArtifactRefs } from "../packages/cli/src/commands/agent-task-run.js"
+import { agentTaskRunExitCode, agentTaskRunTypedArtifacts, normalizeAgentTaskRunCliInput, typedArtifactRefs } from "../packages/cli/src/commands/agent-task-run.js"
 import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
@@ -187,6 +187,22 @@ const typedArtifactMapRefs = typedArtifactRefs({}, {
 assert.equal(typedArtifactMapRefs[0]?.name, "concept_packet")
 assert.equal(typedArtifactMapRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
 assert.deepEqual(typedArtifactMapRefs[0]?.payload, { title: "Repair Bench Supply" })
+
+const runtimeOutputsTypedArtifactRefs = agentTaskRunTypedArtifacts({}, {}, {
+  outputs: {
+    typed_artifacts: {
+      concept_packet: {
+        output_key: "concept_packet",
+        schema: "wp-site-generator/ConceptPacket/v1",
+        artifact: "ConceptPacket",
+        payload: { title: "Second Shift Supper Club" },
+      },
+    },
+  },
+})
+assert.equal(runtimeOutputsTypedArtifactRefs[0]?.name, "concept_packet")
+assert.equal(runtimeOutputsTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
+assert.deepEqual(runtimeOutputsTypedArtifactRefs[0]?.payload, { title: "Second Shift Supper Club" })
 
 const rawRuntimeTypedArtifactRefs = typedArtifactRefs({
   raw: {

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -6,7 +6,7 @@ import { chdir, cwd } from "node:process"
 import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_JSON_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_RESULT_JSON_SCHEMA, HEADLESS_AGENT_TASK_RESULT_SCHEMA, PREVIEW_LEASE_SCHEMA, buildAgentTaskRecipe, headlessAgentTaskRequestToRunInput, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeHeadlessAgentTaskRequest, normalizeHeadlessAgentTaskResult, normalizeRecipeRunSummary, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
-import { agentTaskRunExitCode, agentTaskRunTypedArtifacts, normalizeAgentTaskRunCliInput, typedArtifactRefs } from "../packages/cli/src/commands/agent-task-run.js"
+import { agentTaskResultFromRun, agentTaskRunExitCode, agentTaskRunTypedArtifacts, normalizeAgentTaskRunCliInput, typedArtifactRefs } from "../packages/cli/src/commands/agent-task-run.js"
 import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
@@ -245,6 +245,31 @@ const resultEngineDataTypedArtifactRefs = typedArtifactRefs({
 assert.equal(resultEngineDataTypedArtifactRefs[0]?.name, "concept_packet")
 assert.equal(resultEngineDataTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
 assert.deepEqual(resultEngineDataTypedArtifactRefs[0]?.payload, { title: "Hearth Ledger" })
+
+const snakeCaseAgentTaskResult = agentTaskResultFromRun({
+  agent_task_result: {
+    outputs: {
+      result: {
+        engine_data: {
+          outputs: {
+            typed_artifacts: {
+              concept_packet: {
+                output_key: "concept_packet",
+                schema: "wp-site-generator/ConceptPacket/v1",
+                artifact: "ConceptPacket",
+                payload: { title: "The Repair Drawer" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+const snakeCaseAgentTaskTypedArtifactRefs = typedArtifactRefs(snakeCaseAgentTaskResult)
+assert.equal(snakeCaseAgentTaskTypedArtifactRefs[0]?.name, "concept_packet")
+assert.equal(snakeCaseAgentTaskTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
+assert.deepEqual(snakeCaseAgentTaskTypedArtifactRefs[0]?.payload, { title: "The Repair Drawer" })
 
 const normalizedWithArtifactEnvelope = normalizeAgentTaskRunResult({
   success: true,

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -338,6 +338,17 @@ assert.equal(agentRecipePolicy.commands.includes("wordpress.run-php"), true)
 assert.equal(agentRecipePolicy.commands.includes("wordpress.wp-cli"), true)
 assert.equal(agentRecipePolicy.commands.includes("wp-codebox.agent-sandbox-run"), false)
 
+const benchRecipePolicy = recipePolicy({
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [
+      { command: "wordpress.bench", args: ["plugin-slug=sample-plugin"] },
+    ],
+  },
+} as never)
+assert.equal(benchRecipePolicy.commands.includes("wordpress.bench"), true)
+assert.equal(benchRecipePolicy.commands.includes("wordpress.run-php"), true)
+
 const generatedAgentSandboxPhp = agentSandboxRunCode("Verify registry adapter", "echo 'ok';", [], [])
 assert.doesNotMatch(generatedAgentSandboxPhp, /DataMachine\\Core\\Database\\Agents\\Agents|data_machine_agent_create_failed|agents-api\/agents-api\.php/)
 const generatedDefaultAgentPhp = await resolveSandboxTaskCode({

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -6,7 +6,7 @@ import { chdir, cwd } from "node:process"
 import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_JSON_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_RESULT_JSON_SCHEMA, HEADLESS_AGENT_TASK_RESULT_SCHEMA, PREVIEW_LEASE_SCHEMA, buildAgentTaskRecipe, headlessAgentTaskRequestToRunInput, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeHeadlessAgentTaskRequest, normalizeHeadlessAgentTaskResult, normalizeRecipeRunSummary, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
-import { agentTaskRunExitCode, normalizeAgentTaskRunCliInput } from "../packages/cli/src/commands/agent-task-run.js"
+import { agentTaskRunExitCode, normalizeAgentTaskRunCliInput, typedArtifactRefs } from "../packages/cli/src/commands/agent-task-run.js"
 import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
@@ -173,6 +173,20 @@ assert.equal(strictRuntimeWorkload.diagnostics.some((diagnostic) => diagnostic.c
 const compatRuntimeWorkload = normalizeAgentRuntimeWorkload({ outputs: { answer: "legacy" } }, { compatMode: true })
 assert.deepEqual(compatRuntimeWorkload.outputs, { answer: "legacy" })
 assert.equal(compatRuntimeWorkload.diagnostics.some((diagnostic) => diagnostic.class === "wp-codebox.normalizer.compat_mode_used"), true)
+
+const typedArtifactMapRefs = typedArtifactRefs({}, {
+  typed_artifacts: {
+    concept_packet: {
+      output_key: "concept_packet",
+      schema: "wp-site-generator/ConceptPacket/v1",
+      artifact: "ConceptPacket",
+      payload: { title: "Repair Bench Supply" },
+    },
+  },
+})
+assert.equal(typedArtifactMapRefs[0]?.name, "concept_packet")
+assert.equal(typedArtifactMapRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
+assert.deepEqual(typedArtifactMapRefs[0]?.payload, { title: "Repair Bench Supply" })
 
 const normalizedWithArtifactEnvelope = normalizeAgentTaskRunResult({
   success: true,

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -210,6 +210,26 @@ assert.equal(rawRuntimeTypedArtifactRefs[0]?.name, "concept_packet")
 assert.equal(rawRuntimeTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
 assert.deepEqual(rawRuntimeTypedArtifactRefs[0]?.payload, { title: "Kiln Shelf" })
 
+const resultEngineDataTypedArtifactRefs = typedArtifactRefs({
+  result: {
+    engine_data: {
+      outputs: {
+        typed_artifacts: {
+          concept_packet: {
+            output_key: "concept_packet",
+            schema: "wp-site-generator/ConceptPacket/v1",
+            artifact: "ConceptPacket",
+            payload: { title: "Hearth Ledger" },
+          },
+        },
+      },
+    },
+  },
+})
+assert.equal(resultEngineDataTypedArtifactRefs[0]?.name, "concept_packet")
+assert.equal(resultEngineDataTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
+assert.deepEqual(resultEngineDataTypedArtifactRefs[0]?.payload, { title: "Hearth Ledger" })
+
 const normalizedWithArtifactEnvelope = normalizeAgentTaskRunResult({
   success: true,
   run: { artifactRefs: [{ id: "bundle-1", kind: "artifact-bundle", directory: "artifacts/run-1" }] },

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -188,6 +188,28 @@ assert.equal(typedArtifactMapRefs[0]?.name, "concept_packet")
 assert.equal(typedArtifactMapRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
 assert.deepEqual(typedArtifactMapRefs[0]?.payload, { title: "Repair Bench Supply" })
 
+const rawRuntimeTypedArtifactRefs = typedArtifactRefs({
+  raw: {
+    agent_runtime: {
+      result: {
+        outputs: {
+          typed_artifacts: {
+            concept_packet: {
+              output_key: "concept_packet",
+              schema: "wp-site-generator/ConceptPacket/v1",
+              artifact: "ConceptPacket",
+              payload: { title: "Kiln Shelf" },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+assert.equal(rawRuntimeTypedArtifactRefs[0]?.name, "concept_packet")
+assert.equal(rawRuntimeTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
+assert.deepEqual(rawRuntimeTypedArtifactRefs[0]?.payload, { title: "Kiln Shelf" })
+
 const normalizedWithArtifactEnvelope = normalizeAgentTaskRunResult({
   success: true,
   run: { artifactRefs: [{ id: "bundle-1", kind: "artifact-bundle", directory: "artifacts/run-1" }] },


### PR DESCRIPTION
## Summary
- read typed artifacts from runtime task/result output envelopes used by WP Codebox agent runs
- force the CLI entrypoint to exit after stdout/stderr drain so terminal recipe failures do not leave the Node process alive
- include `wordpress.run-php` in recipe policy for `wordpress.bench` workloads because bench delegates PHP execution internally
- add contract coverage for typed artifact extraction and bench policy derivation

## Validation
- `npm run build`
- `npx tsx tests/recipe-run-output-exit.test.ts`
- `npx tsx scripts/recipe-run-terminal-phase-failure-smoke.ts`
- `npx tsx scripts/cli-unsettled-command-smoke.ts`
- `npx tsx tests/agent-task-contracts.test.ts`
- Lab direct recipe proof: the previously hanging `recipe-run` now returns promptly with structured failure output; after policy fix it moved past `runtime-command-disallowed` to the next Playground blueprint fetch failure.

## Follow-up
- Remaining WPSG validation blocker is outside this PR: Playground blueprint git install intermittently fails fetching `Automattic/blocks-engine` tag `php-transformer-v0.1.0` with isomorphic-git `Invalid PACK header ''`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the recipe-run hang and policy denial, implementing the CLI exit and bench policy fixes, adding coverage, and running local/Lab validation.
