### PR TITLE
Raise snapshot export memory limit

### DIFF
--- a/packages/runtime-playground/src/runtime-snapshot.ts
+++ b/packages/runtime-playground/src/runtime-snapshot.ts
@@ -233,6 +233,8 @@ export function runtimeSnapshotExportPhp(options: RuntimeSnapshotExportOptions =
   const includedOptionNames = JSON.stringify(normalizeStringList(options.includedOptionNames ?? []))
   const includedPostTypes = JSON.stringify(normalizeStringList(options.includedPostTypes ?? []))
   return [String.raw`
+@ini_set( 'memory_limit', '512M' );
+
 global $wpdb;
 
 $wp_codebox_snapshot_excluded_wp_content_paths = json_decode(<<<'WP_CODEBOX_EXCLUDED_WP_CONTENT_PATHS'

--- a/tests/runtime-snapshot-export-memory-limit.test.ts
+++ b/tests/runtime-snapshot-export-memory-limit.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict"
+
+import { runtimeSnapshotExportPhp } from "../packages/runtime-playground/src/runtime-snapshot.js"
+
+const php = runtimeSnapshotExportPhp()
+
+assert.match(php, /@ini_set\( 'memory_limit', '512M' \);/)
+
+console.log("runtime snapshot export memory limit ok")


### PR DESCRIPTION
## Summary
- Set a bounded 512M memory limit inside runtime snapshot export PHP.
- Add focused coverage that the generated snapshot export PHP includes the memory guard.

## Why
A WPCOM PHPUnit recipe run completed successfully, but `collect_artifacts` failed afterward because the snapshot/export PHP request still ran with the default 256M limit:

- Homeboy run: `runner-exec-test-wpcom-homeboy-lab-3569283a-4d69-48bc-901d-a9456ac93e07`
- WP Codebox run: `run_a544c3cc74de43e19532b399d9000a13`
- PHPUnit output: `OK (35 tests, 38 assertions)`
- Failure phase: `collect_artifacts`
- Fatal: `Allowed memory size of 268435456 bytes exhausted ... /internal/eval.php on line 40`

The Playground bootstrap already writes a 512M default php.ini for collection-heavy paths, but this guard makes the snapshot export request itself resilient when the effective request limit is still 256M.

## Verification
- `npx tsx tests/runtime-snapshot-export-memory-limit.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigated the WPCOM artifact collection failure, identified the snapshot export memory-limit gap, implemented the focused runtime guard, and ran targeted verification.