### PR TITLE
Add public WordPress action auth contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "test:production-boundary-enforcement": "tsx tests/production-boundary-enforcement.test.ts",
     "test:public-api-contract": "tsx tests/public-api-contract.test.ts",
     "test:wordpress-runtime-actions": "tsx tests/wordpress-runtime-actions.test.ts",
+    "test:wordpress-action-auth-contract": "tsx tests/wordpress-action-auth-contract.test.ts",
     "test:wordpress-hotspots-contracts": "tsx tests/wordpress-hotspots-contracts.test.ts",
     "test:wordpress-db-contracts": "tsx tests/wordpress-db-contracts.test.ts",
     "test:browser-sdk-facade": "tsx tests/browser-sdk-facade.test.ts",

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -103,6 +103,11 @@ const snapshotScopingAcceptedArgs: CommandDefinition["acceptedArgs"] = [
 const browserActionCaptureValues = ["steps", "actions", "console", "errors", "html", "network", "screenshot", "dom-snapshot"] as const
 const browserScenarioCaptureValues = ["steps", "actions", "console", "errors", "html", "network", "performance", "memory", "screenshot", "dom-snapshot"] as const
 const editorCaptureValues = ["steps", "console", "errors", "html", "screenshot", "editor-state", "editor-validity"] as const
+const wordpressAuthArtifactProperties = {
+  auth: { type: "string" },
+  storageState: { type: "string" },
+  summary: { type: "string" },
+}
 
 const browserProbeValidation: CommandValidationDescriptor = {
   requiredArgs: [
@@ -193,6 +198,55 @@ export const commandRegistry = [
     policyRequirement: "Runtime policy commands must include command-agent-run and the target command.",
     recipe: true,
     handler: { kind: "playground", method: "runCommandAgent" },
+  },
+  {
+    id: "wordpress.session",
+    description: "Resolve a declared WordPress fixture user or named user session and return reviewer-safe session metadata plus optional redaction-required browser storage-state artifacts.",
+    acceptedArgs: [
+      { name: "user", description: "Named fixture user from recipe inputs.fixtureUsers to resolve.", format: "fixture user name" },
+      { name: "session", description: "Named user session from recipe inputs.userSessions to resolve.", format: "user session name" },
+      { name: "role", description: "WordPress role for an ephemeral fixture user when no named user or session is supplied.", format: "wordpress role" },
+      { name: "browser-urls", description: "Optional comma-separated browser origins or URLs whose hosts should receive WordPress auth cookies when storage-state output is requested.", format: "comma-separated URLs" },
+      { name: "output-dir", description: "Optional artifact directory relative to the runtime artifact root; defaults to files/wordpress-auth.", format: "relative path" },
+    ],
+    outputShape: "wp-codebox/wordpress-session/v1 JSON with redacted session summary, fixture user metadata, and artifact refs only for secret cookie material.",
+    outputSchema: artifactSummarySchema("wp-codebox/wordpress-session/v1", wordpressAuthArtifactProperties),
+    policyRequirement: "Runtime policy commands must include wordpress.session.",
+    recipe: true,
+    handler: { kind: "playground", method: "runWordPressSession" },
+  },
+  {
+    id: "wordpress.nonce",
+    description: "Resolve a WordPress nonce for an explicit action in a declared fixture user or named session context and return only redacted nonce metadata.",
+    acceptedArgs: [
+      { name: "action", description: "WordPress nonce action to resolve. Defaults to wp_rest.", format: "string" },
+      { name: "user", description: "Named fixture user from recipe inputs.fixtureUsers to resolve before creating the nonce.", format: "fixture user name" },
+      { name: "session", description: "Named user session from recipe inputs.userSessions to resolve before creating the nonce.", format: "user session name" },
+      { name: "role", description: "WordPress role for an ephemeral fixture user when no named user or session is supplied.", format: "wordpress role" },
+      { name: "output-dir", description: "Optional artifact directory relative to the runtime artifact root; defaults to files/wordpress-auth.", format: "relative path" },
+    ],
+    outputShape: "wp-codebox/wordpress-nonce/v1 JSON with nonce presence, action, user summary, and redaction-required artifact refs without exposing nonce values in stdout.",
+    outputSchema: artifactSummarySchema("wp-codebox/wordpress-nonce/v1", wordpressAuthArtifactProperties),
+    policyRequirement: "Runtime policy commands must include wordpress.nonce.",
+    recipe: true,
+    handler: { kind: "playground", method: "runWordPressNonce" },
+  },
+  {
+    id: "wordpress.action-auth",
+    description: "Resolve WordPress user/session auth, action nonce, REST nonce, and optional browser storage-state artifact for destructive runtime actions.",
+    acceptedArgs: [
+      { name: "action", description: "WordPress action nonce to resolve. Defaults to wp_rest.", format: "string" },
+      { name: "user", description: "Named fixture user from recipe inputs.fixtureUsers to resolve.", format: "fixture user name" },
+      { name: "session", description: "Named user session from recipe inputs.userSessions to resolve.", format: "user session name" },
+      { name: "role", description: "WordPress role for an ephemeral fixture user when no named user or session is supplied.", format: "wordpress role" },
+      { name: "browser-urls", description: "Optional comma-separated browser origins or URLs whose hosts should receive WordPress auth cookies.", format: "comma-separated URLs" },
+      { name: "output-dir", description: "Optional artifact directory relative to the runtime artifact root; defaults to files/wordpress-auth.", format: "relative path" },
+    ],
+    outputShape: "wp-codebox/wordpress-action-auth/v1 JSON with explicit auth/session/nonce capability resolution and only redaction-required artifact refs for secret cookie and nonce values.",
+    outputSchema: artifactSummarySchema("wp-codebox/wordpress-action-auth/v1", wordpressAuthArtifactProperties),
+    policyRequirement: "Runtime policy commands must include wordpress.action-auth.",
+    recipe: true,
+    handler: { kind: "playground", method: "runWordPressActionAuth" },
   },
   {
     id: "wordpress.run-php",

--- a/packages/runtime-core/src/wordpress-runtime-discovery-contracts.ts
+++ b/packages/runtime-core/src/wordpress-runtime-discovery-contracts.ts
@@ -11,7 +11,7 @@ export type WordPressRuntimeInventoryCommand =
   | "wordpress.inventory-database"
   | "wordpress.frontend-url-inventory"
 
-export type WordPressRuntimeDiscoverySurface = "rest" | "admin" | "database" | "frontend" | "blocks"
+export type WordPressRuntimeDiscoverySurface = "rest" | "admin" | "database" | "frontend" | "blocks" | "auth"
 
 export interface WordPressRuntimeDiscoveryResult {
   schema: typeof WORDPRESS_RUNTIME_DISCOVERY_SCHEMA
@@ -23,6 +23,7 @@ export interface WordPressRuntimeDiscoveryResult {
   database?: WordPressDatabaseSchemaDiscovery
   frontend?: WordPressFrontendRouteDiscovery
   blocks?: WordPressBlockEditorTargetDiscovery
+  auth?: WordPressRuntimeAuthDiscovery
   diagnostics: WordPressRuntimeDiscoveryDiagnostic[]
 }
 
@@ -266,4 +267,28 @@ export interface WordPressEditorPostTypeDescriptor {
   label: string
   restBase: string
   editorUrl: string
+}
+
+export interface WordPressRuntimeAuthDiscovery {
+  schema: "wp-codebox/wordpress-auth-discovery/v1"
+  actions: WordPressRuntimeAuthActionDescriptor[]
+  capabilities: {
+    fixtureUsers: boolean
+    userSessions: boolean
+    browserStorageStateArtifacts: boolean
+    restNonce: boolean
+    actionNonce: boolean
+  }
+  resultRedaction: {
+    cookies: "artifact-ref-only"
+    nonces: "redacted-in-summary"
+  }
+}
+
+export interface WordPressRuntimeAuthActionDescriptor {
+  command: "wordpress.session" | "wordpress.nonce" | "wordpress.action-auth"
+  purpose: string
+  acceptedSelectors: string[]
+  artifactKinds: string[]
+  redactionRequired: boolean
 }

--- a/packages/runtime-playground/src/command-router.ts
+++ b/packages/runtime-playground/src/command-router.ts
@@ -9,6 +9,9 @@ interface PlaygroundCommandRuntime {
   runCommandAgent(spec: ExecutionSpec): Promise<PlaygroundCommandOutput>
   runPhp(spec: ExecutionSpec): Promise<PlaygroundCommandOutput>
   runWpCli(spec: ExecutionSpec): Promise<string>
+  runWordPressSession(spec: ExecutionSpec): Promise<string>
+  runWordPressNonce(spec: ExecutionSpec): Promise<string>
+  runWordPressActionAuth(spec: ExecutionSpec): Promise<string>
   runExportBrowserStorageState(spec: ExecutionSpec): Promise<string>
   runCaptureStateBundle(spec: ExecutionSpec): Promise<string>
   runExportReplayPackage(spec: ExecutionSpec): Promise<string>

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -26,6 +26,7 @@ import { createRuntimeWpCliBridge, type RuntimeWpCliBridge } from "./runtime-wp-
 import { writeReplayExportPackage } from "./replayable-wordpress-site-bundle.js"
 import { preflightPhpWasmRuntimeAssets } from "./php-wasm-preflight.js"
 import { previewReviewerAccess } from "./preview-reviewer-access.js"
+import { wordpressActionAuthNoncePhpCode, wordpressFixtureUserWithoutPassword, wordpressUserSessionFromCommandArgs, type WordPressUserSessionResolution } from "./wordpress-user-sessions.js"
 import type {
   ArtifactBundle,
   ArtifactManifestFile,
@@ -1048,6 +1049,112 @@ class PlaygroundRuntime implements Runtime {
     return cleanWpCliOutput(response.text)
   }
 
+  async runWordPressSession(spec: ExecutionSpec): Promise<string> {
+    const server = await this.bootPlayground()
+    const resolution = resolveWordPressActionAuthUser(spec.args ?? [], this.spec)
+    const browserUrls = stringListArg(spec.args ?? [], "browser-urls") ?? [this.spec.preview?.publicUrl ?? server.serverUrl]
+    const outputDirectory = wordpressAuthOutputDirectory(this.artifactRoot, stringArg(spec.args ?? [], "output-dir"))
+    const artifacts = await this.writeWordPressAuthStorageStateArtifacts("wordpress.session", server, outputDirectory, browserUrls, resolution)
+
+    return `${JSON.stringify({
+      schema: "wp-codebox/wordpress-session/v1",
+      status: "resolved",
+      command: "wordpress.session",
+      session: resolution.metadata,
+      redaction: { cookies: "artifact-ref-only" },
+      artifacts: { ...artifacts.paths, redactionRequired: { storageState: true, summary: false } },
+      artifactRefs: artifacts.refs,
+    }, null, 2)}\n`
+  }
+
+  async runWordPressNonce(spec: ExecutionSpec): Promise<string> {
+    return this.runWordPressActionAuthResult("wordpress.nonce", spec, false)
+  }
+
+  async runWordPressActionAuth(spec: ExecutionSpec): Promise<string> {
+    return this.runWordPressActionAuthResult("wordpress.action-auth", spec, true)
+  }
+
+  private async runWordPressActionAuthResult(command: "wordpress.nonce" | "wordpress.action-auth", spec: ExecutionSpec, includeStorageState: boolean): Promise<string> {
+    const server = await this.bootPlayground()
+    const resolution = resolveWordPressActionAuthUser(spec.args ?? [], this.spec)
+    const action = stringArg(spec.args ?? [], "action") ?? "wp_rest"
+    const outputDirectory = wordpressAuthOutputDirectory(this.artifactRoot, stringArg(spec.args ?? [], "output-dir"))
+    const noncePayload = await this.resolveWordPressNonceArtifact(command, server, outputDirectory, action, resolution)
+    const storageArtifacts = includeStorageState
+      ? await this.writeWordPressAuthStorageStateArtifacts(command, server, outputDirectory, stringListArg(spec.args ?? [], "browser-urls") ?? [this.spec.preview?.publicUrl ?? server.serverUrl], resolution)
+      : undefined
+
+    return `${JSON.stringify({
+      schema: command === "wordpress.nonce" ? "wp-codebox/wordpress-nonce/v1" : "wp-codebox/wordpress-action-auth/v1",
+      status: "resolved",
+      command,
+      session: resolution.metadata,
+      nonces: {
+        action,
+        actionNonce: { present: true, redacted: true },
+        restNonce: { action: "wp_rest", present: true, redacted: true },
+      },
+      redaction: { cookies: "artifact-ref-only", nonces: "redacted-in-summary" },
+      artifacts: { auth: noncePayload.path, ...(storageArtifacts?.paths ?? {}), redactionRequired: { auth: true, storageState: Boolean(storageArtifacts), summary: false } },
+      artifactRefs: [noncePayload.ref, ...(storageArtifacts?.refs ?? [])],
+    }, null, 2)}\n`
+  }
+
+  private async resolveWordPressNonceArtifact(command: string, server: PlaygroundCliServer, outputDirectory: string, action: string, resolution: WordPressUserSessionResolution): Promise<{ path: string; ref: RuntimeEpisodeTraceRef }> {
+    const code = wordpressActionAuthNoncePhpCode(command, action, resolution)
+    const response = await this.runPlaygroundCommand(command, server, { code: bootstrapPhpCode(this.spec, code, []) })
+    assertPlaygroundResponseOk(command, response)
+    const secret = JSON.parse(response.text) as Record<string, unknown>
+    const authPath = join(outputDirectory, "action-auth.json")
+    const artifactPath = artifactRelativePath(this.artifactRoot, authPath)
+    const contents = `${JSON.stringify(secret, null, 2)}\n`
+    await mkdir(outputDirectory, { recursive: true })
+    await writeFile(authPath, contents)
+    return {
+      path: artifactPath,
+      ref: { kind: command === "wordpress.nonce" ? "wordpress-nonce" : "wordpress-action-auth", id: `${command}:action-auth`, path: artifactPath, digest: { algorithm: "sha256", value: sha256(Buffer.from(contents, "utf8")) } },
+    }
+  }
+
+  private async writeWordPressAuthStorageStateArtifacts(command: string, server: PlaygroundCliServer, outputDirectory: string, browserUrls: string[], resolution: WordPressUserSessionResolution): Promise<{ paths: { storageState: string; summary: string }; refs: RuntimeEpisodeTraceRef[] }> {
+    const response = await this.runPlaygroundCommand(command, server, { code: bootstrapPhpCode(this.spec, wordpressFixtureUserStorageStatePhpCode({ browserUrls, user: wordpressFixtureUserWithoutPassword(resolution.user) }), []) })
+    assertPlaygroundResponseOk(command, response)
+    const payload = JSON.parse(response.text) as Record<string, unknown>
+    const normalized = normalizeBrowserStorageStatePayload(payload, "inline")
+    if (normalized.summary.status !== "ready") {
+      throw new Error(`${command} could not resolve browser storage state: ${JSON.stringify(normalized.summary.diagnostics)}`)
+    }
+
+    const storageStatePath = join(outputDirectory, "storage-state.json")
+    const summaryPath = join(outputDirectory, "summary.json")
+    const storageStateArtifactPath = artifactRelativePath(this.artifactRoot, storageStatePath)
+    const summaryArtifactPath = artifactRelativePath(this.artifactRoot, summaryPath)
+    const exportedUser = payload.user && typeof payload.user === "object" && !Array.isArray(payload.user) ? payload.user as Record<string, unknown> : {}
+    const summary = {
+      schema: "wp-codebox/wordpress-auth-summary/v1",
+      command,
+      status: "resolved",
+      session: resolution.metadata,
+      user: storageStateUserSummary(exportedUser),
+      storageState: normalized.summary,
+      redaction: { cookies: "artifact-ref-only" },
+      artifacts: { storageState: storageStateArtifactPath, summary: summaryArtifactPath },
+    }
+    const storageStateJson = `${JSON.stringify(normalized.storageState, null, 2)}\n`
+    const summaryJson = `${JSON.stringify(summary, null, 2)}\n`
+    await mkdir(outputDirectory, { recursive: true })
+    await writeFile(storageStatePath, storageStateJson)
+    await writeFile(summaryPath, summaryJson)
+    return {
+      paths: { storageState: storageStateArtifactPath, summary: summaryArtifactPath },
+      refs: [
+        { kind: "browser-storage-state", id: `${command}:storage-state`, path: storageStateArtifactPath, digest: { algorithm: "sha256", value: sha256(Buffer.from(storageStateJson, "utf8")) } },
+        { kind: "browser-storage-state-summary", id: `${command}:storage-state-summary`, path: summaryArtifactPath, digest: { algorithm: "sha256", value: sha256(Buffer.from(summaryJson, "utf8")) } },
+      ],
+    }
+  }
+
   async runExportBrowserStorageState(spec: ExecutionSpec): Promise<string> {
     const server = await this.bootPlayground()
     const outputDirectory = storageStateOutputDirectory(this.artifactRoot, stringArg(spec.args ?? [], "output-dir"))
@@ -1754,6 +1861,42 @@ function storageStateOutputDirectory(artifactRoot: string, requested: string | u
   }
 
   return join(artifactRoot, relativePath)
+}
+
+function wordpressAuthOutputDirectory(artifactRoot: string, requested: string | undefined): string {
+  const relativePath = requested?.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "") || "files/wordpress-auth"
+  if (relativePath.length === 0 || relativePath.includes("..")) {
+    throw new Error("wordpress auth output-dir must be a relative path inside the runtime artifact root")
+  }
+
+  return join(artifactRoot, relativePath)
+}
+
+function resolveWordPressActionAuthUser(args: string[], runtimeSpec: RuntimeCreateSpec): WordPressUserSessionResolution {
+  const recipeResolution = wordpressUserSessionFromCommandArgs(args, runtimeSpec)
+  if (recipeResolution) {
+    return recipeResolution
+  }
+
+  const role = stringArg(args, "role") ?? "administrator"
+  const normalizedRole = role.replace(/[^a-z0-9_-]/gi, "").toLowerCase()
+  if (!normalizedRole) {
+    throw new Error("wordpress auth role must be a non-empty WordPress role slug")
+  }
+
+  return {
+    source: "user",
+    name: `role:${normalizedRole}`,
+    user: { name: `role:${normalizedRole}`, username: `wp-codebox-${normalizedRole}`, role: normalizedRole, email: `wp-codebox-${normalizedRole}@example.test` },
+    metadata: {
+      schema: "wp-codebox/wordpress-user-session/v1",
+      source: "user",
+      name: `role:${normalizedRole}`,
+      user: { name: `role:${normalizedRole}`, username: `wp-codebox-${normalizedRole}`, email: `wp-codebox-${normalizedRole}@example.test`, role: normalizedRole },
+      artifacts: [],
+      redactionRequired: false,
+    },
+  }
 }
 
 function artifactRelativePath(artifactRoot: string, absolutePath: string): string {

--- a/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
+++ b/packages/runtime-playground/src/runtime-discovery-command-handlers.ts
@@ -1,9 +1,9 @@
 import { commaListArg } from "./command-args.js"
 
-export type RuntimeDiscoverySurface = "rest" | "admin" | "database" | "frontend" | "blocks"
+export type RuntimeDiscoverySurface = "rest" | "admin" | "database" | "frontend" | "blocks" | "auth"
 export type RuntimeInventorySurface = "rest" | "admin" | "database" | "frontend"
 
-const runtimeDiscoverySurfaces = ["rest", "admin", "database", "frontend", "blocks"] as const satisfies readonly RuntimeDiscoverySurface[]
+const runtimeDiscoverySurfaces = ["rest", "admin", "database", "frontend", "blocks", "auth"] as const satisfies readonly RuntimeDiscoverySurface[]
 
 export function runtimeDiscoverySurfacesFromArgs(args: string[]): RuntimeDiscoverySurface[] {
   const requested = commaListArg(args, "surface")
@@ -320,6 +320,49 @@ function runtime_discovery_blocks(): array {
     }
 
     return array('payload' => array('schema' => 'wp-codebox/wordpress-block-editor-target-discovery/v1', 'blocks' => $blocks, 'editorPostTypes' => $post_types), 'diagnostics' => array());
+}
+
+function runtime_discovery_auth(): array {
+    return array(
+        'payload' => array(
+            'schema' => 'wp-codebox/wordpress-auth-discovery/v1',
+            'actions' => array(
+                array(
+                    'command' => 'wordpress.session',
+                    'purpose' => 'Resolve a declared fixture user or named user session and produce reviewer-safe session metadata plus optional redaction-required browser storage-state artifacts.',
+                    'acceptedSelectors' => array('user', 'session'),
+                    'artifactKinds' => array('browser-storage-state', 'browser-storage-state-summary'),
+                    'redactionRequired' => true,
+                ),
+                array(
+                    'command' => 'wordpress.nonce',
+                    'purpose' => 'Resolve a WordPress nonce for an explicit action in the selected fixture user or session context.',
+                    'acceptedSelectors' => array('action', 'user', 'session'),
+                    'artifactKinds' => array('wordpress-nonce'),
+                    'redactionRequired' => true,
+                ),
+                array(
+                    'command' => 'wordpress.action-auth',
+                    'purpose' => 'Resolve a fixture user/session, action nonce, REST nonce, and optional browser storage-state artifact for destructive runtime actions.',
+                    'acceptedSelectors' => array('action', 'user', 'session'),
+                    'artifactKinds' => array('wordpress-action-auth', 'browser-storage-state', 'browser-storage-state-summary'),
+                    'redactionRequired' => true,
+                ),
+            ),
+            'capabilities' => array(
+                'fixtureUsers' => true,
+                'userSessions' => true,
+                'browserStorageStateArtifacts' => true,
+                'restNonce' => function_exists('wp_create_nonce'),
+                'actionNonce' => function_exists('wp_create_nonce'),
+            ),
+            'resultRedaction' => array(
+                'cookies' => 'artifact-ref-only',
+                'nonces' => 'redacted-in-summary',
+            ),
+        ),
+        'diagnostics' => array(),
+    );
 }
 
 function runtime_discovery_block_attribute_value($value, int $depth = 0) {

--- a/packages/runtime-playground/src/wordpress-user-sessions.ts
+++ b/packages/runtime-playground/src/wordpress-user-sessions.ts
@@ -116,6 +116,30 @@ if ( ! in_array( $sandbox_role, (array) $sandbox_wp_user->roles, true ) ) {
 wp_set_current_user( $sandbox_user_id );`
 }
 
+export function wordpressActionAuthNoncePhpCode(command: string, action: string, resolution: WordPressUserSessionResolution): string {
+  return `${wordpressFixtureUserPhpCode(wordpressFixtureUserWithoutPassword(resolution.user))}
+$wp_codebox_action_auth_action = ${JSON.stringify(action)};
+$wp_codebox_action_auth_payload = array(
+    'schema' => 'wp-codebox/wordpress-action-auth-secret/v1',
+    'command' => ${JSON.stringify(command)},
+    'user' => array(
+        'id' => get_current_user_id(),
+        'role' => ${JSON.stringify(resolution.metadata.user.role)},
+    ),
+    'nonces' => array(
+        'action' => $wp_codebox_action_auth_action,
+        'actionNonce' => wp_create_nonce( $wp_codebox_action_auth_action ),
+        'restNonce' => wp_create_nonce( 'wp_rest' ),
+    ),
+);
+echo wp_json_encode($wp_codebox_action_auth_payload, JSON_UNESCAPED_SLASHES);`
+}
+
+export function wordpressFixtureUserWithoutPassword(user: WordPressFixtureUserSpec): WordPressFixtureUserSpec {
+  const { password: _password, ...safeUser } = user
+  return safeUser
+}
+
 function wordpressUserSessionResolution(source: "user" | "session", name: string, user: Record<string, unknown>, artifacts: unknown[]): WordPressUserSessionResolution {
   const normalizedUser = normalizeFixtureUser(user)
   const normalizedArtifacts = artifacts.filter(isRecord).map((artifact) => ({

--- a/tests/wordpress-action-auth-contract.test.ts
+++ b/tests/wordpress-action-auth-contract.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict"
+import { commandRegistry } from "../packages/runtime-core/src/command-registry.js"
+import { runtimeDiscoveryPhpCode, runtimeDiscoverySurfacesFromArgs } from "../packages/runtime-playground/src/runtime-discovery-command-handlers.js"
+import { wordpressActionAuthNoncePhpCode, wordpressUserSessionFromCommandArgs } from "../packages/runtime-playground/src/wordpress-user-sessions.js"
+import type { RuntimeCreateSpec } from "../packages/runtime-core/src/runtime-contracts.js"
+
+const authCommands = ["wordpress.session", "wordpress.nonce", "wordpress.action-auth"]
+
+for (const commandId of authCommands) {
+  const command = commandRegistry.find((definition) => definition.id === commandId)
+  assert.ok(command, `${commandId} is registered`)
+  assert.equal(command?.recipe, true, `${commandId} is recipe-visible`)
+  assert.equal(command?.handler.kind, "playground", `${commandId} has a Playground handler`)
+  assert.ok(command?.acceptedArgs.some((arg) => arg.name === "user"), `${commandId} accepts explicit fixture user selectors`)
+  assert.ok(command?.acceptedArgs.some((arg) => arg.name === "session"), `${commandId} accepts explicit session selectors`)
+  assert.ok(command?.acceptedArgs.some((arg) => arg.name === "role"), `${commandId} accepts explicit role selectors`)
+  assert.match(command?.outputShape ?? "", /redact|artifact refs|redaction/i, `${commandId} documents redacted output`)
+}
+
+const sessionCommand = commandRegistry.find((definition) => definition.id === "wordpress.session")
+assert.equal(sessionCommand?.outputSchema?.id, "wp-codebox/wordpress-session/v1")
+assert.ok(sessionCommand?.outputSchema?.jsonSchema)
+
+const nonceCommand = commandRegistry.find((definition) => definition.id === "wordpress.nonce")
+assert.equal(nonceCommand?.outputSchema?.id, "wp-codebox/wordpress-nonce/v1")
+assert.ok(nonceCommand?.acceptedArgs.some((arg) => arg.name === "action"), "nonce command accepts explicit action")
+
+const actionAuthCommand = commandRegistry.find((definition) => definition.id === "wordpress.action-auth")
+assert.equal(actionAuthCommand?.outputSchema?.id, "wp-codebox/wordpress-action-auth/v1")
+assert.ok(actionAuthCommand?.acceptedArgs.some((arg) => arg.name === "browser-urls"), "action-auth can materialize browser auth for explicit URLs")
+
+assert.deepEqual(runtimeDiscoverySurfacesFromArgs(["surface=auth"]), ["auth"])
+const discoveryPhp = runtimeDiscoveryPhpCode(["auth"])
+assert.match(discoveryPhp, /wp-codebox\/wordpress-auth-discovery\/v1/)
+assert.match(discoveryPhp, /wordpress\.session/)
+assert.match(discoveryPhp, /wordpress\.nonce/)
+assert.match(discoveryPhp, /wordpress\.action-auth/)
+assert.match(discoveryPhp, /browserStorageStateArtifacts/)
+assert.match(discoveryPhp, /artifact-ref-only/)
+assert.match(discoveryPhp, /redacted-in-summary/)
+
+const runtimeSpec = {
+  metadata: {
+    recipe: {
+      schema: "wp-codebox/workspace-recipe/v1",
+      inputs: {
+        fixtureUsers: [{ name: "admin", username: "fixture-admin", role: "administrator", password: "secret-password" }],
+        userSessions: [{ name: "admin-session", user: "admin", artifacts: [{ kind: "browser-storage-state", path: "files/auth/storage-state.json" }] }],
+      },
+    },
+  },
+} as RuntimeCreateSpec
+
+const session = wordpressUserSessionFromCommandArgs(["session=admin-session"], runtimeSpec)
+assert.ok(session, "named sessions resolve through the public selector")
+assert.equal(session?.metadata.user.role, "administrator")
+assert.equal(session?.metadata.redactionRequired, true)
+assert.doesNotMatch(JSON.stringify(session?.metadata), /secret-password/)
+
+const noncePhp = wordpressActionAuthNoncePhpCode("wordpress.action-auth", "delete_post_123", session)
+assert.match(noncePhp, /wp_set_current_user\( \$sandbox_user_id \)/)
+assert.match(noncePhp, /wp_create_nonce\( \$wp_codebox_action_auth_action \)/)
+assert.match(noncePhp, /wp_create_nonce\( 'wp_rest' \)/)
+assert.match(noncePhp, /wp-codebox\/wordpress-action-auth-secret\/v1/)
+assert.doesNotMatch(noncePhp, /secret-password/)
+
+console.log("wordpress action auth public contract ok")

--- a/tests/wordpress-runtime-discovery-contracts.test.ts
+++ b/tests/wordpress-runtime-discovery-contracts.test.ts
@@ -23,12 +23,12 @@ const result: WordPressRuntimeDiscoveryResult = {
   schema: WORDPRESS_RUNTIME_DISCOVERY_SCHEMA,
   command: "wordpress.runtime-discovery",
   status: "ok",
-  surfaces: ["rest", "admin", "database", "frontend", "blocks"],
+  surfaces: ["rest", "admin", "database", "frontend", "blocks", "auth"],
   diagnostics: [],
 }
 
 assert.equal(result.schema, "wp-codebox/wordpress-runtime-discovery/v1")
-assert.deepEqual(runtimeDiscoverySurfacesFromArgs([]), ["rest", "admin", "database", "frontend", "blocks"])
+assert.deepEqual(runtimeDiscoverySurfacesFromArgs([]), ["rest", "admin", "database", "frontend", "blocks", "auth"])
 assert.deepEqual(runtimeDiscoverySurfacesFromArgs(["surface=rest,blocks,rest"]), ["rest", "blocks"])
 assert.throws(() => runtimeDiscoverySurfacesFromArgs(["surface=woocommerce"]), /unsupported: woocommerce/)
 


### PR DESCRIPTION
## Summary
- Add first-class public `wordpress.session`, `wordpress.nonce`, and `wordpress.action-auth` runtime commands for explicit role/user/session/nonce auth resolution.
- Expose an `auth` surface in `wordpress.runtime-discovery` with supported auth actions, capabilities, artifact kinds, and redaction contract.
- Return cookie/nonce secrets only through redaction-required artifacts while command stdout exposes reviewer-safe summaries and artifact refs.

## Tests
- `npm run test:wordpress-action-auth-contract`
- `npm run test:recipe-user-session`
- `npm run test:fixture-auth-storage-state`
- `npm run test:wordpress-runtime-discovery-contracts`
- `npm run test:runtime-contract-package-exports`
- `npm run test:public-api-contract`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the public WordPress auth/session/nonce runtime contract, tests, and PR description.