### PR TITLE
Default Playground PHP memory limit to 512M

### DIFF
--- a/packages/runtime-playground/src/playground-cli-runner.ts
+++ b/packages/runtime-playground/src/playground-cli-runner.ts
@@ -14,6 +14,8 @@ import * as PlaygroundStorage from "@wp-playground/storage"
 import { resolveWordPressRelease } from "@wp-playground/wordpress"
 import { phpEnvAssignments, phpWpConfigDefineAssignments } from "./php-snippets.js"
 
+const DEFAULT_RUNTIME_PHP_INI_ENTRIES = { memory_limit: "512M" }
+
 export interface PlaygroundCliModule {
   runCLI(options: {
     command: "server"
@@ -279,7 +281,10 @@ function pluginRuntimeBootstrapPhpIniEntries(spec: RuntimeCreateSpec): Record<st
 }
 
 function pluginRuntimePhpIniEntries(spec: RuntimeCreateSpec): Record<string, string> | undefined {
-  return pluginRuntimePhpEntries(spec, "iniEntries")
+  return {
+    ...DEFAULT_RUNTIME_PHP_INI_ENTRIES,
+    ...(pluginRuntimePhpEntries(spec, "iniEntries") ?? {}),
+  }
 }
 
 function pluginRuntimePhpEntries(spec: RuntimeCreateSpec, key: "iniEntries" | "bootstrapIniEntries"): Record<string, string> | undefined {

--- a/tests/playground-cli-runner-bootstrap-ini.test.ts
+++ b/tests/playground-cli-runner-bootstrap-ini.test.ts
@@ -80,6 +80,18 @@ try {
   assert.equal((await stat(join(sharedMount as string, "preload"))).isDirectory(), true)
 
   calls.length = 0
+  const defaultRuntimeIniSpec: RuntimeCreateSpec = {
+    ...spec,
+    metadata: {},
+  }
+
+  const defaultRuntimeIniServer = await startPlaygroundCliServer(defaultRuntimeIniSpec, [], { cliModule })
+  await defaultRuntimeIniServer[Symbol.asyncDispose]()
+
+  assert.equal(calls.length, 1)
+  assert.deepEqual(calls[0].phpIniEntries, { memory_limit: "512M" })
+
+  calls.length = 0
   const distributionOnlySpec: RuntimeCreateSpec = {
     ...spec,
     metadata: {


### PR DESCRIPTION
## Summary
- Pass WP Codebox's 512M runtime PHP memory default through `phpIniEntries` at Playground startup.
- Preserve recipe-provided `pluginRuntime.php.iniEntries` as overrides.
- Extend bootstrap ini coverage to prove a runtime without pluginRuntime settings still starts with `memory_limit=512M`.

## Why
The WPCOM focused PHPUnit run now executes successfully, but `recipe-run` still fails afterward in `collect_artifacts` with PHP-WASM's default 256M limit:

- Homeboy run: `runner-exec-test-wpcom-homeboy-lab-3569283a-4d69-48bc-901d-a9456ac93e07`
- WP Codebox run: `run_d62ee1e12e864d46bd388b218803ce70`
- Workload result: `OK (35 tests, 38 assertions)`
- Failure: `Allowed memory size of 268435456 bytes exhausted ... /internal/eval.php on line 40`

The prior snapshot export guard runs inside generated PHP, after the Playground PHP request is already executing. This applies the default at runtime startup so eval/bootstrap paths inherit it before command bodies run.

## Verification
- `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts`
- `npx tsx tests/runtime-snapshot-export-memory-limit.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigated the remaining WPCOM artifact collection OOM, fanned out analysis to identify the startup memory-limit layer, implemented the focused WP Codebox runtime default, and ran verification.