### PR TITLE
Raise runtime memory_limit to 512M (fix collect_artifacts OOM)

### DIFF
--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -307,7 +307,16 @@ function pluginRuntimePhpEntries(spec: RuntimeCreateSpec, key: "iniEntries" | "b
 function phpIniContent(entries: Record<string, string>): string {
   const lines = [
     "auto_prepend_file=/internal/shared/auto_prepend_file.php",
-    "memory_limit=256M",
+    // Runtime memory ceiling for all in-sandbox PHP, including artifact
+    // collection. The collect_artifacts phase reads declared/typed artifacts and
+    // runtime snapshot files into memory and base64-encodes them
+    // (file_get_contents + base64_encode + wp_json_encode each hold a copy, so a
+    // single file costs ~2.3x its size in PHP heap). At the old 256M a heavy
+    // fixture could exhaust the limit mid-collection and emit a hard PHP fatal,
+    // sinking the whole batch. 512M keeps collection bounded well below the 2000M
+    // upload/post ceilings already configured below, without uncapping memory.
+    // Recipes can still raise this per-runtime via pluginRuntime.php.iniEntries.
+    "memory_limit=512M",
     "ignore_repeated_errors = 1",
     "error_reporting = E_ALL",
     "display_errors = 1",

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -70,7 +70,11 @@ try {
   assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
   const sharedMount = calls[0]["mount-before-install"]?.[0]?.hostPath
   assert.equal(typeof sharedMount, "string")
-  assert.match(await readFile(join(sharedMount as string, "php.ini"), "utf8"), /opcache\.file_cache = \/tmp\/opcache/)
+  const sharedPhpIni = await readFile(join(sharedMount as string, "php.ini"), "utf8")
+  assert.match(sharedPhpIni, /opcache\.file_cache = \/tmp\/opcache/)
+  // The runtime default memory ceiling stays high enough for collect_artifacts to
+  // base64 heavy snapshot/declared-artifact files without a hard PHP fatal.
+  assert.match(sharedPhpIni, /memory_limit=512M/)
   assert.match(await readFile(join(sharedMount as string, "auto_prepend_file.php"), "utf8"), /<\?php/)
   assert.equal((await stat(join(sharedMount as string, "mu-plugins"))).isDirectory(), true)
   assert.equal((await stat(join(sharedMount as string, "preload"))).isDirectory(), true)


### PR DESCRIPTION
## What
Raises the WP Codebox runtime PHP `memory_limit` 256M → 512M to stop heavy-fixture OOMs in the `collect_artifacts` phase that were sinking SSI fixture-matrix batches.

## Root cause
`collect_artifacts` reads declared/typed artifacts + runtime snapshot files into PHP memory and base64-encodes them (`file_get_contents` + `base64_encode` + `wp_json_encode` each retain a copy, ~2.3x file size in heap). A heavy fixture exhausted the default 256M mid-collection → hard fatal that sank the whole batch.

## Change (`packages/runtime-playground/src/playground-cli-runner.ts`, phpIniContent)
- Default `memory_limit` 256M → 512M — still far below the 2000M upload/post limits already in the same ini; recipes can override per-runtime via `pluginRuntime.php.iniEntries`. Locked with an assertion in `playground-cli-runner-bootstrap-ini.test.ts`.

## Verification
- `npm run build` clean; bootstrap-ini + programmatic-playground-runner tests pass.
- Note: declared artifacts are already capped at 1MB each and the snapshot writer streams file-by-file with unset(); 512M is ample headroom for the observed corpus.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Root-cause diagnosis, fix, and tests under human review.