### PR TITLE
Guard recipe-run artifact paths

### DIFF
--- a/packages/cli/src/commands/recipe-run-artifacts-mount-guard.ts
+++ b/packages/cli/src/commands/recipe-run-artifacts-mount-guard.ts
@@ -1,0 +1,72 @@
+import { relative, resolve } from "node:path"
+import type { WorkspaceRecipe } from "@automattic/wp-codebox-core"
+
+export interface RecipeArtifactsMountConflict {
+  artifactsDirectory: string
+  mountSource: string
+  mountPath: string
+  mountKind: string
+}
+
+export class RecipeArtifactsMountConflictError extends Error {
+  readonly code = "recipe-artifacts-mount-conflict"
+
+  constructor(readonly conflict: RecipeArtifactsMountConflict) {
+    super(`Recipe artifacts directory ${conflict.artifactsDirectory} is inside recipe mount source ${conflict.mountSource}. Choose an --artifacts directory outside mounted sources to avoid recursive artifact collection.`)
+    this.name = "RecipeArtifactsMountConflictError"
+  }
+}
+
+interface RecipeMountSourceCandidate {
+  source: string
+  path: string
+  kind: string
+}
+
+export function recipeArtifactsMountConflict(recipe: WorkspaceRecipe, recipeDirectory: string, artifactsDirectory: string | undefined): RecipeArtifactsMountConflict | undefined {
+  const resolvedArtifactsDirectory = resolve(artifactsDirectory ?? "artifacts")
+  for (const candidate of recipeMountSourceCandidates(recipe)) {
+    const mountSource = resolve(recipeDirectory, candidate.source)
+    if (!pathContainsOrEquals(mountSource, resolvedArtifactsDirectory)) {
+      continue
+    }
+
+    return {
+      artifactsDirectory: resolvedArtifactsDirectory,
+      mountSource,
+      mountPath: candidate.path,
+      mountKind: candidate.kind,
+    }
+  }
+
+  return undefined
+}
+
+function recipeMountSourceCandidates(recipe: WorkspaceRecipe): RecipeMountSourceCandidate[] {
+  const candidates: RecipeMountSourceCandidate[] = []
+
+  for (const [index, mount] of (recipe.runtime?.stack?.mounts ?? []).entries()) {
+    candidates.push({ source: mount.source, path: `$.runtime.stack.mounts[${index}].source`, kind: "runtime-stack-mount" })
+  }
+
+  for (const [index, mount] of (recipe.distribution?.sourceMounts ?? []).entries()) {
+    candidates.push({ source: mount.source, path: `$.distribution.sourceMounts[${index}].source`, kind: "distribution-source-mount" })
+  }
+
+  for (const [index, mount] of (recipe.inputs?.mounts ?? []).entries()) {
+    candidates.push({ source: mount.source, path: `$.inputs.mounts[${index}].source`, kind: "input-mount" })
+  }
+
+  for (const [index, workspace] of (recipe.inputs?.workspaces ?? []).entries()) {
+    if (workspace.seed.type === "directory" && workspace.seed.source) {
+      candidates.push({ source: workspace.seed.source, path: `$.inputs.workspaces[${index}].seed.source`, kind: "workspace-mount" })
+    }
+  }
+
+  return candidates
+}
+
+function pathContainsOrEquals(parent: string, child: string): boolean {
+  const path = relative(parent, child)
+  return path === "" || (!!path && !path.startsWith("..") && !path.startsWith("/"))
+}

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -20,6 +20,7 @@ import { createRecipeRunContext } from "./recipe-run-context.js"
 import { collectRecipeDeclaredArtifacts, materializeTypedRecipeDeclaredArtifacts, recipeDeclaredArtifactFailure, recipeProbeFailure, recipeRuntimeEvidenceFiles } from "./recipe-declared-artifacts.js"
 import { completedRecipeOutputFields, finalizeCompletedRecipeRun, finalizeRecipeValidationFailure, finalizeRecoveredRecipeFailure, runRecipeCleanup, type RunResourceCleanupEvidence } from "./recipe-run-finalizer.js"
 import { RecipeRunPhaseExecutor } from "./recipe-run-phase-executor.js"
+import { RecipeArtifactsMountConflictError, recipeArtifactsMountConflict } from "./recipe-run-artifacts-mount-guard.js"
 import { createRecipeInterruptionController, interruptedRecipeOutput, markRecipeArtifactsFinalized, recipeInterruptionSerializedError } from "./recipe-run-interruption.js"
 import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, printJsonFailureDiagnostic, RecipeRunTimeoutError, RecipeRuntimeCreateError, serializeRecipeRunError, writeRecipeJsonOutput } from "./recipe-run-output.js"
 import { RecipePhaseError } from "./recipe-run-phases.js"
@@ -79,6 +80,11 @@ export async function runRecipeValidateCommand(args: string[]): Promise<number> 
 }
 
 async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterruptionController): Promise<RecipeRunOutput> {
+  const mountConflictFailure = await recipeArtifactsMountConflictFailure(options)
+  if (mountConflictFailure) {
+    return mountConflictFailure
+  }
+
   const context = await createRecipeRunContext(options)
   const { recipePath, recipeDirectory, recipe, configuredArtifactsDirectory, runRegistry, artifactPointer, startedAtMs } = context
   let { runRecord } = context
@@ -492,6 +498,25 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     })
   } finally {
     cancellationWatcher?.dispose()
+  }
+}
+
+async function recipeArtifactsMountConflictFailure(options: RecipeRunOptions): Promise<RecipeRunOutput | undefined> {
+  const recipePath = resolve(options.recipePath)
+  const recipeDirectory = dirname(recipePath)
+  const recipe = await loadWorkspaceRecipe(recipePath)
+  const configuredArtifactsDirectory = options.artifactsDirectory ?? recipe.artifacts?.directory
+  const conflict = recipeArtifactsMountConflict(recipe, recipeDirectory, configuredArtifactsDirectory)
+  if (!conflict) {
+    return undefined
+  }
+
+  return {
+    success: false,
+    schema: "wp-codebox/recipe-run/v1",
+    recipePath,
+    executions: [],
+    error: serializeError(new RecipeArtifactsMountConflictError(conflict)),
   }
 }
 

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -2,6 +2,7 @@ import { basename, dirname, resolve } from "node:path"
 import { fixtureImportDeterministicIdPlan, normalizeRuntimeBackendKind, validateRuntimePolicy, type FixtureImportDeterministicIdPlan, type MountSpec, type RuntimePolicy, type RuntimeWordPressInstallMode, type SandboxWorkspaceMode, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeSiteSeed, type WorkspaceRecipeSiteSeedBootstrap, type WorkspaceRecipeWorkspace } from "@automattic/wp-codebox-core"
 import { SANDBOX_WORKSPACE_ROOT, stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { serializeError } from "./output.js"
+import { RecipeArtifactsMountConflictError, recipeArtifactsMountConflict } from "./commands/recipe-run-artifacts-mount-guard.js"
 import { resolveRecipeSecretEnv, type RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
 import { recipeExternalServiceBoundarySummaries, type RecipeExternalServiceBoundarySummary } from "./recipe-external-services.js"
 import { composerPackageVendorPath, defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
@@ -253,6 +254,19 @@ export async function dryRunRecipe(options: RecipeDryRunOptions, context: Recipe
   try {
     const recipeDirectory = dirname(recipePath)
     const recipe = await loadWorkspaceRecipe(recipePath)
+    const artifactMountConflict = recipeArtifactsMountConflict(recipe, recipeDirectory, options.artifactsDirectory ?? recipe.artifacts?.directory)
+    if (artifactMountConflict) {
+      return {
+        success: false,
+        schema: "wp-codebox/recipe-run-dry-run/v1",
+        recipePath,
+        dryRun: true,
+        valid: false,
+        validation: { issues: [] },
+        error: serializeError(new RecipeArtifactsMountConflictError(artifactMountConflict)),
+      }
+    }
+
     const issues = await validateWorkspaceRecipe(recipe, recipePath)
 
     if (issues.length > 0) {

--- a/tests/recipe-run-artifacts-mount-guard.test.ts
+++ b/tests/recipe-run-artifacts-mount-guard.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict"
+import { mkdir, stat, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+import { captureStdout } from "../packages/cli/src/output.js"
+import { runRecipeRunCommand } from "../packages/cli/src/commands/recipe-run.js"
+import { recipeArtifactsMountConflict } from "../packages/cli/src/commands/recipe-run-artifacts-mount-guard.js"
+import type { WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+await withTempDir("wp-codebox-recipe-artifacts-mount-guard-", async (recipeDirectory) => {
+  const mountedSource = join(recipeDirectory, "mounted-source")
+  const outsideArtifacts = join(recipeDirectory, "artifacts-outside")
+  await mkdir(join(mountedSource, "nested"), { recursive: true })
+  await mkdir(outsideArtifacts, { recursive: true })
+
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: {
+      mounts: [
+        { source: "mounted-source", target: "/wordpress/wp-content/plugins/example", mode: "readwrite" },
+      ],
+    },
+    workflow: { steps: [{ command: "host/test", args: [] }] },
+  }
+
+  assert.equal(recipeArtifactsMountConflict(recipe, recipeDirectory, outsideArtifacts), undefined)
+
+  assert.deepEqual(recipeArtifactsMountConflict(recipe, recipeDirectory, mountedSource), {
+    artifactsDirectory: resolve(mountedSource),
+    mountSource: resolve(mountedSource),
+    mountPath: "$.inputs.mounts[0].source",
+    mountKind: "input-mount",
+  })
+
+  assert.deepEqual(recipeArtifactsMountConflict(recipe, recipeDirectory, join(mountedSource, "nested", "artifacts")), {
+    artifactsDirectory: resolve(mountedSource, "nested", "artifacts"),
+    mountSource: resolve(mountedSource),
+    mountPath: "$.inputs.mounts[0].source",
+    mountKind: "input-mount",
+  })
+
+  const recipePath = join(recipeDirectory, "recipe.json")
+  const conflictingArtifacts = join(mountedSource, "nested", "command-artifacts")
+  await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`)
+
+  const { result: exitCode, logs } = await captureStdout(async () => await runRecipeRunCommand(["--recipe", recipePath, "--artifacts", conflictingArtifacts, "--json"]))
+  assert.equal(exitCode, 1)
+  const output = JSON.parse(logs[0])
+  assert.equal(output.success, false)
+  assert.equal(output.error.code, "recipe-artifacts-mount-conflict")
+  assert.equal(output.error.conflict.artifactsDirectory, resolve(conflictingArtifacts))
+  assert.equal(output.error.conflict.mountSource, resolve(mountedSource))
+  assert.equal(await pathExists(conflictingArtifacts), false)
+})
+
+console.log("recipe run artifacts mount guard ok")
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- Guard `recipe-run` and recipe dry-runs against artifact directories nested inside recipe mount sources.
- Return a structured `recipe-artifacts-mount-conflict` error before runtime boot.
- Include the conflicting artifact directory and mount source in the diagnostic.

Fixes #1660.

## Testing
- `npx tsx tests/recipe-run-artifacts-mount-guard.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, focused test coverage, verification workflow
