### PR TITLE
fix: hydrate runtime package bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-codebox-workspace",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-codebox-workspace",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "ISC",
       "workspaces": [
         "packages/*"
@@ -3928,7 +3928,7 @@
     },
     "packages/cli": {
       "name": "@automattic/wp-codebox-cli",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@automattic/wp-codebox-playground": "file:../runtime-playground"
@@ -3939,14 +3939,14 @@
     },
     "packages/runtime-core": {
       "name": "@automattic/wp-codebox-core",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "ajv": "^8.20.0"
       }
     },
     "packages/runtime-playground": {
       "name": "@automattic/wp-codebox-playground",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@automattic/wp-codebox-core": "file:../runtime-core",
         "@php-wasm/node": "^3.1.35",

--- a/packages/cli/src/agent-code.ts
+++ b/packages/cli/src/agent-code.ts
@@ -1,5 +1,5 @@
-import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
+import { readdir, readFile, stat } from "node:fs/promises"
+import { join, relative, resolve } from "node:path"
 import { normalizeAgentBundles, phpRuntimeComponentLifecycleActionReplayFunction, sandboxAllowedRuntimeToolIds, type SandboxToolPolicySnapshot, type SandboxWorkspaceContract, type StructuredArtifactPayload, type TaskInputAgentBundle } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT } from "@automattic/wp-codebox-core/internals"
 
@@ -39,7 +39,7 @@ export async function resolveSandboxTaskCode(options: AgentSandboxCodeOptions): 
   return `echo json_encode(array('task_received' => true), JSON_PRETTY_PRINT);`
 }
 
-function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
+async function agentChatTaskCode(options: AgentSandboxCodeOptions): Promise<string> {
   const mode = options.mode ?? "sandbox"
   const agentModes = sandboxAgentModes(mode)
   const sandboxToolPolicy = options.sandboxToolPolicy
@@ -90,7 +90,7 @@ function agentChatTaskCode(options: AgentSandboxCodeOptions): string {
   const timeoutSeconds = Number.parseInt(options.timeoutSeconds ?? '', 10)
   const timeoutLimit = Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 0
   const agentBundles = normalizeAgentBundles(options.agentBundles ?? [])
-  const runtimeTask = normalizeRuntimeTask(options.runtimeTask, input)
+  const runtimeTask = await normalizeRuntimeTask(options.runtimeTask, input, sandboxWorkspace)
   return `
 if (function_exists('wp_set_current_user')) {
     wp_set_current_user(1);
@@ -320,15 +320,45 @@ function wp_codebox_registered_provider_ids(object $registry): array {
     return $provider_ids;
 }
 
+function wp_codebox_runtime_task_ability_candidates(string $requested_ability): array {
+    $aliases = function_exists('apply_filters') ? apply_filters('wp_codebox_runtime_task_ability_aliases', array(
+        'runtime-package/run' => array('agents/run-runtime-package', 'wp-codebox/run-runtime-package'),
+    )) : array();
+    $candidates = array($requested_ability);
+    if (is_array($aliases) && isset($aliases[$requested_ability]) && is_array($aliases[$requested_ability])) {
+        $candidates = array_merge($candidates, array_values($aliases[$requested_ability]));
+    }
+    $candidates = array_values(array_unique(array_filter(array_map('strval', $candidates), static fn(string $ability): bool => '' !== $ability)));
+    return !empty($candidates) ? $candidates : array($requested_ability);
+}
+
+function wp_codebox_resolve_runtime_task_ability(string $requested_ability): array {
+    $candidates = wp_codebox_runtime_task_ability_candidates($requested_ability);
+    if (!function_exists('wp_get_ability')) {
+        return array('name' => $requested_ability, 'ability' => null, 'candidates' => $candidates);
+    }
+    foreach ($candidates as $candidate) {
+        $ability = wp_get_ability($candidate);
+        if (null !== $ability && method_exists($ability, 'execute')) {
+            return array('name' => $candidate, 'ability' => $ability, 'candidates' => $candidates);
+        }
+    }
+    return array('name' => $requested_ability, 'ability' => null, 'candidates' => $candidates);
+}
+
 $runtime_task_run = is_array($sandbox_runtime_task) && !empty($sandbox_runtime_task);
-$ability_name = $runtime_task_run ? (string) ($sandbox_runtime_task['ability'] ?? '') : 'agents/chat';
-$ability = empty($sandbox_agent_bundle_import_failures) && function_exists('wp_get_ability') ? wp_get_ability($ability_name) : null;
+$requested_ability_name = $runtime_task_run ? (string) ($sandbox_runtime_task['ability'] ?? '') : 'agents/chat';
+$resolved_runtime_task_ability = empty($sandbox_agent_bundle_import_failures) ? wp_codebox_resolve_runtime_task_ability($requested_ability_name) : array('name' => $requested_ability_name, 'ability' => null, 'candidates' => array($requested_ability_name));
+$ability_name = (string) ($resolved_runtime_task_ability['name'] ?? $requested_ability_name);
+$ability = $resolved_runtime_task_ability['ability'] ?? null;
 $registered_ability_ids = function_exists('wp_get_abilities') ? array_keys(wp_get_abilities()) : array();
 sort($registered_ability_ids);
 $runtime_task_preflight = array(
     'schema' => 'wp-codebox/runtime-task-ability-preflight/v1',
     'runtime_task_requested' => $runtime_task_run,
-    'ability' => $ability_name,
+    'ability' => $requested_ability_name,
+    'resolved_ability' => $ability_name,
+    'ability_candidates' => $resolved_runtime_task_ability['candidates'] ?? array($requested_ability_name),
     'registry_available' => function_exists('wp_get_ability'),
     'available' => null !== $ability && method_exists($ability, 'execute'),
     'registered_ability_ids' => $registered_ability_ids,
@@ -484,7 +514,7 @@ function defaultSandboxWorkspace(workspace: SandboxWorkspaceContract | undefined
   return mount ? { ...mount } : null
 }
 
-function normalizeRuntimeTask(config: Record<string, unknown> | undefined, agentInput: Record<string, unknown>): Record<string, unknown> | null {
+async function normalizeRuntimeTask(config: Record<string, unknown> | undefined, agentInput: Record<string, unknown>, workspace?: SandboxWorkspaceContract): Promise<Record<string, unknown> | null> {
   if (!config || typeof config !== "object" || Array.isArray(config)) return null
 
   const ability = stringFromKeys(config, ["ability", "ability_name", "abilityName"])
@@ -498,7 +528,7 @@ function normalizeRuntimeTask(config: Record<string, unknown> | undefined, agent
     input.task_input = agentInput
   }
 
-  const normalized: Record<string, unknown> = { ability, input }
+  const normalized: Record<string, unknown> = { ability, input: await runtimeTaskInputWithInlineBundle(ability, input, workspace) }
   if (typeof config.wait_for_completion === "boolean") {
     normalized.wait_for_completion = config.wait_for_completion
   }
@@ -512,6 +542,124 @@ function normalizeRuntimeTask(config: Record<string, unknown> | undefined, agent
   }
 
   return normalized
+}
+
+async function runtimeTaskInputWithInlineBundle(ability: string, input: Record<string, unknown>, workspace?: SandboxWorkspaceContract): Promise<Record<string, unknown>> {
+  if (!['runtime-package/run', 'agents/run-runtime-package', 'wp-codebox/run-runtime-package'].includes(ability)) return input
+  const packageDescriptor = recordValue(input.package)
+  if (!packageDescriptor || recordValue(packageDescriptor.bundle)) return input
+  const source = typeof packageDescriptor.source === 'string' ? packageDescriptor.source.trim() : ''
+  if (!source) return input
+  const hostPath = workspaceHostPath(source, workspace)
+  if (!hostPath) return input
+  const bundle = await readDataMachineBundleDirectory(hostPath)
+  if (!bundle) return input
+  return { ...input, package: { ...packageDescriptor, bundle } }
+}
+
+function workspaceHostPath(sandboxPath: string, workspace?: SandboxWorkspaceContract): string {
+  const mounts = Array.isArray(workspace?.mounts) ? workspace.mounts : []
+  for (const mount of mounts) {
+    const mountRecord = mount as unknown as Record<string, unknown>
+    const target = typeof mount?.target === 'string' ? mount.target.replace(/\/+$/, '') : ''
+    const source = typeof mountRecord.source === 'string' ? mountRecord.source.replace(/\/+$/, '') : ''
+    if (!target || !source) continue
+    if (sandboxPath === target || sandboxPath.startsWith(`${target}/`)) {
+      return join(source, sandboxPath.slice(target.length).replace(/^\/+/, ''))
+    }
+  }
+  return ''
+}
+
+async function readDataMachineBundleDirectory(directory: string): Promise<Record<string, unknown> | null> {
+  try {
+    const manifest = JSON.parse(await readFile(join(directory, 'manifest.json'), 'utf8')) as Record<string, unknown>
+    const pipelines = await readJsonDocuments(join(directory, 'pipelines'))
+    const flows = await readJsonDocuments(join(directory, 'flows'))
+    const memory = await readTextFiles(join(directory, 'memory'))
+    return {
+      bundle_version: String(manifest.bundle_version ?? '1'),
+      bundle_slug: String(manifest.bundle_slug ?? recordValue(manifest.agent)?.slug ?? 'agent-bundle'),
+      source_ref: String(manifest.source_ref ?? ''),
+      source_revision: String(manifest.source_revision ?? ''),
+      bundle_schema_version: 1,
+      exported_at: String(manifest.exported_at ?? new Date().toISOString()),
+      agent: bundleAgentFromManifest(recordValue(manifest.agent) ?? {}),
+      files: agentMemoryFiles(memory),
+      pipelines: pipelines.map((pipeline, index) => legacyPipeline(pipeline, index + 1)),
+      flows: flows.map((flow, index) => legacyFlow(flow, index + 1, pipelines)),
+      artifact_files: {},
+      extension_artifacts: [],
+      extras: {},
+      abilities_manifest: {},
+    }
+  } catch {
+    return null
+  }
+}
+
+async function readJsonDocuments(directory: string): Promise<Record<string, unknown>[]> {
+  try {
+    const entries = (await readdir(directory)).filter((entry) => entry.endsWith('.json')).sort()
+    return Promise.all(entries.map(async (entry) => JSON.parse(await readFile(join(directory, entry), 'utf8')) as Record<string, unknown>))
+  } catch {
+    return []
+  }
+}
+
+async function readTextFiles(directory: string, base = directory): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+  try {
+    for (const entry of await readdir(directory)) {
+      const full = join(directory, entry)
+      const info = await stat(full)
+      if (info.isDirectory()) Object.assign(files, await readTextFiles(full, base))
+      if (info.isFile()) files[relative(base, full).replace(/\\/g, '/')] = await readFile(full, 'utf8')
+    }
+  } catch {}
+  return files
+}
+
+function bundleAgentFromManifest(agent: Record<string, unknown>): Record<string, unknown> {
+  return {
+    agent_slug: String(agent.slug ?? 'agent'),
+    agent_name: String(agent.label ?? agent.slug ?? 'Agent'),
+    description: String(agent.description ?? ''),
+    agent_config: recordValue(agent.agent_config) ?? {},
+  }
+}
+
+function agentMemoryFiles(memory: Record<string, string>): Record<string, string> {
+  const files: Record<string, string> = {}
+  for (const [path, contents] of Object.entries(memory)) {
+    if (path.startsWith('agent/')) files[path.slice('agent/'.length)] = contents
+  }
+  return files
+}
+
+function legacyPipeline(pipeline: Record<string, unknown>, id: number): Record<string, unknown> {
+  const config: Record<string, unknown> = {}
+  for (const step of Array.isArray(pipeline.steps) ? pipeline.steps : []) {
+    if (!recordValue(step)) continue
+    const position = Number((step as Record<string, unknown>).step_position ?? Object.keys(config).length)
+    const key = `${id}_bundle_step_${position}`
+    config[key] = { ...(recordValue((step as Record<string, unknown>).step_config) ?? {}), pipeline_step_id: key, step_type: String((step as Record<string, unknown>).step_type ?? ''), execution_order: position }
+  }
+  return { original_id: id, portable_slug: String(pipeline.slug ?? `pipeline-${id}`), pipeline_name: String(pipeline.name ?? 'Pipeline'), pipeline_config: config, memory_file_contents: {} }
+}
+
+function legacyFlow(flow: Record<string, unknown>, id: number, pipelines: Record<string, unknown>[]): Record<string, unknown> {
+  const pipelineIndex = Math.max(0, pipelines.findIndex((pipeline) => pipeline.slug === flow.pipeline_slug))
+  const pipelineId = pipelineIndex + 1
+  const config: Record<string, unknown> = {}
+  for (const step of Array.isArray(flow.steps) ? flow.steps : []) {
+    if (!recordValue(step)) continue
+    const position = Number((step as Record<string, unknown>).step_position ?? Object.keys(config).length)
+    const pipelineStepId = `${pipelineId}_bundle_step_${position}`
+    const key = `${pipelineStepId}_${id}`
+    config[key] = { ...step as Record<string, unknown>, flow_step_id: key, pipeline_step_id: pipelineStepId, pipeline_id: pipelineId, flow_id: id, execution_order: position }
+  }
+  return { original_id: id, original_pipeline_id: pipelineId, portable_slug: String(flow.slug ?? `flow-${id}`), flow_name: String(flow.name ?? 'Flow'), flow_config: config, scheduling_config: { enabled: String(flow.schedule ?? 'manual') !== 'manual', interval: String(flow.schedule ?? 'manual'), max_items: Array.isArray(flow.max_items) ? flow.max_items : [] }, memory_file_contents: {} }
 }
 
 function stringFromKeys(record: Record<string, unknown>, keys: string[]): string {

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -314,6 +314,7 @@ async function prepareComposerAutoloadForPlugin(prepared: PreparedExternalSource
   try {
     const autoload = await stat(join(prepared.source, "vendor", "autoload.php"))
     if (autoload.isFile()) {
+      await writeComposerInstalledPackageAutoloader(prepared.source)
       return prepared
     }
   } catch {
@@ -363,9 +364,7 @@ async function writeComposerInstalledPackageAutoloader(pluginSource: string): Pr
   if (!await pathIsFile(installedPath)) {
     return
   }
-  const installed = JSON.parse(await readFile(installedPath, "utf8")) as unknown
-  const classmapPaths = composerInstalledPackages(installed).flatMap((pkg) => composerInstalledPackageClassmapPaths(pkg))
-  if (classmapPaths.length === 0 || !await pathIsFile(join(pluginSource, "vendor", "composer", "autoload_classmap.php"))) {
+  if (!await pathIsFile(join(pluginSource, "vendor", "composer", "autoload_classmap.php"))) {
     return
   }
 
@@ -378,7 +377,11 @@ if (is_file($wp_codebox_composer_package_classmap)) {
             $loaded_classmap = require $wp_codebox_composer_package_classmap;
             $classmap = is_array($loaded_classmap) ? $loaded_classmap : array();
         }
-        if (!is_array($classmap) || !isset($classmap[$class]) || !is_file($classmap[$class])) {
+    if (!is_array($classmap) || !isset($classmap[$class]) || !is_file($classmap[$class])) {
+            return;
+        }
+        $wp_codebox_php_ai_client_prefix = 'WordPress' . chr(92) . 'AiClient' . chr(92);
+        if (str_starts_with($class, $wp_codebox_php_ai_client_prefix)) {
             return;
         }
         require_once $classmap[$class];
@@ -1510,13 +1513,14 @@ foreach ($plugins as $plugin) {
     if ('.' === $plugin_dir || '' === $plugin_dir) {
         throw new RuntimeException('WP Codebox Composer autoloader plugin entry must include a directory.');
     }
-    $autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
-    if (is_file($autoload)) {
-        $lines[] = "require_once WP_PLUGIN_DIR . '/" . str_replace("'", "\\'", $plugin_dir) . "/vendor/autoload.php';";
-    }
     $package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
     if (is_file($package_autoload)) {
         $lines[] = "require_once WP_PLUGIN_DIR . '/" . str_replace("'", "\\'", $plugin_dir) . "/vendor/autoload_packages.php';";
+        continue;
+    }
+    $autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
+    if (is_file($autoload)) {
+        $lines[] = "require_once WP_PLUGIN_DIR . '/" . str_replace("'", "\\'", $plugin_dir) . "/vendor/autoload.php';";
     }
 }
 if (false === file_put_contents($loader, implode("\n", $lines) . "\n")) {

--- a/packages/runtime-core/src/agent-task-recipe.ts
+++ b/packages/runtime-core/src/agent-task-recipe.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "node:fs"
-import { dirname, join, resolve } from "node:path"
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { SandboxToolPolicySnapshot } from "./sandbox-tool-policy.js"
 import type { StructuredArtifactPayload } from "./structured-artifacts.js"
@@ -87,7 +87,10 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   const artifacts = stringValue(input.artifacts_path)
   const profile = runtimeOverlayProfileDefaults(input)
   const runtimeMounts = runtimeStateMounts(input)
-  const stagedFiles = stagedRuntimeSources(input, taskInput)
+  const sourceRoots = workspaceSourceRoots(input, taskInput)
+  const runtimeTask = runtimeTaskWithInlineBundle(input.runtime_task, sourceRoots)
+  const effectiveInput = { ...input, runtime_task: runtimeTask }
+  const stagedFiles = stagedRuntimeSources(effectiveInput, taskInput, sourceRoots)
   const providerPlugins = providerPluginEntries(input, artifacts)
   const providerSlugs = providerPlugins.map((plugin) => plugin.slug).join(",")
   const providerContracts = providerPlugins.map((plugin) => ({ slug: plugin.slug, pluginFile: plugin.pluginFile, loadAs: plugin.loadAs ?? "plugin" }))
@@ -124,8 +127,8 @@ export function buildAgentTaskRecipe(input: AgentTaskRunInput, taskInput: TaskIn
   if (Array.isArray(input.agent_bundles) && input.agent_bundles.length > 0) {
     workflowArgs.push(`agent-bundles-json=${JSON.stringify(input.agent_bundles)}`)
   }
-  if (input.runtime_task && typeof input.runtime_task === "object" && !Array.isArray(input.runtime_task)) {
-    workflowArgs.push(`runtime-task-json=${JSON.stringify(input.runtime_task)}`)
+  if (runtimeTask && typeof runtimeTask === "object" && !Array.isArray(runtimeTask)) {
+    workflowArgs.push(`runtime-task-json=${JSON.stringify(runtimeTask)}`)
   }
   if (taskInput.structured_artifacts.length > 0) {
     workflowArgs.push(`structured-artifacts-json=${JSON.stringify(taskInput.structured_artifacts)}`)
@@ -336,10 +339,10 @@ function componentMountedPath(slug: string, loadAs: "plugin" | "mu-plugin"): str
     : `/wordpress/wp-content/plugins/${slug}`
 }
 
-function stagedRuntimeSources(input: AgentTaskRunInput, taskInput: TaskInput): WorkspaceRecipeStagedFile[] {
+function stagedRuntimeSources(input: AgentTaskRunInput, taskInput: TaskInput, sourceRoots = workspaceSourceRoots(input, taskInput)): WorkspaceRecipeStagedFile[] {
   const stagedFiles: WorkspaceRecipeStagedFile[] = []
   const seenTargets = new Set<string>()
-  const roots = workspaceSourceRoots(input, taskInput)
+  const roots = sourceRoots
   for (const stagedFile of Array.isArray(input.stagedFiles) ? input.stagedFiles : []) {
     if (!stagedFile?.target || seenTargets.has(stagedFile.target)) continue
     stagedFiles.push(stagedFile)
@@ -351,6 +354,187 @@ function stagedRuntimeSources(input: AgentTaskRunInput, taskInput: TaskInput): W
     seenTargets.add(stagedFile.target)
   }
   return stagedFiles
+}
+
+function runtimeTaskWithInlineBundle(runtimeTask: AgentTaskRunInput["runtime_task"], roots: string[]): AgentTaskRunInput["runtime_task"] {
+  const runtimeTaskInput = objectValue(runtimeTask?.input)
+  const runtimePackage = objectValue(runtimeTaskInput?.package)
+  if (!runtimeTaskInput || !runtimePackage || runtimePackage.bundle) return runtimeTask
+
+  const source = stringValue(runtimePackage.source)
+  if (!source) return runtimeTask
+
+  const localSource = localAgentBundleSource(source, roots)
+  if (!localSource) return runtimeTask
+
+  const bundle = readDataMachineBundleDirectory(localSource)
+  if (!bundle) return runtimeTask
+
+  return {
+    ...(runtimeTask ?? {}),
+    input: {
+      ...runtimeTaskInput,
+      package: {
+        ...runtimePackage,
+        bundle,
+      },
+    },
+  }
+}
+
+function readDataMachineBundleDirectory(directory: string): Record<string, unknown> | undefined {
+	try {
+		const manifest = readJsonFile(resolve(directory, "manifest.json"))
+		const manifestObject = objectValue(manifest) ?? {}
+		const manifestAgent = objectValue(manifestObject.agent) ?? {}
+		if (!manifestAgent.slug) return undefined
+
+		const included = objectValue(manifestObject.included) ?? {}
+		const pipelineDocuments = orderedBundleDocuments(directory, "pipelines", included.pipelines)
+		const flowDocuments = orderedBundleDocuments(directory, "flows", included.flows)
+    const pipelineIds = new Map<string, number>()
+    const pipelineStepKeys = new Map<string, Map<number, string>>()
+
+    const pipelines = pipelineDocuments.map((pipeline, index) => {
+      const pipelineId = index + 1
+      const slug = stringValue(pipeline.slug) || `pipeline-${pipelineId}`
+      const pipelineConfig: Record<string, unknown> = {}
+      const stepKeys = new Map<number, string>()
+      pipelineIds.set(slug, pipelineId)
+      for (const step of Array.isArray(pipeline.steps) ? pipeline.steps.filter(isPlainObject) : []) {
+        const position = numberValue(step.step_position, Object.keys(pipelineConfig).length)
+			const pipelineStepId = `${pipelineId}_bundle_step_${position}`
+			stepKeys.set(position, pipelineStepId)
+			pipelineConfig[pipelineStepId] = {
+				...(objectValue(step.step_config) ?? {}),
+				pipeline_step_id: pipelineStepId,
+				step_type: stringValue(step.step_type),
+				execution_order: position,
+        }
+      }
+      pipelineStepKeys.set(slug, stepKeys)
+      return {
+        original_id: pipelineId,
+        portable_slug: slug,
+        pipeline_name: stringValue(pipeline.name) || slug,
+        pipeline_config: pipelineConfig,
+        memory_file_contents: {},
+      }
+    })
+
+    const flows = flowDocuments.map((flow, index) => {
+      const flowId = index + 1
+      const pipelineSlug = stringValue(flow.pipeline_slug)
+      const pipelineId = pipelineIds.get(pipelineSlug) ?? 0
+      const stepKeys = pipelineStepKeys.get(pipelineSlug) ?? new Map<number, string>()
+      const flowConfig: Record<string, unknown> = {}
+      for (const step of Array.isArray(flow.steps) ? flow.steps.filter(isPlainObject) : []) {
+        const position = numberValue(step.step_position, Object.keys(flowConfig).length)
+        const pipelineStepId = stepKeys.get(position) ?? `${pipelineId}_bundle_step_${position}`
+        const flowStepId = `${pipelineStepId}_${flowId}`
+        flowConfig[flowStepId] = {
+          ...step,
+          flow_step_id: flowStepId,
+          pipeline_step_id: pipelineStepId,
+          pipeline_id: pipelineId,
+          flow_id: flowId,
+          execution_order: position,
+        }
+      }
+      return {
+        original_id: flowId,
+        original_pipeline_id: pipelineId,
+        portable_slug: stringValue(flow.slug) || `flow-${flowId}`,
+        flow_name: stringValue(flow.name) || stringValue(flow.slug) || `Flow ${flowId}`,
+        flow_config: flowConfig,
+        scheduling_config: {
+          enabled: stringValue(flow.schedule) !== "manual",
+          interval: stringValue(flow.schedule) || "manual",
+          max_items: Array.isArray(flow.max_items) ? flow.max_items : [],
+        },
+        memory_file_contents: {},
+      }
+    })
+
+		return {
+			bundle_version: stringValue(manifestObject.bundle_version) || "1",
+			bundle_slug: stringValue(manifestObject.bundle_slug) || stringValue(manifestAgent.slug) || "agent-bundle",
+			source_ref: stringValue(manifestObject.source_ref),
+			source_revision: stringValue(manifestObject.source_revision),
+			bundle_schema_version: 1,
+			exported_at: stringValue(manifestObject.exported_at) || new Date().toISOString(),
+      agent: {
+        agent_slug: stringValue(manifestAgent.slug) || "agent",
+        agent_name: stringValue(manifestAgent.label) || stringValue(manifestAgent.slug) || "Agent",
+        agent_config: objectValue(manifestAgent.agent_config),
+      },
+      files: readTextFiles(resolve(directory, "memory", "agent")),
+      user_template: readOptionalText(resolve(directory, "memory", "USER.md")),
+      pipelines,
+      flows,
+      artifact_files: {},
+      extension_artifacts: {},
+      extras: {},
+      abilities_manifest: {},
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function orderedBundleDocuments(directory: string, kind: "pipelines" | "flows", included: unknown): Array<Record<string, unknown>> {
+  const kindDirectory = resolve(directory, kind)
+  const slugs = Array.isArray(included) ? included.map(stringValue).filter(Boolean) : []
+  const bySlug = new Map<string, Record<string, unknown>>()
+  for (const file of safeDirectoryFiles(kindDirectory).filter((file) => file.endsWith(".json")).sort()) {
+    const document = readJsonFile(resolve(kindDirectory, file))
+    if (isPlainObject(document)) bySlug.set(stringValue(document.slug) || file.replace(/\.json$/i, ""), document)
+  }
+  const ordered = slugs.map((slug) => bySlug.get(slug)).filter(isPlainObject)
+  for (const [slug, document] of bySlug) {
+    if (!slugs.includes(slug)) ordered.push(document)
+  }
+  return ordered
+}
+
+function safeDirectoryFiles(directory: string): string[] {
+  try {
+    return readdirSync(directory, { withFileTypes: true }).filter((entry) => entry.isFile()).map((entry) => entry.name)
+  } catch {
+    return []
+  }
+}
+
+function readTextFiles(directory: string, root = directory): Record<string, string> {
+  const files: Record<string, string> = {}
+  let entries
+  try {
+    entries = readdirSync(directory, { withFileTypes: true })
+  } catch {
+    return files
+  }
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) Object.assign(files, readTextFiles(path, root))
+    if (entry.isFile()) files[relative(root, path).replace(/\\/g, "/")] = readFileSync(path, "utf8")
+  }
+  return files
+}
+
+function readOptionalText(path: string): string {
+  try {
+    return statSync(path).isFile() ? readFileSync(path, "utf8") : ""
+  } catch {
+    return ""
+  }
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+function numberValue(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback
 }
 
 function stagedAgentBundleSources(agentBundles: AgentTaskRunInput["agent_bundles"], roots: string[]): WorkspaceRecipeStagedFile[] {

--- a/packages/runtime-core/src/runtime-php-snippets.ts
+++ b/packages/runtime-core/src/runtime-php-snippets.ts
@@ -190,13 +190,14 @@ function ${preload}(array $plugin, bool $include_plugin_file, string $role = 're
         throw new RuntimeException($command_label . ' cannot preload recipe plugin file "' . $plugin_file . '". ' . ${diagnosticString}($plugin, $role, 'missing or unreadable plugin file'));
     }
     $plugin_dir = dirname($plugin_file);
-    $plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
-    if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
-        require_once $plugin_autoload;
-    }
     $plugin_package_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload_packages.php';
     if ('.' !== $plugin_dir && is_file($plugin_package_autoload)) {
         require_once $plugin_package_autoload;
+    } else {
+        $plugin_autoload = WP_PLUGIN_DIR . '/' . $plugin_dir . '/vendor/autoload.php';
+        if ('.' !== $plugin_dir && is_file($plugin_autoload)) {
+            require_once $plugin_autoload;
+        }
     }
     if (!$include_plugin_file) {
         return ${diagnostic}($plugin, $role);

--- a/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-abilities.php
@@ -54,6 +54,15 @@ final class WP_Codebox_Abilities {
 
 	public function __construct() {
 		if ( ! class_exists( 'WP_Ability' ) ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register_when_abilities_api_is_ready' ) );
+			return;
+		}
+
+		$this->register_when_abilities_api_is_ready();
+	}
+
+	public function register_when_abilities_api_is_ready(): void {
+		if ( ! class_exists( 'WP_Ability' ) ) {
 			return;
 		}
 

--- a/scripts/agent-runtime-task-ability-smoke.ts
+++ b/scripts/agent-runtime-task-ability-smoke.ts
@@ -23,6 +23,14 @@ try {
     concept_packet: { title: "Runtime task ability available" },
   })
 
+  const alias = await runRuntimeTaskRecipe(root, componentPath, "runtime-package/run")
+  const aliasRuntime = sandboxAgentRuntime(alias)
+  assert.equal(alias.success, true, JSON.stringify(aliasRuntime, null, 2))
+  assert.equal(aliasRuntime.success, true, JSON.stringify(aliasRuntime, null, 2))
+  assert.equal(aliasRuntime.result?.schema, "example/runtime-package-result/v1")
+  assert.equal(aliasRuntime.result?.success, true)
+  assert.equal(aliasRuntime.result?.concept_packet?.title, "Runtime task ability available")
+
   const missing = await runRuntimeTaskRecipe(root, componentPath, "example/missing-runtime-task")
   const missingRuntime = sandboxAgentRuntime(missing)
   assert.equal(missingRuntime.success, false)
@@ -66,6 +74,25 @@ add_action( 'wp_abilities_api_init', static function (): void {
             'output_schema' => array( 'type' => 'object' ),
         )
     );
+
+    wp_register_ability(
+        'agents/run-runtime-package',
+        array(
+            'label' => 'Example Runtime Package Adapter',
+            'description' => 'Synthetic runtime package adapter for sandbox ability alias tests.',
+            'category' => 'wp-codebox',
+            'execute_callback' => static function ( array $input ): array {
+                return array(
+                    'schema' => 'example/runtime-package-result/v1',
+                    'success' => true,
+                    'concept_packet' => array( 'title' => (string) ( $input['title'] ?? '' ) ),
+                );
+            },
+            'permission_callback' => '__return_true',
+            'input_schema' => array( 'type' => 'object' ),
+            'output_schema' => array( 'type' => 'object' ),
+        )
+    );
 } );
 `)
   return pluginPath
@@ -89,14 +116,14 @@ async function runRuntimeTaskRecipe(rootPath: string, componentPath: string, abi
   return JSON.parse(output) as { success?: boolean; executions?: Array<{ recipeCommand?: string; stdout?: string; parsed?: unknown }> }
 }
 
-function sandboxAgentRuntime(runOutput: { executions?: Array<{ recipeCommand?: string; stdout?: string; parsed?: unknown }> }): { success?: boolean; result?: unknown; error?: { code?: string; data?: { preflight?: { schema?: string; ability?: string; available?: boolean; registered_ability_ids?: string[] } } } } {
+function sandboxAgentRuntime(runOutput: { executions?: Array<{ recipeCommand?: string; stdout?: string; parsed?: unknown }> }): { success?: boolean; result?: any; error?: { code?: string; data?: { preflight?: { schema?: string; ability?: string; resolved_ability?: string; available?: boolean; registered_ability_ids?: string[] } } } } {
   const execution = runOutput.executions?.find((item) => item.recipeCommand === "wp-codebox.agent-sandbox-run")
   assert.ok(execution, "agent sandbox execution should be present")
   const parsed = typeof execution.parsed === "object" && execution.parsed !== null
     ? execution.parsed as Record<string, unknown>
     : JSON.parse(String(execution.stdout ?? "{}")) as Record<string, unknown>
   const output = typeof parsed.output === "string" ? JSON.parse(parsed.output) as Record<string, unknown> : parsed
-  return output.agent_runtime as { success?: boolean; result?: unknown; error?: { code?: string; data?: { preflight?: { schema?: string; ability?: string; available?: boolean; registered_ability_ids?: string[] } } } }
+  return output.agent_runtime as { success?: boolean; result?: any; error?: { code?: string; data?: { preflight?: { schema?: string; ability?: string; resolved_ability?: string; available?: boolean; registered_ability_ids?: string[] } } } }
 }
 
 async function captureStdout(callback: () => Promise<unknown>): Promise<string> {

--- a/tests/runtime-php-snippets.test.ts
+++ b/tests/runtime-php-snippets.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict"
 import { execFileSync } from "node:child_process"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { mkdtempSync } from "node:fs"
 import { resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { phpRuntimeComponentLifecycleActionReplayFunction, phpRuntimeComponentLifecycleReplayFunction } from "../packages/runtime-core/src/index.js"
 import { bootstrapPhpCode } from "../packages/runtime-playground/src/php-bootstrap.js"
@@ -112,6 +116,34 @@ const sandboxAgentCodeWithRuntimeTask = await resolveSandboxTaskCode({
 })
 assert.match(sandboxAgentCodeWithRuntimeTask, /json_decode\(<<<'WP_CODEBOX_LITERAL_/)
 assert.doesNotMatch(sandboxAgentCodeWithRuntimeTask, /json_decode\(".*\$\{package\.root\}/s)
+
+const bundleRoot = mkdtempSync(join(tmpdir(), "wp-codebox-runtime-package-bundle-"))
+const workspaceRoot = join(bundleRoot, "workspace")
+const bundlePath = join(workspaceRoot, "bundles", "store-idea-agent")
+mkdirSync(join(bundlePath, "pipelines"), { recursive: true })
+mkdirSync(join(bundlePath, "flows"), { recursive: true })
+mkdirSync(join(bundlePath, "memory", "agent"), { recursive: true })
+writeFileSync(join(bundlePath, "manifest.json"), JSON.stringify({ bundle_slug: "store-idea-agent", bundle_version: "1", agent: { slug: "store-idea-agent", label: "Store Idea Agent" } }))
+writeFileSync(join(bundlePath, "pipelines", "store-idea-artifact-pipeline.json"), JSON.stringify({ slug: "store-idea-artifact-pipeline", name: "Store Idea Artifact Pipeline", steps: [{ step_position: 0, step_type: "ai", step_config: { label: "Generate" } }] }))
+writeFileSync(join(bundlePath, "flows", "store-idea-artifact-flow.json"), JSON.stringify({ slug: "store-idea-artifact-flow", name: "Store Idea Artifact", pipeline_slug: "store-idea-artifact-pipeline", schedule: "manual", max_items: [], steps: [{ step_position: 0, step_type: "ai" }] }))
+writeFileSync(join(bundlePath, "memory", "agent", "SOUL.md"), "# Store Idea Agent\n")
+const sandboxAgentCodeWithRuntimePackageBundle = await resolveSandboxTaskCode({
+  task: "Run runtime package",
+  agent: "wp-codebox-sandbox",
+  runtimeTask: {
+    ability: "wp-codebox/run-runtime-package",
+    input: { package: { slug: "store-idea-agent", source: "/workspace/example/bundles/store-idea-agent" } },
+  },
+  sandboxWorkspace: {
+    schema: "wp-codebox/sandbox-workspace/v1",
+    root: "/workspace",
+    defaultMode: "repo-backed",
+    mounts: [{ target: "/workspace/example", source: workspaceRoot, mode: "readwrite", sourceMode: "repo-backed" } as never],
+  },
+  sandboxToolPolicy: { schema: "wp-codebox/sandbox-tool-policy/v1", version: 1, tools: [] },
+})
+assert.match(sandboxAgentCodeWithRuntimePackageBundle, /"bundle_slug":"store-idea-agent"/)
+assert.match(sandboxAgentCodeWithRuntimePackageBundle, /"bundle":\{"bundle_version":"1","bundle_slug":"store-idea-agent"/)
 
 const sandboxAgentCodeWithTools = await resolveSandboxTaskCode({
   task: "Inspect workspace",

--- a/tests/wordpress-plugin-public-runtime-abilities.test.ts
+++ b/tests/wordpress-plugin-public-runtime-abilities.test.ts
@@ -5,6 +5,9 @@ const abilitiesPhp = await readFile("packages/wordpress-plugin/src/class-wp-code
 const schemasPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-schemas.php", "utf8")
 const executionPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php", "utf8")
 
+assert.match(abilitiesPhp, /add_action\(\s*'wp_abilities_api_init',\s*array\(\s*\$this,\s*'register_when_abilities_api_is_ready'\s*\)\s*\)/, "WP Codebox must defer ability registration until the Abilities API is ready")
+assert.match(abilitiesPhp, /function register_when_abilities_api_is_ready\(\): void/, "deferred ability registration callback must be present")
+
 for (const ability of ["wp-codebox/run-wordpress-workload", "wp-codebox/run-fuzz-suite", "wp-codebox/run-runtime-package"]) {
   assert.match(abilitiesPhp, new RegExp(`wp_register_ability\\(\\s*'${ability}'`), `${ability} must be registered`)
   assert.match(abilitiesPhp, new RegExp(`'canonical_ability'\\s*=>\\s*'${ability}'`), `${ability} must mark its canonical id`)


### PR DESCRIPTION
## Summary
- hydrate local Data Machine runtime-package bundle directories into inline `package.bundle` payloads before sandbox execution
- resolve neutral `runtime-package/run` requests to the public WP Codebox runtime-package ability aliases
- defer WP Codebox ability registration until the Abilities API is ready
- prefer package-scoped Composer autoloaders before generic plugin autoloaders to avoid provider/client classmap conflicts

## Verification
- `./node_modules/.bin/tsx tests/runtime-php-snippets.test.ts`
- `./node_modules/.bin/tsx scripts/agent-runtime-task-ability-smoke.ts`
- `node tests/wordpress-plugin-public-runtime-abilities.test.ts`
- `npm run build`
- Lab proof: WPSG controller reached `wp-codebox/run-runtime-package` with `package.bundle.bundle_slug = "store-idea-agent"`; remaining failure is Codex OAuth refresh token freshness, not bundle hydration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** debugging runtime-package execution through WP Codebox, drafting code/test changes, running focused verification, and preparing this PR description.
