### PR TITLE
Require typed workload artifacts

### DIFF
--- a/packages/runtime-core/src/command-registry.ts
+++ b/packages/runtime-core/src/command-registry.ts
@@ -756,15 +756,14 @@ export const commandRegistry = [
   },
   {
     id: "wordpress.collect-workload-result",
-    description: "Collect a generic workload result marker so declarative workload phases can close with a structured success envelope.",
+    description: "Collect a typed workload artifact payload produced by an earlier workload phase.",
     acceptedArgs: [
       { name: "artifact", description: "Logical workload artifact or coverage name requested by the phase.", format: "string" },
       { name: "schema", description: "Optional expected artifact schema id for runtimes that materialize a concrete artifact.", format: "string" },
     ],
-    outputShape: "wp-codebox/workload-result-collection/v1 JSON with command, status, and requested artifact metadata.",
-    outputSchema: objectEnvelopeSchema("wp-codebox/workload-result-collection/v1", {
-      status: { type: "string" },
-      artifact: { type: ["string", "null"] },
+    outputShape: "The requested typed artifact payload, for example wp-codebox/wordpress-rest-db-query-profile/v1.",
+    outputSchema: objectEnvelopeSchema("wp-codebox/typed-workload-artifact/v1", {
+      schema: { type: "string" },
     }),
     policyRequirement: "Runtime policy commands must include wordpress.collect-workload-result.",
     recipe: true,

--- a/packages/runtime-playground/src/playground-runtime.ts
+++ b/packages/runtime-playground/src/playground-runtime.ts
@@ -1395,13 +1395,7 @@ class PlaygroundRuntime implements Runtime {
       const index = arg.indexOf("=")
       return index === -1 ? [arg, ""] : [arg.slice(0, index), arg.slice(index + 1)]
     }))
-    return `${JSON.stringify({
-      schema: "wp-codebox/workload-result-collection/v1",
-      command: spec.command,
-      status: "ok",
-      artifact: args.get("artifact") ?? null,
-      expectedSchema: args.get("schema") ?? null,
-    }, null, 2)}\n`
+    throw new Error(`wordpress.collect-workload-result requires a workload execution context with a typed payload for artifact=${args.get("artifact") ?? ""}`)
   }
 
   async runCrudOperation(spec: ExecutionSpec): Promise<string> {

--- a/packages/runtime-playground/src/public.ts
+++ b/packages/runtime-playground/src/public.ts
@@ -908,31 +908,26 @@ function collectWorkloadResultExecution(step: { command: string; args?: string[]
     return executionMatchesArtifact(execution, artifact)
   })
   const payloads = matchedExecutions.flatMap((execution) => workloadArtifactPayloads(execution, artifact, expectedSchema))
-  const artifactRefs = matchedExecutions.flatMap((execution) => (execution.artifactRefs ?? []).filter((ref) => !artifact || artifactRefMatchesName(ref, artifact)))
-  const requiresProfilePayload = artifactNameMatches(artifact, "rest-db-query-profile")
-  const missing = artifact && (matchedExecutions.length === 0 || (requiresProfilePayload && payloads.length === 0))
-  const payload = {
-    schema: "wp-codebox/wordpress-workload-result-collection/v1",
-    generatedAt: new Date().toISOString(),
-    query: stripUndefined({ artifact: artifact || undefined, command: command || undefined, status: status || undefined, expectedSchema: expectedSchema || undefined }),
-    summary: { steps: matchedExecutions.length, artifactRefs: artifactRefs.length, payloads: payloads.length },
-    steps: matchedExecutions.map((execution) => stripUndefined({ command: execution.command, exitCode: execution.exitCode, result: execution.result?.json })),
-    payloads,
-    artifactRefs,
-  }
-  const diagnostic = missing ? { severity: "error", code: "wp_codebox_workload_result_artifact_missing", message: "Requested workload result artifact was not found or had no payload.", metadata: stripUndefined({ artifact: artifact || undefined, command: command || undefined, status: status || undefined }) } : undefined
+  const missing = artifact && (matchedExecutions.length === 0 || payloads.length === 0)
+  const ambiguous = payloads.length > 1
+  const diagnostic = missing
+    ? { severity: "error", code: "wp_codebox_workload_result_artifact_missing", message: "Requested workload result artifact was not found or had no typed payload.", metadata: stripUndefined({ artifact: artifact || undefined, command: command || undefined, status: status || undefined, expectedSchema: expectedSchema || undefined }) }
+    : ambiguous
+      ? { severity: "error", code: "wp_codebox_workload_result_artifact_ambiguous", message: "Requested workload result artifact resolved multiple typed payloads; refine the collection query.", metadata: stripUndefined({ artifact: artifact || undefined, command: command || undefined, status: status || undefined, expectedSchema: expectedSchema || undefined, payloads: payloads.length }) }
+      : undefined
+  const payload = payloads[0]?.payload ?? {}
   const stdout = `${JSON.stringify(payload)}\n`
   return {
     id: `wordpress-collect-workload-result-${artifact || "workload-result"}`,
     command: "wordpress.collect-workload-result",
     args: step.args ?? [],
-    exitCode: missing ? 1 : 0,
+    exitCode: diagnostic ? 1 : 0,
     stdout,
-    stderr: missing ? diagnostic?.message ?? "" : "",
-    result: { schema: "wp-codebox/runtime-command-result/v1", status: missing ? "error" : "ok", json: payload, diagnostics: diagnostic ? [diagnostic] : undefined },
+    stderr: diagnostic?.message ?? "",
+    result: { schema: "wp-codebox/runtime-command-result/v1", status: diagnostic ? "error" : "ok", json: payload, diagnostics: diagnostic ? [diagnostic] : undefined },
     startedAt,
     finishedAt: new Date().toISOString(),
-    artifactRefs: [{ kind: "wordpress-workload-result-collection", id: artifact || "workload-result", artifactId: artifact || "workload-result", path: `files/workload-results/${safeArtifactSegment(artifact || "workload-result")}.json`, payload } as NonNullable<ExecutionResult["artifactRefs"]>[number]],
+    artifactRefs: payloads[0] ? [{ kind: payloads[0].name, id: artifact || payloads[0].name, artifactId: artifact || payloads[0].name, path: `files/workload-results/${safeArtifactSegment(artifact || payloads[0].name)}.json`, payload } as NonNullable<ExecutionResult["artifactRefs"]>[number]] : [],
   }
 }
 
@@ -955,7 +950,19 @@ function workloadArtifactPayloads(execution: ExecutionResult, artifact: string, 
     }
   }
   collectArtifactPayloadsFromContainer(json, artifact, expectedSchema, payloads)
-  return payloads
+  return dedupeArtifactPayloads(payloads)
+}
+
+function dedupeArtifactPayloads(payloads: Array<{ name: string; payload: Record<string, unknown> }>): Array<{ name: string; payload: Record<string, unknown> }> {
+  const seen = new Set<string>()
+  const out: Array<{ name: string; payload: Record<string, unknown> }> = []
+  for (const item of payloads) {
+    const key = `${item.name}:${JSON.stringify(item.payload)}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(item)
+  }
+  return out
 }
 
 function collectArtifactPayloadsFromContainer(container: Record<string, unknown> | undefined, artifact: string, expectedSchema: string | undefined, out: Array<{ name: string; payload: Record<string, unknown> }>): void {
@@ -1383,10 +1390,6 @@ function containsRestDbQueryProfilerRequest(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(containsRestDbQueryProfilerRequest)
   const record = value as Record<string, unknown>
   if (record.type === "rest-db-query-profiler") return true
-  if (record.schema === "wp-codebox/workload-result-collection/v1" || record.schema === "wp-codebox/wordpress-workload-result-collection/v1") {
-    const artifact = stringValue(record.artifact ?? record.name)
-    if (artifact && artifactNameMatches(artifact, "rest-db-query-profile")) return true
-  }
   return Object.values(record).some(containsRestDbQueryProfilerRequest)
 }
 
@@ -1521,13 +1524,6 @@ function restDbQueryProfilesFromJson(json: Record<string, unknown> | undefined):
       const stepRecord = recordValue(step)
       const profile = recordValue(recordValue(stepRecord?.artifacts)?.["rest-db-query-profile"])
       if (profile?.schema === "wp-codebox/wordpress-rest-db-query-profile/v1") profiles.push({ profile, sourceId: stringValue(stepRecord?.type) })
-    }
-  }
-  if (json?.schema === "wp-codebox/wordpress-workload-result-collection/v1") {
-    for (const item of arrayValue(json.payloads)) {
-      const payloadRecord = recordValue(item)
-      const profile = recordValue(payloadRecord?.payload)
-      if (profile?.schema === "wp-codebox/wordpress-rest-db-query-profile/v1") profiles.push({ profile, sourceId: stringValue(payloadRecord?.name) })
     }
   }
   if (json?.schema === "wp-codebox/recipe-run/v1") {

--- a/packages/wordpress-plugin/src/class-wp-codebox-wordpress-runtime-primitives.php
+++ b/packages/wordpress-plugin/src/class-wp-codebox-wordpress-runtime-primitives.php
@@ -126,32 +126,36 @@ final class WP_Codebox_WordPress_Runtime_Primitives {
 			}
 			$matched_payloads = array_merge( $matched_payloads, self::step_artifact_payloads( $step, $name ) );
 		}
+		$matched_payloads = self::dedupe_artifact_payloads( $matched_payloads );
 		$matched_refs = array_merge( $matched_refs, array_values( array_filter( $artifact_refs, static fn( mixed $ref ): bool => is_array( $ref ) && ( '' === $name || self::artifact_matches_name( $ref, $name ) ) ) ) );
 		$matched_refs = self::dedupe_artifact_refs( $matched_refs );
-		if ( '' !== $name && empty( $matched_refs ) && empty( $matched_payloads ) ) {
+		if ( '' === $name || empty( $matched_payloads ) ) {
 			$diagnostic = array(
 				'severity' => 'error',
 				'code'     => 'wp_codebox_workload_result_artifact_missing',
-				'message'  => 'Requested workload result artifact was not found or had no payload.',
+				'message'  => 'Requested workload result artifact was not found or had no typed payload.',
 				'metadata' => array_filter( array( 'artifact' => $name, 'command' => $command, 'status' => $status ), static fn( mixed $value ): bool => '' !== $value ),
 			);
 
 			return array( 'status' => 'failed', 'payload' => array(), 'artifactRefs' => array(), 'diagnostics' => array( $diagnostic ) );
 		}
-		$payload      = array(
-			'schema'      => 'wp-codebox/wordpress-workload-result-collection/v1',
-			'generatedAt' => gmdate( 'Y-m-d\TH:i:s\Z' ),
-			'query'       => array_filter( array( 'artifact' => $name, 'command' => $command, 'status' => $status ), static fn( mixed $value ): bool => '' !== $value ),
-			'summary'     => array( 'steps' => count( $matched_steps ), 'artifactRefs' => count( $matched_refs ), 'payloads' => count( $matched_payloads ) ),
-			'steps'       => $matched_steps,
-			'payloads'    => $matched_payloads,
-			'artifactRefs'=> $matched_refs,
-		);
+		if ( count( $matched_payloads ) > 1 ) {
+			$diagnostic = array(
+				'severity' => 'error',
+				'code'     => 'wp_codebox_workload_result_artifact_ambiguous',
+				'message'  => 'Requested workload result artifact resolved multiple typed payloads; refine the collection query.',
+				'metadata' => array_filter( array( 'artifact' => $name, 'command' => $command, 'status' => $status, 'payloads' => count( $matched_payloads ) ), static fn( mixed $value ): bool => '' !== $value ),
+			);
+
+			return array( 'status' => 'failed', 'payload' => array(), 'artifactRefs' => array(), 'diagnostics' => array( $diagnostic ) );
+		}
+
+		$payload = is_array( $matched_payloads[0]['payload'] ?? null ) ? $matched_payloads[0]['payload'] : $matched_payloads[0];
 
 		$collection_name = '' === $name ? 'workload-result' : $name;
 		$collection_ref  = array(
 			'name'        => $collection_name,
-			'kind'        => 'wordpress-workload-result-collection',
+			'kind'        => $collection_name,
 			'path'        => 'files/workload-results/' . self::safe_key( $collection_name ) . '.json',
 			'contentType' => 'application/json',
 			'payload'     => $payload,
@@ -217,7 +221,8 @@ final class WP_Codebox_WordPress_Runtime_Primitives {
 	}
 
 	private static function artifact_name_matches( string $candidate, string $name ): bool {
-		return $name === $candidate || str_replace( '_', '-', $name ) === str_replace( '_', '-', $candidate );
+		$normalize = static fn( string $value ): string => str_replace( array( '_', '-' ), '', strtolower( $value ) );
+		return $name === $candidate || str_replace( '_', '-', $name ) === str_replace( '_', '-', $candidate ) || $normalize( $name ) === $normalize( $candidate );
 	}
 
 	/** @param array<string,mixed> $step Step. */
@@ -254,8 +259,28 @@ final class WP_Codebox_WordPress_Runtime_Primitives {
 				$payloads[] = array( 'name' => (string) $artifact_name, 'payload' => $payload );
 			}
 		}
+		foreach ( is_array( $container['artifactRefs'] ?? null ) ? $container['artifactRefs'] : array() as $ref ) {
+			if ( is_array( $ref ) && is_array( $ref['payload'] ?? null ) && ( '' === $name || self::artifact_matches_name( $ref, $name ) ) ) {
+				$payloads[] = array( 'name' => (string) ( $ref['name'] ?? $ref['artifact'] ?? $ref['id'] ?? '' ), 'payload' => $ref['payload'] );
+			}
+		}
 
 		return $payloads;
+	}
+
+	/** @param array<int,array<string,mixed>> $payloads Payloads. @return array<int,array<string,mixed>> */
+	private static function dedupe_artifact_payloads( array $payloads ): array {
+		$seen = array();
+		$out  = array();
+		foreach ( $payloads as $payload ) {
+			$key = (string) ( $payload['name'] ?? '' ) . '|' . wp_json_encode( $payload['payload'] ?? $payload );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$out[]        = $payload;
+		}
+		return $out;
 	}
 
 	/** @param array<int,array<string,mixed>> $refs Refs. @return array<int,array<string,mixed>> */

--- a/scripts/php-fuzz-suite-runner-smoke.php
+++ b/scripts/php-fuzz-suite-runner-smoke.php
@@ -346,12 +346,15 @@ $result = WP_Codebox_Fuzz_Suite_Runner_Smoke::run_fuzz_suite(
 			array(
 				'case_id'   => 'collect-artifact',
 				'phases'    => array(
+					'action' => array(
+						array( 'command' => 'wordpress.run-workload', 'args' => array( 'path=' . $json_workload_path ) ),
+					),
 					'assert' => array(
-						array( 'command' => 'wordpress.collect-workload-result', 'args' => array( 'artifact=report' ) ),
+						array( 'command' => 'wordpress.collect-workload-result', 'args' => array( 'artifact=rest_db_query_profile' ) ),
 					),
 				),
 				'artifacts' => array(
-					array( 'name' => 'report', 'path' => 'php-smoke/report.json', 'metadata' => array( 'semantic_key' => 'fuzz.report' ) ),
+					array( 'name' => 'rest_db_query_profile', 'path' => 'php-smoke/rest-db-query-profile.json', 'metadata' => array( 'semantic_key' => 'fuzz.report' ) ),
 				),
 			),
 			array(
@@ -571,11 +574,9 @@ assert( 'json-workload-profiler' === $result['cases'][21]['id'] );
 assert( 'passed' === $result['cases'][21]['status'] );
 assert( 'workloads/rest-db-query-profile.json' === $result['cases'][21]['metadata']['observations'][0]['artifact'] );
 assert( 'rest_db_query_profile' === $result['cases'][21]['metadata']['observations'][1]['artifact'] );
-assert( 'wp-codebox/wordpress-workload-result-collection/v1' === $result['cases'][21]['metadata']['observations'][1]['payload']['schema'] );
-assert( 1 === $result['cases'][21]['metadata']['observations'][1]['payload']['summary']['payloads'] );
-assert( 'wp-codebox/wordpress-rest-db-query-profile/v1' === $result['cases'][21]['metadata']['observations'][1]['payload']['payloads'][0]['payload']['schema'] );
-assert( 1 === $result['cases'][21]['metadata']['observations'][1]['payload']['payloads'][0]['payload']['summary']['case_count'] );
-assert( 4 === $result['cases'][21]['metadata']['observations'][1]['payload']['payloads'][0]['payload']['summary']['query_count'] );
+assert( 'wp-codebox/wordpress-rest-db-query-profile/v1' === $result['cases'][21]['metadata']['observations'][1]['payload']['schema'] );
+assert( 1 === $result['cases'][21]['metadata']['observations'][1]['payload']['summary']['case_count'] );
+assert( 4 === $result['cases'][21]['metadata']['observations'][1]['payload']['summary']['query_count'] );
 assert( 'array' !== ( $result['cases'][21]['metadata']['observations'][0]['return_type'] ?? null ) );
 assert( is_file( WP_CONTENT_DIR . '/uploads/workloads/rest-db-query-profile.json' ) );
 $workload_report = json_decode( file_get_contents( WP_CONTENT_DIR . '/uploads/workloads/rest-db-query-profile.json' ), true );

--- a/scripts/php-wordpress-workload-runner-smoke.php
+++ b/scripts/php-wordpress-workload-runner-smoke.php
@@ -33,6 +33,10 @@ function home_url( string $path = '/' ): string {
 	return 'https://example.test' . ( str_starts_with( $path, '/' ) ? $path : '/' . $path );
 }
 
+function wp_json_encode( mixed $value, int $flags = 0 ): string|false {
+	return json_encode( $value, $flags );
+}
+
 function wp_remote_request( string $url, array $args = array() ): array|WP_Error {
 	$preempt = apply_filters( 'pre_http_request', false, $args, $url );
 	if ( false !== $preempt ) {
@@ -75,6 +79,30 @@ class WP_Codebox_WordPress_Workload_Runner_Smoke {
 	use WP_Codebox_Abilities_Execution;
 }
 
+$typed_php_workload_path = tempnam( sys_get_temp_dir(), 'wp-codebox-typed-workload-' );
+assert( is_string( $typed_php_workload_path ) );
+file_put_contents(
+	$typed_php_workload_path,
+	<<<'PHP'
+<?php
+return static function (): array {
+	return array(
+		'status' => 'passed',
+		'artifactRefs' => array(
+			array(
+				'name' => 'report',
+				'path' => 'workload/report.json',
+				'payload' => array(
+					'schema' => 'wp-codebox/test-report/v1',
+					'status' => 'passed',
+				),
+			),
+		),
+	);
+};
+PHP
+);
+
 $result = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
 	array(
 		'schema'    => 'wp-codebox/wordpress-workload-run/v1',
@@ -83,11 +111,13 @@ $result = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
 		),
 		'steps'     => array(
 			array( 'command' => 'wordpress.rest-request', 'args' => array( 'path=/wp/v2/status', 'method=GET' ) ),
+			array( 'command' => 'wordpress.run-workload', 'args' => array( 'type=php', 'path=' . $typed_php_workload_path ) ),
 			array( 'command' => 'wordpress.collect-workload-result', 'args' => array( 'artifact=report' ) ),
 			array( 'command' => 'wordpress.unsupported-safe-step', 'advisory' => true ),
 		),
 	)
 );
+@unlink( $typed_php_workload_path );
 
 assert( is_array( $result ) );
 assert( true === $result['success'] );
@@ -96,8 +126,11 @@ assert( 'completed' === $result['status'] );
 assert( 'passed' === $result['steps'][0]['status'] );
 assert( 200 === $result['steps'][0]['observation']['status'] );
 assert( 'workload/report.json' === $result['artifacts'][0]['path'] );
-assert( 'skipped' === $result['steps'][2]['status'] );
-assert( 'wp_codebox_wordpress_workload_step_unsupported' === $result['steps'][2]['diagnostics'][0]['code'] );
+assert( 'passed' === $result['steps'][1]['status'] );
+assert( 'passed' === $result['steps'][2]['status'] );
+assert( 'wp-codebox/test-report/v1' === $result['steps'][2]['observation']['payload']['schema'] );
+assert( 'skipped' === $result['steps'][3]['status'] );
+assert( 'wp_codebox_wordpress_workload_step_unsupported' === $result['steps'][3]['diagnostics'][0]['code'] );
 
 $php_workload_path = tempnam( sys_get_temp_dir(), 'wp-codebox-workload-' );
 assert( is_string( $php_workload_path ) );
@@ -131,15 +164,14 @@ $php_result = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload
 );
 
 assert( is_array( $php_result ) );
-assert( true === $php_result['success'] );
-assert( 'completed' === $php_result['status'] );
+assert( false === $php_result['success'] );
+assert( 'failed' === $php_result['status'] );
 assert( 'passed' === $php_result['steps'][0]['status'] );
 assert( 'wp-codebox/wordpress-workload-run/v1' === $php_result['steps'][0]['observation']['input_schema'] );
 assert( 'php' === $php_result['steps'][0]['observation']['arg_type'] );
 assert( 'workload/php-report.json' === $php_result['artifacts'][0]['path'] );
-assert( 'wp-codebox/wordpress-workload-result-collection/v1' === $php_result['steps'][1]['observation']['payload']['schema'] );
-assert( 1 === $php_result['steps'][1]['observation']['payload']['summary']['steps'] );
-assert( 'workload/php-report.json' === $php_result['steps'][1]['observation']['payload']['artifactRefs'][0]['path'] );
+assert( 'failed' === $php_result['steps'][1]['status'] );
+assert( 'wp_codebox_workload_result_artifact_missing' === $php_result['steps'][1]['diagnostics'][0]['code'] );
 @unlink( $php_workload_path );
 
 $missing_collection_result = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_workload(
@@ -189,14 +221,14 @@ $guardrail_result = WP_Codebox_WordPress_Workload_Runner_Smoke::run_wordpress_wo
 
 assert( is_array( $guardrail_result ) );
 assert( true === $guardrail_result['success'] );
-$blocked_request = $guardrail_result['steps'][2]['observation']['payload']['artifactRefs'][0]['payload']['requests'][0];
+$blocked_request = $guardrail_result['steps'][2]['observation']['payload']['requests'][0];
 assert( 'blocked' === $blocked_request['classification'] );
 assert( str_contains( $blocked_request['url'], 'token=[redacted]' ) );
 assert( str_contains( $blocked_request['url'], '_wpnonce=[redacted]' ) );
 assert( '[redacted]' === $blocked_request['headers']['Authorization'] );
 assert( '[redacted]' === $blocked_request['headers']['X-WP-Nonce'] );
 assert( 'visible' === $blocked_request['headers']['X-Public'] );
-assert( 'wp-codebox/wordpress-workload-result-collection/v1' === $guardrail_result['steps'][2]['observation']['payload']['schema'] );
+assert( 'wp-codebox/external-http-guardrail/v1' === $guardrail_result['steps'][2]['observation']['payload']['schema'] );
 @unlink( $guardrail_workload_path );
 
 $not_callable_path = tempnam( sys_get_temp_dir(), 'wp-codebox-workload-' );

--- a/tests/playground-fuzz-suite-public.test.ts
+++ b/tests/playground-fuzz-suite-public.test.ts
@@ -51,13 +51,13 @@ const episode = {
       "wordpress.browser-actions": { url: "/", browser: { metrics: { layoutShift: 3 } }, timing: { durationMs: 90 } },
       "wordpress.db-operation": { metrics: { query_count: 11, query_time_ms: 22 }, metadata: { dbWriteSet: { schema: "wp-codebox/wordpress-db-write-set/v1", artifactKind: "wordpress-db-write-set", action: "db_operation", target: "wp_fuzz", entries: [{ table: "wp_fuzz", operation: "update", rowsAffected: 1, rowCountBefore: 1, rowCountAfter: 1, resource: { table: "wp_fuzz", identifiers: { id: 1 } }, key: "wp_fuzz:update:1" }], repeatedWrites: [], totals: { writes: 1, rowsAffected: 1, tables: 1, repeatedWriteKeys: 0 } } } },
       "wordpress.crud-operation": { item: { id: 123 }, status: "ok", metadata: { dbWriteSet: { schema: "wp-codebox/wordpress-db-write-set/v1", artifactKind: "wordpress-db-write-set", action: "crud_operation", target: "post:123", entries: [{ table: "wp_posts", operation: "update", rowsAffected: 1, object: { kind: "post", id: 123 }, key: "wp_posts:update:123", repeatedWritesToSameKey: 2 }, { table: "wp_postmeta", operation: "update", rowsAffected: 1, object: { kind: "post", id: 123 }, key: "wp_postmeta:update:123" }], repeatedWrites: [{ table: "wp_posts", operation: "update", rowsAffected: 1, object: { kind: "post", id: 123 }, key: "wp_posts:update:123", repeatedWritesToSameKey: 2 }], totals: { writes: 2, rowsAffected: 2, tables: 2, repeatedWriteKeys: 1 } } } },
-      "wordpress.run-php": runPhpCode.includes("wordpress-rollback-capture-request") ? rollbackCapturePayload(runPhpCode) : runPhpCode.includes("marker-only-rest-db-query-profile") ? { status: "passed", artifactRefs: [{ name: "rest-db-query-profile", path: "workloads/rest-db-query-profile.marker.json" }] } : runPhpCode.includes("recipe-run-missing-rest-db-query-profiler") ? {
+      "wordpress.run-php": runPhpCode.includes("wordpress-rollback-capture-request") ? rollbackCapturePayload(runPhpCode) : runPhpCode.includes("workload-missing-rest-db-query-profiler") ? {
+        schema: "wp-codebox/json-workload-result/v1",
+        steps: [{ type: "rest-db-query-profiler", artifacts: {} }],
+      } : runPhpCode.includes("recipe-run-missing-rest-db-query-profiler") ? {
         schema: "wp-codebox/recipe-run/v1",
         success: true,
-        executions: [
-          { command: "wordpress.run-workload", result: { json: { schema: "wp-codebox/wordpress-workload-run-result/v1", steps: 1, exitCode: 0 } } },
-          { command: "wordpress.collect-workload-result", result: { json: { schema: "wp-codebox/workload-result-collection/v1", command: "wordpress.collect-workload-result", status: "ok", artifact: "rest_db_query_profile", expectedSchema: null } } },
-        ],
+        executions: [{ result: { json: { schema: "wp-codebox/json-workload-result/v1", steps: [{ type: "rest-db-query-profiler", artifacts: {} }] } } }],
       } : runPhpCode.includes("recipe-run-rest-db-query-profiler") ? {
         schema: "wp-codebox/recipe-run/v1",
         success: true,
@@ -190,7 +190,7 @@ assert.equal(Array.isArray(metadataArtifacts?.fuzzHotspotSet?.hotspots), false)
 const missingProfilePayload = await executeWordPressFuzzSuite(episode, fuzzSuiteContract({
   id: "runtime-backed-missing-profile-payload",
   metadata: { disposableSandboxBoundary },
-  cases: [{ id: "marker-only-profile", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.run-workload", args: ["type=php", "path=/tmp/marker-only-rest-db-query-profile.php"] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=rest-db-query-profile"] }] } }],
+  cases: [{ id: "missing-profile", target: { kind: "runtime", id: "wordpress.run-workload", entrypoint: "wordpress.run-workload" }, input: { schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ command: "wordpress.run-workload", args: ["type=php", "path=/tmp/workload-missing-rest-db-query-profiler.php"] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=rest-db-query-profile"] }] } }],
 }), { requireCoverage: true })
 assert.equal(missingProfilePayload.status, "failed")
 assert.equal(missingProfilePayload.cases[0]?.status, "failed")


### PR DESCRIPTION
## Summary
- Make wordpress.collect-workload-result return the resolved typed artifact payload instead of a collection marker envelope.
- Fail marker-only or missing typed payload collection with explicit diagnostics.
- Update runtime and PHP smoke coverage for strict typed workload artifact collection.

## Verification
- npm run test:php-fuzz-suite-runner
- php -d zend.assertions=1 -d assert.exception=1 scripts/php-wordpress-workload-runner-smoke.php
- npm run test:playground-fuzz-suite-public
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and verified the strict typed workload artifact cleanup with Chris's direction.