### PR TITLE
Add recipe-run summary output

### DIFF
--- a/packages/cli/src/commands/recipe-run-output.ts
+++ b/packages/cli/src/commands/recipe-run-output.ts
@@ -1,5 +1,5 @@
 import { setTimeout as delay } from "node:timers/promises"
-import type { RuntimeRunRecord } from "@automattic/wp-codebox-core"
+import type { RecipeRunSummary, RuntimeRunRecord } from "@automattic/wp-codebox-core"
 import { serializeError } from "../output.js"
 import type { RunOutput } from "../runtime-command-wrappers.js"
 import { RecipePhaseError } from "./recipe-run-phases.js"
@@ -96,6 +96,51 @@ function hasTerminalRecipePhaseFailure(output: RecipeRunOutput): boolean {
 
 export async function writeRecipeJsonOutput(output: unknown): Promise<void> {
   await writeStdout(`${JSON.stringify(output, null, 2)}\n`)
+}
+
+export async function writeRecipeSummaryHumanOutput(summary: RecipeRunSummary): Promise<void> {
+  const lines: string[] = []
+  const metadata = summary.metadata ?? {}
+  const artifactBundle = summary.refs.artifact_bundles[0]
+  lines.push("WP Codebox recipe summary")
+  lines.push(`Status: ${summary.status}`)
+  if (typeof metadata.recipe_path === "string") lines.push(`Recipe: ${metadata.recipe_path}`)
+  if (summary.failed_phase) lines.push(`Failed phase: ${summary.failed_phase}`)
+  if (summary.failure_summary) lines.push(`Failure: ${oneLine(summary.failure_summary)}`)
+  if (typeof metadata.run_id === "string" || typeof metadata.run_status === "string") lines.push(`Run: ${metadata.run_id ?? "unknown"}${metadata.run_status ? ` (${metadata.run_status})` : ""}`)
+  if (typeof metadata.runtime_id === "string" || typeof metadata.runtime_status === "string") lines.push(`Runtime: ${metadata.runtime_id ?? "unknown"}${metadata.runtime_status ? ` (${metadata.runtime_status})` : ""}`)
+  if (typeof metadata.artifact_directory === "string") lines.push(`Artifacts: ${metadata.artifact_directory}`)
+  else if (artifactBundle?.path) lines.push(`Artifacts: ${artifactBundle.path}`)
+  if (summary.runtime_access?.preview_url || summary.runtime_access?.public_url || summary.runtime_access?.site_url) lines.push(`Preview: ${summary.runtime_access.preview_url || summary.runtime_access.public_url || summary.runtime_access.site_url}`)
+
+  lines.push(`Commands: ${summary.commands.length}`)
+  for (const command of summary.commands) {
+    const status = command.exit_code === undefined ? command.status : `${command.status} exit=${command.exit_code}`
+    const phase = command.recipe_phase ? ` phase=${command.recipe_phase}` : ""
+    lines.push(`- #${command.index + 1} ${status}${phase}: ${oneLine(command.command)}`)
+    if (command.stderr_tail && command.status !== "succeeded") lines.push(`  stderr: ${tailLines(command.stderr_tail)}`)
+    if (command.stdout_tail && command.status !== "succeeded") lines.push(`  stdout: ${tailLines(command.stdout_tail)}`)
+  }
+
+  const diagnostics = summary.diagnostics.slice(0, 5)
+  if (diagnostics.length > 0) {
+    lines.push(`Diagnostics: ${summary.diagnostics.length}`)
+    for (const diagnostic of diagnostics) {
+      const code = typeof diagnostic.code === "string" ? `${diagnostic.code}: ` : ""
+      const message = typeof diagnostic.message === "string" ? diagnostic.message : JSON.stringify(diagnostic)
+      lines.push(`- ${code}${oneLine(message)}`)
+    }
+  }
+
+  await writeStdout(`${lines.join("\n")}\n`)
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim()
+}
+
+function tailLines(value: string, maxLines = 6): string {
+  return value.split(/\r?\n/).filter(Boolean).slice(-maxLines).map(oneLine).join(" | ")
 }
 
 function writeStdout(contents: string): Promise<void> {

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -21,6 +21,7 @@ export interface RecipeRunOptions {
   previewLeaseFile?: string
   timeoutMs: number
   json: boolean
+  summary: boolean
   dryRun: boolean
 }
 

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRuntimeEnvRecord, parseCommandOptions, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRecipeRunSummary, normalizeRuntimeEnvRecord, parseCommandOptions, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
@@ -21,7 +21,7 @@ import { collectRecipeDeclaredArtifacts, materializeTypedRecipeDeclaredArtifacts
 import { completedRecipeOutputFields, finalizeCompletedRecipeRun, finalizeRecipeValidationFailure, finalizeRecoveredRecipeFailure, runRecipeCleanup, type RunResourceCleanupEvidence } from "./recipe-run-finalizer.js"
 import { RecipeRunPhaseExecutor } from "./recipe-run-phase-executor.js"
 import { createRecipeInterruptionController, interruptedRecipeOutput, markRecipeArtifactsFinalized, recipeInterruptionSerializedError } from "./recipe-run-interruption.js"
-import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, printJsonFailureDiagnostic, RecipeRunTimeoutError, RecipeRuntimeCreateError, serializeRecipeRunError, writeRecipeJsonOutput } from "./recipe-run-output.js"
+import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRunTimeout, exitAfterTerminalRecipePhaseFailure, printJsonFailureDiagnostic, RecipeRunTimeoutError, RecipeRuntimeCreateError, serializeRecipeRunError, writeRecipeJsonOutput, writeRecipeSummaryHumanOutput } from "./recipe-run-output.js"
 import { RecipePhaseError } from "./recipe-run-phases.js"
 import { markPreviewLeaseAvailable, markPreviewLeaseFailed, markPreviewLeaseReleased, startPreviewLeaseRecipeRun } from "./preview-lease.js"
 import { importRecipeSiteSeeds } from "./recipe-site-seeds.js"
@@ -41,6 +41,19 @@ export async function runRecipeRunCommand(args: string[]): Promise<number> {
   const execute = (): Promise<RecipeRunCommandOutput> => options.dryRun ? dryRunRecipe(options, { defaultWordPressVersion: DEFAULT_WORDPRESS_VERSION, resolveExecutionSpec: recipeExecutionSpec }) : runRecipe(options, interruption)
 
   try {
+    if (options.summary) {
+      const { result } = await captureStdout(execute)
+      const output = interruptedRecipeOutput(result, interruption)
+      const summary = normalizeRecipeRunSummary(output)
+      if (options.json) await writeRecipeJsonOutput(summary)
+      else await writeRecipeSummaryHumanOutput(summary)
+      interruption?.propagateIfInterrupted()
+      exitAfterRecipeRunTimeout(output)
+      exitAfterPlaygroundCliBootFailure(output)
+      exitAfterTerminalRecipePhaseFailure(output)
+      return output.success ? 0 : 1
+    }
+
     if (!options.json) {
       const output = interruptedRecipeOutput(await execute(), interruption)
       printRecipeHumanOutput(output)
@@ -598,12 +611,13 @@ function distributionRuntimeEnv(recipe: WorkspaceRecipe): Record<string, string>
 }
 
 function parseRecipeRunOptions(args: string[]): RecipeRunOptions {
-  const parsed = parseCommandOptions(args, new Set(["--json", "--dry-run", "--preview-hold-blocking", "--preview-lease", "--preview-lease-child"]))
+  const parsed = parseCommandOptions(args, new Set(["--json", "--summary", "--summary-only", "--dry-run", "--preview-hold-blocking", "--preview-lease", "--preview-lease-child"]))
   if (parsed.positionals.length > 0) {
     throw new Error(`Invalid argument: ${parsed.positionals[0]}`)
   }
   const options: Partial<RecipeRunOptions> = {
     json: parsed.options.get("--json") === true,
+    summary: parsed.options.get("--summary") === true || parsed.options.get("--summary-only") === true,
     dryRun: parsed.options.get("--dry-run") === true,
     previewHoldBlocking: parsed.options.get("--preview-hold-blocking") === true,
     previewLeaseRequested: parsed.options.get("--preview-lease") === true,

--- a/tests/recipe-run-summary-output.test.ts
+++ b/tests/recipe-run-summary-output.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict"
+import { normalizeRecipeRunSummary } from "@automattic/wp-codebox-core"
+import { writeRecipeJsonOutput, writeRecipeSummaryHumanOutput } from "../packages/cli/src/commands/recipe-run-output.js"
+
+const success = normalizeRecipeRunSummary({
+  success: true,
+  schema: "wp-codebox/recipe-run/v1",
+  recipePath: "/tmp/recipe.json",
+  runtime: { id: "runtime-ok", status: "ready" },
+  run: { runId: "run-ok", status: "succeeded" },
+  artifacts: { directory: "/tmp/artifacts/run-ok" },
+  executions: [{ command: "wordpress.wp-cli option get siteurl", exitCode: 0, durationMs: 12, recipePhase: "run_workloads", recipeStepIndex: 0 }],
+})
+
+const successHuman = await captureStdout(() => writeRecipeSummaryHumanOutput(success))
+assert.match(successHuman, /WP Codebox recipe summary/)
+assert.match(successHuman, /Status: succeeded/)
+assert.match(successHuman, /Recipe: \/tmp\/recipe\.json/)
+assert.match(successHuman, /Run: run-ok \(succeeded\)/)
+assert.match(successHuman, /Runtime: runtime-ok \(ready\)/)
+assert.match(successHuman, /Artifacts: \/tmp\/artifacts\/run-ok/)
+assert.match(successHuman, /Commands: 1/)
+assert.match(successHuman, /#1 succeeded exit=0 phase=run_workloads/)
+
+const failure = normalizeRecipeRunSummary({
+  success: false,
+  schema: "wp-codebox/recipe-run/v1",
+  recipePath: "/tmp/failing.recipe.json",
+  error: { message: "Workflow command failed" },
+  runtime: { id: "runtime-fail", status: "stopped" },
+  run: { runId: "run-fail", status: "failed" },
+  artifacts: { directory: "/tmp/artifacts/run-fail" },
+  phaseEvidence: [{ name: "run_workloads", status: "failed" }],
+  diagnostics: [{ code: "workflow-command-failed", message: "Command exited non-zero" }],
+  executions: [{ command: "wordpress.wp-cli eval 'broken'", exitCode: 1, stdout: "line 1\nline 2\n", stderr: "fatal detail\n", recipePhase: "run_workloads", recipeStepIndex: 0 }],
+})
+
+const failureHuman = await captureStdout(() => writeRecipeSummaryHumanOutput(failure))
+assert.match(failureHuman, /Status: failed/)
+assert.match(failureHuman, /Failed phase: run_workloads/)
+assert.match(failureHuman, /Failure: run_workloads: Workflow command failed/)
+assert.match(failureHuman, /#1 failed exit=1 phase=run_workloads/)
+assert.match(failureHuman, /stderr: fatal detail/)
+assert.match(failureHuman, /stdout: line 1 \| line 2/)
+assert.match(failureHuman, /Diagnostics: 1/)
+
+const failureJson = await captureStdout(() => writeRecipeJsonOutput(failure))
+const parsed = JSON.parse(failureJson)
+assert.equal(parsed.schema, "wp-codebox/recipe-run-summary/v1")
+assert.equal(parsed.status, "failed")
+assert.equal(parsed.failed_phase, "run_workloads")
+assert.equal(parsed.commands[0].exit_code, 1)
+
+async function captureStdout(callback: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let output = ""
+  process.stdout.write = ((chunk: string | Uint8Array, encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void), callback?: (error?: Error | null) => void) => {
+    output += typeof chunk === "string" ? chunk : chunk.toString()
+    if (typeof encodingOrCallback === "function") encodingOrCallback()
+    else callback?.()
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    await callback()
+    return output
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}


### PR DESCRIPTION
## Summary
- Add concise `recipe-run` summary output via `--summary` / `--summary-only`.
- Preserve existing full `--json` output unless the summary flag is requested.
- Support stable JSON summary output when `--json --summary` are combined, plus bounded human-readable output otherwise.

Fixes #1661.

## Testing
- `npm exec -- tsx tests/recipe-run-summary-output.test.ts`
- `npm exec -- tsx scripts/recipe-run-summary-smoke.ts`
- `npm exec -- tsx tests/recipe-run-output-exit.test.ts`
- `npm run build`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, focused test coverage, verification workflow
