### PR TITLE
Align browser artifact projection refs

### DIFF
--- a/packages/runtime-core/src/materialization-contracts.ts
+++ b/packages/runtime-core/src/materialization-contracts.ts
@@ -97,6 +97,7 @@ export interface MaterializationResultEnvelopeExtraction {
 export interface BrowserArtifactProjectionInput {
   artifact?: Record<string, unknown> | null
   artifacts?: unknown
+  artifactRefs?: unknown
   artifact_bundle?: Record<string, unknown> | null
   artifactBundle?: Record<string, unknown> | null
   materialization?: Record<string, unknown> | null
@@ -273,7 +274,10 @@ export function browserArtifactPersistenceProjection(input: BrowserArtifactProje
     ? source.artifacts.filter(isRecord)
     : artifact ? [artifact] : []
   const materialization = asRecord(source.materialization) ?? undefined
-  const artifactRefs = browserArtifactProjectionRefs({ artifactBundle, artifacts, materialization })
+  const artifactRefs = [
+    ...normalizeMaterializationArtifactRefs(Array.isArray(source.artifactRefs) ? source.artifactRefs : []),
+    ...browserArtifactProjectionRefs({ artifactBundle, artifacts, materialization }),
+  ]
 
   return stripUndefined({
     schema: BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA,
@@ -407,7 +411,7 @@ function normalizeDigest(input: unknown): MaterializationArtifactRef["digest"] |
   }
   const value = stringValue(input.value)
   const algorithm = stringValue(input.algorithm) || "sha256"
-  return value ? { algorithm, value } : normalizeDigest(input.sha256) ?? normalizeDigest(input.digest) ?? normalizeDigest(input.contentDigest)
+  return value ? { algorithm, value } : normalizeDigest(input.sha256) ?? normalizeDigest(input.digest) ?? normalizeDigest(input.contentDigest) ?? normalizeDigest(input.content_digest)
 }
 
 function phaseDiagnostics(phase: MaterializationPhaseResult): MaterializationDiagnostic[] {

--- a/tests/browser-sdk-facade.test.ts
+++ b/tests/browser-sdk-facade.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 import vm from "node:vm"
 
+import { browserArtifactPersistenceProjection } from "../packages/runtime-core/src/index.js"
+
 const root = new URL("../", import.meta.url)
 const runtimeSource = await readFile(new URL("packages/wordpress-plugin/assets/browser-runtime.js", root), "utf8")
 
@@ -333,14 +335,20 @@ assert.equal(runtimeTaskResult.schema, "wp-codebox/runtime-task-result/v1")
 assert.deepEqual(plain(runtimeTaskCalls), [{ path: "/wp-codebox/v1/runtime-task", method: "POST", data: plain(runtimeTaskRequest) }])
 ;(sandbox.window as any).wp = previousWp
 
-assert.deepEqual(plain(api.v1.browserArtifactPersistenceRef({
+const persistenceProjectionInput = {
   schema: "wp-codebox/browser-artifact-persistence/ref/v1",
   artifactRefs: [
     { kind: "artifact-bundle", id: "artifact-bundle-sha256-abc", directory: "artifacts/run-1", contentDigest: { algorithm: "sha256", value: "abc" } },
+    { role: "browser-html", path: "files/browser/index.html", digest: { content_digest: "def" } },
   ],
-}).artifactRefs), [
+  artifact: { kind: "browser-html", path: "files/browser/index.html", sha256: "def" },
+}
+const expectedPersistenceArtifactRefs = [
   { kind: "artifact-bundle", id: "artifact-bundle-sha256-abc", path: "artifacts/run-1", digest: { algorithm: "sha256", value: "abc" } },
-])
+  { kind: "browser-html", path: "files/browser/index.html", digest: { algorithm: "sha256", value: "def" } },
+]
+assert.deepEqual(plain(api.v1.browserArtifactPersistenceRef(persistenceProjectionInput).artifactRefs), expectedPersistenceArtifactRefs)
+assert.deepEqual(plain(browserArtifactPersistenceProjection(persistenceProjectionInput).artifactRefs), expectedPersistenceArtifactRefs)
 
 const executableSession = {
   schema: "wp-codebox/browser-executable-session/v1",


### PR DESCRIPTION
## Summary
- preserve explicit artifactRefs when runtime-core builds browser artifact persistence projections
- align nested content_digest digest handling with the browser-runtime projection helper
- compare runtime-core projection output against the browser SDK facade for the same persistence input

## Verification
- npm run test:browser-sdk-facade
- npm run test:browser-callback-materialization-contracts
- npm run test:artifact-reference-dtos
- npm run build
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing browser/runtime artifact projection drift, applying the runtime-core parity fix, and running verification.