### PR TITLE
Extract artifact ability service

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-artifact-ability-service.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-artifact-ability-service.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Artifact ability callback service for WP Codebox.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+final class WP_Codebox_Artifact_Ability_Service {
+
+	private const BROWSER_ARTIFACT_WRITE_SCOPE = 'artifact:write';
+
+	public function __construct(
+		private ?WP_Codebox_Artifacts $artifacts = null
+	) {}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function list_artifacts( array $input = array() ): array|WP_Error {
+		return $this->artifacts()->list( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function get_artifact( array $input ): array|WP_Error {
+		return $this->artifacts()->get( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function inspect_artifact( array $input ): array|WP_Error {
+		return $this->artifacts()->inspect( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function discard_artifact( array $input ): array|WP_Error {
+		return $this->artifacts()->discard( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function normalize_browser_artifact_bundle( array $input ): array|WP_Error {
+		return $this->artifacts()->normalize_browser_bundle( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function persist_browser_artifact( array $input ): array|WP_Error {
+		$result = $this->artifacts()->persist_browser_bundle( $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$authorization = $this->trusted_orchestrator_authorization( $input, self::BROWSER_ARTIFACT_WRITE_SCOPE );
+		if ( ! empty( $authorization['caller'] ) || ! empty( $authorization['scope'] ) ) {
+			$result['authorization'] = $authorization;
+		}
+
+		return $result;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function import_artifact_bundle( array $input ): array|WP_Error {
+		return $this->artifacts()->import_artifact_bundle( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function reimport_artifact_bundle( array $input ): array|WP_Error {
+		return $this->artifacts()->reimport_artifact_bundle( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function review_artifact( array $input ): array|WP_Error {
+		return $this->artifacts()->review_artifact( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function apply_artifact_preflight( array $input ): array|WP_Error {
+		return $this->artifacts()->apply_preflight( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function apply_approved_artifact( array $input ): array|WP_Error {
+		return $this->artifacts()->apply_approved( $input );
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
+	public function stage_artifact_apply( array $input ): array|WP_Error {
+		return WP_Codebox_Pending_Artifact_Apply::stage_apply_artifact( $input );
+	}
+
+	private function artifacts(): WP_Codebox_Artifacts {
+		if ( null === $this->artifacts ) {
+			$this->artifacts = new WP_Codebox_Artifacts();
+		}
+
+		return $this->artifacts;
+	}
+
+	/** @param array<string,mixed> $input Ability input. @return array<string,mixed> */
+	private function trusted_orchestrator_authorization( array $input, string $required_scope ): array {
+		$authorization = is_array( $input['authorization'] ?? null ) ? $input['authorization'] : array();
+		$caller        = trim( (string) ( $authorization['caller'] ?? '' ) );
+		$scope         = trim( (string) ( $authorization['scope'] ?? '' ) );
+		$result        = array_filter(
+			array(
+				'schema'     => 'wp-codebox/trusted-orchestrator-authorization/v1',
+				'caller'     => $caller,
+				'scope'      => $scope,
+				'authorized' => false,
+				'method'     => 'trusted-orchestrator',
+				'reason'     => 'missing-authorization',
+			),
+			static fn( mixed $value ): bool => '' !== $value
+		);
+
+		if ( '' === $caller ) {
+			return $result;
+		}
+
+		if ( $required_scope !== $scope ) {
+			$result['reason'] = 'missing-scope';
+			return $result;
+		}
+
+		/**
+		 * Filters trusted browser-session callers.
+		 *
+		 * @param array<int|string,mixed> $trusted_callers Trusted caller grants.
+		 * @param array<string,mixed>     $authorization   Explicit caller authorization payload.
+		 * @param array<string,mixed>     $input           Ability input.
+		 */
+		$trusted_callers = apply_filters( 'wp_codebox_trusted_browser_session_callers', array(), $authorization, $input );
+		$trusted_callers = is_array( $trusted_callers ) ? $trusted_callers : array();
+
+		if ( $this->trusted_browser_session_caller_has_scope( $trusted_callers, $caller, $scope ) ) {
+			$result['authorized'] = true;
+			$result['reason']     = 'trusted-caller-grant';
+			return $result;
+		}
+
+		$result['reason'] = 'caller-not-trusted';
+
+		return $result;
+	}
+
+	/** @param array<int|string,mixed> $trusted_callers Trusted caller grants. */
+	private function trusted_browser_session_caller_has_scope( array $trusted_callers, string $caller, string $scope ): bool {
+		foreach ( $trusted_callers as $key => $grant ) {
+			if ( is_string( $key ) && $caller === $key ) {
+				$scopes = is_array( $grant ) ? $grant : array( $grant );
+				return in_array( $scope, array_map( 'strval', $scopes ), true );
+			}
+
+			if ( ! is_array( $grant ) || $caller !== (string) ( $grant['caller'] ?? '' ) ) {
+				continue;
+			}
+
+			$scopes = is_array( $grant['scopes'] ?? null ) ? $grant['scopes'] : array( $grant['scope'] ?? '' );
+			if ( in_array( $scope, array_map( 'strval', $scopes ), true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
+++ b/packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php
@@ -3663,72 +3663,66 @@ private static function browser_runtime_has_plugin( array $runtime, string $slug
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function list_artifacts( array $input = array() ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->list( $input );
+	return self::artifact_ability_service()->list_artifacts( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function get_artifact( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->get( $input );
+	return self::artifact_ability_service()->get_artifact( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function inspect_artifact( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->inspect( $input );
+	return self::artifact_ability_service()->inspect_artifact( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function discard_artifact( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->discard( $input );
+	return self::artifact_ability_service()->discard_artifact( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function normalize_browser_artifact_bundle( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->normalize_browser_bundle( $input );
+	return self::artifact_ability_service()->normalize_browser_artifact_bundle( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function persist_browser_artifact( array $input ): array|WP_Error {
-	$result = ( new WP_Codebox_Artifacts() )->persist_browser_bundle( $input );
-	if ( is_wp_error( $result ) ) {
-		return $result;
-	}
-
-	$authorization = self::trusted_orchestrator_authorization( $input, self::BROWSER_ARTIFACT_WRITE_SCOPE );
-	if ( ! empty( $authorization['caller'] ) || ! empty( $authorization['scope'] ) ) {
-		$result['authorization'] = $authorization;
-	}
-
-	return $result;
+	return self::artifact_ability_service()->persist_browser_artifact( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function import_artifact_bundle( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->import_artifact_bundle( $input );
+	return self::artifact_ability_service()->import_artifact_bundle( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function reimport_artifact_bundle( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->reimport_artifact_bundle( $input );
+	return self::artifact_ability_service()->reimport_artifact_bundle( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function review_artifact( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->review_artifact( $input );
+	return self::artifact_ability_service()->review_artifact( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function apply_artifact_preflight( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->apply_preflight( $input );
+	return self::artifact_ability_service()->apply_artifact_preflight( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function apply_approved_artifact( array $input ): array|WP_Error {
-	return ( new WP_Codebox_Artifacts() )->apply_approved( $input );
+	return self::artifact_ability_service()->apply_approved_artifact( $input );
 }
 
 /** @param array<string,mixed> $input Ability input. @return array<string,mixed>|WP_Error */
 public static function stage_artifact_apply( array $input ): array|WP_Error {
-	return WP_Codebox_Pending_Artifact_Apply::stage_apply_artifact( $input );
+	return self::artifact_ability_service()->stage_artifact_apply( $input );
+}
+
+private static function artifact_ability_service(): WP_Codebox_Artifact_Ability_Service {
+	return new WP_Codebox_Artifact_Ability_Service();
 }
 }
 

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -65,6 +65,7 @@ require_once __DIR__ . '/src/class-wp-codebox-agent-sandbox-runner.php';
 require_once __DIR__ . '/src/class-wp-codebox-patch-approval-filter.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-pending-artifact-apply.php';
+require_once __DIR__ . '/src/class-wp-codebox-artifact-ability-service.php';
 require_once __DIR__ . '/src/class-wp-codebox-preview-options.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 require_once __DIR__ . '/src/class-wp-codebox-api.php';


### PR DESCRIPTION
## Summary
- Add `WP_Codebox_Artifact_Ability_Service` to own artifact listing, lookup, browser artifact persistence, import/reimport, review, preflight, stage, and apply ability callbacks.
- Keep existing ability trait methods as thin delegators for compatibility.
- Reuse `WP_Codebox_Artifacts` and `WP_Codebox_Pending_Artifact_Apply` for existing behavior.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-artifact-ability-service.php && php -l packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php && php -l packages/wordpress-plugin/wp-codebox.php`
- `npm run test:php-artifact-import-idempotency`
- `npm run test:php-public-api-facade`
- `npm run test:artifact-result-envelope`
- `npm run test:artifact-reference-dtos`
- `git diff --check`

## Residual risks
- This is a mechanical service extraction; residual risk is limited to preserving the browser artifact authorization metadata assembly now that it lives in the service.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Scoped service extraction and verification