### PR TITLE
Verify staged mount materialization PHP results

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { materializationPhaseResult, namedFileTreeSkipPolicyNames, phpStringArrayLiteral, type MaterializationPhaseResult, type MountSpec } from "@automattic/wp-codebox-core"
 import type { PlaygroundCliServer } from "./preview-server.js"
 import { SKIPPED_CAPTURE_DIRECTORIES } from "./artifacts.js"
+import { assertPlaygroundResponseOk, errorMessage } from "./playground-command-errors.js"
 
 export interface HostMountSnapshot {
   mountIndex: number
@@ -37,11 +38,19 @@ interface HostMountFilePayload {
 }
 
 interface HostMountDirectoryMaterializationResponse {
+  schema?: string
   created?: number
   skipped?: number
   missing?: string[]
   unreadable?: string[]
   unresolved?: string[]
+}
+
+interface HostMountFileMaterializationResponse {
+  schema?: string
+  materialized?: number
+  created?: number
+  skipped?: number
 }
 
 const HOST_MOUNT_FILE_BATCH_SIZE = 100
@@ -196,7 +205,8 @@ async function createHostMountDirectories(server: PlaygroundCliServer, directori
     return { created: 0, skipped: 0 }
   }
   const response = await server.playground.run({ code: hostMountMkdirPhp(directories) })
-  const parsed = JSON.parse(response.text || "{}") as HostMountDirectoryMaterializationResponse
+  assertPlaygroundResponseOk("playground-staged-input-mkdir", response)
+  const parsed = parseMaterializationJson<HostMountDirectoryMaterializationResponse>(response.text, "wp-codebox/host-mount-directory-materialization/v1", "playground-staged-input-mkdir")
   const failures = [
     ...(parsed.missing ?? []).map((path) => `${path} (missing)`),
     ...(parsed.unreadable ?? []).map((path) => `${path} (unreadable)`),
@@ -273,12 +283,26 @@ async function* hostMountEntriesForVfs(mount: MountSpec): AsyncGenerator<HostMou
 
 async function materializeHostMountFilesWithPhp(server: PlaygroundCliServer, files: HostMountFilePayload[], directories: string[]): Promise<{ materialized: number; created: number; skipped: number }> {
   const response = await server.playground.run({ code: hostMountWritePhp(files, directories) })
-  const parsed = JSON.parse(response.text || "{}") as { materialized?: number; created?: number; skipped?: number }
+  assertPlaygroundResponseOk("playground-staged-input-write", response)
+  const parsed = parseMaterializationJson<HostMountFileMaterializationResponse>(response.text, "wp-codebox/host-mount-materialization/v1", "playground-staged-input-write")
   return {
     materialized: parsed.materialized ?? 0,
     created: parsed.created ?? 0,
     skipped: parsed.skipped ?? 0,
   }
+}
+
+function parseMaterializationJson<T extends { schema?: string }>(text: string, schema: string, command: string): T {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text || "{}")
+  } catch (error) {
+    throw new Error(`${command} returned invalid JSON: ${errorMessage(error)}`)
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || (parsed as { schema?: unknown }).schema !== schema) {
+    throw new Error(`${command} did not return ${schema}; received ${text.trim() || "empty response"}`)
+  }
+  return parsed as T
 }
 
 export async function applyVfsMountSnapshots(mounts: MountSpec[], snapshots: VfsMountSnapshot[]): Promise<MountMaterializationResult> {

--- a/packages/runtime-playground/src/programmatic-playground-runner.ts
+++ b/packages/runtime-playground/src/programmatic-playground-runner.ts
@@ -150,7 +150,11 @@ async function mountHostDirectory(php: ProgrammaticPHP, vfsPath: string, hostPat
 
 function ensureVfsParentDirectory(php: ProgrammaticPHP, vfsPath: string): void {
   const parent = dirname(vfsPath.replace(/\/+$/, ""))
-  if (parent && parent !== "." && parent !== "/" && !php.fileExists(parent)) {
+  if (!parent || parent === "." || parent === "/" || php.fileExists(parent)) {
+    return
+  }
+  ensureVfsParentDirectory(php, parent)
+  if (!php.fileExists(parent)) {
     php.mkdir(parent)
   }
 }

--- a/tests/mount-materialization.test.ts
+++ b/tests/mount-materialization.test.ts
@@ -16,7 +16,7 @@ try {
 
   const result = await materializePlaygroundStagedInputs({
     playground: {
-      async run() { return { text: JSON.stringify({ created: 1, skipped: 0 }) } },
+      async run() { return { text: JSON.stringify({ schema: "wp-codebox/host-mount-directory-materialization/v1", created: 1, skipped: 0 }) } },
       async writeFile(target: string, contents: string) { writes[target] = contents },
     },
   } as never, [{
@@ -48,7 +48,7 @@ try {
         for (const directory of payload.directories ?? []) {
           readableDirectories.add(directory)
         }
-        return { text: JSON.stringify({ created: payload.directories?.length ?? 0, skipped: 0 }) }
+        return { text: JSON.stringify({ schema: "wp-codebox/host-mount-directory-materialization/v1", created: payload.directories?.length ?? 0, skipped: 0 }) }
       },
       async writeFile(target: string, contents: string) {
         if (!readableDirectories.has(dirname(target))) {
@@ -89,9 +89,9 @@ try {
         const payload = materializationPayload(code)
         if (code.includes("wp-codebox/host-mount-materialization/v1")) {
           fallbackFileBatches.push(payload.files?.length ?? 0)
-          return { text: JSON.stringify({ materialized: payload.files?.length ?? 0, skipped: 0 }) }
+          return { text: JSON.stringify({ schema: "wp-codebox/host-mount-materialization/v1", materialized: payload.files?.length ?? 0, skipped: 0 }) }
         }
-        return { text: JSON.stringify({ created: payload.directories?.length ?? 0, skipped: 0 }) }
+        return { text: JSON.stringify({ schema: "wp-codebox/host-mount-directory-materialization/v1", created: payload.directories?.length ?? 0, skipped: 0 }) }
       },
     },
   } as never, [{
@@ -121,6 +121,7 @@ try {
           const payload = materializationPayload(code)
           return {
             text: JSON.stringify({
+              schema: "wp-codebox/host-mount-directory-materialization/v1",
               created: payload.directories?.length ?? 0,
               skipped: 0,
               missing: ["/home/example/public_html/bin/tests/i18n-tools"],
@@ -141,6 +142,60 @@ try {
   )
 } finally {
   await rm(unreadableTargetSource, { recursive: true, force: true })
+}
+
+const failedVerificationSource = await mkdtemp(join(tmpdir(), "wp-codebox-failed-directory-verification-"))
+
+try {
+  await mkdir(join(failedVerificationSource, "bin", "tests", "i18n-tools"), { recursive: true })
+
+  await assert.rejects(
+    materializePlaygroundStagedInputs({
+      playground: {
+        async run() {
+          return { exitCode: 1, errors: "mkdir failed", text: "" }
+        },
+        async writeFile() {
+          throw new Error("files should not be written when directory verification exits non-zero")
+        },
+      },
+    } as never, [{
+      type: "directory",
+      source: failedVerificationSource,
+      target: "/home/example/public_html",
+      mode: "readwrite",
+    }]),
+    /playground-staged-input-mkdir failed with exit code 1/,
+  )
+} finally {
+  await rm(failedVerificationSource, { recursive: true, force: true })
+}
+
+const malformedVerificationSource = await mkdtemp(join(tmpdir(), "wp-codebox-malformed-directory-verification-"))
+
+try {
+  await mkdir(join(malformedVerificationSource, "bin", "tests", "i18n-tools"), { recursive: true })
+
+  await assert.rejects(
+    materializePlaygroundStagedInputs({
+      playground: {
+        async run() {
+          return { text: "" }
+        },
+        async writeFile() {
+          throw new Error("files should not be written when directory verification omits its schema")
+        },
+      },
+    } as never, [{
+      type: "directory",
+      source: malformedVerificationSource,
+      target: "/home/example/public_html",
+      mode: "readwrite",
+    }]),
+    /playground-staged-input-mkdir did not return wp-codebox\/host-mount-directory-materialization\/v1/,
+  )
+} finally {
+  await rm(malformedVerificationSource, { recursive: true, force: true })
 }
 
 function materializationPayload(code: string): { directories?: string[]; files?: Array<{ target: string; contentsBase64: string }> } {

--- a/tests/staged-input-materialization.test.ts
+++ b/tests/staged-input-materialization.test.ts
@@ -15,7 +15,7 @@ await withTempDir("wp-codebox-staged-input-materialization-", async (root) => {
   const server = {
     playground: {
       async run() {
-        return { text: JSON.stringify({ created: 2, skipped: 0 }) }
+        return { text: JSON.stringify({ schema: "wp-codebox/host-mount-directory-materialization/v1", created: 2, skipped: 0 }) }
       },
       async writeFile(path: string, contents: string) {
         written.set(path, contents)
@@ -52,9 +52,9 @@ await withTempDir("wp-codebox-staged-input-materialization-fallback-", async (ro
       async run({ code }: { code: string }) {
         if (code.includes("wp-codebox/host-mount-materialization/v1")) {
           fallbackWrites++
-          return { text: JSON.stringify({ materialized: 1, skipped: 0 }) }
+          return { text: JSON.stringify({ schema: "wp-codebox/host-mount-materialization/v1", materialized: 1, skipped: 0 }) }
         }
-        return { text: JSON.stringify({ created: 1, skipped: 0 }) }
+        return { text: JSON.stringify({ schema: "wp-codebox/host-mount-directory-materialization/v1", created: 1, skipped: 0 }) }
       },
       async writeFile(path: string, contents: string) {
         if (path.endsWith("/flows/store.json")) {


### PR DESCRIPTION
## Summary
- Create programmatic Playground mount parent directories recursively before mounting arbitrary absolute VFS targets.
- Treat staged input materialization PHP mkdir/write snippets as failed when Playground returns a non-zero exit or omits the expected schema.
- Update focused materialization tests to cover nested absolute targets and failed/malformed verification responses.

## Testing
- npx tsx tests/mount-materialization.test.ts
- npx tsx tests/staged-input-materialization.test.ts
- npm run test:recipe-runtime-setup-staged-materialization
- npm run build -- --pretty false

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the staged mount materialization/runtime cwd path handling, implemented the fix, added tests, and ran focused verification.