### PR TITLE
Add browser callTool verifier contract

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -482,6 +482,29 @@ and the redaction flag.
 }
 ```
 
+Browser interaction scripts support a generic `callTool` verifier step shape for
+caller-owned external checks:
+
+```json
+{
+  "kind": "callTool",
+  "tool": "client/check_status",
+  "input": { "url": "https://example.test/status", "expected": "ready" }
+}
+```
+
+`tool` is the exact caller-provided host tool command name and must be allowed by
+runtime policy using that same command name. `input` must be JSON-serializable.
+WP Codebox treats this as transport and evidence only; callers own the tool and
+any external system behavior. The current Playground browser-actions runtime
+validates and policy-checks `callTool`, then records a redaction-required
+`wp-codebox/browser-tool-verifier-result/v1` artifact with input shape metadata
+and an `unsupported` status because the host-tool execution bridge is not yet
+available inside browser automation. Raw input values and secrets are not
+serialized into that verifier artifact. Polling fields are intentionally not part
+of this narrow primitive yet; callers should model repeated checks outside the
+browser script until the execution bridge lands.
+
 ## Fixture Browser Auth Storage State
 
 Hosts that need an authenticated browser session for a disposable WordPress

--- a/packages/runtime-core/src/browser-interaction.ts
+++ b/packages/runtime-core/src/browser-interaction.ts
@@ -1,6 +1,8 @@
 import { isPlainObject } from "./object-utils.js"
+import type { JsonValue } from "./host-tool-registry.js"
 
 export const BROWSER_INTERACTION_SCRIPT_SCHEMA = "wp-codebox/browser-interaction-script/v1" as const
+export const BROWSER_TOOL_VERIFIER_RESULT_SCHEMA = "wp-codebox/browser-tool-verifier-result/v1" as const
 
 /**
  * Backend-agnostic browser interaction step contract (issue #310).
@@ -27,6 +29,7 @@ export const BROWSER_INTERACTION_STEP_KINDS = [
   "assertObservation",
   "screenshot",
   "capture",
+  "callTool",
 ] as const
 
 export type BrowserInteractionStepKind = typeof BROWSER_INTERACTION_STEP_KINDS[number]
@@ -85,6 +88,33 @@ export interface BrowserInteractionStep {
   duration?: string
   /** Per-step timeout override (e.g. 5s). */
   timeout?: string
+  /** Caller-provided host tool command name for `callTool`. */
+  tool?: string
+  /** JSON input passed to the caller-provided host tool. */
+  input?: JsonValue
+}
+
+export interface BrowserToolVerifierInputSummary {
+  type: "null" | "boolean" | "number" | "string" | "array" | "object"
+  keys?: string[]
+  itemCount?: number
+}
+
+export interface BrowserToolVerifierResult {
+  schema: typeof BROWSER_TOOL_VERIFIER_RESULT_SCHEMA
+  status: "unsupported" | "ok" | "error"
+  step: { index: number; kind: "callTool"; tool: string }
+  tool: string
+  inputSummary: BrowserToolVerifierInputSummary
+  result?: JsonValue
+  error?: { code: string; message: string }
+  evidence: {
+    redaction: { policy: "required"; sensitive: true; reason: string }
+    rawInputSerialized: false
+    rawSecretsSerialized: false
+  }
+  startedAt: string
+  finishedAt: string
 }
 
 export interface BrowserRandomWalkContract {
@@ -125,6 +155,19 @@ function isBrowserInteractionDragTarget(value: unknown): value is BrowserInterac
   if (!isPlainObject(value)) return false
   if (typeof value.selector === "string" && value.selector.length > 0) return true
   return typeof value.x === "number" && typeof value.y === "number"
+}
+
+export function browserToolVerifierInputSummary(input: JsonValue): BrowserToolVerifierInputSummary {
+  if (input === null) return { type: "null" }
+  if (Array.isArray(input)) return { type: "array", itemCount: input.length }
+  if (typeof input === "object") return { type: "object", keys: Object.keys(input).sort() }
+  return { type: inputType(input) }
+}
+
+function inputType(input: string | number | boolean): "string" | "number" | "boolean" {
+  if (typeof input === "string") return "string"
+  if (typeof input === "number") return "number"
+  return "boolean"
 }
 
 /**
@@ -218,6 +261,16 @@ export function validateBrowserInteractionScript(input: unknown): BrowserInterac
       case "screenshot":
       case "capture":
         break
+      case "callTool":
+        if (typeof step.tool !== "string" || !/^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/i.test(step.tool)) {
+          issues.push({ index, message: "callTool step requires tool as a stable canonical tool id such as client/search_docs" })
+        }
+        if (!Object.prototype.hasOwnProperty.call(step, "input")) {
+          issues.push({ index, message: "callTool step requires input" })
+        } else if (!isJsonValue(step.input)) {
+          issues.push({ index, message: "callTool step input must be JSON-serializable" })
+        }
+        break
     }
 
     steps.push(step)
@@ -237,6 +290,24 @@ function isBrowserInteractionObservationAssertion(raw: string): boolean {
   if (value.startsWith("request-count-by-host:")) return /^.+(>=|<=|==|!=|=|>|<)\s*\d+$/.test(value.slice("request-count-by-host:".length).trim())
   if (value.startsWith("request-count-by-type:")) return /^.+(>=|<=|==|!=|=|>|<)\s*\d+$/.test(value.slice("request-count-by-type:".length).trim())
   return false
+}
+
+/** Exact caller-provided tool command names referenced by `callTool` steps. */
+export function browserInteractionScriptToolCalls(steps: readonly BrowserInteractionStep[]): string[] {
+  return [...new Set(steps.filter((step) => step.kind === "callTool" && typeof step.tool === "string").map((step) => step.tool as string))].sort()
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    return Number.isFinite(value as number) || typeof value !== "number"
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue)
+  }
+  if (!isPlainObject(value)) {
+    return false
+  }
+  return Object.values(value).every(isJsonValue)
 }
 
 export function browserRandomWalkContract(input: Record<string, unknown>): BrowserRandomWalkContract {

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises"
-import { assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, assertRuntimeCommandAllowed, browserInteractionScriptToolCalls, browserInteractionScriptUsesEvaluate, browserToolVerifierInputSummary, resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep, type BrowserToolVerifierResult, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
@@ -79,6 +79,9 @@ export async function runBrowserActionsCommand({
   if (browserInteractionScriptUsesEvaluate(steps)) {
     assertRuntimeCommandAllowed("wordpress.browser-actions.evaluate", runtimeSpec.policy)
   }
+  for (const tool of browserInteractionScriptToolCalls(steps)) {
+    assertRuntimeCommandAllowed(tool, runtimeSpec.policy)
+  }
 
   const capture = runPlan.capture
 
@@ -117,6 +120,7 @@ export async function runBrowserActionsCommand({
   let htmlSha256: string | undefined
   let screenshotSha256: string | undefined
   const domSnapshots: Array<{ screenshot: string; snapshot: string; step?: { index: number; name?: string; kind: string }; elementCount: number; capturedElements: number; truncated: boolean }> = []
+  const verifierResults: NonNullable<BrowserArtifact["summary"]["verifierResults"]> = []
   let viewport: BrowserProbeViewport | null = null
   let authSummary: BrowserProbeAuthSummary | undefined
   let pendingError: Error | undefined
@@ -177,6 +181,18 @@ export async function runBrowserActionsCommand({
         break
       }
       try {
+        if (step.kind === "callTool") {
+          const result = browserToolVerifierUnsupportedResult(step, index, recordStartedAt)
+          const fileName = `verifier-step-${index}.json`
+          await artifactSession.writeJson("verifierResults", fileName, result)
+          const artifactPath = artifactSession.path(fileName)
+          verifierResults.push({ step: result.step, status: result.status, artifact: artifactPath })
+          const serialized = serializeBrowserError("probe-error", new Error(result.error?.message ?? "wordpress.browser-actions callTool is unsupported"))
+          errors.push(serialized)
+          stepRecords.push(browserStepRecord(index, step, "failed", recordStartedAt, recordStartedAtMs, page.url(), { verifierResult: artifactPath, error: serialized }))
+          pendingError = new Error(result.error?.message ?? "wordpress.browser-actions callTool is unsupported")
+          break
+        }
         const outcome = step.kind === "assertObservation"
           ? { assertion: executeBrowserObservationAssertion(step, consoleMessages, errors, network) }
           : await withBrowserCommandLiveness({
@@ -323,6 +339,7 @@ export async function runBrowserActionsCommand({
         ...(redirectDiagnostics ? { redirectDiagnostics: "files/browser/redirect-diagnostics.json" } : {}),
         ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots: domSnapshots.map((snapshot) => snapshot.snapshot) } : {}),
+        ...(verifierResults.length > 0 ? { verifierResults: verifierResults.map((result) => result.artifact) } : {}),
         ...(wordpressDiagnostics ? { wordpressDiagnostics: "files/browser/wordpress-diagnostics.json" } : {}),
         summary: "files/browser/action-summary.json",
       },
@@ -337,6 +354,7 @@ export async function runBrowserActionsCommand({
         ...(server.previewProxyDiagnostics ? { previewProxy: server.previewProxyDiagnostics } : {}),
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots } : {}),
+        ...(verifierResults.length > 0 ? { verifierResults } : {}),
         liveness: { wallTimeoutMs: totalTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
         networkEvents: network.length,
         ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
@@ -371,6 +389,7 @@ export async function runBrowserActionsCommand({
       },
       ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
       ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
+      ...(verifierResults.length > 0 ? { verifierResults } : {}),
       viewport,
       summary: artifact.summary,
     })
@@ -398,6 +417,32 @@ export async function runBrowserActionsCommand({
       summary: artifact.summary,
       steps: stepRecords,
     }, null, 2)}\n`,
+  }
+}
+
+export function browserToolVerifierUnsupportedResult(step: BrowserInteractionStep, index: number, startedAt: string): BrowserToolVerifierResult {
+  const tool = typeof step.tool === "string" ? step.tool : "unknown/unknown"
+  return {
+    schema: BROWSER_TOOL_VERIFIER_RESULT_SCHEMA,
+    status: "unsupported",
+    step: { index, kind: "callTool", tool },
+    tool,
+    inputSummary: browserToolVerifierInputSummary(step.input ?? null),
+    error: {
+      code: "browser-call-tool-bridge-unavailable",
+      message: "wordpress.browser-actions validated a callTool step, but this runtime does not yet expose a host-tool execution bridge inside browser automation.",
+    },
+    evidence: {
+      redaction: {
+        policy: "required",
+        sensitive: true,
+        reason: "Browser verifier artifacts can include caller tool names, input shapes, URLs, page state, or external verification diagnostics.",
+      },
+      rawInputSerialized: false,
+      rawSecretsSerialized: false,
+    },
+    startedAt,
+    finishedAt: now(),
   }
 }
 

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -80,6 +80,7 @@ export interface BrowserArtifactFiles {
   review?: string
   screenshot?: string
   domSnapshots?: string[]
+  verifierResults?: string[]
   sourceScreenshot?: string | string[]
   candidateScreenshot?: string | string[]
   diffScreenshot?: string | string[]
@@ -146,6 +147,11 @@ export interface BrowserArtifactSummary {
     elementCount: number
     capturedElements: number
     truncated: boolean
+  }>
+  verifierResults?: Array<{
+    step: { index: number; kind: "callTool"; tool: string }
+    status: "unsupported" | "ok" | "error"
+    artifact: string
   }>
   networkPolicy?: BrowserProbeNetworkPolicySummary
   previewProxy?: PlaygroundPreviewProxyDiagnostics
@@ -765,6 +771,7 @@ export interface BrowserStepRecord {
   target?: BrowserStepScreenshotTarget
   screenshot?: string
   screenshotFallback?: BrowserStepScreenshotFallback
+  verifierResult?: string
   finalUrl?: string
   error?: BrowserProbeErrorRecord
 }
@@ -1017,6 +1024,7 @@ const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, Browser
   review: { kind: "browser-review", contentType: "application/json", redact: true },
   screenshot: { kind: "browser-screenshot", contentType: "image/png", redact: false },
   domSnapshots: { kind: "browser-dom-snapshot", contentType: "application/json", redact: true },
+  verifierResults: { kind: "browser-verifier-result", contentType: "application/json", redact: true },
   sourceScreenshot: { kind: "browser-visual-source-screenshot", contentType: "image/png", redact: false },
   candidateScreenshot: { kind: "browser-visual-candidate-screenshot", contentType: "image/png", redact: false },
   diffScreenshot: { kind: "browser-visual-diff-screenshot", contentType: "image/png", redact: false },

--- a/packages/runtime-playground/src/browser-interactions.ts
+++ b/packages/runtime-playground/src/browser-interactions.ts
@@ -12,6 +12,7 @@ export interface BrowserStepOutcome {
   screenshot?: string
   screenshotIsDefault?: boolean
   screenshotFallback?: { reason: string; mode: "page-screenshot" }
+  verifierResult?: string
   error?: BrowserProbeErrorRecord
 }
 
@@ -155,6 +156,8 @@ export async function executeBrowserInteractionStep(
     }
     case "capture":
       return {}
+    case "callTool":
+      throw new Error("wordpress.browser-actions callTool requires the host-tool execution bridge, which is not available in this browser step executor")
   }
 
   throw new Error(`wordpress.browser-actions step kind is not supported: ${step.kind}`)
@@ -380,6 +383,7 @@ export function browserStepRecord(
     ...(outcome.target ? { target: outcome.target } : {}),
     ...(outcome.screenshot ? { screenshot: outcome.screenshot } : {}),
     ...(outcome.screenshotFallback ? { screenshotFallback: outcome.screenshotFallback } : {}),
+    ...(outcome.verifierResult ? { verifierResult: outcome.verifierResult } : {}),
     finalUrl,
     ...(outcome.error ? { error: outcome.error } : {}),
   }

--- a/tests/browser-interaction-tool-verifier.test.ts
+++ b/tests/browser-interaction-tool-verifier.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict"
+
+import { BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, browserInteractionScriptToolCalls, validateBrowserInteractionScript } from "../packages/runtime-core/src/index.js"
+import { browserArtifactFileManifest } from "../packages/runtime-playground/src/browser-artifacts.js"
+import { browserToolVerifierUnsupportedResult } from "../packages/runtime-playground/src/browser-actions-runner.js"
+
+const valid = validateBrowserInteractionScript([
+  { kind: "navigate", url: "/" },
+  { kind: "callTool", tool: "client/check_status", input: { url: "https://example.test/?token=secret", expected: "ready" } },
+])
+
+assert.equal(valid.valid, true)
+assert.deepEqual(browserInteractionScriptToolCalls(valid.steps), ["client/check_status"])
+
+const missingInput = validateBrowserInteractionScript([{ kind: "callTool", tool: "client/check_status" }])
+assert.equal(missingInput.valid, false)
+assert.match(missingInput.issues[0]?.message ?? "", /requires input/)
+
+const invalidTool = validateBrowserInteractionScript([{ kind: "callTool", tool: "check-status", input: {} }])
+assert.equal(invalidTool.valid, false)
+assert.match(invalidTool.issues[0]?.message ?? "", /stable canonical tool id/)
+
+const unsupported = browserToolVerifierUnsupportedResult(valid.steps[1]!, 1, "2026-01-01T00:00:00.000Z")
+assert.equal(unsupported.schema, BROWSER_TOOL_VERIFIER_RESULT_SCHEMA)
+assert.equal(unsupported.status, "unsupported")
+assert.equal(unsupported.tool, "client/check_status")
+assert.equal(unsupported.inputSummary.type, "object")
+assert.deepEqual(unsupported.inputSummary.keys, ["expected", "url"])
+assert.equal(Object.prototype.hasOwnProperty.call(unsupported, "input"), false)
+assert.equal(unsupported.evidence.rawInputSerialized, false)
+assert.equal(unsupported.evidence.rawSecretsSerialized, false)
+assert.equal(unsupported.error?.code, "browser-call-tool-bridge-unavailable")
+
+const manifest = browserArtifactFileManifest("verifierResults")
+assert.equal(manifest.kind, "browser-verifier-result")
+assert.equal(manifest.contentType, "application/json")
+assert.equal(manifest.redaction?.policy, "required")
+assert.equal(manifest.redaction?.sensitive, true)


### PR DESCRIPTION
## Summary
- Add a generic `callTool` browser interaction step contract with canonical tool name and JSON input validation.
- Policy-check referenced tool command names exactly, then emit a redaction-required unsupported verifier artifact while the browser host-tool bridge is unavailable.
- Document the narrow primitive and add focused validation/evidence tests.

## Tests
- `npm run build`
- `npx tsx tests/browser-interaction-tool-verifier.test.ts`
- `npm run test:host-command-executor`
- `npm run test:recipe-validation-descriptors`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the browser `callTool` verifier contract, unsupported evidence artifact plumbing, tests, and docs.