### PR TITLE
Expose recipe-run provenance and failure inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "test:recipe-validation-descriptors": "tsx tests/recipe-validation-descriptors.test.ts",
     "test:recipe-runtime-backend-normalization": "tsx tests/recipe-runtime-backend-normalization.test.ts",
     "test:recipe-runtime-setup-staged-materialization": "tsx tests/recipe-runtime-setup-staged-materialization.test.ts",
+    "test:recipe-run-provenance": "tsx tests/recipe-run-provenance.test.ts",
     "test:fuzz-run-recipe": "tsx tests/fuzz-run-recipe.test.ts",
     "test:fuzz-suite-runner": "tsx tests/fuzz-suite-runner.test.ts",
     "test:playground-fuzz-suite-public": "tsx tests/playground-fuzz-suite-public.test.ts",

--- a/packages/cli/src/commands/recipe-run-finalizer.ts
+++ b/packages/cli/src/commands/recipe-run-finalizer.ts
@@ -58,6 +58,7 @@ interface RecipeRunCommonOutputFields {
   completionOutcome?: RecipeRunOutput["completionOutcome"]
   replayStatus?: RecipeRunOutput["replayStatus"]
   fuzzRun?: RecipeRunOutput["fuzzRun"]
+  provenance?: RecipeRunOutput["provenance"]
   artifacts?: ArtifactBundle
   interruption?: RecipeRunOutput["interruption"]
 }
@@ -135,7 +136,7 @@ export function completedRecipeOutputFields(args: {
   }
 }
 
-export async function finalizeRecipeValidationFailure(args: RecipeRunFinalizerBase & { failure: RunOutput["error"]; componentContracts?: RecipeRunComponentContract[]; validation: RecipeRunOutput["validation"] }): Promise<RecipeRunOutput> {
+export async function finalizeRecipeValidationFailure(args: RecipeRunFinalizerBase & { failure: RunOutput["error"]; componentContracts?: RecipeRunComponentContract[]; validation: RecipeRunOutput["validation"]; provenance?: RecipeRunOutput["provenance"] }): Promise<RecipeRunOutput> {
   let runRecord = await args.runRegistry.update(args.runRecord.runId, {
     status: "failed",
     metadata: { runResourceEvidence: await runResourceEvidence({ startedAtMs: args.startedAtMs, status: "failed", failure: args.failure }) },
@@ -148,6 +149,7 @@ export async function finalizeRecipeValidationFailure(args: RecipeRunFinalizerBa
     executions: [],
     componentContracts: args.componentContracts,
     validation: args.validation,
+    provenance: args.provenance,
     run: runRecord,
     error: args.failure,
   })

--- a/packages/cli/src/commands/recipe-run-types.ts
+++ b/packages/cli/src/commands/recipe-run-types.ts
@@ -1,4 +1,4 @@
-import type { AgentTerminalResult, ArtifactBundle, BenchResults, ExecutionResult, PreviewLease, RecipeRunSummary, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef, WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
+import type { AgentTerminalResult, ArtifactBundle, ArtifactPackageProvenance, BenchResults, ExecutionResult, PreviewLease, RecipeRunSummary, RuntimeInfo, RuntimeRunRecord, TypedArtifactRef, WorkspaceRecipe, WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
 import type { RecipeDryRunOutput, RecipeDryRunSiteSeed, RecipeDryRunStagedFile } from "../recipe-dry-run.js"
 import type { AgentSandboxResultSummary, AgentTaskSingleResult, RecipeReplayStatusSummary, SandboxCompletionOutcome } from "../recipe-evidence.js"
 import type { RecipeExternalServiceBoundaryHostCorrelation } from "../recipe-external-services.js"
@@ -75,12 +75,24 @@ export interface RecipeRunOutput {
   completionOutcome?: SandboxCompletionOutcome
   replayStatus?: RecipeReplayStatusSummary
   fuzzRun?: RecipeFuzzRunResult
+  provenance?: RecipeRunProvenance
   result?: RecipeRunSummary
   artifacts?: ArtifactBundle
   run?: RuntimeRunRecord
   interruption?: RecipeInterruptionMetadata
   logs?: string[]
   error?: RunOutput["error"]
+}
+
+export interface RecipeRunProvenance {
+  schema: "wp-codebox/recipe-run-provenance/v1"
+  packages: ArtifactPackageProvenance
+  recipe?: {
+    path?: string
+    sha256?: string
+    effectiveSha256?: string
+    effectiveRecipeRef?: RecipeDiagnosticArtifactRef
+  }
 }
 
 export type RecipeRunCommandOutput = RecipeRunOutput | RecipeDryRunOutput
@@ -105,11 +117,19 @@ export type RecipeExecutionResult = ExecutionResult & {
   recipePhase?: RecipeWorkflowPhase
   recipeStepIndex?: number
   recipeCommand?: string
+  recipeArgs?: RecipeWorkflowArgsEvidence
   recipeAdvisory?: boolean
   fuzzCaseId?: string
   fuzzCaseIndex?: number
   fuzzPhase?: WorkspaceRecipeFuzzCasePhase
   fuzzStepIndex?: number
+}
+
+export interface RecipeWorkflowArgsEvidence {
+  schema: "wp-codebox/recipe-workflow-args/v1"
+  original: string[]
+  effective: string[]
+  rewritten: boolean
 }
 
 export type RecipeFuzzCaseStatus = "passed" | "failed" | "skipped"
@@ -219,6 +239,14 @@ export interface RecipeArtifactPointerState {
   browserEvidence?: RecipeBrowserEvidence[]
   diagnosticArtifacts?: RecipeDiagnosticArtifactRef[]
   result?: RecipeRunSummary
+}
+
+export interface RecipeEffectiveRecipeArtifact {
+  schema: "wp-codebox/recipe-run-effective-recipe/v1"
+  createdAt: string
+  recipePath: string
+  recipe: WorkspaceRecipe
+  sha256: string
 }
 
 export interface RecipeDiagnosticArtifactRef {

--- a/packages/cli/src/commands/recipe-run-workflow-evidence.ts
+++ b/packages/cli/src/commands/recipe-run-workflow-evidence.ts
@@ -10,7 +10,7 @@ import { recipeWorkflowSteps, type RecipeWorkflowPhase } from "../recipe-validat
 import { artifactManifestFilesByPath } from "./recipe-run-benchmark-artifacts.js"
 import { rewriteInputMountPathArgs, type InputMountPathMapping } from "./recipe-runtime-setup.js"
 import { serializeRecipeRunError } from "./recipe-run-output.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe } from "./recipe-run-types.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeBrowserEvidenceFileRef, RecipeExecutionResult, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunOptions, RecipeRunProbe, RecipeWorkflowArgsEvidence } from "./recipe-run-types.js"
 
 export function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase: RecipeWorkflowPhase, recipeStepIndex: number, recipeCommand?: string): RecipeExecutionResult {
   return {
@@ -18,6 +18,21 @@ export function withRecipeExecutionPhase(execution: ExecutionResult, recipePhase
     recipePhase,
     recipeStepIndex,
     recipeCommand,
+  }
+}
+
+export function recipeWorkflowArgsEvidence(original: readonly string[] | undefined, effective: readonly string[] | undefined): RecipeWorkflowArgsEvidence | undefined {
+  const originalArgs = [...(original ?? [])]
+  const effectiveArgs = [...(effective ?? [])]
+  if (originalArgs.length === 0 && effectiveArgs.length === 0) {
+    return undefined
+  }
+
+  return {
+    schema: "wp-codebox/recipe-workflow-args/v1",
+    original: originalArgs,
+    effective: effectiveArgs,
+    rewritten: JSON.stringify(originalArgs) !== JSON.stringify(effectiveArgs),
   }
 }
 
@@ -132,6 +147,7 @@ function recipeCommandProducesBrowserEvidence(command: string): boolean {
 }
 
 export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: ReturnType<typeof recipeWorkflowSteps>[number], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, artifactRoot?: string, options?: RecipeRunOptions, inputMountPathMap: readonly InputMountPathMapping[] = []): Promise<RecipeExecutionResult> {
+  const argsEvidence = recipeWorkflowArgsEvidence(workflowStep.step.args, rewriteInputMountPathArgs(workflowStep.step.args ?? [], inputMountPathMap))
   const step = { ...workflowStep.step, args: rewriteInputMountPathArgs(workflowStep.step.args ?? [], inputMountPathMap) }
   const mappedWorkflowStep = { ...workflowStep, step }
   try {
@@ -158,6 +174,7 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
           startedAt,
           finishedAt,
         }, workflowStep.phase, workflowStep.index, step.command),
+        ...(argsEvidence ? { recipeArgs: argsEvidence } : {}),
         ...(workflowStep.fuzzCaseId ? { fuzzCaseId: workflowStep.fuzzCaseId } : {}),
         ...(workflowStep.fuzzCaseIndex !== undefined ? { fuzzCaseIndex: workflowStep.fuzzCaseIndex } : {}),
         ...(workflowStep.fuzzPhase ? { fuzzPhase: workflowStep.fuzzPhase } : {}),
@@ -165,17 +182,18 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
       }
     }
     if (isRuntimeCheckpointRecipeCommand(step.command)) {
-      return withRecipeExecutionPhase(await executeRuntimeCheckpointRecipeCommand(runtime, step.command, step.args ?? []), workflowStep.phase, workflowStep.index, step.command)
+      return withRecipeExecutionArgs(withRecipeExecutionPhase(await executeRuntimeCheckpointRecipeCommand(runtime, step.command, step.args ?? []), workflowStep.phase, workflowStep.index, step.command), argsEvidence)
     }
     if (step.command === "wp-codebox/run-fuzz-suite") {
-      return withRecipeExecutionPhase(await executeRunFuzzSuiteRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, inputMountPathMap), workflowStep.phase, workflowStep.index, step.command)
+      return withRecipeExecutionArgs(withRecipeExecutionPhase(await executeRunFuzzSuiteRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, inputMountPathMap), workflowStep.phase, workflowStep.index, step.command), argsEvidence)
     }
     if (step.command === "wordpress.run-workload" && commandArgValue(step.args ?? [], "workload-json")) {
-      return withRecipeExecutionPhase(await executeWordPressRunWorkloadJsonRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap), workflowStep.phase, workflowStep.index, step.command)
+      return withRecipeExecutionArgs(withRecipeExecutionPhase(await executeWordPressRunWorkloadJsonRecipeCommand(runtime, step.args ?? [], recipeDirectory, sandboxWorkspace, undefined, undefined, inputMountPathMap), workflowStep.phase, workflowStep.index, step.command), argsEvidence)
     }
     const execution = await runtime.execute(await recipeExecutionSpec(step, recipeDirectory, sandboxWorkspace))
     return {
       ...withRecipeExecutionPhase(execution, workflowStep.phase, workflowStep.index, step.command),
+      ...(argsEvidence ? { recipeArgs: argsEvidence } : {}),
       ...(workflowStep.fuzzCaseId ? { fuzzCaseId: workflowStep.fuzzCaseId } : {}),
       ...(workflowStep.fuzzCaseIndex !== undefined ? { fuzzCaseIndex: workflowStep.fuzzCaseIndex } : {}),
       ...(workflowStep.fuzzPhase ? { fuzzPhase: workflowStep.fuzzPhase } : {}),
@@ -185,6 +203,10 @@ export async function executeRecipeWorkflowStep(runtime: Runtime, workflowStep: 
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Recipe workflow ${mappedWorkflowStep.phase}[${mappedWorkflowStep.index}] failed: ${message}`, { cause: error })
   }
+}
+
+function withRecipeExecutionArgs(execution: RecipeExecutionResult, argsEvidence: RecipeWorkflowArgsEvidence | undefined): RecipeExecutionResult {
+  return argsEvidence ? { ...execution, recipeArgs: argsEvidence } : execution
 }
 
 async function executeWordPressRunWorkloadJsonRecipeCommand(runtime: Runtime, args: string[], recipeDirectory: string, sandboxWorkspace?: ReturnType<typeof sandboxWorkspaceContract>, suite?: FuzzSuiteContract, fuzzCase?: unknown, inputMountPathMap: readonly InputMountPathMapping[] = []): Promise<ExecutionResult> {

--- a/packages/cli/src/commands/recipe-run.ts
+++ b/packages/cli/src/commands/recipe-run.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
 import { basename, dirname, join, resolve } from "node:path"
-import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRecipeRunSummary, normalizeRuntimeEnvRecord, parseCommandOptions, type ArtifactBundle, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
+import { DEFAULT_WORDPRESS_VERSION, createRuntime, normalizeRecipeRunSummary, normalizeRuntimeEnvRecord, parseCommandOptions, type ArtifactBundle, type ArtifactPackageIdentity, type ArtifactPackageProvenance, type Runtime, type RuntimeAssetSpec, type RuntimePreviewSpec, type RuntimeRunRegistry, type WorkspaceRecipe, type WorkspaceRecipeComponentManifest, type WorkspaceRecipeExtraPlugin, type WorkspaceRecipeFixtureDatabase, type WorkspaceRecipeFuzzCasePhase } from "@automattic/wp-codebox-core"
 import { stripUndefined } from "@automattic/wp-codebox-core/internals"
 import { recipeExecutionSpec, sandboxWorkspaceContract } from "../agent-sandbox.js"
 import { captureStdout, printRecipeHumanOutput, printRecipeValidateHumanOutput, serializeError } from "../output.js"
@@ -26,12 +28,13 @@ import { bestEffortTimeout, exitAfterPlaygroundCliBootFailure, exitAfterRecipeRu
 import { RecipePhaseError } from "./recipe-run-phases.js"
 import { markPreviewLeaseAvailable, markPreviewLeaseFailed, markPreviewLeaseReleased, startPreviewLeaseRecipeRun } from "./preview-lease.js"
 import { importRecipeSiteSeeds } from "./recipe-site-seeds.js"
-import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRuntimeSetup, recipeRunDependencyOverlay, recipeRunExtraPlugin, recipeRunStagedFile } from "./recipe-runtime-setup.js"
-import { distributionStartupProbeFailure, executeRecipeCollectWorkloadResult, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowStepIsAdvisory, runDistributionSetupArtifacts, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
-import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeExecutionResult, RecipeFuzzCaseCommandRef, RecipeFuzzCaseResult, RecipeFuzzCaseStatus, RecipeFuzzRunResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
+import { applyRecipeRuntimeSetup, cleanupInputMountBaselines, prepareRecipeRuntimeSetup, recipeRunDependencyOverlay, recipeRunExtraPlugin, recipeRunStagedFile, rewriteInputMountPathArgs } from "./recipe-runtime-setup.js"
+import { distributionStartupProbeFailure, executeRecipeCollectWorkloadResult, executeRecipeWorkflowStep, recipeAdvisoryFailure, recipeBrowserEvidence, recipeWorkflowArgsEvidence, recipeWorkflowStepIsAdvisory, runDistributionSetupArtifacts, runDistributionStartupProbes, runRecipeProbes, withRecipeExecutionPhase } from "./recipe-run-workflow-evidence.js"
+import type { RecipeAdvisoryFailure, RecipeBrowserEvidence, RecipeDiagnosticArtifactRef, RecipeEffectiveRecipeArtifact, RecipeExecutionResult, RecipeFuzzCaseCommandRef, RecipeFuzzCaseResult, RecipeFuzzCaseStatus, RecipeFuzzRunResult, RecipeInterruptionController, RecipePhaseEvidence, RecipePhaseName, RecipePhpWasmRuntimeDiagnostic, RecipeRunCommandOutput, RecipeRunComponentContract, RecipeRunDeclaredArtifact, RecipeRunDistributionSetupArtifact, RecipeRunDistributionStartupProbe, RecipeRunFixtureDatabase, RecipeRunOptions, RecipeRunOutput, RecipeRunProbe, RecipeRunProvenance, RecipeRunStagedFile, RecipeRuntimeDiagnostic, RecipeValidateOptions, RecipeValidateOutput } from "./recipe-run-types.js"
 
 const DEFAULT_RECIPE_RUN_TIMEOUT_MS = 25 * 60 * 1000
 const SUCCESSFUL_RECIPE_RUNTIME_SNAPSHOT_TIMEOUT_MS = 120 * 1000
+const packageRequire = createRequire(import.meta.url)
 export async function runRecipeRunCommand(args: string[]): Promise<number> {
   const options = parseRecipeRunOptions(args)
   if (options.previewLeaseRequested && !options.previewLeaseChild) {
@@ -101,6 +104,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
   const context = await createRecipeRunContext(options)
   const { recipePath, recipeDirectory, recipe, configuredArtifactsDirectory, runRegistry, artifactPointer, startedAtMs } = context
   let { runRecord } = context
+  runRecord = await runRegistry.update(runRecord.runId, { metadata: { provenance: recipeRunProvenance(recipe, recipePath) } })
   await artifactPointer.update({ commandStatus: "queued" })
   const issues = await validateWorkspaceRecipe(recipe, recipePath)
   if (issues.length > 0) {
@@ -118,6 +122,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       failure,
       componentContracts: componentContractResults(recipe, [], [], [], failure),
       validation: { issues },
+      provenance: recipeRunProvenance(recipe, recipePath),
     })
   }
 
@@ -268,7 +273,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         const operation = `workflow.${workflowStep.phase}[${workflowStep.index}]:${workflowStep.step.command}`
         try {
           const execution = await awaitRecipe(operation, async () => workflowStep.step.command === "wordpress.collect-workload-result"
-            ? withRecipeExecutionPhase(executeRecipeCollectWorkloadResult(workflowStep.step, executions, new Date().toISOString()), workflowStep.phase, workflowStep.index, workflowStep.step.command)
+            ? withRecipeExecutionArgs(withRecipeExecutionPhase(executeRecipeCollectWorkloadResult(workflowStep.step, executions, new Date().toISOString()), workflowStep.phase, workflowStep.index, workflowStep.step.command), recipeWorkflowArgsEvidence(workflowStep.step.args, workflowStep.step.args))
             : executeRecipeWorkflowStep(runtime!, workflowStep, recipeDirectory, sandboxWorkspace, configuredArtifactsDirectory, options, inputMountPathMap))
           executions.push({ ...execution, ...(recipeWorkflowStepIsAdvisory(workflowStep.step) ? { recipeAdvisory: true } : {}) })
           interruption?.throwIfInterrupted()
@@ -378,7 +383,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         browserEvidence,
         replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
         failure: recipeFailure,
-        output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }),
+        output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), provenance: recipeRunProvenance(recipe, recipePath) },
       })
     }
 
@@ -397,7 +402,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
       phaseEvidence: phaseTracker.list(),
       browserEvidence,
       replayStatus: evidence.replayStatus ? recipeReplayStatusOutput(evidence.replayStatus) : undefined,
-      output: completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }),
+      output: { ...completedRecipeOutputFields({ executions, componentContracts: componentContractResults(recipe, extraPlugins, phaseTracker.list(), executions), stagedFiles: stagedFiles.map(recipeRunStagedFile), fixtureDatabases, siteSeeds, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts, phaseEvidence: phaseTracker.list(), advisoryFailures, browserEvidence, benchResultsList, fuzzRun: fuzzRunResult, evidence }), provenance: recipeRunProvenance(recipe, recipePath) },
     })
   } catch (error) {
     await markPreviewLeaseFailed(options.previewLeaseFile, error)
@@ -405,6 +410,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     const failureDiagnostics = recipeFailureRuntimeEvidenceFile({
       recipe,
       recipePath,
+      inputMountPathMap,
       extraPlugins,
       dependencyOverlays,
       workspaceMounts,
@@ -445,10 +451,11 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
           await materializeTypedRecipeDeclaredArtifacts(artifacts, declaredArtifacts)
           const evidenceFiles = await appendRecipeRuntimeEvidence(artifacts, [
             ...recipeRuntimeEvidenceFiles(fixtureDatabases, distributionSetupArtifacts, distributionStartupProbes, probes, declaredArtifacts),
+            recipeEffectiveRecipeEvidenceFile(recipe, recipePath, inputMountPathMap),
             failureDiagnostics,
           ])
           diagnosticArtifacts = evidenceFiles
-            .filter((file) => file.kind === failureDiagnostics.kind)
+            .filter((file) => file.kind === failureDiagnostics.kind || file.kind === "recipe-run-effective-recipe")
             .map((file) => ({ path: join(basename(collectedArtifacts.directory), file.path), kind: file.kind, contentType: file.contentType, sha256: file.sha256 }))
         } catch {
           // Preserve the original recipe failure; failure recovery already kept the base artifact bundle.
@@ -470,8 +477,10 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
     }
 
     if (diagnosticArtifacts.length === 0) {
-      const fallbackDiagnostic = await writeRecipeFailureDiagnosticArtifact(configuredArtifactsDirectory, failureDiagnostics.value)
-      diagnosticArtifacts = fallbackDiagnostic ? [fallbackDiagnostic] : []
+      diagnosticArtifacts = await writeRecipeFailureDiagnosticArtifacts(configuredArtifactsDirectory, [
+        recipeEffectiveRecipeEvidenceFile(recipe, recipePath, inputMountPathMap),
+        failureDiagnostics,
+      ])
     }
 
     cleanupEvidence = await runRecipeCleanup(runRegistry, runRecord, async () => {
@@ -510,6 +519,7 @@ async function runRecipe(options: RecipeRunOptions, interruption?: RecipeInterru
         ...(browserEvidence.length > 0 ? { browserEvidence } : {}),
         ...(fuzzRunResult ? { fuzzRun: fuzzRunResult } : {}),
         diagnostics: recipeRuntimeDiagnostics(recipe, executions, error),
+        provenance: recipeRunProvenance(recipe, recipePath, diagnosticArtifacts),
       },
     })
   } finally {
@@ -566,6 +576,10 @@ function watchRunCancellationRequests(runRegistry: RuntimeRunRegistry, runId: st
       clearInterval(timer)
     },
   }
+}
+
+function withRecipeExecutionArgs(execution: RecipeExecutionResult, argsEvidence: RecipeExecutionResult["recipeArgs"]): RecipeExecutionResult {
+  return argsEvidence ? { ...execution, recipeArgs: argsEvidence } : execution
 }
 
 function resolveRecipeRuntimeAssets(recipe: WorkspaceRecipe, recipeDirectory: string): RuntimeAssetSpec | undefined {
@@ -785,6 +799,7 @@ async function importRecipeFixtureDatabases(recipe: WorkspaceRecipe, recipeDirec
 function recipeFailureRuntimeEvidenceFile(args: {
   recipe: WorkspaceRecipe
   recipePath: string
+  inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]>
   extraPlugins: PreparedExtraPlugin[]
   dependencyOverlays: PreparedDependencyOverlay[]
   workspaceMounts: PreparedWorkspaceMount[]
@@ -806,11 +821,15 @@ function recipeFailureRuntimeEvidenceFile(args: {
     value: stripUndefined({
       schema: "wp-codebox/recipe-run-failure-diagnostics/v1",
       createdAt: new Date().toISOString(),
+      provenance: recipeRunProvenance(args.recipe, args.recipePath),
       recipe: {
         path: args.recipePath,
         schema: args.recipe.schema,
+        sourceSha256: recipeDigest(args.recipe),
+        effectiveSha256: recipeDigest(effectiveRecipeForReplay(args.recipe, args.inputMountPathMap)),
+        effectiveJson: effectiveRecipeForReplay(args.recipe, args.inputMountPathMap),
         runtime: args.recipe.runtime ?? {},
-        workflow: recipeWorkflowMetadata(args.recipe),
+        workflow: effectiveRecipeWorkflowMetadata(args.recipe, args.inputMountPathMap),
         inputs: {
           extra_plugins: args.extraPlugins.map(recipeRunExtraPlugin),
           dependency_overlays: args.dependencyOverlays.map(recipeRunDependencyOverlay),
@@ -835,22 +854,36 @@ function recipeFailureRuntimeEvidenceFile(args: {
   }
 }
 
-async function writeRecipeFailureDiagnosticArtifact(artifactsDirectory: string | undefined, value: unknown): Promise<RecipeDiagnosticArtifactRef | undefined> {
+function recipeEffectiveRecipeEvidenceFile(recipe: WorkspaceRecipe, recipePath: string, inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]>): { filename: string; kind: string; value: RecipeEffectiveRecipeArtifact } {
+  const effectiveRecipe = effectiveRecipeForReplay(recipe, inputMountPathMap)
+  return {
+    filename: "recipe-run-effective-recipe.json",
+    kind: "recipe-run-effective-recipe",
+    value: {
+      schema: "wp-codebox/recipe-run-effective-recipe/v1",
+      createdAt: new Date().toISOString(),
+      recipePath,
+      recipe: effectiveRecipe,
+      sha256: recipeDigest(effectiveRecipe),
+    },
+  }
+}
+
+async function writeRecipeFailureDiagnosticArtifacts(artifactsDirectory: string | undefined, files: Array<{ filename: string; kind: string; value: unknown }>): Promise<RecipeDiagnosticArtifactRef[]> {
   if (!artifactsDirectory) {
-    return undefined
+    return []
   }
 
   const directory = resolve(artifactsDirectory)
-  const path = join(directory, "recipe-run-failure-diagnostics.json")
-  const contents = `${JSON.stringify(value, null, 2)}\n`
   await mkdir(directory, { recursive: true })
-  await writeFile(path, contents)
-  return {
-    path: "recipe-run-failure-diagnostics.json",
-    kind: "recipe-run-failure-diagnostics",
-    contentType: "application/json",
-    sha256: createHash("sha256").update(contents).digest("hex"),
+  const refs: RecipeDiagnosticArtifactRef[] = []
+  for (const file of files) {
+    const path = join(directory, file.filename)
+    const contents = `${JSON.stringify(file.value, null, 2)}\n`
+    await writeFile(path, contents)
+    refs.push({ path: file.filename, kind: file.kind, contentType: "application/json", sha256: createHash("sha256").update(contents).digest("hex") })
   }
+  return refs
 }
 
 function parseFixtureDatabaseImportResult(stdout: string): { counts: Record<string, number> } {
@@ -1155,6 +1188,115 @@ function recipeWorkflowMetadata(recipe: WorkspaceRecipe): { before?: Array<{ com
     steps: recipe.workflow.steps.map(recipeStepMetadata),
     ...(recipe.workflow.after ? { after: recipe.workflow.after.map(recipeStepMetadata) } : {}),
   }
+}
+
+function effectiveRecipeWorkflowMetadata(recipe: WorkspaceRecipe, inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]>): { before?: Array<Record<string, unknown>>; steps: Array<Record<string, unknown>>; after?: Array<Record<string, unknown>> } {
+  return {
+    ...(recipe.workflow.before ? { before: recipe.workflow.before.map((step) => effectiveRecipeStepMetadata(step, inputMountPathMap)) } : {}),
+    steps: recipe.workflow.steps.map((step) => effectiveRecipeStepMetadata(step, inputMountPathMap)),
+    ...(recipe.workflow.after ? { after: recipe.workflow.after.map((step) => effectiveRecipeStepMetadata(step, inputMountPathMap)) } : {}),
+  }
+}
+
+function effectiveRecipeStepMetadata(step: WorkspaceRecipe["workflow"]["steps"][number], inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]>): Record<string, unknown> {
+  const original = step.args ?? []
+  const effective = rewriteInputMountPathArgsForEvidence(original, inputMountPathMap)
+  return stripUndefined({ command: step.command, args: effective, originalArgs: original, effectiveArgs: effective, argsRewritten: JSON.stringify(original) !== JSON.stringify(effective) })
+}
+
+function effectiveRecipeForReplay(recipe: WorkspaceRecipe, inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]>): WorkspaceRecipe {
+  return {
+    ...recipe,
+    workflow: stripUndefined({
+      ...recipe.workflow,
+      ...(recipe.workflow.before ? { before: recipe.workflow.before.map((step) => effectiveRecipeStepForReplay(step, inputMountPathMap)) } : {}),
+      steps: recipe.workflow.steps.map((step) => effectiveRecipeStepForReplay(step, inputMountPathMap)),
+      ...(recipe.workflow.after ? { after: recipe.workflow.after.map((step) => effectiveRecipeStepForReplay(step, inputMountPathMap)) } : {}),
+    }) as WorkspaceRecipe["workflow"],
+  }
+}
+
+function effectiveRecipeStepForReplay(step: WorkspaceRecipe["workflow"]["steps"][number], inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]>): WorkspaceRecipe["workflow"]["steps"][number] {
+  return { ...step, args: rewriteInputMountPathArgsForEvidence(step.args ?? [], inputMountPathMap) }
+}
+
+function rewriteInputMountPathArgsForEvidence(args: readonly string[], inputMountPathMap: NonNullable<Awaited<ReturnType<typeof prepareRecipeRuntimeSetup>>["inputMountPathMap"]>): string[] {
+  return rewriteInputMountPathArgs([...args], inputMountPathMap)
+}
+
+function recipeDigest(recipe: WorkspaceRecipe): string {
+  return createHash("sha256").update(`${JSON.stringify(recipe, null, 2)}\n`).digest("hex")
+}
+
+function recipeRunProvenance(recipe: WorkspaceRecipe, recipePath: string, diagnosticArtifacts: RecipeDiagnosticArtifactRef[] = []): RecipeRunProvenance {
+  const effectiveRecipeRef = diagnosticArtifacts.find((artifact) => artifact.kind === "recipe-run-effective-recipe")
+  return stripUndefined({
+    schema: "wp-codebox/recipe-run-provenance/v1",
+    packages: packageProvenance(recipe),
+    recipe: stripUndefined({
+      path: recipePath,
+      sha256: recipeDigest(recipe),
+      effectiveSha256: effectiveRecipeRef?.sha256,
+      effectiveRecipeRef,
+    }),
+  }) as RecipeRunProvenance
+}
+
+function packageProvenance(recipe: WorkspaceRecipe): ArtifactPackageProvenance {
+  const rootPackage = readPackageIdentity("../../../../package.json", "wp-codebox")
+  const cliPackage = readPackageIdentity("../../package.json", "@automattic/wp-codebox-cli")
+  const corePackage = readPackageIdentity("../../../runtime-core/package.json", "@automattic/wp-codebox-core")
+  const playgroundPackage = readPackageIdentity("../../../runtime-playground/package.json", "@automattic/wp-codebox-playground")
+  const playgroundCliVersion = packageDependencyVersion(playgroundPackage.manifest, "@wp-playground/cli")
+  const wordpressBuildsVersion = packageDependencyVersion(playgroundPackage.manifest, "@wp-playground/wordpress-builds")
+
+  return stripUndefined({
+    schema: "wp-codebox/package-provenance/v1",
+    wpCodebox: rootPackage.identity,
+    runtimeCore: corePackage.identity,
+    runtimePlayground: playgroundPackage.identity,
+    cli: cliPackage.identity,
+    playground: stripUndefined({
+      cli: playgroundCliVersion ? { name: "@wp-playground/cli", version: playgroundCliVersion } : undefined,
+      wordpressBuilds: wordpressBuildsVersion ? { name: "@wp-playground/wordpress-builds", version: wordpressBuildsVersion } : undefined,
+    }),
+    environment: stripUndefined({
+      wordpressVersion: recipe.runtime?.wp,
+      phpVersion: recipe.runtime?.phpVersion,
+      nodeVersion: process.versions.node,
+    }),
+  }) as ArtifactPackageProvenance
+}
+
+function readPackageIdentity(packagePath: string, fallbackName: string): { identity: ArtifactPackageIdentity; manifest: Record<string, unknown> } {
+  try {
+    const contents = readPackageContents(packagePath)
+    const manifest = JSON.parse(contents) as Record<string, unknown>
+    return {
+      identity: stripUndefined({
+        name: stringValue(manifest.name) ?? fallbackName,
+        version: stringValue(manifest.version),
+        source: stripUndefined({
+          ref: stringValue(manifest.gitHeadRef) ?? process.env.WP_CODEBOX_SOURCE_REF ?? process.env.GITHUB_REF_NAME ?? process.env.GITHUB_REF,
+          sha: stringValue(manifest.gitHead) ?? process.env.WP_CODEBOX_SOURCE_SHA ?? process.env.GITHUB_SHA,
+          digest: { algorithm: "sha256" as const, value: createHash("sha256").update(contents).digest("hex") },
+        }),
+      }) as ArtifactPackageIdentity,
+      manifest,
+    }
+  } catch {
+    return { identity: { name: fallbackName }, manifest: {} }
+  }
+}
+
+function readPackageContents(packagePath: string): string {
+  return readFileSync(packageRequire.resolve(packagePath), "utf8")
+}
+
+function packageDependencyVersion(manifest: Record<string, unknown>, name: string): string | undefined {
+  return stringValue(recordValue(manifest.dependencies)?.[name])
+    ?? stringValue(recordValue(manifest.devDependencies)?.[name])
+    ?? stringValue(recordValue(manifest.peerDependencies)?.[name])
 }
 
 function recipeStepMetadata(step: WorkspaceRecipe["workflow"]["steps"][number]): { command: string; args: string[] } {

--- a/packages/runtime-core/src/recipe-run-summary.ts
+++ b/packages/runtime-core/src/recipe-run-summary.ts
@@ -18,6 +18,7 @@ export interface RecipeRunSummary {
   commands: RecipeRunCommandSummary[]
   runtime_access?: RuntimeAccess
   preview?: RecipeRunPreviewSummary
+  provenance?: Record<string, unknown>
   refs: {
     startup_logs: AgentTaskRunArtifactRef[]
     probe_json: AgentTaskRunArtifactRef[]
@@ -97,6 +98,7 @@ export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummar
     commands,
     runtime_access: runtimeAccess,
     preview,
+    provenance: objectOrUndefined(result.provenance),
     metadata: stripUndefined({
       run_id: stringValue(objectValue(result.run).runId) || stringValue(objectValue(result.run_metadata).run_id) || stringValue(agentTask.metadata.run_id),
       run_status: stringValue(objectValue(result.run).status) || stringValue(objectValue(result.run_metadata).run_status) || stringValue(agentTask.metadata.run_status),
@@ -106,8 +108,14 @@ export function normalizeRecipeRunSummary(raw: unknown, options: RecipeRunSummar
       failure_phase: failedPhase,
       artifact_directory: stringValue(objectValue(result.artifacts).directory) || stringValue(result.artifacts),
       recipe_path: stringValue(result.recipePath),
+      package_provenance: objectOrUndefined(objectValue(result.provenance).packages),
     }),
   }) as RecipeRunSummary
+}
+
+function objectOrUndefined(value: unknown): Record<string, unknown> | undefined {
+  const object = objectValue(value)
+  return Object.keys(object).length > 0 ? object : undefined
 }
 
 function recipeRunStatus(result: Record<string, unknown>, success: boolean): RecipeRunSummaryStatus {

--- a/packages/runtime-core/src/runtime-contracts.ts
+++ b/packages/runtime-core/src/runtime-contracts.ts
@@ -922,6 +922,7 @@ export interface ArtifactProvenance {
 export interface ArtifactPackageProvenance {
   schema: "wp-codebox/package-provenance/v1"
   wpCodebox?: ArtifactPackageIdentity
+  cli?: ArtifactPackageIdentity
   runtimeCore?: ArtifactPackageIdentity
   runtimePlayground?: ArtifactPackageIdentity
   playground?: {

--- a/scripts/recipe-run-activation-failure-artifacts-smoke.ts
+++ b/scripts/recipe-run-activation-failure-artifacts-smoke.ts
@@ -64,6 +64,8 @@ register_activation_hook(__FILE__, function () {
   const output = JSON.parse(result.stdout)
   assert.equal(output.schema, "wp-codebox/recipe-run/v1")
   assert.equal(output.success, false)
+  assert.equal(output.provenance.schema, "wp-codebox/recipe-run-provenance/v1")
+  assert.equal(output.provenance.packages.schema, "wp-codebox/package-provenance/v1")
   assert.match(JSON.stringify(output.error), /activation failure smoke sentinel|Failed to activate extra plugin/i)
   assert.ok(output.artifacts?.directory, "activation failure should report a runtime artifact directory")
 
@@ -76,17 +78,29 @@ register_activation_hook(__FILE__, function () {
 
   const failureDiagnostic = pointer.diagnosticArtifacts.find((artifact: { kind?: string }) => artifact.kind === "recipe-run-failure-diagnostics")
   assert.ok(failureDiagnostic, "pointer should expose recipe-run failure diagnostics")
+  const effectiveRecipeArtifact = pointer.diagnosticArtifacts.find((artifact: { kind?: string }) => artifact.kind === "recipe-run-effective-recipe")
+  assert.ok(effectiveRecipeArtifact, "pointer should expose the durable effective recipe JSON artifact")
 
   const diagnostics = JSON.parse(await readFile(join(artifacts, failureDiagnostic.path), "utf8"))
   assert.equal(diagnostics.schema, "wp-codebox/recipe-run-failure-diagnostics/v1")
+  assert.equal(diagnostics.provenance.schema, "wp-codebox/recipe-run-provenance/v1")
   assert.equal(diagnostics.recipe.path, recipePath)
+  assert.equal(diagnostics.recipe.effectiveJson.schema, "wp-codebox/workspace-recipe/v1")
+  assert.equal(diagnostics.recipe.effectiveSha256.length, 64)
   assert.equal(diagnostics.recipe.inputs.extra_plugins[0].pluginFile, "failing-plugin/failing-plugin.php")
   assert.equal(diagnostics.recipe.inputs.secretEnv.length, 0)
   assert.equal(diagnostics.phaseEvidence.some((phase: { name: string; status: string }) => phase.name === "activate_plugins" && phase.status === "failed"), true)
 
+  const effectiveRecipe = JSON.parse(await readFile(join(artifacts, effectiveRecipeArtifact.path), "utf8"))
+  assert.equal(effectiveRecipe.schema, "wp-codebox/recipe-run-effective-recipe/v1")
+  assert.equal(effectiveRecipe.recipe.schema, "wp-codebox/workspace-recipe/v1")
+  assert.equal(effectiveRecipe.sha256, diagnostics.recipe.effectiveSha256)
+
   const runtimeManifest = JSON.parse(await readFile(join(artifacts, pointer.paths.runtimeManifest), "utf8"))
   const runtimeDiagnosticPath = failureDiagnostic.path.split("/").slice(1).join("/")
   assert.equal(runtimeManifest.files.some((file: { kind?: string; path?: string }) => file.kind === "recipe-run-failure-diagnostics" && file.path === runtimeDiagnosticPath), true)
+  const runtimeEffectiveRecipePath = effectiveRecipeArtifact.path.split("/").slice(1).join("/")
+  assert.equal(runtimeManifest.files.some((file: { kind?: string; path?: string }) => file.kind === "recipe-run-effective-recipe" && file.path === runtimeEffectiveRecipePath), true)
 
   console.log("recipe run activation failure artifact smoke passed")
 } finally {

--- a/tests/recipe-run-provenance.test.ts
+++ b/tests/recipe-run-provenance.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import { normalizeRecipeRunSummary } from "@automattic/wp-codebox-core"
+import { executeRecipeWorkflowStep } from "../packages/cli/src/commands/recipe-run-workflow-evidence.js"
+
+const provenance = {
+  schema: "wp-codebox/recipe-run-provenance/v1",
+  packages: {
+    schema: "wp-codebox/package-provenance/v1",
+    wpCodebox: { name: "wp-codebox", version: "0.11.0" },
+    cli: { name: "@automattic/wp-codebox-cli", version: "0.11.0" },
+    runtimeCore: { name: "@automattic/wp-codebox-core", version: "0.11.0" },
+  },
+  recipe: {
+    path: "/tmp/recipe.json",
+    sha256: "source-digest",
+    effectiveSha256: "effective-digest",
+    effectiveRecipeRef: { path: "runtime/files/recipe-run-effective-recipe.json", kind: "recipe-run-effective-recipe", contentType: "application/json", sha256: "effective-digest" },
+  },
+}
+
+const summary = normalizeRecipeRunSummary({
+  success: false,
+  schema: "wp-codebox/recipe-run/v1",
+  recipePath: "/tmp/recipe.json",
+  provenance,
+  executions: [],
+  error: { message: "failed" },
+})
+
+assert.deepEqual(summary.provenance, provenance)
+assert.deepEqual(summary.metadata.package_provenance, provenance.packages)
+
+const calls: Array<{ command: string; args?: string[] }> = []
+const runtime = {
+  execute: async (spec: { command: string; args?: string[] }) => {
+    calls.push(spec)
+    return {
+      id: "exec-1",
+      command: spec.command,
+      args: spec.args ?? [],
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:00.001Z",
+    }
+  },
+}
+
+const execution = await executeRecipeWorkflowStep(runtime as never, {
+  phase: "steps",
+  index: 0,
+  step: { command: "wordpress.wp-cli", args: ["--path=/home/example/public_html", "option", "get", "siteurl"] },
+}, "/tmp", undefined, undefined, undefined, [
+  { originalTarget: "/home/example/public_html", canonicalTarget: "/tmp/wp-codebox-inputs/root" },
+])
+
+assert.deepEqual(calls[0]?.args, ["--path=/tmp/wp-codebox-inputs/root", "option", "get", "siteurl"])
+assert.equal(execution.recipeArgs?.schema, "wp-codebox/recipe-workflow-args/v1")
+assert.equal(execution.recipeArgs?.rewritten, true)
+assert.deepEqual(execution.recipeArgs?.original, ["--path=/home/example/public_html", "option", "get", "siteurl"])
+assert.deepEqual(execution.recipeArgs?.effective, ["--path=/tmp/wp-codebox-inputs/root", "option", "get", "siteurl"])
+
+console.log("recipe run provenance ok")


### PR DESCRIPTION
## Summary
- add generic recipe-run provenance with package/build and recipe digest metadata to full output, summaries, and run records
- preserve durable effective recipe JSON in failure artifacts and reference it from failure pointers/provenance
- record original and effective workflow args when recipe-run canonicalizes args before execution

Fixes #1690.

## Tests
- npm run test:recipe-run-provenance
- npx tsx tests/recipe-run-summary-output.test.ts
- npm run test:run-registry
- npx tsx scripts/recipe-run-activation-failure-artifacts-smoke.ts
- npm run test:recipe-runtime-setup-staged-materialization
- npm run build

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the recipe-run provenance/failure artifact changes, added focused coverage, and ran verification.