### PR TITLE
Harden fuzz artifact and observation contracts

### DIFF
--- a/packages/runtime-playground/src/bench-command-handlers.ts
+++ b/packages/runtime-playground/src/bench-command-handlers.ts
@@ -1514,14 +1514,160 @@ function wp_codebox_bench_workload_run_steps(array $workload): array {
     return !empty($steps) ? $steps : array($workload);
 }
 
+function wp_codebox_bench_required_value_specs($values, string $type): array {
+    $specs = array();
+    foreach (is_array($values) ? $values : array() as $value) {
+        if (is_string($value) && trim($value) !== '') {
+            $specs[] = array('type' => $type, 'value' => trim($value));
+        } elseif (is_array($value)) {
+            $spec = array_merge(array('type' => $type), $value);
+            if (!isset($spec['value']) && isset($spec['name'])) {
+                $spec['value'] = $spec['name'];
+            }
+            $specs[] = $spec;
+        }
+    }
+    return $specs;
+}
+
+function wp_codebox_bench_required_artifact_specs_from_declarations($declarations): array {
+    $specs = array();
+    foreach (is_array($declarations) ? $declarations : array() as $key => $declaration) {
+        if (is_array($declaration) && !empty($declaration['required'])) {
+            $spec = array('type' => 'artifact');
+            if (is_string($key) && $key !== '') {
+                $spec['value'] = $key;
+            }
+            foreach (array('name', 'kind', 'schema', 'semantic_key', 'semantic') as $field) {
+                if (isset($declaration[$field]) && is_string($declaration[$field]) && trim($declaration[$field]) !== '') {
+                    $spec[$field] = trim($declaration[$field]);
+                }
+            }
+            if (!isset($spec['value']) && isset($spec['name'])) {
+                $spec['value'] = $spec['name'];
+            }
+            $specs[] = $spec;
+        }
+    }
+    return $specs;
+}
+
+function wp_codebox_bench_workload_required_specs(array $workload): array {
+    return array_merge(
+        wp_codebox_bench_required_value_specs($workload['required_artifacts'] ?? ($workload['requiredArtifacts'] ?? array()), 'artifact'),
+        wp_codebox_bench_required_value_specs($workload['required_artifact_kinds'] ?? ($workload['requiredArtifactKinds'] ?? array()), 'artifact_kind'),
+        wp_codebox_bench_required_value_specs($workload['required_observations'] ?? ($workload['requiredObservations'] ?? array()), 'observation'),
+        wp_codebox_bench_required_artifact_specs_from_declarations($workload['artifacts'] ?? array())
+    );
+}
+
+function wp_codebox_bench_artifact_matches_required_spec(string $key, array $artifact, array $spec): bool {
+    if (($spec['type'] ?? '') === 'artifact_kind') {
+        $expected_kind = isset($spec['value']) && is_string($spec['value']) ? trim($spec['value']) : (isset($spec['kind']) && is_string($spec['kind']) ? trim($spec['kind']) : '');
+        return $expected_kind !== '' && isset($artifact['kind']) && is_string($artifact['kind']) && $artifact['kind'] === $expected_kind;
+    }
+
+    $metadata = isset($artifact['metadata']) && is_array($artifact['metadata']) ? $artifact['metadata'] : array();
+    $candidates = array($key);
+    foreach (array('name', 'kind', 'source', 'path') as $field) {
+        if (isset($artifact[$field]) && is_string($artifact[$field])) {
+            $candidates[] = $artifact[$field];
+        }
+    }
+    foreach (array('schema', 'semantic', 'semantic_key') as $field) {
+        if (isset($metadata[$field]) && is_string($metadata[$field])) {
+            $candidates[] = $metadata[$field];
+        }
+    }
+
+    foreach (array('value', 'name', 'kind', 'schema', 'semantic_key', 'semantic') as $field) {
+        if (!isset($spec[$field]) || !is_string($spec[$field]) || trim($spec[$field]) === '') {
+            continue;
+        }
+        $expected = trim($spec[$field]);
+        foreach ($candidates as $candidate) {
+            if ($candidate === $expected) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function wp_codebox_bench_step_matches_required_spec(array $step, array $spec): bool {
+    $expected = isset($spec['value']) && is_string($spec['value']) ? trim($spec['value']) : '';
+    if ($expected === '') {
+        return false;
+    }
+    foreach (array('type', 'name', 'command', 'ability', 'path', 'route') as $field) {
+        if (isset($step[$field]) && is_scalar($step[$field]) && (string) $step[$field] === $expected) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function wp_codebox_bench_payload_satisfies_required_spec(array $payload, array $spec): bool {
+    foreach (is_array($payload['artifacts'] ?? null) ? $payload['artifacts'] : array() as $key => $artifact) {
+        if (is_array($artifact) && wp_codebox_bench_artifact_matches_required_spec((string) $key, $artifact, $spec)) {
+            return true;
+        }
+    }
+    if (($spec['type'] ?? '') === 'observation') {
+        foreach (is_array($payload['steps'] ?? null) ? $payload['steps'] : array() as $step) {
+            if (is_array($step) && wp_codebox_bench_step_matches_required_spec($step, $spec)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function wp_codebox_bench_required_spec_label(array $spec): string {
+    foreach (array('value', 'name', 'kind', 'schema', 'semantic_key', 'semantic') as $field) {
+        if (isset($spec[$field]) && is_string($spec[$field]) && trim($spec[$field]) !== '') {
+            return ($spec['type'] ?? 'required') . ':' . trim($spec[$field]);
+        }
+    }
+    return (string) ($spec['type'] ?? 'required');
+}
+
+function wp_codebox_bench_assert_required_observations(array $workload, array $payload): void {
+    $required_specs = wp_codebox_bench_workload_required_specs($workload);
+    if (empty($required_specs)) {
+        return;
+    }
+
+    $missing = array();
+    foreach ($required_specs as $spec) {
+        if (!is_array($spec) || wp_codebox_bench_payload_satisfies_required_spec($payload, $spec)) {
+            continue;
+        }
+        $missing[] = wp_codebox_bench_required_spec_label($spec);
+    }
+    if (empty($missing)) {
+        return;
+    }
+
+    $artifact_keys = array_keys(is_array($payload['artifacts'] ?? null) ? $payload['artifacts'] : array());
+    $step_types = array_values(array_filter(array_map(static fn($step) => is_array($step) && isset($step['type']) ? (string) $step['type'] : null, is_array($payload['steps'] ?? null) ? $payload['steps'] : array())));
+    throw new RuntimeException('wordpress.bench required observations were not produced for workload "' . (string) ($workload['id'] ?? 'configured') . '". diagnostic=' . wp_json_encode(array(
+        'schema' => 'wp-codebox/bench-required-observation-diagnostic/v1',
+        'workload_id' => (string) ($workload['id'] ?? 'configured'),
+        'missing' => $missing,
+        'actual' => array(
+            'artifact_keys' => $artifact_keys,
+            'step_count' => count(is_array($payload['steps'] ?? null) ? $payload['steps'] : array()),
+            'step_types' => $step_types,
+        ),
+    ), JSON_UNESCAPED_SLASHES));
+}
+
 function wp_codebox_bench_run_configured_workload(array $workload, string $plugin_path) {
     $steps = wp_codebox_bench_workload_run_steps($workload);
     $payload = array('metrics' => array(), 'metadata' => array(), 'artifacts' => array(), 'steps' => array(), 'diagnostics' => array());
     if (isset($workload['metadata']) && is_array($workload['metadata'])) {
         $payload['metadata'] = array_merge($payload['metadata'], $workload['metadata']);
-    }
-    if (isset($workload['artifacts']) && is_array($workload['artifacts'])) {
-        $payload['artifacts'] = array_merge($payload['artifacts'], $workload['artifacts']);
     }
     foreach ($steps as $step) {
         if (!is_array($step)) {
@@ -1578,6 +1724,7 @@ function wp_codebox_bench_run_configured_workload(array $workload, string $plugi
             }
         }
     }
+    wp_codebox_bench_assert_required_observations($workload, $payload);
     return $payload;
 }
 

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -475,17 +475,24 @@ function resultWithWordPressHotspotsArtifact(result: FuzzSuiteResultEnvelope, ob
   }
   const homeboyObservationRef: FuzzSuiteArtifactRef = homeboyArtifactRef("files/fuzz-observations.json", "fuzz-observation-set", "homeboy/fuzz-observation-set/v1", homeboyObservationContent)
   const homeboyHotspotRef: FuzzSuiteArtifactRef = homeboyArtifactRef("files/fuzz-hotspots.json", "fuzz-hotspot-set", "homeboy/fuzz-hotspot-set/v1", homeboyHotspotContent)
+  const artifactRefs = dedupeFuzzSuiteArtifactRefs([...result.artifactRefs, ref, homeboyObservationRef, homeboyHotspotRef])
+  const linkedMetadataArtifacts = {
+    ...(recordValue(result.metadata?.artifacts) ?? {}),
+    wordpressHotspots: ref,
+    fuzzObservationSet: homeboyObservationRef,
+    fuzzHotspotSet: homeboyHotspotRef,
+  }
+  const resultArtifactContent = `${JSON.stringify({ ...result, artifactRefs, metadata: { ...result.metadata, artifacts: linkedMetadataArtifacts } }, null, 2)}\n`
+  const resultRef: FuzzSuiteArtifactRef = homeboyArtifactRef("files/fuzz-result.json", "fuzz-suite-result", result.schema, resultArtifactContent)
 
   return {
     ...result,
-    artifactRefs: dedupeFuzzSuiteArtifactRefs([...result.artifactRefs, ref, homeboyObservationRef, homeboyHotspotRef]),
+    artifactRefs: dedupeFuzzSuiteArtifactRefs([...artifactRefs, resultRef]),
     metadata: {
       ...result.metadata,
       artifacts: {
-        ...(recordValue(result.metadata?.artifacts) ?? {}),
-        wordpressHotspots: artifact,
-        fuzzObservationSet: homeboyObservationSet,
-        fuzzHotspotSet: homeboyHotspotSet,
+        ...linkedMetadataArtifacts,
+        fuzzResult: resultRef,
       },
     },
   }

--- a/tests/bench-command-step-behavior.test.ts
+++ b/tests/bench-command-step-behavior.test.ts
@@ -57,6 +57,23 @@ const commandStepHelpers = [
   "wp_codebox_bench_workload_run_steps",
 ].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
 
+const configuredWorkloadHelpers = [
+  "wp_codebox_bench_metric_prefix",
+  "wp_codebox_bench_command_step_record",
+  "wp_codebox_bench_run_command_step",
+  "wp_codebox_bench_command_step_payload",
+  "wp_codebox_bench_workload_run_steps",
+  "wp_codebox_bench_required_value_specs",
+  "wp_codebox_bench_required_artifact_specs_from_declarations",
+  "wp_codebox_bench_workload_required_specs",
+  "wp_codebox_bench_artifact_matches_required_spec",
+  "wp_codebox_bench_step_matches_required_spec",
+  "wp_codebox_bench_payload_satisfies_required_spec",
+  "wp_codebox_bench_required_spec_label",
+  "wp_codebox_bench_assert_required_observations",
+  "wp_codebox_bench_run_configured_workload",
+].map((functionName) => phpFunctionBlock(benchRunner, functionName)).join("\n\n")
+
 const externalHttpGuardrailHelpers = [
   "wp_codebox_bench_metric_prefix",
   "wp_codebox_bench_command_step_record",
@@ -126,6 +143,50 @@ assert.equal(typeof commandStepPayload.steps[0].timing.duration_ms, "number")
 assert.equal(typeof commandStepPayload.metrics.ability_duration_ms, "number")
 assert.equal(commandStepPayload.metrics.custom_count, 2)
 assert.deepEqual(commandStepPayload.metadata, { called: "example/run" })
+
+const requiredObservationGate = await withTempDir("wp-codebox-required-observation-gate-", async (directory) => {
+  const phpTestFile = join(directory, "required-observation-gate.php")
+  await writeFile(
+    phpTestFile,
+    `<?php
+${configuredWorkloadHelpers}
+function wp_json_encode($value, $flags = 0) { return json_encode($value, $flags); }
+$messages = array();
+foreach (array(
+    array(
+        'id' => 'declared-report-only',
+        'artifacts' => array('report' => array('required' => true, 'kind' => 'json')),
+        'run' => array(array('type' => 'php', 'code' => 'return array("metrics" => array("ok_count" => 1));')),
+    ),
+    array(
+        'id' => 'missing-profiler-observation',
+        'required_observations' => array('rest-db-query-profiler'),
+        'run' => array(array('type' => 'php', 'code' => 'return array("artifacts" => array("report" => array("name" => "report", "kind" => "json")));')),
+    ),
+) as $workload) {
+    try {
+        wp_codebox_bench_run_configured_workload($workload, ${JSON.stringify(directory)});
+        $messages[] = 'ok';
+    } catch (Throwable $e) {
+        $messages[] = $e->getMessage();
+    }
+}
+$payload = wp_codebox_bench_run_configured_workload(array(
+    'id' => 'emitted-report',
+    'required_artifacts' => array('report'),
+    'run' => array(array('type' => 'php', 'code' => 'return array("artifacts" => array("report" => array("name" => "report", "kind" => "json")), "steps" => array(array("type" => "artifact-postprocess")));')),
+), ${JSON.stringify(directory)});
+$messages[] = array_keys($payload['artifacts'])[0];
+echo json_encode($messages, JSON_UNESCAPED_SLASHES);
+`,
+  )
+  return runPhpFileJson<string[]>(phpTestFile)
+})
+assert.match(requiredObservationGate[0], /required observations were not produced/)
+assert.match(requiredObservationGate[0], /artifact:report/)
+assert.match(requiredObservationGate[0], /"step_count":0/)
+assert.match(requiredObservationGate[1], /observation:rest-db-query-profiler/)
+assert.equal(requiredObservationGate[2], "report")
 
 const externalHttpGuardrailPayload = await withTempDir("wp-codebox-external-http-guardrail-", async (directory) => {
   const phpTestFile = join(directory, "external-http-guardrail.php")

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -116,25 +116,23 @@ const hotspotsRef = result.artifactRefs.find((ref) => ref.kind === "wordpress-ho
 assert.equal(hotspotsRef?.path, "files/wordpress-hotspots.json")
 assert.equal(hotspotsRef?.contentType, "application/json")
 assert.equal(hotspotsRef?.metadata?.schema, "wp-codebox/wordpress-hotspots/v1")
-const hotspots = (result.metadata?.artifacts as { wordpressHotspots?: { schema?: string; summary?: { surfaces?: Record<string, number> }; hotspots?: Array<{ identifier: { surface: string; route?: string; id: string }; metrics: Array<{ kind: string; value: number }> }> } } | undefined)?.wordpressHotspots
-assert.equal(hotspots?.schema, "wp-codebox/wordpress-hotspots/v1")
-assert.equal((hotspots?.summary?.surfaces?.rest ?? 0) >= 1, true)
-assert.equal((hotspots?.summary?.surfaces?.db ?? 0) >= 1, true)
-assert.equal((hotspots?.summary?.surfaces?.browser ?? 0) >= 1, true)
-assert.equal(hotspots?.hotspots?.some((hotspot) => hotspot.identifier.route === "/wp/v2/types" && hotspot.metrics.some((metric) => metric.kind === "query-count" && metric.value === 7)), true)
-assert.equal(hotspots?.hotspots?.some((hotspot) => hotspot.identifier.route === "/wc/store/v1/products" && hotspot.metrics.some((metric) => metric.kind === "query-count" && metric.value === 9)), true)
 const homeboyObservationRef = result.artifactRefs.find((ref) => ref.kind === "fuzz-observation-set")
 assert.equal(homeboyObservationRef?.path, "files/fuzz-observations.json")
 assert.equal(homeboyObservationRef?.metadata?.schema, "homeboy/fuzz-observation-set/v1")
 const homeboyHotspotRef = result.artifactRefs.find((ref) => ref.kind === "fuzz-hotspot-set")
 assert.equal(homeboyHotspotRef?.path, "files/fuzz-hotspots.json")
 assert.equal(homeboyHotspotRef?.metadata?.schema, "homeboy/fuzz-hotspot-set/v1")
-const homeboyObservationSet = (result.metadata?.artifacts as { fuzzObservationSet?: { schema?: string; observations?: Array<{ family?: string; case_id?: string; subject?: string; metric?: string; value?: number; unit?: string }> } } | undefined)?.fuzzObservationSet
-assert.equal(homeboyObservationSet?.schema, "homeboy/fuzz-observation-set/v1")
-assert.equal(homeboyObservationSet?.observations?.some((observation) => observation.family === "database" && observation.case_id === "typed-workload" && observation.subject === "/wc/store/v1/products" && observation.metric === "query-count" && observation.value === 9 && observation.unit === "count"), true)
-const homeboyHotspotSet = (result.metadata?.artifacts as { fuzzHotspotSet?: { schema?: string; hotspots?: Array<{ family?: string; subject?: string; metric?: string; value?: number; rank?: number }> } } | undefined)?.fuzzHotspotSet
-assert.equal(homeboyHotspotSet?.schema, "homeboy/fuzz-hotspot-set/v1")
-assert.equal(homeboyHotspotSet?.hotspots?.some((hotspot) => hotspot.family === "database" && hotspot.subject === "/wc/store/v1/products" && hotspot.metric === "query-count" && hotspot.value === 9 && typeof hotspot.rank === "number"), true)
+const fuzzResultRef = result.artifactRefs.find((ref) => ref.kind === "fuzz-suite-result")
+assert.equal(fuzzResultRef?.path, "files/fuzz-result.json")
+assert.equal(fuzzResultRef?.metadata?.schema, "wp-codebox/fuzz-suite-result/v1")
+const metadataArtifacts = result.metadata?.artifacts as { fuzzResult?: { path?: string }; wordpressHotspots?: { path?: string; hotspots?: unknown[] }; fuzzObservationSet?: { path?: string; observations?: unknown[] }; fuzzHotspotSet?: { path?: string; hotspots?: unknown[] } } | undefined
+assert.equal(metadataArtifacts?.fuzzResult?.path, "files/fuzz-result.json")
+assert.equal(metadataArtifacts?.wordpressHotspots?.path, "files/wordpress-hotspots.json")
+assert.equal(metadataArtifacts?.fuzzObservationSet?.path, "files/fuzz-observations.json")
+assert.equal(metadataArtifacts?.fuzzHotspotSet?.path, "files/fuzz-hotspots.json")
+assert.equal(Array.isArray(metadataArtifacts?.wordpressHotspots?.hotspots), false)
+assert.equal(Array.isArray(metadataArtifacts?.fuzzObservationSet?.observations), false)
+assert.equal(Array.isArray(metadataArtifacts?.fuzzHotspotSet?.hotspots), false)
 
 console.log("playground fuzz suite public ok")
 


### PR DESCRIPTION
## Summary
- Add a canonical fuzz suite result artifact ref instead of duplicating large payloads in metadata.
- Keep standard observation/hotspot artifact refs reviewer-visible.
- Fail configured workload runs loudly when declared required observations/artifacts are missing.

## Verification
- npm ci
- npm run test:bench-command-step-behavior
- npm run test:playground-fuzz-suite-public
- npm run test:fuzz-suite-runner
- npm run test:fuzz-run-recipe
- npm run test:nested-fuzz-suite-recipe-command
- npx tsx tests/public-fuzz-workload-cli.test.ts
- npm run test:wordpress-fuzz-suite-builders
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting the implementation, tests, and verification workflow.