### PR TITLE
Default runtime package workflow

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -437,11 +437,27 @@ final class WP_Codebox_Agents_API_Adapter {
 		if ( is_array( $input['package'] ?? null ) ) {
 			$input['package'] = self::package_descriptor_for_runtime( $input['package'], $input );
 		}
+		$input = self::runtime_package_workflow_for_agents_api( $input );
 		$input = self::stage_runtime_package_wordpress_workload_files( $input );
 
 		$input = self::runtime_package_options_for_agents_api( $input );
 
 		return $this->execute( self::RUN_RUNTIME_PACKAGE, $input );
+	}
+
+	/** @param array<string,mixed> $input Runtime input. @return array<string,mixed> */
+	private static function runtime_package_workflow_for_agents_api( array $input ): array {
+		if ( is_array( $input['workflow'] ?? null ) && ( isset( $input['workflow']['id'] ) || isset( $input['workflow']['spec'] ) ) ) {
+			return $input;
+		}
+
+		$package = is_array( $input['package'] ?? null ) ? $input['package'] : array();
+		$id      = self::string_value( $input['workflow_id'] ?? $input['workflowId'] ?? $package['workflow'] ?? $package['slug'] ?? $package['id'] ?? $input['runtime_package'] ?? '' );
+		if ( '' !== $id ) {
+			$input['workflow'] = array( 'id' => $id );
+		}
+
+		return $input;
 	}
 
 	/** @param array<string,mixed> $input Runtime input. @return array<string,mixed> */
@@ -635,6 +651,10 @@ final class WP_Codebox_Agents_API_Adapter {
 
 	private static function is_absolute_package_source( string $source ): bool {
 		return str_starts_with( $source, '/' ) || 1 === preg_match( '#^[a-z][a-z0-9+.-]*://#i', $source ) || 1 === preg_match( '#^[A-Za-z]:[\\/]#', $source );
+	}
+
+	private static function string_value( mixed $value ): string {
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
 	}
 
 	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -89,6 +89,7 @@ assert( 'wp-codebox/agent-chat-result/v1' === $chat['schema'] );
 assert( 'wp-codebox/agent-task-result/v1' === $task['schema'] );
 assert( 'wp-codebox/runtime-package-result/v1' === $package['schema'] );
 assert( array( 'slug' => 'example-agent' ) === $package['received']['package'] );
+assert( array( 'id' => 'example-agent' ) === $package['received']['workflow'] );
 
 $package_with_descriptor = $adapter->run_runtime_package(
 	array(
@@ -97,6 +98,15 @@ $package_with_descriptor = $adapter->run_runtime_package(
 	)
 );
 assert( array( 'slug' => 'example-agent', 'source' => 'bundles/example-agent' ) === $package_with_descriptor['received']['package'] );
+assert( array( 'id' => 'example-agent' ) === $package_with_descriptor['received']['workflow'] );
+
+$package_with_explicit_workflow = $adapter->run_runtime_package(
+	array(
+		'runtime_package' => 'example-agent',
+		'workflow'        => array( 'id' => 'custom-workflow' ),
+	)
+);
+assert( array( 'id' => 'custom-workflow' ) === $package_with_explicit_workflow['received']['workflow'] );
 
 $workspace_root = sys_get_temp_dir() . '/wp-codebox-runtime-package-' . getmypid();
 mkdir( $workspace_root . '/bundles/example-agent', 0777, true );


### PR DESCRIPTION
## Summary
- Default missing Agents API runtime package workflow IDs from the package descriptor.
- Preserve explicit workflow inputs when callers provide them.
- Extend the Agents API adapter contract smoke test.

## Testing
- 
- No syntax errors detected in packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
- No syntax errors detected in scripts/php-agents-api-adapter-contract-smoke.php
- 

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the runtime-package contract failure, implementing the adapter fix, and adding focused smoke coverage.