### PR TITLE
Expose WordPress fuzz runtime contract fields

### DIFF
--- a/packages/runtime-core/src/runtime-contract-manifest.ts
+++ b/packages/runtime-core/src/runtime-contract-manifest.ts
@@ -4,7 +4,7 @@ import { AGENT_RUNTIME_WORKLOAD_SCHEMA } from "./agent-runtime-workload.js"
 import { ARTIFACT_RESULT_ENVELOPE_SCHEMA, normalizeArtifactResultEnvelope, type ArtifactResultEnvelope } from "./artifact-result-envelope.js"
 import { FANOUT_AGGREGATION_INPUT_SCHEMA, FANOUT_AGGREGATION_OUTPUT_SCHEMA, aggregateFanoutOutputs, normalizeFanoutAggregationInput, validateFanoutAggregationOutput, type FanoutAggregationInput, type FanoutAggregationInputRequest, type FanoutAggregationOutput } from "./fanout-aggregation.js"
 import { FUZZ_COVERAGE_PLAN_SCHEMA } from "./fuzz-coverage-plan-contracts.js"
-import { FUZZ_RUNNER_CAPABILITIES_SCHEMA, FUZZ_RUNNER_READINESS_SCHEMA, FUZZ_SUITE_RESULT_SCHEMA, FUZZ_SUITE_SCHEMA, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA, wordpressFuzzRuntimeContract, type WordPressFuzzRuntimeContract } from "./fuzz-suite-contracts.js"
+import { FUZZ_RUNNER_CAPABILITIES_SCHEMA, FUZZ_RUNNER_READINESS_SCHEMA, FUZZ_SUITE_RESULT_SCHEMA, FUZZ_SUITE_SCHEMA, RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES, WORDPRESS_FUZZ_RUNTIME_CONTRACT_SCHEMA, fuzzRunnerReadinessContract, wordpressFuzzRuntimeContract, type WordPressFuzzRuntimeContract } from "./fuzz-suite-contracts.js"
 import { HOST_DELEGATION_EVENT_SCHEMA, HOST_DELEGATION_REQUEST_SCHEMA, HOST_DELEGATION_RESULT_SCHEMA } from "./fanout-contracts.js"
 import { ARTIFACT_BUNDLE_FILE_MANIFEST_SCHEMA, BROWSER_ARTIFACT_PERSISTENCE_REF_SCHEMA } from "./materialization-contracts.js"
 import { PARENT_TOOL_BRIDGE_SCHEMA, PARENT_TOOL_REQUEST_SCHEMA, PARENT_TOOL_RESULT_SCHEMA } from "./parent-tool-bridge.js"
@@ -73,6 +73,27 @@ export const CODEBOX_PUBLIC_RUNTIME_ABILITIES = {
     runWorkload: CODEBOX_RUN_WORDPRESS_WORKLOAD_ABILITY,
     runFuzzSuite: CODEBOX_RUN_FUZZ_SUITE_ABILITY,
   },
+} as const
+
+export const CODEBOX_PUBLIC_RUNTIME_COMMANDS = {
+  wordpressRuntime: {
+    runWorkload: "run-wordpress-workload",
+    runFuzzSuite: "run-fuzz-suite",
+  },
+} as const
+
+export const CODEBOX_PUBLIC_RUNTIME_WORDPRESS_CAPABILITIES = {
+  wordpressRuntime: {
+    commands: CODEBOX_PUBLIC_RUNTIME_COMMANDS.wordpressRuntime,
+    capabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
+    runner_modes: {
+      "runtime-backed": true,
+    },
+  },
+} as const
+
+export const CODEBOX_PUBLIC_RUNTIME_READINESS = {
+  wordpressRuntime: fuzzRunnerReadinessContract(RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES),
 } as const
 
 export const RUNTIME_CONTRACT_SCHEMAS = {
@@ -215,6 +236,9 @@ export interface RuntimeContractManifest {
   version: 1
   schemas: typeof RUNTIME_CONTRACT_SCHEMAS
   abilities: typeof CODEBOX_PUBLIC_RUNTIME_ABILITIES
+  commands: typeof CODEBOX_PUBLIC_RUNTIME_COMMANDS
+  capabilities: typeof CODEBOX_PUBLIC_RUNTIME_WORDPRESS_CAPABILITIES
+  readiness: typeof CODEBOX_PUBLIC_RUNTIME_READINESS
   providerRuntime: ReturnType<typeof providerRuntimeInvocationContract>
 }
 
@@ -242,6 +266,9 @@ export function runtimeContractManifest(): RuntimeContractManifest {
     version: 1,
     schemas: RUNTIME_CONTRACT_SCHEMAS,
     abilities: CODEBOX_PUBLIC_RUNTIME_ABILITIES,
+    commands: CODEBOX_PUBLIC_RUNTIME_COMMANDS,
+    capabilities: CODEBOX_PUBLIC_RUNTIME_WORDPRESS_CAPABILITIES,
+    readiness: CODEBOX_PUBLIC_RUNTIME_READINESS,
     providerRuntime: providerRuntimeInvocationContract(),
   }
 }

--- a/tests/runtime-contract-manifest.test.ts
+++ b/tests/runtime-contract-manifest.test.ts
@@ -23,6 +23,9 @@ import {
   BROWSER_SESSION_PRODUCT_DTO_SCHEMA,
   CODEBOX_PUBLIC_RUNTIME_CAPABILITIES,
   CODEBOX_PUBLIC_RUNTIME_ABILITIES,
+  CODEBOX_PUBLIC_RUNTIME_COMMANDS,
+  CODEBOX_PUBLIC_RUNTIME_READINESS,
+  CODEBOX_PUBLIC_RUNTIME_WORDPRESS_CAPABILITIES,
   CODEBOX_RESOLVE_RUNTIME_REQUIREMENTS_ABILITY,
   CODEBOX_RUN_AGENT_TASK_ABILITY,
   CODEBOX_RUN_AGENT_TASK_BATCH_ABILITY,
@@ -32,6 +35,7 @@ import {
   CODEBOX_RUN_WORDPRESS_WORKLOAD_ABILITY,
   FANOUT_AGGREGATION_INPUT_SCHEMA,
   FANOUT_AGGREGATION_OUTPUT_SCHEMA,
+  FUZZ_RUNNER_READINESS_SCHEMA,
   FUZZ_COVERAGE_PLAN_SCHEMA,
   FUZZ_SUITE_RESULT_SCHEMA,
   FUZZ_SUITE_SCHEMA,
@@ -82,6 +86,9 @@ assert.equal(manifest.schema, RUNTIME_CONTRACT_MANIFEST_SCHEMA)
 assert.equal(manifest.version, 1)
 assert.deepEqual(manifest.schemas, RUNTIME_CONTRACT_SCHEMAS)
 assert.deepEqual(manifest.abilities, CODEBOX_PUBLIC_RUNTIME_ABILITIES)
+assert.deepEqual(manifest.commands, CODEBOX_PUBLIC_RUNTIME_COMMANDS)
+assert.deepEqual(manifest.capabilities, CODEBOX_PUBLIC_RUNTIME_WORDPRESS_CAPABILITIES)
+assert.deepEqual(manifest.readiness, CODEBOX_PUBLIC_RUNTIME_READINESS)
 
 assert.equal(manifest.schemas.agentTask.runRequest, AGENT_TASK_RUN_REQUEST_SCHEMA)
 assert.equal(manifest.schemas.agentTask.runResult, AGENT_TASK_RUN_RESULT_SCHEMA)
@@ -151,6 +158,17 @@ assert.equal(manifest.abilities.runtimePackage.run, CODEBOX_RUN_RUNTIME_PACKAGE_
 assert.equal(manifest.abilities.runtimeRequirements.resolve, CODEBOX_RESOLVE_RUNTIME_REQUIREMENTS_ABILITY)
 assert.equal(manifest.abilities.wordpressRuntime.runWorkload, CODEBOX_RUN_WORDPRESS_WORKLOAD_ABILITY)
 assert.equal(manifest.abilities.wordpressRuntime.runFuzzSuite, CODEBOX_RUN_FUZZ_SUITE_ABILITY)
+assert.equal(manifest.commands.wordpressRuntime.runWorkload, "run-wordpress-workload")
+assert.equal(manifest.commands.wordpressRuntime.runFuzzSuite, "run-fuzz-suite")
+assert.equal(manifest.capabilities.wordpressRuntime.commands.runWorkload, "run-wordpress-workload")
+assert.equal(manifest.capabilities.wordpressRuntime.commands.runFuzzSuite, "run-fuzz-suite")
+assert.equal(manifest.capabilities.wordpressRuntime.capabilities.commands?.includes("wordpress.run-workload"), true)
+assert.equal(manifest.capabilities.wordpressRuntime.runner_modes["runtime-backed"], true)
+assert.equal(manifest.readiness.wordpressRuntime.schema, FUZZ_RUNNER_READINESS_SCHEMA)
+assert.equal(manifest.readiness.wordpressRuntime.status, "ready")
+assert.equal(manifest.readiness.wordpressRuntime.mode, "runtime-backed")
+assert.equal(manifest.readiness.wordpressRuntime.entrypoint, "run-fuzz-suite --runner-mode=runtime-backed")
+assert.equal(manifest.readiness.wordpressRuntime.capabilities.commands?.includes("wordpress.run-workload"), true)
 assert.equal(manifest.providerRuntime.schema, PROVIDER_RUNTIME_INVOCATION_CONTRACT_SCHEMA)
 assert.deepEqual(manifest.providerRuntime.tasks, PROVIDER_RUNTIME_TASK_NAMES)
 assert.equal(manifest.providerRuntime.tasks.workspaceCommand, "wp-codebox.runner-workspace.command")


### PR DESCRIPTION
## Summary
- Add explicit WordPress fuzz/workload public commands to the runtime contract manifest.
- Add WordPress runtime-backed fuzz capabilities and readiness to the public manifest.
- Cover the Lab-required ability, command, schema, capability, and readiness paths in the manifest test.

## Tests
- npm run test:runtime-contract-manifest
- npx tsx tests/public-fuzz-workload-cli.test.ts
- npm run build
- node packages/cli/dist/index.js runtime descriptor --json

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runtime contract gap, editing the manifest/test coverage, and running targeted verification.