### PR TITLE
Support source-root PHPUnit extra plugins

### DIFF
--- a/packages/cli/src/commands/recipe-build.ts
+++ b/packages/cli/src/commands/recipe-build.ts
@@ -11,6 +11,7 @@ interface WordPressPhpunitBuilderOptions {
   blueprint?: unknown
   wordpressVersion?: string
   mounts?: WorkspaceRecipeMount[]
+  extra_plugins?: WorkspaceRecipeExtraPlugin[]
   pluginSource?: string
   pluginSlug: string
   cwd?: string
@@ -72,6 +73,7 @@ function buildRecipe(recipeType: RecipeBuildOptions["recipeType"], options: Word
         blueprint: phpunitOptions.blueprint,
         wordpressVersion: stringOrUndefined(phpunitOptions.wordpressVersion),
         mounts: Array.isArray(phpunitOptions.mounts) ? phpunitOptions.mounts : [],
+        extra_plugins: Array.isArray(phpunitOptions.extra_plugins) ? phpunitOptions.extra_plugins : [],
         pluginSource: stringOrUndefined(phpunitOptions.pluginSource),
         pluginSlug: requiredString(phpunitOptions.pluginSlug, "pluginSlug"),
         cwd: stringOrUndefined(phpunitOptions.cwd),

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -1379,7 +1379,7 @@ export function recipeExtraPluginSourceSubpath(plugin: WorkspaceRecipeExtraPlugi
 
 function recipeExtraPluginSourceRootContainsSource(plugin: WorkspaceRecipeExtraPlugin, sourceRoot: string, recipeDirectory: string): boolean {
   const relativePath = relative(resolve(recipeDirectory, sourceRoot), resolve(recipeDirectory, plugin.source))
-  return Boolean(relativePath) && !relativePath.startsWith("..") && !isAbsolute(relativePath)
+  return !relativePath.startsWith("..") && !isAbsolute(relativePath)
 }
 
 export function recipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin): string {

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -831,7 +831,7 @@ export function recipePolicy(recipe: WorkspaceRecipe): RuntimePolicy {
   if (recipeWorkflowSteps(recipe).some(({ step }) => step.command === "wordpress.bench" && recipeBenchStepUsesWpCli(step))) {
     commands.unshift("wordpress.wp-cli")
   }
-  if (recipeExtraPlugins(recipe).some((plugin) => plugin.activate !== false)) {
+  if (recipeExtraPlugins(recipe).length > 0) {
     commands.unshift("wordpress.run-php")
   }
   if ((recipe.inputs?.siteSeeds ?? []).some((siteSeed) => siteSeed.type === "fixture")) {

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -14,6 +14,7 @@ export interface WordPressPhpunitRecipeOptions {
   wordpressVersion?: string
   blueprint?: unknown
   mounts?: WorkspaceRecipeMount[]
+  extra_plugins?: WorkspaceRecipeExtraPlugin[]
   pluginSource?: string
   pluginSlug: string
   cwd?: string
@@ -69,6 +70,7 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
       blueprint: options.blueprint ?? { steps: [] },
     },
     inputs: {
+      extra_plugins: normalizeExtraPlugins(options.extra_plugins),
       mounts: normalizeRecipeMounts([
         ...(options.pluginSource ? [{ source: options.pluginSource, target: pluginTarget } satisfies WorkspaceRecipeMount] : []),
         ...(options.mounts ?? []),

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -2,15 +2,37 @@ import assert from "node:assert/strict"
 
 import { buildWordPressPhpunitRecipe } from "../packages/runtime-core/src/recipe-builders.js"
 import { phpunitRunCode } from "../packages/runtime-playground/src/phpunit-command-handlers.js"
+import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
+import { recipeExtraPluginSourceSubpath } from "../packages/cli/src/recipe-sources.js"
 
 const woocommerceAutoload = "/wordpress/wp-content/plugins/woocommerce/vendor/autoload_packages.php"
 
 const recipe = buildWordPressPhpunitRecipe({
   pluginSlug: "woocommerce",
+  extra_plugins: [{
+    source: "/workspace/woocommerce",
+    sourceRoot: "/workspace/woocommerce",
+    sourceSubpath: "plugins/woocommerce",
+    slug: "woocommerce",
+    pluginFile: "woocommerce/woocommerce.php",
+    activate: false,
+  }],
   bootstrapMode: "project",
   projectBootstrap: "tests/legacy/bootstrap.php",
   projectAutoloadFile: woocommerceAutoload,
 })
+
+assert.deepEqual(recipe.inputs.extra_plugins, [{
+  source: "/workspace/woocommerce",
+  sourceRoot: "/workspace/woocommerce",
+  sourceSubpath: "plugins/woocommerce",
+  slug: "woocommerce",
+  pluginFile: "woocommerce/woocommerce.php",
+  activate: false,
+}])
+
+assert.equal(recipeExtraPluginSourceSubpath(recipe.inputs.extra_plugins[0], "/tmp"), "plugins/woocommerce")
+assert.equal(recipePolicy(recipe).commands.includes("wordpress.run-php"), true)
 
 assert.deepEqual(recipe.workflow.steps[0].args.filter((arg) => arg.includes("autoload-file=")), [
   "autoload-file=/wp-codebox-vendor/autoload.php",


### PR DESCRIPTION
## Summary
- Preserve `extra_plugins` when building WordPress PHPUnit recipes.
- Keep `sourceSubpath` when an extra plugin source is the same as its source root, which supports monorepo plugins such as WooCommerce at `plugins/woocommerce`.
- Allow `wordpress.run-php` whenever recipes include extra plugins, because runtime setup uses it for composer autoloader glue even when the plugin is not activated.

## Validation
- `npm run build`
- `npx tsx tests/phpunit-project-autoload.test.ts`
- Homeboy Lab WooCommerce baseline: `runner-exec-homeboy-lab-f01147b4-5524-41f9-a1bb-d4325b853cf9`, `15 passed, 49 assertions`
- Homeboy Lab WooCommerce PR branch ProductsStore: `runner-exec-homeboy-lab-57105b40-53e6-4adc-a763-0e841482dd81`, `15 passed, 49 assertions`
- Homeboy Lab WooCommerce PR branch product datastore: `runner-exec-homeboy-lab-d60ca6db-713b-4dd4-9c6c-d92373699df1`, `15 passed, 35 assertions`
- Homeboy Lab WooCommerce PR branch variation datastore: `runner-exec-homeboy-lab-5dac2346-47f8-45e6-8b73-ef54f898aa89`, `13 passed, 64 assertions`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the PHPUnit source-root recipe path, drafting the code changes, and running validation.
