### PR TITLE
Support nested extra plugin sources

### DIFF
--- a/docs/recipe-contract.md
+++ b/docs/recipe-contract.md
@@ -149,8 +149,11 @@ summary from observed hosts to declared boundary ids where host names match
 ## Extra Plugins
 
 `inputs.extra_plugins` mounts additional WordPress plugins before workflow steps
-run. Each entry requires `source` and may include `slug`, `pluginFile`,
-`activate`, `loadAs`, and `sha256`.
+run. Each entry requires `source` or `sourcePath` and may include `sourceSubdir`,
+`mountSlug`, `pluginFile`, `activate`, `loadAs`, and `sha256`. `sourcePath` is
+the source root, `sourceSubdir` is an optional plugin directory below that root,
+`mountSlug` is the WordPress plugin directory, and `pluginFile` is relative to
+the mounted plugin slug.
 
 ```json
 {
@@ -167,6 +170,12 @@ run. Each entry requires `source` and may include `slug`, `pluginFile`,
         "pluginFile": "caller-runtime-substrate/caller-runtime-substrate.php",
         "activate": false,
         "loadAs": "mu-plugin"
+      },
+      {
+        "sourcePath": "../monorepo",
+        "sourceSubdir": "plugins/example-plugin",
+        "mountSlug": "example-plugin",
+        "pluginFile": "example-plugin/example-plugin.php"
       }
     ]
   }

--- a/docs/runner-workspace-git-tools.md
+++ b/docs/runner-workspace-git-tools.md
@@ -16,17 +16,13 @@ native git + GitHub agent-tool surface so it no longer depends on DMC.
    `agents-api`** into the sandbox WordPress as default runtime components.
    `data-machine-code` is what supplies the agent's `workspace_*` /
    `create_github_*` tools.
-2. Inside the sandbox, the agent runs through the Agents API conversation loop
-   (`agents-api/.../class-wp-agent-conversation-loop.php`). Tool calls are
+2. Inside the sandbox, the agent runs through the configured agent conversation loop. Tool calls are
    executed by a `WP_Agent_Tool_Executor` passed in `$options['tool_executor']`.
    The default executor (`WP_Agent_Ability_Tool_Executor`) dispatches
    `tool_name → wp_get_ability(tool_name)->execute()` via
    `WP_Agent_Ability_Dispatcher`.
-3. Those abilities are DMC's `datamachine-code/workspace-*` and
-   `datamachine-code/*-github-*` abilities
-   (`data-machine-code/inc/Abilities/WorkspaceAbilities.php`,
-   `GitHubAbilities.php`), which shell out to `git` / call the GitHub API on the
-   workspace checkout.
+3. Those abilities are DMC workspace and GitHub abilities, which shell out to
+   `git` / call the GitHub API on the workspace checkout.
 4. Host-side, `wp-codebox`'s `WP_Codebox_Runner_Workspace_Adapter` already
    delegates runner-workspace *operations* to host abilities through the
    `wp_codebox_runner_workspace_backend` filter — but that is host orchestration
@@ -40,9 +36,8 @@ is the clean injection point.
 
 ### Agents API executor contract (reused)
 
-`agents-api/src/Tools/class-wp-agent-tool-executor.php` defines
-`WP_Agent_Tool_Executor::executeWP_Agent_Tool_Call($tool_call, $tool_definition,
-$context)`. We implement it with `WP_Codebox_Runner_Workspace_Executor`
+The agent tool executor contract defines
+`executeWP_Agent_Tool_Call($tool_call, $tool_definition, $context)`. We implement it with `WP_Codebox_Runner_Workspace_Executor`
 (target id `wp-codebox/runner-workspace`), which maps tool names to a native
 engine bound to the resolved workspace root. Root resolution mirrors how the
 adapter already reads `client_context` (`default_workspace.target` /

--- a/packages/cli/src/recipe-dry-run.ts
+++ b/packages/cli/src/recipe-dry-run.ts
@@ -5,7 +5,7 @@ import { serializeError } from "./output.js"
 import { RecipeArtifactsMountConflictError, recipeArtifactsMountConflict } from "./commands/recipe-run-artifacts-mount-guard.js"
 import { resolveRecipeSecretEnv, type RecipeSecretEnvSummaryEntry } from "./recipe-secret-env.js"
 import { recipeExternalServiceBoundarySummaries, type RecipeExternalServiceBoundarySummary } from "./recipe-external-services.js"
-import { composerPackageVendorPath, defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
+import { composerPackageVendorPath, defaultWorkspaceTarget, installMuPluginsCode, pluginTarget, recipeBlueprintWithBootActivePlugins, recipeExtraPluginFile, recipeExtraPluginSlug, recipeExtraPluginSource, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeMountType, recipeSource, recipeSourceProvenance, resolveRecipeExtraPluginFile, stagedFileMountType, stagedFileProvenance, type RecipeSourceProvenance, type RecipeSourceType, type RecipeStagedFileProvenance } from "./recipe-sources.js"
 import { hasExplicitSiteSeedSelectors, loadWorkspaceRecipe, pluginRuntimeHealthProbeStep, recipePolicy, recipeWorkflowSteps, validateWorkspaceRecipe, type RecipeValidationIssue, type RecipeWorkflowPhase } from "./recipe-validation.js"
 import { runtimeOverlayTarget } from "./runtime-overlay-registry.js"
 
@@ -583,9 +583,10 @@ async function recipeDryRunSteps(recipe: WorkspaceRecipe, recipeDirectory: strin
   const steps: Array<Promise<RecipeDryRunStep>> = []
   const dryRunExtraPlugins = await Promise.all(recipeExtraPlugins(recipe).map(async (plugin) => {
     const slug = recipeExtraPluginSlug(plugin)
+    const sourceRef = recipeExtraPluginSource(plugin)
     const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
     return {
-      source: plugin.source,
+      source: sourceRef,
       slug,
       target: pluginTarget(slug, plugin.loadAs ?? "plugin"),
       pluginFile: await resolveRecipeExtraPluginFile(plugin, recipeDirectory),
@@ -676,13 +677,14 @@ function recipeDryRunWorkspaces(recipe: WorkspaceRecipe, recipeDirectory: string
 function recipeDryRunExtraPlugins(recipe: WorkspaceRecipe, recipeDirectory: string): RecipeDryRunExtraPlugin[] {
   return recipeExtraPlugins(recipe).map((plugin) => {
     const slug = recipeExtraPluginSlug(plugin)
+    const sourceRef = recipeExtraPluginSource(plugin)
     const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
     const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
     const source = recipeSource(sourceRoot, plugin.sha256)
     const provenance = recipeSourceProvenance(source, recipeDirectory)
     return {
       source: source.type === "local" ? resolve(recipeDirectory, sourceRoot, sourceSubpath) : source.resolvedUrl,
-      sourceRef: plugin.source,
+      sourceRef,
       sourceRoot,
       sourceSubpath,
       sourceType: source.type,

--- a/packages/cli/src/recipe-sources.ts
+++ b/packages/cli/src/recipe-sources.ts
@@ -270,14 +270,15 @@ export async function prepareRecipeExtraPlugins(recipe: WorkspaceRecipe, recipeD
   const plugins: PreparedExtraPlugin[] = []
   for (const plugin of recipeExtraPlugins(recipe)) {
     const slug = recipeExtraPluginSlug(plugin)
+    const sourceRef = recipeExtraPluginSource(plugin)
     const sourceRootRef = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
     const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
     const resolved = await prepareRecipeSource(sourceRootRef, recipeDirectory, slug, plugin.sha256)
     const pluginResolved = sourceSubpath ? { ...resolved, source: join(resolved.source, sourceSubpath) } : resolved
     const pluginFile = await resolveRecipeExtraPluginFile(plugin, recipeDirectory)
     const loadAs = plugin.loadAs ?? "plugin"
-    const prepared = await prepareComposerAutoloadForPlugin(pluginResolved, slug, plugin.source, resolved.source)
-    await assertPreparedPluginFileExists(prepared.source, pluginFile.slice(slug.length + 1), plugin.source)
+    const prepared = await prepareComposerAutoloadForPlugin(pluginResolved, slug, sourceRef, resolved.source)
+    await assertPreparedPluginFileExists(prepared.source, pluginFile.slice(slug.length + 1), sourceRef)
     plugins.push({
       source: prepared.source,
       slug,
@@ -1338,41 +1339,62 @@ export function recipeSourceProvenance(source: ParsedRecipeSource, recipeDirecto
 }
 
 export function recipeExtraPluginSlug(plugin: WorkspaceRecipeExtraPlugin): string {
+  if (plugin.mountSlug) {
+    return plugin.mountSlug
+  }
+
   if (plugin.slug) {
     return plugin.slug
   }
 
-  const source = recipeSource(plugin.source, plugin.sha256)
+  const sourceRef = recipeExtraPluginSource(plugin)
+  const source = recipeSource(sourceRef, plugin.sha256)
   if (source.wporgSlug) {
     return source.wporgSlug
   }
 
   if (source.type !== "local") {
-    throw new Error(`External extra_plugins sources require slug when it cannot be inferred from a WordPress.org plugin URL: ${plugin.source}`)
+    throw new Error(`External extra_plugins sources require mountSlug or slug when it cannot be inferred from a WordPress.org plugin URL: ${sourceRef}`)
   }
 
-  return basename(resolve(plugin.source))
+  return basename(resolve(sourceRef))
+}
+
+export function recipeExtraPluginSource(plugin: WorkspaceRecipeExtraPlugin): string {
+  if (plugin.source !== undefined) {
+    return plugin.source
+  }
+  if (plugin.sourcePath !== undefined) {
+    return plugin.sourcePath
+  }
+  throw new Error("Recipe extra_plugins entries must include source or sourcePath")
 }
 
 export function recipeExtraPluginSourceRoot(plugin: WorkspaceRecipeExtraPlugin, recipeDirectory = "."): string {
+  if (plugin.sourcePath) {
+    return plugin.sourcePath
+  }
+
   if (plugin.sourceRoot && recipeExtraPluginSourceRootContainsSource(plugin, plugin.sourceRoot, recipeDirectory)) {
     return plugin.sourceRoot
   }
 
-  return plugin.originalSource ?? plugin.source
+  return plugin.originalSource ?? recipeExtraPluginSource(plugin)
 }
 
 export function recipeExtraPluginSourceSubpath(plugin: WorkspaceRecipeExtraPlugin, recipeDirectory: string): string {
-  if (plugin.sourceSubpath && plugin.sourceRoot && recipeExtraPluginSourceRootContainsSource(plugin, plugin.sourceRoot, recipeDirectory)) {
-    return normalizeReviewerSafePath(plugin.sourceSubpath)
+  const explicitSubpath = plugin.sourceSubdir ?? plugin.sourceSubpath
+  if (explicitSubpath) {
+    return normalizeRecipeExtraPluginSourceSubpath(explicitSubpath)
   }
 
   const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
-  if (sourceRoot === plugin.source) {
+  const sourceRef = recipeExtraPluginSource(plugin)
+  if (sourceRoot === sourceRef) {
     return ""
   }
 
-  const relativePath = relative(resolve(recipeDirectory, sourceRoot), resolve(recipeDirectory, plugin.source))
+  const relativePath = relative(resolve(recipeDirectory, sourceRoot), resolve(recipeDirectory, sourceRef))
   if (!relativePath || relativePath.startsWith("..") || isAbsolute(relativePath)) {
     return ""
   }
@@ -1381,8 +1403,16 @@ export function recipeExtraPluginSourceSubpath(plugin: WorkspaceRecipeExtraPlugi
 }
 
 function recipeExtraPluginSourceRootContainsSource(plugin: WorkspaceRecipeExtraPlugin, sourceRoot: string, recipeDirectory: string): boolean {
-  const relativePath = relative(resolve(recipeDirectory, sourceRoot), resolve(recipeDirectory, plugin.source))
+  const relativePath = relative(resolve(recipeDirectory, sourceRoot), resolve(recipeDirectory, recipeExtraPluginSource(plugin)))
   return !relativePath.startsWith("..") && !isAbsolute(relativePath)
+}
+
+export function normalizeRecipeExtraPluginSourceSubpath(value: string): string {
+  const normalized = normalizeReviewerSafePath(value)
+  if (!normalized || normalized === "." || normalized.startsWith("../") || normalized.includes("/../") || isAbsolute(normalized)) {
+    throw new Error(`Recipe extra_plugins sourceSubdir/sourceSubpath must be a safe relative directory: ${value}`)
+  }
+  return normalized
 }
 
 export function recipeExtraPluginFile(plugin: WorkspaceRecipeExtraPlugin): string {
@@ -1416,11 +1446,12 @@ export async function resolveRecipeExtraPluginFile(plugin: WorkspaceRecipeExtraP
     return plugin.pluginFile
   }
 
-  const source = recipeSource(plugin.source, plugin.sha256)
+  const sourceRef = recipeExtraPluginSource(plugin)
+  const source = recipeSource(sourceRef, plugin.sha256)
   if (source.type === "local") {
     const sourceRoot = resolve(recipeDirectory, recipeExtraPluginSourceRoot(plugin, recipeDirectory))
     const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
-    const pluginSource = sourceSubpath ? join(sourceRoot, sourceSubpath) : resolve(recipeDirectory, plugin.source)
+    const pluginSource = sourceSubpath ? join(sourceRoot, sourceSubpath) : resolve(recipeDirectory, sourceRef)
     return resolvePluginEntrypointContract({ source: pluginSource, slug, loadAs: plugin.loadAs }).pluginFile
   }
 

--- a/packages/cli/src/recipe-validation.ts
+++ b/packages/cli/src/recipe-validation.ts
@@ -2,7 +2,7 @@ import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { assertFixtureImportDeterministicIdsSupported, assertWorkspaceRecipeJsonSchema, commandArgValue, normalizeRuntimeBackendKind, normalizeRuntimeMountTarget, parseCommandJson, safeArtifactRelativePath, validateBrowserInteractionScript, validateSourcePackage, workspaceRecipeRuntimeCollectedArtifacts, type MountSpec, type RuntimeAssetSpec, type RuntimePolicy, type RuntimePreviewSpec, type WorkspaceRecipe, type WorkspaceRecipeDeclaredArtifact, type WorkspaceRecipeDependencyOverlay, type WorkspaceRecipeDistribution, type WorkspaceRecipeDistributionStartupProbe, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntime, type WorkspaceRecipePluginRuntimeHealthProbe, type WorkspaceRecipeProbe, type WorkspaceRecipeRuntimeBackendPackage, type WorkspaceRecipeRuntimeOverlay, type WorkspaceRecipeSiteSeed } from "@automattic/wp-codebox-core"
 import { commandValidationDescriptorFor, effectivePolicyCommandsFor, type CommandArgValidationDescriptor } from "@automattic/wp-codebox-core/contracts"
-import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
+import { composerPackageVendorPath, evaluateRecipeSourcePolicy, isComposerPackageName, pluginTarget, recipeExtraPluginSlug, recipeExtraPluginSource, recipeExtraPluginSourceRoot, recipeExtraPluginSourceSubpath, recipeExtraPlugins, recipeSource, resolveRecipeExtraPluginFile } from "./recipe-sources.js"
 import { loadConfiguredRuntimeOverlayDescriptors, registeredRuntimeOverlayDescriptors, runtimeOverlayDescriptor, runtimeOverlayTarget } from "./runtime-overlay-registry.js"
 import { cliRuntimeBackendRecipePolicy, listCliRecipeCommandIds, listCliRuntimeBackendKinds } from "./runtime-backends.js"
 
@@ -178,12 +178,16 @@ export function validateWorkspaceRecipeShape(recipe: WorkspaceRecipe, recipePath
   }
 
   for (const plugin of recipeExtraPlugins(recipe)) {
-    if (!plugin.source) {
-      throw new Error(`Recipe extra_plugins entries must include source: ${recipePath}`)
+    if (!plugin.source && !plugin.sourcePath) {
+      throw new Error(`Recipe extra_plugins entries must include source or sourcePath: ${recipePath}`)
     }
 
     if (plugin.slug && !/^[a-z0-9][a-z0-9-_]*$/i.test(plugin.slug)) {
       throw new Error(`Recipe extra_plugins slug must be a plugin-directory slug: ${recipePath}`)
+    }
+
+    if (plugin.mountSlug && !/^[a-z0-9][a-z0-9-_]*$/i.test(plugin.mountSlug)) {
+      throw new Error(`Recipe extra_plugins mountSlug must be a plugin-directory slug: ${recipePath}`)
     }
 
     if (plugin.loadAs && plugin.loadAs !== "plugin" && plugin.loadAs !== "mu-plugin") {
@@ -523,17 +527,31 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
 
   for (const [index, plugin] of recipeExtraPlugins(recipe).entries()) {
     const path = `$.inputs.extra_plugins[${index}]`
+    let sourceRef: string
+    try {
+      sourceRef = recipeExtraPluginSource(plugin)
+    } catch (error) {
+      addIssue("missing-source", `${path}.source`, error instanceof Error ? error.message : String(error))
+      continue
+    }
     let source: ReturnType<typeof recipeSource>
     try {
-      source = recipeSource(plugin.source, plugin.sha256)
+      source = recipeSource(sourceRef, plugin.sha256)
     } catch (error) {
       addIssue("invalid-source", `${path}.source`, error instanceof Error ? error.message : String(error))
       continue
     }
     const sourceRoot = recipeExtraPluginSourceRoot(plugin, recipeDirectory)
-    const sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
-    const pluginSource = source.type === "local" ? resolve(recipeDirectory, plugin.source) : undefined
-    const pluginMountedSource = source.type === "local" ? resolve(recipeDirectory, sourceRoot, sourceSubpath) : undefined
+    let sourceSubpath = ""
+    try {
+      sourceSubpath = recipeExtraPluginSourceSubpath(plugin, recipeDirectory)
+    } catch (error) {
+      addIssue("invalid-source-subdir", `${path}.${plugin.sourceSubdir !== undefined ? "sourceSubdir" : "sourceSubpath"}`, error instanceof Error ? error.message : String(error))
+      continue
+    }
+    const pluginSource = source.type === "local" ? resolve(recipeDirectory, sourceRef) : undefined
+    const sourceRootPath = resolve(recipeDirectory, sourceRoot)
+    const pluginMountedSource = source.type === "local" ? resolve(sourceRootPath, sourceSubpath) : undefined
     let slug: string
     try {
       slug = recipeExtraPluginSlug(plugin)
@@ -547,11 +565,18 @@ export async function validateWorkspaceRecipeSemantics(recipe: WorkspaceRecipe, 
     if (pluginSource) {
       await validateExistingDirectory(pluginSource, `${path}.source`, addIssue)
     }
-    if (sourceRoot !== plugin.source) {
+    if (sourceRoot !== sourceRef) {
       await validateExistingDirectory(resolve(recipeDirectory, sourceRoot), `${path}.sourceRoot`, addIssue)
     }
+    if (pluginMountedSource && !pluginMountedSource.startsWith(`${sourceRootPath}/`) && pluginMountedSource !== sourceRootPath) {
+      addIssue("invalid-source-subdir", `${path}.${plugin.sourceSubdir !== undefined ? "sourceSubdir" : "sourceSubpath"}`, "Plugin source subdirectory must stay inside the source root.")
+      continue
+    }
+    if (sourceSubpath && pluginMountedSource) {
+      await validateExistingDirectory(pluginMountedSource, `${path}.${plugin.sourceSubdir !== undefined ? "sourceSubdir" : "sourceSubpath"}`, addIssue)
+    }
 
-    if (!pluginFile.startsWith(`${slug}/`)) {
+    if (!/^[^/][^:]*\.php$/.test(pluginFile) || pluginFile.includes("..") || !pluginFile.startsWith(`${slug}/`)) {
       addIssue("invalid-plugin-file", `${path}.pluginFile`, `Plugin file must be relative to the mounted plugin slug (${slug}/...).`)
       continue
     }

--- a/packages/runtime-core/src/recipe-schema.ts
+++ b/packages/runtime-core/src/recipe-schema.ts
@@ -752,16 +752,22 @@ export function createWorkspaceRecipeJsonSchema(options: WorkspaceRecipeJsonSche
       extraPlugin: {
         type: "object",
         additionalProperties: false,
-        required: ["source"],
+        anyOf: [{ required: ["source"] }, { required: ["sourcePath"] }],
         properties: {
           source: {
             type: "string",
             description: "Local plugin directory path, WordPress.org plugin zip URL, or generic HTTPS zip URL.",
           },
+          sourcePath: {
+            type: "string",
+            description: "Local source root path. Use sourceSubdir when the plugin lives below this root in a monorepo.",
+          },
           sourceRoot: { type: "string" },
           sourceSubpath: { type: "string" },
+          sourceSubdir: { type: "string" },
           originalSource: { type: "string" },
           slug: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+          mountSlug: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
           pluginFile: { type: "string" },
           activate: { type: "boolean" },
           loadAs: { enum: ["plugin", "mu-plugin"] },

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -395,11 +395,14 @@ export interface WorkspaceRecipeAgentBundle {
 }
 
 export interface WorkspaceRecipeExtraPlugin {
-  source: string
+  source?: string
+  sourcePath?: string
   sourceRoot?: string
   sourceSubpath?: string
+  sourceSubdir?: string
   originalSource?: string
   slug?: string
+  mountSlug?: string
   pluginFile?: string
   activate?: boolean
   sha256?: string

--- a/tests/recipe-extra-plugin-nested-source.test.ts
+++ b/tests/recipe-extra-plugin-nested-source.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict"
+import { mkdir, stat, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { validateWorkspaceRecipeSemantics } from "../packages/cli/src/recipe-validation.js"
+import { prepareRecipeExtraPlugins } from "../packages/cli/src/recipe-sources.js"
+import { assertWorkspaceRecipeJsonSchema, type WorkspaceRecipe } from "../packages/runtime-core/src/index.js"
+import { withTempDir } from "../scripts/test-kit.js"
+
+await withTempDir("wp-codebox-nested-extra-plugin-", async (recipeDirectory) => {
+  const repo = join(recipeDirectory, "repo")
+  await mkdir(join(repo, "packages", "example-plugin", "includes"), { recursive: true })
+  await writeFile(join(repo, "packages", "example-plugin", "example-plugin.php"), "<?php\n/* Plugin Name: Example Plugin */\n")
+  await writeFile(join(repo, "packages", "example-plugin", "includes", "class-example.php"), "<?php\n")
+
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: {
+      extra_plugins: [{
+        sourcePath: "repo",
+        sourceSubdir: "packages/example-plugin",
+        mountSlug: "example-plugin",
+        pluginFile: "example-plugin/example-plugin.php",
+      }],
+    },
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  }
+
+  assertWorkspaceRecipeJsonSchema(recipe)
+  assert.deepEqual(await validateWorkspaceRecipeSemantics(recipe, join(recipeDirectory, "recipe.json")), [])
+
+  const [plugin] = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
+  assert.ok(plugin)
+  assert.equal(plugin.slug, "example-plugin")
+  assert.equal(plugin.target, "/wordpress/wp-content/plugins/example-plugin")
+  assert.equal(plugin.pluginFile, "example-plugin/example-plugin.php")
+  assert.equal(plugin.metadata?.sourceRoot, "repo")
+  assert.equal(plugin.metadata?.sourceSubpath, "packages/example-plugin")
+  assert.equal((await stat(join(plugin.source, "example-plugin.php"))).isFile(), true)
+})
+
+await withTempDir("wp-codebox-nested-extra-plugin-invalid-", async (recipeDirectory) => {
+  const repo = join(recipeDirectory, "repo")
+  await mkdir(join(repo, "plugins", "nested-plugin"), { recursive: true })
+  await writeFile(join(repo, "plugins", "nested-plugin", "nested-plugin.php"), "<?php\n/* Plugin Name: Nested Plugin */\n")
+
+  const baseRecipe = (extraPlugin: WorkspaceRecipe["inputs"] extends infer Inputs ? Inputs extends { extra_plugins?: Array<infer Plugin> } ? Plugin : never : never): WorkspaceRecipe => ({
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: { extra_plugins: [extraPlugin] },
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  })
+
+  const cases: Array<{ name: string, plugin: NonNullable<WorkspaceRecipe["inputs"]>["extra_plugins"][number], issue: string }> = [
+    {
+      name: "path traversal sourceSubdir",
+      plugin: { sourcePath: "repo", sourceSubdir: "../outside", mountSlug: "nested-plugin", pluginFile: "nested-plugin/nested-plugin.php" },
+      issue: "invalid-source-subdir",
+    },
+    {
+      name: "missing sourceSubdir",
+      plugin: { sourcePath: "repo", sourceSubdir: "plugins/missing-plugin", mountSlug: "nested-plugin", pluginFile: "nested-plugin/nested-plugin.php" },
+      issue: "missing-path",
+    },
+    {
+      name: "pluginFile outside mount slug",
+      plugin: { sourcePath: "repo", sourceSubdir: "plugins/nested-plugin", mountSlug: "nested-plugin", pluginFile: "other-plugin/nested-plugin.php" },
+      issue: "invalid-plugin-file",
+    },
+  ]
+
+  for (const testCase of cases) {
+    const issues = await validateWorkspaceRecipeSemantics(baseRecipe(testCase.plugin), join(recipeDirectory, `${testCase.name}.json`))
+    assert.ok(issues.some((issue) => issue.code === testCase.issue), `${testCase.name} reports ${testCase.issue}`)
+  }
+})
+
+console.log("recipe extra plugin nested source ok")


### PR DESCRIPTION
## Summary
- Add explicit nested/monorepo extra plugin recipe fields: sourcePath, sourceSubdir, and mountSlug.
- Preserve existing source/slug/sourceRoot/sourceSubpath behavior while validating pluginFile against the mounted plugin slug.
- Validate source subdirectory traversal, missing nested source directories, and plugin file mount-slug mismatches.
- Document the public nested plugin contract and clean up public docs boundary wording caught by the docs-boundary test.

## Downstream contract shape
```json
{
  "sourcePath": "/repo",
  "sourceSubdir": "plugins/example-plugin",
  "mountSlug": "example-plugin",
  "pluginFile": "example-plugin/example-plugin.php"
}
```

`sourcePath` can also point directly at the plugin source directory; keep `mountSlug` and `pluginFile` explicit when the source directory name is not the WordPress mount slug.

## Tests
- `npm exec tsx tests/recipe-extra-plugin-nested-source.test.ts`
- `npm run test:recipe-validation-descriptors`
- `npm run test:recipe-runtime-setup-staged-materialization`
- `npm run test:recipe-source-packages`
- `npm run test:docs-boundary-language`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the recipe contract change, tests, docs updates, and local verification.