### PR TITLE
Add browser websocket capture artifacts

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -551,6 +551,11 @@ short-lived in-memory cookies from the disposable WordPress sandbox; `storage-st
 imports caller-provided reusable state. Supplying both is rejected with structured
 storage-state diagnostics rather than silently preferring one source.
 
+Browser commands accept `capture=websocket` to write a generic
+`browser-websocket` artifact. The artifact records safe connection metadata only:
+redacted websocket URLs, open/close/error timestamps, frame counts, and aggregate
+sent/received byte counts. Frame payloads are not written.
+
 ## Recipe Output Evidence
 
 `recipe-run --json` returns `wp-codebox/recipe-run/v1`. Browser command sidecars

--- a/packages/runtime-core/src/artifact-review.ts
+++ b/packages/runtime-core/src/artifact-review.ts
@@ -110,7 +110,9 @@ export interface ArtifactReviewBrowserSummary {
     lifecycle?: string
     network?: string
     waterfall?: string
+    websocket?: string
     networkEvents?: number
+    webSockets?: ArtifactReviewBrowserWebSocketSummary
     checkpoints?: string
     memory?: string
     performance?: string
@@ -141,6 +143,16 @@ export interface ArtifactReviewBrowserSummary {
     wordpressDiagnostics?: ArtifactReviewBrowserWordPressDiagnosticsSummary
     summaryFile?: string
   }>
+}
+
+export interface ArtifactReviewBrowserWebSocketSummary {
+  sockets: number
+  closed: number
+  errors: number
+  framesSent: number
+  framesReceived: number
+  bytesSent: number
+  bytesReceived: number
 }
 
 export interface ArtifactReviewBrowserRedirectDiagnosticsSummary {

--- a/packages/runtime-core/src/browser-probe-contract.ts
+++ b/packages/runtime-core/src/browser-probe-contract.ts
@@ -14,7 +14,7 @@ export type BrowserProbeProfileDefinition = {
 
 export const BROWSER_PROBE_BROWSER_VALUES = ["chromium"] as const
 
-export const BROWSER_PROBE_CAPTURE_VALUES = ["console", "errors", "html", "network", "performance", "memory", "screenshot"] as const
+export const BROWSER_PROBE_CAPTURE_VALUES = ["console", "errors", "html", "network", "websocket", "performance", "memory", "screenshot"] as const
 export const BROWSER_PROBE_CHROMIUM_PROFILE_IDS = ["desktop-chrome", "mobile-chrome", "low-end-mobile-slow-4g"] as const
 export const BROWSER_PROBE_THROTTLE_PROFILE_IDS = ["low-end-mobile-slow-4g"] as const
 

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -4,7 +4,7 @@ import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import { BrowserCommandArtifactError, isBrowserCommandArtifactError } from "./browser-command-artifact-error.js"
-import type { BrowserArtifact, BrowserProbeAuthSummary, BrowserProbeErrorRecord, BrowserProbeNetworkRecord, BrowserProbeViewport, BrowserStepRecord } from "./browser-artifacts.js"
+import type { BrowserArtifact, BrowserProbeAuthSummary, BrowserProbeErrorRecord, BrowserProbeNetworkRecord, BrowserProbeViewport, BrowserProbeWebSocketRecord, BrowserStepRecord } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { captureBrowserDomSnapshot, type BrowserDomSnapshotArtifact } from "./browser-dom-snapshot.js"
 import { browserAssertionsSummary, browserStepRecord, executeBrowserInteractionStep } from "./browser-interactions.js"
@@ -13,7 +13,7 @@ import { serializeBrowserError } from "./browser-metrics.js"
 import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewTopology, resolveBrowserPreviewUrl, routeBrowserPreviewContextNetwork } from "./browser-preview-routing.js"
 import { BROWSER_PROBE_STATE_INIT_SCRIPT, browserProbeReplayability, browserProbeViewport } from "./browser-probe.js"
 import { runBrowserProbeCommand, type BrowserProbeRunPlan } from "./browser-probe-runner.js"
-import { browserActionTargetUrls, browserAuthRequest, browserProbeWaterfallArtifact, browserRedirectDiagnosticsArtifact, browserRequestCoverageArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, browserWordPressDiagnosticsArtifact, createBrowserProbeProgressTracker, fileSha256, installBrowserWordPressDiagnostics, installWordPressAdminAuthCookies, livenessRemainingWallTimeMs, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserStorageStateImport } from "./browser-probe-support.js"
+import { browserActionTargetUrls, browserAuthRequest, browserProbeWaterfallArtifact, browserProbeWebSocketArtifact, browserProbeWebSocketSummary, browserRedirectDiagnosticsArtifact, browserRequestCoverageArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, browserWordPressDiagnosticsArtifact, createBrowserProbeProgressTracker, fileSha256, installBrowserWordPressDiagnostics, installWordPressAdminAuthCookies, livenessRemainingWallTimeMs, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserStorageStateImport } from "./browser-probe-support.js"
 import { positiveIntegerArg } from "./command-args.js"
 import { argValue, commaListArg, durationArg, viewportArg } from "./commands.js"
 import type { PlaygroundRunResponse } from "./playground-command-errors.js"
@@ -82,8 +82,8 @@ export async function runBrowserActionsCommand({
   const capture = runPlan.capture
 
   for (const item of capture) {
-    if (!["steps", "console", "errors", "html", "network", "screenshot", "dom-snapshot"].includes(item)) {
-      throw new Error(`wordpress.browser-actions capture supports steps, console, errors, html, network, screenshot, dom-snapshot: ${item}`)
+    if (!["steps", "console", "errors", "html", "network", "websocket", "screenshot", "dom-snapshot"].includes(item)) {
+      throw new Error(`wordpress.browser-actions capture supports steps, console, errors, html, network, websocket, screenshot, dom-snapshot: ${item}`)
     }
   }
 
@@ -103,6 +103,7 @@ export async function runBrowserActionsCommand({
   const consoleMessages: Record<string, unknown>[] = []
   const errors: BrowserProbeErrorRecord[] = []
   const network: BrowserProbeNetworkRecord[] = []
+  const webSockets: BrowserProbeWebSocketRecord[] = []
   const networkTasks: Array<Promise<void>> = []
   const screenshotPath = artifactSession.absolutePath("screenshot.png")
   const startedAt = now()
@@ -156,11 +157,13 @@ export async function runBrowserActionsCommand({
       captureConsole: capture.has("console"),
       captureErrors: capture.has("errors"),
       captureNetwork: true,
+      captureWebSocket: capture.has("websocket"),
       consoleMessages,
       errors,
       network,
       networkTasks,
       page,
+      webSockets,
     })
 
     for (const [index, step] of steps.entries()) {
@@ -276,6 +279,9 @@ export async function runBrowserActionsCommand({
       await artifactSession.writeJson("requestCoverage", "request-coverage.json", browserRequestCoverageArtifact(network, startedAt))
       await artifactSession.writeJson("waterfall", "waterfall.json", browserProbeWaterfallArtifact(network, startedAt))
     }
+    if (capture.has("websocket")) {
+      await artifactSession.writeJson("websocket", "websocket.json", browserProbeWebSocketArtifact(webSockets, startedAt))
+    }
 
     const redirectDiagnostics = browserRedirectDiagnosticsArtifact({
       artifactPath: "files/browser/redirect-diagnostics.json",
@@ -317,6 +323,7 @@ export async function runBrowserActionsCommand({
 		...(capture.has("network") ? { network: "files/browser/network.jsonl" } : {}),
 		...(capture.has("network") ? { requestCoverage: "files/browser/request-coverage.json" } : {}),
 		...(capture.has("network") ? { waterfall: "files/browser/waterfall.json" } : {}),
+        ...(capture.has("websocket") ? { websocket: "files/browser/websocket.json" } : {}),
         ...(redirectDiagnostics ? { redirectDiagnostics: "files/browser/redirect-diagnostics.json" } : {}),
         ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots: domSnapshots.map((snapshot) => snapshot.snapshot) } : {}),
@@ -336,6 +343,7 @@ export async function runBrowserActionsCommand({
         ...(domSnapshots.length > 0 ? { domSnapshots } : {}),
         liveness: { wallTimeoutMs: totalTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
         networkEvents: network.length,
+        ...(capture.has("websocket") ? { webSockets: browserProbeWebSocketSummary(webSockets) } : {}),
         ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
         ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
         replayability: browserProbeReplayability(capture),

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -76,6 +76,7 @@ export interface BrowserArtifactFiles {
   network?: string
   requestCoverage?: string
   waterfall?: string
+  websocket?: string
   performance?: string
   review?: string
   screenshot?: string
@@ -158,6 +159,7 @@ export interface BrowserArtifactSummary {
   memory?: BrowserProbeMemorySummary
   metrics?: Record<string, number>
   networkEvents: number
+  webSockets?: BrowserProbeWebSocketSummary
   phaseMetrics?: BrowserProbePhaseMetricsArtifact
   performance?: BrowserProbePerformanceSummary
   progress?: BrowserProbeProgressSummary
@@ -338,6 +340,7 @@ export interface BrowserProbeReviewSummary {
     probe: BrowserProbeIssueSummary
   }
   network: BrowserProbeNetworkReviewSummary
+  webSockets?: BrowserProbeWebSocketReviewSummary
   redirectDiagnostics?: BrowserRedirectDiagnosticsSummary
   wordpressDiagnostics?: BrowserWordPressDiagnosticsSummary
   milestones: BrowserProbeMilestoneSummary
@@ -372,6 +375,21 @@ export interface BrowserProbeNetworkCountSummary {
   responses: number
   failures: number
   transferSizeBytes: number
+}
+
+export interface BrowserProbeWebSocketSummary {
+  sockets: number
+  closed: number
+  errors: number
+  framesSent: number
+  framesReceived: number
+  bytesSent: number
+  bytesReceived: number
+}
+
+export interface BrowserProbeWebSocketReviewSummary extends BrowserProbeWebSocketSummary {
+  status: "captured" | "not-captured"
+  artifact?: BrowserProbeArtifactRef
 }
 
 export interface BrowserProbeMilestoneSummary {
@@ -485,7 +503,7 @@ export interface BrowserProbeProgressSummary {
   terminalFailure?: BrowserProbeTerminalFailure
 }
 
-export type BrowserProbeProgressSource = "navigation" | "network" | "console" | "pageerror" | "checkpoint" | "script" | "duration" | "probe-error"
+export type BrowserProbeProgressSource = "navigation" | "network" | "websocket" | "console" | "pageerror" | "checkpoint" | "script" | "duration" | "probe-error"
 
 export interface BrowserProbeTerminalFailure {
   message: string
@@ -852,6 +870,28 @@ export interface BrowserProbeNetworkRecord {
   failure?: ReturnType<Request["failure"]>
 }
 
+export interface BrowserProbeWebSocketRecord {
+  url: string
+  openedAt: string
+  closedAt?: string
+  lastFrameAt?: string
+  lastErrorAt?: string
+  framesSent: number
+  framesReceived: number
+  bytesSent: number
+  bytesReceived: number
+  errors: number
+}
+
+export interface BrowserProbeWebSocketArtifact {
+  schema: "wp-codebox/browser-websocket/v1"
+  version: 1
+  capturedAt: string
+  startedAt: string
+  summary: BrowserProbeWebSocketSummary
+  sockets: BrowserProbeWebSocketRecord[]
+}
+
 export interface BrowserProbeWaterfallArtifact {
   schema: "wp-codebox/browser-waterfall/v1"
   version: 1
@@ -941,7 +981,9 @@ export function browserReviewSummary(probes: BrowserArtifact[]): ArtifactReviewB
       lifecycle: probe.files.lifecycle,
       network: probe.files.network,
       waterfall: probe.files.waterfall,
+      websocket: probe.files.websocket,
       networkEvents: probe.summary.networkEvents,
+      webSockets: probe.summary.webSockets,
       screenshot: probe.files.screenshot,
       domSnapshots: probe.files.domSnapshots,
       console: probe.files.console,
@@ -1013,6 +1055,7 @@ const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, Browser
   network: { kind: "browser-network", contentType: "application/x-ndjson", redact: true },
   requestCoverage: { kind: "browser-request-coverage", contentType: "application/json", redact: true },
   waterfall: { kind: "browser-waterfall", contentType: "application/json", redact: true },
+  websocket: { kind: "browser-websocket", contentType: "application/json", redact: true },
   performance: { kind: "browser-performance", contentType: "application/json", redact: true },
   review: { kind: "browser-review", contentType: "application/json", redact: true },
   screenshot: { kind: "browser-screenshot", contentType: "image/png", redact: false },

--- a/packages/runtime-playground/src/browser-capture-session.ts
+++ b/packages/runtime-playground/src/browser-capture-session.ts
@@ -1,4 +1,5 @@
-import type { BrowserProbeErrorRecord, BrowserProbeNetworkRecord } from "./browser-artifacts.js"
+import { redactString } from "@automattic/wp-codebox-core"
+import type { BrowserProbeErrorRecord, BrowserProbeNetworkRecord, BrowserProbeWebSocketRecord } from "./browser-artifacts.js"
 import { browserCommandLivenessPolicy } from "./browser-liveness.js"
 import { serializeBrowserConsoleMessage, serializeBrowserError, serializeBrowserFinishedRequest, serializeBrowserRequestFailure } from "./browser-metrics.js"
 import type { Browser, Page } from "playwright"
@@ -24,6 +25,7 @@ export function attachBrowserCaptureListeners({
   captureConsole,
   captureErrors,
   captureNetwork,
+  captureWebSocket,
   consoleMessages,
   errors,
   network,
@@ -31,11 +33,14 @@ export function attachBrowserCaptureListeners({
   onConsole,
   onNetwork,
   onPageError,
+  onWebSocket,
   page,
+  webSockets,
 }: {
   captureConsole: boolean
   captureErrors: boolean
   captureNetwork: boolean
+  captureWebSocket?: boolean
   consoleMessages: Record<string, unknown>[]
   errors: BrowserProbeErrorRecord[]
   network: BrowserProbeNetworkRecord[]
@@ -43,7 +48,9 @@ export function attachBrowserCaptureListeners({
   onConsole?: () => void
   onNetwork?: () => void
   onPageError?: () => void
+  onWebSocket?: () => void
   page: Page
+  webSockets?: BrowserProbeWebSocketRecord[]
 }): void {
   if (captureConsole) {
     page.on("console", (message) => {
@@ -70,6 +77,62 @@ export function attachBrowserCaptureListeners({
       onNetwork?.()
       network.push(serializeBrowserRequestFailure(request, new Date().toISOString()))
     })
+  }
+  if (captureWebSocket && webSockets) {
+    page.on("websocket", (socket) => {
+      onWebSocket?.()
+      const record = createBrowserWebSocketRecord(socket.url(), new Date().toISOString())
+      webSockets.push(record)
+      socket.on("framesent", ({ payload }) => {
+        onWebSocket?.()
+        record.framesSent += 1
+        record.bytesSent += browserWebSocketPayloadBytes(payload)
+        record.lastFrameAt = new Date().toISOString()
+      })
+      socket.on("framereceived", ({ payload }) => {
+        onWebSocket?.()
+        record.framesReceived += 1
+        record.bytesReceived += browserWebSocketPayloadBytes(payload)
+        record.lastFrameAt = new Date().toISOString()
+      })
+      socket.on("socketerror", () => {
+        onWebSocket?.()
+        record.errors += 1
+        record.lastErrorAt = new Date().toISOString()
+      })
+      socket.on("close", () => {
+        onWebSocket?.()
+        record.closedAt = new Date().toISOString()
+      })
+    })
+  }
+}
+
+export function createBrowserWebSocketRecord(url: string, openedAt: string): BrowserProbeWebSocketRecord {
+  return {
+    url: redactBrowserWebSocketUrl(url),
+    openedAt,
+    framesSent: 0,
+    framesReceived: 0,
+    bytesSent: 0,
+    bytesReceived: 0,
+    errors: 0,
+  }
+}
+
+export function browserWebSocketPayloadBytes(payload: string | Buffer): number {
+  return typeof payload === "string" ? Buffer.byteLength(payload, "utf8") : payload.byteLength
+}
+
+function redactBrowserWebSocketUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    const search = [...parsed.searchParams.keys()].length > 0
+      ? `?${[...parsed.searchParams.keys()].map((key) => `${encodeURIComponent(key)}=[redacted]`).join("&")}`
+      : ""
+    return `${parsed.origin}${parsed.pathname}${search}${parsed.hash ? "#[redacted]" : ""}`
+  } catch {
+    return redactString(url, { redactAllUrlQueryValues: true, redactUrlHash: true, redactQueryAssignments: true })
   }
 }
 

--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -1,7 +1,7 @@
 import { BROWSER_PROBE_BROWSER_VALUES, BROWSER_PROBE_CAPTURE_VALUES, BROWSER_PROBE_CHROMIUM_PROFILE_IDS, BROWSER_PROBE_PROFILES, BROWSER_PROBE_THROTTLE_PROFILE_IDS, type BrowserProbeProfileDefinition, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js"
-import type { BrowserArtifactFiles, BrowserProbeArtifact, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
+import type { BrowserArtifactFiles, BrowserProbeArtifact, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserProbeWebSocketRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
@@ -11,7 +11,7 @@ import { BROWSER_PROBE_PERFORMANCE_INIT_SCRIPT, BROWSER_PROBE_STATE_INIT_SCRIPT,
 import { argValue, commaListArg, durationArg, strictBooleanArg, viewportArg } from "./commands.js"
 import type { PlaygroundRunResponse } from "./playground-command-errors.js"
 import type { PlaygroundCliServer } from "./preview-server.js"
-import { browserAuthRequest, browserProbeWaterfallArtifact, browserRedirectDiagnosticsArtifact, browserRequestCoverageArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, createBrowserProbeProgressTracker, fileSha256, installWordPressAdminAuthCookies, now, sha256, withBrowserProbeLiveness, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserProbeScriptCheckpoint, type BrowserStorageStateImport } from "./browser-probe-support.js"
+import { browserAuthRequest, browserProbeWaterfallArtifact, browserProbeWebSocketArtifact, browserRedirectDiagnosticsArtifact, browserRequestCoverageArtifact, browserStorageStateAuthSummary, browserStorageStateImportFromArgs, createBrowserProbeProgressTracker, fileSha256, installWordPressAdminAuthCookies, now, sha256, withBrowserProbeLiveness, normalizeBrowserProbeScriptCheckpoint, type BrowserCommandProgressEvent, type BrowserProbeScriptCheckpoint, type BrowserStorageStateImport } from "./browser-probe-support.js"
 import { BrowserProbeSessionResultBuilder, browserProbeCaptureSelection } from "./browser-probe-session-result-builder.js"
 
 const BROWSER_PROBE_PROFILE_OVERRIDES = new Set(["browser", "device", "locale", "permissions", "throttle", "timezone", "user-agent", "viewport"])
@@ -246,6 +246,7 @@ export async function runSingleBrowserProbeCommand({
   const consoleMessages: Record<string, unknown>[] = []
   const errors: BrowserProbeErrorRecord[] = []
   const network: BrowserProbeNetworkRecord[] = []
+  const webSockets: BrowserProbeWebSocketRecord[] = []
   const networkTasks: Array<Promise<void>> = []
   const checkpoints: BrowserProbeCheckpointRecord[] = []
   const screenshotPath = artifactSession.absolutePath("screenshot.png")
@@ -355,6 +356,7 @@ export async function runSingleBrowserProbeCommand({
       captureConsole: captureSelection.console,
       captureErrors: captureSelection.errors,
       captureNetwork: true,
+      captureWebSocket: capture.has("websocket"),
       consoleMessages,
       errors,
       network,
@@ -362,7 +364,9 @@ export async function runSingleBrowserProbeCommand({
       onConsole: () => progress.mark("console"),
       onNetwork: () => progress.mark("network"),
       onPageError: () => progress.mark("pageerror"),
+      onWebSocket: () => progress.mark("websocket"),
       page,
+      webSockets,
     })
 
     const previewReadinessError = browserPreviewReadinessError(preview)
@@ -491,6 +495,9 @@ export async function runSingleBrowserProbeCommand({
       await artifactSession.writeJson("requestCoverage", "request-coverage.json", browserRequestCoverageArtifact(network, startedAt))
       await artifactSession.writeJson("waterfall", "waterfall.json", browserProbeWaterfallArtifact(network, startedAt))
     }
+    if (capture.has("websocket")) {
+      await artifactSession.writeJson("websocket", "websocket.json", browserProbeWebSocketArtifact(webSockets, startedAt))
+    }
     if (checkpoints.length > 0) {
       await artifactSession.writeJsonLines("checkpoints", "checkpoints.jsonl", checkpoints)
     }
@@ -570,6 +577,7 @@ export async function runSingleBrowserProbeCommand({
       topologyOrigins: topology.origins,
       viewport,
       waitFor,
+      webSockets,
       windowLocationOrigin,
       wordpressDiagnostics: wordpressDiagnostics ? { summary: wordpressDiagnostics.summary } : undefined,
     })

--- a/packages/runtime-playground/src/browser-probe-session-result-builder.ts
+++ b/packages/runtime-playground/src/browser-probe-session-result-builder.ts
@@ -1,9 +1,9 @@
 import type { PlaygroundPreviewProxyDiagnostics } from "./preview-server.js"
 import type { BrowserPreviewTopology } from "./browser-preview-routing.js"
-import { addBrowserProbeNetworkCount, browserProbeArtifactRefs, createBrowserProbeProgressTracker, now, requestHost, safeBrowserProbeUrl, sortBrowserProbeNetworkCounts } from "./browser-probe-support.js"
+import { addBrowserProbeNetworkCount, browserProbeArtifactRefs, browserProbeWebSocketSummary, createBrowserProbeProgressTracker, now, requestHost, safeBrowserProbeUrl, sortBrowserProbeNetworkCounts } from "./browser-probe-support.js"
 import { browserProbeBenchMetrics } from "./browser-metrics.js"
 import { browserProbeAssertionsFromArgs, browserProbeAssertionsNeedMetrics, browserProbeAssertionsNeedNetwork, browserProbeReplayability } from "./browser-probe.js"
-import type { BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkPolicySummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserRedirectDiagnosticsSummary, BrowserStepAssertion, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
+import type { BrowserProbeArtifact, BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMeasuredMetric, BrowserProbeMemoryArtifact, BrowserProbeNetworkCountSummary, BrowserProbeNetworkPolicySummary, BrowserProbeNetworkRecord, BrowserProbeNetworkReviewSummary, BrowserProbePerformanceArtifact, BrowserProbePreviewRouting, BrowserProbeReviewSummary, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserProbeWebSocketRecord, BrowserProbeWebSocketReviewSummary, BrowserRedirectDiagnosticsSummary, BrowserStepAssertion, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 
 export interface BrowserProbeCaptureSelection {
   console: boolean
@@ -73,6 +73,7 @@ export interface BrowserProbeSessionResultInput {
   topologyOrigins: BrowserPreviewTopology["origins"]
   viewport: BrowserProbeViewport | null
   waitFor: string
+  webSockets: BrowserProbeWebSocketRecord[]
   windowLocationOrigin?: string
   wordpressDiagnostics?: { summary: BrowserWordPressDiagnosticsSummary }
 }
@@ -105,6 +106,7 @@ export class BrowserProbeSessionResultBuilder {
         memory: Boolean(input.memoryArtifact),
         network: Boolean(files.network),
         waterfall: Boolean(files.waterfall),
+        websocket: Boolean(files.websocket),
         performance: Boolean(input.performanceArtifact),
         redirectDiagnostics: Boolean(input.redirectDiagnostics),
         screenshot: input.hashes.screenshotSha256,
@@ -118,6 +120,7 @@ export class BrowserProbeSessionResultBuilder {
       totalDurationMs: Date.now() - input.startedAtMs,
       viewport: input.viewport,
       waitFor: input.waitFor,
+      webSockets: input.webSockets,
       redirectDiagnostics: input.redirectDiagnostics?.summary,
       wordpressDiagnostics: input.wordpressDiagnostics?.summary,
     })
@@ -164,6 +167,7 @@ function browserProbeArtifactFileMap(input: BrowserProbeSessionResultInput): Bro
 		...(input.capture.has("network") || input.captureSelection?.networkForAssertions ? { network: `${input.browserFilesDirectory}/network.jsonl` } : {}),
 		...(input.capture.has("network") || input.captureSelection?.networkForAssertions ? { requestCoverage: `${input.browserFilesDirectory}/request-coverage.json` } : {}),
 		...(input.capture.has("network") || input.captureSelection?.networkForAssertions ? { waterfall: `${input.browserFilesDirectory}/waterfall.json` } : {}),
+    ...(input.capture.has("websocket") ? { websocket: `${input.browserFilesDirectory}/websocket.json` } : {}),
     ...(input.performanceArtifact ? { performance: `${input.browserFilesDirectory}/performance.json` } : {}),
     ...(input.redirectDiagnostics ? { redirectDiagnostics: `${input.browserFilesDirectory}/redirect-diagnostics.json` } : {}),
     review: `${input.browserFilesDirectory}/review.json`,
@@ -188,6 +192,7 @@ function browserProbeArtifactSummary(input: BrowserProbeSessionResultInput, asse
     ...(input.memoryArtifact ? { memory: input.memoryArtifact.peak } : {}),
     ...(input.memoryArtifact || input.performanceArtifact ? { metrics: browserProbeBenchMetrics(input.memoryArtifact, input.performanceArtifact) } : {}),
     networkEvents: input.network.length,
+    ...(input.capture.has("websocket") ? { webSockets: browserProbeWebSocketSummary(input.webSockets) } : {}),
     ...(input.performanceArtifact?.phaseMetrics ? { phaseMetrics: input.performanceArtifact.phaseMetrics } : {}),
     ...(input.performanceArtifact ? { performance: input.performanceArtifact.peak } : {}),
     progress: input.progress.summary(),
@@ -279,6 +284,7 @@ function browserProbeReviewSummary(input: {
   totalDurationMs: number
   viewport: BrowserProbeViewport | null
   waitFor: string
+  webSockets: BrowserProbeWebSocketRecord[]
   redirectDiagnostics?: BrowserRedirectDiagnosticsSummary
   wordpressDiagnostics?: BrowserWordPressDiagnosticsSummary
 }): BrowserProbeReviewSummary {
@@ -343,6 +349,7 @@ function browserProbeReviewSummary(input: {
       probe: browserProbeIssueSummary(probeErrors.length, Boolean(input.files.errors), input.files.errors?.path),
     },
     network: browserProbeNetworkReviewSummary(input.network, input.files.network, input.files.waterfall),
+    ...(input.files.websocket ? { webSockets: browserProbeWebSocketReviewSummary(input.webSockets, input.files.websocket) } : {}),
     ...(input.redirectDiagnostics ? { redirectDiagnostics: input.redirectDiagnostics } : {}),
     ...(input.wordpressDiagnostics ? { wordpressDiagnostics: input.wordpressDiagnostics } : {}),
     milestones: {
@@ -352,6 +359,18 @@ function browserProbeReviewSummary(input: {
       ...(input.files.checkpoints ? { artifact: input.files.checkpoints.path } : {}),
     },
     artifacts: input.files,
+  }
+}
+
+function browserProbeWebSocketReviewSummary(webSockets: BrowserProbeWebSocketRecord[], websocketArtifact?: BrowserProbeArtifactRef): BrowserProbeWebSocketReviewSummary {
+  if (!websocketArtifact) {
+    return { status: "not-captured", ...browserProbeWebSocketSummary([]) }
+  }
+
+  return {
+    status: "captured",
+    ...browserProbeWebSocketSummary(webSockets),
+    artifact: websocketArtifact,
   }
 }
 

--- a/packages/runtime-playground/src/browser-probe-support.ts
+++ b/packages/runtime-playground/src/browser-probe-support.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { readFile } from "node:fs/promises"
 import { redactString, resolveCommandPath, type BrowserInteractionStep, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { normalizeBrowserStorageStatePayload, type BrowserStorageStateImportSummary } from "./browser-auth-storage-state.js"
-import type { BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeErrorRecord, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeWaterfallArtifact, BrowserProbeWaterfallEntry, BrowserRedirectDiagnosticsSummary, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
+import type { BrowserProbeArtifactRef, BrowserProbeAuthSummary, BrowserProbeErrorRecord, BrowserProbeNetworkCountSummary, BrowserProbeNetworkRecord, BrowserProbeWaterfallArtifact, BrowserProbeWaterfallEntry, BrowserProbeWebSocketArtifact, BrowserProbeWebSocketRecord, BrowserProbeWebSocketSummary, BrowserRedirectDiagnosticsSummary, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness, type BrowserCommandLivenessPolicy } from "./browser-liveness.js"
 import { bootstrapPhpCode } from "./php-bootstrap.js"
 import { phpBrowserWordPressDiagnosticsPlugin } from "./php-snippets.js"
@@ -123,6 +123,29 @@ export function browserProbeWaterfallArtifact(network: BrowserProbeNetworkRecord
   }
 }
 
+export function browserProbeWebSocketArtifact(webSockets: BrowserProbeWebSocketRecord[], startedAt: string): BrowserProbeWebSocketArtifact {
+  return {
+    schema: "wp-codebox/browser-websocket/v1",
+    version: 1,
+    capturedAt: now(),
+    startedAt,
+    summary: browserProbeWebSocketSummary(webSockets),
+    sockets: webSockets,
+  }
+}
+
+export function browserProbeWebSocketSummary(webSockets: BrowserProbeWebSocketRecord[]): BrowserProbeWebSocketSummary {
+  return {
+    sockets: webSockets.length,
+    closed: webSockets.filter((record) => Boolean(record.closedAt)).length,
+    errors: webSockets.reduce((total, record) => total + finiteNumber(record.errors, 0), 0),
+    framesSent: webSockets.reduce((total, record) => total + finiteNumber(record.framesSent, 0), 0),
+    framesReceived: webSockets.reduce((total, record) => total + finiteNumber(record.framesReceived, 0), 0),
+    bytesSent: webSockets.reduce((total, record) => total + finiteNumber(record.bytesSent, 0), 0),
+    bytesReceived: webSockets.reduce((total, record) => total + finiteNumber(record.bytesReceived, 0), 0),
+  }
+}
+
 function browserProbeWaterfallEntry(record: BrowserProbeNetworkRecord): BrowserProbeWaterfallEntry {
   const timings = browserProbeWaterfallTimings(record.timing ?? {})
   const startedDateTime = browserProbeWaterfallStartedDateTime(record)
@@ -232,6 +255,7 @@ export function browserProbeArtifactRefs(browserFilesDirectory: string, capture:
   memory: boolean
   network: boolean
   waterfall: boolean
+  websocket: boolean
   performance: boolean
   redirectDiagnostics: boolean
   screenshot?: string
@@ -246,6 +270,7 @@ export function browserProbeArtifactRefs(browserFilesDirectory: string, capture:
     ...(input.memory ? { memory: { path: `${browserFilesDirectory}/memory.json`, kind: "json" as const } } : {}),
     ...(input.network ? { network: { path: `${browserFilesDirectory}/network.jsonl`, kind: "jsonl" as const } } : {}),
     ...(input.waterfall ? { waterfall: { path: `${browserFilesDirectory}/waterfall.json`, kind: "json" as const } } : {}),
+    ...(input.websocket ? { websocket: { path: `${browserFilesDirectory}/websocket.json`, kind: "json" as const } } : {}),
     ...(input.performance ? { performance: { path: `${browserFilesDirectory}/performance.json`, kind: "json" as const } } : {}),
     ...(input.redirectDiagnostics ? { redirectDiagnostics: { path: `${browserFilesDirectory}/redirect-diagnostics.json`, kind: "json" as const } } : {}),
     review: { path: `${browserFilesDirectory}/review.json`, kind: "json" as const },
@@ -860,7 +885,7 @@ export function sha256(contents: Buffer): string {
   return createHash("sha256").update(contents).digest("hex")
 }
 
-export type BrowserProbeProgressSource = "navigation" | "network" | "console" | "pageerror" | "checkpoint" | "script" | "duration" | "probe-error"
+export type BrowserProbeProgressSource = "navigation" | "network" | "websocket" | "console" | "pageerror" | "checkpoint" | "script" | "duration" | "probe-error"
 
 export class BrowserProbeTerminalFailureError extends Error {
   readonly code = "browser-probe-terminal-failure"

--- a/packages/runtime-playground/src/browser-probe.ts
+++ b/packages/runtime-playground/src/browser-probe.ts
@@ -256,7 +256,7 @@ export function browserProbeReplayability(capture: Set<string>): BrowserProbeRep
     return "artifact-backed"
   }
 
-  if (capture.has("html") || capture.has("screenshot") || capture.has("network")) {
+  if (capture.has("html") || capture.has("screenshot") || capture.has("network") || capture.has("websocket")) {
     return "partial"
   }
 

--- a/tests/browser-artifact-session.test.ts
+++ b/tests/browser-artifact-session.test.ts
@@ -3,7 +3,8 @@ import { resolve } from "node:path"
 
 import { BrowserArtifactSession } from "../packages/runtime-playground/src/browser-artifact-session.js"
 import { browserReviewSummary, type BrowserArtifact } from "../packages/runtime-playground/src/browser-artifacts.js"
-import { browserRequestCoverageArtifact } from "../packages/runtime-playground/src/browser-probe-support.js"
+import { browserWebSocketPayloadBytes, createBrowserWebSocketRecord } from "../packages/runtime-playground/src/browser-capture-session.js"
+import { browserProbeWebSocketArtifact, browserRequestCoverageArtifact } from "../packages/runtime-playground/src/browser-probe-support.js"
 import { assertJsonFile, assertTextFile, withTempDir } from "../scripts/test-kit.js"
 
 await withTempDir("wp-codebox-browser-artifact-session-", async (artifactRoot) => {
@@ -16,6 +17,7 @@ await session.writeText("html", "snapshot.html", "<html><body>secret</body></htm
 await session.writeJsonLines("console", "console.jsonl", [{ type: "log", text: "visible" }])
 await session.writeJson("requestCoverage", "request-coverage.json", { schema: "wp-codebox/browser-request-coverage/v1", totals: { requests: 1 } })
 await session.writeJson("waterfall", "waterfall.json", { schema: "wp-codebox/browser-waterfall/v1", log: { entries: [] } })
+await session.writeJson("websocket", "websocket.json", { schema: "wp-codebox/browser-websocket/v1", summary: { sockets: 0 } })
 await session.writeJson("summary", "summary.json", { schema: "wp-codebox/browser-probe/v1", ok: true })
 await session.writeBuffer("screenshot", "screenshot.png", Buffer.from([0, 1, 2]))
 
@@ -46,6 +48,10 @@ assert.equal(files.get("files/browser/waterfall.json")?.kind, "browser-waterfall
 assert.equal(files.get("files/browser/waterfall.json")?.contentType, "application/json")
 assert.equal(files.get("files/browser/waterfall.json")?.redaction?.policy, "required")
 
+assert.equal(files.get("files/browser/websocket.json")?.kind, "browser-websocket")
+assert.equal(files.get("files/browser/websocket.json")?.contentType, "application/json")
+assert.equal(files.get("files/browser/websocket.json")?.redaction?.policy, "required")
+
 assert.equal(files.get("files/browser/screenshot.png")?.kind, "browser-screenshot")
 assert.equal(files.get("files/browser/screenshot.png")?.contentType, "image/png")
 assert.deepEqual(files.get("files/browser/screenshot.png")?.redaction, { policy: "none", sensitive: false })
@@ -66,10 +72,11 @@ const review = browserReviewSummary([{
   requestedUrl: "https://example.test/",
   url: "https://example.test/",
   preview: { requestedMode: "local", effectiveMode: "local", localOrigin: "https://example.test", effectiveOrigin: "https://example.test", diagnostics: [] },
-  files: { network: "files/browser/network.jsonl", waterfall: "files/browser/waterfall.json", summary: "files/browser/summary.json" },
-  summary: { consoleMessages: 0, errors: 0, finalUrl: "https://example.test/", htmlSnapshot: false, networkEvents: 1, replayability: "partial", screenshot: false, viewport: null },
+  files: { network: "files/browser/network.jsonl", waterfall: "files/browser/waterfall.json", websocket: "files/browser/websocket.json", summary: "files/browser/summary.json" },
+  summary: { consoleMessages: 0, errors: 0, finalUrl: "https://example.test/", htmlSnapshot: false, networkEvents: 1, webSockets: { sockets: 1, closed: 1, errors: 0, framesSent: 1, framesReceived: 1, bytesSent: 4, bytesReceived: 2 }, replayability: "partial", screenshot: false, viewport: null },
 } satisfies BrowserArtifact])
 assert.equal(review?.probes[0]?.waterfall, "files/browser/waterfall.json")
+assert.equal(review?.probes[0]?.websocket, "files/browser/websocket.json")
 })
 
 const requestCoverage = browserRequestCoverageArtifact([{
@@ -99,3 +106,15 @@ assert.equal(requestCoverage.byResourceType.fetch.responses, 1)
 assert.equal(requestCoverage.byMethod.POST.failures, 1)
 assert.equal(requestCoverage.requests[0].url, "https://example.test/wp-json/wp/v2/posts?search=[redacted]#[redacted]")
 assert.equal(requestCoverage.requests[1].url, "https://api.example.test/submit?token=[redacted]")
+
+const webSocketRecord = createBrowserWebSocketRecord("wss://example.test/socket?token=secret#debug", "2026-01-01T00:00:00.000Z")
+webSocketRecord.framesSent += 1
+webSocketRecord.bytesSent += browserWebSocketPayloadBytes("ping")
+webSocketRecord.framesReceived += 1
+webSocketRecord.bytesReceived += browserWebSocketPayloadBytes(Buffer.from([1, 2]))
+webSocketRecord.closedAt = "2026-01-01T00:00:01.000Z"
+const webSocketArtifact = browserProbeWebSocketArtifact([webSocketRecord], "2026-01-01T00:00:00.000Z")
+
+assert.equal(webSocketArtifact.schema, "wp-codebox/browser-websocket/v1")
+assert.equal(webSocketArtifact.sockets[0]?.url, "wss://example.test/socket?token=[redacted]#[redacted]")
+assert.deepEqual(webSocketArtifact.summary, { sockets: 1, closed: 1, errors: 0, framesSent: 1, framesReceived: 1, bytesSent: 4, bytesReceived: 2 })


### PR DESCRIPTION
## Summary
- Add generic Playwright websocket capture for browser probe/actions via capture=websocket.
- Write redacted browser-websocket artifacts with connection timestamps, frame counts, byte totals, and summary refs.
- Register websocket artifact metadata and document the capture option.

## Tests
- npm run test:browser-artifact-session
- npx tsx scripts/browser-probe-contract-smoke.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the websocket capture primitive, docs, tests, and verification.