### PR TITLE
Preserve host files during VFS materialization

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -169,8 +169,6 @@ export async function applyVfsMountSnapshots(mounts: MountSpec[], snapshots: Vfs
       present.add(file.relativePath)
       writableFiles.push(file)
     }
-    const existing = await hostFileHashes(mount.source)
-
     for (const file of writableFiles) {
       if (file.contentsBase64 === undefined) {
         continue
@@ -185,17 +183,20 @@ export async function applyVfsMountSnapshots(mounts: MountSpec[], snapshots: Vfs
       result.materialized++
     }
 
-    for (const relativePath of Object.keys(existing)) {
-      if (present.has(relativePath)) {
-        continue
+    if (mount.metadata && typeof mount.metadata === "object" && !Array.isArray(mount.metadata) && (mount.metadata as { materializeDeletes?: unknown }).materializeDeletes === true) {
+      const existing = await hostFileHashes(mount.source)
+      for (const relativePath of Object.keys(existing)) {
+        if (present.has(relativePath)) {
+          continue
+        }
+        const hostPath = containedHostPath(mount.source, relativePath)
+        if (!hostPath) {
+          result.skipped++
+          continue
+        }
+        await rm(hostPath, { force: true })
+        result.deleted++
       }
-      const hostPath = containedHostPath(mount.source, relativePath)
-      if (!hostPath) {
-        result.skipped++
-        continue
-      }
-      await rm(hostPath, { force: true })
-      result.deleted++
     }
   }
 

--- a/tests/mount-materialization-non-destructive.test.ts
+++ b/tests/mount-materialization-non-destructive.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { applyVfsMountSnapshots } from "../packages/runtime-playground/src/mount-materialization.js"
+
+const root = await mkdtemp(join(tmpdir(), "wp-codebox-mount-materialization-"))
+
+try {
+  await writeFile(join(root, "host-only.txt"), "keep me")
+
+  await applyVfsMountSnapshots([{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite" }], [{
+    mountIndex: 0,
+    target: "/workspace/example",
+    files: [{ relativePath: "changed.txt", sha256: "", contentsBase64: Buffer.from("changed").toString("base64") }],
+  }])
+
+  assert.equal(await readFile(join(root, "host-only.txt"), "utf8"), "keep me", "host-only files are preserved by default")
+  assert.equal(await readFile(join(root, "changed.txt"), "utf8"), "changed", "changed VFS files are written back")
+
+  await applyVfsMountSnapshots([{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite", metadata: { materializeDeletes: true } }], [{
+    mountIndex: 0,
+    target: "/workspace/example",
+    files: [{ relativePath: "changed.txt", sha256: "" }],
+  }])
+
+  await assert.rejects(readFile(join(root, "host-only.txt"), "utf8"), "explicit delete opt-in removes host-only files")
+} finally {
+  await rm(root, { recursive: true, force: true })
+}
+
+console.log("mount materialization non-destructive ok")


### PR DESCRIPTION
## Summary
- Stop VFS-to-host materialization from deleting host files by default.
- Require explicit `metadata.materializeDeletes: true` on a mount before missing VFS files remove host files.
- Add regression coverage for preserving host-only files during materialization.

## Testing
- `npm run build`
- `npx tsx tests/mount-materialization-non-destructive.test.ts`
- `npm run test:recipe-runtime-setup-staged-materialization`
- `npm run test:agent-task-runtime-package-staging`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing host worktree deletion during Codebox artifact collection and drafting the fix/tests.
