### PR TITLE
Align public artifact ref aliases

### DIFF
--- a/packages/runtime-core/src/artifact-references.ts
+++ b/packages/runtime-core/src/artifact-references.ts
@@ -35,6 +35,7 @@ export interface ArtifactReferenceDigestInput {
   sha256?: string | ArtifactReferenceDigestInput
   digest?: string | ArtifactReferenceDigestInput
   contentDigest?: string | ArtifactReferenceDigestInput
+  content_digest?: string | ArtifactReferenceDigestInput
 }
 
 export interface ArtifactReferenceFileInput {
@@ -148,6 +149,7 @@ export function normalizeArtifactDigest(input: string | ArtifactReferenceDigestI
   return normalizeArtifactDigest(input.sha256)
     ?? normalizeArtifactDigest(input.digest)
     ?? normalizeArtifactDigest(input.contentDigest)
+    ?? normalizeArtifactDigest(input.content_digest)
 }
 
 export function normalizeArtifactFileDigest(input: string | ArtifactReferenceDigestInput | undefined): ArtifactFileDigest | undefined {
@@ -162,6 +164,7 @@ export function normalizePublicArtifactRefDTO(input: unknown, defaults: Partial<
 
   const digest = normalizeArtifactDigest(record.digest as ArtifactReferenceDigestInput | string | undefined)
     ?? normalizeArtifactDigest(record.contentDigest as ArtifactReferenceDigestInput | string | undefined)
+    ?? normalizeArtifactDigest(record.content_digest as ArtifactReferenceDigestInput | string | undefined)
     ?? normalizeArtifactDigest(record.sha256 as ArtifactReferenceDigestInput | string | undefined)
     ?? defaults.digest
   const path = stringValue(record.path)
@@ -170,15 +173,16 @@ export function normalizePublicArtifactRefDTO(input: unknown, defaults: Partial<
     || stringValue(record.uri)
     || stringValue(record.directory)
     || stringValue(record.artifacts_path)
+    || stringValue(record.artifactsPath)
     || defaults.path
-  const kind = stringValue(record.kind) || defaults.kind || kindForArtifactPath(path) || "artifact"
+  const kind = stringValue(record.kind) || stringValue(record.artifact_type) || stringValue(record.role) || defaults.kind || kindForArtifactPath(path) || "artifact"
   const sha256 = stringValue(record.sha256) || digest?.value || defaults.sha256
   const metadata = asRecord(record.metadata)
 
   return stripUndefined({
     schema: PUBLIC_ARTIFACT_REF_DTO_SCHEMA,
     kind,
-    id: stringValue(record.id) || stringValue(record.artifact_id) || defaults.id,
+    id: stringValue(record.id) || stringValue(record.artifact_id) || stringValue(record.artifactId) || defaults.id,
     path,
     url: stringValue(record.url) || (stringValue(record.uri) && stringValue(record.uri) !== path ? stringValue(record.uri) : undefined) || defaults.url,
     contentType: normalizeArtifactContentType(record as ArtifactReferenceFileInput, defaults.contentType),

--- a/tests/artifact-reference-dtos.test.ts
+++ b/tests/artifact-reference-dtos.test.ts
@@ -30,6 +30,19 @@ assert.equal(ref?.path, "artifacts/run-1")
 assert.equal(ref?.sha256, "abc123")
 assert.deepEqual(ref?.digest, { algorithm: "sha256", value: "abc123" })
 
+const browserAliasRef = normalizePublicArtifactRefDTO({
+  artifact_type: "browser-screenshot",
+  artifactId: "screenshot-1",
+  artifactsPath: "files/browser/screenshot.png",
+  content_digest: "def456",
+})
+
+assert.equal(browserAliasRef?.kind, "browser-screenshot")
+assert.equal(browserAliasRef?.id, "screenshot-1")
+assert.equal(browserAliasRef?.path, "files/browser/screenshot.png")
+assert.equal(browserAliasRef?.sha256, "def456")
+assert.deepEqual(browserAliasRef?.digest, { algorithm: "sha256", value: "def456" })
+
 const runResult = {
   artifacts: {
     id: "bundle-1",


### PR DESCRIPTION
## Summary
- align public artifact reference DTO normalization with browser/materialization artifact aliases
- accept artifact_type/role, artifactId, artifactsPath, and content_digest in public artifact refs
- cover the browser-style alias shape in artifact reference DTO tests

## Verification
- npm run test:artifact-reference-dtos
- npm run test:browser-callback-materialization-contracts
- npm run test:browser-sdk-facade
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing artifact-reference normalization drift, applying the alias alignment, and running verification.