### PR TITLE
Provision agent-runtime substrate into the browser sandbox by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "test:php-browser-contained-site-contract": "php scripts/php-browser-contained-site-contract-smoke.php",
     "test:php-artifact-import-idempotency": "php scripts/php-artifact-import-idempotency-smoke.php",
     "test:php-browser-runtime-local-package": "php scripts/php-browser-runtime-local-package-smoke.php",
+    "test:php-browser-runtime-agent-substrate": "php scripts/php-browser-runtime-agent-substrate-smoke.php",
     "test:mcp-client-configs": "tsx tests/mcp-client-configs.test.ts",
     "test:runtime-tool-policy": "tsx tests/runtime-tool-policy.test.ts",
     "test:primitive-contract-parity": "tsx tests/primitive-contract-parity.test.ts",

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -135,6 +135,7 @@ final class WP_Codebox_Agents_API_Adapter {
 		}
 
 		add_filter( 'wp_codebox_runtime_profile_registry', array( self::class, 'runtime_profile_registry' ) );
+		add_filter( 'wp_codebox_browser_runtime_required_components', array( self::class, 'browser_runtime_required_components' ) );
 		add_filter( 'wp_codebox_browser_runtime_default_invocation', array( self::class, 'browser_runtime_default_invocation' ) );
 		add_filter( 'wp_codebox_browser_runtime_default_ability', array( self::class, 'default_chat_ability' ) );
 		add_filter( 'wp_codebox_browser_runtime_ability_names', array( self::class, 'ability_names' ) );
@@ -334,7 +335,95 @@ final class WP_Codebox_Agents_API_Adapter {
 			'provenance'             => array( 'adapter' => self::class ),
 		);
 
+		// WP Codebox is the agentic runtime: selecting codebox-agent-runtime must
+		// provision the runtime substrate (agents-api) by default, so consumers
+		// supply domain inputs (bundle, goal, provider selection) only and never
+		// hand-inject the runtime plugins themselves.
+		$registry['codebox-agent-runtime'] = self::merge_default_components(
+			is_array( $registry['codebox-agent-runtime'] ?? null ) ? $registry['codebox-agent-runtime'] : array(),
+			self::default_runtime_component_slugs()
+		);
+
 		return $registry;
+	}
+
+	/**
+	 * Default runtime substrate component slugs provisioned for the agent runtime.
+	 *
+	 * Minimal set proven from code: agents-api ships its own conversation loop,
+	 * workflow runner, and bundle importer, so it runs worker bundles + the agent
+	 * loop without Data Machine. The selected AI provider plugin is provisioned
+	 * separately via the provider profile. Both resolve from the host's installed
+	 * copies. A host/deploy that needs additional substrate (e.g. data-machine /
+	 * data-machine-code for bundles that use those abilities) adds slugs through
+	 * this filter and supplies a source via the component registry/contract or
+	 * host plugin roots filter.
+	 *
+	 * @return array<int,string>
+	 */
+	private static function default_runtime_component_slugs(): array {
+		$slugs = array( 'agents-api' );
+		if ( function_exists( 'apply_filters' ) ) {
+			$filtered = apply_filters( 'wp_codebox_agent_runtime_default_components', $slugs );
+			if ( is_array( $filtered ) ) {
+				$slugs = $filtered;
+			}
+		}
+
+		$normalized = array();
+		foreach ( $slugs as $slug ) {
+			$slug = function_exists( 'sanitize_key' ) ? sanitize_key( (string) $slug ) : strtolower( trim( (string) $slug ) );
+			if ( '' !== $slug && ! in_array( $slug, $normalized, true ) ) {
+				$normalized[] = $slug;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Required browser runtime component slugs.
+	 *
+	 * Ensures the runtime substrate installs even on the required-only browser
+	 * path (when provider plugin paths, connectors, or secret env are present)
+	 * in addition to when the codebox-agent-runtime profile declares it.
+	 *
+	 * @param array<int,string> $slugs Required component slugs.
+	 * @return array<int,string>
+	 */
+	public static function browser_runtime_required_components( array $slugs = array() ): array {
+		foreach ( self::default_runtime_component_slugs() as $slug ) {
+			if ( ! in_array( $slug, $slugs, true ) ) {
+				$slugs[] = $slug;
+			}
+		}
+
+		return $slugs;
+	}
+
+	/**
+	 * Merges default component slugs into a runtime profile registry entry.
+	 *
+	 * @param array<string,mixed> $profile Profile registry entry.
+	 * @param array<int,string>   $slugs   Default component slugs.
+	 * @return array<string,mixed>
+	 */
+	private static function merge_default_components( array $profile, array $slugs ): array {
+		$components = is_array( $profile['components'] ?? null ) ? $profile['components'] : array();
+		$existing   = array();
+		foreach ( $components as $component ) {
+			$existing[] = is_array( $component ) ? (string) ( $component['slug'] ?? '' ) : (string) $component;
+		}
+
+		foreach ( $slugs as $slug ) {
+			if ( ! in_array( $slug, $existing, true ) ) {
+				$components[] = array( 'slug' => $slug );
+			}
+		}
+
+		$profile['components'] = $components;
+
+		return $profile;
 	}
 
 	/** @param array<string,mixed> $task_input_schema Codebox task input schema. @return array<string,mixed> */

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php
@@ -479,6 +479,12 @@ private static function browser_runtime_plugin_specs( array $plugins ): array|WP
 		$resource = (string) ( $plugin['resource'] ?? 'url' );
 		$path     = 'git:directory' === $resource ? '' : self::browser_clean_path( (string) ( $plugin['path'] ?? '' ) );
 		$package  = (string) ( $plugin['package'] ?? '' );
+		if ( 'url' === $resource && '' === $path && 'browser' !== $package && '' === trim( (string) ( $plugin['url'] ?? '' ) ) ) {
+			$host_dir = self::browser_host_runtime_plugin_dir( (string) ( $plugin['slug'] ?? '' ) );
+			if ( '' !== $host_dir ) {
+				$path = $host_dir;
+			}
+		}
 		if ( 'url' === $resource && '' === $path && 'browser' !== $package ) {
 			$slug = self::safe_key( (string) ( $plugin['slug'] ?? '' ) );
 			if ( '' === $slug ) {
@@ -574,6 +580,11 @@ private static function browser_component_plugins( array $input, array $declared
 		$key  = self::browser_runtime_component_key( $slug );
 		$contract = is_array( $contracts[ $slug ] ?? null ) ? $contracts[ $slug ] : ( is_array( $contracts[ $key ] ?? null ) ? $contracts[ $key ] : array() );
 		$path = (string) ( $contract['path'] ?? '' );
+		$source = '' !== $path ? 'host-component-path' : '';
+		if ( '' === $path ) {
+			$path   = self::browser_host_runtime_plugin_dir( $slug );
+			$source = '' !== $path ? 'host-installed-plugin' : '';
+		}
 		if ( '' !== $path ) {
 			if ( ! is_dir( $path ) ) {
 				return new WP_Error( 'wp_codebox_browser_component_path_missing', 'Browser runtime component path does not exist.', array( 'status' => 400, 'slug' => $slug, 'path' => $path ) );
@@ -594,7 +605,7 @@ private static function browser_component_plugins( array $input, array $declared
 				'sha256'                  => $package['sha256'],
 				'provenance'              => array(
 					'schema' => 'wp-codebox/browser-component-plugin-provenance/v1',
-					'source' => 'host-component-path',
+					'source' => $source,
 					'sha256' => $package['sha256'],
 				),
 			);
@@ -603,6 +614,7 @@ private static function browser_component_plugins( array $input, array $declared
 
 		$component = is_array( $registry[ $slug ] ?? null ) ? $registry[ $slug ] : array();
 		if ( empty( $component ) ) {
+			self::browser_runtime_component_unresolved( $slug );
 			continue;
 		}
 
@@ -694,6 +706,84 @@ private static function browser_runtime_component_registry(): array {
 		: array();
 
 	return is_array( $registry ) ? $registry : array();
+}
+
+/**
+ * Resolves a runtime plugin/component slug to a host-installed plugin directory.
+ *
+ * The agent runtime provisions its substrate (e.g. agents-api and the selected
+ * AI provider plugin) into the sandbox from the host's own installed copies, so
+ * consumers select the runtime profile and supply domain inputs only — they
+ * never hand-inject runtime plugin sources. This is the default source strategy;
+ * an explicit component contract path or the browser runtime component registry
+ * still take precedence, and supply a source for plugins not installed locally.
+ *
+ * @param string $slug Plugin slug.
+ * @return string Absolute host plugin directory, or '' when not installed.
+ */
+private static function browser_host_runtime_plugin_dir( string $slug ): string {
+	$slug = self::safe_key( $slug );
+	if ( '' === $slug ) {
+		return '';
+	}
+
+	$roots = array();
+	if ( defined( 'WP_PLUGIN_DIR' ) ) {
+		$roots[] = (string) WP_PLUGIN_DIR;
+	}
+
+	/**
+	 * Filters the host plugin roots searched when resolving a runtime plugin
+	 * slug to an installed source. Defaults to WP_PLUGIN_DIR. A host or deploy
+	 * can add roots so runtime plugins that live outside the standard plugin
+	 * directory still resolve to an installable source.
+	 *
+	 * @param array<int,string> $roots Host plugin roots.
+	 * @param string            $slug  Plugin slug being resolved.
+	 */
+	if ( function_exists( 'apply_filters' ) ) {
+		$roots = apply_filters( 'wp_codebox_browser_runtime_host_plugin_roots', $roots, $slug );
+	}
+
+	foreach ( is_array( $roots ) ? $roots : array() as $root ) {
+		$root = trim( (string) $root );
+		if ( '' === $root ) {
+			continue;
+		}
+
+		$dir = self::browser_clean_path( rtrim( $root, '/\\' ) . DIRECTORY_SEPARATOR . $slug );
+		if ( '' !== $dir && is_dir( $dir ) ) {
+			return $dir;
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Surfaces a required runtime component that has no resolvable source.
+ *
+ * A component reaches this path when it is neither installed on the host nor
+ * backed by a component contract path or registry source. The host or deploy
+ * must provide a source (via wp_codebox_browser_runtime_component_registry,
+ * wp_codebox_component_contracts, or wp_codebox_browser_runtime_host_plugin_roots);
+ * the runtime sandbox cannot fabricate one.
+ *
+ * @param string $slug Unresolved component slug.
+ */
+private static function browser_runtime_component_unresolved( string $slug ): void {
+	$slug = self::safe_key( $slug );
+	if ( '' === $slug ) {
+		return;
+	}
+
+	if ( function_exists( 'do_action' ) ) {
+		do_action( 'wp_codebox_browser_runtime_component_unresolved', $slug );
+	}
+
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log( sprintf( 'WP Codebox: browser runtime component "%s" has no resolvable source. Install it on the host or provide a source via the component registry/contract or host plugin roots filter.', $slug ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+	}
 }
 
 private static function browser_component_plugins_required( array $input ): bool {

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -281,3 +281,32 @@ assert( 'wp-codebox/example-runtime-result/v1' === $explicit_runtime['schema'] )
 $unknown_runtime = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'runtime_provider_id' => 'missing-runtime' ) );
 assert( is_wp_error( $unknown_runtime ) );
 assert( 'wp_codebox_runtime_provider_unavailable' === $unknown_runtime->get_error_code() );
+
+// Default agent-runtime substrate provisioning (issue #1591): selecting
+// codebox-agent-runtime contributes the runtime substrate (agents-api) by
+// default, so consumers supply domain inputs only and never hand-inject
+// agents-api / data-machine / provider plugins.
+$profile_registry = WP_Codebox_Agents_API_Adapter::runtime_profile_registry(
+	array(
+		'codebox-agent-runtime' => array(
+			'id'           => 'codebox-agent-runtime',
+			'capabilities' => array( 'codebox.agent-runtime' ),
+		),
+	)
+);
+$agent_runtime_component_slugs = array_map(
+	static fn( array $component ): string => (string) ( $component['slug'] ?? '' ),
+	is_array( $profile_registry['codebox-agent-runtime']['components'] ?? null ) ? $profile_registry['codebox-agent-runtime']['components'] : array()
+);
+assert( in_array( 'agents-api', $agent_runtime_component_slugs, true ) );
+
+$required_components = WP_Codebox_Agents_API_Adapter::browser_runtime_required_components( array() );
+assert( in_array( 'agents-api', $required_components, true ) );
+
+// A host/deploy that needs additional substrate (e.g. Data Machine for bundles
+// that use those abilities) extends the default set through the filter.
+$GLOBALS['wp_codebox_test_filters']['wp_codebox_agent_runtime_default_components'] = array( 'agents-api', 'data-machine', 'data-machine-code' );
+$extended_required = WP_Codebox_Agents_API_Adapter::browser_runtime_required_components( array() );
+assert( in_array( 'data-machine', $extended_required, true ) );
+assert( in_array( 'data-machine-code', $extended_required, true ) );
+unset( $GLOBALS['wp_codebox_test_filters']['wp_codebox_agent_runtime_default_components'] );

--- a/scripts/php-browser-runtime-agent-substrate-smoke.php
+++ b/scripts/php-browser-runtime-agent-substrate-smoke.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Smoke test: the agentic runtime provisions its runtime substrate into the
+ * browser sandbox by default (issue #1591).
+ *
+ * Proves that with the codebox-agent-runtime profile selected and NO
+ * consumer-supplied component sources, the browser runtime dependency payload
+ * resolves the default substrate (agents-api + the selected provider plugin)
+ * from the host's installed plugin directory, and that an unresolvable required
+ * component is surfaced rather than silently dropped.
+ */
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+final class WP_Error {
+	/** @param array<string,mixed> $data */
+	public function __construct( private string $code = '', private string $message = '', private array $data = array() ) {}
+	public function get_error_code(): string { return $this->code; }
+	public function get_error_message(): string { return $this->message; }
+	/** @return array<string,mixed> */
+	public function get_error_data(): array { return $this->data; }
+}
+
+function is_wp_error( mixed $value ): bool {
+	return $value instanceof WP_Error;
+}
+
+/** @return array{basedir:string,baseurl:string} */
+function wp_upload_dir(): array {
+	return array(
+		'basedir' => $GLOBALS['wp_codebox_substrate_uploads'],
+		'baseurl' => 'https://example.test/wp-content/uploads',
+	);
+}
+
+/** @return array<string,mixed>|false */
+function wp_parse_url( string $url ): array|false {
+	return parse_url( $url );
+}
+
+function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+	unset( $args );
+	return $value;
+}
+
+function do_action( string $hook_name, mixed ...$args ): void {
+	if ( 'wp_codebox_browser_runtime_component_unresolved' === $hook_name ) {
+		$GLOBALS['wp_codebox_substrate_unresolved'][] = (string) ( $args[0] ?? '' );
+	}
+}
+
+function sanitize_key( string $key ): string {
+	return strtolower( preg_replace( '/[^a-zA-Z0-9_-]/', '', $key ) ?? '' );
+}
+
+function sanitize_text_field( string $value ): string {
+	return trim( preg_replace( '/[\r\n\t ]+/', ' ', $value ) ?? '' );
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-path-policy.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php';
+
+final class WP_Codebox_Browser_Runtime_Agent_Substrate_Smoke {
+	use WP_Codebox_Abilities_Browser_Runtime;
+
+	/** @param array<string,mixed> $input @param array<int,array<string,mixed>> $browser_plugins @return array<string,mixed>|WP_Error */
+	public static function dependencies( array $input, array $browser_plugins = array() ): array|WP_Error {
+		return ( new ReflectionMethod( self::class, 'browser_runtime_dependencies' ) )->invoke( null, $input, $browser_plugins, null );
+	}
+
+	/** @param array<string,mixed> $input @param array<int,mixed> $declared_components @return array<int,array<string,mixed>>|WP_Error */
+	public static function component_plugins( array $input, array $declared_components ): array|WP_Error {
+		return ( new ReflectionMethod( self::class, 'browser_component_plugins' ) )->invoke( null, $input, array(), $declared_components );
+	}
+
+	/** @return array<int,string> */
+	private static function string_list( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		return array_values( array_filter( array_map( 'strval', $value ), static fn( string $item ): bool => '' !== trim( $item ) ) );
+	}
+
+	/** @param array<string,mixed> $input @return array<int,string> Provider plugin paths (lives in the inheritance trait in production). */
+	private static function browser_provider_plugin_paths( array $input ): array {
+		return array_values( array_filter( is_array( $input['provider_plugin_paths'] ?? null ) ? $input['provider_plugin_paths'] : array(), static fn( $path ): bool => is_string( $path ) && is_dir( $path ) ) );
+	}
+}
+
+function fail( string $message ): void {
+	fwrite( STDERR, $message . PHP_EOL );
+	exit( 1 );
+}
+
+function remove_tree( string $path ): void {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $iterator as $item ) {
+		if ( $item instanceof SplFileInfo && $item->isDir() ) {
+			rmdir( $item->getPathname() );
+		} elseif ( $item instanceof SplFileInfo ) {
+			unlink( $item->getPathname() );
+		}
+	}
+	rmdir( $path );
+}
+
+/** @param array<int,array<string,mixed>> $plugins @return array<int,array<string,mixed>> */
+function plugin_by_slug( array $plugins, string $slug ): array {
+	foreach ( $plugins as $plugin ) {
+		if ( $slug === ( $plugin['slug'] ?? '' ) ) {
+			return $plugin;
+		}
+	}
+	return array();
+}
+
+$root = sys_get_temp_dir() . '/wp-codebox-agent-substrate-smoke';
+remove_tree( $root );
+$GLOBALS['wp_codebox_substrate_uploads']    = $root . '/uploads';
+$GLOBALS['wp_codebox_substrate_unresolved'] = array();
+
+// -- Phase 1 (BEFORE): no runtime substrate installed on the host. ----------------
+// The agent-runtime profile declares agents-api as a component, but with no host
+// install, contract, or registry source it cannot resolve. Pre-fix this was a
+// silent drop ("plugins (0)"); now it is surfaced via the unresolved action.
+mkdir( $GLOBALS['wp_codebox_substrate_uploads'], 0777, true );
+define( 'WP_PLUGIN_DIR', $root . '/active-plugins' );
+
+$before = WP_Codebox_Browser_Runtime_Agent_Substrate_Smoke::component_plugins(
+	array(),
+	array( array( 'slug' => 'agents-api' ) )
+);
+if ( is_wp_error( $before ) ) {
+	fail( 'Expected component resolution without a source to return an empty list, got error ' . $before->get_error_code() );
+}
+if ( array() !== $before ) {
+	fail( 'Expected no resolvable component plugins when the substrate is not installed.' );
+}
+if ( ! in_array( 'agents-api', $GLOBALS['wp_codebox_substrate_unresolved'], true ) ) {
+	fail( 'Expected the unresolved required component "agents-api" to be surfaced via wp_codebox_browser_runtime_component_unresolved.' );
+}
+
+// -- Phase 2 (AFTER): substrate installed on the host. ----------------------------
+// Install agents-api + the selected provider plugin into WP_PLUGIN_DIR. The
+// browser runtime now resolves both from the host's installed copies with no
+// consumer-supplied component sources.
+mkdir( WP_PLUGIN_DIR . '/agents-api', 0777, true );
+file_put_contents( WP_PLUGIN_DIR . '/agents-api/agents-api.php', "<?php\n/* Plugin Name: Agents API */\n" );
+mkdir( WP_PLUGIN_DIR . '/ai-provider-for-openai', 0777, true );
+file_put_contents( WP_PLUGIN_DIR . '/ai-provider-for-openai/ai-provider-for-openai.php', "<?php\n/* Plugin Name: AI Provider for OpenAI */\n" );
+
+// Shape mirrors WP_Codebox_Runtime_Profile_Resolver output for a selected
+// codebox-agent-runtime + provider-openai profile: agents-api as a declared
+// runtime component, the provider plugin as a slug-only runtime plugin.
+$input = array(
+	'runtime' => array(
+		'components' => array( array( 'slug' => 'agents-api' ) ),
+		'plugins'    => array( array( 'slug' => 'ai-provider-for-openai', 'activate' => true ) ),
+	),
+);
+
+$after = WP_Codebox_Browser_Runtime_Agent_Substrate_Smoke::dependencies( $input );
+if ( is_wp_error( $after ) ) {
+	fail( 'Expected runtime dependencies to resolve, got error ' . $after->get_error_code() . ': ' . $after->get_error_message() );
+}
+
+$plugins = is_array( $after['plugins'] ?? null ) ? $after['plugins'] : array();
+
+$agents_api = plugin_by_slug( $plugins, 'agents-api' );
+if ( empty( $agents_api ) ) {
+	fail( 'Expected the default substrate to provision agents-api from the host install.' );
+}
+if ( true !== ( $agents_api['local_package'] ?? false ) || ! str_starts_with( (string) ( $agents_api['url'] ?? '' ), 'data:application/zip;base64,' ) ) {
+	fail( 'Expected agents-api to be packaged from the host install as a local data: package.' );
+}
+if ( 'host-installed-plugin' !== ( $agents_api['provenance']['source'] ?? '' ) ) {
+	fail( 'Expected agents-api provenance to record host-installed-plugin resolution.' );
+}
+
+$provider = plugin_by_slug( $plugins, 'ai-provider-for-openai' );
+if ( empty( $provider ) ) {
+	fail( 'Expected the selected provider plugin to provision from the host install.' );
+}
+if ( true !== ( $provider['local_package'] ?? false ) || ! str_starts_with( (string) ( $provider['url'] ?? '' ), 'data:application/zip;base64,' ) ) {
+	fail( 'Expected ai-provider-for-openai to be packaged from the host install as a local data: package.' );
+}
+
+if ( ! in_array( 'agents-api', is_array( $after['components'] ?? null ) ? $after['components'] : array(), true ) ) {
+	fail( 'Expected agents-api to appear in the resolved component slug list.' );
+}
+if ( (int) ( $after['summary']['plugins'] ?? 0 ) < 2 ) {
+	fail( 'Expected at least the agents-api + provider substrate in the dependency summary.' );
+}
+
+remove_tree( $root );
+fwrite( STDOUT, "PHP browser runtime agent substrate smoke passed\n" );
+fwrite( STDOUT, "  before: agents-api unresolved (surfaced), plugins (0)\n" );
+fwrite( STDOUT, sprintf( "  after:  plugins (%d) -> agents-api + ai-provider-for-openai from host installs\n", count( $plugins ) ) );

--- a/scripts/smoke-manifest.ts
+++ b/scripts/smoke-manifest.ts
@@ -144,6 +144,7 @@ export const smokeGroups = {
       phpSmoke("php-agents-api-execution-targets-smoke"),
       npmScript("test:php-agents-api-adapter-contract"),
       npmScript("test:php-sandbox-workspace-executor"),
+      phpSmoke("php-browser-runtime-agent-substrate-smoke"),
       phpSmoke("php-run-plan-contract-smoke"),
       tsxSmoke("host-delegation-contract-smoke"),
       tsxSmoke("codex-agent-recipe-smoke"),


### PR DESCRIPTION
Closes #1591

## Problem

WP Codebox **is** the agentic runtime, but selecting the `codebox-agent-runtime` profile did not provision any runtime substrate into the browser/Playground sandbox. The profile (`src/class-wp-codebox-runtime-profile-resolver.php`) declared only capabilities/requires, and the browser component machinery (`wp_codebox_browser_runtime_required_components` / `wp_codebox_browser_runtime_component_registry`) defaulted empty with no registered source. A studio-native sandbox therefore ended up with `plugins (0)` — and a slug-only provider plugin from the provider profile would error on an empty package URL.

The product directive: when used as an agentic runtime, Codebox provisions its substrate **by default**. Consumers orchestrate Codebox APIs and supply **domain inputs only** (worker bundle, goal, provider selection); they must not hand-inject or even know about `agents-api` / provider plugins.

## Runtime-set decision (from code evidence)

The minimal substrate to run agents-api worker bundles + the agent loop in the sandbox is **`agents-api` + the selected AI provider plugin**.

- `agents-api` ships its own conversation loop (`src/Runtime/class-wp-agent-conversation-loop.php`), workflow runner (`src/Workflows/class-wp-agent-workflow-runner.php`), and bundle importer (`src/Registry/register-agent-runtime-bundle-importer.php` → `wp_agent_import_runtime_bundles`).
- It has **zero** references to `data-machine` / `datamachine` / `data_machine` in `src/`, and its `composer.json` `require` is only `php >=8.1`. It is self-described as "WordPress-shaped agent runtime substrate" and runs the loop without Data Machine.
- `data-machine` / `data-machine-code` are **not** in the minimal set. They appear in the CLI host path (`packages/cli/src/agent-sandbox.ts` → `defaultRuntimeComponentSources`) as best-effort, present-only components for the broader coding-agent substrate (workspace/git/memory abilities), filtered out when absent (`uniqueComponentSources`). They are only needed when a worker bundle uses DM abilities.

Both `agents-api` and `ai-provider-for-openai` are installed on the agentic host, so the minimal substrate is fully resolvable from host installed copies on a stock agentic host — **no product blocker, no hardcoded paths.**

## Source-resolution mechanism

Reuses the existing browser component/contract machinery; no parallel installer.

- **Generic host-installed-plugin-dir resolution** (`browser_host_runtime_plugin_dir`): a declared runtime component slug or a slug-only runtime/provider plugin resolves to `WP_PLUGIN_DIR/<slug>` when installed, then is packaged through the existing `browser_package_component_plugin` path into a local `data:` package. Roots are filterable via `wp_codebox_browser_runtime_host_plugin_roots`. Explicit component-contract paths and the `wp_codebox_browser_runtime_component_registry` still take precedence — the registry remains the escape hatch for plugins **not** installed locally.
- **Default substrate declaration** (agents-api adapter): contributes `agents-api` to the `codebox-agent-runtime` profile and to `wp_codebox_browser_runtime_required_components` by default, and exposes `wp_codebox_agent_runtime_default_components` so a host/deploy can extend the substrate (e.g. add `data-machine` / `data-machine-code`).
- **Surfacing**: an unresolvable required component fires `wp_codebox_browser_runtime_component_unresolved` and a `WP_DEBUG` log instead of being silently dropped, so a host/deploy that must supply a source is told so.

## Files changed

- `packages/wordpress-plugin/src/trait-wp-codebox-abilities-browser-runtime.php` — `browser_host_runtime_plugin_dir()` + `browser_runtime_component_unresolved()`; host-dir fallback wired into `browser_component_plugins()` and `browser_runtime_plugin_specs()`.
- `packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php` — default substrate slugs, `browser_runtime_required_components()`, `codebox-agent-runtime` profile augmentation, `wp_codebox_agent_runtime_default_components` filter.
- `scripts/php-browser-runtime-agent-substrate-smoke.php` (new) + `scripts/php-agents-api-adapter-contract-smoke.php` + `scripts/smoke-manifest.ts` + `package.json` — deterministic coverage.

## Before/after verification

New smoke `php-browser-runtime-agent-substrate-smoke` drives the real `browser_runtime_dependencies` path with the `codebox-agent-runtime` profile shape and **no** consumer-supplied component sources:

```
PHP browser runtime agent substrate smoke passed
  before: agents-api unresolved (surfaced), plugins (0)
  after:  plugins (2) -> agents-api + ai-provider-for-openai from host installs
```

- **before** (substrate not installed): component resolution returns empty and `agents-api` is surfaced via the unresolved action — reproducing the `plugins (0)` gap, now visible.
- **after** (substrate installed): payload resolves `agents-api` (provenance `host-installed-plugin`, local `data:` package) + `ai-provider-for-openai`, `agents-api` appears in the component slug list, and `summary.plugins >= 2`.

The adapter contract smoke additionally asserts `codebox-agent-runtime` carries `agents-api` by default, `browser_runtime_required_components()` includes it, and the `wp_codebox_agent_runtime_default_components` filter can extend the set with `data-machine` / `data-machine-code`.

## Test/lint results

- `npm run smoke -- --group=agent` — pass (includes the two substrate smokes)
- `npm run smoke -- --group=core|runtime|policy` — pass
- `npm run build` (lint) — pass
- `php -l` on all changed PHP — clean
- Pre-existing unrelated failure: `mounted-workspace-diff-smoke` (artifact group) fails identically on the clean origin/main tree before any change — a git-diff environment smoke, not touched by this PR.

## Product decision still needed

None blocking. The minimal substrate (agents-api + provider) resolves from stock host installs. If a deploy wants `data-machine` / `data-machine-code` in the default substrate, add the slugs via `wp_codebox_agent_runtime_default_components` and supply a source via the host install, `wp_codebox_browser_runtime_component_registry`, or `wp_codebox_browser_runtime_host_plugin_roots` — no code change required.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Design, implementation, and verification of default agent-runtime provisioning in the Codebox browser sandbox.