### PR TITLE
Materialize staged inputs before workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "test:schema-parity": "tsx tests/schema-parity.test.ts",
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
     "test:recipe-runtime-backend-normalization": "tsx tests/recipe-runtime-backend-normalization.test.ts",
+    "test:recipe-runtime-setup-staged-materialization": "tsx tests/recipe-runtime-setup-staged-materialization.test.ts",
     "test:fuzz-run-recipe": "tsx tests/fuzz-run-recipe.test.ts",
     "test:fuzz-suite-runner": "tsx tests/fuzz-suite-runner.test.ts",
     "test:playground-fuzz-suite-public": "tsx tests/playground-fuzz-suite-public.test.ts",

--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -177,6 +177,18 @@ export async function applyRecipeRuntimeSetup(args: {
     interruption?.throwIfInterrupted()
   }
 
+  if (stagedFiles.length > 0 && typeof runtime.materializeMounts === "function") {
+    const stagedMounts = stagedFiles.map((stagedFile) => ({
+      type: stagedFile.type,
+      source: stagedFile.source,
+      target: stagedFile.target,
+      mode: "readwrite" as const,
+      metadata: stagedFile.metadata,
+    }))
+    await awaitRecipe("staged-file.materialize", () => runtime.materializeMounts!(stagedMounts))
+    interruption?.throwIfInterrupted()
+  }
+
   const muPluginInstallCode = installMuPluginsCode(extraPlugins)
   if (muPluginInstallCode) {
     executions.push(withRecipeExecutionPhase(await runtime.execute({ command: "wordpress.run-php", args: setupPhpArgs(muPluginInstallCode) }), "setup", -2, "extra-plugin.install-mu-loader"))

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -1173,6 +1173,7 @@ export interface ArtifactBundle {
 export interface Runtime {
   info(): Promise<RuntimeInfo>
   mount(spec: MountSpec): Promise<void>
+  materializeMounts?(mounts: MountSpec[]): Promise<unknown>
   execute(spec: ExecutionSpec): Promise<ExecutionResult>
   observe(spec: ObservationSpec): Promise<ObservationResult>
   snapshot(options?: unknown): Promise<Snapshot>

--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { materializationPhaseResult, namedFileTreeSkipPolicyNames, phpStringArrayLiteral, type MaterializationPhaseResult, type MountSpec } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliServer } from "./preview-server.js"
@@ -27,6 +27,11 @@ export interface MountMaterializationResult {
   deleted: number
   skipped: number
   phaseResult: MaterializationPhaseResult
+}
+
+interface HostMountFilePayload {
+  target: string
+  contentsBase64: string
 }
 
 function mountMaterializationResult(input: Omit<MountMaterializationResult, "phaseResult">): MountMaterializationResult {
@@ -60,6 +65,43 @@ export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliSe
   const response = await server.playground.run({ code: vfsMountSnapshotPhp(hostSnapshots) })
   const parsed = JSON.parse(response.text || "{}") as { mounts?: VfsMountSnapshot[] }
   return applyVfsMountSnapshots(mounts, parsed.mounts ?? [])
+}
+
+export async function materializePlaygroundMountsToVfs(server: PlaygroundCliServer, mounts: MountSpec[]): Promise<MountMaterializationResult> {
+  const files: HostMountFilePayload[] = []
+  let skipped = 0
+  for (const mount of mounts) {
+    const collected = await hostMountFilesForVfs(mount)
+    files.push(...collected.files)
+    skipped += collected.skipped
+  }
+  if (files.length === 0) {
+    return {
+      materialized: 0,
+      deleted: 0,
+      skipped,
+      phaseResult: materializationPhaseResult({
+        phase: "playground-host-mount-materialization",
+        status: "skipped",
+        metadata: { materialized: 0, deleted: 0, skipped },
+      }),
+    }
+  }
+
+  const response = await server.playground.run({ code: hostMountWritePhp(files) })
+  const parsed = JSON.parse(response.text || "{}") as { materialized?: number; skipped?: number }
+  const materialized = parsed.materialized ?? 0
+  const totalSkipped = skipped + (parsed.skipped ?? 0)
+  return {
+    materialized,
+    deleted: 0,
+    skipped: totalSkipped,
+    phaseResult: materializationPhaseResult({
+      phase: "playground-host-mount-materialization",
+      status: materialized > 0 ? "completed" : "skipped",
+      metadata: { materialized, deleted: 0, skipped: totalSkipped },
+    }),
+  }
 }
 
 export async function applyVfsMountSnapshots(mounts: MountSpec[], snapshots: VfsMountSnapshot[]): Promise<MountMaterializationResult> {
@@ -154,6 +196,83 @@ async function hostFileHashes(directory: string, relativeDirectory = ""): Promis
   }
 
   return files
+}
+
+async function hostMountFilesForVfs(mount: MountSpec): Promise<{ files: HostMountFilePayload[]; skipped: number }> {
+  const files: HostMountFilePayload[] = []
+  let skipped = 0
+  let sourceStat
+  try {
+    sourceStat = await stat(mount.source)
+  } catch {
+    return { files, skipped: 1 }
+  }
+
+  if (mount.type === "file" || sourceStat.isFile()) {
+    files.push({ target: mount.target, contentsBase64: (await readFile(mount.source)).toString("base64") })
+    return { files, skipped }
+  }
+  if (!sourceStat.isDirectory()) {
+    return { files, skipped: skipped + 1 }
+  }
+
+  for (const file of await hostMountDirectoryFiles(mount.source)) {
+    files.push({ target: `${mount.target.replace(/\/+$/, "")}/${file.relativePath}`, contentsBase64: file.contentsBase64 })
+  }
+  return { files, skipped }
+}
+
+async function hostMountDirectoryFiles(directory: string, relativeDirectory = ""): Promise<Array<{ relativePath: string; contentsBase64: string }>> {
+  const files: Array<{ relativePath: string; contentsBase64: string }> = []
+  let entries
+  try {
+    entries = await readdir(join(directory, relativeDirectory), { withFileTypes: true })
+  } catch {
+    return files
+  }
+
+  for (const entry of entries) {
+    const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
+    const absolutePath = join(directory, relativePath)
+    if (entry.isDirectory()) {
+      files.push(...await hostMountDirectoryFiles(directory, relativePath))
+      continue
+    }
+    if (!entry.isFile()) {
+      continue
+    }
+    files.push({ relativePath, contentsBase64: (await readFile(absolutePath)).toString("base64") })
+  }
+  return files
+}
+
+function hostMountWritePhp(files: HostMountFilePayload[]): string {
+  const payload = JSON.stringify(JSON.stringify({ files }))
+  return `<?php
+$payload = json_decode(${payload}, true);
+$materialized = 0;
+$skipped = 0;
+foreach (($payload['files'] ?? array()) as $file) {
+    $target = (string) ($file['target'] ?? '');
+    $contents = (string) ($file['contentsBase64'] ?? '');
+    if ('' === $target || str_contains($target, "\0")) {
+        $skipped++;
+        continue;
+    }
+    $directory = dirname($target);
+    if (!is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+        $skipped++;
+        continue;
+    }
+    $decoded = base64_decode($contents, true);
+    if (false === $decoded || false === file_put_contents($target, $decoded)) {
+        $skipped++;
+        continue;
+    }
+    $materialized++;
+}
+echo json_encode(array('schema' => 'wp-codebox/host-mount-materialization/v1', 'materialized' => $materialized, 'skipped' => $skipped), JSON_UNESCAPED_SLASHES);
+`
 }
 
 export function vfsMountSnapshotPhp(hostSnapshots: HostMountSnapshot[]): string {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -18,7 +18,7 @@ import { PlaygroundCommandCrashError, assertPlaygroundResponseOk, errorMessage, 
 import { startPlaygroundCliServer, type PlaygroundCliModule } from "./playground-cli-runner.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { collectPlaygroundArtifacts } from "./runtime-artifact-helpers.js"
-import { materializePlaygroundMountsFromVfs } from "./mount-materialization.js"
+import { materializePlaygroundMountsFromVfs, materializePlaygroundMountsToVfs } from "./mount-materialization.js"
 import { runAbilityCommand, runBenchCommand, runCorePhpunitCommand, runHttpRequestCommand, runPageLoadCommand, runPhpCommand, runPhpunitCommand, runPluginCheckCommand, runPluginSetupCommand, runPluginStateCommand, runRestPerformanceObservationCommand, runRestRequestCommand, runRuntimeDiscoveryCommand, runRuntimeInventoryCommand, runServerPageLoadCommand, runThemeCheckCommand, runThemeSetupCommand } from "./wordpress-command-runners.js"
 import { PlaygroundSnapshotRestoreError, contentDigest, mountsFromSnapshot, runtimeSnapshotExportPayload, runtimeSnapshotExportPhp, runtimeSnapshotPayload, runtimeSnapshotRestorePhp, runtimeSpecFromSnapshot, snapshotDigest, type RuntimeSnapshotArtifact, type RuntimeSnapshotExportOptions } from "./runtime-snapshot.js"
 import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-cli-bridge.js"
@@ -261,6 +261,16 @@ class PlaygroundRuntime implements Runtime {
 
     this.mounts.push(mount)
     this.recordEvent("runtime.mounted", { mount })
+  }
+
+  async materializeMounts(mounts: MountSpec[]): Promise<unknown> {
+    if (this.status === "destroyed" || mounts.length === 0) {
+      return undefined
+    }
+
+    const materialization = await materializePlaygroundMountsToVfs(await this.bootPlayground(), mounts)
+    this.recordEvent("runtime.mounts.materialized", { ...materialization, source: "host-to-vfs" })
+    return materialization
   }
 
   async execute(spec: ExecutionSpec): Promise<ExecutionResult> {

--- a/tests/recipe-runtime-setup-staged-materialization.test.ts
+++ b/tests/recipe-runtime-setup-staged-materialization.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+
+import { applyRecipeRuntimeSetup, type PreparedRecipeRuntimeSetup } from "../packages/cli/src/commands/recipe-runtime-setup.js"
+import type { Runtime, WorkspaceRecipe } from "../packages/runtime-core/src/public.js"
+
+const calls: string[] = []
+const recipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  runtime: { backend: "wordpress-playground" },
+  inputs: {},
+  workflow: { steps: [] },
+}
+const prepared: PreparedRecipeRuntimeSetup = {
+  workspaceMounts: [],
+  extraPlugins: [],
+  dependencyOverlays: [],
+  overlays: [],
+  inputMountBaselinePaths: [],
+  stagedFiles: [{
+    source: "/tmp/host-bundle",
+    originalSource: "/tmp/host-bundle",
+    sourceRef: "/tmp/host-bundle",
+    target: "/workspace/example/bundles/runtime-agent",
+    type: "directory",
+    cleanupPaths: [],
+    provenance: { type: "local", source: "/tmp/host-bundle" },
+    metadata: { kind: "runtime-package-source" },
+  }],
+}
+
+const runtime = {
+  async info() { return { id: "runtime", backend: "wordpress-playground", environment: { kind: "wordpress" }, createdAt: new Date().toISOString(), status: "running" } },
+  async mount(spec) { calls.push(`mount:${spec.target}`) },
+  async materializeMounts(mounts) {
+    calls.push(`materialize:${mounts.map((mount) => mount.target).join(",")}`)
+    assert.deepEqual(mounts, [{
+      type: "directory",
+      source: "/tmp/host-bundle",
+      target: "/workspace/example/bundles/runtime-agent",
+      mode: "readwrite",
+      metadata: { kind: "runtime-package-source" },
+    }])
+  },
+  async execute(spec) { calls.push(`execute:${spec.command}`); throw new Error("setup should not execute commands in this fixture") },
+  async observe() { throw new Error("unused") },
+  async snapshot() { throw new Error("unused") },
+  async collectArtifacts() { throw new Error("unused") },
+  async destroy() {},
+} satisfies Runtime
+
+const phaseExecutor = {
+  tracker: {
+    complete(name: string) { calls.push(`phase.complete:${name}`) },
+    async run<T>(name: string, _data: unknown, callback: () => Promise<T>) { calls.push(`phase.run:${name}`); return await callback() },
+    list() { return [] },
+  },
+  async operation<T>(operation: string, promiseOrFactory: Promise<T> | (() => Promise<T>)) {
+    calls.push(`operation:${operation}`)
+    return await (typeof promiseOrFactory === "function" ? promiseOrFactory() : promiseOrFactory)
+  },
+}
+
+await applyRecipeRuntimeSetup({ recipe, recipeDirectory: process.cwd(), runtime, prepared, phaseExecutor: phaseExecutor as never })
+
+const mountIndex = calls.indexOf("mount:/workspace/example/bundles/runtime-agent")
+const materializeOperationIndex = calls.indexOf("operation:staged-file.materialize")
+const materializeIndex = calls.indexOf("materialize:/workspace/example/bundles/runtime-agent")
+assert.ok(mountIndex >= 0, "staged source is mounted")
+assert.ok(materializeOperationIndex > mountIndex, "materialization is scheduled after staged mount")
+assert.ok(materializeIndex > materializeOperationIndex, "materialization runs inside the setup phase before commands")
+assert.equal(calls.some((call) => call.startsWith("execute:")), false)
+
+console.log("recipe runtime setup staged materialization ok")


### PR DESCRIPTION
## Summary
- Add explicit host-to-Playground VFS materialization for staged input mounts.
- Call staged input materialization during recipe runtime setup immediately after staged mounts are registered and before setup/workflow commands run.
- Keep staged targets unchanged, including canonical `/workspace/<slug>/...` runtime-package sources.
- Add setup-order coverage proving staged inputs are materialized before command execution.

## Tests
- `npm run build`
- `npm run test:recipe-runtime-setup-staged-materialization`
- `npm run test:agent-task-runtime-package-staging`
- `npm run test:host-recipe-builder`
- `npm run test:runtime-package-execution`
- `npm run test:recipe-runtime-backend-normalization`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing staged input VFS materialization, setup-order coverage, and focused verification.