### PR TITLE
Add public WordPress fuzz runtime contract

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -154,6 +154,43 @@ caller requests required coverage, pass `requireCoverage: true`; unsupported
 required capabilities fail closed with `status: "error"` instead of looking like a
 successful structured skip.
 
+### WordPress fuzz runtime contract
+
+HBEX and other orchestrator consumers should read the versioned public descriptor
+`wp-codebox/wordpress-fuzz-runtime-contract/v1` instead of probing runtime commands
+or private implementation details. The same descriptor is exposed through:
+
+- PHP: `WP_Codebox_API::wordpress_fuzz_runtime_contract()`
+- Ability discovery metadata on `wp-codebox/run-fuzz-suite`
+- WP-CLI: `wp codebox wordpress-fuzz-runtime-contract --format=json`
+- Node CLI: `wp-codebox fuzz descriptor --format=json`
+- TypeScript: `wordpressFuzzRuntimeContract()` from `@automattic/wp-codebox-core/contracts`
+
+The descriptor enumerates explicit action families, reset modes, artifact
+expectations, destructive-mode requirements, unsupported capabilities, and HBEX
+schema ids. Unsupported features are declared as data in
+`unsupportedCapabilities`; consumers should not infer support by trying commands.
+
+The public destructive contract is bounded: destructive fuzz coverage requires
+`checkpoint-per-case` reset mode plus `mutation-isolation-artifact` and
+`delete-boundary-artifact` evidence. Raw delete capability is intentionally
+`null`; delete coverage is represented by the explicit `delete-boundary-artifact`
+contract.
+
+HBEX schema ids advertised by the descriptor include:
+
+- `wp-codebox/wordpress-fuzz-runtime-contract/v1`
+- `wp-codebox/fuzz-suite/v1`
+- `wp-codebox/fuzz-suite-result/v1`
+- `wp-codebox/fuzz-runner-capabilities/v1`
+- `wp-codebox/fuzz-runner-readiness/v1`
+- `wp-codebox/fuzz-coverage-plan/v1`
+- `wp-codebox/fuzz-fixture-plan/v1`
+- `wp-codebox/rest-mutation-fixture-opt-in/v1`
+- `wp-codebox/mutation-isolation-artifact/v1`
+- `wp-codebox/delete-boundary-artifact/v1`
+- `wp-codebox/wordpress-workload-run/v1`
+
 TypeScript callers running through the public Codebox contract should build fuzz
 suites with `@automattic/wp-codebox-core/contracts`. Use `wp-codebox/run-fuzz-suite`
 or `WP_Codebox_API` for in-process WordPress ability coverage, and use the public

--- a/packages/cli/src/cli-entry.ts
+++ b/packages/cli/src/cli-entry.ts
@@ -10,7 +10,7 @@ import { runMaterializeReplayPackageCommand } from "./commands/replay-package.js
 import { runMcpRenderClientConfigsCommand } from "./commands/mcp.js"
 import { runPreviewLeaseReleaseCommand, runPreviewLeaseStatusCommand } from "./commands/preview-lease.js"
 import { runBootCommand, runRunCommand, runValidateBlueprintCommand } from "./commands/runtime.js"
-import { runFuzzReadinessCommand, runFuzzSuiteCommand, runWordPressWorkloadCommand } from "./commands/wordpress-runtime.js"
+import { runFuzzDescriptorCommand, runFuzzReadinessCommand, runFuzzSuiteCommand, runWordPressWorkloadCommand } from "./commands/wordpress-runtime.js"
 import { runRunsArtifactsCommand, runRunsCancelCommand, runRunsStatusCommand } from "./commands/runs.js"
 import { runTargetProvisionCommand } from "./commands/target.js"
 import { runWorkspacePolicyCheckCommand } from "./commands/workspace-policy.js"
@@ -26,6 +26,7 @@ export async function runCli(args: string[]): Promise<number> {
     agentTaskRun: runAgentTaskRunCommand,
     runFuzzSuite: runFuzzSuiteCommand,
     runWordPressWorkload: runWordPressWorkloadCommand,
+    fuzzDescriptor: runFuzzDescriptorCommand,
     fuzzReadiness: runFuzzReadinessCommand,
     recipeValidate: runRecipeValidateCommand,
     recipeBuild: runRecipeBuildCommand,

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -13,6 +13,7 @@ const cliCommandRoutes = {
   "run-fuzz-suite": "runFuzzSuite",
   "run-wordpress-workload": "runWordPressWorkload",
   fuzz: {
+    descriptor: "fuzzDescriptor",
     readiness: "fuzzReadiness",
     capabilities: "fuzzReadiness",
   },

--- a/packages/cli/src/commands/wordpress-runtime.ts
+++ b/packages/cli/src/commands/wordpress-runtime.ts
@@ -3,7 +3,7 @@ import { existsSync, realpathSync, statSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, isAbsolute, join, resolve } from "node:path"
-import { fuzzRunnerReadinessContract, parseCommandJson, parseCommandOptions, PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, runFuzzSuite, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, wordpressWorkloadRunRecipe, type ExecutionResult, type ExecutionSpec, type FuzzSuiteContract, type FuzzSuiteRuntimeWorkloadExecutionInput, type RuntimePolicy, type WordPressWorkloadRunRecipeOptions, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
+import { fuzzRunnerReadinessContract, parseCommandJson, parseCommandOptions, PHP_IN_PROCESS_FUZZ_SUITE_RUNNER_CAPABILITIES, runFuzzSuite, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, wordpressFuzzRuntimeContract, wordpressWorkloadRunRecipe, type ExecutionResult, type ExecutionSpec, type FuzzSuiteContract, type FuzzSuiteRuntimeWorkloadExecutionInput, type RuntimePolicy, type WordPressWorkloadRunRecipeOptions, type WorkspaceRecipe, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeMount } from "@automattic/wp-codebox-core"
 import { createWordPressEpisode, executeWordPressFuzzSuite } from "@automattic/wp-codebox-playground/public"
 import { captureStdout } from "../output.js"
 import { runRecipeRunCommand } from "./recipe-run.js"
@@ -44,6 +44,25 @@ export async function runFuzzSuiteCommand(args: string[]): Promise<number> {
   })
   const { schema: _schema, ...resultFields } = result
   writeJson({ schema: FUZZ_SUITE_RESULT_SCHEMA, ...resultFields })
+  return 0
+}
+
+export async function runFuzzDescriptorCommand(args: string[]): Promise<number> {
+  if (isHelp(args)) {
+    printFuzzDescriptorHelp()
+    return 0
+  }
+
+  const { options, positionals } = parseCommandOptions(args, new Set(["--json"]))
+  if (positionals.length > 0) {
+    throw new Error(`Invalid argument: ${positionals[0]}`)
+  }
+  for (const name of options.keys()) {
+    if (!["--format", "--json"].includes(name)) {
+      throw new Error(`Unknown option: ${name}`)
+    }
+  }
+  writeJson(wordpressFuzzRuntimeContract())
   return 0
 }
 
@@ -609,6 +628,10 @@ function writeJson(value: unknown): void {
 
 function printFuzzSuiteHelp(): void {
   process.stdout.write(`Usage: wp-codebox run-fuzz-suite --input-file <path> [--format=json] [--dry-run] [--runner-mode=simple|runtime-backed]\n\nRuns a wp-codebox/fuzz-suite/v1 JSON payload through the public fuzz-suite runner.\n`)
+}
+
+function printFuzzDescriptorHelp(): void {
+  process.stdout.write("Usage: wp-codebox fuzz descriptor [--format=json]\n\nPrints the public wp-codebox/wordpress-fuzz-runtime-contract/v1 descriptor for orchestrator consumers.\n")
 }
 
 function printFuzzReadinessHelp(): void {

--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -5,6 +5,7 @@ export const FUZZ_SUITE_SCHEMA = "wp-codebox/fuzz-suite/v1" as const
 export const FUZZ_SUITE_RESULT_SCHEMA = "wp-codebox/fuzz-suite-result/v1" as const
 export const FUZZ_RUNNER_CAPABILITIES_SCHEMA = "wp-codebox/fuzz-runner-capabilities/v1" as const
 export const FUZZ_RUNNER_READINESS_SCHEMA = "wp-codebox/fuzz-runner-readiness/v1" as const
+export const WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA = "wp-codebox/wordpress-fuzz-runtime-contract/v1" as const
 
 export type FuzzSuiteTargetKind = "ability" | "command" | "http" | "rest" | "runtime" | "runtime-action" | (string & {})
 export type FuzzSuiteCaseStatus = "passed" | "failed" | "error" | "skipped"
@@ -122,6 +123,70 @@ export interface FuzzRunnerReadinessContract {
   metadata?: Record<string, unknown>
 }
 
+export interface WordPressFuzzRuntimeContract {
+  schema: typeof WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA
+  version: 1
+  runtime: {
+    id: "wp-codebox"
+    environment: "wordpress"
+  }
+  publicSurfaces: {
+    phpFacade: string
+    ability: string
+    wpCli: string
+    nodeCli: string
+    typescript: string
+  }
+  actionFamilies: WordPressFuzzActionFamily[]
+  resetModes: WordPressFuzzResetMode[]
+  artifactExpectations: WordPressFuzzArtifactExpectation[]
+  destructiveModeRequirements: WordPressFuzzDestructiveModeRequirements
+  unsupportedCapabilities: WordPressFuzzUnsupportedCapability[]
+  hbex: {
+    schemaIds: Record<string, string>
+  }
+}
+
+export interface WordPressFuzzActionFamily {
+  id: string
+  label: string
+  targetKinds: string[]
+  runtimeActionTypes: string[]
+  commands: string[]
+  mutationIntents: FuzzSuiteMutationIntentKind[]
+  supported: boolean
+}
+
+export interface WordPressFuzzResetMode {
+  id: FuzzSuiteResetMode
+  supported: boolean
+  requiredForMutationIntents: FuzzSuiteMutationIntentKind[]
+  artifactKinds: string[]
+}
+
+export interface WordPressFuzzArtifactExpectation {
+  id: string
+  required: boolean
+  schema: string
+  producedBy: string[]
+  description: string
+}
+
+export interface WordPressFuzzDestructiveModeRequirements {
+  supported: boolean
+  destructiveMutationIntent: "destructive"
+  requiredResetModes: FuzzSuiteResetMode[]
+  requiredArtifacts: string[]
+  deleteBoundaryCapability: string
+  rawDeleteCapability: null
+}
+
+export interface WordPressFuzzUnsupportedCapability {
+  id: string
+  reason: string
+  replacement?: string
+}
+
 export interface FuzzRunnerRequiredCapabilities {
   capabilities?: readonly string[]
   targetKinds?: readonly string[]
@@ -179,6 +244,137 @@ export const RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES: FuzzSuiteRunnerCapab
   runtimeActionTypes: ["admin_page", "browser", "browser_probe", "crud_operation", "db_operation", "editor_open", "page", "php", "random_walk", "rest_request", "sequence", "wp_cli"],
   commands: ["wp-codebox.checkpoint-create", "wp-codebox.checkpoint-list", "wp-codebox.checkpoint-restore", "wordpress.ability", "wordpress.browser-actions", "wordpress.browser-page-load", "wordpress.browser-probe", "wordpress.collect-workload-result", "wordpress.crud-operation", "wordpress.db-operation", "wordpress.editor-open", "wordpress.fuzz-admin-pages", "wordpress.fuzz-plugin-module-state", "wordpress.http-request", "wordpress.inventory-plugin-module-options-tables", "wordpress.rest-performance-observation", "wordpress.rest-request", "wordpress.run-php", "wordpress.run-workload", "wordpress.server-page-load", "wordpress.simulated-admin-page-load", "wordpress.simulated-frontend-page-load", "wordpress.wp-cli"],
   unsupportedRequiredCapabilities: [],
+}
+
+export const WORDPRESS_FUZZ_RUNTIME_CONTRACT: WordPressFuzzRuntimeContract = {
+  schema: WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
+  version: 1,
+  runtime: {
+    id: "wp-codebox",
+    environment: "wordpress",
+  },
+  publicSurfaces: {
+    phpFacade: "WP_Codebox_API::wordpress_fuzz_runtime_contract()",
+    ability: "wp-codebox/run-fuzz-suite",
+    wpCli: "wp codebox wordpress-fuzz-runtime-contract",
+    nodeCli: "wp-codebox fuzz descriptor --format=json",
+    typescript: "@automattic/wp-codebox-core/contracts",
+  },
+  actionFamilies: [
+    {
+      id: "ability-http-rest-read",
+      label: "Ability, HTTP, and REST read coverage",
+      targetKinds: ["ability", "http", "rest"],
+      runtimeActionTypes: [],
+      commands: ["wordpress.ability", "wordpress.http-request", "wordpress.rest-request"],
+      mutationIntents: ["read"],
+      supported: true,
+    },
+    {
+      id: "runtime-browser-admin",
+      label: "Runtime browser, admin page, editor, and page coverage",
+      targetKinds: ["runtime", "runtime-action"],
+      runtimeActionTypes: ["admin_page", "browser", "browser_probe", "editor_open", "page", "random_walk", "sequence"],
+      commands: ["wordpress.browser-actions", "wordpress.browser-page-load", "wordpress.browser-probe", "wordpress.editor-open", "wordpress.fuzz-admin-pages", "wordpress.page", "wordpress.simulated-admin-page-load", "wordpress.simulated-frontend-page-load"],
+      mutationIntents: ["read", "write"],
+      supported: true,
+    },
+    {
+      id: "runtime-wordpress-operations",
+      label: "WordPress CLI, PHP, REST, CRUD, and database operation coverage",
+      targetKinds: ["command", "runtime", "runtime-action"],
+      runtimeActionTypes: ["crud_operation", "db_operation", "php", "rest_request", "wp_cli"],
+      commands: ["wordpress.collect-workload-result", "wordpress.crud-operation", "wordpress.db-operation", "wordpress.inventory-plugin-module-options-tables", "wordpress.rest-performance-observation", "wordpress.rest-request", "wordpress.run-php", "wordpress.run-workload", "wordpress.wp-cli"],
+      mutationIntents: ["read", "write", "delete", "destructive"],
+      supported: true,
+    },
+  ],
+  resetModes: [
+    {
+      id: "none",
+      supported: true,
+      requiredForMutationIntents: ["read"],
+      artifactKinds: [],
+    },
+    {
+      id: "checkpoint-per-case",
+      supported: true,
+      requiredForMutationIntents: ["write", "delete", "destructive"],
+      artifactKinds: ["mutation-isolation-artifact", "delete-boundary-artifact"],
+    },
+    {
+      id: "restore-snapshot",
+      supported: false,
+      requiredForMutationIntents: [],
+      artifactKinds: [],
+    },
+  ],
+  artifactExpectations: [
+    {
+      id: "fuzz-suite-result",
+      required: true,
+      schema: FUZZ_SUITE_RESULT_SCHEMA,
+      producedBy: ["run-fuzz-suite"],
+      description: "Every fuzz run returns a structured suite result envelope with case summaries, diagnostics, and artifact references.",
+    },
+    {
+      id: "mutation-isolation-artifact",
+      required: true,
+      schema: "wp-codebox/mutation-isolation-artifact/v1",
+      producedBy: ["rest-mutation:post", "rest-mutation:put", "rest-mutation:patch"],
+      description: "Mutating REST coverage records the fixture opt-in and reset boundary used to isolate the mutation.",
+    },
+    {
+      id: "delete-boundary-artifact",
+      required: true,
+      schema: "wp-codebox/delete-boundary-artifact/v1",
+      producedBy: ["rest-mutation:delete"],
+      description: "Delete coverage records the explicit delete boundary artifact instead of advertising raw delete support.",
+    },
+  ],
+  destructiveModeRequirements: {
+    supported: true,
+    destructiveMutationIntent: "destructive",
+    requiredResetModes: ["checkpoint-per-case"],
+    requiredArtifacts: ["mutation-isolation-artifact", "delete-boundary-artifact"],
+    deleteBoundaryCapability: "delete-boundary-artifact",
+    rawDeleteCapability: null,
+  },
+  unsupportedCapabilities: [
+    {
+      id: "raw-delete",
+      reason: "WordPress fuzz runtime delete coverage is only supported through explicit delete-boundary artifacts.",
+      replacement: "delete-boundary-artifact",
+    },
+    {
+      id: "restore-snapshot-reset",
+      reason: "Snapshot restore is not part of the public WordPress fuzz runtime contract.",
+      replacement: "checkpoint-per-case",
+    },
+    {
+      id: "private-runtime-probing",
+      reason: "Consumers must read this descriptor instead of probing private runtime commands or implementation capabilities.",
+    },
+  ],
+  hbex: {
+    schemaIds: {
+      descriptor: WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
+      fuzzSuite: FUZZ_SUITE_SCHEMA,
+      fuzzSuiteResult: FUZZ_SUITE_RESULT_SCHEMA,
+      fuzzRunnerCapabilities: FUZZ_RUNNER_CAPABILITIES_SCHEMA,
+      fuzzRunnerReadiness: FUZZ_RUNNER_READINESS_SCHEMA,
+      fuzzCoveragePlan: "wp-codebox/fuzz-coverage-plan/v1",
+      fuzzFixturePlan: "wp-codebox/fuzz-fixture-plan/v1",
+      restMutationFixtureOptIn: "wp-codebox/rest-mutation-fixture-opt-in/v1",
+      mutationIsolationArtifact: "wp-codebox/mutation-isolation-artifact/v1",
+      deleteBoundaryArtifact: "wp-codebox/delete-boundary-artifact/v1",
+      wordpressWorkloadRun: "wp-codebox/wordpress-workload-run/v1",
+    },
+  },
+}
+
+export function wordpressFuzzRuntimeContract(): WordPressFuzzRuntimeContract {
+  return WORDPRESS_FUZZ_RUNTIME_CONTRACT
 }
 
 export interface FuzzSuiteDiagnostic {

--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -4,7 +4,7 @@ import { AGENT_RUNTIME_WORKLOAD_SCHEMA } from "./agent-runtime-workload.js"
 import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, normalizeArtifactResultEnvelope, type ArtifactResultEnvelope } from "./artifact-result-envelope.js"
 import { FANOUT_AGGREGATION_INPUT_SCHEMA, FANOUT_AGGREGATION_OUTPUT_SCHEMA, aggregateFanoutOutputs, normalizeFanoutAggregationInput, validateFanoutAggregationOutput, type FanoutAggregationInput, type FanoutAggregationInputRequest, type FanoutAggregationOutput } from "./fanout-aggregation.js"
 import { FUZZ_COVERAGE_PLAN_SCHEMA } from "./fuzz-coverage-plan-contracts.js"
-import { FUZZ_SUITE_RESULT_SCHEMA, FUZZ_SUITE_SCHEMA } from "./fuzz-suite-contracts.js"
+import { FUZZ_RUNNER_CAPABILITIES_SCHEMA, FUZZ_RUNNER_READINESS_SCHEMA, FUZZ_SUITE_RESULT_SCHEMA, FUZZ_SUITE_SCHEMA, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA, wordpressFuzzRuntimeContract, type WordPressFuzzRuntimeContract } from "./fuzz-suite-contracts.js"
 import { HOST_DELEGATION_EVENT_SCHEMA, HOST_DELEGATION_REQUEST_SCHEMA, HOST_DELEGATION_RESULT_SCHEMA } from "./fanout-contracts.js"
 import { ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA, BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA } from "./materialization-contracts.js"
 import { PARENT_TOOL_BRIDGE_SCHEMA, PARENT_TOOL_REQUEST_SCHEMA, PARENT_TOOL_RESULT_SCHEMA } from "./parent-tool-bridge.js"
@@ -191,6 +191,9 @@ export const RUNTIME_CONTRACT_SCHEMAS = {
     fuzzCoveragePlan: FUZZ_COVERAGE_PLAN_SCHEMA,
     fuzzSuite: FUZZ_SUITE_SCHEMA,
     fuzzSuiteResult: FUZZ_SUITE_RESULT_SCHEMA,
+    fuzzRunnerCapabilities: FUZZ_RUNNER_CAPABILITIES_SCHEMA,
+    fuzzRunnerReadiness: FUZZ_RUNNER_READINESS_SCHEMA,
+    wordpressFuzzRuntimeContract: WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
     blockExerciseResult: WORDPRESS_BLOCK_EXERCISE_RESULT_SCHEMA,
   },
 } as const
@@ -220,6 +223,7 @@ export interface RuntimeDescriptor {
   }
   capabilities: typeof CODEBOX_PUBLIC_RUNTIME_CAPABILITIES
   abilities: typeof CODEBOX_PUBLIC_RUNTIME_ABILITIES
+  wordpressFuzzRuntimeContract: WordPressFuzzRuntimeContract
   contractManifest: RuntimeContractManifest
 }
 
@@ -248,6 +252,7 @@ export function runtimeDescriptor(): RuntimeDescriptor {
     },
     capabilities: CODEBOX_PUBLIC_RUNTIME_CAPABILITIES,
     abilities: CODEBOX_PUBLIC_RUNTIME_ABILITIES,
+    wordpressFuzzRuntimeContract: wordpressFuzzRuntimeContract(),
     contractManifest: runtimeContractManifest(),
   }
 }

--- a/packages/runtime-core/src/structured-artifacts.ts
+++ b/packages/runtime-core/src/structured-artifacts.ts
@@ -189,7 +189,7 @@ export function normalizeTypedArtifactDTO(input: unknown, defaults: NormalizeTyp
   const type = stringValue(entry.type) || defaults.type || ""
   if (!name || !type) return undefined
 
-  const artifact = typedArtifactFile(entry.artifact, defaults)
+  const artifact = typedArtifactFile(entry.artifact ?? entry, defaults)
   const hasPayload = "payload" in entry
   if (!artifact && !hasPayload) return undefined
 

--- a/packages/wordpress-plugin/src/class-wp-codebox-api.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-api.php
@@ -12,8 +12,9 @@ defined( 'ABSPATH' ) || exit;
  */
 final class WP_Codebox_API {
 
-	private const RUNTIME_DESCRIPTOR_SCHEMA        = 'wp-codebox/runtime-descriptor/v1';
-	private const RUNTIME_CONTRACT_MANIFEST_SCHEMA = 'wp-codebox/runtime-contract-manifest/v1';
+	private const RUNTIME_DESCRIPTOR_SCHEMA                 = 'wp-codebox/runtime-descriptor/v1';
+	private const RUNTIME_CONTRACT_MANIFEST_SCHEMA          = 'wp-codebox/runtime-contract-manifest/v1';
+	private const WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA    = 'wp-codebox/wordpress-fuzz-runtime-contract/v1';
 
 	/** @var string[] */
 	private const PUBLIC_RUNTIME_CAPABILITIES = array(
@@ -43,6 +44,7 @@ final class WP_Codebox_API {
 	/** @var array<string,string> */
 	private const ABILITY_METHODS = array(
 		'wp-codebox/runtime-descriptor'                     => 'runtime_descriptor',
+		'wp-codebox/wordpress-fuzz-runtime-contract'        => 'wordpress_fuzz_runtime_contract',
 		'wp-codebox/run-agent-task'                         => 'run_agent_task',
 		'wp-codebox/run-agent-task-batch'                   => 'run_agent_task_batch',
 		'wp-codebox/run-agent-task-fanout'                  => 'run_agent_task_fanout',
@@ -113,7 +115,96 @@ final class WP_Codebox_API {
 			),
 			'capabilities'     => self::PUBLIC_RUNTIME_CAPABILITIES,
 			'abilities'        => self::runtime_abilities(),
+			'wordpressFuzzRuntimeContract' => self::wordpress_fuzz_runtime_contract(),
 			'contractManifest' => self::runtime_contract_manifest(),
+		);
+	}
+
+	/** @param array<string,mixed> $input Ignored descriptor input. @return array<string,mixed> */
+	public static function wordpress_fuzz_runtime_contract( array $input = array() ): array {
+		unset( $input );
+
+		return array(
+			'schema'                      => self::WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
+			'version'                     => 1,
+			'runtime'                     => array(
+				'id'          => 'wp-codebox',
+				'environment' => 'wordpress',
+			),
+			'publicSurfaces'              => array(
+				'phpFacade'  => 'WP_Codebox_API::wordpress_fuzz_runtime_contract()',
+				'ability'    => 'wp-codebox/run-fuzz-suite',
+				'wpCli'      => 'wp codebox wordpress-fuzz-runtime-contract',
+				'nodeCli'    => 'wp-codebox fuzz descriptor --format=json',
+				'typescript' => '@automattic/wp-codebox-core/contracts',
+			),
+			'actionFamilies'              => array(
+				array(
+					'id'                 => 'ability-http-rest-read',
+					'label'              => 'Ability, HTTP, and REST read coverage',
+					'targetKinds'        => array( 'ability', 'http', 'rest' ),
+					'runtimeActionTypes' => array(),
+					'commands'           => array( 'wordpress.ability', 'wordpress.http-request', 'wordpress.rest-request' ),
+					'mutationIntents'    => array( 'read' ),
+					'supported'          => true,
+				),
+				array(
+					'id'                 => 'runtime-browser-admin',
+					'label'              => 'Runtime browser, admin page, editor, and page coverage',
+					'targetKinds'        => array( 'runtime', 'runtime-action' ),
+					'runtimeActionTypes' => array( 'admin_page', 'browser', 'browser_probe', 'editor_open', 'page', 'random_walk', 'sequence' ),
+					'commands'           => array( 'wordpress.browser-actions', 'wordpress.browser-page-load', 'wordpress.browser-probe', 'wordpress.editor-open', 'wordpress.fuzz-admin-pages', 'wordpress.page', 'wordpress.simulated-admin-page-load', 'wordpress.simulated-frontend-page-load' ),
+					'mutationIntents'    => array( 'read', 'write' ),
+					'supported'          => true,
+				),
+				array(
+					'id'                 => 'runtime-wordpress-operations',
+					'label'              => 'WordPress CLI, PHP, REST, CRUD, and database operation coverage',
+					'targetKinds'        => array( 'command', 'runtime', 'runtime-action' ),
+					'runtimeActionTypes' => array( 'crud_operation', 'db_operation', 'php', 'rest_request', 'wp_cli' ),
+					'commands'           => array( 'wordpress.collect-workload-result', 'wordpress.crud-operation', 'wordpress.db-operation', 'wordpress.inventory-plugin-module-options-tables', 'wordpress.rest-performance-observation', 'wordpress.rest-request', 'wordpress.run-php', 'wordpress.run-workload', 'wordpress.wp-cli' ),
+					'mutationIntents'    => array( 'read', 'write', 'delete', 'destructive' ),
+					'supported'          => true,
+				),
+			),
+			'resetModes'                  => array(
+				array( 'id' => 'none', 'supported' => true, 'requiredForMutationIntents' => array( 'read' ), 'artifactKinds' => array() ),
+				array( 'id' => 'checkpoint-per-case', 'supported' => true, 'requiredForMutationIntents' => array( 'write', 'delete', 'destructive' ), 'artifactKinds' => array( 'mutation-isolation-artifact', 'delete-boundary-artifact' ) ),
+				array( 'id' => 'restore-snapshot', 'supported' => false, 'requiredForMutationIntents' => array(), 'artifactKinds' => array() ),
+			),
+			'artifactExpectations'        => array(
+				array( 'id' => 'fuzz-suite-result', 'required' => true, 'schema' => 'wp-codebox/fuzz-suite-result/v1', 'producedBy' => array( 'run-fuzz-suite' ), 'description' => 'Every fuzz run returns a structured suite result envelope with case summaries, diagnostics, and artifact references.' ),
+				array( 'id' => 'mutation-isolation-artifact', 'required' => true, 'schema' => 'wp-codebox/mutation-isolation-artifact/v1', 'producedBy' => array( 'rest-mutation:post', 'rest-mutation:put', 'rest-mutation:patch' ), 'description' => 'Mutating REST coverage records the fixture opt-in and reset boundary used to isolate the mutation.' ),
+				array( 'id' => 'delete-boundary-artifact', 'required' => true, 'schema' => 'wp-codebox/delete-boundary-artifact/v1', 'producedBy' => array( 'rest-mutation:delete' ), 'description' => 'Delete coverage records the explicit delete boundary artifact instead of advertising raw delete support.' ),
+			),
+			'destructiveModeRequirements' => array(
+				'supported'                 => true,
+				'destructiveMutationIntent' => 'destructive',
+				'requiredResetModes'        => array( 'checkpoint-per-case' ),
+				'requiredArtifacts'         => array( 'mutation-isolation-artifact', 'delete-boundary-artifact' ),
+				'deleteBoundaryCapability'  => 'delete-boundary-artifact',
+				'rawDeleteCapability'       => null,
+			),
+			'unsupportedCapabilities'     => array(
+				array( 'id' => 'raw-delete', 'reason' => 'WordPress fuzz runtime delete coverage is only supported through explicit delete-boundary artifacts.', 'replacement' => 'delete-boundary-artifact' ),
+				array( 'id' => 'restore-snapshot-reset', 'reason' => 'Snapshot restore is not part of the public WordPress fuzz runtime contract.', 'replacement' => 'checkpoint-per-case' ),
+				array( 'id' => 'private-runtime-probing', 'reason' => 'Consumers must read this descriptor instead of probing private runtime commands or implementation capabilities.' ),
+			),
+			'hbex'                        => array(
+				'schemaIds' => array(
+					'descriptor'                 => self::WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
+					'fuzzSuite'                  => 'wp-codebox/fuzz-suite/v1',
+					'fuzzSuiteResult'            => 'wp-codebox/fuzz-suite-result/v1',
+					'fuzzRunnerCapabilities'     => 'wp-codebox/fuzz-runner-capabilities/v1',
+					'fuzzRunnerReadiness'        => 'wp-codebox/fuzz-runner-readiness/v1',
+					'fuzzCoveragePlan'           => 'wp-codebox/fuzz-coverage-plan/v1',
+					'fuzzFixturePlan'            => 'wp-codebox/fuzz-fixture-plan/v1',
+					'restMutationFixtureOptIn'   => 'wp-codebox/rest-mutation-fixture-opt-in/v1',
+					'mutationIsolationArtifact'  => 'wp-codebox/mutation-isolation-artifact/v1',
+					'deleteBoundaryArtifact'     => 'wp-codebox/delete-boundary-artifact/v1',
+					'wordpressWorkloadRun'       => 'wp-codebox/wordpress-workload-run/v1',
+				),
+			),
 		);
 	}
 
@@ -243,6 +334,9 @@ final class WP_Codebox_API {
 				'fuzzCoveragePlan'    => 'wp-codebox/fuzz-coverage-plan/v1',
 				'fuzzSuite'           => 'wp-codebox/fuzz-suite/v1',
 				'fuzzSuiteResult'     => 'wp-codebox/fuzz-suite-result/v1',
+				'fuzzRunnerCapabilities' => 'wp-codebox/fuzz-runner-capabilities/v1',
+				'fuzzRunnerReadiness' => 'wp-codebox/fuzz-runner-readiness/v1',
+				'wordpressFuzzRuntimeContract' => self::WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
 				'blockExerciseResult' => 'wp-codebox/wordpress-block-exercise-result/v1',
 			),
 		);

--- a/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-cli-command.php
@@ -28,6 +28,7 @@ final class WP_Codebox_CLI_Command {
 		\WP_CLI::add_command( 'codebox run-wordpress-workload', array( $command, 'run_wordpress_workload' ) );
 		\WP_CLI::add_command( 'codebox run-runtime-package', array( $command, 'run_runtime_package' ) );
 		\WP_CLI::add_command( 'codebox resolve-runtime-requirements', array( $command, 'resolve_runtime_requirements' ) );
+		\WP_CLI::add_command( 'codebox wordpress-fuzz-runtime-contract', array( $command, 'wordpress_fuzz_runtime_contract' ) );
 		\WP_CLI::add_command( 'codebox run-fuzz-suite', array( $command, 'run_fuzz_suite' ) );
 	}
 
@@ -189,6 +190,17 @@ final class WP_Codebox_CLI_Command {
 	public function resolve_runtime_requirements( array $args, array $assoc_args ): void {
 		unset( $args );
 		$this->emit( WP_Codebox_API::resolve_runtime_requirements( $this->input_from_args( $assoc_args ) ), $assoc_args );
+	}
+
+	/**
+	 * Print the public WordPress fuzz runtime descriptor contract.
+	 *
+	 * @param array<int,string>   $args       Positional arguments.
+	 * @param array<string,mixed> $assoc_args Associated arguments.
+	 */
+	public function wordpress_fuzz_runtime_contract( array $args, array $assoc_args ): void {
+		unset( $args );
+		$this->emit( WP_Codebox_API::wordpress_fuzz_runtime_contract(), $assoc_args );
 	}
 
 	/**

--- a/packages/wordpress-plugin/src/class-wp-codebox-runtime-ability-descriptors.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-runtime-ability-descriptors.php
@@ -59,7 +59,7 @@ final class WP_Codebox_Runtime_Ability_Descriptors {
 			'output_schema'       => $context['fuzz_suite_result_schema'],
 			'execute_callback'    => array( WP_Codebox_Abilities::class, 'run_fuzz_suite' ),
 			'permission_callback' => array( WP_Codebox_Abilities::class, 'can_run_agent_task' ),
-			'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'runner_capabilities' => $context['fuzz_suite_runner_capabilities_contract'], 'supported_runner_capabilities' => $context['fuzz_suite_supported_runner_capabilities'], 'runtime_backed_execution' => $context['fuzz_suite_runtime_backed_execution_contract'], 'runner_capabilities_schema' => $context['fuzz_runner_capabilities_schema'] ),
+			'meta'                => array( 'show_in_rest' => true, 'canonical_ability' => 'wp-codebox/run-fuzz-suite', 'wordpress_fuzz_runtime_contract' => WP_Codebox_API::wordpress_fuzz_runtime_contract(), 'runner_capabilities' => $context['fuzz_suite_runner_capabilities_contract'], 'supported_runner_capabilities' => $context['fuzz_suite_supported_runner_capabilities'], 'runtime_backed_execution' => $context['fuzz_suite_runtime_backed_execution_contract'], 'runner_capabilities_schema' => $context['fuzz_runner_capabilities_schema'] ),
 		);
 	}
 

--- a/packages/wordpress-plugin/wp-codebox.php
+++ b/packages/wordpress-plugin/wp-codebox.php
@@ -73,8 +73,8 @@ require_once __DIR__ . '/src/class-wp-codebox-pending-artifact-apply.php';
 require_once __DIR__ . '/src/class-wp-codebox-artifact-ability-service.php';
 require_once __DIR__ . '/src/class-wp-codebox-preview-options.php';
 require_once __DIR__ . '/src/class-wp-codebox-runtime-package-executor.php';
-require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 require_once __DIR__ . '/src/class-wp-codebox-api.php';
+require_once __DIR__ . '/src/class-wp-codebox-abilities.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/src/class-wp-codebox-cli-command.php';

--- a/scripts/php-cli-command-smoke.php
+++ b/scripts/php-cli-command-smoke.php
@@ -110,6 +110,7 @@ $expected_commands = array(
 	'codebox run-wordpress-workload',
 	'codebox run-runtime-package',
 	'codebox resolve-runtime-requirements',
+	'codebox wordpress-fuzz-runtime-contract',
 	'codebox run-fuzz-suite',
 );
 
@@ -125,6 +126,16 @@ expect( is_array( $descriptor_output ), 'Expected JSON output for runtime descri
 expect( 'wp-codebox/runtime-descriptor/v1' === $descriptor_output['schema'], 'Runtime descriptor command must emit descriptor schema.' );
 expect( in_array( 'contract-manifest:read', $descriptor_output['capabilities'], true ), 'Runtime descriptor command must include contract manifest capability.' );
 expect( 0 === count( WP_Codebox_Abilities::$calls ), 'Runtime descriptor command must not dispatch through backend abilities.' );
+
+WP_CLI::$lines = array();
+WP_Codebox_Abilities::$calls = array();
+WP_CLI::$commands['codebox wordpress-fuzz-runtime-contract']( array(), array() );
+$fuzz_contract_output = json_decode( WP_CLI::$lines[0] ?? '', true );
+expect( is_array( $fuzz_contract_output ), 'Expected JSON output for WordPress fuzz runtime contract command.' );
+expect( 'wp-codebox/wordpress-fuzz-runtime-contract/v1' === $fuzz_contract_output['schema'], 'WordPress fuzz runtime contract command must emit descriptor schema.' );
+expect( null === $fuzz_contract_output['destructiveModeRequirements']['rawDeleteCapability'], 'WordPress fuzz runtime contract must explicitly reject raw delete capability.' );
+expect( 'wp-codebox/delete-boundary-artifact/v1' === $fuzz_contract_output['hbex']['schemaIds']['deleteBoundaryArtifact'], 'WordPress fuzz runtime contract must include HBEX delete boundary schema id.' );
+expect( 0 === count( WP_Codebox_Abilities::$calls ), 'WordPress fuzz runtime contract command must not dispatch through backend abilities.' );
 
 function run_cli_command( string $command, array $args = array(), array $assoc_args = array() ): array {
 	WP_CLI::$lines = array();

--- a/scripts/php-public-api-facade-smoke.php
+++ b/scripts/php-public-api-facade-smoke.php
@@ -239,7 +239,22 @@ expect( 'wp-codebox/runtime-descriptor/v1' === $descriptor['schema'], 'Expected 
 expect( 'available' === $descriptor['readiness']['status'], 'Expected descriptor readiness status.' );
 expect( in_array( 'runtime-requirements:resolve', $descriptor['capabilities'], true ), 'Expected runtime requirements capability.' );
 expect( 'wp-codebox/resolve-runtime-requirements' === $descriptor['abilities']['runtimeRequirements']['resolve'], 'Expected runtime requirements ability in descriptor.' );
+expect( 'wp-codebox/wordpress-fuzz-runtime-contract/v1' === $descriptor['wordpressFuzzRuntimeContract']['schema'], 'Expected nested WordPress fuzz runtime contract.' );
 expect( 'wp-codebox/runtime-contract-manifest/v1' === $descriptor['contractManifest']['schema'], 'Expected nested runtime contract manifest.' );
+
+$fuzz_runtime_contract = WP_Codebox_API::wordpress_fuzz_runtime_contract();
+expect( 'wp-codebox/wordpress-fuzz-runtime-contract/v1' === $fuzz_runtime_contract['schema'], 'Expected WordPress fuzz runtime contract schema.' );
+expect( 'WP_Codebox_API::wordpress_fuzz_runtime_contract()' === $fuzz_runtime_contract['publicSurfaces']['phpFacade'], 'Expected PHP facade public surface.' );
+expect( 'wp-codebox/run-fuzz-suite' === $fuzz_runtime_contract['publicSurfaces']['ability'], 'Expected ability public surface.' );
+expect( 'wp codebox wordpress-fuzz-runtime-contract' === $fuzz_runtime_contract['publicSurfaces']['wpCli'], 'Expected WP-CLI public surface.' );
+expect( null === $fuzz_runtime_contract['destructiveModeRequirements']['rawDeleteCapability'], 'Expected raw delete to be explicitly unsupported.' );
+expect( in_array( 'checkpoint-per-case', $fuzz_runtime_contract['destructiveModeRequirements']['requiredResetModes'], true ), 'Expected destructive mode reset requirement.' );
+expect( 'wp-codebox/delete-boundary-artifact/v1' === $fuzz_runtime_contract['hbex']['schemaIds']['deleteBoundaryArtifact'], 'Expected HBEX delete boundary schema id.' );
+expect( in_array( 'private-runtime-probing', array_column( $fuzz_runtime_contract['unsupportedCapabilities'], 'id' ), true ), 'Expected explicit unsupported probing capability.' );
+
+$fuzz_contract_ability = WP_Codebox_API::execute_ability( 'wp-codebox/wordpress-fuzz-runtime-contract', array( 'ignored' => true ) );
+expect( is_array( $fuzz_contract_ability ), 'Expected WordPress fuzz runtime contract ability facade result.' );
+expect( 'wp-codebox/wordpress-fuzz-runtime-contract/v1' === $fuzz_contract_ability['schema'], 'Expected WordPress fuzz runtime contract ability schema.' );
 
 $descriptor_ability = WP_Codebox_API::execute_ability( 'wp-codebox/runtime-descriptor', array( 'ignored' => true ) );
 expect( is_array( $descriptor_ability ), 'Expected descriptor ability facade result.' );

--- a/tests/command-router.test.ts
+++ b/tests/command-router.test.ts
@@ -16,6 +16,11 @@ const router = {
   },
   runFuzzSuite: async () => 0,
   runWordPressWorkload: async () => 0,
+  fuzzDescriptor: async (args: string[]) => {
+    calls.push(`fuzzDescriptor:${args.join(" ")}`)
+    return 5
+  },
+  fuzzReadiness: async () => 0,
   recipeValidate: async () => 0,
   recipeBuild: async () => 0,
   workspacePolicyCheck: async () => 0,
@@ -58,5 +63,10 @@ const runtimeDescriptorExitCode = await routeCliCommand(["runtime", "descriptor"
 
 assert.equal(runtimeDescriptorExitCode, 3)
 assert.deepEqual(calls, ["agentTaskRun:--input-file task.json --json", "runtimeDescriptor:--json"])
+
+const fuzzDescriptorExitCode = await routeCliCommand(["fuzz", "descriptor", "--json"], router)
+
+assert.equal(fuzzDescriptorExitCode, 5)
+assert.deepEqual(calls, ["agentTaskRun:--input-file task.json --json", "runtimeDescriptor:--json", "fuzzDescriptor:--json"])
 
 console.log("command-router contract passed")

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -37,6 +37,7 @@ import {
   FUZZ_RUNNER_READINESS_SCHEMA,
   FUZZ_SUITE_RESULT_SCHEMA,
   FUZZ_SUITE_SCHEMA,
+  WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
   REST_MUTATION_FIXTURE_OPT_IN_SCHEMA,
   DELETE_BOUNDARY_ARTIFACT_SCHEMA,
   MUTATION_ISOLATION_ARTIFACT_SCHEMA,
@@ -50,6 +51,7 @@ import {
   fuzzCoveragePlanContract,
   fuzzFixturePlanContract,
   fuzzRunnerReadinessContract,
+  wordpressFuzzRuntimeContract,
   TASK_INPUT_JSON_SCHEMA,
 } from "../packages/runtime-core/src/public.js"
 import * as publicApi from "../packages/runtime-core/src/public.js"
@@ -391,6 +393,11 @@ assert.match(docs, /ability is an in-process WordPress ability only/)
 assert.match(docs, /supported_by_this_ability: false/)
 assert.match(docs, /ability_execution_mode: "php-in-process-only"/)
 assert.match(docs, /wp-codebox run-fuzz-suite --runner-mode=runtime-backed/)
+assert.match(docs, /wp-codebox\/wordpress-fuzz-runtime-contract\/v1/)
+assert.match(docs, /WP_Codebox_API::wordpress_fuzz_runtime_contract\(\)/)
+assert.match(docs, /wp-codebox fuzz descriptor --format=json/)
+assert.match(docs, /unsupportedCapabilities/)
+assert.match(docs, /delete-boundary-artifact/)
 assert.match(docs, /executeWordPressFuzzSuite/)
 assert.match(docs, /manifest intentionally excludes backend handler bindings/)
 assert.doesNotMatch(docs + pluginReadme, /\bData Machine\b|\bData Machine Code\b|\bAgents API\b|\bWordPress Playground\b|generic Data Machine inputs/)
@@ -456,6 +463,8 @@ assert.equal(runtimeContractManifest().schemas.wordpressRuntime.workloadRun, "wp
 assert.equal(runtimeContractManifest().schemas.wordpressRuntime.fuzzCoveragePlan, FUZZ_COVERAGE_PLAN_SCHEMA)
 assert.equal(runtimeContractManifest().schemas.wordpressRuntime.fuzzSuite, FUZZ_SUITE_SCHEMA)
 assert.equal(runtimeContractManifest().schemas.wordpressRuntime.fuzzSuiteResult, FUZZ_SUITE_RESULT_SCHEMA)
+assert.equal(runtimeContractManifest().schemas.wordpressRuntime.fuzzRunnerReadiness, FUZZ_RUNNER_READINESS_SCHEMA)
+assert.equal(runtimeContractManifest().schemas.wordpressRuntime.wordpressFuzzRuntimeContract, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA)
 assert.equal(runtimeContractManifest().schemas.wordpressRuntime.blockExerciseResult, WORDPRESS_BLOCK_EXERCISE_RESULT_SCHEMA)
 assert.equal(runtimeContractManifest().schemas.agentTask.runRequest, "wp-codebox/agent-task-run-request/v1")
 assert.equal(runtimeContractManifest().providerRuntime.tasks.workspaceCommand, "wp-codebox.runner-workspace.command")
@@ -475,6 +484,19 @@ assert.equal(publicApi.deleteBoundaryArtifact({ operation: "rest_request", targe
 assert.equal(fuzzCoveragePlanContract({ id: "coverage-boundary" }).schema, FUZZ_COVERAGE_PLAN_SCHEMA)
 assert.equal(fuzzFixturePlanContract({ id: "fixture-plan-boundary" }).schema, FUZZ_FIXTURE_PLAN_SCHEMA)
 assert.equal(fuzzRunnerReadinessContract(publicApi.RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES).schema, FUZZ_RUNNER_READINESS_SCHEMA)
+const wordpressFuzzDescriptor = wordpressFuzzRuntimeContract()
+assert.equal(wordpressFuzzDescriptor.schema, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA)
+assert.equal(wordpressFuzzDescriptor.publicSurfaces.phpFacade, "WP_Codebox_API::wordpress_fuzz_runtime_contract()")
+assert.equal(wordpressFuzzDescriptor.publicSurfaces.ability, CODEBOX_RUN_FUZZ_SUITE_ABILITY)
+assert.equal(wordpressFuzzDescriptor.publicSurfaces.nodeCli, "wp-codebox fuzz descriptor --format=json")
+assert.deepEqual(wordpressFuzzDescriptor.destructiveModeRequirements.requiredResetModes, ["checkpoint-per-case"])
+assert.equal(wordpressFuzzDescriptor.destructiveModeRequirements.rawDeleteCapability, null)
+assert.equal(wordpressFuzzDescriptor.actionFamilies.some((family) => family.runtimeActionTypes.includes("crud_operation")), true)
+assert.equal(wordpressFuzzDescriptor.resetModes.some((mode) => mode.id === "restore-snapshot" && mode.supported === false), true)
+assert.equal(wordpressFuzzDescriptor.artifactExpectations.some((artifact) => artifact.schema === "wp-codebox/delete-boundary-artifact/v1" && artifact.required), true)
+assert.equal(wordpressFuzzDescriptor.unsupportedCapabilities.some((capability) => capability.id === "private-runtime-probing"), true)
+assert.equal(wordpressFuzzDescriptor.hbex.schemaIds.descriptor, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA)
+assert.equal(publicApi.runtimeDescriptor().wordpressFuzzRuntimeContract.schema, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA)
 assert.equal(publicApi.restMutationFixtureOptInContract({ id: "rest-mutation-opt-in", route: "/example/v1/items", methods: ["post", "DELETE"] }).schema, REST_MUTATION_FIXTURE_OPT_IN_SCHEMA)
 assert.equal(fuzzSuiteContract({ id: "ability-boundary", cases: [{ id: "empty-input" }] }).schema, FUZZ_SUITE_SCHEMA)
 assert.deepEqual(fuzzSuiteResultEnvelope({

--- a/tests/public-fuzz-workload-cli.test.ts
+++ b/tests/public-fuzz-workload-cli.test.ts
@@ -9,10 +9,12 @@ process.env.WP_CODEBOX_NO_JSPI_RESPAWN = "1"
 
 const help = await captureStdout(async () => {
   assert.equal(await runCli(["run-fuzz-suite", "--help"]), 0)
+  assert.equal(await runCli(["fuzz", "descriptor", "--help"]), 0)
   assert.equal(await runCli(["fuzz", "readiness", "--help"]), 0)
   assert.equal(await runCli(["run-wordpress-workload", "--help"]), 0)
 })
 assert.match(help, /run-fuzz-suite/)
+assert.match(help, /fuzz descriptor/)
 assert.match(help, /fuzz readiness/)
 assert.match(help, /run-wordpress-workload/)
 assert.match(help, /--input-file/)
@@ -38,6 +40,19 @@ return static function ( array $input, array $args ): array {
     );
 };
   `, "utf8")
+
+  const descriptorOutput = await captureStdout(async () => {
+    assert.equal(await runCli(["fuzz", "descriptor", "--format=json"]), 0)
+  })
+  const descriptorJson = JSON.parse(descriptorOutput)
+  assert.equal(descriptorJson.schema, "wp-codebox/wordpress-fuzz-runtime-contract/v1")
+  assert.equal(descriptorJson.publicSurfaces.nodeCli, "wp-codebox fuzz descriptor --format=json")
+  assert.equal(descriptorJson.publicSurfaces.wpCli, "wp codebox wordpress-fuzz-runtime-contract")
+  assert.equal(descriptorJson.actionFamilies.some((family: { commands: string[] }) => family.commands.includes("wordpress.rest-request")), true)
+  assert.deepEqual(descriptorJson.destructiveModeRequirements.requiredResetModes, ["checkpoint-per-case"])
+  assert.equal(descriptorJson.destructiveModeRequirements.rawDeleteCapability, null)
+  assert.equal(descriptorJson.unsupportedCapabilities.some((capability: { id: string }) => capability.id === "private-runtime-probing"), true)
+  assert.equal(descriptorJson.hbex.schemaIds.deleteBoundaryArtifact, "wp-codebox/delete-boundary-artifact/v1")
 
   const readinessOutput = await captureStdout(async () => {
     assert.equal(await runCli(["fuzz", "readiness", "--format=json"]), 0)

--- a/tests/wordpress-plugin-public-runtime-abilities.test.ts
+++ b/tests/wordpress-plugin-public-runtime-abilities.test.ts
@@ -9,6 +9,7 @@ const fuzzSuiteRunnerPhp = await readFile("packages/wordpress-plugin/src/class-w
 const runtimePackageServicePhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-runtime-package-service.php", "utf8")
 const runtimePackageExecutorPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-runtime-package-executor.php", "utf8")
 const agentsApiAdapterPhp = await readFile("packages/wordpress-plugin/src/class-wp-codebox-agents-api-adapter.php", "utf8")
+const pluginMainPhp = await readFile("packages/wordpress-plugin/wp-codebox.php", "utf8")
 
 assert.match(abilitiesPhp, /add_action\(\s*'wp_abilities_api_init',\s*array\(\s*\$this,\s*'register_when_abilities_api_is_ready'\s*\)\s*\)/, "WP Codebox must defer ability registration until the Abilities API is ready")
 assert.match(abilitiesPhp, /function register_when_abilities_api_is_ready\(\): void/, "deferred ability registration callback must be present")
@@ -92,6 +93,8 @@ assert.match(fuzzSuiteRunnerPhp, /'ability_execution_mode'\s*=>\s*'php-in-proces
 assert.match(fuzzSuiteRunnerPhp, /'supported_by_this_ability'\s*=>\s*false/)
 assert.match(runtimeDescriptorsPhp, /'supported_runner_capabilities'\s*=>\s*\$context\['fuzz_suite_supported_runner_capabilities'\]/)
 assert.match(runtimeDescriptorsPhp, /'runtime_backed_execution'\s*=>\s*\$context\['fuzz_suite_runtime_backed_execution_contract'\]/)
+assert.match(runtimeDescriptorsPhp, /'wordpress_fuzz_runtime_contract'\s*=>\s*WP_Codebox_API::wordpress_fuzz_runtime_contract\(\)/)
+assert.ok(pluginMainPhp.indexOf("class-wp-codebox-api.php") < pluginMainPhp.indexOf("class-wp-codebox-abilities.php"), "API facade must load before ability descriptors reference it")
 assert.match(fuzzSuiteRunnerPhp, /wordpress\.ensure-plugin-active/)
 assert.match(fuzzSuiteRunnerPhp, /'commands'[\s\S]{0,900}wordpress\.ensure-plugin-active/)
 assert.match(fuzzSuiteRunnerPhp, /'commands'[\s\S]{0,900}wordpress\.plugin-state/)


### PR DESCRIPTION
## Summary
- Add the versioned public `wp-codebox/wordpress-fuzz-runtime-contract/v1` descriptor for WordPress fuzz runtime capabilities.
- Expose the descriptor through TypeScript contracts/runtime descriptor, PHP facade, ability metadata, WP-CLI, and Node CLI.
- Document the HBEX consumer contract, explicit unsupported capabilities, reset modes, artifact expectations, and destructive-mode requirements.
- Accept flattened typed artifact DTOs with top-level path/digest fields to satisfy the existing public DTO contract.

## Tests
- `npm run build`
- `npm run test:public-api-contract`
- `npx tsx tests/public-fuzz-workload-cli.test.ts`
- `npm run test:wordpress-plugin-public-runtime-abilities`
- `npm run test:php-public-api-facade`
- `npm run test:php-cli-command`
- `npm run test:command-router`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Implementing the public descriptor contract, wiring public surfaces, updating docs, adding contract tests, and verifying the branch.