### PR TITLE
Fix run-agent-task checking out wp-codebox at the caller's branch ref

### DIFF
--- a/.github/workflows/run-agent-task.yml
+++ b/.github/workflows/run-agent-task.yml
@@ -180,8 +180,20 @@ jobs:
       - name: Resolve WP Codebox workflow ref
         id: workflow-ref
         env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: printf 'ref=%s\n' "${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+          # `github.job_workflow_sha` is the commit SHA of THIS reusable workflow
+          # file, so the checked-out helper scripts always match the version of
+          # run-agent-task.yml that is executing. `github.workflow_ref` must not be
+          # used here: inside a reusable workflow it resolves to the caller's
+          # top-level workflow ref, so its branch name (e.g. `trunk` for a caller
+          # whose default branch is not `main`) gets used to check out
+          # Automattic/wp-codebox and fails when that ref does not exist here.
+          JOB_WORKFLOW_SHA: ${{ github.job_workflow_sha }}
+        run: |
+          ref="${JOB_WORKFLOW_SHA}"
+          if [ -z "${ref}" ]; then
+            ref="main"
+          fi
+          printf 'ref=%s\n' "${ref}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout WP Codebox workflow helpers
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`run-agent-task.yml` (the reusable agent-task workflow) checks out `Automattic/wp-codebox` to get its helper scripts, but derived the ref from `github.workflow_ref`:

```yaml
WORKFLOW_REF: ${{ github.workflow_ref }}
run: printf 'ref=%s\n' "${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
```

Inside a **reusable** workflow, `github.workflow_ref` resolves to the **caller's top-level** workflow ref, not this workflow's. So the caller's branch name was used to check out wp-codebox:

```
WORKFLOW_REF = Automattic/build-with-wordpress/.github/workflows/developer-docs-agent.yml@refs/heads/trunk
ref          = refs/heads/trunk
→ checkout Automattic/wp-codebox @ refs/heads/trunk
##[error]fatal: couldn't find remote ref refs/heads/trunk
```

It happened to work for callers whose default branch is `main` (e.g. `Automattic/docs-agent`), but **any caller whose default branch is not `main` fails** — e.g. `Automattic/build-with-wordpress` (default `trunk`), whose "Developer Docs Agent" action has been failing on every push since the docs-agent routing moved onto this workflow.

## Fix

Resolve the checkout ref from `github.job_workflow_sha` — the commit SHA of **this reusable workflow file** — so the checked-out helper scripts always match the exact version of `run-agent-task.yml` that is executing, independent of the caller's default branch. Falls back to `main` defensively. The workflow is `workflow_call`-only, so `job_workflow_sha` is always populated in practice.

## Verification

YAML validated; no other `github.workflow_ref`-derived cross-repo checkout exists in the workflow or its scripts. Workflow-context resolution can only be fully confirmed by a live run — re-running `Automattic/build-with-wordpress` "Developer Docs Agent" against this change should get past the `couldn't find remote ref` failure and check out wp-codebox at the workflow's own SHA.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause diagnosis from CI logs and the workflow ref fix.