### PR TITLE
Make fanout aggregation contract canonical

### DIFF
--- a/packages/runtime-core/src/fanout-aggregation.ts
+++ b/packages/runtime-core/src/fanout-aggregation.ts
@@ -127,13 +127,8 @@ export interface FanoutAggregationOutput {
 export type FanoutAggregationInputRequest = Partial<Omit<FanoutAggregationInput, "schema" | "workerResultRefs" | "artifactRefs" | "conflictCandidates">> & {
   schema?: string
   workerResultRefs?: unknown[]
-  worker_results?: unknown[]
-  workerResults?: unknown[]
   artifactRefs?: unknown[]
-  artifact_refs?: unknown[]
   conflictCandidates?: unknown[]
-  conflict_candidates?: unknown[]
-  aggregation?: FanoutAggregatorConfig
 }
 
 export function fanoutAggregationInputFromWorkerArtifacts(options: FanoutAggregationInputFromWorkerArtifactsOptions): FanoutAggregationInput {
@@ -149,8 +144,8 @@ export function fanoutAggregationInputFromWorkerArtifacts(options: FanoutAggrega
 }
 
 export function normalizeFanoutAggregationInput(input: FanoutAggregationInputRequest): FanoutAggregationInput {
-  const workerResultRefs = (input.workerResultRefs ?? input.worker_results ?? input.workerResults ?? []).map(normalizeWorkerResultRef)
-  const inputArtifactRefs = (input.artifactRefs ?? input.artifact_refs ?? []).map((artifact) => normalizeArtifactRef(artifact))
+  const workerResultRefs = (input.workerResultRefs ?? []).map(normalizeWorkerResultRef)
+  const inputArtifactRefs = (input.artifactRefs ?? []).map((artifact) => normalizeArtifactRef(artifact))
   const artifactRefs = input.schema === FANOUT_AGGREGATION_INPUT_SCHEMA
     ? inputArtifactRefs
     : [...inputArtifactRefs, ...workerResultRefs.flatMap((worker) => worker.artifactRefs)]
@@ -159,10 +154,10 @@ export function normalizeFanoutAggregationInput(input: FanoutAggregationInputReq
     schema: FANOUT_AGGREGATION_INPUT_SCHEMA,
     plan: normalizePlan(input.plan),
     policy: input.policy ?? "fail",
-    aggregator: input.aggregator ?? input.aggregation,
+    aggregator: input.aggregator,
     workerResultRefs,
     artifactRefs,
-    conflictCandidates: (input.conflictCandidates ?? input.conflict_candidates ?? []).map(normalizeConflictRecord),
+    conflictCandidates: (input.conflictCandidates ?? []).map(normalizeConflictRecord),
     metadata: input.metadata,
   }
 }
@@ -339,28 +334,26 @@ function normalizePlan(plan: FanoutAggregationInputRequest["plan"]): FanoutPlan 
 
 function normalizeWorkerPlan(worker: unknown): FanoutWorkerPlan {
   const source = isRecord(worker) ? worker : {}
-  const dependsOn = source.dependsOn ?? source.depends_on
 
   return {
     ...source,
     id: isString(source.id) ? source.id : "",
-    dependsOn: Array.isArray(dependsOn) ? dependsOn.filter(isString) : [],
+    dependsOn: Array.isArray(source.dependsOn) ? source.dependsOn.filter(isString) : [],
     required: source.required !== false,
-    artifactNamespace: isString(source.artifactNamespace) ? source.artifactNamespace : isString(source.artifact_namespace) ? source.artifact_namespace : undefined,
+    artifactNamespace: isString(source.artifactNamespace) ? source.artifactNamespace : undefined,
     metadata: isRecord(source.metadata) ? source.metadata : undefined,
   }
 }
 
 function normalizeWorkerResultRef(workerResult: unknown): FanoutWorkerResultRef {
   const source = isRecord(workerResult) ? workerResult : {}
-  const artifactRefs = source.artifactRefs ?? source.artifact_refs
 
   return {
-    workerId: isString(source.workerId) ? source.workerId : isString(source.worker_id) ? source.worker_id : "",
+    workerId: isString(source.workerId) ? source.workerId : "",
     status: isString(source.status) ? normalizeAgentTaskStatus({ status: source.status, success: source.success }) : "missing",
     required: source.required !== false,
-    resultRef: isString(source.resultRef) ? source.resultRef : isString(source.result_ref) ? source.result_ref : undefined,
-    artifactRefs: Array.isArray(artifactRefs) ? artifactRefs.map((artifact) => normalizeArtifactRef(artifact, source.workerId ?? source.worker_id)) : [],
+    resultRef: isString(source.resultRef) ? source.resultRef : undefined,
+    artifactRefs: Array.isArray(source.artifactRefs) ? source.artifactRefs.map((artifact) => normalizeArtifactRef(artifact, source.workerId)) : [],
     error: normalizeError(source.error),
     metadata: isRecord(source.metadata) ? source.metadata : undefined,
   }
@@ -373,10 +366,10 @@ function normalizeArtifactRef(artifactRef: unknown, fallbackWorkerId?: unknown):
     id: isString(source.id) ? source.id : undefined,
     path: isString(source.path) ? source.path : "",
     kind: isString(source.kind) ? source.kind : undefined,
-    workerId: isString(source.workerId) ? source.workerId : isString(source.worker_id) ? source.worker_id : isString(fallbackWorkerId) ? fallbackWorkerId : undefined,
+    workerId: isString(source.workerId) ? source.workerId : isString(fallbackWorkerId) ? fallbackWorkerId : undefined,
     namespace: isString(source.namespace) ? source.namespace : undefined,
-    finalPath: isString(source.finalPath) ? source.finalPath : isString(source.final_path) ? source.final_path : undefined,
-    contentType: isString(source.contentType) ? source.contentType : isString(source.content_type) ? source.content_type : undefined,
+    finalPath: isString(source.finalPath) ? source.finalPath : undefined,
+    contentType: isString(source.contentType) ? source.contentType : undefined,
     sha256: isString(source.sha256) ? source.sha256 : undefined,
     bytes: typeof source.bytes === "number" ? source.bytes : undefined,
     metadata: isRecord(source.metadata) ? source.metadata : undefined,
@@ -385,17 +378,15 @@ function normalizeArtifactRef(artifactRef: unknown, fallbackWorkerId?: unknown):
 
 function normalizeConflictRecord(conflict: unknown): FanoutConflictRecord {
   const source = isRecord(conflict) ? conflict : {}
-  const artifactRefs = source.artifactRefs ?? source.artifact_refs
-  const workerIds = source.workerIds ?? source.worker_ids
 
   return {
     type: isString(source.type) ? source.type : "partial-output",
     severity: isString(source.severity) ? source.severity : "error",
     message: isString(source.message) ? source.message : "Fanout aggregation conflict candidate.",
-    workerIds: Array.isArray(workerIds) ? workerIds.filter(isString) : undefined,
+    workerIds: Array.isArray(source.workerIds) ? source.workerIds.filter(isString) : undefined,
     path: isString(source.path) ? source.path : undefined,
-    artifactRefs: Array.isArray(artifactRefs) ? artifactRefs.map((artifact) => normalizeArtifactRef(artifact)) : undefined,
-    dependencyId: isString(source.dependencyId) ? source.dependencyId : isString(source.dependency_id) ? source.dependency_id : undefined,
+    artifactRefs: Array.isArray(source.artifactRefs) ? source.artifactRefs.map((artifact) => normalizeArtifactRef(artifact)) : undefined,
+    dependencyId: isString(source.dependencyId) ? source.dependencyId : undefined,
     details: isRecord(source.details) ? source.details : undefined,
   }
 }

--- a/packages/wordpress-plugin/assets/browser-runtime.js
+++ b/packages/wordpress-plugin/assets/browser-runtime.js
@@ -2077,33 +2077,33 @@ try {
 	const normalizeFanoutWorkerPlan = ( worker ) => ( {
 		...( worker && typeof worker === 'object' ? worker : {} ),
 		id: typeof worker?.id === 'string' ? worker.id : '',
-		dependsOn: Array.isArray( worker?.dependsOn ) ? worker.dependsOn.filter( ( value ) => typeof value === 'string' && value.length > 0 ) : Array.isArray( worker?.depends_on ) ? worker.depends_on.filter( ( value ) => typeof value === 'string' && value.length > 0 ) : [],
+		dependsOn: Array.isArray( worker?.dependsOn ) ? worker.dependsOn.filter( ( value ) => typeof value === 'string' && value.length > 0 ) : [],
 		required: worker?.required !== false,
-		artifactNamespace: typeof worker?.artifactNamespace === 'string' ? worker.artifactNamespace : typeof worker?.artifact_namespace === 'string' ? worker.artifact_namespace : undefined,
+		artifactNamespace: typeof worker?.artifactNamespace === 'string' ? worker.artifactNamespace : undefined,
 	} );
 
 	const normalizeFanoutArtifactRef = ( artifact, fallbackWorkerId ) => ( {
 		id: typeof artifact?.id === 'string' ? artifact.id : undefined,
 		path: typeof artifact?.path === 'string' ? artifact.path : '',
 		kind: typeof artifact?.kind === 'string' ? artifact.kind : undefined,
-		workerId: typeof artifact?.workerId === 'string' ? artifact.workerId : typeof artifact?.worker_id === 'string' ? artifact.worker_id : typeof fallbackWorkerId === 'string' ? fallbackWorkerId : undefined,
+		workerId: typeof artifact?.workerId === 'string' ? artifact.workerId : typeof fallbackWorkerId === 'string' ? fallbackWorkerId : undefined,
 		namespace: typeof artifact?.namespace === 'string' ? artifact.namespace : undefined,
-		finalPath: typeof artifact?.finalPath === 'string' ? artifact.finalPath : typeof artifact?.final_path === 'string' ? artifact.final_path : undefined,
-		contentType: typeof artifact?.contentType === 'string' ? artifact.contentType : typeof artifact?.content_type === 'string' ? artifact.content_type : undefined,
+		finalPath: typeof artifact?.finalPath === 'string' ? artifact.finalPath : undefined,
+		contentType: typeof artifact?.contentType === 'string' ? artifact.contentType : undefined,
 		sha256: typeof artifact?.sha256 === 'string' ? artifact.sha256 : undefined,
 		bytes: typeof artifact?.bytes === 'number' ? artifact.bytes : undefined,
 		metadata: artifact?.metadata && typeof artifact.metadata === 'object' && ! Array.isArray( artifact.metadata ) ? artifact.metadata : undefined,
 	} );
 
 	const normalizeFanoutWorkerResultRef = ( worker ) => {
-		const artifactRefs = Array.isArray( worker?.artifactRefs ) ? worker.artifactRefs : Array.isArray( worker?.artifact_refs ) ? worker.artifact_refs : [];
-		const workerId = typeof worker?.workerId === 'string' ? worker.workerId : typeof worker?.worker_id === 'string' ? worker.worker_id : '';
+		const artifactRefs = Array.isArray( worker?.artifactRefs ) ? worker.artifactRefs : [];
+		const workerId = typeof worker?.workerId === 'string' ? worker.workerId : '';
 		const status = typeof worker?.status === 'string' && worker.status.length > 0 ? worker.status : 'missing';
 		return {
 			workerId,
 			status: status === 'completed' && worker?.success === true ? 'succeeded' : status,
 			required: worker?.required !== false,
-			resultRef: typeof worker?.resultRef === 'string' ? worker.resultRef : typeof worker?.result_ref === 'string' ? worker.result_ref : undefined,
+			resultRef: typeof worker?.resultRef === 'string' ? worker.resultRef : undefined,
 			artifactRefs: artifactRefs.map( ( artifact ) => normalizeFanoutArtifactRef( artifact, workerId ) ),
 			...( worker?.error && typeof worker.error === 'object' ? { error: worker.error } : {} ),
 			...( worker?.metadata && typeof worker.metadata === 'object' && ! Array.isArray( worker.metadata ) ? { metadata: worker.metadata } : {} ),
@@ -2114,16 +2114,16 @@ try {
 		type: typeof conflict?.type === 'string' ? conflict.type : 'partial-output',
 		severity: typeof conflict?.severity === 'string' ? conflict.severity : 'error',
 		message: typeof conflict?.message === 'string' ? conflict.message : 'Fanout aggregation conflict candidate.',
-		...( Array.isArray( conflict?.workerIds ) ? { workerIds: conflict.workerIds.filter( ( value ) => typeof value === 'string' && value.length > 0 ) } : Array.isArray( conflict?.worker_ids ) ? { workerIds: conflict.worker_ids.filter( ( value ) => typeof value === 'string' && value.length > 0 ) } : {} ),
+		...( Array.isArray( conflict?.workerIds ) ? { workerIds: conflict.workerIds.filter( ( value ) => typeof value === 'string' && value.length > 0 ) } : {} ),
 		...( typeof conflict?.path === 'string' ? { path: conflict.path } : {} ),
-		...( typeof conflict?.dependencyId === 'string' ? { dependencyId: conflict.dependencyId } : typeof conflict?.dependency_id === 'string' ? { dependencyId: conflict.dependency_id } : {} ),
+		...( typeof conflict?.dependencyId === 'string' ? { dependencyId: conflict.dependencyId } : {} ),
 		...( conflict?.details && typeof conflict.details === 'object' && ! Array.isArray( conflict.details ) ? { details: conflict.details } : {} ),
 	} );
 
 	const normalizeFanoutAggregationInput = ( input ) => {
 		const source = input && typeof input === 'object' ? input : {};
-		const workerResultRefs = ( Array.isArray( source.workerResultRefs ) ? source.workerResultRefs : Array.isArray( source.worker_results ) ? source.worker_results : Array.isArray( source.workerResults ) ? source.workerResults : [] ).map( normalizeFanoutWorkerResultRef );
-		const directArtifactRefs = ( Array.isArray( source.artifactRefs ) ? source.artifactRefs : Array.isArray( source.artifact_refs ) ? source.artifact_refs : [] ).map( ( artifact ) => normalizeFanoutArtifactRef( artifact ) );
+		const workerResultRefs = ( Array.isArray( source.workerResultRefs ) ? source.workerResultRefs : [] ).map( normalizeFanoutWorkerResultRef );
+		const directArtifactRefs = ( Array.isArray( source.artifactRefs ) ? source.artifactRefs : [] ).map( ( artifact ) => normalizeFanoutArtifactRef( artifact ) );
 		const artifactRefs = source.schema === fanoutAggregationInputSchema ? directArtifactRefs : [ ...directArtifactRefs, ...workerResultRefs.flatMap( ( worker ) => worker.artifactRefs ) ];
 		return {
 			schema: fanoutAggregationInputSchema,
@@ -2132,10 +2132,10 @@ try {
 				workers: ( Array.isArray( source.plan?.workers ) ? source.plan.workers : [] ).map( normalizeFanoutWorkerPlan ),
 			},
 			policy: typeof source.policy === 'string' ? source.policy : 'fail',
-			aggregator: source.aggregator && typeof source.aggregator === 'object' ? source.aggregator : source.aggregation && typeof source.aggregation === 'object' ? source.aggregation : undefined,
+			aggregator: source.aggregator && typeof source.aggregator === 'object' ? source.aggregator : undefined,
 			workerResultRefs,
 			artifactRefs,
-			conflictCandidates: ( Array.isArray( source.conflictCandidates ) ? source.conflictCandidates : Array.isArray( source.conflict_candidates ) ? source.conflict_candidates : [] ).map( normalizeFanoutConflict ),
+			conflictCandidates: ( Array.isArray( source.conflictCandidates ) ? source.conflictCandidates : [] ).map( normalizeFanoutConflict ),
 			...( source.metadata && typeof source.metadata === 'object' && ! Array.isArray( source.metadata ) ? { metadata: source.metadata } : {} ),
 		};
 	};
@@ -3019,24 +3019,24 @@ echo wp_json_encode( array(
 				plan: {
 					id: 'contract-fanout',
 					workers: [
-						{ id: 'worker-a', artifact_namespace: 'fanout/workers/worker-a' },
-						{ id: 'worker-b', depends_on: [ 'worker-a' ], artifact_namespace: 'fanout/workers/worker-b' },
+						{ id: 'worker-a', artifactNamespace: 'fanout/workers/worker-a' },
+						{ id: 'worker-b', dependsOn: [ 'worker-a' ], artifactNamespace: 'fanout/workers/worker-b' },
 					],
 				},
 				policy: 'fail',
-				aggregation: {
+				aggregator: {
 					outputNamespace: 'aggregate/final',
 				},
-				worker_results: [
+				workerResultRefs: [
 					{
-						worker_id: 'worker-a',
+						workerId: 'worker-a',
 						status: 'succeeded',
-						artifact_refs: [ { path: 'fanout/workers/worker-a/result.json', final_path: 'worker-a/result.json' } ],
+						artifactRefs: [ { path: 'fanout/workers/worker-a/result.json', finalPath: 'worker-a/result.json' } ],
 					},
 					{
-						worker_id: 'worker-b',
+						workerId: 'worker-b',
 						status: 'succeeded',
-						artifact_refs: [ { path: 'fanout/workers/worker-b/result.json', final_path: 'worker-b/result.json' } ],
+						artifactRefs: [ { path: 'fanout/workers/worker-b/result.json', finalPath: 'worker-b/result.json' } ],
 					},
 				],
 			}, { name: 'codebox-contract-fanout-aggregation' } );
@@ -3048,8 +3048,8 @@ echo wp_json_encode( array(
 			return {
 				schema: result.data.schema,
 				status: result.data.status,
-				final_path: result.data.finalArtifactRefs?.[ 0 ]?.path || '',
-				worker_results: result.data.workerResultRefs?.length || 0,
+				finalPath: result.data.finalArtifactRefs?.[ 0 ]?.path || '',
+				workerResults: result.data.workerResultRefs?.length || 0,
 			};
 		} );
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -448,12 +448,12 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 
 		return array_map(
 			fn( array $run ): array => array(
-				'worker_id'     => (string) ( $run['worker_id'] ?? '' ),
+				'workerId'      => (string) ( $run['worker_id'] ?? '' ),
 				'status'        => (string) ( $run['status'] ?? '' ),
 				'success'       => true === ( $run['success'] ?? false ),
 				'required'      => $required_by_id[ (string) ( $run['worker_id'] ?? '' ) ] ?? true,
-				'result_ref'    => 'fanout/workers/' . (string) ( $run['worker_id'] ?? '' ) . '/result.json',
-				'artifact_refs' => $this->fanout_worker_artifact_refs( $run ),
+				'resultRef'     => 'fanout/workers/' . (string) ( $run['worker_id'] ?? '' ) . '/result.json',
+				'artifactRefs'  => $this->fanout_worker_artifact_refs( $run ),
 				'error'         => is_array( $run['error'] ?? null ) ? $run['error'] : null,
 			),
 			$runs

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-task-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-task-ability-descriptors.php
@@ -164,7 +164,6 @@ final class WP_Codebox_Agent_Task_Ability_Descriptors {
 								'task'            => array( 'type' => 'string' ),
 								'agent'           => array( 'type' => 'string' ),
 								'dependsOn'       => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
-								'depends_on'      => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
 								'timeout_seconds' => array( 'type' => 'integer' ),
 							) + $context['task_input_alias_properties'],
 						),

--- a/packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php
@@ -76,8 +76,8 @@ final class WP_Codebox_Fanout_Aggregation {
 
 	/** @param array<string,mixed> $input Aggregation input. @return array<string,mixed> */
 	public function normalize_input( array $input ): array {
-		$worker_results      = $this->normalize_worker_result_refs( $input['workerResultRefs'] ?? $input['worker_results'] ?? $input['workerResults'] ?? array() );
-		$input_artifact_refs = $this->normalize_artifact_refs( $input['artifactRefs'] ?? $input['artifact_refs'] ?? array() );
+		$worker_results      = $this->normalize_worker_result_refs( $input['workerResultRefs'] ?? array() );
+		$input_artifact_refs = $this->normalize_artifact_refs( $input['artifactRefs'] ?? array() );
 		$artifact_refs       = self::INPUT_SCHEMA === (string) ( $input['schema'] ?? '' ) ? $input_artifact_refs : array_merge( $input_artifact_refs, ...array_map( static fn( array $worker ): array => $worker['artifactRefs'] ?? array(), $worker_results ) );
 
 		return array_filter(
@@ -85,10 +85,10 @@ final class WP_Codebox_Fanout_Aggregation {
 				'schema'             => self::INPUT_SCHEMA,
 				'plan'               => $this->normalize_plan( is_array( $input['plan'] ?? null ) ? $input['plan'] : array() ),
 				'policy'             => (string) ( $input['policy'] ?? 'fail' ),
-				'aggregator'         => is_array( $input['aggregator'] ?? null ) ? $input['aggregator'] : ( is_array( $input['aggregation'] ?? null ) ? $input['aggregation'] : null ),
+				'aggregator'         => is_array( $input['aggregator'] ?? null ) ? $input['aggregator'] : null,
 				'workerResultRefs'   => $worker_results,
 				'artifactRefs'       => $artifact_refs,
-				'conflictCandidates' => $this->normalize_conflict_records( $input['conflictCandidates'] ?? $input['conflict_candidates'] ?? array() ),
+				'conflictCandidates' => $this->normalize_conflict_records( $input['conflictCandidates'] ?? array() ),
 				'metadata'           => is_array( $input['metadata'] ?? null ) ? $input['metadata'] : null,
 			),
 			static fn( mixed $value ): bool => null !== $value
@@ -143,11 +143,10 @@ final class WP_Codebox_Fanout_Aggregation {
 
 	/** @param array<string,mixed> $worker Worker plan. @return array<string,mixed> */
 	private function normalize_worker_plan( array $worker ): array {
-		$depends_on = $worker['dependsOn'] ?? $worker['depends_on'] ?? array();
 		$worker['id'] = is_string( $worker['id'] ?? null ) ? $worker['id'] : '';
-		$worker['dependsOn'] = is_array( $depends_on ) ? array_values( array_filter( $depends_on, 'is_string' ) ) : array();
+		$worker['dependsOn'] = is_array( $worker['dependsOn'] ?? null ) ? array_values( array_filter( $worker['dependsOn'], 'is_string' ) ) : array();
 		$worker['required'] = false !== ( $worker['required'] ?? true );
-		$worker['artifactNamespace'] = is_string( $worker['artifactNamespace'] ?? null ) ? $worker['artifactNamespace'] : ( is_string( $worker['artifact_namespace'] ?? null ) ? $worker['artifact_namespace'] : null );
+		$worker['artifactNamespace'] = is_string( $worker['artifactNamespace'] ?? null ) ? $worker['artifactNamespace'] : null;
 		$worker['metadata'] = is_array( $worker['metadata'] ?? null ) ? $worker['metadata'] : null;
 
 		return array_filter( $worker, static fn( mixed $value ): bool => null !== $value );
@@ -164,16 +163,15 @@ final class WP_Codebox_Fanout_Aggregation {
 
 	/** @param array<string,mixed> $worker Worker result. @return array<string,mixed> */
 	private function normalize_worker_result_ref( array $worker ): array {
-		$worker_id = is_string( $worker['workerId'] ?? null ) && '' !== $worker['workerId'] ? $worker['workerId'] : ( is_string( $worker['worker_id'] ?? null ) ? $worker['worker_id'] : '' );
-		$artifacts = $worker['artifactRefs'] ?? $worker['artifact_refs'] ?? array();
+		$worker_id = is_string( $worker['workerId'] ?? null ) && '' !== $worker['workerId'] ? $worker['workerId'] : '';
 
 		return array_filter(
 			array(
 				'workerId'     => $worker_id,
 				'status'       => WP_Codebox_Status_Taxonomy::agent_task_status( array( 'status' => $worker['status'] ?? '', 'success' => $worker['success'] ?? null ) ),
 				'required'     => false !== ( $worker['required'] ?? true ),
-				'resultRef'    => is_string( $worker['resultRef'] ?? null ) ? $worker['resultRef'] : ( is_string( $worker['result_ref'] ?? null ) ? $worker['result_ref'] : null ),
-				'artifactRefs' => $this->normalize_artifact_refs( $artifacts, $worker_id ),
+				'resultRef'    => is_string( $worker['resultRef'] ?? null ) ? $worker['resultRef'] : null,
+				'artifactRefs' => $this->normalize_artifact_refs( $worker['artifactRefs'] ?? array(), $worker_id ),
 				'error'        => $this->normalize_error( $worker['error'] ?? null ),
 				'metadata'     => is_array( $worker['metadata'] ?? null ) ? $worker['metadata'] : null,
 			),
@@ -197,10 +195,10 @@ final class WP_Codebox_Fanout_Aggregation {
 				'id'          => is_string( $artifact['id'] ?? null ) ? $artifact['id'] : null,
 				'path'        => is_string( $artifact['path'] ?? null ) ? $artifact['path'] : '',
 				'kind'        => is_string( $artifact['kind'] ?? null ) ? $artifact['kind'] : null,
-				'workerId'    => is_string( $artifact['workerId'] ?? null ) ? $artifact['workerId'] : ( is_string( $artifact['worker_id'] ?? null ) ? $artifact['worker_id'] : ( is_string( $fallback_worker_id ) ? $fallback_worker_id : null ) ),
+				'workerId'    => is_string( $artifact['workerId'] ?? null ) ? $artifact['workerId'] : ( is_string( $fallback_worker_id ) ? $fallback_worker_id : null ),
 				'namespace'   => is_string( $artifact['namespace'] ?? null ) ? $artifact['namespace'] : null,
-				'finalPath'   => is_string( $artifact['finalPath'] ?? null ) ? $artifact['finalPath'] : ( is_string( $artifact['final_path'] ?? null ) ? $artifact['final_path'] : null ),
-				'contentType' => is_string( $artifact['contentType'] ?? null ) ? $artifact['contentType'] : ( is_string( $artifact['content_type'] ?? null ) ? $artifact['content_type'] : null ),
+				'finalPath'   => is_string( $artifact['finalPath'] ?? null ) ? $artifact['finalPath'] : null,
+				'contentType' => is_string( $artifact['contentType'] ?? null ) ? $artifact['contentType'] : null,
 				'sha256'      => is_string( $artifact['sha256'] ?? null ) ? $artifact['sha256'] : null,
 				'bytes'       => is_int( $artifact['bytes'] ?? null ) || is_float( $artifact['bytes'] ?? null ) ? $artifact['bytes'] : null,
 				'metadata'    => is_array( $artifact['metadata'] ?? null ) ? $artifact['metadata'] : null,
@@ -220,18 +218,15 @@ final class WP_Codebox_Fanout_Aggregation {
 
 	/** @param array<string,mixed> $conflict Conflict record. @return array<string,mixed> */
 	private function normalize_conflict_record( array $conflict ): array {
-		$worker_ids = $conflict['workerIds'] ?? $conflict['worker_ids'] ?? null;
-		$artifacts  = $conflict['artifactRefs'] ?? $conflict['artifact_refs'] ?? null;
-
 		return array_filter(
 			array(
 				'type'         => is_string( $conflict['type'] ?? null ) ? $conflict['type'] : 'partial-output',
 				'severity'     => is_string( $conflict['severity'] ?? null ) ? $conflict['severity'] : 'error',
 				'message'      => is_string( $conflict['message'] ?? null ) ? $conflict['message'] : 'Fanout aggregation conflict candidate.',
-				'workerIds'    => is_array( $worker_ids ) ? array_values( array_filter( $worker_ids, 'is_string' ) ) : null,
+				'workerIds'    => is_array( $conflict['workerIds'] ?? null ) ? array_values( array_filter( $conflict['workerIds'], 'is_string' ) ) : null,
 				'path'         => is_string( $conflict['path'] ?? null ) ? $conflict['path'] : null,
-				'artifactRefs' => is_array( $artifacts ) ? $this->normalize_artifact_refs( $artifacts ) : null,
-				'dependencyId' => is_string( $conflict['dependencyId'] ?? null ) ? $conflict['dependencyId'] : ( is_string( $conflict['dependency_id'] ?? null ) ? $conflict['dependency_id'] : null ),
+				'artifactRefs' => is_array( $conflict['artifactRefs'] ?? null ) ? $this->normalize_artifact_refs( $conflict['artifactRefs'] ) : null,
+				'dependencyId' => is_string( $conflict['dependencyId'] ?? null ) ? $conflict['dependencyId'] : null,
 				'details'      => is_array( $conflict['details'] ?? null ) ? $conflict['details'] : null,
 			),
 			static fn( mixed $value ): bool => null !== $value

--- a/scripts/fanout-aggregation-contract-smoke.ts
+++ b/scripts/fanout-aggregation-contract-smoke.ts
@@ -11,28 +11,28 @@ const successfulInput = {
   plan: {
     id: "fanout-plan-1",
     workers: [
-      { id: "worker-a", artifact_namespace: "workers/worker-a" },
-      { id: "worker-b", depends_on: ["worker-a"], artifact_namespace: "workers/worker-b" },
+      { id: "worker-a", artifactNamespace: "workers/worker-a" },
+      { id: "worker-b", dependsOn: ["worker-a"], artifactNamespace: "workers/worker-b" },
     ],
   },
   policy: "fail" as const,
-  aggregation: {
+  aggregator: {
     agent: "generic-aggregator",
     outputNamespace: "aggregate/final",
   },
-  worker_results: [
+  workerResultRefs: [
     {
-      worker_id: "worker-a",
+      workerId: "worker-a",
       status: "succeeded",
-      artifact_refs: [
-        { path: "workers/worker-a/report.json", final_path: "reports/a.json", kind: "report" },
+      artifactRefs: [
+        { path: "workers/worker-a/report.json", finalPath: "reports/a.json", kind: "report" },
       ],
     },
     {
-      worker_id: "worker-b",
+      workerId: "worker-b",
       status: "succeeded",
-      artifact_refs: [
-        { path: "workers/worker-b/report.json", final_path: "reports/b.json", kind: "report" },
+      artifactRefs: [
+        { path: "workers/worker-b/report.json", finalPath: "reports/b.json", kind: "report" },
       ],
     },
   ],
@@ -53,15 +53,15 @@ assert.equal(success.rawWorkerArtifactRefs.length, 2)
 assert.deepEqual(success.finalArtifactRefs, [{ path: "aggregate/final/report.json", kind: "aggregate-report" }])
 assert.deepEqual(success.conflicts, [])
 
-const legacyWorkerStatuses = normalizeFanoutAggregationInput({
+const normalizedWorkerStatuses = normalizeFanoutAggregationInput({
   ...successfulInput,
-  worker_results: [
-    { worker_id: "worker-a", status: "completed", success: true, artifact_refs: [] },
-    { worker_id: "worker-b", status: "no_op", artifact_refs: [] },
+  workerResultRefs: [
+    { workerId: "worker-a", status: "completed", success: true, artifactRefs: [] },
+    { workerId: "worker-b", status: "no_op", artifactRefs: [] },
   ],
 })
-assert.equal(legacyWorkerStatuses.workerResultRefs[0].status, "succeeded")
-assert.equal(legacyWorkerStatuses.workerResultRefs[1].status, "no_op")
+assert.equal(normalizedWorkerStatuses.workerResultRefs[0].status, "succeeded")
+assert.equal(normalizedWorkerStatuses.workerResultRefs[1].status, "no_op")
 
 const deterministic = aggregateFanoutOutputs(successfulInput)
 assert.equal(defaultFanoutAggregationOutputPath(successfulInput), "aggregate/final/result.json")
@@ -73,16 +73,16 @@ assert.deepEqual(deterministic.finalArtifactRefs, [{
 
 const duplicatePath = aggregateFanoutOutputs({
   ...successfulInput,
-  worker_results: [
+  workerResultRefs: [
     {
-      worker_id: "worker-a",
+      workerId: "worker-a",
       status: "succeeded",
-      artifact_refs: [{ path: "workers/worker-a/index.html", final_path: "site/index.html" }],
+      artifactRefs: [{ path: "workers/worker-a/index.html", finalPath: "site/index.html" }],
     },
     {
-      worker_id: "worker-b",
+      workerId: "worker-b",
       status: "succeeded",
-      artifact_refs: [{ path: "workers/worker-b/index.html", final_path: "site/index.html" }],
+      artifactRefs: [{ path: "workers/worker-b/index.html", finalPath: "site/index.html" }],
     },
   ],
 })
@@ -96,17 +96,17 @@ assert.deepEqual(duplicatePath.conflicts[0].workerIds, ["worker-a", "worker-b"])
 const failedWorker = aggregateFanoutOutputs({
   ...successfulInput,
   policy: "caller-review-required",
-  worker_results: [
+  workerResultRefs: [
     {
-      worker_id: "worker-a",
+      workerId: "worker-a",
       status: "failed",
       error: { code: "worker-exit", message: "Worker exited with code 1." },
-      artifact_refs: [{ path: "workers/worker-a/error.log", kind: "log" }],
+      artifactRefs: [{ path: "workers/worker-a/error.log", kind: "log" }],
     },
     {
-      worker_id: "worker-b",
+      workerId: "worker-b",
       status: "succeeded",
-      artifact_refs: [{ path: "workers/worker-b/report.json", final_path: "reports/b.json" }],
+      artifactRefs: [{ path: "workers/worker-b/report.json", finalPath: "reports/b.json" }],
     },
   ],
 })
@@ -117,11 +117,11 @@ assert.ok(failedWorker.conflicts.some((conflict) => conflict.type === "failed-wo
 const missingDependency = aggregateFanoutOutputs({
   ...successfulInput,
   policy: "partial",
-  worker_results: [
+  workerResultRefs: [
     {
-      worker_id: "worker-b",
+      workerId: "worker-b",
       status: "succeeded",
-      artifact_refs: [{ path: "workers/worker-b/report.json", final_path: "reports/b.json" }],
+      artifactRefs: [{ path: "workers/worker-b/report.json", finalPath: "reports/b.json" }],
     },
   ],
 })
@@ -138,7 +138,7 @@ assert.ok(aggregationFailure.conflicts.some((conflict) => conflict.type === "agg
 const repairPolicy = aggregateFanoutOutputs({
   ...successfulInput,
   policy: "repair",
-  conflict_candidates: [{ type: "incompatible-schema", severity: "error", message: "Worker schemas differ." }],
+  conflictCandidates: [{ type: "incompatible-schema", severity: "error", message: "Worker schemas differ." }],
 })
 assert.equal(repairPolicy.status, "repair_required")
 

--- a/scripts/generate-fanout-aggregation-contract-fixture.ts
+++ b/scripts/generate-fanout-aggregation-contract-fixture.ts
@@ -8,31 +8,31 @@ const successfulInput = {
   plan: {
     id: "fanout-contract-fixture",
     workers: [
-      { id: "alpha", artifact_namespace: "workers/alpha" },
-      { id: "beta", depends_on: ["alpha"], artifact_namespace: "workers/beta" },
+      { id: "alpha", artifactNamespace: "workers/alpha" },
+      { id: "beta", dependsOn: ["alpha"], artifactNamespace: "workers/beta" },
     ],
   },
   policy: "fail",
-  aggregation: {
+  aggregator: {
     agent: "generic-aggregator",
     outputNamespace: "aggregate/final",
   },
-  worker_results: [
+  workerResultRefs: [
     {
-      worker_id: "alpha",
+      workerId: "alpha",
       status: "completed",
       success: true,
-      result_ref: "fanout/workers/alpha/result.json",
-      artifact_refs: [
-        { path: "fanout/workers/alpha/artifacts/report.json", final_path: "reports/alpha.json", kind: "worker-report" },
+      resultRef: "fanout/workers/alpha/result.json",
+      artifactRefs: [
+        { path: "fanout/workers/alpha/artifacts/report.json", finalPath: "reports/alpha.json", kind: "worker-report" },
       ],
     },
     {
-      worker_id: "beta",
+      workerId: "beta",
       status: "succeeded",
-      result_ref: "fanout/workers/beta/result.json",
-      artifact_refs: [
-        { path: "fanout/workers/beta/artifacts/report.json", final_path: "reports/beta.json", kind: "worker-report" },
+      resultRef: "fanout/workers/beta/result.json",
+      artifactRefs: [
+        { path: "fanout/workers/beta/artifacts/report.json", finalPath: "reports/beta.json", kind: "worker-report" },
       ],
     },
   ],
@@ -40,7 +40,7 @@ const successfulInput = {
 
 const vectors = [
   {
-    name: "success-with-legacy-status-and-default-output",
+    name: "success-with-normalized-status-and-default-output",
     input: successfulInput,
   },
   {
@@ -48,9 +48,9 @@ const vectors = [
     input: {
       ...successfulInput,
       policy: "partial",
-      worker_results: [
-        { worker_id: "alpha", status: "succeeded", artifact_refs: [{ path: "fanout/workers/alpha/index.html", final_path: "site/index.html" }] },
-        { worker_id: "beta", status: "succeeded", artifact_refs: [{ path: "fanout/workers/beta/index.html", final_path: "site/index.html" }] },
+      workerResultRefs: [
+        { workerId: "alpha", status: "succeeded", artifactRefs: [{ path: "fanout/workers/alpha/index.html", finalPath: "site/index.html" }] },
+        { workerId: "beta", status: "succeeded", artifactRefs: [{ path: "fanout/workers/beta/index.html", finalPath: "site/index.html" }] },
       ],
     },
   },
@@ -59,14 +59,14 @@ const vectors = [
     input: {
       ...successfulInput,
       policy: "caller-review-required",
-      worker_results: [
+      workerResultRefs: [
         {
-          worker_id: "alpha",
+          workerId: "alpha",
           status: "failed",
           error: { code: "worker-exit", message: "Worker exited with code 1." },
-          artifact_refs: [{ path: "fanout/workers/alpha/error.log", kind: "log" }],
+          artifactRefs: [{ path: "fanout/workers/alpha/error.log", kind: "log" }],
         },
-        { worker_id: "beta", status: "succeeded", artifact_refs: [{ path: "fanout/workers/beta/report.json", final_path: "reports/beta.json" }] },
+        { workerId: "beta", status: "succeeded", artifactRefs: [{ path: "fanout/workers/beta/report.json", finalPath: "reports/beta.json" }] },
       ],
     },
   },
@@ -75,8 +75,8 @@ const vectors = [
     input: {
       ...successfulInput,
       policy: "partial",
-      worker_results: [
-        { worker_id: "beta", status: "succeeded", artifact_refs: [{ path: "fanout/workers/beta/report.json", final_path: "reports/beta.json" }] },
+      workerResultRefs: [
+        { workerId: "beta", status: "succeeded", artifactRefs: [{ path: "fanout/workers/beta/report.json", finalPath: "reports/beta.json" }] },
       ],
     },
   },
@@ -85,7 +85,7 @@ const vectors = [
     input: {
       ...successfulInput,
       policy: "repair",
-      conflict_candidates: [{ type: "incompatible-schema", severity: "error", message: "Worker schemas differ." }],
+      conflictCandidates: [{ type: "incompatible-schema", severity: "error", message: "Worker schemas differ." }],
     },
   },
 ].map((vector) => ({

--- a/tests/agent-fanout-executor.test.ts
+++ b/tests/agent-fanout-executor.test.ts
@@ -46,7 +46,7 @@ await withTempDir("wp-codebox-agent-fanout-executor-", async (root) => {
   assert.equal(result.progress.status, "succeeded")
   assert.equal(result.progress.session_id, "fanout-test")
   assert.equal(result.progress.run_id, "fanout-test")
-  assert.deepEqual(result.progress.progress, { total: 2, active: 0, completed: 2, failed: 0, skipped: 0, cancelled: 0, timed_out: 0 })
+  assert.deepEqual(result.progress.progress, { current: 2, total: 2, active: 0, completed: 2, failed: 0, skipped: 0, cancelled: 0, timed_out: 0, percent: 100 })
 
   const events = (await readFile(join(root, "fanout", "events.jsonl"), "utf8")).trim().split("\n").map((line) => JSON.parse(line))
   const plan = JSON.parse(await readFile(join(root, "fanout", "plan.json"), "utf8"))
@@ -81,7 +81,7 @@ await withTempDir("wp-codebox-agent-fanout-executor-", async (root) => {
   assert.deepEqual(events.map((event) => [event.phase, event.timestamp, event.session_id, event.run_id]), events.map((event) => [event.event, "2026-01-02T03:04:05.000Z", "fanout-test", "fanout-test"]))
   assert.equal(events[0].normalized_progress.schema, "wp-codebox/live-progress-event/v1")
   assert.equal(events[0].normalized_progress.label, "Fanout started")
-  assert.deepEqual(events[0].normalized_progress.progress, { total: 2, active: 0, completed: 0, failed: 0, skipped: 0, cancelled: 0, timed_out: 0 })
+  assert.deepEqual(events[0].normalized_progress.progress, { current: 0, total: 2, active: 0, completed: 0, failed: 0, skipped: 0, cancelled: 0, timed_out: 0, percent: 0 })
   assert.equal(events.at(-1).normalized_progress.phase, "fanout.completed")
   assert.equal(events.at(-1).normalized_progress.status, "succeeded")
 })
@@ -97,7 +97,7 @@ await withTempDir("wp-codebox-agent-fanout-dag-", async (root) => {
       { id: "setup", goal: "Prepare shared context" },
       { id: "failing", goal: "Fail this branch" },
       { id: "after-setup", goal: "Run after setup", dependsOn: ["setup"] },
-      { id: "after-failing", goal: "Skip after failing", depends_on: ["failing"] },
+      { id: "after-failing", goal: "Skip after failing", dependsOn: ["failing"] },
       { id: "after-skipped", goal: "Skip after skipped", dependsOn: ["after-failing"] },
     ],
   }, {

--- a/tests/fanout-aggregation-contract-parity.test.ts
+++ b/tests/fanout-aggregation-contract-parity.test.ts
@@ -27,8 +27,8 @@ assert.throws(() => validateFanoutAggregationOutput({ ...runtimeOutput, rawWorke
 const normalizedFromArtifacts = plain(fanoutAggregationInputFromWorkerArtifacts({
   plan: fixture.vectors[0].input.plan,
   policy: fixture.vectors[0].input.policy,
-  aggregator: fixture.vectors[0].input.aggregation,
-  workerResultRefs: fixture.vectors[0].input.worker_results,
+  aggregator: fixture.vectors[0].input.aggregator,
+  workerResultRefs: fixture.vectors[0].input.workerResultRefs,
 }))
 assert.equal(normalizedFromArtifacts.schema, "wp-codebox/agent-fanout-aggregation-input/v1")
 assert.deepEqual(plain(aggregateFanoutOutputs(normalizedFromArtifacts)), fixture.vectors[0].expectedOutput, "worker artifact refs must normalize into the same aggregation output")

--- a/tests/fixtures/fanout-aggregation-contract.json
+++ b/tests/fixtures/fanout-aggregation-contract.json
@@ -3,51 +3,51 @@
   "source": "packages/runtime-core/src/fanout-aggregation.ts",
   "vectors": [
     {
-      "name": "success-with-legacy-status-and-default-output",
+      "name": "success-with-normalized-status-and-default-output",
       "input": {
         "plan": {
           "id": "fanout-contract-fixture",
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha"
+              "artifactNamespace": "workers/alpha"
             },
             {
               "id": "beta",
-              "depends_on": [
+              "dependsOn": [
                 "alpha"
               ],
-              "artifact_namespace": "workers/beta"
+              "artifactNamespace": "workers/beta"
             }
           ]
         },
         "policy": "fail",
-        "aggregation": {
+        "aggregator": {
           "agent": "generic-aggregator",
           "outputNamespace": "aggregate/final"
         },
-        "worker_results": [
+        "workerResultRefs": [
           {
-            "worker_id": "alpha",
+            "workerId": "alpha",
             "status": "completed",
             "success": true,
-            "result_ref": "fanout/workers/alpha/result.json",
-            "artifact_refs": [
+            "resultRef": "fanout/workers/alpha/result.json",
+            "artifactRefs": [
               {
                 "path": "fanout/workers/alpha/artifacts/report.json",
-                "final_path": "reports/alpha.json",
+                "finalPath": "reports/alpha.json",
                 "kind": "worker-report"
               }
             ]
           },
           {
-            "worker_id": "beta",
+            "workerId": "beta",
             "status": "succeeded",
-            "result_ref": "fanout/workers/beta/result.json",
-            "artifact_refs": [
+            "resultRef": "fanout/workers/beta/result.json",
+            "artifactRefs": [
               {
                 "path": "fanout/workers/beta/artifacts/report.json",
-                "final_path": "reports/beta.json",
+                "finalPath": "reports/beta.json",
                 "kind": "worker-report"
               }
             ]
@@ -63,22 +63,17 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha",
+              "artifactNamespace": "workers/alpha",
               "dependsOn": [],
-              "required": true,
-              "artifactNamespace": "workers/alpha"
+              "required": true
             },
             {
               "id": "beta",
-              "depends_on": [
-                "alpha"
-              ],
-              "artifact_namespace": "workers/beta",
               "dependsOn": [
                 "alpha"
               ],
-              "required": true,
-              "artifactNamespace": "workers/beta"
+              "artifactNamespace": "workers/beta",
+              "required": true
             }
           ]
         },
@@ -148,40 +143,40 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha"
+              "artifactNamespace": "workers/alpha"
             },
             {
               "id": "beta",
-              "depends_on": [
+              "dependsOn": [
                 "alpha"
               ],
-              "artifact_namespace": "workers/beta"
+              "artifactNamespace": "workers/beta"
             }
           ]
         },
         "policy": "partial",
-        "aggregation": {
+        "aggregator": {
           "agent": "generic-aggregator",
           "outputNamespace": "aggregate/final"
         },
-        "worker_results": [
+        "workerResultRefs": [
           {
-            "worker_id": "alpha",
+            "workerId": "alpha",
             "status": "succeeded",
-            "artifact_refs": [
+            "artifactRefs": [
               {
                 "path": "fanout/workers/alpha/index.html",
-                "final_path": "site/index.html"
+                "finalPath": "site/index.html"
               }
             ]
           },
           {
-            "worker_id": "beta",
+            "workerId": "beta",
             "status": "succeeded",
-            "artifact_refs": [
+            "artifactRefs": [
               {
                 "path": "fanout/workers/beta/index.html",
-                "final_path": "site/index.html"
+                "finalPath": "site/index.html"
               }
             ]
           }
@@ -196,22 +191,17 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha",
+              "artifactNamespace": "workers/alpha",
               "dependsOn": [],
-              "required": true,
-              "artifactNamespace": "workers/alpha"
+              "required": true
             },
             {
               "id": "beta",
-              "depends_on": [
-                "alpha"
-              ],
-              "artifact_namespace": "workers/beta",
               "dependsOn": [
                 "alpha"
               ],
-              "required": true,
-              "artifactNamespace": "workers/beta"
+              "artifactNamespace": "workers/beta",
+              "required": true
             }
           ]
         },
@@ -292,31 +282,31 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha"
+              "artifactNamespace": "workers/alpha"
             },
             {
               "id": "beta",
-              "depends_on": [
+              "dependsOn": [
                 "alpha"
               ],
-              "artifact_namespace": "workers/beta"
+              "artifactNamespace": "workers/beta"
             }
           ]
         },
         "policy": "caller-review-required",
-        "aggregation": {
+        "aggregator": {
           "agent": "generic-aggregator",
           "outputNamespace": "aggregate/final"
         },
-        "worker_results": [
+        "workerResultRefs": [
           {
-            "worker_id": "alpha",
+            "workerId": "alpha",
             "status": "failed",
             "error": {
               "code": "worker-exit",
               "message": "Worker exited with code 1."
             },
-            "artifact_refs": [
+            "artifactRefs": [
               {
                 "path": "fanout/workers/alpha/error.log",
                 "kind": "log"
@@ -324,12 +314,12 @@
             ]
           },
           {
-            "worker_id": "beta",
+            "workerId": "beta",
             "status": "succeeded",
-            "artifact_refs": [
+            "artifactRefs": [
               {
                 "path": "fanout/workers/beta/report.json",
-                "final_path": "reports/beta.json"
+                "finalPath": "reports/beta.json"
               }
             ]
           }
@@ -344,22 +334,17 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha",
+              "artifactNamespace": "workers/alpha",
               "dependsOn": [],
-              "required": true,
-              "artifactNamespace": "workers/alpha"
+              "required": true
             },
             {
               "id": "beta",
-              "depends_on": [
-                "alpha"
-              ],
-              "artifact_namespace": "workers/beta",
               "dependsOn": [
                 "alpha"
               ],
-              "required": true,
-              "artifactNamespace": "workers/beta"
+              "artifactNamespace": "workers/beta",
+              "required": true
             }
           ]
         },
@@ -460,30 +445,30 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha"
+              "artifactNamespace": "workers/alpha"
             },
             {
               "id": "beta",
-              "depends_on": [
+              "dependsOn": [
                 "alpha"
               ],
-              "artifact_namespace": "workers/beta"
+              "artifactNamespace": "workers/beta"
             }
           ]
         },
         "policy": "partial",
-        "aggregation": {
+        "aggregator": {
           "agent": "generic-aggregator",
           "outputNamespace": "aggregate/final"
         },
-        "worker_results": [
+        "workerResultRefs": [
           {
-            "worker_id": "beta",
+            "workerId": "beta",
             "status": "succeeded",
-            "artifact_refs": [
+            "artifactRefs": [
               {
                 "path": "fanout/workers/beta/report.json",
-                "final_path": "reports/beta.json"
+                "finalPath": "reports/beta.json"
               }
             ]
           }
@@ -498,22 +483,17 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha",
+              "artifactNamespace": "workers/alpha",
               "dependsOn": [],
-              "required": true,
-              "artifactNamespace": "workers/alpha"
+              "required": true
             },
             {
               "id": "beta",
-              "depends_on": [
-                "alpha"
-              ],
-              "artifact_namespace": "workers/beta",
               "dependsOn": [
                 "alpha"
               ],
-              "required": true,
-              "artifactNamespace": "workers/beta"
+              "artifactNamespace": "workers/beta",
+              "required": true
             }
           ]
         },
@@ -564,50 +544,50 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha"
+              "artifactNamespace": "workers/alpha"
             },
             {
               "id": "beta",
-              "depends_on": [
+              "dependsOn": [
                 "alpha"
               ],
-              "artifact_namespace": "workers/beta"
+              "artifactNamespace": "workers/beta"
             }
           ]
         },
         "policy": "repair",
-        "aggregation": {
+        "aggregator": {
           "agent": "generic-aggregator",
           "outputNamespace": "aggregate/final"
         },
-        "worker_results": [
+        "workerResultRefs": [
           {
-            "worker_id": "alpha",
+            "workerId": "alpha",
             "status": "completed",
             "success": true,
-            "result_ref": "fanout/workers/alpha/result.json",
-            "artifact_refs": [
+            "resultRef": "fanout/workers/alpha/result.json",
+            "artifactRefs": [
               {
                 "path": "fanout/workers/alpha/artifacts/report.json",
-                "final_path": "reports/alpha.json",
+                "finalPath": "reports/alpha.json",
                 "kind": "worker-report"
               }
             ]
           },
           {
-            "worker_id": "beta",
+            "workerId": "beta",
             "status": "succeeded",
-            "result_ref": "fanout/workers/beta/result.json",
-            "artifact_refs": [
+            "resultRef": "fanout/workers/beta/result.json",
+            "artifactRefs": [
               {
                 "path": "fanout/workers/beta/artifacts/report.json",
-                "final_path": "reports/beta.json",
+                "finalPath": "reports/beta.json",
                 "kind": "worker-report"
               }
             ]
           }
         ],
-        "conflict_candidates": [
+        "conflictCandidates": [
           {
             "type": "incompatible-schema",
             "severity": "error",
@@ -624,22 +604,17 @@
           "workers": [
             {
               "id": "alpha",
-              "artifact_namespace": "workers/alpha",
+              "artifactNamespace": "workers/alpha",
               "dependsOn": [],
-              "required": true,
-              "artifactNamespace": "workers/alpha"
+              "required": true
             },
             {
               "id": "beta",
-              "depends_on": [
-                "alpha"
-              ],
-              "artifact_namespace": "workers/beta",
               "dependsOn": [
                 "alpha"
               ],
-              "required": true,
-              "artifactNamespace": "workers/beta"
+              "artifactNamespace": "workers/beta",
+              "required": true
             }
           ]
         },


### PR DESCRIPTION
## Summary
- Remove legacy fanout aggregation alias handling from the runtime-core, PHP, and browser-runtime aggregation implementations.
- Regenerate fanout parity vectors with canonical `workerResultRefs`, `artifactRefs`, `dependsOn`, `artifactNamespace`, `finalPath`, `contentType`, and `aggregator` fields.
- Stop advertising `depends_on` in the fanout ability worker schema and migrate the PHP fanout consumer to pass canonical worker refs into the aggregation primitive.
- Align the fanout executor progress test with the normalized live-progress contract.

## Testing
- `npm run generate:fanout-aggregation-contract`
- `npm run test:fanout-aggregation-contract-parity`
- `npm run test:php-fanout-aggregation-contract`
- `npx tsx scripts/fanout-aggregation-contract-smoke.ts`
- `npm run test:fanout-execution`
- `npm run test:agent-fanout-executor`
- `npm run build`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-fanout-aggregation.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php`
- `php -l packages/wordpress-plugin/src/class-wp-codebox-agent-task-ability-descriptors.php`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Fanout aggregation contract cleanup, migration, tests, and verification.