### PR TITLE
Fallback staged input writes through PHP

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -118,6 +118,7 @@ async function materializeHostMountFilesWithPersistentWriter(server: PlaygroundC
   const directoryResult = await createHostMountDirectories(server, directories)
   let materialized = 0
   let skipped = directoryResult.skipped
+  const failedFiles: HostMountFilePayload[] = []
   for (const file of files) {
     const target = file.target.trim()
     if (!target || target.includes("\0")) {
@@ -128,8 +129,13 @@ async function materializeHostMountFilesWithPersistentWriter(server: PlaygroundC
       await server.playground.writeFile(target, Buffer.from(file.contentsBase64, "base64").toString("utf8"))
       materialized++
     } catch {
-      skipped++
+      failedFiles.push(file)
     }
+  }
+  if (failedFiles.length > 0) {
+    const fallback = await materializeHostMountFilesWithPhp(server, failedFiles)
+    materialized += fallback.materialized
+    skipped += fallback.skipped
   }
   return { materialized, skipped }
 }

--- a/tests/staged-input-materialization.test.ts
+++ b/tests/staged-input-materialization.test.ts
@@ -39,4 +39,45 @@ await withTempDir("wp-codebox-staged-input-materialization-", async (root) => {
   assert.equal(written.get("/workspace/wp-site-generator/bundles/store-idea-agent/flows/store.json"), `${JSON.stringify({ id: "store" })}\n`)
 })
 
+await withTempDir("wp-codebox-staged-input-materialization-fallback-", async (root) => {
+  const source = join(root, "store-idea-agent")
+  await mkdir(join(source, "flows"), { recursive: true })
+  await writeFile(join(source, "manifest.json"), `${JSON.stringify({ schema: "test/runtime-bundle/v1" })}\n`)
+  await writeFile(join(source, "flows", "store.json"), `${JSON.stringify({ id: "store" })}\n`)
+
+  const written = new Map<string, string>()
+  let fallbackWrites = 0
+  const server = {
+    playground: {
+      async run({ code }: { code: string }) {
+        if (code.includes("wp-codebox/host-mount-materialization/v1")) {
+          fallbackWrites++
+          return { text: JSON.stringify({ materialized: 1, skipped: 0 }) }
+        }
+        return { text: JSON.stringify({ created: 1, skipped: 0 }) }
+      },
+      async writeFile(path: string, contents: string) {
+        if (path.endsWith("/flows/store.json")) {
+          throw new Error("persistent writer unavailable for nested file")
+        }
+        written.set(path, contents)
+      },
+    },
+  }
+
+  const result = await materializePlaygroundStagedInputs(server as never, [{
+    type: "directory",
+    source,
+    target: "/workspace/wp-site-generator/bundles/store-idea-agent",
+    mode: "readwrite",
+    metadata: { kind: "runtime-package-source" },
+  }])
+
+  assert.equal(result.materialized, 2)
+  assert.equal(result.deleted, 0)
+  assert.equal(result.skipped, 0)
+  assert.equal(fallbackWrites, 1)
+  assert.equal(written.get("/workspace/wp-site-generator/bundles/store-idea-agent/manifest.json"), `${JSON.stringify({ schema: "test/runtime-bundle/v1" })}\n`)
+})
+
 console.log("staged input materialization ok")


### PR DESCRIPTION
## Summary
- retry staged input files through the PHP writer when the persistent Playground writer fails
- keep invalid targets counted as skipped, but do not leave valid runtime-package directories partially materialized when a write path fails
- add focused coverage for persistent-writer fallback during staged input materialization

## Testing
- npm run build
- npx tsx tests/staged-input-materialization.test.ts
- npx tsx tests/recipe-runtime-setup-staged-materialization.test.ts
- npx tsx tests/agent-task-runtime-package-staging.test.ts
- npx tsx tests/runtime-package-execution.test.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the WPSG N=1 partial staged bundle failure and drafting/verifying the WP Codebox fallback fix.