### PR TITLE
Make fanout request aggregator canonical

### DIFF
--- a/packages/runtime-core/src/fanout-contracts.ts
+++ b/packages/runtime-core/src/fanout-contracts.ts
@@ -76,7 +76,7 @@ export interface FanoutRequestContract {
   concurrency?: number
   agent?: string
   orchestrator?: Record<string, unknown>
-  aggregation?: Record<string, unknown>
+  aggregator?: Record<string, unknown>
   [key: string]: unknown
 }
 

--- a/packages/runtime-core/src/fanout-execution.ts
+++ b/packages/runtime-core/src/fanout-execution.ts
@@ -8,7 +8,7 @@ export interface FanoutExecutionOptions<TWorker extends RunPlanWorkerContract = 
   sessionId?: string
   clock?: RunPlanClock
   aggregationPolicy?: FanoutAggregationPolicy
-  aggregation?: Record<string, unknown>
+  aggregator?: Record<string, unknown>
   finalArtifactRefs?: FanoutArtifactRef[]
   outputNamespace?: string
   onFanoutStarted?: (event: FanoutExecutionLifecycleSnapshot<TWorker>) => Promise<void> | void
@@ -109,11 +109,11 @@ export async function executeFanoutRequest<TWorker extends RunPlanWorkerContract
   const workerResultRefs = execution.workers.map((result, index) => fanoutWorkerResultRefWithDependencyRefs(result, workers[index], execution.workers, workers))
   await options.onAggregationStarted?.({ fanoutId, sessionId, concurrency, workers, plan, execution, workerResultRefs })
 
-  const aggregation = optionalObjectValue(request.aggregation) ?? options.aggregation
+  const aggregator = optionalObjectValue(request.aggregator) ?? options.aggregator
   const aggregationInput = fanoutAggregationInputFromWorkerArtifacts({
     plan: { id: fanoutId, workers: workers.map((worker) => ({ id: worker.id, dependsOn: worker.dependsOn, required: worker.required, artifactNamespace: worker.artifactNamespace })) },
-    policy: options.aggregationPolicy ?? (stringValue(aggregation?.policy) || "fail"),
-    aggregator: aggregation,
+    policy: options.aggregationPolicy ?? (stringValue(aggregator?.policy) || "fail"),
+    aggregator,
     workerResultRefs,
   })
   const aggregate = aggregateFanoutOutputs(aggregationInput, {

--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
@@ -193,8 +193,8 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 			$this->fanout_aggregation->input_from_worker_artifacts(
 				array(
 					'plan'             => $this->fanout_aggregation_plan( $parent_session_id, $workers ),
-					'policy'           => is_array( $input['aggregation'] ?? null ) && is_string( $input['aggregation']['policy'] ?? null ) ? $input['aggregation']['policy'] : 'fail',
-					'aggregator'       => is_array( $input['aggregation'] ?? null ) ? $input['aggregation'] : null,
+					'policy'           => is_array( $input['aggregator'] ?? null ) && is_string( $input['aggregator']['policy'] ?? null ) ? $input['aggregator']['policy'] : 'fail',
+					'aggregator'       => is_array( $input['aggregator'] ?? null ) ? $input['aggregator'] : null,
 					'workerResultRefs' => $this->fanout_worker_result_refs( $runs, $workers ),
 				)
 			),
@@ -526,7 +526,7 @@ final class WP_Codebox_Agent_Sandbox_Runner {
 		$this->ensure_directory( $worker_artifacts_path );
 
 		$input = array_merge( $parent, $worker );
-		unset( $input['workers'], $input['dependencies'], $input['aggregation'], $input['concurrency'], $input['_run_plan_descriptor'] );
+		unset( $input['workers'], $input['dependencies'], $input['aggregator'], $input['concurrency'], $input['_run_plan_descriptor'] );
 
 		$input['goal']               = (string) $worker['goal'];
 		$input['sandbox_session_id'] = $parent_session_id . ':' . (string) $worker['id'];

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -256,7 +256,7 @@ final class WP_Codebox_CLI_Command {
 	}
 
 	private function normalize_value( string $field, mixed $value ): mixed {
-		if ( in_array( $field, array( 'target', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'policy', 'context', 'inherit', 'orchestrator', 'parent_request', 'runtime_task', 'runtime_env', 'playground', 'browser_runner', 'runtime', 'blueprint', 'apply_target', 'aggregation', 'suite', 'package', 'requirements', 'runner_capabilities', 'metadata' ), true ) ) {
+		if ( in_array( $field, array( 'target', 'tool_bridge', 'parent_tool_bridge', 'sandbox_tool_policy', 'policy', 'context', 'inherit', 'orchestrator', 'parent_request', 'runtime_task', 'runtime_env', 'playground', 'browser_runner', 'runtime', 'blueprint', 'apply_target', 'aggregator', 'suite', 'package', 'requirements', 'runner_capabilities', 'metadata' ), true ) ) {
 			return $this->json_object( (string) $value, $field );
 		}
 

--- a/scripts/agent-fanout-execution-smoke.ts
+++ b/scripts/agent-fanout-execution-smoke.ts
@@ -13,7 +13,7 @@ const result = await executeAgentFanoutRequest({
   concurrency: 2,
   agent: "sandbox-worker",
   orchestrator: { request_id: "browser-task-123", product: "smoke" },
-  aggregation: { policy: "fail", outputNamespace: "aggregate/final" },
+  aggregator: { policy: "fail", outputNamespace: "aggregate/final" },
   workers: [
     { id: "design", goal: "Draft a design candidate.", artifactNamespace: "workers/design" },
     { id: "copy", goal: "Draft a copy candidate.", artifactNamespace: "workers/copy" },

--- a/tests/fanout-aggregation-contract-parity.test.ts
+++ b/tests/fanout-aggregation-contract-parity.test.ts
@@ -60,7 +60,7 @@ await withTempDir("wp-codebox-fanout-aggregation-parity-", async (artifactRoot) 
     schema: FANOUT_REQUEST_SCHEMA,
     concurrency: 2,
     orchestrator: { session_id: "fanout-contract-fixture" },
-    aggregation: fixture.vectors[0].input.aggregation,
+    aggregator: fixture.vectors[0].input.aggregator,
     workers: [
       { id: "alpha", goal: "Collect alpha result" },
       { id: "beta", goal: "Collect beta result", dependsOn: ["alpha"] },


### PR DESCRIPTION
## Summary
- rename fanout request/options config from aggregation to aggregator
- pass canonical aggregator config through runtime-core and PHP sandbox fanout execution
- update fanout parity/smoke coverage and CLI object-field parsing

## Verification
- npm run test:fanout-aggregation-contract-parity
- npm run test:php-fanout-aggregation-contract
- npm run test:fanout-execution
- npm run test:agent-fanout-executor
- npx tsx scripts/agent-fanout-execution-smoke.ts
- npm run build
- php -l packages/wordpress-plugin/src/class-wp-codebox-agent-sandbox-runner.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing fanout contract naming drift, applying the canonical rename, and running verification.