### PR TITLE
Verify staged mount target directories

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -36,6 +36,14 @@ interface HostMountFilePayload {
   contentsBase64: string
 }
 
+interface HostMountDirectoryMaterializationResponse {
+  created?: number
+  skipped?: number
+  missing?: string[]
+  unreadable?: string[]
+  unresolved?: string[]
+}
+
 const HOST_MOUNT_FILE_BATCH_SIZE = 100
 const HOST_MOUNT_DIRECTORY_BATCH_SIZE = 500
 
@@ -188,7 +196,15 @@ async function createHostMountDirectories(server: PlaygroundCliServer, directori
     return { created: 0, skipped: 0 }
   }
   const response = await server.playground.run({ code: hostMountMkdirPhp(directories) })
-  const parsed = JSON.parse(response.text || "{}") as { created?: number; skipped?: number }
+  const parsed = JSON.parse(response.text || "{}") as HostMountDirectoryMaterializationResponse
+  const failures = [
+    ...(parsed.missing ?? []).map((path) => `${path} (missing)`),
+    ...(parsed.unreadable ?? []).map((path) => `${path} (unreadable)`),
+    ...(parsed.unresolved ?? []).map((path) => `${path} (unresolved)`),
+  ]
+  if (failures.length > 0) {
+    throw new Error(`Staged input mount target directories are not readable in the sandbox after materialization: ${failures.slice(0, 10).join(", ")}${failures.length > 10 ? `, and ${failures.length - 10} more` : ""}`)
+  }
   return {
     created: parsed.created ?? 0,
     skipped: parsed.skipped ?? 0,
@@ -408,6 +424,9 @@ function hostMountMkdirPhp(directories: string[]): string {
 $payload = json_decode(${payload}, true);
 $created = 0;
 $skipped = 0;
+$missing = array();
+$unreadable = array();
+$unresolved = array();
 foreach (($payload['directories'] ?? array()) as $directory) {
     $directory = (string) $directory;
     if ('' === $directory || str_contains($directory, "\0")) {
@@ -420,7 +439,24 @@ foreach (($payload['directories'] ?? array()) as $directory) {
     }
     $skipped++;
 }
-echo json_encode(array('schema' => 'wp-codebox/host-mount-directory-materialization/v1', 'created' => $created, 'skipped' => $skipped), JSON_UNESCAPED_SLASHES);
+foreach (($payload['directories'] ?? array()) as $directory) {
+    $directory = (string) $directory;
+    if ('' === $directory || str_contains($directory, "\0")) {
+        continue;
+    }
+    if (!is_dir($directory)) {
+        $missing[] = $directory;
+        continue;
+    }
+    if (!is_readable($directory)) {
+        $unreadable[] = $directory;
+        continue;
+    }
+    if (false === realpath($directory)) {
+        $unresolved[] = $directory;
+    }
+}
+echo json_encode(array('schema' => 'wp-codebox/host-mount-directory-materialization/v1', 'created' => $created, 'skipped' => $skipped, 'missing' => $missing, 'unreadable' => $unreadable, 'unresolved' => $unresolved), JSON_UNESCAPED_SLASHES);
 `
 }
 

--- a/tests/mount-materialization.test.ts
+++ b/tests/mount-materialization.test.ts
@@ -108,6 +108,41 @@ try {
   await rm(fallbackSource, { recursive: true, force: true })
 }
 
+const unreadableTargetSource = await mkdtemp(join(tmpdir(), "wp-codebox-unreadable-target-"))
+
+try {
+  await mkdir(join(unreadableTargetSource, "bin", "tests", "i18n-tools"), { recursive: true })
+  await writeFile(join(unreadableTargetSource, "bin", "tests", "i18n-tools", "phpunit.xml"), "<phpunit />")
+
+  await assert.rejects(
+    materializePlaygroundStagedInputs({
+      playground: {
+        async run({ code }: { code: string }) {
+          const payload = materializationPayload(code)
+          return {
+            text: JSON.stringify({
+              created: payload.directories?.length ?? 0,
+              skipped: 0,
+              missing: ["/home/example/public_html/bin/tests/i18n-tools"],
+            }),
+          }
+        },
+        async writeFile() {
+          throw new Error("files should not be written when directory verification fails")
+        },
+      },
+    } as never, [{
+      type: "directory",
+      source: unreadableTargetSource,
+      target: "/home/example/public_html",
+      mode: "readwrite",
+    }]),
+    /Staged input mount target directories are not readable in the sandbox after materialization: \/home\/example\/public_html\/bin\/tests\/i18n-tools \(missing\)/,
+  )
+} finally {
+  await rm(unreadableTargetSource, { recursive: true, force: true })
+}
+
 function materializationPayload(code: string): { directories?: string[]; files?: Array<{ target: string; contentsBase64: string }> } {
   const match = code.match(/\$payload = json_decode\((.*), true\);/)
   assert.ok(match, "materialization PHP includes a JSON payload")


### PR DESCRIPTION
## Summary
- Verify each staged mount directory batch is visible, readable, and resolvable in the Playground sandbox after mkdir materialization.
- Fail input materialization with a clear target-directory error before workflow commands run when a sandbox target subtree is missing/unreadable.
- Add regression coverage for the missing nested cwd-style subtree failure.

## Testing
- `npx tsx tests/mount-materialization.test.ts`
- `npx tsx tests/staged-input-materialization.test.ts`
- `npm run test:recipe-runtime-setup-staged-materialization`
- `npm run build -- --pretty false`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the staged mount materialization contract gap, implemented the target-directory verification fix, added regression coverage, and ran focused validation.