### PR TITLE
Add browser runtime task SDK

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -213,6 +213,12 @@ The stable public surface is grouped by lifecycle area rather than by product:
   starts a Codebox browser preview from the boot DTO and returns
   `wp-codebox/browser-preview-start-result/v1`; `runBrowserSessionRecipe()`
   executes the existing runtime helper and returns the stable browser-run DTO;
+  `createRuntimeTaskRequest()` builds the public
+  `wp-codebox/runtime-task-request/v1` envelope with an explicit `target_id`;
+  `runRuntimeTask()` posts that envelope to Codebox's public
+  `/wp-json/wp-codebox/v1/runtime-task` route, or calls a supplied
+  `executeAbility('wp-codebox/run-runtime-task', request)` adapter, and returns
+  `wp-codebox/runtime-task-result/v1`;
   `methods` exposes stable references to the existing browser runtime helpers for
   callers that need legacy raw results internally. TypeScript consumers outside
   the browser can use the matching DTO helpers exported from

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -11,6 +11,8 @@
 		'browser-runtime:normalize-error',
 		'browser-runtime:normalize-result',
 		'browser-runtime:normalize-browser-run-result',
+		'runtime-task:create-request',
+		'runtime-task:run',
 		'browser-preview:start',
 		'browser-contained-site-sync:consume',
 		'browser-runtime:boot-executable-session',
@@ -335,6 +337,80 @@
 		},
 	} );
 
+	const runtimeTaskRestEndpoint = () => {
+		const root = window.wpApiSettings?.root || window.wp?.apiFetch?.root;
+		if ( typeof root === 'string' && root ) {
+			return new URL( 'wp-codebox/v1/runtime-task', root ).toString();
+		}
+
+		return new URL( '/wp-json/wp-codebox/v1/runtime-task', window.location.origin ).toString();
+	};
+
+	const codeboxRestHeaders = () => {
+		const nonce = window.wpApiSettings?.nonce;
+		return {
+			'Content-Type': 'application/json',
+			...( typeof nonce === 'string' && nonce ? { 'X-WP-Nonce': nonce } : {} ),
+		};
+	};
+
+	const createRuntimeTaskRequest = ( input = {}, defaults = {} ) => {
+		const source = isPlainObject( input ) ? input : { task: input };
+		const fallback = isPlainObject( defaults ) ? defaults : {};
+		const targetId = source.target_id || source.targetId || fallback.target_id || fallback.targetId;
+		const task = source.task ?? fallback.task;
+		if ( typeof targetId !== 'string' || ! targetId.trim() ) {
+			throw runtimeError( 'runtime_task_request', 'runtime_task_target_id_required', 'Runtime task requests require an explicit target_id.' );
+		}
+		if ( ! isPlainObject( task ) && ( typeof task !== 'string' || ! task.trim() ) ) {
+			throw runtimeError( 'runtime_task_request', 'runtime_task_required', 'Runtime task requests require a task string or object.' );
+		}
+
+		const request = {
+			...( isPlainObject( fallback ) ? fallback : {} ),
+			...source,
+			schema: 'wp-codebox/runtime-task-request/v1',
+			target_id: targetId.trim(),
+			task,
+		};
+		delete request.targetId;
+
+		return request;
+	};
+
+	const runRuntimeTask = async ( input = {}, options = {} ) => {
+		const request = input?.schema === 'wp-codebox/runtime-task-request/v1' ? input : createRuntimeTaskRequest( input, options.defaults || {} );
+		if ( typeof options.executeRuntimeTask === 'function' ) {
+			return options.executeRuntimeTask( request );
+		}
+		if ( typeof options.executeAbility === 'function' ) {
+			return options.executeAbility( 'wp-codebox/run-runtime-task', request );
+		}
+		if ( window.wp?.apiFetch ) {
+			return window.wp.apiFetch( {
+				path: '/wp-codebox/v1/runtime-task',
+				method: 'POST',
+				data: request,
+			} );
+		}
+		if ( typeof fetch !== 'function' ) {
+			throw runtimeError( 'runtime_task_run', 'runtime_task_fetch_unavailable', 'Browser fetch or wp.apiFetch is required to run runtime tasks.' );
+		}
+
+		const response = await fetch( runtimeTaskRestEndpoint(), {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: codeboxRestHeaders(),
+			body: JSON.stringify( request ),
+		} );
+		const data = await response.json().catch( () => null );
+		if ( ! response.ok ) {
+			throw runtimeError( 'runtime_task_run', data?.code || 'runtime_task_request_failed', data?.message || 'Runtime task request failed.', { status: response.status, response: data } );
+		}
+
+		return data;
+	};
+
 	const containedSiteSyncRoute = ( delegation, name ) => {
 		const route = String( delegation?.routes?.[ name ] || '' );
 		if ( ! route.startsWith( '/' ) || route.startsWith( '//' ) ) {
@@ -571,6 +647,8 @@
 		normalizeError: normalizeBrowserSdkError,
 		normalizeBrowserRunResult,
 		browserArtifactPersistenceRef,
+		createRuntimeTaskRequest,
+		runRuntimeTask,
 		consumeContainedSiteSync: ( client, delegation, options = {} ) => api.consumeContainedSiteSync( client, delegation, options ),
 		startBrowserPreview: ( input, options = {} ) => api.startBrowserPreview( input, options ),
 		aggregateFanoutOutputs: ( input ) => api.aggregateFanoutOutputs( input ),

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -82,6 +82,15 @@ final class WP_Codebox_Abilities {
 		);
 		register_rest_route(
 			'wp-codebox/v1',
+			'/runtime-task',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( self::class, 'rest_runtime_task' ),
+				'permission_callback' => array( self::class, 'can_run_agent_task' ),
+			)
+		);
+		register_rest_route(
+			'wp-codebox/v1',
 			'/browser-callback/(?P<capability>[A-Za-z0-9][A-Za-z0-9_-]*)',
 			array(
 				'methods'             => 'POST',
@@ -144,6 +153,16 @@ final class WP_Codebox_Abilities {
 		}
 
 		return self::execute_browser_provider_request( $input );
+	}
+
+	/** @param WP_REST_Request $request REST request. @return array<string,mixed>|WP_Error */
+	public static function rest_runtime_task( WP_REST_Request $request ): array|WP_Error {
+		$input = $request->get_json_params();
+		if ( ! is_array( $input ) ) {
+			return new WP_Error( 'wp_codebox_runtime_task_rest_payload_invalid', 'Runtime task requests must send a JSON object.', array( 'status' => 400 ) );
+		}
+
+		return WP_Codebox_API::run_runtime_task( $input );
 	}
 
 	/** @param WP_REST_Request $request REST request. @return array<string,mixed>|WP_Error */

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -32,6 +32,8 @@ assert.deepEqual(plain(api.v1.info()), {
     "browser-runtime:normalize-error",
     "browser-runtime:normalize-result",
     "browser-runtime:normalize-browser-run-result",
+    "runtime-task:create-request",
+    "runtime-task:run",
     "browser-preview:start",
     "browser-contained-site-sync:consume",
     "browser-runtime:boot-executable-session",
@@ -64,6 +66,8 @@ assert.equal(typeof api.v1.consumeContainedSiteSync, "function")
 assert.equal(typeof api.v1.bootExecutableBrowserSession, "function")
 assert.equal(typeof api.v1.createParentToolRequest, "function")
 assert.equal(typeof api.v1.validateBrowserRuntimeMaterialization, "function")
+assert.equal(typeof api.v1.createRuntimeTaskRequest, "function")
+assert.equal(typeof api.v1.runRuntimeTask, "function")
 assert.deepEqual(plain(api.v1.normalizeError(Object.assign(new Error("Nope"), { code: "demo_error", phase: "probe", status: 418, data: { demo: true } }))), {
   schema: "wp-codebox/browser-sdk-error/v1",
   code: "demo_error",
@@ -233,6 +237,38 @@ assert.deepEqual(plain(canonicalBrowserRun.diagnostics), [
 ])
 assert.equal(canonicalBrowserRun.error.schema, "wp-codebox/browser-sdk-error/v1")
 assert.equal(canonicalBrowserRun.error.code, "canonical-failed")
+
+const runtimeTaskRequest = api.v1.createRuntimeTaskRequest({
+  targetId: "wp-codebox/browser-playground",
+  task: "Run the browser task",
+  input: { goal: "Run the browser task" },
+})
+assert.deepEqual(plain(runtimeTaskRequest), {
+  schema: "wp-codebox/runtime-task-request/v1",
+  target_id: "wp-codebox/browser-playground",
+  task: "Run the browser task",
+  input: { goal: "Run the browser task" },
+})
+assert.throws(
+  () => api.v1.createRuntimeTaskRequest({ task: "missing target" }),
+  (error: any) => {
+    assert.equal(error.code, "runtime_task_target_id_required")
+    return true
+  },
+)
+
+const previousWp = (sandbox.window as any).wp
+const runtimeTaskCalls: any[] = []
+;(sandbox.window as any).wp = {
+  apiFetch: async (request: any) => {
+    runtimeTaskCalls.push(request)
+    return { schema: "wp-codebox/runtime-task-result/v1", success: true, status: "completed", result: { ok: true } }
+  },
+}
+const runtimeTaskResult = await api.v1.runRuntimeTask(runtimeTaskRequest)
+assert.equal(runtimeTaskResult.schema, "wp-codebox/runtime-task-result/v1")
+assert.deepEqual(plain(runtimeTaskCalls), [{ path: "/wp-codebox/v1/runtime-task", method: "POST", data: plain(runtimeTaskRequest) }])
+;(sandbox.window as any).wp = previousWp
 
 assert.deepEqual(plain(api.v1.browserArtifactPersistenceRef({
   schema: "wp-codebox/browser-artifact-persistence/ref/v1",

--- a/tests/wordpress-plugin-public-runtime-abilities.test.ts
+++ b/tests/wordpress-plugin-public-runtime-abilities.test.ts
@@ -11,6 +11,9 @@ for (const ability of ["wp-codebox/run-wordpress-workload", "wp-codebox/run-fuzz
 }
 
 assert.match(abilitiesPhp, /'wp-codebox\/run-wordpress-workload'[\s\S]{0,700}'execute_callback'\s*=>\s*array\(\s*self::class,\s*'run_wordpress_workload'\s*\)/, "WordPress workload is implemented by the public ability")
+assert.match(abilitiesPhp, /register_rest_route\(\s*'wp-codebox\/v1',\s*'\/runtime-task'[\s\S]{0,300}'callback'\s*=>\s*array\(\s*self::class,\s*'rest_runtime_task'\s*\)/, "Runtime task REST route must be Codebox-owned")
+assert.match(abilitiesPhp, /function rest_runtime_task\( WP_REST_Request \$request \)/, "Runtime task REST route callback must be present")
+assert.match(abilitiesPhp, /WP_Codebox_API::run_runtime_task\( \$input \)/, "Runtime task REST route must delegate through the public PHP facade")
 assert.doesNotMatch(abilitiesPhp, /'wp-codebox\/run-wordpress-workload'[\s\S]{0,700}'safe_stub'\s*=>\s*true/, "WordPress workload is implemented and must not be marked as a safe stub")
 assert.doesNotMatch(abilitiesPhp, /'wp-codebox\/run-fuzz-suite'[\s\S]{0,700}'safe_stub'\s*=>\s*true/, "Fuzz suite is implemented and must not be marked as a safe stub")
 


### PR DESCRIPTION
## Summary
- add browser SDK v1 helpers to create and run Codebox runtime task requests
- add a Codebox REST wrapper for browser runtime task execution
- document and test the browser runtime-task public boundary

## Verification
- npm run build
- npm run test:browser-sdk-facade
- npm run test:wordpress-plugin-public-runtime-abilities
- npm run test:public-api-contract
- npm run test:docs-boundary-language
- npm run test:php-public-api-facade

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing browser runtime task SDK helpers, REST wrapper, docs, and tests.