### PR TITLE
feat(cli): add --version flag and version command

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "test:reviewer-access": "tsx tests/reviewer-access.test.ts",
     "test:command-router": "tsx tests/command-router.test.ts",
     "test:command-agent-run": "tsx tests/command-agent-run.test.ts",
+    "smoke:cli-version": "tsx scripts/cli-version-smoke.ts",
     "test:host-command-executor": "tsx tests/host-command-executor.test.ts",
     "test:php-host-run-result-normalizer": "php scripts/php-host-run-result-normalizer-smoke.php",
     "test:php-agent-outcome-classifier": "php scripts/php-agent-outcome-classifier-smoke.php",

--- a/packages/cli/src/command-router.ts
+++ b/packages/cli/src/command-router.ts
@@ -1,5 +1,20 @@
 import { spawn } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
 import { wantsJsonOutput, writeJsonFailure } from "./output.js"
+
+const packageRequire = createRequire(import.meta.url)
+
+function readCliVersion(): string {
+  try {
+    const manifest = JSON.parse(readFileSync(packageRequire.resolve("../package.json"), "utf8")) as { version?: unknown }
+    return typeof manifest.version === "string" ? manifest.version : "0.0.0-unknown"
+  } catch {
+    return "0.0.0-unknown"
+  }
+}
+
+const CLI_VERSION = readCliVersion()
 
 type CliCommandHandler = (args: string[]) => Promise<number>
 
@@ -99,6 +114,11 @@ export async function routeCliCommand(argv: string[], router: CliCommandRouter):
   if (!command || command === "help" || command === "--help" || command === "-h") {
     router.printHelp()
     return command ? 0 : 1
+  }
+
+  if (command === "--version" || command === "-v" || command === "version") {
+    console.log(CLI_VERSION)
+    return 0
   }
 
   const route = routeForCommand(command)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -299,6 +299,7 @@ export function printHelp(): void {
   const recipeCommandIds = listCliRecipeCommandDefinitions().map((command) => command.id)
 
   console.log(`Usage:
+  wp-codebox version
   wp-codebox commands [--json]
   wp-codebox runtime descriptor [--json]
   wp-codebox schema recipe [--json]
@@ -450,6 +451,10 @@ Discovery:
   commands             Print supported runtime and recipe command metadata.
   runtime descriptor   Print public runtime readiness, capabilities, ability names, and contract manifest.
   schema recipe        Print the wp-codebox/workspace-recipe/v1 JSON Schema.
+
+Version:
+  version | --version | -v
+                       Print the wp-codebox CLI version (read from the CLI package.json) and exit.
 
 Recipe commands:
 ${recipeCommandIds.map((id) => `  ${id}`).join("\n")}

--- a/scripts/cli-version-smoke.ts
+++ b/scripts/cli-version-smoke.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { runCli } from "../packages/cli/src/cli-entry.js"
+
+const cliPackage = JSON.parse(readFileSync(new URL("../packages/cli/package.json", import.meta.url), "utf8")) as { version: string }
+
+const originalStdoutWrite = process.stdout.write.bind(process.stdout)
+
+async function runCaptureCli(args: string[]): Promise<{ exitCode: number; stdout: string }> {
+  let stdout = ""
+  process.stdout.write = ((chunk: unknown, ..._args: unknown[]) => {
+    stdout += String(chunk)
+    return true
+  }) as typeof process.stdout.write
+
+  const exitCode = await runCli(args)
+  process.stdout.write = originalStdoutWrite
+  return { exitCode, stdout }
+}
+
+for (const args of [["--version"], ["-v"], ["version"]] as const) {
+  const { exitCode, stdout } = await runCaptureCli([...args])
+  assert.equal(exitCode, 0, `expected exit 0 for ${args.join(" ")}, got ${exitCode}`)
+  assert.equal(stdout.trim(), cliPackage.version, `expected version ${cliPackage.version} for ${args.join(" ")}, got ${stdout.trim()}`)
+}
+
+const { exitCode: unknownExitCode } = await runCaptureCli(["not-a-command"])
+assert.equal(unknownExitCode, 1, "unknown command must still exit non-zero")
+
+console.log("cli-version-smoke: ok")


### PR DESCRIPTION
## Summary

Adds `--version` / `-v` / `version` to the `wp-codebox` CLI so homeboy's release build preflight ("WP Codebox CLI setup") can validate the installed binary. The probe runs `wp-codebox --version`; previously the CLI had no version support, so it printed `Unknown command: --version` and the preflight aborted every release with:

```
Error: wp-codebox was found, but no candidate passed 'wp-codebox --version'.
BUILD FAILED: WP Codebox CLI setup
```

This forced unrelated releases to use `--skip-checks`, defeating the gate.

Fixes #1664.

## Change

`packages/cli/src/command-router.ts` intercepts `--version` / `-v` / `version` immediately after the help block and **before** the unknown-command fallback, prints the version on stdout, and exits 0:

```ts
if (command === "--version" || command === "-v" || command === "version") {
  console.log(CLI_VERSION)
  return 0
}
```

The version is read **at runtime** from `packages/cli/package.json` (the CLI sub-package that ships the `wp-codebox` bin entry and whose name is `@automattic/wp-codebox-cli`):

```ts
const packageRequire = createRequire(import.meta.url)

function readCliVersion(): string {
  try {
    const manifest = JSON.parse(readFileSync(packageRequire.resolve("../package.json"), "utf8")) as { version?: unknown }
    return typeof manifest.version === "string" ? manifest.version : "0.0.0-unknown"
  } catch {
    return "0.0.0-unknown"
  }
}
```

This deliberately mirrors the repo's existing package-identity convention (`createRequire(import.meta.url)` + `require.resolve(.../package.json)` + `readFileSync`, see `packages/runtime-playground/src/artifacts.ts`), and the `../package.json` path resolves to `packages/cli/package.json` from both `src/command-router.ts` and the built `dist/command-router.js`. It is **not** a hardcoded literal, so it stays correct as homeboy bumps the version.

### Why `packages/cli/package.json`

Both the root `wp-codebox-workspace` and `packages/cli` (`@automattic/wp-codebox-cli`) are currently at the same version (`0.11.0`). The version is read from `packages/cli/package.json` because that is the package that owns the shipped `wp-codebox` bin entry and is the tightest match to "the CLI's version". `--version` emits the bare semver on stdout (the most greppable form for homeboy's probe).

## Before / after

```
$ wp-codebox --version            (before)
Unknown command: --version
Usage:
  wp-codebox commands [--json]
...
(exit 1)

$ wp-codebox --version            (after)
0.11.0
(exit 0)

$ wp-codebox -v                   (after)
0.11.0

$ wp-codebox version              (after)
0.11.0
```

`printHelp()` also documents the new `version | --version | -v` entry. Unknown commands still exit non-zero (no regression).

## Verification

- `npm run build` (`tsc -b` across runtime-core / runtime-playground / cli) — passes.
- Built entrypoint: `node packages/cli/dist/index.js --version` / `-v` / `version` all print `0.11.0` and exit 0.
- Source runner: `node bin/wp-codebox-source.mjs --version` / `-v` / `version` all print `0.11.0` and exit 0.
- Regression: `--version` no longer prints "Unknown command"; a bogus command still exits 1.
- `npm run test:command-router` — passes.
- `npm run test:distribution-startup-probes` — passes.
- New `npm run smoke:cli-version` (`scripts/cli-version-smoke.ts`, modelled on `scripts/cli-json-failure-smoke.ts`) asserts all three forms print the `packages/cli/package.json` version and exit 0, and that an unknown command still exits non-zero.
- No built `dist/` artifacts are committed (the tree is `.gitignore`d).
- No `CHANGELOG.md` edits and no hand-bumped version strings.