### PR TITLE
Canonicalize recipe input mount paths

### DIFF
--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -8,6 +8,7 @@ import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.
 import { executeAgentFanoutFromArgs } from "../agent-fanout.js"
 import { recipeWorkflowSteps, type RecipeWorkflowPhase } from "../recipe-validation.js"
 import { artifactManifestFilesByPath } from "./recipe-run-benchmark-artifacts.js"
+import { rewriteInputMountPathArgs, type InputMountPathMapping } from "./recipe-runtime-setup.js"
 import { serializeRecipeRunError } from "./recipe-run-output.js"
 import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe } from "./recipe-run-types.js"
 
@@ -130,11 +131,13 @@ function recipeCommandProducesBrowserEvidence(command: string): boolean {
   return command.startsWith("wordpress.browser-") || command === "wordpress.editor-canvas-probe" || command === "wordpress.html-capture"
 }
 
-export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, artifactRoot?: string, options?: RecipeRunOptions): Promise<RecipeExecutionResult> {
+export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, artifactRoot?: string, options?: RecipeRunOptions, inputMountPathMap: readonly InputMountPathMapping[] = []): Promise<RecipeExecutionResult> {
+  const step = { ...workflowStep.step, args: rewriteInputMountPathArgs(workflowStep.step.args ?? [], inputMountPathMap) }
+  const mappedWorkflowStep = { ...workflowStep, step }
   try {
-    if (workflowStep.step.command === "wp-codebox.agent-fanout") {
+    if (step.command === "wp-codebox.agent-fanout") {
       const startedAt = new Date().toISOString()
-      const result = await executeAgentFanoutFromArgs(workflowStep.step.args ?? [], {
+      const result = await executeAgentFanoutFromArgs(step.args ?? [], {
         artifactRoot: artifactRoot || recipeDirectory,
         recipeDirectory,
         previewHoldSeconds: options?.previewHoldSeconds === undefined ? "" : String(options.previewHoldSeconds),
@@ -147,32 +150,32 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
       return {
         ...withRecipeExecutionPhase({
           id: `agent-fanout-${workflowStep.index}`,
-          command: workflowStep.step.command,
-          args: workflowStep.step.args ?? [],
+          command: step.command,
+          args: step.args ?? [],
           exitCode: result.success ? 0 : 1,
           stdout: `${JSON.stringify(result, null, 2)}\n`,
           stderr: "",
           startedAt,
           finishedAt,
-        }, workflowStep.phase, workflowStep.index, workflowStep.step.command),
+        }, workflowStep.phase, workflowStep.index, step.command),
         ...(workflowStep.fuzzCaseId ? { fuzzCaseId: workflowStep.fuzzCaseId } : {}),
         ...(workflowStep.fuzzCaseIndex !== undefined ? { fuzzCaseIndex: workflowStep.fuzzCaseIndex } : {}),
         ...(workflowStep.fuzzPhase ? { fuzzPhase: workflowStep.fuzzPhase } : {}),
         ...(workflowStep.fuzzStepIndex !== undefined ? { fuzzStepIndex: workflowStep.fuzzStepIndex } : {}),
       }
     }
-    if (isRuntimeCheckpointRecipeCommand(workflowStep.step.command)) {
-      return withRecipeExecutionPhase(await executeRuntimeCheckpointRecipeCommand(runtime, workflowStep.step.command, workflowStep.step.args ?? []), workflowStep.phase, workflowStep.index, workflowStep.step.command)
+    if (isRuntimeCheckpointRecipeCommand(step.command)) {
+      return withRecipeExecutionPhase(await executeRuntimeCheckpointRecipeCommand(runtime, step.command, step.args ?? []), workflowStep.phase, workflowStep.index, step.command)
     }
-    if (workflowStep.step.command === "wp-codebox/run-fuzz-suite") {
-      return withRecipeExecutionPhase(await executeRunFuzzSuiteRecipeCommand(runtime, workflowStep.step.args ?? [], recipeDirectory, sandboxWorkspace), workflowStep.phase, workflowStep.index, workflowStep.step.command)
+    if (step.command === "wp-codebox/run-fuzz-suite") {
+      return withRecipeExecutionPhase(await executeRunFuzzSuiteRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, inputMountPathMap), workflowStep.phase, workflowStep.index, step.command)
     }
-    if (workflowStep.step.command === "wordpress.run-workload" && commandArgValue(workflowStep.step.args ?? [], "workload-json")) {
-      return withRecipeExecutionPhase(await executeWordPressRunWorkloadJsonRecipeCommand(runtime, workflowStep.step.args ?? [], recipeDirectory, sandboxWorkspace), workflowStep.phase, workflowStep.index, workflowStep.step.command)
+    if (step.command === "wordpress.run-workload" && commandArgValue(step.args ?? [], "workload-json")) {
+      return withRecipeExecutionPhase(await executeWordPressRunWorkloadJsonRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap), workflowStep.phase, workflowStep.index, step.command)
     }
-    const execution = await runtime.execute(await recipeExecutionSpec(workflowStep.step, recipeDirectory, sandboxWorkspace))
+    const execution = await runtime.execute(await recipeExecutionSpec(step, recipeDirectory, sandboxWorkspace))
     return {
-      ...withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, workflowStep.step.command),
+      ...withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, step.command),
       ...(workflowStep.fuzzCaseId ? { fuzzCaseId: workflowStep.fuzzCaseId } : {}),
       ...(workflowStep.fuzzCaseIndex !== undefined ? { fuzzCaseIndex: workflowStep.fuzzCaseIndex } : {}),
       ...(workflowStep.fuzzPhase ? { fuzzPhase: workflowStep.fuzzPhase } : {}),
@@ -180,11 +183,11 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`Recipe workflow ${workflowStep.phase}[${workflowStep.index}] failed: ${message}`, { cause: error })
+    throw new Error(`Recipe workflow ${mappedWorkflowStep.phase}[${mappedWorkflowStep.index}] failed: ${message}`, { cause: error })
   }
 }
 
-async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, suite?: FuzzSuiteContract, fuzzCase?: unknown): Promise<ExecutionResult> {
+async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, suite?: FuzzSuiteContract, fuzzCase?: unknown, inputMountPathMap: readonly InputMountPathMapping[] = []): Promise<ExecutionResult> {
   const startedAt = new Date().toISOString()
   const workloadJson = commandArgValue(args, "workload-json")
   if (!workloadJson) {
@@ -194,7 +197,7 @@ async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, ar
   const steps = [...workflowStepsFromWorkloadPhase(workload.before, workload, suite, fuzzCase), ...workflowStepsFromWorkloadPhase(workload.steps, workload, suite, fuzzCase), ...workflowStepsFromWorkloadPhase(workload.after, workload, suite, fuzzCase)]
   const executions: ExecutionResult[] = []
   for (const [index, step] of steps.entries()) {
-    const execution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index, step }, recipeDirectory, sandboxWorkspace)
+    const execution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index, step }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap)
     executions.push(execution)
     if (execution.exitCode !== 0 && !step.allowFailure && !step.advisory) {
       break
@@ -216,15 +219,15 @@ async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, ar
   }
 }
 
-async function executeRunFuzzSuiteRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>): Promise<ExecutionResult> {
+async function executeRunFuzzSuiteRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, inputMountPathMap: readonly InputMountPathMapping[] = []): Promise<ExecutionResult> {
   const startedAt = new Date().toISOString()
   const suite = await fuzzSuiteFromRecipeCommandArgs(args, recipeDirectory)
   const result = await runFuzzSuite(suite, {
     runnerCapabilities: RUNTIME_BACKED_FUZZ_SUITE_RUNNER_CAPABILITIES,
-    executor: async (spec) => executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: workflowStepFromExecutionSpec(spec) }, recipeDirectory, sandboxWorkspace),
+    executor: async (spec) => executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: workflowStepFromExecutionSpec(spec) }, recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap),
     runtimeWorkloadExecutor: async ({ suite, workload, case: fuzzCase }) => {
       const workloadJson = JSON.stringify(workload)
-      const execution = await executeWordPressRunWorkloadJsonRecipeCommand(runtime, [`workload-json=${workloadJson}`], recipeDirectory, sandboxWorkspace, suite, fuzzCase)
+      const execution = await executeWordPressRunWorkloadJsonRecipeCommand(runtime, [`workload-json=${workloadJson}`], recipeDirectory, sandboxWorkspace, suite, fuzzCase, inputMountPathMap)
       const parsed = parseCommandJsonObject(execution.stdout, "wordpress.run-workload stdout")
       return {
         ...execution,

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -136,6 +136,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   let stagedFiles: PreparedStagedFile[] = []
   let overlays: PreparedRuntimeOverlay[] = []
   let inputMountBaselinePaths: string[] = []
+  let inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]> = []
   let backendPackage: PreparedRuntimeBackendPackage | undefined
   let runtime: Awaited<ReturnType<typeof createRuntime>> | undefined
   const executions: RecipeExecutionResult[] = []
@@ -165,7 +166,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
 
   try {
     const preparedRuntimeSetup = await prepareRecipeRuntimeSetup(recipe, recipeDirectory, plan.runtime.backend)
-    ;({ workspaceMounts, extraPlugins, dependencyOverlays, stagedFiles, overlays, inputMountBaselinePaths, backendPackage } = preparedRuntimeSetup)
+    ;({ workspaceMounts, extraPlugins, dependencyOverlays, stagedFiles, overlays, inputMountBaselinePaths, inputMountPathMap, backendPackage } = preparedRuntimeSetup)
     interruption?.throwIfInterrupted()
 
     runRecord = await runRegistry.update(runRecord.runId, { status: "booting" })
@@ -266,7 +267,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       for (const workflowStep of workflowSteps) {
         const operation = `workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`
         try {
-          const execution = await awaitRecipe(operation, () => executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options))
+          const execution = await awaitRecipe(operation, () => executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options, inputMountPathMap))
           executions.push({ ...execution, ...(recipeWorkflowStepIsAdvisory(workflowStep.step) ? { recipeAdvisory: true } : {}) })
           interruption?.throwIfInterrupted()
         } catch (error) {

--- a/packages/cli/src/commands/recipe-runtime-setup.ts
+++ b/packages/cli/src/commands/recipe-runtime-setup.ts
@@ -1,6 +1,7 @@
+import { createHash } from "node:crypto"
 import { cp, mkdtemp, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { join, posix, resolve } from "node:path"
 import { phpRuntimeRecipePluginPreloadFunction, type ExecutionResult, type MountSpec, type Runtime, type WorkspaceRecipe, type WorkspaceRecipeMount, type WorkspaceRecipePluginRuntimeHealthProbe } from "@automattic/wp-codebox-core"
 import { installMuPluginsCode, installPluginComposerAutoloadersCode, prepareRecipeDependencyOverlays, prepareRecipeExtraPlugins, prepareRecipeRuntimeOverlays, prepareRecipeStagedFiles, prepareRecipeWorkspacePreloads, prepareRecipeWorkspaces, recipeMountType, type PreparedDependencyOverlay, type PreparedExtraPlugin, type PreparedRuntimeOverlay, type PreparedStagedFile, type PreparedWorkspaceMount } from "../recipe-sources.js"
 import { pluginRuntimeHealthProbeStep, type RecipeWorkflowPhase } from "../recipe-validation.js"
@@ -17,7 +18,13 @@ export interface PreparedRecipeRuntimeSetup {
   stagedFiles: PreparedStagedFile[]
   overlays: PreparedRuntimeOverlay[]
   inputMountBaselinePaths: string[]
+  inputMountPathMap: InputMountPathMapping[]
   backendPackage?: PreparedRuntimeBackendPackage
+}
+
+export interface InputMountPathMapping {
+  originalTarget: string
+  canonicalTarget: string
 }
 
 export interface RecipeRuntimeSetupResult {
@@ -37,6 +44,7 @@ export async function prepareRecipeRuntimeSetup(recipe: WorkspaceRecipe, recipeD
     stagedFiles: await prepareRecipeStagedFiles(recipe, recipeDirectory),
     overlays: await prepareRecipeRuntimeOverlaysForRun(recipe, recipeDirectory),
     inputMountBaselinePaths: [],
+    inputMountPathMap: recipeInputMountPathMap(recipe),
     backendPackage: await prepareRecipeRuntimeBackendPackage(recipe, recipeDirectory, runtimeBackend),
   }
 }
@@ -50,7 +58,7 @@ export async function applyRecipeRuntimeSetup(args: {
   interruption?: RecipeInterruptionController
 }): Promise<RecipeRuntimeSetupResult> {
   const { recipe, recipeDirectory, runtime, prepared, phaseExecutor, interruption } = args
-  const { workspaceMounts, extraPlugins, dependencyOverlays, stagedFiles, overlays, inputMountBaselinePaths } = prepared
+  const { workspaceMounts, extraPlugins, dependencyOverlays, stagedFiles, overlays, inputMountBaselinePaths, inputMountPathMap } = prepared
   const executions: RecipeExecutionResult[] = []
   const phaseTracker = phaseExecutor.tracker
   const awaitRecipe = <T>(operation: string, promiseOrFactory: Promise<T> | (() => Promise<T>), timeoutMs?: number): Promise<T> => phaseExecutor.operation(operation, promiseOrFactory, timeoutMs)
@@ -154,13 +162,14 @@ export async function applyRecipeRuntimeSetup(args: {
   }
 
   const inputMounts: MountSpec[] = []
-  for (const mount of recipe.inputs?.mounts ?? []) {
+  for (const [index, mount] of (recipe.inputs?.mounts ?? []).entries()) {
     const source = resolve(recipeDirectory, mount.source)
-    const metadata = await inputMountMetadataWithBaseline(source, mount, inputMountBaselinePaths)
+    const target = inputMountPathMap[index]?.canonicalTarget ?? mount.target
+    const metadata = await inputMountMetadataWithBaseline(source, mount, inputMountBaselinePaths, target)
     const inputMount: MountSpec = {
       type: await recipeMountType(source, mount.type),
       source,
-      target: mount.target,
+      target,
       mode: mount.mode ?? "readwrite",
       metadata,
     }
@@ -276,6 +285,63 @@ export function recipeRunExtraPlugin(plugin: PreparedExtraPlugin): Record<string
     provenance: plugin.provenance,
     metadata: plugin.metadata,
   }
+}
+
+export function recipeInputMountPathMap(recipe: WorkspaceRecipe): InputMountPathMapping[] {
+  return (recipe.inputs?.mounts ?? []).map((mount, index) => ({
+    originalTarget: normalizeSandboxPath(mount.target),
+    canonicalTarget: canonicalInputMountTarget(mount.target, index),
+  }))
+}
+
+export function rewriteInputMountPathArgs(args: readonly string[] = [], mappings: readonly InputMountPathMapping[] = []): string[] {
+  if (mappings.length === 0) {
+    return [...args]
+  }
+  return args.map((arg) => {
+    const separator = arg.indexOf("=")
+    if (separator <= 0) {
+      return arg
+    }
+    const value = arg.slice(separator + 1)
+    if (!value.startsWith("/")) {
+      return arg
+    }
+    const rewritten = rewriteInputMountPath(value, mappings)
+    return rewritten === value ? arg : `${arg.slice(0, separator + 1)}${rewritten}`
+  })
+}
+
+export function rewriteInputMountPath(path: string, mappings: readonly InputMountPathMapping[] = []): string {
+  const normalized = normalizeSandboxPath(path)
+  const match = [...mappings]
+    .sort((a, b) => b.originalTarget.length - a.originalTarget.length)
+    .find((mapping) => pathHasMappedPrefix(normalized, mapping.originalTarget))
+  if (!match) {
+    return path
+  }
+  const suffix = normalized.slice(match.originalTarget.length)
+  return `${match.canonicalTarget}${suffix}`
+}
+
+function canonicalInputMountTarget(target: string, index: number): string {
+  const normalized = normalizeSandboxPath(target)
+  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, 12)
+  const name = safeInputMountTargetName(posix.basename(normalized)) || "mount"
+  return `/tmp/wp-codebox-inputs/${index}-${name}-${hash}`
+}
+
+function safeInputMountTargetName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 48)
+}
+
+function normalizeSandboxPath(path: string): string {
+  const normalized = posix.normalize(path.trim().replace(/\\+/g, "/"))
+  return normalized === "/" ? normalized : normalized.replace(/\/+$/g, "")
+}
+
+function pathHasMappedPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}/`)
 }
 
 async function prepareRecipeRuntimeOverlaysForRun(recipe: WorkspaceRecipe, recipeDirectory: string): Promise<PreparedRuntimeOverlay[]> {
@@ -416,8 +482,14 @@ function distributionRuntimeData(recipe: WorkspaceRecipe): Record<string, unknow
   }
 }
 
-async function inputMountMetadataWithBaseline(source: string, mount: WorkspaceRecipeMount, cleanupPaths: string[]): Promise<Record<string, unknown> | undefined> {
-  const metadata = mount.metadata ? { ...mount.metadata } : {}
+async function inputMountMetadataWithBaseline(source: string, mount: WorkspaceRecipeMount, cleanupPaths: string[], canonicalTarget: string): Promise<Record<string, unknown> | undefined> {
+  const originalTarget = normalizeSandboxPath(mount.target)
+  const metadata: Record<string, unknown> = {
+    ...(mount.metadata ?? {}),
+    originalTarget,
+    canonicalTarget,
+    canonicalizedTarget: canonicalTarget !== originalTarget,
+  }
   if ((mount.mode ?? "readwrite") !== "readwrite") {
     return Object.keys(metadata).length > 0 ? metadata : undefined
   }

--- a/tests/recipe-runtime-setup-staged-materialization.test.ts
+++ b/tests/recipe-runtime-setup-staged-materialization.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { applyRecipeRuntimeSetup, type PreparedRecipeRuntimeSetup } from "../packages/cli/src/commands/recipe-runtime-setup.js"
+import { applyRecipeRuntimeSetup, recipeInputMountPathMap, rewriteInputMountPathArgs, type PreparedRecipeRuntimeSetup } from "../packages/cli/src/commands/recipe-runtime-setup.js"
+import { executeRecipeWorkflowStep } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
 import type { Runtime, WorkspaceRecipe } from "../packages/runtime-core/src/public.js"
 
 const calls: string[] = []
@@ -15,7 +16,7 @@ const recipe: WorkspaceRecipe = {
   inputs: {
     mounts: [{
       source: inputMountSource,
-      target: "/home/example/public_html/bin/tests",
+      target: "/home/example/public_html",
       mode: "readonly",
     }],
   },
@@ -27,6 +28,7 @@ const prepared: PreparedRecipeRuntimeSetup = {
   dependencyOverlays: [],
   overlays: [],
   inputMountBaselinePaths: [],
+  inputMountPathMap: recipeInputMountPathMap(recipe),
   stagedFiles: [{
     source: "/tmp/host-bundle",
     originalSource: "/tmp/host-bundle",
@@ -41,7 +43,12 @@ const prepared: PreparedRecipeRuntimeSetup = {
 
 const runtime = {
   async info() { return { id: "runtime", backend: "wordpress-playground", environment: { kind: "wordpress" }, createdAt: new Date().toISOString(), status: "running" } },
-  async mount(spec) { calls.push(`mount:${spec.target}`) },
+  async mount(spec) {
+    calls.push(`mount:${spec.target}`)
+    if (spec.metadata?.originalTarget) {
+      calls.push(`metadata:${spec.metadata.originalTarget}->${spec.metadata.canonicalTarget}`)
+    }
+  },
   async materializeStagedInputs(mounts) {
     assert.equal(this, runtime, "setup calls staged input materializer with runtime binding")
     calls.push(`materialize:${mounts.map((mount) => mount.target).join(",")}`)
@@ -49,9 +56,13 @@ const runtime = {
       {
         type: "directory",
         source: inputMountSource,
-        target: "/home/example/public_html/bin/tests",
+        target: prepared.inputMountPathMap[0].canonicalTarget,
         mode: "readonly",
-        metadata: undefined,
+        metadata: {
+          originalTarget: "/home/example/public_html",
+          canonicalTarget: prepared.inputMountPathMap[0].canonicalTarget,
+          canonicalizedTarget: true,
+        },
       },
       {
         type: "directory",
@@ -89,14 +100,63 @@ try {
 }
 
 const mountIndex = calls.indexOf("mount:/workspace/example/bundles/runtime-agent")
-const inputMountIndex = calls.indexOf("mount:/home/example/public_html/bin/tests")
+const inputMountIndex = calls.indexOf(`mount:${prepared.inputMountPathMap[0].canonicalTarget}`)
 const materializeOperationIndex = calls.indexOf("operation:input.materialize")
-const materializeIndex = calls.indexOf("materialize:/home/example/public_html/bin/tests,/workspace/example/bundles/runtime-agent")
+const materializeIndex = calls.indexOf(`materialize:${prepared.inputMountPathMap[0].canonicalTarget},/workspace/example/bundles/runtime-agent`)
 assert.ok(inputMountIndex >= 0, "input source is mounted")
+assert.match(prepared.inputMountPathMap[0].canonicalTarget, /^\/tmp\/wp-codebox-inputs\/0-public_html-[a-f0-9]{12}$/)
+assert.ok(calls.includes(`metadata:/home/example/public_html->${prepared.inputMountPathMap[0].canonicalTarget}`), "input mount metadata records original and canonical targets")
 assert.ok(mountIndex >= 0, "staged source is mounted")
 assert.ok(materializeOperationIndex > inputMountIndex, "materialization is scheduled after input mount")
 assert.ok(materializeOperationIndex > mountIndex, "materialization is scheduled after staged mount")
 assert.ok(materializeIndex > materializeOperationIndex, "materialization runs inside the setup phase before commands")
 assert.equal(calls.some((call) => call.startsWith("execute:")), false)
+
+const workflowRuntime = {
+  async info() { return { id: "runtime", backend: "wordpress-playground", environment: { kind: "wordpress" }, createdAt: new Date().toISOString(), status: "running" } },
+  async mount() { throw new Error("unused") },
+  async execute(spec) {
+    return {
+      id: "workflow-step",
+      command: spec.command,
+      args: spec.args ?? [],
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    }
+  },
+  async observe() { throw new Error("unused") },
+  async snapshot() { throw new Error("unused") },
+  async collectArtifacts() { throw new Error("unused") },
+  async destroy() {},
+} satisfies Runtime
+
+const workflowExecution = await executeRecipeWorkflowStep(workflowRuntime, {
+  phase: "steps",
+  index: 0,
+  step: {
+    command: "wordpress.phpunit",
+    args: [
+      "cwd=/home/example/public_html/bin/tests/foo",
+      "test-root=/home/example/public_html/bin/tests/foo",
+      "phpunit-xml=/home/example/public_html/bin/tests/foo/phpunit.xml",
+      "note=this mentions /home/example/public_html/bin/tests/foo but is not a path value",
+    ],
+  },
+}, process.cwd(), undefined, undefined, undefined, prepared.inputMountPathMap)
+
+assert.deepEqual(workflowExecution.args, [
+  `cwd=${prepared.inputMountPathMap[0].canonicalTarget}/bin/tests/foo`,
+  `test-root=${prepared.inputMountPathMap[0].canonicalTarget}/bin/tests/foo`,
+  `phpunit-xml=${prepared.inputMountPathMap[0].canonicalTarget}/bin/tests/foo/phpunit.xml`,
+  "note=this mentions /home/example/public_html/bin/tests/foo but is not a path value",
+])
+
+assert.deepEqual(rewriteInputMountPathArgs(["cwd=/home/example/public_html/bin/tests/foo"], [
+  { originalTarget: "/home/example/public_html", canonicalTarget: "/tmp/wp-codebox-inputs/root" },
+  { originalTarget: "/home/example/public_html/bin/tests", canonicalTarget: "/tmp/wp-codebox-inputs/tests" },
+]), ["cwd=/tmp/wp-codebox-inputs/tests/foo"])
 
 console.log("recipe runtime setup staged materialization ok")


### PR DESCRIPTION
## Summary
- Canonicalize recipe input mount targets under /tmp/wp-codebox-inputs before mounting/materialization.
- Preserve original/canonical target metadata on input mounts.
- Rewrite workflow command args with mapped absolute path values using longest-prefix matching.

## Testing
- npx tsx tests/mount-materialization.test.ts
- npx tsx tests/staged-input-materialization.test.ts
- npm run test:recipe-runtime-setup-staged-materialization
- npm run build -- --pretty false

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the canonical input mount path mapping, workflow arg propagation, focused tests, and verification in collaboration with Chris.