### PR TITLE
Clarify WordPress page-load command modes

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -20,6 +20,7 @@ export interface CommandOutputSchemaContract {
 export interface CommandDefinition {
   id: string
   description: string
+  metadata?: CommandDefinitionMetadata
   acceptedArgs: Array<{
     name: string
     description: string
@@ -34,6 +35,13 @@ export interface CommandDefinition {
   validation?: CommandValidationDescriptor
   recipe: boolean
   handler: CommandHandlerBinding
+}
+
+export interface CommandDefinitionMetadata {
+  deprecated?: boolean
+  aliasOnly?: boolean
+  aliasFor?: string
+  excludeFromFuzzTargets?: boolean
 }
 
 export interface CommandValidationDescriptor {
@@ -526,6 +534,7 @@ export const commandRegistry = [
   {
     id: "wordpress.admin-page-load",
     description: "Backward-compatible alias for wordpress.simulated-admin-page-load. Loads a WordPress admin target in-process; it does not perform a real server or browser page load.",
+    metadata: { deprecated: true, aliasOnly: true, aliasFor: "wordpress.simulated-admin-page-load", excludeFromFuzzTargets: true },
     acceptedArgs: [
       { name: "path", description: "Admin path relative to wp-admin, such as index.php or edit.php?post_type=page. Defaults to index.php.", format: "admin path" },
       { name: "url", description: "Optional admin URL or path. Relative paths are resolved under wp-admin/.", format: "path or URL" },
@@ -564,6 +573,7 @@ export const commandRegistry = [
   {
     id: "wordpress.frontend-page-load",
     description: "Backward-compatible alias for wordpress.simulated-frontend-page-load. Loads a WordPress frontend target in-process; it does not perform a real server or browser page load.",
+    metadata: { deprecated: true, aliasOnly: true, aliasFor: "wordpress.simulated-frontend-page-load", excludeFromFuzzTargets: true },
     acceptedArgs: [
       { name: "path", description: "Frontend path relative to home URL. Defaults to /.", format: "frontend path" },
       { name: "url", description: "Optional frontend URL or path.", format: "path or URL" },
@@ -1123,6 +1133,10 @@ export function effectivePolicyCommandsFor(commands: readonly string[], definiti
 
 export function runtimeCommandDefinitions(): CommandDefinition[] {
   return commandRegistry.filter((definition) => definition.handler.kind === "playground")
+}
+
+export function fuzzTargetCommandDefinitions(): CommandDefinition[] {
+  return runtimeCommandDefinitions().filter((definition) => !definition.metadata?.excludeFromFuzzTargets)
 }
 
 export function recipeCommandDefinitions(): CommandDefinition[] {

--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -122,7 +122,7 @@ export const RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES: FuzzSuiteRunnerCapab
   ],
   targetKinds: ["ability", "command", "http", "rest", "runtime", "runtime-action"],
   runtimeActionTypes: ["admin_page", "browser", "browser_probe", "crud_operation", "db_operation", "editor_open", "page", "php", "rest_request", "wp_cli"],
-  commands: ["wp-codebox.checkpoint-create", "wp-codebox.checkpoint-list", "wp-codebox.checkpoint-restore", "wordpress.ability", "wordpress.admin-page-load", "wordpress.browser-actions", "wordpress.browser-page-load", "wordpress.browser-probe", "wordpress.crud-operation", "wordpress.db-operation", "wordpress.editor-open", "wordpress.frontend-page-load", "wordpress.http-request", "wordpress.rest-performance-observation", "wordpress.rest-request", "wordpress.run-php", "wordpress.run-workload", "wordpress.server-page-load", "wordpress.simulated-admin-page-load", "wordpress.simulated-frontend-page-load", "wordpress.wp-cli"],
+  commands: ["wp-codebox.checkpoint-create", "wp-codebox.checkpoint-list", "wp-codebox.checkpoint-restore", "wordpress.ability", "wordpress.browser-actions", "wordpress.browser-page-load", "wordpress.browser-probe", "wordpress.crud-operation", "wordpress.db-operation", "wordpress.editor-open", "wordpress.http-request", "wordpress.rest-performance-observation", "wordpress.rest-request", "wordpress.run-php", "wordpress.run-workload", "wordpress.server-page-load", "wordpress.simulated-admin-page-load", "wordpress.simulated-frontend-page-load", "wordpress.wp-cli"],
   unsupportedRequiredCapabilities: [],
 }
 

--- a/packages/runtime-core/src/wordpress-page-load-contracts.ts
+++ b/packages/runtime-core/src/wordpress-page-load-contracts.ts
@@ -5,6 +5,7 @@ export const WORDPRESS_PAGE_LOAD_RESULT_SCHEMA = "wp-codebox/wordpress-page-load
 
 export type WordPressPageLoadCommand = "wordpress.admin-page-load" | "wordpress.frontend-page-load" | "wordpress.simulated-admin-page-load" | "wordpress.simulated-frontend-page-load" | "wordpress.server-page-load" | "wordpress.browser-page-load"
 export type WordPressPageLoadMode = "simulated" | "server-http" | "browser"
+export type WordPressPageLoadSource = "in-process" | "server-http" | "browser"
 export type WordPressPageLoadTargetKind = "admin" | "frontend"
 export type WordPressPageLoadStatus = "ok" | "redirect" | "error"
 
@@ -57,6 +58,7 @@ export interface WordPressPageLoadTarget {
 export interface WordPressPageLoadResult {
   schema: typeof WORDPRESS_PAGE_LOAD_RESULT_SCHEMA
   mode: WordPressPageLoadMode
+  source: WordPressPageLoadSource
   command: WordPressPageLoadCommand
   status: WordPressPageLoadStatus
   target: WordPressPageLoadTarget
@@ -75,10 +77,11 @@ export const WORDPRESS_PAGE_LOAD_RESULT_JSON_SCHEMA = {
   $id: WORDPRESS_PAGE_LOAD_RESULT_SCHEMA,
   type: "object",
   additionalProperties: true,
-  required: ["schema", "mode", "command", "status", "target"],
+  required: ["schema", "mode", "source", "command", "status", "target"],
   properties: {
     schema: { const: WORDPRESS_PAGE_LOAD_RESULT_SCHEMA },
     mode: { enum: ["simulated", "server-http", "browser"] },
+    source: { enum: ["in-process", "server-http", "browser"] },
     command: { enum: ["wordpress.admin-page-load", "wordpress.frontend-page-load", "wordpress.simulated-admin-page-load", "wordpress.simulated-frontend-page-load", "wordpress.server-page-load", "wordpress.browser-page-load"] },
     status: { enum: ["ok", "redirect", "error"] },
     target: {
@@ -111,6 +114,7 @@ export function wordpressPageLoadResult(input: Omit<WordPressPageLoadResult, "sc
   return stripUndefined({
     schema: WORDPRESS_PAGE_LOAD_RESULT_SCHEMA,
     mode: input.mode,
+    source: input.source,
     command: input.command,
     status: input.status,
     target: input.target,

--- a/packages/runtime-playground/src/http-request-command-handlers.ts
+++ b/packages/runtime-playground/src/http-request-command-handlers.ts
@@ -41,6 +41,7 @@ export async function runHttpRequest(input: HttpRequestCommandInput, baseUrl: st
     ...(command === "wordpress.server-page-load" ? {
       schema: "wp-codebox/wordpress-page-load-result/v1",
       mode: "server-http",
+      source: "server-http",
     } : {}),
     command,
     method: input.method,

--- a/packages/runtime-playground/src/page-load-command-handlers.ts
+++ b/packages/runtime-playground/src/page-load-command-handlers.ts
@@ -175,6 +175,7 @@ $wp_codebox_page_load_status = !empty($wp_codebox_page_load_errors) ? 'error' : 
 $wp_codebox_page_load_result = array(
     'schema' => 'wp-codebox/wordpress-page-load-result/v1',
     'mode' => 'simulated',
+    'source' => 'in-process',
     'command' => $wp_codebox_page_load_command,
     'status' => $wp_codebox_page_load_status,
     'target' => array('kind' => $wp_codebox_page_load_surface, 'path' => $wp_codebox_page_load_path, 'method' => $wp_codebox_page_load_method, 'query' => $wp_codebox_page_load_query, 'body' => $wp_codebox_page_load_body, 'userSession' => is_array($wp_codebox_page_load_user_session) ? $wp_codebox_page_load_user_session : null),

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1665,6 +1665,7 @@ function normalizeBrowserPageLoadOutput(output: string, surface: "admin" | "fron
     browserProbeSchema: entry.schema,
     schema: "wp-codebox/wordpress-page-load-result/v1",
     mode: "browser",
+    source: "browser",
     command: "wordpress.browser-page-load",
     status: browserPageLoadStatus(entry),
     target: { kind: surface, path, method: "GET" },
@@ -1678,6 +1679,7 @@ function normalizeBrowserPageLoadOutput(output: string, surface: "admin" | "fron
     parsed.outputs = normalizedOutputs
     parsed.schema = "wp-codebox/wordpress-page-load-result/v1"
     parsed.mode = "browser"
+    parsed.source = "browser"
     parsed.command = "wordpress.browser-page-load"
     parsed.status = normalizedOutputs.some((entry) => isRecord(entry) && entry.status === "error") ? "error" : "ok"
     parsed.target = { kind: surface, path, method: "GET" }

--- a/tests/page-load-command-contracts.test.ts
+++ b/tests/page-load-command-contracts.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { getCommandDefinition } from "../packages/runtime-core/src/contracts.js"
+import { RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, fuzzTargetCommandDefinitions, getCommandDefinition } from "../packages/runtime-core/src/contracts.js"
 import { httpRequestInputFromArgs } from "../packages/runtime-playground/src/commands.js"
 import { pageLoadInputFromArgs } from "../packages/runtime-playground/src/page-load-command-handlers.js"
 import { wordpressBrowserPageLoadAction, wordpressServerPageLoadAction, wordpressSimulatedAdminPageLoadAction, wordpressSimulatedFrontendPageLoadAction } from "../packages/runtime-playground/src/public.js"
@@ -14,14 +14,28 @@ const browserPageLoad = getCommandDefinition("wordpress.browser-page-load")
 assert.equal(adminAlias?.handler.kind, "playground")
 assert.equal(adminAlias?.handler.method, "runAdminPageLoad")
 assert.match(adminAlias?.description ?? "", /Backward-compatible alias/)
+assert.deepEqual(adminAlias?.metadata, { deprecated: true, aliasOnly: true, aliasFor: "wordpress.simulated-admin-page-load", excludeFromFuzzTargets: true })
 assert.equal(simulatedAdmin?.handler.kind, "playground")
 assert.equal(simulatedAdmin?.handler.method, "runAdminPageLoad")
+assert.equal(simulatedAdmin?.metadata?.deprecated, undefined)
 
 assert.equal(frontendAlias?.handler.kind, "playground")
 assert.equal(frontendAlias?.handler.method, "runFrontendPageLoad")
 assert.match(frontendAlias?.description ?? "", /Backward-compatible alias/)
+assert.deepEqual(frontendAlias?.metadata, { deprecated: true, aliasOnly: true, aliasFor: "wordpress.simulated-frontend-page-load", excludeFromFuzzTargets: true })
 assert.equal(simulatedFrontend?.handler.kind, "playground")
 assert.equal(simulatedFrontend?.handler.method, "runFrontendPageLoad")
+assert.equal(simulatedFrontend?.metadata?.deprecated, undefined)
+
+const fuzzTargetCommands = fuzzTargetCommandDefinitions().map((command) => command.id)
+assert.equal(fuzzTargetCommands.includes("wordpress.admin-page-load"), false)
+assert.equal(fuzzTargetCommands.includes("wordpress.frontend-page-load"), false)
+assert.equal(fuzzTargetCommands.includes("wordpress.simulated-admin-page-load"), true)
+assert.equal(fuzzTargetCommands.includes("wordpress.simulated-frontend-page-load"), true)
+assert.equal(RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES.commands.includes("wordpress.admin-page-load"), false)
+assert.equal(RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES.commands.includes("wordpress.frontend-page-load"), false)
+assert.equal(RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES.commands.includes("wordpress.simulated-admin-page-load"), true)
+assert.equal(RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES.commands.includes("wordpress.simulated-frontend-page-load"), true)
 
 assert.equal(serverPageLoad?.handler.kind, "playground")
 assert.equal(serverPageLoad?.handler.method, "runServerPageLoad")

--- a/tests/wordpress-page-load-contracts.test.ts
+++ b/tests/wordpress-page-load-contracts.test.ts
@@ -7,6 +7,7 @@ import { getCommandDefinition } from "../packages/runtime-core/src/contracts.js"
 
 const result = wordpressPageLoadResult({
   mode: "simulated",
+  source: "in-process",
   command: "wordpress.frontend-page-load",
   status: "ok",
   target: { kind: "frontend", path: "/hello-world/", method: "GET" },
@@ -15,6 +16,8 @@ const result = wordpressPageLoadResult({
     schema: "wp-codebox/performance-observation/v1",
     command: "wordpress.frontend-page-load",
     target: "/hello-world/",
+    source: "in-process",
+    kind: "simulated-page-load",
     database: { queryCount: 3, totalTimeMs: 1.25, fingerprints: [], repeatedQueries: [] },
     hooks: { timings: [] },
   },
@@ -23,9 +26,12 @@ const result = wordpressPageLoadResult({
 
 assert.equal(result.schema, WORDPRESS_PAGE_LOAD_RESULT_SCHEMA)
 assert.equal(result.mode, "simulated")
+assert.equal(result.source, "in-process")
 assert.equal(result.command, "wordpress.frontend-page-load")
 assert.equal(result.status, "ok")
 assert.equal(result.performance?.database?.queryCount, 3)
+assert.equal(result.performance?.source, "in-process")
+assert.equal(result.performance?.kind, "simulated-page-load")
 assert.equal(result.artifactRefs?.[0]?.kind, "wordpress-page-load-result")
 
 const adminDefinition = getCommandDefinition("wordpress.admin-page-load")


### PR DESCRIPTION
## Summary
- Clarifies simulated page-load aliases as backward-compatible in-process command modes.
- Adds page-load result source metadata for simulated, server HTTP, and browser command outputs.
- Keeps deprecated aliases out of fuzz targets and covers the contract changes with focused tests.

## Tests
- npx tsx tests/page-load-command-contracts.test.ts
- npx tsx tests/wordpress-page-load-contracts.test.ts
- npm run build
- npx tsx scripts/command-registry-smoke.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Clarified page-load command modes, alias metadata, and focused tests.