### PR TITLE
Execute browser callTool host tools

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -538,14 +538,17 @@ caller-owned external checks:
 `tool` is the exact caller-provided host tool command name and must be allowed by
 runtime policy using that same command name. `input` must be JSON-serializable.
 WP Codebox treats this as transport and evidence only; callers own the tool and
-any external system behavior. The current Playground browser-actions runtime
-validates and policy-checks `callTool`, then records a redaction-required
-`wp-codebox/browser-tool-verifier-result/v1` artifact with input shape metadata
-and an `unsupported` status because the host-tool execution bridge is not yet
-available inside browser automation. Raw input values and secrets are not
-serialized into that verifier artifact. Polling fields are intentionally not part
-of this narrow primitive yet; callers should model repeated checks outside the
-browser script until the execution bridge lands.
+any external system behavior. The Playground browser-actions runtime validates
+and policy-checks `callTool`; when the caller provides a matching host tool via
+`RuntimeCreateSpec.hostTools`, Codebox executes it through the generic host-tool
+transport and records the `wp-codebox/host-tool-result/v1` result inside a
+redaction-required `wp-codebox/browser-tool-verifier-result/v1` artifact. When no
+host-tool registry or matching tool is available, or runtime policy does not
+allow the exact tool command, Codebox records stable `unsupported` verifier
+evidence instead of executing the step. Raw input values and secrets are not
+serialized into unsupported verifier artifacts. Polling fields are intentionally
+not part of this narrow primitive yet; callers should model repeated checks
+outside the browser script.
 
 ## Fixture Browser Auth Storage State
 

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises"
-import { BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, assertRuntimeCommandAllowed, browserInteractionScriptToolCalls, browserInteractionScriptUsesEvaluate, browserToolVerifierInputSummary, resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep, type BrowserToolVerifierResult, type ExecutionSpec, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, HostToolRegistry, assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, browserToolVerifierInputSummary, createHostToolRegistry, executeHostTool, resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep, type BrowserToolVerifierResult, type ExecutionSpec, type HostToolDefinition, type JsonValue, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
@@ -23,6 +23,10 @@ import type { Page } from "playwright"
 
 const BROWSER_STEP_DEFAULT_TIMEOUT_MS = 15_000
 const BROWSER_SCRIPT_DEFAULT_TIMEOUT_MS = 120_000
+
+interface HostToolLookup {
+  get(name: string): ReturnType<HostToolRegistry["get"]>
+}
 
 export interface BrowserActionsRunPlan {
   initialUrl?: string
@@ -79,10 +83,6 @@ export async function runBrowserActionsCommand({
   if (browserInteractionScriptUsesEvaluate(steps)) {
     assertRuntimeCommandAllowed("wordpress.browser-actions.evaluate", runtimeSpec.policy)
   }
-  for (const tool of browserInteractionScriptToolCalls(steps)) {
-    assertRuntimeCommandAllowed(tool, runtimeSpec.policy)
-  }
-
   const capture = runPlan.capture
 
   for (const item of capture) {
@@ -185,15 +185,19 @@ export async function runBrowserActionsCommand({
       }
       try {
         if (step.kind === "callTool") {
-          const result = browserToolVerifierUnsupportedResult(step, index, recordStartedAt)
+          const result = await browserToolVerifierResult(step, index, recordStartedAt, runtimeSpec)
           const fileName = `verifier-step-${index}.json`
           await artifactSession.writeJson("verifierResults", fileName, result)
           const artifactPath = artifactSession.path(fileName)
           verifierResults.push({ step: result.step, status: result.status, artifact: artifactPath })
-          const serialized = serializeBrowserError("probe-error", new Error(result.error?.message ?? "wordpress.browser-actions callTool is unsupported"))
+          if (result.status === "ok") {
+            stepRecords.push(browserStepRecord(index, step, "ok", recordStartedAt, recordStartedAtMs, page.url(), { verifierResult: artifactPath }))
+            continue
+          }
+          const serialized = serializeBrowserError("probe-error", new Error(result.error?.message ?? "wordpress.browser-actions callTool verifier failed"))
           errors.push(serialized)
           stepRecords.push(browserStepRecord(index, step, "failed", recordStartedAt, recordStartedAtMs, page.url(), { verifierResult: artifactPath, error: serialized }))
-          pendingError = new Error(result.error?.message ?? "wordpress.browser-actions callTool is unsupported")
+          pendingError = new Error(result.error?.message ?? "wordpress.browser-actions callTool verifier failed")
           break
         }
         const outcome = step.kind === "assertObservation"
@@ -430,6 +434,69 @@ export async function runBrowserActionsCommand({
 
 export function browserToolVerifierUnsupportedResult(step: BrowserInteractionStep, index: number, startedAt: string): BrowserToolVerifierResult {
   const tool = typeof step.tool === "string" ? step.tool : "unknown/unknown"
+  return browserToolVerifierUnsupportedResultWithError(step, index, startedAt, "browser-call-tool-bridge-unavailable", "wordpress.browser-actions validated a callTool step, but this runtime does not expose a host-tool execution bridge inside browser automation.")
+}
+
+export async function browserToolVerifierResult(step: BrowserInteractionStep, index: number, startedAt: string, runtimeSpec: RuntimeCreateSpec): Promise<BrowserToolVerifierResult> {
+  const tool = typeof step.tool === "string" ? step.tool : "unknown/unknown"
+  const input = step.input ?? null
+  const registry = hostToolLookupFromRuntimeSpec(runtimeSpec)
+
+  try {
+    assertRuntimeCommandAllowed(tool, runtimeSpec.policy)
+  } catch (error) {
+    return browserToolVerifierUnsupportedResultWithError(step, index, startedAt, "browser-call-tool-policy-denied", error instanceof Error ? error.message : String(error))
+  }
+
+  if (!registry) {
+    return browserToolVerifierUnsupportedResult(step, index, startedAt)
+  }
+
+  const definition = registry.get(tool)
+  if (!definition) {
+    return browserToolVerifierUnsupportedResultWithError(step, index, startedAt, "browser-call-tool-unregistered", `wordpress.browser-actions callTool requested an unregistered host tool: ${tool}`)
+  }
+
+  const result = await executeHostTool(definition, input, {
+    tool,
+    policyCommand: tool,
+    metadata: { browserActionStep: index },
+  })
+
+  return {
+    schema: BROWSER_TOOL_VERIFIER_RESULT_SCHEMA,
+    status: result.status,
+    step: { index, kind: "callTool", tool },
+    tool,
+    inputSummary: browserToolVerifierInputSummary(input),
+    result: result as unknown as JsonValue,
+    ...(result.status === "error" ? { error: { code: result.error.code, message: result.error.message } } : {}),
+    evidence: browserToolVerifierEvidence(),
+    startedAt,
+    finishedAt: now(),
+  }
+}
+
+function hostToolLookupFromRuntimeSpec(runtimeSpec: RuntimeCreateSpec): HostToolLookup | undefined {
+  const hostTools = runtimeSpec.hostTools as unknown
+  if (hostTools instanceof HostToolRegistry) {
+    return hostTools
+  }
+  if (Array.isArray(hostTools)) {
+    return createHostToolRegistry(hostTools as HostToolDefinition[])
+  }
+  if (isHostToolLookup(hostTools)) {
+    return hostTools
+  }
+  return undefined
+}
+
+function isHostToolLookup(value: unknown): value is HostToolLookup {
+  return Boolean(value) && typeof value === "object" && typeof (value as { get?: unknown }).get === "function"
+}
+
+function browserToolVerifierUnsupportedResultWithError(step: BrowserInteractionStep, index: number, startedAt: string, code: string, message: string): BrowserToolVerifierResult {
+  const tool = typeof step.tool === "string" ? step.tool : "unknown/unknown"
   return {
     schema: BROWSER_TOOL_VERIFIER_RESULT_SCHEMA,
     status: "unsupported",
@@ -437,20 +504,24 @@ export function browserToolVerifierUnsupportedResult(step: BrowserInteractionSte
     tool,
     inputSummary: browserToolVerifierInputSummary(step.input ?? null),
     error: {
-      code: "browser-call-tool-bridge-unavailable",
-      message: "wordpress.browser-actions validated a callTool step, but this runtime does not yet expose a host-tool execution bridge inside browser automation.",
+      code,
+      message,
     },
-    evidence: {
-      redaction: {
-        policy: "required",
-        sensitive: true,
-        reason: "Browser verifier artifacts can include caller tool names, input shapes, URLs, page state, or external verification diagnostics.",
-      },
-      rawInputSerialized: false,
-      rawSecretsSerialized: false,
-    },
+    evidence: browserToolVerifierEvidence(),
     startedAt,
     finishedAt: now(),
+  }
+}
+
+function browserToolVerifierEvidence(): BrowserToolVerifierResult["evidence"] {
+  return {
+    redaction: {
+      policy: "required",
+      sensitive: true,
+      reason: "Browser verifier artifacts can include caller tool names, input shapes, URLs, page state, host-tool outputs, or external verification diagnostics.",
+    },
+    rawInputSerialized: false,
+    rawSecretsSerialized: false,
   }
 }
 

--- a/tests/browser-interaction-tool-verifier.test.ts
+++ b/tests/browser-interaction-tool-verifier.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict"
 
-import { BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, browserInteractionScriptToolCalls, validateBrowserInteractionScript } from "../packages/runtime-core/src/index.js"
+import { BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, HOST_TOOL_RESULT_SCHEMA, createHostToolRegistry, browserInteractionScriptToolCalls, validateBrowserInteractionScript, type RuntimeCreateSpec } from "../packages/runtime-core/src/index.js"
 import { browserArtifactFileManifest } from "../packages/runtime-playground/src/browser-artifacts.js"
-import { browserToolVerifierUnsupportedResult } from "../packages/runtime-playground/src/browser-actions-runner.js"
+import { browserToolVerifierResult, browserToolVerifierUnsupportedResult } from "../packages/runtime-playground/src/browser-actions-runner.js"
 
 const valid = validateBrowserInteractionScript([
   { kind: "navigate", url: "/" },
@@ -36,3 +36,56 @@ assert.equal(manifest.kind, "browser-verifier-result")
 assert.equal(manifest.contentType, "application/json")
 assert.equal(manifest.redaction?.policy, "required")
 assert.equal(manifest.redaction?.sensitive, true)
+
+let calls = 0
+const registry = createHostToolRegistry([{
+  name: "client/check_status",
+  description: "Check status",
+  inputSchema: { type: "object", required: ["expected"] },
+  outputSchema: { type: "object", required: ["status"] },
+  policy: { capability: "client/check_status", risk: "read" },
+  handler: (input, context) => {
+    calls++
+    assert.equal(context.tool, "client/check_status")
+    assert.equal(context.policyCommand, "client/check_status")
+    assert.deepEqual(input, { expected: "ready" })
+    return { status: "ready" }
+  },
+}])
+
+const runtimeSpec: RuntimeCreateSpec = {
+  backend: "wordpress-playground",
+  environment: {},
+  policy: {
+    network: "deny",
+    filesystem: "sandbox",
+    commands: ["wordpress.browser-actions", "client/check_status"],
+    secrets: "none",
+    approvals: "never",
+  },
+  hostTools: registry,
+}
+
+const executed = await browserToolVerifierResult({ kind: "callTool", tool: "client/check_status", input: { expected: "ready" } }, 2, "2026-01-01T00:00:00.000Z", runtimeSpec)
+assert.equal(executed.status, "ok")
+assert.equal(executed.tool, "client/check_status")
+assert.equal(calls, 1)
+assert.equal((executed.result as Record<string, unknown>).schema, HOST_TOOL_RESULT_SCHEMA)
+assert.equal((executed.result as Record<string, unknown>).status, "ok")
+assert.equal(Object.prototype.hasOwnProperty.call(executed, "input"), false)
+assert.equal(executed.evidence.redaction.policy, "required")
+
+const missingTool = await browserToolVerifierResult({ kind: "callTool", tool: "client/missing", input: {} }, 3, "2026-01-01T00:00:00.000Z", {
+  ...runtimeSpec,
+  policy: { ...runtimeSpec.policy, commands: ["wordpress.browser-actions", "client/missing"] },
+})
+assert.equal(missingTool.status, "unsupported")
+assert.equal(missingTool.error?.code, "browser-call-tool-unregistered")
+
+const denied = await browserToolVerifierResult({ kind: "callTool", tool: "client/check_status", input: { expected: "ready" } }, 4, "2026-01-01T00:00:00.000Z", {
+  ...runtimeSpec,
+  policy: { ...runtimeSpec.policy, commands: ["wordpress.browser-actions"] },
+})
+assert.equal(denied.status, "unsupported")
+assert.equal(denied.error?.code, "browser-call-tool-policy-denied")
+assert.equal(calls, 1)


### PR DESCRIPTION
## Summary
- Execute browser-actions callTool steps through caller-provided host tools when registered and policy-allowed.
- Preserve redaction-required verifier artifacts for host-tool results and stable unsupported evidence for missing bridge/tool/policy denial.
- Document the updated recipe contract and cover success, missing tool, and policy-denied behavior with a focused verifier test.

## Tests
- npx tsx tests/browser-interaction-tool-verifier.test.ts
- npm run test:command-router
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the generic browser callTool host-tool execution bridge and tests.