### PR TITLE
fix: keep WordPress-tree input mounts at their declared paths

### DIFF
--- a/packages/cli/src/input-mount-paths.ts
+++ b/packages/cli/src/input-mount-paths.ts
@@ -99,11 +99,30 @@ function originalPathReferencePattern(path: string): RegExp {
   return new RegExp(`${escapeRegExp(path)}(?=$|[\\/\\s'"\\]\\}\\),:;])`)
 }
 
+// Mounts targeting the WordPress install tree (ABSPATH is `/wordpress/` in the
+// Playground runtime) must keep their declared paths. WordPress core, plugin
+// activation, and the phpunit handler (which computes
+// `/wordpress/wp-content/plugins/<slug>`) all depend on those exact locations,
+// and the Playground VFS mounts them cleanly in place. Canonicalizing them into
+// `/tmp/wp-codebox-inputs/...` relocates the plugin-under-test outside the
+// plugins directory, so WordPress never loads it and its composer autoloader
+// never registers — crashing phpunit at class-collection time. Relocation is
+// only needed for mounts targeting arbitrary paths that collide with sandbox
+// internals (e.g. `/home/wpcom/public_html`, `/wp-codebox-vendor`).
+const RESERVED_INPUT_MOUNT_TARGET_ROOT = "/wordpress"
+
 function canonicalInputMountTarget(target: string, index: number): string {
   const normalized = normalizeSandboxPath(target)
+  if (isReservedInputMountTarget(normalized)) {
+    return normalized
+  }
   const hash = createHash("sha256").update(normalized).digest("hex").slice(0, 12)
   const name = safeInputMountTargetName(posix.basename(normalized)) || "mount"
   return `/tmp/wp-codebox-inputs/${index}-${name}-${hash}`
+}
+
+function isReservedInputMountTarget(normalized: string): boolean {
+  return normalized === RESERVED_INPUT_MOUNT_TARGET_ROOT || normalized.startsWith(`${RESERVED_INPUT_MOUNT_TARGET_ROOT}/`)
 }
 
 function safeInputMountTargetName(name: string): string {

--- a/tests/recipe-runtime-setup-staged-materialization.test.ts
+++ b/tests/recipe-runtime-setup-staged-materialization.test.ts
@@ -240,4 +240,50 @@ assert.deepEqual(executedWorkflowSpecs.map((spec) => spec.command), ["wordpress.
 assert.deepEqual(executedWorkflowSpecs[0]?.args, wpcomPhpunitExecution.args)
 assert.equal(executedWorkflowSpecs[0]?.args?.some((arg) => arg.includes("/wp-codebox-vendor") || arg.includes("/home/wpcom/public_html")), false)
 
+// Regression (Extra-Chill/data-machine#2840): the plugin-under-test is mounted
+// at /wordpress/wp-content/plugins/<slug>. Canonicalizing that mount into
+// /tmp/wp-codebox-inputs/... relocated the plugin outside the WordPress plugins
+// directory, so WordPress never loaded it, its composer autoloader never
+// registered, and phpunit crashed at class collection ("Class ... not found").
+// WordPress-tree mounts must keep their declared paths (identity mapping) while
+// mounts targeting sandbox-colliding paths are still canonicalized.
+const pluginUnderTestPathMap = recipeInputMountPathMap({
+  schema: "wp-codebox/workspace-recipe/v1",
+  inputs: {
+    mounts: [
+      { source: "/workspace/data-machine", target: "/wordpress/wp-content/plugins/data-machine", mode: "readwrite" },
+      { source: "/workspace/vendor", target: "/wp-codebox-vendor", mode: "readonly" },
+    ],
+  },
+  workflow: { steps: [] },
+})
+assert.equal(pluginUnderTestPathMap[0].originalTarget, "/wordpress/wp-content/plugins/data-machine")
+assert.equal(pluginUnderTestPathMap[0].canonicalTarget, "/wordpress/wp-content/plugins/data-machine", "plugin-under-test mount under /wordpress must not be relocated")
+assert.ok(pluginUnderTestPathMap[1].canonicalTarget.startsWith("/tmp/wp-codebox-inputs/"), "sandbox-colliding mounts are still canonicalized")
+
+const pluginUnderTestExecution = await executeRecipeWorkflowStep(workflowRuntime, {
+  phase: "steps",
+  index: 0,
+  step: {
+    command: "wordpress.phpunit",
+    args: [
+      "plugin-slug=data-machine",
+      "autoload-file=/wp-codebox-vendor/autoload.php",
+      "tests-dir=/wp-codebox-vendor/wp-phpunit/wp-phpunit",
+      "cwd=/wordpress/wp-content/plugins/data-machine",
+      "test-root=/wordpress/wp-content/plugins/data-machine/tests",
+      "phpunit-xml=/wordpress/wp-content/plugins/data-machine/phpunit.xml.dist",
+    ],
+  },
+}, process.cwd(), undefined, undefined, undefined, pluginUnderTestPathMap)
+
+assert.deepEqual(pluginUnderTestExecution.args, [
+  "plugin-slug=data-machine",
+  `autoload-file=${pluginUnderTestPathMap[1].canonicalTarget}/autoload.php`,
+  `tests-dir=${pluginUnderTestPathMap[1].canonicalTarget}/wp-phpunit/wp-phpunit`,
+  "cwd=/wordpress/wp-content/plugins/data-machine",
+  "test-root=/wordpress/wp-content/plugins/data-machine/tests",
+  "phpunit-xml=/wordpress/wp-content/plugins/data-machine/phpunit.xml.dist",
+], "plugin-under-test path args stay under /wordpress; only sandbox-colliding vendor paths are canonicalized")
+
 console.log("recipe runtime setup staged materialization ok")


### PR DESCRIPTION
## Summary

Fixes a coding-agent CI runtime regression: running a WordPress plugin PHPUnit suite inside the WP Codebox Playground runtime crashes during **test collection** because composer-autoloaded plugin classes are no longer found.

Concrete signature (from data-machine CI):

```
wordpress.phpunit could not run: Error: Class "DataMachine\Core\OAuth\BaseAuthProvider" not found
  at /tmp/wp-codebox-inputs/0-data-machine-.../tests/Unit/Abilities/AuthAbilitiesTest.php:17
```

PHPUnit crashes at autoload during collection, *before* any test runs (`test_failure_count: 0`, no stdout). The class exists in the plugin source and is in the plugin's `vendor/composer/autoload_classmap.php` — this is not a plugin bug.

## Root cause

`recipeInputMountPathMap()` in `packages/cli/src/input-mount-paths.ts` canonicalized the target of **every** recipe input mount into `/tmp/wp-codebox-inputs/<index>-<name>-<hash>`.

The plugin-under-test is itself an input mount: `buildWordPressPhpunitRecipe()` (`packages/runtime-core/src/recipe-builders.ts:77-80`) mounts `options.pluginSource` at `pluginTarget = /wordpress/wp-content/plugins/<slug>`. After #1698, that mount was physically relocated to `/tmp/wp-codebox-inputs/0-<slug>-<hash>` (the exact path in the error), i.e. **outside** the WordPress plugins directory.

Consequences:
- WordPress (`ABSPATH = /wordpress/`, see `phpunit-command-handlers.ts:551`) never finds/activates the plugin, because the phpunit handler computes `$plugin_path = '/wordpress/wp-content/plugins/' . $plugin_slug` (`phpunit-command-handlers.ts:288`).
- The plugin bootstrap that registers its Composer autoloader (on `plugins_loaded`) never runs.
- PHPUnit then hits an unautoloaded plugin class during collection and dies.

The legitimate goal of #1698 (issue #1696) was to relocate mounts whose targets collide with sandbox internals — WPCOM-style mounts at `/home/wpcom/public_html`, `/wp-codebox-vendor`, `/homeboy-extension` — which the sandbox can't materialize in place. But it over-applied canonicalization to WordPress-tree mounts that the Playground VFS already mounts cleanly at their declared paths.

### Temporal proof

The same data-machine suite passed **1370 tests on 2026-07-02** (before #1698 merged) and crashes at autoload **~24h later on 2026-07-03** (after it), with `wp-codebox@main` being the only thing that changed. The `v0.12.0` release (`536fc6fd`, 2026-07-02 19:37) predates the merge and was good. Suspected cause: PR #1698 / commit `242e36f8` "Resolve recipe input mount paths before execution" (merged 2026-07-03 ~00:34–00:40 UTC).

## The fix

Skip canonicalization for mounts whose target is at or under `/wordpress` (the Playground `ABSPATH`). `canonicalInputMountTarget()` now returns the original normalized target for those, producing an **identity mapping** — which the existing downstream logic already handles gracefully:

- `rewriteInputMountPath()` becomes a no-op when `canonicalTarget === originalTarget` (suffix concatenation yields the same path).
- `staleInputMountPathReferences()` already filters out mappings where `originalTarget === canonicalTarget`, so the `assertResolvedInputMountPathArgs()` guard does not false-trip on `/wordpress` args.

Mounts targeting sandbox-colliding paths (`/home/wpcom/public_html`, `/wp-codebox-vendor`, …) are still canonicalized exactly as #1698 intended — mount indices and hashes are unchanged, so existing WPCOM coverage is unaffected. This is a surgical fix; #1698 is **not** reverted.

## Verification

- `tsx tests/recipe-runtime-setup-staged-materialization.test.ts` — **pass** (added a regression case: a `/wordpress/wp-content/plugins/<slug>` plugin mount alongside a `/wp-codebox-vendor` mount; asserts the plugin mount keeps its path while the vendor mount is canonicalized, and the resulting `wordpress.phpunit` args keep the plugin paths under `/wordpress` while vendor paths are rewritten).
- `tsx tests/phpunit-project-autoload.test.ts` — **pass** (WPCOM-style `/wp-codebox-vendor` canonicalization unchanged).
- `tsx tests/host-recipe-builder.test.ts` — **pass**.
- `npm run test:nested-fuzz-suite-recipe-command` — **pass**.
- `npm run build` — **pass**.
- `git diff --check` — clean.

I could not run the full Playground PHPUnit end-to-end locally, so the plugin-load path is proven by reasoning + the mount-path/arg unit coverage above; noting that honestly.

Refs:
- Downstream report: Extra-Chill/data-machine#2840
- Suspected cause: #1698 / `242e36f8`
- Original intent preserved: #1696