### PR TITLE
Preserve nested plugin source metadata

### DIFF
--- a/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
@@ -217,7 +217,7 @@ final class WP_Codebox_Host_Recipe_Builder {
 		$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
 		$components = array();
 		foreach ( is_array( $runtime['components'] ?? null ) ? $runtime['components'] : array() as $component ) {
-			if ( is_array( $component ) && '' !== trim( (string) ( $component['source'] ?? $component['path'] ?? '' ) ) ) {
+			if ( is_array( $component ) && '' !== trim( (string) ( $component['source'] ?? $component['sourcePath'] ?? $component['source_path'] ?? $component['path'] ?? '' ) ) ) {
 				$components[] = self::normalize_provider_plugin( $component );
 			}
 		}
@@ -230,7 +230,7 @@ final class WP_Codebox_Host_Recipe_Builder {
 		$runtime = is_array( $input['runtime'] ?? null ) ? $input['runtime'] : array();
 		$plugins = array();
 		foreach ( is_array( $runtime['plugins'] ?? null ) ? $runtime['plugins'] : array() as $plugin ) {
-			if ( is_array( $plugin ) && '' !== trim( (string) ( $plugin['source'] ?? $plugin['path'] ?? '' ) ) ) {
+			if ( is_array( $plugin ) && '' !== trim( (string) ( $plugin['source'] ?? $plugin['sourcePath'] ?? $plugin['source_path'] ?? $plugin['path'] ?? '' ) ) ) {
 				$plugins[] = self::normalize_provider_plugin( $plugin );
 			}
 		}
@@ -241,14 +241,20 @@ final class WP_Codebox_Host_Recipe_Builder {
 	/** @param array<string,mixed> $plugin Provider plugin input. @return array<string,mixed> */
 	private static function normalize_provider_plugin( array $plugin ): array {
 		$source = trim( (string) ( $plugin['source'] ?? $plugin['path'] ?? '' ) );
+		$source_path = trim( (string) ( $plugin['sourcePath'] ?? $plugin['source_path'] ?? '' ) );
 		return array_filter(
 			array(
-				'source'     => $source,
-				'slug'       => trim( (string) ( $plugin['slug'] ?? basename( $source ) ) ),
-				'pluginFile' => trim( (string) ( $plugin['pluginFile'] ?? $plugin['plugin_file'] ?? '' ) ),
-				'activate'   => array_key_exists( 'activate', $plugin ) ? (bool) $plugin['activate'] : true,
-				'loadAs'     => trim( (string) ( $plugin['loadAs'] ?? $plugin['load_as'] ?? '' ) ),
-				'metadata'   => is_array( $plugin['metadata'] ?? null ) ? $plugin['metadata'] : array(),
+				'source'        => $source,
+				'sourcePath'    => $source_path,
+				'sourceRoot'    => trim( (string) ( $plugin['sourceRoot'] ?? $plugin['source_root'] ?? '' ) ),
+				'sourceSubdir'  => trim( (string) ( $plugin['sourceSubdir'] ?? $plugin['source_subdir'] ?? '' ) ),
+				'sourceSubpath' => trim( (string) ( $plugin['sourceSubpath'] ?? $plugin['source_subpath'] ?? '' ) ),
+				'slug'          => trim( (string) ( $plugin['slug'] ?? basename( '' !== $source ? $source : $source_path ) ) ),
+				'mountSlug'     => trim( (string) ( $plugin['mountSlug'] ?? $plugin['mount_slug'] ?? '' ) ),
+				'pluginFile'    => trim( (string) ( $plugin['pluginFile'] ?? $plugin['plugin_file'] ?? '' ) ),
+				'activate'      => array_key_exists( 'activate', $plugin ) ? (bool) $plugin['activate'] : true,
+				'loadAs'        => trim( (string) ( $plugin['loadAs'] ?? $plugin['load_as'] ?? '' ) ),
+				'metadata'      => is_array( $plugin['metadata'] ?? null ) ? $plugin['metadata'] : array(),
 			),
 			static fn( mixed $value ): bool => '' !== $value && array() !== $value
 		);

--- a/packages/wordpress-plugin/src/class-wp-codebox-host-runtime-config-builder.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-host-runtime-config-builder.php
@@ -160,7 +160,11 @@ final class WP_Codebox_Host_Runtime_Config_Builder {
 	public function component_plugins( array $paths ): array {
 		$plugins = array();
 		foreach ( $paths as $index => $contract ) {
-			$path = (string) ( $contract['path'] ?? '' );
+			$path = trim( (string) ( $contract['path'] ?? $contract['source'] ?? '' ) );
+			$source_path = trim( (string) ( $contract['sourcePath'] ?? $contract['source_path'] ?? '' ) );
+			if ( '' === $path ) {
+				$path = $source_path;
+			}
 			if ( '' === $path ) {
 				continue;
 			}
@@ -169,26 +173,37 @@ final class WP_Codebox_Host_Runtime_Config_Builder {
 			$load_as  = (string) ( $contract['loadAs'] ?? 'mu-plugin' );
 			$activate = (bool) ( $contract['activate'] ?? false );
 
-			$plugins[] = array(
-				'source'   => $path,
-				'slug'     => $slug,
-				'activate' => $activate,
-				'loadAs'   => $load_as,
-				'metadata' => array(
-					'componentContract' => array_filter(
-						array(
-							'index'         => $index,
-							'slug'          => $slug,
-							'requestedPath' => $path,
-							'originalPath'  => isset( $contract['original_path'] ) ? (string) $contract['original_path'] : ( isset( $contract['originalPath'] ) ? (string) $contract['originalPath'] : '' ),
-							'preparedPath'  => $path,
-							'loadAs'        => $load_as,
-							'activate'      => $activate,
-						),
-						static fn( mixed $value ): bool => '' !== $value
+			$plugin = array_filter(
+				array(
+					'source'        => '' === $source_path ? $path : '',
+					'sourcePath'    => $source_path,
+					'sourceRoot'    => trim( (string) ( $contract['sourceRoot'] ?? $contract['source_root'] ?? '' ) ),
+					'sourceSubdir'  => trim( (string) ( $contract['sourceSubdir'] ?? $contract['source_subdir'] ?? '' ) ),
+					'sourceSubpath' => trim( (string) ( $contract['sourceSubpath'] ?? $contract['source_subpath'] ?? '' ) ),
+					'slug'          => $slug,
+					'mountSlug'     => trim( (string) ( $contract['mountSlug'] ?? $contract['mount_slug'] ?? '' ) ),
+					'pluginFile'    => trim( (string) ( $contract['pluginFile'] ?? $contract['plugin_file'] ?? '' ) ),
+					'activate'      => $activate,
+					'loadAs'        => $load_as,
+				),
+				static fn( mixed $value ): bool => '' !== $value
+			);
+
+			$plugin['metadata'] = array(
+				'componentContract' => array_filter(
+					array(
+						'index'         => $index,
+						'slug'          => $slug,
+						'requestedPath' => $path,
+						'originalPath'  => isset( $contract['original_path'] ) ? (string) $contract['original_path'] : ( isset( $contract['originalPath'] ) ? (string) $contract['originalPath'] : '' ),
+						'preparedPath'  => $path,
+						'loadAs'        => $load_as,
+						'activate'      => $activate,
 					),
+					static fn( mixed $value ): bool => '' !== $value
 				),
 			);
+			$plugins[] = $plugin;
 		}
 
 		return $plugins;

--- a/tests/host-recipe-builder.test.ts
+++ b/tests/host-recipe-builder.test.ts
@@ -14,6 +14,7 @@ const result = await runPhpJson<{
     inputs: { secretEnv: string[]; runtimeEnv: Record<string, string>; extra_plugins: Array<{ slug: string }> }
     workflow: { steps: Array<{ args: string[] }> }
   }
+  nested_component_plugins: unknown[]
 }>(`
 define('ABSPATH', ${phpStringLiteral(repoRoot)});
 class WP_Error {
@@ -39,6 +40,7 @@ function apply_filters( $hook, $value, ...$args ) {
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-dependency-plan.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-runtime-profile-resolver.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-browser-task-builder.php`)};
+require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-host-runtime-config-builder.php`)};
 require ${phpStringLiteral(`${repoRoot}/packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php`)};
 
 $legacy_adapter_calls = array();
@@ -126,8 +128,17 @@ $recipe = json_decode( file_get_contents( $result['path'] ), true );
 unlink( $result['path'] );
 $preset_recipe = json_decode( file_get_contents( $preset_result['path'] ), true );
 unlink( $preset_result['path'] );
+$runtime_config_builder = new WP_Codebox_Host_Runtime_Config_Builder();
+$nested_component_plugins = $runtime_config_builder->component_plugins( array( array(
+	'sourcePath' => '/workspace/repo',
+	'sourceSubdir' => 'plugins/example',
+	'mountSlug' => 'example',
+	'pluginFile' => 'example/example.php',
+	'loadAs' => 'plugin',
+	'activate' => true,
+) ) );
 
-echo json_encode( array( 'legacy_adapter_calls' => $legacy_adapter_calls, 'recipe' => $recipe, 'preset_result' => $preset_result, 'preset_recipe' => $preset_recipe ), JSON_UNESCAPED_SLASHES );
+echo json_encode( array( 'legacy_adapter_calls' => $legacy_adapter_calls, 'recipe' => $recipe, 'preset_result' => $preset_result, 'preset_recipe' => $preset_recipe, 'nested_component_plugins' => $nested_component_plugins ), JSON_UNESCAPED_SLASHES );
 `)
 
 assert.deepEqual(result.legacy_adapter_calls, [])
@@ -140,6 +151,16 @@ assert.deepEqual(result.recipe.inputs.extra_plugins, [
   { source: "/components/demo-plugin", slug: "demo-plugin", activate: true, loadAs: "plugin" },
   { source: "/plugins/planned-provider", slug: "planned-provider", activate: false },
 ])
+assert.deepEqual(result.nested_component_plugins[0], {
+  sourcePath: "/workspace/repo",
+  sourceSubdir: "plugins/example",
+  slug: "repo",
+  mountSlug: "example",
+  pluginFile: "example/example.php",
+  activate: true,
+  loadAs: "plugin",
+  metadata: { componentContract: { index: 0, slug: "repo", requestedPath: "/workspace/repo", preparedPath: "/workspace/repo", loadAs: "plugin", activate: true } },
+})
 assert.equal(result.recipe.workflow.steps[0].command, "wp-codebox.agent-sandbox-run")
 assert.ok(result.recipe.workflow.steps[0].args.includes("agent=planned-agent"))
 assert.ok(result.recipe.workflow.steps[0].args.includes("mode=planned-mode"))

--- a/tests/recipe-extra-plugin-nested-source.test.ts
+++ b/tests/recipe-extra-plugin-nested-source.test.ts
@@ -39,6 +39,37 @@ await withTempDir("wp-codebox-nested-extra-plugin-", async (recipeDirectory) => 
   assert.equal((await stat(join(plugin.source, "example-plugin.php"))).isFile(), true)
 })
 
+await withTempDir("wp-codebox-nested-extra-plugin-source-path-", async (recipeDirectory) => {
+  const sourceRoot = join(recipeDirectory, "source-root")
+  await mkdir(join(sourceRoot, "plugins", "example", "includes"), { recursive: true })
+  await writeFile(join(sourceRoot, "plugins", "example", "example.php"), "<?php\n/* Plugin Name: Example */\n")
+
+  const recipe: WorkspaceRecipe = {
+    schema: "wp-codebox/workspace-recipe/v1",
+    inputs: {
+      extra_plugins: [{
+        sourcePath: "source-root",
+        sourceSubdir: "plugins/example",
+        mountSlug: "example",
+        pluginFile: "example/example.php",
+      }],
+    },
+    workflow: { steps: [{ command: "inspect-mounted-inputs" }] },
+  }
+
+  assertWorkspaceRecipeJsonSchema(recipe)
+  assert.deepEqual(await validateWorkspaceRecipeSemantics(recipe, join(recipeDirectory, "recipe.json")), [])
+
+  const [plugin] = await prepareRecipeExtraPlugins(recipe, recipeDirectory)
+  assert.ok(plugin)
+  assert.equal(plugin.slug, "example")
+  assert.equal(plugin.target, "/wordpress/wp-content/plugins/example")
+  assert.equal(plugin.pluginFile, "example/example.php")
+  assert.equal(plugin.metadata?.sourceRoot, "source-root")
+  assert.equal(plugin.metadata?.sourceSubpath, "plugins/example")
+  assert.equal((await stat(join(plugin.source, "example.php"))).isFile(), true)
+})
+
 await withTempDir("wp-codebox-nested-extra-plugin-invalid-", async (recipeDirectory) => {
   const repo = join(recipeDirectory, "repo")
   await mkdir(join(repo, "plugins", "nested-plugin"), { recursive: true })


### PR DESCRIPTION
## Summary
- Preserve nested plugin source fields when host recipe builder normalizes runtime plugins/components.
- Preserve nested source fields when host runtime component contracts are materialized into recipe extra_plugins.
- Extend nested extra plugin coverage with sourcePath + sourceSubdir + mountSlug + pluginFile shape.

## Testing
- npx tsx tests/recipe-extra-plugin-nested-source.test.ts
- npm run test:host-recipe-builder
- npm run build
- php -l packages/wordpress-plugin/src/class-wp-codebox-host-recipe-builder.php
- php -l packages/wordpress-plugin/src/class-wp-codebox-host-runtime-config-builder.php
- npm run check fails in existing unrelated browser callback materialization assertion: tests/browser-callback-materialization-contracts.test.ts expects artifact-bundle path/digest but actual omits them.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing nested plugin source materialization, implementing the fix, and adding tests.