### PR TITLE
Fix reserved RUNNER_WORKSPACE env collision crashing run-agent-task

### DIFF
--- a/.github/scripts/run-agent-task/build-codebox-task-request.mjs
+++ b/.github/scripts/run-agent-task/build-codebox-task-request.mjs
@@ -53,7 +53,7 @@ const request = {
     provider: process.env.PROVIDER || "openai",
     name: process.env.MODEL || "gpt-5.5",
   },
-  runner_workspace: parseJson("RUNNER_WORKSPACE", {}, "object"),
+  runner_workspace: parseJson("RUNNER_WORKSPACE_CONFIG", {}, "object"),
   validation_dependencies: process.env.VALIDATION_DEPENDENCIES || "",
   context_repositories: parseJson("CONTEXT_REPOSITORIES", [], "array"),
   verification_commands: parseJson("VERIFICATION_COMMANDS", [], "array"),

--- a/.github/workflows/run-agent-task.yml
+++ b/.github/workflows/run-agent-task.yml
@@ -215,7 +215,11 @@ jobs:
           WRITABLE_PATHS: ${{ inputs.writable_paths }}
           PROVIDER: ${{ inputs.provider }}
           MODEL: ${{ inputs.model }}
-          RUNNER_WORKSPACE: ${{ inputs.runner_workspace }}
+          # Not `RUNNER_WORKSPACE`: that name is a reserved GitHub Actions
+          # built-in (the `RUNNER_` prefix cannot be overridden), so a workflow
+          # value set under it is ignored and the script receives the runner's
+          # workspace path instead of this JSON config.
+          RUNNER_WORKSPACE_CONFIG: ${{ inputs.runner_workspace }}
           VALIDATION_DEPENDENCIES: ${{ inputs.validation_dependencies }}
           CONTEXT_REPOSITORIES: ${{ inputs.context_repositories }}
           VERIFICATION_COMMANDS: ${{ inputs.verification_commands }}


### PR DESCRIPTION
## Problem

The `Build Codebox task request` step in `run-agent-task.yml` passed the runner-workspace JSON config through an env var named **`RUNNER_WORKSPACE`**, and `build-codebox-task-request.mjs` did `JSON.parse()` on it.

But **`RUNNER_WORKSPACE` is a reserved GitHub Actions built-in** — `RUNNER_`-prefixed env vars cannot be overridden by a workflow. So the workflow's value was ignored and the script received the runner's workspace **path** instead:

```
SyntaxError: Unexpected token '/', "/home/runn"... is not valid JSON
    at JSON.parse (<anonymous>)
    at build-codebox-task-request.mjs:56  // runner_workspace: parseJson("RUNNER_WORKSPACE", ...)
```

`/home/runner/work/<repo>` is the built-in `RUNNER_WORKSPACE` value. This failed for **every** caller of the workflow — it was previously masked because the wp-codebox checkout step failed first (#1617). With that fixed, this is the next failure (seen live on `Automattic/build-with-wordpress`).

## Fix

Rename the env var to **`RUNNER_WORKSPACE_CONFIG`** in both the workflow step and the script, so the JSON config reaches `JSON.parse` intact. (`RUNNER_RECIPE` etc. are unaffected — they don't collide with a built-in.)

## Verification

Ran `build-codebox-task-request.mjs` locally with the built-in `RUNNER_WORKSPACE=/home/runner/work/...` set **and** `RUNNER_WORKSPACE_CONFIG` = the JSON config: the line-56 `SyntaxError` is gone and execution proceeds normally through required-field validation. YAML + `node --check` pass. Full confirmation is a live `build-with-wordpress` run (next).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Root-cause diagnosis from CI logs and the env-var collision fix.