### PR TITLE
fix: register agents-api adapter on wp_abilities_api_init (stop pre-init abilities access)

### DIFF
--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -71,7 +71,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/src/class-wp-codebox-cli-command.php';
 }
 
-add_action( 'plugins_loaded', array( WP_Codebox_Agents_API_Adapter::class, 'register_if_available' ), 20 );
+// The Agents API adapter probes the abilities registry (wp_get_ability) to
+// decide whether to register its runtime profiles/provider. As of WordPress 7.0
+// the Abilities API moved into core and WP_Abilities_Registry::get_instance()
+// emits a _doing_it_wrong notice when accessed before the `init` action. Hook
+// this on `wp_abilities_api_init` — the same signal the plugin's own abilities
+// register on — so the registry is never touched before it is initialized.
+add_action( 'wp_abilities_api_init', array( WP_Codebox_Agents_API_Adapter::class, 'register_if_available' ) );
 add_action( 'plugins_loaded', array( WP_Codebox_Php_Ai_Client_Browser_Provider_Adapter::class, 'register' ), 20 );
 new WP_Codebox_Abilities();
 WP_Codebox_Browser_Provider_Bridge::register();


### PR DESCRIPTION
## Summary

WordPress 7.0 moved the Abilities API into core (`wp-includes/abilities-api/`) and added a strict timing guard: `WP_Abilities_Registry::get_instance()` emits a `_doing_it_wrong` notice ("Ability API should not be initialized before the init action has fired") when accessed **before** the `init` action.

wp-codebox tripped this on **every** bootstrap (web + WP-CLI + cron) because `WP_Codebox_Agents_API_Adapter::register_if_available` was hooked on `plugins_loaded`, which fires before `init`.

### Impact being fixed
- **~71,500 PHP notices/day** — 94.7% of all logged errors on a production WP 7.0 multisite.
- `debug.log` ballooned to **167 MB**.
- Guard fired ~6,000 times/hour.

## Root cause

`plugins_loaded` (priority 20) → `register_if_available()` → `register_runtime_profiles()` → `should_register_adapter()` → `( new self() )->is_available( self::RUN_RUNTIME_PACKAGE )` → `is_available()` calls `wp_get_ability( $ability_name )` → `WP_Abilities_Registry::get_instance()` **before `init`**, tripping the WP 7.0 guard.

Backtrace captured on the live site:

```
#3 _doing_it_wrong (wp-includes/abilities-api/class-wp-abilities-registry.php:274)
#4 WP_Abilities_Registry::get_instance (wp-includes/abilities-api.php:390)
#5 wp_get_ability (src/class-wp-codebox-agents-api-adapter.php:478)
#6 WP_Codebox_Agents_API_Adapter->is_available (:177)
#7 WP_Codebox_Agents_API_Adapter::should_register_adapter (:133)
#8 WP_Codebox_Agents_API_Adapter::register_runtime_profiles (:172)
#9 WP_Codebox_Agents_API_Adapter::register_if_available  ← hooked on plugins_loaded
```

## The change

In `packages/wordpress-plugin/wp-codebox.php`, move the adapter registration hook:

```diff
-add_action( 'plugins_loaded', array( WP_Codebox_Agents_API_Adapter::class, 'register_if_available' ), 20 );
+add_action( 'wp_abilities_api_init', array( WP_Codebox_Agents_API_Adapter::class, 'register_if_available' ) );
```

`wp_abilities_api_init` is the **same signal the plugin's own abilities register on** (see `WP_Codebox_Abilities::register()`, which hooks `wp_abilities_api_init`), and it fires on `init` — i.e. after the core registry is initialized. This is the canonical "abilities are ready" hook, so `wp_get_ability()` is never reachable before the registry exists. This is a real hook move, not a `did_action( 'init' )` guard left on `plugins_loaded`.

### Why the later registration is safe (ordering)
The adapter only **registers filters and an in-memory provider** (`wp_codebox_runtime_profile_registry`, `wp_codebox_browser_runtime_*`, `WP_Codebox_Runtime_Provider_Registry::register`). Every consumer of those is read during **ability execution** (request/runtime time), which always happens after `init`:
- `wp_codebox_runtime_profile_registry` → read in `WP_Codebox_Runtime_Profile_Resolver` during task resolution.
- `WP_Codebox_Runtime_Provider_Registry::invoke` / `resolve_runtime_requirements` → called inside ability `execute_callback`s (`trait-wp-codebox-abilities-execution.php`).
- The `wp_codebox_browser_runtime_*` filters → read in browser task builders/invokers during a run.

None run at or before `plugins_loaded`, so moving registration from `plugins_loaded` to `wp_abilities_api_init` does not miss any consumer.

### Second adapter checked, intentionally unchanged
`WP_Codebox_Php_Ai_Client_Browser_Provider_Adapter::register` (the other `plugins_loaded` hook) was audited for the same pre-init access — `grep` for `wp_get_ability` / `WP_Abilities_Registry` / `get_instance` / `wp_has_ability` in that file returns **zero matches**. It only registers a browser-provider auth strategy and a credential-resolver filter, neither of which touches the abilities registry. It is left on `plugins_loaded` to keep the change minimal.

## Verification

- `php -l packages/wordpress-plugin/wp-codebox.php` → clean
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php` → clean
- `npm run test:php-agents-api-adapter-contract` → pass
- `npm run test:wordpress-plugin-public-runtime-abilities` → pass
- `npm run test:distribution-startup-probes` → pass (validates clean plugin bootstrap)

After the change, `wp_get_ability()` is only reachable from `register_if_available()` once `wp_abilities_api_init` has fired (on `init`), so the WP 7.0 `WP_Abilities_Registry::get_instance()` pre-init guard can no longer be tripped during bootstrap.

Closes #1588