### PR TITLE
Align agent-task-contracts test to DM-free default substrate

### DIFF
--- a/tests/agent-task-contracts.test.ts
+++ b/tests/agent-task-contracts.test.ts
@@ -446,10 +446,14 @@ try {
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.pluginFile === "wordpress-plugin/wp-codebox.php"), true)
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "agents-api"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "agents-api"), true)
-  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine"), true)
-  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine-code"), true)
-  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), true)
-  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code"), true)
+  // Default runtime substrate is agents-api + the bundled wp-codebox plugin only.
+  // Data Machine / Data Machine Code are no longer mounted by default; they are
+  // provisioned only when a caller passes them explicitly (see the explicit
+  // component_contracts recipe below).
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine"), false)
+  assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "data-machine-code"), false)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine"), false)
+  assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "data-machine-code"), false)
   assert.equal(genericRecipe.inputs?.extra_plugins?.some((plugin) => plugin.slug === "profile-provider"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.providers.some((component) => component.slug === "profile-provider"), true)
   assert.equal(genericRecipe.inputs?.component_manifest?.components.some((component) => component.slug === "profile-component"), true)
@@ -460,8 +464,8 @@ try {
   const genericRuntimeComponents = JSON.parse(genericRuntimeComponentsArg.slice("runtime-component-contracts-json=".length)) as Array<{ slug?: string }>
   assert.equal(genericRuntimeComponents.some((component) => component.slug === "wordpress-plugin"), true)
   assert.equal(genericRuntimeComponents.some((component) => component.slug === "agents-api"), true)
-  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine"), true)
-  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine-code"), true)
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine"), false)
+  assert.equal(genericRuntimeComponents.some((component) => component.slug === "data-machine-code"), false)
 
   const recipe = buildAgentTaskRecipe({
     goal: "Verify extra plugin propagation",


### PR DESCRIPTION
## Summary

Fixes a stale test that was red on `main`. The generic agent-task recipe (`packages/runtime-core/src/agent-task-recipe.ts`, `defaultRuntimeComponentSources()`) no longer mounts `data-machine` or `data-machine-code` by default — the default runtime substrate is now `agents-api` (when resolvable) plus the bundled `wordpress-plugin` (wp-codebox) only. The external coding-agent plugin is no longer mounted by default.

`tests/agent-task-contracts.test.ts` still asserted, against the `genericRecipe` (built with no Data Machine inputs, relying on the default substrate), that `data-machine` / `data-machine-code` appeared in `extra_plugins`, `component_manifest.components`, and the `runtime-component-contracts-json` step arg. Those assertions now fail.

## Changes

Only `tests/agent-task-contracts.test.ts`, only the `genericRecipe` default-substrate assertions:

- `extra_plugins` contains `data-machine` / `data-machine-code`: `true` → `false`
- `component_manifest.components` contains `data-machine` / `data-machine-code`: `true` → `false`
- `runtime-component-contracts-json` arg contains `data-machine` / `data-machine-code`: `true` → `false`
- Added an explanatory comment documenting the agents-api + wp-codebox-plugin substrate.

The existing positive assertions (`agents-api` and `wordpress-plugin` present) are unchanged. The separate explicit-propagation recipe below still passes `data-machine` / `data-machine-code` via `component_contracts` and still asserts they ARE provisioned — explicit caller propagation remains fully covered, so this is not a weakening to a no-op.

This aligns the test to merged intent (DM-free default substrate per the code comment and native-runtime direction), not masking a regression.

## Test

```
$ npm run test:legacy-agent-task-contracts
agent task contracts passed
```

Confirmed red before the change (`actual: false, expected: true`) and green after. Adjacent recipe tests (`test:recipe-validation-descriptors`, `test:host-recipe-builder`) also pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8)
- **Used for:** Aligning the stale `agent-task-contracts` test to the DM-free default substrate.
