### PR TITLE
Add seeded browser action corpus

### DIFF
--- a/packages/runtime-core/src/browser-interaction.ts
+++ b/packages/runtime-core/src/browser-interaction.ts
@@ -35,6 +35,8 @@ export const BROWSER_INTERACTION_STEP_KINDS = [
 export type BrowserInteractionStepKind = typeof BROWSER_INTERACTION_STEP_KINDS[number]
 
 export const BROWSER_RANDOM_WALK_SCHEMA = "wp-codebox/browser-random-walk/v1" as const
+export const BROWSER_ACTION_CORPUS_SCHEMA = "wp-codebox/browser-action-corpus/v1" as const
+export const BROWSER_ACTION_CORPUS_ARTIFACT_SCHEMA = "wp-codebox/browser-action-corpus-artifact/v1" as const
 
 export const BROWSER_RANDOM_WALK_CONTEXTS = ["browser", "admin", "editor"] as const
 export type BrowserRandomWalkContext = typeof BROWSER_RANDOM_WALK_CONTEXTS[number]
@@ -138,6 +140,73 @@ export interface BrowserRandomWalkPlan {
   steps: BrowserInteractionStep[]
   replay: Record<string, unknown>
   diagnostics: { code: string; message: string; metadata?: Record<string, unknown> }[]
+}
+
+export const BROWSER_ACTION_CORPUS_GENERATOR_KINDS = ["text", "email", "url", "search", "number", "password", "textarea", "checkbox", "radio", "select"] as const
+export type BrowserActionCorpusGeneratorKind = typeof BROWSER_ACTION_CORPUS_GENERATOR_KINDS[number]
+
+export type BrowserActionCorpusDescriptorKind = "link" | "button" | "input" | "textarea" | "select"
+
+export interface BrowserActionCorpusDescriptor {
+  id: string
+  kind: BrowserActionCorpusDescriptorKind
+  selector: string
+  label?: string
+  name?: string
+  role?: string
+  type?: string
+  formId?: string
+  href?: string
+  optionValues?: string[]
+  disabled?: boolean
+  readonly?: boolean
+}
+
+export interface BrowserActionCorpusContract {
+  schema: typeof BROWSER_ACTION_CORPUS_SCHEMA
+  context: BrowserRandomWalkContext
+  seed: string
+  maxSteps: number
+  startUrl?: string
+  includeFamilies: BrowserRandomWalkActionFamily[]
+  generatorPrefix: string
+  metadata?: Record<string, unknown>
+}
+
+export interface BrowserActionCorpusPlan {
+  schema: typeof BROWSER_ACTION_CORPUS_SCHEMA
+  status: "planned" | "empty"
+  context: BrowserRandomWalkContext
+  seed: string
+  maxSteps: number
+  startUrl?: string
+  descriptors: BrowserActionCorpusDescriptor[]
+  steps: BrowserInteractionStep[]
+  replay: {
+    schema: typeof BROWSER_ACTION_CORPUS_SCHEMA
+    seed: string
+    maxSteps: number
+    context: BrowserRandomWalkContext
+    startUrl?: string
+    descriptorIds: string[]
+    steps: BrowserInteractionStep[]
+  }
+  observations: {
+    descriptorsDiscovered: number
+    descriptorsSelected: number
+    stepsPlanned: number
+    fillSteps: number
+    clickSteps: number
+    selectSteps: number
+  }
+  diagnostics: { code: string; message: string; metadata?: Record<string, unknown> }[]
+}
+
+export interface BrowserActionCorpusArtifact {
+  schema: typeof BROWSER_ACTION_CORPUS_ARTIFACT_SCHEMA
+  contract: BrowserActionCorpusContract
+  plan: BrowserActionCorpusPlan
+  capturedAt: string
 }
 
 export interface BrowserInteractionStepValidationIssue {
@@ -371,6 +440,89 @@ export function planBrowserRandomWalk(input: Record<string, unknown>): BrowserRa
   }
 }
 
+export function browserActionCorpusContract(input: Record<string, unknown>): BrowserActionCorpusContract {
+  const context = normalizeBrowserRandomWalkContext(input.context)
+  const seed = typeof input.seed === "string" && input.seed.length > 0 ? input.seed : "browser-action-corpus"
+  return {
+    schema: BROWSER_ACTION_CORPUS_SCHEMA,
+    context,
+    seed,
+    maxSteps: normalizeBrowserRandomWalkMaxSteps(input.maxSteps ?? input.max_steps),
+    startUrl: typeof input.startUrl === "string" ? input.startUrl : typeof input.start_url === "string" ? input.start_url : defaultBrowserRandomWalkStartUrl(context),
+    includeFamilies: normalizeBrowserRandomWalkActionFamilies(input.includeFamilies ?? input.include_families),
+    generatorPrefix: typeof input.generatorPrefix === "string" && input.generatorPrefix.length > 0 ? input.generatorPrefix : "wp-codebox",
+    metadata: isPlainObject(input.metadata) ? input.metadata : undefined,
+  }
+}
+
+export function planBrowserActionCorpus(contractInput: Record<string, unknown> | BrowserActionCorpusContract, descriptorsInput: readonly BrowserActionCorpusDescriptor[]): BrowserActionCorpusPlan {
+  const contract = isBrowserActionCorpusContract(contractInput) ? contractInput : browserActionCorpusContract(contractInput)
+  const diagnostics: BrowserActionCorpusPlan["diagnostics"] = []
+  const descriptors = normalizeBrowserActionCorpusDescriptors(descriptorsInput)
+  const candidates = seededBrowserActionCorpusOrder(descriptors, contract.seed)
+  const steps: BrowserInteractionStep[] = []
+  const descriptorIds: string[] = []
+
+  for (const descriptor of candidates) {
+    if (steps.length >= contract.maxSteps) break
+    const planned = browserActionCorpusStep(descriptor, contract, steps.length)
+    if (!planned || !contract.includeFamilies.includes(planned.family)) continue
+    steps.push(planned.step)
+    descriptorIds.push(descriptor.id)
+  }
+
+  if (steps.length === 0) {
+    diagnostics.push({ code: "browser_action_corpus_no_steps", message: "No actionable controls produced executable seeded browser steps.", metadata: { descriptors: descriptors.length } })
+  }
+
+  const fillSteps = steps.filter((step) => step.kind === "fill" || step.kind === "press").length
+  const clickSteps = steps.filter((step) => step.kind === "click").length
+  const selectSteps = steps.filter((step) => step.kind === "select").length
+
+  return {
+    schema: BROWSER_ACTION_CORPUS_SCHEMA,
+    status: steps.length > 0 ? "planned" : "empty",
+    context: contract.context,
+    seed: contract.seed,
+    maxSteps: contract.maxSteps,
+    startUrl: contract.startUrl,
+    descriptors,
+    steps,
+    replay: {
+      schema: BROWSER_ACTION_CORPUS_SCHEMA,
+      seed: contract.seed,
+      maxSteps: contract.maxSteps,
+      context: contract.context,
+      startUrl: contract.startUrl,
+      descriptorIds,
+      steps,
+    },
+    observations: {
+      descriptorsDiscovered: descriptors.length,
+      descriptorsSelected: descriptorIds.length,
+      stepsPlanned: steps.length,
+      fillSteps,
+      clickSteps,
+      selectSteps,
+    },
+    diagnostics,
+  }
+}
+
+export function browserActionCorpusArtifact(contractInput: Record<string, unknown> | BrowserActionCorpusContract, descriptors: readonly BrowserActionCorpusDescriptor[], capturedAt: string): BrowserActionCorpusArtifact {
+  const contract = isBrowserActionCorpusContract(contractInput) ? contractInput : browserActionCorpusContract(contractInput)
+  return {
+    schema: BROWSER_ACTION_CORPUS_ARTIFACT_SCHEMA,
+    contract,
+    plan: planBrowserActionCorpus(contract, descriptors),
+    capturedAt,
+  }
+}
+
+function isBrowserActionCorpusContract(value: Record<string, unknown> | BrowserActionCorpusContract): value is BrowserActionCorpusContract {
+  return value.schema === BROWSER_ACTION_CORPUS_SCHEMA
+}
+
 function normalizeBrowserRandomWalkContext(value: unknown): BrowserRandomWalkContext {
   return (BROWSER_RANDOM_WALK_CONTEXTS as readonly string[]).includes(String(value)) ? value as BrowserRandomWalkContext : "browser"
 }
@@ -401,6 +553,67 @@ function browserRandomWalkStep(family: BrowserRandomWalkActionFamily, contract: 
   if (family === "select") return { kind: "select", selector: "select", value: "" }
   if (family === "capture") return { kind: "capture" }
   return undefined
+}
+
+function normalizeBrowserActionCorpusDescriptors(descriptors: readonly BrowserActionCorpusDescriptor[]): BrowserActionCorpusDescriptor[] {
+  const seen = new Set<string>()
+  const normalized: BrowserActionCorpusDescriptor[] = []
+  for (const descriptor of descriptors) {
+    if (!descriptor || typeof descriptor.selector !== "string" || descriptor.selector.length === 0 || typeof descriptor.id !== "string" || descriptor.id.length === 0) continue
+    if (descriptor.disabled || descriptor.readonly || seen.has(descriptor.id)) continue
+    seen.add(descriptor.id)
+    normalized.push({
+      id: descriptor.id,
+      kind: descriptor.kind,
+      selector: descriptor.selector,
+      ...(typeof descriptor.label === "string" && descriptor.label.length > 0 ? { label: descriptor.label } : {}),
+      ...(typeof descriptor.name === "string" && descriptor.name.length > 0 ? { name: descriptor.name } : {}),
+      ...(typeof descriptor.role === "string" && descriptor.role.length > 0 ? { role: descriptor.role } : {}),
+      ...(typeof descriptor.type === "string" && descriptor.type.length > 0 ? { type: descriptor.type.toLowerCase() } : {}),
+      ...(typeof descriptor.formId === "string" && descriptor.formId.length > 0 ? { formId: descriptor.formId } : {}),
+      ...(typeof descriptor.href === "string" && descriptor.href.length > 0 ? { href: descriptor.href } : {}),
+      ...(Array.isArray(descriptor.optionValues) ? { optionValues: descriptor.optionValues.filter((value) => typeof value === "string") } : {}),
+    })
+  }
+  return normalized
+}
+
+function seededBrowserActionCorpusOrder(descriptors: readonly BrowserActionCorpusDescriptor[], seed: string): BrowserActionCorpusDescriptor[] {
+  return [...descriptors].sort((a, b) => deterministicHash(`${seed}:${a.id}`) - deterministicHash(`${seed}:${b.id}`) || a.id.localeCompare(b.id))
+}
+
+function browserActionCorpusStep(descriptor: BrowserActionCorpusDescriptor, contract: BrowserActionCorpusContract, index: number): { family: BrowserRandomWalkActionFamily; step: BrowserInteractionStep } | undefined {
+  if (descriptor.kind === "select") {
+    const values = descriptor.optionValues?.filter((value) => value.length > 0) ?? []
+    if (values.length === 0) return undefined
+    return { family: "select", step: { kind: "select", selector: descriptor.selector, value: pickDeterministic(values, `${contract.seed}:${descriptor.id}`) } }
+  }
+  if (descriptor.kind === "textarea" || descriptor.kind === "input") {
+    const type = normalizeBrowserActionCorpusGeneratorKind(descriptor.kind === "textarea" ? "textarea" : descriptor.type)
+    if (type === "checkbox" || type === "radio") return { family: "click", step: { kind: "click", selector: descriptor.selector } }
+    return { family: "fill", step: { kind: "fill", selector: descriptor.selector, value: browserActionCorpusGeneratedValue(type, contract, descriptor, index) } }
+  }
+  if (descriptor.kind === "button") return { family: "click", step: { kind: "click", selector: descriptor.selector } }
+  if (descriptor.kind === "link") return { family: "click", step: { kind: "click", selector: descriptor.selector } }
+  return undefined
+}
+
+function normalizeBrowserActionCorpusGeneratorKind(value: unknown): BrowserActionCorpusGeneratorKind {
+  const normalized = String(value || "text").toLowerCase()
+  if ((BROWSER_ACTION_CORPUS_GENERATOR_KINDS as readonly string[]).includes(normalized)) return normalized as BrowserActionCorpusGeneratorKind
+  return "text"
+}
+
+function browserActionCorpusGeneratedValue(kind: BrowserActionCorpusGeneratorKind, contract: BrowserActionCorpusContract, descriptor: BrowserActionCorpusDescriptor, index: number): string {
+  const suffix = deterministicHash(`${contract.seed}:${descriptor.id}:${index}`).toString(36).slice(0, 8)
+  const prefix = contract.generatorPrefix.replace(/[^a-zA-Z0-9._-]+/g, "-") || "wp-codebox"
+  if (kind === "email") return `${prefix}-${suffix}@example.test`
+  if (kind === "url") return `https://example.test/${prefix}-${suffix}`
+  if (kind === "number") return String((deterministicHash(`${contract.seed}:${descriptor.id}`) % 900) + 100)
+  if (kind === "password") return `${prefix}-${suffix}-Passw0rd!`
+  if (kind === "search") return `${prefix} search ${suffix}`
+  if (kind === "textarea") return `${prefix} generated text ${suffix}`
+  return `${prefix}-${suffix}`
 }
 
 function pickDeterministic<T>(items: readonly T[], seed: string): T {

--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -1078,6 +1078,7 @@ export const commandRegistry = [
     acceptedArgs: [
       { name: "url", description: "Initial preview path or absolute URL to visit when the script omits an initial navigate step.", format: "path or URL" },
       { name: "steps-json", description: "Ordered interaction script: navigate, click, fill, type, press, drag, hover, select, waitFor, evaluate, expect, screenshot, and capture steps. waitFor and screenshot steps support generic painted-readiness waits: painted, frame-painted:<iframe-selector>, and frame-url-painted:<url-fragment>.", format: "JSON array (inline or @<path>)" },
+      { name: "action-corpus-json", description: "Optional wp-codebox/browser-action-corpus/v1 object. The runtime loads the start URL, discovers visible links, buttons, inputs, textareas, and selects, creates deterministic seeded fill/click/select steps from stable descriptors, and writes replayable corpus artifacts.", format: "JSON object" },
       { name: "step-timeout", description: "Per-step timeout applied to each interaction step.", format: "duration, e.g. 5s or 500ms" },
       { name: "timeout", description: "Total-script timeout bounding the whole interaction run.", format: "duration, e.g. 30s or 1500ms" },
       { name: "auth", description: "Optional in-memory browser authentication mode. Use wordpress-admin to bootstrap WordPress admin cookies from PHP without writing token-bearing storage-state artifacts.", format: "wordpress-admin" },
@@ -1086,7 +1087,7 @@ export const commandRegistry = [
       { name: "capture", description: "Comma-separated artifacts to capture after interactions.", format: "steps,console,errors,html,network,screenshot,dom-snapshot" },
       { name: "max-dom-snapshot-elements", description: "Maximum visible elements captured in each screenshot sidecar DOM/style snapshot; defaults to 160.", format: "positive integer" },
     ],
-    outputShape: "JSON summary plus files/browser/steps.jsonl, action-summary.json (with assertions pass/fail), named screenshots, sidecar DOM/style snapshots, and optional console/errors/network/html/screenshot artifacts.",
+    outputShape: "JSON summary plus files/browser/steps.jsonl, action-summary.json (with assertions pass/fail), optional action-corpus.json replay artifacts, named screenshots, sidecar DOM/style snapshots, and optional console/errors/network/html/screenshot artifacts.",
     policyRequirement: "Runtime policy commands must include wordpress.browser-actions. The evaluate step additionally requires wordpress.browser-actions.evaluate.",
     validation: browserActionsValidation,
     recipe: true,

--- a/packages/runtime-playground/src/browser-actions-runner.ts
+++ b/packages/runtime-playground/src/browser-actions-runner.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises"
-import { BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, HostToolRegistry, assertRuntimeCommandAllowed, browserInteractionScriptUsesEvaluate, browserToolVerifierInputSummary, createHostToolRegistry, executeHostTool, resolveCommandPath, validateBrowserInteractionScript, type BrowserInteractionStep, type BrowserToolVerifierResult, type ExecutionSpec, type HostToolDefinition, type JsonValue, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
+import { BROWSER_ACTION_CORPUS_SCHEMA, BROWSER_TOOL_VERIFIER_RESULT_SCHEMA, HostToolRegistry, assertRuntimeCommandAllowed, browserActionCorpusArtifact, browserActionCorpusContract, browserInteractionScriptUsesEvaluate, browserToolVerifierInputSummary, createHostToolRegistry, executeHostTool, resolveCommandPath, validateBrowserInteractionScript, type BrowserActionCorpusArtifact, type BrowserActionCorpusContract, type BrowserActionCorpusDescriptor, type BrowserInteractionStep, type BrowserToolVerifierResult, type ExecutionSpec, type HostToolDefinition, type JsonValue, type RuntimeCreateSpec } from "@automattic/wp-codebox-core"
 import { now, sha256 } from "@automattic/wp-codebox-core/internals"
 import { browserInteractionStepsFromArgs, browserStepTimeoutMs, durationStringMs, sanitizeScreenshotName } from "./browser-actions.js"
 import { BrowserArtifactSession } from "./browser-artifact-session.js"
@@ -39,6 +39,7 @@ export interface BrowserActionsRunPlan {
   authRequest?: { userId: number }
   storageStateImport?: BrowserStorageStateImport
   maxDomSnapshotElements: number
+  actionCorpus?: BrowserActionCorpusContract
 }
 
 interface BrowserRunPlan {
@@ -127,6 +128,8 @@ export async function runBrowserActionsCommand({
   let pendingError: Error | undefined
   let artifact: BrowserArtifact | undefined
   let wordpressDiagnosticsReady = false
+  let actionCorpusArtifact: BrowserActionCorpusArtifact | undefined
+  let actionCorpusSummary: BrowserArtifact["summary"]["actionCorpus"] | undefined
 
   try {
     const context = browserPreviewNeedsContextRouting(networkPolicy) || !!storageStateImport ? await browser.newContext({
@@ -171,7 +174,47 @@ export async function runBrowserActionsCommand({
       webSockets,
     })
 
-    for (const [index, step] of steps.entries()) {
+    if (runPlan.actionCorpus) {
+      if (!steps.some((step) => step.kind === "navigate") && runPlan.actionCorpus.startUrl) {
+        steps.unshift({ kind: "navigate", url: runPlan.actionCorpus.startUrl, waitFor: "domcontentloaded" })
+      }
+      if (steps[0]?.kind === "navigate") {
+        const navigateStep = steps.shift()!
+        const navigateStartedAt = now()
+        const navigateStartedAtMs = Date.now()
+        try {
+          await executeBrowserInteractionStep(page, navigateStep, preview.effectiveOrigin, stepTimeoutMs, async (fileName, write) => {
+            await artifactSession.writeGenerated("screenshot", fileName, write)
+            return { path: artifactSession.path(fileName), isDefault: fileName === "screenshot.png" }
+          })
+          finalUrl = page.url()
+          requestedUrl = resolveBrowserPreviewUrl((navigateStep.url ?? "").trim(), preview.effectiveOrigin)
+          stepRecords.push(browserStepRecord(0, navigateStep, "ok", navigateStartedAt, navigateStartedAtMs, finalUrl, {}))
+        } catch (error) {
+          const serialized = serializeBrowserError("probe-error", error)
+          errors.push(serialized)
+          stepRecords.push(browserStepRecord(0, navigateStep, "failed", navigateStartedAt, navigateStartedAtMs, page.url(), { error: serialized }))
+          throw error
+        }
+      }
+      const descriptors = await discoverBrowserActionCorpusDescriptors(page)
+      actionCorpusArtifact = browserActionCorpusArtifact(runPlan.actionCorpus, descriptors, now())
+      await artifactSession.writeJson("actionCorpus", "action-corpus.json", actionCorpusArtifact)
+      const corpusSteps = actionCorpusArtifact.plan.steps
+      steps.unshift(...corpusSteps)
+      actionCorpusSummary = {
+        schema: BROWSER_ACTION_CORPUS_SCHEMA,
+        seed: actionCorpusArtifact.contract.seed,
+        descriptorsDiscovered: actionCorpusArtifact.plan.observations.descriptorsDiscovered,
+        descriptorsSelected: actionCorpusArtifact.plan.observations.descriptorsSelected,
+        stepsPlanned: actionCorpusArtifact.plan.observations.stepsPlanned,
+        artifact: "files/browser/action-corpus.json",
+      }
+    }
+
+    const stepIndexOffset = stepRecords.length
+    for (const [loopIndex, step] of steps.entries()) {
+      const index = loopIndex + stepIndexOffset
       const recordStartedAt = now()
       const recordStartedAtMs = Date.now()
       // Total-script timeout: stop before starting a step that would exceed the budget.
@@ -351,6 +394,7 @@ export async function runBrowserActionsCommand({
         ...(capture.has("screenshot") ? { screenshot: "files/browser/screenshot.png" } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots: domSnapshots.map((snapshot) => snapshot.snapshot) } : {}),
         ...(verifierResults.length > 0 ? { verifierResults: verifierResults.map((result) => result.artifact) } : {}),
+        ...(actionCorpusArtifact ? { actionCorpus: "files/browser/action-corpus.json" } : {}),
         ...(wordpressDiagnostics ? { wordpressDiagnostics: "files/browser/wordpress-diagnostics.json" } : {}),
         summary: "files/browser/action-summary.json",
       },
@@ -366,6 +410,7 @@ export async function runBrowserActionsCommand({
         ...(browserPreviewNetworkPolicyIsActive(networkPolicy) ? { networkPolicy: browserPreviewNetworkPolicySummary(networkPolicy) } : {}),
         ...(domSnapshots.length > 0 ? { domSnapshots } : {}),
         ...(verifierResults.length > 0 ? { verifierResults } : {}),
+        ...(actionCorpusSummary ? { actionCorpus: actionCorpusSummary } : {}),
         liveness: { wallTimeoutMs: totalTimeoutMs, networkSettleTimeoutMs: livenessPolicy.networkSettleTimeoutMs },
         networkEvents: network.length,
         ...(capture.has("websocket") ? { webSockets: browserProbeWebSocketSummary(webSockets) } : {}),
@@ -402,6 +447,7 @@ export async function runBrowserActionsCommand({
       ...(redirectDiagnosticsSummary ? { redirectDiagnostics: redirectDiagnosticsSummary } : {}),
       ...(wordpressDiagnosticsSummary ? { wordpressDiagnostics: wordpressDiagnosticsSummary } : {}),
       ...(verifierResults.length > 0 ? { verifierResults } : {}),
+      ...(actionCorpusArtifact ? { actionCorpus: actionCorpusArtifact.plan } : {}),
       viewport,
       summary: artifact.summary,
     })
@@ -547,7 +593,79 @@ async function browserActionsRunPlanFromArgs(args: string[], artifactRoot: strin
     authRequest: browserAuthRequest(args),
     storageStateImport: await browserStorageStateImportFromArgs(args, "wordpress.browser-actions", artifactRoot),
     maxDomSnapshotElements: positiveIntegerArg(args, "max-dom-snapshot-elements", 160),
+    actionCorpus: browserActionCorpusFromArgs(args),
   }
+}
+
+function browserActionCorpusFromArgs(args: string[]): BrowserActionCorpusContract | undefined {
+  const raw = argValue(args, "action-corpus-json")
+  if (typeof raw !== "string" || raw.trim().length === 0) return undefined
+  const parsed = JSON.parse(raw) as Record<string, unknown>
+  return browserActionCorpusContract(parsed)
+}
+
+async function discoverBrowserActionCorpusDescriptors(page: Page): Promise<BrowserActionCorpusDescriptor[]> {
+  return await page.evaluate(() => {
+    const descriptors: BrowserActionCorpusDescriptor[] = []
+    const cssEscape = (value: string) => {
+      const escapeFn = (globalThis as typeof globalThis & { CSS?: { escape?: (raw: string) => string } }).CSS?.escape
+      return escapeFn ? escapeFn(value) : value.replace(/[^a-zA-Z0-9_-]/g, "\\$&")
+    }
+    const text = (value: string | null | undefined) => (value || "").replace(/\s+/g, " ").trim().slice(0, 120)
+    const selectorFor = (element: Element) => {
+      const id = element.getAttribute("id")
+      if (id) return `#${cssEscape(id)}`
+      const name = element.getAttribute("name")
+      if (name) return `${element.tagName.toLowerCase()}[name="${cssEscape(name)}"]`
+      const aria = element.getAttribute("aria-label")
+      if (aria) return `${element.tagName.toLowerCase()}[aria-label="${cssEscape(aria)}"]`
+      const type = element.getAttribute("type")
+      return `${element.tagName.toLowerCase()}${type ? `[type="${cssEscape(type)}"]` : ""}:nth-of-type(${Array.from(element.parentElement?.children || []).filter((child) => child.tagName === element.tagName).indexOf(element) + 1})`
+    }
+    const labelFor = (element: Element) => {
+      const labelledBy = element.getAttribute("aria-labelledby")
+      if (labelledBy) {
+        const labelled = labelledBy.split(/\s+/).map((id) => document.getElementById(id)?.textContent).filter(Boolean).join(" ")
+        if (text(labelled)) return text(labelled)
+      }
+      const aria = text(element.getAttribute("aria-label"))
+      if (aria) return aria
+      const id = element.getAttribute("id")
+      const label = id ? document.querySelector(`label[for="${cssEscape(id)}"]`) : null
+      if (label && text(label.textContent)) return text(label.textContent)
+      return text(element.textContent)
+    }
+    const descriptorId = (kind: string, element: Element) => `${kind}:${selectorFor(element)}:${element.getAttribute("name") || ""}:${labelFor(element)}`
+    const visible = (element: Element) => {
+      const htmlElement = element as HTMLElement
+      const style = window.getComputedStyle(htmlElement)
+      const rect = htmlElement.getBoundingClientRect()
+      return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none"
+    }
+    document.querySelectorAll("a[href], button, input, textarea, select").forEach((element) => {
+      if (!visible(element)) return
+      const tag = element.tagName.toLowerCase()
+      const input = element as HTMLInputElement
+      const kind = tag === "a" ? "link" : tag === "button" ? "button" : tag === "textarea" ? "textarea" : tag === "select" ? "select" : "input"
+      const selector = selectorFor(element)
+      const descriptor: BrowserActionCorpusDescriptor = {
+        id: descriptorId(kind, element),
+        kind,
+        selector,
+        label: labelFor(element),
+        name: element.getAttribute("name") || undefined,
+        role: element.getAttribute("role") || undefined,
+        type: input.type || element.getAttribute("type") || undefined,
+        formId: (element as HTMLInputElement).form?.id || undefined,
+        href: tag === "a" ? (element as HTMLAnchorElement).href : undefined,
+        disabled: Boolean((element as HTMLButtonElement).disabled),
+        readonly: Boolean(input.readOnly),
+        optionValues: tag === "select" ? Array.from((element as HTMLSelectElement).options).map((option) => option.value).filter(Boolean) : undefined,
+      }
+      descriptors.push(descriptor)
+    })
+    return descriptors
+  })
 }
 
 async function captureBrowserActionDomSnapshot({

--- a/packages/runtime-playground/src/browser-artifacts.ts
+++ b/packages/runtime-playground/src/browser-artifacts.ts
@@ -82,6 +82,7 @@ export interface BrowserArtifactFiles {
   screenshot?: string
   domSnapshots?: string[]
   verifierResults?: string[]
+  actionCorpus?: string
   sourceScreenshot?: string | string[]
   candidateScreenshot?: string | string[]
   diffScreenshot?: string | string[]
@@ -154,6 +155,14 @@ export interface BrowserArtifactSummary {
     status: "unsupported" | "ok" | "error"
     artifact: string
   }>
+  actionCorpus?: {
+    schema: "wp-codebox/browser-action-corpus/v1"
+    seed: string
+    descriptorsDiscovered: number
+    descriptorsSelected: number
+    stepsPlanned: number
+    artifact: string
+  }
   networkPolicy?: BrowserProbeNetworkPolicySummary
   previewProxy?: PlaygroundPreviewProxyDiagnostics
   lifecycle?: BrowserProbeLifecycleSummary
@@ -1068,6 +1077,7 @@ const BROWSER_ARTIFACT_FILE_MANIFEST: Record<keyof BrowserArtifactFiles, Browser
   screenshot: { kind: "browser-screenshot", contentType: "image/png", redact: false },
   domSnapshots: { kind: "browser-dom-snapshot", contentType: "application/json", redact: true },
   verifierResults: { kind: "browser-verifier-result", contentType: "application/json", redact: true },
+  actionCorpus: { kind: "browser-action-corpus", contentType: "application/json", redact: true },
   sourceScreenshot: { kind: "browser-visual-source-screenshot", contentType: "image/png", redact: false },
   candidateScreenshot: { kind: "browser-visual-candidate-screenshot", contentType: "image/png", redact: false },
   diffScreenshot: { kind: "browser-visual-diff-screenshot", contentType: "image/png", redact: false },

--- a/tests/browser-action-corpus.test.ts
+++ b/tests/browser-action-corpus.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { getCommandDefinition } from "../packages/runtime-core/src/command-registry.js"
+import {
+  BROWSER_ACTION_CORPUS_ARTIFACT_SCHEMA,
+  BROWSER_ACTION_CORPUS_SCHEMA,
+  browserActionCorpusArtifact,
+  browserActionCorpusContract,
+  planBrowserActionCorpus,
+  type BrowserActionCorpusDescriptor,
+} from "../packages/runtime-core/src/browser-interaction.js"
+
+const representativeFormDescriptors: BrowserActionCorpusDescriptor[] = [
+  { id: "input:#title::Title", kind: "input", selector: "#title", label: "Title", name: "title", type: "text", formId: "post" },
+  { id: "textarea:#content::Content", kind: "textarea", selector: "#content", label: "Content", name: "content", formId: "post" },
+  { id: "input:#email::Email", kind: "input", selector: "#email", label: "Email", name: "email", type: "email", formId: "post" },
+  { id: "select:#status::Status", kind: "select", selector: "#status", label: "Status", name: "status", formId: "post", optionValues: ["draft", "publish"] },
+  { id: "button:#save::Save", kind: "button", selector: "#save", label: "Save", type: "submit", formId: "post" },
+  { id: "link:#preview::Preview", kind: "link", selector: "#preview", label: "Preview", href: "https://example.test/?preview=true" },
+]
+
+test("browser action corpus command contract is public on browser-actions", () => {
+  const definition = getCommandDefinition("wordpress.browser-actions")
+  const actionCorpusArg = definition?.acceptedArgs.find((arg) => arg.name === "action-corpus-json")
+
+  assert.equal(actionCorpusArg?.format, "JSON object")
+  assert.match(actionCorpusArg?.description ?? "", /discovers visible links, buttons, inputs, textareas, and selects/)
+})
+
+test("seeded browser action corpus generation is deterministic for a representative form", () => {
+  const contract = browserActionCorpusContract({ seed: "admin-form-seed", context: "admin", maxSteps: 5, generatorPrefix: "sample" })
+  const first = planBrowserActionCorpus(contract, representativeFormDescriptors)
+  const second = planBrowserActionCorpus(contract, representativeFormDescriptors)
+  const differentSeed = planBrowserActionCorpus({ ...contract, seed: "different-seed" }, representativeFormDescriptors)
+
+  assert.equal(contract.schema, BROWSER_ACTION_CORPUS_SCHEMA)
+  assert.deepEqual(second.steps, first.steps)
+  assert.notDeepEqual(differentSeed.steps, first.steps)
+  assert.equal(first.status, "planned")
+  assert.equal(first.steps.length, 5)
+  assert.equal(first.observations.descriptorsDiscovered, representativeFormDescriptors.length)
+  assert.ok(first.observations.fillSteps >= 1)
+  assert.ok(first.observations.clickSteps + first.observations.selectSteps >= 1)
+  assert.ok(first.steps.every((step) => typeof step.selector === "string" && step.selector.length > 0))
+  assert.ok(first.steps.filter((step) => step.kind === "fill").every((step) => typeof step.value === "string" && step.value.includes("sample")))
+})
+
+test("browser action corpus artifact records replayable steps and correlated observations", () => {
+  const capturedAt = "2026-06-29T16:00:00.000Z"
+  const artifact = browserActionCorpusArtifact({ seed: "replay-seed", context: "admin", maxSteps: 4, startUrl: "/wp-admin/post-new.php" }, representativeFormDescriptors, capturedAt)
+
+  assert.equal(artifact.schema, BROWSER_ACTION_CORPUS_ARTIFACT_SCHEMA)
+  assert.equal(artifact.capturedAt, capturedAt)
+  assert.equal(artifact.plan.replay.schema, BROWSER_ACTION_CORPUS_SCHEMA)
+  assert.deepEqual(artifact.plan.replay.steps, artifact.plan.steps)
+  assert.equal(artifact.plan.replay.descriptorIds.length, artifact.plan.steps.length)
+  assert.equal(artifact.plan.observations.stepsPlanned, artifact.plan.steps.length)
+  assert.equal(artifact.plan.observations.descriptorsSelected, artifact.plan.replay.descriptorIds.length)
+  assert.equal(artifact.plan.replay.startUrl, "/wp-admin/post-new.php")
+  assert.ok(artifact.plan.descriptors.some((descriptor) => descriptor.formId === "post"))
+})


### PR DESCRIPTION
## Summary
- Adds a public seeded browser action corpus contract for generic browser/admin action generation.
- Discovers visible links, buttons, inputs, textareas, and selects at runtime and plans deterministic fill/click/select steps from stable descriptors.
- Records replayable action-corpus artifacts and correlated observation counts alongside existing browser-actions artifacts.

## Testing
- npx tsx tests/browser-action-corpus.test.ts
- npx tsx tests/wordpress-admin-action-contracts.test.ts
- npx tsx tests/browser-interaction-tool-verifier.test.ts
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the contract, implementation, tests, and PR description.