### PR TITLE
Add native runtime package executor

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agent-runtime-invoker.php
@@ -195,7 +195,10 @@ return $ability->execute( $input );
 }
 
 function wp_codebox_browser_runtime_prepare_input( array $payload, array $invocation, string $session_id, array $runtime_tool_declarations, array $ability_tools, array $allowed_tool_ids, array $sandbox_tool_ids ): array {
-$agent = sanitize_key( (string) ( $payload['agent'] ?? 'wp-codebox-sandbox' ) );
+$agent = sanitize_key( (string) ( $payload['agent'] ?? '' ) );
+if ( '' === $agent ) {
+	$agent = 'wp-codebox-sandbox';
+}
 $message = (string) ( $payload['message'] ?? ( $payload['task_input']['goal'] ?? '' ) );
 $artifact_environment = function_exists( 'wp_codebox_browser_artifact_environment' ) ? wp_codebox_browser_artifact_environment( $payload ) : array();
 $artifact_contract_schema = (string) ( $artifact_environment['contract']['schema'] ?? '' );

--- a/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php
@@ -36,6 +36,7 @@ final class WP_Codebox_Agents_API_Adapter {
 	private const RUNTIME_BUNDLE_IMPORT_FILTER = 'wp_agent_runtime_import_bundle';
 	private const RUNTIME_RESOLVED_TOOLS_FILTER = 'wp_agent_runtime_resolved_tools';
 	private const CHAT_RUNTIME_PRINCIPAL_PERMISSION_FILTER = 'agents_chat_runtime_principal_permission';
+	private const SANDBOX_AGENT = 'wp-codebox-sandbox';
 
 	private const RESPONSE_SCHEMAS = array(
 		self::CHAT                 => 'wp-codebox/agent-chat-result/v1',
@@ -130,7 +131,7 @@ final class WP_Codebox_Agents_API_Adapter {
 	}
 
 	public static function register_runtime_profiles(): void {
-		if ( ! function_exists( 'add_filter' ) || ! self::should_register_adapter() ) {
+		if ( ! function_exists( 'add_filter' ) ) {
 			return;
 		}
 
@@ -164,7 +165,29 @@ final class WP_Codebox_Agents_API_Adapter {
 				'public_label' => 'Codebox agent runtime',
 				'public_kind'  => 'runtime-profile',
 				'capabilities' => array( 'codebox.runtime-package' ),
-				'default'      => true,
+				'default'      => false,
+			)
+		);
+	}
+
+	public static function register_sandbox_agent(): void {
+		if ( ! function_exists( 'wp_register_agent' ) ) {
+			return;
+		}
+		if ( function_exists( 'wp_has_agent' ) && wp_has_agent( self::SANDBOX_AGENT ) ) {
+			return;
+		}
+
+		wp_register_agent(
+			self::SANDBOX_AGENT,
+			array(
+				'label'       => 'WP Codebox Sandbox',
+				'description' => 'Default runtime agent for executing WP Codebox tasks inside disposable sandbox environments.',
+				'meta'        => array(
+					'source_plugin'  => 'wp-codebox',
+					'source_type'    => 'plugin-default',
+					'source_package' => 'wp-codebox',
+				),
 			)
 		);
 	}
@@ -219,7 +242,11 @@ final class WP_Codebox_Agents_API_Adapter {
 			}
 		}
 
-		$agent = sanitize_key( (string) ( $payload['agent'] ?? $input['agent'] ?? 'wp-codebox-sandbox' ) );
+		$agent = sanitize_key( (string) ( $payload['agent'] ?? $input['agent'] ?? '' ) );
+		if ( '' === $agent ) {
+			$agent = self::SANDBOX_AGENT;
+		}
+		$input['agent'] = $agent;
 		$input['principal'] = array(
 			'acting_user_id'     => 0,
 			'effective_agent_id' => $agent,

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-ability-descriptors.php
@@ -86,13 +86,13 @@ final class WP_Codebox_Runtime_Ability_Descriptors {
 	public static function run_runtime_package( array $context ): array {
 		return array(
 			'label'               => 'Run Runtime Package',
-			'description'         => 'Run a runtime package through the WP Codebox public runtime boundary using the configured backend ability adapter.',
+			'description'         => 'Run a runtime package through the WP Codebox public runtime boundary using the configured runtime provider.',
 			'category'            => 'wp-codebox',
 			'input_schema'        => $context['runtime_package_task_schema'],
 			'output_schema'       => $context['runtime_package_result_schema'],
 			'execute_callback'    => array( WP_Codebox_Abilities::class, 'run_runtime_package' ),
 			'permission_callback' => array( WP_Codebox_Abilities::class, 'can_run_agent_task' ),
-			'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-runtime-package', 'backend_adapter' => 'agents-api-runtime-package' ),
+			'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-runtime-package', 'backend_adapter' => 'codebox-runtime-package' ),
 		);
 	}
 }

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-package-executor.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-package-executor.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Standalone WP Codebox runtime package executor.
+ *
+ * @package WPCodebox
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Executes runtime packages through the local WordPress ability surface.
+ */
+final class WP_Codebox_Runtime_Package_Executor {
+
+	private const PROVIDER_ID = 'codebox-runtime-package';
+
+	public static function register_runtime_provider(): void {
+		if ( ! class_exists( 'WP_Codebox_Runtime_Provider_Registry' ) ) {
+			return;
+		}
+
+		WP_Codebox_Runtime_Provider_Registry::register(
+			self::PROVIDER_ID,
+			array( new self(), 'run' ),
+			array(
+				'label'        => 'WP Codebox runtime package executor',
+				'kind'         => 'ability-executor',
+				'public_id'    => 'codebox-runtime-package',
+				'public_label' => 'WP Codebox runtime package executor',
+				'public_kind'  => 'runtime-profile',
+				'capabilities' => array( 'codebox.runtime-package' ),
+				'default'      => true,
+			)
+		);
+	}
+
+	/** @param array<string,mixed> $task Runtime package task. @return array<string,mixed>|WP_Error */
+	public function run( array $task ): array|WP_Error {
+		$imports = $this->import_package_bundle( $task );
+		if ( is_wp_error( $imports ) ) {
+			return $imports;
+		}
+
+		$result = $this->execute_workflow( $task );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return $this->result_with_artifact_validation( $result, $task, $imports );
+	}
+
+	/** @param array<string,mixed> $task Runtime package task. @return array<int,array<string,mixed>>|WP_Error */
+	private function import_package_bundle( array $task ): array|WP_Error {
+		$package = is_array( $task['package'] ?? null ) ? $task['package'] : array();
+		$source  = $this->string_value( $package['source'] ?? '' );
+		$slug    = $this->string_value( $package['slug'] ?? '' );
+		if ( '' === $source ) {
+			return new WP_Error( 'wp_codebox_runtime_package_source_missing', 'Runtime package execution requires package.source.', array( 'status' => 400 ) );
+		}
+
+		$bundle_spec = array_filter(
+			array(
+				'source'      => $source,
+				'slug'        => $slug,
+				'on_conflict' => 'upgrade',
+			),
+			static fn( mixed $value ): bool => '' !== $value
+		);
+
+		$imports = $this->import_runtime_bundles( array( $bundle_spec ) );
+		$failed  = array_values( array_filter( $imports, static fn( mixed $import ): bool => is_array( $import ) && empty( $import['success'] ) ) );
+		if ( ! empty( $failed ) ) {
+			return new WP_Error( 'wp_codebox_runtime_package_import_failed', 'Runtime package bundle import failed.', array( 'status' => 500, 'agent_bundle_imports' => $failed ) );
+		}
+
+		return $imports;
+	}
+
+	/** @param array<int,array<string,mixed>> $bundle_specs Runtime bundle specs. @return array<int,array<string,mixed>> */
+	private function import_runtime_bundles( array $bundle_specs ): array {
+		$function = function_exists( 'apply_filters' ) ? (string) apply_filters( 'wp_codebox_browser_runtime_bundle_import_function', 'wp_agent_import_runtime_bundles' ) : 'wp_agent_import_runtime_bundles';
+		if ( '' !== $function && ! function_exists( $function ) && class_exists( 'WP_Codebox_Agents_API_Adapter' ) ) {
+			foreach ( WP_Codebox_Agents_API_Adapter::runtime_bundle_importer_paths() as $path ) {
+				if ( is_readable( $path ) ) {
+					require_once $path;
+					break;
+				}
+			}
+		}
+		if ( '' !== $function && function_exists( $function ) ) {
+			$result = $function( $bundle_specs, array( 'owner_id' => $this->owner_id() ) );
+			return is_array( $result ) ? $result : array();
+		}
+
+		$imports = array();
+		foreach ( $bundle_specs as $index => $spec ) {
+			$input = array(
+				'source'      => (string) ( $spec['source'] ?? '' ),
+				'slug'        => (string) ( $spec['slug'] ?? '' ),
+				'on_conflict' => (string) ( $spec['on_conflict'] ?? 'upgrade' ),
+				'owner_id'    => $this->owner_id(),
+			);
+			$result = function_exists( 'apply_filters' ) ? apply_filters( 'wp_agent_runtime_import_bundle', null, $spec, array_filter( $input, static fn( mixed $value ): bool => '' !== $value ), $index ) : null;
+			$imports[] = is_wp_error( $result )
+				? array( 'success' => false, 'index' => $index, 'source' => (string) ( $spec['source'] ?? '' ), 'error' => array( 'code' => $result->get_error_code(), 'message' => $result->get_error_message(), 'data' => $result->get_error_data() ) )
+				: array_merge( array( 'success' => null !== $result, 'index' => $index, 'source' => (string) ( $spec['source'] ?? '' ) ), is_array( $result ) ? $result : array() );
+		}
+
+		return $imports;
+	}
+
+	/** @param array<string,mixed> $task Runtime package task. @return array<string,mixed>|WP_Error */
+	private function execute_workflow( array $task ): array|WP_Error {
+		$workflow         = is_array( $task['workflow'] ?? null ) ? $task['workflow'] : array();
+		$package_workflow = $this->load_package_workflow( $task, $workflow );
+		if ( is_wp_error( $package_workflow ) ) {
+			return $package_workflow;
+		}
+
+		$ability = $this->workflow_ability_name( $workflow );
+		$input   = $this->workflow_input( $task, $package_workflow );
+
+		if ( '' === $ability ) {
+			return new WP_Error( 'wp_codebox_runtime_package_workflow_missing', 'Runtime package workflow must resolve to a local ability.', array( 'status' => 400, 'workflow' => $workflow ) );
+		}
+		if ( 'wp-codebox/run-runtime-package' === $ability ) {
+			return new WP_Error( 'wp_codebox_runtime_package_recursive_workflow', 'Runtime package workflows cannot invoke wp-codebox/run-runtime-package recursively.', array( 'status' => 400, 'workflow' => $workflow ) );
+		}
+
+		$ability_object = function_exists( 'wp_get_ability' ) ? wp_get_ability( $ability ) : null;
+		if ( ! is_object( $ability_object ) || ! method_exists( $ability_object, 'execute' ) ) {
+			return new WP_Error( 'wp_codebox_runtime_package_workflow_unavailable', 'Runtime package workflow ability is unavailable.', array( 'status' => 500, 'ability' => $ability, 'workflow' => $workflow ) );
+		}
+
+		$result = $ability_object->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		if ( ! is_array( $result ) ) {
+			return new WP_Error( 'wp_codebox_runtime_package_workflow_invalid_result', 'Runtime package workflow returned an invalid result.', array( 'status' => 500, 'ability' => $ability ) );
+		}
+
+		$result['metadata'] = array_merge(
+			is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(),
+			array(
+				'workflow_ability' => $ability,
+				'workflow_id'      => (string) ( $package_workflow['flow']['slug'] ?? $workflow['id'] ?? '' ),
+				'pipeline_id'      => (string) ( $package_workflow['pipeline']['slug'] ?? $package_workflow['flow']['pipeline_slug'] ?? '' ),
+			)
+		);
+
+		return $result;
+	}
+
+	/** @param array<string,mixed> $task Runtime package task. @param array<string,mixed> $workflow Runtime workflow. @return array{manifest:array<string,mixed>,flow:array<string,mixed>,pipeline:array<string,mixed>}|WP_Error */
+	private function load_package_workflow( array $task, array $workflow ): array|WP_Error {
+		$package = is_array( $task['package'] ?? null ) ? $task['package'] : array();
+		$root    = $this->package_root( $package );
+		if ( '' === $root ) {
+			return new WP_Error( 'wp_codebox_runtime_package_root_missing', 'Runtime package source must be a readable directory or file.', array( 'status' => 400, 'package' => $package ) );
+		}
+
+		$manifest = $this->read_json_file( $root . '/manifest.json' );
+		if ( is_wp_error( $manifest ) ) {
+			return $manifest;
+		}
+
+		$workflow_id = $this->string_value( $workflow['id'] ?? $workflow['slug'] ?? $manifest['bundle_slug'] ?? $package['slug'] ?? '' );
+		if ( '' === $workflow_id ) {
+			return new WP_Error( 'wp_codebox_runtime_package_workflow_id_missing', 'Runtime package workflow.id is required.', array( 'status' => 400 ) );
+		}
+
+		$flow = $this->read_json_file( $root . '/flows/' . $this->safe_slug( $workflow_id ) . '.json' );
+		if ( is_wp_error( $flow ) ) {
+			return $flow;
+		}
+
+		$pipeline_slug = $this->string_value( $flow['pipeline_slug'] ?? $flow['pipeline'] ?? '' );
+		$pipeline      = array();
+		if ( '' !== $pipeline_slug ) {
+			$pipeline = $this->read_json_file( $root . '/pipelines/' . $this->safe_slug( $pipeline_slug ) . '.json' );
+			if ( is_wp_error( $pipeline ) ) {
+				return $pipeline;
+			}
+		}
+
+		return array(
+			'manifest' => $manifest,
+			'flow'     => $flow,
+			'pipeline' => $pipeline,
+		);
+	}
+
+	/** @param array<string,mixed> $workflow Runtime package workflow. */
+	private function workflow_ability_name( array $workflow ): string {
+		foreach ( array( 'ability', 'ability_name', 'name', 'id' ) as $field ) {
+			$value = $this->string_value( $workflow[ $field ] ?? '' );
+			if ( str_contains( $value, '/' ) ) {
+				return $value;
+			}
+		}
+
+		return function_exists( 'apply_filters' ) ? (string) apply_filters( 'wp_codebox_runtime_package_default_workflow_ability', 'agents/chat', $workflow ) : 'agents/chat';
+	}
+
+	/** @param array<string,mixed> $task Runtime package task. @param array{manifest:array<string,mixed>,flow:array<string,mixed>,pipeline:array<string,mixed>} $package_workflow Package workflow. @return array<string,mixed> */
+	private function workflow_input( array $task, array $package_workflow ): array {
+		$workflow       = is_array( $task['workflow'] ?? null ) ? $task['workflow'] : array();
+		$input          = is_array( $task['input'] ?? null ) ? $task['input'] : array();
+		$manifest       = $package_workflow['manifest'];
+		$agent_manifest = is_array( $manifest['agent'] ?? null ) ? $manifest['agent'] : array();
+		$agent          = $this->string_value( $workflow['agent'] ?? $agent_manifest['slug'] ?? ( is_array( $task['package'] ?? null ) ? ( $task['package']['slug'] ?? '' ) : '' ) );
+		if ( '' !== $agent && ! isset( $input['agent'] ) ) {
+			$input['agent'] = $agent;
+		}
+		if ( ! isset( $input['message'] ) ) {
+			$input['message'] = $this->runtime_flow_message( $input, $task, $package_workflow );
+		}
+		$input['runtime_package_flow']     = $package_workflow['flow'];
+		$input['runtime_package_pipeline'] = $package_workflow['pipeline'];
+		$input['runtime_package_manifest'] = $manifest;
+		$input['runtime_package_task']     = $task;
+		$assertions                        = $this->completion_assertions( $package_workflow['flow'], $package_workflow['pipeline'] );
+		if ( ! empty( $assertions ) && ! isset( $input['completion_assertions'] ) ) {
+			$input['completion_assertions'] = $assertions;
+		}
+
+		return $input;
+	}
+
+	/** @param array<string,mixed> $input Caller input. @param array<string,mixed> $task Runtime task. @param array{manifest:array<string,mixed>,flow:array<string,mixed>,pipeline:array<string,mixed>} $package_workflow Package workflow. */
+	private function runtime_flow_message( array $input, array $task, array $package_workflow ): string {
+		$parts = array_filter( array( $this->string_value( $input['prompt'] ?? $task['metadata']['prompt'] ?? '' ) ) );
+		foreach ( is_array( $package_workflow['flow']['steps'] ?? null ) ? $package_workflow['flow']['steps'] : array() as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			foreach ( is_array( $step['prompt_queue'] ?? null ) ? $step['prompt_queue'] : array() as $prompt ) {
+				$text = is_array( $prompt ) ? $this->string_value( $prompt['prompt'] ?? '' ) : $this->string_value( $prompt );
+				if ( '' !== $text ) {
+					$parts[] = $text;
+				}
+			}
+		}
+		foreach ( is_array( $package_workflow['pipeline']['steps'] ?? null ) ? $package_workflow['pipeline']['steps'] : array() as $step ) {
+			$config        = is_array( $step ) && is_array( $step['step_config'] ?? null ) ? $step['step_config'] : array();
+			$system_prompt = $this->string_value( $config['system_prompt'] ?? '' );
+			if ( '' !== $system_prompt ) {
+				$parts[] = $system_prompt;
+			}
+		}
+
+		return implode( "\n\n", array_values( array_unique( $parts ) ) );
+	}
+
+	/** @param array<string,mixed> $flow Flow config. @param array<string,mixed> $pipeline Pipeline config. @return array<string,mixed> */
+	private function completion_assertions( array $flow, array $pipeline ): array {
+		$required = array();
+		foreach ( is_array( $pipeline['steps'] ?? null ) ? $pipeline['steps'] : array() as $step ) {
+			$config     = is_array( $step ) && is_array( $step['step_config'] ?? null ) ? $step['step_config'] : array();
+			$assertions = is_array( $config['completion_assertions'] ?? null ) ? $config['completion_assertions'] : array();
+			foreach ( is_array( $assertions['required_artifact_outputs'] ?? null ) ? $assertions['required_artifact_outputs'] : array() as $artifact ) {
+				if ( is_array( $artifact ) ) {
+					$required[] = $artifact;
+				}
+			}
+		}
+		foreach ( is_array( $flow['steps'] ?? null ) ? $flow['steps'] : array() as $step ) {
+			$configs        = is_array( $step ) && is_array( $step['handler_configs'] ?? null ) ? $step['handler_configs'] : array();
+			$typed_artifact = is_array( $configs['typed_artifact'] ?? null ) ? $configs['typed_artifact'] : array();
+			if ( ! empty( $typed_artifact ) ) {
+				$required[] = $typed_artifact;
+			}
+		}
+
+		return empty( $required ) ? array() : array( 'required_artifact_outputs' => array_values( $required ) );
+	}
+
+	/** @param array<string,mixed> $result Workflow result. @param array<string,mixed> $task Runtime package task. @param array<int,array<string,mixed>> $imports Import results. @return array<string,mixed> */
+	private function result_with_artifact_validation( array $result, array $task, array $imports ): array {
+		$artifacts   = $this->result_artifacts( $result );
+		$diagnostics = is_array( $result['diagnostics'] ?? null ) ? $result['diagnostics'] : array();
+		$names       = array_values( array_filter( array_map( static fn( mixed $artifact ): string => is_array( $artifact ) ? (string) ( $artifact['name'] ?? '' ) : '', $artifacts ) ) );
+
+		foreach ( is_array( $task['required_artifacts'] ?? null ) ? $task['required_artifacts'] : array() as $required ) {
+			$required = (string) $required;
+			if ( '' !== $required && ! in_array( $required, $names, true ) ) {
+				$diagnostics[] = array(
+					'schema'   => 'wp-codebox/runtime-package-diagnostic/v1',
+					'code'     => 'runtime_package_required_artifact_missing',
+					'message'  => 'Runtime package result is missing required artifact: ' . $required . '.',
+					'severity' => 'error',
+					'path'     => 'artifacts',
+				);
+			}
+		}
+
+		$result['diagnostics'] = $diagnostics;
+		$result['artifacts']   = $artifacts;
+		$result['success']     = false === ( $result['success'] ?? true ) ? false : empty( array_filter( $diagnostics, static fn( mixed $diagnostic ): bool => is_array( $diagnostic ) && 'error' === (string) ( $diagnostic['severity'] ?? '' ) ) );
+		$result['metadata']    = array_merge( is_array( $result['metadata'] ?? null ) ? $result['metadata'] : array(), array( 'agent_bundle_imports' => $imports ) );
+
+		return $result;
+	}
+
+	/** @param array<string,mixed> $result Workflow result. @return array<int,array<string,mixed>> */
+	private function result_artifacts( array $result ): array {
+		$artifacts = is_array( $result['artifacts'] ?? null ) ? $result['artifacts'] : array();
+		foreach ( is_array( $result['typed_artifacts'] ?? null ) ? $result['typed_artifacts'] : array() as $typed_artifact ) {
+			if ( ! is_array( $typed_artifact ) ) {
+				continue;
+			}
+			$artifacts[] = array_filter(
+				array(
+					'name'          => $this->string_value( $typed_artifact['output_key'] ?? $typed_artifact['name'] ?? '' ),
+					'type'          => 'typed_artifact',
+					'payloadSchema' => $typed_artifact['schema'] ?? null,
+					'payload'       => $typed_artifact['payload'] ?? null,
+				),
+				static fn( mixed $value ): bool => null !== $value && '' !== $value
+			);
+		}
+
+		return array_values( array_filter( $artifacts, 'is_array' ) );
+	}
+
+	/** @param array<string,mixed> $package Package descriptor. */
+	private function package_root( array $package ): string {
+		$source = $this->string_value( $package['source'] ?? '' );
+		if ( '' === $source || ! file_exists( $source ) ) {
+			return '';
+		}
+		$root = is_file( $source ) ? dirname( $source ) : $source;
+		$real = realpath( $root );
+
+		return false !== $real ? $real : rtrim( $root, '/\\' );
+	}
+
+	/** @return array<string,mixed>|WP_Error */
+	private function read_json_file( string $path ): array|WP_Error {
+		if ( ! is_readable( $path ) ) {
+			return new WP_Error( 'wp_codebox_runtime_package_file_missing', 'Runtime package file is missing or unreadable.', array( 'status' => 400, 'path' => $path ) );
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Runtime package files are local sandbox inputs.
+		$json = file_get_contents( $path );
+		$data = false !== $json ? json_decode( $json, true ) : null;
+		if ( ! is_array( $data ) ) {
+			return new WP_Error( 'wp_codebox_runtime_package_file_invalid', 'Runtime package file must contain a JSON object.', array( 'status' => 400, 'path' => $path ) );
+		}
+
+		return $data;
+	}
+
+	private function safe_slug( string $slug ): string {
+		$slug = basename( str_replace( '\\', '/', trim( $slug ) ) );
+		return preg_replace( '/[^A-Za-z0-9_.-]+/', '-', $slug ) ?? '';
+	}
+
+	private function owner_id(): int {
+		return function_exists( 'get_current_user_id' ) ? max( 1, (int) get_current_user_id() ) : 1;
+	}
+
+	private function string_value( mixed $value ): string {
+		return is_scalar( $value ) ? trim( (string) $value ) : '';
+	}
+}

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -72,6 +72,7 @@ require_once __DIR__ . '/src/class-wp-codebox-artifacts.php';
 require_once __DIR__ . '/src/class-wp-codebox-pending-artifact-apply.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifact-ability-service.php';
 require_once __DIR__ . '/src/class-wp-codebox-preview-options.php';
+require_once __DIR__ . '/src/class-wp-codebox-runtime-package-executor.php';
 require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 require_once __DIR__ . '/src/class-wp-codebox-api.php';
 
@@ -86,6 +87,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 // this on `wp_abilities_api_init` — the same signal the plugin's own abilities
 // register on — so the registry is never touched before it is initialized.
 add_action( 'wp_abilities_api_init', array( WP_Codebox_Agents_API_Adapter::class, 'register_if_available' ) );
+add_action( 'wp_abilities_api_init', array( WP_Codebox_Runtime_Package_Executor::class, 'register_runtime_provider' ) );
+add_action( 'wp_agents_api_init', array( WP_Codebox_Agents_API_Adapter::class, 'register_sandbox_agent' ) );
 add_action( 'plugins_loaded', array( WP_Codebox_Php_Ai_Client_Browser_Provider_Adapter::class, 'register' ), 20 );
 new WP_Codebox_Abilities();
 WP_Codebox_Browser_Provider_Bridge::register();

--- a/scripts/php-agents-api-adapter-contract-smoke.php
+++ b/scripts/php-agents-api-adapter-contract-smoke.php
@@ -94,10 +94,13 @@ assert( 'codebox-agent-runtime' === $early_providers['agents-api-adapter']['id']
 assert( 'Codebox agent runtime' === $early_providers['agents-api-adapter']['label'] );
 assert( 'runtime-profile' === $early_providers['agents-api-adapter']['kind'] );
 assert( array( 'codebox.runtime-package' ) === $early_providers['agents-api-adapter']['capabilities'] );
-assert( 'agents-api-adapter' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
+assert( '' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
 $early_runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
 assert( is_wp_error( $early_runtime_package ) );
-assert( 'wp_codebox_agents_api_ability_unavailable' === $early_runtime_package->get_error_code() );
+assert( 'wp_codebox_runtime_provider_default_missing' === $early_runtime_package->get_error_code() );
+$early_adapter_runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'runtime_provider' => 'agents-api-adapter', 'package' => array( 'id' => 'example' ) ) );
+assert( is_wp_error( $early_adapter_runtime_package ) );
+assert( 'wp_codebox_agents_api_ability_unavailable' === $early_adapter_runtime_package->get_error_code() );
 
 $GLOBALS['wp_codebox_test_abilities'][ $names['chat'] ]                = new WP_Ability( array( 'schema' => 'agents-api/chat-result/v1', 'raw' => array( 'schema' => 'agents-api.chat-result' ) ) );
 $GLOBALS['wp_codebox_test_abilities'][ $names['run_task'] ]            = new WP_Ability( array( 'schema' => 'agents-api/task-result/v1' ) );
@@ -193,15 +196,24 @@ assert( true === $GLOBALS['wp_codebox_test_abilities'][ $names['run_runtime_pack
 assert( 1200000 === $GLOBALS['wp_codebox_test_abilities'][ $names['run_runtime_package'] ]->last_input['input']['time_budget_ms'] );
 assert( array( 'wait_for_completion' => true, 'time_budget_ms' => 1200000 ) === $GLOBALS['wp_codebox_test_abilities'][ $names['run_runtime_package'] ]->last_input['options'] );
 
+$default_chat_browser_input = WP_Codebox_Agents_API_Adapter::browser_runtime_invocation_input(
+	array( 'client_context' => array() ),
+	array( 'agent' => '' ),
+	array( 'type' => 'ability', 'name' => 'agents/chat' ),
+	'codebox-session'
+);
+assert( 'wp-codebox-sandbox' === $default_chat_browser_input['agent'] );
+assert( 'wp-codebox-sandbox' === $default_chat_browser_input['principal']['effective_agent_id'] );
+
 $runtime_package_browser_input = WP_Codebox_Agents_API_Adapter::browser_runtime_invocation_input(
 	array(
-		'agent'          => 'example-agent',
+		'agent'          => '',
 		'provider'       => 'codex',
 		'model'          => 'gpt-5.5',
 		'client_context' => array(),
 	),
 	array(
-		'agent'      => 'example-agent',
+		'agent'      => '',
 		'task_input' => array(
 			'runtime_task' => array(
 				'kind'    => 'bundle',
@@ -221,6 +233,8 @@ assert( array( 'slug' => 'example-agent', 'source' => 'bundles/example-agent' ) 
 assert( array( 'id' => 'example-artifact-flow' ) === $runtime_package_browser_input['workflow'] );
 assert( array( 'wait_for_completion' => true ) === $runtime_package_browser_input['input'] );
 assert( 'runtime' === $runtime_package_browser_input['principal']['auth_source'] );
+assert( 'wp-codebox-sandbox' === $runtime_package_browser_input['agent'] );
+assert( 'wp-codebox-sandbox' === $runtime_package_browser_input['principal']['effective_agent_id'] );
 
 $package_with_workspace_relative_runtime_package = $adapter->run_runtime_package(
 	array(
@@ -248,12 +262,11 @@ WP_Codebox_Agents_API_Adapter::register_runtime_provider();
 $providers = WP_Codebox_Runtime_Provider_Registry::providers();
 assert( isset( $providers['agents-api-adapter'] ) );
 assert( 'codebox-agent-runtime' === $providers['agents-api-adapter']['id'] );
-assert( 'agents-api-adapter' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
+assert( '' === WP_Codebox_Runtime_Provider_Registry::default_provider() );
 
 $default_registered_runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'package' => array( 'id' => 'example' ) ) );
-assert( ! is_wp_error( $default_registered_runtime_package ) );
-assert( 'codebox-agent-runtime' === $default_registered_runtime_package['runtime_provider']['id'] );
-assert( false === str_contains( json_encode( $default_registered_runtime_package['runtime_provider'] ), 'agents-api' ) );
+assert( is_wp_error( $default_registered_runtime_package ) );
+assert( 'wp_codebox_runtime_provider_default_missing' === $default_registered_runtime_package->get_error_code() );
 
 $runtime_package = WP_Codebox_Runtime_Provider_Registry::invoke( array( 'runtime_provider_id' => 'agents-api-adapter', 'package' => array( 'id' => 'example' ) ) );
 assert( ! is_wp_error( $runtime_package ) );

--- a/scripts/php-codebox-sandbox-agent-registration-smoke.php
+++ b/scripts/php-codebox-sandbox-agent-registration-smoke.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+define( 'ABSPATH', __DIR__ );
+
+$registered_agents = array();
+
+function doing_action( string $hook_name ): bool {
+	return ( $GLOBALS['current_action'] ?? '' ) === $hook_name;
+}
+
+function wp_has_agent( string $slug ): bool {
+	return isset( $GLOBALS['registered_agents'][ $slug ] );
+}
+
+function wp_register_agent( string $slug, array $args = array() ): ?array {
+	if ( ! doing_action( 'wp_agents_api_init' ) ) {
+		return null;
+	}
+	$GLOBALS['registered_agents'][ $slug ] = $args;
+	return $args;
+}
+
+function smoke_assert( bool $condition, string $message ): void {
+	if ( ! $condition ) {
+		fwrite( STDERR, $message . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php';
+
+$bootstrap = (string) file_get_contents( __DIR__ . '/../packages/wordpress-plugin/wp-codebox.php' );
+smoke_assert( str_contains( $bootstrap, "add_action( 'wp_agents_api_init', array( WP_Codebox_Agents_API_Adapter::class, 'register_sandbox_agent' ) );" ), 'sandbox agent registration callback is hooked' );
+
+$GLOBALS['current_action'] = 'wp_agents_api_init';
+WP_Codebox_Agents_API_Adapter::register_sandbox_agent();
+$GLOBALS['current_action'] = '';
+
+smoke_assert( isset( $registered_agents['wp-codebox-sandbox'] ), 'wp-codebox-sandbox agent is registered' );
+smoke_assert( 'WP Codebox Sandbox' === $registered_agents['wp-codebox-sandbox']['label'], 'sandbox agent label is stable' );
+smoke_assert( 'wp-codebox' === $registered_agents['wp-codebox-sandbox']['meta']['source_plugin'], 'sandbox agent provenance is Codebox-owned' );
+
+echo "codebox sandbox agent registration smoke passed\n";

--- a/scripts/php-runtime-package-public-contract-smoke.php
+++ b/scripts/php-runtime-package-public-contract-smoke.php
@@ -6,6 +6,7 @@ define( 'ABSPATH', __DIR__ );
 function is_wp_error( mixed $value ): bool {
 	return $value instanceof WP_Error;
 }
+function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false { return json_encode( $value, $flags, $depth ); }
 
 final class WP_Error {
 	public function __construct( private string $code, private string $message, private array $data = array() ) {}
@@ -15,7 +16,42 @@ final class WP_Error {
 }
 
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-provider-registry.php';
+require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-runtime-package-executor.php';
 require_once __DIR__ . '/../packages/wordpress-plugin/src/class-wp-codebox-abilities.php';
+
+$GLOBALS['wp_codebox_runtime_package_smoke_filters'] = array();
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	unset( $priority, $accepted_args );
+	$GLOBALS['wp_codebox_runtime_package_smoke_filters'][ $hook ][] = $callback;
+}
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	foreach ( $GLOBALS['wp_codebox_runtime_package_smoke_filters'][ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+	return $value;
+}
+function get_current_user_id(): int { return 1; }
+
+final class WP_Codebox_Runtime_Package_Smoke_Ability {
+	public function execute( array $input ): array {
+		$GLOBALS['wp_codebox_runtime_package_smoke_input'] = $input;
+		return array(
+			'success'         => true,
+			'outputs'         => array( 'summary' => 'native semantic output', 'agent' => $input['agent'] ?? '' ),
+			'typed_artifacts' => array(
+				array(
+					'output_key' => 'concept_packet',
+					'schema'     => 'wp-site-generator/ConceptPacket/v1',
+					'payload'    => array( 'title' => 'Runtime package concept' ),
+				),
+			),
+		);
+	}
+}
+function wp_get_ability( string $name ): ?WP_Codebox_Runtime_Package_Smoke_Ability {
+	$GLOBALS['wp_codebox_runtime_package_smoke_abilities'][] = $name;
+	return 'agents/chat' === $name ? new WP_Codebox_Runtime_Package_Smoke_Ability() : null;
+}
 
 WP_Codebox_Runtime_Provider_Registry::register(
 	'contract-runtime',
@@ -51,6 +87,35 @@ assert( array( 'name' => 'report', 'type' => 'markdown', 'path' => 'files/report
 assert( array() === $result['diagnostics'] );
 assert( 'contract-runtime' === $result['metadata']['runtime_provider']['id'] );
 assert( isset( $result['metadata']['received'] ) );
+
+$bundle_root = realpath( (string) ( getenv( 'WP_CODEBOX_RUNTIME_PACKAGE_FIXTURE' ) ?: __DIR__ . '/../tests/fixtures/wpsg-runtime-package' ) );
+assert( false !== $bundle_root );
+
+$wpsg_like_task = array(
+	'schema'                => 'wp-codebox/runtime-package-task/v1',
+	'package'               => array( 'slug' => 'store-idea-agent', 'source' => $bundle_root ),
+	'workflow'              => array( 'id' => 'store-idea-artifact-flow' ),
+	'input'                 => array( 'prompt' => 'Industry: open' ),
+	'artifact_declarations' => array( array( 'name' => 'concept_packet', 'type' => 'typed_artifact', 'required' => true ) ),
+	'required_artifacts'    => array( 'concept_packet' ),
+	'metadata'              => array( 'caller' => 'wpsg-like-contract-smoke' ),
+);
+
+WP_Codebox_Runtime_Package_Executor::register_runtime_provider();
+add_filter( 'wp_agent_runtime_import_bundle', static fn( mixed $result, array $spec ): array => array( 'success' => true, 'slug' => $spec['slug'] ?? '' ), 10, 2 );
+$native = WP_Codebox_Abilities::run_runtime_package( $wpsg_like_task + array( 'runtime_provider' => 'codebox-runtime-package' ) );
+assert( ! is_wp_error( $native ) );
+assert( true === $native['success'] );
+assert( 'native semantic output' === $native['outputs']['summary'] );
+assert( 'store-idea-agent' === $native['outputs']['agent'] );
+assert( 'store-idea-artifact-flow' === $native['metadata']['workflow_id'] );
+assert( 'store-idea-artifact-pipeline' === $native['metadata']['pipeline_id'] );
+assert( 'concept_packet' === $native['artifacts'][0]['name'] );
+assert( 'store-idea-artifact-flow' === $GLOBALS['wp_codebox_runtime_package_smoke_input']['runtime_package_flow']['slug'] );
+assert( 'store-idea-artifact-pipeline' === $GLOBALS['wp_codebox_runtime_package_smoke_input']['runtime_package_pipeline']['slug'] );
+assert( str_contains( $GLOBALS['wp_codebox_runtime_package_smoke_input']['message'], 'ConceptPacket' ) );
+assert( 'codebox-runtime-package' === $native['metadata']['runtime_provider']['id'] );
+assert( ! in_array( 'agents/run-runtime-package', $GLOBALS['wp_codebox_runtime_package_smoke_abilities'], true ) );
 
 $invalid = WP_Codebox_Abilities::run_runtime_package( array( 'schema' => 'wp-codebox/runtime-package-task/v1', 'package' => array( 'slug' => 'example-agent' ) ) );
 assert( is_wp_error( $invalid ) );

--- a/tests/fixtures/wpsg-runtime-package/flows/store-idea-artifact-flow.json
+++ b/tests/fixtures/wpsg-runtime-package/flows/store-idea-artifact-flow.json
@@ -1,0 +1,38 @@
+{
+  "max_items": [],
+  "name": "Store Idea Artifact",
+  "pipeline_slug": "store-idea-artifact-pipeline",
+  "schedule": "manual",
+  "schema_version": 1,
+  "slug": "store-idea-artifact-flow",
+  "steps": [
+    {
+      "disabled_tools": ["list_github_issues", "github_issue_publish"],
+      "handler_configs": [],
+      "prompt_queue": [
+        {
+          "prompt": "Industry: open. Generate one distinct, buildable store concept as a ConceptPacket typed artifact with output_key=concept_packet and schema wp-site-generator/ConceptPacket/v1."
+        }
+      ],
+      "queue_mode": "static",
+      "step_position": 0,
+      "step_type": "ai"
+    },
+    {
+      "disabled_tools": [],
+      "enabled": true,
+      "handler_configs": {
+        "typed_artifact": {
+          "output_key": "concept_packet",
+          "schema": "wp-site-generator/ConceptPacket/v1",
+          "artifact": "ConceptPacket"
+        }
+      },
+      "handler_slugs": ["typed_artifact"],
+      "prompt_queue": [],
+      "queue_mode": "static",
+      "step_position": 1,
+      "step_type": "publish"
+    }
+  ]
+}

--- a/tests/fixtures/wpsg-runtime-package/manifest.json
+++ b/tests/fixtures/wpsg-runtime-package/manifest.json
@@ -1,0 +1,30 @@
+{
+  "agent": {
+    "agent_config": {
+      "description": "Generates distinct commerce store concepts.",
+      "mode_models": {
+        "chat": { "provider": "openai", "model": "gpt-5.5" },
+        "pipeline": { "provider": "openai", "model": "gpt-5.5" }
+      }
+    },
+    "label": "Store Idea Agent",
+    "slug": "store-idea-agent"
+  },
+  "agent_package": {
+    "meta": {
+      "exported_by": "wp-site-generator",
+      "source_package": "wp-site-generator",
+      "source_type": "runtime-agent-package"
+    },
+    "slug": "store-idea-agent",
+    "version": "1"
+  },
+  "bundle_slug": "store-idea-agent",
+  "bundle_version": "1",
+  "included": {
+    "flows": ["store-idea-artifact-flow"],
+    "memory": ["agent/SOUL.md"],
+    "pipelines": ["store-idea-artifact-pipeline"]
+  },
+  "schema_version": 1
+}

--- a/tests/fixtures/wpsg-runtime-package/memory/agent/SOUL.md
+++ b/tests/fixtures/wpsg-runtime-package/memory/agent/SOUL.md
@@ -1,0 +1,3 @@
+# Store Idea Agent
+
+Generate distinct commerce store concepts as typed artifacts.

--- a/tests/fixtures/wpsg-runtime-package/pipelines/store-idea-artifact-pipeline.json
+++ b/tests/fixtures/wpsg-runtime-package/pipelines/store-idea-artifact-pipeline.json
@@ -1,0 +1,26 @@
+{
+  "name": "Store Idea Artifact Pipeline",
+  "schema_version": 1,
+  "slug": "store-idea-artifact-pipeline",
+  "steps": [
+    {
+      "step_config": {
+        "execution_order": 0,
+        "completion_assertions": {
+          "required_artifact_outputs": [
+            {
+              "output_key": "concept_packet",
+              "schema": "wp-site-generator/ConceptPacket/v1",
+              "artifact": "ConceptPacket"
+            }
+          ]
+        },
+        "label": "Generate ConceptPacket",
+        "step_type": "ai",
+        "system_prompt": "You are the Store Idea Agent. Generate one distinct commerce store concept. Call emit_typed_artifact with output_key=concept_packet, schema=wp-site-generator/ConceptPacket/v1, artifact=ConceptPacket, and payload=<ConceptPacket>."
+      },
+      "step_position": 0,
+      "step_type": "ai"
+    }
+  ]
+}

--- a/tests/wordpress-plugin-public-runtime-abilities.test.ts
+++ b/tests/wordpress-plugin-public-runtime-abilities.test.ts
@@ -7,6 +7,8 @@ const schemasPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebo
 const executionPhp = await readFile("packages/wordpress-plugin/src/trait-wp-codebox-abilities-execution.php", "utf8")
 const fuzzSuiteRunnerPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-fuzz-suite-runner.php", "utf8")
 const runtimePackageServicePhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-runtime-package-service.php", "utf8")
+const runtimePackageExecutorPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-runtime-package-executor.php", "utf8")
+const agentsApiAdapterPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php", "utf8")
 
 assert.match(abilitiesPhp, /add_action\(\s*'wp_abilities_api_init',\s*array\(\s*\$this,\s*'register_when_abilities_api_is_ready'\s*\)\s*\)/, "WP Codebox must defer ability registration until the Abilities API is ready")
 assert.match(abilitiesPhp, /function register_when_abilities_api_is_ready\(\): void/, "deferred ability registration callback must be present")
@@ -51,6 +53,15 @@ assert.match(runtimePackageServicePhp, /function normalize_task_input\( array \$
 assert.match(runtimePackageServicePhp, /function legacy_task_input\( array \$input \)/)
 assert.match(runtimePackageServicePhp, /function normalize_result\( array \$result, array \$task \)/)
 assert.match(runtimePackageServicePhp, /WP_Codebox_Runtime_Provider_Registry::invoke\( \$task \)/)
+assert.match(runtimePackageExecutorPhp, /final class WP_Codebox_Runtime_Package_Executor/)
+assert.match(runtimePackageExecutorPhp, /WP_Codebox_Runtime_Provider_Registry::register\([\s\S]{0,500}'codebox-runtime-package'/)
+assert.match(runtimePackageExecutorPhp, /function import_package_bundle\( array \$task \)/)
+assert.match(runtimePackageExecutorPhp, /function execute_workflow\( array \$task \)/)
+assert.match(runtimePackageExecutorPhp, /function load_package_workflow\( array \$task, array \$workflow \)/)
+assert.match(runtimePackageExecutorPhp, /\/flows\/.*safe_slug\( \$workflow_id \).*\.json/s)
+assert.match(runtimePackageExecutorPhp, /\/pipelines\/.*safe_slug\( \$pipeline_slug \).*\.json/s)
+assert.doesNotMatch(runtimePackageExecutorPhp, /agents\/run-runtime-package|Data Machine|Homeboy|WPSG|wp-site-generator/i)
+assert.match(agentsApiAdapterPhp, /'default'\s*=>\s*false/)
 assert.match(executionPhp, /unsafe_execution_fields/)
 assert.match(executionPhp, /collect_unsafe_execution_fields/)
 assert.match(executionPhp, /'code', 'php', 'php_code', 'raw_code', 'eval', 'shell'/)
@@ -87,6 +98,6 @@ assert.match(fuzzSuiteRunnerPhp, /'commands'[\s\S]{0,900}wordpress\.plugin-state
 assert.match(fuzzSuiteRunnerPhp, /WP_CODEBOX_FUZZ_WORKLOAD_ROOT/)
 assert.doesNotMatch(executionPhp, /wp_codebox_fuzz_suite_runner_unavailable/)
 
-assert.doesNotMatch(abilitiesPhp + runtimeDescriptorsPhp + schemasPhp + executionPhp + fuzzSuiteRunnerPhp + runtimePackageServicePhp, /WooCommerce|Jetpack|Data Machine/i)
+assert.doesNotMatch(abilitiesPhp + runtimeDescriptorsPhp + schemasPhp + executionPhp + fuzzSuiteRunnerPhp + runtimePackageServicePhp + runtimePackageExecutorPhp, /WooCommerce|Jetpack|Data Machine/i)
 
 console.log("wordpress plugin public runtime abilities contract ok")


### PR DESCRIPTION
## Summary
- Add a WP Codebox-owned `codebox-runtime-package` provider for `wp-codebox/run-runtime-package`.
- Load runtime-agent-package directories by resolving `manifest.json`, `flows/<workflow-id>.json`, and referenced `pipelines/*.json`.
- Keep the Agents API adapter available as an explicit non-default provider.
- Register/default the `wp-codebox-sandbox` agent for blank sandbox payloads.

## Verification
- `npm run test:php-runtime-package-public-contract`
- `WP_CODEBOX_RUNTIME_PACKAGE_FIXTURE="/Users/chubes/Developer/wp-site-generator@fix-generic-typed-artifact-consumers/bundles/store-idea-agent" npm run test:php-runtime-package-public-contract`
- `npm run test:php-agents-api-adapter-contract`
- `php -d zend.assertions=1 -d assert.exception=1 scripts/php-codebox-sandbox-agent-registration-smoke.php`
- `npm run test:php-runtime-task-runner`
- `npm run test:wordpress-plugin-public-runtime-abilities`
- `npm run test:runtime-package-execution`
- `npm run test:runtime-php-snippets`
- `npm run build`
- PHP lint on changed PHP files

## Runtime evidence
- Confirmed Homeboy Extensions maps Codex provider configuration and mounts the Codex-capable `ai-provider-for-openai` checkout when using `/Users/chubes/Developer/ai-provider-for-openai@proof-codex-provider-20260627`.
- A live Codebox cook still fails before agent execution because the sandbox does not mount `agents-api`; transcript reports `agents_api_loaded=false`, `agents_registry_class=false`, and `agents/chat` unavailable. That is a separate provisioning gap in the Homeboy Extensions Codebox agent-task path, not this WP Codebox runtime-package contract.

Fixes #1627.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, test updates, verification, and PR drafting.
