### PR TITLE
Add generated fanout aggregation parity vectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "release:package": "tsx scripts/package-release-artifact.ts",
     "wp-codebox": "node packages/cli/dist/index.js",
     "wp-codebox:source": "node bin/wp-codebox-source.mjs",
+    "generate:fanout-aggregation-contract": "tsx scripts/generate-fanout-aggregation-contract-fixture.ts",
     "smoke": "tsx scripts/run-smoke.ts",
     "test:redaction": "tsx tests/redaction.test.ts",
     "test:legacy-agent-task-contracts": "tsx tests/agent-task-contracts.test.ts",

--- a/scripts/generate-fanout-aggregation-contract-fixture.ts
+++ b/scripts/generate-fanout-aggregation-contract-fixture.ts
@@ -1,0 +1,96 @@
+import { writeFile } from "node:fs/promises"
+
+import { aggregateFanoutOutputs } from "../packages/runtime-core/src/index.js"
+
+const fixtureUrl = new URL("../tests/fixtures/fanout-aggregation-contract.json", import.meta.url)
+
+const successfulInput = {
+  plan: {
+    id: "fanout-contract-fixture",
+    workers: [
+      { id: "alpha", artifact_namespace: "workers/alpha" },
+      { id: "beta", depends_on: ["alpha"], artifact_namespace: "workers/beta" },
+    ],
+  },
+  policy: "fail",
+  aggregation: {
+    agent: "generic-aggregator",
+    outputNamespace: "aggregate/final",
+  },
+  worker_results: [
+    {
+      worker_id: "alpha",
+      status: "completed",
+      success: true,
+      result_ref: "fanout/workers/alpha/result.json",
+      artifact_refs: [
+        { path: "fanout/workers/alpha/artifacts/report.json", final_path: "reports/alpha.json", kind: "worker-report" },
+      ],
+    },
+    {
+      worker_id: "beta",
+      status: "succeeded",
+      result_ref: "fanout/workers/beta/result.json",
+      artifact_refs: [
+        { path: "fanout/workers/beta/artifacts/report.json", final_path: "reports/beta.json", kind: "worker-report" },
+      ],
+    },
+  ],
+}
+
+const vectors = [
+  {
+    name: "success-with-legacy-status-and-default-output",
+    input: successfulInput,
+  },
+  {
+    name: "duplicate-final-path-partial-policy",
+    input: {
+      ...successfulInput,
+      policy: "partial",
+      worker_results: [
+        { worker_id: "alpha", status: "succeeded", artifact_refs: [{ path: "fanout/workers/alpha/index.html", final_path: "site/index.html" }] },
+        { worker_id: "beta", status: "succeeded", artifact_refs: [{ path: "fanout/workers/beta/index.html", final_path: "site/index.html" }] },
+      ],
+    },
+  },
+  {
+    name: "failed-required-worker-caller-review-policy",
+    input: {
+      ...successfulInput,
+      policy: "caller-review-required",
+      worker_results: [
+        {
+          worker_id: "alpha",
+          status: "failed",
+          error: { code: "worker-exit", message: "Worker exited with code 1." },
+          artifact_refs: [{ path: "fanout/workers/alpha/error.log", kind: "log" }],
+        },
+        { worker_id: "beta", status: "succeeded", artifact_refs: [{ path: "fanout/workers/beta/report.json", final_path: "reports/beta.json" }] },
+      ],
+    },
+  },
+  {
+    name: "missing-dependency-partial-policy",
+    input: {
+      ...successfulInput,
+      policy: "partial",
+      worker_results: [
+        { worker_id: "beta", status: "succeeded", artifact_refs: [{ path: "fanout/workers/beta/report.json", final_path: "reports/beta.json" }] },
+      ],
+    },
+  },
+  {
+    name: "repair-policy-conflict-candidate",
+    input: {
+      ...successfulInput,
+      policy: "repair",
+      conflict_candidates: [{ type: "incompatible-schema", severity: "error", message: "Worker schemas differ." }],
+    },
+  },
+].map((vector) => ({
+  ...vector,
+  expectedOutput: aggregateFanoutOutputs(vector.input),
+}))
+
+await writeFile(fixtureUrl, `${JSON.stringify({ generatedBy: "scripts/generate-fanout-aggregation-contract-fixture.ts", source: "packages/runtime-core/src/fanout-aggregation.ts", vectors }, null, 2)}\n`)

--- a/scripts/php-fanout-aggregation-contract-smoke.php
+++ b/scripts/php-fanout-aggregation-contract-smoke.php
@@ -20,28 +20,20 @@ if ( ! is_array( $fixture ) ) {
 	exit( 1 );
 }
 
-$aggregation = new WP_Codebox_Fanout_Aggregation();
-$output      = $aggregation->aggregate( $fixture['input'] );
-assert_same_contract( $fixture['expectedOutput'], $output, 'PHP fanout aggregation output' );
+$vectors = $fixture['vectors'] ?? null;
+if ( ! is_array( $vectors ) ) {
+	fwrite( STDERR, "Fanout aggregation contract fixture must include generated vectors.\n" );
+	exit( 1 );
+}
 
-$duplicate_output = $aggregation->aggregate(
-	array(
-		'plan'           => array(
-			'id'      => 'duplicate-final-path',
-			'workers' => array(
-				array( 'id' => 'one' ),
-				array( 'id' => 'two' ),
-			),
-		),
-		'policy'         => 'partial',
-		'worker_results' => array(
-			array( 'worker_id' => 'one', 'status' => 'succeeded', 'artifact_refs' => array( array( 'path' => 'one.json', 'final_path' => 'same.json' ) ) ),
-			array( 'worker_id' => 'two', 'status' => 'succeeded', 'artifact_refs' => array( array( 'path' => 'two.json', 'final_path' => 'same.json' ) ) ),
-		),
-	)
-);
-assert_same_contract( 'partial', $duplicate_output['status'], 'partial policy conflict status' );
-assert_same_contract( 'duplicate-final-artifact-path', $duplicate_output['conflicts'][0]['type'], 'duplicate final-path conflict' );
-assert_same_contract( array(), $duplicate_output['finalArtifactRefs'], 'conflicted aggregation final refs' );
+$aggregation = new WP_Codebox_Fanout_Aggregation();
+foreach ( $vectors as $vector ) {
+	if ( ! is_array( $vector ) ) {
+		fwrite( STDERR, "Fanout aggregation contract vector must be an object.\n" );
+		exit( 1 );
+	}
+	$output = $aggregation->aggregate( is_array( $vector['input'] ?? null ) ? $vector['input'] : array() );
+	assert_same_contract( $vector['expectedOutput'] ?? null, $output, 'PHP fanout aggregation output vector ' . (string) ( $vector['name'] ?? '' ) );
+}
 
 echo "PHP fanout aggregation contract smoke passed\n";

--- a/tests/fanout-aggregation-contract-parity.test.ts
+++ b/tests/fanout-aggregation-contract-parity.test.ts
@@ -11,20 +11,27 @@ const root = new URL("../", import.meta.url)
 const fixture = JSON.parse(await readFile(new URL("fixtures/fanout-aggregation-contract.json", import.meta.url), "utf8"))
 const plain = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
-const runtimeOutput = plain(aggregateFanoutOutputs(fixture.input))
-assert.deepEqual(plain(validateFanoutAggregationOutput(runtimeOutput)), fixture.expectedOutput, "canonical fanout output fixture must validate")
-assert.deepEqual(runtimeOutput, fixture.expectedOutput, "runtime-core aggregation output must match the canonical fixture")
+assert.equal(fixture.generatedBy, "scripts/generate-fanout-aggregation-contract-fixture.ts", "fanout fixture must declare its runtime-core generator")
+assert.ok(Array.isArray(fixture.vectors) && fixture.vectors.length > 1, "fanout fixture must cover multiple aggregation vectors")
+
+for (const vector of fixture.vectors) {
+  const runtimeOutput = plain(aggregateFanoutOutputs(vector.input))
+  assert.deepEqual(plain(validateFanoutAggregationOutput(runtimeOutput)), vector.expectedOutput, `${vector.name}: canonical fanout output fixture must validate`)
+  assert.deepEqual(runtimeOutput, vector.expectedOutput, `${vector.name}: runtime-core aggregation output must match the generated fixture`)
+}
+
+const runtimeOutput = plain(aggregateFanoutOutputs(fixture.vectors[0].input))
 assert.throws(() => validateFanoutAggregationOutput({ ...runtimeOutput, workerResultRefs: undefined }), /workerResultRefs/, "canonical fanout output requires worker result refs")
 assert.throws(() => validateFanoutAggregationOutput({ ...runtimeOutput, rawWorkerArtifactRefs: [{ kind: "worker-report" }] }), /requires path/, "canonical fanout output requires artifact ref paths")
 
 const normalizedFromArtifacts = plain(fanoutAggregationInputFromWorkerArtifacts({
-  plan: fixture.input.plan,
-  policy: fixture.input.policy,
-  aggregator: fixture.input.aggregation,
-  workerResultRefs: fixture.input.worker_results,
+  plan: fixture.vectors[0].input.plan,
+  policy: fixture.vectors[0].input.policy,
+  aggregator: fixture.vectors[0].input.aggregation,
+  workerResultRefs: fixture.vectors[0].input.worker_results,
 }))
 assert.equal(normalizedFromArtifacts.schema, "wp-codebox/agent-fanout-aggregation-input/v1")
-assert.deepEqual(plain(aggregateFanoutOutputs(normalizedFromArtifacts)), fixture.expectedOutput, "worker artifact refs must normalize into the same aggregation output")
+assert.deepEqual(plain(aggregateFanoutOutputs(normalizedFromArtifacts)), fixture.vectors[0].expectedOutput, "worker artifact refs must normalize into the same aggregation output")
 
 const runtimeSource = await readFile(new URL("packages/wordpress-plugin/assets/browser-runtime.js", root), "utf8")
 const sandbox = {
@@ -37,14 +44,16 @@ const sandbox = {
 vm.runInNewContext(runtimeSource, sandbox, { filename: "browser-runtime.js" })
 const browserAggregate = sandbox.window.wpCodeboxBrowser?.v1?.aggregateFanoutOutputs
 assert.equal(typeof browserAggregate, "function", "browser runtime must expose the aggregation contract helper")
-assert.deepEqual(plain(browserAggregate?.(fixture.input)), fixture.expectedOutput, "WordPress browser runtime aggregation output must match runtime-core")
+for (const vector of fixture.vectors) {
+  assert.deepEqual(plain(browserAggregate?.(vector.input)), vector.expectedOutput, `${vector.name}: WordPress browser runtime aggregation output must match runtime-core`)
+}
 
 await withTempDir("wp-codebox-fanout-aggregation-parity-", async (artifactRoot) => {
   const result = await executeAgentFanoutRequest({
     schema: FANOUT_REQUEST_SCHEMA,
     concurrency: 2,
     orchestrator: { session_id: "fanout-contract-fixture" },
-    aggregation: fixture.input.aggregation,
+    aggregation: fixture.vectors[0].input.aggregation,
     workers: [
       { id: "alpha", goal: "Collect alpha result" },
       { id: "beta", goal: "Collect beta result", dependsOn: ["alpha"] },

--- a/tests/fixtures/fanout-aggregation-contract.json
+++ b/tests/fixtures/fanout-aggregation-contract.json
@@ -1,137 +1,705 @@
 {
-  "input": {
-    "plan": {
-      "id": "fanout-contract-fixture",
-      "workers": [
-        {
-          "id": "alpha",
-          "artifact_namespace": "workers/alpha"
+  "generatedBy": "scripts/generate-fanout-aggregation-contract-fixture.ts",
+  "source": "packages/runtime-core/src/fanout-aggregation.ts",
+  "vectors": [
+    {
+      "name": "success-with-legacy-status-and-default-output",
+      "input": {
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta"
+            }
+          ]
         },
-        {
-          "id": "beta",
-          "depends_on": [
-            "alpha"
-          ],
-          "artifact_namespace": "workers/beta"
-        }
-      ]
-    },
-    "policy": "fail",
-    "aggregation": {
-      "agent": "generic-aggregator",
-      "outputNamespace": "aggregate/final"
-    },
-    "worker_results": [
-      {
-        "worker_id": "alpha",
-        "status": "completed",
-        "success": true,
-        "result_ref": "fanout/workers/alpha/result.json",
-        "artifact_refs": [
+        "policy": "fail",
+        "aggregation": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "worker_results": [
           {
-            "path": "fanout/workers/alpha/artifacts/report.json",
-            "final_path": "reports/alpha.json",
-            "kind": "worker-report"
+            "worker_id": "alpha",
+            "status": "completed",
+            "success": true,
+            "result_ref": "fanout/workers/alpha/result.json",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/alpha/artifacts/report.json",
+                "final_path": "reports/alpha.json",
+                "kind": "worker-report"
+              }
+            ]
+          },
+          {
+            "worker_id": "beta",
+            "status": "succeeded",
+            "result_ref": "fanout/workers/beta/result.json",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/beta/artifacts/report.json",
+                "final_path": "reports/beta.json",
+                "kind": "worker-report"
+              }
+            ]
           }
         ]
       },
-      {
-        "worker_id": "beta",
+      "expectedOutput": {
+        "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
         "status": "succeeded",
-        "result_ref": "fanout/workers/beta/result.json",
-        "artifact_refs": [
-          {
-            "path": "fanout/workers/beta/artifacts/report.json",
-            "final_path": "reports/beta.json",
-            "kind": "worker-report"
-          }
-        ]
-      }
-    ]
-  },
-  "expectedOutput": {
-    "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
-    "status": "succeeded",
-    "policy": "fail",
-    "plan": {
-      "id": "fanout-contract-fixture",
-      "workers": [
-        {
-          "id": "alpha",
-          "artifact_namespace": "workers/alpha",
-          "dependsOn": [],
-          "required": true,
-          "artifactNamespace": "workers/alpha"
+        "policy": "fail",
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha",
+              "dependsOn": [],
+              "required": true,
+              "artifactNamespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta",
+              "dependsOn": [
+                "alpha"
+              ],
+              "required": true,
+              "artifactNamespace": "workers/beta"
+            }
+          ]
         },
-        {
-          "id": "beta",
-          "depends_on": [
-            "alpha"
-          ],
-          "artifact_namespace": "workers/beta",
-          "dependsOn": [
-            "alpha"
-          ],
-          "required": true,
-          "artifactNamespace": "workers/beta"
-        }
-      ]
-    },
-    "aggregator": {
-      "agent": "generic-aggregator",
-      "outputNamespace": "aggregate/final"
-    },
-    "workerResultRefs": [
-      {
-        "workerId": "alpha",
-        "status": "succeeded",
-        "required": true,
-        "resultRef": "fanout/workers/alpha/result.json",
-        "artifactRefs": [
+        "aggregator": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "workerResultRefs": [
+          {
+            "workerId": "alpha",
+            "status": "succeeded",
+            "required": true,
+            "resultRef": "fanout/workers/alpha/result.json",
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/artifacts/report.json",
+                "kind": "worker-report",
+                "workerId": "alpha",
+                "finalPath": "reports/alpha.json"
+              }
+            ]
+          },
+          {
+            "workerId": "beta",
+            "status": "succeeded",
+            "required": true,
+            "resultRef": "fanout/workers/beta/result.json",
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/beta/artifacts/report.json",
+                "kind": "worker-report",
+                "workerId": "beta",
+                "finalPath": "reports/beta.json"
+              }
+            ]
+          }
+        ],
+        "rawWorkerArtifactRefs": [
           {
             "path": "fanout/workers/alpha/artifacts/report.json",
             "kind": "worker-report",
             "workerId": "alpha",
             "finalPath": "reports/alpha.json"
-          }
-        ]
-      },
-      {
-        "workerId": "beta",
-        "status": "succeeded",
-        "required": true,
-        "resultRef": "fanout/workers/beta/result.json",
-        "artifactRefs": [
+          },
           {
             "path": "fanout/workers/beta/artifacts/report.json",
             "kind": "worker-report",
             "workerId": "beta",
             "finalPath": "reports/beta.json"
           }
+        ],
+        "finalArtifactRefs": [
+          {
+            "path": "aggregate/final/result.json",
+            "kind": "fanout-aggregate-output",
+            "contentType": "application/json"
+          }
+        ],
+        "conflicts": []
+      }
+    },
+    {
+      "name": "duplicate-final-path-partial-policy",
+      "input": {
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta"
+            }
+          ]
+        },
+        "policy": "partial",
+        "aggregation": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "worker_results": [
+          {
+            "worker_id": "alpha",
+            "status": "succeeded",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/alpha/index.html",
+                "final_path": "site/index.html"
+              }
+            ]
+          },
+          {
+            "worker_id": "beta",
+            "status": "succeeded",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/beta/index.html",
+                "final_path": "site/index.html"
+              }
+            ]
+          }
+        ]
+      },
+      "expectedOutput": {
+        "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
+        "status": "partial",
+        "policy": "partial",
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha",
+              "dependsOn": [],
+              "required": true,
+              "artifactNamespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta",
+              "dependsOn": [
+                "alpha"
+              ],
+              "required": true,
+              "artifactNamespace": "workers/beta"
+            }
+          ]
+        },
+        "aggregator": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "workerResultRefs": [
+          {
+            "workerId": "alpha",
+            "status": "succeeded",
+            "required": true,
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/index.html",
+                "workerId": "alpha",
+                "finalPath": "site/index.html"
+              }
+            ]
+          },
+          {
+            "workerId": "beta",
+            "status": "succeeded",
+            "required": true,
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/beta/index.html",
+                "workerId": "beta",
+                "finalPath": "site/index.html"
+              }
+            ]
+          }
+        ],
+        "rawWorkerArtifactRefs": [
+          {
+            "path": "fanout/workers/alpha/index.html",
+            "workerId": "alpha",
+            "finalPath": "site/index.html"
+          },
+          {
+            "path": "fanout/workers/beta/index.html",
+            "workerId": "beta",
+            "finalPath": "site/index.html"
+          }
+        ],
+        "finalArtifactRefs": [],
+        "conflicts": [
+          {
+            "type": "duplicate-final-artifact-path",
+            "severity": "error",
+            "message": "Multiple fanout worker artifacts target final path site/index.html.",
+            "path": "site/index.html",
+            "workerIds": [
+              "alpha",
+              "beta"
+            ],
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/index.html",
+                "workerId": "alpha",
+                "finalPath": "site/index.html"
+              },
+              {
+                "path": "fanout/workers/beta/index.html",
+                "workerId": "beta",
+                "finalPath": "site/index.html"
+              }
+            ]
+          }
         ]
       }
-    ],
-    "rawWorkerArtifactRefs": [
-      {
-        "path": "fanout/workers/alpha/artifacts/report.json",
-        "kind": "worker-report",
-        "workerId": "alpha",
-        "finalPath": "reports/alpha.json"
+    },
+    {
+      "name": "failed-required-worker-caller-review-policy",
+      "input": {
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta"
+            }
+          ]
+        },
+        "policy": "caller-review-required",
+        "aggregation": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "worker_results": [
+          {
+            "worker_id": "alpha",
+            "status": "failed",
+            "error": {
+              "code": "worker-exit",
+              "message": "Worker exited with code 1."
+            },
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/alpha/error.log",
+                "kind": "log"
+              }
+            ]
+          },
+          {
+            "worker_id": "beta",
+            "status": "succeeded",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/beta/report.json",
+                "final_path": "reports/beta.json"
+              }
+            ]
+          }
+        ]
       },
-      {
-        "path": "fanout/workers/beta/artifacts/report.json",
-        "kind": "worker-report",
-        "workerId": "beta",
-        "finalPath": "reports/beta.json"
+      "expectedOutput": {
+        "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
+        "status": "caller_review_required",
+        "policy": "caller-review-required",
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha",
+              "dependsOn": [],
+              "required": true,
+              "artifactNamespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta",
+              "dependsOn": [
+                "alpha"
+              ],
+              "required": true,
+              "artifactNamespace": "workers/beta"
+            }
+          ]
+        },
+        "aggregator": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "workerResultRefs": [
+          {
+            "workerId": "alpha",
+            "status": "failed",
+            "required": true,
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/error.log",
+                "kind": "log",
+                "workerId": "alpha"
+              }
+            ],
+            "error": {
+              "code": "worker-exit",
+              "message": "Worker exited with code 1."
+            }
+          },
+          {
+            "workerId": "beta",
+            "status": "succeeded",
+            "required": true,
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/beta/report.json",
+                "workerId": "beta",
+                "finalPath": "reports/beta.json"
+              }
+            ]
+          }
+        ],
+        "rawWorkerArtifactRefs": [
+          {
+            "path": "fanout/workers/alpha/error.log",
+            "kind": "log",
+            "workerId": "alpha"
+          },
+          {
+            "path": "fanout/workers/beta/report.json",
+            "workerId": "beta",
+            "finalPath": "reports/beta.json"
+          }
+        ],
+        "finalArtifactRefs": [],
+        "conflicts": [
+          {
+            "type": "failed-worker",
+            "severity": "error",
+            "message": "Required fanout worker alpha ended with status failed.",
+            "workerIds": [
+              "alpha"
+            ],
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/error.log",
+                "kind": "log",
+                "workerId": "alpha"
+              }
+            ],
+            "details": {
+              "error": {
+                "code": "worker-exit",
+                "message": "Worker exited with code 1."
+              }
+            }
+          },
+          {
+            "type": "failed-worker-dependency",
+            "severity": "error",
+            "message": "Fanout worker beta depends on alpha, which ended with status failed.",
+            "workerIds": [
+              "beta",
+              "alpha"
+            ],
+            "dependencyId": "alpha",
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/error.log",
+                "kind": "log",
+                "workerId": "alpha"
+              }
+            ]
+          }
+        ]
       }
-    ],
-    "finalArtifactRefs": [
-      {
-        "path": "aggregate/final/result.json",
-        "kind": "fanout-aggregate-output",
-        "contentType": "application/json"
+    },
+    {
+      "name": "missing-dependency-partial-policy",
+      "input": {
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta"
+            }
+          ]
+        },
+        "policy": "partial",
+        "aggregation": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "worker_results": [
+          {
+            "worker_id": "beta",
+            "status": "succeeded",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/beta/report.json",
+                "final_path": "reports/beta.json"
+              }
+            ]
+          }
+        ]
+      },
+      "expectedOutput": {
+        "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
+        "status": "partial",
+        "policy": "partial",
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha",
+              "dependsOn": [],
+              "required": true,
+              "artifactNamespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta",
+              "dependsOn": [
+                "alpha"
+              ],
+              "required": true,
+              "artifactNamespace": "workers/beta"
+            }
+          ]
+        },
+        "aggregator": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "workerResultRefs": [
+          {
+            "workerId": "beta",
+            "status": "succeeded",
+            "required": true,
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/beta/report.json",
+                "workerId": "beta",
+                "finalPath": "reports/beta.json"
+              }
+            ]
+          }
+        ],
+        "rawWorkerArtifactRefs": [
+          {
+            "path": "fanout/workers/beta/report.json",
+            "workerId": "beta",
+            "finalPath": "reports/beta.json"
+          }
+        ],
+        "finalArtifactRefs": [],
+        "conflicts": [
+          {
+            "type": "missing-worker-dependency",
+            "severity": "error",
+            "message": "Fanout worker beta depends on missing worker alpha.",
+            "workerIds": [
+              "beta"
+            ],
+            "dependencyId": "alpha"
+          }
+        ]
       }
-    ],
-    "conflicts": []
-  }
+    },
+    {
+      "name": "repair-policy-conflict-candidate",
+      "input": {
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta"
+            }
+          ]
+        },
+        "policy": "repair",
+        "aggregation": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "worker_results": [
+          {
+            "worker_id": "alpha",
+            "status": "completed",
+            "success": true,
+            "result_ref": "fanout/workers/alpha/result.json",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/alpha/artifacts/report.json",
+                "final_path": "reports/alpha.json",
+                "kind": "worker-report"
+              }
+            ]
+          },
+          {
+            "worker_id": "beta",
+            "status": "succeeded",
+            "result_ref": "fanout/workers/beta/result.json",
+            "artifact_refs": [
+              {
+                "path": "fanout/workers/beta/artifacts/report.json",
+                "final_path": "reports/beta.json",
+                "kind": "worker-report"
+              }
+            ]
+          }
+        ],
+        "conflict_candidates": [
+          {
+            "type": "incompatible-schema",
+            "severity": "error",
+            "message": "Worker schemas differ."
+          }
+        ]
+      },
+      "expectedOutput": {
+        "schema": "wp-codebox/agent-fanout-aggregation-output/v1",
+        "status": "repair_required",
+        "policy": "repair",
+        "plan": {
+          "id": "fanout-contract-fixture",
+          "workers": [
+            {
+              "id": "alpha",
+              "artifact_namespace": "workers/alpha",
+              "dependsOn": [],
+              "required": true,
+              "artifactNamespace": "workers/alpha"
+            },
+            {
+              "id": "beta",
+              "depends_on": [
+                "alpha"
+              ],
+              "artifact_namespace": "workers/beta",
+              "dependsOn": [
+                "alpha"
+              ],
+              "required": true,
+              "artifactNamespace": "workers/beta"
+            }
+          ]
+        },
+        "aggregator": {
+          "agent": "generic-aggregator",
+          "outputNamespace": "aggregate/final"
+        },
+        "workerResultRefs": [
+          {
+            "workerId": "alpha",
+            "status": "succeeded",
+            "required": true,
+            "resultRef": "fanout/workers/alpha/result.json",
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/alpha/artifacts/report.json",
+                "kind": "worker-report",
+                "workerId": "alpha",
+                "finalPath": "reports/alpha.json"
+              }
+            ]
+          },
+          {
+            "workerId": "beta",
+            "status": "succeeded",
+            "required": true,
+            "resultRef": "fanout/workers/beta/result.json",
+            "artifactRefs": [
+              {
+                "path": "fanout/workers/beta/artifacts/report.json",
+                "kind": "worker-report",
+                "workerId": "beta",
+                "finalPath": "reports/beta.json"
+              }
+            ]
+          }
+        ],
+        "rawWorkerArtifactRefs": [
+          {
+            "path": "fanout/workers/alpha/artifacts/report.json",
+            "kind": "worker-report",
+            "workerId": "alpha",
+            "finalPath": "reports/alpha.json"
+          },
+          {
+            "path": "fanout/workers/beta/artifacts/report.json",
+            "kind": "worker-report",
+            "workerId": "beta",
+            "finalPath": "reports/beta.json"
+          }
+        ],
+        "finalArtifactRefs": [],
+        "conflicts": [
+          {
+            "type": "incompatible-schema",
+            "severity": "error",
+            "message": "Worker schemas differ."
+          }
+        ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add a runtime-core-authored generator for canonical fanout aggregation contract vectors
- replace the single hand-maintained fanout fixture with generated vectors covering success, duplicate final paths, failed workers, missing dependencies, and repair policy conflicts
- strengthen TS/browser and PHP parity checks to run every generated vector

## Verification
- npm run generate:fanout-aggregation-contract
- npm run test:fanout-aggregation-contract-parity
- npm run test:php-fanout-aggregation-contract
- php -l packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php
- php -l scripts/php-fanout-aggregation-contract-smoke.php
- git diff --check
- git diff --cached --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode subagent
- **Used for:** Fanout aggregation duplication cleanup, tests, and verification.