### PR TITLE
Fix aborted preview proxy requests

### DIFF
--- a/packages/runtime-playground/src/preview-server.ts
+++ b/packages/runtime-playground/src/preview-server.ts
@@ -160,12 +160,18 @@ function createPreviewRouteRegistry(): InternalPreviewRouteRegistry {
 function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {
   return new Promise((resolve) => {
     let settled = false
+    let targetResponse: IncomingMessage | undefined
     const settle = () => {
       if (settled) {
         return
       }
       settled = true
       resolve()
+    }
+    const abortUpstream = () => {
+      targetRequest.destroy()
+      targetResponse?.destroy()
+      settle()
     }
 
     const targetRequest = httpRequest(
@@ -177,15 +183,16 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
         path: incoming.url ?? "/",
         headers: proxyRequestHeaders(incoming.headers),
       },
-      (targetResponse) => {
-        outgoing.writeHead(targetResponse.statusCode ?? 502, targetResponse.statusMessage, proxyResponseHeaders(targetResponse.headers))
-        targetResponse.on("error", (error) => {
+      (response) => {
+        targetResponse = response
+        outgoing.writeHead(response.statusCode ?? 502, response.statusMessage, proxyResponseHeaders(response.headers))
+        response.on("error", (error) => {
           outgoing.destroy(error)
           settle()
         })
         outgoing.on("finish", settle)
         outgoing.on("close", settle)
-        targetResponse.pipe(outgoing)
+        response.pipe(outgoing)
       },
     )
 
@@ -194,9 +201,10 @@ function proxyPreviewRequest(target: URL, incoming: IncomingMessage, outgoing: S
       settle()
     })
     incoming.on("error", () => {
-      targetRequest.destroy()
-      settle()
+      abortUpstream()
     })
+    outgoing.on("error", abortUpstream)
+    outgoing.on("close", abortUpstream)
     incoming.pipe(targetRequest)
   })
 }

--- a/tests/browser-callback-materialization-contracts.test.ts
+++ b/tests/browser-callback-materialization-contracts.test.ts
@@ -24,6 +24,8 @@ import {
 import { browserPreviewAuthCookieUrls, browserPreviewTopology } from "../packages/runtime-playground/src/browser-preview-routing.js"
 import { closeHttpServer, listenLocalHttpServer, withPreviewProxy, type PlaygroundCliServer } from "../packages/runtime-playground/src/preview-server.js"
 
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
 assert.deepEqual(trustedBrowserSessionOrigin("http://localhost:8881/path?x=1"), {
   schema: "wp-codebox/trusted-browser-session-origin/v1",
   origin: "http://localhost:8881",
@@ -146,6 +148,41 @@ try {
   await closeHttpServer(targetServer)
 }
 assert.equal(disposed, true)
+
+let hangingRequestReached: (() => void) | undefined
+const hangingRequest = new Promise<void>((resolve) => {
+  hangingRequestReached = resolve
+})
+const hangingTargetServer = createServer((request, response) => {
+  if (request.url === "/hang") {
+    hangingRequestReached?.()
+    return
+  }
+
+  response.end("ok")
+})
+const hangingTargetServerUrl = await listenLocalHttpServer(hangingTargetServer)
+const abortableProxy = await withPreviewProxy({
+  playground: { async run() { return { text: "" } } },
+  serverUrl: hangingTargetServerUrl,
+  async [Symbol.asyncDispose]() {},
+} satisfies PlaygroundCliServer, 0)
+try {
+  const controller = new AbortController()
+  const abortedRequest = fetch(`${abortableProxy.serverUrl}/hang`, { signal: controller.signal }).catch((error) => error)
+  await hangingRequest
+  controller.abort()
+  await abortedRequest
+
+  const nextRequest = await Promise.race([
+    fetch(`${abortableProxy.serverUrl}/ok`).then((response) => response.text()),
+    wait(500).then(() => "timed-out"),
+  ])
+  assert.equal(nextRequest, "ok", "aborted preview requests must release the serialized upstream proxy slot")
+} finally {
+  await abortableProxy[Symbol.asyncDispose]()
+  await closeHttpServer(hangingTargetServer)
+}
 
 const phase = materializationPhaseResult({
   phase: "persist-browser-artifacts",


### PR DESCRIPTION
## Summary
- Cancel upstream preview proxy requests when the browser/client aborts navigation.
- Release the serialized preview proxy queue slot on aborted client responses.
- Add a regression covering an aborted hanging proxied request followed by a healthy request.

## Root cause
The preview proxy serialized upstream requests, but a client-aborted browser navigation could leave the upstream request alive and the queue slot unsettled. A reachability probe could pass while the later Playwright navigation sat behind that stale request until timeout.

## Testing
- npm run test:browser-callback-materialization-contracts
- npm run test:browser-visual-compare-capture-reliability
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis, implementation, regression test, and PR preparation.