### PR TITLE
Collect scenario workload artifacts

### DIFF
--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -295,6 +295,9 @@ function collectRecipeArtifactPayloadsFromContainer(container: Record<string, un
     const payload = isRecord(value) ? value : undefined
     if (payload && (!expectedSchema || payload.schema === expectedSchema)) out.push({ name, payload })
   }
+  for (const scenario of Array.isArray(container.scenarios) ? container.scenarios : []) {
+    if (isRecord(scenario)) collectRecipeArtifactPayloadsFromContainer(scenario, artifact, expectedSchema, out)
+  }
   for (const nestedStep of Array.isArray(container.steps) ? container.steps : []) {
     if (isRecord(nestedStep)) collectRecipeArtifactPayloadsFromContainer(nestedStep, artifact, expectedSchema, out)
   }
@@ -338,8 +341,20 @@ function recipeWorkloadExecutionArtifacts(executions: ExecutionResult[]): Record
       artifacts[name] = profile
       restDbQueryProfileIndex += 1
     }
+    for (const { name, payload } of recipeAllWorkloadArtifactPayloadsFromJson(json)) {
+      const fingerprint = `${name}:${JSON.stringify(payload)}`
+      if (seen.has(fingerprint)) continue
+      seen.add(fingerprint)
+      artifacts[name] = payload
+    }
   }
   return artifacts
+}
+
+function recipeAllWorkloadArtifactPayloadsFromJson(json: Record<string, unknown> | undefined): Array<{ name: string; payload: Record<string, unknown> }> {
+  const payloads: Array<{ name: string; payload: Record<string, unknown> }> = []
+  collectRecipeArtifactPayloadsFromContainer(json, "", undefined, payloads)
+  return payloads.filter(({ payload }) => typeof payload.schema === "string")
 }
 
 function recipeWorkloadResultArtifactRefs(execution: ExecutionResult): NonNullable<ExecutionResult["artifactRefs"]> {

--- a/tests/nested-fuzz-suite-recipe-command.test.ts
+++ b/tests/nested-fuzz-suite-recipe-command.test.ts
@@ -65,6 +65,23 @@ const runtime = {
         result: { schema: "wp-codebox/runtime-command-result/v1", status: "ok", json: payload },
       }
     }
+    if (spec.command === "wordpress.bench" && (spec.args ?? []).some((arg) => arg.includes("db-inventory"))) {
+      const payload = {
+        schema: "wp-codebox/bench-results/v1",
+        scenarios: [{ id: "recipe-db-inventory", artifacts: { "db-inventory": { schema: "wp-codebox/wordpress-db-inventory/v1", inventory: { totals: { tableCount: 12 } } } } }],
+      }
+      return {
+        id: `exec-${executed.length}`,
+        command: spec.command,
+        args: spec.args ?? [],
+        exitCode: 0,
+        stdout: `${JSON.stringify(payload)}\n`,
+        stderr: "",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:00:01.000Z",
+        result: { schema: "wp-codebox/runtime-command-result/v1", status: "ok", json: payload },
+      }
+    }
     return {
       id: `exec-${executed.length}`,
       command: spec.command,
@@ -205,6 +222,23 @@ assert.equal(directTypedJsonCollectResult.schema, "wp-codebox/wordpress-workload
 assert.equal(directTypedJsonCollectResult.steps, 2)
 assert.equal(directTypedJsonCollectResult.artifacts["rest-db-query-profile"].schema, "wp-codebox/wordpress-rest-db-query-profile/v1")
 assert.equal(directTypedJsonCollectResult.artifacts["rest-db-query-profile"].summary.query_count, 7)
+assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.bench"])
+
+executed.length = 0
+const directDbInventoryCollectWorkload: WorkspaceRecipe = {
+  schema: "wp-codebox/workspace-recipe/v1",
+  workflow: {
+    steps: [{ command: "wordpress.run-workload", args: [`workload-json=${JSON.stringify({ schema: "wp-codebox/wordpress-workload-run/v1", steps: [{ type: "db-inventory", "include-columns": true, "include-indexes": true }], after: [{ command: "wordpress.collect-workload-result", args: ["artifact=db_inventory"] }] })}`] }],
+  },
+}
+assertWorkspaceRecipeJsonSchema(directDbInventoryCollectWorkload, { recipeCommandIds: ["wordpress.run-workload", "wordpress.bench", "wordpress.collect-workload-result"] })
+const directDbInventoryCollectExecution = await executeRecipeWorkflowStep(runtime, { phase: "steps", index: 0, step: directDbInventoryCollectWorkload.workflow.steps[0]! }, process.cwd())
+const directDbInventoryCollectResult = JSON.parse(directDbInventoryCollectExecution.stdout)
+assert.equal(directDbInventoryCollectExecution.exitCode, 0)
+assert.equal(directDbInventoryCollectResult.schema, "wp-codebox/wordpress-workload-run-result/v1")
+assert.equal(directDbInventoryCollectResult.steps, 2)
+assert.equal(directDbInventoryCollectResult.artifacts["db-inventory"].schema, "wp-codebox/wordpress-db-inventory/v1")
+assert.equal(directDbInventoryCollectResult.artifacts["db-inventory"].inventory.totals.tableCount, 12)
 assert.deepEqual(executed.map((spec) => spec.command), ["wordpress.bench"])
 
 executed.length = 0


### PR DESCRIPTION
## Summary
- Collect typed workload artifacts from scenario containers, including `db-inventory` emitted through `wp-codebox/bench-results/v1`.
- Preserve strict `wordpress.collect-workload-result` behavior while allowing DB inventory workloads to return their durable typed payload.
- Add regression coverage for collecting `db_inventory` from a typed workload run.

## Testing
- `npm run test:nested-fuzz-suite-recipe-command`
- `npm run test:playground-fuzz-suite-public`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosed the failed WooCommerce Lab workload collection path, implemented the scenario artifact extraction fix, and ran targeted verification.
