### PR TITLE
Add browser action observation assertions

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -715,6 +715,27 @@ Supported assertion forms are the current command contract:
 Prefix an assertion with `advisory:` to record a failing assertion without
 failing the command.
 
+`wordpress.browser-actions` can assert over observations captured by prior action
+steps with an `assertObservation` step. Supported observation assertions are:
+
+- `no-console-errors`
+- `no-page-errors`
+- `request-count-by-host:<host><op><number>`
+- `request-count-by-type:<type><op><number>`
+
+Failed `assertObservation` steps are recorded in the action step records and
+assertion summary, and they fail the browser-actions command.
+
+```json
+{
+  "command": "wordpress.browser-actions",
+  "args": [
+    "url=/",
+    "steps-json=[{\"kind\":\"waitFor\",\"waitFor\":\"networkidle\"},{\"kind\":\"assertObservation\",\"assertion\":\"request-count-by-host:example.test<=2\"},{\"kind\":\"assertObservation\",\"assertion\":\"no-console-errors\"}]"
+  ]
+}
+```
+
 Do not use `assert=script:passed equals true`. That syntax is not supported by
 the current WP Codebox browser assertion contract. Use `wordpress.browser-actions`
 with an `evaluate` step and `assert` value when a page script must prove state:

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "test:runtime-php-snippets": "tsx tests/runtime-php-snippets.test.ts",
     "test:agent-no-data-machine-loop": "tsx tests/agent-no-data-machine-loop.test.ts",
     "test:browser-runner-template": "tsx tests/browser-runner-template.test.ts",
+    "test:browser-observation-assertions": "tsx tests/browser-observation-assertions.test.ts",
     "test:editor-actions": "tsx tests/editor-actions.test.ts",
     "test:editor-validate-blocks": "tsx tests/editor-validate-blocks.test.ts",
     "test:artifact-result-envelope": "tsx tests/artifact-result-envelope.test.ts",

--- a/packages/runtime-core/src/browser-interaction.ts
+++ b/packages/runtime-core/src/browser-interaction.ts
@@ -24,6 +24,7 @@ export const BROWSER_INTERACTION_STEP_KINDS = [
   "waitFor",
   "evaluate",
   "expect",
+  "assertObservation",
   "screenshot",
   "capture",
 ] as const
@@ -70,6 +71,8 @@ export interface BrowserInteractionStep {
   expression?: string
   /** Optional expected value an `evaluate` result must deep-equal to assert. */
   assert?: unknown
+  /** Observation assertion for captured browser runtime evidence. */
+  assertion?: string
   /** Expected locator state for `expect`. */
   state?: BrowserInteractionExpectState
   /** Optional screenshot name for `screenshot`; screenshot steps may also use waitFor for painted-readiness waits before capture. */
@@ -205,6 +208,13 @@ export function validateBrowserInteractionScript(input: unknown): BrowserInterac
           issues.push({ index, message: `expect step state must be one of ${BROWSER_INTERACTION_EXPECT_STATES.join(", ")}` })
         }
         break
+      case "assertObservation":
+        if (typeof step.assertion !== "string" || step.assertion.trim().length === 0) {
+          issues.push({ index, message: "assertObservation step requires assertion" })
+        } else if (!isBrowserInteractionObservationAssertion(step.assertion)) {
+          issues.push({ index, message: "assertObservation supports no-console-errors, no-page-errors, request-count-by-host:<host><op><number>, and request-count-by-type:<type><op><number>" })
+        }
+        break
       case "screenshot":
       case "capture":
         break
@@ -219,6 +229,14 @@ export function validateBrowserInteractionScript(input: unknown): BrowserInterac
 /** True when an interaction script contains at least one policy-gated evaluate step. */
 export function browserInteractionScriptUsesEvaluate(steps: readonly BrowserInteractionStep[]): boolean {
   return steps.some((step) => step.kind === "evaluate")
+}
+
+function isBrowserInteractionObservationAssertion(raw: string): boolean {
+  const value = raw.trim()
+  if (value === "no-console-errors" || value === "no-page-errors") return true
+  if (value.startsWith("request-count-by-host:")) return /^.+(>=|<=|==|!=|=|>|<)\s*\d+$/.test(value.slice("request-count-by-host:".length).trim())
+  if (value.startsWith("request-count-by-type:")) return /^.+(>=|<=|==|!=|=|>|<)\s*\d+$/.test(value.slice("request-count-by-type:".length).trim())
+  return false
 }
 
 export function browserRandomWalkContract(input: Record<string, unknown>): BrowserRandomWalkContract {

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -10,6 +10,7 @@ import { captureBrowserDomSnapshot, type BrowserDomSnapshotArtifact } from "./br
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness } from "./browser-liveness.js"
 import { serializeBrowserError } from "./browser-metrics.js"
+import { executeBrowserObservationAssertion } from "./browser-observation-assertions.js"
 import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewTopology, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeReplayability, browserProbeViewport } from "./browser-probe.js"
 import { runBrowserProbeCommand, type BrowserProbeRunPlan } from "./browser-probe-runner.js"
@@ -176,15 +177,17 @@ export async function runBrowserActionsCommand({
         break
       }
       try {
-        const outcome = await withBrowserCommandLiveness({
-          command: "wordpress.browser-actions",
-          phase: `step ${index} (${step.kind})`,
-          operation: executeBrowserInteractionStep(page, step, preview.effectiveOrigin, stepTimeoutMs, async (fileName, write) => {
-            await artifactSession.writeGenerated("screenshot", fileName, write)
-            return { path: artifactSession.path(fileName), isDefault: fileName === "screenshot.png" }
-          }),
-          policy: { wallTimeoutMs: Math.min(browserStepTimeoutMs(step, stepTimeoutMs), livenessRemainingWallTimeMs(startedAtMs, totalTimeoutMs)), idleTimeoutMs: 0 },
-        })
+        const outcome = step.kind === "assertObservation"
+          ? { assertion: executeBrowserObservationAssertion(step, consoleMessages, errors, network) }
+          : await withBrowserCommandLiveness({
+            command: "wordpress.browser-actions",
+            phase: `step ${index} (${step.kind})`,
+            operation: executeBrowserInteractionStep(page, step, preview.effectiveOrigin, stepTimeoutMs, async (fileName, write) => {
+              await artifactSession.writeGenerated("screenshot", fileName, write)
+              return { path: artifactSession.path(fileName), isDefault: fileName === "screenshot.png" }
+            }),
+            policy: { wallTimeoutMs: Math.min(browserStepTimeoutMs(step, stepTimeoutMs), livenessRemainingWallTimeMs(startedAtMs, totalTimeoutMs)), idleTimeoutMs: 0 },
+          })
         finalUrl = page.url()
         if (step.kind === "navigate") {
           requestedUrl = resolveBrowserPreviewUrl((step.url ?? "").trim(), preview.effectiveOrigin)

--- a/packages/runtime-playground/src/browser-interactions.ts
+++ b/packages/runtime-playground/src/browser-interactions.ts
@@ -126,6 +126,8 @@ export async function executeBrowserInteractionStep(
       const passed = await browserExpectState(page, selector, state, timeout)
       return { assertion: { kind: "expect", selector, state, passed } }
     }
+    case "assertObservation":
+      return {}
     case "screenshot": {
       const readiness = isPaintedReadinessWait(step.waitFor) ? await waitForPaintedReadiness(page, step.waitFor, timeout) : undefined
       const frameTarget = await screenshotFrameTarget(page, step, timeout)

--- a/packages/runtime-playground/src/browser-observation-assertions.ts
+++ b/packages/runtime-playground/src/browser-observation-assertions.ts
@@ -1,0 +1,115 @@
+import type { BrowserInteractionStep } from "@automattic/wp-codebox-core"
+import type { BrowserProbeErrorRecord, BrowserProbeNetworkRecord, BrowserStepAssertion } from "./browser-artifacts.js"
+
+type BrowserObservationAssertionType = "no-console-errors" | "no-page-errors" | "request-count-by-host" | "request-count-by-type"
+type BrowserObservationAssertionOperator = "=" | "==" | "!=" | ">" | ">=" | "<" | "<="
+
+interface BrowserObservationAssertionSpec {
+  raw: string
+  type: BrowserObservationAssertionType
+  name?: string
+  operator?: BrowserObservationAssertionOperator
+  expected?: number
+}
+
+export function executeBrowserObservationAssertion(
+  step: BrowserInteractionStep,
+  consoleMessages: Record<string, unknown>[],
+  pageErrors: BrowserProbeErrorRecord[],
+  network: BrowserProbeNetworkRecord[],
+): BrowserStepAssertion {
+  const spec = parseBrowserObservationAssertion(String(step.assertion ?? ""))
+  const base = {
+    kind: "probe" as const,
+    id: spec.raw,
+    assertion: spec.raw,
+    name: spec.name,
+    state: spec.type,
+    operator: spec.operator,
+    expected: spec.expected,
+  }
+
+  switch (spec.type) {
+    case "no-console-errors": {
+      const actual = consoleMessages.filter((message) => message.type === "error").length
+      return finalizeBrowserObservationAssertion(base, actual, 0, actual === 0, ["files/browser/console.jsonl"])
+    }
+    case "no-page-errors": {
+      const actual = pageErrors.filter((error) => error.type === "pageerror").length
+      return finalizeBrowserObservationAssertion(base, actual, 0, actual === 0, ["files/browser/errors.jsonl"])
+    }
+    case "request-count-by-host": {
+      const actual = network.filter((record) => requestHost(record.url) === spec.name).length
+      return finalizeBrowserObservationAssertion(base, actual, spec.expected, compareNumbers(actual, spec.expected ?? 0, spec.operator ?? "<="), ["files/browser/network.jsonl"])
+    }
+    case "request-count-by-type": {
+      const actual = network.filter((record) => record.resourceType === spec.name).length
+      return finalizeBrowserObservationAssertion(base, actual, spec.expected, compareNumbers(actual, spec.expected ?? 0, spec.operator ?? "<="), ["files/browser/network.jsonl"])
+    }
+  }
+}
+
+function parseBrowserObservationAssertion(rawValue: string): BrowserObservationAssertionSpec {
+  const raw = rawValue.trim()
+  if (raw === "no-console-errors" || raw === "no-page-errors") {
+    return { raw, type: raw }
+  }
+
+  for (const type of ["request-count-by-host", "request-count-by-type"] as const) {
+    const prefix = `${type}:`
+    if (raw.startsWith(prefix)) {
+      const parsed = raw.slice(prefix.length).trim().match(/^(.*?)(>=|<=|==|!=|=|>|<)\s*(\d+)$/)
+      if (!parsed || !parsed[1].trim()) {
+        break
+      }
+      return { raw, type, name: parsed[1].trim(), operator: parsed[2] as BrowserObservationAssertionOperator, expected: Number.parseInt(parsed[3], 10) }
+    }
+  }
+
+  throw new Error(`wordpress.browser-actions assertObservation supports no-console-errors, no-page-errors, request-count-by-host:<host><op><number>, and request-count-by-type:<type><op><number>: ${rawValue}`)
+}
+
+function finalizeBrowserObservationAssertion(
+  base: Omit<BrowserStepAssertion, "passed">,
+  observed: unknown,
+  expectedBudget: unknown,
+  passed: boolean,
+  supportingArtifacts: string[],
+): BrowserStepAssertion {
+  return {
+    ...base,
+    status: passed ? "pass" : "fail",
+    expected: expectedBudget,
+    expectedBudget,
+    actual: observed,
+    observed,
+    supportingArtifacts,
+    passed,
+  }
+}
+
+function requestHost(url: string): string | undefined {
+  try {
+    return new URL(url).host
+  } catch {
+    return undefined
+  }
+}
+
+function compareNumbers(actual: number, expected: number, operator: BrowserObservationAssertionOperator): boolean {
+  switch (operator) {
+    case "=":
+    case "==":
+      return actual === expected
+    case "!=":
+      return actual !== expected
+    case ">":
+      return actual > expected
+    case ">=":
+      return actual >= expected
+    case "<":
+      return actual < expected
+    case "<=":
+      return actual <= expected
+  }
+}

--- a/tests/browser-observation-assertions.test.ts
+++ b/tests/browser-observation-assertions.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+
+import { validateBrowserInteractionScript } from "../packages/runtime-core/src/browser-interaction.js"
+import { executeBrowserObservationAssertion } from "../packages/runtime-playground/src/browser-observation-assertions.js"
+import type { BrowserProbeNetworkRecord } from "../packages/runtime-playground/src/browser-artifacts.js"
+
+const valid = validateBrowserInteractionScript([
+  { kind: "navigate", url: "/" },
+  { kind: "assertObservation", assertion: "request-count-by-host:example.test<=2" },
+  { kind: "assertObservation", assertion: "request-count-by-type:script=1" },
+  { kind: "assertObservation", assertion: "no-page-errors" },
+  { kind: "assertObservation", assertion: "no-console-errors" },
+])
+assert.equal(valid.valid, true)
+assert.equal(valid.issues.length, 0)
+
+const invalid = validateBrowserInteractionScript([
+  { kind: "assertObservation" },
+  { kind: "assertObservation", assertion: "total-transfer-size<=100" },
+])
+assert.equal(invalid.valid, false)
+assert.deepEqual(invalid.issues.map((issue) => issue.message), [
+  "assertObservation step requires assertion",
+  "assertObservation supports no-console-errors, no-page-errors, request-count-by-host:<host><op><number>, and request-count-by-type:<type><op><number>",
+])
+
+const network: BrowserProbeNetworkRecord[] = [
+  { type: "response", url: "https://example.test/app.js", method: "GET", resourceType: "script", timestamp: "2026-06-29T00:00:00.000Z" },
+  { type: "response", url: "https://example.test/style.css", method: "GET", resourceType: "stylesheet", timestamp: "2026-06-29T00:00:00.000Z" },
+  { type: "response", url: "https://cdn.example.test/app.js", method: "GET", resourceType: "script", timestamp: "2026-06-29T00:00:00.000Z" },
+]
+
+assert.deepEqual(executeBrowserObservationAssertion({ kind: "assertObservation", assertion: "request-count-by-host:example.test=2" }, [], [], network), {
+  kind: "probe",
+  id: "request-count-by-host:example.test=2",
+  assertion: "request-count-by-host:example.test=2",
+  name: "example.test",
+  state: "request-count-by-host",
+  operator: "=",
+  expected: 2,
+  status: "pass",
+  expectedBudget: 2,
+  actual: 2,
+  observed: 2,
+  supportingArtifacts: ["files/browser/network.jsonl"],
+  passed: true,
+})
+
+assert.equal(executeBrowserObservationAssertion({ kind: "assertObservation", assertion: "request-count-by-type:script<2" }, [], [], network).passed, false)
+assert.equal(executeBrowserObservationAssertion({ kind: "assertObservation", assertion: "no-console-errors" }, [{ type: "log" }, { type: "error" }], [], network).passed, false)
+assert.equal(executeBrowserObservationAssertion({ kind: "assertObservation", assertion: "no-page-errors" }, [], [{ type: "pageerror", name: "Error", message: "boom", timestamp: "2026-06-29T00:00:00.000Z" }], network).passed, false)
+
+console.log("browser observation assertions ok")


### PR DESCRIPTION
## Summary
- Add a backend-agnostic `assertObservation` browser-actions step kind for generic captured-observation assertions.
- Support `request-count-by-host`, `request-count-by-type`, `no-page-errors`, and `no-console-errors` over existing browser-actions observation streams.
- Record observation assertion outcomes in existing step records and assertion summaries, with failed assertions failing `wordpress.browser-actions`.
- Update recipe contract docs and add focused schema/evaluator tests.

## Tests
- `npm run test:browser-observation-assertions`
- `npm run test:recipe-validation-descriptors`
- `npm run build`

## Residual risks
- `npm run test:docs-boundary-language` fails on existing public-doc boundary language in `README.md` matching `/agents-api\/[a-z0-9._/-]+/i`; this PR does not edit that content.
- No live browser test was added; the new primitive is covered at schema validation and in-memory assertion evaluation layers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the browser-actions observation assertion primitive, docs, tests, and verification workflow.
