### PR TITLE
Make VFS mount back-materialization opt in

### DIFF
--- a/packages/runtime-playground/src/mount-materialization.ts
+++ b/packages/runtime-playground/src/mount-materialization.ts
@@ -70,7 +70,7 @@ function mountMaterializationResult(input: Omit<MountMaterializationResult, "pha
 export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliServer, mounts: MountSpec[]): Promise<MountMaterializationResult> {
   const writableDirectoryMounts = mounts
     .map((mount, mountIndex) => ({ mount, mountIndex }))
-    .filter(({ mount }) => mount.mode === "readwrite" && mount.type !== "file")
+    .filter(({ mount }) => mount.mode === "readwrite" && mount.type !== "file" && mountMaterializesVfsToHost(mount))
   if (writableDirectoryMounts.length === 0) {
     return mountMaterializationResult({ materialized: 0, deleted: 0, skipped: 0 })
   }
@@ -87,6 +87,10 @@ export async function materializePlaygroundMountsFromVfs(server: PlaygroundCliSe
   const response = await server.playground.run({ code: vfsMountSnapshotPhp(hostSnapshots) })
   const parsed = JSON.parse(response.text || "{}") as { mounts?: VfsMountSnapshot[] }
   return applyVfsMountSnapshots(mounts, parsed.mounts ?? [])
+}
+
+function mountMaterializesVfsToHost(mount: MountSpec): boolean {
+  return Boolean(mount.metadata && typeof mount.metadata === "object" && !Array.isArray(mount.metadata) && mount.metadata.materializeVfsToHost === true)
 }
 
 export async function materializePlaygroundMountsToVfs(server: PlaygroundCliServer, mounts: MountSpec[]): Promise<MountMaterializationResult> {

--- a/tests/mount-materialization-non-destructive.test.ts
+++ b/tests/mount-materialization-non-destructive.test.ts
@@ -3,12 +3,23 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
-import { applyVfsMountSnapshots } from "../packages/runtime-playground/src/mount-materialization.js"
+import { applyVfsMountSnapshots, materializePlaygroundMountsFromVfs } from "../packages/runtime-playground/src/mount-materialization.js"
 
 const root = await mkdtemp(join(tmpdir(), "wp-codebox-mount-materialization-"))
 
 try {
   await writeFile(join(root, "host-only.txt"), "keep me")
+
+  const skippedMaterialization = await materializePlaygroundMountsFromVfs({
+    playground: {
+      async run() {
+        throw new Error("default readwrite mounts should not be snapshotted from VFS")
+      },
+    },
+  } as never, [{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite" }])
+
+  assert.equal(skippedMaterialization.phaseResult.status, "skipped")
+  assert.equal(skippedMaterialization.materialized, 0)
 
   await applyVfsMountSnapshots([{ type: "directory", source: root, target: "/workspace/example", mode: "readwrite" }], [{
     mountIndex: 0,


### PR DESCRIPTION
## Summary
- Stop automatically snapshotting every readwrite directory mount from the Playground VFS during artifact collection.
- Require `mount.metadata.materializeVfsToHost === true` before VFS contents are back-materialized to the host.
- Keep direct `applyVfsMountSnapshots()` behavior unchanged for callers that already opted into captured snapshots.

## Why
After making runtime snapshots opt-in, the WPCOM focused PHPUnit run still passed but `collect_artifacts` failed with the same PHP OOM. The remaining automatic PHP collection path is VFS back-materialization for readwrite directory mounts. For WPCOM, the configured readwrite mount is the whole repo, so collection was still asking PHP to walk/hash/base64 a very large tree.

Latest evidence:
- WP Codebox cache: `5758901fe9b5fb9a2ac00074ceb281181cedadf0`
- WP Codebox run: `run_470875ea38ea40959168212365a92066`
- Workload result: `OK (35 tests, 38 assertions)`
- Failure phase: `collect_artifacts`
- Fatal: `Allowed memory size of 268435456 bytes exhausted ... /internal/eval.php on line 40`

Default artifact collection should not require exporting a whole readwrite mount back to the host. Callers that need write-back can opt in explicitly per mount.

## Verification
- `npx tsx tests/mount-materialization-non-destructive.test.ts`
- `npx tsx tests/recipe-runtime-artifacts-snapshot-policy.test.ts`
- `npm run build`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Traced the remaining WPCOM artifact collection OOM to VFS mount back-materialization, implemented the opt-in mount metadata gate, and ran targeted verification.