### PR TITLE
Bound WordPress diagnostic setup/collect in capture-html (fix 25-min hang under contention)

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "test:generic-primitives": "npm run test:artifact-path-primitives && npm run test:browser-callback-materialization-contracts && npm run test:source-package-compiler-primitives && npm run test:bench-command-step-behavior && npm run test:generic-ability-runtime-run",
     "test:browser-artifact-session": "tsx tests/browser-artifact-session.test.ts",
     "test:browser-diagnostic-providers": "tsx tests/browser-diagnostic-providers.test.ts",
+    "test:browser-capture-html-diagnostics-reliability": "tsx tests/browser-capture-html-diagnostics-reliability.test.ts",
     "test:browser-provider-permissions": "tsx tests/browser-provider-permissions.test.ts",
     "test:browser-provider-bridge-inheritance": "tsx tests/browser-provider-bridge-inheritance.test.ts",
     "test:fixture-auth-storage-state": "tsx tests/fixture-auth-storage-state.test.ts",

--- a/packages/runtime-playground/src/browser-command-runners.ts
+++ b/packages/runtime-playground/src/browser-command-runners.ts
@@ -15,6 +15,7 @@ export { wordpressAdminAuthCookiePhpCode } from "./browser-probe-support.js"
 export { runVisualCompareCommand } from "./browser-visual-compare.js"
 
 export async function runHtmlCaptureCommand(input: {
+  abortSignal?: AbortSignal
   artifactRoot: string
   runtimeSpec: RuntimeCreateSpec
   runPlaygroundCommand?: (command: string, server: PlaygroundCliServer, options: { code: string } | { scriptPath: string }) => Promise<PlaygroundRunResponse>

--- a/packages/runtime-playground/src/browser-probe-runner.ts
+++ b/packages/runtime-playground/src/browser-probe-runner.ts
@@ -3,7 +3,7 @@ import { BrowserArtifactSession } from "./browser-artifact-session.js"
 import { BrowserCommandArtifactError } from "./browser-command-artifact-error.js"
 import type { BrowserArtifactFiles, BrowserProbeArtifact, BrowserProbeAuthSummary, BrowserProbeCapabilityDiagnostics, BrowserProbeCheckpointRecord, BrowserProbeContextDetails, BrowserProbeErrorRecord, BrowserProbeLifecycleArtifact, BrowserProbeMemoryArtifact, BrowserProbeNetworkRecord, BrowserProbePerformanceArtifact, BrowserProbeScriptMetadata, BrowserProbeViewport, BrowserProbeWebSocketRecord, BrowserWordPressDiagnosticsSummary } from "./browser-artifacts.js"
 import { attachBrowserCaptureListeners, chromiumBrowserMetadata, launchChromiumBrowser, settleBrowserNetworkTasks } from "./browser-capture-session.js"
-import { browserCommandLivenessPolicy, isBrowserCommandLivenessError } from "./browser-liveness.js"
+import { browserCommandLivenessPolicy, isBrowserCommandLivenessError, withBrowserCommandLiveness } from "./browser-liveness.js"
 import { browserProbeLifecycleArtifact, browserProbeLifecycleInitScript, collectBrowserProbeLifecycle } from "./browser-lifecycle.js"
 import { browserProbeBenchMetrics, serializeBrowserError } from "./browser-metrics.js"
 import { browserPreviewNetworkPolicyIsActive, browserPreviewNetworkPolicySummary, browserPreviewNeedsContextRouting, browserPreviewReadinessError, browserPreviewSecureContextError, browserPreviewTopology, createBrowserPreviewRouteTracker, drainBrowserPreviewRouteTracker, routeBrowserPreviewContextNetwork, routeBrowserPreviewPageNetwork } from "./browser-preview-routing.js"
@@ -232,6 +232,10 @@ export async function runSingleBrowserProbeCommand({
   const stallTimeoutMs = runPlan.stallTimeoutMs
   const wallTimeoutMs = runPlan.wallTimeoutMs
   const livenessPolicy = browserCommandLivenessPolicy({ wallTimeoutMs, idleTimeoutMs: stallTimeoutMs })
+  // Diagnostic providers run external playground commands (e.g. browser-diagnostics-setup) that
+  // can wedge under runtime contention. Bound them with the same wall budget as navigation so a
+  // stuck provider fails fast with a clear error instead of riding the recipe-level timeout.
+  const diagnosticsTimeoutMs = wallTimeoutMs > 0 ? wallTimeoutMs : livenessPolicy.idleTimeoutMs
   const lifecycleSelectors = runPlan.lifecycleSelectors
   const assertions = runPlan.assertions
   const activeDiagnosticProviders = runPlan.diagnosticProviders ?? diagnosticProviders ?? []
@@ -347,7 +351,16 @@ export async function runSingleBrowserProbeCommand({
       await page.addInitScript(prePageScript)
     }
     for (const provider of activeDiagnosticProviders) {
-      diagnosticSetupResults.set(provider.id, await provider.setup({ command, runPlaygroundCommand, server }))
+      const setupResult = await runBoundedBrowserDiagnostic({
+        command,
+        phase: `diagnostics-setup:${provider.id}`,
+        operation: provider.setup({ command, runPlaygroundCommand, server }),
+        timeoutMs: diagnosticsTimeoutMs,
+        onError: (error) => errors.push(serializeBrowserError("probe-error", error)),
+      })
+      if (setupResult.ok) {
+        diagnosticSetupResults.set(provider.id, setupResult.value)
+      }
     }
     viewport = await browserProbeViewport(page)
     contextDetails = await browserProbeContextDetails(page, requestedContext, viewport)
@@ -523,14 +536,21 @@ export async function runSingleBrowserProbeCommand({
     }
     const diagnostics: BrowserProbeCollectedDiagnostic[] = []
     for (const provider of activeDiagnosticProviders) {
-      const diagnostic = await provider.collect({
-        artifactPath: `${browserFilesDirectory}/${provider.id}-diagnostics.json`,
+      const collected = await runBoundedBrowserDiagnostic({
         command,
-        network,
-        runPlaygroundCommand,
-        server,
-        setupResult: diagnosticSetupResults.get(provider.id),
+        phase: `diagnostics-collect:${provider.id}`,
+        operation: provider.collect({
+          artifactPath: `${browserFilesDirectory}/${provider.id}-diagnostics.json`,
+          command,
+          network,
+          runPlaygroundCommand,
+          server,
+          setupResult: diagnosticSetupResults.get(provider.id),
+        }),
+        timeoutMs: diagnosticsTimeoutMs,
+        onError: (error) => errors.push(serializeBrowserError("probe-error", error)),
       })
+      const diagnostic = collected.ok ? collected.value : undefined
       if (diagnostic) {
         diagnostics.push(diagnostic)
         await artifactSession.writeJson(diagnostic.key, diagnostic.fileName, diagnostic.artifact)
@@ -611,6 +631,47 @@ async function closeBrowserBestEffort(browser: import("playwright").Browser): Pr
       timeout.unref()
     }),
   ])
+}
+
+export type BoundedBrowserDiagnosticResult<T> = { ok: true; value: T } | { ok: false; error: Error }
+
+/**
+ * Runs a best-effort browser diagnostic provider operation under a bounded wall timeout.
+ *
+ * Diagnostic providers shell out to playground commands (e.g. wordpress.browser-diagnostics-setup)
+ * that can wedge under runtime contention. Without a bound, a stuck provider rides the recipe-level
+ * timeout — observed as wordpress.capture-html hanging for the full recipe budget while the sibling
+ * navigation path failed fast. This wraps the operation so it fails fast with a clear, non-empty
+ * liveness error that is surfaced through onError as a non-fatal probe error rather than aborting
+ * the capture. The discriminated result distinguishes a legitimately resolved value (including
+ * undefined or false) from a timeout/failure.
+ */
+export async function runBoundedBrowserDiagnostic<T>({
+  command,
+  phase,
+  operation,
+  timeoutMs,
+  onError,
+}: {
+  command: string
+  phase: string
+  operation: Promise<T>
+  timeoutMs: number
+  onError: (error: Error) => void
+}): Promise<BoundedBrowserDiagnosticResult<T>> {
+  try {
+    const value = await withBrowserCommandLiveness({
+      command,
+      phase,
+      operation,
+      policy: { wallTimeoutMs: timeoutMs, idleTimeoutMs: 0 },
+    })
+    return { ok: true, value }
+  } catch (error) {
+    const normalized = error instanceof Error ? error : new Error(String(error))
+    onError(normalized)
+    return { ok: false, error: normalized }
+  }
 }
 
 function browserProbeProfileIds(args: string[]): string[] {

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -859,7 +859,7 @@ class PlaygroundRuntime implements Runtime {
     const server = await this.bootPlayground()
     let result: Awaited<ReturnType<typeof runHtmlCaptureCommand>>
     try {
-      result = await runHtmlCaptureCommand({ artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec })
+      result = await runHtmlCaptureCommand({ abortSignal: this.activeExecutionSignal, artifactRoot: this.artifactRoot, runtimeSpec: this.spec, runPlaygroundCommand: (command, targetServer, options) => this.runPlaygroundCommand(command, targetServer, options), server, spec })
     } catch (error) {
       if (isBrowserCommandArtifactError(error)) {
         this.browserProbes.push(error.artifact)

--- a/tests/browser-capture-html-diagnostics-reliability.test.ts
+++ b/tests/browser-capture-html-diagnostics-reliability.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict"
+
+import { runBoundedBrowserDiagnostic } from "../packages/runtime-playground/src/browser-probe-runner.js"
+
+// Regression coverage for the wordpress.capture-html navigation/diagnostics hang.
+//
+// capture-html attaches the WordPress diagnostic provider, whose setup shells out to a
+// playground command (wordpress.browser-diagnostics-setup) BEFORE navigation, and whose
+// collect runs in the finally block. Both were previously awaited with no liveness bound,
+// so a provider wedged under runtime contention rode the recipe-level timeout (observed as
+// capture-html hanging for the full 25-minute recipe budget while the sibling browser-probe
+// navigation path failed fast at its 120s wall bound). runBoundedBrowserDiagnostic bounds
+// these calls so a stuck provider fails fast with a clear, non-empty error surfaced as a
+// non-fatal probe error.
+
+async function main(): Promise<void> {
+  // 1. A provider operation that never settles must fail fast within the wall budget,
+  //    surface a clear non-empty liveness error through onError, and never ride a longer timeout.
+  {
+    const onErrors: Error[] = []
+    // A long-running operation that outlives the wall budget models a wedged playground command.
+    // The backing timer is ref'd so the event loop stays alive long enough for the bounded wall
+    // timeout to fire, then it is cleared after the assertions so the test process exits cleanly.
+    let hungTimer: NodeJS.Timeout | undefined
+    const hungOperation = new Promise<boolean>((resolve) => {
+      hungTimer = setTimeout(() => resolve(true), 30_000)
+    })
+    const startedAt = Date.now()
+    const result = await runBoundedBrowserDiagnostic({
+      command: "wordpress.capture-html",
+      phase: "diagnostics-setup:wordpress",
+      operation: hungOperation,
+      timeoutMs: 50,
+      onError: (error) => onErrors.push(error),
+    })
+    const elapsedMs = Date.now() - startedAt
+    if (hungTimer) {
+      clearTimeout(hungTimer)
+    }
+
+    assert.equal(result.ok, false, "a hung diagnostic operation must report failure, not success")
+    assert.equal(onErrors.length, 1, "the bounded failure must be surfaced exactly once via onError")
+    assert.ok(onErrors[0] instanceof Error, "onError must receive an Error instance")
+    assert.ok(onErrors[0].message.length > 0, "the surfaced error must be non-empty")
+    assert.match(onErrors[0].message, /exceeded 50ms/, "the surfaced error must describe the wall timeout")
+    assert.match(onErrors[0].message, /diagnostics-setup:wordpress/, "the surfaced error must name the failing phase")
+    assert.ok(elapsedMs < 5_000, `a hung diagnostic must fail fast, not ride a long timeout (took ${elapsedMs}ms)`)
+  }
+
+  // 2. A legitimately resolved value — including a falsy result like setup returning false —
+  //    must be preserved as ok:true without invoking onError.
+  {
+    const onErrors: Error[] = []
+    const falseResult = await runBoundedBrowserDiagnostic({
+      command: "wordpress.capture-html",
+      phase: "diagnostics-setup:wordpress",
+      operation: Promise.resolve(false),
+      timeoutMs: 5_000,
+      onError: (error) => onErrors.push(error),
+    })
+    assert.equal(falseResult.ok, true, "a resolved diagnostic must report success even when the value is falsy")
+    assert.equal(falseResult.ok === true && falseResult.value, false, "the resolved falsy value must be preserved")
+    assert.equal(onErrors.length, 0, "a successful diagnostic must not surface an error")
+
+    const valueResult = await runBoundedBrowserDiagnostic({
+      command: "wordpress.capture-html",
+      phase: "diagnostics-collect:wordpress",
+      operation: Promise.resolve({ key: "wordpressDiagnostics" }),
+      timeoutMs: 5_000,
+      onError: (error) => onErrors.push(error),
+    })
+    assert.equal(valueResult.ok, true)
+    assert.deepEqual(valueResult.ok === true ? valueResult.value : undefined, { key: "wordpressDiagnostics" })
+    assert.equal(onErrors.length, 0)
+  }
+
+  // 3. A provider that rejects must surface the real underlying error (not an empty or generic
+  //    message) and report failure, keeping diagnostics best-effort.
+  {
+    const onErrors: Error[] = []
+    const result = await runBoundedBrowserDiagnostic({
+      command: "wordpress.capture-html",
+      phase: "diagnostics-collect:wordpress",
+      operation: Promise.reject(new Error("playground command failed: boom")),
+      timeoutMs: 5_000,
+      onError: (error) => onErrors.push(error),
+    })
+    assert.equal(result.ok, false)
+    assert.equal(onErrors.length, 1)
+    assert.match(onErrors[0].message, /playground command failed: boom/, "the real rejection reason must be surfaced")
+  }
+
+  console.log("browser-capture-html-diagnostics-reliability: ok")
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## What
Fixes `wordpress.capture-html` hanging the full 25-min recipe timeout under contention — the blocker behind the live-WP parity cross-check (all 5 fixtures of an offloaded matrix run hung at `steps[3]: capture-html`).

## Root cause (verified — not the obvious one)
Navigation is NOT the problem: `capture-html` and `browser-probe` both route through `runSingleBrowserProbeCommand`, and `page.goto` is bounded identically (`timeout: wallTimeoutMs` + `withBrowserProbeLiveness(..., "navigation")`, 120s). The real issue is the **WordPress diagnostic provider** that only capture-html-style calls attach:
- `browser-probe-runner.ts` `await provider.setup(...)` runs BEFORE navigation, **unbounded**. `setup` = `installBrowserWordPressDiagnostics`, which runs the external `wordpress.browser-diagnostics-setup` PHP command. Under contention (~21 children / ~10GB RSS) that wedges → unbounded await → the whole command hangs and rides the 25-min recipe timeout. (`browser-probe` failed fast at 120s because *navigation* timed out; capture-html never reached navigation — it hung in setup.)
- `await provider.collect(...)` in the `finally` block was likewise unbounded.
- Compounding: `runHtmlCapture` didn't pass `abortSignal` (browser-probe did), so the orchestrator couldn't interrupt capture-html.
- (Blocked external requests are already `route.abort("blockedbyclient")`'d — they don't leave the page pending; no change needed there.)

## Fix
- `runBoundedBrowserDiagnostic`: wraps each provider `setup`/`collect` in `withBrowserCommandLiveness` with `diagnosticsTimeoutMs` (= the 120s nav wall). A stuck/failing provider now fails fast with a clear, non-empty liveness error surfaced as a non-fatal probe error; diagnostics degrade to best-effort instead of hanging. A discriminated result preserves legitimately-resolved falsy values (`setup` can return `false`).
- Threaded `abortSignal` through `runHtmlCaptureCommand` + passed `this.activeExecutionSignal` from `playground-runtime.runHtmlCapture`, so capture-html is interruptible like browser-probe.
- Left the nav wait-state as-is (already bounded by goto timeout + wall, so even `networkidle` against WP heartbeat fails fast at the wall rather than hanging — changing the default would alter the contract without fixing the actual hang).

## Verification
- `npm run build` (tsc -b) clean.
- `test:browser-diagnostic-providers`, `test:browser-runner-template`, `browser-probe-contract-smoke` green. New `tests/browser-capture-html-diagnostics-reliability.test.ts`: hung op fails fast (<5s, names the phase), resolved-falsy preserved as ok, rejection surfaces the real message.

## Honest limit
Single-fixture live `capture-html` confirmation is PENDING — it boots a full Playground+Chromium sandbox (RAM-heavy; site rules require offloaded homeboy-lab, not set up in this scoped pass). Why it resolves deterministically: the only capture-html-specific unbounded paths (provider setup pre-nav, collect in finally) are now bounded by the same 120s wall as navigation → worst case ~setup+nav+collect (a few min), well under the 1,500,000ms recipe timeout; otherwise DOM returns via `page.content()` normally with diagnostics degraded to best-effort. Unit test proves the bounding + real-error + value-preservation without a sandbox.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Root-cause investigation, fix, and tests under human review.
