### PR TITLE
fix: expose canonical typed artifact DTOs

### DIFF
--- a/packages/cli/src/commands/agent-task-run.ts
+++ b/packages/cli/src/commands/agent-task-run.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { AGENT_TASK_RUN_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_SCHEMA, artifactResultEnvelope, buildAgentTaskRecipe, DEFAULT_WORDPRESS_VERSION, headlessAgentTaskRequestToRunInput, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeHeadlessAgentTaskRequest, normalizeHeadlessAgentTaskResult, normalizeTaskInput, parseCommandJson, parseCommandOptions, resolveEffectiveRuntimeToolPolicy, type AgentTaskRunInput, type AgentTaskRunResultSummary, type AgentTerminalResult, type ArtifactResultEnvelope, type HeadlessAgentTaskResult, type SandboxToolPolicySnapshot } from "@automattic/wp-codebox-core"
+import { AGENT_TASK_RUN_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_SCHEMA, artifactResultEnvelope, buildAgentTaskRecipe, DEFAULT_WORDPRESS_VERSION, headlessAgentTaskRequestToRunInput, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeArtifactResultTypedArtifacts, normalizeHeadlessAgentTaskRequest, normalizeHeadlessAgentTaskResult, normalizeTaskInput, parseCommandJson, parseCommandOptions, resolveEffectiveRuntimeToolPolicy, type AgentTaskRunInput, type AgentTaskRunResultSummary, type AgentTerminalResult, type ArtifactResultEnvelope, type HeadlessAgentTaskResult, type SandboxToolPolicySnapshot, type TypedArtifactDTO } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { runRecipeRunCommand } from "./recipe-run.js"
 
@@ -35,7 +35,7 @@ export interface AgentTaskRunOutput {
   completion_outcome: Record<string, unknown>
   component_contracts: Array<Record<string, unknown>>
   structured_artifacts: Array<Record<string, unknown>>
-  typed_artifacts: Array<Record<string, unknown>>
+  typed_artifacts: TypedArtifactDTO[]
   outputs: Record<string, unknown>
   artifact_result: ArtifactResultEnvelope
   run: Record<string, unknown>
@@ -198,16 +198,16 @@ export async function runAgentTask(input: AgentTaskRunInput, options: AgentTaskR
     const session = sandboxSession(input, run, artifacts, success ? "completed" : "failed")
     const structuredArtifacts = structuredArtifactRefs(agentTaskResult, workload.outputs)
     const outputs = stripUndefined({ ...workload.outputs })
-    const typedArtifacts = agentTaskRunTypedArtifacts(agentTaskResult, outputs, run)
+    const typedArtifacts = normalizeArtifactResultTypedArtifacts({ typed_artifacts: [...arrayRecords(agentTaskResult.typed_artifacts), ...arrayRecords(outputs.typed_artifacts)] })
     const evidence = evidenceRefs(run, artifacts, failureEvidence)
     const artifactResult = artifactResultEnvelope({
       operation: "agent-task-run",
       status: success ? "created" : "failed",
       artifactBundle: agentTaskRunResult.refs.artifact_bundles[0],
       artifactRefs: [...agentTaskRunResult.refs.artifact_bundles, ...agentTaskRunResult.artifacts],
+      typedArtifacts,
       result: {
         structured_artifacts: structuredArtifacts,
-        typed_artifacts: typedArtifacts,
         agent_reply: agentReply(agentResult, terminalResult, agentTaskRunResult),
         transcript_refs: agentTaskRunResult.refs.transcripts,
         evidence_refs: evidence,
@@ -625,36 +625,6 @@ function structuredArtifactRefs(agentTaskResult: Record<string, unknown>, worklo
   return dedupeRecords([...fromOutputs, ...fromWorkloadOutputs].filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry))))
 }
 
-export function typedArtifactRefs(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown> = {}): Array<Record<string, unknown>> {
-  const outputs = objectValue(agentTaskResult.outputs) || {}
-  const outputsResult = objectValue(outputs.result) || {}
-  const result = objectValue(agentTaskResult.result) || {}
-  const raw = objectValue(agentTaskResult.raw) || {}
-  const rawResult = objectValue(raw.result) || {}
-  const rawRuntimeResult = objectValue(objectValue(raw.agent_runtime)?.result) || {}
-  return dedupeRecords([
-    agentTaskResult.typed_artifacts,
-    outputs.typed_artifacts,
-    objectValue(outputsResult.outputs)?.typed_artifacts,
-    objectValue(outputsResult.engine_data)?.outputs && objectValue(objectValue(outputsResult.engine_data)?.outputs)?.typed_artifacts,
-    workloadOutputs.typed_artifacts,
-    result.typed_artifacts,
-    objectValue(result.outputs)?.typed_artifacts,
-    objectValue(result.engine_data)?.outputs && objectValue(objectValue(result.engine_data)?.outputs)?.typed_artifacts,
-    rawResult.typed_artifacts,
-    objectValue(rawResult.outputs)?.typed_artifacts,
-    objectValue(rawResult.engine_data)?.outputs && objectValue(objectValue(rawResult.engine_data)?.outputs)?.typed_artifacts,
-    rawRuntimeResult.typed_artifacts,
-    objectValue(rawRuntimeResult.outputs)?.typed_artifacts,
-    objectValue(rawRuntimeResult.engine_data)?.outputs && objectValue(objectValue(rawRuntimeResult.engine_data)?.outputs)?.typed_artifacts,
-  ].flatMap(typedArtifactList))
-}
-
-export function agentTaskRunTypedArtifacts(agentTaskResult: Record<string, unknown>, workloadOutputs: Record<string, unknown>, run: Record<string, unknown>): Array<Record<string, unknown>> {
-  const runtimeOutputs = objectValue(run.outputs) || {}
-  return typedArtifactRefs(agentTaskResult, stripUndefined({ ...runtimeOutputs, ...workloadOutputs }))
-}
-
 export function agentTaskResultFromRun(run: Record<string, unknown>, runRecord: Record<string, unknown> = {}, artifactsRecord: Record<string, unknown> = {}): Record<string, unknown> {
   return objectValue(run.agentTaskResult)
     || objectValue(run.agent_task_result)
@@ -663,34 +633,6 @@ export function agentTaskResultFromRun(run: Record<string, unknown>, runRecord: 
     || objectValue(artifactsRecord.agentTaskResult)
     || objectValue(artifactsRecord.agent_task_result)
     || {}
-}
-
-function typedArtifactList(value: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(value)) {
-    return value.filter((entry): entry is Record<string, unknown> => Boolean(objectValue(entry)))
-  }
-
-  const record = objectValue(value)
-  if (!record) {
-    return []
-  }
-
-  return Object.entries(record)
-    .map(([name, artifact]) => typedArtifactFromMapEntry(name, artifact))
-    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
-}
-
-function typedArtifactFromMapEntry(name: string, artifact: unknown): Record<string, unknown> | undefined {
-  const record = objectValue(artifact)
-  if (!record) {
-    return undefined
-  }
-
-  return stripUndefined({
-    ...record,
-    name: stringValue(record.name) || stringValue(record.output_key) || name,
-    artifact_schema: stringValue(record.artifact_schema) || stringValue(record.schema) || undefined,
-  })
 }
 
 function agentReply(agentResult: Record<string, unknown>, terminalResult: AgentTerminalResult | undefined, runResult: AgentTaskRunResultSummary): Record<string, unknown> | undefined {

--- a/packages/runtime-core/src/artifact-result-envelope.ts
+++ b/packages/runtime-core/src/artifact-result-envelope.ts
@@ -1,5 +1,6 @@
 import type { MaterializationArtifactRef, MaterializationDiagnostic } from "./materialization-contracts.js"
 import { buildArtifactDiagnostics, type ArtifactDiagnosticNormalizerOptions, type ArtifactDiagnostics } from "./artifact-diagnostics.js"
+import { normalizeTypedArtifactDTOs, type TypedArtifactDTO } from "./structured-artifacts.js"
 
 export const ARTIFACT_RESULT_ENVELOPE_SCHEMA = "wp-codebox/artifact-result-envelope/v1" as const
 
@@ -14,6 +15,7 @@ export interface ArtifactResultEnvelopeBase {
   artifactBundle?: MaterializationArtifactRef
   artifactRefs: MaterializationArtifactRef[]
   evidenceRefs: MaterializationArtifactRef[]
+  typed_artifacts: TypedArtifactDTO[]
   verification?: Record<string, unknown>
   result?: Record<string, unknown>
   diagnostics: MaterializationDiagnostic[]
@@ -51,6 +53,7 @@ export function artifactDiagnosticsResultEnvelope(input: {
   artifactBundle?: MaterializationArtifactRef
   artifactRefs?: MaterializationArtifactRef[]
   evidenceRefs?: MaterializationArtifactRef[]
+  typedArtifacts?: unknown
   verification?: Record<string, unknown>
   result?: Record<string, unknown>
   metadata?: Record<string, unknown>
@@ -64,6 +67,7 @@ export function artifactDiagnosticsResultEnvelope(input: {
     artifactBundle: input.artifactBundle,
     artifactRefs: input.artifactRefs,
     evidenceRefs: input.evidenceRefs,
+    typedArtifacts: input.typedArtifacts,
     verification: input.verification,
     result: stripUndefined({
       ...input.result,
@@ -82,6 +86,7 @@ export function artifactResultEnvelope(input: {
   artifactBundle?: MaterializationArtifactRef
   artifactRefs?: MaterializationArtifactRef[]
   evidenceRefs?: MaterializationArtifactRef[]
+  typedArtifacts?: unknown
   verification?: Record<string, unknown>
   result?: Record<string, unknown>
   diagnostics?: MaterializationDiagnostic[]
@@ -92,6 +97,7 @@ export function artifactResultEnvelope(input: {
   const status = input.status ?? (input.error ? "failed" : "created")
   const artifactRefs = normalizeArtifactRefs([...(input.artifactBundle ? [input.artifactBundle] : []), ...(input.artifactRefs ?? [])])
   const evidenceRefs = normalizeArtifactRefs(input.evidenceRefs ?? [])
+  const typedArtifacts = normalizeArtifactResultTypedArtifacts(input.typedArtifacts ?? input.result)
   const diagnostics = input.diagnostics ?? []
   const base = stripUndefined({
     schema: ARTIFACT_RESULT_ENVELOPE_SCHEMA,
@@ -101,8 +107,9 @@ export function artifactResultEnvelope(input: {
     artifactBundle: input.artifactBundle,
     artifactRefs,
     evidenceRefs,
+    typed_artifacts: typedArtifacts,
     verification: input.verification,
-    result: input.result,
+    result: resultWithoutTypedArtifacts(input.result),
     diagnostics,
     metadata: input.metadata,
   })
@@ -141,6 +148,7 @@ export function normalizeArtifactResultEnvelope(input: unknown, fallbackOperatio
       artifactBundle: materializationArtifactRef(record.artifactBundle),
       artifactRefs: Array.isArray(record.artifactRefs) ? record.artifactRefs.map(materializationArtifactRef).filter(isDefined) : [],
       evidenceRefs: Array.isArray(record.evidenceRefs) ? record.evidenceRefs.map(materializationArtifactRef).filter(isDefined) : [],
+      typedArtifacts: record.typed_artifacts,
       verification: asRecord(record.verification),
       result: asRecord(record.result),
       diagnostics: Array.isArray(record.diagnostics) ? record.diagnostics.map(materializationDiagnostic).filter(isDefined) : [],
@@ -157,10 +165,28 @@ export function normalizeArtifactResultEnvelope(input: unknown, fallbackOperatio
     artifactBundle: materializationArtifactRef(result.artifactBundle ?? result.artifact_bundle ?? result.artifact_ref),
     artifactRefs: Array.isArray(result.artifactRefs) ? result.artifactRefs.map(materializationArtifactRef).filter(isDefined) : [],
     evidenceRefs: Array.isArray(result.evidenceRefs) ? result.evidenceRefs.map(materializationArtifactRef).filter(isDefined) : [],
+    typedArtifacts: result.typed_artifacts,
     verification: asRecord(result.verification),
     result,
     error: result.success === false ? errorObject(result.error) ?? "Artifact operation failed." : undefined,
   })
+}
+
+function resultWithoutTypedArtifacts(result: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!result || !("typed_artifacts" in result)) return result
+  const { typed_artifacts, ...rest } = result
+  void typed_artifacts
+  return rest
+}
+
+export function normalizeArtifactResultTypedArtifacts(input: unknown): TypedArtifactDTO[] {
+  const record = asRecord(input)
+  const source = Array.isArray(input)
+    ? input
+    : Array.isArray(record?.typed_artifacts)
+      ? record.typed_artifacts
+      : []
+  return normalizeTypedArtifactDTOs(source)
 }
 
 function normalizeArtifactRefs(refs: MaterializationArtifactRef[]): MaterializationArtifactRef[] {

--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -14,7 +14,7 @@ import { RUNTIME_PACKAGE_DIAGNOSTIC_SCHEMA, RUNTIME_PACKAGE_RESULT_SCHEMA, RUNTI
 import { CODEBOX_RUN_RUNTIME_PACKAGE_ABILITY, RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA, RUNTIME_PACKAGE_EXECUTION_INPUT_SCHEMA, RUNTIME_PACKAGE_EXECUTION_RESULT_SCHEMA, RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA } from "./runtime-package-execution.js"
 import { WORDPRESS_REST_MATRIX_RESULT_SCHEMA, WORDPRESS_REST_MATRIX_SCHEMA } from "./rest-matrix-contracts.js"
 import { BROWSER_CONTAINED_SITE_OPEN_SCHEMA, BROWSER_CONTAINED_SITE_STATUS_SCHEMA, BROWSER_PREVIEW_BOOT_CONFIG_SCHEMA, BROWSER_SESSION_PRODUCT_DTO_SCHEMA, PREVIEW_LEASE_SCHEMA, PREVIEW_REVIEWER_ACCESS_SCHEMA, RUNTIME_ACCESS_SCHEMA, RUNTIME_PROFILE_SCHEMA, normalizePreviewReviewerAccess, normalizeRuntimeAccess, normalizeRuntimeProfile, type RuntimeAccess, type RuntimeProfile } from "./runtime-boundary-contracts.js"
-import { STRUCTURED_ARTIFACT_SCHEMA, TYPED_ARTIFACT_INDEX_SCHEMA, normalizeTypedArtifactDTO, normalizeTypedArtifactIndex, type TypedArtifactIndex, type TypedArtifactRef } from "./structured-artifacts.js"
+import { TYPED_ARTIFACT_INDEX_SCHEMA, TYPED_ARTIFACT_SCHEMA, normalizeTypedArtifactDTO, normalizeTypedArtifactIndex, type TypedArtifactDTO, type TypedArtifactIndex } from "./structured-artifacts.js"
 import {
   RUNNER_WORKSPACE_CAPTURE_REQUEST_SCHEMA,
   RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA,
@@ -112,7 +112,7 @@ export const RUNTIME_CONTRACT_SCHEMAS = {
   },
   artifact: {
     resultEnvelope: ARTIFACT_RESULT_ENVELOPE_SCHEMA,
-    typedArtifact: STRUCTURED_ARTIFACT_SCHEMA,
+    typedArtifact: TYPED_ARTIFACT_SCHEMA,
     typedArtifactIndex: TYPED_ARTIFACT_INDEX_SCHEMA,
     runtimePackageDeclaration: RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA,
     runtimePackageProjection: RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA,
@@ -285,6 +285,6 @@ export const RUNTIME_CONTRACT_NORMALIZERS = {
   runtimeProfile: (input: unknown) => RuntimeProfile
   runtimeAccess: (input: unknown) => RuntimeAccess
   previewReviewerAccess: typeof normalizePreviewReviewerAccess
-  typedArtifact: (input: unknown) => TypedArtifactRef | undefined
+  typedArtifact: (input: unknown) => TypedArtifactDTO | undefined
   typedArtifactIndex: (input: unknown) => TypedArtifactIndex
 }

--- a/packages/runtime-core/src/structured-artifacts.ts
+++ b/packages/runtime-core/src/structured-artifacts.ts
@@ -2,6 +2,7 @@ import { isPlainObject } from "./object-utils.js"
 import { artifactFileDigest, type ArtifactFileDigest } from "./artifact-manifest.js"
 
 export const STRUCTURED_ARTIFACT_SCHEMA = "wp-codebox/structured-artifact/v1" as const
+export const TYPED_ARTIFACT_SCHEMA = "wp-codebox/typed-artifact/v1" as const
 export const STRUCTURED_ARTIFACT_INDEX_SCHEMA = "wp-codebox/structured-artifacts-index/v1" as const
 export const TYPED_ARTIFACT_INDEX_SCHEMA = "wp-codebox/typed-artifacts-index/v1" as const
 
@@ -36,7 +37,7 @@ export interface StructuredArtifactIndex {
 }
 
 export interface TypedArtifactRef {
-  schema: typeof STRUCTURED_ARTIFACT_SCHEMA
+  schema: typeof TYPED_ARTIFACT_SCHEMA
   name: string
   type: string
   payload_schema?: string | Record<string, unknown>
@@ -54,6 +55,10 @@ export interface TypedArtifactRef {
   }
 }
 
+export interface TypedArtifactDTO extends Omit<TypedArtifactRef, "artifact"> {
+  artifact?: TypedArtifactRef["artifact"]
+}
+
 export interface TypedArtifactIndex {
   schema: typeof TYPED_ARTIFACT_INDEX_SCHEMA
   direction: "output"
@@ -67,7 +72,8 @@ export interface NormalizeTypedArtifactDTODefaults {
   contentType?: string
 }
 
-export interface MaterializedStructuredArtifactRef extends Omit<StructuredArtifactPayload, "payload"> {
+export interface MaterializedStructuredArtifactRef extends Omit<StructuredArtifactPayload, "schema" | "payload"> {
+  schema: typeof STRUCTURED_ARTIFACT_SCHEMA | typeof TYPED_ARTIFACT_SCHEMA
   payload?: unknown
   artifact?: {
     path: string
@@ -114,8 +120,10 @@ export function materializeStructuredArtifactFiles<TArtifact extends StructuredA
     const extension = input.extension ? input.extension(contentType, artifact, index) : structuredArtifactExtension(contentType)
     const path = `${artifactPathPrefix}/${safeStructuredArtifactName(artifact.name)}-${index + 1}${extension}`
     const sha256 = artifactFileDigest(contents)
+    const schema = input.artifactKind === "typed-artifact" ? TYPED_ARTIFACT_SCHEMA : artifact.schema
     const ref: MaterializedStructuredArtifactRef = stripUndefined({
       ...artifact,
+      schema,
       artifact: {
         path,
         kind: input.artifactKind,
@@ -173,27 +181,28 @@ export function normalizeStructuredArtifacts(value: unknown, direction: Structur
   })
 }
 
-export function normalizeTypedArtifactDTO(input: unknown, defaults: NormalizeTypedArtifactDTODefaults = {}): TypedArtifactRef | undefined {
+export function normalizeTypedArtifactDTO(input: unknown, defaults: NormalizeTypedArtifactDTODefaults = {}): TypedArtifactDTO | undefined {
   const entry = isPlainObject(input) ? input : undefined
   if (!entry) return undefined
 
   const name = stringValue(entry.name) || defaults.name || ""
-  const type = stringValue(entry.type) || stringValue(entry.kind) || defaults.type || ""
+  const type = stringValue(entry.type) || defaults.type || ""
   if (!name || !type) return undefined
 
-  const artifact = typedArtifactFile(entry.artifact ?? entry.file ?? entry.ref ?? entry, defaults)
-  if (!artifact) return undefined
+  const artifact = typedArtifactFile(entry.artifact, defaults)
+  const hasPayload = "payload" in entry
+  if (!artifact && !hasPayload) return undefined
 
   const provenance = isPlainObject(entry.provenance) ? entry.provenance : {}
   const source = stringValue(provenance.source) || stringValue(entry.source) || defaults.source || "runtime"
-  const payloadSchema = structuredPayloadSchema(entry.payload_schema ?? entry.payloadSchema ?? entry.artifact_schema ?? entry.artifactSchema)
+  const payloadSchema = structuredPayloadSchema(entry.payload_schema)
 
   return stripUndefined({
-    schema: STRUCTURED_ARTIFACT_SCHEMA,
+    schema: TYPED_ARTIFACT_SCHEMA,
     name,
     type,
     ...(payloadSchema !== undefined ? { payload_schema: payloadSchema } : {}),
-    ...("payload" in entry ? { payload: entry.payload } : {}),
+    ...(hasPayload ? { payload: entry.payload } : {}),
     metadata: isPlainObject(entry.metadata) ? entry.metadata : {},
     provenance: {
       ...provenance,
@@ -201,10 +210,10 @@ export function normalizeTypedArtifactDTO(input: unknown, defaults: NormalizeTyp
       source,
     },
     artifact,
-  }) as TypedArtifactRef
+  }) as TypedArtifactDTO
 }
 
-export function normalizeTypedArtifactDTOs(input: unknown): TypedArtifactRef[] {
+export function normalizeTypedArtifactDTOs(input: unknown): TypedArtifactDTO[] {
   const artifacts = Array.isArray(input)
     ? input
     : isPlainObject(input) && Array.isArray(input.artifacts)
@@ -220,12 +229,9 @@ export function normalizeTypedArtifactIndex(input: unknown): TypedArtifactIndex 
   return {
     schema: TYPED_ARTIFACT_INDEX_SCHEMA,
     direction: "output",
-    artifacts: normalizeTypedArtifactDTOs(input),
+    artifacts: normalizeTypedArtifactDTOs(input).filter((artifact): artifact is TypedArtifactRef => Boolean(artifact.artifact)),
   }
 }
-
-export const normalizeTypedArtifactRef = normalizeTypedArtifactDTO
-export const normalizeTypedArtifactRefs = normalizeTypedArtifactDTOs
 
 function structuredPayloadSchema(value: unknown): string | Record<string, unknown> | undefined {
   if (typeof value === "string" && value.trim()) return value.trim()

--- a/scripts/typed-artifacts-smoke.ts
+++ b/scripts/typed-artifacts-smoke.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { Ajv2020 } from "ajv/dist/2020.js"
 import {
   STRUCTURED_ARTIFACT_SCHEMA,
+  TYPED_ARTIFACT_SCHEMA,
   TYPED_ARTIFACT_INDEX_SCHEMA,
   artifactFileDigest,
   calculateArtifactContentDigest,
@@ -74,7 +75,7 @@ async function writeTypedArtifactBundle(directory: string, options: { omitTypedA
     schema: TYPED_ARTIFACT_INDEX_SCHEMA,
     direction: "output",
     artifacts: [{
-      schema: STRUCTURED_ARTIFACT_SCHEMA,
+      schema: TYPED_ARTIFACT_SCHEMA,
       name: "summary",
       type: "example.summary",
       payload_schema: options.invalidPayloadForSchema ? { $id: "example/summary/v1", type: "object", required: ["ok"], properties: { ok: { type: "boolean" } } } : "example/summary/v1",

--- a/tests/agent-runtime-workload-normalizers.test.ts
+++ b/tests/agent-runtime-workload-normalizers.test.ts
@@ -67,7 +67,7 @@ const adaptedSingleResultShape = normalizeAgentRuntimeWorkload({
   schema: "example/runtime-package-result/v1",
   success: true,
   concept_packet: { title: "Generated concept" },
-  typed_artifacts: [{ name: "concept_packet", artifact_schema: "example/concept-packet/v1", payload: { title: "Generated concept" } }],
+  typed_artifacts: [{ name: "concept_packet", type: "example.concept-packet", payload_schema: "example/concept-packet/v1", payload: { title: "Generated concept" } }],
   structured_artifacts: [{ name: "concept_packet", schema: "example/concept-packet/v1", payload: { title: "Generated concept" } }],
 }, { normalizerAdapters: legacyAgentRuntimeWorkloadNormalizerAdapters })
 assert.equal(adaptedSingleResultShape.success, true)

--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -3,10 +3,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { chdir, cwd } from "node:process"
-import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_JSON_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_RESULT_JSON_SCHEMA, HEADLESS_AGENT_TASK_RESULT_SCHEMA, PREVIEW_LEASE_SCHEMA, buildAgentTaskRecipe, headlessAgentTaskRequestToRunInput, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeHeadlessAgentTaskRequest, normalizeHeadlessAgentTaskResult, normalizeRecipeRunSummary, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
+import { AGENT_TASK_RUN_REQUEST_SCHEMA, AGENT_TASK_RUN_RESULT_JSON_SCHEMA, AGENT_TASK_RUN_RESULT_SCHEMA, ARTIFACT_RESULT_ENVELOPE_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_JSON_SCHEMA, HEADLESS_AGENT_TASK_REQUEST_SCHEMA, HEADLESS_AGENT_TASK_RESULT_JSON_SCHEMA, HEADLESS_AGENT_TASK_RESULT_SCHEMA, PREVIEW_LEASE_SCHEMA, TYPED_ARTIFACT_SCHEMA, buildAgentTaskRecipe, headlessAgentTaskRequestToRunInput, normalizeAgentRuntimeWorkload, normalizeAgentTaskRunResult, normalizeAgentTerminalResult, normalizeArtifactResultTypedArtifacts, normalizeHeadlessAgentTaskRequest, normalizeHeadlessAgentTaskResult, normalizeRecipeRunSummary, normalizeTaskInput } from "../packages/runtime-core/src/index.js"
 import { effectivePolicyCommands } from "../packages/runtime-core/src/contracts.js"
 import { commandCatalogOutput } from "../packages/cli/src/commands/discovery.js"
-import { agentTaskResultFromRun, agentTaskRunExitCode, agentTaskRunJsonOutput, agentTaskRunTypedArtifacts, normalizeAgentTaskRunCliInput, typedArtifactRefs } from "../packages/cli/src/commands/agent-task-run.js"
+import { agentTaskResultFromRun, agentTaskRunExitCode, agentTaskRunJsonOutput, normalizeAgentTaskRunCliInput } from "../packages/cli/src/commands/agent-task-run.js"
 import { agentSandboxRunCode, resolveSandboxTaskCode } from "../packages/cli/src/agent-code.js"
 import { dryRunRecipe } from "../packages/cli/src/recipe-dry-run.js"
 import { recipePolicy } from "../packages/cli/src/recipe-validation.js"
@@ -237,77 +237,26 @@ const compatRuntimeWorkload = normalizeAgentRuntimeWorkload({ outputs: { answer:
 assert.deepEqual(compatRuntimeWorkload.outputs, { answer: "legacy" })
 assert.equal(compatRuntimeWorkload.diagnostics.some((diagnostic) => diagnostic.class === "wp-codebox.normalizer.compat_mode_used"), true)
 
-const typedArtifactMapRefs = typedArtifactRefs({}, {
-  typed_artifacts: {
-    concept_packet: {
-      output_key: "concept_packet",
-      schema: "wp-site-generator/ConceptPacket/v1",
-      artifact: "ConceptPacket",
-      payload: { title: "Repair Bench Supply" },
+const typedArtifactRefs = normalizeArtifactResultTypedArtifacts({
+  typed_artifacts: [{
+    schema: TYPED_ARTIFACT_SCHEMA,
+    name: "concept_packet",
+    type: "wp-site-generator.concept-packet",
+    payload_schema: "wp-site-generator/ConceptPacket/v1",
+    payload: { title: "Repair Bench Supply" },
+    artifact: {
+      path: "files/runtime-evidence/typed-artifacts/concept-packet-1.json",
+      kind: "typed-artifact",
+      contentType: "application/json",
+      sha256: "a".repeat(64),
     },
-  },
+  }],
 })
-assert.equal(typedArtifactMapRefs[0]?.name, "concept_packet")
-assert.equal(typedArtifactMapRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
-assert.deepEqual(typedArtifactMapRefs[0]?.payload, { title: "Repair Bench Supply" })
-
-const runtimeOutputsTypedArtifactRefs = agentTaskRunTypedArtifacts({}, {}, {
-  outputs: {
-    typed_artifacts: {
-      concept_packet: {
-        output_key: "concept_packet",
-        schema: "wp-site-generator/ConceptPacket/v1",
-        artifact: "ConceptPacket",
-        payload: { title: "Second Shift Supper Club" },
-      },
-    },
-  },
-})
-assert.equal(runtimeOutputsTypedArtifactRefs[0]?.name, "concept_packet")
-assert.equal(runtimeOutputsTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
-assert.deepEqual(runtimeOutputsTypedArtifactRefs[0]?.payload, { title: "Second Shift Supper Club" })
-
-const rawRuntimeTypedArtifactRefs = typedArtifactRefs({
-  raw: {
-    agent_runtime: {
-      result: {
-        outputs: {
-          typed_artifacts: {
-            concept_packet: {
-              output_key: "concept_packet",
-              schema: "wp-site-generator/ConceptPacket/v1",
-              artifact: "ConceptPacket",
-              payload: { title: "Kiln Shelf" },
-            },
-          },
-        },
-      },
-    },
-  },
-})
-assert.equal(rawRuntimeTypedArtifactRefs[0]?.name, "concept_packet")
-assert.equal(rawRuntimeTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
-assert.deepEqual(rawRuntimeTypedArtifactRefs[0]?.payload, { title: "Kiln Shelf" })
-
-const resultEngineDataTypedArtifactRefs = typedArtifactRefs({
-  result: {
-    engine_data: {
-      outputs: {
-        typed_artifacts: {
-          concept_packet: {
-            output_key: "concept_packet",
-            schema: "wp-site-generator/ConceptPacket/v1",
-            artifact: "ConceptPacket",
-            payload: { title: "Hearth Ledger" },
-          },
-        },
-      },
-    },
-  },
-})
-assert.equal(resultEngineDataTypedArtifactRefs[0]?.name, "concept_packet")
-assert.equal(resultEngineDataTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
-assert.deepEqual(resultEngineDataTypedArtifactRefs[0]?.payload, { title: "Hearth Ledger" })
+assert.equal(typedArtifactRefs[0]?.schema, TYPED_ARTIFACT_SCHEMA)
+assert.equal(typedArtifactRefs[0]?.name, "concept_packet")
+assert.equal(typedArtifactRefs[0]?.payload_schema, "wp-site-generator/ConceptPacket/v1")
+assert.deepEqual(typedArtifactRefs[0]?.payload, { title: "Repair Bench Supply" })
+assert.equal(typedArtifactRefs[0]?.artifact?.path, "files/runtime-evidence/typed-artifacts/concept-packet-1.json")
 
 const snakeCaseAgentTaskResult = agentTaskResultFromRun({
   agent_task_result: {
@@ -329,10 +278,7 @@ const snakeCaseAgentTaskResult = agentTaskResultFromRun({
     },
   },
 })
-const snakeCaseAgentTaskTypedArtifactRefs = typedArtifactRefs(snakeCaseAgentTaskResult)
-assert.equal(snakeCaseAgentTaskTypedArtifactRefs[0]?.name, "concept_packet")
-assert.equal(snakeCaseAgentTaskTypedArtifactRefs[0]?.artifact_schema, "wp-site-generator/ConceptPacket/v1")
-assert.deepEqual(snakeCaseAgentTaskTypedArtifactRefs[0]?.payload, { title: "The Repair Drawer" })
+assert.deepEqual(normalizeArtifactResultTypedArtifacts(snakeCaseAgentTaskResult), [])
 
 const normalizedWithArtifactEnvelope = normalizeAgentTaskRunResult({
   success: true,

--- a/tests/artifact-reference-dtos.test.ts
+++ b/tests/artifact-reference-dtos.test.ts
@@ -4,6 +4,7 @@ import {
   BROWSER_SESSION_PRODUCT_DTO_SCHEMA,
   PUBLIC_ARTIFACT_REF_DTO_SCHEMA,
   TYPED_ARTIFACT_INDEX_SCHEMA,
+  TYPED_ARTIFACT_SCHEMA,
   changedFilesArtifactRefs,
   findChangedFilesArtifactRef,
   findPatchArtifactRef,
@@ -92,18 +93,21 @@ assert.equal(session.artifact_refs.changed_files[0]?.path, "artifacts/browser-se
 assert.equal(session.artifact_refs.patches[0]?.path, "artifacts/browser-session-1/files/patch.diff")
 
 const typedArtifact = normalizeTypedArtifactDTO({
+  schema: TYPED_ARTIFACT_SCHEMA,
   name: "review-summary",
-  kind: "review",
-  payloadSchema: "example/review/v1",
+  type: "review",
+  payload_schema: "example/review/v1",
   payload: { status: "passed" },
   source: "runtime-command",
-  artifact_path: "files/typed/review-summary.json",
-  content_type: "application/json",
-  digest: { algorithm: "sha256", value: "d".repeat(64) },
+  artifact: {
+    path: "files/typed/review-summary.json",
+    contentType: "application/json",
+    sha256: "d".repeat(64),
+  },
   metadata: { scenario: "homepage" },
 })
 
-assert.equal(typedArtifact?.schema, "wp-codebox/structured-artifact/v1")
+assert.equal(typedArtifact?.schema, TYPED_ARTIFACT_SCHEMA)
 assert.equal(typedArtifact?.name, "review-summary")
 assert.equal(typedArtifact?.type, "review")
 assert.equal(typedArtifact?.payload_schema, "example/review/v1")

--- a/tests/artifact-result-envelope.test.ts
+++ b/tests/artifact-result-envelope.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, artifactResultEnvelope, normalizeArtifactResultEnvelope } from "../packages/runtime-core/src/index.js"
+import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, TYPED_ARTIFACT_SCHEMA, artifactResultEnvelope, normalizeArtifactResultEnvelope } from "../packages/runtime-core/src/index.js"
 
 const envelope = artifactResultEnvelope({
   operation: "agent-task-run",
@@ -7,8 +7,20 @@ const envelope = artifactResultEnvelope({
   artifactBundle: { kind: "artifact-bundle", path: "artifacts/run-1", digest: { algorithm: "sha256", value: "abc" } },
   artifactRefs: [{ kind: "codebox-patch", path: "files/patch.diff" }],
   evidenceRefs: [{ kind: "evidence-bundle", path: "files/evidence.json" }],
+  typedArtifacts: [{
+    schema: TYPED_ARTIFACT_SCHEMA,
+    name: "runtime-package-report",
+    type: "application/json",
+    payload_schema: "example/report/v1",
+    payload: { ok: true },
+    artifact: {
+      path: "files/runtime-evidence/typed-artifacts/runtime-package-report-1.json",
+      kind: "typed-artifact",
+      contentType: "application/json",
+      sha256: "a".repeat(64),
+    },
+  }],
   result: {
-    typed_artifacts: [{ name: "report", artifact_schema: "example/report/v1", payload: { ok: true } }],
     outputs: { answer: 42 },
   },
   diagnostics: [{ code: "wp-codebox.test", message: "test diagnostic", severity: "info" }],
@@ -20,8 +32,12 @@ assert.equal(envelope.success, true)
 assert.equal(envelope.artifactBundle?.path, "artifacts/run-1")
 assert.equal(envelope.artifactRefs.length, 2)
 assert.deepEqual(envelope.evidenceRefs, [{ kind: "evidence-bundle", path: "files/evidence.json" }])
+assert.equal(envelope.typed_artifacts[0]?.schema, TYPED_ARTIFACT_SCHEMA)
+assert.equal(envelope.typed_artifacts[0]?.name, "runtime-package-report")
+assert.equal(envelope.typed_artifacts[0]?.payload_schema, "example/report/v1")
+assert.deepEqual(envelope.typed_artifacts[0]?.payload, { ok: true })
+assert.equal(envelope.typed_artifacts[0]?.artifact?.path, "files/runtime-evidence/typed-artifacts/runtime-package-report-1.json")
 assert.deepEqual(envelope.result?.outputs, { answer: 42 })
-assert.equal(envelope.result?.typed_artifacts?.[0]?.name, "report")
 
 const normalized = normalizeArtifactResultEnvelope({
   schema: ARTIFACT_RESULT_ENVELOPE_SCHEMA,
@@ -30,12 +46,24 @@ const normalized = normalizeArtifactResultEnvelope({
   artifactBundle: { kind: "bundle", path: "artifacts/run-2" },
   artifactRefs: [{ kind: "log", path: "files/log.txt" }],
   evidenceRefs: [{ kind: "probe", path: "files/probe.json" }],
-  result: { ok: true },
+  typed_artifacts: [{
+    schema: TYPED_ARTIFACT_SCHEMA,
+    name: "runtime-package-inline",
+    type: "example.inline",
+    payload_schema: { type: "object" },
+    payload: { answer: 42 },
+    metadata: { runtime_package: "example/package" },
+    provenance: { source: "wp-codebox/run-runtime-package" },
+  }],
+  result: { ok: true, typed_artifacts: [{ name: "ignored", type: "example.ignored", payload: {} }] },
 })
 
 assert.equal(normalized.artifactBundle?.kind, "bundle")
 assert.equal(normalized.artifactRefs[0].path, "artifacts/run-2")
 assert.equal(normalized.evidenceRefs[0].path, "files/probe.json")
+assert.equal(normalized.typed_artifacts.length, 1)
+assert.equal(normalized.typed_artifacts[0]?.name, "runtime-package-inline")
+assert.deepEqual(normalized.typed_artifacts[0]?.payload, { answer: 42 })
 assert.deepEqual(normalized.result, { ok: true })
 assert.deepEqual(normalized.diagnostics, [])
 

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -57,6 +57,7 @@ import {
   RUNTIME_PROFILE_SCHEMA,
   RUNTIME_DESCRIPTOR_SCHEMA,
   RUNTIME_RUN_RESULT_SCHEMA,
+  TYPED_ARTIFACT_SCHEMA,
   WORDPRESS_REST_MATRIX_RESULT_SCHEMA,
   WORDPRESS_REST_MATRIX_SCHEMA,
   RUNNER_WORKSPACE_CAPTURE_RESULT_SCHEMA,
@@ -98,7 +99,7 @@ assert.equal(manifest.schemas.browserSession.containedSiteApplyResult, BROWSER_C
 assert.equal(manifest.schemas.preview.lease, PREVIEW_LEASE_SCHEMA)
 assert.equal(manifest.schemas.preview.reviewerAccess, "wp-codebox/preview-reviewer-access/v1")
 assert.equal(manifest.schemas.artifact.resultEnvelope, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
-assert.equal(manifest.schemas.artifact.typedArtifact, "wp-codebox/structured-artifact/v1")
+assert.equal(manifest.schemas.artifact.typedArtifact, TYPED_ARTIFACT_SCHEMA)
 assert.equal(manifest.schemas.artifact.typedArtifactIndex, "wp-codebox/typed-artifacts-index/v1")
 assert.equal(manifest.schemas.artifact.runtimePackageDeclaration, RUNTIME_PACKAGE_ARTIFACT_DECLARATION_SCHEMA)
 assert.equal(manifest.schemas.artifact.runtimePackageProjection, RUNTIME_PACKAGE_OUTPUT_PROJECTION_SCHEMA)
@@ -164,8 +165,8 @@ assert.equal(RUNTIME_CONTRACT_NORMALIZERS.agentTaskRunResult({ status: "complete
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.artifactResultEnvelope({ success: true, result: { artifact_ref: { kind: "bundle", path: "artifacts/run" } } }).schema, ARTIFACT_RESULT_ENVELOPE_SCHEMA)
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.runtimeProfile({ schema: RUNTIME_PROFILE_SCHEMA, components: [] }).schema, RUNTIME_PROFILE_SCHEMA)
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.previewReviewerAccess(undefined).status, "unavailable")
-assert.equal(RUNTIME_CONTRACT_NORMALIZERS.typedArtifact({ name: "report", type: "json", path: "files/report.json", sha256: "a".repeat(64) })?.artifact.kind, "typed-artifact")
-assert.equal(RUNTIME_CONTRACT_NORMALIZERS.typedArtifactIndex({ artifacts: [{ name: "report", type: "json", path: "files/report.json", sha256: "a".repeat(64) }] }).artifacts.length, 1)
+assert.equal(RUNTIME_CONTRACT_NORMALIZERS.typedArtifact({ name: "report", type: "json", artifact: { path: "files/report.json", sha256: "a".repeat(64) } })?.artifact?.kind, "typed-artifact")
+assert.equal(RUNTIME_CONTRACT_NORMALIZERS.typedArtifactIndex({ artifacts: [{ name: "report", type: "json", artifact: { path: "files/report.json", sha256: "a".repeat(64) } }] }).artifacts.length, 1)
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationInput({ plan: { workers: [] } }).schema, FANOUT_AGGREGATION_INPUT_SCHEMA)
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationOutput({ plan: { workers: [] } }).schema, FANOUT_AGGREGATION_OUTPUT_SCHEMA)
 assert.equal(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationOutputEnvelope(RUNTIME_CONTRACT_NORMALIZERS.fanoutAggregationOutput({ plan: { workers: [] } })).schema, FANOUT_AGGREGATION_OUTPUT_SCHEMA)

--- a/tests/structured-artifact-materializer.test.ts
+++ b/tests/structured-artifact-materializer.test.ts
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer"
 import {
   STRUCTURED_ARTIFACT_INDEX_SCHEMA,
   STRUCTURED_ARTIFACT_SCHEMA,
+  TYPED_ARTIFACT_SCHEMA,
   TYPED_ARTIFACT_INDEX_SCHEMA,
   materializeStructuredArtifactFiles,
   type StructuredArtifactPayload,
@@ -77,5 +78,6 @@ assert.deepEqual(typedMaterialized.refs[0].artifact, {
   contentType: "application/json",
   sha256: typedMaterialized.files[0].sha256.value,
 })
+assert.equal(typedMaterialized.refs[0].schema, TYPED_ARTIFACT_SCHEMA)
 
 console.log("structured artifact materializer passed")


### PR DESCRIPTION
## Summary
- add canonical `wp-codebox/typed-artifact/v1` DTOs to the public artifact-result envelope
- expose `artifactResultEnvelope.typed_artifacts` as the only typed-artifact projection surface
- remove legacy CLI typed-artifact scraping from nested runtime/result shapes
- update runtime contract manifest and tests for the canonical DTO

## Verification
- `npm run build`
- `npm run test:artifact-result-envelope`
- `npm run test:artifact-reference-dtos`
- `npm run test:runtime-contract-manifest`
- `npm run test:runtime-package-execution`
- `npm run test:agent-runtime-workload-normalizers`
- `npx tsx tests/structured-artifact-materializer.test.ts`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** identifying the missing typed-artifact primitive, drafting code/tests, running verification, and preparing this PR description.
