### PR TITLE
Extract recipe bench profile payloads

### DIFF
--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -304,6 +304,14 @@ function recipeRestDbQueryProfilesFromJson(json: Record<string, unknown> | undef
   const profiles: Array<{ profile: Record<string, unknown> }> = []
   if (!json) return profiles
   if (json.schema === "wp-codebox/wordpress-rest-db-query-profile/v1") profiles.push({ profile: json })
+  if (json.schema === "wp-codebox/bench-results/v1") {
+    for (const scenario of Array.isArray(json.scenarios) ? json.scenarios : []) {
+      const scenarioRecord = isRecord(scenario) ? scenario : undefined
+      const artifacts = isRecord(scenarioRecord?.artifacts) ? scenarioRecord.artifacts : undefined
+      const profile = isRecord(artifacts?.["rest-db-query-profile"]) ? artifacts["rest-db-query-profile"] : undefined
+      if (profile?.schema === "wp-codebox/wordpress-rest-db-query-profile/v1") profiles.push({ profile })
+    }
+  }
   for (const step of Array.isArray(json.steps) ? json.steps : []) {
     const stepRecord = isRecord(step) ? step : undefined
     const artifacts = isRecord(stepRecord?.artifacts) ? stepRecord.artifacts : undefined

--- a/tests/nested-fuzz-suite-recipe-command.test.ts
+++ b/tests/nested-fuzz-suite-recipe-command.test.ts
@@ -48,6 +48,23 @@ const runtime = {
         result: { schema: "wp-codebox/runtime-command-result/v1", status: "ok", json: payload },
       }
     }
+    if (spec.command === "wordpress.bench" && (spec.args ?? []).some((arg) => arg.includes("rest-db-query-profiler"))) {
+      const payload = {
+        schema: "wp-codebox/bench-results/v1",
+        scenarios: [{ id: "recipe-profile", artifacts: { "rest-db-query-profile": { schema: "wp-codebox/wordpress-rest-db-query-profile/v1", summary: { case_count: 1, query_count: 7 } } } }],
+      }
+      return {
+        id: `exec-${executed.length}`,
+        command: spec.command,
+        args: spec.args ?? [],
+        exitCode: 0,
+        stdout: `${JSON.stringify(payload)}\n`,
+        stderr: "",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:00:01.000Z",
+        result: { schema: "wp-codebox/runtime-command-result/v1", status: "ok", json: payload },
+      }
+    }
     return {
       id: `exec-${executed.length}`,
       command: spec.command,
@@ -172,6 +189,23 @@ assert.equal(directJsonCollectResult.schema, "wp-codebox/wordpress-workload-run-
 assert.equal(directJsonCollectResult.steps, 2)
 assert.equal(directJsonCollectResult.artifacts["rest-db-query-profile"].schema, "wp-codebox/wordpress-rest-db-query-profile/v1")
 assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.run-php"])
+
+executed.length = 0
+const directTypedJsonCollectWorkload: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [{ command: "wordpress.run-workload", args: [`workload-json=${JSON.stringify({ schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ type: "rest-db-query-profiler", rest_request_cases: [{ id: "products", method: "GET", path: "/wc/store/v1/products" }] }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=rest_db_query_profile"] }] })}`] }],
+  },
+}
+assertWorkspaceRecipeJsonSchema(directTypedJsonCollectWorkload, { recipeCommandIds: ["wordpress.run-workload", "wordpress.bench", "wordpress.collect-workload-result"] })
+const directTypedJsonCollectExecution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: directTypedJsonCollectWorkload.workflow.steps[0]! }, process.cwd())
+const directTypedJsonCollectResult = JSON.parse(directTypedJsonCollectExecution.stdout)
+assert.equal(directTypedJsonCollectExecution.exitCode, 0)
+assert.equal(directTypedJsonCollectResult.schema, "wp-codebox/wordpress-workload-run-result/v1")
+assert.equal(directTypedJsonCollectResult.steps, 2)
+assert.equal(directTypedJsonCollectResult.artifacts["rest-db-query-profile"].schema, "wp-codebox/wordpress-rest-db-query-profile/v1")
+assert.equal(directTypedJsonCollectResult.artifacts["rest-db-query-profile"].summary.query_count, 7)
+assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.bench"])
 
 executed.length = 0
 const nestedJsonWorkloadSuite = fuzzSuiteContract({


### PR DESCRIPTION
## Summary
- Extract typed REST DB query profile payloads from wp-codebox/bench-results/v1 scenario artifacts.
- Add regression coverage for workload-json rest-db-query-profiler collection through wordpress.bench output.

## Verification
- npx tsx tests/nested-fuzz-suite-recipe-command.test.ts
- npm run build
- npm run test:playground-fuzz-suite-public

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Subagent diagnosed the missing bench-results payload extraction path and implemented focused coverage with Chris's direction.