### PR TITLE
Add external service boundary recipe contract

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -83,6 +83,7 @@ top-level fields:
 - `dependency_overlays`
 - `runtimeEnv`
 - `secretEnv`
+- `externalServices`
 - `pluginRuntime`
 - `fixtureDatabases`
 - `fixtureUsers`
@@ -103,6 +104,47 @@ imports.
 Use `inputs.workspace_preloads` for generic `agent-runtime/workspace-preload`
 artifact contracts. WP Codebox materializes declared repositories as sandbox
 workspace mounts; callers own the policy that decides which artifacts to pass.
+
+## External Service Boundaries
+
+Use `inputs.externalServices` to declare reviewer-safe boundaries for services a
+recipe may observe while collecting browser or runtime evidence. The primitive is
+product-neutral: it names the boundary, classifies the environment, declares host
+sets, records the write policy, and lists secret environment variable names
+without serializing secret values.
+
+```json
+{
+  "inputs": {
+    "externalServices": [
+      {
+        "id": "checkout-staging",
+        "label": "Checkout staging API",
+        "environment": "staging",
+        "allowedHosts": ["api.example.test"],
+        "blockedHosts": ["api.example.com"],
+        "writes": "record-only",
+        "secretEnv": ["CHECKOUT_API_TOKEN"],
+        "redaction": {
+          "policy": "redact-fields",
+          "fields": ["authorization", "set-cookie"]
+        }
+      }
+    ]
+  }
+}
+```
+
+Supported `environment` values are `local`, `fixture`, `staging`, `production`,
+and `external`. Supported `writes` values are `forbidden`, `record-only`, and
+`allowed-with-approval`. Supported redaction policies are `metadata-only`,
+`redact-fields`, and `omit`.
+
+Dry-run plans, run attestations, failure diagnostics, and browser evidence expose
+only the declared boundary metadata and secret env names. When browser evidence
+contains network-policy host observations, WP Codebox adds a safe correlation
+summary from observed hosts to declared boundary ids where host names match
+`allowedHosts` or `blockedHosts`.
 
 ## Extra Plugins
 

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -1,6 +1,7 @@
 import type { AgentTerminalResult, ArtifactBundle, BenchResults, ExecutionResult, PreviewLease, RecipeRunSummary, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef, WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
 import type { RecipeDryRunOutput, RecipeDryRunSiteSeed, RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import type { AgentSandboxResultSummary, AgentTaskSingleResult, RecipeReplayStatusSummary, SandboxCompletionOutcome } from "../recipe-evidence.js"
+import type { RecipeExternalServiceBoundaryHostCorrelation } from "../recipe-external-services.js"
 import type { RecipeValidationIssue, RecipeWorkflowPhase } from "../recipe-validation.js"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 
@@ -201,6 +202,7 @@ export interface RecipeBrowserEvidence {
   summaryFile?: RecipeBrowserEvidenceFileRef
   files: Record<string, RecipeBrowserEvidenceFileRef | RecipeBrowserEvidenceFileRef[]>
   summary?: unknown
+  externalServiceBoundaries?: RecipeExternalServiceBoundaryHostCorrelation
   scriptResult?: unknown
 }
 

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { commandArgValue, parseCommandJson, parseCommandJsonObject, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, runFuzzSuite, runtimeCheckpointUnsupportedDiagnostic, type ArtifactBundle, type ArtifactManifestFile, type ExecutionResult, type FuzzSuiteContract, type Runtime, type RuntimeCheckpointFailureDiagnostic, type RuntimeCheckpointOperation, type RuntimeCheckpointResult, type WorkspaceRecipe, type WorkspaceRecipeDistributionSetupArtifact, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeProbe } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
+import { correlateObservedHostsToExternalServiceBoundaries, recipeExternalServiceBoundarySummaries } from "../recipe-external-services.js"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { recipeWorkflowSteps, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -34,12 +35,12 @@ export function recipeAdvisoryFailure(workflowStep: ReturnType<typeof recipeWork
   }
 }
 
-export async function recipeBrowserEvidence(artifacts: ArtifactBundle, executions: RecipeExecutionResult[]): Promise<RecipeBrowserEvidence[]> {
+export async function recipeBrowserEvidence(artifacts: ArtifactBundle, executions: RecipeExecutionResult[], recipe?: WorkspaceRecipe): Promise<RecipeBrowserEvidence[]> {
   const manifestFiles = await artifactManifestFilesByPath(artifacts)
-  return executions.flatMap((execution) => recipeBrowserEvidenceForExecution(execution, manifestFiles))
+  return executions.flatMap((execution) => recipeBrowserEvidenceForExecution(execution, manifestFiles, recipe))
 }
 
-function recipeBrowserEvidenceForExecution(execution: RecipeExecutionResult, manifestFiles: Map<string, ArtifactManifestFile>): RecipeBrowserEvidence[] {
+function recipeBrowserEvidenceForExecution(execution: RecipeExecutionResult, manifestFiles: Map<string, ArtifactManifestFile>, recipe: WorkspaceRecipe | undefined): RecipeBrowserEvidence[] {
   const command = execution.recipeCommand ?? execution.command
   if (!recipeCommandProducesBrowserEvidence(command)) {
     return []
@@ -52,16 +53,16 @@ function recipeBrowserEvidenceForExecution(execution: RecipeExecutionResult, man
 
   if (Array.isArray(parsed.profiles)) {
     return parsed.profiles.flatMap((profile) => {
-      const profileEvidence = recipeBrowserEvidenceFromParsedExecution(execution, command, profile, manifestFiles)
+      const profileEvidence = recipeBrowserEvidenceFromParsedExecution(execution, command, profile, manifestFiles, recipe)
       return profileEvidence ? [profileEvidence] : []
     })
   }
 
-  const evidence = recipeBrowserEvidenceFromParsedExecution(execution, command, parsed, manifestFiles)
+  const evidence = recipeBrowserEvidenceFromParsedExecution(execution, command, parsed, manifestFiles, recipe)
   return evidence ? [evidence] : []
 }
 
-function recipeBrowserEvidenceFromParsedExecution(execution: RecipeExecutionResult, command: string, parsed: Record<string, unknown>, manifestFiles: Map<string, ArtifactManifestFile>): RecipeBrowserEvidence | undefined {
+function recipeBrowserEvidenceFromParsedExecution(execution: RecipeExecutionResult, command: string, parsed: Record<string, unknown>, manifestFiles: Map<string, ArtifactManifestFile>, recipe: WorkspaceRecipe | undefined): RecipeBrowserEvidence | undefined {
   const files = recipeBrowserEvidenceFiles(parsed.files, manifestFiles)
   const summaryFile = browserEvidenceFileRef(stringValue((parsed.files as Record<string, unknown> | undefined)?.summary), manifestFiles)
   if (Object.keys(files).length === 0 && !summaryFile) {
@@ -70,6 +71,9 @@ function recipeBrowserEvidenceFromParsedExecution(execution: RecipeExecutionResu
 
   const summary = parsed.summary
   const summaryObject = isRecord(summary) ? summary : undefined
+  const networkPolicy = isRecord(summaryObject?.networkPolicy) ? summaryObject.networkPolicy : isRecord(parsed.networkPolicy) ? parsed.networkPolicy : undefined
+  const observedHosts = isRecord(networkPolicy?.hosts) ? networkPolicy.hosts : undefined
+  const externalServiceBoundaries = recipe ? correlateObservedHostsToExternalServiceBoundaries(observedHosts, recipeExternalServiceBoundarySummaries(recipe)) : undefined
   return stripUndefined({
     schema: "wp-codebox/recipe-browser-evidence/v1",
     phase: execution.recipePhase,
@@ -81,6 +85,7 @@ function recipeBrowserEvidenceFromParsedExecution(execution: RecipeExecutionResu
     summaryFile,
     files,
     summary,
+    externalServiceBoundaries,
     scriptResult: summaryObject?.scriptResult,
   }) as RecipeBrowserEvidence
 }

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -8,6 +8,7 @@ import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, 
 import { parsePreviewBind, parsePreviewHoldSeconds, parsePreviewLease, parsePreviewPort, parsePreviewPublicUrl } from "../preview-options.js"
 import { dryRunRecipe, planWorkspaceRecipe, recipeDryRunSiteSeeds } from "../recipe-dry-run.js"
 import { appendRecipeRuntimeEvidence, collectAndFinalizeFailedRecipeArtifacts, collectRecipeRuntimeArtifacts, finalizeAgentSandboxEvidence, finalizeRecipeArtifactEvidence, recipeAgentResultFailure, recipeArtifactEvidenceFailure, recipeReplayStatusOutput, recipeVerifyStepFailure } from "../recipe-evidence.js"
+import { recipeExternalServiceBoundarySummaries } from "../recipe-external-services.js"
 import { resolveRecipeSecretEnv } from "../recipe-secret-env.js"
 import type { PreparedRuntimeBackendPackage } from "../recipe-backend-package.js"
 import { cleanupRecipePreparedSources, recipeBlueprintWithBootActivePlugins, recipeExtraPlugins, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
@@ -272,7 +273,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       await awaitRecipe("runtime.observe:mounts", runtime!.observe({ type: "mounts" }))
       runRecord = await runRegistry.update(runRecord.runId, { status: "collecting_artifacts", runtime: await runtime!.info() })
       artifacts = await awaitRecipe("runtime.collect-artifacts", collectRecipeRuntimeArtifacts(runtime!, { includeLogs: true, includeObservations: true }, { snapshotTimeoutMs: SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS }))
-      browserEvidence = await recipeBrowserEvidence(artifacts, executions)
+      browserEvidence = await recipeBrowserEvidence(artifacts, executions, recipe)
       await artifactPointer.update({ runtime: await runtime!.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
       await appendRecipeRuntimeEvidence(artifacts, recipeRuntimeEvidenceFiles(fixtureDatabases, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts))
@@ -295,7 +296,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const successfulRecipe = !recipeFailure
     if (successfulRecipe && options.previewHoldSeconds) {
       artifacts = await awaitRecipe("runtime.collect-artifacts.preview-hold", collectRecipeRuntimeArtifacts(runtime, { includeLogs: true, includeObservations: true, previewHoldSeconds: options.previewHoldSeconds }, { snapshotTimeoutMs: SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS }))
-      browserEvidence = await recipeBrowserEvidence(artifacts, executions)
+      browserEvidence = await recipeBrowserEvidence(artifacts, executions, recipe)
       await artifactPointer.update({ runtime: await runtime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
       declaredArtifacts = await collectRecipeDeclaredArtifacts(recipe, runtime)
       await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
@@ -413,7 +414,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       }))
       if (artifacts) {
         const collectedArtifacts = artifacts
-        browserEvidence = await recipeBrowserEvidence(artifacts, executions)
+        browserEvidence = await recipeBrowserEvidence(artifacts, executions, recipe)
         await artifactPointer.update({ runtime: await activeRuntime.info(), artifacts, phases: phaseTracker.list(), browserEvidence })
         try {
           if (declaredArtifacts.length === 0) {
@@ -774,6 +775,7 @@ function recipeFailureRuntimeEvidenceFile(args: {
           workspaces: args.workspaceMounts.map((workspace) => ({ target: workspace.target, mode: workspace.mode, metadata: workspace.metadata })),
           stagedFiles: args.stagedFiles.map(recipeRunStagedFile),
           secretEnv: args.recipe.inputs?.secretEnv ?? [],
+          externalServices: recipeExternalServiceBoundarySummaries(args.recipe),
         },
         artifacts: args.recipe.artifacts ?? {},
       },
@@ -1165,6 +1167,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         stagedFiles: recipe.inputs?.stagedFiles ?? [],
         stagedFileProvenance,
         secretEnv: recipe.inputs?.secretEnv ?? [],
+        externalServices: recipeExternalServiceBoundarySummaries(recipe),
         inherit: recipe.inputs?.inherit ?? {},
         inheritance: recipe.inputs?.inheritance ?? {},
       },
@@ -1195,6 +1198,7 @@ function recipeRunMetadata(recipe: WorkspaceRecipe, recipePath: string, workspac
         stagedFiles: recipe.inputs?.stagedFiles ?? [],
         stagedFileProvenance,
         secretEnv: recipe.inputs?.secretEnv ?? [],
+        externalServices: recipeExternalServiceBoundarySummaries(recipe),
         inherit: recipe.inputs?.inherit ?? {},
         inheritance: recipe.inputs?.inheritance ?? {},
       },

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -3,6 +3,7 @@ import { fixtureImportDeterministicIdPlan, normalizeRuntimeBackendKind, validate
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { serializeError } from "./output.js"
 import { resolveRecipeSecretEnv, type RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
+import { recipeExternalServiceBoundarySummaries, type RecipeExternalServiceBoundarySummary } from "./recipe-external-services.js"
 import { composerPackageVendorPath, defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
 import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
 import { runtimeOverlayTarget } from "./runtime-overlay-registry.js"
@@ -65,6 +66,7 @@ export interface RecipePlan {
   fixtureDatabases: RecipeDryRunFixtureDatabase[]
   siteSeeds: RecipeDryRunSiteSeed[]
   stagedFiles: RecipeDryRunStagedFile[]
+  externalServices: RecipeExternalServiceBoundarySummary[]
   probes: RecipeDryRunProbe[]
   secretEnv: Array<{ name: string; available: boolean; status: RecipeSecretEnvSummaryEntry["status"]; source?: string }>
   policy: RuntimePolicy & {
@@ -432,6 +434,7 @@ export async function planWorkspaceRecipe(recipe: WorkspaceRecipe, recipeDirecto
     fixtureDatabases,
     siteSeeds,
     stagedFiles,
+    externalServices: recipeExternalServiceBoundarySummaries(recipe),
     probes,
     secretEnv: secretEnvSummary.map(recipeDryRunSecretEnvEntry),
     policy: {

--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CAPTURED_ARTIFACT_MAX_BYTES, DEFAULT_WORDPRESS_VERSION, STRUCTU
 import { verifyArtifactBundle, type ArtifactBundleVerificationResult } from "@automattic/wp-codebox-core/artifacts"
 import { isPlainObject as isRecord, sha256StableJson, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import type { RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
+import { recipeExternalServiceBoundarySummaries, type RecipeExternalServiceBoundarySummary } from "./recipe-external-services.js"
 
 export interface RecipeArtifactEvidenceFile {
   path: string
@@ -227,6 +228,11 @@ export interface RecipeRunAttestation {
     count: number
     secrets: Array<{ name: string; status: RecipeSecretEnvSummaryEntry["status"]; source?: string }>
     redaction: "names-only"
+  }
+  externalServices: {
+    schema: "wp-codebox/external-service-boundaries-attestation/v1"
+    boundaries: RecipeExternalServiceBoundarySummary[]
+    redaction: "secret-env-names-only"
   }
   evidenceRefs: {
     workspacePolicyResult?: RunAttestationEvidenceRef
@@ -1315,6 +1321,11 @@ async function buildRecipeRunAttestation(args: {
       count: args.secretEnv.filter((entry) => entry.status === "available").length,
       secrets: [...args.secretEnv].sort((a, b) => a.name.localeCompare(b.name)),
       redaction: "names-only",
+    },
+    externalServices: {
+      schema: "wp-codebox/external-service-boundaries-attestation/v1",
+      boundaries: recipeExternalServiceBoundarySummaries(args.recipe),
+      redaction: "secret-env-names-only",
     },
     evidenceRefs: stripUndefined({
       workspacePolicyResult: workspacePolicyRef,

--- a/packages/cli/src/recipe-external-services.ts
+++ b/packages/cli/src/recipe-external-services.ts
@@ -1,0 +1,93 @@
+import type { WorkspaceRecipe, WorkspaceRecipeExternalServiceBoundary } from "@automattic/wp-codebox-core"
+import { stripUndefined } from "@automattic/wp-codebox-core/internals"
+
+export interface RecipeExternalServiceBoundarySummary {
+  schema: "wp-codebox/external-service-boundary-summary/v1"
+  id: string
+  label?: string
+  environment: WorkspaceRecipeExternalServiceBoundary["environment"]
+  allowedHosts: string[]
+  blockedHosts: string[]
+  writes: WorkspaceRecipeExternalServiceBoundary["writes"]
+  secretEnv: string[]
+  redaction: {
+    policy: NonNullable<WorkspaceRecipeExternalServiceBoundary["redaction"]>["policy"]
+    fields: string[]
+  }
+}
+
+export interface RecipeExternalServiceBoundaryHostCorrelation {
+  schema: "wp-codebox/external-service-boundary-host-correlation/v1"
+  observedHosts: Array<{
+    host: string
+    boundaryIds: string[]
+    requests?: number
+    external?: boolean
+    blocked?: number
+    routed?: number
+  }>
+  unmatchedHosts: string[]
+}
+
+export function recipeExternalServiceBoundarySummaries(recipe: WorkspaceRecipe): RecipeExternalServiceBoundarySummary[] {
+  return (recipe.inputs?.externalServices ?? []).map((boundary) => stripUndefined({
+    schema: "wp-codebox/external-service-boundary-summary/v1" as const,
+    id: boundary.id,
+    label: boundary.label,
+    environment: boundary.environment,
+    allowedHosts: [...(boundary.allowedHosts ?? [])].map(normalizeHost).filter(Boolean).sort(),
+    blockedHosts: [...(boundary.blockedHosts ?? [])].map(normalizeHost).filter(Boolean).sort(),
+    writes: boundary.writes,
+    secretEnv: [...(boundary.secretEnv ?? [])].sort(),
+    redaction: {
+      policy: boundary.redaction?.policy ?? "metadata-only",
+      fields: [...(boundary.redaction?.fields ?? [])].sort(),
+    },
+  }))
+}
+
+export function correlateObservedHostsToExternalServiceBoundaries(observedHosts: Record<string, unknown> | undefined, boundaries: RecipeExternalServiceBoundarySummary[]): RecipeExternalServiceBoundaryHostCorrelation | undefined {
+  if (!observedHosts || boundaries.length === 0) {
+    return undefined
+  }
+
+  const observed = Object.entries(observedHosts).map(([host, value]) => {
+    const normalized = normalizeHost(host)
+    const stat = recordValue(value)
+    const boundaryIds = boundaries
+      .filter((boundary) => boundary.allowedHosts.includes(normalized) || boundary.blockedHosts.includes(normalized))
+      .map((boundary) => boundary.id)
+      .sort()
+    return stripUndefined({
+      host: normalized,
+      boundaryIds,
+      requests: numberValue(stat?.requests),
+      external: typeof stat?.external === "boolean" ? stat.external : undefined,
+      blocked: numberValue(stat?.blocked),
+      routed: numberValue(stat?.routed),
+    })
+  }).filter((entry) => entry.host !== "")
+    .sort((left, right) => left.host.localeCompare(right.host))
+
+  if (observed.length === 0) {
+    return undefined
+  }
+
+  return {
+    schema: "wp-codebox/external-service-boundary-host-correlation/v1",
+    observedHosts: observed,
+    unmatchedHosts: observed.filter((entry) => entry.boundaryIds.length === 0).map((entry) => entry.host),
+  }
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/\/.*$/, "").replace(/:\d+$/, "")
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -605,6 +605,8 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
     }
   }
 
+  validateRecipeExternalServiceBoundaries(recipe, addIssue)
+
   for (const [name, value] of Object.entries(recipe.inputs?.runtimeEnv ?? {})) {
     if (!/^[A-Z_][A-Z0-9_]*$/.test(name)) {
       addIssue("invalid-runtime-env", `$.inputs.runtimeEnv.${name}`, `Runtime environment variable names must match /^[A-Z_][A-Z0-9_]*$/: ${name}`)
@@ -637,6 +639,32 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
   }
 
   return issues
+}
+
+function validateRecipeExternalServiceBoundaries(recipe: WorkspaceRecipe, addIssue: (code: string, path: string, message: string) => void): void {
+  const seenIds = new Set<string>()
+  for (const [index, boundary] of (recipe.inputs?.externalServices ?? []).entries()) {
+    const path = `$.inputs.externalServices[${index}]`
+    if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(boundary.id)) {
+      addIssue("invalid-external-service-id", `${path}.id`, `External service boundary ids must be stable identifiers: ${boundary.id}`)
+    }
+    if (seenIds.has(boundary.id)) {
+      addIssue("duplicate-external-service-id", `${path}.id`, `External service boundary ids must be unique: ${boundary.id}`)
+    }
+    seenIds.add(boundary.id)
+
+    for (const [hostIndex, host] of [...(boundary.allowedHosts ?? []), ...(boundary.blockedHosts ?? [])].entries()) {
+      if (!/^[a-z0-9.-]+(?::\d+)?$/i.test(host)) {
+        addIssue("invalid-external-service-host", `${path}.${hostIndex < (boundary.allowedHosts ?? []).length ? "allowedHosts" : "blockedHosts"}[${hostIndex < (boundary.allowedHosts ?? []).length ? hostIndex : hostIndex - (boundary.allowedHosts ?? []).length}]`, `External service hosts must be hostnames with optional ports: ${host}`)
+      }
+    }
+
+    for (const [secretIndex, name] of (boundary.secretEnv ?? []).entries()) {
+      if (!/^[A-Z_][A-Z0-9_]*$/.test(name)) {
+        addIssue("invalid-external-service-secret-env", `${path}.secretEnv[${secretIndex}]`, `External service secret environment variable names must match /^[A-Z_][A-Z0-9_]*$/: ${name}`)
+      }
+    }
+  }
 }
 
 async function validateRecipeDistribution(distribution: WorkspaceRecipeDistribution | undefined, recipeDirectory: string, addIssue: (code: string, path: string, message: string) => void): Promise<void> {

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -171,6 +171,11 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
             type: "array",
             items: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" },
           },
+          externalServices: {
+            type: "array",
+            description: "Declared external service boundaries used for reviewer-safe browser and recipe evidence correlation. Secret material is represented by environment variable names only.",
+            items: { $ref: "#/$defs/externalServiceBoundary" },
+          },
           pluginRuntime: { $ref: "#/$defs/pluginRuntime" },
           fixtureDatabases: {
             type: "array",
@@ -509,6 +514,30 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
           source: { type: "string" },
           target: { type: "string", pattern: "^/" },
           mode: { enum: ["readonly", "readwrite"] },
+          metadata: { $ref: "#/$defs/metadata" },
+        },
+      },
+      externalServiceBoundary: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "environment", "writes"],
+        properties: {
+          id: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*$" },
+          label: { type: "string" },
+          environment: { enum: ["local", "fixture", "staging", "production", "external"] },
+          allowedHosts: { type: "array", items: { type: "string" } },
+          blockedHosts: { type: "array", items: { type: "string" } },
+          writes: { enum: ["forbidden", "record-only", "allowed-with-approval"] },
+          secretEnv: { type: "array", items: { type: "string", pattern: "^[A-Z_][A-Z0-9_]*$" } },
+          redaction: {
+            type: "object",
+            additionalProperties: false,
+            required: ["policy"],
+            properties: {
+              policy: { enum: ["metadata-only", "redact-fields", "omit"] },
+              fields: { type: "array", items: { type: "string" } },
+            },
+          },
           metadata: { $ref: "#/$defs/metadata" },
         },
       },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -112,6 +112,25 @@ export interface WorkspaceRecipeMount {
   metadata?: Record<string, unknown>
 }
 
+export type WorkspaceRecipeExternalServiceEnvironment = "local" | "fixture" | "staging" | "production" | "external"
+export type WorkspaceRecipeExternalServiceWrites = "forbidden" | "record-only" | "allowed-with-approval"
+export type WorkspaceRecipeExternalServiceRedactionPolicy = "metadata-only" | "redact-fields" | "omit"
+
+export interface WorkspaceRecipeExternalServiceBoundary {
+  id: string
+  label?: string
+  environment: WorkspaceRecipeExternalServiceEnvironment
+  allowedHosts?: string[]
+  blockedHosts?: string[]
+  writes: WorkspaceRecipeExternalServiceWrites
+  secretEnv?: string[]
+  redaction?: {
+    policy: WorkspaceRecipeExternalServiceRedactionPolicy
+    fields?: string[]
+  }
+  metadata?: Record<string, unknown>
+}
+
 export interface WorkspaceRecipeRuntimeStack {
   mounts?: WorkspaceRecipeMount[]
 }
@@ -558,6 +577,7 @@ export interface WorkspaceRecipe {
     dependency_overlays?: WorkspaceRecipeDependencyOverlay[]
     runtimeEnv?: Record<string, string>
     secretEnv?: string[]
+    externalServices?: WorkspaceRecipeExternalServiceBoundary[]
     pluginRuntime?: WorkspaceRecipePluginRuntime
     fixtureDatabases?: WorkspaceRecipeFixtureDatabase[]
     fixtureUsers?: WorkspaceRecipeFixtureUser[]

--- a/tests/recipe-external-service-boundaries.test.ts
+++ b/tests/recipe-external-service-boundaries.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict"
+
+import { validateWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { planWorkspaceRecipe } from "../packages/cli/src/recipe-dry-run.js"
+import { recipeExternalServiceBoundarySummaries, correlateObservedHostsToExternalServiceBoundaries } from "../packages/cli/src/recipe-external-services.js"
+import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.js"
+
+const recipe: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    secretEnv: ["GLOBAL_SERVICE_TOKEN"],
+    externalServices: [
+      {
+        id: "checkout-staging",
+        label: "Checkout staging API",
+        environment: "staging",
+        allowedHosts: ["API.EXAMPLE.test:443"],
+        blockedHosts: ["prod.example.test"],
+        writes: "record-only",
+        secretEnv: ["CHECKOUT_API_TOKEN"],
+        redaction: { policy: "redact-fields", fields: ["authorization", "set-cookie"] },
+        metadata: { owner: "payments" },
+      },
+    ],
+  },
+  workflow: { steps: [{ command: "wordpress.run-php", args: ["code=<?php echo 'ok';"] }] },
+}
+
+assert.equal(validateWorkspaceRecipeJsonSchema(recipe).valid, true)
+assert.deepEqual(await validateWorkspaceRecipeSemantics(recipe, "recipe.json"), [])
+
+const summaries = recipeExternalServiceBoundarySummaries(recipe)
+assert.deepEqual(summaries, [
+  {
+    schema: "wp-codebox/external-service-boundary-summary/v1",
+    id: "checkout-staging",
+    label: "Checkout staging API",
+    environment: "staging",
+    allowedHosts: ["api.example.test"],
+    blockedHosts: ["prod.example.test"],
+    writes: "record-only",
+    secretEnv: ["CHECKOUT_API_TOKEN"],
+    redaction: { policy: "redact-fields", fields: ["authorization", "set-cookie"] },
+  },
+])
+assert.doesNotMatch(JSON.stringify(summaries), /secret-value|GLOBAL_SERVICE_TOKEN=.*|CHECKOUT_API_TOKEN=.*/)
+
+const plan = await planWorkspaceRecipe(recipe, process.cwd(), { recipePath: "recipe.json" }, {
+  defaultWordPressVersion: "latest",
+  resolveExecutionSpec: async (step) => ({ command: step.command, args: step.args ?? [] }),
+})
+assert.deepEqual(plan.externalServices, summaries)
+
+const correlation = correlateObservedHostsToExternalServiceBoundaries({
+  "api.example.test": { requests: 2, external: true, blocked: 0, routed: 0 },
+  "cdn.example.test": { requests: 1, external: true, blocked: 0, routed: 0 },
+}, summaries)
+assert.deepEqual(correlation, {
+  schema: "wp-codebox/external-service-boundary-host-correlation/v1",
+  observedHosts: [
+    { host: "api.example.test", boundaryIds: ["checkout-staging"], requests: 2, external: true, blocked: 0, routed: 0 },
+    { host: "cdn.example.test", boundaryIds: [], requests: 1, external: true, blocked: 0, routed: 0 },
+  ],
+  unmatchedHosts: ["cdn.example.test"],
+})
+
+const invalidRecipe: WorkspaceRecipe = {
+  ...recipe,
+  inputs: {
+    externalServices: [
+      { id: "service", environment: "external", writes: "forbidden", allowedHosts: ["https://bad.example.test/path"], secretEnv: ["bad-secret"] },
+      { id: "service", environment: "external", writes: "forbidden" },
+    ],
+  },
+}
+const invalidIssues = await validateWorkspaceRecipeSemantics(invalidRecipe, "recipe.json")
+assert.deepEqual(invalidIssues.map((issue) => issue.code), ["invalid-external-service-host", "invalid-external-service-secret-env", "duplicate-external-service-id"])
+
+console.log("recipe external service boundaries ok")


### PR DESCRIPTION
## Summary
- Add generic inputs.externalServices recipe declarations for external service boundaries.
- Surface redacted boundary summaries in dry-run plans, run attestations, run metadata, failure diagnostics, and browser evidence host correlation.
- Document the product-neutral contract and add focused validation/dry-run/evidence serialization coverage.

## Tests
- npm run build
- npx tsx tests/recipe-external-service-boundaries.test.ts
- npx tsx tests/recipe-secret-env.test.ts
- npx tsx tests/recipe-validation-descriptors.test.ts
- npx tsx tests/evidence-bundle-digest-and-recipe-artifact.test.ts

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the generic external service boundary contract, tests, docs, and verification.