### PR TITLE
Stage runtime package bundle sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "test:redaction": "tsx tests/redaction.test.ts",
     "test:legacy-agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",
     "test:agent-runtime-workload-normalizers": "tsx tests/agent-runtime-workload-normalizers.test.ts",
+    "test:agent-task-runtime-package-staging": "tsx tests/agent-task-runtime-package-staging.test.ts",
     "test:browser-task-builder": "tsx tests/browser-task-builder.test.ts",
     "test:browser-runtime-generic-invoker": "tsx tests/browser-runtime-generic-invoker.test.ts",
     "test:browser-visual-compare-blocks-engine-adapter": "tsx tests/browser-visual-compare-blocks-engine-adapter.test.ts",

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -86,8 +86,7 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   const artifacts = stringValue(input.artifacts_path)
   const profile = runtimeOverlayProfileDefaults(input)
   const runtimeMounts = runtimeStateMounts(input)
-  const agentBundleStagedFiles = stagedAgentBundleSources(input.agent_bundles)
-  const stagedFiles = [...(Array.isArray(input.stagedFiles) ? input.stagedFiles : []), ...agentBundleStagedFiles]
+  const stagedFiles = stagedRuntimeSources(input)
   const providerPlugins = providerPluginEntries(input, artifacts)
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
   const providerContracts = providerPlugins.map((plugin) => ({ slug: plugin.slug, pluginFile: plugin.pluginFile, loadAs: plugin.loadAs ?? "plugin" }))
@@ -336,6 +335,22 @@ function componentMountedPath(slug: string, loadAs: "plugin" | "mu-plugin"): str
     : `/wordpress/wp-content/plugins/${slug}`
 }
 
+function stagedRuntimeSources(input: AgentTaskRunInput): WorkspaceRecipeStagedFile[] {
+  const stagedFiles: WorkspaceRecipeStagedFile[] = []
+  const seenTargets = new Set<string>()
+  for (const stagedFile of Array.isArray(input.stagedFiles) ? input.stagedFiles : []) {
+    if (!stagedFile?.target || seenTargets.has(stagedFile.target)) continue
+    stagedFiles.push(stagedFile)
+    seenTargets.add(stagedFile.target)
+  }
+  for (const stagedFile of [...stagedAgentBundleSources(input.agent_bundles), ...stagedRuntimePackageSources(input.runtime_task)]) {
+    if (!stagedFile.target || seenTargets.has(stagedFile.target)) continue
+    stagedFiles.push(stagedFile)
+    seenTargets.add(stagedFile.target)
+  }
+  return stagedFiles
+}
+
 function stagedAgentBundleSources(agentBundles: AgentTaskRunInput["agent_bundles"]): WorkspaceRecipeStagedFile[] {
   if (!Array.isArray(agentBundles)) return []
 
@@ -353,6 +368,18 @@ function stagedAgentBundleSources(agentBundles: AgentTaskRunInput["agent_bundles
     seenTargets.add(source)
   }
   return stagedFiles
+}
+
+function stagedRuntimePackageSources(runtimeTask: AgentTaskRunInput["runtime_task"]): WorkspaceRecipeStagedFile[] {
+  const runtimeTaskInput = objectValue(runtimeTask?.input)
+  const runtimePackage = objectValue(runtimeTaskInput?.package)
+  const source = stringValue(runtimePackage?.source)
+  if (!source) return []
+
+  const localSource = localAgentBundleSource(source)
+  if (!localSource) return []
+
+  return [{ source: localSource, target: source }]
 }
 
 function localAgentBundleSource(source: string): string {

--- a/tests/agent-task-runtime-package-staging.test.ts
+++ b/tests/agent-task-runtime-package-staging.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict"
+import { mkdir } from "node:fs/promises"
+import { join } from "node:path"
+
+import { buildAgentTaskRecipe } from "../packages/runtime-core/src/agent-task-recipe.js"
+import type { TaskInput } from "../packages/runtime-core/src/task-input.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+const taskInput: TaskInput = {
+  schema: "wp-codebox/task-input/v1",
+  version: 1,
+  goal: "Replay runtime package",
+  target: {},
+  allowed_tools: [],
+  expected_artifacts: [],
+  structured_artifacts: [],
+  staged_files: [],
+  agent_bundles: [],
+  tool_bridge: {},
+  parent_tool_bridge: {},
+  sandbox_tool_policy: {},
+  policy: {},
+  context: {},
+}
+
+await withTempDir("wp-codebox-runtime-package-staging-", async (root) => {
+  const previousCwd = process.cwd()
+  const workspaceRoot = join(root, "wp-site-generator")
+  const bundleSource = join(workspaceRoot, "bundles", "store-idea-agent")
+  await mkdir(bundleSource, { recursive: true })
+
+  try {
+    process.chdir(workspaceRoot)
+    const runtimeTask = {
+      kind: "bundle",
+      ability: "wp-codebox/run-runtime-package",
+      input: {
+        schema: "wp-codebox/runtime-package-task/v1",
+        package: {
+          slug: "store-idea-agent",
+          source: "/workspace/wp-site-generator/bundles/store-idea-agent",
+        },
+        workflow: { id: "store-idea-agent" },
+        input: { prompt: "Generate store idea" },
+        artifact_declarations: [],
+        required_artifacts: [],
+      },
+    }
+    const recipe = buildAgentTaskRecipe({ runtime_task: runtimeTask }, taskInput, "latest")
+    assert.equal(recipe.inputs?.stagedFiles?.length, 1)
+    assert.equal(recipe.inputs?.stagedFiles?.[0]?.target, "/workspace/wp-site-generator/bundles/store-idea-agent")
+    assert.ok(recipe.inputs?.stagedFiles?.[0]?.source.endsWith("/wp-site-generator/bundles/store-idea-agent"))
+
+    const runtimeTaskArg = recipe.workflow.steps[0].args?.find((arg) => arg.startsWith("runtime-task-json="))
+    assert.ok(runtimeTaskArg)
+    const encodedRuntimeTask = JSON.parse(runtimeTaskArg.slice("runtime-task-json=".length))
+    assert.deepEqual(encodedRuntimeTask.input.package, runtimeTask.input.package)
+    assert.equal(JSON.stringify(encodedRuntimeTask).includes("runtime_package"), false)
+  } finally {
+    process.chdir(previousCwd)
+  }
+})
+
+await withTempDir("wp-codebox-runtime-package-staging-dedupe-", async (root) => {
+  const previousCwd = process.cwd()
+  const workspaceRoot = join(root, "wp-site-generator")
+  const bundleSource = join(workspaceRoot, "bundles", "store-idea-agent")
+  await mkdir(bundleSource, { recursive: true })
+
+  try {
+    process.chdir(workspaceRoot)
+    const recipe = buildAgentTaskRecipe({
+      stagedFiles: [{ source: bundleSource, target: "/workspace/wp-site-generator/bundles/store-idea-agent" }],
+      runtime_task: {
+        input: {
+          package: {
+            slug: "store-idea-agent",
+            source: "/workspace/wp-site-generator/bundles/store-idea-agent",
+          },
+        },
+      },
+    }, taskInput, "latest")
+    assert.deepEqual(recipe.inputs?.stagedFiles, [{ source: bundleSource, target: "/workspace/wp-site-generator/bundles/store-idea-agent" }])
+  } finally {
+    process.chdir(previousCwd)
+  }
+})
+
+console.log("agent task runtime package staging ok")


### PR DESCRIPTION
## Summary
- Stage canonical runtime-package bundle sources from `runtime_task.input.package.source` when building agent task recipes.
- Preserve the canonical runtime task payload while making host-backed `/workspace/...` package sources readable in the Playground VFS.
- Dedupe staged targets across explicit staged files, agent bundles, and runtime-package sources.

## Tests
- `npm run build`
- `npm run test:agent-task-runtime-package-staging`
- `npm run test:host-recipe-builder`
- `npm run test:agent-runtime-workload-normalizers`
- `npm run test:runtime-package-execution`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the runtime-package source staging fix, focused recipe staging tests, and verification.