### PR TITLE
Expose admin bar toggle on browser SDK facade

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -583,6 +583,7 @@
 		createParentToolRequest: api.createParentToolRequest,
 		dispatchParentTool: api.dispatchParentTool,
 		runBrowserSessionRecipe: async ( client, session, taskPayload, options = {} ) => normalizeBrowserRunResult( await api.runBrowserSessionRecipe( client, session, taskPayload, options ), 'browser-session-recipe' ),
+		setFrontendAdminBarVisible: api.setFrontendAdminBarVisible,
 		methods: Object.freeze( {
 			activateTheme: api.activateTheme,
 			browserSessionRecipe: api.browserSessionRecipe,

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -56,6 +56,8 @@ assert.deepEqual(plain(api.v1.info()), {
 assert.equal(api.v1.methods.runPhpRequest, api.runPhpRequest)
 assert.equal(api.v1.methods.writeFile, api.writeFile)
 assert.equal(api.v1.methods.validateBrowserRuntimeMaterialization, api.validateBrowserRuntimeMaterialization)
+assert.equal(api.v1.setFrontendAdminBarVisible, api.setFrontendAdminBarVisible)
+assert.equal(api.v1.methods.setFrontendAdminBarVisible, api.setFrontendAdminBarVisible)
 assert.equal(typeof api.v1.runBrowserSessionRecipe, "function")
 assert.equal(typeof api.v1.startBrowserPreview, "function")
 assert.equal(typeof api.v1.consumeContainedSiteSync, "function")


### PR DESCRIPTION
## Summary
- Expose setFrontendAdminBarVisible on the stable wpCodeboxBrowser.v1 facade.
- Keep the existing v1.methods.setFrontendAdminBarVisible alias intact.
- Cover both facade paths in the browser SDK facade test.

## Testing
- node --experimental-strip-types tests/browser-sdk-facade.test.ts
- node --check packages/wordpress-plugin/assets/browser-runtime.js

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Studio Native browser SDK facade mismatch, drafting the code/test change, and running verification.