### PR TITLE
Extract runner workspace ability descriptors

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/class-wp-codebox-wordpress-workload-runner.php';
 require_once __DIR__ . '/class-wp-codebox-fuzz-suite-runner.php';
 require_once __DIR__ . '/class-wp-codebox-agent-task-ability-descriptors.php';
 require_once __DIR__ . '/class-wp-codebox-runtime-ability-descriptors.php';
+require_once __DIR__ . '/class-wp-codebox-runner-workspace-ability-descriptors.php';
 require_once __DIR__ . '/class-wp-codebox-browser-ability-descriptors.php';
 require_once __DIR__ . '/class-wp-codebox-browser-contained-site-service.php';
 require_once __DIR__ . '/class-wp-codebox-browser-task-contract-service.php';
@@ -445,51 +446,17 @@ final class WP_Codebox_Abilities {
 				)
 			);
 
-			$runner_workspace_abilities = array(
+			$runner_workspace_abilities = WP_Codebox_Runner_Workspace_Ability_Descriptors::descriptors(
 				array(
-					'canonical_ability'     => 'wp-codebox/runner-workspace-prepare',
-					'aliases_before'        => array( 'wp-codebox/prepare' ),
-					'aliases_after'         => array( 'wp-codebox/prepare-runner-workspace' ),
-					'label'                 => 'Prepare Runner Workspace',
-					'canonical_description' => 'Prepare a runner-owned workspace through the WP Codebox runner boundary using the configured workspace backend adapter.',
-					'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-prepare. Prefer the canonical WP Codebox runner workspace prepare ability in new integrations.',
-					'input_schema'          => self::runner_workspace_prepare_input_schema(),
-					'output_schema'         => self::runner_workspace_prepare_output_schema(),
-					'execute_callback'      => array( self::class, 'prepare_runner_workspace' ),
-				),
-				array(
-					'canonical_ability'     => 'wp-codebox/runner-workspace-publish',
-					'aliases_before'        => array( 'wp-codebox/publish', 'wp-codebox/publish-runner-workspace' ),
-					'aliases_after'         => array(),
-					'label'                 => 'Publish Runner Workspace',
-					'canonical_description' => 'Publish runner-owned workspace changes through the WP Codebox runner boundary using the configured publication backend adapter.',
-					'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-publish. Prefer the canonical WP Codebox runner workspace publish ability in new integrations.',
-					'input_schema'          => self::runner_workspace_publication_input_schema(),
-					'output_schema'         => self::runner_workspace_publication_output_schema(),
-					'execute_callback'      => array( self::class, 'publish_runner_workspace' ),
-				),
-				array(
-					'canonical_ability'     => 'wp-codebox/runner-workspace-capture',
-					'aliases_before'        => array( 'wp-codebox/capture' ),
-					'aliases_after'         => array( 'wp-codebox/capture-runner-workspace' ),
-					'label'                 => 'Capture Runner Workspace',
-					'canonical_description' => 'Capture runner-owned workspace status and diff metadata through the WP Codebox runner boundary using the configured workspace backend adapter.',
-					'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-capture. Prefer the canonical WP Codebox runner workspace capture ability in new integrations.',
-					'input_schema'          => self::runner_workspace_capture_input_schema(),
-					'output_schema'         => self::runner_workspace_capture_output_schema(),
-					'execute_callback'      => array( self::class, 'capture_runner_workspace' ),
-				),
-				array(
-					'canonical_ability'     => 'wp-codebox/runner-workspace-command',
-					'aliases_before'        => array( 'wp-codebox/command', 'wp-codebox/run-runner-workspace-command' ),
-					'aliases_after'         => array(),
-					'label'                 => 'Run Runner Workspace Command',
-					'canonical_description' => 'Run a bounded verification or drift-check command against a runner-owned workspace through the WP Codebox runner boundary.',
-					'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-command. Prefer the canonical WP Codebox runner workspace command ability in new integrations.',
-					'input_schema'          => self::runner_workspace_command_input_schema(),
-					'output_schema'         => self::runner_workspace_command_output_schema(),
-					'execute_callback'      => array( self::class, 'run_runner_workspace_command' ),
-				),
+					'prepare_input_schema'      => self::runner_workspace_prepare_input_schema(),
+					'prepare_output_schema'     => self::runner_workspace_prepare_output_schema(),
+					'publication_input_schema'  => self::runner_workspace_publication_input_schema(),
+					'publication_output_schema' => self::runner_workspace_publication_output_schema(),
+					'capture_input_schema'      => self::runner_workspace_capture_input_schema(),
+					'capture_output_schema'     => self::runner_workspace_capture_output_schema(),
+					'command_input_schema'      => self::runner_workspace_command_input_schema(),
+					'command_output_schema'     => self::runner_workspace_command_output_schema(),
+				)
 			);
 
 			foreach ( $runner_workspace_abilities as $runner_workspace_ability ) {

--- a/packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-ability-descriptors.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Runner workspace ability descriptors.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provides runner workspace ability registration descriptors.
+ */
+final class WP_Codebox_Runner_Workspace_Ability_Descriptors {
+
+	/**
+	 * @param array<string,mixed> $context Shared schemas assembled by WP_Codebox_Abilities.
+	 * @return array<int,array<string,mixed>> Runner workspace descriptors in registration order.
+	 */
+	public static function descriptors( array $context ): array {
+		return array(
+			array(
+				'canonical_ability'     => 'wp-codebox/runner-workspace-prepare',
+				'aliases_before'        => array( 'wp-codebox/prepare' ),
+				'aliases_after'         => array( 'wp-codebox/prepare-runner-workspace' ),
+				'label'                 => 'Prepare Runner Workspace',
+				'canonical_description' => 'Prepare a runner-owned workspace through the WP Codebox runner boundary using the configured workspace backend adapter.',
+				'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-prepare. Prefer the canonical WP Codebox runner workspace prepare ability in new integrations.',
+				'input_schema'          => $context['prepare_input_schema'],
+				'output_schema'         => $context['prepare_output_schema'],
+				'execute_callback'      => array( WP_Codebox_Abilities::class, 'prepare_runner_workspace' ),
+			),
+			array(
+				'canonical_ability'     => 'wp-codebox/runner-workspace-publish',
+				'aliases_before'        => array( 'wp-codebox/publish', 'wp-codebox/publish-runner-workspace' ),
+				'aliases_after'         => array(),
+				'label'                 => 'Publish Runner Workspace',
+				'canonical_description' => 'Publish runner-owned workspace changes through the WP Codebox runner boundary using the configured publication backend adapter.',
+				'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-publish. Prefer the canonical WP Codebox runner workspace publish ability in new integrations.',
+				'input_schema'          => $context['publication_input_schema'],
+				'output_schema'         => $context['publication_output_schema'],
+				'execute_callback'      => array( WP_Codebox_Abilities::class, 'publish_runner_workspace' ),
+			),
+			array(
+				'canonical_ability'     => 'wp-codebox/runner-workspace-capture',
+				'aliases_before'        => array( 'wp-codebox/capture' ),
+				'aliases_after'         => array( 'wp-codebox/capture-runner-workspace' ),
+				'label'                 => 'Capture Runner Workspace',
+				'canonical_description' => 'Capture runner-owned workspace status and diff metadata through the WP Codebox runner boundary using the configured workspace backend adapter.',
+				'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-capture. Prefer the canonical WP Codebox runner workspace capture ability in new integrations.',
+				'input_schema'          => $context['capture_input_schema'],
+				'output_schema'         => $context['capture_output_schema'],
+				'execute_callback'      => array( WP_Codebox_Abilities::class, 'capture_runner_workspace' ),
+			),
+			array(
+				'canonical_ability'     => 'wp-codebox/runner-workspace-command',
+				'aliases_before'        => array( 'wp-codebox/command', 'wp-codebox/run-runner-workspace-command' ),
+				'aliases_after'         => array(),
+				'label'                 => 'Run Runner Workspace Command',
+				'canonical_description' => 'Run a bounded verification or drift-check command against a runner-owned workspace through the WP Codebox runner boundary.',
+				'alias_description'     => 'Compatibility alias for wp-codebox/runner-workspace-command. Prefer the canonical WP Codebox runner workspace command ability in new integrations.',
+				'input_schema'          => $context['command_input_schema'],
+				'output_schema'         => $context['command_output_schema'],
+				'execute_callback'      => array( WP_Codebox_Abilities::class, 'run_runner_workspace_command' ),
+			),
+		);
+	}
+}

--- a/scripts/php-runner-workspace-adapter-boundary-smoke.php
+++ b/scripts/php-runner-workspace-adapter-boundary-smoke.php
@@ -127,7 +127,11 @@ register_test_ability( 'fake-runner-workspace-backend/run-runner-workspace-comma
 register_test_ability( 'fake-runner-workspace-backend/publish-runner-workspace', static fn( array $input ): array => array( 'success' => true, 'workspace_handle' => $input['workspace_handle'], 'head' => 'agent/change', 'commit_sha' => 'abc123', 'pr_number' => 7, 'pr_url' => 'https://example.test/pr/7' ) );
 
 $abilities_source = file_get_contents( __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php' );
+$descriptor_source = file_get_contents( __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-ability-descriptors.php' );
 assert_same_contract( true, is_string( $abilities_source ), 'ability source is readable' );
+assert_same_contract( true, is_string( $descriptor_source ), 'runner workspace descriptor source is readable' );
+assert_same_contract( true, str_contains( $abilities_source, 'WP_Codebox_Runner_Workspace_Ability_Descriptors::descriptors' ), 'ability hub registers runner workspace descriptors' );
+
 $public_runner_workspace_abilities = array(
 	'wp-codebox/runner-workspace-prepare',
 	'wp-codebox/runner-workspace-publish',
@@ -135,7 +139,7 @@ $public_runner_workspace_abilities = array(
 	'wp-codebox/runner-workspace-command',
 );
 foreach ( $public_runner_workspace_abilities as $ability_name ) {
-	assert_same_contract( true, str_contains( $abilities_source, "wp_register_ability(\n\t\t\t\t'" . $ability_name . "'" ), $ability_name . ' registered as a public wrapper' );
+	assert_same_contract( true, str_contains( $descriptor_source, "'" . $ability_name . "'" ), $ability_name . ' has a public wrapper descriptor' );
 }
 
 $prepared = WP_Codebox_Abilities::prepare_runner_workspace( array( 'repo' => 'Automattic/wp-codebox', 'checkout_path' => '/tmp/checkout', 'branch' => 'agent/change' ) );


### PR DESCRIPTION
## Summary
- Extract runner workspace ability registration descriptors into `WP_Codebox_Runner_Workspace_Ability_Descriptors`.
- Keep the ability hub responsible for registration order, aliases, permissions, and schema assembly.
- Update the adapter-boundary smoke assertion so it follows the descriptor extraction instead of requiring inline `wp_register_ability()` calls.

## Tests
- `php -l packages/wordpress-plugin/src/class-wp-codebox-abilities.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-runner-workspace-ability-descriptors.php`
- `php -l scripts/php-runner-workspace-adapter-boundary-smoke.php`
- `npm run test:public-ability-aliases`
- `npm run test:php-runner-workspace-backend-contract`
- `php scripts/php-runner-workspace-adapter-boundary-smoke.php`
- `npm run test:php-public-api-facade`
- `git diff --check`

## Residual risks
- Runner workspace execution remains in `WP_Codebox_Abilities_Runner_Publication`; this PR intentionally stops at descriptor extraction to avoid broader behavior churn.
- `npm run test:php-runner-workspace-adapter-boundary` is not defined in `package.json`; the underlying PHP smoke was run directly.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Scoped descriptor/service extraction and verification