### PR TITLE
Make recipe runtime snapshots opt in

### DIFF
--- a/packages/cli/src/recipe-evidence.ts
+++ b/packages/cli/src/recipe-evidence.ts
@@ -340,25 +340,21 @@ export async function collectAndFinalizeFailedRecipeArtifacts(args: {
 }
 
 export async function collectRecipeRuntimeArtifacts(runtime: Runtime, spec: ArtifactSpec, options: RecipeRuntimeArtifactCollectionOptions = {}): Promise<ArtifactBundle> {
-  let snapshotCaptured = false
-  try {
-    const snapshot = runtime.snapshot()
-    if (options.snapshotTimeoutMs && options.snapshotTimeoutMs > 0) {
-      snapshot.catch(() => undefined)
-      const settled = await timeoutOrUndefined(snapshot, options.snapshotTimeoutMs)
-      snapshotCaptured = settled !== undefined
-    } else {
-      await snapshot
-      snapshotCaptured = true
+  if (spec.includeRuntimeSnapshotBundles === true) {
+    try {
+      const snapshot = runtime.snapshot()
+      if (options.snapshotTimeoutMs && options.snapshotTimeoutMs > 0) {
+        snapshot.catch(() => undefined)
+        await timeoutOrUndefined(snapshot, options.snapshotTimeoutMs)
+      } else {
+        await snapshot
+      }
+    } catch {
+      // Preserve artifact collection on runtimes that are too broken to snapshot.
     }
-  } catch {
-    // Preserve artifact collection on runtimes that are too broken to snapshot.
   }
 
-  const collectSpec: ArtifactSpec = snapshotCaptured && spec.includeRuntimeSnapshotBundles !== false
-    ? { ...spec, includeRuntimeSnapshotBundles: true }
-    : spec
-  const artifacts = runtime.collectArtifacts(collectSpec)
+  const artifacts = runtime.collectArtifacts(spec)
   if (options.timeoutMs && options.timeoutMs > 0) {
     return timeoutOrReject(artifacts, options.timeoutMs, `Runtime artifact collection exceeded ${options.timeoutMs}ms`)
   }

--- a/packages/runtime-playground/src/artifact-bundle-builder.ts
+++ b/packages/runtime-playground/src/artifact-bundle-builder.ts
@@ -145,10 +145,12 @@ export class ArtifactBundleBuilder {
       probes: source.browserArtifacts(),
       redactor,
     })
-    const replaySnapshot = portableSiteReplaySnapshot(
-      await firstRuntimeStateSnapshotPayload(source.snapshots),
-      source.spec.environment.blueprint,
-    )
+    const replaySnapshot = spec.includeRuntimeSnapshotBundles
+      ? portableSiteReplaySnapshot(
+        await firstRuntimeStateSnapshotPayload(source.snapshots),
+        source.spec.environment.blueprint,
+      )
+      : undefined
     const runtimeSnapshots = spec.includeRuntimeSnapshotBundles ? source.snapshots : []
     const runtimeSnapshotFiles = runtimeSnapshots.flatMap((snapshot) =>
       (snapshot.artifactRefs ?? [])

--- a/tests/recipe-runtime-artifacts-snapshot-policy.test.ts
+++ b/tests/recipe-runtime-artifacts-snapshot-policy.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+
+import type { ArtifactSpec, Runtime } from "@automattic/wp-codebox-core"
+import { collectRecipeRuntimeArtifacts } from "../packages/cli/src/recipe-evidence.js"
+
+async function collectWithSpec(spec: ArtifactSpec) {
+  let snapshotCalls = 0
+  let collectSpec: ArtifactSpec | undefined
+  const runtime = {
+    async snapshot() {
+      snapshotCalls++
+      return { id: "snapshot-1" }
+    },
+    async collectArtifacts(input: ArtifactSpec) {
+      collectSpec = input
+      return { id: "bundle-1" }
+    },
+  } as unknown as Runtime
+
+  await collectRecipeRuntimeArtifacts(runtime, spec)
+  return { snapshotCalls, collectSpec }
+}
+
+assert.deepEqual(await collectWithSpec({ includeLogs: true, includeObservations: true }), {
+  snapshotCalls: 0,
+  collectSpec: { includeLogs: true, includeObservations: true },
+})
+
+assert.deepEqual(await collectWithSpec({ includeLogs: true, includeRuntimeSnapshotBundles: false }), {
+  snapshotCalls: 0,
+  collectSpec: { includeLogs: true, includeRuntimeSnapshotBundles: false },
+})
+
+assert.deepEqual(await collectWithSpec({ includeRuntimeSnapshotBundles: true }), {
+  snapshotCalls: 1,
+  collectSpec: { includeRuntimeSnapshotBundles: true },
+})
+
+console.log("recipe runtime artifacts snapshot policy ok")


### PR DESCRIPTION
## Summary
- Stop taking full runtime snapshots during default recipe artifact collection.
- Preserve snapshot capture and runtime snapshot bundle inclusion when callers explicitly set `includeRuntimeSnapshotBundles: true`.
- Gate replay snapshot loading behind the same opt-in flag.
- Add focused policy coverage for default, explicit false, and explicit true artifact specs.

## Why
The WPCOM focused PHPUnit run succeeds, but default `recipe-run collect_artifacts` still fails afterward while exporting a full runtime snapshot:

- WP Codebox run after startup memory fix: `run_b67d7b515bb84fe0bac7b4f7dcee22ae`
- Workload result: `OK (35 tests, 38 assertions)`
- Failure phase: `collect_artifacts`
- Fatal: `Allowed memory size of 268435456 bytes exhausted ... /internal/eval.php on line 40`

Full runtime snapshots are expensive and optional. Default recipe artifacts should still collect logs, command output, observations, mount diffs, and declared artifacts without requiring a full site snapshot. Callers that need replayable runtime-state snapshots can still opt in explicitly.

## Verification
- `npx tsx tests/recipe-runtime-artifacts-snapshot-policy.test.ts`
- `npx tsx tests/runtime-snapshot-export-memory-limit.test.ts`
- `npx tsx tests/playground-cli-runner-bootstrap-ini.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Investigated the post-PHPUnit artifact collection OOM, split the structural snapshot policy change, implemented the opt-in behavior, and ran targeted verification.