### PR TITLE
Fail recipes on workflow step errors

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -1131,18 +1131,18 @@ export function recipeAgentResultFailure(agentResult: RecipeArtifactEvidenceResu
  * change until its verification gates are green.
  */
 export function recipeVerifyStepFailure(
-  executions: ReadonlyArray<{ exitCode: number; recipePhase?: string; recipeCommand?: string; command?: string }>,
+  executions: ReadonlyArray<{ exitCode: number; recipePhase?: string; recipeCommand?: string; command?: string; recipeAdvisory?: boolean }>,
 ): { name: string; code: string; message: string } | undefined {
-  const failed = executions.find((execution) => execution.recipePhase === "after" && execution.exitCode !== 0)
+  const failed = executions.find((execution) => execution.exitCode !== 0 && execution.recipeAdvisory !== true)
   if (!failed) {
     return undefined
   }
 
-  const stepName = failed.recipeCommand || failed.command || "verify"
+  const stepName = failed.recipeCommand || failed.command || "recipe"
   return {
     name: "RecipeVerifyError",
     code: "verify-step-failed",
-    message: `Verification step ${stepName} failed with exit code ${failed.exitCode}.`,
+    message: `Recipe step ${stepName} failed with exit code ${failed.exitCode}.`,
   }
 }
 

--- a/tests/recipe-evidence-failures.test.ts
+++ b/tests/recipe-evidence-failures.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict"
+
+import { recipeVerifyStepFailure } from "../packages/cli/src/recipe-evidence.js"
+
+assert.equal(recipeVerifyStepFailure([{ exitCode: 0, recipePhase: "steps", recipeCommand: "wordpress.run-workload" }]), undefined)
+assert.equal(recipeVerifyStepFailure([{ exitCode: 1, recipePhase: "steps", recipeCommand: "wordpress.collect-workload-result", recipeAdvisory: true }]), undefined)
+
+const failedWorkflow = recipeVerifyStepFailure([{ exitCode: 1, recipePhase: "steps", recipeCommand: "wordpress.collect-workload-result" }])
+assert.equal(failedWorkflow?.code, "verify-step-failed")
+assert.match(failedWorkflow?.message ?? "", /wordpress\.collect-workload-result failed with exit code 1/)
+
+const failedAfter = recipeVerifyStepFailure([{ exitCode: 2, recipePhase: "after", recipeCommand: "wordpress.run-php" }])
+assert.equal(failedAfter?.code, "verify-step-failed")
+assert.match(failedAfter?.message ?? "", /wordpress\.run-php failed with exit code 2/)
+
+console.log("recipe evidence failures ok")


### PR DESCRIPTION
## Summary
- Make recipe failure detection reject any non-advisory failed workflow execution, not only after-phase verification failures.
- Add regression coverage for failed workflow steps and advisory failures.

## Verification
- npx tsx tests/recipe-evidence-failures.test.ts
- npx tsx tests/nested-fuzz-suite-recipe-command.test.ts
- npm run build
- npm run test:playground-fuzz-suite-public

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the false-pass recipe outcome from the Lab Woo fuzzer and implemented the failure gate fix with Chris's direction.