### PR TITLE
Normalize runtime package task results

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -185,8 +185,15 @@ final class WP_Codebox_Agents_API_Adapter {
 		return function_exists( 'apply_filters' ) && (bool) apply_filters( 'wp_codebox_agents_api_adapter_enabled', false );
 	}
 
-	/** @return array<string,string> */
-	public static function browser_runtime_default_invocation(): array {
+	/** @param array<string,mixed> $input Runtime input. @param array<string,mixed> $defaults Caller defaults. @return array<string,string> */
+	public static function browser_runtime_default_invocation( array $input = array(), array $defaults = array() ): array {
+		if ( ! empty( self::runtime_task_from_browser_input( $input, $defaults ) ) ) {
+			return array(
+				'type' => 'ability',
+				'name' => self::RUN_RUNTIME_PACKAGE,
+			);
+		}
+
 		return array(
 			'type' => 'ability',
 			'name' => self::default_chat_ability(),
@@ -202,6 +209,12 @@ final class WP_Codebox_Agents_API_Adapter {
 		$ability_name = (string) ( $invocation['name'] ?? '' );
 		if ( '' === $ability_name || ! in_array( $ability_name, self::ability_names(), true ) ) {
 			return $input;
+		}
+		if ( self::RUN_RUNTIME_PACKAGE === $ability_name ) {
+			$runtime_task_input = self::runtime_package_input_from_runtime_task( self::runtime_task_from_browser_payload( $payload ) );
+			if ( ! empty( $runtime_task_input ) ) {
+				$input = array_replace_recursive( $input, $runtime_task_input );
+			}
 		}
 
 		$agent = sanitize_key( (string) ( $payload['agent'] ?? $input['agent'] ?? 'wp-codebox-sandbox' ) );
@@ -230,6 +243,59 @@ final class WP_Codebox_Agents_API_Adapter {
 		$input['client_context']['peer_agent_call'] = true;
 
 		return $input;
+	}
+
+	/** @param array<string,mixed> $input Runtime input. @param array<string,mixed> $defaults Caller defaults. @return array<string,mixed> */
+	private static function runtime_task_from_browser_input( array $input, array $defaults = array() ): array {
+		foreach ( array( $input, $defaults ) as $candidate ) {
+			$runtime_task = self::runtime_task_from_candidate( $candidate );
+			if ( ! empty( $runtime_task ) ) {
+				return $runtime_task;
+			}
+		}
+
+		return array();
+	}
+
+	/** @param array<string,mixed> $payload Browser runtime payload. @return array<string,mixed> */
+	private static function runtime_task_from_browser_payload( array $payload ): array {
+		$task_input = is_array( $payload['task_input'] ?? null ) ? $payload['task_input'] : array();
+
+		return self::runtime_task_from_candidate( $task_input );
+	}
+
+	/** @param array<string,mixed> $candidate Runtime input candidate. @return array<string,mixed> */
+	private static function runtime_task_from_candidate( array $candidate ): array {
+		if ( is_array( $candidate['runtime_task'] ?? null ) ) {
+			return $candidate['runtime_task'];
+		}
+		if ( is_array( $candidate['runtimeTask'] ?? null ) ) {
+			return $candidate['runtimeTask'];
+		}
+
+		$agent_runtime = $candidate['agent_runtime'] ?? $candidate['agentRuntime'] ?? null;
+		if ( is_array( $agent_runtime ) ) {
+			if ( is_array( $agent_runtime['runtime_task'] ?? null ) ) {
+				return $agent_runtime['runtime_task'];
+			}
+			if ( is_array( $agent_runtime['runtimeTask'] ?? null ) ) {
+				return $agent_runtime['runtimeTask'];
+			}
+		}
+
+		return array();
+	}
+
+	/** @param array<string,mixed> $runtime_task Runtime task descriptor. @return array<string,mixed> */
+	private static function runtime_package_input_from_runtime_task( array $runtime_task ): array {
+		if ( is_array( $runtime_task['input'] ?? null ) && in_array( (string) ( $runtime_task['ability'] ?? '' ), array( 'runtime-package/run', 'wp-codebox/run-runtime-package' ), true ) ) {
+			return $runtime_task['input'];
+		}
+		if ( is_array( $runtime_task['input'] ?? null ) && 'bundle' === (string) ( $runtime_task['kind'] ?? '' ) ) {
+			return $runtime_task['input'];
+		}
+
+		return $runtime_task;
 	}
 
 	/** @param array<string,mixed> $permission_input Permission input. */

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -631,9 +631,11 @@ final class WP_Codebox_Agents_API_Adapter {
 			if ( array_key_exists( $field, $input ) && ! array_key_exists( $field, $options ) ) {
 				$options[ $field ] = $input[ $field ];
 			}
+			if ( array_key_exists( $field, $options ) && ! array_key_exists( $field, $workflow_input ) ) {
+				$workflow_input[ $field ] = $options[ $field ];
+			}
 			if ( array_key_exists( $field, $workflow_input ) && ! array_key_exists( $field, $options ) ) {
 				$options[ $field ] = $workflow_input[ $field ];
-				unset( $workflow_input[ $field ] );
 			}
 		}
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-run-result-normalizer.php
@@ -414,7 +414,7 @@ final class WP_Codebox_Host_Run_Result_Normalizer {
 		$from_outputs   = is_array( $outputs['typed_artifacts'] ?? null ) ? $outputs['typed_artifacts'] : array();
 		$runtime_outputs = $this->runtime_outputs( $agent_task_result );
 		$engine_outputs = is_array( $task_input['agent_bundle']['engine_data_outputs'] ?? null ) ? $task_input['agent_bundle']['engine_data_outputs'] : array();
-		$typed          = array_values( array_filter( array_merge( $direct, $from_outputs ), 'is_array' ) );
+		$typed          = array_values( array_filter( array_merge( $direct, $from_outputs, $this->datamachine_typed_artifacts( $agent_task_result ) ), 'is_array' ) );
 
 		foreach ( $runtime_outputs as $name => $payload ) {
 			if ( 'typed_artifacts' === $name || 'structured_artifacts' === $name ) {
@@ -434,6 +434,44 @@ final class WP_Codebox_Host_Run_Result_Normalizer {
 		}
 
 		return $this->dedupe_records( $typed );
+	}
+
+	/** @param array<string,mixed> $agent_task_result @return array<int,array<string,mixed>> */
+	private function datamachine_typed_artifacts( array $agent_task_result ): array {
+		$sources = array(
+			$agent_task_result['outputs']['result']['engine_data']['outputs']['typed_artifacts'] ?? null,
+			$agent_task_result['result']['engine_data']['outputs']['typed_artifacts'] ?? null,
+			$agent_task_result['raw']['agent_runtime']['result']['result']['engine_data']['outputs']['typed_artifacts'] ?? null,
+		);
+
+		$typed = array();
+		foreach ( $sources as $source ) {
+			if ( ! is_array( $source ) ) {
+				continue;
+			}
+			foreach ( $source as $key => $entry ) {
+				if ( ! is_array( $entry ) || ! array_key_exists( 'payload', $entry ) ) {
+					continue;
+				}
+
+				$name = (string) ( $entry['name'] ?? $entry['output_key'] ?? ( is_string( $key ) ? $key : '' ) );
+				if ( '' === $name ) {
+					continue;
+				}
+
+				$typed[] = array_filter(
+					array(
+						'name'            => $name,
+						'artifact_schema' => (string) ( $entry['artifact_schema'] ?? $entry['schema'] ?? '' ),
+						'artifact'        => (string) ( $entry['artifact'] ?? '' ),
+						'payload'         => $entry['payload'],
+					),
+					static fn( mixed $value ): bool => '' !== $value
+				);
+			}
+		}
+
+		return $typed;
 	}
 
 	/** @param array<string,mixed> $agent_task_result @return array<string,mixed> */

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -19,6 +19,10 @@ function wp_get_ability( string $name ): ?WP_Ability {
 	return $GLOBALS['wp_codebox_test_abilities'][ $name ] ?? null;
 }
 
+function sanitize_key( string $key ): string {
+	return strtolower( preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key ) ?? '' );
+}
+
 final class WP_Error {
 	public function __construct( private string $code, private string $message, private array $data = array() ) {}
 	public function get_error_code(): string { return $this->code; }
@@ -59,6 +63,23 @@ assert( 'agents/run-task' === $names['run_task'] );
 assert( 'agents/run-runtime-package' === $names['run_runtime_package'] );
 assert( 'agents/get-task-run' === $names['get_task_run'] );
 assert( 'agents/get-chat-run' === $names['get_chat_run'] );
+
+$default_invocation = WP_Codebox_Agents_API_Adapter::browser_runtime_default_invocation();
+assert( array( 'type' => 'ability', 'name' => 'agents/chat' ) === $default_invocation );
+
+$runtime_task_invocation = WP_Codebox_Agents_API_Adapter::browser_runtime_default_invocation(
+	array(
+		'runtime_task' => array(
+			'kind'    => 'bundle',
+			'ability' => 'runtime-package/run',
+			'input'   => array(
+				'package'  => array( 'slug' => 'store-idea-agent' ),
+				'workflow' => array( 'id' => 'store-idea-artifact-flow' ),
+			),
+		),
+	)
+);
+assert( array( 'type' => 'ability', 'name' => 'agents/run-runtime-package' ) === $runtime_task_invocation );
 
 $adapter = new WP_Codebox_Agents_API_Adapter();
 assert( false === $adapter->is_available( WP_Codebox_Agents_API_Adapter::default_chat_ability() ) );
@@ -127,6 +148,35 @@ $package_with_workspace_source = $adapter->run_runtime_package(
 assert( array( 'slug' => 'example-agent', 'source' => $workspace_root . '/bundles/example-agent' ) === $package_with_workspace_source['received']['package'] );
 assert( array( 'topic' => 'coffee' ) === $package_with_workspace_source['received']['input'] );
 assert( array( 'provider' => 'codex', 'model' => 'gpt-5.5', 'wait_for_completion' => true ) === $package_with_workspace_source['received']['options'] );
+
+$runtime_package_browser_input = WP_Codebox_Agents_API_Adapter::browser_runtime_invocation_input(
+	array(
+		'agent'          => 'store-idea-agent',
+		'provider'       => 'codex',
+		'model'          => 'gpt-5.5',
+		'client_context' => array(),
+	),
+	array(
+		'agent'      => 'store-idea-agent',
+		'task_input' => array(
+			'runtime_task' => array(
+				'kind'    => 'bundle',
+				'ability' => 'runtime-package/run',
+				'input'   => array(
+					'package'  => array( 'slug' => 'store-idea-agent', 'source' => 'bundles/store-idea-agent' ),
+					'workflow' => array( 'id' => 'store-idea-artifact-flow' ),
+					'input'    => array( 'wait_for_completion' => true ),
+				),
+			),
+		),
+	),
+	array( 'type' => 'ability', 'name' => 'agents/run-runtime-package' ),
+	'codebox-session'
+);
+assert( array( 'slug' => 'store-idea-agent', 'source' => 'bundles/store-idea-agent' ) === $runtime_package_browser_input['package'] );
+assert( array( 'id' => 'store-idea-artifact-flow' ) === $runtime_package_browser_input['workflow'] );
+assert( array( 'wait_for_completion' => true ) === $runtime_package_browser_input['input'] );
+assert( 'runtime' === $runtime_package_browser_input['principal']['auth_source'] );
 assert( 'running' === $adapter->get_task_run( array( 'run_id' => 'task-run', 'session_id' => 'session' ) )['status'] );
 assert( 'running' === $adapter->get_chat_run( array( 'run_id' => 'chat-run', 'session_id' => 'session' ) )['status'] );
 assert_no_agents_api_schema_leaks( $chat, 'chat' );

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -146,8 +146,21 @@ $package_with_workspace_source = $adapter->run_runtime_package(
 	)
 );
 assert( array( 'slug' => 'example-agent', 'source' => $workspace_root . '/bundles/example-agent' ) === $package_with_workspace_source['received']['package'] );
-assert( array( 'topic' => 'coffee' ) === $package_with_workspace_source['received']['input'] );
+assert( true === $package_with_workspace_source['received']['input']['wait_for_completion'] );
+assert( 'coffee' === $package_with_workspace_source['received']['input']['topic'] );
 assert( array( 'provider' => 'codex', 'model' => 'gpt-5.5', 'wait_for_completion' => true ) === $package_with_workspace_source['received']['options'] );
+
+$package_with_options_only_controls = $adapter->run_runtime_package(
+	array(
+		'runtime_package' => 'example-agent',
+		'input'           => array( 'topic' => 'tea' ),
+		'options'         => array( 'wait_for_completion' => true, 'time_budget_ms' => 1200000 ),
+	)
+);
+assert( 'tea' === $package_with_options_only_controls['received']['input']['topic'] );
+assert( true === $package_with_options_only_controls['received']['input']['wait_for_completion'] );
+assert( 1200000 === $package_with_options_only_controls['received']['input']['time_budget_ms'] );
+assert( array( 'wait_for_completion' => true, 'time_budget_ms' => 1200000 ) === $package_with_options_only_controls['received']['options'] );
 
 $runtime_package_browser_input = WP_Codebox_Agents_API_Adapter::browser_runtime_invocation_input(
 	array(

--- a/scripts/php-host-run-result-normalizer-smoke.php
+++ b/scripts/php-host-run-result-normalizer-smoke.php
@@ -131,4 +131,43 @@ smoke_assert( 'ssi/concept-packet/v1' === $success['artifact_result']['result'][
 smoke_assert( 'Stabilized public envelope' === $success['artifact_result']['result']['typed_artifacts'][0]['payload']['title'], 'typed artifact preserves runtime output payload' );
 smoke_assert( ! isset( $success['artifact_result']['metadata']['agent_runtime'] ), 'artifact result metadata does not expose private agent runtime internals' );
 
+$datamachine_success = $normalizer->normalize(
+	$prepared,
+	array(
+		'exit_code' => 0,
+		'output'    => json_encode(
+			array(
+				'agentResult'     => array(
+					'artifacts' => array( 'directory' => '/tmp/wp-codebox-artifacts' ),
+					'summary'   => 'Runtime package completed',
+				),
+				'agentTaskResult' => array(
+					'status'  => 'completed',
+					'outputs' => array(
+						'result' => array(
+							'engine_data' => array(
+								'outputs' => array(
+									'typed_artifacts' => array(
+										'concept_packet' => array(
+											'output_key' => 'concept_packet',
+											'schema'     => 'wp-site-generator/ConceptPacket/v1',
+											'artifact'   => 'ConceptPacket',
+											'payload'    => array( 'title' => 'Kiln Shelf Supply' ),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		),
+	),
+	$adapters
+);
+smoke_assert( is_array( $datamachine_success ) && ! is_wp_error( $datamachine_success ), 'Data Machine runtime package success returns result envelope' );
+smoke_assert( 'concept_packet' === $datamachine_success['artifact_result']['result']['typed_artifacts'][0]['name'], 'Data Machine engine typed artifact is exposed by name' );
+smoke_assert( 'wp-site-generator/ConceptPacket/v1' === $datamachine_success['artifact_result']['result']['typed_artifacts'][0]['artifact_schema'], 'Data Machine engine typed artifact schema is exposed' );
+smoke_assert( 'Kiln Shelf Supply' === $datamachine_success['artifact_result']['result']['typed_artifacts'][0]['payload']['title'], 'Data Machine engine typed artifact payload is exposed' );
+
 echo "host run result normalizer smoke passed\n";


### PR DESCRIPTION
## Summary
- Route browser `runtime_task` requests through the runtime-package ability path.
- Preserve runtime-package control fields in both workflow input and options so downstream runtimes can honor wait budgets.
- Normalize host run results that expose Data Machine typed artifacts.

## Validation
- `npm run test:php-agents-api-adapter-contract`
- `npm run test:php-host-run-result-normalizer`

## Notes
- This fixes the confirmed WP Codebox boundary issue discovered while running runtime-package tasks from the Homeboy lab loop.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the browser runtime-task routing/result-normalization gap, implementing the fix, and adding contract smoke coverage.