### PR TITLE
Add generated REST mutation fixture contract

### DIFF
--- a/docs/public-api-contract.md
+++ b/docs/public-api-contract.md
@@ -187,9 +187,20 @@ HBEX schema ids advertised by the descriptor include:
 - `wp-codebox/fuzz-coverage-plan/v1`
 - `wp-codebox/fuzz-fixture-plan/v1`
 - `wp-codebox/rest-mutation-fixture-opt-in/v1`
+- `wp-codebox/rest-mutation-generated-fixtures/v1`
 - `wp-codebox/mutation-isolation-artifact/v1`
 - `wp-codebox/delete-boundary-artifact/v1`
 - `wp-codebox/wordpress-workload-run/v1`
+
+Generic mutating REST fixture generation is exposed as the public
+`wp-codebox/rest-mutation-generated-fixtures/v1` contract through
+`restMutationGeneratedFixturesContract()`. It derives bounded disposable sandbox
+payload fixtures from route schemas, optional existing collection samples, and
+typed generators. Generated operations carry explicit `confidence`, `sources`,
+`bounded`, `semanticValidity`, and `unsupportedReasons` metadata. The contract
+does not claim complete semantic validity; unsupported bindings remain data in
+the `unsupported` list, and callers pass the returned opt-ins into fuzz-suite
+builders when they accept those generated fixtures for a disposable Codebox run.
 
 TypeScript callers running through the public Codebox contract should build fuzz
 suites with `@automattic/wp-codebox-core/contracts`. Use `wp-codebox/run-fuzz-suite`

--- a/packages/runtime-core/src/fuzz-fixture-plan-contracts.ts
+++ b/packages/runtime-core/src/fuzz-fixture-plan-contracts.ts
@@ -1,11 +1,15 @@
 import { stripUndefined } from "./object-utils.js"
 import type { FuzzSuiteResetPolicy } from "./fuzz-suite-contracts.js"
+import type { WordPressRestRouteArgDescriptor, WordPressRestRouteDescriptor, WordPressRestRouteEndpointDescriptor } from "./wordpress-runtime-discovery-contracts.js"
 
 export const FUZZ_FIXTURE_PLAN_SCHEMA = "wp-codebox/fuzz-fixture-plan/v1" as const
 export const REST_MUTATION_FIXTURE_OPT_IN_SCHEMA = "wp-codebox/rest-mutation-fixture-opt-in/v1" as const
+export const REST_MUTATION_GENERATED_FIXTURES_SCHEMA = "wp-codebox/rest-mutation-generated-fixtures/v1" as const
 
 export type FuzzFixtureOperationKind = "crud" | "read" | "mutation" | (string & {})
 export type FuzzFixtureMutationMethod = "POST" | "PUT" | "PATCH" | "DELETE" | (string & {})
+export type RestMutationFixtureConfidence = "high" | "medium" | "low" | "unsupported"
+export type RestMutationFixtureSource = "collection-sample" | "route-schema" | "typed-generator"
 
 export interface FuzzFixtureResourceRef {
   kind: string
@@ -44,6 +48,34 @@ export interface RestMutationFixtureOptInContract {
   rollback_policy?: FuzzSuiteResetPolicy
   fixturePlan?: FuzzFixturePlanContract
   fixturePlanRef?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface RestMutationGeneratedFixturesContract {
+  schema: typeof REST_MUTATION_GENERATED_FIXTURES_SCHEMA
+  id: string
+  route: string
+  methods: FuzzFixtureMutationMethod[]
+  fixturePlan: FuzzFixturePlanContract
+  optIns: RestMutationFixtureOptInContract[]
+  unsupported: RestMutationGeneratedFixtureUnsupported[]
+  artifacts: RestMutationFixtureArtifactRef[]
+  metadata?: Record<string, unknown>
+}
+
+export interface RestMutationGeneratedFixtureUnsupported {
+  method: string
+  route: string
+  reasons: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface RestMutationFixtureArtifactRef {
+  schema: typeof REST_MUTATION_GENERATED_FIXTURES_SCHEMA
+  kind: "rest-mutation-generated-fixtures"
+  path: string
+  bounded: true
+  contentType: "application/json"
   metadata?: Record<string, unknown>
 }
 
@@ -108,6 +140,56 @@ export function restMutationFixtureOptInContract(input: {
   })
 }
 
+export function restMutationGeneratedFixturesContract(input: {
+  id: string
+  route: WordPressRestRouteDescriptor
+  methods?: readonly string[]
+  auth?: RestMutationAuthPolicy
+  resetPolicy?: FuzzSuiteResetPolicy
+  collectionSamples?: readonly Record<string, unknown>[]
+  artifactPath?: string
+  metadata?: Record<string, unknown>
+}): RestMutationGeneratedFixturesContract {
+  const methods = dedupeStrings((input.methods ?? input.route.methods).map((method) => method.toUpperCase())).filter((method) => ["POST", "PUT", "PATCH", "DELETE"].includes(method))
+  const generated = methods.map((method) => generatedRestMutationOperation(input.route, method, input.collectionSamples ?? [])).filter((entry): entry is GeneratedRestMutationOperation => Boolean(entry))
+  const operations = generated.filter((entry) => entry.confidence !== "unsupported").map((entry) => entry.operation)
+  const fixturePlan = fuzzFixturePlanContract({
+    id: `${input.id}-fixture-plan`,
+    operations,
+    metadata: stripUndefined({
+      source: "rest-mutation-generated-fixtures",
+      route: input.route.route,
+      bounded: true,
+      semanticValidity: "syntactic-route-schema-fixtures-only",
+      collectionSampleCount: input.collectionSamples?.length,
+    }),
+  })
+  const optIns = operations.map((operation) => restMutationFixtureOptInContract({
+    id: `${input.id}-${String(operation.method ?? "mutation").toLowerCase()}-opt-in`,
+    route: input.route.route,
+    methods: operation.method ? [operation.method] : [],
+    auth: input.auth,
+    rollbackPolicy: input.resetPolicy,
+    fixturePlan,
+    metadata: stripUndefined({ source: REST_MUTATION_GENERATED_FIXTURES_SCHEMA, confidence: operation.metadata?.confidence, bounded: true }),
+  }))
+  const unsupported = generated.filter((entry) => entry.confidence === "unsupported").map((entry) => ({ method: entry.method, route: input.route.route, reasons: entry.unsupportedReasons, metadata: { source: REST_MUTATION_GENERATED_FIXTURES_SCHEMA } }))
+  const artifactPath = input.artifactPath ?? `rest-mutation-fixtures/${slugify(input.route.namespace || "rest")}-${slugify(input.route.route)}.json`
+  const artifacts: RestMutationFixtureArtifactRef[] = [{ schema: REST_MUTATION_GENERATED_FIXTURES_SCHEMA, kind: "rest-mutation-generated-fixtures", path: artifactPath, bounded: true, contentType: "application/json", metadata: { route: input.route.route, operationCount: operations.length } }]
+
+  return stripUndefined({
+    schema: REST_MUTATION_GENERATED_FIXTURES_SCHEMA,
+    id: input.id,
+    route: input.route.route,
+    methods: methods as FuzzFixtureMutationMethod[],
+    fixturePlan,
+    optIns,
+    unsupported,
+    artifacts,
+    metadata: stripUndefined({ ...input.metadata, source: "wordpress.rest-route-schema", collectionSampleCount: input.collectionSamples?.length, bounded: true, confidence: aggregateConfidence(generated.map((entry) => entry.confidence)), semanticValidity: "not-claimed" }),
+  })
+}
+
 function fuzzFixtureSeedOperation(input: FuzzFixtureSeedOperation): FuzzFixtureSeedOperation {
   return stripUndefined({
     id: input.id,
@@ -123,4 +205,121 @@ function fuzzFixtureSeedOperation(input: FuzzFixtureSeedOperation): FuzzFixtureS
 
 function dedupeStrings(values: readonly string[]): string[] {
   return [...new Set(values.filter((value) => Boolean(value)))]
+}
+
+interface GeneratedRestMutationOperation {
+  method: string
+  confidence: RestMutationFixtureConfidence
+  unsupportedReasons: string[]
+  operation: FuzzFixtureSeedOperation
+}
+
+function generatedRestMutationOperation(route: WordPressRestRouteDescriptor, method: string, collectionSamples: readonly Record<string, unknown>[]): GeneratedRestMutationOperation | undefined {
+  const endpoint = route.endpoints?.find((candidate) => candidate.methods.map((entry) => entry.toUpperCase()).includes(method))
+  const args = endpoint?.args ?? []
+  const pathBindings = bindPathTokens(route.route, args, collectionSamples)
+  const bodyBindings = bindBodyArgs(args, pathBindings.tokenNames)
+  const unsupportedReasons = [...pathBindings.unsupportedReasons, ...bodyBindings.unsupportedReasons]
+  const confidence = unsupportedReasons.length ? "unsupported" : generatedConfidence(pathBindings.sources, bodyBindings.sources, endpoint)
+  const operation = mutationFixtureSeedOperation({
+    id: `${method.toLowerCase()}-${slugify(route.route)}`,
+    method,
+    target: pathBindings.path,
+    input: stripUndefined({ bodyJson: Object.keys(bodyBindings.bodyJson).length ? bodyBindings.bodyJson : {}, params: undefined }),
+    metadata: stripUndefined({
+      source: REST_MUTATION_GENERATED_FIXTURES_SCHEMA,
+      confidence,
+      sources: dedupeStrings([...pathBindings.sources, ...bodyBindings.sources]),
+      unsupportedReasons: unsupportedReasons.length ? unsupportedReasons : undefined,
+      bounded: true,
+      semanticValidity: "syntactic-route-schema-fixtures-only",
+      route: route.route,
+      namespace: route.namespace,
+    }),
+  })
+  return { method, confidence, unsupportedReasons, operation }
+}
+
+function bindPathTokens(route: string, args: readonly WordPressRestRouteArgDescriptor[], collectionSamples: readonly Record<string, unknown>[]): { path: string; tokenNames: string[]; sources: RestMutationFixtureSource[]; unsupportedReasons: string[] } {
+  let path = route
+  const sources: RestMutationFixtureSource[] = []
+  const unsupportedReasons: string[] = []
+  const tokenNames = [...route.matchAll(/\(\?P<([^>]+)>[^)]+\)/g)].map((match) => match[1]).filter((name): name is string => Boolean(name))
+  for (const name of tokenNames) {
+    const sample = collectionSampleValue(collectionSamples, name) ?? typedArgSample(args.find((arg) => arg.name === name), restRoutePathPattern(route, name))
+    if (sample === undefined || typeof sample === "object") {
+      unsupportedReasons.push(`path_token_${name}_unbound`)
+      continue
+    }
+    sources.push(collectionSampleValue(collectionSamples, name) === undefined ? "typed-generator" : "collection-sample")
+    path = path.replace(restRoutePathTokenPattern(name), encodeURIComponent(String(sample)))
+  }
+  return { path, tokenNames, sources, unsupportedReasons }
+}
+
+function bindBodyArgs(args: readonly WordPressRestRouteArgDescriptor[], pathArgNames: readonly string[]): { bodyJson: Record<string, unknown>; sources: RestMutationFixtureSource[]; unsupportedReasons: string[] } {
+  const bodyJson: Record<string, unknown> = {}
+  const sources: RestMutationFixtureSource[] = []
+  const unsupportedReasons: string[] = []
+  for (const arg of args.filter((candidate) => !pathArgNames.includes(candidate.name) && candidate.required)) {
+    const sample = typedArgSample(arg)
+    if (sample === undefined) {
+      unsupportedReasons.push(`required_arg_${arg.name}_unsupported`)
+      continue
+    }
+    bodyJson[arg.name] = sample
+    sources.push(arg.enum?.length ? "route-schema" : "typed-generator")
+  }
+  return { bodyJson, sources, unsupportedReasons }
+}
+
+function collectionSampleValue(collectionSamples: readonly Record<string, unknown>[], name: string): unknown {
+  for (const sample of collectionSamples) {
+    const value = sample[name] ?? sample.id ?? sample.ID
+    if (["string", "number", "boolean"].includes(typeof value)) return value
+  }
+  return undefined
+}
+
+function typedArgSample(arg: WordPressRestRouteArgDescriptor | undefined, pathPattern?: string): unknown {
+  if (arg?.enum?.length) return arg.enum[0]
+  const type = Array.isArray(arg?.type) ? arg.type.find((candidate) => candidate !== "null") : arg?.type
+  if (type === "integer" || type === "number") return 1
+  if (type === "boolean") return true
+  if (type === "array") return []
+  if (type === "object") return {}
+  if (arg?.format === "date-time") return "2000-01-01T00:00:00"
+  if (arg?.format === "date") return "2000-01-01"
+  if (arg?.format === "email") return "sample@example.com"
+  if (pathPattern && /\\d|\[0-9]|\[\\d]/.test(pathPattern)) return 1
+  return "sample"
+}
+
+function generatedConfidence(sources: RestMutationFixtureSource[], bodySources: RestMutationFixtureSource[], endpoint: WordPressRestRouteEndpointDescriptor | undefined): RestMutationFixtureConfidence {
+  if (sources.includes("collection-sample") && endpoint) return "high"
+  if (bodySources.length || endpoint) return "medium"
+  return "low"
+}
+
+function aggregateConfidence(confidences: RestMutationFixtureConfidence[]): RestMutationFixtureConfidence {
+  if (!confidences.length || confidences.every((confidence) => confidence === "unsupported")) return "unsupported"
+  if (confidences.includes("high")) return "high"
+  if (confidences.includes("medium")) return "medium"
+  return "low"
+}
+
+function restRoutePathPattern(route: string, name: string): string | undefined {
+  return route.match(restRoutePathTokenPattern(name))?.[1]
+}
+
+function restRoutePathTokenPattern(name: string): RegExp {
+  return new RegExp(`\\(\\?P<${escapeRegExp(name)}>([^)]+)\\)`)
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function slugify(input: string): string {
+  return input.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "root"
 }

--- a/packages/runtime-core/src/fuzz-suite-contracts.ts
+++ b/packages/runtime-core/src/fuzz-suite-contracts.ts
@@ -377,6 +377,7 @@ export const WORDPRESS_FUZZ_RUNTIME_CONTRACT: WordPressFuzzRuntimeContract = {
       fuzzCoveragePlan: "wp-codebox/fuzz-coverage-plan/v1",
       fuzzFixturePlan: "wp-codebox/fuzz-fixture-plan/v1",
       restMutationFixtureOptIn: "wp-codebox/rest-mutation-fixture-opt-in/v1",
+      restMutationGeneratedFixtures: "wp-codebox/rest-mutation-generated-fixtures/v1",
       mutationIsolationArtifact: "wp-codebox/mutation-isolation-artifact/v1",
       deleteBoundaryArtifact: "wp-codebox/delete-boundary-artifact/v1",
       wordpressWorkloadRun: "wp-codebox/wordpress-workload-run/v1",

--- a/tests/fuzz-fixture-plan-contracts.test.ts
+++ b/tests/fuzz-fixture-plan-contracts.test.ts
@@ -5,6 +5,7 @@ import {
   fuzzFixturePlanContract,
   mutationFixtureSeedOperation,
   readFixtureSeedOperation,
+  restMutationGeneratedFixturesContract,
   restMutationFixtureOptInContract,
   restRouteInventoryToFuzzSuite,
 } from "../packages/runtime-core/src/public.js"
@@ -71,5 +72,81 @@ const deleteCase = suite.cases.find((candidate) => candidate.id === "rest-delete
 assert.equal(deleteCase?.target?.kind, "runtime-action")
 assert.equal((deleteCase?.metadata?.requiredRunnerCapabilities as { capabilities?: string[] } | undefined)?.capabilities?.includes("delete-boundary-artifact"), true)
 assert.equal((deleteCase?.metadata?.requiredRunnerCapabilities as { capabilities?: string[] } | undefined)?.capabilities?.includes("rest-mutation:delete:delete-boundary-artifact"), true)
+
+const generatedFixtures = restMutationGeneratedFixturesContract({
+  id: "generated-entity-fixtures",
+  route: {
+    route: "/example/v1/entities/(?P<id>[\\d]+)",
+    namespace: "example/v1",
+    methods: ["GET", "POST", "PATCH", "DELETE"],
+    argNames: ["id", "name", "status", "featured"],
+    endpoints: [{
+      methods: ["POST", "PATCH", "DELETE"],
+      permission: { mode: "callback" },
+      args: [
+        { name: "id", required: true, type: "integer" },
+        { name: "name", required: true, type: "string" },
+        { name: "status", required: true, type: "string", enum: ["draft", "published"] },
+        { name: "featured", required: true, type: "boolean" },
+      ],
+    }],
+  },
+  collectionSamples: [{ id: 44, name: "Existing entity" }],
+  auth: { user: "fixture-user" },
+  resetPolicy: { mode: "checkpoint-per-case", checkpointName: "generated-rest-fixtures" },
+})
+
+assert.equal(generatedFixtures.schema, "wp-codebox/rest-mutation-generated-fixtures/v1")
+assert.equal(generatedFixtures.fixturePlan.operations.length, 3)
+assert.deepEqual(generatedFixtures.fixturePlan.operationKinds, ["mutation"])
+assert.equal(generatedFixtures.artifacts[0]?.bounded, true)
+assert.equal(generatedFixtures.metadata?.semanticValidity, "not-claimed")
+assert.equal(generatedFixtures.unsupported.length, 0)
+for (const operation of generatedFixtures.fixturePlan.operations) {
+  assert.equal(operation.target, "/example/v1/entities/44")
+  assert.equal(operation.metadata?.bounded, true)
+  assert.equal(operation.metadata?.confidence, "high")
+  assert.deepEqual(operation.metadata?.sources, ["collection-sample", "typed-generator", "route-schema"])
+  assert.equal((operation.input as { bodyJson?: Record<string, unknown> }).bodyJson?.status, "draft")
+  assert.equal((operation.input as { bodyJson?: Record<string, unknown> }).bodyJson?.featured, true)
+}
+assert.equal(generatedFixtures.optIns.length, 3)
+assert.equal(generatedFixtures.optIns[0]?.fixturePlan?.id, "generated-entity-fixtures-fixture-plan")
+
+const generatedFixtureSuite = restRouteInventoryToFuzzSuite({ ...routeInventory, routes: [{
+  route: "/example/v1/entities/(?P<id>[\\d]+)",
+  namespace: "example/v1",
+  methods: ["GET", "POST", "PATCH", "DELETE"],
+  argNames: ["id", "name", "status", "featured"],
+  endpoints: [{
+    methods: ["POST", "PATCH", "DELETE"],
+    permission: { mode: "callback" },
+    args: [
+      { name: "id", required: true, type: "integer" },
+      { name: "name", required: true, type: "string" },
+      { name: "status", required: true, type: "string", enum: ["draft", "published"] },
+      { name: "featured", required: true, type: "boolean" },
+    ],
+  }],
+}] }, { restMutationOptIns: generatedFixtures.optIns })
+const generatedPatchCase = generatedFixtureSuite.cases.find((candidate) => candidate.id === "rest-patch-example-v1-entities-p-id-d-0")
+assert.equal(generatedPatchCase?.target.kind, "runtime-action")
+assert.equal((generatedPatchCase?.input as Record<string, unknown> | undefined)?.path, "/example/v1/entities/44")
+assert.equal((generatedPatchCase?.input as Record<string, unknown> | undefined)?.restMutationFixture, "generated-entity-fixtures-fixture-plan")
+assert.equal((generatedPatchCase?.metadata?.restMutationFixtureOptIn as Record<string, unknown> | undefined)?.schema, "wp-codebox/rest-mutation-fixture-opt-in/v1")
+
+const unsupportedGeneratedFixtures = restMutationGeneratedFixturesContract({
+  id: "unsupported-generated-fixtures",
+  route: {
+    route: "/example/v1/entities/(?P<compound>.+)",
+    namespace: "example/v1",
+    methods: ["PATCH"],
+    argNames: ["compound"],
+    endpoints: [{ methods: ["PATCH"], permission: { mode: "callback" }, args: [{ name: "compound", required: true, type: "object" }] }],
+  },
+})
+assert.equal(unsupportedGeneratedFixtures.metadata?.confidence, "unsupported")
+assert.equal(unsupportedGeneratedFixtures.fixturePlan.operations.length, 0)
+assert.deepEqual(unsupportedGeneratedFixtures.unsupported[0]?.reasons, ["path_token_compound_unbound"])
 
 console.log("fuzz fixture plan contracts ok")

--- a/tests/public-api-contract.test.ts
+++ b/tests/public-api-contract.test.ts
@@ -39,6 +39,7 @@ import {
   FUZZ_SUITE_SCHEMA,
   WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA,
   REST_MUTATION_FIXTURE_OPT_IN_SCHEMA,
+  REST_MUTATION_GENERATED_FIXTURES_SCHEMA,
   DELETE_BOUNDARY_ARTIFACT_SCHEMA,
   MUTATION_ISOLATION_ARTIFACT_SCHEMA,
   SANDBOX_ISOLATION_PROOF_SCHEMA,
@@ -206,6 +207,7 @@ assert.deepEqual(barrelExportModules(publicBarrel), [
   "./workspace-preload-artifacts.js",
   "./wordpress-crud-contracts.js",
   "./wordpress-block-exercise-contracts.js",
+  "./wordpress-admin-action-contracts.js",
   "./wordpress-page-load-contracts.js",
   "./wordpress-db-contracts.js",
   "./wordpress-runtime-discovery-contracts.js",
@@ -511,8 +513,10 @@ assert.equal(wordpressFuzzDescriptor.resetModes.some((mode) => mode.id === "rest
 assert.equal(wordpressFuzzDescriptor.artifactExpectations.some((artifact) => artifact.schema === "wp-codebox/delete-boundary-artifact/v1" && artifact.required), true)
 assert.equal(wordpressFuzzDescriptor.unsupportedCapabilities.some((capability) => capability.id === "private-runtime-probing"), true)
 assert.equal(wordpressFuzzDescriptor.hbex.schemaIds.descriptor, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA)
+assert.equal(wordpressFuzzDescriptor.hbex.schemaIds.restMutationGeneratedFixtures, REST_MUTATION_GENERATED_FIXTURES_SCHEMA)
 assert.equal(publicApi.runtimeDescriptor().wordpressFuzzRuntimeContract.schema, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA)
 assert.equal(publicApi.restMutationFixtureOptInContract({ id: "rest-mutation-opt-in", route: "/example/v1/items", methods: ["post", "DELETE"] }).schema, REST_MUTATION_FIXTURE_OPT_IN_SCHEMA)
+assert.equal(publicApi.restMutationGeneratedFixturesContract({ id: "rest-mutation-generated", route: { route: "/example/v1/items", namespace: "example/v1", methods: ["POST"], argNames: [], endpoints: [{ methods: ["POST"], permission: { mode: "callback" }, args: [] }] } }).schema, REST_MUTATION_GENERATED_FIXTURES_SCHEMA)
 assert.equal(fuzzSuiteContract({ id: "ability-boundary", cases: [{ id: "empty-input" }] }).schema, FUZZ_SUITE_SCHEMA)
 assert.deepEqual(fuzzSuiteResultEnvelope({
   suite: { id: "ability-boundary" },


### PR DESCRIPTION
## Summary
- Add public `wp-codebox/rest-mutation-generated-fixtures/v1` for generic mutating REST fixture generation.
- Derive bounded disposable sandbox mutation operations from route schemas, optional collection samples, and typed generators.
- Return fixture-plan opt-ins plus explicit confidence, source, boundedness, semantic-validity, artifact, and unsupported-reason metadata.
- Advertise the schema through the WordPress fuzz runtime descriptor and public API docs.

## Tests
- `npx tsx tests/fuzz-fixture-plan-contracts.test.ts`
- `npm run test:public-api-contract`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the generated REST mutation fixture contract, tests, docs, and PR preparation.