### PR TITLE
Handle workload-json in nested recipe fuzz execution

### DIFF
--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -221,7 +221,7 @@ async function executeRunFuzzSuiteRecipeCommand(runtime: Runtime, args: string[]
   const suite = await fuzzSuiteFromRecipeCommandArgs(args, recipeDirectory)
   const result = await runFuzzSuite(suite, {
     runnerCapabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
-    executor: async (spec) => runtime.execute(await recipeExecutionSpec(workflowStepFromExecutionSpec(spec), recipeDirectory, sandboxWorkspace)),
+    executor: async (spec) => executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: workflowStepFromExecutionSpec(spec) }, recipeDirectory, sandboxWorkspace),
     runtimeWorkloadExecutor: async ({ suite, workload, case: fuzzCase }) => {
       const workloadJson = JSON.stringify(workload)
       const execution = await executeWordPressRunWorkloadJsonRecipeCommand(runtime, [`workload-json=${workloadJson}`], recipeDirectory, sandboxWorkspace, suite, fuzzCase)

--- a/packages/runtime-core/src/artifact-references.ts
+++ b/packages/runtime-core/src/artifact-references.ts
@@ -40,6 +40,9 @@ export interface ArtifactReferenceFileInput {
   path?: string
   kind?: string
   contentType?: string
+  content_type?: string
+  mimeType?: string
+  mime?: string
   sha256?: string | ArtifactReferenceDigestInput
   digest?: string | ArtifactReferenceDigestInput
   viewer?: ArtifactViewerMetadata
@@ -278,7 +281,7 @@ function browserSessionRuntimeAccess(session: Record<string, unknown>): RuntimeA
 }
 
 export function normalizeArtifactContentType(input: ArtifactReferenceFileInput | undefined, fallback = "application/octet-stream"): string {
-  const contentType = input?.contentType
+  const contentType = input?.contentType ?? input?.content_type ?? input?.mimeType ?? input?.mime
   return typeof contentType === "string" && contentType.trim().length > 0 ? contentType : fallback
 }
 

--- a/packages/runtime-core/src/materialization-contracts.ts
+++ b/packages/runtime-core/src/materialization-contracts.ts
@@ -294,10 +294,10 @@ export function normalizeMaterializationArtifactRef(input: unknown, defaults: Pa
     return undefined
   }
 
-  const kind = stringValue(source.kind) || defaults.kind
-  const id = stringValue(source.id) || defaults.id
-  const path = stringValue(source.path) || defaults.path
-  const digest = normalizeDigest(source.digest ?? source.sha256) ?? defaults.digest
+  const kind = stringValue(source.kind ?? source.role ?? source.artifact_type) || defaults.kind
+  const id = stringValue(source.id ?? source.artifact_id) || defaults.id
+  const path = stringValue(source.path ?? source.artifacts_path ?? source.directory) || defaults.path
+  const digest = normalizeDigest(source.digest ?? source.contentDigest ?? source.content_digest ?? source.sha256) ?? defaults.digest
 
   if (!id && !path && !digest && !stringValue(source.kind)) {
     return undefined

--- a/tests/nested-fuzz-suite-recipe-command.test.ts
+++ b/tests/nested-fuzz-suite-recipe-command.test.ts
@@ -158,4 +158,34 @@ assert.equal(nestedJsonExecution.exitCode, 0)
 assert.equal(nestedJsonResult.status, "passed")
 assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.run-php"])
 
+executed.length = 0
+const childSuite = fuzzSuiteContract({
+  id: "nested-child-suite",
+  cases: [{
+    id: "child-command-case",
+    target: { kind: "command", id: "wordpress.run-php", entrypoint: "wordpress.run-php" },
+    input: { args: ["code=echo 'child';"] },
+  }],
+})
+const workloadJsonFallbackSuite = fuzzSuiteContract({
+  id: "nested-workload-json-fallback-suite",
+  cases: [{
+    id: "workload-json-fallback-case",
+    target: { kind: "command", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" },
+    input: {
+      args: [`workload-json=${JSON.stringify({
+        schema: "wp-codebox/wordpress-workload-run/v1",
+        before: [{ command: "wordpress.run-php", args: ["code=echo 'before';"] }],
+        steps: [{ command: "wp-codebox/run-fuzz-suite", args: [`input-json=${JSON.stringify(childSuite)}`] }],
+        after: [],
+      })}`],
+    },
+  }],
+})
+const fallbackExecution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: { command: "wp-codebox/run-fuzz-suite", args: [`input-json=${JSON.stringify(workloadJsonFallbackSuite)}`] } }, process.cwd())
+const fallbackResult = JSON.parse(fallbackExecution.stdout)
+assert.equal(fallbackExecution.exitCode, 0)
+assert.equal(fallbackResult.status, "passed")
+assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.run-php", "wordpress.run-php"])
+
 console.log("nested fuzz suite recipe command ok")


### PR DESCRIPTION
## Summary
- route nested fuzz-suite fallback specs through recipe workflow execution so wordpress.run-workload workload-json uses the JSON workload executor
- preserve PHP workload conversion behavior through the existing recipeExecutionSpec path
- add regression coverage for a nested fuzz-suite recipe command that plans wordpress.run-workload with workload-json containing regular recipe commands
- normalize artifact reference aliases uncovered while running the repo check script

## Testing
- npm run test:nested-fuzz-suite-recipe-command
- npm run build
- npm run test:fuzz-suite-runner
- npm run test:playground-fuzz-suite-public
- npm run test:browser-callback-materialization-contracts
- npm exec -- tsx scripts/artifact-reference-normalization-smoke.ts
- npm run check (still fails in unrelated executable-browser-dto-smoke: undefined Smoke_Browser_DTO::compact_browser_materializer_contract_dto())

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the recipe/fuzz nested workload execution path, implementing the routing fix, adding regression coverage, and fixing artifact reference normalization issues found during verification.