### PR TITLE
Materialize recipe input mounts before workflow commands

### DIFF
--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -1,7 +1,7 @@
 import { cp, mkdtemp, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
-import { phpRuntimeRecipePluginPreloadFunction, type ExecutionResult, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe } from "@automattic/wp-codebox-core"
+import { phpRuntimeRecipePluginPreloadFunction, type ExecutionResult, type MountSpec, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe } from "@automattic/wp-codebox-core"
 import { installMuPluginsCode, installPluginComposerAutoloadersCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspacePreloads, prepareRecipeWorkspaces, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { pluginRuntimeHealthProbeStep, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { pluginRuntimeHealthProbeStepIndex, pluginRuntimeSetupStepIndex } from "../recipe-dry-run.js"
@@ -153,16 +153,19 @@ export async function applyRecipeRuntimeSetup(args: {
     interruption?.throwIfInterrupted()
   }
 
+  const inputMounts: MountSpec[] = []
   for (const mount of recipe.inputs?.mounts ?? []) {
     const source = resolve(recipeDirectory, mount.source)
     const metadata = await inputMountMetadataWithBaseline(source, mount, inputMountBaselinePaths)
-    await awaitRecipe(`input.mount:${mount.target}`, runtime.mount({
+    const inputMount: MountSpec = {
       type: await recipeMountType(source, mount.type),
       source,
       target: mount.target,
       mode: mount.mode ?? "readwrite",
       metadata,
-    }))
+    }
+    inputMounts.push(inputMount)
+    await awaitRecipe(`input.mount:${mount.target}`, runtime.mount(inputMount))
     interruption?.throwIfInterrupted()
   }
 
@@ -177,16 +180,19 @@ export async function applyRecipeRuntimeSetup(args: {
     interruption?.throwIfInterrupted()
   }
 
-  const canMaterializeStagedInputs = typeof runtime.materializeStagedInputs === "function" || typeof runtime.materializeMounts === "function"
-  if (stagedFiles.length > 0 && canMaterializeStagedInputs) {
-    const stagedMounts = stagedFiles.map((stagedFile) => ({
+  const materializableMounts: MountSpec[] = [
+    ...inputMounts,
+    ...stagedFiles.map((stagedFile) => ({
       type: stagedFile.type,
       source: stagedFile.source,
       target: stagedFile.target,
       mode: "readwrite" as const,
       metadata: stagedFile.metadata,
-    }))
-    await awaitRecipe("staged-file.materialize", () => runtime.materializeStagedInputs ? runtime.materializeStagedInputs(stagedMounts) : runtime.materializeMounts!(stagedMounts))
+    })),
+  ]
+  const canMaterializeStagedInputs = typeof runtime.materializeStagedInputs === "function" || typeof runtime.materializeMounts === "function"
+  if (materializableMounts.length > 0 && canMaterializeStagedInputs) {
+    await awaitRecipe("input.materialize", () => runtime.materializeStagedInputs ? runtime.materializeStagedInputs(materializableMounts) : runtime.materializeMounts!(materializableMounts))
     interruption?.throwIfInterrupted()
   }
 

--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -282,25 +282,34 @@ async function hostMountFilesForVfs(mount: MountSpec): Promise<{ files: HostMoun
 
 async function hostMountDirectoryFiles(directory: string, relativeDirectory = ""): Promise<Array<{ relativePath: string; contentsBase64: string }>> {
   const files: Array<{ relativePath: string; contentsBase64: string }> = []
-  let entries
-  try {
-    entries = await readdir(join(directory, relativeDirectory), { withFileTypes: true })
-  } catch {
-    return files
+  const pending = [relativeDirectory]
+
+  while (pending.length > 0) {
+    const currentDirectory = pending.pop() ?? ""
+    let entries
+    try {
+      entries = await readdir(join(directory, currentDirectory), { withFileTypes: true })
+    } catch {
+      continue
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory() && SKIPPED_CAPTURE_DIRECTORIES.has(entry.name)) {
+        continue
+      }
+      const relativePath = currentDirectory ? `${currentDirectory}/${entry.name}` : entry.name
+      const absolutePath = join(directory, relativePath)
+      if (entry.isDirectory()) {
+        pending.push(relativePath)
+        continue
+      }
+      if (!entry.isFile()) {
+        continue
+      }
+      files.push({ relativePath, contentsBase64: (await readFile(absolutePath)).toString("base64") })
+    }
   }
 
-  for (const entry of entries) {
-    const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
-    const absolutePath = join(directory, relativePath)
-    if (entry.isDirectory()) {
-      files.push(...await hostMountDirectoryFiles(directory, relativePath))
-      continue
-    }
-    if (!entry.isFile()) {
-      continue
-    }
-    files.push({ relativePath, contentsBase64: (await readFile(absolutePath)).toString("base64") })
-  }
   return files
 }
 

--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -78,7 +78,9 @@ export async function materializePlaygroundStagedInputs(server: PlaygroundCliSer
   let skipped = 0
   for (const mount of mounts) {
     const collected = await hostMountFilesForVfs(mount)
-    files.push(...collected.files)
+    for (const file of collected.files) {
+      files.push(file)
+    }
     skipped += collected.skipped
   }
   if (files.length === 0) {

--- a/tests/mount-materialization.test.ts
+++ b/tests/mount-materialization.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { materializePlaygroundStagedInputs } from "../packages/runtime-playground/src/mount-materialization.js"
+
+const source = await mkdtemp(join(tmpdir(), "wp-codebox-mount-materialization-"))
+const writes: Record<string, string> = {}
+
+try {
+  await mkdir(join(source, "src"), { recursive: true })
+  await mkdir(join(source, "node_modules", "large-package"), { recursive: true })
+  await writeFile(join(source, "src", "example.php"), "<?php echo 'ok';")
+  await writeFile(join(source, "node_modules", "large-package", "ignored.php"), "<?php echo 'ignored';")
+
+  const result = await materializePlaygroundStagedInputs({
+    playground: {
+      async run() { return { text: JSON.stringify({ created: 1, skipped: 0 }) } },
+      async writeFile(target: string, contents: string) { writes[target] = contents },
+    },
+  } as never, [{
+    type: "directory",
+    source,
+    target: "/wordpress/project",
+    mode: "readwrite",
+  }])
+
+  assert.equal(result.materialized, 1)
+  assert.deepEqual(Object.keys(writes), ["/wordpress/project/src/example.php"])
+  assert.equal(writes["/wordpress/project/src/example.php"], "<?php echo 'ok';")
+} finally {
+  await rm(source, { recursive: true, force: true })
+}
+
+console.log("mount materialization ok")

--- a/tests/recipe-runtime-setup-staged-materialization.test.ts
+++ b/tests/recipe-runtime-setup-staged-materialization.test.ts
@@ -1,13 +1,24 @@
 import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import { applyRecipeRuntimeSetup, type PreparedRecipeRuntimeSetup } from "../packages/cli/src/commands/recipe-runtime-setup.js"
 import type { Runtime, WorkspaceRecipe } from "../packages/runtime-core/src/public.js"
 
 const calls: string[] = []
+const inputMountSource = await mkdtemp(join(tmpdir(), "wp-codebox-input-mount-test-"))
+await writeFile(join(inputMountSource, "phpunit.xml"), "<phpunit />")
 const recipe: WorkspaceRecipe = {
   schema: "wp-codebox/workspace-recipe/v1",
   runtime: { backend: "wordpress-playground" },
-  inputs: {},
+  inputs: {
+    mounts: [{
+      source: inputMountSource,
+      target: "/home/example/public_html/bin/tests",
+      mode: "readonly",
+    }],
+  },
   workflow: { steps: [] },
 }
 const prepared: PreparedRecipeRuntimeSetup = {
@@ -34,13 +45,22 @@ const runtime = {
   async materializeStagedInputs(mounts) {
     assert.equal(this, runtime, "setup calls staged input materializer with runtime binding")
     calls.push(`materialize:${mounts.map((mount) => mount.target).join(",")}`)
-    assert.deepEqual(mounts, [{
-      type: "directory",
-      source: "/tmp/host-bundle",
-      target: "/workspace/example/bundles/runtime-agent",
-      mode: "readwrite",
-      metadata: { kind: "runtime-package-source" },
-    }])
+    assert.deepEqual(mounts, [
+      {
+        type: "directory",
+        source: inputMountSource,
+        target: "/home/example/public_html/bin/tests",
+        mode: "readonly",
+        metadata: undefined,
+      },
+      {
+        type: "directory",
+        source: "/tmp/host-bundle",
+        target: "/workspace/example/bundles/runtime-agent",
+        mode: "readwrite",
+        metadata: { kind: "runtime-package-source" },
+      },
+    ])
   },
   async materializeMounts() { throw new Error("setup should use materializeStagedInputs when available") },
   async execute(spec) { calls.push(`execute:${spec.command}`); throw new Error("setup should not execute commands in this fixture") },
@@ -62,12 +82,19 @@ const phaseExecutor = {
   },
 }
 
-await applyRecipeRuntimeSetup({ recipe, recipeDirectory: process.cwd(), runtime, prepared, phaseExecutor: phaseExecutor as never })
+try {
+  await applyRecipeRuntimeSetup({ recipe, recipeDirectory: process.cwd(), runtime, prepared, phaseExecutor: phaseExecutor as never })
+} finally {
+  await rm(inputMountSource, { recursive: true, force: true })
+}
 
 const mountIndex = calls.indexOf("mount:/workspace/example/bundles/runtime-agent")
-const materializeOperationIndex = calls.indexOf("operation:staged-file.materialize")
-const materializeIndex = calls.indexOf("materialize:/workspace/example/bundles/runtime-agent")
+const inputMountIndex = calls.indexOf("mount:/home/example/public_html/bin/tests")
+const materializeOperationIndex = calls.indexOf("operation:input.materialize")
+const materializeIndex = calls.indexOf("materialize:/home/example/public_html/bin/tests,/workspace/example/bundles/runtime-agent")
+assert.ok(inputMountIndex >= 0, "input source is mounted")
 assert.ok(mountIndex >= 0, "staged source is mounted")
+assert.ok(materializeOperationIndex > inputMountIndex, "materialization is scheduled after input mount")
 assert.ok(materializeOperationIndex > mountIndex, "materialization is scheduled after staged mount")
 assert.ok(materializeIndex > materializeOperationIndex, "materialization runs inside the setup phase before commands")
 assert.equal(calls.some((call) => call.startsWith("execute:")), false)


### PR DESCRIPTION
## Summary
- Materializes generic recipe input mounts through the Playground VFS materialization hook before workflow commands run.
- Keeps staged file materialization in the same setup phase so custom PHPUnit roots from mounted inputs are readable before execution.
- Avoids recursive host mount walks and skips large/cache directories while materializing directory mounts into Playground.
- Extends regression coverage for both generic input mounts and skipped directory materialization.

## Testing
- npx tsx tests/mount-materialization.test.ts
- npm run test:recipe-runtime-setup-staged-materialization
- npm run build -- --pretty false

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Debugging the input mount materialization gap, implementing the fix, and drafting regression tests.