### PR TITLE
Support workload-json in runtime workload recipe steps

### DIFF
--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -166,22 +166,15 @@ async function wordpressRunWorkloadExecutionSpec(step: WorkspaceRecipe["workflow
   const args = step.args ?? []
   const workloadJson = commandArgValue(args, "workload-json")
   if (workloadJson) {
-    const workload = JSON.parse(workloadJson) as Record<string, unknown>
-    const phases = [workload.before, workload.steps, workload.after].flatMap((value) => Array.isArray(value) ? value : [])
-    const commandStep = phases.find((entry) => entry && typeof entry === "object" && !Array.isArray(entry) && (entry as Record<string, unknown>).command === "wordpress.run-workload") as Record<string, unknown> | undefined
-    if (commandStep) {
-      const nestedArgs = Array.isArray(commandStep.args) ? commandStep.args.map(String) : []
-      return await wordpressRunWorkloadExecutionSpec({ command: "wordpress.run-workload", args: nestedArgs, diagnostics: step.diagnostics })
-    }
-    if (phases.some((entry) => entry && typeof entry === "object" && !Array.isArray(entry) && typeof (entry as Record<string, unknown>).type === "string")) {
-      return {
-        command: "wordpress.bench",
-        args: [
-          `plugin-slug=${wordpressWorkloadPluginSlug(workload)}`,
-          `workloads-json=${JSON.stringify([{ id: typeof workload.id === "string" ? workload.id : "wordpress-workload", run: phases, metadata: workload.metadata }])}`,
-        ],
-        diagnostics: step.diagnostics,
-      }
+    JSON.parse(workloadJson)
+    return {
+      command: "wordpress.ability",
+      args: [
+        "name=wp-codebox/run-wordpress-workload",
+        `input=${workloadJson}`,
+        "expected-result-schema=\"wp-codebox/wordpress-workload-run-result/v1\"",
+      ],
+      diagnostics: step.diagnostics,
     }
   }
   const parsedArgs = commandArgsRecord(args)
@@ -222,22 +215,6 @@ function commandArgsRecord(args: string[]): Record<string, string> {
     if (key) parsed[key] = value
   }
   return parsed
-}
-
-function wordpressWorkloadPluginSlug(workload: Record<string, unknown>): string {
-  const metadata = recordValue(workload.metadata)
-  const explicit = stringValue(workload.pluginSlug) ?? stringValue(workload.plugin_slug) ?? stringValue(metadata?.plugin_slug)
-  if (explicit) return explicit
-  const activation = stringValue(recordValue(recordValue(recordValue(metadata?.intent)?.plugin)?.activation)?.entrypoint) ?? stringValue(recordValue(recordValue(metadata?.intent)?.plugin)?.activation)
-  return activation?.split("/")[0]?.trim() || "wordpress"
-}
-
-function recordValue(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined
 }
 
 export function agentRuntimeMetadata(options: AgentRuntimeProbeOptions, runtimeMetadata: (artifactsDirectory: string | undefined, wpVersion: string) => Record<string, unknown>, defaultWordPressVersion: string): Record<string, unknown> {

--- a/tests/command-diagnostics.test.ts
+++ b/tests/command-diagnostics.test.ts
@@ -36,3 +36,22 @@ assert.deepEqual(withCapture, {
   args: ["code=echo 'ok';", "capture-diagnostics=wpdb-queries", "diagnostics-max-items=1", "diagnostics-max-bytes=128"],
   diagnostics: { capture: ["wpdb-queries"], maxItems: 1, maxBytes: 128 },
 })
+
+const workloadJson = JSON.stringify({
+  schema: "wp-codebox/wordpress-workload-run/v1",
+  steps: [{ command: "wordpress.rest-request", args: ["path=/wp/v2/types"] }],
+})
+const workloadSpec = await recipeExecutionSpec({ command: "wordpress.run-workload", args: [`workload-json=${workloadJson}`] }, process.cwd())
+assert.deepEqual(workloadSpec, {
+  command: "wordpress.ability",
+  args: [
+    "name=wp-codebox/run-wordpress-workload",
+    `input=${workloadJson}`,
+    "expected-result-schema=\"wp-codebox/wordpress-workload-run-result/v1\"",
+  ],
+  diagnostics: undefined,
+})
+
+const phpWorkloadSpec = await recipeExecutionSpec({ command: "wordpress.run-workload", args: ["type=php", "path=/tmp/workload.php"] }, process.cwd())
+assert.equal(phpWorkloadSpec.command, "wordpress.run-php")
+assert.match(phpWorkloadSpec.args[0] ?? "", /require "\/tmp\/workload\.php"/)


### PR DESCRIPTION
## Summary
- Route `wordpress.run-workload workload-json=...` recipe steps through the public `wp-codebox/run-wordpress-workload` ability contract.
- Preserve existing `type=php` recipe lowering behavior.
- Add direct coverage for the handler that previously emitted the `type=php` guard error.

## Tests
- `npx tsx tests/command-diagnostics.test.ts`
- `npm run test:nested-fuzz-suite-recipe-command`
- `npm run build`

## Notes
- `npm run check` remains blocked locally by unrelated smoke baseline failures observed during this work. With an unrelated `executable-browser-dto-smoke` harness repair applied only for diagnosis, the run progressed to the unrelated `mounted-workspace-diff-smoke` baseline failure. Those unrelated smoke changes are not included in this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the runtime-backed workload recipe handler, implementing the focused fix, adding targeted coverage, and running verification.