### PR TITLE
Add PHP contract parity guardrails

### DIFF
--- a/scripts/php-primitive-contract-parity-smoke.php
+++ b/scripts/php-primitive-contract-parity-smoke.php
@@ -40,6 +40,7 @@ require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runti
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-run-plan.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-fuzz-suite-runner.php';
 
 $fixture = json_decode( file_get_contents( __DIR__ . '/../tests/fixtures/primitive-contracts.json' ), true );
 if ( ! is_array( $fixture ) ) {
@@ -142,5 +143,11 @@ assert_same_contract( $fixture['runPlan']['dependencyBatches'], $run_plan->depen
 assert_same_contract( $fixture['runPlan']['concurrency']['defaulted'], $run_plan->normalize_concurrency( '', array( 'default_concurrency' => 3, 'max_concurrency' => 5 ) ), 'run-plan default concurrency' );
 assert_same_contract( $fixture['runPlan']['concurrency']['clamped'], $run_plan->normalize_concurrency( 99, array( 'max_concurrency' => 2 ) ), 'run-plan clamped concurrency' );
 assert_same_contract( $fixture['runPlan']['progress'], $run_plan->progress_snapshot( $fixture['runPlan']['progressInput'] ), 'run-plan progress snapshot' );
+
+assert_same_contract(
+	$fixture['fuzzRunner']['phpInProcessCapabilities'],
+	WP_Codebox_Fuzz_Suite_Runner::fuzz_suite_runner_capabilities_contract(),
+	'PHP in-process fuzz runner capabilities contract'
+);
 
 fwrite( STDOUT, "PHP primitive contract parity smoke passed\n" );

--- a/scripts/primitive-contract-fixture.ts
+++ b/scripts/primitive-contract-fixture.ts
@@ -6,6 +6,7 @@ import {
   normalizeRunPlanConcurrency,
   normalizeRunPlanProgressSnapshot,
   normalizeRuntimeMountTarget,
+  PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES,
   redactJsonValue,
   resolveEffectiveRuntimeToolPolicy,
   resolveRuntimeToolAlias,
@@ -224,6 +225,15 @@ export function primitiveContractsFixture(): Record<string, unknown> {
       progressInput: runPlanProgressInput,
       progress: normalizeRunPlanProgressSnapshot(runPlanProgressInput),
       schemas: { plan: RUN_PLAN_SCHEMA, event: RUN_PLAN_EVENT_SCHEMA, progress: RUN_PLAN_PROGRESS_SCHEMA, result: RUN_PLAN_RESULT_SCHEMA },
+    },
+    fuzzRunner: {
+      phpInProcessCapabilities: {
+        schema: PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES.schema,
+        mode: PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES.mode,
+        capabilities: PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES.capabilities,
+        targetKinds: PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES.targetKinds,
+        unsupportedRequiredCapabilities: PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES.unsupportedRequiredCapabilities,
+      },
     },
   }
 }

--- a/tests/fixtures/primitive-contracts.json
+++ b/tests/fixtures/primitive-contracts.json
@@ -590,5 +590,22 @@
       "progress": "wp-codebox/run-plan-progress/v1",
       "result": "wp-codebox/run-plan-result/v1"
     }
+  },
+  "fuzzRunner": {
+    "phpInProcessCapabilities": {
+      "schema": "wp-codebox/fuzz-runner-capabilities/v1",
+      "mode": "php-in-process",
+      "capabilities": [
+        "target:ability",
+        "target:http",
+        "target:rest"
+      ],
+      "targetKinds": [
+        "ability",
+        "http",
+        "rest"
+      ],
+      "unsupportedRequiredCapabilities": []
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add the TS PHP-in-process fuzz runner capability contract fields to the primitive contract fixture.
- Assert the PHP fuzz runner's duplicated capability metadata stays aligned with that TS-derived fixture.
- Keep the change test-only with no runtime behavior changes.

## Tests
- npm run test:php-primitive-contract-parity
- npm run test:primitive-contract-parity
- npm run test:php-fuzz-suite-runner
- npm run test:fanout-aggregation-contract-parity
- npm run test:php-fanout-aggregation-contract
- npm run test:schema-parity
- git diff --check

## Residual risks
- The guardrail covers the PHP in-process fuzz runner fields duplicated in PHP today; it intentionally does not require PHP to expose TS-only optional fields that PHP does not currently report.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Scoped parity test implementation and verification