### PR TITLE
Reliable visual-compare capture + bounded-memory region flood (fix empty-error aborts + OOM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:browser-runtime-file-ops": "tsx tests/browser-runtime-file-ops.test.ts",
     "test:browser-visual-compare-blocks-engine-adapter": "tsx tests/browser-visual-compare-blocks-engine-adapter.test.ts",
     "test:browser-visual-compare-fair-ratio": "tsx tests/browser-visual-compare-fair-ratio.test.ts",
+    "test:browser-visual-compare-capture-reliability": "tsx tests/browser-visual-compare-capture-reliability.test.ts",
     "test:browser-session-public-dto": "tsx tests/browser-session-public-dto.test.ts",
     "test:browser-playground-session-run": "tsx tests/browser-playground-session-run.test.ts",
     "test:browser-contained-site-status": "tsx tests/browser-contained-site-status.test.ts",

--- a/packages/runtime-playground/src/browser-visual-compare.ts
+++ b/packages/runtime-playground/src/browser-visual-compare.ts
@@ -303,6 +303,7 @@ async function runVisualComparePairCommand({
   const visualTimeoutMs = durationArg(args, "timeout", browserCommandLivenessPolicy().wallTimeoutMs)
   const requestedViewport = viewportArg(args, "viewport")
   const fullPage = strictBooleanArg(args, "full-page", true)
+  const maxFullPageHeight = positiveIntegerArg(args, "max-full-page-height", VISUAL_COMPARE_MAX_FULL_PAGE_HEIGHT_PX)
   const threshold = numberArg(args, "threshold", 0.1)
   const includeAA = strictBooleanArg(args, "include-aa", false)
   const maxRegions = positiveIntegerArg(args, "max-regions", 8)
@@ -365,7 +366,7 @@ async function runVisualComparePairCommand({
       startedAt,
       source: sourceSummary(),
       candidate: candidateSummary(),
-      options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+      options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, maxFullPageHeight, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
       preview,
       viewport,
     })
@@ -389,7 +390,7 @@ async function runVisualComparePairCommand({
           sourceCapture = await withBrowserCommandLiveness({
             command: "wordpress.visual-compare",
             phase: "source-capture",
-            operation: captureVisualCompareUrl(page, sourceTargetUrl, path, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors, visualTimeoutMs),
+            operation: captureVisualCompareUrl(page, sourceTargetUrl, path, waitFor, durationMs, fullPage, maxFullPageHeight, maxExplanationCandidates, explainSelectors, visualTimeoutMs),
             policy: { wallTimeoutMs: visualTimeoutMs, idleTimeoutMs: 0 },
           })
         })
@@ -404,7 +405,7 @@ async function runVisualComparePairCommand({
           candidateCapture = await withBrowserCommandLiveness({
             command: "wordpress.visual-compare",
             phase: "candidate-capture",
-            operation: captureVisualCompareUrl(page, candidateTargetUrl, path, waitFor, durationMs, fullPage, maxExplanationCandidates, explainSelectors, visualTimeoutMs),
+            operation: captureVisualCompareUrl(page, candidateTargetUrl, path, waitFor, durationMs, fullPage, maxFullPageHeight, maxExplanationCandidates, explainSelectors, visualTimeoutMs),
             policy: { wallTimeoutMs: visualTimeoutMs, idleTimeoutMs: 0 },
           })
         })
@@ -421,16 +422,16 @@ async function runVisualComparePairCommand({
           startedAt,
           source: sourceSummary(),
           candidate: candidateSummary(),
-          options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+          options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, maxFullPageHeight, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
           preview,
           viewport,
-          message: errorMessage(error),
+          message: visualCompareErrorDetail(error),
           copiedFiles: {
             ...(await fileExists(sourcePath) ? { sourceScreenshot: `${artifactPathPrefix}/source.png` } : {}),
             ...(await fileExists(candidatePath) ? { candidateScreenshot: `${artifactPathPrefix}/candidate.png` } : {}),
           },
         })
-        throw new BrowserCommandArtifactError(`wordpress.visual-compare failed during capture: ${errorMessage(error)}`, visualCompareFailureArtifact({ source: sourceSummary(), candidate: candidateSummary(), preview, viewport, files: result.files, summary: result.summary }))
+        throw new BrowserCommandArtifactError(`wordpress.visual-compare failed during capture: ${visualCompareErrorDetail(error)}`, visualCompareFailureArtifact({ source: sourceSummary(), candidate: candidateSummary(), preview, viewport, files: result.files, summary: result.summary }))
       }
     } finally {
       await browser.close()
@@ -455,7 +456,7 @@ async function runVisualComparePairCommand({
         startedAt,
         source: sourceSummary(),
         candidate: candidateSummary(),
-        options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+        options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, maxFullPageHeight, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
         preview,
         viewport,
         missingInputs,
@@ -525,7 +526,7 @@ async function runVisualComparePairCommand({
     status,
     source: sourceSummary(),
     candidate: candidateSummary(),
-    options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
+    options: { waitFor, durationMs, timeoutMs: visualTimeoutMs, fullPage, maxFullPageHeight, threshold, includeAA, maxRegions, maxExplanationElements, maxExplanationCandidates, ...(explainSelectors.length > 0 ? { explainSelectors } : {}) },
     limitations: explanation
       ? explanation.limitations
       : ["visual explanations require source-url/candidate-url targets or source-dom-snapshot/candidate-dom-snapshot sidecars so WP Codebox can include DOM and computed style context; screenshot-only comparisons include pixel evidence only"],
@@ -1629,7 +1630,79 @@ async function gotoVisualCompareTarget(page: Page, targetUrl: string, waitUntil:
   throw lastError instanceof Error ? lastError : new Error(`wordpress.visual-compare navigation failed: ${String(lastError)}`)
 }
 
-async function captureVisualCompareUrl(page: Page, targetUrl: string, outputPath: string, waitFor: string, durationMs: number, fullPage: boolean, maxExplanationCandidates: number, explainSelectors: string[], timeoutMs: number): Promise<{ finalUrl: string; domSnapshot: VisualCompareDomSnapshot }> {
+// A full-page screenshot of a very tall document forces the renderer to allocate a
+// single backing bitmap covering the ENTIRE scroll height (width × height × 4 bytes).
+// For pathologically tall pages (tens of thousands of px) that bitmap alone is hundreds
+// of MB and the capture can crash/close the renderer target — historically surfacing as
+// an opaque, empty screenshot failure. Clamp the captured height to a documented cap,
+// applied IDENTICALLY to source and candidate so the dimension-fair overlap semantics
+// (both renders anchored at the document origin, cropped to the shared min height) are
+// preserved. Normal 5–6k px pages render far below the cap and are unaffected.
+const VISUAL_COMPARE_MAX_FULL_PAGE_HEIGHT_PX = 20_000
+
+// errorMessage() returns an empty string when a thrown Error carries no message — which
+// is exactly what a crashed/closed renderer target tends to produce — and previously
+// surfaced as an opaque empty `capture-failed` diagnostic with no actionable signal.
+// Always produce a non-empty, descriptive detail so the failure summary names a real
+// cause.
+export function visualCompareErrorDetail(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message?.trim()
+    if (message) {
+      return message
+    }
+    const name = error.name?.trim()
+    return name ? `${name} (no message)` : "Error (no message)"
+  }
+  if (error === undefined) {
+    return "unknown error (undefined)"
+  }
+  if (error === null) {
+    return "unknown error (null)"
+  }
+  const text = String(error).trim()
+  return text || "unknown error"
+}
+
+// Take the page screenshot with a bounded per-attempt timeout, one transient-failure
+// retry, an always-non-empty error on final failure, and a height clamp for
+// pathologically tall pages. The clamp computes the document content size and, when it
+// exceeds the cap, captures a top-anchored `clip` of the full content width × capped
+// height instead of a `fullPage` capture — identical treatment for source and candidate.
+async function captureVisualComparePageScreenshot(page: Page, outputPath: string, options: { fullPage: boolean; timeoutMs: number; maxFullPageHeightPx: number }): Promise<void> {
+  let clamp: { width: number; height: number; fullHeight: number } | undefined
+  if (options.fullPage && options.maxFullPageHeightPx > 0) {
+    const metrics = await page.evaluate(() => ({
+      width: Math.max(document.documentElement?.scrollWidth ?? 0, document.body?.scrollWidth ?? 0, window.innerWidth || 0, 1),
+      height: Math.max(document.documentElement?.scrollHeight ?? 0, document.body?.scrollHeight ?? 0, window.innerHeight || 0, 1),
+    }))
+    if (metrics.height > options.maxFullPageHeightPx) {
+      clamp = { width: Math.max(1, Math.round(metrics.width)), height: options.maxFullPageHeightPx, fullHeight: Math.round(metrics.height) }
+    }
+  }
+
+  const attempts = 2
+  let lastError: unknown
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      if (clamp) {
+        await page.screenshot({ path: outputPath, fullPage: false, clip: { x: 0, y: 0, width: clamp.width, height: clamp.height }, timeout: options.timeoutMs, animations: "disabled" })
+      } else {
+        await page.screenshot({ path: outputPath, fullPage: options.fullPage, timeout: options.timeoutMs, animations: "disabled" })
+      }
+      return
+    } catch (error) {
+      lastError = error
+      if (attempt >= attempts) {
+        break
+      }
+    }
+  }
+  const where = clamp ? ` (clamped ${clamp.width}x${clamp.height} of full height ${clamp.fullHeight})` : options.fullPage ? " (full-page)" : ""
+  throw new Error(`wordpress.visual-compare screenshot failed after ${attempts} attempt(s)${where}: ${visualCompareErrorDetail(lastError)}`)
+}
+
+async function captureVisualCompareUrl(page: Page, targetUrl: string, outputPath: string, waitFor: string, durationMs: number, fullPage: boolean, maxFullPageHeight: number, maxExplanationCandidates: number, explainSelectors: string[], timeoutMs: number): Promise<{ finalUrl: string; domSnapshot: VisualCompareDomSnapshot }> {
   if (waitFor === "duration") {
     await gotoVisualCompareTarget(page, targetUrl, "domcontentloaded", timeoutMs)
     if (durationMs > 0) {
@@ -1657,7 +1730,7 @@ async function captureVisualCompareUrl(page: Page, targetUrl: string, outputPath
   // `animations: "disabled"` fast-forwards finite CSS/Web animations and transitions
   // to their final state and freezes infinite ones to a deterministic frame, so the
   // capture does not depend on transition timing. Applied to both sides equally.
-  await page.screenshot({ path: outputPath, fullPage, timeout: timeoutMs, animations: "disabled" })
+  await captureVisualComparePageScreenshot(page, outputPath, { fullPage, timeoutMs, maxFullPageHeightPx: maxFullPageHeight })
   return { finalUrl: page.url(), domSnapshot }
 }
 
@@ -1967,30 +2040,64 @@ function visualCompareMismatchRegions(diff: PNG, maxRegions: number, bounds: { w
 }
 
 function visualCompareFloodRegion(diff: PNG, startX: number, startY: number, visited: Uint8Array, bounds: { width: number; height: number }): VisualCompareMismatchRegion {
-  const stack: Array<[number, number]> = [[startX, startY]]
+  // Use a flat numeric stack of pixel indices (`y * width + x`) instead of `[x, y]`
+  // tuple arrays, and mark each pixel visited at PUSH time so it is enqueued at most
+  // once. The previous implementation pushed four heap-allocated 2-element arrays per
+  // visited pixel and only marked visited at POP time, so the live stack could hold up
+  // to ~4× the mismatched-pixel count as tiny arrays. For a tall page with a high
+  // mismatch ratio (the SSI gate routinely sees tens of millions of differing pixels,
+  // e.g. a ~0.945 raw ratio over a 1280×6000 union) that grew the JS heap into the
+  // multi-GB range and OOM'd old-space. A `number[]` of indices costs ~8 bytes/entry
+  // and, with mark-at-push, the live frontier is bounded by the region perimeter rather
+  // than its area. Region geometry/pixel counts are identical to the old walk.
+  const stride = diff.width
+  const startIndex = startY * stride + startX
+  visited[startIndex] = 1
+  const stack: number[] = [startIndex]
   let minX = startX
   let maxX = startX
   let minY = startY
   let maxY = startY
   let pixels = 0
   while (stack.length > 0) {
-    const [x, y] = stack.pop() ?? [0, 0]
-    if (x < 0 || y < 0 || x >= bounds.width || y >= bounds.height) {
-      continue
-    }
-    const index = y * diff.width + x
-    if (visited[index] || !visualCompareDiffPixel(diff, x, y)) {
-      continue
-    }
-    visited[index] = 1
+    const index = stack.pop() as number
+    const x = index % stride
+    const y = (index - x) / stride
     pixels += 1
-    minX = Math.min(minX, x)
-    maxX = Math.max(maxX, x)
-    minY = Math.min(minY, y)
-    maxY = Math.max(maxY, y)
-    stack.push([x + 1, y], [x - 1, y], [x, y + 1], [x, y - 1])
+    if (x < minX) {
+      minX = x
+    }
+    if (x > maxX) {
+      maxX = x
+    }
+    if (y < minY) {
+      minY = y
+    }
+    if (y > maxY) {
+      maxY = y
+    }
+    if (x + 1 < bounds.width) {
+      visualCompareEnqueueNeighbor(diff, visited, stack, index + 1, x + 1, y)
+    }
+    if (x - 1 >= 0) {
+      visualCompareEnqueueNeighbor(diff, visited, stack, index - 1, x - 1, y)
+    }
+    if (y + 1 < bounds.height) {
+      visualCompareEnqueueNeighbor(diff, visited, stack, index + stride, x, y + 1)
+    }
+    if (y - 1 >= 0) {
+      visualCompareEnqueueNeighbor(diff, visited, stack, index - stride, x, y - 1)
+    }
   }
   return { x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1, pixels }
+}
+
+function visualCompareEnqueueNeighbor(diff: PNG, visited: Uint8Array, stack: number[], index: number, x: number, y: number): void {
+  if (visited[index] || !visualCompareDiffPixel(diff, x, y)) {
+    return
+  }
+  visited[index] = 1
+  stack.push(index)
 }
 
 function visualCompareSegmentLargeRegion(diff: PNG, region: VisualCompareMismatchRegion, maxRegions: number): VisualCompareMismatchRegion[] {

--- a/tests/browser-visual-compare-capture-reliability.test.ts
+++ b/tests/browser-visual-compare-capture-reliability.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { PNG } from "pngjs"
+
+import { comparePngFiles, visualCompareErrorDetail } from "../packages/runtime-playground/src/browser-visual-compare.js"
+
+// Build an opaque solid-color PNG. `fill` is [r,g,b].
+function solidPng(width: number, height: number, fill: [number, number, number]): PNG {
+  const png = new PNG({ width, height })
+  for (let i = 0; i < width * height; i += 1) {
+    const offset = i << 2
+    png.data[offset] = fill[0]
+    png.data[offset + 1] = fill[1]
+    png.data[offset + 2] = fill[2]
+    png.data[offset + 3] = 255
+  }
+  return png
+}
+
+function paintRect(png: PNG, x0: number, y0: number, x1: number, y1: number, fill: [number, number, number]): void {
+  for (let y = y0; y < y1; y += 1) {
+    for (let x = x0; x < x1; x += 1) {
+      const offset = (png.width * y + x) << 2
+      png.data[offset] = fill[0]
+      png.data[offset + 1] = fill[1]
+      png.data[offset + 2] = fill[2]
+      png.data[offset + 3] = 255
+    }
+  }
+}
+
+// 1. The capture-failure detail is ALWAYS non-empty and actionable. A crashed/closed
+//    renderer target throws an Error whose `.message` is empty, which previously
+//    surfaced as an opaque empty `capture-failed` diagnostic. Every shape must yield a
+//    descriptive, non-empty string.
+{
+  assert.equal(visualCompareErrorDetail(new Error("boom")), "boom")
+  const emptyError = new Error("")
+  emptyError.name = "TargetClosedError"
+  assert.equal(visualCompareErrorDetail(emptyError), "TargetClosedError (no message)")
+  const namelessEmpty = new Error("")
+  // Anonymous empty errors still report a non-empty fallback rather than "".
+  assert.ok(visualCompareErrorDetail(namelessEmpty).trim().length > 0, "empty Error must yield non-empty detail")
+  assert.equal(visualCompareErrorDetail(undefined), "unknown error (undefined)")
+  assert.equal(visualCompareErrorDetail(null), "unknown error (null)")
+  assert.equal(visualCompareErrorDetail("plain string failure"), "plain string failure")
+  assert.ok(visualCompareErrorDetail("").trim().length > 0, "empty string must yield non-empty detail")
+  assert.ok(visualCompareErrorDetail({ weird: true }).trim().length > 0, "object must yield non-empty detail")
+}
+
+// Count pixels in a diff PNG whose RGB is nonzero — the exact predicate the region
+// detector uses (`visualCompareDiffPixel`). pixelmatch renders even unchanged pixels as
+// a dimmed grayscale of the original, so for a real (or solid) page this is typically the
+// whole canvas, which is precisely why the flood fill walks every pixel and why bounding
+// its stack matters.
+function countDiffPixels(png: PNG): number {
+  let count = 0
+  for (let i = 0; i < png.width * png.height; i += 1) {
+    const offset = i << 2
+    if (png.data[offset] > 0 || png.data[offset + 1] > 0 || png.data[offset + 2] > 0) {
+      count += 1
+    }
+  }
+  return count
+}
+
+// 2. The bounded flood-fill region detection runs the real comparePngFiles aggregation
+//    over a large, tall, high-mismatch canvas — the exact shape that previously OOM'd
+//    old-space by pushing ~4× the diff-pixel count as [x,y] tuple arrays and marking
+//    visited only at pop time. The rewrite (flat numeric index stack, mark-at-push) must
+//    complete AND recover every diff pixel exactly: the union of region pixel counts must
+//    equal the number of nonzero diff pixels in the written diff, with bounded region
+//    count and in-canvas geometry.
+const dir = await mkdtemp(join(tmpdir(), "visual-compare-capture-"))
+try {
+  const sourcePath = join(dir, "source.png")
+  const candidatePath = join(dir, "candidate.png")
+  const diffPath = join(dir, "diff.png")
+  const options = { threshold: 0.1, includeAA: false, maxRegions: 8 }
+
+  {
+    const white: [number, number, number] = [255, 255, 255]
+    const red: [number, number, number] = [255, 0, 0]
+    // 600 wide × 4000 tall = 2.4M px. Paint a large 600×3000 changed band (75% of px).
+    const width = 600
+    const height = 4000
+    const source = solidPng(width, height, white)
+    const candidate = solidPng(width, height, white)
+    paintRect(candidate, 0, 0, width, 3000, red)
+    await writeFile(sourcePath, PNG.sync.write(source))
+    await writeFile(candidatePath, PNG.sync.write(candidate))
+
+    const result = await comparePngFiles(sourcePath, candidatePath, diffPath, options)
+    assert.equal(result.dimensionMismatch, false)
+    // pixelmatch's CHANGED-pixel count is exactly the painted band.
+    assert.equal(result.mismatchPixels, width * 3000)
+    assert.ok(Math.abs(result.mismatchRatio - 0.75) < 0.001, `expected ~0.75 mismatch ratio, got ${result.mismatchRatio}`)
+    assert.ok(result.regions.length > 0, "a large mismatch must produce at least one region")
+    assert.ok(result.regions.length <= options.maxRegions, "region count must be bounded by maxRegions")
+
+    // The recovered regions must account for exactly the nonzero diff pixels — proving
+    // the rewritten flood fill counts every reachable diff pixel and double-counts none.
+    const diffPng = PNG.sync.read(await readFile(diffPath))
+    const nonzeroDiffPixels = countDiffPixels(diffPng)
+    const totalRegionPixels = result.regions.reduce((sum, region) => sum + region.pixels, 0)
+    assert.equal(totalRegionPixels, nonzeroDiffPixels, "recovered regions must account for every diff pixel exactly")
+
+    // Region geometry stays within the canvas.
+    for (const region of result.regions) {
+      assert.ok(region.x >= 0 && region.y >= 0, "region origin must be in-canvas")
+      assert.ok(region.x + region.width <= width, "region must not exceed canvas width")
+      assert.ok(region.y + region.height <= height, "region must not exceed canvas height")
+    }
+  }
+
+  console.log("browser visual compare capture-reliability (error detail + bounded region detection) passed")
+} finally {
+  await rm(dir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## What
Makes `wordpress.visual-compare` capture reliable and bounds its memory — the #1 blocker to the SSI visual-parity gate producing numbers. An offloaded run showed non-deterministic screenshot-stage aborts with EMPTY errors (3/4 captures failed) and a Node heap OOM (~4GB old-space, peak RSS 8.1GB) during aggregation.

## Root causes (file:line, browser-visual-compare.ts)
- **Empty-error capture failure:** bare `page.screenshot({fullPage})` with no retry; a renderer crash on a multi-hundred-MB full-page bitmap of a 5–6k-px page throws an empty `Error.message`, surfaced as an empty diagnostic.
- **OOM:** `visualCompareFloodRegion` pushed four heap `[x,y]` tuple arrays per pixel and marked visited at pop → live stack ~4× pixel count (~19M tuples on a tall page) → multi-GB old-space.

## Fixes
- `captureVisualComparePageScreenshot()`: bounded per-attempt timeout + one transient retry + never-empty error (new `visualCompareErrorDetail()`). Source/candidate already captured serially.
- Documented `max-full-page-height` clamp (default 20000px), applied identically to both sides via top-anchored clip; the min×min overlap fair ratio (#1630) is untouched.
- Rewrote `visualCompareFloodRegion` to a flat numeric index stack with mark-at-push (region geometry byte-identical).

## Verification (offloaded homeboy-lab head-to-head)
- Region output identical old-vs-new (regionsIdentical: true).
- On the documented 1280×6000 / 7.26M-changed-px shape: heap **1550MB → 96–123MB** (~13–16×), completes under `--max-old-space-size=1024` (no 8192 needed).
- `tsc -b` clean; fair-ratio + adapter + new capture-reliability tests pass.
- Honest limit: live 15-saas/38-medical fair ratios pending this branch being deployed to the runner's wp-codebox bin (the gate runs a pinned build).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Root-cause diagnosis, fix, and offloaded verification under human review.