### PR TITLE
Record WordPress queries without SAVEQUERIES

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -417,7 +417,7 @@ export const commandRegistry = [
       { name: "hook-sample-limit", description: "Maximum hook hotspot rows to include; defaults to 50.", format: "non-negative integer" },
       { name: "hook-limit", description: "Maximum distinct hooks tracked before truncation; defaults to 500.", format: "positive integer" },
     ],
-    outputShape: "wp-codebox/performance-observation/v1 JSON with source=in-process, kind=rest-request, timing/memory, database query fingerprints when $wpdb->queries is available, and hook hotspot samples captured through the all hook.",
+    outputShape: "wp-codebox/performance-observation/v1 JSON with source=in-process, kind=rest-request, timing/memory, database query fingerprints captured through the bounded query recorder, and hook hotspot samples captured through the all hook.",
     outputSchema: objectEnvelopeSchema(PERFORMANCE_OBSERVATION_SCHEMA, {
       timing: { type: "object" },
       memory: { type: "object" },

--- a/packages/runtime-playground/src/page-load-command-handlers.ts
+++ b/packages/runtime-playground/src/page-load-command-handlers.ts
@@ -1,4 +1,5 @@
 import { argValue, booleanArg, commaListArg, jsonObjectArg } from "./command-args.js"
+import { wordpressQueryRecorderPhp } from "./query-recorder.js"
 import { wordpressFixtureUserPhpCode, type WordPressUserSessionResolution } from "./wordpress-user-sessions.js"
 
 export type PageLoadSurface = "admin" | "frontend"
@@ -32,10 +33,10 @@ export function pageLoadInputFromArgs(args: string[], surface: PageLoadSurface, 
 
 export function pageLoadPhpCode(input: PageLoadCommandInput): string {
   const userSessionMetadata = input.userSession?.metadata
-  return `$wp_codebox_page_load_started_at = gmdate('Y-m-d\\TH:i:s.v\\Z');
+  return `${wordpressQueryRecorderPhp()}
+$wp_codebox_page_load_started_at = gmdate('Y-m-d\\TH:i:s.v\\Z');
 $wp_codebox_page_load_start_time = microtime(true);
 $wp_codebox_page_load_start_memory = memory_get_usage(true);
-$wp_codebox_page_load_query_start = isset($GLOBALS['wpdb']->queries) && is_array($GLOBALS['wpdb']->queries) ? count($GLOBALS['wpdb']->queries) : 0;
 $wp_codebox_page_load_command = ${JSON.stringify(input.command)};
 $wp_codebox_page_load_surface = ${JSON.stringify(input.surface)};
 $wp_codebox_page_load_method = ${JSON.stringify(input.method)};
@@ -43,9 +44,10 @@ $wp_codebox_page_load_path = ${JSON.stringify(input.path)};
 $wp_codebox_page_load_query = json_decode(${JSON.stringify(JSON.stringify(input.query))}, true);
 $wp_codebox_page_load_body = json_decode(${JSON.stringify(JSON.stringify(input.body))}, true);
 $wp_codebox_page_load_capture = json_decode(${JSON.stringify(JSON.stringify(input.captureDiagnostics))}, true);
-$wp_codebox_page_load_capture_request = json_decode(${JSON.stringify(JSON.stringify(input.capture))}, true);
+$wp_codebox_page_load_capture_request = json_decode(${JSON.stringify(JSON.stringify(input.capture ?? {}))}, true);
 $wp_codebox_page_load_user_session = json_decode(${JSON.stringify(JSON.stringify(userSessionMetadata ?? null))}, true);
 $wp_codebox_page_load_capture_queries_requested = is_array($wp_codebox_page_load_capture_request) && array_key_exists('queries', $wp_codebox_page_load_capture_request) ? (bool) $wp_codebox_page_load_capture_request['queries'] : in_array('wpdb-queries', $wp_codebox_page_load_capture, true);
+$wp_codebox_page_load_query_recorder_start = $wp_codebox_page_load_capture_queries_requested ? wp_codebox_query_recorder_start('page-load', 50, 500) : array('status' => 'uncaptured', 'reason' => 'query_capture_not_requested');
 $wp_codebox_page_load_notices = array();
 $wp_codebox_page_load_errors = array();
 $wp_codebox_page_load_redirect = null;
@@ -161,33 +163,13 @@ $wp_codebox_page_load_identity = array_filter($wp_codebox_page_load_identity, st
 $wp_codebox_page_load_query_count = 0;
 $wp_codebox_page_load_query_time_ms = 0.0;
 $wp_codebox_page_load_query_fingerprints = array();
-$wp_codebox_page_load_queries_available = $wp_codebox_page_load_capture_queries_requested && isset($GLOBALS['wpdb']->queries) && is_array($GLOBALS['wpdb']->queries);
-if ($wp_codebox_page_load_queries_available) {
-    foreach (array_slice($GLOBALS['wpdb']->queries, $wp_codebox_page_load_query_start) as $wp_codebox_page_load_query_record) {
-        $wp_codebox_page_load_sql = is_array($wp_codebox_page_load_query_record) && isset($wp_codebox_page_load_query_record[0]) ? (string) $wp_codebox_page_load_query_record[0] : '';
-        if ($wp_codebox_page_load_sql === '') {
-            continue;
-        }
-        $wp_codebox_page_load_query_count++;
-        $wp_codebox_page_load_elapsed_ms = is_array($wp_codebox_page_load_query_record) && isset($wp_codebox_page_load_query_record[1]) ? round(((float) $wp_codebox_page_load_query_record[1]) * 1000, 3) : null;
-        if ($wp_codebox_page_load_elapsed_ms !== null) {
-            $wp_codebox_page_load_query_time_ms += $wp_codebox_page_load_elapsed_ms;
-        }
-        $wp_codebox_page_load_fingerprint = preg_replace('/\\s+/', ' ', trim($wp_codebox_page_load_sql));
-        $wp_codebox_page_load_fingerprint = preg_replace("/'(?:''|[^'])*'/", "'?'", $wp_codebox_page_load_fingerprint);
-        $wp_codebox_page_load_fingerprint = preg_replace('/\\b\\d+(?:\\.\\d+)?\\b/', '?', $wp_codebox_page_load_fingerprint);
-        $wp_codebox_page_load_key = hash('sha256', $wp_codebox_page_load_fingerprint);
-        if (!isset($wp_codebox_page_load_query_fingerprints[$wp_codebox_page_load_key])) {
-            $wp_codebox_page_load_query_fingerprints[$wp_codebox_page_load_key] = array('fingerprint' => $wp_codebox_page_load_fingerprint, 'count' => 0, 'sampleMs' => $wp_codebox_page_load_elapsed_ms, 'totalTimeMs' => 0);
-        }
-        $wp_codebox_page_load_query_fingerprints[$wp_codebox_page_load_key]['count']++;
-        if ($wp_codebox_page_load_elapsed_ms !== null) {
-            $wp_codebox_page_load_query_fingerprints[$wp_codebox_page_load_key]['totalTimeMs'] = round($wp_codebox_page_load_query_fingerprints[$wp_codebox_page_load_key]['totalTimeMs'] + $wp_codebox_page_load_elapsed_ms, 3);
-        }
-    }
-}
-$wp_codebox_page_load_query_capture_status = $wp_codebox_page_load_capture_queries_requested ? ($wp_codebox_page_load_queries_available ? 'captured' : 'unavailable') : 'uncaptured';
-$wp_codebox_page_load_query_capture_reason = $wp_codebox_page_load_capture_queries_requested ? ($wp_codebox_page_load_queries_available ? null : 'wpdb_queries_unavailable') : 'query_capture_not_requested';
+$wp_codebox_page_load_query_report = $wp_codebox_page_load_capture_queries_requested && ($wp_codebox_page_load_query_recorder_start['status'] ?? null) === 'captured' ? wp_codebox_query_recorder_report('page-load') : array('status' => (string) ($wp_codebox_page_load_query_recorder_start['status'] ?? 'unavailable'), 'reason' => $wp_codebox_page_load_query_recorder_start['reason'] ?? 'query_recorder_unavailable', 'queryCount' => 0, 'totalTimeMs' => 0, 'fingerprints' => array(), 'repeatedQueries' => array());
+$wp_codebox_page_load_query_capture_status = (string) ($wp_codebox_page_load_query_report['status'] ?? 'unavailable');
+$wp_codebox_page_load_query_capture_reason = $wp_codebox_page_load_query_report['reason'] ?? null;
+$wp_codebox_page_load_query_count = (int) ($wp_codebox_page_load_query_report['queryCount'] ?? 0);
+$wp_codebox_page_load_query_time_ms = (float) ($wp_codebox_page_load_query_report['totalTimeMs'] ?? 0);
+$wp_codebox_page_load_query_fingerprints = is_array($wp_codebox_page_load_query_report['fingerprints'] ?? null) ? $wp_codebox_page_load_query_report['fingerprints'] : array();
+$wp_codebox_page_load_repeated_queries = is_array($wp_codebox_page_load_query_report['repeatedQueries'] ?? null) ? $wp_codebox_page_load_query_report['repeatedQueries'] : array();
 $wp_codebox_page_load_finished_at = gmdate('Y-m-d\\TH:i:s.v\\Z');
 $wp_codebox_page_load_status = !empty($wp_codebox_page_load_errors) ? 'error' : ($wp_codebox_page_load_redirect ? 'redirect' : 'ok');
 $wp_codebox_page_load_result = array(
@@ -201,7 +183,7 @@ $wp_codebox_page_load_result = array(
     'redirect' => $wp_codebox_page_load_redirect,
     'notices' => $wp_codebox_page_load_notices,
     'errors' => $wp_codebox_page_load_errors,
-    'performance' => array('schema' => 'wp-codebox/performance-observation/v1', 'command' => $wp_codebox_page_load_command, 'target' => $wp_codebox_page_load_path, 'source' => 'in-process', 'kind' => 'simulated-page-load', 'timing' => array('status' => 'captured', 'startedAt' => $wp_codebox_page_load_started_at, 'finishedAt' => $wp_codebox_page_load_finished_at, 'durationMs' => round((microtime(true) - $wp_codebox_page_load_start_time) * 1000, 3)), 'memory' => array('status' => 'captured', 'startBytes' => $wp_codebox_page_load_start_memory, 'endBytes' => memory_get_usage(true), 'deltaBytes' => memory_get_usage(true) - $wp_codebox_page_load_start_memory, 'peakBytes' => memory_get_peak_usage(true)), 'database' => array('status' => $wp_codebox_page_load_query_capture_status, 'reason' => $wp_codebox_page_load_query_capture_reason, 'queryCount' => $wp_codebox_page_load_query_count, 'totalTimeMs' => round($wp_codebox_page_load_query_time_ms, 3), 'fingerprints' => array_values($wp_codebox_page_load_query_fingerprints), 'repeatedQueries' => array_values(array_filter(array_values($wp_codebox_page_load_query_fingerprints), static fn($query) => isset($query['count']) && $query['count'] > 1))), 'hooks' => array('status' => 'unsupported', 'reason' => 'hook_timing_not_instrumented', 'timings' => array()), 'network' => array('status' => 'unsupported', 'reason' => 'in_process_page_load'), 'browser' => array('status' => 'unsupported', 'reason' => 'not_a_browser_observation'), 'capture' => array('requested' => array('queries' => $wp_codebox_page_load_capture_queries_requested), 'queries' => array('requested' => $wp_codebox_page_load_capture_queries_requested, 'status' => $wp_codebox_page_load_query_capture_status, 'reason' => $wp_codebox_page_load_query_capture_reason)), 'metadata' => array('runner' => 'wp-codebox/runtime-playground', 'surface' => $wp_codebox_page_load_surface)),
+    'performance' => array('schema' => 'wp-codebox/performance-observation/v1', 'command' => $wp_codebox_page_load_command, 'target' => $wp_codebox_page_load_path, 'source' => 'in-process', 'kind' => 'simulated-page-load', 'timing' => array('status' => 'captured', 'startedAt' => $wp_codebox_page_load_started_at, 'finishedAt' => $wp_codebox_page_load_finished_at, 'durationMs' => round((microtime(true) - $wp_codebox_page_load_start_time) * 1000, 3)), 'memory' => array('status' => 'captured', 'startBytes' => $wp_codebox_page_load_start_memory, 'endBytes' => memory_get_usage(true), 'deltaBytes' => memory_get_usage(true) - $wp_codebox_page_load_start_memory, 'peakBytes' => memory_get_peak_usage(true)), 'database' => array('status' => $wp_codebox_page_load_query_capture_status, 'reason' => $wp_codebox_page_load_query_capture_reason, 'queryCount' => $wp_codebox_page_load_query_count, 'totalTimeMs' => round($wp_codebox_page_load_query_time_ms, 3), 'fingerprints' => array_values($wp_codebox_page_load_query_fingerprints), 'repeatedQueries' => $wp_codebox_page_load_repeated_queries), 'hooks' => array('status' => 'unsupported', 'reason' => 'hook_timing_not_instrumented', 'timings' => array()), 'network' => array('status' => 'unsupported', 'reason' => 'in_process_page_load'), 'browser' => array('status' => 'unsupported', 'reason' => 'not_a_browser_observation'), 'capture' => array('requested' => array('queries' => $wp_codebox_page_load_capture_queries_requested), 'queries' => array('requested' => $wp_codebox_page_load_capture_queries_requested, 'status' => $wp_codebox_page_load_query_capture_status, 'reason' => $wp_codebox_page_load_query_capture_reason)), 'metadata' => array('runner' => 'wp-codebox/runtime-playground', 'surface' => $wp_codebox_page_load_surface)),
     'artifactRefs' => array(),
     'diagnostics' => array('bufferBytes' => strlen((string) $wp_codebox_page_load_buffer), 'capture' => $wp_codebox_page_load_capture),
 );

--- a/packages/runtime-playground/src/performance-observation-command-handlers.ts
+++ b/packages/runtime-playground/src/performance-observation-command-handlers.ts
@@ -1,4 +1,5 @@
 import { argValue, booleanArg, jsonObjectArg, nonNegativeIntegerArg, positiveIntegerArg } from "./command-args.js"
+import { wordpressQueryRecorderPhp } from "./query-recorder.js"
 import { wordpressFixtureUserPhpCode, type WordPressUserSessionResolution } from "./wordpress-user-sessions.js"
 
 export interface RestPerformanceObservationInput {
@@ -34,20 +35,21 @@ export function restPerformanceObservationInputFromArgs(args: string[]): RestPer
 export function restPerformanceObservationPhpCode(input: RestPerformanceObservationInput): string {
   const userSessionMetadata = input.userSession?.metadata
   return `define( 'REST_REQUEST', true );
+${wordpressQueryRecorderPhp()}
 $wp_codebox_observation_started_at = gmdate( 'Y-m-d\\TH:i:s.v\\Z' );
 $wp_codebox_observation_start_time = microtime( true );
 $wp_codebox_observation_start_memory = memory_get_usage( true );
-$wp_codebox_query_start = isset( $GLOBALS['wpdb']->queries ) && is_array( $GLOBALS['wpdb']->queries ) ? count( $GLOBALS['wpdb']->queries ) : 0;
 $wp_codebox_method = ${JSON.stringify(input.method)};
 $wp_codebox_path = ${JSON.stringify(input.path)};
 $wp_codebox_params = json_decode( ${JSON.stringify(JSON.stringify(input.params))}, true );
-$wp_codebox_capture = json_decode( ${JSON.stringify(JSON.stringify(input.capture))}, true );
+$wp_codebox_capture = json_decode( ${JSON.stringify(JSON.stringify(input.capture ?? {}))}, true );
 $wp_codebox_query_fingerprint_limit = ${input.queryFingerprintLimit};
 $wp_codebox_hook_sample_limit = ${input.hookSampleLimit};
 $wp_codebox_hook_limit = ${input.hookLimit};
 $wp_codebox_query_length_limit = ${input.queryLengthLimit};
 $wp_codebox_user_session = json_decode( ${JSON.stringify(JSON.stringify(userSessionMetadata ?? null))}, true );
 $wp_codebox_capture_queries_requested = is_array( $wp_codebox_capture ) && array_key_exists( 'queries', $wp_codebox_capture ) ? (bool) $wp_codebox_capture['queries'] : true;
+$wp_codebox_query_recorder_start = $wp_codebox_capture_queries_requested ? wp_codebox_query_recorder_start( 'rest-performance-observation', $wp_codebox_query_fingerprint_limit, $wp_codebox_query_length_limit ) : array( 'status' => 'uncaptured', 'reason' => 'query_capture_not_requested' );
 
 if ( ! class_exists( 'WP_REST_Request' ) || ! function_exists( 'rest_do_request' ) ) {
     throw new RuntimeException( 'The WordPress REST API is not available in this runtime.' );
@@ -108,42 +110,13 @@ try {
 $wp_codebox_finished_at = microtime( true );
 $wp_codebox_observation_finished_at = gmdate( 'Y-m-d\\TH:i:s.v\\Z' );
 $wp_codebox_end_memory = memory_get_usage( true );
-$wp_codebox_queries_available = $wp_codebox_capture_queries_requested && isset( $GLOBALS['wpdb']->queries ) && is_array( $GLOBALS['wpdb']->queries );
-$wp_codebox_query_groups = array();
-$wp_codebox_query_count = 0;
-$wp_codebox_query_total_ms = 0.0;
-if ( $wp_codebox_queries_available ) {
-    foreach ( array_slice( $GLOBALS['wpdb']->queries, $wp_codebox_query_start ) as $wp_codebox_query ) {
-        $wp_codebox_sql = is_array( $wp_codebox_query ) && isset( $wp_codebox_query[0] ) ? (string) $wp_codebox_query[0] : '';
-        if ( '' === $wp_codebox_sql ) {
-            continue;
-        }
-        ++$wp_codebox_query_count;
-        $wp_codebox_elapsed_ms = is_array( $wp_codebox_query ) && isset( $wp_codebox_query[1] ) ? round( ( (float) $wp_codebox_query[1] ) * 1000, 3 ) : null;
-        if ( null !== $wp_codebox_elapsed_ms ) {
-            $wp_codebox_query_total_ms += $wp_codebox_elapsed_ms;
-        }
-        $wp_codebox_fingerprint = preg_replace( '/\/\*.*?\*\//s', '/* ? */', $wp_codebox_sql );
-        $wp_codebox_fingerprint = preg_replace( "/'(?:''|[^'])*'/", "'?'", is_string( $wp_codebox_fingerprint ) ? $wp_codebox_fingerprint : $wp_codebox_sql );
-        $wp_codebox_fingerprint = preg_replace( '/\"(?:\"\"|[^\"])*\"/', '\"?\"', is_string( $wp_codebox_fingerprint ) ? $wp_codebox_fingerprint : $wp_codebox_sql );
-        $wp_codebox_fingerprint = preg_replace( '/\\b[-+]?\\d+(?:\\.\\d+)?(?:e[-+]?\\d+)?\\b/i', '?', is_string( $wp_codebox_fingerprint ) ? $wp_codebox_fingerprint : $wp_codebox_sql );
-        $wp_codebox_fingerprint = trim( (string) preg_replace( '/\\s+/', ' ', is_string( $wp_codebox_fingerprint ) ? $wp_codebox_fingerprint : $wp_codebox_sql ) );
-        $wp_codebox_key = hash( 'sha256', strtolower( $wp_codebox_fingerprint ) );
-        if ( ! isset( $wp_codebox_query_groups[ $wp_codebox_key ] ) ) {
-            $wp_codebox_query_groups[ $wp_codebox_key ] = array( 'fingerprint' => substr( strtolower( $wp_codebox_fingerprint ), 0, $wp_codebox_query_length_limit ), 'count' => 0, 'sampleMs' => $wp_codebox_elapsed_ms, 'totalTimeMs' => 0, 'caller' => is_array( $wp_codebox_query ) && isset( $wp_codebox_query[2] ) ? substr( (string) $wp_codebox_query[2], 0, 240 ) : null );
-        }
-        ++$wp_codebox_query_groups[ $wp_codebox_key ]['count'];
-        if ( null !== $wp_codebox_elapsed_ms ) {
-            $wp_codebox_query_groups[ $wp_codebox_key ]['totalTimeMs'] = round( $wp_codebox_query_groups[ $wp_codebox_key ]['totalTimeMs'] + $wp_codebox_elapsed_ms, 3 );
-        }
-    }
-}
-$wp_codebox_query_capture_status = $wp_codebox_capture_queries_requested ? ( $wp_codebox_queries_available ? 'captured' : 'unavailable' ) : 'uncaptured';
-$wp_codebox_query_capture_reason = $wp_codebox_capture_queries_requested ? ( $wp_codebox_queries_available ? null : 'wpdb_queries_unavailable' ) : 'query_capture_not_requested';
-$wp_codebox_fingerprints = array_values( $wp_codebox_query_groups );
-usort( $wp_codebox_fingerprints, static fn( $a, $b ) => ( (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 ) ) ?: strcmp( (string) ( $a['fingerprint'] ?? '' ), (string) ( $b['fingerprint'] ?? '' ) ) );
-$wp_codebox_fingerprints = array_slice( $wp_codebox_fingerprints, 0, $wp_codebox_query_fingerprint_limit );
-$wp_codebox_repeated_queries = array_values( array_filter( $wp_codebox_fingerprints, static fn( $query ) => isset( $query['count'] ) && $query['count'] > 1 ) );
+$wp_codebox_query_report = $wp_codebox_capture_queries_requested && ( $wp_codebox_query_recorder_start['status'] ?? null ) === 'captured' ? wp_codebox_query_recorder_report( 'rest-performance-observation' ) : array( 'status' => (string) ( $wp_codebox_query_recorder_start['status'] ?? 'unavailable' ), 'reason' => $wp_codebox_query_recorder_start['reason'] ?? 'query_recorder_unavailable', 'queryCount' => 0, 'totalTimeMs' => 0, 'fingerprints' => array(), 'repeatedQueries' => array() );
+$wp_codebox_query_capture_status = (string) ( $wp_codebox_query_report['status'] ?? 'unavailable' );
+$wp_codebox_query_capture_reason = $wp_codebox_query_report['reason'] ?? null;
+$wp_codebox_query_count = (int) ( $wp_codebox_query_report['queryCount'] ?? 0 );
+$wp_codebox_query_total_ms = (float) ( $wp_codebox_query_report['totalTimeMs'] ?? 0 );
+$wp_codebox_fingerprints = is_array( $wp_codebox_query_report['fingerprints'] ?? null ) ? $wp_codebox_query_report['fingerprints'] : array();
+$wp_codebox_repeated_queries = is_array( $wp_codebox_query_report['repeatedQueries'] ?? null ) ? $wp_codebox_query_report['repeatedQueries'] : array();
 
 $wp_codebox_hook_timings = array_values( array_map( static fn( $sample ) => array_filter( array( 'hook' => $sample['hook'], 'count' => (int) $sample['count'], 'totalTimeMs' => round( max( 0, ( (float) $sample['last'] - (float) $sample['first'] ) * 1000 ), 3 ), 'callbackCount' => (int) $sample['callbackCount'] ), static fn( $value ) => 0 !== $value && '' !== $value ), $wp_codebox_hook_samples ) );
 usort( $wp_codebox_hook_timings, static fn( $a, $b ) => ( (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 ) ) ?: strcmp( (string) ( $a['hook'] ?? '' ), (string) ( $b['hook'] ?? '' ) ) );

--- a/packages/runtime-playground/src/query-recorder.ts
+++ b/packages/runtime-playground/src/query-recorder.ts
@@ -1,0 +1,78 @@
+export function wordpressQueryRecorderPhp(): string {
+  return `if ( ! function_exists( 'wp_codebox_query_recorder_start' ) ) {
+    function wp_codebox_query_recorder_fingerprint( $sql, $length_limit ) {
+        $fingerprint = preg_replace( '#/\\*.*?\\*/#s', '/* ? */', (string) $sql );
+        $fingerprint = preg_replace( "/'(?:''|[^'])*'/", "'?'", is_string( $fingerprint ) ? $fingerprint : (string) $sql );
+        $fingerprint = preg_replace( '/\"(?:\"\"|[^\"])*\"/', '\"?\"', is_string( $fingerprint ) ? $fingerprint : (string) $sql );
+        $fingerprint = preg_replace( '/\\b[-+]?\\d+(?:\\.\\d+)?(?:e[-+]?\\d+)?\\b/i', '?', is_string( $fingerprint ) ? $fingerprint : (string) $sql );
+        $fingerprint = strtolower( trim( (string) preg_replace( '/\\s+/', ' ', is_string( $fingerprint ) ? $fingerprint : (string) $sql ) ) );
+        return substr( $fingerprint, 0, max( 1, (int) $length_limit ) );
+    }
+
+    function wp_codebox_query_recorder_start( $id, $fingerprint_limit = 50, $length_limit = 500 ) {
+        if ( ! function_exists( 'add_filter' ) ) {
+            return array( 'status' => 'unavailable', 'reason' => 'wordpress_filter_api_unavailable' );
+        }
+        if ( ! isset( $GLOBALS['wp_codebox_query_recorders'] ) || ! is_array( $GLOBALS['wp_codebox_query_recorders'] ) ) {
+            $GLOBALS['wp_codebox_query_recorders'] = array();
+        }
+        $id = (string) $id;
+        $fingerprint_limit = max( 0, (int) $fingerprint_limit );
+        $length_limit = max( 1, (int) $length_limit );
+        $callback = static function ( $query ) use ( $id, $fingerprint_limit, $length_limit ) {
+            if ( ! isset( $GLOBALS['wp_codebox_query_recorders'][ $id ] ) || ! is_array( $GLOBALS['wp_codebox_query_recorders'][ $id ] ) ) {
+                return $query;
+            }
+            $sql = (string) $query;
+            if ( '' === trim( $sql ) ) {
+                return $query;
+            }
+            $fingerprint = wp_codebox_query_recorder_fingerprint( $sql, $length_limit );
+            $key = hash( 'sha256', $fingerprint );
+            ++$GLOBALS['wp_codebox_query_recorders'][ $id ]['queryCount'];
+            if ( ! isset( $GLOBALS['wp_codebox_query_recorders'][ $id ]['fingerprints'][ $key ] ) ) {
+                if ( count( $GLOBALS['wp_codebox_query_recorders'][ $id ]['fingerprints'] ) >= $fingerprint_limit ) {
+                    $GLOBALS['wp_codebox_query_recorders'][ $id ]['truncated'] = true;
+                    return $query;
+                }
+                $GLOBALS['wp_codebox_query_recorders'][ $id ]['fingerprints'][ $key ] = array( 'fingerprint' => $fingerprint, 'count' => 0, 'totalTimeMs' => 0 );
+            }
+            ++$GLOBALS['wp_codebox_query_recorders'][ $id ]['fingerprints'][ $key ]['count'];
+            return $query;
+        };
+        $GLOBALS['wp_codebox_query_recorders'][ $id ] = array(
+            'queryCount' => 0,
+            'totalTimeMs' => 0.0,
+            'fingerprints' => array(),
+            'truncated' => false,
+            'callback' => $callback,
+        );
+        add_filter( 'query', $callback, PHP_INT_MIN, 1 );
+        return array( 'status' => 'captured', 'reason' => null );
+    }
+
+    function wp_codebox_query_recorder_report( $id ) {
+        $id = (string) $id;
+        if ( ! isset( $GLOBALS['wp_codebox_query_recorders'][ $id ] ) || ! is_array( $GLOBALS['wp_codebox_query_recorders'][ $id ] ) ) {
+            return array( 'status' => 'unavailable', 'reason' => 'query_recorder_not_started', 'queryCount' => 0, 'totalTimeMs' => 0, 'fingerprints' => array(), 'repeatedQueries' => array() );
+        }
+        $recorder = $GLOBALS['wp_codebox_query_recorders'][ $id ];
+        if ( function_exists( 'remove_filter' ) && isset( $recorder['callback'] ) ) {
+            remove_filter( 'query', $recorder['callback'], PHP_INT_MIN );
+        }
+        unset( $GLOBALS['wp_codebox_query_recorders'][ $id ] );
+        $fingerprints = array_values( is_array( $recorder['fingerprints'] ?? null ) ? $recorder['fingerprints'] : array() );
+        usort( $fingerprints, static fn( $a, $b ) => ( (int) ( $b['count'] ?? 0 ) <=> (int) ( $a['count'] ?? 0 ) ) ?: strcmp( (string) ( $a['fingerprint'] ?? '' ), (string) ( $b['fingerprint'] ?? '' ) ) );
+        $repeated = array_values( array_filter( $fingerprints, static fn( $query ) => isset( $query['count'] ) && $query['count'] > 1 ) );
+        return array(
+            'status' => 'captured',
+            'reason' => ! empty( $recorder['truncated'] ) ? 'query_fingerprint_limit_reached' : null,
+            'queryCount' => (int) ( $recorder['queryCount'] ?? 0 ),
+            'totalTimeMs' => 0,
+            'fingerprints' => $fingerprints,
+            'repeatedQueries' => $repeated,
+        );
+    }
+}
+`
+}

--- a/packages/runtime-playground/src/rest-request-command-handlers.ts
+++ b/packages/runtime-playground/src/rest-request-command-handlers.ts
@@ -1,4 +1,5 @@
 import { argValue, booleanArg, jsonObjectArg } from "./command-args.js"
+import { wordpressQueryRecorderPhp } from "./query-recorder.js"
 import { wordpressFixtureUserPhpCode, type WordPressUserSessionResolution } from "./wordpress-user-sessions.js"
 
 export interface RestRequestCommandInput {
@@ -33,18 +34,19 @@ export function restRequestInputFromArgs(args: string[]): RestRequestCommandInpu
 export function restRequestPhpCode(input: RestRequestCommandInput): string {
   const userSessionMetadata = input.userSession?.metadata
   return `define( 'REST_REQUEST', true );
+${wordpressQueryRecorderPhp()}
 $wp_codebox_started_at = microtime( true );
 $wp_codebox_observation_started_at = gmdate( 'Y-m-d\\TH:i:s.v\\Z' );
 $wp_codebox_start_memory = memory_get_usage( true );
-$wp_codebox_query_start = isset( $GLOBALS['wpdb']->queries ) && is_array( $GLOBALS['wpdb']->queries ) ? count( $GLOBALS['wpdb']->queries ) : 0;
 $wp_codebox_method = ${JSON.stringify(input.method)};
 $wp_codebox_path = ${JSON.stringify(input.path)};
 $wp_codebox_headers = json_decode( ${JSON.stringify(JSON.stringify(input.headers))}, true );
 $wp_codebox_params = json_decode( ${JSON.stringify(JSON.stringify(input.params))}, true );
 $wp_codebox_body = ${JSON.stringify(input.body)};
-$wp_codebox_capture = json_decode( ${JSON.stringify(JSON.stringify(input.capture))}, true );
+$wp_codebox_capture = json_decode( ${JSON.stringify(JSON.stringify(input.capture ?? {}))}, true );
 $wp_codebox_user_session = json_decode( ${JSON.stringify(JSON.stringify(userSessionMetadata ?? null))}, true );
 $wp_codebox_capture_queries_requested = is_array( $wp_codebox_capture ) && array_key_exists( 'queries', $wp_codebox_capture ) ? (bool) $wp_codebox_capture['queries'] : false;
+$wp_codebox_query_recorder_start = $wp_codebox_capture_queries_requested ? wp_codebox_query_recorder_start( 'rest-request', 50, 500 ) : array( 'status' => 'uncaptured', 'reason' => 'query_capture_not_requested' );
 
 if ( ! class_exists( 'WP_REST_Request' ) || ! function_exists( 'rest_do_request' ) ) {
     throw new RuntimeException( 'The WordPress REST API is not available in this runtime.' );
@@ -88,46 +90,13 @@ $wp_codebox_data = $wp_codebox_server->response_to_data( $wp_codebox_response, f
 $wp_codebox_finished_at = microtime( true );
 $wp_codebox_observation_finished_at = gmdate( 'Y-m-d\\TH:i:s.v\\Z' );
 $wp_codebox_end_memory = memory_get_usage( true );
-$wp_codebox_queries = array();
-$wp_codebox_query_count = 0;
-$wp_codebox_query_total_ms = 0.0;
-$wp_codebox_queries_available = $wp_codebox_capture_queries_requested && isset( $GLOBALS['wpdb']->queries ) && is_array( $GLOBALS['wpdb']->queries );
-if ( $wp_codebox_queries_available ) {
-    foreach ( array_slice( $GLOBALS['wpdb']->queries, $wp_codebox_query_start ) as $wp_codebox_query ) {
-        $wp_codebox_sql = is_array( $wp_codebox_query ) && isset( $wp_codebox_query[0] ) ? (string) $wp_codebox_query[0] : '';
-        if ( '' === $wp_codebox_sql ) {
-            continue;
-        }
-        $wp_codebox_query_count++;
-        $wp_codebox_elapsed_ms = is_array( $wp_codebox_query ) && isset( $wp_codebox_query[1] ) ? round( ( (float) $wp_codebox_query[1] ) * 1000, 3 ) : null;
-        if ( null !== $wp_codebox_elapsed_ms ) {
-            $wp_codebox_query_total_ms += $wp_codebox_elapsed_ms;
-        }
-        $wp_codebox_fingerprint = preg_replace( '/\\s+/', ' ', trim( $wp_codebox_sql ) );
-        $wp_codebox_fingerprint = preg_replace( "/'(?:''|[^'])*'/", "'?'", $wp_codebox_fingerprint );
-        $wp_codebox_fingerprint = preg_replace( '/\\b\\d+(?:\\.\\d+)?\\b/', '?', $wp_codebox_fingerprint );
-        $wp_codebox_key = hash( 'sha256', $wp_codebox_fingerprint );
-        if ( ! isset( $wp_codebox_queries[ $wp_codebox_key ] ) ) {
-            $wp_codebox_queries[ $wp_codebox_key ] = array(
-                'fingerprint' => $wp_codebox_fingerprint,
-                'count' => 0,
-                'sampleMs' => $wp_codebox_elapsed_ms,
-                'totalTimeMs' => 0,
-                'caller' => is_array( $wp_codebox_query ) && isset( $wp_codebox_query[2] ) ? substr( (string) $wp_codebox_query[2], 0, 240 ) : null,
-            );
-        }
-        $wp_codebox_queries[ $wp_codebox_key ]['count']++;
-        if ( null !== $wp_codebox_elapsed_ms ) {
-            $wp_codebox_queries[ $wp_codebox_key ]['totalTimeMs'] = round( $wp_codebox_queries[ $wp_codebox_key ]['totalTimeMs'] + $wp_codebox_elapsed_ms, 3 );
-        }
-    }
-}
-$wp_codebox_query_capture_status = $wp_codebox_capture_queries_requested ? ( $wp_codebox_queries_available ? 'captured' : 'unavailable' ) : 'uncaptured';
-$wp_codebox_query_capture_reason = $wp_codebox_capture_queries_requested ? ( $wp_codebox_queries_available ? null : 'wpdb_queries_unavailable' ) : 'query_capture_not_requested';
-$wp_codebox_fingerprints = array_values( $wp_codebox_queries );
-$wp_codebox_repeated_queries = array_values( array_filter( $wp_codebox_fingerprints, static function ( $wp_codebox_query ) {
-    return isset( $wp_codebox_query['count'] ) && $wp_codebox_query['count'] > 1;
-} ) );
+$wp_codebox_query_report = $wp_codebox_capture_queries_requested && ( $wp_codebox_query_recorder_start['status'] ?? null ) === 'captured' ? wp_codebox_query_recorder_report( 'rest-request' ) : array( 'status' => (string) ( $wp_codebox_query_recorder_start['status'] ?? 'unavailable' ), 'reason' => $wp_codebox_query_recorder_start['reason'] ?? 'query_recorder_unavailable', 'queryCount' => 0, 'totalTimeMs' => 0, 'fingerprints' => array(), 'repeatedQueries' => array() );
+$wp_codebox_query_capture_status = (string) ( $wp_codebox_query_report['status'] ?? 'unavailable' );
+$wp_codebox_query_capture_reason = $wp_codebox_query_report['reason'] ?? null;
+$wp_codebox_query_count = (int) ( $wp_codebox_query_report['queryCount'] ?? 0 );
+$wp_codebox_query_total_ms = (float) ( $wp_codebox_query_report['totalTimeMs'] ?? 0 );
+$wp_codebox_fingerprints = is_array( $wp_codebox_query_report['fingerprints'] ?? null ) ? $wp_codebox_query_report['fingerprints'] : array();
+$wp_codebox_repeated_queries = is_array( $wp_codebox_query_report['repeatedQueries'] ?? null ) ? $wp_codebox_query_report['repeatedQueries'] : array();
 $wp_codebox_performance = array(
     'schema' => 'wp-codebox/performance-observation/v1',
     'command' => 'wordpress.rest-request',

--- a/tests/performance-observation-contracts.test.ts
+++ b/tests/performance-observation-contracts.test.ts
@@ -5,6 +5,7 @@ import { runHttpRequest } from "../packages/runtime-playground/src/http-request-
 import { pageLoadPhpCode } from "../packages/runtime-playground/src/page-load-command-handlers.js"
 import { restPerformanceObservationInputFromArgs, restPerformanceObservationPhpCode } from "../packages/runtime-playground/src/performance-observation-command-handlers.js"
 import { restRequestPhpCode } from "../packages/runtime-playground/src/rest-request-command-handlers.js"
+import { runPhpJson } from "../scripts/test-kit.js"
 
 const observation = performanceObservation({
   command: "wordpress.rest-request",
@@ -64,7 +65,8 @@ assert.equal(restObservationInput.hookSampleLimit, 2)
 const restObservationCode = restPerformanceObservationPhpCode(restObservationInput)
 assert.match(restObservationCode, /'schema' => 'wp-codebox\/performance-observation\/v1'/)
 assert.match(restObservationCode, /'command' => 'wordpress.rest-performance-observation'/)
-assert.match(restObservationCode, /'database' => array\( 'status' => \$wp_codebox_queries_available \? 'captured' : 'uncaptured'/)
+assert.match(restObservationCode, /wp_codebox_query_recorder_start\( 'rest-performance-observation'/)
+assert.match(restObservationCode, /'database' => array\( 'status' => \$wp_codebox_query_capture_status/)
 assert.match(restObservationCode, /'hooks' => array\( 'status' => 'captured'/)
 assert.match(restObservationCode, /add_filter\( 'all', \$wp_codebox_hook_sampler, PHP_INT_MIN, 0 \)/)
 
@@ -80,17 +82,49 @@ const pageLoadCode = pageLoadPhpCode({
 assert.match(pageLoadCode, /'timing' => array\('status' => 'captured'/)
 assert.match(pageLoadCode, /'mode' => 'simulated'/)
 assert.match(pageLoadCode, /'memory' => array\('status' => 'captured'/)
-assert.match(pageLoadCode, /'status' => \$wp_codebox_page_load_queries_available \? 'captured' : 'uncaptured'/)
+assert.match(pageLoadCode, /wp_codebox_query_recorder_start\('page-load'/)
+assert.match(pageLoadCode, /'status' => \$wp_codebox_page_load_query_capture_status/)
 assert.match(pageLoadCode, /'reason' => 'hook_timing_not_instrumented'/)
 assert.match(pageLoadCode, /'reason' => 'not_a_browser_observation'/)
 assert.match(pageLoadCode, /'metadata' => array\('runner' => 'wp-codebox\/runtime-playground'/)
 
-const restCode = restRequestPhpCode({ method: "GET", path: "/wp/v2/posts", headers: {}, params: {}, body: "" })
+const restCode = restRequestPhpCode({ method: "GET", path: "/wp/v2/posts", headers: {}, params: {}, body: "", capture: {} })
 assert.match(restCode, /'timing' => array\(\n        'status' => 'captured'/)
 assert.match(restCode, /'memory' => array\(\n        'status' => 'captured'/)
-assert.match(restCode, /'status' => \$wp_codebox_queries_available \? 'captured' : 'uncaptured'/)
-assert.match(restCode, /'reason' => \$wp_codebox_queries_available \? null : 'wpdb_queries_unavailable'/)
+assert.match(restCode, /wp_codebox_query_recorder_start\( 'rest-request'/)
+assert.match(restCode, /'status' => \$wp_codebox_query_capture_status/)
 assert.match(restCode, /'network' => array\( 'status' => 'unsupported', 'reason' => 'in_process_rest_request' \)/)
+
+const capturedRestCode = restRequestPhpCode({ method: "GET", path: "/wp/v2/posts", headers: {}, params: {}, body: "", capture: { queries: true } })
+const capturedRest = await runPhpJson<any>(`
+$GLOBALS['wp_codebox_test_filters'] = array();
+function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) { $GLOBALS['wp_codebox_test_filters'][ $hook ][] = $callback; }
+function remove_filter( $hook, $callback, $priority = 10 ) { $GLOBALS['wp_codebox_test_filters'][ $hook ] = array_values( array_filter( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array(), static fn( $item ) => $item !== $callback ) ); }
+function apply_filters( $hook, $value ) { foreach ( $GLOBALS['wp_codebox_test_filters'][ $hook ] ?? array() as $callback ) { $value = $callback( $value ); } return $value; }
+class WP_REST_Request { public string $method; public string $route; public array $params = array(); public function __construct( $method, $route ) { $this->method = $method; $this->route = $route; } public function set_header( $name, $value ) {} public function set_param( $name, $value ) { $this->params[ $name ] = $value; } public function has_param( $name ) { return array_key_exists( $name, $this->params ); } public function set_body( $body ) {} }
+class WP_Codebox_Test_REST_Response { public function get_status() { return 200; } public function get_headers() { return array(); } public function get_data() { return array( 'ok' => true ); } }
+function rest_do_request( $request ) { apply_filters( 'query', 'SELECT * FROM wp_posts WHERE ID = 123' ); apply_filters( 'query', 'SELECT * FROM wp_posts WHERE ID = 456' ); return new WP_Codebox_Test_REST_Response(); }
+function rest_get_server() { return new class { public function response_to_data( $response, $embed ) { return $response->get_data(); } }; }
+function wp_json_encode( $data, $flags = 0 ) { return json_encode( $data, $flags ); }
+${capturedRestCode}
+`)
+assert.equal(capturedRest.performance.database.status, "captured")
+assert.equal(capturedRest.performance.database.queryCount, 2)
+assert.equal(capturedRest.performance.database.fingerprints[0].fingerprint, "select * from wp_posts where id = ?")
+assert.equal(capturedRest.performance.database.fingerprints[0].count, 2)
+assert.equal(capturedRest.performance.database.repeatedQueries[0].count, 2)
+
+const unavailableObservationCode = restPerformanceObservationPhpCode(restPerformanceObservationInputFromArgs(["path=/wp/v2/posts", "capture-queries=true"]))
+const unavailableObservation = await runPhpJson<any>(`
+class WP_REST_Request { public function __construct( $method, $route ) {} public function set_param( $name, $value ) {} }
+class WP_Codebox_Test_REST_Response { public function get_status() { return 200; } }
+function rest_do_request( $request ) { return new WP_Codebox_Test_REST_Response(); }
+function wp_json_encode( $data, $flags = 0 ) { return json_encode( $data, $flags ); }
+${unavailableObservationCode}
+`)
+assert.equal(unavailableObservation.database.status, "unavailable")
+assert.equal(unavailableObservation.database.reason, "wordpress_filter_api_unavailable")
+assert.equal(unavailableObservation.database.queryCount, 0)
 
 const previousFetch = globalThis.fetch
 globalThis.fetch = async () =>


### PR DESCRIPTION
## Summary
- Add a bounded WordPress query recorder that uses the generic query filter instead of ambient `$GLOBALS['wpdb']->queries`.
- Wire REST request, REST performance observation, and simulated page-load observations to consume recorder reports.
- Add tests for populated recorder-backed observations and explicit unavailable evidence when the recorder cannot install.

## Verification
- `npm exec tsx tests/performance-observation-contracts.test.ts`
- `npm exec tsx tests/rest-request-query-params.test.ts`
- `npm exec tsx tests/page-load-command-contracts.test.ts`
- `npm exec tsx tests/wordpress-runtime-actions.test.ts`
- `npm exec tsx tests/fuzz-suite-runner.test.ts`
- `npm exec tsx tests/playground-fuzz-suite-public.test.ts`
- `npm exec tsx tests/command-router.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the bounded query recorder, wiring runtime observations, adding focused tests, and running verification.