### PR TITLE
fix: attach wp-codebox.zip as GitHub Release asset

### DIFF
--- a/scripts/build-wordpress-plugin-zip.ts
+++ b/scripts/build-wordpress-plugin-zip.ts
@@ -1,50 +1,21 @@
 import { execFile } from "node:child_process"
-import { cp, mkdir, mkdtemp, rm, stat } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { resolve } from "node:path"
 import { promisify } from "node:util"
+
+import { assembleWordpressPluginZip } from "./lib/assemble-wordpress-plugin-zip.ts"
 
 const execFileAsync = promisify(execFile)
 const repoRoot = resolve(import.meta.dirname, "..")
-const pluginSource = join(repoRoot, "packages", "wordpress-plugin")
-const outputDirectory = join(pluginSource, "dist")
-const outputZip = join(outputDirectory, "wp-codebox.zip")
-const stagingRoot = await mkdtemp(join(tmpdir(), "wp-codebox-plugin-"))
-const stagingPlugin = join(stagingRoot, "wp-codebox")
-const cliPackageRoot = join(repoRoot, "dist", "release", "wp-codebox-cli")
-const recursiveRmOptions = { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }
 
-try {
-	await execFileAsync("npm", ["run", "release:package"], {
-		cwd: repoRoot,
-		env: {
-			...process.env,
-			WP_CODEBOX_RELEASE_PLATFORM: process.env.WP_CODEBOX_RELEASE_PLATFORM ?? "linux",
-			WP_CODEBOX_RELEASE_ARCH: process.env.WP_CODEBOX_RELEASE_ARCH ?? "x64",
-		},
-		maxBuffer: 1024 * 1024 * 20,
-	})
-	await mkdir(outputDirectory, { recursive: true })
-	await mkdir(stagingPlugin, { recursive: true })
-	await cp(join(pluginSource, "wp-codebox.php"), join(stagingPlugin, "wp-codebox.php"))
-	await cp(join(pluginSource, "README.md"), join(stagingPlugin, "README.md"))
-	await cp(join(pluginSource, "src"), join(stagingPlugin, "src"), { recursive: true })
-	if (await exists(join(pluginSource, "assets"))) {
-		await cp(join(pluginSource, "assets"), join(stagingPlugin, "assets"), { recursive: true })
-	}
-	await cp(cliPackageRoot, join(stagingPlugin, "vendor", "wp-codebox-cli"), { recursive: true })
-	await rm(outputZip, { force: true })
-  await execFileAsync("zip", ["-qr", outputZip, "wp-codebox"], { cwd: stagingRoot })
-  console.log(`Built ${outputZip}`)
-} finally {
-  await rm(stagingRoot, recursiveRmOptions)
-}
+await execFileAsync("npm", ["run", "release:package"], {
+	cwd: repoRoot,
+	env: {
+		...process.env,
+		WP_CODEBOX_RELEASE_PLATFORM: process.env.WP_CODEBOX_RELEASE_PLATFORM ?? "linux",
+		WP_CODEBOX_RELEASE_ARCH: process.env.WP_CODEBOX_RELEASE_ARCH ?? "x64",
+	},
+	maxBuffer: 1024 * 1024 * 20,
+})
 
-async function exists(path: string): Promise<boolean> {
-	try {
-		await stat(path)
-		return true
-	} catch {
-		return false
-	}
-}
+const outputZip = await assembleWordpressPluginZip(repoRoot)
+console.log(`Built ${outputZip}`)

--- a/scripts/lib/assemble-wordpress-plugin-zip.ts
+++ b/scripts/lib/assemble-wordpress-plugin-zip.ts
@@ -1,0 +1,60 @@
+import { execFile } from "node:child_process"
+import { cp, mkdir, mkdtemp, rm, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const recursiveRmOptions = { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }
+
+/**
+ * Assemble the WordPress plugin distribution zip from already-staged inputs.
+ *
+ * This helper assumes the CLI release bundle has already been staged at
+ * `dist/release/wp-codebox-cli` (produced by `package-release-artifact.ts`).
+ * It does NOT invoke `release:package` itself, so it is safe to call from
+ * inside the release artifact script without recursing.
+ *
+ * @param repoRoot Absolute path to the repository root.
+ * @returns Absolute path to the produced `wp-codebox.zip`.
+ */
+export async function assembleWordpressPluginZip(repoRoot: string): Promise<string> {
+	const pluginSource = join(repoRoot, "packages", "wordpress-plugin")
+	const outputDirectory = join(pluginSource, "dist")
+	const outputZip = join(outputDirectory, "wp-codebox.zip")
+	const cliPackageRoot = join(repoRoot, "dist", "release", "wp-codebox-cli")
+	const stagingRoot = await mkdtemp(join(tmpdir(), "wp-codebox-plugin-"))
+	const stagingPlugin = join(stagingRoot, "wp-codebox")
+
+	try {
+		await mkdir(outputDirectory, { recursive: true })
+		await mkdir(stagingPlugin, { recursive: true })
+		await cp(join(pluginSource, "wp-codebox.php"), join(stagingPlugin, "wp-codebox.php"))
+		await cp(join(pluginSource, "README.md"), join(stagingPlugin, "README.md"))
+		await cp(join(pluginSource, "src"), join(stagingPlugin, "src"), { recursive: true })
+		if (await exists(join(pluginSource, "assets"))) {
+			await cp(join(pluginSource, "assets"), join(stagingPlugin, "assets"), { recursive: true })
+		}
+		await cp(cliPackageRoot, join(stagingPlugin, "vendor", "wp-codebox-cli"), { recursive: true })
+		await rm(outputZip, { force: true })
+		await execFileAsync("zip", ["-qr", outputZip, "wp-codebox"], { cwd: stagingRoot })
+		return outputZip
+	} finally {
+		await rm(stagingRoot, recursiveRmOptions)
+	}
+}
+
+async function exists(path: string): Promise<boolean> {
+	try {
+		await stat(path)
+		return true
+	} catch {
+		return false
+	}
+}
+
+if (import.meta.filename === resolve(process.argv[1] ?? "")) {
+	const repoRoot = resolve(import.meta.dirname, "..", "..")
+	const outputZip = await assembleWordpressPluginZip(repoRoot)
+	console.log(`Built ${outputZip}`)
+}

--- a/scripts/package-release-artifact.ts
+++ b/scripts/package-release-artifact.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 
+import { assembleWordpressPluginZip } from "./lib/assemble-wordpress-plugin-zip.ts"
+
 const execFileAsync = promisify(execFile)
 const repoRoot = resolve(import.meta.dirname, "..")
 const releaseRoot = resolve(repoRoot, "dist", "release")
@@ -73,7 +75,18 @@ exec "\${NODE_BIN}" "\${SCRIPT_DIR}/../packages/cli/dist/index.js" "$@"
     maxBuffer: 1024 * 1024 * 10,
   })
 
-  process.stdout.write(JSON.stringify([{ path: `dist/${artifactName}`, type: "node-cli-tarball", platform: `${platformName}-${archName}` }]) + "\n")
+  // The deployable artifact is the WordPress plugin zip declared by homeboy.json
+  // (build_artifact: packages/wordpress-plugin/dist/wp-codebox.zip). It bundles
+  // the CLI release tree staged above, so build it here and surface it in the
+  // manifest so the release pipeline uploads it as a GitHub Release asset.
+  await assembleWordpressPluginZip(repoRoot)
+
+  process.stdout.write(
+    JSON.stringify([
+      { path: "packages/wordpress-plugin/dist/wp-codebox.zip", type: "wordpress-plugin-zip" },
+      { path: `dist/${artifactName}`, type: "node-cli-tarball", platform: `${platformName}-${archName}` },
+    ]) + "\n",
+  )
 } finally {
   await rm(stagingReleaseRoot, recursiveRmOptions)
 }


### PR DESCRIPTION
## Root cause

`homeboy.json` declares the deployable as the WordPress plugin zip:

```json
"build_artifact": "packages/wordpress-plugin/dist/wp-codebox.zip"
```

But the release pipeline only attached the npm CLI tarball to the GitHub Release — never `wp-codebox.zip`.

The mechanism: `scripts/package-release-artifact.ts` (run by `npm run release:package`, which is the release step in `homeboy.json` `scripts.test`) writes a stdout JSON manifest of artifacts to upload. That manifest declared **only** the CLI tarball:

```js
process.stdout.write(JSON.stringify([{ path: `dist/${artifactName}`, type: "node-cli-tarball", ... }]) + "\n")
```

The plugin zip was never built or declared by `release:package`, so the pipeline never uploaded it. The package is `"private": true`, so npm publish is correctly skipped and the build artifact *is* the deliverable — but that deliverable wasn't reaching the Release.

### Evidence (from the v0.10.2 release/deploy)

`gh release view v0.10.2 --json assets` showed only:

```
01-wp-codebox-workspace-0.10.2.tgz
```

— **no** `wp-codebox.zip`. So the default `homeboy deploy wp-codebox` (`artifact_source: release_asset`) failed:

```
Failed to download release artifact from
https://github.com/Automattic/wp-codebox/releases/download/v0.10.2/wp-codebox.zip:
curl: (22) ... 404
```

Operators had to fall back to `homeboy deploy --tagged`.

## The change

1. **`scripts/lib/assemble-wordpress-plugin-zip.ts` (new)** — extracts the plugin-zip assembly (stage `wp-codebox.php`, `README.md`, `src`, `assets`, and the already-staged `dist/release/wp-codebox-cli` vendor tree, then `zip` it to `packages/wordpress-plugin/dist/wp-codebox.zip`). It does **not** invoke `release:package`, so it can be called from inside the release script without recursion.
2. **`scripts/package-release-artifact.ts`** — after staging the CLI release bundle (`dist/release/wp-codebox-cli`), it now also calls `assembleWordpressPluginZip()` and lists the zip first in the emitted manifest:

   ```js
   [
     { path: "packages/wordpress-plugin/dist/wp-codebox.zip", type: "wordpress-plugin-zip" },
     { path: `dist/${artifactName}`, type: "node-cli-tarball", platform: ... },
   ]
   ```
3. **`scripts/build-wordpress-plugin-zip.ts`** — refactored to reuse the shared lib (runs `release:package`, then assembles via the lib). Behavior is unchanged; it just no longer duplicates the assembly logic.

The emitted path is **exactly** `packages/wordpress-plugin/dist/wp-codebox.zip`, matching `homeboy.json` `build_artifact`, and the zip filename on disk is exactly `wp-codebox.zip` — the name the default deploy fetches.

## Why this fixes the 404

`homeboy release` uploads the artifacts declared in the `release:package` stdout manifest. With the zip now both **built** at the declared path and **declared** in the manifest, the release attaches an asset literally named `wp-codebox.zip`. The default `homeboy deploy` (`artifact_source: release_asset`) downloads from `releases/download/<tag>/wp-codebox.zip` — which will now exist, so the download succeeds and the `--tagged` fallback is no longer required.

## Verification

- `npm run release:package` →
  ```
  [{"path":"packages/wordpress-plugin/dist/wp-codebox.zip","type":"wordpress-plugin-zip"},{"path":"dist/wp-codebox-cli-linux-x64.tar.gz","type":"node-cli-tarball","platform":"linux-x64"}]
  ```
  and produced `packages/wordpress-plugin/dist/wp-codebox.zip` (~445 MB, well-formed; `unzip -Z1` shows `wp-codebox/...` with the full `vendor/wp-codebox-cli/` tree).
- `npm run package:wordpress-plugin` still builds the zip at the same path, exit 0 (no regression from the refactor).
- `npm run smoke -- --group package` (the `package` smoke group → `npm run build`) passes, exit 0 — confirms the new TS files typecheck and compile.
- No PHP changed, so no `php -l` needed.

Closes #1592