### PR TITLE
Support workload JSON files in agent sandbox

### DIFF
--- a/packages/cli/src/agent-sandbox.ts
+++ b/packages/cli/src/agent-sandbox.ts
@@ -109,7 +109,7 @@ export function agentRuntimeMounts(options: AgentRuntimeProbeOptions): AgentRunt
 
 export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string, sandboxWorkspace?: SandboxWorkspaceContract): Promise<ExecutionSpec & { args: string[] }> {
   if (step.command === "wordpress.run-workload") {
-    return await wordpressRunWorkloadExecutionSpec(step)
+    return await wordpressRunWorkloadExecutionSpec(step, recipeDirectory)
   }
 
   if (step.command === "wp-codebox.agent-runtime-probe") {
@@ -162,16 +162,16 @@ export async function recipeExecutionSpec(step: WorkspaceRecipe["workflow"]["ste
   return { command: step.command, args: [...(step.args ?? []), ...commandDiagnosticsCaptureArgs(step.diagnostics)], diagnostics: step.diagnostics }
 }
 
-async function wordpressRunWorkloadExecutionSpec(step: WorkspaceRecipe["workflow"]["steps"][number]): Promise<ExecutionSpec & { args: string[] }> {
+async function wordpressRunWorkloadExecutionSpec(step: WorkspaceRecipe["workflow"]["steps"][number], recipeDirectory: string): Promise<ExecutionSpec & { args: string[] }> {
   const args = step.args ?? []
   const workloadJson = commandArgValue(args, "workload-json")
   if (workloadJson) {
-    JSON.parse(workloadJson)
+    const workloadInput = await wordpressWorkloadJsonInput(workloadJson, recipeDirectory)
     return {
       command: "wordpress.ability",
       args: [
         "name=wp-codebox/run-wordpress-workload",
-        `input=${workloadJson}`,
+        `input=${workloadInput}`,
         "expected-result-schema=\"wp-codebox/wordpress-workload-run-result/v1\"",
       ],
       diagnostics: step.diagnostics,
@@ -181,7 +181,7 @@ async function wordpressRunWorkloadExecutionSpec(step: WorkspaceRecipe["workflow
   const path = parsedArgs.path ?? parsedArgs.file
   const type = parsedArgs.type?.toLowerCase() ?? (path?.toLowerCase().endsWith(".php") ? "php" : undefined)
   if (type !== "php") {
-    throw new Error(`wordpress.run-workload recipe steps currently require type=php; received args=${JSON.stringify(args)}`)
+    throw new Error(`wordpress.run-workload recipe steps require workload-json=<json-or-file> or type=php; received args=${JSON.stringify(args)}`)
   }
   if (!path) {
     throw new Error("wordpress.run-workload recipe steps require path=<php-file> or file=<php-file>")
@@ -195,6 +195,23 @@ async function wordpressRunWorkloadExecutionSpec(step: WorkspaceRecipe["workflow
   const callableLoader = encodedSource ? `$__wp_codebox_workload_file = tempnam(sys_get_temp_dir(), 'wp-codebox-workload-');\nif (false === $__wp_codebox_workload_file) { throw new RuntimeException('Unable to create temporary PHP workload file.'); }\nfile_put_contents($__wp_codebox_workload_file, base64_decode('${encodedSource}'));\n$__wp_codebox_workload_callable = require $__wp_codebox_workload_file;\nunlink($__wp_codebox_workload_file);` : `$__wp_codebox_workload_callable = require ${JSON.stringify(path)};`
   const code = `$__wp_codebox_workload_args = json_decode(base64_decode('${encodedArgs}'), true);\n${callableLoader}\nif (!is_callable($__wp_codebox_workload_callable)) { throw new RuntimeException('PHP workload file must return a callable.'); }\n$__wp_codebox_workload_result = $__wp_codebox_workload_callable(array(), is_array($__wp_codebox_workload_args) ? $__wp_codebox_workload_args : array());\nif (is_array($__wp_codebox_workload_result) || is_object($__wp_codebox_workload_result)) { echo json_encode($__wp_codebox_workload_result, JSON_UNESCAPED_SLASHES) . "\\n"; } elseif (false === $__wp_codebox_workload_result) { exit(1); }`
   return { command: "wordpress.run-php", args: [`code=${code}`, ...commandDiagnosticsCaptureArgs(step.diagnostics)], diagnostics: step.diagnostics }
+}
+
+async function wordpressWorkloadJsonInput(value: string, recipeDirectory: string): Promise<string> {
+  try {
+    parseCommandJsonObject(value, "workload-json")
+    return value
+  } catch (inlineError) {
+    const path = resolve(recipeDirectory, value)
+    let source: string
+    try {
+      source = await readFile(path, "utf8")
+    } catch {
+      throw inlineError
+    }
+    const workload = parseCommandJsonObject(source, `workload-json file ${value}`)
+    return JSON.stringify(workload)
+  }
 }
 
 async function readableTextFile(path: string): Promise<string | undefined> {

--- a/tests/command-diagnostics.test.ts
+++ b/tests/command-diagnostics.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { createWorkspaceRecipeJsonSchema, commandDiagnosticsCaptureArgs, commandDiagnosticsCaptureSpecFromArgs, normalizeCommandDiagnosticsCaptureSpec } from "../packages/runtime-core/src/index.js"
 import { recipeExecutionSpec } from "../packages/cli/src/agent-sandbox.js"
 
@@ -51,6 +54,15 @@ assert.deepEqual(workloadSpec, {
   ],
   diagnostics: undefined,
 })
+
+const workloadDirectory = await mkdtemp(join(tmpdir(), "wp-codebox-workload-json-"))
+try {
+  await writeFile(join(workloadDirectory, "workload.json"), workloadJson)
+  const workloadFileSpec = await recipeExecutionSpec({ command: "wordpress.run-workload", args: ["workload-json=workload.json"] }, workloadDirectory)
+  assert.deepEqual(workloadFileSpec, workloadSpec)
+} finally {
+  await rm(workloadDirectory, { recursive: true, force: true })
+}
 
 const phpWorkloadSpec = await recipeExecutionSpec({ command: "wordpress.run-workload", args: ["type=php", "path=/tmp/workload.php"] }, process.cwd())
 assert.equal(phpWorkloadSpec.command, "wordpress.run-php")


### PR DESCRIPTION
## Summary
- Accept recipe-relative workload JSON files in agent sandbox lowering for `wordpress.run-workload workload-json=...`.
- Keep inline workload JSON lowering through `wp-codebox/run-wordpress-workload` / `wordpress.ability`.
- Preserve existing `type=php` workload behavior and replace the old exact unsupported-args error string.

## Tests
- `npx tsx tests/command-diagnostics.test.ts`
- `npm run build`
- `npm run check` failed at existing `executable-browser-dto-smoke`: `Call to undefined method Smoke_Browser_DTO::compact_browser_materializer_contract_dto()`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Patch implementation, targeted regression test, local build/check execution, and PR preparation.