### PR TITLE
Bind staged input materializer calls

### DIFF
--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -177,8 +177,8 @@ export async function applyRecipeRuntimeSetup(args: {
     interruption?.throwIfInterrupted()
   }
 
-  const materializeStagedInputs = runtime.materializeStagedInputs ?? runtime.materializeMounts
-  if (stagedFiles.length > 0 && typeof materializeStagedInputs === "function") {
+  const canMaterializeStagedInputs = typeof runtime.materializeStagedInputs === "function" || typeof runtime.materializeMounts === "function"
+  if (stagedFiles.length > 0 && canMaterializeStagedInputs) {
     const stagedMounts = stagedFiles.map((stagedFile) => ({
       type: stagedFile.type,
       source: stagedFile.source,
@@ -186,7 +186,7 @@ export async function applyRecipeRuntimeSetup(args: {
       mode: "readwrite" as const,
       metadata: stagedFile.metadata,
     }))
-    await awaitRecipe("staged-file.materialize", () => materializeStagedInputs(stagedMounts))
+    await awaitRecipe("staged-file.materialize", () => runtime.materializeStagedInputs ? runtime.materializeStagedInputs(stagedMounts) : runtime.materializeMounts!(stagedMounts))
     interruption?.throwIfInterrupted()
   }
 

--- a/tests/recipe-runtime-setup-staged-materialization.test.ts
+++ b/tests/recipe-runtime-setup-staged-materialization.test.ts
@@ -32,6 +32,7 @@ const runtime = {
   async info() { return { id: "runtime", backend: "wordpress-playground", environment: { kind: "wordpress" }, createdAt: new Date().toISOString(), status: "running" } },
   async mount(spec) { calls.push(`mount:${spec.target}`) },
   async materializeStagedInputs(mounts) {
+    assert.equal(this, runtime, "setup calls staged input materializer with runtime binding")
     calls.push(`materialize:${mounts.map((mount) => mount.target).join(",")}`)
     assert.deepEqual(mounts, [{
       type: "directory",


### PR DESCRIPTION
## Summary
- keep staged input materialization calls bound to the runtime instance
- preserve fallback to the legacy mount materialization hook without extracting runtime methods
- add a regression assertion that setup invokes the staged-input materializer with the runtime binding

## Testing
- npm run build
- npx tsx tests/recipe-runtime-setup-staged-materialization.test.ts
- npx tsx tests/staged-input-materialization.test.ts
- npx tsx tests/agent-task-runtime-package-staging.test.ts
- npx tsx tests/runtime-package-execution.test.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WPSG N=1 runtime failure and drafting/verifying the WP Codebox binding fix.