### PR TITLE
Fix REST DB profiler source-backed workload cases

### DIFF
--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -1245,7 +1245,7 @@ function queryObservationArtifactsFromFuzzResult(result: FuzzSuiteResultEnvelope
     const command = stringValue(execution?.command)
     const target = fuzzCase.target?.id ?? fuzzCase.target?.entrypoint ?? stringValue(json?.path ?? json?.route ?? json?.url)
     const direct = queryObservationFromDatabaseRecord({ result, fuzzCase, command, target, database: recordValue(recordValue(json?.performance)?.database) ?? recordValue(json?.database) ?? recordValue(json?.metrics), source: "fuzz-case-execution" })
-    return [direct, ...queryObservationsFromBenchResult({ result, fuzzCase, command, target, json })].filter((item): item is QueryObservationArtifact => Boolean(item))
+    return [direct, ...queryObservationsFromRestDbProfiles({ result, fuzzCase, command, target, json }), ...queryObservationsFromPerformanceObservations({ result, fuzzCase, json })].filter((item): item is QueryObservationArtifact => Boolean(item))
   })
 }
 
@@ -1274,13 +1274,9 @@ function queryObservationFromDatabaseRecord(input: { result: FuzzSuiteResultEnve
   })
 }
 
-function queryObservationsFromBenchResult(input: { result: FuzzSuiteResultEnvelope; fuzzCase: FuzzSuiteResultEnvelope["cases"][number]; command?: string; target?: string; json?: Record<string, unknown> }): QueryObservationArtifact[] {
-  if (input.json?.schema !== "wp-codebox/bench-results/v1") return []
+function queryObservationsFromRestDbProfiles(input: { result: FuzzSuiteResultEnvelope; fuzzCase: FuzzSuiteResultEnvelope["cases"][number]; command?: string; target?: string; json?: Record<string, unknown> }): QueryObservationArtifact[] {
   const out: QueryObservationArtifact[] = []
-  for (const scenario of arrayValue(input.json.scenarios)) {
-    const scenarioRecord = recordValue(scenario)
-    const profile = recordValue(recordValue(scenarioRecord?.artifacts)?.["rest-db-query-profile"])
-    if (profile?.schema !== "wp-codebox/wordpress-rest-db-query-profile/v1") continue
+  for (const { profile, sourceId } of restDbQueryProfilesFromJson(input.json)) {
     for (const profileCase of arrayValue(profile.cases)) {
       const caseRecord = recordValue(profileCase)
       const summary = recordValue(caseRecord?.summary)
@@ -1299,11 +1295,46 @@ function queryObservationsFromBenchResult(input: { result: FuzzSuiteResultEnvelo
         source: "rest-db-query-profiler",
       })
       if (observation) {
-        out.push({ ...observation, metadata: { ...observation.metadata, scenarioId: stringValue(scenarioRecord?.id), profileCaseId: stringValue(caseRecord?.case_id) } })
+        out.push({ ...observation, metadata: { ...observation.metadata, sourceId, profileCaseId: stringValue(caseRecord?.case_id) } })
       }
     }
   }
   return out
+}
+
+function restDbQueryProfilesFromJson(json: Record<string, unknown> | undefined): Array<{ profile: Record<string, unknown>; sourceId?: string }> {
+  const profiles: Array<{ profile: Record<string, unknown>; sourceId?: string }> = []
+  if (json?.schema === "wp-codebox/bench-results/v1") {
+    for (const scenario of arrayValue(json.scenarios)) {
+      const scenarioRecord = recordValue(scenario)
+      const profile = recordValue(recordValue(scenarioRecord?.artifacts)?.["rest-db-query-profile"])
+      if (profile?.schema === "wp-codebox/wordpress-rest-db-query-profile/v1") profiles.push({ profile, sourceId: stringValue(scenarioRecord?.id) })
+    }
+  }
+  if (json?.schema === "wp-codebox/json-workload-result/v1") {
+    for (const step of arrayValue(json.steps)) {
+      const stepRecord = recordValue(step)
+      const profile = recordValue(recordValue(stepRecord?.artifacts)?.["rest-db-query-profile"])
+      if (profile?.schema === "wp-codebox/wordpress-rest-db-query-profile/v1") profiles.push({ profile, sourceId: stringValue(stepRecord?.type) })
+    }
+  }
+  return profiles
+}
+
+function queryObservationsFromPerformanceObservations(input: { result: FuzzSuiteResultEnvelope; fuzzCase: FuzzSuiteResultEnvelope["cases"][number]; json?: Record<string, unknown> }): QueryObservationArtifact[] {
+  return arrayValue(input.json?.observations).flatMap((item) => {
+    const observation = recordValue(item)
+    if (observation?.schema !== "wp-codebox/performance-observation/v1") return []
+    const queryObservation = queryObservationFromDatabaseRecord({
+      result: input.result,
+      fuzzCase: input.fuzzCase,
+      command: stringValue(observation.command),
+      target: stringValue(observation.target),
+      database: recordValue(observation.database),
+      source: stringValue(observation.source) ?? "performance-observation",
+    })
+    return queryObservation ? [queryObservation] : []
+  })
 }
 
 function normalizeQueryFingerprint(value: unknown): QueryObservationFingerprint[] {
@@ -1543,17 +1574,13 @@ function performanceObservationsFromWorkloadExecution(execution: ExecutionResult
   const raw = arrayValue(json?.observations ?? json?.performanceObservations ?? json?.performance_observations)
   return [
     ...raw.flatMap((item) => isPerformanceObservation(item) ? [item] : []),
-    ...performanceObservationsFromBenchResult(json, execution),
+    ...performanceObservationsFromRestDbProfiles(json, execution),
   ]
 }
 
-function performanceObservationsFromBenchResult(json: Record<string, unknown> | undefined, execution: ExecutionResult): PerformanceObservation[] {
-  if (json?.schema !== "wp-codebox/bench-results/v1") return []
+function performanceObservationsFromRestDbProfiles(json: Record<string, unknown> | undefined, execution: ExecutionResult): PerformanceObservation[] {
   const observations: PerformanceObservation[] = []
-  for (const scenario of arrayValue(json.scenarios)) {
-    const scenarioRecord = recordValue(scenario)
-    const profile = recordValue(recordValue(scenarioRecord?.artifacts)?.["rest-db-query-profile"])
-    if (profile?.schema !== "wp-codebox/wordpress-rest-db-query-profile/v1") continue
+  for (const { profile, sourceId } of restDbQueryProfilesFromJson(json)) {
     for (const profileCase of arrayValue(profile.cases)) {
       const caseRecord = recordValue(profileCase)
       const summary = recordValue(caseRecord?.summary)
@@ -1567,7 +1594,7 @@ function performanceObservationsFromBenchResult(json: Record<string, unknown> | 
         source: "rest-db-query-profiler",
         kind: "rest-request",
         database: queryCount !== undefined || totalTimeMs !== undefined ? { queryCount, totalTimeMs } : undefined,
-        metadata: { executionId: execution.id, scenarioId: stringValue(scenarioRecord?.id), caseId: stringValue(caseRecord?.case_id) },
+        metadata: { executionId: execution.id, sourceId, caseId: stringValue(caseRecord?.case_id) },
       }
       if (hasObservationMetrics(observation)) {
         observations.push(observation)

--- a/packages/wordpress-plugin/src/class-wp-codebox-fuzz-suite-runner.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-fuzz-suite-runner.php
@@ -1307,6 +1307,24 @@ private static function execute_fuzz_suite_json_php_step( array $step, int $inde
 /** @param array<string,mixed> $step Step. @return array<string,mixed> */
 private static function execute_fuzz_suite_json_rest_db_query_profiler_step( array $step, int $index ): array {
 	$cases = is_array( $step['rest_request_cases'] ?? null ) ? $step['rest_request_cases'] : array();
+	if ( empty( $cases ) && isset( $step['request_cases'] ) && is_array( $step['request_cases'] ) ) {
+		$cases = $step['request_cases'];
+	}
+	if ( empty( $cases ) && isset( $step['rest_request_cases_source'] ) && is_array( $step['rest_request_cases_source'] ) ) {
+		$cases = self::fuzz_suite_rest_request_cases_from_source( $step['rest_request_cases_source'] );
+		if ( is_wp_error( $cases ) ) {
+			return self::failed_fuzz_suite_rest_db_query_profiler_step( $index, $cases->code, $cases->get_error_message() );
+		}
+		if ( empty( $cases ) ) {
+			return self::failed_fuzz_suite_rest_db_query_profiler_step( $index, 'wp_codebox_fuzz_rest_request_cases_source_empty', 'rest_request_cases_source did not resolve any request cases.' );
+		}
+	}
+	if ( empty( $cases ) && ( isset( $step['path'] ) || isset( $step['route'] ) ) ) {
+		$cases = array( $step );
+	}
+	if ( empty( $cases ) ) {
+		return self::failed_fuzz_suite_rest_db_query_profiler_step( $index, 'wp_codebox_fuzz_rest_db_query_profiler_cases_empty', 'rest-db-query-profiler requires at least one REST request case.' );
+	}
 	$requests = array();
 	$failed = 0;
 	foreach ( $cases as $case ) {
@@ -1323,6 +1341,7 @@ private static function execute_fuzz_suite_json_rest_db_query_profiler_step( arr
 	$total_queries        = array_sum( array_map( static fn( array $request ): int => (int) ( $request['queryCount'] ?? 0 ), $requests ) );
 	$query_fingerprints  = self::merge_fuzz_suite_query_fingerprints( $requests, (int) ( $step['fingerprintLimit'] ?? 50 ) );
 	$fingerprint_count   = count( $query_fingerprints );
+	$profile_artifact    = self::fuzz_suite_rest_db_query_profile_artifact( $requests, (int) ( $step['sampleLimit'] ?? 50 ), (int) ( $step['queryLengthLimit'] ?? 500 ) );
 	return array(
 		'type'        => 'rest-db-query-profiler',
 		'index'       => $index,
@@ -1330,8 +1349,100 @@ private static function execute_fuzz_suite_json_rest_db_query_profiler_step( arr
 		'status'      => 0 === $failed ? 'passed' : 'failed',
 		'observation' => array( 'metricPrefix' => (string) ( $step['metric-prefix'] ?? 'rest_db_query_profile' ), 'requestCount' => count( $requests ), 'queryCount' => $total_queries, 'fingerprintCount' => $fingerprint_count ),
 		'metrics'     => array( (string) ( $step['metric-prefix'] ?? 'rest_db_query_profile' ) . '.query_count' => $total_queries, (string) ( $step['metric-prefix'] ?? 'rest_db_query_profile' ) . '.request_count' => count( $requests ), (string) ( $step['metric-prefix'] ?? 'rest_db_query_profile' ) . '.fingerprint_count' => $fingerprint_count ),
+		'artifacts'   => array( 'rest-db-query-profile' => $profile_artifact ),
 		'requests'    => $requests,
 		'queryFingerprints' => $query_fingerprints,
+	);
+}
+
+private static function failed_fuzz_suite_rest_db_query_profiler_step( int $index, string $code, string $message ): array {
+	return array(
+		'type'        => 'rest-db-query-profiler',
+		'index'       => $index,
+		'success'     => false,
+		'status'      => 'failed',
+		'observation' => array( 'metricPrefix' => 'rest_db_query_profile', 'requestCount' => 0, 'queryCount' => 0, 'fingerprintCount' => 0 ),
+		'metrics'     => array( 'rest_db_query_profile.query_count' => 0, 'rest_db_query_profile.request_count' => 0, 'rest_db_query_profile.fingerprint_count' => 0 ),
+		'diagnostics' => array( self::fuzz_suite_diagnostic( 'error', $code, $message, array( 'step_index' => $index ) ) ),
+	);
+}
+
+/** @param array<string,mixed> $source Source. @return array<int,array<string,mixed>>|WP_Error */
+private static function fuzz_suite_rest_request_cases_from_source( array $source ): array|WP_Error {
+	$type = isset( $source['type'] ) && is_string( $source['type'] ) ? $source['type'] : '';
+	if ( 'artifact' !== $type ) {
+		return new WP_Error( 'wp_codebox_fuzz_rest_request_cases_source_type_invalid', 'rest_request_cases_source only supports artifact sources.' );
+	}
+
+	$root = getenv( 'WP_CODEBOX_BENCH_SHARED_STATE' );
+	if ( ! is_string( $root ) || '' === $root || ! is_dir( $root ) ) {
+		return new WP_Error( 'wp_codebox_fuzz_rest_request_cases_source_root_unavailable', 'rest_request_cases_source artifact root is unavailable.' );
+	}
+
+	$artifact_globs     = isset( $source['artifact_globs'] ) && is_array( $source['artifact_globs'] ) ? $source['artifact_globs'] : array();
+	$max_route_cases    = isset( $source['maxRouteCases'] ) && is_numeric( $source['maxRouteCases'] ) ? max( 0, (int) $source['maxRouteCases'] ) : 100;
+	$max_artifact_bytes = isset( $source['maxArtifactBytes'] ) && is_numeric( $source['maxArtifactBytes'] ) ? max( 0, (int) $source['maxArtifactBytes'] ) : 1048576;
+	$expected_schema    = isset( $source['schema'] ) && is_string( $source['schema'] ) ? $source['schema'] : '';
+	$cases              = array();
+	if ( 0 === $max_route_cases ) {
+		return $cases;
+	}
+
+	foreach ( $artifact_globs as $artifact_glob ) {
+		if ( ! is_string( $artifact_glob ) || '' === $artifact_glob || str_starts_with( $artifact_glob, '/' ) || str_contains( $artifact_glob, '..' ) ) {
+			return new WP_Error( 'wp_codebox_fuzz_rest_request_cases_source_glob_invalid', 'rest_request_cases_source artifact_globs must be safe relative glob paths.' );
+		}
+		foreach ( glob( rtrim( $root, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR . $artifact_glob ) ?: array() as $artifact_path ) {
+			if ( ! is_file( $artifact_path ) ) {
+				continue;
+			}
+			$bytes = filesize( $artifact_path );
+			if ( false === $bytes || $bytes > $max_artifact_bytes ) {
+				return new WP_Error( 'wp_codebox_fuzz_rest_request_cases_source_artifact_too_large', 'rest_request_cases_source artifact exceeds maxArtifactBytes.' );
+			}
+			$artifact = json_decode( (string) file_get_contents( $artifact_path ), true );
+			if ( ! is_array( $artifact ) ) {
+				return new WP_Error( 'wp_codebox_fuzz_rest_request_cases_source_json_invalid', 'rest_request_cases_source artifact is not valid JSON.' );
+			}
+			if ( '' !== $expected_schema && isset( $artifact['schema'] ) && $expected_schema !== $artifact['schema'] ) {
+				continue;
+			}
+			foreach ( isset( $artifact['cases'] ) && is_array( $artifact['cases'] ) ? $artifact['cases'] : array() as $request_case ) {
+				if ( ! is_array( $request_case ) ) {
+					continue;
+				}
+				$cases[] = $request_case;
+				if ( count( $cases ) >= $max_route_cases ) {
+					return $cases;
+				}
+			}
+		}
+	}
+
+	return $cases;
+}
+
+/** @param array<int,array<string,mixed>> $requests Requests. @return array<string,mixed> */
+private static function fuzz_suite_rest_db_query_profile_artifact( array $requests, int $sample_limit, int $query_length_limit ): array {
+	$cases = array();
+	$total_queries = 0;
+	foreach ( $requests as $index => $request ) {
+		$query_count = (int) ( $request['queryCount'] ?? 0 );
+		$total_queries += $query_count;
+		$cases[] = array(
+			'case_id' => (string) ( $request['id'] ?? 'case-' . $index ),
+			'method'  => (string) ( $request['method'] ?? 'GET' ),
+			'path'    => (string) ( $request['path'] ?? '' ),
+			'summary' => array( 'query_count' => $query_count, 'total_time_ms' => 0.0 ),
+			'samples' => is_array( $request['sampledQueries'] ?? null ) ? $request['sampledQueries'] : array(),
+			'queries' => is_array( $request['queryFingerprints'] ?? null ) ? $request['queryFingerprints'] : array(),
+		);
+	}
+
+	return array(
+		'schema'  => 'wp-codebox/wordpress-rest-db-query-profile/v1',
+		'summary' => array( 'case_count' => count( $cases ), 'query_count' => $total_queries, 'total_time_ms' => 0.0, 'sample_limit' => $sample_limit, 'query_length_limit' => $query_length_limit ),
+		'cases'   => $cases,
 	);
 }
 

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -3,16 +3,33 @@ declare(strict_types=1);
 
 $wp_codebox_smoke_root = sys_get_temp_dir() . '/wp-codebox-fuzz-smoke-' . getmypid() . '/';
 mkdir( $wp_codebox_smoke_root . 'wp-admin/includes', 0777, true );
+mkdir( $wp_codebox_smoke_root . 'generated-rest-request-cases', 0777, true );
 register_shutdown_function(
 	static function () use ( $wp_codebox_smoke_root ): void {
 		@unlink( $wp_codebox_smoke_root . 'rest-db-query-profile.workload.json' );
+		@unlink( $wp_codebox_smoke_root . 'empty-rest-db-query-profile.workload.json' );
+		@unlink( $wp_codebox_smoke_root . 'generated-rest-request-cases/status.json' );
 		@unlink( $wp_codebox_smoke_root . 'closure-workload.php' );
 		@unlink( $wp_codebox_smoke_root . 'wp-admin/menu.php' );
 		@unlink( $wp_codebox_smoke_root . 'wp-admin/includes/admin.php' );
 		@rmdir( $wp_codebox_smoke_root . 'wp-admin/includes' );
 		@rmdir( $wp_codebox_smoke_root . 'wp-admin' );
+		@rmdir( $wp_codebox_smoke_root . 'generated-rest-request-cases' );
 		@rmdir( $wp_codebox_smoke_root );
 	}
+);
+putenv( 'WP_CODEBOX_BENCH_SHARED_STATE=' . $wp_codebox_smoke_root );
+file_put_contents(
+	$wp_codebox_smoke_root . 'generated-rest-request-cases/status.json',
+	json_encode(
+		array(
+			'schema' => 'wp-codebox/generated-rest-request-cases/v1',
+			'cases'  => array(
+				array( 'id' => 'status', 'method' => 'GET', 'path' => '/wp/v2/status', 'params' => array( 'per_page' => 1 ) ),
+			),
+		),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	)
 );
 file_put_contents( $wp_codebox_smoke_root . 'wp-admin/includes/admin.php', "<?php\n" );
 file_put_contents(
@@ -266,8 +283,12 @@ file_put_contents(
 					'metric-prefix'      => 'rest_db_query_profile',
 					'sampleLimit'        => 50,
 					'queryLengthLimit'   => 500,
-					'rest_request_cases' => array(
-						array( 'id' => 'status', 'method' => 'GET', 'path' => '/wp/v2/status', 'params' => array( 'per_page' => 1 ) ),
+					'rest_request_cases_source' => array(
+						'type'             => 'artifact',
+						'schema'           => 'wp-codebox/generated-rest-request-cases/v1',
+						'artifact_globs'   => array( 'generated-rest-request-cases/*.json' ),
+						'maxRouteCases'    => 80,
+						'maxArtifactBytes' => 1048576,
 					),
 				),
 				array(
@@ -280,6 +301,27 @@ file_put_contents(
 				),
 			),
 			'metadata' => array( 'runner' => 'wp-codebox', 'workload' => 'rest-db-query-profile' ),
+		),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	)
+);
+
+$empty_json_workload_path = $wp_codebox_smoke_root . 'empty-rest-db-query-profile.workload.json';
+file_put_contents(
+	$empty_json_workload_path,
+	wp_json_encode(
+		array(
+			'id'  => 'empty-rest-db-query-profile',
+			'run' => array(
+				array(
+					'type'                      => 'rest-db-query-profiler',
+					'rest_request_cases_source' => array(
+						'type'           => 'artifact',
+						'schema'         => 'wp-codebox/generated-rest-request-cases/v1',
+						'artifact_globs' => array( 'missing-rest-request-cases/*.json' ),
+					),
+				),
+			),
 		),
 		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
 	)
@@ -531,6 +573,10 @@ $workload_report = json_decode( file_get_contents( WP_CONTENT_DIR . '/uploads/wo
 assert( 'wp-codebox/json-workload-result/v1' === $workload_report['schema'] );
 assert( 4 === $workload_report['steps'][1]['observation']['queryCount'] );
 assert( 3 === $workload_report['steps'][1]['observation']['fingerprintCount'] );
+assert( 'wp-codebox/wordpress-rest-db-query-profile/v1' === $workload_report['steps'][1]['artifacts']['rest-db-query-profile']['schema'] );
+assert( 1 === $workload_report['steps'][1]['artifacts']['rest-db-query-profile']['summary']['case_count'] );
+assert( 4 === $workload_report['steps'][1]['artifacts']['rest-db-query-profile']['summary']['query_count'] );
+assert( 'status' === $workload_report['steps'][1]['artifacts']['rest-db-query-profile']['cases'][0]['case_id'] );
 assert( 4 === $workload_report['steps'][1]['requests'][0]['queryCount'] );
 assert( "SELECT * FROM wp_posts WHERE post_type = '?' AND ID IN (?)" === $workload_report['steps'][1]['requests'][0]['sampledQueries'][0]['sql'] );
 assert( 2 === $workload_report['steps'][1]['queryFingerprints'][0]['count'] );
@@ -563,6 +609,27 @@ assert( in_array( 'target:rest', $result['metadata']['runnerCapabilities']['capa
 assert( in_array( 'target:runtime-action', $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'], true ) );
 assert( in_array( 'target:runtime', $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'], true ) );
 assert( in_array( 'runtime-action:browser', $result['metadata']['runnerCapabilities']['unsupportedRequiredCapabilities'], true ) );
+
+$empty_source_result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
+	array(
+		'schema' => 'wp-codebox/fuzz-suite/v1',
+		'id'     => 'empty-source-suite',
+		'cases'  => array(
+			array(
+				'id'     => 'empty-source-profiler',
+				'phases' => array(
+					'action' => array(
+						array( 'command' => 'wordpress.run-workload', 'args' => array( 'path=' . $empty_json_workload_path ) ),
+					),
+				),
+			),
+		),
+	)
+);
+assert( false === $empty_source_result['success'] );
+assert( 'failed' === $empty_source_result['status'] );
+assert( 'wp_codebox_fuzz_rest_request_cases_source_empty' === $empty_source_result['diagnostics'][0]['code'] );
+assert( 'wp_codebox_fuzz_rest_request_cases_source_empty' === $empty_source_result['cases'][0]['diagnostics'][0]['code'] );
 
 $runtime_backed_request = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 	array(

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -52,9 +52,9 @@ const episode = {
       "wordpress.db-operation": { metrics: { query_count: 11, query_time_ms: 22 }, metadata: { dbWriteSet: { schema: "wp-codebox/wordpress-db-write-set/v1", artifactKind: "wordpress-db-write-set", action: "db_operation", target: "wp_fuzz", entries: [{ table: "wp_fuzz", operation: "update", rowsAffected: 1, rowCountBefore: 1, rowCountAfter: 1, resource: { table: "wp_fuzz", identifiers: { id: 1 } }, key: "wp_fuzz:update:1" }], repeatedWrites: [], totals: { writes: 1, rowsAffected: 1, tables: 1, repeatedWriteKeys: 0 } } } },
       "wordpress.crud-operation": { item: { id: 123 }, status: "ok", metadata: { dbWriteSet: { schema: "wp-codebox/wordpress-db-write-set/v1", artifactKind: "wordpress-db-write-set", action: "crud_operation", target: "post:123", entries: [{ table: "wp_posts", operation: "update", rowsAffected: 1, object: { kind: "post", id: 123 }, key: "wp_posts:update:123", repeatedWritesToSameKey: 2 }, { table: "wp_postmeta", operation: "update", rowsAffected: 1, object: { kind: "post", id: 123 }, key: "wp_postmeta:update:123" }], repeatedWrites: [{ table: "wp_posts", operation: "update", rowsAffected: 1, object: { kind: "post", id: 123 }, key: "wp_posts:update:123", repeatedWritesToSameKey: 2 }], totals: { writes: 2, rowsAffected: 2, tables: 2, repeatedWriteKeys: 1 } } } },
       "wordpress.run-php": runPhpCode.includes("wordpress-rollback-capture-request") ? rollbackCapturePayload(runPhpCode) : runPhpCode.includes("rest-db-query-profiler") ? {
-        schema: "wp-codebox/bench-results/v1",
-        scenarios: [{
-          id: "typed-rest-profile",
+        schema: "wp-codebox/json-workload-result/v1",
+        steps: [{
+          type: "rest-db-query-profiler",
           artifacts: {
             "rest-db-query-profile": {
               schema: "wp-codebox/wordpress-rest-db-query-profile/v1",
@@ -165,6 +165,7 @@ assert.equal(metadataArtifacts?.fuzzHotspotSet?.metadata?.schema, "wp-codebox/fu
 assert.equal(metadataArtifacts?.queryObservations?.persisted, false)
 assert.equal(metadataArtifacts?.queryObservations?.metadata?.schema, "wp-codebox/query-observation/v1")
 assert.equal(metadataArtifacts?.queryObservations?.observations?.some((item) => item.caseId === "rest" && item.queryCount === 3), true)
+assert.equal(metadataArtifacts?.queryObservations?.observations?.some((item) => item.caseId === "typed-workload" && item.queryCount === 9), true)
 assert.equal(Array.isArray(metadataArtifacts?.wordpressHotspots?.hotspots), false)
 assert.equal(Array.isArray(metadataArtifacts?.fuzzObservationSet?.observations), false)
 assert.equal(Array.isArray(metadataArtifacts?.fuzzHotspotSet?.hotspots), false)


### PR DESCRIPTION
## Summary
- Resolve rest-db-query-profiler request cases from rest_request_cases_source in the PHP fuzz/workload runner.
- Fail profiler workload steps when source-backed case resolution returns zero cases instead of passing with zero requests.
- Emit the wordpress-rest-db-query-profile artifact shape from workload profiler steps and normalize workload profile observations downstream.

## Tests
- npm run build
- npm run test:php-fuzz-suite-runner
- npm run test:bench-command-step-behavior
- npm run test:playground-fuzz-suite-public

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the REST DB query profiler source-case fix and regression coverage.