### PR TITLE
Support custom WordPress PHPUnit test roots

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -952,6 +952,7 @@ export const commandRegistry = [
     acceptedArgs: [
       { name: "plugin-slug", description: "Plugin slug under wp-content/plugins.", format: "slug" },
       { name: "cwd", description: "Sandbox working directory for the PHPUnit process. Relative values resolve inside the mounted plugin directory; defaults to wp-content/plugins/<plugin-slug>.", format: "sandbox path" },
+      { name: "test-root", description: "Sandbox directory containing PHPUnit test files. Relative values resolve inside the mounted plugin directory; defaults to wp-content/plugins/<plugin-slug>/tests.", format: "sandbox path" },
       { name: "code", description: "Inline override PHP runner code.", format: "PHP string" },
       { name: "code-file", description: "Path to override PHP runner code.", format: "path" },
       { name: "autoload-file", description: "WP Codebox/PHPUnit harness autoload path inside the sandbox. In project bootstrap mode this is optional when the project bootstrap loads PHPUnit.", format: "sandbox path" },

--- a/packages/runtime-core/src/recipe-builders.ts
+++ b/packages/runtime-core/src/recipe-builders.ts
@@ -26,6 +26,8 @@ export interface WordPressPhpunitRecipeOptions {
   autoloadFile?: string
   projectAutoloadFile?: string
   testsDir?: string
+  testRoot?: string
+  phpunitXml?: string
   dependencyMounts?: string[]
   bootstrapFiles?: string[]
   phpunitArgs?: string[]
@@ -91,6 +93,8 @@ export function buildWordPressPhpunitRecipe(options: WordPressPhpunitRecipeOptio
           commandArg("autoload-file", options.autoloadFile ?? "/wp-codebox-vendor/autoload.php"),
           commandArg("project-autoload-file", options.projectAutoloadFile ?? ""),
           commandArg("tests-dir", options.testsDir ?? "/wp-codebox-vendor/wp-phpunit/wp-phpunit"),
+          commandArg("test-root", options.testRoot ?? `${pluginTarget}/tests`),
+          commandArg("phpunit-xml", options.phpunitXml ?? `${pluginTarget}/phpunit.xml.dist`),
           commandStringListArg("dependency-mounts", options.dependencyMounts ?? []),
           commandJsonArg("bootstrap-files-json", options.bootstrapFiles ?? []),
           commandJsonArg("phpunit-args-json", options.phpunitArgs ?? []),

--- a/packages/runtime-playground/src/phpunit-command-handlers.ts
+++ b/packages/runtime-playground/src/phpunit-command-handlers.ts
@@ -6,6 +6,7 @@ export interface PhpunitRunCodeOptions {
   autoloadFile: string
   projectAutoloadFile?: string
   testsDir: string
+  testRoot?: string
   phpunitXml: string
   selectedTestFile: string
   changedTestFiles: unknown[]
@@ -292,6 +293,7 @@ $pg_stage_output_buffering = false;
 $autoload_file = ${JSON.stringify(options.autoloadFile)};
 $project_autoload_file = ${JSON.stringify(options.projectAutoloadFile ?? "")};
 $tests_dir = ${JSON.stringify(options.testsDir)};
+$test_root = ${JSON.stringify(options.testRoot || `/wordpress/wp-content/plugins/${options.pluginSlug}/tests`)};
 $selected_test_file = ${JSON.stringify(options.selectedTestFile)};
 $changed_test_files_raw = ${JSON.stringify(JSON.stringify(options.changedTestFiles))};
 $phpunit_args_raw = json_decode(${JSON.stringify(JSON.stringify(options.phpunitArgs))}, true);
@@ -577,12 +579,22 @@ function pg_resolve_runtime_cwd(string $cwd, string $plugin_path): string {
         $cwd = rtrim($plugin_path, '/') . '/' . ltrim($cwd, '/');
     }
     $real = realpath($cwd);
-    $plugin_real = realpath($plugin_path);
-    if ($real === false || $plugin_real === false || !is_dir($real)) {
+    if ($real === false || !is_dir($real)) {
         throw new RuntimeException('cwd is not a readable sandbox directory: ' . $cwd);
     }
-    if ($real !== $plugin_real && strpos($real, rtrim($plugin_real, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR) !== 0) {
-        throw new RuntimeException('cwd must resolve inside the mounted plugin directory: ' . $cwd);
+    return $real;
+}
+
+function pg_resolve_test_root(string $root, string $plugin_path): string {
+    $root = trim(str_replace('\\\\', '/', $root));
+    if ($root === '') {
+        $root = $plugin_path . '/tests';
+    } elseif ($root[0] !== '/') {
+        $root = rtrim($plugin_path, '/') . '/' . ltrim($root, '/');
+    }
+    $real = realpath($root);
+    if ($real === false || !is_dir($real)) {
+        throw new RuntimeException('test root is not a readable sandbox directory: ' . $root);
     }
     return $real;
 }
@@ -891,8 +903,10 @@ pg_install_diagnostics_handlers();
 pg_stage_begin('cwd');
 try {
     $runtime_cwd = pg_resolve_runtime_cwd($runtime_cwd, $plugin_path);
+    $test_root = pg_resolve_test_root($test_root, $plugin_path);
     chdir($runtime_cwd);
     pg_log('CWD:' . $runtime_cwd);
+    pg_log('TEST_ROOT:' . $test_root);
     pg_stage_ok('cwd');
 } catch (Throwable $e) {
     pg_stage_fail('cwd', $e);
@@ -1025,8 +1039,8 @@ ${phpunitConfigDiscoveryPhp({
     includeParseFailureDetail: true,
     loadedConfigMessage: "NOTICE:phpunit.xml.dist loaded from ",
     fallbackXmlDist: true,
-    restrictDirectoriesToTests: true,
-    basePathExpression: "dirname($test_dir_default)",
+    restrictDirectoriesToTests: !options.testRoot,
+    basePathExpression: "dirname($xml_path)",
     uniqueReturnValues: false,
     replaceDefaultMatchers: true,
   })}
@@ -1035,7 +1049,7 @@ ${phpunitDiscoveryPhp("wp_codebox_phpunit_discover", "pg_log")}
 
 pg_stage_begin('discover_tests');
 try {
-    $test_dir = $plugin_path . '/tests';
+    $test_dir = $test_root;
     if (!is_dir($test_dir)) {
         pg_log('NO_TEST_FILES');
         pg_log('NOTICE:tests directory not found at ' . $test_dir);
@@ -1044,9 +1058,9 @@ try {
     }
     list($directories, $suffixes, $prefixes, $excludes) = wp_codebox_phpunit_parse_config(${JSON.stringify(options.phpunitXml)}, $test_dir);
     $test_files = wp_codebox_phpunit_discover($directories, $suffixes, $prefixes, $excludes);
-    $test_files = pg_filter_changed_test_files($test_files, $changed_test_files_raw, $plugin_path);
+    $test_files = pg_filter_changed_test_files($test_files, $changed_test_files_raw, $test_dir);
     if ($selected_test_file !== '') {
-        $selected_abs = $plugin_path . '/' . ltrim($selected_test_file, '/');
+        $selected_abs = $selected_test_file[0] === '/' ? $selected_test_file : $test_dir . '/' . ltrim($selected_test_file, '/');
         if (!in_array($selected_abs, $test_files, true)) {
             $selected_real = realpath($selected_abs);
             $tests_real = realpath($test_dir);

--- a/packages/runtime-playground/src/wordpress-command-runners.ts
+++ b/packages/runtime-playground/src/wordpress-command-runners.ts
@@ -912,6 +912,7 @@ export async function runPhpunitCommand({
     autoloadFile: argValue(args, "autoload-file")?.trim() || "/wp-codebox-vendor/autoload.php",
     projectAutoloadFile: argValue(args, "project-autoload-file")?.trim() || "",
     testsDir: argValue(args, "tests-dir")?.trim() || "/wp-codebox-vendor/wp-phpunit/wp-phpunit",
+    testRoot: argValue(args, "test-root")?.trim() || `/wordpress/wp-content/plugins/${pluginSlug}/tests`,
     phpunitXml: argValue(args, "phpunit-xml")?.trim() || `/wordpress/wp-content/plugins/${pluginSlug}/phpunit.xml.dist`,
     selectedTestFile: argValue(args, "test-file")?.trim() || "",
     changedTestFiles: jsonArrayArg(args, "changed-tests-json"),

--- a/tests/phpunit-project-autoload.test.ts
+++ b/tests/phpunit-project-autoload.test.ts
@@ -20,6 +20,10 @@ const recipe = buildWordPressPhpunitRecipe({
   bootstrapMode: "project",
   projectBootstrap: "tests/legacy/bootstrap.php",
   projectAutoloadFile: woocommerceAutoload,
+  cwd: "/home/example/public_html",
+  testRoot: "/home/example/public_html/bin/tests/phpunit",
+  phpunitXml: "/home/example/public_html/bin/tests/phpunit/phpunit.xml.dist",
+  mounts: [{ source: "/workspace/project-tests", target: "/home/example/public_html/bin/tests", mode: "readonly" }],
 })
 
 assert.deepEqual(recipe.inputs.extra_plugins, [{
@@ -33,17 +37,24 @@ assert.deepEqual(recipe.inputs.extra_plugins, [{
 
 assert.equal(recipeExtraPluginSourceSubpath(recipe.inputs.extra_plugins[0], "/tmp"), "plugins/woocommerce")
 assert.equal(recipePolicy(recipe).commands.includes("wordpress.run-php"), true)
+assert.deepEqual(recipe.inputs.mounts?.filter((mount) => mount.target === "/home/example/public_html/bin/tests"), [
+  { source: "/workspace/project-tests", target: "/home/example/public_html/bin/tests", mode: "readonly" },
+])
 
 assert.deepEqual(recipe.workflow.steps[0].args.filter((arg) => arg.includes("autoload-file=")), [
   "autoload-file=/wp-codebox-vendor/autoload.php",
   `project-autoload-file=${woocommerceAutoload}`,
 ])
+assert.ok(recipe.workflow.steps[0].args.includes("cwd=/home/example/public_html"))
+assert.ok(recipe.workflow.steps[0].args.includes("test-root=/home/example/public_html/bin/tests/phpunit"))
+assert.ok(recipe.workflow.steps[0].args.includes("phpunit-xml=/home/example/public_html/bin/tests/phpunit/phpunit.xml.dist"))
 
 const projectModeCode = phpunitRunCode({
   pluginSlug: "woocommerce",
   cwd: "/wordpress/wp-content/plugins/woocommerce",
   autoloadFile: woocommerceAutoload,
   testsDir: "/wp-codebox-vendor/wp-phpunit/wp-phpunit",
+  testRoot: "/home/example/public_html/bin/tests/phpunit",
   phpunitXml: "/wordpress/wp-content/plugins/woocommerce/phpunit.xml.dist",
   selectedTestFile: "",
   changedTestFiles: [],
@@ -66,6 +77,8 @@ assert.ok(projectAutoloadIndex > projectBootstrapIndex)
 assert.ok(projectModeCode.includes("'autoload_required' => $bootstrap_mode !== 'project'"))
 assert.ok(projectModeCode.includes("$legacy_project_autoload_file = $autoload_file"))
 assert.ok(projectModeCode.includes("NOTICE:project bootstrap mode continuing without readable PHPUnit harness autoload"))
+assert.ok(projectModeCode.includes("$test_root = \"/home/example/public_html/bin/tests/phpunit\";"))
+assert.ok(projectModeCode.includes("pg_resolve_test_root"))
 
 const managedModeCode = phpunitRunCode({
   pluginSlug: "demo-plugin",


### PR DESCRIPTION
## Summary
- add `test-root` and `phpunit-xml` support to the `wordpress.phpunit` recipe builder/command path
- allow explicit sandbox PHPUnit cwd/test roots for monorepo-style WordPress test profiles
- keep default plugin `/tests` behavior unchanged when custom paths are not supplied

## Testing
- `npx tsx tests/phpunit-project-autoload.test.ts`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Drafting and applying the implementation, focused verification, and PR preparation.