### PR TITLE
Add front-page editor-open target (validate the imported post)

### DIFF
--- a/packages/runtime-playground/src/editor-actions.ts
+++ b/packages/runtime-playground/src/editor-actions.ts
@@ -1,10 +1,22 @@
 import { readFile } from "node:fs/promises"
-import { resolveCommandPath } from "@automattic/wp-codebox-core"
+import { resolveCommandPath, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { argValue } from "./commands.js"
+import { bootstrapPhpCode } from "./php-bootstrap.js"
+import { assertPlaygroundResponseOk, type PlaygroundRunResponse } from "./playground-command-errors.js"
+import type { PlaygroundCliServer } from "./preview-server.js"
+import { cleanWpCliOutput } from "./wp-cli-command-handlers.js"
+
+// Callback shape every editor command already holds for running PHP/WP-CLI inside
+// the sandbox (the same one used to mint admin auth cookies).
+export type RunPlaygroundCommand = (
+  command: string,
+  server: PlaygroundCliServer,
+  options: { code: string } | { scriptPath: string },
+) => Promise<PlaygroundRunResponse>
 
 export interface EditorOpenTarget {
   url: string
-  kind: "post" | "post-new" | "site" | "url"
+  kind: "post" | "post-new" | "site" | "url" | "front-page"
   postId?: number
   postType?: string
   waitSelector: string
@@ -31,6 +43,16 @@ export function editorOpenTargetFromArgs(args: string[]): EditorOpenTarget {
   if (target === "site") {
     return { url: "/wp-admin/site-editor.php", kind: "site", waitSelector }
   }
+  // The site's static front page (`page_on_front`). Its concrete post id is only
+  // known at runtime — e.g. after an importer materializes pages and points
+  // `page_on_front` at the imported home page — so the URL is resolved against
+  // the running WordPress by `resolveEditorOpenTargetUrl` before navigation,
+  // turning into `post.php?post=<page_on_front>&action=edit`. This lets a recipe
+  // open and validate the actual imported front page without knowing its id when
+  // the recipe is built.
+  if (target === "front-page") {
+    return { url: "", kind: "front-page", waitSelector }
+  }
 
   const postType = argValue(args, "post-type")?.trim() || "post"
   if (!/^[a-zA-Z0-9_-]+$/.test(postType)) {
@@ -47,10 +69,72 @@ export function editorOpenTargetFromArgs(args: string[]): EditorOpenTarget {
   }
 
   if (target !== "post-new") {
-    throw new Error(`wordpress.editor-open target supports post-new, site, or url=<path-or-url>: ${target}`)
+    throw new Error(`wordpress.editor-open target supports post-new, site, front-page, or url=<path-or-url>: ${target}`)
   }
 
   return { url: `/wp-admin/post-new.php?post_type=${encodeURIComponent(postType)}`, kind: "post-new", postType, waitSelector }
+}
+
+// Resolve an editor-open target that can only be pinned to a concrete editor URL
+// at runtime. Today that is `kind: "front-page"`, which asks the running
+// WordPress for its static front page (`page_on_front`) and rewrites the target
+// to `post.php?post=<id>&action=edit` so the editor opens the real page. Targets
+// that already carry a concrete URL (post, post-new, site, url) are returned
+// unchanged. Throws when `front-page` is requested but the site has no static
+// front page configured (`show_on_front` is not `page`, or `page_on_front` is
+// unset) — that is a real misconfiguration the caller must surface, not paper
+// over by silently opening an empty editor.
+export async function resolveEditorOpenTarget(
+  target: EditorOpenTarget,
+  context: {
+    command: string
+    runPlaygroundCommand?: RunPlaygroundCommand
+    runtimeSpec?: RuntimeCreateSpec
+    server: PlaygroundCliServer
+  },
+): Promise<EditorOpenTarget> {
+  if (target.kind !== "front-page") {
+    return target
+  }
+  const { command, runPlaygroundCommand, runtimeSpec, server } = context
+  if (!runPlaygroundCommand) {
+    throw new Error(`${command} target=front-page requires Playground PHP command support`)
+  }
+  if (!runtimeSpec) {
+    throw new Error(`${command} target=front-page requires a runtime spec`)
+  }
+
+  const resolveCommand = `${command}.resolve-front-page`
+  const response = await runPlaygroundCommand(resolveCommand, server, {
+    code: bootstrapPhpCode(runtimeSpec, frontPagePostIdPhpCode(), []),
+  })
+  assertPlaygroundResponseOk(resolveCommand, response)
+
+  const frontPageId = Number.parseInt(cleanWpCliOutput(response.text).trim(), 10)
+  if (!Number.isInteger(frontPageId) || frontPageId <= 0) {
+    throw new Error(
+      `${command} target=front-page found no static front page: WordPress has show_on_front != "page" or page_on_front is unset. Configure a static front page (e.g. an importer that sets page_on_front) before validating the front page.`,
+    )
+  }
+
+  return {
+    ...target,
+    kind: "post",
+    postId: frontPageId,
+    url: `/wp-admin/post.php?post=${frontPageId}&action=edit`,
+  }
+}
+
+// PHP that echoes the static front page id, or `0` when the site is not
+// configured to show a static page on the front.
+function frontPagePostIdPhpCode(): string {
+  return `
+$front_page_id = 0;
+if ( 'page' === get_option( 'show_on_front' ) ) {
+    $front_page_id = (int) get_option( 'page_on_front' );
+}
+echo $front_page_id;
+`
 }
 
 export const EDITOR_VALIDATE_BLOCKS_DEFAULT_PROVIDER = "wordpress-block-editor"

--- a/packages/runtime-playground/src/editor-command-runners.ts
+++ b/packages/runtime-playground/src/editor-command-runners.ts
@@ -9,7 +9,7 @@ import { browserStepRecord } from "./browser-interactions.js"
 import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewOrigins, browserPreviewReadinessError, browserPreviewRouting, browserPreviewSecureContextError, browserPreviewTopology, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { browserProbeReplayability, browserProbeViewport } from "./browser-probe.js"
 import { argValue, commaListArg, durationArg, jsonArrayArg } from "./commands.js"
-import { editorActionStepsFromArgs, editorOpenTargetFromArgs, editorValidateContentFromArgs, editorValidateProviderFromArgs, type EditorActionStep } from "./editor-actions.js"
+import { editorActionStepsFromArgs, editorOpenTargetFromArgs, editorValidateContentFromArgs, editorValidateProviderFromArgs, resolveEditorOpenTarget, type EditorActionStep } from "./editor-actions.js"
 import type { PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { serializeBrowserError } from "./browser-metrics.js"
@@ -497,7 +497,12 @@ export async function runEditorOpenCommand({
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
-  const target = editorOpenTargetFromArgs(args)
+  const target = await resolveEditorOpenTarget(editorOpenTargetFromArgs(args), {
+    command: "wordpress.editor-open",
+    runPlaygroundCommand,
+    runtimeSpec,
+    server,
+  })
   const capture = new Set(commaListArg(args, "capture"))
   if (capture.size === 0) {
     capture.add("steps")
@@ -704,7 +709,12 @@ export async function runEditorActionsCommand({
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
-  const target = editorOpenTargetFromArgs(args)
+  const target = await resolveEditorOpenTarget(editorOpenTargetFromArgs(args), {
+    command: "wordpress.editor-actions",
+    runPlaygroundCommand,
+    runtimeSpec,
+    server,
+  })
   const actionSteps = await editorActionStepsFromArgs(args)
   const capture = new Set(commaListArg(args, "capture"))
   if (capture.size === 0) {
@@ -1524,7 +1534,12 @@ export async function runEditorValidateBlocksCommand({
   spec: ExecutionSpec
 }): Promise<{ artifact: BrowserArtifact; output: string }> {
   const args = spec.args ?? []
-  const target = editorOpenTargetFromArgs(args)
+  const target = await resolveEditorOpenTarget(editorOpenTargetFromArgs(args), {
+    command: "wordpress.editor-validate-blocks",
+    runPlaygroundCommand,
+    runtimeSpec,
+    server,
+  })
   const content = await editorValidateContentFromArgs(args)
   const provider = editorValidateProviderFromArgs(args)
   const waitTimeoutMs = durationArg(args, "wait-timeout", EDITOR_VALIDATE_BLOCKS_READY_TIMEOUT_MS)

--- a/tests/editor-actions.test.ts
+++ b/tests/editor-actions.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { captureEditorValidity } from "../packages/runtime-playground/src/editor-command-runners.js"
-import { editorActionStepsFromArgs, editorOpenTargetFromArgs } from "../packages/runtime-playground/src/editor-actions.js"
+import { editorActionStepsFromArgs, editorOpenTargetFromArgs, resolveEditorOpenTarget } from "../packages/runtime-playground/src/editor-actions.js"
 
 const steps = await editorActionStepsFromArgs([
   `steps-json=${JSON.stringify([
@@ -39,5 +39,52 @@ assert.equal(validity.schema, "wp-codebox/editor-validity/v1")
 assert.equal(validity.summary.status, "warnings")
 assert.equal(validity.summary.warningCount, 1)
 assert.deepEqual(validity.summary.messages, ["This block contains unexpected or invalid content."])
+
+// target=front-page parses to a runtime-resolved target with an empty URL until
+// resolveEditorOpenTarget pins it to the static front page.
+const frontPageTarget = editorOpenTargetFromArgs(["target=front-page"])
+assert.equal(frontPageTarget.kind, "front-page")
+assert.equal(frontPageTarget.url, "")
+
+// resolveEditorOpenTarget asks the running WordPress for page_on_front and rewrites
+// the target to open that exact post in the editor.
+const resolveCalls: string[] = []
+const resolved = await resolveEditorOpenTarget(frontPageTarget, {
+  command: "wordpress.editor-validate-blocks",
+  runPlaygroundCommand: async (command) => {
+    resolveCalls.push(command)
+    return { ok: true, text: "57\n" } as never
+  },
+  runtimeSpec: { wp: "latest" } as never,
+  server: { serverUrl: "http://localhost" } as never,
+})
+assert.equal(resolved.kind, "post")
+assert.equal(resolved.postId, 57)
+assert.equal(resolved.url, "/wp-admin/post.php?post=57&action=edit")
+assert.deepEqual(resolveCalls, ["wordpress.editor-validate-blocks.resolve-front-page"])
+
+// No static front page configured (page_on_front resolves to 0) is a real
+// misconfiguration, not a silent empty-editor open.
+await assert.rejects(
+  resolveEditorOpenTarget(frontPageTarget, {
+    command: "wordpress.editor-validate-blocks",
+    runPlaygroundCommand: async () => ({ ok: true, text: "0" } as never),
+    runtimeSpec: { wp: "latest" } as never,
+    server: { serverUrl: "http://localhost" } as never,
+  }),
+  /no static front page/,
+)
+
+// Concrete targets pass through resolveEditorOpenTarget unchanged (no PHP call).
+const postTarget = editorOpenTargetFromArgs(["post-id=12"])
+const passthrough = await resolveEditorOpenTarget(postTarget, {
+  command: "wordpress.editor-open",
+  runPlaygroundCommand: async () => {
+    throw new Error("resolveEditorOpenTarget should not run PHP for a concrete target")
+  },
+  runtimeSpec: { wp: "latest" } as never,
+  server: { serverUrl: "http://localhost" } as never,
+})
+assert.equal(passthrough.url, "/wp-admin/post.php?post=12&action=edit")
 
 console.log("editor actions ok")


### PR DESCRIPTION
## What
Adds a `target=front-page` mode to the editor-open target resolution so editor commands (`editor-validate-blocks`, `editor-open`, `editor-actions`) can validate the imported front page instead of a bare empty `post-new.php`. `editorOpenTargetFromArgs` previously only accepted a literal `post-id`, which isn't knowable at recipe-build time for a freshly-imported post.

## Change
- `packages/runtime-playground/src/editor-actions.ts`: new `front-page` target kind + async `resolveEditorOpenTarget()` that queries `page_on_front` at runtime and rewrites to `post.php?post=<id>&action=edit`; hard-errors if no static front page is configured (no silent empty-editor fallback).
- `editor-command-runners.ts`: all three editor runners resolve through it.

## Verification
- Build + `test:editor-actions` + `test:editor-validate-blocks` pass. Used downstream in a live rigs run that validated real imported posts (post=4/post=7, edited-post-content).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, fix, and live verification under human review.