### PR TITLE
Harden artifact postprocess host helpers

### DIFF
--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -236,6 +236,53 @@ function wp_codebox_bench_run_wp_cli_step(array $step) {
     return $stdout;
 }
 
+function wp_codebox_bench_host_node_bridge_failure_detail(array $result): string {
+    $parts = array();
+    foreach (array('error', 'stdout', 'stderr') as $field) {
+        $value = isset($result[$field]) ? trim((string) $result[$field]) : '';
+        if ($value !== '') {
+            $parts[] = $field . ': ' . $value;
+        }
+    }
+    return implode(' ', $parts);
+}
+
+function wp_codebox_bench_run_host_node_command(array $args, array $env, string $cwd): array {
+    global $wp_cli_bridge_url, $wp_cli_bridge_token;
+    if (!is_string($wp_cli_bridge_url) || $wp_cli_bridge_url === '' || !is_string($wp_cli_bridge_token) || $wp_cli_bridge_token === '') {
+        throw new RuntimeException('artifact-postprocess workload steps require the host command bridge.');
+    }
+
+    $response = wp_remote_post($wp_cli_bridge_url . '/execute', array(
+        'headers' => array(
+            'authorization' => 'Bearer ' . $wp_cli_bridge_token,
+            'content-type' => 'application/json',
+        ),
+        'body' => wp_json_encode(array('type' => 'host_node', 'args' => array_values($args), 'env' => $env, 'cwd' => $cwd), JSON_UNESCAPED_SLASHES),
+        'timeout' => 300,
+    ));
+    if (is_wp_error($response)) {
+        throw new RuntimeException('artifact-postprocess host command bridge request failed: ' . $response->get_error_message());
+    }
+    $body = wp_remote_retrieve_body($response);
+    $result = json_decode($body, true);
+    if (!is_array($result)) {
+        throw new RuntimeException('artifact-postprocess host command bridge returned invalid JSON.');
+    }
+    $bridge_detail = wp_codebox_bench_host_node_bridge_failure_detail($result);
+    $bridge_error = isset($result['error']) && is_string($result['error']) ? trim($result['error']) : '';
+    if (!isset($result['exitCode']) && $bridge_detail !== '') {
+        throw new RuntimeException('artifact-postprocess host command bridge failed: ' . $bridge_detail);
+    }
+    return array(
+        'stdout' => isset($result['stdout']) ? (string) $result['stdout'] : '',
+        'stderr' => isset($result['stderr']) ? (string) $result['stderr'] : '',
+        'exit_code' => isset($result['exitCode']) && is_numeric($result['exitCode']) ? (int) $result['exitCode'] : 1,
+        'error' => $bridge_error,
+        'detail' => $bridge_detail,
+    );
+}
+
 function wp_codebox_bench_metric_prefix(array $step, string $fallback): string {
     $prefix = isset($step['metric-prefix']) && is_string($step['metric-prefix']) ? $step['metric-prefix'] : $fallback;
     $prefix = preg_replace('/[^A-Za-z0-9_]+/', '_', trim($prefix));
@@ -482,19 +529,23 @@ function wp_codebox_bench_run_artifact_postprocess_step(array $step, string $plu
         }
     }
 
-    $execution = wp_codebox_bench_run_command_step($step, 'artifact-postprocess', static function () use ($command, $expanded_args, $env): array {
-        $pipes = array();
-        $process = proc_open(array_merge(array($command), $expanded_args), array(1 => array('pipe', 'w'), 2 => array('pipe', 'w')), $pipes, null, $env);
-        if (!is_resource($process)) {
-            throw new RuntimeException('artifact-postprocess helper process could not be started.');
-        }
-        $stdout = stream_get_contents($pipes[1]);
-        fclose($pipes[1]);
-        $stderr = stream_get_contents($pipes[2]);
-        fclose($pipes[2]);
-        $exit_code = proc_close($process);
+    $execution = wp_codebox_bench_run_command_step($step, 'artifact-postprocess', static function () use ($command, $expanded_args, $env, $helper_path): array {
+        $result = wp_codebox_bench_run_host_node_command($expanded_args, $env, dirname($helper_path));
+        $stdout = $result['stdout'];
+        $stderr = $result['stderr'];
+        $exit_code = $result['exit_code'];
         if ($exit_code !== 0) {
-            throw new RuntimeException('artifact-postprocess helper failed with exit code ' . $exit_code . ': ' . trim((string) $stderr));
+            $detail = isset($result['detail']) && is_string($result['detail']) ? trim($result['detail']) : '';
+            if ($detail === '') {
+                $detail = trim((string) $stderr);
+            }
+            if ($detail === '') {
+                $detail = trim((string) $stdout);
+            }
+            if ($detail === '' && isset($result['error']) && is_string($result['error'])) {
+                $detail = trim($result['error']);
+            }
+            throw new RuntimeException('artifact-postprocess helper failed with exit code ' . $exit_code . ': ' . $detail);
         }
         return array('stdout' => (string) $stdout, 'stderr' => (string) $stderr, 'exit_code' => $exit_code);
     });

--- a/packages/runtime-playground/src/runtime-wp-cli-bridge.ts
+++ b/packages/runtime-playground/src/runtime-wp-cli-bridge.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from "node:crypto"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
 import { createServer as createHttpServer } from "node:http"
 import { cleanWpCliOutput, shellArgv } from "./commands.js"
 import { closeHttpServer, listenLocalHttpServer, readBridgeJson, writeBridgeJson, type PlaygroundServerRunResponse } from "./preview-server.js"
@@ -13,6 +15,13 @@ interface RuntimeWpCliCommandResult {
   exitCode: number
   stdout: string
   stderr: string
+}
+
+interface RuntimeHostNodeCommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+  error: string
 }
 
 type RuntimeWpCliRunner = (argv: string[]) => Promise<PlaygroundServerRunResponse>
@@ -34,6 +43,28 @@ export async function createRuntimeWpCliBridge(runWpCliCommand: RuntimeWpCliRunn
       const action = await readBridgeJson(request)
       const type = typeof action.type === "string" ? action.type.trim() : ""
       const command = typeof action.command === "string" ? action.command.trim() : ""
+      if (type === "host_node") {
+        const started = Date.now()
+        const args = Array.isArray(action.args) ? action.args.filter((arg): arg is string => typeof arg === "string") : []
+        const env = action.env && typeof action.env === "object" && !Array.isArray(action.env) ? normalizeHostNodeEnv(action.env as Record<string, unknown>) : {}
+        const cwd = typeof action.cwd === "string" && action.cwd.trim() !== "" ? action.cwd.trim() : undefined
+        const result = await runRuntimeHostNodeBridgeCommand(args, env, cwd)
+        const exitCode = result.exitCode
+        writeBridgeJson(response, 200, {
+          type,
+          command: "node",
+          args,
+          exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+          success: exitCode === 0,
+          timedOut: false,
+          durationMs: Date.now() - started,
+          error: exitCode === 0 ? "" : (result.error || result.stderr.trim() || result.stdout.trim() || "host node command failed"),
+        })
+        return
+      }
+
       if (type !== "wp_cli" || command === "") {
         writeBridgeJson(response, 400, { success: false, error: "wp_cli command is required" })
         return
@@ -64,6 +95,51 @@ export async function createRuntimeWpCliBridge(runWpCliCommand: RuntimeWpCliRunn
     token,
     close: () => closeHttpServer(bridge),
   }
+}
+
+async function runRuntimeHostNodeBridgeCommand(args: string[], env: Record<string, string>, cwd?: string): Promise<RuntimeHostNodeCommandResult> {
+  if (args.length === 0) {
+    throw new Error("host_node args are required")
+  }
+
+  return new Promise((resolve) => {
+    let stdout = ""
+    let stderr = ""
+    const execPath = process.execPath
+    const nodeCommand = existsSync(execPath) ? execPath : "node"
+    const child = spawn(nodeCommand, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8")
+    })
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8")
+    })
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      const diagnostic = nodeCommand === "node"
+        ? `Host Node executable was unavailable: process.execPath (${execPath}) does not exist and node was not found on PATH. Update the WP Codebox runner PATH or restart the runner with a valid Node installation. ${error.message}`
+        : `Host Node executable could not be started from process.execPath (${nodeCommand}). Restart the WP Codebox runner with a valid Node installation. ${error.message}`
+      resolve({ exitCode: 127, stdout, stderr, error: diagnostic })
+    })
+    child.on("close", (exitCode) => {
+      resolve({ exitCode: exitCode ?? 1, stdout, stderr, error: "" })
+    })
+  })
+}
+
+function normalizeHostNodeEnv(env: Record<string, unknown>): Record<string, string> {
+  const normalized: Record<string, string> = {}
+  for (const [name, value] of Object.entries(env)) {
+    if (/^[A-Z_][A-Z0-9_]*$/.test(name)) {
+      normalized[name] = typeof value === "string" ? value : String(value)
+    }
+  }
+  return normalized
 }
 
 async function runRuntimeWpCliBridgeCommand(runWpCliCommand: RuntimeWpCliRunner, command: string): Promise<RuntimeWpCliCommandResult> {

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -946,7 +946,7 @@ function benchWorkloadsUseWpCli(value: unknown): boolean {
   }
 
   const record = value as { type?: unknown; run?: unknown }
-  return record.type === "wp-cli" || benchWorkloadsUseWpCli(record.run)
+  return record.type === "wp-cli" || record.type === "artifact-postprocess" || benchWorkloadsUseWpCli(record.run)
 }
 
 async function themeCheckPluginInstalled(runPlaygroundCommand: RunPlaygroundCommand, server: PlaygroundCliServer): Promise<boolean> {

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -41,6 +41,7 @@ assert.match(runExternalHttpGuardrailStep, /wp-codebox\/wordpress-external-http-
 assert.match(runExternalHttpGuardrailStep, /wp_codebox_bench_install_external_http_guardrail/)
 assert.match(runArtifactPostprocessStep, /artifact-postprocess workload steps only support the node command/)
 assert.match(runArtifactPostprocessStep, /WP_CODEBOX_ARTIFACT_INPUT_ROOT/)
+assert.match(benchRunner, /'type' => 'host_node'/)
 assert.match(commandStepRecord, /'schema' => 'wp-codebox\/bench-command-step\/v1'/)
 assert.doesNotMatch(runCommandStep, /\$type === 'ability'/)
 assert.ok(
@@ -81,6 +82,8 @@ const artifactPostprocessHelpers = [
   "wp_codebox_bench_artifact_postprocess_scan_input",
   "wp_codebox_bench_artifact_postprocess_expand_value",
   "wp_codebox_bench_artifact_postprocess_content_type",
+  "wp_codebox_bench_host_node_bridge_failure_detail",
+  "wp_codebox_bench_run_host_node_command",
   "wp_codebox_bench_run_artifact_postprocess_step",
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
@@ -179,6 +182,21 @@ const artifactPostprocessPayload = await withTempDir("wp-codebox-artifact-postpr
     phpTestFile,
     `<?php
 ${artifactPostprocessHelpers}
+$wp_cli_bridge_url = 'http://wp-codebox-bridge.test';
+$wp_cli_bridge_token = 'test-token';
+function wp_json_encode($value, $flags = 0) { return json_encode($value, $flags); }
+function is_wp_error($value) { return false; }
+function wp_remote_retrieve_body($response) { return $response['body']; }
+function wp_remote_post($url, $options) {
+    $action = json_decode($options['body'], true);
+    $pipes = array();
+    $env = array_merge(getenv(), is_array($action['env'] ?? null) ? $action['env'] : array());
+    $process = proc_open(array_merge(array(PHP_BINARY), array('-r', 'passthru("node " . implode(" ", array_map("escapeshellarg", array_slice($argv, 1))), $exitCode); exit($exitCode);'), $action['args']), array(1 => array('pipe', 'w'), 2 => array('pipe', 'w')), $pipes, $action['cwd'], $env);
+    $stdout = stream_get_contents($pipes[1]); fclose($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]); fclose($pipes[2]);
+    $exit_code = proc_close($process);
+    return array('body' => json_encode(array('success' => $exit_code === 0, 'exitCode' => $exit_code, 'stdout' => $stdout, 'stderr' => $stderr)));
+}
 $plugin_path = ${JSON.stringify(pluginDirectory)};
 $payload = wp_codebox_bench_run_artifact_postprocess_step(array(
     'type' => 'artifact-postprocess',
@@ -229,6 +247,14 @@ const artifactPostprocessFailures = await withTempDir("wp-codebox-artifact-postp
     phpTestFile,
     `<?php
 ${artifactPostprocessHelpers}
+$wp_cli_bridge_url = 'http://wp-codebox-bridge.test';
+$wp_cli_bridge_token = 'test-token';
+function wp_json_encode($value, $flags = 0) { return json_encode($value, $flags); }
+function is_wp_error($value) { return false; }
+function wp_remote_retrieve_body($response) { return $response['body']; }
+function wp_remote_post($url, $options) {
+    return array('body' => json_encode($GLOBALS['wp_codebox_bridge_response'] ?? array('success' => true, 'exitCode' => 0, 'stdout' => '', 'stderr' => '')));
+}
 $plugin_path = ${JSON.stringify(pluginDirectory)};
 $artifact_root = ${JSON.stringify(artifactDirectory)};
 $messages = array();
@@ -245,6 +271,13 @@ foreach (array(
         $messages[] = $e->getMessage();
     }
 }
+$GLOBALS['wp_codebox_bridge_response'] = array('success' => false, 'exitCode' => 1, 'error' => 'bridge error', 'stdout' => 'bridge stdout', 'stderr' => 'bridge stderr');
+try {
+    wp_codebox_bench_run_artifact_postprocess_step(array('type' => 'artifact-postprocess', 'helperPath' => 'helpers/noop.mjs', 'inputArtifactRoot' => $artifact_root, 'outputArtifactPath' => 'out.json'), $plugin_path);
+    $messages[] = 'ok';
+} catch (Throwable $e) {
+    $messages[] = $e->getMessage();
+}
 echo json_encode($messages, JSON_UNESCAPED_SLASHES);
 `,
   )
@@ -254,6 +287,9 @@ assert.match(artifactPostprocessFailures[0], /parent traversal/)
 assert.match(artifactPostprocessFailures[1], /relative path/)
 assert.match(artifactPostprocessFailures[2], /did not create the expected output artifact/)
 assert.match(artifactPostprocessFailures[3], /only support the node command/)
+assert.match(artifactPostprocessFailures[4], /error: bridge error/)
+assert.match(artifactPostprocessFailures[4], /stdout: bridge stdout/)
+assert.match(artifactPostprocessFailures[4], /stderr: bridge stderr/)
 
 const restDbQueryProfilerPayload = await withTempDir("wp-codebox-rest-db-query-profiler-", async (directory) => {
   const phpTestFile = join(directory, "rest-db-query-profiler.php")

--- a/tests/runtime-wp-cli-bridge.test.ts
+++ b/tests/runtime-wp-cli-bridge.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+import { createRuntimeWpCliBridge } from "../packages/runtime-playground/src/runtime-wp-cli-bridge.js"
+
+const bridge = await createRuntimeWpCliBridge(async () => ({ exitCode: 0, text: "", errors: "" }))
+try {
+  const literal = "literal;touch shell-expanded"
+  const noShellResponse = await postBridgeAction(bridge.url, bridge.token, {
+    type: "host_node",
+    args: ["-e", "console.log(JSON.stringify(process.argv.slice(1)))", literal],
+  })
+  assert.equal(noShellResponse.success, true)
+  assert.deepEqual(JSON.parse(noShellResponse.stdout), [literal])
+  assert.equal(noShellResponse.command, "node")
+  assert.deepEqual(noShellResponse.args, ["-e", "console.log(JSON.stringify(process.argv.slice(1)))", literal])
+
+  const originalExecPath = process.execPath
+  const fallbackDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-node-fallback-"))
+  try {
+    const nodeShim = join(fallbackDirectory, "node")
+    await writeFile(nodeShim, `#!/bin/sh\nprintf 'fallback-node:%s\\n' "$1"\n`, { mode: 0o755 })
+    Object.defineProperty(process, "execPath", { value: join(fallbackDirectory, "missing-node"), configurable: true, writable: true })
+    const fallbackResponse = await postBridgeAction(bridge.url, bridge.token, {
+      type: "host_node",
+      args: ["helper.mjs"],
+      env: { PATH: `${fallbackDirectory}${delimiter}${process.env.PATH ?? ""}` },
+    })
+    assert.equal(fallbackResponse.success, true)
+    assert.equal(fallbackResponse.stdout, "fallback-node:helper.mjs\n")
+  } finally {
+    Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true, writable: true })
+    await rm(fallbackDirectory, { recursive: true, force: true })
+  }
+
+  const originalExecPathForFailure = process.execPath
+  const emptyPathDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-node-missing-"))
+  try {
+    Object.defineProperty(process, "execPath", { value: join(emptyPathDirectory, "missing-node"), configurable: true, writable: true })
+    const missingNodeResponse = await postBridgeAction(bridge.url, bridge.token, {
+      type: "host_node",
+      args: ["helper.mjs"],
+      env: { PATH: emptyPathDirectory },
+    })
+    assert.equal(missingNodeResponse.success, false)
+    assert.equal(missingNodeResponse.exitCode, 127)
+    assert.match(missingNodeResponse.error, /process\.execPath/)
+    assert.match(missingNodeResponse.error, /node was not found on PATH/)
+  } finally {
+    Object.defineProperty(process, "execPath", { value: originalExecPathForFailure, configurable: true, writable: true })
+    await rm(emptyPathDirectory, { recursive: true, force: true })
+  }
+} finally {
+  await bridge.close()
+}
+
+async function postBridgeAction(url: string, token: string, action: Record<string, unknown>): Promise<Record<string, any>> {
+  const response = await fetch(`${url}/execute`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(action),
+  })
+  assert.equal(response.status, 200)
+  return await response.json() as Record<string, any>
+}


### PR DESCRIPTION
## Summary
- Route artifact-postprocess `.mjs` helpers through the host bridge instead of Playground PHP process execution.
- Add a `host_node` bridge action with no shell expansion and actionable Node startup diagnostics.
- Open the bench bridge for artifact-postprocess workloads and preserve existing helper/input/output validation.

Closes #1542.

## Testing
- `npm run build`
- `npm run test:bench-command-step-behavior`
- `npx tsx tests/runtime-wp-cli-bridge.test.ts`
- `npm run test:playground-fuzz-suite-public`
- `npx tsx tests/fuzz-suite-runner.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the host-node bridge hardening, diagnostics, and focused tests.
