### PR TITLE
Fallback to direct Playground PHP execution

### DIFF
--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -1298,6 +1298,9 @@ try {
 		if ( ! options.forceRequest && typeof client.run === 'function' ) {
 			return await runPhpDirect( client, code, options );
 		}
+		if ( options.forceRequest && typeof client?.writeFile !== 'function' && typeof client.run === 'function' ) {
+			return await runPhpDirect( client, code, options );
+		}
 
 		const runnerDir = String( options.runnerDir || defaultRunnerDir );
 		const runnerUrlBase = String( options.runnerUrlBase || defaultRunnerUrlBase );

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -90,6 +90,21 @@ assert.equal(failed.success, false)
 assert.equal(failed.error.code, "demo_failed")
 assert.equal(failed.error.message, "Broken")
 
+let directRunCode = ""
+const directRunClient = {
+  run: async (input: { code?: string } | string) => {
+    directRunCode = typeof input === "string" ? input : input.code || ""
+    return JSON.stringify({ success: true, data: { mode: "direct-run" }, error: null })
+  },
+}
+const directRunResult = await api.v1.methods.runPhpRequest(directRunClient, {
+  code: "<?php echo wp_json_encode( array( 'success' => true ) );",
+  expectJson: true,
+  forceRequest: true,
+})
+assert.equal(directRunCode.includes("wp_json_encode"), true)
+assert.deepEqual(plain(directRunResult), { success: true, data: { mode: "direct-run" }, error: null })
+
 const browserRun = api.v1.normalizeBrowserRunResult({
   success: true,
   data: {


### PR DESCRIPTION
## Summary
- Fall back to direct `client.run()` PHP execution when request-file staging is forced but the Playground client does not expose `writeFile()`.
- Add browser SDK facade coverage for the forced-request fallback path.

## Testing
- `npm run test:browser-sdk-facade`
- Local runtime served `wp-codebox/assets/browser-runtime.js` includes the fallback.
- Studio Native local runtime `POST /wp-json/studio-native/v1/targets/preview-session` returned a hydratable `wp-codebox/browser-blueprint-ref/v1` with a browser-principal cookie.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Studio Native/WP Codebox browser runtime failure, drafting the fallback change, adding test coverage, and preparing this PR.
