### PR TITLE
Propagate workload wrapper settings

### DIFF
--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -106,7 +106,7 @@ export async function runWordPressWorkloadCommand(args: string[]): Promise<numbe
 async function runWordPressWorkloadFuzzCase(input: FuzzSuiteRuntimeWorkloadExecutionInput, options: PublicRuntimeCommandOptions): Promise<ExecutionResult> {
   const startedAt = new Date().toISOString()
   const requirements = fuzzSuiteRuntimeRequirements(options.input)
-  const workload = normalizeWordPressWorkloadRequest(input.workload, options.input)
+  const workload = normalizeWordPressWorkloadRequest(input.workload, options.input, requirements)
   const recipe = wordpressWorkloadRunRecipe(workloadRecipeOptions(workload, requirements)) as WorkspaceRecipe
   applyFuzzSuiteRuntimeRequirements(recipe, requirements)
   const tempDir = await mkdtemp(join(tmpdir(), "wp-codebox-fuzz-workload-"))
@@ -145,7 +145,7 @@ function applyFuzzSuiteRuntimeRequirements(recipe: WorkspaceRecipe, requirements
   recipe.inputs = {
     ...inputs,
     extra_plugins: runtimeRequirementExtraPlugins(requirements, inputs.extra_plugins),
-    runtimeEnv: runtimeRequirementEnv(inputs.runtimeEnv, requirements.runtime_env),
+    runtimeEnv: runtimeRequirementEnv(inputs.runtimeEnv, requirements.runtime_env, requirements.bench_env),
   }
   recipe.runtime = {
     ...runtime,
@@ -191,11 +191,13 @@ function normalizeRuntimeRequirementExtraPlugins(value: unknown[], fallback: Wor
   return plugins.length > 0 ? plugins : fallback
 }
 
-function runtimeRequirementEnv(base: Record<string, string> | undefined, extra: unknown): Record<string, string> | undefined {
+function runtimeRequirementEnv(base: Record<string, string> | undefined, ...extras: unknown[]): Record<string, string> | undefined {
   const merged: Record<string, string> = { ...(base ?? {}) }
-  for (const [key, value] of Object.entries(objectOption(extra) ?? {})) {
-    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-      merged[key] = String(value)
+  for (const extra of extras) {
+    for (const [key, value] of Object.entries(objectOption(extra) ?? {})) {
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        merged[key] = String(value)
+      }
     }
   }
   return Object.keys(merged).length > 0 ? merged : undefined
@@ -274,16 +276,17 @@ function workloadRecipeOptions(input: Record<string, unknown>, runtimeRequiremen
   }
 }
 
-function normalizeWordPressWorkloadRequest(input: Record<string, unknown>, suiteInput?: Record<string, unknown>): Record<string, unknown> {
+function normalizeWordPressWorkloadRequest(input: Record<string, unknown>, suiteInput?: Record<string, unknown>, runtimeRequirements?: Record<string, unknown>): Record<string, unknown> {
   const stagedFiles = arrayOption(input.stagedFiles ?? input.staged_files)
   let changed = false
-  const normalized: Record<string, unknown> = { ...input }
+  const normalized: Record<string, unknown> = workloadWithRuntimeRequirementSettings(input, runtimeRequirements)
+  changed = normalized !== input
   const packageRoot = workloadPackageRoot(input, suiteInput)
 
   for (const phase of ["before", "steps", "after"] as const) {
     const steps = arrayOption(input[phase])
     const nextSteps = steps.map((step) => {
-      const normalizedStep = normalizeWordPressWorkloadStep(step, input, packageRoot, stagedFiles)
+      const normalizedStep = normalizeWordPressWorkloadStep(step, normalized, packageRoot, stagedFiles)
       if (normalizedStep !== step) changed = true
       return normalizedStep
     })
@@ -360,9 +363,34 @@ function workloadPackageRoot(input: Record<string, unknown>, suiteInput?: Record
 }
 
 function wordpressWorkloadPhpWrapper(path: string, workload: Record<string, unknown>, args: Record<string, string>): string {
-  const encodedInput = Buffer.from(JSON.stringify(workload), "utf8").toString("base64")
+  const encodedInput = Buffer.from(JSON.stringify(wordpressWorkloadPhpWrapperInput(workload)), "utf8").toString("base64")
   const encodedArgs = Buffer.from(JSON.stringify(args), "utf8").toString("base64")
   return `$__wp_codebox_workload_input = json_decode(base64_decode('${encodedInput}'), true);\n$__wp_codebox_workload_args = json_decode(base64_decode('${encodedArgs}'), true);\n$__wp_codebox_workload_callable = require ${JSON.stringify(path)};\nif (!is_callable($__wp_codebox_workload_callable)) { throw new RuntimeException('PHP workload file must return a callable.'); }\n$__wp_codebox_workload_result = $__wp_codebox_workload_callable(is_array($__wp_codebox_workload_input) ? $__wp_codebox_workload_input : array(), is_array($__wp_codebox_workload_args) ? $__wp_codebox_workload_args : array());\nif (is_array($__wp_codebox_workload_result) || is_object($__wp_codebox_workload_result)) { echo json_encode($__wp_codebox_workload_result, JSON_UNESCAPED_SLASHES) . "\\n"; } elseif (false === $__wp_codebox_workload_result) { exit(1); }`
+}
+
+function workloadWithRuntimeRequirementSettings(workload: Record<string, unknown>, runtimeRequirements: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!runtimeRequirements) return workload
+  const next: Record<string, unknown> = { ...workload }
+  let changed = false
+  for (const [sourceKey, targetKey] of [["runtime_env", "runtime_env"], ["bench_env", "bench_env"], ["settings", "settings"]] as const) {
+    const value = runtimeRequirements[sourceKey]
+    if (objectOption(value) && next[targetKey] === undefined) {
+      next[targetKey] = value
+      changed = true
+    }
+  }
+  return changed ? next : workload
+}
+
+function wordpressWorkloadPhpWrapperInput(workload: Record<string, unknown>): Record<string, unknown> {
+  const input: Record<string, unknown> = { ...workload }
+  if (input.runtimeEnv === undefined && objectOption(input.runtime_env)) {
+    input.runtimeEnv = input.runtime_env
+  }
+  if (input.runtime_env === undefined && objectOption(input.runtimeEnv)) {
+    input.runtime_env = input.runtimeEnv
+  }
+  return input
 }
 
 function parseStepArgs(args: unknown[]): Record<string, string> {

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -586,9 +586,20 @@ function stepArgMap(args: string[] | undefined): Record<string, string> {
 function wordpressWorkloadPhpWrapper(path: string, workload: Record<string, unknown>, args: Record<string, string>): string {
   const normalizedArgs: Record<string, string> = { ...args, path }
   delete normalizedArgs.file
-  const encodedInput = Buffer.from(JSON.stringify(workload), "utf8").toString("base64")
+  const encodedInput = Buffer.from(JSON.stringify(wordpressWorkloadPhpWrapperInput(workload)), "utf8").toString("base64")
   const encodedArgs = Buffer.from(JSON.stringify(normalizedArgs), "utf8").toString("base64")
   return `$__wp_codebox_workload_input = json_decode(base64_decode('${encodedInput}'), true);\n$__wp_codebox_workload_args = json_decode(base64_decode('${encodedArgs}'), true);\n$__wp_codebox_workload_callable = require ${JSON.stringify(path)};\nif (!is_callable($__wp_codebox_workload_callable)) { throw new RuntimeException('PHP workload file must return a callable.'); }\n$__wp_codebox_workload_result = $__wp_codebox_workload_callable(is_array($__wp_codebox_workload_input) ? $__wp_codebox_workload_input : array(), is_array($__wp_codebox_workload_args) ? $__wp_codebox_workload_args : array());\nif (is_array($__wp_codebox_workload_result) || is_object($__wp_codebox_workload_result)) { echo json_encode($__wp_codebox_workload_result, JSON_UNESCAPED_SLASHES) . "\\n"; } elseif (false === $__wp_codebox_workload_result) { exit(1); }`
+}
+
+function wordpressWorkloadPhpWrapperInput(workload: Record<string, unknown>): Record<string, unknown> {
+  const input: Record<string, unknown> = { ...workload }
+  if (input.runtimeEnv === undefined && recordValue(input.runtime_env)) {
+    input.runtimeEnv = input.runtime_env
+  }
+  if (input.runtime_env === undefined && recordValue(input.runtimeEnv)) {
+    input.runtime_env = input.runtimeEnv
+  }
+  return input
 }
 
 function workloadResultArtifactRefs(execution: ExecutionResult): NonNullable<ExecutionResult["artifactRefs"]> {

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -69,7 +69,7 @@ const result = await executeWordPressFuzzSuite(episode, fuzzSuiteContract({
     { id: "browser", target: { kind: "runtime-action" }, input: { type: "browser", operation: "navigate", url: "/" } },
     { id: "db", target: { kind: "runtime-action" }, input: { type: "db_operation", operation: "inspect", resource: { table: "posts" } } },
     { id: "workload", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.rest-performance-observation", args: ["path=/wp/v2/types", "capture-queries=1"] }] } },
-    { id: "php-workload", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.run-workload", args: ["type=php", "path=/tmp/wp-codebox-workloads/rest-product-batch-import.php"] }] } },
+    { id: "php-workload", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", runtime_env: { WC_REST_BATCH_IMPORT_ITEMS: "2" }, settings: { fixtureMode: "small" }, steps: [{ command: "wordpress.run-workload", args: ["type=php", "path=/tmp/wp-codebox-workloads/rest-product-batch-import.php"] }] } },
   ],
 }), { requireCoverage: true })
 
@@ -91,6 +91,10 @@ assert.equal(JSON.parse(steps[7]?.args?.[0]?.replace("operation-json=", "") ?? "
 assert.deepEqual(steps[9]?.args, ["path=/wp/v2/types", "capture-queries=1"])
 assert.equal(steps[11]?.command, "wordpress.run-php")
 assert.match(steps[11]?.args?.[0] ?? "", /^code=/)
+const nestedPhpInput = decodeFirstWrapperJson(steps[11]?.args?.[0] ?? "")
+assert.deepEqual(nestedPhpInput.runtimeEnv, { WC_REST_BATCH_IMPORT_ITEMS: "2" })
+assert.deepEqual(nestedPhpInput.runtime_env, { WC_REST_BATCH_IMPORT_ITEMS: "2" })
+assert.deepEqual(nestedPhpInput.settings, { fixtureMode: "small" })
 assert.equal(result.cases[4]?.artifactRefs?.some((ref) => ref.path === "workloads/php-report.json"), true)
 const hotspotsRef = result.artifactRefs.find((ref) => ref.kind === "wordpress-hotspots")
 assert.equal(hotspotsRef?.path, "files/wordpress-hotspots.json")
@@ -104,3 +108,9 @@ assert.equal((hotspots?.summary?.surfaces?.browser ?? 0) >= 1, true)
 assert.equal(hotspots?.hotspots?.some((hotspot) => hotspot.identifier.route === "/wp/v2/types" && hotspot.metrics.some((metric) => metric.kind === "query-count" && metric.value === 7)), true)
 
 console.log("playground fuzz suite public ok")
+
+function decodeFirstWrapperJson(codeArg: string): Record<string, unknown> {
+  const match = codeArg.match(/base64_decode\('([^']+)'\)/)
+  assert.ok(match)
+  return JSON.parse(Buffer.from(match[1], "base64").toString("utf8"))
+}

--- a/tests/public-fuzz-workload-cli.test.ts
+++ b/tests/public-fuzz-workload-cli.test.ts
@@ -110,6 +110,10 @@ return static function ( array $input, array $args ): array {
     metadata: {
       runtime_package_descriptor: { source: samplePluginSource },
       requiredRunnerCapabilities: { targetKinds: ["runtime"], commands: ["wordpress.run-workload"] },
+      runtime_requirements: {
+        bench_env: { WC_REST_BATCH_IMPORT_ITEMS: "2" },
+        settings: { fixtureMode: "small" },
+      },
     },
     cases: [{
       id: "php-workload",
@@ -131,7 +135,11 @@ return static function ( array $input, array $args ): array {
   assert.equal(phpRuntimeFuzzJson.cases[0].metadata.adapter.adapterKind, "runtime-workload")
   assert.equal(phpRuntimeFuzzJson.cases[0].metadata.execution.result.json.schema, "wp-codebox/recipe-run-dry-run/v1")
   assert.equal(phpRuntimeFuzzJson.cases[0].metadata.execution.result.json.plan.workflow.steps[0].command, "wordpress.run-php")
-  assert.match(phpRuntimeFuzzJson.cases[0].metadata.execution.result.json.plan.workflow.steps[0].args[0], /^code=/)
+  const nestedPhpCode = phpRuntimeFuzzJson.cases[0].metadata.execution.result.json.plan.workflow.steps[0].args[0]
+  assert.match(nestedPhpCode, /^code=/)
+  const nestedPhpInput = decodeFirstWrapperJson(nestedPhpCode)
+  assert.deepEqual(nestedPhpInput.bench_env, { WC_REST_BATCH_IMPORT_ITEMS: "2" })
+  assert.deepEqual(nestedPhpInput.settings, { fixtureMode: "small" })
   assert.equal(phpRuntimeFuzzJson.cases[0].metadata.execution.result.json.plan.stagedFiles[0].target.includes("/tmp/wp-codebox-workloads/"), true)
   assert.equal(phpRuntimeFuzzJson.cases[0].metadata.execution.result.json.plan.stagedFiles[0].source.endsWith("bench/rest-product-batch-import.php"), true)
 
@@ -156,6 +164,12 @@ return static function ( array $input, array $args ): array {
 }
 
 console.log("public fuzz/workload CLI contract passed")
+
+function decodeFirstWrapperJson(codeArg: string): Record<string, unknown> {
+  const match = codeArg.match(/base64_decode\('([^']+)'\)/)
+  assert.ok(match)
+  return JSON.parse(Buffer.from(match[1], "base64").toString("utf8"))
+}
 
 async function captureStdout(callback: () => Promise<void>): Promise<string> {
   const originalWrite = process.stdout.write.bind(process.stdout)


### PR DESCRIPTION
## Summary
- Merge fuzz-suite runtime requirement env and bench_env into the generated workload recipe runtimeEnv.
- Copy caller runtime requirements/settings into JSON workload wrappers before nested PHP execution.
- Normalize runtime_env/runtimeEnv aliases for nested PHP workload callable input.

Fixes #1543.

## Tests
- npx tsx tests/public-fuzz-workload-cli.test.ts
- npx tsx tests/playground-fuzz-suite-public.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigating the wrapper boundary, implementing the fix, adding regression coverage, and running verification.